### PR TITLE
fix(openai): allow reasoning_effort when model metadata declares supports_reasoning

### DIFF
--- a/litellm/llms/openai/chat/gpt_transformation.py
+++ b/litellm/llms/openai/chat/gpt_transformation.py
@@ -180,14 +180,9 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
                 "user"
             )  # user is not a param supported by all openai-compatible endpoints - e.g. azure ai
         supported_params = base_params + model_specific_params
-        model_for_metadata: Final = (
-            model.split("responses/", 1)[1] if "responses/" in model else model
-        )
+        model_for_metadata: Final = model.split("responses/", 1)[1] if "responses/" in model else model
         model_info = litellm.model_cost.get(model_for_metadata) or {}
-        if (
-            model_info.get("supports_reasoning") is True
-            and "reasoning_effort" not in supported_params
-        ):
+        if model_info.get("supports_reasoning") is True and "reasoning_effort" not in supported_params:
             return supported_params + ["reasoning_effort"]
         return supported_params
 

--- a/litellm/llms/openai/chat/gpt_transformation.py
+++ b/litellm/llms/openai/chat/gpt_transformation.py
@@ -180,10 +180,15 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
                 "user"
             )  # user is not a param supported by all openai-compatible endpoints - e.g. azure ai
         supported_params = base_params + model_specific_params
-        from litellm.utils import supports_reasoning
-
-        if supports_reasoning(model=model, custom_llm_provider="openai") and "reasoning_effort" not in supported_params:
-            supported_params.append("reasoning_effort")
+        model_for_metadata: Final = (
+            model.split("responses/", 1)[1] if "responses/" in model else model
+        )
+        model_info = litellm.model_cost.get(model_for_metadata) or {}
+        if (
+            model_info.get("supports_reasoning") is True
+            and "reasoning_effort" not in supported_params
+        ):
+            return supported_params + ["reasoning_effort"]
         return supported_params
 
     @staticmethod

--- a/litellm/llms/openai/chat/gpt_transformation.py
+++ b/litellm/llms/openai/chat/gpt_transformation.py
@@ -182,9 +182,12 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
         supported_params = base_params + model_specific_params
         if OpenAIGPTConfig.is_openai_catalog_model(model):
             model_for_metadata: Final = model.split("responses/", 1)[1] if "responses/" in model else model
-            model_info = litellm.model_cost.get(model_for_metadata) or {}
-            if model_info.get("supports_reasoning") is True and "reasoning_effort" not in supported_params:
-                return supported_params + ["reasoning_effort"]
+            # gpt-5-chat* are regular chat models (#13781); bundled model_cost may still
+            # carry supports_reasoning without exposing reasoning_effort on this path.
+            if not model_for_metadata.split("/")[-1].startswith("gpt-5-chat"):
+                model_info = litellm.model_cost.get(model_for_metadata) or {}
+                if model_info.get("supports_reasoning") is True and "reasoning_effort" not in supported_params:
+                    return supported_params + ["reasoning_effort"]
         return supported_params
 
     @staticmethod

--- a/litellm/llms/openai/chat/gpt_transformation.py
+++ b/litellm/llms/openai/chat/gpt_transformation.py
@@ -180,10 +180,11 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
                 "user"
             )  # user is not a param supported by all openai-compatible endpoints - e.g. azure ai
         supported_params = base_params + model_specific_params
-        model_for_metadata: Final = model.split("responses/", 1)[1] if "responses/" in model else model
-        model_info = litellm.model_cost.get(model_for_metadata) or {}
-        if model_info.get("supports_reasoning") is True and "reasoning_effort" not in supported_params:
-            return supported_params + ["reasoning_effort"]
+        if OpenAIGPTConfig.is_openai_catalog_model(model):
+            model_for_metadata: Final = model.split("responses/", 1)[1] if "responses/" in model else model
+            model_info = litellm.model_cost.get(model_for_metadata) or {}
+            if model_info.get("supports_reasoning") is True and "reasoning_effort" not in supported_params:
+                return supported_params + ["reasoning_effort"]
         return supported_params
 
     @staticmethod

