### PR TITLE
test: map vertex ocr tests between python and rust

### DIFF
--- a/tests/ocr_tests/test_ocr_vertex_ai.py
+++ b/tests/ocr_tests/test_ocr_vertex_ai.py
@@ -9,7 +9,9 @@ import json
 import os
 import tempfile
 from typing import Final
+from unittest.mock import MagicMock
 
+import httpx
 import pytest
 from base_ocr_unit_tests import BaseOCRTest
 
@@ -143,7 +145,9 @@ def test_vertex_ai_ocr_routing():
     ), "DeepSeek variant should route to VertexAIDeepSeekOCRConfig"
 
 
-@pytest.mark.parametrize("model", ("deepseek-ocr-maas", "deepseek-ai/deepseek-ocr-maas"))
+@pytest.mark.parametrize(
+    "model", ("deepseek-ocr-maas", "deepseek-ai/deepseek-ocr-maas")
+)
 def test_deepseek_request_uses_single_provider_namespace(model: str) -> None:
     from litellm.llms.vertex_ai.ocr.deepseek_transformation import (
         VertexAIDeepSeekOCRConfig,
@@ -157,3 +161,68 @@ def test_deepseek_request_uses_single_provider_namespace(model: str) -> None:
     )
 
     assert request.data["model"] == "deepseek-ai/deepseek-ocr-maas"
+
+
+def test_vertex_mistral_url_uses_project_location_and_model() -> None:
+    """Vertex Mistral OCR URL is built from project, location, and model in the Mistral publisher path."""
+    from litellm.llms.vertex_ai.ocr.transformation import VertexAIOCRConfig
+
+    url: Final = VertexAIOCRConfig().get_complete_url(
+        api_base=None,
+        model="mistral-ocr-maas",
+        optional_params={},
+        litellm_params={"vertex_project": "proj-1", "vertex_location": "europe-west4"},
+    )
+
+    assert url == (
+        "https://europe-west4-aiplatform.googleapis.com/v1/projects/proj-1"
+        "/locations/europe-west4/publishers/mistralai/models/mistral-ocr-maas:rawPredict"
+    )
+
+
+def test_vertex_mistral_reuses_mistral_body_transform() -> None:
+    """Vertex Mistral OCR delegates request-body construction to MistralOCRConfig unchanged."""
+    from litellm.llms.vertex_ai.ocr.transformation import VertexAIOCRConfig
+
+    request: Final = VertexAIOCRConfig().transform_ocr_request(
+        model="mistral-ocr-maas",
+        document={"type": "image_url", "image_url": "data:image/png;base64,abc"},
+        optional_params={},
+        headers={},
+    )
+
+    assert request.data["model"] == "mistral-ocr-maas"
+    assert request.data["document"]["image_url"] == "data:image/png;base64,abc"
+
+
+def test_vertex_deepseek_response_wraps_markdown_content() -> None:
+    """Vertex DeepSeek OCR wraps a plain-markdown chat completion into a single-page OCR response."""
+    from litellm.llms.vertex_ai.ocr.deepseek_transformation import (
+        VertexAIDeepSeekOCRConfig,
+    )
+
+    raw_response: Final = httpx.Response(
+        status_code=200,
+        json={
+            "choices": [{"message": {"content": "# OCR text"}}],
+            "usage": {"prompt_tokens": 1},
+        },
+    )
+
+    response = VertexAIDeepSeekOCRConfig().transform_ocr_response(
+        model="deepseek-ocr-maas",
+        raw_response=raw_response,
+        logging_obj=MagicMock(),
+    )
+
+    assert [page.model_dump() for page in response.pages] == [
+        {
+            "index": 0,
+            "markdown": "# OCR text",
+            "images": None,
+            "dimensions": None,
+        }
+    ]
+    assert response.model == "deepseek-ocr-maas"
+    assert response.usage_info is not None
+    assert response.usage_info.model_dump()["prompt_tokens"] == 1

