### PR TITLE
fix: apply per-callback message redaction on the failure logging path

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -3398,11 +3398,14 @@ class Logging(LiteLLMLoggingBaseClass):
                         and is_sync_request
                         and self.call_type != CallTypes.pass_through.value
                     ):  # custom logger class
+                        model_call_details = callback.redact_standard_logging_payload_from_model_call_details(
+                            model_call_details=self.model_call_details
+                        )
                         callback.log_failure_event(
                             start_time=start_time,
                             end_time=end_time,
                             response_obj=result,
-                            kwargs=self.model_call_details,
+                            kwargs=model_call_details,
                         )
                     if callback == "langfuse":
                         global langFuseLogger
@@ -3532,8 +3535,11 @@ class Logging(LiteLLMLoggingBaseClass):
                 if not should_run:
                     continue
                 if isinstance(callback, CustomLogger):  # custom logger class
+                    model_call_details = callback.redact_standard_logging_payload_from_model_call_details(
+                        model_call_details=self.model_call_details
+                    )
                     await callback.async_log_failure_event(
-                        kwargs=self.model_call_details,
+                        kwargs=model_call_details,
                         response_obj=result,
                         start_time=start_time,
                         end_time=end_time,

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -6253,3 +6253,106 @@ def test_passthrough_embeddings_result_swapped_for_callbacks():
 
     assert isinstance(swapped_result, EmbeddingResponse)
     assert swapped_result.data[0]["embedding"] == [0.1, 0.2, 0.3]
+
+
+class _FailurePayloadRecorder(CustomLogger):
+    """Records the kwargs a failure callback is handed, so tests can inspect them."""
+
+    def __init__(self, turn_off_message_logging: bool):
+        super().__init__()
+        self.turn_off_message_logging = turn_off_message_logging
+        self.received_kwargs = None
+
+    def log_failure_event(self, kwargs, response_obj, start_time, end_time):
+        self.received_kwargs = kwargs
+
+    async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
+        self.received_kwargs = kwargs
+
+
+def _failure_logging_obj(messages, sync_callbacks=None, async_callbacks=None):
+    logging_obj = LitellmLogging(
+        model="gpt-4o",
+        messages=messages,
+        stream=False,
+        call_type="completion",
+        start_time=time.time(),
+        litellm_call_id="failure-redaction-call-id",
+        function_id="failure-redaction-function-id",
+        dynamic_failure_callbacks=sync_callbacks,
+        dynamic_async_failure_callbacks=async_callbacks,
+    )
+    logging_obj.update_environment_variables(
+        model="gpt-4o",
+        user="test-user",
+        optional_params={},
+        litellm_params={},
+    )
+    return logging_obj
+
+
+def _recorded_messages(recorder):
+    assert recorder.received_kwargs is not None
+    return recorder.received_kwargs["standard_logging_object"]["messages"]
+
+
+@pytest.mark.asyncio
+async def test_async_failure_handler_applies_per_callback_message_redaction(monkeypatch):
+    """A callback that opted out of message logging must not receive prompts when a request fails.
+
+    The success path routes every custom logger through
+    ``redact_standard_logging_payload_from_model_call_details``. Without the same call on the
+    failure path, a callback with ``turn_off_message_logging=True`` is handed the full prompt
+    whenever a request fails, while a second callback on the same request must still get the
+    real messages.
+    """
+    monkeypatch.setattr(litellm, "turn_off_message_logging", False)
+    messages = [{"role": "user", "content": "user prompt"}]
+    opted_out = _FailurePayloadRecorder(turn_off_message_logging=True)
+    opted_in = _FailurePayloadRecorder(turn_off_message_logging=False)
+
+    logging_obj = _failure_logging_obj(messages, async_callbacks=[opted_out, opted_in])
+    await logging_obj._async_failure_handler_body(ValueError("boom"), "traceback")
+
+    assert [message["content"] for message in _recorded_messages(opted_out)] == ["redacted-by-litellm"]
+    assert _recorded_messages(opted_in) == messages
+    assert logging_obj.model_call_details["standard_logging_object"]["messages"] == messages
+
+
+def test_failure_handler_applies_per_callback_message_redaction(monkeypatch):
+    """Sync failure path equivalent of the async per-callback redaction test."""
+    monkeypatch.setattr(litellm, "turn_off_message_logging", False)
+    messages = [{"role": "user", "content": "user prompt"}]
+    opted_out = _FailurePayloadRecorder(turn_off_message_logging=True)
+    opted_in = _FailurePayloadRecorder(turn_off_message_logging=False)
+
+    logging_obj = _failure_logging_obj(messages, sync_callbacks=[opted_out, opted_in])
+    logging_obj._failure_handler_body(ValueError("boom"), "traceback")
+
+    assert [message["content"] for message in _recorded_messages(opted_out)] == ["redacted-by-litellm"]
+    assert _recorded_messages(opted_in) == messages
+    assert logging_obj.model_call_details["standard_logging_object"]["messages"] == messages
+
+
+@pytest.mark.asyncio
+async def test_failure_handlers_pass_through_model_call_details_when_no_callback_opts_out(
+    monkeypatch,
+):
+    """With nobody opting out, both failure paths hand over the shared dict itself, untouched.
+
+    The redaction hook early-returns its argument in that case, so the default configuration
+    keeps handing callbacks the very same object it handed them before.
+    """
+    monkeypatch.setattr(litellm, "turn_off_message_logging", False)
+    messages = [{"role": "user", "content": "user prompt"}]
+    async_recorder = _FailurePayloadRecorder(turn_off_message_logging=False)
+    sync_recorder = _FailurePayloadRecorder(turn_off_message_logging=False)
+
+    async_logging_obj = _failure_logging_obj(messages, async_callbacks=[async_recorder])
+    await async_logging_obj._async_failure_handler_body(ValueError("boom"), "traceback")
+
+    sync_logging_obj = _failure_logging_obj(messages, sync_callbacks=[sync_recorder])
+    sync_logging_obj._failure_handler_body(ValueError("boom"), "traceback")
+
+    assert async_recorder.received_kwargs is async_logging_obj.model_call_details
+    assert sync_recorder.received_kwargs is sync_logging_obj.model_call_details


### PR DESCRIPTION
## TLDR

Problem this solves:

- Per-callback message redaction is skipped when a request fails
- Callbacks that opted out still receive full user prompts
- No config avoids it, the global flag redacts for everyone
- Silent exposure on exactly the requests people inspect most

How it solves it:

- Failure paths now call the same redaction hook the success path uses
- Applied per callback, so other callbacks keep full content
- Returned copy is passed along, shared state is never mutated
- Both the sync and async failure paths are covered

## User Flow

Before: an admin who set up one full-content logging destination and one redacted destination finds real user prompts sitting in the redacted one as soon as a request fails

1. The admin starts the proxy with two logging destinations configured, leaves global message logging on, and turns message logging off for the second destination only
2. A developer sends POST http://localhost:4000/v1/chat/completions for a Claude model, with a prompt containing a customer name and account number, and a max_tokens value the provider will reject
3. The provider rejects the call and the developer gets back HTTP 400 carrying an invalid_request_error about max_tokens
4. The admin opens the first destination and sees the request with the full prompt, which is what that destination is for
5. The admin opens the second destination and sees the same full prompt, "My name is Jane Doe and my account number is 12345678", where they expected "redacted-by-litellm"
6. Anyone who has access only to the second destination, deliberately the wider audience, can read prompt content for every failed request

After: the same failed request leaves prompt content only in the destination that is meant to hold it

1. The admin starts the proxy with two logging destinations configured, leaves global message logging on, and turns message logging off for the second destination only
2. A developer sends POST http://localhost:4000/v1/chat/completions for a Claude model, with a prompt containing a customer name and account number, and a max_tokens value the provider will reject
3. The provider rejects the call and the developer gets back HTTP 400 carrying an invalid_request_error about max_tokens
4. The admin opens the first destination and sees the request with the full prompt, which is what that destination is for
5. The admin opens the second destination and sees "redacted-by-litellm" in place of the prompt
6. Someone who has access only to the second destination can no longer read prompt content for failed requests, and full content debugging in the first destination is unchanged

## Relevant issues

Fixes #39385

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup for both runs.

`config.yaml`:

```yaml
model_list:
  - model_name: claude-test
    litellm_params:
      model: anthropic/claude-sonnet-4-5-20250929
      api_key: os.environ/ANTHROPIC_API_KEY

litellm_settings:
  turn_off_message_logging: false
  callbacks: ["custom_callbacks.redacted_logger", "custom_callbacks.full_logger"]
```

`custom_callbacks.py`, two logging destinations that write what they were handed to a file so the contents are visible without standing up two SaaS accounts:

```python
import json
import os
from litellm.integrations.custom_logger import CustomLogger

OUT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "out")


class RecordingLogger(CustomLogger):
    def __init__(self, name, turn_off_message_logging):
        super().__init__()
        self.name = name
        self.turn_off_message_logging = turn_off_message_logging

    def _dump(self, kwargs):
        slo = (kwargs or {}).get("standard_logging_object") or {}
        with open(os.path.join(OUT, f"{self.name}.json"), "w") as f:
            json.dump({"status": slo.get("status"), "messages": slo.get("messages")}, f, indent=2, default=str)

    async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
        self._dump(kwargs)

    def log_failure_event(self, kwargs, response_obj, start_time, end_time):
        self._dump(kwargs)


redacted_logger = RecordingLogger("redacted_callback", turn_off_message_logging=True)
full_logger = RecordingLogger("full_callback", turn_off_message_logging=False)
```

Env vars the proxy ran with: `ANTHROPIC_API_KEY` (a real key, redacted here), `LITELLM_MASTER_KEY=sk-1234`, and `PYTHONPATH` pointing at the directory holding `custom_callbacks.py`

### Before (a677242)

1. Start the proxy

```
$ python litellm/proxy/proxy_cli.py --config config.yaml --port 4000
```

2. Send a request the provider rejects, so the failure path runs against a real Anthropic API call

```
$ curl -s -X POST http://127.0.0.1:4000/v1/chat/completions \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"model":"claude-test","messages":[{"role":"user","content":"My name is Jane Doe and my account number is 12345678"}],"max_tokens":999999}' \
    -w "\nHTTP_STATUS:%{http_code}\n"

{"error":{"message":"litellm.BadRequestError: AnthropicException - {\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"max_tokens: 999999 > 64000, which is the maximum allowed number of output tokens for claude-sonnet-4-5-20250929\"},\"request_id\":\"req_011CefBCRdr1SGHC8o2eqYjS\"}. Received Model Group=claude-test\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"400"}}
HTTP_STATUS:400
```

3. Read what each destination was handed. Both files carry the full prompt, so turning message logging off for the first destination did nothing

```
$ cat out/redacted_callback.json
{
  "status": "failure",
  "messages": [
    {
      "role": "user",
      "content": "My name is Jane Doe and my account number is 12345678"
    }
  ]
}

$ cat out/full_callback.json
{
  "status": "failure",
  "messages": [
    {
      "role": "user",
      "content": "My name is Jane Doe and my account number is 12345678"
    }
  ]
}
```

### After (44d18bc)

1. Start the proxy

```
$ python litellm/proxy/proxy_cli.py --config config.yaml --port 4000
```

2. Send the same request, which the provider rejects the same way

```
$ curl -s -X POST http://127.0.0.1:4000/v1/chat/completions \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"model":"claude-test","messages":[{"role":"user","content":"My name is Jane Doe and my account number is 12345678"}],"max_tokens":999999}' \
    -w "\nHTTP_STATUS:%{http_code}\n"

{"error":{"message":"litellm.BadRequestError: AnthropicException - {\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"max_tokens: 999999 > 64000, which is the maximum allowed number of output tokens for claude-sonnet-4-5-20250929\"},\"request_id\":\"req_011CefBUHwgmuXdXnZhXE8Ug\"}. Received Model Group=claude-test\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"400"}}
HTTP_STATUS:400
```

3. Read what each destination was handed. The one that turned message logging off now gets redacted content, and the one that did not still gets the real prompt on the same request

```
$ cat out/redacted_callback.json
{
  "status": "failure",
  "messages": [
    {
      "content": "redacted-by-litellm",
      "role": "assistant",
      "tool_calls": null,
      "function_call": null,
      "provider_specific_fields": null
    }
  ]
}

$ cat out/full_callback.json
{
  "status": "failure",
  "messages": [
    {
      "role": "user",
      "content": "My name is Jane Doe and my account number is 12345678"
    }
  ]
}
```

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Older `message_logging` attribute still gates a separate helper
- Left alone here to keep the change focused

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
