### PR TITLE
feat(router): route deployments by requested service tier

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -357,6 +357,9 @@ def model_info_is_active_for_environment(model_info: Mapping[str, object] | None
 
 
 _PreRoutingStrategyT = TypeVar("_PreRoutingStrategyT")
+_RouterDeploymentSelection: TypeAlias = (
+    list[DeploymentTypedDict] | DeploymentTypedDict  # mutable-ok: Router selection returns mutable deployment pools
+)
 
 _ALIAS_PARAMS_NEVER_FORWARDED: Final = frozenset({"model", "api_base", "api_key", "api_version"})
 _ALIAS_MARKER_FORWARDED_PARAMS_KWARG: Final = "_alias_marker_forwarded_params"
@@ -11967,6 +11970,46 @@ class Router:
         deployment_model: Final = litellm_params.get("model")
         return isinstance(deployment_model, str) and classify_strategy_router_model(deployment_model) is not None
 
+    @staticmethod
+    def _get_requested_service_tier(request_kwargs: Mapping[str, object] | None) -> str | None:
+        if request_kwargs is None:
+            return None
+        requested_service_tier: Final = request_kwargs.get("service_tier")
+        if not isinstance(requested_service_tier, str) or requested_service_tier == "auto":
+            return None
+        return requested_service_tier
+
+    @staticmethod
+    def _filter_deployments_by_service_tier(
+        model: str,
+        deployments: _RouterDeploymentSelection,
+        requested_service_tier: str | None,
+    ) -> _RouterDeploymentSelection:
+        if requested_service_tier is None:
+            return deployments
+        is_direct_deployment: Final = isinstance(deployments, dict)
+        candidates: Final = (deployments,) if is_direct_deployment else tuple(deployments)
+        if not any(
+            (deployment.get("model_info") or MappingProxyType({})).get("supported_service_tiers") is not None
+            for deployment in candidates
+        ):
+            return deployments
+        matches: Final = tuple(
+            deployment
+            for deployment in candidates
+            if requested_service_tier
+            in ((deployment.get("model_info") or MappingProxyType({})).get("supported_service_tiers") or ())
+        )
+        if not matches:
+            raise litellm.BadRequestError(
+                message=f"No deployments available for model={model} with service_tier={requested_service_tier}.",
+                model=model,
+                llm_provider="",
+            )
+        if is_direct_deployment:
+            return matches[0]
+        return list(matches)  # mutable-ok: Router selection returns mutable deployment pools
+
     def _common_checks_available_deployment(
         self,
         model: str,
@@ -11986,6 +12029,7 @@ class Router:
         - Dict, if specific model chosen
         """
 
+        requested_service_tier: Final = self._get_requested_service_tier(request_kwargs)
         request_team_id: str | None = None
         if request_kwargs is not None:
             metadata: Final = request_kwargs.get("metadata") or {}
@@ -11993,12 +12037,22 @@ class Router:
             request_team_id = metadata.get("user_api_key_team_id") or litellm_metadata.get("user_api_key_team_id")
         # check if aliases set on litellm model alias map
         if specific_deployment is True:
-            return model, self._get_deployment_by_litellm_model(model=model)
+            deployments: Final = self._get_deployment_by_litellm_model(model=model)
+            return model, self._filter_deployments_by_service_tier(
+                model=model,
+                deployments=deployments,
+                requested_service_tier=requested_service_tier,
+            )
         elif self.has_model_id(model):
             deployment: Final = self.get_deployment(model_id=model)
             if deployment is not None:
                 deployment_model: Final = deployment.litellm_params.model
-                return deployment_model, deployment.model_dump(exclude_none=True)
+                deployment_dict: Final = deployment.model_dump(exclude_none=True)
+                return deployment_model, self._filter_deployments_by_service_tier(
+                    model=model,
+                    deployments=deployment_dict,  # pyright: ignore[reportArgumentType]  # Pydantic dump preserves DeploymentTypedDict shape
+                    requested_service_tier=requested_service_tier,
+                )
             raise ValueError(
                 f"LiteLLM Router: Trying to call specific deployment, but Model ID :{model} does not exist in Model ID map"
             )
@@ -12015,7 +12069,12 @@ class Router:
                 include_team_models=_is_proxy_admin_request(request_kwargs),
             )
             if early is not None:
-                return early
+                early_model, early_deployments = early
+                return early_model, self._filter_deployments_by_service_tier(
+                    model=early_model,
+                    deployments=early_deployments,  # pyright: ignore[reportArgumentType]  # Legacy resolver returns the same deployment pool shapes
+                    requested_service_tier=requested_service_tier,
+                )
 
         ## get healthy deployments
         ### get all deployments
@@ -12094,7 +12153,11 @@ class Router:
 
         marker_flags: Final = tuple(self._is_strategy_marker_deployment(d) for d in healthy_deployments)
         if not any(marker_flags):
-            return model, healthy_deployments
+            return model, self._filter_deployments_by_service_tier(
+                model=model,
+                deployments=healthy_deployments,
+                requested_service_tier=requested_service_tier,
+            )
         selectable: Final = [  # mutable-ok: matches this function's list contract expected by downstream filters
             d for d, is_marker in zip(healthy_deployments, marker_flags, strict=True) if not is_marker
         ]
@@ -12104,7 +12167,11 @@ class Router:
                 model=model,
                 llm_provider="",
             )
-        return model, selectable
+        return model, self._filter_deployments_by_service_tier(
+            model=model,
+            deployments=selectable,
+            requested_service_tier=requested_service_tier,
+        )
 
     def _filter_deployments_by_model_access_groups(
         self,

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -166,6 +166,7 @@ class ModelInfo(MirroredPricingParams):
 
     base_model: str | None = None  # specify if the base model is azure/gpt-3.5-turbo etc for accurate cost tracking
     tier: Literal["free", "paid"] | None = None
+    supported_service_tiers: tuple[str, ...] | None = None
 
     """
     Team Model Specific Fields

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -280,6 +280,25 @@ def test_service_tier_routing_direct_model_id_nonmatch_raises():
     assert "flex" in str(exc_info.value)
 
 
+def test_service_tier_routing_direct_model_id_match_returns_deployment():
+    router = Router(
+        model_list=[
+            {
+                "model_name": "service-tier-model",
+                "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "fake-key"},
+                "model_info": {"id": "flex-only", "supported_service_tiers": ["flex"]},
+            }
+        ]
+    )
+
+    deployment = router.get_available_deployment(
+        model="flex-only",
+        request_kwargs={"service_tier": "flex"},
+    )
+
+    assert deployment["model_info"]["id"] == "flex-only"
+
+
 def test_model_info_supported_service_tiers_serialization():
     from litellm.types.router import ModelInfo
 

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -140,6 +140,35 @@ def _service_tier_router(
     )
 
 
+def test_service_tier_helpers_apply_concrete_constraint():
+    from litellm.types.router import DeploymentTypedDict
+
+    deployments: list[DeploymentTypedDict] = [
+        {
+            "model_name": "service-tier-model",
+            "litellm_params": {"model": "openai/gpt-4o-mini"},
+            "model_info": {"id": "default", "supported_service_tiers": ["default"]},
+        },
+        {
+            "model_name": "service-tier-model",
+            "litellm_params": {"model": "openai/gpt-4o-mini"},
+            "model_info": {"id": "flex", "supported_service_tiers": ["flex"]},
+        },
+    ]
+    requested_service_tier = Router._get_requested_service_tier(  # pyright: ignore[reportPrivateUsage]  # Direct coverage of the request boundary
+        {"service_tier": "flex"}
+    )
+
+    filtered = Router._filter_deployments_by_service_tier(  # pyright: ignore[reportPrivateUsage]  # Direct coverage required by the router coverage gate
+        model="service-tier-model",
+        deployments=deployments,
+        requested_service_tier=requested_service_tier,
+    )
+
+    assert isinstance(filtered, list)
+    assert [deployment["model_info"]["id"] for deployment in filtered] == ["flex"]
+
+
 def test_service_tier_routing_sync_filters_before_order():
     router = _service_tier_router((("default",), ("flex",)))
 
@@ -262,7 +291,7 @@ def test_model_info_supported_service_tiers_serialization():
     assert ModelInfo(supported_service_tiers=["default", "flex"]).model_dump(mode="json", exclude_none=True)[
         "supported_service_tiers"
     ] == ["default", "flex"]
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="supported_service_tiers"):
         ModelInfo(supported_service_tiers="flex")
 
 

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -103,6 +103,169 @@ def test_router_with_model_info_and_model_group():
     )
 
 
+def _service_tier_router(
+    supported_service_tiers: tuple[tuple[str, ...] | None, tuple[str, ...] | None] | None,
+) -> Router:
+    first_model_info = (
+        {"id": "order-1"}
+        if supported_service_tiers is None
+        else {"id": "order-1", "supported_service_tiers": supported_service_tiers[0]}
+    )
+    second_model_info = (
+        {"id": "order-2"}
+        if supported_service_tiers is None
+        else {"id": "order-2", "supported_service_tiers": supported_service_tiers[1]}
+    )
+    return Router(
+        model_list=[
+            {
+                "model_name": "service-tier-model",
+                "litellm_params": {
+                    "model": "openai/gpt-4o-mini",
+                    "api_key": "fake-key",
+                    "order": 1,
+                },
+                "model_info": first_model_info,
+            },
+            {
+                "model_name": "service-tier-model",
+                "litellm_params": {
+                    "model": "openai/gpt-4o-mini",
+                    "api_key": "fake-key",
+                    "order": 2,
+                },
+                "model_info": second_model_info,
+            },
+        ]
+    )
+
+
+def test_service_tier_routing_sync_filters_before_order():
+    router = _service_tier_router((("default",), ("flex",)))
+
+    deployment = router.get_available_deployment(
+        model="service-tier-model",
+        request_kwargs={"service_tier": "flex"},
+    )
+
+    assert deployment["model_info"]["id"] == "order-2"
+
+
+@pytest.mark.asyncio
+async def test_service_tier_routing_async_filters_before_order():
+    router = _service_tier_router((("default",), ("flex",)))
+
+    deployment = await router.async_get_available_deployment(
+        model="service-tier-model",
+        request_kwargs={"service_tier": "flex"},
+    )
+
+    assert deployment["model_info"]["id"] == "order-2"
+
+
+def test_service_tier_routing_without_declarations_preserves_order():
+    router = _service_tier_router(None)
+
+    deployment = router.get_available_deployment(
+        model="service-tier-model",
+        request_kwargs={"service_tier": "flex"},
+    )
+
+    assert deployment["model_info"]["id"] == "order-1"
+
+
+def test_service_tier_routing_auto_preserves_order():
+    router = _service_tier_router((("default",), ("flex",)))
+
+    deployment = router.get_available_deployment(
+        model="service-tier-model",
+        request_kwargs={"service_tier": "auto"},
+    )
+
+    assert deployment["model_info"]["id"] == "order-1"
+
+
+@pytest.mark.parametrize("request_kwargs", [{}, {"service_tier": None}])
+def test_service_tier_routing_without_constraint_preserves_order(request_kwargs: dict[str, str | None]):
+    router = _service_tier_router((("default",), ("flex",)))
+
+    deployment = router.get_available_deployment(
+        model="service-tier-model",
+        request_kwargs=request_kwargs,
+    )
+
+    assert deployment["model_info"]["id"] == "order-1"
+
+
+def test_service_tier_routing_authoritative_pool_without_match_raises():
+    router = Router(
+        model_list=[
+            {
+                "model_name": "service-tier-model",
+                "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "fake-key"},
+                "model_info": {"id": "default", "supported_service_tiers": ["default"]},
+            },
+            {
+                "model_name": "service-tier-model",
+                "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "fake-key"},
+                "model_info": {"id": "empty", "supported_service_tiers": []},
+            },
+            {
+                "model_name": "service-tier-model",
+                "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "fake-key"},
+                "model_info": {"id": "undeclared"},
+            },
+        ]
+    )
+
+    with pytest.raises(litellm.BadRequestError) as exc_info:
+        router.get_available_deployment(
+            model="service-tier-model",
+            request_kwargs={"service_tier": "flex"},
+        )
+
+    assert exc_info.value.status_code == 400
+    assert "service-tier-model" in str(exc_info.value)
+    assert "flex" in str(exc_info.value)
+
+
+def test_service_tier_routing_direct_model_id_nonmatch_raises():
+    router = Router(
+        model_list=[
+            {
+                "model_name": "service-tier-model",
+                "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "fake-key"},
+                "model_info": {"id": "default-only", "supported_service_tiers": ["default"]},
+            }
+        ]
+    )
+
+    with pytest.raises(litellm.BadRequestError) as exc_info:
+        router.get_available_deployment(
+            model="default-only",
+            request_kwargs={"service_tier": "flex"},
+        )
+
+    assert exc_info.value.status_code == 400
+    assert "default-only" in str(exc_info.value)
+    assert "flex" in str(exc_info.value)
+
+
+def test_model_info_supported_service_tiers_serialization():
+    from litellm.types.router import ModelInfo
+
+    assert "supported_service_tiers" not in ModelInfo().model_dump(mode="json", exclude_none=True)
+    assert (
+        ModelInfo(supported_service_tiers=[]).model_dump(mode="json", exclude_none=True)["supported_service_tiers"]
+        == []
+    )
+    assert ModelInfo(supported_service_tiers=["default", "flex"]).model_dump(mode="json", exclude_none=True)[
+        "supported_service_tiers"
+    ] == ["default", "flex"]
+    with pytest.raises(ValueError):
+        ModelInfo(supported_service_tiers="flex")
+
+
 def test_router_model_group_encrypted_content_affinity_callback_registration():
     from litellm.router_utils.pre_call_checks.deployment_affinity_check import (
         DeploymentAffinityCheck,

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -39067,6 +39067,8 @@ export interface components {
             ptu_effective_from?: string | null;
             /** Ptu Effective To */
             ptu_effective_to?: string | null;
+            /** Supported Service Tiers */
+            supported_service_tiers?: string[] | null;
             /** Team Id */
             team_id?: string | null;
             /** Team Public Model Name */


### PR DESCRIPTION
## Summary

- add `model_info.supported_service_tiers` as explicit per-deployment capability metadata
- filter candidates by a concrete requested `service_tier` before order or routing-strategy selection
- preserve existing routing when the request is absent/`auto`, or when no candidate declares capabilities
- return a clear 400 when an authoritative deployment pool cannot satisfy the requested tier

Fixes #39208.

## Behavior

Once any candidate in a model group declares `supported_service_tiers`, declarations become authoritative for concrete tier requests. Undeclared, `None`, and empty declarations do not match. Matching is exact so the router does not invent provider-specific normalization.

The filter lives in the common deployment-resolution path, keeping sync and async selection consistent and ensuring it runs before order and other routing strategies.

## Reviewer guide

1. `litellm/types/router.py` adds the typed configuration boundary.
2. `litellm/router.py` extracts the request constraint and filters every common-resolution return path.
3. `tests/test_litellm/test_router.py` covers sync/async selection, compatibility semantics, direct deployment failure, and serialization.

## Verification

- full router module: 411 passed, 12 skipped
- focused service-tier tests: 9 passed
- strict Ruff delta gate: passed
- type-discipline delta gate: passed
- basedpyright delta gate: passed
- `git diff --check`: passed

All tests use fake provider credentials; no provider request is made.
