### PR TITLE
ci(lint): gate top-level tests/e2e and litellm files in the diff-scoped lint steps

### DIFF
--- a/.github/workflows/test-linting.yml
+++ b/.github/workflows/test-linting.yml
@@ -113,7 +113,7 @@ jobs:
       - name: Check ruff format
         if: steps.changes.outputs.decision != 'skip'
         run: |
-          git diff --name-only --diff-filter=ACMR "$GATE_BASE_SHA" HEAD -- 'litellm/**/*.py' | grep -v '^litellm/enterprise/' > "$RUNNER_TEMP/ruff_format_files.txt" || true
+          git diff --name-only --diff-filter=ACMR "$GATE_BASE_SHA" HEAD -- ':(glob)litellm/**/*.py' | grep -v '^litellm/enterprise/' > "$RUNNER_TEMP/ruff_format_files.txt" || true
           if [ ! -s "$RUNNER_TEMP/ruff_format_files.txt" ]; then
             echo "No changed litellm Python files to check with ruff format."
             exit 0
@@ -172,7 +172,7 @@ jobs:
       - name: Check tests/e2e basedpyright (zero errors)
         if: steps.changes.outputs.decision != 'skip'
         run: |
-          if git diff --name-only --diff-filter=ACMRD "$GATE_BASE_SHA" HEAD -- 'tests/e2e/**/*.py' | grep -q .; then
+          if git diff --name-only --diff-filter=ACMRD "$GATE_BASE_SHA" HEAD -- ':(glob)tests/e2e/**/*.py' | grep -q .; then
             uv run --no-sync basedpyright tests/e2e
           else
             echo "No changed tests/e2e Python files; skipping."

--- a/Makefile
+++ b/Makefile
@@ -147,8 +147,8 @@ lint-install:
 # Diff-scoped format check, mirroring test-linting.yml's "Check ruff format" step:
 # only the litellm Python files changed vs the base are checked, so a pre-existing
 # format issue elsewhere doesn't block an unrelated commit. Git pathspecs match
-# recursively, so 'litellm/*.py' covers nested modules and the top-level files that
-# CI's 'litellm/**/*.py' skips, which makes this target a superset of the CI step.
+# recursively, so 'litellm/*.py' covers top-level files and nested modules alike,
+# the same set CI's ':(glob)litellm/**/*.py' selects.
 lint-format-check-changed: $(LINT_DEP_INSTALL) $(LINT_DEP_BASE)
 	@files=$$(git diff --name-only --diff-filter=ACMR origin/litellm_internal_staging...HEAD -- 'litellm/*.py' | grep -v '^litellm/enterprise/' || true); \
 	if [ -z "$$files" ]; then \

--- a/tests/e2e/zz_pathspec_probe.py
+++ b/tests/e2e/zz_pathspec_probe.py
@@ -1,0 +1,3 @@
+from typing import Final
+
+PROBE: Final[int] = "a string where the gate must see an int"

--- a/tests/e2e/zz_pathspec_probe.py
+++ b/tests/e2e/zz_pathspec_probe.py
@@ -1,3 +1,0 @@
-from typing import Final
-
-PROBE: Final[int] = "a string where the gate must see an int"

--- a/tests/test_litellm/test_lint_workflow_diff_gates.py
+++ b/tests/test_litellm/test_lint_workflow_diff_gates.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import re
+import shlex
+import subprocess
+from pathlib import Path
+from typing import Final
+
+import pytest
+
+WORKFLOW: Final = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "test-linting.yml"
+DIFF_GATE: Final = re.compile(r'git diff --name-only --diff-filter=\w+ "\$GATE_BASE_SHA" HEAD -- (.+?) \|')
+GATES: Final = tuple(tuple(shlex.split(gate.group(1))) for gate in DIFF_GATE.finditer(WORKFLOW.read_text()))
+
+
+def _git(cwd: Path, *args: str) -> str:
+    return subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True).stdout
+
+
+def _scoped_root(pathspec: str) -> str:
+    return re.sub(r"^:\([^)]*\)", "", pathspec).split("*", 1)[0]
+
+
+def _changed_files_selected_by(tmp_path: Path, pathspecs: tuple[str, ...], files: tuple[str, ...]) -> frozenset[str]:
+    _git(tmp_path, "init", "-q", "-b", "main")
+    _git(tmp_path, "config", "user.email", "t@t")
+    _git(tmp_path, "config", "user.name", "t")
+    _git(tmp_path, "commit", "-q", "--allow-empty", "-m", "base")
+    for name in files:
+        target = tmp_path / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("x = 1\n")
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-qm", "change")
+    return frozenset(
+        _git(tmp_path, "diff", "--name-only", "--diff-filter=ACMRD", "HEAD~1", "HEAD", "--", *pathspecs).split()
+    )
+
+
+def test_workflow_still_carries_the_ruff_format_and_e2e_basedpyright_diff_gates() -> None:
+    assert frozenset(_scoped_root(gate[0]) for gate in GATES) == frozenset({"litellm/", "tests/e2e/"})
+
+
+@pytest.mark.parametrize("pathspecs", GATES, ids=" ".join)
+def test_diff_gate_selects_top_level_and_nested_python_files_only(tmp_path: Path, pathspecs: tuple[str, ...]) -> None:
+    root = _scoped_root(pathspecs[0])
+    top_level = f"{root}top_level_module.py"
+    nested = f"{root}pkg/sub/nested_module.py"
+    selected = _changed_files_selected_by(
+        tmp_path,
+        pathspecs,
+        (top_level, nested, f"{root}notes.md", "elsewhere/top_level_module.py", "elsewhere/pkg/nested_module.py"),
+    )
+    assert selected == frozenset({top_level, nested})


### PR DESCRIPTION
## TLDR

Problem this solves:

- CI's e2e basedpyright gate never ran for top-level `tests/e2e/*.py` files
- PR #39209 shipped three type errors that way and staging `make check` went red
- The ruff format gate skipped top-level `litellm/*.py` (`main.py`, `utils.py`) the same way

How it solves it:

- Both gate pathspecs now carry `:(glob)`, so `/**/` matches zero or more directories
- A regression test runs the workflow's own pathspecs against a throwaway git repo

## User Flow

Before: a contributor adds a top-level `tests/e2e` file with type errors and the lint check passes without ever type-checking it

1. They add `tests/e2e/test_junit_properties.py` on their branch and open a PR against `litellm_internal_staging` at https://github.com/BerriAI/litellm/pulls
2. The `LiteLLM Linting / lint` check goes green on the PR's Checks tab
3. They open that run's log at https://github.com/BerriAI/litellm/actions/runs/33570491632 and the `Check tests/e2e basedpyright (zero errors)` step reads `No changed tests/e2e Python files; skipping.`
4. The PR merges, and the next person running `make check` on staging sees `lint-e2e-basedpyright` fail with three errors in the file that PR added

After: the same PR gets its top-level `tests/e2e` file type-checked and the lint check stays red until the errors are fixed

1. They add `tests/e2e/test_junit_properties.py` on their branch and open a PR against `litellm_internal_staging` at https://github.com/BerriAI/litellm/pulls
2. The `LiteLLM Linting / lint` check goes red on the PR's Checks tab
3. They open that run's log and the `Check tests/e2e basedpyright (zero errors)` step lists the three `reportArgumentType` errors with file and line numbers
4. They fix the errors and push, the check goes green, and `make check` on staging stays green after the merge

## Relevant issues

## Linear ticket

Resolves LIT-6673

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup: the gate is `git diff --name-only --diff-filter=ACMRD "$GATE_BASE_SHA" HEAD -- <pathspec> | grep -q .`, and the pathspec in each leg is read straight out of `.github/workflows/test-linting.yml` at that commit. The commit ranges are real staging history: PR #39209's own range (merge base `346efa0c` to head `e11a2ec0`, two top-level `tests/e2e` files), the merge of PR #39197 (`346efa0c`, nested `tests/e2e/router/*.py` plus top-level `tests/e2e/models.py`), the merge of PR #38969 (`9c417ba0`, `litellm/utils.py` plus nested router modules), and `e2c3f51c` (no `tests/e2e` file at all)

### Before (e2c3f51c46)

#### PR #39209's own lint run skipped the gate

