### PR TITLE
fix(ui): stop the create team form resetting organization and models

### DIFF
--- a/ui/litellm-dashboard/eslint-suppressions.json
+++ b/ui/litellm-dashboard/eslint-suppressions.json
@@ -1399,9 +1399,6 @@
     },
     "prefer-const": {
       "count": 2
-    },
-    "react-hooks/set-state-in-effect": {
-      "count": 1
     }
   },
   "src/components/TeamsPage/teamTableColumns.tsx": {

--- a/ui/litellm-dashboard/src/components/Teams.test.tsx
+++ b/ui/litellm-dashboard/src/components/Teams.test.tsx
@@ -1619,6 +1619,26 @@ describe("Teams - the create form keeps the organization and models picks while 
     expect(orgField()).toBeEnabled();
   });
 
+  it("refuses to create the team in an organization the admin has lost access to", async () => {
+    const user = userEvent.setup();
+    const orgAdminOrgs = ORGS.map((org) => ({ ...org, members: [{ user_id: "user-123", user_role: "org_admin" }] }));
+    mockUseOrganizations.mockReturnValue({ data: orgAdminOrgs });
+    renderWithQueryClient(<Teams accessToken="test-token" userID="user-123" userRole="Internal User" />);
+    await openCreateModal();
+
+    fireEvent.change(screen.getByTestId("team-name-input"), { target: { value: "Revoked Team" } });
+    await chooseSelectOption(user, orgField(), /Org 1/);
+
+    mockUseOrganizations.mockReturnValue({ data: [orgAdminOrgs[1]] });
+    fireEvent.click(screen.getByText("Additional Settings"));
+
+    const submitButtons = screen.getAllByRole("button", { name: /create team/i });
+    fireEvent.click(submitButtons[submitButtons.length - 1]);
+
+    await screen.findByText(/no longer create teams in this organization/i);
+    expect(teamCreateCall).not.toHaveBeenCalled();
+  });
+
   it("starts the form clean again when the modal is closed and reopened", async () => {
     const user = userEvent.setup();
     renderWithQueryClient(<Teams accessToken="test-token" userID="user-123" userRole="Admin" />);

--- a/ui/litellm-dashboard/src/components/Teams.test.tsx
+++ b/ui/litellm-dashboard/src/components/Teams.test.tsx
@@ -15,6 +15,7 @@ import {
   teamCreateCall,
 } from "./networking";
 import Teams from "./Teams";
+import { chooseSelectOption } from "../../tests/test-utils";
 
 const can = vi.fn();
 vi.mock("@/app/(dashboard)/hooks/useCan", () => ({
@@ -1486,5 +1487,150 @@ describe("Teams - the exact bytes the create call sends", () => {
 
     expect(await screen.findByText("Please input a team name")).toBeInTheDocument();
     expect(teamCreateCall).not.toHaveBeenCalled();
+  });
+});
+
+describe("Teams - the create form keeps the organization and models picks while it is open", () => {
+  const ORGS = [
+    { organization_id: "org-1", organization_alias: "Org 1", models: [], members: [] },
+    { organization_id: "org-2", organization_alias: "Org 2", models: [], members: [] },
+  ];
+
+  const orgField = () => screen.getByRole("combobox", { name: /organization/i });
+  const modelsField = () => screen.getByTestId("create-team-models-select");
+
+  const openCreateModal = async () => {
+    act(() => {
+      fireEvent.click(screen.getAllByRole("button", { name: /create team/i })[0]);
+    });
+    await screen.findByLabelText(/team name/i);
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTeamInfoView.mockClear();
+    vi.mocked(fetchAvailableModelsForTeamOrKey).mockResolvedValue(["gpt-4", "gpt-3.5-turbo"]);
+    vi.mocked(fetchMCPAccessGroups).mockResolvedValue([]);
+    vi.mocked(getGuardrailsList).mockResolvedValue({ guardrails: [] });
+    vi.mocked(getDefaultTeamSettings).mockResolvedValue({ values: {} });
+    mockUseOrganizations.mockReturnValue({ data: ORGS });
+  });
+
+  it("keeps both picks when the organizations list comes back changed from a refetch", async () => {
+    const user = userEvent.setup();
+    renderWithQueryClient(<Teams accessToken="test-token" userID="user-123" userRole="Admin" />);
+    await openCreateModal();
+
+    await chooseSelectOption(user, orgField(), /Org 1/);
+    fireEvent.change(modelsField(), { target: { value: "gpt-4" } });
+
+    mockUseOrganizations.mockReturnValue({ data: ORGS.map((org) => ({ ...org, spend: 1 })) });
+    fireEvent.click(screen.getByText("Additional Settings"));
+
+    expect(orgField()).toHaveValue("Org 1");
+    expect(modelsField()).toHaveValue("gpt-4");
+  });
+
+  it("keeps models picked before the available models finish loading", async () => {
+    let resolveModels: (models: string[]) => void = () => {};
+    vi.mocked(fetchAvailableModelsForTeamOrKey).mockReturnValue(
+      new Promise<string[]>((resolve) => {
+        resolveModels = resolve;
+      }),
+    );
+    renderWithQueryClient(<Teams accessToken="test-token" userID="user-123" userRole="Admin" />);
+    await openCreateModal();
+
+    fireEvent.change(modelsField(), { target: { value: "gpt-4" } });
+    await act(async () => {
+      resolveModels(["gpt-4", "gpt-3.5-turbo"]);
+    });
+
+    expect(modelsField()).toHaveValue("gpt-4");
+  });
+
+  it("clears the models pick when the organization is changed, since models are org scoped", async () => {
+    const user = userEvent.setup();
+    renderWithQueryClient(<Teams accessToken="test-token" userID="user-123" userRole="Admin" />);
+    await openCreateModal();
+
+    await chooseSelectOption(user, orgField(), /Org 1/);
+    fireEvent.change(modelsField(), { target: { value: "gpt-4" } });
+    await chooseSelectOption(user, orgField(), /Org 2/);
+
+    await waitFor(() => expect(orgField()).toHaveValue("Org 2"));
+    expect(modelsField()).toHaveValue("");
+  });
+
+  it("keeps the models pick when the same organization is chosen again", async () => {
+    const user = userEvent.setup();
+    renderWithQueryClient(<Teams accessToken="test-token" userID="user-123" userRole="Admin" />);
+    await openCreateModal();
+
+    await chooseSelectOption(user, orgField(), /Org 1/);
+    fireEvent.change(modelsField(), { target: { value: "gpt-4" } });
+    await chooseSelectOption(user, orgField(), /Org 1/);
+
+    expect(orgField()).toHaveValue("Org 1");
+    expect(modelsField()).toHaveValue("gpt-4");
+  });
+
+  it("still preselects the only organization an org admin can create teams in", async () => {
+    mockUseOrganizations.mockReturnValue({
+      data: [
+        {
+          organization_id: "org-1",
+          organization_alias: "Org 1",
+          models: [],
+          members: [{ user_id: "user-123", user_role: "org_admin" }],
+        },
+      ],
+    });
+    renderWithQueryClient(<Teams accessToken="test-token" userID="user-123" userRole="Internal User" />);
+    await openCreateModal();
+
+    expect(orgField()).toHaveValue("Org 1");
+    expect(orgField()).toBeDisabled();
+  });
+
+  it("leaves an org admin able to pick when their admin orgs narrow to one while the form is open", async () => {
+    const orgAdminOrgs = [
+      {
+        organization_id: "org-1",
+        organization_alias: "Org 1",
+        models: [],
+        members: [{ user_id: "user-123", user_role: "org_admin" }],
+      },
+      {
+        organization_id: "org-2",
+        organization_alias: "Org 2",
+        models: [],
+        members: [{ user_id: "user-123", user_role: "org_admin" }],
+      },
+    ];
+    mockUseOrganizations.mockReturnValue({ data: orgAdminOrgs });
+    renderWithQueryClient(<Teams accessToken="test-token" userID="user-123" userRole="Internal User" />);
+    await openCreateModal();
+    expect(orgField()).toHaveValue("");
+
+    mockUseOrganizations.mockReturnValue({ data: [orgAdminOrgs[0]] });
+    fireEvent.click(screen.getByText("Additional Settings"));
+
+    expect(orgField()).toBeEnabled();
+  });
+
+  it("starts the form clean again when the modal is closed and reopened", async () => {
+    const user = userEvent.setup();
+    renderWithQueryClient(<Teams accessToken="test-token" userID="user-123" userRole="Admin" />);
+    await openCreateModal();
+
+    await chooseSelectOption(user, orgField(), /Org 1/);
+    fireEvent.change(modelsField(), { target: { value: "gpt-4" } });
+    fireEvent.click(screen.getByRole("button", { name: /^close$/i }));
+    await waitFor(() => expect(screen.queryByLabelText(/team name/i)).not.toBeInTheDocument());
+
+    await openCreateModal();
+    expect(orgField()).toHaveValue("");
+    expect(modelsField()).toHaveValue("");
   });
 });

--- a/ui/litellm-dashboard/src/components/Teams.test.tsx
+++ b/ui/litellm-dashboard/src/components/Teams.test.tsx
@@ -1643,7 +1643,7 @@ describe("Teams - the create form keeps the organization and models picks while 
     const user = userEvent.setup();
     const orgAdminOrgs = ORGS.map((org) => ({ ...org, members: [{ user_id: "user-123", user_role: "org_admin" }] }));
     mockUseOrganizations.mockReturnValue({ data: orgAdminOrgs });
-    vi.mocked(teamCreateCall).mockResolvedValue({
+    const createdTeam = {
       team_id: "new-team-1",
       team_alias: "Recovered Team",
       models: [],
@@ -1651,7 +1651,8 @@ describe("Teams - the create form keeps the organization and models picks while 
       keys: [],
       members_with_roles: [],
       spend: 0,
-    });
+    };
+    vi.mocked(teamCreateCall).mockResolvedValue(createdTeam);
     renderWithQueryClient(<Teams accessToken="test-token" userID="user-123" userRole="Internal User" />);
     await openCreateModal();
 

--- a/ui/litellm-dashboard/src/components/Teams.test.tsx
+++ b/ui/litellm-dashboard/src/components/Teams.test.tsx
@@ -1639,6 +1639,41 @@ describe("Teams - the create form keeps the organization and models picks while 
     expect(teamCreateCall).not.toHaveBeenCalled();
   });
 
+  it("lets the admin switch to the one organization left after losing access to their pick", async () => {
+    const user = userEvent.setup();
+    const orgAdminOrgs = ORGS.map((org) => ({ ...org, members: [{ user_id: "user-123", user_role: "org_admin" }] }));
+    mockUseOrganizations.mockReturnValue({ data: orgAdminOrgs });
+    vi.mocked(teamCreateCall).mockResolvedValue({
+      team_id: "new-team-1",
+      team_alias: "Recovered Team",
+      models: [],
+      organization_id: "org-2",
+      keys: [],
+      members_with_roles: [],
+      spend: 0,
+    });
+    renderWithQueryClient(<Teams accessToken="test-token" userID="user-123" userRole="Internal User" />);
+    await openCreateModal();
+
+    fireEvent.change(screen.getByTestId("team-name-input"), { target: { value: "Recovered Team" } });
+    await chooseSelectOption(user, orgField(), /Org 1/);
+
+    mockUseOrganizations.mockReturnValue({ data: [orgAdminOrgs[1]] });
+    fireEvent.click(screen.getByText("Additional Settings"));
+
+    expect(orgField()).toBeEnabled();
+    await chooseSelectOption(user, orgField(), /Org 2/);
+    const submitButtons = screen.getAllByRole("button", { name: /create team/i });
+    fireEvent.click(submitButtons[submitButtons.length - 1]);
+
+    await waitFor(() =>
+      expect(teamCreateCall).toHaveBeenCalledWith(
+        "test-token",
+        expect.objectContaining({ team_alias: "Recovered Team", organization_id: "org-2" }),
+      ),
+    );
+  });
+
   it("starts the form clean again when the modal is closed and reopened", async () => {
     const user = userEvent.setup();
     renderWithQueryClient(<Teams accessToken="test-token" userID="user-123" userRole="Admin" />);

--- a/ui/litellm-dashboard/src/components/Teams.tsx
+++ b/ui/litellm-dashboard/src/components/Teams.tsx
@@ -215,17 +215,33 @@ const Teams: React.FC<TeamProps> = ({ accessToken, userID, userRole, premiumUser
   const [agentSettingsOpen, setAgentSettingsOpen] = useState(false);
   const [searchToolSettingsOpen, setSearchToolSettingsOpen] = useState(false);
 
+  const adminOrgs = useMemo(
+    () => getAdminOrganizations(userRole, userID, organizations),
+    [userRole, userID, organizations],
+  );
+
   const teamCreateSchema = useMemo(
     () =>
       teamCreateFieldsSchema.superRefine((values, ctx) => {
         if (isOrgAdmin && !values.organization_id) {
           ctx.addIssue({ code: "custom", message: SUPPRESSED_BY_DESCRIPTION, path: ["organization_id"] });
         }
+        const organizationIsStillPickable =
+          values.organization_id == null ||
+          organizations == null ||
+          adminOrgs.some((org) => org.organization_id === values.organization_id);
+        if (!organizationIsStillPickable) {
+          ctx.addIssue({
+            code: "custom",
+            message: "You can no longer create teams in this organization",
+            path: ["organization_id"],
+          });
+        }
         if (additionalSettingsOpen && !isParsableJson(values.secret_manager_settings)) {
           ctx.addIssue({ code: "custom", message: SUPPRESSED_BY_DESCRIPTION, path: ["secret_manager_settings"] });
         }
       }),
-    [isOrgAdmin, additionalSettingsOpen],
+    [isOrgAdmin, additionalSettingsOpen, adminOrgs, organizations],
   );
 
   const form = useZodForm(teamCreateSchema, { defaultValues: EMPTY_TEAM_CREATE_VALUES });
@@ -298,8 +314,6 @@ const Teams: React.FC<TeamProps> = ({ accessToken, userID, userRole, premiumUser
   }, [accessToken, canViewPolicies]);
 
   const openCreateTeamModal = () => {
-    const adminOrgs = getAdminOrganizations(userRole, userID, organizations);
-
     // Org admins must scope a team to an org, so with exactly one we preselect it.
     // Proxy admins can create org-less teams, so the field stays optional regardless of org count.
     if (isOrgAdmin && adminOrgs.length === 1) {
@@ -682,7 +696,6 @@ const Teams: React.FC<TeamProps> = ({ accessToken, userID, userRole, premiumUser
                     )}
                   </FormField>
                   {(() => {
-                    const adminOrgs = getAdminOrganizations(userRole, userID, organizations);
                     const isSingleOrg = adminOrgs.length === 1;
                     const hasNoOrgs = adminOrgs.length === 0;
 

--- a/ui/litellm-dashboard/src/components/Teams.tsx
+++ b/ui/litellm-dashboard/src/components/Teams.tsx
@@ -208,7 +208,6 @@ const Teams: React.FC<TeamProps> = ({ accessToken, userID, userRole, premiumUser
   const queryClient = useQueryClient();
   const refreshTeams = () => queryClient.invalidateQueries({ queryKey: teamsTableKeys.all });
   const [currentOrg] = useState<Organization | null>(null);
-  const [currentOrgForCreateTeam, setCurrentOrgForCreateTeam] = useState<Organization | null>(null);
 
   const isOrgAdmin = userRole !== "Admin";
   const [additionalSettingsOpen, setAdditionalSettingsOpen] = useState(false);
@@ -264,28 +263,6 @@ const Teams: React.FC<TeamProps> = ({ accessToken, userID, userRole, premiumUser
     ? `Default: ${getBudgetDurationLabel(defaultBudgetDuration)} (${defaultBudgetDuration})`
     : "n/a";
 
-  useEffect(() => {
-    form.setValue("models", []);
-  }, [currentOrgForCreateTeam, userModels]);
-
-  // Handle organization preselection when modal opens
-  useEffect(() => {
-    if (isTeamModalVisible) {
-      const adminOrgs = getAdminOrganizations(userRole, userID, organizations);
-
-      // Org admins must scope a team to an org, so with exactly one we preselect it.
-      // Proxy admins can create org-less teams, so the field stays optional regardless of org count.
-      if (isOrgAdmin && adminOrgs.length === 1) {
-        const org = adminOrgs[0];
-        form.setValue("organization_id", org.organization_id);
-        setCurrentOrgForCreateTeam(org);
-      } else {
-        form.setValue("organization_id", currentOrg?.organization_id || null);
-        setCurrentOrgForCreateTeam(currentOrg);
-      }
-    }
-  }, [isTeamModalVisible, isOrgAdmin, userRole, userID, organizations, currentOrg]);
-
   // Add this useEffect to fetch guardrails
   useEffect(() => {
     const fetchGuardrails = async () => {
@@ -319,6 +296,28 @@ const Teams: React.FC<TeamProps> = ({ accessToken, userID, userRole, premiumUser
     fetchGuardrails();
     if (canViewPolicies) fetchPolicies();
   }, [accessToken, canViewPolicies]);
+
+  const openCreateTeamModal = () => {
+    const adminOrgs = getAdminOrganizations(userRole, userID, organizations);
+
+    // Org admins must scope a team to an org, so with exactly one we preselect it.
+    // Proxy admins can create org-less teams, so the field stays optional regardless of org count.
+    if (isOrgAdmin && adminOrgs.length === 1) {
+      form.setValue("organization_id", adminOrgs[0].organization_id);
+    }
+    setIsTeamModalVisible(true);
+  };
+
+  const selectCreateTeamOrganization = (
+    next: string,
+    currentOrganizationId: string | null,
+    onChange: (organizationId: string | null) => void,
+  ) => {
+    const nextOrganizationId = next === "" ? null : next;
+    if (nextOrganizationId === currentOrganizationId) return;
+    onChange(nextOrganizationId);
+    form.setValue("models", []);
+  };
 
   const resetCreateForm = () => {
     form.reset(EMPTY_TEAM_CREATE_VALUES);
@@ -636,7 +635,7 @@ const Teams: React.FC<TeamProps> = ({ accessToken, userID, userRole, premiumUser
             subtitle="Manage teams, members, and their access to models and budgets"
             primaryAction={
               canCreateOrManageTeams(userRole, userID, organizations) ? (
-                <UIButton onClick={() => setIsTeamModalVisible(true)} data-testid="create-team-button">
+                <UIButton onClick={openCreateTeamModal} data-testid="create-team-button">
                   <Plus className="size-4" />
                   Create Team
                 </UIButton>
@@ -715,18 +714,13 @@ const Teams: React.FC<TeamProps> = ({ accessToken, userID, userRole, premiumUser
                                 label: org.organization_alias ?? "",
                                 sublabel: org.organization_id ?? "",
                               }))}
-                              disabled={isOrgAdmin && isSingleOrg}
+                              disabled={isOrgAdmin && isSingleOrg && (value ?? "") !== ""}
                               allowClear={!isOrgAdmin}
                               placeholder={
                                 hasNoOrgs ? "No organizations available" : "Search or select an Organization"
                               }
                               emptyText="No organizations available"
-                              onValueChange={(next) => {
-                                onChange(next === "" ? null : next);
-                                setCurrentOrgForCreateTeam(
-                                  adminOrgs.find((org) => org.organization_id === next) ?? null,
-                                );
-                              }}
+                              onValueChange={(next) => selectCreateTeamOrganization(next, value ?? null, onChange)}
                             />
                           )}
                         </FormField>

--- a/ui/litellm-dashboard/src/components/Teams.tsx
+++ b/ui/litellm-dashboard/src/components/Teams.tsx
@@ -698,6 +698,7 @@ const Teams: React.FC<TeamProps> = ({ accessToken, userID, userRole, premiumUser
                   {(() => {
                     const isSingleOrg = adminOrgs.length === 1;
                     const hasNoOrgs = adminOrgs.length === 0;
+                    const soleOrganizationId = isSingleOrg ? adminOrgs[0].organization_id ?? null : null;
 
                     return (
                       <>
@@ -727,7 +728,7 @@ const Teams: React.FC<TeamProps> = ({ accessToken, userID, userRole, premiumUser
                                 label: org.organization_alias ?? "",
                                 sublabel: org.organization_id ?? "",
                               }))}
-                              disabled={isOrgAdmin && isSingleOrg && (value ?? "") !== ""}
+                              disabled={isOrgAdmin && soleOrganizationId !== null && value === soleOrganizationId}
                               allowClear={!isOrgAdmin}
                               placeholder={
                                 hasNoOrgs ? "No organizations available" : "Search or select an Organization"


### PR DESCRIPTION
## TLDR

Problem this solves:

- Create Team blanks the Organization pick mid-form
- The Models pick gets wiped along with it
- Users re-enter both, or learn to fill them last

How it solves it:

- Preselect the organization once, when the modal opens
- Clear models only when the user picks a different organization
- Refuse the create if that organization is no longer available

## User Flow

Before: an admin filling out Create Team loses the Organization and Models picks partway through the form

1. They open http://localhost:4000/ui/?page=teams and click Create Team
2. They type a team name, pick an Organization, then pick a Model
3. They switch to another browser tab to copy an id, then come back to finish the form
4. Organization has gone back to "Search or select an Organization" and Models back to "Select Models", while Team Name is still filled in
5. They re-enter both fields, or learn to leave those two for last

After: the same picks are still there when they come back

1. They open http://localhost:4000/ui/?page=teams and click Create Team
2. They type a team name, pick an Organization, then pick a Model
3. They switch to another browser tab, then come back to finish the form
4. Organization and Models still show what they picked, and the team saves with them
5. Picking a different Organization still empties Models, since models are scoped to the organization
6. If they lose access to the picked Organization while the form is open, Create Team stops and says so under that field instead of the proxy rejecting the request, and they can pick another Organization right away

## Relevant issues

Reported by a customer (Pylon #8004)

## Linear ticket

Resolves LIT-6541

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup, a real proxy on postgres with two organizations, and the dashboard dev server pointed at it. Chromium drives the form, so every step below is a real click in a real browser

```bash
service postgresql start
DATABASE_URL="postgresql://...:5432/litellm_proof" LITELLM_MASTER_KEY=sk-1234 UI_USERNAME=admin UI_PASSWORD=sk-1234 \
  uv run python litellm/proxy/proxy_cli.py --config proof_config.yaml --port 4111
for name in "Research Org" "Platform Org"; do
  curl -s -X POST http://127.0.0.1:4111/organization/new -H 'Authorization: Bearer sk-1234' \
    -H 'content-type: application/json' -d "{\"organization_alias\":\"$name\",\"models\":[\"proof-gpt-4o\",\"proof-gpt-4o-mini\"]}"
done
NEXT_PUBLIC_BASE_URL=http://localhost:4111 npx next dev --port 3111
```

The browser script opens Create Team, picks Organization then Models, has another admin touch the org list, fires the window refocus that makes react-query refetch it, and reads both fields back

### Before (78ff5ac9c)

1. Run the script against the untouched merge base

```
[before] filled in     -> organization='Research Org' models='proof-gpt-4o'
[before] after refetch -> organization='' models=''
```

2. Both fields are empty. Team Name still holds "Proof Team", so it is only these two that reset

### After (6a50f2f35)

#### The two picks survive a refetch

1. Run the same script against this branch

```
[after] filled in     -> organization='Research Org' models='proof-gpt-4o'
[after] after refetch -> organization='Research Org' models='proof-gpt-4o'
```

#### Changing the organization still clears models, and the team saves with what is on screen

1. Pick an organization and a model, switch to the other organization, re-pick models, re-pick the same organization, refocus the window, then submit

```
picked Research Org + proof-gpt-4o -> ('Research Org', 'proof-gpt-4o')
switched to Platform Org           -> ('Platform Org', '')                (models cleared on a real org change)
re-picked the same org             -> ('Platform Org', 'proof-gpt-4o-mini') (models kept)
after a window refocus             -> ('Platform Org', 'proof-gpt-4o-mini')
```

2. Read the created team back from the proxy

```
created team -> alias='Adjacent Proof Team' organization_id='30aaa3c6-aaa7-42f0-b8fa-12819d5a782b' models=['proof-gpt-4o-mini']
                (Platform Org is 30aaa3c6-aaa7-42f0-b8fa-12819d5a782b)
```

To reproduce by hand: open http://localhost:4000/ui/?page=teams, click Create Team, fill Team Name, pick an Organization and a Model, switch to another browser tab and come back, and both picks should still be there

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- The same effect-driven reset pattern still exists in the create key form

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR