### PR TITLE
feat(ui): update OpenAI preset model tiers

### DIFF
--- a/ui/litellm-dashboard/src/autorouter_presets.json
+++ b/ui/litellm-dashboard/src/autorouter_presets.json
@@ -68,13 +68,16 @@
   },
   "openai_family": {
     "label": "OpenAI Family",
-    "description": "Routes across the GPT model family: gpt-5.4-nano for simple queries, gpt-5.4-mini for medium, gpt-5.4 for complex, o3 for reasoning-heavy requests.",
+    "description": "Routes across the GPT model family: Luna for simple queries, Terra for medium, Sol for complex, Sol at xhigh thinking for reasoning.",
     "complexity_router_config": {
       "tiers": {
-        "SIMPLE": ["gpt-5.4-nano"],
-        "MEDIUM": ["gpt-5.4-mini"],
-        "COMPLEX": ["gpt-5.4"],
-        "REASONING": ["o3"]
+        "SIMPLE": ["gpt-5.6-luna"],
+        "MEDIUM": ["gpt-5.6-terra"],
+        "COMPLEX": ["gpt-5.6-sol"],
+        "REASONING": ["gpt-5.6-sol"]
+      },
+      "tier_model_configs": {
+        "REASONING": [{ "model_name": "gpt-5.6-sol", "litellm_params": { "reasoning_effort": "xhigh" } }]
       },
       "classifier_type": "heuristic",
       "escalation_keywords": ["LITELLM ESCALATE"],

--- a/ui/litellm-dashboard/src/lib/autorouter_presets.test.ts
+++ b/ui/litellm-dashboard/src/lib/autorouter_presets.test.ts
@@ -158,6 +158,24 @@ describe("autorouter_presets", () => {
     });
   });
 
+  it("pins the OpenAI preset to the Luna, Terra, and Sol progression", () => {
+    const preset = getPresetByKey("openai_family")!;
+    const expectedTiers = {
+      SIMPLE: ["gpt-5.6-luna"],
+      MEDIUM: ["gpt-5.6-terra"],
+      COMPLEX: ["gpt-5.6-sol"],
+      REASONING: ["gpt-5.6-sol"],
+    };
+    expect(preset.complexity_router_config.tiers).toEqual(expectedTiers);
+    expect(preset.complexity_router_config.tier_model_configs).toEqual({
+      REASONING: [{ model_name: "gpt-5.6-sol", litellm_params: { reasoning_effort: "xhigh" } }],
+    });
+    const prefill = buildPresetPrefill(preset.complexity_router_config, groupsOnly(getRequiredModelsInPreset(preset)));
+    expect(prefill.complexityRouterConfig.tier_model_params).toEqual({
+      REASONING: { "gpt-5.6-sol": { reasoning_effort: "xhigh" } },
+    });
+  });
+
   it("pins the gemini preset to concrete model ids, never Google's hot-swapping -latest aliases", () => {
     const gemini = getPresetByKey("gemini_family")!;
     const config = gemini.complexity_router_config;


### PR DESCRIPTION
## TLDR

Problem this solves:

- The OpenAI Family preset used the older GPT-5.4 and o3 lineup
- Its reasoning tier had no explicit thinking effort

How it solves it:

- Routes simple, medium, and complex work to GPT-5.6 Luna, Terra, and Sol
- Routes reasoning work to Sol with xhigh thinking

## User Flow

Before: selecting OpenAI Family populated the older model progression

1. An admin opens the Auto Router form
2. They select OpenAI Family
3. The form shows GPT-5.4 Nano, GPT-5.4 Mini, GPT-5.4, and o3

After: selecting OpenAI Family populates the GPT-5.6 progression with explicit reasoning effort

1. An admin opens the Auto Router form
2. They select OpenAI Family
3. The form shows GPT-5.6 Luna, GPT-5.6 Terra, GPT-5.6 Sol, and GPT-5.6 Sol with xhigh thinking

## Relevant issues


## Linear ticket


## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

### After (661e01e296)

1. `npm run test:unit -- src/lib/autorouter_presets.test.ts` passed with 80 tests
2. The regression test verifies the four model assignments and the xhigh reasoning prefill

## Type

New Feature

## Caveats (if any)


## Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
