### PR TITLE
fix(cost): price Vertex AI DeepSeek OCR by token usage

### DIFF
--- a/litellm-rust/crates/core/src/providers/vertex_ai/ocr/transformation.rs
+++ b/litellm-rust/crates/core/src/providers/vertex_ai/ocr/transformation.rs
@@ -298,7 +298,8 @@ impl OcrProviderConfig for VertexAiDeepSeekOcrConfig {
             })?;
         let usage = response.get("usage").cloned();
         let content = first_choice_content(&response_json)?;
-        let mut ocr_data = ocr_data_from_content(content.clone(), usage.clone(), model);
+        let provider_model = deepseek_model_name(model);
+        let mut ocr_data = ocr_data_from_content(content.clone(), usage.clone(), &provider_model);
 
         if !ocr_data.get("pages").is_some_and(Value::is_array) {
             ocr_data = json!({
@@ -309,7 +310,7 @@ impl OcrProviderConfig for VertexAiDeepSeekOcrConfig {
                         other => other.to_string(),
                     }
                 }],
-                "model": ocr_data.get("model").and_then(Value::as_str).unwrap_or(model),
+                "model": ocr_data.get("model").and_then(Value::as_str).unwrap_or(&provider_model),
                 "usage_info": ocr_data.get("usage_info").cloned().or(usage).unwrap_or_else(|| json!({})),
             });
         }
@@ -332,7 +333,7 @@ impl OcrProviderConfig for VertexAiDeepSeekOcrConfig {
             model: object
                 .get("model")
                 .and_then(Value::as_str)
-                .unwrap_or(model)
+                .unwrap_or(&provider_model)
                 .to_string(),
             document_annotation: object.get("document_annotation").cloned(),
             usage_info,
@@ -429,7 +430,7 @@ mod tests {
             response.pages,
             vec![json!({"index": 0, "markdown": "# OCR text"})]
         );
-        assert_eq!(response.model, "deepseek-ocr-maas");
+        assert_eq!(response.model, "deepseek-ai/deepseek-ocr-maas");
         assert_eq!(response.usage_info, Some(json!({"prompt_tokens": 1})));
     }
 }

--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -133,6 +133,7 @@ if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import (
         Logging as LitellmLoggingObject,
     )
+    from litellm.llms.base_llm.ocr.transformation import OCRUsageInfo
 else:
     LitellmLoggingObject = Any
 
@@ -1871,6 +1872,23 @@ def response_cost_calculator(
         raise e
 
 
+def _ocr_token_cost(usage_info: "OCRUsageInfo", model_info: ModelInfo | None) -> tuple[float, float] | None:
+    if model_info is None:
+        return None
+    input_cost_per_token: Final = model_info.get("input_cost_per_token") or 0.0
+    output_cost_per_token: Final = model_info.get("output_cost_per_token") or 0.0
+    if input_cost_per_token == 0.0 and output_cost_per_token == 0.0:
+        return None
+    token_counts: Final = usage_info.model_extra
+    if token_counts is None:
+        return None
+    prompt_tokens: Final = token_counts.get("prompt_tokens")
+    completion_tokens: Final = token_counts.get("completion_tokens")
+    if not isinstance(prompt_tokens, int) or not isinstance(completion_tokens, int):
+        return None
+    return prompt_tokens * input_cost_per_token, completion_tokens * output_cost_per_token
+
+
 def ocr_cost(
     model: str,
     custom_llm_provider: str | None,
@@ -1883,9 +1901,7 @@ def ocr_cost(
         response: Optional[Any] - response object
 
     Returns:
-        Tuple[float, float]: cost of OCR processing
-
-        (Parent function requires a tuple, so we return a tuple. Cost is only in the first element.)
+        Tuple[float, float]: (prompt cost, completion cost) when priced per token, otherwise the page cost in the first element
     """
     from litellm.llms.base_llm.ocr.transformation import OCRResponse
 
@@ -1917,6 +1933,12 @@ def ocr_cost(
     pages_processed: Final = response.usage_info.pages_processed
     annotation_pages: Final = response.usage_info.pages_processed_annotation or 0
     has_billable_annotation_pages: Final = annotation_rate is not None and annotation_pages > 0
+    has_page_pricing: Final = (
+        pages_processed is not None and ocr_cost_per_page is not None
+    ) or has_billable_annotation_pages
+    token_cost: Final = _ocr_token_cost(response.usage_info, model_info)
+    if not has_page_pricing and token_cost is not None:
+        return token_cost
 
     if pages_processed is None and not has_billable_annotation_pages:
         if cost_per_credit is not None or ocr_cost_per_page is None:

--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -1901,7 +1901,8 @@ def ocr_cost(
         response: Optional[Any] - response object
 
     Returns:
-        Tuple[float, float]: (prompt cost, completion cost) when priced per token, otherwise the page cost in the first element
+        Tuple[float, float]: (prompt cost, completion cost) when priced per token,
+        otherwise the page cost in the first element
     """
     from litellm.llms.base_llm.ocr.transformation import OCRResponse
 

--- a/litellm/llms/vertex_ai/ocr/deepseek_transformation.py
+++ b/litellm/llms/vertex_ai/ocr/deepseek_transformation.py
@@ -26,6 +26,10 @@ else:
     LiteLLMLoggingObj = Any
 
 
+def _provider_model_name(model: str) -> str:
+    return model if model.startswith("deepseek-ai/") else f"deepseek-ai/{model}"
+
+
 class VertexAIDeepSeekOCRConfig(BaseOCRConfig):
     """
     Vertex AI DeepSeek OCR transformation configuration.
@@ -177,7 +181,7 @@ class VertexAIDeepSeekOCRConfig(BaseOCRConfig):
             content_item = {"type": "image_url", "image_url": document_url}
 
         # Build DeepSeek OCR request
-        provider_model: Final = model if model.startswith("deepseek-ai/") else f"deepseek-ai/{model}"
+        provider_model: Final = _provider_model_name(model)
         data: Final = {
             "model": provider_model,
             "messages": [{"role": "user", "content": [content_item]}],
@@ -261,6 +265,7 @@ class VertexAIDeepSeekOCRConfig(BaseOCRConfig):
         """
         verbose_logger.debug("Vertex AI DeepSeek OCR transform_ocr_response called")
         verbose_logger.debug("Raw response: %s", raw_response.text)
+        provider_model: Final = _provider_model_name(model)
 
         try:
             response_json: Final = raw_response.json()
@@ -288,14 +293,14 @@ class VertexAIDeepSeekOCRConfig(BaseOCRConfig):
                     # If content is markdown text, create a single page with the markdown
                     ocr_data = {
                         "pages": [{"index": 0, "markdown": content}],
-                        "model": model,
+                        "model": provider_model,
                         "usage_info": response_json.get("usage", {}),
                     }
             except json.JSONDecodeError:
                 # If JSON parsing fails, treat content as markdown
                 ocr_data = {
                     "pages": [{"index": 0, "markdown": content}],
-                    "model": model,
+                    "model": provider_model,
                     "usage_info": response_json.get("usage", {}),
                 }
 
@@ -309,7 +314,7 @@ class VertexAIDeepSeekOCRConfig(BaseOCRConfig):
                             "markdown": (content if isinstance(content, str) else json.dumps(content)),
                         }
                     ],
-                    "model": ocr_data.get("model", model),
+                    "model": ocr_data.get("model", provider_model),
                     "usage_info": ocr_data.get("usage_info", response_json.get("usage", {})),
                 }
 
@@ -339,7 +344,7 @@ class VertexAIDeepSeekOCRConfig(BaseOCRConfig):
 
             return OCRResponse(
                 pages=pages,
-                model=ocr_data.get("model", model),
+                model=ocr_data.get("model", provider_model),
                 document_annotation=ocr_data.get("document_annotation"),
                 usage_info=usage_info,
                 object="ocr",

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -45806,7 +45806,6 @@
         "mode": "ocr",
         "input_cost_per_token": 3e-07,
         "output_cost_per_token": 1.2e-06,
-        "ocr_cost_per_page": 0.0003,
         "source": "https://cloud.google.com/vertex-ai/pricing",
         "supported_regions": [
             "us-central1"

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -45806,7 +45806,6 @@
         "mode": "ocr",
         "input_cost_per_token": 3e-07,
         "output_cost_per_token": 1.2e-06,
-        "ocr_cost_per_page": 0.0003,
         "source": "https://cloud.google.com/vertex-ai/pricing",
         "supported_regions": [
             "us-central1"

--- a/tests/test_litellm/llms/vertex_ai/ocr/test_deepseek_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/ocr/test_deepseek_transformation.py
@@ -1,0 +1,67 @@
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from litellm.cost_calculator import completion_cost
+from litellm.llms.vertex_ai.ocr.deepseek_transformation import VertexAIDeepSeekOCRConfig
+
+PROMPT_TOKENS = 901
+COMPLETION_TOKENS = 212
+INPUT_COST_PER_TOKEN = 3e-07
+OUTPUT_COST_PER_TOKEN = 1.2e-06
+
+
+def _deepseek_chat_response() -> httpx.Response:
+    return httpx.Response(
+        status_code=200,
+        json={
+            "choices": [{"message": {"role": "assistant", "content": "# OCR text"}}],
+            "usage": {
+                "prompt_tokens": PROMPT_TOKENS,
+                "completion_tokens": COMPLETION_TOKENS,
+                "total_tokens": PROMPT_TOKENS + COMPLETION_TOKENS,
+            },
+        },
+        request=httpx.Request("POST", "https://us-central1-aiplatform.googleapis.com"),
+    )
+
+
+@pytest.mark.parametrize("model", ["deepseek-ocr-maas", "deepseek-ai/deepseek-ocr-maas"])
+def test_response_is_priced_from_token_usage_for_either_model_name(local_model_cost_map: None, model: str) -> None:
+    response = VertexAIDeepSeekOCRConfig().transform_ocr_response(
+        model=model,
+        raw_response=_deepseek_chat_response(),
+        logging_obj=MagicMock(),
+    )
+
+    cost = completion_cost(
+        completion_response=response,
+        model=f"vertex_ai/{model}",
+        custom_llm_provider="vertex_ai",
+        call_type="ocr",
+    )
+
+    assert response.model == "deepseek-ai/deepseek-ocr-maas"
+    assert cost == pytest.approx(PROMPT_TOKENS * INPUT_COST_PER_TOKEN + COMPLETION_TOKENS * OUTPUT_COST_PER_TOKEN)
+    assert cost > 0
+
+
+def test_json_content_without_pages_reports_the_canonical_model(local_model_cost_map: None) -> None:
+    raw_response = httpx.Response(
+        200,
+        json={
+            "choices": [{"message": {"role": "assistant", "content": '{"text": "# OCR text"}'}}],
+            "usage": {"prompt_tokens": PROMPT_TOKENS, "completion_tokens": COMPLETION_TOKENS},
+        },
+        request=httpx.Request("POST", "https://example.invalid"),
+    )
+
+    response = VertexAIDeepSeekOCRConfig().transform_ocr_response(
+        model="deepseek-ocr-maas",
+        raw_response=raw_response,
+        logging_obj=MagicMock(),
+    )
+
+    assert response.model == "deepseek-ai/deepseek-ocr-maas"
+    assert response.pages[0].markdown == '{"text": "# OCR text"}'

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -10,12 +10,14 @@ from pydantic import BaseModel
 import litellm
 from litellm.cost_calculator import (
     BaseTokenUsageProcessor,
-    RealtimeAPITokenUsageProcessor,
     completion_cost,
     cost_per_token,
     handle_realtime_stream_cost_calculation,
+    ocr_cost,
+    RealtimeAPITokenUsageProcessor,
     response_cost_calculator,
 )
+from litellm.llms.base_llm.ocr.transformation import OCRPage, OCRResponse, OCRUsageInfo
 from litellm.types.llms.openai import OpenAIRealtimeStreamList
 from litellm.types.utils import (
     CacheCreationTokenDetails,
@@ -4473,3 +4475,100 @@ def test_explicit_pricing_precedes_private_provider_response_model(
     )
 
     assert selected == expected
+
+
+def test_ocr_cost_prices_token_usage_when_pages_are_not_reported(_local_model_cost_map):
+    response = OCRResponse(
+        pages=[OCRPage(index=0, markdown="# OCR text")],
+        model="vertex_ai/deepseek-ai/deepseek-ocr-maas",
+        usage_info=OCRUsageInfo.model_validate({"prompt_tokens": 901, "completion_tokens": 278, "total_tokens": 1179}),
+    )
+
+    cost = completion_cost(
+        completion_response=response,
+        model="vertex_ai/deepseek-ai/deepseek-ocr-maas",
+        custom_llm_provider="vertex_ai",
+        call_type="ocr",
+    )
+
+    assert cost == pytest.approx(901 * 3e-07 + 278 * 1.2e-06)
+
+
+def test_ocr_cost_does_not_price_tokens_for_page_priced_models(_local_model_cost_map):
+    response = OCRResponse(
+        pages=[OCRPage(index=0, markdown="# OCR text")],
+        model="mistral/mistral-ocr-latest",
+        usage_info=OCRUsageInfo.model_validate({"prompt_tokens": 901, "completion_tokens": 278}),
+    )
+
+    with pytest.raises(ValueError, match="pages_processed is None"):
+        completion_cost(
+            completion_response=response,
+            model="mistral/mistral-ocr-latest",
+            custom_llm_provider="mistral",
+            call_type="ocr",
+        )
+
+
+def test_ocr_cost_prefers_page_pricing_when_pages_are_reported(_local_model_cost_map, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setitem(
+        litellm.model_cost,
+        "vertex_ai/page-and-token-ocr",
+        {
+            "mode": "ocr",
+            "litellm_provider": "vertex_ai",
+            "input_cost_per_token": 3e-07,
+            "output_cost_per_token": 1.2e-06,
+            "ocr_cost_per_page": 0.001,
+        },
+    )
+    response = OCRResponse(
+        pages=[OCRPage(index=0, markdown="# OCR text")],
+        model="vertex_ai/page-and-token-ocr",
+        usage_info=OCRUsageInfo.model_validate(
+            {"pages_processed": 2, "prompt_tokens": 901, "completion_tokens": 278}
+        ),
+    )
+
+    cost = completion_cost(
+        completion_response=response,
+        model="vertex_ai/page-and-token-ocr",
+        custom_llm_provider="vertex_ai",
+        call_type="ocr",
+    )
+
+    assert cost == pytest.approx(2 * 0.001)
+
+
+def test_ocr_cost_splits_token_cost_into_prompt_and_completion(_local_model_cost_map):
+    response = OCRResponse(
+        pages=[OCRPage(index=0, markdown="# OCR text")],
+        model="vertex_ai/deepseek-ai/deepseek-ocr-maas",
+        usage_info=OCRUsageInfo.model_validate({"prompt_tokens": 901, "completion_tokens": 278}),
+    )
+
+    prompt_cost, completion_cost_value = ocr_cost(
+        model="vertex_ai/deepseek-ai/deepseek-ocr-maas",
+        custom_llm_provider="vertex_ai",
+        response=response,
+    )
+
+    assert prompt_cost == pytest.approx(901 * 3e-07)
+    assert completion_cost_value == pytest.approx(278 * 1.2e-06)
+
+
+def test_ocr_cost_stays_zero_when_token_priced_response_lacks_token_counts(_local_model_cost_map):
+    response = OCRResponse(
+        pages=[OCRPage(index=0, markdown="# OCR text")],
+        model="vertex_ai/deepseek-ai/deepseek-ocr-maas",
+        usage_info=OCRUsageInfo(),
+    )
+
+    cost = completion_cost(
+        completion_response=response,
+        model="vertex_ai/deepseek-ai/deepseek-ocr-maas",
+        custom_llm_provider="vertex_ai",
+        call_type="ocr",
+    )
+
+    assert cost == 0.0


### PR DESCRIPTION
## TLDR

Problem this solves:

- Vertex AI DeepSeek OCR responses report tokens, never pages, so they were never priced
- Cost-map name `vertex_ai/deepseek-ai/deepseek-ocr-maas`: no `x-litellm-response-cost` header at all
- Short name `vertex_ai/deepseek-ocr-maas`: cost 0.0 in the headers and $0 in the spend logs

How it solves it:

- OCR cost falls back to token pricing when the model has token rates and reports no pages
- The DeepSeek OCR response carries the `deepseek-ai/` model name, so the short deployment name finds its price
- Drop the unsourced `ocr_cost_per_page` from the DeepSeek entry: Google bills DeepSeek-OCR on Vertex per token
- The Rust OCR port reports the same `deepseek-ai/` response model

## User Flow

Before: a developer OCRs an image through the gateway's Vertex AI DeepSeek OCR deployment and the request is never priced, so the logs page and key spend stay at $0

1. They send POST https://litellm-domain/v1/ocr with `{"model": "vertex_ai/deepseek-ai/deepseek-ocr-maas", "document": {"type": "image_url", "image_url": "data:image/png;base64,..."}}`
2. 200 OK comes back with the OCR markdown and `usage_info` reporting `prompt_tokens: 901`, `completion_tokens: 1057`, `pages_processed: null`, but no `x-litellm-response-cost` header at all and `x-litellm-key-spend: 0.0`
3. They send the same POST with `"model": "vertex_ai/deepseek-ocr-maas"`, the short name their admin deployed
4. 200 OK again with the same kind of markdown and token counts, this time with every `x-litellm-response-cost-*` breakdown header at `0.0` and `x-litellm-key-spend: 0.0`
5. They open https://litellm-domain/ui/?page=logs (or GET https://litellm-domain/spend/logs?request_id=...) and both requests sit at `spend: 0.0`, so the usage page and the key's budget never move

After: the same two requests come back priced from Google's published per-token DeepSeek-OCR rates, and the spend shows up in the logs

1. They send POST https://litellm-domain/v1/ocr with `{"model": "vertex_ai/deepseek-ai/deepseek-ocr-maas", "document": {"type": "image_url", "image_url": "data:image/png;base64,..."}}`
2. 200 OK comes back with the OCR markdown and the same kind of token counts, now with `x-litellm-response-cost: 0.0003879` (901 prompt tokens at $0.30 per 1M plus 98 completion tokens at $1.20 per 1M), `x-litellm-response-cost-input: 0.0002703`, `x-litellm-response-cost-output: 0.0001176`, and `x-litellm-key-spend` moving by the same amount
3. They send the same POST with `"model": "vertex_ai/deepseek-ocr-maas"`
4. 200 OK again, now with `x-litellm-response-cost: 0.0007143` for 901 prompt and 370 completion tokens
5. They open https://litellm-domain/ui/?page=logs (or GET https://litellm-domain/spend/logs?request_id=...) and both requests show that same non-zero spend

## Relevant issues

## Linear ticket

Resolves LIT-6727

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Setup shared by both legs: a proxy booted with `--num_workers 2` on a fresh Postgres database, `VERTEX_AI_API_KEY` set to a `gcloud auth print-access-token` value, and this config

```yaml
model_list:
  - model_name: vertex_ai/deepseek-ai/deepseek-ocr-maas
    litellm_params:
      model: vertex_ai/deepseek-ai/deepseek-ocr-maas
      vertex_project: <project>
      vertex_location: us-central1
      api_key: os.environ/VERTEX_AI_API_KEY
  - model_name: vertex_ai/deepseek-ocr-maas
    litellm_params:
      model: vertex_ai/deepseek-ocr-maas
      vertex_project: <project>
      vertex_location: us-central1
      api_key: os.environ/VERTEX_AI_API_KEY
general_settings:
  master_key: sk-1234
```

The same loop runs on both legs against a 100 KB PNG of a rendered text page, then reads each request back through the spend logs API

```bash
b64=$(base64 -i ocr-input.png | tr -d '\n')
for M in vertex_ai/deepseek-ai/deepseek-ocr-maas vertex_ai/deepseek-ocr-maas; do
  printf '{"model": "%s", "document": {"type": "image_url", "image_url": "data:image/png;base64,%s"}}' "$M" "$b64" > ocr.json
  echo "== POST /v1/ocr model=$M"
  curl -s -D headers.txt -o body.json -X POST http://localhost:4000/v1/ocr -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" --data-binary @ocr.json
  grep -i "^HTTP\|x-litellm-response-cost\|x-litellm-key-spend\|x-litellm-call-id" headers.txt
  python3 -c "import json; d=json.load(open('body.json')); u=d['usage_info']; print(d['model'], {k: u.get(k) for k in ('pages_processed', 'prompt_tokens', 'completion_tokens')})"
done
sleep 12
for id in <the two x-litellm-call-id values>; do
  echo "== GET /spend/logs?request_id=$id"
  curl -s "http://localhost:4000/spend/logs?request_id=$id" -H "Authorization: Bearer sk-1234" | python3 -c "import json, sys; print([{k: r.get(k) for k in ('model', 'spend', 'prompt_tokens', 'completion_tokens', 'call_type')} for r in json.load(sys.stdin)])"
done
```

### Before (ba2e5d2d8e)

#### Cost-map name vertex_ai/deepseek-ai/deepseek-ocr-maas

1. `POST /v1/ocr`, no `x-litellm-response-cost` header at all
   ```
   HTTP/1.1 200 OK
   x-litellm-call-id: 89c64bc3-0ca3-4107-a8a1-74ed37e7aee6
   x-litellm-key-spend: 0.0
   vertex_ai/deepseek-ai/deepseek-ocr-maas {'pages_processed': None, 'prompt_tokens': 901, 'completion_tokens': 1057}
   ```
2. `GET /spend/logs?request_id=89c64bc3-0ca3-4107-a8a1-74ed37e7aee6`
   ```
   [{'model': 'vertex_ai/deepseek-ai/deepseek-ocr-maas', 'spend': 0.0, 'prompt_tokens': 901, 'completion_tokens': 1057, 'call_type': 'aocr'}]
   ```

#### Short name vertex_ai/deepseek-ocr-maas

1. `POST /v1/ocr`, every cost breakdown header at 0.0
   ```
   HTTP/1.1 200 OK
   x-litellm-call-id: cfabd49d-847d-4adb-8f40-e92879d6fbc7
   x-litellm-response-cost-original: 0.0
   x-litellm-response-cost-discount-amount: 0.0
   x-litellm-response-cost-margin-amount: 0.0
   x-litellm-response-cost-margin-percent: 0.0
   x-litellm-response-cost-input: 0.0
   x-litellm-response-cost-output: 0.0
   x-litellm-response-cost-tool-usage: 0.0
   x-litellm-key-spend: 0.0
   vertex_ai/deepseek-ocr-maas {'pages_processed': None, 'prompt_tokens': 901, 'completion_tokens': 115}
   ```
2. `GET /spend/logs?request_id=cfabd49d-847d-4adb-8f40-e92879d6fbc7`
   ```
   [{'model': 'vertex_ai/deepseek-ocr-maas', 'spend': 0.0, 'prompt_tokens': 901, 'completion_tokens': 115, 'call_type': 'aocr'}]
   ```

### After (24299c3c5e)

Head is 4f99996b8e since this run: the only commit after 24299c3c5e wraps a docstring line in `litellm/cost_calculator.py`, which cannot change behavior

#### Cost-map name vertex_ai/deepseek-ai/deepseek-ocr-maas

1. `POST /v1/ocr`, priced at 901 x $0.30/1M + 98 x $1.20/1M
   ```
   HTTP/1.1 200 OK
   x-litellm-call-id: d6adfcce-77db-468d-9d81-ae90541ebc0a
   x-litellm-response-cost: 0.0003879
   x-litellm-response-cost-original: 0.0003879
   x-litellm-response-cost-discount-amount: 0.0
   x-litellm-response-cost-margin-amount: 0.0
   x-litellm-response-cost-margin-percent: 0.0
   x-litellm-response-cost-input: 0.0002703
   x-litellm-response-cost-output: 0.0001176
   x-litellm-response-cost-tool-usage: 0.0
   x-litellm-key-spend: 0.0003879
   vertex_ai/deepseek-ai/deepseek-ocr-maas {'pages_processed': None, 'prompt_tokens': 901, 'completion_tokens': 98}
   ```
2. `GET /spend/logs?request_id=d6adfcce-77db-468d-9d81-ae90541ebc0a`
   ```
   [{'model': 'vertex_ai/deepseek-ai/deepseek-ocr-maas', 'spend': 0.0003879, 'prompt_tokens': 901, 'completion_tokens': 98, 'call_type': 'aocr'}]
   ```

#### Short name vertex_ai/deepseek-ocr-maas

1. `POST /v1/ocr`, priced at 901 x $0.30/1M + 370 x $1.20/1M
   ```
   HTTP/1.1 200 OK
   x-litellm-call-id: 7af206e7-e2a2-456b-bc60-ef8029a9b8c3
   x-litellm-response-cost: 0.0007143
   x-litellm-response-cost-original: 0.0007143
   x-litellm-response-cost-discount-amount: 0.0
   x-litellm-response-cost-margin-amount: 0.0
   x-litellm-response-cost-margin-percent: 0.0
   x-litellm-response-cost-input: 0.0002703
   x-litellm-response-cost-output: 0.000444
   x-litellm-response-cost-tool-usage: 0.0
   x-litellm-key-spend: 0.0007143
   vertex_ai/deepseek-ocr-maas {'pages_processed': None, 'prompt_tokens': 901, 'completion_tokens': 370}
   ```
2. `GET /spend/logs?request_id=7af206e7-e2a2-456b-bc60-ef8029a9b8c3`
   ```
   [{'model': 'vertex_ai/deepseek-ocr-maas', 'spend': 0.0007143, 'prompt_tokens': 901, 'completion_tokens': 370, 'call_type': 'aocr'}]
   ```

QA notes, none caused or changed by this PR:

- Master key `x-litellm-key-spend` shows the request's own cost, not a running total
- Before leg's short name emits only the `-*` breakdown headers, no bare total
- The two legs got different completion token counts for the same image

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- Keys and teams near their budget now get 429s on DeepSeek OCR calls, since those calls are finally charged
  - Seen live: a key with `max_budget: 0.0002` made one OCR call, then its next one got `429 Budget has been exceeded`

### Low

- The OCR response's `model` field is now always `deepseek-ai/deepseek-ocr-maas`
  - Before, it was whatever Vertex echoed back, which was already that name in every run here
  - Proxy clients still see the name they requested, unless the deployment sets `return_raw_model_name`
- The Vertex OCR docs page still quotes a flat "$0.0005 per page" that never applied to DeepSeek; docs follow-up
- `x-litellm-response-cost` can carry float noise (`0.00041430000000000004`), the same formatting other providers' cost headers already have
- Reducto OCR and the Rust OCR path were not exercised live (no key, `litellm_rust` not installed); the page-priced branch was verified live with Mistral OCR and is unchanged

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 24299c3c5e passes /live-pr-risk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OCR spend calculation and enables non-zero charges for DeepSeek OCR (including budget 429s); page-priced OCR paths are preserved when pages are reported.
> 
> **Overview**
> Fixes **$0 spend** on Vertex AI DeepSeek OCR when responses report **token usage** but not **pages_processed**.
> 
> **OCR billing** now uses **`_ocr_token_cost`** in `ocr_cost`: if the model has no applicable per-page (or annotation) pricing but has `input_cost_per_token` / `output_cost_per_token` and integer `prompt_tokens` / `completion_tokens`, cost is computed from tokens. **Page-based pricing still wins** when `pages_processed` and `ocr_cost_per_page` apply (e.g. Mistral OCR).
> 
> **DeepSeek OCR responses** (Python and Rust) normalize the returned **`model`** to the canonical **`deepseek-ai/deepseek-ocr-maas`** via `_provider_model_name` / `deepseek_model_name`, so short deployment names still match the cost map. The **`vertex_ai/deepseek-ai/deepseek-ocr-maas`** entry drops the unsourced **`ocr_cost_per_page`** so billing aligns with Google’s per-token rates.
> 
> Tests cover token fallback, page-priority, and end-to-end pricing for both model name forms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f99996b8e799a39c8ebc8d0691e13b817e51e07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->