--- a/tests/rust-python-harness/strategies/unit_tests/ledgers/ocr/ocr_test_ledger.json
+++ b/tests/rust-python-harness/strategies/unit_tests/ledgers/ocr/ocr_test_ledger.json
@@ -9,7 +9,8 @@
     "tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_cost.py",
     "tests/test_litellm/ocr/test_ocr_native_format.py",
     "tests/test_litellm/llms/ocr/guardrail_translation/test_ocr_guardrail_handler.py",
-    "tests/test_litellm/proxy/ocr_endpoints/test_endpoints.py"
+    "tests/test_litellm/proxy/ocr_endpoints/test_endpoints.py",
+    "tests/ocr_tests/test_ocr_vertex_ai.py"
   ],
   "rust_scope": [
     "litellm-rust/crates/ai-gateway/src/ocr/common_utils.rs",
@@ -927,6 +928,56 @@
       "python_test": "test_explicit_false_overrides_process_enable",
       "status": "unmapped",
       "reason": "bridge-plumbing: asserts the explicit-per-request rust:False override wins over the Python process flag, no Rust-owned behavior runs"
+    },
+    {
+      "python_file": "tests/ocr_tests/test_ocr_vertex_ai.py",
+      "python_test": "test_vertex_ai_ocr_routing",
+      "status": "unmapped",
+      "reason": "model-name based routing dispatch (mistral vs deepseek config selection) is Python-only; the closest Rust behavior (is_deepseek_model) has no dedicated unit test at this layer"
+    },
+    {
+      "python_file": "tests/ocr_tests/test_ocr_vertex_ai.py",
+      "python_test": "test_deepseek_request_uses_single_provider_namespace",
+      "status": "mapped",
+      "rust_file": "litellm-rust/crates/core/src/providers/vertex_ai/ocr/transformation.rs",
+      "rust_test": "vertex_deepseek_request_uses_ocr_endpoint_shape",
+      "justification": "both assert an unprefixed deepseek model name is normalized to the deepseek-ai/ provider namespace in the built request body"
+    },
+    {
+      "python_file": "tests/ocr_tests/test_ocr_vertex_ai.py",
+      "python_test": "test_vertex_mistral_url_uses_project_location_and_model",
+      "status": "mapped",
+      "rust_file": "litellm-rust/crates/core/src/providers/vertex_ai/ocr/transformation.rs",
+      "rust_test": "vertex_mistral_url_uses_project_location_and_model",
+      "justification": "both assert the Vertex Mistral OCR URL is built from project, location, and model in the mistralai publisher rawPredict path"
+    },
+    {
+      "python_file": "tests/ocr_tests/test_ocr_vertex_ai.py",
+      "python_test": "test_vertex_mistral_reuses_mistral_body_transform",
+      "status": "mapped",
+      "rust_file": "litellm-rust/crates/core/src/providers/vertex_ai/ocr/transformation.rs",
+      "rust_test": "vertex_mistral_reuses_mistral_body_transform",
+      "justification": "both assert Vertex Mistral OCR delegates request-body construction to the Mistral transform unchanged for an already-data-URI document"
+    },
+    {
+      "python_file": "tests/ocr_tests/test_ocr_vertex_ai.py",
+      "python_test": "test_vertex_deepseek_response_wraps_markdown_content",
+      "status": "mapped",
+      "rust_file": "litellm-rust/crates/core/src/providers/vertex_ai/ocr/transformation.rs",
+      "rust_test": "vertex_deepseek_response_wraps_markdown_content",
+      "justification": "both assert a plain-markdown DeepSeek chat completion is wrapped into a single page (index 0) with the response usage carried through"
+    },
+    {
+      "python_file": "tests/ocr_tests/test_ocr_vertex_ai.py",
+      "python_test": "TestVertexAIDeepSeekOCR::test_basic_ocr_with_url",
+      "status": "unmapped",
+      "reason": "no-op override that skips the inherited live-API base test (DeepSeek OCR does not support PDF URLs); no behavior runs"
+    },
+    {
+      "python_file": "tests/ocr_tests/test_ocr_vertex_ai.py",
+      "python_test": "TestVertexAIDeepSeekOCR::test_ocr_response_structure",
+      "status": "unmapped",
+      "reason": "no-op override that skips the inherited live-API base test (DeepSeek OCR does not support PDF URLs); no behavior runs"
     }
   ],
   "rust_only_tests": [
@@ -1029,26 +1080,6 @@
       "rust_file": "litellm-rust/crates/core/src/providers/azure_ai/ocr/transformation.rs",
       "rust_test": "document_intelligence_request_uses_base64_source_for_data_uri",
       "reason": "no Python test asserts on the base64Source request body shape"
-    },
-    {
-      "rust_file": "litellm-rust/crates/core/src/providers/vertex_ai/ocr/transformation.rs",
-      "rust_test": "vertex_mistral_url_uses_project_location_and_model",
-      "reason": "vertex OCR support has no Python unit test coverage yet"
-    },
-    {
-      "rust_file": "litellm-rust/crates/core/src/providers/vertex_ai/ocr/transformation.rs",
-      "rust_test": "vertex_mistral_reuses_mistral_body_transform",
-      "reason": "vertex OCR support has no Python unit test coverage yet"
-    },
-    {
-      "rust_file": "litellm-rust/crates/core/src/providers/vertex_ai/ocr/transformation.rs",
-      "rust_test": "vertex_deepseek_request_uses_ocr_endpoint_shape",
-      "reason": "vertex OCR support has no Python unit test coverage yet"
-    },
-    {
-      "rust_file": "litellm-rust/crates/core/src/providers/vertex_ai/ocr/transformation.rs",
-      "rust_test": "vertex_deepseek_response_wraps_markdown_content",
-      "reason": "vertex OCR support has no Python unit test coverage yet"
     },
     {
       "rust_file": "litellm-rust/crates/core/src/providers/mistral/ocr/transformation.rs",


### PR DESCRIPTION
## TLDR

Problem this solves:

- 4 Rust vertex OCR transformation tests had no Python counterpart in the parity ledger
- The deterministic Python vertex OCR tests weren't tracked in the ledger at all

How it solves it:

- Added 3 new deterministic Python unit tests for behavior the Rust side already covers (URL building, Mistral body delegation, DeepSeek markdown wrapping)
- Mapped the existing DeepSeek model-namespace test to its matching Rust test
- Updated ocr_test_ledger.json so all 4 previously rust-only vertex tests are now mapped, and every test in tests/ocr_tests/test_ocr_vertex_ai.py is tracked

## Relevant issues

## Linear ticket

Resolves LIT-6792

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

This PR is test-infrastructure only (new unit tests plus a parity ledger update), so there's no end-user behavior to curl against a live proxy. Proof here is the actual test and ledger-validator runs.

### Before (291d02f8c)

1. `uv run python -m tests.rust-python-harness --validate-ledger --function ocr` reports `vertex_mistral_url_uses_project_location_and_model`, `vertex_mistral_reuses_mistral_body_transform`, `vertex_deepseek_request_uses_ocr_endpoint_shape`, and `vertex_deepseek_response_wraps_markdown_content` under `rust_only_tests`, and `tests/ocr_tests/test_ocr_vertex_ai.py` is entirely untracked by the ledger

### After (7a117846d)

1. `uv run pytest tests/ocr_tests/test_ocr_vertex_ai.py -q` -> `6 passed, 5 skipped` (the 5 skips are the opt-in live E2E classes, unchanged)
2. `cd litellm-rust && cargo test -p litellm-core providers::vertex_ai::ocr` -> `test result: ok. 4 passed; 0 failed`
3. `cargo fmt --check` and `cargo clippy -p litellm-core --all-targets -- -D warnings` -> clean, no Rust source changed
4. `uv run python -m tests.rust-python-harness --validate-ledger --function ocr` -> `20/153 python tests mapped to rust`, `26 rust-only tests with no python counterpart`, `ledger is in sync with the live test files`
5. All 4 previously rust-only vertex tests now have a 1:1 Python mapping; 0 remain in `rust_only_tests` for the vertex module

## Type

✅ Test

## Caveats (if any)

### Low

- `test_vertex_ai_ocr_routing` (model-name based mistral/deepseek dispatch) stays unmapped: it's Python-only routing logic, and Rust's closest equivalent (`is_deepseek_model`) has no dedicated unit test at this layer, so I didn't stretch this ticket's slice to add one