### PR TITLE
fix(hosted_vllm): forward truncate_prompt_tokens on rerank requests

### DIFF
--- a/litellm/llms/hosted_vllm/rerank/transformation.py
+++ b/litellm/llms/hosted_vllm/rerank/transformation.py
@@ -7,8 +7,10 @@ from types import MappingProxyType
 from typing import Any, Final
 
 import httpx
+from pydantic import ValidationError
 
 from litellm._uuid import uuid
+from litellm.exceptions import UnsupportedParamsError
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.llms.base_llm.chat.transformation import BaseLLMException
 from litellm.llms.base_llm.rerank.transformation import BaseRerankConfig
@@ -34,6 +36,13 @@ class HostedVLLMRerankError(BaseLLMException):
         headers: dict | httpx.Headers | None = None,
     ):
         super().__init__(status_code=status_code, message=message, headers=headers)
+
+
+def validated_truncation_params(non_default_params: Mapping[str, object] | None) -> HostedVLLMRerankTruncationParams:
+    try:
+        return HostedVLLMRerankTruncationParams.model_validate(non_default_params or MappingProxyType({}))
+    except ValidationError as error:
+        raise UnsupportedParamsError(status_code=400, message=f"hosted_vllm rerank: {error}") from error
 
 
 class HostedVLLMRerankConfig(BaseRerankConfig):
@@ -106,7 +115,7 @@ class HostedVLLMRerankConfig(BaseRerankConfig):
         if instruction is not None:
             mapped_params["instruction"] = instruction
 
