### PR TITLE
feat(fal_ai): add video generation provider

### DIFF
--- a/litellm/llms/fal_ai/videos/__init__.py
+++ b/litellm/llms/fal_ai/videos/__init__.py
@@ -1,0 +1,3 @@
+from .transformation import FAL_QUEUE_API_BASE, FalAIVideoConfig, FalAIVideoError
+
+__all__ = ("FAL_QUEUE_API_BASE", "FalAIVideoConfig", "FalAIVideoError")

--- a/litellm/llms/fal_ai/videos/transformation.py
+++ b/litellm/llms/fal_ai/videos/transformation.py
@@ -1,0 +1,602 @@
+"""Video generation for fal.ai through its queue API (https://queue.fal.run)."""
+
+import base64
+import mimetypes
+import time
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Final, Protocol, TypeAlias, runtime_checkable
+
+import httpx
+from httpx._types import RequestFiles
+from typing_extensions import ReadOnly, TypedDict
+
+import litellm
+from litellm._logging import verbose_logger
+from litellm.images.utils import ImageEditRequestUtils
+from litellm.litellm_core_utils.url_utils import encode_url_path_segment
+from litellm.llms.base_llm.chat.transformation import BaseLLMException
+from litellm.llms.base_llm.videos.transformation import BaseVideoConfig
+from litellm.llms.custom_httpx.http_handler import (
+    AsyncHTTPHandler,
+    HTTPHandler,
+    get_async_httpx_client,
+)
+from litellm.secret_managers.main import get_secret_str
+from litellm.types.router import GenericLiteLLMParams
+from litellm.types.videos.main import VideoCreateOptionalRequestParams, VideoObject
+from litellm.types.videos.utils import (
+    decode_video_id_with_provider,
+    encode_video_id_with_provider,
+)
+
+if TYPE_CHECKING:
+    from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+
+FAL_QUEUE_API_BASE: Final = "https://queue.fal.run"
+
+_PROVIDER_PREFIX: Final = f"{litellm.LlmProviders.FAL_AI.value}/"
+
+_SUPPORTED_OPENAI_PARAMS: Final = ("model", "prompt", "input_reference", "seconds", "size", "user", "extra_headers")
+
+_STATUS_MAP: Final[Mapping[str, str]] = MappingProxyType(
+    {"IN_QUEUE": "queued", "IN_PROGRESS": "in_progress", "COMPLETED": "completed"}
+)
+
+_PENDING_STATUSES: Final = frozenset({"IN_QUEUE", "IN_PROGRESS"})
+
+_EMPTY: Final[Mapping[str, object]] = MappingProxyType({})
+
+_VIDEO_REFERENCE_ENDPOINTS: Final = frozenset({"video-to-video", "video-edit", "edit-video", "extend-video"})
+
+_NO_DURATION_ENDPOINTS: Final = frozenset({"video-edit", "edit-video", "extend-video"})
+
+
+@dataclass(frozen=True, slots=True)
+class _FamilyRules:
+    default_seconds: int = 5
+    takes_duration: bool = True
+    duration_as_string: bool = False
+    resolution_upper: bool = False
+
+
+_DEFAULT_FAMILY_RULES: Final = _FamilyRules()
+
+_FAMILY_RULES: Final[Mapping[str, _FamilyRules]] = MappingProxyType(
+    {
+        "minimax/h3": _FamilyRules(resolution_upper=True),
+        "bytedance/seedance-2.0": _FamilyRules(duration_as_string=True),
+        "xai/grok-imagine-video": _FamilyRules(default_seconds=6),
+        "fal-ai/ltx-video": _FamilyRules(takes_duration=False),
+    }
+)
+
+
+class _FalQueueResponse(TypedDict, total=False):
+    request_id: ReadOnly[str]
+    status: ReadOnly[str]
+    response_url: ReadOnly[str]
+    error: ReadOnly[object]
+    detail: ReadOnly[object]
+
+
+class _FalResult(TypedDict, total=False):
+    video: ReadOnly[Mapping[str, object] | str]
+    videos: ReadOnly[Sequence[Mapping[str, object] | str]]
+    status: ReadOnly[str]
+    error: ReadOnly[object]
+    detail: ReadOnly[object]
+
+
+@runtime_checkable
+class _Readable(Protocol):
+    def read(self) -> object: ...
+
+
+@runtime_checkable
+class _Seekable(Protocol):
+    def seek(self, offset: int, /) -> int: ...
+
+
+@dataclass(frozen=True, slots=True)
+class _PollTarget:
+    model_path: str
+    request_id: str
+    headers: Mapping[str, str]
+
+
+@dataclass(frozen=True, slots=True)
+class _VideoReady:
+    url: str
+
+
+@dataclass(frozen=True, slots=True)
+class _VideoPending:
+    status: str
+
+
+@dataclass(frozen=True, slots=True)
+class _VideoFailed:
+    detail: str
+
+
+_ResultState: TypeAlias = _VideoReady | _VideoPending | _VideoFailed
+
+
+class FalAIVideoError(BaseLLMException):
+    pass
+
+
+def _model_path(model: str) -> str:
+    return model.removeprefix(_PROVIDER_PREFIX).strip("/")
+
+
+def _root_app_id(model_path: str) -> str:
+    return "/".join(model_path.split("/")[:2])
+
+
+def _endpoint(model_path: str) -> str:
+    return model_path.rsplit("/", 1)[-1]
+
+
+def _rules(model_path: str) -> _FamilyRules:
+    return _FAMILY_RULES.get(_root_app_id(model_path), _DEFAULT_FAMILY_RULES)
+
+
+def _takes_duration(model_path: str) -> bool:
+    return _rules(model_path).takes_duration and _endpoint(model_path) not in _NO_DURATION_ENDPOINTS
+
+
+def _seconds_or_default(model_path: str, seconds: object) -> int:
+    try:
+        return int(float(str(seconds)))
+    except ValueError:
+        return _rules(model_path).default_seconds
+
+
+def _duration_value(model_path: str, seconds: int) -> str | int:
+    return str(seconds) if _rules(model_path).duration_as_string else seconds
+
+
+def _size_to_resolution(model_path: str, size: object) -> str | None:
+    if not isinstance(size, str) or "x" not in size.lower():
+        return None
+    width_str, _, height_str = size.lower().partition("x")
+    if not (width_str.isdigit() and height_str.isdigit()):
+        return None
+    short_side: Final = min(int(width_str), int(height_str))
+    if not _rules(model_path).resolution_upper:
+        return f"{short_side}p"
+    if short_side >= 2160:
+        return "4K"
+    if short_side >= 1440:
+        return "2K"
+    return f"{short_side}P"
+
+
+def _split_reference(reference: object) -> tuple[str | None, object, str | None]:
+    if not isinstance(reference, (tuple, list)):
+        name: Final = getattr(reference, "name", None)
+        return (name if isinstance(name, str) else None), reference, None
+    parts: Final[tuple[object, ...]] = (*reference, None, None, None)
+    filename: Final = parts[0] if isinstance(parts[0], str) else None
+    content_type: Final = parts[2] if isinstance(parts[2], str) else None
+    return filename, parts[1], content_type
+
+
+def _read_bytes(payload: object) -> bytes | None:
+    if isinstance(payload, (bytes, bytearray)):
+        return bytes(payload)
+    if not isinstance(payload, _Readable):
+        return None
+    if isinstance(payload, _Seekable):
+        payload.seek(0)
+    data: Final = payload.read()
+    return data if isinstance(data, bytes) else None
+
+
+def _content_type(filename: str | None, declared: str | None, data: bytes, default_mime: str) -> str:
+    if declared:
+        return declared
+    guessed: Final = mimetypes.guess_type(filename)[0] if filename else None
+    if guessed:
+        return guessed
+    if default_mime.startswith("video/"):
+        return default_mime
+    return ImageEditRequestUtils.get_image_content_type(data)
+
+
+def _reference_url(reference: object, default_mime: str) -> object:
+    if reference is None or isinstance(reference, str):
+        return reference
+    filename, payload, declared = _split_reference(reference)
+    data: Final = _read_bytes(payload)
+    if data is None:
+        return reference
+    content_type: Final = _content_type(filename, declared, data, default_mime)
+    return f"data:{content_type};base64,{base64.b64encode(data).decode('ascii')}"
+
+
+def _url_of(item: Mapping[str, object] | str | None) -> str | None:
+    if isinstance(item, str):
+        return item or None
+    if item is None:
+        return None
+    url: Final = item.get("url")
+    return url if isinstance(url, str) and url else None
+
+
+def _video_url(result: _FalResult) -> str | None:
+    videos: Final = result.get("videos")
+    return _url_of(result.get("video")) or _url_of(videos[0] if videos else None)
+
+
+def _result_state(result: _FalResult) -> _ResultState:
+    url: Final = _video_url(result)
+    if url:
+        return _VideoReady(url)
+    status: Final = str(result.get("status", "")).upper()
+    if status in _PENDING_STATUSES:
+        return _VideoPending(status)
+    detail: Final = result.get("error") or result.get("detail")
+    return _VideoFailed(str(detail) if detail else f"video url not found in result keys {sorted(result)}")
+
+
+def _error_detail(response: httpx.Response) -> str:
+    try:
+        body: Final[_FalQueueResponse] = response.json()
+    except ValueError:
+        return response.text[:500]
+    detail: Final = body.get("error") or body.get("detail")
+    return str(detail) if detail else response.text[:500]
+
+
+class FalAIVideoConfig(BaseVideoConfig):
+    """
+    fal.ai runs every model behind one async queue:
+    1. POST /<model path> submits the job and returns a request id
+    2. GET /<root app id>/requests/<id>/status reports IN_QUEUE, IN_PROGRESS or COMPLETED
+    3. GET /<root app id>/requests/<id> returns the result payload with the video url
+
+    The root app id is the first two segments of the model path. The full model
+    path is encoded into the video id so status and content calls can rebuild
+    the queue URLs and the proxy can route them back to the same deployment.
+    """
+
+    def __init__(self, result_client: HTTPHandler | None = None) -> None:
+        super().__init__()
+        self._result_client = result_client
+        self._poll_target: _PollTarget | None = None
+
+    def get_supported_openai_params(self, model: str) -> list[str]:  # mutable-ok: BaseVideoConfig contract
+        return list(_SUPPORTED_OPENAI_PARAMS)  # mutable-ok: BaseVideoConfig returns list
+
+    def map_openai_params(
+        self,
+        video_create_optional_params: VideoCreateOptionalRequestParams,
+        model: str,
+        drop_params: bool,
+    ) -> dict[str, object]:  # mutable-ok: BaseVideoConfig contract; the caller merges extra_body into this dict
+        model_path: Final = _model_path(model)
+        return {  # mutable-ok: VideoGenerationRequestUtils.update/pop extra_body onto this mapping
+            **self._reference_param(model_path, video_create_optional_params),
+            **self._duration_param(model_path, video_create_optional_params),
+            **self._resolution_param(model_path, video_create_optional_params),
+            **self._passthrough_params(video_create_optional_params),
+        }
+
+    @staticmethod
+    def _passthrough_params(params: VideoCreateOptionalRequestParams) -> Mapping[str, object]:
+        return MappingProxyType({key: value for key, value in params.items() if key not in _SUPPORTED_OPENAI_PARAMS})
+
+    @staticmethod
+    def _reference_param(model_path: str, params: VideoCreateOptionalRequestParams) -> Mapping[str, object]:
+        if "input_reference" not in params:
+            return _EMPTY
+        reference: Final = params["input_reference"]
+        if _endpoint(model_path) in _VIDEO_REFERENCE_ENDPOINTS:
+            return MappingProxyType({"video_url": _reference_url(reference, "video/mp4")})
+        return MappingProxyType({"image_url": _reference_url(reference, "image/png")})
+
+    @staticmethod
+    def _duration_param(model_path: str, params: VideoCreateOptionalRequestParams) -> Mapping[str, object]:
+        seconds: Final = params.get("seconds")
+        if seconds is None or not _takes_duration(model_path):
+            return _EMPTY
+        return MappingProxyType({"duration": _duration_value(model_path, _seconds_or_default(model_path, seconds))})
+
+    @staticmethod
+    def _resolution_param(model_path: str, params: VideoCreateOptionalRequestParams) -> Mapping[str, object]:
+        resolution: Final = _size_to_resolution(model_path, params.get("size"))
+        return _EMPTY if resolution is None else MappingProxyType({"resolution": resolution})
+
+    def validate_environment(
+        self,
+        headers: Mapping[str, str],
+        model: str,
+        api_key: str | None = None,
+        litellm_params: GenericLiteLLMParams | None = None,
+    ) -> dict[str, str]:  # mutable-ok: BaseVideoConfig contract
+        resolved_key: Final = (
+            api_key
+            or (litellm_params.api_key if litellm_params is not None else None)
+            or litellm.api_key
+            or get_secret_str("FAL_AI_API_KEY")
+            or get_secret_str("FAL_KEY")
+        )
+        if resolved_key is None:
+            raise ValueError("fal.ai API key is required. Set FAL_AI_API_KEY or pass api_key")
+        return {  # mutable-ok: httpx headers are a dict
+            **headers,
+            "Authorization": f"Key {resolved_key}",
+            "Content-Type": "application/json",
+        }
+
+    def get_complete_url(
+        self,
+        model: str,
+        api_base: str | None,
+        litellm_params: Mapping[str, object],
+    ) -> str:
+        return (api_base or FAL_QUEUE_API_BASE).rstrip("/")
+
+    def transform_video_create_request(
+        self,
+        model: str,
+        prompt: str,
+        api_base: str,
+        video_create_optional_request_params: Mapping[str, object],
+        litellm_params: GenericLiteLLMParams,
+        headers: Mapping[str, str],
+    ) -> tuple[dict[str, object], RequestFiles, str]:  # mutable-ok: BaseVideoConfig contract
+        model_path: Final = _model_path(model)
+        request_data: Final[dict[str, object]] = {  # mutable-ok: httpx json body must be a dict
+            "prompt": prompt,
+            **video_create_optional_request_params,
+            **self._pinned_duration(model_path, video_create_optional_request_params),
+        }
+        return request_data, (), f"{api_base}/{model_path}"
+
+    @staticmethod
+    def _pinned_duration(model_path: str, request_params: Mapping[str, object]) -> Mapping[str, object]:
+        if "duration" in request_params or not _takes_duration(model_path):
+            return _EMPTY
+        return MappingProxyType({"duration": _duration_value(model_path, _rules(model_path).default_seconds)})
+
+    def transform_video_create_response(
+        self,
+        model: str,
+        raw_response: httpx.Response,
+        logging_obj: "LiteLLMLoggingObj",
+        custom_llm_provider: str | None = None,
+        request_data: Mapping[str, object] | None = None,
+    ) -> VideoObject:
+        response_data: Final[_FalQueueResponse] = raw_response.json()
+        model_path: Final = _model_path(model)
+        request_id: Final = response_data.get("request_id")
+        if not request_id:
+            raise ValueError(f"fal.ai submit response contains no request_id: {response_data}")
+        request_params: Final = request_data or _EMPTY
+        billed_seconds: Final = _seconds_or_default(model_path, request_params.get("duration"))
+        resolution: Final = request_params.get("resolution")
+        video_resolution: Final = resolution.lower() if isinstance(resolution, str) else None
+        return VideoObject(
+            id=self._encoded_id(request_id, custom_llm_provider, model_path),
+            object="video",
+            status=_STATUS_MAP.get(str(response_data.get("status", "IN_QUEUE")).upper(), "queued"),
+            created_at=int(time.time()),
+            model=model_path,
+            seconds=str(billed_seconds),
+            size=video_resolution,
+            usage={  # mutable-ok: VideoObject.usage is a dict field
+                key: value
+                for key, value in (
+                    ("duration_seconds", float(billed_seconds)),
+                    ("video_resolution", video_resolution),
+                )
+                if value is not None
+            },
+        )
+
+    @staticmethod
+    def _encoded_id(request_id: str, custom_llm_provider: str | None, model_path: str | None) -> str:
+        if not custom_llm_provider:
+            return request_id
+        return encode_video_id_with_provider(request_id, custom_llm_provider, model_path)
+
+    def _remember_poll_target(self, video_id: str, headers: Mapping[str, str]) -> _PollTarget:
+        decoded: Final = decode_video_id_with_provider(video_id)
+        model_path: Final = decoded.get("model_id")
+        if not model_path:
+            raise ValueError(f"fal.ai video id '{video_id}' does not carry a model path, cannot build the queue URL")
+        target: Final = _PollTarget(
+            model_path=_model_path(model_path),
+            request_id=decoded.get("video_id") or video_id,
+            headers=MappingProxyType(dict(headers)),  # mutable-ok: snapshot of the handler's header dict
+        )
+        self._poll_target = target
+        return target
+
+    @staticmethod
+    def _request_url(api_base: str, target: _PollTarget) -> str:
+        encoded_request_id: Final = encode_url_path_segment(target.request_id, field_name="video_id")
+        return f"{api_base}/{_root_app_id(target.model_path)}/requests/{encoded_request_id}"
+
+    def transform_video_status_retrieve_request(
+        self,
+        video_id: str,
+        api_base: str,
+        litellm_params: GenericLiteLLMParams,
+        headers: Mapping[str, str],
+    ) -> tuple[str, dict[str, str]]:  # mutable-ok: BaseVideoConfig contract
+        target: Final = self._remember_poll_target(video_id, headers)
+        return f"{self._request_url(api_base, target)}/status", {}  # mutable-ok: BaseVideoConfig contract
+
+    def transform_video_status_retrieve_response(
+        self,
+        raw_response: httpx.Response,
+        logging_obj: "LiteLLMLoggingObj",
+        custom_llm_provider: str | None = None,
+    ) -> VideoObject:
+        response_data: Final[_FalQueueResponse] = raw_response.json()
+        raw_status: Final = str(response_data.get("status", "")).upper()
+        mapped_status: Final = _STATUS_MAP.get(raw_status, "failed")
+        failure: Final = self._completed_job_failure(response_data) if mapped_status == "completed" else None
+        status: Final = "failed" if failure is not None else mapped_status
+        target: Final = self._poll_target
+        request_id: Final = response_data.get("request_id") or (target.request_id if target else "")
+        now: Final = int(time.time())
+        return VideoObject(
+            id=self._encoded_id(request_id, custom_llm_provider, target.model_path if target else None),
+            object="video",
+            status=status,
+            created_at=now,
+            completed_at=now if status == "completed" else None,
+            error=self._error(raw_status, failure, response_data) if status == "failed" else None,
+        )
+
+    @staticmethod
+    def _error(
+        raw_status: str, failure: str | None, response_data: _FalQueueResponse
+    ) -> dict[str, str]:  # mutable-ok: VideoObject.error is a dict field
+        detail: Final = response_data.get("error") or response_data.get("detail")
+        return {  # mutable-ok: VideoObject.error is a dict field
+            "code": raw_status or "unknown",
+            "message": failure or (str(detail) if detail else "fal.ai video job failed"),
+        }
+
+    def _completed_job_failure(self, response_data: _FalQueueResponse) -> str | None:
+        """
+        fal reports COMPLETED for failed jobs too. Only the result payload tells a
+        finished video from a failure, so peek at it and downgrade the status
+        instead of handing the caller an opaque error on the content fetch.
+        """
+        result_url: Final = response_data.get("response_url")
+        target: Final = self._poll_target
+        if not result_url or target is None:
+            return None
+        try:
+            result: Final = (self._result_client or litellm.module_level_client).get(
+                result_url,
+                headers=dict(target.headers),  # mutable-ok: httpx headers are a dict
+            )
+        except Exception as exc:
+            verbose_logger.warning("fal.ai result peek failed, keeping status completed: %s", exc)
+            return None
+        if result.status_code >= 400:
+            return f"fal.ai video generation failed: {_error_detail(result)}"
+        match _result_state(result.json()):
+            case _VideoFailed(detail):
+                return f"fal.ai video generation failed: {detail}"
+            case _VideoReady() | _VideoPending():
+                return None
+
+    def transform_video_content_request(
+        self,
+        video_id: str,
+        api_base: str,
+        litellm_params: GenericLiteLLMParams,
+        headers: Mapping[str, str],
+        variant: str | None = None,
+    ) -> tuple[str, dict[str, str]]:  # mutable-ok: BaseVideoConfig contract
+        target: Final = self._remember_poll_target(video_id, headers)
+        return self._request_url(api_base, target), {}  # mutable-ok: BaseVideoConfig contract
+
+    @staticmethod
+    def _ready_video_url(raw_response: httpx.Response) -> str:
+        match _result_state(raw_response.json()):
+            case _VideoReady(url):
+                return url
+            case _VideoPending(status):
+                raise ValueError(f"Video is still processing (status: {status}). Please wait and try again.")
+            case _VideoFailed(detail):
+                raise ValueError(f"fal.ai video generation failed: {detail}")
+
+    def transform_video_content_response(
+        self,
+        raw_response: httpx.Response,
+        logging_obj: "LiteLLMLoggingObj",
+    ) -> bytes:
+        video_url: Final = self._ready_video_url(raw_response)
+        video_response: Final = litellm.module_level_client.get(video_url)
+        video_response.raise_for_status()
+        return video_response.content
+
+    async def async_transform_video_content_response(
+        self,
+        raw_response: httpx.Response,
+        logging_obj: "LiteLLMLoggingObj",
+    ) -> bytes:
+        video_url: Final = self._ready_video_url(raw_response)
+        async_client: Final[AsyncHTTPHandler] = get_async_httpx_client(llm_provider=litellm.LlmProviders.FAL_AI)
+        video_response: Final = await async_client.get(video_url)
+        video_response.raise_for_status()
+        return video_response.content
+
+    def transform_video_remix_request(
+        self,
+        video_id: str,
+        prompt: str,
+        api_base: str,
+        litellm_params: GenericLiteLLMParams,
+        headers: Mapping[str, str],
+        extra_body: Mapping[str, object] | None = None,
+    ) -> tuple[str, dict[str, object]]:  # mutable-ok: BaseVideoConfig contract
+        raise NotImplementedError("video remix is not supported for fal.ai")
+
+    def transform_video_remix_response(
+        self,
+        raw_response: httpx.Response,
+        logging_obj: "LiteLLMLoggingObj",
+        custom_llm_provider: str | None = None,
+    ) -> VideoObject:
+        raise NotImplementedError("video remix is not supported for fal.ai")
+
+    def transform_video_list_request(
+        self,
+        api_base: str,
+        litellm_params: GenericLiteLLMParams,
+        headers: Mapping[str, str],
+        after: str | None = None,
+        limit: int | None = None,
+        order: str | None = None,
+        extra_query: Mapping[str, object] | None = None,
+    ) -> tuple[str, dict[str, object]]:  # mutable-ok: BaseVideoConfig contract
+        raise NotImplementedError("video list is not supported for fal.ai")
+
+    def transform_video_list_response(
+        self,
+        raw_response: httpx.Response,
+        logging_obj: "LiteLLMLoggingObj",
+        custom_llm_provider: str | None = None,
+    ) -> dict[str, str]:  # mutable-ok: BaseVideoConfig contract
+        raise NotImplementedError("video list is not supported for fal.ai")
+
+    def transform_video_delete_request(
+        self,
+        video_id: str,
+        api_base: str,
+        litellm_params: GenericLiteLLMParams,
+        headers: Mapping[str, str],
+    ) -> tuple[str, dict[str, object]]:  # mutable-ok: BaseVideoConfig contract
+        raise NotImplementedError("video delete is not supported for fal.ai")
+
+    def transform_video_delete_response(
+        self,
+        raw_response: httpx.Response,
+        logging_obj: "LiteLLMLoggingObj",
+    ) -> VideoObject:
+        raise NotImplementedError("video delete is not supported for fal.ai")
+
+    def get_error_class(
+        self,
+        error_message: str,
+        status_code: int,
+        headers: Mapping[str, str] | httpx.Headers,
+    ) -> BaseLLMException:
+        return FalAIVideoError(
+            status_code=status_code,
+            message=error_message,
+            headers=headers if isinstance(headers, httpx.Headers) else dict(headers),  # mutable-ok: exception contract
+        )

