### PR TITLE
ci(rust): build and test the ai-gateway server feature

### DIFF
--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -74,8 +74,8 @@ jobs:
       - name: Run Clippy with Bedrock auth
         run: cargo clippy -p litellm-core --all-targets --features bedrock-auth --locked -- -D warnings
 
-      - name: Run Clippy with the gateway server
-        run: cargo clippy -p litellm-ai-gateway --all-targets --features server --locked -- -D warnings
+      - name: Run Clippy with all gateway features
+        run: cargo clippy -p litellm-ai-gateway --all-targets --all-features --locked -- -D warnings
 
       - name: Run Rust tests
         run: cargo test --workspace --locked
@@ -83,6 +83,7 @@ jobs:
       - name: Run core tests with Bedrock auth
         run: cargo test -p litellm-core --features bedrock-auth --locked
 
+      # Not --all-features: python-config links libpython, which this job does not install.
       - name: Run gateway tests with the server feature
         run: cargo test -p litellm-ai-gateway --features server --locked
 

--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -74,11 +74,17 @@ jobs:
       - name: Run Clippy with Bedrock auth
         run: cargo clippy -p litellm-core --all-targets --features bedrock-auth --locked -- -D warnings
 
+      - name: Run Clippy with the gateway server
+        run: cargo clippy -p litellm-ai-gateway --all-targets --features server --locked -- -D warnings
+
       - name: Run Rust tests
         run: cargo test --workspace --locked
 
       - name: Run core tests with Bedrock auth
         run: cargo test -p litellm-core --features bedrock-auth --locked
+
+      - name: Run gateway tests with the server feature
+        run: cargo test -p litellm-ai-gateway --features server --locked
 
   release-wheel:
     name: release wheel

--- a/litellm-rust/ADDING_A_PROVIDER.md
+++ b/litellm-rust/ADDING_A_PROVIDER.md
@@ -26,4 +26,4 @@ variants of it. The test for a good abstraction is that adding the next provider
 is a few declarative lines, not a new file of duplicated flow. Only diverge from
 the base when behavior is genuinely different, and say so explicitly in the PR.
 
-**Calling:** hosts invoke the core entrypoint — the Python bridge and the `ai-gateway` route service both call `litellm_core::messages::messages`. Never add a provider handler to `ai-gateway`. Register new modules in `lib.rs` / `mod.rs`, then run `cargo fmt && cargo clippy --workspace -- -D warnings && cargo test --workspace`.
+**Calling:** hosts invoke the core entrypoint — the Python bridge and the `ai-gateway` route service both call `litellm_core::messages::messages`. Never add a provider handler to `ai-gateway`. Register new modules in `lib.rs` / `mod.rs`, then run the commands under "Checks" in [CLAUDE.md](CLAUDE.md).

--- a/litellm-rust/CLAUDE.md
+++ b/litellm-rust/CLAUDE.md
@@ -178,6 +178,8 @@ cargo fmt --check
 cargo clippy -p litellm-ai-gateway --all-targets --features server -- -D warnings
 cargo clippy -p litellm-core -p litellm-python-interop -p litellm-python-bridge --all-targets -- -D warnings
 cargo test --workspace
+# the `auth`, `routes`, `state` and `realtime` tests only exist under `server`
+cargo test -p litellm-ai-gateway --features server
 ```
 
 When a Rust path is exposed through Python, add Python parity tests that compare

--- a/litellm-rust/CLAUDE.md
+++ b/litellm-rust/CLAUDE.md
@@ -174,10 +174,12 @@ for changes under `litellm-rust/`.
 ```bash
 cd litellm-rust
 cargo fmt --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo clippy -p litellm-core --all-targets --features bedrock-auth -- -D warnings
 # the ai-gateway binary + server code is behind the `server` feature
-cargo clippy -p litellm-ai-gateway --all-targets --features server -- -D warnings
-cargo clippy -p litellm-core -p litellm-python-interop -p litellm-python-bridge --all-targets -- -D warnings
+cargo clippy -p litellm-ai-gateway --all-targets --all-features -- -D warnings
 cargo test --workspace
