### PR TITLE
fix(test): drop the duplicate embedding_executor arg in the Bedrock KB fake handler

### DIFF
--- a/tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py
+++ b/tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py
@@ -376,7 +376,6 @@ async def test_bedrock_kb_request_body_has_transformed_filters(
         timeout=None,
         client=None,
         _is_async=False,
-        embedding_executor=None,
     ):
         litellm_params_dict = (
             litellm_params.model_dump(exclude_none=False)


### PR DESCRIPTION
## TLDR

Problem this solves:

- The Bedrock KB test file does not compile on staging
- All 13 tests in it are uncollectable, `logging_testing` is red

How it solves it:

- Delete the duplicate `embedding_executor` parameter

## User Flow

This is a test-only change with no runtime surface, so there is no end-user flow to walk through. Nothing a caller of the proxy or the SDK can do changes with this PR

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

There is no proxy route to curl here: the defect is that a test module fails to compile, so the proof is the module compiling and the file collecting. Both sides run the same two commands

### Before (3cac5e5cd4)

1. `python -c "compile(open('tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py').read(), 'tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py', 'exec')"`

```
  File "tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py", line 379
    ):
      ^
SyntaxError: duplicate argument 'embedding_executor' in function definition
```

2. CircleCI `logging_testing` on this commit reports the same thing as a collection failure, so none of the 13 tests run:

```
E     File "/home/circleci/project/tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py", line 379
E       embedding_executor=None,
E       ^^^^^^^^^^^^^^^^^^
E   SyntaxError: duplicate argument 'embedding_executor' in function definition
```

### After (47611fa207)

1. `python -c "compile(open('tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py').read(), 'tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py', 'exec'); print('compiles')"`

```
compiles
```

2. `pytest tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py --collect-only -q`

```
13 tests collected in 0.01s
```

3. `pytest tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py::test_bedrock_kb_request_body_has_transformed_filters -q`

```
.                                                                        [100%]
1 passed in 4.65s
```

## Type

🐛 Bug Fix
✅ Test

## Caveats (if any)

### Low

- The rest of that file still needs live AWS credentials to pass

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only syntax fix with no runtime or production code touched.
> 
> **Overview**
> Fixes a **SyntaxError** in `test_bedrock_knowledgebase_hook.py` that blocked the whole module from loading and broke the `logging_testing` CI job.
> 
> In `test_bedrock_kb_request_body_has_transformed_filters`, the patched `fake_async_vector_store_search_handler` listed `embedding_executor=None` twice in its parameter list. Python rejects duplicate parameter names, so pytest could not collect any of the 13 tests in that file.
> 
> The change **removes the extra `embedding_executor` argument**, leaving a single parameter that still matches `async_vector_store_search_handler` on the real HTTP handler. **Test-only**; no production or proxy behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47611fa207f020f521d82e248df24c6c97df0bb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->