### PR TITLE
Add HeFu as OpenAI-compatible provider

### DIFF
--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -130,10 +130,7 @@
     "param_mappings": {
       "max_completion_tokens": "max_tokens"
     },
-    "supported_endpoints": [
-      "/v1/chat/completions",
-      "/v1/responses"
-    ]
+    "supported_endpoints": ["/v1/chat/completions", "/v1/responses"]
   },
   "tensormesh": {
     "base_url": "https://serverless.tensormesh.ai/v1",
@@ -143,19 +140,13 @@
     "param_mappings": {
       "max_completion_tokens": "max_tokens"
     },
-    "supported_endpoints": [
-      "/v1/chat/completions",
-      "/v1/responses"
-    ]
+    "supported_endpoints": ["/v1/chat/completions", "/v1/responses"]
   },
   "parasail": {
     "base_url": "https://api.parasail.io/v1",
     "api_key_env": "PARASAIL_API_KEY",
     "api_base_env": "PARASAIL_API_BASE",
-    "supported_endpoints": [
-      "/v1/chat/completions",
-      "/v1/responses"
-    ],
+    "supported_endpoints": ["/v1/chat/completions", "/v1/responses"],
     "special_handling": {
       "force_store_false": true
     }
@@ -175,21 +166,14 @@
     "param_mappings": {
       "max_completion_tokens": "max_tokens"
     },
-    "supported_endpoints": [
-      "/v1/chat/completions",
-      "/v1/responses"
-    ]
+    "supported_endpoints": ["/v1/chat/completions", "/v1/responses"]
   },
   "meta": {
     "base_url": "https://api.meta.ai/v1",
     "api_key_env": "META_API_KEY",
     "api_base_env": "META_API_BASE",
     "base_class": "openai_gpt",
-    "supported_endpoints": [
-      "/v1/chat/completions",
-      "/v1/responses",
-      "/v1/messages"
-    ]
+    "supported_endpoints": ["/v1/chat/completions", "/v1/responses", "/v1/messages"]
   },
   "cognition": {
     "base_url": "https://api.cognition.ai/v1",
@@ -203,11 +187,7 @@
     "param_mappings": {
       "max_completion_tokens": "max_tokens"
     },
-    "supported_endpoints": [
-      "/v1/chat/completions",
-      "/v1/responses",
-      "/v1/embeddings"
-    ]
+    "supported_endpoints": ["/v1/chat/completions", "/v1/responses", "/v1/embeddings"]
   },
   "scx-ai": {
     "base_url": "https://api.scx.ai/v1",
@@ -219,9 +199,7 @@
     "constraints": {
       "temperature_max": 1.99
     },
-    "supported_endpoints": [
-      "/v1/chat/completions"
-    ]
+    "supported_endpoints": ["/v1/chat/completions"]
   },
   "hefu": {
     "base_url": "https://api.hefu.hk/v1",

--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -130,7 +130,10 @@
     "param_mappings": {
       "max_completion_tokens": "max_tokens"
     },
-    "supported_endpoints": ["/v1/chat/completions", "/v1/responses"]
+    "supported_endpoints": [
+      "/v1/chat/completions",
+      "/v1/responses"
+    ]
   },
   "tensormesh": {
     "base_url": "https://serverless.tensormesh.ai/v1",
@@ -140,13 +143,19 @@
     "param_mappings": {
       "max_completion_tokens": "max_tokens"
     },
-    "supported_endpoints": ["/v1/chat/completions", "/v1/responses"]
+    "supported_endpoints": [
+      "/v1/chat/completions",
+      "/v1/responses"
+    ]
   },
   "parasail": {
     "base_url": "https://api.parasail.io/v1",
     "api_key_env": "PARASAIL_API_KEY",
     "api_base_env": "PARASAIL_API_BASE",
-    "supported_endpoints": ["/v1/chat/completions", "/v1/responses"],
+    "supported_endpoints": [
+      "/v1/chat/completions",
+      "/v1/responses"
+    ],
     "special_handling": {
       "force_store_false": true
     }
@@ -166,14 +175,21 @@
     "param_mappings": {
       "max_completion_tokens": "max_tokens"
     },
-    "supported_endpoints": ["/v1/chat/completions", "/v1/responses"]
+    "supported_endpoints": [
+      "/v1/chat/completions",
+      "/v1/responses"
+    ]
   },
   "meta": {
     "base_url": "https://api.meta.ai/v1",
     "api_key_env": "META_API_KEY",
     "api_base_env": "META_API_BASE",
     "base_class": "openai_gpt",
-    "supported_endpoints": ["/v1/chat/completions", "/v1/responses", "/v1/messages"]
+    "supported_endpoints": [
+      "/v1/chat/completions",
+      "/v1/responses",
+      "/v1/messages"
+    ]
   },
   "cognition": {
     "base_url": "https://api.cognition.ai/v1",
@@ -187,7 +203,11 @@
     "param_mappings": {
       "max_completion_tokens": "max_tokens"
     },
-    "supported_endpoints": ["/v1/chat/completions", "/v1/responses", "/v1/embeddings"]
+    "supported_endpoints": [
+      "/v1/chat/completions",
+      "/v1/responses",
+      "/v1/embeddings"
+    ]
   },
   "scx-ai": {
     "base_url": "https://api.scx.ai/v1",
@@ -199,6 +219,13 @@
     "constraints": {
       "temperature_max": 1.99
     },
-    "supported_endpoints": ["/v1/chat/completions"]
+    "supported_endpoints": [
+      "/v1/chat/completions"
+    ]
+  },
+  "hefu": {
+    "base_url": "https://api.hefu.hk/v1",
+    "api_key_env": "HEFU_API_KEY",
+    "api_base_env": "HEFU_API_BASE"
   }
 }


### PR DESCRIPTION
## TLDR

Problem this solves:

- HeFu (OpenAI-compatible AI API gateway) requires manual `openai/` prefix + `api_base` today
- Users want `hefu/<model>` + `HEFU_API_KEY` like other named providers

How it solves it:

- Adds a `hefu` entry to `litellm/llms/openai_like/providers.json` (base_url, api_key_env, api_base_env)

## About HeFu

- OpenAI-compatible AI API gateway: one key for DeepSeek, Kimi (Moonshot), Qwen, GLM (Zhipu), MiniMax, OpenAI GPT series, Anthropic Claude, Google Gemini
- API base: `https://api.hefu.hk/v1` (standard OpenAI surface: `/v1/chat/completions`, `/v1/models`)
- Pay-as-you-go billing in USD

## Validation (real calls against production endpoint)

Validated with litellm at commit of this branch, providers.json patched with this entry:

```python
import os, litellm
os.environ["HEFU_API_KEY"] = "sk-..."

# named provider path (this PR)
r = litellm.completion(model="hefu/gemini-3.6-flash",
    messages=[{"role": "user", "content": "Reply with exactly: ok"}], max_tokens=5)
print(r.choices[0].message.content)  # -> "ok"

# generic openai/ path (works today without this PR)
r = litellm.completion(model="openai/gemini-3.6-flash",
    api_key=os.environ["HEFU_API_KEY"], api_base="https://api.hefu.hk/v1",
    messages=[{"role": "user", "content": "Reply with exactly: ok"}], max_tokens=5)
print(r.choices[0].message.content)  # -> "ok"
```

Both paths returned successful chat completions against the live endpoint.

Docs PR (provider page in litellm-docs) will follow as a companion.
