### PR TITLE
fix: support ValkeySemanticCache import layouts

### DIFF
--- a/litellm/caching/valkey_semantic_cache.py
+++ b/litellm/caching/valkey_semantic_cache.py
@@ -24,7 +24,10 @@ from typing import Any, Final
 from redis import Redis
 from redis.asyncio import Redis as AsyncRedis
 from redis.commands.search.field import TagField, VectorField
-from redis.commands.search.indexDefinition import IndexDefinition, IndexType
+try:  # redis-py >= 5 (module renamed to snake_case)
+    from redis.commands.search.index_definition import IndexDefinition, IndexType
+except ModuleNotFoundError:  # redis-py 4.x (last version with camelCase name)
+    from redis.commands.search.indexDefinition import IndexDefinition, IndexType
 from redis.commands.search.query import Query
 
 from litellm._logging import print_verbose

--- a/litellm/caching/valkey_semantic_cache.py
+++ b/litellm/caching/valkey_semantic_cache.py
@@ -24,6 +24,7 @@ from typing import Any, Final
 from redis import Redis
 from redis.asyncio import Redis as AsyncRedis
 from redis.commands.search.field import TagField, VectorField
+
 try:  # redis-py >= 5 (module renamed to snake_case)
     from redis.commands.search.index_definition import IndexDefinition, IndexType
 except ModuleNotFoundError:  # redis-py 4.x (last version with camelCase name)

--- a/tests/test_litellm/caching/test_valkey_semantic_cache.py
+++ b/tests/test_litellm/caching/test_valkey_semantic_cache.py
@@ -534,3 +534,45 @@ def test_importing_caching_does_not_require_redis():
     )
     assert result.returncode == 0, result.stderr
     assert "ok" in result.stdout
+
+
+def test_valkey_cache_supports_redis_py_4_index_module():
+    code = textwrap.dedent(
+        """
+        import builtins
+        import sys
+        import types
+
+        from redis.commands.search.index_definition import IndexDefinition, IndexType
+
+        legacy = types.ModuleType("redis.commands.search.indexDefinition")
+        legacy.IndexDefinition = IndexDefinition
+        legacy.IndexType = IndexType
+        sys.modules[legacy.__name__] = legacy
+        original_import = builtins.__import__
+
+        def compatibility_import(name, *args, **kwargs):
+            if name == "redis.commands.search.index_definition":
+                raise ModuleNotFoundError(name=name)
+            return original_import(name, *args, **kwargs)
+
+        builtins.__import__ = compatibility_import
+        from litellm.caching.valkey_semantic_cache import ValkeySemanticCache
+
+        cache = ValkeySemanticCache(
+            similarity_threshold=0.8,
+            sync_client=object(),
+            async_client=object(),
+        )
+        assert cache._index_definition().__class__ is IndexDefinition
+        print("ok")
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONPATH": _REPO_ROOT},
+    )
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout

--- a/tests/test_litellm/caching/test_valkey_semantic_cache.py
+++ b/tests/test_litellm/caching/test_valkey_semantic_cache.py
@@ -548,7 +548,7 @@ def test_valkey_cache_supports_redis_py_4_index_module():
                 pass
 
         class IndexType:
-            pass
+            HASH = "HASH"
 
         legacy = types.ModuleType("redis.commands.search.indexDefinition")
         legacy.IndexDefinition = IndexDefinition

--- a/tests/test_litellm/caching/test_valkey_semantic_cache.py
+++ b/tests/test_litellm/caching/test_valkey_semantic_cache.py
@@ -543,12 +543,18 @@ def test_valkey_cache_supports_redis_py_4_index_module():
         import sys
         import types
 
-        from redis.commands.search.index_definition import IndexDefinition, IndexType
+        class IndexDefinition:
+            def __init__(self, *args, **kwargs):
+                pass
+
+        class IndexType:
+            pass
 
         legacy = types.ModuleType("redis.commands.search.indexDefinition")
         legacy.IndexDefinition = IndexDefinition
         legacy.IndexType = IndexType
         sys.modules[legacy.__name__] = legacy
+
         original_import = builtins.__import__
 
         def compatibility_import(name, *args, **kwargs):


### PR DESCRIPTION
## Description

Fixes #39180 - ValkeySemanticCache crashes at import with redis-py >= 5 due to stale camelCase import of .

## Changes

- Added try/except block to handle the module rename from camelCase () to snake_case () in redis-py 5.0
- Maintains backward compatibility with redis-py 4.x

## Testing

The fix was verified by the issue reporter. The import now works correctly with:
- redis-py 4.6.0 (camelCase module)
- redis-py >= 5.0 (snake_case module)

## Type

- [x] Bug fix