### PR TITLE
fix(proxy-extras): give prisma migrate deploy its own timeout budget

### DIFF
--- a/litellm-proxy-extras/litellm_proxy_extras/prisma_toolchain.py
+++ b/litellm-proxy-extras/litellm_proxy_extras/prisma_toolchain.py
@@ -14,9 +14,19 @@ then fails on a Node binary that was never written. Deleting a cache directory
 that exists without a Node binary is what turns a killed bootstrap back into a
 recoverable one.
 
-Both budgets are overridable so an operator can widen them without a release:
-``LITELLM_PRISMA_BOOTSTRAP_TIMEOUT`` for the toolchain install and
-``LITELLM_PRISMA_COMMAND_TIMEOUT`` for every individual Prisma command.
+``prisma migrate deploy`` is the other command whose runtime is not a
+constant: it grows with the number of pending migrations, so a fresh database
+that has to replay every migration this package ships overruns a per-command
+budget sized for the short bookkeeping commands, on a laptop as much as on a
+slow CI runner. The Python ``prisma`` wrapper spawns Node and the schema engine
+as separate children, so killing the wrapper on timeout leaves them running:
+the retry then contends with that orphan for Prisma's advisory lock and cannot
+finish any sooner. Migrate deploy therefore runs under its own budget.
+
+All three budgets are overridable so an operator can widen them without a
+release: ``LITELLM_PRISMA_BOOTSTRAP_TIMEOUT`` for the toolchain install,
+``LITELLM_PRISMA_MIGRATE_DEPLOY_TIMEOUT`` for ``prisma migrate deploy`` and
+``LITELLM_PRISMA_COMMAND_TIMEOUT`` for every other Prisma command.
 """
 
 import math
@@ -36,10 +46,12 @@ except ImportError:
 
 PRISMA_COMMAND_TIMEOUT_ENV_VAR = "LITELLM_PRISMA_COMMAND_TIMEOUT"
 PRISMA_BOOTSTRAP_TIMEOUT_ENV_VAR = "LITELLM_PRISMA_BOOTSTRAP_TIMEOUT"
+PRISMA_MIGRATE_DEPLOY_TIMEOUT_ENV_VAR = "LITELLM_PRISMA_MIGRATE_DEPLOY_TIMEOUT"
 NODEENV_CACHE_DIR_ENV_VAR = "PRISMA_NODEENV_CACHE_DIR"
 
 DEFAULT_PRISMA_COMMAND_TIMEOUT = 60.0
 DEFAULT_PRISMA_BOOTSTRAP_TIMEOUT = 600.0
+DEFAULT_PRISMA_MIGRATE_DEPLOY_TIMEOUT = 600.0
 
 BOOTSTRAP_ARG = "--version"
 
@@ -85,6 +97,13 @@ def prisma_bootstrap_timeout() -> float:
     """Seconds the one-time Node toolchain install may run for."""
     return _timeout_from_env(
         PRISMA_BOOTSTRAP_TIMEOUT_ENV_VAR, DEFAULT_PRISMA_BOOTSTRAP_TIMEOUT
+    )
+
+
+def prisma_migrate_deploy_timeout() -> float:
+    """Seconds one ``prisma migrate deploy`` may run for, however many migrations are pending."""
+    return _timeout_from_env(
+        PRISMA_MIGRATE_DEPLOY_TIMEOUT_ENV_VAR, DEFAULT_PRISMA_MIGRATE_DEPLOY_TIMEOUT
     )
 
 

--- a/litellm-proxy-extras/litellm_proxy_extras/prisma_toolchain.py
+++ b/litellm-proxy-extras/litellm_proxy_extras/prisma_toolchain.py
@@ -26,7 +26,10 @@ finish any sooner. Migrate deploy therefore runs under its own budget.
 All three budgets are overridable so an operator can widen them without a
 release: ``LITELLM_PRISMA_BOOTSTRAP_TIMEOUT`` for the toolchain install,
 ``LITELLM_PRISMA_MIGRATE_DEPLOY_TIMEOUT`` for ``prisma migrate deploy`` and
-``LITELLM_PRISMA_COMMAND_TIMEOUT`` for every other Prisma command.
+``LITELLM_PRISMA_COMMAND_TIMEOUT`` for every other Prisma command. The
+per-command budget used to bound migrate deploy as well, so a deployment that
+raised it above the deploy default keeps that larger budget for deploy unless
+the deploy override says otherwise.
 """
 
 import math
