### PR TITLE
fix(proxy): treat empty/unparseable budget_duration as invalid instead of silently resetting daily

### DIFF
--- a/litellm/litellm_core_utils/duration_parser.py
+++ b/litellm/litellm_core_utils/duration_parser.py
@@ -12,8 +12,6 @@ from datetime import datetime, time, timedelta, timezone, tzinfo
 from typing import Final
 from zoneinfo import ZoneInfo
 
-from litellm._logging import verbose_logger
-
 _BUDGET_DURATION_WORD_ALIASES: Final[dict[str, str]] = {
     "hourly": "1h",
     "daily": "24h",
@@ -131,6 +129,9 @@ def get_next_standardized_reset_time(
 
     Returns:
     - Next reset time at a standardized interval in the specified timezone
+
+    Raises:
+    - ValueError: If the duration string is empty or cannot be parsed.
     """
     # Set up timezone and normalize current time
     current_time, _ = _setup_timezone(current_time, timezone_str)
@@ -138,12 +139,10 @@ def get_next_standardized_reset_time(
     # Parse duration
     value, unit = _parse_duration(_normalize_duration(duration))
     if value is None:
-        verbose_logger.warning(
-            "Unrecognized budget_duration %r; falling back to a next-midnight reset. "
-            "Use the <int><unit> format (e.g. '1h', '7d', '30d', '1mo').",
-            duration,
+        raise ValueError(
+            f"Invalid budget_duration {duration!r}. "
+            "Use the <int><unit> format (e.g. '1h', '7d', '30d', '1mo')."
         )
-        return current_time.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=1)
 
     # Midnight of the current day in the specified timezone
     base_midnight: Final = current_time.replace(hour=0, minute=0, second=0, microsecond=0)

--- a/litellm/proxy/common_utils/reset_budget_job.py
+++ b/litellm/proxy/common_utils/reset_budget_job.py
@@ -657,7 +657,7 @@ class ResetBudgetJob:
                     compute_budget_reset_at(budget_duration=b.budget_duration, settings=self.reset_settings),
                 )
                 for b in budgets_to_reset
-                if b.budget_id is not None and b.budget_duration is not None
+                if b.budget_id is not None and b.budget_duration
             ),
             endusers=await self._collect_endusers_to_reset(budget_ids),
             counter_resets=(
@@ -1266,6 +1266,12 @@ class ResetBudgetJob:
             except Exception as redis_err:
                 verbose_proxy_logger.warning("Failed to reset Redis counter %s: %s", counter_key, redis_err)
         budget_duration: Final = window["budget_duration"]
+        if not budget_duration:
+            verbose_proxy_logger.warning(
+                "Skipping window reset for entity %s: budget_duration is empty or missing",
+                entity_id,
+            )
+            return False
         next_reset_at: Final = compute_budget_reset_at(budget_duration=budget_duration, settings=reset_settings)
         window["reset_at"] = next_reset_at.isoformat()
         await ResetBudgetJob._roll_window_spend_row(
@@ -1444,7 +1450,7 @@ class ResetBudgetJob:
         """
         try:
             item.spend = _carried_spend(item.spend, _rollover_cap(item.max_budget)) if _rollover_enabled() else 0.0
-            if hasattr(item, "budget_duration") and item.budget_duration is not None:
+            if hasattr(item, "budget_duration") and item.budget_duration:
                 item.budget_reset_at = compute_budget_reset_at(
                     budget_duration=item.budget_duration, settings=reset_settings
                 )


### PR DESCRIPTION
## Summary

Closes #39368.

An empty string `""` passed as `budget_duration` (or any other value the parser cannot read) was silently treated as "reset every 24 hours at midnight UTC" in two separate codepaths:

1. **`get_next_standardized_reset_time`** in `duration_parser.py` — when `_parse_duration` returned `(None, None)`, the code logged a `WARNING` and returned `next-midnight` instead of raising.
2. **`ResetBudgetJob`** in `reset_budget_job.py` — the three call-sites that invoke `compute_budget_reset_at` guarded on `budget_duration is not None`, which passes empty strings through to the parser.

### Changes

**`litellm/litellm_core_utils/duration_parser.py`**
- Replace the warning + next-midnight fallback with a `ValueError` that names the bad value and points to the expected format.
- Remove the now-unused `verbose_logger` import.

**`litellm/proxy/common_utils/reset_budget_job.py`**
- `_BudgetCascade` construction (budget-limits path): change `b.budget_duration is not None` → truthy check so empty strings are excluded.
- `_reset_budget_common`: same truthy guard so a stale `budget_duration=""` row no longer triggers `compute_budget_reset_at`.
- `_reset_expired_window`: add an explicit early-return with a `WARNING` when `window["budget_duration"]` is falsy, preventing the window from being rescheduled with a bogus reset time.

### Why no breakage at creation endpoints

`validate_budget_duration` in `management_endpoints/common_utils.py` already calls `duration_in_seconds(budget_duration)` before calling `get_next_standardized_reset_time`. For `""`, `duration_in_seconds` raises `ValueError` via `_extract_from_regex`, which `validate_budget_duration` catches and converts to `HTTP 400`. The change to `get_next_standardized_reset_time` is therefore unreachable from a valid creation request — it only removes the silent fallback for the reset-job path.

## Test plan

- [ ] `tests/test_litellm/litellm_core_utils/test_duration_parser.py` — confirm `get_next_standardized_reset_time("", ...)` now raises `ValueError`.
- [ ] `tests/test_litellm/litellm_core_utils/test_duration_parser.py` — confirm valid durations (`"1h"`, `"7d"`, `"1mo"`) still return correct reset times.
- [ ] Manual: `POST /team/new` with `"budget_duration": ""` returns HTTP 400.
- [ ] Manual: proxy reset job runs without error on a DB that has no rows with `budget_duration=""`.