### PR TITLE
fix(headroom): bound the /v1/compress and /v1/retrieve calls with a timeout

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/headroom/__init__.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/headroom/__init__.py
@@ -35,6 +35,7 @@ def initialize_guardrail(litellm_params: LitellmParams, guardrail: Guardrail) ->
         event_hook=_coerce_event_hook(litellm_params.mode),
         default_on=litellm_params.default_on or False,
         unreachable_fallback=litellm_params.unreachable_fallback,
+        timeout=litellm_params.timeout,
     )
     litellm.logging_callback_manager.add_litellm_callback(  # pyright: ignore[reportUnknownMemberType]
         _callback

--- a/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import math
 import re
 import time
 import uuid
@@ -55,15 +56,8 @@ BYPASS_HEADER: Final = "x-headroom-bypass"
 _STREAM_CONVERTIBLE_CALL_TYPES: Final = frozenset(
     (CallTypes.completion, CallTypes.acompletion, CallTypes.responses, CallTypes.aresponses)
 )
-# Default budget for a call to the compression service. The shared GuardrailCallback
-# client is built with no params, so its read/write/pool legs are 600s (or
-# litellm.request_timeout when that is set explicitly, which defaults to 6000s). That
-# is far too long for a pre-call guardrail: a stalled service holds the caller's
-# request open for the whole window instead of reaching unreachable_fallback, and
-# because that client is shared with every other no-params guardrail, each stalled
-# call also holds a pooled connection for the same window, so once the pool saturates
-# unrelated requests block on the pool leg too. Overridable per guardrail with
-# `timeout` in litellm_params.
+# The shared GuardrailCallback client carries no per-call bound, so without this a
+# stalled service holds the caller's request and a pooled connection for 600s or more.
 _COMPRESS_TIMEOUT_SECONDS: Final = 60.0
 HEADROOM_RETRIEVE_TOOL_NAME: Final = "headroom_retrieve"
 _HASH_PATTERN: Final = re.compile(r"hash=([a-f0-9]{24})")
@@ -529,32 +523,22 @@ class HeadroomGuardrail(CustomGuardrail):
     def _resolve_timeout(timeout: float | None) -> httpx.Timeout:
         """Budget for one call to the compression service, unset meaning the default.
 
-        A non-positive value is rejected rather than passed through: httpx accepts it
-        and the aiohttp transport then reads 0 as "no deadline" (restoring the
-        unbounded stall this bound exists to prevent) and a negative one as a deadline
-        already in the past, which fails every call instantly. The connect leg is
-        clamped to the budget so a short one is honored end to end rather than
-        spending the http_handler default on connect alone.
+        Zero, negative and non-finite values are rejected instead of passed through:
+        httpx accepts them, and the transport then reads 0 and inf as no deadline at
+        all and a negative one as a deadline already past.
         """
-        if timeout is not None and timeout <= 0:
+        rejected: Final = timeout is not None and not (math.isfinite(timeout) and timeout > 0)
+        if rejected:
             verbose_proxy_logger.warning(
-                "Headroom: ignoring non-positive timeout %s, using %s seconds",
+                "Headroom: ignoring unusable timeout %s, using %s seconds",
                 timeout,
                 _COMPRESS_TIMEOUT_SECONDS,
             )
-        seconds: Final = _COMPRESS_TIMEOUT_SECONDS if timeout is None or timeout <= 0 else timeout
+        seconds: Final = _COMPRESS_TIMEOUT_SECONDS if timeout is None or rejected else timeout
         return httpx.Timeout(timeout=seconds, connect=min(seconds, HTTP_HANDLER_CONNECT_TIMEOUT_SECONDS))
 
     def update_in_memory_litellm_params(self, litellm_params: LitellmParams) -> None:
-        """Re-resolve the timeout after an in-place guardrail update.
-
-        The base implementation copies every LitellmParams attribute onto the
-        guardrail, so an unset timeout would overwrite the resolved httpx.Timeout
-        with None and put the compress call back on the shared client's 600s. No
-        route reaches this today (guardrail updates rebuild the instance through
-        ``reinitialize_guardrail``), so this guards the method's own contract for
-        whoever calls it next.
-        """
+        """Re-resolve the timeout, which the base implementation would otherwise null out."""
         super().update_in_memory_litellm_params(litellm_params)
         self.timeout = self._resolve_timeout(litellm_params.timeout)
 

--- a/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
@@ -15,6 +15,7 @@ from pydantic import TypeAdapter
 import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.compression.compress import get_protected_indices
+from litellm.constants import HTTP_HANDLER_CONNECT_TIMEOUT_SECONDS
 from litellm.integrations.custom_guardrail import (
     CustomGuardrail,
     log_guardrail_information,
@@ -47,12 +48,23 @@ from litellm.types.utils import CallTypes, GenericGuardrailAPIInputs
 
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+    from litellm.types.guardrails import LitellmParams
     from litellm.types.proxy.guardrails.guardrail_hooks.base import GuardrailConfigModel
 
 BYPASS_HEADER: Final = "x-headroom-bypass"
 _STREAM_CONVERTIBLE_CALL_TYPES: Final = frozenset(
     (CallTypes.completion, CallTypes.acompletion, CallTypes.responses, CallTypes.aresponses)
 )
+# Default budget for a call to the compression service. The shared GuardrailCallback
+# client is built with no params, so its read/write/pool legs are 600s (or
+# litellm.request_timeout when that is set explicitly, which defaults to 6000s). That
+# is far too long for a pre-call guardrail: a stalled service holds the caller's
+# request open for the whole window instead of reaching unreachable_fallback, and
+# because that client is shared with every other no-params guardrail, each stalled
+# call also holds a pooled connection for the same window, so once the pool saturates
+# unrelated requests block on the pool leg too. Overridable per guardrail with
+# `timeout` in litellm_params.
+_COMPRESS_TIMEOUT_SECONDS: Final = 60.0
 HEADROOM_RETRIEVE_TOOL_NAME: Final = "headroom_retrieve"
 _HASH_PATTERN: Final = re.compile(r"hash=([a-f0-9]{24})")
 _HASH_CACHE_TTL_SECONDS: Final = 15 * 60
@@ -472,6 +484,7 @@ class HeadroomGuardrail(CustomGuardrail):
         event_hook: GuardrailEventHooks | list[GuardrailEventHooks] | Mode | None = None,
         default_on: bool = False,
         unreachable_fallback: str | None = None,
+        timeout: float | None = None,
     ):
         self.headroom_api_base = (api_base or get_secret_str("HEADROOM_API_BASE") or "").rstrip("/")
         if not self.headroom_api_base:
@@ -484,6 +497,7 @@ class HeadroomGuardrail(CustomGuardrail):
         self.unreachable_fallback: Literal["fail_closed", "fail_open"] = (
             "fail_open" if unreachable_fallback == "fail_open" else "fail_closed"
         )
+        self.timeout: httpx.Timeout = self._resolve_timeout(timeout)
         self.async_handler = get_async_httpx_client(
             llm_provider=httpxSpecialProvider.GuardrailCallback,
         )
@@ -510,6 +524,39 @@ class HeadroomGuardrail(CustomGuardrail):
         if self.headroom_api_key:
             headers["Authorization"] = f"Bearer {self.headroom_api_key}"
         return headers
+
+    @staticmethod
+    def _resolve_timeout(timeout: float | None) -> httpx.Timeout:
+        """Budget for one call to the compression service, unset meaning the default.
+
+        A non-positive value is rejected rather than passed through: httpx accepts it
+        and the aiohttp transport then reads 0 as "no deadline" (restoring the
+        unbounded stall this bound exists to prevent) and a negative one as a deadline
+        already in the past, which fails every call instantly. The connect leg is
+        clamped to the budget so a short one is honored end to end rather than
+        spending the http_handler default on connect alone.
+        """
+        if timeout is not None and timeout <= 0:
+            verbose_proxy_logger.warning(
+                "Headroom: ignoring non-positive timeout %s, using %s seconds",
+                timeout,
+                _COMPRESS_TIMEOUT_SECONDS,
+            )
+        seconds: Final = _COMPRESS_TIMEOUT_SECONDS if timeout is None or timeout <= 0 else timeout
+        return httpx.Timeout(timeout=seconds, connect=min(seconds, HTTP_HANDLER_CONNECT_TIMEOUT_SECONDS))
+
+    def update_in_memory_litellm_params(self, litellm_params: LitellmParams) -> None:
+        """Re-resolve the timeout after an in-place guardrail update.
+
+        The base implementation copies every LitellmParams attribute onto the
+        guardrail, so an unset timeout would overwrite the resolved httpx.Timeout
+        with None and put the compress call back on the shared client's 600s. No
+        route reaches this today (guardrail updates rebuild the instance through
+        ``reinitialize_guardrail``), so this guards the method's own contract for
+        whoever calls it next.
+        """
+        super().update_in_memory_litellm_params(litellm_params)
+        self.timeout = self._resolve_timeout(litellm_params.timeout)
 
     def _prune_expired_hashes(self) -> None:
         now: Final = time.monotonic()
@@ -548,6 +595,7 @@ class HeadroomGuardrail(CustomGuardrail):
                 url=f"{self.headroom_api_base}/v1/compress",
                 json=payload,
                 headers=self._request_headers(),
+                timeout=self.timeout,
             )
         except httpx.HTTPStatusError as e:
             return (
@@ -685,6 +733,7 @@ class HeadroomGuardrail(CustomGuardrail):
                 url=f"{self.headroom_api_base}/v1/retrieve/{hash_value}",
                 params=params,
                 headers=self._request_headers(),
+                timeout=self.timeout,
             )
         except (httpx.ConnectError, httpx.TimeoutException, httpx.TransportError, litellm.Timeout) as e:
             verbose_proxy_logger.warning("Headroom: retrieve failed for hash=%s: %s", hash_value, e)

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_headroom.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_headroom.py
@@ -2732,3 +2732,174 @@ async def test_chat_followup_echoes_only_the_retrieve_call(guardrail: HeadroomGu
     assert assistant["content"] == "Getting the original first."
     assert [tc["id"] for tc in assistant["tool_calls"]] == ["call_1"]
     assert [m["tool_call_id"] for m in messages[2:]] == ["call_1"]
+
+
+# --- LIT-5881: the calls to the compression service must be time-bounded ---
+
+
+def _timeout_of(mock_call) -> httpx.Timeout:
+    timeout = mock_call.kwargs["timeout"]
+    assert isinstance(timeout, httpx.Timeout), timeout
+    return timeout
+
+
+@pytest.mark.asyncio
+async def test_compress_call_passes_bounded_timeout(guardrail: HeadroomGuardrail):
+    """Regression test: /v1/compress must carry an explicit timeout.
+
+    Without one the call inherits the shared GuardrailCallback client, whose read
+    timeout is 600s (or litellm.request_timeout when set), so a stalled Headroom
+    service holds the caller's request open for the whole window instead of
+    hitting unreachable_fallback.
+    """
+    inputs = GenericGuardrailAPIInputs(texts=["A" * 5000], structured_messages=ORIGINAL_MESSAGES)
+
+    with patch.object(
+        guardrail.async_handler,
+        "post",
+        new_callable=AsyncMock,
+        return_value=_make_compress_response(COMPRESSED_MESSAGES),
+    ) as mock_post:
+        await guardrail.apply_guardrail(inputs=inputs, request_data={}, input_type="request")
+
+    timeout = _timeout_of(mock_post.call_args)
+    assert timeout.read == 60.0
+    assert timeout.write == 60.0
+    assert timeout.pool == 60.0
+    # The connect leg keeps the http_handler default so an unroutable host still
+    # fails in 5s rather than waiting out the read budget.
+    assert timeout.connect == 5.0
+
+
+@pytest.mark.asyncio
+async def test_retrieve_call_passes_bounded_timeout(guardrail: HeadroomGuardrail):
+    """The retrieval leg runs on the same request and needs the same bound."""
+    with patch.object(
+        guardrail.async_handler,
+        "get",
+        new_callable=AsyncMock,
+        return_value=_make_retrieve_response("original"),
+    ) as mock_get:
+        result = await guardrail._call_retrieve("a" * 24)
+
+    assert result == "original"
+    timeout = _timeout_of(mock_get.call_args)
+    assert timeout.read == 60.0
+    assert timeout.connect == 5.0
+
+
+@pytest.mark.asyncio
+async def test_configured_timeout_overrides_the_default():
+    """litellm_params.timeout is documented as the per-request guardrail timeout;
+    Headroom previously accepted it and ignored it."""
+    guardrail = _make_guardrail(timeout=3.5)
+    inputs = GenericGuardrailAPIInputs(texts=["A" * 5000], structured_messages=ORIGINAL_MESSAGES)
+
+    with patch.object(
+        guardrail.async_handler,
+        "post",
+        new_callable=AsyncMock,
+        return_value=_make_compress_response(COMPRESSED_MESSAGES),
+    ) as mock_post:
+        await guardrail.apply_guardrail(inputs=inputs, request_data={}, input_type="request")
+
+    timeout = _timeout_of(mock_post.call_args)
+    assert timeout.read == 3.5
+    # A configured budget shorter than the connect default shrinks the connect leg
+    # too, so the whole call still fits inside what the admin asked for.
+    assert timeout.connect == 3.5
+
+
+@pytest.mark.asyncio
+async def test_read_timeout_is_surfaced_as_unreachable_under_fail_closed():
+    """A stalled service must reach the fail policy, not escape as a 500."""
+    guardrail = _make_guardrail()
+    inputs = GenericGuardrailAPIInputs(texts=["hello"], structured_messages=ORIGINAL_MESSAGES)
+
+    with patch.object(
+        guardrail.async_handler,
+        "post",
+        new_callable=AsyncMock,
+        side_effect=httpx.ReadTimeout("timed out"),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await guardrail.apply_guardrail(inputs=inputs, request_data={}, input_type="request")
+
+    assert exc_info.value.status_code == 502
+    assert "unreachable" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_read_timeout_forwards_uncompressed_under_fail_open():
+    guardrail = _make_guardrail(unreachable_fallback="fail_open")
+    inputs = GenericGuardrailAPIInputs(texts=["hello"], structured_messages=ORIGINAL_MESSAGES)
+
+    with patch.object(
+        guardrail.async_handler,
+        "post",
+        new_callable=AsyncMock,
+        side_effect=httpx.ReadTimeout("timed out"),
+    ):
+        result = await guardrail.apply_guardrail(inputs=inputs, request_data={}, input_type="request")
+
+    assert result.get("structured_messages") == ORIGINAL_MESSAGES
+
+
+def test_initializer_forwards_configured_timeout(monkeypatch: pytest.MonkeyPatch):
+    """The config value has to reach the guardrail; wiring it only in __init__
+    leaves `timeout:` in config.yaml silently ignored."""
+    from litellm.proxy.guardrails.guardrail_hooks.headroom import initialize_guardrail
+    from litellm.types.guardrails import LitellmParams
+
+    monkeypatch.setattr(
+        litellm.logging_callback_manager,
+        "add_litellm_callback",
+        lambda callback: None,
+    )
+    params = LitellmParams(
+        guardrail="headroom",
+        mode="pre_call",
+        api_base=FAKE_API_BASE,
+        api_key=FAKE_API_KEY,
+        timeout=7.0,
+    )
+    callback = initialize_guardrail(params, {"guardrail_name": "headroom"})  # type: ignore[arg-type]
+
+    assert callback.timeout.read == 7.0
+
+
+def test_in_place_update_keeps_the_timeout_resolved():
+    """Regression: CustomGuardrail.update_in_memory_litellm_params copies every
+    LitellmParams attribute onto the guardrail, so an unset timeout would replace
+    the resolved httpx.Timeout with None and put the compress call back on the
+    shared client's 600s."""
+    from litellm.types.guardrails import LitellmParams
+
+    guardrail = _make_guardrail(timeout=5.0)
+    assert guardrail.timeout.read == 5.0
+
+    guardrail.update_in_memory_litellm_params(
+        LitellmParams(guardrail="headroom", mode="pre_call", api_base=FAKE_API_BASE)
+    )
+    assert isinstance(guardrail.timeout, httpx.Timeout)
+    assert guardrail.timeout.read == 60.0
+
+    guardrail.update_in_memory_litellm_params(
+        LitellmParams(guardrail="headroom", mode="pre_call", api_base=FAKE_API_BASE, timeout=7.0)
+    )
+    assert guardrail.timeout.read == 7.0
+
+
+@pytest.mark.parametrize("configured", [0, 0.0, -1, -30.0])
+def test_non_positive_timeout_falls_back_to_the_default(configured: float):
+    """A non-positive budget must not reach httpx.
+
+    Under the default aiohttp transport 0 means "no deadline", which restores the
+    unbounded stall this bound exists to prevent, and a negative one is a deadline
+    already in the past, so every compress call fails instantly and fail_closed
+    turns that into a 502 on every request.
+    """
+    guardrail = _make_guardrail(timeout=configured)
+
+    assert guardrail.timeout.read == 60.0
+    assert guardrail.timeout.connect == 5.0

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_headroom.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_headroom.py
@@ -1694,8 +1694,6 @@ async def test_apply_guardrail_litellm_timeout_fail_open_forwards_uncompressed()
     assert result["structured_messages"] == ORIGINAL_MESSAGES
 
 
-
-
 # ---------------------------------------------------------------------------
 # Content-parts flattening (LIT-4795)
 #
@@ -2669,7 +2667,9 @@ async def _plan_for(guardrail: HeadroomGuardrail, response, messages: list):
         return_value=_make_retrieve_response("ORIGINAL CONTENT"),
     ):
         return await guardrail.async_build_agentic_loop_plan(
-            tools={"tool_calls": [{"id": "call_1", "name": HEADROOM_RETRIEVE_TOOL_NAME, "arguments": {"hash": "h" * 24}}]},
+            tools={
+                "tool_calls": [{"id": "call_1", "name": HEADROOM_RETRIEVE_TOOL_NAME, "arguments": {"hash": "h" * 24}}]
+            },
             model="claude-sonnet-4-5-20250929",
             messages=messages,
             response=response,
@@ -2745,13 +2745,7 @@ def _timeout_of(mock_call) -> httpx.Timeout:
 
 @pytest.mark.asyncio
 async def test_compress_call_passes_bounded_timeout(guardrail: HeadroomGuardrail):
-    """Regression test: /v1/compress must carry an explicit timeout.
-
-    Without one the call inherits the shared GuardrailCallback client, whose read
-    timeout is 600s (or litellm.request_timeout when set), so a stalled Headroom
-    service holds the caller's request open for the whole window instead of
-    hitting unreachable_fallback.
-    """
+    """Without an explicit timeout the call inherits the shared client's 600s read leg."""
     inputs = GenericGuardrailAPIInputs(texts=["A" * 5000], structured_messages=ORIGINAL_MESSAGES)
 
     with patch.object(
@@ -2766,8 +2760,6 @@ async def test_compress_call_passes_bounded_timeout(guardrail: HeadroomGuardrail
     assert timeout.read == 60.0
     assert timeout.write == 60.0
     assert timeout.pool == 60.0
-    # The connect leg keeps the http_handler default so an unroutable host still
-    # fails in 5s rather than waiting out the read budget.
     assert timeout.connect == 5.0
 
 
@@ -2790,8 +2782,7 @@ async def test_retrieve_call_passes_bounded_timeout(guardrail: HeadroomGuardrail
 
 @pytest.mark.asyncio
 async def test_configured_timeout_overrides_the_default():
-    """litellm_params.timeout is documented as the per-request guardrail timeout;
-    Headroom previously accepted it and ignored it."""
+    """Headroom accepted litellm_params.timeout and ignored it."""
     guardrail = _make_guardrail(timeout=3.5)
     inputs = GenericGuardrailAPIInputs(texts=["A" * 5000], structured_messages=ORIGINAL_MESSAGES)
 
@@ -2805,8 +2796,6 @@ async def test_configured_timeout_overrides_the_default():
 
     timeout = _timeout_of(mock_post.call_args)
     assert timeout.read == 3.5
-    # A configured budget shorter than the connect default shrinks the connect leg
-    # too, so the whole call still fits inside what the admin asked for.
     assert timeout.connect == 3.5
 
 
@@ -2846,8 +2835,7 @@ async def test_read_timeout_forwards_uncompressed_under_fail_open():
 
 
 def test_initializer_forwards_configured_timeout(monkeypatch: pytest.MonkeyPatch):
-    """The config value has to reach the guardrail; wiring it only in __init__
-    leaves `timeout:` in config.yaml silently ignored."""
+    """Wiring it only in __init__ leaves `timeout:` in config.yaml silently ignored."""
     from litellm.proxy.guardrails.guardrail_hooks.headroom import initialize_guardrail
     from litellm.types.guardrails import LitellmParams
 
@@ -2869,10 +2857,7 @@ def test_initializer_forwards_configured_timeout(monkeypatch: pytest.MonkeyPatch
 
 
 def test_in_place_update_keeps_the_timeout_resolved():
-    """Regression: CustomGuardrail.update_in_memory_litellm_params copies every
-    LitellmParams attribute onto the guardrail, so an unset timeout would replace
-    the resolved httpx.Timeout with None and put the compress call back on the
-    shared client's 600s."""
+    """The base implementation copies every attribute over, nulling an unset timeout."""
     from litellm.types.guardrails import LitellmParams
 
     guardrail = _make_guardrail(timeout=5.0)
@@ -2890,15 +2875,9 @@ def test_in_place_update_keeps_the_timeout_resolved():
     assert guardrail.timeout.read == 7.0
 
 
-@pytest.mark.parametrize("configured", [0, 0.0, -1, -30.0])
-def test_non_positive_timeout_falls_back_to_the_default(configured: float):
-    """A non-positive budget must not reach httpx.
-
-    Under the default aiohttp transport 0 means "no deadline", which restores the
-    unbounded stall this bound exists to prevent, and a negative one is a deadline
-    already in the past, so every compress call fails instantly and fail_closed
-    turns that into a 502 on every request.
-    """
+@pytest.mark.parametrize("configured", [0, 0.0, -1, -30.0, float("inf"), float("-inf"), float("nan")])
+def test_unusable_timeout_falls_back_to_the_default(configured: float):
+    """0 and inf read as no deadline at all, a negative one as a deadline already past."""
     guardrail = _make_guardrail(timeout=configured)
 
     assert guardrail.timeout.read == 60.0


### PR DESCRIPTION
## TLDR

Problem this solves:

- Headroom's compress call had no timeout, so a stalled service froze requests
- The proxy hung about ten minutes per request before returning a 502
- A `timeout` set on a Headroom guardrail was accepted and silently ignored

How it solves it:

- Bound both calls to the Headroom service at 60 seconds by default
- Honor `timeout` in the guardrail's `litellm_params` when set
- Keep the connect leg short so a dead host still fails fast

## User Flow

Before: an admin turns on Headroom prompt compression, the compression service becomes unreachable, and every chat request hangs for ten minutes before failing.

1. The admin adds a Headroom guardrail on https://litellm-domain/ui/?page=guardrails pointing at their Headroom service
2. Their network starts dropping traffic to that service, so it accepts connections and never replies
3. A developer sends POST https://litellm-domain/v1/chat/completions
4. The request hangs for 600 seconds with nothing returned
5. After 600 seconds it fails with `502 Headroom compression service unreachable`
6. Every retry costs another ten minutes, and the same happens on /v1/messages and /v1/responses
7. Setting `timeout: 5` on the guardrail changes nothing, the request still takes 600 seconds
8. In https://litellm-domain/ui/?page=llm-playground the reply spinner is still turning thirteen minutes after the developer hit send

After: the same request fails in one minute instead of ten, and the admin can make it fail sooner.

1. The admin adds the same Headroom guardrail on https://litellm-domain/ui/?page=guardrails
2. Their network starts dropping traffic to that service, so it accepts connections and never replies
3. A developer sends POST https://litellm-domain/v1/chat/completions
4. The request fails after 60 seconds with `502 Headroom compression service unreachable`
5. The admin sets `timeout: 5` on the guardrail and the same request now fails in 5 seconds
6. With `unreachable_fallback: fail_open` the developer gets a normal answer in https://litellm-domain/ui/?page=llm-playground after about a minute instead of waiting out the ten

## Relevant issues

## Linear ticket

Resolves LIT-5881

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Real OpenAI keys, real Postgres, real Admin UI, and a real HTTP listener standing in for the customer's unreachable Headroom service. No mocks anywhere.

1. Start a listener that accepts the connection and never answers, which is what a stalled service looks like on the wire

```bash
cat > headroom_stub.py <<'PY'
import time
from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
class H(BaseHTTPRequestHandler):
    protocol_version = "HTTP/1.1"
    def do_POST(self):
        self.rfile.read(int(self.headers.get("Content-Length") or 0))
        time.sleep(900)
    def do_GET(self):
        time.sleep(900)
ThreadingHTTPServer(("127.0.0.1", 18881), H).serve_forever()
PY
python headroom_stub.py &
```

2. Write the base config. The three variants below add one line each under `litellm_params`: `timeout: 5`, `timeout: .inf`, and `unreachable_fallback: fail_open`

```bash
cat > config_5881.yaml <<'YAML'
model_list:
  - model_name: gpt-4.1-mini
    litellm_params:
      model: openai/gpt-4.1-mini
      api_key: os.environ/OPENAI_API_KEY

guardrails:
  - guardrail_name: headroom-compression
    litellm_params:
      guardrail: headroom
      mode: pre_call
      default_on: true
      api_base: http://127.0.0.1:18881
      api_key: sk-headroom-stub

general_settings:
  master_key: sk-1234
YAML
```

3. Run one proxy per config variant on each side against the same Postgres, base checked out at d23bec84c4 and head at a1c6d8805a

```bash
# base, d23bec84c4
litellm --config config_5881.yaml         --port 20886 --detailed_debug --use_prisma_db_push
litellm --config config_timeout5.yaml     --port 20890 --detailed_debug --use_prisma_db_push
litellm --config config_timeoutinf.yaml   --port 20897 --detailed_debug --use_prisma_db_push
litellm --config config_failopen.yaml     --port 20886 --detailed_debug --use_prisma_db_push
# head, a1c6d8805a
litellm --config config_5881.yaml         --port 20887 --detailed_debug --use_prisma_db_push
litellm --config config_timeout5.yaml     --port 20891 --detailed_debug --use_prisma_db_push
litellm --config config_timeoutinf.yaml   --port 20898 --detailed_debug --use_prisma_db_push
litellm --config config_failopen.yaml     --port 20902 --detailed_debug --use_prisma_db_push
```

### Before (d23bec84c4)

#### chat (/v1/chat/completions)

1. Send a conversation long enough for Headroom to compress

```bash
curl -sS -m 700 -w '\nSTATUS=%{http_code}\nTIME=%{time_total}\n' http://127.0.0.1:20886/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"gpt-4.1-mini","messages":[{"role":"system","content":"You are a helpful assistant."},{"role":"user","content":"What is 2+2? Reply with just the number."},{"role":"assistant","content":"4"},{"role":"user","content":"And 3+3?"}]}'
```

2. It hangs for ten minutes, then fails

```
{"error":{"message":"Headroom compression service unreachable","type":"None","param":"None","code":"502","provider_specific_fields":{"error":"Headroom compression service unreachable","detail":"litellm.Timeout: Connection timed out. Timeout passed=Timeout(connect=5.0, read=600.0, write=600.0, pool=600.0), time taken=600.105 seconds","guardrail_name":"headroom-compression","guardrail_mode":"pre_call"}}}
STATUS=502
TIME=601.625196
```

#### messages (/v1/messages)

1. Same conversation through the Anthropic Messages route

```bash
curl -sS -m 700 -w '\nSTATUS=%{http_code}\nTIME=%{time_total}\n' http://127.0.0.1:20886/v1/messages \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"gpt-4.1-mini","max_tokens":32,"messages":[{"role":"user","content":"What is 2+2? Reply with just the number."},{"role":"assistant","content":"4"},{"role":"user","content":"And 3+3?"}]}'
```

2. Same ten minute hang

```
STATUS=502
TIME=601.620339
```

#### responses (/v1/responses)

1. Same conversation through the Responses route

```bash
curl -sS -m 700 -w '\nSTATUS=%{http_code}\nTIME=%{time_total}\n' http://127.0.0.1:20886/v1/responses \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"gpt-4.1-mini","input":[{"role":"user","content":"What is 2+2? Reply with just the number."},{"role":"assistant","content":"4"},{"role":"user","content":"And 3+3?"}]}'
```

2. Same ten minute hang

```
STATUS=502
TIME=601.584869
```

#### configured timeout (`timeout: 5`)

1. Send the same chat request to the proxy running the `timeout: 5` config

```bash
curl -sS -m 700 -w '\nSTATUS=%{http_code}\nTIME=%{time_total}\n' http://127.0.0.1:20890/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"gpt-4.1-mini","messages":[{"role":"system","content":"You are a helpful assistant."},{"role":"user","content":"What is 2+2? Reply with just the number."},{"role":"assistant","content":"4"},{"role":"user","content":"And 3+3?"}]}'
```

2. The setting is ignored, the call still runs the full ten minutes

```
"detail":"litellm.Timeout: Connection timed out. Timeout passed=Timeout(connect=5.0, read=600.0, write=600.0, pool=600.0), time taken=600.08 seconds"
STATUS=502
TIME=601.534021
```

#### unusable timeout (`timeout: .inf`)

1. Send the same chat request to the proxy running the `timeout: .inf` config

```bash
curl -sS -m 700 -w '\nSTATUS=%{http_code}\nTIME=%{time_total}\n' http://127.0.0.1:20897/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"gpt-4.1-mini","messages":[{"role":"system","content":"You are a helpful assistant."},{"role":"user","content":"What is 2+2? Reply with just the number."},{"role":"assistant","content":"4"},{"role":"user","content":"And 3+3?"}]}'
```

2. Also ignored, also ten minutes

```
"detail":"litellm.Timeout: Connection timed out. Timeout passed=Timeout(connect=5.0, read=600.0, write=600.0, pool=600.0), time taken=600.069 seconds"
STATUS=502
TIME=601.502054
```

#### Admin UI playground with `unreachable_fallback: fail_open`

1. Open http://127.0.0.1:20905/ui/?page=llm-playground, log in as admin, pick `gpt-4.1-mini`
2. Send "What is 2+2? Reply with just the number." and get "4" back in about a second
3. Send "And 3+3?", which now carries enough history for Headroom to compress
4. Thirteen minutes later the reply is still a spinner

![before](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr39527/lit5881/before-playground-v2.png)

#### healthy service control

1. Point the same config at a stub that answers normally and send the same chat request

```
STATUS=200
TIME=2.288669
```

### After (a1c6d8805a)

#### chat (/v1/chat/completions)

1. Same request against the fixed proxy

```bash
curl -sS -m 700 -w '\nSTATUS=%{http_code}\nTIME=%{time_total}\n' http://127.0.0.1:20887/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"gpt-4.1-mini","messages":[{"role":"system","content":"You are a helpful assistant."},{"role":"user","content":"What is 2+2? Reply with just the number."},{"role":"assistant","content":"4"},{"role":"user","content":"And 3+3?"}]}'
```

2. It fails in one minute instead of ten

```
{"error":{"message":"Headroom compression service unreachable","type":"None","param":"None","code":"502","provider_specific_fields":{"error":"Headroom compression service unreachable","detail":"litellm.Timeout: Connection timed out. Timeout passed=Timeout(connect=5.0, read=60.0, write=60.0, pool=60.0), time taken=60.085 seconds","guardrail_name":"headroom-compression","guardrail_mode":"pre_call"}}}
STATUS=502
TIME=61.202093
```

#### messages (/v1/messages)

1. Same conversation through the Anthropic Messages route

```bash
curl -sS -m 700 -w '\nSTATUS=%{http_code}\nTIME=%{time_total}\n' http://127.0.0.1:20887/v1/messages \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"gpt-4.1-mini","max_tokens":32,"messages":[{"role":"user","content":"What is 2+2? Reply with just the number."},{"role":"assistant","content":"4"},{"role":"user","content":"And 3+3?"}]}'
```

2. Bounded the same way

```
STATUS=502
TIME=61.271588
```

#### responses (/v1/responses)

1. Same conversation through the Responses route

```bash
curl -sS -m 700 -w '\nSTATUS=%{http_code}\nTIME=%{time_total}\n' http://127.0.0.1:20887/v1/responses \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"gpt-4.1-mini","input":[{"role":"user","content":"What is 2+2? Reply with just the number."},{"role":"assistant","content":"4"},{"role":"user","content":"And 3+3?"}]}'
```

2. Bounded the same way

```
STATUS=502
TIME=61.247184
```

#### configured timeout (`timeout: 5`)

1. Same chat request against the `timeout: 5` proxy

```bash
curl -sS -m 700 -w '\nSTATUS=%{http_code}\nTIME=%{time_total}\n' http://127.0.0.1:20891/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"gpt-4.1-mini","messages":[{"role":"system","content":"You are a helpful assistant."},{"role":"user","content":"What is 2+2? Reply with just the number."},{"role":"assistant","content":"4"},{"role":"user","content":"And 3+3?"}]}'
```

2. The setting is now honored

```
"detail":"litellm.Timeout: Connection timed out. Timeout passed=Timeout(timeout=5.0), time taken=5.018 seconds"
STATUS=502
TIME=5.457379
```

#### unusable timeout (`timeout: .inf`)

1. Same chat request against the `timeout: .inf` proxy

```bash
curl -sS -m 700 -w '\nSTATUS=%{http_code}\nTIME=%{time_total}\n' http://127.0.0.1:20898/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"gpt-4.1-mini","messages":[{"role":"system","content":"You are a helpful assistant."},{"role":"user","content":"What is 2+2? Reply with just the number."},{"role":"assistant","content":"4"},{"role":"user","content":"And 3+3?"}]}'
```

2. The value is refused and the 60 second default applies, with the reason in the proxy log

```
STATUS=502
TIME=61.248796
```

```
Headroom: ignoring unusable timeout inf, using 60.0 seconds
```

#### Admin UI playground with `unreachable_fallback: fail_open`

1. Open http://127.0.0.1:20902/ui/?page=llm-playground, log in as admin, pick `gpt-4.1-mini`
2. Send "What is 2+2? Reply with just the number." and get "4" back
3. Send "And 3+3?", which now carries enough history for Headroom to compress
4. The real OpenAI answer arrives at 60.86s instead of never

![after](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr39527/lit5881/after-playground-v2.png)

#### healthy service control

1. Point the same config at a stub that answers normally and send the same chat request

```
STATUS=200
TIME=1.678830
```

## Type

🐛 Bug Fix

## Caveats (if any)

### Severe

- Compress calls over 60s now fail where they used to succeed, so a slow but healthy service needs `timeout` raised before rollout

### Medium

- `timeout` on a Headroom guardrail was ignored before and now applies
- A `litellm_settings: request_timeout` below 60 used to bound the compress call and no longer does, so set `timeout` on the guardrail to keep the old ceiling
- Agentic loop plans call `/v1/retrieve` once per hash, so a stalled service still costs 60s per hash

### Low

- A service that trickles bytes stays unbounded, the same as before this PR
- A `timeout` under 5 shrinks the connect leg to match, so a slow-to-connect host fails sooner
- `timeout` is config and API only, it is not in the Admin UI guardrail form
- Removing a Headroom guardrail from `config.yaml` still needs a restart

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

ran /live-pr-risk and found no regressions/backward incompatible risks
