### PR TITLE
test(vector-store): accept embedding_executor in the Bedrock KB hook fake handler

### DIFF
--- a/tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py
+++ b/tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py
@@ -370,6 +370,7 @@ async def test_bedrock_kb_request_body_has_transformed_filters(
         custom_llm_provider,
         litellm_params,
         logging_obj,
+        embedding_executor=None,
         extra_headers=None,
         extra_body=None,
         timeout=None,


### PR DESCRIPTION
## TLDR

Problem this solves:

- Every `run-ci` pipeline off staging fails logging_testing on one Bedrock KB hook test
- #38936 started passing `embedding_executor` to the vector store search handler
- The test's fake handler never learned that parameter, so the hook call blows up
- The hook swallows the error and the test asserts on an empty capture

How it solves it:

- The fake handler takes `embedding_executor` in the same position as the real one
- No production code changes, only the test double

## User Flow

Before: a contributor opens a PR against `litellm_internal_staging` and the CircleCI logging_testing job goes red on a test their change never touched

1. They push a branch, open https://github.com/BerriAI/litellm/pull/39411, and add the `run-ci` label
2. CircleCI starts pipeline https://app.circleci.com/pipelines/github/BerriAI/litellm/88933 for the PR head
3. The logging_testing job at https://app.circleci.com/pipelines/github/BerriAI/litellm/88933/workflows/50855b20-d927-4fcc-bd8b-83f2f73be620/jobs/2148726 finishes with 358 passed and 1 failed: `test_bedrock_kb_request_body_has_transformed_filters` with `AssertionError: Bedrock KB request body was not captured`, and its log shows `fake_async_vector_store_search_handler() got an unexpected keyword argument 'embedding_executor'`
4. They click "Rerun failed jobs" and get the same failure, so the workflow stays red and the PR cannot be handed off as green

After: the same contributor's PR gets a green logging_testing job

1. They push a branch, open a PR against `litellm_internal_staging`, and add the `run-ci` label
2. CircleCI starts a pipeline for the PR head
3. The logging_testing job finishes with 359 passed and the workflow is green

## Relevant issues

## Linear ticket

Resolves LIT-6785

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This is a test-only change, so the proof is the test itself: the same pytest command at the merge base and at the PR tip, plus the CircleCI logging_testing job at the PR tip. Both local runs used the repo venv with the real provider keys from `.env` loaded

### Before (78ff5ac9cd)

1. `uv run pytest tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py -q -k test_bedrock_kb_request_body_has_transformed_filters`
2. Output:
   ```
   LiteLLM:ERROR: vector_store_pre_call_hook.py:171 - Error in VectorStorePreCallHook: litellm.APIConnectionError: test_bedrock_kb_request_body_has_transformed_filters.<locals>.fake_async_vector_store_search_handler() got an unexpected keyword argument 'embedding_executor'
   >       assert "body" in captured_request_body, "Bedrock KB request body was not captured"
   E       AssertionError: Bedrock KB request body was not captured
   E       assert 'body' in {}
   FAILED tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py::test_bedrock_kb_request_body_has_transformed_filters
   1 failed, 12 deselected
   ```
3. The same test on CircleCI, job 2148726 of #39411's pipeline 88933 (a tree that already carries #38936): 358 passed, 1 failed with the same `AssertionError: Bedrock KB request body was not captured`

### After (f81928f7ae)

1. `uv run pytest tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py -q -k test_bedrock_kb_request_body_has_transformed_filters`
2. Output:
   ```
   1 passed, 12 deselected
   ```
3. The logging_testing job at https://app.circleci.com/pipelines/github/BerriAI/litellm/88936/workflows/e223ff24-0f7b-4fcf-bf68-37c85e78e688/jobs/2148834 on this PR's `run-ci` pipeline: 359 passed, including `test_bedrock_kb_request_body_has_transformed_filters`

## Type

✅ Test

## Caveats (if any)

### Low

- Running the whole file locally still shows other failures that CI does not: the Bedrock e2e cases in it need the CI account's knowledge base and a SigV4 credential chain, and on a laptop whose default AWS profile uses `login_session` without `botocore[crt]` they die with `MissingDependencyException` (LIT-6726's bug, unrelated to this test double). The logging_testing job at the PR tip is the run that covers them
- The same pipeline is red on build_docker_database_image, with the 11 proxy jobs downstream of that image not run: that job fails on every pipeline off staging since #39412 (its dashboard test mock imports a JSON file from outside `ui/litellm-dashboard/`, which the Dockerfiles never copy) and is tracked as LIT-6783. This PR touches no Docker or dashboard file

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates a test double’s signature to match the real handler; no runtime or production code paths change.
> 
> **Overview**
> Fixes a **logging_testing** failure where `test_bedrock_kb_request_body_has_transformed_filters` could not capture the Bedrock KB request body.
> 
> After vector store search started passing **`embedding_executor`** into `async_vector_store_search_handler`, the test’s patched **`fake_async_vector_store_search_handler`** rejected that keyword, the pre-call hook swallowed the error, and assertions failed on an empty capture. The fake now accepts **`embedding_executor=None`** in the same position as the real handler so the mock runs and filter transformation assertions still apply.
> 
> **Test-only** change; no production behavior is modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f81928f7aec870adc4491fd19025c16bef4a8cf6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->