### PR TITLE
test: add mistral ocr transformation parity coverage

### DIFF
--- a/litellm-rust/crates/core/src/providers/mistral/ocr/transformation.rs
+++ b/litellm-rust/crates/core/src/providers/mistral/ocr/transformation.rs
@@ -186,68 +186,180 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn supported_params_match_python_mistral_ocr_config() {
+    fn extract_header_is_a_supported_ocr_param() {
+        assert!(supported_ocr_params().contains(&"extract_header"));
+    }
+
+    #[test]
+    fn extract_footer_is_a_supported_ocr_param() {
+        assert!(supported_ocr_params().contains(&"extract_footer"));
+    }
+
+    #[test]
+    fn existing_ocr_params_remain_supported() {
+        for param in [
+            "pages",
+            "include_image_base64",
+            "image_limit",
+            "image_min_size",
+            "bbox_annotation_format",
+            "document_annotation_format",
+        ] {
+            assert!(supported_ocr_params().contains(&param));
+        }
+    }
+
+    #[test]
+    fn map_ocr_params_forwards_extract_header() {
+        let params = json!({"extract_header": true});
         assert_eq!(
-            supported_ocr_params(),
-            &[
-                "pages",
-                "include_image_base64",
-                "image_limit",
-                "image_min_size",
-                "bbox_annotation_format",
-                "document_annotation_format",
-                "document_annotation_prompt",
-                "extract_header",
-                "extract_footer",
-                "table_format",
-                "confidence_scores_granularity",
-                "include_blocks",
-                "id",
-            ]
+            map_ocr_params(params.as_object().unwrap()),
+            params.as_object().unwrap().clone()
+        );
+    }
+
+    #[test]
+    fn map_ocr_params_forwards_extract_footer() {
+        let params = json!({"extract_footer": true});
+        assert_eq!(
+            map_ocr_params(params.as_object().unwrap()),
+            params.as_object().unwrap().clone()
+        );
+    }
+
+    #[test]
+    fn map_ocr_params_forwards_extract_header_and_footer() {
+        let params = json!({"extract_header": true, "extract_footer": false});
+        assert_eq!(
+            map_ocr_params(params.as_object().unwrap()),
+            params.as_object().unwrap().clone()
         );
     }
 
     #[test]
     fn map_ocr_params_drops_unknown_params() {
-        let params = json!({
-            "extract_header": true,
-            "unsupported_param": "value",
-            "pages": [0, 1]
-        });
+        let params = json!({"extract_header": true, "unsupported_param": "value"});
         let mapped = map_ocr_params(params.as_object().unwrap());
-
         assert_eq!(mapped.get("extract_header"), Some(&json!(true)));
-        assert_eq!(mapped.get("pages"), Some(&json!([0, 1])));
         assert!(!mapped.contains_key("unsupported_param"));
     }
 
     #[test]
-    fn transform_ocr_request_builds_mistral_body() {
+    fn new_ocr_params_are_supported() {
+        for param in [
+            "table_format",
+            "confidence_scores_granularity",
+            "document_annotation_prompt",
+            "include_blocks",
+            "id",
+        ] {
+            assert!(supported_ocr_params().contains(&param));
+        }
+    }
+
+    #[test]
+    fn map_ocr_params_forwards_new_ocr_params() {
+        for (param, value) in [
+            ("table_format", json!("html")),
+            ("confidence_scores_granularity", json!("word")),
+            (
+                "document_annotation_prompt",
+                json!("Extract all invoice line items"),
+            ),
+            ("include_blocks", json!(true)),
+            ("id", json!("req-123")),
+        ] {
+            let params = json!({param: value});
+            assert_eq!(
+                map_ocr_params(params.as_object().unwrap()),
+                params.as_object().unwrap().clone()
+            );
+        }
+    }
+
+    #[test]
+    fn transform_ocr_request_includes_each_optional_param() {
+        let document = json!({
+            "type": "document_url",
+            "document_url": "https://example.com/doc.pdf"
+        });
+        for (param, value) in [
+            ("table_format", json!("html")),
+            ("confidence_scores_granularity", json!("word")),
+            (
+                "document_annotation_prompt",
+                json!("Extract all invoice line items"),
+            ),
+            ("id", json!("req-123")),
+            ("extract_header", json!(true)),
+            ("include_blocks", json!(true)),
+            ("pages", json!([0, 1])),
+        ] {
+            let result = transform_ocr_request(
+                "mistral-ocr-latest",
+                document.clone(),
+                json!({param: value}).as_object().unwrap().clone(),
+            )
+            .expect("request should transform");
+            assert_eq!(result.data.get(param), Some(&value));
+            assert_eq!(result.data.get("model"), Some(&json!("mistral-ocr-latest")));
+            assert_eq!(result.data.get("document"), Some(&document));
+            assert_eq!(result.files, None);
+        }
+    }
+
+    #[test]
+    fn transform_ocr_request_includes_multiple_new_params() {
         let document = json!({
             "type": "document_url",
             "document_url": "https://example.com/doc.pdf"
         });
         let optional_params = json!({
-            "include_image_base64": true,
-            "table_format": "html"
+            "table_format": "html",
+            "confidence_scores_granularity": "page",
+            "extract_header": true
         })
         .as_object()
         .unwrap()
         .clone();
-
-        let result = transform_ocr_request("mistral-ocr-latest", document.clone(), optional_params)
+        let result = transform_ocr_request("mistral-ocr-latest", document, optional_params)
             .expect("request should transform");
-
+        assert_eq!(result.data.get("table_format"), Some(&json!("html")));
         assert_eq!(
-            result.data,
-            json!({
-                "model": "mistral-ocr-latest",
-                "document": document,
-                "include_image_base64": true,
-                "table_format": "html"
-            })
+            result.data.get("confidence_scores_granularity"),
+            Some(&json!("page"))
         );
-        assert_eq!(result.files, None);
+        assert_eq!(result.data.get("extract_header"), Some(&json!(true)));
+    }
+
+    #[test]
+    fn transform_ocr_response_preserves_blocks_and_confidence_scores() {
+        let blocks = json!([{"type": "title", "content": "Invoice"}]);
+        let confidence_scores = json!({"page": 0.98});
+        let response = json!({
+            "pages": [{"index": 0, "markdown": "# Invoice", "blocks": blocks, "confidence_scores": confidence_scores}],
+            "model": "mistral-ocr-4-0",
+            "usage_info": {"pages_processed": 1}
+        });
+        let result =
+            transform_ocr_response("mistral-ocr-4-0", response).expect("response should transform");
+        assert_eq!(result.pages[0].get("blocks"), Some(&blocks));
+        assert_eq!(
+            result.pages[0].get("confidence_scores"),
+            Some(&confidence_scores)
+        );
+    }
+
+    #[test]
+    fn transform_ocr_response_preserves_ocr4_page_fields() {
+        let response = json!({
+            "pages": [{"index": 0, "markdown": "table page", "tables": [{"rows": 2, "cols": 3}], "hyperlinks": ["https://example.com"], "header": "Acme Corp", "footer": "Page 1"}],
+            "model": "mistral-ocr-4-0",
+            "usage_info": {"pages_processed": 1}
+        });
+        let result = transform_ocr_response("mistral-ocr-4-0", response.clone())
+            .expect("response should transform");
+        assert_eq!(result.pages[0], response["pages"][0]);
     }
 
     #[test]

--- a/tests/rust-python-harness/strategies/unit_tests/ledgers/ocr/ocr_test_ledger.json
+++ b/tests/rust-python-harness/strategies/unit_tests/ledgers/ocr/ocr_test_ledger.json
@@ -20,189 +20,1065 @@
     "litellm-rust/crates/ai-gateway/src/integrations/custom_logger/mod.rs"
   ],
   "entries": [
-    {"python_file": "tests/test_litellm/llms/azure_ai/test_azure_document_intelligence_ocr_transformation.py", "python_test": "test_should_encode_azure_document_intelligence_model_id", "status": "unmapped", "reason": "model-id URL percent-encoding has no Rust test; Rust only tests pages/features query building"},
-    {"python_file": "tests/test_litellm/llms/azure_ai/test_azure_document_intelligence_ocr_transformation.py", "python_test": "test_should_reject_dot_segment_azure_document_intelligence_model_id", "status": "unmapped", "reason": "model-id dot-segment validation has no Rust test"},
-    {"python_file": "tests/test_litellm/llms/azure_ai/test_azure_document_intelligence_ocr_transformation.py", "python_test": "test_transform_ocr_response_preserves_azure_native_fields", "status": "mapped", "rust_file": "litellm-rust/crates/core/src/providers/azure_ai/ocr/transformation.rs", "rust_test": "document_intelligence_response_normalizes_pages", "justification": "both assert page markdown, dimension (inch-to-pixel) normalization, and usage_info.pages_processed from the same Azure succeeded response shape"},
-    {"python_file": "tests/test_litellm/llms/azure_ai/test_azure_document_intelligence_ocr_transformation.py", "python_test": "test_async_transform_ocr_response_preserves_azure_native_fields", "status": "mapped", "rust_file": "litellm-rust/crates/core/src/providers/azure_ai/ocr/transformation.rs", "rust_test": "document_intelligence_response_normalizes_pages", "justification": "async twin of the sync case above, same underlying transform is exercised on the Rust side"},
-    {"python_file": "tests/test_litellm/llms/azure_ai/test_azure_document_intelligence_ocr_transformation.py", "python_test": "test_transform_ocr_response_tolerates_missing_native_fields", "status": "unmapped", "reason": "tables/keyValuePairs absence tolerance is not asserted by the Rust response test"},
-    {"python_file": "tests/test_litellm/llms/azure_ai/test_azure_document_intelligence_ocr_transformation.py", "python_test": "test_transform_ocr_response_non_succeeded_status_raises", "status": "unmapped", "reason": "no Rust test asserts on a non-succeeded Azure DI status"},
-    {"python_file": "tests/test_litellm/llms/azure_ai/test_azure_document_intelligence_ocr_transformation.py", "python_test": "test_get_supported_ocr_params_includes_features", "status": "unmapped", "reason": "supported-params list content has no Rust equivalent for Azure"},
-    {"python_file": "tests/test_litellm/llms/azure_ai/test_azure_document_intelligence_ocr_transformation.py", "python_test": "test_transform_ocr_response_native_format_carries_raw_operation", "status": "unmapped", "reason": "native req_format raw-operation passthrough is not tested in Rust"},
-    {"python_file": "tests/test_litellm/llms/azure_ai/test_azure_document_intelligence_ocr_transformation.py", "python_test": "test_async_transform_ocr_response_native_format_carries_raw_operation", "status": "unmapped", "reason": "native req_format raw-operation passthrough is not tested in Rust"},
-    {"python_file": "tests/test_litellm/llms/azure_ai/test_azure_document_intelligence_ocr_transformation.py", "python_test": "test_transform_ocr_response_default_format_omits_raw_operation", "status": "unmapped", "reason": "req_format gating of raw-operation output has no Rust test"},
-    {"python_file": "tests/test_litellm/llms/azure_ai/test_azure_document_intelligence_ocr_transformation.py", "python_test": "test_map_ocr_params_passes_through_req_format", "status": "unmapped", "reason": "req_format passthrough in map_ocr_params has no Rust test"},
-    {"python_file": "tests/test_litellm/llms/azure_ai/test_azure_document_intelligence_ocr_transformation.py", "python_test": "test_map_ocr_params_rejects_unknown_req_format_as_bad_request", "status": "unmapped", "reason": "req_format validation error path has no Rust test"},
-    {"python_file": "tests/test_litellm/llms/azure_ai/test_azure_document_intelligence_ocr_transformation.py", "python_test": "test_get_complete_url_omits_req_format_query_param", "status": "unmapped", "reason": "no Rust test asserts req_format is excluded from the built URL"},
-    {"python_file": "tests/test_litellm/llms/azure_ai/test_azure_document_intelligence_ocr_transformation.py", "python_test": "test_map_ocr_params_features", "status": "unmapped", "reason": "features-string normalization in map_ocr_params has no Rust test"},
-    {"python_file": "tests/test_litellm/llms/azure_ai/test_azure_document_intelligence_ocr_transformation.py", "python_test": "test_map_ocr_params_empty_features_list_omitted", "status": "unmapped", "reason": "empty-features omission has no Rust test"},
-    {"python_file": "tests/test_litellm/llms/azure_ai/test_azure_document_intelligence_ocr_transformation.py", "python_test": "test_map_ocr_params_invalid_features_raises", "status": "unmapped", "reason": "features validation error path has no Rust test"},
-    {"python_file": "tests/test_litellm/llms/azure_ai/test_azure_document_intelligence_ocr_transformation.py", "python_test": "test_get_complete_url_appends_features_query", "status": "unmapped", "reason": "features query-param construction has no Rust test"},
-    {"python_file": "tests/test_litellm/llms/azure_ai/test_azure_document_intelligence_ocr_transformation.py", "python_test": "test_get_complete_url_combines_pages_and_features", "status": "mapped", "rust_file": "litellm-rust/crates/core/src/providers/azure_ai/ocr/transformation.rs", "rust_test": "document_intelligence_url_normalizes_zero_based_pages", "justification": "both assert 0-based, duplicate page indices are deduped, sorted, and rewritten 1-based into the request URL"},
-    {"python_file": "tests/test_litellm/llms/azure_ai/test_azure_document_intelligence_ocr_transformation.py", "python_test": "test_validate_environment_uses_subscription_key", "status": "unmapped", "reason": "Python-side header derivation from litellm_params; Rust's poll test only checks the header is present, not how it was resolved"},
-    {"python_file": "tests/test_litellm/llms/azure_ai/test_azure_document_intelligence_ocr_transformation.py", "python_test": "test_validate_environment_falls_back_to_entra_token", "status": "unmapped", "reason": "Entra bearer-token fallback logic has no Rust test"},
-    {"python_file": "tests/test_litellm/ocr/test_ocr_azure_document_intelligence_api_base.py", "python_test": "TestIsAzureDocumentIntelligenceModel::test_matches_doc_intelligence_route", "status": "unmapped", "reason": "model-route string matching is Python-only dispatch logic"},
-    {"python_file": "tests/test_litellm/ocr/test_ocr_azure_document_intelligence_api_base.py", "python_test": "TestIsAzureDocumentIntelligenceModel::test_matches_documentintelligence_and_is_case_insensitive", "status": "unmapped", "reason": "model-route string matching is Python-only dispatch logic"},
-    {"python_file": "tests/test_litellm/ocr/test_ocr_azure_document_intelligence_api_base.py", "python_test": "TestIsAzureDocumentIntelligenceModel::test_does_not_match_mistral_route", "status": "unmapped", "reason": "model-route string matching is Python-only dispatch logic"},
-    {"python_file": "tests/test_litellm/ocr/test_ocr_azure_document_intelligence_api_base.py", "python_test": "TestDocIntelligenceApiBaseResolution::test_generic_azure_ai_base_does_not_hijack_doc_intelligence", "status": "unmapped", "reason": "api_base resolution from the secret manager runs before the Rust bridge is called, no Rust test exists for it"},
-    {"python_file": "tests/test_litellm/ocr/test_ocr_azure_document_intelligence_api_base.py", "python_test": "TestDocIntelligenceApiBaseResolution::test_explicit_api_base_is_honoured_for_doc_intelligence", "status": "unmapped", "reason": "api_base precedence resolution is Python-only"},
-    {"python_file": "tests/test_litellm/ocr/test_ocr_azure_document_intelligence_api_base.py", "python_test": "TestDocIntelligenceApiBaseResolution::test_generic_azure_ai_base_still_applies_to_mistral_ocr", "status": "unmapped", "reason": "api_base precedence resolution is Python-only"},
-
-    {"python_file": "tests/test_litellm/ocr/test_rust_bridge.py", "python_test": "test_use_litellm_rust_toggles_flag", "status": "unmapped", "reason": "bridge-plumbing: Python-side feature-flag toggle, no Rust equivalent"},
-    {"python_file": "tests/test_litellm/ocr/test_rust_bridge.py", "python_test": "test_env_var_enables_rust_ocr", "status": "unmapped", "reason": "bridge-plumbing: Python-side env-var flag gating"},
-    {"python_file": "tests/test_litellm/ocr/test_rust_bridge.py", "python_test": "test_load_rust_ocr_returns_injected_impl", "status": "unmapped", "reason": "bridge-plumbing: dependency-injection test hook, not provider behavior"},
-    {"python_file": "tests/test_litellm/ocr/test_rust_bridge.py", "python_test": "test_native_bridge_loader_returns_none_when_extension_absent", "status": "unmapped", "reason": "bridge-plumbing: native-extension import/loader fallback"},
-    {"python_file": "tests/test_litellm/ocr/test_rust_bridge.py", "python_test": "test_native_bridge_loader_caches_absent_extension", "status": "unmapped", "reason": "bridge-plumbing: loader caching behavior"},
-    {"python_file": "tests/test_litellm/ocr/test_rust_bridge.py", "python_test": "test_native_bridge_available_reflects_loader", "status": "unmapped", "reason": "bridge-plumbing: loader availability check"},
-    {"python_file": "tests/test_litellm/ocr/test_rust_bridge.py", "python_test": "test_load_rust_aocr_returns_injected_impl", "status": "unmapped", "reason": "bridge-plumbing: dependency-injection test hook"},
-    {"python_file": "tests/test_litellm/ocr/test_rust_bridge.py", "python_test": "test_toggle_without_ocr_arg_preserves_injected_impl", "status": "unmapped", "reason": "bridge-plumbing: injected-impl state retention regression"},
-    {"python_file": "tests/test_litellm/ocr/test_rust_bridge.py", "python_test": "test_explicit_ocr_none_clears_injected_impl", "status": "unmapped", "reason": "bridge-plumbing: injected-impl clearing behavior"},
-    {"python_file": "tests/test_litellm/ocr/test_rust_bridge.py", "python_test": "test_load_rust_ocr_none_when_extension_absent", "status": "unmapped", "reason": "bridge-plumbing: degrade path when the native extension is missing"},
-    {"python_file": "tests/test_litellm/ocr/test_rust_bridge.py", "python_test": "test_load_rust_ocr_uses_compiled_extension", "status": "unmapped", "reason": "bridge-plumbing: native module resolution"},
-    {"python_file": "tests/test_litellm/ocr/test_rust_bridge.py", "python_test": "test_timeout_to_seconds_handles_float_timeout_and_none", "status": "unmapped", "reason": "bridge-plumbing: Python-side timeout normalization helper"},
-    {"python_file": "tests/test_litellm/ocr/test_rust_bridge.py", "python_test": "test_bridge_wrapper_forwards_prepared_args_and_wraps_response", "status": "unmapped", "reason": "bridge-plumbing: wrapper argument forwarding, asserted against a fake bridge not the real Rust code"},
-    {"python_file": "tests/test_litellm/ocr/test_rust_bridge.py", "python_test": "test_bridge_wrapper_forwards_prepared_async_args_and_wraps_response", "status": "unmapped", "reason": "bridge-plumbing: async wrapper argument forwarding"},
-    {"python_file": "tests/test_litellm/ocr/test_rust_bridge.py", "python_test": "test_run_rust_ocr_prepares_request_and_wraps_response", "status": "unmapped", "reason": "bridge-plumbing: request preparation and response wrapping in Python"},
-    {"python_file": "tests/test_litellm/ocr/test_rust_bridge.py", "python_test": "test_run_rust_ocr_resolves_key_via_secret_manager_when_missing", "status": "unmapped", "reason": "secret-manager: API key resolution happens in Python before the bridge is invoked"},
-    {"python_file": "tests/test_litellm/ocr/test_rust_bridge.py", "python_test": "test_run_rust_ocr_prefers_explicit_key_over_resolver", "status": "unmapped", "reason": "secret-manager: key precedence resolution"},
-    {"python_file": "tests/test_litellm/ocr/test_rust_bridge.py", "python_test": "test_run_rust_ocr_uses_provider_api_key_env_var", "status": "unmapped", "reason": "secret-manager: provider-specific env var name resolution"},
-    {"python_file": "tests/test_litellm/ocr/test_rust_bridge.py", "python_test": "test_prepare_rust_ocr_call_forwards_vertex_routing_metadata", "status": "unmapped", "reason": "secret-manager: vertex routing metadata merge happens in Python"},
-    {"python_file": "tests/test_litellm/ocr/test_rust_bridge.py", "python_test": "test_prepare_rust_ocr_call_resolves_vertex_routing_metadata_from_secret_manager", "status": "unmapped", "reason": "secret-manager: vertex project/location resolution"},
-    {"python_file": "tests/test_litellm/ocr/test_rust_bridge.py", "python_test": "test_prepare_rust_ocr_call_resolves_azure_ai_api_base_from_secret_manager", "status": "unmapped", "reason": "secret-manager: azure_ai api_base resolution"},
-    {"python_file": "tests/test_litellm/ocr/test_rust_bridge.py", "python_test": "test_prepare_rust_ocr_call_resolves_document_intelligence_endpoint", "status": "unmapped", "reason": "secret-manager: doc-intelligence endpoint resolution"},
-    {"python_file": "tests/test_litellm/ocr/test_rust_bridge.py", "python_test": "test_run_rust_ocr_runs_pre_call_logging", "status": "unmapped", "reason": "bridge-plumbing: Python logging-object pre_call invocation"},
-    {"python_file": "tests/test_litellm/ocr/test_rust_bridge.py", "python_test": "test_ocr_routes_to_rust_when_enabled", "status": "unmapped", "reason": "bridge-plumbing: routing to a fake bridge, not the real Rust transform"},
-    {"python_file": "tests/test_litellm/ocr/test_rust_bridge.py", "python_test": "test_ocr_routes_azure_ai_to_rust_when_enabled", "status": "unmapped", "reason": "bridge-plumbing: provider-prefix stripping before routing"},
-    {"python_file": "tests/test_litellm/ocr/test_rust_bridge.py", "python_test": "test_ocr_rust_path_converts_file_document_before_bridge", "status": "unmapped", "reason": "file-normalization: raw-bytes-to-data-URI conversion happens in Python before the bridge call"},
-    {"python_file": "tests/test_litellm/ocr/test_rust_bridge.py", "python_test": "test_ocr_exception_type_uses_resolved_provider_context", "status": "unmapped", "reason": "bridge-plumbing: Python exception-type mapping on bridge failure"},
-    {"python_file": "tests/test_litellm/ocr/test_rust_bridge.py", "python_test": "test_aocr_routes_to_async_rust_when_enabled", "status": "unmapped", "reason": "bridge-plumbing: async routing to a fake bridge"},
-    {"python_file": "tests/test_litellm/ocr/test_rust_bridge.py", "python_test": "test_aocr_exception_type_uses_resolved_provider_context", "status": "unmapped", "reason": "bridge-plumbing: async exception-type mapping on bridge failure"},
-    {"python_file": "tests/test_litellm/ocr/test_rust_bridge.py", "python_test": "test_ocr_does_not_route_to_rust_when_disabled", "status": "unmapped", "reason": "bridge-plumbing: Python control flow for the toggle-disabled branch, no Rust-owned behavior runs"},
-    {"python_file": "tests/test_litellm/ocr/test_rust_bridge.py", "python_test": "test_ocr_falls_back_to_python_when_bridge_unavailable", "status": "unmapped", "reason": "bridge-plumbing: Python-only fallback when the compiled Rust extension is absent, Rust cannot test its own absence"},
-    {"python_file": "tests/test_litellm/ocr/test_rust_bridge.py", "python_test": "test_ocr_forwards_timeout_to_rust", "status": "unmapped", "reason": "bridge-plumbing: asserts the Python call site forwards a timeout kwarg, Rust receives an already-constructed request"},
-    {"python_file": "tests/test_litellm/ocr/test_rust_bridge.py", "python_test": "test_ocr_passes_default_request_timeout_to_rust", "status": "unmapped", "reason": "bridge-plumbing: asserts the Python call site supplies a default timeout kwarg, no Rust equivalent"},
-    {"python_file": "tests/test_litellm/ocr/test_rust_bridge.py", "python_test": "test_ocr_provider_configs_expose_api_key_env_vars", "status": "unmapped", "reason": "asserts per-provider get_api_key_env_var() strings; the closest Rust test (ocr_dispatch_supports_migrated_providers) asserts provider dispatch/param resolution instead, not API key env var names"},
-
-    {"python_file": "tests/test_litellm/ocr/test_ocr_file_input.py", "python_test": "TestGetMimeType::test_should_detect_pdf_mime_type", "status": "unmapped", "reason": "file-normalization: MIME detection is Python-only preprocessing before the bridge call"},
-    {"python_file": "tests/test_litellm/ocr/test_ocr_file_input.py", "python_test": "TestGetMimeType::test_should_detect_png_mime_type", "status": "unmapped", "reason": "file-normalization: MIME detection"},
-    {"python_file": "tests/test_litellm/ocr/test_ocr_file_input.py", "python_test": "TestGetMimeType::test_should_detect_jpg_mime_type", "status": "unmapped", "reason": "file-normalization: MIME detection"},
-    {"python_file": "tests/test_litellm/ocr/test_ocr_file_input.py", "python_test": "TestGetMimeType::test_should_detect_jpeg_mime_type", "status": "unmapped", "reason": "file-normalization: MIME detection"},
-    {"python_file": "tests/test_litellm/ocr/test_ocr_file_input.py", "python_test": "TestGetMimeType::test_should_detect_gif_mime_type", "status": "unmapped", "reason": "file-normalization: MIME detection"},
-    {"python_file": "tests/test_litellm/ocr/test_ocr_file_input.py", "python_test": "TestGetMimeType::test_should_detect_webp_mime_type", "status": "unmapped", "reason": "file-normalization: MIME detection"},
-    {"python_file": "tests/test_litellm/ocr/test_ocr_file_input.py", "python_test": "TestGetMimeType::test_should_detect_tiff_mime_type", "status": "unmapped", "reason": "file-normalization: MIME detection"},
-    {"python_file": "tests/test_litellm/ocr/test_ocr_file_input.py", "python_test": "TestGetMimeType::test_should_detect_tif_mime_type", "status": "unmapped", "reason": "file-normalization: MIME detection"},
-    {"python_file": "tests/test_litellm/ocr/test_ocr_file_input.py", "python_test": "TestGetMimeType::test_should_detect_bmp_mime_type", "status": "unmapped", "reason": "file-normalization: MIME detection"},
-    {"python_file": "tests/test_litellm/ocr/test_ocr_file_input.py", "python_test": "TestGetMimeType::test_should_be_case_insensitive", "status": "unmapped", "reason": "file-normalization: MIME detection case handling"},
-    {"python_file": "tests/test_litellm/ocr/test_ocr_file_input.py", "python_test": "TestGetMimeType::test_should_fallback_for_unknown_extension", "status": "unmapped", "reason": "file-normalization: MIME detection fallback"},
-    {"python_file": "tests/test_litellm/ocr/test_ocr_file_input.py", "python_test": "TestConvertFileDocumentToUrlDocument::test_should_convert_pdf_pathlib_path_to_document_url", "status": "unmapped", "reason": "file-normalization: local-path-to-data-URI conversion happens in Python"},
-    {"python_file": "tests/test_litellm/ocr/test_ocr_file_input.py", "python_test": "TestConvertFileDocumentToUrlDocument::test_should_convert_image_pathlib_path_to_image_url", "status": "unmapped", "reason": "file-normalization: local-path-to-data-URI conversion"},
-    {"python_file": "tests/test_litellm/ocr/test_ocr_file_input.py", "python_test": "TestConvertFileDocumentToUrlDocument::test_should_reject_bare_str_path", "status": "unmapped", "reason": "file-normalization: arbitrary-file-read guard on bare str paths"},
-    {"python_file": "tests/test_litellm/ocr/test_ocr_file_input.py", "python_test": "TestConvertFileDocumentToUrlDocument::test_should_convert_pathlib_path", "status": "unmapped", "reason": "file-normalization: local-path-to-data-URI conversion"},
-    {"python_file": "tests/test_litellm/ocr/test_ocr_file_input.py", "python_test": "TestConvertFileDocumentToUrlDocument::test_should_convert_raw_bytes", "status": "unmapped", "reason": "file-normalization: raw-bytes-to-data-URI conversion"},
-    {"python_file": "tests/test_litellm/ocr/test_ocr_file_input.py", "python_test": "TestConvertFileDocumentToUrlDocument::test_should_convert_raw_bytes_with_explicit_mime_type", "status": "unmapped", "reason": "file-normalization: explicit MIME override on raw bytes"},
-    {"python_file": "tests/test_litellm/ocr/test_ocr_file_input.py", "python_test": "TestConvertFileDocumentToUrlDocument::test_should_convert_raw_bytes_with_image_mime_type", "status": "unmapped", "reason": "file-normalization: explicit MIME override on raw bytes"},
-    {"python_file": "tests/test_litellm/ocr/test_ocr_file_input.py", "python_test": "TestConvertFileDocumentToUrlDocument::test_should_convert_file_like_object", "status": "unmapped", "reason": "file-normalization: file-like-object conversion"},
-    {"python_file": "tests/test_litellm/ocr/test_ocr_file_input.py", "python_test": "TestConvertFileDocumentToUrlDocument::test_should_convert_file_like_object_with_name", "status": "unmapped", "reason": "file-normalization: file-like-object name-based MIME detection"},
-    {"python_file": "tests/test_litellm/ocr/test_ocr_file_input.py", "python_test": "TestConvertFileDocumentToUrlDocument::test_should_raise_error_for_missing_file_field", "status": "unmapped", "reason": "file-normalization: missing-field validation"},
-    {"python_file": "tests/test_litellm/ocr/test_ocr_file_input.py", "python_test": "TestConvertFileDocumentToUrlDocument::test_should_raise_error_for_nonexistent_pathlib_path", "status": "unmapped", "reason": "file-normalization: missing-file validation"},
-    {"python_file": "tests/test_litellm/ocr/test_ocr_file_input.py", "python_test": "TestConvertFileDocumentToUrlDocument::test_should_raise_error_for_empty_file", "status": "unmapped", "reason": "file-normalization: empty-file validation"},
-    {"python_file": "tests/test_litellm/ocr/test_ocr_file_input.py", "python_test": "TestConvertFileDocumentToUrlDocument::test_should_raise_error_for_unsupported_type", "status": "unmapped", "reason": "file-normalization: unsupported input type validation"},
-    {"python_file": "tests/test_litellm/ocr/test_ocr_file_input.py", "python_test": "TestConvertFileDocumentToUrlDocument::test_should_raise_error_for_invalid_mime_type", "status": "unmapped", "reason": "file-normalization: MIME-type injection validation"},
-    {"python_file": "tests/test_litellm/ocr/test_ocr_file_input.py", "python_test": "TestConvertFileDocumentToUrlDocument::test_should_override_mime_type_for_pathlib_path", "status": "unmapped", "reason": "file-normalization: explicit MIME override precedence"},
-    {"python_file": "tests/test_litellm/ocr/test_ocr_file_input.py", "python_test": "TestBuildDocumentFromUpload::test_should_build_document_url_for_pdf", "status": "unmapped", "reason": "file-normalization: multipart upload conversion"},
-    {"python_file": "tests/test_litellm/ocr/test_ocr_file_input.py", "python_test": "TestBuildDocumentFromUpload::test_should_build_image_url_for_png", "status": "unmapped", "reason": "file-normalization: multipart upload conversion"},
-    {"python_file": "tests/test_litellm/ocr/test_ocr_file_input.py", "python_test": "TestBuildDocumentFromUpload::test_should_build_image_url_for_jpeg", "status": "unmapped", "reason": "file-normalization: multipart upload conversion"},
-    {"python_file": "tests/test_litellm/ocr/test_ocr_file_input.py", "python_test": "TestBuildDocumentFromUpload::test_should_detect_mime_from_filename_when_content_type_is_octet_stream", "status": "unmapped", "reason": "file-normalization: filename-based MIME fallback"},
-    {"python_file": "tests/test_litellm/ocr/test_ocr_file_input.py", "python_test": "TestBuildDocumentFromUpload::test_should_detect_mime_from_filename_when_content_type_is_none", "status": "unmapped", "reason": "file-normalization: filename-based MIME fallback"},
-    {"python_file": "tests/test_litellm/ocr/test_ocr_file_input.py", "python_test": "TestBuildDocumentFromUpload::test_should_fallback_to_octet_stream_for_unknown", "status": "unmapped", "reason": "file-normalization: default MIME fallback"},
-    {"python_file": "tests/test_litellm/ocr/test_ocr_file_input.py", "python_test": "TestBuildDocumentFromUpload::test_should_preserve_base64_content_correctly", "status": "unmapped", "reason": "file-normalization: binary round-trip through base64"},
-    {"python_file": "tests/test_litellm/ocr/test_ocr_file_input.py", "python_test": "TestBuildDocumentFromUpload::test_should_strip_mime_parameters_from_content_type", "status": "unmapped", "reason": "file-normalization: content-type parameter stripping"},
-    {"python_file": "tests/test_litellm/ocr/test_ocr_file_input.py", "python_test": "TestBuildDocumentFromUpload::test_should_strip_mime_parameters_with_multiple_params", "status": "unmapped", "reason": "file-normalization: content-type parameter stripping"},
-    {"python_file": "tests/test_litellm/ocr/test_ocr_file_input.py", "python_test": "TestProxySecurityGuard::test_should_reject_file_type_document_in_json_body", "status": "unmapped", "reason": "proxy-layer JSON-body file-type guard, a different mechanism than Rust's URL-fetch SSRF guard"},
-    {"python_file": "tests/test_litellm/ocr/test_ocr_file_input.py", "python_test": "TestProxySecurityGuard::test_should_accept_document_url_type_in_json_body", "status": "unmapped", "reason": "proxy-layer JSON-body parsing"},
-    {"python_file": "tests/test_litellm/ocr/test_ocr_file_input.py", "python_test": "TestProxySecurityGuard::test_should_raise_on_invalid_json_body", "status": "unmapped", "reason": "proxy-layer JSON-body parsing error path"},
-    {"python_file": "tests/test_litellm/ocr/test_ocr_file_input.py", "python_test": "TestProxySecurityGuard::test_should_ignore_document_form_field_injection", "status": "unmapped", "reason": "proxy-layer multipart form-field injection guard, a different mechanism than Rust's URL-fetch SSRF guard"},
-
-    {"python_file": "tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_transformation.py", "python_test": "TestGetSupportedOcrParams::test_extract_header_in_supported_params", "status": "unmapped", "reason": "Rust's fixed-list test checks the full list as one assertion, not this individual param"},
-    {"python_file": "tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_transformation.py", "python_test": "TestGetSupportedOcrParams::test_extract_footer_in_supported_params", "status": "unmapped", "reason": "Rust's fixed-list test checks the full list as one assertion, not this individual param"},
-    {"python_file": "tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_transformation.py", "python_test": "TestGetSupportedOcrParams::test_existing_params_still_present", "status": "mapped", "rust_file": "litellm-rust/crates/core/src/providers/mistral/ocr/transformation.rs", "rust_test": "supported_params_match_python_mistral_ocr_config", "justification": "both assert the full supported_ocr_params list matches the same fixed set of param names"},
-    {"python_file": "tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_transformation.py", "python_test": "TestMapOcrParams::test_extract_header_passed_through", "status": "mapped", "rust_file": "litellm-rust/crates/core/src/providers/mistral/ocr/transformation.rs", "rust_test": "map_ocr_params_drops_unknown_params", "justification": "both assert extract_header survives map_ocr_params filtering unchanged"},
-    {"python_file": "tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_transformation.py", "python_test": "TestMapOcrParams::test_extract_footer_passed_through", "status": "unmapped", "reason": "Rust's map_ocr_params test does not assert on extract_footer specifically"},
-    {"python_file": "tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_transformation.py", "python_test": "TestMapOcrParams::test_extract_header_and_footer_together", "status": "unmapped", "reason": "combined extract_header+extract_footer passthrough is not asserted together in Rust"},
-    {"python_file": "tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_transformation.py", "python_test": "TestMapOcrParams::test_unknown_param_is_dropped", "status": "mapped", "rust_file": "litellm-rust/crates/core/src/providers/mistral/ocr/transformation.rs", "rust_test": "map_ocr_params_drops_unknown_params", "justification": "both assert an unrecognized param key is dropped while a known one is kept"},
-    {"python_file": "tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_transformation.py", "python_test": "TestNewSupportedParams::test_new_param_in_supported_list", "status": "unmapped", "reason": "OCR4-specific new params (table_format etc) are not individually verified against the Rust fixed-list test"},
-    {"python_file": "tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_transformation.py", "python_test": "TestNewParamsMapOcr::test_new_param_passed_through", "status": "unmapped", "reason": "OCR4-specific new params are not individually asserted in the Rust map_ocr_params test"},
-    {"python_file": "tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_transformation.py", "python_test": "TestTransformOcrRequest::test_param_included_in_request_body", "status": "mapped", "rust_file": "litellm-rust/crates/core/src/providers/mistral/ocr/transformation.rs", "rust_test": "transform_ocr_request_builds_mistral_body", "justification": "both assert an optional param value ends up in the built request body alongside model/document"},
-    {"python_file": "tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_transformation.py", "python_test": "TestTransformOcrRequest::test_multiple_new_params_together", "status": "mapped", "rust_file": "litellm-rust/crates/core/src/providers/mistral/ocr/transformation.rs", "rust_test": "transform_ocr_request_builds_mistral_body", "justification": "both assert multiple optional params (table_format/include_image_base64) land correctly in the same request body"},
-    {"python_file": "tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_transformation.py", "python_test": "TestTransformOcrResponseOcr4Fields::test_blocks_and_confidence_scores_preserved", "status": "unmapped", "reason": "OCR4 blocks/confidence_scores fields are not asserted by the Rust response test"},
-    {"python_file": "tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_transformation.py", "python_test": "TestTransformOcrResponseOcr4Fields::test_ocr4_fields_survive_model_dump", "status": "unmapped", "reason": "OCR4 tables/hyperlinks/header/footer fields are not asserted by the Rust response test"},
-
-    {"python_file": "tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_cost.py", "python_test": "test_model_info_ocr4_price", "status": "unmapped", "reason": "cost-calc: pricing/model-info lookup is Python-only"},
-    {"python_file": "tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_cost.py", "python_test": "test_ocr4_cost_scales_with_pages", "status": "unmapped", "reason": "cost-calc: per-page pricing math is Python-only"},
-    {"python_file": "tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_cost.py", "python_test": "test_ocr3_pricing_entry", "status": "unmapped", "reason": "cost-calc: cost-map JSON entry validation is Python-only"},
-    {"python_file": "tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_cost.py", "python_test": "test_ocr3_model_info_price", "status": "unmapped", "reason": "cost-calc: pricing/model-info lookup is Python-only"},
-    {"python_file": "tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_cost.py", "python_test": "test_ocr3_cost_scales_with_pages", "status": "unmapped", "reason": "cost-calc: per-page pricing math is Python-only"},
-    {"python_file": "tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_cost.py", "python_test": "test_ocr3_bills_ocr_and_annotation_pages_at_their_own_rates", "status": "unmapped", "reason": "cost-calc: mixed-rate billing math is Python-only"},
-    {"python_file": "tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_cost.py", "python_test": "test_ocr3_bills_annotation_only_response", "status": "unmapped", "reason": "cost-calc: annotation-only billing math is Python-only"},
-    {"python_file": "tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_cost.py", "python_test": "test_ocr3_bills_annotation_pages_when_pages_processed_missing", "status": "unmapped", "reason": "cost-calc: fallback billing math is Python-only"},
-    {"python_file": "tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_cost.py", "python_test": "test_azure_doc_ai_annotation_pages_fall_back_to_ocr_rate", "status": "unmapped", "reason": "cost-calc: fallback billing math is Python-only"},
-
-    {"python_file": "tests/test_litellm/ocr/test_ocr_native_format.py", "python_test": "test_rust_ocr_serves_default_format", "status": "unmapped", "reason": "request-format gating decision is made in Python before the Rust bridge is ever invoked"},
-    {"python_file": "tests/test_litellm/ocr/test_ocr_native_format.py", "python_test": "test_rust_ocr_skipped_for_native_format", "status": "unmapped", "reason": "request-format gating decision is made in Python before the Rust bridge is ever invoked"},
-    {"python_file": "tests/test_litellm/ocr/test_ocr_native_format.py", "python_test": "test_native_format_rejected_for_provider_without_support_as_bad_request", "status": "unmapped", "reason": "provider-support validation for req_format happens in Python"},
-    {"python_file": "tests/test_litellm/ocr/test_ocr_native_format.py", "python_test": "test_unknown_format_rejected_for_provider_without_support_as_bad_request", "status": "unmapped", "reason": "req_format validation error path is Python-only"},
-
-    {"python_file": "tests/test_litellm/llms/ocr/guardrail_translation/test_ocr_guardrail_handler.py", "python_test": "TestHandlerDiscovery::test_handler_discovered_for_ocr", "status": "unmapped", "reason": "guardrail-translation handler discovery is a Python proxy-layer concern"},
-    {"python_file": "tests/test_litellm/llms/ocr/guardrail_translation/test_ocr_guardrail_handler.py", "python_test": "TestHandlerDiscovery::test_handler_discovered_for_aocr", "status": "unmapped", "reason": "guardrail-translation handler discovery is a Python proxy-layer concern"},
-    {"python_file": "tests/test_litellm/llms/ocr/guardrail_translation/test_ocr_guardrail_handler.py", "python_test": "TestInputProcessing::test_process_document_url", "status": "unmapped", "reason": "scoped to the Python translation handler, not the Rust gateway's guardrail hook lifecycle"},
-    {"python_file": "tests/test_litellm/llms/ocr/guardrail_translation/test_ocr_guardrail_handler.py", "python_test": "TestInputProcessing::test_process_image_url", "status": "unmapped", "reason": "scoped to the Python translation handler, not the Rust gateway's guardrail hook lifecycle"},
-    {"python_file": "tests/test_litellm/llms/ocr/guardrail_translation/test_ocr_guardrail_handler.py", "python_test": "TestInputProcessing::test_process_no_document", "status": "unmapped", "reason": "scoped to the Python translation handler, not the Rust gateway's guardrail hook lifecycle"},
-    {"python_file": "tests/test_litellm/llms/ocr/guardrail_translation/test_ocr_guardrail_handler.py", "python_test": "TestInputProcessing::test_process_invalid_document", "status": "unmapped", "reason": "scoped to the Python translation handler, not the Rust gateway's guardrail hook lifecycle"},
-    {"python_file": "tests/test_litellm/llms/ocr/guardrail_translation/test_ocr_guardrail_handler.py", "python_test": "TestInputProcessing::test_input_blocking_guardrail", "status": "unmapped", "reason": "scoped to the Python translation handler, not the Rust gateway's guardrail hook lifecycle"},
-    {"python_file": "tests/test_litellm/llms/ocr/guardrail_translation/test_ocr_guardrail_handler.py", "python_test": "TestOutputProcessing::test_process_single_page", "status": "unmapped", "reason": "scoped to the Python translation handler, not the Rust gateway's guardrail hook lifecycle"},
-    {"python_file": "tests/test_litellm/llms/ocr/guardrail_translation/test_ocr_guardrail_handler.py", "python_test": "TestOutputProcessing::test_process_multiple_pages", "status": "unmapped", "reason": "scoped to the Python translation handler, not the Rust gateway's guardrail hook lifecycle"},
-    {"python_file": "tests/test_litellm/llms/ocr/guardrail_translation/test_ocr_guardrail_handler.py", "python_test": "TestOutputProcessing::test_process_empty_pages", "status": "unmapped", "reason": "scoped to the Python translation handler, not the Rust gateway's guardrail hook lifecycle"},
-    {"python_file": "tests/test_litellm/llms/ocr/guardrail_translation/test_ocr_guardrail_handler.py", "python_test": "TestOutputProcessing::test_process_page_with_empty_markdown", "status": "unmapped", "reason": "scoped to the Python translation handler, not the Rust gateway's guardrail hook lifecycle"},
-    {"python_file": "tests/test_litellm/llms/ocr/guardrail_translation/test_ocr_guardrail_handler.py", "python_test": "TestOutputProcessing::test_process_preserves_page_metadata", "status": "unmapped", "reason": "scoped to the Python translation handler, not the Rust gateway's guardrail hook lifecycle"},
-    {"python_file": "tests/test_litellm/llms/ocr/guardrail_translation/test_ocr_guardrail_handler.py", "python_test": "TestOutputProcessing::test_output_blocking_guardrail", "status": "unmapped", "reason": "scoped to the Python translation handler, not the Rust gateway's guardrail hook lifecycle"},
-    {"python_file": "tests/test_litellm/llms/ocr/guardrail_translation/test_ocr_guardrail_handler.py", "python_test": "TestPIIMaskingScenario::test_pii_masking_in_ocr_pages", "status": "unmapped", "reason": "PII redaction in the translation handler has no Rust equivalent"},
-
-    {"python_file": "tests/test_litellm/proxy/ocr_endpoints/test_endpoints.py", "python_test": "test_should_read_req_format_from_header", "status": "unmapped", "reason": "proxy-layer header parsing has no Rust equivalent"},
-    {"python_file": "tests/test_litellm/proxy/ocr_endpoints/test_endpoints.py", "python_test": "test_should_prefer_body_req_format_over_header", "status": "unmapped", "reason": "proxy-layer body-vs-header precedence has no Rust equivalent"},
-    {"python_file": "tests/test_litellm/proxy/ocr_endpoints/test_endpoints.py", "python_test": "test_should_omit_req_format_when_header_absent", "status": "unmapped", "reason": "proxy-layer parsing has no Rust equivalent"},
-    {"python_file": "tests/test_litellm/proxy/ocr_endpoints/test_endpoints.py", "python_test": "test_should_reject_unknown_req_format", "status": "unmapped", "reason": "proxy-layer validation has no Rust equivalent"},
-    {"python_file": "tests/test_litellm/proxy/ocr_endpoints/test_endpoints.py", "python_test": "test_should_return_native_payload_with_litellm_response_headers", "status": "unmapped", "reason": "proxy-layer response construction has no Rust equivalent"},
-    {"python_file": "tests/test_litellm/proxy/ocr_endpoints/test_endpoints.py", "python_test": "test_should_return_normalized_response_when_no_native_payload", "status": "unmapped", "reason": "proxy-layer response construction has no Rust equivalent"}
+    {
+      "python_file": "tests/test_litellm/llms/azure_ai/test_azure_document_intelligence_ocr_transformation.py",
+      "python_test": "test_should_encode_azure_document_intelligence_model_id",
+      "status": "unmapped",
+      "reason": "model-id URL percent-encoding has no Rust test; Rust only tests pages/features query building"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/azure_ai/test_azure_document_intelligence_ocr_transformation.py",
+      "python_test": "test_should_reject_dot_segment_azure_document_intelligence_model_id",
+      "status": "unmapped",
+      "reason": "model-id dot-segment validation has no Rust test"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/azure_ai/test_azure_document_intelligence_ocr_transformation.py",
+      "python_test": "test_transform_ocr_response_preserves_azure_native_fields",
+      "status": "mapped",
+      "rust_file": "litellm-rust/crates/core/src/providers/azure_ai/ocr/transformation.rs",
+      "rust_test": "document_intelligence_response_normalizes_pages",
+      "justification": "both assert page markdown, dimension (inch-to-pixel) normalization, and usage_info.pages_processed from the same Azure succeeded response shape"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/azure_ai/test_azure_document_intelligence_ocr_transformation.py",
+      "python_test": "test_async_transform_ocr_response_preserves_azure_native_fields",
+      "status": "mapped",
+      "rust_file": "litellm-rust/crates/core/src/providers/azure_ai/ocr/transformation.rs",
+      "rust_test": "document_intelligence_response_normalizes_pages",
+      "justification": "async twin of the sync case above, same underlying transform is exercised on the Rust side"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/azure_ai/test_azure_document_intelligence_ocr_transformation.py",
+      "python_test": "test_transform_ocr_response_tolerates_missing_native_fields",
+      "status": "unmapped",
+      "reason": "tables/keyValuePairs absence tolerance is not asserted by the Rust response test"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/azure_ai/test_azure_document_intelligence_ocr_transformation.py",
+      "python_test": "test_transform_ocr_response_non_succeeded_status_raises",
+      "status": "unmapped",
+      "reason": "no Rust test asserts on a non-succeeded Azure DI status"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/azure_ai/test_azure_document_intelligence_ocr_transformation.py",
+      "python_test": "test_get_supported_ocr_params_includes_features",
+      "status": "unmapped",
+      "reason": "supported-params list content has no Rust equivalent for Azure"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/azure_ai/test_azure_document_intelligence_ocr_transformation.py",
+      "python_test": "test_transform_ocr_response_native_format_carries_raw_operation",
+      "status": "unmapped",
+      "reason": "native req_format raw-operation passthrough is not tested in Rust"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/azure_ai/test_azure_document_intelligence_ocr_transformation.py",
+      "python_test": "test_async_transform_ocr_response_native_format_carries_raw_operation",
+      "status": "unmapped",
+      "reason": "native req_format raw-operation passthrough is not tested in Rust"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/azure_ai/test_azure_document_intelligence_ocr_transformation.py",
+      "python_test": "test_transform_ocr_response_default_format_omits_raw_operation",
+      "status": "unmapped",
+      "reason": "req_format gating of raw-operation output has no Rust test"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/azure_ai/test_azure_document_intelligence_ocr_transformation.py",
+      "python_test": "test_map_ocr_params_passes_through_req_format",
+      "status": "unmapped",
+      "reason": "req_format passthrough in map_ocr_params has no Rust test"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/azure_ai/test_azure_document_intelligence_ocr_transformation.py",
+      "python_test": "test_map_ocr_params_rejects_unknown_req_format_as_bad_request",
+      "status": "unmapped",
+      "reason": "req_format validation error path has no Rust test"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/azure_ai/test_azure_document_intelligence_ocr_transformation.py",
+      "python_test": "test_get_complete_url_omits_req_format_query_param",
+      "status": "unmapped",
+      "reason": "no Rust test asserts req_format is excluded from the built URL"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/azure_ai/test_azure_document_intelligence_ocr_transformation.py",
+      "python_test": "test_map_ocr_params_features",
+      "status": "unmapped",
+      "reason": "features-string normalization in map_ocr_params has no Rust test"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/azure_ai/test_azure_document_intelligence_ocr_transformation.py",
+      "python_test": "test_map_ocr_params_empty_features_list_omitted",
+      "status": "unmapped",
+      "reason": "empty-features omission has no Rust test"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/azure_ai/test_azure_document_intelligence_ocr_transformation.py",
+      "python_test": "test_map_ocr_params_invalid_features_raises",
+      "status": "unmapped",
+      "reason": "features validation error path has no Rust test"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/azure_ai/test_azure_document_intelligence_ocr_transformation.py",
+      "python_test": "test_get_complete_url_appends_features_query",
+      "status": "unmapped",
+      "reason": "features query-param construction has no Rust test"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/azure_ai/test_azure_document_intelligence_ocr_transformation.py",
+      "python_test": "test_get_complete_url_combines_pages_and_features",
+      "status": "mapped",
+      "rust_file": "litellm-rust/crates/core/src/providers/azure_ai/ocr/transformation.rs",
+      "rust_test": "document_intelligence_url_normalizes_zero_based_pages",
+      "justification": "both assert 0-based, duplicate page indices are deduped, sorted, and rewritten 1-based into the request URL"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/azure_ai/test_azure_document_intelligence_ocr_transformation.py",
+      "python_test": "test_validate_environment_uses_subscription_key",
+      "status": "unmapped",
+      "reason": "Python-side header derivation from litellm_params; Rust's poll test only checks the header is present, not how it was resolved"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/azure_ai/test_azure_document_intelligence_ocr_transformation.py",
+      "python_test": "test_validate_environment_falls_back_to_entra_token",
+      "status": "unmapped",
+      "reason": "Entra bearer-token fallback logic has no Rust test"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_ocr_azure_document_intelligence_api_base.py",
+      "python_test": "TestIsAzureDocumentIntelligenceModel::test_matches_doc_intelligence_route",
+      "status": "unmapped",
+      "reason": "model-route string matching is Python-only dispatch logic"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_ocr_azure_document_intelligence_api_base.py",
+      "python_test": "TestIsAzureDocumentIntelligenceModel::test_matches_documentintelligence_and_is_case_insensitive",
+      "status": "unmapped",
+      "reason": "model-route string matching is Python-only dispatch logic"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_ocr_azure_document_intelligence_api_base.py",
+      "python_test": "TestIsAzureDocumentIntelligenceModel::test_does_not_match_mistral_route",
+      "status": "unmapped",
+      "reason": "model-route string matching is Python-only dispatch logic"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_ocr_azure_document_intelligence_api_base.py",
+      "python_test": "TestDocIntelligenceApiBaseResolution::test_generic_azure_ai_base_does_not_hijack_doc_intelligence",
+      "status": "unmapped",
+      "reason": "api_base resolution from the secret manager runs before the Rust bridge is called, no Rust test exists for it"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_ocr_azure_document_intelligence_api_base.py",
+      "python_test": "TestDocIntelligenceApiBaseResolution::test_explicit_api_base_is_honoured_for_doc_intelligence",
+      "status": "unmapped",
+      "reason": "api_base precedence resolution is Python-only"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_ocr_azure_document_intelligence_api_base.py",
+      "python_test": "TestDocIntelligenceApiBaseResolution::test_generic_azure_ai_base_still_applies_to_mistral_ocr",
+      "status": "unmapped",
+      "reason": "api_base precedence resolution is Python-only"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_rust_bridge.py",
+      "python_test": "test_use_litellm_rust_toggles_flag",
+      "status": "unmapped",
+      "reason": "bridge-plumbing: Python-side feature-flag toggle, no Rust equivalent"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_rust_bridge.py",
+      "python_test": "test_env_var_enables_rust_ocr",
+      "status": "unmapped",
+      "reason": "bridge-plumbing: Python-side env-var flag gating"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_rust_bridge.py",
+      "python_test": "test_load_rust_ocr_returns_injected_impl",
+      "status": "unmapped",
+      "reason": "bridge-plumbing: dependency-injection test hook, not provider behavior"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_rust_bridge.py",
+      "python_test": "test_native_bridge_loader_returns_none_when_extension_absent",
+      "status": "unmapped",
+      "reason": "bridge-plumbing: native-extension import/loader fallback"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_rust_bridge.py",
+      "python_test": "test_native_bridge_loader_caches_absent_extension",
+      "status": "unmapped",
+      "reason": "bridge-plumbing: loader caching behavior"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_rust_bridge.py",
+      "python_test": "test_native_bridge_available_reflects_loader",
+      "status": "unmapped",
+      "reason": "bridge-plumbing: loader availability check"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_rust_bridge.py",
+      "python_test": "test_load_rust_aocr_returns_injected_impl",
+      "status": "unmapped",
+      "reason": "bridge-plumbing: dependency-injection test hook"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_rust_bridge.py",
+      "python_test": "test_toggle_without_ocr_arg_preserves_injected_impl",
+      "status": "unmapped",
+      "reason": "bridge-plumbing: injected-impl state retention regression"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_rust_bridge.py",
+      "python_test": "test_explicit_ocr_none_clears_injected_impl",
+      "status": "unmapped",
+      "reason": "bridge-plumbing: injected-impl clearing behavior"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_rust_bridge.py",
+      "python_test": "test_load_rust_ocr_none_when_extension_absent",
+      "status": "unmapped",
+      "reason": "bridge-plumbing: degrade path when the native extension is missing"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_rust_bridge.py",
+      "python_test": "test_load_rust_ocr_uses_compiled_extension",
+      "status": "unmapped",
+      "reason": "bridge-plumbing: native module resolution"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_rust_bridge.py",
+      "python_test": "test_timeout_to_seconds_handles_float_timeout_and_none",
+      "status": "unmapped",
+      "reason": "bridge-plumbing: Python-side timeout normalization helper"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_rust_bridge.py",
+      "python_test": "test_bridge_wrapper_forwards_prepared_args_and_wraps_response",
+      "status": "unmapped",
+      "reason": "bridge-plumbing: wrapper argument forwarding, asserted against a fake bridge not the real Rust code"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_rust_bridge.py",
+      "python_test": "test_bridge_wrapper_forwards_prepared_async_args_and_wraps_response",
+      "status": "unmapped",
+      "reason": "bridge-plumbing: async wrapper argument forwarding"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_rust_bridge.py",
+      "python_test": "test_run_rust_ocr_prepares_request_and_wraps_response",
+      "status": "unmapped",
+      "reason": "bridge-plumbing: request preparation and response wrapping in Python"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_rust_bridge.py",
+      "python_test": "test_run_rust_ocr_resolves_key_via_secret_manager_when_missing",
+      "status": "unmapped",
+      "reason": "secret-manager: API key resolution happens in Python before the bridge is invoked"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_rust_bridge.py",
+      "python_test": "test_run_rust_ocr_prefers_explicit_key_over_resolver",
+      "status": "unmapped",
+      "reason": "secret-manager: key precedence resolution"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_rust_bridge.py",
+      "python_test": "test_run_rust_ocr_uses_provider_api_key_env_var",
+      "status": "unmapped",
+      "reason": "secret-manager: provider-specific env var name resolution"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_rust_bridge.py",
+      "python_test": "test_prepare_rust_ocr_call_forwards_vertex_routing_metadata",
+      "status": "unmapped",
+      "reason": "secret-manager: vertex routing metadata merge happens in Python"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_rust_bridge.py",
+      "python_test": "test_prepare_rust_ocr_call_resolves_vertex_routing_metadata_from_secret_manager",
+      "status": "unmapped",
+      "reason": "secret-manager: vertex project/location resolution"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_rust_bridge.py",
+      "python_test": "test_prepare_rust_ocr_call_resolves_azure_ai_api_base_from_secret_manager",
+      "status": "unmapped",
+      "reason": "secret-manager: azure_ai api_base resolution"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_rust_bridge.py",
+      "python_test": "test_prepare_rust_ocr_call_resolves_document_intelligence_endpoint",
+      "status": "unmapped",
+      "reason": "secret-manager: doc-intelligence endpoint resolution"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_rust_bridge.py",
+      "python_test": "test_run_rust_ocr_runs_pre_call_logging",
+      "status": "unmapped",
+      "reason": "bridge-plumbing: Python logging-object pre_call invocation"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_rust_bridge.py",
+      "python_test": "test_ocr_routes_to_rust_when_enabled",
+      "status": "unmapped",
+      "reason": "bridge-plumbing: routing to a fake bridge, not the real Rust transform"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_rust_bridge.py",
+      "python_test": "test_ocr_routes_azure_ai_to_rust_when_enabled",
+      "status": "unmapped",
+      "reason": "bridge-plumbing: provider-prefix stripping before routing"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_rust_bridge.py",
+      "python_test": "test_ocr_rust_path_converts_file_document_before_bridge",
+      "status": "unmapped",
+      "reason": "file-normalization: raw-bytes-to-data-URI conversion happens in Python before the bridge call"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_rust_bridge.py",
+      "python_test": "test_ocr_exception_type_uses_resolved_provider_context",
+      "status": "unmapped",
+      "reason": "bridge-plumbing: Python exception-type mapping on bridge failure"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_rust_bridge.py",
+      "python_test": "test_aocr_routes_to_async_rust_when_enabled",
+      "status": "unmapped",
+      "reason": "bridge-plumbing: async routing to a fake bridge"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_rust_bridge.py",
+      "python_test": "test_aocr_exception_type_uses_resolved_provider_context",
+      "status": "unmapped",
+      "reason": "bridge-plumbing: async exception-type mapping on bridge failure"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_rust_bridge.py",
+      "python_test": "test_ocr_does_not_route_to_rust_when_disabled",
+      "status": "unmapped",
+      "reason": "bridge-plumbing: Python control flow for the toggle-disabled branch, no Rust-owned behavior runs"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_rust_bridge.py",
+      "python_test": "test_ocr_falls_back_to_python_when_bridge_unavailable",
+      "status": "unmapped",
+      "reason": "bridge-plumbing: Python-only fallback when the compiled Rust extension is absent, Rust cannot test its own absence"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_rust_bridge.py",
+      "python_test": "test_ocr_forwards_timeout_to_rust",
+      "status": "unmapped",
+      "reason": "bridge-plumbing: asserts the Python call site forwards a timeout kwarg, Rust receives an already-constructed request"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_rust_bridge.py",
+      "python_test": "test_ocr_passes_default_request_timeout_to_rust",
+      "status": "unmapped",
+      "reason": "bridge-plumbing: asserts the Python call site supplies a default timeout kwarg, no Rust equivalent"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_rust_bridge.py",
+      "python_test": "test_ocr_provider_configs_expose_api_key_env_vars",
+      "status": "unmapped",
+      "reason": "asserts per-provider get_api_key_env_var() strings; the closest Rust test (ocr_dispatch_supports_migrated_providers) asserts provider dispatch/param resolution instead, not API key env var names"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_ocr_file_input.py",
+      "python_test": "TestGetMimeType::test_should_detect_pdf_mime_type",
+      "status": "unmapped",
+      "reason": "file-normalization: MIME detection is Python-only preprocessing before the bridge call"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_ocr_file_input.py",
+      "python_test": "TestGetMimeType::test_should_detect_png_mime_type",
+      "status": "unmapped",
+      "reason": "file-normalization: MIME detection"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_ocr_file_input.py",
+      "python_test": "TestGetMimeType::test_should_detect_jpg_mime_type",
+      "status": "unmapped",
+      "reason": "file-normalization: MIME detection"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_ocr_file_input.py",
+      "python_test": "TestGetMimeType::test_should_detect_jpeg_mime_type",
+      "status": "unmapped",
+      "reason": "file-normalization: MIME detection"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_ocr_file_input.py",
+      "python_test": "TestGetMimeType::test_should_detect_gif_mime_type",
+      "status": "unmapped",
+      "reason": "file-normalization: MIME detection"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_ocr_file_input.py",
+      "python_test": "TestGetMimeType::test_should_detect_webp_mime_type",
+      "status": "unmapped",
+      "reason": "file-normalization: MIME detection"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_ocr_file_input.py",
+      "python_test": "TestGetMimeType::test_should_detect_tiff_mime_type",
+      "status": "unmapped",
+      "reason": "file-normalization: MIME detection"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_ocr_file_input.py",
+      "python_test": "TestGetMimeType::test_should_detect_tif_mime_type",
+      "status": "unmapped",
+      "reason": "file-normalization: MIME detection"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_ocr_file_input.py",
+      "python_test": "TestGetMimeType::test_should_detect_bmp_mime_type",
+      "status": "unmapped",
+      "reason": "file-normalization: MIME detection"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_ocr_file_input.py",
+      "python_test": "TestGetMimeType::test_should_be_case_insensitive",
+      "status": "unmapped",
+      "reason": "file-normalization: MIME detection case handling"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_ocr_file_input.py",
+      "python_test": "TestGetMimeType::test_should_fallback_for_unknown_extension",
+      "status": "unmapped",
+      "reason": "file-normalization: MIME detection fallback"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_ocr_file_input.py",
+      "python_test": "TestConvertFileDocumentToUrlDocument::test_should_convert_pdf_pathlib_path_to_document_url",
+      "status": "unmapped",
+      "reason": "file-normalization: local-path-to-data-URI conversion happens in Python"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_ocr_file_input.py",
+      "python_test": "TestConvertFileDocumentToUrlDocument::test_should_convert_image_pathlib_path_to_image_url",
+      "status": "unmapped",
+      "reason": "file-normalization: local-path-to-data-URI conversion"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_ocr_file_input.py",
+      "python_test": "TestConvertFileDocumentToUrlDocument::test_should_reject_bare_str_path",
+      "status": "unmapped",
+      "reason": "file-normalization: arbitrary-file-read guard on bare str paths"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_ocr_file_input.py",
+      "python_test": "TestConvertFileDocumentToUrlDocument::test_should_convert_pathlib_path",
+      "status": "unmapped",
+      "reason": "file-normalization: local-path-to-data-URI conversion"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_ocr_file_input.py",
+      "python_test": "TestConvertFileDocumentToUrlDocument::test_should_convert_raw_bytes",
+      "status": "unmapped",
+      "reason": "file-normalization: raw-bytes-to-data-URI conversion"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_ocr_file_input.py",
+      "python_test": "TestConvertFileDocumentToUrlDocument::test_should_convert_raw_bytes_with_explicit_mime_type",
+      "status": "unmapped",
+      "reason": "file-normalization: explicit MIME override on raw bytes"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_ocr_file_input.py",
+      "python_test": "TestConvertFileDocumentToUrlDocument::test_should_convert_raw_bytes_with_image_mime_type",
+      "status": "unmapped",
+      "reason": "file-normalization: explicit MIME override on raw bytes"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_ocr_file_input.py",
+      "python_test": "TestConvertFileDocumentToUrlDocument::test_should_convert_file_like_object",
+      "status": "unmapped",
+      "reason": "file-normalization: file-like-object conversion"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_ocr_file_input.py",
+      "python_test": "TestConvertFileDocumentToUrlDocument::test_should_convert_file_like_object_with_name",
+      "status": "unmapped",
+      "reason": "file-normalization: file-like-object name-based MIME detection"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_ocr_file_input.py",
+      "python_test": "TestConvertFileDocumentToUrlDocument::test_should_raise_error_for_missing_file_field",
+      "status": "unmapped",
+      "reason": "file-normalization: missing-field validation"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_ocr_file_input.py",
+      "python_test": "TestConvertFileDocumentToUrlDocument::test_should_raise_error_for_nonexistent_pathlib_path",
+      "status": "unmapped",
+      "reason": "file-normalization: missing-file validation"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_ocr_file_input.py",
+      "python_test": "TestConvertFileDocumentToUrlDocument::test_should_raise_error_for_empty_file",
+      "status": "unmapped",
+      "reason": "file-normalization: empty-file validation"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_ocr_file_input.py",
+      "python_test": "TestConvertFileDocumentToUrlDocument::test_should_raise_error_for_unsupported_type",
+      "status": "unmapped",
+      "reason": "file-normalization: unsupported input type validation"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_ocr_file_input.py",
+      "python_test": "TestConvertFileDocumentToUrlDocument::test_should_raise_error_for_invalid_mime_type",
+      "status": "unmapped",
+      "reason": "file-normalization: MIME-type injection validation"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_ocr_file_input.py",
+      "python_test": "TestConvertFileDocumentToUrlDocument::test_should_override_mime_type_for_pathlib_path",
+      "status": "unmapped",
+      "reason": "file-normalization: explicit MIME override precedence"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_ocr_file_input.py",
+      "python_test": "TestBuildDocumentFromUpload::test_should_build_document_url_for_pdf",
+      "status": "unmapped",
+      "reason": "file-normalization: multipart upload conversion"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_ocr_file_input.py",
+      "python_test": "TestBuildDocumentFromUpload::test_should_build_image_url_for_png",
+      "status": "unmapped",
+      "reason": "file-normalization: multipart upload conversion"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_ocr_file_input.py",
+      "python_test": "TestBuildDocumentFromUpload::test_should_build_image_url_for_jpeg",
+      "status": "unmapped",
+      "reason": "file-normalization: multipart upload conversion"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_ocr_file_input.py",
+      "python_test": "TestBuildDocumentFromUpload::test_should_detect_mime_from_filename_when_content_type_is_octet_stream",
+      "status": "unmapped",
+      "reason": "file-normalization: filename-based MIME fallback"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_ocr_file_input.py",
+      "python_test": "TestBuildDocumentFromUpload::test_should_detect_mime_from_filename_when_content_type_is_none",
+      "status": "unmapped",
+      "reason": "file-normalization: filename-based MIME fallback"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_ocr_file_input.py",
+      "python_test": "TestBuildDocumentFromUpload::test_should_fallback_to_octet_stream_for_unknown",
+      "status": "unmapped",
+      "reason": "file-normalization: default MIME fallback"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_ocr_file_input.py",
+      "python_test": "TestBuildDocumentFromUpload::test_should_preserve_base64_content_correctly",
+      "status": "unmapped",
+      "reason": "file-normalization: binary round-trip through base64"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_ocr_file_input.py",
+      "python_test": "TestBuildDocumentFromUpload::test_should_strip_mime_parameters_from_content_type",
+      "status": "unmapped",
+      "reason": "file-normalization: content-type parameter stripping"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_ocr_file_input.py",
+      "python_test": "TestBuildDocumentFromUpload::test_should_strip_mime_parameters_with_multiple_params",
+      "status": "unmapped",
+      "reason": "file-normalization: content-type parameter stripping"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_ocr_file_input.py",
+      "python_test": "TestProxySecurityGuard::test_should_reject_file_type_document_in_json_body",
+      "status": "unmapped",
+      "reason": "proxy-layer JSON-body file-type guard, a different mechanism than Rust's URL-fetch SSRF guard"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_ocr_file_input.py",
+      "python_test": "TestProxySecurityGuard::test_should_accept_document_url_type_in_json_body",
+      "status": "unmapped",
+      "reason": "proxy-layer JSON-body parsing"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_ocr_file_input.py",
+      "python_test": "TestProxySecurityGuard::test_should_raise_on_invalid_json_body",
+      "status": "unmapped",
+      "reason": "proxy-layer JSON-body parsing error path"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_ocr_file_input.py",
+      "python_test": "TestProxySecurityGuard::test_should_ignore_document_form_field_injection",
+      "status": "unmapped",
+      "reason": "proxy-layer multipart form-field injection guard, a different mechanism than Rust's URL-fetch SSRF guard"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_transformation.py",
+      "python_test": "TestGetSupportedOcrParams::test_extract_header_in_supported_params",
+      "status": "mapped",
+      "rust_file": "litellm-rust/crates/core/src/providers/mistral/ocr/transformation.rs",
+      "rust_test": "extract_header_is_a_supported_ocr_param",
+      "justification": "both assert extract_header appears in the Mistral supported OCR params list"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_transformation.py",
+      "python_test": "TestGetSupportedOcrParams::test_extract_footer_in_supported_params",
+      "status": "mapped",
+      "rust_file": "litellm-rust/crates/core/src/providers/mistral/ocr/transformation.rs",
+      "rust_test": "extract_footer_is_a_supported_ocr_param",
+      "justification": "both assert extract_footer appears in the Mistral supported OCR params list"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_transformation.py",
+      "python_test": "TestGetSupportedOcrParams::test_existing_params_still_present",
+      "status": "mapped",
+      "rust_file": "litellm-rust/crates/core/src/providers/mistral/ocr/transformation.rs",
+      "rust_test": "existing_ocr_params_remain_supported",
+      "justification": "both assert the previously supported params are still present in the supported list"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_transformation.py",
+      "python_test": "TestMapOcrParams::test_extract_header_passed_through",
+      "status": "mapped",
+      "rust_file": "litellm-rust/crates/core/src/providers/mistral/ocr/transformation.rs",
+      "rust_test": "map_ocr_params_forwards_extract_header",
+      "justification": "both assert extract_header alone survives map_ocr_params unchanged"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_transformation.py",
+      "python_test": "TestMapOcrParams::test_extract_footer_passed_through",
+      "status": "mapped",
+      "rust_file": "litellm-rust/crates/core/src/providers/mistral/ocr/transformation.rs",
+      "rust_test": "map_ocr_params_forwards_extract_footer",
+      "justification": "both assert extract_footer alone survives map_ocr_params unchanged"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_transformation.py",
+      "python_test": "TestMapOcrParams::test_extract_header_and_footer_together",
+      "status": "mapped",
+      "rust_file": "litellm-rust/crates/core/src/providers/mistral/ocr/transformation.rs",
+      "rust_test": "map_ocr_params_forwards_extract_header_and_footer",
+      "justification": "both assert header and footer passed together are both forwarded with their given values"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_transformation.py",
+      "python_test": "TestMapOcrParams::test_unknown_param_is_dropped",
+      "status": "mapped",
+      "rust_file": "litellm-rust/crates/core/src/providers/mistral/ocr/transformation.rs",
+      "rust_test": "map_ocr_params_drops_unknown_params",
+      "justification": "both assert an unrecognized param key is dropped while a known one is kept"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_transformation.py",
+      "python_test": "TestNewSupportedParams::test_new_param_in_supported_list",
+      "status": "mapped",
+      "rust_file": "litellm-rust/crates/core/src/providers/mistral/ocr/transformation.rs",
+      "rust_test": "new_ocr_params_are_supported",
+      "justification": "both assert each OCR4 param is in the supported list"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_transformation.py",
+      "python_test": "TestNewParamsMapOcr::test_new_param_passed_through",
+      "status": "mapped",
+      "rust_file": "litellm-rust/crates/core/src/providers/mistral/ocr/transformation.rs",
+      "rust_test": "map_ocr_params_forwards_new_ocr_params",
+      "justification": "both assert each OCR4 param/value pair survives map_ocr_params unchanged"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_transformation.py",
+      "python_test": "TestTransformOcrRequest::test_param_included_in_request_body",
+      "status": "mapped",
+      "rust_file": "litellm-rust/crates/core/src/providers/mistral/ocr/transformation.rs",
+      "rust_test": "transform_ocr_request_includes_each_optional_param",
+      "justification": "both assert each optional param value lands in the built request body alongside model/document with no files"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_transformation.py",
+      "python_test": "TestTransformOcrRequest::test_multiple_new_params_together",
+      "status": "mapped",
+      "rust_file": "litellm-rust/crates/core/src/providers/mistral/ocr/transformation.rs",
+      "rust_test": "transform_ocr_request_includes_multiple_new_params",
+      "justification": "both assert multiple OCR4 params passed together all land in the same request body"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_transformation.py",
+      "python_test": "TestTransformOcrResponseOcr4Fields::test_blocks_and_confidence_scores_preserved",
+      "status": "mapped",
+      "rust_file": "litellm-rust/crates/core/src/providers/mistral/ocr/transformation.rs",
+      "rust_test": "transform_ocr_response_preserves_blocks_and_confidence_scores",
+      "justification": "both assert blocks and confidence_scores survive the OCR response transform on the returned page"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_transformation.py",
+      "python_test": "TestTransformOcrResponseOcr4Fields::test_ocr4_fields_survive_model_dump",
+      "status": "mapped",
+      "rust_file": "litellm-rust/crates/core/src/providers/mistral/ocr/transformation.rs",
+      "rust_test": "transform_ocr_response_preserves_ocr4_page_fields",
+      "justification": "both assert tables, hyperlinks, header and footer survive the OCR response transform on the returned page"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_cost.py",
+      "python_test": "test_model_info_ocr4_price",
+      "status": "unmapped",
+      "reason": "cost-calc: pricing/model-info lookup is Python-only"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_cost.py",
+      "python_test": "test_ocr4_cost_scales_with_pages",
+      "status": "unmapped",
+      "reason": "cost-calc: per-page pricing math is Python-only"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_cost.py",
+      "python_test": "test_ocr3_pricing_entry",
+      "status": "unmapped",
+      "reason": "cost-calc: cost-map JSON entry validation is Python-only"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_cost.py",
+      "python_test": "test_ocr3_model_info_price",
+      "status": "unmapped",
+      "reason": "cost-calc: pricing/model-info lookup is Python-only"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_cost.py",
+      "python_test": "test_ocr3_cost_scales_with_pages",
+      "status": "unmapped",
+      "reason": "cost-calc: per-page pricing math is Python-only"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_cost.py",
+      "python_test": "test_ocr3_bills_ocr_and_annotation_pages_at_their_own_rates",
+      "status": "unmapped",
+      "reason": "cost-calc: mixed-rate billing math is Python-only"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_cost.py",
+      "python_test": "test_ocr3_bills_annotation_only_response",
+      "status": "unmapped",
+      "reason": "cost-calc: annotation-only billing math is Python-only"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_cost.py",
+      "python_test": "test_ocr3_bills_annotation_pages_when_pages_processed_missing",
+      "status": "unmapped",
+      "reason": "cost-calc: fallback billing math is Python-only"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_cost.py",
+      "python_test": "test_azure_doc_ai_annotation_pages_fall_back_to_ocr_rate",
+      "status": "unmapped",
+      "reason": "cost-calc: fallback billing math is Python-only"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_ocr_native_format.py",
+      "python_test": "test_rust_ocr_serves_default_format",
+      "status": "unmapped",
+      "reason": "request-format gating decision is made in Python before the Rust bridge is ever invoked"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_ocr_native_format.py",
+      "python_test": "test_rust_ocr_skipped_for_native_format",
+      "status": "unmapped",
+      "reason": "request-format gating decision is made in Python before the Rust bridge is ever invoked"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_ocr_native_format.py",
+      "python_test": "test_native_format_rejected_for_provider_without_support_as_bad_request",
+      "status": "unmapped",
+      "reason": "provider-support validation for req_format happens in Python"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_ocr_native_format.py",
+      "python_test": "test_unknown_format_rejected_for_provider_without_support_as_bad_request",
+      "status": "unmapped",
+      "reason": "req_format validation error path is Python-only"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/ocr/guardrail_translation/test_ocr_guardrail_handler.py",
+      "python_test": "TestHandlerDiscovery::test_handler_discovered_for_ocr",
+      "status": "unmapped",
+      "reason": "guardrail-translation handler discovery is a Python proxy-layer concern"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/ocr/guardrail_translation/test_ocr_guardrail_handler.py",
+      "python_test": "TestHandlerDiscovery::test_handler_discovered_for_aocr",
+      "status": "unmapped",
+      "reason": "guardrail-translation handler discovery is a Python proxy-layer concern"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/ocr/guardrail_translation/test_ocr_guardrail_handler.py",
+      "python_test": "TestInputProcessing::test_process_document_url",
+      "status": "unmapped",
+      "reason": "scoped to the Python translation handler, not the Rust gateway's guardrail hook lifecycle"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/ocr/guardrail_translation/test_ocr_guardrail_handler.py",
+      "python_test": "TestInputProcessing::test_process_image_url",
+      "status": "unmapped",
+      "reason": "scoped to the Python translation handler, not the Rust gateway's guardrail hook lifecycle"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/ocr/guardrail_translation/test_ocr_guardrail_handler.py",
+      "python_test": "TestInputProcessing::test_process_no_document",
+      "status": "unmapped",
+      "reason": "scoped to the Python translation handler, not the Rust gateway's guardrail hook lifecycle"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/ocr/guardrail_translation/test_ocr_guardrail_handler.py",
+      "python_test": "TestInputProcessing::test_process_invalid_document",
+      "status": "unmapped",
+      "reason": "scoped to the Python translation handler, not the Rust gateway's guardrail hook lifecycle"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/ocr/guardrail_translation/test_ocr_guardrail_handler.py",
+      "python_test": "TestInputProcessing::test_input_blocking_guardrail",
+      "status": "unmapped",
+      "reason": "scoped to the Python translation handler, not the Rust gateway's guardrail hook lifecycle"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/ocr/guardrail_translation/test_ocr_guardrail_handler.py",
+      "python_test": "TestOutputProcessing::test_process_single_page",
+      "status": "unmapped",
+      "reason": "scoped to the Python translation handler, not the Rust gateway's guardrail hook lifecycle"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/ocr/guardrail_translation/test_ocr_guardrail_handler.py",
+      "python_test": "TestOutputProcessing::test_process_multiple_pages",
+      "status": "unmapped",
+      "reason": "scoped to the Python translation handler, not the Rust gateway's guardrail hook lifecycle"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/ocr/guardrail_translation/test_ocr_guardrail_handler.py",
+      "python_test": "TestOutputProcessing::test_process_empty_pages",
+      "status": "unmapped",
+      "reason": "scoped to the Python translation handler, not the Rust gateway's guardrail hook lifecycle"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/ocr/guardrail_translation/test_ocr_guardrail_handler.py",
+      "python_test": "TestOutputProcessing::test_process_page_with_empty_markdown",
+      "status": "unmapped",
+      "reason": "scoped to the Python translation handler, not the Rust gateway's guardrail hook lifecycle"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/ocr/guardrail_translation/test_ocr_guardrail_handler.py",
+      "python_test": "TestOutputProcessing::test_process_preserves_page_metadata",
+      "status": "unmapped",
+      "reason": "scoped to the Python translation handler, not the Rust gateway's guardrail hook lifecycle"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/ocr/guardrail_translation/test_ocr_guardrail_handler.py",
+      "python_test": "TestOutputProcessing::test_output_blocking_guardrail",
+      "status": "unmapped",
+      "reason": "scoped to the Python translation handler, not the Rust gateway's guardrail hook lifecycle"
+    },
+    {
+      "python_file": "tests/test_litellm/llms/ocr/guardrail_translation/test_ocr_guardrail_handler.py",
+      "python_test": "TestPIIMaskingScenario::test_pii_masking_in_ocr_pages",
+      "status": "unmapped",
+      "reason": "PII redaction in the translation handler has no Rust equivalent"
+    },
+    {
+      "python_file": "tests/test_litellm/proxy/ocr_endpoints/test_endpoints.py",
+      "python_test": "test_should_read_req_format_from_header",
+      "status": "unmapped",
+      "reason": "proxy-layer header parsing has no Rust equivalent"
+    },
+    {
+      "python_file": "tests/test_litellm/proxy/ocr_endpoints/test_endpoints.py",
+      "python_test": "test_should_prefer_body_req_format_over_header",
+      "status": "unmapped",
+      "reason": "proxy-layer body-vs-header precedence has no Rust equivalent"
+    },
+    {
+      "python_file": "tests/test_litellm/proxy/ocr_endpoints/test_endpoints.py",
+      "python_test": "test_should_omit_req_format_when_header_absent",
+      "status": "unmapped",
+      "reason": "proxy-layer parsing has no Rust equivalent"
+    },
+    {
+      "python_file": "tests/test_litellm/proxy/ocr_endpoints/test_endpoints.py",
+      "python_test": "test_should_reject_unknown_req_format",
+      "status": "unmapped",
+      "reason": "proxy-layer validation has no Rust equivalent"
+    },
+    {
+      "python_file": "tests/test_litellm/proxy/ocr_endpoints/test_endpoints.py",
+      "python_test": "test_should_return_native_payload_with_litellm_response_headers",
+      "status": "unmapped",
+      "reason": "proxy-layer response construction has no Rust equivalent"
+    },
+    {
+      "python_file": "tests/test_litellm/proxy/ocr_endpoints/test_endpoints.py",
+      "python_test": "test_should_return_normalized_response_when_no_native_payload",
+      "status": "unmapped",
+      "reason": "proxy-layer response construction has no Rust equivalent"
+    },
+    {
+      "python_file": "tests/test_litellm/ocr/test_rust_bridge.py",
+      "python_test": "test_explicit_false_overrides_process_enable",
+      "status": "unmapped",
+      "reason": "bridge-plumbing: asserts the explicit-per-request rust:False override wins over the Python process flag, no Rust-owned behavior runs"
+    }
   ],
   "rust_only_tests": [
-    {"rust_file": "litellm-rust/crates/ai-gateway/src/integrations/custom_logger/mod.rs", "rust_test": "rust_custom_logger_reads_failure_payload_for_non_ocr_call_type", "reason": "exercises the non-OCR (acompletion) call-type branch of the logger; the OCR branch is covered separately by rust_custom_logger_reads_success_payload_for_ocr"},
-    {"rust_file": "litellm-rust/crates/ai-gateway/src/integrations/custom_logger/mod.rs", "rust_test": "no_callback_fast_path_dispatches_nothing", "reason": "Rust-only fast-path optimization test for when zero callbacks are registered; Python has no equivalent no-op dispatch path"},
-    {"rust_file": "litellm-rust/crates/ai-gateway/src/integrations/custom_logger/mod.rs", "rust_test": "with_standard_logging_payload_keeps_top_level_fields_in_sync", "reason": "Rust-internal builder-method invariant, Python has no equivalent internal builder"},
-    {"rust_file": "litellm-rust/crates/ai-gateway/src/ocr/common_utils.rs", "rust_test": "blocks_private_and_metadata_ips", "reason": "SSRF IP-blocking helper has no Python unit test; Python relies on the proxy-layer JSON/form guards instead"},
-    {"rust_file": "litellm-rust/crates/ai-gateway/src/ocr/common_utils.rs", "rust_test": "convert_document_url_rejects_loopback_fetch", "reason": "URL-fetch SSRF protection is Rust-gateway-only"},
-    {"rust_file": "litellm-rust/crates/ai-gateway/src/ocr/common_utils.rs", "rust_test": "convert_document_url_leaves_data_uri_untouched", "reason": "URL-fetch SSRF protection is Rust-gateway-only"},
-    {"rust_file": "litellm-rust/crates/ai-gateway/src/ocr/tests.rs", "rust_test": "truncate_error_body_passes_short_strings_through", "reason": "Rust-gateway error-body truncation helper has no Python counterpart"},
-    {"rust_file": "litellm-rust/crates/ai-gateway/src/ocr/tests.rs", "rust_test": "truncate_error_body_caps_long_payloads", "reason": "Rust-gateway error-body truncation helper has no Python counterpart"},
-    {"rust_file": "litellm-rust/crates/ai-gateway/src/ocr/tests.rs", "rust_test": "truncate_error_body_does_not_split_multibyte_chars", "reason": "Rust-gateway error-body truncation helper has no Python counterpart"},
-    {"rust_file": "litellm-rust/crates/ai-gateway/src/ocr/tests.rs", "rust_test": "ocr_dispatch_supports_migrated_providers", "reason": "Rust-internal provider-config dispatch table has no equivalent Python unit test"},
-    {"rust_file": "litellm-rust/crates/ai-gateway/src/ocr/tests.rs", "rust_test": "string_headers_accepts_string_values", "reason": "Rust-gateway header-coercion helper has no Python counterpart"},
-    {"rust_file": "litellm-rust/crates/ai-gateway/src/ocr/tests.rs", "rust_test": "auth_header_detection_is_case_insensitive", "reason": "Rust-gateway header-detection helper has no Python counterpart"},
-    {"rust_file": "litellm-rust/crates/ai-gateway/src/ocr/tests.rs", "rust_test": "ocr_lifecycle_runs_pre_during_and_success_hooks", "reason": "full gateway-level guardrail-hook-plus-HTTP-lifecycle test with no Python equivalent at this integration scope"},
-    {"rust_file": "litellm-rust/crates/ai-gateway/src/ocr/tests.rs", "rust_test": "ocr_lifecycle_runs_failure_hook_on_provider_error", "reason": "full gateway-level failure-hook-plus-HTTP-lifecycle test with no Python equivalent at this integration scope"},
-    {"rust_file": "litellm-rust/crates/ai-gateway/src/ocr/tests.rs", "rust_test": "ocr_lifecycle_pre_call_block_skips_provider_socket", "reason": "full gateway-level pre-call-block-plus-socket-skip test with no Python equivalent at this integration scope"},
-    {"rust_file": "litellm-rust/crates/ai-gateway/src/ocr/tests.rs", "rust_test": "ocr_does_not_duplicate_authorization_header_when_header_is_supplied", "reason": "outgoing HTTP header dedup at the Rust gateway has no Python counterpart"},
-    {"rust_file": "litellm-rust/crates/ai-gateway/src/ocr/tests.rs", "rust_test": "document_intelligence_poll_uses_resolved_subscription_key", "reason": "full Azure DI poll-loop integration test with no Python equivalent at this scope"},
-    {"rust_file": "litellm-rust/crates/ai-gateway/src/ocr/tests.rs", "rust_test": "string_headers_rejects_non_string_values", "reason": "Rust-gateway header-coercion error path has no Python counterpart"},
-    {"rust_file": "litellm-rust/crates/core/src/providers/azure_ai/ocr/transformation.rs", "rust_test": "azure_ai_reuses_mistral_body_transform", "reason": "Rust-internal delegation-to-Mistral-transform implementation detail, no Python test asserts this delegation"},
-    {"rust_file": "litellm-rust/crates/core/src/providers/azure_ai/ocr/transformation.rs", "rust_test": "document_intelligence_request_uses_base64_source_for_data_uri", "reason": "no Python test asserts on the base64Source request body shape"},
-    {"rust_file": "litellm-rust/crates/core/src/providers/vertex_ai/ocr/transformation.rs", "rust_test": "vertex_mistral_url_uses_project_location_and_model", "reason": "vertex OCR support has no Python unit test coverage yet"},
-    {"rust_file": "litellm-rust/crates/core/src/providers/vertex_ai/ocr/transformation.rs", "rust_test": "vertex_mistral_reuses_mistral_body_transform", "reason": "vertex OCR support has no Python unit test coverage yet"},
-    {"rust_file": "litellm-rust/crates/core/src/providers/vertex_ai/ocr/transformation.rs", "rust_test": "vertex_deepseek_request_uses_ocr_endpoint_shape", "reason": "vertex OCR support has no Python unit test coverage yet"},
-    {"rust_file": "litellm-rust/crates/core/src/providers/vertex_ai/ocr/transformation.rs", "rust_test": "vertex_deepseek_response_wraps_markdown_content", "reason": "vertex OCR support has no Python unit test coverage yet"},
-    {"rust_file": "litellm-rust/crates/core/src/providers/mistral/ocr/transformation.rs", "rust_test": "transform_ocr_request_rejects_non_object_document", "reason": "non-object document rejection has no dedicated Python unit test"},
-    {"rust_file": "litellm-rust/crates/core/src/providers/mistral/ocr/transformation.rs", "rust_test": "transform_ocr_response_normalizes_mistral_json", "reason": "Python's response tests target OCR4-specific fields only, none asserts the same base normalization this Rust test checks"},
-    {"rust_file": "litellm-rust/crates/core/src/providers/mistral/ocr/transformation.rs", "rust_test": "complete_url_defaults_and_dedupes_v1", "reason": "URL-building/defaulting for Mistral has no Python unit test"},
-    {"rust_file": "litellm-rust/crates/core/src/providers/mistral/ocr/transformation.rs", "rust_test": "resolve_api_key_prefers_param_then_env", "reason": "API key resolution precedence at the Rust provider-config layer has no Python unit test"},
-    {"rust_file": "litellm-rust/crates/core/src/providers/mistral/ocr/transformation.rs", "rust_test": "resolve_api_key_errors_when_absent", "reason": "API key resolution error path at the Rust provider-config layer has no Python unit test"},
-    {"rust_file": "litellm-rust/crates/ai-gateway/src/integrations/custom_logger/mod.rs", "rust_test": "rust_custom_logger_reads_success_payload_for_ocr", "reason": "Rust-internal custom-logger dispatch for OCR payloads has no Python unit test at this layer"}
+    {
+      "rust_file": "litellm-rust/crates/ai-gateway/src/integrations/custom_logger/mod.rs",
+      "rust_test": "rust_custom_logger_reads_failure_payload_for_non_ocr_call_type",
+      "reason": "exercises the non-OCR (acompletion) call-type branch of the logger; the OCR branch is covered separately by rust_custom_logger_reads_success_payload_for_ocr"
+    },
+    {
+      "rust_file": "litellm-rust/crates/ai-gateway/src/integrations/custom_logger/mod.rs",
+      "rust_test": "no_callback_fast_path_dispatches_nothing",
+      "reason": "Rust-only fast-path optimization test for when zero callbacks are registered; Python has no equivalent no-op dispatch path"
+    },
+    {
+      "rust_file": "litellm-rust/crates/ai-gateway/src/integrations/custom_logger/mod.rs",
+      "rust_test": "with_standard_logging_payload_keeps_top_level_fields_in_sync",
+      "reason": "Rust-internal builder-method invariant, Python has no equivalent internal builder"
+    },
+    {
+      "rust_file": "litellm-rust/crates/ai-gateway/src/ocr/common_utils.rs",
+      "rust_test": "blocks_private_and_metadata_ips",
+      "reason": "SSRF IP-blocking helper has no Python unit test; Python relies on the proxy-layer JSON/form guards instead"
+    },
+    {
+      "rust_file": "litellm-rust/crates/ai-gateway/src/ocr/common_utils.rs",
+      "rust_test": "convert_document_url_rejects_loopback_fetch",
+      "reason": "URL-fetch SSRF protection is Rust-gateway-only"
+    },
+    {
+      "rust_file": "litellm-rust/crates/ai-gateway/src/ocr/common_utils.rs",
+      "rust_test": "convert_document_url_leaves_data_uri_untouched",
+      "reason": "URL-fetch SSRF protection is Rust-gateway-only"
+    },
+    {
+      "rust_file": "litellm-rust/crates/ai-gateway/src/ocr/tests.rs",
+      "rust_test": "truncate_error_body_passes_short_strings_through",
+      "reason": "Rust-gateway error-body truncation helper has no Python counterpart"
+    },
+    {
+      "rust_file": "litellm-rust/crates/ai-gateway/src/ocr/tests.rs",
+      "rust_test": "truncate_error_body_caps_long_payloads",
+      "reason": "Rust-gateway error-body truncation helper has no Python counterpart"
+    },
+    {
+      "rust_file": "litellm-rust/crates/ai-gateway/src/ocr/tests.rs",
+      "rust_test": "truncate_error_body_does_not_split_multibyte_chars",
+      "reason": "Rust-gateway error-body truncation helper has no Python counterpart"
+    },
+    {
+      "rust_file": "litellm-rust/crates/ai-gateway/src/ocr/tests.rs",
+      "rust_test": "ocr_dispatch_supports_migrated_providers",
+      "reason": "Rust-internal provider-config dispatch table has no equivalent Python unit test"
+    },
+    {
+      "rust_file": "litellm-rust/crates/ai-gateway/src/ocr/tests.rs",
+      "rust_test": "string_headers_accepts_string_values",
+      "reason": "Rust-gateway header-coercion helper has no Python counterpart"
+    },
+    {
+      "rust_file": "litellm-rust/crates/ai-gateway/src/ocr/tests.rs",
+      "rust_test": "auth_header_detection_is_case_insensitive",
+      "reason": "Rust-gateway header-detection helper has no Python counterpart"
+    },
+    {
+      "rust_file": "litellm-rust/crates/ai-gateway/src/ocr/tests.rs",
+      "rust_test": "ocr_lifecycle_runs_pre_during_and_success_hooks",
+      "reason": "full gateway-level guardrail-hook-plus-HTTP-lifecycle test with no Python equivalent at this integration scope"
+    },
+    {
+      "rust_file": "litellm-rust/crates/ai-gateway/src/ocr/tests.rs",
+      "rust_test": "ocr_lifecycle_runs_failure_hook_on_provider_error",
+      "reason": "full gateway-level failure-hook-plus-HTTP-lifecycle test with no Python equivalent at this integration scope"
+    },
+    {
+      "rust_file": "litellm-rust/crates/ai-gateway/src/ocr/tests.rs",
+      "rust_test": "ocr_lifecycle_pre_call_block_skips_provider_socket",
+      "reason": "full gateway-level pre-call-block-plus-socket-skip test with no Python equivalent at this integration scope"
+    },
+    {
+      "rust_file": "litellm-rust/crates/ai-gateway/src/ocr/tests.rs",
+      "rust_test": "ocr_does_not_duplicate_authorization_header_when_header_is_supplied",
+      "reason": "outgoing HTTP header dedup at the Rust gateway has no Python counterpart"
+    },
+    {
+      "rust_file": "litellm-rust/crates/ai-gateway/src/ocr/tests.rs",
+      "rust_test": "document_intelligence_poll_uses_resolved_subscription_key",
+      "reason": "full Azure DI poll-loop integration test with no Python equivalent at this scope"
+    },
+    {
+      "rust_file": "litellm-rust/crates/ai-gateway/src/ocr/tests.rs",
+      "rust_test": "string_headers_rejects_non_string_values",
+      "reason": "Rust-gateway header-coercion error path has no Python counterpart"
+    },
+    {
+      "rust_file": "litellm-rust/crates/core/src/providers/azure_ai/ocr/transformation.rs",
+      "rust_test": "azure_ai_reuses_mistral_body_transform",
+      "reason": "Rust-internal delegation-to-Mistral-transform implementation detail, no Python test asserts this delegation"
+    },
+    {
+      "rust_file": "litellm-rust/crates/core/src/providers/azure_ai/ocr/transformation.rs",
+      "rust_test": "document_intelligence_request_uses_base64_source_for_data_uri",
+      "reason": "no Python test asserts on the base64Source request body shape"
+    },
+    {
+      "rust_file": "litellm-rust/crates/core/src/providers/vertex_ai/ocr/transformation.rs",
+      "rust_test": "vertex_mistral_url_uses_project_location_and_model",
+      "reason": "vertex OCR support has no Python unit test coverage yet"
+    },
+    {
+      "rust_file": "litellm-rust/crates/core/src/providers/vertex_ai/ocr/transformation.rs",
+      "rust_test": "vertex_mistral_reuses_mistral_body_transform",
+      "reason": "vertex OCR support has no Python unit test coverage yet"
+    },
+    {
+      "rust_file": "litellm-rust/crates/core/src/providers/vertex_ai/ocr/transformation.rs",
+      "rust_test": "vertex_deepseek_request_uses_ocr_endpoint_shape",
+      "reason": "vertex OCR support has no Python unit test coverage yet"
+    },
+    {
+      "rust_file": "litellm-rust/crates/core/src/providers/vertex_ai/ocr/transformation.rs",
+      "rust_test": "vertex_deepseek_response_wraps_markdown_content",
+      "reason": "vertex OCR support has no Python unit test coverage yet"
+    },
+    {
+      "rust_file": "litellm-rust/crates/core/src/providers/mistral/ocr/transformation.rs",
+      "rust_test": "transform_ocr_request_rejects_non_object_document",
+      "reason": "non-object document rejection has no dedicated Python unit test"
+    },
+    {
+      "rust_file": "litellm-rust/crates/core/src/providers/mistral/ocr/transformation.rs",
+      "rust_test": "transform_ocr_response_normalizes_mistral_json",
+      "reason": "Python's response tests target OCR4-specific fields only, none asserts the same base normalization this Rust test checks"
+    },
+    {
+      "rust_file": "litellm-rust/crates/core/src/providers/mistral/ocr/transformation.rs",
+      "rust_test": "complete_url_defaults_and_dedupes_v1",
+      "reason": "URL-building/defaulting for Mistral has no Python unit test"
+    },
+    {
+      "rust_file": "litellm-rust/crates/core/src/providers/mistral/ocr/transformation.rs",
+      "rust_test": "resolve_api_key_prefers_param_then_env",
+      "reason": "API key resolution precedence at the Rust provider-config layer has no Python unit test"
+    },
+    {
+      "rust_file": "litellm-rust/crates/core/src/providers/mistral/ocr/transformation.rs",
+      "rust_test": "resolve_api_key_errors_when_absent",
+      "reason": "API key resolution error path at the Rust provider-config layer has no Python unit test"
+    },
+    {
+      "rust_file": "litellm-rust/crates/ai-gateway/src/integrations/custom_logger/mod.rs",
+      "rust_test": "rust_custom_logger_reads_success_payload_for_ocr",
+      "reason": "Rust-internal custom-logger dispatch for OCR payloads has no Python unit test at this layer"
+    }
   ]
 }


### PR DESCRIPTION
## TLDR

Problem this solves:

- Mistral OCR ledger mappings reused broad Rust tests
- Eight Mistral transformation contracts were not mapped

How it solves it:

- Adds dedicated Rust assertions for each Python contract
- Maps all 13 Mistral OCR contracts one-to-one

## User Flow

Before: a developer enabling newer Mistral OCR options has incomplete Rust parity evidence

1. They send an OCR request with OCR4 parameters such as `table_format` or `include_blocks`
2. Rust supports the values, but broad tests cover several behaviors together
3. The parity ledger maps 5 of 13 Python Mistral transformation contracts

After: the same OCR options each have a dedicated Rust parity assertion

1. They send the same OCR request with OCR4 parameters
2. The Rust transformation keeps each parameter and structured response field
3. The ledger maps 13 of 13 Python Mistral transformation contracts to distinct Rust tests

## Relevant issues

## Linear ticket

Resolves LIT-6790

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

### Before (upstream/litellm_internal_staging)

1. The OCR parity ledger maps 5/13 Mistral Python transformation contracts through 3 shared Rust tests

### After (b9810817f2)

1. `uv run python -m tests.rust-python-harness --validate-ledger --function ocr` reports 16/146 OCR mappings and an in-sync ledger
2. Mistral maps 13/13 contracts to 13 unique Rust targets
3. Python Mistral OCR transformation tests: 29 passed
4. Rust Mistral OCR tests: 18 passed
5. `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` pass

## Type

✅ Test

## Caveats (if any)

### Low

- The OCR-wide validator remains inventory-only; LIT-6789 adds strict duplicate enforcement
