### PR TITLE
fix(proxy): hydrate non-LLM objects when the model reconcile fails

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7131,7 +7131,7 @@ class ProxyConfig:
         try:
             # initialize vector stores, guardrails, etc. table in db
             await self._init_non_llm_objects_in_db(prisma_client=prisma_client)
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - same swallow the single handler above already had; a hydration failure must not stop the reconcile
             verbose_proxy_logger.exception(
                 "litellm.proxy.proxy_server.py::ProxyConfig:add_deployment non-LLM objects - %s", e
             )

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7123,11 +7123,18 @@ class ProxyConfig:
                     db_general_settings=db_general_settings.param_value,
                 )
 
-            # initialize vector stores, guardrails, etc. table in db
-            await self._init_non_llm_objects_in_db(prisma_client=prisma_client)
-
         except Exception as e:
             verbose_proxy_logger.exception("litellm.proxy.proxy_server.py::ProxyConfig:add_deployment - %s", e)
+
+        # Own try: the model reconcile above must not decide whether guardrails, vector
+        # stores, MCP servers and agents get hydrated. They read their own tables.
+        try:
+            # initialize vector stores, guardrails, etc. table in db
+            await self._init_non_llm_objects_in_db(prisma_client=prisma_client)
+        except Exception as e:
+            verbose_proxy_logger.exception(
+                "litellm.proxy.proxy_server.py::ProxyConfig:add_deployment non-LLM objects - %s", e
+            )
 
         # Read while the lock is still held: once it is released the next reconcile can
         # begin, and clear_cache's leading wipe would make this look like a mass drop.

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -1053,6 +1053,80 @@ async def test_initialize_scheduled_jobs_hydrates_mcp_when_store_model_in_db_fal
 
 
 @pytest.mark.asyncio
