### PR TITLE
fix(speech): use the provider api key get_llm_provider resolves

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -8073,7 +8073,8 @@ def speech(
         # set API KEY
         api_key = (
             api_key
-            or litellm.api_key  # for deepinfra/perplexity/anyscale we check in get_llm_provider and pass in the api key from there
+            or dynamic_api_key  # for deepinfra/perplexity/anyscale we check in get_llm_provider and pass in the api key from there
+            or litellm.api_key
             or litellm.openai_key
             or get_secret("OPENAI_API_KEY")
         )
@@ -8157,6 +8158,7 @@ def speech(
 
             api_key = (
                 api_key
+                or dynamic_api_key
                 or litellm.api_key
                 or litellm.azure_key
                 or get_secret("AZURE_OPENAI_API_KEY")

--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -1,5 +1,6 @@
 import asyncio
 import base64
+import queue
 import threading
 from datetime import datetime
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -3265,11 +3266,11 @@ def test_stream_chunk_builder_leaves_xai_reported_cost_to_the_calculator(monkeyp
 
 @contextlib.contextmanager
 def _recording_tts_server():
-    received: Final[list[Mapping[str, str]]] = []
+    received: Final[queue.Queue[Mapping[str, str]]] = queue.Queue()
 
     class _Handler(BaseHTTPRequestHandler):
         def do_POST(self):
-            received.append({key.lower(): value for key, value in self.headers.items()})
+            received.put({key.lower(): value for key, value in self.headers.items()})
             self.rfile.read(int(self.headers.get("Content-Length") or 0))
             body = b"ID3\x04\x00\x00\x00fake-mp3-payload"
             self.send_response(200)
@@ -3308,8 +3309,8 @@ def test_speech_openai_compatible_sends_the_provider_scoped_key(monkeypatch: pyt
         )
 
     assert response.content == b"ID3\x04\x00\x00\x00fake-mp3-payload"
-    assert len(received) == 1
-    assert received[0]["authorization"] == "Bearer hosted-vllm-scoped-key"
+    assert received.get(timeout=5)["authorization"] == "Bearer hosted-vllm-scoped-key"
+    assert received.empty()
 
 
 def test_speech_azure_sends_the_provider_scoped_key(monkeypatch: pytest.MonkeyPatch):
@@ -3330,8 +3331,8 @@ def test_speech_azure_sends_the_provider_scoped_key(monkeypatch: pytest.MonkeyPa
         )
 
     assert response.content == b"ID3\x04\x00\x00\x00fake-mp3-payload"
-    assert len(received) == 1
-    assert received[0]["api-key"] == "azure-ai-scoped-key"
+    assert received.get(timeout=5)["api-key"] == "azure-ai-scoped-key"
+    assert received.empty()
 
 
 def test_speech_keeps_an_explicitly_passed_api_key_over_the_provider_scoped_one(monkeypatch: pytest.MonkeyPatch):
@@ -3349,5 +3350,5 @@ def test_speech_keeps_an_explicitly_passed_api_key_over_the_provider_scoped_one(
             api_key="caller-supplied-key",
         )
 
-    assert len(received) == 1
-    assert received[0]["authorization"] == "Bearer caller-supplied-key"
+    assert received.get(timeout=5)["authorization"] == "Bearer caller-supplied-key"
+    assert received.empty()

--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -3332,3 +3332,22 @@ def test_speech_azure_sends_the_provider_scoped_key(monkeypatch: pytest.MonkeyPa
     assert response.content == b"ID3\x04\x00\x00\x00fake-mp3-payload"
     assert len(received) == 1
     assert received[0]["api-key"] == "azure-ai-scoped-key"
+
+
+def test_speech_keeps_an_explicitly_passed_api_key_over_the_provider_scoped_one(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(litellm, "api_key", None)
+    monkeypatch.setattr(litellm, "openai_key", None)
+    monkeypatch.setattr(litellm, "api_base", None)
+    monkeypatch.setenv("HOSTED_VLLM_API_KEY", "hosted-vllm-scoped-key")
+
+    with _recording_tts_server() as (api_base, received):
+        litellm.speech(
+            model="hosted_vllm/tts-1",
+            input="which key goes out",
+            voice="alloy",
+            api_base=api_base,
+            api_key="caller-supplied-key",
+        )
+
+    assert len(received) == 1
+    assert received[0]["authorization"] == "Bearer caller-supplied-key"

--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -1,6 +1,8 @@
 import asyncio
 import base64
+import threading
 from datetime import datetime
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import contextlib
 import copy
 import json
@@ -3259,3 +3261,74 @@ def test_stream_chunk_builder_leaves_xai_reported_cost_to_the_calculator(monkeyp
     assert getattr(response.usage, "cost", None) == pytest.approx(0.42)
     assert response._hidden_params.get("response_cost") is None
     assert logging_obj._response_cost_calculator(result=response) == pytest.approx(0.63)
+
+
+@contextlib.contextmanager
+def _recording_tts_server():
+    received: Final[list[Mapping[str, str]]] = []
+
+    class _Handler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            received.append({key.lower(): value for key, value in self.headers.items()})
+            self.rfile.read(int(self.headers.get("Content-Length") or 0))
+            body = b"ID3\x04\x00\x00\x00fake-mp3-payload"
+            self.send_response(200)
+            self.send_header("Content-Type", "audio/mpeg")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format, *args):
+            return
+
+    server: Final = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+    thread: Final = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}", received
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def test_speech_openai_compatible_sends_the_provider_scoped_key(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(litellm, "api_key", None)
+    monkeypatch.setattr(litellm, "openai_key", None)
+    monkeypatch.setattr(litellm, "api_base", None)
+    monkeypatch.setenv("HOSTED_VLLM_API_KEY", "hosted-vllm-scoped-key")
+    monkeypatch.setenv("OPENAI_API_KEY", "generic-openai-key")
+
+    with _recording_tts_server() as (api_base, received):
+        response: Final = litellm.speech(
+            model="hosted_vllm/tts-1",
+            input="which key goes out",
+            voice="alloy",
+            api_base=api_base,
+        )
+
+    assert response.content == b"ID3\x04\x00\x00\x00fake-mp3-payload"
+    assert len(received) == 1
+    assert received[0]["authorization"] == "Bearer hosted-vllm-scoped-key"
+
+
+def test_speech_azure_sends_the_provider_scoped_key(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(litellm, "api_key", None)
+    monkeypatch.setattr(litellm, "azure_key", None)
+    monkeypatch.setattr(litellm, "api_base", None)
+    monkeypatch.setenv("AZURE_AI_API_KEY", "azure-ai-scoped-key")
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "legacy-azure-openai-key")
+    monkeypatch.setenv("AZURE_API_KEY", "legacy-azure-key")
+
+    with _recording_tts_server() as (api_base, received):
+        response: Final = litellm.speech(
+            model="azure_ai/tts-1",
+            input="which key goes out",
+            voice="alloy",
+            api_base=api_base,
+            api_version="2024-05-01-preview",
+        )
+
+    assert response.content == b"ID3\x04\x00\x00\x00fake-mp3-payload"
+    assert len(received) == 1
+    assert received[0]["api-key"] == "azure-ai-scoped-key"


### PR DESCRIPTION
## TLDR

Problem this solves:

- Text-to-speech ignores the provider's own API key variable
- Azure and OpenAI-compatible TTS fail naming variables nobody set
- Chat works on the same model, so it looks random

How it solves it:

- `speech()` now falls back to the key its provider lookup resolved
- Folded into both dispatch branches' key chains, so an explicit `api_key` still wins

## User Flow

Before: an admin whose TTS key lives in that provider's own environment variable cannot get audio out of the gateway, and the error names a variable they never configured

1. They export `AZURE_AI_API_BASE` and `AZURE_AI_API_KEY` for their Azure AI Foundry resource, put `model: azure_ai/tts-1` in config.yaml with no `api_key` on it, and start the proxy
2. They send `POST http://litellm-domain/v1/audio/speech` with `{"model": "foundry-tts", "input": "...", "voice": "alloy"}`
3. They get `HTTP 500` and `Missing credentials. Please pass one of api_key, azure_ad_token, azure_ad_token_provider, or the AZURE_OPENAI_API_KEY or AZURE_OPENAI_AD_TOKEN environment variables`, naming a variable that has nothing to do with an `azure_ai` setup
4. They try the same thing against their self-hosted OpenAI-compatible server with `HOSTED_VLLM_API_KEY` exported, and get `HTTP 401` and `The api_key client option must be set either by passing api_key to the client or by setting the HOSTED_VLLM_API_KEY environment variable`, which is the variable they already set
5. They send `POST http://litellm-domain/v1/chat/completions` against a model on the same provider and it answers fine, so nothing tells them TTS is the odd one out
6. The only way out is to copy the same key into `OPENAI_API_KEY` or `AZURE_API_KEY`, or to write `api_key` on every TTS deployment by hand

After: the same setup returns audio, with no second copy of the key anywhere

1. They export `AZURE_AI_API_BASE` and `AZURE_AI_API_KEY` for their Azure AI Foundry resource, put `model: azure_ai/tts-1` in config.yaml with no `api_key` on it, and start the proxy
2. They send `POST http://litellm-domain/v1/audio/speech` with `{"model": "foundry-tts", "input": "...", "voice": "alloy"}`
3. They get `HTTP 200` with `content-type: audio/mpeg` and a playable MP3 body
4. The same request against their self-hosted OpenAI-compatible server with `HOSTED_VLLM_API_KEY` exported also returns `HTTP 200` and an MP3
5. `POST http://litellm-domain/v1/chat/completions` on the same provider still answers fine, so speech and chat now read the same credential
6. A deployment that does carry its own `api_key` keeps using that one, so nothing they already had working changes

## Relevant issues

## Linear ticket

Resolves LIT-6822

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both legs run the same live proxy against a real Azure AI Foundry `tts-1` deployment, two uvicorn workers each, no database, and the same config. Neither worktree carries a `.env`, so every credential below comes from the exported variables and nothing else. Only the commit the proxy boots from differs

Shared config (`tts_config.yaml`). Note that only the third deployment carries an `api_key`:

```yaml
model_list:
  - model_name: foundry-tts
    litellm_params:
      model: azure_ai/tts-1
      api_base: os.environ/AZURE_AI_API_BASE
  - model_name: selfhosted-tts
    litellm_params:
      model: hosted_vllm/tts-1
      api_base: os.environ/HOSTED_VLLM_API_BASE
  - model_name: explicit-key-tts
    litellm_params:
      model: deepinfra/tts-1
      api_base: os.environ/HOSTED_VLLM_API_BASE
      api_key: os.environ/EXPLICIT_TTS_KEY
general_settings:
  master_key: sk-lit6822-local
```

Shared environment. The legacy variables (`AZURE_OPENAI_API_KEY`, `AZURE_API_KEY`, `OPENAI_API_KEY`) are deliberately left unset, and `DEEPINFRA_API_KEY` deliberately holds a value that is not the configured one:

```bash
export AZURE_AI_API_BASE='https://<resource>.services.ai.azure.com'
export AZURE_AI_API_KEY='<real Foundry key>'
export HOSTED_VLLM_API_BASE="$AZURE_AI_API_BASE/openai/v1"
export HOSTED_VLLM_API_KEY='<real Foundry key>'
export EXPLICIT_TTS_KEY='<real Foundry key>'
export DEEPINFRA_API_KEY='not-the-configured-key'

python litellm/proxy/proxy_cli.py --config tts_config.yaml --port <port> --num_workers 2 --detailed_debug
```

### Before (658f50663d)

#### Azure branch (`azure_ai/tts-1`)

1. Command:

   ```bash
   curl -sS -o out.mp3 -w 'HTTP %{http_code}  bytes=%{size_download}  ct=%{content_type}\n' \
     -X POST http://127.0.0.1:33115/v1/audio/speech \
     -H 'Authorization: Bearer sk-lit6822-local' -H 'Content-Type: application/json' \
     -d '{"model":"foundry-tts","input":"LiteLLM speech key resolution check.","voice":"alloy"}'
   ```

2. Output:

   ```
   HTTP 500  bytes=6061  ct=application/json
   {"error":{"message":"litellm.APIConnectionError: AzureException APIConnectionError - Missing credentials. Please pass one of `api_key`, `azure_ad_token`, `azure_ad_token_provider`, or the `AZURE_OPENAI_API_KEY` or `AZURE_OPENAI_AD_TOKEN` environment variables. ...
   ```

#### OpenAI-compatible branch (`hosted_vllm/tts-1`)

1. Command:

   ```bash
   curl -sS -o out.mp3 -w 'HTTP %{http_code}  bytes=%{size_download}  ct=%{content_type}\n' \
     -X POST http://127.0.0.1:33115/v1/audio/speech \
     -H 'Authorization: Bearer sk-lit6822-local' -H 'Content-Type: application/json' \
     -d '{"model":"selfhosted-tts","input":"LiteLLM speech key resolution check.","voice":"alloy"}'
   ```

2. Output:

   ```
   HTTP 401  bytes=346  ct=application/json
   {"error":{"message":"litellm.AuthenticationError: AuthenticationError: Hosted_vllmException - The api_key client option must be set either by passing api_key to the client or by setting the HOSTED_VLLM_API_KEY environment variable. Received Model Group=selfhosted-tts\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"401"}}
   ```

#### Deployment carrying its own `api_key` (`deepinfra/tts-1`)

1. Command:

   ```bash
   curl -sS -o out.mp3 -w 'HTTP %{http_code}  bytes=%{size_download}  ct=%{content_type}\n' \
     -X POST http://127.0.0.1:33115/v1/audio/speech \
     -H 'Authorization: Bearer sk-lit6822-local' -H 'Content-Type: application/json' \
     -d '{"model":"explicit-key-tts","input":"LiteLLM speech key resolution check.","voice":"alloy"}'
   ```

2. Output:

   ```
   HTTP 200  bytes=66472  ct=audio/mpeg
   $ file -b out.mp3
   Audio file with ID3 version 2.4.0, contains:
   - MPEG ADTS, layer III, v2, 160 kbps, 24 kHz, Monaural
   ```

### After (3ceaf793ac)

#### Azure branch (`azure_ai/tts-1`)

1. Command:

   ```bash
   curl -sS -o out.mp3 -w 'HTTP %{http_code}  bytes=%{size_download}  ct=%{content_type}\n' \
     -X POST http://127.0.0.1:55983/v1/audio/speech \
     -H 'Authorization: Bearer sk-lit6822-local' -H 'Content-Type: application/json' \
     -d '{"model":"foundry-tts","input":"LiteLLM speech key resolution check.","voice":"alloy"}'
   ```

2. Output:

   ```
   HTTP 200  bytes=65993  ct=audio/mpeg
   $ file -b out.mp3
   Audio file with ID3 version 2.4.0, contains:
   - MPEG ADTS, layer III, v2, 160 kbps, 24 kHz, Monaural
   ```

#### OpenAI-compatible branch (`hosted_vllm/tts-1`)

1. Command:

   ```bash
   curl -sS -o out.mp3 -w 'HTTP %{http_code}  bytes=%{size_download}  ct=%{content_type}\n' \
     -X POST http://127.0.0.1:55983/v1/audio/speech \
     -H 'Authorization: Bearer sk-lit6822-local' -H 'Content-Type: application/json' \
     -d '{"model":"selfhosted-tts","input":"LiteLLM speech key resolution check.","voice":"alloy"}'
   ```

2. Output:

   ```
   HTTP 200  bytes=64553  ct=audio/mpeg
   $ file -b out.mp3
   Audio file with ID3 version 2.4.0, contains:
   - MPEG ADTS, layer III, v2, 160 kbps, 24 kHz, Monaural
   ```

#### Deployment carrying its own `api_key` (`deepinfra/tts-1`)

1. Command:

   ```bash
   curl -sS -o out.mp3 -w 'HTTP %{http_code}  bytes=%{size_download}  ct=%{content_type}\n' \
     -X POST http://127.0.0.1:55983/v1/audio/speech \
     -H 'Authorization: Bearer sk-lit6822-local' -H 'Content-Type: application/json' \
     -d '{"model":"explicit-key-tts","input":"LiteLLM speech key resolution check.","voice":"alloy"}'
   ```

2. Output:

   ```
   HTTP 200  bytes=65993  ct=audio/mpeg
   $ file -b out.mp3
   Audio file with ID3 version 2.4.0, contains:
   - MPEG ADTS, layer III, v2, 160 kbps, 24 kHz, Monaural
   ```

The two later commits, `bc0c5b5ba7` and `33f71357d2`, only touch unit tests, so they cannot change what the proxy does and the run above still stands at the tip

Notes from the run, things the diff does not show:

- `/v1/audio/speech` returns no cost header at all
- Status plus audio bytes are the only end-user observables here
- The 401 names the very variable the admin already set
- An `azure_ai/` model is told to set `AZURE_OPENAI_API_KEY`

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- The provider's own key variable now outranks `litellm.api_key` for TTS
  - Of the two shapes the fix could take, this takes the second: folding `dynamic_api_key` into both branches' chains right after the caller's `api_key`, rather than `transcription()`'s blanket `api_key = dynamic_api_key` assignment
  - The blanket form would also override an `api_key` the caller passed explicitly, which several providers resolve from a bare environment lookup, so a configured key could lose to an unrelated variable
  - What it moves: for TTS on any OpenAI-compatible provider, `<PROVIDER>_API_KEY` now wins over `litellm.api_key`, `litellm.openai_key`, and `OPENAI_API_KEY`, and `AZURE_AI_API_KEY` wins over `AZURE_OPENAI_API_KEY` and `AZURE_API_KEY`
  - Only a config holding both a provider-specific key and a conflicting generic one changes behavior, and chat completions already read the provider-specific one, so that config was already broken everywhere except TTS
  - Left as is on purpose: putting `dynamic_api_key` last instead would keep a stale `OPENAI_API_KEY` beating the provider's own key, which is the bug being fixed

- Local-inference providers now send their own placeholder key for TTS
  - `hosted_vllm`, `lm_studio`, `llamafile` and `datarobot` resolve to the literal `fake-api-key` when their own variable is unset
  - So TTS on one of them, with the key parked only in `OPENAI_API_KEY`, now sends that placeholder
  - Checked against a local recording server: before `Bearer generic-openai-key`, after `Bearer fake-api-key`
  - `/v1/chat/completions` already sends `Bearer fake-api-key` for that same config, so this is TTS catching up
  - Left as is on purpose: skipping the placeholder means special-casing a magic string and re-splitting TTS from chat

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to TTS key precedence; explicit api_key is unchanged, with provider-specific keys now preferred over generic globals—matching existing chat behavior.
> 
> **Overview**
> **`speech()`** now includes **`dynamic_api_key`** (from **`get_llm_provider`**) in the API key fallback chain for both OpenAI-compatible and Azure TTS paths, placed after an explicit **`api_key`** and before global **`litellm.api_key`** / generic env vars.
> 
> This aligns TTS credential resolution with chat and fixes cases where provider-specific env keys (e.g. **`HOSTED_VLLM_API_KEY`**, **`AZURE_AI_API_KEY`**) were ignored while **`OPENAI_API_KEY`** or legacy Azure vars were required instead.
> 
> New integration-style tests use a local HTTP recorder to assert the outgoing **`Authorization`** / **`api-key`** header uses the scoped key, and that a caller-supplied **`api_key`** still wins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33f71357d22493ccc85f0c521e74ea79bd6c4e84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
