### PR TITLE
perf(db): index SpendLogs on (user, startTime), (api_key, startTime)

### DIFF
--- a/db_scripts/partition_spend_logs.sql
+++ b/db_scripts/partition_spend_logs.sql
@@ -53,6 +53,10 @@ ALTER INDEX IF EXISTS "LiteLLM_SpendLogs_end_user_idx"
     RENAME TO "LiteLLM_SpendLogs_legacy_end_user_idx";
 ALTER INDEX IF EXISTS "LiteLLM_SpendLogs_session_id_idx"
     RENAME TO "LiteLLM_SpendLogs_legacy_session_id_idx";
+ALTER INDEX IF EXISTS "LiteLLM_SpendLogs_user_startTime_idx"
+    RENAME TO "LiteLLM_SpendLogs_legacy_user_startTime_idx";
+ALTER INDEX IF EXISTS "LiteLLM_SpendLogs_api_key_startTime_idx"
+    RENAME TO "LiteLLM_SpendLogs_legacy_api_key_startTime_idx";
 
 CREATE TABLE "LiteLLM_SpendLogs" (
     LIKE "LiteLLM_SpendLogs_legacy" INCLUDING DEFAULTS INCLUDING GENERATED
@@ -77,6 +81,12 @@ CREATE INDEX IF NOT EXISTS "LiteLLM_SpendLogs_end_user_idx"
 
 CREATE INDEX IF NOT EXISTS "LiteLLM_SpendLogs_session_id_idx"
     ON "LiteLLM_SpendLogs" ("session_id");
+
+CREATE INDEX IF NOT EXISTS "LiteLLM_SpendLogs_user_startTime_idx"
+    ON "LiteLLM_SpendLogs" ("user", "startTime" DESC);
+
+CREATE INDEX IF NOT EXISTS "LiteLLM_SpendLogs_api_key_startTime_idx"
+    ON "LiteLLM_SpendLogs" ("api_key", "startTime" DESC);
 
 -- Safety net: any row whose startTime has no explicit partition lands here so
 -- writes never fail. The cleanup job never drops the DEFAULT partition.

--- a/db_scripts/unpartition_spend_logs.sql
+++ b/db_scripts/unpartition_spend_logs.sql
@@ -40,6 +40,10 @@ ALTER INDEX IF EXISTS "LiteLLM_SpendLogs_end_user_idx"
     RENAME TO "LiteLLM_SpendLogs_partitioned_end_user_idx";
 ALTER INDEX IF EXISTS "LiteLLM_SpendLogs_session_id_idx"
     RENAME TO "LiteLLM_SpendLogs_partitioned_session_id_idx";
+ALTER INDEX IF EXISTS "LiteLLM_SpendLogs_user_startTime_idx"
+    RENAME TO "LiteLLM_SpendLogs_partitioned_user_startTime_idx";
+ALTER INDEX IF EXISTS "LiteLLM_SpendLogs_api_key_startTime_idx"
+    RENAME TO "LiteLLM_SpendLogs_partitioned_api_key_startTime_idx";
 
 CREATE TABLE "LiteLLM_SpendLogs" (
     LIKE "LiteLLM_SpendLogs_partitioned" INCLUDING DEFAULTS INCLUDING GENERATED
@@ -59,6 +63,12 @@ CREATE INDEX IF NOT EXISTS "LiteLLM_SpendLogs_end_user_idx"
 
 CREATE INDEX IF NOT EXISTS "LiteLLM_SpendLogs_session_id_idx"
     ON "LiteLLM_SpendLogs" ("session_id");
+
+CREATE INDEX IF NOT EXISTS "LiteLLM_SpendLogs_user_startTime_idx"
+    ON "LiteLLM_SpendLogs" ("user", "startTime" DESC);
+
+CREATE INDEX IF NOT EXISTS "LiteLLM_SpendLogs_api_key_startTime_idx"
+    ON "LiteLLM_SpendLogs" ("api_key", "startTime" DESC);
 
 INSERT INTO "LiteLLM_SpendLogs"
 SELECT * FROM "LiteLLM_SpendLogs_partitioned"

--- a/litellm-proxy-extras/litellm_proxy_extras/migrations/20260902000000_add_spend_logs_user_start_time_idx/migration.sql
+++ b/litellm-proxy-extras/litellm_proxy_extras/migrations/20260902000000_add_spend_logs_user_start_time_idx/migration.sql
@@ -1,0 +1,6 @@
+-- CreateIndex
+-- Plain build on purpose: Postgres refuses CONCURRENTLY on a partitioned parent (what
+-- db_scripts/partition_spend_logs.sql leaves behind) and inside the transaction prisma migrate
+-- deploy runs this in. Inserts to "LiteLLM_SpendLogs" block for the build; operators can
+-- pre-create the index under this exact name and this statement then no-ops.
+CREATE INDEX IF NOT EXISTS "LiteLLM_SpendLogs_user_startTime_idx" ON "LiteLLM_SpendLogs"("user", "startTime" DESC);

--- a/litellm-proxy-extras/litellm_proxy_extras/migrations/20260902000100_add_spend_logs_api_key_start_time_idx/migration.sql
+++ b/litellm-proxy-extras/litellm_proxy_extras/migrations/20260902000100_add_spend_logs_api_key_start_time_idx/migration.sql
@@ -1,0 +1,5 @@
+-- CreateIndex
+-- Same constraints as 20260902000000_add_spend_logs_user_start_time_idx: plain build so
+-- partitioned parents can take it, inserts block for the duration, pre-creating under this
+-- name makes it a no-op.
+CREATE INDEX IF NOT EXISTS "LiteLLM_SpendLogs_api_key_startTime_idx" ON "LiteLLM_SpendLogs"("api_key", "startTime" DESC);

--- a/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
+++ b/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
@@ -662,6 +662,8 @@ model LiteLLM_SpendLogs {
   @@index([startTime, request_id])
   @@index([end_user])
   @@index([session_id])
+  @@index([user, startTime(sort: Desc)])
+  @@index([api_key, startTime(sort: Desc)])
 }
 
 model LiteLLM_BudgetWindowSpend {

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -662,6 +662,8 @@ model LiteLLM_SpendLogs {
   @@index([startTime, request_id])
   @@index([end_user])
   @@index([session_id])
+  @@index([user, startTime(sort: Desc)])
+  @@index([api_key, startTime(sort: Desc)])
 }
 
 model LiteLLM_BudgetWindowSpend {

--- a/schema.prisma
+++ b/schema.prisma
@@ -662,6 +662,8 @@ model LiteLLM_SpendLogs {
   @@index([startTime, request_id])
   @@index([end_user])
   @@index([session_id])
+  @@index([user, startTime(sort: Desc)])
+  @@index([api_key, startTime(sort: Desc)])
 }
 
 model LiteLLM_BudgetWindowSpend {

--- a/tests/proxy_migration_tests/test_db_schema_migration.py
+++ b/tests/proxy_migration_tests/test_db_schema_migration.py
@@ -1,8 +1,12 @@
+import json
 import os
 import shutil
 import subprocess
 import tempfile
+import uuid
+from collections.abc import Iterator
 from pathlib import Path
+from typing import Final
 
 import pytest
 
@@ -68,3 +72,127 @@ def test_schema_migration_in_sync():
         assert diff.returncode == 0, f"prisma migrate diff errored: {diff.stderr}"
     finally:
         shutil.rmtree(temp_base, ignore_errors=True)
+
+
+requires_db: Final = pytest.mark.skipif(
+    "DATABASE_URL" not in os.environ,
+    reason="requires a postgres database (DATABASE_URL)",
+)
+
+MIGRATIONS_DIR: Final = Path("./litellm-proxy-extras/litellm_proxy_extras/migrations")
+
+SPEND_LOGS_FILTER_INDEXES: Final = (
+    ('"user"', "user-7", "LiteLLM_SpendLogs_user_startTime_idx"),
+    ("api_key", "key-7", "LiteLLM_SpendLogs_api_key_startTime_idx"),
+)
+
+SPEND_LOGS_PROBE_SQL: Final = """
+CREATE TABLE "LiteLLM_SpendLogs" (
+    request_id TEXT PRIMARY KEY,
+    api_key TEXT NOT NULL DEFAULT '',
+    "startTime" TIMESTAMP(3) NOT NULL,
+    "user" TEXT DEFAULT ''
+);
+CREATE INDEX "LiteLLM_SpendLogs_startTime_idx" ON "LiteLLM_SpendLogs"("startTime");
+CREATE INDEX "LiteLLM_SpendLogs_startTime_request_id_idx" ON "LiteLLM_SpendLogs"("startTime", "request_id");
+INSERT INTO "LiteLLM_SpendLogs" (request_id, api_key, "startTime", "user")
+SELECT 'req-' || g, 'key-' || (g % 200), TIMESTAMP '2026-08-01' + g * INTERVAL '1 minute', 'user-' || (g % 200)
+FROM generate_series(1, 60000) AS g;
+ANALYZE "LiteLLM_SpendLogs";
+"""
+
+SPEND_LOGS_PARTITIONED_PROBE_SQL: Final = """
+CREATE TABLE "LiteLLM_SpendLogs" (
+    request_id TEXT NOT NULL,
+    api_key TEXT NOT NULL DEFAULT '',
+    "startTime" TIMESTAMP(3) NOT NULL,
+    "user" TEXT DEFAULT '',
+    PRIMARY KEY (request_id, "startTime")
+) PARTITION BY RANGE ("startTime");
+CREATE TABLE "LiteLLM_SpendLogs_pdefault" PARTITION OF "LiteLLM_SpendLogs" DEFAULT;
+"""
+
+
+def _in_schema(schema: str, sql: str) -> list[tuple[object, ...]]:
+    psycopg: Final = pytest.importorskip("psycopg")
+    with psycopg.connect(os.environ["DATABASE_URL"].split("?")[0], autocommit=True) as conn:
+        conn.execute(f'SET search_path TO "{schema}"')
+        cursor: Final = conn.execute(sql)
+        return cursor.fetchall() if cursor.description is not None else []
+
+
+def _migration_creating(index_name: str) -> str:
+    creating: Final = tuple(
+        sql
+        for sql in (path.read_text() for path in sorted(MIGRATIONS_DIR.glob("*/migration.sql")))
+        if index_name in sql
+    )
+    assert len(creating) == 1, f"expected exactly one migration creating {index_name}, found {len(creating)}"
+    return creating[0]
+
+
+def _bounded_count_plan(schema: str, column: str, value: str) -> str:
+    rows: Final = _in_schema(
+        schema,
+        f"""
+        EXPLAIN (FORMAT JSON)
+        SELECT COUNT(*) AS total_count
+        FROM (
+            SELECT 1
+            FROM "LiteLLM_SpendLogs"
+            WHERE "startTime" >= ('2026-08-10T00:00:00Z'::timestamptz AT TIME ZONE 'UTC')
+              AND "startTime" <= ('2026-08-17T00:00:00Z'::timestamptz AT TIME ZONE 'UTC')
+              AND {column} = '{value}'
+            LIMIT 10001
+        ) AS bounded_matches
+        """,
+    )
+    return json.dumps(rows[0][0])
+
+
+@pytest.fixture
+def spend_logs_scratch_schema() -> Iterator[str]:
+    schema: Final = f"spend_logs_idx_{uuid.uuid4().hex[:8]}"
+    _in_schema("public", f'CREATE SCHEMA "{schema}"')
+    yield schema
+    _in_schema("public", f'DROP SCHEMA "{schema}" CASCADE')
+
+
+@requires_db
+@pytest.mark.parametrize(("column", "value", "index_name"), SPEND_LOGS_FILTER_INDEXES, ids=("user", "api_key"))
+def test_spend_logs_bounded_count_is_served_by_the_filter_column_index(
+    spend_logs_scratch_schema: str, column: str, value: str, index_name: str
+) -> None:
+    """The /spend/logs/v2 count for one user or key inside a startTime window must read that
+    user's rows only. Without a filter-column-led index it range-scans the whole window and
+    post-filters every row, which times out on multi-day windows at production volume.
+    """
+    _in_schema(spend_logs_scratch_schema, SPEND_LOGS_PROBE_SQL)
+    _in_schema(spend_logs_scratch_schema, _migration_creating(index_name))
+    _in_schema(spend_logs_scratch_schema, 'ANALYZE "LiteLLM_SpendLogs"')
+
+    plan: Final = _bounded_count_plan(spend_logs_scratch_schema, column, value)
+
+    assert f'"Index Name": "{index_name}"' in plan, plan
+    assert '"Filter"' not in plan, plan
+
+
+@requires_db
+def test_spend_logs_filter_index_migrations_apply_to_a_partitioned_table(spend_logs_scratch_schema: str) -> None:
+    """db_scripts/partition_spend_logs.sql leaves LiteLLM_SpendLogs a partitioned parent, and
+    Postgres rejects CONCURRENTLY there, so a concurrent build would abort every partitioned
+    deployment's rollout. Apply the shipped statements against that shape for real.
+    """
+    _in_schema(spend_logs_scratch_schema, SPEND_LOGS_PARTITIONED_PROBE_SQL)
+    for _column, _value, index_name in SPEND_LOGS_FILTER_INDEXES:
+        _in_schema(spend_logs_scratch_schema, _migration_creating(index_name))
+
+    parent_indexes: Final = frozenset(
+        str(row[0])
+        for row in _in_schema(
+            spend_logs_scratch_schema,
+            "SELECT indexname FROM pg_indexes WHERE schemaname = current_schema() AND tablename = 'LiteLLM_SpendLogs'",
+        )
+    )
+
+    assert {index_name for _column, _value, index_name in SPEND_LOGS_FILTER_INDEXES} <= parent_indexes, parent_indexes


### PR DESCRIPTION
## TLDR

Problem this solves:

- `LiteLLM_SpendLogs` has no index led by `"user"` or `api_key`
- Filtering spend logs by one user scans the whole date range
- Cost grows with the window width, not the result size
- Wide windows blow the DB read timeout and return 500
- Same gap makes the Logs tab's key filter slow

How it solves it:

- Adds `("user", "startTime" DESC)` and `("api_key", "startTime" DESC)`
- Declared in the schema, shipped as two migrations
- Count becomes an index-only scan, flat across window widths
- Page query also loses its sort step
- Partition and unpartition runbooks carry both indexes

## User Flow

Before: an admin filtering the Logs page by one user over a week gets an error instead of results

1. They open `https://litellm-domain/ui/?page=logs`, set the user filter to a single user id and the date range to 1 day — the table loads normally
2. They widen the same filter to 7 days
3. The page fails to load; the request behind it, `GET https://litellm-domain/spend/logs/v2?user_id=<id>&start_date=2026-08-01&end_date=2026-08-08&page=1&page_size=50`, returns `500` with a database read timeout
4. Narrowing back to 1–2 days works again, so what breaks it is how wide the date range is, not how many rows that user actually has
5. The same widening breaks the API-key filter on the same page

After: the same 7-day filter returns the page

1. They open `https://litellm-domain/ui/?page=logs`, set the user filter to a single user id and the date range to 1 day — the table loads normally
2. They widen the same filter to 7 days
3. `GET https://litellm-domain/spend/logs/v2?user_id=<id>&start_date=2026-08-01&end_date=2026-08-08&page=1&page_size=50` returns `200` with the first 50 rows and a total count
4. Widening further to 30 days still returns `200`, and takes about as long as the 1-day request did
5. The API-key filter on the same page behaves the same way

## Relevant issues

Same class of gap, `api_key` half only, all still unmerged: #37983, #37167, #37379.

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

This one is not visible through a response body — the endpoint returns the same JSON either way, it
just stops timing out — so the proof is the query plan, same framing as #37379. Plan shape and buffer
counts are hardware-independent; the millisecond figures come from a small test box and are there for
scale only.

Shared setup, identical on both sides: Postgres 16.12, a `LiteLLM_SpendLogs` clone seeded with 400,000
rows over a 30-day window across 1,200 users, then `ANALYZE`. One user (`user-0`) holds 75 rows inside
the 7-day window measured; a second (`whale`) holds 13,421, i.e. above the query's `LIMIT 10001` cap.
The statement measured is exactly what `ui_view_spend_logs` emits for
`GET /spend/logs/v2?user_id=…&start_date=…&end_date=…&page=1&page_size=50`, run through
`EXPLAIN (ANALYZE, BUFFERS)` with `plan_cache_mode = force_custom_plan`.

### Before (31ca4ddf32)

#### Count, one user, window widened 1 → 30 days

1. `EXPLAIN (ANALYZE, BUFFERS)` the bounded count at each window width:

   | Window | Plan | Rows discarded | Rows returned | Buffers | Time |
   |---|---|---|---|---|---|
   | 1 day | Bitmap Heap Scan on `startTime_idx` + `Filter` | 13,325 | 16 | 7,557 | 16.9 ms |
   | 3 days | same | 40,352 | 31 | 10,189 | 26.9 ms |
   | 7 days | same | 93,444 | 75 | 10,501 | 46.6 ms |
   | 14 days | Parallel Seq Scan | 133,286 /worker | 48 | 10,215 | 36.8 ms |
   | 30 days | Parallel Seq Scan | 133,238 /worker | 95 | 10,215 | 38.0 ms |

2. The 7-day plan, in full:

```
 Aggregate  (actual time=46.6..46.6 rows=1 loops=1)
   ->  Limit  (actual time=10.001..46.556 rows=75 loops=1)
         ->  Bitmap Heap Scan on "LiteLLM_SpendLogs"  (actual time=10.001..46.556 rows=75 loops=1)
               Recheck Cond: (("startTime" >= '2026-08-01') AND ("startTime" <= '2026-08-08'))
               Filter: ("user" = 'user-0'::text)
               Rows Removed by Filter: 93444
               Buffers: shared hit=10501
               ->  Bitmap Index Scan on "LiteLLM_SpendLogs_startTime_idx"  (rows=93519 loops=1)
```

3. The work is done by `Filter`, after the fact — 93,519 rows read to return 75. `LIMIT 10001` never
   fires because the user does not have that many rows, so nothing stops the scan early.

#### Control: the same window for a user above the LIMIT cap

1. Same statement, same 7-day window, `user = 'whale'` (13,421 rows in range):

```
 Aggregate  (actual time=39.9 rows=1 loops=1)
   ->  Limit  (actual time=9.229..38.102 rows=10001 loops=1)
         ->  Bitmap Heap Scan on "LiteLLM_SpendLogs"  (rows=10001 loops=1)
               Filter: ("user" = 'whale'::text)
               Rows Removed by Filter: 59508
               Buffers: shared hit=7853
```

2. It matches 179× more rows than `user-0` and costs less — 7,853 buffers vs 10,501 — because the
   `LIMIT` short-circuits for it. Table size and DB health are the same in both runs; the only
   variable is how selective the filter is.

#### Page fetch, one user

1. 7-day window: `Sort` (quicksort, `Sort Key: "startTime" DESC`) over the same Bitmap Heap Scan —
   `Buffers: shared hit=10504`, 47.3 ms.
2. 30-day window: `Index Scan Backward using "LiteLLM_SpendLogs_startTime_idx"` +
   `Filter: ("user" = 'user-0')`, `Rows Removed by Filter: 70291`, `Buffers: shared hit=70820`, 60.9 ms.

#### Count, one API key

1. 7-day window, `api_key = 'key-7'` (461 rows in range): Bitmap Heap Scan on `startTime_idx`,
   `Filter: (api_key = 'key-7'::text)`, `Rows Removed by Filter: 93058`, `Buffers: shared hit=10501`,
   40.2 ms.
2. 30-day window: Parallel Seq Scan, `Buffers: shared hit=10215`, 31.8 ms.

### After (94b6d0642b)

1. Apply this PR's two migration files verbatim to the same seeded table, then `ANALYZE`:

```
CREATE INDEX
Time: 1169.627 ms (00:01.170)
CREATE INDEX
Time: 764.474 ms
```

   Both build plainly, no `CONCURRENTLY`. Index sizes against an 80 MB heap: 18 MB for the `user`
   index, 16 MB for the `api_key` index — about 47 and 42 bytes per row.

#### Count, one user, window widened 1 → 30 days

1. Same `EXPLAIN (ANALYZE, BUFFERS)` at each window width:

   | Window | Plan | Buffers | Time | Before → After buffers |
   |---|---|---|---|---|
   | 1 day | `Index Only Scan` on `LiteLLM_SpendLogs_user_startTime_idx` | 4 | 0.049 ms | 7,557 → 4 |
   | 3 days | same | 4 | 0.089 ms | 10,189 → 4 |
   | 7 days | same | 4 | 0.078 ms | 10,501 → 4 |
   | 14 days | same | 5 | 0.109 ms | 10,215 → 5 |
   | 30 days | same | 5 | 0.183 ms | 10,215 → 5 |

2. The 7-day plan, in full:

```
 Aggregate  (cost=6.73..6.74 rows=1 width=8) (actual time=0.059..0.059 rows=1 loops=1)
   ->  Limit  (cost=0.42..5.91 rows=66 width=4) (actual time=0.025..0.050 rows=75 loops=1)
         ->  Index Only Scan using "LiteLLM_SpendLogs_user_startTime_idx" on "LiteLLM_SpendLogs"
               Index Cond: (("user" = 'user-0'::text)
                            AND ("startTime" >= '2026-08-01') AND ("startTime" <= '2026-08-08'))
               Heap Fetches: 0
               Buffers: shared hit=4
 Execution Time: 0.078 ms
```

3. Both predicates are now inside `Index Cond`. There is no `Filter` node and no heap access at all
   (`Heap Fetches: 0`). Cost is flat from 1 day to 30 days, which is the actual fix: the query stops
   caring how wide the window is.

#### Control: the same window for a user above the LIMIT cap

1. Same statement, `user = 'whale'`: `Index Only Scan` on the new index, 54 buffers, 5.6 ms
   (from 7,853 buffers / 39.9 ms). It still stops at 10,001 rows; it just reaches them through
   the index now.

#### Page fetch, one user

1. 7-day window: `Index Scan using "LiteLLM_SpendLogs_user_startTime_idx"`, **no `Sort` node**,
   `Buffers: shared hit=53`, 0.24 ms (from 10,504 buffers / 47.3 ms).
2. 30-day window: same plan, 53 buffers, 0.23 ms (from 70,820 buffers / 60.9 ms). The `DESC` second
   column is what removes the sort — the index already delivers `ORDER BY "startTime" DESC`.

#### Count, one API key

1. 7-day window: `Index Only Scan using "LiteLLM_SpendLogs_api_key_startTime_idx"`,
   `Buffers: shared hit=7`, 0.21 ms (from 10,501 buffers / 40.2 ms).
2. 30-day window: same plan, 14 buffers, 0.81 ms (from 10,215 buffers / 31.8 ms).

#### Test suite

1. `DATABASE_URL=… uv run pytest tests/proxy_migration_tests/test_db_schema_migration.py tests/proxy_migration_tests/test_replica_identity_full.py -v` → `12 passed`.
2. `test_schema_migration_in_sync` is the definition pin: it deploys all 165 migrations and
   `prisma migrate diff`s the result against `schema.prisma`, so it fails if the migration SQL and the
   `@@index` declarations ever disagree on name, column order, or `DESC`.
3. With the two migration directories removed, the three new tests fail with
   `expected exactly one migration creating LiteLLM_SpendLogs_user_startTime_idx, found 0`.

One caveat on reading the Before table honestly: buffer counts plateau at ~10,215 from 7 days on
because that is the entire heap of a 400k-row test table — the scan saturates and cannot grow further.
The linear term is in rows examined (13k → 40k → 93k) and time (16.9 → 26.9 → 46.6 ms) over 1–7 days.
On a real deployment nothing saturates, and rows there are far fatter than these seeded ones, so this
is a floor on the effect rather than a ceiling. #37167 measured 96.7 s → 0.37 s for the `api_key` half
at 10^7 rows.

## Type

🐛 Bug Fix
🚄 Infrastructure

## Caveats (if any)

### Severe

- Both indexes build during the migration step of an upgrade
- Build is plain, not `CONCURRENTLY` — deliberate, see below
- Each build holds a `SHARE` lock on `LiteLLM_SpendLogs`
- Reads continue; **inserts to that table block** for the build
- Measured 1.2 s per 400k rows; minutes per index on a large table
- Rolling deploys keep old pods inserting, so those inserts stall
- Escape hatch: pre-create both indexes before upgrading, same names —
  `LiteLLM_SpendLogs_user_startTime_idx`, `LiteLLM_SpendLogs_api_key_startTime_idx`.
  `IF NOT EXISTS` then makes both migrations no-ops.
  - Plain table: `CREATE INDEX CONCURRENTLY`
  - Partitioned table: per-partition builds + `ATTACH PARTITION INDEX`
- Why not `CONCURRENTLY` in the migration: Postgres rejects it on a partitioned parent, and inside the
  transaction `prisma migrate deploy` runs each migration in. This is what forced a revision of #37379.
- Two migration files, not one, so the two lock windows are separate rather than held back to back

### Medium

- Two more btrees maintained on the hottest insert path
- ~47 bytes per row each: roughly 2.8 GB apiece at 60M rows
- Overlaps #37983 / #37167; if either lands first, drop the `api_key` half here

### Low

- Forward-only, like every migration here: reverting the commit leaves the indexes on databases that
  already applied it. Harmless; drop by hand if unwanted.
- `db_scripts/partition_spend_logs.sql` and `unpartition_spend_logs.sql` had to learn both index names
  too — `LIKE … INCLUDING DEFAULTS` does not copy indexes, and index names are unique per schema, so
  without the rename-aside the recreate would be silently skipped by `IF NOT EXISTS`

## Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
