### PR TITLE
fix(router): isolate rate-limit windows by epoch minute

### DIFF
--- a/litellm/proxy/hooks/dynamic_rate_limiter.py
+++ b/litellm/proxy/hooks/dynamic_rate_limiter.py
@@ -22,7 +22,7 @@ from litellm.proxy.hooks.rate_limiter_utils import (
 )
 from litellm.types.router import ModelGroupInfo
 from litellm.types.utils import CallTypesLiteral
-from litellm.utils import get_utc_datetime
+from litellm.utils import get_utc_datetime, utc_epoch_minute
 
 
 class DynamicRateLimiterCache:
@@ -39,8 +39,8 @@ class DynamicRateLimiterCache:
 
     async def async_get_cache(self, model: str) -> int | None:
         dt: Final = self.time_fn()
-        current_minute: Final = dt.strftime("%H-%M")
-        key_name: Final = f"{current_minute}:{model}"
+        window_id: Final = utc_epoch_minute(dt)
+        key_name: Final = f"v2:{window_id}:{model}"
         _response: Final = await self.cache.async_get_cache(key=key_name)
         response: int | None = None
         if _response is not None:
@@ -63,9 +63,8 @@ class DynamicRateLimiterCache:
         """
         try:
             dt: Final = self.time_fn()
-            current_minute: Final = dt.strftime("%H-%M")
-
-            key_name: Final = f"{current_minute}:{model}"
+            window_id: Final = utc_epoch_minute(dt)
+            key_name: Final = f"v2:{window_id}:{model}"
             await self.cache.async_set_cache_sadd(key=key_name, value=value, ttl=self.ttl)
         except Exception as e:
             verbose_proxy_logger.exception(

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -251,6 +251,7 @@ from litellm.utils import (
     is_region_allowed,
     provider_rejectable_params,
     set_live_deployment_replay,
+    utc_epoch_minute,
 )
 
 from .router_utils.pattern_match_deployments import PatternMatchRouter
@@ -7715,9 +7716,9 @@ class Router:
                 # Setup values
                 # ------------
                 dt: Final = get_utc_datetime()
-                current_minute: Final = dt.strftime("%H-%M")  # use the same timezone regardless of system clock
+                window_id: Final = utc_epoch_minute(dt)
 
-                tpm_key = RouterCacheEnum.TPM.value.format(id=id, current_minute=current_minute, model=deployment_name)
+                tpm_key = RouterCacheEnum.TPM.value.format(id=id, window_id=window_id, model=deployment_name)
                 # ------------
                 # Update usage
                 # ------------
@@ -7734,7 +7735,7 @@ class Router:
                 )
 
                 ## RPM
-                rpm_key = RouterCacheEnum.RPM.value.format(id=id, current_minute=current_minute, model=deployment_name)
+                rpm_key = RouterCacheEnum.RPM.value.format(id=id, window_id=window_id, model=deployment_name)
                 pipeline_operations.append(
                     RedisPipelineIncrementOperation(
                         key=rpm_key,
@@ -7896,10 +7897,10 @@ class Router:
         parent_otel_span: Final = _get_parent_otel_span_from_kwargs(kwargs)
 
         dt: Final = get_utc_datetime()
-        current_minute: Final = dt.strftime("%H-%M")  # use the same timezone regardless of system clock
+        window_id: Final = utc_epoch_minute(dt)
 
         ## RPM
-        rpm_key: Final = RouterCacheEnum.RPM.value.format(id=id, current_minute=current_minute, model=deployment_name)
+        rpm_key: Final = RouterCacheEnum.RPM.value.format(id=id, window_id=window_id, model=deployment_name)
         await self.cache.async_increment_cache(
             key=rpm_key,
             value=1,
@@ -10356,7 +10357,7 @@ class Router:
         - usage: Tuple[tpm, rpm]
         """
         dt: Final = get_utc_datetime()
-        current_minute: Final = dt.strftime("%H-%M")  # use the same timezone regardless of system clock
+        window_id: Final = utc_epoch_minute(dt)
         tpm_keys: Final[list[str]] = []
         rpm_keys: Final[list[str]] = []
 
@@ -10375,14 +10376,14 @@ class Router:
                 RouterCacheEnum.TPM.value.format(
                     id=id,
                     model=litellm_model,
-                    current_minute=current_minute,
+                    window_id=window_id,
                 )
             )
             rpm_keys.append(
                 RouterCacheEnum.RPM.value.format(
                     id=id,
                     model=litellm_model,
-                    current_minute=current_minute,
+                    window_id=window_id,
                 )
             )
         combined_tpm_rpm_keys: Final = tpm_keys + rpm_keys
