### PR TITLE
fix(proxy): give spend logs and callbacks one shared session id

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2504,6 +2504,10 @@ class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
         None,
         description="max request size in MB, if a request is larger than this size it will be rejected",
     )
+    enforce_session_id: bool | None = Field(
+        None,
+        description="reject inference requests that arrive without a session id (a session header or metadata.session_id) with a 400",
+    )
     max_batch_file_size_mb: int | None = Field(
         None,
         description="max batch input file size in MB for /v1/files uploads with purpose=batch, if a file is larger than this size it will be rejected before being forwarded to the provider",

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -73,6 +73,7 @@ _EXPLICIT_SESSION_HEADERS: Final = frozenset({"x-litellm-trace-id", "x-litellm-s
 # ``session-id``/``thread-id``; builds before the codex-api split sent
 # ``session_id``/``conversation_id``. Ordered session before thread.
 _CODEX_SESSION_ID_HEADERS: Final = ("session-id", "session_id", "thread-id", "conversation_id")
+
 # Matches every first-party Codex originator: codex-tui, codex_cli_rs, codex_exec,
 # codex_vscode, "Codex ...". A separator is required so an unrelated "codexfoo" client
 # does not read as Codex.
@@ -1342,6 +1343,24 @@ class LiteLLMProxyRequestSetup:
         return data
 
     @staticmethod
+    def resolve_session_id(caller_session_id: object, enforce_session_id: bool) -> str:
+        from litellm._uuid import uuid
+
+        if caller_session_id:
+            return str(caller_session_id)
+        if enforce_session_id:
+            raise ProxyException(
+                message=(
+                    "No session id provided. Pass a session header (e.g. 'x-litellm-session-id') "
+                    "or 'metadata.session_id'. 'enforce_session_id'=True"
+                ),
+                type=ProxyErrorTypes.bad_request_error,
+                param="session_id",
+                code=400,
+            )
+        return str(uuid.uuid4())
+
+    @staticmethod
     def get_sanitized_user_information_from_key(
         user_api_key_dict: UserAPIKeyAuth,
     ) -> StandardLoggingUserAPIKeyMetadata:
@@ -1818,6 +1837,15 @@ async def add_litellm_data_to_request(
         data=data,
         _metadata_variable_name=_metadata_variable_name,
     )
+
+    metadata_for_session: Final = data.get(_metadata_variable_name)
+    if isinstance(metadata_for_session, dict):
+        resolved_session_id: Final = LiteLLMProxyRequestSetup.resolve_session_id(
+            caller_session_id=metadata_for_session.get("session_id") or data.get("litellm_session_id"),
+            enforce_session_id=general_settings is not None and bool(general_settings.get("enforce_session_id")),
+        )
+        data["litellm_session_id"] = resolved_session_id  # rebind-ok: data is an out-param
+        metadata_for_session["session_id"] = resolved_session_id
 
     # Expose request headers under the metadata field for guardrails (fixes #17477)
     if _metadata_variable_name in data and isinstance(data[_metadata_variable_name], dict):

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -3287,6 +3287,144 @@ def test_add_litellm_metadata_from_anthropic_user_id_dict_ignores_invalid_sessio
     assert data == {"metadata": {"user_id": user_id}}
 
 
+def _session_request(session_id: str | None) -> MagicMock:
+    request_mock = MagicMock(spec=Request)
+    request_mock.url = MagicMock()
+    request_mock.url.path = "/v1/chat/completions"
+    request_mock.url.__str__.return_value = "http://localhost/v1/chat/completions"
+    request_mock.method = "POST"
+    request_mock.query_params = {}
+    request_mock.headers = (
+        {"Content-Type": "application/json", "x-litellm-session-id": session_id}
+        if session_id is not None
+        else {"Content-Type": "application/json"}
+    )
+    request_mock.client = MagicMock()
+    request_mock.client.host = "127.0.0.1"
+    return request_mock
+
+
+def _session_user_api_key_dict() -> UserAPIKeyAuth:
+    return UserAPIKeyAuth(
+        api_key="hashed-key",
+        metadata={},
+        team_metadata={},
+        spend=0.0,
+        max_budget=100.0,
+        model_max_budget={},
+        team_spend=0.0,
+        team_max_budget=200.0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_add_litellm_data_to_request_gives_spend_log_and_callbacks_one_session_id_without_a_header():
+    """No session header: the fabricated id lands in both authoritative fields, so the two systems agree."""
+    import uuid as _uuid
+
+    updated = await add_litellm_data_to_request(
+        data={"model": "gpt-5.4-mini", "metadata": {}},
+        request=_session_request(session_id=None),
+        user_api_key_dict=_session_user_api_key_dict(),
+        proxy_config=MagicMock(),
+        general_settings={},
+        version="test-version",
+    )
+    session_id = updated["metadata"]["session_id"]
+    _uuid.UUID(session_id)
+    assert updated["litellm_session_id"] == session_id
+
+
+@pytest.mark.asyncio
+async def test_add_litellm_data_to_request_promotes_body_session_id_onto_litellm_session_id():
+    """A body metadata.session_id with no header is promoted onto litellm_session_id.
+
+    litellm_session_id is the top spend-log trace_id candidate, so promoting it keeps the spend
+    log from falling back to the router's per-call litellm_trace_id and diverging from callbacks.
+    """
+    updated = await add_litellm_data_to_request(
+        data={"model": "gpt-5.4-mini", "metadata": {"session_id": "body-session"}},
+        request=_session_request(session_id=None),
+        user_api_key_dict=_session_user_api_key_dict(),
+        proxy_config=MagicMock(),
+        general_settings={},
+        version="test-version",
+    )
+    assert updated["litellm_session_id"] == "body-session"
+    assert updated["metadata"]["session_id"] == "body-session"
+
+
+@pytest.mark.asyncio
+async def test_add_litellm_data_to_request_enforce_session_id_rejects_request_without_one():
+    """enforce_session_id on with no session id anywhere is a 400, not a fabricated id."""
+    with pytest.raises(ProxyException) as exc_info:
+        await add_litellm_data_to_request(
+            data={"model": "gpt-5.4-mini", "metadata": {}},
+            request=_session_request(session_id=None),
+            user_api_key_dict=_session_user_api_key_dict(),
+            proxy_config=MagicMock(),
+            general_settings={"enforce_session_id": True},
+            version="test-version",
+        )
+    assert exc_info.value.code in (400, "400")
+
+
+@pytest.mark.asyncio
+async def test_add_litellm_data_to_request_enforce_session_id_keeps_header_session_id_in_both_fields():
+    """enforce_session_id on with a session header passes, and the header id is what both fields carry."""
+    updated = await add_litellm_data_to_request(
+        data={"model": "gpt-5.4-mini", "metadata": {}},
+        request=_session_request(session_id="header-session"),
+        user_api_key_dict=_session_user_api_key_dict(),
+        proxy_config=MagicMock(),
+        general_settings={"enforce_session_id": True},
+        version="test-version",
+    )
+    assert updated["litellm_session_id"] == "header-session"
+    assert updated["metadata"]["session_id"] == "header-session"
+
+
+@pytest.mark.asyncio
+async def test_add_litellm_data_to_request_fabricated_session_id_is_what_the_spend_log_records():
+    """The fabricated id is what the spend log computes, so a lookup across systems agrees.
+
+    Spend tracking derives the spend log session_id from the standard logging payload trace_id,
+    whose top default candidate is litellm_session_id. Pre-call sets that field, so the spend
+    log ignores the router's unrelated per-call litellm_trace_id and matches the callbacks.
+    """
+    from litellm.litellm_core_utils.litellm_logging import StandardLoggingPayloadSetup
+    from litellm.proxy.spend_tracking.spend_tracking_utils import _get_session_id_for_spend_log
+
+    updated = await add_litellm_data_to_request(
+        data={"model": "gpt-5.4-mini", "metadata": {}},
+        request=_session_request(session_id=None),
+        user_api_key_dict=_session_user_api_key_dict(),
+        proxy_config=MagicMock(),
+        general_settings={},
+        version="test-version",
+    )
+    fabricated = updated["metadata"]["session_id"]
+
+    class _StubLogging:
+        litellm_trace_id = "unrelated-per-call-trace"
+        litellm_session_id = ""
+
+    litellm_params = {
+        "litellm_session_id": updated["litellm_session_id"],
+        "litellm_trace_id": "router-per-call-trace-id",
+        "metadata": {"session_id": fabricated},
+    }
+    resolved_trace_id = StandardLoggingPayloadSetup.get_standard_logging_payload_trace_id(
+        logging_obj=_StubLogging(), litellm_params=litellm_params
+    )
+    assert resolved_trace_id == fabricated
+
+    spend_log_session_id = _get_session_id_for_spend_log(
+        kwargs={}, standard_logging_payload={"trace_id": resolved_trace_id}
+    )
+    assert spend_log_session_id == fabricated
+
+
 def test_add_litellm_metadata_from_request_headers_explicit_header_beats_generic():
     """Explicit x-litellm-trace-id wins over a generic x-*-session-id header."""
     headers = {

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -25530,6 +25530,11 @@ export interface components {
              */
             enforce_fallback_model_access?: boolean | null;
             /**
+             * Enforce Session Id
+             * @description reject inference requests that arrive without a session id (a session header or metadata.session_id) with a 400
+             */
+            enforce_session_id?: boolean | null;
+            /**
              * Forward Client Headers To Llm Api
              * @description If True, forwards client headers (e.g. Authorization) to the LLM API. Required for Claude Code with Max subscription.
              */


### PR DESCRIPTION
## TLDR

Problem this solves:

- Without a session header, spend logs and Langfuse disagree on session id
- A session id read from the spend log finds no Langfuse trace
- No way to require a session id on every request

How it solves it:

- Proxy picks one session id per request before callbacks run
- The same id lands in the spend log and in Langfuse
- New opt-in `enforce_session_id` rejects session-less requests with a 400

Assumption: at pre-call, share one session id between the spend log and callbacks, with no provenance marker since neither surface shows one, and make `enforce_session_id` opt-in so it 400s before any id is fabricated

## User Flow

Before: a developer cross-referencing a request's session between the spend logs and Langfuse finds no matching Langfuse trace

1. They send POST https://litellm-domain/v1/chat/completions with a normal chat body and no session header
2. They open https://litellm-domain/spend/logs?request_id=<request id> and read the request's `session_id`, a uuid like `5fb7432e-ed93-4a47-a73e-d78c4e47163b`
3. They query Langfuse GET https://cloud.langfuse.com/api/public/traces?sessionId=5fb7432e-ed93-4a47-a73e-d78c4e47163b and get `{"data": []}`, zero traces
4. They open that call's Langfuse trace and its `sessionId` is `null`, so the session cannot be matched across the two systems

After: the same cross-reference now finds the request's Langfuse trace under that session id

1. They send the same POST https://litellm-domain/v1/chat/completions with a normal chat body and no session header
2. https://litellm-domain/spend/logs?request_id=<request id> shows the request's `session_id`, a uuid like `5fb7432e-ed93-4a47-a73e-d78c4e47163b`
3. Langfuse GET https://cloud.langfuse.com/api/public/traces?sessionId=5fb7432e-ed93-4a47-a73e-d78c4e47163b now returns one trace, that request's call
4. That trace's `sessionId` equals the spend log's `session_id`, so the session lines up across both systems

## Relevant issues

## Linear ticket

Resolves LIT-6694

## Type

🆕 New Feature
🐛 Bug Fix

## Screenshots / Proof of Fix

QA in progress: before at the merge base and after at the PR tip, covering /v1/chat/completions, /v1/responses and /v1/messages without a session header, the same three with a header, and the `enforce_session_id` 400/200 flow.

## Caveats (if any)

### Low

- `enforce_session_id` defaults off, so existing behavior is unchanged
- A fabricated id carries no marker distinguishing it from a client-supplied one

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
