### PR TITLE
fix(images): stop forwarding the raw image[] and mask[] form keys

### DIFF
--- a/litellm/proxy/image_endpoints/endpoints.py
+++ b/litellm/proxy/image_endpoints/endpoints.py
@@ -21,6 +21,10 @@ from litellm.types.llms.openai import ChatCompletionUserMessage
 
 router: Final = APIRouter()
 
+IMAGE_ARRAY_FIELD: Final = "image[]"
+MASK_ARRAY_FIELD: Final = "mask[]"
+BRACKETED_FILE_FIELDS: Final = frozenset({IMAGE_ARRAY_FIELD, MASK_ARRAY_FIELD})
+
 
 async def uploadfile_to_bytesio(upload: UploadFile) -> io.BytesIO:
     """
@@ -229,9 +233,9 @@ async def image_edit_api(
     fastapi_response: Response,
     user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
     image: list[UploadFile] | None = File(None),
-    image_array: list[UploadFile] | None = File(None, alias="image[]"),
+    image_array: list[UploadFile] | None = File(None, alias=IMAGE_ARRAY_FIELD),
     mask: list[UploadFile] | None = File(None),
-    mask_array: list[UploadFile] | None = File(None, alias="mask[]"),
+    mask_array: list[UploadFile] | None = File(None, alias=MASK_ARRAY_FIELD),
     model: str | None = None,
 ):
     """