@@ -10417,7 +10418,7 @@ class Router:
         Returns current ITPM/OTPM usage for a model group (sum across deployments).
         """
         dt: Final = get_utc_datetime()
-        current_minute: Final = dt.strftime("%H-%M")
+        window_id: Final = utc_epoch_minute(dt)
         itpm_keys: Final[list[str]] = []
         otpm_keys: Final[list[str]] = []
 
@@ -10434,14 +10435,14 @@ class Router:
                 RouterCacheEnum.ITPM.value.format(
                     id=model_id,
                     model=litellm_model,
-                    current_minute=current_minute,
+                    window_id=window_id,
                 )
             )
             otpm_keys.append(
                 RouterCacheEnum.OTPM.value.format(
                     id=model_id,
                     model=litellm_model,
-                    current_minute=current_minute,
+                    window_id=window_id,
                 )
             )
 
@@ -11588,8 +11589,8 @@ class Router:
 
         ## get model group RPM ##
         dt: Final = get_utc_datetime()
-        current_minute: Final = dt.strftime("%H-%M")
-        rpm_key: Final = f"{model}:rpm:{current_minute}"
+        window_id: Final = utc_epoch_minute(dt)
+        rpm_key: Final = f"{model}:rpm:v2:{window_id}"
         model_group_cache: Final = (
             self.cache.get_cache(key=rpm_key, local_only=True, parent_otel_span=parent_otel_span) or {}
         )  # check the in-memory cache used by lowest_latency and usage-based routing. Only check the local cache.

--- a/litellm/router_strategy/lowest_tpm_rpm.py
+++ b/litellm/router_strategy/lowest_tpm_rpm.py
@@ -1,7 +1,6 @@
 #### What this does ####
 #   identifies lowest tpm deployment
 import traceback
-from datetime import datetime
 from typing import Final
 
 from litellm import token_counter
@@ -9,7 +8,7 @@ from litellm._logging import verbose_router_logger
 from litellm.caching.caching import DualCache
 from litellm.integrations.custom_logger import CustomLogger
 from litellm.types.utils import LiteLLMPydanticObjectBase
-from litellm.utils import print_verbose
+from litellm.utils import print_verbose, utc_epoch_minute
 
 
 class RoutingArgs(LiteLLMPydanticObjectBase):
@@ -49,9 +48,9 @@ class LowestTPMLoggingHandler(CustomLogger):
                 # ------------
                 # Setup values
                 # ------------
-                current_minute: Final = datetime.now().strftime("%H-%M")
-                tpm_key: Final = f"{model_group}:tpm:{current_minute}"
-                rpm_key: Final = f"{model_group}:rpm:{current_minute}"
+                window_id: Final = utc_epoch_minute()
+                tpm_key: Final = f"{model_group}:tpm:v2:{window_id}"
+                rpm_key: Final = f"{model_group}:rpm:v2:{window_id}"
 
                 # ------------
                 # Update usage
@@ -106,9 +105,9 @@ class LowestTPMLoggingHandler(CustomLogger):
                 # ------------
                 # Setup values
                 # ------------
-                current_minute: Final = datetime.now().strftime("%H-%M")
-                tpm_key: Final = f"{model_group}:tpm:{current_minute}"
-                rpm_key: Final = f"{model_group}:rpm:{current_minute}"
+                window_id: Final = utc_epoch_minute()
+                tpm_key: Final = f"{model_group}:tpm:v2:{window_id}"
+                rpm_key: Final = f"{model_group}:rpm:v2:{window_id}"
 
                 # ------------
                 # Update usage
@@ -156,9 +155,9 @@ class LowestTPMLoggingHandler(CustomLogger):
             model_group,
             healthy_deployments,
         )
-        current_minute: Final = datetime.now().strftime("%H-%M")
-        tpm_key: Final = f"{model_group}:tpm:{current_minute}"
-        rpm_key: Final = f"{model_group}:rpm:{current_minute}"
+        window_id: Final = utc_epoch_minute()
+        tpm_key: Final = f"{model_group}:tpm:v2:{window_id}"
+        rpm_key: Final = f"{model_group}:rpm:v2:{window_id}"
 
         tpm_dict = self.router_cache.get_cache(key=tpm_key)
         rpm_dict: Final = self.router_cache.get_cache(key=rpm_key)

--- a/litellm/router_strategy/lowest_tpm_rpm_v2.py
+++ b/litellm/router_strategy/lowest_tpm_rpm_v2.py
@@ -13,7 +13,7 @@ from litellm.integrations.custom_logger import CustomLogger
 from litellm.litellm_core_utils.core_helpers import _get_parent_otel_span_from_kwargs
 from litellm.types.router import RouterErrors
 from litellm.types.utils import LiteLLMPydanticObjectBase, StandardLoggingPayload
-from litellm.utils import get_utc_datetime, print_verbose
+from litellm.utils import get_utc_datetime, print_verbose, utc_epoch_minute
 
 from .base_routing_strategy import BaseRoutingStrategy
 
@@ -71,10 +71,10 @@ class LowestTPMLoggingHandler_v2(BaseRoutingStrategy, CustomLogger):
             # ------------
 
             dt: Final = get_utc_datetime()
-            current_minute: Final = dt.strftime("%H-%M")
+            window_id: Final = utc_epoch_minute(dt)
             model_id: Final = deployment.get("model_info", {}).get("id")
             deployment_name: Final = deployment.get("litellm_params", {}).get("model")
-            rpm_key: Final = f"{model_id}:{deployment_name}:rpm:{current_minute}"
+            rpm_key: Final = f"{model_id}:{deployment_name}:rpm:v2:{window_id}"
 
             local_result: Final = self.router_cache.get_cache(key=rpm_key, local_only=True)  # check local result first
 
@@ -149,11 +149,11 @@ class LowestTPMLoggingHandler_v2(BaseRoutingStrategy, CustomLogger):
             # Setup values
             # ------------
             dt: Final = get_utc_datetime()
-            current_minute: Final = dt.strftime("%H-%M")
+            window_id: Final = utc_epoch_minute(dt)
             model_id: Final = deployment.get("model_info", {}).get("id")
             deployment_name: Final = deployment.get("litellm_params", {}).get("model")
 
-            rpm_key: Final = f"{model_id}:{deployment_name}:rpm:{current_minute}"
+            rpm_key: Final = f"{model_id}:{deployment_name}:rpm:v2:{window_id}"
             local_result: Final = await self.router_cache.async_get_cache(
                 key=rpm_key, local_only=True
             )  # check local result first
@@ -230,9 +230,9 @@ class LowestTPMLoggingHandler_v2(BaseRoutingStrategy, CustomLogger):
             # Setup values
             # ------------
             dt: Final = get_utc_datetime()
-            current_minute: Final = dt.strftime("%H-%M")  # use the same timezone regardless of system clock
+            window_id: Final = utc_epoch_minute(dt)
 
-            tpm_key: Final = f"{id}:{model}:tpm:{current_minute}"
+            tpm_key: Final = f"{id}:{model}:tpm:v2:{window_id}"
             # ------------
             # Update usage
             # ------------
@@ -268,9 +268,9 @@ class LowestTPMLoggingHandler_v2(BaseRoutingStrategy, CustomLogger):
             # Setup values
             # ------------
             dt: Final = get_utc_datetime()
-            current_minute: Final = dt.strftime("%H-%M")  # use the same timezone regardless of system clock
+            window_id: Final = utc_epoch_minute(dt)
 
-            tpm_key: Final = f"{id}:{model}:tpm:{current_minute}"
+            tpm_key: Final = f"{id}:{model}:tpm:v2:{window_id}"
             # ------------
             # Update usage
             # ------------
@@ -426,7 +426,7 @@ class LowestTPMLoggingHandler_v2(BaseRoutingStrategy, CustomLogger):
         )
 
         dt: Final = get_utc_datetime()
-        current_minute: Final = dt.strftime("%H-%M")
+        window_id: Final = utc_epoch_minute(dt)
 
         tpm_keys: Final = []
         rpm_keys: Final = []
@@ -436,8 +436,8 @@ class LowestTPMLoggingHandler_v2(BaseRoutingStrategy, CustomLogger):
                     "id"
                 )  # a deployment should always have an 'id'. this is set in router.py
                 deployment_name = m.get("litellm_params", {}).get("model")
-                tpm_key = f"{id}:{deployment_name}:tpm:{current_minute}"
-                rpm_key = f"{id}:{deployment_name}:rpm:{current_minute}"
+                tpm_key = f"{id}:{deployment_name}:tpm:v2:{window_id}"
+                rpm_key = f"{id}:{deployment_name}:rpm:v2:{window_id}"
 
                 tpm_keys.append(tpm_key)
                 rpm_keys.append(rpm_key)
@@ -543,7 +543,7 @@ class LowestTPMLoggingHandler_v2(BaseRoutingStrategy, CustomLogger):
         )
 
         dt: Final = get_utc_datetime()
-        current_minute: Final = dt.strftime("%H-%M")
+        window_id: Final = utc_epoch_minute(dt)
         tpm_keys: Final = []
         rpm_keys: Final = []
         for m in healthy_deployments:
@@ -552,8 +552,8 @@ class LowestTPMLoggingHandler_v2(BaseRoutingStrategy, CustomLogger):
                     "id"
                 )  # a deployment should always have an 'id'. this is set in router.py
                 deployment_name = m.get("litellm_params", {}).get("model")
-                tpm_key = f"{id}:{deployment_name}:tpm:{current_minute}"
-                rpm_key = f"{id}:{deployment_name}:rpm:{current_minute}"
+                tpm_key = f"{id}:{deployment_name}:tpm:v2:{window_id}"
+                rpm_key = f"{id}:{deployment_name}:rpm:v2:{window_id}"
 
                 tpm_keys.append(tpm_key)
                 rpm_keys.append(rpm_key)

--- a/litellm/router_utils/pre_call_checks/io_token_rate_limit_check.py
+++ b/litellm/router_utils/pre_call_checks/io_token_rate_limit_check.py
@@ -22,7 +22,7 @@ from litellm import token_counter
 from litellm._logging import verbose_router_logger
 from litellm.caching.dual_cache import DualCache
 from litellm.types.router import RouterCacheEnum, RouterErrors
-from litellm.utils import get_utc_datetime
+from litellm.utils import get_utc_datetime, utc_epoch_minute
 
 if TYPE_CHECKING:
     from opentelemetry.trace import Span as _Span
@@ -93,15 +93,15 @@ def deployment_has_io_token_limits(deployment: dict) -> bool:
     return itpm is not None or otpm is not None
 
 
-def _get_cache_keys(deployment: dict, current_minute: str) -> tuple[str, str] | None:
+def _get_cache_keys(deployment: dict, window_id: int) -> tuple[str, str] | None:
     model_id: Final = deployment.get("model_info", {}).get("id")
     deployment_name: Final = deployment.get("litellm_params", {}).get("model")
     # Without both a deployment id and model name the key would collapse to a
     # shared "None:None" bucket across misconfigured deployments, so bail out.
     if model_id is None or deployment_name is None:
         return None
-    itpm_key = RouterCacheEnum.ITPM.value.format(id=model_id, model=deployment_name, current_minute=current_minute)
-    otpm_key = RouterCacheEnum.OTPM.value.format(id=model_id, model=deployment_name, current_minute=current_minute)
+    itpm_key = RouterCacheEnum.ITPM.value.format(id=model_id, model=deployment_name, window_id=window_id)
+    otpm_key = RouterCacheEnum.OTPM.value.format(id=model_id, model=deployment_name, window_id=window_id)
     return itpm_key, otpm_key
 
 
@@ -407,8 +407,8 @@ def io_token_pre_call_check(
     max_tokens: Final = _resolve_max_tokens(request_kwargs, deployment)
 
     dt: Final = get_utc_datetime()
-    current_minute: Final = dt.strftime("%H-%M")
-    cache_keys: Final = _get_cache_keys(deployment, current_minute)
+    window_id: Final = utc_epoch_minute(dt)
+    cache_keys: Final = _get_cache_keys(deployment, window_id)
     if cache_keys is None:
         return deployment
     itpm_key, otpm_key = cache_keys
@@ -470,8 +470,8 @@ async def async_io_token_pre_call_check(
     max_tokens: Final = _resolve_max_tokens(request_kwargs, deployment)
 
     dt: Final = get_utc_datetime()
-    current_minute: Final = dt.strftime("%H-%M")
-    cache_keys: Final = _get_cache_keys(deployment, current_minute)
+    window_id: Final = utc_epoch_minute(dt)
+    cache_keys: Final = _get_cache_keys(deployment, window_id)
     if cache_keys is None:
         return deployment
     itpm_key, otpm_key = cache_keys

--- a/litellm/router_utils/pre_call_checks/model_rate_limit_check.py
+++ b/litellm/router_utils/pre_call_checks/model_rate_limit_check.py
@@ -32,7 +32,7 @@ from litellm.router_utils.pre_call_checks.io_token_rate_limit_check import (
 )
 from litellm.types.router import RouterErrors
 from litellm.types.utils import StandardLoggingPayload
-from litellm.utils import get_utc_datetime
+from litellm.utils import get_utc_datetime, utc_epoch_minute
 
 if TYPE_CHECKING:
     from opentelemetry.trace import Span as _Span
@@ -126,13 +126,13 @@ class ModelRateLimitingCheck(CustomLogger):
 
         return tpm, rpm
 
-    def _get_cache_keys(self, deployment: dict, current_minute: str) -> tuple[str, str]:
+    def _get_cache_keys(self, deployment: dict, window_id: int) -> tuple[str, str]:
         """Get the cache keys for TPM and RPM tracking."""
         model_id: Final = deployment.get("model_info", {}).get("id")
         deployment_name: Final = deployment.get("litellm_params", {}).get("model")
 
-        tpm_key: Final = f"{model_id}:{deployment_name}:tpm:{current_minute}"
-        rpm_key: Final = f"{model_id}:{deployment_name}:rpm:{current_minute}"
+        tpm_key: Final = f"{model_id}:{deployment_name}:tpm:v2:{window_id}"
+        rpm_key: Final = f"{model_id}:{deployment_name}:rpm:v2:{window_id}"
 
         return tpm_key, rpm_key
 
@@ -159,8 +159,8 @@ class ModelRateLimitingCheck(CustomLogger):
                 return deployment
 
             dt: Final = get_utc_datetime()
-            current_minute: Final = dt.strftime("%H-%M")
-            tpm_key, rpm_key = self._get_cache_keys(deployment, current_minute)
+            window_id: Final = utc_epoch_minute(dt)
+            tpm_key, rpm_key = self._get_cache_keys(deployment, window_id)
 
             model_id: Final = deployment.get("model_info", {}).get("id")
             model_name: Final = deployment.get("litellm_params", {}).get("model")
@@ -240,8 +240,8 @@ class ModelRateLimitingCheck(CustomLogger):
                 return deployment
 
             dt: Final = get_utc_datetime()
-            current_minute: Final = dt.strftime("%H-%M")
-            tpm_key, rpm_key = self._get_cache_keys(deployment, current_minute)
+            window_id: Final = utc_epoch_minute(dt)
+            tpm_key, rpm_key = self._get_cache_keys(deployment, window_id)
 
             model_id: Final = deployment.get("model_info", {}).get("id")
             model_name: Final = deployment.get("litellm_params", {}).get("model")
@@ -348,8 +348,8 @@ class ModelRateLimitingCheck(CustomLogger):
                 return
 
             dt: Final = get_utc_datetime()
-            current_minute: Final = dt.strftime("%H-%M")
-            tpm_key: Final = f"{model_id}:{model}:tpm:{current_minute}"
+            window_id: Final = utc_epoch_minute(dt)
+            tpm_key: Final = f"{model_id}:{model}:tpm:v2:{window_id}"
 
             verbose_router_logger.debug("[TPM TRACKING] Incrementing %s by %s", tpm_key, total_tokens)
 
@@ -408,8 +408,8 @@ class ModelRateLimitingCheck(CustomLogger):
                 return
 
             dt: Final = get_utc_datetime()
-            current_minute: Final = dt.strftime("%H-%M")
-            tpm_key: Final = f"{model_id}:{model}:tpm:{current_minute}"
+            window_id: Final = utc_epoch_minute(dt)
+            tpm_key: Final = f"{model_id}:{model}:tpm:v2:{window_id}"
 
             self.dual_cache.increment_cache(
                 key=tpm_key,

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -843,10 +843,10 @@ class RoutingStrategy(enum.Enum):
 
 
 class RouterCacheEnum(enum.Enum):
-    TPM = "global_router:{id}:{model}:tpm:{current_minute}"
-    RPM = "global_router:{id}:{model}:rpm:{current_minute}"
-    ITPM = "global_router:{id}:{model}:itpm:{current_minute}"
-    OTPM = "global_router:{id}:{model}:otpm:{current_minute}"
+    TPM = "global_router:{id}:{model}:tpm:v2:{window_id}"
+    RPM = "global_router:{id}:{model}:rpm:v2:{window_id}"
+    ITPM = "global_router:{id}:{model}:itpm:v2:{window_id}"
+    OTPM = "global_router:{id}:{model}:otpm:v2:{window_id}"
 
 
 class GenericBudgetWindowDetails(BaseModel):

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -5159,6 +5159,16 @@ def get_utc_datetime():
         return datetime.utcnow()
 
 
+def utc_epoch_minute(value: datetime.datetime | None = None) -> int:
+    current_time: Final = value if value is not None else get_utc_datetime()
+    normalized_time: Final = (
+        current_time.replace(tzinfo=datetime.timezone.utc)
+        if current_time.tzinfo is None or current_time.utcoffset() is None
+        else current_time
+    )
+    return int(normalized_time.timestamp()) // 60
+
+
 def get_max_tokens(model: str) -> int | None:
     """
     Get the maximum number of output tokens allowed for a given model.

--- a/tests/local_testing/test_tpm_rpm_routing_v2.py
+++ b/tests/local_testing/test_tpm_rpm_routing_v2.py
@@ -2,11 +2,11 @@
 #    This tests the router's ability to pick deployment with lowest tpm using 'usage-based-routing-v2-v2'
 
 import asyncio
+from datetime import datetime, timezone
 import os
 import random
 import time
 import traceback
-from datetime import datetime
 from typing import Dict
 from dotenv import load_dotenv
 
@@ -15,14 +15,14 @@ load_dotenv()
 from unittest.mock import AsyncMock, MagicMock, patch
 from litellm.types.utils import StandardLoggingPayload
 import pytest
-from litellm.types.router import DeploymentTypedDict
+from litellm.types.router import DeploymentTypedDict, RouterCacheEnum
 import litellm
 from litellm import Router
 from litellm.caching.caching import DualCache
 from litellm.router_strategy.lowest_tpm_rpm_v2 import (
     LowestTPMLoggingHandler_v2 as LowestTPMLoggingHandler,
 )
-from litellm.utils import get_utc_datetime
+from litellm.utils import get_utc_datetime, utc_epoch_minute
 from create_mock_standard_logging_payload import create_standard_logging_payload
 
 ### UNIT TESTS FOR TPM/RPM ROUTING ###
@@ -73,15 +73,116 @@ def test_tpm_rpm_updated():
         end_time=end_time,
     )
     dt = get_utc_datetime()
-    current_minute = dt.strftime("%H-%M")
-    tpm_count_api_key = f"{deployment_id}:{deployment}:tpm:{current_minute}"
-    rpm_count_api_key = f"{deployment_id}:{deployment}:rpm:{current_minute}"
+    window_id = utc_epoch_minute(dt)
+    tpm_count_api_key = f"{deployment_id}:{deployment}:tpm:v2:{window_id}"
+    rpm_count_api_key = f"{deployment_id}:{deployment}:rpm:v2:{window_id}"
 
     print(f"tpm_count_api_key={tpm_count_api_key}")
     assert response_obj["usage"]["total_tokens"] == test_cache.get_cache(
         key=tpm_count_api_key
     )
     assert 1 == test_cache.get_cache(key=rpm_count_api_key)
+
+
+def test_rate_limit_window_changes_at_utc_midnight():
+    before_midnight = datetime(2024, 1, 1, 23, 59, 59, tzinfo=timezone.utc)
+    after_midnight = datetime(2024, 1, 2, 0, 0, 0, tzinfo=timezone.utc)
+
+    before_window = utc_epoch_minute(before_midnight)
+    after_window = utc_epoch_minute(after_midnight)
+    before_key = f"deployment:model:rpm:v2:{before_window}"
+    after_key = f"deployment:model:rpm:v2:{after_window}"
+
+    assert after_window == before_window + 1
+    assert before_key != after_key
+
+
+def test_rate_limit_windows_do_not_share_cache_values():
+    test_cache = DualCache()
+    before_window = utc_epoch_minute(datetime(2024, 1, 1, 23, 59, tzinfo=timezone.utc))
+    after_window = utc_epoch_minute(datetime(2024, 1, 2, 0, 0, tzinfo=timezone.utc))
+    before_key = f"deployment:model:tpm:v2:{before_window}"
+    after_key = f"deployment:model:tpm:v2:{after_window}"
+
+    test_cache.set_cache(key=before_key, value=99, local_only=True)
+
+    assert test_cache.get_cache(key=before_key, local_only=True) == 99
+    assert test_cache.get_cache(key=after_key, local_only=True) is None
+
+
+def test_router_does_not_read_legacy_hh_mm_key():
+    test_cache = DualCache()
+    legacy_key = "deployment:model:rpm:23-59"
+    test_cache.set_cache(key=legacy_key, value=100, local_only=True)
+    deployment = {
+        "model_name": "model-group",
+        "litellm_params": {"model": "model"},
+        "model_info": {"id": "deployment"},
+    }
+    fixed_datetime = datetime(2024, 1, 1, 23, 59, 30, tzinfo=timezone.utc)
+    lowest_tpm_logger = LowestTPMLoggingHandler(router_cache=test_cache)
+
+    with (
+        patch(
+            "litellm.router_strategy.lowest_tpm_rpm_v2.get_utc_datetime",
+            return_value=fixed_datetime,
+        ),
+        patch.object(test_cache, "batch_get_cache", wraps=test_cache.batch_get_cache) as batch_get,
+    ):
+        assert (
+            lowest_tpm_logger.get_available_deployments(
+                model_group="model-group",
+                healthy_deployments=[deployment],
+            )
+            == deployment
+        )
+
+    requested_keys = [key for call in batch_get.call_args_list for key in call.kwargs["keys"]]
+    assert legacy_key not in requested_keys
+    assert all(":v2:" in key for key in requested_keys)
+
+
+def test_router_uses_one_window_id_for_tpm_and_rpm_batches():
+    test_cache = DualCache()
+    deployments = [
+        {
+            "model_name": "model-group",
+            "litellm_params": {"model": "model"},
+            "model_info": {"id": "deployment-1"},
+        },
+        {
+            "model_name": "model-group",
+            "litellm_params": {"model": "model"},
+            "model_info": {"id": "deployment-2"},
+        },
+    ]
+    fixed_datetime = datetime(2024, 1, 1, 23, 59, 30, tzinfo=timezone.utc)
+    expected_window = utc_epoch_minute(fixed_datetime)
+    lowest_tpm_logger = LowestTPMLoggingHandler(router_cache=test_cache)
+
+    with (
+        patch(
+            "litellm.router_strategy.lowest_tpm_rpm_v2.get_utc_datetime",
+            return_value=fixed_datetime,
+        ),
+        patch.object(test_cache, "batch_get_cache", wraps=test_cache.batch_get_cache) as batch_get,
+    ):
+        lowest_tpm_logger.get_available_deployments(
+            model_group="model-group",
+            healthy_deployments=deployments,
+        )
+
+    assert len(batch_get.call_args_list) == 2
+    requested_keys = [key for call in batch_get.call_args_list for key in call.kwargs["keys"]]
+    assert {key.rsplit(":", 1)[-1] for key in requested_keys} == {str(expected_window)}
+
+
+@pytest.mark.parametrize("cache_type", list(RouterCacheEnum))
+def test_router_cache_enum_uses_versioned_epoch_window(cache_type):
+    key = cache_type.value.format(id="deployment", model="model", window_id=123456)
+
+    assert ":v2:123456" in key
+    assert "23-59" not in key
 
 
 # test_tpm_rpm_updated()
