### PR TITLE
fix(guardrails): apply the `with` guards to `async with` in the sandbox

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/custom_code/sandbox.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/custom_code/sandbox.py
@@ -31,6 +31,7 @@ from RestrictedPython.Eval import default_guarded_getitem, default_guarded_getit
 from RestrictedPython.Guards import (
     full_write_guard,
     guarded_iter_unpack_sequence,
+    guarded_unpack_sequence,
     safer_getattr,
 )
 
@@ -115,6 +116,12 @@ def build_sandbox_globals() -> dict[str, object]:
         "_getitem_": default_guarded_getitem,
         "_getiter_": default_guarded_getiter,
         "_iter_unpack_sequence_": guarded_iter_unpack_sequence,
+        # RestrictedPython emits _unpack_sequence_ for every tuple-unpacking
+        # target that is not a for-loop target — ``a, b = pair``,
+        # ``a, *rest = seq``, ``with x as (a, b)`` — and, like _inplacevar_,
+        # ships no default. Without it those statements compile and then raise
+        # NameError the first time the guardrail runs.
+        "_unpack_sequence_": guarded_unpack_sequence,
         "_write_": full_write_guard,
         "_inplacevar_": _inplacevar_,
     }

--- a/litellm/proxy/guardrails/guardrail_hooks/custom_code/sandbox.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/custom_code/sandbox.py
@@ -45,7 +45,10 @@ class AsyncAwareTransformer(RestrictingNodeTransformer):
     has the same ``_fields`` as ``FunctionDef`` and the same security
     semantics, so we delegate to ``visit_FunctionDef`` — name check, argument
     check, print-scope wrapping, and any future additions to that method are
