### PR TITLE
feat(gemini): day-0 pricing for gemini-3.8-flash

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -23514,6 +23514,63 @@
         "web_search_billing_unit": "per_query",
         "google_maps_grounding_cost_per_query": 0.014
     },
+    "vertex_ai/gemini-3.8-flash": {
+        "prompt_cache_min_tokens": 4096,
+        "cache_read_input_token_cost": 7.5e-08,
+        "cache_read_input_token_cost_flex": 3.75e-08,
+        "input_cost_per_token": 7.5e-07,
+        "input_cost_per_token_batches": 3.75e-07,
+        "input_cost_per_token_flex": 3.75e-07,
+        "litellm_provider": "vertex_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "output_cost_per_reasoning_token": 3.75e-06,
+        "output_cost_per_token": 3.75e-06,
+        "output_cost_per_token_batches": 1.875e-06,
+        "output_cost_per_token_flex": 1.875e-06,
+        "regional_endpoint_uplift_multiplier": 1.1,
+        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/completions",
+            "/v1/batch"
+        ],
+        "supported_modalities": [
+            "text",
+            "image",
+            "audio",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_audio_input": true,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_url_context": true,
+        "supports_video_input": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_native_streaming": true,
+        "input_cost_per_token_priority": 1.35e-06,
+        "output_cost_per_token_priority": 6.75e-06,
+        "cache_read_input_token_cost_priority": 1.35e-07,
+        "search_context_cost_per_query": {
+            "search_context_size_low": 0.014,
+            "search_context_size_medium": 0.014,
+            "search_context_size_high": 0.014
+        },
+        "web_search_billing_unit": "per_query",
+        "google_maps_grounding_cost_per_query": 0.014
+    },
     "vertex_ai/gemini-3.1-pro-preview": {
         "prompt_cache_min_tokens": 4096,
         "cache_read_input_token_cost": 2e-07,
@@ -25351,6 +25408,65 @@
         "web_search_billing_unit": "per_query",
         "google_maps_grounding_cost_per_query": 0.014
     },
+    "gemini/gemini-3.8-flash": {
+        "prompt_cache_min_tokens": 4096,
+        "cache_read_input_token_cost": 7.5e-08,
+        "cache_read_input_token_cost_flex": 3.75e-08,
+        "input_cost_per_token": 7.5e-07,
+        "input_cost_per_token_batches": 3.75e-07,
+        "input_cost_per_token_flex": 3.75e-07,
+        "litellm_provider": "gemini",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "output_cost_per_reasoning_token": 3.75e-06,
+        "output_cost_per_token": 3.75e-06,
+        "output_cost_per_token_batches": 1.875e-06,
+        "output_cost_per_token_flex": 1.875e-06,
+        "rpm": 2000,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/completions",
+            "/v1/batch"
+        ],
+        "supported_modalities": [
+            "text",
+            "image",
+            "audio",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_audio_output": false,
+        "supports_audio_input": true,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_url_context": true,
+        "supports_video_input": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_native_streaming": true,
+        "tpm": 800000,
+        "input_cost_per_token_priority": 1.35e-06,
+        "output_cost_per_token_priority": 6.75e-06,
+        "cache_read_input_token_cost_priority": 1.35e-07,
+        "search_context_cost_per_query": {
+            "search_context_size_low": 0.014,
+            "search_context_size_medium": 0.014,
+            "search_context_size_high": 0.014
+        },
+        "web_search_billing_unit": "per_query",
+        "google_maps_grounding_cost_per_query": 0.014
+    },
     "gemini/gemini-omni-flash-preview": {
         "input_cost_per_audio_token": 1.5e-06,
         "input_cost_per_token": 1.5e-06,
@@ -25703,6 +25819,63 @@
         "google_maps_grounding_cost_per_query": 0.014
     },
     "gemini-3.7-flash": {
+        "prompt_cache_min_tokens": 4096,
+        "cache_read_input_token_cost": 7.5e-08,
+        "cache_read_input_token_cost_flex": 3.75e-08,
+        "input_cost_per_token": 7.5e-07,
+        "input_cost_per_token_batches": 3.75e-07,
+        "input_cost_per_token_flex": 3.75e-07,
+        "litellm_provider": "vertex_ai-language-models",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "output_cost_per_reasoning_token": 3.75e-06,
+        "output_cost_per_token": 3.75e-06,
+        "output_cost_per_token_batches": 1.875e-06,
+        "output_cost_per_token_flex": 1.875e-06,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/completions",
+            "/v1/batch"
+        ],
+        "supported_modalities": [
+            "text",
+            "image",
+            "audio",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_audio_output": false,
+        "supports_audio_input": true,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_url_context": true,
+        "supports_video_input": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_native_streaming": true,
+        "input_cost_per_token_priority": 1.35e-06,
+        "output_cost_per_token_priority": 6.75e-06,
+        "cache_read_input_token_cost_priority": 1.35e-07,
+        "search_context_cost_per_query": {
+            "search_context_size_low": 0.014,
+            "search_context_size_medium": 0.014,
+            "search_context_size_high": 0.014
+        },
+        "web_search_billing_unit": "per_query",
+        "google_maps_grounding_cost_per_query": 0.014
+    },
+    "gemini-3.8-flash": {
         "prompt_cache_min_tokens": 4096,
         "cache_read_input_token_cost": 7.5e-08,
         "cache_read_input_token_cost_flex": 3.75e-08,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -23514,6 +23514,63 @@
         "web_search_billing_unit": "per_query",
         "google_maps_grounding_cost_per_query": 0.014
     },
+    "vertex_ai/gemini-3.8-flash": {
+        "prompt_cache_min_tokens": 4096,
+        "cache_read_input_token_cost": 7.5e-08,
+        "cache_read_input_token_cost_flex": 3.75e-08,
+        "input_cost_per_token": 7.5e-07,
+        "input_cost_per_token_batches": 3.75e-07,
+        "input_cost_per_token_flex": 3.75e-07,
+        "litellm_provider": "vertex_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "output_cost_per_reasoning_token": 3.75e-06,
+        "output_cost_per_token": 3.75e-06,
+        "output_cost_per_token_batches": 1.875e-06,
+        "output_cost_per_token_flex": 1.875e-06,
+        "regional_endpoint_uplift_multiplier": 1.1,
+        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/completions",
+            "/v1/batch"
+        ],
+        "supported_modalities": [
+            "text",
+            "image",
+            "audio",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_audio_input": true,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_url_context": true,
+        "supports_video_input": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_native_streaming": true,
+        "input_cost_per_token_priority": 1.35e-06,
+        "output_cost_per_token_priority": 6.75e-06,
+        "cache_read_input_token_cost_priority": 1.35e-07,
+        "search_context_cost_per_query": {
+            "search_context_size_low": 0.014,
+            "search_context_size_medium": 0.014,
+            "search_context_size_high": 0.014
+        },
+        "web_search_billing_unit": "per_query",
+        "google_maps_grounding_cost_per_query": 0.014
+    },
     "vertex_ai/gemini-3.1-pro-preview": {
         "prompt_cache_min_tokens": 4096,
         "cache_read_input_token_cost": 2e-07,
@@ -25351,6 +25408,65 @@
         "web_search_billing_unit": "per_query",
         "google_maps_grounding_cost_per_query": 0.014
     },
+    "gemini/gemini-3.8-flash": {
+        "prompt_cache_min_tokens": 4096,
+        "cache_read_input_token_cost": 7.5e-08,
+        "cache_read_input_token_cost_flex": 3.75e-08,
+        "input_cost_per_token": 7.5e-07,
+        "input_cost_per_token_batches": 3.75e-07,
+        "input_cost_per_token_flex": 3.75e-07,
+        "litellm_provider": "gemini",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "output_cost_per_reasoning_token": 3.75e-06,
+        "output_cost_per_token": 3.75e-06,
+        "output_cost_per_token_batches": 1.875e-06,
+        "output_cost_per_token_flex": 1.875e-06,
+        "rpm": 2000,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/completions",
+            "/v1/batch"
+        ],
+        "supported_modalities": [
+            "text",
+            "image",
+            "audio",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_audio_output": false,
+        "supports_audio_input": true,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_url_context": true,
+        "supports_video_input": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_native_streaming": true,
+        "tpm": 800000,
+        "input_cost_per_token_priority": 1.35e-06,
+        "output_cost_per_token_priority": 6.75e-06,
+        "cache_read_input_token_cost_priority": 1.35e-07,
+        "search_context_cost_per_query": {
+            "search_context_size_low": 0.014,
+            "search_context_size_medium": 0.014,
+            "search_context_size_high": 0.014
+        },
+        "web_search_billing_unit": "per_query",
+        "google_maps_grounding_cost_per_query": 0.014
+    },
     "gemini/gemini-omni-flash-preview": {
         "input_cost_per_audio_token": 1.5e-06,
         "input_cost_per_token": 1.5e-06,
@@ -25703,6 +25819,63 @@
         "google_maps_grounding_cost_per_query": 0.014
     },
     "gemini-3.7-flash": {
+        "prompt_cache_min_tokens": 4096,
+        "cache_read_input_token_cost": 7.5e-08,
+        "cache_read_input_token_cost_flex": 3.75e-08,
+        "input_cost_per_token": 7.5e-07,
+        "input_cost_per_token_batches": 3.75e-07,
+        "input_cost_per_token_flex": 3.75e-07,
+        "litellm_provider": "vertex_ai-language-models",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "output_cost_per_reasoning_token": 3.75e-06,
+        "output_cost_per_token": 3.75e-06,
+        "output_cost_per_token_batches": 1.875e-06,
+        "output_cost_per_token_flex": 1.875e-06,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/completions",
+            "/v1/batch"
+        ],
+        "supported_modalities": [
+            "text",
+            "image",
+            "audio",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_audio_output": false,
+        "supports_audio_input": true,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_url_context": true,
+        "supports_video_input": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_native_streaming": true,
+        "input_cost_per_token_priority": 1.35e-06,
+        "output_cost_per_token_priority": 6.75e-06,
+        "cache_read_input_token_cost_priority": 1.35e-07,
+        "search_context_cost_per_query": {
+            "search_context_size_low": 0.014,
+            "search_context_size_medium": 0.014,
+            "search_context_size_high": 0.014
+        },
+        "web_search_billing_unit": "per_query",
+        "google_maps_grounding_cost_per_query": 0.014
+    },
+    "gemini-3.8-flash": {
         "prompt_cache_min_tokens": 4096,
         "cache_read_input_token_cost": 7.5e-08,
         "cache_read_input_token_cost_flex": 3.75e-08,

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
@@ -4220,9 +4220,44 @@ def test_gemini_38_flash_launch_pricing(model, input_cost, output_cost, cache_re
     assert model_cost_map["max_input_tokens"] == 1048576
 
 
-def test_gemini_38_flash_matches_37_flash_promotional_pricing(_local_model_cost_map):
-    for prefix in ("", "gemini/", "vertex_ai/"):
-        assert litellm.model_cost[f"{prefix}gemini-3.8-flash"] == litellm.model_cost[f"{prefix}gemini-3.7-flash"]
+GEMINI_38_FLASH_FIELDS_SHARED_WITH_37_FLASH = (
+    "input_cost_per_token",
+    "output_cost_per_token",
+    "output_cost_per_reasoning_token",
+    "cache_read_input_token_cost",
+    "input_cost_per_token_batches",
+    "output_cost_per_token_batches",
+    "input_cost_per_token_flex",
+    "output_cost_per_token_flex",
+    "cache_read_input_token_cost_flex",
+    "input_cost_per_token_priority",
+    "output_cost_per_token_priority",
+    "cache_read_input_token_cost_priority",
+    "search_context_cost_per_query",
+    "google_maps_grounding_cost_per_query",
+    "prompt_cache_min_tokens",
+    "max_input_tokens",
+    "max_output_tokens",
+    "supports_reasoning",
+    "supports_function_calling",
+    "supports_prompt_caching",
+    "supports_vision",
+    "supports_pdf_input",
+    "supports_audio_input",
+    "supports_video_input",
+    "supports_response_schema",
+    "supports_tool_choice",
+    "supports_web_search",
+    "supports_url_context",
+)
+
+
+@pytest.mark.parametrize("prefix", ["", "gemini/", "vertex_ai/"])
+def test_gemini_38_flash_matches_37_flash_promotional_pricing(prefix, _local_model_cost_map):
+    new_model = litellm.model_cost[f"{prefix}gemini-3.8-flash"]
+    old_model = litellm.model_cost[f"{prefix}gemini-3.7-flash"]
+    for field in GEMINI_38_FLASH_FIELDS_SHARED_WITH_37_FLASH:
+        assert new_model[field] == old_model[field], field
 
 
 def test_generic_cost_per_token_gemini_38_flash(_local_model_cost_map):

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
@@ -4200,6 +4200,51 @@ def test_generic_cost_per_token_gemini_37_flash(_local_model_cost_map):
     assert completion_cost == pytest.approx(0.001875)
 
 
+GEMINI_38_FLASH_LAUNCH_PRICING = [
+    ("gemini-3.8-flash", 7.5e-07, 3.75e-06, 7.5e-08),
+    ("gemini/gemini-3.8-flash", 7.5e-07, 3.75e-06, 7.5e-08),
+    ("vertex_ai/gemini-3.8-flash", 7.5e-07, 3.75e-06, 7.5e-08),
+]
+
+
+@pytest.mark.parametrize("model,input_cost,output_cost,cache_read_cost", GEMINI_38_FLASH_LAUNCH_PRICING)
+def test_gemini_38_flash_launch_pricing(model, input_cost, output_cost, cache_read_cost, _local_model_cost_map):
+    model_cost_map = litellm.model_cost[model]
+    assert model_cost_map["input_cost_per_token"] == input_cost
+    assert model_cost_map["output_cost_per_token"] == output_cost
+    assert model_cost_map["output_cost_per_reasoning_token"] == output_cost
+    assert model_cost_map["cache_read_input_token_cost"] == cache_read_cost
+    assert model_cost_map["mode"] == "chat"
+    assert model_cost_map["supports_reasoning"] is True
+    assert model_cost_map["supports_function_calling"] is True
+    assert model_cost_map["max_input_tokens"] == 1048576
+
+
+def test_gemini_38_flash_matches_37_flash_promotional_pricing(_local_model_cost_map):
+    for prefix in ("", "gemini/", "vertex_ai/"):
+        assert litellm.model_cost[f"{prefix}gemini-3.8-flash"] == litellm.model_cost[f"{prefix}gemini-3.7-flash"]
+
+
+def test_generic_cost_per_token_gemini_38_flash(_local_model_cost_map):
+    usage = Usage(
+        prompt_tokens=1000,
+        completion_tokens=500,
+        total_tokens=1500,
+        completion_tokens_details=CompletionTokensDetailsWrapper(
+            reasoning_tokens=200,
+            text_tokens=300,
+        ),
+        prompt_tokens_details=PromptTokensDetailsWrapper(text_tokens=1000),
+    )
+    prompt_cost, completion_cost = generic_cost_per_token(
+        model="gemini-3.8-flash",
+        usage=usage,
+        custom_llm_provider="gemini",
+    )
+    assert prompt_cost == pytest.approx(0.00075)
+    assert completion_cost == pytest.approx(0.001875)
+
+
 def test_grok_46_launch_pricing(_local_model_cost_map):
     model_cost_map = litellm.model_cost["xai/grok-4.6"]
     assert model_cost_map["input_cost_per_token"] == 2e-06

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_ai_gemini_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_ai_gemini_transformation.py
@@ -1096,10 +1096,13 @@ def test_natively_signed_parallel_turn_never_carries_a_placeholder(model):
         "gemini-3.5-flash",
         "gemini-3.6-flash",
         "gemini-3.7-flash",
+        "gemini-3.8-flash",
         "vertex_ai/gemini-3.5-flash",
         "vertex_ai/gemini-3.7-flash",
+        "vertex_ai/gemini-3.8-flash",
         "gemini/gemini-3.5-flash",
         "gemini/gemini-3.7-flash",
+        "gemini/gemini-3.8-flash",
     ],
 )
 def test_placeholder_scoped_to_first_call_across_gemini_3_variants(model):

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -4655,6 +4655,7 @@ GEMINI_4096_CACHE_MIN_MODELS: Final = tuple(
         "gemini-3.5-flash",
         "gemini-3.6-flash",
         "gemini-3.7-flash",
+        "gemini-3.8-flash",
         "gemini-3.1-pro-preview",
         "gemini-3.1-pro-preview-customtools",
     )