--- a/litellm/llms/openai/chat/gpt_transformation.py
+++ b/litellm/llms/openai/chat/gpt_transformation.py
@@ -179,7 +179,12 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
             model_specific_params.append(
                 "user"
             )  # user is not a param supported by all openai-compatible endpoints - e.g. azure ai
-        return base_params + model_specific_params
+        supported_params = base_params + model_specific_params
+        from litellm.utils import supports_reasoning
+
+        if supports_reasoning(model=model, custom_llm_provider="openai") and "reasoning_effort" not in supported_params:
+            supported_params.append("reasoning_effort")
+        return supported_params
 
     @staticmethod
     def is_openai_catalog_model(model: str) -> bool:

--- a/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
+++ b/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
@@ -155,28 +155,24 @@ class TestGetOptionalParamsIntegration:
         )
         assert "reasoning_effort" in supported_params
 
-    def test_reasoning_effort_not_supported_for_known_non_reasoning_models(self):
+    def test_reasoning_effort_not_supported_for_known_non_reasoning_models(self, monkeypatch):
         """Known OpenAI models keep failing closed client-side."""
         import litellm
         from litellm.llms.openai.openai import OpenAIConfig
 
         gpt4o_entry = litellm.model_cost.get("gpt-4o")
         if isinstance(gpt4o_entry, dict) and gpt4o_entry.get("supports_reasoning"):
