### PR TITLE
fix(bedrock_mantle): anchor MANTLE_HOST_RE so custom Mantle hosts are honored

### DIFF
--- a/litellm/llms/bedrock_mantle/common_utils.py
+++ b/litellm/llms/bedrock_mantle/common_utils.py
@@ -29,7 +29,7 @@ from litellm.secret_managers.main import get_secret_str
 BEDROCK_MANTLE_DEFAULT_REGION: Final = "us-east-1"
 
 # Standard Mantle host: https://bedrock-mantle.<region>.api.aws (group 1 = region).
-MANTLE_HOST_RE: Final = re.compile(r"^https?://bedrock-mantle\.([^/.]+)\.api\.aws", re.IGNORECASE)
+MANTLE_HOST_RE: Final = re.compile(r"^https?://bedrock-mantle\.([^/.]+)\.api\.aws(?=/|$)", re.IGNORECASE)
 
 
 def resolve_mantle_bearer_token(api_key: str | None) -> str | None:

--- a/tests/test_litellm/llms/bedrock_mantle/passthrough/test_bedrock_mantle_passthrough_transformation.py
+++ b/tests/test_litellm/llms/bedrock_mantle/passthrough/test_bedrock_mantle_passthrough_transformation.py
@@ -68,6 +68,27 @@ def test_explicit_region_and_non_mantle_api_base_are_kept(no_ambient_aws):
     assert base_url == vpc_endpoint
 
 
