### PR TITLE
fix(security): restrict and validate file uploads at /v1/files and /upload/logo

### DIFF
--- a/litellm/llms/base_llm/files/azure_blob_storage_backend.py
+++ b/litellm/llms/base_llm/files/azure_blob_storage_backend.py
@@ -7,14 +7,34 @@ to reuse all authentication and Azure Storage operations.
 """
 
 import time
+from pathlib import Path
 from typing import Final
 from urllib.parse import quote, urlparse
 
 from litellm._logging import verbose_logger
 from litellm._uuid import uuid
 from litellm.integrations.azure_storage.azure_storage import AzureBlobStorageLogger
+from litellm.proxy.common_utils.path_utils import safe_filename
 
 from .storage_backend import BaseFileStorageBackend
+
+
+def _safe_basename(original_filename: str) -> str:
+    try:
+        return safe_filename(original_filename)
+    except ValueError:
+        return "file"
+
+
+def _safe_extension(original_filename: str) -> str:
+    """The extension off a basename, with no path separators or traversal sequences.
+
+    original_filename.split(".")[-1] does not parse path structure, so a filename
+    like "a.jsonl/../../etc/cron.d/x" would put "../../etc/cron.d/x" straight into
+    the blob path built below. Path.suffix only ever looks at the last path
+    component, so routing through safe_filename() first closes that off.
+    """
+    return Path(_safe_basename(original_filename)).suffix.lstrip(".")
 
 
 class AzureBlobStorageBackend(BaseFileStorageBackend, AzureBlobStorageLogger):
@@ -81,16 +101,15 @@ class AzureBlobStorageBackend(BaseFileStorageBackend, AzureBlobStorageLogger):
     def _generate_file_name(self, original_filename: str, file_naming_strategy: str) -> str:
         """Generate file name based on naming strategy."""
         if file_naming_strategy == "original_filename":
-            # Use original filename, but sanitize it
-            return quote(original_filename, safe="")
+            return quote(_safe_basename(original_filename), safe="")
         elif file_naming_strategy == "timestamp":
             # Use timestamp
-            extension = original_filename.split(".")[-1] if "." in original_filename else ""
+            extension = _safe_extension(original_filename)
             timestamp: Final = int(time.time() * 1000)  # milliseconds
             return f"{timestamp}.{extension}" if extension else str(timestamp)
         else:  # default to "uuid"
             # Use UUID
-            extension = original_filename.split(".")[-1] if "." in original_filename else ""
+            extension = _safe_extension(original_filename)
             file_uuid: Final = str(uuid.uuid4())
             return f"{file_uuid}.{extension}" if extension else file_uuid
 

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2508,6 +2508,14 @@ class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
         None,
         description="max batch input file size in MB for /v1/files uploads with purpose=batch, if a file is larger than this size it will be rejected before being forwarded to the provider",
     )
+    max_file_size_mb: int | None = Field(
+        None,
+        description="max file size in MB for /v1/files uploads, for any purpose, if a file is larger than this size it will be rejected before being forwarded to the provider",
+    )
+    blocked_file_extensions: tuple[str, ...] | None = Field(
+        None,
+        description="file extensions (e.g. ['.exe', '.sh']) rejected on /v1/files uploads, for any purpose, matched case-insensitively against the uploaded filename",
+    )
     max_response_size_mb: int | None = Field(
         None,
         description="max response size in MB, if a response is larger than this size it will be rejected",

--- a/litellm/proxy/openai_files_endpoints/files_endpoints.py
+++ b/litellm/proxy/openai_files_endpoints/files_endpoints.py
@@ -75,6 +75,8 @@ from litellm.proxy.openai_files_endpoints.general_upload_validation import (
     check_blocked_extension,
     check_unsafe_filename,
     check_upload_file_size,
+    coerce_optional_int_setting,
+    coerce_optional_str_list_setting,
     raise_upload_validation_failure,
 )
 from litellm.proxy.utils import ProxyLogging, is_known_model
@@ -90,8 +92,6 @@ from litellm.types.llms.openai import (
 router: Final = APIRouter()
 
 _MAX_BATCH_FILE_SIZE_MB_ADAPTER: Final = TypeAdapter(int | None)
-_MAX_FILE_SIZE_MB_ADAPTER: Final = TypeAdapter(int | None)
-_BLOCKED_FILE_EXTENSIONS_ADAPTER: Final = TypeAdapter(list[str] | None)
 
 
 class UploadedFileInfo(TypedDict):
@@ -410,10 +410,7 @@ async def create_file(
         if unsafe_filename_failure is not None:
             raise_upload_validation_failure(unsafe_filename_failure)
 
-        max_file_size_mb: Final = cast(
-            "int | None",
-            _MAX_FILE_SIZE_MB_ADAPTER.validate_python(general_settings.get("max_file_size_mb")),
-        )
+        max_file_size_mb: Final = coerce_optional_int_setting(general_settings.get("max_file_size_mb"))
 
         # Batch uploads can be gigabytes. Starlette has already spooled the upload
         # to disk, so stream from that handle instead of reading it into memory.
@@ -468,9 +465,7 @@ async def create_file(
         if general_size_failure is not None:
             raise_upload_validation_failure(general_size_failure)
 
-        blocked_extensions: Final = tuple(
-            _BLOCKED_FILE_EXTENSIONS_ADAPTER.validate_python(general_settings.get("blocked_file_extensions")) or ()
-        )
+        blocked_extensions: Final = coerce_optional_str_list_setting(general_settings.get("blocked_file_extensions"))
         blocked_extension_failure: Final = check_blocked_extension(file.filename, blocked_extensions)
         if blocked_extension_failure is not None:
             raise_upload_validation_failure(blocked_extension_failure)

--- a/litellm/proxy/openai_files_endpoints/files_endpoints.py
+++ b/litellm/proxy/openai_files_endpoints/files_endpoints.py
@@ -70,6 +70,13 @@ from litellm.proxy.openai_files_endpoints.common_utils import (
     validate_managed_files_requirement,
     validate_managed_id_requirement,
 )
+from litellm.proxy.openai_files_endpoints.general_upload_validation import (
+    MB,
+    check_blocked_extension,
+    check_unsafe_filename,
+    check_upload_file_size,
+    raise_upload_validation_failure,
+)
 from litellm.proxy.utils import ProxyLogging, is_known_model
 from litellm.repositories.table_repositories import ManagedFileRepository
 from litellm.router import Router
@@ -83,6 +90,8 @@ from litellm.types.llms.openai import (
 router: Final = APIRouter()
 
 _MAX_BATCH_FILE_SIZE_MB_ADAPTER: Final = TypeAdapter(int | None)
+_MAX_FILE_SIZE_MB_ADAPTER: Final = TypeAdapter(int | None)
+_BLOCKED_FILE_EXTENSIONS_ADAPTER: Final = TypeAdapter(list[str] | None)
 
 
 class UploadedFileInfo(TypedDict):
@@ -397,13 +406,26 @@ async def create_file(
     # descriptor and its disk blocks until the collector runs.
     spools: Final[list[BinaryIO]] = []  # mutable-ok: filled as the scan opens handles
     try:
+        unsafe_filename_failure: Final = check_unsafe_filename(file.filename)
+        if unsafe_filename_failure is not None:
+            raise_upload_validation_failure(unsafe_filename_failure)
+
+        max_file_size_mb: Final = cast(
+            "int | None",
+            _MAX_FILE_SIZE_MB_ADAPTER.validate_python(general_settings.get("max_file_size_mb")),
+        )
+
         # Batch uploads can be gigabytes. Starlette has already spooled the upload
         # to disk, so stream from that handle instead of reading it into memory.
-        # Other uploads are small and stay in-memory bytes.
+        # Other uploads stay in-memory bytes, bounded to max_file_size_mb (plus one
+        # byte, to still tell "exactly at the limit" from "over it") when it is set,
+        # so an oversized upload cannot be read to completion before it is rejected.
         file_source: bytes | BinaryIO
         if purpose == "batch":
             await file.seek(0)
             file_source = file.file
+        elif max_file_size_mb is not None and max_file_size_mb > 0:
+            file_source = await file.read(max_file_size_mb * MB + 1)
         else:
             file_source = await file.read()
         custom_llm_provider = (
@@ -441,6 +463,17 @@ async def create_file(
             )
         # Cast purpose to OpenAIFilesPurpose type
         purpose = cast(OpenAIFilesPurpose, purpose)
+
+        general_size_failure: Final = check_upload_file_size(file_source, max_file_size_mb)
+        if general_size_failure is not None:
+            raise_upload_validation_failure(general_size_failure)
+
+        blocked_extensions: Final = tuple(
+            _BLOCKED_FILE_EXTENSIONS_ADAPTER.validate_python(general_settings.get("blocked_file_extensions")) or ()
+        )
+        blocked_extension_failure: Final = check_blocked_extension(file.filename, blocked_extensions)
+        if blocked_extension_failure is not None:
+            raise_upload_validation_failure(blocked_extension_failure)
 
         if purpose == "batch":
             batch_file_failure: Final = await asyncio.to_thread(

--- a/litellm/proxy/openai_files_endpoints/general_upload_validation.py
+++ b/litellm/proxy/openai_files_endpoints/general_upload_validation.py
@@ -1,0 +1,123 @@
+"""
+Upload validation applied to every purpose at POST /v1/files.
+
+batch_file_validation.py checks the JSONL shape of purpose="batch" uploads; this
+module applies the same fast-fail-before-forwarding shape (size cap, blocked
+extensions, path-traversal filenames) regardless of purpose.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import BinaryIO, Final, NoReturn, assert_never
+
+from litellm.proxy._types import ProxyException
+from litellm.proxy.common_utils.path_utils import safe_filename
+
+MB: Final = 1024 * 1024
+
+
+@dataclass(frozen=True, slots=True)
+class UploadedFileTooLarge:
+    size_bytes: int
+    limit_mb: int
+
+
+@dataclass(frozen=True, slots=True)
+class UploadedFileBlockedExtension:
+    extension: str
+
+
+@dataclass(frozen=True, slots=True)
+class UploadedFileUnsafeFilename:
+    filename: str
+
+
+UploadValidationFailure = UploadedFileTooLarge | UploadedFileBlockedExtension | UploadedFileUnsafeFilename
+
+
+def _file_size_bytes(file_source: bytes | BinaryIO) -> int:
+    if isinstance(file_source, bytes):
+        return len(file_source)
+    file_source.seek(0, 2)
+    size: Final = file_source.tell()
+    file_source.seek(0)
+    return size
+
+
+def check_upload_file_size(
+    file_source: bytes | BinaryIO,
+    max_file_size_mb: int | None,
+) -> UploadedFileTooLarge | None:
+    if max_file_size_mb is None or max_file_size_mb <= 0:
+        return None
+    size_bytes: Final = _file_size_bytes(file_source)
+    if size_bytes > max_file_size_mb * MB:
+        return UploadedFileTooLarge(size_bytes=size_bytes, limit_mb=max_file_size_mb)
+    return None
+
+
+def check_blocked_extension(
+    filename: str | None,
+    blocked_extensions: tuple[str, ...],
+) -> UploadedFileBlockedExtension | None:
+    if not blocked_extensions or not filename:
+        return None
+    try:
+        extension: Final = Path(safe_filename(filename)).suffix.lower()
+    except ValueError:
+        return None
+    if extension and extension in blocked_extensions:
+        return UploadedFileBlockedExtension(extension=extension)
+    return None
+
+
+def check_unsafe_filename(filename: str | None) -> UploadedFileUnsafeFilename | None:
+    """Reject a filename before it can influence any storage path or backend call.
+
+    Only flags a genuine traversal component ("..") or a null byte, so an ordinary
+    name like "report.v2.pdf" or ".env" is never rejected.
+    """
+    if not filename:
+        return None
+    if "\x00" in filename:
+        return UploadedFileUnsafeFilename(filename=filename)
+    normalized: Final = filename.replace("\\", "/")
+    if any(part == ".." for part in normalized.split("/")):
+        return UploadedFileUnsafeFilename(filename=filename)
+    return None
+
+
+def raise_upload_validation_failure(failure: UploadValidationFailure) -> NoReturn:
+    match failure:
+        case UploadedFileTooLarge(size_bytes=size_bytes, limit_mb=limit_mb):
+            raise ProxyException(
+                message=(
+                    f"Uploaded file exceeds the configured max_file_size_mb of {limit_mb} MB "
+                    f"(read stopped at {size_bytes / MB:.1f} MB). The file was not forwarded to the provider."
+                ),
+                type="invalid_request_error",
+                param="file",
+                code=413,
+            )
+        case UploadedFileBlockedExtension(extension=extension):
+            raise ProxyException(
+                message=(
+                    f"File extension '{extension}' is blocked by this proxy's blocked_file_extensions "
+                    "setting. The file was not forwarded to the provider."
+                ),
+                type="invalid_request_error",
+                param="file",
+                code=400,
+            )
+        case UploadedFileUnsafeFilename(filename=filename):
+            raise ProxyException(
+                message=(
+                    f"Filename '{filename}' is not allowed: directory traversal sequences are not "
+                    "permitted in uploaded file names. The file was not forwarded to the provider."
+                ),
+                type="invalid_request_error",
+                param="file",
+                code=400,
+            )
+        case _:
+            assert_never(failure)

