### PR TITLE
feat(complexity_router): opt-in modality override of a kept session-affinity pin

### DIFF
--- a/litellm/proxy/public_endpoints/autorouter_presets.json
+++ b/litellm/proxy/public_endpoints/autorouter_presets.json
@@ -17,6 +17,7 @@
       "classification_mode": "every_request",
       "session_affinity": false,
       "modality_routing": false,
+      "modality_pin_override": false,
       "deployment_affinity": true
     }
   },
@@ -35,6 +36,7 @@
       "classification_mode": "every_request",
       "session_affinity": false,
       "modality_routing": false,
+      "modality_pin_override": false,
       "deployment_affinity": true
     }
   },
@@ -63,6 +65,7 @@
       "classification_mode": "every_request",
       "session_affinity": false,
       "modality_routing": false,
+      "modality_pin_override": false,
       "deployment_affinity": true
     }
   },
@@ -84,6 +87,7 @@
       "classification_mode": "every_request",
       "session_affinity": false,
       "modality_routing": false,
+      "modality_pin_override": false,
       "deployment_affinity": true
     }
   }

--- a/litellm/router_strategy/complexity_router/README.md
+++ b/litellm/router_strategy/complexity_router/README.md
@@ -187,6 +187,9 @@ model_list:
 
         # Replace a routed model that cannot take image input (default: false)
         modality_routing: true