+cargo test -p litellm-core --features bedrock-auth
 # the `auth`, `routes`, `state` and `realtime` tests only exist under `server`
 cargo test -p litellm-ai-gateway --features server
 ```

--- a/litellm-rust/README.md
+++ b/litellm-rust/README.md
@@ -49,11 +49,6 @@ function per top-level route, mirroring the core entrypoints.
 
 ## Checks
 
-Run these before pushing Rust changes. GitHub Actions runs the same checks for
-changes under `litellm-rust/`.
-
-```bash
-cargo fmt --check
-cargo clippy --workspace --all-targets -- -D warnings
-cargo test --workspace
-```
+Run the commands under "Checks" in [CLAUDE.md](CLAUDE.md) before pushing Rust
+changes. That list is the single source of truth and matches what GitHub Actions
+runs for changes under `litellm-rust/`.

--- a/litellm-rust/crates/CODING_STANDARDS/PROVIDER_CODING_STANDARDS.md
+++ b/litellm-rust/crates/CODING_STANDARDS/PROVIDER_CODING_STANDARDS.md
@@ -49,11 +49,5 @@ Rules for adding or changing an LLM provider/route in `litellm-rust`. `messages`
 
 ## Checks before push
 
-25. Run, and keep green:
-    ```bash
-    cd litellm-rust
-    cargo fmt --check
-    cargo clippy -p litellm-ai-gateway --all-targets --features server -- -D warnings
-    cargo clippy -p litellm-core -p litellm-python-interop -p litellm-python-bridge --all-targets -- -D warnings
-    cargo test --workspace
-    ```
+25. Run, and keep green, the commands under "Checks" in `litellm-rust/CLAUDE.md`.
+    That list is the single source of truth and matches what GitHub Actions runs.

--- a/litellm-rust/crates/ai-gateway/Dockerfile
+++ b/litellm-rust/crates/ai-gateway/Dockerfile
@@ -36,12 +36,12 @@ FROM chef AS builder
 # whenever only gateway source changes.
 COPY --from=planner /build/litellm-rust/recipe.json recipe.json
 RUN cargo chef cook --locked --release \
-        -p litellm-ai-gateway --features python-config \
+        -p litellm-ai-gateway --features server,python-config \
         --recipe-path recipe.json
 # Now copy the real sources and build the gateway binary. Deps are already cooked
 # above, so this step only recompiles the gateway crate.
 COPY litellm-rust/ .
-RUN cargo build --locked --release -p litellm-ai-gateway --features python-config
+RUN cargo build --locked --release -p litellm-ai-gateway --bin litellm-ai-gateway --features server,python-config
 
 # ---- Runtime ----------------------------------------------------------------
 # python:3.11-slim-bookworm ships libpython3.11, matching the builder's PyO3

--- a/litellm-rust/crates/ai-gateway/README.md
+++ b/litellm-rust/crates/ai-gateway/README.md
@@ -100,7 +100,7 @@ Worker tuning, rarely needed: `LITELLM_LOG_CHANNEL_CAPACITY` (4096),
 
 ## Build & run with Docker
 
-The image is built `--features python-config` and installs litellm **from this
+The image is built `--features server,python-config` and installs litellm **from this
 repo's source** (the config reader is newer than any PyPI release), so the build
 **context is the repo root**:
 
@@ -135,10 +135,10 @@ docker run --rm -p 4001:4001 \
 ```bash
 # config.yaml mode — needs litellm importable in the active python env
 LITELLM_CONFIG_PATH=./crates/ai-gateway/config.yaml \
-  cargo run --release -p litellm-ai-gateway --features python-config
+  cargo run --release -p litellm-ai-gateway --features server,python-config
 
 # env stand-in mode — no python, no config
