### PR TITLE
feat(router): arm safeguard-refusal fallback on generic chains when no content-policy list exists

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -145,8 +145,10 @@ from litellm.router_utils.fallback_event_handlers import (
     _check_non_standard_fallback_format,
     clear_pre_routing_selection,
     fallback_lookup_groups,
+    fallbacks_disabled_for_request,
     get_fallback_model_group_for_lookup_groups,
     get_pre_routing_selection,
+    record_disable_fallbacks,
     record_pre_routing_selection,
     run_async_fallback,
 )
@@ -5123,7 +5125,7 @@ class Router:
                         if not has_generated_content and error_event is None
                         else None
                     )
-                    if refusal_stop_details is not None and self._has_content_policy_fallback(model, initial_kwargs):
+                    if refusal_stop_details is not None and self._refusal_fallback_available(model, initial_kwargs):
                         refusal_error = safeguard_refusal_error(model=model, stop_details=refusal_stop_details)
                         raise MidStreamFallbackError(
                             message=refusal_error.message,
@@ -7143,6 +7145,7 @@ class Router:
                     _fallback_metadata["original_model_group"] = model_group
         include_fallback_errors: Final = kwargs.get("include_fallback_errors", False) is True
         disable_fallbacks: Final[bool | None] = kwargs.pop("disable_fallbacks", False)
+        record_disable_fallbacks(kwargs, disable_fallbacks is True)
         fallbacks: Final[list | None] = kwargs.get("fallbacks", self.fallbacks)
         context_window_fallbacks: list | None = kwargs.get("context_window_fallbacks", self.context_window_fallbacks)
         content_policy_fallbacks: list | None = kwargs.get("content_policy_fallbacks", self.content_policy_fallbacks)
@@ -8008,6 +8011,29 @@ class Router:
         )
         return False
 
+    def _refusal_fallback_available(self, model_group: str, kwargs: Mapping[str, Any]) -> bool:
+        """
+        Whether a safeguard refusal can actually be recovered by the dispatcher. A configured
+        content-policy list is authoritative; with none configured at all, the dispatcher falls
+        through to the generic fallbacks lookup, so the gate mirrors that reachability and arms
+        on a resolving generic chain (tier first, then the requested group, then "*").
+        """
+        if fallbacks_disabled_for_request(kwargs):
+            return False
+        content_policy_fallbacks: Final = kwargs.get("content_policy_fallbacks", self.content_policy_fallbacks)
+        if content_policy_fallbacks is not None:
+            return self._has_content_policy_fallback(model_group, kwargs)
+        if self._has_default_fallbacks():
+            return True
+        fallbacks: Final = kwargs.get("fallbacks", self.fallbacks)
+        if fallbacks is None:
+            return False
+        resolved, _ = get_fallback_model_group_for_lookup_groups(
+            fallbacks=fallbacks,
+            lookup_groups=fallback_lookup_groups(kwargs, model_group),
+        )
+        return resolved is not None
+
     def _should_raise_content_policy_error(self, model: str, response: ModelResponse, kwargs: dict) -> bool:
         """
         Determines if a content policy error should be raised.
@@ -8039,7 +8065,7 @@ class Router:
             return False
         if get_safeguard_refusal_stop_details(response) is None:
             return False
-        return self._has_content_policy_fallback(model, kwargs)
+        return self._refusal_fallback_available(model, kwargs)
 
     def _get_healthy_deployments(self, model: str, parent_otel_span: Span | None):
         _all_deployments: list = []

--- a/litellm/router_utils/fallback_event_handlers.py
+++ b/litellm/router_utils/fallback_event_handlers.py
@@ -264,6 +264,38 @@ def get_pre_routing_selection(kwargs: Mapping[str, Any]) -> str | None:
     return next((selected for selected in selections if isinstance(selected, str) and selected), None)
 
 
+DISABLE_FALLBACKS_METADATA_KEY: Final = "_disable_fallbacks"
+
+
+def record_disable_fallbacks(request_kwargs: Mapping[str, Any] | None, disabled: bool) -> None:
+    """
+    Write-or-clear the request's disable_fallbacks verdict into the router-internal metadata
+    bucket. The wrapper pops the raw kwarg before any downstream frame runs, so the refusal
+    gate (which decides whether to convert a refusal into a recoverable error) needs this
+    carrier to know recovery is impossible.
+    """
+    from litellm.litellm_core_utils.core_helpers import get_metadata_variable_name_from_kwargs
+
+    if request_kwargs is None:
+        return
+    bucket: Final = request_kwargs.get(get_metadata_variable_name_from_kwargs(request_kwargs))
+    if not isinstance(bucket, dict):
+        return
+    if disabled:
+        bucket[DISABLE_FALLBACKS_METADATA_KEY] = True
+    else:
+        bucket.pop(DISABLE_FALLBACKS_METADATA_KEY, None)
+
+
+def fallbacks_disabled_for_request(kwargs: Mapping[str, Any]) -> bool:
+    """True when this request opted out of fallbacks, read from the raw kwarg (pre-pop
+    snapshots keep it) or the router-internal bucket the wrapper stamps after popping it."""
+    if kwargs.get("disable_fallbacks") is True:
+        return True
+    buckets: Final = (kwargs.get(name) for name in _ROUTER_METADATA_BUCKETS)
+    return any(isinstance(bucket, dict) and bucket.get(DISABLE_FALLBACKS_METADATA_KEY) is True for bucket in buckets)
+
+
 def fallback_lookup_groups(kwargs: Mapping[str, Any], model_group: str | None) -> tuple[str, ...]:
     """
     Ordered keys for resolving a fallback chain: the tier a pre-routing hook selected wins,

