### PR TITLE
fix(helm): render ingress-nginx compatible path types via ingress.controller

### DIFF
--- a/helm/litellm/templates/_helpers.tpl
+++ b/helm/litellm/templates/_helpers.tpl
@@ -428,3 +428,16 @@ envFrom:
 {{- end }}
 {{- end }}
 {{- end -}}
+
+{{/*
+ingress-nginx's admission webhook rejects a dot in an Exact or Prefix path
+(strict-validate-path-type) and serves ImplementationSpecific as a plain
+prefix location, so a dotted path takes that type there.
+*/}}
+{{- define "litellm.ingress.pathType" -}}
+{{- if and (eq .controller "nginx") (contains "." .path) -}}
+ImplementationSpecific
+{{- else -}}
+{{- .pathType -}}
+{{- end -}}
+{{- end -}}

--- a/helm/litellm/templates/ingress.yaml
+++ b/helm/litellm/templates/ingress.yaml
@@ -170,10 +170,11 @@ spec:
           {{- if not $target }}
           {{- fail (printf "ingress.extraPaths[%d] (path %s): unknown service %q, expected one of backend, gateway, ui" $idx $extra.path $service) }}
           {{- end }}
-          {{- $pathType := $extra.pathType | default "Prefix" }}
-          {{- if not (has $pathType (list "Prefix" "Exact" "ImplementationSpecific")) }}
-          {{- fail (printf "ingress.extraPaths[%d] (path %s): unknown pathType %q, expected one of Exact, ImplementationSpecific, Prefix" $idx $extra.path $pathType) }}
+          {{- $requestedPathType := $extra.pathType | default "Prefix" }}
+          {{- if not (has $requestedPathType (list "Prefix" "Exact" "ImplementationSpecific")) }}
+          {{- fail (printf "ingress.extraPaths[%d] (path %s): unknown pathType %q, expected one of Exact, ImplementationSpecific, Prefix" $idx $extra.path $requestedPathType) }}
           {{- end }}
+          {{- $pathType := include "litellm.ingress.pathType" (dict "controller" $controller "path" $extra.path "pathType" $requestedPathType) }}
           {{- if eq $extra.path "/" }}
           {{- fail (printf "ingress.extraPaths[%d]: path / is already routed in both directions, Exact to ui and Prefix to backend, so no pathType leaves a request for an entry here to capture" $idx) }}
           {{- end }}

--- a/helm/litellm/templates/ingress.yaml
+++ b/helm/litellm/templates/ingress.yaml
@@ -5,6 +5,10 @@
 {{- $gatewayPort := .Values.gateway.service.port -}}
 {{- $backendPort := .Values.backend.service.port -}}
 {{- $uiPort := .Values.ui.service.port -}}
+{{- $controller := .Values.ingress.controller | default "alb" -}}
+{{- if not (has $controller (list "alb" "nginx")) }}
+{{- fail (printf "ingress.controller: unknown controller %q, expected one of alb, nginx" $controller) }}
+{{- end }}
 {{/*
   Backends addressable from ingress.extraPaths, keyed by the `service` field.
 */}}
@@ -27,10 +31,11 @@
   /litellm-asset-prefix, so without /*.txt they fall to the backend catch-all
   → 404 → client-side navigation never settles and the login flow spins in an
   infinite redirect loop (/ ⇄ /ui/login). ui/nginx.conf already serves *.txt
-  from the export; the rule only routes the request to it. Needs an ingress
-  controller whose ImplementationSpecific path is a wildcard pattern
-  (AWS ALB: `*` = 0+ chars); this chart targets the AWS Load Balancer
-  Controller.
+  from the export; the rule only routes the request to it. It needs an
+  ingress controller whose ImplementationSpecific path is a wildcard pattern
+  (AWS ALB: `*` = 0+ chars), so it is rendered for ingress.controller=alb
+  only: ingress-nginx serves ImplementationSpecific as a literal prefix
+  location, where /*.txt can never match.
 */}}
 {{- $uiPaths := list
     (dict "path" "/" "pathType" "Exact")
@@ -38,8 +43,10 @@
     (dict "path" "/litellm-asset-prefix" "pathType" "Prefix")
     (dict "path" "/_next" "pathType" "Prefix")
     (dict "path" "/ui" "pathType" "Prefix")
-    (dict "path" "/*.txt" "pathType" "ImplementationSpecific")
 -}}
+{{- if eq $controller "alb" }}
+{{- $uiPaths = append $uiPaths (dict "path" "/*.txt" "pathType" "ImplementationSpecific") }}
+{{- end }}
 {{/*
   Gateway data-plane prefixes — must mirror gateway/routes/allowlist.py.
   Versioned paths are listed explicitly to avoid routing management routes
@@ -83,12 +90,6 @@
   adding to it.
 */}}
 {{- $builtinPathKeys := list "/test|Exact" "/|Prefix" -}}
-{{- range $uiPaths }}
-{{- $builtinPathKeys = append $builtinPathKeys (printf "%s|%s" .path .pathType) }}
-{{- end }}
-{{- range $gatewayPrefixes }}
-{{- $builtinPathKeys = append $builtinPathKeys (printf "%s|Prefix" .) }}
-{{- end }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -115,8 +116,10 @@ spec:
         paths:
           # --- UI (Next.js static export) ---
           {{- range $uiPaths }}
+          {{- $pathType := include "litellm.ingress.pathType" (dict "controller" $controller "path" .path "pathType" .pathType) }}
+          {{- $builtinPathKeys = append $builtinPathKeys (printf "%s|%s" .path $pathType) }}
           - path: {{ .path }}
-            pathType: {{ .pathType }}
+            pathType: {{ $pathType }}
             backend:
               service:
                 name: {{ $uiName }}
@@ -134,8 +137,10 @@ spec:
                 port:
                   number: {{ $gatewayPort }}
           {{- range $gatewayPrefixes }}
+          {{- $pathType := include "litellm.ingress.pathType" (dict "controller" $controller "path" . "pathType" "Prefix") }}
+          {{- $builtinPathKeys = append $builtinPathKeys (printf "%s|%s" . $pathType) }}
           - path: {{ . }}
-            pathType: Prefix
+            pathType: {{ $pathType }}
             backend:
               service:
                 name: {{ $gatewayName }}
@@ -147,10 +152,11 @@ spec:
             Rendered after every built-in path so an entry can never take
             precedence over a default, and before the backend catch-all.
             Position only decides the match on controllers that honour manifest
-            order: the AWS Load Balancer Controller this chart targets sorts
-            Exact paths first and Prefix paths longest-first, but keeps
+            order: the AWS Load Balancer Controller (ingress.controller=alb)
+            sorts Exact paths first and Prefix paths longest-first, but keeps
             ImplementationSpecific paths in manifest order, which is what the
-            /*.txt rule above already depends on.
+            /*.txt rule above already depends on. ingress-nginx ignores order
+            and serves the longest matching location.
           */}}
           {{- range $idx, $extra := .Values.ingress.extraPaths }}
           {{- if not (kindIs "map" $extra) }}

--- a/helm/litellm/tests/ingress_controller_tests.yaml
+++ b/helm/litellm/tests/ingress_controller_tests.yaml
@@ -127,3 +127,79 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: 'ingress.controller: unknown controller "traefik", expected one of alb, nginx'
+
+  - it: rejects an extraPaths entry that repeats a built-in path once ingress-nginx normalizes its pathType
+    set:
+      ingress.enabled: true
+      ingress.controller: nginx
+      ingress.extraPaths:
+        - path: /favicon.ico
+          service: ui
+    asserts:
+      - failedTemplate:
+          errorMessage: "ingress.extraPaths[0]: path /favicon.ico with pathType ImplementationSpecific is already routed by this chart, and a duplicate would take it over rather than add to it"
+
+  - it: renders a dotted extraPaths entry as ImplementationSpecific for ingress-nginx
+    set:
+      ingress.enabled: true
+      ingress.controller: nginx
+      ingress.extraPaths:
+        - path: /eu.assemblyai.custom
+          service: gateway
+        - path: /robots.txt
+          service: ui
+          pathType: Exact
+    asserts:
+      - notMatchRegexRaw:
+          pattern: 'path: "?/\S*\.\S*"?\n\s+pathType: (Exact|Prefix)\n'
+      - contains:
+          path: spec.rules[0].http.paths
+          content:
+            path: /eu.assemblyai.custom
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: RELEASE-NAME-litellm-gateway
+                port:
+                  number: 4000
+      - contains:
+          path: spec.rules[0].http.paths
+          content:
+            path: /robots.txt
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: RELEASE-NAME-litellm-ui
+                port:
+                  number: 3000
+
+  - it: keeps the requested pathType of a dotted extraPaths entry for the AWS Load Balancer Controller
+    set:
+      ingress.enabled: true
+      ingress.extraPaths:
+        - path: /eu.assemblyai.custom
+          service: gateway
+        - path: /robots.txt
+          service: ui
+          pathType: Exact
+    asserts:
+      - contains:
+          path: spec.rules[0].http.paths
+          content:
+            path: /eu.assemblyai.custom
+            pathType: Prefix
+            backend:
+              service:
+                name: RELEASE-NAME-litellm-gateway
+                port:
+                  number: 4000
+      - contains:
+          path: spec.rules[0].http.paths
+          content:
+            path: /robots.txt
+            pathType: Exact
+            backend:
+              service:
+                name: RELEASE-NAME-litellm-ui
+                port:
+                  number: 3000