-cargo run --release -p litellm-ai-gateway
+cargo run --release -p litellm-ai-gateway --features server
 ```
 
 ## Deploy on Render

--- a/litellm-rust/crates/ai-gateway/src/realtime/streaming.rs
+++ b/litellm-rust/crates/ai-gateway/src/realtime/streaming.rs
@@ -106,16 +106,16 @@ impl RealTimeStreaming {
     /// `litellm_call_id`, replacing the gateway-generated fallback.
     fn on_session(&mut self, event: &RealtimeEvent) {
         let session = event.data.get("session").and_then(Value::as_object);
-        if let Some(id) = session.and_then(|s| s.get("id")).and_then(Value::as_str) {
-            if !id.is_empty() {
-                self.id = id.to_string();
-                self.litellm_call_id = id.to_string();
-            }
+        if let Some(id) = session.and_then(|s| s.get("id")).and_then(Value::as_str)
+            && !id.is_empty()
+        {
+            self.id = id.to_string();
+            self.litellm_call_id = id.to_string();
         }
-        if let Some(model) = session.and_then(|s| s.get("model")).and_then(Value::as_str) {
-            if !model.is_empty() {
-                self.model = model.to_string();
-            }
+        if let Some(model) = session.and_then(|s| s.get("model")).and_then(Value::as_str)
+            && !model.is_empty()
+        {
+            self.model = model.to_string();
         }
     }
 

--- a/litellm-rust/crates/ai-gateway/src/realtime/streaming.rs
+++ b/litellm-rust/crates/ai-gateway/src/realtime/streaming.rs
@@ -324,6 +324,32 @@ mod tests {
     }
 
     #[test]
+    fn blank_session_id_and_model_keep_the_gateway_fallbacks() {
+        let mut streaming = RealTimeStreaming::new(
+            Vec::new(),
+            "call_fallback".to_string(),
+            "gpt-realtime".to_string(),
+            RequestMetadata::default(),
+        );
+
+        streaming.observe(&event(
+            r#"{"type":"session.created","session":{"id":"","model":""}}"#,
+        ));
+        let payload = streaming.build_payload();
+        assert_eq!(payload.id, "call_fallback");
+        assert_eq!(payload.litellm_call_id, "call_fallback");
+        assert_eq!(payload.model, "gpt-realtime");
+
+        streaming.observe(&event(
+            r#"{"type":"session.updated","session":{"id":"sess_002","model":""}}"#,
+        ));
+        let payload = streaming.build_payload();
+        assert_eq!(payload.id, "sess_002");
+        assert_eq!(payload.litellm_call_id, "sess_002");
+        assert_eq!(payload.model, "gpt-realtime");
+    }
+
+    #[test]
     fn payload_serializes_with_camelcase_times_and_realtime_call_type() {
         let mut streaming = RealTimeStreaming::new(
             Vec::new(),

--- a/litellm-rust/crates/ai-gateway/src/routes/realtime/service.rs
+++ b/litellm-rust/crates/ai-gateway/src/routes/realtime/service.rs
@@ -50,18 +50,17 @@ where
         provider_model,
         params.api_key.as_deref(),
         params.api_base.as_deref(),
-    ) {
-        if let Some(handoff) = pool.take(&key) {
-            return crate::io::realtime::realtime_warm(
-                provider_model,
-                handoff,
-                idle_timeout,
-                observe,
-                client_in,
-                client_out,
-            )
-            .await;
-        }
+    ) && let Some(handoff) = pool.take(&key)
+    {
+        return crate::io::realtime::realtime_warm(
+            provider_model,
+            handoff,
+            idle_timeout,
+            observe,
+            client_in,
+            client_out,
+        )
+        .await;
     }
 
     // Cold path: fresh dial (the original behavior).


### PR DESCRIPTION
## TLDR

Problem this solves:

- Nothing in the repo turns the ai-gateway `server` feature on
- So CI never compiled `auth`, `routes`, `state` or `realtime`
- 43 of the crate's 57 tests ran; 14 never did
- The release image's builder produced no binary, so its `COPY` failed
- Both `cargo run` commands the gateway README documents fail too

How it solves it:

- CI now runs clippy on every gateway feature and tests `server`
- The Dockerfile asks for `server` and names the bin explicitly
- The README's two run commands ask for it as well
- One checks runbook in `litellm-rust/CLAUDE.md`; three stale copies point at it

## User Flow

Three people hit the same root cause, so all three flows are here.

Before: a contributor whose change breaks the gateway's server code still gets a green Rust check, so the break merges

1. They edit `litellm-rust/crates/ai-gateway/src/routes/` in a way that does not compile with the `server` feature on
2. They open a PR against `litellm_internal_staging`, and the "LiteLLM Rust / rustfmt, clippy, test" check starts
3. The check reports success in about 45 seconds, every step green
4. Anyone who later runs the clippy command in `litellm-rust/CLAUDE.md` hits compile errors that CI never showed them
5. The 14 tests covering the gateway's master-key auth, `/v1/messages` routing, `/v1/responses` upgrade rejection, and realtime usage logging never ran on that PR at all

After: the same PR gets a red Rust check naming the step that broke, so the break cannot merge

1. They make the same edit under `litellm-rust/crates/ai-gateway/src/routes/`
2. They open the same PR, and the same "LiteLLM Rust / rustfmt, clippy, test" check starts
3. The check now fails at "Run Clippy with all gateway features", printing the compile errors in the job log
4. They fix them locally with the command `litellm-rust/CLAUDE.md` documents, push again, and the check goes green
5. "Run gateway tests with the server feature" runs every gateway test, including the 14 that never ran before

Before: someone building the Rust ai-gateway image gets a build that dies partway through, with nothing saying why

1. They point a build at `litellm-rust/crates/ai-gateway/Dockerfile`, the path `litellm-rust/crates/ai-gateway/render.yaml` points the `litellm-rust-ai-gateway` service at
2. The builder's cargo step prints `Finished release profile` and succeeds, so that stage looks fine
3. The next step, copying the compiled gateway out of the builder, fails with `"/build/litellm-rust/target/release/litellm-ai-gateway": not found`
4. Nothing in the log says a binary was skipped, so the only clue is a path that does not exist
5. That binary has been missing since 2026-06-24, the day after the Dockerfile landed, when #31218 put the gateway bin behind the `server` feature and nothing built the image to notice

After: the builder produces the binary the copy step looks for

1. They point a build at the same `litellm-rust/crates/ai-gateway/Dockerfile`
2. The builder's cargo step compiles the gateway binary, not just the library, so `/build/litellm-rust/target/release/litellm-ai-gateway` is there for the `COPY` to find
3. If someone later changes which features the binary needs, the cargo step itself fails and names the missing feature, instead of quietly building nothing
4. The image still does not build end to end: its runtime stage has a second, unrelated break this PR does not touch, filed as LIT-6815

Before: a contributor follows the gateway's own README to run it locally, and neither command it gives works

1. They open `litellm-rust/crates/ai-gateway/README.md` and copy the plain run command
2. `cargo run --release -p litellm-ai-gateway` exits 101 with ``error: target `litellm-ai-gateway` in package `litellm-ai-gateway` requires the features: `server` ``
3. The README's other command, the `--features python-config` one, fails exactly the same way

After: both commands the README gives start the gateway

1. They copy the same two commands from the same README
2. `cargo run --release -p litellm-ai-gateway --features server` builds and runs
3. The other command now reads `--features server,python-config` and runs too

## Relevant issues

## Linear ticket

Resolves LIT-6803

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The end users here are a contributor watching a GitHub check, a person building the gateway image, and a contributor following the gateway README, so the CI cases ran on real GitHub Actions, the image case ran real `docker build`s, and the README case ran the commands it prints.

Shared setup for the CI cases: two throwaway branches carry the exact same broken gateway change, the Rust half of the open PR #39440, whose `routes/ocr` module does not compile with the `server` feature. The only difference between them is `.github/workflows/test-rust.yml`: the Before branch has the merge base's version, the After branch has this PR's. Every other workflow filters its `push` trigger to `main` and the staging branches, so each push cost exactly one Rust job.

Each leg below is labelled with the commit it actually ran at: the CI and image legs at `70dc0a69a4`, and the README leg at `5120590890`, the docs-only commit that rewrites those two commands.

### Before (ff17e8b987fb6e56a30cfd9c76bc4c321a20270e, this PR's merge base)

#### A broken gateway server change

1. Push the branch and open the check at https://github.com/BerriAI/litellm/actions/runs/33716907385 (d5d53e70894ceab87d5162cfc9404b3ea396ee53)
2. "LiteLLM Rust / rustfmt, clippy, test" reports **success** in 43 seconds (04:57:01Z -> 04:57:44Z), every step green:

```
success  Check Rust formatting
success  Run Clippy
success  Run Clippy with Bedrock auth
success  Run Rust tests
success  Run core tests with Bedrock auth
```

3. Nothing in that list ever turns the `server` feature on, so the broken code is free to merge

#### Gateway tests that actually ran

1. Open the "Run Rust tests" step log of the same run
2. The gateway crate reports 43 tests:

```
     Running unittests src/lib.rs (target/debug/deps/litellm_ai_gateway-7fc0e3f44c3b8604)