### PR DESCRIPTION
## TLDR

Problem this solves:

- Gemini 3.8 Flash launched today with no cost map entry
- Requests route fine but spend tracking silently records $0

How it solves it:

- Adds `gemini/`, `vertex_ai/`, and bare `gemini-3.8-flash` cost map entries
- Same promo pricing as 3.7 Flash through Dec 31, 2026: $0.75 input / $3.75 output per 1M
- Limits and capabilities mirror 3.7 Flash: 1M context, 64k output, thinking, caching, batch
- Regression tests lock the launch prices and the 4096-token cache minimum in

## User Flow

Before: a team adds Gemini 3.8 Flash to their gateway on launch day and every request comes back unpriced, so spend tracking and budgets silently miss it

1. The proxy admin adds a `gemini/gemini-3.8-flash` deployment to the model list and starts the proxy
2. A developer sends POST https://litellm-domain/v1/chat/completions with `"model": "gemini-3.8-flash"` and a user message
3. They get a 200 with the model's reply and real token usage, but the response has no `x-litellm-response-cost` header, only `x-litellm-response-cost-input: 0.0` and `x-litellm-response-cost-output: 0.0`
4. GET https://litellm-domain/spend/logs lists the request with `"spend": 0.0`, and key and team budgets never count it

After: the same request is priced at the launch rate and spend shows up everywhere

