### PR TITLE
fix(guardrails): wire _unpack_sequence_ into the custom-code sandbox

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/custom_code/sandbox.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/custom_code/sandbox.py
@@ -31,6 +31,7 @@ from RestrictedPython.Eval import default_guarded_getitem, default_guarded_getit
 from RestrictedPython.Guards import (
     full_write_guard,
     guarded_iter_unpack_sequence,
+    guarded_unpack_sequence,
     safer_getattr,
 )
 
@@ -115,6 +116,12 @@ def build_sandbox_globals() -> dict[str, object]:
         "_getitem_": default_guarded_getitem,
         "_getiter_": default_guarded_getiter,
         "_iter_unpack_sequence_": guarded_iter_unpack_sequence,
+        # RestrictedPython emits _unpack_sequence_ for every tuple-unpacking
+        # target that is not a for-loop target — ``a, b = pair``,
+        # ``a, *rest = seq``, ``with x as (a, b)`` — and, like _inplacevar_,
+        # ships no default. Without it those statements compile and then raise
+        # NameError the first time the guardrail runs.
+        "_unpack_sequence_": guarded_unpack_sequence,
         "_write_": full_write_guard,
         "_inplacevar_": _inplacevar_,
     }

--- a/tests/test_litellm/proxy/guardrails/test_custom_code_security.py
+++ b/tests/test_litellm/proxy/guardrails/test_custom_code_security.py
@@ -228,3 +228,32 @@ def test_augmented_assignment_works():
 def test_missing_apply_guardrail_raises():
     with pytest.raises(CustomCodeCompilationError, match="apply_guardrail"):
         _compile("x = 1\n")
+
+
+@pytest.mark.parametrize(
+    ("body", "expected"),
+    [
+        # Every one of these compiles fine and then raises
+        # "NameError: name '_unpack_sequence_' is not defined" at call time when
+        # the guard is missing from the sandbox globals.
+        ("    a, b = inputs['pair']\n    return a + b\n", 3),
+        ("    a, (b, c) = inputs['nested']\n    return a + b + c\n", 6),
+        ("    a, *rest = inputs['seq']\n    return rest\n", [2, 3]),
+        ("    with inputs['ctx'] as (a, b):\n        return a + b\n", 15),
+    ],
+)
+def test_tuple_unpacking_runs(body: str, expected):
+    """Ordinary tuple unpacking must work inside a guardrail, not NameError."""
+
+    class _Ctx:
+        def __enter__(self):
+            return (7, 8)
+
+        def __exit__(self, *args):
+            return False
+
+    guardrail = _compile("def apply_guardrail(inputs, request_data, input_type):\n" + body)
+    fn = guardrail._compiled_function
+    assert fn is not None
+    inputs = {"pair": (1, 2), "nested": (1, (2, 3)), "seq": [1, 2, 3], "ctx": _Ctx()}
+    assert fn(inputs, {}, "request") == expected


### PR DESCRIPTION
## TLDR

Problem this solves:

- Tuple unpacking in a custom-code guardrail raises NameError
- `a, b = x`, `a, *rest = x`, `with c as (a, b)` all fail
- The guardrail never runs, so the request errors out

How it solves it:

- Register RestrictedPython's `guarded_unpack_sequence` as `_unpack_sequence_`
- RestrictedPython ships no default for it, like `_inplacevar_`

## User Flow

Before: a proxy admin writing a guardrail cannot use ordinary tuple unpacking; the guardrail fails on every request instead of inspecting it

1. They POST https://litellm-domain/guardrails/test_custom_code with guardrail code whose first line is `label, body = inputs["texts"][0].split(":", 1)`
2. The response comes back `"success": false` with `"error": "Execution error: name '_unpack_sequence_' is not defined"`
3. Rewriting the same logic without tuple unpacking (`parts = ...; parts[0]`) makes it work, with no hint that unpacking was the problem

After: the same guardrail code runs and returns its verdict

1. They POST the same request to https://litellm-domain/guardrails/test_custom_code
2. The response comes back `"success": true` with `"result": {"action": "block", "reason": "secret marker found"}`

## Relevant issues

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Shared setup — a proxy started from this config, no model needed:

```yaml
model_list: []
general_settings:
  master_key: sk-qa-1234
```

Each case POSTs to `/guardrails/test_custom_code` with `"test_input": {"texts": ["SECRET:hello"]}`.

### Before (2ade3e16a9)

#### tuple assignment — `label, body = inputs["texts"][0].split(":", 1)`

1. `curl -s -X POST http://127.0.0.1:4010/guardrails/test_custom_code -H "Authorization: Bearer sk-qa-1234" -H "Content-Type: application/json" -d @tuple_assign.req.json`
2. `{"success":false,"result":null,"error":"Execution error: name '_unpack_sequence_' is not defined","error_type":"execution"}`

#### starred assignment — `head, *rest = inputs["texts"]`

1. Same curl with `starred_assign.req.json`
2. `{"success":false,"result":null,"error":"Execution error: name '_unpack_sequence_' is not defined","error_type":"execution"}`

#### with-as tuple — `a, (b, c) = (1, (2, 3))`

1. Same curl with `with_as_tuple.req.json`
2. `{"success":false,"result":null,"error":"Execution error: name '_unpack_sequence_' is not defined","error_type":"execution"}`

### After (6d0146a3f3)

#### tuple assignment — `label, body = inputs["texts"][0].split(":", 1)`

1. Same curl
2. `{"success":true,"result":{"action":"block","reason":"secret marker found"},"error":null,"error_type":null}`

#### starred assignment — `head, *rest = inputs["texts"]`

1. Same curl
2. `{"success":true,"result":{"action":"block","reason":"secret marker found"},"error":null,"error_type":null}`

#### with-as tuple — `a, (b, c) = (1, (2, 3))`

1. Same curl
2. `{"success":true,"result":{"action":"block","reason":"unpacked fine"},"error":null,"error_type":null}`

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Fails closed today: the NameError surfaces as an error, not a skipped guardrail
- `for a, b in x` already worked; it uses `_iter_unpack_sequence_`, which was registered

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
