### PR TITLE
fix(utils): redact credential kwargs from the set_verbose request line

### DIFF
--- a/litellm/litellm_core_utils/secret_redaction.py
+++ b/litellm/litellm_core_utils/secret_redaction.py
@@ -11,7 +11,7 @@ from typing import Final
 
 from litellm.constants import MINIMUM_CUSTOM_KEY_LENGTH
 
-_REDACTED: Final = "REDACTED"
+REDACTED: Final = "REDACTED"
 
 
 def _build_secret_patterns() -> "re.Pattern[str]":
@@ -89,7 +89,7 @@ _SECRET_RE: Final = _build_secret_patterns()
 
 def redact_string(value: str) -> str:
     """Scrub known secret/credential patterns from *value* and return the result."""
-    return _SECRET_RE.sub(_REDACTED, value)
+    return _SECRET_RE.sub(REDACTED, value)
 
 
 _UNIX_SYSTEM_PATH: Final = r"/(?:etc|var|opt|usr|home|root|private|Users|tmp|mnt|srv)/[^\s'\"\)\]}>,]+"
@@ -110,7 +110,7 @@ def redact_internal_details(value: str) -> str:
     on top of redact_string(). For client-facing messages only: server logs keep this detail."""
     marker_index: Final = value.find(_TRACEBACK_MARKER)
     without_traceback: Final = value[:marker_index].rstrip() if marker_index != -1 else value
-    return _INTERNAL_DETAIL_RE.sub(_REDACTED, redact_string(without_traceback))
+    return _INTERNAL_DETAIL_RE.sub(REDACTED, redact_string(without_traceback))
 
 
 def redact_structured_value(key: str | None, value: str) -> str:
@@ -126,4 +126,4 @@ def redact_structured_value(key: str | None, value: str) -> str:
     if scrubbed != value or key is None:
         return scrubbed
     rendered: Final = f"'{key}': '{value}'"
-    return _REDACTED if redact_string(rendered) != rendered else value
+    return REDACTED if redact_string(rendered) != rendered else value

--- a/litellm/litellm_core_utils/sensitive_data_masker.py
+++ b/litellm/litellm_core_utils/sensitive_data_masker.py
@@ -1,4 +1,4 @@
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from typing import Any, Final
 
 from pydantic import BaseModel
@@ -225,8 +225,8 @@ def redact_credentials_in_payload(data: Mapping[str, object]) -> Mapping[str, ob
     :func:`mask_credentials_in_payload`, no prefix or suffix of the secret survives
     and non-string secrets are covered too, which is what a payload rendered
     straight to stdout needs. ``None`` is preserved so an unset credential still
-    reads as unset, and non-mapping containers are left alone so the caller's
-    ``repr`` is unchanged.
+    reads as unset, and lists and tuples are rebuilt element by element so a
+    credential nested inside one is caught as well.
     """
     return _redact_mapping(data, 0)
 
@@ -242,7 +242,16 @@ def _redact_entry(key: str, value: object, depth: int) -> object:
         return REDACTED
     if isinstance(value, Mapping):
         return _redact_mapping(value, depth + 1)
+    if isinstance(value, (list, tuple)):
+        return _redact_sequence(value, depth + 1)
     return value
+
+
+def _redact_sequence(values: Sequence[object], depth: int) -> Sequence[object]:
+    if depth >= DEFAULT_MAX_RECURSE_DEPTH_SENSITIVE_DATA_MASKER:
+        return values
+    redacted: Final = tuple(_redact_entry("", item, depth) for item in values)
+    return redacted if isinstance(values, tuple) else list(redacted)
 
 
 # Usage example:

--- a/litellm/litellm_core_utils/sensitive_data_masker.py
+++ b/litellm/litellm_core_utils/sensitive_data_masker.py
@@ -4,6 +4,7 @@ from typing import Any, Final
 from pydantic import BaseModel
 
 from litellm.constants import DEFAULT_MAX_RECURSE_DEPTH_SENSITIVE_DATA_MASKER
+from litellm.litellm_core_utils.secret_redaction import REDACTED
 
 
 class SensitiveDataMasker:
@@ -212,6 +213,36 @@ def mask_sensitive_keys(data: dict[str, Any], sensitive_fields: set[str]) -> dic
         else:
             masked[key] = value
     return masked
+
+
+def redact_credentials_in_payload(data: Mapping[str, object]) -> Mapping[str, object]:
+    """Return a copy of ``data`` where every value under a credential-named key is
+    replaced by the shared ``REDACTED`` marker, nested mappings are recursed into,
+    and every other value is preserved by identity.
+
+    Sensitive-key detection is delegated to the shared :class:`SensitiveDataMasker`,
+    so the credential names stay in one place. Unlike
+    :func:`mask_credentials_in_payload`, no prefix or suffix of the secret survives
+    and non-string secrets are covered too, which is what a payload rendered
+    straight to stdout needs. ``None`` is preserved so an unset credential still
+    reads as unset, and non-mapping containers are left alone so the caller's
+    ``repr`` is unchanged.
+    """
+    return _redact_mapping(data, 0)
+
+
+def _redact_mapping(data: Mapping[str, object], depth: int) -> Mapping[str, object]:
+    if depth >= DEFAULT_MAX_RECURSE_DEPTH_SENSITIVE_DATA_MASKER:
+        return data
+    return {key: _redact_entry(key, value, depth) for key, value in data.items()}
+
+
+def _redact_entry(key: str, value: object, depth: int) -> object:
+    if value is not None and _default_masker.is_sensitive_key(key):
+        return REDACTED
+    if isinstance(value, Mapping):
+        return _redact_mapping(value, depth + 1)
+    return value
 
 
 # Usage example:

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -83,6 +83,7 @@ from litellm.constants import (
 from litellm.litellm_core_utils.fallback_generalizations import (
     match_capability_generalizations,
 )
+from litellm.litellm_core_utils.sensitive_data_masker import redact_credentials_in_payload
 
 _CachingHandlerResponse = None
 _LLMCachingHandler = None
@@ -7459,7 +7460,8 @@ def print_args_passed_to_litellm(original_function, args, kwargs):
             return
 
         args_str: Final = ", ".join(map(repr, args))
-        kwargs_str: Final = ", ".join(f"{key}={value!r}" for key, value in kwargs.items())
+        redacted_kwargs: Final = redact_credentials_in_payload(kwargs)
+        kwargs_str: Final = ", ".join(f"{key}={value!r}" for key, value in redacted_kwargs.items())
         print_verbose(
             "\n",
         )  # new line before

--- a/tests/test_litellm/litellm_core_utils/test_sensitive_data_masker.py
+++ b/tests/test_litellm/litellm_core_utils/test_sensitive_data_masker.py
@@ -348,3 +348,27 @@ def test_redact_credentials_in_payload_leaves_no_fragment_of_the_secret():
     assert result["max_tokens"] == 17
     assert result["temperature"] == 0.25
     assert result["api_base"] is None
+
+
+def test_redact_credentials_in_payload_reaches_credentials_nested_in_sequences():
+    """Free-form kwargs like extra_body and metadata routinely carry lists of dicts, so a
+    credential hiding one level inside a list or tuple must be replaced too, while the
+    surrounding container keeps its type and every ordinary element stays verbatim."""
+    from litellm.litellm_core_utils.sensitive_data_masker import redact_credentials_in_payload
+
+    result = redact_credentials_in_payload(
+        {
+            "extra_body": {"providers": [{"name": "openai", "api_key": "sk-fake-lit6823-in-a-list"}]},
+            "metadata": {"upstreams": ({"aws_secret_access_key": "fake-aws-in-a-tuple"},)},
+            "messages": [{"role": "user", "content": "hello"}],
+        }
+    )
+
+    assert "sk-fake-lit6823-in-a-list" not in str(result)
+    assert "fake-aws-in-a-tuple" not in str(result)
+    assert result["extra_body"]["providers"][0]["api_key"] == "REDACTED"
+    assert result["extra_body"]["providers"][0]["name"] == "openai"
+    assert isinstance(result["extra_body"]["providers"], list)
+    assert result["metadata"]["upstreams"][0]["aws_secret_access_key"] == "REDACTED"
+    assert isinstance(result["metadata"]["upstreams"], tuple)
+    assert result["messages"] == [{"role": "user", "content": "hello"}]

--- a/tests/test_litellm/litellm_core_utils/test_sensitive_data_masker.py
+++ b/tests/test_litellm/litellm_core_utils/test_sensitive_data_masker.py
@@ -312,3 +312,39 @@ def test_mask_credentials_in_payload_masks_only_sensitive_string_leaves():
     assert masked != plaintext
     assert masked.startswith(plaintext[:4])
     assert masked.endswith(plaintext[-4:])
+
+
+def test_redact_credentials_in_payload_leaves_no_fragment_of_the_secret():
+    """A payload rendered straight to stdout cannot afford the partial reveal
+    mask_credentials_in_payload leaves, so every credential-named value is replaced
+    whole, nested header dicts included, while ordinary params survive verbatim."""
+    from litellm.litellm_core_utils.sensitive_data_masker import redact_credentials_in_payload
+
+    fake_key = "sk-fake-lit6823-0000000000000000"
+    fake_token = "fake-azure-ad-token-0000"
+    result = redact_credentials_in_payload(
+        {
+            "api_key": fake_key,
+            "azure_ad_token": fake_token,
+            "aws_secret_access_key": "fake-aws-secret-0000",
+            "vertex_credentials": {"private_key": "fake-pem"},
+            "extra_headers": {"Authorization": "Bearer fake-bearer-0000", "x-request-id": "abc123"},
+            "model": "gpt-4o-mini",
+            "max_tokens": 17,
+            "temperature": 0.25,
+            "api_base": None,
+        }
+    )
+
+    assert fake_key not in str(result)
+    assert fake_token not in str(result)
+    assert "fake-aws-secret-0000" not in str(result)
+    assert "fake-pem" not in str(result)
+    assert "fake-bearer-0000" not in str(result)
+    assert result["api_key"] == "REDACTED"
+    assert result["extra_headers"]["Authorization"] == "REDACTED"
+    assert result["extra_headers"]["x-request-id"] == "abc123"
+    assert result["model"] == "gpt-4o-mini"
+    assert result["max_tokens"] == 17
+    assert result["temperature"] == 0.25
+    assert result["api_base"] is None

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -5805,3 +5805,53 @@ class TestIsVisionExplicitlyDisabled:
             is_vision_explicitly_disabled("fireworks_ai/accounts/fireworks/models/deepseek-v4-flash-0731") is True
         )
         assert is_vision_explicitly_disabled("anthropic/claude-sonnet-4-5") is False
+
+
+class TestVerboseRequestLineRedaction:
+    """`litellm.set_verbose = True` echoes the caller's kwargs to stdout, so a credential
+    kwarg lands in whatever collects stdout: a terminal, a container log drain, a CI job
+    log. Credential-named kwargs must not survive that echo, while ordinary params still
+    must, or the line stops telling the developer what they called."""
+
+    FAKE_API_KEY: Final = "sk-fake-lit6823-0000000000000000"
+
+    def _verbose_stdout(self, capsys, monkeypatch, **kwargs) -> str:
+        monkeypatch.setattr(litellm, "set_verbose", True)
+        monkeypatch.setattr("litellm._logging.set_verbose", True)
+        capsys.readouterr()
+        litellm.completion(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": "hello"}],
+            mock_response="hi",
+            **kwargs,
+        )
+        captured: Final = capsys.readouterr()
+        return captured.out + captured.err
+
+    def test_api_key_never_reaches_stdout(self, capsys, monkeypatch):
+        printed: Final = self._verbose_stdout(capsys, monkeypatch, api_key=self.FAKE_API_KEY)
+
+        assert "Request to litellm:" in printed
+        assert self.FAKE_API_KEY not in printed
+        assert "api_key='REDACTED'" in printed
+
+    def test_credential_headers_never_reach_stdout(self, capsys, monkeypatch):
+        printed: Final = self._verbose_stdout(
+            capsys,
+            monkeypatch,
+            api_key=self.FAKE_API_KEY,
+            extra_headers={"Authorization": "Bearer fake-lit6823-header", "x-request-id": "abc123"},
+        )
+
+        assert "fake-lit6823-header" not in printed
+        assert "'Authorization': 'REDACTED'" in printed
+        assert "'x-request-id': 'abc123'" in printed
+
+    def test_ordinary_params_still_printed(self, capsys, monkeypatch):
+        printed: Final = self._verbose_stdout(
+            capsys, monkeypatch, api_key=self.FAKE_API_KEY, max_tokens=17, temperature=0.25
+        )
+
+        assert "model='gpt-3.5-turbo'" in printed
+        assert "max_tokens=17" in printed
+        assert "temperature=0.25" in printed

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -5808,14 +5808,15 @@ class TestIsVisionExplicitlyDisabled:
 
 
 class TestVerboseRequestLineRedaction:
-    """`litellm.set_verbose = True` echoes the caller's kwargs to stdout, so a credential
-    kwarg lands in whatever collects stdout: a terminal, a container log drain, a CI job
-    log. Credential-named kwargs must not survive that echo, while ordinary params still
-    must, or the line stops telling the developer what they called."""
+    """`litellm.set_verbose = True` echoes the caller's kwargs back as a `litellm.completion(...)`
+    line on stdout, so a credential kwarg lands in whatever collects stdout: a terminal, a
+    container log drain, a CI job log. Credential-named kwargs must not survive that echo,
+    at any nesting depth, while ordinary params still must, or the line stops telling the
+    developer what they called."""
 
     FAKE_API_KEY: Final = "sk-fake-lit6823-0000000000000000"
 
-    def _verbose_stdout(self, capsys, monkeypatch, **kwargs) -> str:
+    def _verbose_request_line(self, capsys, monkeypatch, **kwargs) -> str:
         monkeypatch.setattr(litellm, "set_verbose", True)
         monkeypatch.setattr("litellm._logging.set_verbose", True)
         capsys.readouterr()
@@ -5826,17 +5827,17 @@ class TestVerboseRequestLineRedaction:
             **kwargs,
         )
         captured: Final = capsys.readouterr()
-        return captured.out + captured.err
+        return "\n".join(line for line in (captured.out + captured.err).splitlines() if "litellm.completion(" in line)
 
-    def test_api_key_never_reaches_stdout(self, capsys, monkeypatch):
-        printed: Final = self._verbose_stdout(capsys, monkeypatch, api_key=self.FAKE_API_KEY)
+    def test_api_key_never_reaches_the_request_line(self, capsys, monkeypatch):
+        printed: Final = self._verbose_request_line(capsys, monkeypatch, api_key=self.FAKE_API_KEY)
 
-        assert "Request to litellm:" in printed
+        assert "litellm.completion(" in printed
         assert self.FAKE_API_KEY not in printed
         assert "api_key='REDACTED'" in printed
 
-    def test_credential_headers_never_reach_stdout(self, capsys, monkeypatch):
-        printed: Final = self._verbose_stdout(
+    def test_credential_headers_never_reach_the_request_line(self, capsys, monkeypatch):
+        printed: Final = self._verbose_request_line(
             capsys,
             monkeypatch,
             api_key=self.FAKE_API_KEY,
@@ -5847,8 +5848,19 @@ class TestVerboseRequestLineRedaction:
         assert "'Authorization': 'REDACTED'" in printed
         assert "'x-request-id': 'abc123'" in printed
 
+    def test_credentials_nested_in_a_list_never_reach_the_request_line(self, capsys, monkeypatch):
+        printed: Final = self._verbose_request_line(
+            capsys,
+            monkeypatch,
+            api_key=self.FAKE_API_KEY,
+            extra_body={"providers": [{"name": "openai", "api_key": "sk-fake-lit6823-nested"}]},
+        )
+
+        assert "sk-fake-lit6823-nested" not in printed
+        assert "'name': 'openai'" in printed
+
     def test_ordinary_params_still_printed(self, capsys, monkeypatch):
-        printed: Final = self._verbose_stdout(
+        printed: Final = self._verbose_request_line(
             capsys, monkeypatch, api_key=self.FAKE_API_KEY, max_tokens=17, temperature=0.25
         )
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- `litellm.set_verbose = True` echoed the caller's `api_key` back to stdout in plaintext
- Terminals, CI job logs and log drains captured a working provider key
- The same statement's logger copy was already redacted, so the two halves of one print disagreed

How it solves it:

- Mask credential-named kwargs before the `Request to litellm:` line is built
- Reuse the sensitive-key names the shared `SensitiveDataMasker` already carries, and the shared `REDACTED` marker, so both debug surfaces agree on what a credential is
- Cover nested dicts, lists and tuples, since `extra_headers` and `extra_body` routinely carry one
- Ordinary params like `model`, `max_tokens` and `temperature` still print unchanged

Masking by key name rather than by value shape is the point: `redact_string` only catches a value that already looks like a secret (an `sk-` prefix and friends), so a key whose shape nobody anticipated is exactly the one that slips through.

## User Flow

Before: a developer who turns on verbose debugging to diagnose a failing call gets their provider key printed in full into the terminal and into whatever collects that output

1. They add `litellm.set_verbose = True` to their script
2. They call `litellm.completion(model="gpt-4o-mini", api_key=<their provider key>, messages=[...])`
3. The console prints a `Request to litellm:` line listing every argument they passed, with the `api_key` value shown verbatim
4. The call itself succeeds and returns a normal completion
5. They paste that output into a bug report, or their CI job archives it, and anyone who can read that log now holds a working provider key

After: the same debugging session prints the same request line with the credential replaced, so the log is safe to keep or share

1. They add `litellm.set_verbose = True` to their script
2. They call `litellm.completion(model="gpt-4o-mini", api_key=<their provider key>, messages=[...])`
3. The console prints the same `Request to litellm:` line, now showing `api_key='REDACTED'`, while `model`, `max_tokens` and `temperature` are still printed as before
4. The call itself succeeds and returns a normal completion
5. They paste that output into a bug report, or their CI job archives it, and the log carries no usable credential

The proxy is not on this flow. A proxy passes the provider key to the router after the request line is built, so `--detailed_debug` never printed it; the QA below runs all three proxy endpoints anyway as a no-regression check.

## Relevant issues

## Linear ticket

Resolves LIT-6823

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both legs ran live against real OpenAI and Anthropic APIs (real spend), each in its own worktree with its own `.venv`, its own `.env` derived from the main checkout, and its own random free high port. No mocks, no stubs, no pytest. Every credential check is a `grep -c` count, so no key value is ever printed.

Setup, identical on both legs apart from the commit:

```
git -C /Users/mateo/Development/litellm worktree add <leg worktree> <commit> --detach
cd <leg worktree> && make bootstrap
grep -v -E '^(DATABASE_URL|STORE_MODEL_IN_DB)=' /Users/mateo/Development/litellm/.env > ./.env
lsof -nP -iTCP:<port> -sTCP:LISTEN          # must print nothing
./.venv/bin/python -c "import litellm; print(litellm.__file__)"   # must resolve inside the leg worktree
```

The SDK script turns on verbose debugging and makes four calls, passing the provider key explicitly the way the ticket's flow does:

```
litellm.set_verbose = True
litellm._logging.set_verbose = True
litellm.completion(model="gpt-4o-mini", api_key=OPENAI_KEY, messages=[...], max_tokens=16)
litellm.responses(model="gpt-4o-mini", api_key=OPENAI_KEY, input="say hi", max_output_tokens=16)
asyncio.run(litellm.anthropic_messages(model="claude-sonnet-5", api_key=ANTHROPIC_KEY, messages=[...], max_tokens=16))
litellm.completion(model="gpt-4o-mini", api_key=OPENAI_KEY, messages=[...], max_tokens=16,
                   metadata={"upstreams": [{"name": "openai", "api_key": "sk-fake-lit6823-nested-in-a-list"}]})
```

```
set -a; . ./.env; set +a
./.venv/bin/python sdk_verbose_qa.py > sdk.log 2>&1; echo "exit=$?"
grep -c 'Request to litellm:' sdk.log
grep -c "api_key='sk-" sdk.log
grep -c -F "$OPENAI_API_KEY" sdk.log
grep -c -F "$ANTHROPIC_API_KEY" sdk.log
grep -c "api_key='REDACTED'" sdk.log
grep -c 'max_tokens=16' sdk.log
grep -c "model='gpt-4o-mini'" sdk.log
grep -c -F 'sk-fake-lit6823-nested-in-a-list' sdk.log
grep -c -F "'name': 'openai'" sdk.log
```

The proxy leg boots the same commit with `--detailed_debug` and two uvicorn workers, then hits all three unified endpoints:

```
./.venv/bin/python litellm/proxy/proxy_cli.py --config lit6823.yaml --port <port> --num_workers 2 --detailed_debug > proxy.log 2>&1 &
until [ "$(curl -s -o /dev/null -m 3 -w '%{http_code}' http://127.0.0.1:<port>/health/readiness)" = "200" ]; do sleep 2; done
curl -s -o r_chat.json -w '%{http_code}\n' -X POST http://127.0.0.1:<port>/v1/chat/completions \
  -H "Authorization: Bearer $MASTER_KEY" -H 'Content-Type: application/json' \
  -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"say hi"}],"max_tokens":16}'
curl -s -o r_resp.json -w '%{http_code}\n' -X POST http://127.0.0.1:<port>/v1/responses \
  -H "Authorization: Bearer $MASTER_KEY" -H 'Content-Type: application/json' \
  -d '{"model":"gpt-4o-mini","input":"say hi","max_output_tokens":16}'
curl -s -o r_msg.json -w '%{http_code}\n' -X POST http://127.0.0.1:<port>/v1/messages \
  -H "Authorization: Bearer $MASTER_KEY" -H 'Content-Type: application/json' \
  -d '{"model":"claude-sonnet-5","messages":[{"role":"user","content":"say hi"}],"max_tokens":16}'
# then the same greps against proxy.log
```

### Before, at the merge base `658f50663d19f613a3f5caf998168da019764ad8`

SDK, three calls (the nested-metadata case was added later and is after-leg only, which changes nothing here since no kwarg was redacted at all at this commit), script exit 0, port 38417:

| grep over `sdk.log` | count |
|---|---|
| `Request to litellm:` | 3 |
| `api_key='sk-` | **3** |
| `-F "$OPENAI_API_KEY"` | **2** |
| `-F "$ANTHROPIC_API_KEY"` | **1** |
| `api_key='REDACTED'` | 0 |

| call | model returned | text len |
|---|---|---|
| `litellm.completion` | gpt-4o-mini-2024-07-18 | 31 |
| `litellm.responses` | gpt-4o-mini-2024-07-18 | 37 |
| `litellm.anthropic_messages` | claude-sonnet-5 | 37 |

Every provider key the developer passed is in stdout verbatim, zero redactions, while all three calls return real provider responses.

Live proxy, `--detailed_debug`, 2 workers, 563 log lines:

| endpoint | HTTP | model | assistant text |
|---|---|---|---|
| `/v1/chat/completions` | 200 | gpt-4o-mini | Hi! How can I assist you today? |
| `/v1/responses` | 200 | gpt-4o-mini | Hi there! How can I assist you today? |
| `/v1/messages` | 200 | claude-sonnet-5 | Hi there! How can I help you today? |

| grep over `proxy.log` | count |
|---|---|
| `Request to litellm:` | 4 |
| `api_key='sk-` | 0 |
| `-F "$OPENAI_API_KEY"` | 0 |
| `-F "$ANTHROPIC_API_KEY"` | 0 |
| master key, key prefixes, first 20 and last 8 chars of each key | 0 |

The proxy never printed a provider key even before the fix, because the router attaches the resolved key after this line is built. That is why the User Flow above is SDK-only and the proxy leg is a no-regression check.

### After, at the PR head `0a62195db25dabfd980fbd0fa50d5b0f4a33f624`

SDK, four calls, script exit 0, port 25341:

| grep over `sdk.log` | count |
|---|---|
| `Request to litellm:` | 4 |
| `api_key='sk-` | **0** |
| `-F "$OPENAI_API_KEY"` | **0** |
| `-F "$ANTHROPIC_API_KEY"` | **0** |
| `api_key='REDACTED'` | **4** |
| `max_tokens=16` | 3 |
| `model='gpt-4o-mini'` | 3 |
| `-F 'sk-fake-lit6823-nested-in-a-list'` | **0** |
| `-F "'name': 'openai'"` | 1 |

| call | model returned | text len |
|---|---|---|
| `litellm.completion` | gpt-4o-mini-2024-07-18 | 37 |
| `litellm.responses` | gpt-4o-mini-2024-07-18 | 37 |
| `litellm.anthropic_messages` | claude-sonnet-5 | 29 |
| `litellm.completion` with a credential nested in a list | gpt-4o-mini-2024-07-18 | 37 |

The counted grep the ticket asks about goes 3 to 0 while `api_key='REDACTED'` goes 0 to 4, the nested-in-a-list credential is gone too, its ordinary sibling `'name': 'openai'` survives, and `max_tokens` and `model` still print. Positive control: the same `-F` greps return 1 against the leg's own `.env`, so the zeros are real absences rather than a broken grep.

Live proxy, `--detailed_debug`, 2 workers, 565 log lines:

| endpoint | HTTP | model | assistant text |
|---|---|---|---|
| `/v1/chat/completions` | 200 | gpt-4o-mini | Hi there! How can I assist you today? |
| `/v1/responses` | 200 | gpt-4o-mini | Hi there! How are you today? |
| `/v1/messages` | 200 | claude-sonnet-5 | Hi! How can I help you today? |

| grep over `proxy.log` | count |
|---|---|
| `Request to litellm:` | 4 |
| `api_key='sk-` | 0 |
| `-F "$OPENAI_API_KEY"` | 0 |
| `-F "$ANTHROPIC_API_KEY"` | 0 |
| master key anywhere, any `sk-` substring | 0 |
| `max_tokens=16` / `max_output_tokens=16` | 2 / 3 |
| `model='openai/gpt-4o-mini'` / `model='anthropic/claude-sonnet-5'` | 3 / 1 |

All three endpoints still answer 200 with real provider text and the request line still carries the params a developer debugs with, so nothing regressed on the surface that never leaked

Both legs' logs and response bodies were deleted after counting, both proxies were stopped, and both ports were confirmed free with no orphan workers

Observations the diff does not show:

- Proxy request line never carried `api_key` at all
- `litellm.set_verbose` alone does not enable the print
- `litellm._logging.set_verbose` must be set too
- Four request lines printed for three proxy requests
- Nested `metadata` is stripped before the provider payload

## Type

🐛 Bug Fix

## Caveats (if any)

- **Low.** A credential nested under `extra_body` still reaches stdout, on a different line. `set_verbose` also prints `Final returned optional params: {...}` from `litellm/utils.py`, and that statement is outside this fix. Probed at this head, it is the only surviving surface and only for `extra_body`: a top-level `api_key` and a credential nested in `metadata` both count 0. Tracked as LIT-6835 rather than fixed here, because that call site is not behind the debug guard this one sits behind, so redacting it costs about 225 us on every request on top of the 25 us the f-string already spends, and the obvious guard is wrong: the guard helper reads `litellm._logging.set_verbose` while that print reads `litellm.set_verbose`, so guarding would silently drop the line for anyone using the documented flag. Changing an unguarded hot-path line on every request, for a credential someone deliberately nested under `extra_body`, is a worse trade than leaving it to its own PR
- **Low.** The proxy's `--detailed_debug` request line now prints `user_api_key_request_route`, `user_api_key_user_id` and `user_api_key_spend` as `REDACTED`. Those are proxy-injected metadata, not secrets, so a little debuggability is lost on a surface that was never leaking. The shared masker does support an exact-match exclusion set, but enumerating these names here would go stale the moment a genuinely secret `user_api_key_*` field is added, and that is the exact shape of leak this PR exists to prevent. Redacting by default is the safer side of that trade, and the route is still readable from the proxy's own request logs
- **Low.** `secret_fields` is redacted too. That one is correct rather than collateral: it carries `raw_headers`, Authorization tokens included, and both the spend-tracking body scrubber and the guardrail path already strip it elsewhere

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches a hot debug/logging path and broad key-name redaction (including nested structures), which could over-redact proxy metadata fields but prevents credential leaks in shared logs.
> 
> **Overview**
> **Fixes plaintext credential leakage** when `set_verbose` prints the `litellm.completion(...)` request line to stdout (terminals, CI, log drains).
> 
> The verbose path now runs kwargs through a new **`redact_credentials_in_payload`** helper before formatting the debug string. That helper uses the same sensitive-key rules as `SensitiveDataMasker` but replaces entire values with the shared **`REDACTED`** marker (no partial `sk-xxxx****` reveal), including non-string secrets. It recurses into nested dicts and list/tuple elements so keys like `api_key`, `Authorization`, and credentials inside `extra_body` / `extra_headers` are scrubbed while ordinary params (`model`, `max_tokens`, etc.) still print unchanged.
> 
> **`secret_redaction`** exports `REDACTED` (renamed from private `_REDACTED`) so stdout redaction matches other scrubbers. Unit tests cover the new helper and the verbose request-line behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a62195db25dabfd980fbd0fa50d5b0f4a33f624. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->