### PR TITLE
fix(proxy): stop putting the literal string "None" in error payloads

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -467,6 +467,42 @@ def _getattr_object(value: object, name: str, default: object = None) -> object:
     return getattr(value, name, default)
 
 
+_OPENAI_ERROR_TYPE_BY_STATUS: Final[Mapping[int, str]] = MappingProxyType(
+    {
+        status.HTTP_401_UNAUTHORIZED: "authentication_error",
+        status.HTTP_403_FORBIDDEN: "permission_error",
+        status.HTTP_429_TOO_MANY_REQUESTS: "rate_limit_error",
+    }
+)
+
+
+def _error_status_code(exc: object, default: int) -> int:
+    """The HTTP status an exception carries, or ``default`` when it carries none."""
+    carried: Final = _getattr_object(exc, "status_code")
+    return carried if isinstance(carried, int) and not isinstance(carried, bool) else default
+
+
+def _openai_error_type(exc: object, status_code: int) -> str:
+    """OpenAI types ``error.type`` as a required string, so an exception carrying none
+    falls back to the type its status code stands for."""
+    carried: Final = _getattr_object(exc, "type")
+    if isinstance(carried, str):
+        return carried
+    mapped: Final = _OPENAI_ERROR_TYPE_BY_STATUS.get(status_code)
+    if mapped is not None:
+        return mapped
+    if status_code < status.HTTP_500_INTERNAL_SERVER_ERROR:
+        return "invalid_request_error"
+    return "internal_server_error"
+
+
+def _openai_error_param(exc: object) -> str | None:
+    """OpenAI types ``error.param`` as nullable, so an exception carrying none
+    serializes as JSON ``null``."""
+    carried: Final = _getattr_object(exc, "param")
+    return carried if isinstance(carried, str) else None
+
+
 class _UpstreamHttpResponse(Protocol):
     @property
     def status_code(self) -> int: ...