@@ -102,9 +105,11 @@ def prisma_bootstrap_timeout() -> float:
 
 def prisma_migrate_deploy_timeout() -> float:
     """Seconds one ``prisma migrate deploy`` may run for, however many migrations are pending."""
-    return _timeout_from_env(
-        PRISMA_MIGRATE_DEPLOY_TIMEOUT_ENV_VAR, DEFAULT_PRISMA_MIGRATE_DEPLOY_TIMEOUT
-    )
+    if os.getenv(PRISMA_MIGRATE_DEPLOY_TIMEOUT_ENV_VAR) is not None:
+        return _timeout_from_env(
+            PRISMA_MIGRATE_DEPLOY_TIMEOUT_ENV_VAR, DEFAULT_PRISMA_MIGRATE_DEPLOY_TIMEOUT
+        )
+    return max(DEFAULT_PRISMA_MIGRATE_DEPLOY_TIMEOUT, prisma_command_timeout())
 
 
 def nodeenv_cache_dir() -> Optional[Path]:

--- a/litellm-proxy-extras/litellm_proxy_extras/utils.py
+++ b/litellm-proxy-extras/litellm_proxy_extras/utils.py
@@ -15,8 +15,10 @@ from litellm_proxy_extras.replica_identity import (
     apply_replica_identity_full,
 )
 from litellm_proxy_extras.prisma_toolchain import (
+    PRISMA_MIGRATE_DEPLOY_TIMEOUT_ENV_VAR,
     ensure_prisma_toolchain,
     prisma_command_timeout,
+    prisma_migrate_deploy_timeout,
 )
 
 
@@ -698,12 +700,13 @@ class ProxyExtrasDBManager:
 
         original_dir = os.getcwd()
         os.chdir(migrations_dir)
