### PR TITLE
fix(ui): preserve full AgentCore runtime ARN in agent edit form

### DIFF
--- a/litellm/proxy/public_endpoints/agent_create_fields.json
+++ b/litellm/proxy/public_endpoints/agent_create_fields.json
@@ -107,7 +107,9 @@
         "required": true,
         "field_type": "text",
         "default_value": null,
-        "include_in_litellm_params": false
+        "include_in_litellm_params": false,
+        "validation_pattern": "^arn:aws[a-zA-Z0-9-]*:bedrock-agentcore:[a-z0-9-]+:[0-9]{12}:runtime/.+$",
+        "validation_message": "Enter the complete Bedrock AgentCore runtime ARN, including the runtime ID after \"runtime/\" (e.g. arn:aws:bedrock-agentcore:us-west-2:123456789012:runtime/my-agent-runtime)."
       }
     ],
     "litellm_params_template": {

--- a/litellm/types/proxy/public_endpoints/public_endpoints.py
+++ b/litellm/types/proxy/public_endpoints/public_endpoints.py
@@ -43,6 +43,8 @@ class AgentCredentialField(BaseModel):
     options: list[str] | None = None
     default_value: str | None = None
     include_in_litellm_params: bool | None = None
+    validation_pattern: str | None = None
+    validation_message: str | None = None
 
 
 class AgentCreateInfo(BaseModel):

--- a/tests/test_litellm/proxy/public_endpoints/test_public_endpoints.py
+++ b/tests/test_litellm/proxy/public_endpoints/test_public_endpoints.py
@@ -1,3 +1,4 @@
+import re
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -754,6 +755,45 @@ def test_public_agent_hub_returns_empty_when_no_public_groups():
 
     assert response.status_code == 200
     assert response.json() == []
+
+
+# ---------------------------------------------------------------------------
+# /public/agents/fields
+# ---------------------------------------------------------------------------
+
+
+def test_bedrock_agentcore_runtime_arn_validation_pattern_accepts_full_resource_path():
+    """Regression for LIT-6737: the AgentCore agent_runtime_arn field's
+    validation_pattern must accept a complete runtime ARN whose resource part
+    is itself multi-segment (``runtime/<runtime-id>``), and reject the exact
+    truncated shape a naive split("/")-by-position parse used to produce (the
+    ARN cut off right after the ``runtime`` resource type).
+    """
+    app_instance = FastAPI()
+    app_instance.include_router(router)
+    test_client = TestClient(app_instance)
+
+    response = test_client.get("/public/agents/fields")
+    assert response.status_code == 200
+    agents = response.json()
+
+    bedrock_agentcore = next((a for a in agents if a["agent_type"] == "bedrock_agentcore"), None)
+    assert bedrock_agentcore is not None, "bedrock_agentcore agent type not found"
+    assert bedrock_agentcore["model_template"] == "bedrock/agentcore/{agent_runtime_arn}"
+
+    fields_by_key = {f["key"]: f for f in bedrock_agentcore["credential_fields"]}
+    arn_field = fields_by_key["agent_runtime_arn"]
+    assert arn_field["required"] is True
+    assert arn_field["include_in_litellm_params"] is False
+
+    pattern = arn_field.get("validation_pattern")
+    assert pattern, "agent_runtime_arn must ship a validation_pattern so the UI can reject a truncated ARN"
+
+    full_arn = "arn:aws:bedrock-agentcore:eu-central-1:123456789012:runtime/hosted_agent_4vm3i-BaTdfOELAs"
+    truncated_arn = "arn:aws:bedrock-agentcore:eu-central-1:123456789012:runtime"
+
+    assert re.match(pattern, full_arn), "the validator must accept a complete runtime ARN"
+    assert not re.match(pattern, truncated_arn), "the validator must reject the truncated ARN"
 
 
 # ---------------------------------------------------------------------------

--- a/ui/litellm-dashboard/src/app/(dashboard)/agents/_components/agent_info.integration.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/agents/_components/agent_info.integration.test.tsx
@@ -75,6 +75,40 @@ const langgraphInfo: AgentCreateInfo = {
   ],
 };
 
+const FULL_RUNTIME_ARN = "arn:aws:bedrock-agentcore:eu-central-1:123456789012:runtime/hosted_agent_4vm3i-BaTdfOELAs";
+
+const BEDROCK_AGENTCORE_AGENT = {
+  agent_id: "agent-3",
+  agent_name: "bedrock-agent",
+  agent_card_params: { name: "bedrock-agent", description: "agentcore agent", url: "", version: "1.0.0", skills: [] },
+  litellm_params: {
+    custom_llm_provider: "bedrock",
+    model: `bedrock/agentcore/${FULL_RUNTIME_ARN}`,
+  },
+};
+
+const bedrockAgentcoreInfo: AgentCreateInfo = {
+  agent_type: "bedrock_agentcore",
+  agent_type_display_name: "Bedrock AgentCore",
+  description: "Bedrock AgentCore runtimes",
+  logo_url: "/b.png",
+  use_a2a_form_fields: false,
+  litellm_params_template: { custom_llm_provider: "bedrock" },
+  model_template: "bedrock/agentcore/{agent_runtime_arn}",
+  credential_fields: [
+    {
+      key: "agent_runtime_arn",
+      label: "Agent Runtime ARN",
+      field_type: "text",
+      required: true,
+      include_in_litellm_params: false,
+      validation_pattern: "^arn:aws[a-zA-Z0-9-]*:bedrock-agentcore:[a-z0-9-]+:[0-9]{12}:runtime/.+$",
+      validation_message:
+        'Enter the complete Bedrock AgentCore runtime ARN, including the runtime ID after "runtime/".',
+    },
+  ],
+};
+
 const setup = () => userEvent.setup({ pointerEventsCheck: PointerEventsCheckLevel.Never });
 
 const renderView = () => render(<AgentInfoView agentId="agent-1" onClose={vi.fn()} accessToken="tok" isAdmin={true} />);
@@ -245,6 +279,69 @@ describe("AgentInfoView update payload", () => {
         model: "langgraph/asst_1",
       },
     });
+  });
+
+  it("preserves the full AgentCore runtime ARN (including the resource id after runtime/) across an unedited save", async () => {
+    vi.mocked(networking.getAgentCreateMetadata).mockResolvedValue([bedrockAgentcoreInfo]);
+    vi.mocked(networking.getAgentInfo).mockResolvedValue(BEDROCK_AGENTCORE_AGENT as never);
+    const user = setup();
+    renderView();
+    await openEditor(user);
+
+    expect(await screen.findByLabelText("Agent Runtime ARN")).toHaveValue(FULL_RUNTIME_ARN);
+
+    await save(user);
+
+    expect((patchedPayload().litellm_params as Record<string, unknown>).model).toBe(
+      `bedrock/agentcore/${FULL_RUNTIME_ARN}`,
+    );
+  });
+
+  it("blocks the save and shows a validation error when the Agent Runtime ARN is truncated", async () => {
+    vi.mocked(networking.getAgentCreateMetadata).mockResolvedValue([bedrockAgentcoreInfo]);
+    vi.mocked(networking.getAgentInfo).mockResolvedValue(BEDROCK_AGENTCORE_AGENT as never);
+    const user = setup();
+    renderView();
+    await openEditor(user);
+
+    const arnField = await screen.findByLabelText("Agent Runtime ARN");
+    await user.clear(arnField);
+    fireEvent.change(arnField, {
+      target: { value: "arn:aws:bedrock-agentcore:eu-central-1:123456789012:runtime" },
+    });
+    await user.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    expect(
+      await screen.findByText(
+        'Enter the complete Bedrock AgentCore runtime ARN, including the runtime ID after "runtime/".',
+      ),
+    ).toBeInTheDocument();
+    expect(networking.patchAgentCall).not.toHaveBeenCalled();
+  });
+
+  it("renders and saves normally when a field's validation_pattern is not a valid regex", async () => {
+    const infoWithBadPattern: AgentCreateInfo = {
+      ...bedrockAgentcoreInfo,
+      credential_fields: [
+        {
+          ...bedrockAgentcoreInfo.credential_fields[0],
+          validation_pattern: "(unterminated",
+        },
+      ],
+    };
+    vi.mocked(networking.getAgentCreateMetadata).mockResolvedValue([infoWithBadPattern]);
+    vi.mocked(networking.getAgentInfo).mockResolvedValue(BEDROCK_AGENTCORE_AGENT as never);
+    const user = setup();
+    renderView();
+    await openEditor(user);
+
+    expect(await screen.findByLabelText("Agent Runtime ARN")).toHaveValue(FULL_RUNTIME_ARN);
+
+    await save(user);
+
+    expect((patchedPayload().litellm_params as Record<string, unknown>).model).toBe(
+      `bedrock/agentcore/${FULL_RUNTIME_ARN}`,
+    );
   });
 
   it("reloads the agent and leaves edit mode when the edit is cancelled", async () => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/agents/_components/agent_type_utils.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/agents/_components/agent_type_utils.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { detectAgentType, extractModelTemplateValues, parseDynamicAgentForForm } from "./agent_type_utils";
+import type { AgentCreateInfo } from "@/components/networking";
+import type { Agent } from "@/components/agents/types";
+
+const FULL_RUNTIME_ARN = "arn:aws:bedrock-agentcore:eu-central-1:123456789012:runtime/hosted_agent_4vm3i-BaTdfOELAs";
+
+const bedrockAgentcoreInfo: AgentCreateInfo = {
+  agent_type: "bedrock_agentcore",
+  agent_type_display_name: "Bedrock AgentCore",
+  model_template: "bedrock/agentcore/{agent_runtime_arn}",
+  credential_fields: [
+    {
+      key: "agent_runtime_arn",
+      label: "Agent Runtime ARN",
+      required: true,
+      include_in_litellm_params: false,
+    },
+  ],
+};
+
+describe("extractModelTemplateValues", () => {
+  it("recovers a placeholder value that itself contains '/' (an AWS ARN resource path)", () => {
+    const values = extractModelTemplateValues(
+      "bedrock/agentcore/{agent_runtime_arn}",
+      `bedrock/agentcore/${FULL_RUNTIME_ARN}`,
+    );
+
+    expect(values.agent_runtime_arn).toBe(FULL_RUNTIME_ARN);
+  });
+
+  it("recovers a placeholder value with no '/' (single path segment)", () => {
+    const values = extractModelTemplateValues("langgraph/{assistant_id}", "langgraph/asst_1");
+
+    expect(values.assistant_id).toBe("asst_1");
+  });
+
+  it("returns no match when the model does not fit the template", () => {
+    const values = extractModelTemplateValues("langgraph/{assistant_id}", "azure_ai/agents/asst_1");
+
+    expect(values).toEqual({});
+  });
+});
+
+describe("parseDynamicAgentForForm", () => {
+  it("preserves the full runtime ARN, including the resource id after 'runtime/', when populating the edit form", () => {
+    const agent = {
+      agent_id: "agent-1",
+      agent_name: "bedrock-agent",
+      agent_card_params: { description: "" },
+      litellm_params: {
+        custom_llm_provider: "bedrock",
+        model: `bedrock/agentcore/${FULL_RUNTIME_ARN}`,
+      },
+    } as unknown as Agent;
+
+    const values = parseDynamicAgentForForm(agent, bedrockAgentcoreInfo);
+
+    expect(values.agent_runtime_arn).toBe(FULL_RUNTIME_ARN);
+  });
+});
+
+describe("detectAgentType", () => {
+  it("detects bedrock_agentcore agents from the model prefix", () => {
+    const agent = {
+      agent_id: "agent-1",
+      agent_name: "bedrock-agent",
+      litellm_params: { model: `bedrock/agentcore/${FULL_RUNTIME_ARN}` },
+    } as unknown as Agent;
+
+    expect(detectAgentType(agent)).toBe("bedrock_agentcore");
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/agents/_components/agent_type_utils.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/agents/_components/agent_type_utils.ts
@@ -25,6 +25,29 @@ export const detectAgentType = (agent: Agent): string => {
   return "a2a";
 };
 
+const escapeRegExp = (segment: string): string => segment.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+/**
+ * Reverses a `model_template` (e.g. "bedrock/agentcore/{agent_runtime_arn}") against a stored
+ * `model` string to recover the placeholder values that produced it. Builds a regex from the
+ * template's literal segments rather than matching by split("/") position, because a
+ * placeholder's value can itself contain "/" (an AWS ARN's "runtime/<runtime-id>" resource path,
+ * a Vertex AI reasoning engine's "projects/.../reasoningEngines/..." resource id) and would
+ * otherwise be cut off at the first one.
+ */
+export const extractModelTemplateValues = (template: string, model: string): Record<string, string> => {
+  // Splitting on a regex with a capturing group interleaves the captured placeholder
+  // names between the surrounding literal segments, e.g. "a/{x}/b" -> ["a/", "x", "/b"].
+  const parts = template.split(/\{([a-zA-Z0-9_]+)\}/g);
+  const fieldNames = parts.filter((_part, index) => index % 2 === 1);
+  const pattern = parts.map((part, index) => (index % 2 === 1 ? "(.+)" : escapeRegExp(part))).join("");
+
+  const match = model.match(new RegExp(`^${pattern}$`));
+  if (!match) return {};
+
+  return Object.fromEntries(fieldNames.map((name, index) => [name, match[index + 1]]));
+};
+
 /**
  * Parses agent data for dynamic form fields (non-A2A agents).
  * Extracts values from litellm_params based on the agent type metadata.
@@ -35,24 +58,18 @@ export const parseDynamicAgentForForm = (agent: Agent, agentTypeInfo: AgentCreat
     description: agent.agent_card_params?.description || "",
   };
 
+  const templateValues =
+    agentTypeInfo.model_template && agent.litellm_params?.model
+      ? extractModelTemplateValues(agentTypeInfo.model_template, agent.litellm_params.model)
+      : {};
+
   // Extract credential field values from litellm_params
   for (const field of agentTypeInfo.credential_fields) {
     if (field.include_in_litellm_params !== false) {
       values[field.key] = agent.litellm_params?.[field.key] || field.default_value || "";
-    } else {
-      // For fields not in litellm_params (like agent_id), try to extract from model string
-      if (agentTypeInfo.model_template && agent.litellm_params?.model) {
-        const model = agent.litellm_params.model;
-        const templateParts = agentTypeInfo.model_template.split("/");
-        const modelParts = model.split("/");
-
-        // Find the placeholder position and extract the value
-        templateParts.forEach((part, index) => {
-          if (part === `{${field.key}}` && modelParts[index]) {
-            values[field.key] = modelParts[index];
-          }
-        });
-      }
+    } else if (templateValues[field.key] !== undefined) {
+      // For fields not in litellm_params (like agent_runtime_arn), recover from the model string
+      values[field.key] = templateValues[field.key];
     }
   }
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/agents/_components/dynamic_agent_form_fields.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/agents/_components/dynamic_agent_form_fields.tsx
@@ -24,58 +24,80 @@ interface DynamicAgentFormFieldsProps {
 export const unmountedDynamicFieldNames = (mountedPanels: readonly string[]): readonly string[] =>
   mountedPanels.includes(AGENT_FORM_CONFIG.cost.key) ? [] : COST_FIELD_NAMES;
 
-const CredentialField = ({ field }: { field: AgentCredentialFieldMetadata }) => (
-  <AgentFormField
-    name={field.key}
-    label={field.tooltip ? labelWithHint(field.label, field.tooltip) : field.label}
-    defaultValue={field.default_value ?? undefined}
-    rules={field.required ? { required: `Please enter ${field.label}` } : undefined}
-  >
-    {({ value, onChange, ref, ...control }) => {
-      const text = typeof value === "string" ? value : "";
-      if (field.field_type === "password") {
-        return (
-          <PasswordInput
-            {...control}
-            value={typeof value === "string" ? value : ""}
-            onChange={onChange}
-            ref={ref}
-            placeholder={field.placeholder || ""}
-          />
-        );
-      }
-      if (field.field_type === "textarea") {
-        return (
-          <Textarea
-            {...control}
-            ref={ref}
-            rows={3}
-            placeholder={field.placeholder || ""}
-            value={text}
-            onChange={onChange}
-          />
-        );
-      }
-      if (field.field_type === "select" && field.options) {
-        return (
-          <Select value={text || null} onValueChange={onChange}>
-            <SelectTrigger {...control} className="w-full">
-              <SelectValue placeholder={field.placeholder || ""} />
-            </SelectTrigger>
-            <SelectContent>
-              {field.options.map((option) => (
-                <SelectItem key={option} value={option} title={option}>
-                  {option}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        );
-      }
-      return <Input {...control} ref={ref} placeholder={field.placeholder || ""} value={text} onChange={onChange} />;
-    }}
-  </AgentFormField>
-);
+// A field's validation_pattern is server-supplied metadata; if it's ever not a valid regex, skip
+// validation rather than throwing during render and taking the whole form down with it.
+const buildValidationPatternRule = (
+  field: AgentCredentialFieldMetadata,
+): { value: RegExp; message: string } | undefined => {
+  if (!field.validation_pattern) return undefined;
+  try {
+    return {
+      value: new RegExp(field.validation_pattern),
+      message: field.validation_message || `${field.label} looks incomplete or malformed`,
+    };
+  } catch {
+    return undefined;
+  }
+};
+
+const CredentialField = ({ field }: { field: AgentCredentialFieldMetadata }) => {
+  const patternRule = buildValidationPatternRule(field);
+  return (
+    <AgentFormField
+      name={field.key}
+      label={field.tooltip ? labelWithHint(field.label, field.tooltip) : field.label}
+      defaultValue={field.default_value ?? undefined}
+      rules={{
+        ...(field.required ? { required: `Please enter ${field.label}` } : {}),
+        ...(patternRule ? { pattern: patternRule } : {}),
+      }}
+    >
+      {({ value, onChange, ref, ...control }) => {
+        const text = typeof value === "string" ? value : "";
+        if (field.field_type === "password") {
+          return (
+            <PasswordInput
+              {...control}
+              value={typeof value === "string" ? value : ""}
+              onChange={onChange}
+              ref={ref}
+              placeholder={field.placeholder || ""}
+            />
+          );
+        }
+        if (field.field_type === "textarea") {
+          return (
+            <Textarea
+              {...control}
+              ref={ref}
+              rows={3}
+              placeholder={field.placeholder || ""}
+              value={text}
+              onChange={onChange}
+            />
+          );
+        }
+        if (field.field_type === "select" && field.options) {
+          return (
+            <Select value={text || null} onValueChange={onChange}>
+              <SelectTrigger {...control} className="w-full">
+                <SelectValue placeholder={field.placeholder || ""} />
+              </SelectTrigger>
+              <SelectContent>
+                {field.options.map((option) => (
+                  <SelectItem key={option} value={option} title={option}>
+                    {option}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          );
+        }
+        return <Input {...control} ref={ref} placeholder={field.placeholder || ""} value={text} onChange={onChange} />;
+      }}
+    </AgentFormField>
+  );
+};
 
 const DynamicAgentFormFields: React.FC<DynamicAgentFormFieldsProps> = ({ agentTypeInfo, panels }) => (
   <>

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -310,6 +310,8 @@ export interface AgentCredentialFieldMetadata {
   options?: string[] | null;
   default_value?: string | null;
   include_in_litellm_params?: boolean;
+  validation_pattern?: string | null;
+  validation_message?: string | null;
 }
 
 export interface AgentCreateInfo {

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -22868,6 +22868,10 @@ export interface components {
             required: boolean;
             /** Tooltip */
             tooltip?: string | null;
+            /** Validation Message */
+            validation_message?: string | null;
+            /** Validation Pattern */
+            validation_pattern?: string | null;
         };
         /**
          * AgentExtension


### PR DESCRIPTION
## TLDR

Problem this solves:

- Editing an AgentCore agent showed a truncated runtime ARN and silently corrupted it on save

How it solves it:

- Recovers the ARN from the stored model string with a regex instead of matching split("/") segments by position
- Rejects a malformed or truncated ARN before save with a clear inline error

## User Flow

Before: opening an AgentCore agent's settings and saving without any changes corrupts its runtime ARN

1. Admin opens the Agents page, clicks an AgentCore agent, then "Edit Settings"
2. The "Agent Runtime ARN" field shows only `arn:aws:bedrock-agentcore:eu-central-1:123456789012:runtime`, missing everything after `runtime/`
3. They click "Save Changes" without editing the field
4. The agent's stored ARN is now permanently truncated, and calls through this agent fail

After: the same flow shows and saves the complete ARN every time, and a bad value is caught before it can be saved

1. Admin opens the Agents page, clicks an AgentCore agent, then "Edit Settings"
2. The "Agent Runtime ARN" field shows the complete ARN, including the resource id after `runtime/`
3. They click "Save Changes" without editing the field
4. Reopening "Edit Settings" shows the identical, complete ARN
5. If they instead type a truncated or malformed ARN and click "Save Changes", the field shows a validation error and nothing is saved

## Relevant issues

## Linear ticket

Resolves LIT-6737

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Setup shared across cases: local proxy + Postgres, and the dashboard dev server, both from this branch. An AgentCore agent was created through `POST /v1/agents` with `litellm_params.model` set to `bedrock/agentcore/arn:aws:bedrock-agentcore:eu-central-1:123456789012:runtime/hosted_agent_4vm3i-BaTdfOELAs`, then edited through the Admin UI (Agents -> agent -> Settings -> Edit Settings).

### Before (a677242d6f)

#### Edit form displays and saves the runtime ARN

1. Open Settings -> Edit Settings for the agent. The "Agent Runtime ARN" field renders truncated, missing the resource id after `runtime/`:
   ![Before: truncated ARN field](https://raw.githubusercontent.com/yassin-berriai/litellm-pr-media/main/lit-6737/01-before-truncated-field-zoom.png)
   ![Before: full settings form](https://raw.githubusercontent.com/yassin-berriai/litellm-pr-media/main/lit-6737/02-before-truncated-field-full.jpg)
2. Click "Save Changes" without editing anything. The toast confirms the save, and `GET /v1/agents/{agent_id}` now returns the truncated value:
   ```
   $ curl -s http://127.0.0.1:16737/v1/agents/071bfa0d-0a38-46ec-9e10-142ce2fe90a9 -H "Authorization: Bearer $MASTER_KEY" | jq -r .litellm_params.model
   bedrock/agentcore/arn:aws:bedrock-agentcore:eu-central-1:123456789012:runtime
   ```
   The resource id is gone for good and the agent is corrupted

#### Malformed ARN is rejected before saving

1. There is no client-side validation on this commit, so the exact same click in the previous case is the "before" for this case too: whatever the field holds, truncated or otherwise, saves silently with no warning

### After (443f8df808)

#### Edit form displays and saves the runtime ARN

1. Open Settings -> Edit Settings for a freshly created agent carrying the same full ARN. The field now renders the complete value:
   ![After: full ARN field](https://raw.githubusercontent.com/yassin-berriai/litellm-pr-media/main/lit-6737/03-after-full-arn-field-zoom.png)
   ![After: full settings form](https://raw.githubusercontent.com/yassin-berriai/litellm-pr-media/main/lit-6737/04-after-full-arn-field-full.jpg)
2. Click "Save Changes" without editing anything. `GET /v1/agents/{agent_id}` returns the byte-identical full ARN:
   ```
   $ curl -s http://127.0.0.1:16737/v1/agents/f3b2207f-88b6-49d3-b841-f65e524424a3 -H "Authorization: Bearer $MASTER_KEY" | jq -r .litellm_params.model
   bedrock/agentcore/arn:aws:bedrock-agentcore:eu-central-1:123456789012:runtime/hosted_agent_4vm3i-BaTdfOELAs
   ```
3. Reopening "Edit Settings" shows the same complete ARN, confirming the round trip:
   ![After: reopened after save](https://raw.githubusercontent.com/yassin-berriai/litellm-pr-media/main/lit-6737/05-after-roundtrip-reopened-zoom.png)

#### Malformed ARN is rejected before saving

1. In the same edit form, replace the ARN with a truncated value (`arn:aws:bedrock-agentcore:eu-central-1:123456789012:runtime`, missing the resource id) and click "Save Changes". The field shows a validation error and the request never goes out:
   ![After: validation error blocks save](https://raw.githubusercontent.com/yassin-berriai/litellm-pr-media/main/lit-6737/06-after-validation-error-full.jpg)
2. `GET /v1/agents/{agent_id}` confirms the stored value is unchanged (still the full ARN from the previous case)

## Type

🐛 Bug Fix

## Caveats

### Low

- The validator checks the overall shape of a Bedrock AgentCore runtime ARN (partition, region, account id, and a non-empty resource id after `runtime/`); it is not a full ARN grammar validator, matching the acceptance criteria's ask for a lightweight check

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