+
+        # Let that replacement also override a kept session pin, for image turns only (default: false)
+        modality_pin_override: true
 ```
 
 ## Usage
@@ -227,8 +230,15 @@ vision model sits below the decided tier gets the 400 and an actionable message 
 A same-tier re-pick keeps the decision's cause and adds `modality:image` to `signals`; a tier
 change or default takeover records `cause: modality_escalation` with the displaced placement
 (`modality_escalated_from:<TIER>` or `modality_displaced_default_model`). Escalations are never
-pinned by session affinity, and a KEPT session pin bypasses the gate entirely: a session pinned
+pinned by session affinity, and by default a KEPT session pin bypasses the gate: a session pinned
 to a text-only model keeps it even when an image arrives.
+
+Add `modality_pin_override: true` to lift that last exemption. The image turn is then re-placed
+the same way every other decision is, and records `cause: modality_pin_override` whether or not
+the tier moved, since the model left the pin either way. The pin itself is untouched: the session
+affinity write happens upstream of the gate and stores the session's own model, so the next text
+turn replays the original pin and the override is never pinned in its place. It does nothing
+unless `modality_routing` is also on.
 
 ### Heuristic-first chaining
 

--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -747,7 +747,8 @@ def _decision_is_pinnable(decision: StandardLoggingRoutingDecision | None) -> bo
 
     A modality escalation is transient the same way: it describes what this one call carries (an
     image), not what the session's traffic looks like, and pinning it would hold every following
-    text turn on the vision-capable model the image forced.
+    text turn on the vision-capable model the image forced. A modality pin override is the same
+    fact on a session that already holds a pin, so it must not overwrite the pin it displaced.
     """
     return decision is None or (
         decision.get("cause")
@@ -756,6 +757,7 @@ def _decision_is_pinnable(decision: StandardLoggingRoutingDecision | None) -> bo
             "plan_mode",
             "housekeeping",
             "modality_escalation",
+            "modality_pin_override",
         )
         and not decision.get("context_escalated")
     )
@@ -2389,8 +2391,11 @@ class ComplexityRouter(CustomLogger):
         """Replace a routed model that cannot accept this request's image input.
 
         The single modality owner, applied to the decided response at the hook's exits so every
-        routing path is covered uniformly. A KEPT session pin is exempt by design (its cause);
-        replacement picks and every other path are just responses. The re-placement walks
+        routing path is covered uniformly. A KEPT session pin is exempt by design (its cause)
+        unless modality_pin_override is set, in which case the image turn is re-placed and reported
+        as modality_pin_override while the stored pin, written upstream from the session's own
+        model, is left for the next text turn; replacement picks and every other path are just
+        responses. The re-placement walks
         UPWARD-ONLY from the decision's tier (so a plan-mode floor can never be undercut), picks
         through `_pick_model_for_tier` so routing plugins still apply, then falls to
         default_model (never on plugin routers, and never on a plan-floored decision, since
@@ -2403,7 +2408,11 @@ class ComplexityRouter(CustomLogger):
             not self.config.modality_routing
             or not resolved_messages
             or response.model is None
-            or (decision is not None and decision.get("cause") == "session_affinity_pin")
+            or (
+                decision is not None
+                and decision.get("cause") == "session_affinity_pin"
+                and not self.config.modality_pin_override
+            )
             or not request_contains_image_content(resolved_messages)
             or self._model_accepts_image_input(response.model)
         ):
@@ -2445,6 +2454,10 @@ class ComplexityRouter(CustomLogger):
         self._restamp_adaptive_choice(request_kwargs, response.model, new_model)
         same_tier: Final = capable is not None and decided == capable
         base_cause: Final = (decision.get("cause") if decision is not None else None) or "default_fallback"
+        # Reaching here on a kept pin means modality_pin_override is on, since the guard above
+        # returns otherwise. The model moved off the pin even on a same-tier repick, so reporting
+        # the pin's own cause would claim the session's model served a request it did not.
+        displaced_pin: Final = base_cause == "session_affinity_pin"
         displaced_default: Final = decided is None and response.model == self.config.default_model
         markers: Final = (
             "modality:image",
@@ -2454,7 +2467,7 @@ class ComplexityRouter(CustomLogger):
         old_signals: Final = tuple(decision.get("signals") or ()) if decision is not None else ()
         new_decision: Final = self._build_routing_decision(
             routed_model=new_model,
-            cause=base_cause if same_tier else "modality_escalation",
+            cause="modality_pin_override" if displaced_pin else (base_cause if same_tier else "modality_escalation"),
             tier=new_tier,
             score=decision.get("score") if decision is not None else None,
             signals=(*old_signals, *markers),

--- a/litellm/router_strategy/complexity_router/config.py
+++ b/litellm/router_strategy/complexity_router/config.py
@@ -883,7 +883,20 @@ class ComplexityRouterConfig(BaseModel):
             "a routed model explicitly declared supports_vision false (deployment model_info "
             "or the model cost map; unmapped names stay routable) is replaced by the nearest "
             "HIGHER tier holding a capable model, then default_model, else a clear 400. A kept "
-            "session-affinity pin still wins even when an image arrives."
+            "session-affinity pin still wins even when an image arrives, unless "
+            "modality_pin_override is also enabled."
+        ),
+    )
+    modality_pin_override: bool = Field(
+        default=False,
+        description=(
+            "Let modality_routing replace a kept session-affinity pin on the turns that carry an "
+            "image. Without this, a session pinned to a text-only model fails every image turn with "
+            "a provider 400, since the pin is exempt from the modality gate. When enabled, such a "
+            "turn routes to a capable model for that request only and the stored pin is left "
+            "untouched, so the next text turn replays the session's own model; the override is "
+            "reported as cause modality_pin_override and is never itself pinned. Inert unless "
+            "modality_routing is also enabled."
         ),
     )
 

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2879,6 +2879,10 @@ RoutingDecisionCause = Literal[
     # routed model does not accept image input, so the nearest higher capable tier or
     # default_model served instead. The displaced placement rides in signals.
     "modality_escalation",
+    # modality_pin_override replaced a KEPT session-affinity pin for this request only: the turn
+    # carries an image the pinned model cannot accept. The stored pin is untouched, so the next
+    # text turn replays it. Distinct from "modality_escalation", which never displaces a pin.
+    "modality_pin_override",
     "session_affinity_pin",
     "session_affinity_escalation",
     # classification_mode 'user_turn': the request is an agent loop's continuation turn (no new

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -10777,6 +10777,9 @@ class TestModalityRouting:
             ("custom_tiers_walk", "premium-model", "modality_escalation"),
             ("pin_kept_bypasses", "text-cheap", "session_affinity_pin"),
             ("pin_replacement_gated", "vision-big", "modality_escalation"),
+            ("pin_override_escalates", "vision-mid", "modality_pin_override"),
+            ("pin_override_same_tier", "vision-cheap", "modality_pin_override"),
+            ("pin_override_inert_without_modality_routing", "text-cheap", "session_affinity_pin"),
             ("adaptive_pick_rewritten", "vision-mid", "modality_escalation"),
         ],
     )
@@ -10827,7 +10830,7 @@ class TestModalityRouting:
             messages = [
                 {"role": "user", "content": [{"type": "text", "text": "quick lookup: what is this?"}, IMG_PART]}
             ]
-        elif path in ("pin_kept_bypasses", "pin_replacement_gated"):
+        elif path.startswith(("pin_kept", "pin_replacement", "pin_override")):
             cache = AsyncMock()
             cache.async_get_cache = AsyncMock(return_value={"model": "text-cheap", "tier": "SIMPLE"})
             mock_router_instance.cache = cache
@@ -10839,6 +10842,13 @@ class TestModalityRouting:
                 messages = [
                     {"role": "user", "content": [{"type": "text", "text": "LITELLM ESCALATE describe this"}, IMG_PART]}
                 ]
+            elif path == "pin_override_same_tier":
+                config["modality_pin_override"] = True
+                config["tiers"]["SIMPLE"] = ["text-cheap", "vision-cheap"]
+                vision["vision-cheap"] = True
+            elif path == "pin_override_inert_without_modality_routing":
+                config["modality_routing"] = False
+            config["modality_pin_override"] = path.startswith("pin_override")
         elif path == "adaptive_pick_rewritten":
             config["adaptive"] = True
             mock_router_instance.model_list = []
@@ -11005,4 +11015,60 @@ class TestModalityRouting:
         from litellm.router_strategy.complexity_router.complexity_router import _decision_is_pinnable
 
         assert _decision_is_pinnable({"cause": "modality_escalation"}) is False
+        assert _decision_is_pinnable({"cause": "modality_pin_override"}) is False
         assert _decision_is_pinnable({"cause": "heuristic_scorer"}) is True
+
+    @pytest.mark.asyncio
+    async def test_pin_override_serves_the_image_turn_without_repinning(self, mock_router_instance):
+        """The override is for one request: the session keeps the model it was pinned to."""
+        cache = AsyncMock()
+        cache.async_get_cache = AsyncMock(return_value={"model": "text-cheap", "tier": "SIMPLE"})
+        mock_router_instance.cache = cache
+        router = self._router(
+            mock_router_instance,
+            {
+                "tiers": dict(self.BASE_TIERS),
+                "modality_routing": True,
+                "modality_pin_override": True,
+                "session_affinity": True,
+            },
+            dict(self.BASE_VISION),
+        )
+        request_kwargs = {"metadata": {"session_id": "s1"}}
+
+        image_turn = await router.async_pre_routing_hook(
+            model="m", request_kwargs=request_kwargs, messages=self.IMAGE_MESSAGE
+        )
+        assert image_turn.model == "vision-mid"
+        assert image_turn.routing_decision["cause"] == "modality_pin_override"
+        assert "modality_escalated_from:SIMPLE" in image_turn.routing_decision["signals"]
+
+        assert cache.async_set_cache.await_args.kwargs["value"] == {"model": "text-cheap", "tier": "SIMPLE"}
+
+        text_turn = await router.async_pre_routing_hook(
+            model="m", request_kwargs={"metadata": {"session_id": "s1"}}, messages=[{"role": "user", "content": "hi"}]
+        )
+        assert text_turn.model == "text-cheap"
+        assert text_turn.routing_decision["cause"] == "session_affinity_pin"
+
+    @pytest.mark.asyncio
+    async def test_pin_override_with_no_capable_model_rejects_and_keeps_the_pin(self, mock_router_instance):
+        """The clear 400 replaces the provider's, and a rejected turn must not cost the session its pin."""
+        cache = AsyncMock()
+        cache.async_get_cache = AsyncMock(return_value={"model": "text-cheap", "tier": "SIMPLE"})
+        mock_router_instance.cache = cache
+        router = self._router(
+            mock_router_instance,
+            {
+                "tiers": {"SIMPLE": "text-cheap", "COMPLEX": "text-big"},
+                "modality_routing": True,
+                "modality_pin_override": True,
+                "session_affinity": True,
+            },
+            {"text-cheap": False, "text-big": False},
+        )
+        with pytest.raises(litellm.BadRequestError, match="no model"):
+            await router.async_pre_routing_hook(
+                model="m", request_kwargs={"metadata": {"session_id": "s1"}}, messages=self.IMAGE_MESSAGE
+            )
+        assert cache.async_set_cache.await_args.kwargs["value"] == {"model": "text-cheap", "tier": "SIMPLE"}

--- a/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.test.tsx
@@ -880,6 +880,44 @@ describe("ComplexityRouterConfig modality panel", () => {
 
     expect(screen.getByRole("switch", { name: "Route image requests to vision-capable models" })).toBeChecked();
   });
+
+  // The backend ignores modality_pin_override unless modality_routing is on, so offering it while
+  // image routing is off would let an operator save a flag that does nothing.
+  it("disables the pin-override switch while image routing is off", () => {
+    const onChange = vi.fn();
+    renderWithProviders(<ComplexityRouterConfig {...baseProps} onChange={onChange} />);
+    fireEvent.click(screen.getByText("Advanced: Modality Routing"));
+
+    const override = screen.getByRole("switch", { name: "Override session pin for image requests" });
+    expect(override).toHaveAttribute("aria-disabled", "true");
+    fireEvent.click(override);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("writes modality_pin_override through onChange once image routing is on", () => {
+    const onChange = vi.fn();
+    const value = { ...defaultValue, modality_routing: true };
+    renderWithProviders(<ComplexityRouterConfig {...baseProps} value={value} onChange={onChange} />);
+    fireEvent.click(screen.getByText("Advanced: Modality Routing"));
+
+    const override = screen.getByRole("switch", { name: "Override session pin for image requests" });
+    expect(override).not.toBeChecked();
+    fireEvent.click(override);
+
+    expect(onChange).toHaveBeenCalledWith({ ...value, modality_pin_override: true });
+  });
+
+  it("renders a stored modality_pin_override=true as on", () => {
+    renderWithProviders(
+      <ComplexityRouterConfig
+        {...baseProps}
+        value={{ ...defaultValue, modality_routing: true, modality_pin_override: true }}
+      />,
+    );
+    fireEvent.click(screen.getByText("Advanced: Modality Routing"));
+
+    expect(screen.getByRole("switch", { name: "Override session pin for image requests" })).toBeChecked();
+  });
 });
 
 describe("ComplexityRouterConfig affinity panel", () => {

--- a/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.tsx
@@ -410,6 +410,7 @@ export interface ComplexityRouterConfigValue {
   classification_mode?: ClassificationMode;
   session_affinity?: boolean;
   modality_routing?: boolean;
+  modality_pin_override?: boolean;
   deployment_affinity?: boolean;
   /** Plan-mode floor as a tier ROW ID, unset meaning off. The wire carries the row's name. */
   plan_mode_min_tier?: string;

--- a/ui/litellm-dashboard/src/components/add_model/ModalityRoutingControls.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/ModalityRoutingControls.tsx
@@ -7,20 +7,36 @@ import type { ComplexityRouterConfigValue } from "./ComplexityRouterConfig";
 export const ModalityRoutingControls: React.FC<{
   value: ComplexityRouterConfigValue;
   onChange: (value: ComplexityRouterConfigValue) => void;
-}> = ({ value, onChange }) => (
-  <>
-    <div className="flex items-center gap-2 mb-2">
-      <Switch
-        checked={value.modality_routing ?? false}
-        onCheckedChange={(modalityRouting) => onChange({ ...value, modality_routing: modalityRouting })}
-        aria-label="Route image requests to vision-capable models"
-      />
-      <strong className="font-semibold">Route image requests to vision-capable models</strong>
-    </div>
-    <span className="block text-xs text-muted-foreground">
-      Replaces a routed model that cannot take image input with the nearest higher tier that can, then the default
-      model, instead of failing with a provider 400. Only models explicitly declared supports_vision false are replaced,
-      and a kept session pin still wins.
-    </span>
-  </>
-);
+}> = ({ value, onChange }) => {
+  const modalityRouting = value.modality_routing ?? false;
+  return (
+    <>
+      <div className="flex items-center gap-2 mb-2">
+        <Switch
+          checked={modalityRouting}
+          onCheckedChange={(nextModalityRouting) => onChange({ ...value, modality_routing: nextModalityRouting })}
+          aria-label="Route image requests to vision-capable models"
+        />
+        <strong className="font-semibold">Route image requests to vision-capable models</strong>
+      </div>
+      <span className="block text-xs mb-3 text-muted-foreground">
+        Replaces a routed model that cannot take image input with the nearest higher tier that can, then the default
+        model, instead of failing with a provider 400. Only models explicitly declared supports_vision false are
+        replaced, and a kept session pin still wins unless you turn on the override below.
+      </span>
+      <div className="flex items-center gap-2 mb-2">
+        <Switch
+          checked={value.modality_pin_override ?? false}
+          onCheckedChange={(modalityPinOverride) => onChange({ ...value, modality_pin_override: modalityPinOverride })}
+          disabled={!modalityRouting}
+          aria-label="Override session pin for image requests"
+        />
+        <strong className="font-semibold">Override session pin for image requests</strong>
+      </div>
+      <span className="block text-xs text-muted-foreground">
+        Route an image turn to a capable model even when the session is pinned to one that cannot take images. The pin
+        is kept, so the next text turn goes back to it. Needs image routing turned on.
+      </span>
+    </>
+  );
+};

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
@@ -590,6 +590,44 @@ describe("AddAutoRouterTab", () => {
     });
   });
 
+  it("writes both modality flags as false into the create payload when the panel stays untouched", async () => {
+    const user = userEvent.setup();
+    vi.mocked(getMissingTiersError).mockReturnValue(null);
+
+    renderWithProviders(<Harness />);
+
+    fireEvent.change(screen.getByPlaceholderText(/smart_router/i), { target: { value: "modality-router" } });
+
+    await user.click(screen.getByRole("button", { name: /add auto router/i }));
+
+    await waitFor(() => expect(handleAddAutoRouterSubmit).toHaveBeenCalled());
+    expect(vi.mocked(handleAddAutoRouterSubmit).mock.calls.at(-1)?.[0].complexity_router_config).toMatchObject({
+      modality_routing: false,
+      modality_pin_override: false,
+    });
+  });
+
+  it("carries the pin override through to the create payload once image routing unlocks it", async () => {
+    const user = userEvent.setup();
+    vi.mocked(getMissingTiersError).mockReturnValue(null);
+
+    renderWithProviders(<Harness />);
+
+    fireEvent.change(screen.getByPlaceholderText(/smart_router/i), { target: { value: "modality-router" } });
+    expandDetailedConfiguration();
+    await user.click(screen.getByText("Advanced: Modality Routing"));
+    await user.click(await screen.findByRole("switch", { name: "Route image requests to vision-capable models" }));
+    await user.click(await screen.findByRole("switch", { name: "Override session pin for image requests" }));
+
+    await user.click(screen.getByRole("button", { name: /add auto router/i }));
+
+    await waitFor(() => expect(handleAddAutoRouterSubmit).toHaveBeenCalled());
+    expect(vi.mocked(handleAddAutoRouterSubmit).mock.calls.at(-1)?.[0].complexity_router_config).toMatchObject({
+      modality_routing: true,
+      modality_pin_override: true,
+    });
+  });
+
   // Custom is the escape hatch, not the headline choice, so it's listed after every bundled preset
   // rather than first.
   it("lists Custom Configuration after the bundled presets", () => {

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
@@ -358,6 +358,7 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
     classifierFallback: complexityRouterConfig.classifier_fallback,
     sessionAffinity: complexityRouterConfig.session_affinity ?? DEFAULT_SESSION_AFFINITY,
     modalityRouting: complexityRouterConfig.modality_routing ?? false,
+    modalityPinOverride: complexityRouterConfig.modality_pin_override ?? false,
     deploymentAffinity: complexityRouterConfig.deployment_affinity ?? DEFAULT_DEPLOYMENT_AFFINITY,
     customTechnicalKeywords,
     keywordTierRules,

--- a/ui/litellm-dashboard/src/components/add_model/build_complexity_router_config.test.ts
+++ b/ui/litellm-dashboard/src/components/add_model/build_complexity_router_config.test.ts
@@ -56,6 +56,7 @@ describe("buildComplexityRouterConfig", () => {
       session_affinity: false,
       deployment_affinity: true,
       modality_routing: false,
+      modality_pin_override: false,
       escalation_keywords: ["LITELLM ESCALATE"],
     };
     expect(config).toEqual(expected);
@@ -268,6 +269,14 @@ describe("buildComplexityRouterConfig", () => {
     expect(buildComplexityRouterConfig({ ...baseParams, modalityRouting: true }).modality_routing).toBe(true);
     expect(buildComplexityRouterConfig(baseParams).modality_routing).toBe(false);
     expect(buildComplexityRouterConfig({ ...baseParams, modalityRouting: false }).modality_routing).toBe(false);
+  });
+
+  it("writes modality_pin_override explicitly both ways, so the stored config never relies on the backend default", () => {
+    expect(buildComplexityRouterConfig({ ...baseParams, modalityPinOverride: true }).modality_pin_override).toBe(true);
+    expect(buildComplexityRouterConfig(baseParams).modality_pin_override).toBe(false);
+    expect(buildComplexityRouterConfig({ ...baseParams, modalityPinOverride: false }).modality_pin_override).toBe(
+      false,
+    );
   });
 
   it("writes session_affinity=true so turning the toggle on overrides the backend's off-by-default", () => {

--- a/ui/litellm-dashboard/src/components/add_model/build_complexity_router_config.ts
+++ b/ui/litellm-dashboard/src/components/add_model/build_complexity_router_config.ts
@@ -111,6 +111,7 @@ export interface BuildComplexityRouterConfigParams {
   classificationMode: ClassificationMode | undefined;
   sessionAffinity: boolean;
   modalityRouting?: boolean;
+  modalityPinOverride?: boolean;
   deploymentAffinity: boolean;
   customTechnicalKeywords: string[];
   keywordTierRules: KeywordTierRule[];
@@ -169,6 +170,7 @@ export interface ComplexityRouterConfigPayload {
   session_affinity: boolean;
   deployment_affinity: boolean;
   modality_routing: boolean;
+  modality_pin_override: boolean;
   custom_technical_keywords?: string[];
   keyword_tier_rules?: { keywords: string[]; tier: KeywordTierRule["tier"] }[];
   semantic_keyword_matching?: boolean;
@@ -409,6 +411,7 @@ export const buildComplexityRouterConfig = ({
   classificationMode,
   sessionAffinity,
   modalityRouting,
+  modalityPinOverride,
   deploymentAffinity,
   customTechnicalKeywords,
   keywordTierRules,
@@ -472,6 +475,7 @@ export const buildComplexityRouterConfig = ({
     session_affinity: sessionAffinity,
     deployment_affinity: deploymentAffinity,
     modality_routing: modalityRouting ?? false,
+    modality_pin_override: modalityPinOverride ?? false,
     ...(customTechnicalKeywords.length > 0 && { custom_technical_keywords: customTechnicalKeywords }),
     ...(cleanedKeywordTierRules.length > 0 && { keyword_tier_rules: cleanedKeywordTierRules }),
     escalation_keywords: cleanedEscalationKeywords,

--- a/ui/litellm-dashboard/src/components/edit_auto_router/build_updated_complexity_router_config.test.ts
+++ b/ui/litellm-dashboard/src/components/edit_auto_router/build_updated_complexity_router_config.test.ts
@@ -257,6 +257,30 @@ describe("buildUpdatedComplexityRouterConfig session affinity", () => {
   });
 });
 
+describe("buildUpdatedComplexityRouterConfig modality pin override", () => {
+  it("writes modality_pin_override explicitly both ways", () => {
+    expect(
+      buildUpdatedComplexityRouterConfig(STORED, { ...FORM_VALUE, modality_pin_override: true }).modality_pin_override,
+    ).toBe(true);
+    expect(
+      buildUpdatedComplexityRouterConfig(STORED, { ...FORM_VALUE, modality_pin_override: false }).modality_pin_override,
+    ).toBe(false);
+  });
+
+  it("re-asserts the backend's off-by-default when the form value is absent, rather than dropping the key", () => {
+    const result = buildUpdatedComplexityRouterConfig({ ...STORED, modality_pin_override: true }, FORM_VALUE);
+    expect(result.modality_pin_override).toBe(false);
+  });
+
+  it("round-trips a stored modality_pin_override=true through hydrate then save", () => {
+    const stored = { ...STORED, modality_routing: true, modality_pin_override: true };
+    const hydrated = hydrateComplexityRouterConfig(stored, undefined);
+
+    expect(hydrated.modality_pin_override).toBe(true);
+    expect(buildUpdatedComplexityRouterConfig(stored, hydrated).modality_pin_override).toBe(true);
+  });
+});
+
 describe("buildUpdatedComplexityRouterConfig classification mode", () => {
   it("round-trips a stored user_turn through hydrate then save", () => {
     const stored = { ...STORED, classification_mode: "user_turn" };
@@ -505,6 +529,8 @@ describe("managed keys survive an untouched open-and-save", () => {
     classifier_fallback: "default_model",
     classification_mode: "user_turn",
     session_affinity: true,
+    modality_routing: true,
+    modality_pin_override: true,
     deployment_affinity: false,
     adaptive: true,
     adaptive_weights: { quality: 0.4, cost: 0.6 },

--- a/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.test.ts
+++ b/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.test.ts
@@ -51,6 +51,7 @@ const expectedClassifiedTierConfig = {
   session_affinity: false,
   deployment_affinity: true,
   modality_routing: false,
+  modality_pin_override: false,
   adaptive: true,
   adaptive_weights: { quality: 0.4, cost: 0.6 },
   adaptive_eligible: "classified_tier",
@@ -74,6 +75,7 @@ const expectedAdaptiveDisabledConfig = {
   session_affinity: false,
   deployment_affinity: true,
   modality_routing: false,
+  modality_pin_override: false,
 };
 
 describe("buildUpdatedComplexityRouterConfig", () => {
@@ -107,6 +109,26 @@ describe("buildUpdatedComplexityRouterConfig", () => {
       { ...classifiedTierValue, modality_routing: false },
     );
     expect(disabled.modality_routing).toBe(false);
+  });
+
+  it("hydrates a stored modality_pin_override into form state and defaults absent to off", () => {
+    expect(
+      hydrateComplexityRouterConfig({ ...storedConfig, modality_pin_override: true }, null).modality_pin_override,
+    ).toBe(true);
+    expect(hydrateComplexityRouterConfig(storedConfig, null).modality_pin_override).toBe(false);
+  });
+
+  it("round-trips modality_pin_override explicitly in both directions", () => {
+    const enabled = buildUpdatedComplexityRouterConfig(storedConfig, {
+      ...classifiedTierValue,
+      modality_pin_override: true,
+    });
+    expect(enabled.modality_pin_override).toBe(true);
+    const disabled = buildUpdatedComplexityRouterConfig(
+      { ...storedConfig, modality_pin_override: true },
+      { ...classifiedTierValue, modality_pin_override: false },
+    );
+    expect(disabled.modality_pin_override).toBe(false);
   });
 
   it("includes return_raw_model_name only when enabled", () => {

--- a/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.test.tsx
+++ b/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.test.tsx
@@ -549,6 +549,50 @@ describe("EditAutoRouterModal deployment affinity", () => {
     await waitFor(() => expect(modelPatchUpdateCall).toHaveBeenCalled());
     expect(savedConfig().deployment_affinity).toBe(false);
   });
+
+  // modality_pin_override is a managed key, so the modal rewrites it from form state on save. A
+  // hydration gap would silently turn a stored override off on the next untouched save.
+  it("shows a stored modality_pin_override=true as on and preserves it through an untouched save", async () => {
+    const user = userEvent.setup();
+    renderWithStoredConfig({ ...STORED_CONFIG, modality_routing: true, modality_pin_override: true });
+
+    await user.click(await screen.findByText("Advanced: Modality Routing"));
+    expect(await screen.findByRole("switch", { name: "Override session pin for image requests" })).toBeChecked();
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => expect(modelPatchUpdateCall).toHaveBeenCalled());
+    expect(savedConfig().modality_pin_override).toBe(true);
+  });
+
+  it("persists turning the modality pin override on", async () => {
+    const user = userEvent.setup();
+    renderWithStoredConfig({ ...STORED_CONFIG, modality_routing: true });
+
+    await user.click(await screen.findByText("Advanced: Modality Routing"));
+    await user.click(await screen.findByRole("switch", { name: "Override session pin for image requests" }));
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => expect(modelPatchUpdateCall).toHaveBeenCalled());
+    expect(savedConfig().modality_pin_override).toBe(true);
+  });
+
+  it("writes modality_pin_override=false for a stored config that never carried the key", async () => {
+    const user = userEvent.setup();
+    renderWithStoredConfig(STORED_CONFIG);
+
+    await user.click(await screen.findByText("Advanced: Modality Routing"));
+    expect(await screen.findByRole("switch", { name: "Override session pin for image requests" })).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => expect(modelPatchUpdateCall).toHaveBeenCalled());
+    expect(savedConfig().modality_pin_override).toBe(false);
+  });
 });
 
 describe("EditAutoRouterModal custom classifier prompt and fallback", () => {

--- a/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.tsx
+++ b/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.tsx
@@ -104,6 +104,7 @@ export interface StoredComplexityRouterConfig {
   reasoning_override_min_score?: unknown;
   session_affinity?: unknown;
   modality_routing?: unknown;
+  modality_pin_override?: unknown;
   deployment_affinity?: unknown;
   adaptive?: boolean;
   adaptive_weights?: AdaptiveRouterWeights;
@@ -181,6 +182,8 @@ export const hydrateComplexityRouterConfig = (
     session_affinity:
       typeof parsedConfig.session_affinity === "boolean" ? parsedConfig.session_affinity : DEFAULT_SESSION_AFFINITY,
     modality_routing: typeof parsedConfig.modality_routing === "boolean" ? parsedConfig.modality_routing : false,
+    modality_pin_override:
+      typeof parsedConfig.modality_pin_override === "boolean" ? parsedConfig.modality_pin_override : false,
     deployment_affinity:
       typeof parsedConfig.deployment_affinity === "boolean"
         ? parsedConfig.deployment_affinity
@@ -221,6 +224,7 @@ export const MANAGED_COMPLEXITY_ROUTER_KEYS = new Set([
   "classification_mode",
   "session_affinity",
   "modality_routing",
+  "modality_pin_override",
   "deployment_affinity",
   "adaptive",
   "adaptive_weights",
@@ -318,6 +322,7 @@ export const buildUpdatedComplexityRouterConfig = (
     classifierFallback: value.classifier_fallback,
     sessionAffinity: value.session_affinity ?? DEFAULT_SESSION_AFFINITY,
     modalityRouting: value.modality_routing ?? false,
+    modalityPinOverride: value.modality_pin_override ?? false,
     deploymentAffinity: value.deployment_affinity ?? DEFAULT_DEPLOYMENT_AFFINITY,
     customTechnicalKeywords: customTechnicalKeywords ?? [],
     keywordTierRules: keywordMatching?.keywordTierRules ?? [],

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/RoutingDecisionCard.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/RoutingDecisionCard.test.tsx
@@ -186,6 +186,12 @@ describe("RoutingDecisionCard", () => {
     expect(screen.queryByText("housekeeping")).not.toBeInTheDocument();
   });
 
+  it("labels a modality pin override instead of showing the raw cause token", () => {
+    render(<RoutingDecisionCard decision={{ ...heuristic, cause: "modality_pin_override" }} />);
+    expect(screen.getByText("Overrode session pin for image input")).toBeInTheDocument();
+    expect(screen.queryByText("modality_pin_override")).not.toBeInTheDocument();
+  });
+
   it("labels a modality escalation instead of showing the raw cause token", () => {
     render(<RoutingDecisionCard decision={{ ...heuristic, cause: "modality_escalation" }} />);
     expect(screen.getByText("Escalated for image input")).toBeInTheDocument();

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/RoutingDecisionCard.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/RoutingDecisionCard.tsx
@@ -93,6 +93,7 @@ const CONSTANT_CAUSE_LABELS: Record<string, string> = {
   session_affinity_escalation: "Escalated from session pin",
   user_turn_continuation: "Continuation turn, classifier skipped",
   modality_escalation: "Escalated for image input",
+  modality_pin_override: "Overrode session pin for image input",
   quality_tier: "Quality tier mapping",
   bandit: "Adaptive bandit",
   default_fallback: "Default model, no route matched",

--- a/ui/litellm-dashboard/src/lib/autorouter_presets.test.ts
+++ b/ui/litellm-dashboard/src/lib/autorouter_presets.test.ts
@@ -148,6 +148,25 @@ describe("autorouter_presets", () => {
     expect(withoutFlag.complexityRouterConfig.modality_routing).toBe(false);
   });
 
+  it("carries a preset's modality_pin_override into the prefilled form state", () => {
+    const preset = getPresetByKey("anthropic_family")!;
+    const withFlag = { ...preset.complexity_router_config, modality_routing: true, modality_pin_override: true };
+    const prefill = buildPresetPrefill(withFlag, groupsOnly(getRequiredModelsInPreset(preset)));
+    expect(prefill.complexityRouterConfig.modality_pin_override).toBe(true);
+    const withoutFlag = buildPresetPrefill(
+      preset.complexity_router_config,
+      groupsOnly(getRequiredModelsInPreset(preset)),
+    );
+    expect(withoutFlag.complexityRouterConfig.modality_pin_override).toBe(false);
+  });
+
+  it("ships every bundled preset with both modality flags written out, since the payload type requires them", () => {
+    for (const preset of getAllPresets()) {
+      expect(preset.complexity_router_config.modality_routing, preset.key).toBe(false);
+      expect(preset.complexity_router_config.modality_pin_override, preset.key).toBe(false);
+    }
+  });
+
   it("prefills the anthropic preset's effort through to tier_model_params", () => {
     const preset = getPresetByKey("anthropic_family")!;
     const prefill = buildPresetPrefill(preset.complexity_router_config, groupsOnly(getRequiredModelsInPreset(preset)));

--- a/ui/litellm-dashboard/src/lib/autorouter_presets.ts
+++ b/ui/litellm-dashboard/src/lib/autorouter_presets.ts
@@ -286,6 +286,7 @@ export const buildPresetPrefill = (
       session_affinity: config.session_affinity ?? DEFAULT_SESSION_AFFINITY,
       deployment_affinity: config.deployment_affinity ?? DEFAULT_DEPLOYMENT_AFFINITY,
       modality_routing: config.modality_routing ?? false,
+      modality_pin_override: config.modality_pin_override ?? false,
       adaptive: config.adaptive,
       adaptive_weights: config.adaptive_weights,
       tier_distance_penalty: config.tier_distance_penalty,

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -34736,8 +34736,14 @@ export interface components {
              */
             match_threshold: number;
             /**
+             * Modality Pin Override
+             * @description Let modality_routing replace a kept session-affinity pin on the turns that carry an image. Without this, a session pinned to a text-only model fails every image turn with a provider 400, since the pin is exempt from the modality gate. When enabled, such a turn routes to a capable model for that request only and the stored pin is left untouched, so the next text turn replays the session's own model; the override is reported as cause modality_pin_override and is never itself pinned. Inert unless modality_routing is also enabled.
+             * @default false
+             */
+            modality_pin_override: boolean;
+            /**
              * Modality Routing
-             * @description Route image-bearing requests only to models that can accept image input. The classifier reads text alone, so an image request whose text classifies cheap otherwise lands on a text-only model and fails with a provider 400. When enabled, a routed model explicitly declared supports_vision false (deployment model_info or the model cost map; unmapped names stay routable) is replaced by the nearest HIGHER tier holding a capable model, then default_model, else a clear 400. A kept session-affinity pin still wins even when an image arrives.
+             * @description Route image-bearing requests only to models that can accept image input. The classifier reads text alone, so an image request whose text classifies cheap otherwise lands on a text-only model and fails with a provider 400. When enabled, a routed model explicitly declared supports_vision false (deployment model_info or the model cost map; unmapped names stay routable) is replaced by the nearest HIGHER tier holding a capable model, then default_model, else a clear 400. A kept session-affinity pin still wins even when an image arrives, unless modality_pin_override is also enabled.
              * @default false
              */
             modality_routing: boolean;
@@ -35940,7 +35946,7 @@ export interface components {
              * Cause
              * @enum {string}
              */
-            cause?: "heuristic_scorer" | "heuristic_v2" | "reasoning_override" | "llm_classifier" | "heuristic_first_short_circuit" | "hybrid_short_circuit" | "classifier_plugin" | "classifier_fallback" | "default_model_fallback" | "literal_keyword_match" | "semantic_keyword_match" | "plan_mode" | "housekeeping" | "modality_escalation" | "session_affinity_pin" | "session_affinity_escalation" | "user_turn_continuation" | "default_fallback" | "keyword" | "quality_tier" | "bandit";
+            cause?: "heuristic_scorer" | "heuristic_v2" | "reasoning_override" | "llm_classifier" | "heuristic_first_short_circuit" | "hybrid_short_circuit" | "classifier_plugin" | "classifier_fallback" | "default_model_fallback" | "literal_keyword_match" | "semantic_keyword_match" | "plan_mode" | "housekeeping" | "modality_escalation" | "modality_pin_override" | "session_affinity_pin" | "session_affinity_escalation" | "user_turn_continuation" | "default_fallback" | "keyword" | "quality_tier" | "bandit";
             /** Classifier Cost */
             classifier_cost?: number;
             /** Classifier Model */


### PR DESCRIPTION
## TLDR

Problem this solves:

- A pinned session 400s on every image turn
- The modality gate skips a kept pin entirely
- Operators have no way to opt out

How it solves it:

- New opt-in `modality_pin_override` lifts that exemption
- Image turns re-route to a capable model
- The stored pin survives, so text turns replay it

## User Flow

Before: a developer using an auto-router with session pinning cannot send a screenshot mid-conversation, because the session is stuck on a text-only model

1. They send POST https://litellm-domain/v1/chat/completions with `"model": "smart-router"` and a `session_id`, asking a plain text question, and get a 200 served by the cheap text-only model
2. They send a follow-up on the same `session_id` with an `image_url` content block
3. They get `400 Bad Request` reading `does not support image inputs. Use a Fireworks vision model or remove image_url content blocks`
4. The only ways out are dropping the image, starting a new session, or turning session pinning off for everyone

After: the same follow-up is answered, and the conversation stays on its own model afterwards

1. The proxy admin adds `modality_pin_override: true` to the router config, next to `modality_routing`, and restarts the proxy
2. The developer sends the same plain text question with a `session_id` and gets a 200 from the cheap text-only model
3. They send the same follow-up carrying the `image_url` block
4. It returns `200 OK`, answered by the vision-capable model, and https://litellm-domain/ui/?page=logs shows that request with cause `Overrode session pin for image input`
5. Their next text turn on the same `session_id` returns to the original cheap model, so the pin was never moved

## Relevant issues

- Follow-up to the modality routing feature, which deliberately let a kept pin win over the gate
- Reported as a gap by an operator running both `session_affinity` and `modality_routing`

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Shared setup: local proxy on :4711 backed by real Postgres, real LLM calls through the sandbox gateway to Fireworks (`deepseek-v4-flash-0731`) and Anthropic (`claude-opus-4-8`), costing real money. The test image is a solid red PNG. The same config file, including `modality_pin_override`, is used for both runs, so the code is the only variable. Older proxies accept the unknown key and ignore it, which the Before run also demonstrates.

```yaml
model_list:
  - model_name: pin-router
    litellm_params:
      model: auto_router/complexity_router
      complexity_router_config:
        classifier_type: heuristic
        modality_routing: true
        modality_pin_override: true
        session_affinity: true
        tiers:
          SIMPLE: deepseek-flash
          MEDIUM: deepseek-flash
          COMPLEX: claude-opus
          REASONING: claude-opus
  - model_name: pin-nooverride-router    # same, modality_pin_override: false
  - model_name: pin-nocap-router         # override on, SIMPLE and MEDIUM only, both text-only
  - model_name: deepseek-flash
    litellm_params:
      model: openai/fireworks_ai/deepseek-v4-flash-0731
      api_base: https://gateway.litellm-sandbox.ai/v1
      api_key: os.environ/GW_KEY
    model_info:
      supports_vision: false
  - model_name: claude-opus
    litellm_params:
      model: openai/anthropic/claude-opus-4-8
      api_base: https://gateway.litellm-sandbox.ai/v1
      api_key: os.environ/GW_KEY
    model_info:
      supports_vision: true