1. `gh api --allow-escape-sequences repos/BerriAI/litellm/actions/jobs/100063172356/logs | grep -E 'GATE_BASE_SHA|No changed tests/e2e'` (run https://github.com/BerriAI/litellm/actions/runs/33570491632 at head `e11a2ec0`)
2. Output:
   ```
   GATE_BASE_SHA: 346efa0c33f344114327a2d7432ed5b4cd5da8a3
   No changed tests/e2e Python files; skipping.
   ```
3. `uv run --no-sync basedpyright tests/e2e` at `e2c3f51c46`, the staging tip that run merged into, ends with `3 errors, 0 warnings, 0 notes`, all three in `tests/e2e/test_junit_properties.py`

#### Top-level tests/e2e file (PR #39209 range)

1. `git diff --name-only --diff-filter=ACMRD 346efa0c e11a2ec0 -- 'tests/e2e/**/*.py'`
2. Output: empty, so `grep -q .` exits 1 and the step prints `skipping` (the full range is `tests/e2e/junit_properties.py` and `tests/e2e/test_junit_properties.py`)

#### Nested tests/e2e file (PR #39197 merge)

1. `git diff --name-only --diff-filter=ACMRD 346efa0c^1 346efa0c -- 'tests/e2e/**/*.py'`
2. Output: `tests/e2e/router/reliability_support.py`, `tests/e2e/router/test_reliability_fallbacks_e2e.py`, `tests/e2e/router/test_reliability_retries_e2e.py` (the range also changed `tests/e2e/models.py`, which the pathspec dropped)

#### Top-level litellm file (PR #38969 merge)

1. `git diff --name-only --diff-filter=ACMR 9c417ba0^1 9c417ba0 -- 'litellm/**/*.py'`
2. Output: three `litellm/router_utils/...` files; `litellm/utils.py`, which the range also changed, is missing, so the ruff format check never saw it

#### Commit with no tests/e2e file (e2c3f51c)

1. `git diff --name-only --diff-filter=ACMRD e2c3f51c^1 e2c3f51c -- 'tests/e2e/**/*.py'`
2. Output: empty (correct)

### After (b0aafabdee)

The tip `eb49135f2a` differs from `b0aafabdee` only by the probe commits below, which add and then remove `tests/e2e/zz_pathspec_probe.py`: `git diff --stat b0aafabdee eb49135f2a` is empty, so the workflow, Makefile, and test proven here are byte-identical at the tip

#### Throwaway top-level tests/e2e file with a type error makes the gate run and fail in CI

1. Commit `9d6b8bb14a` added `tests/e2e/zz_pathspec_probe.py` with `PROBE: Final[int] = "a string where the gate must see an int"` and nothing else, so the diff vs the merge base carries exactly one top-level `tests/e2e` file
2. Its lint run https://github.com/BerriAI/litellm/actions/runs/33595148626 (job `100137007964`) went red on the `Check tests/e2e basedpyright (zero errors)` step, which ran instead of skipping. `gh api --allow-escape-sequences repos/BerriAI/litellm/actions/jobs/100137007964/logs | grep -E 'GATE_BASE_SHA:|zz_pathspec_probe|errors, .* warnings|No changed tests/e2e' | sort -u`:
   ```
   GATE_BASE_SHA: e2c3f51c46aa2a11a930b6c19bc28e4144a38a1e
   /home/runner/work/litellm/litellm/tests/e2e/zz_pathspec_probe.py:3:21 - error: Type "Literal['a string where the gate must see an int']" is not assignable to declared type "int"
   4 errors, 0 warnings, 0 notes
   ```
   The other three errors are the pre-existing `test_junit_properties.py` ones PR #39209 shipped past the skipped gate, which PR #39246 fixes
3. Commit `eb49135f2a` removed the probe, so the diff vs the merge base has no `tests/e2e` file again. Its lint run https://github.com/BerriAI/litellm/actions/runs/33595587068 is green and the same step prints `No changed tests/e2e Python files; skipping.`

#### Top-level tests/e2e file (PR #39209 range)

1. `git diff --name-only --diff-filter=ACMRD 346efa0c e11a2ec0 -- ':(glob)tests/e2e/**/*.py'`
2. Output: `tests/e2e/junit_properties.py`, `tests/e2e/test_junit_properties.py`, so the step runs `basedpyright tests/e2e`

#### Nested tests/e2e file (PR #39197 merge)

1. `git diff --name-only --diff-filter=ACMRD 346efa0c^1 346efa0c -- ':(glob)tests/e2e/**/*.py'`
2. Output: `tests/e2e/models.py`, `tests/e2e/router/reliability_support.py`, `tests/e2e/router/test_reliability_fallbacks_e2e.py`, `tests/e2e/router/test_reliability_retries_e2e.py`

#### Top-level litellm file (PR #38969 merge)

1. `git diff --name-only --diff-filter=ACMR 9c417ba0^1 9c417ba0 -- ':(glob)litellm/**/*.py'`
2. Output: the same three `litellm/router_utils/...` files plus `litellm/utils.py`

#### Commit with no tests/e2e file (e2c3f51c)

1. `git diff --name-only --diff-filter=ACMRD e2c3f51c^1 e2c3f51c -- ':(glob)tests/e2e/**/*.py'`
2. Output: empty (correct)

#### Regression test kills the old pathspecs

1. `uv run --no-sync pytest tests/test_litellm/test_lint_workflow_diff_gates.py -q` at the tip: `3 passed`
2. The same command with the workflow's two pathspecs reverted to their `**/*.py` form: `2 failed, 1 passed`, one failure per gate, each asserting the top-level file is missing from the selection

## Type

🚄 Infrastructure
✅ Test

## Caveats (if any)

### Low

- Until PR #39246 lands, any PR touching `tests/e2e` goes red on its three pre-existing errors
  - Already true today for nested files, since the step checks the whole `tests/e2e` tree
- All 21 top-level `litellm/*.py` files were ruff-format clean at the base, so the widened format gate adds no pre-existing red
- The Makefile's `lint-format-check-changed` keeps its `'litellm/*.py'` pathspec, which already selected the same set

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] eb49135f2a91887fa35e5c9dc820e643b2458034 passes /live-pr-risk