--- a/litellm/llms/fal_ai/videos/transformation.py
+++ b/litellm/llms/fal_ai/videos/transformation.py
@@ -15,7 +15,7 @@ from typing_extensions import ReadOnly, TypedDict
 import litellm
 from litellm._logging import verbose_logger
 from litellm.images.utils import ImageEditRequestUtils
-from litellm.litellm_core_utils.url_utils import encode_url_path_segment
+from litellm.litellm_core_utils.url_utils import async_safe_get, encode_url_path_segment, safe_get
 from litellm.llms.base_llm.chat.transformation import BaseLLMException
 from litellm.llms.base_llm.videos.transformation import BaseVideoConfig
 from litellm.llms.custom_httpx.http_handler import (
@@ -76,7 +76,6 @@ _FAMILY_RULES: Final[Mapping[str, _FamilyRules]] = MappingProxyType(
 class _FalQueueResponse(TypedDict, total=False):
     request_id: ReadOnly[str]
     status: ReadOnly[str]
-    response_url: ReadOnly[str]
     error: ReadOnly[object]
     detail: ReadOnly[object]
 
@@ -103,6 +102,7 @@ class _Seekable(Protocol):
 class _PollTarget:
     model_path: str
     request_id: str
+    result_url: str
     headers: Mapping[str, str]
 
 
@@ -151,7 +151,7 @@ def _takes_duration(model_path: str) -> bool:
 def _seconds_or_default(model_path: str, seconds: object) -> int:
     try:
         return int(float(str(seconds)))
-    except ValueError:
+    except (ValueError, OverflowError):
         return _rules(model_path).default_seconds
 
 
@@ -405,23 +405,21 @@ class FalAIVideoConfig(BaseVideoConfig):
             return request_id
         return encode_video_id_with_provider(request_id, custom_llm_provider, model_path)
 
-    def _remember_poll_target(self, video_id: str, headers: Mapping[str, str]) -> _PollTarget:
+    def _remember_poll_target(self, video_id: str, api_base: str, headers: Mapping[str, str]) -> _PollTarget:
         decoded: Final = decode_video_id_with_provider(video_id)
         model_path: Final = decoded.get("model_id")
         if not model_path:
             raise ValueError(f"fal.ai video id '{video_id}' does not carry a model path, cannot build the queue URL")
+        request_id: Final = decoded.get("video_id") or video_id
+        encoded_request_id: Final = encode_url_path_segment(request_id, field_name="video_id")
         target: Final = _PollTarget(
             model_path=_model_path(model_path),
-            request_id=decoded.get("video_id") or video_id,
+            request_id=request_id,
+            result_url=f"{api_base}/{_root_app_id(_model_path(model_path))}/requests/{encoded_request_id}",
             headers=MappingProxyType(dict(headers)),  # mutable-ok: snapshot of the handler's header dict
         )
         self._poll_target = target
         return target
-
-    @staticmethod
-    def _request_url(api_base: str, target: _PollTarget) -> str:
-        encoded_request_id: Final = encode_url_path_segment(target.request_id, field_name="video_id")
-        return f"{api_base}/{_root_app_id(target.model_path)}/requests/{encoded_request_id}"
 
     def transform_video_status_retrieve_request(
         self,
@@ -430,8 +428,8 @@ class FalAIVideoConfig(BaseVideoConfig):
         litellm_params: GenericLiteLLMParams,
         headers: Mapping[str, str],
     ) -> tuple[str, dict[str, str]]:  # mutable-ok: BaseVideoConfig contract
-        target: Final = self._remember_poll_target(video_id, headers)
-        return f"{self._request_url(api_base, target)}/status", {}  # mutable-ok: BaseVideoConfig contract
+        target: Final = self._remember_poll_target(video_id, api_base, headers)
+        return f"{target.result_url}/status", {}  # mutable-ok: BaseVideoConfig contract
 
     def transform_video_status_retrieve_response(
         self,
@@ -442,7 +440,7 @@ class FalAIVideoConfig(BaseVideoConfig):
         response_data: Final[_FalQueueResponse] = raw_response.json()
         raw_status: Final = str(response_data.get("status", "")).upper()
         mapped_status: Final = _STATUS_MAP.get(raw_status, "failed")
-        failure: Final = self._completed_job_failure(response_data) if mapped_status == "completed" else None
+        failure: Final = self._completed_job_failure() if mapped_status == "completed" else None
         status: Final = "failed" if failure is not None else mapped_status
         target: Final = self._poll_target
         request_id: Final = response_data.get("request_id") or (target.request_id if target else "")
@@ -466,19 +464,18 @@ class FalAIVideoConfig(BaseVideoConfig):
             "message": failure or (str(detail) if detail else "fal.ai video job failed"),
         }
 
-    def _completed_job_failure(self, response_data: _FalQueueResponse) -> str | None:
+    def _completed_job_failure(self) -> str | None:
         """
         fal reports COMPLETED for failed jobs too. Only the result payload tells a
         finished video from a failure, so peek at it and downgrade the status
         instead of handing the caller an opaque error on the content fetch.
         """
-        result_url: Final = response_data.get("response_url")
         target: Final = self._poll_target
-        if not result_url or target is None:
+        if target is None:
             return None
         try:
             result: Final = (self._result_client or litellm.module_level_client).get(
-                result_url,
+                target.result_url,
                 headers=dict(target.headers),  # mutable-ok: httpx headers are a dict
             )
         except Exception as exc:
@@ -500,8 +497,8 @@ class FalAIVideoConfig(BaseVideoConfig):
         headers: Mapping[str, str],
         variant: str | None = None,
     ) -> tuple[str, dict[str, str]]:  # mutable-ok: BaseVideoConfig contract
-        target: Final = self._remember_poll_target(video_id, headers)
-        return self._request_url(api_base, target), {}  # mutable-ok: BaseVideoConfig contract
+        target: Final = self._remember_poll_target(video_id, api_base, headers)
+        return target.result_url, {}  # mutable-ok: BaseVideoConfig contract
 
     @staticmethod
     def _ready_video_url(raw_response: httpx.Response) -> str:
@@ -519,7 +516,7 @@ class FalAIVideoConfig(BaseVideoConfig):
         logging_obj: "LiteLLMLoggingObj",
     ) -> bytes:
         video_url: Final = self._ready_video_url(raw_response)
