### PR TITLE
feat(guardrails): add Airia guardrail integration

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/airia/__init__.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/airia/__init__.py
@@ -1,0 +1,32 @@
+from typing import TYPE_CHECKING, Final
+
+from litellm.proxy.guardrails.guardrail_hooks.airia.airia import AiriaGuardrail
+from litellm.types.guardrails import SupportedGuardrailIntegrations
+
+if TYPE_CHECKING:
+    from litellm.types.guardrails import Guardrail, LitellmParams
+
+
+def initialize_guardrail(litellm_params: "LitellmParams", guardrail: "Guardrail") -> AiriaGuardrail:
+    import litellm
+
+    _airia_callback: Final = AiriaGuardrail(
+        api_base=litellm_params.api_base,
+        api_key=litellm_params.api_key,
+        timeout=litellm_params.timeout,
+        guardrail_name=guardrail.get("guardrail_name", ""),
+        event_hook=litellm_params.mode,
+        default_on=litellm_params.default_on,
+    )
+    litellm.logging_callback_manager.add_litellm_callback(_airia_callback)
+
+    return _airia_callback
+
+
+guardrail_initializer_registry: Final = {  # mutable-ok: module-level registry, built once and never mutated
+    SupportedGuardrailIntegrations.AIRIA.value: initialize_guardrail,
+}
+
+guardrail_class_registry: Final = {  # mutable-ok: module-level registry, built once and never mutated
+    SupportedGuardrailIntegrations.AIRIA.value: AiriaGuardrail,
+}

