### PR TITLE
docs: define Rust Python harness structure

### DIFF
--- a/tests/rust-python-harness/AGENTS.md
+++ b/tests/rust-python-harness/AGENTS.md
@@ -1,0 +1,44 @@
+# Expected Structure
+
+```text
+tests/rust-python-harness/
+├── __main__.py
+│
+├── strategies/
+│   ├── e2e_parity/
+│   │   ├── runner.py
+│   │   ├── sdk/
+│   │   │   ├── ocr/
+│   │   │   ├── messages/
+│   │   │   ├── chat_completions/
+│   │   │   └── responses/
+│   │   └── gateway/
+│   │
+│   ├── trace_parity/
+│   │   ├── runner.py
+│   │   ├── sdk/
+│   │   └── gateway/
+│   │
+│   └── unit_tests/
+│       ├── runner.py
+│       ├── mapping_validator.py
+│       ├── python_runner.py
+│       └── rust_runner.py
+│
+└── shared/
+    ├── parity/
+    ├── tracing/
+    └── reporting/
+```
+
+- Run locally only; no CI integration
+- `__main__.py` selects strategies and combines their reports; each strategy also runs independently
+- `e2e_parity/` compares SDK objects, exceptions, callbacks, and streams, or gateway HTTP responses
+- `trace_parity/` compares mapped operations, call counts, and required execution ordering
+- E2E and trace runners share orchestration across `sdk/` and `gateway/`; surface-specific execution lives in those folders
+- `unit_tests/runner.py` combines mapping validation, Python test runs, and native Rust test runs
+- `mapping_validator.py` matches Python/Rust tests by agreed names or annotations and reports missing or ambiguous counterparts
+- `python_runner.py` runs existing Python tests with Rust disabled and enabled in separate processes, verifies backend selection, and compares results
+- `rust_runner.py` runs Cargo tests; native Rust unit tests stay beside their implementation
+- `shared/` contains reusable parity, tracing, and reporting machinery
+- Keep fixtures with their owning API and existing Python tests in their current locations


### PR DESCRIPTION
## TLDR

Problem this solves:

- Migration harness organization and runner responsibilities need agreement

How it solves it:

- Document the expected structure and local execution rules
- Keep native Rust tests beside their implementation

## User Flow

Before: contributors lack a documented migration testing layout

1. They consult the harness contributor instructions
2. They find no guidance on organizing migration checks

After: contributors can follow an agreed migration testing layout

1. They consult the harness contributor instructions
2. They find strategy responsibilities and independent execution guidance

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [ ] I have added meaningful tests (documentation only)
- [ ] Relevant tests pass locally (not run, documentation only)
- [ ] My PR passes all required CI/CD checks
- [x] My PR only solves one specific problem
- [ ] Greptile Confidence Score is at least 4/5

## Screenshots / Proof of Fix

### Before (993766be0e)

1. Run `git ls-tree 993766be0e -- tests/rust-python-harness/AGENTS.md`
2. Observe no entry

### After (fced0d5bb3)

1. Run `git show fced0d5bb3:tests/rust-python-harness/AGENTS.md`
2. Observe the expected directory tree and concise responsibility bullets
3. Run `git diff --check 993766be0e...fced0d5bb3` and observe no whitespace errors

## Type

Documentation

## Caveats (if any)

### Low

- Documents the intended structure; implementation remains separate

## Final Attestation

- [x] Reviewed the documentation against the agreed harness design