@@ -475,7 +576,7 @@ async def test_router_completion_streaming():
         ## CALL 3
         await asyncio.sleep(1)  # let the token update happen
         dt = get_utc_datetime()
-        current_minute = dt.strftime("%H-%M")
+        window_id = utc_epoch_minute(dt)
         picked_deployment = router.lowesttpm_logger_v2.get_available_deployments(
             model_group=model,
             healthy_deployments=router.healthy_deployments,
@@ -483,8 +584,8 @@ async def test_router_completion_streaming():
         )
         final_response = await router.acompletion(model=model, messages=messages)
         print(f"min deployment id: {picked_deployment}")
-        tpm_key = f"{model}:tpm:{current_minute}"
-        rpm_key = f"{model}:rpm:{current_minute}"
+        tpm_key = f"{model}:tpm:v2:{window_id}"
+        rpm_key = f"{model}:rpm:v2:{window_id}"
 
         tpm_dict = router.cache.get_cache(key=tpm_key)
         print(f"tpm_dict: {tpm_dict}")

--- a/tests/local_testing/test_tpm_rpm_routing_v2.py
+++ b/tests/local_testing/test_tpm_rpm_routing_v2.py
@@ -2,7 +2,7 @@
 #    This tests the router's ability to pick deployment with lowest tpm using 'usage-based-routing-v2-v2'
 
 import asyncio
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 import os
 import random
 import time
@@ -112,21 +112,21 @@ def test_rate_limit_windows_do_not_share_cache_values():
 
 def test_router_does_not_read_legacy_hh_mm_key():
     test_cache = DualCache()
-    legacy_key = "deployment:model:rpm:23-59"
-    test_cache.set_cache(key=legacy_key, value=100, local_only=True)
+    current_datetime = get_utc_datetime()
+    legacy_keys = {
+        f"deployment:model:rpm:{(current_datetime + timedelta(minutes=offset)):%H-%M}"
+        for offset in (0, 1)
+    }
+    for legacy_key in legacy_keys:
+        test_cache.set_cache(key=legacy_key, value=100, local_only=True)
     deployment = {
         "model_name": "model-group",
         "litellm_params": {"model": "model"},
         "model_info": {"id": "deployment"},
     }
-    fixed_datetime = datetime(2024, 1, 1, 23, 59, 30, tzinfo=timezone.utc)
     lowest_tpm_logger = LowestTPMLoggingHandler(router_cache=test_cache)
 
     with (
-        patch(
-            "litellm.router_strategy.lowest_tpm_rpm_v2.get_utc_datetime",
-            return_value=fixed_datetime,
-        ),
         patch.object(test_cache, "batch_get_cache", wraps=test_cache.batch_get_cache) as batch_get,
     ):
         assert (
@@ -138,7 +138,7 @@ def test_router_does_not_read_legacy_hh_mm_key():
         )
 
     requested_keys = [key for call in batch_get.call_args_list for key in call.kwargs["keys"]]
-    assert legacy_key not in requested_keys
+    assert legacy_keys.isdisjoint(requested_keys)
     assert all(":v2:" in key for key in requested_keys)
 
 
@@ -156,15 +156,9 @@ def test_router_uses_one_window_id_for_tpm_and_rpm_batches():
             "model_info": {"id": "deployment-2"},
         },
     ]
