### PR TITLE
refactor(rust): standardize the core Error type

### DIFF
--- a/litellm-rust/crates/ai-gateway/src/audio_transcription/common_utils.rs
+++ b/litellm-rust/crates/ai-gateway/src/audio_transcription/common_utils.rs
@@ -1,10 +1,8 @@
-use std::collections::BTreeMap;
-
-use litellm_core::CoreResult;
 use litellm_core::audio_transcription::transformation::AudioTranscriptionProviderConfig;
-use litellm_core::error::CoreError;
+use litellm_core::error::Error;
 use litellm_core::providers::bedrock::audio_transcription::BEDROCK_AUDIO_TRANSCRIPTION_CONFIG;
 use serde_json::{Map, Value};
+use std::collections::BTreeMap;
 
 pub(super) fn audio_transcription_provider_config(
     provider: &str,
@@ -17,7 +15,7 @@ pub(super) fn audio_transcription_provider_config(
 
 pub(super) fn string_headers(
     headers: Option<Map<String, Value>>,
-) -> CoreResult<BTreeMap<String, String>> {
+) -> Result<BTreeMap<String, String>, Error> {
     headers
         .unwrap_or_default()
         .into_iter()
@@ -26,7 +24,7 @@ pub(super) fn string_headers(
                 .as_str()
                 .map(|value| (key.clone(), value.to_string()))
                 .ok_or_else(|| {
-                    CoreError::InvalidRequest(format!(
+                    Error::InvalidRequest(format!(
                         "audio transcription extra_headers.{key} must be a string"
                     ))
                 })

--- a/litellm-rust/crates/ai-gateway/src/audio_transcription/handler.rs
+++ b/litellm-rust/crates/ai-gateway/src/audio_transcription/handler.rs
@@ -1,11 +1,9 @@
-use std::time::SystemTime;
-
-use litellm_core::CoreResult;
 use litellm_core::audio_transcription::transformation::AudioTranscriptionAuth;
-use litellm_core::error::CoreError;
+use litellm_core::error::Error;
 use litellm_core::providers::bedrock::audio_transcription::aws_auth_config;
 use litellm_core::providers::bedrock::aws_base::{resolve_credentials, sign_bedrock_post};
 use serde_json::Value;
+use std::time::SystemTime;
 
 use super::common_utils::truncate_error_body;
 use super::types::ProviderAudioTranscriptionRequest;
@@ -13,10 +11,9 @@ use crate::client::http_client;
 
 pub(crate) async fn execute_audio_transcription_provider_call(
     request: ProviderAudioTranscriptionRequest,
-) -> CoreResult<Value> {
-    let body = serde_json::to_vec(&request.body).map_err(|error| {
-        CoreError::InvalidRequest(format!("invalid audio request body: {error}"))
-    })?;
+) -> Result<Value, Error> {
+    let body = serde_json::to_vec(&request.body)
+        .map_err(|error| Error::InvalidRequest(format!("invalid audio request body: {error}")))?;
     let mut request_builder = http_client().post(&request.url).body(body.clone());
     for (key, value) in &request.upstream_headers {
         request_builder = request_builder.header(key, value);
@@ -27,21 +24,20 @@ pub(crate) async fn execute_audio_transcription_provider_call(
     let response = request_builder
         .send()
         .await
-        .map_err(|error| CoreError::Network(error.to_string()))?;
+        .map_err(|error| Error::Network(error.to_string()))?;
     let status = response.status();
     let text = response
         .text()
         .await
-        .map_err(|error| CoreError::Network(error.to_string()))?;
+        .map_err(|error| Error::Network(error.to_string()))?;
     if !status.is_success() {
-        return Err(CoreError::Http {
+        return Err(Error::Http {
             status: status.as_u16(),
             body: truncate_error_body(&text),
         });
     }
-    let response_json: Value = serde_json::from_str(&text).map_err(|error| {
-        CoreError::InvalidResponse(format!("invalid audio response JSON: {error}"))
-    })?;
+    let response_json: Value = serde_json::from_str(&text)
+        .map_err(|error| Error::InvalidResponse(format!("invalid audio response JSON: {error}")))?;
     Ok(request
         .config
         .transform_transcription_response(&request.model, response_json)?
@@ -51,14 +47,13 @@ pub(crate) async fn execute_audio_transcription_provider_call(
 pub(crate) async fn sign_request(
     request: &ProviderAudioTranscriptionRequest,
     optional_params: &serde_json::Map<String, Value>,
-) -> CoreResult<ProviderAudioTranscriptionRequest> {
+) -> Result<ProviderAudioTranscriptionRequest, Error> {
     let env_lookup = environment_lookup;
     let auth = request
         .config
         .auth_strategy(&request.model, optional_params, &env_lookup)?;
-    let body = serde_json::to_vec(&request.body).map_err(|error| {
-        CoreError::InvalidRequest(format!("invalid audio request body: {error}"))
-    })?;
+    let body = serde_json::to_vec(&request.body)
+        .map_err(|error| Error::InvalidRequest(format!("invalid audio request body: {error}")))?;
     let mut headers = super::common_utils::string_headers(None)?;
     headers.insert("Content-Type".to_string(), "application/json".to_string());
     headers.extend(request.upstream_headers.iter().cloned());

--- a/litellm-rust/crates/ai-gateway/src/audio_transcription/hooks.rs
+++ b/litellm-rust/crates/ai-gateway/src/audio_transcription/hooks.rs
@@ -1,11 +1,9 @@
-use std::future::Future;
-use std::pin::Pin;
-
-use litellm_core::CoreResult;
 use litellm_core::audio_transcription::transformation::AudioTranscriptionAuth;
 use litellm_core::call_lifecycle::{CallLifecycleContext, CallLifecycleHooks, CallLifecycleTiming};
-use litellm_core::error::CoreError;
+use litellm_core::error::Error;
 use serde_json::{Map, Value, json};
+use std::future::Future;
+use std::pin::Pin;
 
 use super::common_utils::{audio_transcription_provider_config, has_header, string_headers};
 use super::handler::sign_request;
@@ -26,7 +24,7 @@ pub(crate) struct AudioTranscriptionLifecycleHooks {
     request_metadata: RequestMetadata,
 }
 
-type AudioFuture<'a, T> = Pin<Box<dyn Future<Output = CoreResult<T>> + Send + 'a>>;
+type AudioFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T, Error>> + Send + 'a>>;
 type AudioLogFuture<'a> = Pin<Box<dyn Future<Output = ()> + Send + 'a>>;
 
 impl AudioTranscriptionLifecycleHooks {
@@ -45,7 +43,7 @@ impl AudioTranscriptionLifecycleHooks {
     async fn run_pre_call_guardrails(
         &self,
         request: PreparedAudioTranscriptionRequest,
-    ) -> CoreResult<PreparedAudioTranscriptionRequest> {
+    ) -> Result<PreparedAudioTranscriptionRequest, Error> {
         if self.guardrail_runner.is_empty() {
             return Ok(request);
         }
@@ -63,17 +61,17 @@ impl AudioTranscriptionLifecycleHooks {
             .await
             .map_err(guardrail_error_to_core_error)?;
         let Value::Object(mut data) = guardrail_request.data else {
-            return Err(CoreError::InvalidRequest(
+            return Err(Error::InvalidRequest(
                 "audio transcription pre_call guardrail must return an object".to_string(),
             ));
         };
         let audio = data.remove("audio").ok_or_else(|| {
-            CoreError::InvalidRequest("audio transcription guardrail removed audio".to_string())
+            Error::InvalidRequest("audio transcription guardrail removed audio".to_string())
         })?;
         let optional_params = match data.remove("optional_params") {
             Some(Value::Object(value)) => value,
             Some(_) => {
-                return Err(CoreError::InvalidRequest(
+                return Err(Error::InvalidRequest(
                     "audio transcription optional_params must be an object".to_string(),
                 ));
             }
@@ -89,9 +87,9 @@ impl AudioTranscriptionLifecycleHooks {
     async fn prepare_provider_request(
         &self,
         request: PreparedAudioTranscriptionRequest,
-    ) -> CoreResult<ProviderAudioTranscriptionRequest> {
+    ) -> Result<ProviderAudioTranscriptionRequest, Error> {
         let config = audio_transcription_provider_config(&request.custom_llm_provider)
-            .ok_or_else(|| CoreError::InvalidProvider(request.custom_llm_provider.clone()))?;
+            .ok_or_else(|| Error::InvalidProvider(request.custom_llm_provider.clone()))?;
         let env_lookup = super::handler::environment_lookup;
         let headers = string_headers(request.extra_headers)?;
         let url = config.complete_url(
@@ -135,7 +133,7 @@ impl AudioTranscriptionLifecycleHooks {
     async fn run_during_call_guardrails(
         &self,
         request: ProviderAudioTranscriptionRequest,
-    ) -> CoreResult<ProviderAudioTranscriptionRequest> {
+    ) -> Result<ProviderAudioTranscriptionRequest, Error> {
         if self.guardrail_runner.is_empty() {
             return Ok(request);
         }
@@ -153,12 +151,12 @@ impl AudioTranscriptionLifecycleHooks {
             .await
             .map_err(guardrail_error_to_core_error)?;
         let Value::Object(mut data) = guardrail_request.data else {
-            return Err(CoreError::InvalidRequest(
+            return Err(Error::InvalidRequest(
                 "audio transcription during_call guardrail must return an object".to_string(),
             ));
         };
         let body = data.remove("body").ok_or_else(|| {
-            CoreError::InvalidRequest("audio transcription guardrail removed body".to_string())
+            Error::InvalidRequest("audio transcription guardrail removed body".to_string())
         })?;
         Ok(ProviderAudioTranscriptionRequest { body, ..request })
     }
@@ -241,7 +239,7 @@ impl CallLifecycleHooks<PreparedAudioTranscriptionRequest, ProviderAudioTranscri
     fn async_log_failure_event<'a>(
         &'a self,
         context: &'a CallLifecycleContext,
-        error: &'a CoreError,
+        error: &'a Error,
         timing: &'a CallLifecycleTiming,
     ) -> Self::FailureFuture<'a> {
         Box::pin(async move {
@@ -281,22 +279,22 @@ fn guardrail_context(metadata: &RequestMetadata) -> GuardrailContext {
     }
 }
 
-fn guardrail_error_to_core_error(error: GuardrailError) -> CoreError {
-    CoreError::InvalidRequest(format!("{}: {}", error.kind, error.message))
+fn guardrail_error_to_core_error(error: GuardrailError) -> Error {
+    Error::InvalidRequest(format!("{}: {}", error.kind, error.message))
 }
 
-fn core_error_kind(error: &CoreError) -> &'static str {
+fn core_error_kind(error: &Error) -> &'static str {
     match error {
-        CoreError::Auth(_) => "AuthError",
-        CoreError::InvalidProvider(_) => "InvalidProvider",
-        CoreError::InvalidRequest(_) => "InvalidRequest",
-        CoreError::InvalidType { .. } => "InvalidType",
-        CoreError::MissingField(_) => "MissingField",
-        CoreError::Http { .. } => "HttpError",
-        CoreError::InvalidResponse(_) => "InvalidResponse",
-        CoreError::Network(_) => "NetworkError",
-        CoreError::Connect(_) => "ConnectError",
-        CoreError::Routing(_) => "RoutingError",
-        CoreError::Unsupported(_) => "UnsupportedRequest",
+        Error::Auth(_) => "AuthError",
+        Error::InvalidProvider(_) => "InvalidProvider",
+        Error::InvalidRequest(_) => "InvalidRequest",
+        Error::InvalidType { .. } => "InvalidType",
+        Error::MissingField(_) => "MissingField",
+        Error::Http { .. } => "HttpError",
+        Error::InvalidResponse(_) => "InvalidResponse",
+        Error::Network(_) => "NetworkError",
+        Error::Connect(_) => "ConnectError",
+        Error::Routing(_) => "RoutingError",
+        Error::Unsupported(_) => "UnsupportedRequest",
     }
 }

--- a/litellm-rust/crates/ai-gateway/src/audio_transcription/mod.rs
+++ b/litellm-rust/crates/ai-gateway/src/audio_transcription/mod.rs
@@ -1,4 +1,4 @@
-use litellm_core::CoreResult;
+use litellm_core::Error;
 use litellm_core::call_lifecycle::CallLifecycle;
 use serde_json::Value;
 
@@ -13,7 +13,7 @@ pub use types::AudioTranscriptionRequest;
 use handler::execute_audio_transcription_provider_call;
 use prepare::{PreparedAudioTranscriptionCall, prepare_audio_transcription_call};
 
-pub async fn audio_transcription(request: AudioTranscriptionRequest<'_>) -> CoreResult<Value> {
+pub async fn audio_transcription(request: AudioTranscriptionRequest<'_>) -> Result<Value, Error> {
     let PreparedAudioTranscriptionCall { request, hooks } =
         prepare_audio_transcription_call(request);
     CallLifecycle::default()

--- a/litellm-rust/crates/ai-gateway/src/io/realtime.rs
+++ b/litellm-rust/crates/ai-gateway/src/io/realtime.rs
@@ -15,8 +15,7 @@ use std::time::Duration;
 
 use futures_util::stream::{SplitSink, SplitStream};
 use futures_util::{Sink, SinkExt, Stream, StreamExt};
-use litellm_core::CoreResult;
-use litellm_core::error::CoreError;
+use litellm_core::error::Error;
 use litellm_core::realtime::transformation::RealtimeProviderConfig;
 use litellm_core::realtime::types::RealtimeEvent;
 use tokio::net::TcpStream;
@@ -48,7 +47,7 @@ pub(crate) type UpstreamRx = SplitStream<UpstreamWs>;
 /// Resolve the OpenAI API key from the explicit param or the environment.
 ///
 /// Blank/whitespace values are treated as absent (guard at resolution time).
-pub(crate) fn resolve_api_key(api_key: Option<&str>) -> CoreResult<String> {
+pub(crate) fn resolve_api_key(api_key: Option<&str>) -> Result<String, Error> {
     api_key
         .map(str::trim)
         .filter(|key| !key.is_empty())
@@ -58,7 +57,7 @@ pub(crate) fn resolve_api_key(api_key: Option<&str>) -> CoreResult<String> {
                 .ok()
                 .filter(|key| !key.trim().is_empty())
         })
-        .ok_or_else(|| CoreError::Auth(MISSING_KEY_MESSAGE.to_string()))
+        .ok_or_else(|| Error::Auth(MISSING_KEY_MESSAGE.to_string()))
 }
 
 /// Open the upstream WebSocket to OpenAI for `(model, api_key, api_base)`.
@@ -70,24 +69,24 @@ pub(crate) async fn dial_upstream(
     model: &str,
     api_key: &str,
     api_base: Option<&str>,
-) -> CoreResult<UpstreamWs> {
+) -> Result<UpstreamWs, Error> {
     let url = OPENAI_REALTIME_CONFIG.complete_url(api_base, model);
 
     let mut request = url
         .as_str()
         .into_client_request()
-        .map_err(|err| CoreError::Network(err.to_string()))?;
+        .map_err(|err| Error::Network(err.to_string()))?;
     // GA realtime: only Authorization. The legacy OpenAI-Beta header triggers
     // beta_api_shape_disabled, so we do not send it.
     request.headers_mut().insert(
         AUTHORIZATION,
         HeaderValue::from_str(&format!("Bearer {api_key}"))
-            .map_err(|err| CoreError::Auth(err.to_string()))?,
+            .map_err(|err| Error::Auth(err.to_string()))?,
     );
 
     let (upstream, _response) = connect_async(request)
         .await
-        .map_err(|err| CoreError::Network(err.to_string()))?;
+        .map_err(|err| Error::Network(err.to_string()))?;
     Ok(upstream)
 }
 
@@ -96,22 +95,22 @@ pub(crate) async fn dial_upstream(
 /// Used by the pool to pre-read OpenAI's unprompted `session.created`. Returns an
 /// error on a non-text frame, a closed socket, or undecodable JSON so the pool can
 /// discard a misbehaving socket rather than warm it.
-pub(crate) async fn read_event(upstream_rx: &mut UpstreamRx) -> CoreResult<RealtimeEvent> {
+pub(crate) async fn read_event(upstream_rx: &mut UpstreamRx) -> Result<RealtimeEvent, Error> {
     loop {
         let message = upstream_rx
             .next()
             .await
-            .ok_or_else(|| CoreError::Network("upstream closed before first event".to_string()))?
-            .map_err(|err| CoreError::Network(err.to_string()))?;
+            .ok_or_else(|| Error::Network("upstream closed before first event".to_string()))?
+            .map_err(|err| Error::Network(err.to_string()))?;
         match message {
             Message::Text(text) => {
                 return serde_json::from_str(&text)
-                    .map_err(|err| CoreError::InvalidResponse(err.to_string()));
+                    .map_err(|err| Error::InvalidResponse(err.to_string()));
             }
             // Ignore protocol frames (ping/pong) while waiting for the first event.
             Message::Ping(_) | Message::Pong(_) => continue,
             Message::Close(_) => {
-                return Err(CoreError::Network(
+                return Err(Error::Network(
                     "upstream closed before first event".to_string(),
                 ));
             }
@@ -139,7 +138,7 @@ pub(crate) async fn splice<In, Out>(
     mut observe: impl FnMut(&RealtimeEvent) + Send,
     mut client_in: In,
     mut client_out: Out,
-) -> CoreResult<()>
+) -> Result<(), Error>
 where
     In: Stream<Item = RealtimeEvent> + Unpin + Send,
     Out: Sink<RealtimeEvent> + Unpin + Send,
@@ -154,7 +153,7 @@ where
             client_out
                 .send(outbound)
                 .await
-                .map_err(|err| CoreError::Network(err.to_string()))?;
+                .map_err(|err| Error::Network(err.to_string()))?;
         }
     }
 
@@ -175,26 +174,26 @@ where
                 // inflate its own spend log. Logging observes upstream events only.
                 for outbound in config.transform_realtime_request(&event, model)?.events {
                     let payload = serde_json::to_string(&outbound)
-                        .map_err(|err| CoreError::InvalidResponse(err.to_string()))?;
+                        .map_err(|err| Error::InvalidResponse(err.to_string()))?;
                     upstream_tx
                         .send(Message::Text(payload))
                         .await
-                        .map_err(|err| CoreError::Network(err.to_string()))?;
+                        .map_err(|err| Error::Network(err.to_string()))?;
                 }
             }
             // upstream -> client
             upstream_message = upstream_rx.next() => {
                 let Some(message) = upstream_message else { break }; // upstream closed
-                match message.map_err(|err| CoreError::Network(err.to_string()))? {
+                match message.map_err(|err| Error::Network(err.to_string()))? {
                     Message::Text(text) => {
                         let event: RealtimeEvent = serde_json::from_str(&text)
-                            .map_err(|err| CoreError::InvalidResponse(err.to_string()))?;
+                            .map_err(|err| Error::InvalidResponse(err.to_string()))?;
                         observe(&event);
                         for outbound in config.transform_realtime_response(&event, model)?.events {
                             client_out
                                 .send(outbound)
                                 .await
-                                .map_err(|err| CoreError::Network(err.to_string()))?;
+                                .map_err(|err| Error::Network(err.to_string()))?;
                         }
                     }
                     Message::Close(_) => break,
@@ -225,7 +224,7 @@ pub async fn realtime<In, Out>(
     observe: impl FnMut(&RealtimeEvent) + Send,
     client_in: In,
     client_out: Out,
-) -> CoreResult<()>
+) -> Result<(), Error>
 where
     In: Stream<Item = RealtimeEvent> + Unpin + Send,
     Out: Sink<RealtimeEvent> + Unpin + Send,
@@ -258,7 +257,7 @@ pub async fn realtime_warm<In, Out>(
     observe: impl FnMut(&RealtimeEvent) + Send,
     client_in: In,
     client_out: Out,
-) -> CoreResult<()>
+) -> Result<(), Error>
 where
     In: Stream<Item = RealtimeEvent> + Unpin + Send,
     Out: Sink<RealtimeEvent> + Unpin + Send,

--- a/litellm-rust/crates/ai-gateway/src/io/realtime_pool.rs
+++ b/litellm-rust/crates/ai-gateway/src/io/realtime_pool.rs
@@ -28,7 +28,7 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use futures_util::StreamExt;
-use litellm_core::CoreResult;
+use litellm_core::Error;
 use litellm_core::realtime::types::RealtimeEvent;
 
 use crate::io::realtime::{
@@ -438,7 +438,7 @@ impl RealtimePool {
 ///
 /// `key.api_key` is already resolved (non-blank). The first frame OpenAI sends
 /// unprompted is `session.created`; we buffer exactly that and read nothing more.
-async fn warm_one(key: &UpstreamKey) -> CoreResult<WarmConnection> {
+async fn warm_one(key: &UpstreamKey) -> Result<WarmConnection, Error> {
     let upstream: UpstreamWs =
         dial_upstream(&key.model, &key.api_key, key.api_base.as_deref()).await?;
     let (tx, mut rx) = upstream.split();

--- a/litellm-rust/crates/ai-gateway/src/io/responses_ws.rs
+++ b/litellm-rust/crates/ai-gateway/src/io/responses_ws.rs
@@ -4,10 +4,10 @@ use std::time::Duration;
 
 use futures_util::stream::{SplitSink, SplitStream};
 use futures_util::{Sink, SinkExt, Stream, StreamExt};
+use litellm_core::Error;
 use litellm_core::providers::openai::responses::transformation::OPENAI_RESPONSES_WS_CONFIG;
 use litellm_core::responses::types::ResponsesWsEvent;
 use litellm_core::responses::websocket::ResponsesWebSocketProviderConfig;
-use litellm_core::{CoreError, CoreResult};
 use tokio::net::TcpStream;
 use tokio::sync::Mutex;
 use tokio_tungstenite::tungstenite::Message;
@@ -37,51 +37,49 @@ impl ResponsesWebSocketConnection {
         url: &str,
         headers: &HashMap<String, String>,
         timeout: Option<Duration>,
-    ) -> CoreResult<Self> {
+    ) -> Result<Self, Error> {
         let mut request = url
             .into_client_request()
-            .map_err(|error| CoreError::Network(error.to_string()))?;
+            .map_err(|error| Error::Network(error.to_string()))?;
         for (name, value) in headers {
             let header_name = name
                 .parse::<HeaderName>()
-                .map_err(|error| CoreError::InvalidRequest(error.to_string()))?;
+                .map_err(|error| Error::InvalidRequest(error.to_string()))?;
             let header_value = HeaderValue::from_str(value)
-                .map_err(|error| CoreError::InvalidRequest(error.to_string()))?;
+                .map_err(|error| Error::InvalidRequest(error.to_string()))?;
             request.headers_mut().insert(header_name, header_value);
         }
         let connect = connect_async(request);
         let result = match timeout {
             Some(timeout) => tokio::time::timeout(timeout, connect).await.map_err(|_| {
-                CoreError::Network("Responses WebSocket connection timed out".to_string())
+                Error::Network("Responses WebSocket connection timed out".to_string())
             })?,
             None => connect.await,
         };
         let (socket, _) = result.map_err(|error| match error {
-            tokio_tungstenite::tungstenite::Error::Http(response) => CoreError::Http {
+            tokio_tungstenite::tungstenite::Error::Http(response) => Error::Http {
                 status: response.status().as_u16(),
                 body: String::new(),
             },
-            other => CoreError::Network(other.to_string()),
+            other => Error::Network(other.to_string()),
         })?;
         Ok(Self {
             socket: Arc::new(Mutex::new(Some(socket))),
         })
     }
 
-    pub async fn send_text(&self, text: String) -> CoreResult<()> {
+    pub async fn send_text(&self, text: String) -> Result<(), Error> {
         let mut socket = self.socket.lock().await;
         let Some(socket) = socket.as_mut() else {
-            return Err(CoreError::Network(
-                "Responses WebSocket is closed".to_string(),
-            ));
+            return Err(Error::Network("Responses WebSocket is closed".to_string()));
         };
         socket
             .send(Message::Text(text))
             .await
-            .map_err(|error| CoreError::Network(error.to_string()))
+            .map_err(|error| Error::Network(error.to_string()))
     }
 
-    pub async fn recv_text(&self) -> CoreResult<Option<String>> {
+    pub async fn recv_text(&self) -> Result<Option<String>, Error> {
         let mut socket_guard = self.socket.lock().await;
         let Some(socket) = socket_guard.as_mut() else {
             return Ok(None);
@@ -90,27 +88,27 @@ impl ResponsesWebSocketConnection {
             Some(Ok(Message::Text(text))) => Ok(Some(text)),
             Some(Ok(Message::Binary(bytes))) => String::from_utf8(bytes.to_vec())
                 .map(Some)
-                .map_err(|error| CoreError::InvalidResponse(error.to_string())),
+                .map_err(|error| Error::InvalidResponse(error.to_string())),
             Some(Ok(Message::Close(_))) | None => Ok(None),
             Some(Ok(_)) => Ok(None),
-            Some(Err(error)) => Err(CoreError::Network(error.to_string())),
+            Some(Err(error)) => Err(Error::Network(error.to_string())),
         }
     }
 
-    pub async fn close(&self) -> CoreResult<()> {
+    pub async fn close(&self) -> Result<(), Error> {
         let mut socket = self.socket.lock().await;
         if let Some(socket) = socket.as_mut() {
             socket
                 .close(None)
                 .await
-                .map_err(|error| CoreError::Network(error.to_string()))?;
+                .map_err(|error| Error::Network(error.to_string()))?;
         }
         *socket = None;
         Ok(())
     }
 }
 
-pub(crate) fn resolve_api_key(api_key: Option<&str>) -> CoreResult<String> {
+pub(crate) fn resolve_api_key(api_key: Option<&str>) -> Result<String, Error> {
     api_key
         .map(str::trim)
         .filter(|value| !value.is_empty())
@@ -120,38 +118,38 @@ pub(crate) fn resolve_api_key(api_key: Option<&str>) -> CoreResult<String> {
                 .ok()
                 .filter(|value| !value.trim().is_empty())
         })
-        .ok_or_else(|| CoreError::Auth(MISSING_KEY_MESSAGE.to_string()))
+        .ok_or_else(|| Error::Auth(MISSING_KEY_MESSAGE.to_string()))
 }
 
 async fn dial_upstream(
     model: &str,
     api_key: &str,
     api_base: Option<&str>,
-) -> CoreResult<ResponsesUpstreamWs> {
+) -> Result<ResponsesUpstreamWs, Error> {
     let url = OPENAI_RESPONSES_WS_CONFIG.complete_websocket_url(api_base, model);
     let mut request = url
         .as_str()
         .into_client_request()
-        .map_err(|error| CoreError::Network(error.to_string()))?;
+        .map_err(|error| Error::Network(error.to_string()))?;
     request.headers_mut().insert(
         AUTHORIZATION,
         HeaderValue::from_str(&format!("Bearer {api_key}"))
-            .map_err(|error| CoreError::Auth(error.to_string()))?,
+            .map_err(|error| Error::Auth(error.to_string()))?,
     );
     let result = tokio::time::timeout(
         Duration::from_secs(DEFAULT_RESPONSES_WS_CONNECT_TIMEOUT_SECS),
         connect_async(request),
     )
     .await
-    .map_err(|_| CoreError::Network("Responses WebSocket connection timed out".to_string()))?;
+    .map_err(|_| Error::Network("Responses WebSocket connection timed out".to_string()))?;
     result
         .map(|(socket, _)| socket)
         .map_err(|error| match error {
-            tokio_tungstenite::tungstenite::Error::Http(response) => CoreError::Http {
+            tokio_tungstenite::tungstenite::Error::Http(response) => Error::Http {
                 status: response.status().as_u16(),
                 body: String::new(),
             },
-            other => CoreError::Network(other.to_string()),
+            other => Error::Network(other.to_string()),
         })
 }
 
@@ -166,7 +164,7 @@ impl ResponsesWebSocketStreaming {
         observe: impl FnMut(&ResponsesWsEvent) + Send,
         client_in: In,
         client_out: Out,
-    ) -> CoreResult<()>
+    ) -> Result<(), Error>
     where
         In: Stream<Item = ResponsesWsEvent> + Unpin + Send,
         Out: Sink<ResponsesWsEvent> + Unpin + Send,
@@ -193,7 +191,7 @@ pub(crate) async fn splice<In, Out>(
     mut observe: impl FnMut(&ResponsesWsEvent) + Send,
     mut client_in: In,
     mut client_out: Out,
-) -> CoreResult<()>
+) -> Result<(), Error>
 where
     In: Stream<Item = ResponsesWsEvent> + Unpin + Send,
     Out: Sink<ResponsesWsEvent> + Unpin + Send,
@@ -210,18 +208,18 @@ where
                     .events
                 {
                     let payload = serde_json::to_string(&outbound)
-                        .map_err(|error| CoreError::InvalidResponse(error.to_string()))?;
+                        .map_err(|error| Error::InvalidResponse(error.to_string()))?;
                     upstream_tx.send(Message::Text(payload))
                         .await
-                        .map_err(|error| CoreError::Network(error.to_string()))?;
+                        .map_err(|error| Error::Network(error.to_string()))?;
                 }
             }
             message = upstream_rx.next() => {
                 let Some(message) = message else { break };
-                match message.map_err(|error| CoreError::Network(error.to_string()))? {
+                match message.map_err(|error| Error::Network(error.to_string()))? {
                     Message::Text(text) => {
                         let event = serde_json::from_str::<ResponsesWsEvent>(&text)
-                            .map_err(|error| CoreError::InvalidResponse(error.to_string()))?;
+                            .map_err(|error| Error::InvalidResponse(error.to_string()))?;
                         observe(&event);
                         for outbound in OPENAI_RESPONSES_WS_CONFIG
                             .transform_ws_response(&event, model)?
@@ -229,7 +227,7 @@ where
                         {
                             client_out.send(outbound)
                                 .await
-                                .map_err(|error| CoreError::Network(error.to_string()))?;
+                                .map_err(|error| Error::Network(error.to_string()))?;
                         }
                     }
                     Message::Close(_) => break,
@@ -252,7 +250,7 @@ pub async fn async_responses_websocket<In, Out>(
     mut observe: impl FnMut(&ResponsesWsEvent) + Send,
     client_in: In,
     client_out: Out,
-) -> CoreResult<()>
+) -> Result<(), Error>
 where
     In: Stream<Item = ResponsesWsEvent> + Unpin + Send,
     Out: Sink<ResponsesWsEvent> + Unpin + Send,
@@ -267,11 +265,11 @@ where
             .events
         {
             let payload = serde_json::to_string(&outbound)
-                .map_err(|error| CoreError::InvalidResponse(error.to_string()))?;
+                .map_err(|error| Error::InvalidResponse(error.to_string()))?;
             upstream_tx
                 .send(Message::Text(payload))
                 .await
-                .map_err(|error| CoreError::Network(error.to_string()))?;
+                .map_err(|error| Error::Network(error.to_string()))?;
         }
     }
     ResponsesWebSocketStreaming::bidirectional_forward(
@@ -296,7 +294,7 @@ pub async fn responses_ws<In, Out>(
     observe: impl FnMut(&ResponsesWsEvent) + Send,
     client_in: In,
     client_out: Out,
-) -> CoreResult<()>
+) -> Result<(), Error>
 where
     In: Stream<Item = ResponsesWsEvent> + Unpin + Send,
     Out: Sink<ResponsesWsEvent> + Unpin + Send,
@@ -514,7 +512,7 @@ mod tests {
         )
         .await
         .expect_err("status error");
-        assert!(matches!(error, CoreError::Http { status: 401, .. }));
+        assert!(matches!(error, Error::Http { status: 401, .. }));
         server.await.expect("server task");
     }
 
@@ -543,7 +541,7 @@ mod tests {
         )
         .await
         .expect_err("status error");
-        assert!(matches!(error, CoreError::Http { status: 500, .. }));
+        assert!(matches!(error, Error::Http { status: 500, .. }));
         server.await.expect("server task");
     }
 }

--- a/litellm-rust/crates/ai-gateway/src/ocr/common_utils.rs
+++ b/litellm-rust/crates/ai-gateway/src/ocr/common_utils.rs
@@ -3,8 +3,7 @@ use std::time::{Duration, Instant};
 
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
-use litellm_core::CoreResult;
-use litellm_core::error::CoreError;
+use litellm_core::error::Error;
 use litellm_core::ocr::transformation::OcrProviderConfig;
 use reqwest::Url;
 use serde_json::{Map, Value};
@@ -56,7 +55,7 @@ fn is_azure_document_intelligence_model(model: &str) -> bool {
 
 pub(super) fn string_headers(
     extra_headers: Option<Map<String, Value>>,
-) -> CoreResult<Vec<(String, String)>> {
+) -> Result<Vec<(String, String)>, Error> {
     extra_headers
         .unwrap_or_default()
         .into_iter()
@@ -65,7 +64,7 @@ pub(super) fn string_headers(
                 .as_str()
                 .map(|value| (key.clone(), value.to_string()))
                 .ok_or_else(|| {
-                    CoreError::InvalidRequest(format!(
+                    Error::InvalidRequest(format!(
                         "OCR extra_headers.{key} must be a string, got {}",
                         litellm_core::error::json_type_name(&value)
                     ))
@@ -80,7 +79,7 @@ pub(super) fn has_header(headers: &[(String, String)], name: &str) -> bool {
         .any(|(key, _)| key.eq_ignore_ascii_case(name))
 }
 
-fn document_url_field(document: &Value) -> CoreResult<Option<(&str, &str)>> {
+fn document_url_field(document: &Value) -> Result<Option<(&str, &str)>, Error> {
     let Some(object) = document.as_object() else {
         return Ok(None);
     };
@@ -138,13 +137,13 @@ fn is_blocked_ip(ip: IpAddr) -> bool {
     }
 }
 
-fn blocked_url_error(url: &Url) -> CoreError {
-    CoreError::InvalidRequest(format!(
+fn blocked_url_error(url: &Url) -> Error {
+    Error::InvalidRequest(format!(
         "OCR document URL rejected by SSRF protection: {url}"
     ))
 }
 
-async fn validate_safe_fetch_url(url: &Url) -> CoreResult<()> {
+async fn validate_safe_fetch_url(url: &Url) -> Result<(), Error> {
     if !matches!(url.scheme(), "http" | "https") {
         return Err(blocked_url_error(url));
     }
@@ -162,7 +161,7 @@ async fn validate_safe_fetch_url(url: &Url) -> CoreResult<()> {
         .ok_or_else(|| blocked_url_error(url))?;
     let addresses = tokio::net::lookup_host((host, port))
         .await
-        .map_err(|err| CoreError::Network(err.to_string()))?;
+        .map_err(|err| Error::Network(err.to_string()))?;
     let mut saw_address = false;
     for address in addresses {
         saw_address = true;
@@ -176,25 +175,25 @@ async fn validate_safe_fetch_url(url: &Url) -> CoreResult<()> {
     Ok(())
 }
 
-fn redirect_location(response: &reqwest::Response, url: &Url) -> CoreResult<Url> {
+fn redirect_location(response: &reqwest::Response, url: &Url) -> Result<Url, Error> {
     let location = response
         .headers()
         .get(reqwest::header::LOCATION)
         .and_then(|value| value.to_str().ok())
         .ok_or_else(|| {
-            CoreError::InvalidResponse("OCR document redirect missing Location header".to_string())
+            Error::InvalidResponse("OCR document redirect missing Location header".to_string())
         })?;
     url.join(location)
-        .map_err(|err| CoreError::InvalidResponse(format!("invalid OCR document redirect: {err}")))
+        .map_err(|err| Error::InvalidResponse(format!("invalid OCR document redirect: {err}")))
 }
 
-async fn safe_get_document_url(url: &str) -> CoreResult<(Url, reqwest::Response)> {
+async fn safe_get_document_url(url: &str) -> Result<(Url, reqwest::Response), Error> {
     let client = reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::none())
         .build()
-        .map_err(|err| CoreError::Network(err.to_string()))?;
+        .map_err(|err| Error::Network(err.to_string()))?;
     let mut current_url = Url::parse(url)
-        .map_err(|err| CoreError::InvalidRequest(format!("invalid OCR document URL: {err}")))?;
+        .map_err(|err| Error::InvalidRequest(format!("invalid OCR document URL: {err}")))?;
 
     for _ in 0..MAX_SAFE_FETCH_REDIRECTS {
         validate_safe_fetch_url(&current_url).await?;
@@ -202,28 +201,28 @@ async fn safe_get_document_url(url: &str) -> CoreResult<(Url, reqwest::Response)
             .get(current_url.clone())
             .send()
             .await
-            .map_err(|err| CoreError::Network(err.to_string()))?;
+            .map_err(|err| Error::Network(err.to_string()))?;
         if !response.status().is_redirection() {
             return Ok((current_url, response));
         }
         current_url = redirect_location(&response, &current_url)?;
     }
 
-    Err(CoreError::InvalidRequest(
+    Err(Error::InvalidRequest(
         "Too many redirects while fetching OCR document URL".to_string(),
     ))
 }
 
-fn enforce_download_size(content_length: u64, max_bytes: u64, url: &Url) -> CoreResult<()> {
+fn enforce_download_size(content_length: u64, max_bytes: u64, url: &Url) -> Result<(), Error> {
     if max_bytes == 0 {
-        return Err(CoreError::InvalidRequest(format!(
+        return Err(Error::InvalidRequest(format!(
             "OCR document URL download is disabled (MAX_IMAGE_URL_DOWNLOAD_SIZE_MB=0). url={url}"
         )));
     }
     if content_length > max_bytes {
         let size_mb = content_length as f64 / (1024.0 * 1024.0);
         let max_size_mb = max_bytes as f64 / (1024.0 * 1024.0);
-        return Err(CoreError::InvalidRequest(format!(
+        return Err(Error::InvalidRequest(format!(
             "OCR document size ({size_mb:.2}MB) exceeds maximum allowed size ({max_size_mb:.2}MB). url={url}"
         )));
     }
@@ -233,7 +232,7 @@ fn enforce_download_size(content_length: u64, max_bytes: u64, url: &Url) -> Core
 async fn read_response_with_limit(
     mut response: reqwest::Response,
     url: &Url,
-) -> CoreResult<Vec<u8>> {
+) -> Result<Vec<u8>, Error> {
     let max_bytes = max_document_download_bytes();
     if let Some(content_length) = response.content_length() {
         enforce_download_size(content_length, max_bytes, url)?;
@@ -246,7 +245,7 @@ async fn read_response_with_limit(
     while let Some(chunk) = response
         .chunk()
         .await
-        .map_err(|err| CoreError::Network(err.to_string()))?
+        .map_err(|err| Error::Network(err.to_string()))?
     {
         bytes_downloaded += chunk.len() as u64;
         enforce_download_size(bytes_downloaded, max_bytes, url)?;
@@ -255,7 +254,7 @@ async fn read_response_with_limit(
     Ok(bytes)
 }
 
-pub(super) async fn convert_document_url_to_data_uri(document: Value) -> CoreResult<Value> {
+pub(super) async fn convert_document_url_to_data_uri(document: Value) -> Result<Value, Error> {
     let Some((field, url)) = document_url_field(&document)? else {
         return Ok(document);
     };
@@ -267,7 +266,7 @@ pub(super) async fn convert_document_url_to_data_uri(document: Value) -> CoreRes
     let status = response.status();
     if !status.is_success() {
         let body = response.text().await.unwrap_or_default();
-        return Err(CoreError::Http {
+        return Err(Error::Http {
             status: status.as_u16(),
             body: truncate_error_body(&body),
         });
@@ -290,7 +289,7 @@ pub(super) async fn convert_document_url_to_data_uri(document: Value) -> CoreRes
     let mut transformed = document
         .as_object()
         .cloned()
-        .ok_or_else(|| CoreError::InvalidRequest("OCR document must be an object".to_string()))?;
+        .ok_or_else(|| Error::InvalidRequest("OCR document must be an object".to_string()))?;
     transformed.insert(field.to_string(), Value::String(data_uri));
     Ok(Value::Object(transformed))
 }
@@ -316,11 +315,11 @@ fn retry_after_secs(response: &reqwest::Response) -> u64 {
         .unwrap_or(2)
 }
 
-fn operation_status(response_json: &Value) -> CoreResult<&str> {
+fn operation_status(response_json: &Value) -> Result<&str, Error> {
     let status = response_json
         .get("status")
         .and_then(Value::as_str)
-        .ok_or(CoreError::MissingField("status"))?;
+        .ok_or(Error::MissingField("status"))?;
     match status {
         "succeeded" => Ok("succeeded"),
         "running" | "notStarted" => Ok("running"),
@@ -330,11 +329,11 @@ fn operation_status(response_json: &Value) -> CoreResult<&str> {
                 .and_then(|error| error.get("message"))
                 .and_then(Value::as_str)
                 .unwrap_or("Unknown error");
-            Err(CoreError::InvalidResponse(format!(
+            Err(Error::InvalidResponse(format!(
                 "Azure Document Intelligence analysis failed: {message}"
             )))
         }
-        other => Err(CoreError::InvalidResponse(format!(
+        other => Err(Error::InvalidResponse(format!(
             "Unknown operation status: {other}"
         ))),
     }
@@ -345,9 +344,9 @@ pub(super) async fn poll_document_intelligence(
     original_url: &str,
     headers: &[(String, String)],
     timeout: Option<Duration>,
-) -> CoreResult<Value> {
+) -> Result<Value, Error> {
     if !same_origin(operation_url, original_url) {
-        return Err(CoreError::InvalidResponse(
+        return Err(Error::InvalidResponse(
             "Azure Document Intelligence: rejected cross-origin polling URL".to_string(),
         ));
     }
@@ -358,7 +357,7 @@ pub(super) async fn poll_document_intelligence(
     ));
     loop {
         if start.elapsed() > timeout {
-            return Err(CoreError::Network(format!(
+            return Err(Error::Network(format!(
                 "Azure Document Intelligence operation polling timed out after {} seconds",
                 timeout.as_secs()
             )));
@@ -373,21 +372,21 @@ pub(super) async fn poll_document_intelligence(
         let response = request_builder
             .send()
             .await
-            .map_err(|err| CoreError::Network(err.to_string()))?;
+            .map_err(|err| Error::Network(err.to_string()))?;
         let retry_after = retry_after_secs(&response);
         let status = response.status();
         let text = response
             .text()
             .await
-            .map_err(|err| CoreError::Network(err.to_string()))?;
+            .map_err(|err| Error::Network(err.to_string()))?;
         if !status.is_success() {
-            return Err(CoreError::Http {
+            return Err(Error::Http {
                 status: status.as_u16(),
                 body: truncate_error_body(&text),
             });
         }
         let response_json: Value = serde_json::from_str(&text).map_err(|err| {
-            CoreError::InvalidResponse(format!("invalid Azure DI poll response JSON: {err}"))
+            Error::InvalidResponse(format!("invalid Azure DI poll response JSON: {err}"))
         })?;
         if operation_status(&response_json)? == "succeeded" {
             return Ok(response_json);
@@ -426,7 +425,7 @@ mod tests {
 
         assert!(matches!(
             error,
-            CoreError::InvalidRequest(message)
+            Error::InvalidRequest(message)
                 if message.contains("SSRF protection")
         ));
     }

--- a/litellm-rust/crates/ai-gateway/src/ocr/handler.rs
+++ b/litellm-rust/crates/ai-gateway/src/ocr/handler.rs
@@ -1,5 +1,4 @@
-use litellm_core::CoreResult;
-use litellm_core::error::CoreError;
+use litellm_core::error::Error;
 use litellm_core::ocr::transformation::OcrResponseHandling;
 use serde_json::Value;
 
@@ -7,7 +6,7 @@ use super::common_utils::{poll_document_intelligence, truncate_error_body};
 use super::types::ProviderOcrRequest;
 use crate::client::http_client;
 
-pub(crate) async fn execute_ocr_provider_call(request: ProviderOcrRequest) -> CoreResult<Value> {
+pub(crate) async fn execute_ocr_provider_call(request: ProviderOcrRequest) -> Result<Value, Error> {
     let mut request_builder = http_client().post(&request.url).json(&request.body);
     for (key, value) in &request.upstream_headers {
         request_builder = request_builder.header(key, value);
@@ -19,7 +18,7 @@ pub(crate) async fn execute_ocr_provider_call(request: ProviderOcrRequest) -> Co
     let response = request_builder
         .send()
         .await
-        .map_err(|err| CoreError::Network(err.to_string()))?;
+        .map_err(|err| Error::Network(err.to_string()))?;
 
     let status = response.status();
     if request.config.response_handling() == OcrResponseHandling::AzureDocumentIntelligencePoll
@@ -31,7 +30,7 @@ pub(crate) async fn execute_ocr_provider_call(request: ProviderOcrRequest) -> Co
             .and_then(|value| value.to_str().ok())
             .map(str::to_string)
             .ok_or_else(|| {
-                CoreError::InvalidResponse(
+                Error::InvalidResponse(
                     "Azure Document Intelligence returned 202 but no Operation-Location header found"
                         .to_string(),
                 )
@@ -52,17 +51,17 @@ pub(crate) async fn execute_ocr_provider_call(request: ProviderOcrRequest) -> Co
     let text = response
         .text()
         .await
-        .map_err(|err| CoreError::Network(err.to_string()))?;
+        .map_err(|err| Error::Network(err.to_string()))?;
 
     if !status.is_success() {
-        return Err(CoreError::Http {
+        return Err(Error::Http {
             status: status.as_u16(),
             body: truncate_error_body(&text),
         });
     }
 
     let response_json: Value = serde_json::from_str(&text)
-        .map_err(|err| CoreError::InvalidResponse(format!("invalid OCR response JSON: {err}")))?;
+        .map_err(|err| Error::InvalidResponse(format!("invalid OCR response JSON: {err}")))?;
 
     Ok(request
         .config

--- a/litellm-rust/crates/ai-gateway/src/ocr/hooks.rs
+++ b/litellm-rust/crates/ai-gateway/src/ocr/hooks.rs
@@ -1,11 +1,9 @@
-use std::future::Future;
-use std::pin::Pin;
-
-use litellm_core::CoreResult;
 use litellm_core::call_lifecycle::{CallLifecycleContext, CallLifecycleHooks, CallLifecycleTiming};
-use litellm_core::error::CoreError;
+use litellm_core::error::Error;
 use litellm_core::ocr::transformation::OcrAuthStrategy;
 use serde_json::{Map, Value, json};
+use std::future::Future;
+use std::pin::Pin;
 
 use super::common_utils::{
     convert_document_url_to_data_uri, has_header, ocr_provider_config, string_headers,
@@ -27,7 +25,7 @@ pub(crate) struct OcrLifecycleHooks {
     request_metadata: RequestMetadata,
 }
 
-type OcrFuture<'a, T> = Pin<Box<dyn Future<Output = CoreResult<T>> + Send + 'a>>;
+type OcrFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T, Error>> + Send + 'a>>;
 type OcrLogFuture<'a> = Pin<Box<dyn Future<Output = ()> + Send + 'a>>;
 
 impl OcrLifecycleHooks {
@@ -46,7 +44,7 @@ impl OcrLifecycleHooks {
     async fn run_pre_call_guardrails(
         &self,
         request: PreparedOcrRequest,
-    ) -> CoreResult<PreparedOcrRequest> {
+    ) -> Result<PreparedOcrRequest, Error> {
         if self.guardrail_runner.is_empty() {
             return Ok(request);
         }
@@ -74,9 +72,9 @@ impl OcrLifecycleHooks {
     async fn prepare_provider_request(
         &self,
         request: PreparedOcrRequest,
-    ) -> CoreResult<ProviderOcrRequest> {
+    ) -> Result<ProviderOcrRequest, Error> {
         let config = ocr_provider_config(&request.custom_llm_provider, &request.model)
-            .ok_or_else(|| CoreError::InvalidProvider(request.custom_llm_provider.clone()))?;
+            .ok_or_else(|| Error::InvalidProvider(request.custom_llm_provider.clone()))?;
         let env_lookup = |key: &str| std::env::var(key).ok();
         let headers = string_headers(request.extra_headers)?;
         let auth_strategy = config.auth_strategy();
@@ -120,7 +118,7 @@ impl OcrLifecycleHooks {
         custom_llm_provider: &str,
         url: &str,
         body: Value,
-    ) -> CoreResult<Value> {
+    ) -> Result<Value, Error> {
         if self.guardrail_runner.is_empty() {
             return Ok(body);
         }
@@ -217,7 +215,7 @@ impl CallLifecycleHooks<PreparedOcrRequest, ProviderOcrRequest, Value> for OcrLi
     fn async_log_failure_event<'a>(
         &'a self,
         context: &'a CallLifecycleContext,
-        error: &'a CoreError,
+        error: &'a Error,
         timing: &'a CallLifecycleTiming,
     ) -> Self::FailureFuture<'a> {
         Box::pin(async move {
@@ -278,19 +276,19 @@ fn guardrail_context(metadata: &RequestMetadata) -> GuardrailContext {
 
 fn parse_ocr_pre_call_guardrail_request(
     request: GuardrailRequest,
-) -> CoreResult<(Value, Map<String, Value>)> {
+) -> Result<(Value, Map<String, Value>), Error> {
     let Value::Object(mut data) = request.data else {
-        return Err(CoreError::InvalidRequest(
+        return Err(Error::InvalidRequest(
             "OCR pre_call guardrail must return an object".to_string(),
         ));
     };
     let document = data.remove("document").ok_or_else(|| {
-        CoreError::InvalidRequest("OCR pre_call guardrail removed document".to_string())
+        Error::InvalidRequest("OCR pre_call guardrail removed document".to_string())
     })?;
     let optional_params = match data.remove("optional_params") {
         Some(Value::Object(params)) => params,
         Some(_) => {
-            return Err(CoreError::InvalidRequest(
+            return Err(Error::InvalidRequest(
                 "OCR pre_call guardrail optional_params must be an object".to_string(),
             ));
         }
@@ -299,33 +297,32 @@ fn parse_ocr_pre_call_guardrail_request(
     Ok((document, optional_params))
 }
 
-fn parse_ocr_during_call_guardrail_request(request: GuardrailRequest) -> CoreResult<Value> {
+fn parse_ocr_during_call_guardrail_request(request: GuardrailRequest) -> Result<Value, Error> {
     let Value::Object(mut data) = request.data else {
-        return Err(CoreError::InvalidRequest(
+        return Err(Error::InvalidRequest(
             "OCR during_call guardrail must return an object".to_string(),
         ));
     };
-    data.remove("body").ok_or_else(|| {
-        CoreError::InvalidRequest("OCR during_call guardrail removed body".to_string())
-    })
+    data.remove("body")
+        .ok_or_else(|| Error::InvalidRequest("OCR during_call guardrail removed body".to_string()))
 }
 
-fn guardrail_error_to_core_error(error: GuardrailError) -> CoreError {
-    CoreError::InvalidRequest(format!("{}: {}", error.kind, error.message))
+fn guardrail_error_to_core_error(error: GuardrailError) -> Error {
+    Error::InvalidRequest(format!("{}: {}", error.kind, error.message))
 }
 
-fn core_error_kind(error: &CoreError) -> &'static str {
+fn core_error_kind(error: &Error) -> &'static str {
     match error {
-        CoreError::Auth(_) => "AuthError",
-        CoreError::InvalidProvider(_) => "InvalidProvider",
-        CoreError::InvalidRequest(_) => "InvalidRequest",
-        CoreError::InvalidType { .. } => "InvalidType",
-        CoreError::MissingField(_) => "MissingField",
-        CoreError::Http { .. } => "HttpError",
-        CoreError::InvalidResponse(_) => "InvalidResponse",
-        CoreError::Network(_) => "NetworkError",
-        CoreError::Connect(_) => "ConnectError",
-        CoreError::Routing(_) => "RoutingError",
-        CoreError::Unsupported(_) => "UnsupportedRequest",
+        Error::Auth(_) => "AuthError",
+        Error::InvalidProvider(_) => "InvalidProvider",
+        Error::InvalidRequest(_) => "InvalidRequest",
+        Error::InvalidType { .. } => "InvalidType",
+        Error::MissingField(_) => "MissingField",
+        Error::Http { .. } => "HttpError",
+        Error::InvalidResponse(_) => "InvalidResponse",
+        Error::Network(_) => "NetworkError",
+        Error::Connect(_) => "ConnectError",
+        Error::Routing(_) => "RoutingError",
+        Error::Unsupported(_) => "UnsupportedRequest",
     }
 }

--- a/litellm-rust/crates/ai-gateway/src/ocr/mod.rs
+++ b/litellm-rust/crates/ai-gateway/src/ocr/mod.rs
@@ -1,4 +1,4 @@
-use litellm_core::CoreResult;
+use litellm_core::Error;
 use litellm_core::call_lifecycle::CallLifecycle;
 use serde_json::Value;
 
@@ -13,7 +13,7 @@ pub use types::OcrRequest;
 use handler::execute_ocr_provider_call;
 use prepare::{PreparedOcrCall, prepare_ocr_call};
 
-pub async fn ocr(request: OcrRequest<'_>) -> CoreResult<Value> {
+pub async fn ocr(request: OcrRequest<'_>) -> Result<Value, Error> {
     let PreparedOcrCall { request, hooks } = prepare_ocr_call(request);
     CallLifecycle::default()
         .run_request(request, &hooks, execute_ocr_provider_call)

--- a/litellm-rust/crates/ai-gateway/src/ocr/tests.rs
+++ b/litellm-rust/crates/ai-gateway/src/ocr/tests.rs
@@ -1,7 +1,7 @@
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use litellm_core::error::CoreError;
+use litellm_core::error::Error;
 use litellm_core::ocr::transformation::OcrResponseHandling;
 use serde_json::{Map, Value, json};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -395,7 +395,7 @@ async fn ocr_lifecycle_runs_failure_hook_on_provider_error() {
     .await
     .expect_err("provider error propagates");
 
-    assert!(matches!(err, CoreError::Http { status: 500, .. }));
+    assert!(matches!(err, Error::Http { status: 500, .. }));
     server.await.expect("server task completes");
     assert_eq!(
         logger.events(),
@@ -439,7 +439,7 @@ async fn ocr_lifecycle_pre_call_block_skips_provider_socket() {
     .await
     .expect_err("guardrail blocks request");
 
-    assert!(matches!(err, CoreError::InvalidRequest(_)));
+    assert!(matches!(err, Error::InvalidRequest(_)));
     assert_eq!(guardrail.events(), vec!["async_pre_call_hook"]);
     assert_eq!(
         logger.events(),
@@ -607,7 +607,7 @@ fn string_headers_rejects_non_string_values() {
     let err = string_headers(Some(headers)).expect_err("non-string header rejected");
     assert_eq!(
         err,
-        CoreError::InvalidRequest(
+        Error::InvalidRequest(
             "OCR extra_headers.x-retry-count must be a string, got number".to_string()
         )
     );

--- a/litellm-rust/crates/ai-gateway/src/python/config.rs
+++ b/litellm-rust/crates/ai-gateway/src/python/config.rs
@@ -6,33 +6,31 @@
 //! (and recorded in [`crate::gil`]); the realtime hot path never touches Python.
 //!
 //! Compiled only under the `python-config` feature.
-
-use litellm_core::CoreResult;
-use litellm_core::error::CoreError;
+use litellm_core::error::Error;
 use litellm_core::router::{Deployment, Router};
 use pyo3::prelude::*;
 
 use crate::gil;
 
 /// Load the router's `model_list` from `config_path` via the Python reader.
-pub fn load_router_from_config(config_path: &str) -> CoreResult<Router> {
+pub fn load_router_from_config(config_path: &str) -> Result<Router, Error> {
     gil::record_acquisition();
     Python::attach(|py| {
         let model_list = py
             .import("litellm.proxy.read_model_list")
             .and_then(|module| module.getattr("read_model_list"))
             .and_then(|reader| reader.call1((config_path,)))
-            .map_err(|err| CoreError::Routing(format!("read_model_list failed: {err}")))?;
+            .map_err(|err| Error::Routing(format!("read_model_list failed: {err}")))?;
 
         let model_list_json: String = py
             .import("json")
             .and_then(|json| json.getattr("dumps"))
             .and_then(|dumps| dumps.call1((model_list,)))
             .and_then(|encoded| encoded.extract())
-            .map_err(|err| CoreError::Routing(format!("serializing model_list failed: {err}")))?;
+            .map_err(|err| Error::Routing(format!("serializing model_list failed: {err}")))?;
 
         let deployments: Vec<Deployment> = serde_json::from_str(&model_list_json)
-            .map_err(|err| CoreError::Routing(format!("parsing model_list failed: {err}")))?;
+            .map_err(|err| Error::Routing(format!("parsing model_list failed: {err}")))?;
 
         Ok(Router::new(deployments))
     })

--- a/litellm-rust/crates/ai-gateway/src/routes/messages/mod.rs
+++ b/litellm-rust/crates/ai-gateway/src/routes/messages/mod.rs
@@ -9,7 +9,7 @@ use axum::http::StatusCode;
 use axum::http::header::{CACHE_CONTROL, CONTENT_TYPE, HeaderMap, HeaderValue};
 use axum::response::{IntoResponse, Response};
 use axum::routing::post;
-use litellm_core::CoreError;
+use litellm_core::Error;
 use serde_json::{Map, Value};
 
 use crate::auth::RequireMasterKey;
@@ -46,7 +46,7 @@ fn stream_response(upstream: reqwest::Response) -> Result<Response, MessagesRout
     let mut response = Response::builder()
         .status(
             StatusCode::from_u16(upstream.status().as_u16()).map_err(|error| {
-                MessagesRouteError(CoreError::InvalidResponse(format!(
+                MessagesRouteError(Error::InvalidResponse(format!(
                     "invalid upstream response status: {error}"
                 )))
             })?,
@@ -58,13 +58,13 @@ fn stream_response(upstream: reqwest::Response) -> Result<Response, MessagesRout
     response
         .body(Body::from_stream(upstream.bytes_stream()))
         .map_err(|error| {
-            MessagesRouteError(CoreError::InvalidResponse(format!(
+            MessagesRouteError(Error::InvalidResponse(format!(
                 "failed to build streaming response: {error}"
             )))
         })
 }
 
-fn forwarded_headers(headers: &HeaderMap) -> Result<Option<Map<String, Value>>, CoreError> {
+fn forwarded_headers(headers: &HeaderMap) -> Result<Option<Map<String, Value>>, Error> {
     let forwarded = headers
         .iter()
         .filter(|(name, _)| {
@@ -74,19 +74,19 @@ fn forwarded_headers(headers: &HeaderMap) -> Result<Option<Map<String, Value>>, 
         })
         .map(|(name, value)| {
             let value = value.to_str().map_err(|_| {
-                CoreError::InvalidRequest(format!("invalid value for header {}", name.as_str()))
+                Error::InvalidRequest(format!("invalid value for header {}", name.as_str()))
             })?;
             Ok((name.to_string(), Value::String(value.to_string())))
         })
-        .collect::<Result<Map<_, _>, CoreError>>()?;
+        .collect::<Result<Map<_, _>, Error>>()?;
     Ok((!forwarded.is_empty()).then_some(forwarded))
 }
 
 #[derive(Debug)]
-struct MessagesRouteError(CoreError);
+struct MessagesRouteError(Error);
 
-impl From<CoreError> for MessagesRouteError {
-    fn from(error: CoreError) -> Self {
+impl From<Error> for MessagesRouteError {
+    fn from(error: Error) -> Self {
         Self(error)
     }
 }
@@ -94,28 +94,28 @@ impl From<CoreError> for MessagesRouteError {
 impl IntoResponse for MessagesRouteError {
     fn into_response(self) -> Response {
         let (status, message) = match self.0 {
-            CoreError::InvalidRequest(message) => (StatusCode::BAD_REQUEST, message),
-            CoreError::InvalidProvider(_) | CoreError::Routing(_) => (
+            Error::InvalidRequest(message) => (StatusCode::BAD_REQUEST, message),
+            Error::InvalidProvider(_) | Error::Routing(_) => (
                 StatusCode::NOT_FOUND,
                 "no messages deployment is configured for this model".to_string(),
             ),
-            CoreError::Auth(_) => (
+            Error::Auth(_) => (
                 StatusCode::BAD_GATEWAY,
                 "messages provider authentication failed".to_string(),
             ),
-            CoreError::Http { .. }
-            | CoreError::Network(_)
-            | CoreError::Connect(_)
-            | CoreError::InvalidResponse(_)
-            | CoreError::InvalidType { .. }
-            | CoreError::MissingField(_) => (
+            Error::Http { .. }
+            | Error::Network(_)
+            | Error::Connect(_)
+            | Error::InvalidResponse(_)
+            | Error::InvalidType { .. }
+            | Error::MissingField(_) => (
                 StatusCode::BAD_GATEWAY,
                 "messages provider request failed".to_string(),
             ),
             // The gateway has no Python implementation to decline to, so a
             // request the core cannot serve is reported to the caller. The
             // reason is a fixed internal string, never provider content.
-            CoreError::Unsupported(reason) => (
+            Error::Unsupported(reason) => (
                 StatusCode::BAD_REQUEST,
                 format!("messages request is not supported: {reason}"),
             ),

--- a/litellm-rust/crates/ai-gateway/src/routes/messages/service.rs
+++ b/litellm-rust/crates/ai-gateway/src/routes/messages/service.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
+use litellm_core::Error;
 use litellm_core::constants::ANTHROPIC_MESSAGES_PROVIDER;
 use litellm_core::messages::types::MessagesRequest;
 use litellm_core::messages::{messages, messages_stream};
 use litellm_core::router::Router;
-use litellm_core::{CoreError, CoreResult};
 use serde_json::{Map, Value};
 
 pub(crate) enum MessagesResponse {
@@ -16,16 +16,16 @@ pub async fn run(
     router: &Arc<Router>,
     body: Value,
     extra_headers: Option<Map<String, Value>>,
-) -> CoreResult<MessagesResponse> {
+) -> Result<MessagesResponse, Error> {
     let model = body
         .get("model")
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|model| !model.is_empty())
-        .ok_or_else(|| CoreError::InvalidRequest("messages body requires a model".to_string()))?;
-    let deployment = router.get_available_deployment(model).ok_or_else(|| {
-        CoreError::Routing(format!("no deployment available for model '{model}'"))
-    })?;
+        .ok_or_else(|| Error::InvalidRequest("messages body requires a model".to_string()))?;
+    let deployment = router
+        .get_available_deployment(model)
+        .ok_or_else(|| Error::Routing(format!("no deployment available for model '{model}'")))?;
     let provider_model = deployment.litellm_params.model.as_str();
     let upstream_model = provider_model
         .split_once('/')
@@ -37,7 +37,7 @@ pub async fn run(
     };
     let mut body = body;
     body.as_object_mut()
-        .ok_or_else(|| CoreError::InvalidRequest("messages body must be an object".to_string()))?
+        .ok_or_else(|| Error::InvalidRequest("messages body must be an object".to_string()))?
         .insert(
             "model".to_string(),
             Value::String(upstream_model.to_string()),
@@ -60,6 +60,6 @@ pub async fn run(
     serde_json::to_value(response)
         .map(MessagesResponse::Json)
         .map_err(|err| {
-            CoreError::InvalidResponse(format!("failed to serialize messages response: {err}"))
+            Error::InvalidResponse(format!("failed to serialize messages response: {err}"))
         })
 }

--- a/litellm-rust/crates/ai-gateway/src/routes/realtime/service.rs
+++ b/litellm-rust/crates/ai-gateway/src/routes/realtime/service.rs
@@ -11,8 +11,7 @@ use std::time::Duration;
 
 use crate::io::realtime_pool::{RealtimePool, upstream_key};
 use futures_util::{Sink, Stream};
-use litellm_core::CoreResult;
-use litellm_core::error::CoreError;
+use litellm_core::error::Error;
 use litellm_core::realtime::types::RealtimeEvent;
 use litellm_core::router::Router;
 
@@ -29,15 +28,15 @@ pub async fn run<In, Out>(
     observe: impl FnMut(&RealtimeEvent) + Send,
     client_in: In,
     client_out: Out,
-) -> CoreResult<()>
+) -> Result<(), Error>
 where
     In: Stream<Item = RealtimeEvent> + Unpin + Send,
     Out: Sink<RealtimeEvent> + Unpin + Send,
     <Out as Sink<RealtimeEvent>>::Error: std::fmt::Display,
 {
-    let deployment = router.get_available_deployment(model).ok_or_else(|| {
-        CoreError::Routing(format!("no deployment available for model '{model}'"))
-    })?;
+    let deployment = router
+        .get_available_deployment(model)
+        .ok_or_else(|| Error::Routing(format!("no deployment available for model '{model}'")))?;
     let params = &deployment.litellm_params;
     // Strip a leading `openai/` so the OpenAI-only realtime fn gets the bare model.
     let provider_model = params

--- a/litellm-rust/crates/ai-gateway/src/routes/responses/service.rs
+++ b/litellm-rust/crates/ai-gateway/src/routes/responses/service.rs
@@ -2,13 +2,13 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use futures_util::{Sink, Stream};
+use litellm_core::Error;
 use litellm_core::call_lifecycle::{CallLifecycle, CallLifecycleContext};
 use litellm_core::responses::instrumentation::{
     ResponsesWsCallbackPayload, ResponsesWsInstrumentation, ResponsesWsLogOutcome,
     ResponsesWsMetadata,
 };
 use litellm_core::responses::types::ResponsesWsEvent;
-use litellm_core::{CoreError, CoreResult};
 
 use crate::integrations::custom_logger::{
     CallbackTiming, CallbackValue, CustomLogger, CustomLoggerRunner, LoggingError, ModelCallDetails,
@@ -26,22 +26,22 @@ pub async fn run<In, Out>(
     metadata: RequestMetadata,
     client_in: In,
     client_out: Out,
-) -> CoreResult<()>
+) -> Result<(), Error>
 where
     In: Stream<Item = ResponsesWsEvent> + Unpin + Send,
     Out: Sink<ResponsesWsEvent> + Unpin + Send,
     Out::Error: std::fmt::Display,
 {
-    let deployment = router.get_available_deployment(model).ok_or_else(|| {
-        CoreError::Routing(format!("no deployment available for model '{model}'"))
-    })?;
+    let deployment = router
+        .get_available_deployment(model)
+        .ok_or_else(|| Error::Routing(format!("no deployment available for model '{model}'")))?;
     let params = &deployment.litellm_params;
     let provider_model = params
         .model
         .strip_prefix("openai/")
         .unwrap_or(&params.model);
     if params.model.contains('/') && !params.model.starts_with("openai/") {
-        return Err(CoreError::InvalidProvider(
+        return Err(Error::InvalidProvider(
             "Responses WebSocket route supports OpenAI deployments only".to_string(),
         ));
     }

--- a/litellm-rust/crates/core/src/audio_transcription/transformation.rs
+++ b/litellm-rust/crates/core/src/audio_transcription/transformation.rs
@@ -1,6 +1,5 @@
+use crate::Error;
 use serde_json::{Map, Value};
-
-use crate::CoreResult;
 
 use super::types::{AudioTranscriptionRequestData, AudioTranscriptionResponseData};
 
@@ -32,13 +31,13 @@ pub trait AudioTranscriptionProviderConfig: Sync {
         model: &str,
         audio: Value,
         optional_params: Map<String, Value>,
-    ) -> CoreResult<AudioTranscriptionRequestData>;
+    ) -> Result<AudioTranscriptionRequestData, Error>;
 
     fn transform_transcription_response(
         &self,
         model: &str,
         response_json: Value,
-    ) -> CoreResult<AudioTranscriptionResponseData>;
+    ) -> Result<AudioTranscriptionResponseData, Error>;
 
     fn complete_url(
         &self,
@@ -46,12 +45,12 @@ pub trait AudioTranscriptionProviderConfig: Sync {
         model: &str,
         optional_params: &Map<String, Value>,
         env_lookup: &dyn Fn(&str) -> Option<String>,
-    ) -> CoreResult<String>;
+    ) -> Result<String, Error>;
 
     fn auth_strategy(
         &self,
         model: &str,
         optional_params: &Map<String, Value>,
         env_lookup: &dyn Fn(&str) -> Option<String>,
-    ) -> CoreResult<AudioTranscriptionAuth>;
+    ) -> Result<AudioTranscriptionAuth, Error>;
 }

--- a/litellm-rust/crates/core/src/call_lifecycle/mod.rs
+++ b/litellm-rust/crates/core/src/call_lifecycle/mod.rs
@@ -1,7 +1,7 @@
 use std::future::Future;
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
-use crate::{CoreError, CoreResult};
+use crate::Error;
 
 pub mod types;
 
@@ -11,14 +11,14 @@ pub use types::{
 };
 
 pub trait CallLifecycleHooks<InitialReq, ProviderReq, Resp>: Send + Sync {
-    type PreCallFuture<'a>: Future<Output = CoreResult<InitialReq>> + Send + 'a
+    type PreCallFuture<'a>: Future<Output = Result<InitialReq, Error>> + Send + 'a
     where
         Self: 'a,
         InitialReq: 'a,
         ProviderReq: 'a,
         Resp: 'a;
 
-    type DuringCallFuture<'a>: Future<Output = CoreResult<ProviderReq>> + Send + 'a
+    type DuringCallFuture<'a>: Future<Output = Result<ProviderReq, Error>> + Send + 'a
     where
         Self: 'a,
         InitialReq: 'a,
@@ -56,7 +56,7 @@ pub trait CallLifecycleHooks<InitialReq, ProviderReq, Resp>: Send + Sync {
     fn async_log_failure_event<'a>(
         &'a self,
         context: &'a CallLifecycleContext,
-        error: &'a CoreError,
+        error: &'a Error,
         timing: &'a CallLifecycleTiming,
     ) -> Self::FailureFuture<'a>;
 }
@@ -86,12 +86,12 @@ impl<'a> CallLifecycle<'a> {
         request: InitialReq,
         hooks: &Hooks,
         provider_call: ProviderCall,
-    ) -> CoreResult<Resp>
+    ) -> Result<Resp, Error>
     where
         InitialReq: CallLifecycleRequest,
         Hooks: CallLifecycleHooks<InitialReq, ProviderReq, Resp>,
         ProviderCall: FnOnce(ProviderReq) -> ProviderFuture,
-        ProviderFuture: Future<Output = CoreResult<Resp>>,
+        ProviderFuture: Future<Output = Result<Resp, Error>>,
     {
         let context = request.lifecycle_context();
         self.run(context, request, hooks, provider_call).await
@@ -103,11 +103,11 @@ impl<'a> CallLifecycle<'a> {
         request: InitialReq,
         hooks: &Hooks,
         provider_call: ProviderCall,
-    ) -> CoreResult<Resp>
+    ) -> Result<Resp, Error>
     where
         Hooks: CallLifecycleHooks<InitialReq, ProviderReq, Resp>,
         ProviderCall: FnOnce(ProviderReq) -> ProviderFuture,
-        ProviderFuture: Future<Output = CoreResult<Resp>>,
+        ProviderFuture: Future<Output = Result<Resp, Error>>,
     {
         let call_start = epoch_seconds();
         let mut phases = Vec::new();
@@ -166,7 +166,7 @@ impl<'a> CallLifecycle<'a> {
         &self,
         context: &CallLifecycleContext,
         hooks: &Hooks,
-        error: &CoreError,
+        error: &Error,
         call_start: f64,
         phases: &mut Vec<CallLifecyclePhaseTiming>,
     ) where
@@ -251,8 +251,8 @@ mod tests {
     }
 
     impl CallLifecycleHooks<String, String, String> for RecordingHooks {
-        type PreCallFuture<'a> = BoxFuture<'a, CoreResult<String>>;
-        type DuringCallFuture<'a> = BoxFuture<'a, CoreResult<String>>;
+        type PreCallFuture<'a> = BoxFuture<'a, Result<String, Error>>;
+        type DuringCallFuture<'a> = BoxFuture<'a, Result<String, Error>>;
         type SuccessFuture<'a> = BoxFuture<'a, ()>;
         type FailureFuture<'a> = BoxFuture<'a, ()>;
 
@@ -294,7 +294,7 @@ mod tests {
         fn async_log_failure_event<'a>(
             &'a self,
             _context: &'a CallLifecycleContext,
-            _error: &'a CoreError,
+            _error: &'a Error,
             _timing: &'a CallLifecycleTiming,
         ) -> Self::FailureFuture<'a> {
             Box::pin(async move {
@@ -304,8 +304,8 @@ mod tests {
     }
 
     impl CallLifecycleHooks<RecordingRequest, String, String> for RecordingHooks {
-        type PreCallFuture<'a> = BoxFuture<'a, CoreResult<RecordingRequest>>;
-        type DuringCallFuture<'a> = BoxFuture<'a, CoreResult<String>>;
+        type PreCallFuture<'a> = BoxFuture<'a, Result<RecordingRequest, Error>>;
+        type DuringCallFuture<'a> = BoxFuture<'a, Result<String, Error>>;
         type SuccessFuture<'a> = BoxFuture<'a, ()>;
         type FailureFuture<'a> = BoxFuture<'a, ()>;
 
@@ -345,7 +345,7 @@ mod tests {
         fn async_log_failure_event<'a>(
             &'a self,
             _context: &'a CallLifecycleContext,
-            _error: &'a CoreError,
+            _error: &'a Error,
             _timing: &'a CallLifecycleTiming,
         ) -> Self::FailureFuture<'a> {
             Box::pin(async move {
@@ -383,13 +383,13 @@ mod tests {
                 "request".to_string(),
                 &hooks,
                 |_request| async move {
-                    Err::<String, CoreError>(CoreError::Network("provider down".to_string()))
+                    Err::<String, Error>(Error::Network("provider down".to_string()))
                 },
             )
             .await
             .expect_err("call fails");
 
-        assert_eq!(error, CoreError::Network("provider down".to_string()));
+        assert_eq!(error, Error::Network("provider down".to_string()));
         assert_eq!(hooks.events(), vec!["pre_call", "during_call", "failure"]);
     }
 

--- a/litellm-rust/crates/core/src/chat_completions/common_utils.rs
+++ b/litellm-rust/crates/core/src/chat_completions/common_utils.rs
@@ -1,8 +1,7 @@
-use serde_json::{Map, Value};
-
-use crate::error::CoreResult;
+use crate::Error;
 use crate::http_utils::string_headers as shared_string_headers;
 use crate::providers::anthropic::chat_completions::transformation::ANTHROPIC_CHAT_COMPLETIONS_CONFIG;
+use serde_json::{Map, Value};
 
 use super::transformation::ChatCompletionsProviderConfig;
 
@@ -23,6 +22,6 @@ pub(super) fn chat_completions_provider_config(
 
 pub(super) fn string_headers(
     extra_headers: Option<Map<String, Value>>,
-) -> CoreResult<Vec<(String, String)>> {
+) -> Result<Vec<(String, String)>, Error> {
     shared_string_headers(HEADER_CONTEXT, extra_headers)
 }

--- a/litellm-rust/crates/core/src/chat_completions/handler.rs
+++ b/litellm-rust/crates/core/src/chat_completions/handler.rs
@@ -1,6 +1,6 @@
 use serde_json::Value;
 
-use crate::error::{CoreError, CoreResult};
+use crate::error::Error;
 use crate::http_utils::truncate_error_body;
 
 use super::client::http_client;
@@ -11,9 +11,9 @@ use super::types::{
 
 pub(super) async fn execute_chat_completions_provider_call(
     request: ProviderChatCompletionsRequest,
-) -> CoreResult<ChatCompletionsResponse> {
+) -> Result<ChatCompletionsResponse, Error> {
     let body = serde_json::to_vec(&request.body).map_err(|err| {
-        CoreError::InvalidRequest(format!(
+        Error::InvalidRequest(format!(
             "failed to serialize chat completions request: {err}"
         ))
     })?;
@@ -32,9 +32,9 @@ pub(super) async fn execute_chat_completions_provider_call(
         // so the host can still serve it. Everything else here, a timeout
         // above all, may have reached the provider and been answered.
         if err.is_connect() || err.is_builder() {
-            CoreError::Connect(err.to_string())
+            Error::Connect(err.to_string())
         } else {
-            CoreError::Network(err.to_string())
+            Error::Network(err.to_string())
         }
     })?;
 
@@ -42,17 +42,17 @@ pub(super) async fn execute_chat_completions_provider_call(
     let text = response
         .text()
         .await
-        .map_err(|err| CoreError::Network(err.to_string()))?;
+        .map_err(|err| Error::Network(err.to_string()))?;
 
     if !status.is_success() {
-        return Err(CoreError::Http {
+        return Err(Error::Http {
             status: status.as_u16(),
             body: truncate_error_body(&text),
         });
     }
 
     let body: Value = serde_json::from_str(&text).map_err(|err| {
-        CoreError::InvalidResponse(format!("invalid chat completions response JSON: {err}"))
+        Error::InvalidResponse(format!("invalid chat completions response JSON: {err}"))
     })?;
     request
         .config
@@ -69,10 +69,10 @@ pub(super) async fn execute_chat_completions_provider_call(
 /// second kind has already been billed, and a host that keeps a reference
 /// implementation must not retry those, so collapse them to one variant that
 /// can only mean the provider was already called.
-pub(super) fn as_response_error(err: CoreError) -> CoreError {
+pub(super) fn as_response_error(err: Error) -> Error {
     match err {
-        already @ (CoreError::InvalidResponse(_) | CoreError::Http { .. }) => already,
-        other => CoreError::InvalidResponse(other.to_string()),
+        already @ (Error::InvalidResponse(_) | Error::Http { .. }) => already,
+        other => Error::InvalidResponse(other.to_string()),
     }
 }
 
@@ -80,7 +80,7 @@ pub(super) fn as_response_error(err: CoreError) -> CoreError {
 pub(super) async fn signed_headers(
     request: &ProviderChatCompletionsRequest,
     body: &[u8],
-) -> CoreResult<Vec<(String, String)>> {
+) -> Result<Vec<(String, String)>, Error> {
     use std::collections::BTreeMap;
     use std::time::SystemTime;
 
@@ -101,7 +101,7 @@ pub(super) async fn signed_headers(
         .iter()
         .any(|(name, _)| is_sigv4_computed_header(name))
     {
-        return Err(CoreError::Unsupported(
+        return Err(Error::Unsupported(
             "request forwards a header AWS SigV4 computes",
         ));
     }
@@ -137,9 +137,9 @@ pub(super) async fn signed_headers(
 pub(super) async fn signed_headers(
     request: &ProviderChatCompletionsRequest,
     _body: &[u8],
-) -> CoreResult<Vec<(String, String)>> {
+) -> Result<Vec<(String, String)>, Error> {
     match &request.auth {
-        ChatCompletionsAuth::AwsSigV4 { .. } => Err(CoreError::Unsupported(
+        ChatCompletionsAuth::AwsSigV4 { .. } => Err(Error::Unsupported(
             "AWS SigV4 requires the bedrock-auth feature",
         )),
         _ => Ok(request.upstream_headers.clone()),

--- a/litellm-rust/crates/core/src/chat_completions/mod.rs
+++ b/litellm-rust/crates/core/src/chat_completions/mod.rs
@@ -6,6 +6,7 @@
 //! credentials, and it resolves the provider, translates the conversation,
 //! calls the provider, and returns a typed OpenAI-shaped response.
 
+use crate::Error;
 mod client;
 mod common_utils;
 pub mod conversation;
@@ -17,15 +18,13 @@ pub mod types;
 
 use serde_json::{Map, Value};
 
-use crate::error::CoreResult;
-
 use handler::execute_chat_completions_provider_call;
 use prepare::{parse_messages, prepare_chat_completions_call, resolve_provider_config};
 use types::{ChatCompletionsRequest, ChatCompletionsResponse};
 
 pub async fn chat_completions(
     request: ChatCompletionsRequest<'_>,
-) -> CoreResult<ChatCompletionsResponse> {
+) -> Result<ChatCompletionsResponse, Error> {
     execute_chat_completions_provider_call(prepare_chat_completions_call(request)?).await
 }
 

--- a/litellm-rust/crates/core/src/chat_completions/prepare.rs
+++ b/litellm-rust/crates/core/src/chat_completions/prepare.rs
@@ -1,6 +1,6 @@
 use serde_json::Value;
 
-use crate::error::{CoreError, CoreResult};
+use crate::error::Error;
 use crate::http_utils::has_header;
 use crate::routing_utils::provider::{CustomLlmProvider, get_custom_llm_provider};
 
@@ -11,7 +11,7 @@ use super::types::{ChatCompletionsRequest, ChatMessage, ProviderChatCompletionsR
 pub(super) fn resolve_provider_config<'a>(
     model: &'a str,
     custom_llm_provider: Option<&'a str>,
-) -> CoreResult<(String, &'static dyn ChatCompletionsProviderConfig)> {
+) -> Result<(String, &'static dyn ChatCompletionsProviderConfig), Error> {
     let provider_info = get_custom_llm_provider(model, custom_llm_provider)
         .or_else(|| {
             custom_llm_provider.map(|provider| CustomLlmProvider {
@@ -20,35 +20,34 @@ pub(super) fn resolve_provider_config<'a>(
             })
         })
         .ok_or_else(|| {
-            CoreError::InvalidProvider(
+            Error::InvalidProvider(
                 "unable to resolve custom_llm_provider for chat completions request".to_string(),
             )
         })?;
     let config = chat_completions_provider_config(provider_info.custom_llm_provider)
-        .ok_or_else(|| CoreError::InvalidProvider(provider_info.custom_llm_provider.to_string()))?;
+        .ok_or_else(|| Error::InvalidProvider(provider_info.custom_llm_provider.to_string()))?;
     Ok((provider_info.model.to_string(), config))
 }
 
-pub(super) fn parse_messages(messages: Value) -> CoreResult<Vec<ChatMessage>> {
-    serde_json::from_value(messages).map_err(|err| {
-        CoreError::InvalidRequest(format!("invalid chat completions messages: {err}"))
-    })
+pub(super) fn parse_messages(messages: Value) -> Result<Vec<ChatMessage>, Error> {
+    serde_json::from_value(messages)
+        .map_err(|err| Error::InvalidRequest(format!("invalid chat completions messages: {err}")))
 }
 
 pub(super) fn prepare_chat_completions_call(
     request: ChatCompletionsRequest<'_>,
-) -> CoreResult<ProviderChatCompletionsRequest> {
+) -> Result<ProviderChatCompletionsRequest, Error> {
     let (model, config) = resolve_provider_config(request.model, request.custom_llm_provider)?;
     let env_lookup = |key: &str| std::env::var(key).ok();
 
     let messages = parse_messages(request.messages)?;
     if messages.is_empty() {
-        return Err(CoreError::InvalidRequest(
+        return Err(Error::InvalidRequest(
             "chat completions requires at least one message".to_string(),
         ));
     }
     if let Some(reason) = config.unsupported_reason(&messages, &request.optional_params) {
-        return Err(CoreError::Unsupported(reason.0));
+        return Err(Error::Unsupported(reason.0));
     }
 
     let mut headers = string_headers(request.extra_headers)?;

--- a/litellm-rust/crates/core/src/chat_completions/tests.rs
+++ b/litellm-rust/crates/core/src/chat_completions/tests.rs
@@ -1,6 +1,6 @@
 use serde_json::{Map, Value, json};
 
-use crate::error::CoreError;
+use crate::error::Error;
 
 use super::prepare::prepare_chat_completions_call;
 use super::transformation::ChatCompletionsAuth;
@@ -29,7 +29,7 @@ fn request<'a>(
 
 /// `ProviderChatCompletionsRequest` deliberately has no `Debug` (its headers
 /// carry resolved credentials), so unwrap the failure case by hand.
-fn decline(request: ChatCompletionsRequest<'_>) -> CoreError {
+fn decline(request: ChatCompletionsRequest<'_>) -> Error {
     match prepare_chat_completions_call(request) {
         Err(error) => error,
         Ok(prepared) => panic!("expected a decline, prepared a call to {}", prepared.url),
@@ -196,7 +196,7 @@ fn declines_an_unsupported_request_before_resolving_credentials() {
     call.api_key = None;
     // No api_key is set and no env is consulted: the gate must run first, so the
     // error is the decline rather than a missing-credential error.
-    assert_eq!(decline(call), CoreError::Unsupported("streaming"));
+    assert_eq!(decline(call), Error::Unsupported("streaming"));
 }
 
 #[test]
@@ -208,7 +208,7 @@ fn rejects_an_unknown_provider() {
             json!([{"role": "user", "content": "hi"}]),
             json!({}),
         )),
-        CoreError::InvalidProvider("openai".to_string())
+        Error::InvalidProvider("openai".to_string())
     );
 }
 
@@ -221,7 +221,7 @@ fn rejects_a_model_with_no_resolvable_provider() {
             json!([{"role": "user", "content": "hi"}]),
             json!({}),
         )),
-        CoreError::InvalidProvider(_)
+        Error::InvalidProvider(_)
     ));
 }
 
@@ -234,7 +234,7 @@ fn rejects_an_empty_or_malformed_message_list() {
             json!([]),
             json!({}),
         )),
-        CoreError::InvalidRequest("chat completions requires at least one message".to_string())
+        Error::InvalidRequest("chat completions requires at least one message".to_string())
     );
     assert!(matches!(
         decline(request(
@@ -243,7 +243,7 @@ fn rejects_an_empty_or_malformed_message_list() {
             json!("not a list"),
             json!({}),
         )),
-        CoreError::InvalidRequest(_)
+        Error::InvalidRequest(_)
     ));
 }
 
@@ -258,7 +258,7 @@ fn rejects_non_string_extra_headers() {
     call.extra_headers = Some(Map::from_iter([("x-trace".to_string(), json!(7))]));
     assert_eq!(
         decline(call),
-        CoreError::InvalidRequest(
+        Error::InvalidRequest(
             "chat completions extra_headers.x-trace must be a string, got number".to_string()
         )
     );
@@ -374,7 +374,7 @@ async fn a_forwarded_header_the_signer_computes_declines_to_python() {
             .await
             .expect_err("{forwarded} should decline instead of being signed");
         assert!(
-            matches!(error, CoreError::Unsupported(_)),
+            matches!(error, Error::Unsupported(_)),
             "{forwarded} declined as {error:?}, which the host would not fall back on"
         );
     }
@@ -727,7 +727,7 @@ mod round_trip {
         .expect_err("response cannot be normalized");
         handle.await.expect("server task");
         assert!(
-            matches!(err, CoreError::InvalidResponse(_)),
+            matches!(err, Error::InvalidResponse(_)),
             "expected a post-send error, got {err:?}"
         );
     }
@@ -745,7 +745,7 @@ mod round_trip {
         .expect_err("response cannot be normalized");
         handle.await.expect("server task");
         assert!(
-            matches!(err, CoreError::InvalidResponse(_)),
+            matches!(err, Error::InvalidResponse(_)),
             "expected a post-send error, got {err:?}"
         );
     }
@@ -763,7 +763,7 @@ mod round_trip {
         .expect_err("upstream rejects");
         handle.await.expect("server task");
         assert!(
-            matches!(err, CoreError::Http { status: 429, .. }),
+            matches!(err, Error::Http { status: 429, .. }),
             "expected a 429, got {err:?}"
         );
     }
@@ -787,7 +787,7 @@ mod round_trip {
         .await
         .expect_err("nothing is listening");
         assert!(
-            matches!(err, CoreError::Connect(_)),
+            matches!(err, Error::Connect(_)),
             "expected a pre-send connect failure, got {err:?}"
         );
     }
@@ -797,24 +797,24 @@ mod round_trip {
         use crate::chat_completions::handler::as_response_error;
 
         for original in [
-            CoreError::MissingField("usage"),
-            CoreError::Unsupported("non-text response content block"),
-            CoreError::InvalidRequest("whatever".to_string()),
-            CoreError::Auth("whatever".to_string()),
+            Error::MissingField("usage"),
+            Error::Unsupported("non-text response content block"),
+            Error::InvalidRequest("whatever".to_string()),
+            Error::Auth("whatever".to_string()),
         ] {
             let label = format!("{original:?}");
             assert!(
-                matches!(as_response_error(original), CoreError::InvalidResponse(_)),
+                matches!(as_response_error(original), Error::InvalidResponse(_)),
                 "{label} must not stay retryable once the provider has answered"
             );
         }
         // An upstream status is already unambiguous, so it survives intact.
         assert!(matches!(
-            as_response_error(CoreError::Http {
+            as_response_error(Error::Http {
                 status: 500,
                 body: "boom".to_string()
             }),
-            CoreError::Http { status: 500, .. }
+            Error::Http { status: 500, .. }
         ));
     }
 }

--- a/litellm-rust/crates/core/src/chat_completions/transformation.rs
+++ b/litellm-rust/crates/core/src/chat_completions/transformation.rs
@@ -1,6 +1,5 @@
+use crate::Error;
 use serde_json::{Map, Value};
-
-use crate::error::CoreResult;
 
 use super::types::{
     ChatCompletionsResponse, ChatMessage, ChatMessageContent, ProviderChatRequestData,
@@ -39,7 +38,7 @@ pub trait ChatCompletionsProviderConfig: Sync {
         model: &str,
         optional_params: &Map<String, Value>,
         env_lookup: &dyn Fn(&str) -> Option<String>,
-    ) -> CoreResult<String>;
+    ) -> Result<String, Error>;
 
     fn auth(
         &self,
@@ -47,7 +46,7 @@ pub trait ChatCompletionsProviderConfig: Sync {
         model: &str,
         optional_params: &Map<String, Value>,
         env_lookup: &dyn Fn(&str) -> Option<String>,
-    ) -> CoreResult<ChatCompletionsAuth>;
+    ) -> Result<ChatCompletionsAuth, Error>;
 
     fn default_headers(&self) -> &'static [(&'static str, &'static str)] {
         &[("content-type", "application/json")]
@@ -91,13 +90,13 @@ pub trait ChatCompletionsProviderConfig: Sync {
         model: &str,
         messages: Vec<ChatMessage>,
         optional_params: Map<String, Value>,
-    ) -> CoreResult<ProviderChatRequestData>;
+    ) -> Result<ProviderChatRequestData, Error>;
 
     fn transform_response(
         &self,
         model: &str,
         response: ProviderChatResponseData,
-    ) -> CoreResult<ChatCompletionsResponse>;
+    ) -> Result<ChatCompletionsResponse, Error>;
 }
 
 pub fn unsupported_param(

--- a/litellm-rust/crates/core/src/error.rs
+++ b/litellm-rust/crates/core/src/error.rs
@@ -1,9 +1,7 @@
-use thiserror::Error;
+use thiserror::Error as ThisError;
 
-pub type CoreResult<T> = Result<T, CoreError>;
-
-#[derive(Debug, Error, PartialEq, Eq)]
-pub enum CoreError {
+#[derive(Debug, ThisError, PartialEq, Eq)]
+pub enum Error {
     #[error("expected {expected}, got {actual}")]
     InvalidType {
         expected: &'static str,

--- a/litellm-rust/crates/core/src/http_utils.rs
+++ b/litellm-rust/crates/core/src/http_utils.rs
@@ -3,7 +3,7 @@
 use serde_json::{Map, Value};
 
 use crate::constants::UPSTREAM_ERROR_BODY_MAX_CHARS;
-use crate::error::{CoreError, CoreResult, json_type_name};
+use crate::error::{Error, json_type_name};
 
 /// Bound an upstream error body before it crosses a host boundary, so provider
 /// bodies stay data-minimized.
@@ -18,7 +18,7 @@ pub fn truncate_error_body(body: &str) -> String {
 pub fn string_headers(
     context: &'static str,
     extra_headers: Option<Map<String, Value>>,
-) -> CoreResult<Vec<(String, String)>> {
+) -> Result<Vec<(String, String)>, Error> {
     extra_headers
         .unwrap_or_default()
         .into_iter()
@@ -27,7 +27,7 @@ pub fn string_headers(
                 .as_str()
                 .map(|value| (key.clone(), value.to_string()))
                 .ok_or_else(|| {
-                    CoreError::InvalidRequest(format!(
+                    Error::InvalidRequest(format!(
                         "{context} extra_headers.{key} must be a string, got {}",
                         json_type_name(&value)
                     ))
@@ -81,7 +81,7 @@ mod tests {
         let err = string_headers("chat completions", Some(headers)).expect_err("non-string value");
         assert_eq!(
             err,
-            CoreError::InvalidRequest(
+            Error::InvalidRequest(
                 "chat completions extra_headers.x-trace must be a string, got number".to_string()
             )
         );

--- a/litellm-rust/crates/core/src/lib.rs
+++ b/litellm-rust/crates/core/src/lib.rs
@@ -13,4 +13,4 @@ pub mod responses;
 pub mod router;
 pub mod routing_utils;
 
-pub use error::{CoreError, CoreResult};
+pub use error::Error;

--- a/litellm-rust/crates/core/src/messages/common_utils.rs
+++ b/litellm-rust/crates/core/src/messages/common_utils.rs
@@ -1,9 +1,8 @@
-use serde_json::{Map, Value};
-
-use crate::error::CoreResult;
+use crate::Error;
 use crate::http_utils::string_headers as shared_string_headers;
 use crate::providers::anthropic::messages::transformation::ANTHROPIC_MESSAGES_CONFIG;
 use crate::providers::azure_ai::messages::transformation::AZURE_ANTHROPIC_MESSAGES_CONFIG;
+use serde_json::{Map, Value};
 
 use super::transformation::AnthropicMessagesProviderConfig;
 
@@ -23,6 +22,6 @@ pub(super) fn messages_provider_config(
 
 pub(super) fn string_headers(
     extra_headers: Option<Map<String, Value>>,
-) -> CoreResult<Vec<(String, String)>> {
+) -> Result<Vec<(String, String)>, Error> {
     shared_string_headers(HEADER_CONTEXT, extra_headers)
 }

--- a/litellm-rust/crates/core/src/messages/handler.rs
+++ b/litellm-rust/crates/core/src/messages/handler.rs
@@ -1,5 +1,5 @@
 use crate::constants::ANTHROPIC_MESSAGES_PROVIDER;
-use crate::error::{CoreError, CoreResult};
+use crate::error::Error;
 
 use super::client::http_client;
 use super::common_utils::truncate_error_body;
@@ -7,7 +7,7 @@ use super::types::{AnthropicMessagesResponse, ProviderMessagesRequest};
 
 pub(super) async fn execute_messages_provider_call(
     request: ProviderMessagesRequest,
-) -> CoreResult<AnthropicMessagesResponse> {
+) -> Result<AnthropicMessagesResponse, Error> {
     let mut request_builder = http_client().post(&request.url).json(&request.body);
     for (key, value) in &request.upstream_headers {
         request_builder = request_builder.header(key, value);
@@ -19,32 +19,31 @@ pub(super) async fn execute_messages_provider_call(
     let response = request_builder
         .send()
         .await
-        .map_err(|err| CoreError::Network(err.to_string()))?;
+        .map_err(|err| Error::Network(err.to_string()))?;
 
     let status = response.status();
     let text = response
         .text()
         .await
-        .map_err(|err| CoreError::Network(err.to_string()))?;
+        .map_err(|err| Error::Network(err.to_string()))?;
 
     if !status.is_success() {
-        return Err(CoreError::Http {
+        return Err(Error::Http {
             status: status.as_u16(),
             body: truncate_error_body(&text),
         });
     }
 
-    let response = serde_json::from_str(&text).map_err(|err| {
-        CoreError::InvalidResponse(format!("invalid messages response JSON: {err}"))
-    })?;
+    let response = serde_json::from_str(&text)
+        .map_err(|err| Error::InvalidResponse(format!("invalid messages response JSON: {err}")))?;
     request.config.transform_response(&request.model, response)
 }
 
 pub(super) async fn execute_messages_provider_stream(
     request: ProviderMessagesRequest,
-) -> CoreResult<reqwest::Response> {
+) -> Result<reqwest::Response, Error> {
     if request.provider != ANTHROPIC_MESSAGES_PROVIDER {
-        return Err(CoreError::InvalidRequest(
+        return Err(Error::InvalidRequest(
             "streaming messages is not supported for this provider".to_string(),
         ));
     }
@@ -60,14 +59,14 @@ pub(super) async fn execute_messages_provider_stream(
     let response = request_builder
         .send()
         .await
-        .map_err(|err| CoreError::Network(err.to_string()))?;
+        .map_err(|err| Error::Network(err.to_string()))?;
     let status = response.status();
     if !status.is_success() {
         let text = response
             .text()
             .await
-            .map_err(|err| CoreError::Network(err.to_string()))?;
-        return Err(CoreError::Http {
+            .map_err(|err| Error::Network(err.to_string()))?;
+        return Err(Error::Http {
             status: status.as_u16(),
             body: truncate_error_body(&text),
         });

--- a/litellm-rust/crates/core/src/messages/mod.rs
+++ b/litellm-rust/crates/core/src/messages/mod.rs
@@ -7,6 +7,7 @@
 //! is the streaming variant; it hands the raw upstream response back so a host
 //! can splice the event stream to its own caller.
 
+use crate::Error;
 mod client;
 mod common_utils;
 mod handler;
@@ -14,17 +15,15 @@ mod prepare;
 pub mod transformation;
 pub mod types;
 
-use crate::error::CoreResult;
-
 use handler::{execute_messages_provider_call, execute_messages_provider_stream};
 use prepare::prepare_messages_call;
 use types::{AnthropicMessagesResponse, MessagesRequest};
 
-pub async fn messages(request: MessagesRequest<'_>) -> CoreResult<AnthropicMessagesResponse> {
+pub async fn messages(request: MessagesRequest<'_>) -> Result<AnthropicMessagesResponse, Error> {
     execute_messages_provider_call(prepare_messages_call(request)?).await
 }
 
-pub async fn messages_stream(request: MessagesRequest<'_>) -> CoreResult<reqwest::Response> {
+pub async fn messages_stream(request: MessagesRequest<'_>) -> Result<reqwest::Response, Error> {
     execute_messages_provider_stream(prepare_messages_call(request)?).await
 }
 

--- a/litellm-rust/crates/core/src/messages/prepare.rs
+++ b/litellm-rust/crates/core/src/messages/prepare.rs
@@ -1,4 +1,4 @@
-use crate::error::{CoreError, CoreResult};
+use crate::error::Error;
 use crate::routing_utils::provider::{CustomLlmProvider, get_custom_llm_provider};
 
 use super::common_utils::{has_bearer_auth, has_header, messages_provider_config, string_headers};
@@ -7,7 +7,7 @@ use super::types::{MessagesRequest, ProviderMessagesRequest};
 
 pub(super) fn prepare_messages_call(
     request: MessagesRequest<'_>,
-) -> CoreResult<ProviderMessagesRequest> {
+) -> Result<ProviderMessagesRequest, Error> {
     let provider_info = get_custom_llm_provider(request.model, request.custom_llm_provider)
         .or_else(|| {
             request
@@ -18,7 +18,7 @@ pub(super) fn prepare_messages_call(
                 })
         })
         .ok_or_else(|| {
-            CoreError::InvalidProvider(
+            Error::InvalidProvider(
                 "unable to resolve custom_llm_provider for messages request".to_string(),
             )
         })?;
@@ -26,7 +26,7 @@ pub(super) fn prepare_messages_call(
     let provider = provider_info.custom_llm_provider;
 
     let config = messages_provider_config(provider)
-        .ok_or_else(|| CoreError::InvalidProvider(provider.to_string()))?;
+        .ok_or_else(|| Error::InvalidProvider(provider.to_string()))?;
     let env_lookup = |key: &str| std::env::var(key).ok();
 
     let mut headers = string_headers(request.extra_headers)?;
@@ -53,11 +53,11 @@ pub(super) fn prepare_messages_call(
 
     let url = config.complete_url(request.api_base, &model, &env_lookup)?;
     let typed_request = serde_json::from_value(request.body).map_err(|err| {
-        CoreError::InvalidRequest(format!("invalid Anthropic messages request: {err}"))
+        Error::InvalidRequest(format!("invalid Anthropic messages request: {err}"))
     })?;
     let transformed = config.transform_request(typed_request)?;
     let body = serde_json::to_value(transformed).map_err(|err| {
-        CoreError::InvalidRequest(format!(
+        Error::InvalidRequest(format!(
             "failed to serialize Anthropic messages request: {err}"
         ))
     })?;

--- a/litellm-rust/crates/core/src/messages/tests.rs
+++ b/litellm-rust/crates/core/src/messages/tests.rs
@@ -4,7 +4,7 @@ use serde_json::{Map, Value, json};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 
-use crate::error::CoreError;
+use crate::error::Error;
 
 use super::common_utils::{
     has_bearer_auth, has_header, messages_provider_config, string_headers, truncate_error_body,
@@ -77,7 +77,7 @@ fn truncate_error_body_caps_long_payloads() {
 fn string_headers_rejects_non_string_values() {
     let headers = json!({"x-count": 3}).as_object().unwrap().clone();
     let err = string_headers(Some(headers)).expect_err("non-string header rejected");
-    assert!(matches!(err, CoreError::InvalidRequest(_)));
+    assert!(matches!(err, Error::InvalidRequest(_)));
 }
 
 #[test]
@@ -341,7 +341,7 @@ async fn messages_requires_auth_when_no_key_and_no_header() {
     .await
     .expect_err("missing auth errors");
 
-    assert!(matches!(err, CoreError::Auth(_)));
+    assert!(matches!(err, Error::Auth(_)));
 }
 
 #[tokio::test]
@@ -420,7 +420,7 @@ async fn messages_maps_provider_error_status_to_http_error() {
     .await
     .expect_err("provider error propagates");
 
-    assert!(matches!(err, CoreError::Http { status: 401, .. }));
+    assert!(matches!(err, Error::Http { status: 401, .. }));
 }
 
 #[tokio::test]
@@ -437,5 +437,5 @@ async fn messages_rejects_unsupported_provider() {
     .await
     .expect_err("unsupported provider errors");
 
-    assert!(matches!(err, CoreError::InvalidProvider(provider) if provider == "openai"));
+    assert!(matches!(err, Error::InvalidProvider(provider) if provider == "openai"));
 }

--- a/litellm-rust/crates/core/src/messages/transformation.rs
+++ b/litellm-rust/crates/core/src/messages/transformation.rs
@@ -1,6 +1,5 @@
-use crate::error::CoreResult;
-
 use super::types::{AnthropicMessagesRequest, AnthropicMessagesResponse};
+use crate::Error;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum MessagesAuthStrategy {
@@ -23,13 +22,13 @@ pub trait AnthropicMessagesProviderConfig: Sync {
         api_base: Option<&str>,
         model: &str,
         env_lookup: &dyn Fn(&str) -> Option<String>,
-    ) -> CoreResult<String>;
+    ) -> Result<String, Error>;
 
     fn resolve_api_key(
         &self,
         api_key: Option<&str>,
         env_lookup: &dyn Fn(&str) -> Option<String>,
-    ) -> CoreResult<String>;
+    ) -> Result<String, Error>;
 
     fn auth_strategy(&self) -> MessagesAuthStrategy {
         MessagesAuthStrategy::Header("x-api-key")
@@ -49,7 +48,7 @@ pub trait AnthropicMessagesProviderConfig: Sync {
     fn transform_request(
         &self,
         request: AnthropicMessagesRequest,
-    ) -> CoreResult<AnthropicMessagesRequest> {
+    ) -> Result<AnthropicMessagesRequest, Error> {
         Ok(request)
     }
 
@@ -57,7 +56,7 @@ pub trait AnthropicMessagesProviderConfig: Sync {
         &self,
         _model: &str,
         response: AnthropicMessagesResponse,
-    ) -> CoreResult<AnthropicMessagesResponse> {
+    ) -> Result<AnthropicMessagesResponse, Error> {
         Ok(response)
     }
 }

--- a/litellm-rust/crates/core/src/ocr/transformation.rs
+++ b/litellm-rust/crates/core/src/ocr/transformation.rs
@@ -1,6 +1,5 @@
+use crate::Error;
 use serde_json::{Map, Value};
-
-use crate::CoreResult;
 
 use super::types::{OcrRequestData, OcrResponseData};
 
@@ -43,13 +42,13 @@ pub trait OcrProviderConfig: Sync {
         model: &str,
         document: Value,
         optional_params: Map<String, Value>,
-    ) -> CoreResult<OcrRequestData>;
+    ) -> Result<OcrRequestData, Error>;
 
     fn transform_ocr_response(
         &self,
         model: &str,
         response_json: Value,
-    ) -> CoreResult<OcrResponseData>;
+    ) -> Result<OcrResponseData, Error>;
 
     fn complete_url(
         &self,
@@ -57,13 +56,13 @@ pub trait OcrProviderConfig: Sync {
         model: &str,
         optional_params: &Map<String, Value>,
         env_lookup: &dyn Fn(&str) -> Option<String>,
-    ) -> CoreResult<String>;
+    ) -> Result<String, Error>;
 
     fn resolve_api_key(
         &self,
         api_key: Option<&str>,
         env_lookup: &dyn Fn(&str) -> Option<String>,
-    ) -> CoreResult<String>;
+    ) -> Result<String, Error>;
 
     fn auth_strategy(&self) -> OcrAuthStrategy {
         OcrAuthStrategy::Bearer

--- a/litellm-rust/crates/core/src/providers/anthropic/chat_completions/tests.rs
+++ b/litellm-rust/crates/core/src/providers/anthropic/chat_completions/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::Error;
 use serde_json::json;
 
 fn messages(value: Value) -> Vec<ChatMessage> {
@@ -19,7 +20,7 @@ fn transform(model: &str, msgs: Value, opts: Value) -> Value {
         .body
 }
 
-fn transform_response(body: Value) -> CoreResult<ChatCompletionsResponse> {
+fn transform_response(body: Value) -> Result<ChatCompletionsResponse, Error> {
     ANTHROPIC_CHAT_COMPLETIONS_CONFIG
         .transform_response("claude-sonnet-4-5", ProviderChatResponseData { body })
 }
@@ -390,29 +391,26 @@ fn declines_a_response_carrying_a_non_text_block() {
         "usage": {"input_tokens": 1, "output_tokens": 1}
     }))
     .expect_err("non-text block");
-    assert_eq!(
-        err,
-        CoreError::Unsupported("non-text response content block")
-    );
+    assert_eq!(err, Error::Unsupported("non-text response content block"));
 }
 
 #[test]
 fn errors_on_a_response_missing_required_fields() {
     assert_eq!(
         transform_response(json!("nope")).expect_err("not an object"),
-        CoreError::InvalidResponse("messages response is not an object".to_string())
+        Error::InvalidResponse("messages response is not an object".to_string())
     );
     assert_eq!(
         transform_response(json!({"model": "m", "usage": {}})).expect_err("no content"),
-        CoreError::MissingField("content")
+        Error::MissingField("content")
     );
     assert_eq!(
         transform_response(json!({"model": "m", "content": []})).expect_err("no usage"),
-        CoreError::MissingField("usage")
+        Error::MissingField("usage")
     );
     assert_eq!(
         transform_response(json!({"content": [], "usage": {}})).expect_err("no model"),
-        CoreError::MissingField("model")
+        Error::MissingField("model")
     );
 }
 

--- a/litellm-rust/crates/core/src/providers/anthropic/chat_completions/transformation.rs
+++ b/litellm-rust/crates/core/src/providers/anthropic/chat_completions/transformation.rs
@@ -10,7 +10,7 @@ use crate::chat_completions::types::{
     ProviderChatRequestData, ProviderChatResponseData,
 };
 use crate::constants::ANTHROPIC_OAUTH_TOKEN_PREFIX;
-use crate::error::{CoreError, CoreResult};
+use crate::error::Error;
 use crate::providers::anthropic::messages::transformation::{
     complete_anthropic_url, resolve_anthropic_api_key,
 };
@@ -74,7 +74,7 @@ impl ChatCompletionsProviderConfig for AnthropicChatCompletionsConfig {
         _model: &str,
         _optional_params: &Map<String, Value>,
         env_lookup: &dyn Fn(&str) -> Option<String>,
-    ) -> CoreResult<String> {
+    ) -> Result<String, Error> {
         Ok(complete_anthropic_url(api_base, env_lookup))
     }
 
@@ -84,7 +84,7 @@ impl ChatCompletionsProviderConfig for AnthropicChatCompletionsConfig {
         _model: &str,
         _optional_params: &Map<String, Value>,
         env_lookup: &dyn Fn(&str) -> Option<String>,
-    ) -> CoreResult<ChatCompletionsAuth> {
+    ) -> Result<ChatCompletionsAuth, Error> {
         Ok(ChatCompletionsAuth::Header {
             name: "x-api-key",
             value: resolve_anthropic_api_key(api_key, env_lookup)?,
@@ -137,7 +137,7 @@ impl ChatCompletionsProviderConfig for AnthropicChatCompletionsConfig {
         model: &str,
         messages: Vec<ChatMessage>,
         optional_params: Map<String, Value>,
-    ) -> CoreResult<ProviderChatRequestData> {
+    ) -> Result<ProviderChatRequestData, Error> {
         Ok(ProviderChatRequestData {
             body: anthropic_body(model, &build_conversation(&messages), optional_params),
         })
@@ -147,15 +147,16 @@ impl ChatCompletionsProviderConfig for AnthropicChatCompletionsConfig {
         &self,
         _model: &str,
         response: ProviderChatResponseData,
-    ) -> CoreResult<ChatCompletionsResponse> {
-        let body = response.body.as_object().ok_or_else(|| {
-            CoreError::InvalidResponse("messages response is not an object".into())
-        })?;
+    ) -> Result<ChatCompletionsResponse, Error> {
+        let body = response
+            .body
+            .as_object()
+            .ok_or_else(|| Error::InvalidResponse("messages response is not an object".into()))?;
 
         let content = body
             .get("content")
             .and_then(Value::as_array)
-            .ok_or(CoreError::MissingField("content"))?;
+            .ok_or(Error::MissingField("content"))?;
         // The route declines tool and thinking requests, so a non-text block
         // means the response carries something this path never asked for.
         // Decline rather than silently dropping it; the host falls back.
@@ -163,7 +164,7 @@ impl ChatCompletionsProviderConfig for AnthropicChatCompletionsConfig {
             .iter()
             .any(|block| block.get("type").and_then(Value::as_str) != Some("text"))
         {
-            return Err(CoreError::Unsupported("non-text response content block"));
+            return Err(Error::Unsupported("non-text response content block"));
         }
         let text: String = content
             .iter()
@@ -173,7 +174,7 @@ impl ChatCompletionsProviderConfig for AnthropicChatCompletionsConfig {
         let usage = body
             .get("usage")
             .and_then(Value::as_object)
-            .ok_or(CoreError::MissingField("usage"))?;
+            .ok_or(Error::MissingField("usage"))?;
         let field = |name: &str| usage.get(name).and_then(Value::as_u64).unwrap_or(0);
 
         Ok(ChatCompletionsResponse {
@@ -181,7 +182,7 @@ impl ChatCompletionsProviderConfig for AnthropicChatCompletionsConfig {
             model: body
                 .get("model")
                 .and_then(Value::as_str)
-                .ok_or(CoreError::MissingField("model"))?
+                .ok_or(Error::MissingField("model"))?
                 .to_string(),
             choices: vec![ChatCompletionsChoice {
                 index: 0,

--- a/litellm-rust/crates/core/src/providers/anthropic/messages/transformation.rs
+++ b/litellm-rust/crates/core/src/providers/anthropic/messages/transformation.rs
@@ -1,4 +1,4 @@
-use crate::error::{CoreError, CoreResult};
+use crate::error::Error;
 use crate::messages::transformation::{AnthropicMessagesProviderConfig, MessagesAuthStrategy};
 
 const ANTHROPIC_API_KEY_ENV: &str = "ANTHROPIC_API_KEY";
@@ -17,12 +17,12 @@ pub fn non_empty(value: Option<&str>) -> Option<&str> {
 pub fn resolve_anthropic_api_key(
     api_key: Option<&str>,
     env_lookup: &dyn Fn(&str) -> Option<String>,
-) -> CoreResult<String> {
+) -> Result<String, Error> {
     non_empty(api_key)
         .map(str::to_string)
         .or_else(|| env_lookup(ANTHROPIC_API_KEY_ENV).filter(|value| !value.trim().is_empty()))
         .ok_or_else(|| {
-            CoreError::Auth(
+            Error::Auth(
                 "Missing Anthropic API Key - Set `api_key` or the ANTHROPIC_API_KEY \
                  environment variable"
                     .to_string(),
@@ -52,7 +52,7 @@ impl AnthropicMessagesProviderConfig for AnthropicMessagesConfig {
         api_base: Option<&str>,
         _model: &str,
         env_lookup: &dyn Fn(&str) -> Option<String>,
-    ) -> CoreResult<String> {
+    ) -> Result<String, Error> {
         Ok(complete_anthropic_url(api_base, env_lookup))
     }
 
@@ -60,7 +60,7 @@ impl AnthropicMessagesProviderConfig for AnthropicMessagesConfig {
         &self,
         api_key: Option<&str>,
         env_lookup: &dyn Fn(&str) -> Option<String>,
-    ) -> CoreResult<String> {
+    ) -> Result<String, Error> {
         resolve_anthropic_api_key(api_key, env_lookup)
     }
 
@@ -121,7 +121,7 @@ mod tests {
         );
         assert!(matches!(
             resolve_anthropic_api_key(None, &|_| None).expect_err("missing key"),
-            CoreError::Auth(_)
+            Error::Auth(_)
         ));
     }
 

--- a/litellm-rust/crates/core/src/providers/azure_ai/messages/transformation.rs
+++ b/litellm-rust/crates/core/src/providers/azure_ai/messages/transformation.rs
@@ -1,4 +1,4 @@
-use crate::error::{CoreError, CoreResult};
+use crate::error::Error;
 use crate::messages::transformation::{AnthropicMessagesProviderConfig, MessagesAuthStrategy};
 use crate::messages::types::{
     AnthropicMessage, AnthropicMessagesRequest, AnthropicMessagesResponse, ContentBlock,
@@ -28,12 +28,12 @@ pub const AZURE_ANTHROPIC_MESSAGES_CONFIG: AzureAnthropicMessagesConfig =
 pub fn resolve_azure_api_key(
     api_key: Option<&str>,
     env_lookup: &dyn Fn(&str) -> Option<String>,
-) -> CoreResult<String> {
+) -> Result<String, Error> {
     non_empty(api_key)
         .map(str::to_string)
         .or_else(|| env_lookup(AZURE_API_KEY_ENV).filter(|value| !value.trim().is_empty()))
         .ok_or_else(|| {
-            CoreError::Auth(
+            Error::Auth(
                 "Missing Azure API Key - Set `api_key` or the AZURE_API_KEY environment variable"
                     .to_string(),
             )
@@ -43,12 +43,12 @@ pub fn resolve_azure_api_key(
 pub fn complete_azure_anthropic_url(
     api_base: Option<&str>,
     env_lookup: &dyn Fn(&str) -> Option<String>,
-) -> CoreResult<String> {
+) -> Result<String, Error> {
     let api_base = non_empty(api_base)
         .map(str::to_string)
         .or_else(|| env_lookup(AZURE_API_BASE_ENV).filter(|value| !value.trim().is_empty()))
         .ok_or_else(|| {
-            CoreError::Auth(
+            Error::Auth(
                 "Missing Azure API Base - Set `api_base` or the AZURE_API_BASE environment variable. \
                  Expected format: https://<resource-name>.services.ai.azure.com/anthropic"
                     .to_string(),
@@ -147,7 +147,7 @@ impl AnthropicMessagesProviderConfig for AzureAnthropicMessagesConfig {
         api_base: Option<&str>,
         _model: &str,
         env_lookup: &dyn Fn(&str) -> Option<String>,
-    ) -> CoreResult<String> {
+    ) -> Result<String, Error> {
         complete_azure_anthropic_url(api_base, env_lookup)
     }
 
@@ -155,7 +155,7 @@ impl AnthropicMessagesProviderConfig for AzureAnthropicMessagesConfig {
         &self,
         api_key: Option<&str>,
         env_lookup: &dyn Fn(&str) -> Option<String>,
-    ) -> CoreResult<String> {
+    ) -> Result<String, Error> {
         resolve_azure_api_key(api_key, env_lookup)
     }
 
@@ -174,7 +174,7 @@ impl AnthropicMessagesProviderConfig for AzureAnthropicMessagesConfig {
     fn transform_request(
         &self,
         request: AnthropicMessagesRequest,
-    ) -> CoreResult<AnthropicMessagesRequest> {
+    ) -> Result<AnthropicMessagesRequest, Error> {
         let mut request = fold_system_role_messages(request);
         if let Some(system) = request.system.as_mut() {
             strip_scope_from_system(system);
@@ -190,7 +190,7 @@ impl AnthropicMessagesProviderConfig for AzureAnthropicMessagesConfig {
         &self,
         model: &str,
         response: AnthropicMessagesResponse,
-    ) -> CoreResult<AnthropicMessagesResponse> {
+    ) -> Result<AnthropicMessagesResponse, Error> {
         self.anthropic.transform_response(model, response)
     }
 }
@@ -268,7 +268,7 @@ mod tests {
             "https://env.services.ai.azure.com/anthropic/v1/messages"
         );
         let err = complete_azure_anthropic_url(Some("  "), &|_| None).expect_err("missing base");
-        assert!(matches!(err, CoreError::Auth(_)));
+        assert!(matches!(err, Error::Auth(_)));
     }
 
     #[test]
@@ -284,7 +284,7 @@ mod tests {
         );
         assert!(matches!(
             resolve_azure_api_key(None, &|_| None).expect_err("missing key"),
-            CoreError::Auth(_)
+            Error::Auth(_)
         ));
     }
 

--- a/litellm-rust/crates/core/src/providers/azure_ai/ocr/transformation.rs
+++ b/litellm-rust/crates/core/src/providers/azure_ai/ocr/transformation.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeSet;
 
-use crate::error::{CoreError, CoreResult, json_type_name};
+use crate::error::{Error, json_type_name};
 use crate::ocr::transformation::{OcrAuthStrategy, OcrProviderConfig, OcrResponseHandling};
 use crate::ocr::types::{OcrRequestData, OcrResponseData};
 use serde_json::{Map, Value, json};
@@ -32,17 +32,17 @@ fn resolve_value(
     env_name: &str,
     env_lookup: &dyn Fn(&str) -> Option<String>,
     missing_message: &str,
-) -> CoreResult<String> {
+) -> Result<String, Error> {
     non_empty(explicit)
         .map(str::to_string)
         .or_else(|| env_lookup(env_name).filter(|value| !value.trim().is_empty()))
-        .ok_or_else(|| CoreError::Auth(missing_message.to_string()))
+        .ok_or_else(|| Error::Auth(missing_message.to_string()))
 }
 
 pub fn resolve_azure_ai_api_key(
     api_key: Option<&str>,
     env_lookup: &dyn Fn(&str) -> Option<String>,
-) -> CoreResult<String> {
+) -> Result<String, Error> {
     resolve_value(
         api_key,
         AZURE_AI_API_KEY_ENV,
@@ -54,7 +54,7 @@ pub fn resolve_azure_ai_api_key(
 pub fn resolve_azure_ai_api_base(
     api_base: Option<&str>,
     env_lookup: &dyn Fn(&str) -> Option<String>,
-) -> CoreResult<String> {
+) -> Result<String, Error> {
     resolve_value(
         api_base,
         AZURE_AI_API_BASE_ENV,
@@ -66,7 +66,7 @@ pub fn resolve_azure_ai_api_base(
 pub fn complete_azure_ai_url(
     api_base: Option<&str>,
     env_lookup: &dyn Fn(&str) -> Option<String>,
-) -> CoreResult<String> {
+) -> Result<String, Error> {
     let base = resolve_azure_ai_api_base(api_base, env_lookup)?;
     Ok(format!(
         "{}/providers/mistral/azure/ocr",
@@ -77,7 +77,7 @@ pub fn complete_azure_ai_url(
 pub fn resolve_document_intelligence_api_key(
     api_key: Option<&str>,
     env_lookup: &dyn Fn(&str) -> Option<String>,
-) -> CoreResult<String> {
+) -> Result<String, Error> {
     resolve_value(
         api_key,
         AZURE_DOCUMENT_INTELLIGENCE_API_KEY_ENV,
@@ -89,7 +89,7 @@ pub fn resolve_document_intelligence_api_key(
 pub fn resolve_document_intelligence_endpoint(
     api_base: Option<&str>,
     env_lookup: &dyn Fn(&str) -> Option<String>,
-) -> CoreResult<String> {
+) -> Result<String, Error> {
     resolve_value(
         api_base,
         AZURE_DOCUMENT_INTELLIGENCE_ENDPOINT_ENV,
@@ -127,7 +127,7 @@ fn pages_token_is_valid(token: &str) -> bool {
     }
 }
 
-fn normalize_pages_param(pages: &Value) -> CoreResult<Option<String>> {
+fn normalize_pages_param(pages: &Value) -> Result<Option<String>, Error> {
     match pages {
         Value::String(value) => {
             let normalized = value
@@ -138,7 +138,7 @@ fn normalize_pages_param(pages: &Value) -> CoreResult<Option<String>> {
             if normalized.split(',').all(pages_token_is_valid) {
                 Ok(Some(normalized))
             } else {
-                Err(CoreError::InvalidRequest(format!(
+                Err(Error::InvalidRequest(format!(
                     "Invalid `pages` string for Azure Document Intelligence: {value:?}. Expected format like '1-3,5,7-9'."
                 )))
             }
@@ -152,7 +152,7 @@ fn normalize_pages_param(pages: &Value) -> CoreResult<Option<String>> {
                 for value in values {
                     let page = value.as_i64().expect("checked is_i64");
                     if page < 0 {
-                        return Err(CoreError::InvalidRequest(
+                        return Err(Error::InvalidRequest(
                             "`pages` integers must be >= 0 (Mistral 0-based indices)".to_string(),
                         ));
                     }
@@ -176,16 +176,16 @@ fn normalize_pages_param(pages: &Value) -> CoreResult<Option<String>> {
                 if normalized.split(',').all(pages_token_is_valid) {
                     return Ok(Some(normalized));
                 }
-                return Err(CoreError::InvalidRequest(format!(
+                return Err(Error::InvalidRequest(format!(
                     "Invalid `pages` list for Azure Document Intelligence: {values:?}. Expected tokens like '1' or '3-5'."
                 )));
             }
-            Err(CoreError::InvalidRequest(
+            Err(Error::InvalidRequest(
                 "`pages` must be a list[int] (0-based, Mistral-style) or a string like '1-3,5,7-9'."
                     .to_string(),
             ))
         }
-        _ => Err(CoreError::InvalidRequest(
+        _ => Err(Error::InvalidRequest(
             "`pages` must be a list[int] (0-based, Mistral-style) or a string like '1-3,5,7-9'."
                 .to_string(),
         )),
@@ -197,7 +197,7 @@ pub fn complete_document_intelligence_url(
     model: &str,
     optional_params: &Map<String, Value>,
     env_lookup: &dyn Fn(&str) -> Option<String>,
-) -> CoreResult<String> {
+) -> Result<String, Error> {
     let endpoint = resolve_document_intelligence_endpoint(api_base, env_lookup)?;
     let mut url = format!(
         "{}/documentintelligence/documentModels/{}:analyze?api-version={}",
@@ -216,20 +216,20 @@ pub fn complete_document_intelligence_url(
     Ok(url)
 }
 
-fn document_url_from_mistral_document(document: &Value) -> CoreResult<&str> {
-    let object = document.as_object().ok_or_else(|| CoreError::InvalidType {
+fn document_url_from_mistral_document(document: &Value) -> Result<&str, Error> {
+    let object = document.as_object().ok_or_else(|| Error::InvalidType {
         expected: "object",
         actual: json_type_name(document),
     })?;
     let doc_type = object
         .get("type")
         .and_then(Value::as_str)
-        .ok_or(CoreError::MissingField("document.type"))?;
+        .ok_or(Error::MissingField("document.type"))?;
     let field_name = match doc_type {
         "document_url" => "document_url",
         "image_url" => "image_url",
         other => {
-            return Err(CoreError::InvalidRequest(format!(
+            return Err(Error::InvalidRequest(format!(
                 "Invalid document type: {other}. Must be 'document_url' or 'image_url'"
             )));
         }
@@ -238,7 +238,7 @@ fn document_url_from_mistral_document(document: &Value) -> CoreResult<&str> {
         .get(field_name)
         .and_then(Value::as_str)
         .filter(|value| !value.is_empty())
-        .ok_or(CoreError::MissingField(field_name))
+        .ok_or(Error::MissingField(field_name))
 }
 
 fn extract_base64_from_data_uri(data_uri: &str) -> &str {
@@ -290,7 +290,7 @@ impl OcrProviderConfig for AzureAiOcrConfig {
         model: &str,
         document: Value,
         optional_params: Map<String, Value>,
-    ) -> CoreResult<OcrRequestData> {
+    ) -> Result<OcrRequestData, Error> {
         MISTRAL_OCR_CONFIG.transform_ocr_request(model, document, optional_params)
     }
 
@@ -298,7 +298,7 @@ impl OcrProviderConfig for AzureAiOcrConfig {
         &self,
         model: &str,
         response_json: Value,
-    ) -> CoreResult<OcrResponseData> {
+    ) -> Result<OcrResponseData, Error> {
         MISTRAL_OCR_CONFIG.transform_ocr_response(model, response_json)
     }
 
@@ -308,7 +308,7 @@ impl OcrProviderConfig for AzureAiOcrConfig {
         _model: &str,
         _optional_params: &Map<String, Value>,
         env_lookup: &dyn Fn(&str) -> Option<String>,
-    ) -> CoreResult<String> {
+    ) -> Result<String, Error> {
         complete_azure_ai_url(api_base, env_lookup)
     }
 
@@ -316,7 +316,7 @@ impl OcrProviderConfig for AzureAiOcrConfig {
         &self,
         api_key: Option<&str>,
         env_lookup: &dyn Fn(&str) -> Option<String>,
-    ) -> CoreResult<String> {
+    ) -> Result<String, Error> {
         resolve_azure_ai_api_key(api_key, env_lookup)
     }
 
@@ -335,7 +335,7 @@ impl OcrProviderConfig for AzureDocumentIntelligenceOcrConfig {
         _model: &str,
         document: Value,
         _optional_params: Map<String, Value>,
-    ) -> CoreResult<OcrRequestData> {
+    ) -> Result<OcrRequestData, Error> {
         let document_url = document_url_from_mistral_document(&document)?;
         let mut data = Map::new();
         if document_url.starts_with("data:") {
@@ -359,19 +359,19 @@ impl OcrProviderConfig for AzureDocumentIntelligenceOcrConfig {
         &self,
         model: &str,
         response_json: Value,
-    ) -> CoreResult<OcrResponseData> {
+    ) -> Result<OcrResponseData, Error> {
         let response = response_json
             .as_object()
-            .ok_or_else(|| CoreError::InvalidType {
+            .ok_or_else(|| Error::InvalidType {
                 expected: "object",
                 actual: json_type_name(&response_json),
             })?;
         let status = response
             .get("status")
             .and_then(Value::as_str)
-            .ok_or(CoreError::MissingField("status"))?;
+            .ok_or(Error::MissingField("status"))?;
         if status != "succeeded" {
-            return Err(CoreError::InvalidResponse(format!(
+            return Err(Error::InvalidResponse(format!(
                 "Azure Document Intelligence analysis failed with status: {status}"
             )));
         }
@@ -414,7 +414,7 @@ impl OcrProviderConfig for AzureDocumentIntelligenceOcrConfig {
         model: &str,
         optional_params: &Map<String, Value>,
         env_lookup: &dyn Fn(&str) -> Option<String>,
-    ) -> CoreResult<String> {
+    ) -> Result<String, Error> {
         complete_document_intelligence_url(api_base, model, optional_params, env_lookup)
     }
 
@@ -422,7 +422,7 @@ impl OcrProviderConfig for AzureDocumentIntelligenceOcrConfig {
         &self,
         api_key: Option<&str>,
         env_lookup: &dyn Fn(&str) -> Option<String>,
-    ) -> CoreResult<String> {
+    ) -> Result<String, Error> {
         resolve_document_intelligence_api_key(api_key, env_lookup)
     }
 

--- a/litellm-rust/crates/core/src/providers/bedrock/audio_transcription.rs
+++ b/litellm-rust/crates/core/src/providers/bedrock/audio_transcription.rs
@@ -6,7 +6,7 @@ use crate::audio_transcription::transformation::{
 use crate::audio_transcription::types::{
     AudioTranscriptionRequestData, AudioTranscriptionResponseData,
 };
-use crate::error::{CoreError, CoreResult, json_type_name};
+use crate::error::{Error, json_type_name};
 
 pub use super::aws_base::{aws_auth_config, bedrock_model_id_and_region, resolve_bedrock_region};
 use super::constants::{BEDROCK_RUNTIME_ENDPOINT_TEMPLATE, BEDROCK_SERVICE};
@@ -18,8 +18,8 @@ pub static BEDROCK_AUDIO_TRANSCRIPTION_CONFIG: BedrockAudioTranscriptionConfig =
 
 pub struct BedrockAudioTranscriptionConfig;
 
-fn audio_fields(audio: Value) -> CoreResult<(String, String)> {
-    let object = audio.as_object().ok_or_else(|| CoreError::InvalidType {
+fn audio_fields(audio: Value) -> Result<(String, String), Error> {
+    let object = audio.as_object().ok_or_else(|| Error::InvalidType {
         expected: "object",
         actual: json_type_name(&audio),
     })?;
@@ -27,13 +27,13 @@ fn audio_fields(audio: Value) -> CoreResult<(String, String)> {
         .get("data")
         .and_then(Value::as_str)
         .filter(|value| !value.is_empty())
-        .ok_or(CoreError::MissingField("audio.data"))?;
+        .ok_or(Error::MissingField("audio.data"))?;
     let format = object
         .get("format")
         .and_then(Value::as_str)
         .filter(|value| matches!(*value, "wav" | "mp3" | "flac" | "ogg"))
         .ok_or_else(|| {
-            CoreError::InvalidRequest("audio.format must be wav, mp3, flac, or ogg".to_string())
+            Error::InvalidRequest("audio.format must be wav, mp3, flac, or ogg".to_string())
         })?;
     Ok((data.to_string(), format.to_string()))
 }
@@ -55,7 +55,7 @@ impl AudioTranscriptionProviderConfig for BedrockAudioTranscriptionConfig {
         _model: &str,
         audio: Value,
         optional_params: Map<String, Value>,
-    ) -> CoreResult<AudioTranscriptionRequestData> {
+    ) -> Result<AudioTranscriptionRequestData, Error> {
         let (data, format) = audio_fields(audio)?;
         let mut instruction = "Transcribe the audio. Respond with only the transcript.".to_string();
         if let Some(language) = optional_string(&optional_params, "language") {
@@ -87,14 +87,14 @@ impl AudioTranscriptionProviderConfig for BedrockAudioTranscriptionConfig {
         &self,
         _model: &str,
         response_json: Value,
-    ) -> CoreResult<AudioTranscriptionResponseData> {
+    ) -> Result<AudioTranscriptionResponseData, Error> {
         let content = response_json
             .get("output")
             .and_then(|value| value.get("message"))
             .and_then(|value| value.get("content"))
             .and_then(Value::as_array)
             .ok_or_else(|| {
-                CoreError::InvalidResponse("Bedrock response has no output content".to_string())
+                Error::InvalidResponse("Bedrock response has no output content".to_string())
             })?;
         let mut text = String::new();
         for block in content {
@@ -111,7 +111,7 @@ impl AudioTranscriptionProviderConfig for BedrockAudioTranscriptionConfig {
         model: &str,
         optional_params: &Map<String, Value>,
         env_lookup: &dyn Fn(&str) -> Option<String>,
-    ) -> CoreResult<String> {
+    ) -> Result<String, Error> {
         let (model_id, model_region) = bedrock_model_id_and_region(model);
         let region = resolve_bedrock_region(model_region.as_deref(), optional_params, env_lookup);
         let endpoint = optional_params
@@ -133,7 +133,7 @@ impl AudioTranscriptionProviderConfig for BedrockAudioTranscriptionConfig {
         model: &str,
         optional_params: &Map<String, Value>,
         env_lookup: &dyn Fn(&str) -> Option<String>,
-    ) -> CoreResult<AudioTranscriptionAuth> {
+    ) -> Result<AudioTranscriptionAuth, Error> {
         let (_, model_region) = bedrock_model_id_and_region(model);
         Ok(AudioTranscriptionAuth::AwsSigV4 {
             region: resolve_bedrock_region(model_region.as_deref(), optional_params, env_lookup),

--- a/litellm-rust/crates/core/src/providers/bedrock/aws_base.rs
+++ b/litellm-rust/crates/core/src/providers/bedrock/aws_base.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::caching::in_memory_cache::InMemoryCache;
-use crate::error::{CoreError, CoreResult};
+use crate::error::Error;
 use aws_credential_types::Credentials;
 use aws_credential_types::provider::ProvideCredentials;
 use aws_sigv4::http_request::{
@@ -197,7 +197,7 @@ pub fn classify_auth(
 pub async fn resolve_credentials(
     config: AwsAuthConfig,
     env_lookup: &(dyn Fn(&str) -> Option<String> + Sync),
-) -> CoreResult<Credentials> {
+) -> Result<Credentials, Error> {
     let resolved = config.clone().with_environment(env_lookup);
     let flow = classify_auth(config, env_lookup);
     match flow {
@@ -244,9 +244,10 @@ pub async fn resolve_credentials(
             let provider = aws_config::profile::ProfileFileCredentialsProvider::builder()
                 .profile_name(name)
                 .build();
-            provider.provide_credentials().await.map_err(|error| {
-                CoreError::Auth(format!("AWS profile credentials failed: {error}"))
-            })
+            provider
+                .provide_credentials()
+                .await
+                .map_err(|error| Error::Auth(format!("AWS profile credentials failed: {error}")))
         }
         AwsAuthFlow::AssumeRole { role, session_name } => {
             if is_already_running_as_role(&role, &resolved).await? {
@@ -260,7 +261,7 @@ pub async fn resolve_credentials(
                         .build()
                         .await;
                 let credentials = provider.provide_credentials().await.map_err(|error| {
-                    CoreError::Auth(format!("AWS default credentials failed: {error}"))
+                    Error::Auth(format!("AWS default credentials failed: {error}"))
                 })?;
                 set_cached_credentials(
                     key,
@@ -301,7 +302,7 @@ pub async fn resolve_credentials(
             provider
                 .provide_credentials()
                 .await
-                .map_err(|error| CoreError::Auth(format!("AWS role credentials failed: {error}")))
+                .map_err(|error| Error::Auth(format!("AWS role credentials failed: {error}")))
         }
         AwsAuthFlow::WebIdentity {
             token,
@@ -325,13 +326,13 @@ pub async fn resolve_credentials(
                 .send()
                 .await
                 .map_err(|error| {
-                    CoreError::Auth(format!("AWS web identity credentials failed: {error}"))
+                    Error::Auth(format!("AWS web identity credentials failed: {error}"))
                 })?;
             let credentials = response.credentials().ok_or_else(|| {
-                CoreError::Auth("AWS web identity response had no credentials".to_string())
+                Error::Auth("AWS web identity response had no credentials".to_string())
             })?;
             let expiration = SystemTime::try_from(*credentials.expiration()).map_err(|error| {
-                CoreError::Auth(format!("AWS web identity expiration was invalid: {error}"))
+                Error::Auth(format!("AWS web identity expiration was invalid: {error}"))
             })?;
             Ok(Credentials::new(
                 credentials.access_key_id(),
@@ -350,9 +351,10 @@ pub async fn resolve_credentials(
                 aws_config::default_provider::credentials::DefaultCredentialsChain::builder()
                     .build()
                     .await;
-            let credentials = provider.provide_credentials().await.map_err(|error| {
-                CoreError::Auth(format!("AWS default credentials failed: {error}"))
-            })?;
+            let credentials = provider
+                .provide_credentials()
+                .await
+                .map_err(|error| Error::Auth(format!("AWS default credentials failed: {error}")))?;
             set_cached_credentials(
                 key,
                 credentials.clone(),
@@ -363,7 +365,7 @@ pub async fn resolve_credentials(
     }
 }
 
-async fn is_already_running_as_role(role: &str, config: &AwsAuthConfig) -> CoreResult<bool> {
+async fn is_already_running_as_role(role: &str, config: &AwsAuthConfig) -> Result<bool, Error> {
     if role_identity(role).is_none() {
         return Ok(false);
     }
@@ -437,7 +439,7 @@ pub fn sign_bedrock_post(
     region: &str,
     credentials: &Credentials,
     signing_time: SystemTime,
-) -> CoreResult<BTreeMap<String, String>> {
+) -> Result<BTreeMap<String, String>, Error> {
     let identity: Identity = credentials.clone().into();
     let params = v4::SigningParams::builder()
         .identity(&identity)
@@ -447,14 +449,14 @@ pub fn sign_bedrock_post(
         .settings(SigningSettings::default())
         .build()
         .map(SigningParams::from)
-        .map_err(|error| CoreError::Auth(format!("AWS signing parameters failed: {error}")))?;
+        .map_err(|error| Error::Auth(format!("AWS signing parameters failed: {error}")))?;
     let header_refs = headers
         .iter()
         .map(|(name, value)| (name.as_str(), value.as_str()));
     let request = SignableRequest::new("POST", url, header_refs, SignableBody::Bytes(body))
-        .map_err(|error| CoreError::Auth(format!("AWS signable request failed: {error}")))?;
+        .map_err(|error| Error::Auth(format!("AWS signable request failed: {error}")))?;
     let (instructions, _) = sign(request, &params)
-        .map_err(|error| CoreError::Auth(format!("AWS request signing failed: {error}")))?
+        .map_err(|error| Error::Auth(format!("AWS request signing failed: {error}")))?
         .into_parts();
     Ok(instructions
         .headers()

--- a/litellm-rust/crates/core/src/providers/bedrock/chat_completions/tests.rs
+++ b/litellm-rust/crates/core/src/providers/bedrock/chat_completions/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::Error;
 use serde_json::json;
 
 fn messages(value: Value) -> Vec<ChatMessage> {
@@ -23,7 +24,7 @@ fn transform(msgs: Value, opts: Value) -> Value {
         .body
 }
 
-fn transform_response(body: Value) -> CoreResult<ChatCompletionsResponse> {
+fn transform_response(body: Value) -> Result<ChatCompletionsResponse, Error> {
     BEDROCK_CHAT_COMPLETIONS_CONFIG.transform_response(
         "anthropic.claude-sonnet-4-5-v1:0",
         ProviderChatResponseData { body },
@@ -478,25 +479,22 @@ fn declines_a_response_carrying_a_tool_use_block() {
         "usage": {"inputTokens": 1, "outputTokens": 1}
     }))
     .expect_err("tool use block");
-    assert_eq!(
-        err,
-        CoreError::Unsupported("non-text response content block")
-    );
+    assert_eq!(err, Error::Unsupported("non-text response content block"));
 }
 
 #[test]
 fn errors_on_a_response_missing_required_fields() {
     assert_eq!(
         transform_response(json!("nope")).expect_err("not an object"),
-        CoreError::InvalidResponse("converse response is not an object".to_string())
+        Error::InvalidResponse("converse response is not an object".to_string())
     );
     assert_eq!(
         transform_response(json!({"usage": {}})).expect_err("no output"),
-        CoreError::MissingField("output.message.content")
+        Error::MissingField("output.message.content")
     );
     assert_eq!(
         transform_response(json!({"output": {"message": {"content": []}}})).expect_err("no usage"),
-        CoreError::MissingField("usage")
+        Error::MissingField("usage")
     );
 }
 

--- a/litellm-rust/crates/core/src/providers/bedrock/chat_completions/transformation.rs
+++ b/litellm-rust/crates/core/src/providers/bedrock/chat_completions/transformation.rs
@@ -11,7 +11,7 @@ use crate::chat_completions::types::{
     ChatCompletionsUsage, ChatMessage, ChatMessageContent, ProviderChatRequestData,
     ProviderChatResponseData,
 };
-use crate::error::{CoreError, CoreResult};
+use crate::error::Error;
 
 use super::super::aws_base::{bedrock_model_id_and_region, resolve_bedrock_region};
 use super::super::constants::{AWS_BEARER_TOKEN_BEDROCK, BEDROCK_RUNTIME_ENDPOINT_TEMPLATE};
@@ -110,7 +110,7 @@ impl ChatCompletionsProviderConfig for BedrockChatCompletionsConfig {
         model: &str,
         optional_params: &Map<String, Value>,
         env_lookup: &dyn Fn(&str) -> Option<String>,
-    ) -> CoreResult<String> {
+    ) -> Result<String, Error> {
         let (model_id, model_region) = bedrock_model_id_and_region(model);
         let region = resolve_bedrock_region(model_region.as_deref(), optional_params, env_lookup);
         let endpoint = optional_params
@@ -137,7 +137,7 @@ impl ChatCompletionsProviderConfig for BedrockChatCompletionsConfig {
         model: &str,
         optional_params: &Map<String, Value>,
         env_lookup: &dyn Fn(&str) -> Option<String>,
-    ) -> CoreResult<ChatCompletionsAuth> {
+    ) -> Result<ChatCompletionsAuth, Error> {
         // Python reads `api_key` as the Bedrock bearer token and consults the
         // env only when the caller passed none, so a caller-supplied empty key
         // falls through to SigV4 without reaching for the environment. An
@@ -208,7 +208,7 @@ impl ChatCompletionsProviderConfig for BedrockChatCompletionsConfig {
         _model: &str,
         messages: Vec<ChatMessage>,
         optional_params: Map<String, Value>,
-    ) -> CoreResult<ProviderChatRequestData> {
+    ) -> Result<ProviderChatRequestData, Error> {
         Ok(ProviderChatRequestData {
             body: converse_body(&build_conversation(&messages), &optional_params),
         })
@@ -218,17 +218,18 @@ impl ChatCompletionsProviderConfig for BedrockChatCompletionsConfig {
         &self,
         model: &str,
         response: ProviderChatResponseData,
-    ) -> CoreResult<ChatCompletionsResponse> {
-        let body = response.body.as_object().ok_or_else(|| {
-            CoreError::InvalidResponse("converse response is not an object".into())
-        })?;
+    ) -> Result<ChatCompletionsResponse, Error> {
+        let body = response
+            .body
+            .as_object()
+            .ok_or_else(|| Error::InvalidResponse("converse response is not an object".into()))?;
 
         let content = body
             .get("output")
             .and_then(|output| output.get("message"))
             .and_then(|message| message.get("content"))
             .and_then(Value::as_array)
-            .ok_or(CoreError::MissingField("output.message.content"))?;
+            .ok_or(Error::MissingField("output.message.content"))?;
         // The route declines tool requests, so anything other than a text block
         // is something this path never asked for. Decline; the host falls back.
         if content.iter().any(|block| {
@@ -236,7 +237,7 @@ impl ChatCompletionsProviderConfig for BedrockChatCompletionsConfig {
                 .as_object()
                 .is_none_or(|block| block.len() != 1 || !block.contains_key("text"))
         }) {
-            return Err(CoreError::Unsupported("non-text response content block"));
+            return Err(Error::Unsupported("non-text response content block"));
         }
         let text: String = content
             .iter()
@@ -246,7 +247,7 @@ impl ChatCompletionsProviderConfig for BedrockChatCompletionsConfig {
         let usage = body
             .get("usage")
             .and_then(Value::as_object)
-            .ok_or(CoreError::MissingField("usage"))?;
+            .ok_or(Error::MissingField("usage"))?;
         let field = |name: &str| usage.get(name).and_then(Value::as_u64).unwrap_or(0);
         let computed = usage_from_parts(
             field("inputTokens"),

--- a/litellm-rust/crates/core/src/providers/mistral/ocr/transformation.rs
+++ b/litellm-rust/crates/core/src/providers/mistral/ocr/transformation.rs
@@ -1,4 +1,4 @@
-use crate::error::{CoreError, CoreResult, json_type_name};
+use crate::error::{Error, json_type_name};
 use crate::ocr::transformation::OcrProviderConfig;
 use crate::ocr::types::{OcrRequestData, OcrResponseData};
 use serde_json::{Map, Value};
@@ -47,7 +47,7 @@ pub fn complete_url(api_base: Option<&str>) -> String {
 
 /// Resolve the Mistral API key from the explicit param or the environment.
 ///
-/// Blank/whitespace values are treated as absent. Returns `CoreError::Auth`
+/// Blank/whitespace values are treated as absent. Returns `Error::Auth`
 /// when no usable key is available.
 ///
 /// Note: the env fallback only reads the process environment. Secret-manager
@@ -56,13 +56,13 @@ pub fn complete_url(api_base: Option<&str>) -> String {
 pub fn resolve_api_key(
     api_key: Option<&str>,
     env_lookup: &dyn Fn(&str) -> Option<String>,
-) -> CoreResult<String> {
+) -> Result<String, Error> {
     api_key
         .map(str::trim)
         .filter(|key| !key.is_empty())
         .map(str::to_string)
         .or_else(|| env_lookup(MISTRAL_API_KEY_ENV).filter(|key| !key.trim().is_empty()))
-        .ok_or_else(|| CoreError::Auth(MISSING_KEY_MESSAGE.to_string()))
+        .ok_or_else(|| Error::Auth(MISSING_KEY_MESSAGE.to_string()))
 }
 
 pub struct MistralOcrConfig;
@@ -79,9 +79,9 @@ impl OcrProviderConfig for MistralOcrConfig {
         model: &str,
         document: Value,
         optional_params: Map<String, Value>,
-    ) -> CoreResult<OcrRequestData> {
+    ) -> Result<OcrRequestData, Error> {
         if !document.is_object() {
-            return Err(CoreError::InvalidType {
+            return Err(Error::InvalidType {
                 expected: "object",
                 actual: json_type_name(&document),
             });
@@ -104,10 +104,10 @@ impl OcrProviderConfig for MistralOcrConfig {
         &self,
         model: &str,
         response_json: Value,
-    ) -> CoreResult<OcrResponseData> {
+    ) -> Result<OcrResponseData, Error> {
         let response_object = response_json
             .as_object()
-            .ok_or_else(|| CoreError::InvalidType {
+            .ok_or_else(|| Error::InvalidType {
                 expected: "object",
                 actual: json_type_name(&response_json),
             })?;
@@ -140,7 +140,7 @@ impl OcrProviderConfig for MistralOcrConfig {
         _model: &str,
         _optional_params: &Map<String, Value>,
         _env_lookup: &dyn Fn(&str) -> Option<String>,
-    ) -> CoreResult<String> {
+    ) -> Result<String, Error> {
         Ok(complete_url(api_base))
     }
 
@@ -148,7 +148,7 @@ impl OcrProviderConfig for MistralOcrConfig {
         &self,
         api_key: Option<&str>,
         env_lookup: &dyn Fn(&str) -> Option<String>,
-    ) -> CoreResult<String> {
+    ) -> Result<String, Error> {
         resolve_api_key(api_key, env_lookup)
     }
 }
@@ -165,11 +165,11 @@ pub fn transform_ocr_request(
     model: &str,
     document: Value,
     optional_params: Map<String, Value>,
-) -> CoreResult<OcrRequestData> {
+) -> Result<OcrRequestData, Error> {
     MISTRAL_OCR_CONFIG.transform_ocr_request(model, document, optional_params)
 }
 
-pub fn transform_ocr_response(model: &str, response_json: Value) -> CoreResult<OcrResponseData> {
+pub fn transform_ocr_response(model: &str, response_json: Value) -> Result<OcrResponseData, Error> {
     MISTRAL_OCR_CONFIG.transform_ocr_response(model, response_json)
 }
 
@@ -250,7 +250,7 @@ mod tests {
 
         assert_eq!(
             err,
-            CoreError::InvalidType {
+            Error::InvalidType {
                 expected: "object",
                 actual: "string",
             }
@@ -307,6 +307,6 @@ mod tests {
     #[test]
     fn resolve_api_key_errors_when_absent() {
         let err = resolve_api_key(None, &|_| None).expect_err("missing key should error");
-        assert_eq!(err, CoreError::Auth(MISSING_KEY_MESSAGE.to_string()));
+        assert_eq!(err, Error::Auth(MISSING_KEY_MESSAGE.to_string()));
     }
 }

--- a/litellm-rust/crates/core/src/providers/openai/realtime/transformation.rs
+++ b/litellm-rust/crates/core/src/providers/openai/realtime/transformation.rs
@@ -1,4 +1,4 @@
-use crate::CoreResult;
+use crate::Error;
 use crate::realtime::transformation::RealtimeProviderConfig;
 use crate::realtime::types::{RealtimeEvent, RealtimeTransformResult};
 
@@ -72,7 +72,7 @@ impl RealtimeProviderConfig for OpenAiRealtimeConfig {
         &self,
         event: &RealtimeEvent,
         _model: &str,
-    ) -> CoreResult<RealtimeTransformResult> {
+    ) -> Result<RealtimeTransformResult, Error> {
         Ok(RealtimeTransformResult::passthrough(event.clone()))
     }
 
@@ -80,7 +80,7 @@ impl RealtimeProviderConfig for OpenAiRealtimeConfig {
         &self,
         event: &RealtimeEvent,
         _model: &str,
-    ) -> CoreResult<RealtimeTransformResult> {
+    ) -> Result<RealtimeTransformResult, Error> {
         Ok(RealtimeTransformResult::passthrough(event.clone()))
     }
 }
@@ -88,14 +88,14 @@ impl RealtimeProviderConfig for OpenAiRealtimeConfig {
 pub fn transform_realtime_request(
     event: &RealtimeEvent,
     model: &str,
-) -> CoreResult<RealtimeTransformResult> {
+) -> Result<RealtimeTransformResult, Error> {
     OPENAI_REALTIME_CONFIG.transform_realtime_request(event, model)
 }
 
 pub fn transform_realtime_response(
     event: &RealtimeEvent,
     model: &str,
-) -> CoreResult<RealtimeTransformResult> {
+) -> Result<RealtimeTransformResult, Error> {
     OPENAI_REALTIME_CONFIG.transform_realtime_response(event, model)
 }
 

--- a/litellm-rust/crates/core/src/providers/openai/responses/transformation.rs
+++ b/litellm-rust/crates/core/src/providers/openai/responses/transformation.rs
@@ -1,4 +1,4 @@
-use crate::CoreResult;
+use crate::Error;
 use crate::responses::types::{ResponsesWsEvent, ResponsesWsTransformResult};
 use crate::responses::websocket::{ResponsesWebSocketProviderConfig, enforce_model};
 
@@ -15,7 +15,7 @@ impl ResponsesWebSocketProviderConfig for OpenAIResponsesWsConfig {
         &self,
         event: &ResponsesWsEvent,
         model: &str,
-    ) -> CoreResult<ResponsesWsTransformResult> {
+    ) -> Result<ResponsesWsTransformResult, Error> {
         Ok(ResponsesWsTransformResult::passthrough(enforce_model(
             event, model,
         )))
@@ -25,7 +25,7 @@ impl ResponsesWebSocketProviderConfig for OpenAIResponsesWsConfig {
         &self,
         event: &ResponsesWsEvent,
         _model: &str,
-    ) -> CoreResult<ResponsesWsTransformResult> {
+    ) -> Result<ResponsesWsTransformResult, Error> {
         Ok(ResponsesWsTransformResult::passthrough(event.clone()))
     }
 }

--- a/litellm-rust/crates/core/src/providers/vertex_ai/ocr/transformation.rs
+++ b/litellm-rust/crates/core/src/providers/vertex_ai/ocr/transformation.rs
@@ -1,4 +1,4 @@
-use crate::error::{CoreError, CoreResult, json_type_name};
+use crate::error::{Error, json_type_name};
 use crate::ocr::transformation::OcrProviderConfig;
 use crate::ocr::types::{OcrRequestData, OcrResponseData};
 use serde_json::{Map, Value, json};
@@ -43,7 +43,7 @@ pub fn is_deepseek_model(model: &str) -> bool {
 pub fn resolve_vertex_api_key(
     api_key: Option<&str>,
     env_lookup: &dyn Fn(&str) -> Option<String>,
-) -> CoreResult<String> {
+) -> Result<String, Error> {
     api_key
         .map(str::trim)
         .filter(|key| !key.is_empty())
@@ -51,7 +51,7 @@ pub fn resolve_vertex_api_key(
         .or_else(|| env_lookup(VERTEX_AI_API_KEY_ENV).filter(|key| !key.trim().is_empty()))
         .or_else(|| env_lookup(VERTEXAI_API_KEY_ENV).filter(|key| !key.trim().is_empty()))
         .ok_or_else(|| {
-            CoreError::Auth(
+            Error::Auth(
                 "Missing Vertex AI access token - pass api_key or provide Authorization via extra_headers"
                     .to_string(),
             )
@@ -61,12 +61,12 @@ pub fn resolve_vertex_api_key(
 fn vertex_project(
     params: &Map<String, Value>,
     env_lookup: &dyn Fn(&str) -> Option<String>,
-) -> CoreResult<String> {
+) -> Result<String, Error> {
     string_param(params, &["vertex_project", "vertex_ai_project"])
         .map(str::to_string)
         .or_else(|| env_lookup(VERTEXAI_PROJECT_ENV).filter(|value| !value.trim().is_empty()))
         .ok_or_else(|| {
-            CoreError::InvalidRequest(
+            Error::InvalidRequest(
                 "Missing vertex_project - Set VERTEXAI_PROJECT environment variable or pass vertex_project parameter"
                     .to_string(),
             )
@@ -99,7 +99,7 @@ pub fn complete_vertex_mistral_url(
     model: &str,
     optional_params: &Map<String, Value>,
     env_lookup: &dyn Fn(&str) -> Option<String>,
-) -> CoreResult<String> {
+) -> Result<String, Error> {
     let project = vertex_project(optional_params, env_lookup)?;
     let location = vertex_location(optional_params, env_lookup);
     let base = vertex_mistral_api_base(api_base, &location);
@@ -112,7 +112,7 @@ pub fn complete_vertex_deepseek_url(
     api_base: Option<&str>,
     optional_params: &Map<String, Value>,
     env_lookup: &dyn Fn(&str) -> Option<String>,
-) -> CoreResult<String> {
+) -> Result<String, Error> {
     let project = vertex_project(optional_params, env_lookup)?;
     let location = vertex_location(optional_params, env_lookup);
     let base = api_base
@@ -125,20 +125,20 @@ pub fn complete_vertex_deepseek_url(
     ))
 }
 
-fn document_content_item(document: &Value) -> CoreResult<Value> {
-    let object = document.as_object().ok_or_else(|| CoreError::InvalidType {
+fn document_content_item(document: &Value) -> Result<Value, Error> {
+    let object = document.as_object().ok_or_else(|| Error::InvalidType {
         expected: "object",
         actual: json_type_name(document),
     })?;
     let doc_type = object
         .get("type")
         .and_then(Value::as_str)
-        .ok_or(CoreError::MissingField("document.type"))?;
+        .ok_or(Error::MissingField("document.type"))?;
     let url_field = match doc_type {
         "image_url" => "image_url",
         "document_url" => "document_url",
         other => {
-            return Err(CoreError::InvalidRequest(format!(
+            return Err(Error::InvalidRequest(format!(
                 "Unsupported document type: {other}. Expected 'image_url' or 'document_url'"
             )));
         }
@@ -147,7 +147,7 @@ fn document_content_item(document: &Value) -> CoreResult<Value> {
         .get(url_field)
         .and_then(Value::as_str)
         .filter(|value| !value.is_empty())
-        .ok_or(CoreError::MissingField(url_field))?;
+        .ok_or(Error::MissingField(url_field))?;
 
     Ok(json!({
         "type": "image_url",
@@ -163,7 +163,7 @@ fn deepseek_model_name(model: &str) -> String {
     }
 }
 
-fn first_choice_content(response: &Value) -> CoreResult<Value> {
+fn first_choice_content(response: &Value) -> Result<Value, Error> {
     response
         .get("choices")
         .and_then(Value::as_array)
@@ -176,9 +176,7 @@ fn first_choice_content(response: &Value) -> CoreResult<Value> {
             Value::Object(_) => true,
             _ => false,
         })
-        .ok_or_else(|| {
-            CoreError::InvalidResponse("No content in DeepSeek OCR response".to_string())
-        })
+        .ok_or_else(|| Error::InvalidResponse("No content in DeepSeek OCR response".to_string()))
 }
 
 fn ocr_data_from_content(content: Value, usage: Option<Value>, model: &str) -> Value {
@@ -219,7 +217,7 @@ impl OcrProviderConfig for VertexAiOcrConfig {
         model: &str,
         document: Value,
         optional_params: Map<String, Value>,
-    ) -> CoreResult<OcrRequestData> {
+    ) -> Result<OcrRequestData, Error> {
         MISTRAL_OCR_CONFIG.transform_ocr_request(model, document, optional_params)
     }
 
@@ -227,7 +225,7 @@ impl OcrProviderConfig for VertexAiOcrConfig {
         &self,
         model: &str,
         response_json: Value,
-    ) -> CoreResult<OcrResponseData> {
+    ) -> Result<OcrResponseData, Error> {
         MISTRAL_OCR_CONFIG.transform_ocr_response(model, response_json)
     }
 
@@ -237,7 +235,7 @@ impl OcrProviderConfig for VertexAiOcrConfig {
         model: &str,
         optional_params: &Map<String, Value>,
         env_lookup: &dyn Fn(&str) -> Option<String>,
-    ) -> CoreResult<String> {
+    ) -> Result<String, Error> {
         complete_vertex_mistral_url(api_base, model, optional_params, env_lookup)
     }
 
@@ -245,7 +243,7 @@ impl OcrProviderConfig for VertexAiOcrConfig {
         &self,
         api_key: Option<&str>,
         env_lookup: &dyn Fn(&str) -> Option<String>,
-    ) -> CoreResult<String> {
+    ) -> Result<String, Error> {
         resolve_vertex_api_key(api_key, env_lookup)
     }
 
@@ -264,7 +262,7 @@ impl OcrProviderConfig for VertexAiDeepSeekOcrConfig {
         model: &str,
         document: Value,
         optional_params: Map<String, Value>,
-    ) -> CoreResult<OcrRequestData> {
+    ) -> Result<OcrRequestData, Error> {
         let mut data = Map::new();
         data.insert(
             "model".to_string(),
@@ -289,10 +287,10 @@ impl OcrProviderConfig for VertexAiDeepSeekOcrConfig {
         &self,
         model: &str,
         response_json: Value,
-    ) -> CoreResult<OcrResponseData> {
+    ) -> Result<OcrResponseData, Error> {
         let response = response_json
             .as_object()
-            .ok_or_else(|| CoreError::InvalidType {
+            .ok_or_else(|| Error::InvalidType {
                 expected: "object",
                 actual: json_type_name(&response_json),
             })?;
@@ -314,7 +312,7 @@ impl OcrProviderConfig for VertexAiDeepSeekOcrConfig {
             });
         }
 
-        let object = ocr_data.as_object().ok_or_else(|| CoreError::InvalidType {
+        let object = ocr_data.as_object().ok_or_else(|| Error::InvalidType {
             expected: "object",
             actual: json_type_name(&ocr_data),
         })?;
@@ -346,7 +344,7 @@ impl OcrProviderConfig for VertexAiDeepSeekOcrConfig {
         _model: &str,
         optional_params: &Map<String, Value>,
         env_lookup: &dyn Fn(&str) -> Option<String>,
-    ) -> CoreResult<String> {
+    ) -> Result<String, Error> {
         complete_vertex_deepseek_url(api_base, optional_params, env_lookup)
     }
 
@@ -354,7 +352,7 @@ impl OcrProviderConfig for VertexAiDeepSeekOcrConfig {
         &self,
         api_key: Option<&str>,
         env_lookup: &dyn Fn(&str) -> Option<String>,
-    ) -> CoreResult<String> {
+    ) -> Result<String, Error> {
         resolve_vertex_api_key(api_key, env_lookup)
     }
 }

--- a/litellm-rust/crates/core/src/realtime/transformation.rs
+++ b/litellm-rust/crates/core/src/realtime/transformation.rs
@@ -1,4 +1,4 @@
-use crate::CoreResult;
+use crate::Error;
 use crate::realtime::types::{RealtimeEvent, RealtimeTransformResult};
 
 pub trait RealtimeProviderConfig {
@@ -11,12 +11,12 @@ pub trait RealtimeProviderConfig {
         &self,
         event: &RealtimeEvent,
         model: &str,
-    ) -> CoreResult<RealtimeTransformResult>;
+    ) -> Result<RealtimeTransformResult, Error>;
 
     /// Transform a backend → client event before it is forwarded downstream.
     fn transform_realtime_response(
         &self,
         event: &RealtimeEvent,
         model: &str,
-    ) -> CoreResult<RealtimeTransformResult>;
+    ) -> Result<RealtimeTransformResult, Error>;
 }

--- a/litellm-rust/crates/core/src/responses/instrumentation.rs
+++ b/litellm-rust/crates/core/src/responses/instrumentation.rs
@@ -5,9 +5,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde_json::Value;
 
+use crate::Error;
 use crate::call_lifecycle::{CallLifecycleContext, CallLifecycleHooks, CallLifecycleTiming};
 use crate::responses::types::{ResponsesWsEvent, ResponsesWsEventType};
-use crate::{CoreError, CoreResult};
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct ResponsesWsUsage {
@@ -205,7 +205,7 @@ impl ResponsesWsInstrumentation {
     }
 }
 
-type LifecycleFuture<'a, T> = Pin<Box<dyn Future<Output = CoreResult<T>> + Send + 'a>>;
+type LifecycleFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T, Error>> + Send + 'a>>;
 
 impl CallLifecycleHooks<(), (), ()> for ResponsesWsInstrumentation {
     type PreCallFuture<'a> = LifecycleFuture<'a, ()>;
@@ -246,7 +246,7 @@ impl CallLifecycleHooks<(), (), ()> for ResponsesWsInstrumentation {
     fn async_log_failure_event<'a>(
         &'a self,
         _context: &'a CallLifecycleContext,
-        _error: &'a CoreError,
+        _error: &'a Error,
         _timing: &'a CallLifecycleTiming,
     ) -> Self::FailureFuture<'a> {
         Box::pin(async move {
@@ -342,7 +342,7 @@ mod tests {
                 ),
                 (),
                 &instrumentation,
-                |_| async { Ok::<(), CoreError>(()) },
+                |_| async { Ok::<(), Error>(()) },
             )
             .await;
 

--- a/litellm-rust/crates/core/src/responses/websocket.rs
+++ b/litellm-rust/crates/core/src/responses/websocket.rs
@@ -1,4 +1,4 @@
-use crate::CoreResult;
+use crate::Error;
 use crate::constants::{OPENAI_RESPONSES_DEFAULT_API_BASE, OPENAI_RESPONSES_PATH};
 use crate::responses::types::{ResponsesWsEvent, ResponsesWsEventType, ResponsesWsTransformResult};
 
@@ -19,13 +19,13 @@ pub trait ResponsesWebSocketProviderConfig: Sync {
         &self,
         event: &ResponsesWsEvent,
         model: &str,
-    ) -> CoreResult<ResponsesWsTransformResult>;
+    ) -> Result<ResponsesWsTransformResult, Error>;
 
     fn transform_ws_response(
         &self,
         event: &ResponsesWsEvent,
         model: &str,
-    ) -> CoreResult<ResponsesWsTransformResult>;
+    ) -> Result<ResponsesWsTransformResult, Error>;
 }
 
 pub fn complete_websocket_url(

--- a/litellm-rust/crates/python-bridge/src/lib.rs
+++ b/litellm-rust/crates/python-bridge/src/lib.rs
@@ -10,7 +10,7 @@ use litellm_core::chat_completions::types::{ChatCompletionsRequest, ChatCompleti
 use litellm_core::chat_completions::{
     chat_completions as run_chat_completions, chat_completions_decline_reason,
 };
-use litellm_core::error::CoreError;
+use litellm_core::error::Error;
 use litellm_core::messages::messages as run_messages;
 use litellm_core::messages::types::{AnthropicMessagesResponse, MessagesRequest};
 use litellm_python_interop::{from_py, release_count, release_gil, to_py};
@@ -54,13 +54,13 @@ fn chat_completions_response_to_py(
     to_py(py, &response)
 }
 
-fn core_error_to_pyerr(err: CoreError) -> PyErr {
+fn core_error_to_pyerr(err: Error) -> PyErr {
     match err {
-        CoreError::Auth(message) => PyValueError::new_err(message),
-        CoreError::InvalidProvider(_)
-        | CoreError::InvalidRequest(_)
-        | CoreError::InvalidType { .. }
-        | CoreError::MissingField(_) => PyValueError::new_err(err.to_string()),
+        Error::Auth(message) => PyValueError::new_err(message),
+        Error::InvalidProvider(_)
+        | Error::InvalidRequest(_)
+        | Error::InvalidType { .. }
+        | Error::MissingField(_) => PyValueError::new_err(err.to_string()),
         other => PyRuntimeError::new_err(other.to_string()),
     }
 }
@@ -71,22 +71,22 @@ fn core_error_to_pyerr(err: CoreError) -> PyErr {
 /// Everything raised before the request goes out is safe for the host to retry
 /// on its own path; anything after it is not, because the provider has already
 /// done the work and billed for it.
-fn chat_completions_error_to_pyerr(err: CoreError) -> PyErr {
+fn chat_completions_error_to_pyerr(err: Error) -> PyErr {
     match err {
-        CoreError::Unsupported(_)
-        | CoreError::Auth(_)
-        | CoreError::InvalidProvider(_)
-        | CoreError::InvalidRequest(_)
-        | CoreError::InvalidType { .. }
-        | CoreError::MissingField(_)
-        | CoreError::Routing(_)
+        Error::Unsupported(_)
+        | Error::Auth(_)
+        | Error::InvalidProvider(_)
+        | Error::InvalidRequest(_)
+        | Error::InvalidType { .. }
+        | Error::MissingField(_)
+        | Error::Routing(_)
         // Nothing reached the provider, so serving it on Python cannot double
         // bill and is the only way the caller gets an answer at all.
-        | CoreError::Connect(_) => RustBridgeDeclined::new_err(err.to_string()),
-        CoreError::Http { status, body } => {
+        | Error::Connect(_) => RustBridgeDeclined::new_err(err.to_string()),
+        Error::Http { status, body } => {
             RustUpstreamError::new_err((status, format!("{status}: {body}")))
         }
-        CoreError::Network(message) | CoreError::InvalidResponse(message) => {
+        Error::Network(message) | Error::InvalidResponse(message) => {
             RustUpstreamError::new_err((0u16, message))
         }
     }


### PR DESCRIPTION
Layer 3 of 17 in the reorganized Rust bridge stack.

## Scope

Makes `Error` the sole public core error type. Removes the `CoreError` compatibility alias, removes the `CoreResult<T>` alias, and migrates every existing Rust caller to `Error` plus explicit standard-library `Result<T, Error>` signatures.

## Review boundary

This is intentionally a mechanical whole-workspace API rename. It does not change fallback policy or error classification; those remain in later layers.

## Validation

This PR was checked independently in a dedicated worktree: formatting, all-features workspace compilation, and strict Clippy for core, interop, and bridge pass. The final stack additionally passes bridge tests.