### PR TITLE
test(e2e/ui): give the seeded users passwords that pass the default password policy

### DIFF
--- a/tests/e2e/ui/constants.ts
+++ b/tests/e2e/ui/constants.ts
@@ -30,6 +30,7 @@ export const E2E_PROXY_ADMIN_EMAIL = "admin@test.local";
 export const E2E_INTERNAL_USER_ID = "e2e-internal-user";
 export const E2E_INTERNAL_USER_EMAIL = "internal@test.local";
 export const E2E_TEAM_ADMIN_USER_ID = "e2e-team-admin";
+export const E2E_SEEDED_USER_PASSWORD = "E2e-Test-Pass-2026!";
 
 // Key aliases for seeded test keys (match seed.sql)
 export const E2E_UPDATE_LIMITS_KEY_ALIAS = "e2eUpdateLimitsKey";

--- a/tests/e2e/ui/fixtures/seed.sql
+++ b/tests/e2e/ui/fixtures/seed.sql
@@ -24,18 +24,18 @@ INSERT INTO "LiteLLM_OrganizationTable" (
   'e2e-proxy-admin', 'e2e-proxy-admin'
 );
 
--- 4. Users (password hash is scrypt of "test")
+-- 4. Users (password hash is scrypt of E2E_SEEDED_USER_PASSWORD from constants.ts)
 INSERT INTO "LiteLLM_UserTable" ("user_id", "user_email", "user_role", "teams", "password")
 VALUES