```

Each case sends three turns on one `session_id`: a text ask, then the image, then another text ask.

### Before (993766be0e)

#### Pinned session, image turn, via /v1/chat/completions

1. Turn 1, text: `200 OK`, `x-litellm-model-name: openai/fireworks_ai/deepseek-v4-flash-0731`
2. Turn 2, same session, image block: `400 Bad Request` with `litellm.BadRequestError: Fireworks AI model accounts/fireworks/models/deepseek-v4-flash-0731 does not support image inputs. Use a Fireworks vision model or remove image_url content blocks`
3. Turn 3, text: `200 OK`, back on `deepseek-v4-flash-0731`
4. Proxy log for turn 2 reads `cause=session_affinity_pin, routed_model=deepseek-flash`, so the gate never ran

#### Flag off control, via /v1/chat/completions

1. Same three turns against `pin-nooverride-router`
2. `200 OK`, then the same `400 Bad Request`, then `200 OK`

#### No vision-capable model anywhere, via /v1/chat/completions

1. Same three turns against `pin-nocap-router`
2. `200 OK`, then `400 Bad Request` carrying the provider error rather than a router message, then `200 OK`
3. All three routers behave identically here, including `pin-router` whose config already sets `modality_pin_override: true`, which is what proves an older proxy accepts the key and ignores it

### After (030c8b7fab)

#### Pinned session, image turn, via /v1/chat/completions

1. Turn 1, text: `200 OK`, `openai/fireworks_ai/deepseek-v4-flash-0731`
2. Turn 2, same session, image block: `200 OK`, `openai/anthropic/claude-opus-4-8`, content `Red`
3. Turn 3, text: `200 OK`, back on `openai/fireworks_ai/deepseek-v4-flash-0731`
4. Spend log rows, in order: `cause=heuristic_scorer`, then `cause=modality_pin_override` with `signals=["modality:image", "modality_escalated_from:SIMPLE"]`, then `cause=session_affinity_pin`. The third row is the proof the pin was never overwritten

#### Pinned session, image turn, via /v1/messages

1. Same three turns with an Anthropic `{"type":"image","source":{...}}` block
2. `200 OK` on `deepseek-v4-flash-0731`, then `200 OK` on `claude-opus-4-8`, then `200 OK` back on `deepseek-v4-flash-0731`

#### Pinned session, image turn, via /v1/responses

1. Same three turns with an `input_image` part
2. `200 OK` on `deepseek-v4-flash-0731`, then `200 OK` on `claude-opus-4-8`, then `200 OK` back on `deepseek-v4-flash-0731`

#### Flag off, same binary

1. Same three turns against `pin-nooverride-router`
2. `200 OK`, then `400 Bad Request` with the original Fireworks error byte for byte, then `200 OK`
3. Today's behavior is preserved exactly when the flag is not set

#### No vision-capable model anywhere

1. Same three turns against `pin-nocap-router`
2. Turn 2 returns `400 Bad Request` with `Auto-router pin-nocap-router received a request with image input, but no model at or above the decided tier accepts images and modality_routing is enabled. Tiers checked: SIMPLE, MEDIUM, COMPLEX, REASONING. Add a vision-capable model to a tier, or set a vision-capable default_model, or remove the image content.`
3. Turn 3 returns `200 OK` on `deepseek-v4-flash-0731`, so a rejected image turn does not cost the session its pin

#### Admin UI

The new switch lives inside Advanced: Modality Routing on the Add Auto Router form (models page, Auto-Routers tab), and the same pair renders on the edit form. It stays disabled until image routing is turned on.

Both switches off, override disabled:

![Override session pin switch disabled while modality routing is off](https://raw.githubusercontent.com/BerriAI/litellm/litellm_modality_pin_override_assets/pr39454/modality_pin_override_disabled.png)

Image routing on, override enabled and turned on:

![Override session pin switch enabled and on](https://raw.githubusercontent.com/BerriAI/litellm/litellm_modality_pin_override_assets/pr39454/modality_pin_override_enabled.png)

## Type

🆕 New Feature

## Caveats (if any)

### Medium

- Older proxies accept `modality_pin_override` and silently ignore it
- Turning it on makes image turns cost more on a pinned session

### Low

- Inert unless `modality_routing` is also on

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