--- a/litellm/proxy/guardrails/guardrail_hooks/airia/airia.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/airia/airia.py
@@ -1,0 +1,169 @@
+import os
+import uuid
+from typing import (
+    TYPE_CHECKING,
+    Any,  # noqa: TID251  # **kwargs forwards verbatim to CustomGuardrail.__init__; see ruff-strict.toml
+    Final,
+    Literal,
+)
+
+import httpx
+
+from litellm._logging import verbose_proxy_logger
+from litellm.exceptions import GuardrailRaisedException
+from litellm.integrations.custom_guardrail import (
+    CustomGuardrail,
+    log_guardrail_information,
+)
+from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+from litellm.llms.custom_httpx.http_handler import (
+    get_async_httpx_client,
+    httpxSpecialProvider,
+)
+from litellm.types.guardrails import GuardrailEventHooks
+from litellm.types.utils import GenericGuardrailAPIInputs
+
+if TYPE_CHECKING:
+    from litellm.types.proxy.guardrails.guardrail_hooks.base import GuardrailConfigModel
+
+GUARDRAIL_PATH: Final = "/v1/guardrails/litellm"
+
+ACTION_NONE: Final = "NONE"
+ACTION_BLOCKED: Final = "BLOCKED"
+ACTION_INTERVENED: Final = "GUARDRAIL_INTERVENED"
+
+DEFAULT_BLOCKED_MESSAGE: Final = "Blocked by your organization's content policy."
+
+SUPPORTED_EVENT_HOOKS: Final = (GuardrailEventHooks.pre_call, GuardrailEventHooks.post_call)
+
+
+class AiriaGuardrail(CustomGuardrail):
+    """Evaluates prompts and responses against your Airia guardrail policy."""
+
+    def __init__(
+        self,
+        api_base: str | None = None,
+        api_key: str | None = None,
+        timeout: float | None = None,
+        supported_event_hooks: list[GuardrailEventHooks] | None = None,  # mutable-ok: matches CustomGuardrail.__init__
+        **kwargs: Any,  # kwargs-ok: forwarded verbatim to CustomGuardrail.__init__, whose param list is wide and evolving
+    ) -> None:
+        resolved_timeout: Final = timeout or float(os.getenv("AIRIA_TIMEOUT", "10"))
+
+        self.async_handler = get_async_httpx_client(
+            llm_provider=httpxSpecialProvider.GuardrailCallback,
+            params={"timeout": httpx.Timeout(timeout=resolved_timeout, connect=5.0)},  # mutable-ok: one-shot params
+        )
+
+        self.api_base = (api_base or os.getenv("AIRIA_GATEWAY_URL", "")).rstrip("/")
+        self.api_key = api_key or os.getenv("AIRIA_API_KEY")
+        self.streaming_transform_mode: Final[Literal["block_only", "incremental_diff"]] = "incremental_diff"
+        self.streaming_end_of_stream_only: Final = True
+
+        if not self.api_base:
+            raise ValueError("AiriaGuardrail requires api_base, or the AIRIA_GATEWAY_URL environment variable.")
+        if not self.api_key:
+            raise ValueError("AiriaGuardrail requires api_key, or the AIRIA_API_KEY environment variable.")
+
+        self.optional_params = kwargs
+        super().__init__(
+            supported_event_hooks=supported_event_hooks or [*SUPPORTED_EVENT_HOOKS],  # mutable-ok: base needs a list
+            **kwargs,
+        )
+        verbose_proxy_logger.info("AiriaGuardrail initialized with gateway: %s", self.api_base)
+
+    @log_guardrail_information
+    async def apply_guardrail(
+        self,
+        inputs: GenericGuardrailAPIInputs,
+        request_data: dict[str, object],  # mutable-ok: overrides CustomGuardrail.apply_guardrail's plain-dict contract
+        input_type: Literal["request", "response"],
+        logging_obj: "LiteLLMLoggingObj | None" = None,
+    ) -> GenericGuardrailAPIInputs:
+        call_id: Final = (
+            logging_obj.litellm_call_id
+            if logging_obj
+            else (request_data.get("litellm_call_id") if request_data else None)
+        ) or str(uuid.uuid4())
+
+        try:
+            response: Final = await self.async_handler.post(
+                f"{self.api_base}{GUARDRAIL_PATH}",
+                json={  # mutable-ok: one-shot HTTP request body, never mutated after construction
+                    "input_type": input_type,
+                    "texts": inputs.get("texts") or (),
+                    "structured_messages": inputs.get("structured_messages") or (),
+                    "tools": inputs.get("tools") or (),
+                    "tool_calls": inputs.get("tool_calls") or (),
+                    "model": inputs.get("model"),
+                    "litellm_call_id": call_id,
+                },
+                headers={"Authorization": f"Bearer {self.api_key}"},  # mutable-ok: one-shot HTTP headers
+            )
+            response.raise_for_status()
+            body: Final = response.json()
+        except Exception as error:
+            verbose_proxy_logger.error(
+                "Airia guardrail could not evaluate the request (litellm_call_id=%s, input_type=%s): %s",
+                call_id,
+                input_type,
+                error,
+            )
+            raise GuardrailRaisedException(
+                guardrail_name=self.guardrail_name,
+                message=f"Airia guardrail could not evaluate the request: {error}",
+                blocked_content=False,
+            ) from error
+
+        action: Final = body.get("action")
+
+        if action == ACTION_BLOCKED:
+            raise GuardrailRaisedException(
+                guardrail_name=self.guardrail_name,
+                message=body.get("blocked_reason") or DEFAULT_BLOCKED_MESSAGE,
+                blocked_content=True,
+            )
+
+        if action == ACTION_INTERVENED:
+            return self._rewritten(body, inputs)
+
+        if action != ACTION_NONE:
+            raise self._blocked()
+
+        return inputs
+
+    def _rewritten(
+        self,
+        body: dict[str, object],  # mutable-ok: response.json() returns a plain dict
+        inputs: GenericGuardrailAPIInputs,
+    ) -> GenericGuardrailAPIInputs:
+        texts: Final = body.get("texts")
+        structured_messages: Final = body.get("structured_messages")
+        if texts is None and structured_messages is None:
+            raise self._blocked()
+        if not (texts is None or isinstance(texts, list)):
+            raise self._blocked()
+        if not (structured_messages is None or isinstance(structured_messages, list)):
+            raise self._blocked()
+
+        rewritten: Final[GenericGuardrailAPIInputs] = {**inputs}  # mutable-ok: fresh copy; caller's object untouched
+        if isinstance(texts, list):
+            rewritten["texts"] = texts
+        if isinstance(structured_messages, list):
+            rewritten["structured_messages"] = structured_messages
+        return rewritten
+
+    def _blocked(self) -> GuardrailRaisedException:
+        return GuardrailRaisedException(
+            guardrail_name=self.guardrail_name,
+            message=DEFAULT_BLOCKED_MESSAGE,
+            blocked_content=True,
+        )
+
+    @staticmethod
+    def get_config_model() -> type["GuardrailConfigModel"] | None:
+        from litellm.types.proxy.guardrails.guardrail_hooks.airia import (
+            AiriaGuardrailConfigModel,
+        )
+
+        return AiriaGuardrailConfigModel

--- a/litellm/types/guardrails.py
+++ b/litellm/types/guardrails.py
@@ -137,6 +137,7 @@ class SupportedGuardrailIntegrations(Enum):
     COMPRESR = "compresr"
     STRAIKER = "straiker"
     ALICE = "alice"
+    AIRIA = "airia"
 
 
 class Role(Enum):

--- a/litellm/types/proxy/guardrails/guardrail_hooks/airia.py
+++ b/litellm/types/proxy/guardrails/guardrail_hooks/airia.py
@@ -1,0 +1,24 @@
+from pydantic import Field
+
+from .base import GuardrailConfigModel
+
+
+class AiriaGuardrailConfigModel(GuardrailConfigModel):
+    api_base: str | None = Field(
+        default=None,
+        description="Base URL of the Airia AI Gateway, e.g. https://gateway.airia.ai. If not "
+        "provided, the `AIRIA_GATEWAY_URL` environment variable is checked.",
+    )
+    api_key: str | None = Field(
+        default=None,
+        description="An Airia API key. If not provided, the `AIRIA_API_KEY` environment variable is checked.",
+    )
+    timeout: float | None = Field(
+        default=None,
+        description="Request timeout in seconds. If not provided, the `AIRIA_TIMEOUT` environment "
+        "variable is checked, defaulting to 10.",
+    )
+
+    @staticmethod
+    def ui_friendly_name() -> str:
+        return "Airia Guardrail"

--- a/ruff-strict.toml
+++ b/ruff-strict.toml
@@ -30,6 +30,7 @@ external = [
 # grows over time; typing it concretely (`object`) broke that forwarding call outright —
 # basedpyright turned every named param into a reportArgumentType error. Any is correct here.
 "litellm/proxy/guardrails/guardrail_hooks/alice/alice.py" = ["ANN401"]
+"litellm/proxy/guardrails/guardrail_hooks/airia/airia.py" = ["ANN401"]
 
 [lint.mccabe]
 max-complexity = 15

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_airia.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_airia.py
@@ -1,0 +1,366 @@
+import uuid
+from typing import Literal, cast
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+import litellm
+from litellm.exceptions import GuardrailRaisedException
+from litellm.proxy.guardrails.guardrail_hooks.airia.airia import AiriaGuardrail
+from litellm.proxy.guardrails.init_guardrails import init_guardrails_v2
+from litellm.types.guardrails import GuardrailEventHooks
+from litellm.types.proxy.guardrails.guardrail_hooks.airia import AiriaGuardrailConfigModel
+from litellm.types.utils import GenericGuardrailAPIInputs
+
+API_BASE = "https://gateway.airia.ai"
+API_KEY = "ak-test-key"
+
+
+def _make_guardrail(**kwargs) -> AiriaGuardrail:
+    """Build a guardrail; tests replace `async_handler.post`, so no socket is ever opened."""
+    kwargs.setdefault("api_base", API_BASE)
+    kwargs.setdefault("api_key", API_KEY)
+    kwargs.setdefault("guardrail_name", "airia-guard")
+    return AiriaGuardrail(**kwargs)
+
+
+def _mock_response(payload: dict, status_code: int = 200) -> MagicMock:
+    response = MagicMock()
+    response.status_code = status_code
+    response.json.return_value = payload
+    response.raise_for_status = MagicMock()
+    return response
+
+
+def _inputs(**overrides: object) -> GenericGuardrailAPIInputs:
+    return cast(
+        GenericGuardrailAPIInputs, {"texts": ["hello"], "model": "gpt-4o", **overrides}
+    )  # cast-ok: test fixture
+
+
+def test_airia_guardrail_config(monkeypatch: pytest.MonkeyPatch):
+    """The guardrail registers through init_guardrails_v2 under the `airia` key."""
+    monkeypatch.setattr(litellm, "guardrail_name_config_map", {})
+    monkeypatch.setattr(litellm, "callbacks", [])
+    monkeypatch.setenv("AIRIA_GATEWAY_URL", API_BASE)
+    monkeypatch.setenv("AIRIA_API_KEY", API_KEY)
+
+    init_guardrails_v2(
+        all_guardrails=[
+            {
+                "guardrail_name": "airia-guard",
+                "litellm_params": {
+                    "guardrail": "airia",
+                    "mode": "pre_call",
+                    "default_on": True,
+                    "timeout": 45.0,
+                },
+            }
+        ],
+        config_file_path="",
+    )
+
+    registered = [c for c in litellm.callbacks if isinstance(c, AiriaGuardrail)]
+    assert len(registered) == 1
+    assert registered[0].guardrail_name == "airia-guard"
+    assert registered[0].default_on is True
+    assert registered[0].event_hook == "pre_call"
+    assert registered[0].async_handler.timeout.read == 45.0
+
+
+def test_during_call_is_not_a_supported_event_hook():
+    """during_call runs concurrently with the upstream call, so a block can land too late."""
+    hooks = _make_guardrail().supported_event_hooks
+
+    assert hooks is not None
+    assert GuardrailEventHooks.during_call not in hooks
+    assert list(hooks) == [GuardrailEventHooks.pre_call, GuardrailEventHooks.post_call]
+
+
+@pytest.mark.parametrize("missing", ["api_base", "api_key"])
+def test_missing_credentials_raise_at_construction(missing: str, monkeypatch: pytest.MonkeyPatch):
+    """Fail at startup rather than on the first request."""
+    monkeypatch.delenv("AIRIA_GATEWAY_URL", raising=False)
+    monkeypatch.delenv("AIRIA_API_KEY", raising=False)
+
+    kwargs = {"api_base": API_BASE, "api_key": API_KEY}
+    kwargs[missing] = None
+
+    with pytest.raises(ValueError, match="AiriaGuardrail requires"):
+        _make_guardrail(**kwargs)
+
+
+def test_credentials_fall_back_to_environment(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("AIRIA_GATEWAY_URL", API_BASE)
+    monkeypatch.setenv("AIRIA_API_KEY", API_KEY)
+
+    guardrail = _make_guardrail(api_base=None, api_key=None)
+
+    assert guardrail.api_base == API_BASE
+    assert guardrail.api_key == API_KEY
+
+
+def test_trailing_slash_is_stripped_from_api_base():
+    guardrail = _make_guardrail(api_base=f"{API_BASE}/")
+
+    assert guardrail.api_base == API_BASE
+
+
+def test_custom_timeout_from_kwargs():
+    guardrail = _make_guardrail(timeout=45.0)
+
+    assert guardrail.async_handler.timeout.read == 45.0
+    assert guardrail.async_handler.timeout.connect == 5.0
+
+
+def test_timeout_falls_back_to_environment(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("AIRIA_TIMEOUT", "30")
+
+    guardrail = _make_guardrail()
+
+    assert guardrail.async_handler.timeout.read == 30.0
+
+
+@pytest.mark.asyncio
+async def test_request_payload_and_auth_header():
+    guardrail = _make_guardrail()
+    guardrail.async_handler.post = AsyncMock(return_value=_mock_response({"action": "NONE"}))
+
+    inputs = _inputs(
+        structured_messages=[{"role": "user", "content": "hello"}],
+        tools=[{"type": "function", "function": {"name": "f"}}],
+        tool_calls=[{"id": "c1", "function": {"name": "f", "arguments": "{}"}}],
+    )
+    await guardrail.apply_guardrail(inputs=inputs, request_data={"litellm_call_id": "call-123"}, input_type="request")
+
+    call = guardrail.async_handler.post.call_args
+    assert call.args[0] == f"{API_BASE}/v1/guardrails/litellm"
+    assert call.kwargs["headers"] == {"Authorization": f"Bearer {API_KEY}"}
+
+    payload = call.kwargs["json"]
+    assert payload["input_type"] == "request"
+    assert payload["texts"] == ["hello"]
+    assert payload["structured_messages"] == [{"role": "user", "content": "hello"}]
+    assert payload["tools"] == [{"type": "function", "function": {"name": "f"}}]
+    assert payload["tool_calls"] == [{"id": "c1", "function": {"name": "f", "arguments": "{}"}}]
+    assert payload["model"] == "gpt-4o"
+    assert payload["litellm_call_id"] == "call-123"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("input_type", ["request", "response"])
+async def test_input_type_is_forwarded_verbatim(input_type: Literal["request", "response"]):
+    guardrail = _make_guardrail()
+    guardrail.async_handler.post = AsyncMock(return_value=_mock_response({"action": "NONE"}))
+
+    await guardrail.apply_guardrail(inputs=_inputs(), request_data={}, input_type=input_type)
+
+    assert guardrail.async_handler.post.call_args.kwargs["json"]["input_type"] == input_type
+
+
+@pytest.mark.asyncio
+async def test_call_id_falls_back_to_a_generated_uuid():
+    guardrail = _make_guardrail()
+    guardrail.async_handler.post = AsyncMock(return_value=_mock_response({"action": "NONE"}))
+
+    await guardrail.apply_guardrail(inputs=_inputs(), request_data={}, input_type="request")
+
+    call_id = guardrail.async_handler.post.call_args.kwargs["json"]["litellm_call_id"]
+    assert uuid.UUID(call_id).version == 4
+
+
+@pytest.mark.asyncio
+async def test_action_none_returns_inputs_unchanged():
+    guardrail = _make_guardrail()
+    guardrail.async_handler.post = AsyncMock(return_value=_mock_response({"action": "NONE"}))
+    inputs = _inputs(structured_messages=[{"role": "user", "content": "hello"}])
+
+    result = await guardrail.apply_guardrail(inputs=inputs, request_data={}, input_type="request")
+
+    assert result["texts"] == ["hello"]
+    assert result["structured_messages"] == [{"role": "user", "content": "hello"}]
+
+
+@pytest.mark.asyncio
+async def test_action_blocked_raises_with_blocked_content_set():
+    guardrail = _make_guardrail()
+    guardrail.async_handler.post = AsyncMock(
+        return_value=_mock_response({"action": "BLOCKED", "blocked_reason": "Contains a secret"})
+    )
+
+    with pytest.raises(GuardrailRaisedException) as excinfo:
+        await guardrail.apply_guardrail(inputs=_inputs(), request_data={}, input_type="request")
+
+    assert excinfo.value.blocked_content is True
+    assert "Contains a secret" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_action_blocked_without_a_reason_uses_the_default_message():
+    guardrail = _make_guardrail()
+    guardrail.async_handler.post = AsyncMock(return_value=_mock_response({"action": "BLOCKED"}))
+
+    with pytest.raises(GuardrailRaisedException) as excinfo:
+        await guardrail.apply_guardrail(inputs=_inputs(), request_data={}, input_type="request")
+
+    assert excinfo.value.blocked_content is True
+    assert "Blocked by your organization's content policy." in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_intervened_replaces_both_text_bearing_fields():
+    """Substituting only one field would leave the other still carrying the unredacted text."""
+    guardrail = _make_guardrail()
+    guardrail.async_handler.post = AsyncMock(
+        return_value=_mock_response(
+            {
+                "action": "GUARDRAIL_INTERVENED",
+                "texts": ["my email is [EmailAddress1]"],
+                "structured_messages": [{"role": "user", "content": "my email is [EmailAddress1]"}],
+            }
+        )
+    )
+    inputs = _inputs(
+        texts=["my email is a@b.com"],
+        structured_messages=[{"role": "user", "content": "my email is a@b.com"}],
+    )
+
+    result = await guardrail.apply_guardrail(inputs=inputs, request_data={}, input_type="request")
+
+    assert result["texts"] == ["my email is [EmailAddress1]"]
+    assert result["structured_messages"] == [{"role": "user", "content": "my email is [EmailAddress1]"}]
+    assert "a@b.com" not in str(result)
+
+
+@pytest.mark.asyncio
+async def test_intervened_leaves_a_field_alone_when_airia_omits_it():
+    """An omitted field means "not rewritten", not "rewritten to empty"."""
+    guardrail = _make_guardrail()
+    guardrail.async_handler.post = AsyncMock(
+        return_value=_mock_response({"action": "GUARDRAIL_INTERVENED", "texts": ["redacted"]})
+    )
+    inputs = _inputs(texts=["original"], structured_messages=[{"role": "user", "content": "keep me"}])
+
+    result = await guardrail.apply_guardrail(inputs=inputs, request_data={}, input_type="request")
+
+    assert result["texts"] == ["redacted"]
+    assert result["structured_messages"] == [{"role": "user", "content": "keep me"}]
+
+
+@pytest.mark.asyncio
+async def test_intervened_with_a_non_list_field_is_treated_as_a_block():
+    """A rewrite this version cannot apply must not let the original text through."""
+    guardrail = _make_guardrail()
+    guardrail.async_handler.post = AsyncMock(
+        return_value=_mock_response({"action": "GUARDRAIL_INTERVENED", "texts": "not a list"})
+    )
+
+    with pytest.raises(GuardrailRaisedException) as excinfo:
+        await guardrail.apply_guardrail(inputs=_inputs(texts=["secret"]), request_data={}, input_type="request")
+
+    assert excinfo.value.blocked_content is True
+
+
+@pytest.mark.asyncio
+async def test_intervened_with_a_non_list_structured_messages_is_treated_as_a_block():
+    guardrail = _make_guardrail()
+    guardrail.async_handler.post = AsyncMock(
+        return_value=_mock_response({"action": "GUARDRAIL_INTERVENED", "structured_messages": {"role": "user"}})
+    )
+
+    with pytest.raises(GuardrailRaisedException) as excinfo:
+        await guardrail.apply_guardrail(inputs=_inputs(), request_data={}, input_type="request")
+
+    assert excinfo.value.blocked_content is True
+
+
+@pytest.mark.asyncio
+async def test_intervened_without_any_rewritten_field_is_treated_as_a_block():
+    """An intervention the proxy cannot apply must not let the original content through."""
+    guardrail = _make_guardrail()
+    guardrail.async_handler.post = AsyncMock(
+        return_value=_mock_response({"action": "GUARDRAIL_INTERVENED", "tool_calls": []})
+    )
+
+    with pytest.raises(GuardrailRaisedException) as excinfo:
+        await guardrail.apply_guardrail(inputs=_inputs(texts=["secret"]), request_data={}, input_type="request")
+
+    assert excinfo.value.blocked_content is True
+
+
+@pytest.mark.asyncio
+async def test_intervened_returns_a_copy_and_leaves_the_caller_object_untouched():
+    guardrail = _make_guardrail()
+    guardrail.async_handler.post = AsyncMock(
+        return_value=_mock_response({"action": "GUARDRAIL_INTERVENED", "texts": ["redacted"]})
+    )
+    inputs = _inputs(texts=["original"])
+
+    result = await guardrail.apply_guardrail(inputs=inputs, request_data={}, input_type="request")
+
+    assert result["texts"] == ["redacted"]
+    assert inputs["texts"] == ["original"]
+
+
+def test_streaming_moderates_the_whole_response_then_emits_it_redacted():
+    """block_only (the default) drops rewrites; per-chunk rounds can underflow when an entity spans them."""
+    guardrail = _make_guardrail()
+
+    assert guardrail.streaming_transform_mode == "incremental_diff"
+    assert guardrail.streaming_end_of_stream_only is True
+
+
+def test_config_model_is_exposed():
+    assert AiriaGuardrail.get_config_model() is AiriaGuardrailConfigModel
+    assert AiriaGuardrailConfigModel.ui_friendly_name() == "Airia Guardrail"
+
+
+@pytest.mark.asyncio
+async def test_unrecognized_action_is_treated_as_a_block():
+    """An action this version cannot interpret must not become an allow."""
+    guardrail = _make_guardrail()
+    guardrail.async_handler.post = AsyncMock(return_value=_mock_response({"action": "SOME_FUTURE_ACTION"}))
+
+    with pytest.raises(GuardrailRaisedException) as excinfo:
+        await guardrail.apply_guardrail(inputs=_inputs(), request_data={}, input_type="request")
+
+    assert excinfo.value.blocked_content is True
+
+
+@pytest.mark.asyncio
+async def test_missing_action_is_treated_as_a_block():
+    """A response with no action at all is not an allow either."""
+    guardrail = _make_guardrail()
+    guardrail.async_handler.post = AsyncMock(return_value=_mock_response({}))
+
+    with pytest.raises(GuardrailRaisedException) as excinfo:
+        await guardrail.apply_guardrail(inputs=_inputs(), request_data={}, input_type="request")
+
+    assert excinfo.value.blocked_content is True
+
+
+@pytest.mark.asyncio
+async def test_transport_failure_fails_closed_but_is_not_reported_as_a_verdict():
+    """Still refused, but blocked_content stays False: could not evaluate is not a verdict."""
+    guardrail = _make_guardrail()
+    guardrail.async_handler.post = AsyncMock(side_effect=httpx.ConnectError("connection refused"))
+
+    with pytest.raises(GuardrailRaisedException) as excinfo:
+        await guardrail.apply_guardrail(inputs=_inputs(), request_data={}, input_type="request")
+
+    assert excinfo.value.blocked_content is False
+    assert "could not evaluate" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_non_2xx_fails_closed_but_is_not_reported_as_a_verdict():
+    guardrail = _make_guardrail()
+    response = _mock_response({}, status_code=503)
+    response.raise_for_status.side_effect = httpx.HTTPStatusError("503", request=MagicMock(), response=MagicMock())
+    guardrail.async_handler.post = AsyncMock(return_value=response)
+
+    with pytest.raises(GuardrailRaisedException) as excinfo:
+        await guardrail.apply_guardrail(inputs=_inputs(), request_data={}, input_type="request")
+
+    assert excinfo.value.blocked_content is False


### PR DESCRIPTION
## TLDR

Problem this solves:

- Airia customers on LiteLLM have no way to enforce Airia guardrails on proxy traffic
- Today they must copy a Python file onto the proxy host and reference it by dotted path

How it solves it:

- Adds `airia` as a built-in guardrail provider, configured with `api_base` + `api_key`
- Prompts are checked before the model call (`pre_call`), responses after it (`post_call`)
- Airia returns allow / block / redact; redactions are applied before the text moves on
- Streamed responses are moderated whole, then delivered redacted (`incremental_diff` + `streaming_end_of_stream_only`)

## User Flow

Before: a proxy admin who wants Airia guardrails cannot reference the provider by name

1. They add `guardrail: airia` under `guardrails:` in `config.yaml` and start the proxy
2. Startup logs `Skipping guardrail 'airia': invalid configuration ... Unsupported guardrail: airia`
3. Every POST to `http://litellm-domain/v1/chat/completions` reaches the model unchecked

After: the same config enforces the Airia policy on every call

1. They add `guardrail: airia` under `guardrails:` in `config.yaml` and start the proxy
2. The proxy starts with the guardrail active
3. POST `/v1/chat/completions` with `"my aws key is AKIAIOSFODNN7EXAMPLE"` returns `400` — `Guardrail raised an exception, Guardrail: airia, Message: <the message configured on their Airia guardrail>`. The model is never called
4. POST with `"Contact me at ada@example.com"` returns `200`; the model received `Contact me at [EmailAddress1]`
5. POST with a benign prompt returns `200` unchanged

## Relevant issues

—

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally: `uv run pytest tests/test_litellm/proxy/guardrails/guardrail_hooks/test_airia.py -v` → 21 passed
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] Greptile Confidence Score of at least 4/5

## Screenshots / Proof of Fix

Setup shared by both runs. `config.yaml`:

```yaml
model_list:
  - model_name: gpt-4o-mini
    litellm_params:
      model: openai/harness-echo          # local echo endpoint that records exactly what it received,
      api_base: http://127.0.0.1:8931     # so the redacted text the MODEL saw is observable
      api_key: not-a-real-key
guardrails:
  - guardrail_name: "airia"
    litellm_params:
      guardrail: airia
      mode: ["pre_call", "post_call"]
      default_on: true
      api_base: os.environ/AIRIA_GATEWAY_URL   # a running Airia AI Gateway; policy: PII → redact, Secrets → block
      api_key: os.environ/AIRIA_API_KEY
general_settings:
  master_key: sk-1234
```

The guardrail side is a live Airia deployment, not a mock. The model is a local echo endpoint because that is the only way to show what the provider actually received; nothing in the guardrail path is stubbed.

### Before (b4f5b6a)

1. `litellm --config config.yaml --port 4096`
2. Output:
   ```
   LiteLLM Proxy:ERROR: init_guardrails.py:37 - Skipping guardrail 'airia': invalid configuration, proxy is starting WITHOUT this guardrail: Unsupported guardrail: airia
   ```

### After (5e60018b)

#### Blocked — secret in the prompt

1. ```shell
   curl -s http://127.0.0.1:4097/v1/chat/completions -H 'Content-Type: application/json' -H 'Authorization: Bearer sk-1234' \
     -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"my aws key is AKIAIOSFODNN7EXAMPLE"}]}'
   ```
2. `HTTP 400`
   ```json
   {"error": {"message": "Guardrail raised an exception, Guardrail: airia, Message: Secret blocked by A51-317 demo policy.", "type": "None", "param": "None", "code": "400"}}
   ```
3. Echo endpoint call log: **0 calls** for this request — the model was never invoked

#### Redacted — PII in the prompt

1. ```shell
   curl -s http://127.0.0.1:4097/v1/chat/completions -H 'Content-Type: application/json' -H 'Authorization: Bearer sk-1234' \
     -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Contact me at ada@example.com"}]}'
   ```
2. `HTTP 200`, `choices[0].message.content = "echo: Contact me at [EmailAddress1]"`
3. Echo endpoint call log shows the model received `['Contact me at [EmailAddress1]']` — the address never reached it

#### Allowed — benign prompt

1. ```shell
   curl -s http://127.0.0.1:4097/v1/chat/completions -H 'Content-Type: application/json' -H 'Authorization: Bearer sk-1234' \
     -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Explain recursion in one sentence."}]}'
   ```
2. `HTTP 200`, `choices[0].message.content = "echo: Explain recursion in one sentence."`
3. Echo endpoint call log shows the model received the prompt unchanged

#### Redacted — PII in the model's response (`post_call`)

The echo endpoint answers the fixed prompt `please share the demo contact` (no PII on the way in) with `Sure, reach me at ada@example.com or call 415-555-0199.`

1. ```shell
   curl -s http://127.0.0.1:4097/v1/chat/completions -H 'Content-Type: application/json' -H 'Authorization: Bearer sk-1234' \
     -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"please share the demo contact"}]}'
   ```
2. `HTTP 200`, `choices[0].message.content = "echo: Sure, reach me at [EmailAddress1] or call 415-555-0199."`

#### Redacted — PII in a streamed response (`post_call`, `stream: true`)

1. ```shell
   curl -sN http://127.0.0.1:4097/v1/chat/completions -H 'Content-Type: application/json' -H 'Authorization: Bearer sk-1234' \
     -d '{"model":"gpt-4o-mini","stream":true,"messages":[{"role":"user","content":"please share the demo contact"}]}'
   ```
2. `HTTP 200`; the stream is held until the response is complete and Airia has answered, then one delta carries `echo: Sure, reach me at [EmailAddress1] or call 415-555-0199.`
3. `grep -c 'ada@example.com'` over the raw SSE bytes: `0`

## Type

🆕 New Feature

## Caveats (if any)

### Medium

- Streamed tool-call chunks are forwarded before the end-of-stream verdict: the unified hook's incremental mode passes them through and inspects the assembled call only at the end. Framework behavior shared by every `incremental_diff` guardrail. A follow-up in the unified hook (buffer tool-call chunks until moderated) would close it for all providers

### Low

- Streamed text arrives in one delta at end of stream rather than incrementally: the trade for redactions that can never underflow. Blocks still terminate the stream immediately

- `during_call` is deliberately not offered; it runs concurrently with the model call, so a block could land after the prompt reached the provider
- The proof's model is a local echo endpoint; the guardrail path is a live Airia deployment. No provider key is available to this machine for a paid-model run
- If Airia is unreachable the request is refused (`blocked_content=False`), not passed through — same fail-closed stance as the other guardrail providers
- Docs page will follow in a separate PR to `litellm-docs`

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
