### PR TITLE
feat(azure-ai): support Cohere Parse OCR

### DIFF
--- a/litellm/llms/azure_ai/ocr/__init__.py
+++ b/litellm/llms/azure_ai/ocr/__init__.py
@@ -1,5 +1,6 @@
 """Azure AI OCR module."""
 
+from .cohere_parse_transformation import AzureAICohereParseConfig
 from .common_utils import get_azure_ai_ocr_config
 from .document_intelligence.transformation import (
     AzureDocumentIntelligenceOCRConfig,
@@ -7,6 +8,7 @@ from .document_intelligence.transformation import (
 from .transformation import AzureAIOCRConfig
 
 __all__ = [
+    "AzureAICohereParseConfig",
     "AzureAIOCRConfig",
     "AzureDocumentIntelligenceOCRConfig",
     "get_azure_ai_ocr_config",

--- a/litellm/llms/azure_ai/ocr/cohere_parse_transformation.py
+++ b/litellm/llms/azure_ai/ocr/cohere_parse_transformation.py
@@ -1,0 +1,232 @@
+"""Azure AI Cohere Parse OCR transformation."""
+
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING, Final, Literal
+
+import httpx
+from pydantic import ConfigDict, TypeAdapter
+from typing_extensions import ReadOnly, TypedDict
+
+from litellm.llms.azure_ai.ocr.transformation import AzureAIOCRConfig
+from litellm.llms.base_llm.ocr.transformation import (
+    DocumentType,
+    OCRPage,
+    OCRPageImage,
+    OCRRequestData,
+    OCRResponse,
+    OCRUsageInfo,
+)
+from litellm.types.llms.base import LiteLLMPydanticObjectBase
+
+if TYPE_CHECKING:
+    from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+
+
+class _CohereParseMarkdown(LiteLLMPydanticObjectBase):
+    content: str = ""
+    images: Sequence[OCRPageImage] | None = None
+
+    model_config = ConfigDict(extra="allow", frozen=True)
+
+
+class _CohereParsePage(LiteLLMPydanticObjectBase):
+    index: int | None = None
+    markdown: _CohereParseMarkdown | str | None = None
+    blocks: Sequence[Mapping[str, object]] | None = None
+
+    model_config = ConfigDict(extra="allow", frozen=True)
+
+
+class _CohereParseBilledUnits(LiteLLMPydanticObjectBase):
+    pages: int | None = None
+
+    model_config = ConfigDict(extra="allow", frozen=True)
+
+
+class _CohereParseMeta(LiteLLMPydanticObjectBase):
+    billed_units: _CohereParseBilledUnits | None = None
+
+    model_config = ConfigDict(extra="allow", frozen=True)
+
+
+class _CohereParseResponse(LiteLLMPydanticObjectBase):
+    pages: Sequence[_CohereParsePage]
+    model: str | None = None
+    meta: _CohereParseMeta | None = None
+
+    model_config = ConfigDict(extra="allow", frozen=True)
+
+
+class _CohereImageDocument(TypedDict):
+    type: ReadOnly[Literal["image_url"]]
+    image_url: ReadOnly[str]
+
+
+class _CohereRequestPayload(TypedDict):
+    model: ReadOnly[str]
+    document: ReadOnly[_CohereImageDocument]
+    output_format: ReadOnly[object]
+
+
+class _OCRRequestDataPayload(TypedDict):
+    data: ReadOnly[_CohereRequestPayload]
+    files: ReadOnly[None]
+
+
+class _NormalizedPageData(TypedDict):
+    index: ReadOnly[int]
+    markdown: ReadOnly[str]
+    images: ReadOnly[Sequence[OCRPageImage] | None]
+    blocks: ReadOnly[Sequence[Mapping[str, object]] | None]
+
+
+class _NormalizedResponseData(TypedDict):
+    pages: ReadOnly[Sequence[OCRPage]]
+    model: ReadOnly[str]
+    usage_info: ReadOnly[OCRUsageInfo]
+    object: ReadOnly[Literal["ocr"]]
+
+
+_NATIVE_RESPONSE_ADAPTER: Final = TypeAdapter(Mapping[str, object])
+
+
+class AzureAICohereParseConfig(AzureAIOCRConfig):
+    """Translate LiteLLM OCR requests and Cohere Parse responses on Azure AI."""
+
+    def get_supported_ocr_params(self, model: str) -> list[str]:  # mutable-ok: BaseOCRConfig requires a list
+        return ["output_format"]  # mutable-ok: BaseOCRConfig requires a list
+
+    def map_ocr_params(
+        self,
+        non_default_params: Mapping[str, object],
+        optional_params: Mapping[str, object],
+        model: str,
+    ) -> dict[str, object]:  # mutable-ok: BaseOCRConfig requires a dict
+        output_format: Final = non_default_params.get("output_format")
+        if output_format is None:
+            return dict(optional_params)  # mutable-ok: BaseOCRConfig requires a dict
+        if output_format not in ("markdown", "blocks"):
+            raise ValueError("Cohere Parse output_format must be either 'markdown' or 'blocks'.")
+        return {**optional_params, "output_format": output_format}  # mutable-ok: BaseOCRConfig requires a dict
+
+    def get_complete_url(
+        self,
+        api_base: str | None,
+        model: str,
+        optional_params: Mapping[str, object],
+        litellm_params: Mapping[str, object] | None = None,
+        **kwargs: object,  # kwargs-ok: BaseOCRConfig forwards provider-specific extras
+    ) -> str:
+        if api_base is None:
+            raise ValueError(
+                "Missing Azure AI API Base - Set AZURE_AI_API_BASE environment variable or pass api_base parameter"
+            )
+
+        original_url: Final = httpx.URL(api_base)
+        if not original_url.is_absolute_url:
+            raise ValueError(f"Azure AI API Base must be an absolute URL including scheme. Got api_base={api_base!r}.")
+
+        normalized_path: Final = original_url.path.rstrip("/")
+        if normalized_path.endswith("/v2/parse"):
+            return str(original_url.copy_with(path=normalized_path))
+
+        if original_url.host and original_url.host.endswith(".models.ai.azure.com"):
+            dedicated_path: Final = f"{normalized_path}/v2/parse" if normalized_path else "/v2/parse"
+            return str(original_url.copy_with(path=dedicated_path))
+
+        foundry_path: Final = normalized_path.removesuffix("/models")
+        provider_path: Final = f"{foundry_path}/providers/cohere/v2/parse"
+        return str(original_url.copy_with(path=provider_path))
+
+    @staticmethod
+    def _validate_image_document(document: DocumentType) -> str:
+        if document.get("type") != "image_url":
+            raise ValueError(
+                "Cohere Parse currently supports only document.type='image_url'; "
+                "document_url and PDF inputs are not supported"
+            )
+
+        image_url: Final = document.get("image_url", "")
+        if not image_url:
+            raise ValueError("Cohere Parse image_url must not be empty")
+        if image_url.lower().startswith("data:application/pdf"):
+            raise ValueError("Cohere Parse does not support PDF inputs; provide an image_url")
+        return image_url
+
+    def transform_ocr_request(
+        self,
+        model: str,
+        document: DocumentType,
+        optional_params: Mapping[str, object],
+        headers: Mapping[str, object],
+        **kwargs: object,  # kwargs-ok: BaseOCRConfig forwards provider-specific extras
+    ) -> OCRRequestData:
+        image_url: Final = self._validate_image_document(document)
+        converted_url: Final = (
+            image_url if image_url.startswith("data:") else self._convert_url_to_data_uri_sync(url=image_url)
+        )
+        return self._build_request(model=model, image_url=converted_url, optional_params=optional_params)
+
+    async def async_transform_ocr_request(
+        self,
+        model: str,
+        document: DocumentType,
+        optional_params: Mapping[str, object],
+        headers: Mapping[str, object],
+        **kwargs: object,  # kwargs-ok: BaseOCRConfig forwards provider-specific extras
+    ) -> OCRRequestData:
+        image_url: Final = self._validate_image_document(document)
+        converted_url: Final = (
+            image_url if image_url.startswith("data:") else await self._convert_url_to_data_uri_async(url=image_url)
+        )
+        return self._build_request(model=model, image_url=converted_url, optional_params=optional_params)
+
+    @staticmethod
+    def _build_request(model: str, image_url: str, optional_params: Mapping[str, object]) -> OCRRequestData:
+        document: Final[_CohereImageDocument] = {"type": "image_url", "image_url": image_url}
+        payload: Final[_CohereRequestPayload] = {
+            "model": model,
+            "document": document,
+            "output_format": optional_params.get("output_format", "markdown"),
+        }
+        request_data: Final[_OCRRequestDataPayload] = {"data": payload, "files": None}
+        return OCRRequestData.model_validate(request_data)
+
+    @staticmethod
+    def _normalize_page(page: _CohereParsePage, page_number: int) -> OCRPage:
+        markdown_value: Final = page.markdown
+        markdown: Final = markdown_value.content if isinstance(markdown_value, _CohereParseMarkdown) else markdown_value
+        images: Final = markdown_value.images if isinstance(markdown_value, _CohereParseMarkdown) else None
+        page_data: Final[_NormalizedPageData] = {
+            "index": page.index if page.index is not None else page_number,
+            "markdown": markdown or "",
+            "images": images,
+            "blocks": page.blocks,
+        }
+        return OCRPage.model_validate(page_data)
+
+    def transform_ocr_response(
+        self,
+        model: str,
+        raw_response: httpx.Response,
+        logging_obj: "LiteLLMLoggingObj",
+        **kwargs: object,  # kwargs-ok: BaseOCRConfig forwards provider-specific extras
+    ) -> OCRResponse:
+        native_response: Final = _NATIVE_RESPONSE_ADAPTER.validate_json(raw_response.content)
+        response_data: Final = _CohereParseResponse.model_validate(native_response)
+        normalized_pages: Final = tuple(
+            self._normalize_page(page=page, page_number=page_number)
+            for page_number, page in enumerate(response_data.pages)
+        )
+        billed_units: Final = response_data.meta.billed_units if response_data.meta is not None else None
+        normalized_response: Final[_NormalizedResponseData] = {
+            "pages": normalized_pages,
+            "model": response_data.model or model,
+            "usage_info": OCRUsageInfo(pages_processed=billed_units.pages if billed_units is not None else None),
+            "object": "ocr",
+        }
+        response: Final = OCRResponse.model_validate(normalized_response)
+        response.set_provider_native_response(  # pyright: ignore[reportUnknownMemberType]  # base mapping values are untyped
+            native_response
+        )
+        return response

--- a/litellm/llms/azure_ai/ocr/common_utils.py
+++ b/litellm/llms/azure_ai/ocr/common_utils.py
@@ -24,13 +24,20 @@ def is_azure_document_intelligence_model(model: str) -> bool:
     return "doc-intelligence" in lowered or "documentintelligence" in lowered
 
 
+def is_azure_cohere_parse_model(model: str) -> bool:
+    """Whether an Azure AI OCR model routes to Cohere Parse."""
+    normalized: Final = model.lower().replace("_", "-").rsplit("/", 1)[-1]
+    return normalized == "cohere-parse-v5"
+
+
 def get_azure_ai_ocr_config(model: str) -> Optional["BaseOCRConfig"]:
     """
     Determine which Azure AI OCR configuration to use based on the model name.
 
     Azure AI supports multiple OCR services:
     - Azure Document Intelligence: azure_ai/doc-intelligence/<model>
-    - Mistral OCR (via Azure AI): azure_ai/<model>
+    - Cohere Parse: azure_ai/Cohere-parse-v5
+    - Mistral OCR (via Azure AI): other azure_ai OCR models
 
     Args:
         model: The model name (e.g., "azure_ai/doc-intelligence/prebuilt-read",
@@ -46,6 +53,9 @@ def get_azure_ai_ocr_config(model: str) -> Optional["BaseOCRConfig"]:
         >>> get_azure_ai_ocr_config("azure_ai/pixtral-12b-2409")
         <AzureAIOCRConfig object>
     """
+    from litellm.llms.azure_ai.ocr.cohere_parse_transformation import (
+        AzureAICohereParseConfig,
+    )
     from litellm.llms.azure_ai.ocr.document_intelligence.transformation import (
         AzureDocumentIntelligenceOCRConfig,
     )
@@ -55,6 +65,10 @@ def get_azure_ai_ocr_config(model: str) -> Optional["BaseOCRConfig"]:
     if is_azure_document_intelligence_model(model):
         verbose_logger.debug("Routing %s to Azure Document Intelligence OCR config", model)
         return AzureDocumentIntelligenceOCRConfig()
+
+    if is_azure_cohere_parse_model(model):
+        verbose_logger.debug("Routing %s to Azure AI Cohere Parse config", model)
+        return AzureAICohereParseConfig()
 
     # Default to Mistral-based OCR for other azure_ai models
     verbose_logger.debug("Routing %s to Azure AI (Mistral) OCR config", model)

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -9953,6 +9953,25 @@
         "supports_tool_choice": true,
         "supports_reasoning": true
     },
+    "azure_ai/Cohere-parse-v5": {
+        "deprecation_date": "2026-12-15",
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 8192,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "ocr",
+        "ocr_cost_per_page": 0.0015,
+        "source": "https://cohere.com/blog/parse",
+        "supported_endpoints": [
+            "/v1/ocr"
+        ],
+        "supported_modalities": [
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ]
+    },
     "azure_ai/mistral-document-ai-2505": {
         "deprecation_date": "2026-07-20",
         "litellm_provider": "azure_ai",

--- a/litellm/ocr/main.py
+++ b/litellm/ocr/main.py
@@ -19,6 +19,7 @@ from litellm._logging import verbose_logger
 from litellm.constants import request_timeout
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.llms.azure_ai.ocr.common_utils import (
+    is_azure_cohere_parse_model,
     is_azure_document_intelligence_model,
 )
 from litellm.llms.base_llm.ocr.transformation import (
@@ -190,6 +191,9 @@ def _prepare_ocr_request(
 
 def _rust_ocr_supported(prepared_request: _PreparedOCRRequest) -> bool:
     if prepared_request.optional_params.get(OCR_REQUEST_FORMAT_PARAM) == "native":
+        return False
+    if prepared_request.custom_llm_provider == "azure_ai" and is_azure_cohere_parse_model(prepared_request.model):
+        # The Rust Azure OCR bridge currently implements the Mistral schema only.
         return False
     return prepared_request.custom_llm_provider in _RUST_OCR_PROVIDERS
 

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -9953,6 +9953,25 @@
         "supports_tool_choice": true,
         "supports_reasoning": true
     },
+    "azure_ai/Cohere-parse-v5": {
+        "deprecation_date": "2026-12-15",
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 8192,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "ocr",
+        "ocr_cost_per_page": 0.0015,
+        "source": "https://cohere.com/blog/parse",
+        "supported_endpoints": [
+            "/v1/ocr"
+        ],
+        "supported_modalities": [
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ]
+    },
     "azure_ai/mistral-document-ai-2505": {
         "deprecation_date": "2026-07-20",
         "litellm_provider": "azure_ai",

--- a/tests/test_litellm/llms/azure_ai/test_cohere_parse_transformation.py
+++ b/tests/test_litellm/llms/azure_ai/test_cohere_parse_transformation.py
@@ -1,0 +1,212 @@
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from litellm.llms.azure_ai.ocr.cohere_parse_transformation import (
+    AzureAICohereParseConfig,
+)
+from litellm.llms.azure_ai.ocr.common_utils import get_azure_ai_ocr_config
+from litellm.llms.azure_ai.ocr.transformation import AzureAIOCRConfig
+
+
+@pytest.fixture
+def local_model_cost_map(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+
+    import litellm
+
+    return litellm.get_model_cost_map(url="")
+
+
+def test_cohere_parse_uses_its_own_azure_ocr_config():
+    assert isinstance(get_azure_ai_ocr_config("Cohere-parse-v5"), AzureAICohereParseConfig)
+    assert type(get_azure_ai_ocr_config("parse-v5.0")) is AzureAIOCRConfig
+
+
+@pytest.mark.parametrize(
+    "api_base,expected",
+    [
+        (
+            "https://example.services.ai.azure.com",
+            "https://example.services.ai.azure.com/providers/cohere/v2/parse",
+        ),
+        (
+            "https://region.api.cognitive.microsoft.com/models",
+            "https://region.api.cognitive.microsoft.com/providers/cohere/v2/parse",
+        ),
+        (
+            "https://cohere-parse-v5.region.models.ai.azure.com",
+            "https://cohere-parse-v5.region.models.ai.azure.com/v2/parse",
+        ),
+        (
+            "https://example.services.ai.azure.com/providers/cohere/v2/parse",
+            "https://example.services.ai.azure.com/providers/cohere/v2/parse",
+        ),
+    ],
+)
+def test_cohere_parse_url(api_base: str, expected: str):
+    config = AzureAICohereParseConfig()
+
+    assert (
+        config.get_complete_url(
+            api_base=api_base,
+            model="Cohere-parse-v5",
+            optional_params={},
+        )
+        == expected
+    )
+
+
+def test_cohere_parse_uses_bearer_authentication():
+    config = AzureAICohereParseConfig()
+
+    headers = config.validate_environment(
+        headers={},
+        model="Cohere-parse-v5",
+        api_key="test-key",
+        api_base="https://example.services.ai.azure.com",
+    )
+
+    assert headers == {
+        "Authorization": "Bearer test-key",
+        "Content-Type": "application/json",
+    }
+
+
+def test_cohere_parse_validates_output_format():
+    config = AzureAICohereParseConfig()
+
+    assert config.map_ocr_params(
+        non_default_params={"output_format": "blocks"},
+        optional_params={},
+        model="Cohere-parse-v5",
+    ) == {"output_format": "blocks"}
+    with pytest.raises(ValueError, match="either 'markdown' or 'blocks'"):
+        config.map_ocr_params(
+            non_default_params={"output_format": "json"},
+            optional_params={},
+            model="Cohere-parse-v5",
+        )
+
+
+def test_cohere_parse_request_uses_exact_azure_model_and_cohere_schema():
+    config = AzureAICohereParseConfig()
+
+    request = config.transform_ocr_request(
+        model="Cohere-parse-v5",
+        document={
+            "type": "image_url",
+            "image_url": "data:image/png;base64,aGVsbG8=",
+        },
+        optional_params={"output_format": "blocks"},
+        headers={},
+    )
+
+    assert request.data == {
+        "model": "Cohere-parse-v5",
+        "document": {
+            "type": "image_url",
+            "image_url": "data:image/png;base64,aGVsbG8=",
+        },
+        "output_format": "blocks",
+    }
+    assert request.files is None
+
+
+@pytest.mark.parametrize(
+    "document,error",
+    [
+        (
+            {"type": "document_url", "document_url": "https://example.com/document.pdf"},
+            "document_url and PDF inputs are not supported",
+        ),
+        (
+            {"type": "document_url", "document_url": "data:application/pdf;base64,JVBERi0="},
+            "document_url and PDF inputs are not supported",
+        ),
+        (
+            {"type": "image_url", "image_url": "data:application/pdf;base64,JVBERi0="},
+            "does not support PDF inputs",
+        ),
+    ],
+)
+def test_cohere_parse_rejects_document_urls_and_pdfs(document: dict[str, str], error: str):
+    config = AzureAICohereParseConfig()
+
+    with pytest.raises(ValueError, match=error):
+        config.transform_ocr_request(
+            model="Cohere-parse-v5",
+            document=document,
+            optional_params={},
+            headers={},
+        )
+
+
+@pytest.mark.asyncio
+async def test_cohere_parse_async_rejects_document_urls():
+    config = AzureAICohereParseConfig()
+
+    with pytest.raises(ValueError, match="document_url and PDF inputs are not supported"):
+        await config.async_transform_ocr_request(
+            model="Cohere-parse-v5",
+            document={"type": "document_url", "document_url": "https://example.com/document.pdf"},
+            optional_params={},
+            headers={},
+        )
+
+
+def test_cohere_parse_response_is_normalized_to_litellm_ocr():
+    config = AzureAICohereParseConfig()
+    native_response = {
+        "id": "parse-123",
+        "pages": [
+            {
+                "type": "markdown",
+                "index": 0,
+                "markdown": {
+                    "content": "# Invoice",
+                    "images": [
+                        {
+                            "id": "img-0",
+                            "description": "Company logo",
+                            "bounding_box": {"top_left_x": 1},
+                        }
+                    ],
+                },
+            }
+        ],
+        "meta": {"billed_units": {"pages": 1}},
+    }
+    raw_response = httpx.Response(
+        status_code=200,
+        json=native_response,
+        request=httpx.Request("POST", "https://example.test/v2/parse"),
+    )
+
+    response = config.transform_ocr_response(
+        model="Cohere-parse-v5",
+        raw_response=raw_response,
+        logging_obj=MagicMock(),
+    )
+
+    assert response.model == "Cohere-parse-v5"
+    assert response.pages[0].markdown == "# Invoice"
+    assert response.pages[0].images is not None
+    assert response.pages[0].images[0].model_extra["id"] == "img-0"
+    assert response.usage_info is not None
+    assert response.usage_info.pages_processed == 1
+    assert response.get_provider_native_response() == native_response
+
+
+def test_cohere_parse_model_metadata(local_model_cost_map: dict):
+    model_info = local_model_cost_map["azure_ai/Cohere-parse-v5"]
+
+    assert model_info["litellm_provider"] == "azure_ai"
+    assert model_info["mode"] == "ocr"
+    assert model_info["max_input_tokens"] == 8192
+    assert model_info["max_output_tokens"] == 64000
+    assert model_info["ocr_cost_per_page"] == 0.0015
+    assert model_info["deprecation_date"] == "2026-12-15"
+    assert model_info["supported_modalities"] == ["image"]
+    assert model_info["supported_output_modalities"] == ["text"]

--- a/tests/test_litellm/ocr/test_ocr_native_format.py
+++ b/tests/test_litellm/ocr/test_ocr_native_format.py
@@ -39,6 +39,13 @@ def test_rust_ocr_skipped_for_native_format():
     assert _rust_ocr_supported(_prepared({"req_format": "native"})) is False
 
 
+def test_rust_ocr_skipped_for_cohere_parse_schema():
+    prepared = _prepared({})
+    prepared.model = "Cohere-parse-v5"
+
+    assert _rust_ocr_supported(prepared) is False
+
+
 @pytest.mark.asyncio
 async def test_native_format_rejected_for_provider_without_support_as_bad_request():
     with pytest.raises(litellm.BadRequestError, match="not supported for provider") as exc_info:


### PR DESCRIPTION
## TLDR

Problem this solves:

- Azure Cohere Parse requests use the Mistral OCR route
- Cohere page pricing and model limits are missing

How it solves it:

- Adds Cohere routing, request, response, and usage transforms
- Adds exact model metadata and input validation

## User Flow

Before: a developer cannot parse an image with an Azure Cohere Parse deployment

1. They configure `azure_ai/Cohere-parse-v5` with an Azure endpoint
2. They send `POST https://litellm-domain/v1/ocr` with an `image_url` data URI
3. Azure receives a Mistral OCR request and the parse fails

After: the same developer receives normalized OCR pages and billed-page usage

1. They configure `azure_ai/Cohere-parse-v5` with an Azure endpoint
2. They send `POST https://litellm-domain/v1/ocr` with an `image_url` data URI
3. The request returns 200 with `pages` and `usage_info.pages_processed`

## Relevant issues

## Linear ticket

## Sources

- [Azure model catalog](https://ai.azure.com/catalog/models/Cohere-parse-v5)
- [Cohere Parse API](https://docs.cohere.com/v2/reference/parse)
- [Cohere Parse pricing](https://cohere.com/blog/parse)
- [Cohere on Azure](https://docs.cohere.com/v1/docs/cohere-on-microsoft-azure)

## Validation notes

- France Central and West US Azure endpoints returned HTTP 200
- Direct requests used Bearer auth and exact model `Cohere-parse-v5`
- Both direct responses reported one page and one billed page
- A live LiteLLM gateway `/v1/ocr` request returned HTTP 200
- Native name `parse-v5.0` returned `DeploymentNotFound`

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

The live requests used an image data URI because Parse currently accepts image input only

### Before (4c51ca72d6)

1. This revision had no Cohere Parse dispatch, so no successful live gateway result was captured

### After (10039d7f12)

1. `POST https://<gateway>/v1/ocr` used model `cohere-parse-v5` and an `image_url` data URI
2. The gateway returned HTTP 200
3. `POST https://<france-central-resource>/providers/cohere/v2/parse` used `Cohere-parse-v5`
4. Azure returned HTTP 200 with one page and one billed page
5. `POST https://<west-us-resource>.services.ai.azure.com/providers/cohere/v2/parse` used the same payload
6. Azure returned HTTP 200 with one page and one billed page
7. Replacing the model with `parse-v5.0` returned `DeploymentNotFound`

## Type

New Feature
Test

## Caveats (if any)

### Medium

- Per-page pricing is provider-derived until Azure publishes its meter

### Low

- The API currently accepts only `image_url` inputs
- `document_url` and PDF inputs fail before the provider call
- The retirement date comes from the live Azure catalog

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
