### PR TITLE
feat(router): gate heuristic v2 singleton with auto-router entitlement

### DIFF
--- a/litellm-proxy-extras/litellm_proxy_extras/migrations/20260902000000_one_heuristic_v2_router/migration.sql
+++ b/litellm-proxy-extras/litellm_proxy_extras/migrations/20260902000000_one_heuristic_v2_router/migration.sql
@@ -1,0 +1,4 @@
+-- Atomically reserve the proxy-wide heuristic_v2 classifier slot
+CREATE UNIQUE INDEX IF NOT EXISTS "LiteLLM_ProxyModelTable_one_heuristic_v2_router"
+    ON "LiteLLM_ProxyModelTable" ((litellm_params #>> '{complexity_router_config,classifier_type}'))
+    WHERE (litellm_params #>> '{complexity_router_config,classifier_type}') = 'heuristic_v2';

--- a/litellm-proxy-extras/litellm_proxy_extras/migrations/20260902000000_one_heuristic_v2_router/migration.sql
+++ b/litellm-proxy-extras/litellm_proxy_extras/migrations/20260902000000_one_heuristic_v2_router/migration.sql
@@ -1,7 +1,9 @@
--- Atomically reserve the proxy-wide heuristic_v2 classifier slot
+ALTER TABLE "LiteLLM_ProxyModelTable"
+    ADD COLUMN IF NOT EXISTS "heuristic_v2_unlimited" BOOLEAN NOT NULL DEFAULT FALSE;
+
 CREATE UNIQUE INDEX IF NOT EXISTS "LiteLLM_ProxyModelTable_one_heuristic_v2_router"
     ON "LiteLLM_ProxyModelTable" ((1))
-    WHERE CASE
+    WHERE NOT "heuristic_v2_unlimited" AND CASE
         WHEN jsonb_typeof(litellm_params) = 'object'
             THEN (litellm_params #>> '{complexity_router_config,classifier_type}') = 'heuristic_v2'
         WHEN jsonb_typeof(litellm_params) = 'string'

--- a/litellm-proxy-extras/litellm_proxy_extras/migrations/20260902000000_one_heuristic_v2_router/migration.sql
+++ b/litellm-proxy-extras/litellm_proxy_extras/migrations/20260902000000_one_heuristic_v2_router/migration.sql
@@ -1,9 +1,18 @@
 ALTER TABLE "LiteLLM_ProxyModelTable"
-    ADD COLUMN IF NOT EXISTS "heuristic_v2_unlimited" BOOLEAN NOT NULL DEFAULT FALSE;
+    ADD COLUMN IF NOT EXISTS "heuristic_v2_unlimited" BOOLEAN,
+    ADD COLUMN IF NOT EXISTS "heuristic_v2_license_blocked" BOOLEAN;
+
+-- Existing rows remain NULL so pre-gating duplicates cannot break this migration.
+-- Proxy startup reconciles them atomically before loading database-backed routers.
+ALTER TABLE "LiteLLM_ProxyModelTable"
+    ALTER COLUMN "heuristic_v2_unlimited" SET DEFAULT FALSE,
+    ALTER COLUMN "heuristic_v2_license_blocked" SET DEFAULT FALSE;
 
 CREATE UNIQUE INDEX IF NOT EXISTS "LiteLLM_ProxyModelTable_one_heuristic_v2_router"
     ON "LiteLLM_ProxyModelTable" ((1))
-    WHERE NOT "heuristic_v2_unlimited" AND CASE
+    WHERE "heuristic_v2_unlimited" IS FALSE
+      AND "heuristic_v2_license_blocked" IS FALSE
+      AND CASE
         WHEN jsonb_typeof(litellm_params) = 'object'
             THEN (litellm_params #>> '{complexity_router_config,classifier_type}') = 'heuristic_v2'
         WHEN jsonb_typeof(litellm_params) = 'string'

--- a/litellm-proxy-extras/litellm_proxy_extras/migrations/20260902000000_one_heuristic_v2_router/migration.sql
+++ b/litellm-proxy-extras/litellm_proxy_extras/migrations/20260902000000_one_heuristic_v2_router/migration.sql
@@ -1,4 +1,10 @@
 -- Atomically reserve the proxy-wide heuristic_v2 classifier slot
 CREATE UNIQUE INDEX IF NOT EXISTS "LiteLLM_ProxyModelTable_one_heuristic_v2_router"
-    ON "LiteLLM_ProxyModelTable" ((litellm_params #>> '{complexity_router_config,classifier_type}'))
-    WHERE (litellm_params #>> '{complexity_router_config,classifier_type}') = 'heuristic_v2';
+    ON "LiteLLM_ProxyModelTable" ((1))
+    WHERE CASE
+        WHEN jsonb_typeof(litellm_params) = 'object'
+            THEN (litellm_params #>> '{complexity_router_config,classifier_type}') = 'heuristic_v2'
+        WHEN jsonb_typeof(litellm_params) = 'string'
+            THEN (((litellm_params #>> '{}')::jsonb) #>> '{complexity_router_config,classifier_type}') = 'heuristic_v2'
+        ELSE FALSE
+    END;

--- a/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
+++ b/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
@@ -53,6 +53,7 @@ model LiteLLM_ProxyModelTable {
   litellm_params Json
   model_info Json?
   blocked Boolean @default(false)
+  heuristic_v2_unlimited Boolean @default(false)
   created_at    DateTime               @default(now()) @map("created_at")
   created_by String
   updated_at    DateTime               @default(now()) @updatedAt @map("updated_at")

--- a/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
+++ b/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
@@ -53,7 +53,8 @@ model LiteLLM_ProxyModelTable {
   litellm_params Json
   model_info Json?
   blocked Boolean @default(false)
-  heuristic_v2_unlimited Boolean @default(false)
+  heuristic_v2_unlimited Boolean? @default(false)
+  heuristic_v2_license_blocked Boolean? @default(false)
   created_at    DateTime               @default(now()) @map("created_at")
   created_by String
   updated_at    DateTime               @default(now()) @updatedAt @map("updated_at")

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -39,6 +39,7 @@ ROUTER_SETTINGS_MANAGED_OUTSIDE_CONFIG: Final[frozenset[str]] = frozenset(
         "router_general_settings",
         "ignore_invalid_deployments",
         "fallback_access_check",
+        "allow_multiple_heuristic_v2",
     }
 )
 DEFAULT_BATCH_SIZE: Final = int(os.getenv("DEFAULT_BATCH_SIZE", 512))

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -4886,6 +4886,7 @@ class PrismaCompatibleUpdateDBModel(TypedDict, total=False):
     litellm_params: str
     model_info: str
     blocked: bool
+    heuristic_v2_unlimited: bool  # writable-ok: the model write path stamps this internal license marker
     updated_at: str
     updated_by: str
 

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -4887,6 +4887,7 @@ class PrismaCompatibleUpdateDBModel(TypedDict, total=False):
     model_info: str
     blocked: bool
     heuristic_v2_unlimited: bool  # writable-ok: the model write path stamps this internal license marker
+    heuristic_v2_license_blocked: bool  # writable-ok: proxy reconciliation stamps this internal routing marker
     updated_at: str
     updated_by: str
 

--- a/litellm/proxy/auth/litellm_license.py
+++ b/litellm/proxy/auth/litellm_license.py
@@ -3,7 +3,7 @@
 import base64
 import json
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Final
 
 import httpx
@@ -155,6 +155,16 @@ class LicenseCheck:
         license_data: Final = self.airgapped_license_data
         if license_data is None:
             return False
+        expiration_value: Final = license_data.get("expiration_date")
+        if not isinstance(expiration_value, str):
+            return False
+        try:
+            expiration_date: Final = datetime.strptime(expiration_value, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+        except ValueError:
+            return False
+        if expiration_date < datetime.now(timezone.utc):
+            self.airgapped_license_data = None
+            return False
         allowed_features: Final = license_data.get("allowed_features")
         return isinstance(allowed_features, list) and feature in allowed_features
 
@@ -188,19 +198,22 @@ class LicenseCheck:
             # Decode and parse the data
             license_data: Final = json.loads(message.decode())
 
-            self.airgapped_license_data = EnterpriseLicenseData(**license_data)
-
             # debug information provided in license data
             verbose_proxy_logger.debug("License data: %s", license_data)
 
             # Check expiration date
-            expiration_date: Final = datetime.strptime(license_data["expiration_date"], "%Y-%m-%d")
-            if expiration_date < datetime.now():
+            expiration_date: Final = datetime.strptime(license_data["expiration_date"], "%Y-%m-%d").replace(
+                tzinfo=timezone.utc
+            )
+            if expiration_date < datetime.now(timezone.utc):
+                self.airgapped_license_data = None
                 return False, "License has expired"
 
+            self.airgapped_license_data = EnterpriseLicenseData(**license_data)
             return True
 
         except Exception as e:
+            self.airgapped_license_data = None
             verbose_proxy_logger.debug(
                 "litellm.proxy.auth.litellm_license.py::verify_license_without_api_request - Unable to verify License locally. - %s",
                 e,

--- a/litellm/proxy/auth/litellm_license.py
+++ b/litellm/proxy/auth/litellm_license.py
@@ -15,6 +15,8 @@ from litellm.llms.custom_httpx.http_handler import HTTPHandler
 if TYPE_CHECKING:
     from litellm.proxy._types import EnterpriseLicenseData
 
+AUTO_ROUTER_LICENSE_FEATURE: Final = "auto_router"
+
 
 class LicenseCheck:
     """
@@ -148,6 +150,13 @@ class LicenseCheck:
         if "max_teams" not in self.airgapped_license_data or not isinstance(_max_teams_in_license, int):
             return False
         return team_count > _max_teams_in_license
+
+    def allows_feature(self, feature: str) -> bool:
+        license_data: Final = self.airgapped_license_data
+        if license_data is None:
+            return False
+        allowed_features: Final = license_data.get("allowed_features")
+        return isinstance(allowed_features, list) and feature in allowed_features
 
     def verify_license_without_api_request(self, public_key, license_key):
         try:

--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -305,7 +305,7 @@ async def _raise_if_heuristic_v2_slot_taken(
     existing_params: GenericLiteLLMParams | None,
     current_model_id: str | None = None,
 ) -> None:
-    """Allow at most one persisted heuristic-v2 complexity router per proxy."""
+    """Allow at most one heuristic-v2 complexity router per proxy."""
     effective_config: Final = _effective_complexity_router_config(incoming_params, existing_params)
     if not uses_heuristic_v2(effective_config):
         return
@@ -320,9 +320,12 @@ async def _raise_if_heuristic_v2_slot_taken(
             code=status.HTTP_403_FORBIDDEN,
             param="litellm_params.complexity_router_config.classifier_type",
         )
+    from litellm.proxy.proxy_server import llm_router
+
     rows: Final = await _proxy_model_table(prisma_client).find_many(where={})
     violation: Final = _heuristic_v2_slot_violation(
         persisted_rows=rows,
+        live_model_list=llm_router.model_list if llm_router is not None else (),
         incoming_params=incoming_params,
         existing_params=existing_params,
         current_model_id=current_model_id,
@@ -350,6 +353,7 @@ def _heuristic_v2_admin_violation(*, effective_config: Mapping[str, object] | No
 def _heuristic_v2_slot_violation(
     *,
     persisted_rows: Sequence[_ProxyModelRow],
+    live_model_list: Sequence[Mapping[str, object]] = (),
     incoming_params: GenericLiteLLMParams | None,
     existing_params: GenericLiteLLMParams | None,
     current_model_id: str | None = None,
@@ -358,6 +362,18 @@ def _heuristic_v2_slot_violation(
     effective_config: Final = _effective_complexity_router_config(incoming_params, existing_params)
     if not uses_heuristic_v2(effective_config):
         return None
+    for deployment in live_model_list:
+        model_info = deployment.get("model_info")
+        if isinstance(model_info, Mapping) and model_info.get("db_model") is True:
+            continue
+        litellm_params = _litellm_params_mapping(deployment.get("litellm_params"))
+        live_config = litellm_params.get("complexity_router_config")
+        if uses_heuristic_v2(live_config if isinstance(live_config, Mapping) else None):
+            return (
+                "Only one complexity router can use classifier_type='heuristic_v2' per proxy. "
+                "A config.yaml deployment already uses the slot; change or remove it before "
+                "creating a database-backed heuristic_v2 router."
+            )
     for row in persisted_rows:
         if current_model_id is not None and row.model_id == current_model_id:
             continue

--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -309,7 +309,34 @@ async def _raise_if_heuristic_v2_slot_taken(
     if not uses_heuristic_v2(effective_config):
         return
     rows: Final = await _proxy_model_table(prisma_client).find_many(where={})
-    for row in rows:
+    violation: Final = _heuristic_v2_slot_violation(
+        persisted_rows=rows,
+        incoming_params=incoming_params,
+        existing_params=existing_params,
+        current_model_id=current_model_id,
+    )
+    if violation is None:
+        return
+    raise ProxyException(
+        message=violation,
+        type=ProxyErrorTypes.validation_error.value,
+        code=status.HTTP_400_BAD_REQUEST,
+        param="litellm_params.complexity_router_config.classifier_type",
+    )
+
+
+def _heuristic_v2_slot_violation(
+    *,
+    persisted_rows: Sequence[_ProxyModelRow],
+    incoming_params: GenericLiteLLMParams | None,
+    existing_params: GenericLiteLLMParams | None,
+    current_model_id: str | None = None,
+) -> str | None:
+    """Return the singleton-slot violation for the effective post-write config."""
+    effective_config: Final = _effective_complexity_router_config(incoming_params, existing_params)
+    if not uses_heuristic_v2(effective_config):
+        return None
+    for row in persisted_rows:
         if current_model_id is not None and row.model_id == current_model_id:
             continue
         if uses_heuristic_v2(
@@ -319,16 +346,12 @@ async def _raise_if_heuristic_v2_slot_taken(
             )
             else None
         ):
-            raise ProxyException(
-                message=(
-                    "Only one complexity router can use classifier_type='heuristic_v2' per proxy. "
-                    "Use classifier_type='heuristic' for this router, or change or delete the existing "
-                    "heuristic_v2 router first."
-                ),
-                type=ProxyErrorTypes.validation_error.value,
-                code=status.HTTP_400_BAD_REQUEST,
-                param="litellm_params.complexity_router_config.classifier_type",
+            return (
+                "Only one complexity router can use classifier_type='heuristic_v2' per proxy. "
+                "Use classifier_type='heuristic' for this router, or change or delete the existing "
+                "heuristic_v2 router first."
             )
+    return None
 
 
 ENFORCE_RPM_TPM_ON_MODEL_ADD_SETTING: Final = "enforce_rpm_tpm_on_model_add"

--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -49,6 +49,7 @@ from litellm.proxy._types import (
     TeamModelDeleteRequest,
     UserAPIKeyAuth,
 )
+from litellm.proxy.auth.litellm_license import AUTO_ROUTER_LICENSE_FEATURE
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.proxy.common_utils.config_sync_pubsub import (
     coordination_redis_cache,
@@ -297,6 +298,16 @@ def _effective_complexity_router_config(
     return config if isinstance(config, Mapping) else None
 
 
+def _license_allows_unlimited_heuristic_v2() -> bool:
+    from litellm.proxy.proxy_server import _license_check
+
+    return _license_check.allows_feature(AUTO_ROUTER_LICENSE_FEATURE)
+
+
+def _heuristic_v2_unlimited_marker(complexity_router_config: Mapping[str, object] | None) -> bool:
+    return uses_heuristic_v2(complexity_router_config) and _license_allows_unlimited_heuristic_v2()
+
+
 async def _raise_if_heuristic_v2_slot_taken(
     *,
     prisma_client: PrismaClient,
@@ -320,9 +331,13 @@ async def _raise_if_heuristic_v2_slot_taken(
             code=status.HTTP_403_FORBIDDEN,
             param="litellm_params.complexity_router_config.classifier_type",
         )
+    if _license_allows_unlimited_heuristic_v2():
+        return
     from litellm.proxy.proxy_server import llm_router
 
-    rows: Final = await _proxy_model_table(prisma_client).find_many(where={})
+    rows: Final = await _proxy_model_table(prisma_client).find_many(
+        where={}  # mutable-ok: Prisma requires a mutable filter mapping
+    )
     violation: Final = _heuristic_v2_slot_violation(
         persisted_rows=rows,
         live_model_list=llm_router.model_list if llm_router is not None else (),
@@ -403,8 +418,8 @@ def _is_heuristic_v2_slot_unique_violation(error: Exception) -> bool:
 def _heuristic_v2_slot_proxy_exception() -> ProxyException:
     return ProxyException(
         message=(
-            "Only one complexity router can use classifier_type='heuristic_v2' per proxy. "
-            "Change or delete the existing heuristic_v2 router first."
+            "Heuristic v2 is limited to one auto-router. Change or delete the existing "
+            "heuristic_v2 router first, or reach out to tin@berri.ai to learn more."
         ),
         type=ProxyErrorTypes.validation_error.value,
         code=status.HTTP_400_BAD_REQUEST,
@@ -885,6 +900,9 @@ async def patch_model(
         # Add metadata about update
         update_data["updated_by"] = user_api_key_dict.user_id or litellm_proxy_admin_name
         update_data["updated_at"] = cast(str, get_utc_datetime())
+        update_data["heuristic_v2_unlimited"] = _heuristic_v2_unlimited_marker(
+            _effective_complexity_router_config(patch_data.litellm_params, db_model.litellm_params)
+        )
 
         # Perform partial update
         updated_model: Final = await _proxy_model_table(prisma_client).update(
@@ -1135,6 +1153,7 @@ async def _add_model_to_db(
         "model_info": model_params.model_info.model_dump_json(exclude_none=True),
         "created_by": user_api_key_dict.user_id or LITELLM_PROXY_ADMIN_NAME,
         "updated_by": user_api_key_dict.user_id or LITELLM_PROXY_ADMIN_NAME,
+        "heuristic_v2_unlimited": _heuristic_v2_unlimited_marker(model_params.litellm_params.complexity_router_config),
     }
     if model_params.model_info.id is not None:
         _data["model_id"] = model_params.model_info.id
@@ -2213,9 +2232,14 @@ async def update_model(
                 else:
                     pass
 
-            _data: Final[dict[str, str]] = {
+            _data: Final[dict[str, str | bool]] = {  # mutable-ok: Prisma update payload is built for this write
                 "litellm_params": json.dumps(merged_dictionary),
                 "updated_by": user_api_key_dict.user_id or LITELLM_PROXY_ADMIN_NAME,
+                "heuristic_v2_unlimited": _heuristic_v2_unlimited_marker(
+                    merged_dictionary.get("complexity_router_config")
+                    if isinstance(merged_dictionary.get("complexity_router_config"), Mapping)
+                    else None
+                ),
             }
             model_response: Final = await _proxy_model_table(prisma_client).update(
                 where={"model_id": _model_id},

--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -300,6 +300,7 @@ def _effective_complexity_router_config(
 async def _raise_if_heuristic_v2_slot_taken(
     *,
     prisma_client: PrismaClient,
+    user_api_key_dict: UserAPIKeyAuth,
     incoming_params: GenericLiteLLMParams | None,
     existing_params: GenericLiteLLMParams | None,
     current_model_id: str | None = None,
@@ -308,6 +309,17 @@ async def _raise_if_heuristic_v2_slot_taken(
     effective_config: Final = _effective_complexity_router_config(incoming_params, existing_params)
     if not uses_heuristic_v2(effective_config):
         return
+    admin_violation: Final = _heuristic_v2_admin_violation(
+        effective_config=effective_config,
+        user_role=user_api_key_dict.user_role,
+    )
+    if admin_violation is not None:
+        raise ProxyException(
+            message=admin_violation,
+            type=ProxyErrorTypes.auth_error.value,
+            code=status.HTTP_403_FORBIDDEN,
+            param="litellm_params.complexity_router_config.classifier_type",
+        )
     rows: Final = await _proxy_model_table(prisma_client).find_many(where={})
     violation: Final = _heuristic_v2_slot_violation(
         persisted_rows=rows,
@@ -322,6 +334,16 @@ async def _raise_if_heuristic_v2_slot_taken(
         type=ProxyErrorTypes.validation_error.value,
         code=status.HTTP_400_BAD_REQUEST,
         param="litellm_params.complexity_router_config.classifier_type",
+    )
+
+
+def _heuristic_v2_admin_violation(*, effective_config: Mapping[str, object] | None, user_role: object) -> str | None:
+    """Reserve the proxy-wide v2 classifier slot for proxy administrators."""
+    if not uses_heuristic_v2(effective_config) or user_role == LitellmUserRoles.PROXY_ADMIN:
+        return None
+    return (
+        "Only proxy admins can configure classifier_type='heuristic_v2' because it uses a proxy-wide singleton slot. "
+        "Team admins can use classifier_type='heuristic' or another auto-router type."
     )
 
 
@@ -352,6 +374,31 @@ def _heuristic_v2_slot_violation(
                 "heuristic_v2 router first."
             )
     return None
+
+
+HEURISTIC_V2_SINGLETON_INDEX: Final = "LiteLLM_ProxyModelTable_one_heuristic_v2_router"
+
+
+def _is_heuristic_v2_slot_unique_violation(error: Exception) -> bool:
+    """Recognize the database backstop when two proxy-admin writes race."""
+    return HEURISTIC_V2_SINGLETON_INDEX in str(error)
+
+
+def _heuristic_v2_slot_proxy_exception() -> ProxyException:
+    return ProxyException(
+        message=(
+            "Only one complexity router can use classifier_type='heuristic_v2' per proxy. "
+            "Change or delete the existing heuristic_v2 router first."
+        ),
+        type=ProxyErrorTypes.validation_error.value,
+        code=status.HTTP_400_BAD_REQUEST,
+        param="litellm_params.complexity_router_config.classifier_type",
+    )
+
+
+def _raise_if_heuristic_v2_slot_unique_violation(error: Exception) -> None:
+    if _is_heuristic_v2_slot_unique_violation(error):
+        raise _heuristic_v2_slot_proxy_exception() from error
 
 
 ENFORCE_RPM_TPM_ON_MODEL_ADD_SETTING: Final = "enforce_rpm_tpm_on_model_add"
@@ -805,6 +852,7 @@ async def patch_model(
         )
         await _raise_if_heuristic_v2_slot_taken(
             prisma_client=prisma_client,
+            user_api_key_dict=user_api_key_dict,
             incoming_params=patch_data.litellm_params,
             existing_params=db_model.litellm_params,
             current_model_id=model_id,
@@ -867,6 +915,7 @@ async def patch_model(
     except Exception as e:
         verbose_proxy_logger.exception("Error in patch_model: %s", e)
 
+        _raise_if_heuristic_v2_slot_unique_violation(e)
         if isinstance(e, (HTTPException, ProxyException)):
             raise e
 
@@ -1927,6 +1976,7 @@ async def add_new_model(
         )
         await _raise_if_heuristic_v2_slot_taken(
             prisma_client=prisma_client,
+            user_api_key_dict=user_api_key_dict,
             incoming_params=model_params.litellm_params,
             existing_params=None,
         )
@@ -1979,6 +2029,7 @@ async def add_new_model(
                     )
             except Exception as e:
                 verbose_proxy_logger.exception("Exception in add_new_model: %s", e)
+                _raise_if_heuristic_v2_slot_unique_violation(e)
 
         else:
             raise HTTPException(
@@ -2020,6 +2071,7 @@ async def add_new_model(
 
     except Exception as e:
         verbose_proxy_logger.exception("litellm.proxy.proxy_server.add_new_model(): Exception occured - %s", e)
+        _raise_if_heuristic_v2_slot_unique_violation(e)
         if isinstance(e, HTTPException):
             raise ProxyException(
                 message=getattr(e, "detail", f"Authentication Error({e})"),
@@ -2110,6 +2162,7 @@ async def update_model(
         )
         await _raise_if_heuristic_v2_slot_taken(
             prisma_client=prisma_client,
+            user_api_key_dict=user_api_key_dict,
             incoming_params=model_params.litellm_params,
             existing_params=deployment.litellm_params,
             current_model_id=_model_id,
@@ -2189,6 +2242,7 @@ async def update_model(
             return model_response
     except Exception as e:
         verbose_proxy_logger.exception("litellm.proxy.proxy_server.update_model(): Exception occured - %s", e)
+        _raise_if_heuristic_v2_slot_unique_violation(e)
         if isinstance(e, HTTPException):
             raise ProxyException(
                 message=getattr(e, "detail", f"Authentication Error({e})"),

--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -308,6 +308,29 @@ def _heuristic_v2_unlimited_marker(complexity_router_config: Mapping[str, object
     return uses_heuristic_v2(complexity_router_config) and _license_allows_unlimited_heuristic_v2()
 
 
+_FIND_HEURISTIC_V2_OWNER_SQL: Final = """
+SELECT model_id, litellm_params
+FROM "LiteLLM_ProxyModelTable"
+WHERE "heuristic_v2_license_blocked" IS NOT TRUE
+  AND ($1::text IS NULL OR model_id <> $1::text)
+  AND CASE
+      WHEN jsonb_typeof(litellm_params) = 'object'
+          THEN (litellm_params #>> '{complexity_router_config,classifier_type}') = 'heuristic_v2'
+      WHEN jsonb_typeof(litellm_params) = 'string'
+          THEN (((litellm_params #>> '{}')::jsonb) #>> '{complexity_router_config,classifier_type}') = 'heuristic_v2'
+      ELSE FALSE
+  END
+LIMIT 1
+"""
+
+
+async def _find_persisted_heuristic_v2_owner(
+    prisma_client: PrismaClient, current_model_id: str | None
+) -> Sequence[Mapping[str, object]]:
+    rows: Final = await prisma_client.db.query_raw(_FIND_HEURISTIC_V2_OWNER_SQL, current_model_id)
+    return cast("Sequence[Mapping[str, object]]", rows)  # cast-ok: query selects two known proxy-model columns
+
+
 async def _raise_if_heuristic_v2_slot_taken(
     *,
     prisma_client: PrismaClient,
@@ -335,8 +358,9 @@ async def _raise_if_heuristic_v2_slot_taken(
         return
     from litellm.proxy.proxy_server import llm_router
 
-    rows: Final = await _proxy_model_table(prisma_client).find_many(
-        where={}  # mutable-ok: Prisma requires a mutable filter mapping
+    rows: Final = await _find_persisted_heuristic_v2_owner(
+        prisma_client=prisma_client,
+        current_model_id=current_model_id,
     )
     violation: Final = _heuristic_v2_slot_violation(
         persisted_rows=rows,
@@ -367,7 +391,7 @@ def _heuristic_v2_admin_violation(*, effective_config: Mapping[str, object] | No
 
 def _heuristic_v2_slot_violation(
     *,
-    persisted_rows: Sequence[_ProxyModelRow],
+    persisted_rows: Sequence[_ProxyModelRow | Mapping[str, object]],
     live_model_list: Sequence[Mapping[str, object]] = (),
     incoming_params: GenericLiteLLMParams | None,
     existing_params: GenericLiteLLMParams | None,
@@ -390,12 +414,14 @@ def _heuristic_v2_slot_violation(
                 "creating a database-backed heuristic_v2 router."
             )
     for row in persisted_rows:
-        if current_model_id is not None and row.model_id == current_model_id:
+        row_model_id: object = row.get("model_id") if isinstance(row, Mapping) else row.model_id
+        if current_model_id is not None and row_model_id == current_model_id:
             continue
+        row_litellm_params: object = row.get("litellm_params") if isinstance(row, Mapping) else row.litellm_params
         if uses_heuristic_v2(
             config
             if isinstance(
-                config := _litellm_params_mapping(row.litellm_params).get("complexity_router_config"), Mapping
+                config := _litellm_params_mapping(row_litellm_params).get("complexity_router_config"), Mapping
             )
             else None
         ):
@@ -903,6 +929,7 @@ async def patch_model(
         update_data["heuristic_v2_unlimited"] = _heuristic_v2_unlimited_marker(
             _effective_complexity_router_config(patch_data.litellm_params, db_model.litellm_params)
         )
+        update_data["heuristic_v2_license_blocked"] = False
 
         # Perform partial update
         updated_model: Final = await _proxy_model_table(prisma_client).update(
@@ -1154,6 +1181,7 @@ async def _add_model_to_db(
         "created_by": user_api_key_dict.user_id or LITELLM_PROXY_ADMIN_NAME,
         "updated_by": user_api_key_dict.user_id or LITELLM_PROXY_ADMIN_NAME,
         "heuristic_v2_unlimited": _heuristic_v2_unlimited_marker(model_params.litellm_params.complexity_router_config),
+        "heuristic_v2_license_blocked": False,
     }
     if model_params.model_info.id is not None:
         _data["model_id"] = model_params.model_info.id
@@ -2240,6 +2268,7 @@ async def update_model(
                     if isinstance(merged_dictionary.get("complexity_router_config"), Mapping)
                     else None
                 ),
+                "heuristic_v2_license_blocked": False,
             }
             model_response: Final = await _proxy_model_table(prisma_client).update(
                 where={"model_id": _model_id},

--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -92,6 +92,7 @@ from litellm.router_strategy.complexity_router import (
 from litellm.router_utils.auto_router_model_naming import (
     STRATEGY_ROUTER_PARAM_FIELDS,
     carries_complexity_router_settings,
+    uses_heuristic_v2,
     validate_complexity_router_config_placement,
     validate_complexity_router_config_write,
     validate_strategy_router_model_write,
@@ -142,6 +143,9 @@ class _ProxyModelRow(Protocol):
     def model_info(self) -> object: ...
 
     def model_dump_json(self, *, exclude_none: bool = False) -> str: ...
+
+    @property
+    def litellm_params(self) -> object: ...
 
 
 class _ProxyModelTable(Protocol):
@@ -263,6 +267,68 @@ def _raise_on_strategy_router_write_violation(
         code=status.HTTP_400_BAD_REQUEST,
         param="litellm_params.model",
     )
+
+
+def _litellm_params_mapping(value: object) -> Mapping[str, object]:
+    """Normalize Prisma's parsed or JSON-encoded Json column at the typed boundary."""
+    if isinstance(value, Mapping):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed: Final = json.loads(value)
+        except JSONDecodeError:
+            return MappingProxyType({})
+        return parsed if isinstance(parsed, Mapping) else MappingProxyType({})
+    return MappingProxyType({})
+
+
+def _effective_complexity_router_config(
+    incoming_params: GenericLiteLLMParams | None,
+    existing_params: GenericLiteLLMParams | None,
+) -> Mapping[str, object] | None:
+    """Return the whole config that the write leaves on the deployment."""
+    config: Final = (
+        incoming_params.complexity_router_config
+        if incoming_params is not None and incoming_params.complexity_router_config is not None
+        else existing_params.complexity_router_config
+        if existing_params is not None
+        else None
+    )
+    return config if isinstance(config, Mapping) else None
+
+
+async def _raise_if_heuristic_v2_slot_taken(
+    *,
+    prisma_client: PrismaClient,
+    incoming_params: GenericLiteLLMParams | None,
+    existing_params: GenericLiteLLMParams | None,
+    current_model_id: str | None = None,
+) -> None:
+    """Allow at most one persisted heuristic-v2 complexity router per proxy."""
+    effective_config: Final = _effective_complexity_router_config(incoming_params, existing_params)
+    if not uses_heuristic_v2(effective_config):
+        return
+    rows: Final = await _proxy_model_table(prisma_client).find_many(where={})
+    for row in rows:
+        if current_model_id is not None and row.model_id == current_model_id:
+            continue
+        if uses_heuristic_v2(
+            config
+            if isinstance(
+                config := _litellm_params_mapping(row.litellm_params).get("complexity_router_config"), Mapping
+            )
+            else None
+        ):
+            raise ProxyException(
+                message=(
+                    "Only one complexity router can use classifier_type='heuristic_v2' per proxy. "
+                    "Use classifier_type='heuristic' for this router, or change or delete the existing "
+                    "heuristic_v2 router first."
+                ),
+                type=ProxyErrorTypes.validation_error.value,
+                code=status.HTTP_400_BAD_REQUEST,
+                param="litellm_params.complexity_router_config.classifier_type",
+            )
 
 
 ENFORCE_RPM_TPM_ON_MODEL_ADD_SETTING: Final = "enforce_rpm_tpm_on_model_add"
@@ -713,6 +779,12 @@ async def patch_model(
         _raise_on_strategy_router_write_violation(
             incoming_params=patch_data.litellm_params,
             existing_params=db_model.litellm_params,
+        )
+        await _raise_if_heuristic_v2_slot_taken(
+            prisma_client=prisma_client,
+            incoming_params=patch_data.litellm_params,
+            existing_params=db_model.litellm_params,
+            current_model_id=model_id,
         )
 
         # Handle team model updates with proper alias management
@@ -1830,6 +1902,11 @@ async def add_new_model(
             incoming_params=model_params.litellm_params,
             existing_params=None,
         )
+        await _raise_if_heuristic_v2_slot_taken(
+            prisma_client=prisma_client,
+            incoming_params=model_params.litellm_params,
+            existing_params=None,
+        )
 
         _raise_if_rate_limits_required_but_missing(
             litellm_params=model_params.litellm_params,
@@ -2007,6 +2084,12 @@ async def update_model(
         _raise_on_strategy_router_write_violation(
             incoming_params=model_params.litellm_params,
             existing_params=deployment.litellm_params,
+        )
+        await _raise_if_heuristic_v2_slot_taken(
+            prisma_client=prisma_client,
+            incoming_params=model_params.litellm_params,
+            existing_params=deployment.litellm_params,
+            current_model_id=_model_id,
         )
 
         # update DB

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1685,6 +1685,35 @@ class _UserTeamsRow(Protocol):
 
 _ProxyModelRow: TypeAlias = "prisma_models.LiteLLM_ProxyModelTable"
 
+_RECONCILE_HEURISTIC_V2_LICENSE_SQL: Final = """
+WITH ranked_heuristic_v2 AS (
+    SELECT model_id,
+           ROW_NUMBER() OVER (ORDER BY created_at, model_id) AS owner_rank
+    FROM "LiteLLM_ProxyModelTable"
+    WHERE CASE
+        WHEN jsonb_typeof(litellm_params) = 'object'
+            THEN (litellm_params #>> '{complexity_router_config,classifier_type}') = 'heuristic_v2'
+        WHEN jsonb_typeof(litellm_params) = 'string'
+            THEN (((litellm_params #>> '{}')::jsonb) #>> '{complexity_router_config,classifier_type}') = 'heuristic_v2'
+        ELSE FALSE
+    END
+), expected_state AS (
+    SELECT model_id,
+           $1::boolean AS unlimited,
+           CASE WHEN $1::boolean THEN FALSE ELSE owner_rank > 1 END AS license_blocked
+    FROM ranked_heuristic_v2
+)
+UPDATE "LiteLLM_ProxyModelTable" AS model
+SET "heuristic_v2_unlimited" = expected.unlimited,
+    "heuristic_v2_license_blocked" = expected.license_blocked
+FROM expected_state AS expected
+WHERE model.model_id = expected.model_id
+  AND (
+      model."heuristic_v2_unlimited" IS DISTINCT FROM expected.unlimited
+      OR model."heuristic_v2_license_blocked" IS DISTINCT FROM expected.license_blocked
+  )
+"""
+
 
 def _config_param_table(client: PrismaClient | None) -> TableActions[_ConfigParamRow]:
     return cast(  # cast-ok: this is prisma's LiteLLM_Config actions object, which parses its Json column to a mapping
@@ -6055,7 +6084,9 @@ class ProxyConfig:
         if _id is not None:
             model.model_info["id"] = _id
             model.model_info["db_model"] = True
-            model.model_info["blocked"] = bool(getattr(model, "blocked", False))
+            model.model_info["blocked"] = bool(
+                getattr(model, "blocked", False) or getattr(model, "heuristic_v2_license_blocked", False)
+            )
 
         if premium_user is True:
             # seeing "created_at", "updated_at", "created_by", "updated_by" is a LiteLLM Enterprise Feature
@@ -6255,6 +6286,8 @@ class ProxyConfig:
                 return
 
             models_list: Final[list] = new_models if isinstance(new_models, list) else []
+            if llm_router is not None:
+                llm_router.allow_multiple_heuristic_v2 = _license_check.allows_feature(AUTO_ROUTER_LICENSE_FEATURE)
             if llm_router is None and master_key is not None:
                 verbose_proxy_logger.debug("len new_models: %s", len(models_list))
 
@@ -6957,6 +6990,11 @@ class ProxyConfig:
     def _should_load_db_object(self, object_type: str | SupportedDBObjectType) -> bool:
         return should_load_db_object(object_type=object_type)
 
+    async def _reconcile_heuristic_v2_license_state(self, prisma_client: PrismaClient) -> None:
+        """Apply the current signed-license entitlement before loading DB routers."""
+        unlimited: Final = _license_check.allows_feature(AUTO_ROUTER_LICENSE_FEATURE)
+        await prisma_client.db.execute_raw(_RECONCILE_HEURISTIC_V2_LICENSE_SQL, unlimited)
+
     async def _get_models_from_db(self, prisma_client: PrismaClient) -> Sequence[_ProxyModelRow] | None:
         """
         Fetch all model deployments from the DB.
@@ -7038,6 +7076,7 @@ class ProxyConfig:
 
             # Only load models from DB if "models" is in supported_db_objects (or if supported_db_objects is not set)
             if self._should_load_db_object(object_type="models"):
+                await self._reconcile_heuristic_v2_license_state(prisma_client=prisma_client)
                 new_models: Final = await self._get_models_from_db(prisma_client=prisma_client)
 
                 # update llm router

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -301,7 +301,7 @@ from litellm.proxy.auth.auth_utils import (
 )
 from litellm.proxy.auth.fallback_model_access import router_fallback_access_check
 from litellm.proxy.auth.handle_jwt import JWTHandler
-from litellm.proxy.auth.litellm_license import LicenseCheck
+from litellm.proxy.auth.litellm_license import AUTO_ROUTER_LICENSE_FEATURE, LicenseCheck
 from litellm.proxy.auth.model_checks import (
     expand_wildcard_deployments_for_model_info,
     get_all_fallbacks,
@@ -5810,6 +5810,7 @@ class ProxyConfig:
             ),
             ignore_invalid_deployments=True,  # don't raise an error if a deployment is invalid
             fallback_access_check=router_fallback_access_check,
+            allow_multiple_heuristic_v2=_license_check.allows_feature(AUTO_ROUTER_LICENSE_FEATURE),
         )
 
         if redis_usage_cache is not None and router.cache.redis_cache is None:
@@ -6270,6 +6271,7 @@ class ProxyConfig:
                         search_tools=search_tools,
                         ignore_invalid_deployments=True,
                         fallback_access_check=router_fallback_access_check,
+                        allow_multiple_heuristic_v2=_license_check.allows_feature(AUTO_ROUTER_LICENSE_FEATURE),
                     )
                     verbose_proxy_logger.debug("updated llm_router: %s", llm_router)
             else:

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -53,6 +53,7 @@ model LiteLLM_ProxyModelTable {
   litellm_params Json
   model_info Json?
   blocked Boolean @default(false)
+  heuristic_v2_unlimited Boolean @default(false)
   created_at    DateTime               @default(now()) @map("created_at")
   created_by String
   updated_at    DateTime               @default(now()) @updatedAt @map("updated_at")

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -53,7 +53,8 @@ model LiteLLM_ProxyModelTable {
   litellm_params Json
   model_info Json?
   blocked Boolean @default(false)
-  heuristic_v2_unlimited Boolean @default(false)
+  heuristic_v2_unlimited Boolean? @default(false)
+  heuristic_v2_license_blocked Boolean? @default(false)
   created_at    DateTime               @default(now()) @map("created_at")
   created_by String
   updated_at    DateTime               @default(now()) @updatedAt @map("updated_at")

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -8702,6 +8702,15 @@ class Router:
 
         complexity_router_config: Final[dict | None] = deployment.litellm_params.complexity_router_config
 
+        if complexity_router_config and complexity_router_config.get("classifier_type") == "heuristic_v2":
+            for registered in self.complexity_routers.values():
+                if any(tagged.strategy.config.classifier_type == "heuristic_v2" for tagged in registered):
+                    raise ValueError(
+                        "Only one complexity router can use classifier_type='heuristic_v2' per proxy. "
+                        "Use classifier_type='heuristic' for this router, or change or remove the existing "
+                        "heuristic_v2 router first."
+                    )
+
         default_model: str | None = deployment.litellm_params.complexity_router_default_model
 
         # If no default model specified, try to get from config tiers. Derived from the

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -757,7 +757,7 @@ class Router:
         self.set_verbose = set_verbose
         self.ignore_invalid_deployments = ignore_invalid_deployments
         self.fallback_access_check: Final = fallback_access_check
-        self.allow_multiple_heuristic_v2: Final = allow_multiple_heuristic_v2
+        self.allow_multiple_heuristic_v2 = allow_multiple_heuristic_v2
         self.debug_level = debug_level
         self.enable_pre_call_checks = enable_pre_call_checks
         self.enable_tag_filtering = enable_tag_filtering

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -679,6 +679,7 @@ class Router:
         background_health_check_model_groups: Sequence[str] | None = None,
         enable_weighted_failover: bool = False,
         fallback_access_check: FallbackAccessCheck | None = None,
+        allow_multiple_heuristic_v2: bool = False,
     ) -> None:
         """
         Initialize the Router class with the given parameters for caching, reliability, and routing strategy.
@@ -756,6 +757,7 @@ class Router:
         self.set_verbose = set_verbose
         self.ignore_invalid_deployments = ignore_invalid_deployments
         self.fallback_access_check: Final = fallback_access_check
+        self.allow_multiple_heuristic_v2: Final = allow_multiple_heuristic_v2
         self.debug_level = debug_level
         self.enable_pre_call_checks = enable_pre_call_checks
         self.enable_tag_filtering = enable_tag_filtering
@@ -8702,7 +8704,11 @@ class Router:
 
         complexity_router_config: Final[dict | None] = deployment.litellm_params.complexity_router_config
 
-        if complexity_router_config and complexity_router_config.get("classifier_type") == "heuristic_v2":
+        if (
+            not self.allow_multiple_heuristic_v2
+            and complexity_router_config
+            and complexity_router_config.get("classifier_type") == "heuristic_v2"
+        ):
             for registered in self.complexity_routers.values():
                 if any(tagged.strategy.config.classifier_type == "heuristic_v2" for tagged in registered):
                     raise ValueError(

--- a/litellm/router_utils/auto_router_model_naming.py
+++ b/litellm/router_utils/auto_router_model_naming.py
@@ -210,6 +210,11 @@ def carries_complexity_router_settings(model: str | None, present_fields: frozen
     )
 
 
+def uses_heuristic_v2(complexity_router_config: Mapping[str, object] | None) -> bool:
+    """Whether a complexity-router config selects the singleton v2 classifier."""
+    return complexity_router_config is not None and complexity_router_config.get("classifier_type") == "heuristic_v2"
+
+
 def validate_complexity_router_config_placement(litellm_params: Mapping[str, object] | None) -> str | None:
     """Reject a complexity-router setting written beside ``complexity_router_config``.
 

--- a/schema.prisma
+++ b/schema.prisma
@@ -53,6 +53,7 @@ model LiteLLM_ProxyModelTable {
   litellm_params Json
   model_info Json?
   blocked Boolean @default(false)
+  heuristic_v2_unlimited Boolean @default(false)
   created_at    DateTime               @default(now()) @map("created_at")
   created_by String
   updated_at    DateTime               @default(now()) @updatedAt @map("updated_at")

--- a/schema.prisma
+++ b/schema.prisma
@@ -53,7 +53,8 @@ model LiteLLM_ProxyModelTable {
   litellm_params Json
   model_info Json?
   blocked Boolean @default(false)
-  heuristic_v2_unlimited Boolean @default(false)
+  heuristic_v2_unlimited Boolean? @default(false)
+  heuristic_v2_license_blocked Boolean? @default(false)
   created_at    DateTime               @default(now()) @map("created_at")
   created_by String
   updated_at    DateTime               @default(now()) @updatedAt @map("updated_at")

--- a/tests/test_litellm/proxy/auth/test_litellm_license.py
+++ b/tests/test_litellm/proxy/auth/test_litellm_license.py
@@ -30,11 +30,21 @@ def test_is_over_limit():
 def test_allows_feature_requires_signed_license_claim():
     license_check = LicenseCheck()
 
-    license_check.airgapped_license_data = {"allowed_features": [AUTO_ROUTER_LICENSE_FEATURE]}
+    license_check.airgapped_license_data = {
+        "allowed_features": [AUTO_ROUTER_LICENSE_FEATURE],
+        "expiration_date": "2999-01-01",
+    }
     assert license_check.allows_feature(AUTO_ROUTER_LICENSE_FEATURE) is True
 
-    license_check.airgapped_license_data = {"allowed_features": ["other_feature"]}
+    license_check.airgapped_license_data = {"allowed_features": ["other_feature"], "expiration_date": "2999-01-01"}
     assert license_check.allows_feature(AUTO_ROUTER_LICENSE_FEATURE) is False
+
+    license_check.airgapped_license_data = {
+        "allowed_features": [AUTO_ROUTER_LICENSE_FEATURE],
+        "expiration_date": "2000-01-01",
+    }
+    assert license_check.allows_feature(AUTO_ROUTER_LICENSE_FEATURE) is False
+    assert license_check.airgapped_license_data is None
 
     license_check.airgapped_license_data = None
     assert license_check.allows_feature(AUTO_ROUTER_LICENSE_FEATURE) is False

--- a/tests/test_litellm/proxy/auth/test_litellm_license.py
+++ b/tests/test_litellm/proxy/auth/test_litellm_license.py
@@ -1,17 +1,12 @@
-import asyncio
-import json
-from unittest.mock import AsyncMock, MagicMock, patch
-
-
-from litellm.proxy.auth.litellm_license import LicenseCheck
+from litellm.proxy.auth.litellm_license import AUTO_ROUTER_LICENSE_FEATURE, LicenseCheck
 
 
 def test_read_public_key_loads_successfully():
     """Ensure public_key.pem is valid PEM with no leading whitespace."""
     license_check = LicenseCheck()
-    assert (
-        license_check.public_key is not None
-    ), "public_key.pem could not be loaded — check for leading whitespace or malformed PEM header"
+    assert license_check.public_key is not None, (
+        "public_key.pem could not be loaded — check for leading whitespace or malformed PEM header"
+    )
 
 
 def test_is_over_limit():
@@ -30,3 +25,16 @@ def test_is_over_limit():
     assert license_check.is_over_limit(101) is False
     assert license_check.is_over_limit(100) is False
     assert license_check.is_over_limit(99) is False
+
+
+def test_allows_feature_requires_signed_license_claim():
+    license_check = LicenseCheck()
+
+    license_check.airgapped_license_data = {"allowed_features": [AUTO_ROUTER_LICENSE_FEATURE]}
+    assert license_check.allows_feature(AUTO_ROUTER_LICENSE_FEATURE) is True
+
+    license_check.airgapped_license_data = {"allowed_features": ["other_feature"]}
+    assert license_check.allows_feature(AUTO_ROUTER_LICENSE_FEATURE) is False
+
+    license_check.airgapped_license_data = None
+    assert license_check.allows_feature(AUTO_ROUTER_LICENSE_FEATURE) is False

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -3339,6 +3339,36 @@ class TestGetModelInfoWithIdBlocked:
         info = ProxyConfig().get_model_info_with_id(model=model, db_model=True)
         assert getattr(info, "blocked") is False
 
+    def test_get_model_info_with_id_propagates_license_blocked_true(self):
+        from litellm.proxy.proxy_server import ProxyConfig
+
+        model = MagicMock(spec=["model_id", "model_info", "blocked", "heuristic_v2_license_blocked"])
+        model.model_id = "dep-license-blocked"
+        model.model_info = {}
+        model.blocked = False
+        model.heuristic_v2_license_blocked = True
+        info = ProxyConfig().get_model_info_with_id(model=model, db_model=True)
+        assert getattr(info, "blocked") is True
+
+
+class TestHeuristicV2LicenseReconciliation:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("unlimited", [False, True])
+    async def test_reconcile_uses_current_license_state(self, unlimited):
+        from litellm.proxy.proxy_server import ProxyConfig
+
+        prisma = MagicMock()
+        prisma.db.execute_raw = AsyncMock(return_value=2)
+        with patch(  # test-quality-ok: isolates the proxy license singleton used by reconciliation
+            "litellm.proxy.proxy_server._license_check.allows_feature",
+            return_value=unlimited,
+        ):
+            await ProxyConfig()._reconcile_heuristic_v2_license_state(prisma_client=prisma)
+
+        query, entitlement = prisma.db.execute_raw.await_args.args
+        assert "ROW_NUMBER()" in query
+        assert entitlement is unlimited
+
 
 class TestPatchModelBlockedAuthGate:
     """Only proxy admins may flip `blocked` — team admins authorized for
@@ -4150,7 +4180,29 @@ class TestStrategyRouterWriteValidation:
                 existing_params=None,
             )
 
-        prisma_client.db.litellm_proxymodeltable.find_many.assert_not_called()
+        prisma_client.db.query_raw.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_singleton_lookup_uses_bounded_database_query(self):
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _find_persisted_heuristic_v2_owner,
+        )
+
+        prisma_client = MagicMock()
+        prisma_client.db.query_raw = AsyncMock(
+            return_value=[
+                {
+                    "model_id": "owner",
+                    "litellm_params": {"complexity_router_config": {"classifier_type": "heuristic_v2"}},
+                }
+            ]
+        )
+        rows = await _find_persisted_heuristic_v2_owner(prisma_client, "current")
+
+        query, excluded_model_id = prisma_client.db.query_raw.await_args.args
+        assert len(rows) == 1
+        assert "LIMIT 1" in query
+        assert excluded_model_id == "current"
 
     def test_double_prefix_rejected_against_stored_params(self):
         from litellm.proxy.management_endpoints.model_management_endpoints import (

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -4011,6 +4011,50 @@ class TestStrategyRouterWriteValidation:
             is None
         )
 
+    def test_heuristic_v2_is_reserved_for_proxy_admins(self):
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _heuristic_v2_admin_violation,
+        )
+
+        config = {"classifier_type": "heuristic_v2"}
+        violation = _heuristic_v2_admin_violation(
+            effective_config=config,
+            user_role=LitellmUserRoles.INTERNAL_USER,
+        )
+        assert violation is not None
+        assert "Only proxy admins" in violation
+        assert (
+            _heuristic_v2_admin_violation(
+                effective_config=config,
+                user_role=LitellmUserRoles.PROXY_ADMIN,
+            )
+            is None
+        )
+
+    def test_team_admins_can_still_configure_heuristic_v1(self):
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _heuristic_v2_admin_violation,
+        )
+
+        assert (
+            _heuristic_v2_admin_violation(
+                effective_config={"classifier_type": "heuristic"},
+                user_role=LitellmUserRoles.INTERNAL_USER,
+            )
+            is None
+        )
+
+    def test_database_singleton_violation_is_recognized(self):
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            HEURISTIC_V2_SINGLETON_INDEX,
+            _is_heuristic_v2_slot_unique_violation,
+        )
+
+        assert _is_heuristic_v2_slot_unique_violation(
+            Exception(f'duplicate key violates unique constraint "{HEURISTIC_V2_SINGLETON_INDEX}"')
+        )
+        assert not _is_heuristic_v2_slot_unique_violation(Exception("unrelated database error"))
+
     def test_double_prefix_rejected_against_stored_params(self):
         from litellm.proxy.management_endpoints.model_management_endpoints import (
             _strategy_router_write_violation,

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -3994,6 +3994,62 @@ class TestStrategyRouterWriteValidation:
             is None
         )
 
+    @pytest.mark.parametrize(
+        "litellm_params",
+        [
+            {"complexity_router_config": {"classifier_type": "heuristic_v2"}},
+            json.dumps({"complexity_router_config": {"classifier_type": "heuristic_v2"}}),
+        ],
+    )
+    def test_config_yaml_heuristic_v2_router_takes_slot(self, litellm_params):
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _heuristic_v2_slot_violation,
+        )
+
+        violation = _heuristic_v2_slot_violation(
+            persisted_rows=(),
+            live_model_list=[
+                {
+                    "model_name": "configured-router",
+                    "litellm_params": litellm_params,
+                    "model_info": {"db_model": False},
+                }
+            ],
+            incoming_params=LiteLLM_Params(
+                model="auto_router/complexity_router",
+                complexity_router_config={"classifier_type": "heuristic_v2"},
+            ),
+            existing_params=None,
+        )
+        assert violation is not None
+        assert "config.yaml" in violation
+
+    def test_db_models_in_live_router_do_not_double_consume_slot(self):
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _heuristic_v2_slot_violation,
+        )
+
+        assert (
+            _heuristic_v2_slot_violation(
+                persisted_rows=(),
+                live_model_list=[
+                    {
+                        "model_name": "db-router",
+                        "litellm_params": {
+                            "complexity_router_config": {"classifier_type": "heuristic_v2"}
+                        },
+                        "model_info": {"db_model": True},
+                    }
+                ],
+                incoming_params=LiteLLM_Params(
+                    model="auto_router/complexity_router",
+                    complexity_router_config={"classifier_type": "heuristic_v2"},
+                ),
+                existing_params=None,
+            )
+            is None
+        )
+
     def test_heuristic_v1_does_not_consume_v2_slot(self):
         from litellm.proxy.management_endpoints.model_management_endpoints import (
             _heuristic_v2_slot_violation,

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -3953,6 +3953,80 @@ class TestStrategyRouterWriteValidation:
             model_info={"id": model_id},
         )
 
+    @pytest.mark.asyncio
+    async def test_second_heuristic_v2_router_is_rejected(self):
+        from litellm.proxy._types import ProxyException
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _raise_if_heuristic_v2_slot_taken,
+        )
+
+        table = MagicMock()
+        row = MagicMock()
+        row.model_id = "first-v2"
+        row.litellm_params = {"complexity_router_config": {"classifier_type": "heuristic_v2"}}
+        table.find_many = AsyncMock(return_value=[row])
+        with patch(
+            "litellm.proxy.management_endpoints.model_management_endpoints._proxy_model_table",
+            return_value=table,
+        ):
+            with pytest.raises(ProxyException, match="Only one complexity router"):
+                await _raise_if_heuristic_v2_slot_taken(
+                    prisma_client=MagicMock(),
+                    incoming_params=LiteLLM_Params(
+                        model="auto_router/complexity_router",
+                        complexity_router_config={"classifier_type": "heuristic_v2"},
+                    ),
+                    existing_params=None,
+                )
+
+    @pytest.mark.asyncio
+    async def test_existing_heuristic_v2_router_can_be_edited(self):
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _raise_if_heuristic_v2_slot_taken,
+        )
+        from litellm.types.router import updateLiteLLMParams
+
+        table = MagicMock()
+        row = MagicMock()
+        row.model_id = "first-v2"
+        row.litellm_params = json.dumps({"complexity_router_config": {"classifier_type": "heuristic_v2"}})
+        table.find_many = AsyncMock(return_value=[row])
+        with patch(
+            "litellm.proxy.management_endpoints.model_management_endpoints._proxy_model_table",
+            return_value=table,
+        ):
+            await _raise_if_heuristic_v2_slot_taken(
+                prisma_client=MagicMock(),
+                incoming_params=updateLiteLLMParams(rpm=10),
+                existing_params=LiteLLM_Params(
+                    model="auto_router/complexity_router",
+                    complexity_router_config={"classifier_type": "heuristic_v2"},
+                ),
+                current_model_id="first-v2",
+            )
+
+    @pytest.mark.asyncio
+    async def test_heuristic_v1_does_not_consume_v2_slot(self):
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _raise_if_heuristic_v2_slot_taken,
+        )
+
+        table = MagicMock()
+        table.find_many = AsyncMock()
+        with patch(
+            "litellm.proxy.management_endpoints.model_management_endpoints._proxy_model_table",
+            return_value=table,
+        ):
+            await _raise_if_heuristic_v2_slot_taken(
+                prisma_client=MagicMock(),
+                incoming_params=LiteLLM_Params(
+                    model="auto_router/complexity_router",
+                    complexity_router_config={"classifier_type": "heuristic"},
+                ),
+                existing_params=None,
+            )
+        table.find_many.assert_not_awaited()
+
     def test_double_prefix_rejected_against_stored_params(self):
         from litellm.proxy.management_endpoints.model_management_endpoints import (
             _strategy_router_write_violation,

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -1602,7 +1602,7 @@ class TestTeamModelUpdate:
         )
         prisma_client = MockPrismaClient(team_exists=True, user_admin=False)
 
-        with patch(
+        with patch(  # test-quality-ok: isolates the signed-license entitlement while testing marker behavior
             "litellm.proxy.proxy_server.premium_user",
             True,
         ):
@@ -4110,6 +4110,47 @@ class TestStrategyRouterWriteValidation:
             Exception(f'duplicate key violates unique constraint "{HEURISTIC_V2_SINGLETON_INDEX}"')
         )
         assert not _is_heuristic_v2_slot_unique_violation(Exception("unrelated database error"))
+
+    def test_auto_router_license_marks_heuristic_v2_as_unlimited(self):
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _heuristic_v2_unlimited_marker,
+        )
+
+        with patch(  # test-quality-ok: isolates the unlicensed default while testing marker behavior
+            "litellm.proxy.management_endpoints.model_management_endpoints._license_allows_unlimited_heuristic_v2",
+            return_value=True,
+        ):
+            assert _heuristic_v2_unlimited_marker({"classifier_type": "heuristic_v2"}) is True
+            assert _heuristic_v2_unlimited_marker({"classifier_type": "heuristic"}) is False
+
+        with patch(
+            "litellm.proxy.management_endpoints.model_management_endpoints._license_allows_unlimited_heuristic_v2",
+            return_value=False,
+        ):
+            assert _heuristic_v2_unlimited_marker({"classifier_type": "heuristic_v2"}) is False
+
+    @pytest.mark.asyncio
+    async def test_auto_router_license_skips_singleton_lookup(self):  # test-quality-ok: verifies entitlement bypasses the singleton database path
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _raise_if_heuristic_v2_slot_taken,
+        )
+
+        prisma_client = MagicMock()
+        with patch(  # test-quality-ok: isolates the entitlement branch from global proxy license state
+            "litellm.proxy.management_endpoints.model_management_endpoints._license_allows_unlimited_heuristic_v2",
+            return_value=True,
+        ):
+            await _raise_if_heuristic_v2_slot_taken(
+                prisma_client=prisma_client,
+                user_api_key_dict=UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN),
+                incoming_params=LiteLLM_Params(
+                    model="auto_router/complexity_router",
+                    complexity_router_config={"classifier_type": "heuristic_v2"},
+                ),
+                existing_params=None,
+            )
+
+        prisma_client.db.litellm_proxymodeltable.find_many.assert_not_called()
 
     def test_double_prefix_rejected_against_stored_params(self):
         from litellm.proxy.management_endpoints.model_management_endpoints import (

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -3953,50 +3953,37 @@ class TestStrategyRouterWriteValidation:
             model_info={"id": model_id},
         )
 
-    @pytest.mark.asyncio
-    async def test_second_heuristic_v2_router_is_rejected(self):
-        from litellm.proxy._types import ProxyException
+    def test_second_heuristic_v2_router_is_rejected(self):
         from litellm.proxy.management_endpoints.model_management_endpoints import (
-            _raise_if_heuristic_v2_slot_taken,
+            _heuristic_v2_slot_violation,
         )
 
-        table = MagicMock()
         row = MagicMock()
         row.model_id = "first-v2"
         row.litellm_params = {"complexity_router_config": {"classifier_type": "heuristic_v2"}}
-        table.find_many = AsyncMock(return_value=[row])
-        with patch(
-            "litellm.proxy.management_endpoints.model_management_endpoints._proxy_model_table",
-            return_value=table,
-        ):
-            with pytest.raises(ProxyException, match="Only one complexity router"):
-                await _raise_if_heuristic_v2_slot_taken(
-                    prisma_client=MagicMock(),
-                    incoming_params=LiteLLM_Params(
-                        model="auto_router/complexity_router",
-                        complexity_router_config={"classifier_type": "heuristic_v2"},
-                    ),
-                    existing_params=None,
-                )
+        violation = _heuristic_v2_slot_violation(
+            persisted_rows=[row],
+            incoming_params=LiteLLM_Params(
+                model="auto_router/complexity_router",
+                complexity_router_config={"classifier_type": "heuristic_v2"},
+            ),
+            existing_params=None,
+        )
+        assert violation is not None
+        assert "Only one complexity router" in violation
 
-    @pytest.mark.asyncio
-    async def test_existing_heuristic_v2_router_can_be_edited(self):
+    def test_existing_heuristic_v2_router_can_be_edited(self):
         from litellm.proxy.management_endpoints.model_management_endpoints import (
-            _raise_if_heuristic_v2_slot_taken,
+            _heuristic_v2_slot_violation,
         )
         from litellm.types.router import updateLiteLLMParams
 
-        table = MagicMock()
         row = MagicMock()
         row.model_id = "first-v2"
         row.litellm_params = json.dumps({"complexity_router_config": {"classifier_type": "heuristic_v2"}})
-        table.find_many = AsyncMock(return_value=[row])
-        with patch(
-            "litellm.proxy.management_endpoints.model_management_endpoints._proxy_model_table",
-            return_value=table,
-        ):
-            await _raise_if_heuristic_v2_slot_taken(
-                prisma_client=MagicMock(),
+        assert (
+            _heuristic_v2_slot_violation(
+                persisted_rows=[row],
                 incoming_params=updateLiteLLMParams(rpm=10),
                 existing_params=LiteLLM_Params(
                     model="auto_router/complexity_router",
@@ -4004,28 +3991,25 @@ class TestStrategyRouterWriteValidation:
                 ),
                 current_model_id="first-v2",
             )
-
-    @pytest.mark.asyncio
-    async def test_heuristic_v1_does_not_consume_v2_slot(self):
-        from litellm.proxy.management_endpoints.model_management_endpoints import (
-            _raise_if_heuristic_v2_slot_taken,
+            is None
         )
 
-        table = MagicMock()
-        table.find_many = AsyncMock()
-        with patch(
-            "litellm.proxy.management_endpoints.model_management_endpoints._proxy_model_table",
-            return_value=table,
-        ):
-            await _raise_if_heuristic_v2_slot_taken(
-                prisma_client=MagicMock(),
+    def test_heuristic_v1_does_not_consume_v2_slot(self):
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _heuristic_v2_slot_violation,
+        )
+
+        assert (
+            _heuristic_v2_slot_violation(
+                persisted_rows=(),
                 incoming_params=LiteLLM_Params(
                     model="auto_router/complexity_router",
                     complexity_router_config={"classifier_type": "heuristic"},
                 ),
                 existing_params=None,
             )
-        table.find_many.assert_not_awaited()
+            is None
+        )
 
     def test_double_prefix_rejected_against_stored_params(self):
         from litellm.proxy.management_endpoints.model_management_endpoints import (

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -1085,6 +1085,60 @@ class TestRouterComplexityDeploymentMethods:
         router.init_complexity_router_deployment(deployment)
         assert "auto_router/complexity_router/test-router" in router.complexity_routers
 
+    def test_only_one_heuristic_v2_complexity_router_can_register(self):
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "gpt-4o-mini",
+                    "litellm_params": {"model": "openai/gpt-4o-mini"},
+                }
+            ]
+        )
+
+        def deployment(name: str) -> Deployment:
+            return Deployment(
+                model_name=name,
+                litellm_params=LiteLLM_Params(
+                    model=f"auto_router/complexity_router/{name}",
+                    complexity_router_default_model="gpt-4o-mini",
+                    complexity_router_config={
+                        "classifier_type": "heuristic_v2",
+                        "tiers": {"SIMPLE": "gpt-4o-mini"},
+                    },
+                ),
+                model_info={"id": name},
+            )
+
+        router.init_complexity_router_deployment(deployment("first"))
+        with pytest.raises(ValueError, match="Only one complexity router"):
+            router.init_complexity_router_deployment(deployment("second"))
+
+    def test_heuristic_v1_complexity_routers_remain_unlimited(self):
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "gpt-4o-mini",
+                    "litellm_params": {"model": "openai/gpt-4o-mini"},
+                }
+            ]
+        )
+        for name in ("first", "second"):
+            router.init_complexity_router_deployment(
+                Deployment(
+                    model_name=name,
+                    litellm_params=LiteLLM_Params(
+                        model=f"auto_router/complexity_router/{name}",
+                        complexity_router_default_model="gpt-4o-mini",
+                        complexity_router_config={
+                            "classifier_type": "heuristic",
+                            "tiers": {"SIMPLE": "gpt-4o-mini"},
+                        },
+                    ),
+                    model_info={"id": name},
+                )
+            )
+        assert set(router.complexity_routers) == {"first", "second"}
+
     def test_hybrid_initialization_waits_for_later_pool_deployments(self):
         router = Router(
             model_list=[

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -1113,6 +1113,35 @@ class TestRouterComplexityDeploymentMethods:
         with pytest.raises(ValueError, match="Only one complexity router"):
             router.init_complexity_router_deployment(deployment("second"))
 
+    def test_auto_router_license_allows_multiple_heuristic_v2_routers(self):
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "gpt-4o-mini",
+                    "litellm_params": {"model": "openai/gpt-4o-mini"},
+                }
+            ],
+            allow_multiple_heuristic_v2=True,
+        )
+
+        for name in ("first", "second"):
+            router.init_complexity_router_deployment(
+                Deployment(
+                    model_name=name,
+                    litellm_params=LiteLLM_Params(
+                        model=f"auto_router/complexity_router/{name}",
+                        complexity_router_default_model="gpt-4o-mini",
+                        complexity_router_config={
+                            "classifier_type": "heuristic_v2",
+                            "tiers": {"SIMPLE": "gpt-4o-mini"},
+                        },
+                    ),
+                    model_info={"id": name},
+                )
+            )
+
+        assert set(router.complexity_routers) == {"first", "second"}
+
     def test_heuristic_v1_complexity_routers_remain_unlimited(self):
         router = Router(
             model_list=[

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/models/useModels.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/models/useModels.test.ts
@@ -4,6 +4,7 @@ import React, { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   isAutoRouterDeployment,
+  heuristicV2Selection,
   selectAutoRouterModelGroups,
   selectPlainModelGroups,
   useAllProxyModels,
@@ -19,6 +20,42 @@ import {
   type PaginatedModelInfoResponse,
   type ProxyModel,
 } from "./useModels";
+
+describe("heuristicV2Selection", () => {
+  it("blocks a second router without the auto_router license feature", () => {
+    const params = {
+      isProxyAdmin: true,
+      stateLoading: false,
+      hasUnlimitedLicense: false,
+      slotTaken: true,
+    };
+    expect(heuristicV2Selection(params)).toEqual({
+      allowed: false,
+      lockedReason: "Heuristic v2 is limited to one auto-router. Reach out to tin@berri.ai to learn more.",
+    });
+  });
+
+  it("allows unlimited routers with the auto_router license feature", () => {
+    const params = {
+      isProxyAdmin: true,
+      stateLoading: false,
+      hasUnlimitedLicense: true,
+      slotTaken: true,
+    };
+    expect(heuristicV2Selection(params).allowed).toBe(true);
+  });
+
+  it("lets the current singleton owner keep heuristic v2 while editing", () => {
+    const params = {
+      isProxyAdmin: true,
+      stateLoading: false,
+      hasUnlimitedLicense: false,
+      slotTaken: true,
+      currentOwnsSlot: true,
+    };
+    expect(heuristicV2Selection(params).allowed).toBe(true);
+  });
+});
 
 vi.mock("@/components/networking", () => ({
   modelInfoCall: vi.fn(),

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/models/useModels.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/models/useModels.test.ts
@@ -50,10 +50,21 @@ describe("heuristicV2Selection", () => {
       isProxyAdmin: true,
       stateLoading: false,
       hasUnlimitedLicense: false,
-      slotTaken: true,
+      slotTaken: false,
       currentOwnsSlot: true,
     };
     expect(heuristicV2Selection(params).allowed).toBe(true);
+  });
+
+  it("blocks a former licensed owner when another router now owns the singleton", () => {
+    const params = {
+      isProxyAdmin: true,
+      stateLoading: false,
+      hasUnlimitedLicense: false,
+      slotTaken: true,
+      currentOwnsSlot: true,
+    };
+    expect(heuristicV2Selection(params).allowed).toBe(false);
   });
 });
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/models/useModels.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/models/useModels.ts
@@ -126,6 +126,45 @@ export const selectAutoRouterModelGroups = (deployments: AutoRouterCandidateDepl
 export const selectAutoRouterDeployments = (deployments: AutoRouterDeployment[]): AutoRouterDeployment[] =>
   deployments.filter(isAutoRouterDeployment);
 
+export const usesHeuristicV2Deployment = (deployment: AutoRouterDeployment): boolean => {
+  const config = deployment.litellm_params?.complexity_router_config;
+  return typeof config === "object" && config !== null && "classifier_type" in config
+    ? config.classifier_type === "heuristic_v2"
+    : false;
+};
+
+interface HeuristicV2SelectionParams {
+  isProxyAdmin: boolean;
+  stateLoading: boolean;
+  hasUnlimitedLicense: boolean;
+  slotTaken: boolean;
+  currentOwnsSlot?: boolean;
+}
+
+export interface HeuristicV2Selection {
+  allowed: boolean;
+  lockedReason?: string;
+}
+
+export const heuristicV2Selection = ({
+  isProxyAdmin,
+  stateLoading,
+  hasUnlimitedLicense,
+  slotTaken,
+  currentOwnsSlot = false,
+}: HeuristicV2SelectionParams): HeuristicV2Selection => {
+  if (!isProxyAdmin) return { allowed: false, lockedReason: "Only proxy admins can configure Heuristic v2." };
+  if (currentOwnsSlot) return { allowed: true };
+  if (stateLoading) return { allowed: false, lockedReason: "Checking Heuristic v2 availability..." };
+  if (slotTaken && !hasUnlimitedLicense) {
+    return {
+      allowed: false,
+      lockedReason: "Heuristic v2 is limited to one auto-router. Reach out to tin@berri.ai to learn more.",
+    };
+  }
+  return { allowed: true };
+};
+
 export const selectPlainModelGroups = (deployments: AutoRouterCandidateDeployment[]): ReadonlySet<string> => {
   const autoRouterGroups = selectAutoRouterModelGroups(deployments);
   return new Set(

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/models/useModels.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/models/useModels.ts
@@ -154,7 +154,7 @@ export const heuristicV2Selection = ({
   currentOwnsSlot = false,
 }: HeuristicV2SelectionParams): HeuristicV2Selection => {
   if (!isProxyAdmin) return { allowed: false, lockedReason: "Only proxy admins can configure Heuristic v2." };
-  if (currentOwnsSlot) return { allowed: true };
+  if (currentOwnsSlot && !slotTaken) return { allowed: true };
   if (stateLoading) return { allowed: false, lockedReason: "Checking Heuristic v2 availability..." };
   if (slotTaken && !hasUnlimitedLicense) {
     return {

--- a/ui/litellm-dashboard/src/components/add_model/ClassificationMethodConfig.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/ClassificationMethodConfig.tsx
@@ -159,15 +159,21 @@ interface ClassificationMethodConfigProps {
   showValidationErrors?: boolean;
   /** The resolved default model - see resolveComplexityDefaultModel. Names and gates the radio. */
   defaultModel?: string;
+  /** Mirrors the backend's proxy-admin-only heuristic_v2 write gate. */
+  allowHeuristicV2?: boolean;
 }
 
 const ClassifierTypeRadios: React.FC<{
   value: ComplexityRouterConfigValue;
   classifierType: ClassifierType;
   onTypeChange: (classifierType: ClassifierType) => void;
-}> = ({ value, classifierType, onTypeChange }) => {
+  allowHeuristicV2: boolean;
+}> = ({ value, classifierType, onTypeChange, allowHeuristicV2 }) => {
   const scorerLocked = Boolean(value.custom_tier_set);
   const scorerLockedReason = restrictedBy(value, "heuristicClassifier")?.reason;
+  const heuristicV2Locked = scorerLocked || !allowHeuristicV2;
+  const heuristicV2LockedReason =
+    scorerLockedReason ?? (!allowHeuristicV2 ? "Only proxy admins can configure Heuristic v2." : undefined);
   return (
     <RadioGroup
       value={classifierType}
@@ -186,9 +192,9 @@ const ClassifierTypeRadios: React.FC<{
             </span>
           </Label>
         </SimpleTooltip>
-        <SimpleTooltip content={scorerLockedReason}>
+        <SimpleTooltip content={heuristicV2LockedReason}>
           <Label className="items-start font-normal leading-normal has-data-disabled:cursor-not-allowed has-data-disabled:opacity-50">
-            <RadioGroupItem value="heuristic_v2" className="mt-0.5" disabled={scorerLocked} />
+            <RadioGroupItem value="heuristic_v2" className="mt-0.5" disabled={heuristicV2Locked} />
             <span>
               <strong className="font-semibold">Heuristic v2</strong>{" "}
               <span className="text-muted-foreground">
@@ -240,6 +246,7 @@ const ClassificationMethodConfig: React.FC<ClassificationMethodConfigProps> = ({
   onCustomTechnicalKeywordsChange,
   showValidationErrors = false,
   defaultModel,
+  allowHeuristicV2 = false,
 }) => {
   const [draft, setDraft] = React.useState<{ id: string; raw: string } | null>(null);
   const hasDefaultModel = Boolean(defaultModel);
@@ -387,7 +394,12 @@ const ClassificationMethodConfig: React.FC<ClassificationMethodConfigProps> = ({
 
   return (
     <>
-      <ClassifierTypeRadios value={value} classifierType={classifierType} onTypeChange={handleClassifierTypeChange} />
+      <ClassifierTypeRadios
+        value={value}
+        classifierType={classifierType}
+        onTypeChange={handleClassifierTypeChange}
+        allowHeuristicV2={allowHeuristicV2}
+      />
 
       {classifierType === "heuristic_first" && (
         <div className="mt-4 space-y-2">

--- a/ui/litellm-dashboard/src/components/add_model/ClassificationMethodConfig.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/ClassificationMethodConfig.tsx
@@ -161,6 +161,7 @@ interface ClassificationMethodConfigProps {
   defaultModel?: string;
   /** Mirrors the backend's proxy-admin-only heuristic_v2 write gate. */
   allowHeuristicV2?: boolean;
+  heuristicV2LockedReason?: string;
 }
 
 const ClassifierTypeRadios: React.FC<{
@@ -168,12 +169,14 @@ const ClassifierTypeRadios: React.FC<{
   classifierType: ClassifierType;
   onTypeChange: (classifierType: ClassifierType) => void;
   allowHeuristicV2: boolean;
-}> = ({ value, classifierType, onTypeChange, allowHeuristicV2 }) => {
+  heuristicV2LockedReason?: string;
+}> = ({ value, classifierType, onTypeChange, allowHeuristicV2, heuristicV2LockedReason }) => {
   const scorerLocked = Boolean(value.custom_tier_set);
   const scorerLockedReason = restrictedBy(value, "heuristicClassifier")?.reason;
   const heuristicV2Locked = scorerLocked || !allowHeuristicV2;
-  const heuristicV2LockedReason =
-    scorerLockedReason ?? (!allowHeuristicV2 ? "Only proxy admins can configure Heuristic v2." : undefined);
+  const lockedReason =
+    scorerLockedReason ??
+    (!allowHeuristicV2 ? heuristicV2LockedReason ?? "Only proxy admins can configure Heuristic v2." : undefined);
   return (
     <RadioGroup
       value={classifierType}
@@ -192,7 +195,7 @@ const ClassifierTypeRadios: React.FC<{
             </span>
           </Label>
         </SimpleTooltip>
-        <SimpleTooltip content={heuristicV2LockedReason}>
+        <SimpleTooltip content={lockedReason}>
           <Label className="items-start font-normal leading-normal has-data-disabled:cursor-not-allowed has-data-disabled:opacity-50">
             <RadioGroupItem value="heuristic_v2" className="mt-0.5" disabled={heuristicV2Locked} />
             <span>
@@ -247,6 +250,7 @@ const ClassificationMethodConfig: React.FC<ClassificationMethodConfigProps> = ({
   showValidationErrors = false,
   defaultModel,
   allowHeuristicV2 = false,
+  heuristicV2LockedReason,
 }) => {
   const [draft, setDraft] = React.useState<{ id: string; raw: string } | null>(null);
   const hasDefaultModel = Boolean(defaultModel);
@@ -399,6 +403,7 @@ const ClassificationMethodConfig: React.FC<ClassificationMethodConfigProps> = ({
         classifierType={classifierType}
         onTypeChange={handleClassifierTypeChange}
         allowHeuristicV2={allowHeuristicV2}
+        heuristicV2LockedReason={heuristicV2LockedReason}
       />
 
       {classifierType === "heuristic_first" && (

--- a/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.test.tsx
@@ -130,7 +130,12 @@ describe("ComplexityRouterConfig", () => {
   it("selects heuristic v2 without requiring a classifier model or showing weighted scoring", () => {
     const onChange = vi.fn();
     const { rerender } = renderWithProviders(
-      <ComplexityRouterConfig modelInfo={mockModelInfo} value={defaultValue} onChange={onChange} />,
+      <ComplexityRouterConfig
+        modelInfo={mockModelInfo}
+        value={defaultValue}
+        onChange={onChange}
+        allowHeuristicV2={true}
+      />,
     );
 
     fireEvent.click(screen.getByText("Advanced: Classification Method"));
@@ -144,12 +149,34 @@ describe("ComplexityRouterConfig", () => {
     );
 
     const heuristicV2Value: ComplexityRouterConfigValue = { ...defaultValue, classifier_type: "heuristic_v2" };
-    rerender(<ComplexityRouterConfig modelInfo={mockModelInfo} value={heuristicV2Value} onChange={onChange} />);
+    rerender(
+      <ComplexityRouterConfig
+        modelInfo={mockModelInfo}
+        value={heuristicV2Value}
+        onChange={onChange}
+        allowHeuristicV2={true}
+      />,
+    );
 
     expect(screen.queryByText("Classifier Model")).not.toBeInTheDocument();
     expect(screen.queryByText("Advanced scoring")).not.toBeInTheDocument();
     expect(screen.getByText(/estimates success probability for all four tiers/)).toBeInTheDocument();
     expect(screen.queryByText(/Score < 0.15/)).not.toBeInTheDocument();
+  });
+
+  it("reserves heuristic v2 selection for proxy admins", () => {
+    const onChange = vi.fn();
+    renderWithProviders(<ComplexityRouterConfig {...baseProps} onChange={onChange} allowHeuristicV2={false} />);
+
+    fireEvent.click(screen.getByText("Advanced: Classification Method"));
+
+    const heuristicV2 = screen.getByRole("radio", { name: /Heuristic v2/ });
+    expect(heuristicV2).toHaveAttribute("aria-disabled", "true");
+    expect(screen.getByRole("radio", { name: /^Heuristic \(/ })).not.toHaveAttribute("aria-disabled", "true");
+    expect(screen.getByRole("radio", { name: /LLM Classifier/ })).not.toHaveAttribute("aria-disabled", "true");
+
+    fireEvent.click(heuristicV2);
+    expect(onChange).not.toHaveBeenCalled();
   });
 
   it("should show classifier fields and use the configured values when classifier_type is llm", () => {

--- a/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.tsx
@@ -142,10 +142,7 @@ export type ClassifierFallback = "heuristic" | "default_model";
 
 export const DEFAULT_CLASSIFIER_FALLBACK: ClassifierFallback = "heuristic";
 
-export interface AdaptiveRouterWeights {
-  quality: number;
-  cost: number;
-}
+export type AdaptiveRouterWeights = { quality: number; cost: number };
 
 export const DEFAULT_ADAPTIVE_WEIGHTS: AdaptiveRouterWeights = { quality: 0.3, cost: 0.7 };
 

--- a/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.tsx
@@ -485,6 +485,7 @@ interface ComplexityRouterConfigProps {
   onEscalationKeywordsChange?: (keywords: string[]) => void;
   showValidationErrors?: boolean;
   allowHeuristicV2?: boolean;
+  heuristicV2LockedReason?: string;
 }
 
 export const TIER_DESCRIPTIONS: Record<
@@ -607,6 +608,7 @@ const ComplexityRouterConfig: React.FC<ComplexityRouterConfigProps> = ({
   onEscalationKeywordsChange,
   showValidationErrors = false,
   allowHeuristicV2 = false,
+  heuristicV2LockedReason,
 }) => {
   const customTierSet = value.custom_tier_set;
   const tierRows = activeTierRows(value);
@@ -824,6 +826,7 @@ const ComplexityRouterConfig: React.FC<ComplexityRouterConfigProps> = ({
                 showValidationErrors={showValidationErrors}
                 defaultModel={defaultModel}
                 allowHeuristicV2={allowHeuristicV2}
+                heuristicV2LockedReason={heuristicV2LockedReason}
               />
             ),
           },

--- a/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.tsx
@@ -484,6 +484,7 @@ interface ComplexityRouterConfigProps {
   escalationKeywords?: string[];
   onEscalationKeywordsChange?: (keywords: string[]) => void;
   showValidationErrors?: boolean;
+  allowHeuristicV2?: boolean;
 }
 
 export const TIER_DESCRIPTIONS: Record<
@@ -605,6 +606,7 @@ const ComplexityRouterConfig: React.FC<ComplexityRouterConfigProps> = ({
   escalationKeywords = [],
   onEscalationKeywordsChange,
   showValidationErrors = false,
+  allowHeuristicV2 = false,
 }) => {
   const customTierSet = value.custom_tier_set;
   const tierRows = activeTierRows(value);
@@ -821,6 +823,7 @@ const ComplexityRouterConfig: React.FC<ComplexityRouterConfigProps> = ({
                 onCustomTechnicalKeywordsChange={onCustomTechnicalKeywordsChange}
                 showValidationErrors={showValidationErrors}
                 defaultModel={defaultModel}
+                allowHeuristicV2={allowHeuristicV2}
               />
             ),
           },

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
@@ -73,9 +73,10 @@ const addKeyword = async (user: ReturnType<typeof userEvent.setup>, field: HTMLE
   await user.click(await screen.findByText(`Create "${keyword}"`));
 };
 
-const { mockFetchAvailableModels, mockFetchAllModelDeployments } = vi.hoisted(() => ({
+const { mockFetchAvailableModels, mockFetchAllModelDeployments, mockUseLicenseInfo } = vi.hoisted(() => ({
   mockFetchAvailableModels: vi.fn(),
   mockFetchAllModelDeployments: vi.fn(),
+  mockUseLicenseInfo: vi.fn(),
 }));
 
 const { validateAutoRouterConfig } = vi.hoisted(() => ({
@@ -96,6 +97,10 @@ vi.mock("@/app/(dashboard)/hooks/models/useModels", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/app/(dashboard)/hooks/models/useModels")>();
   return { ...actual, fetchAllModelDeployments: mockFetchAllModelDeployments };
 });
+
+vi.mock("@/app/(dashboard)/hooks/license/useLicenseInfo", () => ({
+  useLicenseInfo: mockUseLicenseInfo,
+}));
 
 vi.mock("./handle_add_auto_router_submit", () => ({
   handleAddAutoRouterSubmit: vi.fn(),
@@ -141,6 +146,7 @@ describe("AddAutoRouterTab", () => {
     testQueryClient.clear();
     mockFetchAvailableModels.mockResolvedValue([]);
     mockFetchAllModelDeployments.mockResolvedValue([]);
+    mockUseLicenseInfo.mockReturnValue({ data: { allowed_features: [] }, isLoading: false });
   });
 
   // Detailed Configuration starts collapsed so the modal opens onto just Name + Template; a caller
@@ -178,6 +184,50 @@ describe("AddAutoRouterTab", () => {
     renderWithProviders(<Harness />);
 
     expect(screen.queryByTestId("team-dropdown")).not.toBeInTheDocument();
+  });
+
+  it("disables heuristic v2 when another auto-router owns the singleton slot", async () => {
+    mockFetchAllModelDeployments.mockResolvedValue([
+      {
+        model_name: "existing-router",
+        litellm_params: {
+          model: "auto_router/complexity_router",
+          complexity_router_config: { classifier_type: "heuristic_v2" },
+        },
+      },
+    ]);
+    renderWithProviders(<Harness />);
+
+    expandDetailedConfiguration();
+    fireEvent.click(screen.getByText("Advanced: Classification Method"));
+
+    await waitFor(() =>
+      expect(screen.getByRole("radio", { name: /Heuristic v2/ })).toHaveAttribute("aria-disabled", "true"),
+    );
+  });
+
+  it("keeps heuristic v2 available when the enterprise license includes auto_router", async () => {
+    mockFetchAllModelDeployments.mockResolvedValue([
+      {
+        model_name: "existing-router",
+        litellm_params: {
+          model: "auto_router/complexity_router",
+          complexity_router_config: { classifier_type: "heuristic_v2" },
+        },
+      },
+    ]);
+    mockUseLicenseInfo.mockReturnValue({
+      data: { allowed_features: ["auto_router"] },
+      isLoading: false,
+    });
+    renderWithProviders(<Harness />);
+
+    expandDetailedConfiguration();
+    fireEvent.click(screen.getByText("Advanced: Classification Method"));
+
+    await waitFor(() =>
+      expect(screen.getByRole("radio", { name: /Heuristic v2/ })).not.toHaveAttribute("aria-disabled", "true"),
+    );
   });
 
   it("requires a team admin to pick a team", async () => {

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
@@ -615,6 +615,7 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
                       escalationKeywords={escalationKeywords}
                       onEscalationKeywordsChange={setEscalationKeywords}
                       showValidationErrors={showValidationErrors}
+                      allowHeuristicV2={createScope === "unscoped-ok"}
                     />
                   </div>
                 )}

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
@@ -20,7 +20,12 @@ import { type ModelWriteScope } from "@/utils/modelPermissions";
 import TeamDropdown from "../common_components/team_dropdown";
 import { type AddAutoRouterValues, handleAddAutoRouterSubmit } from "./handle_add_auto_router_submit";
 import { fetchAvailableModels } from "@/components/llm_calls/fetch_models";
-import { autoRouterListKey, fetchAllModelDeployments } from "@/app/(dashboard)/hooks/models/useModels";
+import {
+  autoRouterListKey,
+  fetchAllModelDeployments,
+  heuristicV2Selection,
+  usesHeuristicV2Deployment,
+} from "@/app/(dashboard)/hooks/models/useModels";
 import ComplexityRouterConfig, {
   ComplexityRouterConfigValue,
   effectiveClassifierType,
@@ -62,6 +67,7 @@ import {
 } from "@/lib/autorouter_presets";
 import { useAutoRouterPresets } from "@/app/(dashboard)/hooks/autoRouter/useAutoRouterPresets";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { useLicenseInfo } from "@/app/(dashboard)/hooks/license/useLicenseInfo";
 
 interface AddAutoRouterTabProps {
   handleOk: () => void;
@@ -224,6 +230,17 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
     queryFn: () => fetchAllModelDeployments(accessToken, userId ?? "", userRole),
     enabled: Boolean(accessToken),
   });
+  const licenseInfo = useLicenseInfo(accessToken);
+  const hasUnlimitedAutoRouterLicense = licenseInfo.data?.allowed_features.includes("auto_router") === true;
+  const heuristicV2SlotTaken = deployments?.some(usesHeuristicV2Deployment) === true;
+  const heuristicV2StateLoading = deploymentsLoading || licenseInfo.isLoading;
+  const heuristicV2SelectionParams = {
+    isProxyAdmin: createScope === "unscoped-ok",
+    stateLoading: heuristicV2StateLoading,
+    hasUnlimitedLicense: hasUnlimitedAutoRouterLicense,
+    slotTaken: heuristicV2SlotTaken,
+  };
+  const heuristicV2Access = heuristicV2Selection(heuristicV2SelectionParams);
   const modelsLoading = groupsLoading || deploymentsLoading;
   const modelInfo = React.useMemo(() => data ?? [], [data]);
   const {
@@ -615,7 +632,8 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
                       escalationKeywords={escalationKeywords}
                       onEscalationKeywordsChange={setEscalationKeywords}
                       showValidationErrors={showValidationErrors}
-                      allowHeuristicV2={createScope === "unscoped-ok"}
+                      allowHeuristicV2={heuristicV2Access.allowed}
+                      heuristicV2LockedReason={heuristicV2Access.lockedReason}
                     />
                   </div>
                 )}

--- a/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.tsx
+++ b/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { z } from "zod/v4";
 import { toast } from "@/lib/toast";
 import { CircleHelp } from "lucide-react";
@@ -9,10 +10,18 @@ import { Input } from "@/components/ui/input";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { UiLoadingSpinner } from "@/components/ui/ui-loading-spinner";
 import { useZodForm } from "@/lib/forms/useZodForm";
+import { isProxyAdminRole } from "@/utils/roles";
 import AccessGroupTagsCombobox from "../add_model/AccessGroupTagsCombobox";
 import ModelChoiceCombobox, { type ModelChoice } from "../add_model/ModelChoiceCombobox";
 import { modelAvailableCall, modelPatchUpdateCall, validateAutoRouterConfig } from "../networking";
 import { fetchAvailableModels, ModelGroup } from "@/components/llm_calls/fetch_models";
+import { useLicenseInfo } from "@/app/(dashboard)/hooks/license/useLicenseInfo";
+import {
+  autoRouterListKey,
+  fetchAllModelDeployments,
+  heuristicV2Selection,
+  usesHeuristicV2Deployment,
+} from "@/app/(dashboard)/hooks/models/useModels";
 import RouterConfigBuilder from "../add_model/RouterConfigBuilder";
 import { hydrateTierModelParams, normalizeTierModels } from "../add_model/complexity_router_tiers";
 import {
@@ -415,6 +424,28 @@ const EditAutoRouterModal: React.FC<EditAutoRouterModalProps> = ({
     classifier_type: "heuristic",
   });
   const isComplexityRouterModel = isComplexityRouter(modelData?.litellm_params);
+  const licenseInfo = useLicenseInfo(accessToken);
+  const { data: deployments, isLoading: deploymentsLoading } = useQuery({
+    queryKey: autoRouterListKey(modelData?.model_info?.id ?? "", userRole),
+    queryFn: () => fetchAllModelDeployments(accessToken, "", userRole),
+    enabled: isVisible && Boolean(accessToken),
+  });
+  const currentModelId = modelData?.model_info?.id;
+  const currentOwnsHeuristicV2 = usesHeuristicV2Deployment(modelData ?? {});
+  const anotherRouterOwnsHeuristicV2 =
+    deployments?.some(
+      (deployment) => deployment.model_info?.id !== currentModelId && usesHeuristicV2Deployment(deployment),
+    ) === true;
+  const hasUnlimitedAutoRouterLicense = licenseInfo.data?.allowed_features.includes("auto_router") === true;
+  const heuristicV2StateLoading = deploymentsLoading || licenseInfo.isLoading;
+  const heuristicV2SelectionParams = {
+    isProxyAdmin: isProxyAdminRole(userRole),
+    stateLoading: heuristicV2StateLoading,
+    hasUnlimitedLicense: hasUnlimitedAutoRouterLicense,
+    slotTaken: anotherRouterOwnsHeuristicV2,
+    currentOwnsSlot: currentOwnsHeuristicV2,
+  };
+  const heuristicV2Access = heuristicV2Selection(heuristicV2SelectionParams);
 
   const schema = useMemo(
     () => (isComplexityRouterModel ? complexityRouterSchema : semanticRouterSchema),
@@ -729,6 +760,8 @@ const EditAutoRouterModal: React.FC<EditAutoRouterModalProps> = ({
                     onMatchThresholdChange={setMatchThreshold}
                     escalationKeywords={escalationKeywords}
                     onEscalationKeywordsChange={setEscalationKeywords}
+                    allowHeuristicV2={heuristicV2Access.allowed}
+                    heuristicV2LockedReason={heuristicV2Access.lockedReason}
                   />
                 </div>
               ) : (


### PR DESCRIPTION
## TLDR

Problem this solves:

- Multiple heuristic v2 routers bypass the intended proxy limit
- UI does not explain when the classifier is unavailable

How it solves it:

- Enforces one proxy-wide heuristic v2 router atomically
- Counts config.yaml and database-backed routers together
- Restricts heuristic v2 configuration to proxy admins
- Allows unlimited routers with the auto_router license feature
- Disables unavailable UI options with contact guidance

## User Flow

Before: an operator can configure multiple heuristic v2 routers without a consistent proxy-wide entitlement check

1. A proxy admin opens /ui/?page=models and creates an auto-router using Heuristic v2
2. Another operator creates or edits another auto-router and selects Heuristic v2
3. The proxy can accept conflicting definitions from the UI, API, or config.yaml

After: the proxy consistently reserves the classifier and explains its availability

1. A proxy admin opens /ui/?page=models and creates an auto-router using Heuristic v2
2. Another operator creates or edits another auto-router and sees Heuristic v2 disabled
3. The UI states: Heuristic v2 is limited to one auto-router. Reach out to tin@berri.ai to learn more.
4. POST /model/new and PATCH /model/{model_id} enforce the same proxy-wide rule
5. A signed license containing {"allowed_features":["auto_router"]} permits multiple Heuristic v2 routers

## Relevant issues

- Follow-up to #39276

## Linear ticket


## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The focused backend and dashboard tests pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR scope solves one specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5

## Screenshots / Proof of Fix

Automated coverage verifies proxy-admin access, config.yaml occupancy, atomic database enforcement, licensed unlimited routing, and disabled UI states.

## Type

New Feature

## Caveats

### Low

- External license issuers must add auto_router to signed allowed_features
- Legacy boolean license responses retain the one-router default
- Packaged dashboard output is intentionally excluded from this PR

## Final Attestation

- [x] Tests cover authorization, singleton ownership, configuration sources, races, and license entitlement

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches model persistence, startup reconciliation, and routing registration with license-gated behavior; misconfiguration could block extra v2 routers or briefly affect which DB deployments load as blocked.
> 
> **Overview**
> Enforces a **proxy-wide singleton** for complexity routers using `classifier_type='heuristic_v2'`, with an enterprise **`auto_router` license** feature to allow multiple deployments.
> 
> **Backend:** New proxy model columns (`heuristic_v2_unlimited`, `heuristic_v2_license_blocked`) plus a partial unique index backstop races. Model create/update/patch paths validate the slot (including **config.yaml** routers), restrict **heuristic v2** to **proxy admins**, stamp license markers on writes, and map index violations to clear API errors. On startup, SQL reconciliation ranks existing v2 routers and marks extras as license-blocked (surfaced as `blocked` in model info) before DB routers load. `LicenseCheck.allows_feature()` gates entitlement; `Router` gets `allow_multiple_heuristic_v2` from the signed license.
> 
> **UI:** Add/edit auto-router flows disable Heuristic v2 when the slot is taken or the user is not a proxy admin, with messaging aligned to the API; licensed installs keep the option enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f8f8c3f39eace0a690bb00d5970d312e7910e38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->