--- a/helm/litellm/tests/ingress_controller_tests.yaml
+++ b/helm/litellm/tests/ingress_controller_tests.yaml
@@ -1,0 +1,129 @@
+suite: test ingress.controller
+templates:
+  - ingress.yaml
+values:
+  - ./values/required.yaml
+tests:
+  - it: keeps the AWS Load Balancer Controller path types by default
+    set:
+      ingress.enabled: true
+    asserts:
+      - contains:
+          path: spec.rules[0].http.paths
+          content:
+            path: /favicon.ico
+            pathType: Exact
+            backend:
+              service:
+                name: RELEASE-NAME-litellm-ui
+                port:
+                  number: 3000
+      - contains:
+          path: spec.rules[0].http.paths
+          content:
+            path: /eu.assemblyai
+            pathType: Prefix
+            backend:
+              service:
+                name: RELEASE-NAME-litellm-gateway
+                port:
+                  number: 4000
+      - contains:
+          path: spec.rules[0].http.paths
+          content:
+            path: /*.txt
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: RELEASE-NAME-litellm-ui
+                port:
+                  number: 3000
+
+  - it: renders no dotted Exact or Prefix path for ingress-nginx, whose admission webhook rejects them
+    set:
+      ingress.enabled: true
+      ingress.controller: nginx
+    asserts:
+      - notMatchRegexRaw:
+          pattern: 'path: /\S*\.\S*\n\s+pathType: (Exact|Prefix)\n'
+      - contains:
+          path: spec.rules[0].http.paths
+          content:
+            path: /favicon.ico
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: RELEASE-NAME-litellm-ui
+                port:
+                  number: 3000
+      - contains:
+          path: spec.rules[0].http.paths
+          content:
+            path: /eu.assemblyai
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: RELEASE-NAME-litellm-gateway
+                port:
+                  number: 4000
+
+  - it: drops the /*.txt wildcard for ingress-nginx and keeps every other route as is
+    set:
+      ingress.enabled: true
+      ingress.controller: nginx
+    asserts:
+      - notContains:
+          path: spec.rules[0].http.paths
+          content:
+            path: /*.txt
+          any: true
+      - contains:
+          path: spec.rules[0].http.paths
+          content:
+            path: /ui
+            pathType: Prefix
+            backend:
+              service:
+                name: RELEASE-NAME-litellm-ui
+                port:
+                  number: 3000
+      - contains:
+          path: spec.rules[0].http.paths
+          content:
+            path: /test
+            pathType: Exact
+            backend:
+              service:
+                name: RELEASE-NAME-litellm-gateway
+                port:
+                  number: 4000
+      - equal:
+          path: spec.rules[0].http.paths[-1]
+          value:
+            path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: RELEASE-NAME-litellm-backend
+                port:
+                  number: 4001
+
+  - it: rejects an extraPaths entry that repeats a built-in path at the pathType ingress-nginx renders it with
+    set:
+      ingress.enabled: true
+      ingress.controller: nginx
+      ingress.extraPaths:
+        - path: /favicon.ico
+          service: ui
+          pathType: ImplementationSpecific
+    asserts:
+      - failedTemplate:
+          errorMessage: "ingress.extraPaths[0]: path /favicon.ico with pathType ImplementationSpecific is already routed by this chart, and a duplicate would take it over rather than add to it"
+
+  - it: rejects a controller it has no path types for
+    set:
+      ingress.enabled: true
+      ingress.controller: traefik
+    asserts:
+      - failedTemplate:
+          errorMessage: 'ingress.controller: unknown controller "traefik", expected one of alb, nginx'

--- a/helm/litellm/values.yaml
+++ b/helm/litellm/values.yaml
@@ -11,7 +11,8 @@ ingress:
   enabled: false
   className: ""
   # Which ingress controller serves this Ingress. Controllers disagree on the
-  # pathTypes they accept, so this picks the pathType of a few built-in paths:
+  # pathTypes they accept, so this picks the pathType of the dotted paths, the
+  # built-in ones and any dotted extraPaths entry alike:
   #   alb    AWS Load Balancer Controller (default): Exact and Prefix paths plus
   #          the /*.txt wildcard that routes the UI's RSC payloads.
   #   nginx  ingress-nginx: its admission webhook rejects a dot in an Exact or
@@ -37,7 +38,8 @@ ingress:
   #
   #   path      required; the HTTP path to route
   #   service   which component serves it: gateway (default), backend, or ui
-  #   pathType  Prefix (default), Exact, or ImplementationSpecific
+  #   pathType  Prefix (default), Exact, or ImplementationSpecific; a dotted
+  #             path renders as ImplementationSpecific when controller is nginx
   #
   # The target component only answers paths its own route allowlist keeps, so
   # a path here still has to be one that component serves.

--- a/helm/litellm/values.yaml
+++ b/helm/litellm/values.yaml
@@ -10,6 +10,17 @@ imagePullSecrets: []
 ingress:
   enabled: false
   className: ""
+  # Which ingress controller serves this Ingress. Controllers disagree on the
+  # pathTypes they accept, so this picks the pathType of a few built-in paths:
+  #   alb    AWS Load Balancer Controller (default): Exact and Prefix paths plus
+  #          the /*.txt wildcard that routes the UI's RSC payloads.
+  #   nginx  ingress-nginx: its admission webhook rejects a dot in an Exact or
+  #          Prefix path (strict-validate-path-type, on by default from v1.12.0
+  #          until v1.12.6 / v1.13.2 allowed dots again), so /favicon.ico and
+  #          /eu.assemblyai render as ImplementationSpecific, which nginx serves
+  #          as a plain prefix location. /*.txt is dropped: nginx has no
+  #          wildcard pathType, so that rule could never match there.
+  controller: alb
   annotations: {}
   host: ""        # optional; if set, becomes the rule's host
   tls: []


### PR DESCRIPTION
## TLDR

Problem this solves:

- ingress-nginx's admission webhook rejects the chart's `/favicon.ico` (Exact) and `/eu.assemblyai` (Prefix) rules
- `helm install` with `ingress.enabled: true` fails on clusters fronted by ingress-nginx v1.12.0 to v1.13.1
- Hand-written replacement ingresses tend to miss the `/` catch-all, so `/v2/login` 404s

How it solves it:

- New `ingress.controller: alb | nginx` value, default `alb`, default render byte-identical
- Under `nginx`, dotted built-in paths render as `ImplementationSpecific`, a plain prefix location there
- Under `nginx`, the ALB-only `/*.txt` wildcard rule is dropped since it could never match
- Dotted `extraPaths` entries get the same nginx normalization before the duplicate check and the render
- An unknown `ingress.controller` fails the render with a clear message

## User Flow

Before: an operator on an on-prem cluster fronted by ingress-nginx cannot install the chart with its ingress enabled, and the ingress they hand-write instead breaks UI login

1. They run `helm install litellm oci://ghcr.io/berriai/litellm/chart/litellm -f values.yaml` with `ingress.enabled: true` and `ingress.className: nginx`
2. helm prints `INSTALLATION FAILED: ... admission webhook "validate.nginx.ingress.kubernetes.io" denied the request: ingress contains invalid paths: path /favicon.ico cannot be used with pathType Exact` and `path /eu.assemblyai cannot be used with pathType Prefix`, and `helm list` shows the release as `failed`
3. They set `ingress.enabled: false` and hand-write an Ingress listing the chart's paths, without a `/` catch-all
4. They open https://litellm-domain/ui/login, enter `admin` plus the master key, and the login's POST https://litellm-domain/v2/login comes back 404 Not Found

After: the same install goes through with one extra value, and UI login works through the chart's own ingress

1. They run the same `helm install` with `ingress.controller: nginx` added next to `ingress.className: nginx`
2. helm prints `STATUS: deployed`, and the Ingress lists `/favicon.ico` and `/eu.assemblyai` with pathType `ImplementationSpecific`
3. GET https://litellm-domain/favicon.ico returns 200 `image/x-icon` from the UI, and POST https://litellm-domain/eu.assemblyai/v2/transcript reaches the gateway (401 without a key)
4. They open https://litellm-domain/ui/login, enter `admin` plus the master key, POST https://litellm-domain/v2/login returns 200, and the dashboard loads

## Relevant issues

Reported on the community Discord (no GitHub issue)

## Linear ticket

Resolves LIT-6689

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `helm unittest helm/litellm -f 'tests/*.yaml'` (13 suites, 118 tests)
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Setup: kind v0.33.0 cluster with ingress-nginx controller v1.13.1 (`kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.13.1/deploy/static/provider/kind/deploy.yaml`), an in-cluster `postgres:16` plus the chart's two required Secrets in namespace `lit6689`, the real `ghcr.io/berriai/litellm-{gateway,backend,ui,migrations}:v1.99.1` images, and ingress-nginx reached through `kubectl -n ingress-nginx port-forward svc/ingress-nginx-controller 30586:80`. `values-nginx.yaml`:

```yaml
ingress:
  enabled: true
  className: nginx
  host: localhost
migrationJob:
  image:
    tag: v1.99.1
database:
  writer:
    host: postgres.lit6689.svc.cluster.local
    port: 5432
    dbname: litellm
gateway:
  image:
    tag: v1.99.1
backend:
  image:
    tag: v1.99.1
ui:
  image:
    tag: v1.99.1
```

### Before (ff1f21aea9)

#### helm install with ingress.className nginx

1. `helm install litellm helm/litellm -n lit6689 -f values-nginx.yaml --timeout 8m`

```
I0902 18:44:33.956000   59603 warnings.go:107] "Warning: path /favicon.ico cannot be used with pathType Exact"
I0902 18:44:33.956044   59603 warnings.go:107] "Warning: path /eu.assemblyai cannot be used with pathType Prefix"
Error: INSTALLATION FAILED: server-side apply failed for object lit6689/litellm-litellm networking.k8s.io/v1, Kind=Ingress: admission webhook "validate.nginx.ingress.kubernetes.io" denied the request: ingress contains invalid paths: path /favicon.ico cannot be used with pathType Exact
path /eu.assemblyai cannot be used with pathType Prefix
exit: 1
```

2. `helm -n lit6689 list`

```
NAME   	NAMESPACE	REVISION	UPDATED                             	STATUS	CHART        	APP VERSION
litellm	lit6689  	1       	2026-09-02 18:42:26.752569 -0700 PDT	failed	litellm-0.1.0	0.1.0
```

3. `kubectl -n lit6689 get ingress`

```
No resources found in lit6689 namespace.
```

#### Routes through ingress-nginx

4. `for p in /favicon.ico /eu.assemblyai/v2/transcript /v2/login /ui/login /health/readiness /key/generate /test; do curl -s -o /dev/null -w "%{http_code}  %{content_type}  $p\n" http://localhost:30586$p; done`

```
404  text/html  /favicon.ico
404  text/html  /eu.assemblyai/v2/transcript
404  text/html  /v2/login
404  text/html  /ui/login
404  text/html  /health/readiness
404  text/html  /key/generate
404  text/html  /test
```

### After (ad0f0af192, PR tip)

Same cluster, torn down to an empty namespace and installed from scratch at the PR tip. On top of `values-nginx.yaml` this leg adds `values-extra.yaml`, which sets `ingress.controller: nginx`, one dotted operator path through `ingress.extraPaths`, and a `startupProbe` for the two Python components. The probe is not part of the fix: the laptop hosting this cluster is loaded enough that a cold start outlasts the chart's default liveness budget, and `gateway.startupProbe` / `backend.startupProbe` are the knobs the chart already documents for that.

```yaml
ingress:
  controller: nginx
  extraPaths:
    - path: /eu.assemblyai.custom
      pathType: Prefix
      service: gateway
gateway:
  startupProbe:
    httpGet: { path: /health/readiness, port: http }
    failureThreshold: 40
    periodSeconds: 10
backend:
  startupProbe:
    httpGet: { path: /health/readiness, port: http }
    failureThreshold: 40
    periodSeconds: 10
```

#### helm install with ingress.className nginx

1. `helm install litellm helm/litellm -n lit6689 -f values-nginx.yaml -f values-extra.yaml --timeout 20m --wait`

```
NAME: litellm
LAST DEPLOYED: Wed Sep  2 21:40:02 2026
NAMESPACE: lit6689
STATUS: deployed
REVISION: 1
DESCRIPTION: Install complete
TEST SUITE: None
```

2. `helm -n lit6689 list`

```
NAME   	NAMESPACE	REVISION	UPDATED                            	STATUS  	CHART        	APP VERSION
litellm	lit6689  	1       	2026-09-02 21:40:02.66926 -0700 PDT	deployed	litellm-0.1.0	0.1.0
```

3. `kubectl -n lit6689 get ingress litellm-litellm -o jsonpath='{range .spec.rules[0].http.paths[*]}{.path} {.pathType} -> {.backend.service.name}:{.backend.service.port.number}{"\n"}{end}' | grep -E '\.|\*'`

```
/favicon.ico ImplementationSpecific -> litellm-litellm-ui:3000
/eu.assemblyai ImplementationSpecific -> litellm-litellm-gateway:4000
/eu.assemblyai.custom ImplementationSpecific -> litellm-litellm-gateway:4000
```

#### Routes through ingress-nginx

4. `for p in /favicon.ico /eu.assemblyai/v2/transcript /eu.assemblyai.custom/v2/transcript /v2/login /ui/login /health/readiness /key/generate /test; do curl -s -o /dev/null -w "%{http_code}  %{content_type}  $p\n" http://localhost:30586$p; done`

```
200  image/x-icon  /favicon.ico
401  application/json  /eu.assemblyai/v2/transcript
404  application/json  /eu.assemblyai.custom/v2/transcript
405  application/json  /v2/login
200  text/html  /ui/login
200  application/json  /health/readiness
405  application/json  /key/generate
200  application/json  /test
```

5. `kubectl -n ingress-nginx logs deploy/ingress-nginx-controller --tail=400   # path -> status via upstream`

```
/favicon.ico -> 200 via lit6689-litellm-litellm-ui-3000
/ui/login -> 200 via lit6689-litellm-litellm-ui-3000
/eu.assemblyai/v2/transcript -> 401 via lit6689-litellm-litellm-gateway-4000
/eu.assemblyai.custom/v2/transcript -> 404 via lit6689-litellm-litellm-gateway-4000
/v2/login -> 405 via lit6689-litellm-litellm-backend-4001
/health/readiness -> 200 via lit6689-litellm-litellm-gateway-4000
/key/generate -> 405 via lit6689-litellm-litellm-backend-4001
/test -> 200 via lit6689-litellm-litellm-gateway-4000
```

`/v2/login` answering 405 rather than 404 is the login fix: the route exists and only rejects the GET, so the browser's POST from `/ui/login` reaches the backend. `/eu.assemblyai.custom/v2/transcript` answering 404 from the gateway (not `text/html` from nginx's default backend) is the extra path reaching the right upstream, with the gateway declining a passthrough it has no credentials for.

#### The extraPaths normalization, against the live admission webhook

The second commit is what covers `ingress.extraPaths`. Rendering the same manifest at each commit and applying it with `--server-dry-run` against the running webhook:

6. `helm template ... (at b8680120ce) | kubectl apply --server-dry-run -f -`

```
Resource: "networking.k8s.io/v1, Resource=ingresses", GroupVersionKind: "networking.k8s.io/v1, Kind=Ingress"
Name: "litellm-litellm", Namespace: "lit6689"
error when patching "prev-ingress.yaml": admission webhook "validate.nginx.ingress.kubernetes.io" denied the request: ingress contains invalid paths: path /eu.assemblyai.custom cannot be used with pathType Prefix
```

7. `helm template ... (at ad0f0af192) | kubectl apply --server-dry-run -f -`

```
ingress.networking.k8s.io/litellm-litellm configured (server dry run)
```

#### The ALB default is untouched

8. `chart-base/` is `helm/litellm` archived at `ff1f21aea9`. `values-alb.yaml` is the same install with `className: alb` and no `ingress.controller`; `values-extra-alb.yaml` adds the dotted `extraPaths` entry from the nginx leg on top of it

```
$ diff <(helm template litellm chart-base/helm/litellm -f values-alb.yaml) <(helm template litellm helm/litellm -f values-alb.yaml) && echo IDENTICAL
IDENTICAL
$ diff <(helm template litellm chart-base/helm/litellm -f values-extra-alb.yaml) <(helm template litellm helm/litellm -f values-extra-alb.yaml) && echo IDENTICAL
IDENTICAL
$ helm template litellm helm/litellm -f values-extra-alb.yaml | grep -A1 "eu.assemblyai.custom"
          - path: "/eu.assemblyai.custom"
            pathType: Prefix
```

The whole-chart render is byte-identical at the base and at the tip, with and without a dotted extra path, and ALB still gets the `Prefix` it asked for

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Under nginx the root-level RSC payloads the UI image ships (`/index.txt`, `/__next.*.txt`) route to the backend, not the UI
  - The dashboard only ever requested `/ui.txt`, which is absent from the export, so it 404s on ALB too
  - Login and navigation behaved the same as on ALB in the run; nginx-only rules for files nothing requests are not worth adding
- ingress-nginx v1.12.6 / v1.13.2 and newer accept dots again, so the flag matters on v1.12.0 to v1.13.1
  - `strict-validate-path-type: "false"` in the controller ConfigMap is the other way around it
  - Not worth gating the value on a controller version the chart cannot see, and `ImplementationSpecific` behaves the same on the newer builds
- An `ingress.extraPaths[].pathType` outside `Exact` / `Prefix` / `ImplementationSpecific` now fails the render instead of reaching the API server
  - Those three are the only values Kubernetes defines, so nothing valid is rejected; it turns a server-side rejection into a message naming the offending entry
- `gce` and `azure-application-gateway` class names keep the `alb` rendering they had before
  - Adding modes for them would be guesswork until someone reports an actual rejection; `ingress.controller` is open for it when that happens
- `ui.backendUrl` renders `LITELLM_BACKEND_URL`, which nothing in the repo reads (pre-existing, untouched)
  - Unrelated to path types, so removing it here would widen the blast radius of an ingress fix for no gain

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Helm ingress templating only; default `alb` rendering stays byte-identical, with routing differences isolated to explicit `ingress.controller: nginx`.
> 
> **Overview**
> Adds **`ingress.controller`** (`alb` | `nginx`, default **`alb`**) so the chart can emit Ingress rules that pass ingress-nginx’s admission webhook without changing the default ALB manifest.
> 
> For **`nginx`**, a new **`litellm.ingress.pathType`** helper rewrites paths containing a dot (e.g. `/favicon.ico`, `/eu.assemblyai`) from **Exact/Prefix** to **ImplementationSpecific**, and the ALB-only **`/*.txt`** UI wildcard rule is omitted because nginx cannot match it. Built-in UI/gateway paths, **`ingress.extraPaths`**, and duplicate-path checks all use the **normalized** pathType so operators cannot collide with chart routes under nginx.
> 
> Unknown controllers fail at **`helm template`** time. Helm unit tests cover ALB defaults, nginx normalization, wildcard omission, extraPaths behavior, and validation errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad0f0af1922e226a34baf5e59bccef58761ada2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->