--- a/litellm/proxy/openai_files_endpoints/general_upload_validation.py
+++ b/litellm/proxy/openai_files_endpoints/general_upload_validation.py
@@ -16,6 +16,28 @@ from litellm.proxy.common_utils.path_utils import safe_filename
 MB: Final = 1024 * 1024
 
 
+def coerce_optional_int_setting(raw: object) -> int | None:
+    """A general_settings value declared as an optional integer, e.g. max_file_size_mb.
+
+    bool is an int subclass, so an explicit isinstance(raw, bool) exclusion is needed
+    or a YAML `true`/`false` would silently pass as 1/0.
+    """
+    if raw is None:
+        return None
+    if isinstance(raw, int) and not isinstance(raw, bool):
+        return raw
+    raise TypeError(f"expected an integer, got {raw!r}")
+
+
+def coerce_optional_str_list_setting(raw: object) -> tuple[str, ...]:
+    """A general_settings value declared as an optional list of strings, e.g. blocked_file_extensions."""
+    if raw is None:
+        return ()
+    if not isinstance(raw, list) or not all(isinstance(item, str) for item in raw):
+        raise TypeError(f"expected a list of strings, got {raw!r}")
+    return tuple(raw)
+
+
 @dataclass(frozen=True, slots=True)
 class UploadedFileTooLarge:
     size_bytes: int

