### PR TITLE
fix(otel): stamp Langfuse root observation input and output from the request task

### DIFF
--- a/litellm/integrations/otel/langfuse_logger.py
+++ b/litellm/integrations/otel/langfuse_logger.py
@@ -8,33 +8,18 @@ from litellm.integrations.otel.model.request_io import request_input, response_o
 from litellm.integrations.otel.plumbing.context import request_root_span
 
 if TYPE_CHECKING:
-    from litellm.caching.dual_cache import DualCache
     from litellm.proxy._types import UserAPIKeyAuth
-    from litellm.types.utils import CallTypesLiteral, ModelResponseStream
-
-ROOT_OBSERVATION_IO_CALL_TYPES: Final = frozenset(
-    {"completion", "acompletion", "responses", "aresponses", "anthropic_messages", "aanthropic_messages"}
-)
+    from litellm.types.utils import ModelResponseStream
 
 
 class LangfuseOpenTelemetryV2(OpenTelemetryV2):
     """Stamps the request's input and output on the root observation while it is still recording.
 
     Langfuse shows a trace's input and output from its root observation. The proxy's root span ends
-    when the response is sent, before the success callback runs, so the stamps have to come from the
-    request-task hooks: input at pre-call, output at post-call success or at the end of the stream.
+    when the response is sent, before the success callback runs, so both stamps come from the
+    post-call hooks in the request task: the request as it stands after the pre-call chain and the
+    response as it is returned, for the call types whose response renders as a message.
     """
-
-    async def async_pre_call_hook(
-        self,
-        user_api_key_dict: "UserAPIKeyAuth",
-        cache: "DualCache",
-        data: Mapping[str, object],
-        call_type: "CallTypesLiteral",
-    ) -> None:
-        await super().async_pre_call_hook(user_api_key_dict, cache, data, call_type)
-        if call_type in ROOT_OBSERVATION_IO_CALL_TYPES:
-            self._stamp_root(LANGFUSE_OBSERVATION_INPUT, lambda: request_input(data))
 
     async def async_post_call_success_hook(
         self,
@@ -42,7 +27,7 @@ class LangfuseOpenTelemetryV2(OpenTelemetryV2):
         user_api_key_dict: "UserAPIKeyAuth",
         response: object,
     ) -> None:
-        self._stamp_root(LANGFUSE_OBSERVATION_OUTPUT, lambda: response_output(response))
+        self._stamp_root_io(data, lambda: response_output(response))
 
     async def async_post_call_streaming_iterator_hook(
         self,
@@ -54,16 +39,22 @@ class LangfuseOpenTelemetryV2(OpenTelemetryV2):
         async for chunk in response:
             relayed.append(chunk)
             yield chunk
-        self._stamp_root(LANGFUSE_OBSERVATION_OUTPUT, lambda: stream_output(tuple(relayed), request_data))
+        self._stamp_root_io(request_data, lambda: stream_output(tuple(relayed), request_data))
 
-    def _stamp_root(self, key: str, render: Callable[[], str | None]) -> None:
+    def _stamp_root_io(self, data: Mapping[str, object], render_output: Callable[[], str | None]) -> None:
         root: Final = request_root_span()
         if root is None or not root.is_recording():
             return
         try:
-            value: Final = render()
+            output: Final = render_output()
+            if output is None:
+                return
+            root.set_attribute(LANGFUSE_OBSERVATION_OUTPUT, output)
+            rendered_input: Final = request_input(data)
         except Exception:  # noqa: BLE001  # telemetry must never fail the request it describes
-            verbose_logger.debug("otel v2 langfuse: could not render %s for the root observation", key, exc_info=True)
+            verbose_logger.debug(
+                "otel v2 langfuse: could not render the root observation input or output", exc_info=True
+            )
             return
-        if value is not None:
-            root.set_attribute(key, value)
+        if rendered_input is not None:
+            root.set_attribute(LANGFUSE_OBSERVATION_INPUT, rendered_input)

--- a/litellm/integrations/otel/langfuse_logger.py
+++ b/litellm/integrations/otel/langfuse_logger.py
@@ -1,0 +1,69 @@
+from collections.abc import AsyncGenerator, AsyncIterator, Callable, Mapping
+from typing import TYPE_CHECKING, Final
+
+from litellm._logging import verbose_logger
+from litellm.integrations.otel.logger import OpenTelemetryV2
+from litellm.integrations.otel.mappers.langfuse import LANGFUSE_OBSERVATION_INPUT, LANGFUSE_OBSERVATION_OUTPUT
+from litellm.integrations.otel.model.request_io import request_input, response_output, stream_output
+from litellm.integrations.otel.plumbing.context import request_root_span
+
+if TYPE_CHECKING:
+    from litellm.caching.dual_cache import DualCache
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.types.utils import CallTypesLiteral, ModelResponseStream
+
+ROOT_OBSERVATION_IO_CALL_TYPES: Final = frozenset(
+    {"completion", "acompletion", "responses", "aresponses", "anthropic_messages", "aanthropic_messages"}
+)
+
+
+class LangfuseOpenTelemetryV2(OpenTelemetryV2):
+    """Stamps the request's input and output on the root observation while it is still recording.
+
+    Langfuse shows a trace's input and output from its root observation. The proxy's root span ends
+    when the response is sent, before the success callback runs, so the stamps have to come from the
+    request-task hooks: input at pre-call, output at post-call success or at the end of the stream.
+    """
+
+    async def async_pre_call_hook(
+        self,
+        user_api_key_dict: "UserAPIKeyAuth",
+        cache: "DualCache",
+        data: Mapping[str, object],
+        call_type: "CallTypesLiteral",
+    ) -> None:
+        await super().async_pre_call_hook(user_api_key_dict, cache, data, call_type)
+        if call_type in ROOT_OBSERVATION_IO_CALL_TYPES:
+            self._stamp_root(LANGFUSE_OBSERVATION_INPUT, lambda: request_input(data))
+
+    async def async_post_call_success_hook(
+        self,
+        data: Mapping[str, object],
+        user_api_key_dict: "UserAPIKeyAuth",
+        response: object,
+    ) -> None:
+        self._stamp_root(LANGFUSE_OBSERVATION_OUTPUT, lambda: response_output(response))
+
+    async def async_post_call_streaming_iterator_hook(
+        self,
+        user_api_key_dict: "UserAPIKeyAuth",
+        response: "AsyncIterator[ModelResponseStream]",
+        request_data: Mapping[str, object],
+    ) -> "AsyncGenerator[ModelResponseStream, None]":
+        relayed: Final[list[ModelResponseStream]] = []  # mutable-ok: relayed as they arrive, assembled at end of stream
+        async for chunk in response:
+            relayed.append(chunk)
+            yield chunk
+        self._stamp_root(LANGFUSE_OBSERVATION_OUTPUT, lambda: stream_output(tuple(relayed), request_data))
+
+    def _stamp_root(self, key: str, render: Callable[[], str | None]) -> None:
+        root: Final = request_root_span()
+        if root is None or not root.is_recording():
+            return
+        try:
+            value: Final = render()
+        except Exception:  # noqa: BLE001  # telemetry must never fail the request it describes
+            verbose_logger.debug("otel v2 langfuse: could not render %s for the root observation", key, exc_info=True)
+            return
+        if value is not None:
+            root.set_attribute(key, value)

--- a/litellm/integrations/otel/logger.py
+++ b/litellm/integrations/otel/logger.py
@@ -723,13 +723,14 @@ class OpenTelemetryV2(CustomLogger):
         self,
         user_api_key_dict: "UserAPIKeyAuth",
         cache: "DualCache",
-        data: Mapping[str, object],
+        data: dict,
         call_type: "CallTypesLiteral",
-    ) -> None:
+    ) -> dict:
         self.seed_request_identity(
             user_api_key_dict,
             model=model_from_request_data(data),
         )
+        return data
 
     def record_error_attributes_on_span(
         self,

--- a/litellm/integrations/otel/logger.py
+++ b/litellm/integrations/otel/logger.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 from collections.abc import Callable, Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from datetime import datetime
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Final, cast
 
 from opentelemetry.context import Context, attach, get_current
@@ -722,14 +723,13 @@ class OpenTelemetryV2(CustomLogger):
         self,
         user_api_key_dict: "UserAPIKeyAuth",
         cache: "DualCache",
-        data: dict,
+        data: Mapping[str, object],
         call_type: "CallTypesLiteral",
-    ) -> dict:
+    ) -> None:
         self.seed_request_identity(
             user_api_key_dict,
             model=model_from_request_data(data),
         )
-        return data
 
     def record_error_attributes_on_span(
         self,
@@ -909,3 +909,29 @@ def phase_span(name: str) -> "Iterator[Span | None]":
         return
     with logger.start_phase_span(name) as span:
         yield span
+
+
+def build_otel_v2_logger(
+    config: OpenTelemetryV2Config,
+    callback_name: str | None = None,
+    tracer_provider: TracerProvider | None = None,
+    logger_provider: LoggerProvider | None = None,
+    meter_provider: "MeterProvider | None" = None,
+    settings: Mapping[str, object] = MappingProxyType({}),
+) -> OpenTelemetryV2:
+    return _logger_class(config)(
+        config=config,
+        callback_name=callback_name,
+        tracer_provider=tracer_provider,
+        logger_provider=logger_provider,
+        meter_provider=meter_provider,
+        **settings,
+    )
+
+
+def _logger_class(config: OpenTelemetryV2Config) -> type[OpenTelemetryV2]:
+    if "langfuse" not in config.mapper_names or not config.capture_span_content:
+        return OpenTelemetryV2
+    from litellm.integrations.otel.langfuse_logger import LangfuseOpenTelemetryV2
+
+    return LangfuseOpenTelemetryV2

--- a/litellm/integrations/otel/mappers/langfuse.py
+++ b/litellm/integrations/otel/mappers/langfuse.py
@@ -11,6 +11,7 @@ the JSON-serialized payloads. ``_llm_call`` just applies both tables.
 
 import json
 from collections.abc import Callable
+from typing import Final
 
 from litellm.integrations.otel.mappers.base import AttributeMap, AttrValue, SpanData
 from litellm.integrations.otel.mappers.utils import (
@@ -24,6 +25,9 @@ from litellm.integrations.otel.model.payloads import (
     LLMRequestParams,
     LLMUsage,
 )
+
+LANGFUSE_OBSERVATION_INPUT: Final = "langfuse.observation.input"
+LANGFUSE_OBSERVATION_OUTPUT: Final = "langfuse.observation.output"
 
 
 class LangfuseMapper:
@@ -56,8 +60,8 @@ class LangfuseMapper:
         "langfuse.observation.model.parameters": lambda d: json_if(
             collect(LangfuseMapper._MODEL_PARAMS, d.request_params)
         ),
-        "langfuse.observation.input": lambda d: serialize_messages(d.messages_in),
-        "langfuse.observation.output": lambda d: serialize_messages(output_messages(d)),
+        LANGFUSE_OBSERVATION_INPUT: lambda d: serialize_messages(d.messages_in),
+        LANGFUSE_OBSERVATION_OUTPUT: lambda d: serialize_messages(output_messages(d)),
         "langfuse.observation.usage_details": lambda d: json_if(collect(LangfuseMapper._USAGE_FIELDS, d.usage)),
         "langfuse.observation.cost_details": lambda d: (
             json.dumps({"total": d.response_cost}) if d.response_cost is not None else None

--- a/litellm/integrations/otel/model/request_io.py
+++ b/litellm/integrations/otel/model/request_io.py
@@ -1,0 +1,90 @@
+from collections.abc import Mapping, Sequence
+from typing import Final, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, ValidationError
+from typing_extensions import ReadOnly, TypedDict
+
+import litellm
+from litellm.integrations.otel.mappers.utils import json_or_none
+from litellm.proxy.guardrails.anthropic_sse import assemble_anthropic_sse_stream, is_raw_sse_stream
+from litellm.types.llms.openai import ResponseCompletedEvent, ResponsesAPIResponse
+from litellm.types.utils import ModelResponse, ModelResponseStream
+
+_SYSTEM_KEYS: Final = ("system", "instructions")
+_TURNS: Final = TypeAdapter(tuple[object, ...])
+_MESSAGES: Final = TypeAdapter(list[object] | None)
+
+
+class _Turn(TypedDict):
+    role: ReadOnly[str]
+    content: ReadOnly[object]
+
+
+class _AnthropicMessage(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    type: Literal["message"] = Field(exclude=True)
+    role: str = "assistant"
+    content: object = None
+
+
+def request_input(data: Mapping[str, object]) -> str | None:
+    turns: Final = data.get("messages", data.get("input"))
+    if turns is None:
+        return None
+    return json_or_none((*_system_turns(data), *_user_turns(turns)))
+
+
+def _system_turns(data: Mapping[str, object]) -> tuple[_Turn, ...]:
+    return tuple(_Turn(role="system", content=data[key]) for key in _SYSTEM_KEYS if data.get(key) is not None)
+
+
+def _user_turns(turns: object) -> tuple[object, ...]:
+    if isinstance(turns, str):
+        return (_Turn(role="user", content=turns),)
+    try:
+        return _TURNS.validate_python(turns)
+    except ValidationError:
+        return (_Turn(role="user", content=turns),)
+
+
+def response_output(response: object) -> str | None:
+    match response:
+        case ModelResponse():
+            return json_or_none(tuple(choice.message.model_dump(exclude_none=True) for choice in response.choices))
+        case ResponsesAPIResponse():
+            return json_or_none(response.model_dump(exclude_none=True).get("output"))
+        case _:
+            return _anthropic_message_output(response)
+
+
+def _anthropic_message_output(message: object) -> str | None:
+    try:
+        parsed: Final = _AnthropicMessage.model_validate(message)
+    except ValidationError:
+        return None
+    return json_or_none((parsed.model_dump(),))
+
+
+def stream_output(chunks: Sequence[object], data: Mapping[str, object]) -> str | None:
+    if not chunks:
+        return None
+    if is_raw_sse_stream(chunks):
+        return response_output(assemble_anthropic_sse_stream(chunks))
+    if all(isinstance(chunk, ModelResponseStream) for chunk in chunks):
+        return response_output(_assembled_chat_stream(chunks, data))
+    return response_output(_completed_response(chunks))
+
+
+def _assembled_chat_stream(chunks: Sequence[object], data: Mapping[str, object]) -> object:
+    try:
+        return litellm.stream_chunk_builder(  # pyright: ignore[reportUnknownMemberType]  # upstream types chunks as a bare list
+            chunks=list(chunks),  # mutable-ok: stream_chunk_builder takes a list
+            messages=_MESSAGES.validate_python(data.get("messages")),
+        )
+    except (litellm.APIError, ValidationError):
+        return None
+
+
+def _completed_response(chunks: Sequence[object]) -> ResponsesAPIResponse | None:
+    return next((chunk.response for chunk in reversed(chunks) if isinstance(chunk, ResponseCompletedEvent)), None)

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -4390,13 +4390,15 @@ def _init_custom_logger_compatible_class(
             from litellm.integrations.otel.model.config import is_otel_v2_enabled
 
             if is_otel_v2_enabled():
-                from litellm.integrations.otel.logger import OpenTelemetryV2
+                from litellm.integrations.otel.logger import OpenTelemetryV2, build_otel_v2_logger
+                from litellm.integrations.otel.model.config import OpenTelemetryV2Config
 
                 for callback in _in_memory_loggers:
-                    if type(callback) is OpenTelemetryV2:
+                    if isinstance(callback, OpenTelemetryV2):
                         return callback
-                otel_logger_v2: Final = OpenTelemetryV2(
-                    **_get_custom_logger_settings_from_proxy_server(callback_name=logging_integration)
+                otel_settings: Final = _get_custom_logger_settings_from_proxy_server(callback_name=logging_integration)
+                otel_logger_v2: Final = build_otel_v2_logger(
+                    config=OpenTelemetryV2Config(**otel_settings), settings=otel_settings
                 )
                 _in_memory_loggers.append(otel_logger_v2)
                 _maybe_auto_initialize_arize_phoenix(_in_memory_loggers)
@@ -4759,7 +4761,7 @@ def _maybe_construct_otel_v2(callback_name: str, _in_memory_loggers: list[Custom
 
     if not is_otel_v2_enabled():
         return None
-    from litellm.integrations.otel.logger import OpenTelemetryV2
+    from litellm.integrations.otel.logger import OpenTelemetryV2, build_otel_v2_logger
     from litellm.integrations.otel.presets import PRESET_BY_CALLBACK
 
     preset_fn: Final = PRESET_BY_CALLBACK.get(callback_name)
@@ -4774,7 +4776,7 @@ def _maybe_construct_otel_v2(callback_name: str, _in_memory_loggers: list[Custom
         # If env vars are missing or the preset raises, defer to the legacy path
         # so customers get the same error story they had before V2 landed.
         return None
-    v2_logger: Final = OpenTelemetryV2(config=config, callback_name=callback_name)
+    v2_logger: Final = build_otel_v2_logger(config=config, callback_name=callback_name)
     _in_memory_loggers.append(v2_logger)
     return v2_logger
 

--- a/tests/test_litellm/integrations/otel/test_langfuse_logger.py
+++ b/tests/test_litellm/integrations/otel/test_langfuse_logger.py
@@ -1,0 +1,317 @@
+"""Tests for ``LangfuseOpenTelemetryV2``: the root observation's input and output are stamped from the
+request-task hooks, while the root span is still recording, so Langfuse can show them on the trace."""
+
+import asyncio
+import json
+from collections.abc import AsyncIterator, Sequence
+from typing import Final
+
+import pytest
+
+pytest.importorskip("opentelemetry")
+
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter  # noqa: E402
+
+from litellm.caching.dual_cache import DualCache  # noqa: E402
+from litellm.integrations.otel.langfuse_logger import LangfuseOpenTelemetryV2  # noqa: E402
+from litellm.integrations.otel.logger import OpenTelemetryV2, build_otel_v2_logger  # noqa: E402
+from litellm.integrations.otel.model.config import OpenTelemetryV2Config, is_otel_v2_enabled  # noqa: E402
+from litellm.integrations.otel.model.spans import LITELLM_PROXY_REQUEST_SPAN_NAME, SpanRole  # noqa: E402
+from litellm.integrations.otel.plumbing import context as otel_context  # noqa: E402
+from litellm.integrations.otel.plumbing import providers  # noqa: E402
+from litellm.integrations.otel.plumbing.context import set_request_root_span  # noqa: E402
+from litellm.litellm_core_utils.litellm_logging import _maybe_construct_otel_v2  # noqa: E402
+from litellm.proxy._types import UserAPIKeyAuth  # noqa: E402
+from litellm.types.llms.openai import (  # noqa: E402
+    ResponseCompletedEvent,
+    ResponsesAPIResponse,
+    ResponsesAPIStreamEvents,
+)
+from litellm.types.utils import (  # noqa: E402
+    Choices,
+    Delta,
+    Message,
+    ModelResponse,
+    ModelResponseStream,
+    StreamingChoices,
+)
+
+INPUT_ATTR: Final = "langfuse.observation.input"
+OUTPUT_ATTR: Final = "langfuse.observation.output"
+CHAT_DATA: Final = {"model": "gpt-5.4-mini", "messages": [{"role": "user", "content": "ping"}]}
+
+
+@pytest.fixture(autouse=True)
+def _reset_request_root_span():
+    otel_context._request_root_span.set(None)
+    yield
+    otel_context._request_root_span.set(None)
+
+
+def _logger(*, capture: str = "span_only", mappers: Sequence[str] = ("genai", "langfuse")):
+    cfg = OpenTelemetryV2Config(exporter="in_memory", mapper_names=list(mappers), capture_message_content=capture)
+    exporter = InMemorySpanExporter()
+    tracer_provider = providers.build_tracer_provider(cfg, exporter=exporter)
+    return build_otel_v2_logger(config=cfg, tracer_provider=tracer_provider), exporter
+
+
+def _start_root(logger):
+    root = logger._emitter.start_span(SpanRole.PROXY_REQUEST, LITELLM_PROXY_REQUEST_SPAN_NAME)
+    set_request_root_span(root)
+    return root
+
+
+def _root_attrs(exporter):
+    by_name = {span.name: span for span in exporter.get_finished_spans()}
+    return dict(by_name[LITELLM_PROXY_REQUEST_SPAN_NAME].attributes or {})
+
+
+def _run_request(logger, data: dict, call_type: str, response: object):
+    root = _start_root(logger)
+    asyncio.run(logger.async_pre_call_hook(UserAPIKeyAuth(), DualCache(), data, call_type))
+    asyncio.run(logger.async_post_call_success_hook(data=data, user_api_key_dict=UserAPIKeyAuth(), response=response))
+    root.end()
+
+
+async def _relay(logger, chunks: Sequence[object], data: dict) -> list[object]:
+    async def source() -> AsyncIterator[object]:
+        for chunk in chunks:
+            yield chunk
+
+    return [chunk async for chunk in logger.async_post_call_streaming_iterator_hook(UserAPIKeyAuth(), source(), data)]
+
+
+def _run_stream(logger, data: dict, chunks: Sequence[object]) -> list[object]:
+    root = _start_root(logger)
+    asyncio.run(logger.async_pre_call_hook(UserAPIKeyAuth(), DualCache(), data, "acompletion"))
+    relayed = asyncio.run(_relay(logger, chunks, data))
+    root.end()
+    return relayed
+
+
+def _chat_chunk(content: str | None, finish_reason: str | None = None) -> ModelResponseStream:
+    return ModelResponseStream(
+        id="chatcmpl-1",
+        created=1,
+        model="gpt-5.4-mini",
+        choices=[StreamingChoices(index=0, delta=Delta(content=content), finish_reason=finish_reason)],
+    )
+
+
+def _responses_api_response() -> ResponsesAPIResponse:
+    return ResponsesAPIResponse(
+        id="resp_1",
+        created_at=1,
+        output=[
+            {
+                "type": "message",
+                "id": "msg_1",
+                "status": "completed",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "pong", "annotations": []}],
+            }
+        ],
+    )
+
+
+def _anthropic_sse_frames() -> tuple[bytes, ...]:
+    events = (
+        {
+            "type": "message_start",
+            "message": {
+                "id": "msg_1",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-sonnet-4-5",
+                "content": [],
+                "stop_reason": None,
+                "usage": {"input_tokens": 1, "output_tokens": 0},
+            },
+        },
+        {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}},
+        {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "po"}},
+        {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "ng"}},
+        {"type": "content_block_stop", "index": 0},
+        {"type": "message_delta", "delta": {"stop_reason": "end_turn"}, "usage": {"output_tokens": 2}},
+        {"type": "message_stop"},
+    )
+    return tuple(f"event: {event['type']}\ndata: {json.dumps(event)}\n\n".encode() for event in events)
+
+
+def test_chat_request_stamps_root_observation_input_and_output():
+    logger, exporter = _logger()
+    response = ModelResponse(choices=[Choices(message=Message(role="assistant", content="pong"))])
+
+    _run_request(logger, CHAT_DATA, "acompletion", response)
+
+    attrs = _root_attrs(exporter)
+    assert json.loads(attrs[INPUT_ATTR]) == [{"role": "user", "content": "ping"}]
+    output = json.loads(attrs[OUTPUT_ATTR])
+    assert [(turn["role"], turn["content"]) for turn in output] == [("assistant", "pong")]
+
+
+def test_responses_request_folds_instructions_into_input_and_stamps_output_items():
+    logger, exporter = _logger()
+    data = {"model": "gpt-5.4-mini", "instructions": "be terse", "input": "ping"}
+
+    _run_request(logger, data, "aresponses", _responses_api_response())
+
+    attrs = _root_attrs(exporter)
+    assert json.loads(attrs[INPUT_ATTR]) == [
+        {"role": "system", "content": "be terse"},
+        {"role": "user", "content": "ping"},
+    ]
+    output = json.loads(attrs[OUTPUT_ATTR])
+    assert output[0]["role"] == "assistant"
+    assert output[0]["content"][0]["text"] == "pong"
+
+
+def test_anthropic_messages_request_folds_system_into_input_and_stamps_content_blocks():
+    logger, exporter = _logger()
+    data = {"model": "claude-sonnet-4-5", "system": "be terse", "messages": [{"role": "user", "content": "ping"}]}
+    response = {"type": "message", "role": "assistant", "content": [{"type": "text", "text": "pong"}]}
+
+    _run_request(logger, data, "aanthropic_messages", response)
+
+    attrs = _root_attrs(exporter)
+    assert json.loads(attrs[INPUT_ATTR]) == [
+        {"role": "system", "content": "be terse"},
+        {"role": "user", "content": "ping"},
+    ]
+    assert json.loads(attrs[OUTPUT_ATTR]) == [{"role": "assistant", "content": [{"type": "text", "text": "pong"}]}]
+
+
+def test_chat_stream_relays_chunks_untouched_and_stamps_assembled_output():
+    logger, exporter = _logger()
+    chunks = (_chat_chunk("po"), _chat_chunk("ng"), _chat_chunk(None, finish_reason="stop"))
+
+    relayed = _run_stream(logger, CHAT_DATA, chunks)
+
+    assert [id(chunk) for chunk in relayed] == [id(chunk) for chunk in chunks]
+    output = json.loads(_root_attrs(exporter)[OUTPUT_ATTR])
+    assert [(turn["role"], turn["content"]) for turn in output] == [("assistant", "pong")]
+
+
+def test_responses_stream_stamps_output_from_the_completed_event():
+    logger, exporter = _logger()
+    completed = ResponseCompletedEvent(
+        type=ResponsesAPIStreamEvents.RESPONSE_COMPLETED, response=_responses_api_response()
+    )
+    chunks = ({"type": "response.created"}, {"type": "response.output_text.delta", "delta": "pong"}, completed)
+
+    relayed = _run_stream(logger, {"model": "gpt-5.4-mini", "input": "ping"}, chunks)
+
+    assert relayed == list(chunks)
+    output = json.loads(_root_attrs(exporter)[OUTPUT_ATTR])
+    assert output[0]["content"][0]["text"] == "pong"
+
+
+def test_anthropic_sse_stream_stamps_output_from_the_assembled_frames():
+    logger, exporter = _logger()
+    frames = _anthropic_sse_frames()
+
+    relayed = _run_stream(
+        logger, {"model": "claude-sonnet-4-5", "messages": [{"role": "user", "content": "ping"}]}, frames
+    )
+
+    assert relayed == list(frames)
+    output = json.loads(_root_attrs(exporter)[OUTPUT_ATTR])
+    assert [(turn["role"], turn["content"]) for turn in output] == [("assistant", "pong")]
+
+
+def test_root_observation_io_survives_the_root_ending_before_the_success_callback():
+    logger, exporter = _logger()
+    response = ModelResponse(choices=[Choices(message=Message(role="assistant", content="pong"))])
+    root = _start_root(logger)
+    asyncio.run(logger.async_pre_call_hook(UserAPIKeyAuth(), DualCache(), CHAT_DATA, "acompletion"))
+    logger.log_pre_api_call(
+        model="gpt-5.4-mini",
+        messages=[],
+        kwargs={"litellm_call_id": "call_1", "litellm_params": {"metadata": {}}},
+    )
+    asyncio.run(
+        logger.async_post_call_success_hook(data=CHAT_DATA, user_api_key_dict=UserAPIKeyAuth(), response=response)
+    )
+    root.end()
+
+    payload = {
+        "call_type": "acompletion",
+        "custom_llm_provider": "openai",
+        "model": "gpt-5.4-mini",
+        "messages": CHAT_DATA["messages"],
+        "response": response.model_dump(),
+        "status": "success",
+        "litellm_call_id": "call_1",
+        "metadata": {},
+        "hidden_params": {},
+    }
+    asyncio.run(
+        logger.async_log_success_event(
+            {"standard_logging_object": payload, "litellm_params": {"metadata": {}}}, response, None, None
+        )
+    )
+
+    attrs = _root_attrs(exporter)
+    assert INPUT_ATTR in attrs and OUTPUT_ATTR in attrs
+    generation = next(span for span in exporter.get_finished_spans() if span.name != LITELLM_PROXY_REQUEST_SPAN_NAME)
+    assert OUTPUT_ATTR in dict(generation.attributes or {})
+
+
+def test_root_already_ended_is_left_alone():
+    logger, exporter = _logger()
+    root = _start_root(logger)
+    root.end()
+
+    asyncio.run(logger.async_pre_call_hook(UserAPIKeyAuth(), DualCache(), CHAT_DATA, "acompletion"))
+
+    assert INPUT_ATTR not in _root_attrs(exporter)
+
+
+def test_non_chat_call_types_do_not_stamp_input():
+    logger, exporter = _logger()
+    root = _start_root(logger)
+
+    asyncio.run(
+        logger.async_pre_call_hook(UserAPIKeyAuth(), DualCache(), {"model": "e", "input": "ping"}, "aembedding")
+    )
+    root.end()
+
+    assert INPUT_ATTR not in _root_attrs(exporter)
+
+
+def test_unrenderable_output_never_raises_into_the_request():
+    logger, exporter = _logger()
+
+    _run_request(logger, CHAT_DATA, "acompletion", object())
+
+    assert OUTPUT_ATTR not in _root_attrs(exporter)
+
+
+@pytest.mark.parametrize(
+    ("capture", "mappers"),
+    [("no_content", ("genai", "langfuse")), ("span_only", ("genai",))],
+)
+def test_factory_keeps_the_base_logger_unless_langfuse_content_capture_is_on(capture, mappers):
+    logger, exporter = _logger(capture=capture, mappers=mappers)
+
+    assert type(logger) is OpenTelemetryV2
+    _run_request(logger, CHAT_DATA, "acompletion", ModelResponse())
+    attrs = _root_attrs(exporter)
+    assert INPUT_ATTR not in attrs and OUTPUT_ATTR not in attrs
+
+
+def test_langfuse_otel_preset_builds_the_langfuse_logger(monkeypatch):
+    monkeypatch.setenv("LITELLM_OTEL_V2", "true")
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk")
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk")
+    monkeypatch.setenv("LANGFUSE_HOST", "https://cloud.langfuse.com")
+    monkeypatch.setenv("OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", "span_only")
+    is_otel_v2_enabled.cache_clear()
+
+    loggers: list = []
+    try:
+        built = _maybe_construct_otel_v2("langfuse_otel", loggers)
+        assert isinstance(built, LangfuseOpenTelemetryV2)
+        assert _maybe_construct_otel_v2("langfuse_otel", loggers) is built
+    finally:
+        is_otel_v2_enabled.cache_clear()

--- a/tests/test_litellm/integrations/otel/test_langfuse_logger.py
+++ b/tests/test_litellm/integrations/otel/test_langfuse_logger.py
@@ -12,9 +12,9 @@ pytest.importorskip("opentelemetry")
 
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter  # noqa: E402
 
+import litellm  # noqa: E402
 from litellm.caching.dual_cache import DualCache  # noqa: E402
-from litellm.integrations.otel.langfuse_logger import LangfuseOpenTelemetryV2  # noqa: E402
-from litellm.integrations.otel.logger import OpenTelemetryV2, build_otel_v2_logger  # noqa: E402
+from litellm.integrations.otel.logger import build_otel_v2_logger  # noqa: E402
 from litellm.integrations.otel.model.config import OpenTelemetryV2Config, is_otel_v2_enabled  # noqa: E402
 from litellm.integrations.otel.model.spans import LITELLM_PROXY_REQUEST_SPAN_NAME, SpanRole  # noqa: E402
 from litellm.integrations.otel.plumbing import context as otel_context  # noqa: E402
@@ -22,6 +22,7 @@ from litellm.integrations.otel.plumbing import providers  # noqa: E402
 from litellm.integrations.otel.plumbing.context import set_request_root_span  # noqa: E402
 from litellm.litellm_core_utils.litellm_logging import _maybe_construct_otel_v2  # noqa: E402
 from litellm.proxy._types import UserAPIKeyAuth  # noqa: E402
+from litellm.proxy.utils import ProxyLogging  # noqa: E402
 from litellm.types.llms.openai import (  # noqa: E402
     ResponseCompletedEvent,
     ResponsesAPIResponse,
@@ -294,13 +295,29 @@ def test_unrenderable_output_never_raises_into_the_request():
 def test_factory_keeps_the_base_logger_unless_langfuse_content_capture_is_on(capture, mappers):
     logger, exporter = _logger(capture=capture, mappers=mappers)
 
-    assert type(logger) is OpenTelemetryV2
     _run_request(logger, CHAT_DATA, "acompletion", ModelResponse())
     attrs = _root_attrs(exporter)
     assert INPUT_ATTR not in attrs and OUTPUT_ATTR not in attrs
 
 
-def test_langfuse_otel_preset_builds_the_langfuse_logger(monkeypatch):
+@pytest.mark.parametrize(
+    ("capture", "mappers", "relays_streams"),
+    [
+        ("span_only", ("genai", "langfuse"), True),
+        ("no_content", ("genai", "langfuse"), False),
+        ("span_only", ("genai",), False),
+    ],
+)
+def test_only_langfuse_content_capture_takes_proxy_streams_off_the_fast_path(
+    monkeypatch, capture, mappers, relays_streams
+):
+    logger, _ = _logger(capture=capture, mappers=mappers)
+    monkeypatch.setattr(litellm, "callbacks", [logger])
+
+    assert ProxyLogging._callback_capabilities().has_iterator_override is relays_streams
+
+
+def test_langfuse_otel_preset_builds_a_logger_that_stamps_the_root(monkeypatch):
     monkeypatch.setenv("LITELLM_OTEL_V2", "true")
     monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk")
     monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk")
@@ -311,7 +328,10 @@ def test_langfuse_otel_preset_builds_the_langfuse_logger(monkeypatch):
     loggers: list = []
     try:
         built = _maybe_construct_otel_v2("langfuse_otel", loggers)
-        assert isinstance(built, LangfuseOpenTelemetryV2)
+        assert built is not None
         assert _maybe_construct_otel_v2("langfuse_otel", loggers) is built
+        root = _start_root(built)
+        asyncio.run(built.async_pre_call_hook(UserAPIKeyAuth(), DualCache(), CHAT_DATA, "acompletion"))
+        assert INPUT_ATTR in dict(root.attributes or {})
     finally:
         is_otel_v2_enabled.cache_clear()

--- a/tests/test_litellm/integrations/otel/test_langfuse_logger.py
+++ b/tests/test_litellm/integrations/otel/test_langfuse_logger.py
@@ -31,6 +31,8 @@ from litellm.types.llms.openai import (  # noqa: E402
 from litellm.types.utils import (  # noqa: E402
     Choices,
     Delta,
+    Embedding,
+    EmbeddingResponse,
     Message,
     ModelResponse,
     ModelResponseStream,
@@ -258,26 +260,41 @@ def test_root_observation_io_survives_the_root_ending_before_the_success_callbac
     assert OUTPUT_ATTR in dict(generation.attributes or {})
 
 
+def test_root_input_is_the_request_as_the_pre_call_chain_left_it():
+    logger, exporter = _logger()
+    raw = {"model": "gpt-5.4-mini", "messages": [{"role": "user", "content": "my ssn is 123-45-6789"}]}
+    masked = {"model": "gpt-5.4-mini", "messages": [{"role": "user", "content": "my ssn is [REDACTED]"}]}
+    response = ModelResponse(choices=[Choices(message=Message(role="assistant", content="noted"))])
+    root = _start_root(logger)
+    asyncio.run(logger.async_pre_call_hook(UserAPIKeyAuth(), DualCache(), raw, "acompletion"))
+    asyncio.run(logger.async_post_call_success_hook(data=masked, user_api_key_dict=UserAPIKeyAuth(), response=response))
+    root.end()
+
+    assert json.loads(_root_attrs(exporter)[INPUT_ATTR]) == masked["messages"]
+
+
 def test_root_already_ended_is_left_alone():
     logger, exporter = _logger()
+    response = ModelResponse(choices=[Choices(message=Message(role="assistant", content="pong"))])
     root = _start_root(logger)
     root.end()
-
-    asyncio.run(logger.async_pre_call_hook(UserAPIKeyAuth(), DualCache(), CHAT_DATA, "acompletion"))
-
-    assert INPUT_ATTR not in _root_attrs(exporter)
-
-
-def test_non_chat_call_types_do_not_stamp_input():
-    logger, exporter = _logger()
-    root = _start_root(logger)
 
     asyncio.run(
-        logger.async_pre_call_hook(UserAPIKeyAuth(), DualCache(), {"model": "e", "input": "ping"}, "aembedding")
+        logger.async_post_call_success_hook(data=CHAT_DATA, user_api_key_dict=UserAPIKeyAuth(), response=response)
     )
-    root.end()
 
-    assert INPUT_ATTR not in _root_attrs(exporter)
+    attrs = _root_attrs(exporter)
+    assert INPUT_ATTR not in attrs and OUTPUT_ATTR not in attrs
+
+
+def test_responses_without_a_message_body_stamp_neither_input_nor_output():
+    logger, exporter = _logger()
+    embedding = EmbeddingResponse(model="e", data=[Embedding(embedding=[0.1], index=0, object="embedding")])
+
+    _run_request(logger, {"model": "e", "input": "ping"}, "aembedding", embedding)
+
+    attrs = _root_attrs(exporter)
+    assert INPUT_ATTR not in attrs and OUTPUT_ATTR not in attrs
 
 
 def test_unrenderable_output_never_raises_into_the_request():
@@ -285,7 +302,8 @@ def test_unrenderable_output_never_raises_into_the_request():
 
     _run_request(logger, CHAT_DATA, "acompletion", object())
 
-    assert OUTPUT_ATTR not in _root_attrs(exporter)
+    attrs = _root_attrs(exporter)
+    assert INPUT_ATTR not in attrs and OUTPUT_ATTR not in attrs
 
 
 @pytest.mark.parametrize(
@@ -331,7 +349,11 @@ def test_langfuse_otel_preset_builds_a_logger_that_stamps_the_root(monkeypatch):
         assert built is not None
         assert _maybe_construct_otel_v2("langfuse_otel", loggers) is built
         root = _start_root(built)
-        asyncio.run(built.async_pre_call_hook(UserAPIKeyAuth(), DualCache(), CHAT_DATA, "acompletion"))
-        assert INPUT_ATTR in dict(root.attributes or {})
+        response = ModelResponse(choices=[Choices(message=Message(role="assistant", content="pong"))])
+        asyncio.run(
+            built.async_post_call_success_hook(data=CHAT_DATA, user_api_key_dict=UserAPIKeyAuth(), response=response)
+        )
+        attrs = dict(root.attributes or {})
+        assert INPUT_ATTR in attrs and OUTPUT_ATTR in attrs
     finally:
         is_otel_v2_enabled.cache_clear()


### PR DESCRIPTION
## TLDR

Problem this solves:

- Langfuse OTel traces from the proxy have an empty root observation
- Only the nested `chat <model>` generation carries the prompt and reply
- Langfuse shows trace input and output from the root, so both stay blank
- #38472 stamped the root after its span had already ended

How it solves it:

- A Langfuse-specific OTel v2 logger stamps the root while it is still recording
- Both come from the post-call hook or the end of the stream, after the pre-call guardrails
- Covers `/v1/chat/completions`, `/v1/responses`, and `/v1/messages`, streaming and not
- Only built when the `langfuse` mapper is on and content capture is enabled

## User Flow

Before: a developer whose app sends requests through the proxy opens the trace in Langfuse and finds it empty at the trace level; only the nested generation shows the prompt and reply

1. The proxy admin sets `callbacks: ["langfuse_otel"]`, the `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY` env vars, and `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=span_only`, then restarts the proxy
2. The developer sends POST https://litellm-domain/v1/chat/completions with `{"model": "gpt-5.4-mini", "messages": [{"role": "user", "content": "Reply with exactly: pong chat"}]}` and gets 200 with `"content": "pong chat"`
3. They open https://cloud.langfuse.com/project/{projectId}/traces and the new `POST /v1/chat/completions` row has empty Input and Output columns
4. They click the trace: the root `POST /v1/chat/completions` observation shows Input `null` and Output `undefined`; the prompt and reply only appear after expanding the nested `chat gpt-5.4-mini` generation
5. POST https://litellm-domain/v1/responses and POST https://litellm-domain/v1/messages, streaming or not, look the same: every root observation is empty

After: the same trace carries the prompt and reply on its root observation, so the trace list and trace view are populated

1. The proxy admin sets `callbacks: ["langfuse_otel"]`, the `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY` env vars, and `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=span_only`, then restarts the proxy
2. The developer sends POST https://litellm-domain/v1/chat/completions with `{"model": "gpt-5.4-mini", "messages": [{"role": "user", "content": "Reply with exactly: pong chat"}]}` and gets 200 with `"content": "pong chat"`
3. They open https://cloud.langfuse.com/project/{projectId}/traces and the new `POST /v1/chat/completions` row shows the user message in its Input column and `pong chat` in its Output column
4. They click the trace: the root `POST /v1/chat/completions` observation shows User `Reply with exactly: pong chat` and Assistant `pong chat` without expanding anything
5. POST https://litellm-domain/v1/responses and POST https://litellm-domain/v1/messages, streaming or not, show their request input and the response's output items (responses) or assistant message with content blocks (messages) on the root observation

## Relevant issues

Supersedes #38472, which stamped the same attributes from the success callback after the root span had already ended. Its attribute keys and Langfuse mapper constants carry over here

## Linear ticket

Resolves LIT-6327

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup: a proxy per side against a real Langfuse Cloud project and real OpenAI calls, `LITELLM_OTEL_V2=true OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=span_only` plus `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY` in the environment, and this config:

```yaml
model_list:
  - model_name: gpt-5.4-mini
    litellm_params:
      model: openai/gpt-5.4-mini
      api_key: os.environ/OPENAI_API_KEY

litellm_settings:
  callbacks: ["langfuse_otel"]

general_settings:
  master_key: sk-lit6327
```

Before runs at the merge base `4049a075bd` on port 49124, After at the tip `5da9b7ef90` on port 31510. Each case sends one request and pastes what the command printed, then reads the trace back through the Langfuse public API: `GET https://cloud.langfuse.com/api/public/traces?limit=100&orderBy=timestamp.desc` to find the trace, then `GET https://cloud.langfuse.com/api/public/observations?traceId=<id>&limit=50`, printing the observation with no `parentObservationId` as `ROOT` with its `input` and `output` (cut at 160 characters) and every other observation as `child` with whether its `input` / `output` is set

### Before (4049a075bd)

#### /v1/chat/completions

1. `curl -sS -D - -o resp.json http://localhost:49124/v1/chat/completions -H 'Authorization: Bearer sk-lit6327' -H 'Content-Type: application/json' -d '{"model":"gpt-5.4-mini","messages":[{"role":"user","content":"Reply with exactly: pong before6 chat"}]}' | grep -i "^HTTP\|x-litellm-call-id"; python3 -c 'import json; print(json.load(open("resp.json"))["choices"][0]["message"]["content"])'`

```
HTTP/1.1 200 OK
x-litellm-call-id: fda7c8c6-41d0-4e12-87d8-f5ae9710d0e2
pong before6 chat
```

2. Root observation of trace `1cd84940b088a14fbce3f457b92bd900` read back from the Langfuse public API

```
trace 1cd84940b088a14fbce3f457b92bd900 name=POST /v1/chat/completions ts=2026-09-02T21:18:49.087Z
  ROOT POST /v1/chat/completions type=GENERATION input=null output=null
```

#### /v1/chat/completions stream

1. `curl -sS http://localhost:49124/v1/chat/completions -N -H 'Authorization: Bearer sk-lit6327' -H 'Content-Type: application/json' -d '{"model":"gpt-5.4-mini","stream":true,"messages":[{"role":"user","content":"Reply with exactly: pong before6 stream"}]}' | grep -o '"content":"[^"]*"' | tr -d '\n'`

```
"content":"""content":"pong""content":" before""content":"6""content":" stream"
```

2. Root observation of trace `f169a6a15e237bcfb9b1b6bf1d934ebf` read back from the Langfuse public API

```
trace f169a6a15e237bcfb9b1b6bf1d934ebf name=POST /v1/chat/completions ts=2026-09-02T21:18:58.761Z
  ROOT POST /v1/chat/completions type=GENERATION input=null output=null
```

#### /v1/responses

1. `curl -sS http://localhost:49124/v1/responses -H 'Authorization: Bearer sk-lit6327' -H 'Content-Type: application/json' -d '{"model":"gpt-5.4-mini","input":"Reply with exactly: pong before6 responses"}' | python3 -c 'import json,sys; r=json.load(sys.stdin); print(r["id"], [c.get("text") for o in r["output"] if o.get("type")=="message" for c in o["content"]])'`

```
resp_ikYAwQmHKMATMfpyN-wWJ-sVqwoyvpaxBqwfXJMyrmlGrzcuACPpjdX1urKkU7HPExSW2b4dVfxa4QPeXRw3ZuRCHrqnCzkqcabxnNPcdSGKdFIFTuqxbWwArCH0N6az-NTEEGwOdLjQ-fLWTHUpsFCfAqrGCKwOUW-9MbmSx9cwdpvU_LbmJu7oqUAryzZLbOI8Z126bkL-5Cv6rktFXWtO0qNq2V0LvaYtq2sTrzYjbK1u-09VLLBOxE6xvULuItMAir6F_nNSSAGKVC32lHMeb1A0qN5gE-HYpFtHf-1ez-AXpTj5DuMpkPEl5k3b3ae1aNKc1zSkA9ZXSvYCCHeyREoBhKiyTbF-_GqRyavUPz-IK6kBoZ9a8vzllFJAxtRQLJ5JYdLEXFQn53sxWQR0ZRQumyj8WqrXvhRB8Dc3fEhVvwiJzSn55Wqi7astUZ-5AaLI7HYR9FNqagm5vQlq ['pong before6 responses']
```

2. Root observation of trace `fed7188f4c65201591b514eaf4166a6d` read back from the Langfuse public API

```
trace fed7188f4c65201591b514eaf4166a6d name=POST /v1/responses ts=2026-09-02T21:18:59.406Z
  ROOT POST /v1/responses type=GENERATION input=null output=null
```

#### /v1/responses stream

1. `curl -sS http://localhost:49124/v1/responses -N -H 'Authorization: Bearer sk-lit6327' -H 'Content-Type: application/json' -d '{"model":"gpt-5.4-mini","stream":true,"input":"Reply with exactly: pong before6 responses-stream"}' | grep -o '"type":"response.completed"\|"delta":"[^"]*"' | tr '\n' ' '`

```
"delta":"pong" "delta":" before" "delta":"6" "delta":" responses" "delta":"-stream" "type":"response.completed" 
```

2. Root observation of trace `e599748f74122805453cb5c6dca1530a` read back from the Langfuse public API

```
trace e599748f74122805453cb5c6dca1530a name=POST /v1/responses ts=2026-09-02T21:19:01.947Z
  ROOT POST /v1/responses type=GENERATION input=null output=null
```

#### /v1/messages

1. `curl -sS http://localhost:49124/v1/messages -H 'Authorization: Bearer sk-lit6327' -H 'Content-Type: application/json' -d '{"model":"gpt-5.4-mini","max_tokens":64,"messages":[{"role":"user","content":"Reply with exactly: pong before6 messages"}]}' | python3 -c 'import json,sys; r=json.load(sys.stdin); print(r["id"], [c.get("text") for c in r["content"]])'`

```
resp_bGl0ZWxsbTpjdXN0b21fbGxtX3Byb3ZpZGVyOm9wZW5haTttb2RlbF9pZDpmYmIxOTZjODk5MDQxYTg5YmEzMThjNjRiZDZmOWQ0Y2ExNWU2ZDFiNjgzMWNlY2MwYzZmZGU4MTg3MGI2ZTRjO3Jlc3BvbnNlX2lkOnJlc3BfMGRlNTMwZWY2MzY1Mzg5NzAwNmE5ODkyYzUyMGUwODdkMGI0Nzk4ZGU2YjdmMjdkMTU= ['pong']
```

2. Root observation of trace `54bf6d81badb09e7729d942e47613623` read back from the Langfuse public API

```
trace 54bf6d81badb09e7729d942e47613623 name=POST /v1/messages ts=2026-09-02T21:19:00.873Z
  ROOT POST /v1/messages type=GENERATION input=null output=null
```

#### /v1/messages stream

1. `curl -sS http://localhost:49124/v1/messages -N -H 'Authorization: Bearer sk-lit6327' -H 'Content-Type: application/json' -d '{"model":"gpt-5.4-mini","max_tokens":64,"stream":true,"messages":[{"role":"user","content":"Reply with exactly: pong before6 messages-stream"}]}' | grep -o '"text":"[^"]*"\|event: message_stop' | tr '\n' ' '`

```
event: message_stop 
```

2. Root observation of trace `dbc44f5cfb756ed32fae96f6ba03a677` read back from the Langfuse public API

```
trace dbc44f5cfb756ed32fae96f6ba03a677 name=POST /v1/messages ts=2026-09-02T21:19:02.947Z
  ROOT POST /v1/messages type=GENERATION input=null output=null
```

### After (5da9b7ef90)

#### /v1/chat/completions

1. `curl -sS -D - -o resp.json http://localhost:31510/v1/chat/completions -H 'Authorization: Bearer sk-lit6327' -H 'Content-Type: application/json' -d '{"model":"gpt-5.4-mini","messages":[{"role":"user","content":"Reply with exactly: pong after5 chat"}]}' | grep -i "^HTTP\|x-litellm-call-id"; python3 -c 'import json; print(json.load(open("resp.json"))["choices"][0]["message"]["content"])'`

```
HTTP/1.1 200 OK
x-litellm-call-id: f18d12a1-190a-452e-849a-026527c53842
pong after5 chat
```

2. Root observation of trace `cc15c4f93ef896a5637731f4ace2697c` read back from the Langfuse public API

```
trace cc15c4f93ef896a5637731f4ace2697c name=POST /v1/chat/completions ts=2026-09-02T19:52:23.146Z
  ROOT POST /v1/chat/completions type=GENERATION input=[{"role": "user", "content": "Reply with exactly: pong after5 chat"}] output=[{"content": "pong after5 chat", "role": "assistant", "provider_specific_fields": {"refusal": null}, "annotations": []}]
```

3. Langfuse UI, trace view: root shows User `Reply with exactly: pong after5 chat`, Assistant `pong after5 chat`

#### /v1/chat/completions stream

1. `curl -sS http://localhost:31510/v1/chat/completions -N -H 'Authorization: Bearer sk-lit6327' -H 'Content-Type: application/json' -d '{"model":"gpt-5.4-mini","stream":true,"messages":[{"role":"user","content":"Reply with exactly: pong after5 stream"}]}' | grep -o '"content":"[^"]*"' | tr -d '\n'`

```
"content":"""content":"pong""content":" after""content":"5""content":" stream"
```

2. Root observation of trace `112ec87631f201f49dcec12ce2f0ef3d` read back from the Langfuse public API

```
trace 112ec87631f201f49dcec12ce2f0ef3d name=POST /v1/chat/completions ts=2026-09-02T19:52:26.063Z
  ROOT POST /v1/chat/completions type=GENERATION input=[{"role": "user", "content": "Reply with exactly: pong after5 stream"}] output=[{"content": "pong after5 stream", "role": "assistant"}]
```

#### /v1/responses

1. `curl -sS http://localhost:31510/v1/responses -H 'Authorization: Bearer sk-lit6327' -H 'Content-Type: application/json' -d '{"model":"gpt-5.4-mini","input":"Reply with exactly: pong after5 responses"}' | python3 -c 'import json,sys; r=json.load(sys.stdin); print(r["id"], [c.get("text") for o in r["output"] if o.get("type")=="message" for c in o["content"]])'`

```
resp_6Dg3Lw4nV84RXZZ4x6fehG4XZbVsKxoNYbdmqR1fnxg4cVnXmlef4_9crJ9jnCnPISMB0Ku65ePS1ZL8zTlZg66TgpSUtRPE7rlkmfx2agmWSkYNbIGrvdBd6e_n1_ILFflipbFq3FxFO8hajkj6oKHCuPF8XXtUQn7hLoLCtVpAjT3O5VcvV0sQoiiONc-hobneaB33tuJh1Ljvyfua0HLjOcunL1DiLiSC5lUmPVm5czO8_CZasQ0fpZbIdMlryerTTR8GQ1iCWfuaFcFsT-OWacDGXfUxlycRQNT2FVA69tPxe2BrThYYFO_88gGG2Uugrg9BxHLoMlNgO8Zd_49Hj7nbEjZrr-EgiNXU_eUczSr8njjrobIDjXNUWiCcI95J2RXq6FXt5r7iwj7OtwNmPXTEoR-oR3634sqpoIpqmYIjfEgrsGBi6Q-MOJcuv1ypyZH3Q6m7Qf7rHoMNHXQV ['pong']
```

2. Root observation of trace `39561926e9f644b523cb9c984cc5cd78` read back from the Langfuse public API

```
trace 39561926e9f644b523cb9c984cc5cd78 name=POST /v1/responses ts=2026-09-02T19:52:26.611Z
  ROOT POST /v1/responses type=GENERATION input=[{"role": "user", "content": "Reply with exactly: pong after5 responses"}] output=[{"id": "msg_0b543517b7dd5a09006a987e7b3dd087d09e74188a745a8227", "content": [{"annotations": [], "text": "pong", "type": "output_text", "logprobs": []}], "role...
```

#### /v1/responses stream

1. `curl -sS http://localhost:31510/v1/responses -N -H 'Authorization: Bearer sk-lit6327' -H 'Content-Type: application/json' -d '{"model":"gpt-5.4-mini","stream":true,"input":"Reply with exactly: pong after5 responses-stream"}' | grep -o '"type":"response.completed"\|"delta":"[^"]*"' | tr '\n' ' '`

```
"delta":"pong" "type":"response.completed" 
```

2. Root observation of trace `afb639bfd0bd53857eda320e4d778b4a` read back from the Langfuse public API

```
trace afb639bfd0bd53857eda320e4d778b4a name=POST /v1/responses ts=2026-09-02T19:52:28.645Z
  ROOT POST /v1/responses type=GENERATION input=[{"role": "user", "content": "Reply with exactly: pong after5 responses-stream"}] output=[{"id": "msg_011cae8fc373b59d006a987e7d4e5c87d093c21932575b4ce9", "content": [{"annotations": [], "text": "pong", "type": "output_text", "logprobs": []}], "role...
```

#### /v1/messages

1. `curl -sS http://localhost:31510/v1/messages -H 'Authorization: Bearer sk-lit6327' -H 'Content-Type: application/json' -d '{"model":"gpt-5.4-mini","max_tokens":64,"messages":[{"role":"user","content":"Reply with exactly: pong after5 messages"}]}' | python3 -c 'import json,sys; r=json.load(sys.stdin); print(r["id"], [c.get("text") for c in r["content"]])'`

```
resp_bGl0ZWxsbTpjdXN0b21fbGxtX3Byb3ZpZGVyOm9wZW5haTttb2RlbF9pZDpmYmIxOTZjODk5MDQxYTg5YmEzMThjNjRiZDZmOWQ0Y2ExNWU2ZDFiNjgzMWNlY2MwYzZmZGU4MTg3MGI2ZTRjO3Jlc3BvbnNlX2lkOnJlc3BfMDliY2Y3ZWRiNDdjMDhjMzAwNmE5ODdlN2JjYjAwODdkMGIwOTdjNTQzNDFkY2ZhNzY= ['pong after5 messages']
```

2. Root observation of trace `7b3bd72f71d157004ce098cd1e977d35` read back from the Langfuse public API

```
trace 7b3bd72f71d157004ce098cd1e977d35 name=POST /v1/messages ts=2026-09-02T19:52:27.620Z
  ROOT POST /v1/messages type=GENERATION input=[{"role": "user", "content": "Reply with exactly: pong after5 messages"}] output=[{"role": "assistant", "content": [{"type": "text", "text": "pong after5 messages"}]}]
```

#### /v1/messages stream

1. `curl -sS http://localhost:31510/v1/messages -N -H 'Authorization: Bearer sk-lit6327' -H 'Content-Type: application/json' -d '{"model":"gpt-5.4-mini","max_tokens":64,"stream":true,"messages":[{"role":"user","content":"Reply with exactly: pong after5 messages-stream"}]}' | grep -o '"text":"[^"]*"\|event: message_stop' | tr '\n' ' '`

```
event: message_stop 
```

2. Root observation of trace `caaaa140c5b2e4329913fedd87e1f329` read back from the Langfuse public API

```
trace caaaa140c5b2e4329913fedd87e1f329 name=POST /v1/messages ts=2026-09-02T19:52:29.599Z
  ROOT POST /v1/messages type=GENERATION input=[{"role": "user", "content": "Reply with exactly: pong after5 messages-stream"}] output=[{"content": "pong after5 messages-stream", "role": "assistant"}]
```

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- Streamed root output is assembled from the chunks the logger relays, so a streaming guardrail listed after `langfuse_otel` (every guardrail from the `guardrails` section is) masks the client's stream but not the root output; the nested generation already has the same limitation

### Low

- Root stamping follows the content-capture setting: `no_content` or unset changes nothing
- Requests that fail get no root input or output, and a guardrail that blocks a non-streamed response leaves the root empty; a buffered end-of-stream guardrail exhausts the relay before it blocks, so a blocked stream still stamps the model's output
- Non-streaming chat output is the full message, so `provider_specific_fields` and `annotations` ride along
- A streamed `/v1/messages` root output lands chat-shaped, not as Anthropic content blocks
- Pre-existing, untouched: `/v1/responses` child generation has no output, every proxy observation is typed `GENERATION`
- `langfuse_otel` streams pass through one extra relay and skip the no-override fast path, and the end-of-stream chunk assembly runs on the request task before the stream closes; other OTel v2 setups keep the fast path
- `LangfuseOpenTelemetryV2` inherits `async_pre_call_hook` without overriding it, and the proxy's pre-call checks are leaf-class only, so that hook never runs for it; nothing observable today, since auth already seeds the identity attributes
- Plain `otel` with `callback_settings.otel.mapper_names: [genai, langfuse]` and content capture on gets the same root stamping; no test covers that path or the `is_recording` guard on its own

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
- [x] 5da9b7ef90 passes /live-pr-risk
