### PR TITLE
fix(streaming): coerce raw provider usage models so cached_tokens survive

### DIFF
--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -1670,7 +1670,16 @@ class CustomStreamWrapper:
                 if not isinstance(usage_from_chunk, Usage) and hasattr(
                     usage_from_chunk, "model_dump"
                 ):
-                    usage_from_chunk = Usage(**usage_from_chunk.model_dump())
+                    usage_fields = usage_from_chunk.model_dump()
+                    # Do NOT adopt a provider-reported cost. `cost` IS a declared
+                    # field on litellm Usage and cost tracking bills it as the
+                    # response cost, but providers report it in their own unit --
+                    # one gateway sends an integer that is neither dollars nor
+                    # cents, and adopting it recorded 555533 for a request that
+                    # costs 0.008. Only the token fields are coerced here.
+                    usage_fields.pop("cost", None)
+                    usage_fields.pop("cost_details", None)
+                    usage_from_chunk = Usage(**usage_fields)
                 model_response.usage = usage_from_chunk
 
             ## RETURN ARG

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -1667,9 +1667,7 @@ class CustomStreamWrapper:
                 # usage model loses prompt_tokens_details with it: cached_tokens
                 # disappear and cached input is billed at the full input rate.
                 usage_from_chunk = chunk.usage
-                if not isinstance(usage_from_chunk, Usage) and hasattr(
-                    usage_from_chunk, "model_dump"
-                ):
+                if not isinstance(usage_from_chunk, Usage) and hasattr(usage_from_chunk, "model_dump"):
                     usage_fields = usage_from_chunk.model_dump()
                     # Do NOT adopt a provider-reported cost. `cost` IS a declared
                     # field on litellm Usage and cost tracking bills it as the

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -1659,7 +1659,19 @@ class CustomStreamWrapper:
                 self.tool_call = True
 
             if hasattr(chunk, "usage") and chunk.usage is not None:
-                model_response.usage = chunk.usage
+                # A provider may attach the final usage to a chunk that still
+                # carries a choice, which routes it here rather than through the
+                # usage-only path. `usage` is not a declared field on
+                # ModelResponseStream, so this assignment does not coerce -- and
+                # cost tracking only understands litellm Usage, so a raw provider
+                # usage model loses prompt_tokens_details with it: cached_tokens
+                # disappear and cached input is billed at the full input rate.
+                usage_from_chunk = chunk.usage
+                if not isinstance(usage_from_chunk, Usage) and hasattr(
+                    usage_from_chunk, "model_dump"
+                ):
+                    usage_from_chunk = Usage(**usage_from_chunk.model_dump())
+                model_response.usage = usage_from_chunk
 
             ## RETURN ARG
             result: Final = self.return_processed_chunk_logic(

--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -4877,6 +4877,19 @@ class TestStableStreamingResponseId:
         assert wrapper.model_response_creator().id == "chatcmpl-from-provider"
 
 
+def _chunk_with_provider_usage(usage) -> ModelResponseStream:
+    """A chunk that carries usage AND a choice, the shape that skips the usage-only path."""
+    chunk = ModelResponseStream(
+        id="chatcmpl-1",
+        object="chat.completion.chunk",
+        created=1000000,
+        model="openai/some-model",
+        choices=[StreamingChoices(index=0, delta=Delta(), finish_reason=None)],
+    )
+    chunk.usage = usage
+    return chunk
+
+
 def test_provider_usage_model_is_coerced_to_litellm_usage(
     initialized_custom_stream_wrapper: CustomStreamWrapper,
 ):
@@ -4896,22 +4909,16 @@ def test_provider_usage_model_is_coerced_to_litellm_usage(
     wrapper.received_finish_reason = "stop"
     wrapper.sent_last_chunk = True
 
-    chunk = ModelResponseStream(
-        id="chatcmpl-1",
-        object="chat.completion.chunk",
-        created=1000000,
-        model="openai/some-model",
-        choices=[StreamingChoices(index=0, delta=Delta(), finish_reason=None)],
+    result = wrapper.chunk_creator(
+        chunk=_chunk_with_provider_usage(
+            CompletionUsage(
+                prompt_tokens=1000,
+                completion_tokens=5,
+                total_tokens=1005,
+                prompt_tokens_details=PromptTokensDetails(cached_tokens=900),
+            )
+        )
     )
-    # what a provider SDK hands over: not a litellm Usage
-    chunk.usage = CompletionUsage(
-        prompt_tokens=1000,
-        completion_tokens=5,
-        total_tokens=1005,
-        prompt_tokens_details=PromptTokensDetails(cached_tokens=900),
-    )
-
-    result = wrapper.chunk_creator(chunk=chunk)
 
     assert result is not None, "the usage-bearing chunk must not be dropped"
     assert isinstance(result.usage, Usage), (
@@ -4920,3 +4927,42 @@ def test_provider_usage_model_is_coerced_to_litellm_usage(
     assert result.usage.prompt_tokens == 1000
     assert result.usage.prompt_tokens_details is not None
     assert result.usage.prompt_tokens_details.cached_tokens == 900
+
+
+def test_provider_reported_cost_is_not_adopted_when_coercing(
+    initialized_custom_stream_wrapper: CustomStreamWrapper,
+):
+    """Coercing must not adopt a provider-reported cost.
+
+    `cost` is a declared field on litellm `Usage` and cost tracking bills it as
+    the response cost -- but providers report it in their own unit. One gateway
+    sends an integer that is neither dollars nor cents, so carrying it over
+    recorded 555533 for a request costing 0.008.
+    """
+    from pydantic import BaseModel
+
+    class _ProviderUsage(BaseModel):
+        prompt_tokens: int
+        completion_tokens: int
+        total_tokens: int
+        cost: float
+
+    wrapper = initialized_custom_stream_wrapper
+    wrapper.custom_llm_provider = "openai"
+    wrapper.received_finish_reason = "stop"
+    wrapper.sent_last_chunk = True
+
+    result = wrapper.chunk_creator(
+        chunk=_chunk_with_provider_usage(
+            _ProviderUsage(
+                prompt_tokens=1000, completion_tokens=5, total_tokens=1005, cost=555533
+            )
+        )
+    )
+
+    assert result is not None
+    assert isinstance(result.usage, Usage)
+    assert result.usage.prompt_tokens == 1000
+    assert not getattr(result.usage, "cost", None), (
+        "a provider-reported cost must not be adopted: it is in the provider's own unit"
+    )

--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -4875,3 +4875,48 @@ class TestStableStreamingResponseId:
         )
         wrapper.response_id = "chatcmpl-from-provider"
         assert wrapper.model_response_creator().id == "chatcmpl-from-provider"
+
+
+def test_provider_usage_model_is_coerced_to_litellm_usage(
+    initialized_custom_stream_wrapper: CustomStreamWrapper,
+):
+    """A raw provider usage model must be coerced, or its details are lost.
+
+    Some providers attach the final usage to a chunk that still carries a
+    choice, so it does not take the usage-only path. `usage` is not a declared
+    field on ModelResponseStream, so assigning it there does not coerce, and
+    cost tracking only understands litellm `Usage`: prompt_tokens_details, and
+    with it cached_tokens, is dropped and cached input is billed at the full
+    input rate. See #36168.
+    """
+    from openai.types.completion_usage import CompletionUsage, PromptTokensDetails
+
+    wrapper = initialized_custom_stream_wrapper
+    wrapper.custom_llm_provider = "openai"
+    wrapper.received_finish_reason = "stop"
+    wrapper.sent_last_chunk = True
+
+    chunk = ModelResponseStream(
+        id="chatcmpl-1",
+        object="chat.completion.chunk",
+        created=1000000,
+        model="openai/some-model",
+        choices=[StreamingChoices(index=0, delta=Delta(), finish_reason=None)],
+    )
+    # what a provider SDK hands over: not a litellm Usage
+    chunk.usage = CompletionUsage(
+        prompt_tokens=1000,
+        completion_tokens=5,
+        total_tokens=1005,
+        prompt_tokens_details=PromptTokensDetails(cached_tokens=900),
+    )
+
+    result = wrapper.chunk_creator(chunk=chunk)
+
+    assert result is not None, "the usage-bearing chunk must not be dropped"
+    assert isinstance(result.usage, Usage), (
+        f"usage stayed a {type(result.usage).__name__}, so cost tracking cannot read it"
+    )
+    assert result.usage.prompt_tokens == 1000
+    assert result.usage.prompt_tokens_details is not None
+    assert result.usage.prompt_tokens_details.cached_tokens == 900


### PR DESCRIPTION
## The bug

Fixes #36168.

A provider may attach its final `usage` to a chunk that still carries a `choices` entry. Such a chunk does not take the usage-only path, so it lands in the delta branch, where `usage` is assigned to the `ModelResponseStream`:

```python
if hasattr(chunk, "usage") and chunk.usage is not None:
    model_response.usage = chunk.usage
```

`usage` is not a declared field on `ModelResponseStream`, so this assignment does **not** coerce, and the object stays whatever the provider SDK handed over (`openai.types.CompletionUsage` in our case). Cost tracking only understands litellm's `Usage`, so it substitutes a token estimate — and `prompt_tokens_details` goes with the discarded object. The visible consequence is that `cached_tokens` disappear and cached input is billed at the full input rate.

Measured through a proxy in front of a gateway that sends this shape, same 30 583-token prompt, `zai-org/GLM-5.3`:

| | prompt_tokens | cached_tokens | cost |
| --- | --- | --- | --- |
| non-streamed | 30582 | 30528 | 0.0138 USD |
| streamed | 29212 | *(missing)* | 0.0522 USD |

The upstream stream itself is fine — called directly, the gateway reports `{"prompt_tokens": 30583, "prompt_tokens_details": {"cached_tokens": 30528}}` on every stream, asked or not.

Over 24h of production traffic the split followed the route, not the model: **13 of 1640** `/v1/chat/completions` requests accounted cache, against **576 of 594** on `/v1/responses` and 90 of 103 on `/v1/messages`, which assemble usage differently. Where cache is measurable, 89% of prompt tokens are hits, so this is not a rounding error.

## The change

Coerce a raw provider usage model into `litellm.Usage` at the point of assignment. Deliberately narrow: only objects that are not already `Usage` and that expose `model_dump()` are converted, so a provider config that already builds a proper `Usage` is untouched and anything exotic behaves exactly as before.

## Relation to the other open PRs

* #36678 fixes the **dict** arm (`litellm.Usage(**response_obj["usage"])`). I applied it to a local install and this case still lost its usage — the raw-SDK-object arm is a different path.
* #39095 targets the same line but in the opposite direction: it keeps the built `Usage` and ignores the provider's. That is right when a built `Usage` already carries the details; here the provider's object is the only one that knows about the cache, so discarding it would keep the bug.

## Test

`test_provider_usage_model_is_coerced_to_litellm_usage` drives `chunk_creator` with a chunk that carries an inert choice and a `CompletionUsage` holding `cached_tokens=900`, and asserts the result is a litellm `Usage` that still has them. Verified to fail before the change (`usage stayed a CompletionUsage`) and pass after.

```
pytest tests/test_litellm/litellm_core_utils/test_streaming_handler.py -k coerced_to_litellm_usage
```