### PR TITLE
fix(tests): drop the duplicate embedding_executor kwarg that breaks collection

### DIFF
--- a/tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py
+++ b/tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py
@@ -376,7 +376,6 @@ async def test_bedrock_kb_request_body_has_transformed_filters(
         timeout=None,
         client=None,
         _is_async=False,
-        embedding_executor=None,
     ):
         litellm_params_dict = (
             litellm_params.model_dump(exclude_none=False)


### PR DESCRIPTION
## TLDR

Problem this solves:

- Staging HEAD does not compile
- A duplicate `embedding_executor` kwarg is a `SyntaxError`
- The 13 Bedrock KB hook tests cannot be collected
- Every branch merging staging inherits the failure

How it solves it:

- Deletes the duplicated trailing `embedding_executor=None,`
- Keeps the one both parents already agreed on

## User Flow

Before: a developer who branches off staging and runs the Bedrock knowledge base tests gets a parse error instead of any test result

1. They branch from `litellm_internal_staging` and run `tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py`
2. Python refuses to parse the file, reporting `SyntaxError: duplicate argument 'embedding_executor' in function definition` at line 379
3. Nothing runs, so all 13 tests in the file report no result at all
4. The lint job on their branch fails the same way with `invalid-syntax: Duplicate parameter "embedding_executor"`

After: the same run parses and executes, so the developer gets real results back

1. They branch from `litellm_internal_staging` and run the same file
2. The file parses, and all 13 tests are collected and run
3. They get real pass/fail results for those tests
4. The lint job on their branch no longer reports invalid syntax

## Relevant issues

## Linear ticket

Resolves LIT-6814

## Pre-Submission checklist

- [ ] I have added meaningful tests
- [ ] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

The symptom is a parse failure, so the proof is `py_compile` on the exact file content at each commit. Same two commands on both sides, only the commit changes.

### Before (ecabfbd5af)

1. Pull the file as it exists at the merge base and compile it

```
$ git show ecabfbd5af:tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py > /tmp/kb.py
$ python3 -m py_compile /tmp/kb.py; echo "exit=$?"
  File "/tmp/kb.py", line 379
    embedding_executor=None,
    ^^^^^^^^^^^^^^^^^^
SyntaxError: duplicate argument 'embedding_executor' in function definition
exit=1
```

### After (2d861ba722)

1. Pull the same file at this PR's tip and compile it the same way

```
$ git show 2d861ba722:tests/logging_callback_tests/test_bedrock_knowledgebase_hook.py > /tmp/kb.py
$ python3 -m py_compile /tmp/kb.py; echo "exit=$?"
exit=0
```

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- 7 of the 13 tests in this file still fail locally
  - They fail on live Bedrock 403s against a knowledge base, a local credential problem
  - Out of scope here: this PR only makes the file parse again

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line test-only syntax fix with no runtime or production code changes.
> 
> **Overview**
> Removes a **duplicate** `embedding_executor=None` parameter from the nested `fake_async_vector_store_search_handler` in `test_bedrock_knowledgebase_hook.py`. The parameter was listed twice in the same function signature, which is invalid Python and caused a `SyntaxError` on import/collection.
> 
> After the fix, the test module parses again so pytest can collect and run the Bedrock knowledge base hook tests; behavior of the mock handler is unchanged because the remaining `embedding_executor` argument is the same as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d861ba722557ab6dc604eff4bd728f763436aa8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->