-  ('e2e-proxy-admin',      'admin@test.local',       'proxy_admin',           '{"e2e-team-crud"}',                  'scrypt:MU5CcTAi6rVK1HfY1rVPEWq6r4sxg837eq9dG4n5Q6BhDJ44442+seC6LAhLEAYr'),
-  ('e2e-admin-viewer',     'adminviewer@test.local',  'proxy_admin_viewer',   '{}',                                 'scrypt:MU5CcTAi6rVK1HfY1rVPEWq6r4sxg837eq9dG4n5Q6BhDJ44442+seC6LAhLEAYr'),
-  ('e2e-internal-user',    'internal@test.local',     'internal_user',        '{"e2e-team-crud","e2e-team-org","e2e-team-keygen"}', 'scrypt:MU5CcTAi6rVK1HfY1rVPEWq6r4sxg837eq9dG4n5Q6BhDJ44442+seC6LAhLEAYr'),
-  ('e2e-internal-viewer',  'viewer@test.local',       'internal_user_viewer', '{"e2e-team-crud"}',                  'scrypt:MU5CcTAi6rVK1HfY1rVPEWq6r4sxg837eq9dG4n5Q6BhDJ44442+seC6LAhLEAYr'),
-  ('e2e-team-admin',       'teamadmin@test.local',    'internal_user',        '{"e2e-team-crud","e2e-team-delete"}', 'scrypt:MU5CcTAi6rVK1HfY1rVPEWq6r4sxg837eq9dG4n5Q6BhDJ44442+seC6LAhLEAYr'),
-  ('e2e-invitable-user',   'invitable@test.local',    'internal_user',        '{}',                                 'scrypt:MU5CcTAi6rVK1HfY1rVPEWq6r4sxg837eq9dG4n5Q6BhDJ44442+seC6LAhLEAYr'),
-  ('e2e-internal-noteam',  'noteam@test.local',       'internal_user',        '{}',                                 'scrypt:MU5CcTAi6rVK1HfY1rVPEWq6r4sxg837eq9dG4n5Q6BhDJ44442+seC6LAhLEAYr'),
-  ('e2e-invitable-by-team-admin', 'invitable-team@test.local', 'internal_user', '{}',                                'scrypt:MU5CcTAi6rVK1HfY1rVPEWq6r4sxg837eq9dG4n5Q6BhDJ44442+seC6LAhLEAYr'),
-  ('e2e-removable-member', 'removable@test.local',    'internal_user',        '{"e2e-team-crud"}',                  'scrypt:MU5CcTAi6rVK1HfY1rVPEWq6r4sxg837eq9dG4n5Q6BhDJ44442+seC6LAhLEAYr');
+  ('e2e-proxy-admin',      'admin@test.local',       'proxy_admin',           '{"e2e-team-crud"}',                  'scrypt:KdnTJwPb3gswdqSznPE5CC6apeFIMycd6BG7yRWndZa3QZPcVs37y7jvrQCaPUNq'),
+  ('e2e-admin-viewer',     'adminviewer@test.local',  'proxy_admin_viewer',   '{}',                                 'scrypt:KdnTJwPb3gswdqSznPE5CC6apeFIMycd6BG7yRWndZa3QZPcVs37y7jvrQCaPUNq'),
+  ('e2e-internal-user',    'internal@test.local',     'internal_user',        '{"e2e-team-crud","e2e-team-org","e2e-team-keygen"}', 'scrypt:KdnTJwPb3gswdqSznPE5CC6apeFIMycd6BG7yRWndZa3QZPcVs37y7jvrQCaPUNq'),
+  ('e2e-internal-viewer',  'viewer@test.local',       'internal_user_viewer', '{"e2e-team-crud"}',                  'scrypt:KdnTJwPb3gswdqSznPE5CC6apeFIMycd6BG7yRWndZa3QZPcVs37y7jvrQCaPUNq'),
+  ('e2e-team-admin',       'teamadmin@test.local',    'internal_user',        '{"e2e-team-crud","e2e-team-delete"}', 'scrypt:KdnTJwPb3gswdqSznPE5CC6apeFIMycd6BG7yRWndZa3QZPcVs37y7jvrQCaPUNq'),
+  ('e2e-invitable-user',   'invitable@test.local',    'internal_user',        '{}',                                 'scrypt:KdnTJwPb3gswdqSznPE5CC6apeFIMycd6BG7yRWndZa3QZPcVs37y7jvrQCaPUNq'),
+  ('e2e-internal-noteam',  'noteam@test.local',       'internal_user',        '{}',                                 'scrypt:KdnTJwPb3gswdqSznPE5CC6apeFIMycd6BG7yRWndZa3QZPcVs37y7jvrQCaPUNq'),
+  ('e2e-invitable-by-team-admin', 'invitable-team@test.local', 'internal_user', '{}',                                'scrypt:KdnTJwPb3gswdqSznPE5CC6apeFIMycd6BG7yRWndZa3QZPcVs37y7jvrQCaPUNq'),
+  ('e2e-removable-member', 'removable@test.local',    'internal_user',        '{"e2e-team-crud"}',                  'scrypt:KdnTJwPb3gswdqSznPE5CC6apeFIMycd6BG7yRWndZa3QZPcVs37y7jvrQCaPUNq');
 
 -- 5. Teams (members_with_roles is required JSON)
 INSERT INTO "LiteLLM_TeamTable" (

--- a/tests/e2e/ui/fixtures/users.ts
+++ b/tests/e2e/ui/fixtures/users.ts
@@ -1,6 +1,7 @@
 import {
   ADMIN_STORAGE_PATH,
   ADMIN_VIEWER_STORAGE_PATH,
+  E2E_SEEDED_USER_PASSWORD,
   INTERNAL_USER_STORAGE_PATH,
   INTERNAL_VIEWER_STORAGE_PATH,
   TEAM_ADMIN_STORAGE_PATH,
@@ -23,22 +24,22 @@ export const users: Record<Role, { email: string; password: string; seedApiRole?
   },
   [Role.ProxyAdminViewer]: {
     email: "adminviewer@test.local",
-    password: "test",
+    password: E2E_SEEDED_USER_PASSWORD,
     seedApiRole: "proxy_admin_viewer",
   },
   [Role.InternalUser]: {
     email: "internal@test.local",
-    password: "test",
+    password: E2E_SEEDED_USER_PASSWORD,
     seedApiRole: "internal_user",
   },
   [Role.InternalUserViewer]: {
     email: "viewer@test.local",
-    password: "test",
+    password: E2E_SEEDED_USER_PASSWORD,
     seedApiRole: "internal_user_viewer",
   },
   [Role.TeamAdmin]: {
     email: "teamadmin@test.local",
-    password: "test",
+    password: E2E_SEEDED_USER_PASSWORD,
     seedApiRole: "internal_user",
   },
 };

--- a/tests/e2e/ui/tests/internal-user/internalUserNoTeam.spec.ts
+++ b/tests/e2e/ui/tests/internal-user/internalUserNoTeam.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "@playwright/test";
 import { navigateToPage } from "../../helpers/navigation";
 import { Page } from "../../fixtures/pages";
+import { E2E_SEEDED_USER_PASSWORD } from "../../constants";
 
 /**
  * Logs in fresh inside the test rather than reusing a stored session because
@@ -15,7 +16,7 @@ test.describe("Internal User with no team memberships", () => {
     // Log in via the form as the no-team seeded user.
     await page.goto("/ui/login");
     await page.getByPlaceholder("Enter your username").fill("noteam@test.local");
-    await page.getByPlaceholder("Enter your password").fill("test");
+    await page.getByPlaceholder("Enter your password").fill(E2E_SEEDED_USER_PASSWORD);
     await page.getByRole("button", { name: "Login", exact: true }).click();
     await expect(page.getByRole("complementary").getByText("Virtual Keys")).toBeVisible({ timeout: 30_000 });
     expect(new URL(page.url()).pathname).not.toMatch(/\/connect$/);

--- a/tests/e2e/ui/tests/proxy-admin/secondAdmin.spec.ts
+++ b/tests/e2e/ui/tests/proxy-admin/secondAdmin.spec.ts
@@ -10,7 +10,7 @@ test.describe("Second proxy admin", () => {
   test("an invited admin can log in, mint a key, and call a model with it", async ({ page, browser, request }) => {
     const suffix = Date.now();
     const email = `second-admin-${suffix}@test.local`;
-    const password = "e2e-second-admin-password";
+    const password = "E2e-Second-Admin-Pass-1!";
     const auth = { Authorization: `Bearer ${masterKey()}` };
 
     const inviteAdminUser = async (): Promise<string> => {


### PR DESCRIPTION
## TLDR

Problem this solves:

- #39381 turned the password policy on by default (12 chars, upper, number, special)
- The UI e2e suite seeds its users with the password "test"
- Global setup's `/user/update` now gets a 400 and both UI e2e jobs go red on every PR

How it solves it:

- One `E2E_SEEDED_USER_PASSWORD` constant that satisfies the default policy
- `users.ts`, the no-team spec, and `seed.sql`'s scrypt hash all use it
- The second-admin spec's inline password meets the policy too
- The default policy stays on, so the suite logs in the way a fresh install does

## User Flow

Before: the UI e2e jobs go red during global setup because the proxy rejects the seeded password `test`, so zero specs run on any PR

1. A contributor pushes to their PR and adds the `run-ci` label, and CircleCI starts `e2e_ui_testing` and `e2e_ui_testing_server_root_path`
2. Each job boots a proxy at http://localhost:4000 with the suite's seed data loaded, then runs the Playwright suite against it
3. Global setup sends `PATCH http://localhost:4000/update/ui_settings` with `{"enable_projects_ui": true}` and the master key -> 200
4. It sends `POST http://localhost:4000/user/new` with `{"user_email":"adminviewer@test.local","user_role":"proxy_admin_viewer","auto_create_key":false}` -> 200 with a `user_id` (409 when the seed already created the user)
5. It sends `POST http://localhost:4000/user/update` with `{"user_email":"adminviewer@test.local","password":"test"}` -> `400 Password does not meet the required policy: must be at least 12 characters long, include an uppercase letter, include a number, include a special character`
6. Global setup stops with `Setting password for adminviewer@test.local failed (400)`, no spec runs, and both jobs show as failed on the PR

After: global setup resets every seeded user's password, logs each role in, and the specs run, so the two jobs report on the PR's own change

1. A contributor pushes to their PR and adds the `run-ci` label, and CircleCI starts `e2e_ui_testing` and `e2e_ui_testing_server_root_path`
2. Each job boots a proxy at http://localhost:4000 with the suite's seed data loaded, then runs the Playwright suite against it
3. Global setup sends `PATCH http://localhost:4000/update/ui_settings` with `{"enable_projects_ui": true}` and the master key -> 200
4. It sends `POST http://localhost:4000/user/new` with `{"user_email":"adminviewer@test.local","user_role":"proxy_admin_viewer","auto_create_key":false}` -> 200 with a `user_id` (409 when the seed already created the user)
5. It sends `POST http://localhost:4000/user/update` with `{"user_email":"adminviewer@test.local","password":"E2e-Test-Pass-2026!"}` -> 200 with the same `user_id`, and the same for the other three seeded roles
6. For each role it opens http://localhost:4000/ui/login, fills the email and that password, clicks Login, and lands on the dashboard with Virtual Keys in the sidebar
7. The specs run: the no-team spec logs in as `noteam@test.local` with `E2e-Test-Pass-2026!`, the second-admin spec invites an admin with `E2e-Second-Admin-Pass-1!`, and both jobs show as passed on the PR

## Relevant issues

## Linear ticket

Resolves LIT-6775

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Setup shared by both runs: a proxy carrying #39381's default password policy on `localhost:43721` with a fresh Postgres, plus the CircleCI `run-ci` workflow for the UI e2e jobs. `<master key>` stands for the proxy's master key

### Before (c9562e1dd9; the CircleCI run below is from 0f628f78e7, whose `tests/e2e/ui` and password policy are identical to the merge base)

#### Global setup's password reset

1. The UI suite's global setup does what CI does: `curl -X POST localhost:43721/user/new -H 'Authorization: Bearer <master key>' -d '{"user_email":"policy-proof2@test.local","user_role":"internal_user","auto_create_key":false}'` -> 200 with a `user_id`
2. Then `curl -X POST localhost:43721/user/update -H 'Authorization: Bearer <master key>' -d '{"user_email":"policy-proof2@test.local","password":"test"}'` -> `400 Password does not meet the required policy: must be at least 12 characters long, include an uppercase letter, include a number, include a special character`
3. `curl -X POST localhost:43721/login --data-urlencode username=policy-proof2@test.local --data-urlencode password=test` -> 401

#### CircleCI UI e2e jobs

1. `e2e_ui_testing` stops in `globalSetup.ts:49` with `Setting password for adminviewer@test.local failed (400)` and runs zero specs: https://app.circleci.com/pipelines/github/BerriAI/litellm/88910/workflows/ac2c0a72-9db7-4f16-9834-33e6c787efe4/jobs/2147694
2. `e2e_ui_testing_server_root_path` fails the same way: https://app.circleci.com/pipelines/github/BerriAI/litellm/88910/workflows/ac2c0a72-9db7-4f16-9834-33e6c787efe4/jobs/2147682

### After (e641864e6f)

#### Global setup's password reset

1. Same `curl -X POST localhost:43721/user/new ...` -> 200 with a `user_id`
2. `curl -X POST localhost:43721/user/update -H 'Authorization: Bearer <master key>' -d '{"user_email":"policy-proof2@test.local","password":"E2e-Test-Pass-2026!"}'` -> 200 with the same `user_id`
3. `curl -X POST localhost:43721/login --data-urlencode username=policy-proof2@test.local --data-urlencode 'password=E2e-Test-Pass-2026!'` -> `303` to `/ui?login=success`

#### CircleCI UI e2e jobs

1. `e2e_ui_testing` runs global setup, the no-team login, and the second-admin spec and passes: https://app.circleci.com/workflow/df986193-8cb8-4006-9fef-d0d8af946cc9/job/9dfef295-ca62-432a-b862-d14383ae54c3
2. `e2e_ui_testing_server_root_path` passes the same way: https://app.circleci.com/workflow/df986193-8cb8-4006-9fef-d0d8af946cc9/job/8b706af4-dd1d-4f02-b9c7-114b94608379

## Type

✅ Test

## Caveats (if any)

### Low

- A UI suite pointed at a database seeded before this change needs `seed.sql` re-applied
  - Global setup resets the five role passwords itself; only `noteam@test.local` relies on the seeded hash

## QA runbook

- tests/e2e/ui/tests/internal-user/internalUserNoTeam.spec.ts - the seeded no-team user can still log in through the form with the new password
  - [ ] Apply `tests/e2e/ui/fixtures/seed.sql` to a fresh proxy database and boot the proxy with `tests/e2e/ui/fixtures/config.yml`
  - [ ] Open http://localhost:4000/ui/login, enter `noteam@test.local` and `E2e-Test-Pass-2026!`, and expect the dashboard with an empty team dropdown in Create Key
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky
- tests/e2e/ui/tests/proxy-admin/secondAdmin.spec.ts - an invited admin's password now clears the default policy
  - [ ] POST /user/update with the master key, the invited admin's email, and `E2e-Second-Admin-Pass-1!`, and expect 200 (the old `e2e-second-admin-password` returns 400 naming the uppercase rule)
  - [ ] Log in at http://localhost:4000/ui/login with that email and password and expect the admin dashboard
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

## /live-pr-risk report (e641864e6f)

Verdict: no breaking or backward-incompatible change. The diff only moves test fixtures, and every consumer of the values it changes was enumerated and either sits inside the diff or was exercised by the CircleCI UI e2e jobs at the tip

- Changed items and their dependents
  - `E2E_SEEDED_USER_PASSWORD` (new constant): read by `fixtures/users.ts` and `internalUserNoTeam.spec.ts`, both in the diff
  - The four role passwords in `fixtures/users.ts`: read only by `globalSetup.ts` (POST `/user/update`, then the login form). Every other `users[...].password` reader (`login.spec.ts`, `routerSettings.spec.ts`, `addModel.spec.ts`, `credentials.spec.ts`, `clearCustomPricing.spec.ts`) reads `Role.ProxyAdmin`, whose password is the master key and is untouched
  - The scrypt hash in `seed.sql`: applied by `.circleci/config.yml` (both UI e2e jobs) and `tests/e2e/ui/run_e2e.sh`. Of the 9 seeded rows only `noteam@test.local` logs in with the seeded hash (the four roles are reset by global setup, `admin@test.local` uses the master key, the other 3 are invite and removal targets that never log in)
  - `secondAdmin.spec.ts` password: local to the spec
- Sweeps that found nothing left to update: literal `"test"` passwords under `tests/e2e/ui`, the old hash anywhere in the repo, `test.local` logins outside `tests/e2e/ui`, and the sibling docs checkout
- Verified live: the password policy curls in the proof (before 400 and 401, after 200 and 303) and the two CircleCI UI e2e jobs at e641864e6f, which run global setup, the no-team login, and the second-admin spec end to end
- Not verified: nothing outstanding

- [x] e641864e6f passes /live-pr-risk