-        video_response: Final = litellm.module_level_client.get(video_url)
+        video_response: Final = safe_get(litellm.module_level_client, video_url)
         video_response.raise_for_status()
         return video_response.content
 
@@ -530,7 +527,7 @@ class FalAIVideoConfig(BaseVideoConfig):
     ) -> bytes:
         video_url: Final = self._ready_video_url(raw_response)
         async_client: Final[AsyncHTTPHandler] = get_async_httpx_client(llm_provider=litellm.LlmProviders.FAL_AI)
-        video_response: Final = await async_client.get(video_url)
+        video_response: Final = await async_safe_get(async_client, video_url)
         video_response.raise_for_status()
         return video_response.content
 

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -20820,6 +20820,307 @@
         ],
         "supports_vision": true
     },
+    "fal_ai/minimax/h3/text-to-video": {
+        "litellm_provider": "fal_ai",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.13,
+        "output_cost_per_second_480p": 0.05,
+        "output_cost_per_second_768p": 0.06,
+        "output_cost_per_second_4k": 0.16,
+        "source": "https://fal.ai/models/minimax/h3/text-to-video",
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "default resolution 2K; 480P, 768P and 4K priced per tier"
+        }
+    },
+    "fal_ai/minimax/h3/image-to-video": {
+        "litellm_provider": "fal_ai",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.13,
+        "output_cost_per_second_480p": 0.05,
+        "output_cost_per_second_768p": 0.06,
+        "output_cost_per_second_4k": 0.16,
+        "source": "https://fal.ai/models/minimax/h3/image-to-video",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "default resolution 2K; 480P, 768P and 4K priced per tier"
+        }
+    },
+    "fal_ai/minimax/h3/reference-to-video": {
+        "litellm_provider": "fal_ai",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.13,
+        "output_cost_per_second_480p": 0.05,
+        "output_cost_per_second_768p": 0.06,
+        "output_cost_per_second_4k": 0.16,
+        "source": "https://fal.ai/models/minimax/h3/reference-to-video",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "default resolution 2K; 480P, 768P and 4K priced per tier"
+        }
+    },
+    "fal_ai/bytedance/seedance-2.0/text-to-video": {
+        "litellm_provider": "fal_ai",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.3034,
+        "output_cost_per_second_1080p": 0.682,
+        "source": "https://fal.ai/models/bytedance/seedance-2.0/text-to-video",
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "default resolution 720p"
+        }
+    },
+    "fal_ai/bytedance/seedance-2.0/image-to-video": {
+        "litellm_provider": "fal_ai",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.3024,
+        "source": "https://fal.ai/models/bytedance/seedance-2.0/image-to-video",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "default resolution 720p"
+        }
+    },
+    "fal_ai/bytedance/seedance-2.0/reference-to-video": {
+        "litellm_provider": "fal_ai",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.3024,
+        "source": "https://fal.ai/models/bytedance/seedance-2.0/reference-to-video",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "default resolution 720p"
+        }
+    },
+    "fal_ai/alibaba/happy-horse/text-to-video": {
+        "litellm_provider": "fal_ai",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.28,
+        "output_cost_per_second_720p": 0.14,
+        "source": "https://fal.ai/models/alibaba/happy-horse/text-to-video",
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "default resolution 1080p"
+        }
+    },
+    "fal_ai/alibaba/happy-horse/image-to-video": {
+        "litellm_provider": "fal_ai",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.28,
+        "output_cost_per_second_720p": 0.14,
+        "source": "https://fal.ai/models/alibaba/happy-horse/image-to-video",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "default resolution 1080p"
+        }
+    },
+    "fal_ai/alibaba/happy-horse/reference-to-video": {
+        "litellm_provider": "fal_ai",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.28,
+        "output_cost_per_second_720p": 0.14,
+        "source": "https://fal.ai/models/alibaba/happy-horse/reference-to-video",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "default resolution 1080p"
+        }
+    },
+    "fal_ai/alibaba/happy-horse/video-edit": {
+        "litellm_provider": "fal_ai",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.28,
+        "output_cost_per_second_720p": 0.14,
+        "source": "https://fal.ai/models/alibaba/happy-horse/video-edit",
+        "supported_modalities": [
+            "text",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "default resolution 1080p; billed per second of output"
+        }
+    },
+    "fal_ai/blackforestlabs/flux-3/text-to-video": {
+        "litellm_provider": "fal_ai",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.17,
+        "output_cost_per_second_1080p": 0.29,
+        "source": "https://fal.ai/models/blackforestlabs/flux-3/text-to-video",
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "default resolution 720p"
+        }
+    },
+    "fal_ai/blackforestlabs/flux-3/image-to-video": {
+        "litellm_provider": "fal_ai",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.17,
+        "output_cost_per_second_1080p": 0.29,
+        "source": "https://fal.ai/models/blackforestlabs/flux-3/image-to-video",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "default resolution 720p"
+        }
+    },
+    "fal_ai/blackforestlabs/flux-3/extend-video": {
+        "litellm_provider": "fal_ai",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.205,
+        "source": "https://fal.ai/models/blackforestlabs/flux-3/extend-video",
+        "supported_modalities": [
+            "text",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "default resolution 720p"
+        }
+    },
+    "fal_ai/xai/grok-imagine-video/text-to-video": {
+        "litellm_provider": "fal_ai",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.07,
+        "output_cost_per_second_480p": 0.05,
+        "source": "https://fal.ai/models/xai/grok-imagine-video/text-to-video",
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "default resolution 720p"
+        }
+    },
+    "fal_ai/xai/grok-imagine-video/image-to-video": {
+        "litellm_provider": "fal_ai",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.07,
+        "output_cost_per_second_480p": 0.05,
+        "source": "https://fal.ai/models/xai/grok-imagine-video/image-to-video",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "default resolution 720p"
+        }
+    },
+    "fal_ai/xai/grok-imagine-video/edit-video": {
+        "litellm_provider": "fal_ai",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.08,
+        "output_cost_per_second_480p": 0.06,
+        "source": "https://fal.ai/models/xai/grok-imagine-video/edit-video",
+        "supported_modalities": [
+            "text",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "default resolution 720p; input video seconds included in the rate"
+        }
+    },
+    "fal_ai/fal-ai/ltx-video": {
+        "litellm_provider": "fal_ai",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.004,
+        "source": "https://fal.ai/models/fal-ai/ltx-video",
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "$0.02 flat per video; billed as 5 seconds at $0.004 per second"
+        }
+    },
+    "fal_ai/fal-ai/ltx-video/image-to-video": {
+        "litellm_provider": "fal_ai",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.004,
+        "source": "https://fal.ai/models/fal-ai/ltx-video/image-to-video",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "$0.02 flat per video; billed as 5 seconds at $0.004 per second"
+        }
+    },
     "featherless_ai/featherless-ai/Qwerky-72B": {
         "litellm_provider": "featherless_ai",
         "max_input_tokens": 32768,

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -9174,6 +9174,10 @@ class ProviderConfigManager:
             from litellm.llms.runwayml.videos.transformation import RunwayMLVideoConfig
 
             return RunwayMLVideoConfig()
+        elif LlmProviders.FAL_AI == provider:
+            from litellm.llms.fal_ai.videos.transformation import FalAIVideoConfig
+
+            return FalAIVideoConfig()
         elif LlmProviders.HOSTED_VLLM == provider:
             from litellm.llms.hosted_vllm.videos import get_hosted_vllm_video_config
 

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -20820,6 +20820,307 @@
         ],
         "supports_vision": true
     },
+    "fal_ai/minimax/h3/text-to-video": {
+        "litellm_provider": "fal_ai",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.13,
+        "output_cost_per_second_480p": 0.05,
+        "output_cost_per_second_768p": 0.06,
+        "output_cost_per_second_4k": 0.16,
+        "source": "https://fal.ai/models/minimax/h3/text-to-video",
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "default resolution 2K; 480P, 768P and 4K priced per tier"
+        }
+    },
+    "fal_ai/minimax/h3/image-to-video": {
+        "litellm_provider": "fal_ai",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.13,
+        "output_cost_per_second_480p": 0.05,
+        "output_cost_per_second_768p": 0.06,
+        "output_cost_per_second_4k": 0.16,
+        "source": "https://fal.ai/models/minimax/h3/image-to-video",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "default resolution 2K; 480P, 768P and 4K priced per tier"
+        }
+    },
+    "fal_ai/minimax/h3/reference-to-video": {
+        "litellm_provider": "fal_ai",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.13,
+        "output_cost_per_second_480p": 0.05,
+        "output_cost_per_second_768p": 0.06,
+        "output_cost_per_second_4k": 0.16,
+        "source": "https://fal.ai/models/minimax/h3/reference-to-video",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "default resolution 2K; 480P, 768P and 4K priced per tier"
+        }
+    },
+    "fal_ai/bytedance/seedance-2.0/text-to-video": {
+        "litellm_provider": "fal_ai",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.3034,
+        "output_cost_per_second_1080p": 0.682,
+        "source": "https://fal.ai/models/bytedance/seedance-2.0/text-to-video",
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "default resolution 720p"
+        }
+    },
+    "fal_ai/bytedance/seedance-2.0/image-to-video": {
+        "litellm_provider": "fal_ai",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.3024,
+        "source": "https://fal.ai/models/bytedance/seedance-2.0/image-to-video",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "default resolution 720p"
+        }
+    },
+    "fal_ai/bytedance/seedance-2.0/reference-to-video": {
+        "litellm_provider": "fal_ai",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.3024,
+        "source": "https://fal.ai/models/bytedance/seedance-2.0/reference-to-video",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "default resolution 720p"
+        }
+    },
+    "fal_ai/alibaba/happy-horse/text-to-video": {
+        "litellm_provider": "fal_ai",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.28,
+        "output_cost_per_second_720p": 0.14,
+        "source": "https://fal.ai/models/alibaba/happy-horse/text-to-video",
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "default resolution 1080p"
+        }
+    },
+    "fal_ai/alibaba/happy-horse/image-to-video": {
+        "litellm_provider": "fal_ai",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.28,
+        "output_cost_per_second_720p": 0.14,
+        "source": "https://fal.ai/models/alibaba/happy-horse/image-to-video",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "default resolution 1080p"
+        }
+    },
+    "fal_ai/alibaba/happy-horse/reference-to-video": {
+        "litellm_provider": "fal_ai",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.28,
+        "output_cost_per_second_720p": 0.14,
+        "source": "https://fal.ai/models/alibaba/happy-horse/reference-to-video",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "default resolution 1080p"
+        }
+    },
+    "fal_ai/alibaba/happy-horse/video-edit": {
+        "litellm_provider": "fal_ai",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.28,
+        "output_cost_per_second_720p": 0.14,
+        "source": "https://fal.ai/models/alibaba/happy-horse/video-edit",
+        "supported_modalities": [
+            "text",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "default resolution 1080p; billed per second of output"
+        }
+    },
+    "fal_ai/blackforestlabs/flux-3/text-to-video": {
+        "litellm_provider": "fal_ai",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.17,
+        "output_cost_per_second_1080p": 0.29,
+        "source": "https://fal.ai/models/blackforestlabs/flux-3/text-to-video",
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "default resolution 720p"
+        }
+    },
+    "fal_ai/blackforestlabs/flux-3/image-to-video": {
+        "litellm_provider": "fal_ai",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.17,
+        "output_cost_per_second_1080p": 0.29,
+        "source": "https://fal.ai/models/blackforestlabs/flux-3/image-to-video",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "default resolution 720p"
+        }
+    },
+    "fal_ai/blackforestlabs/flux-3/extend-video": {
+        "litellm_provider": "fal_ai",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.205,
+        "source": "https://fal.ai/models/blackforestlabs/flux-3/extend-video",
+        "supported_modalities": [
+            "text",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "default resolution 720p"
+        }
+    },
+    "fal_ai/xai/grok-imagine-video/text-to-video": {
+        "litellm_provider": "fal_ai",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.07,
+        "output_cost_per_second_480p": 0.05,
+        "source": "https://fal.ai/models/xai/grok-imagine-video/text-to-video",
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "default resolution 720p"
+        }
+    },
+    "fal_ai/xai/grok-imagine-video/image-to-video": {
+        "litellm_provider": "fal_ai",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.07,
+        "output_cost_per_second_480p": 0.05,
+        "source": "https://fal.ai/models/xai/grok-imagine-video/image-to-video",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "default resolution 720p"
+        }
+    },
+    "fal_ai/xai/grok-imagine-video/edit-video": {
+        "litellm_provider": "fal_ai",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.08,
+        "output_cost_per_second_480p": 0.06,
+        "source": "https://fal.ai/models/xai/grok-imagine-video/edit-video",
+        "supported_modalities": [
+            "text",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "default resolution 720p; input video seconds included in the rate"
+        }
+    },
+    "fal_ai/fal-ai/ltx-video": {
+        "litellm_provider": "fal_ai",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.004,
+        "source": "https://fal.ai/models/fal-ai/ltx-video",
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "$0.02 flat per video; billed as 5 seconds at $0.004 per second"
+        }
+    },
+    "fal_ai/fal-ai/ltx-video/image-to-video": {
+        "litellm_provider": "fal_ai",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.004,
+        "source": "https://fal.ai/models/fal-ai/ltx-video/image-to-video",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "$0.02 flat per video; billed as 5 seconds at $0.004 per second"
+        }
+    },
     "featherless_ai/featherless-ai/Qwerky-72B": {
         "litellm_provider": "featherless_ai",
         "max_input_tokens": 32768,

--- a/model_prices_and_context_window.schema.json
+++ b/model_prices_and_context_window.schema.json
@@ -458,6 +458,14 @@
           "type": "number",
           "minimum": 0
         },