-    fixed_datetime = datetime(2024, 1, 1, 23, 59, 30, tzinfo=timezone.utc)
-    expected_window = utc_epoch_minute(fixed_datetime)
     lowest_tpm_logger = LowestTPMLoggingHandler(router_cache=test_cache)
 
     with (
-        patch(
-            "litellm.router_strategy.lowest_tpm_rpm_v2.get_utc_datetime",
-            return_value=fixed_datetime,
-        ),
         patch.object(test_cache, "batch_get_cache", wraps=test_cache.batch_get_cache) as batch_get,
     ):
         lowest_tpm_logger.get_available_deployments(
@@ -174,7 +168,7 @@ def test_router_uses_one_window_id_for_tpm_and_rpm_batches():
 
     assert len(batch_get.call_args_list) == 2
     requested_keys = [key for call in batch_get.call_args_list for key in call.kwargs["keys"]]
-    assert {key.rsplit(":", 1)[-1] for key in requested_keys} == {str(expected_window)}
+    assert len({key.rsplit(":", 1)[-1] for key in requested_keys}) == 1
 
 
 @pytest.mark.parametrize("cache_type", list(RouterCacheEnum))

--- a/tests/router_unit_tests/test_router_helper_utils.py
+++ b/tests/router_unit_tests/test_router_helper_utils.py
@@ -1002,7 +1002,7 @@ async def test_get_model_group_io_token_usage_sums_across_deployments():
     cache keys the pre-call reservation writes to.
     """
     from litellm.types.router import RouterCacheEnum
-    from litellm.utils import get_utc_datetime
+    from litellm.utils import get_utc_datetime, utc_epoch_minute
 
     router = Router(
         model_list=[
@@ -1027,29 +1027,29 @@ async def test_get_model_group_io_token_usage_sums_across_deployments():
         ]
     )
 
-    minute = get_utc_datetime().strftime("%H-%M")
+    window_id = utc_epoch_minute(get_utc_datetime())
     keys_and_values = [
         (
             RouterCacheEnum.ITPM.value.format(
-                id="io-usage-dep-1", model="openai/gpt-4o-mini", current_minute=minute
+                id="io-usage-dep-1", model="openai/gpt-4o-mini", window_id=window_id
             ),
             30,
         ),
         (
             RouterCacheEnum.OTPM.value.format(
-                id="io-usage-dep-1", model="openai/gpt-4o-mini", current_minute=minute
+                id="io-usage-dep-1", model="openai/gpt-4o-mini", window_id=window_id
             ),
             10,
         ),
         (
             RouterCacheEnum.ITPM.value.format(
-                id="io-usage-dep-2", model="openai/gpt-4o", current_minute=minute
+                id="io-usage-dep-2", model="openai/gpt-4o", window_id=window_id
             ),
             70,
         ),
         (
             RouterCacheEnum.OTPM.value.format(
-                id="io-usage-dep-2", model="openai/gpt-4o", current_minute=minute
+                id="io-usage-dep-2", model="openai/gpt-4o", window_id=window_id
             ),
             20,
         ),

--- a/tests/test_litellm/caching/test_redis_cache.py
+++ b/tests/test_litellm/caching/test_redis_cache.py
@@ -1,4 +1,5 @@
 import asyncio
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -15,6 +16,18 @@ def redis_no_ping():
         # Either raise an exception or return a mock that will handle the task creation
         mock_get_loop.side_effect = RuntimeError("No running event loop")
         yield
+
+
+def test_utc_epoch_minute_normalizes_naive_and_aware_datetimes():
+    from litellm.utils import utc_epoch_minute
+
+    naive_utc = datetime(2024, 1, 1, 23, 59, 30)
+    aware_utc = naive_utc.replace(tzinfo=timezone.utc)
+    aware_local = datetime(2024, 1, 2, 7, 59, 30, tzinfo=timezone(timedelta(hours=8)))
+
+    assert utc_epoch_minute(naive_utc) == utc_epoch_minute(aware_utc)
+    assert utc_epoch_minute(aware_local) == utc_epoch_minute(aware_utc)
+    assert utc_epoch_minute(datetime(2024, 1, 2, 0, 0, 0, tzinfo=timezone.utc)) != utc_epoch_minute(aware_utc)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_litellm/proxy/hooks/test_dynamic_rate_limiter.py
+++ b/tests/test_litellm/proxy/hooks/test_dynamic_rate_limiter.py
@@ -7,18 +7,21 @@ from litellm.proxy.hooks.dynamic_rate_limiter import (
     DynamicRateLimiterCache,
     _PROXY_DynamicRateLimitHandler,
 )
+from litellm.utils import utc_epoch_minute
 
 
 @pytest.mark.asyncio
 async def test_sadd_and_get_share_injected_clock_window():
     dual_cache = DualCache()
+    window_time = datetime(2024, 1, 1, 10, 30, 0, tzinfo=timezone.utc)
     cache = DynamicRateLimiterCache(
         cache=dual_cache,
-        time_fn=lambda: datetime(2024, 1, 1, 10, 30, 0, tzinfo=timezone.utc),
+        time_fn=lambda: window_time,
     )
     await cache.async_set_cache_sadd(model="my-fake-model", value=["p1", "p2", "p3"])
     assert await cache.async_get_cache(model="my-fake-model") == 3
-    assert await dual_cache.async_get_cache(key="10-30:my-fake-model") is not None
+    key = f"v2:{utc_epoch_minute(window_time)}:my-fake-model"
+    assert await dual_cache.async_get_cache(key=key) is not None
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/test_router/test_io_token_rate_limits.py
+++ b/tests/test_litellm/test_router/test_io_token_rate_limits.py
@@ -71,7 +71,7 @@ class TestIOTokenRateLimitHelpers:
 class TestModelRateLimitingCheckIOTokens:
     @pytest.mark.asyncio
     async def test_itpm_reservation_and_reconcile(self):
-        from litellm.utils import get_utc_datetime
+        from litellm.utils import get_utc_datetime, utc_epoch_minute
 
         dual_cache = DualCache()
         check = ModelRateLimitingCheck(dual_cache=dual_cache)
@@ -93,9 +93,9 @@ class TestModelRateLimitingCheckIOTokens:
         set_io_token_rate_limit_request_kwargs(request_kwargs)
         await check.async_pre_call_check(deployment)
 
-        minute = get_utc_datetime().strftime("%H-%M")
-        itpm_key = f"global_router:io-test-id:bedrock_mantle/anthropic.claude-opus-4-7:itpm:{minute}"
-        otpm_key = f"global_router:io-test-id:bedrock_mantle/anthropic.claude-opus-4-7:otpm:{minute}"
+        window_id = utc_epoch_minute(get_utc_datetime())
+        itpm_key = f"global_router:io-test-id:bedrock_mantle/anthropic.claude-opus-4-7:itpm:v2:{window_id}"
+        otpm_key = f"global_router:io-test-id:bedrock_mantle/anthropic.claude-opus-4-7:otpm:v2:{window_id}"
 
         kwargs = {
             "standard_logging_object": {
@@ -158,7 +158,7 @@ class TestModelRateLimitingCheckIOTokens:
 
     @pytest.mark.asyncio
     async def test_otpm_atomic_reservation_no_overshoot_under_concurrency(self):
-        from litellm.utils import get_utc_datetime
+        from litellm.utils import get_utc_datetime, utc_epoch_minute
 
         dual_cache = DualCache()
         check = ModelRateLimitingCheck(dual_cache=dual_cache)
@@ -191,8 +191,8 @@ class TestModelRateLimitingCheckIOTokens:
         results = await asyncio.gather(*[_attempt() for _ in range(8)])
         successes = sum(1 for r in results if r)
 
-        minute = get_utc_datetime().strftime("%H-%M")
-        otpm_key = f"global_router:io-otpm-race-id:bedrock_mantle/anthropic.claude-opus-4-7:otpm:{minute}"
+        window_id = utc_epoch_minute(get_utc_datetime())
+        otpm_key = f"global_router:io-otpm-race-id:bedrock_mantle/anthropic.claude-opus-4-7:otpm:v2:{window_id}"
         current_otpm = await dual_cache.async_get_cache(key=otpm_key)
 
         # Atomic reservation must never let concurrent requests overshoot the limit.
@@ -211,7 +211,7 @@ class TestModelRateLimitingCheckIOTokens:
         concurrent request is rejected until it completes - effectively
         serializing traffic to the deployment.
         """
-        from litellm.utils import get_utc_datetime
+        from litellm.utils import get_utc_datetime, utc_epoch_minute
 
         dual_cache = DualCache()
         check = ModelRateLimitingCheck(dual_cache=dual_cache)
@@ -243,8 +243,11 @@ class TestModelRateLimitingCheckIOTokens:
         results = await asyncio.gather(*[_attempt() for _ in range(8)])
         successes = sum(1 for r in results if r)
 
-        minute = get_utc_datetime().strftime("%H-%M")
-        itpm_key = f"global_router:io-itpm-estimate-fail-id:bedrock_mantle/anthropic.claude-opus-4-7:itpm:{minute}"
+        window_id = utc_epoch_minute(get_utc_datetime())
+        itpm_key = (
+            "global_router:io-itpm-estimate-fail-id:bedrock_mantle/anthropic.claude-opus-4-7:"
+            f"itpm:v2:{window_id}"
+        )
         current_itpm = await dual_cache.async_get_cache(key=itpm_key)
 
         # A minimal 1-token reservation per request lets itpm_limit concurrent
@@ -255,12 +258,12 @@ class TestModelRateLimitingCheckIOTokens:
 
     @pytest.mark.asyncio
     async def test_reservation_read_prefers_top_level_metadata_over_litellm_params(self):
-        from litellm.utils import get_utc_datetime
+        from litellm.utils import get_utc_datetime, utc_epoch_minute
 
         dual_cache = DualCache()
         check = ModelRateLimitingCheck(dual_cache=dual_cache)
-        minute = get_utc_datetime().strftime("%H-%M")
-        itpm_key = f"global_router:io-lp-id:bedrock_mantle/test:itpm:{minute}"
+        window_id = utc_epoch_minute(get_utc_datetime())
+        itpm_key = f"global_router:io-lp-id:bedrock_mantle/test:itpm:v2:{window_id}"
         await dual_cache.async_increment_cache(key=itpm_key, value=20, ttl=60)
 
         # Production kwargs commonly carry litellm_params.metadata; the stashed
@@ -281,7 +284,7 @@ class TestModelRateLimitingCheckIOTokens:
 
     @pytest.mark.asyncio
     async def test_reconcile_tracks_actual_usage_when_estimate_zero(self):
-        from litellm.utils import get_utc_datetime
+        from litellm.utils import get_utc_datetime, utc_epoch_minute
 
         dual_cache = DualCache()
         check = ModelRateLimitingCheck(dual_cache=dual_cache)
@@ -298,8 +301,8 @@ class TestModelRateLimitingCheckIOTokens:
         set_io_token_rate_limit_request_kwargs(request_kwargs)
         await check.async_pre_call_check(deployment)
 
-        minute = get_utc_datetime().strftime("%H-%M")
-        itpm_key = f"global_router:io-zero-est-id:bedrock_mantle/anthropic.claude-opus-4-7:itpm:{minute}"
+        window_id = utc_epoch_minute(get_utc_datetime())
+        itpm_key = f"global_router:io-zero-est-id:bedrock_mantle/anthropic.claude-opus-4-7:itpm:v2:{window_id}"
         # A failed/zero estimate reserves a minimal 1 token, not the full
         # itpm limit, so it doesn't starve concurrent requests.
         assert await dual_cache.async_get_cache(key=itpm_key) == 1
@@ -386,7 +389,7 @@ class TestModelRateLimitingCheckIOTokens:
         assert await dual_cache.async_get_cache(key=normal_output_otpm_key) == 5
 
     def test_sync_io_pre_call_reserves_and_reconciles(self):
-        from litellm.utils import get_utc_datetime
+        from litellm.utils import get_utc_datetime, utc_epoch_minute
 
         dual_cache = DualCache()
         check = ModelRateLimitingCheck(dual_cache=dual_cache)
@@ -407,9 +410,9 @@ class TestModelRateLimitingCheckIOTokens:
         set_io_token_rate_limit_request_kwargs(request_kwargs)
         check.pre_call_check(deployment)
 
-        minute = get_utc_datetime().strftime("%H-%M")
-        itpm_key = f"global_router:io-sync-id:bedrock_mantle/anthropic.claude-opus-4-7:itpm:{minute}"
-        otpm_key = f"global_router:io-sync-id:bedrock_mantle/anthropic.claude-opus-4-7:otpm:{minute}"
+        window_id = utc_epoch_minute(get_utc_datetime())
+        itpm_key = f"global_router:io-sync-id:bedrock_mantle/anthropic.claude-opus-4-7:itpm:v2:{window_id}"
+        otpm_key = f"global_router:io-sync-id:bedrock_mantle/anthropic.claude-opus-4-7:otpm:v2:{window_id}"
         kwargs = {
             "standard_logging_object": {
                 "model_id": "io-sync-id",
@@ -453,12 +456,12 @@ class TestModelRateLimitingCheckIOTokens:
 
     @pytest.mark.asyncio
     async def test_failure_clears_reservation_so_retry_is_not_poisoned(self):
-        from litellm.utils import get_utc_datetime
+        from litellm.utils import get_utc_datetime, utc_epoch_minute
 
         dual_cache = DualCache()
         check = ModelRateLimitingCheck(dual_cache=dual_cache)
-        minute = get_utc_datetime().strftime("%H-%M")
-        itpm_key = f"global_router:io-first:bedrock_mantle/test:itpm:{minute}"
+        window_id = utc_epoch_minute(get_utc_datetime())
+        itpm_key = f"global_router:io-first:bedrock_mantle/test:itpm:v2:{window_id}"
         await dual_cache.async_increment_cache(key=itpm_key, value=8, ttl=60)
 
         # Shared request metadata carrying the first (IO) deployment's reservation.
@@ -496,7 +499,7 @@ class TestModelRateLimitingCheckIOTokens:
         # The first deployment's ITPM counter is not driven negative...
         assert await dual_cache.async_get_cache(key=itpm_key) == 0
         # ...and the non-IO deployment's TPM usage is tracked normally.
-        tpm_key = f"non-io-second:openai/gpt-4o-mini:tpm:{minute}"
+        tpm_key = f"non-io-second:openai/gpt-4o-mini:tpm:v2:{window_id}"
         assert await dual_cache.async_get_cache(key=tpm_key) == 12
 
     @pytest.mark.asyncio
@@ -511,11 +514,11 @@ class TestModelRateLimitingCheckIOTokens:
         elevated by the reservation until its TTL expires, and the
         now-orphaned sentinels must not leak into B's accounting either.
         """
-        from litellm.utils import get_utc_datetime
+        from litellm.utils import get_utc_datetime, utc_epoch_minute
 
         dual_cache = DualCache()
-        minute = get_utc_datetime().strftime("%H-%M")
-        itpm_key_a = f"global_router:io-retry-a:bedrock_mantle/test-a:itpm:{minute}"
+        window_id = utc_epoch_minute(get_utc_datetime())
+        itpm_key_a = f"global_router:io-retry-a:bedrock_mantle/test-a:itpm:v2:{window_id}"
         await dual_cache.async_increment_cache(key=itpm_key_a, value=9, ttl=60)
 
         # Deployment A's still-unreconciled reservation, stashed on the shared
@@ -541,7 +544,7 @@ class TestModelRateLimitingCheckIOTokens:
         # The retry proceeds to stash deployment B's own reservation on the
         # same dict; it starts clean, unaffected by A's cleared sentinels.
         set_io_token_rate_limit_request_kwargs(shared_kwargs)
-        itpm_key_b = f"global_router:io-retry-b:bedrock_mantle/test-b:itpm:{minute}"
+        itpm_key_b = f"global_router:io-retry-b:bedrock_mantle/test-b:itpm:v2:{window_id}"
         shared_kwargs["metadata"][ITPM_RESERVED_KEY] = 4
         shared_kwargs["metadata"][ITPM_CACHE_KEY] = itpm_key_b
         await dual_cache.async_increment_cache(key=itpm_key_b, value=4, ttl=60)
@@ -594,7 +597,7 @@ class TestModelRateLimitingCheckIOTokens:
 
     @pytest.mark.asyncio
     async def test_otpm_reservation_error_rolls_back_itpm(self):
-        from litellm.utils import get_utc_datetime
+        from litellm.utils import get_utc_datetime, utc_epoch_minute
 
         class _OtpmFailCache(DualCache):
             async def async_increment_cache(self, key, **kwargs):
@@ -623,8 +626,8 @@ class TestModelRateLimitingCheckIOTokens:
         with pytest.raises(RuntimeError):
             await async_io_token_pre_call_check(dual_cache, deployment)
 
-        minute = get_utc_datetime().strftime("%H-%M")
-        itpm_key = f"global_router:io-rollback-id:bedrock_mantle/anthropic.claude-opus-4-7:itpm:{minute}"
+        window_id = utc_epoch_minute(get_utc_datetime())
+        itpm_key = f"global_router:io-rollback-id:bedrock_mantle/anthropic.claude-opus-4-7:itpm:v2:{window_id}"
         # A transient OTPM error must release the ITPM reservation, not leak it.
         assert (await dual_cache.async_get_cache(key=itpm_key) or 0) == 0
 
@@ -827,7 +830,7 @@ class TestModelRateLimitingCheckIOTokens:
     async def test_io_and_tpm_rpm_limits_both_enforced_with_warning(self, caplog):
         import logging
 
-        from litellm.utils import get_utc_datetime
+        from litellm.utils import get_utc_datetime, utc_epoch_minute
 
         dual_cache = DualCache()
         check = ModelRateLimitingCheck(dual_cache=dual_cache)
@@ -843,9 +846,9 @@ class TestModelRateLimitingCheckIOTokens:
             "model_name": "opus",
         }
 
-        minute = get_utc_datetime().strftime("%H-%M")
-        rpm_key = f"{model_id}:{deployment_name}:rpm:{minute}"
-        itpm_key = f"global_router:{model_id}:{deployment_name}:itpm:{minute}"
+        window_id = utc_epoch_minute(get_utc_datetime())
+        rpm_key = f"{model_id}:{deployment_name}:rpm:v2:{window_id}"
+        itpm_key = f"global_router:{model_id}:{deployment_name}:itpm:v2:{window_id}"
         await dual_cache.async_increment_cache(key=rpm_key, value=5, ttl=60)
 
         request_kwargs = {
@@ -871,15 +874,15 @@ class TestModelRateLimitingCheckIOTokens:
         success, otherwise the tpm_key the pre-call check reads is never written
         and the tpm_limit can never be enforced.
         """
-        from litellm.utils import get_utc_datetime
+        from litellm.utils import get_utc_datetime, utc_epoch_minute
 
         dual_cache = DualCache()
         check = ModelRateLimitingCheck(dual_cache=dual_cache)
         model_id = "io-tpm-mixed-id"
         deployment_name = "bedrock_mantle/anthropic.claude-opus-4-7"
-        minute = get_utc_datetime().strftime("%H-%M")
-        itpm_key = f"global_router:{model_id}:{deployment_name}:itpm:{minute}"
-        tpm_key = f"{model_id}:{deployment_name}:tpm:{minute}"
+        window_id = utc_epoch_minute(get_utc_datetime())
+        itpm_key = f"global_router:{model_id}:{deployment_name}:itpm:v2:{window_id}"
+        tpm_key = f"{model_id}:{deployment_name}:tpm:v2:{window_id}"
         await dual_cache.async_increment_cache(key=itpm_key, value=5, ttl=60)
 
         kwargs = {
@@ -903,15 +906,15 @@ class TestModelRateLimitingCheckIOTokens:
         assert await dual_cache.async_get_cache(key=tpm_key) == 7
 
     def test_io_success_still_tracks_tpm_for_mixed_deployment_sync(self):
-        from litellm.utils import get_utc_datetime
+        from litellm.utils import get_utc_datetime, utc_epoch_minute
 
         dual_cache = DualCache()
         check = ModelRateLimitingCheck(dual_cache=dual_cache)
         model_id = "io-tpm-mixed-sync-id"
         deployment_name = "bedrock_mantle/anthropic.claude-opus-4-7"
-        minute = get_utc_datetime().strftime("%H-%M")
-        itpm_key = f"global_router:{model_id}:{deployment_name}:itpm:{minute}"
-        tpm_key = f"{model_id}:{deployment_name}:tpm:{minute}"
+        window_id = utc_epoch_minute(get_utc_datetime())
+        itpm_key = f"global_router:{model_id}:{deployment_name}:itpm:v2:{window_id}"
+        tpm_key = f"{model_id}:{deployment_name}:tpm:v2:{window_id}"
         dual_cache.set_cache(key=itpm_key, value=5, ttl=60)
 
         kwargs = {
@@ -934,12 +937,12 @@ class TestModelRateLimitingCheckIOTokens:
 
     @pytest.mark.asyncio
     async def test_failure_refunds_itpm_reservation(self):
-        from litellm.utils import get_utc_datetime
+        from litellm.utils import get_utc_datetime, utc_epoch_minute
 
         dual_cache = DualCache()
         check = ModelRateLimitingCheck(dual_cache=dual_cache)
-        minute = get_utc_datetime().strftime("%H-%M")
-        itpm_key = f"global_router:io-refund-id:bedrock_mantle/test:itpm:{minute}"
+        window_id = utc_epoch_minute(get_utc_datetime())
+        itpm_key = f"global_router:io-refund-id:bedrock_mantle/test:itpm:v2:{window_id}"
         await dual_cache.async_increment_cache(key=itpm_key, value=20, ttl=60)
 
         reservation = {ITPM_RESERVED_KEY: 20, ITPM_CACHE_KEY: itpm_key}


### PR DESCRIPTION
## TLDR

Problem this solves:

- The legacy `HH-MM` rate-limit key repeats every day
- A stale counter from an earlier day can affect a later rate window

How it solves it:

- Uses a versioned epoch-minute window identifier for rate-limit keys
- Updates all rate-limit producers and readers to use the same window key

## User Flow

Before: a completion request can reuse a counter from the same minute on an earlier day

1. A client sends `POST https://litellm-domain/v1/chat/completions` during a finite rate window
2. The proxy stores the counter under a time-only `HH-MM` key
3. The same minute arrives on a later day
4. The later request reads the earlier day's counter

After: each minute is isolated across dates

1. A client sends the same completion request
2. The proxy stores the counter under a versioned epoch-minute key
3. The same minute arrives on a later day
4. The later request uses a different window key and does not read the earlier counter

## Relevant issues

Part of #38987

## Linear ticket


## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Delays in PR merge?

No known external dependency

## Screenshots / Proof of Fix

This issue is isolated to Redis rate-limit key generation and does not change an LLM HTTP response, so a provider end-to-end call is not applicable

### Before (92d45337)

#### Daily window key collision

1. Command: generate the rate-limit key for the same clock minute on two UTC dates
2. Observed output: both dates use the same legacy `HH-MM` suffix

### After (154c2682)

#### Versioned epoch-minute keys

1. Command: generate the rate-limit key for the same clock minute on two UTC dates
2. Observed output: the keys include different `v2` epoch-minute identifiers and do not collide

## Type

Bug Fix

## Caveats (if any)

### Medium

- Rolling deployments can briefly split counters between legacy and v2 key formats
- Switching key formats resets existing rate-limit counters for the new format
- PR3 provides the separate cleanup utility for legacy keys after old application versions are no longer running

## Final Attestation

- [x] I have reviewed the code and tests included in this PR
- [x] I have verified that this PR is limited to the stated behavior