+async def test_add_deployment_hydrates_non_llm_objects_when_model_reconcile_fails():
+    """
+    Regression: _add_deployment_locked ran the model reconcile and the non-LLM object
+    hydration inside one try/except. A failure in the reconcile skipped guardrails,
+    vector stores, MCP servers, agents and pass-through endpoints for that pass, and
+    the swallowed exception left only a log line behind. add_deployment also runs on a
+    timer, so a transient DB error dropped every non-LLM object until a later pass.
+    """
+    from litellm.proxy.proxy_server import ProxyConfig
+    from litellm.proxy.utils import ProxyLogging
+
+    class FailingReconcileProxyConfig(ProxyConfig):
+        """Reconcile fails the way a DB outage makes it fail; hydration records itself."""
+
+        def __init__(self):
+            super().__init__()
+            self.non_llm_hydrations = 0
+
+        async def _get_models_from_db(self, prisma_client):
+            raise RuntimeError("db unavailable")
+
+        async def _init_non_llm_objects_in_db(self, prisma_client):
+            self.non_llm_hydrations += 1
+
+    proxy_config = FailingReconcileProxyConfig()
+
+    outcome = await proxy_config._add_deployment_locked(
+        prisma_client=MagicMock(),
+        proxy_logging_obj=MagicMock(spec=ProxyLogging),
+    )
+
+    assert proxy_config.non_llm_hydrations == 1
+    assert outcome.still_desired is None
+
+
+@pytest.mark.asyncio
+async def test_add_deployment_survives_a_non_llm_hydration_failure():
+    """
+    The new hydration boundary must behave like the reconcile one: log the error and
+    carry on, so a failing guardrail or vector-store table cannot take down the whole
+    reconcile pass or escape into the scheduler job that calls it.
+    """
+    from litellm.proxy.proxy_server import ProxyConfig
+    from litellm.proxy.utils import ProxyLogging
+
+    class FailingHydrationProxyConfig(ProxyConfig):
+        """Reconcile succeeds, hydration raises the way an unavailable table does."""
+
+        def __init__(self):
+            super().__init__()
+            self.reconcile_ran = False
+
+        async def _get_models_from_db(self, prisma_client):
+            return []
+
+        async def _update_llm_router(self, new_models, proxy_logging_obj):
+            self.reconcile_ran = True
+            return frozenset()
+
+        async def _init_non_llm_objects_in_db(self, prisma_client):
+            raise RuntimeError("guardrail table unavailable")
+
+    proxy_config = FailingHydrationProxyConfig()
+
+    outcome = await proxy_config._add_deployment_locked(
+        prisma_client=MagicMock(),
+        proxy_logging_obj=MagicMock(spec=ProxyLogging),
+    )
+
+    assert proxy_config.reconcile_ran is True
+    assert outcome.still_desired == frozenset()
+
+
+@pytest.mark.asyncio
 async def test_init_mcp_servers_from_db_respects_supported_db_objects(monkeypatch):
     """
     init_mcp_servers_from_db hydrates MCP from the DB by default but skips it when

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -1104,6 +1104,7 @@ async def test_add_deployment_survives_a_non_llm_hydration_failure():
         def __init__(self):
             super().__init__()
             self.reconcile_ran = False
+            self.hydration_attempted = False
 
         async def _get_models_from_db(self, prisma_client):
             return []
@@ -1113,6 +1114,7 @@ async def test_add_deployment_survives_a_non_llm_hydration_failure():
             return frozenset()
 
         async def _init_non_llm_objects_in_db(self, prisma_client):
+            self.hydration_attempted = True
             raise RuntimeError("guardrail table unavailable")
 
     proxy_config = FailingHydrationProxyConfig()
@@ -1123,6 +1125,7 @@ async def test_add_deployment_survives_a_non_llm_hydration_failure():
     )
 
     assert proxy_config.reconcile_ran is True
+    assert proxy_config.hydration_attempted is True
     assert outcome.still_desired == frozenset()
 
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- One model-sync error also skips guardrails, vector stores and MCP
- Nothing surfaces: the handler only writes a log line
- The sync runs on a timer, so a brief DB blip drops them all

How it solves it:

- Give the non-LLM object hydration its own try/except
- It reads its own tables, so the model sync cannot gate it

## User Flow

Before: an admin whose proxy hit a brief database error at startup finds their guardrails gone, with nothing in the response to say why

1. The admin has guardrails and a vector store saved in the database, and starts the proxy
2. The database is slow or briefly unreachable while the proxy reads its config
3. The proxy finishes starting and serves traffic normally
4. They send POST https://litellm-domain/v1/chat/completions with a prompt their guardrail is meant to block
5. The request succeeds and returns a normal completion, because no guardrail was loaded
6. They open https://litellm-domain/ui/?page=guardrails and see an empty list, although the guardrail is still in the database
7. The list stays empty until a later refresh happens to succeed

After: the same brief database error leaves the guardrails loaded

1. The admin has the same guardrails and vector store saved, and starts the proxy
2. The database is slow or briefly unreachable while the proxy reads its config
3. The proxy finishes starting and serves traffic normally
4. They send the same POST https://litellm-domain/v1/chat/completions with the prompt the guardrail blocks
5. The request is blocked by the guardrail, as it is on a healthy start
6. https://litellm-domain/ui/?page=guardrails lists the guardrail

## Relevant issues

None filed. I found this while withdrawing #32630, which claimed the wrong root cause for a related report.

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally: `pytest tests/test_litellm/proxy/test_proxy_server.py -k "add_deployment or mcp or non_llm or reconcile"` gives 5 passed
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

I do not have proxy credentials or a paid provider account, so I cannot supply the live end-to-end run this section asks for. Please treat what follows as short of the bar. The failure also needs a database error at the moment the proxy reads its config. That is hard to stage by hand against a healthy deployment.

The deterministic evidence I can give is below. It drives the real `_add_deployment_locked` on a `ProxyConfig` subclass. The subclass fails the model reconcile the way a DB outage does, and counts its own hydration calls, so the test injects no patches.

### Before (`92d45337`, the merge base)

#### The model reconcile fails, so non-LLM objects never hydrate

1. `pytest tests/test_litellm/proxy/test_proxy_server.py::test_add_deployment_hydrates_non_llm_objects_when_model_reconcile_fails`
2. Observed: `assert 0 == 1`, from `assert proxy_config.non_llm_hydrations == 1`. The injected `RuntimeError: db unavailable` is logged at `proxy_server.py:6988` and swallowed, which is the behaviour that hides this.

### After (`668a02bc`)

#### The model reconcile fails, so non-LLM objects never hydrate

1. `pytest tests/test_litellm/proxy/test_proxy_server.py::test_add_deployment_hydrates_non_llm_objects_when_model_reconcile_fails`
2. Observed: passed. The hydration still runs, and the reconcile still reports no desired ids.

A second case covers the new boundary itself. A raising `_init_non_llm_objects_in_db` must be logged and swallowed, not escape into the scheduler job that calls this. Removing the handler fails it with the raw `RuntimeError`.

Related tests at the PR tip:

```
pytest tests/test_litellm/proxy/test_proxy_server.py -k "add_deployment or mcp or non_llm or reconcile"
6 passed, 350 deselected
```

Reverting only the source change and keeping the test fails it with the assertion above, so the test holds the behaviour rather than restating it.

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- A failed model reconcile now runs one more DB read
- That read was always intended to run on this path

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

Basis: the test fails the reconcile at `_get_models_from_db`, inside the shared `try` and before the hydration, which is where a DB outage lands. `prefetch_config_params` swallows its own errors, so it is not a usable injection point. It asserts both halves. The hydration runs, and the reconcile still returns no desired ids, so the fix does not mask the original error.