### PR TITLE
fix(proxy): kill the whole prisma process group when a boot migration command times out

### DIFF
--- a/litellm/proxy/db/check_migration.py
+++ b/litellm/proxy/db/check_migration.py
@@ -46,17 +46,25 @@ def extract_sql_commands(diff_output: str) -> list[str]:
 
 def check_prisma_schema_diff_helper(db_url: str) -> tuple[bool, list[str]]:
     """Checks for differences between current database and Prisma schema.
+
+    Never raises: a diff that cannot be produced, because the command failed or
+    because it outlived its budget, is reported as "no diff" so boot continues.
+
     Returns:
         A tuple containing:
         - A boolean indicating if differences were found (True) or not (False).
-        - A string with the diff output or error message.
-    Raises:
-        subprocess.CalledProcessError: If the Prisma command fails.
-        Exception: For any other errors during execution.
+        - The SQL commands that would close the diff, empty when there is none.
     """
+    from litellm_proxy_extras.prisma_toolchain import (
+        PRISMA_COMMAND_TIMEOUT_ENV_VAR,
+        prisma_command_timeout,
+        run_prisma,
+    )
+
     verbose_logger.debug("Checking for Prisma schema diff...")
+    timeout: Final = prisma_command_timeout()
     try:
-        result: Final = subprocess.run(
+        result: Final = run_prisma(
             [
                 "prisma",
                 "migrate",
@@ -67,12 +75,10 @@ def check_prisma_schema_diff_helper(db_url: str) -> tuple[bool, list[str]]:
                 "./schema.prisma",
                 "--script",
             ],
-            capture_output=True,
-            text=True,
-            check=True,
+            timeout=timeout,
+            env=os.environ.copy(),
         )
 
-        # return True, "Migration diff generated successfully."
         sql_commands: Final = extract_sql_commands(result.stdout)
 
         if sql_commands:
@@ -83,6 +89,12 @@ def check_prisma_schema_diff_helper(db_url: str) -> tuple[bool, list[str]]:
             return True, sql_commands
         else:
             return False, []
+    except subprocess.TimeoutExpired:
+        print(  # noqa: T201  # boot-time operator output, same channel as this helper's other messages
+            f"Timed out after {timeout}s generating the migration diff. "
+            f"Raise {PRISMA_COMMAND_TIMEOUT_ENV_VAR} if this database needs longer."
+        )
+        return False, []
     except subprocess.CalledProcessError as e:
         error_message: Final = f"Failed to generate migration diff. Error: {e.stderr}"
         print(error_message)  # noqa: T201

--- a/litellm/proxy/db/check_migration.py
+++ b/litellm/proxy/db/check_migration.py
@@ -47,19 +47,26 @@ def extract_sql_commands(diff_output: str) -> list[str]:
 def check_prisma_schema_diff_helper(db_url: str) -> tuple[bool, list[str]]:
     """Checks for differences between current database and Prisma schema.
 
-    Never raises: a diff that cannot be produced, because the command failed or
-    because it outlived its budget, is reported as "no diff" so boot continues.
+    Never raises: a diff that cannot be produced, because the runner is missing,
+    because the command failed, or because it outlived its budget, is reported as
+    "no diff" so boot continues.
 
     Returns:
         A tuple containing:
         - A boolean indicating if differences were found (True) or not (False).
         - The SQL commands that would close the diff, empty when there is none.
     """
-    from litellm_proxy_extras.prisma_toolchain import (
-        PRISMA_COMMAND_TIMEOUT_ENV_VAR,
-        prisma_command_timeout,
-        run_prisma,
-    )
+    try:
+        from litellm_proxy_extras.prisma_toolchain import (
+            PRISMA_COMMAND_TIMEOUT_ENV_VAR,
+            prisma_command_timeout,
+            run_prisma,
+        )
+    except ImportError as e:
+        print(  # noqa: T201  # boot-time operator output, same channel as this helper's other messages
+            f"Skipping the migration diff: litellm-proxy-extras has no Prisma runner. Error: {e}"
+        )
+        return False, []
 
     verbose_logger.debug("Checking for Prisma schema diff...")
     timeout: Final = prisma_command_timeout()

--- a/litellm/proxy/db/prisma_client.py
+++ b/litellm/proxy/db/prisma_client.py
@@ -937,9 +937,13 @@ class PrismaManager:
                         use_v2_resolver=use_v2_resolver,
                     )
                 else:
+                    from litellm_proxy_extras.prisma_toolchain import (
+                        prisma_command_timeout,
+                        run_prisma,
+                    )
+
                     PrismaManager._raise_if_partitioned_spend_logs()
-                    # Use prisma db push with increased timeout
-                    subprocess.run(
+                    run_prisma(
                         [
                             "prisma",
                             "db",
@@ -947,13 +951,15 @@ class PrismaManager:
                             "--accept-data-loss",
                             "--skip-generate",
                         ],
-                        timeout=60,
-                        check=True,
+                        timeout=prisma_command_timeout(),
+                        env=os.environ.copy(),
+                        stdout=None,
+                        stderr=None,
                     )
                     PrismaManager._apply_replica_identity_full_if_requested()
                     return True
-            except subprocess.TimeoutExpired:
-                verbose_proxy_logger.warning("Attempt %s timed out", attempt + 1)
+            except subprocess.TimeoutExpired as e:
+                verbose_proxy_logger.warning("Attempt %s timed out after %.0fs", attempt + 1, e.timeout)
                 time.sleep(random.randrange(5, 15))
             except subprocess.CalledProcessError as e:
                 attempts_left = 3 - attempt

--- a/litellm/proxy/db/prisma_client.py
+++ b/litellm/proxy/db/prisma_client.py
@@ -937,10 +937,14 @@ class PrismaManager:
                         use_v2_resolver=use_v2_resolver,
                     )
                 else:
-                    from litellm_proxy_extras.prisma_toolchain import (
-                        prisma_command_timeout,
-                        run_prisma,
-                    )
+                    try:
+                        from litellm_proxy_extras.prisma_toolchain import (
+                            prisma_command_timeout,
+                            run_prisma,
+                        )
+                    except ImportError as e:
+                        verbose_proxy_logger.error("\x1b[1;31mLiteLLM: Failed to import proxy extras. Got %s\x1b[0m", e)
+                        return False
 
                     PrismaManager._raise_if_partitioned_spend_logs()
                     run_prisma(

--- a/tests/test_litellm/proxy/db/conftest.py
+++ b/tests/test_litellm/proxy/db/conftest.py
@@ -1,5 +1,11 @@
+import json
 import os
+import signal
+import sys
+import time
 from collections.abc import Generator
+from dataclasses import dataclass
+from pathlib import Path
 from typing import Optional
 
 import pytest
@@ -75,3 +81,76 @@ def reset_entra_token_provider_cache() -> Generator[None, None, None]:
 def unset_database_url(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("DATABASE_URL", "about-to-be-unset")
     monkeypatch.delenv("DATABASE_URL")
+
+
+FAKE_PRISMA_CLI = """#!{python}
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import time
+
+calls_file = pathlib.Path(os.environ["FAKE_PRISMA_CALLS"])
+earlier_calls = calls_file.read_text().splitlines() if calls_file.exists() else []
+with calls_file.open("a") as log:
+    print(json.dumps(sys.argv[1:]), file=log)
+if not earlier_calls and os.environ.get("FAKE_PRISMA_HANG_FIRST"):
+    grandchild = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(600)"])
+    pathlib.Path(os.environ["FAKE_PRISMA_GRANDCHILD_PIDFILE"]).write_text(str(grandchild.pid))
+    time.sleep(600)
+sys.exit(0)
+"""
+
+
+@dataclass(frozen=True, slots=True)
+class FakePrismaCli:
+    """A stand-in `prisma` on PATH, recording every invocation.
+
+    With FAKE_PRISMA_HANG_FIRST set it hangs on its first call from a process tree
+    of its own, the way the real CLI wraps Node around a Rust schema engine, so a
+    timeout that kills only the direct child leaves the rest of that tree running.
+    """
+
+    calls_file: Path
+    grandchild_pidfile: Path
+
+    @property
+    def calls(self) -> list[list[str]]:
+        if not self.calls_file.exists():
+            return []
+        return [json.loads(line) for line in self.calls_file.read_text().splitlines()]
+
+    def grandchild_is_gone(self, within_seconds: float) -> bool:
+        deadline = time.monotonic() + within_seconds
+        while time.monotonic() < deadline:
+            try:
+                os.kill(int(self.grandchild_pidfile.read_text()), 0)
+            except ProcessLookupError:
+                return True
+            time.sleep(0.05)
+        return False
+
+
+@pytest.fixture
+def fake_prisma_cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Generator[FakePrismaCli, None, None]:
+    bin_dir = tmp_path / "fakebin"
+    bin_dir.mkdir()
+    script = bin_dir / "prisma"
+    script.write_text(FAKE_PRISMA_CLI.format(python=sys.executable))
+    script.chmod(0o755)
+    cli = FakePrismaCli(
+        calls_file=tmp_path / "calls.jsonl",
+        grandchild_pidfile=tmp_path / "grandchild.pid",
+    )
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ['PATH']}")
+    monkeypatch.setenv("FAKE_PRISMA_CALLS", str(cli.calls_file))
+    monkeypatch.setenv("FAKE_PRISMA_GRANDCHILD_PIDFILE", str(cli.grandchild_pidfile))
+    monkeypatch.setenv("LITELLM_PRISMA_COMMAND_TIMEOUT", "1")
+    monkeypatch.delenv("FAKE_PRISMA_HANG_FIRST", raising=False)
+    yield cli
+    if cli.grandchild_pidfile.exists():
+        try:
+            os.kill(int(cli.grandchild_pidfile.read_text()), signal.SIGKILL)
+        except ProcessLookupError:
+            pass

--- a/tests/test_litellm/proxy/db/test_check_migration.py
+++ b/tests/test_litellm/proxy/db/test_check_migration.py
@@ -37,3 +37,21 @@ def test_check_migration_out_of_sync(mocker):
     check_migration.verbose_logger.exception.assert_called_once()
     actual_message = check_migration.verbose_logger.exception.call_args[0][0]
     assert "prisma schema out of sync with db" in actual_message
+
+
+@pytest.mark.timeout(30)
+def test_migrate_diff_stops_at_its_budget_and_takes_its_process_tree_with_it(fake_prisma_cli, monkeypatch):
+    """
+    `prisma migrate diff` ran unbounded, so a database that never answers hung boot
+    before uvicorn ever started, and interrupting the proxy orphaned the schema engine.
+    """
+    from litellm.proxy.db.check_migration import check_prisma_schema_diff_helper
+
+    monkeypatch.setenv("FAKE_PRISMA_HANG_FIRST", "1")
+
+    assert check_prisma_schema_diff_helper("postgresql://u:p@localhost:9/x") == (False, [])
+    assert fake_prisma_cli.calls == [
+        ["migrate", "diff", "--from-url", "postgresql://u:p@localhost:9/x",
+         "--to-schema-datamodel", "./schema.prisma", "--script"]
+    ]
+    assert fake_prisma_cli.grandchild_is_gone(within_seconds=5)

--- a/tests/test_litellm/proxy/db/test_check_migration.py
+++ b/tests/test_litellm/proxy/db/test_check_migration.py
@@ -55,3 +55,17 @@ def test_migrate_diff_stops_at_its_budget_and_takes_its_process_tree_with_it(fak
          "--to-schema-datamodel", "./schema.prisma", "--script"]
     ]
     assert fake_prisma_cli.grandchild_is_gone(within_seconds=5)
+
+
+def test_migrate_diff_without_the_prisma_runner_skips_instead_of_crashing_boot(monkeypatch):
+    """
+    Boot calls this helper directly, so an ImportError here takes the proxy down before
+    uvicorn starts. An install without the runner must lose the diagnostic, not the proxy.
+    """
+    import sys
+
+    from litellm.proxy.db.check_migration import check_prisma_schema_diff_helper
+
+    monkeypatch.setitem(sys.modules, "litellm_proxy_extras.prisma_toolchain", None)
+
+    assert check_prisma_schema_diff_helper("postgresql://u:p@localhost:9/x") == (False, [])

--- a/tests/test_litellm/proxy/db/test_prisma_client.py
+++ b/tests/test_litellm/proxy/db/test_prisma_client.py
@@ -387,3 +387,16 @@ def test_db_push_timeout_takes_its_process_tree_with_it(fake_prisma_cli, unset_d
     assert PrismaManager.setup_database(use_migrate=False) is True
     assert fake_prisma_cli.calls == [DB_PUSH_ARGV, DB_PUSH_ARGV]
     assert fake_prisma_cli.grandchild_is_gone(within_seconds=5)
+
+
+def test_db_push_without_the_prisma_runner_fails_the_migration_instead_of_crashing_boot(
+    fake_prisma_cli, unset_database_url, monkeypatch
+):
+    """
+    An ImportError out of setup_database escapes the caller's RuntimeError handler and
+    kills boot, bypassing the operator's enforce_prisma_migration_check choice.
+    """
+    monkeypatch.setitem(sys.modules, "litellm_proxy_extras.prisma_toolchain", None)
+
+    assert PrismaManager.setup_database(use_migrate=False) is False
+    assert fake_prisma_cli.calls == []

--- a/tests/test_litellm/proxy/db/test_prisma_client.py
+++ b/tests/test_litellm/proxy/db/test_prisma_client.py
@@ -10,7 +10,7 @@ from fastapi.testclient import TestClient
 
 
 
-from litellm.proxy.db.prisma_client import PrismaWrapper, should_update_prisma_schema
+from litellm.proxy.db.prisma_client import PrismaManager, PrismaWrapper, should_update_prisma_schema
 
 
 @pytest.fixture(autouse=True)
@@ -193,7 +193,10 @@ async def test_recreate_prisma_client_recovers_from_disconnected_client(
     mock_new_prisma.connect.assert_awaited_once()
 
 
-def test_db_push_applies_replica_identity_full_when_requested(monkeypatch):
+DB_PUSH_ARGV = ["db", "push", "--accept-data-loss", "--skip-generate"]
+
+
+def test_db_push_applies_replica_identity_full_when_requested(monkeypatch, fake_prisma_cli, unset_database_url):
     """`prisma db push` bypasses litellm-proxy-extras, so it needs its own call
     into the opt-in REPLICA IDENTITY FULL step."""
     from litellm.proxy.db.prisma_client import PrismaManager
@@ -208,14 +211,13 @@ def test_db_push_applies_replica_identity_full_when_requested(monkeypatch):
         staticmethod(lambda: applied.append(True)),
     )
 
-    with patch("litellm.proxy.db.prisma_client.subprocess.run") as mock_run:
-        assert PrismaManager.setup_database(use_migrate=False) is True
+    assert PrismaManager.setup_database(use_migrate=False) is True
 
-    assert mock_run.call_args[0][0][:3] == ["prisma", "db", "push"]
+    assert fake_prisma_cli.calls == [DB_PUSH_ARGV]
     assert applied == [True]
 
 
-def test_db_push_is_rejected_when_spend_logs_is_partitioned(monkeypatch):
+def test_db_push_is_rejected_when_spend_logs_is_partitioned(monkeypatch, fake_prisma_cli, unset_database_url):
     """A doc-partitioned LiteLLM_SpendLogs makes `prisma db push` rewrite the
     primary key back to ("request_id"), which Postgres rejects; the guard must
     fail fast with guidance instead of running the push."""
@@ -228,29 +230,23 @@ def test_db_push_is_rejected_when_spend_logs_is_partitioned(monkeypatch):
     monkeypatch.setattr(
         ProxyExtrasDBManager, "spend_logs_is_partitioned", staticmethod(lambda: True)
     )
-    with patch(  # test-quality-ok: subprocess.run is the external prisma CLI boundary, asserted never reached
-        "litellm.proxy.db.prisma_client.subprocess.run"
-    ) as mock_run:
-        with pytest.raises(RuntimeError) as err:
-            PrismaManager.setup_database(use_migrate=False)
+    with pytest.raises(RuntimeError) as err:
+        PrismaManager.setup_database(use_migrate=False)
 
     assert str(err.value) == PARTITIONED_SPEND_LOGS_PUSH_ERROR
-    mock_run.assert_not_called()
+    assert fake_prisma_cli.calls == []
 
 
-def test_db_push_proceeds_when_spend_logs_is_not_partitioned(monkeypatch):
+def test_db_push_proceeds_when_spend_logs_is_not_partitioned(monkeypatch, fake_prisma_cli, unset_database_url):
     from litellm.proxy.db.prisma_client import PrismaManager
     from litellm_proxy_extras.utils import ProxyExtrasDBManager
 
     monkeypatch.setattr(
         ProxyExtrasDBManager, "spend_logs_is_partitioned", staticmethod(lambda: False)
     )
-    with patch(  # test-quality-ok: subprocess.run is the external prisma CLI boundary, not SDK logic
-        "litellm.proxy.db.prisma_client.subprocess.run"
-    ) as mock_run:
-        assert PrismaManager.setup_database(use_migrate=False) is True
+    assert PrismaManager.setup_database(use_migrate=False) is True
 
-    assert mock_run.call_args[0][0][:3] == ["prisma", "db", "push"]
+    assert fake_prisma_cli.calls == [DB_PUSH_ARGV]
 
 
 def _entra_jwt(expires_in_seconds: int) -> str:
@@ -377,3 +373,17 @@ def test_minting_without_the_database_env_vars_names_them(azure_env, monkeypatch
 
     with pytest.raises(RuntimeError, match="DATABASE_HOST"):
         wrapper.get_rds_iam_token()
+
+
+@pytest.mark.timeout(45)
+def test_db_push_timeout_takes_its_process_tree_with_it(fake_prisma_cli, unset_database_url, monkeypatch):
+    """
+    A timed-out `db push` used to leave Node and the schema engine writing the schema,
+    so the next attempt pushed into a database the abandoned one was still mutating.
+    """
+    monkeypatch.delenv("LITELLM_SET_REPLICA_IDENTITY_FULL", raising=False)
+    monkeypatch.setenv("FAKE_PRISMA_HANG_FIRST", "1")
+
+    assert PrismaManager.setup_database(use_migrate=False) is True
+    assert fake_prisma_cli.calls == [DB_PUSH_ARGV, DB_PUSH_ARGV]
+    assert fake_prisma_cli.grandchild_is_gone(within_seconds=5)


### PR DESCRIPTION
## TLDR

Problem this solves:

- Boot's `prisma db push` timeout killed only the wrapper process
- Node and the schema engine survived, still writing the schema
- Four retries stacked four live engines on one database
- Boot's `prisma migrate diff` had no timeout at all
- A busy database hung boot forever with zero log output

How it solves it:

- Both call sites now go through `run_prisma`
- It starts prisma in its own process group
- A timeout SIGKILLs the whole group, engine included
- `migrate diff` gets the same budget, overridable per deployment

Based on `litellm_prisma_timeout_killpg` (#39466), which adds `run_prisma`, rather than duplicating
the helper. Retarget to `litellm_internal_staging` once that merges.

That base predates #39478, so `ci/circleci: build_docker_database_image` fails here on the dashboard
type check for `tests/mocks/autoRouterPresets.ts`. Nothing in this PR touches the UI, and staging
already carries the fix.

## User Flow

Before: an operator restarting the proxy while their database is busy gets a proxy that never
becomes ready and leaves prisma processes running on the host after they stop it.

1. They start the proxy with `--use_prisma_db_push` against a Postgres where a long-running
   migration or analytics transaction holds a lock the schema update needs
2. The proxy log prints `Attempt 1 timed out` through `Attempt 4 timed out`, then
   `LiteLLM Proxy: Database migration failed but continuing startup.`
3. They stop the proxy the way a Kubernetes pod delete does, with SIGTERM
4. `ps -eo pid,ppid,command | grep schema-engine` still lists a `schema-engine-*` process owned by
   pid 1, still connected to their database and still writing the schema
5. They try the other boot path instead, `DISABLE_SCHEMA_UPDATE=true`, and the proxy prints nothing
   at all: the log file stays 0 bytes and
   `curl http://127.0.0.1:<port>/health/liveliness` fails with exit 7 for as long as they wait
6. They SIGTERM that proxy too, and `ps` shows the whole `prisma migrate diff` chain surviving with
   ppid 1

After: the same restart gives up on schedule, comes up healthy on the second path, and leaves
nothing running behind it.

1. They start the proxy with `--use_prisma_db_push` against the same busy Postgres
2. The proxy log prints `Attempt 1 timed out after 60s` through `Attempt 4 timed out after 60s`,
   then `LiteLLM Proxy: Database migration failed but continuing startup.`
3. They stop the proxy with SIGTERM
4. `ps -eo pid,ppid,command | grep schema-engine` lists nothing
5. They try `DISABLE_SCHEMA_UPDATE=true`, and after 60 seconds the proxy prints
   `Timed out after 60.0s generating the migration diff. Raise LITELLM_PRISMA_COMMAND_TIMEOUT if
   this database needs longer.` and finishes booting, so
   `curl http://127.0.0.1:<port>/health/liveliness` returns 200
6. They SIGTERM that proxy, and `ps` shows no surviving prisma processes

## Relevant issues

## Linear ticket

Resolves LIT-6801

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup, identical on both sides: a real Postgres, a real Anthropic key, and a table lock that
keeps the schema update from finishing inside its budget, which is what a live migration or a long
analytics transaction does on a real deployment. Both sides boot with `--num_workers 2`.

```bash
docker run -d --name lit6801-pg -p 5459:5432 \
  -e POSTGRES_USER=lit6801 -e POSTGRES_PASSWORD=lit6801 -e POSTGRES_DB=lit6801 postgres:16
export DATABASE_URL='postgresql://lit6801:lit6801@127.0.0.1:5459/lit6801'

cat config.yaml
model_list:
  - model_name: anthropic-haiku-4-5
    litellm_params:
      model: anthropic/claude-haiku-4-5
      api_key: os.environ/ANTHROPIC_API_KEY
general_settings:
  master_key: sk-lit6801

docker exec lit6801-pg psql -U lit6801 -d lit6801 \
  -c 'ALTER TABLE "LiteLLM_SpendLogs" DROP COLUMN "session_id";'
docker exec lit6801-pg psql -U lit6801 -d lit6801 \
  -c 'BEGIN; LOCK TABLE "LiteLLM_SpendLogs" IN ACCESS EXCLUSIVE MODE; SELECT pg_sleep(5400); COMMIT;' &
```

### Before (9f4fe3144a)

#### prisma db push

1. Boot the proxy on the legacy push path.

```
$ python litellm/proxy/proxy_cli.py --config config.yaml --port 18831 --num_workers 2 --use_prisma_db_push
```

2. All four attempts burn their budget and boot moves on.

```
21:56:36 - LiteLLM Proxy:WARNING: prisma_client.py:956 - Attempt 1 timed out
21:57:49 - LiteLLM Proxy:WARNING: prisma_client.py:956 - Attempt 2 timed out
21:59:01 - LiteLLM Proxy:WARNING: prisma_client.py:956 - Attempt 3 timed out
22:00:12 - LiteLLM Proxy:WARNING: prisma_client.py:956 - Attempt 4 timed out
LiteLLM Proxy: Database migration failed but continuing startup.
```

3. Stop the proxy the way a pod delete does, then look for prisma on the host.

```
$ kill -TERM 48225
$ ps -eo pid,ppid,command | grep schema-engine
63122     1 .../bin/node .../prisma/build/index.js db push --accept-data-loss --skip-generate
63297 63122 .../prisma/5.4.2/.../schema-engine-darwin-arm64
```

The engine is still running under pid 1, still connected to the database and still writing the
schema.

#### prisma migrate diff

1. Boot the proxy on the other path, with the schema update disabled.

```
$ DISABLE_SCHEMA_UPDATE=true python litellm/proxy/proxy_cli.py --config config.yaml --port 18847 --num_workers 2
```

2. Nothing happens: the proxy never becomes ready and prints nothing at all.

```
$ curl -s -m 5 -o /dev/null -w '%{http_code}\n' http://127.0.0.1:18847/health/liveliness
000
curl exit=7
$ wc -c lit6801-diff-before.log
       0
```

3. Stop it after 12 minutes of hanging and look for prisma on the host.

```
$ kill -TERM 21350
$ ps -eo pid,ppid,command | grep -E 'schema-engine|migrate diff'
22110     1 .../.venv/bin/prisma migrate diff --from-url postgresql://... --to-schema-datamodel ./schema.prisma --script
22427 22110 .../prisma/build/index.js migrate diff --from-url postgresql://... --script
22428 22427 .../@prisma/engines/schema-engine-darwin-arm64
```

4. The four new tests, run against the merge base `9f4fe3144a` with only the test files copied over,
   fail there for the reasons this PR fixes.

```
$ PYTHONPATH=$PWD .venv/bin/python -m pytest -p no:randomly -q --tb=line \
    tests/test_litellm/proxy/db/test_check_migration.py::test_migrate_diff_stops_at_its_budget_and_takes_its_process_tree_with_it \
    tests/test_litellm/proxy/db/test_check_migration.py::test_migrate_diff_without_the_prisma_runner_skips_instead_of_crashing_boot \
    tests/test_litellm/proxy/db/test_prisma_client.py::test_db_push_timeout_takes_its_process_tree_with_it \
    tests/test_litellm/proxy/db/test_prisma_client.py::test_db_push_without_the_prisma_runner_fails_the_migration_instead_of_crashing_boot
E   Failed: Timeout (>30.0s) from pytest-timeout.        selectors.py:415    (migrate diff never returns)
E   Failed: Timeout (>45.0s) from pytest-timeout.        subprocess.py:2047  (db push waits out its budget, tree still alive)
E   FileNotFoundError: [Errno 2] No such file or directory: 'prisma'         (the helper raises into boot)
E   assert True is False                                 test_prisma_client.py:401
4 failed, 1 warning in 75.36s (0:01:15)
```

### After (f8e34d90cd)

#### prisma db push

1. Boot the proxy on the legacy push path, same lock still held.

```
$ python litellm/proxy/proxy_cli.py --config config.yaml --port 19851 --num_workers 2 --use_prisma_db_push
```

2. All four attempts give up on schedule, and the log now names the budget they spent.

```
00:55:19 - LiteLLM Proxy:WARNING: prisma_client.py:966 - Attempt 1 timed out after 60s
00:56:25 - LiteLLM Proxy:WARNING: prisma_client.py:966 - Attempt 2 timed out after 60s
00:57:32 - LiteLLM Proxy:WARNING: prisma_client.py:966 - Attempt 3 timed out after 60s
00:58:39 - LiteLLM Proxy:WARNING: prisma_client.py:966 - Attempt 4 timed out after 60s
LiteLLM Proxy: Database migration failed but continuing startup. Set --enforce_prisma_migration_check or ENFORCE_PRISMA_MIGRATION_CHECK=true to exit on failure.
```

3. The proxy comes up and serves a real Anthropic call.

```
$ curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:19851/health/liveliness
200
$ curl -s http://127.0.0.1:19851/v1/chat/completions -H 'Authorization: Bearer sk-lit6801' \
    -H 'Content-Type: application/json' \
    -d '{"model":"anthropic-haiku-4-5","messages":[{"role":"user","content":"Reply with exactly: lit6801 push after ok"}]}'
anthropic-haiku-4-5 | lit6801 push after ok | {'prompt_tokens': 18, 'completion_tokens': 10, 'total_tokens': 28}
```

4. Stop it the same way, and nothing prisma is left on the host.

```
$ kill -TERM 38507
$ ps -eo pid,ppid,command | grep -E 'schema-engine|db push'
$ lsof -nP -iTCP:19851 -sTCP:LISTEN
```

Both come back empty.

#### prisma migrate diff

1. Boot the proxy on the other path, with the schema update disabled.

```
$ DISABLE_SCHEMA_UPDATE=true python litellm/proxy/proxy_cli.py --config config.yaml --port 19857 --num_workers 2
```

2. After 60 seconds it says why it stopped waiting and finishes booting.

```
INFO:     Uvicorn running on http://0.0.0.0:19857 (Press CTRL+C to quit)
Timed out after 60.0s generating the migration diff. Raise LITELLM_PRISMA_COMMAND_TIMEOUT if this database needs longer.
INFO:     Application startup complete.
```

3. The proxy is ready and serves a real Anthropic call.

```
$ curl -s -o /dev/null -w 'liveliness=%{http_code}\n' http://127.0.0.1:19857/health/liveliness
liveliness=200
$ curl -s http://127.0.0.1:19857/v1/chat/completions -H 'Authorization: Bearer sk-lit6801' \
    -H 'Content-Type: application/json' \
    -d '{"model":"anthropic-haiku-4-5","messages":[{"role":"user","content":"Reply with exactly: lit6801 diff after ok"}]}'
anthropic-haiku-4-5 | lit6801 diff after ok | {'prompt_tokens': 18, 'completion_tokens': 10, 'total_tokens': 28}
```

4. Stop it the same way, and nothing prisma is left on the host.

```
$ kill -TERM 79092
$ ps -eo pid,ppid,command | grep -E 'schema-engine|migrate diff'
$ lsof -nP -iTCP:19857 -sTCP:LISTEN
```

Both come back empty.

#### An older proxy-extras install alongside this code

The two packages ship together, so this pairing only happens on a raw `pip install '.[proxy]'` of
the git tree between releases. Same clean database, same `--use_prisma_db_push` boot, with the
published `litellm-proxy-extras==0.4.92` ahead of the worktree on `PYTHONPATH`.

At the merge base the push runs and the schema lands:

```
🚀  Your database is now in sync with your Prisma schema. Done in 1.23s
$ curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:19877/health/liveliness
200
```

At this tip the import fails, boot says so and carries on, exactly as the default `migrate` path
already does when it cannot import the extras:

```
prisma_client.py:946 - LiteLLM: Failed to import proxy extras. Got cannot import name 'run_prisma' from 'litellm_proxy_extras.prisma_toolchain'
LiteLLM Proxy: Database migration failed but continuing startup. Set --enforce_prisma_migration_check or ENFORCE_PRISMA_MIGRATION_CHECK=true to exit on failure.
$ curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:19863/health/liveliness
200
```

`--enforce_prisma_migration_check` (or `ENFORCE_PRISMA_MIGRATION_CHECK=true`) still turns that into
an exit, which is the operator's existing lever for a migration that did not run.

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- A diff slower than 60s now reports no drift instead of hanging
  - The printed message names `LITELLM_PRISMA_COMMAND_TIMEOUT` for a longer budget
  - Boot proceeds either way; the old behavior was an unbounded hang
- `prisma generate` and the CLI runnability probe stay unbounded
  - Neither opens a database connection, so neither can hang on one
- Pairing this proxy code with an extras build that predates `run_prisma` skips the command, not boot
  - `migrate diff` loses the drift diagnostic; `db push` logs the failure and leaves the schema alone
  - `enforce_prisma_migration_check` still decides whether that skipped push stops startup
  - Only a raw `pip install` of the git tree can pair them; releases publish both together
- On Windows the runner still kills just the wrapper, not its descendants
  - Same as today: `subprocess.run` never reached them either, so nothing regresses

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] f8e34d90cd passes /live-pr-risk
