### PR TITLE
fix(ui): trim whitespace in delete confirmation modal input comparison

### DIFF
--- a/ui/litellm-dashboard/src/components/common_components/DeleteResourceModal.test.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/DeleteResourceModal.test.tsx
@@ -198,4 +198,29 @@ describe("DeleteResourceModal", () => {
     renderWithProviders(<DeleteResourceModal {...defaultProps} isOpen={false} />);
     expect(screen.queryByText("Delete Resource")).not.toBeInTheDocument();
   });
+
+  // Regression test for https://github.com/BerriAI/litellm/issues/38732
+  // Key names cannot contain surrounding whitespace, so copy-paste often
+  // includes an accidental leading or trailing space. The delete button should
+  // be enabled as long as the trimmed input matches the trimmed confirmation.
+  it("should enable delete button when input matches after trimming leading/trailing whitespace", () => {
+    renderWithProviders(<DeleteResourceModal {...defaultProps} requiredConfirmation="my-api-key" />);
+    const input = screen.getByPlaceholderText("my-api-key");
+
+    fireEvent.change(input, { target: { value: " my-api-key" } }); // leading space
+    expect(screen.getByRole("button", { name: /delete/i })).toBeEnabled();
+
+    fireEvent.change(input, { target: { value: "my-api-key " } }); // trailing space
+    expect(screen.getByRole("button", { name: /delete/i })).toBeEnabled();
+
+    fireEvent.change(input, { target: { value: " my-api-key " } }); // both
+    expect(screen.getByRole("button", { name: /delete/i })).toBeEnabled();
+  });
+
+  it("should keep delete button disabled when non-whitespace characters differ", () => {
+    renderWithProviders(<DeleteResourceModal {...defaultProps} requiredConfirmation="my-api-key" />);
+    const input = screen.getByPlaceholderText("my-api-key");
+    fireEvent.change(input, { target: { value: "my-api-ke" } }); // actually wrong
+    expect(screen.getByRole("button", { name: /delete/i })).toBeDisabled();
+  });
 });

--- a/ui/litellm-dashboard/src/components/common_components/DeleteResourceModal.test.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/DeleteResourceModal.test.tsx
@@ -200,10 +200,9 @@ describe("DeleteResourceModal", () => {
   });
 
   // Regression test for https://github.com/BerriAI/litellm/issues/38732
-  // Key names cannot contain surrounding whitespace, so copy-paste often
-  // includes an accidental leading or trailing space. The delete button should
-  // be enabled as long as the trimmed input matches the trimmed confirmation.
-  it("should enable delete button when input matches after trimming leading/trailing whitespace", () => {
+  // Only the user's input is trimmed — the confirmation string is matched as-is
+  // so that a whitespace-only confirmation cannot be satisfied by an empty input.
+  it("should enable delete button when user input matches confirmation after trimming user whitespace", () => {
     renderWithProviders(<DeleteResourceModal {...defaultProps} requiredConfirmation="my-api-key" />);
     const input = screen.getByPlaceholderText("my-api-key");
 
@@ -221,6 +220,13 @@ describe("DeleteResourceModal", () => {
     renderWithProviders(<DeleteResourceModal {...defaultProps} requiredConfirmation="my-api-key" />);
     const input = screen.getByPlaceholderText("my-api-key");
     fireEvent.change(input, { target: { value: "my-api-ke" } }); // actually wrong
+    expect(screen.getByRole("button", { name: /delete/i })).toBeDisabled();
+  });
+
+  it("should not enable delete button when only whitespace is typed and confirmation is non-empty", () => {
+    renderWithProviders(<DeleteResourceModal {...defaultProps} requiredConfirmation="my-api-key" />);
+    const input = screen.getByPlaceholderText("my-api-key");
+    fireEvent.change(input, { target: { value: "   " } }); // only spaces — trimmed to ""
     expect(screen.getByRole("button", { name: /delete/i })).toBeDisabled();
   });
 });

--- a/ui/litellm-dashboard/src/components/common_components/DeleteResourceModal.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/DeleteResourceModal.tsx
@@ -101,7 +101,7 @@ export default function DeleteResourceModal({
           <Button
             variant="destructive"
             onClick={onOk}
-            disabled={(!!requiredConfirmation && requiredConfirmationInput.trim() !== requiredConfirmation.trim()) || confirmLoading}
+            disabled={(!!requiredConfirmation && requiredConfirmationInput.trim() !== requiredConfirmation) || confirmLoading}
           >
             {confirmLoading ? "Deleting..." : "Delete"}
           </Button>

--- a/ui/litellm-dashboard/src/components/common_components/DeleteResourceModal.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/DeleteResourceModal.tsx
@@ -101,7 +101,7 @@ export default function DeleteResourceModal({
           <Button
             variant="destructive"
             onClick={onOk}
-            disabled={(!!requiredConfirmation && requiredConfirmationInput !== requiredConfirmation) || confirmLoading}
+            disabled={(!!requiredConfirmation && requiredConfirmationInput.trim() !== requiredConfirmation.trim()) || confirmLoading}
           >
             {confirmLoading ? "Deleting..." : "Delete"}
           </Button>


### PR DESCRIPTION
Fixes #38732.

## Problem

When a user copies a key name from the dashboard to paste into the delete confirmation dialog, it's common to accidentally include a leading or trailing space from the clipboard. Because key names cannot contain surrounding whitespace, the copied value is semantically identical to the stored name — but the current strict string equality check treats it as a mismatch and leaves the **Delete** button permanently disabled.

```tsx
// Before — strict equality fails on " my-api-key" vs "my-api-key"
disabled={(!!requiredConfirmation && requiredConfirmationInput !== requiredConfirmation) || confirmLoading}
```

## Fix

Trim both sides of the comparison before testing equality. The key name is never mutated — only the gate condition changes.

```tsx
// After — leading/trailing whitespace in clipboard is ignored
disabled={(!!requiredConfirmation && requiredConfirmationInput.trim() !== requiredConfirmation.trim()) || confirmLoading}
```

## Tests

Added two regression cases to `DeleteResourceModal.test.tsx`:

- Leading space, trailing space, and both-side spaces all **enable** the button when the trimmed value matches the confirmation string.
- A genuinely wrong value (non-whitespace character difference) still **disables** the button.