### PR TITLE
build(otel): ship the b3 propagator so OTEL_PROPAGATORS can name it

### DIFF
--- a/litellm/integrations/otel/README.md
+++ b/litellm/integrations/otel/README.md
@@ -70,8 +70,17 @@ matching the FastAPI server span); only a genuine error sets `ERROR`.
 
 - **Server spans** (one per HTTP route) are created by the
   `opentelemetry-instrumentation-fastapi` package. It stamps `http.*` attributes
-  and extracts inbound `traceparent` headers. This package does **not** create
-  or modify server spans — request routes never touch spans.
+  and extracts inbound trace context. Which formats a caller can join a trace
+  with is the operator's choice, set the standard way with `OTEL_PROPAGATORS`:
+  it defaults to `tracecontext,baggage` (W3C `traceparent`), and a caller
+  propagating Zipkin B3 needs `b3` (single header) or `b3multi` (`X-B3-*`)
+  added, e.g. `OTEL_PROPAGATORS=tracecontext,b3multi`. The
+  `opentelemetry-propagator-b3` package ships with the proxy, so naming `b3` or
+  `b3multi` is safe. Naming one that is *not* installed is worse than a typo: OTel
+  raises while loading the propagators, `mount.py` swallows it as a failed
+  instrumentation attempt, and the proxy serves traffic with no server spans at
+  all, saying so only at debug level. This package does **not** create or modify
+  server spans — request routes never touch spans.
 - **Gen-AI spans** (LLM calls, guardrails, internal service calls) are created
   by this package from LiteLLM's logging callbacks. Request-level spans parent to
   the server span via the captured anchor; DB/service spans parent to the active

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,6 +156,7 @@ proxy-runtime = [
     "opentelemetry-sdk==1.28.0",
     "opentelemetry-exporter-otlp==1.28.0",
     "opentelemetry-instrumentation-fastapi==0.49b0",
+    "opentelemetry-propagator-b3==1.28.0",
     "ddtrace>=4.8.2,<5.0",
     "sentry-sdk>=2.21.0,<3.0",
     "mangum>=0.17.0,<1.0",
@@ -200,6 +201,7 @@ dev = [
     "opentelemetry-sdk==1.28.0",
     "opentelemetry-exporter-otlp==1.28.0",
     "opentelemetry-instrumentation-fastapi==0.49b0",
+    "opentelemetry-propagator-b3==1.28.0",
     "langfuse==2.59.7",
     "fastapi-offline==1.7.6",
     "fakeredis==2.34.1",
@@ -225,6 +227,7 @@ proxy-dev = [
     "opentelemetry-sdk==1.28.0",
     "opentelemetry-exporter-otlp==1.28.0",
     "opentelemetry-instrumentation-fastapi==0.49b0",
+    "opentelemetry-propagator-b3==1.28.0",
     "azure-identity==1.25.2",
     "a2a-sdk==1.1.0",
 ]

--- a/tests/test_litellm/integrations/otel/test_otel_v2_mount.py
+++ b/tests/test_litellm/integrations/otel/test_otel_v2_mount.py
@@ -96,6 +96,40 @@ def test_instrumented_app_emits_server_span():
     assert any("route" in k or "method" in k for k in attrs)
 
 
+def test_server_span_joins_caller_trace_from_b3_headers():
+    """Which formats a caller can join a trace with is the operator's choice
+    (OTEL_PROPAGATORS); the instrumentor reads whatever is configured. The b3
+    propagator ships with the proxy, so naming it does not break startup."""
+    from opentelemetry.propagate import get_global_textmap, set_global_textmap
+    from opentelemetry.propagators.b3 import B3MultiFormat
+    from opentelemetry.propagators.composite import CompositePropagator
+
+    trace_id, span_id = "80f198ee56343ba864fe8b2a57d3eff7", "e457b5a2e4d86bd1"
+    app, logger = _instrumented_app()
+    exporter = InMemorySpanExporter()
+    logger._tracer_provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    previous = get_global_textmap()
+    set_global_textmap(CompositePropagator([B3MultiFormat()]))
+    try:
+        TestClient(app).get(
+            "/ping",
+            headers={
+                "X-B3-TraceId": trace_id,
+                "X-B3-SpanId": span_id,
+                "X-B3-Sampled": "1",
+            },
+        )
+    finally:
+        set_global_textmap(previous)
+
+    server_span = next(
+        s for s in exporter.get_finished_spans() if s.kind is SpanKind.SERVER
+    )
+    assert format(server_span.context.trace_id, "032x") == trace_id
+    assert format(server_span.parent.span_id, "016x") == span_id
+
+
 def test_logger_and_instrumentor_share_provider():
     """Gen-ai spans (logger) and server spans (instrumentor) write to one provider."""
     _, logger = _instrumented_app()

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-08-30T17:51:25.171404Z"
+exclude-newer = "2026-08-31T09:46:06.3307294Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -4371,6 +4371,7 @@ proxy-runtime = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp" },
     { name = "opentelemetry-instrumentation-fastapi" },
+    { name = "opentelemetry-propagator-b3" },
     { name = "opentelemetry-sdk" },
     { name = "prometheus-client" },
     { name = "pypdf" },
@@ -4436,6 +4437,7 @@ dev = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp" },
     { name = "opentelemetry-instrumentation-fastapi" },
+    { name = "opentelemetry-propagator-b3" },
     { name = "opentelemetry-sdk" },
     { name = "parameterized" },
     { name = "psycopg" },
@@ -4477,6 +4479,7 @@ proxy-dev = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp" },
     { name = "opentelemetry-instrumentation-fastapi" },
+    { name = "opentelemetry-propagator-b3" },
     { name = "opentelemetry-sdk" },
     { name = "prisma" },
     { name = "prometheus-client" },
@@ -4541,6 +4544,7 @@ requires-dist = [
     { name = "opentelemetry-api", marker = "extra == 'proxy-runtime'", specifier = "==1.28.0" },
     { name = "opentelemetry-exporter-otlp", marker = "extra == 'proxy-runtime'", specifier = "==1.28.0" },
     { name = "opentelemetry-instrumentation-fastapi", marker = "extra == 'proxy-runtime'", specifier = "==0.49b0" },
+    { name = "opentelemetry-propagator-b3", marker = "extra == 'proxy-runtime'", specifier = "==1.28.0" },
     { name = "opentelemetry-sdk", marker = "extra == 'proxy-runtime'", specifier = "==1.28.0" },
     { name = "orjson", marker = "extra == 'proxy'", specifier = ">=3.11.6,<4.0" },
     { name = "polars", marker = "extra == 'proxy'", specifier = ">=1.38.1,<2.0" },
@@ -4621,6 +4625,7 @@ dev = [
     { name = "opentelemetry-api", specifier = "==1.28.0" },
     { name = "opentelemetry-exporter-otlp", specifier = "==1.28.0" },
     { name = "opentelemetry-instrumentation-fastapi", specifier = "==0.49b0" },
+    { name = "opentelemetry-propagator-b3", specifier = "==1.28.0" },
     { name = "opentelemetry-sdk", specifier = "==1.28.0" },
     { name = "parameterized", specifier = "==0.9.0" },
     { name = "psycopg", specifier = "==3.3.3" },
@@ -4662,6 +4667,7 @@ proxy-dev = [
     { name = "opentelemetry-api", specifier = "==1.28.0" },
     { name = "opentelemetry-exporter-otlp", specifier = "==1.28.0" },
     { name = "opentelemetry-instrumentation-fastapi", specifier = "==0.49b0" },
+    { name = "opentelemetry-propagator-b3", specifier = "==1.28.0" },
     { name = "opentelemetry-sdk", specifier = "==1.28.0" },
     { name = "prisma", specifier = "==0.11.0" },
     { name = "prometheus-client", specifier = "==0.20.0" },
@@ -6360,6 +6366,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1d/50/38b46f295c4f28301d6aea15aeddcbc9550bb51a005da95045310549191f/opentelemetry_instrumentation_weaviate-0.33.12.tar.gz", hash = "sha256:1d14949e2123e5a2bd0eb149d8281713b33623d3f09f7aa587d4fca130d11b70", size = 4635, upload-time = "2024-11-13T20:28:27.189Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/28/e7/16d9a936d716af84546045fa62e593079069e14c667d049602b6e19d6e31/opentelemetry_instrumentation_weaviate-0.33.12-py3-none-any.whl", hash = "sha256:afa500e59bd7059495c6190decb1dd57dc620e17181c9543bd91e26afce74dcd", size = 6428, upload-time = "2024-11-13T20:27:48.71Z" },
+]
+
+[[package]]
+name = "opentelemetry-propagator-b3"
+version = "1.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecated" },
+    { name = "opentelemetry-api" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6f/1d/225ea036785119964509e92f4e1bc0313ba6ec790fbf51bd363abafeafae/opentelemetry_propagator_b3-1.28.0.tar.gz", hash = "sha256:cf6f0d2a1881c4858898be47e8a94b11bc5b16fc73b6c37ebfa2121c4825adc6", size = 9592, upload-time = "2024-11-05T19:14:57.193Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/fa/438d53d73a6c45df5d416b56dc371a65d0b07859bc107ab632349a079d4a/opentelemetry_propagator_b3-1.28.0-py3-none-any.whl", hash = "sha256:9f6923a5da56d7da6724e4fdd758a67ede2a2732efb929e538cf6fea337700c5", size = 8917, upload-time = "2024-11-05T19:14:37.317Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## TLDR

Problem this solves:

- B3-propagating callers cannot join the gateway's traces
- Setting `OTEL_PROPAGATORS=b3multi` silently costs every server span

How it solves it:

- Ships `opentelemetry-propagator-b3` in the otel dependency sets
- Documents the setting and its silent-skip failure mode

## User Flow

Before: a caller whose services propagate Zipkin B3 sees the gateway open an unrelated trace, so the LLM call cannot be reached from the calling service's trace

1. The operator sets `OTEL_PROPAGATORS=tracecontext,b3multi` and starts the proxy
2. The proxy serves traffic normally, but no request shows up in their tracing backend at all
3. Dropping that setting brings traces back, so the caller sends POST https://litellm-domain/v1/chat/completions with `X-B3-TraceId: 80f198ee56343ba864fe8b2a57d3eff7`, `X-B3-SpanId: e457b5a2e4d86bd1`, `X-B3-Sampled: 1`
4. The answer is normal, but the gateway's span carries a trace id nobody sent, and the calling service's trace still ends at its outbound call

After: the same headers put the gateway's span inside the caller's trace

1. The operator sets `OTEL_PROPAGATORS=tracecontext,b3multi` and starts the proxy
2. The caller sends the same POST with the same three `X-B3-*` headers
3. The answer is unchanged
4. Their tracing backend shows the gateway span inside trace `80f198ee56343ba864fe8b2a57d3eff7`, as a child of span `e457b5a2e4d86bd1`, so the LLM call is reachable from the calling service's trace

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup, both sides:

```bash
export ANTHROPIC_API_KEY=...
export LITELLM_OTEL_V2=1
export OTEL_PROPAGATORS=tracecontext,b3multi   # OTEL_EXPORTER defaults to console
yq -i '.litellm_settings.callbacks += ["otel"]' litellm/proxy/dev_config.yaml
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log
```

### Before (31ca4ddf3)

1. Start the proxy with the setup above; `grep -i "Skipping OTel V2 FastAPI instrumentation" litellm.log` prints the skip line, because `b3multi` is not installed
2. Send a request carrying B3 trace context:

```bash
curl -sS http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -H "X-B3-TraceId: 80f198ee56343ba864fe8b2a57d3eff7" \
  -H "X-B3-SpanId: e457b5a2e4d86bd1" -H "X-B3-Sampled: 1" \
  -d '{"model": "anthropic-sonnet-5", "messages": [{"role": "user", "content": "say b3"}]}'
```

3. The completion comes back, and `grep -c '"name": "POST /v1/chat/completions"' litellm.log` is 0: no server span was exported

### After (f785c3414)

1. Start the proxy with the same setup; the skip line is gone
2. Send the same request as above
3. The completion comes back, and the exported server span carries the caller's ids:

```bash
grep -A6 'POST /v1/chat/completions' litellm.log | grep -E "trace_id|parent_id"
# expect trace_id=0x80f198ee56343ba864fe8b2a57d3eff7 and parent_id=0xe457b5a2e4d86bd1
```

4. Repeat with `-H "traceparent: 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"` instead of the `X-B3-*` headers: the span joins that trace instead, so W3C callers are unaffected

## Type

📖 Documentation
🚄 Infrastructure
✅ Test

## Caveats (if any)

### Medium

- Opt-in: b3 is ignored until `OTEL_PROPAGATORS` names it
- Only applies with `LITELLM_OTEL_V2=1`, which mounts the instrumentation

### Low

- With V2 off, inbound b3 is still ignored everywhere
- Naming an uninstalled propagator drops all server spans silently

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