--- a/litellm/proxy/openai_files_endpoints/general_upload_validation.py
+++ b/litellm/proxy/openai_files_endpoints/general_upload_validation.py
@@ -60,9 +60,10 @@ UploadValidationFailure = UploadedFileTooLarge | UploadedFileBlockedExtension | 
 def _file_size_bytes(file_source: bytes | BinaryIO) -> int:
     if isinstance(file_source, bytes):
         return len(file_source)
+    original_position: Final = file_source.tell()
     file_source.seek(0, 2)
     size: Final = file_source.tell()
-    file_source.seek(0)
+    file_source.seek(original_position)
     return size
 
 

--- a/litellm/proxy/openai_files_endpoints/general_upload_validation.py
+++ b/litellm/proxy/openai_files_endpoints/general_upload_validation.py
@@ -88,7 +88,11 @@ def check_blocked_extension(
         extension: Final = Path(safe_filename(filename)).suffix.lower()
     except ValueError:
         return None
-    if extension and extension in blocked_extensions:
+    # The uploaded name's extension is normalized above; blocked_extensions comes
+    # straight from config.yaml or the DB and is normalized here too, so a
+    # differently-cased entry (".EXE") still catches a lowercase upload.
+    normalized_blocked: Final = frozenset(item.lower() for item in blocked_extensions)
+    if extension and extension in normalized_blocked:
         return UploadedFileBlockedExtension(extension=extension)
     return None
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -6647,6 +6647,9 @@ class ProxyConfig:
         if "max_file_size_mb" not in self._yaml_general_settings_keys:
             general_settings["max_file_size_mb"] = _general_settings.get("max_file_size_mb")
 
+        if "blocked_file_extensions" not in self._yaml_general_settings_keys:
+            general_settings["blocked_file_extensions"] = _general_settings.get("blocked_file_extensions")
+
         ## ALERTING ARGS ##
         if "alerting_args" in _general_settings:
             general_settings["alerting_args"] = _general_settings["alerting_args"]

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -6644,6 +6644,9 @@ class ProxyConfig:
         if "max_batch_file_size_mb" not in self._yaml_general_settings_keys:
             general_settings["max_batch_file_size_mb"] = _general_settings.get("max_batch_file_size_mb")
 
+        if "max_file_size_mb" not in self._yaml_general_settings_keys:
+            general_settings["max_file_size_mb"] = _general_settings.get("max_file_size_mb")
+
         ## ALERTING ARGS ##
         if "alerting_args" in _general_settings:
             general_settings["alerting_args"] = _general_settings["alerting_args"]
@@ -16412,6 +16415,8 @@ _GENERAL_SETTINGS_CONFIG_LIST_FIELD_TYPES: Final[Mapping[str, str]] = MappingPro
         "global_max_parallel_requests": "Integer",
         "max_request_size_mb": "Integer",
         "max_batch_file_size_mb": "Integer",
+        "max_file_size_mb": "Integer",
+        "blocked_file_extensions": "List",
         "max_response_size_mb": "Integer",
         "proxy_config_reload_interval_seconds": "Integer",
         "pass_through_endpoints": "PydanticModel",

--- a/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
+++ b/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
@@ -1594,13 +1594,22 @@ async def update_ui_settings(
     tags=["UI Theme Settings"],
     dependencies=[Depends(user_api_key_auth)],
 )
-async def upload_logo(file: UploadFile = File(...)):
+async def upload_logo(
+    file: UploadFile = File(...),
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+):
     """
     Upload a custom logo for the admin UI.
     Accepts image files (PNG, JPG, JPEG, SVG) and stores them for use in the UI.
     """
     import os
     from pathlib import Path
+
+    if user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN:
+        raise HTTPException(
+            status_code=403,
+            detail="Only proxy admins can upload a UI logo.",
+        )
 
     # Validate file type
     allowed_extensions: Final = {".png", ".jpg", ".jpeg", ".svg"}
@@ -1612,9 +1621,11 @@ async def upload_logo(file: UploadFile = File(...)):
             detail=f"Invalid file type. Allowed types: {', '.join(allowed_extensions)}",
         )
 