@@ -540,11 +576,12 @@ def proxy_exception_from_http_exception(exc: HTTPException, headers: dict[str, s
     message, structured_fields = serialize_http_exception_detail(raw_detail)
     existing_fields: Final = getattr(exc, "provider_specific_fields", None) or {}
     merged_fields: Final = {**existing_fields, **structured_fields} if structured_fields else (existing_fields or None)
+    error_status: Final = _error_status_code(exc, status.HTTP_400_BAD_REQUEST)
     return ProxyException(
         message=message,
-        type=getattr(exc, "type", "None"),
-        param=getattr(exc, "param", "None"),
-        code=getattr(exc, "status_code", status.HTTP_400_BAD_REQUEST),
+        type=_openai_error_type(exc, error_status),
+        param=_openai_error_param(exc),
+        code=error_status,
         provider_specific_fields=merged_fields,
         headers=headers,
     )
@@ -827,25 +864,22 @@ def sse_error_payload(exc: BaseException) -> tuple[int, Mapping[str, object]]:
     are byte-identical.
     """
     # Preserve status code from HTTPException (e.g. guardrail blocks)
-    error_status: Final = getattr(exc, "status_code", status.HTTP_500_INTERNAL_SERVER_ERROR)
+    error_status: Final = _error_status_code(exc, status.HTTP_500_INTERNAL_SERVER_ERROR)
     raw_detail: Final = _getattr_object(exc, "detail", "Error processing stream start")
     message, structured_fields = serialize_http_exception_detail(raw_detail)
 
     existing_fields: Final = getattr(exc, "provider_specific_fields", None) or {}
     merged_fields: Final = {**existing_fields, **structured_fields} if structured_fields else (existing_fields or None)
 
-    # Built in one statement then given its one optional key, rather than spread
-    # conditionally: the spread form costs two extra dict constructions, which
-    # type-discipline-budget.json's LIT002 ceiling has no room for.
     error_obj: Final = {
         "message": message,
-        "type": getattr(exc, "type", "None"),
-        "param": getattr(exc, "param", "None"),
+        "type": _openai_error_type(exc, error_status),
+        "param": _openai_error_param(exc),
         "code": str(error_status),
     }
-    if merged_fields:
-        error_obj["provider_specific_fields"] = merged_fields
-    return error_status, error_obj
+    if not merged_fields:
+        return error_status, error_obj
+    return error_status, {**error_obj, "provider_specific_fields": merged_fields}
 
 
 def _sse_error_frames(error_obj: Mapping[str, object]) -> tuple[str, str]:
@@ -922,7 +956,7 @@ async def create_response(
                 "error": {
                     "message": _CLIENT_DISCONNECT_DETAIL,
                     "type": "client_disconnect",
-                    "param": "None",
+                    "param": None,
                     "code": str(LITELLM_HTTP_STATUS_CLIENT_DISCONNECTED),
                 }
             },
@@ -3417,8 +3451,8 @@ class ProxyBaseLLMRequestProcessing:
             _code = status.HTTP_500_INTERNAL_SERVER_ERROR
         raise ProxyException(
             message=redact_internal_details_from_client_message(getattr(e, "message", error_msg)),
-            type=getattr(e, "type", "None"),
-            param=getattr(e, "param", "None"),
+            type=_openai_error_type(e, _code),
+            param=_openai_error_param(e),
             openai_code=getattr(e, "code", None),
             code=_code,
             provider_specific_fields=getattr(e, "provider_specific_fields", None),
@@ -3628,11 +3662,12 @@ class ProxyBaseLLMRequestProcessing:
 
             if isinstance(e, HTTPException):
                 raise e
+            stream_error_status: Final = _error_status_code(e, status.HTTP_500_INTERNAL_SERVER_ERROR)
             proxy_exception: Final = ProxyException(
                 message=redact_internal_details_from_client_message(getattr(e, "message", str(e))),
-                type=getattr(e, "type", "None"),
-                param=getattr(e, "param", "None"),
-                code=getattr(e, "status_code", 500),
+                type=_openai_error_type(e, stream_error_status),
+                param=_openai_error_param(e),
+                code=stream_error_status,
             )
             stream_completed = True
             yield serialize_error(proxy_exception)

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -1540,8 +1540,8 @@ class TestCommonRequestProcessingHelpers:
         expected_error_data = {
             "error": {
                 "message": "Error processing stream start",
-                "type": "None",
-                "param": "None",
+                "type": "internal_server_error",
+                "param": None,
                 "code": str(status.HTTP_500_INTERNAL_SERVER_ERROR),
             }
         }
@@ -1569,8 +1569,8 @@ class TestCommonRequestProcessingHelpers:
         expected_error_data = {
             "error": {
                 "message": "Content blocked by guardrail",
-                "type": "None",
-                "param": "None",
+                "type": "invalid_request_error",
+                "param": None,
                 "code": "400",
             }
         }
@@ -1932,6 +1932,104 @@ class TestCommonRequestProcessingHelpers:
             # Since JSONResponse is returned instead of StreamingResponse, streaming tracing should not be triggered
             # tracer.trace should not be called
             assert mock_tracer.trace.call_count == 0
+
+
+def _stringified_none_paths(node: object, path: str = "error") -> tuple[str, ...]:
+    if isinstance(node, dict):
+        return tuple(
+            found
+            for key, value in node.items()
+            for found in _stringified_none_paths(value, f"{path}.{key}")
+        )
+    if isinstance(node, (list, tuple)):
+        return tuple(
+            found
+            for index, value in enumerate(node)
+            for found in _stringified_none_paths(value, f"{path}[{index}]")
+        )
+    return (path,) if node == "None" else ()
+
+
+def _blocked_guardrail_exception() -> HTTPException:
+    return HTTPException(
+        status_code=400,
+        detail={
+            "error": "Violated guardrail policy",
+            "bedrock_guardrail_response": {"action": "GUARDRAIL_INTERVENED"},
+            "guardrailIdentifier": "gf3sc1mzinjw",
+            "guardrailVersion": "DRAFT",
+        },
+    )
+
+
+class TestGuardrailBlockErrorPayloadNeverStringifiesNone:
+    """Regression for LIT-6808: a blocked-guardrail error body carried the literal string
+    "None" for type and param instead of a real error type and JSON null."""
+
+    def test_non_streaming_block_payload_carries_a_real_type_and_null_param(self):
+        from litellm.proxy.common_request_processing import (
+            proxy_exception_from_http_exception,
+        )
+
+        payload = json.loads(
+            json.dumps(proxy_exception_from_http_exception(_blocked_guardrail_exception(), {}).to_dict())
+        )
+
+        assert _stringified_none_paths(payload) == ()
+        assert payload["type"] == "invalid_request_error"
+        assert payload["param"] is None
+        assert payload["code"] == "400"
+        assert payload["message"] == "Violated guardrail policy"
+
+    def test_streaming_block_frame_carries_a_real_type_and_null_param(self):
+        from litellm.proxy.common_request_processing import sse_error_payload
+
+        error_status, error_obj = sse_error_payload(_blocked_guardrail_exception())
+        frame = json.loads(json.dumps({"error": dict(error_obj)}))
+
+        assert error_status == 400
+        assert _stringified_none_paths(frame["error"]) == ()
+        assert frame["error"]["type"] == "invalid_request_error"
+        assert frame["error"]["param"] is None
+        assert frame["error"]["code"] == "400"
+
+    @pytest.mark.parametrize(
+        "status_code, expected_type",
+        [
+            (400, "invalid_request_error"),
+            (401, "authentication_error"),
+            (403, "permission_error"),
+            (404, "invalid_request_error"),
+            (429, "rate_limit_error"),
+            (500, "internal_server_error"),
+            (503, "internal_server_error"),
+        ],
+    )
+    def test_status_code_decides_the_type_when_the_exception_carries_none(self, status_code, expected_type):
+        from litellm.proxy.common_request_processing import (
+            proxy_exception_from_http_exception,
+        )
+
+        payload = proxy_exception_from_http_exception(
+            HTTPException(status_code=status_code, detail="blocked"), {}
+        ).to_dict()
+
+        assert payload["type"] == expected_type
+        assert payload["param"] is None
+
+    def test_a_type_and_param_the_exception_carries_win_over_the_fallback(self):
+        from litellm.proxy.common_request_processing import (
+            proxy_exception_from_http_exception,
+        )
+
+        exc = HTTPException(status_code=400, detail="unknown model")
+        exc.type = "authentication_error"
+        exc.param = "model"
+
+        payload = proxy_exception_from_http_exception(exc, {}).to_dict()
+
+        assert payload["type"] == "authentication_error"
+        assert payload["param"] == "model"
 
 
 class TestExtractErrorFromSSEChunk:
@@ -2998,6 +3096,25 @@ class TestHandleLLMApiExceptionDictDetail:
         proxy_exc = await self._invoke(exc)
         assert proxy_exc.message == "Content blocked by guardrail"
         assert proxy_exc.provider_specific_fields is None
+
+    async def test_blocked_guardrail_error_body_never_carries_the_string_none(self):
+        """Regression for LIT-6808: the error body a blocked request returns must carry a real
+        error type and JSON null rather than the literal string "None"."""
+        proxy_exc = await self._invoke(_blocked_guardrail_exception())
+        payload = json.loads(json.dumps(proxy_exc.to_dict()))
+
+        assert _stringified_none_paths(payload) == ()
+        assert payload["type"] == "invalid_request_error"
+        assert payload["param"] is None
+
+    async def test_unclassified_exception_error_body_never_carries_the_string_none(self):
+        """The same holds on the generic fallback, where nothing carries a type at all."""
+        proxy_exc = await self._invoke(ValueError("Something broke"))
+        payload = json.loads(json.dumps(proxy_exc.to_dict()))
+
+        assert _stringified_none_paths(payload) == ()
+        assert payload["type"] == "internal_server_error"
+        assert payload["param"] is None
 
     async def test_not_found_error_preserves_404(self):
         """NotFoundError with status_code=404 should map to ProxyException code=404."""


### PR DESCRIPTION
## TLDR

Problem this solves:

- Guardrail blocks return `"type": "None"` and `"param": "None"` as strings
- Clients matching OpenAI's error types match neither, so they retry
- Hits /v1/chat/completions, /v1/responses, /v1/messages, streaming and not

How it solves it:

- The `getattr` defaults were the string `"None"`, not `None`
- `type` now falls back to the type its status code stands for
- `param` now serializes as JSON `null`

## User Flow

Before: a developer whose app routes chat through the gateway with a Bedrock guardrail turned on gets an error body whose `type` and `param` are the literal string `None`, so their error handling matches no known type and retries a block that will never succeed

1. They send POST https://litellm-domain/v1/chat/completions with `{"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "How do I brew the perfect cup of coffee?"}]}`, a prompt their guardrail denies
2. They get HTTP 400 with `{"error": {"message": "Violated guardrail policy", "type": "None", "param": "None", "code": "400", ...}}`
3. Their handler compares `error.type` against OpenAI's values (`invalid_request_error`, `rate_limit_error`, ...), matches none, and falls into its generic unknown-error branch, which retries the same blocked prompt
4. They read `error.param` to say which field was at fault and get the four-character string `None`, so the message they show says the problem is in a field called None
5. They send the same prompt to POST https://litellm-domain/v1/responses and POST https://litellm-domain/v1/messages, and to /v1/chat/completions with `"stream": true`, and every one of them carries the same two `"None"` strings
6. From the OpenAI Python SDK the call raises `BadRequestError` whose `err.body["param"]` is `'None'`, a truthy string, so `if err.body["param"]:` takes the wrong branch

After: the same block comes back with a real error type and a null param, so their handler recognizes it, shows the guardrail message, and stops retrying

1. They send the same POST https://litellm-domain/v1/chat/completions with the same denied prompt
2. They get HTTP 400 with `{"error": {"message": "Violated guardrail policy", "type": "invalid_request_error", "param": null, "code": "400", ...}}`
3. Their handler matches `invalid_request_error`, surfaces the guardrail message to the user, and does not retry
4. They read `error.param`, get JSON `null`, and skip the which-field branch entirely
5. The same prompt on POST https://litellm-domain/v1/responses, POST https://litellm-domain/v1/messages, and /v1/chat/completions with `"stream": true` all carry the same real type and null param
6. From the OpenAI Python SDK the call raises `BadRequestError` whose `err.body["param"]` is `None`, so `if err.body["param"]:` takes the branch they meant

## Relevant issues

## Linear ticket

Resolves LIT-6808

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup, identical on both sides: one config with a real Bedrock guardrail that denies the topic "coffee", each proxy booted with 2 uvicorn workers on its own port, both against the same Postgres.

```yaml
model_list:
  - model_name: gpt-4o-mini
    litellm_params:
      model: openai/gpt-4o-mini
      api_key: os.environ/OPENAI_API_KEY

guardrails:
  - guardrail_name: bedrock-pre-guard
    litellm_params:
      guardrail: bedrock
      mode: pre_call
      guardrailIdentifier: gf3sc1mzinjw
      guardrailVersion: DRAFT
      aws_region_name: us-east-1
      default_on: true

general_settings:
  master_key: sk-1234
```

```bash
# before leg, at the merge base
git worktree add --detach ../litellm-base 658f50663d
PYTHONPATH=$PWD/../litellm-base python litellm/proxy/proxy_cli.py --config guardrail_config.yaml --port 31877 --num_workers 2 --detailed_debug

# after leg, at this PR's tip
PYTHONPATH=$PWD python litellm/proxy/proxy_cli.py --config guardrail_config.yaml --port 27431 --num_workers 2 --detailed_debug
```

### Before (658f50663d)

#### POST /v1/chat/completions

1. Send the denied prompt:

```bash
curl -sS -i -X POST http://127.0.0.1:31877/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"How do I brew the perfect cup of coffee?"}]}'
```

2. The block comes back with both fields as the string `"None"`:

```
HTTP/1.1 400 Bad Request
{"error":{"message":"Violated guardrail policy","type":"None","param":"None","code":"400","provider_specific_fields":{"error":"Violated guardrail policy","bedrock_guardrail_response":"Sorry, the model cannot answer this question.","guardrailIdentifier":"gf3sc1mzinjw","guardrailVersion":"DRAFT","assessments":[{"policy":"topicPolicy","matches":[{"category":"topics","name":"coffee","type":"DENY","action":"BLOCKED"}]}],"guardrail_name":"bedrock-pre-guard","guardrail_mode":"pre_call"}}}
```

#### POST /v1/chat/completions with "stream": true

1. Send the same prompt as a stream:

```bash
curl -sS -i -X POST http://127.0.0.1:31877/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"gpt-4o-mini","stream":true,"messages":[{"role":"user","content":"How do I brew the perfect cup of coffee?"}]}'
```

2. Same two `"None"` strings:

```
HTTP/1.1 400 Bad Request
{"error":{"message":"Violated guardrail policy","type":"None","param":"None","code":"400","provider_specific_fields":{"error":"Violated guardrail policy","bedrock_guardrail_response":"Sorry, the model cannot answer this question.","guardrailIdentifier":"gf3sc1mzinjw","guardrailVersion":"DRAFT","assessments":[{"policy":"topicPolicy","matches":[{"category":"topics","name":"coffee","type":"DENY","action":"BLOCKED"}]}],"guardrail_name":"bedrock-pre-guard","guardrail_mode":"pre_call"}}}
```

#### POST /v1/responses

1. Send the denied prompt:

```bash
curl -sS -i -X POST http://127.0.0.1:31877/v1/responses \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"gpt-4o-mini","input":"How do I brew the perfect cup of coffee?"}'
```

2. Same two `"None"` strings:

```
HTTP/1.1 400 Bad Request
{"error":{"message":"Violated guardrail policy","type":"None","param":"None","code":"400","provider_specific_fields":{"error":"Violated guardrail policy","bedrock_guardrail_response":"Sorry, the model cannot answer this question.","guardrailIdentifier":"gf3sc1mzinjw","guardrailVersion":"DRAFT","assessments":[{"policy":"topicPolicy","matches":[{"category":"topics","name":"coffee","type":"DENY","action":"BLOCKED"}]}],"guardrail_name":"bedrock-pre-guard","guardrail_mode":"pre_call"}}}
```

#### POST /v1/messages

1. Send the denied prompt:

```bash
curl -sS -i -X POST http://127.0.0.1:31877/v1/messages \
  -H "x-api-key: sk-1234" -H "anthropic-version: 2023-06-01" -H "Content-Type: application/json" \
  -d '{"model":"gpt-4o-mini","max_tokens":64,"messages":[{"role":"user","content":"How do I brew the perfect cup of coffee?"}]}'
```

2. Same two `"None"` strings:

```
HTTP/1.1 400 Bad Request
{"error":{"message":"Violated guardrail policy","type":"None","param":"None","code":"400","provider_specific_fields":{"error":"Violated guardrail policy","bedrock_guardrail_response":"Sorry, the model cannot answer this question.","guardrailIdentifier":"gf3sc1mzinjw","guardrailVersion":"DRAFT","assessments":[{"policy":"topicPolicy","matches":[{"category":"topics","name":"coffee","type":"DENY","action":"BLOCKED"}]}],"guardrail_name":"bedrock-pre-guard","guardrail_mode":"pre_call"}}}
```

#### OpenAI Python SDK

1. Run the client code a developer would actually write:

```python
import openai

client = openai.OpenAI(base_url="http://127.0.0.1:31877/v1", api_key="sk-1234")
try:
    client.chat.completions.create(
        model="gpt-4o-mini",
        messages=[{"role": "user", "content": "How do I brew the perfect cup of coffee?"}],
    )
except openai.BadRequestError as err:
    print("error.type :", repr(err.body["type"]))
    print("error.param:", repr(err.body["param"]))
```

2. Both come back as truthy strings:

```
error.type : 'None'
error.param: 'None'
```

### After (1b4d2e25db)

#### POST /v1/chat/completions

1. Send the denied prompt:

```bash
curl -sS -i -X POST http://127.0.0.1:27431/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"How do I brew the perfect cup of coffee?"}]}'
```

2. Real type, null param, everything else unchanged:

```
HTTP/1.1 400 Bad Request
{"error":{"message":"Violated guardrail policy","type":"invalid_request_error","param":null,"code":"400","provider_specific_fields":{"error":"Violated guardrail policy","bedrock_guardrail_response":"Sorry, the model cannot answer this question.","guardrailIdentifier":"gf3sc1mzinjw","guardrailVersion":"DRAFT","assessments":[{"policy":"topicPolicy","matches":[{"category":"topics","name":"coffee","type":"DENY","action":"BLOCKED"}]}],"guardrail_name":"bedrock-pre-guard","guardrail_mode":"pre_call"}}}
```

#### POST /v1/chat/completions with "stream": true

1. Send the same prompt as a stream:

```bash
curl -sS -i -X POST http://127.0.0.1:27431/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"gpt-4o-mini","stream":true,"messages":[{"role":"user","content":"How do I brew the perfect cup of coffee?"}]}'
```

2. Real type, null param:

```
HTTP/1.1 400 Bad Request
{"error":{"message":"Violated guardrail policy","type":"invalid_request_error","param":null,"code":"400","provider_specific_fields":{"error":"Violated guardrail policy","bedrock_guardrail_response":"Sorry, the model cannot answer this question.","guardrailIdentifier":"gf3sc1mzinjw","guardrailVersion":"DRAFT","assessments":[{"policy":"topicPolicy","matches":[{"category":"topics","name":"coffee","type":"DENY","action":"BLOCKED"}]}],"guardrail_name":"bedrock-pre-guard","guardrail_mode":"pre_call"}}}
```

#### POST /v1/responses

1. Send the denied prompt:

```bash
curl -sS -i -X POST http://127.0.0.1:27431/v1/responses \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"gpt-4o-mini","input":"How do I brew the perfect cup of coffee?"}'
```

2. Real type, null param:

```
HTTP/1.1 400 Bad Request
{"error":{"message":"Violated guardrail policy","type":"invalid_request_error","param":null,"code":"400","provider_specific_fields":{"error":"Violated guardrail policy","bedrock_guardrail_response":"Sorry, the model cannot answer this question.","guardrailIdentifier":"gf3sc1mzinjw","guardrailVersion":"DRAFT","assessments":[{"policy":"topicPolicy","matches":[{"category":"topics","name":"coffee","type":"DENY","action":"BLOCKED"}]}],"guardrail_name":"bedrock-pre-guard","guardrail_mode":"pre_call"}}}
```

#### POST /v1/messages

1. Send the denied prompt:

```bash
curl -sS -i -X POST http://127.0.0.1:27431/v1/messages \
  -H "x-api-key: sk-1234" -H "anthropic-version: 2023-06-01" -H "Content-Type: application/json" \
  -d '{"model":"gpt-4o-mini","max_tokens":64,"messages":[{"role":"user","content":"How do I brew the perfect cup of coffee?"}]}'
```

2. Real type, null param:

```
HTTP/1.1 400 Bad Request
{"error":{"message":"Violated guardrail policy","type":"invalid_request_error","param":null,"code":"400","provider_specific_fields":{"error":"Violated guardrail policy","bedrock_guardrail_response":"Sorry, the model cannot answer this question.","guardrailIdentifier":"gf3sc1mzinjw","guardrailVersion":"DRAFT","assessments":[{"policy":"topicPolicy","matches":[{"category":"topics","name":"coffee","type":"DENY","action":"BLOCKED"}]}],"guardrail_name":"bedrock-pre-guard","guardrail_mode":"pre_call"}}}
```

#### OpenAI Python SDK

1. Run the same client code against the after proxy:

```python
import openai

client = openai.OpenAI(base_url="http://127.0.0.1:27431/v1", api_key="sk-1234")
try:
    client.chat.completions.create(
        model="gpt-4o-mini",
        messages=[{"role": "user", "content": "How do I brew the perfect cup of coffee?"}],
    )
except openai.BadRequestError as err:
    print("error.type :", repr(err.body["type"]))
    print("error.param:", repr(err.body["param"]))
```

2. A real type and a genuine `None`:

```
error.type : 'invalid_request_error'
error.param: None
```

Notes from the run:

- The status code decides the type: 401 gives `authentication_error`, 403 `permission_error`, 429 `rate_limit_error`
- Anything a caller sets on the exception still wins over the fallback
- `provider_specific_fields` is untouched, so the guardrail detail still rides along
- Every HTTP error the proxy converts was affected, not just guardrails
- Live 401 and 429 bodies are byte-identical before and after

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Every error on these routes gets a real `type`, not only guardrail blocks
  - Exceptions carrying no `type` used to serialize as JSON `null`
  - A 500 now reads `internal_server_error`, LiteLLM's own value
  - Values the exception does carry still win unchanged
- Other endpoint files still pass `"None"` as a `getattr` default
  - Roughly 150 sites across 17 files, none on this error path
  - `GET /v1/files` with a bad `target_model_names` still shows it
  - Follow-up sweep tracked as LIT-6829, and the `type` half as LIT-6839
- A stringified `request_id` in spend logs looks related but is not
  - It comes from the spend-log row builder, a different module
  - Fixing it needs its own change

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 1b4d2e25db passes /live-pr-risk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared proxy error-shaping for all routes; behavior is more correct for clients but any consumer that depended on the string `"None"` will see different `type`/`param` values.
> 
> **Overview**
> Fixes proxy error JSON that used the literal strings `"None"` for `error.type` and `error.param` when exceptions did not carry those fields—most visible on guardrail blocks and generic failures across streaming and non-streaming routes.
> 
> **Centralized helpers** in `common_request_processing.py` (`_openai_error_type`, `_openai_error_param`, `_error_status_code`) now derive a real OpenAI-style `type` from the HTTP status (e.g. 400 → `invalid_request_error`, 401 → `authentication_error`, 429 → `rate_limit_error`) while still honoring `type`/`param` set on the exception. `param` serializes as JSON `null` when absent.
> 
> Those helpers replace the old `getattr(..., "None")` defaults in `proxy_exception_from_http_exception`, `sse_error_payload`, client-disconnect responses, `_handle_llm_api_exception`, and streaming generator error paths so surfaces stay aligned with `ProxyException.to_dict()`. Tests add LIT-6808 regressions and update expected SSE/non-streaming payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b4d2e25dbae78c7c3779f9fcb1485948c0c6cc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


