### PR TITLE
fix(utils): redact credentials nested in extra_body on the verbose optional-params line

### DIFF
--- a/litellm/litellm_core_utils/secret_redaction.py
+++ b/litellm/litellm_core_utils/secret_redaction.py
@@ -11,7 +11,7 @@ from typing import Final
 
 from litellm.constants import MINIMUM_CUSTOM_KEY_LENGTH
 
-_REDACTED: Final = "REDACTED"
+REDACTED: Final = "REDACTED"
 
 
 def _build_secret_patterns() -> "re.Pattern[str]":
@@ -89,7 +89,7 @@ _SECRET_RE: Final = _build_secret_patterns()
 
 def redact_string(value: str) -> str:
     """Scrub known secret/credential patterns from *value* and return the result."""
-    return _SECRET_RE.sub(_REDACTED, value)
+    return _SECRET_RE.sub(REDACTED, value)
 
 
 _UNIX_SYSTEM_PATH: Final = r"/(?:etc|var|opt|usr|home|root|private|Users|tmp|mnt|srv)/[^\s'\"\)\]}>,]+"
@@ -110,7 +110,7 @@ def redact_internal_details(value: str) -> str:
     on top of redact_string(). For client-facing messages only: server logs keep this detail."""
     marker_index: Final = value.find(_TRACEBACK_MARKER)
     without_traceback: Final = value[:marker_index].rstrip() if marker_index != -1 else value
-    return _INTERNAL_DETAIL_RE.sub(_REDACTED, redact_string(without_traceback))
+    return _INTERNAL_DETAIL_RE.sub(REDACTED, redact_string(without_traceback))
 
 
 def redact_structured_value(key: str | None, value: str) -> str:
@@ -126,4 +126,4 @@ def redact_structured_value(key: str | None, value: str) -> str:
     if scrubbed != value or key is None:
         return scrubbed
     rendered: Final = f"'{key}': '{value}'"
-    return _REDACTED if redact_string(rendered) != rendered else value
+    return REDACTED if redact_string(rendered) != rendered else value

--- a/litellm/litellm_core_utils/sensitive_data_masker.py
+++ b/litellm/litellm_core_utils/sensitive_data_masker.py
@@ -1,4 +1,4 @@
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from typing import Any, Final
 
 from pydantic import BaseModel
@@ -225,8 +225,8 @@ def redact_credentials_in_payload(data: Mapping[str, object]) -> Mapping[str, ob
     :func:`mask_credentials_in_payload`, no prefix or suffix of the secret survives
     and non-string secrets are covered too, which is what a payload rendered
     straight to stdout needs. ``None`` is preserved so an unset credential still
-    reads as unset, and non-mapping containers are left alone so the caller's
-    ``repr`` is unchanged.
+    reads as unset, and lists and tuples are rebuilt element by element so a
+    credential nested inside one is caught as well.
     """
     return _redact_mapping(data, 0)
 
@@ -242,7 +242,16 @@ def _redact_entry(key: str, value: object, depth: int) -> object:
         return REDACTED
     if isinstance(value, Mapping):
         return _redact_mapping(value, depth + 1)
+    if isinstance(value, (list, tuple)):
+        return _redact_sequence(value, depth + 1)
     return value
+
+
+def _redact_sequence(values: Sequence[object], depth: int) -> Sequence[object]:
+    if depth >= DEFAULT_MAX_RECURSE_DEPTH_SENSITIVE_DATA_MASKER:
+        return values
+    redacted: Final = tuple(_redact_entry("", item, depth) for item in values)
+    return redacted if isinstance(values, tuple) else list(redacted)
 
 
 # Usage example:

--- a/litellm/litellm_core_utils/sensitive_data_masker.py
+++ b/litellm/litellm_core_utils/sensitive_data_masker.py
@@ -4,6 +4,7 @@ from typing import Any, Final
 from pydantic import BaseModel
 
 from litellm.constants import DEFAULT_MAX_RECURSE_DEPTH_SENSITIVE_DATA_MASKER
+from litellm.litellm_core_utils.secret_redaction import REDACTED
 
 
 class SensitiveDataMasker:
@@ -212,6 +213,36 @@ def mask_sensitive_keys(data: dict[str, Any], sensitive_fields: set[str]) -> dic
         else:
             masked[key] = value
     return masked
+
+
+def redact_credentials_in_payload(data: Mapping[str, object]) -> Mapping[str, object]:
+    """Return a copy of ``data`` where every value under a credential-named key is
+    replaced by the shared ``REDACTED`` marker, nested mappings are recursed into,
+    and every other value is preserved by identity.
+
+    Sensitive-key detection is delegated to the shared :class:`SensitiveDataMasker`,
+    so the credential names stay in one place. Unlike
+    :func:`mask_credentials_in_payload`, no prefix or suffix of the secret survives
+    and non-string secrets are covered too, which is what a payload rendered
+    straight to stdout needs. ``None`` is preserved so an unset credential still
+    reads as unset, and non-mapping containers are left alone so the caller's
+    ``repr`` is unchanged.
+    """
+    return _redact_mapping(data, 0)
+
+
+def _redact_mapping(data: Mapping[str, object], depth: int) -> Mapping[str, object]:
+    if depth >= DEFAULT_MAX_RECURSE_DEPTH_SENSITIVE_DATA_MASKER:
+        return data
+    return {key: _redact_entry(key, value, depth) for key, value in data.items()}
+
+
+def _redact_entry(key: str, value: object, depth: int) -> object:
+    if value is not None and _default_masker.is_sensitive_key(key):
+        return REDACTED
+    if isinstance(value, Mapping):
+        return _redact_mapping(value, depth + 1)
+    return value
 
 
 # Usage example:

--- a/litellm/litellm_core_utils/sensitive_data_masker.py
+++ b/litellm/litellm_core_utils/sensitive_data_masker.py
@@ -226,30 +226,30 @@ def redact_credentials_in_payload(data: Mapping[str, object]) -> Mapping[str, ob
     and non-string secrets are covered too, which is what a payload rendered
     straight to stdout needs. ``None`` is preserved so an unset credential still
     reads as unset, and lists and tuples are rebuilt element by element so a
-    credential nested inside one is caught as well.
+    credential nested inside one is caught as well. A container sitting at the
+    recursion limit is replaced wholesale rather than passed through, so nesting a
+    payload deeper than the limit hides it instead of exposing it.
     """
     return _redact_mapping(data, 0)
 
 
 def _redact_mapping(data: Mapping[str, object], depth: int) -> Mapping[str, object]:
-    if depth >= DEFAULT_MAX_RECURSE_DEPTH_SENSITIVE_DATA_MASKER:
-        return data
     return {key: _redact_entry(key, value, depth) for key, value in data.items()}
 
 
 def _redact_entry(key: str, value: object, depth: int) -> object:
     if value is not None and _default_masker.is_sensitive_key(key):
         return REDACTED
+    if not isinstance(value, (Mapping, list, tuple)):
+        return value
+    if depth >= DEFAULT_MAX_RECURSE_DEPTH_SENSITIVE_DATA_MASKER:
+        return REDACTED
     if isinstance(value, Mapping):
         return _redact_mapping(value, depth + 1)
-    if isinstance(value, (list, tuple)):
-        return _redact_sequence(value, depth + 1)
-    return value
+    return _redact_sequence(value, depth + 1)
 
 
 def _redact_sequence(values: Sequence[object], depth: int) -> Sequence[object]:
-    if depth >= DEFAULT_MAX_RECURSE_DEPTH_SENSITIVE_DATA_MASKER:
-        return values
     redacted: Final = tuple(_redact_entry("", item, depth) for item in values)
     return redacted if isinstance(values, tuple) else list(redacted)
 

--- a/litellm/litellm_core_utils/sensitive_data_masker.py
+++ b/litellm/litellm_core_utils/sensitive_data_masker.py
@@ -3,7 +3,7 @@ from typing import Any, Final
 
 from pydantic import BaseModel
 
-from litellm.constants import DEFAULT_MAX_RECURSE_DEPTH_SENSITIVE_DATA_MASKER
+from litellm.constants import DEFAULT_MAX_RECURSE_DEPTH, DEFAULT_MAX_RECURSE_DEPTH_SENSITIVE_DATA_MASKER
 from litellm.litellm_core_utils.secret_redaction import REDACTED
 
 
@@ -226,9 +226,10 @@ def redact_credentials_in_payload(data: Mapping[str, object]) -> Mapping[str, ob
     and non-string secrets are covered too, which is what a payload rendered
     straight to stdout needs. ``None`` is preserved so an unset credential still
     reads as unset, and lists and tuples are rebuilt element by element so a
-    credential nested inside one is caught as well. A container sitting at the
-    recursion limit is replaced wholesale rather than passed through, so nesting a
-    payload deeper than the limit hides it instead of exposing it.
+    credential nested inside one is caught as well. The walk is bounded only to stop
+    runaway recursion, and a container sitting at that bound is replaced wholesale
+    rather than passed through, so burying a credential deeper than the walk goes
+    hides it instead of exposing it.
     """
     return _redact_mapping(data, 0)
 
@@ -242,7 +243,7 @@ def _redact_entry(key: str, value: object, depth: int) -> object:
         return REDACTED
     if not isinstance(value, (Mapping, list, tuple)):
         return value
-    if depth >= DEFAULT_MAX_RECURSE_DEPTH_SENSITIVE_DATA_MASKER:
+    if depth >= DEFAULT_MAX_RECURSE_DEPTH:
         return REDACTED
     if isinstance(value, Mapping):
         return _redact_mapping(value, depth + 1)

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -83,6 +83,7 @@ from litellm.constants import (
 from litellm.litellm_core_utils.fallback_generalizations import (
     match_capability_generalizations,
 )
+from litellm.litellm_core_utils.sensitive_data_masker import redact_credentials_in_payload
 
 _CachingHandlerResponse = None
 _LLMCachingHandler = None
@@ -7459,7 +7460,8 @@ def print_args_passed_to_litellm(original_function, args, kwargs):
             return
 
         args_str: Final = ", ".join(map(repr, args))
-        kwargs_str: Final = ", ".join(f"{key}={value!r}" for key, value in kwargs.items())
+        redacted_kwargs: Final = redact_credentials_in_payload(kwargs)
+        kwargs_str: Final = ", ".join(f"{key}={value!r}" for key, value in redacted_kwargs.items())
         print_verbose(
             "\n",
         )  # new line before

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -544,6 +544,14 @@ def print_verbose(
         pass
 
 
+def _print_verbose_is_active() -> bool:
+    """Whether print_verbose would reach either of its two consumers, so a call site can skip
+    building a payload nothing would read. _is_debugging_on() is not the same predicate: it reads
+    litellm._logging.set_verbose, while print_verbose's print reads litellm.set_verbose, and
+    assigning the documented litellm.set_verbose = True rebinds only the latter."""
+    return litellm.set_verbose is True or verbose_logger.isEnabledFor(logging.DEBUG)
+
+
 ####### CLIENT ###################
 # make it easy to log if completion/embedding runs succeeded or failed + see what happened | Non-Blocking
 def custom_llm_setup():
@@ -4705,7 +4713,8 @@ def get_optional_params(
         openai_params=list(DEFAULT_CHAT_COMPLETION_PARAM_VALUES.keys()),
         additional_drop_params=additional_drop_params,
     )
-    print_verbose(f"Final returned optional params: {optional_params}")
+    if _print_verbose_is_active():
+        print_verbose(f"Final returned optional params: {redact_credentials_in_payload(optional_params)}")
     optional_params = _apply_openai_param_overrides(
         optional_params=optional_params,
         non_default_params=non_default_params,

--- a/tests/test_litellm/litellm_core_utils/test_sensitive_data_masker.py
+++ b/tests/test_litellm/litellm_core_utils/test_sensitive_data_masker.py
@@ -372,3 +372,24 @@ def test_redact_credentials_in_payload_reaches_credentials_nested_in_sequences()
     assert result["metadata"]["upstreams"][0]["aws_secret_access_key"] == "REDACTED"
     assert isinstance(result["metadata"]["upstreams"], tuple)
     assert result["messages"] == [{"role": "user", "content": "hello"}]
+
+
+@pytest.mark.parametrize("wrap", ["mapping", "sequence"])
+def test_redact_credentials_in_payload_hides_containers_at_the_recursion_limit(wrap):
+    """The recursion limit exists to bound the walk, not to grant an exemption, so a caller who
+    buries a credential deeper than the limit must get the container hidden rather than handed
+    back verbatim. Nesting through lists costs depth twice as fast as nesting through mappings,
+    so both shapes are pushed well past the limit here."""
+    from litellm.constants import DEFAULT_MAX_RECURSE_DEPTH_SENSITIVE_DATA_MASKER
+    from litellm.litellm_core_utils.sensitive_data_masker import redact_credentials_in_payload
+
+    fake_key = "sk-fake-lit6835-past-the-limit"
+    node = {"api_key": fake_key}
+    for _ in range(2 * DEFAULT_MAX_RECURSE_DEPTH_SENSITIVE_DATA_MASKER + 1):
+        node = {"extra_body": node} if wrap == "mapping" else {"providers": [node]}
+
+    result = redact_credentials_in_payload({**node, "max_tokens": 17})
+
+    assert fake_key not in str(result)
+    assert "REDACTED" in str(result)
+    assert result["max_tokens"] == 17

--- a/tests/test_litellm/litellm_core_utils/test_sensitive_data_masker.py
+++ b/tests/test_litellm/litellm_core_utils/test_sensitive_data_masker.py
@@ -348,3 +348,27 @@ def test_redact_credentials_in_payload_leaves_no_fragment_of_the_secret():
     assert result["max_tokens"] == 17
     assert result["temperature"] == 0.25
     assert result["api_base"] is None
+
+
+def test_redact_credentials_in_payload_reaches_credentials_nested_in_sequences():
+    """Free-form kwargs like extra_body and metadata routinely carry lists of dicts, so a
+    credential hiding one level inside a list or tuple must be replaced too, while the
+    surrounding container keeps its type and every ordinary element stays verbatim."""
+    from litellm.litellm_core_utils.sensitive_data_masker import redact_credentials_in_payload
+
+    result = redact_credentials_in_payload(
+        {
+            "extra_body": {"providers": [{"name": "openai", "api_key": "sk-fake-lit6823-in-a-list"}]},
+            "metadata": {"upstreams": ({"aws_secret_access_key": "fake-aws-in-a-tuple"},)},
+            "messages": [{"role": "user", "content": "hello"}],
+        }
+    )
+
+    assert "sk-fake-lit6823-in-a-list" not in str(result)
+    assert "fake-aws-in-a-tuple" not in str(result)
+    assert result["extra_body"]["providers"][0]["api_key"] == "REDACTED"
+    assert result["extra_body"]["providers"][0]["name"] == "openai"
+    assert isinstance(result["extra_body"]["providers"], list)
+    assert result["metadata"]["upstreams"][0]["aws_secret_access_key"] == "REDACTED"
+    assert isinstance(result["metadata"]["upstreams"], tuple)
+    assert result["messages"] == [{"role": "user", "content": "hello"}]

--- a/tests/test_litellm/litellm_core_utils/test_sensitive_data_masker.py
+++ b/tests/test_litellm/litellm_core_utils/test_sensitive_data_masker.py
@@ -312,3 +312,39 @@ def test_mask_credentials_in_payload_masks_only_sensitive_string_leaves():
     assert masked != plaintext
     assert masked.startswith(plaintext[:4])
     assert masked.endswith(plaintext[-4:])
+
+
+def test_redact_credentials_in_payload_leaves_no_fragment_of_the_secret():
+    """A payload rendered straight to stdout cannot afford the partial reveal
+    mask_credentials_in_payload leaves, so every credential-named value is replaced
+    whole, nested header dicts included, while ordinary params survive verbatim."""
+    from litellm.litellm_core_utils.sensitive_data_masker import redact_credentials_in_payload
+
+    fake_key = "sk-fake-lit6823-0000000000000000"
+    fake_token = "fake-azure-ad-token-0000"
+    result = redact_credentials_in_payload(
+        {
+            "api_key": fake_key,
+            "azure_ad_token": fake_token,
+            "aws_secret_access_key": "fake-aws-secret-0000",
+            "vertex_credentials": {"private_key": "fake-pem"},
+            "extra_headers": {"Authorization": "Bearer fake-bearer-0000", "x-request-id": "abc123"},
+            "model": "gpt-4o-mini",
+            "max_tokens": 17,
+            "temperature": 0.25,
+            "api_base": None,
+        }
+    )
+
+    assert fake_key not in str(result)
+    assert fake_token not in str(result)
+    assert "fake-aws-secret-0000" not in str(result)
+    assert "fake-pem" not in str(result)
+    assert "fake-bearer-0000" not in str(result)
+    assert result["api_key"] == "REDACTED"
+    assert result["extra_headers"]["Authorization"] == "REDACTED"
+    assert result["extra_headers"]["x-request-id"] == "abc123"
+    assert result["model"] == "gpt-4o-mini"
+    assert result["max_tokens"] == 17
+    assert result["temperature"] == 0.25
+    assert result["api_base"] is None

--- a/tests/test_litellm/litellm_core_utils/test_sensitive_data_masker.py
+++ b/tests/test_litellm/litellm_core_utils/test_sensitive_data_masker.py
@@ -380,12 +380,12 @@ def test_redact_credentials_in_payload_hides_containers_at_the_recursion_limit(w
     buries a credential deeper than the limit must get the container hidden rather than handed
     back verbatim. Nesting through lists costs depth twice as fast as nesting through mappings,
     so both shapes are pushed well past the limit here."""
-    from litellm.constants import DEFAULT_MAX_RECURSE_DEPTH_SENSITIVE_DATA_MASKER
+    from litellm.constants import DEFAULT_MAX_RECURSE_DEPTH
     from litellm.litellm_core_utils.sensitive_data_masker import redact_credentials_in_payload
 
     fake_key = "sk-fake-lit6835-past-the-limit"
     node = {"api_key": fake_key}
-    for _ in range(2 * DEFAULT_MAX_RECURSE_DEPTH_SENSITIVE_DATA_MASKER + 1):
+    for _ in range(2 * DEFAULT_MAX_RECURSE_DEPTH + 1):
         node = {"extra_body": node} if wrap == "mapping" else {"providers": [node]}
 
     result = redact_credentials_in_payload({**node, "max_tokens": 17})
@@ -393,3 +393,40 @@ def test_redact_credentials_in_payload_hides_containers_at_the_recursion_limit(w
     assert fake_key not in str(result)
     assert "REDACTED" in str(result)
     assert result["max_tokens"] == 17
+
+
+def test_redact_credentials_in_payload_leaves_a_realistic_tool_schema_intact():
+    """The bound must not eat ordinary payloads: a tool whose JSON schema nests an array of
+    objects inside a nested object is what agent traffic looks like, and the verbose line is
+    useless if those leaves come back as REDACTED."""
+    from litellm.litellm_core_utils.sensitive_data_masker import redact_credentials_in_payload
+
+    tool = {
+        "type": "function",
+        "function": {
+            "name": "search_orders",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "filters": {
+                        "type": "object",
+                        "properties": {
+                            "items": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {"sku": {"type": "string"}, "qty": {"type": "integer"}},
+                                },
+                            }
+                        },
+                    }
+                },
+            },
+        },
+    }
+
+    result = redact_credentials_in_payload({"model": "gpt-4o-mini", "tools": [tool], "api_key": "sk-fake-lit6835"})
+
+    assert "REDACTED" not in str(result["tools"])
+    assert result["tools"][0] == tool
+    assert result["api_key"] == "REDACTED"

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -5805,3 +5805,53 @@ class TestIsVisionExplicitlyDisabled:
             is_vision_explicitly_disabled("fireworks_ai/accounts/fireworks/models/deepseek-v4-flash-0731") is True
         )
         assert is_vision_explicitly_disabled("anthropic/claude-sonnet-4-5") is False
+
+
+class TestVerboseRequestLineRedaction:
+    """`litellm.set_verbose = True` echoes the caller's kwargs to stdout, so a credential
+    kwarg lands in whatever collects stdout: a terminal, a container log drain, a CI job
+    log. Credential-named kwargs must not survive that echo, while ordinary params still
+    must, or the line stops telling the developer what they called."""
+
+    FAKE_API_KEY: Final = "sk-fake-lit6823-0000000000000000"
+
+    def _verbose_stdout(self, capsys, monkeypatch, **kwargs) -> str:
+        monkeypatch.setattr(litellm, "set_verbose", True)
+        monkeypatch.setattr("litellm._logging.set_verbose", True)
+        capsys.readouterr()
+        litellm.completion(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": "hello"}],
+            mock_response="hi",
+            **kwargs,
+        )
+        captured: Final = capsys.readouterr()
+        return captured.out + captured.err
+
+    def test_api_key_never_reaches_stdout(self, capsys, monkeypatch):
+        printed: Final = self._verbose_stdout(capsys, monkeypatch, api_key=self.FAKE_API_KEY)
+
+        assert "Request to litellm:" in printed
+        assert self.FAKE_API_KEY not in printed
+        assert "api_key='REDACTED'" in printed
+
+    def test_credential_headers_never_reach_stdout(self, capsys, monkeypatch):
+        printed: Final = self._verbose_stdout(
+            capsys,
+            monkeypatch,
+            api_key=self.FAKE_API_KEY,
+            extra_headers={"Authorization": "Bearer fake-lit6823-header", "x-request-id": "abc123"},
+        )
+
+        assert "fake-lit6823-header" not in printed
+        assert "'Authorization': 'REDACTED'" in printed
+        assert "'x-request-id': 'abc123'" in printed
+
+    def test_ordinary_params_still_printed(self, capsys, monkeypatch):
+        printed: Final = self._verbose_stdout(
+            capsys, monkeypatch, api_key=self.FAKE_API_KEY, max_tokens=17, temperature=0.25
+        )
+
+        assert "model='gpt-3.5-turbo'" in printed
+        assert "max_tokens=17" in printed
+        assert "temperature=0.25" in printed

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -5808,14 +5808,15 @@ class TestIsVisionExplicitlyDisabled:
 
 
 class TestVerboseRequestLineRedaction:
-    """`litellm.set_verbose = True` echoes the caller's kwargs to stdout, so a credential
-    kwarg lands in whatever collects stdout: a terminal, a container log drain, a CI job
-    log. Credential-named kwargs must not survive that echo, while ordinary params still
-    must, or the line stops telling the developer what they called."""
+    """`litellm.set_verbose = True` echoes the caller's kwargs back as a `litellm.completion(...)`
+    line on stdout, so a credential kwarg lands in whatever collects stdout: a terminal, a
+    container log drain, a CI job log. Credential-named kwargs must not survive that echo,
+    at any nesting depth, while ordinary params still must, or the line stops telling the
+    developer what they called."""
 
     FAKE_API_KEY: Final = "sk-fake-lit6823-0000000000000000"
 
-    def _verbose_stdout(self, capsys, monkeypatch, **kwargs) -> str:
+    def _verbose_request_line(self, capsys, monkeypatch, **kwargs) -> str:
         monkeypatch.setattr(litellm, "set_verbose", True)
         monkeypatch.setattr("litellm._logging.set_verbose", True)
         capsys.readouterr()
@@ -5826,17 +5827,17 @@ class TestVerboseRequestLineRedaction:
             **kwargs,
         )
         captured: Final = capsys.readouterr()
-        return captured.out + captured.err
+        return "\n".join(line for line in (captured.out + captured.err).splitlines() if "litellm.completion(" in line)
 
-    def test_api_key_never_reaches_stdout(self, capsys, monkeypatch):
-        printed: Final = self._verbose_stdout(capsys, monkeypatch, api_key=self.FAKE_API_KEY)
+    def test_api_key_never_reaches_the_request_line(self, capsys, monkeypatch):
+        printed: Final = self._verbose_request_line(capsys, monkeypatch, api_key=self.FAKE_API_KEY)
 
-        assert "Request to litellm:" in printed
+        assert "litellm.completion(" in printed
         assert self.FAKE_API_KEY not in printed
         assert "api_key='REDACTED'" in printed
 
-    def test_credential_headers_never_reach_stdout(self, capsys, monkeypatch):
-        printed: Final = self._verbose_stdout(
+    def test_credential_headers_never_reach_the_request_line(self, capsys, monkeypatch):
+        printed: Final = self._verbose_request_line(
             capsys,
             monkeypatch,
             api_key=self.FAKE_API_KEY,
@@ -5847,8 +5848,19 @@ class TestVerboseRequestLineRedaction:
         assert "'Authorization': 'REDACTED'" in printed
         assert "'x-request-id': 'abc123'" in printed
 
+    def test_credentials_nested_in_a_list_never_reach_the_request_line(self, capsys, monkeypatch):
+        printed: Final = self._verbose_request_line(
+            capsys,
+            monkeypatch,
+            api_key=self.FAKE_API_KEY,
+            extra_body={"providers": [{"name": "openai", "api_key": "sk-fake-lit6823-nested"}]},
+        )
+
+        assert "sk-fake-lit6823-nested" not in printed
+        assert "'name': 'openai'" in printed
+
     def test_ordinary_params_still_printed(self, capsys, monkeypatch):
-        printed: Final = self._verbose_stdout(
+        printed: Final = self._verbose_request_line(
             capsys, monkeypatch, api_key=self.FAKE_API_KEY, max_tokens=17, temperature=0.25
         )
 

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -5867,3 +5867,73 @@ class TestVerboseRequestLineRedaction:
         assert "model='gpt-3.5-turbo'" in printed
         assert "max_tokens=17" in printed
         assert "temperature=0.25" in printed
+
+
+class TestFinalOptionalParamsLineRedaction:
+    """A verbose run echoes the fully built optional params too, and `extra_body` carries whatever the
+    caller nested inside it straight onto that line, so a credential tucked in there lands in a terminal
+    or a log drain in plaintext. It has to be redacted on both surfaces `print_verbose` writes to, and the
+    line has to keep printing on both, because `litellm.set_verbose` and the DEBUG logger are independent
+    switches and neither implies the other."""
+
+    FAKE_NESTED_KEY: Final = "sk-fake-lit6835-nested-0000000000"
+
+    def _complete(self, **kwargs) -> None:
+        litellm.completion(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": "hello"}],
+            mock_response="hi",
+            **kwargs,
+        )
+
+    def _printed_line(self, capsys) -> str:
+        captured: Final = capsys.readouterr()
+        return "\n".join(
+            line for line in (captured.out + captured.err).splitlines() if "Final returned optional params" in line
+        )
+
+    def test_nested_credential_is_redacted_when_only_set_verbose_is_on(self, capsys, caplog, monkeypatch):
+        monkeypatch.setattr(litellm, "set_verbose", True)
+        with caplog.at_level(logging.WARNING, logger=verbose_logger.name):
+            capsys.readouterr()
+            self._complete(extra_body={"providers": [{"name": "openai", "api_key": self.FAKE_NESTED_KEY}]})
+            printed: Final = self._printed_line(capsys)
+
+        assert printed
+        assert self.FAKE_NESTED_KEY not in printed
+        assert "'api_key': 'REDACTED'" in printed
+        assert "'name': 'openai'" in printed
+
+    def test_line_still_reaches_the_logger_when_only_the_debug_logger_is_on(self, capsys, caplog, monkeypatch):
+        monkeypatch.setattr(litellm, "set_verbose", False)
+        with caplog.at_level(logging.DEBUG, logger=verbose_logger.name):
+            self._complete(extra_body={"providers": [{"name": "openai", "api_key": self.FAKE_NESTED_KEY}]})
+            logged: Final = "\n".join(
+                record.getMessage()
+                for record in caplog.records
+                if "Final returned optional params" in record.getMessage()
+            )
+
+        assert logged
+        assert self.FAKE_NESTED_KEY not in logged
+        assert "'name': 'openai'" in logged
+
+    def test_nothing_is_emitted_when_neither_verbose_switch_is_on(self, capsys, caplog, monkeypatch):
+        monkeypatch.setattr(litellm, "set_verbose", False)
+        with caplog.at_level(logging.WARNING, logger=verbose_logger.name):
+            capsys.readouterr()
+            self._complete(extra_body={"providers": [{"name": "openai", "api_key": self.FAKE_NESTED_KEY}]})
+            captured: Final = capsys.readouterr()
+
+        assert "Final returned optional params" not in captured.out + captured.err
+        assert self.FAKE_NESTED_KEY not in captured.out + captured.err
+
+    def test_ordinary_optional_params_still_reach_the_line(self, capsys, caplog, monkeypatch):
+        monkeypatch.setattr(litellm, "set_verbose", True)
+        with caplog.at_level(logging.WARNING, logger=verbose_logger.name):
+            capsys.readouterr()
+            self._complete(max_tokens=17, temperature=0.25)
+            printed: Final = self._printed_line(capsys)
+
+        assert "'max_tokens': 17" in printed
+        assert "'temperature': 0.25" in printed


### PR DESCRIPTION
## TLDR

Problem this solves:

- A credential nested in `extra_body` printed in plaintext
- It lands on the verbose "Final returned optional params" line
- Under the documented flag it is the only line the credential lands on
- Terminal scrollback, log drains, and CI job logs keep it
- The redactor itself also handed back anything nested past its depth limit

How it solves it:

- Redact that line with `redact_credentials_in_payload`, the helper #39526 added
- Guard the call site so the walk only runs when something reads it
- Guard is the union of both switches `print_verbose` writes to
- Net effect on the hot path is faster than today, not slower
- Fail closed past the walk's bound, and widen that bound so tool schemas survive

Three calls worth explaining. The guard reads `litellm.set_verbose` or the LiteLLM logger's DEBUG level rather than reconciling the two `set_verbose` flags, because reconciling changes what four other `_is_debugging_on()` call sites emit for everyone using the documented flag, which is a behavior change well outside a credential-leak fix. The union is exactly the condition `print_verbose` itself already uses, so the line prints in exactly the same cases it did before. And this branches off #39526's head rather than `litellm_internal_staging`, because `redact_credentials_in_payload` does not exist on staging yet; the cost is that this lands after #39526 does, and merging staging in after that is a no-op on the helper. The third is that the redactor's own depth-limit fix rides here rather than on #39526: Greptile caught it on this PR, #39526 already has auto-merge armed and a reviewer waiting, and restarting its loop to move one commit across would delay the first half of the fix for no gain. That fix is two halves, because failing closed at the masker's depth of 10 turned an ordinary nested tool schema into `REDACTED` leaves; the walk now uses the generic `DEFAULT_MAX_RECURSE_DEPTH` of 100, which no real payload reaches, and the shared masker's own limit is left alone.

## User Flow

Before: a developer debugging a provider-specific call gets the credential they tucked into `extra_body` printed in full

1. They set `litellm.set_verbose = True` in their script, or an operator puts `set_verbose: true` under `litellm_settings` in the proxy's config.yaml
2. They call `litellm.completion(model="gpt-4o-mini", api_key=<their key>, extra_body={"providers": [{"name": "openai", "api_key": <a second key>}]}, messages=[...])`, or POST `https://litellm-domain/v1/chat/completions` with that same `extra_body`
3. The console prints `Final returned optional params: {...}` with the `extra_body` credential spelled out in full
4. That is the only line the credential lands on, because the `Request to litellm:` line #39526 redacted is printed only when `LITELLM_LOG=DEBUG` is set instead of this flag
5. The call returns 200 with a normal completion, so nothing looks wrong from the client's side
6. Anyone who can read that output, a teammate opening the CI job log or whoever holds the container log drain, can lift the second provider key and call that provider as them

After: the same session prints the same line with the nested credential replaced by `REDACTED`

1. They set `litellm.set_verbose = True` in their script, or an operator puts `set_verbose: true` under `litellm_settings` in the proxy's config.yaml
2. They call `litellm.completion(model="gpt-4o-mini", api_key=<their key>, extra_body={"providers": [{"name": "openai", "api_key": <a second key>}]}, messages=[...])`, or POST `https://litellm-domain/v1/chat/completions` with that same `extra_body`
3. The console prints `Final returned optional params: {...}` with the `extra_body` credential shown as `REDACTED`, the provider name and every ordinary param still readable
4. Running the same script under `LITELLM_LOG=DEBUG` instead still prints that line, still redacted, next to the `Request to litellm:` line, so neither switch lost output
5. The call returns 200 with a normal completion, so nothing looks wrong from the client's side
6. Nobody reading that output can lift the second provider key, because it is no longer in it

## Relevant issues

## Linear ticket

Resolves LIT-6835

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Every run below uses a throwaway placeholder in the nested `api_key` slot, never a real key, and reads the result with `grep -c` only, so no credential value appears anywhere in this PR. The real OpenRouter key that authenticates the call is checked for separately and never appears in the captured output on either side.

Shared setup, used by every case:

- the nested value under test is a fake string exported as `LIT6835_FAKE_NESTED_KEY`
- the model is `openrouter/openai/gpt-4o-mini`, hit live, with real spend. OpenAI itself rejects `extra_body={"providers": [...]}` with a 400, so it cannot carry a flow whose last step is a successful call
- Before is `0a62195db2`, the commit immediately under this one, which is #39526's head rather than
  the merge base with `litellm_internal_staging`; that is the only base where the helper this calls exists
- the proxy case boots with `--num_workers 2` and this config:

```yaml
model_list:
  - model_name: gpt-4o-mini
    litellm_params:
      model: openrouter/openai/gpt-4o-mini
      api_key: os.environ/OPENROUTER_API_KEY

litellm_settings:
  set_verbose: true
```

### Before (0a62195db2)

#### Case 1: Python SDK, `litellm.set_verbose = True`

1. Run the script the ticket describes:

```
$ cat repro.py
import os

import litellm

litellm.set_verbose = True

response = litellm.completion(
    model="openrouter/openai/gpt-4o-mini",
    api_key=os.environ["OPENROUTER_API_KEY"],
    extra_body={"providers": [{"name": "openai", "api_key": os.environ["LIT6835_FAKE_NESTED_KEY"]}]},
    messages=[{"role": "user", "content": "Reply with the single word: ok"}],
)
print("COMPLETION_OK:", response.choices[0].message.content.strip()[:20])

$ python repro.py > out.txt 2>&1
```

2. Count what landed in the captured output, without printing any of it:

```
$ echo "completion_succeeded=$(grep -c 'COMPLETION_OK: ok' out.txt)"
$ echo "optional_params_line_printed=$(grep -c 'Final returned optional params' out.txt)"
$ echo "fake_nested_credential_on_optional_params_line=$(grep 'Final returned optional params' out.txt | grep -c -- "$LIT6835_FAKE_NESTED_KEY")"
$ echo "redacted_marker_on_optional_params_line=$(grep 'Final returned optional params' out.txt | grep -c REDACTED)"
$ echo "provider_name_still_readable=$(grep 'Final returned optional params' out.txt | grep -cF "name': 'openai")"
$ echo "real_openrouter_key_in_output=$(grep -c -- "$OPENROUTER_API_KEY" out.txt)"

completion_succeeded=1
optional_params_line_printed=1
fake_nested_credential_on_optional_params_line=1
redacted_marker_on_optional_params_line=0
provider_name_still_readable=1
real_openrouter_key_in_output=0
```

The call succeeds and the nested credential is on the line, exactly as the ticket describes.

#### Case 2: proxy, `litellm_settings: set_verbose: true`

1. Boot the proxy from this commit on a random free port with two workers, then send the same body a client would:

```
$ curl -sS -o /dev/null -w '%{http_code}\n' -X POST http://127.0.0.1:21933/v1/chat/completions \
    -H 'Authorization: Bearer sk-lit6835-qa-master' -H 'Content-Type: application/json' \
    -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Reply with the single word: ok"}],"extra_body":{"providers":[{"name":"openai","api_key":"<fake key>"}]}}'
200
```

2. Count what landed in the proxy's own output:

```
optional_params_line_printed=1
fake_nested_credential_on_optional_params_line=1
fake_nested_credential_anywhere_in_proxy_log=1
redacted_marker_on_optional_params_line=0
provider_name_still_readable=1
real_openrouter_key_in_proxy_log=0
```

#### Case 3: Python SDK, DEBUG logger instead of `set_verbose`

1. Same call, but with `os.environ["LITELLM_LOG"] = "DEBUG"` and the debug logger turned on instead of `litellm.set_verbose = True`.

2. Same counts:

```
completion_succeeded=1
optional_params_line_printed=2
fake_nested_credential_on_optional_params_line=0
redacted_marker_on_optional_params_line=2
provider_name_still_readable=2
real_openrouter_key_in_output=0
```

This switch never leaked, because the logging path already collapses a credential-named pair before it is written. Only the `print` path that `litellm.set_verbose` turns on was leaking. The case is here so the After side can show the line is still emitted on this switch too, which is what the guard has to preserve.

#### Case 4: Python SDK, credential nested past the redactor's depth limit

1. Same script as case 1, but the fake credential is wrapped in ten `{"providers": [ ... ]}` layers instead of one, which is past the walk's depth limit:

```
completion_succeeded=1
optional_params_line_printed=1
fake_deep_credential_on_optional_params_line=1
fake_deep_credential_anywhere_in_output=1
redacted_marker_on_optional_params_line=0
real_openrouter_key_in_output=0
```

The walk stopped at its limit and handed the rest of the payload back untouched, so the credential printed in full even though the redactor ran.

#### Case 5: Python SDK, a tool whose JSON schema nests an array of objects

1. Same script as case 1, plus a `search_orders` tool whose parameters nest an array of objects two levels down, which is what agent traffic looks like:

```
completion_succeeded=1
optional_params_line_printed=1
fake_nested_credential_on_optional_params_line=1
tool_schema_leaf_sku_readable_on_line=1
tool_schema_leaf_qty_readable_on_line=1
real_openrouter_key_in_output=0
```

The credential leaks as in case 1, and the tool schema's leaves are readable, which is the half that must not regress.

#### Case 6: hot path with debugging off

1. Call `get_optional_params` in a loop with a realistic payload (12 tools of 8 properties each), asserting up front that `litellm.set_verbose` is `False` and the LiteLLM logger is not at DEBUG, then report microseconds per call:

```
base-r1  us_per_call_median=63.5
base-r2  us_per_call_median=63.6
base-r3  us_per_call_median=64.2
```

### After (86c5159d96)

#### Case 1: Python SDK, `litellm.set_verbose = True`

1. Same script, same commands, run against this commit:

```
completion_succeeded=1
optional_params_line_printed=1
fake_nested_credential_on_optional_params_line=0
redacted_marker_on_optional_params_line=1
provider_name_still_readable=1
real_openrouter_key_in_output=0
```

The call still succeeds, the line is still printed, the provider name is still readable, and the nested credential is gone.

#### Case 2: proxy, `litellm_settings: set_verbose: true`

1. Same boot, same curl (fresh port for this leg):

```
$ curl -sS -o /dev/null -w '%{http_code}\n' -X POST http://127.0.0.1:21418/v1/chat/completions \
    -H 'Authorization: Bearer sk-lit6835-qa-master' -H 'Content-Type: application/json' \
    -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Reply with the single word: ok"}],"extra_body":{"providers":[{"name":"openai","api_key":"<fake key>"}]}}'
200
```

2. Same counts:

```
optional_params_line_printed=1
fake_nested_credential_on_optional_params_line=0
fake_nested_credential_anywhere_in_proxy_log=0
redacted_marker_on_optional_params_line=1
provider_name_still_readable=1
real_openrouter_key_in_proxy_log=0
```

#### Case 3: Python SDK, DEBUG logger instead of `set_verbose`

1. Same call, same counts:

```
completion_succeeded=1
optional_params_line_printed=2
fake_nested_credential_on_optional_params_line=0
redacted_marker_on_optional_params_line=2
provider_name_still_readable=2
real_openrouter_key_in_output=0
```

The line is still emitted on this switch, which is the half a plain `_is_debugging_on()` guard would have kept and the half a plain `litellm.set_verbose` guard would have dropped.

#### Case 4: Python SDK, credential nested past the redactor's depth limit

1. Same ten-layer script, same counts:

```
completion_succeeded=1
optional_params_line_printed=1
fake_deep_credential_on_optional_params_line=0
fake_deep_credential_anywhere_in_output=0
redacted_marker_on_optional_params_line=1
real_openrouter_key_in_output=0
```

The walk now reaches this depth and redacts by key name, and past the bound a container is replaced wholesale instead of handed back, so burying a credential deeper still hides it rather than exposing it.

#### Case 5: Python SDK, a tool whose JSON schema nests an array of objects

1. Same tool, same counts:

```
completion_succeeded=1
optional_params_line_printed=1
fake_nested_credential_on_optional_params_line=0
tool_schema_leaf_sku_readable_on_line=1
tool_schema_leaf_qty_readable_on_line=1
real_openrouter_key_in_output=0
```

The credential is gone and the schema's leaves are still readable, so the fail-closed cutoff costs nothing on an ordinary payload.

#### Case 6: hot path with debugging off

1. Same loop, same assertions, five alternating rounds on the same machine and the same venv, plus a third tree carrying the redaction with no guard so the guard's own worth is visible:

| variant | r1 | r2 | r3 | r4 | r5 |
| --- | --- | --- | --- | --- | --- |
| base, leaks, no redaction | 63.5 us | 63.6 us | 64.2 us | 90.5 us | 95.5 us |
| redaction with no guard | 401.5 us | 404.4 us | 423.4 us | 475.7 us | 642.7 us |
| this PR, guard plus redaction | 24.6 us | 24.6 us | 24.5 us | 34.9 us | 34.7 us |

Rounds 4 and 5 ran with the machine under other load, which is why every absolute number there is higher; the alternating order keeps the three variants comparable inside each round. Redacting without a guard costs 6.3x to 6.7x what the line costs today. With the guard it lands at roughly 0.4x, faster than today, because the f-string was being rendered on every request even when nothing was going to read it.

Observations from the runs:

- Only the `print` path leaked; the logging path already redacted
- Verified with an opaque fake too, so not pattern luck
- OpenAI 400s on `extra_body={"providers": [...]}`; OpenRouter accepts it
- Logger path collapses the whole pair, losing the key name
- This PR's line keeps the key name next to `REDACTED`
- Three non-secret param names read `REDACTED` too

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Stacked on #39526; that has to merge first
- The helper only matches credential-shaped names, same as #39526
- Other `print_verbose` call sites still build payloads unguarded
- A container past the walk's bound now reads `REDACTED` whole, so a payload nested
  deeper than 100 containers loses its non-secret detail from the line too. That is
  the fail-closed direction, and nothing in the flows above comes close to that depth.
  The bound also caps the walk's stack: pushed past it, it needs at most 216 of Python's
  1000 default recursion slots, and a self-referential payload now stops instead of
  being handed to `repr`
- The guard reads the logger's effective DEBUG level, not whether a handler will actually
  emit, so a DEBUG logger with every handler filtered still pays for the walk. That is the
  same predicate `print_verbose` itself uses, and narrowing it would change when the line prints
- `print_args_passed_to_litellm`, the request line #39526 redacted, still reads
  `litellm._logging.set_verbose`, so it never prints for someone on the documented
  `litellm.set_verbose = True`. Pre-existing and deliberately left alone here, since
  reconciling the two flags changes what four other call sites emit
- The sibling `mask_dict` and `_walk_payload` in the same module still hand back the subtree
  at their depth of 10. They feed SpendLogs and OTel, where failing closed would write
  `REDACTED` into stored records, so the direction that is right for a printed line is wrong
  for them
- `prompt_cache_key`, `prompt_cache_isolation_key` and `return_token_ids` read `REDACTED`
  on this line as well. All three are non-secret and the loss is a little debug detail, not
  correctness; they are already redacted the same way on #39526's request line, and widening the
  shared masker's overrides to spare them would change every other caller of it, which is a bigger
  blast radius than the three names are worth

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what verbose/debug logs emit and adds recursive payload walks on those paths; behavior is security-oriented but could over-redact deep containers or misclassified key names in debug output.
> 
> **Overview**
> Stops **credential leaks in verbose/debug output** when `litellm.set_verbose` or DEBUG logging echoes call kwargs and built optional params (including credentials nested in `extra_body`, headers, and lists).
> 
> Adds **`redact_credentials_in_payload`**, which walks nested dicts/lists/tuples, uses the shared `SensitiveDataMasker` key rules, replaces sensitive values with the public **`REDACTED`** marker (no partial reveal), preserves `None` and non-secret fields, and **fails closed** past `DEFAULT_MAX_RECURSE_DEPTH` by redacting whole containers. Exposes **`REDACTED`** from `secret_redaction` for reuse.
> 
> **`utils.py`** redacts kwargs on the `litellm.completion(...)` request line and redacts optional params on the “Final returned optional params” line only when **`_print_verbose_is_active()`** is true (`litellm.set_verbose` or LiteLLM logger DEBUG), avoiding the redaction walk on the hot path when nothing prints.
> 
> Tests cover full redaction, nested sequences, depth-limit behavior, realistic tool schemas, and integration with verbose output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86c5159d96ac76f12738e30b6e2b3ddeba645480. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->