1. The proxy admin adds a `gemini/gemini-3.8-flash` deployment to the model list and starts the proxy
2. A developer sends POST https://litellm-domain/v1/chat/completions with `"model": "gemini-3.8-flash"` and a user message
3. They get a 200 with the model's reply, and the response carries `x-litellm-response-cost: 0.00111525`, exactly 12 input tokens at $0.75/M plus 295 output tokens (262 reasoning + 33 text) at $3.75/M
4. GET https://litellm-domain/spend/logs lists the request with `"spend": 0.00111525`, and key and team budgets count it

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Live proxies, real Gemini API calls, same config, prompt, and request order on both legs. Each leg runs 2 uvicorn workers against its own Postgres with `LITELLM_LOCAL_MODEL_COST_MAP=True`, so it prices from the bundled map of the commit it was booted from. The change lives in the shared cost map, so all three unified endpoints are proven on each leg

Config:

```yaml
model_list:
  - model_name: gemini-3.8-flash
    litellm_params:
      model: gemini/gemini-3.8-flash
      api_key: os.environ/GEMINI_API_KEY

general_settings:
  master_key: sk-gemini38-qa
```

Requests, identical on both legs (prompt `In one short sentence, what is LiteLLM?`):

```bash
H='-H "Authorization: Bearer sk-gemini38-qa" -H "Content-Type: application/json"'
curl -sD - -o /dev/null http://localhost:$PORT/v1/chat/completions $H -d '{"model":"gemini-3.8-flash","messages":[{"role":"user","content":"<prompt>"}]}' | grep -i x-litellm-response-cost
curl -sD - -o /dev/null http://localhost:$PORT/v1/responses $H -d '{"model":"gemini-3.8-flash","input":"<prompt>"}' | grep -i x-litellm-response-cost
curl -sD - -o /dev/null http://localhost:$PORT/v1/messages $H -d '{"model":"gemini-3.8-flash","max_tokens":512,"messages":[{"role":"user","content":"<prompt>"}]}' | grep -i x-litellm-response-cost
curl -s http://localhost:$PORT/spend/logs $H | jq -r '.[] | [.call_type, .model, .spend, .prompt_tokens, .completion_tokens] | @tsv'
curl -s "http://localhost:$PORT/v1/model/info" $H | jq '.data[0].model_info | {max_input_tokens, input_cost_per_token, output_cost_per_token, supports_reasoning}'
```

### Before (31ca4ddf32, merge base, port 16280)

1. POST /v1/chat/completions: 200, usage 12 prompt / 335 completion (302 reasoning + 33 text), no `x-litellm-response-cost` header, breakdown all zeros
2. POST /v1/responses: 200, usage 12 input / 265 output, no `x-litellm-response-cost` header, breakdown all zeros
3. POST /v1/messages: 200, usage 12 input / 305 output, no `x-litellm-response-cost` header, breakdown all zeros
4. GET /spend/logs: every row for the model is recorded at zero spend

```
x-litellm-response-cost-original: 0.0
x-litellm-response-cost-input: 0.0
x-litellm-response-cost-output: 0.0
```

```
acompletion         gemini/gemini-3.8-flash  0.0  12  335
aresponses          gemini/gemini-3.8-flash  0.0  12  265
anthropic_messages  gemini/gemini-3.8-flash  0.0  12  305
```

5. GET /v1/model/info: `max_input_tokens: null`, `input_cost_per_token: 0`, `output_cost_per_token: 0`, `supports_reasoning: null`

### After (69cd1bada6, PR tip, port 16281)

1. POST /v1/chat/completions: 200, usage 12 prompt / 295 completion (262 reasoning + 33 text), priced
2. POST /v1/responses: 200, usage 12 input / 245 output, priced
3. POST /v1/messages: 200, usage 12 input / 224 output, priced
4. GET /spend/logs: every row carries the real spend

```
x-litellm-response-cost: 0.00111525            # chat completions
x-litellm-response-cost-input: 9e-06
x-litellm-response-cost-output: 0.00110625
x-litellm-response-cost-reasoning: 0.0009825

x-litellm-response-cost: 0.0009277500000000001 # responses
x-litellm-response-cost-input: 9e-06
x-litellm-response-cost-output: 0.0009187500000000001

x-litellm-response-cost: 0.000849              # messages
x-litellm-response-cost-input: 9e-06
x-litellm-response-cost-output: 0.00084
```

```
acompletion         gemini/gemini-3.8-flash  0.00111525  12  295
aresponses          gemini/gemini-3.8-flash  0.00092775  12  245
anthropic_messages  gemini/gemini-3.8-flash  0.000849    12  224
```

5. GET /v1/model/info: `max_input_tokens: 1048576`, `input_cost_per_token: 7.5e-7`, `output_cost_per_token: 3.75e-6`, `supports_reasoning: true`

Cost math, every endpoint: 12 * 0.75/1e6 + output_tokens * 3.75/1e6, e.g. chat 9e-6 + 0.00110625 = 0.00111525, matching the header and the spend row exactly

Merge-ref check: the tip merged into current `litellm_internal_staging` (da749ef0bf) boots and prices all three endpoints the same way (0.0013365 / 0.001164 / 0.001404 for 354 / 308 / 372 output tokens)

QA notes, observed on both legs and left alone by this PR:

- Streamed chat sends its cost headers as 0.0 on both legs
- The streamed request's spend row is priced correctly on the tip
- `/model_group/info` reports `supports_prompt_caching: null` on both legs

## Type

🆕 New Feature

## Caveats (if any)

### Low

- Prices are Google's promo rate through Dec 31, 2026 and need a bump when it ends
- Only the `gemini/` leg was QA'd live; the `vertex_ai/` entry mirrors 3.7 Flash's and Vertex availability wasn't checked
- Bare `gemini-3.8-flash` in the SDK now resolves to Vertex AI instead of raising a missing-provider error, the same as every other bare Gemini entry in the map
- The Gemini Family auto-router preset still points its COMPLEX tier at 3.7 Flash, left for a separate call

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> JSON cost-map and test-only changes; incorrect rates would misreport spend but would not affect routing or auth.
> 
> **Overview**
> Adds **Gemini 3.8 Flash** to LiteLLM’s model cost maps so proxy spend tracking, cost headers, and budgets stop recording **$0** for that model on launch day.
> 
> New entries cover **`gemini/gemini-3.8-flash`**, **`vertex_ai/gemini-3.8-flash`**, and bare **`gemini-3.8-flash`**, with promo rates aligned to **3.7 Flash** ($0.75/M input, $3.75/M output), flex/batch/priority tiers, 1M context, reasoning, caching (**4096** min cache tokens), and web search / grounding costs. **`model_prices_and_context_window.json`** and its backup are updated in parallel.
> 
> Tests lock launch pricing across all three key forms, assert **3.8 matches 3.7** on shared cost/limit fields, exercise **`generic_cost_per_token`** with reasoning tokens, include **3.8** in the Vertex Gemini 3 placeholder regression list, and extend the **4096 cache minimum** model tuple.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69cd1bada6249889a9412155a6086faea65bfe6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
- [x] 69cd1bada6249889a9412155a6086faea65bfe6c passes /live-pr-risk
