### PR TITLE
feat(azure-ai): add latest catalog model metadata

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -9412,12 +9412,15 @@
         "supports_tool_choice": true
     },
     "azure_ai/FW-DeepSeek-V4-Flash-0731": {
+        "cache_read_input_token_cost": 7e-09,
         "deprecation_date": "2027-08-15",
+        "input_cost_per_token": 2.2e-07,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 1048576,
         "max_output_tokens": 131072,
         "max_tokens": 131072,
         "mode": "chat",
+        "output_cost_per_token": 6.6e-07,
         "reasoning_effort_levels": [
             "low",
             "high",
@@ -9772,7 +9775,7 @@
         "deprecation_date": "2026-10-01"
     },
     "azure_ai/MAI-Image-2.5-Pro": {
-        "deprecation_date": "2026-10-01",
+        "deprecation_date": "2026-10-31",
         "input_cost_per_image_token": 8e-06,
         "input_cost_per_token": 5e-06,
         "litellm_provider": "azure_ai",

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -9333,6 +9333,26 @@
         "source": "https://marketplace.microsoft.com/en-us/marketplace/apps/cohere.cohere-embed-v3-english-offer?tab=PlansAndPrice",
         "supports_embedding_image_input": true
     },
+    "azure_ai/Codestral-2501": {
+        "input_cost_per_token": 3e-07,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 256000,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "mode": "chat",
+        "output_cost_per_token": 9e-07,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/mistral/",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_native_streaming": true
+    },
     "azure_ai/FLUX-1.1-pro": {
         "litellm_provider": "azure_ai",
         "mode": "image_generation",
@@ -9388,6 +9408,32 @@
         "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
         "supports_function_calling": true,
         "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "azure_ai/FW-DeepSeek-V4-Flash-0731": {
+        "deprecation_date": "2027-08-15",
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "reasoning_effort_levels": [
+            "low",
+            "high",
+            "max"
+        ],
+        "source": "https://fireworks.ai/models/deepseek-ai/deepseek-v4-flash-0731",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
@@ -9451,6 +9497,38 @@
         "supports_function_calling": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "azure_ai/FW-GLM-5.3": {
+        "cache_read_input_token_cost": 2.6e-07,
+        "deprecation_date": "2027-09-01",
+        "input_cost_per_token": 1.4e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 4.4e-06,
+        "reasoning_effort_levels": [
+            "low",
+            "high",
+            "max"
+        ],
+        "source": "https://fireworks.ai/models/fireworks/glm-5p3",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
         "supports_tool_choice": true
     },
     "azure_ai/FW-Inkling": {
@@ -9572,6 +9650,39 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
+    "azure_ai/Kimi-K3": {
+        "cache_read_input_token_cost": 3e-07,
+        "deprecation_date": "2026-11-26",
+        "input_cost_per_token": 3e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-05,
+        "reasoning_effort_levels": [
+            "low",
+            "high",
+            "max"
+        ],
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/kimi/",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "azure_ai/FW-MiniMax-M2.5": {
         "deprecation_date": "2027-07-01",
         "cache_read_input_token_cost": 3.3e-08,
@@ -9660,6 +9771,28 @@
         ],
         "deprecation_date": "2026-10-01"
     },
+    "azure_ai/MAI-Image-2.5-Pro": {
+        "deprecation_date": "2026-10-01",
+        "input_cost_per_image_token": 8e-06,
+        "input_cost_per_token": 5e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 32000,
+        "mode": "image_generation",
+        "output_cost_per_image_token": 0.000106,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/microsoft/",
+        "supported_endpoints": [
+            "/v1/images/generations",
+            "/v1/images/edits"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "image"
+        ],
+        "supports_vision": true
+    },
     "azure_ai/MAI-Image-2e": {
         "deprecation_date": "2026-08-15",
         "input_cost_per_token": 5e-06,
@@ -9671,6 +9804,31 @@
         "supported_endpoints": [
             "/v1/images/generations"
         ]
+    },
+    "azure_ai/MAI-Thinking-1": {
+        "cache_read_input_token_cost": 2e-07,
+        "deprecation_date": "2026-11-04",
+        "input_cost_per_token": 2e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 256000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "output_cost_per_token": 8e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/microsoft/",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
     },
     "azure_ai/Llama-3.2-11B-Vision-Instruct": {
         "deprecation_date": "2026-06-13",
@@ -9971,6 +10129,28 @@
             "/v1/ocr"
         ],
         "source": "https://ai.azure.com/catalog/models/mistral-document-ai-2512"
+    },
+    "azure_ai/mistral-ocr-4-0": {
+        "annotation_cost_per_page": 0.005,
+        "deprecation_date": "2027-10-01",
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "mode": "ocr",
+        "ocr_cost_per_page": 0.004,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/mistral/",
+        "supported_endpoints": [
+            "/v1/ocr"
+        ],
+        "supported_modalities": [
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_pdf_input": true,
+        "supports_vision": true
     },
     "azure_ai/doc-intelligence/prebuilt-read": {
         "litellm_provider": "azure_ai",
@@ -10304,6 +10484,34 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_web_search": true
+    },
+    "azure_ai/grok-4.6": {
+        "cache_read_input_token_cost": 5e-07,
+        "deprecation_date": "2027-08-24",
+        "input_cost_per_token": 2e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 6e-06,
+        "source": "https://docs.x.ai/developers/models/grok-4.6",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
     },
     "azure_ai/grok-4-fast-non-reasoning": {
         "deprecation_date": "2026-05-01",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -9412,12 +9412,15 @@
         "supports_tool_choice": true
     },
     "azure_ai/FW-DeepSeek-V4-Flash-0731": {
+        "cache_read_input_token_cost": 7e-09,
         "deprecation_date": "2027-08-15",
+        "input_cost_per_token": 2.2e-07,
         "litellm_provider": "azure_ai",
         "max_input_tokens": 1048576,
         "max_output_tokens": 131072,
         "max_tokens": 131072,
         "mode": "chat",
+        "output_cost_per_token": 6.6e-07,
         "reasoning_effort_levels": [
             "low",
             "high",
@@ -9772,7 +9775,7 @@
         "deprecation_date": "2026-10-01"
     },
     "azure_ai/MAI-Image-2.5-Pro": {
-        "deprecation_date": "2026-10-01",
+        "deprecation_date": "2026-10-31",
         "input_cost_per_image_token": 8e-06,
         "input_cost_per_token": 5e-06,
         "litellm_provider": "azure_ai",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -9333,6 +9333,26 @@
         "source": "https://marketplace.microsoft.com/en-us/marketplace/apps/cohere.cohere-embed-v3-english-offer?tab=PlansAndPrice",
         "supports_embedding_image_input": true
     },
+    "azure_ai/Codestral-2501": {
+        "input_cost_per_token": 3e-07,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 256000,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "mode": "chat",
+        "output_cost_per_token": 9e-07,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/mistral/",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_native_streaming": true
+    },
     "azure_ai/FLUX-1.1-pro": {
         "litellm_provider": "azure_ai",
         "mode": "image_generation",
@@ -9388,6 +9408,32 @@
         "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
         "supports_function_calling": true,
         "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "azure_ai/FW-DeepSeek-V4-Flash-0731": {
+        "deprecation_date": "2027-08-15",
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "reasoning_effort_levels": [
+            "low",
+            "high",
+            "max"
+        ],
+        "source": "https://fireworks.ai/models/deepseek-ai/deepseek-v4-flash-0731",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
@@ -9451,6 +9497,38 @@
         "supports_function_calling": true,
         "supports_prompt_caching": true,
         "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "azure_ai/FW-GLM-5.3": {
+        "cache_read_input_token_cost": 2.6e-07,
+        "deprecation_date": "2027-09-01",
+        "input_cost_per_token": 1.4e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 4.4e-06,
+        "reasoning_effort_levels": [
+            "low",
+            "high",
+            "max"
+        ],
+        "source": "https://fireworks.ai/models/fireworks/glm-5p3",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
         "supports_tool_choice": true
     },
     "azure_ai/FW-Inkling": {
@@ -9572,6 +9650,39 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
+    "azure_ai/Kimi-K3": {
+        "cache_read_input_token_cost": 3e-07,
+        "deprecation_date": "2026-11-26",
+        "input_cost_per_token": 3e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-05,
+        "reasoning_effort_levels": [
+            "low",
+            "high",
+            "max"
+        ],
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/kimi/",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "azure_ai/FW-MiniMax-M2.5": {
         "deprecation_date": "2027-07-01",
         "cache_read_input_token_cost": 3.3e-08,
@@ -9660,6 +9771,28 @@
         ],
         "deprecation_date": "2026-10-01"
     },
+    "azure_ai/MAI-Image-2.5-Pro": {
+        "deprecation_date": "2026-10-01",
+        "input_cost_per_image_token": 8e-06,
+        "input_cost_per_token": 5e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 32000,
+        "mode": "image_generation",
+        "output_cost_per_image_token": 0.000106,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/microsoft/",
+        "supported_endpoints": [
+            "/v1/images/generations",
+            "/v1/images/edits"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "image"
+        ],
+        "supports_vision": true
+    },
     "azure_ai/MAI-Image-2e": {
         "deprecation_date": "2026-08-15",
         "input_cost_per_token": 5e-06,
@@ -9671,6 +9804,31 @@
         "supported_endpoints": [
             "/v1/images/generations"
         ]
+    },
+    "azure_ai/MAI-Thinking-1": {
+        "cache_read_input_token_cost": 2e-07,
+        "deprecation_date": "2026-11-04",
+        "input_cost_per_token": 2e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 256000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "output_cost_per_token": 8e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/microsoft/",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
     },
     "azure_ai/Llama-3.2-11B-Vision-Instruct": {
         "deprecation_date": "2026-06-13",
@@ -9971,6 +10129,28 @@
             "/v1/ocr"
         ],
         "source": "https://ai.azure.com/catalog/models/mistral-document-ai-2512"
+    },
+    "azure_ai/mistral-ocr-4-0": {
+        "annotation_cost_per_page": 0.005,
+        "deprecation_date": "2027-10-01",
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "mode": "ocr",
+        "ocr_cost_per_page": 0.004,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/mistral/",
+        "supported_endpoints": [
+            "/v1/ocr"
+        ],
+        "supported_modalities": [
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_pdf_input": true,
+        "supports_vision": true
     },
     "azure_ai/doc-intelligence/prebuilt-read": {
         "litellm_provider": "azure_ai",
@@ -10304,6 +10484,34 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_web_search": true
+    },
+    "azure_ai/grok-4.6": {
+        "cache_read_input_token_cost": 5e-07,
+        "deprecation_date": "2027-08-24",
+        "input_cost_per_token": 2e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 6e-06,
+        "source": "https://docs.x.ai/developers/models/grok-4.6",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
     },
     "azure_ai/grok-4-fast-non-reasoning": {
         "deprecation_date": "2026-05-01",

--- a/tests/test_litellm/test_azure_ai_catalog_model_metadata.py
+++ b/tests/test_litellm/test_azure_ai_catalog_model_metadata.py
@@ -1,0 +1,154 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from litellm.cost_calculator import cost_per_token
+from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+
+REPO_ROOT = Path(__file__).parents[2]
+MAIN_PATH = REPO_ROOT / "model_prices_and_context_window.json"
+BACKUP_PATH = REPO_ROOT / "litellm" / "model_prices_and_context_window_backup.json"
+
+MODEL_LIMITS = (
+    ("azure_ai/FW-DeepSeek-V4-Flash-0731", "chat", 1048576, 131072, "2027-08-15"),
+    ("azure_ai/FW-GLM-5.3", "chat", 1048576, 131072, "2027-09-01"),
+    ("azure_ai/MAI-Thinking-1", "chat", 256000, 64000, "2026-11-04"),
+    ("azure_ai/Codestral-2501", "chat", 256000, 4096, None),
+    ("azure_ai/Kimi-K3", "chat", 1048576, 131072, "2026-11-26"),
+    ("azure_ai/grok-4.6", "chat", 200000, 128000, "2027-08-24"),
+    ("azure_ai/MAI-Image-2.5-Pro", "image_generation", 32000, None, "2026-10-01"),
+    ("azure_ai/mistral-ocr-4-0", "ocr", 128000, 4096, "2027-10-01"),
+)
+
+CHAT_PRICING = (
+    ("azure_ai/FW-GLM-5.3", 1.4e-06, 4.4e-06, 2.6e-07),
+    ("azure_ai/MAI-Thinking-1", 2e-06, 8e-06, 2e-07),
+    ("azure_ai/Codestral-2501", 3e-07, 9e-07, None),
+    ("azure_ai/Kimi-K3", 3e-06, 1.5e-05, 3e-07),
+    ("azure_ai/grok-4.6", 2e-06, 6e-06, 5e-07),
+)
+
+REASONING_MODELS = (
+    "azure_ai/FW-DeepSeek-V4-Flash-0731",
+    "azure_ai/FW-GLM-5.3",
+    "azure_ai/MAI-Thinking-1",
+    "azure_ai/Kimi-K3",
+    "azure_ai/grok-4.6",
+)
+
+
+def _load(path: Path) -> dict[str, dict[str, object]]:
+    with open(path, encoding="utf-8") as model_cost_file:
+        return json.load(model_cost_file)
+
+
+@pytest.mark.parametrize("model, mode, max_input, max_output, deprecation", MODEL_LIMITS)
+def test_azure_ai_catalog_model_limits(
+    model: str,
+    mode: str,
+    max_input: int,
+    max_output: int | None,
+    deprecation: str | None,
+) -> None:
+    info = _load(MAIN_PATH).get(model)
+    assert info is not None, f"{model} missing from model_prices_and_context_window.json"
+
+    assert info["litellm_provider"] == "azure_ai"
+    assert info["mode"] == mode
+    assert info["max_input_tokens"] == max_input
+    assert info.get("max_output_tokens") == max_output
+    assert info.get("max_tokens") == max_output
+    assert info.get("deprecation_date") == deprecation
+
+
+@pytest.mark.parametrize("model, input_cost, output_cost, cache_cost", CHAT_PRICING)
+def test_azure_ai_catalog_chat_pricing(
+    local_model_cost_map: None,
+    model: str,
+    input_cost: float,
+    output_cost: float,
+    cache_cost: float | None,
+) -> None:
+    info = _load(MAIN_PATH)[model]
+    prompt_cost, completion_cost = cost_per_token(model=model, prompt_tokens=1000, completion_tokens=500)
+
+    assert info["input_cost_per_token"] == input_cost
+    assert info["output_cost_per_token"] == output_cost
+    assert info.get("cache_read_input_token_cost") == cache_cost
+    assert prompt_cost == pytest.approx(1000 * input_cost)
+    assert completion_cost == pytest.approx(500 * output_cost)
+
+
+def test_provisioned_deepseek_model_has_no_paygo_token_price() -> None:
+    info = _load(MAIN_PATH)["azure_ai/FW-DeepSeek-V4-Flash-0731"]
+
+    assert "input_cost_per_token" not in info
+    assert "output_cost_per_token" not in info
+    assert "cache_read_input_token_cost" not in info
+
+
+@pytest.mark.parametrize("model", REASONING_MODELS)
+def test_azure_ai_catalog_reasoning_capabilities(model: str) -> None:
+    info = _load(MAIN_PATH)[model]
+
+    assert info["supports_reasoning"] is True
+    assert info["supports_function_calling"] is True
+    assert info["supports_tool_choice"] is True
+
+
+@pytest.mark.parametrize(
+    "model",
+    ("azure_ai/FW-DeepSeek-V4-Flash-0731", "azure_ai/FW-GLM-5.3", "azure_ai/Kimi-K3"),
+)
+def test_azure_ai_catalog_reasoning_effort_levels(model: str) -> None:
+    assert _load(MAIN_PATH)[model]["reasoning_effort_levels"] == ["low", "high", "max"]
+
+
+def test_mai_image_2_5_pro_pricing_and_modalities() -> None:
+    info = _load(MAIN_PATH)["azure_ai/MAI-Image-2.5-Pro"]
+
+    assert info["input_cost_per_token"] == 5e-06
+    assert info["input_cost_per_image_token"] == 8e-06
+    assert info["output_cost_per_image_token"] == 0.000106
+    assert info["supported_modalities"] == ["text", "image"]
+    assert info["supported_output_modalities"] == ["image"]
+    assert info["supported_endpoints"] == ["/v1/images/generations", "/v1/images/edits"]
+
+
+def test_mistral_ocr_4_pricing_and_modalities() -> None:
+    info = _load(MAIN_PATH)["azure_ai/mistral-ocr-4-0"]
+
+    assert info["ocr_cost_per_page"] == 0.004
+    assert info["annotation_cost_per_page"] == 0.005
+    assert info["supported_modalities"] == ["image"]
+    assert info["supported_output_modalities"] == ["text"]
+    assert info["supports_pdf_input"] is True
+    assert info["supported_endpoints"] == ["/v1/ocr"]
+
+
+@pytest.mark.parametrize("model, _mode, _max_input, _max_output, _deprecation", MODEL_LIMITS)
+def test_azure_ai_catalog_models_route_to_azure_ai(
+    model: str,
+    _mode: str,
+    _max_input: int,
+    _max_output: int | None,
+    _deprecation: str | None,
+) -> None:
+    routed_model, provider, _, _ = get_llm_provider(model=model)
+
+    assert routed_model == model.split("/", 1)[1]
+    assert provider == "azure_ai"
+
+
+@pytest.mark.parametrize("model, _mode, _max_input, _max_output, _deprecation", MODEL_LIMITS)
+def test_azure_ai_catalog_backup_matches_main(
+    model: str,
+    _mode: str,
+    _max_input: int,
+    _max_output: int | None,
+    _deprecation: str | None,
+) -> None:
+    assert _load(BACKUP_PATH).get(model) == _load(MAIN_PATH).get(model), (
+        f"{model} differs between main and backup model cost maps"
+    )

--- a/tests/test_litellm/test_azure_ai_catalog_model_metadata.py
+++ b/tests/test_litellm/test_azure_ai_catalog_model_metadata.py
@@ -17,11 +17,12 @@ MODEL_LIMITS = (
     ("azure_ai/Codestral-2501", "chat", 256000, 4096, None),
     ("azure_ai/Kimi-K3", "chat", 1048576, 131072, "2026-11-26"),
     ("azure_ai/grok-4.6", "chat", 200000, 128000, "2027-08-24"),
-    ("azure_ai/MAI-Image-2.5-Pro", "image_generation", 32000, None, "2026-10-01"),
+    ("azure_ai/MAI-Image-2.5-Pro", "image_generation", 32000, None, "2026-10-31"),
     ("azure_ai/mistral-ocr-4-0", "ocr", 128000, 4096, "2027-10-01"),
 )
 
 CHAT_PRICING = (
+    ("azure_ai/FW-DeepSeek-V4-Flash-0731", 2.2e-07, 6.6e-07, 7e-09),
     ("azure_ai/FW-GLM-5.3", 1.4e-06, 4.4e-06, 2.6e-07),
     ("azure_ai/MAI-Thinking-1", 2e-06, 8e-06, 2e-07),
     ("azure_ai/Codestral-2501", 3e-07, 9e-07, None),
@@ -78,14 +79,6 @@ def test_azure_ai_catalog_chat_pricing(
     assert info.get("cache_read_input_token_cost") == cache_cost
     assert prompt_cost == pytest.approx(1000 * input_cost)
     assert completion_cost == pytest.approx(500 * output_cost)
-
-
-def test_provisioned_deepseek_model_has_no_paygo_token_price() -> None:
-    info = _load(MAIN_PATH)["azure_ai/FW-DeepSeek-V4-Flash-0731"]
-
-    assert "input_cost_per_token" not in info
-    assert "output_cost_per_token" not in info
-    assert "cache_read_input_token_cost" not in info
 
 
 @pytest.mark.parametrize("model", REASONING_MODELS)


### PR DESCRIPTION
## TLDR

Problem this solves:

- Eight exact Azure AI catalog IDs lack model metadata
- Missing prices and limits weaken routing and spend tracking

How it solves it:

- Adds modes, prices, limits, capabilities, and retirement dates
- Keeps primary and bundled catalogs covered by focused tests

## User Flow

Before: a developer cannot inspect complete built-in metadata for a newly configured Azure AI catalog deployment

1. They configure `azure_ai/FW-GLM-5.3` for an Azure AI deployment
2. They call `GET https://litellm-domain/v1/model/info`
3. The deployment has no built-in price, context, retirement, or capability metadata

After: the same developer can inspect the model's published metadata before sending traffic

1. They configure `azure_ai/FW-GLM-5.3` for an Azure AI deployment
2. They call `GET https://litellm-domain/v1/model/info`
3. The deployment includes its price, context, retirement, and capability metadata

## Relevant issues

## Linear ticket

## Sources

- Catalog metadata: [DeepSeek](https://ai.azure.com/catalog/models/FW-DeepSeek-V4-Flash-0731), [GLM](https://ai.azure.com/catalog/models/FW-GLM-5.3), [MAI Thinking](https://ai.azure.com/catalog/models/MAI-Thinking-1), [Codestral](https://ai.azure.com/catalog/models/Codestral-2501), [Kimi](https://ai.azure.com/catalog/models/Kimi-K3), [Grok](https://ai.azure.com/catalog/models/grok-4.6), [MAI Image](https://ai.azure.com/catalog/models/MAI-Image-2.5-Pro), and [Mistral OCR](https://ai.azure.com/catalog/models/mistral-ocr-4-0)
- Azure pricing: [Microsoft](https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/microsoft/), [Mistral](https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/mistral/), and [Kimi](https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/kimi/)
- Provider pricing: [Fireworks DeepSeek](https://fireworks.ai/models/deepseek-ai/deepseek-v4-flash-0731), [Fireworks GLM](https://fireworks.ai/models/fireworks/glm-5p3), and [xAI Grok](https://docs.x.ai/developers/models/grok-4.6)
- Lifecycle dates: [Microsoft model retirement schedule](https://learn.microsoft.com/en-us/azure/foundry/openai/concepts/model-retirement-schedule)

## Validation notes

- Native Azure `Kimi-K3` deployments provisioned successfully in two regions
- Both regional native inference endpoints returned HTTP 404
- The live gateway removed those routes and retained working `FW-Kimi-K3`
- The `Kimi-K3` entry remains published catalog metadata, not live-route validation

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

This PR adds catalog metadata only; live inference varies by model and Azure deployment

## Type

New Feature
Test

## Caveats (if any)

### Medium

- Fireworks DeepSeek pricing is provisional until Azure publishes its meter
- Fireworks GLM pricing is provisional until Azure publishes its meter
- xAI Grok pricing is provisional until Azure publishes its meter
- Native `Kimi-K3` metadata does not imply working Azure inference
  - Two regional deployments provisioned successfully
  - Both regional inference endpoints returned HTTP 404
  - Live routes were removed while `FW-Kimi-K3` remained active

### Low

- MAI Image uses the live Azure catalog retirement date
- Microsoft's public schedule currently reports 2026-10-01 instead

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
