### PR TITLE
fix(transformation): merge consecutive system and developer messages for non-OpenAI providers and Responses API

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -455,6 +455,9 @@ STS_CREDENTIAL_EXPIRY_SAFETY_MARGIN_SECONDS: Final = 60
 BEDROCK_MIN_THINKING_BUDGET_TOKENS: Final = int(os.getenv("BEDROCK_MIN_THINKING_BUDGET_TOKENS", 1024))
 # Anthropic's Messages API rejects thinking.budget_tokens < 1024.
 ANTHROPIC_MIN_THINKING_BUDGET_TOKENS: Final = 1024
+# System content with this prefix is Claude Code billing metadata; Anthropic-family
+# transformations match on it to strip the block for providers that reject it.
+ANTHROPIC_BILLING_METADATA_PREFIX: Final = "x-anthropic-billing-header:"
 REPLICATE_POLLING_DELAY_SECONDS: Final = float(os.getenv("REPLICATE_POLLING_DELAY_SECONDS", 0.5))
 DEFAULT_ANTHROPIC_CHAT_MAX_TOKENS: Final = int(os.getenv("DEFAULT_ANTHROPIC_CHAT_MAX_TOKENS", 4096))
 DEFAULT_OCI_CHAT_MAX_TOKENS: Final = 4096

--- a/litellm/llms/base_llm/base_utils.py
+++ b/litellm/llms/base_llm/base_utils.py
@@ -5,7 +5,6 @@ Utility functions for base LLM classes.
 import copy
 import json
 from abc import ABC, abstractmethod
-from functools import reduce
 from typing import Any, Final, TypeAlias
 
 from openai.lib import _parsing, _pydantic
@@ -262,18 +261,15 @@ def _is_billing_metadata(message: ChatCompletionSystemMessage) -> bool:
 
 
 def _fold_into_previous_system(
-    acc: tuple[AllMessageValues, ...], message: AllMessageValues
-) -> tuple[AllMessageValues, ...]:
-    if not acc or message["role"] != "system":
-        return (*acc, message)
-    previous: Final = acc[-1]
-    if previous["role"] != "system":
-        return (*acc, message)
+    previous: AllMessageValues, message: AllMessageValues
+) -> ChatCompletionSystemMessage | None:
+    if previous["role"] != "system" or message["role"] != "system":
+        return None
     if _is_billing_metadata(previous) or _is_billing_metadata(message):
         # Anthropic-family transformations strip billing metadata by matching the
         # block's prefix; merging would hide the marker or the neighbor behind it.
