### PR TITLE
test(bedrock): accept the router kwarg in the knowledge base search fake

### DIFF
--- a/tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py
+++ b/tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py
@@ -333,6 +333,7 @@ async def test_bedrock_kb_request_body_has_transformed_filters(
         timeout=None,
         client=None,
         _is_async=False,
+        router=None,
     ):
         litellm_params_dict = (
             litellm_params.model_dump(exclude_none=False)

--- a/tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py
+++ b/tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py
@@ -333,7 +333,7 @@ async def test_bedrock_kb_request_body_has_transformed_filters(
         timeout=None,
         client=None,
         _is_async=False,
-        router=None,
+        router: "litellm.Router | None" = None,
     ):
         litellm_params_dict = (
             litellm_params.model_dump(exclude_none=False)


### PR DESCRIPTION
## TLDR

Problem this solves:

- CircleCI `logging_testing` is red on staging since PR #34788
- The test's fake search handler rejects the new `router` kwarg
- Every PR that merges staging inherits the red job until this lands

How it solves it:

- The fake now accepts `router=None`, matching the real handler
- Test-only change, no product code touched

## User Flow

Before: any PR that merges staging inherits a red CircleCI `logging_testing` job, because `test_bedrock_kb_request_body_has_transformed_filters` dies with `TypeError: got an unexpected keyword argument 'router'` before it asserts anything

After: the same job runs that test through its assertions and goes green, so PRs merging staging stop inheriting the red job

## Relevant issues

None

## Linear ticket

Resolves LIT-6766

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This change has no end-user surface, so the proof is the failing test itself: the same pytest command at the merge base and at the tip, run from a bootstrapped worktree, plus the CircleCI `logging_testing` job on this PR

### Before (719b67114d)

1. `uv run --no-sync pytest tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py::test_bedrock_kb_request_body_has_transformed_filters -q -p no:cacheprovider`
2. Observed output:

```
TypeError: test_bedrock_kb_request_body_has_transformed_filters.<locals>.fake_async_vector_store_search_handler() got an unexpected keyword argument 'router'
=========================== short test summary info ============================
FAILED tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py::test_bedrock_kb_request_body_has_transformed_filters
1 failed in 32.69s
```

### After (8e26d13fa0)

1. `uv run --no-sync pytest tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py::test_bedrock_kb_request_body_has_transformed_filters -q -p no:cacheprovider`
2. Observed output:

```
.                                                                        [100%]
1 passed in 7.12s
```

3. `uv run --no-sync pytest tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py -q -p no:cacheprovider` (the whole file)
4. Observed output (the other 7 failures are local-environment only: the machine's AWS login credential provider needs `botocore[crt]`, and the mock-OpenAI cases fail the same way at the merge base, where the whole file reads `8 failed, 4 passed, 1 warning in 25.51s`; the only delta between the two runs is this PR's test):

```
FAILED tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py::test_e2e_bedrock_knowledgebase_retrieval_with_completion
FAILED tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py::test_e2e_bedrock_knowledgebase_retrieval_with_llm_api_call
FAILED tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py::test_e2e_bedrock_knowledgebase_retrieval_with_llm_api_call_streaming
FAILED tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py::test_e2e_bedrock_knowledgebase_retrieval_with_llm_api_call_with_tools_and_filters
FAILED tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py::test_openai_with_knowledge_base_mock_openai
FAILED tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py::test_openai_with_mixed_tool_call_mock_openai
FAILED tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py::test_openai_with_vector_store_ids_in_tool_call_mock_openai
7 failed, 5 passed, 1 warning in 13.54s
```

5. CircleCI `logging_testing` on this PR: [green at b6b5b31ce4](https://app.circleci.com/workflow/0797b106-bb95-4234-9e20-67578c2a5d13/job/014e6456-279e-4656-b637-40dc70daa81e) (the same fix before the `router` parameter got its annotation); at this tip: [green at 8e26d13fa0](https://app.circleci.com/workflow/0bc50ee7-b134-4244-975b-c43b52bff210/job/da531903-f485-42a2-88e3-b366b85274b6). The three red non-required jobs in that workflow (`local_testing_part1`, `local_testing_part2`, `litellm_router_testing`) each fail on a single live-OpenAI timeout test (`test_openai_embedding_timeouts`, `test_timeout_streaming`, `test_router_timeout`) with an httpx connection error, the known timeout flakes, unrelated to this file

## Type

✅ Test

## Caveats (if any)

### Low

- No end-user-visible behavior changes (test-only), so the proof is the pytest Before/After plus the CircleCI job rather than a live proxy run
- The fake ignores `router`; the test asserts the Bedrock request body, not routing
- Only the new `router` parameter carries a type annotation; the fake's other twelve parameters stay untyped as they were, since the file sits outside the basedpyright gate
- /live-pr-risk: no product code changes and the fake's only dependent is the `patch.object` in the same test, so there is no proxy path to A/B; CHECKED at 8e26d13fa0: CircleCI `logging_testing` green, no untested dependent path, no breaking change
- `captured_request_body: dict = {}` predates this PR and stays untouched

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
