### PR TITLE
fix: avoid mutable default in InfinityError headers

### DIFF
--- a/litellm/llms/infinity/common_utils.py
+++ b/litellm/llms/infinity/common_utils.py
@@ -4,7 +4,7 @@ from litellm.llms.base_llm.chat.transformation import BaseLLMException
 
 
 class InfinityError(BaseLLMException):
-    def __init__(self, status_code: int, message: str, headers: dict | httpx.Headers = {}):
+    def __init__(self, status_code: int, message: str, headers: dict | httpx.Headers | None = None):
         self.status_code = status_code
         self.message = message
         self.request = httpx.Request(method="POST", url="https://github.com/michaelfeil/infinity")


### PR DESCRIPTION
## Description

Fixes #38909 - InfinityError uses a mutable default argument for headers, shared across all instances.

## Changes

- Changed  default from  to  to match the convention used by , , and .
- This prevents the bug where all  instances without explicit headers share the same mutable dictionary.

## Testing

The issue reporter provided a reproduction case:
