### PR TITLE
fix(bedrock): stop sending toolConfig tool definitions to guardrails on passthrough converse

### DIFF
--- a/litellm/llms/bedrock/passthrough/guardrail_translation/handler.py
+++ b/litellm/llms/bedrock/passthrough/guardrail_translation/handler.py
@@ -89,11 +89,24 @@ def _extract_converse_texts(
     top-level ``text`` blocks this scans the arbitrary-JSON fields a caller can
     hide prompt content in -- ``toolUse.input`` and
     ``toolResult.content[].json`` (alongside ``toolResult.content[].text``) --
-    as well as the request-level fields still forwarded to Bedrock that a caller
-    can route blocked content through: ``toolConfig.tools`` (tool names,
-    descriptions and input schemas) and ``additionalModelRequestFields``. Tool
-    message blocks are skipped when tool messages are excluded, but tool
-    definitions are always scanned to match the chat-completions guardrail path.
+    as well as ``additionalModelRequestFields``, a free-form model-parameter bag
+    with no schema that a caller can route blocked content through.
+
+    ``toolConfig.tools`` is deliberately NOT scanned. Tool definitions are
+    app-authored config, so their names, descriptions and JSON-schema strings
+    ("object", property names, titles, type names, enum values) would each reach
+    the guardrail as a separate INPUT item, producing false positives and
+    inflating guardrail usage for a request whose only prompt is one user
+    message. No other guardrail translation handler puts tool definitions in
+    ``texts``; the chat and messages handlers carry them in the structured
+    ``tools`` input instead, which this handler does not populate because a
+    Bedrock ``toolSpec`` is not the OpenAI tool shape those consumers expect.
+
+    ``additionalModelRequestFields`` is treated differently on purpose. Bedrock
+    gives ``toolConfig.tools`` a fixed schema whose contents are tool metadata by
+    contract, while ``additionalModelRequestFields`` is free-form and defined by
+    the target model, so what it carries cannot be classified without knowing
+    that model. Scanning it stays the fail-closed default.
     """
     holders: Final[list[_StringHolder]] = []
 
@@ -120,10 +133,6 @@ def _extract_converse_texts(
                     if isinstance(inner, dict):
                         _collect_block_text(inner, holders)
                         _collect_strings(inner.get("json"), holders)
-
-    tool_config: Final = body.get("toolConfig")
-    if isinstance(tool_config, dict):
-        _collect_strings(tool_config.get("tools"), holders)
 
     _collect_strings(body.get("additionalModelRequestFields"), holders)
 

--- a/tests/test_litellm/llms/bedrock/passthrough/guardrail_translation/test_handler.py
+++ b/tests/test_litellm/llms/bedrock/passthrough/guardrail_translation/test_handler.py
@@ -170,22 +170,27 @@ class TestExtractConverseTexts:
         texts, _ = _extract_converse_texts(body, skip_system=False, skip_tool=False)
         assert texts == []
 
-    def test_extracts_tool_config_description_and_schema(self):
+    def test_tool_config_definitions_not_extracted(self):
+        """Tool definitions are app-authored config, so nothing under
+        toolConfig.tools reaches the guardrail as input content."""
         body = {
-            "messages": [{"role": "user", "content": [{"text": "hi"}]}],
+            "messages": [
+                {"role": "user", "content": [{"text": "How much lag is there in my data?"}]}
+            ],
             "toolConfig": {
                 "tools": [
                     {
                         "toolSpec": {
                             "name": "lookup",
-                            "description": "blocked tool description",
+                            "description": "tool description",
                             "inputSchema": {
                                 "json": {
                                     "type": "object",
                                     "properties": {
-                                        "q": {
+                                        "agent_name": {
                                             "type": "string",
-                                            "description": "blocked schema description",
+                                            "title": "Agent Name",
+                                            "enum": ["alpha", "beta", "gamma"],
                                         }
                                     },
                                 }
@@ -196,20 +201,56 @@ class TestExtractConverseTexts:
             },
         }
         texts, _ = _extract_converse_texts(body, skip_system=False, skip_tool=False)
-        assert "blocked tool description" in texts
-        assert "blocked schema description" in texts
+        assert texts == ["How much lag is there in my data?"]
 
-    def test_tool_config_scanned_even_when_tool_messages_skipped(self):
+    def test_every_tool_definition_excluded_not_just_the_first(self):
+        """A per-tool scan that only skipped tools[0] would still leak the rest."""
         body = {
             "messages": [{"role": "user", "content": [{"text": "hi"}]}],
             "toolConfig": {
                 "tools": [
-                    {"toolSpec": {"name": "fn", "description": "blocked description"}}
+                    {"toolSpec": {"name": "first", "description": "first description"}},
+                    {"toolSpec": {"name": "second", "description": "second description"}},
+                    {"toolSpec": {"name": "third", "description": "third description"}},
+                ]
+            },
+        }
+        texts, _ = _extract_converse_texts(body, skip_system=False, skip_tool=False)
+        assert texts == ["hi"]
+
+    def test_tool_config_definitions_not_extracted_when_tool_messages_skipped(self):
+        body = {
+            "messages": [{"role": "user", "content": [{"text": "hi"}]}],
+            "toolConfig": {
+                "tools": [
+                    {"toolSpec": {"name": "fn", "description": "tool description"}}
                 ]
             },
         }
         texts, _ = _extract_converse_texts(body, skip_system=False, skip_tool=True)
-        assert "blocked description" in texts
+        assert texts == ["hi"]
+
+    def test_tool_use_input_still_extracted_alongside_tool_config(self):
+        """Only tool DEFINITIONS are excluded; caller content inside a toolUse
+        block is still scanned."""
+        body = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"text": "hi"},
+                        {"toolUse": {"toolUseId": "t1", "name": "fn", "input": {"q": "user secret"}}},
+                    ],
+                }
+            ],
+            "toolConfig": {
+                "tools": [
+                    {"toolSpec": {"name": "fn", "description": "tool description"}}
+                ]
+            },
+        }
+        texts, _ = _extract_converse_texts(body, skip_system=False, skip_tool=False)
+        assert texts == ["hi", "user secret"]
 
     def test_extracts_additional_model_request_fields(self):
         body = {
@@ -437,9 +478,9 @@ class TestBedrockPassthroughGuardrailHandlerInput:
         assert "blocked content" in sent_texts
 
     @pytest.mark.asyncio
-    async def test_tool_config_description_scanned_and_masked(self):
-        """Blocked text hidden in toolConfig.tools[].toolSpec.description is still
-        forwarded to Bedrock, so the guardrail must see it and mask it in place."""
+    async def test_tool_config_definitions_not_sent_and_left_untouched(self):
+        """Tool definitions never reach the guardrail, and the body forwarded to
+        Bedrock keeps them byte for byte."""
         handler = BedrockPassthroughGuardrailHandler()
         data = _converse_data()
         data["data"]["toolConfig"] = {
@@ -453,36 +494,42 @@ class TestBedrockPassthroughGuardrailHandlerInput:
                 }
             ]
         }
-        guardrail = _make_guardrail(
-            {"texts": ["You are helpful.", "Hello world", "lookup", "[REDACTED]", "object"]}
-        )
+        original_tool_config = copy.deepcopy(data["data"]["toolConfig"])
+        guardrail = _make_guardrail({"texts": ["[REDACTED]", "[REDACTED]"]})
 
         result = await handler.process_input_messages(data=data, guardrail_to_apply=guardrail)
 
         sent_texts = guardrail.apply_guardrail.call_args.kwargs["inputs"]["texts"]
-        assert "email john@example.com" in sent_texts
-        tool_spec = result["data"]["toolConfig"]["tools"][0]["toolSpec"]
-        assert tool_spec["description"] == "[REDACTED]"
+        assert sent_texts == ["You are helpful.", "Hello world"]
+        assert result["data"]["toolConfig"] == original_tool_config
 
     @pytest.mark.asyncio
-    async def test_tool_config_description_blocking_propagates(self):
-        """A blocking guardrail must reject content hidden in a tool description."""
+    async def test_blocking_guardrail_not_triggered_by_tool_description(self):
+        """LIT-5797: a request whose only prompt is a benign user message must not
+        be blocked because a denied term appears in a tool definition."""
         handler = BedrockPassthroughGuardrailHandler()
         data = _converse_data()
         data["data"]["toolConfig"] = {
             "tools": [{"toolSpec": {"name": "fn", "description": "blocked content"}}]
         }
+
+        async def _block_on_denied_term(**kwargs):
+            texts = kwargs["inputs"]["texts"]
+            if any("blocked content" in text for text in texts):
+                raise GuardrailBlocked("Blocked")
+            return {"texts": texts}
+
         guardrail = MagicMock()
         guardrail.guardrail_name = "block-guard"
         guardrail.skip_system_message_in_guardrail = False
         guardrail.skip_tool_message_in_guardrail = False
-        guardrail.apply_guardrail = AsyncMock(side_effect=GuardrailBlocked("Blocked"))
+        guardrail.apply_guardrail = AsyncMock(side_effect=_block_on_denied_term)
 
-        with pytest.raises(GuardrailBlocked):
-            await handler.process_input_messages(data=data, guardrail_to_apply=guardrail)
+        result = await handler.process_input_messages(data=data, guardrail_to_apply=guardrail)
 
         sent_texts = guardrail.apply_guardrail.call_args.kwargs["inputs"]["texts"]
-        assert "blocked content" in sent_texts
+        assert "blocked content" not in sent_texts
+        assert result["data"]["toolConfig"]["tools"][0]["toolSpec"]["description"] == "blocked content"
 
     @pytest.mark.asyncio
     async def test_additional_model_request_fields_scanned_and_masked(self):


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bedrock passthrough guardrails scanned tool definitions as user content
- Tool names, descriptions and schema strings each became a separate scan item
- A benign prompt was blocked because a term sat in a tool description
- No way to turn it off; stricter than our own /chat/completions path

How it solves it:

- toolConfig.tools is no longer collected into the guardrail input texts
- Matches every other guardrail translation handler in the repo
- Caller content stays scanned: messages, toolUse, toolResult, additionalModelRequestFields
- Also closes a bypass under experimental_use_latest_role_message_only

## User Flow

Before: a developer calling Bedrock Converse through the gateway gets a benign question blocked because one of their tool definitions mentions a term their guardrail denies

1. Their app sends POST https://litellm-domain/bedrock/model/us.anthropic.claude-sonnet-4-5-20250929-v1:0/converse with one user message, `How much lag is there in my data?`, and a `toolConfig` holding a single tool whose description mentions a denied term
2. The gateway answers `400` with `Violated guardrail policy` and the guardrail's blocked-input message, even though the user never typed the denied term
3. The same request with `"converse-stream"` fails the same way
4. They open https://litellm-domain/ui/?page=guardrails-monitor and see every one of their requests counted as a Blocked Request, `0%` pass rate
5. There is no setting that turns this off, so their only option is to rewrite their tool descriptions

After: the same request goes through, and only text the user actually sent is scanned

1. Their app sends the same POST https://litellm-domain/bedrock/model/us.anthropic.claude-sonnet-4-5-20250929-v1:0/converse with the same message and the same `toolConfig`
2. The gateway answers `200` with the model's reply
3. The same request with `"converse-stream"` streams normally
4. A request that really does carry the denied term in the user message still answers `400 Violated guardrail policy`
5. https://litellm-domain/ui/?page=guardrails-monitor now shows `66.7%` pass rate, with only the genuine violation counted as blocked

Security consequence: with `experimental_use_latest_role_message_only` turned on, another user could previously push a denied term past the guardrail by appending any tool definition to the request, because the guardrail only inspected the last extracted string and tool strings were appended after the message. That no longer works.

## Relevant issues

## Linear ticket

Resolves LIT-5797

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Shared setup for every case below, identical on both sides.

Real AWS Bedrock guardrail `6hbgpnnqoeb1` in `us-east-1`, word policy denying `hexblade`, blocked-input message `BLOCKED_BY_LIT5797_GUARDRAIL_INPUT`. Real model `us.anthropic.claude-sonnet-4-5-20250929-v1:0`. Real Postgres. No mocks anywhere.

`config.yaml`

```yaml
model_list:
  - model_name: "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
    litellm_params:
      model: "bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0"
      aws_region_name: us-east-1

guardrails:
  - guardrail_name: "bedrock-word-guard"
    litellm_params:
      guardrail: bedrock
      mode: "pre_call"
      guardrailIdentifier: os.environ/LIT5797_GUARDRAIL_ID
      guardrailVersion: "DRAFT"
      aws_region_name: us-east-1
      default_on: true

general_settings:
  master_key: sk-1234
```

`tooldesc.json`, the ticket's repro: the denied term appears only in the tool description, never in the prompt

```json
{
  "messages": [{"role": "user", "content": [{"text": "How much lag is there in my data?"}]}],
  "toolConfig": {
    "tools": [
      {
        "toolSpec": {
          "name": "lookup_agent",
          "description": "Look up the hexblade agent registry for an agent",
          "inputSchema": {
            "json": {
              "type": "object",
              "properties": {
                "agent_name": {"type": "string", "title": "Agent Name", "enum": ["alpha", "beta", "gamma"]}
              }
            }
          }
        }
      }
    ]
  }
}
```

`usercontent.json`, the control: the denied term is in the prompt itself

```json
{"messages": [{"role": "user", "content": [{"text": "Tell me about the hexblade please"}]}]}
```

### Before (31ca4ddf32)

#### 1 Benign prompt, denied term only in the tool definition

1. `curl -sS -o /dev/null -w "%{http_code}" http://127.0.0.1:20799/bedrock/model/us.anthropic.claude-sonnet-4-5-20250929-v1:0/converse -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d @tooldesc.json`
2. `400`, body `{"error":{"message":"Violated guardrail policy", ... "bedrock_guardrail_response":"BLOCKED_BY_LIT5797_GUARDRAIL_INPUT", ...}}`

#### 2 Same request, streaming

1. Same curl against `.../converse-stream`
2. `400`, same `Violated guardrail policy` body

#### 3 Denied term in the user message

1. Same curl with `-d @usercontent.json`
2. `400 Violated guardrail policy`

#### 4 What the guardrail was handed

1. A `CustomGuardrail` loaded through the documented extension point recorded the `texts` list it received for case 1
2. 9 items: `["How much lag is there in my data?", "lookup_agent", "Look up the hexblade agent registry for an agent", "object", "string", "Agent Name", "alpha", "beta", "gamma"]`

#### 5 Guardrails Monitor after the three requests above

1. Open `http://127.0.0.1:20799/ui/?page=guardrails-monitor`
2. Total Evaluations 3, Blocked Requests 3, Pass Rate 0%, fail rate 100%

![before guardrails monitor](https://raw.githubusercontent.com/BerriAI/litellm/assets-lit5797/final-base-guardrails-monitor.png)

#### 6 Request Logs after the three requests above

1. Open `http://127.0.0.1:20799/ui/?page=logs`
2. Three rows, all `Failure`, cost `-`, 0 tokens, because none of them reached the model

![before request logs](https://raw.githubusercontent.com/BerriAI/litellm/assets-lit5797/final-base-logs.png)

### After (63ef60eb82)

#### 1 Benign prompt, denied term only in the tool definition

1. `curl -sS -o /dev/null -w "%{http_code}" http://127.0.0.1:20797/bedrock/model/us.anthropic.claude-sonnet-4-5-20250929-v1:0/converse -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d @tooldesc.json`
2. `200`, body `{"metrics":{"latencyMs":3368},"output":{"message":{"content":[{"text":"I'd be happy to help you check the lag in your data ..."}]}}}`

#### 2 Same request, streaming

1. Same curl against `.../converse-stream`
2. `200`, a normal `vnd.amazon.eventstream` response starting with `messageStart`

#### 3 Denied term in the user message

1. Same curl with `-d @usercontent.json`
2. `400 Violated guardrail policy`, unchanged

#### 4 What the guardrail was handed

1. Same recorder, same case 1 request
2. 1 item: `["How much lag is there in my data?"]`

#### 5 Guardrails Monitor after the three requests above

1. Open `http://127.0.0.1:20797/ui/?page=guardrails-monitor`
2. Total Evaluations 3, Blocked Requests 1, Pass Rate 66.7%, fail rate 33.3%

![after guardrails monitor](https://raw.githubusercontent.com/BerriAI/litellm/assets-lit5797/final-head-guardrails-monitor.png)

#### 6 Request Logs after the three requests above

1. Open `http://127.0.0.1:20797/ui/?page=logs`
2. Two `Success` rows with real cost and real token counts, and one `Failure`, the genuine violation

![after request logs](https://raw.githubusercontent.com/BerriAI/litellm/assets-lit5797/final-head-logs.png)

## Native AWS Bedrock evidence

The same policy was driven directly against the Bedrock Converse API, with no LiteLLM in the path: the same real guardrail, real model, and denied word.

| Denied word location | Native Converse result |
|---|---|
| `toolConfig.tools[].toolSpec.description` | Allowed; the definition text was excluded from guardrail input coverage |
| User message text | Blocked by the word policy |

AWS documents this behavior in [Use a guardrail with the Converse API](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-use-converse-api.html): `toolConfig.tools[].toolSpec.description` and `.inputSchema` are not evaluated by guardrail filters. The [content-filter documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-content-filters.html) independently says tool definitions are not evaluated in tool-use workloads.

This change removes a passthrough-only policy that was stricter than native Bedrock for tool definitions. It does not stop LiteLLM from scanning caller message text, tool inputs, tool results, or `additionalModelRequestFields`.

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- A Converse body whose only scannable strings were tool definitions no longer runs the guardrail at all
  - Happens when every message block is an image or document and a `toolConfig` is present
  - Same gate the OpenAI chat handler already applies, so `/chat/completions` behaves this way today
  - Before #30194 landed in v1.90.0, Bedrock passthrough ran no guardrails at all, so this is not a regression against v1.89.7

### Low

- `additionalModelRequestFields` is still scanned on purpose
  - It is a free-form model-parameter bag with no schema, so caller text can genuinely live there
  - The ticket's expected outcome names tool definitions only
- Tool definitions are not forwarded in the structured `tools` input either
  - Bedrock `toolSpec` is not the OpenAI tool shape guardrails expect there
  - Worth a follow-up if a tool-allowlist guardrail should cover this route
- The ticket's unverified secondary claim did not reproduce
  - Bedrock passthrough blocks do reach the Guardrails Monitor on both sides, screenshots above

Final-head live-pr-risk rerun at 63ef60eb82 completed after the bot loop. The full matrix and configuration-family checks used the real Bedrock guardrail, real Bedrock model, real Postgres, and two live proxy processes.

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

ran /live-pr-risk and found no regressions/backward incompatible risks