running 43 tests

test result: ok. 42 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.13s
```

#### The gateway release image's binary

1. Build the builder stage from the merge base's Dockerfile. Both sides get one identical patch first, `FROM rust:1.90-slim-bookworm` -> `1.98`, because the pinned base is now older than `Cargo.lock` needs and would otherwise stop both builds long before they reach the feature bug (that one is filed as LIT-6815). Nothing else differs between the two builds:

```
$ docker build --progress=plain --target builder \
    -f litellm-rust/crates/ai-gateway/Dockerfile -t lit6803c:before .
#12 [builder 4/4] RUN cargo build --locked --release -p litellm-ai-gateway --features python-config
#12 3.122    Compiling litellm-ai-gateway v0.1.0 (/build/litellm-rust/crates/ai-gateway)
#12 10.49     Finished `release` profile [optimized] target(s) in 10.29s
#12 DONE 10.6s
$ echo $?
0
```

2. cargo reported success, so ask the builder image for the file the next Dockerfile line copies out of it:

```
$ docker run --rm --entrypoint /bin/sh lit6803c:before \
    -c 'ls -l /build/litellm-rust/target/release/litellm-ai-gateway'
ls: cannot access '/build/litellm-rust/target/release/litellm-ai-gateway': No such file or directory
$ echo $?
2
```

3. That path is exactly what `COPY --from=builder` reads, so the full build dies there with nothing explaining why: the bin target carries `required-features = ["server"]` and this command never asked for it

#### The README's run commands

1. Run the command `litellm-rust/crates/ai-gateway/README.md` gives for a plain local run:

```
$ cd litellm-rust
$ cargo run --release -p litellm-ai-gateway
error: target `litellm-ai-gateway` in package `litellm-ai-gateway` requires the features: `server`
Consider enabling them by passing, e.g., `--features="server"`
$ echo $?
101
```

2. Run the other one it gives, for a run with the python config reader:

```
$ cargo run --release -p litellm-ai-gateway --features python-config
error: target `litellm-ai-gateway` in package `litellm-ai-gateway` requires the features: `server`
Consider enabling them by passing, e.g., `--features="server"`
$ echo $?
101
```

### After (70dc0a69a4bbd9d1c7e23c72d516dba28ab39d6c; the README leg at 5120590890)

#### A broken gateway server change

1. Push the branch and open the check at https://github.com/BerriAI/litellm/actions/runs/33718265201 (1d4b2f4711782df1c9f1d74f315324699a28ed91)
2. "LiteLLM Rust / rustfmt, clippy, test" reports **failure** in 51 seconds (05:17:51Z -> 05:18:42Z), stopping at the new step:

```
success  Run Clippy with Bedrock auth
failure  Run Clippy with all gateway features
skipped  Run Rust tests
skipped  Run core tests with Bedrock auth
skipped  Run gateway tests with the server feature
```

3. The step log names every problem the old workflow hid:

```
error[E0425]: cannot find function `ocr` in module `ocr`
error: unused import: `serde_json::json`
error[E0599]: no method named `get_deployment` found for reference `&litellm_core::router::Router` in the current scope
error[E0277]: `auth::RequireMasterKey` doesn't implement `std::fmt::Debug`
error[E0277]: `auth::RequireMasterKey` doesn't implement `std::fmt::Debug`
error: could not compile `litellm-ai-gateway` (lib) due to 4 previous errors
error: could not compile `litellm-ai-gateway` (lib test) due to 5 previous errors
##[error]Process completed with exit code 101.
```

#### Gateway tests that actually ran

1. The run above stops at clippy, so the passing count comes from this PR's own head at https://github.com/BerriAI/litellm/actions/runs/33718198024
2. That check is green end to end in 94 seconds (05:16:52Z -> 05:18:26Z), including both new steps:

```
success  Run Clippy with all gateway features
success  Run Rust tests
success  Run core tests with Bedrock auth
success  Run gateway tests with the server feature
```

3. The "Run gateway tests with the server feature" step log shows all 58, the 14 previously invisible ones plus the one this PR adds:

```
     Running unittests src/lib.rs (target/debug/deps/litellm_ai_gateway-8524827c757bf410)