+        deploy_timeout = prisma_migrate_deploy_timeout()
         try:
             for attempt in range(4):
                 try:
                     result = subprocess.run(
                         [_get_prisma_command(), "migrate", "deploy"],
-                        timeout=prisma_command_timeout(),
+                        timeout=deploy_timeout,
                         check=True,
                         capture_output=True,
                         text=True,
@@ -713,8 +716,12 @@ class ProxyExtrasDBManager:
                     return True
 
                 except subprocess.TimeoutExpired:
-                    logger.info(
-                        f"prisma migrate deploy attempt {attempt + 1} timed out, retrying"
+                    logger.warning(
+                        "prisma migrate deploy attempt %s timed out after %ss, retrying. "
+                        "Raise %s if this database needs longer to apply its pending migrations.",
+                        attempt + 1,
+                        deploy_timeout,
+                        PRISMA_MIGRATE_DEPLOY_TIMEOUT_ENV_VAR,
                     )
                     time.sleep(random.randrange(5, 15))
                     continue
@@ -823,7 +830,8 @@ class ProxyExtrasDBManager:
                 "Database migration failed after 4 attempts (retry loop "
                 "exhausted by timeouts or repeated idempotent-recovery "
                 "continues). Check database connectivity, load, and "
-                "_prisma_migrations ledger state."
+                "_prisma_migrations ledger state, and raise "
+                f"{PRISMA_MIGRATE_DEPLOY_TIMEOUT_ENV_VAR} if the attempts timed out."
             )
         finally:
             os.chdir(original_dir)
@@ -908,7 +916,7 @@ class ProxyExtrasDBManager:
                         # Set migrations directory for Prisma
                         result = subprocess.run(
                             [_get_prisma_command(), "migrate", "deploy"],
-                            timeout=prisma_command_timeout(),
+                            timeout=prisma_migrate_deploy_timeout(),
                             check=True,
                             capture_output=True,
                             text=True,
@@ -1126,7 +1134,11 @@ class ProxyExtrasDBManager:
                     )
                     return True
             except subprocess.TimeoutExpired:
-                logger.info(f"Attempt {attempt + 1} timed out")
+                logger.warning(
+                    "Attempt %s timed out. Raise %s if this database needs longer to apply its pending migrations.",
+                    attempt + 1,
+                    PRISMA_MIGRATE_DEPLOY_TIMEOUT_ENV_VAR,
+                )
                 time.sleep(random.randrange(5, 15))
             except subprocess.CalledProcessError as e:
                 attempts_left = 3 - attempt

--- a/litellm-proxy-extras/litellm_proxy_extras/utils.py
+++ b/litellm-proxy-extras/litellm_proxy_extras/utils.py
@@ -15,6 +15,7 @@ from litellm_proxy_extras.replica_identity import (
     apply_replica_identity_full,
 )
 from litellm_proxy_extras.prisma_toolchain import (
+    PRISMA_COMMAND_TIMEOUT_ENV_VAR,
     PRISMA_MIGRATE_DEPLOY_TIMEOUT_ENV_VAR,
     ensure_prisma_toolchain,
     prisma_command_timeout,
@@ -1135,9 +1136,9 @@ class ProxyExtrasDBManager:
                     return True
             except subprocess.TimeoutExpired:
                 logger.warning(
-                    "Attempt %s timed out. Raise %s if this database needs longer to apply its pending migrations.",
+                    "Attempt %s timed out. Raise %s if this database needs longer to apply its schema.",
                     attempt + 1,
-                    PRISMA_MIGRATE_DEPLOY_TIMEOUT_ENV_VAR,
+                    PRISMA_MIGRATE_DEPLOY_TIMEOUT_ENV_VAR if use_migrate else PRISMA_COMMAND_TIMEOUT_ENV_VAR,
                 )
                 time.sleep(random.randrange(5, 15))
             except subprocess.CalledProcessError as e:

--- a/tests/proxy_migration_tests/test_prisma_toolchain.py
+++ b/tests/proxy_migration_tests/test_prisma_toolchain.py
@@ -7,6 +7,11 @@ attempt fails identically. These tests pin the two behaviours that keep a
 container recoverable: an incomplete cache is deleted before Prisma is
 invoked, and the install gets a budget of its own rather than sharing the one
 that bounds each migration command.
+
+``prisma migrate deploy`` gets a budget of its own for the same reason: its
+runtime grows with the number of pending migrations, so a fresh database that
+replays every migration overran the per-command budget on slow machines and
+the proxy gave up after four identical timeouts.
 """
 
 import ast
@@ -14,19 +19,23 @@ import json
 import os
 import sys
 import time
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
 
 from litellm_proxy_extras.prisma_toolchain import (
     DEFAULT_PRISMA_COMMAND_TIMEOUT,
+    DEFAULT_PRISMA_MIGRATE_DEPLOY_TIMEOUT,
     PRISMA_BOOTSTRAP_TIMEOUT_ENV_VAR,
     PRISMA_COMMAND_TIMEOUT_ENV_VAR,
+    PRISMA_MIGRATE_DEPLOY_TIMEOUT_ENV_VAR,
     ensure_prisma_toolchain,
     heal_incomplete_nodeenv_cache,
     node_binary_path,
     prisma_bootstrap_timeout,
     prisma_command_timeout,
+    prisma_migrate_deploy_timeout,
 )
 from litellm_proxy_extras.utils import ProxyExtrasDBManager
 
@@ -42,13 +51,24 @@ import time
 
 args = sys.argv[1:]
 cache_dir = os.environ["PRISMA_NODEENV_CACHE_DIR"]
-with pathlib.Path(os.environ["FAKE_PRISMA_LOG"]).open("a") as log:
+log_path = pathlib.Path(os.environ["FAKE_PRISMA_LOG"])
+earlier_deploys = sum(
+    1
+    for line in (log_path.read_text().splitlines() if log_path.exists() else [])
+    if json.loads(line)["args"][:2] == ["migrate", "deploy"]
+)
+with log_path.open("a") as log:
     log.write(
         json.dumps({{"args": args, "cache_dir_present": os.path.isdir(cache_dir)}})
         + "\\n"
     )
 time.sleep(float(os.environ.get("FAKE_PRISMA_SLEEP", "0")))
 if args[:2] == ["migrate", "deploy"]:
+    if earlier_deploys == 0:
+        time.sleep(float(os.environ.get("FAKE_PRISMA_FIRST_DEPLOY_SLEEP", "0")))
+    elif os.environ.get("FAKE_PRISMA_LATER_DEPLOY_STDERR"):
+        print(os.environ["FAKE_PRISMA_LATER_DEPLOY_STDERR"], file=sys.stderr)
+        sys.exit(1)
     print("No pending migrations to apply")
 sys.exit(0)
 """
@@ -80,7 +100,12 @@ def toolchain_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path
     monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ['PATH']}")
     monkeypatch.delenv(PRISMA_COMMAND_TIMEOUT_ENV_VAR, raising=False)
     monkeypatch.delenv(PRISMA_BOOTSTRAP_TIMEOUT_ENV_VAR, raising=False)
+    monkeypatch.delenv(PRISMA_MIGRATE_DEPLOY_TIMEOUT_ENV_VAR, raising=False)
     return cache_dir, log_path
+
+
+def _deploy_calls(log_path: Path) -> list[list[str]]:
+    return [call["args"] for call in _fake_prisma_calls(log_path) if call["args"][:2] == ["migrate", "deploy"]]
 
 
 def _make_incomplete_cache(cache_dir: Path) -> None:
@@ -209,25 +234,70 @@ def test_setup_database_prepares_the_toolchain_before_migrating(
     assert calls[0]["cache_dir_present"] is False
 
 
+@pytest.mark.parametrize("use_v2_resolver", [False, True], ids=["v1", "v2"])
+def test_migrate_deploy_is_not_bounded_by_the_per_command_timeout(
+    toolchain_env: tuple[Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    use_v2_resolver: bool,
+) -> None:
+    """A fresh database replays every migration, which takes longer than any bookkeeping command."""
+    _, log_path = toolchain_env
+    monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@localhost:9/x")
+    monkeypatch.setenv(PRISMA_COMMAND_TIMEOUT_ENV_VAR, "1")
+    monkeypatch.setenv("FAKE_PRISMA_FIRST_DEPLOY_SLEEP", "3")
+
+    assert ProxyExtrasDBManager.setup_database(use_migrate=True, use_v2_resolver=use_v2_resolver) is True
+    assert _deploy_calls(log_path) == [["migrate", "deploy"]]
+
+
+def test_migrate_deploy_stops_at_its_own_timeout(
+    toolchain_env: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The deploy budget still bounds a deploy that hangs, so boot cannot wait forever."""
+    _, log_path = toolchain_env
+    monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@localhost:9/x")
+    monkeypatch.setenv(PRISMA_MIGRATE_DEPLOY_TIMEOUT_ENV_VAR, "1")
+    monkeypatch.setenv("FAKE_PRISMA_FIRST_DEPLOY_SLEEP", "60")
+    monkeypatch.setenv("FAKE_PRISMA_LATER_DEPLOY_STDERR", "Error: P3018 permission denied for schema public")
+
+    started = time.monotonic()
+    with pytest.raises(RuntimeError, match="insufficient permissions"):
+        ProxyExtrasDBManager.setup_database(use_migrate=True, use_v2_resolver=True)
+    elapsed = time.monotonic() - started
+
+    assert len(_deploy_calls(log_path)) == 2
+    assert elapsed < 30
+
+
 @pytest.mark.parametrize(
     "raw",
     ["", "0", "-5", "not-a-number", "nan", "inf", "-inf", "1e400"],
 )
+@pytest.mark.parametrize(
+    ("env_var", "read_timeout", "default"),
+    [
+        (PRISMA_COMMAND_TIMEOUT_ENV_VAR, prisma_command_timeout, DEFAULT_PRISMA_COMMAND_TIMEOUT),
+        (PRISMA_MIGRATE_DEPLOY_TIMEOUT_ENV_VAR, prisma_migrate_deploy_timeout, DEFAULT_PRISMA_MIGRATE_DEPLOY_TIMEOUT),
+    ],
+    ids=["command", "migrate_deploy"],
+)
 def test_unusable_timeout_override_falls_back_to_the_default(
-    raw: str, monkeypatch: pytest.MonkeyPatch
+    raw: str, env_var: str, read_timeout: Callable[[], float], default: float, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A non-finite override would silently disable the timeout it configures."""
-    monkeypatch.setenv(PRISMA_COMMAND_TIMEOUT_ENV_VAR, raw)
+    monkeypatch.setenv(env_var, raw)
 
-    assert prisma_command_timeout() == DEFAULT_PRISMA_COMMAND_TIMEOUT
+    assert read_timeout() == default
 
 
 def test_timeout_overrides_are_independent(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(PRISMA_COMMAND_TIMEOUT_ENV_VAR, "12")
     monkeypatch.setenv(PRISMA_BOOTSTRAP_TIMEOUT_ENV_VAR, "900")
+    monkeypatch.setenv(PRISMA_MIGRATE_DEPLOY_TIMEOUT_ENV_VAR, "1200")
 
     assert prisma_command_timeout() == 12
     assert prisma_bootstrap_timeout() == 900
+    assert prisma_migrate_deploy_timeout() == 1200
 
 
 @pytest.mark.parametrize("module", ["utils.py", "replica_identity.py"])

--- a/tests/proxy_migration_tests/test_prisma_toolchain.py
+++ b/tests/proxy_migration_tests/test_prisma_toolchain.py
@@ -16,11 +16,13 @@ the proxy gave up after four identical timeouts.
 
 import ast
 import json
+import logging
 import os
 import sys
 import time
 from collections.abc import Callable
 from pathlib import Path
+from typing import Optional
 
 import pytest
 
@@ -52,10 +54,10 @@ import time
 args = sys.argv[1:]
 cache_dir = os.environ["PRISMA_NODEENV_CACHE_DIR"]
 log_path = pathlib.Path(os.environ["FAKE_PRISMA_LOG"])
-earlier_deploys = sum(
+earlier_same_command = sum(
     1
     for line in (log_path.read_text().splitlines() if log_path.exists() else [])
-    if json.loads(line)["args"][:2] == ["migrate", "deploy"]
+    if json.loads(line)["args"][:2] == args[:2]
 )
 with log_path.open("a") as log:
     log.write(
@@ -64,12 +66,14 @@ with log_path.open("a") as log:
     )
 time.sleep(float(os.environ.get("FAKE_PRISMA_SLEEP", "0")))
 if args[:2] == ["migrate", "deploy"]:
-    if earlier_deploys == 0:
+    if earlier_same_command == 0:
         time.sleep(float(os.environ.get("FAKE_PRISMA_FIRST_DEPLOY_SLEEP", "0")))
     elif os.environ.get("FAKE_PRISMA_LATER_DEPLOY_STDERR"):
         print(os.environ["FAKE_PRISMA_LATER_DEPLOY_STDERR"], file=sys.stderr)
         sys.exit(1)
     print("No pending migrations to apply")
+if args[:2] == ["db", "push"] and earlier_same_command == 0:
+    time.sleep(float(os.environ.get("FAKE_PRISMA_FIRST_PUSH_SLEEP", "0")))
 sys.exit(0)
 """
 
@@ -267,6 +271,47 @@ def test_migrate_deploy_stops_at_its_own_timeout(
 
     assert len(_deploy_calls(log_path)) == 2
     assert elapsed < 30
+
+
+def test_db_push_timeout_hint_names_the_per_command_budget(
+    toolchain_env: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """``db push`` keeps the per-command budget, so its timeout hint has to name that variable."""
+    _, log_path = toolchain_env
+    monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@localhost:9/x")
+    monkeypatch.setenv(PRISMA_COMMAND_TIMEOUT_ENV_VAR, "1")
+    monkeypatch.setenv("FAKE_PRISMA_FIRST_PUSH_SLEEP", "3")
+
+    with caplog.at_level(logging.WARNING, logger="litellm_proxy_extras"):
+        assert ProxyExtrasDBManager.setup_database(use_migrate=False, use_v2_resolver=False) is True
+
+    assert [call["args"][:2] for call in _fake_prisma_calls(log_path)].count(["db", "push"]) == 2
+    assert [record.getMessage() for record in caplog.records if "timed out" in record.getMessage()] == [
+        f"Attempt 1 timed out. Raise {PRISMA_COMMAND_TIMEOUT_ENV_VAR} if this database needs longer to apply its schema."
+    ]
+
+
+@pytest.mark.parametrize(
+    ("command_timeout", "deploy_timeout", "expected"),
+    [
+        ("900", None, 900.0),
+        ("12", None, DEFAULT_PRISMA_MIGRATE_DEPLOY_TIMEOUT),
+        ("900", "1200", 1200.0),
+        ("900", "300", 300.0),
+    ],
+    ids=["raised_command_budget_carries_over", "lowered_command_budget_does_not", "override_wins_upward", "override_wins_downward"],
+)
+def test_migrate_deploy_budget_keeps_a_raised_command_budget(
+    command_timeout: str, deploy_timeout: Optional[str], expected: float, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Deployments that raised the per-command budget to survive a long deploy keep that budget for deploy."""
+    monkeypatch.setenv(PRISMA_COMMAND_TIMEOUT_ENV_VAR, command_timeout)
+    if deploy_timeout is None:
+        monkeypatch.delenv(PRISMA_MIGRATE_DEPLOY_TIMEOUT_ENV_VAR, raising=False)
+    else:
+        monkeypatch.setenv(PRISMA_MIGRATE_DEPLOY_TIMEOUT_ENV_VAR, deploy_timeout)
+
+    assert prisma_migrate_deploy_timeout() == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/proxy_migration_tests/test_prisma_toolchain.py
+++ b/tests/proxy_migration_tests/test_prisma_toolchain.py
@@ -22,7 +22,6 @@ import sys
 import time
 from collections.abc import Callable
 from pathlib import Path
-from typing import Optional
 
 import pytest
 
@@ -302,7 +301,7 @@ def test_db_push_timeout_hint_names_the_per_command_budget(
     ids=["raised_command_budget_carries_over", "lowered_command_budget_does_not", "override_wins_upward", "override_wins_downward"],
 )
 def test_migrate_deploy_budget_keeps_a_raised_command_budget(
-    command_timeout: str, deploy_timeout: Optional[str], expected: float, monkeypatch: pytest.MonkeyPatch
+    command_timeout: str, deploy_timeout: str | None, expected: float, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Deployments that raised the per-command budget to survive a long deploy keep that budget for deploy."""
     monkeypatch.setenv(PRISMA_COMMAND_TIMEOUT_ENV_VAR, command_timeout)


### PR DESCRIPTION
## TLDR

Problem this solves:

- `prisma migrate deploy` shared the 60s per-command Prisma budget
- A fresh database replays all 163 migrations, which takes longer on slow machines
- Boot killed the deploy 4 times in a row and exited with "Database migration failed after 4 attempts"

How it solves it:

- New `LITELLM_PRISMA_MIGRATE_DEPLOY_TIMEOUT` budget, default 600s, for both migrate deploy call sites
- With that variable unset, a `LITELLM_PRISMA_COMMAND_TIMEOUT` raised above 600s still bounds migrate deploy, so deployments that widened the old budget to get through slow deploys keep that budget
- Timeout logs now say which budget expired and which env var raises it: the deploy variable for migrate deploy, `LITELLM_PRISMA_COMMAND_TIMEOUT` for `db push`
- Regression tests fail when migrate deploy runs under the per-command budget again

## User Flow

Before: a developer booting the proxy against an empty local Postgres never gets past migrations

1. They start `DATABASE_URL=postgresql://... python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --use_v2_migration_resolver`
2. The log shows `Found 163 migrations`, then `prisma migrate deploy attempt 1 timed out, retrying` after about 60s
3. Attempts 2, 3, and 4 log the same line, each about 60s apart
4. The process exits with `Database migration cannot proceed. Database migration failed after 4 attempts`
5. GET http://localhost:4000/health/liveliness fails to connect because nothing is listening

After: the same boot applies every migration and serves traffic

1. They start `DATABASE_URL=postgresql://... python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --use_v2_migration_resolver`
2. The log shows `Found 163 migrations`, then the migrate deploy output listing `Applying migration ...` for all 163
3. The log shows `Uvicorn running on http://0.0.0.0:4000` and `Application startup complete`
4. GET http://localhost:4000/health/liveliness returns 200 `"I'm alive!"` and GET http://localhost:4000/health/readiness returns 200 with `"db": "connected"`

## Relevant issues

## Linear ticket

Resolves LIT-6724

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Setup shared by every run: an empty Postgres 16 in Docker (`docker run -d --name lit6724-pg -e POSTGRES_PASSWORD=devpg -p 59748:5432 postgres:16`, one fresh `createdb` per run), the proxy on port 48803 with `--num_workers 2`, and `LITELLM_PRISMA_COMMAND_TIMEOUT=5` standing in for the slow machine in the report. The default budget is 60s and a fresh 163-migration deploy takes 11s to 83s on this laptop depending on load, so with defaults the base commit only fails here when the box is busy: under load ~40 it logged `prisma migrate deploy attempt 1 timed out, retrying` at 60s, and the same deploy run by hand on that database (`cd litellm-proxy-extras/litellm_proxy_extras && prisma migrate deploy`) took `wall_seconds=83.0`. The 5s budget makes that failure reproducible on any box. Both resolvers are covered because both deploy call sites change: `--use_v2_migration_resolver` from the report and the default resolver

### Before (55e9e4ce2f)

`--use_v2_migration_resolver`, fresh database:

1. `LITELLM_PRISMA_COMMAND_TIMEOUT=5 DATABASE_URL="postgresql://postgres:devpg@127.0.0.1:59748/litellm_before6" python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --use_v2_migration_resolver --num_workers 2 --port 48803`
2. Observed log, then the process exits and nothing ever listens on 48803:
   ```
   11:20:27 Using v2 migration resolver (--use_v2_migration_resolver)
   11:20:27 Found 163 migrations at .../litellm_proxy_extras
   11:20:33 prisma migrate deploy attempt 1 timed out, retrying
   11:20:46 prisma migrate deploy attempt 2 timed out, retrying
   11:21:02 prisma migrate deploy attempt 3 timed out, retrying
   11:21:18 prisma migrate deploy attempt 4 timed out, retrying
   11:21:31 LiteLLM Proxy: Database migration cannot proceed. Database migration failed after 4 attempts (retry loop exhausted by timeouts or repeated idempotent-recovery continues). Check database connectivity, load, and _prisma_migrations ledger state.
   ```

Default resolver, fresh database:

1. `LITELLM_PRISMA_COMMAND_TIMEOUT=5 DATABASE_URL="postgresql://postgres:devpg@127.0.0.1:59748/litellm_before8" python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --num_workers 2 --port 48803`
2. Observed log: every attempt times out, then the proxy boots on the empty schema and every startup task logs a missing-table error:
   ```
   11:25:10 Running prisma migrate deploy
   11:25:15 Attempt 1 timed out
   11:25:27 Attempt 2 timed out
   11:25:40 Attempt 3 timed out
   11:25:57 Attempt 4 timed out
   11:26:12 LiteLLM Proxy: Database migration failed but continuing startup. Set --enforce_prisma_migration_check or ENFORCE_PRISMA_MIGRATION_CHECK=true to exit on failure.
   11:26:14 INFO:     Uvicorn running on http://0.0.0.0:48803 (Press CTRL+C to quit)
   11:27:09 LiteLLM Proxy:ERROR: proxy_server.py:6908 - litellm.proxy_server.py::add_deployment() - Error getting new models from DB - The table `public.LiteLLM_ProxyModelTable` does not exist in the current database.
   11:27:09 LiteLLM Proxy:ERROR: utils.py:3886 - LiteLLM Prisma Client Exception get_generic_data: The table `public.LiteLLM_Config` does not exist in the current database.
   11:27:09 INFO:     Application startup complete.
   11:27:09 INFO:     Application startup complete.
   11:27:10 LiteLLM Proxy:ERROR: utils.py:5849 - Error getting LiteLLM_SpendLogs row count: relation "LiteLLM_SpendLogs" does not exist
   ```
3. `/health/liveliness` and `/health/readiness` both answer 200 (`{"status":"healthy","db":"connected"}`) with no table in the database

### After (c83b4a1d19)

The only commit since, 3af19cbf61, changes a type annotation in the test file and cannot change proxy behavior, so this run stands for the tip

`--use_v2_migration_resolver`, fresh database, same 5s per-command budget:

1. `LITELLM_PRISMA_COMMAND_TIMEOUT=5 DATABASE_URL="postgresql://postgres:devpg@127.0.0.1:59748/litellm_after10" python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --use_v2_migration_resolver --num_workers 2 --port 48803`
2. Observed log: the deploy runs for 93s (the box was under load, so this run also outlived the old 60s default) under its own 600s budget and both workers come up:
   ```
   12:12:54 Using v2 migration resolver (--use_v2_migration_resolver)
   12:12:56 Found 163 migrations at .../litellm_proxy_extras
   12:14:29 Datasource "client": PostgreSQL database "litellm_after10", schema "public" at "127.0.0.1:59748"
   12:14:29 The following migrations have been applied:
   12:14:29   └─ 20250326162113_baseline/
   ...
   12:14:29   └─ 20260901000000_shadow_eval_multi_router/
   12:14:29 All migrations have been successfully applied.
   12:14:38 INFO:     Uvicorn running on http://0.0.0.0:48803 (Press CTRL+C to quit)
   12:14:38 INFO:     Started parent process [43047]
   12:15:39 INFO:     Started server process [57679]
   12:15:43 INFO:     Application startup complete.
   12:15:47 INFO:     Started server process [58083]
   12:15:50 INFO:     Application startup complete.
   ```
3. `curl -sS -w '\nhttp=%{http_code}\n' http://127.0.0.1:48803/health/liveliness`
   ```
   "I'm alive!"
   http=200
   ```
4. `curl -sS -w '\nhttp=%{http_code}\n' http://127.0.0.1:48803/health/readiness`
   ```
   {"status":"healthy","db":"connected"}
   http=200
   ```

`--use_v2_migration_resolver`, fresh database, no env overrides (`litellm_after11`): `Found 163 migrations` at 12:16:35, `All migrations have been successfully applied` at 12:17:38, the first worker's `Application startup complete` at 12:18:26 (the second worker was still starting when the run was torn down after the probes), both health endpoints 200

Default resolver, fresh database, same 5s budget (`litellm_after12`): `Running prisma migrate deploy` at 12:19:40, `All migrations have been successfully applied` at 12:20:48 (68s, thirteen times the per-command budget and past the old 60s default). The follow-up `migrate diff` steps of that loop then log `Migration diff generation timed out` and `Migration diff application timed out`, since they are other Prisma commands and keep the per-command budget (the 5s stand-in here); they are warnings and startup continues. Two `Application startup complete` lines at 12:21:42, both health endpoints 200

`--use_v2_migration_resolver`, second boot on the already migrated `litellm_after10` database, same 5s budget: `Found 163 migrations` at 12:22:43, `No pending migrations to apply.` at 12:23:03, `Application startup complete` at 12:23:51 and 12:24:02, both health endpoints 200

The three 5s runs also exercise the new floor: with `LITELLM_PRISMA_MIGRATE_DEPLOY_TIMEOUT` unset the deploy budget is `max(600, LITELLM_PRISMA_COMMAND_TIMEOUT)`, which is what let a 93s and a 68s deploy finish under a 5s per-command budget

Observed alongside the fix:
- Default resolver boots after failed migrations; pre-existing, PR leaves it alone
- Readiness healthy on an empty schema; pre-existing, PR leaves it alone

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- The 600s default also bounds a deploy that hangs on a dead database, so a broken connection now takes up to 10 minutes per attempt before the retry
  - `LITELLM_PRISMA_MIGRATE_DEPLOY_TIMEOUT` lowers it for deployments that want the old fail-fast
- Killing a timed-out deploy only kills the Python `prisma` wrapper; Node and the schema engine keep running and keep Prisma's advisory lock, so the retry contends on it
  - Pre-existing for every Prisma call at boot; after this PR a deploy only trips it past 600s or on a database that never answers
  - Left alone here because the fix (a process-group kill across all 13 Prisma call sites, a Windows guard, and the mid-DDL interplay with P3009 recovery) is a bigger change than this PR and the PR already makes the trigger rarer; tracked in LIT-6743

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
- [x] 0c53961445 passes /live-pr-risk
- [x] c83b4a1d19 passes /live-pr-risk (3af19cbf61 only changes a test annotation, so it carries over)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scope is proxy-extras migration timeouts and logging only; no auth, schema, or runtime API behavior changes beyond allowing long deploys to finish.
> 
> **Overview**
> **`prisma migrate deploy` no longer shares the 60s per-command Prisma timeout**, which caused fresh databases replaying many migrations to fail boot after four ~60s timeouts.
> 
> The change adds **`LITELLM_PRISMA_MIGRATE_DEPLOY_TIMEOUT`** (default **600s**) via `prisma_migrate_deploy_timeout()`, and wires it into both migration resolver paths in `ProxyExtrasDBManager`. If the deploy override is unset, deploy still uses **`max(600, LITELLM_PRISMA_COMMAND_TIMEOUT)`** so operators who previously raised the shared budget keep a long deploy window. **`db push` and other Prisma commands stay on the per-command budget.**
> 
> Timeout retries are **warning-level logs** that name the env var to raise (`LITELLM_PRISMA_MIGRATE_DEPLOY_TIMEOUT` vs `LITELLM_PRISMA_COMMAND_TIMEOUT`), and exhausted-retry errors mention the deploy variable when relevant.
> 
> **Tests** in `test_prisma_toolchain.py` cover deploy surviving a low command timeout, deploy honoring its own cap, env fallback behavior, and correct hints for `db push`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3af19cbf61706f1cf3d3360b8802b5cbc1991827. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->