### PR TITLE
feat(azure_ai): add Nemotron 3.5 Lightning pricing

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -9611,6 +9611,30 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
+    "azure_ai/FW-Nemotron-Lightning-3.5-30B-A3B": {
+        "deprecation_date": "2027-08-23",
+        "cache_read_input_token_cost": 1e-08,
+        "input_cost_per_token": 6e-08,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "output_cost_per_token": 2.2e-07,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": false
+    },
     "azure_ai/FW-Nemotron-3-Ultra-NVFP4": {
         "cache_read_input_token_cost": 1.19e-07,
         "input_cost_per_token": 6e-07,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -9611,6 +9611,30 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
+    "azure_ai/FW-Nemotron-Lightning-3.5-30B-A3B": {
+        "deprecation_date": "2027-08-23",
+        "cache_read_input_token_cost": 1e-08,
+        "input_cost_per_token": 6e-08,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "output_cost_per_token": 2.2e-07,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": false
+    },
     "azure_ai/FW-Nemotron-3-Ultra-NVFP4": {
         "cache_read_input_token_cost": 1.19e-07,
         "input_cost_per_token": 6e-07,

--- a/tests/test_litellm/llms/azure_ai/test_azure_ai_fw_models_metadata.py
+++ b/tests/test_litellm/llms/azure_ai/test_azure_ai_fw_models_metadata.py
@@ -81,6 +81,16 @@ FW_MODELS = {
         "max_input_tokens": 1000000,
         "max_output_tokens": 1000000,
     },
+    "azure_ai/FW-Nemotron-Lightning-3.5-30B-A3B": {
+        "input_cost_per_token": 6e-08,
+        "output_cost_per_token": 2.2e-07,
+        "cache_read_input_token_cost": 1e-08,
+        "max_input_tokens": 262144,
+        "max_output_tokens": 32768,
+        "deprecation_date": "2027-08-23",
+        "supports_response_schema": True,
+        "supports_vision": False,
+    },
     "azure_ai/FW-Nemotron-3-Ultra-NVFP4": {
         "input_cost_per_token": 6e-07,
         "output_cost_per_token": 2.4e-06,
@@ -162,8 +172,15 @@ def test_azure_ai_fw_model_info(use_local_model_cost_map, model_key, expected):
     assert model_info["supports_reasoning"] is True
     assert model_info["supports_tool_choice"] is True
     assert model_info["supports_prompt_caching"] is True
-    if expected.get("supports_vision"):
-        assert model_info["supports_vision"] is True
+    if "supports_vision" in expected:
+        assert model_info.get("supports_vision", False) is expected["supports_vision"]
+    if "deprecation_date" in expected:
+        assert (
+            use_local_model_cost_map.model_cost[model_key]["deprecation_date"]
+            == expected["deprecation_date"]
+        )
+    if "supports_response_schema" in expected:
+        assert model_info["supports_response_schema"] is expected["supports_response_schema"]
 
 
 @pytest.mark.parametrize(
@@ -175,6 +192,7 @@ def test_azure_ai_fw_model_info(use_local_model_cost_map, model_key, expected):
         ("FW-Kimi-K3", 3.3, 16.5),
         ("FW-MiniMax-M2.5", 0.33, 1.32),
         ("FW-Inkling", 1.0, 4.05),
+        ("FW-Nemotron-Lightning-3.5-30B-A3B", 0.06, 0.22),
         ("FW-Nemotron-3-Ultra-NVFP4", 0.6, 2.4),
     ],
 )
@@ -194,6 +212,16 @@ def test_azure_ai_fw_cost_per_token(
 
     assert prompt_cost == pytest.approx(expected_prompt)
     assert completion_cost == pytest.approx(expected_completion)
+
+
+def test_azure_ai_fw_nemotron_lightning_supports_tool_choice(use_local_model_cost_map):
+    from litellm.llms.azure_ai.chat.transformation import AzureAIStudioConfig
+
+    supported_params = AzureAIStudioConfig().get_supported_openai_params(
+        "FW-Nemotron-Lightning-3.5-30B-A3B"
+    )
+
+    assert "tool_choice" in supported_params
 
 
 def test_azure_ai_fw_kimi_k26_case_insensitive_lookup(use_local_model_cost_map):


### PR DESCRIPTION
## TLDR

Problem this solves:

- Azure Nemotron Lightning metadata is missing
- Azure usage cannot use its published token prices

How it solves it:

- Adds the exact Azure Foundry model key
- Adds pricing, limits, capabilities, and deprecation metadata
- Tests model lookup, tool choice, and cost calculation

## User Flow

Before: a developer can configure the Azure deployment, but LiteLLM cannot identify its capabilities or Azure price

1. The proxy admin configures `azure_ai/FW-Nemotron-Lightning-3.5-30B-A3B`
2. The developer sends POST http://localhost:4000/v1/chat/completions with required tool choice
3. LiteLLM treats the model as unmapped and cannot apply its Azure token rates

After: the same deployment is recognized with its supported capabilities and Azure price

1. The proxy admin configures `azure_ai/FW-Nemotron-Lightning-3.5-30B-A3B`
2. The developer sends POST http://localhost:4000/v1/chat/completions with required tool choice
3. LiteLLM accepts tool choice and calculates input, cached-input, and output spend using the published Azure rates

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

Live requests were sent to two standard Azure AI deployments and one development gateway. Hostnames, prompts, and bearer tokens are redacted

Direct Azure AI request:

```bash
curl --silent --show-error --write-out "\nHTTP %{http_code}\n" \
  --request POST \
  "https://<azure-ai-host>/models/chat/completions?api-version=2024-05-01-preview" \
  --header "Authorization: Bearer <redacted>" \
  --header "Content-Type: application/json" \
  --data '{"model":"FW-Nemotron-Lightning-3.5-30B-A3B","messages":[{"role":"user","content":"<test prompt>"}],"max_tokens":16}'
```

Gateway request:

```bash
curl --silent --show-error --write-out "\nHTTP %{http_code}\n" \
  --request POST \
  "https://<development-gateway>/v1/chat/completions" \
  --header "Authorization: Bearer <redacted>" \
  --header "Content-Type: application/json" \
  --data '{"model":"nemotron-lightning-3.5-30b-a3b","messages":[{"role":"user","content":"<test prompt>"}],"max_tokens":16}'
```

### Before (1bb9b175e2)

1. The exact model was absent from the LiteLLM catalog
2. LiteLLM could not identify its capabilities or calculate spend with its Azure token rates

### After (6ad137f11f)

#### South Central US deployment

1. Send the direct Azure AI request to the South Central US deployment
2. Observe `HTTP 200`

#### West US deployment

1. Send the direct Azure AI request to the West US deployment
2. Observe `HTTP 200`

#### Development gateway

1. Send the gateway request using logical model `nemotron-lightning-3.5-30b-a3b`
2. Observe `HTTP 200`

## Type

New Feature
Test

## Caveats (if any)

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
