### PR TITLE
fix(spend logs): sort session-grouped logs by session total spend

### DIFF
--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -2614,6 +2614,8 @@ async def ui_view_spend_logs(
             sql_params.append(f"%{error_message}%")
             p += 1
 
+        session_grouping: Final = group_by_session is True
+
         # Build the ORDER BY expression. ttft_ms is computed from
         # completionStartTime - startTime; non-streaming rows (where
         # completionStartTime is null or equals endTime) yield NULL, so we
@@ -2623,7 +2625,12 @@ async def ui_view_spend_logs(
         # semantics.
         _sql_dir: Final = "ASC" if order_direction == "asc" else "DESC"
         _nulls_clause = ""
-        if order_column == "ttft_ms":
+        # The Cost column displays the session total, so a grouped spend sort orders
+        # by the window SUM (computed before DISTINCT ON prunes to one row per session).
+        sort_by_session_spend: Final = session_grouping and order_column == "spend"
+        if sort_by_session_spend:
+            _order_expr = "session_spend_in_window"
+        elif order_column == "ttft_ms":
             _order_expr = (
                 'CASE WHEN "completionStartTime" IS NULL '
                 'OR "completionStartTime" = "endTime" THEN NULL '
@@ -2636,7 +2643,6 @@ async def ui_view_spend_logs(
             _order_expr = order_column
 
         joined_conditions: Final = " AND ".join(sql_conditions)
-        session_grouping: Final = group_by_session is True
         count_group_clause: Final = f"GROUP BY {_SESSION_GROUP_KEY_SQL}" if session_grouping else ""
         count_query: Final = f"""
             SELECT COUNT(*) AS total_count
@@ -2663,11 +2669,17 @@ async def ui_view_spend_logs(
                 organization_id, end_user, requester_ip_address,
                 session_id, status, mcp_namespaced_tool_name, agent_id,
                 COALESCE(request_duration_ms, (EXTRACT(EPOCH FROM ("endTime" - "startTime")) * 1000)::INTEGER) AS request_duration_ms"""
+        grouped_select_columns: Final = (
+            f"{select_columns},\n"
+            f"                        SUM(spend) OVER (PARTITION BY {_SESSION_GROUP_KEY_SQL}) AS session_spend_in_window"
+            if sort_by_session_spend
+            else select_columns
+        )
         sql_query: Final = (
             f"""
                 SELECT * FROM (
                     SELECT DISTINCT ON ({_SESSION_GROUP_KEY_SQL})
-                        {select_columns}
+                        {grouped_select_columns}
                     FROM "LiteLLM_SpendLogs"
                     WHERE {joined_conditions}
                     ORDER BY {_SESSION_GROUP_KEY_SQL}, call_type IN {_MCP_CALL_TYPES_SQL}, "startTime" DESC
@@ -2688,6 +2700,12 @@ async def ui_view_spend_logs(
         sql_params.extend([page_size, skip])
 
         data: Final = await prisma_client.db.query_raw(sql_query, *sql_params)
+
+        if sort_by_session_spend:
+            # ORDER BY helper only; the response already carries session_total_spend.
+            for row in data:
+                if isinstance(row, dict):
+                    row.pop("session_spend_in_window", None)
 
         _hydrate_spend_log_metadata(data)
 

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_query_optimization.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_query_optimization.py
@@ -568,6 +568,102 @@ async def test_spend_logs_ui_group_by_session_paginates_sessions(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_spend_logs_ui_group_by_session_sorts_by_session_total_spend(monkeypatch):
+    """
+    With group_by_session=true, sort_by=spend must order sessions by their
+    in-window total spend (what the UI's Cost column shows), not by the
+    representative row's own spend — and the helper column must not leak
+    into API rows.
+    """
+    from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+    from litellm.proxy.spend_tracking.spend_management_endpoints import ui_view_spend_logs
+
+    page_rows = [
+        {
+            "request_id": "req-1",
+            "metadata": "{}",
+            "session_id": "sess-1",
+            "session_spend_in_window": 42.5,
+        },
+    ]
+    mock_prisma = _make_ui_spend_logs_mock(count_total=1, page_rows=page_rows)
+    # A session_id row triggers a third query_raw (session stats enrichment).
+    mock_prisma.db.query_raw = AsyncMock(side_effect=[[{"total_count": 1}], page_rows, []])
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma)
+
+    auth = UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin")
+    mock_request = MagicMock()
+    mock_request.url.path = "/spend/logs/ui"
+
+    response = await ui_view_spend_logs(
+        request=mock_request,
+        api_key=None,
+        user_id=None,
+        request_id=None,
+        start_date="2026-02-16 00:00:00",
+        end_date="2026-02-16 23:59:59",
+        page=1,
+        page_size=50,
+        sort_by="spend",
+        sort_order="desc",
+        user_api_key_dict=auth,
+        group_by_session=True,
+    )
+
+    group_key = "COALESCE(NULLIF(session_id, ''), request_id), api_key"
+    page_sql = mock_prisma.db.query_raw.call_args_list[1][0][0]
+    assert f"SUM(spend) OVER (PARTITION BY {group_key}) AS session_spend_in_window" in page_sql, (
+        f"grouped spend sort must compute the per-session in-window total. SQL was:\n{page_sql}"
+    )
+    assert "ORDER BY session_spend_in_window DESC, request_id" in page_sql, (
+        f"grouped spend sort must order by the session total, not the representative row. SQL was:\n{page_sql}"
+    )
+    assert "session_spend_in_window" not in response["data"][0], (
+        "the ORDER BY helper column must not leak into API rows"
+    )
+
+
+@pytest.mark.asyncio
+async def test_spend_logs_ui_ungrouped_spend_sort_keeps_plain_column(monkeypatch):
+    """
+    Without group_by_session (the /spend/logs/v2 shape), every row displays its
+    own spend, so sort_by=spend must stay a plain `ORDER BY spend` on the raw
+    column — no window SUM, no helper column.
+    """
+    from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+    from litellm.proxy.spend_tracking.spend_management_endpoints import ui_view_spend_logs
+
+    page_rows = [{"request_id": "req-1", "metadata": "{}", "session_id": None}]
+    mock_prisma = _make_ui_spend_logs_mock(count_total=1, page_rows=page_rows)
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma)
+
+    auth = UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin")
+    mock_request = MagicMock()
+    mock_request.url.path = "/spend/logs/ui"
+
+    await ui_view_spend_logs(
+        request=mock_request,
+        api_key=None,
+        user_id=None,
+        request_id=None,
+        start_date="2026-02-16 00:00:00",
+        end_date="2026-02-16 23:59:59",
+        page=1,
+        page_size=50,
+        sort_by="spend",
+        sort_order="desc",
+        user_api_key_dict=auth,
+        group_by_session=False,
+    )
+
+    page_sql = mock_prisma.db.query_raw.call_args_list[1][0][0]
+    assert "session_spend_in_window" not in page_sql, (
+        f"ungrouped queries must not pay for the window sum. SQL was:\n{page_sql}"
+    )
+    assert "ORDER BY spend DESC" in page_sql, f"ungrouped spend sort must stay on the raw column. SQL was:\n{page_sql}"
+
+
+@pytest.mark.asyncio
 async def test_spend_logs_ui_request_id_lookup_with_grouping_returns_exact_row(monkeypatch):
     """
     A request_id lookup with group_by_session=true must still resolve the


### PR DESCRIPTION
## TLDR

Problem this solves:

- Logs page sorted by Cost returns rows in no visible cost order
- Cost column shows session totals, but sort used the newest row's own spend

How it solves it:

- Session-grouped spend sort now orders by each session's total spend
- One window SUM over the existing pass; no extra query

## User Flow

Before: an admin sorting the Logs page by Cost sees costs out of order

1. They open https://litellm-domain/ui/?page=logs showing sessions with Cost "session total" values like $0.30, $0.20, $0.03
2. They click the Cost header and pick sort descending
3. The table reloads showing $0.20, then $0.30, then $0.03 — the $0.30 session lands below the $0.20 one

After: the same click orders rows by the Cost values on screen

1. They open https://litellm-domain/ui/?page=logs showing the same sessions
2. They click the Cost header and pick sort descending
3. The table reloads showing $0.30, $0.20, $0.03 — descending, matching the displayed totals

## Relevant issues

None found for this specific sort; reproduced from a production deployment running a recent main image.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Setup (shared by both runs): fresh postgres 16, schema created with `prisma db push`, then seeded three sessions:

```sql
-- sess-A: 3 calls of $0.10  -> session total $0.30 (newest row's own spend $0.10)
-- sess-B: 1 call  of $0.20  -> session total $0.20 (newest row's own spend $0.20)
-- sess-C: $0.01 + $0.02     -> session total $0.03 (newest row's own spend $0.02)
INSERT INTO "LiteLLM_SpendLogs" (request_id, call_type, api_key, spend, total_tokens, prompt_tokens, completion_tokens, "startTime", "endTime", model, session_id, metadata, request_tags, messages, response, "user", status) VALUES
  ('req-a1','acompletion','hash-demo',0.10,100,60,40,'2026-09-03 10:00:00','2026-09-03 10:00:05','gpt-4o','sess-A','{}','[]','{}','{}','demo','success'),
  ('req-a2','acompletion','hash-demo',0.10,100,60,40,'2026-09-03 10:01:00','2026-09-03 10:01:05','gpt-4o','sess-A','{}','[]','{}','{}','demo','success'),
  ('req-a3','acompletion','hash-demo',0.10,100,60,40,'2026-09-03 10:02:00','2026-09-03 10:02:05','gpt-4o','sess-A','{}','[]','{}','{}','demo','success'),
  ('req-b1','acompletion','hash-demo',0.20,200,120,80,'2026-09-03 10:03:00','2026-09-03 10:03:05','gpt-4o','sess-B','{}','[]','{}','{}','demo','success'),
  ('req-c1','acompletion','hash-demo',0.01,10,6,4,'2026-09-03 10:04:00','2026-09-03 10:04:05','gpt-4o','sess-C','{}','[]','{}','{}','demo','success'),
  ('req-c2','acompletion','hash-demo',0.02,20,12,8,'2026-09-03 10:05:00','2026-09-03 10:05:05','gpt-4o','sess-C','{}','[]','{}','{}','demo','success');
```

Proxy started with only `DATABASE_URL` + `LITELLM_MASTER_KEY`, then queried exactly as the Logs page does:

```bash
curl -s "http://localhost:4056/spend/logs/ui?start_date=2026-09-01%2000:00:00&end_date=2026-09-04%2000:00:00&page=1&page_size=50&sort_by=spend&sort_order=desc&group_by_session=true" -H "Authorization: Bearer sk-1234"
```

### Before (658f506)

1. Ran the curl above against the proxy at the merge base
2. Observed row order (`spend` = row shown, `session_total_spend` = what the Cost column displays):

```text
row  session   rep_row_spend   displayed_session_total
  1  sess-B    0.2             0.2
  2  sess-A    0.1             0.3     <-- $0.30 session sorted BELOW the $0.20 one
  3  sess-C    0.02            0.03
```

### After (f9f7c81)

Captured at 6a91838; the tip f9f7c81 differs from it only in Python comments/docstrings (no SQL or logic change — unit tests re-run green at f9f7c81), so the run below reflects the code at tip.

1. Ran the same curl against the proxy at this PR's tip
2. Observed row order:

```text
row  session   rep_row_spend   displayed_session_total
  1  sess-A    0.1             0.3     <-- ordered by the displayed total
  2  sess-B    0.2             0.2
  3  sess-C    0.02            0.03
```

3. `sort_order=asc` returns sess-C, sess-B, sess-A; `group_by_session=false` still orders rows by their own spend
4. No `session_spend_in_window` helper field appears in any returned row

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Sort uses the session's spend inside the filtered time window; the Cost column's total is the session's all-time spend, so a session straddling the window edge can still sort slightly off its displayed total
- `/spend/logs/v2` with `group_by_session=true&sort_by=spend` changes the same way (sessions now ordered by session total); ungrouped queries are untouched
