### PR TITLE
test(guardrails): expect the end-of-stream scan skip in the CrowdStrike AIDR cadence tests

### DIFF
--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_crowdstrike_aidr.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_crowdstrike_aidr.py
@@ -1703,8 +1703,8 @@ async def _guard_calls_for_stream(handler: CrowdStrikeAIDRHandler, chunk_texts: 
 @pytest.mark.parametrize(
     ("configured", "expected_calls"),
     [
-        ({}, 3),
-        ({"streaming_sampling_rate": 2}, 6),
+        ({}, 2),
+        ({"streaming_sampling_rate": 2}, 5),
         ({"streaming_end_of_stream_only": True}, 1),
         ({"streaming_end_of_stream_only": True, "streaming_sampling_rate": 2}, 1),
     ],
@@ -1712,7 +1712,7 @@ async def _guard_calls_for_stream(handler: CrowdStrikeAIDRHandler, chunk_texts: 
 async def test_streaming_params_from_config_control_output_scan_cadence(
     configured: dict[str, object], expected_calls: int
 ) -> None:
-    """10 chunks: default samples at 5 and 10 plus the final pass, rate 2 samples 5 times plus final, end-of-stream scans once."""
+    """10 chunks: default samples at 5 and 10, rate 2 samples every second chunk, end-of-stream scans once; the closing pass is skipped when the last sample already covered the whole output."""
     handler = _initialize_from_config(mode="post_call", **configured)
 
     assert await _guard_calls_for_stream(handler, list("ABCDEFGHIJ")) == expected_calls


### PR DESCRIPTION
## TLDR

Problem this solves:

- `proxy-endpoints / Run tests` is red on every staging commit since #39386 landed
- Two CrowdStrike AIDR streaming cadence tests still expect the end-of-stream scan #39386 now skips
- Every open PR inherits the failure through its merge-ref CI run

How it solves it:

- Updates the two expected call counts (3 -> 2, 6 -> 5) to the new cadence
- Rewrites the test docstring so it describes why the closing pass is skipped

## User Flow

### Before

The flow fails at step 3: the required `proxy-endpoints / Run tests` check is red on a PR that never touched guardrails, so the Merge button stays locked

1. A contributor pushes a branch off `litellm_internal_staging` and opens a PR at https://github.com/BerriAI/litellm/compare/litellm_internal_staging...their-branch
2. They open https://github.com/BerriAI/litellm/pull/{number}/checks and wait for the `Unit Tests` workflow
3. `proxy-endpoints / Run tests` turns red with `test_crowdstrike_aidr.py::test_streaming_params_from_config_control_output_scan_cadence[configured0-3] - assert 2 == 3` and `[configured1-6] - assert 5 == 6`
4. The Merge button reads "Required statuses must pass before merging", auto-merge never fires, and re-running the job fails the same way
5. They open https://github.com/BerriAI/litellm/actions?query=branch%3Alitellm_internal_staging and see every staging commit since #39386 red on the same job

### After

The flow succeeds: the `proxy-endpoints / Run tests` check goes green on the PR and on every later staging commit

1. A contributor pushes a branch off `litellm_internal_staging` and opens a PR at https://github.com/BerriAI/litellm/compare/litellm_internal_staging...their-branch
2. They open https://github.com/BerriAI/litellm/pull/{number}/checks and wait for the `Unit Tests` workflow
3. `proxy-endpoints / Run tests` turns green, with the two CrowdStrike AIDR cadence tests passing alongside the rest of the job
4. The Merge button unlocks as soon as the other required checks are green, and auto-merge fires
5. They open https://github.com/BerriAI/litellm/actions?query=branch%3Alitellm_internal_staging and see the `Unit Tests` runs green again from this merge onward

## Relevant issues

## Linear ticket

Resolves LIT-6786

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes them faster than a laptop does
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after you push changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

### Before (78ff5ac9cd)

#### proxy-endpoints CI job on staging

1. Open the `Unit Tests` run for staging commit 78ff5ac9cd, job `proxy-endpoints / Run tests`: https://github.com/BerriAI/litellm/actions/runs/33703987674/job/100489072305
2. Observed: `FAILED tests/test_litellm/proxy/guardrails/guardrail_hooks/test_crowdstrike_aidr.py::test_streaming_params_from_config_control_output_scan_cadence[configured0-3] - assert 2 == 3` and `[configured1-6] - assert 5 == 6`, then `2 failed, 8909 passed, 2 skipped, 1 xfailed, 449 warnings, 4 rerun`
3. The same two failures appear on the merge-ref run of every open PR, for example https://github.com/BerriAI/litellm/actions/runs/33704749790/job/100491385000 on #39234

#### Test file at the staging tip

1. `git checkout 78ff5ac9cd && uv run pytest tests/test_litellm/proxy/guardrails/guardrail_hooks/test_crowdstrike_aidr.py::test_streaming_params_from_config_control_output_scan_cadence -q`
2. Observed: `assert 2 == 3`, `assert 5 == 6`, `2 failed, 2 passed`

### After (9f4ea45540)

#### proxy-endpoints CI job on staging

1. Open this PR's `Unit Tests` run, job `proxy-endpoints / Run tests`: run in progress, link added when it finishes
2. Observed: pending

#### Test file at the staging tip

1. `uv run pytest tests/test_litellm/proxy/guardrails/guardrail_hooks/test_crowdstrike_aidr.py -q`
2. Observed: `61 passed`

## Type

✅ Test

## Caveats (if any)

### Low

- Test-only change; #39386 already changed the streaming scan behavior on purpose

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
