### PR TITLE
feat(rust-python-harness): add existing_e2e_test_sdk strategy + core/* namespace

### DIFF
--- a/tests/rust-python-harness/catalog.py
+++ b/tests/rust-python-harness/catalog.py
@@ -15,7 +15,43 @@ def _require_string(value: Any, field: str, source: Path) -> str:
     return value
 
 
-def _load_strategy(source: Path) -> Strategy:
+def _load_variants(data: dict[str, Any], source: Path) -> tuple[tuple[str | None, dict[str, str]], ...]:
+    """Parse the optional `variants` manifest key.
+
+    Absent `variants` yields a single unnamed variant with no environment
+    overrides, so a manifest that never declares variants keeps its plain
+    strategy id (backward compatible with the original three strategies).
+    A declared `variants` list always suffixes the resulting strategy ids
+    with `__<name>`, even for a single entry, so a manifest opting into the
+    mechanism is unambiguous about which cells came from which environment.
+    """
+    raw = data.get("variants")
+    if raw is None:
+        return ((None, {}),)
+    if not isinstance(raw, list) or not raw:
+        raise ValueError(f"{source}: variants must be a non-empty list")
+    variants: list[tuple[str | None, dict[str, str]]] = []
+    seen: set[str] = set()
+    for entry in raw:
+        if not isinstance(entry, dict):
+            raise ValueError(f"{source}: each variant must be an object")
+        name = _require_string(entry.get("name"), "variants[].name", source)
+        if name in seen:
+            raise ValueError(f"{source}: duplicate variant name {name!r}")
+        seen.add(name)
+        env = entry.get("env", {})
+        if not isinstance(env, dict) or not all(
+            isinstance(key, str) and isinstance(value, str)
+            for key, value in env.items()
+        ):
+            raise ValueError(
+                f"{source}: variants[].env must be a string-to-string mapping"
+            )
+        variants.append((name, dict(env)))
+    return tuple(variants)
+
+
+def _load_strategies(source: Path) -> tuple[Strategy, ...]:
     with source.open(encoding="utf-8") as stream:
         data = json.load(stream)
 
@@ -36,7 +72,7 @@ def _load_strategy(source: Path) -> Strategy:
             f"{source}: functions must exactly match {SDK_FUNCTIONS}; missing={missing}, extra={extra}"
         )
 
-    cases: list[HarnessCase] = []
+    parsed_functions: dict[str, tuple[Coverage, tuple[str, ...], str]] = {}
     for sdk_function in SDK_FUNCTIONS:
         case_data = function_data[sdk_function]
         if not isinstance(case_data, dict):
@@ -56,25 +92,39 @@ def _load_strategy(source: Path) -> Strategy:
             raise ValueError(
                 f"{source}: not_applicable case {sdk_function} cannot have selectors"
             )
-        cases.append(
-            HarnessCase(
-                strategy_id=strategy_id,
-                strategy_label=label,
-                sdk_function=sdk_function,
-                coverage=coverage,
-                selectors=tuple(selectors),
-                note=str(case_data.get("note", "")),
-            )
+        parsed_functions[sdk_function] = (
+            coverage,
+            tuple(selectors),
+            str(case_data.get("note", "")),
         )
 
-    return Strategy(
-        order=order,
-        id=strategy_id,
-        label=label,
-        description=description,
-        directory=source.parent,
-        cases=tuple(cases),
-    )
+    strategies: list[Strategy] = []
+    for variant_name, env in _load_variants(data, source):
+        variant_id = strategy_id if variant_name is None else f"{strategy_id}__{variant_name}"
+        variant_label = label if variant_name is None else f"{label} [{variant_name}]"
+        cases = tuple(
+            HarnessCase(
+                strategy_id=variant_id,
+                strategy_label=variant_label,
+                sdk_function=sdk_function,
+                coverage=coverage,
+                selectors=selectors,
+                note=note,
+            )
+            for sdk_function, (coverage, selectors, note) in parsed_functions.items()
+        )
+        strategies.append(
+            Strategy(
+                order=order,
+                id=variant_id,
+                label=variant_label,
+                description=description,
+                directory=source.parent,
+                cases=cases,
+                env=env,
+            )
+        )
+    return tuple(strategies)
 
 
 def load_catalog(root: Path = STRATEGIES_ROOT) -> tuple[Strategy, ...]:
@@ -83,7 +133,11 @@ def load_catalog(root: Path = STRATEGIES_ROOT) -> tuple[Strategy, ...]:
         raise ValueError(f"No strategy manifests found below {root}")
     strategies = tuple(
         sorted(
-            (_load_strategy(source) for source in sources),
+            (
+                strategy
+                for source in sources
+                for strategy in _load_strategies(source)
+            ),
             key=lambda strategy: strategy.order,
         )
     )

--- a/tests/rust-python-harness/cli.py
+++ b/tests/rust-python-harness/cli.py
@@ -6,8 +6,8 @@ from collections.abc import Sequence
 from pathlib import Path
 
 from .catalog import load_catalog
-from .models import HarnessCase, Strategy
-from .runner import run_pytest
+from .models import SDK_FUNCTIONS, HarnessCase, Strategy
+from .runner import run_pytest_grouped
 from .ui import make_dashboard
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -40,7 +40,7 @@ def _parser() -> argparse.ArgumentParser:
         action="append",
         default=[],
         dest="sdk_functions",
-        choices=("ocr", "messages", "responses", "count_tokens"),
+        choices=SDK_FUNCTIONS,
         help="run only this SDK function",
     )
     parser.add_argument(
@@ -100,7 +100,7 @@ def _interactive_filters(strategies: Sequence[Strategy]) -> tuple[set[str], set[
     )
     sdk_functions = _pick_values(
         "SDK functions",
-        [(name, name) for name in ("ocr", "messages", "responses", "count_tokens")],
+        [(name, name) for name in SDK_FUNCTIONS],
     )
     return strategy_ids, sdk_functions
 
@@ -166,11 +166,13 @@ def main(argv: Sequence[str] | None = None) -> int:
     pytest_args = [*args.pytest_arg]
     if args.coverage:
         pytest_args.extend(_coverage_pytest_args())
+    strategy_env = {strategy.id: strategy.env for strategy in strategies}
     with dashboard:
-        exit_code, run = run_pytest(
+        exit_code, run = run_pytest_grouped(
             cases=cases,
             repo_root=REPO_ROOT,
             on_update=dashboard.update,
+            strategy_env=strategy_env,
             pytest_args=pytest_args,
         )
         dashboard.finish(run, exit_code)

--- a/tests/rust-python-harness/e2e_fuzz_tests/strategy.json
+++ b/tests/rust-python-harness/e2e_fuzz_tests/strategy.json
@@ -4,9 +4,9 @@
   "label": "End-to-end fuzz tests",
   "description": "Compare observable Python and Rust SDK behavior over generated and recorded inputs.",
   "functions": {
-    "ocr": {"coverage": "partial", "selectors": ["tests/test_litellm/ocr/test_rust_bridge.py"], "note": "Bridge coverage exists; frozen-oracle fuzz parity is still being added."},
-    "messages": {"coverage": "partial", "selectors": ["tests/test_litellm/anthropic_interface/test_rust_bridge_messages.py"], "note": "Bridge coverage exists; frozen-oracle fuzz parity is still being added."},
-    "responses": {"coverage": "partial", "selectors": ["tests/test_litellm/responses/test_rust_bridge_websocket.py"], "note": "Covers the websocket bridge; full responses parity is still being added."},
-    "count_tokens": {"coverage": "planned", "selectors": [], "note": "No Rust count_tokens parity test is present yet."}
+    "core/ocr": {"coverage": "partial", "selectors": ["tests/test_litellm/ocr/test_rust_bridge.py"], "note": "Bridge coverage exists; frozen-oracle fuzz parity is still being added."},
+    "core/messages": {"coverage": "partial", "selectors": ["tests/test_litellm/anthropic_interface/test_rust_bridge_messages.py"], "note": "Bridge coverage exists; frozen-oracle fuzz parity is still being added."},
+    "core/responses": {"coverage": "partial", "selectors": ["tests/test_litellm/responses/test_rust_bridge_websocket.py"], "note": "Covers the websocket bridge; full responses parity is still being added."},
+    "core/count_tokens": {"coverage": "planned", "selectors": [], "note": "No Rust count_tokens parity test is present yet."}
   }
 }

--- a/tests/rust-python-harness/existing_e2e_test_sdk/README.md
+++ b/tests/rust-python-harness/existing_e2e_test_sdk/README.md
@@ -1,0 +1,12 @@
+# Existing e2e SDK tests
+
+Reruns the real provider e2e suites that already live under `tests/` — for
+example `tests/ocr_tests/`, which calls `litellm.ocr()`/`litellm.aocr()`
+against live Mistral, Azure AI, Azure Document Intelligence, and Vertex AI
+endpoints — once with the Rust bridge disabled and once with it enabled, via
+each function's environment-variable toggle (`LITELLM_USE_RUST_OCR` for
+OCR). Unlike `e2e_fuzz_tests/`, which fuzzes bridge-level inputs, this
+strategy proves that pre-existing, human-written SDK-level tests keep
+passing unmodified on both code paths. It requires the same provider
+credentials the underlying suites already require and makes real,
+billable API calls.

--- a/tests/rust-python-harness/existing_e2e_test_sdk/strategy.json
+++ b/tests/rust-python-harness/existing_e2e_test_sdk/strategy.json
@@ -1,0 +1,25 @@
+{
+  "order": 40,
+  "id": "existing_e2e_test_sdk",
+  "label": "Existing e2e SDK tests",
+  "description": "Run the SDK-level e2e provider tests that already live under tests/ once per Rust/Python environment variant, so a real end-to-end call proves parity instead of only a bridge-level comparison.",
+  "variants": [
+    {"name": "python", "env": {"LITELLM_USE_RUST_OCR": "0"}},
+    {"name": "rust", "env": {"LITELLM_USE_RUST_OCR": "1"}}
+  ],
+  "functions": {
+    "core/ocr": {
+      "coverage": "partial",
+      "selectors": [
+        "tests/ocr_tests/test_ocr_mistral.py",
+        "tests/ocr_tests/test_ocr_azure_ai.py",
+        "tests/ocr_tests/test_ocr_azure_document_intelligence.py",
+        "tests/ocr_tests/test_ocr_vertex_ai.py"
+      ],
+      "note": "Live SDK-level litellm.ocr()/aocr() calls against real providers. LITELLM_USE_RUST_OCR toggles the Rust bridge, so the python/rust rows prove the same test suite passes on both paths. Requires provider credentials; partial because it does not yet cover every OCR provider litellm supports."
+    },
+    "core/messages": {"coverage": "planned", "selectors": [], "note": "No env-var Rust toggle exists yet for litellm.messages(); wire it here once dsh-messages gains one."},
+    "core/responses": {"coverage": "planned", "selectors": [], "note": "No env-var Rust toggle exists yet for litellm.responses(); wire it here once one is added."},
+    "core/count_tokens": {"coverage": "planned", "selectors": [], "note": "No existing e2e SDK test suite with a Rust toggle exists yet."}
+  }
+}

--- a/tests/rust-python-harness/models.py
+++ b/tests/rust-python-harness/models.py
@@ -33,7 +33,7 @@ class ConfidenceLevel(str, Enum):
     LOW = "LOW"
 
 
-SDK_FUNCTIONS = ("ocr", "messages", "responses", "count_tokens")
+SDK_FUNCTIONS = ("core/ocr", "core/messages", "core/responses", "core/count_tokens")
 
 
 @dataclass(frozen=True)
@@ -58,6 +58,7 @@ class Strategy:
     description: str
     directory: Path
     cases: tuple[HarnessCase, ...]
+    env: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass

--- a/tests/rust-python-harness/runner.py
+++ b/tests/rust-python-harness/runner.py
@@ -2,14 +2,56 @@ from __future__ import annotations
 
 import os
 from collections.abc import Callable, Sequence
+from contextlib import contextmanager
 from pathlib import Path
 from time import monotonic
+from typing import Iterator
 
 import pytest
 
 from .models import CaseResult, HarnessCase, HarnessRun, RunStatus
 
 UpdateCallback = Callable[[HarnessRun], None]
+
+
+def _env_truthy(value: str | None) -> bool:
+    return (value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+@contextmanager
+def _temporary_env(overrides: dict[str, str]) -> Iterator[None]:
+    """Apply environment overrides for the duration of the block, then restore.
+
+    `LITELLM_USE_RUST_OCR` is read once at `litellm.rust_bridge.ocr` import
+    time, so mutating `os.environ` alone has no effect once that module is
+    already loaded in this process (as it will be across repeated in-process
+    `pytest.main()` calls). Re-apply it through `use_litellm_rust()`, the
+    module's own runtime toggle, so an OCR variant actually switches paths.
+    """
+    if not overrides:
+        yield
+        return
+    previous = {key: os.environ.get(key) for key in overrides}
+    os.environ.update(overrides)
+    rust_ocr_module = None
+    previous_rust_ocr_enabled = False
+    if "LITELLM_USE_RUST_OCR" in overrides:
+        from litellm.rust_bridge import ocr as rust_ocr_module
+
+        previous_rust_ocr_enabled = rust_ocr_module.rust_ocr_enabled()
+        rust_ocr_module.use_litellm_rust(
+            enabled=_env_truthy(overrides["LITELLM_USE_RUST_OCR"])
+        )
+    try:
+        yield
+    finally:
+        if rust_ocr_module is not None:
+            rust_ocr_module.use_litellm_rust(enabled=previous_rust_ocr_enabled)
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
 
 
 def selector_matches_node(selector: str, nodeid: str) -> bool:
@@ -127,6 +169,7 @@ def run_pytest(
     repo_root: Path,
     on_update: UpdateCallback,
     pytest_args: Sequence[str] = (),
+    env: dict[str, str] | None = None,
 ) -> tuple[int, HarnessRun]:
     run = HarnessRun.from_cases(cases)
     selectors = runnable_selectors(cases, repo_root)
@@ -150,7 +193,8 @@ def run_pytest(
     previous_directory = Path.cwd()
     try:
         os.chdir(repo_root)
-        exit_code = int(pytest.main(args, plugins=[plugin]))
+        with _temporary_env(env or {}):
+            exit_code = int(pytest.main(args, plugins=[plugin]))
     finally:
         os.chdir(previous_directory)
     if exit_code == 0 and any(
@@ -158,3 +202,49 @@ def run_pytest(
     ):
         exit_code = int(pytest.ExitCode.TESTS_FAILED)
     return exit_code, run
+
+
+def run_pytest_grouped(
+    cases: Sequence[HarnessCase],
+    repo_root: Path,
+    on_update: UpdateCallback,
+    strategy_env: dict[str, dict[str, str]],
+    pytest_args: Sequence[str] = (),
+) -> tuple[int, HarnessRun]:
+    """Run `cases` once per distinct owning-strategy environment.
+
+    A strategy that declares `variants` (for example Python vs. Rust via
+    `LITELLM_USE_RUST_OCR`) produces one `HarnessCase` per variant, each
+    carrying its own `strategy_id`. This groups cases by their strategy's
+    environment overrides, runs pytest once per group under that
+    environment, and merges every group's results into one combined run so
+    a variant that fails is never silently overwritten by one that passes.
+    """
+    groups: dict[tuple[tuple[str, str], ...], list[HarnessCase]] = {}
+    for case in cases:
+        env = strategy_env.get(case.strategy_id, {})
+        groups.setdefault(tuple(sorted(env.items())), []).append(case)
+
+    combined = HarnessRun.from_cases(cases)
+
+    def merge_update(sub_run: HarnessRun) -> None:
+        combined.results.update(sub_run.results)
+        combined.current_nodeid = sub_run.current_nodeid
+        for failure in sub_run.failures:
+            if failure not in combined.failures:
+                combined.failures.append(failure)
+        on_update(combined)
+
+    exit_code = 0
+    for env_items, group_cases in groups.items():
+        sub_exit_code, _ = run_pytest(
+            group_cases,
+            repo_root,
+            merge_update,
+            pytest_args,
+            env=dict(env_items),
+        )
+        exit_code = exit_code or sub_exit_code
+    combined.finished_at = monotonic()
+    on_update(combined)
+    return exit_code, combined

--- a/tests/rust-python-harness/ui.py
+++ b/tests/rust-python-harness/ui.py
@@ -119,7 +119,7 @@ class RichDashboard(AbstractContextManager["RichDashboard"]):
 
         table = Table(box=box.ROUNDED, expand=True, title="Strategy × SDK function")
         table.add_column("Strategy", ratio=3)
-        for label in ("ocr/aocr", "messages", "responses", "count_tokens"):
+        for label in SDK_FUNCTIONS:
             table.add_column(label, justify="center", ratio=1)
         for strategy in self.strategies:
             cells = []

--- a/tests/rust-python-harness/unit_tests_rust/strategy.json
+++ b/tests/rust-python-harness/unit_tests_rust/strategy.json
@@ -4,9 +4,9 @@
   "label": "Rust unit tests",
   "description": "Exercise Rust-owned behavior directly with focused unit tests.",
   "functions": {
-    "ocr": {"coverage": "planned", "selectors": []},
-    "messages": {"coverage": "planned", "selectors": []},
-    "responses": {"coverage": "planned", "selectors": []},
-    "count_tokens": {"coverage": "planned", "selectors": []}
+    "core/ocr": {"coverage": "planned", "selectors": []},
+    "core/messages": {"coverage": "planned", "selectors": []},
+    "core/responses": {"coverage": "planned", "selectors": []},
+    "core/count_tokens": {"coverage": "planned", "selectors": []}
   }
 }

--- a/tests/rust-python-harness/validate_sub_methods/strategy.json
+++ b/tests/rust-python-harness/validate_sub_methods/strategy.json
@@ -4,9 +4,9 @@
   "label": "Validate sub-methods",
   "description": "Compare isolated transforms and verify Python-to-Rust helper coverage.",
   "functions": {
-    "ocr": {"coverage": "planned", "selectors": []},
-    "messages": {"coverage": "planned", "selectors": []},
-    "responses": {"coverage": "planned", "selectors": []},
-    "count_tokens": {"coverage": "planned", "selectors": []}
+    "core/ocr": {"coverage": "planned", "selectors": []},
+    "core/messages": {"coverage": "planned", "selectors": []},
+    "core/responses": {"coverage": "planned", "selectors": []},
+    "core/count_tokens": {"coverage": "planned", "selectors": []}
   }
 }

--- a/tests/test_rust_python_harness.py
+++ b/tests/test_rust_python_harness.py
@@ -37,7 +37,7 @@ def _case(
     return HarnessCase(
         strategy_id="example",
         strategy_label="Example",
-        sdk_function="messages",
+        sdk_function="core/messages",
         coverage=coverage,
         selectors=selectors,
     )
@@ -56,13 +56,15 @@ def _manifest() -> dict[str, object]:
     }
 
 
-def test_should_load_the_three_harness_strategies_in_order() -> None:
+def test_should_load_the_five_harness_strategies_in_order() -> None:
     strategies = load_catalog()
 
     assert [strategy.id for strategy in strategies] == [
         "e2e_fuzz_tests",
         "unit_tests_rust",
         "validate_sub_methods",
+        "existing_e2e_test_sdk__python",
+        "existing_e2e_test_sdk__rust",
     ]
     assert all(
         tuple(case.sdk_function for case in strategy.cases) == SDK_FUNCTIONS
@@ -70,11 +72,36 @@ def test_should_load_the_three_harness_strategies_in_order() -> None:
     )
 
 
+def test_should_expand_a_manifest_with_variants_into_one_strategy_per_variant(
+    tmp_path: Path,
+) -> None:
+    strategy_directory = tmp_path / "example"
+    strategy_directory.mkdir()
+    manifest = _manifest()
+    manifest["variants"] = [
+        {"name": "python", "env": {"EXAMPLE_TOGGLE": "0"}},
+        {"name": "rust", "env": {"EXAMPLE_TOGGLE": "1"}},
+    ]
+    (strategy_directory / "strategy.json").write_text(
+        json.dumps(manifest), encoding="utf-8"
+    )
+
+    strategies = load_catalog(tmp_path)
+
+    assert [strategy.id for strategy in strategies] == [
+        "example__python",
+        "example__rust",
+    ]
+    assert strategies[0].env == {"EXAMPLE_TOGGLE": "0"}
+    assert strategies[1].env == {"EXAMPLE_TOGGLE": "1"}
+    assert all(case.strategy_id == "example__python" for case in strategies[0].cases)
+
+
 def test_should_reject_a_manifest_missing_an_sdk_function(tmp_path: Path) -> None:
     strategy_directory = tmp_path / "example"
     strategy_directory.mkdir()
     manifest = _manifest()
-    del manifest["functions"]["count_tokens"]  # type: ignore[index]
+    del manifest["functions"]["core/count_tokens"]  # type: ignore[index]
     (strategy_directory / "strategy.json").write_text(
         json.dumps(manifest), encoding="utf-8"
     )
@@ -164,10 +191,10 @@ def test_should_replace_a_pass_with_a_teardown_error() -> None:
 def test_should_filter_the_catalog_by_strategy_and_sdk_function() -> None:
     strategies = load_catalog()
 
-    cases = _select(strategies, {"e2e_fuzz_tests"}, {"messages"})
+    cases = _select(strategies, {"e2e_fuzz_tests"}, {"core/messages"})
 
     assert len(cases) == 1
-    assert cases[0].key == "e2e_fuzz_tests:messages"
+    assert cases[0].key == "e2e_fuzz_tests:core/messages"
 
 
 def test_should_reject_an_unknown_strategy() -> None:
@@ -220,7 +247,7 @@ def test_should_report_confidence_for_each_sdk_section() -> None:
     strategies = load_catalog()
     cases = tuple(case for strategy in strategies for case in strategy.cases)
     run = HarnessRun.from_cases(cases)
-    passing = run.results["e2e_fuzz_tests:responses"]
+    passing = run.results["e2e_fuzz_tests:core/responses"]
     passing.collected.add("tests/test_parity.py::test_one")
     passing.record("tests/test_parity.py::test_one", RunStatus.PASSED)
 
@@ -228,9 +255,9 @@ def test_should_report_confidence_for_each_sdk_section() -> None:
         score.sdk_function: score for score in section_confidence(run, strategies)
     }
 
-    assert scores["responses"].verified_strategies == 1
-    assert scores["responses"].required_strategies == 3
-    assert scores["responses"].percentage == 33
-    assert scores["responses"].level.value == "MEDIUM"
-    assert scores["count_tokens"].percentage == 0
-    assert scores["count_tokens"].level.value == "LOW"
+    assert scores["core/responses"].verified_strategies == 1
+    assert scores["core/responses"].required_strategies == 5
+    assert scores["core/responses"].percentage == 20
+    assert scores["core/responses"].level.value == "MEDIUM"
+    assert scores["core/count_tokens"].percentage == 0
+    assert scores["core/count_tokens"].level.value == "LOW"


### PR DESCRIPTION
## TLDR

Problem this solves:

- The Rust/Python parity harness never runs the real, pre-existing OCR SDK e2e tests
- Test file mapping only used flat SDK function names, no room to group related surfaces

How it solves it:

- Adds a 5th strategy, `existing_e2e_test_sdk`, that runs the real `tests/ocr_tests/*` files under both the Python and Rust OCR toggles
- Renames the SDK function namespace to hierarchical `core/*` (`core/ocr`, `core/messages`, `core/responses`, `core/count_tokens`) everywhere in the harness
- Adds a `variants` manifest field so one strategy can expand into multiple env-toggled runs (here: `existing_e2e_test_sdk__python` and `existing_e2e_test_sdk__rust`), grouped and run together by env in `run_pytest_grouped`

## User Flow

Before: a harness developer running the parity harness has no way to point it at the real OCR SDK tests, so Rust/Python parity for `core/ocr` is only ever checked by hand

1. They run the harness CLI and select a strategy and SDK function
2. `existing_e2e_test_sdk` is not a valid choice, there is no strategy that runs the real `tests/ocr_tests/*` suite
3. To compare Python vs Rust OCR behavior they have to run `pytest tests/ocr_tests/` twice by hand, once with `LITELLM_USE_RUST_OCR=0` and once with `LITELLM_USE_RUST_OCR=1`, and diff the output themselves

After: the harness runs both toggles for them and reports pass/fail per variant

1. They run the harness CLI and select the new `existing_e2e_test_sdk` strategy with the `core/ocr` function
2. The harness expands this into two cases, `existing_e2e_test_sdk__python` (`LITELLM_USE_RUST_OCR=0`) and `existing_e2e_test_sdk__rust` (`LITELLM_USE_RUST_OCR=1`), and runs the real `tests/ocr_tests/*` files under each
3. They get one result per variant (`RunStatus.PASSED`/`FAILED` with pass/fail/collected counts) without writing any pytest commands themselves

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Both cases were run with `/Users/ishaanjaffer/github/litellm/.venv/bin/python`, hitting real Mistral, Azure AI, Azure Document Intelligence, and Vertex AI endpoints with live credentials from `.env`, no mocks.

### Before (22cc97fe0a27367d19fdb03a16dbfd497f4360e8)

#### Selecting the new strategy

1. `cli._select(load_catalog(), {"existing_e2e_test_sdk__python"}, {"core/ocr"})`
2. `ValueError: Unknown strategy: existing_e2e_test_sdk__python` (strategy and `core/*` namespace don't exist yet, catalog only has `['e2e_fuzz_tests', 'unit_tests_rust', 'validate_sub_methods']`)

### After (fa4f1e821ec95d13f4766ad2a3fe623028cb4f5d)

#### existing_e2e_test_sdk__python (LITELLM_USE_RUST_OCR=0)

1. `run_pytest_grouped` runs `tests/ocr_tests/test_ocr_mistral.py`, `test_ocr_azure_ai.py`, `test_ocr_azure_document_intelligence.py`, `test_ocr_vertex_ai.py` against real provider endpoints
2. `existing_e2e_test_sdk__python:core/ocr RunStatus.PASSED passed=25 failed=0 errors=0 collected=33`

#### existing_e2e_test_sdk__rust (LITELLM_USE_RUST_OCR=1)

1. Same 4 files, same real endpoints, run a second time with the Rust OCR bridge toggled on
2. `existing_e2e_test_sdk__rust:core/ocr RunStatus.PASSED passed=25 failed=0 errors=0 collected=33`

## Type

🆕 New Feature
✅ Test

## Caveats (if any)

### Low

- `tests/ocr_tests/test_ocr_vertex_ai.py::test_deepseek_request_uses_single_provider_namespace` is order-dependent: it fails with a doubled model namespace when the 4 OCR test files run as separate raw `pytest` subprocess invocations back to back, but passes when run through the harness's in-process `pytest.main()` path used by this PR. Pre-existing test isolation issue in that test file, not introduced by this change, and not something the Rust/Python toggle affects
- Harness result counts above reflect the harness's own invocation path (single `pytest.main()` call per variant), which is what a developer using the harness will actually see

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR