### PR TITLE
fix(guardrails): preserve non-text content during masking

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -2954,6 +2954,8 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                     new_item["text"] = masked_texts[masking_index]
                     masking_index += 1
                 new_content.append(new_item)
+            elif isinstance(item, dict):
+                new_content.append(item)
             elif isinstance(item, str):
                 if masking_index < len(masked_texts):
                     item = masked_texts[masking_index]

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
@@ -4051,6 +4051,28 @@ async def test_apply_guardrail_unrecoverable_failure_logs_exactly_once_as_failed
     assert mock_log.call_args.kwargs["guardrail_status"] == "guardrail_failed_to_respond"
 
 
+def test_masking_preserves_non_text_content_parts():
+    """Masking text must not remove image parts from the model request."""
+    guardrail = _bedrock_guardrail_for_chunk_tests()
+    image_part = {
+        "type": "image_url",
+        "image_url": {"url": "https://example.com/image.png"},
+    }
+    messages = [
+        {
+            "role": "user",
+            "content": [{"type": "text", "text": "my ssn is 123-45-6789"}, image_part],
+        }
+    ]
+
+    updated = guardrail._apply_masking_to_messages(messages=messages, masked_texts=["my ssn is {SSN}"])
+
+    assert updated[0]["content"] == [
+        {"type": "text", "text": "my ssn is {SSN}"},
+        image_part,
+    ]
+
+
 @pytest.mark.asyncio
 async def test_apply_guardrail_chunk_merge_preserves_masking_position():
     """An earlier chunk that comes back clean (empty `outputs`) must not


### PR DESCRIPTION
## TLDR

Problem this solves:

- Masking rebuilt multimodal messages without their non-text content
- Images disappeared before the model received the request

How it solves it:

- Preserve dictionary content parts that do not contain text
- Add regression coverage for masked multimodal messages

## User Flow

Before: a developer masks sensitive request text, but the accompanying image disappears before inference

1. The proxy admin enables a Bedrock pre-call guardrail with request masking
2. The developer sends POST https://litellm-domain/v1/chat/completions with sensitive text and an `image_url` part
3. The guardrail anonymizes the text, but the model receives no image
4. The model cannot answer a question whose answer is visible only in the image

After: the same masked request keeps its image and reaches the model intact

1. The proxy admin enables the same Bedrock pre-call guardrail with request masking
2. The developer sends the same POST https://litellm-domain/v1/chat/completions request
3. The guardrail anonymizes the text while preserving the `image_url` part
4. The model can answer the image-dependent question without receiving sensitive text

## Relevant issues

- Extracted from #38175

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

Live Before and After proof still needs a Bedrock guardrail configured to anonymize request text and a multimodal model

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- This PR preserves images during masking but does not scan them

## Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