+        "output_cost_per_second_720p": {
+          "type": "number",
+          "minimum": 0
+        },
+        "output_cost_per_second_768p": {
+          "type": "number",
+          "minimum": 0
+        },
         "output_cost_per_token": {
           "type": "number",
           "minimum": 0,

--- a/tests/test_litellm/llms/fal_ai/videos/test_fal_ai_video_transformation.py
+++ b/tests/test_litellm/llms/fal_ai/videos/test_fal_ai_video_transformation.py
@@ -1,0 +1,653 @@
+"""
+Tests for fal.ai video generation transformation.
+"""
+
+import base64
+import io
+import json
+from typing import Final
+
+import httpx
+import pytest
+
+import litellm
+from litellm.cost_calculator import default_video_cost_calculator
+from litellm.llms.base_llm.chat.transformation import BaseLLMException
+from litellm.llms.custom_httpx.http_handler import HTTPHandler
+from litellm.llms.fal_ai.videos.transformation import FAL_QUEUE_API_BASE, FalAIVideoConfig, FalAIVideoError
+from litellm.types.router import GenericLiteLLMParams
+from litellm.types.videos.utils import decode_video_id_with_provider, encode_video_id_with_provider
+from litellm.utils import ProviderConfigManager
+
+PNG_BYTES: Final = b"\x89PNG\r\n\x1a\n" + b"fakepixels"
+JPEG_BYTES: Final = b"\xff\xd8\xff\xe0" + b"fakepixels"
+MP4_BYTES: Final = b"\x00\x00\x00\x18ftypisom" + b"fakeframes"
+
+STATUS_URL: Final = "https://queue.fal.run/minimax/h3/requests/req-abc-123/status"
+RESULT_URL: Final = "https://queue.fal.run/minimax/h3/requests/req-abc-123"
+
+
+def make_response(payload: dict, status_code: int = 200) -> httpx.Response:
+    return httpx.Response(
+        status_code=status_code,
+        json=payload,
+        request=httpx.Request("GET", STATUS_URL),
+    )
+
+
+def encoded_id(model: str = "minimax/h3/image-to-video", request_id: str = "req-abc-123") -> str:
+    return encode_video_id_with_provider(request_id, "fal_ai", model)
+
+
+def decode_data_url(data_url: str) -> tuple[str, bytes]:
+    head, _, b64 = data_url.partition(";base64,")
+    return head.removeprefix("data:"), base64.b64decode(b64)
+
+
+class _RecordingClient(HTTPHandler):
+    """Stand-in for the shared httpx client: replays one response and records the call."""
+
+    def __init__(self, response: httpx.Response | None = None, exc: Exception | None = None):
+        super().__init__(client=httpx.Client(transport=httpx.MockTransport(lambda request: httpx.Response(500))))
+        self._response = response
+        self._exc = exc
+        self.url: str | None = None
+        self.headers: dict | None = None
+
+    def get(self, url, params=None, headers=None, follow_redirects=None, timeout=None):
+        if self._exc is not None:
+            raise self._exc
+        self.url = url
+        self.headers = headers
+        assert self._response is not None
+        return self._response
+
+
+@pytest.fixture
+def config() -> FalAIVideoConfig:
+    return FalAIVideoConfig()
+
+
+class TestProviderRegistration:
+    def test_fal_ai_resolves_to_video_config(self):
+        cfg = ProviderConfigManager.get_provider_video_config(
+            model="fal-ai/ltx-video", provider=litellm.LlmProviders.FAL_AI
+        )
+        assert isinstance(cfg, FalAIVideoConfig)
+
+    def test_get_llm_provider_splits_fal_ai_prefix(self):
+        model, provider, _, _ = litellm.get_llm_provider(model="fal_ai/minimax/h3/text-to-video")
+        assert provider == "fal_ai"
+        assert model == "minimax/h3/text-to-video"
+
+
+class TestMapOpenAIParams:
+    def test_input_reference_maps_to_image_url(self, config):
+        mapped = config.map_openai_params(
+            {"input_reference": "https://example.com/cat.png"},
+            model="minimax/h3/image-to-video",
+            drop_params=False,
+        )
+        assert mapped == {"image_url": "https://example.com/cat.png"}
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "alibaba/happy-horse/video-edit",
+            "xai/grok-imagine-video/edit-video",
+            "blackforestlabs/flux-3/extend-video",
+            "some-vendor/some-model/video-to-video",
+        ],
+    )
+    def test_input_reference_maps_to_video_url_for_video_endpoints(self, config, model):
+        mapped = config.map_openai_params(
+            {"input_reference": "https://example.com/clip.mp4"},
+            model=model,
+            drop_params=False,
+        )
+        assert mapped == {"video_url": "https://example.com/clip.mp4"}
+
+    def test_seconds_maps_to_int_duration(self, config):
+        mapped = config.map_openai_params({"seconds": "8"}, model="minimax/h3/text-to-video", drop_params=False)
+        assert mapped == {"duration": 8}
+
+    def test_seconds_maps_to_string_duration_for_seedance(self, config):
+        mapped = config.map_openai_params(
+            {"seconds": "8"}, model="bytedance/seedance-2.0/text-to-video", drop_params=False
+        )
+        assert mapped == {"duration": "8"}
+
+    @pytest.mark.parametrize("model", ["alibaba/happy-horse/video-edit", "fal-ai/ltx-video"])
+    def test_seconds_dropped_for_endpoints_without_duration(self, config, model):
+        mapped = config.map_openai_params({"seconds": "8"}, model=model, drop_params=False)
+        assert "duration" not in mapped
+
+    def test_unparseable_seconds_falls_back_to_family_default(self, config):
+        mapped = config.map_openai_params(
+            {"seconds": "auto"}, model="xai/grok-imagine-video/text-to-video", drop_params=False
+        )
+        assert mapped == {"duration": 6}
+
+    def test_size_maps_to_short_side_resolution(self, config):
+        mapped = config.map_openai_params(
+            {"size": "1280x720"}, model="xai/grok-imagine-video/text-to-video", drop_params=False
+        )
+        assert mapped == {"resolution": "720p"}
+
+    @pytest.mark.parametrize(
+        "size,expected",
+        [("1366x768", "768P"), ("2560x1440", "2K"), ("3840x2160", "4K")],
+    )
+    def test_size_maps_to_uppercase_tiers_for_minimax(self, config, size, expected):
+        mapped = config.map_openai_params({"size": size}, model="minimax/h3/text-to-video", drop_params=False)
+        assert mapped == {"resolution": expected}
+
+    def test_unknown_params_pass_through_verbatim(self, config):
+        mapped = config.map_openai_params(
+            {"enable_prompt_expansion": False, "aspect_ratio": "9:16", "seed": 42},
+            model="minimax/h3/text-to-video",
+            drop_params=False,
+        )
+        assert mapped == {"enable_prompt_expansion": False, "aspect_ratio": "9:16", "seed": 42}
+
+    def test_openai_only_params_are_not_forwarded(self, config):
+        mapped = config.map_openai_params(
+            {"user": "someone", "extra_headers": {"x": "y"}, "model": "minimax/h3/text-to-video"},
+            model="minimax/h3/text-to-video",
+            drop_params=False,
+        )
+        assert mapped == {}
+
+
+class TestBinaryInputReference:
+    """The proxy hands input_reference over as a file upload. fal's body is JSON, so it must become a data URL."""
+
+    def test_bytesio_with_name_becomes_data_url(self, config):
+        buf = io.BytesIO(PNG_BYTES)
+        buf.name = "input_image.png"
+        mapped = config.map_openai_params(
+            {"input_reference": buf}, model="alibaba/happy-horse/image-to-video", drop_params=False
+        )
+        assert decode_data_url(mapped["image_url"]) == ("image/png", PNG_BYTES)
+
+    def test_bytesio_is_read_from_the_start(self, config):
+        buf = io.BytesIO(PNG_BYTES)
+        buf.name = "input_image.png"
+        buf.read()
+        mapped = config.map_openai_params(
+            {"input_reference": buf}, model="minimax/h3/image-to-video", drop_params=False
+        )
+        assert decode_data_url(mapped["image_url"])[1] == PNG_BYTES
+
+    def test_raw_bytes_content_type_sniffed_from_magic(self, config):
+        mapped = config.map_openai_params(
+            {"input_reference": JPEG_BYTES}, model="minimax/h3/image-to-video", drop_params=False
+        )
+        assert decode_data_url(mapped["image_url"]) == ("image/jpeg", JPEG_BYTES)
+
+    def test_tuple_content_type_wins(self, config):
+        mapped = config.map_openai_params(
+            {"input_reference": ("frame.bin", io.BytesIO(PNG_BYTES), "image/webp")},
+            model="minimax/h3/image-to-video",
+            drop_params=False,
+        )
+        assert decode_data_url(mapped["image_url"])[0] == "image/webp"
+
+    def test_video_reference_becomes_video_data_url(self, config):
+        buf = io.BytesIO(MP4_BYTES)
+        buf.name = "clip.mp4"
+        mapped = config.map_openai_params(
+            {"input_reference": buf}, model="alibaba/happy-horse/video-edit", drop_params=False
+        )
+        assert decode_data_url(mapped["video_url"]) == ("video/mp4", MP4_BYTES)
+
+    def test_unnamed_video_bytes_default_to_mp4(self, config):
+        mapped = config.map_openai_params(
+            {"input_reference": MP4_BYTES}, model="xai/grok-imagine-video/edit-video", drop_params=False
+        )
+        assert decode_data_url(mapped["video_url"])[0] == "video/mp4"
+
+    def test_mapped_payload_is_json_serializable(self, config):
+        buf = io.BytesIO(PNG_BYTES)
+        buf.name = "input_image.png"
+        mapped = config.map_openai_params(
+            {"input_reference": buf, "seconds": "5"},
+            model="alibaba/happy-horse/image-to-video",
+            drop_params=False,
+        )
+        assert json.loads(json.dumps(mapped)) == mapped
+
+
+class TestCreateRequest:
+    def test_submit_url_is_the_full_model_path(self, config):
+        data, files, url = config.transform_video_create_request(
+            model="minimax/h3/image-to-video",
+            prompt="a cat",
+            api_base=FAL_QUEUE_API_BASE,
+            video_create_optional_request_params={"image_url": "https://example.com/cat.png"},
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+        assert url == "https://queue.fal.run/minimax/h3/image-to-video"
+        assert data == {"prompt": "a cat", "image_url": "https://example.com/cat.png", "duration": 5}
+        assert not files
+
+    def test_submit_strips_provider_prefix(self, config):
+        _, _, url = config.transform_video_create_request(
+            model="fal_ai/fal-ai/ltx-video",
+            prompt="a cat",
+            api_base=FAL_QUEUE_API_BASE,
+            video_create_optional_request_params={},
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+        assert url == "https://queue.fal.run/fal-ai/ltx-video"
+
+    @pytest.mark.parametrize(
+        "model,expected_duration",
+        [
+            ("minimax/h3/text-to-video", 5),
+            ("bytedance/seedance-2.0/text-to-video", "5"),
+            ("xai/grok-imagine-video/text-to-video", 6),
+        ],
+    )
+    def test_default_duration_pinned_when_caller_gives_none(self, config, model, expected_duration):
+        data, _, _ = config.transform_video_create_request(
+            model=model,
+            prompt="a cat",
+            api_base=FAL_QUEUE_API_BASE,
+            video_create_optional_request_params={},
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+        assert data["duration"] == expected_duration
+
+    @pytest.mark.parametrize("model", ["fal-ai/ltx-video", "alibaba/happy-horse/video-edit"])
+    def test_no_duration_for_endpoints_without_one(self, config, model):
+        data, _, _ = config.transform_video_create_request(
+            model=model,
+            prompt="a cat",
+            api_base=FAL_QUEUE_API_BASE,
+            video_create_optional_request_params={},
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+        assert "duration" not in data
+
+    def test_caller_duration_is_kept(self, config):
+        data, _, _ = config.transform_video_create_request(
+            model="minimax/h3/text-to-video",
+            prompt="a cat",
+            api_base=FAL_QUEUE_API_BASE,
+            video_create_optional_request_params={"duration": 10},
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+        assert data["duration"] == 10
+
+
+class TestCreateResponse:
+    def test_id_carries_provider_model_path_and_request_id(self, config):
+        video = config.transform_video_create_response(
+            model="minimax/h3/image-to-video",
+            raw_response=make_response({"request_id": "req-abc-123", "status": "IN_QUEUE"}),
+            logging_obj=None,
+            custom_llm_provider="fal_ai",
+            request_data={"prompt": "a cat", "duration": 6},
+        )
+        assert video.id.startswith("video_")
+        assert decode_video_id_with_provider(video.id) == {
+            "custom_llm_provider": "fal_ai",
+            "model_id": "minimax/h3/image-to-video",
+            "video_id": "req-abc-123",
+        }
+
+    def test_status_and_billed_seconds_come_from_the_request(self, config):
+        video = config.transform_video_create_response(
+            model="minimax/h3/text-to-video",
+            raw_response=make_response({"request_id": "req-1", "status": "IN_QUEUE"}),
+            logging_obj=None,
+            custom_llm_provider="fal_ai",
+            request_data={"prompt": "x", "duration": 12, "resolution": "768P"},
+        )
+        assert video.status == "queued"
+        assert video.model == "minimax/h3/text-to-video"
+        assert video.seconds == "12"
+        assert video.size == "768p"
+        assert video.usage == {"duration_seconds": 12.0, "video_resolution": "768p"}
+
+    def test_missing_duration_bills_the_family_default(self, config):
+        video = config.transform_video_create_response(
+            model="xai/grok-imagine-video/text-to-video",
+            raw_response=make_response({"request_id": "req-2"}),
+            logging_obj=None,
+            custom_llm_provider="fal_ai",
+            request_data={"prompt": "x"},
+        )
+        assert video.usage == {"duration_seconds": 6.0}
+
+    def test_auto_duration_bills_the_family_default(self, config):
+        video = config.transform_video_create_response(
+            model="bytedance/seedance-2.0/text-to-video",
+            raw_response=make_response({"request_id": "req-3"}),
+            logging_obj=None,
+            custom_llm_provider="fal_ai",
+            request_data={"prompt": "x", "duration": "auto"},
+        )
+        assert video.usage == {"duration_seconds": 5.0}
+
+    def test_missing_request_id_raises(self, config):
+        with pytest.raises(ValueError, match="request_id"):
+            config.transform_video_create_response(
+                model="fal-ai/ltx-video",
+                raw_response=make_response({"detail": "boom"}),
+                logging_obj=None,
+                custom_llm_provider="fal_ai",
+                request_data={"prompt": "x"},
+            )
+
+
+class TestStatus:
+    def test_status_url_uses_root_app_id(self, config):
+        url, data = config.transform_video_status_retrieve_request(
+            video_id=encoded_id(),
+            api_base=FAL_QUEUE_API_BASE,
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+        assert url == STATUS_URL
+        assert data == {}
+
+    @pytest.mark.parametrize(
+        "model,expected_url",
+        [
+            (
+                "xai/grok-imagine-video/v1.5/image-to-video",
+                "https://queue.fal.run/xai/grok-imagine-video/requests/r1/status",
+            ),
+            ("fal-ai/ltx-video", "https://queue.fal.run/fal-ai/ltx-video/requests/r1/status"),
+        ],
+    )
+    def test_status_url_keeps_only_two_path_segments(self, config, model, expected_url):
+        url, _ = config.transform_video_status_retrieve_request(
+            video_id=encoded_id(model=model, request_id="r1"),
+            api_base=FAL_QUEUE_API_BASE,
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+        assert url == expected_url
+
+    def test_request_id_is_path_encoded(self, config):
+        url, _ = config.transform_video_status_retrieve_request(
+            video_id=encoded_id(request_id="../../other?x=1"),
+            api_base=FAL_QUEUE_API_BASE,
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+        assert url == "https://queue.fal.run/minimax/h3/requests/..%2F..%2Fother%3Fx%3D1/status"
+
+    def test_video_id_without_model_path_raises(self, config):
+        with pytest.raises(ValueError, match="model path"):
+            config.transform_video_status_retrieve_request(
+                video_id="raw-fal-request-id",
+                api_base=FAL_QUEUE_API_BASE,
+                litellm_params=GenericLiteLLMParams(),
+                headers={},
+            )
+
+    @pytest.mark.parametrize(
+        "fal_status,expected",
+        [
+            ("IN_QUEUE", "queued"),
+            ("IN_PROGRESS", "in_progress"),
+            ("FAILED", "failed"),
+            ("SOMETHING_NEW", "failed"),
+            ("", "failed"),
+        ],
+    )
+    def test_status_mapping(self, config, fal_status, expected):
+        config.transform_video_status_retrieve_request(
+            video_id=encoded_id(), api_base=FAL_QUEUE_API_BASE, litellm_params=GenericLiteLLMParams(), headers={}
+        )
+        video = config.transform_video_status_retrieve_response(
+            raw_response=make_response({"status": fal_status, "request_id": "req-abc-123"}),
+            logging_obj=None,
+            custom_llm_provider="fal_ai",
+        )
+        assert video.status == expected
+        assert (video.error is not None) == (expected == "failed")
+
+    def test_status_response_id_stays_routable(self, config):
+        config.transform_video_status_retrieve_request(
+            video_id=encoded_id(), api_base=FAL_QUEUE_API_BASE, litellm_params=GenericLiteLLMParams(), headers={}
+        )
+        video = config.transform_video_status_retrieve_response(
+            raw_response=make_response({"status": "IN_PROGRESS", "request_id": "req-abc-123"}),
+            logging_obj=None,
+            custom_llm_provider="fal_ai",
+        )
+        assert decode_video_id_with_provider(video.id) == {
+            "custom_llm_provider": "fal_ai",
+            "model_id": "minimax/h3/image-to-video",
+            "video_id": "req-abc-123",
+        }
+
+
+class TestCompletedResultPeek:
+    """fal reports COMPLETED for failed jobs too, so a completed poll peeks at the result."""
+
+    def poll(self, config: FalAIVideoConfig, payload: dict):
+        config.transform_video_status_retrieve_request(
+            video_id=encoded_id(),
+            api_base=FAL_QUEUE_API_BASE,
+            litellm_params=GenericLiteLLMParams(),
+            headers={"Authorization": "Key k"},
+        )
+        return config.transform_video_status_retrieve_response(
+            raw_response=make_response({"request_id": "req-abc-123", "response_url": RESULT_URL, **payload}),
+            logging_obj=None,
+            custom_llm_provider="fal_ai",
+        )
+
+    def test_failed_result_downgrades_status_to_failed(self):
+        client = _RecordingClient(
+            response=make_response(
+                {"detail": [{"msg": "Image dimensions are too small.", "type": "image_too_small"}]}, status_code=422
+            )
+        )
+        video = self.poll(FalAIVideoConfig(result_client=client), {"status": "COMPLETED"})
+        assert video.status == "failed"
+        assert "image_too_small" in video.error["message"]
+        assert client.url == RESULT_URL
+        assert client.headers == {"Authorization": "Key k"}
+
+    def test_result_with_error_body_downgrades_status_to_failed(self):
+        client = _RecordingClient(response=make_response({"detail": "invalid image_url"}))
+        video = self.poll(FalAIVideoConfig(result_client=client), {"status": "COMPLETED"})
+        assert video.status == "failed"
+        assert video.error == {"code": "COMPLETED", "message": "fal.ai video generation failed: invalid image_url"}
+
+    def test_result_with_video_stays_completed(self):
+        client = _RecordingClient(response=make_response({"video": {"url": "https://fal.media/out.mp4"}}))
+        video = self.poll(FalAIVideoConfig(result_client=client), {"status": "COMPLETED"})
+        assert video.status == "completed"
+        assert video.error is None
+        assert video.completed_at is not None
+
+    def test_peek_network_error_keeps_completed(self):
+        client = _RecordingClient(exc=httpx.ConnectError("boom"))
+        video = self.poll(FalAIVideoConfig(result_client=client), {"status": "COMPLETED"})
+        assert video.status == "completed"
+
+    def test_still_processing_result_keeps_completed(self):
+        client = _RecordingClient(response=make_response({"status": "IN_PROGRESS"}))
+        video = self.poll(FalAIVideoConfig(result_client=client), {"status": "COMPLETED"})
+        assert video.status == "completed"
+
+    def test_non_completed_statuses_never_peek(self):
+        client = _RecordingClient(exc=AssertionError("peek must not run for non-completed statuses"))
+        video = self.poll(FalAIVideoConfig(result_client=client), {"status": "IN_QUEUE"})
+        assert video.status == "queued"
+
+
+class TestContent:
+    def test_content_url_uses_root_app_id(self, config):
+        url, params = config.transform_video_content_request(
+            video_id=encoded_id(),
+            api_base=FAL_QUEUE_API_BASE,
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+        assert url == RESULT_URL
+        assert params == {}
+
+    @pytest.mark.parametrize(
+        "payload,expected",
+        [
+            ({"video": {"url": "https://cdn.fal/v.mp4"}}, "https://cdn.fal/v.mp4"),
+            ({"video": "https://cdn.fal/v1.mp4"}, "https://cdn.fal/v1.mp4"),
+            ({"videos": [{"url": "https://cdn.fal/v2.mp4"}]}, "https://cdn.fal/v2.mp4"),
+        ],
+    )
+    def test_video_url_shapes(self, config, payload, expected):
+        assert config._ready_video_url(make_response(payload)) == expected
+
+    def test_still_processing_result_raises(self, config):
+        with pytest.raises(ValueError, match="still processing"):
+            config._ready_video_url(make_response({"status": "IN_PROGRESS"}))
+
+    def test_error_result_raises(self, config):
+        with pytest.raises(ValueError, match="failed: invalid image_url"):
+            config._ready_video_url(make_response({"detail": "invalid image_url"}))
+
+
+class TestValidateEnvironment:
+    def test_explicit_api_key_beats_deployment_credential(self, config):
+        headers = config.validate_environment(
+            headers={},
+            model="fal-ai/ltx-video",
+            api_key="explicit-key",
+            litellm_params=GenericLiteLLMParams(api_key="credential-key"),
+        )
+        assert headers["Authorization"] == "Key explicit-key"
+
+    def test_deployment_credential_beats_env_var(self, config, monkeypatch):
+        monkeypatch.setenv("FAL_AI_API_KEY", "env-key")
+        headers = config.validate_environment(
+            headers={},
+            model="fal-ai/ltx-video",
+            litellm_params=GenericLiteLLMParams(api_key="credential-key"),
+        )
+        assert headers["Authorization"] == "Key credential-key"
+
+    @pytest.mark.parametrize("env_var", ["FAL_AI_API_KEY", "FAL_KEY"])
+    def test_env_var_fallbacks(self, config, monkeypatch, env_var):
+        monkeypatch.delenv("FAL_AI_API_KEY", raising=False)
+        monkeypatch.delenv("FAL_KEY", raising=False)
+        monkeypatch.setenv(env_var, "env-key")
+        monkeypatch.setattr(litellm, "api_key", None)
+        headers = config.validate_environment(headers={"X-Trace": "1"}, model="fal-ai/ltx-video")
+        assert headers == {"X-Trace": "1", "Authorization": "Key env-key", "Content-Type": "application/json"}
+
+    def test_missing_key_raises(self, config, monkeypatch):
+        monkeypatch.delenv("FAL_AI_API_KEY", raising=False)
+        monkeypatch.delenv("FAL_KEY", raising=False)
+        monkeypatch.setattr(litellm, "api_key", None)
+        with pytest.raises(ValueError, match="fal.ai API key"):
+            config.validate_environment(headers={}, model="fal-ai/ltx-video")
+
+    def test_get_complete_url_defaults_to_the_queue(self, config):
+        assert config.get_complete_url(model="x/y", api_base=None, litellm_params={}) == FAL_QUEUE_API_BASE
+        assert config.get_complete_url(model="x/y", api_base="https://proxy.example/", litellm_params={}) == (
+            "https://proxy.example"
+        )
+
+    def test_get_error_class_returns_fal_error(self, config):
+        error = config.get_error_class(error_message="bad key", status_code=401, headers={})
+        assert isinstance(error, FalAIVideoError)
+        assert isinstance(error, BaseLLMException)
+        assert error.status_code == 401
+
+
+class TestSdkRoundTrip:
+    """litellm.video_generation and litellm.video_status through an injected HTTP client."""
+
+    def make_client(self, handler) -> HTTPHandler:
+        return HTTPHandler(client=httpx.Client(transport=httpx.MockTransport(handler)))
+
+    def test_video_generation_submits_to_the_queue_and_encodes_the_id(self):
+        seen: list = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen.append(request)
+            return httpx.Response(200, json={"request_id": "req-e2e-1", "status": "IN_QUEUE"})
+
+        video = litellm.video_generation(
+            model="fal_ai/minimax/h3/image-to-video",
+            prompt="a cat surfing",
+            seconds="6",
+            api_key="test-key",
+            extra_body={"image_url": "https://example.com/cat.png", "resolution": "768P"},
+            client=self.make_client(handler),
+        )
+
+        (sent,) = seen
+        assert str(sent.url) == "https://queue.fal.run/minimax/h3/image-to-video"
+        assert sent.headers["authorization"] == "Key test-key"
+        assert json.loads(sent.content) == {
+            "prompt": "a cat surfing",
+            "image_url": "https://example.com/cat.png",
+            "duration": 6,
+            "resolution": "768P",
+        }
+        assert decode_video_id_with_provider(video.id) == {
+            "custom_llm_provider": "fal_ai",
+            "model_id": "minimax/h3/image-to-video",
+            "video_id": "req-e2e-1",
+        }
+        assert video.usage == {"duration_seconds": 6.0, "video_resolution": "768p"}
+
+    def test_video_status_routes_by_the_encoded_id(self):
+        seen: list = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen.append(request)
+            return httpx.Response(200, json={"status": "IN_PROGRESS", "request_id": "req-e2e-2"})
+
+        video = litellm.video_status(
+            video_id=encode_video_id_with_provider("req-e2e-2", "fal_ai", "minimax/h3/image-to-video"),
+            api_key="test-key",
+            client=self.make_client(handler),
+        )
+
+        (sent,) = seen
+        assert str(sent.url) == "https://queue.fal.run/minimax/h3/requests/req-e2e-2/status"
+        assert sent.headers["authorization"] == "Key test-key"
+        assert video.status == "in_progress"
+        assert decode_video_id_with_provider(video.id)["model_id"] == "minimax/h3/image-to-video"
+
+
+class TestPricing:
+    @pytest.fixture(autouse=True)
+    def _use_local_model_cost_map(self, monkeypatch):
+        monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+        monkeypatch.setattr(litellm, "model_cost", litellm.get_model_cost_map(url=""))
+
+    @pytest.mark.parametrize(
+        "model,resolution,expected",
+        [
+            ("fal_ai/minimax/h3/text-to-video", None, 5 * 0.13),
+            ("fal_ai/minimax/h3/text-to-video", "768p", 5 * 0.06),
+            ("fal_ai/alibaba/happy-horse/image-to-video", "720p", 5 * 0.14),
+            ("fal_ai/xai/grok-imagine-video/text-to-video", "480p", 5 * 0.05),
+            ("fal_ai/fal-ai/ltx-video", None, 0.02),
+        ],
+    )
+    def test_video_cost_uses_fal_price_map_entries(self, model, resolution, expected):
+        cost = default_video_cost_calculator(
+            model=model,
+            duration_seconds=5.0,
+            custom_llm_provider="fal_ai",
+            video_resolution=resolution,
+        )
+        assert cost == pytest.approx(expected)

--- a/tests/test_litellm/llms/fal_ai/videos/test_fal_ai_video_transformation.py
+++ b/tests/test_litellm/llms/fal_ai/videos/test_fal_ai_video_transformation.py
@@ -12,6 +12,7 @@ import pytest
 
 import litellm
 from litellm.cost_calculator import default_video_cost_calculator
+from litellm.litellm_core_utils.url_utils import SSRFError
 from litellm.llms.base_llm.chat.transformation import BaseLLMException
 from litellm.llms.custom_httpx.http_handler import HTTPHandler
 from litellm.llms.fal_ai.videos.transformation import FAL_QUEUE_API_BASE, FalAIVideoConfig, FalAIVideoError
@@ -122,9 +123,10 @@ class TestMapOpenAIParams:
         mapped = config.map_openai_params({"seconds": "8"}, model=model, drop_params=False)
         assert "duration" not in mapped
 
-    def test_unparseable_seconds_falls_back_to_family_default(self, config):
+    @pytest.mark.parametrize("seconds", ["auto", "inf", "-inf", "nan"])
+    def test_unparseable_seconds_fall_back_to_family_default(self, config, seconds):
         mapped = config.map_openai_params(
-            {"seconds": "auto"}, model="xai/grok-imagine-video/text-to-video", drop_params=False
+            {"seconds": seconds}, model="xai/grok-imagine-video/text-to-video", drop_params=False
         )
         assert mapped == {"duration": 6}
 
@@ -444,7 +446,7 @@ class TestCompletedResultPeek:
             headers={"Authorization": "Key k"},
         )
         return config.transform_video_status_retrieve_response(
-            raw_response=make_response({"request_id": "req-abc-123", "response_url": RESULT_URL, **payload}),
+            raw_response=make_response({"request_id": "req-abc-123", **payload}),
             logging_obj=None,
             custom_llm_provider="fal_ai",
         )
@@ -466,6 +468,14 @@ class TestCompletedResultPeek:
         video = self.poll(FalAIVideoConfig(result_client=client), {"status": "COMPLETED"})
         assert video.status == "failed"
         assert video.error == {"code": "COMPLETED", "message": "fal.ai video generation failed: invalid image_url"}
+
+    def test_peek_ignores_the_response_url_fal_returns(self):
+        client = _RecordingClient(response=make_response({"video": {"url": "https://fal.media/out.mp4"}}))
+        self.poll(
+            FalAIVideoConfig(result_client=client),
+            {"status": "COMPLETED", "response_url": "http://169.254.169.254/latest/meta-data"},
+        )
+        assert client.url == RESULT_URL
 
     def test_result_with_video_stays_completed(self):
         client = _RecordingClient(response=make_response({"video": {"url": "https://fal.media/out.mp4"}}))
@@ -511,6 +521,20 @@ class TestContent:
     )
     def test_video_url_shapes(self, config, payload, expected):
         assert config._ready_video_url(make_response(payload)) == expected
+
+    @pytest.mark.parametrize("url", ["http://169.254.169.254/latest/meta-data", "http://127.0.0.1:8080/secret"])
+    def test_private_video_url_is_refused(self, config, url):
+        with pytest.raises(SSRFError):
+            config.transform_video_content_response(
+                raw_response=make_response({"video": {"url": url}}), logging_obj=None
+            )
+
+    @pytest.mark.parametrize("url", ["http://169.254.169.254/latest/meta-data", "http://127.0.0.1:8080/secret"])
+    async def test_private_video_url_is_refused_async(self, config, url):
+        with pytest.raises(SSRFError):
+            await config.async_transform_video_content_response(
+                raw_response=make_response({"video": {"url": url}}), logging_obj=None
+            )
 
     def test_still_processing_result_raises(self, config):
         with pytest.raises(ValueError, match="still processing"):


### PR DESCRIPTION
## TLDR

Problem this solves:

- fal.ai hosts many video models but LiteLLM had no video provider for it
- `litellm.video_generation(model="fal_ai/...")` and the proxy's `/v1/videos` routes rejected fal.ai
- Nothing priced fal.ai video output, so nothing could bill it

How it solves it:

- Adds `FalAIVideoConfig` on top of fal's queue API: submit, poll status, fetch result
- Encodes the fal model path into the video id so polls rebuild the queue URL and route to the same deployment
- Pins a per-family default duration so a job never bills zero seconds
- Adds price map entries for fal.ai video models with per-resolution tiers where fal prices differ

## User Flow

Before: a developer with a fal.ai key cannot generate video through the proxy

1. The proxy admin adds a deployment with `model: fal_ai/fal-ai/ltx-video` and their fal key to config.yaml and starts the proxy
2. The developer sends POST http://localhost:4000/v1/videos with `{"model": "fal-ltx-video", "prompt": "a red bicycle leaning on a brick wall, gentle camera pan"}`
3. The response is a 500 saying `video generation is not supported for fal_ai`

After: the same request returns a video id that can be polled and downloaded

1. The proxy admin adds the same deployment and starts the proxy
2. The developer sends the same POST http://localhost:4000/v1/videos
3. The response is 200 with `{"id": "video_...", "status": "queued", "seconds": "5", ...}` and an `x-litellm-response-cost: 0.02` header
4. GET http://localhost:4000/v1/videos/video_... returns `"status": "queued"`, then `"in_progress"`, then `"completed"`
5. GET http://localhost:4000/v1/videos/video_.../content returns the mp4 bytes

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Config the proxy ran with for both runs. `FAL_KEY` was exported in the shell (value redacted) and `LITELLM_LOCAL_MODEL_COST_MAP=True` was set so the price map entries from this branch apply before the hosted map is republished

```yaml
model_list:
  - model_name: fal-ltx-video
    litellm_params:
      model: fal_ai/fal-ai/ltx-video
      api_key: os.environ/FAL_KEY
general_settings:
  master_key: sk-proof-1234
```

Started with `python litellm/proxy/proxy_cli.py --config config.yaml --port 4000`. Real fal.ai calls, $0.02 per generated video. Unrelated security headers trimmed from the output below

### Before (31ca4ddf3)

1. `curl -si http://localhost:4000/v1/videos -H 'Authorization: Bearer sk-proof-1234' -H 'content-type: application/json' -d '{"model":"fal-ltx-video","prompt":"a red bicycle leaning on a brick wall, gentle camera pan"}'`
2. Output, the provider is rejected:
   ```
   HTTP/1.1 500 Internal Server Error
   x-litellm-call-id: 720226b1-767e-4867-821a-6c1bad840114
   x-litellm-version: 1.100.0
   x-litellm-response-cost: 0
   x-litellm-key-spend: 0.0

   {"error":{"message":"litellm.APIConnectionError: video generation is not supported for fal_ai\nTraceback (most recent call last):\n  File \"/Users/meet/workspace/Personal/litellm/litellm/videos/main.py\", line 215, in video_generation\n    raise ValueError(f\"video generation is not supported for {custom_llm_provider}\")\nValueError: video generation is not supported for fal_ai\n. Received Model Group=fal-ltx-video\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"500"}}
   ```

### After (0018a3c21)

1. `curl -si http://localhost:4000/v1/videos -H 'Authorization: Bearer sk-proof-1234' -H 'content-type: application/json' -d '{"model":"fal-ltx-video","prompt":"a red bicycle leaning on a brick wall, gentle camera pan"}'`
2. Output, queued with the cost header:
   ```
   HTTP/1.1 200 OK
   content-type: application/json
   x-litellm-call-id: 3c007d3d-aa97-475b-9a05-71903b5e89e1
   x-litellm-model-id: 9366f16e34f793e063727804731f8a54d96c792087eefb2734f4ed0e66b841d5
   x-litellm-model-name: fal_ai/fal-ai/ltx-video
   x-litellm-version: 1.100.0
   x-litellm-response-cost: 0.02
   x-litellm-key-spend: 0.02
   x-litellm-model-group: fal-ltx-video

   {"id":"video_bGl0ZWxsbTpjdXN0b21fbGxtX3Byb3ZpZGVyOmZhbF9haTttb2RlbF9pZDpmYWwtYWkvbHR4LXZpZGVvO3ZpZGVvX2lkOjAxYTA2NjNhLTRhOTEtNzliMy05MTcyLWJkZTk3MDJkNjMzOQ==","object":"video","status":"queued","created_at":1788421491,"completed_at":null,"expires_at":null,"error":null,"progress":null,"remixed_from_video_id":null,"seconds":"5","size":null,"model":"fal-ltx-video","usage":{"duration_seconds":5.0}}
   ```
3. `curl -si http://localhost:4000/v1/videos/video_bGl0ZWxsbTpjdXN0b21fbGxtX3Byb3ZpZGVyOmZhbF9haTttb2RlbF9pZDpmYWwtYWkvbHR4LXZpZGVvO3ZpZGVvX2lkOjAxYTA2NjNhLTRhOTEtNzliMy05MTcyLWJkZTk3MDJkNjMzOQ== -H 'Authorization: Bearer sk-proof-1234'` every 5 seconds
4. Output, `queued` for about 110 seconds, `in_progress` for 25 seconds, then completed:
   ```
   HTTP/1.1 200 OK
   content-type: application/json
   x-litellm-call-id: 6b61920f-3dda-48c5-a098-a8c0d9fb8463
   x-litellm-model-id: 9366f16e34f793e063727804731f8a54d96c792087eefb2734f4ed0e66b841d5
   x-litellm-model-name: fal_ai/fal-ai/ltx-video
   x-litellm-version: 1.100.0
   x-litellm-model-group: fal-ltx-video

   {"id":"video_bGl0ZWxsbTpjdXN0b21fbGxtX3Byb3ZpZGVyOmZhbF9haTttb2RlbF9pZDpmYWwtYWkvbHR4LXZpZGVvO3ZpZGVvX2lkOjAxYTA2NjNhLTRhOTEtNzliMy05MTcyLWJkZTk3MDJkNjMzOQ==","object":"video","status":"completed","created_at":1788421637,"completed_at":1788421637,"expires_at":null,"error":null,"progress":null,"remixed_from_video_id":null,"seconds":null,"size":null,"model":"fal-ltx-video","usage":null}
   ```
5. `curl -s http://localhost:4000/v1/videos/video_bGl0ZWxsbTpjdXN0b21fbGxtX3Byb3ZpZGVyOmZhbF9haTttb2RlbF9pZDpmYWwtYWkvbHR4LXZpZGVvO3ZpZGVvX2lkOjAxYTA2NjNhLTRhOTEtNzliMy05MTcyLWJkZTk3MDJkNjMzOQ==/content -H 'Authorization: Bearer sk-proof-1234' -o out.mp4 -D content_headers.txt && cat content_headers.txt && ls -la out.mp4 && file out.mp4`
6. Output, a playable mp4:
   ```
   HTTP/1.1 200 OK
   content-disposition: attachment; filename=video_video_bGl0ZWxsbTpjdXN0b21fbGxtX3Byb3ZpZGVyOmZhbF9haTttb2RlbF9pZDpmYWwtYWkvbHR4LXZpZGVvO3ZpZGVvX2lkOjAxYTA2NjNhLTRhOTEtNzliMy05MTcyLWJkZTk3MDJkNjMzOQ==.mp4
   content-length: 768418
   content-type: video/mp4

   -rw-r--r--@ 1 meet  wheel  768418 Sep  3 13:17 out.mp4
   out.mp4: ISO Media, MP4 Base Media v1 [ISO 14496-12:2003]
   ```

## Type

🆕 New Feature

## Caveats (if any)

### Medium

- fal marks failed jobs COMPLETED, so a completed poll fetches the result once to surface the failure
  - that peek is a sync HTTP call inside the status transform, the same pattern as RunwayML's content download
  - it hits the queue URL built from the video id, never a URL taken from fal's response
- Billing uses the requested duration at submit time, not the rendered one; fal does not return duration in the submit response

### Low

- Only per-second output pricing is modeled; per-reference-image add-ons are not
- Video remix, list and delete raise NotImplementedError; fal's queue has no equivalent

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
