### PR TITLE
fix(proxy-extras): only spend a migrate-deploy attempt when a pass made no progress

### DIFF
--- a/litellm-proxy-extras/litellm_proxy_extras/utils.py
+++ b/litellm-proxy-extras/litellm_proxy_extras/utils.py
@@ -6,6 +6,7 @@ import shutil
 import subprocess
 import tempfile
 import time
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Optional
 
@@ -44,6 +45,38 @@ def _get_prisma_env() -> dict:
 _MIGRATION_TS_RE = re.compile(r"^(\d{14})_")
 
 _MIGRATION_DEADLOCK_MARKER = "deadlock detected"
+
+MAX_MIGRATE_DEPLOY_ATTEMPTS = 4
+
+
+@dataclass(frozen=True)
+class _MigrateAttemptBudget:
+    """Retries left, and the recoveries already run.
+
+    A recovery that lands something new costs nothing, so a database full of
+    objects `prisma db push` created works through them one per pass. Anything
+    that made no progress spends an attempt, so a stuck run still gives up.
+    """
+
+    attempts_left: int
+    recoveries: frozenset[str] = frozenset()
+
+    @property
+    def exhausted(self) -> bool:
+        return self.attempts_left <= 0
+
+    @property
+    def attempt_number(self) -> int:
+        return MAX_MIGRATE_DEPLOY_ATTEMPTS - self.attempts_left + 1
+
+    def spend(self) -> "_MigrateAttemptBudget":
+        return replace(self, attempts_left=self.attempts_left - 1)
+
+    def after_recovery(self, recovery: str) -> "_MigrateAttemptBudget":
+        if recovery in self.recoveries:
+            return self.spend()
+        return replace(self, recoveries=self.recoveries | {recovery})
+
 
 _SPEND_LOGS_ALTER_RE = re.compile(r'^ALTER\s+TABLE\s+"LiteLLM_SpendLogs"\s', re.IGNORECASE)
 _SPEND_LOGS_ARTIFACT_DROP_RE = re.compile(
@@ -716,6 +749,9 @@ class ProxyExtrasDBManager:
         Ahead-of-HEAD state (DB has migrations newer than this build ships)
         is logged as a warning, not a fatal error — users whose DBs got into
         weird shapes from the old thrashing should still be able to start.
+
+        The retry budget only counts attempts that made no progress: see
+        _MigrateAttemptBudget.
         """
         schema_path = ProxyExtrasDBManager._get_prisma_dir() + "/schema.prisma"
         migrations_dir = ProxyExtrasDBManager._get_prisma_dir()
@@ -749,8 +785,9 @@ class ProxyExtrasDBManager:
         original_dir = os.getcwd()
         os.chdir(migrations_dir)
         deploy_timeout = prisma_migrate_deploy_timeout()
+        budget = _MigrateAttemptBudget(attempts_left=MAX_MIGRATE_DEPLOY_ATTEMPTS)
         try:
-            for attempt in range(4):
+            while not budget.exhausted:
                 try:
                     result = subprocess.run(
                         [_get_prisma_command(), "migrate", "deploy"],
@@ -767,10 +804,11 @@ class ProxyExtrasDBManager:
                     logger.warning(
                         "prisma migrate deploy attempt %s timed out after %ss, retrying. "
                         "Raise %s if this database needs longer to apply its pending migrations.",
-                        attempt + 1,
+                        budget.attempt_number,
                         deploy_timeout,
                         PRISMA_MIGRATE_DEPLOY_TIMEOUT_ENV_VAR,
                     )
+                    budget = budget.spend()
                     time.sleep(random.randrange(5, 15))
                     continue
 
@@ -781,7 +819,14 @@ class ProxyExtrasDBManager:
                         logger.info(
                             "Schema exists but no migrations ledger — creating baseline"
                         )
-                        ProxyExtrasDBManager._create_baseline_migration(schema_path)
+                        baselined = ProxyExtrasDBManager._create_baseline_migration(
+                            schema_path
+                        )
+                        budget = (
+                            budget.after_recovery("baseline")
+                            if baselined
+                            else budget.spend()
+                        )
                         continue
 
                     if "P3009" in stderr:
@@ -818,6 +863,7 @@ class ProxyExtrasDBManager:
                                     f"intervention may be required.\n\n"
                                     f"Detail: {resolve_err}"
                                 ) from resolve_err
+                            budget = budget.after_recovery(f"resolved:{name}")
                             continue
                         if migration_match:
                             migration_name = migration_match.group(1)
@@ -831,6 +877,7 @@ class ProxyExtrasDBManager:
                                     migration_name,
                                 )
                                 ProxyExtrasDBManager._roll_back_migration_best_effort(migration_name)
+                                budget = budget.spend()
                                 time.sleep(random.randrange(5, 15))
                                 continue
                         raise RuntimeError(
@@ -876,6 +923,7 @@ class ProxyExtrasDBManager:
                                     f"intervention may be required.\n\n"
                                     f"Detail: {resolve_err}"
                                 ) from resolve_err
+                            budget = budget.after_recovery(f"resolved:{name}")
                             continue
 
                         if migration_match and _MIGRATION_DEADLOCK_MARKER in stderr:
@@ -888,6 +936,7 @@ class ProxyExtrasDBManager:
                             ProxyExtrasDBManager._roll_back_migration_best_effort(
                                 migration_match.group(1)
                             )
+                            budget = budget.spend()
                             time.sleep(random.randrange(5, 15))
                             continue
 
@@ -900,8 +949,9 @@ class ProxyExtrasDBManager:
                         logger.info(
                             "prisma migrate deploy attempt %s deadlocked against "
                             "a concurrent migrate deploy, retrying",
-                            attempt + 1,
+                            budget.attempt_number,
                         )
+                        budget = budget.spend()
                         time.sleep(random.randrange(5, 15))
                         continue
 
@@ -909,8 +959,9 @@ class ProxyExtrasDBManager:
                         logger.info(
                             "prisma migrate deploy attempt %s timed out waiting for "
                             "the advisory lock a concurrent migrate deploy holds, retrying",
-                            attempt + 1,
+                            budget.attempt_number,
                         )
+                        budget = budget.spend()
                         time.sleep(random.randrange(5, 15))
                         continue
 
@@ -920,9 +971,9 @@ class ProxyExtrasDBManager:
                     ) from e
 
             raise RuntimeError(
-                "Database migration failed after 4 attempts (retry loop "
-                "exhausted by timeouts, deadlock retries, or repeated "
-                "idempotent-recovery continues). Check database connectivity, "
+                f"Database migration failed after {MAX_MIGRATE_DEPLOY_ATTEMPTS} "
+                "attempts that made no progress (timeouts, deadlock retries, or a "
+                "recovery that had already run once). Check database connectivity, "
                 "load, and _prisma_migrations ledger state, and raise "
                 f"{PRISMA_MIGRATE_DEPLOY_TIMEOUT_ENV_VAR} if the attempts timed out."
             )

--- a/litellm-proxy-extras/litellm_proxy_extras/utils.py
+++ b/litellm-proxy-extras/litellm_proxy_extras/utils.py
@@ -808,167 +808,16 @@ class ProxyExtrasDBManager:
                         deploy_timeout,
                         PRISMA_MIGRATE_DEPLOY_TIMEOUT_ENV_VAR,
                     )
-                    budget = budget.spend()
-                    time.sleep(random.randrange(5, 15))
-                    continue
+                    next_budget = budget.spend()
 
                 except subprocess.CalledProcessError as e:
-                    stderr = e.stderr or ""
+                    next_budget = ProxyExtrasDBManager._budget_after_deploy_failure(
+                        e, budget, schema_path
+                    )
 
-                    if "P3005" in stderr and "database schema is not empty" in stderr:
-                        logger.info(
-                            "Schema exists but no migrations ledger — creating baseline"
-                        )
-                        baselined = ProxyExtrasDBManager._create_baseline_migration(
-                            schema_path
-                        )
-                        budget = (
-                            budget.after_recovery("baseline")
-                            if baselined
-                            else budget.spend()
-                        )
-                        continue
-
-                    if "P3009" in stderr:
-                        migration_match = re.search(r"`(\d+_\S+?)`", stderr)
-                        if (
-                            migration_match
-                            and ProxyExtrasDBManager._is_idempotent_error(stderr)
-                        ):
-                            name = migration_match.group(1)
-                            logger.info(
-                                f"Migration {name} failed idempotently — marking applied and retrying"
-                            )
-                            try:
-                                ProxyExtrasDBManager._roll_back_migration(name)
-                            except (
-                                subprocess.CalledProcessError,
-                                subprocess.TimeoutExpired,
-                            ):
-                                pass  # may already be rolled-back
-                            try:
-                                ProxyExtrasDBManager._resolve_specific_migration(name)
-                            except (
-                                subprocess.CalledProcessError,
-                                subprocess.TimeoutExpired,
-                            ) as resolve_err:
-                                # We're already inside the outer
-                                # `except CalledProcessError` handler —
-                                # re-raising CalledProcessError from here
-                                # would escape as itself, bypassing
-                                # proxy_cli.py's `except RuntimeError`.
-                                raise RuntimeError(
-                                    f"Failed to mark migration {name} as applied "
-                                    f"after idempotent recovery. Manual "
-                                    f"intervention may be required.\n\n"
-                                    f"Detail: {resolve_err}"
-                                ) from resolve_err
-                            budget = budget.after_recovery(f"resolved:{name}")
-                            continue
-                        if migration_match:
-                            migration_name = migration_match.group(1)
-                            ledger_logs = ProxyExtrasDBManager._failed_migration_logs(migration_name)
-                            if ledger_logs is not None and (
-                                ledger_logs == "" or _MIGRATION_DEADLOCK_MARKER in ledger_logs
-                            ):
-                                logger.info(
-                                    "Migration %s failed in a concurrent migrate deploy "
-                                    "deadlock race, rolling its ledger row back and retrying",
-                                    migration_name,
-                                )
-                                ProxyExtrasDBManager._roll_back_migration_best_effort(migration_name)
-                                budget = budget.spend()
-                                time.sleep(random.randrange(5, 15))
-                                continue
-                        raise RuntimeError(
-                            "Database migration failed and cannot be auto-recovered. "
-                            f"Manual intervention required.\n\nPrisma error:\n{stderr}"
-                        ) from e
-
-                    if "P3018" in stderr:
-                        if ProxyExtrasDBManager._is_permission_error(stderr):
-                            raise RuntimeError(
-                                "Database migration failed due to insufficient "
-                                "permissions. Please grant the required privileges "
-                                f"and retry.\n\nPrisma error:\n{stderr}"
-                            ) from e
-
-                        migration_match = re.search(
-                            r"Migration name: (\d+_\S+)", stderr
-                        )
-                        if (
-                            migration_match
-                            and ProxyExtrasDBManager._is_idempotent_error(stderr)
-                        ):
-                            name = migration_match.group(1)
-                            logger.info(
-                                f"Migration {name} SQL hit idempotent error — marking applied and retrying"
-                            )
-                            try:
-                                ProxyExtrasDBManager._roll_back_migration(name)
-                            except (
-                                subprocess.CalledProcessError,
-                                subprocess.TimeoutExpired,
-                            ):
-                                pass  # may already be rolled-back
-                            try:
-                                ProxyExtrasDBManager._resolve_specific_migration(name)
-                            except (
-                                subprocess.CalledProcessError,
-                                subprocess.TimeoutExpired,
-                            ) as resolve_err:
-                                raise RuntimeError(
-                                    f"Failed to mark migration {name} as applied "
-                                    f"after idempotent recovery. Manual "
-                                    f"intervention may be required.\n\n"
-                                    f"Detail: {resolve_err}"
-                                ) from resolve_err
-                            budget = budget.after_recovery(f"resolved:{name}")
-                            continue
-
-                        if migration_match and _MIGRATION_DEADLOCK_MARKER in stderr:
-                            logger.info(
-                                "Migration %s deadlocked against a concurrent "
-                                "migrate deploy, rolling its ledger row back "
-                                "and retrying",
-                                migration_match.group(1),
-                            )
-                            ProxyExtrasDBManager._roll_back_migration_best_effort(
-                                migration_match.group(1)
-                            )
-                            budget = budget.spend()
-                            time.sleep(random.randrange(5, 15))
-                            continue
-
-                        raise RuntimeError(
-                            "Database migration failed and cannot be auto-recovered. "
-                            f"Manual intervention required.\n\nPrisma error:\n{stderr}"
-                        ) from e
-
-                    if _MIGRATION_DEADLOCK_MARKER in stderr:
-                        logger.info(
-                            "prisma migrate deploy attempt %s deadlocked against "
-                            "a concurrent migrate deploy, retrying",
-                            budget.attempt_number,
-                        )
-                        budget = budget.spend()
-                        time.sleep(random.randrange(5, 15))
-                        continue
-
-                    if "P1002" in stderr and "advisory lock" in stderr:
-                        logger.info(
-                            "prisma migrate deploy attempt %s timed out waiting for "
-                            "the advisory lock a concurrent migrate deploy holds, retrying",
-                            budget.attempt_number,
-                        )
-                        budget = budget.spend()
-                        time.sleep(random.randrange(5, 15))
-                        continue
-
-                    raise RuntimeError(
-                        "Database migration failed and cannot be auto-recovered. "
-                        f"Manual intervention required.\n\nPrisma error:\n{stderr}"
-                    ) from e
+                if next_budget.attempts_left < budget.attempts_left:
+                    time.sleep(random.randrange(5, 15))
+                budget = next_budget  # rebind-ok: the loop carries the budget from one migrate deploy pass to the next
 
             raise RuntimeError(
                 f"Database migration failed after {MAX_MIGRATE_DEPLOY_ATTEMPTS} "
@@ -979,6 +828,130 @@ class ProxyExtrasDBManager:
             )
         finally:
             os.chdir(original_dir)
+
+    @staticmethod
+    def _budget_after_deploy_failure(
+        error: subprocess.CalledProcessError,
+        budget: "_MigrateAttemptBudget",
+        schema_path: str,
+    ) -> "_MigrateAttemptBudget":
+        """Recover from one failed `prisma migrate deploy`, and price the pass.
+
+        Returns the budget the next pass runs under, or raises when the failure
+        is not one this resolver knows how to recover from.
+        """
+        stderr = error.stderr or ""
+
+        if "P3005" in stderr and "database schema is not empty" in stderr:
+            logger.info("Schema exists but no migrations ledger — creating baseline")
+            if ProxyExtrasDBManager._create_baseline_migration(schema_path):
+                return budget.after_recovery("baseline")
+            return budget.spend()
+
+        if "P3009" in stderr:
+            migration_match = re.search(r"`(\d+_\S+?)`", stderr)
+            if migration_match and ProxyExtrasDBManager._is_idempotent_error(stderr):
+                name = migration_match.group(1)
+                logger.info(
+                    f"Migration {name} failed idempotently — marking applied and retrying"
+                )
+                ProxyExtrasDBManager._mark_migration_applied(name)
+                return budget.after_recovery(f"resolved:{name}")
+            if migration_match:
+                migration_name = migration_match.group(1)
+                ledger_logs = ProxyExtrasDBManager._failed_migration_logs(migration_name)
+                if ledger_logs is not None and (
+                    ledger_logs == "" or _MIGRATION_DEADLOCK_MARKER in ledger_logs
+                ):
+                    logger.info(
+                        "Migration %s failed in a concurrent migrate deploy "
+                        "deadlock race, rolling its ledger row back and retrying",
+                        migration_name,
+                    )
+                    ProxyExtrasDBManager._roll_back_migration_best_effort(migration_name)
+                    return budget.spend()
+            raise RuntimeError(
+                "Database migration failed and cannot be auto-recovered. "
+                f"Manual intervention required.\n\nPrisma error:\n{stderr}"
+            ) from error
+
+        if "P3018" in stderr:
+            if ProxyExtrasDBManager._is_permission_error(stderr):
+                raise RuntimeError(
+                    "Database migration failed due to insufficient "
+                    "permissions. Please grant the required privileges "
+                    f"and retry.\n\nPrisma error:\n{stderr}"
+                ) from error
+
+            migration_match = re.search(r"Migration name: (\d+_\S+)", stderr)
+            if migration_match and ProxyExtrasDBManager._is_idempotent_error(stderr):
+                name = migration_match.group(1)
+                logger.info(
+                    f"Migration {name} SQL hit idempotent error — marking applied and retrying"
+                )
+                ProxyExtrasDBManager._mark_migration_applied(name)
+                return budget.after_recovery(f"resolved:{name}")
+
+            if migration_match and _MIGRATION_DEADLOCK_MARKER in stderr:
+                logger.info(
+                    "Migration %s deadlocked against a concurrent "
+                    "migrate deploy, rolling its ledger row back "
+                    "and retrying",
+                    migration_match.group(1),
+                )
+                ProxyExtrasDBManager._roll_back_migration_best_effort(
+                    migration_match.group(1)
+                )
+                return budget.spend()
+
+            raise RuntimeError(
+                "Database migration failed and cannot be auto-recovered. "
+                f"Manual intervention required.\n\nPrisma error:\n{stderr}"
+            ) from error
+
+        if _MIGRATION_DEADLOCK_MARKER in stderr:
+            logger.info(
+                "prisma migrate deploy attempt %s deadlocked against "
+                "a concurrent migrate deploy, retrying",
+                budget.attempt_number,
+            )
+            return budget.spend()
+
+        if "P1002" in stderr and "advisory lock" in stderr:
+            logger.info(
+                "prisma migrate deploy attempt %s timed out waiting for "
+                "the advisory lock a concurrent migrate deploy holds, retrying",
+                budget.attempt_number,
+            )
+            return budget.spend()
+
+        raise RuntimeError(
+            "Database migration failed and cannot be auto-recovered. "
+            f"Manual intervention required.\n\nPrisma error:\n{stderr}"
+        ) from error
+
+    @staticmethod
+    def _mark_migration_applied(name: str) -> None:
+        """Roll a failed ledger row back if it is still there, then mark it applied."""
+        try:
+            ProxyExtrasDBManager._roll_back_migration(name)
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+            pass  # may already be rolled-back
+        try:
+            ProxyExtrasDBManager._resolve_specific_migration(name)
+        except (
+            subprocess.CalledProcessError,
+            subprocess.TimeoutExpired,
+        ) as resolve_err:
+            # We're called from inside an `except CalledProcessError` handler —
+            # re-raising CalledProcessError from here would escape as itself,
+            # bypassing proxy_cli.py's `except RuntimeError`.
+            raise RuntimeError(
+                f"Failed to mark migration {name} as applied "
+                f"after idempotent recovery. Manual "
+                f"intervention may be required.\n\n"
+                f"Detail: {resolve_err}"
+            ) from resolve_err
 
     @staticmethod
     def apply_replica_identity_full_if_requested() -> bool:

--- a/tests/litellm-proxy-extras/test_litellm_proxy_extras_utils.py
+++ b/tests/litellm-proxy-extras/test_litellm_proxy_extras_utils.py
@@ -703,3 +703,170 @@ class TestSpendLogsPartitionDetectionMissingPsycopg:
         assert any(
             "psycopg is not installed" in record.message for record in caplog.records
         )
+
+
+_ATTEMPT_BUDGET = 4
+
+_P3005_STDERR = """Error: P3005
+
+The database schema is not empty. Read more about how to baseline an existing production database: https://pris.ly/d/migrate-baseline
+"""
+
+
+def _p3018_stderr(migration_name):
+    return f"""Error: P3018
+
+A migration failed to apply. New migrations cannot be applied before the error is recovered from.
+
+Migration name: {migration_name}
+
+Database error code: 42P07
+
+Database error:
+ERROR: relation "SomeTable" already exists
+"""
+
+
+class _MigrateDeployHarness:
+    """Drives _setup_database_v2 with a scripted sequence of
+    `prisma migrate deploy` outcomes, with every recovery command faked out so
+    nothing touches a database or the packaged migrations directory."""
+
+    def __init__(self, monkeypatch, tmp_path, outcomes, repeat_last=False):
+        import subprocess as subprocess_module
+
+        import litellm_proxy_extras.utils as utils_module
+
+        self.deploy_calls = []
+        self.resolved = []
+        self.baselines = 0
+        self._outcomes = list(outcomes)
+        self._repeat_last = repeat_last
+        self._subprocess_module = subprocess_module
+
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        monkeypatch.setattr(
+            ProxyExtrasDBManager, "_get_prisma_dir", staticmethod(lambda: str(tmp_path))
+        )
+        monkeypatch.setattr(
+            ProxyExtrasDBManager,
+            "_create_baseline_migration",
+            staticmethod(self._fake_baseline),
+        )
+        monkeypatch.setattr(
+            ProxyExtrasDBManager,
+            "_roll_back_migration",
+            staticmethod(lambda name: None),
+        )
+        monkeypatch.setattr(
+            ProxyExtrasDBManager,
+            "_resolve_specific_migration",
+            staticmethod(self.resolved.append),
+        )
+        monkeypatch.setattr(utils_module.subprocess, "run", self._fake_run)
+        monkeypatch.setattr(utils_module.time, "sleep", lambda seconds: None)
+
+        self.baseline_succeeds = True
+
+    def _fake_baseline(self, *args, **kwargs):
+        self.baselines += 1
+        return self.baseline_succeeds
+
+    def _next_outcome(self):
+        if self._outcomes:
+            if self._repeat_last and len(self._outcomes) == 1:
+                return self._outcomes[0]
+            return self._outcomes.pop(0)
+        raise AssertionError("prisma migrate deploy called more times than scripted")
+
+    def _fake_run(self, cmd, **kwargs):
+        assert cmd[1:] == ["migrate", "deploy"], f"unexpected prisma command: {cmd}"
+        self.deploy_calls.append(cmd)
+        outcome = self._next_outcome()
+        if outcome == "ok":
+            return _FakeCompleted()
+        if outcome == "timeout":
+            raise self._subprocess_module.TimeoutExpired(cmd, 1)
+        raise self._subprocess_module.CalledProcessError(1, cmd, stderr=outcome)
+
+    def run(self):
+        return ProxyExtrasDBManager._setup_database_v2(use_migrate=True)
+
+
+class TestMigrateDeployAttemptAccounting:
+    """A `prisma db push` database has a full schema and no ledger, so the v2
+    resolver baselines it and then works through every migration whose objects
+    already exist. Those recoveries make progress, so they must not spend the
+    retry budget, which is there to stop a run that is getting nowhere."""
+
+    def test_a_push_created_database_finishes_bootstrapping(
+        self, monkeypatch, tmp_path
+    ):
+        already_there = [
+            "20250329084805_new_cron_job_table",
+            "20250806095134_rename_alias_to_server_name_mcp_table",
+            "20260224203854_add_agent_object_permissions_table",
+            "20260301120000_fourth_table",
+            "20260302120000_fifth_table",
+            "20260303120000_sixth_table",
+        ]
+        harness = _MigrateDeployHarness(
+            monkeypatch,
+            tmp_path,
+            [_P3005_STDERR]
+            + [_p3018_stderr(name) for name in already_there]
+            + ["ok"],
+        )
+
+        assert harness.run() is True
+        assert harness.baselines == 1
+        assert harness.resolved == already_there
+        assert len(harness.deploy_calls) == len(already_there) + 2
+
+    def test_repeated_recovery_of_one_migration_still_gives_up(
+        self, monkeypatch, tmp_path
+    ):
+        harness = _MigrateDeployHarness(
+            monkeypatch,
+            tmp_path,
+            [_p3018_stderr("20250329084805_new_cron_job_table")],
+            repeat_last=True,
+        )
+
+        with pytest.raises(RuntimeError):
+            harness.run()
+        assert len(harness.deploy_calls) <= _ATTEMPT_BUDGET + 1
+
+    def test_timeouts_still_spend_the_budget(self, monkeypatch, tmp_path):
+        harness = _MigrateDeployHarness(
+            monkeypatch, tmp_path, ["timeout"], repeat_last=True
+        )
+
+        with pytest.raises(RuntimeError):
+            harness.run()
+        assert len(harness.deploy_calls) == _ATTEMPT_BUDGET
+
+    def test_a_baseline_that_never_lands_stops_after_the_budget(
+        self, monkeypatch, tmp_path
+    ):
+        harness = _MigrateDeployHarness(
+            monkeypatch, tmp_path, [_P3005_STDERR], repeat_last=True
+        )
+        harness.baseline_succeeds = False
+
+        with pytest.raises(RuntimeError):
+            harness.run()
+        assert len(harness.deploy_calls) == _ATTEMPT_BUDGET
+
+    def test_an_unrecoverable_error_is_not_retried(self, monkeypatch, tmp_path):
+        harness = _MigrateDeployHarness(
+            monkeypatch,
+            tmp_path,
+            ["Error: P3018\n\nMigration name: 20260101000000_x\n\nERROR: syntax error at or near \"SLECT\"\n"],
+            repeat_last=True,
+        )
+
+        with pytest.raises(RuntimeError):
+            harness.run()
+        assert len(harness.deploy_calls) == 1
+        assert harness.resolved == []


### PR DESCRIPTION
## TLDR

Problem this solves:

- A `--use_prisma_db_push` database can never boot under `--use_v2_migration_resolver`
- Every recovery burned one of only 4 migrate attempts
- The proxy exits before binding its port, so nothing serves

How it solves it:

- Attempts are only spent when a pass made no progress
- Baselining, and each migration newly marked applied, cost nothing
- Timeouts, deadlock retries, and repeat recoveries still spend
- A repeat of the same recovery still ends the run

## User Flow

Before: an operator who first brought their database up with `--use_prisma_db_push` cannot switch that same database to `--use_v2_migration_resolver`, and the proxy never starts

1. They start the proxy once with `--use_prisma_db_push` against an empty Postgres, and it serves `POST https://litellm-domain/v1/chat/completions` normally
2. They restart the same proxy against the same database with `--use_v2_migration_resolver` instead
3. Boot logs `Schema exists but no migrations ledger — creating baseline`, then three `SQL hit idempotent error — marking applied and retrying` lines
4. Boot stops with `Database migration cannot proceed. Database migration failed after 4 attempts` and the process exits
5. `GET https://litellm-domain/health/readiness` never answers because the port was never bound, and every request their apps send fails to connect

After: the same restart works through the objects the push already created and the proxy comes up

1. They start the proxy once with `--use_prisma_db_push` against an empty Postgres, and it serves `POST https://litellm-domain/v1/chat/completions` normally
2. They restart the same proxy against the same database with `--use_v2_migration_resolver` instead
3. Boot logs the same baseline line, then works through each `SQL hit idempotent error — marking applied and retrying` in turn instead of stopping at the fourth
4. Boot finishes and the proxy binds its port
5. `GET https://litellm-domain/health/readiness` returns 200 with `{"status":"healthy","db":"connected"}`, and `POST https://litellm-domain/v1/chat/completions` serves normally again

## Relevant issues

## Linear ticket

Resolves LIT-6802

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- Boot takes one migrate pass per pre-existing object
  - Roughly 25s each on the database this was measured against
  - Bounded by the migrations shipped, and it is a boot that now finishes

### Low

- `attempt N` in the logs now counts no-progress attempts, not passes
- A baseline that fails to land now backs off before the retry, like every other no-progress path

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Both legs run against the same Postgres 16 container, and each leg starts from a database that was just brought up by `--use_prisma_db_push` and then dropped and recreated so the second boot sees exactly the push-created state.

Shared setup:

```bash
docker run -d --name lit6802-pg-push -p 127.0.0.1:45871:5432 \
  -e POSTGRES_USER=lit6802 -e POSTGRES_PASSWORD=lit6802 -e POSTGRES_DB=lit6802push postgres:16

cat > config.yaml <<'YAML'
model_list:
  - model_name: gpt-5-mini
    litellm_params:
      model: openai/gpt-5-mini
      api_key: os.environ/OPENAI_API_KEY

general_settings:
  master_key: sk-lit6802
YAML

export DATABASE_URL='postgresql://lit6802:lit6802@127.0.0.1:45871/lit6802push'
```

Both legs are preceded by the same push boot, which is what creates the schema without a ledger:

```bash
python litellm/proxy/proxy_cli.py --config config.yaml --port 45881 --num_workers 2 --use_prisma_db_push
# serves normally, then is stopped
docker exec lit6802-pg-push psql -U lit6802 -d lit6802push -tAc \
  "SELECT count(*) FROM information_schema.tables WHERE table_schema='public';"
# 85
docker exec lit6802-pg-push psql -U lit6802 -d lit6802push -tAc \
  "SELECT coalesce(to_regclass('public._prisma_migrations')::text,'NO_LEDGER');"
# NO_LEDGER
```

### Before (ff17e8b)

1. Boot that same database with the v2 resolver:

```bash
python litellm/proxy/proxy_cli.py --config config.yaml --port 45881 --num_workers 2 --use_v2_migration_resolver
```

```
INFO - Using v2 migration resolver (--use_v2_migration_resolver)
INFO - Found 163 migrations at .../litellm-proxy-extras/litellm_proxy_extras
INFO - Schema exists but no migrations ledger — creating baseline
INFO - Generating baseline migration...
INFO - Marking baseline migration as applied...
Migration 0_init marked as applied.
INFO - Migration 20250329084805_new_cron_job_table SQL hit idempotent error — marking applied and retrying
INFO - Migration 20250806095134_rename_alias_to_server_name_mcp_table SQL hit idempotent error — marking applied and retrying
INFO - Migration 20260224203854_add_agent_object_permissions_table SQL hit idempotent error — marking applied and retrying
LiteLLM Proxy: Database migration cannot proceed. Database migration failed after 4 attempts ...
EXIT_CODE=2
```

2. The port was never bound:

```bash
lsof -nP -iTCP:45881 -sTCP:LISTEN
```

```
(no output)
```

3. Readiness never answers, so there is nothing to send a completion to:

```bash
curl -s -m 20 -w '\nHTTP %{http_code}\n' http://127.0.0.1:45881/health/readiness
```

```
HTTP 000
```

4. The ledger is stuck three migrations in:

```bash
docker exec lit6802-pg-push psql -U lit6802 -d lit6802push -tAc \
  "SELECT count(*), count(finished_at) FROM _prisma_migrations;"
```

```
95|92
```

### After (8572544b44)

1. Same command against the same freshly push-created database:

```bash
python litellm/proxy/proxy_cli.py --config config.yaml --port 45881 --num_workers 2 --use_v2_migration_resolver
```

```
INFO - Using v2 migration resolver (--use_v2_migration_resolver)
INFO - Found 163 migrations at .../litellm-proxy-extras/litellm_proxy_extras
INFO - Schema exists but no migrations ledger — creating baseline
INFO - Marking baseline migration as applied...
Migration 0_init marked as applied.
INFO - Migration 20250329084805_new_cron_job_table SQL hit idempotent error — marking applied and retrying
INFO - Migration 20250806095134_rename_alias_to_server_name_mcp_table SQL hit idempotent error — marking applied and retrying
INFO - Migration 20260224203854_add_agent_object_permissions_table SQL hit idempotent error — marking applied and retrying
INFO - Migration 20260331000000_add_prompt_environment_and_created_by SQL hit idempotent error — marking applied and retrying
... 13 more, 17 recoveries in total, where the old code stopped after 3 ...
INFO:     Uvicorn running on http://0.0.0.0:45881 (Press CTRL+C to quit)
```

2. The port is bound:

```bash
lsof -nP -iTCP:45881 -sTCP:LISTEN
```

```
python3.1 17999 mateo    7u  IPv4 0xf3d2a60da5fdae2f      0t0  TCP *:45881 (LISTEN)
python3.1 54519 mateo    7u  IPv4 0xf3d2a60da5fdae2f      0t0  TCP *:45881 (LISTEN)
python3.1 54520 mateo    7u  IPv4 0xf3d2a60da5fdae2f      0t0  TCP *:45881 (LISTEN)
```

3. Readiness answers:

```bash
curl -s -m 20 -w '\nHTTP %{http_code}\n' http://127.0.0.1:45881/health/readiness
```

```
{"status":"healthy","db":"connected"}
HTTP 200
```

4. A real `gpt-5-mini` completion through the recovered database:

```bash
curl -s -m 90 -w '\nHTTP %{http_code}\n' http://127.0.0.1:45881/v1/chat/completions \
  -H 'Authorization: Bearer sk-lit6802' -H 'Content-Type: application/json' \
  -d '{"model":"gpt-5-mini","messages":[{"role":"user","content":"Reply with exactly: ok LIT6802 refactor"}]}'
```

```
{"id":"chatcmpl-EJw0bXKB7b5ycwJs1NYkDix8gim8o","created":1788419925,"model":"gpt-5-mini","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"ok LIT6802 refactor","role":"assistant",...}}],"usage":{"completion_tokens":80,"prompt_tokens":17,"total_tokens":97,...}}
HTTP 200
```

5. The ledger reached every migration (163 shipped plus the `0_init` baseline), where the Before leg stopped at 92:

```bash
docker exec lit6802-pg-push psql -U lit6802 -d lit6802push -tAc \
  "SELECT count(*), count(finished_at) FROM _prisma_migrations;"
```

```
181|164
```

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

