### PR TITLE
fix(helm): gate the DD_* env-vars test on those values being set

### DIFF
--- a/helm/litellm-helm/templates/tests/test-env-vars.yaml
+++ b/helm/litellm-helm/templates/tests/test-env-vars.yaml
@@ -1,3 +1,5 @@
+{{- $envVars := .Values.envVars | default dict }}
+{{- if and $envVars.DD_ENV $envVars.DD_SERVICE $envVars.USE_DDTRACE }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -41,3 +43,4 @@ spec:
         - name: USE_DDTRACE
           value: {{ .Values.envVars.USE_DDTRACE | quote }}
   restartPolicy: Never
+{{- end -}}


### PR DESCRIPTION
## TLDR

Problem this solves:

- `helm test <release>` fails on every install that doesn't set Datadog env vars
- The failed test masks the useful `test-connection` test (helm stops at first failure)

How it solves it:

- Render the `test-env-vars` hook pod only when `DD_ENV`, `DD_SERVICE` and `USE_DDTRACE` are actually set in `.Values.envVars`
- CI (`ci/test-values.yaml`) already sets all three, so the chart's own test coverage is unchanged

## User Flow

Before: an operator installs the chart with default values, then runs `helm test` to sanity-check the release, and gets a false failure instead of a real result

1. They run `helm install litellm ./helm/litellm-helm` with no `envVars` set (the chart's own default)
2. They run `helm test litellm --logs`
3. The `litellm-env-test` pod fails with "❌ Environment variable DD_ENV mismatch. Expected: dev_helm, Got: "
4. Because that test failed first, helm never reports the result of the `litellm-test-connection` pod, so the operator has no idea if the proxy is actually reachable

After: the same commands report on the thing the operator actually cares about

1. They run `helm install litellm ./helm/litellm-helm` with no `envVars` set
2. They run `helm test litellm --logs`
3. The `litellm-env-test` pod isn't created at all (its values aren't set), so it can't fail
4. `litellm-test-connection` runs and reports whether the proxy answers, which is the signal the operator was after

## Relevant issues



## Linear ticket



## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

This is a one-file Helm chart template change with no Python code involved, so the pytest-oriented items above don't apply; I verified it with `helm lint` and `helm template` instead (see Screenshots / Proof of Fix).

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Ran locally against `helm/litellm-helm` with Helm v4.2.4.

### Before (e0e249225b1fd2d6620eaad90a13a5a8e62f713d)

#### Default install (no envVars set)

1. `helm template t helm/litellm-helm --show-only templates/tests/test-env-vars.yaml` renders the pod, asserting `DD_ENV`/`DD_SERVICE`/`USE_DDTRACE` against an empty `.Values.envVars`
2. Under a real `helm install` + `helm test`, this pod fails: `❌ Environment variable DD_ENV mismatch. Expected: dev_helm, Got: `

#### CI values (`ci/test-values.yaml`)

1. `helm template litellm helm/litellm-helm -f helm/litellm-helm/ci/test-values.yaml --show-only templates/tests/test-env-vars.yaml` renders the pod with `DD_ENV=dev_helm`, `DD_SERVICE=litellm`, `USE_DDTRACE=true`
2. `helm lint helm/litellm-helm -f helm/litellm-helm/ci/test-values.yaml` passes

### After (558ad86c1f3a83f1e5f0c8194ae165469c22e1a6)

#### Default install (no envVars set)

1. `helm template t helm/litellm-helm --show-only templates/tests/test-env-vars.yaml` now errors `Error: could not find template templates/tests/test-env-vars.yaml in chart` — the pod is not rendered at all
2. `helm template t helm/litellm-helm | grep -c env-test` returns `0`
3. `helm lint helm/litellm-helm` passes (1 chart linted, 0 failed)

#### CI values (`ci/test-values.yaml`)

1. `helm template litellm helm/litellm-helm -f helm/litellm-helm/ci/test-values.yaml --show-only templates/tests/test-env-vars.yaml` renders the pod, byte-for-byte identical to the Before output
2. `helm lint helm/litellm-helm -f helm/litellm-helm/ci/test-values.yaml` passes (1 chart linted, 0 failed)

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- If someone sets only one or two of the three `DD_*` values (not all three), the test now silently skips instead of failing on the missing one; given they're only ever set together today, this trades a confusing false-positive failure for a quieter one

## Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
