### PR TITLE
build(deps): bump pypdf and tornado to clear osv-scan

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,7 +161,7 @@ proxy-runtime = [
     "mangum>=0.17.0,<1.0",
     "azure-ai-contentsafety>=1.0.0,<2.0",
     "azure-storage-file-datalake>=12.20.0,<13.0",
-    "pypdf>=6.12.0,<7.0",
+    "pypdf>=6.16.1,<7.0",
     "llm-sandbox>=0.3.39,<1.0",
     "detect-secrets>=1.5.0,<2.0",
 ]
@@ -292,7 +292,7 @@ exclude = [
 
 [tool.uv]
 constraint-dependencies = [
-    "tornado>=6.5.6",
+    "tornado>=6.5.8",
     "aiohttp>=3.14.2,<4.0",
     "packaging>=24.0",
     "soupsieve>=2.8.4",

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-08-29T17:58:57.633306Z"
+exclude-newer = "2026-08-30T06:08:59.323034Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -25,7 +25,7 @@ constraints = [
     { name = "packaging", specifier = ">=24.0" },
     { name = "setuptools", specifier = ">=83.0.0" },
     { name = "soupsieve", specifier = ">=2.8.4" },
-    { name = "tornado", specifier = ">=6.5.6" },
+    { name = "tornado", specifier = ">=6.5.8" },
 ]
 overrides = [
     { name = "cryptography", specifier = ">=50.0.0,<51.0" },
@@ -4552,7 +4552,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.14.1,<3.0" },
     { name = "pyjwt", marker = "extra == 'proxy'", specifier = ">=2.13.0,<3.0" },
     { name = "pynacl", marker = "extra == 'proxy'", specifier = ">=1.6.2,<2.0" },
-    { name = "pypdf", marker = "extra == 'proxy-runtime'", specifier = ">=6.12.0,<7.0" },
+    { name = "pypdf", marker = "extra == 'proxy-runtime'", specifier = ">=6.16.1,<7.0" },
     { name = "pyroscope-io", marker = "sys_platform != 'win32' and extra == 'proxy'", specifier = ">=0.8.16,<1.0" },
     { name = "python-dotenv", specifier = ">=1.0.0,<2.0" },
     { name = "python-multipart", marker = "extra == 'proxy'", specifier = ">=0.0.27,<1.0" },
@@ -7564,14 +7564,14 @@ wheels = [
 
 [[package]]
 name = "pypdf"
-version = "6.15.0"
+version = "6.16.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/17/17/ee75a92718ec7212de831e71454d702225aa5e474a805cce169806044453/pypdf-6.15.0.tar.gz", hash = "sha256:d39c4d955a76409284a905e2d65b40076d77ab76129e0faaeeb6612403ecfc79", size = 6993794, upload-time = "2026-08-06T13:06:49.929Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/66/54212e75406afd9f3e933d0dda23072f6aecc55c5a273077dc2e0b028b23/pypdf-6.16.2.tar.gz", hash = "sha256:595647f6191de6f402cfde1d0c455d6cbccbd509aac32b34783009c032de5d6e", size = 7008996, upload-time = "2026-08-23T13:50:07.135Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/72/ce3067ac31e214a66388159f8462ddb8c13dd00170f24d555a1f1ae8ee91/pypdf-6.15.0-py3-none-any.whl", hash = "sha256:14e001d6504822cb1ca9c7ed9a69bccb320f59b320730f55af804361abe4d5ee", size = 378123, upload-time = "2026-08-06T13:06:47.709Z" },
+    { url = "https://files.pythonhosted.org/packages/13/f1/a2da3b55acd4ab737bf728c97edaaed5ec1d3c1236acb639dcdfa97e42c7/pypdf-6.16.2-py3-none-any.whl", hash = "sha256:c8b09a59399062fb45a1b8156c18a787a10a3dae03ac9674397a226712c94604", size = 385060, upload-time = "2026-08-23T13:50:05.349Z" },
 ]
 
 [[package]]
@@ -9441,19 +9441,19 @@ wheels = [
 
 [[package]]
 name = "tornado"
-version = "6.5.7"
+version = "6.5.8"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/64/24/95ec527ad67b76d59299e5465b3935d05e4294b7e0290a3924b7487df30b/tornado-6.5.7.tar.gz", hash = "sha256:66c513a76cda70d53907bc27cf1447557699c2e95aa48ba27a442ff61c3ddfc2", size = 519252, upload-time = "2026-06-08T17:34:51.232Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/d3/343e5bb989d6515b1646cf3d40135d73f3d5e45339bded401b56cdac24dd/tornado-6.5.8.tar.gz", hash = "sha256:9452e1b208a8bd771e2cb1f2ff564985b9b214bdebbe622793e1799e0a6bd23f", size = 520493, upload-time = "2026-08-07T02:12:42.971Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/dc/c7043cab6fed8ae159fc1923ce829ada35c4dbd797d408a43858ffaf9639/tornado-6.5.7-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:148b2eb15c2c765a50796172c1e499649b35f30d2e3c3d3e15913cfa56bfb163", size = 448543, upload-time = "2026-06-08T17:34:38.052Z" },
-    { url = "https://files.pythonhosted.org/packages/92/4f/090b1431e5a43df696feceffc268c5383cc079ecb5f08ce58f917109aafe/tornado-6.5.7-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:9da38de27f1da3b78a966f0dae12b5a1ea9afe72ca805d84ff06508272ddf100", size = 446707, upload-time = "2026-06-08T17:34:39.594Z" },
-    { url = "https://files.pythonhosted.org/packages/37/d8/ef374952fd5da67d4463122c2b8e5a96536ec10b4b339254c6dcde81d01c/tornado-6.5.7-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8d759e71906ee783f8867b93bf26a265743da4c1e2f4a018464c1ba019862972", size = 449774, upload-time = "2026-06-08T17:34:41.204Z" },
-    { url = "https://files.pythonhosted.org/packages/35/37/d434c73f4c6e014b745b9b37085f34f40c022f007efff3d7fe65991899f3/tornado-6.5.7-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a46347a18f23fb92b396beebe0fb78f61dda0cc302445202c16203d8a18848b", size = 450745, upload-time = "2026-06-08T17:34:42.531Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/2b/56b9aff361d7f1ab728a805ec7d7ea835f8807afa9f5cc690ea0e630efb9/tornado-6.5.7-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7778b30bef919231265e91c69963ce0f49a1e9c07ac900bbe75b19ce2575ba92", size = 450578, upload-time = "2026-06-08T17:34:43.787Z" },
-    { url = "https://files.pythonhosted.org/packages/02/30/a7444fb23aa76860a14198fab96ac79f1866b0a6e19e26c4381b0938e50f/tornado-6.5.7-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e726f0c75da7726eec023aa62751ff8878bd2737e34fbdd33b1ae5897d2200f5", size = 449985, upload-time = "2026-06-08T17:34:45.326Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/42/5f0e56c01e8d9d36f4e23f367b85ae6cae0c1ecddd5e6977d8388ad27488/tornado-6.5.7-cp39-abi3-win32.whl", hash = "sha256:f8de3bf12d3efdd0cbe7c8887868198f8a91415e3f29fcf258d9b8eb7b1d9ae4", size = 451047, upload-time = "2026-06-08T17:34:46.784Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/a4/b393076ffb21b469eec5b328a0534cf03a3b90bfc6b1f09507cdd075d938/tornado-6.5.7-cp39-abi3-win_amd64.whl", hash = "sha256:de942f843533a039ef9fa3d9c88c7cd8a7c94553fb5ad0154270989b3d99a2c4", size = 451485, upload-time = "2026-06-08T17:34:48.248Z" },
-    { url = "https://files.pythonhosted.org/packages/71/2e/7b1c769803121b809112cf9a00681c472eae1d80e32d7ec0e0bd61d0d0e1/tornado-6.5.7-cp39-abi3-win_arm64.whl", hash = "sha256:ff934fce95643af5f11efdae618eaa73d469dc588641e5c8d19295a0c65c4796", size = 450506, upload-time = "2026-06-08T17:34:49.702Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/d5/007086fd8df5489338e204f65adce33fd4f21a4999dbb2b9cff2f897b5f4/tornado-6.5.8-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:cc6aa787d7cfab7c3d35189dc7a56fbd2399a569624c730c6b55b3d6531d0403", size = 449487, upload-time = "2026-08-07T02:12:28.682Z" },
+    { url = "https://files.pythonhosted.org/packages/70/c8/5a24a99495903f594f6a199dd7beead1cbc0a13e2cb9102727bcaaf2a997/tornado-6.5.8-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:9715b5eb79735b2bcd454ce216a9275b7c0470e64ea1bf5742f78b2f72b26eeb", size = 447649, upload-time = "2026-08-07T02:12:30.306Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/de/f2e733f386b85962d1b1dc82cd63d169b5b4580062b35397eac9244a41fe/tornado-6.5.8-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:547d63f450d570c14fe0e8db2cfb14c9bbd1c2503b4a6612586267955aa47b58", size = 450707, upload-time = "2026-08-07T02:12:31.95Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/94/20efeee9a01c141e9ac47c397f81679dfda24b32768fc4fff24e76d36c2c/tornado-6.5.8-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7e2360a0ffbe145eca8af0b19cb7203d79b1a98dd4cccdd6b368f6f49c2e3808", size = 451677, upload-time = "2026-08-07T02:12:33.512Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ec/a96ccb8ccf0de2b7bc2c5fa1608a4803735018242e90c4882365a9fd418f/tornado-6.5.8-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:5d242290bdf7ab3151bc1065fdd75c0dcc21cbc7b49f22a4c56329c2d6566d22", size = 451510, upload-time = "2026-08-07T02:12:35.346Z" },
+    { url = "https://files.pythonhosted.org/packages/29/b5/93185859245ad3f00e62175f29607346788b696369347f0146e0421286bb/tornado-6.5.8-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7b94ff0e128fe0542f3bd331fb44d06260fc4ac16881545159f34ef08aad4195", size = 450917, upload-time = "2026-08-07T02:12:36.963Z" },
+    { url = "https://files.pythonhosted.org/packages/97/cf/fe33cf062834487d34d1559746a4a12521033c22645b6d74d4bca702e018/tornado-6.5.8-cp39-abi3-win32.whl", hash = "sha256:67832909c4779c64942380cb5f044a5c6163d00831472d80e25e115de9917836", size = 451952, upload-time = "2026-08-07T02:12:38.512Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e1/468ad54333e92ccb62627e62cb88e5fc14a2171daa67ed47b1b8542d5b86/tornado-6.5.8-cp39-abi3-win_amd64.whl", hash = "sha256:11881db6b7c168494be2c2d12e65931451bdf7ee718535418ae1d8855dd5a0ee", size = 452391, upload-time = "2026-08-07T02:12:39.971Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/3e/cd5e4f06e34cde33b8ef66cf36aa2b5ad46354cc1af7d2136bbe365fee1d/tornado-6.5.8-cp39-abi3-win_arm64.whl", hash = "sha256:68a7468c7e289f8514d7d664101753903217eff1bb6822c6b5994a0b5f5bcb26", size = 451411, upload-time = "2026-08-07T02:12:41.469Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## TLDR

Problem this solves:

- `osv-scan` is red on every PR into `litellm_**`
- `uv.lock` pins `pypdf` 6.15.0 and `tornado` 6.5.7

How it solves it:

- Bump both past their fixed releases
- Raise the two version floors so nothing slides back

## User Flow

Before: a maintainer opening any PR into a `litellm_**` branch sees `osv-scan` fail, and cannot tell a real regression from the pre-existing staging failure.

1. They open a PR into `litellm_internal_staging`
2. The `osv-scan` check goes red, for example https://github.com/BerriAI/litellm/actions/runs/33593410427/job/100131879716
3. The log names `pypdf` 6.15.0 and `tornado` 6.5.7 in `uv.lock`, five advisories, four Medium and one Low
4. Every later PR into that branch inherits the same red check

After: the same PR shows `osv-scan` green, so a red check again means that PR brought something in.

1. They open a PR into `litellm_internal_staging`
2. The `osv-scan` check passes
3. The scan log prints "No issues found" and exits 0

## Relevant issues

Triggered by the failing `osv-scan` check on every open PR, for example https://github.com/BerriAI/litellm/actions/runs/33593410427/job/100131879716

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

No new tests: this is a dependency bump, and the scanner run below is the check that covers it. `pypdf` is the only one of the two that LiteLLM imports directly, in `litellm/rag/ingestion/file_parsers/pdf_parser.py`, and `tests/test_litellm/test_rag_openai_ingestion.py` passes against 6.16.2

## Advisories cleared

- GHSA-jp53-mhqp-8xcg, CVSS 6.9, PyPI `pypdf`. Infinite loop in `TreeObject.insert_child`, reachable from an attacker-supplied PDF. Fixed in 6.16.0
- GHSA-23w6-3w8w-8484, CVSS 4.8, PyPI `pypdf`. Long runtimes and large memory use when retrieving outlines. Fixed in 6.16.1
- GHSA-763m-79hh-57f2, CVSS 4.8, PyPI `pypdf`. Same shape when extracting XForm objects. Fixed in 6.16.1
- GHSA-8423-8fgw-73vq, CVSS 6.9, PyPI `tornado`. Multipart parsing builds the whole split list before the `max_parts` check, so a crafted body amplifies memory. Fixed in 6.5.8
- GHSA-wwv5-g3v4-889x, CVSS 2.3, PyPI `tornado`. Cookie attribute injection re-opened through the legacy case-insensitive `**kwargs` path in `set_cookie`, an incomplete fix for CVE-2026-35536. Fixed in 6.5.8

`pypdf` went to 6.16.2, the latest 6.16.x, and `tornado` to 6.5.8. The floors move with them, `pypdf>=6.16.1,<7.0` in the main dependency list and `tornado>=6.5.8` in `[tool.uv] constraint-dependencies`, which is where `tornado` was already pinned for the same reason. `uv lock --upgrade-package pypdf --upgrade-package tornado` touched nothing else: the resolution still holds 453 packages, and the only version lines in the `uv.lock` diff are those two. No `osv-scanner.toml` entry was added or extended, and the two existing ones for `diskcache` and `mlflow` are untouched since neither has a fixed release yet. Nothing is deferred by this PR

## Screenshots / Proof of Fix

Pinned scanner, same version and config as CI, built for this machine instead of CI's linux_amd64 (osv-scanner v2.3.8, `osv-scanner_darwin_arm64`, sha256 `a8cd6507b06239f463a7642430cfd2d154882f150f6e30cdc0653e28dfc34216`, verified against the release's own `osv-scanner_SHA256SUMS`, whose linux_amd64 line matches the digest in `.github/workflows/osv-scan.yml`):

```
/tmp/osv-scanner scan source --config osv-scanner.toml -L uv.lock -L ui/litellm-dashboard/package-lock.json
```

### Before (e2c3f51c46)

1. Run the scanner on both lockfiles at the merge base

   ```
   Scanned /Users/xiaominghao/code/litellm/uv.lock file and found 453 packages
   Scanned /Users/xiaominghao/code/litellm/ui/litellm-dashboard/package-lock.json file and found 879 packages
   GHSA-w8v5-vhqr-4h9v and 2 aliases have been filtered out because: diskcache has no fixed release published; remove this entry once one exists
   GHSA-h7x2-h6g9-p789 and 1 alias have been filtered out because: mlflow has no fixed release published; remove this entry once one exists
   Filtered 3 vulnerabilities from output

   Total 2 packages affected by 5 known vulnerabilities (0 Critical, 0 High, 4 Medium, 1 Low, 0 Unknown) from 1 ecosystem.
   5 vulnerabilities can be fixed.

   +-------------------------------------+------+-----------+---------+---------+---------------+---------+
   | OSV URL                             | CVSS | ECOSYSTEM | PACKAGE | VERSION | FIXED VERSION | SOURCE  |
   +-------------------------------------+------+-----------+---------+---------+---------------+---------+
   | https://osv.dev/GHSA-23w6-3w8w-8484 | 4.8  | PyPI      | pypdf   | 6.15.0  | 6.16.1        | uv.lock |
   | https://osv.dev/GHSA-763m-79hh-57f2 | 4.8  | PyPI      | pypdf   | 6.15.0  | 6.16.1        | uv.lock |
   | https://osv.dev/GHSA-jp53-mhqp-8xcg | 6.9  | PyPI      | pypdf   | 6.15.0  | 6.16.0        | uv.lock |
   | https://osv.dev/GHSA-8423-8fgw-73vq | 6.9  | PyPI      | tornado | 6.5.7   | 6.5.8         | uv.lock |
   | https://osv.dev/GHSA-wwv5-g3v4-889x | 2.3  | PyPI      | tornado | 6.5.7   | 6.5.8         | uv.lock |
   +-------------------------------------+------+-----------+---------+---------+---------------+---------+
   ```
2. `echo $?` prints `1`

### After (52b2adf599)

1. Run the same command at the PR tip

   ```
   Scanned /Users/xiaominghao/code/litellm/uv.lock file and found 453 packages
   Scanned /Users/xiaominghao/code/litellm/ui/litellm-dashboard/package-lock.json file and found 879 packages
   GHSA-w8v5-vhqr-4h9v and 2 aliases have been filtered out because: diskcache has no fixed release published; remove this entry once one exists
   GHSA-h7x2-h6g9-p789 and 1 alias have been filtered out because: mlflow has no fixed release published; remove this entry once one exists
   Filtered 3 vulnerabilities from output

   No issues found
   ```
2. `echo $?` prints `0`

## Type

🚄 Infrastructure

## Caveats (if any)

### Low

- `pypdf`'s floor moves to 6.16.1 for anyone installing litellm
- both bumps are patch or minor, no API change

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