-    inherited automatically. ``AsyncFor``/``AsyncWith``/``Await`` delegate to
+    inherited automatically. ``AsyncWith`` gets the same treatment for the same
+    reason: ``node_contents_visit`` only recurses into children, so routing it
+    there left ``async with x as (a, b)`` without the unpack guard that
+    ``with x as (a, b)`` gets. ``AsyncFor``/``Await`` delegate to
     ``node_contents_visit`` so their children still get transformed.
     """
 
@@ -56,7 +59,7 @@ class AsyncAwareTransformer(RestrictingNodeTransformer):
         return self.node_contents_visit(node)
 
     def visit_AsyncWith(self, node: ast.AsyncWith) -> ast.AST:
-        return self.node_contents_visit(node)
+        return self.visit_With(node)
 
     def visit_Await(self, node: ast.Await) -> ast.AST:
         return self.node_contents_visit(node)

--- a/tests/test_litellm/proxy/guardrails/test_custom_code_security.py
+++ b/tests/test_litellm/proxy/guardrails/test_custom_code_security.py
@@ -228,3 +228,32 @@ def test_augmented_assignment_works():
 def test_missing_apply_guardrail_raises():
     with pytest.raises(CustomCodeCompilationError, match="apply_guardrail"):
         _compile("x = 1\n")
+
+
+@pytest.mark.parametrize(
+    ("body", "expected"),
+    [
+        # Every one of these compiles fine and then raises
+        # "NameError: name '_unpack_sequence_' is not defined" at call time when
+        # the guard is missing from the sandbox globals.
+        ("    a, b = inputs['pair']\n    return a + b\n", 3),
+        ("    a, (b, c) = inputs['nested']\n    return a + b + c\n", 6),
+        ("    a, *rest = inputs['seq']\n    return rest\n", [2, 3]),
+        ("    with inputs['ctx'] as (a, b):\n        return a + b\n", 15),
+    ],
+)
+def test_tuple_unpacking_runs(body: str, expected):
+    """Ordinary tuple unpacking must work inside a guardrail, not NameError."""
+
+    class _Ctx:
+        def __enter__(self):
+            return (7, 8)
+
+        def __exit__(self, *args):
+            return False
+
+    guardrail = _compile("def apply_guardrail(inputs, request_data, input_type):\n" + body)
+    fn = guardrail._compiled_function
+    assert fn is not None
+    inputs = {"pair": (1, 2), "nested": (1, (2, 3)), "seq": [1, 2, 3], "ctx": _Ctx()}
+    assert fn(inputs, {}, "request") == expected

--- a/tests/test_litellm/proxy/guardrails/test_custom_code_security.py
+++ b/tests/test_litellm/proxy/guardrails/test_custom_code_security.py
@@ -257,3 +257,57 @@ def test_tuple_unpacking_runs(body: str, expected):
     assert fn is not None
     inputs = {"pair": (1, 2), "nested": (1, (2, 3)), "seq": [1, 2, 3], "ctx": _Ctx()}
     assert fn(inputs, {}, "request") == expected
+
+
+def _guard_names(source: str) -> set[str]:
+    """Names of the RestrictedPython guards the compiled bytecode calls."""
+    import types
+
+    from litellm.proxy.guardrails.guardrail_hooks.custom_code.sandbox import (
+        compile_sandboxed,
+    )
+
+    found: set[str] = set()
+    stack = [compile_sandboxed(source)]
+    while stack:
+        code = stack.pop()
+        found |= {n for n in code.co_names + code.co_varnames if n.startswith("_") and n.endswith("_")}
+        stack += [c for c in code.co_consts if isinstance(c, types.CodeType)]
+    return found
+
+
+def test_async_with_gets_the_same_guards_as_with():
+    """`async with` is the async spelling of `with`; it must not enforce less."""
+    sync_guards = _guard_names("def f(x):\n    with x as (a, b):\n        pass\n")
+    async_guards = _guard_names("async def f(x):\n    async with x as (a, b):\n        pass\n")
+
+    assert "_unpack_sequence_" in sync_guards, "precondition: `with` unpacking is guarded"
+    assert sync_guards <= async_guards
+
+
+@pytest.mark.asyncio
+async def test_async_with_still_executes():
+    """Guarding `async with` must not break it."""
+    from litellm.proxy.guardrails.guardrail_hooks.custom_code.sandbox import (
+        build_sandbox_globals,
+        compile_sandboxed,
+    )
+
+    class _ACtx:
+        def __init__(self, value):
+            self.value = value
+
+        async def __aenter__(self):
+            return self.value
+
+        async def __aexit__(self, *args):
+            return False
+
+    sandbox_globals = build_sandbox_globals()
+    exec(  # noqa: S102
+        compile_sandboxed(
+            "async def f(ctx):\n    async with ctx as (a, b):\n        return a + b\n"
+        ),
+        sandbox_globals,
+    )
+    assert await sandbox_globals["f"](_ACtx((5, 6))) == 11


### PR DESCRIPTION
> Stacked on #39406. GitHub shows both commits until that one merges; the commit belonging to this PR is `9dcaca2522`.

## TLDR

Problem this solves:

- `async with` skips the sandbox guards that `with` gets
- The async spelling enforces less than the sync one

How it solves it:

- `visit_AsyncWith` delegates to `visit_With`, like `AsyncFunctionDef` does
- Inherits that visitor's rewriting instead of only recursing

## User Flow

There is no user-visible behaviour change, so a Before/After walkthrough would be invented rather than observed. Being explicit instead:

- A guardrail author cannot reach `async with` today. Defining a class is blocked in the sandbox, and no primitive returns an async context manager, so there is no async context manager for guardrail code to enter.
- Even if there were, LiteLLM wires `_getiter_` to `default_guarded_getiter`, which is the identity function, so the missing guard is not bypassable in the current configuration.

What changes is that the sandbox stops enforcing less than the policy it documents, and a future restrictive `_getiter_` will actually apply to `async with` instead of being silently skipped.

## Relevant issues

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

The observable is which guards the sandbox compiler emits. Shared setup — `guards.py` compiles each snippet with `compile_sandboxed` and prints the guard names found in the resulting bytecode:

```python
import types
from litellm.proxy.guardrails.guardrail_hooks.custom_code.sandbox import compile_sandboxed

def guards(src):
    found = set()
    stack = [compile_sandboxed(src)]
    while stack:
        c = stack.pop()
        found |= {n for n in c.co_names + c.co_varnames if n.startswith("_") and n.endswith("_")}
        stack += [k for k in c.co_consts if isinstance(k, types.CodeType)]
    return ", ".join(sorted(found)) or "(none)"
```

### Before (2ade3e16a9)

1. `python guards.py`
2. ```
   with x as (a, b)         _getiter_, _unpack_sequence_
   async with x as (a, b)   (none)
   ```

### After (9dcaca2522)

1. `python guards.py`
2. ```
   with x as (a, b)         _getiter_, _unpack_sequence_
   async with x as (a, b)   _getiter_, _unpack_sequence_
   ```

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- No exploit today: `_getiter_` is the identity function
- Value is guard parity, so a stricter `_getiter_` later is not skipped
- The tuple-target case needs #39406's `_unpack_sequence_` to run

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
