### PR TITLE
fix: use None defaults for vector store registries

### DIFF
--- a/litellm/vector_stores/vector_store_registry.py
+++ b/litellm/vector_stores/vector_store_registry.py
@@ -6,6 +6,7 @@ from typing import (
     TYPE_CHECKING,
     Any,  # noqa: TID251  # untyped non_default_params dict is the only source of the unknown key type
     Final,
+    Optional,
     cast,  # noqa: TID251  # untyped non_default_params dict is the only source of the unknown key type
     get_args,
 )
@@ -32,8 +33,13 @@ else:
 
 
 class VectorStoreIndexRegistry:
-    def __init__(self, vector_store_indexes: list[LiteLLM_ManagedVectorStoreIndex] = []):
-        self.vector_store_indexes: list[LiteLLM_ManagedVectorStoreIndex] = vector_store_indexes
+    def __init__(
+        self,
+        vector_store_indexes: Optional[list[LiteLLM_ManagedVectorStoreIndex]] = None,
+    ):
+        self.vector_store_indexes: list[LiteLLM_ManagedVectorStoreIndex] = (
+            vector_store_indexes if vector_store_indexes is not None else []
+        )
 
     def get_vector_store_indexes(self) -> list[LiteLLM_ManagedVectorStoreIndex]:
         """
@@ -101,8 +107,13 @@ class VectorStoreIndexRegistry:
 
 
 class VectorStoreRegistry:
-    def __init__(self, vector_stores: list[LiteLLM_ManagedVectorStore] = []):
-        self.vector_stores: list[LiteLLM_ManagedVectorStore] = vector_stores
+    def __init__(
+        self,
+        vector_stores: Optional[list[LiteLLM_ManagedVectorStore]] = None,
+    ):
+        self.vector_stores: list[LiteLLM_ManagedVectorStore] = (
+            vector_stores if vector_stores is not None else []
+        )
         self.vector_store_ids_to_vector_store_map: dict[str, LiteLLM_ManagedVectorStore] = {}
 
     def _extract_tool_params(self, tool: dict) -> VectorStoreToolParams:

--- a/litellm/vector_stores/vector_store_registry.py
+++ b/litellm/vector_stores/vector_store_registry.py
@@ -111,9 +111,7 @@ class VectorStoreRegistry:
         self,
         vector_stores: Optional[list[LiteLLM_ManagedVectorStore]] = None,
     ):
-        self.vector_stores: list[LiteLLM_ManagedVectorStore] = (
-            vector_stores if vector_stores is not None else []
-        )
+        self.vector_stores: list[LiteLLM_ManagedVectorStore] = vector_stores if vector_stores is not None else []
         self.vector_store_ids_to_vector_store_map: dict[str, LiteLLM_ManagedVectorStore] = {}
 
     def _extract_tool_params(self, tool: dict) -> VectorStoreToolParams:

--- a/litellm/vector_stores/vector_store_registry.py
+++ b/litellm/vector_stores/vector_store_registry.py
@@ -6,7 +6,6 @@ from typing import (
     TYPE_CHECKING,
     Any,  # noqa: TID251  # untyped non_default_params dict is the only source of the unknown key type
     Final,
-    Optional,
     cast,  # noqa: TID251  # untyped non_default_params dict is the only source of the unknown key type
     get_args,
 )
@@ -35,7 +34,7 @@ else:
 class VectorStoreIndexRegistry:
     def __init__(
         self,
-        vector_store_indexes: Optional[list[LiteLLM_ManagedVectorStoreIndex]] = None,
+        vector_store_indexes: list[LiteLLM_ManagedVectorStoreIndex] | None = None,
     ):
         self.vector_store_indexes: list[LiteLLM_ManagedVectorStoreIndex] = (
             vector_store_indexes if vector_store_indexes is not None else []
@@ -109,7 +108,7 @@ class VectorStoreIndexRegistry:
 class VectorStoreRegistry:
     def __init__(
         self,
-        vector_stores: Optional[list[LiteLLM_ManagedVectorStore]] = None,
+        vector_stores: list[LiteLLM_ManagedVectorStore] | None = None,
     ):
         self.vector_stores: list[LiteLLM_ManagedVectorStore] = vector_stores if vector_stores is not None else []
         self.vector_store_ids_to_vector_store_map: dict[str, LiteLLM_ManagedVectorStore] = {}

--- a/tests/test_litellm/vector_stores/test_vector_store_registry.py
+++ b/tests/test_litellm/vector_stores/test_vector_store_registry.py
@@ -71,6 +71,22 @@ def test_get_credentials_for_vector_store():
     assert result == {}
 
 
+def test_vector_store_registries_do_not_share_default_list():
+    first = VectorStoreRegistry()
+    second = VectorStoreRegistry()
+
+    first.vector_stores.append(
+        LiteLLM_ManagedVectorStore(
+            vector_store_id="first",
+            custom_llm_provider="openai",
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+    )
+
+    assert second.vector_stores == []
+
+
 def test_add_vector_store_to_registry():
     """Test that add_vector_store_to_registry adds vector store correctly when there are pre-existing stores"""
     # Create pre-existing vector stores

--- a/tests/test_litellm/vector_stores/test_vector_store_registry.py
+++ b/tests/test_litellm/vector_stores/test_vector_store_registry.py
@@ -11,9 +11,13 @@ from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
 import litellm
-from litellm.types.vector_stores import LiteLLM_ManagedVectorStore
+from litellm.types.vector_stores import (
+    IndexCreateLiteLLMParams,
+    LiteLLM_ManagedVectorStore,
+    LiteLLM_ManagedVectorStoreIndex,
+)
 from litellm.vector_stores.main import search
-from litellm.vector_stores.vector_store_registry import VectorStoreRegistry
+from litellm.vector_stores.vector_store_registry import VectorStoreIndexRegistry, VectorStoreRegistry
 
 
 @pytest.fixture(autouse=True)
@@ -85,6 +89,24 @@ def test_vector_store_registries_do_not_share_default_list():
     )
 
     assert second.vector_stores == []
+
+
+def test_vector_store_index_registries_do_not_share_default_list():
+    first = VectorStoreIndexRegistry()
+    second = VectorStoreIndexRegistry()
+
+    first.vector_store_indexes.append(
+        LiteLLM_ManagedVectorStoreIndex(
+            id="first",
+            index_name="first",
+            litellm_params=IndexCreateLiteLLMParams(
+                vector_store_index="first",
+                vector_store_name="first",
+            ),
+        )
+    )
+
+    assert second.vector_store_indexes == []
 
 
 def test_add_vector_store_to_registry():


### PR DESCRIPTION
## Description

Fixes #38874 - VectorStoreIndexRegistry and VectorStoreRegistry use mutable default list arguments ([]), causing shared state between instances.

## Changes

- Changed  to use  as default and instantiate a new list per instance
- Changed  to use  as default and instantiate a new list per instance
- Added  to typing imports

## Testing

The issue reporter provided a reproduction case:
