### PR TITLE
feat: add dotenv loading opt-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ response = completion(model="openai/gpt-4o", messages=[{"role": "user", "content
 response = completion(model="anthropic/claude-sonnet-4-20250514", messages=[{"role": "user", "content": "Hello!"}])
 ```
 
+By default, LiteLLM loads `.env` when imported in DEV mode. To disable this for the SDK and proxy, set
+`LITELLM_DISABLE_DOTENV=1` in the process environment before importing LiteLLM. Setting it inside `.env` is too late
+because LiteLLM reads the flag before loading that file
+
 ### AI Gateway (Proxy Server)
 
 [**Getting Started - E2E Tutorial**](https://docs.litellm.ai/docs/proxy/docker_quick_start) - Setup virtual keys, make your first request

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -11,11 +11,13 @@ warnings.filterwarnings("ignore", message=".*Accessing the.*attribute on the ins
 # cannot enforce it at runtime, which floods proxy boot once such a type is schema-walked
 warnings.filterwarnings("ignore", message=".*`ReadOnly` qualifier.*")
 ### INIT VARIABLES #########################
-import threading
 import os
+import threading
 
 # Load .env before any other litellm imports so env vars (e.g. LITELLM_UI_SESSION_DURATION) are available
 import dotenv as _dotenv
+
+from ._dotenv_loader import should_load_dotenv as _should_load_dotenv
 
 
 def _dev_env_hot_reload_enabled() -> bool:
@@ -26,7 +28,7 @@ def _dev_env_hot_reload_enabled() -> bool:
     return os.getenv("LITELLM_DEV_ENV_HOT_RELOAD") == "True"
 
 
-if os.getenv("LITELLM_MODE", "DEV") == "DEV":
+if _should_load_dotenv():
     _dotenv.load_dotenv(override=_dev_env_hot_reload_enabled())
 
 from collections.abc import Sequence

--- a/litellm/_dotenv_loader.py
+++ b/litellm/_dotenv_loader.py
@@ -1,0 +1,9 @@
+import os
+from typing import Final
+
+_TRUTHY_VALUES: Final = frozenset({"1", "true", "t", "yes", "y"})
+
+
+def should_load_dotenv() -> bool:
+    disable_dotenv: Final = os.getenv("LITELLM_DISABLE_DOTENV", "").strip().casefold()
+    return os.getenv("LITELLM_MODE", "DEV") == "DEV" and disable_dotenv not in _TRUTHY_VALUES

--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -17,6 +17,7 @@ from dotenv import load_dotenv
 from pydantic import BaseModel, ConfigDict
 
 import litellm
+from litellm._dotenv_loader import should_load_dotenv
 from litellm.constants import DEFAULT_NUM_WORKERS_LITELLM_PROXY
 from litellm.proxy.db.query_engine_reaper import start_query_engine_reaper
 
@@ -46,7 +47,7 @@ sys.path.append(os.getcwd())
 config_filename: Final = "litellm.secrets"
 
 litellm_mode: Final = os.getenv("LITELLM_MODE", "DEV")  # "PRODUCTION", "DEV"
-if litellm_mode == "DEV":
+if should_load_dotenv():
     load_dotenv()
 from enum import Enum
 

--- a/tests/test_litellm/test__dotenv_loader.py
+++ b/tests/test_litellm/test__dotenv_loader.py
@@ -1,0 +1,84 @@
+import os
+import subprocess
+import sys
+import textwrap
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Final
+
+import pytest
+
+
+_CONTROL_ENV_VARIABLES: Final = frozenset(
+    {
+        "LITELLM_DISABLE_DOTENV",
+        "LITELLM_DEV_ENV_HOT_RELOAD",
+        "LITELLM_DOTENV_LOADED",
+        "LITELLM_MODE",
+    }
+)
+_REPOSITORY_ROOT: Final = Path(__file__).resolve().parents[2]
+
+
+def _dotenv_was_loaded(module: str, environment: Mapping[str, str]) -> bool:
+    process_environment: Final = {
+        key: value for key, value in os.environ.items() if key not in _CONTROL_ENV_VARIABLES
+    } | dict(environment)
+    script: Final = textwrap.dedent(
+        f"""
+        import os
+        import dotenv
+
+        def load_dotenv(*args, **kwargs):
+            os.environ["LITELLM_DOTENV_LOADED"] = "1"
+            return True
+
+        dotenv.load_dotenv = load_dotenv
+        import {module}
+        print(f"LITELLM_DOTENV_LOADED={{os.environ.get('LITELLM_DOTENV_LOADED', '0')}}")
+        """
+    )
+    result: Final = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=_REPOSITORY_ROOT,
+        env=process_environment,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    marker: Final = "LITELLM_DOTENV_LOADED="
+    output_line: Final = next(line for line in result.stdout.splitlines() if line.startswith(marker))
+    return output_line.removeprefix(marker) == "1"
+
+
+def test_default_dev_mode_loads_dotenv() -> None:
+    assert _dotenv_was_loaded("litellm", {})
+
+
+@pytest.mark.parametrize("value", ("1", "true", "t", "yes", "y", "TRUE", "YeS"))
+def test_disable_dotenv_truthy_values_prevent_loading(value: str) -> None:
+    assert not _dotenv_was_loaded("litellm", {"LITELLM_DISABLE_DOTENV": value})
+
+
+def test_disable_dotenv_false_value_preserves_loading() -> None:
+    assert _dotenv_was_loaded("litellm", {"LITELLM_DISABLE_DOTENV": "false"})
+
+
+def test_production_mode_still_skips_dotenv() -> None:
+    assert not _dotenv_was_loaded("litellm", {"LITELLM_MODE": "PRODUCTION"})
+
+
+def test_disable_dotenv_wins_over_dev_hot_reload() -> None:
+    environment: Final = {
+        "LITELLM_DISABLE_DOTENV": "1",
+        "LITELLM_DEV_ENV_HOT_RELOAD": "True",
+    }
+    assert not _dotenv_was_loaded("litellm", environment)
+
+
+def test_proxy_cli_respects_disable_dotenv() -> None:
+    assert not _dotenv_was_loaded("litellm.proxy.proxy_cli", {"LITELLM_DISABLE_DOTENV": "1"})
+
+
+def test_proxy_cli_default_dev_mode_loads_dotenv() -> None:
+    assert _dotenv_was_loaded("litellm.proxy.proxy_cli", {})


### PR DESCRIPTION
## TLDR

Problem this solves:

- SDK imports can unexpectedly load application `.env` files
- Existing workarounds affect broader runtime behavior

How it solves it:

- Add `LITELLM_DISABLE_DOTENV` as a targeted opt-out
- Cover SDK, proxy CLI, and DEV hot reload
- Preserve existing behavior when unset or false

## User Flow

Before: a developer opts out, but importing LiteLLM still loads `.env`

1. They create `.env` containing `UNRELATED_SECRET=loaded-by-litellm`
2. They run `LITELLM_DISABLE_DOTENV=1 python -c "import litellm, os; print(os.environ.get('UNRELATED_SECRET'))"`
3. The command prints `loaded-by-litellm`, showing the opt-out was ignored

After: the same import leaves the application environment unchanged

1. They create `.env` containing `UNRELATED_SECRET=loaded-by-litellm`
2. They run `LITELLM_DISABLE_DOTENV=1 python -c "import litellm, os; print(os.environ.get('UNRELATED_SECRET'))"`
3. The command prints `None`, showing LiteLLM ignored `.env`

## Relevant issues

Fixes #39109

Related to #12576 and #4361

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

Run from the PR checkout with its development dependencies installed:

```bash
PR_CHECKOUT="$(pwd)"
PYTHON="$PR_CHECKOUT/.venv/bin/python"
BEFORE_CHECKOUT=/tmp/litellm-dotenv-before
PROOF_DIR=/tmp/litellm-dotenv-proof

git worktree add --detach "$BEFORE_CHECKOUT" ec3f8183c3
mkdir -p "$PROOF_DIR"
printf 'UNRELATED_SECRET=loaded-by-litellm\n' > "$PROOF_DIR/.env"
cd "$PROOF_DIR"
```

### Before (ec3f8183c3)

#### SDK import

1. Run:

```bash
env -u UNRELATED_SECRET \
  -u PYTHON_DOTENV_DISABLED \
  -u LITELLM_MODE \
  -u LITELLM_DEV_ENV_HOT_RELOAD \
  LITELLM_DISABLE_DOTENV=1 \
  LITELLM_LOCAL_MODEL_COST_MAP=True \
  PYTHONPATH="$BEFORE_CHECKOUT" \
  "$PYTHON" -c \
  "import litellm, os; print(os.environ.get('UNRELATED_SECRET'))"
```

2. Observe:

```text
loaded-by-litellm
```

#### Proxy CLI import

1. Run:

```bash
env -u UNRELATED_SECRET \
  -u PYTHON_DOTENV_DISABLED \
  -u LITELLM_MODE \
  -u LITELLM_DEV_ENV_HOT_RELOAD \
  LITELLM_DISABLE_DOTENV=1 \
  LITELLM_LOCAL_MODEL_COST_MAP=True \
  PYTHONPATH="$BEFORE_CHECKOUT" \
  "$PYTHON" -c \
  "import litellm.proxy.proxy_cli, os; print(os.environ.get('UNRELATED_SECRET'))"
```

2. Observe:

```text
loaded-by-litellm
```

### After (f37595bdba)

#### SDK import

1. Run:

```bash
env -u UNRELATED_SECRET \
  -u PYTHON_DOTENV_DISABLED \
  -u LITELLM_MODE \
  -u LITELLM_DEV_ENV_HOT_RELOAD \
  LITELLM_DISABLE_DOTENV=1 \
  LITELLM_LOCAL_MODEL_COST_MAP=True \
  PYTHONPATH="$PR_CHECKOUT" \
  "$PYTHON" -c \
  "import litellm, os; print(os.environ.get('UNRELATED_SECRET'))"
```

2. Observe:

```text
None
```

#### Proxy CLI import

1. Run:

```bash
env -u UNRELATED_SECRET \
  -u PYTHON_DOTENV_DISABLED \
  -u LITELLM_MODE \
  -u LITELLM_DEV_ENV_HOT_RELOAD \
  LITELLM_DISABLE_DOTENV=1 \
  LITELLM_LOCAL_MODEL_COST_MAP=True \
  PYTHONPATH="$PR_CHECKOUT" \
  "$PYTHON" -c \
  "import litellm.proxy.proxy_cli, os; print(os.environ.get('UNRELATED_SECRET'))"
```

2. Observe:

```text
None
```

## Type

🆕 New Feature

## Caveats (if any)

### Low

- The flag must be set before LiteLLM is imported
- Setting it inside `.env` cannot prevent that file's load

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR