### PR TITLE
fix: preserve top-level cache token counts with partial usage details

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -1343,7 +1343,26 @@ def completion_cost(
                         and _usage["prompt_tokens_details"]
                     ):
                         prompt_tokens_details = _usage.get("prompt_tokens_details") or {}
-                        cache_read_input_tokens = prompt_tokens_details.get("cached_tokens", 0)
+                        # Only prefer details when they actually carry cached_tokens.
+                        # OpenAI-compatible providers often send both top-level
+                        # cache_read_input_tokens and a partial prompt_tokens_details
+                        # object (e.g. audio_tokens only). Using `.get(..., 0)` would
+                        # wipe the top-level cache count with a default of 0 (#39505).
+                        if (
+                            isinstance(prompt_tokens_details, dict)
+                            and "cached_tokens" in prompt_tokens_details
+                            and prompt_tokens_details["cached_tokens"] is not None
+                        ):
+                            cache_read_input_tokens = prompt_tokens_details["cached_tokens"]
+                        if (
+                            isinstance(prompt_tokens_details, dict)
+                            and not cache_creation_input_tokens
+                        ):
+                            cache_write_tokens = prompt_tokens_details.get(
+                                "cache_write_tokens"
+                            ) or prompt_tokens_details.get("cache_creation_tokens")
+                            if isinstance(cache_write_tokens, int):
+                                cache_creation_input_tokens = cache_write_tokens
 
                     total_time = getattr(completion_response, "_response_ms", 0)
 

--- a/tests/local_testing/test_completion_cost.py
+++ b/tests/local_testing/test_completion_cost.py
@@ -2928,3 +2928,48 @@ def test_batch_cost_calculator():
 
     cost = completion_cost(**args)
     assert cost > 0
+
+
+def test_openai_compatible_top_level_cache_tokens_survive_partial_details(monkeypatch):
+    """Regression for #39505.
+
+    OpenAI-compatible providers may return top-level cache_read_input_tokens
+    together with a partial prompt_tokens_details object that omits
+    cached_tokens. The details branch must not default-wipe the top-level
+    cache count to 0.
+    """
+    captured = {}
+
+    def _fake_cost_per_token(**kwargs):
+        captured.update(kwargs)
+        return 0.01, 0.02
+
+    monkeypatch.setattr(litellm.cost_calculator, "cost_per_token", _fake_cost_per_token)
+    monkeypatch.setattr(litellm, "cost_per_token", _fake_cost_per_token)
+
+    response = {
+        "id": "chatcmpl-test-cache",
+        "object": "chat.completion",
+        "created": 1,
+        "model": "gpt-4o",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "ok"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 100,
+            "completion_tokens": 10,
+            "total_tokens": 110,
+            "cache_read_input_tokens": 80,
+            "cache_creation_input_tokens": 5,
+            "prompt_tokens_details": {"audio_tokens": 0},
+        },
+    }
+
+    cost = completion_cost(model="gpt-4o", completion_response=response)
+    assert cost == 0.03
+    assert captured.get("cache_read_input_tokens") == 80
+    assert captured.get("cache_creation_input_tokens") == 5


### PR DESCRIPTION
## Summary
- Fixes #39505: OpenAI-compatible usage that includes top-level `cache_read_input_tokens` / `cache_creation_input_tokens` plus a partial `prompt_tokens_details` object (e.g. only `audio_tokens`) was losing the cache counts because `.get("cached_tokens", 0)` defaulted missing keys to `0`.
- Prefer `prompt_tokens_details.cached_tokens` only when that key is explicitly present; otherwise keep the top-level cache fields. Also pick up `cache_write_tokens` / `cache_creation_tokens` from details when top-level creation count is absent.

## Test plan
- [x] Standalone logic check: partial details wipe → 0 before; keep 80/5 after; explicit `cached_tokens: 40` still wins
- [x] Added `test_openai_compatible_top_level_cache_tokens_survive_partial_details` in `tests/local_testing/test_completion_cost.py`
- [ ] CI / full litellm suite

AI assistance was used to draft this fix; I reviewed and verified the change.


Made with [Cursor](https://cursor.com)