@@ -279,7 +283,11 @@ async def image_edit_api(
     #########################################################
     # Read request body and convert UploadFiles to BytesIO
     #########################################################
-    data: Final = await _read_request_body(request=request)
+    data: Final = {
+        key: value
+        for key, value in (await _read_request_body(request=request)).items()
+        if key not in BRACKETED_FILE_FIELDS
+    }
     image_files: Final = await batch_to_bytesio(image)
     mask_files: Final = await batch_to_bytesio(mask)
     if image_files:

--- a/tests/test_litellm/proxy/image_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/image_endpoints/test_endpoints.py
@@ -5,10 +5,13 @@ from typing import Any, Dict
 
 import orjson
 import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 from starlette.requests import Request
 from starlette.responses import Response
 
 from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.proxy.image_endpoints import endpoints
 
 
@@ -115,3 +118,75 @@ async def test_image_generation_prompt_rerouting(monkeypatch):
     assert captured_route_request_data["prompt"] == "sanitized prompt"
     assert "messages" not in captured_route_request_data
     assert response.headers.get("x-callback-test") == "value"
+
+
+def _image_edit_client(monkeypatch, captured: Dict[str, Any]) -> TestClient:
+    class CaptureProcessing:
+        def __init__(self, data: Dict[str, Any]) -> None:
+            captured.update(data)
+
+        async def base_process_llm_request(self, **_: Any) -> Dict[str, Any]:
+            return {"data": [{"b64_json": "aGk="}]}
+
+    monkeypatch.setattr(endpoints, "ProxyBaseLLMRequestProcessing", CaptureProcessing)
+    monkeypatch.setattr("litellm.proxy.proxy_server.general_settings", {})
+    monkeypatch.setattr("litellm.proxy.proxy_server.user_model", None)
+
+    app = FastAPI()
+    app.include_router(endpoints.router)
+    app.dependency_overrides[user_api_key_auth] = lambda: UserAPIKeyAuth()
+    return TestClient(app)
+
+
+def test_image_edit_image_array_alias_is_not_forwarded(monkeypatch):
+    """The documented `image[]` alias must reach the provider only as `image`."""
+    captured: Dict[str, Any] = {}
+
+    response = _image_edit_client(monkeypatch, captured).post(
+        "/v1/images/edits",
+        files={"image[]": ("tree.png", b"\x89PNG\r\n\x1a\ntree", "image/png")},
+        data={"model": "gpt-image-1", "prompt": "add a hat"},
+    )
+
+    assert response.status_code == 200
+    assert "image[]" not in captured
+    assert [buffer.getvalue() for buffer in captured["image"]] == [b"\x89PNG\r\n\x1a\ntree"]
+    assert [buffer.name for buffer in captured["image"]] == ["tree.png"]
+
+
+def test_image_edit_mask_array_alias_is_not_forwarded(monkeypatch):
+    """`mask[]` has the same shape as `image[]` and must be dropped the same way."""
+    captured: Dict[str, Any] = {}
+
+    response = _image_edit_client(monkeypatch, captured).post(
+        "/v1/images/edits",
+        files={
+            "image": ("tree.png", b"\x89PNG\r\n\x1a\ntree", "image/png"),
+            "mask[]": ("mask.png", b"\x89PNG\r\n\x1a\nmask", "image/png"),
+        },
+        data={"model": "gpt-image-1", "prompt": "add a hat"},
+    )
+
+    assert response.status_code == 200
+    assert "mask[]" not in captured
+    assert [buffer.getvalue() for buffer in captured["mask"]] == [b"\x89PNG\r\n\x1a\nmask"]
+    assert [buffer.getvalue() for buffer in captured["image"]] == [b"\x89PNG\r\n\x1a\ntree"]
+
+
+def test_image_edit_canonical_file_fields_still_reach_the_provider(monkeypatch):
+    """Dropping the bracketed aliases must not touch the canonical fields."""
+    captured: Dict[str, Any] = {}
+
+    response = _image_edit_client(monkeypatch, captured).post(
+        "/v1/images/edits",
+        files={
+            "image": ("tree.png", b"\x89PNG\r\n\x1a\ntree", "image/png"),
+            "mask": ("mask.png", b"\x89PNG\r\n\x1a\nmask", "image/png"),
+        },
+        data={"model": "gpt-image-1", "prompt": "add a hat"},
+    )
+
+    assert response.status_code == 200
+    assert [buffer.getvalue() for buffer in captured["image"]] == [b"\x89PNG\r\n\x1a\ntree"]
+    assert [buffer.getvalue() for buffer in captured["mask"]] == [b"\x89PNG\r\n\x1a\nmask"]
+    assert captured["prompt"] == "add a hat"


### PR DESCRIPTION
## TLDR

Problem this solves:

- `/v1/images/edits` forwarded the raw `image[]` key to providers
- OpenAI 400s the documented alias: "Invalid type for 'image[0]'"
- `mask[]` 400s the same way: "This parameter already has a different value"

How it solves it:

- Drop `image[]` and `mask[]` from what gets forwarded
- The handler already folded them into `image` and `mask`
- Provider-agnostic: no OpenAI special-casing

## User Flow

Before: a developer following LiteLLM's own documented `image[]` form gets a 400 and no edited image

1. They send `POST https://litellm-domain/v1/images/edits` with `model=gpt-image-1`, `image[]=@tree.png`, and `prompt=add a small red hat on top`, exactly the form the endpoint's own docs show
2. They get back HTTP 400: `Invalid type for 'image[0]': expected a file, but got a string instead.`
3. They drop the brackets and send the same request with `image=@tree.png`, which returns HTTP 200 with an edited image
4. They add a mask the documented way, sending `image=@tree.png` plus `mask[]=@mask.png`, and get back HTTP 400: `Invalid parameter: 'mask'. This parameter already has a different value in your parameters.`
5. They drop those brackets too and send `mask=@mask.png`, which returns HTTP 200, so the documented bracketed form is unusable through the gateway on either field

After: the same documented `image[]` and `mask[]` requests come back with an edited image

1. They send `POST https://litellm-domain/v1/images/edits` with `model=gpt-image-1`, `image[]=@tree.png`, and `prompt=add a small red hat on top`, exactly the form the endpoint's own docs show
2. They get back HTTP 200 with a `b64_json` image and a `usage` block
3. They send the same request with `image=@tree.png`, which returns HTTP 200 with an edited image
4. They add a mask the documented way, sending `image=@tree.png` plus `mask[]=@mask.png`, and get back HTTP 200 with an edited image
5. They send `mask=@mask.png` instead and get HTTP 200 as well, so both spellings work on both fields
6. Sending `image` and `image[]` together still returns HTTP 422 `Cannot specify both 'image' and 'image[]'`, so the existing guard against ambiguous requests is unchanged

## Relevant issues

Fixes #41421

## Affected release

regression in v1.100.0 (PR #38104), still present in v1.101.0 and v1.102.0-rc.2

## Linear ticket

Resolves LIT-6816

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both legs run the same proxy config against the real OpenAI API with `gpt-image-2.5-sunburst`, the model the reporting customer hit this on, two uvicorn workers (`--num_workers 2`) on each proxy, and the same 256x256 `tree.png` / `tree2.png` / `tree3.png` / `mask.png` set. The customer's own call shape is the OpenAI Python SDK's `client.images.edit(image=[...])`, which the SDK sends as repeated `image[]` parts, so the SDK cases come first and the curl cases cover the documented bracketed forms directly. Real spend on every 200. Before is the merge base `bc9f4fec5b` (current main), After is this PR's tip `255190ca35`, same nine cases in the same order on both

`config.yaml`:

```yaml
model_list:
  - model_name: gpt-image-2.5-sunburst
    litellm_params:
      model: openai/gpt-image-2.5-sunburst
      api_key: os.environ/OPENAI_API_KEY
  - model_name: gpt-image-1
    litellm_params:
      model: openai/gpt-image-1
      api_key: os.environ/OPENAI_API_KEY

general_settings:
  master_key: sk-lit6816
```

`sdk_edit.py`:

```python
import sys, json
from openai import OpenAI, APIStatusError
base_url, model, mode = sys.argv[1], sys.argv[2], sys.argv[3]
client = OpenAI(base_url=base_url, api_key="sk-lit6816")
files = {"single": open("tree.png", "rb"), "list1": [open("tree.png", "rb")], "list3": [open("tree.png", "rb"), open("tree2.png", "rb"), open("tree3.png", "rb")]}[mode]
try:
    r = client.images.edit(model=model, image=files, prompt="add a small red hat on top of the tree", size="1024x1024", quality="low")
    print(json.dumps({"created": r.created, "usage_total_tokens": r.usage.total_tokens if r.usage else None, "b64_json_length": len(r.data[0].b64_json or "")}))
except APIStatusError as e:
    print(f"HTTP {e.status_code}", json.dumps(e.body)[:400])
```

Each case is the command followed by its output. A 200 is summarized to `created`, `usage.total_tokens`, the `b64_json` length, and the number of images returned; an error shows the proxy's response body

### Before (bc9f4fec5b)

#### SDK: three images in a list (the customer flow)

```
$ python sdk_edit.py http://127.0.0.1:34271 gpt-image-2.5-sunburst list3   # OpenAI SDK: client.images.edit(model=..., image=<list3>, prompt=..., size="1024x1024", quality="low")
HTTP 400 {"message": "litellm.BadRequestError: OpenAIException - {\n  \"error\": {\n    \"message\": \"Invalid type for 'image[0]': expected a file, but got a string instead.\",\n    \"type\": \"invalid_request_error\",\n    \"param\": \"image[0]\",\n    \"code\": \"invalid_type\"\n  }\n}. Received Model Group=gpt-image-2.5-sunburst\nAvailable Model Group Fallbacks=None", "type": "invalid_request_error", "
```

#### SDK: a list of one image

```
$ python sdk_edit.py http://127.0.0.1:34271 gpt-image-2.5-sunburst list1   # OpenAI SDK: client.images.edit(model=..., image=<list1>, prompt=..., size="1024x1024", quality="low")
HTTP 400 {"message": "litellm.BadRequestError: OpenAIException - {\n  \"error\": {\n    \"message\": \"Invalid type for 'image[0]': expected a file, but got a string instead.\",\n    \"type\": \"invalid_request_error\",\n    \"param\": \"image[0]\",\n    \"code\": \"invalid_type\"\n  }\n}. Received Model Group=gpt-image-2.5-sunburst\nAvailable Model Group Fallbacks=None", "type": "invalid_request_error", "
```

#### SDK: a single image, not a list

```
$ python sdk_edit.py http://127.0.0.1:34271 gpt-image-2.5-sunburst single   # OpenAI SDK: client.images.edit(model=..., image=<single>, prompt=..., size="1024x1024", quality="low")
{"created": 1789682988, "usage_total_tokens": 478, "b64_json_length": 1143356}
```

#### curl: two image[] parts

```
$ curl -s http://127.0.0.1:34271/v1/images/edits -H "Authorization: Bearer sk-lit6816" -F "model=gpt-image-2.5-sunburst" -F "prompt=add a small red hat on top of the tree" -F "image[]=@tree.png" -F "image[]=@tree2.png" -F "size=1024x1024" -F "quality=low"
HTTP 400 {"error": {"message": "litellm.BadRequestError: OpenAIException - {\n  \"error\": {\n    \"message\": \"Invalid type for 'image[0]': expected a file, but got a string instead.\",\n    \"type\": \"invalid_request_error\",\n    \"param\": \"image[0]\",\n    \"code\": \"invalid_type\"\n  }\n}. Received Model Group=gpt-image-2.5-sunburst\nAvailable Model Group Fallbacks=None", "type": "invalid_request
```

#### curl: one image[] part

```
$ curl -s http://127.0.0.1:34271/v1/images/edits -H "Authorization: Bearer sk-lit6816" -F "model=gpt-image-2.5-sunburst" -F "prompt=add a small red hat on top of the tree" -F "image[]=@tree.png" -F "size=1024x1024" -F "quality=low"
HTTP 400 {"error": {"message": "litellm.BadRequestError: OpenAIException - {\n  \"error\": {\n    \"message\": \"Invalid type for 'image[0]': expected a file, but got a string instead.\",\n    \"type\": \"invalid_request_error\",\n    \"param\": \"image[0]\",\n    \"code\": \"invalid_type\"\n  }\n}. Received Model Group=gpt-image-2.5-sunburst\nAvailable Model Group Fallbacks=None", "type": "invalid_request
```

#### curl: canonical image part

```
$ curl -s http://127.0.0.1:34271/v1/images/edits -H "Authorization: Bearer sk-lit6816" -F "model=gpt-image-2.5-sunburst" -F "prompt=add a small red hat on top of the tree" -F "image=@tree.png" -F "size=1024x1024" -F "quality=low"
HTTP 200 {"created": 1789683015, "usage_total_tokens": 478, "b64_json_length": 1139820, "images": 1}
```

#### curl: image plus mask[]

```
$ curl -s http://127.0.0.1:34271/v1/images/edits -H "Authorization: Bearer sk-lit6816" -F "model=gpt-image-2.5-sunburst" -F "prompt=add a small red hat on top of the tree" -F "image=@tree.png" -F "mask[]=@mask.png" -F "size=1024x1024" -F "quality=low"
HTTP 400 {"error": {"message": "litellm.BadRequestError: OpenAIException - {\n  \"error\": {\n    \"message\": \"Invalid parameter: 'mask'. This parameter already has a different value in your parameters. Please check your parameters.\",\n    \"type\": \"invalid_request_error\",\n    \"param\": \"mask\",\n    \"code\": \"invalid_parameter\"\n  }\n}. Received Model Group=gpt-image-2.5-sunburst\nAvailable Mo
```

#### curl: image plus canonical mask

```
$ curl -s http://127.0.0.1:34271/v1/images/edits -H "Authorization: Bearer sk-lit6816" -F "model=gpt-image-2.5-sunburst" -F "prompt=add a small red hat on top of the tree" -F "image=@tree.png" -F "mask=@mask.png" -F "size=1024x1024" -F "quality=low"
HTTP 200 {"created": 1789683035, "usage_total_tokens": 478, "b64_json_length": 1111556, "images": 1}
```

#### curl: image and image[] in one request (rejected on both sides)

```
$ curl -s http://127.0.0.1:34271/v1/images/edits -H "Authorization: Bearer sk-lit6816" -F "model=gpt-image-2.5-sunburst" -F "prompt=add a small red hat on top of the tree" -F "image=@tree.png" -F "image[]=@tree2.png" -F "size=1024x1024" -F "quality=low"
HTTP 422 {"detail": "Cannot specify both 'image' and 'image[]'"}
```

### After (255190ca35)

#### SDK: three images in a list (the customer flow)

```
$ python sdk_edit.py http://127.0.0.1:51671 gpt-image-2.5-sunburst list3   # OpenAI SDK: client.images.edit(model=..., image=<list3>, prompt=..., size="1024x1024", quality="low")
{"created": 1789683089, "usage_total_tokens": 1010, "b64_json_length": 1143568}
```

#### SDK: a list of one image

```
$ python sdk_edit.py http://127.0.0.1:51671 gpt-image-2.5-sunburst list1   # OpenAI SDK: client.images.edit(model=..., image=<list1>, prompt=..., size="1024x1024", quality="low")
{"created": 1789683105, "usage_total_tokens": 478, "b64_json_length": 1139396}
```

#### SDK: a single image, not a list

```
$ python sdk_edit.py http://127.0.0.1:51671 gpt-image-2.5-sunburst single   # OpenAI SDK: client.images.edit(model=..., image=<single>, prompt=..., size="1024x1024", quality="low")
{"created": 1789683122, "usage_total_tokens": 478, "b64_json_length": 1142032}
```

#### curl: two image[] parts

```
$ curl -s http://127.0.0.1:51671/v1/images/edits -H "Authorization: Bearer sk-lit6816" -F "model=gpt-image-2.5-sunburst" -F "prompt=add a small red hat on top of the tree" -F "image[]=@tree.png" -F "image[]=@tree2.png" -F "size=1024x1024" -F "quality=low"
HTTP 200 {"created": 1789683133, "usage_total_tokens": 744, "b64_json_length": 1147548, "images": 1}
```

#### curl: one image[] part

```
$ curl -s http://127.0.0.1:51671/v1/images/edits -H "Authorization: Bearer sk-lit6816" -F "model=gpt-image-2.5-sunburst" -F "prompt=add a small red hat on top of the tree" -F "image[]=@tree.png" -F "size=1024x1024" -F "quality=low"
HTTP 200 {"created": 1789683144, "usage_total_tokens": 478, "b64_json_length": 1139776, "images": 1}
```

#### curl: canonical image part

```
$ curl -s http://127.0.0.1:51671/v1/images/edits -H "Authorization: Bearer sk-lit6816" -F "model=gpt-image-2.5-sunburst" -F "prompt=add a small red hat on top of the tree" -F "image=@tree.png" -F "size=1024x1024" -F "quality=low"
HTTP 200 {"created": 1789683155, "usage_total_tokens": 478, "b64_json_length": 1144872, "images": 1}
```

#### curl: image plus mask[]

```
$ curl -s http://127.0.0.1:51671/v1/images/edits -H "Authorization: Bearer sk-lit6816" -F "model=gpt-image-2.5-sunburst" -F "prompt=add a small red hat on top of the tree" -F "image=@tree.png" -F "mask[]=@mask.png" -F "size=1024x1024" -F "quality=low"
HTTP 200 {"created": 1789683167, "usage_total_tokens": 478, "b64_json_length": 1105448, "images": 1}
```

#### curl: image plus canonical mask

```
$ curl -s http://127.0.0.1:51671/v1/images/edits -H "Authorization: Bearer sk-lit6816" -F "model=gpt-image-2.5-sunburst" -F "prompt=add a small red hat on top of the tree" -F "image=@tree.png" -F "mask=@mask.png" -F "size=1024x1024" -F "quality=low"
HTTP 200 {"created": 1789683176, "usage_total_tokens": 478, "b64_json_length": 1110120, "images": 1}
```

#### curl: image and image[] in one request (rejected on both sides)

```
$ curl -s http://127.0.0.1:51671/v1/images/edits -H "Authorization: Bearer sk-lit6816" -F "model=gpt-image-2.5-sunburst" -F "prompt=add a small red hat on top of the tree" -F "image=@tree.png" -F "image[]=@tree2.png" -F "size=1024x1024" -F "quality=low"
HTTP 422 {"detail": "Cannot specify both 'image' and 'image[]'"}
```

Observations from the run:

- `mask[]` 400s too on Before, different OpenAI error; fixed here
- Single-image SDK calls never hit the bug; unchanged
- `image` plus `image[]` still 422s on both sides; unchanged
- Two `image[]` parts yield one edited image, 744 tokens; provider behavior
- Gemini answers the same on both sides; masks unsupported there

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Three non-required CircleCI jobs are red at this tip
  - [`llm_translation_testing`](https://app.circleci.com/pipelines/github/BerriAI/litellm/89745/workflows/1d2f8ddf-e00c-4861-9048-ca9c1b197c97/jobs/2184422), [`litellm_utils_testing`](https://app.circleci.com/pipelines/github/BerriAI/litellm/89745/workflows/1d2f8ddf-e00c-4861-9048-ca9c1b197c97/jobs/2184463), [`ocr_testing`](https://app.circleci.com/pipelines/github/BerriAI/litellm/89745/workflows/1d2f8ddf-e00c-4861-9048-ca9c1b197c97/jobs/2184464)
  - The same tests fail on unrelated PRs, #41419 included
  - Causes sit on main; this diff touches none of them
- Only OpenAI and Gemini were driven live
  - No provider transformation reads the dropped `image[]` / `mask[]` keys
- Indexed `image[0]` parts still 500 on both sides
  - Undocumented spelling, left alone here

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped bug fix to proxy image-edit request shaping with new regression tests; no auth or billing changes.
> 
> **Overview**
> Fixes a regression where **`/v1/images/edits`** still forwarded raw multipart keys **`image[]`** and **`mask[]`** to upstream providers after the handler had already normalized those uploads into **`image`** / **`mask`**, which caused OpenAI (and SDK clients using bracketed parts) to return 400s.
> 
> The image edit handler now defines shared constants for those aliases and **strips `image[]` and `mask[]` from the coerced form `data`** before routing, while continuing to populate **`image`** and **`mask`** from the file parameters. Tests assert bracketed aliases are omitted from the forwarded payload, canonical **`image`**/**`mask`** uploads are unchanged, and existing multipart numeric coercion behavior is preserved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 255190ca355899d8ec032f8104cdd7d3016d024a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

- [x] 255190ca355899d8ec032f8104cdd7d3016d024a passes /live-pr-risk