running 58 tests

test auth::tests::hash_token_matches_python_sha256_hexdigest ... ok
test realtime::streaming::tests::blank_session_id_and_model_keep_the_gateway_fallbacks ... ok
test realtime::streaming::tests::failing_logger_bumps_dropped_counter ... ok
test realtime::streaming::tests::observe_accumulates_model_and_tokens_then_logs ... ok
test realtime::streaming::tests::payload_serializes_with_camelcase_times_and_realtime_call_type ... ok
test routes::messages::tests::route_constructs_anthropic_upstream_request ... ok
test routes::messages::tests::route_maps_streaming_upstream_errors_before_starting_response ... ok
test routes::messages::tests::route_rejects_invalid_master_key ... ok
test routes::messages::tests::route_rejects_malformed_json_without_panicking ... ok
test routes::messages::tests::route_rejects_missing_master_key ... ok
test routes::messages::tests::route_streams_anthropic_events_without_buffering_or_reordering ... ok
test routes::messages::tests::route_substitutes_model_alias_with_provider_model_upstream ... ok
test routes::responses::tests::auth_rejects_responses_upgrade_before_handler ... ok
test routes::responses::tests::pre_call_error_matches_python_frame_and_close ... ok
test routes::responses::tests::unknown_query_model_is_rejected_before_upgrade ... ok
test result: ok. 57 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.14s
     Running unittests src/main.rs (target/debug/deps/litellm_ai_gateway-53009fc43b087087)
```

4. That last line is the `litellm-ai-gateway` binary, which carries `required-features = ["server"]` and so was never built by CI before either

#### The gateway release image's binary

1. Build the builder stage from this PR's Dockerfile, same patch, same context, same machine:

```
$ docker build --progress=plain --target builder \
    -f litellm-rust/crates/ai-gateway/Dockerfile -t lit6803c:after .
#12 [builder 4/4] RUN cargo build --locked --release -p litellm-ai-gateway --bin litellm-ai-gateway --features server,python-config
#12 3.003    Compiling litellm-ai-gateway v0.1.0 (/build/litellm-rust/crates/ai-gateway)
#12 30.57     Finished `release` profile [optimized] target(s) in 30.36s
#12 DONE 30.7s
$ echo $?
0
```

2. Ask the same question of the after image:

```
$ docker run --rm --entrypoint /bin/sh lit6803c:after \
    -c 'ls -l /build/litellm-rust/target/release/litellm-ai-gateway'
-rwxr-xr-x 2 root root 5915512 Sep  3 07:16 /build/litellm-rust/target/release/litellm-ai-gateway
$ echo $?
0
```

3. The 10.29s vs 30.36s gap is the binary itself: the same crate, now linked into an executable instead of compiled as a library only

4. Naming the bin also makes a future feature drift loud instead of silent:

```
$ cargo build --locked --release -p litellm-ai-gateway --bin litellm-ai-gateway --features python-config
error: target `litellm-ai-gateway` in package `litellm-ai-gateway` requires the features: `server`
Consider enabling them by passing, e.g., `--features="server"`
$ echo $?
101
```

#### The README's run commands

1. Run the plain command this PR's README gives:

```
$ cd litellm-rust
$ PORT=39117 cargo run --release -p litellm-ai-gateway --features server
    Finished `release` profile [optimized] target(s) in 0.43s
     Running `target/release/litellm-ai-gateway`
warning: OPENAI_API_KEY is not set; realtime requests will fail with auth errors
realtime connection pool enabled: target 4 warm sockets/key, max idle 30s
litellm-ai-gateway listening on 127.0.0.1:39117
```

2. Run the python-config one it now gives:

```
$ PORT=39118 cargo run --release -p litellm-ai-gateway --features server,python-config
    Finished `release` profile [optimized] target(s) in 1.49s
     Running `target/release/litellm-ai-gateway`
config load failed (routing error: read_model_list failed: ModuleNotFoundError: No module named 'litellm'); falling back to env deployment
warning: OPENAI_API_KEY is not set; realtime requests will fail with auth errors
realtime connection pool enabled: target 4 warm sockets/key, max idle 30s
litellm-ai-gateway listening on 127.0.0.1:39118
```

3. Both serve. The second one's config warning is this shell having no `litellm` on its `PYTHONPATH`, which is the embedded reader running and falling back, not the feature gate refusing to build

Notes from the run:

- The default workspace run still reports 43, unchanged
- The new steps cost about 50 seconds on a warm cache
- Three `collapsible_if` violations had piled up behind the flag
- Every workspace crate but ai-gateway was already covered
- The image has two more, older breaks of its own: LIT-6815

## Type

🚄 Infrastructure

🐛 Bug Fix

✅ Test

## Caveats (if any)

### Low

- Two older, unrelated breaks still stop the image: LIT-6815
- `tests/rust-python-harness` is still in zero CI configs
- Its live-provider strategies need their own design, so separate PR
- Clippy covers `python-config`; tests cannot, since they link libpython
- No CI job builds the Docker image; the `--bin` flag catches the drift

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