--- a/tests/router_unit_tests/test_router_anthropic_messages_fallback.py
+++ b/tests/router_unit_tests/test_router_anthropic_messages_fallback.py
@@ -338,6 +338,112 @@ def test_record_pre_routing_selection_writes_only_the_internal_bucket():
     assert kwargs["metadata"] == {"user_id": "u1"}
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stream", [False, True], ids=["non-streaming", "streaming"])
+async def test_generic_only_row_recovers_safeguard_refusal(stream):
+    """With no content-policy list configured, a generic fallback row covers safeguard refusals,
+    so the dashboard's generic fallbacks work without config-only content_policy rows."""
+    fake = FakeAnthropicUpstream()
+    router = Router(model_list=[FABLE_TIER, OPUS_TARGET], fallbacks=[{"fable-tier": ["opus-target"]}])
+
+    with fake.install():
+        response = await router.aanthropic_messages(
+            model="fable-tier", max_tokens=16, stream=stream, messages=[{"role": "user", "content": "hi"}]
+        )
+        body = await _collect(response) if stream else response
+
+    if stream:
+        assert b'"refusal"' not in body
+        assert b"text_delta" in body
+    else:
+        assert body["stop_reason"] == "end_turn"
+    assert len(fake.calls) == 2
+    assert "claude-opus-5" in fake.calls[1]
+
+
+@pytest.mark.asyncio
+async def test_configured_content_policy_list_stays_authoritative_over_generic_rows():
+    fake = FakeAnthropicUpstream()
+    router = Router(
+        model_list=[FABLE_TIER, OPUS_TARGET],
+        fallbacks=[{"fable-tier": ["opus-target"]}],
+        content_policy_fallbacks=[{"unrelated-group": ["opus-target"]}],
+    )
+
+    with fake.install():
+        response = await router.aanthropic_messages(
+            model="fable-tier", max_tokens=16, messages=[{"role": "user", "content": "hi"}]
+        )
+
+    assert response["stop_reason"] == "refusal"
+    assert len(fake.calls) == 1
+
+
+def test_refusal_fallback_available_arms_on_generic_rows_only_without_content_policy():
+    router = Router(model_list=[FABLE_TIER, OPUS_TARGET], fallbacks=[{"tier-group": ["opus-target"]}])
+    stamped = {"litellm_metadata": {PRE_ROUTING_SELECTED_MODEL_KEY: "tier-group"}}
+
+    assert router._refusal_fallback_available("router-group", stamped) is True
+    assert router._refusal_fallback_available("router-group", {}) is False
+    assert router._refusal_fallback_available("router-group", {"content_policy_fallbacks": [{"other": ["x"]}]}) is False
+
+
+def test_chat_content_filter_gate_unchanged_by_generic_rows():
+    """The generic-row arming is scoped to /v1/messages safeguard refusals; the chat surface's
+    content_filter gate keeps its long-standing content-policy-only semantics."""
+    from litellm.types.utils import Choices, ModelResponse
+
+    router = Router(model_list=[FABLE_TIER, OPUS_TARGET], fallbacks=[{"fable-tier": ["opus-target"]}])
+    response = ModelResponse(choices=[Choices(finish_reason="content_filter")])
+
+    assert router._should_raise_content_policy_error(model="fable-tier", response=response, kwargs={}) is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stream", [False, True], ids=["non-streaming", "streaming"])
+async def test_disable_fallbacks_returns_the_refusal_instead_of_raising(stream):
+    """A request that opted out of fallbacks must receive the provider's refusal response,
+    never a ContentPolicyViolationError the dispatcher refuses to recover."""
+    fake = FakeAnthropicUpstream()
+    router = Router(model_list=[FABLE_TIER, OPUS_TARGET], fallbacks=[{"fable-tier": ["opus-target"]}])
+
+    with fake.install():
+        response = await router.aanthropic_messages(
+            model="fable-tier",
+            max_tokens=16,
+            stream=stream,
+            disable_fallbacks=True,
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        body = await _collect(response) if stream else response
+
+    if stream:
+        assert b'"stop_reason": "refusal"' in body
+    else:
+        assert body["stop_reason"] == "refusal"
+    assert len(fake.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_disable_fallbacks_beats_a_content_policy_row_too():
+    fake = FakeAnthropicUpstream()
+    router = Router(
+        model_list=[FABLE_TIER, OPUS_TARGET],
+        content_policy_fallbacks=[{"fable-tier": ["opus-target"]}],
+    )
+
+    with fake.install():
+        response = await router.aanthropic_messages(
+            model="fable-tier",
+            max_tokens=16,
+            disable_fallbacks=True,
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+    assert response["stop_reason"] == "refusal"
+    assert len(fake.calls) == 1
+
+
 def test_refusal_gate_keys_on_pre_routing_tier_stamp():
     router = _router(content_policy_fallbacks=[{"tier-group": ["opus-target"]}])
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Safeguard-refusal fallback (#39157) only arms on `content_policy_fallbacks`
- The dashboard's Fallbacks page can only write generic `fallbacks` rows
- So a UI-configured tier fallback never covers `[cyber]`-style flags

How it solves it:

- With no content-policy list configured, the refusal gate arms on a resolving generic chain
- The dispatcher already falls through to generic fallbacks in exactly that case; the gate now mirrors it
- A configured `content_policy_fallbacks` list stays authoritative, and chat completions is untouched

## User Flow

Before: an admin configures a fallback in the dashboard, but safeguard flags still kill sessions

1. The admin opens https://litellm-domain/ui/router-settings, Fallbacks tab, and adds `anthropic/claude-fable-5` to `anthropic/claude-opus-5`
2. A developer sends POST https://litellm-domain/v1/messages with `"model": "my-fable-router"`
3. Anthropic's safeguard flags the request on the fable tier and the refusal reaches the client unchanged; the configured fallback never fires

After: the same UI row covers safeguard flags

1. The admin configures the same row in the same dashboard tab
2. The developer sends the same POST https://litellm-domain/v1/messages
3. The safeguard flags the request, the gateway retries it on `anthropic/claude-opus-5`, and the client receives a normal answer

## Relevant issues

- Follow-up to #39157: arms the /v1/messages safeguard-refusal gate on generic fallback chains when no `content_policy_fallbacks` list exists, so dashboard-configured rows work without hand-editing config.yaml
- `content_policy_fallbacks`, when configured, remains authoritative (configured-but-no-match still passes the refusal through, unchanged)
- Scoped to /v1/messages safeguard refusals; the chat-completions `content_filter` gate keeps its long-standing content-policy-only semantics, pinned by a test
- Review round: the gate now short-circuits when the request disabled fallbacks (raw kwarg or the key-metadata path), since the dispatcher cannot recover in that case; the popped flag rides the router-internal metadata bucket the wrapper already stamps. Verified live: a virtual key with `metadata.disable_fallbacks: true` receives the refusal verbatim while a normal key recovers on the real fallback model

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Live proxy (port 4642, real Postgres), complexity router `test-fable-router` whose tiers all resolve to `anthropic/claude-fable-5` (a recording stub returning the documented safeguard-refusal 200, since real flags cannot be triggered on demand); fallback target `anthropic/claude-opus-5` is a real model behind a live gateway. Router settings contain ONLY a generic row, exactly what the dashboard writes: `fallbacks: [{"anthropic/claude-fable-5": ["anthropic/claude-opus-5"]}]`. No `content_policy_fallbacks` anywhere

### Before (31ca4ddf32)

1. `curl -s http://127.0.0.1:4642/v1/messages -H "Authorization: Bearer sk-rig..." -d '{"model":"test-fable-router","max_tokens":64,"messages":[{"role":"user","content":"Reply with exactly: generic row works"}]}'`
2. Response carries `"stop_reason":"refusal"` and `stop_details` verbatim; the generic row never fires (proxy printed `has_gate False` for the tree assertion)

### After (d8e46400ad)

1. Same curl
2. Response: `"model":"claude-opus-5"`, `"text":"generic row works"`; streaming variant returns a clean opus lifecycle with `"stop_reason":"end_turn"` and no refusal frames; a real Claude Code session (`ANTHROPIC_BASE_URL=... claude --model test-fable-router -p ...`) prints the answer with no safeguard banner

## Type

🆕 New Feature

## Caveats (if any)

### Low

- Deliberate surface asymmetry: chat completions `content_filter` still requires content-policy rows; a test pins this so the difference is explicit rather than accidental

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mid-stream Anthropic refusal handling and fallback gating in the router dispatch path; behavior shifts for generic-only fallback configs but is scoped with tests and explicit disable_fallbacks short-circuit.
> 
> **Overview**
> **Safeguard refusals on `/v1/messages` can now trigger recovery using dashboard-style generic `fallbacks` rows**, not only `content_policy_fallbacks`. The mid-stream and non-stream refusal gates call a new `_refusal_fallback_available` helper that mirrors dispatcher reachability: if a content-policy list exists it stays authoritative (including “configured but no matching row” → pass refusal through); otherwise the gate arms when generic fallbacks resolve for the tier/request group lookup order.
> 
> **Requests that opt out of fallbacks** (`disable_fallbacks=True`, including after the kwarg is popped) **no longer get converted into recoverable policy errors**. The wrapper stamps `_disable_fallbacks` on the router-internal metadata bucket via `record_disable_fallbacks` / `fallbacks_disabled_for_request`, so refusals return verbatim even when content-policy or generic chains would otherwise apply.
> 
> Chat completions **`content_filter` handling is unchanged**—still content-policy-only; tests cover generic-row recovery, authoritative content-policy lists, `disable_fallbacks`, and streaming/non-streaming paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8e46400adf74b9776e1faf27364a2406e8280cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->