+@pytest.mark.parametrize(
+    "lookalike_host",
+    [
+        "https://bedrock-mantle.us-east-1.api.aws.internal.example.com",
+        "https://bedrock-mantle.us-gov-west-1.api.aws-int.example.com",
+        "https://bedrock-mantle.us-east-1.api.aws:8443",
+    ],
+)
+def test_lookalike_mantle_host_api_base_is_kept(no_ambient_aws, lookalike_host):
+    url, base_url = BedrockMantlePassthroughConfig().get_complete_url(
+        api_base=lookalike_host,
+        api_key=None,
+        model="us.openai.gpt-5.6-sol",
+        endpoint=INVOKE_ENDPOINT,
+        request_query_params=None,
+        litellm_params={"api_base": lookalike_host},
+    )
+    assert str(url) == f"{lookalike_host}/{INVOKE_ENDPOINT}"
+    assert base_url == lookalike_host
+
+
 def test_region_falls_back_to_the_mantle_default_without_any_hint(no_ambient_aws):
     url, _ = BedrockMantlePassthroughConfig().get_complete_url(
         api_base=None,

--- a/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_responses_transformation.py
+++ b/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_responses_transformation.py
@@ -26,6 +26,12 @@ from litellm.llms.bedrock_mantle.responses.transformation import (
 from litellm.types.router import GenericLiteLLMParams
 from litellm.types.utils import LlmProviders
 
+LOOKALIKE_MANTLE_HOSTS = (
+    "https://bedrock-mantle.us-east-1.api.aws.internal.example.com",
+    "https://bedrock-mantle.us-gov-west-1.api.aws-int.example.com",
+    "https://bedrock-mantle.us-east-1.api.aws:8443",
+)
+
 
 class TestBedrockMantleResponsesURL:
     def test_url_uses_region_from_env(self, monkeypatch):
@@ -1554,6 +1560,23 @@ class TestBedrockMantleResponsesSigV4:
             litellm_params={"aws_region_name": "us-east-2"},
         )
         assert url == "https://mantle-proxy.internal.example/openai/v1/responses"
+
+    @pytest.mark.parametrize("lookalike_host", LOOKALIKE_MANTLE_HOSTS)
+    def test_lookalike_mantle_host_from_api_base_is_preserved(self, monkeypatch, lookalike_host):
+        monkeypatch.delenv("BEDROCK_MANTLE_API_BASE", raising=False)
+        cfg = BedrockMantleResponsesAPIConfig()
+        url = cfg.get_complete_url(
+            api_base=f"{lookalike_host}/openai/v1",
+            litellm_params={"aws_region_name": "us-east-2"},
+        )
+        assert url == f"{lookalike_host}/openai/v1/responses"
+
+    @pytest.mark.parametrize("lookalike_host", LOOKALIKE_MANTLE_HOSTS)
+    def test_lookalike_mantle_host_from_env_is_preserved(self, monkeypatch, lookalike_host):
+        monkeypatch.setenv("BEDROCK_MANTLE_API_BASE", lookalike_host)
+        cfg = BedrockMantleResponsesAPIConfig()
+        url = cfg.get_complete_url(api_base=None, litellm_params={})
+        assert url == f"{lookalike_host}/openai/v1/responses"
 
     def test_caller_authorization_does_not_override_sigv4(self, monkeypatch):
         """Adversarial-review regression: a caller-supplied Authorization header (e.g.

--- a/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py
+++ b/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py
@@ -399,6 +399,46 @@ class TestBedrockMantleChatAuth:
         assert "/eu-west-1/bedrock/aws4_request" in headers["Authorization"]
         assert "/us-west-2/bedrock/aws4_request" not in headers["Authorization"]
 
+    @pytest.mark.parametrize(
+        ("region_params", "env", "expected_region"),
+        [
+            ({"aws_region_name": "us-west-2"}, {}, "us-west-2"),
+            ({}, {"BEDROCK_MANTLE_REGION": "ap-southeast-2"}, "ap-southeast-2"),
+        ],
+    )
+    def test_sigv4_scope_ignores_the_region_segment_of_a_lookalike_host(
+        self, monkeypatch, region_params, env, expected_region
+    ):
+        from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
+
+        for var in (
+            "BEDROCK_MANTLE_API_KEY",
+            "AWS_BEARER_TOKEN_BEDROCK",
+            "BEDROCK_MANTLE_REGION",
+            "BEDROCK_MANTLE_API_BASE",
+            "AWS_REGION",
+            "AWS_REGION_NAME",
+        ):
+            monkeypatch.delenv(var, raising=False)
+        for var, value in env.items():
+            monkeypatch.setenv(var, value)
+
+        cfg = BedrockMantleChatConfig(aws_signer=BaseAWSLLM())
+        headers, _ = cfg.sign_request(
+            headers={},
+            optional_params={
+                "aws_access_key_id": "AKIAEXAMPLE",
+                "aws_secret_access_key": "c2VjcmV0LXRlc3Qtc2VjcmV0LXRlc3Qtc2VjcmV0",
+                **region_params,
+            },
+            request_data={"input": "hi"},
+            api_base="https://bedrock-mantle.eu-west-1.api.aws.internal.example.com/openai/v1/chat/completions",
+            api_key=None,
+        )
+
+        assert f"/{expected_region}/bedrock/aws4_request" in headers["Authorization"]
+        assert "/eu-west-1/bedrock/aws4_request" not in headers["Authorization"]
+
     def test_no_bearer_and_no_credentials_raises_value_error(self, monkeypatch):
         from unittest.mock import MagicMock
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Custom Mantle hosts starting with `bedrock-mantle.<region>.api.aws` were rewritten to the public host
- Responses, GPT-5.x chat (served through Responses), and native passthrough all ignored the configured host
- Closed environments timed out against a host they cannot reach, with no config workaround

How it solves it:

- Anchor the public-host pattern so only the exact `bedrock-mantle.<region>.api.aws` host matches
- Suffixed, alternate-partition, and non-443-port hosts now pass through unchanged
- A lookalike host no longer lends its region to SigV4; explicit region config wins

## User Flow

Before: an operator whose Mantle endpoint is a private host like `https://bedrock-mantle.us-east-1.api.aws.corp.example` sets it as `BEDROCK_MANTLE_API_BASE` (or as the deployment's `api_base`), and every Responses, GPT-5.x chat, and native passthrough call still goes to the public AWS host, which their network cannot reach

1. They set `BEDROCK_MANTLE_API_BASE=https://bedrock-mantle.us-east-1.api.aws.corp.example` (or that value as `api_base` on the deployment) and start the proxy with a `bedrock_mantle/openai.gpt-5.6-sol` deployment
2. They send POST https://litellm-domain/v1/responses with `{"model": "mantle-gpt", "input": "Say pong"}`
3. The call fails with a 500 connection timeout naming `bedrock-mantle.us-east-1.api.aws`, and their private endpoint's access log shows no request
4. They send POST https://litellm-domain/v1/chat/completions with the same GPT-5.x deployment and get the same timeout, since that model is served through Responses
5. They send POST https://litellm-domain/bedrock/model/us.openai.gpt-5.6-sol/converse and it times out against `bedrock-runtime.us-east-1.amazonaws.com` instead of their host
6. Only POST https://litellm-domain/v1/chat/completions with a `bedrock_mantle/openai.gpt-oss-120b` deployment reaches their private host

After: the same private host is honored on every route, and the calls come back 200 through it

1. They set `BEDROCK_MANTLE_API_BASE=https://bedrock-mantle.us-east-1.api.aws.corp.example` (or that value as `api_base` on the deployment) and start the proxy with a `bedrock_mantle/openai.gpt-5.6-sol` deployment
2. They send POST https://litellm-domain/v1/responses with `{"model": "mantle-gpt", "input": "Say pong"}`
3. The call returns 200 with an id like `resp_...`, and their private endpoint's access log shows `POST /openai/v1/responses`
4. They send POST https://litellm-domain/v1/chat/completions with the same GPT-5.x deployment and get 200 with `"content": "pong"`, again through their private host
5. They send POST https://litellm-domain/bedrock/model/us.openai.gpt-5.6-sol/converse and get 200 through `https://bedrock-mantle.us-east-1.api.aws.corp.example/model/us.openai.gpt-5.6-sol/converse`
6. POST https://litellm-domain/v1/chat/completions with the `bedrock_mantle/openai.gpt-oss-120b` deployment keeps reaching their private host as before

## Relevant issues

## Linear ticket

Resolves LIT-6640

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup, identical on both sides: a local TLS reverse proxy plays the customer-shaped private host `https://bedrock-mantle.us-east-1.api.aws.localtest.me:9443` (a `bedrock-mantle.<region>.api.aws.<y>.<z>` name, resolving to 127.0.0.1) and forwards to the real public Mantle host (and to the real `bedrock-runtime` for `/model/...` paths), appending one line per hit to its access log. Real calls, real spend, `AWS_BEARER_TOKEN_BEDROCK` from the CI account. Both proxies run with no DB, 2 uvicorn workers each (`--num_workers 2`), on a random port with this env and config

```
BEDROCK_MANTLE_API_BASE=https://bedrock-mantle.us-east-1.api.aws.localtest.me:9443
SSL_CERT_FILE=<certifi bundle plus the reverse proxy CA>
AWS_BEARER_TOKEN_BEDROCK=<real token>
```

```yaml
model_list:
  - model_name: mantle-gpt
    litellm_params:
      model: bedrock_mantle/openai.gpt-5.6-sol
      aws_region_name: us-east-1
  - model_name: mantle-gpt-apibase
    litellm_params:
      model: bedrock_mantle/openai.gpt-5.6-sol
      aws_region_name: us-east-1
      api_base: https://bedrock-mantle.us-east-1.api.aws.localtest.me:9443/openai/v1
  - model_name: mantle-gpt-pt
    litellm_params:
      model: bedrock_mantle/us.openai.gpt-5.6-sol
      aws_region_name: us-east-1
      api_base: https://bedrock-mantle.us-east-1.api.aws.localtest.me:9443
  - model_name: mantle-gpt-public
    litellm_params:
      model: bedrock_mantle/openai.gpt-5.6-sol
      aws_region_name: us-east-1
      api_base: https://bedrock-mantle.us-east-1.api.aws/openai/v1
general_settings:
  master_key: sk-1234
```

The Before proxy runs the merge base on port 44776 and the After proxy runs the PR tip on port 58776, which is why the curls below name those ports instead of 4000. Each case shows the curl, the response, and the new lines in the private host's access log, which is the operator's own evidence of whether the request reached their endpoint. Cases 1 through 5 are the surfaces that ride the anchored pattern (Responses directly, chat completions and Anthropic messages on a GPT-5.x model that LiteLLM serves through Responses, and native passthrough); cases 6 and 7 are controls that must not change


### Before (2ffe6a1dc8)

#### Case 1: Responses with `BEDROCK_MANTLE_API_BASE` only (`mantle-gpt`)

1. Run
   ```
   curl -sD - http://127.0.0.1:44776/v1/responses -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"mantle-gpt","input":"Say pong","max_output_tokens":64}'
   ```
2. Response
   ```
   HTTP/1.1 200 OK
   x-litellm-model-api-base: https://bedrock-mantle.us-east-1.api.aws.localtest.me:9443
   body: {"id":"resp_8QRZRFwyr8EgcFPIMeWruG8lqkkakzsP__1UE9kvTRIFlWWD6GmAxlrNvu_VwKDqlJm_eW8MsLB1lSFeXcufcPvBfyNY7ex-VEqp7f9CoGn5OAIXRXwsTQLpfbPYdsID91fv2XDSTooSUGMBmyyU8vSyx8WJOH8m3fGYBz1GA8ANFHLgKz0NvhTl5AIMOL3l3b2ZLV2HTOtlo0n0U0_gZgapGMNuWS51pgiFlVRJGj_95mpai_XduNhC
   ```
3. New lines in the private host's access log
   ```
   (none)
   ```

#### Case 2: Responses with `api_base` on the deployment (`mantle-gpt-apibase`)

1. Run
   ```
   curl -sD - http://127.0.0.1:44776/v1/responses -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"mantle-gpt-apibase","input":"Say pong","max_output_tokens":64}'
   ```
2. Response
   ```
   HTTP/1.1 200 OK
   x-litellm-model-api-base: https://bedrock-mantle.us-east-1.api.aws.localtest.me:9443/openai/v1
   body: {"id":"resp_2b_WeRJFZaHABV3lsliwYcRbar2r4NO3lnc8TLRreOUkuvQ9j-t_M0-BFJDUGBECuldRMKjZSb8hKdUbXSmY_vZov8rhmtsTnr9gtrHHkfIFvdJC7CROKk9SuuIBYQhAy_Akr8f9nzno5eoC0nID6e43sMN0SxHLT_Kf_dmZVmGPsox9BxP-iigeLjZinXQutCukOxphCzdMiG9-O5ViKRlLVDXB87xxdDBpg9K8ZLf-75tF5C-7Brrs
   ```
3. New lines in the private host's access log
   ```
   (none)
   ```

#### Case 3: Chat completions on a GPT-5.x deployment, served through Responses (`mantle-gpt-apibase`)

1. Run
   ```
   curl -sD - http://127.0.0.1:44776/v1/chat/completions -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"mantle-gpt-apibase","messages":[{"role":"user","content":"Say pong"}],"max_tokens":64}'
   ```
2. Response
   ```
   HTTP/1.1 200 OK
   x-litellm-model-api-base: https://bedrock-mantle.us-east-1.api.aws.localtest.me:9443/openai/v1
   body: {"id":"chatcmpl-c03f12f1-8783-4cbe-85ff-0619d0adbdea","created":1788371944,"model":"mantle-gpt-apibase","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"pong","role":"assistant"}}],"usage":{"completion_tokens":5,"pr
   ```
3. New lines in the private host's access log
   ```
   (none)
   ```

#### Case 4: Anthropic messages on a GPT-5.x deployment, served through Responses (`mantle-gpt-apibase`)

1. Run
   ```
   curl -sD - http://127.0.0.1:44776/v1/messages -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"mantle-gpt-apibase","max_tokens":32,"messages":[{"role":"user","content":"Say pong"}]}'
   ```
2. Response
   ```
   HTTP/1.1 200 OK
   body: {"id":"chatcmpl-25d100ec-b4c4-4576-9339-82c360526190","type":"message","role":"assistant","model":"mantle-gpt-apibase","stop_sequence":null,"usage":{"input_tokens":8,"output_tokens":5},"content":[{"type":"text","text":"pong"}],"stop_reason":"end_turn"}
   ```
3. New lines in the private host's access log
   ```
   (none)
   ```

#### Case 5: Native Bedrock passthrough converse with `api_base` on the deployment (`mantle-gpt-pt`)

1. Run
   ```
   curl -sD - http://127.0.0.1:44776/bedrock/model/mantle-gpt-pt/converse -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"messages":[{"role":"user","content":[{"text":"Say pong"}]}],"inferenceConfig":{"maxTokens":32}}'
   ```
2. Response
   ```
   HTTP/1.1 200 OK
   body: {"metrics":{"latencyMs":28024},"output":{"message":{"content":[{"text":"pong"}],"role":"assistant"}},"stopReason":"end_turn","usage":{"cacheReadInputTokenCount":0,"cacheReadInputTokens":0,"inputTokens":8,"outputTokens":5,"serverToolUsage":{},"totalTokens":13}}
   ```
3. New lines in the private host's access log
   ```
   (none)
   ```

#### Case 6: Plain chat completions on gpt-oss, control (`mantle-oss-apibase`)

1. Run
   ```
   curl -sD - http://127.0.0.1:44776/v1/chat/completions -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"mantle-oss-apibase","messages":[{"role":"user","content":"Say pong"}],"max_tokens":64}'
   ```
2. Response
   ```
   HTTP/1.1 400 Bad Request
   body: {"error":{"message":"litellm.BadRequestError: BedrockException - {\"error\":{\"code\":\"validation_error\",\"message\":\"model `openai.gpt-oss-120b` isn't supported on this route\",\"param\":null,\"type\":\"invalid_request_error\"}}. Received Model Group=mantl
   ```
3. New lines in the private host's access log
   ```
   POST client_sni=bedrock-mantle.us-east-1.api.aws.localtest.me upstream=('bedrock-mantle.us-east-1.api.aws', 443) path=/openai/v1/chat/completions status=400
   ```

#### Case 7: Responses against the public host, control (`mantle-gpt-public`)

1. Run
   ```
   curl -sD - http://127.0.0.1:44776/v1/responses -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"mantle-gpt-public","input":"Say pong","max_output_tokens":64}'
   ```
2. Response
   ```
   HTTP/1.1 200 OK
   x-litellm-model-api-base: https://bedrock-mantle.us-east-1.api.aws/openai/v1
   body: {"id":"resp_wwR7qc2zMzHFGA96rI3Ez1UqY3CmD8p_Zw0BRbQtJwdY1rCsw1-J-LM5x8UBRvPxxVPAgTyEGBgNzQlnYvBaKRSJaK5DLcDNqZCPIXOZQSq3Zwa-MOT6L4p-R_CVexzSf4yrlvqHfF0rcbL84PQOy7PvsLTAds-Wt8hdhiQHDjKGrpA6geIPKO_HWry5k0Fw5sGlnDr-RMoj_nGrr--NYMgy1wOKqwjsueefBgsgkJPfQEvLS3ThHcz_
   ```
3. New lines in the private host's access log
   ```
   (none)
   ```

### After (6f904d44)

#### Case 1: Responses with `BEDROCK_MANTLE_API_BASE` only (`mantle-gpt`)

1. Run
   ```
   curl -sD - http://127.0.0.1:58776/v1/responses -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"mantle-gpt","input":"Say pong","max_output_tokens":64}'
   ```
2. Response
   ```
   HTTP/1.1 200 OK
   x-litellm-model-api-base: https://bedrock-mantle.us-east-1.api.aws.localtest.me:9443
   body: {"id":"resp_RLlkPCCyfipRer62vozS0pVL-2CxWhmoQ-4UeGJnn2XXxr6z1s0snUzV0dKyEb5iLlJ4zZyJKrwprzZT9oVvHauuMjZIXzfm29EjkhDEQA3ZR3VBWngQJuTOaqbxFxb9_UzwFLXOPbn0armln4nkmYiDRVdL0IEyVcpMb6BenfxFPkxAbekMfYGBIO4mhhNqh_mRBtoJGo9Dt_zrq0HxtoExtWQ9bPxy_mB9xxrxJeUx8oCGk4gksHr0
   ```
3. New lines in the private host's access log
   ```
   POST client_sni=bedrock-mantle.us-east-1.api.aws.localtest.me upstream=('bedrock-mantle.us-east-1.api.aws', 443) path=/openai/v1/responses status=200
   ```

#### Case 2: Responses with `api_base` on the deployment (`mantle-gpt-apibase`)

1. Run
   ```
   curl -sD - http://127.0.0.1:58776/v1/responses -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"mantle-gpt-apibase","input":"Say pong","max_output_tokens":64}'
   ```
2. Response
   ```
   HTTP/1.1 200 OK
   x-litellm-model-api-base: https://bedrock-mantle.us-east-1.api.aws.localtest.me:9443/openai/v1
   body: {"id":"resp_VUNwsc2O4-nlgVgOjzZDOvrYukDWfeCdaJiRmT_6qtCe4-lPY3xO7jDW0qPziy68nhX5v4HT3ylnYbYZkRB8E2gEuistfzH7MvJ6nBZnHlm0GdvPT7nehnWNuzQLIEHQAg67_SO7NT4dDhRbokaE-k2flo1owP2c2SEvc9V1f7NRPyyEUi04wmhDtMrVyNoCVM1cYJhFPSb5T0_eIg_reipZNbGWWMuxCpWvVP5zEUAH9abR6z5Ch9A9
   ```
3. New lines in the private host's access log
   ```
   POST client_sni=bedrock-mantle.us-east-1.api.aws.localtest.me upstream=('bedrock-mantle.us-east-1.api.aws', 443) path=/openai/v1/responses status=200
   ```

#### Case 3: Chat completions on a GPT-5.x deployment, served through Responses (`mantle-gpt-apibase`)

1. Run
   ```
   curl -sD - http://127.0.0.1:58776/v1/chat/completions -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"mantle-gpt-apibase","messages":[{"role":"user","content":"Say pong"}],"max_tokens":64}'
   ```
2. Response
   ```
   HTTP/1.1 200 OK
   x-litellm-model-api-base: https://bedrock-mantle.us-east-1.api.aws.localtest.me:9443/openai/v1
   body: {"id":"chatcmpl-86f9bb76-ce55-41bb-b17f-6bbe43f8c927","created":1788372050,"model":"mantle-gpt-apibase","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"pong","role":"assistant"}}],"usage":{"completion_tokens":5,"pr
   ```
3. New lines in the private host's access log
   ```
   POST client_sni=bedrock-mantle.us-east-1.api.aws.localtest.me upstream=('bedrock-mantle.us-east-1.api.aws', 443) path=/openai/v1/responses status=200
   ```

#### Case 4: Anthropic messages on a GPT-5.x deployment, served through Responses (`mantle-gpt-apibase`)

1. Run
   ```
   curl -sD - http://127.0.0.1:58776/v1/messages -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"mantle-gpt-apibase","max_tokens":32,"messages":[{"role":"user","content":"Say pong"}]}'
   ```
2. Response
   ```
   HTTP/1.1 200 OK
   body: {"id":"chatcmpl-fadef5f0-920d-4b8b-bc13-a0be34fa786c","type":"message","role":"assistant","model":"mantle-gpt-apibase","stop_sequence":null,"usage":{"input_tokens":8,"output_tokens":5},"content":[{"type":"text","text":"pong"}],"stop_reason":"end_turn"}
   ```
3. New lines in the private host's access log
   ```
   POST client_sni=bedrock-mantle.us-east-1.api.aws.localtest.me upstream=('bedrock-mantle.us-east-1.api.aws', 443) path=/openai/v1/responses status=200
   ```

#### Case 5: Native Bedrock passthrough converse with `api_base` on the deployment (`mantle-gpt-pt`)

1. Run
   ```
   curl -sD - http://127.0.0.1:58776/bedrock/model/mantle-gpt-pt/converse -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"messages":[{"role":"user","content":[{"text":"Say pong"}]}],"inferenceConfig":{"maxTokens":32}}'
   ```
2. Response
   ```
   HTTP/1.1 200 OK
   body: {"metrics":{"latencyMs":11501},"output":{"message":{"content":[{"text":"pong"}],"role":"assistant"}},"stopReason":"end_turn","usage":{"cacheReadInputTokenCount":0,"cacheReadInputTokens":0,"inputTokens":8,"outputTokens":5,"serverToolUsage":{},"totalTokens":13}}
   ```
3. New lines in the private host's access log
   ```
   POST client_sni=bedrock-mantle.us-east-1.api.aws.localtest.me upstream=('bedrock-runtime.us-east-1.amazonaws.com', 443) path=/model/us.openai.gpt-5.6-sol/converse status=200
   ```

#### Case 6: Plain chat completions on gpt-oss, control (`mantle-oss-apibase`)

1. Run
   ```
   curl -sD - http://127.0.0.1:58776/v1/chat/completions -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"mantle-oss-apibase","messages":[{"role":"user","content":"Say pong"}],"max_tokens":64}'
   ```
2. Response
   ```
   HTTP/1.1 400 Bad Request
   body: {"error":{"message":"litellm.BadRequestError: BedrockException - {\"error\":{\"code\":\"validation_error\",\"message\":\"model `openai.gpt-oss-120b` isn't supported on this route\",\"param\":null,\"type\":\"invalid_request_error\"}}. Received Model Group=mantl
   ```
3. New lines in the private host's access log
   ```
   POST client_sni=bedrock-mantle.us-east-1.api.aws.localtest.me upstream=('bedrock-mantle.us-east-1.api.aws', 443) path=/openai/v1/chat/completions status=400
   ```

#### Case 7: Responses against the public host, control (`mantle-gpt-public`)

1. Run
   ```
   curl -sD - http://127.0.0.1:58776/v1/responses -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"mantle-gpt-public","input":"Say pong","max_output_tokens":64}'
   ```
2. Response
   ```
   HTTP/1.1 200 OK
   x-litellm-model-api-base: https://bedrock-mantle.us-east-1.api.aws/openai/v1
   body: {"id":"resp__HQj81A7nFtJVw0TJUi3bprBow9Ba9JkwV2tcZBHRaivWqXNz4dfo3EQn22Y_koYUR9arFwYX9IAtLd63G5jP-1nxmMEMpaeDREnFEp9B-oBJ43O01X6D784YBxhJ68gaxnHsEn1YIHtByy7uGmUCRHCFK1_eXiNLjHijPoZCts88n0IM2id3yWpnXATPFmc6-YqQTx3tXeZWEaEgOk9pHVI4hC0vKstJVH_tewk_TuMJrOtG5kHAaC3
   ```
3. New lines in the private host's access log
   ```
   (none)
   ```

Observations from the run, none caused by this PR

- Before: `x-litellm-model-api-base` named the private host while the call went public; this PR fixes it
- gpt-oss-120b gets 400 "isn't supported on this route" on `/openai/v1/chat/completions`, both sides; left alone
- `bedrock/mantle/*` messages route ignores `BEDROCK_MANTLE_API_BASE`, both sides; LIT-6641, left alone
- One env value cannot serve both a bare host and an `/openai/v1` base; left alone

## /live-pr-risk report (6f904d44)

Verdict: no breaking dependents. The only backward-incompatible behavior is for lookalike hosts (a suffix, port, or partition after `.api.aws`), which now count as custom hosts and no longer lend a SigV4 region; that is the Medium caveat below

- Changed item and its dependents
  - `MANTLE_HOST_RE` (now anchored): matched by `bedrock_mantle/responses/transformation.py:114` (public host rebuild for Responses and the chat and messages bridges), `bedrock_mantle/common_utils.py:47` (`resolve_mantle_region`) and `:85` (SigV4 signing region), and `bedrock_mantle/passthrough/transformation.py:41` (runtime endpoint). No reference in `enterprise/`, the dashboard, or config
  - `resolve_mantle_region`: called from `bedrock_mantle/common_utils.py:67` and `bedrock_mantle/passthrough/transformation.py:32`, both inside the graph above
- Producers that must still match: every public host literal in the tree (`bedrock_mantle/chat/transformation.py:69`, `bedrock_mantle/responses/transformation.py:105` and `:115`, `bedrock/common_utils.py:772` with its `/anthropic/v1/messages` path) ends at `.api.aws` followed by `/` or the end of the string, so the anchored regex matches all of them
- Verified live: the 7 proof cases above at the tip (Responses, chat and messages through the Responses bridge, native passthrough, gpt-oss chat, and the public-host control), bearer auth against the customer-shaped private host and the real public host
- Not verified: the SigV4 (IAM credential) path against a lookalike host; the QA account authenticates with `AWS_BEARER_TOKEN_BEDROCK` only. `test_sigv4_scope_ignores_the_region_segment_of_a_lookalike_host` and `test_sign_request_falls_back_to_sigv4_scoped_to_the_mantle_region` cover the signing scope

- [x] 6f904d44 passes /live-pr-risk

## Type

🐛 Bug Fix

## Caveats

Medium: a lookalike host (anything that merely starts with `bedrock-mantle.<region>.api.aws`) no longer supplies the SigV4 signing region or the `resolve_mantle_region` fallback. Operators who sign with IAM credentials against such a host and set no region anywhere (`aws_region_name`, `BEDROCK_MANTLE_REGION`, `AWS_REGION`, `AWS_REGION_NAME`) fall through to the existing default-region path and should set one explicitly. Bearer-token users are unaffected

Low: `https://bedrock-mantle.<region>.api.aws:8443` now counts as a custom host and is sent as-is instead of being folded into the public 443 host. The ticket's expectation table asks for exactly that, and it means a non-default port is honored rather than silently dropped

Low: the non-required `ci/circleci: litellm_router_testing` check is red on `tests/local_testing/test_router.py::test_router_timeout` (OpenAI connection error where the test expects a `Timeout` at `timeout=0.0001`). That single test failed five consecutive staging schedule runs on 2026-09-03 before passing again and never references the Mantle host regex, so it is a pre-existing flake tracked in LIT-6928, not a finding against this change. `osv-scan` is the fleet-wide advisory on `uv.lock`, which this PR does not touch

## Final Attestation

- [x] I have followed the rules in this template, including the ones inside HTML comments, and I have not fabricated any proof or content

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes URL routing and SigV4/region resolution for Mantle endpoints; IAM users on lookalike hosts without an explicit region may fall back to defaults, while bearer auth is unaffected.
> 
> **Overview**
> Fixes Bedrock Mantle routing so **private or suffixed hosts** that only *look like* `bedrock-mantle.<region>.api.aws` are no longer rewritten to the public AWS endpoint.
> 
> **`MANTLE_HOST_RE`** now requires the hostname to end at `.api.aws` (path, end of URL, or port), so URLs such as `…api.aws.corp.example`, `…api.aws-int…`, or `…api.aws:8443` are treated as **custom `api_base` values** and passed through on Responses, chat (including GPT-5.x via Responses), and native passthrough.
> 
> Because lookalikes no longer match the standard host pattern, **SigV4 region** and **`resolve_mantle_region`** no longer infer region from the hostname segment on those URLs; explicit `aws_region_name` / env region wins instead. Tests cover URL preservation and signing scope for lookalike hosts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f904d4414823783531464192a5b2f09b5071b49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

