### PR TITLE
fix(ui): replace the key detail URL entry when a virtual key is rotated

### DIFF
--- a/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.test.tsx
+++ b/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.test.tsx
@@ -179,6 +179,8 @@ const openFilters = () => fireEvent.click(screen.getByRole("button", { name: "Fi
 const lastKeyParam = (onUrlUpdate: Mock<OnUrlUpdateFunction>) =>
   onUrlUpdate.mock.calls.at(-1)?.[0].searchParams.get("key");
 
+const lastHistoryMode = (onUrlUpdate: Mock<OnUrlUpdateFunction>) => onUrlUpdate.mock.calls.at(-1)?.[0].options.history;
+
 beforeEach(() => {
   vi.clearAllMocks();
 
@@ -374,6 +376,7 @@ it("clicking the key cell deep-links via ?key=", async () => {
   await waitFor(() => {
     expect(lastKeyParam(onUrlUpdate)).toBe(mockKey.token);
   });
+  expect(lastHistoryMode(onUrlUpdate)).toBe("push");
 });
 
 it("renders KeyInfoView when the URL has ?key= for a key on the current page, without refetching it", async () => {
@@ -414,6 +417,7 @@ it("repoints ?key= to the rotated hash once the regenerate dialog is dismissed",
   await waitFor(() => {
     expect(lastKeyParam(onUrlUpdate)).toBe("rotated-hash-456");
   });
+  expect(lastHistoryMode(onUrlUpdate)).toBe("replace");
 });
 
 it("fetches the key by id when the URL has ?key= for a key not in the loaded page", async () => {

--- a/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.tsx
+++ b/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.tsx
@@ -143,7 +143,7 @@ export function VirtualKeysTable({ headerActions }: VirtualKeysTableProps) {
     (updated: Partial<KeyResponse>) => {
       const rotatedToken = updated.token ?? updated.token_id;
       if (!rotatedToken || rotatedToken === selectedKeyId) return;
-      void setSelectedKeyId(rotatedToken);
+      void setSelectedKeyId(rotatedToken, { history: "replace" });
       void refetch();
     },
     [refetch, selectedKeyId, setSelectedKeyId],


### PR DESCRIPTION
## TLDR

Problem this solves:

- Rotating a key leaves the revoked key hash in browser history
- Pressing Back after a rotate shows a "Key not found" error
- The user has to press Back twice to escape it

How it solves it:

- The post-rotate URL update replaces the history entry instead of adding one
- Opening a key from the table still adds one, so Back still works

## User Flow

Before: an admin who rotates a virtual key and then presses Back gets an error for a key that no longer exists

1. They open https://litellm-domain/ui/?page=api-keys and click a key row, landing on https://litellm-domain/ui/api-keys/?key=595c3931...
2. They click "Regenerate Key", then "Regenerate", copy the new secret, and click "Close"
3. The address bar moves to `?key=82d332bc...` and the page shows the rotated key, as expected
4. They press the browser Back button
5. The address bar goes back to `?key=595c3931...`, the pane sits on "Loading key...", and a red "Not Found - Failed to fetch key info - Key not found in database" toast appears
6. Getting out means pressing Back again or clicking "Virtual Keys" in the sidebar

After: the same admin lands back on the key list, because the revoked hash is no longer somewhere they can navigate to

1. They open https://litellm-domain/ui/?page=api-keys and click a key row, landing on https://litellm-domain/ui/api-keys/?key=675621b8...
2. They click "Regenerate Key", then "Regenerate", copy the new secret, and click "Close"
3. The address bar moves to `?key=e6713e54...` and the page shows the rotated key, as before
4. They press the browser Back button
5. The address bar goes to https://litellm-domain/ui/api-keys/, the Virtual Keys table is on screen, and there is no error toast

## Relevant issues

## Linear ticket

Resolves LIT-5736

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/your_test_file.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup for both runs. The dashboard is built from the commit under test and served by the proxy, so the browser gets that commit's code. Regenerate Key is an enterprise control, so this needs a licensed instance.

```bash
cd ui/litellm-dashboard && npm ci && ./build_ui.sh                  # build the UI at the commit under test
python litellm/proxy/proxy_cli.py --config CONFIG.yaml --port 4000  # proxy against a local postgres
curl -s -X POST http://localhost:4000/key/generate \
  -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"key_alias":"lit5736","max_budget":10}'
```

### Before (78ff5ac9c)

1. Open http://localhost:4000/ui/?page=api-keys and click the `lit5736` row. The address bar becomes `http://localhost:4000/ui/api-keys/?key=595c3931f2b05333d8314183924b011ab04c1d12c41613ac6b00b3d3b4a64c0b`
2. Click "Regenerate Key", then "Regenerate" in the dialog. The network tab shows `POST /key/595c3931.../regenerate` -> 200
3. Click "Close". The address bar moves to `?key=82d332bcc543ca770ce72c5f23a9131474e0e758e0756591a53f5daf753a6b71` and `GET /key/info?key=82d332bc...` -> 200. The rotated key renders
4. Press the browser Back button. The address bar goes back to `?key=595c3931...` and the network tab shows the revoked hash being looked up and rejected:

```
GET /key/info?key=595c3931f2b05333d8314183924b011ab04c1d12c41613ac6b00b3d3b4a64c0b -> 404
GET /key/info?key=595c3931f2b05333d8314183924b011ab04c1d12c41613ac6b00b3d3b4a64c0b -> 404
GET /key/info?key=595c3931f2b05333d8314183924b011ab04c1d12c41613ac6b00b3d3b4a64c0b -> 404
```

5. The pane reads "Loading key..." and a red toast reads "Not Found - Failed to fetch key info - Key not found in database"

### After (dc7eb889e)

1. Open http://localhost:4000/ui/?page=api-keys and click the `lit5736` row. The address bar becomes `http://localhost:4000/ui/api-keys/?key=675621b8562a0f724909c3574e02ee3956ea4e2195de01a1e8f8fa8d4293b73e`
2. Click "Regenerate Key", then "Regenerate" in the dialog. The network tab shows `POST /key/675621b8.../regenerate` -> 200
3. Click "Close". The address bar moves to `?key=e6713e54da44426e29f7364e20fbaea415b248609167e3060614e606175aa5ed` and `GET /key/info?key=e6713e54...` -> 200. The rotated key renders, with the new Key ID on the header
4. Open the "Settings" tab, click "Edit Settings", change Max Budget to 42 and click "Save". `POST /key/update` -> 200 and the page shows no error
5. Press the browser Back button. The address bar goes to `http://localhost:4000/ui/api-keys/`, the Virtual Keys table is on screen, no `/key/info` call is made for the revoked hash, and no error toast appears

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Rotating a key opened by a pasted deep link still leaves the app on Back
- That page never had a keys-list entry behind it to return to