-        return (*acc, message)
-    return (*acc[:-1], _merged_system_messages(previous, message))
+        return None
+    return _merged_system_messages(previous, message)
 
 
 def map_developer_role_to_system_role(
@@ -283,6 +279,14 @@ def map_developer_role_to_system_role(
     Translate `developer` role to `system` role for non-OpenAI providers, merging
     the consecutive system messages this creates for backends that allow only one.
     """
-    empty: Final[tuple[AllMessageValues, ...]] = ()
-    merged: Final = reduce(_fold_into_previous_system, map(_as_system_message, messages), empty)
-    return list(merged)  # mutable-ok: callers expect the list the pre-merge implementation returned
+    # A single linear pass that folds into the last element in place: an
+    # immutable accumulator would copy the prefix on every step, which is O(n^2)
+    # in the number of messages and request size is not bounded by default.
+    merged: Final[list[AllMessageValues]] = []  # mutable-ok: linear-time accumulator
+    for message in map(_as_system_message, messages):
+        folded = _fold_into_previous_system(merged[-1], message) if merged else None
+        if folded is None:
+            merged.append(message)
+        else:
+            merged[-1] = folded
+    return merged

--- a/litellm/llms/base_llm/base_utils.py
+++ b/litellm/llms/base_llm/base_utils.py
@@ -272,18 +272,42 @@ def _fold_into_previous_system(
     return _merged_system_messages(previous, message)
 
 
+def _leading_system_block_length(messages: list[AllMessageValues]) -> int:
+    return next(
+        (index for index, message in enumerate(messages) if message["role"] not in ("system", "developer")),
+        len(messages),
+    )
+
+
+def _hoist_developer_messages(messages: list[AllMessageValues]) -> tuple[AllMessageValues, ...]:
+    leading_length: Final = _leading_system_block_length(messages)
+    later: Final = messages[leading_length:]
+    hoisted: Final = tuple(message for message in later if message["role"] == "developer")
+    if hoisted:
+        verbose_logger.debug(
+            "Hoisting %d developer message(s) into the leading system block for non-OpenAI providers.",
+            len(hoisted),
+        )
+    return (
+        *messages[:leading_length],
+        *hoisted,
+        *(message for message in later if message["role"] != "developer"),
+    )
+
+
 def map_developer_role_to_system_role(
     messages: list[AllMessageValues],
 ) -> list[AllMessageValues]:
     """
-    Translate `developer` role to `system` role for non-OpenAI providers, merging
-    the consecutive system messages this creates for backends that allow only one.
+    Translate `developer` role to `system` role for non-OpenAI providers, hoisting
+    developer messages that arrive after the first user turn into the leading system
+    block and merging that block into one message for backends that allow only one.
     """
     # A single linear pass that folds into the last element in place: an
     # immutable accumulator would copy the prefix on every step, which is O(n^2)
     # in the number of messages and request size is not bounded by default.
     merged: Final[list[AllMessageValues]] = []  # mutable-ok: linear-time accumulator
-    for message in map(_as_system_message, messages):
+    for message in map(_as_system_message, _hoist_developer_messages(messages)):
         folded = _fold_into_previous_system(merged[-1], message) if merged else None
         if folded is None:
             merged.append(message)

--- a/litellm/llms/base_llm/base_utils.py
+++ b/litellm/llms/base_llm/base_utils.py
@@ -5,13 +5,14 @@ Utility functions for base LLM classes.
 import copy
 import json
 from abc import ABC, abstractmethod
-from typing import Any, Final
+from functools import reduce
+from typing import Any, Final, TypeAlias
 
 from openai.lib import _parsing, _pydantic
-from pydantic import BaseModel
+from pydantic import BaseModel, TypeAdapter
 
 from litellm._logging import verbose_logger
-from litellm.types.llms.openai import AllMessageValues, ChatCompletionToolCallChunk
+from litellm.types.llms.openai import AllMessageValues, ChatCompletionSystemMessage, ChatCompletionToolCallChunk
 from litellm.types.utils import Message, ProviderSpecificModelInfo, TokenCountResponse
 
 
@@ -204,19 +205,72 @@ def type_to_response_format_param(
     }
 
 
+SystemMessageContent: TypeAlias = str | list[object]
+
+
+def _content_blocks(content: SystemMessageContent) -> list[object]:  # mutable-ok: block lists are the wire format
+    if not isinstance(content, str):
+        return content
+    return [{"type": "text", "text": content}] if content else []  # mutable-ok: text block for str content
+
+
+def merge_system_message_contents(first: SystemMessageContent, second: SystemMessageContent) -> SystemMessageContent:
+    """
+    Merge the contents of two consecutive system messages: str pairs join with a
+    blank line, anything involving block lists concatenates as blocks.
+    """
+    if isinstance(first, str) and isinstance(second, str):
+        return f"{first}\n\n{second}" if first and second else first or second
+    return _content_blocks(first) + _content_blocks(second)
+
+
+_system_content_adapter: Final = TypeAdapter[SystemMessageContent](SystemMessageContent)
+
+
+def _system_content(message: ChatCompletionSystemMessage) -> SystemMessageContent:
+    return _system_content_adapter.validate_python(message["content"])
+
+
+def _as_system_message(message: AllMessageValues) -> AllMessageValues:
+    if message["role"] != "developer":
+        return message
+    verbose_logger.debug(
+        "Translating developer role to system role for non-OpenAI providers."
+    )  # ensure user knows what's happening with their input.
+    translated: Final[ChatCompletionSystemMessage] = {**message, "role": "system"}
+    return translated
+
+
+def _merged_system_messages(
+    first: ChatCompletionSystemMessage, second: ChatCompletionSystemMessage
+) -> ChatCompletionSystemMessage:
+    merged: Final[ChatCompletionSystemMessage] = {
+        **second,
+        **first,
+        "role": "system",
+        "content": merge_system_message_contents(_system_content(first), _system_content(second)),
+    }
+    return merged
+
+
+def _fold_into_previous_system(
+    acc: tuple[AllMessageValues, ...], message: AllMessageValues
+) -> tuple[AllMessageValues, ...]:
+    if not acc or message["role"] != "system":
+        return (*acc, message)
+    previous: Final = acc[-1]
+    if previous["role"] != "system":
+        return (*acc, message)
+    return (*acc[:-1], _merged_system_messages(previous, message))
+
+
 def map_developer_role_to_system_role(
     messages: list[AllMessageValues],
 ) -> list[AllMessageValues]:
     """
-    Translate `developer` role to `system` role for non-OpenAI providers.
+    Translate `developer` role to `system` role for non-OpenAI providers, merging
+    the consecutive system messages this creates for backends that allow only one.
     """
-    new_messages: Final[list[AllMessageValues]] = []
-    for m in messages:
-        if m["role"] == "developer":
-            verbose_logger.debug(
-                "Translating developer role to system role for non-OpenAI providers."
-            )  # ensure user knows what's happening with their input.
-            new_messages.append({"role": "system", "content": m["content"]})
-        else:
-            new_messages.append(m)
-    return new_messages
+    empty: Final[tuple[AllMessageValues, ...]] = ()
+    merged: Final = reduce(_fold_into_previous_system, map(_as_system_message, messages), empty)
+    return list(merged)  # mutable-ok: callers expect the list the pre-merge implementation returned

--- a/litellm/llms/base_llm/base_utils.py
+++ b/litellm/llms/base_llm/base_utils.py
@@ -12,6 +12,7 @@ from openai.lib import _parsing, _pydantic
 from pydantic import BaseModel, TypeAdapter
 
 from litellm._logging import verbose_logger
+from litellm.constants import ANTHROPIC_BILLING_METADATA_PREFIX
 from litellm.types.llms.openai import AllMessageValues, ChatCompletionSystemMessage, ChatCompletionToolCallChunk
 from litellm.types.utils import Message, ProviderSpecificModelInfo, TokenCountResponse
 
@@ -244,13 +245,20 @@ def _as_system_message(message: AllMessageValues) -> AllMessageValues:
 def _merged_system_messages(
     first: ChatCompletionSystemMessage, second: ChatCompletionSystemMessage
 ) -> ChatCompletionSystemMessage:
+    # A cache_control breakpoint covers the prefix up to its block, so the later
+    # message's marker is the one that still means the same thing after the merge.
     merged: Final[ChatCompletionSystemMessage] = {
-        **second,
         **first,
+        **second,
         "role": "system",
         "content": merge_system_message_contents(_system_content(first), _system_content(second)),
     }
     return merged
+
+
+def _is_billing_metadata(message: ChatCompletionSystemMessage) -> bool:
+    content: Final = _system_content(message)
+    return isinstance(content, str) and content.startswith(ANTHROPIC_BILLING_METADATA_PREFIX)
 
 
 def _fold_into_previous_system(
@@ -260,6 +268,10 @@ def _fold_into_previous_system(
         return (*acc, message)
     previous: Final = acc[-1]
     if previous["role"] != "system":
+        return (*acc, message)
+    if _is_billing_metadata(previous) or _is_billing_metadata(message):
+        # Anthropic-family transformations strip billing metadata by matching the
+        # block's prefix; merging would hide the marker or the neighbor behind it.
         return (*acc, message)
     return (*acc[:-1], _merged_system_messages(previous, message))
 

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -38,6 +38,7 @@ from litellm.litellm_core_utils.get_supported_openai_params import (
     get_supported_openai_params,
 )
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+from litellm.llms.base_llm.base_utils import SystemMessageContent, merge_system_message_contents
 from litellm.responses.litellm_completion_transformation.session_handler import (
     ResponsesSessionHandler,
 )
@@ -401,28 +402,38 @@ class LiteLLMCompletionResponsesConfig:
         guardrail scanning) leave it off, because they need every piece of text
         in the request to stay readable as message ``content``.
         """
-        messages: list[
-            AllMessageValues
-            | GenericChatCompletionMessage
-            | ChatCompletionMessageToolCall
-            | ChatCompletionResponseMessage
-            | Message
-        ] = []
-        if responses_api_request.get("instructions"):
-            messages.append(
-                LiteLLMCompletionResponsesConfig.transform_instructions_to_system_message(
-                    responses_api_request.get("instructions")
-                )
-            )
-
-        messages.extend(
+        input_messages: Final = (
             LiteLLMCompletionResponsesConfig._transform_response_input_param_to_chat_completion_message(
                 input=input,
                 replay_reasoning=replay_reasoning,
             )
         )
+        instructions: Final = cast(  # cast-ok: instructions is a str per the Responses API
+            "str | None", responses_api_request.get("instructions")
+        )
+        if not instructions:
+            return list(input_messages)  # mutable-ok: widened copy for the declared return union
 
-        return messages
+        first_message: Final = input_messages[0] if input_messages else None
+        if isinstance(first_message, dict):
+            leading: Final = cast(  # cast-ok: every dict message form carries role and content
+                "GenericChatCompletionMessage", first_message
+            )
+            if leading["role"] in ("system", "developer"):
+                merged_content: Final = merge_system_message_contents(
+                    instructions,
+                    cast("SystemMessageContent", leading["content"]),  # cast-ok: content field is typed as a bare list
+                )
+                merged_first: Final = cast(  # cast-ok: source message shape is kept, only content changes
+                    "GenericChatCompletionMessage",
+                    {**leading, "content": merged_content},  # mutable-ok: chat messages travel as plain dicts
+                )
+                return [merged_first, *input_messages[1:]]  # mutable-ok: declared return type is a list
+
+        return [  # mutable-ok: declared return type is a list
+            LiteLLMCompletionResponsesConfig.transform_instructions_to_system_message(instructions),
+            *input_messages,
+        ]
 
     @staticmethod
     async def async_responses_api_session_handler(

--- a/tests/test_litellm/llms/base_llm/test_base_utils.py
+++ b/tests/test_litellm/llms/base_llm/test_base_utils.py
@@ -133,7 +133,7 @@ class TestMapDeveloperRoleToSystemRole:
             {"role": "user", "content": "Hello"},
         ]
 
-    def test_non_consecutive_system_messages_stay_separate(self):
+    def test_developer_message_after_a_user_turn_is_hoisted_into_the_leading_system_message(self):
         messages = [
             {"role": "system", "content": "System turn 1"},
             {"role": "user", "content": "User turn 1"},
@@ -141,11 +141,66 @@ class TestMapDeveloperRoleToSystemRole:
             {"role": "user", "content": "User turn 2"},
         ]
         assert map_developer_role_to_system_role(messages) == [
-            {"role": "system", "content": "System turn 1"},
+            {"role": "system", "content": "System turn 1\n\nDeveloper turn 2"},
             {"role": "user", "content": "User turn 1"},
-            {"role": "system", "content": "Developer turn 2"},
             {"role": "user", "content": "User turn 2"},
         ]
+
+    def test_developer_message_in_second_position_without_a_leading_system_message_is_hoisted(self):
+        messages = [
+            {"role": "user", "content": "Hi there"},
+            {"role": "developer", "content": "Answer with exactly one word."},
+            {"role": "user", "content": "What is the capital of France?"},
+        ]
+        assert map_developer_role_to_system_role(messages) == [
+            {"role": "system", "content": "Answer with exactly one word."},
+            {"role": "user", "content": "Hi there"},
+            {"role": "user", "content": "What is the capital of France?"},
+        ]
+
+    def test_every_later_developer_message_is_hoisted_in_order_across_assistant_and_tool_turns(self):
+        messages = [
+            {"role": "system", "content": "Base"},
+            {"role": "user", "content": "Turn 1"},
+            {"role": "assistant", "content": "Reply 1"},
+            {"role": "developer", "content": "Update A"},
+            {"role": "user", "content": "Turn 2"},
+            {"role": "developer", "content": "Update B"},
+        ]
+        assert map_developer_role_to_system_role(messages) == [
+            {"role": "system", "content": "Base\n\nUpdate A\n\nUpdate B"},
+            {"role": "user", "content": "Turn 1"},
+            {"role": "assistant", "content": "Reply 1"},
+            {"role": "user", "content": "Turn 2"},
+        ]
+
+    def test_hoisted_block_content_developer_message_merges_as_blocks_after_string_instructions(self):
+        messages = [
+            {"role": "system", "content": "You are Codex"},
+            {"role": "user", "content": [{"type": "text", "text": "# AGENTS.md"}]},
+            {"role": "developer", "content": [{"type": "text", "text": "<permissions instructions>"}]},
+            {"role": "user", "content": [{"type": "text", "text": "What is the capital of France?"}]},
+        ]
+        assert map_developer_role_to_system_role(messages) == [
+            {
+                "role": "system",
+                "content": [
+                    {"type": "text", "text": "You are Codex"},
+                    {"type": "text", "text": "<permissions instructions>"},
+                ],
+            },
+            {"role": "user", "content": [{"type": "text", "text": "# AGENTS.md"}]},
+            {"role": "user", "content": [{"type": "text", "text": "What is the capital of France?"}]},
+        ]
+
+    def test_non_consecutive_native_system_messages_stay_where_the_client_put_them(self):
+        messages = [
+            {"role": "system", "content": "System turn 1"},
+            {"role": "user", "content": "User turn 1"},
+            {"role": "system", "content": "System turn 2"},
+            {"role": "user", "content": "User turn 2"},
+        ]
+        assert map_developer_role_to_system_role(messages) == messages
 
     def test_list_content_merge_preserves_block_level_cache_control(self):
         messages = [

--- a/tests/test_litellm/llms/base_llm/test_base_utils.py
+++ b/tests/test_litellm/llms/base_llm/test_base_utils.py
@@ -94,6 +94,30 @@ class TestMapDeveloperRoleToSystemRole:
             {"role": "user", "content": "Hello"},
         ]
 
+    def test_merge_keeps_later_cache_control_when_both_set(self):
+        messages = [
+            {"role": "system", "content": "A", "cache_control": {"type": "ephemeral", "ttl": "5m"}},
+            {"role": "system", "content": "B", "cache_control": {"type": "ephemeral", "ttl": "1h"}},
+        ]
+        assert map_developer_role_to_system_role(messages) == [
+            {"role": "system", "content": "A\n\nB", "cache_control": {"type": "ephemeral", "ttl": "1h"}},
+        ]
+
+    def test_merge_keeps_cache_control_supplied_only_by_later_message(self):
+        messages = [
+            {"role": "system", "content": "A"},
+            {"role": "developer", "content": "B", "cache_control": {"type": "ephemeral"}},
+        ]
+        assert map_developer_role_to_system_role(messages) == [
+            {"role": "system", "content": "A\n\nB", "cache_control": {"type": "ephemeral"}},
+        ]
+
+    def test_billing_metadata_system_message_is_never_merged(self):
+        billing = {"role": "system", "content": "x-anthropic-billing-header: cc_version=1.0;"}
+        advisory = {"role": "system", "content": "Guardrail advisory: request was flagged"}
+        assert map_developer_role_to_system_role([billing, advisory]) == [billing, advisory]
+        assert map_developer_role_to_system_role([advisory, billing]) == [advisory, billing]
+
     def test_merge_preserves_cache_control_of_first_message(self):
         messages = [
             {"role": "system", "content": "Cached prompt", "cache_control": {"type": "ephemeral"}},

--- a/tests/test_litellm/llms/base_llm/test_base_utils.py
+++ b/tests/test_litellm/llms/base_llm/test_base_utils.py
@@ -1,0 +1,141 @@
+from litellm.llms.base_llm.base_utils import (
+    map_developer_role_to_system_role,
+    merge_system_message_contents,
+)
+
+
+class TestMergeSystemMessageContents:
+    def test_strings_join_with_blank_line(self):
+        assert merge_system_message_contents("System 1", "System 2") == "System 1\n\nSystem 2"
+
+    def test_empty_strings_do_not_pad(self):
+        assert merge_system_message_contents("", "System 2") == "System 2"
+        assert merge_system_message_contents("System 1", "") == "System 1"
+        assert merge_system_message_contents("", "") == ""
+
+    def test_lists_concatenate(self):
+        first = [{"type": "text", "text": "Part 1"}]
+        second = [{"type": "text", "text": "Part 2"}]
+        assert merge_system_message_contents(first, second) == [
+            {"type": "text", "text": "Part 1"},
+            {"type": "text", "text": "Part 2"},
+        ]
+
+    def test_str_and_list_normalize_to_blocks(self):
+        text = "System preamble"
+        blocks = [{"type": "text", "text": "System rules"}]
+        assert merge_system_message_contents(text, blocks) == [
+            {"type": "text", "text": "System preamble"},
+            {"type": "text", "text": "System rules"},
+        ]
+        assert merge_system_message_contents(blocks, text) == [
+            {"type": "text", "text": "System rules"},
+            {"type": "text", "text": "System preamble"},
+        ]
+
+    def test_empty_str_and_list_drop_the_empty_side(self):
+        blocks = [{"type": "text", "text": "System rules"}]
+        assert merge_system_message_contents("", blocks) == blocks
+        assert merge_system_message_contents(blocks, "") == blocks
+
+
+class TestMapDeveloperRoleToSystemRole:
+    def test_single_developer_message(self):
+        messages = [
+            {"role": "developer", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Hello"},
+        ]
+        assert map_developer_role_to_system_role(messages) == [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Hello"},
+        ]
+
+    def test_consecutive_developer_messages_merge(self):
+        messages = [
+            {"role": "developer", "content": "Rule 1: Be concise."},
+            {"role": "developer", "content": "Rule 2: Respond in Markdown."},
+            {"role": "user", "content": "Hello"},
+        ]
+        assert map_developer_role_to_system_role(messages) == [
+            {"role": "system", "content": "Rule 1: Be concise.\n\nRule 2: Respond in Markdown."},
+            {"role": "user", "content": "Hello"},
+        ]
+
+    def test_system_followed_by_developer_merges(self):
+        messages = [
+            {"role": "system", "content": "Base instructions."},
+            {"role": "developer", "content": "Developer override."},
+            {"role": "user", "content": "Hello"},
+        ]
+        assert map_developer_role_to_system_role(messages) == [
+            {"role": "system", "content": "Base instructions.\n\nDeveloper override."},
+            {"role": "user", "content": "Hello"},
+        ]
+
+    def test_developer_followed_by_system_merges(self):
+        messages = [
+            {"role": "developer", "content": "Developer instruction."},
+            {"role": "system", "content": "System instruction."},
+            {"role": "user", "content": "Hello"},
+        ]
+        assert map_developer_role_to_system_role(messages) == [
+            {"role": "system", "content": "Developer instruction.\n\nSystem instruction."},
+            {"role": "user", "content": "Hello"},
+        ]
+
+    def test_consecutive_native_system_messages_merge(self):
+        messages = [
+            {"role": "system", "content": "System part 1."},
+            {"role": "system", "content": "System part 2."},
+            {"role": "user", "content": "Hello"},
+        ]
+        assert map_developer_role_to_system_role(messages) == [
+            {"role": "system", "content": "System part 1.\n\nSystem part 2."},
+            {"role": "user", "content": "Hello"},
+        ]
+
+    def test_merge_preserves_cache_control_of_first_message(self):
+        messages = [
+            {"role": "system", "content": "Cached prompt", "cache_control": {"type": "ephemeral"}},
+            {"role": "developer", "content": "Additional instructions"},
+            {"role": "user", "content": "Hello"},
+        ]
+        assert map_developer_role_to_system_role(messages) == [
+            {
+                "role": "system",
+                "content": "Cached prompt\n\nAdditional instructions",
+                "cache_control": {"type": "ephemeral"},
+            },
+            {"role": "user", "content": "Hello"},
+        ]
+
+    def test_non_consecutive_system_messages_stay_separate(self):
+        messages = [
+            {"role": "system", "content": "System turn 1"},
+            {"role": "user", "content": "User turn 1"},
+            {"role": "developer", "content": "Developer turn 2"},
+            {"role": "user", "content": "User turn 2"},
+        ]
+        assert map_developer_role_to_system_role(messages) == [
+            {"role": "system", "content": "System turn 1"},
+            {"role": "user", "content": "User turn 1"},
+            {"role": "system", "content": "Developer turn 2"},
+            {"role": "user", "content": "User turn 2"},
+        ]
+
+    def test_list_content_merge_preserves_block_level_cache_control(self):
+        messages = [
+            {"role": "system", "content": [{"type": "text", "text": "Cached", "cache_control": {"type": "ephemeral"}}]},
+            {"role": "developer", "content": [{"type": "text", "text": "Extra"}]},
+            {"role": "user", "content": "Hello"},
+        ]
+        assert map_developer_role_to_system_role(messages) == [
+            {
+                "role": "system",
+                "content": [
+                    {"type": "text", "text": "Cached", "cache_control": {"type": "ephemeral"}},
+                    {"type": "text", "text": "Extra"},
+                ],
+            },
+            {"role": "user", "content": "Hello"},
+        ]

--- a/tests/test_litellm/llms/fireworks_ai/chat/test_fireworks_ai_chat_transformation.py
+++ b/tests/test_litellm/llms/fireworks_ai/chat/test_fireworks_ai_chat_transformation.py
@@ -1814,3 +1814,19 @@ def test_streaming_preserves_selected_model_for_private_accounting():
         completion_response=assembled,
         custom_llm_provider="fireworks_ai",
     ) == pytest.approx(expected_cost)
+
+
+def test_translate_developer_role_hoists_a_later_developer_message_into_one_leading_system_message():
+    config = FireworksAIConfig()
+
+    messages = config.translate_developer_role_to_system_role(
+        messages=[
+            {"role": "system", "content": "You are Codex"},
+            {"role": "user", "content": "Hi there"},
+            {"role": "developer", "content": "Answer with exactly one word."},
+            {"role": "user", "content": "What is the capital of France?"},
+        ]
+    )
+
+    assert [message["role"] for message in messages] == ["system", "user", "user"]
+    assert messages[0]["content"] == "You are Codex\n\nAnswer with exactly one word."

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -4163,3 +4163,48 @@ class TestStreamingSnapshotItemIds:
         reasoning_items = _bridged_output_items(completed_event.response, "reasoning")
         assert len(reasoning_items) == 1
         assert reasoning_items[0].id == streamed_event.item_id
+
+
+class TestInstructionsMergedWithLeadingSystemInput:
+    def test_responses_api_instructions_merged_with_developer_message(self):
+        input_items = [
+            {"role": "developer", "content": "Always output valid JSON"},
+            {"role": "user", "content": "Give me data"},
+        ]
+        responses_api_request = {"instructions": "You are a data exporter"}
+        messages = LiteLLMCompletionResponsesConfig.transform_responses_api_input_to_messages(
+            input=input_items,
+            responses_api_request=responses_api_request,
+        )
+        assert len(messages) == 2
+        assert messages[0]["role"] == "developer"
+        assert messages[0]["content"] == "You are a data exporter\n\nAlways output valid JSON"
+        assert messages[1]["role"] == "user"
+
+    def test_responses_api_instructions_merged_with_system_message(self):
+        input_items = [
+            {"role": "system", "content": "Always output valid JSON"},
+            {"role": "user", "content": "Give me data"},
+        ]
+        responses_api_request = {"instructions": "You are a data exporter"}
+        messages = LiteLLMCompletionResponsesConfig.transform_responses_api_input_to_messages(
+            input=input_items,
+            responses_api_request=responses_api_request,
+        )
+        assert len(messages) == 2
+        assert messages[0]["role"] == "system"
+        assert messages[0]["content"] == "You are a data exporter\n\nAlways output valid JSON"
+        assert messages[1]["role"] == "user"
+
+    def test_responses_api_instructions_with_plain_user_input(self):
+        input_items = "Hello, world!"
+        responses_api_request = {"instructions": "You are a helpful assistant"}
+        messages = LiteLLMCompletionResponsesConfig.transform_responses_api_input_to_messages(
+            input=input_items,
+            responses_api_request=responses_api_request,
+        )
+        assert len(messages) == 2
+        assert messages[0]["role"] == "system"
+        assert messages[0]["content"] == "You are a helpful assistant"
+        assert messages[1]["role"] == "user"
+        assert messages[1]["content"] == "Hello, world!"

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -4196,6 +4196,26 @@ class TestInstructionsMergedWithLeadingSystemInput:
         assert messages[0]["content"] == "You are a data exporter\n\nAlways output valid JSON"
         assert messages[1]["role"] == "user"
 
+    def test_responses_api_developer_input_without_instructions_passes_through(self):
+        input_items = [
+            {"role": "developer", "content": "Always output valid JSON"},
+            {"role": "user", "content": "Give me data"},
+        ]
+        messages = LiteLLMCompletionResponsesConfig.transform_responses_api_input_to_messages(
+            input=input_items,
+            responses_api_request={},
+        )
+        assert len(messages) == 2
+        assert messages[0]["role"] == "developer"
+        assert messages[0]["content"] == "Always output valid JSON"
+
+    def test_responses_api_instructions_with_empty_input(self):
+        messages = LiteLLMCompletionResponsesConfig.transform_responses_api_input_to_messages(
+            input=[],
+            responses_api_request={"instructions": "You are a data exporter"},
+        )
+        assert messages == [{"role": "system", "content": "You are a data exporter"}]
+
     def test_responses_api_instructions_with_plain_user_input(self):
         input_items = "Hello, world!"
         responses_api_request = {"instructions": "You are a helpful assistant"}


### PR DESCRIPTION
## TLDR

Problem this solves:

- Responses API requests with `instructions` plus `developer` input produced several `system` messages
- Two native `system` messages also reached backends unmerged
- A `developer` message placed after the first user turn (Codex CLI's per-turn permissions item, a re-injected instruction after compaction, a mid-conversation policy update) was translated to a `system` message in place, so it landed mid-conversation
- System-first chat templates (Fireworks qwen3.8, Qwen, Ollama, DeepSeek) reject any of these with 400 `System message must be at the beginning.`

How it solves it:

- Developer role translation now folds consecutive system messages into one
- Developer messages that arrive after the leading system block are hoisted into that block first, so they merge into the single leading system message; client-authored mid-conversation `system` messages stay where the client put them
- The Responses bridge merges `instructions` into a leading system or developer item
- String contents join with a blank line, block lists concatenate

Trade-off called out for reviewers: a hoisted developer instruction is applied from the start of the conversation rather than at the position the client placed it. For system-first templates the alternative is a hard 400, and for templates that accept later system messages the instruction content is unchanged, only its position moves. Providers that receive the developer role natively (OpenAI o-series and gpt-5 family) are untouched

## User Flow

Before: a Codex CLI session pointed at the gateway with a Fireworks qwen3.8 deployment dies on its first turn, and a developer instruction placed after the first input item fails the same way from any Responses API client

1. They configure Codex CLI to use the gateway (`base_url = https://litellm-domain/v1`, `wire_api = "responses"`, model `fireworks-qwen3p8`) and start a session in a repo
2. They type `What is the capital of France? Answer in one word.` and Codex sends POST https://litellm-domain/v1/responses with `instructions`, a developer item carrying its permissions text, a user item carrying AGENTS.md, and a user item carrying the prompt
3. The pane shows a red 400 from the gateway, `jinja template rendering failed. System message must be at the beginning.`, and no reply
4. Their own Responses API client sends POST https://litellm-domain/v1/responses with `input` of a user item, then a developer item `Answer with exactly one word.`, then the user question
5. The gateway answers the same 400 and the client gets no output

After: the same session answers on its first turn, and a developer instruction placed after the first input item is honored

1. They configure Codex CLI to use the gateway (`base_url = https://litellm-domain/v1`, `wire_api = "responses"`, model `fireworks-qwen3p8`) and start a session in a repo
2. They type `What is the capital of France? Answer in one word.` and Codex sends POST https://litellm-domain/v1/responses with `instructions`, a developer item carrying its permissions text, a user item carrying AGENTS.md, and a user item carrying the prompt
3. The pane shows `Paris` and the session keeps going
4. Their own Responses API client sends POST https://litellm-domain/v1/responses with `input` of a user item, then a developer item `Answer with exactly one word.`, then the user question
5. The gateway answers 200 with a single-word output text, `Paris`

## Relevant issues

Fixes #26879

## Linear ticket

Resolves LIT-7019

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)
## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup, identical for both legs. Two proxies from two worktrees, each with `--num_workers 2`, hitting the real Fireworks API (real $$$)

```yaml
model_list:
  - model_name: fireworks-qwen3p8
    litellm_params:
      model: fireworks_ai/accounts/fireworks/models/qwen3p8-2p4t-a95b
      api_key: os.environ/FIREWORKS_API_KEY
      additional_drop_params: ["client_metadata"]

general_settings:
  master_key: sk-lit7019
```

```
# Before: worktree at the merge base 4990f06acc
python litellm/proxy/proxy_cli.py --config repro_config.yaml --port 21943 --num_workers 2 --detailed_debug
# After: worktree at the PR tip 25186b1e7b
python litellm/proxy/proxy_cli.py --config repro_config.yaml --port 29240 --num_workers 2 --detailed_debug
```

Codex CLI 0.145.0 `config.toml` (only `base_url` differs between legs):

```toml
model = "fireworks-qwen3p8"
model_provider = "litellm"

[model_providers.litellm]
name = "LiteLLM"
base_url = "http://localhost:29240/v1"
env_key = "LITELLM_QA_KEY"
wire_api = "responses"
```

`additional_drop_params: ["client_metadata"]` is unrelated to this PR: Codex sends `client_metadata` on every request and Fireworks rejects it (tracked in #28539 and #36268)

### Before (4990f06acc)

#### Codex CLI first turn

1. `LITELLM_QA_KEY=sk-lit7019 codex` in a trusted repo, type `What is the capital of France? Answer with exactly one word.` and press Enter. Codex sends `instructions`, a developer item with its permissions text, a user item with AGENTS.md, and the prompt
2. Observed: a red 400 in the pane and no answer

![pr39282-25186b1e7b-lit7019-before-codex-first-turn.png](https://github.com/mateo-berri/qa-screenshots/releases/download/assets/pr39282-25186b1e7b-lit7019-before-codex-first-turn.png)

#### /v1/responses, developer item after the first input item (the customer's captured shape)

1. Run

   ```
   curl -sS http://localhost:21943/v1/responses -H 'Authorization: Bearer sk-lit7019' -H 'content-type: application/json' -d '{"model":"fireworks-qwen3p8","input":[{"role":"user","content":"Hi there"},{"role":"developer","content":"Answer with exactly one word."},{"role":"user","content":"What is the capital of France?"}]}'
   ```

2. Observed

   ```
   HTTP 400
   error: litellm.BadRequestError: Fireworks_aiException - {"error":{"object":"error","type":"invalid_request_error","code":"invalid_request_error","message":"jinja template rendering failed. System message must be at the beginning."}}. Received Model Group=fireworks-qwen3p8
   ```

#### /v1/responses, instructions plus a leading developer item (Codex first turn shape)

1. Run

   ```
   curl -sS http://localhost:21943/v1/responses -H 'Authorization: Bearer sk-lit7019' -H 'content-type: application/json' -d '{"model":"fireworks-qwen3p8","instructions":"You are a terse assistant.","input":[{"role":"developer","content":[{"type":"input_text","text":"Answer with exactly one word."}]},{"role":"user","content":[{"type":"input_text","text":"What is the capital of France?"}]}]}'
   ```

2. Observed

   ```
   HTTP 400
   error: litellm.BadRequestError: Fireworks_aiException - {"error":{"object":"error","type":"invalid_request_error","code":"invalid_request_error","message":"jinja template rendering failed. System message must be at the beginning."}}. Received Model Group=fireworks-qwen3p8
   ```

#### /v1/chat/completions, developer message after the first user turn

1. Run

   ```
   curl -sS http://localhost:21943/v1/chat/completions -H 'Authorization: Bearer sk-lit7019' -H 'content-type: application/json' -d '{"model":"fireworks-qwen3p8","messages":[{"role":"system","content":"You are a terse assistant."},{"role":"user","content":"Hi there"},{"role":"assistant","content":"Hello! How can I help?"},{"role":"developer","content":"Answer with exactly one word."},{"role":"user","content":"What is the capital of France?"}]}'
   ```

2. Observed

   ```
   HTTP 400
   error: litellm.BadRequestError: Fireworks_aiException - {"error":{"object":"error","type":"invalid_request_error","code":"invalid_request_error","message":"jinja template rendering failed. System message must be at the beginning."}}. Received Model Group=fireworks-qwen3p8
   ```

#### /v1/messages, system prompt with a multi-turn conversation (control, unaffected path)

1. Run

   ```
   curl -sS http://localhost:21943/v1/messages -H 'Authorization: Bearer sk-lit7019' -H 'content-type: application/json' -d '{"model":"fireworks-qwen3p8","max_tokens":64,"system":"Answer with exactly one word.","messages":[{"role":"user","content":"Hi there"},{"role":"assistant","content":"Hello!"},{"role":"user","content":"What is the capital of France?"}]}'
   ```

2. Observed

   ```
   HTTP 200
   assistant: Paris
   ```

### After (25186b1e7b)

#### Codex CLI first turn

1. Same Codex session against port 29240, same prompt
2. Observed: `Paris`

![pr39282-25186b1e7b-lit7019-after-codex-first-turn.png](https://github.com/mateo-berri/qa-screenshots/releases/download/assets/pr39282-25186b1e7b-lit7019-after-codex-first-turn.png)

3. `/permissions`, pick `Approve for me`, then type `And of Germany? Same rule, one word.` Codex now sends the customer's exact shape, a developer item after the first user turn: input roles `developer, user, user, assistant, developer, user`
4. Observed: `Berlin`, and the proxy log shows the hoist doing the work

   ```
   19:17:59 - LiteLLM:DEBUG: base_utils.py:287 - Hoisting 1 developer message(s) into the leading system block for non-OpenAI providers.
   ```

![pr39282-25186b1e7b-lit7019-after-codex-permissions-second-turn.png](https://github.com/mateo-berri/qa-screenshots/releases/download/assets/pr39282-25186b1e7b-lit7019-after-codex-permissions-second-turn.png)

#### /v1/responses, developer item after the first input item (the customer's captured shape)

1. Run

   ```
   curl -sS http://localhost:29240/v1/responses -H 'Authorization: Bearer sk-lit7019' -H 'content-type: application/json' -d '{"model":"fireworks-qwen3p8","input":[{"role":"user","content":"Hi there"},{"role":"developer","content":"Answer with exactly one word."},{"role":"user","content":"What is the capital of France?"}]}'
   ```

2. Observed

   ```
   HTTP 200
   output_text: Paris
   ```

#### /v1/responses, instructions plus a leading developer item (Codex first turn shape)

1. Run

   ```
   curl -sS http://localhost:29240/v1/responses -H 'Authorization: Bearer sk-lit7019' -H 'content-type: application/json' -d '{"model":"fireworks-qwen3p8","instructions":"You are a terse assistant.","input":[{"role":"developer","content":[{"type":"input_text","text":"Answer with exactly one word."}]},{"role":"user","content":[{"type":"input_text","text":"What is the capital of France?"}]}]}'
   ```

2. Observed

   ```
   HTTP 200
   output_text: Paris
   ```

#### /v1/chat/completions, developer message after the first user turn

1. Run

   ```
   curl -sS http://localhost:29240/v1/chat/completions -H 'Authorization: Bearer sk-lit7019' -H 'content-type: application/json' -d '{"model":"fireworks-qwen3p8","messages":[{"role":"system","content":"You are a terse assistant."},{"role":"user","content":"Hi there"},{"role":"assistant","content":"Hello! How can I help?"},{"role":"developer","content":"Answer with exactly one word."},{"role":"user","content":"What is the capital of France?"}]}'
   ```

2. Observed

   ```
   HTTP 200
   assistant: Paris
   ```

#### /v1/messages, system prompt with a multi-turn conversation (control, unaffected path)

1. Run

   ```
   curl -sS http://localhost:29240/v1/messages -H 'Authorization: Bearer sk-lit7019' -H 'content-type: application/json' -d '{"model":"fireworks-qwen3p8","max_tokens":64,"system":"Answer with exactly one word.","messages":[{"role":"user","content":"Hi there"},{"role":"assistant","content":"Hello!"},{"role":"user","content":"What is the capital of France?"}]}'
   ```

2. Observed

   ```
   HTTP 200
   assistant: Paris
   ```

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Hoisted developer instructions apply from conversation start, not their original position
- Merging applies to all non-OpenAI providers, including ones tolerating multiple system messages
- When both merged messages set `cache_control`, the later marker wins, matching breakpoint semantics
- Billing metadata system blocks are never merged, keeping provider-side stripping intact
- Client-authored mid-conversation `system` messages still stay where they are
- Native Fireworks Responses path in #39826 needs the same hoist once it lands
- Codex `client_metadata` still needs `additional_drop_params` (#28539, #36268)

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
