### PR TITLE
feat(ui): add 1M context auto-router preset

### DIFF
--- a/litellm/proxy/public_endpoints/autorouter_presets.json
+++ b/litellm/proxy/public_endpoints/autorouter_presets.json
@@ -12,7 +12,7 @@
       "tier_model_configs": {
         "REASONING": [{ "model_name": "claude-opus-5", "litellm_params": { "reasoning_effort": "high" } }]
       },
-      "classifier_type": "heuristic",
+      "classifier_type": "heuristic_v2",
       "escalation_keywords": ["LITELLM ESCALATE"],
       "classification_mode": "every_request",
       "session_affinity": false,

--- a/litellm/proxy/public_endpoints/autorouter_presets.json
+++ b/litellm/proxy/public_endpoints/autorouter_presets.json
@@ -1,4 +1,26 @@
 {
+  "1m_context": {
+    "label": "1M Context",
+    "description": "Routes across models with 1M-token context windows: Luna for simple queries, Terra for medium, Opus 5 for complex, Opus 5 at high thinking for reasoning.",
+    "complexity_router_config": {
+      "tiers": {
+        "SIMPLE": ["gpt-5.6-luna"],
+        "MEDIUM": ["gpt-5.6-terra"],
+        "COMPLEX": ["claude-opus-5"],
+        "REASONING": ["claude-opus-5"]
+      },
+      "tier_model_configs": {
+        "REASONING": [{ "model_name": "claude-opus-5", "litellm_params": { "reasoning_effort": "high" } }]
+      },
+      "classifier_type": "heuristic",
+      "escalation_keywords": ["LITELLM ESCALATE"],
+      "classification_mode": "every_request",
+      "session_affinity": false,
+      "modality_routing": false,
+      "modality_pin_override": false,
+      "deployment_affinity": true
+    }
+  },
   "anthropic_family": {
     "label": "Anthropic Family",
     "description": "Routes across the Claude model family: Haiku for simple queries, Sonnet for medium, Opus for complex, Opus at high thinking for reasoning.",

--- a/tests/test_litellm/proxy/public_endpoints/test_public_endpoints.py
+++ b/tests/test_litellm/proxy/public_endpoints/test_public_endpoints.py
@@ -1104,6 +1104,15 @@ def test_get_autorouter_presets_local_mode_serves_bundled_catalog(
     assert response.status_code == 200
     payload = response.json()
     assert "anthropic_family" in payload
+    assert payload["1m_context"]["complexity_router_config"]["tiers"] == {
+        "SIMPLE": ["gpt-5.6-luna"],
+        "MEDIUM": ["gpt-5.6-terra"],
+        "COMPLEX": ["claude-opus-5"],
+        "REASONING": ["claude-opus-5"],
+    }
+    assert payload["1m_context"]["complexity_router_config"]["tier_model_configs"] == {
+        "REASONING": [{"model_name": "claude-opus-5", "litellm_params": {"reasoning_effort": "high"}}]
+    }
     for preset in payload.values():
         assert isinstance(preset["label"], str)
         assert isinstance(preset["description"], str)

--- a/tests/test_litellm/proxy/public_endpoints/test_public_endpoints.py
+++ b/tests/test_litellm/proxy/public_endpoints/test_public_endpoints.py
@@ -1104,6 +1104,7 @@ def test_get_autorouter_presets_local_mode_serves_bundled_catalog(
     assert response.status_code == 200
     payload = response.json()
     assert "anthropic_family" in payload
+    assert payload["1m_context"]["complexity_router_config"]["classifier_type"] == "heuristic_v2"
     assert payload["1m_context"]["complexity_router_config"]["tiers"] == {
         "SIMPLE": ["gpt-5.6-luna"],
         "MEDIUM": ["gpt-5.6-terra"],

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
@@ -636,7 +636,14 @@ describe("AddAutoRouterTab", () => {
 
     const labels = visibleOptions().map((option) => option.querySelector(".font-medium")?.textContent);
 
-    expect(labels).toEqual(["Anthropic Family", "Gemini Family", "Lite", "OpenAI Family", "Custom Configuration"]);
+    expect(labels).toEqual([
+      "1M Context",
+      "Anthropic Family",
+      "Gemini Family",
+      "Lite",
+      "OpenAI Family",
+      "Custom Configuration",
+    ]);
   });
 
   describe("routing test", () => {
@@ -1060,7 +1067,14 @@ describe("AddAutoRouterTab", () => {
         expect(isOptionDisabled(optionByLabel("Anthropic Family")!)).toBe(false);
       });
       const labels = visibleOptions().map((option) => option.querySelector(".font-medium")?.textContent);
-      expect(labels).toEqual(["Anthropic Family", "Gemini Family", "Lite", "OpenAI Family", "Custom Configuration"]);
+      expect(labels).toEqual([
+        "Anthropic Family",
+        "1M Context",
+        "Gemini Family",
+        "Lite",
+        "OpenAI Family",
+        "Custom Configuration",
+      ]);
     });
 
     it.each([

--- a/ui/litellm-dashboard/src/lib/autorouter_presets.test.ts
+++ b/ui/litellm-dashboard/src/lib/autorouter_presets.test.ts
@@ -210,13 +210,14 @@ describe("autorouter_presets", () => {
 
   it("pins the 1M context preset to Luna, Terra, and Opus at high thinking", () => {
     const preset = getPresetByKey("1m_context")!;
-    expect(preset.complexity_router_config.classifier_type).toBe("heuristic_v2");
-    expect(preset.complexity_router_config.tiers).toEqual({
+    const expectedTiers = {
       SIMPLE: ["gpt-5.6-luna"],
       MEDIUM: ["gpt-5.6-terra"],
       COMPLEX: ["claude-opus-5"],
       REASONING: ["claude-opus-5"],
-    });
+    };
+    expect(preset.complexity_router_config.classifier_type).toBe("heuristic_v2");
+    expect(preset.complexity_router_config.tiers).toEqual(expectedTiers);
     expect(preset.complexity_router_config.tier_model_configs).toEqual({
       REASONING: [{ model_name: "claude-opus-5", litellm_params: { reasoning_effort: "high" } }],
     });

--- a/ui/litellm-dashboard/src/lib/autorouter_presets.test.ts
+++ b/ui/litellm-dashboard/src/lib/autorouter_presets.test.ts
@@ -28,7 +28,13 @@ const getPresetByKey = (key: string): AutoRouterPreset | undefined => PRESETS.fi
 describe("autorouter_presets", () => {
   it("hydrates exactly the bundled presets", () => {
     const presets = getAllPresets();
-    expect(presets.map((p) => p.label).sort()).toEqual(["Anthropic Family", "Gemini Family", "Lite", "OpenAI Family"]);
+    expect(presets.map((p) => p.label).sort()).toEqual([
+      "1M Context",
+      "Anthropic Family",
+      "Gemini Family",
+      "Lite",
+      "OpenAI Family",
+    ]);
     // Every preset carries all four fields the UI relies on; a JSON typo dropping one fails here.
     for (const p of presets) {
       expect(p).toMatchObject({ key: expect.any(String), label: expect.any(String), description: expect.any(String) });
@@ -199,6 +205,23 @@ describe("autorouter_presets", () => {
     const prefill = buildPresetPrefill(preset.complexity_router_config, groupsOnly(getRequiredModelsInPreset(preset)));
     expect(prefill.complexityRouterConfig.tier_model_params).toEqual({
       REASONING: { "gpt-5.6-sol": { reasoning_effort: "xhigh" } },
+    });
+  });
+
+  it("pins the 1M context preset to Luna, Terra, and Opus at high thinking", () => {
+    const preset = getPresetByKey("1m_context")!;
+    expect(preset.complexity_router_config.tiers).toEqual({
+      SIMPLE: ["gpt-5.6-luna"],
+      MEDIUM: ["gpt-5.6-terra"],
+      COMPLEX: ["claude-opus-5"],
+      REASONING: ["claude-opus-5"],
+    });
+    expect(preset.complexity_router_config.tier_model_configs).toEqual({
+      REASONING: [{ model_name: "claude-opus-5", litellm_params: { reasoning_effort: "high" } }],
+    });
+    const prefill = buildPresetPrefill(preset.complexity_router_config, groupsOnly(getRequiredModelsInPreset(preset)));
+    expect(prefill.complexityRouterConfig.tier_model_params).toEqual({
+      REASONING: { "claude-opus-5": { reasoning_effort: "high" } },
     });
   });
 

--- a/ui/litellm-dashboard/src/lib/autorouter_presets.test.ts
+++ b/ui/litellm-dashboard/src/lib/autorouter_presets.test.ts
@@ -210,6 +210,7 @@ describe("autorouter_presets", () => {
 
   it("pins the 1M context preset to Luna, Terra, and Opus at high thinking", () => {
     const preset = getPresetByKey("1m_context")!;
+    expect(preset.complexity_router_config.classifier_type).toBe("heuristic_v2");
     expect(preset.complexity_router_config.tiers).toEqual({
       SIMPLE: ["gpt-5.6-luna"],
       MEDIUM: ["gpt-5.6-terra"],


### PR DESCRIPTION
## TLDR

Problem this solves:

- No preset covers mixed-provider 1M-context routing

How it solves it:

- Adds Luna, Terra, and Opus tier routing
- Runs the reasoning tier with high thinking
- Uses the calibrated Heuristic v2 classifier

## User Flow

Before: an admin cannot start an auto-router from a ready-made 1M-context configuration

1. They open `http://localhost:4000/ui/?page=models&selectedTab=add-auto-router`
2. They open the template picker
3. The picker has no 1M-context option, so they must configure all four tiers manually

After: the same admin can prefill all four tiers from the 1M Context template

1. They open `http://localhost:4000/ui/?page=models&selectedTab=add-auto-router`
2. They open the template picker
3. They choose `1M Context` and see Luna, Terra, Opus 5, and Opus 5 with high thinking prefilled
4. They expand Detailed Configuration and see `Heuristic v2` selected

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

### Before (e058aa68c4)

1. Open `http://localhost:4000/ui/?page=models&selectedTab=add-auto-router`
2. Open the template picker and observe that `1M Context` is absent

### After (400be7a78f)

1. Open `http://localhost:4000/ui/?page=models&selectedTab=add-auto-router`
2. Open the template picker and select `1M Context`
3. Observe Luna, Terra, Opus 5, and Opus 5 with high thinking in the four tiers
4. Expand Detailed Configuration and observe `Heuristic v2` selected

## Type

🆕 New Feature
✅ Test

## Caveats (if any)

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
