### PR TITLE
feat(router): gate heuristic v2 to one admin slot

### DIFF
--- a/litellm-proxy-extras/litellm_proxy_extras/migrations/20260902000000_one_heuristic_v2_router/migration.sql
+++ b/litellm-proxy-extras/litellm_proxy_extras/migrations/20260902000000_one_heuristic_v2_router/migration.sql
@@ -1,0 +1,4 @@
+-- Atomically reserve the proxy-wide heuristic_v2 classifier slot
+CREATE UNIQUE INDEX IF NOT EXISTS "LiteLLM_ProxyModelTable_one_heuristic_v2_router"
+    ON "LiteLLM_ProxyModelTable" ((litellm_params #>> '{complexity_router_config,classifier_type}'))
+    WHERE (litellm_params #>> '{complexity_router_config,classifier_type}') = 'heuristic_v2';

--- a/litellm-proxy-extras/litellm_proxy_extras/migrations/20260902000000_one_heuristic_v2_router/migration.sql
+++ b/litellm-proxy-extras/litellm_proxy_extras/migrations/20260902000000_one_heuristic_v2_router/migration.sql
@@ -1,4 +1,10 @@
 -- Atomically reserve the proxy-wide heuristic_v2 classifier slot
 CREATE UNIQUE INDEX IF NOT EXISTS "LiteLLM_ProxyModelTable_one_heuristic_v2_router"
-    ON "LiteLLM_ProxyModelTable" ((litellm_params #>> '{complexity_router_config,classifier_type}'))
-    WHERE (litellm_params #>> '{complexity_router_config,classifier_type}') = 'heuristic_v2';
+    ON "LiteLLM_ProxyModelTable" ((1))
+    WHERE CASE
+        WHEN jsonb_typeof(litellm_params) = 'object'
+            THEN (litellm_params #>> '{complexity_router_config,classifier_type}') = 'heuristic_v2'
+        WHEN jsonb_typeof(litellm_params) = 'string'
+            THEN (((litellm_params #>> '{}')::jsonb) #>> '{complexity_router_config,classifier_type}') = 'heuristic_v2'
+        ELSE FALSE
+    END;

--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -305,7 +305,7 @@ async def _raise_if_heuristic_v2_slot_taken(
     existing_params: GenericLiteLLMParams | None,
     current_model_id: str | None = None,
 ) -> None:
-    """Allow at most one persisted heuristic-v2 complexity router per proxy."""
+    """Allow at most one heuristic-v2 complexity router per proxy."""
     effective_config: Final = _effective_complexity_router_config(incoming_params, existing_params)
     if not uses_heuristic_v2(effective_config):
         return
@@ -320,9 +320,12 @@ async def _raise_if_heuristic_v2_slot_taken(
             code=status.HTTP_403_FORBIDDEN,
             param="litellm_params.complexity_router_config.classifier_type",
         )
+    from litellm.proxy.proxy_server import llm_router
+
     rows: Final = await _proxy_model_table(prisma_client).find_many(where={})
     violation: Final = _heuristic_v2_slot_violation(
         persisted_rows=rows,
+        live_model_list=llm_router.model_list if llm_router is not None else (),
         incoming_params=incoming_params,
         existing_params=existing_params,
         current_model_id=current_model_id,
@@ -350,6 +353,7 @@ def _heuristic_v2_admin_violation(*, effective_config: Mapping[str, object] | No
 def _heuristic_v2_slot_violation(
     *,
     persisted_rows: Sequence[_ProxyModelRow],
+    live_model_list: Sequence[Mapping[str, object]] = (),
     incoming_params: GenericLiteLLMParams | None,
     existing_params: GenericLiteLLMParams | None,
     current_model_id: str | None = None,
@@ -358,6 +362,18 @@ def _heuristic_v2_slot_violation(
     effective_config: Final = _effective_complexity_router_config(incoming_params, existing_params)
     if not uses_heuristic_v2(effective_config):
         return None
+    for deployment in live_model_list:
+        model_info = deployment.get("model_info")
+        if isinstance(model_info, Mapping) and model_info.get("db_model") is True:
+            continue
+        litellm_params = _litellm_params_mapping(deployment.get("litellm_params"))
+        live_config = litellm_params.get("complexity_router_config")
+        if uses_heuristic_v2(live_config if isinstance(live_config, Mapping) else None):
+            return (
+                "Only one complexity router can use classifier_type='heuristic_v2' per proxy. "
+                "A config.yaml deployment already uses the slot; change or remove it before "
+                "creating a database-backed heuristic_v2 router."
+            )
     for row in persisted_rows:
         if current_model_id is not None and row.model_id == current_model_id:
             continue

--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -309,7 +309,34 @@ async def _raise_if_heuristic_v2_slot_taken(
     if not uses_heuristic_v2(effective_config):
         return
     rows: Final = await _proxy_model_table(prisma_client).find_many(where={})
-    for row in rows:
+    violation: Final = _heuristic_v2_slot_violation(
+        persisted_rows=rows,
+        incoming_params=incoming_params,
+        existing_params=existing_params,
+        current_model_id=current_model_id,
+    )
+    if violation is None:
+        return
+    raise ProxyException(
+        message=violation,
+        type=ProxyErrorTypes.validation_error.value,
+        code=status.HTTP_400_BAD_REQUEST,
+        param="litellm_params.complexity_router_config.classifier_type",
+    )
+
+
+def _heuristic_v2_slot_violation(
+    *,
+    persisted_rows: Sequence[_ProxyModelRow],
+    incoming_params: GenericLiteLLMParams | None,
+    existing_params: GenericLiteLLMParams | None,
+    current_model_id: str | None = None,
+) -> str | None:
+    """Return the singleton-slot violation for the effective post-write config."""
+    effective_config: Final = _effective_complexity_router_config(incoming_params, existing_params)
+    if not uses_heuristic_v2(effective_config):
+        return None
+    for row in persisted_rows:
         if current_model_id is not None and row.model_id == current_model_id:
             continue
         if uses_heuristic_v2(
@@ -319,16 +346,12 @@ async def _raise_if_heuristic_v2_slot_taken(
             )
             else None
         ):
-            raise ProxyException(
-                message=(
-                    "Only one complexity router can use classifier_type='heuristic_v2' per proxy. "
-                    "Use classifier_type='heuristic' for this router, or change or delete the existing "
-                    "heuristic_v2 router first."
-                ),
-                type=ProxyErrorTypes.validation_error.value,
-                code=status.HTTP_400_BAD_REQUEST,
-                param="litellm_params.complexity_router_config.classifier_type",
+            return (
+                "Only one complexity router can use classifier_type='heuristic_v2' per proxy. "
+                "Use classifier_type='heuristic' for this router, or change or delete the existing "
+                "heuristic_v2 router first."
             )
+    return None
 
 
 ENFORCE_RPM_TPM_ON_MODEL_ADD_SETTING: Final = "enforce_rpm_tpm_on_model_add"

--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -300,6 +300,7 @@ def _effective_complexity_router_config(
 async def _raise_if_heuristic_v2_slot_taken(
     *,
     prisma_client: PrismaClient,
+    user_api_key_dict: UserAPIKeyAuth,
     incoming_params: GenericLiteLLMParams | None,
     existing_params: GenericLiteLLMParams | None,
     current_model_id: str | None = None,
@@ -308,6 +309,17 @@ async def _raise_if_heuristic_v2_slot_taken(
     effective_config: Final = _effective_complexity_router_config(incoming_params, existing_params)
     if not uses_heuristic_v2(effective_config):
         return
+    admin_violation: Final = _heuristic_v2_admin_violation(
+        effective_config=effective_config,
+        user_role=user_api_key_dict.user_role,
+    )
+    if admin_violation is not None:
+        raise ProxyException(
+            message=admin_violation,
+            type=ProxyErrorTypes.auth_error.value,
+            code=status.HTTP_403_FORBIDDEN,
+            param="litellm_params.complexity_router_config.classifier_type",
+        )
     rows: Final = await _proxy_model_table(prisma_client).find_many(where={})
     violation: Final = _heuristic_v2_slot_violation(
         persisted_rows=rows,
@@ -322,6 +334,16 @@ async def _raise_if_heuristic_v2_slot_taken(
         type=ProxyErrorTypes.validation_error.value,
         code=status.HTTP_400_BAD_REQUEST,
         param="litellm_params.complexity_router_config.classifier_type",
+    )
+
+
+def _heuristic_v2_admin_violation(*, effective_config: Mapping[str, object] | None, user_role: object) -> str | None:
+    """Reserve the proxy-wide v2 classifier slot for proxy administrators."""
+    if not uses_heuristic_v2(effective_config) or user_role == LitellmUserRoles.PROXY_ADMIN:
+        return None
+    return (
+        "Only proxy admins can configure classifier_type='heuristic_v2' because it uses a proxy-wide singleton slot. "
+        "Team admins can use classifier_type='heuristic' or another auto-router type."
     )
 
 
@@ -352,6 +374,31 @@ def _heuristic_v2_slot_violation(
                 "heuristic_v2 router first."
             )
     return None
+
+
+HEURISTIC_V2_SINGLETON_INDEX: Final = "LiteLLM_ProxyModelTable_one_heuristic_v2_router"
+
+
+def _is_heuristic_v2_slot_unique_violation(error: Exception) -> bool:
+    """Recognize the database backstop when two proxy-admin writes race."""
+    return HEURISTIC_V2_SINGLETON_INDEX in str(error)
+
+
+def _heuristic_v2_slot_proxy_exception() -> ProxyException:
+    return ProxyException(
+        message=(
+            "Only one complexity router can use classifier_type='heuristic_v2' per proxy. "
+            "Change or delete the existing heuristic_v2 router first."
+        ),
+        type=ProxyErrorTypes.validation_error.value,
+        code=status.HTTP_400_BAD_REQUEST,
+        param="litellm_params.complexity_router_config.classifier_type",
+    )
+
+
+def _raise_if_heuristic_v2_slot_unique_violation(error: Exception) -> None:
+    if _is_heuristic_v2_slot_unique_violation(error):
+        raise _heuristic_v2_slot_proxy_exception() from error
 
 
 ENFORCE_RPM_TPM_ON_MODEL_ADD_SETTING: Final = "enforce_rpm_tpm_on_model_add"
@@ -805,6 +852,7 @@ async def patch_model(
         )
         await _raise_if_heuristic_v2_slot_taken(
             prisma_client=prisma_client,
+            user_api_key_dict=user_api_key_dict,
             incoming_params=patch_data.litellm_params,
             existing_params=db_model.litellm_params,
             current_model_id=model_id,
@@ -867,6 +915,7 @@ async def patch_model(
     except Exception as e:
         verbose_proxy_logger.exception("Error in patch_model: %s", e)
 
+        _raise_if_heuristic_v2_slot_unique_violation(e)
         if isinstance(e, (HTTPException, ProxyException)):
             raise e
 
@@ -1927,6 +1976,7 @@ async def add_new_model(
         )
         await _raise_if_heuristic_v2_slot_taken(
             prisma_client=prisma_client,
+            user_api_key_dict=user_api_key_dict,
             incoming_params=model_params.litellm_params,
             existing_params=None,
         )
@@ -1979,6 +2029,7 @@ async def add_new_model(
                     )
             except Exception as e:
                 verbose_proxy_logger.exception("Exception in add_new_model: %s", e)
+                _raise_if_heuristic_v2_slot_unique_violation(e)
 
         else:
             raise HTTPException(
@@ -2020,6 +2071,7 @@ async def add_new_model(
 
     except Exception as e:
         verbose_proxy_logger.exception("litellm.proxy.proxy_server.add_new_model(): Exception occured - %s", e)
+        _raise_if_heuristic_v2_slot_unique_violation(e)
         if isinstance(e, HTTPException):
             raise ProxyException(
                 message=getattr(e, "detail", f"Authentication Error({e})"),
@@ -2110,6 +2162,7 @@ async def update_model(
         )
         await _raise_if_heuristic_v2_slot_taken(
             prisma_client=prisma_client,
+            user_api_key_dict=user_api_key_dict,
             incoming_params=model_params.litellm_params,
             existing_params=deployment.litellm_params,
             current_model_id=_model_id,
@@ -2189,6 +2242,7 @@ async def update_model(
             return model_response
     except Exception as e:
         verbose_proxy_logger.exception("litellm.proxy.proxy_server.update_model(): Exception occured - %s", e)
+        _raise_if_heuristic_v2_slot_unique_violation(e)
         if isinstance(e, HTTPException):
             raise ProxyException(
                 message=getattr(e, "detail", f"Authentication Error({e})"),

--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -92,6 +92,7 @@ from litellm.router_strategy.complexity_router import (
 from litellm.router_utils.auto_router_model_naming import (
     STRATEGY_ROUTER_PARAM_FIELDS,
     carries_complexity_router_settings,
+    uses_heuristic_v2,
     validate_complexity_router_config_placement,
     validate_complexity_router_config_write,
     validate_strategy_router_model_write,
@@ -142,6 +143,9 @@ class _ProxyModelRow(Protocol):
     def model_info(self) -> object: ...
 
     def model_dump_json(self, *, exclude_none: bool = False) -> str: ...
+
+    @property
+    def litellm_params(self) -> object: ...
 
 
 class _ProxyModelTable(Protocol):
@@ -263,6 +267,68 @@ def _raise_on_strategy_router_write_violation(
         code=status.HTTP_400_BAD_REQUEST,
         param="litellm_params.model",
     )
+
+
+def _litellm_params_mapping(value: object) -> Mapping[str, object]:
+    """Normalize Prisma's parsed or JSON-encoded Json column at the typed boundary."""
+    if isinstance(value, Mapping):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed: Final = json.loads(value)
+        except JSONDecodeError:
+            return MappingProxyType({})
+        return parsed if isinstance(parsed, Mapping) else MappingProxyType({})
+    return MappingProxyType({})
+
+
+def _effective_complexity_router_config(
+    incoming_params: GenericLiteLLMParams | None,
+    existing_params: GenericLiteLLMParams | None,
+) -> Mapping[str, object] | None:
+    """Return the whole config that the write leaves on the deployment."""
+    config: Final = (
+        incoming_params.complexity_router_config
+        if incoming_params is not None and incoming_params.complexity_router_config is not None
+        else existing_params.complexity_router_config
+        if existing_params is not None
+        else None
+    )
+    return config if isinstance(config, Mapping) else None
+
+
+async def _raise_if_heuristic_v2_slot_taken(
+    *,
+    prisma_client: PrismaClient,
+    incoming_params: GenericLiteLLMParams | None,
+    existing_params: GenericLiteLLMParams | None,
+    current_model_id: str | None = None,
+) -> None:
+    """Allow at most one persisted heuristic-v2 complexity router per proxy."""
+    effective_config: Final = _effective_complexity_router_config(incoming_params, existing_params)
+    if not uses_heuristic_v2(effective_config):
+        return
+    rows: Final = await _proxy_model_table(prisma_client).find_many(where={})
+    for row in rows:
+        if current_model_id is not None and row.model_id == current_model_id:
+            continue
+        if uses_heuristic_v2(
+            config
+            if isinstance(
+                config := _litellm_params_mapping(row.litellm_params).get("complexity_router_config"), Mapping
+            )
+            else None
+        ):
+            raise ProxyException(
+                message=(
+                    "Only one complexity router can use classifier_type='heuristic_v2' per proxy. "
+                    "Use classifier_type='heuristic' for this router, or change or delete the existing "
+                    "heuristic_v2 router first."
+                ),
+                type=ProxyErrorTypes.validation_error.value,
+                code=status.HTTP_400_BAD_REQUEST,
+                param="litellm_params.complexity_router_config.classifier_type",
+            )
 
 
 ENFORCE_RPM_TPM_ON_MODEL_ADD_SETTING: Final = "enforce_rpm_tpm_on_model_add"
@@ -713,6 +779,12 @@ async def patch_model(
         _raise_on_strategy_router_write_violation(
             incoming_params=patch_data.litellm_params,
             existing_params=db_model.litellm_params,
+        )
+        await _raise_if_heuristic_v2_slot_taken(
+            prisma_client=prisma_client,
+            incoming_params=patch_data.litellm_params,
+            existing_params=db_model.litellm_params,
+            current_model_id=model_id,
         )
 
         # Handle team model updates with proper alias management
@@ -1830,6 +1902,11 @@ async def add_new_model(
             incoming_params=model_params.litellm_params,
             existing_params=None,
         )
+        await _raise_if_heuristic_v2_slot_taken(
+            prisma_client=prisma_client,
+            incoming_params=model_params.litellm_params,
+            existing_params=None,
+        )
 
         _raise_if_rate_limits_required_but_missing(
             litellm_params=model_params.litellm_params,
@@ -2007,6 +2084,12 @@ async def update_model(
         _raise_on_strategy_router_write_violation(
             incoming_params=model_params.litellm_params,
             existing_params=deployment.litellm_params,
+        )
+        await _raise_if_heuristic_v2_slot_taken(
+            prisma_client=prisma_client,
+            incoming_params=model_params.litellm_params,
+            existing_params=deployment.litellm_params,
+            current_model_id=_model_id,
         )
 
         # update DB

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -8579,6 +8579,15 @@ class Router:
 
         complexity_router_config: Final[dict | None] = deployment.litellm_params.complexity_router_config
 
+        if complexity_router_config and complexity_router_config.get("classifier_type") == "heuristic_v2":
+            for registered in self.complexity_routers.values():
+                if any(tagged.strategy.config.classifier_type == "heuristic_v2" for tagged in registered):
+                    raise ValueError(
+                        "Only one complexity router can use classifier_type='heuristic_v2' per proxy. "
+                        "Use classifier_type='heuristic' for this router, or change or remove the existing "
+                        "heuristic_v2 router first."
+                    )
+
         default_model: str | None = deployment.litellm_params.complexity_router_default_model
 
         # If no default model specified, try to get from config tiers. Derived from the

--- a/litellm/router_utils/auto_router_model_naming.py
+++ b/litellm/router_utils/auto_router_model_naming.py
@@ -210,6 +210,11 @@ def carries_complexity_router_settings(model: str | None, present_fields: frozen
     )
 
 
+def uses_heuristic_v2(complexity_router_config: Mapping[str, object] | None) -> bool:
+    """Whether a complexity-router config selects the singleton v2 classifier."""
+    return complexity_router_config is not None and complexity_router_config.get("classifier_type") == "heuristic_v2"
+
+
 def validate_complexity_router_config_placement(litellm_params: Mapping[str, object] | None) -> str | None:
     """Reject a complexity-router setting written beside ``complexity_router_config``.
 

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -4011,6 +4011,50 @@ class TestStrategyRouterWriteValidation:
             is None
         )
 
+    def test_heuristic_v2_is_reserved_for_proxy_admins(self):
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _heuristic_v2_admin_violation,
+        )
+
+        config = {"classifier_type": "heuristic_v2"}
+        violation = _heuristic_v2_admin_violation(
+            effective_config=config,
+            user_role=LitellmUserRoles.INTERNAL_USER,
+        )
+        assert violation is not None
+        assert "Only proxy admins" in violation
+        assert (
+            _heuristic_v2_admin_violation(
+                effective_config=config,
+                user_role=LitellmUserRoles.PROXY_ADMIN,
+            )
+            is None
+        )
+
+    def test_team_admins_can_still_configure_heuristic_v1(self):
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _heuristic_v2_admin_violation,
+        )
+
+        assert (
+            _heuristic_v2_admin_violation(
+                effective_config={"classifier_type": "heuristic"},
+                user_role=LitellmUserRoles.INTERNAL_USER,
+            )
+            is None
+        )
+
+    def test_database_singleton_violation_is_recognized(self):
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            HEURISTIC_V2_SINGLETON_INDEX,
+            _is_heuristic_v2_slot_unique_violation,
+        )
+
+        assert _is_heuristic_v2_slot_unique_violation(
+            Exception(f'duplicate key violates unique constraint "{HEURISTIC_V2_SINGLETON_INDEX}"')
+        )
+        assert not _is_heuristic_v2_slot_unique_violation(Exception("unrelated database error"))
+
     def test_double_prefix_rejected_against_stored_params(self):
         from litellm.proxy.management_endpoints.model_management_endpoints import (
             _strategy_router_write_violation,

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -3994,6 +3994,62 @@ class TestStrategyRouterWriteValidation:
             is None
         )
 
+    @pytest.mark.parametrize(
+        "litellm_params",
+        [
+            {"complexity_router_config": {"classifier_type": "heuristic_v2"}},
+            json.dumps({"complexity_router_config": {"classifier_type": "heuristic_v2"}}),
+        ],
+    )
+    def test_config_yaml_heuristic_v2_router_takes_slot(self, litellm_params):
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _heuristic_v2_slot_violation,
+        )
+
+        violation = _heuristic_v2_slot_violation(
+            persisted_rows=(),
+            live_model_list=[
+                {
+                    "model_name": "configured-router",
+                    "litellm_params": litellm_params,
+                    "model_info": {"db_model": False},
+                }
+            ],
+            incoming_params=LiteLLM_Params(
+                model="auto_router/complexity_router",
+                complexity_router_config={"classifier_type": "heuristic_v2"},
+            ),
+            existing_params=None,
+        )
+        assert violation is not None
+        assert "config.yaml" in violation
+
+    def test_db_models_in_live_router_do_not_double_consume_slot(self):
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _heuristic_v2_slot_violation,
+        )
+
+        assert (
+            _heuristic_v2_slot_violation(
+                persisted_rows=(),
+                live_model_list=[
+                    {
+                        "model_name": "db-router",
+                        "litellm_params": {
+                            "complexity_router_config": {"classifier_type": "heuristic_v2"}
+                        },
+                        "model_info": {"db_model": True},
+                    }
+                ],
+                incoming_params=LiteLLM_Params(
+                    model="auto_router/complexity_router",
+                    complexity_router_config={"classifier_type": "heuristic_v2"},
+                ),
+                existing_params=None,
+            )
+            is None
+        )
+
     def test_heuristic_v1_does_not_consume_v2_slot(self):
         from litellm.proxy.management_endpoints.model_management_endpoints import (
             _heuristic_v2_slot_violation,

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -3953,6 +3953,80 @@ class TestStrategyRouterWriteValidation:
             model_info={"id": model_id},
         )
 
+    @pytest.mark.asyncio
+    async def test_second_heuristic_v2_router_is_rejected(self):
+        from litellm.proxy._types import ProxyException
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _raise_if_heuristic_v2_slot_taken,
+        )
+
+        table = MagicMock()
+        row = MagicMock()
+        row.model_id = "first-v2"
+        row.litellm_params = {"complexity_router_config": {"classifier_type": "heuristic_v2"}}
+        table.find_many = AsyncMock(return_value=[row])
+        with patch(
+            "litellm.proxy.management_endpoints.model_management_endpoints._proxy_model_table",
+            return_value=table,
+        ):
+            with pytest.raises(ProxyException, match="Only one complexity router"):
+                await _raise_if_heuristic_v2_slot_taken(
+                    prisma_client=MagicMock(),
+                    incoming_params=LiteLLM_Params(
+                        model="auto_router/complexity_router",
+                        complexity_router_config={"classifier_type": "heuristic_v2"},
+                    ),
+                    existing_params=None,
+                )
+
+    @pytest.mark.asyncio
+    async def test_existing_heuristic_v2_router_can_be_edited(self):
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _raise_if_heuristic_v2_slot_taken,
+        )
+        from litellm.types.router import updateLiteLLMParams
+
+        table = MagicMock()
+        row = MagicMock()
+        row.model_id = "first-v2"
+        row.litellm_params = json.dumps({"complexity_router_config": {"classifier_type": "heuristic_v2"}})
+        table.find_many = AsyncMock(return_value=[row])
+        with patch(
+            "litellm.proxy.management_endpoints.model_management_endpoints._proxy_model_table",
+            return_value=table,
+        ):
+            await _raise_if_heuristic_v2_slot_taken(
+                prisma_client=MagicMock(),
+                incoming_params=updateLiteLLMParams(rpm=10),
+                existing_params=LiteLLM_Params(
+                    model="auto_router/complexity_router",
+                    complexity_router_config={"classifier_type": "heuristic_v2"},
+                ),
+                current_model_id="first-v2",
+            )
+
+    @pytest.mark.asyncio
+    async def test_heuristic_v1_does_not_consume_v2_slot(self):
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _raise_if_heuristic_v2_slot_taken,
+        )
+
+        table = MagicMock()
+        table.find_many = AsyncMock()
+        with patch(
+            "litellm.proxy.management_endpoints.model_management_endpoints._proxy_model_table",
+            return_value=table,
+        ):
+            await _raise_if_heuristic_v2_slot_taken(
+                prisma_client=MagicMock(),
+                incoming_params=LiteLLM_Params(
+                    model="auto_router/complexity_router",
+                    complexity_router_config={"classifier_type": "heuristic"},
+                ),
+                existing_params=None,
+            )
+        table.find_many.assert_not_awaited()
+
     def test_double_prefix_rejected_against_stored_params(self):
         from litellm.proxy.management_endpoints.model_management_endpoints import (
             _strategy_router_write_violation,

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -3953,50 +3953,37 @@ class TestStrategyRouterWriteValidation:
             model_info={"id": model_id},
         )
 
-    @pytest.mark.asyncio
-    async def test_second_heuristic_v2_router_is_rejected(self):
-        from litellm.proxy._types import ProxyException
+    def test_second_heuristic_v2_router_is_rejected(self):
         from litellm.proxy.management_endpoints.model_management_endpoints import (
-            _raise_if_heuristic_v2_slot_taken,
+            _heuristic_v2_slot_violation,
         )
 
-        table = MagicMock()
         row = MagicMock()
         row.model_id = "first-v2"
         row.litellm_params = {"complexity_router_config": {"classifier_type": "heuristic_v2"}}
-        table.find_many = AsyncMock(return_value=[row])
-        with patch(
-            "litellm.proxy.management_endpoints.model_management_endpoints._proxy_model_table",
-            return_value=table,
-        ):
-            with pytest.raises(ProxyException, match="Only one complexity router"):
-                await _raise_if_heuristic_v2_slot_taken(
-                    prisma_client=MagicMock(),
-                    incoming_params=LiteLLM_Params(
-                        model="auto_router/complexity_router",
-                        complexity_router_config={"classifier_type": "heuristic_v2"},
-                    ),
-                    existing_params=None,
-                )
+        violation = _heuristic_v2_slot_violation(
+            persisted_rows=[row],
+            incoming_params=LiteLLM_Params(
+                model="auto_router/complexity_router",
+                complexity_router_config={"classifier_type": "heuristic_v2"},
+            ),
+            existing_params=None,
+        )
+        assert violation is not None
+        assert "Only one complexity router" in violation
 
-    @pytest.mark.asyncio
-    async def test_existing_heuristic_v2_router_can_be_edited(self):
+    def test_existing_heuristic_v2_router_can_be_edited(self):
         from litellm.proxy.management_endpoints.model_management_endpoints import (
-            _raise_if_heuristic_v2_slot_taken,
+            _heuristic_v2_slot_violation,
         )
         from litellm.types.router import updateLiteLLMParams
 
-        table = MagicMock()
         row = MagicMock()
         row.model_id = "first-v2"
         row.litellm_params = json.dumps({"complexity_router_config": {"classifier_type": "heuristic_v2"}})
-        table.find_many = AsyncMock(return_value=[row])
-        with patch(
-            "litellm.proxy.management_endpoints.model_management_endpoints._proxy_model_table",
-            return_value=table,
-        ):
-            await _raise_if_heuristic_v2_slot_taken(
-                prisma_client=MagicMock(),
+        assert (
+            _heuristic_v2_slot_violation(
+                persisted_rows=[row],
                 incoming_params=updateLiteLLMParams(rpm=10),
                 existing_params=LiteLLM_Params(
                     model="auto_router/complexity_router",
@@ -4004,28 +3991,25 @@ class TestStrategyRouterWriteValidation:
                 ),
                 current_model_id="first-v2",
             )
-
-    @pytest.mark.asyncio
-    async def test_heuristic_v1_does_not_consume_v2_slot(self):
-        from litellm.proxy.management_endpoints.model_management_endpoints import (
-            _raise_if_heuristic_v2_slot_taken,
+            is None
         )
 
-        table = MagicMock()
-        table.find_many = AsyncMock()
-        with patch(
-            "litellm.proxy.management_endpoints.model_management_endpoints._proxy_model_table",
-            return_value=table,
-        ):
-            await _raise_if_heuristic_v2_slot_taken(
-                prisma_client=MagicMock(),
+    def test_heuristic_v1_does_not_consume_v2_slot(self):
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _heuristic_v2_slot_violation,
+        )
+
+        assert (
+            _heuristic_v2_slot_violation(
+                persisted_rows=(),
                 incoming_params=LiteLLM_Params(
                     model="auto_router/complexity_router",
                     complexity_router_config={"classifier_type": "heuristic"},
                 ),
                 existing_params=None,
             )
-        table.find_many.assert_not_awaited()
+            is None
+        )
 
     def test_double_prefix_rejected_against_stored_params(self):
         from litellm.proxy.management_endpoints.model_management_endpoints import (

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -1085,6 +1085,60 @@ class TestRouterComplexityDeploymentMethods:
         router.init_complexity_router_deployment(deployment)
         assert "auto_router/complexity_router/test-router" in router.complexity_routers
 
+    def test_only_one_heuristic_v2_complexity_router_can_register(self):
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "gpt-4o-mini",
+                    "litellm_params": {"model": "openai/gpt-4o-mini"},
+                }
+            ]
+        )
+
+        def deployment(name: str) -> Deployment:
+            return Deployment(
+                model_name=name,
+                litellm_params=LiteLLM_Params(
+                    model=f"auto_router/complexity_router/{name}",
+                    complexity_router_default_model="gpt-4o-mini",
+                    complexity_router_config={
+                        "classifier_type": "heuristic_v2",
+                        "tiers": {"SIMPLE": "gpt-4o-mini"},
+                    },
+                ),
+                model_info={"id": name},
+            )
+
+        router.init_complexity_router_deployment(deployment("first"))
+        with pytest.raises(ValueError, match="Only one complexity router"):
+            router.init_complexity_router_deployment(deployment("second"))
+
+    def test_heuristic_v1_complexity_routers_remain_unlimited(self):
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "gpt-4o-mini",
+                    "litellm_params": {"model": "openai/gpt-4o-mini"},
+                }
+            ]
+        )
+        for name in ("first", "second"):
+            router.init_complexity_router_deployment(
+                Deployment(
+                    model_name=name,
+                    litellm_params=LiteLLM_Params(
+                        model=f"auto_router/complexity_router/{name}",
+                        complexity_router_default_model="gpt-4o-mini",
+                        complexity_router_config={
+                            "classifier_type": "heuristic",
+                            "tiers": {"SIMPLE": "gpt-4o-mini"},
+                        },
+                    ),
+                    model_info={"id": name},
+                )
+            )
+        assert set(router.complexity_routers) == {"first", "second"}
+
     def test_hybrid_initialization_waits_for_later_pool_deployments(self):
         router = Router(
             model_list=[

--- a/ui/litellm-dashboard/src/components/add_model/ClassificationMethodConfig.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/ClassificationMethodConfig.tsx
@@ -157,15 +157,21 @@ interface ClassificationMethodConfigProps {
   showValidationErrors?: boolean;
   /** The resolved default model - see resolveComplexityDefaultModel. Names and gates the radio. */
   defaultModel?: string;
+  /** Mirrors the backend's proxy-admin-only heuristic_v2 write gate. */
+  allowHeuristicV2?: boolean;
 }
 
 const ClassifierTypeRadios: React.FC<{
   value: ComplexityRouterConfigValue;
   classifierType: ClassifierType;
   onTypeChange: (classifierType: ClassifierType) => void;
-}> = ({ value, classifierType, onTypeChange }) => {
+  allowHeuristicV2: boolean;
+}> = ({ value, classifierType, onTypeChange, allowHeuristicV2 }) => {
   const scorerLocked = Boolean(value.custom_tier_set);
   const scorerLockedReason = restrictedBy(value, "heuristicClassifier")?.reason;
+  const heuristicV2Locked = scorerLocked || !allowHeuristicV2;
+  const heuristicV2LockedReason =
+    scorerLockedReason ?? (!allowHeuristicV2 ? "Only proxy admins can configure Heuristic v2." : undefined);
   return (
     <RadioGroup
       value={classifierType}
@@ -184,9 +190,9 @@ const ClassifierTypeRadios: React.FC<{
             </span>
           </Label>
         </SimpleTooltip>
-        <SimpleTooltip content={scorerLockedReason}>
+        <SimpleTooltip content={heuristicV2LockedReason}>
           <Label className="items-start font-normal leading-normal has-data-disabled:cursor-not-allowed has-data-disabled:opacity-50">
-            <RadioGroupItem value="heuristic_v2" className="mt-0.5" disabled={scorerLocked} />
+            <RadioGroupItem value="heuristic_v2" className="mt-0.5" disabled={heuristicV2Locked} />
             <span>
               <strong className="font-semibold">Heuristic v2</strong>{" "}
               <span className="text-muted-foreground">
@@ -226,6 +232,7 @@ const ClassificationMethodConfig: React.FC<ClassificationMethodConfigProps> = ({
   onCustomTechnicalKeywordsChange,
   showValidationErrors = false,
   defaultModel,
+  allowHeuristicV2 = false,
 }) => {
   const [draft, setDraft] = React.useState<{ id: string; raw: string } | null>(null);
   const hasDefaultModel = Boolean(defaultModel);
@@ -364,7 +371,12 @@ const ClassificationMethodConfig: React.FC<ClassificationMethodConfigProps> = ({
 
   return (
     <>
-      <ClassifierTypeRadios value={value} classifierType={classifierType} onTypeChange={handleClassifierTypeChange} />
+      <ClassifierTypeRadios
+        value={value}
+        classifierType={classifierType}
+        onTypeChange={handleClassifierTypeChange}
+        allowHeuristicV2={allowHeuristicV2}
+      />
 
       {classifierType === "heuristic_first" && (
         <div className="mt-4 space-y-2">

--- a/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.test.tsx
@@ -130,7 +130,12 @@ describe("ComplexityRouterConfig", () => {
   it("selects heuristic v2 without requiring a classifier model or showing weighted scoring", () => {
     const onChange = vi.fn();
     const { rerender } = renderWithProviders(
-      <ComplexityRouterConfig modelInfo={mockModelInfo} value={defaultValue} onChange={onChange} />,
+      <ComplexityRouterConfig
+        modelInfo={mockModelInfo}
+        value={defaultValue}
+        onChange={onChange}
+        allowHeuristicV2={true}
+      />,
     );
 
     fireEvent.click(screen.getByText("Advanced: Classification Method"));
@@ -144,12 +149,34 @@ describe("ComplexityRouterConfig", () => {
     );
 
     const heuristicV2Value: ComplexityRouterConfigValue = { ...defaultValue, classifier_type: "heuristic_v2" };
-    rerender(<ComplexityRouterConfig modelInfo={mockModelInfo} value={heuristicV2Value} onChange={onChange} />);
+    rerender(
+      <ComplexityRouterConfig
+        modelInfo={mockModelInfo}
+        value={heuristicV2Value}
+        onChange={onChange}
+        allowHeuristicV2={true}
+      />,
+    );
 
     expect(screen.queryByText("Classifier Model")).not.toBeInTheDocument();
     expect(screen.queryByText("Advanced scoring")).not.toBeInTheDocument();
     expect(screen.getByText(/estimates success probability for all four tiers/)).toBeInTheDocument();
     expect(screen.queryByText(/Score < 0.15/)).not.toBeInTheDocument();
+  });
+
+  it("reserves heuristic v2 selection for proxy admins", () => {
+    const onChange = vi.fn();
+    renderWithProviders(<ComplexityRouterConfig {...baseProps} onChange={onChange} allowHeuristicV2={false} />);
+
+    fireEvent.click(screen.getByText("Advanced: Classification Method"));
+
+    const heuristicV2 = screen.getByRole("radio", { name: /Heuristic v2/ });
+    expect(heuristicV2).toHaveAttribute("aria-disabled", "true");
+    expect(screen.getByRole("radio", { name: /^Heuristic \(/ })).not.toHaveAttribute("aria-disabled", "true");
+    expect(screen.getByRole("radio", { name: /LLM Classifier/ })).not.toHaveAttribute("aria-disabled", "true");
+
+    fireEvent.click(heuristicV2);
+    expect(onChange).not.toHaveBeenCalled();
   });
 
   it("should show classifier fields and use the configured values when classifier_type is llm", () => {

--- a/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.tsx
@@ -481,6 +481,7 @@ interface ComplexityRouterConfigProps {
   escalationKeywords?: string[];
   onEscalationKeywordsChange?: (keywords: string[]) => void;
   showValidationErrors?: boolean;
+  allowHeuristicV2?: boolean;
 }
 
 export const TIER_DESCRIPTIONS: Record<
@@ -599,6 +600,7 @@ const ComplexityRouterConfig: React.FC<ComplexityRouterConfigProps> = ({
   escalationKeywords = [],
   onEscalationKeywordsChange,
   showValidationErrors = false,
+  allowHeuristicV2 = false,
 }) => {
   const customTierSet = value.custom_tier_set;
   const tierRows = activeTierRows(value);
@@ -815,6 +817,7 @@ const ComplexityRouterConfig: React.FC<ComplexityRouterConfigProps> = ({
                 onCustomTechnicalKeywordsChange={onCustomTechnicalKeywordsChange}
                 showValidationErrors={showValidationErrors}
                 defaultModel={defaultModel}
+                allowHeuristicV2={allowHeuristicV2}
               />
             ),
           },

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
@@ -600,6 +600,7 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
                       escalationKeywords={escalationKeywords}
                       onEscalationKeywordsChange={setEscalationKeywords}
                       showValidationErrors={showValidationErrors}
+                      allowHeuristicV2={createScope === "unscoped-ok"}
                     />
                   </div>
                 )}


### PR DESCRIPTION
## TLDR

Adds governance for `classifier_type: heuristic_v2` on top of #39276: one proxy-wide slot, configurable only by proxy administrators.

## What changed

- Rejects a second database-backed heuristic v2 router across model create, patch, and update paths
- Counts config.yaml-defined heuristic v2 routers toward the same proxy-wide slot
- Allows editing, downgrading, or deleting the existing database-backed router
- Keeps heuristic v1 and every other auto-router type available to team administrators
- Adds a runtime registration guard for config and reload paths
- Adds a PostgreSQL partial unique index for atomic enforcement across concurrent writes and replicas
- Supports both object-shaped and JSON-string-shaped `litellm_params` rows
- Translates unique-index races into the normal model-management validation error

## Authorization

- Proxy admins may select or retain `classifier_type: heuristic_v2`
- Team admins may continue creating and managing team-scoped routers using other classifier types
- The restriction is proxy-wide because the classifier currently has one shared slot

## Config-defined routers

If config.yaml already defines a heuristic v2 router, API creation of another v2 router fails before the database write. Runtime registration independently rejects duplicate config or mixed config/database registrations.

## Atomicity

The partial unique index covers the two representations currently returned by Prisma:

- JSON objects
- JSON strings containing the serialized parameter object

A live PostgreSQL 16 check confirmed that either representation prevents inserting the other as a second heuristic v2 row.

## Verification

- 6 focused model-management tests passed
- 2 focused Router singleton tests passed
- Strict Ruff passed
- Test-quality gate passed
- Type-discipline gate passed
- Differential basedpyright gate passed
- PostgreSQL 16 mixed-representation uniqueness check passed

## Dependency

Stacked on #39276. After #39276 merges, this PR can be retargeted to `litellm_internal_staging` without changing its code.

## Type

Feature

Security

Test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes model-management authorization and persistence invariants for complexity routers; misconfiguration could block legitimate admin setup, but scope is limited to heuristic_v2 singleton enforcement.
> 
> **Overview**
> This PR enforces **one proxy-wide `classifier_type='heuristic_v2'` complexity router** and limits who can configure it.
> 
> Model **create, patch, and update** paths now run pre-write checks: non–proxy-admins get **403** when the effective config uses `heuristic_v2`; proxy admins are blocked with **400** if another DB row, a **config.yaml** deployment (non-`db_model`), or the in-memory router already holds the slot. Updates to the **same** model id are allowed. **`heuristic`** and other classifier types are unchanged for team admins.
> 
> A **partial unique index** on `LiteLLM_ProxyModelTable` backs concurrent writes (object or string `litellm_params`); unique violations are mapped to the same validation error. **`Router.init_complexity_router_deployment`** rejects registering a second v2 router at load/reload time.
> 
> Shared helper **`uses_heuristic_v2`** centralizes detection; tests cover slot logic, admin gating, config.yaml vs DB, and router registration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79f01c9461b4f5bb0035a871affa52e3081ab0b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->