### PR TITLE
fix(ui): prefill the key edit Organization picker from org_id

### DIFF
--- a/ui/litellm-dashboard/src/components/templates/keyEditFieldNormalizers.ts
+++ b/ui/litellm-dashboard/src/components/templates/keyEditFieldNormalizers.ts
@@ -9,6 +9,9 @@ const WORD_FORM_BUDGET_DURATIONS: Record<string, string> = {
 export const canonicalBudgetDuration = (duration: string | null | undefined): string | null =>
   duration ? WORD_FORM_BUDGET_DURATIONS[duration] ?? duration : null;
 
+export const keyOrganizationId = (key: { organization_id?: string | null; org_id?: string | null }): string | null =>
+  key.organization_id || key.org_id || null;
+
 // Determine the key_type display value from allowed_routes
 export const keyTypeFromRoutes = (allowedRoutes: string[] | null | undefined): string => {
   if (!allowedRoutes || allowedRoutes.length === 0) return "default";

--- a/ui/litellm-dashboard/src/components/templates/keyEditFormValues.ts
+++ b/ui/litellm-dashboard/src/components/templates/keyEditFormValues.ts
@@ -4,7 +4,7 @@ import { KeyResponse } from "../key_team_helpers/key_list";
 import { extractLoggingSettings, formatMetadataForDisplay, stripTagsFromMetadata } from "../key_info_utils";
 import { mapInternalToDisplayNames } from "../callback_info_helpers";
 import { estimateChecks, estimateFields } from "./estimatedOutputTokens";
-import { canonicalBudgetDuration } from "./keyEditFieldNormalizers";
+import { canonicalBudgetDuration, keyOrganizationId } from "./keyEditFieldNormalizers";
 
 export interface McpServersAndGroups {
   servers: string[];
@@ -99,7 +99,7 @@ export const toKeyEditFormValues = (keyData: KeyResponse): KeyEditFormValues => 
     agents: keyData.object_permission?.agents || [],
     accessGroups: keyData.object_permission?.agent_access_groups || [],
   },
-  organization_id: keyData.organization_id,
+  organization_id: keyOrganizationId(keyData),
   team_id: keyData.team_id,
   logging_settings: extractLoggingSettings(keyData.metadata),
   metadata: formatMetadataForDisplay(stripTagsFromMetadata(keyData.metadata)),

--- a/ui/litellm-dashboard/src/components/templates/key_edit_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_edit_view.test.tsx
@@ -1435,6 +1435,39 @@ describe("KeyEditView", () => {
       expect(await screen.findByText("Engineering")).toBeInTheDocument();
     });
 
+    it("should initialize organization from a key list row that only carries org_id", async () => {
+      const keyFromList = {
+        ...MOCK_KEY_DATA,
+        organization_id: null,
+        org_id: "org-1",
+      };
+
+      renderWithProviders(
+        <KeyEditView
+          keyData={keyFromList}
+          teams={[
+            { team_id: "team-a", team_alias: "Alpha", organization_id: "org-1" },
+            { team_id: "team-b", team_alias: "Beta", organization_id: "org-2" },
+          ]}
+          onCancel={() => {}}
+          onSubmit={async () => {}}
+          accessToken=""
+          userID=""
+          userRole="Admin"
+          premiumUser={false}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByLabelText("Organization")).toHaveValue("Engineering");
+      });
+
+      await userEvent.click(screen.getByLabelText("Team ID"));
+
+      expect(await screen.findByRole("option", { name: /Alpha/ })).toBeInTheDocument();
+      expect(screen.queryByRole("option", { name: /Beta/ })).not.toBeInTheDocument();
+    });
+
     it("should initialize organization from keyData", async () => {
       const keyWithOrg = {
         ...MOCK_KEY_DATA,

--- a/ui/litellm-dashboard/src/components/templates/key_edit_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_edit_view.test.tsx
@@ -1468,6 +1468,40 @@ describe("KeyEditView", () => {
       expect(screen.queryByRole("option", { name: /Beta/ })).not.toBeInTheDocument();
     });
 
+    it("should re-scope teams when the edited key switches to another organization", async () => {
+      const sharedProps = {
+        teams: [
+          { team_id: "team-a", team_alias: "Alpha", organization_id: "org-1" },
+          { team_id: "team-b", team_alias: "Beta", organization_id: "org-2" },
+        ],
+        onCancel: () => {},
+        onSubmit: async () => {},
+        accessToken: "",
+        userID: "",
+        userRole: "Admin",
+        premiumUser: false,
+      };
+
+      const { rerender } = renderWithProviders(
+        <KeyEditView keyData={{ ...MOCK_KEY_DATA, organization_id: null, org_id: "org-1" }} {...sharedProps} />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByLabelText("Organization")).toHaveValue("Engineering");
+      });
+
+      rerender(<KeyEditView keyData={{ ...MOCK_KEY_DATA, organization_id: null, org_id: "org-2" }} {...sharedProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText("Organization")).toHaveValue("Sales");
+      });
+
+      await userEvent.click(screen.getByLabelText("Team ID"));
+
+      expect(await screen.findByRole("option", { name: /Beta/ })).toBeInTheDocument();
+      expect(screen.queryByRole("option", { name: /Alpha/ })).not.toBeInTheDocument();
+    });
+
     it("should initialize organization from keyData", async () => {
       const keyWithOrg = {
         ...MOCK_KEY_DATA,

--- a/ui/litellm-dashboard/src/components/templates/key_edit_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_edit_view.test.tsx
@@ -1502,6 +1502,43 @@ describe("KeyEditView", () => {
       expect(screen.queryByRole("option", { name: /Alpha/ })).not.toBeInTheDocument();
     });
 
+    it("should adopt the organization of a team picked in the form", async () => {
+      const onSubmitMock = vi.fn().mockResolvedValue(undefined);
+
+      renderWithProviders(
+        <KeyEditView
+          keyData={{ ...MOCK_KEY_DATA, organization_id: null, org_id: null }}
+          teams={[
+            { team_id: "team-a", team_alias: "Alpha", organization_id: "org-1" },
+            { team_id: "team-b", team_alias: "Beta", organization_id: "org-2" },
+          ]}
+          onCancel={() => {}}
+          onSubmit={onSubmitMock}
+          accessToken=""
+          userID=""
+          userRole="Admin"
+          premiumUser={false}
+        />,
+      );
+
+      await screen.findByRole("button", { name: /save changes/i });
+      expect(screen.getByLabelText("Organization")).toHaveValue("");
+
+      await userEvent.click(screen.getByLabelText("Team ID"));
+      await userEvent.click(await screen.findByRole("option", { name: /Beta/ }));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText("Organization")).toHaveValue("Sales");
+      });
+
+      await userEvent.click(screen.getByRole("button", { name: /save changes/i }));
+
+      await waitFor(() => {
+        expect(onSubmitMock).toHaveBeenCalled();
+      });
+      expect(onSubmitMock.mock.calls[0][0].organization_id).toBe("org-2");
+    });
+
     it("should initialize organization from keyData", async () => {
       const keyWithOrg = {
         ...MOCK_KEY_DATA,

--- a/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
@@ -312,10 +312,8 @@ export function KeyEditView({
     setField(teamId);
     const selectedTeam = teams?.find((t) => t.team_id === teamId) || null;
     if (selectedTeam?.organization_id) {
-      setSelectedOrganizationId(selectedTeam.organization_id);
       form.setValue("organization_id", selectedTeam.organization_id);
     } else if (!teamId) {
-      setSelectedOrganizationId(null);
       form.setValue("organization_id", undefined);
     }
   };

--- a/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
@@ -28,7 +28,6 @@ import { routerSettingsEditorValue, routerSettingsUpdate } from "../common_compo
 import { estimateTooltips, withNormalizedEstimates } from "./estimatedOutputTokens";
 import {
   currentValuePlaceholder,
-  keyOrganizationId,
   keyTypeFromRoutes,
   modelSentinelOptions,
   parseAllowedRoutes,
@@ -106,7 +105,6 @@ export function KeyEditView({
       ? mapInternalToDisplayNames(keyData.metadata.litellm_disabled_callbacks)
       : [],
   );
-  const [selectedOrganizationId, setSelectedOrganizationId] = useState<string | null>(keyOrganizationId(keyData));
   const [autoRotationEnabled, setAutoRotationEnabled] = useState<boolean>(keyData.auto_rotate || false);
   const [rotationInterval, setRotationInterval] = useState<string>(keyData.rotation_interval || "");
   const [neverExpire, setNeverExpire] = useState<boolean>(!keyData.expires);
@@ -135,6 +133,7 @@ export function KeyEditView({
     return project?.project_alias ? `${project.project_alias} (${keyData.project_id})` : keyData.project_id;
   })();
 
+  const selectedOrganizationId = form.watch("organization_id") ?? null;
   const allowedRoutesValue = form.watch("allowed_routes");
   const selectedModels = (form.watch("models") as string[] | undefined) ?? [];
   const allowedRoutes = parseAllowedRoutes(allowedRoutesValue);
@@ -306,7 +305,6 @@ export function KeyEditView({
 
   const handleOrganizationChange = (setField: (value: string | undefined) => void, orgId: string | undefined) => {
     setField(orgId);
-    setSelectedOrganizationId(orgId || null);
     form.setValue("team_id", undefined);
   };
 

--- a/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
@@ -28,6 +28,7 @@ import { routerSettingsEditorValue, routerSettingsUpdate } from "../common_compo
 import { estimateTooltips, withNormalizedEstimates } from "./estimatedOutputTokens";
 import {
   currentValuePlaceholder,
+  keyOrganizationId,
   keyTypeFromRoutes,
   modelSentinelOptions,
   parseAllowedRoutes,
@@ -105,7 +106,7 @@ export function KeyEditView({
       ? mapInternalToDisplayNames(keyData.metadata.litellm_disabled_callbacks)
       : [],
   );
-  const [selectedOrganizationId, setSelectedOrganizationId] = useState<string | null>(keyData.organization_id || null);
+  const [selectedOrganizationId, setSelectedOrganizationId] = useState<string | null>(keyOrganizationId(keyData));
   const [autoRotationEnabled, setAutoRotationEnabled] = useState<boolean>(keyData.auto_rotate || false);
   const [rotationInterval, setRotationInterval] = useState<string>(keyData.rotation_interval || "");
   const [neverExpire, setNeverExpire] = useState<boolean>(!keyData.expires);

--- a/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
@@ -40,6 +40,7 @@ import { RegenerateKeyModal } from "../organisms/RegenerateKeyModal";
 import { parseErrorMessage } from "../shared/errorUtils";
 import { InheritedBudgetHint, inheritedBudgetGates } from "../shared/InheritedBudgetHint";
 import { KeyEditView } from "./key_edit_view";
+import { keyOrganizationId } from "./keyEditFieldNormalizers";
 
 interface KeyInfoViewProps {
   keyId: string;
@@ -468,7 +469,7 @@ export default function KeyInfoView({
   const lastConfiguredAt = currentKeyData.settings_updated_at || currentKeyData.created_at;
 
   const parentTeam = currentKeyData.team_id ? teamsData?.find((team) => team.team_id === currentKeyData.team_id) : null;
-  const orgId = currentKeyData.organization_id || currentKeyData.org_id || parentTeam?.organization_id || "";
+  const orgId = keyOrganizationId(currentKeyData) || parentTeam?.organization_id || "";
   const parentOrg = orgId ? organizations?.find((org) => org.organization_id === orgId) : null;
 
   const hasOwnBudget = currentKeyData.max_budget !== null;
@@ -835,7 +836,7 @@ export default function KeyInfoView({
 
                   <div>
                     <p className="text-sm font-medium">Organization</p>
-                    <p className="text-sm">{(currentKeyData.organization_id ?? currentKeyData.org_id) || "Not Set"}</p>
+                    <p className="text-sm">{keyOrganizationId(currentKeyData) || "Not Set"}</p>
                   </div>
 
                   <div>


### PR DESCRIPTION
## TLDR

Problem this solves:

- Key edit form showed no organization for keys that have one
- Only keys opened from the Virtual Keys list were affected
- Clearing an organization first forced the admin to pick one

How it solves it:

- Read the organization under either field name the API returns
- One shared helper now feeds the form and the read-only panel
- The team list follows the organization field the form holds

## User Flow

Before: an admin editing a key from the Virtual Keys list is told the key has no organization, one line under a panel showing the organization it has

1. They open https://litellm-domain/ui/api-keys and click the `lit6833-key` row
2. The key detail page opens at https://litellm-domain/ui/api-keys?key=ac938a82edb4... and its header reads `ORGANIZATION lit6833-org`
3. They click the Settings tab; the read-only panel also lists the organization
4. They click "Edit Settings"; the Organization field reads "All Organizations", the same thing it shows for a key with no organization
5. They click "Save Changes" without touching anything; the save returns 200 and the organization survives, but the form never told them which organization the key is in, and moving or clearing it means picking an organization from the dropdown first

After: the same admin sees the key's real organization in the edit form, with a clear button next to it

1. They open https://litellm-domain/ui/api-keys and click the `lit6833-key` row
2. The key detail page opens at https://litellm-domain/ui/api-keys?key=ac938a82edb4... and its header reads `ORGANIZATION lit6833-org`
3. They click the Settings tab; the read-only panel also lists the organization
4. They click "Edit Settings"; the Organization field reads `lit6833-org` with an X to clear it
5. They click "Save Changes" without touching anything; the save returns 200 and sends the organization it displayed, so the field now round-trips what the admin sees

## Relevant issues

## Linear ticket

Resolves LIT-6833

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup, one proxy with 2 uvicorn workers plus the Admin UI dev server, same database for both legs:

```
.venv/bin/python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml \
  --port 6741 --num_workers 2 --detailed_debug --use_v2_migration_resolver

cd ui/litellm-dashboard && NEXT_PUBLIC_BASE_URL=http://localhost:6741 npm run dev -- -p 8462

curl -sX POST http://localhost:6741/organization/new -H "Authorization: Bearer $MASTER" \
  -H 'Content-Type: application/json' -d '{"organization_alias":"lit6833-org"}'
# -> "organization_id": "7cf26804-e8cd-48a2-855c-b717345a04e4"

curl -sX POST http://localhost:6741/key/generate -H "Authorization: Bearer $MASTER" \
  -H 'Content-Type: application/json' \
  -d '{"key_alias":"lit6833-key","organization_id":"7cf26804-e8cd-48a2-855c-b717345a04e4"}'
# -> "token": "ac938a82edb45417de0a7dc871ce29313c0051f06837a390966cbe0c03f678c5"
```

The two routes behind the page disagree on the field name, which is what the form has to cope with:

```
curl -s "http://localhost:6741/key/info?key=ac938a82edb4..." -H "Authorization: Bearer $MASTER"
# -> organization_id: 7cf26804-e8cd-48a2-855c-b717345a04e4   org_id: None

curl -s "http://localhost:6741/key/list?page=1&size=100&return_full_object=true" -H "Authorization: Bearer $MASTER"
# lit6833-key row -> organization_id: None   org_id: '7cf26804-e8cd-48a2-855c-b717345a04e4'
```

### Before (658f50663d)

1. Open http://localhost:8462/api-keys/ and click the `lit6833-key` row. The detail page opens and its header reads `ORGANIZATION lit6833-org`.

2. Click the Settings tab. The read-only panel lists the organization:

   ```
   Organization | 7cf26804-e8cd-48a2-855c-b717345a04e4
   ```

3. Click "Edit Settings". The Organization field is empty, showing only its "All Organizations" placeholder, the same thing a key with no organization shows:

   ```
   label "Organization" -> visible input value "", placeholder "All Organizations"
                           hidden input value ""
   ```

4. Click "Save Changes" without touching anything. The form sends no organization at all:

   ```
   POST http://localhost:6741/key/update -> 200
   {"key_alias":"lit6833-key", ... ,"access_group_ids":[],"team_id":null, ... }
   ```

### After (2223084ce6)

1. Open http://localhost:8462/api-keys/ and click the `lit6833-key` row. Same header as before.

2. Click the Settings tab. Same read-only panel as before.

3. Click "Edit Settings". The Organization field now shows the key's organization, with an X to clear it:

   ```
   label "Organization" -> visible input value "lit6833-org", placeholder "All Organizations"
                           hidden input value "7cf26804-e8cd-48a2-855c-b717345a04e4"
   ```

4. Click "Save Changes" without touching anything. The form now sends the organization it displayed:

   ```
   POST http://localhost:6741/key/update -> 200
   {"key_alias":"lit6833-key", ... ,"access_group_ids":[],"organization_id":"7cf26804-e8cd-48a2-855c-b717345a04e4","team_id":null, ... }
   ```

Worth noting from the run:

- The two key routes name the organization field differently
- That naming split is older than this PR
- The read-only panel already worked around it separately
- An untouched save at base kept the organization anyway

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Overlaps #39436 by file only, not by line
  - #39436 changes what the picker's Clear button sends
  - this changes what the picker opens on
  - both were confirmed present on the same base
- Every save now sends the organization the form displays
  - saves that keep the same organization skip the membership check
  - deleting an organization deletes its keys, so the id cannot dangle
- The Team picker still opens empty on a key that has a team
  - same prefill gap, and it behaves identically on base and head
- A key whose team sits in another organization shows the team as a bare id
  - the team list is scoped to the organization the form holds
  - only reachable by setting the organization straight through the API
  - the save still sends that team back unchanged, verified live
  - left alone: cosmetic, and widening the team list costs more than it saves

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard-only normalization and form state wiring for key organization display; no auth or API contract changes beyond including organization_id on save when shown.
> 
> **Overview**
> Fixes the Virtual Key **Edit Settings** form showing no organization when list rows only expose **`org_id`** (while **`/key/info`** uses **`organization_id`**).
> 
> Adds shared **`keyOrganizationId`** and uses it when seeding form defaults and in the key info read-only panel. **`KeyEditView`** drops duplicate organization state and drives the Organization picker and team filtering from **`form.watch("organization_id")`**, so saves round-trip the displayed org and team options stay scoped to the selected organization.
> 
> Tests cover **`org_id`-only** prefill, team list rescoping when the key’s org changes, and adopting an org when a team is picked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2223084ce64d19d307a1645fc6109725a69285d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