-            litellm.model_cost["gpt-4o"] = {**gpt4o_entry, "supports_reasoning": False}
-            try:
-                config = OpenAIConfig()
-                assert "reasoning_effort" not in config.get_supported_openai_params("gpt-4o")
-                assert "reasoning_effort" not in config.get_supported_openai_params(
-                    "responses/gpt-4.1-mini"
-                )
-            finally:
-                litellm.model_cost["gpt-4o"] = gpt4o_entry
-        else:
-            config = OpenAIConfig()
-            assert "reasoning_effort" not in config.get_supported_openai_params("gpt-4o")
-            assert "reasoning_effort" not in config.get_supported_openai_params(
-                "responses/gpt-4.1-mini"
+            monkeypatch.setitem(
+                litellm.model_cost,
+                "gpt-4o",
+                {**gpt4o_entry, "supports_reasoning": False},
             )
+
+        config = OpenAIConfig()
+        assert "reasoning_effort" not in config.get_supported_openai_params("gpt-4o")
+        assert "reasoning_effort" not in config.get_supported_openai_params(
+            "responses/gpt-4.1-mini"
+        )
 
     def test_reasoning_effort_not_inherited_by_openai_compatible_subclasses(self):
         """Providers subclassing either openai config keep their own reasoning_effort gating
@@ -210,33 +206,29 @@ class TestGetOptionalParamsIntegration:
         )
         assert optional_params.get("reasoning_effort") == "low"
 
-    def test_reasoning_effort_still_rejected_for_known_non_reasoning_model(self):
+    def test_reasoning_effort_still_rejected_for_known_non_reasoning_model(self, monkeypatch):
         """A real OpenAI model that doesn't reason still rejects the param client-side."""
         import litellm
         from litellm.utils import get_optional_params
 
         gpt4o_entry = litellm.model_cost.get("gpt-4o")
         if isinstance(gpt4o_entry, dict) and gpt4o_entry.get("supports_reasoning"):
-            litellm.model_cost["gpt-4o"] = {**gpt4o_entry, "supports_reasoning": False}
-            try:
-                with pytest.raises(litellm.utils.UnsupportedParamsError):
-                    get_optional_params(
-                        model="gpt-4o",
-                        custom_llm_provider="openai",
-                        reasoning_effort="low",
-                    )
-            finally:
-                litellm.model_cost["gpt-4o"] = gpt4o_entry
-        else:
-            with pytest.raises(litellm.utils.UnsupportedParamsError):
-                get_optional_params(
-                    model="gpt-4o",
-                    custom_llm_provider="openai",
-                    reasoning_effort="low",
-                )
+            monkeypatch.setitem(
+                litellm.model_cost,
+                "gpt-4o",
+                {**gpt4o_entry, "supports_reasoning": False},
+            )
+
+        with pytest.raises(litellm.utils.UnsupportedParamsError):
+            get_optional_params(
+                model="gpt-4o",
+                custom_llm_provider="openai",
+                reasoning_effort="low",
+            )
 
     def test_reasoning_effort_allowed_when_catalog_model_declares_supports_reasoning(
         self,
+        monkeypatch,
     ):
         """openai/ catalog models with supports_reasoning=true in model metadata should
         accept reasoning_effort and pass it through unchanged."""
@@ -246,29 +238,27 @@ class TestGetOptionalParamsIntegration:
 
         model = "gpt-4o"
         original_entry = litellm.model_cost.get(model)
-        litellm.model_cost[model] = {
-            **(original_entry or {}),
-            "supports_reasoning": True,
-            "litellm_provider": "openai",
-            "reasoning_effort_levels": ["low", "high", "max"],
-        }
+        monkeypatch.setitem(
+            litellm.model_cost,
+            model,
+            {
+                **(original_entry or {}),
+                "supports_reasoning": True,
+                "litellm_provider": "openai",
+                "reasoning_effort_levels": ["low", "high", "max"],
+            },
+        )
 
-        try:
-            supported_params = OpenAIConfig().get_supported_openai_params(model)
-            assert "reasoning_effort" in supported_params
+        supported_params = OpenAIConfig().get_supported_openai_params(model)
+        assert "reasoning_effort" in supported_params
 
-            for effort in ("low", "high", "max"):
-                optional_params = get_optional_params(
-                    model=model,
-                    custom_llm_provider="openai",
-                    reasoning_effort=effort,
-                )
-                assert optional_params.get("reasoning_effort") == effort
-        finally:
-            if original_entry is None:
-                litellm.model_cost.pop(model, None)
-            else:
-                litellm.model_cost[model] = original_entry
+        for effort in ("low", "high", "max"):
+            optional_params = get_optional_params(
+                model=model,
+                custom_llm_provider="openai",
+                reasoning_effort=effort,
+            )
+            assert optional_params.get("reasoning_effort") == effort
 
 
 class TestOpenAIChatCompletionStreamingHandler:

--- a/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
+++ b/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
@@ -163,12 +163,20 @@ class TestGetOptionalParamsIntegration:
         gpt4o_entry = litellm.model_cost.get("gpt-4o")
         if isinstance(gpt4o_entry, dict) and gpt4o_entry.get("supports_reasoning"):
             litellm.model_cost["gpt-4o"] = {**gpt4o_entry, "supports_reasoning": False}
-
-        config = OpenAIConfig()
-        assert "reasoning_effort" not in config.get_supported_openai_params("gpt-4o")
-        assert "reasoning_effort" not in config.get_supported_openai_params(
-            "responses/gpt-4.1-mini"
-        )
+            try:
+                config = OpenAIConfig()
+                assert "reasoning_effort" not in config.get_supported_openai_params("gpt-4o")
+                assert "reasoning_effort" not in config.get_supported_openai_params(
+                    "responses/gpt-4.1-mini"
+                )
+            finally:
+                litellm.model_cost["gpt-4o"] = gpt4o_entry
+        else:
+            config = OpenAIConfig()
+            assert "reasoning_effort" not in config.get_supported_openai_params("gpt-4o")
+            assert "reasoning_effort" not in config.get_supported_openai_params(
+                "responses/gpt-4.1-mini"
+            )
 
     def test_reasoning_effort_not_inherited_by_openai_compatible_subclasses(self):
         """Providers subclassing either openai config keep their own reasoning_effort gating
@@ -210,13 +218,22 @@ class TestGetOptionalParamsIntegration:
         gpt4o_entry = litellm.model_cost.get("gpt-4o")
         if isinstance(gpt4o_entry, dict) and gpt4o_entry.get("supports_reasoning"):
             litellm.model_cost["gpt-4o"] = {**gpt4o_entry, "supports_reasoning": False}
-
-        with pytest.raises(litellm.utils.UnsupportedParamsError):
-            get_optional_params(
-                model="gpt-4o",
-                custom_llm_provider="openai",
-                reasoning_effort="low",
-            )
+            try:
+                with pytest.raises(litellm.utils.UnsupportedParamsError):
+                    get_optional_params(
+                        model="gpt-4o",
+                        custom_llm_provider="openai",
+                        reasoning_effort="low",
+                    )
+            finally:
+                litellm.model_cost["gpt-4o"] = gpt4o_entry
+        else:
+            with pytest.raises(litellm.utils.UnsupportedParamsError):
+                get_optional_params(
+                    model="gpt-4o",
+                    custom_llm_provider="openai",
+                    reasoning_effort="low",
+                )
 
     def test_reasoning_effort_allowed_when_catalog_model_declares_supports_reasoning(
         self,

--- a/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
+++ b/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
@@ -157,7 +157,12 @@ class TestGetOptionalParamsIntegration:
 
     def test_reasoning_effort_not_supported_for_known_non_reasoning_models(self):
         """Known OpenAI models keep failing closed client-side."""
+        import litellm
         from litellm.llms.openai.openai import OpenAIConfig
+
+        gpt4o_entry = litellm.model_cost.get("gpt-4o")
+        if isinstance(gpt4o_entry, dict) and gpt4o_entry.get("supports_reasoning"):
+            litellm.model_cost["gpt-4o"] = {**gpt4o_entry, "supports_reasoning": False}
 
         config = OpenAIConfig()
         assert "reasoning_effort" not in config.get_supported_openai_params("gpt-4o")
@@ -199,7 +204,12 @@ class TestGetOptionalParamsIntegration:
 
     def test_reasoning_effort_still_rejected_for_known_non_reasoning_model(self):
         """A real OpenAI model that doesn't reason still rejects the param client-side."""
+        import litellm
         from litellm.utils import get_optional_params
+
+        gpt4o_entry = litellm.model_cost.get("gpt-4o")
+        if isinstance(gpt4o_entry, dict) and gpt4o_entry.get("supports_reasoning"):
+            litellm.model_cost["gpt-4o"] = {**gpt4o_entry, "supports_reasoning": False}
 
         with pytest.raises(litellm.utils.UnsupportedParamsError):
             get_optional_params(
@@ -207,6 +217,41 @@ class TestGetOptionalParamsIntegration:
                 custom_llm_provider="openai",
                 reasoning_effort="low",
             )
+
+    def test_reasoning_effort_allowed_when_catalog_model_declares_supports_reasoning(
+        self,
+    ):
+        """openai/ catalog models with supports_reasoning=true in model metadata should
+        accept reasoning_effort and pass it through unchanged."""
+        import litellm
+        from litellm.llms.openai.openai import OpenAIConfig
+        from litellm.utils import get_optional_params
+
+        model = "gpt-4o"
+        original_entry = litellm.model_cost.get(model)
+        litellm.model_cost[model] = {
+            **(original_entry or {}),
+            "supports_reasoning": True,
+            "litellm_provider": "openai",
+            "reasoning_effort_levels": ["low", "high", "max"],
+        }
+
+        try:
+            supported_params = OpenAIConfig().get_supported_openai_params(model)
+            assert "reasoning_effort" in supported_params
+
+            for effort in ("low", "high", "max"):
+                optional_params = get_optional_params(
+                    model=model,
+                    custom_llm_provider="openai",
+                    reasoning_effort=effort,
+                )
+                assert optional_params.get("reasoning_effort") == effort
+        finally:
+            if original_entry is None:
+                litellm.model_cost.pop(model, None)
+            else:
+                litellm.model_cost[model] = original_entry
 
 
 class TestOpenAIChatCompletionStreamingHandler:

--- a/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
+++ b/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
@@ -260,6 +260,15 @@ class TestGetOptionalParamsIntegration:
             )
             assert optional_params.get("reasoning_effort") == effort
 