-    # Validate file size (max 5MB)
-    file_content: Final = await file.read()
-    if len(file_content) > 5 * 1024 * 1024:  # 5MB
+    # Read bounded to one byte past the limit, so an oversized upload is never
+    # fully buffered in memory before being rejected.
+    max_logo_size_bytes: Final = 5 * 1024 * 1024
+    file_content: Final = await file.read(max_logo_size_bytes + 1)
+    if len(file_content) > max_logo_size_bytes:
         raise HTTPException(status_code=400, detail="File size too large. Maximum size is 5MB.")
 
     # Create uploads directory if it doesn't exist

--- a/tests/test_litellm/llms/base_llm/files/test_azure_blob_storage_backend.py
+++ b/tests/test_litellm/llms/base_llm/files/test_azure_blob_storage_backend.py
@@ -185,6 +185,50 @@ async def test_download_file_drops_query_string_from_the_stored_url(mock_env_var
 
 
 @pytest.mark.parametrize(
+    "malicious_filename",
+    [
+        "report.jsonl/../../etc/cron.d/evil",
+        "a.b/../../../root/.ssh/authorized_keys",
+    ],
+)
+@pytest.mark.parametrize("strategy", ["uuid", "timestamp"])
+@pytest.mark.asyncio
+async def test_generate_file_name_strips_path_traversal_from_extension(mock_env_vars, malicious_filename, strategy):
+    """
+    original_filename.split(".")[-1] does not parse path structure, so a filename whose
+    last "." is followed by a directory traversal sequence used to put that sequence
+    straight into the blob path built from this name. The mutant this pins is reverting
+    _safe_extension() back to that bare split.
+    """
+    backend = _make_backend()
+    generated = backend._generate_file_name(malicious_filename, strategy)
+    assert "/" not in generated
+    assert ".." not in generated
+
+
+@pytest.mark.asyncio
+async def test_generate_file_name_uuid_strategy_preserves_ordinary_extension(mock_env_vars):
+    backend = _make_backend()
+    generated = backend._generate_file_name("data.jsonl", "uuid")
+    assert generated.endswith(".jsonl")
+
+
+@pytest.mark.asyncio
+async def test_generate_file_name_original_filename_strategy_strips_directory_components(mock_env_vars):
+    """The blob name must never carry a directory the caller supplied, traversal or not."""
+    backend = _make_backend()
+    generated = backend._generate_file_name("../../etc/passwd", "original_filename")
+    assert generated == "passwd"
+
+
+@pytest.mark.asyncio
+async def test_generate_file_name_null_byte_filename_falls_back_to_safe_default(mock_env_vars):
+    backend = _make_backend()
+    generated = backend._generate_file_name("report.pdf\x00.exe", "uuid")
+    assert "\x00" not in generated
+
+
+@pytest.mark.parametrize(
     "env_fixture, expected_suffix",
     [("mock_env_vars", "core.windows.net"), ("mock_gov_env_vars", GOV_SUFFIX)],
 )

--- a/tests/test_litellm/proxy/openai_files_endpoint/test_files_endpoint.py
+++ b/tests/test_litellm/proxy/openai_files_endpoint/test_files_endpoint.py
@@ -4555,3 +4555,114 @@ def test_create_file_async_pre_call_hook_rejection_blocks_upload(monkeypatch, ll
     assert response.status_code == 400, response.text
     assert "file upload not allowed" in response.text
     assert provider_route.call_count == 0
+
+
+def test_create_file_non_batch_over_max_file_size_mb_rejected_before_forwarding(monkeypatch, llm_router: Router):
+    """max_file_size_mb applies to every purpose, unlike the batch-only max_batch_file_size_mb."""
+    import litellm.proxy.proxy_server as ps
+
+    forwarded_calls = _setup_batch_upload_endpoint(monkeypatch, llm_router)
+    monkeypatch.setitem(ps.general_settings, "max_file_size_mb", 1)
+
+    oversized = b"x" * (2 * 1024 * 1024)
+    try:
+        response = client.post(
+            "/v1/files",
+            files={"file": ("labels.jsonl", oversized, "application/octet-stream")},
+            data={"purpose": "user_data"},
+            headers={"Authorization": "Bearer test-key"},
+        )
+    finally:
+        _teardown_batch_upload_endpoint()
+
+    assert response.status_code == 413, response.text
+    error = response.json()["error"]
+    assert error["type"] == "invalid_request_error"
+    assert error["param"] == "file"
+    assert "max_file_size_mb" in error["message"]
+    assert "1 MB" in error["message"]
+    assert forwarded_calls == []
+
+
+def test_create_file_non_batch_under_max_file_size_mb_forwards(monkeypatch, llm_router: Router):
+    import litellm.proxy.proxy_server as ps
+
+    forwarded_calls = _setup_batch_upload_endpoint(monkeypatch, llm_router)
+    monkeypatch.setitem(ps.general_settings, "max_file_size_mb", 1)
+
+    try:
+        response = client.post(
+            "/v1/files",
+            files={"file": ("labels.jsonl", b"small content", "application/octet-stream")},
+            data={"purpose": "user_data"},
+            headers={"Authorization": "Bearer test-key"},
+        )
+    finally:
+        _teardown_batch_upload_endpoint()
+
+    assert response.status_code == 200, response.text
+    assert len(forwarded_calls) == 1
+
+
+def test_create_file_blocked_extension_rejected_before_forwarding(monkeypatch, llm_router: Router):
+    import litellm.proxy.proxy_server as ps
+
+    forwarded_calls = _setup_batch_upload_endpoint(monkeypatch, llm_router)
+    monkeypatch.setitem(ps.general_settings, "blocked_file_extensions", [".exe", ".sh"])
+
+    try:
+        response = client.post(
+            "/v1/files",
+            files={"file": ("payload.exe", b"MZ\x90\x00", "application/octet-stream")},
+            data={"purpose": "user_data"},
+            headers={"Authorization": "Bearer test-key"},
+        )
+    finally:
+        _teardown_batch_upload_endpoint()
+
+    assert response.status_code == 400, response.text
+    error = response.json()["error"]
+    assert error["type"] == "invalid_request_error"
+    assert error["param"] == "file"
+    assert ".exe" in error["message"]
+    assert "blocked_file_extensions" in error["message"]
+    assert forwarded_calls == []
+
+
+def test_create_file_blocked_extension_unset_allows_everything(monkeypatch, llm_router: Router):
+    forwarded_calls = _setup_batch_upload_endpoint(monkeypatch, llm_router)
+
+    try:
+        response = client.post(
+            "/v1/files",
+            files={"file": ("payload.exe", b"MZ\x90\x00", "application/octet-stream")},
+            data={"purpose": "user_data"},
+            headers={"Authorization": "Bearer test-key"},
+        )
+    finally:
+        _teardown_batch_upload_endpoint()
+
+    assert response.status_code == 200, response.text
+    assert len(forwarded_calls) == 1
+
+
+def test_create_file_path_traversal_filename_rejected_before_forwarding(monkeypatch, llm_router: Router):
+    """A filename carrying a directory-traversal component must never reach storage or the provider."""
+    forwarded_calls = _setup_batch_upload_endpoint(monkeypatch, llm_router)
+
+    try:
+        response = client.post(
+            "/v1/files",
+            files={"file": ("../../etc/passwd", b"malicious content", "text/plain")},
+            data={"purpose": "user_data"},
+            headers={"Authorization": "Bearer test-key"},
+        )
+    finally:
+        _teardown_batch_upload_endpoint()
+
+    assert response.status_code == 400, response.text
+    error = response.json()["error"]
+    assert error["type"] == "invalid_request_error"
+    assert error["param"] == "file"
+    assert "traversal" in error["message"].lower()
+    assert forwarded_calls == []

--- a/tests/test_litellm/proxy/openai_files_endpoint/test_general_upload_validation.py
+++ b/tests/test_litellm/proxy/openai_files_endpoint/test_general_upload_validation.py
@@ -24,12 +24,20 @@ def test_size_over_cap_rejected_for_bytes():
     assert check_upload_file_size(content, 1) == UploadedFileTooLarge(size_bytes=len(content), limit_mb=1)
 
 
-def test_size_over_cap_rejected_for_binaryio_and_resets_position():
+def test_size_over_cap_rejected_for_binaryio_and_restores_caller_position():
+    """The handle is caller-owned; inspecting its size must not discard where the caller had it."""
     content = b"x" * (2 * MB)
     handle = io.BytesIO(content)
     handle.seek(17)
     assert check_upload_file_size(handle, 1) == UploadedFileTooLarge(size_bytes=len(content), limit_mb=1)
-    assert handle.tell() == 0
+    assert handle.tell() == 17
+
+
+def test_size_under_cap_allowed_for_binaryio_restores_caller_position():
+    handle = io.BytesIO(b"x" * 100)
+    handle.seek(42)
+    assert check_upload_file_size(handle, 1) is None
+    assert handle.tell() == 42
 
 
 def test_size_exactly_at_cap_allowed():

--- a/tests/test_litellm/proxy/openai_files_endpoint/test_general_upload_validation.py
+++ b/tests/test_litellm/proxy/openai_files_endpoint/test_general_upload_validation.py
@@ -54,6 +54,11 @@ def test_blocked_extension_match_is_case_insensitive():
     assert check_blocked_extension("payload.EXE", (".exe",)) == UploadedFileBlockedExtension(extension=".exe")
 
 
+def test_blocked_extension_match_is_case_insensitive_for_configured_value():
+    """A config entry like blocked_file_extensions: ['.EXE'] must still catch a lowercase upload."""
+    assert check_blocked_extension("payload.exe", (".EXE",)) == UploadedFileBlockedExtension(extension=".exe")
+
+
 def test_extension_not_in_blocklist_allowed():
     assert check_blocked_extension("report.pdf", (".exe", ".sh")) is None
 

--- a/tests/test_litellm/proxy/openai_files_endpoint/test_general_upload_validation.py
+++ b/tests/test_litellm/proxy/openai_files_endpoint/test_general_upload_validation.py
@@ -1,0 +1,121 @@
+import io
+
+import pytest
+
+from litellm.proxy._types import ProxyException
+from litellm.proxy.openai_files_endpoints.general_upload_validation import (
+    MB,
+    UploadedFileBlockedExtension,
+    UploadedFileTooLarge,
+    UploadedFileUnsafeFilename,
+    check_blocked_extension,
+    check_unsafe_filename,
+    check_upload_file_size,
+    raise_upload_validation_failure,
+)
+
+
+def test_size_under_cap_allowed():
+    assert check_upload_file_size(b"x" * 100, 1) is None
+
+
+def test_size_over_cap_rejected_for_bytes():
+    content = b"x" * (2 * MB)
+    assert check_upload_file_size(content, 1) == UploadedFileTooLarge(size_bytes=len(content), limit_mb=1)
+
+
+def test_size_over_cap_rejected_for_binaryio_and_resets_position():
+    content = b"x" * (2 * MB)
+    handle = io.BytesIO(content)
+    handle.seek(17)
+    assert check_upload_file_size(handle, 1) == UploadedFileTooLarge(size_bytes=len(content), limit_mb=1)
+    assert handle.tell() == 0
+
+
+def test_size_exactly_at_cap_allowed():
+    content = b"x" * MB
+    assert check_upload_file_size(content, 1) is None
+
+
+def test_no_cap_skips_size_check():
+    assert check_upload_file_size(b"x" * (10 * MB), None) is None
+
+
+@pytest.mark.parametrize("cap", [0, -3])
+def test_nonpositive_cap_disables_size_check(cap):
+    assert check_upload_file_size(b"x" * (10 * MB), cap) is None
+
+
+def test_blocked_extension_rejected():
+    assert check_blocked_extension("payload.exe", (".exe", ".sh")) == UploadedFileBlockedExtension(extension=".exe")
+
+
+def test_blocked_extension_match_is_case_insensitive():
+    assert check_blocked_extension("payload.EXE", (".exe",)) == UploadedFileBlockedExtension(extension=".exe")
+
+
+def test_extension_not_in_blocklist_allowed():
+    assert check_blocked_extension("report.pdf", (".exe", ".sh")) is None
+
+
+def test_empty_blocklist_allows_everything():
+    assert check_blocked_extension("payload.exe", ()) is None
+
+
+def test_no_filename_skips_extension_check():
+    assert check_blocked_extension(None, (".exe",)) is None
+
+
+def test_path_traversal_filename_rejected():
+    assert check_unsafe_filename("../../etc/passwd") == UploadedFileUnsafeFilename(filename="../../etc/passwd")
+
+
+def test_windows_style_path_traversal_filename_rejected():
+    assert check_unsafe_filename("..\\..\\windows\\system32\\config") == UploadedFileUnsafeFilename(
+        filename="..\\..\\windows\\system32\\config"
+    )
+
+
+def test_traversal_embedded_after_extension_rejected():
+    assert check_unsafe_filename("report.jsonl/../../etc/cron.d/evil") == UploadedFileUnsafeFilename(
+        filename="report.jsonl/../../etc/cron.d/evil"
+    )
+
+
+def test_null_byte_filename_rejected():
+    assert check_unsafe_filename("report.pdf\x00.exe") == UploadedFileUnsafeFilename(filename="report.pdf\x00.exe")
+
+
+@pytest.mark.parametrize("filename", ["report.pdf", ".env", "a.b.c.jsonl", "my file (1).csv", None])
+def test_ordinary_filenames_allowed(filename):
+    assert check_unsafe_filename(filename) is None
+
+
+@pytest.mark.parametrize(
+    "failure, expected_code, expected_fragments",
+    [
+        (
+            UploadedFileTooLarge(size_bytes=15728640, limit_mb=10),
+            "413",
+            ("15.0 MB", "max_file_size_mb", "10 MB", "not forwarded"),
+        ),
+        (
+            UploadedFileBlockedExtension(extension=".exe"),
+            "400",
+            (".exe", "blocked_file_extensions", "not forwarded"),
+        ),
+        (
+            UploadedFileUnsafeFilename(filename="../../etc/passwd"),
+            "400",
+            ("../../etc/passwd", "traversal", "not forwarded"),
+        ),
+    ],
+)
+def test_failures_map_to_openai_shaped_proxy_exceptions(failure, expected_code, expected_fragments):
+    with pytest.raises(ProxyException) as exc_info:
+        raise_upload_validation_failure(failure)
+    assert exc_info.value.code == expected_code
+    assert exc_info.value.type == "invalid_request_error"
+    assert exc_info.value.param == "file"
+    for fragment in expected_fragments:
+        assert fragment in exc_info.value.message

--- a/tests/test_litellm/proxy/ui_crud_endpoints/test_proxy_setting_endpoints.py
+++ b/tests/test_litellm/proxy/ui_crud_endpoints/test_proxy_setting_endpoints.py
@@ -3006,6 +3006,56 @@ def test_update_mcp_semantic_filter_settings_requires_proxy_admin(monkeypatch):
         app.dependency_overrides.pop(user_api_key_auth, None)
 
 
+def test_upload_logo_requires_proxy_admin(monkeypatch):
+    """Any authenticated key could previously write a file to the server's disk here."""
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+
+    async def _internal_user_auth():
+        return UserAPIKeyAuth(
+            user_id="internal-user-1",
+            api_key="hashed-internal-key",
+            user_role=LitellmUserRoles.INTERNAL_USER,
+        )
+
+    app.dependency_overrides[user_api_key_auth] = _internal_user_auth
+    try:
+        resp = client.post(
+            "/upload/logo",
+            files={"file": ("logo.png", b"\x89PNG\r\n\x1a\n" + b"x" * 32, "image/png")},
+        )
+        assert resp.status_code == 403
+        assert "proxy admin" in resp.json()["detail"].lower()
+    finally:
+        app.dependency_overrides.pop(user_api_key_auth, None)
+
+
+def test_upload_logo_allows_proxy_admin(monkeypatch, tmp_path):
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+
+    async def _admin_auth():
+        return UserAPIKeyAuth(
+            user_id="admin-1",
+            api_key="hashed-admin-key",
+            user_role=LitellmUserRoles.PROXY_ADMIN,
+        )
+
+    app.dependency_overrides[user_api_key_auth] = _admin_auth
+    try:
+        resp = client.post(
+            "/upload/logo",
+            files={"file": ("logo.png", b"\x89PNG\r\n\x1a\n" + b"x" * 32, "image/png")},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["status"] == "success"
+    finally:
+        app.dependency_overrides.pop(user_api_key_auth, None)
+        uploaded_path = resp.json().get("file_path")
+        if uploaded_path and os.path.exists(uploaded_path):
+            os.remove(uploaded_path)
+
+
 class TestPtuCostAttributionUISetting:
     """``enable_ptu_cost_attribution`` is derived from the environment on every GET.
 

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -25435,6 +25435,11 @@ export interface components {
              */
             background_health_checks?: boolean | null;
             /**
+             * Blocked File Extensions
+             * @description file extensions (e.g. ['.exe', '.sh']) rejected on /v1/files uploads, for any purpose, matched case-insensitively against the uploaded filename
+             */
+            blocked_file_extensions?: string[] | null;
+            /**
              * Cancel On Disconnect
              * @description cancel the in-flight upstream LLM request (non-streaming) when the client disconnects, freeing backend capacity (e.g. a vLLM GPU slot); the request is logged as a 499 failure
              */
@@ -25573,6 +25578,11 @@ export interface components {
              * @description max batch input file size in MB for /v1/files uploads with purpose=batch, if a file is larger than this size it will be rejected before being forwarded to the provider
              */
             max_batch_file_size_mb?: number | null;
+            /**
+             * Max File Size Mb
+             * @description max file size in MB for /v1/files uploads, for any purpose, if a file is larger than this size it will be rejected before being forwarded to the provider
+             */
+            max_file_size_mb?: number | null;
             /**
              * Max Parallel Requests
              * @description maximum parallel requests for each api key


### PR DESCRIPTION
## TLDR

Problem this solves:

- POST /v1/files had no size or type checks for any purpose except `batch`
- A crafted filename could embed a directory traversal sequence into a stored blob path
- POST /upload/logo (admin UI logo upload) had no admin-role check at all

How it solves it:

- Adds a configurable `max_file_size_mb` size cap and `blocked_file_extensions` denylist, applied to every purpose at /v1/files
- Rejects any uploaded filename carrying a `..` path component before it is read, stored, or forwarded
- Fixes the Azure Blob Storage backend's blob-path extension derivation to route through the existing `safe_filename()` helper
- Adds the missing `PROXY_ADMIN` role check to /upload/logo

## User Flow

Before: a self-hosted proxy operator has no way to cap upload size or block file types on any file purpose other than `batch`, and any authenticated API key, not just an admin key, can write a file to the proxy server's disk

1. A caller sends POST https://litellm-domain/v1/files with `purpose=user_data` and a 2 MB file; it is fully forwarded to the provider with no size check
2. A caller sends the same request with a `.exe` file; it is fully forwarded to the provider with no type check
3. A caller sends the same request with `filename=../../etc/passwd`; the traversal-carrying name is forwarded to the provider verbatim
4. A non-admin API key sends POST https://litellm-domain/upload/logo with an image file; the proxy writes it to its own `litellm/proxy/uploads/` directory and returns 200

After: the operator can cap size and block extensions for every purpose, unsafe filenames are rejected up front, and only a proxy admin can upload a logo

1. The operator sets `general_settings.max_file_size_mb` and `general_settings.blocked_file_extensions` in config.yaml
2. The same 2 MB `user_data` upload now returns 413 naming `max_file_size_mb`, before anything reaches the provider
3. The same `.exe` upload now returns 400 naming `blocked_file_extensions`, before anything reaches the provider
4. The same `../../etc/passwd` filename now returns 400 before anything is read or forwarded
5. The non-admin API key's POST https://litellm-domain/upload/logo now returns 403; only a `PROXY_ADMIN` key can upload a logo

## Relevant issues

## Linear ticket

Resolves LIT-6746

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy on localhost:4746, `general_settings: {max_file_size_mb: 1, blocked_file_extensions: [.exe, .sh]}`, a real `openai/gpt-4.1-mini` deployment with a real `OPENAI_API_KEY`. Every "forwarded" claim below was independently confirmed with a direct `GET`/`DELETE` against `api.openai.com` using the same key, then cleaned up.

### Before (a677242d6f)

#### Oversized upload (2 MB, no cap for non-batch purposes)

1. `curl -X POST http://localhost:4746/v1/files -H "Authorization: Bearer sk-litfiles-1234" -F purpose="user_data" -F "file=@big.bin"` (2 MB file)
2. `{"id":"file-5TkuERJkUBWUiNHBbqhxbe","bytes":2000000,...,"status":"processed"}` — HTTP 200, fully forwarded and stored on OpenAI

#### Blocked-type upload (.exe, no type check for non-batch purposes)

1. `curl -X POST http://localhost:4746/v1/files -H "Authorization: Bearer sk-litfiles-1234" -F purpose="user_data" -F "file=@payload.exe"`
2. `{"id":"file-LgcWM2gkyz8ghNNTTXLRCK",...,"filename":"litfiles_payload.exe",...,"status":"processed"}` — HTTP 200, forwarded and stored on OpenAI

#### Path-traversal filename

1. `curl -X POST http://localhost:4746/v1/files -H "Authorization: Bearer sk-litfiles-1234" -F purpose="assistants" -F "file=@small.txt;filename=../../etc/passwd"`
2. `{"id":"file-Qj2yHDQ2TgpaNbbTuMxQp4",...,"filename":"../../etc/passwd",...,"status":"processed"}` — HTTP 200, the traversal-carrying name is forwarded to OpenAI verbatim

### After (860e3745da)

Captured at f72fed0ba2. The commits on top of it touch settings-coercion internals, persistence wiring, a generated schema file, and two real fixes (blocked_file_extensions is now lowercased at comparison time so a config entry like `.EXE` still catches a lowercase upload, and the size check now restores the caller's stream position instead of always resetting it to 0) — the captured legs below never depended on either behavior (lowercase config against a lowercase upload; a stream this endpoint always reads from position 0), so the response bodies are unaffected and the capture was not re-run.

#### Oversized upload (2 MB, cap is 1 MB)

1. `curl -X POST http://localhost:4746/v1/files -H "Authorization: Bearer sk-litfiles-1234" -F purpose="user_data" -F "file=@big.bin"`
2. `{"error":{"message":"Uploaded file exceeds the configured max_file_size_mb of 1 MB (read stopped at 1.0 MB). The file was not forwarded to the provider.","type":"invalid_request_error","param":"file","code":"413"}}` — HTTP 413

#### Blocked-type upload (.exe)

1. `curl -X POST http://localhost:4746/v1/files -H "Authorization: Bearer sk-litfiles-1234" -F purpose="user_data" -F "file=@payload.exe"`
2. `{"error":{"message":"File extension '.exe' is blocked by this proxy's blocked_file_extensions setting. The file was not forwarded to the provider.","type":"invalid_request_error","param":"file","code":"400"}}` — HTTP 400

#### Path-traversal filename

1. `curl -X POST http://localhost:4746/v1/files -H "Authorization: Bearer sk-litfiles-1234" -F purpose="user_data" -F "file=@small.txt;filename=../../etc/passwd"`
2. `{"error":{"message":"Filename '../../etc/passwd' is not allowed: directory traversal sequences are not permitted in uploaded file names. The file was not forwarded to the provider.","type":"invalid_request_error","param":"file","code":"400"}}` — HTTP 400

#### Legitimate upload still succeeds (real provider call)

1. `curl -X POST http://localhost:4746/v1/files -H "Authorization: Bearer sk-litfiles-1234" -F purpose="assistants" -F "file=@notes.txt"` (53 bytes, plain text)
2. `{"id":"file-MGLQK2EBF8y78MwVGPVBLp","bytes":53,"created_at":1788377893,"filename":"notes.txt","object":"file","purpose":"assistants","status":"processed",...}` — HTTP 200; confirmed with a direct `GET https://api.openai.com/v1/files/file-MGLQK2EBF8y78MwVGPVBLp` returning the same object, then deleted

#### /upload/logo admin-only enforcement (pytest, mutation-tested)

`tests/test_litellm/proxy/ui_crud_endpoints/test_proxy_setting_endpoints.py::test_upload_logo_requires_proxy_admin` and `::test_upload_logo_allows_proxy_admin`. Reverting the fix and re-running the first test fails it (`assert 200 == 403`), confirming the test pins the gap: before the fix, an `INTERNAL_USER`-role key got a 200 and could write to the server's disk; after the fix, it gets a 403 and only a `PROXY_ADMIN` key succeeds. Not captured as a live curl leg because this deployment has no database configured, so there is no way to mint a second, lower-privileged API key to drive it end to end; the unit test drives the same FastAPI app instance directly.

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- `blocked_file_extensions` is a denylist, not an allowlist, and is extension-based rather than content-sniffed. `litellm/proxy/rag_endpoints/upload_security.py` already has a hand-rolled magic-byte inspector (`inspect_content()`, no external dependency) for RAG uploads, narrowly scoped to an allowlist of two formats (PDF, UTF-8 text); /v1/files serves far more purposes with far more legitimate formats (jsonl, images, arbitrary documents for `user_data`), so reusing that pattern here needs a purpose-to-allowed-formats matrix, which is a real design decision rather than a drop-in change. Flagging as a follow-up rather than guessing that matrix in this PR
- `max_file_size_mb` and the existing `max_batch_file_size_mb` are independent settings; a `batch` upload is checked against both if both are set

### Low

- The customer's own repro (affected endpoint, exact payload, scanner evidence) is still pending their September 7 working session per the ticket; this PR covers everything findable by inventorying every upload surface in the proxy (`/v1/files`, batch uploads, provider passthrough, RAG/document-ingestion uploads, and admin UI upload endpoints) without it
- RAG document uploads (`litellm/proxy/rag_endpoints/`) already enforce a size cap, content-sniffed type allowlist, a malware-scan hook, and a server-generated filename (the client filename never reaches storage) via `upload_security.py`; image/OCR/video/skills upload endpoints forward directly to the configured provider with no local persistence, so provider-side validation already applies and there was nothing proxy-side left to add there
- LIT-5274 (batch input-file size cap and provider-specific checks) and LIT-3543 (`require_managed_files` enforcement) were already shipped and are unaffected by this change

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
