### PR TITLE
Litellm websearch conventional function name

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -695,7 +695,25 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
 
         if len(choices) == 0:
             if raw_response.incomplete_details is not None and raw_response.incomplete_details.reason is not None:
-                raise ValueError(f"{model} unable to complete request: {raw_response.incomplete_details.reason}")
+                # The model hit max_output_tokens (e.g. reasoning/thinking tokens consumed
+                # the whole budget) before producing any output item. This is a normal
+                # truncation, not an error -- return an empty completion with
+                # finish_reason="length" instead of failing the whole request.
+                from litellm.types.utils import Choices, Message
+
+                verbose_logger.warning(
+                    "Responses API returned no output items for model=%s (incomplete_details.reason=%s); "
+                    "returning an empty truncated completion instead of raising.",
+                    model,
+                    raw_response.incomplete_details.reason,
+                )
+                choices = [
+                    Choices(
+                        message=Message(role="assistant", content=""),
+                        finish_reason=self._map_responses_status_to_finish_reason(raw_response.status),
+                        index=0,
+                    )
+                ]
             else:
                 raise ValueError(f"Unknown items in responses API response: {output_items}")
 

--- a/litellm/integrations/websearch_interception/tools.py
+++ b/litellm/integrations/websearch_interception/tools.py
@@ -155,12 +155,15 @@ def is_web_search_tool_chat_completion(tool: Dict[str, Any]) -> bool:
     """
     Check if a tool is a web search tool for Chat Completions API (strict check).
 
-    This is a stricter version that ONLY checks for the exact LiteLLM web search tool name.
+    This is a stricter version that checks for the exact LiteLLM web search tool name,
+    plus the bare conventional ``web_search`` function-tool shape (name only, no schema).
     Use this for Chat Completions API to avoid false positives with user-defined tools.
 
     Detects ONLY:
     - LiteLLM standard: name == "litellm_web_search" (Anthropic format)
     - OpenAI format: type == "function" with function.name == "litellm_web_search"
+    - OpenAI format, bare conventional name: type == "function" with
+      function == {"name": "web_search"} and no other function fields
 
     Args:
         tool: Tool dictionary to check
@@ -173,6 +176,8 @@ def is_web_search_tool_chat_completion(tool: Dict[str, Any]) -> bool:
         True
         >>> is_web_search_tool_chat_completion({"type": "function", "function": {"name": "litellm_web_search"}})
         True
+        >>> is_web_search_tool_chat_completion({"type": "function", "function": {"name": "web_search"}})
+        True
         >>> is_web_search_tool_chat_completion({"name": "web_search"})
         False
         >>> is_web_search_tool_chat_completion({"name": "WebSearch"})
@@ -184,8 +189,12 @@ def is_web_search_tool_chat_completion(tool: Dict[str, Any]) -> bool:
     # Check for OpenAI format: {"type": "function", "function": {"name": "litellm_web_search"}}
     if tool_type == "function" and "function" in tool:
         function_def = tool.get("function", {})
+        if not isinstance(function_def, dict):
+            return False
         function_name = function_def.get("name", "")
         if function_name == LITELLM_WEB_SEARCH_TOOL_NAME:
+            return True
+        if function_name == "web_search" and function_def.keys() == {"name"}:
             return True
 
     # Check for LiteLLM standard tool (Anthropic format)
@@ -223,6 +232,8 @@ def is_web_search_tool(tool: Dict[str, Any]) -> bool:
     Detects:
     - LiteLLM standard: name == "litellm_web_search"
     - OpenAI format: type == "function" with function.name == "litellm_web_search"
+    - OpenAI format, bare conventional name: type == "function" with
+      function == {"name": "web_search"} and no other function fields
     - Anthropic native: type starts with "web_search_" (e.g., "web_search_20250305")
     - Claude Code: name == "web_search" with a type field
     - Custom: name == "WebSearch" (legacy interception marker — only matched
@@ -268,8 +279,12 @@ def is_web_search_tool(tool: Dict[str, Any]) -> bool:
     # Check for OpenAI format: {"type": "function", "function": {"name": "..."}}
     if tool_type == "function" and "function" in tool:
         function_def = tool.get("function", {})
+        if not isinstance(function_def, dict):
+            return False
         function_name = function_def.get("name", "")
         if function_name == LITELLM_WEB_SEARCH_TOOL_NAME:
+            return True
+        if function_name == "web_search" and function_def.keys() == {"name"}:
             return True
 
     # Check for LiteLLM standard tool (Anthropic format)

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -1464,6 +1464,18 @@ class LiteLLMAnthropicMessagesAdapter:
             return "signature_delta", ContentThinkingSignatureBlockDelta(
                 type="signature_delta", signature=reasoning_signature
             )
+        elif text:
+            # A single upstream chunk can carry a trailing reasoning_content fragment
+            # *and* the start of real content at the same time -- e.g. vLLM's reasoning
+            # parser closes out "thinking" in the same chunk it starts the answer.
+            # _translate_streaming_openai_chunk_to_anthropic_content_block (which decides
+            # whether to open a new block) checks `content` before `reasoning_content`,
+            # so a chunk like this always opens a "text" block. The delta type returned
+            # here must agree, or a text-typed block receives a thinking_delta, which
+            # real Anthropic SDK clients reject as invalid and disconnect on -- dropping
+            # the rest of the response. Any trailing reasoning_content on the same chunk
+            # is dropped here rather than misrouted into the wrong block type.
+            return "text_delta", ContentTextBlockDelta(type="text_delta", text=text)
         elif reasoning_content:
             return "thinking_delta", ContentThinkingBlockDelta(type="thinking_delta", thinking=reasoning_content)
         else:

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -58,6 +58,51 @@ from litellm.types.guardrails import GuardrailEventHooks
 from litellm.types.router import RouterRateLimitError
 from litellm.types.utils import ServerToolUse
 
+
+def _dedup_system_messages(messages: list) -> list:
+    """Merge multiple system messages into a single system message.
+
+    Some clients (e.g. Claude Code SDK) send multiple system messages:
+    1. A tool-calling system message (from the generate_ppt tool)
+    2. A SharePoint context system message (from file retrieval)
+
+    vLLM's Qwen model requires the system message to be at the beginning
+    and only accepts one, so we merge all system messages into one.
+
+    Args:
+        messages: List of message dicts with 'role' and 'content' keys
+
+    Returns:
+        Deduplicated messages list with at most one system message at position 0
+    """
+    system_messages = []
+    non_system_messages = []
+
+    for msg in messages:
+        role = msg.get("role", "")
+        if role == "system":
+            content = msg.get("content", "")
+            if content:
+                system_messages.append(str(content))
+        else:
+            non_system_messages.append(msg)
+
+    if not system_messages:
+        return messages
+
+    # If there are system messages, merge them and put at the beginning
+    merged_system = "\n\n---\n\n".join(system_messages)
+    deduped = [{"role": "system", "content": merged_system}]
+    deduped.extend(non_system_messages)
+
+    verbose_proxy_logger.debug(
+        "Merged %d system messages into one (total chars: %d)",
+        len(system_messages),
+        len(merged_system),
+    )
+
+    return deduped
+
 # Type alias for streaming chunk serializer (chunk after hooks + cost injection -> wire format)
 StreamChunkSerializer = Callable[[Any], str]
 # Type alias for streaming error serializer (ProxyException -> wire format)
@@ -1295,6 +1340,8 @@ class ProxyBaseLLMRequestProcessing:
                 self.data["router_settings_override"] = router_settings
 
         if "messages" in self.data and self.data["messages"]:
+            # Deduplicate system messages (some clients send multiple)
+            self.data["messages"] = _dedup_system_messages(self.data["messages"])
             logging_obj.update_messages(self.data["messages"])
 
         return self.data, logging_obj

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -58,51 +58,6 @@ from litellm.types.guardrails import GuardrailEventHooks
 from litellm.types.router import RouterRateLimitError
 from litellm.types.utils import ServerToolUse
 
-
-def _dedup_system_messages(messages: list) -> list:
-    """Merge multiple system messages into a single system message.
-
-    Some clients (e.g. Claude Code SDK) send multiple system messages:
-    1. A tool-calling system message (from the generate_ppt tool)
-    2. A SharePoint context system message (from file retrieval)
-
-    vLLM's Qwen model requires the system message to be at the beginning
-    and only accepts one, so we merge all system messages into one.
-
-    Args:
-        messages: List of message dicts with 'role' and 'content' keys
-
-    Returns:
-        Deduplicated messages list with at most one system message at position 0
-    """
-    system_messages = []
-    non_system_messages = []
-
-    for msg in messages:
-        role = msg.get("role", "")
-        if role == "system":
-            content = msg.get("content", "")
-            if content:
-                system_messages.append(str(content))
-        else:
-            non_system_messages.append(msg)
-
-    if not system_messages:
-        return messages
-
-    # If there are system messages, merge them and put at the beginning
-    merged_system = "\n\n---\n\n".join(system_messages)
-    deduped = [{"role": "system", "content": merged_system}]
-    deduped.extend(non_system_messages)
-
-    verbose_proxy_logger.debug(
-        "Merged %d system messages into one (total chars: %d)",
-        len(system_messages),
-        len(merged_system),
-    )
-
-    return deduped
-
 # Type alias for streaming chunk serializer (chunk after hooks + cost injection -> wire format)
 StreamChunkSerializer = Callable[[Any], str]
 # Type alias for streaming error serializer (ProxyException -> wire format)
@@ -1340,8 +1295,6 @@ class ProxyBaseLLMRequestProcessing:
                 self.data["router_settings_override"] = router_settings
 
         if "messages" in self.data and self.data["messages"]:
-            # Deduplicate system messages (some clients send multiple)
-            self.data["messages"] = _dedup_system_messages(self.data["messages"])
             logging_obj.update_messages(self.data["messages"])
 
         return self.data, logging_obj

--- a/tests/test_litellm/integrations/websearch_interception/test_websearch_tools.py
+++ b/tests/test_litellm/integrations/websearch_interception/test_websearch_tools.py
@@ -1,0 +1,57 @@
+"""Unit tests for web search tool shape detection."""
+
+from typing import Any, Dict
+
+import pytest
+
+from litellm.integrations.websearch_interception.tools import (
+    is_web_search_tool,
+    is_web_search_tool_chat_completion,
+)
+
+
+@pytest.mark.parametrize(
+    "tool",
+    [
+        {"type": "function", "function": {"name": "litellm_web_search"}},
+        {"type": "function", "function": {"name": "web_search"}},
+    ],
+)
+def test_recognized_function_tool_shapes_are_detected(tool: Dict[str, Any]):
+    """Regression: {"type": "function", "function": {"name": "web_search"}} (the shape sent by
+    Anthropic-style clients over Chat Completions) must be recognized, not just the LiteLLM
+    standard name. Before the fix this fell through to provider tool mapping and raised
+    "Missing required parameter: name".
+    """
+    assert is_web_search_tool(tool) is True
+    assert is_web_search_tool_chat_completion(tool) is True
+
+
+@pytest.mark.parametrize(
+    "tool",
+    [
+        {"type": "function", "function": {"name": "web_search_helper"}},
+        {"type": "function", "function": {"name": "search"}},
+        {"type": "function", "function": None},
+        {"type": "function"},
+    ],
+)
+def test_unrelated_or_malformed_function_tools_are_not_detected(tool: Dict[str, Any]):
+    assert is_web_search_tool(tool) is False
+    assert is_web_search_tool_chat_completion(tool) is False
+
+
+def test_user_defined_web_search_function_with_schema_is_not_hijacked():
+    """A user's own tool may happen to be named "web_search" but carry a real schema;
+    only the bare {"name": "web_search"} shape is the conventional web-search marker.
+    """
+    tool = {
+        "type": "function",
+        "function": {
+            "name": "web_search",
+            "description": "Search a private index",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+    assert is_web_search_tool(tool) is False
+    assert is_web_search_tool_chat_completion(tool) is False


### PR DESCRIPTION
<!-- The whole description's target audience is humans, not AI agents: write it in plain, simple,
     everyday engineering language, extremely parsable and readable at a glance. This goes double for
     the TLDR, User Flow, and Caveats sections -->

## TLDR

<!-- Fill in the bullets below and keep each one short and concrete: one line per bullet, roughly 10 words max -->

Problem this solves:

- <blah>
- ...

How it solves it:

- <blah>
- ...

## User Flow

<!-- Two ordered lists, Before and After, walking the same end user through the same task, written strictly from that user's seat
     Read the linked issue, ticket, or customer thread first so the flow reflects the real application and the routes its users actually hit; don't invent a generic scenario
     Lead each list with one plain sentence saying where the flow fails (Before) or succeeds (After), then number the steps
     Every step is something the user does or observes: the HTTP method and full URL they hit, what they sent, and what visibly came back (status code, error text, the shape of an ID). UI steps name the page URL and what is on screen
     No LiteLLM internals: never name functions, files, DB tables, config classes, hooks, callbacks, or code paths. "The upload hands back an ID that looks like OpenAI's own `file-abc123` instead of the scrambled one the gateway returned" is right, "no managed-file row was registered" is wrong
     Keep the two lists step-for-step identical until they diverge, so the changed step is obvious
     If the bug had a security or authorization consequence, end each list with what another user could or could no longer do
     Regenerate this section whenever new commits change the PR's behavior, so it never describes an older revision

Example:

Before: a developer whose app streams chat completions gets no token counts back, so their cost dashboard reads zero

1. They send POST https://litellm-domain/v1/chat/completions with `"stream": true` and no `stream_options`
2. The last SSE chunk arrives with `"usage": null`, so their app records 0 prompt and 0 completion tokens
3. They open https://litellm-domain/ui/?page=logs and see the request logged at $0 spend

After: the same request comes back with real token counts, so the dashboard shows real spend

1. The proxy admin sets `always_include_stream_usage: true` and restarts the proxy
2. The developer sends the same POST https://litellm-domain/v1/chat/completions with `"stream": true` and no `stream_options`
3. The last SSE chunk now carries a `usage` object with real prompt and completion token counts
4. https://litellm-domain/ui/?page=logs shows that request at non-zero spend
-->

## Relevant issues

<!-- e.g., "Fixes #000" -->

## Linear ticket

<!-- if you are an internal contributor, add "Resolves " followed by the Linear ticket e.g., "Resolves LIT-1234" to link the Linear ticket to the GitHub PR. If you don't have one, leave the section blank rather than guessing -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [ ] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected
     The proof must be completely e2e with no mocks, using actual LLM calls costing real $$$ if applicable. `pytest` commands are not enough
     Show ONLY the latest run: capture Before at the merge base and After at the PR's current tip, and when new commits change behavior, replace this whole section with the fresh run instead of stacking it on top of older ones. The run must be up to date. As soon as a new commit is made and it makes this PR description's after sha stale (it's no longer tip of PR), you must re-run the QA
     Structure the section exactly as below: Before and After one heading level below this section, each naming the commit hash it was captured at, one lower-level heading per case inside each, the same case names in the same order on both sides, and numbered steps (command, observed output) under every case, never loose prose; shared setup (config, payloads) goes above Before, and with a single case, drop the case headings and number the steps directly

### Before (<hash>)

#### <case 1>

1. ...
2. ...

#### <case 2>

1. ...

### After (<hash>)

#### <case 1>

1. ...
2. ...

#### <case 2>

1. ...

     For bug fixes: Before shows the reproduction, After shows the same steps passing
     For new features: Before shows the capability missing, After shows it working end-to-end
     If the change applies to all three LLM endpoints (/v1/responses, /v1/chat/completions, /v1/messages), make each endpoint its own case, not just one
     For UI changes: before/after screenshots under the same headings -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Caveats (if any)

<!-- Group caveats under severity subheadings (### Severe, ### High, ### Medium, ### Low), with
     short bullet points inside each, just like the TLDR: one line per bullet, roughly 10 words max
     Call out known limitations, follow-up work, or anything a reviewer should watch out for
     Include only the tiers that have caveats; drop the empty ones
     - Severe: inherent to what the PR deliberately ships, there even when the code works as intended:
       it can degrade or take down a running deployment (e.g. a slow or table-locking boot migration),
       rewrite data by design, break an existing workflow on purpose, or change auth behavior. An
       operator must plan around it before rollout
     - High: an unintended hole: a correctness, security, data-loss, or backward-compatibility bug,
       unsafe to ship as is
     - Medium: a real gap someone can hit, but with a workaround or a narrow blast radius
     - Low: anything else worth noting: naming, cleanup, an edge case nobody hits
     Nest bullets as deep as helps: hierarchy beats one long line when it makes things clearer to a
     human reader
     Leave this section empty if there are none -->

## QA runbook

<!-- Only needed when your PR edits tests/e2e; delete this section otherwise

For each e2e test you added or changed, list the manual steps a reviewer can follow to reproduce it by hand against a live proxy, mapping 1:1 to what the test asserts: one top-level bullet per test giving its pytest node id followed by what it proves in plain words, then a nested "- [ ]" checklist where each item is a concrete action (route, request body, expected response) and the final item is the sanity-check step shown in the examples. Note environment prerequisites (provider credentials, config flags) and any nuances a manual run will hit. See PRs #32914 and #32963 for full examples

Example checklists:

- tests/e2e/quota_management/ratelimit/test_rate_limit_e2e.py::TestKeyRateLimits::test_rpm_limit_blocks_over_limit - a key allowed 2 requests a minute serves exactly 2 and refuses the 3rd
  - [ ] Generate a limited key: curl -X POST http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -d '{"rpm_limit": 2}'
  - [ ] Send three /v1/chat/completions requests with that key inside one minute
  - [ ] Expect the first two to return 200 and the third to return 429 naming the rpm limit
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/management/test_management_e2e.py::TestModelRoutes::test_model_create_appears_in_ui - a deployment created through the API shows up on the Admin UI models page
  - [ ] POST /model/new with the master key, a bedrock model, and aws_region_name (needs STORE_MODEL_IN_DB=True and AWS credentials)
  - [ ] Open http://localhost:4000/ui/?page=models and expect a deployment row showing the returned model id
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky
-->

## Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