-        truncation: Final = HostedVLLMRerankTruncationParams.model_validate(non_default_params or MappingProxyType({}))
+        truncation: Final = validated_truncation_params(non_default_params)
         forwarded: Final[OptionalRerankParams] = {
             **mapped_params,
             "max_tokens_per_doc": max_tokens_per_doc,

--- a/litellm/llms/hosted_vllm/rerank/transformation.py
+++ b/litellm/llms/hosted_vllm/rerank/transformation.py
@@ -3,6 +3,7 @@ Transformation logic for Hosted VLLM rerank
 """
 
 from collections.abc import Mapping
+from types import MappingProxyType
 from typing import Any, Final
 
 import httpx
@@ -13,6 +14,7 @@ from litellm.llms.base_llm.chat.transformation import BaseLLMException
 from litellm.llms.base_llm.rerank.transformation import BaseRerankConfig
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.rerank import (
+    HostedVLLMRerankTruncationParams,
     OptionalRerankParams,
     RerankBilledUnits,
     RerankRequest,
@@ -62,7 +64,11 @@ class HostedVLLMRerankConfig(BaseRerankConfig):
             "top_n",
             "rank_fields",
             "return_documents",
+            "max_tokens_per_doc",
             "instruction",
+            "truncate_prompt_tokens",
+            "truncation_side",
+            "max_tokens_per_query",
         ]
 
     def map_cohere_rerank_params(
@@ -100,7 +106,15 @@ class HostedVLLMRerankConfig(BaseRerankConfig):
         if instruction is not None:
             mapped_params["instruction"] = instruction
 
-        return dict(mapped_params)
+        truncation: Final = HostedVLLMRerankTruncationParams.model_validate(non_default_params or MappingProxyType({}))
+        forwarded: Final[OptionalRerankParams] = {
+            **mapped_params,
+            "max_tokens_per_doc": max_tokens_per_doc,
+            "truncate_prompt_tokens": truncation.truncate_prompt_tokens,
+            "truncation_side": truncation.truncation_side,
+            "max_tokens_per_query": truncation.max_tokens_per_query,
+        }
+        return dict(forwarded)
 
     def validate_environment(
         self,
@@ -138,6 +152,7 @@ class HostedVLLMRerankConfig(BaseRerankConfig):
         if "documents" not in optional_rerank_params:
             raise ValueError("documents is required for Hosted VLLM rerank")
 
+        truncation: Final = HostedVLLMRerankTruncationParams.model_validate(optional_rerank_params)
         rerank_request: Final = RerankRequest(
             model=model,
             query=optional_rerank_params["query"],
@@ -146,6 +161,10 @@ class HostedVLLMRerankConfig(BaseRerankConfig):
             rank_fields=optional_rerank_params.get("rank_fields", None),
             return_documents=optional_rerank_params.get("return_documents", None),
             instruction=optional_rerank_params.get("instruction", None),
+            max_tokens_per_doc=truncation.max_tokens_per_doc,
+            truncate_prompt_tokens=truncation.truncate_prompt_tokens,
+            truncation_side=truncation.truncation_side,
+            max_tokens_per_query=truncation.max_tokens_per_query,
         )
         return rerank_request.model_dump(exclude_none=True)
 

--- a/litellm/types/rerank.py
+++ b/litellm/types/rerank.py
@@ -4,8 +4,10 @@ https://docs.cohere.com/reference/rerank
 
 """
 
-from pydantic import BaseModel, PrivateAttr
-from typing_extensions import Required, TypedDict
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, PrivateAttr
+from typing_extensions import ReadOnly, Required, TypedDict
 
 
 class RerankRequest(BaseModel):
@@ -21,6 +23,18 @@ class RerankRequest(BaseModel):
     # (e.g. hosted vLLM / Qwen3-Reranker, DeepInfra). Omitted from the outgoing
     # request when None, so this is fully backward-compatible.
     instruction: str | None = None
+    truncate_prompt_tokens: int | None = None
+    truncation_side: Literal["left", "right"] | None = None
+    max_tokens_per_query: int | None = None
+
+
+class HostedVLLMRerankTruncationParams(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    truncate_prompt_tokens: int | None = None
+    truncation_side: Literal["left", "right"] | None = None
+    max_tokens_per_query: int | None = None
+    max_tokens_per_doc: int | None = None
 
 
 class OptionalRerankParams(TypedDict, total=False):
@@ -32,6 +46,9 @@ class OptionalRerankParams(TypedDict, total=False):
     max_chunks_per_doc: int | None
     max_tokens_per_doc: int | None
     instruction: str | None
+    truncate_prompt_tokens: ReadOnly[int | None]
+    truncation_side: ReadOnly[Literal["left", "right"] | None]
+    max_tokens_per_query: ReadOnly[int | None]
 
 
 class RerankBilledUnits(TypedDict, total=False):

--- a/tests/test_litellm/llms/hosted_vllm/test_hosted_vllm_rerank_transformation.py
+++ b/tests/test_litellm/llms/hosted_vllm/test_hosted_vllm_rerank_transformation.py
@@ -1,6 +1,7 @@
 import json
 import os
 import sys
+from typing import Final
 from unittest.mock import MagicMock, patch
 
 import httpx
@@ -182,7 +183,7 @@ class TestHostedVLLMRerankTruncationParams:
         self.model = "hosted-vllm-model"
 
     def test_map_cohere_rerank_params_forwards_vllm_truncation_params(self):
-        params = self.config.map_cohere_rerank_params(
+        params: Final = self.config.map_cohere_rerank_params(
             non_default_params={
                 "truncate_prompt_tokens": 512,
                 "truncation_side": "left",
@@ -202,15 +203,20 @@ class TestHostedVLLMRerankTruncationParams:
         assert "metadata" not in params
 
     def test_map_cohere_rerank_params_omits_truncation_params_when_absent(self):
-        params = self.config.map_cohere_rerank_params(
+        params: Final = self.config.map_cohere_rerank_params(
             non_default_params={"metadata": {"user_api_key": "sk-test"}},
             model=self.model,
             drop_params=False,
             query="test query",
             documents=["doc1", "doc2"],
         )
-        body = self.config.transform_rerank_request(model=self.model, optional_rerank_params=params, headers={})
-        truncation_keys = {"truncate_prompt_tokens", "truncation_side", "max_tokens_per_query", "max_tokens_per_doc"}
+        body: Final = self.config.transform_rerank_request(model=self.model, optional_rerank_params=params, headers={})
+        truncation_keys: Final = {
+            "truncate_prompt_tokens",
+            "truncation_side",
+            "max_tokens_per_query",
+            "max_tokens_per_doc",
+        }
         assert not truncation_keys & body.keys()
         assert body == {
             "model": self.model,
@@ -230,7 +236,7 @@ class TestHostedVLLMRerankTruncationParams:
             )
 
     def test_transform_request_forwards_truncation_params(self):
-        body = self.config.transform_rerank_request(
+        body: Final = self.config.transform_rerank_request(
             model=self.model,
             optional_rerank_params={
                 "query": "test query",
@@ -248,7 +254,7 @@ class TestHostedVLLMRerankTruncationParams:
         assert body["max_tokens_per_doc"] == 128
 
     def test_transform_request_omits_truncation_params_when_absent(self):
-        body = self.config.transform_rerank_request(
+        body: Final = self.config.transform_rerank_request(
             model=self.model,
             optional_rerank_params={"query": "test query", "documents": ["doc1", "doc2"]},
             headers={},
@@ -259,8 +265,8 @@ class TestHostedVLLMRerankTruncationParams:
         assert "max_tokens_per_doc" not in body
 
     def test_rerank_sends_truncate_prompt_tokens_to_vllm(self):
-        client = HTTPHandler()
-        mock_response = MagicMock(spec=httpx.Response)
+        client: Final = HTTPHandler()
+        mock_response: Final = MagicMock(spec=httpx.Response)
         mock_response.status_code = 200
         mock_response.json.return_value = {
             "id": "score-1",
@@ -277,7 +283,7 @@ class TestHostedVLLMRerankTruncationParams:
                 truncation_side="left",
                 client=client,
             )
-        sent_body = json.loads(mock_post.call_args.kwargs["data"])
+        sent_body: Final = json.loads(mock_post.call_args.kwargs["data"])
         assert mock_post.call_args.kwargs["url"] == "http://vllm.local:8000/rerank"
         assert sent_body["truncate_prompt_tokens"] == 512
         assert sent_body["truncation_side"] == "left"

--- a/tests/test_litellm/llms/hosted_vllm/test_hosted_vllm_rerank_transformation.py
+++ b/tests/test_litellm/llms/hosted_vllm/test_hosted_vllm_rerank_transformation.py
@@ -202,6 +202,22 @@ class TestHostedVLLMRerankTruncationParams:
         assert params["max_tokens_per_doc"] == 128
         assert "metadata" not in params
 
+    @pytest.mark.parametrize(
+        "bad_params",
+        [{"truncation_side": "middle"}, {"truncate_prompt_tokens": "lots"}, {"max_tokens_per_query": -1.5}],
+    )
+    def test_map_cohere_rerank_params_rejects_invalid_truncation_params_as_400(self, bad_params: dict[str, object]):
+        with pytest.raises(litellm.UnsupportedParamsError) as raised:
+            self.config.map_cohere_rerank_params(
+                non_default_params=dict(bad_params),
+                model=self.model,
+                drop_params=False,
+                query="test query",
+                documents=["doc1", "doc2"],
+            )
+        assert raised.value.status_code == 400
+        assert next(iter(bad_params)) in str(raised.value)
+
     def test_map_cohere_rerank_params_omits_truncation_params_when_absent(self):
         params: Final = self.config.map_cohere_rerank_params(
             non_default_params={"metadata": {"user_api_key": "sk-test"}},
@@ -224,16 +240,6 @@ class TestHostedVLLMRerankTruncationParams:
             "documents": ["doc1", "doc2"],
             "return_documents": True,
         }
-
-    def test_map_cohere_rerank_params_rejects_invalid_truncation_side(self):
-        with pytest.raises(ValueError, match="truncation_side"):
-            self.config.map_cohere_rerank_params(
-                non_default_params={"truncation_side": "middle"},
-                model=self.model,
-                drop_params=False,
-                query="test query",
-                documents=["doc1", "doc2"],
-            )
 
     def test_transform_request_forwards_truncation_params(self):
         body: Final = self.config.transform_rerank_request(

--- a/tests/test_litellm/llms/hosted_vllm/test_hosted_vllm_rerank_transformation.py
+++ b/tests/test_litellm/llms/hosted_vllm/test_hosted_vllm_rerank_transformation.py
@@ -1,8 +1,13 @@
+import json
 import os
 import sys
+from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 
+import litellm
+from litellm.llms.custom_httpx.http_handler import HTTPHandler
 from litellm.llms.hosted_vllm.rerank.transformation import HostedVLLMRerankConfig
 from litellm.rerank_api.rerank_utils import get_optional_rerank_params
 from litellm.types.rerank import (
@@ -87,9 +92,7 @@ class TestHostedVLLMRerankTransform:
         assert "instruction" not in body
 
     def test_map_cohere_rerank_params_raises_on_max_chunks_per_doc(self):
-        with pytest.raises(
-            ValueError, match="Hosted VLLM does not support max_chunks_per_doc"
-        ):
+        with pytest.raises(ValueError, match="Hosted VLLM does not support max_chunks_per_doc"):
             self.config.map_cohere_rerank_params(
                 non_default_params=None,
                 model=self.model,
@@ -104,12 +107,10 @@ class TestHostedVLLMRerankTransform:
         url = self.config.get_complete_url(base, self.model)
         assert url == "https://api.example.com/rerank"
         # Already ends with /rerank
-        url2 = self.config.get_complete_url(
-            "https://api.example.com/rerank", self.model
-        )
+        url2 = self.config.get_complete_url("https://api.example.com/rerank", self.model)
         assert url2 == "https://api.example.com/rerank"
         # Raises if api_base is None
-        with pytest.raises(ValueError, match='api_base must be provided for Hosted VLLM rerank'):
+        with pytest.raises(ValueError, match="api_base must be provided for Hosted VLLM rerank"):
             self.config.get_complete_url(None, self.model)
 
     def test_transform_response(self):
@@ -173,3 +174,110 @@ class TestGetOptionalRerankParamsInstruction:
             documents=["doc1", "doc2"],
         )
         assert "instruction" not in params
+
+
+class TestHostedVLLMRerankTruncationParams:
+    def setup_method(self):
+        self.config = HostedVLLMRerankConfig()
+        self.model = "hosted-vllm-model"
+
+    def test_map_cohere_rerank_params_forwards_vllm_truncation_params(self):
+        params = self.config.map_cohere_rerank_params(
+            non_default_params={
+                "truncate_prompt_tokens": 512,
+                "truncation_side": "left",
+                "max_tokens_per_query": 64,
+                "metadata": {"user_api_key": "sk-test"},
+            },
+            model=self.model,
+            drop_params=False,
+            query="test query",
+            documents=["doc1", "doc2"],
+            max_tokens_per_doc=128,
+        )
+        assert params["truncate_prompt_tokens"] == 512
+        assert params["truncation_side"] == "left"
+        assert params["max_tokens_per_query"] == 64
+        assert params["max_tokens_per_doc"] == 128
+        assert "metadata" not in params
+
+    def test_map_cohere_rerank_params_omits_truncation_params_when_absent(self):
+        params = self.config.map_cohere_rerank_params(
+            non_default_params={"metadata": {"user_api_key": "sk-test"}},
+            model=self.model,
+            drop_params=False,
+            query="test query",
+            documents=["doc1", "doc2"],
+        )
+        body = self.config.transform_rerank_request(model=self.model, optional_rerank_params=params, headers={})
+        truncation_keys = {"truncate_prompt_tokens", "truncation_side", "max_tokens_per_query", "max_tokens_per_doc"}
+        assert not truncation_keys & body.keys()
+        assert body == {
+            "model": self.model,
+            "query": "test query",
+            "documents": ["doc1", "doc2"],
+            "return_documents": True,
+        }
+
+    def test_map_cohere_rerank_params_rejects_invalid_truncation_side(self):
+        with pytest.raises(ValueError, match="truncation_side"):
+            self.config.map_cohere_rerank_params(
+                non_default_params={"truncation_side": "middle"},
+                model=self.model,
+                drop_params=False,
+                query="test query",
+                documents=["doc1", "doc2"],
+            )
+
+    def test_transform_request_forwards_truncation_params(self):
+        body = self.config.transform_rerank_request(
+            model=self.model,
+            optional_rerank_params={
+                "query": "test query",
+                "documents": ["doc1", "doc2"],
+                "truncate_prompt_tokens": 512,
+                "truncation_side": "left",
+                "max_tokens_per_query": 64,
+                "max_tokens_per_doc": 128,
+            },
+            headers={},
+        )
+        assert body["truncate_prompt_tokens"] == 512
+        assert body["truncation_side"] == "left"
+        assert body["max_tokens_per_query"] == 64
+        assert body["max_tokens_per_doc"] == 128
+
+    def test_transform_request_omits_truncation_params_when_absent(self):
+        body = self.config.transform_rerank_request(
+            model=self.model,
+            optional_rerank_params={"query": "test query", "documents": ["doc1", "doc2"]},
+            headers={},
+        )
+        assert "truncate_prompt_tokens" not in body
+        assert "truncation_side" not in body
+        assert "max_tokens_per_query" not in body
+        assert "max_tokens_per_doc" not in body
+
+    def test_rerank_sends_truncate_prompt_tokens_to_vllm(self):
+        client = HTTPHandler()
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "id": "score-1",
+            "results": [{"index": 0, "relevance_score": 0.5}],
+            "usage": {"total_tokens": 512},
+        }
+        with patch.object(client, "post", return_value=mock_response) as mock_post:
+            litellm.rerank(
+                model="hosted_vllm/BAAI/bge-reranker-base",
+                api_base="http://vllm.local:8000",
+                query="List all the unique case ids",
+                documents=["a document longer than the reranker context window"],
+                truncate_prompt_tokens=512,
+                truncation_side="left",
+                client=client,
+            )
+        sent_body = json.loads(mock_post.call_args.kwargs["data"])
+        assert mock_post.call_args.kwargs["url"] == "http://vllm.local:8000/rerank"
+        assert sent_body["truncate_prompt_tokens"] == 512
+        assert sent_body["truncation_side"] == "left"


### PR DESCRIPTION
## TLDR

Problem this solves:

- hosted_vllm rerank dropped `truncate_prompt_tokens`, so long documents failed with a context-length 400
- vLLM's other truncation knobs (`truncation_side`, `max_tokens_per_query`, `max_tokens_per_doc`) were dropped too

How it solves it:

- Forward vLLM's truncation params in the hosted_vllm rerank request body
- Validate them with a typed frozen model, so unrelated kwargs stay out
- Reject an invalid truncation value with a 400 that names the field, instead of dropping it silently

## User Flow

Before: a developer reranking long documents through a self-hosted vLLM reranker gets a context-length 400 even though the request asked vLLM to truncate

1. The admin adds the reranker with POST https://litellm-domain/model/new: `model: hosted_vllm/BAAI/bge-reranker-base`, `api_base: http://vllm-host:8000`, `mode: rerank`
2. The developer sends POST https://litellm-domain/v1/rerank with `model: bge-reranker-base`, a query, one document longer than 512 tokens, and `truncate_prompt_tokens: 512`
3. HTTP 400 comes back: `This model's maximum context length is 512 tokens. However, you requested 0 output tokens and your prompt contains at least 513 input tokens ...`
4. The same body sent straight to POST http://vllm-host:8000/rerank returns HTTP 200 with `usage.prompt_tokens: 512` and a results list, so only the gateway path fails
5. A typo such as `truncation_side: middle` is dropped silently and the request returns HTTP 200 as if no truncation had been asked for

After: the same request succeeds through the gateway, with vLLM truncating the document exactly as it does when called directly

1. The admin adds the reranker with POST https://litellm-domain/model/new: `model: hosted_vllm/BAAI/bge-reranker-base`, `api_base: http://vllm-host:8000`, `mode: rerank`
2. The developer sends POST https://litellm-domain/v1/rerank with `model: bge-reranker-base`, a query, one document longer than 512 tokens, and `truncate_prompt_tokens: 512`
3. HTTP 200 comes back with an `id` like `score-b38d6e296dea9e3d`, a `results` list scoring the document, and `meta` reporting 512 input tokens
4. `truncation_side`, `max_tokens_per_query`, and `max_tokens_per_doc` sent the same way now reach vLLM as well
5. A typo such as `truncation_side: middle` returns HTTP 400 `litellm.UnsupportedParamsError: hosted_vllm rerank: ... truncation_side Input should be 'left' or 'right'` before anything is sent to vLLM

## Relevant issues

## Linear ticket

Resolves LIT-4176

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Setup shared by both legs: vLLM v0.28.0 (CPU build) serving `BAAI/bge-reranker-base`, a 512-token cross-encoder, on a GCE VM tunnelled to `localhost:18201`; a DB-backed proxy per leg (before on port 26739, after on port 34152) with the reranker added once through the admin API

```bash
curl -s http://localhost:26739/model/new -H 'Authorization: Bearer sk-lit4176-master' -H 'Content-Type: application/json' -d '{
  "model_name": "bge-reranker-base",
  "litellm_params": {"model": "hosted_vllm/BAAI/bge-reranker-base", "custom_llm_provider": "hosted_vllm", "api_base": "http://localhost:18201", "max_input_tokens": "8192", "disable_token_checking": "true"},
  "model_info": {"mode": "rerank"}
}'
```

### Before (2ffe6a1dc8)

#### Long document with truncate_prompt_tokens: 512

1. Build a request whose single document is 12 repeated case summaries (about 750 tokens, well past the reranker's 512-token window) and ask vLLM to truncate at 512

```bash
UNIT='Case id CS-1042 was opened on March 3 after the customer reported that the reranker returned an error for long inputs. Case id CS-1077 tracks the follow-up where the platform team asked for truncation support. Case id CS-1103 is a duplicate of CS-1042 filed by a second team.'
DOC=$(python3 -c "import sys; print(' '.join([sys.argv[1]] * 12))" "$UNIT")
jq -n --arg doc "$DOC" '{model: "bge-reranker-base", query: "List all the unique case ids", documents: [$doc], truncate_prompt_tokens: 512}' > rerank_request.json
jq -c '.documents[0] |= .[:60] + "..."' rerank_request.json
```

```
{"model":"bge-reranker-base","query":"List all the unique case ids","documents":["Case id CS-1042 was opened on March 3 after the customer rep..."],"truncate_prompt_tokens":512}
```

2. Send it through the proxy

```bash
curl -s http://localhost:26739/v1/rerank -H 'Authorization: Bearer sk-lit4176-master' -H 'Content-Type: application/json' -d @rerank_request.json -o response.json -w 'HTTP %{http_code}\n'
jq -c 'if .results then .results[0].document.text |= .[:60] + "..." else . end' response.json
```

```
HTTP 400
{"error":{"message":"litellm.ContextWindowExceededError: litellm.BadRequestError: ContextWindowExceededError: Hosted_vllmException - {\"error\":{\"message\":\"This model's maximum context length is 512 tokens. However, you requested 0 output tokens and your prompt contains at least 513 input tokens, for a total of at least 513 tokens. Please reduce the length of the input prompt or the number of requested output tokens. (parameter=input_tokens, value=513)\",\"type\":\"BadRequestError\",\"param\":\"input_tokens\",\"code\":400}}\nmodel=bge-reranker-base. context_window_fallbacks=None. fallbacks=None.\n\nSet 'context_window_fallback' - https://docs.litellm.ai/docs/routing#fallbacks. Received Model Group=bge-reranker-base\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"400"}}
```

vLLM never saw `truncate_prompt_tokens`, so it rejected the 750-token prompt outright

#### Long document with max_tokens_per_doc: 100 and truncation_side: left

1. Build the same long document request, this time capping each document at 100 tokens and truncating from the left

```bash
jq -n --arg doc "$DOC" '{model: "bge-reranker-base", query: "List all the unique case ids", documents: [$doc], max_tokens_per_doc: 100, truncation_side: "left"}' > rerank_request_doc_cap.json
jq -c '.documents[0] |= .[:60] + "..."' rerank_request_doc_cap.json
```

```
{"model":"bge-reranker-base","query":"List all the unique case ids","documents":["Case id CS-1042 was opened on March 3 after the customer rep..."],"max_tokens_per_doc":100,"truncation_side":"left"}
```

2. Send it through the proxy

```bash
curl -s http://localhost:26739/v1/rerank -H 'Authorization: Bearer sk-lit4176-master' -H 'Content-Type: application/json' -d @rerank_request_doc_cap.json -o response_doc_cap.json -w 'HTTP %{http_code}\n'
jq -c 'if .results then .results[0].document.text |= .[:60] + "..." else . end' response_doc_cap.json
```

```
HTTP 400
{"error":{"message":"litellm.ContextWindowExceededError: litellm.BadRequestError: ContextWindowExceededError: Hosted_vllmException - {\"error\":{\"message\":\"This model's maximum context length is 512 tokens. However, you requested 0 output tokens and your prompt contains at least 513 input tokens, for a total of at least 513 tokens. Please reduce the length of the input prompt or the number of requested output tokens. (parameter=input_tokens, value=513)\",\"type\":\"BadRequestError\",\"param\":\"input_tokens\",\"code\":400}}\nmodel=bge-reranker-base. context_window_fallbacks=None. fallbacks=None.\n\nSet 'context_window_fallback' - https://docs.litellm.ai/docs/routing#fallbacks. Received Model Group=bge-reranker-base\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"400"}}
```

`max_tokens_per_doc` and `truncation_side` were dropped the same way, so the same 400 comes back

#### Invalid truncation_side: middle

1. Send a short request with a `truncation_side` value vLLM does not accept

```bash
curl -s http://localhost:26739/v1/rerank -H 'Authorization: Bearer sk-lit4176-master' -H 'Content-Type: application/json' -d '{"model": "bge-reranker-base", "query": "capital of France", "documents": ["Ottawa is the capital of Canada.", "Paris is the capital of France.", "The Eiffel Tower is in Paris."], "truncation_side": "middle"}' -w '\nHTTP %{http_code}\n'
```

```
{"id":"score-82769410379c2b81","results":[{"index":1,"relevance_score":0.9998937845230103,"document":{"text":"Paris is the capital of France."}},{"index":2,"relevance_score":0.9860824346542358,"document":{"text":"The Eiffel Tower is in Paris."}},{"index":0,"relevance_score":0.01727464236319065,"document":{"text":"Ottawa is the capital of Canada."}}],"meta":{"billed_units":{"total_tokens":43},"tokens":{"input_tokens":43}}}
HTTP 200
```

The typo was dropped silently and the request went through as if no truncation had been asked for

### After (ef14bed029)

#### Long document with truncate_prompt_tokens: 512

1. Build a request whose single document is 12 repeated case summaries (about 750 tokens, well past the reranker's 512-token window) and ask vLLM to truncate at 512

```bash
UNIT='Case id CS-1042 was opened on March 3 after the customer reported that the reranker returned an error for long inputs. Case id CS-1077 tracks the follow-up where the platform team asked for truncation support. Case id CS-1103 is a duplicate of CS-1042 filed by a second team.'
DOC=$(python3 -c "import sys; print(' '.join([sys.argv[1]] * 12))" "$UNIT")
jq -n --arg doc "$DOC" '{model: "bge-reranker-base", query: "List all the unique case ids", documents: [$doc], truncate_prompt_tokens: 512}' > rerank_request.json
jq -c '.documents[0] |= .[:60] + "..."' rerank_request.json
```

```
{"model":"bge-reranker-base","query":"List all the unique case ids","documents":["Case id CS-1042 was opened on March 3 after the customer rep..."],"truncate_prompt_tokens":512}
```

2. Send it through the proxy

```bash
curl -s http://localhost:34152/v1/rerank -H 'Authorization: Bearer sk-lit4176-master' -H 'Content-Type: application/json' -d @rerank_request.json -o response.json -w 'HTTP %{http_code}\n'
jq -c 'if .results then .results[0].document.text |= .[:60] + "..." else . end' response.json
```

```
HTTP 200
{"id":"score-af93855559cbca39","results":[{"index":0,"relevance_score":0.18084223568439484,"document":{"text":"Case id CS-1042 was opened on March 3 after the customer rep..."}}],"meta":{"billed_units":{"total_tokens":512},"tokens":{"input_tokens":512}}}
```

vLLM truncated the prompt to exactly 512 tokens and scored the document; `meta.tokens.input_tokens` is 512, matching what vLLM reports when called directly

#### Long document with max_tokens_per_doc: 100 and truncation_side: left

1. Build the same long document request, this time capping each document at 100 tokens and truncating from the left

```bash
jq -n --arg doc "$DOC" '{model: "bge-reranker-base", query: "List all the unique case ids", documents: [$doc], max_tokens_per_doc: 100, truncation_side: "left"}' > rerank_request_doc_cap.json
jq -c '.documents[0] |= .[:60] + "..."' rerank_request_doc_cap.json
```

```
{"model":"bge-reranker-base","query":"List all the unique case ids","documents":["Case id CS-1042 was opened on March 3 after the customer rep..."],"max_tokens_per_doc":100,"truncation_side":"left"}
```

2. Send it through the proxy

```bash
curl -s http://localhost:34152/v1/rerank -H 'Authorization: Bearer sk-lit4176-master' -H 'Content-Type: application/json' -d @rerank_request_doc_cap.json -o response_doc_cap.json -w 'HTTP %{http_code}\n'
jq -c 'if .results then .results[0].document.text |= .[:60] + "..." else . end' response_doc_cap.json
```

```
HTTP 200
{"id":"score-8af00717aa15bac2","results":[{"index":0,"relevance_score":0.1546282321214676,"document":{"text":"Case id CS-1042 was opened on March 3 after the customer rep..."}}],"meta":{"billed_units":{"total_tokens":111},"tokens":{"input_tokens":111}}}
```

The document was capped at 100 tokens before scoring: `input_tokens` is 111 (100 document tokens plus the query and special tokens), so both extra knobs reach vLLM as well

#### Invalid truncation_side: middle

1. Send a short request with a `truncation_side` value vLLM does not accept

```bash
curl -s http://localhost:34152/v1/rerank -H 'Authorization: Bearer sk-lit4176-master' -H 'Content-Type: application/json' -d '{"model": "bge-reranker-base", "query": "capital of France", "documents": ["Ottawa is the capital of Canada.", "Paris is the capital of France.", "The Eiffel Tower is in Paris."], "truncation_side": "middle"}' -w '\nHTTP %{http_code}\n'
```

```
{"error":{"message":"litellm.UnsupportedParamsError: hosted_vllm rerank: 1 validation error for HostedVLLMRerankTruncationParams\ntruncation_side\n  Input should be 'left' or 'right' [type=literal_error, input_value='middle', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.13/v/literal_error. Received Model Group=bge-reranker-base\nAvailable Model Group Fallbacks=None","type":"None","param":null,"code":"400"}}
HTTP 400
```

The request is rejected with a 400 naming the bad field before anything reaches vLLM; `truncate_prompt_tokens: "lots"` and `max_tokens_per_query: -1.5` get the same treatment

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Only vLLM's truncation params are forwarded; `priority`, `cache_salt`, `request_id`, `use_activation` still are not
- An invalid truncation value now returns HTTP 400 `litellm.UnsupportedParamsError` where it used to be dropped silently; `max_chunks_per_doc` keeps its pre-existing 500 `ValueError`, untouched here
- The hosted_vllm rerank docs live in the docs repo; BerriAI/litellm-docs#1130 documents the new params

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] ef14bed0296b4a6c48777b8f9df8018b11179c4b passes /live-pr-risk