+    def test_gpt5_chat_catalog_metadata_does_not_add_reasoning_effort(self):
+        """gpt-5-chat* stays off the metadata reasoning path even when bundled
+        model_cost marks supports_reasoning (#13781)."""
+        from litellm.llms.openai.openai import OpenAIConfig
+
+        assert "reasoning_effort" not in OpenAIConfig().get_supported_openai_params(
+            "gpt-5-chat-latest"
+        )
+
 
 class TestOpenAIChatCompletionStreamingHandler:
     """Tests for OpenAIChatCompletionStreamingHandler.chunk_parser()"""


### PR DESCRIPTION
## TLDR

Problem this solves:

- openai/ chat requests with reasoning_effort were rejected client-side
- model metadata had supports_reasoning=true but catalog models still failed validation

How it solves it:

- honor supports_reasoning in model_cost for openai catalog models only
- pass reasoning_effort through unchanged to the upstream adapter
- exclude gpt-5-chat* from this metadata path (#13781: regular chat family, not reasoning_effort)
- read model_cost directly (no supports_reasoning() provider lookup) to avoid authenticating-provider regressions

## User Flow

Before: a developer sending reasoning_effort to an openai-compatible model whose metadata declares supports_reasoning gets HTTP 400 before the upstream sees the request

1. They configure an openai/ model with supports_reasoning=true in model metadata
2. They send POST https://litellm-domain/v1/chat/completions with `"reasoning_effort": "high"`
3. The gateway responds HTTP 400 with openai does not support parameters: ['reasoning_effort']

After: the same request is forwarded with reasoning_effort intact

1. They configure the same openai/ model with supports_reasoning=true in model metadata
2. They send POST https://litellm-domain/v1/chat/completions with `"reasoning_effort": "high"`
3. The request reaches the upstream OpenAI-compatible adapter with reasoning_effort unchanged

## Relevant issues

Fixes #39280

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

### Before (31ca4dd)

#### catalog model with supports_reasoning metadata

1. `python -c "from litellm.utils import get_optional_params; get_optional_params(model='gpt-4o', custom_llm_provider='openai', reasoning_effort='high')"` after setting model_cost supports_reasoning=True raises UnsupportedParamsError

### After (HEAD)

#### catalog model with supports_reasoning metadata

1. `pytest tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py::TestGetOptionalParamsIntegration -k reasoning_effort` passes, including test_reasoning_effort_allowed_when_catalog_model_declares_supports_reasoning

#### gpt-5-chat-latest unchanged (#13781)

1. `pytest tests/test_litellm/llms/openai/test_gpt5_transformation.py::test_gpt5_chat_does_not_support_reasoning_effort` passes
2. `test_gpt5_chat_catalog_metadata_does_not_add_reasoning_effort` guards the metadata path even when bundled model_cost marks supports_reasoning

## Type

🐛 Bug Fix

## Caveats (if any)

- Metadata-driven reasoning_effort applies only to openai catalog models, not provider-prefixed aliases (e.g. openrouter/...).
- gpt-5-chat* is excluded: bundled model_cost may carry supports_reasoning=true but these models are non-reasoning chat variants per #13781.
- osv-scan failures on the branch are unrelated dependency-scan noise.

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
