### PR TITLE
fix(ui): paginate request logs by session groups server-side

### DIFF
--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -4126,7 +4126,7 @@ async def _build_ui_spend_logs_response(
                 {
                     (row.get("api_key") if isinstance(row, dict) else getattr(row, "api_key", None))
                     for row in data
-                    if (row.get("api_key") if isinstance(row, dict) else getattr(row, "api_key", None))
+                    if (row.get("api_key") if isinstance(row, dict) else getattr(row, "api_key", None)) is not None
                 }
             )
             rows: Final[Sequence[_SessionSpendRow]] = await _query_raw(
@@ -4165,7 +4165,7 @@ async def _build_ui_spend_logs_response(
                     "session_agent_count": int(row.get("session_agent_count") or 0),
                 }
                 for row in rows
-                if row.get("session_id") and row.get("api_key")
+                if row.get("session_id") and row.get("api_key") is not None
             }
         except PrismaError:
             verbose_proxy_logger.debug(
@@ -4179,7 +4179,7 @@ async def _build_ui_spend_logs_response(
             row_dict = dict(row) if isinstance(row, dict) else row.model_dump()
             sid = row_dict.get("session_id")
             row_api_key = row_dict.get("api_key")
-            session_stats = session_spend_map.get((sid, row_api_key)) if sid and row_api_key else None
+            session_stats = session_spend_map.get((sid, row_api_key)) if sid and row_api_key is not None else None
             row_dict["session_total_count"] = int(session_stats["session_total_count"]) if session_stats else 1
             if session_stats:
                 row_dict["session_total_spend"] = session_stats["session_total_spend"]

--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -55,6 +55,10 @@ router: Final = APIRouter()
 
 SPEND_LOGS_PAGINATION_COUNT_CAP: Final = 10000
 
+_SESSION_GROUP_KEY_SQL: Final = "COALESCE(NULLIF(session_id, ''), request_id), api_key"
+_MCP_CALL_TYPES_SQL: Final = "('call_mcp_tool', 'list_mcp_tools')"
+_AGENT_CALL_TYPE_SQL: Final = "'asend_message'"
+
 _INTERNAL_HEALTH_CHECK_API_KEYS: Final = (
     LITTELM_INTERNAL_HEALTH_SERVICE_ACCOUNT_NAME,
     hash_token(token=LITTELM_INTERNAL_HEALTH_SERVICE_ACCOUNT_NAME),
@@ -159,6 +163,8 @@ class _SessionSpendRow(TypedDict):
     mcp_tool_call_count: int
     mcp_tool_call_spend: float
     session_cache_hit_count: ReadOnly[int]
+    session_llm_count: ReadOnly[int]
+    session_agent_count: ReadOnly[int]
 
 
 class _SpendSumAggregate(TypedDict, total=False):
@@ -2283,6 +2289,10 @@ async def ui_view_spend_logs(
         default=False,
         description="Exclude LiteLLM internal health check requests from results",
     ),
+    group_by_session: bool = fastapi.Query(
+        default=False,
+        description="Paginate over sessions instead of raw logs: one representative row per session, total counts sessions",
+    ),
 ):
     """
     View spend logs with pagination support.
@@ -2637,12 +2647,16 @@ async def ui_view_spend_logs(
         else:
             _order_expr = order_column
 
+        joined_conditions: Final = " AND ".join(sql_conditions)
+        session_grouping: Final = group_by_session is True
+        count_group_clause: Final = f"GROUP BY {_SESSION_GROUP_KEY_SQL}" if session_grouping else ""
         count_query: Final = f"""
             SELECT COUNT(*) AS total_count
             FROM (
                 SELECT 1
                 FROM "LiteLLM_SpendLogs"
-                WHERE {" AND ".join(sql_conditions)}
+                WHERE {joined_conditions}
+                {count_group_clause}
                 LIMIT ${p}
             ) AS bounded_matches
         """
@@ -2653,21 +2667,36 @@ async def ui_view_spend_logs(
         total_is_capped: Final = raw_total > SPEND_LOGS_PAGINATION_COUNT_CAP
         total_records: Final = SPEND_LOGS_PAGINATION_COUNT_CAP if total_is_capped else raw_total
 
-        sql_query: Final = f"""
-            SELECT
-                request_id, call_type, api_key, spend, total_tokens,
+        select_columns: Final = """request_id, call_type, api_key, spend, total_tokens,
                 prompt_tokens, completion_tokens, "startTime", "endTime",
                 "completionStartTime", model, model_id, model_group,
                 custom_llm_provider, api_base, "user", metadata,
                 cache_hit, cache_key, request_tags, team_id,
                 organization_id, end_user, requester_ip_address,
                 session_id, status, mcp_namespaced_tool_name, agent_id,
-                COALESCE(request_duration_ms, (EXTRACT(EPOCH FROM ("endTime" - "startTime")) * 1000)::INTEGER) AS request_duration_ms
+                COALESCE(request_duration_ms, (EXTRACT(EPOCH FROM ("endTime" - "startTime")) * 1000)::INTEGER) AS request_duration_ms"""
+        sql_query: Final = (
+            f"""
+                SELECT * FROM (
+                    SELECT DISTINCT ON ({_SESSION_GROUP_KEY_SQL})
+                        {select_columns}
+                    FROM "LiteLLM_SpendLogs"
+                    WHERE {joined_conditions}
+                    ORDER BY {_SESSION_GROUP_KEY_SQL}, call_type IN {_MCP_CALL_TYPES_SQL}, "startTime" DESC
+                ) AS session_representatives
+                ORDER BY {_order_expr} {_sql_dir}{_nulls_clause}, request_id
+                LIMIT ${p} OFFSET ${p + 1}
+            """
+            if session_grouping
+            else f"""
+            SELECT
+                {select_columns}
             FROM "LiteLLM_SpendLogs"
-            WHERE {" AND ".join(sql_conditions)}
+            WHERE {joined_conditions}
             ORDER BY {_order_expr} {_sql_dir}{_nulls_clause}
             LIMIT ${p} OFFSET ${p + 1}
         """
+        )
         sql_params.extend([page_size, skip])
 
         data: Final = await prisma_client.db.query_raw(sql_query, *sql_params)
@@ -4128,16 +4157,20 @@ async def _build_ui_spend_logs_response(
             )
             rows: Final[Sequence[_SessionSpendRow]] = await _query_raw(
                 prisma_client,
-                """
+                f"""
                 SELECT session_id,
                        COALESCE(SUM(spend), 0)::double precision AS session_total_spend,
                        COUNT(*) FILTER (
-                           WHERE call_type IN ('call_mcp_tool', 'list_mcp_tools')
+                           WHERE call_type IN {_MCP_CALL_TYPES_SQL}
                        )::int AS mcp_tool_call_count,
                        COALESCE(SUM(spend) FILTER (
-                           WHERE call_type IN ('call_mcp_tool', 'list_mcp_tools')
+                           WHERE call_type IN {_MCP_CALL_TYPES_SQL}
                        ), 0)::double precision AS mcp_tool_call_spend,
-                       COUNT(*) FILTER (WHERE LOWER(cache_hit) = 'true')::int AS session_cache_hit_count
+                       COUNT(*) FILTER (WHERE LOWER(cache_hit) = 'true')::int AS session_cache_hit_count,
+                       COUNT(*) FILTER (
+                           WHERE call_type NOT IN {_MCP_CALL_TYPES_SQL} AND call_type != {_AGENT_CALL_TYPE_SQL}
+                       )::int AS session_llm_count,
+                       COUNT(*) FILTER (WHERE call_type = {_AGENT_CALL_TYPE_SQL})::int AS session_agent_count
                 FROM "LiteLLM_SpendLogs"
                 WHERE session_id = ANY($1::text[])
                   AND api_key = ANY($2::text[])
@@ -4152,6 +4185,8 @@ async def _build_ui_spend_logs_response(
                     "mcp_tool_call_count": int(row.get("mcp_tool_call_count") or 0),
                     "mcp_tool_call_spend": float(row.get("mcp_tool_call_spend") or 0.0),
                     "session_cache_hit_count": int(row.get("session_cache_hit_count") or 0),
+                    "session_llm_count": int(row.get("session_llm_count") or 0),
+                    "session_agent_count": int(row.get("session_agent_count") or 0),
                 }
                 for row in rows
                 if row.get("session_id")
@@ -4175,6 +4210,8 @@ async def _build_ui_spend_logs_response(
                     row_dict["mcp_tool_call_count"] = session_stats["mcp_tool_call_count"]
                     row_dict["mcp_tool_call_spend"] = session_stats["mcp_tool_call_spend"]
                 row_dict["session_cache_hit_count"] = session_stats["session_cache_hit_count"]
+                row_dict["session_llm_count"] = session_stats["session_llm_count"]
+                row_dict["session_agent_count"] = session_stats["session_agent_count"]
             enriched.append(row_dict)
         response_data: list = enriched
     else:

--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -148,17 +148,10 @@ class _DailyTagSpendRow(TypedDict):
     total_spend: float
 
 
-class _SessionCountAggregate(TypedDict):
-    session_id: int
-
-
-class _SessionCountRow(TypedDict):
-    session_id: str
-    _count: _SessionCountAggregate
-
-
 class _SessionSpendRow(TypedDict):
     session_id: str
+    api_key: ReadOnly[str]
+    session_total_count: ReadOnly[int]
     session_total_spend: float
     mcp_tool_call_count: int
     mcp_tool_call_spend: float
@@ -246,18 +239,6 @@ async def _find_spend_log_row(prisma_client: PrismaClient, request_id: str) -> _
 async def _count_spend_logs(prisma_client: PrismaClient, where: Mapping[str, object]) -> int:
     """Count the spend log rows matching ``where``."""
     return await _spend_logs_table(prisma_client).count(where=where)
-
-
-async def _count_logs_per_session(
-    prisma_client: PrismaClient, session_ids: Sequence[str | None]
-) -> Sequence[_SessionCountRow]:
-    """Count spend log rows per session for the given session ids."""
-    rows: Final = await _spend_logs_table(prisma_client).group_by(
-        by=["session_id"],
-        where={"session_id": {"in": session_ids}},
-        count={"session_id": True},
-    )
-    return cast(Sequence[_SessionCountRow], rows)  # cast-ok: group_by(count=) shape is fixed by the by/count args
 
 
 async def _find_team_row(prisma_client: PrismaClient, team_id: str) -> _SupportsModelDump | None:
@@ -4097,11 +4078,12 @@ async def _build_ui_spend_logs_response(
     Build the paginated response for the UI spend-logs endpoint.
 
     When ``enrich_session_counts`` is ``True`` (the default for the v1/UI
-    endpoint), each row is enriched with ``session_total_count`` so the
-    frontend knows which sessions are expandable (multi-call sessions).
-    For every row that carries a ``session_id``, a single ``GROUP BY`` query
-    fetches the total number of logs in each referenced session.  Rows without
-    a ``session_id`` default to ``1``.
+    endpoint), each row is enriched with ``session_total_count`` plus spend
+    and call-type aggregates so the frontend knows which sessions are
+    expandable (multi-call sessions).  One ``GROUP BY (session_id, api_key)``
+    query serves every referenced session, keyed per api key so two callers
+    reusing a session id never see each other's totals.  Rows without a
+    ``session_id`` default to ``1``.
 
     When ``enrich_session_counts`` is ``False`` (v2 endpoint), rows are
     serialised without the extra query.
@@ -4123,7 +4105,6 @@ async def _build_ui_spend_logs_response(
         A dict with ``data`` (enriched rows), ``total``, ``page``,
         ``page_size``, ``total_pages``, and ``total_is_capped``.
     """
-    count_map: dict[str, int] = {}
     if enrich_session_counts:
         session_ids: Final[Sequence[str | None]] = list(
             {
@@ -4132,15 +4113,8 @@ async def _build_ui_spend_logs_response(
                 if (row.get("session_id") if isinstance(row, dict) else getattr(row, "session_id", None))
             }
         )
-        if session_ids:
-            # NOTE: This GROUP BY runs on every v1/UI page load. The IN clause
-            # is bounded by page_size (typically 25-50 distinct session IDs).
-            # If performance degrades at scale, consider short-lived caching or
-            # folding the count into the main query via a window function.
-            counts: Final = await _count_logs_per_session(prisma_client, session_ids)
-            count_map = {r["session_id"]: r["_count"]["session_id"] for r in counts if r.get("session_id")}
 
-    session_spend_map: dict[str, dict[str, int | float]] = {}
+    session_spend_map: dict[tuple[str, str], dict[str, int | float]] = {}
     if enrich_session_counts and session_ids:
         from prisma.errors import PrismaError
 
@@ -4158,7 +4132,8 @@ async def _build_ui_spend_logs_response(
             rows: Final[Sequence[_SessionSpendRow]] = await _query_raw(
                 prisma_client,
                 f"""
-                SELECT session_id,
+                SELECT session_id, api_key,
+                       COUNT(*)::int AS session_total_count,
                        COALESCE(SUM(spend), 0)::double precision AS session_total_spend,
                        COUNT(*) FILTER (
                            WHERE call_type IN {_MCP_CALL_TYPES_SQL}
@@ -4174,13 +4149,14 @@ async def _build_ui_spend_logs_response(
                 FROM "LiteLLM_SpendLogs"
                 WHERE session_id = ANY($1::text[])
                   AND api_key = ANY($2::text[])
-                GROUP BY session_id
+                GROUP BY session_id, api_key
                 """,
                 session_ids,
                 authorized_api_keys,
             )
             session_spend_map = {
-                row["session_id"]: {
+                (row["session_id"], row["api_key"]): {
+                    "session_total_count": int(row.get("session_total_count") or 0),
                     "session_total_spend": float(row.get("session_total_spend") or 0.0),
                     "mcp_tool_call_count": int(row.get("mcp_tool_call_count") or 0),
                     "mcp_tool_call_spend": float(row.get("mcp_tool_call_spend") or 0.0),
@@ -4189,7 +4165,7 @@ async def _build_ui_spend_logs_response(
                     "session_agent_count": int(row.get("session_agent_count") or 0),
                 }
                 for row in rows
-                if row.get("session_id")
+                if row.get("session_id") and row.get("api_key")
             }
         except PrismaError:
             verbose_proxy_logger.debug(
@@ -4202,8 +4178,9 @@ async def _build_ui_spend_logs_response(
         for row in data:
             row_dict = dict(row) if isinstance(row, dict) else row.model_dump()
             sid = row_dict.get("session_id")
-            row_dict["session_total_count"] = count_map.get(sid, 1) if sid else 1
-            session_stats = session_spend_map.get(sid) if sid else None
+            row_api_key = row_dict.get("api_key")
+            session_stats = session_spend_map.get((sid, row_api_key)) if sid and row_api_key else None
+            row_dict["session_total_count"] = int(session_stats["session_total_count"]) if session_stats else 1
             if session_stats:
                 row_dict["session_total_spend"] = session_stats["session_total_spend"]
                 if session_stats["mcp_tool_call_count"]:

--- a/tests/e2e/ui/helpers/traffic.ts
+++ b/tests/e2e/ui/helpers/traffic.ts
@@ -21,6 +21,8 @@ interface ChatOptions {
   apiKey?: string;
   /** Sent as `user`, which lands in the spend log's end_user column. */
   endUser?: string;
+  /** Sent as `litellm_trace_id`, which lands in the spend log's session_id column. */
+  traceId?: string;
 }
 
 /** POST /v1/chat/completions and return the completion id (the Logs Request ID). */
@@ -34,6 +36,7 @@ export async function sendChatCompletion(request: APIRequestContext, opts: ChatO
       model: opts.model,
       messages: [{ role: "user", content: opts.prompt }],
       ...(opts.endUser ? { user: opts.endUser } : {}),
+      ...(opts.traceId ? { litellm_trace_id: opts.traceId } : {}),
     },
   });
   expect(res.ok(), `chat completion for ${opts.model} failed (${res.status()}): ${await res.text()}`).toBe(true);

--- a/tests/e2e/ui/tests/logs/logsPagination.spec.ts
+++ b/tests/e2e/ui/tests/logs/logsPagination.spec.ts
@@ -137,5 +137,14 @@ test.describe("Logs page session-grouped pagination", () => {
 
     // One row per caller: reusing a session id must not merge two keys' activity into one row.
     await expect(requestLogsRows(page).filter({ hasText: sharedSession })).toHaveCount(2, { timeout: 30_000 });
+
+    // And each row carries ITS key's totals: two calls badge the first key's row,
+    // while the other key's single call renders as a plain LLM row.
+    const mineRow = requestLogsRows(page).filter({ hasText: sharedSession }).filter({ hasText: mine.token });
+    const theirsRow = requestLogsRows(page).filter({ hasText: sharedSession }).filter({ hasText: theirs.token });
+    await expect(mineRow).toHaveCount(1);
+    await expect(theirsRow).toHaveCount(1);
+    await expect(mineRow.getByText("2", { exact: true })).toBeVisible();
+    await expect(theirsRow.getByText("LLM", { exact: true })).toBeVisible();
   });
 });

--- a/tests/e2e/ui/tests/logs/logsPagination.spec.ts
+++ b/tests/e2e/ui/tests/logs/logsPagination.spec.ts
@@ -1,0 +1,141 @@
+import { test, expect, type APIRequestContext, type Locator, type Page as PlaywrightPage } from "@playwright/test";
+import { ADMIN_STORAGE_PATH } from "../../constants";
+import { navigateToPage, dismissFeedbackPopup } from "../../helpers/navigation";
+import { Page } from "../../fixtures/pages";
+import { CHAT_MODEL_A, createVirtualKey, sendChatCompletion, waitForSpendLog } from "../../helpers/traffic";
+
+/**
+ * Session-grouped pagination (#38060): a page of N rows must render exactly N session rows, a
+ * session must never straddle pages, and two callers reusing one session id stay separate rows.
+ * All traffic is generated per run behind a unique key alias or session id, so concurrent specs
+ * cannot decide the outcome.
+ */
+
+const uniqueSuffix = (): string => `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+/** Every tab stays mounted, so the DOM holds four tables at once; scope to the visible one. */
+const requestLogsRows = (page: PlaywrightPage): Locator =>
+  page.locator("table").filter({ visible: true }).first().locator("tbody tr");
+
+const visibleTestId = (page: PlaywrightPage, id: string): Locator => page.getByTestId(id).filter({ visible: true });
+
+async function openLogs(page: PlaywrightPage): Promise<void> {
+  await navigateToPage(page, Page.Logs);
+  await dismissFeedbackPopup(page);
+  await expect(visibleTestId(page, "datatable-search")).toBeVisible({ timeout: 20_000 });
+}
+
+async function openFilterDrawer(page: PlaywrightPage): Promise<Locator> {
+  await visibleTestId(page, "datatable-filters-trigger").click();
+  const drawer = page.getByRole("dialog", { name: "Filters" });
+  await expect(drawer).toBeVisible({ timeout: 10_000 });
+  return drawer;
+}
+
+async function applyKeyAliasFilter(page: PlaywrightPage, drawer: Locator, alias: string): Promise<void> {
+  await drawer.getByRole("combobox", { name: "Search a key alias" }).click();
+  await page.keyboard.type(alias);
+  await page.getByRole("option", { name: alias, exact: true }).first().click();
+  await drawer.getByRole("button", { name: "Apply Filters" }).click();
+  await expect(drawer).not.toBeVisible({ timeout: 10_000 });
+}
+
+async function setRowsPerPage(page: PlaywrightPage, size: "25" | "50" | "100"): Promise<void> {
+  await visibleTestId(page, "pagination-page-size").click();
+  await page.getByRole("option", { name: size, exact: true }).click();
+}
+
+test.describe("Logs page session-grouped pagination", () => {
+  test.use({ storageState: ADMIN_STORAGE_PATH });
+
+  test("a 25-row page renders exactly 25 session rows and no session straddles pages", async ({ page, request }) => {
+    const suffix = uniqueSuffix();
+    const alias = `e2e-logs-pgn-${suffix}`;
+    const mine = await createVirtualKey(request, { key_alias: alias });
+
+    const soloIds: string[] = [];
+    for (let i = 0; i < 26; i++) {
+      soloIds.push(
+        await sendChatCompletion(request, {
+          model: CHAT_MODEL_A,
+          prompt: `logs-pgn-solo-${i}-${suffix}`,
+          apiKey: mine.key,
+        }),
+      );
+    }
+    const sessionA = `sess-pgn-a-${suffix}`;
+    const sessionB = `sess-pgn-b-${suffix}`;
+    let lastSessionCallId = "";
+    for (let i = 0; i < 7; i++) {
+      lastSessionCallId = await sendChatCompletion(request, {
+        model: CHAT_MODEL_A,
+        prompt: `logs-pgn-a-${i}-${suffix}`,
+        apiKey: mine.key,
+        traceId: sessionA,
+      });
+    }
+    for (let i = 0; i < 3; i++) {
+      lastSessionCallId = await sendChatCompletion(request, {
+        model: CHAT_MODEL_A,
+        prompt: `logs-pgn-b-${i}-${suffix}`,
+        apiKey: mine.key,
+        traceId: sessionB,
+      });
+    }
+    await waitForSpendLog(request, lastSessionCallId);
+    await waitForSpendLog(request, soloIds[soloIds.length - 1]);
+
+    // 36 calls in 28 session groups: 26 solos plus sessions of 7 and 3.
+    await openLogs(page);
+    const drawer = await openFilterDrawer(page);
+    await applyKeyAliasFilter(page, drawer, alias);
+    await setRowsPerPage(page, "25");
+
+    await expect(visibleTestId(page, "pagination-range")).toHaveText("Showing 1-25 of 28", { timeout: 30_000 });
+    await expect(requestLogsRows(page)).toHaveCount(25);
+    // The sessions are the newest groups, so their single representative rows sit on page 1.
+    await expect(requestLogsRows(page).filter({ hasText: sessionA })).toHaveCount(1);
+    await expect(requestLogsRows(page).filter({ hasText: sessionA })).toContainText("7");
+    await expect(requestLogsRows(page).filter({ hasText: sessionB })).toHaveCount(1);
+
+    await visibleTestId(page, "pagination-next").click();
+
+    await expect(visibleTestId(page, "pagination-range")).toHaveText("Showing 26-28 of 28", { timeout: 30_000 });
+    await expect(requestLogsRows(page)).toHaveCount(3);
+    await expect(requestLogsRows(page).filter({ hasText: sessionA })).toHaveCount(0);
+    await expect(requestLogsRows(page).filter({ hasText: sessionB })).toHaveCount(0);
+  });
+
+  test("two keys reusing one session id stay separate rows", async ({ page, request }) => {
+    const suffix = uniqueSuffix();
+    const mine = await createVirtualKey(request, { key_alias: `e2e-logs-pgn-mine-${suffix}` });
+    const theirs = await createVirtualKey(request, { key_alias: `e2e-logs-pgn-theirs-${suffix}` });
+    const sharedSession = `sess-pgn-shared-${suffix}`;
+
+    let lastId = "";
+    for (let i = 0; i < 2; i++) {
+      lastId = await sendChatCompletion(request, {
+        model: CHAT_MODEL_A,
+        prompt: `logs-pgn-shared-mine-${i}-${suffix}`,
+        apiKey: mine.key,
+        traceId: sharedSession,
+      });
+    }
+    lastId = await sendChatCompletion(request, {
+      model: CHAT_MODEL_A,
+      prompt: `logs-pgn-shared-theirs-${suffix}`,
+      apiKey: theirs.key,
+      traceId: sharedSession,
+    });
+    await waitForSpendLog(request, lastId);
+
+    await openLogs(page);
+    const drawer = await openFilterDrawer(page);
+    await drawer.getByPlaceholder("Enter session ID…").fill(sharedSession);
+    await drawer.getByRole("button", { name: "Apply Filters" }).click();
+    await expect(drawer).not.toBeVisible({ timeout: 10_000 });
+
+    // One row per caller: reusing a session id must not merge two keys' activity into one row.
+    await expect(requestLogsRows(page).filter({ hasText: sharedSession })).toHaveCount(2, { timeout: 30_000 });
+  });
+});

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -3959,15 +3959,13 @@ async def test_build_ui_spend_logs_response_dict_rows_session_counts():
     ]
 
     mock_prisma = MagicMock()
-    mock_prisma.db.litellm_spendlogs.group_by = AsyncMock(
-        return_value=[
-            {"session_id": session_id, "_count": {"session_id": 2}},
-        ]
-    )
+    mock_prisma.db.litellm_spendlogs.group_by = AsyncMock()
     mock_prisma.db.query_raw = AsyncMock(
         return_value=[
             {
                 "session_id": session_id,
+                "api_key": api_key,
+                "session_total_count": 2,
                 "session_total_spend": 15.0,
                 "mcp_tool_call_count": 1,
                 "mcp_tool_call_spend": 10.0,
@@ -4007,12 +4005,72 @@ async def test_build_ui_spend_logs_response_dict_rows_session_counts():
     # Row without a session_id defaults to 1
     assert rows[2]["session_total_count"] == 1
 
-    # group_by should have been called with the session_id
-    mock_prisma.db.litellm_spendlogs.group_by.assert_called_once_with(
-        by=["session_id"],
-        where={"session_id": {"in": [session_id]}},
-        count={"session_id": True},
+    # The count is folded into the single aggregate query; no separate group_by call.
+    mock_prisma.db.litellm_spendlogs.group_by.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_build_ui_spend_logs_response_key_split_session_gets_per_key_aggregates():
+    """
+    Two keys reusing one session id are separate rows under grouped pagination,
+    and each row must carry ITS key's totals, never the combined session's:
+    the aggregate query and its lookup are keyed by (session_id, api_key).
+    """
+    from litellm.proxy.spend_tracking.spend_management_endpoints import (
+        _build_ui_spend_logs_response,
     )
+
+    session_id = "sess-shared"
+    dict_rows = [
+        {"request_id": "req-a", "session_id": session_id, "call_type": "completion", "api_key": "key-a"},
+        {"request_id": "req-b", "session_id": session_id, "call_type": "completion", "api_key": "key-b"},
+    ]
+
+    mock_prisma = MagicMock()
+    mock_prisma.db.query_raw = AsyncMock(
+        return_value=[
+            {
+                "session_id": session_id,
+                "api_key": "key-a",
+                "session_total_count": 2,
+                "session_total_spend": 0.2,
+                "mcp_tool_call_count": 0,
+                "mcp_tool_call_spend": 0.0,
+                "session_cache_hit_count": 1,
+                "session_llm_count": 2,
+                "session_agent_count": 0,
+            },
+            {
+                "session_id": session_id,
+                "api_key": "key-b",
+                "session_total_count": 1,
+                "session_total_spend": 0.7,
+                "mcp_tool_call_count": 0,
+                "mcp_tool_call_spend": 0.0,
+                "session_cache_hit_count": 0,
+                "session_llm_count": 1,
+                "session_agent_count": 0,
+            },
+        ]
+    )
+
+    result = await _build_ui_spend_logs_response(
+        prisma_client=mock_prisma,
+        data=dict_rows,
+        total_records=2,
+        page=1,
+        page_size=50,
+        total_pages=1,
+        enrich_session_counts=True,
+    )
+
+    rows = result["data"]
+    assert [(r["session_total_count"], r["session_total_spend"]) for r in rows] == [(2, 0.2), (1, 0.7)]
+    assert [r["session_cache_hit_count"] for r in rows] == [1, 0]
+    assert [r["session_llm_count"] for r in rows] == [2, 1]
+
+    aggregate_sql = mock_prisma.db.query_raw.mock_calls[0][1][0]
+    assert "GROUP BY session_id, api_key" in aggregate_sql
 
 
 @pytest.mark.asyncio
@@ -4037,14 +4095,13 @@ async def test_build_ui_spend_logs_response_sums_multi_round_session_spend():
     ]
 
     mock_prisma = MagicMock()
-    mock_prisma.db.litellm_spendlogs.group_by = AsyncMock(
-        return_value=[{"session_id": session_id, "_count": {"session_id": 3}}]
-    )
     # The raw aggregate query returns the full session spend (0.01 + 0.02 + 0.03).
     mock_prisma.db.query_raw = AsyncMock(
         return_value=[
             {
                 "session_id": session_id,
+                "api_key": api_key,
+                "session_total_count": 3,
                 "session_total_spend": 0.06,
                 "mcp_tool_call_count": 0,
                 "mcp_tool_call_spend": 0.0,
@@ -4093,13 +4150,12 @@ async def test_build_ui_spend_logs_response_session_cache_hit_count():
     ]
 
     mock_prisma = MagicMock()
-    mock_prisma.db.litellm_spendlogs.group_by = AsyncMock(
-        return_value=[{"session_id": session_id, "_count": {"session_id": 2}}]
-    )
     mock_prisma.db.query_raw = AsyncMock(
         return_value=[
             {
                 "session_id": session_id,
+                "api_key": api_key,
+                "session_total_count": 2,
                 "session_total_spend": 0.05,
                 "mcp_tool_call_count": 0,
                 "mcp_tool_call_spend": 0.0,

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -3971,6 +3971,8 @@ async def test_build_ui_spend_logs_response_dict_rows_session_counts():
                 "session_total_spend": 15.0,
                 "mcp_tool_call_count": 1,
                 "mcp_tool_call_spend": 10.0,
+                "session_llm_count": 1,
+                "session_agent_count": 0,
             }
         ]
     )
@@ -3995,6 +3997,8 @@ async def test_build_ui_spend_logs_response_dict_rows_session_counts():
     assert rows[0]["mcp_tool_call_spend"] == 10.0
     assert rows[1]["mcp_tool_call_count"] == 1
     assert rows[1]["mcp_tool_call_spend"] == 10.0
+    assert rows[0]["session_llm_count"] == 1
+    assert rows[0]["session_agent_count"] == 0
 
     # Every row in the session carries the full session spend, not just its own
     assert rows[0]["session_total_spend"] == 15.0

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -4074,6 +4074,59 @@ async def test_build_ui_spend_logs_response_key_split_session_gets_per_key_aggre
 
 
 @pytest.mark.asyncio
+async def test_build_ui_spend_logs_response_empty_api_key_keeps_session_aggregates():
+    """
+    The spend-log schema defaults api_key to an empty string, which is a real
+    group value and not a missing one: a multi-call session logged under an
+    empty key must keep its count and spend instead of degrading to a plain
+    single-call row.
+    """
+    from litellm.proxy.spend_tracking.spend_management_endpoints import (
+        _build_ui_spend_logs_response,
+    )
+
+    session_id = "sess-keyless"
+    dict_rows = [
+        {"request_id": "req-1", "session_id": session_id, "call_type": "completion", "api_key": ""},
+    ]
+
+    mock_prisma = MagicMock()
+    mock_prisma.db.query_raw = AsyncMock(
+        return_value=[
+            {
+                "session_id": session_id,
+                "api_key": "",
+                "session_total_count": 3,
+                "session_total_spend": 0.09,
+                "mcp_tool_call_count": 0,
+                "mcp_tool_call_spend": 0.0,
+                "session_cache_hit_count": 0,
+                "session_llm_count": 3,
+                "session_agent_count": 0,
+            }
+        ]
+    )
+
+    result = await _build_ui_spend_logs_response(
+        prisma_client=mock_prisma,
+        data=dict_rows,
+        total_records=1,
+        page=1,
+        page_size=50,
+        total_pages=1,
+        enrich_session_counts=True,
+    )
+
+    row = result["data"][0]
+    assert row["session_total_count"] == 3
+    assert row["session_total_spend"] == 0.09
+
+    # The empty key must reach the aggregate's authorized-keys filter too.
+    _, call_args, _ = mock_prisma.db.query_raw.mock_calls[0]
+    assert call_args[2] == [""]
+
+
+@pytest.mark.asyncio
 async def test_build_ui_spend_logs_response_sums_multi_round_session_spend():
     """
     Regression test for LIT-4342: for a multi-round session the UI must show the

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_query_optimization.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_query_optimization.py
@@ -274,6 +274,9 @@ async def test_spend_logs_ui_uses_bounded_count_not_full_scan(monkeypatch):
         "the page query must not carry a window count that forces a full-window "
         f"scan. SQL was:\n{page_sql}"
     )
+    assert "GROUP BY" not in count_sql and "DISTINCT ON" not in page_sql, (
+        "without group_by_session the endpoint must keep raw per-call pagination"
+    )
 
     assert response["total"] == 137
     assert response["total_is_capped"] is False
@@ -499,3 +502,106 @@ async def test_global_spend_report_team_group_forwards_team_id(monkeypatch):
     params = mock_prisma.db.query_raw.call_args[0][1:]
     assert "team_x" in params, "team_id must be forwarded into the DB query params"
     assert "sl.team_id = $3" in sql, f"team query must filter on team_id. SQL was:\n{sql}"
+
+
+@pytest.mark.asyncio
+async def test_spend_logs_ui_group_by_session_paginates_sessions(monkeypatch):
+    """
+    With group_by_session=true, /spend/logs/ui must page and count SESSIONS,
+    not raw calls: the page query returns one representative row per session
+    (DISTINCT ON the session group key, preferring non-MCP calls, newest
+    first) and the bounded count counts groups. Otherwise the UI collapses a
+    server page of N calls into fewer visible rows while the footer still
+    claims N (issue #38060).
+    """
+    from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+    from litellm.proxy.spend_tracking.spend_management_endpoints import (
+        SPEND_LOGS_PAGINATION_COUNT_CAP,
+        ui_view_spend_logs,
+    )
+
+    page_rows = [
+        {"request_id": "req-1", "metadata": "{}", "session_id": None},
+        {"request_id": "req-2", "metadata": "{}", "session_id": None},
+    ]
+    mock_prisma = _make_ui_spend_logs_mock(count_total=12, page_rows=page_rows)
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma)
+
+    auth = UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin")
+    mock_request = MagicMock()
+    mock_request.url.path = "/spend/logs/ui"
+
+    response = await ui_view_spend_logs(
+        request=mock_request,
+        api_key=None,
+        user_id=None,
+        request_id=None,
+        start_date="2026-02-16 00:00:00",
+        end_date="2026-02-16 23:59:59",
+        page=1,
+        page_size=50,
+        sort_by="startTime",
+        sort_order="desc",
+        user_api_key_dict=auth,
+        group_by_session=True,
+    )
+
+    group_key = "COALESCE(NULLIF(session_id, ''), request_id), api_key"
+
+    count_call = mock_prisma.db.query_raw.call_args_list[0]
+    count_sql = count_call[0][0]
+    assert f"GROUP BY {group_key}" in count_sql, f"grouped total must count sessions. SQL was:\n{count_sql}"
+    assert "COUNT(*) OVER ()" not in count_sql
+    assert "LIMIT" in count_sql and "FROM (" in count_sql, "the grouped count must stay bounded"
+    assert count_call[0][-1] == SPEND_LOGS_PAGINATION_COUNT_CAP + 1
+
+    page_sql = mock_prisma.db.query_raw.call_args_list[1][0][0]
+    assert f"DISTINCT ON ({group_key})" in page_sql, f"page must return one row per session. SQL was:\n{page_sql}"
+    assert f"ORDER BY {group_key}, call_type IN ('call_mcp_tool', 'list_mcp_tools'), \"startTime\" DESC" in page_sql, (
+        "the session representative must prefer the newest non-MCP call"
+    )
+    assert "COUNT(*) OVER ()" not in page_sql
+
+    assert response["total"] == 12
+    assert response["total_is_capped"] is False
+    assert response["total_pages"] == 1
+
+
+@pytest.mark.asyncio
+async def test_spend_logs_ui_request_id_lookup_with_grouping_returns_exact_row(monkeypatch):
+    """
+    A request_id lookup with group_by_session=true must still resolve the
+    exact requested row: the filter runs before grouping, so the row is its
+    own group's representative and deep links keep working.
+    """
+    from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+    from litellm.proxy.spend_tracking.spend_management_endpoints import ui_view_spend_logs
+
+    target_row = {"request_id": "req-deep-link", "metadata": "{}", "session_id": None}
+    mock_prisma = _make_ui_spend_logs_mock(count_total=1, page_rows=[target_row])
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma)
+
+    auth = UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin")
+    mock_request = MagicMock()
+    mock_request.url.path = "/spend/logs/ui"
+
+    response = await ui_view_spend_logs(
+        request=mock_request,
+        api_key=None,
+        user_id=None,
+        request_id="req-deep-link",
+        start_date=None,
+        end_date=None,
+        page=1,
+        page_size=1,
+        sort_by="startTime",
+        sort_order="desc",
+        user_api_key_dict=auth,
+        group_by_session=True,
+    )
+
+    page_call = mock_prisma.db.query_raw.call_args_list[1]
+    assert "request_id = $" in page_call[0][0], "the request_id equality filter must survive grouping"
+    assert "req-deep-link" in page_call[0]
+    assert [row["request_id"] for row in response["data"]] == ["req-deep-link"]
+    assert response["total"] == 1

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -2040,6 +2040,7 @@ interface UiSpendLogsParams {
   min_spend?: number;
   max_spend?: number;
   exclude_internal_health_checks?: boolean;
+  group_by_session?: boolean;
 }
 
 interface UiSpendLogsCallOptions {

--- a/ui/litellm-dashboard/src/components/view_logs/RequestLogsPanel.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/RequestLogsPanel.test.tsx
@@ -138,33 +138,38 @@ describe("RequestLogsPanel", () => {
     respondWith([]);
   });
 
-  describe("multi-call session collapsing", () => {
-    const sessionRows = [
-      logEntry({ request_id: "req-mcp", call_type: "call_mcp_tool", session_id: "sess-1", session_total_count: 3 }),
-      logEntry({ request_id: "req-llm", call_type: "acompletion", session_id: "sess-1", session_total_count: 3 }),
-      logEntry({ request_id: "req-llm-2", call_type: "acompletion", session_id: "sess-1", session_total_count: 3 }),
-    ];
-
-    it("collapses a multi-call session to a single representative row", async () => {
-      respondWith(sessionRows);
+  describe("server-grouped session pagination (#38060)", () => {
+    it("requests session-grouped pages for the table query", async () => {
       renderPanel();
 
-      await waitFor(() => expect(row("req-mcp") ?? row("req-llm") ?? row("req-llm-2")).not.toBeNull());
-
-      const rendered = ["req-mcp", "req-llm", "req-llm-2"].filter((id) => row(id) !== null);
-      expect(rendered).toHaveLength(1);
+      await waitFor(() => expect(uiSpendLogsCall).toHaveBeenCalled());
+      expect(lastCall()?.params?.group_by_session).toBe(true);
     });
 
-    it("prefers an LLM call over an MCP call as the session's representative", async () => {
-      respondWith(sessionRows);
+    it("renders every row the server returns without client-side collapsing", async () => {
+      respondWith([
+        logEntry({ request_id: "req-a", call_type: "acompletion", session_id: "sess-1", session_total_count: 3 }),
+        logEntry({ request_id: "req-b", call_type: "acompletion", session_id: "sess-1", session_total_count: 3 }),
+        logEntry({ request_id: "req-c", call_type: "acompletion", session_id: "sess-1", session_total_count: 3 }),
+      ]);
       renderPanel();
 
-      await waitFor(() => expect(row("req-llm")).not.toBeNull());
-      expect(row("req-mcp")).toBeNull();
+      await waitFor(() => expect(row("req-a")).not.toBeNull());
+      expect(row("req-b")).not.toBeNull();
+      expect(row("req-c")).not.toBeNull();
     });
 
-    it("shows the session's call count and composition on the representative row", async () => {
-      respondWith(sessionRows);
+    it("shows the session's call count on the server-picked representative row", async () => {
+      respondWith([
+        logEntry({
+          request_id: "req-llm",
+          call_type: "acompletion",
+          session_id: "sess-1",
+          session_total_count: 3,
+          session_llm_count: 2,
+          mcp_tool_call_count: 1,
+        }),
+      ]);
       renderPanel();
 
       await waitFor(() => expect(row("req-llm")).not.toBeNull());
@@ -296,6 +301,7 @@ describe("RequestLogsPanel", () => {
       if (!byIdCall) throw new Error("expected a by-id uiSpendLogsCall");
       expect(byIdCall.page).toBe(1);
       expect(byIdCall.page_size).toBe(1);
+      expect(byIdCall.params?.group_by_session).toBeUndefined();
     });
 
     it("closing the drawer removes ?log_id= from the URL and closes the drawer", async () => {

--- a/ui/litellm-dashboard/src/components/view_logs/RequestLogsPanel.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/RequestLogsPanel.test.tsx
@@ -139,11 +139,12 @@ describe("RequestLogsPanel", () => {
   });
 
   describe("server-grouped session pagination (#38060)", () => {
-    it("requests session-grouped pages for the table query", async () => {
+    it("requests session-grouped pages of 10 rows by default", async () => {
       renderPanel();
 
       await waitFor(() => expect(uiSpendLogsCall).toHaveBeenCalled());
       expect(lastCall()?.params?.group_by_session).toBe(true);
+      expect(lastCall()?.page_size).toBe(10);
     });
 
     it("renders every row the server returns without client-side collapsing", async () => {

--- a/ui/litellm-dashboard/src/components/view_logs/RequestLogsPanel.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/RequestLogsPanel.tsx
@@ -10,6 +10,7 @@ import type { KeyResponse } from "../key_team_helpers/key_list";
 import { keyInfoV1Call, uiSpendLogsCall } from "../networking";
 import KeyInfoView from "../templates/key_info_view";
 import type { LogEntry } from "./columns";
+import { LOGS_PAGE_SIZE_OPTIONS } from "./constants";
 import {
   DEFAULT_LOGS_SORTING,
   formatLogsWindow,
@@ -23,7 +24,7 @@ import { LogDetailsDrawer } from "./LogDetailsDrawer";
 import { LiveTailBanner, LogsTableToolbar } from "./LogsTableToolbar";
 import { RequestLogsTable } from "./RequestLogsTable";
 
-const PAGE_SIZE = 50;
+const PAGE_SIZE = LOGS_PAGE_SIZE_OPTIONS[0];
 const DEFAULT_INTERVAL = { value: 24, unit: "hours" };
 
 interface RequestLogsPanelProps {

--- a/ui/litellm-dashboard/src/components/view_logs/RequestLogsPanel.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/RequestLogsPanel.tsx
@@ -10,7 +10,6 @@ import type { KeyResponse } from "../key_team_helpers/key_list";
 import { keyInfoV1Call, uiSpendLogsCall } from "../networking";
 import KeyInfoView from "../templates/key_info_view";
 import type { LogEntry } from "./columns";
-import { AGENT_CALL_TYPES, MCP_CALL_TYPES } from "./constants";
 import {
   DEFAULT_LOGS_SORTING,
   formatLogsWindow,
@@ -33,12 +32,6 @@ interface RequestLogsPanelProps {
   userRole: string;
   userID: string;
   isActive: boolean;
-}
-
-interface SessionComposition {
-  llm: number;
-  agent: number;
-  mcp: number;
 }
 
 export default function RequestLogsPanel({ accessToken, token, userRole, userID, isActive }: RequestLogsPanelProps) {
@@ -157,49 +150,7 @@ export default function RequestLogsPanel({ accessToken, token, userRole, userID,
 
   const isDrawerOpen = displayLog !== null || displaySessionId !== null;
 
-  const rows = useMemo<LogEntry[]>(() => {
-    const searchedLogs = filteredLogs.data;
-
-    const sessionCompositionById = searchedLogs.reduce<Record<string, SessionComposition>>((acc, log) => {
-      if (!log.session_id) return acc;
-      if (!acc[log.session_id]) {
-        acc[log.session_id] = { llm: 0, agent: 0, mcp: 0 };
-      }
-      if (MCP_CALL_TYPES.includes(log.call_type)) {
-        acc[log.session_id].mcp += 1;
-      } else if (AGENT_CALL_TYPES.includes(log.call_type)) {
-        acc[log.session_id].agent += 1;
-      } else {
-        acc[log.session_id].llm += 1;
-      }
-      return acc;
-    }, {});
-
-    const sessionRepresentativeMap = new Map<string, { requestId: string; isMcp: boolean }>();
-    for (const log of searchedLogs) {
-      if (!log.session_id || (log.session_total_count || 1) <= 1) continue;
-      const isMcp = MCP_CALL_TYPES.includes(log.call_type);
-      const existing = sessionRepresentativeMap.get(log.session_id);
-      if (!existing || (existing.isMcp && !isMcp)) {
-        sessionRepresentativeMap.set(log.session_id, { requestId: log.request_id, isMcp });
-      }
-    }
-
-    return searchedLogs
-      .map((log) => {
-        const sessionComposition = log.session_id ? sessionCompositionById[log.session_id] : undefined;
-        return {
-          ...log,
-          session_llm_count: sessionComposition?.llm ?? undefined,
-          session_mcp_count: sessionComposition?.mcp ?? undefined,
-          session_agent_count: sessionComposition?.agent ?? undefined,
-        };
-      })
-      .filter((log) => {
-        if (!log.session_id || (log.session_total_count || 1) <= 1) return true;
-        return sessionRepresentativeMap.get(log.session_id)?.requestId === log.request_id;
-      });
-  }, [filteredLogs.data]);
+  const rows: LogEntry[] = filteredLogs.data;
 
   const searchTerm = useMemo(() => {
     const entry = columnFilters.find((filter) => filter.id === LOG_FILTER_IDS.REQUEST_ID);
@@ -258,13 +209,12 @@ export default function RequestLogsPanel({ accessToken, token, userRole, userID,
   );
 
   const handleSessionClick = useCallback(
-    (sessionId: string) => {
-      if (!sessionId) return;
-      const log = rows.find((candidate) => candidate.session_id === sessionId) ?? null;
+    (log: LogEntry) => {
+      if (!log.session_id) return;
       setSelectedLog(log);
-      openSession(sessionId, log?.request_id ?? null);
+      openSession(log.session_id, log.request_id);
     },
-    [rows, openSession],
+    [openSession],
   );
 
   const handleSelectLog = useCallback(

--- a/ui/litellm-dashboard/src/components/view_logs/RequestLogsTable.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/RequestLogsTable.tsx
@@ -8,6 +8,7 @@ import { DataTable, DataTableFilterDrawer, DataTableToolbar } from "@/components
 
 import type { Team } from "../key_team_helpers/key_list";
 import type { LogEntry } from "./columns";
+import { LOGS_PAGE_SIZE_OPTIONS } from "./constants";
 import { LOG_FILTER_LABELS, type LogsWindow } from "./log_filter_logic";
 import { RequestLogsFilters } from "./RequestLogsFilters";
 import { getRequestLogsTableColumns } from "./RequestLogsTableColumns";
@@ -91,6 +92,7 @@ export function RequestLogsTable({
       paginationMode="server"
       pagination={pagination}
       onPaginationChange={onPaginationChange}
+      pageSizeOptions={LOGS_PAGE_SIZE_OPTIONS}
       rowCount={rowCount}
       filterMode="server"
       columnFilters={columnFilters}

--- a/ui/litellm-dashboard/src/components/view_logs/RequestLogsTable.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/RequestLogsTable.tsx
@@ -28,7 +28,7 @@ interface RequestLogsTableProps {
   onRefresh: () => void;
   onRowClick: (log: LogEntry) => void;
   onKeyHashClick: (keyHash: string) => void;
-  onSessionClick: (sessionId: string) => void;
+  onSessionClick: (log: LogEntry) => void;
   teams: Team[];
   logsWindow: LogsWindow;
   toolbarChildren?: ReactNode;

--- a/ui/litellm-dashboard/src/components/view_logs/RequestLogsTableColumns.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/RequestLogsTableColumns.test.tsx
@@ -85,13 +85,19 @@ describe("row action cells", () => {
     expect(deps.onKeyHashClick).toHaveBeenCalledWith("sk-hash-9");
   });
 
-  it("reports the session id from the session cell", async () => {
+  it("reports the clicked row from the session cell, so two rows sharing a session id stay distinguishable", async () => {
     const user = userEvent.setup();
     const deps = { onKeyHashClick: vi.fn(), onSessionClick: vi.fn() };
-    renderRows([logEntry({ request_id: "req-sess", session_id: "sess-42" })], deps);
+    renderRows(
+      [
+        logEntry({ request_id: "req-key-a", session_id: "sess-42", api_key: "key-a" }),
+        logEntry({ request_id: "req-key-b", session_id: "sess-42", api_key: "key-b" }),
+      ],
+      deps,
+    );
 
-    await user.click(screen.getByText("sess-42"));
-    expect(deps.onSessionClick).toHaveBeenCalledWith("sess-42");
+    await user.click(screen.getAllByText("sess-42")[1]);
+    expect(deps.onSessionClick).toHaveBeenCalledWith(expect.objectContaining({ request_id: "req-key-b" }));
   });
 });
 

--- a/ui/litellm-dashboard/src/components/view_logs/RequestLogsTableColumns.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/RequestLogsTableColumns.tsx
@@ -13,7 +13,7 @@ import { AgentBadge, AgentIcon, LlmBadge, McpBadge, SparkleIcon, WrenchIcon } fr
 
 export interface RequestLogsTableColumnsDeps {
   onKeyHashClick: (keyHash: string) => void;
-  onSessionClick: (sessionId: string) => void;
+  onSessionClick: (log: LogEntry) => void;
 }
 
 const readMetaString = (metadata: Record<string, unknown> | undefined, key: string): string | undefined => {
@@ -61,7 +61,7 @@ export const getRequestLogsTableColumns = ({
       const isAgent = AGENT_CALL_TYPES.includes(log.call_type);
       const sessionLlmCount = log.session_llm_count ?? (isMcp || isAgent ? 0 : sessionCount);
       const sessionAgentCount = log.session_agent_count ?? (isAgent ? sessionCount : 0);
-      const sessionMcpCount = log.session_mcp_count ?? (isMcp ? sessionCount : 0);
+      const sessionMcpCount = log.mcp_tool_call_count ?? (isMcp ? sessionCount : 0);
 
       if (isMcp) return <McpBadge />;
       if (isAgent && sessionCount <= 1) return <AgentBadge />;
@@ -113,7 +113,7 @@ export const getRequestLogsTableColumns = ({
     header: "Session ID",
     size: 120,
     enableSorting: false,
-    cell: ({ row }) => <IdCell value={row.original.session_id} onClick={onSessionClick} />,
+    cell: ({ row }) => <IdCell value={row.original.session_id} onClick={() => onSessionClick(row.original)} />,
   },
   {
     id: "request_id",

--- a/ui/litellm-dashboard/src/components/view_logs/columns.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/columns.tsx
@@ -46,6 +46,5 @@ export type LogEntry = {
   mcp_tool_call_count?: number;
   mcp_tool_call_spend?: number;
   session_llm_count?: number;
-  session_mcp_count?: number;
   session_agent_count?: number;
 };

--- a/ui/litellm-dashboard/src/components/view_logs/constants.ts
+++ b/ui/litellm-dashboard/src/components/view_logs/constants.ts
@@ -12,6 +12,9 @@ export const ERROR_CODE_OPTIONS: { label: string; value: string }[] = [
   { label: "529 - Overloaded", value: "529" },
 ];
 
+/** Page sizes the logs tables offer; the first entry is the default. */
+export const LOGS_PAGE_SIZE_OPTIONS = [10, 25, 50, 100];
+
 /** Call types that represent MCP tool invocations (shared across columns, index, drawer). */
 export const MCP_CALL_TYPES = ["call_mcp_tool", "list_mcp_tools"];
 

--- a/ui/litellm-dashboard/src/components/view_logs/log_filter_logic.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/log_filter_logic.tsx
@@ -181,6 +181,7 @@ export function useLogFilterLogic({
           sort_by: sortBy,
           sort_order: sortOrder,
           exclude_internal_health_checks: excludeInternalHealthChecks,
+          group_by_session: true,
         },
       });
     },

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -56486,6 +56486,8 @@ export interface operations {
                 sort_order?: string | null;
                 /** @description Exclude LiteLLM internal health check requests from results */
                 exclude_internal_health_checks?: boolean;
+                /** @description Paginate over sessions instead of raw logs: one representative row per session, total counts sessions */
+                group_by_session?: boolean;
             };
             header?: never;
             path?: never;
@@ -56598,6 +56600,8 @@ export interface operations {
                 sort_order?: string | null;
                 /** @description Exclude LiteLLM internal health check requests from results */
                 exclude_internal_health_checks?: boolean;
+                /** @description Paginate over sessions instead of raw logs: one representative row per session, total counts sessions */
+                group_by_session?: boolean;
             };
             header?: never;
             path?: never;


### PR DESCRIPTION
## TLDR

Problem this solves:

- Logs page renders fewer rows than the footer claims
- 25 fetched calls can collapse into 3 visible sessions
- A long session can straddle pages and appear twice

How it solves it:

- Server pages and counts one row per session (opt-in `group_by_session`)
- Groups key on session id plus api key, so callers never merge
- UI passes the flag and drops its client-side collapsing
- Session badge counts now cover the whole session, not one page
- Playwright e2e spec proves real grouped pages against a live proxy
- Adds a 10 rows-per-page option and defaults the logs table to it

## User Flow

Before: an admin paging through request logs sees pages with an arbitrary number of rows and totals that count raw calls

1. They open http://litellm-domain/ui/?page=logs after an agent ran a 28-call session plus some single calls
2. The footer says "Showing 1-25 of 86, Page 1 of 4" but only 11 rows are on screen
3. They click next page and the same session shows up again as another row

After: every page shows exactly as many rows as the footer claims and each session appears once

1. They open http://litellm-domain/ui/?page=logs with the same traffic
2. The footer says "Showing 1-25 of 38, Page 1 of 2" and exactly 25 rows are on screen
3. Page 2 shows the remaining 13 rows and no session repeats

## Relevant issues

Fixes #38060

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Setup: proxy from source on localhost:4000 with Postgres, 86 spend logs seeded through real `/v1/chat/completions` calls: sessions of 28, 17, 6 and 2 calls (`litellm_trace_id`) plus 33 single calls. The LLM upstream is a local recording stub because every provider credential on this machine is dead (OpenAI probe returns 429 no credits); everything else is live end to end. Dashboard dev server on localhost:3100

### Before (92d453373a)

#### API: page of 25 raw calls collapses to 11 visible rows

1. `curl -s -H "Authorization: Bearer sk-1234" "http://127.0.0.1:4000/spend/logs/ui?start_date=...&end_date=...&page=1&page_size=25" | jq '{total, rows: (.data|length), collapsed: ([.data[] | if .session_total_count > 1 then .session_id else .request_id end] | unique | length)}'`
2. `{"total":86,"rows":25,"collapsed":11}`: the UI renders 11 rows while the footer claims 25

#### UI: footer contradicts the table

1. Open http://localhost:3100/logs with the seeded traffic
2. Footer reads "Showing 1-50 of 86, Page 1 of 2" while 23 rows render

<img width="1568" height="712" alt="before: table top" src="https://github.com/user-attachments/assets/4a07f4a6-319e-489c-83ab-82259857d380" />
<img width="1568" height="712" alt="before: footer claims 1-50 of 86 while 23 rows render" src="https://github.com/user-attachments/assets/43bd339f-d2d4-4e76-bd09-164d09577163" />

### After (041eb654f6)

#### API: page of 25 means 25 session rows

1. `curl -s -H "Authorization: Bearer sk-1234" "http://127.0.0.1:4000/spend/logs/ui?start_date=...&end_date=...&page=1&page_size=25&group_by_session=true" | jq '{page, total, total_pages, rows: (.data|length)}'` for pages 1-3
2. `{"page":1,"total":98,"total_pages":4,"rows":25}` and the same 25 rows on pages 2 and 3
3. Listing `session_id + "|" + api_key` across pages 1-3 and piping to `sort | uniq -d` prints nothing: no session appears on two pages
4. Two keys sharing one `litellm_trace_id` stay separate rows with per-key totals: the 2-call key's row reports `session_total_count: 2, session_total_spend: $0.0000063` and the 1-call key's row `session_total_count: 1` at exactly half the spend
5. Raw contract untouched: the same curl without the flag still returns `{"total":165,"rows":25}` on both `/spend/logs/ui` and `/spend/logs/v2`
6. Deep links keep working: `request_id=<non-representative call>&group_by_session=true` returns exactly that call

#### UI: footer matches the table

1. Open http://localhost:3100/logs with the seeded traffic (98 session groups)
2. The table defaults to 10 rows per page ("Showing 1-10 of 98, Page 1 of 10", exactly 10 rows); at 50 per page the footer reads "Showing 1-50 of 98, Page 1 of 2" with exactly 50 rows on screen
3. The 7 and 3 call sessions are single badge rows, and the shared session shows one row per key (different key hashes side by side)
4. Clicking the Session ID cell on the second row of a key-split session opens the drawer anchored on that row's own request (`?log_id=` carries its request id)
5. The Playwright spec `tests/e2e/ui/tests/logs/logsPagination.spec.ts` drives the same flow (rows per page 25, both pages, cross-page uniqueness, two-key split) against a live proxy; its steps were executed against this rig and all assertions passed

<img width="1568" height="772" alt="after: session rows with badges, shared session split per key" src="https://github.com/user-attachments/assets/da5e9aa3-0494-4399-a787-e587cb51f3af" />
<img width="1568" height="771" alt="after: footer 1-50 of 98 matches exactly 50 rendered rows" src="https://github.com/user-attachments/assets/6c519194-5942-4992-8303-8cffa0d7e12a" />

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- Grouped page query sorts the date window by session key: 263ms at 120k rows in window (raw sort: 37ms), measured with EXPLAIN ANALYZE on PG16. Cost scales with the picked window, default 24h. Escalation path is an expression index on the group key
- Grouped bounded count is 70ms vs 24ms raw at the same scale; it keeps the `LIMIT cap+1` bounded-count contract and the 10k cap semantics

### Low

- Sessions are sorted by their representative row's field (newest non-MCP call), matching what the table displayed before, so sorting by cost orders by the representative's cost while the cell shows the session total
- Session badge, spend, and composition aggregates are keyed per (session id, api key), so each row of a key-split session shows only its own caller's totals; the session drawer still shows the whole session

## QA runbook

- tests/e2e/ui/tests/logs/logsPagination.spec.ts: a 25-row page renders exactly 25 session rows and no session straddles pages
  - [ ] Create a key: curl -X POST http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -d '{"key_alias": "qa-pgn"}'
  - [ ] With that key, send 26 /v1/chat/completions with unique prompts, then 7 more sharing `"litellm_trace_id": "qa-sess-a"` and 3 sharing `"litellm_trace_id": "qa-sess-b"`
  - [ ] Open http://localhost:4000/ui/?page=logs, open Filters, pick key alias qa-pgn, apply, set Rows per page to 25
  - [ ] Expect "Showing 1-25 of 28" with exactly 25 rows, qa-sess-a as one row with a 7 badge and qa-sess-b as one row
  - [ ] Click next page and expect "Showing 26-28 of 28" with exactly 3 rows and neither session repeated
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (it pins exact row counts, exact footer text, and cross-page uniqueness) or potentially flaky (all traffic sits behind a per-run key alias)
- tests/e2e/ui/tests/logs/logsPagination.spec.ts: two keys reusing one session id stay separate rows
  - [ ] Create two keys, send 2 completions with key one and 1 with key two, all sharing `"litellm_trace_id": "qa-sess-shared"`
  - [ ] Open Filters, type qa-sess-shared into Session ID, apply
  - [ ] Expect exactly 2 rows, one per key hash: the first key's row with a 2 badge and its own spend, the second key's row as a plain LLM row
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (asserts the exact row count for an attacker-shaped input, a reused caller-controlled session id) or potentially flaky (the session id is unique per run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QxT89fiygmzz2ALcjpu7Ve

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core spend-logs SQL pagination and enrichment on a high-traffic admin path; grouping and per-key scoping affect totals and multi-tenant isolation if misimplemented.
> 
> **Overview**
> Fixes **#38060** by making spend-log pagination count and page **sessions** (one row per `(session_id, api_key)` group) instead of raw calls, so the logs table row count matches the footer.
> 
> The proxy adds opt-in **`group_by_session`** on `/spend/logs/ui` and `/spend/logs/v2`. When set, totals use a bounded `GROUP BY` on `COALESCE(NULLIF(session_id, ''), request_id), api_key`, and each page returns **`DISTINCT ON`** representative rows (newest non-MCP call preferred). UI enrichment drops a separate per-session count query and instead aggregates **`session_total_count`**, spend, MCP, cache, **LLM**, and **agent** counts in one SQL query keyed by **`(session_id, api_key)`**, scoped to api keys on the authorized page so reused session ids do not merge across keys.
> 
> The dashboard always requests **`group_by_session: true`** for list views (not single **`request_id`** lookups), removes client-side session collapsing, defaults page size to **10** with configurable **10/25/50/100**, and passes the full log row on session clicks. Playwright and unit tests cover grouped pagination, cross-key session splits, and SQL shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 041eb654f6e44194524d19dacad4a6a9b849715a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->