### PR TITLE
fix: avoid mutable default in InfinityError

### DIFF
--- a/litellm/llms/infinity/common_utils.py
+++ b/litellm/llms/infinity/common_utils.py
@@ -4,7 +4,9 @@ from litellm.llms.base_llm.chat.transformation import BaseLLMException
 
 
 class InfinityError(BaseLLMException):
-    def __init__(self, status_code: int, message: str, headers: dict | httpx.Headers = {}):
+    def __init__(self, status_code: int, message: str, headers: dict | httpx.Headers | None = None):
+        if headers is None:
+            headers = {}
         self.status_code = status_code
         self.message = message
         self.request = httpx.Request(method="POST", url="https://github.com/michaelfeil/infinity")

--- a/litellm/llms/infinity/common_utils.py
+++ b/litellm/llms/infinity/common_utils.py
@@ -5,8 +5,7 @@ from litellm.llms.base_llm.chat.transformation import BaseLLMException
 
 class InfinityError(BaseLLMException):
     def __init__(self, status_code: int, message: str, headers: dict | httpx.Headers | None = None):
-        if headers is None:
-            headers = {}
+        resolved_headers = {} if headers is None else headers
         self.status_code = status_code
         self.message = message
         self.request = httpx.Request(method="POST", url="https://github.com/michaelfeil/infinity")
@@ -16,5 +15,5 @@ class InfinityError(BaseLLMException):
             message=message,
             request=self.request,
             response=self.response,
-            headers=headers,
+            headers=resolved_headers,
         )  # Call the base class constructor with the parameters it needs

--- a/tests/llm_translation/test_infinity.py
+++ b/tests/llm_translation/test_infinity.py
@@ -15,6 +15,24 @@ from test_rerank import assert_response_shape
 from base_embedding_unit_tests import BaseLLMEmbeddingTest
 from litellm.llms.custom_httpx.http_handler import HTTPHandler, AsyncHTTPHandler
 from litellm.types.utils import EmbeddingResponse, Usage
+from litellm.llms.infinity.common_utils import InfinityError
+
+
+def test_infinity_error_uses_fresh_headers_when_omitted():
+    first = InfinityError(status_code=400, message="first")
+    second = InfinityError(status_code=400, message="second")
+
+    assert first.headers == {}
+    assert second.headers == {}
+    assert first.headers is not second.headers
+
+
+def test_infinity_error_preserves_supplied_headers():
+    headers = {"x-request-id": "request-1"}
+
+    error = InfinityError(status_code=400, message="failed", headers=headers)
+
+    assert error.headers is headers
 
 
 @pytest.mark.asyncio()


### PR DESCRIPTION
## Description
Fix mutable default argument anti-pattern in `InfinityError.__init__`. Using mutable default arguments like `dict={}` or `list=[]` in Python function definitions is dangerous because the default value is shared across all calls to the function. Any modifications to the mutable default argument will persist across subsequent calls.

## Changes
- Changed `headers: dict | httpx.Headers = {}` to `headers: dict | httpx.Headers | None = None`
- Added `if headers is None: headers = {}` inside the `__init__` method

## Testing
This is a bug fix that doesn't change the public API behavior, but prevents potential issues when the `headers` parameter is not provided or when the same instance is modified multiple times.

## Related
This is a common Python anti-pattern known as "mutable default arguments" - see https://docs.python-guide.org/writing/gotchas/