### PR TITLE
fix: avoid mutable defaults in Gemini part checks

### DIFF
--- a/litellm/llms/infinity/common_utils.py
+++ b/litellm/llms/infinity/common_utils.py
@@ -4,7 +4,9 @@ from litellm.llms.base_llm.chat.transformation import BaseLLMException
 
 
 class InfinityError(BaseLLMException):
-    def __init__(self, status_code: int, message: str, headers: dict | httpx.Headers = {}):
+    def __init__(self, status_code: int, message: str, headers: dict | httpx.Headers | None = None):
+        if headers is None:
+            headers = {}
         self.status_code = status_code
         self.message = message
         self.request = httpx.Request(method="POST", url="https://github.com/michaelfeil/infinity")

--- a/litellm/llms/infinity/common_utils.py
+++ b/litellm/llms/infinity/common_utils.py
@@ -5,8 +5,7 @@ from litellm.llms.base_llm.chat.transformation import BaseLLMException
 
 class InfinityError(BaseLLMException):
     def __init__(self, status_code: int, message: str, headers: dict | httpx.Headers | None = None):
-        if headers is None:
-            headers = {}
+        resolved_headers = {} if headers is None else headers
         self.status_code = status_code
         self.message = message
         self.request = httpx.Request(method="POST", url="https://github.com/michaelfeil/infinity")
@@ -16,5 +15,5 @@ class InfinityError(BaseLLMException):
             message=message,
             request=self.request,
             response=self.response,
-            headers=headers,
+            headers=resolved_headers,
         )  # Call the base class constructor with the parameters it needs

--- a/litellm/llms/vertex_ai/gemini/transformation.py
+++ b/litellm/llms/vertex_ai/gemini/transformation.py
@@ -613,11 +613,13 @@ def _get_equivalent_key(key: str, available_keys: set) -> str | None:
     return None
 
 
-def check_if_part_exists_in_parts(parts: list[PartType], part: PartType, excluded_keys: list[str] = []) -> bool:
+def check_if_part_exists_in_parts(parts: list[PartType], part: PartType, excluded_keys: list[str] | None = None) -> bool:
     """
     Check if a part exists in a list of parts
     Handles both camelCase and snake_case key variations (e.g., function_call vs functionCall)
     """
+    if excluded_keys is None:
+        excluded_keys = []
     keys_to_compare: Final = set(part.keys()) - set(excluded_keys)
     for p in parts:
         p_keys = set(p.keys())

--- a/litellm/llms/vertex_ai/gemini/transformation.py
+++ b/litellm/llms/vertex_ai/gemini/transformation.py
@@ -618,9 +618,8 @@ def check_if_part_exists_in_parts(parts: list[PartType], part: PartType, exclude
     Check if a part exists in a list of parts
     Handles both camelCase and snake_case key variations (e.g., function_call vs functionCall)
     """
-    if excluded_keys is None:
-        excluded_keys = []
-    keys_to_compare: Final = set(part.keys()) - set(excluded_keys)
+    resolved_excluded_keys = [] if excluded_keys is None else excluded_keys
+    keys_to_compare: Final = set(part.keys()) - set(resolved_excluded_keys)
     for p in parts:
         p_keys = set(p.keys())
         # Check if all keys in part have equivalent values in p

--- a/litellm/llms/vertex_ai/gemini/transformation.py
+++ b/litellm/llms/vertex_ai/gemini/transformation.py
@@ -613,7 +613,9 @@ def _get_equivalent_key(key: str, available_keys: set) -> str | None:
     return None
 
 
-def check_if_part_exists_in_parts(parts: list[PartType], part: PartType, excluded_keys: list[str] | None = None) -> bool:
+def check_if_part_exists_in_parts(
+    parts: list[PartType], part: PartType, excluded_keys: list[str] | None = None
+) -> bool:
     """
     Check if a part exists in a list of parts
     Handles both camelCase and snake_case key variations (e.g., function_call vs functionCall)


### PR DESCRIPTION
## Description
Fix mutable default argument anti-pattern in `check_if_part_exists_in_parts`. Using mutable default arguments like `list=[]` in Python function definitions is dangerous because the default value is shared across all calls to the function.

## Changes
- Changed `excluded_keys: list[str] = []` to `excluded_keys: list[str] | None = None`
- Added `if excluded_keys is None: excluded_keys = []` inside the function

## Testing
This is a bug fix that doesn't change the public API behavior, but prevents potential issues when the `excluded_keys` parameter is not provided.

## Related
This is a common Python anti-pattern known as "mutable default arguments" - see https://docs.python-guide.org/writing/gotchas/