### PR TITLE
fix(proxy): stop answering with the literal string "None" on the proxy-server, auth, and health routes

### DIFF
--- a/litellm/proxy/auth/auth_exception_handler.py
+++ b/litellm/proxy/auth/auth_exception_handler.py
@@ -24,6 +24,7 @@ from litellm.proxy.auth.auth_utils import (
     is_invalid_virtual_key_error,
     mark_invalid_virtual_key_error,
 )
+from litellm.proxy.common_utils.openai_error_payload import openai_error_param
 from litellm.proxy.db.exception_handler import PrismaDBExceptionHandler
 from litellm.types.services import ServiceTypes
 
@@ -54,7 +55,7 @@ def _as_proxy_exception(e: Exception) -> ProxyException:
         return ProxyException(
             message=getattr(e, "detail", f"Authentication Error({e})"),
             type=ProxyErrorTypes.auth_error,
-            param=getattr(e, "param", "None"),
+            param=openai_error_param(e),
             code=getattr(e, "status_code", status.HTTP_401_UNAUTHORIZED),
         )
     if isinstance(e, ProxyException):
@@ -63,13 +64,13 @@ def _as_proxy_exception(e: Exception) -> ProxyException:
         return ProxyException(
             message=PrismaDBExceptionHandler.database_unavailable_message(e),
             type=ProxyErrorTypes.no_db_connection,
-            param="None",
+            param=None,
             code=status.HTTP_503_SERVICE_UNAVAILABLE,
         )
     return ProxyException(
         message="Authentication Error, " + str(e),
         type=ProxyErrorTypes.auth_error,
-        param=getattr(e, "param", "None"),
+        param=openai_error_param(e),
         code=status.HTTP_401_UNAUTHORIZED,
     )
 

--- a/litellm/proxy/auth/handle_jwt.py
+++ b/litellm/proxy/auth/handle_jwt.py
@@ -142,7 +142,7 @@ def jwks_unavailable_exception(error: JWKSUnreachableError) -> ProxyException:
             f"unreachable, so the JWT signature could not be verified. Please retry shortly. Error: {error}"
         ),
         type=ProxyErrorTypes.auth_provider_unavailable,
-        param="None",
+        param=None,
         code=status.HTTP_503_SERVICE_UNAVAILABLE,
     )
 

--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -40,6 +40,7 @@ from litellm.proxy.auth.auth_utils import (
     _BANNED_REQUEST_BODY_PARAMS,  # pyright: ignore[reportPrivateUsage]  # one canonical list, shared with the request-body check
 )
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+from litellm.proxy.common_utils.openai_error_payload import openai_error_param
 from litellm.proxy.db.exception_handler import PrismaDBExceptionHandler
 from litellm.proxy.db.proxy_worker_heartbeat import count_live_proxy_workers
 from litellm.proxy.health_check import (
@@ -529,7 +530,7 @@ async def health_services_endpoint(
             raise ProxyException(
                 message=getattr(e, "detail", f"Authentication Error({e})"),
                 type=ProxyErrorTypes.auth_error,
-                param=getattr(e, "param", "None"),
+                param=openai_error_param(e),
                 code=getattr(e, "status_code", status.HTTP_500_INTERNAL_SERVER_ERROR),
             )
         elif isinstance(e, ProxyException):
@@ -537,7 +538,7 @@ async def health_services_endpoint(
         raise ProxyException(
             message="Authentication Error, " + str(e),
             type=ProxyErrorTypes.auth_error,
-            param=getattr(e, "param", "None"),
+            param=openai_error_param(e),
             code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         )
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -112,6 +112,11 @@ from litellm.proxy.common_utils.callback_utils import (
     process_callback,
     strip_callback_config,
 )
+from litellm.proxy.common_utils.openai_error_payload import (
+    error_status_code,
+    openai_error_param,
+    openai_error_type,
+)
 from litellm.proxy.common_utils.realtime_utils import _realtime_request_body
 from litellm.router_utils.add_retry_fallback_headers import (
     get_fallback_errors_from_headers,
@@ -8160,9 +8165,9 @@ async def async_assistants_data_generator(response, user_api_key_dict: UserAPIKe
 
         proxy_exception: Final = ProxyException(
             message=getattr(e, "message", error_msg),
-            type=getattr(e, "type", "None"),
-            param=getattr(e, "param", "None"),
-            code=getattr(e, "status_code", 500),
+            type=openai_error_type(e, error_status_code(e, 500)),
+            param=openai_error_param(e),
+            code=error_status_code(e, 500),
         )
         error_returned: Final = json.dumps({"error": proxy_exception.to_dict()})
         yield f"data: {error_returned}\n\n"
@@ -8867,9 +8872,9 @@ async def async_data_generator(
 
         proxy_exception: Final = ProxyException(
             message=getattr(e, "message", error_msg),
-            type=getattr(e, "type", "None"),
-            param=getattr(e, "param", "None"),
-            code=getattr(e, "status_code", 500),
+            type=openai_error_type(e, error_status_code(e, 500)),
+            param=openai_error_param(e),
+            code=error_status_code(e, 500),
         )
         error_returned: Final = json.dumps({"error": proxy_exception.to_dict()})
         stream_completed = True
@@ -10819,10 +10824,10 @@ async def completion(
         error_msg: Final = f"{e}"
         raise ProxyException(
             message=getattr(e, "message", error_msg),
-            type=getattr(e, "type", "None"),
-            param=getattr(e, "param", "None"),
+            type=openai_error_type(e, error_status_code(e, 500)),
+            param=openai_error_param(e),
             openai_code=getattr(e, "code", None),
-            code=getattr(e, "status_code", 500),
+            code=error_status_code(e, 500),
         )
 
 
@@ -11052,17 +11057,17 @@ async def moderations(
         if isinstance(e, HTTPException):
             raise ProxyException(
                 message=getattr(e, "message", str(e)),
-                type=getattr(e, "type", "None"),
-                param=getattr(e, "param", "None"),
-                code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
+                type=openai_error_type(e, error_status_code(e, status.HTTP_400_BAD_REQUEST)),
+                param=openai_error_param(e),
+                code=error_status_code(e, status.HTTP_400_BAD_REQUEST),
             )
         else:
             error_msg: Final = f"{e}"
             raise ProxyException(
                 message=getattr(e, "message", error_msg),
-                type=getattr(e, "type", "None"),
-                param=getattr(e, "param", "None"),
-                code=getattr(e, "status_code", 500),
+                type=openai_error_type(e, error_status_code(e, 500)),
+                param=openai_error_param(e),
+                code=error_status_code(e, 500),
             )
 
 
@@ -11199,10 +11204,10 @@ async def audio_speech(
             raise e
         raise ProxyException(
             message=getattr(e, "message", f"{e}"),
-            type=getattr(e, "type", "None"),
-            param=getattr(e, "param", "None"),
+            type=openai_error_type(e, error_status_code(e, 500)),
+            param=openai_error_param(e),
             openai_code=getattr(e, "code", None),
-            code=getattr(e, "status_code", 500),
+            code=error_status_code(e, 500),
         )
 
 
@@ -11347,18 +11352,18 @@ async def audio_transcriptions(
         if isinstance(e, HTTPException):
             raise ProxyException(
                 message=getattr(e, "message", str(e.detail)),
-                type=getattr(e, "type", "None"),
-                param=getattr(e, "param", "None"),
-                code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
+                type=openai_error_type(e, error_status_code(e, status.HTTP_400_BAD_REQUEST)),
+                param=openai_error_param(e),
+                code=error_status_code(e, status.HTTP_400_BAD_REQUEST),
             )
         else:
             error_msg: Final = f"{e}"
             raise ProxyException(
                 message=getattr(e, "message", error_msg),
-                type=getattr(e, "type", "None"),
-                param=getattr(e, "param", "None"),
+                type=openai_error_type(e, error_status_code(e, 500)),
+                param=openai_error_param(e),
                 openai_code=getattr(e, "code", None),
-                code=getattr(e, "status_code", 500),
+                code=error_status_code(e, 500),
             )
 
 
@@ -11645,18 +11650,18 @@ async def get_assistants(
         if isinstance(e, HTTPException):
             raise ProxyException(
                 message=getattr(e, "message", str(e.detail)),
-                type=getattr(e, "type", "None"),
-                param=getattr(e, "param", "None"),
-                code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
+                type=openai_error_type(e, error_status_code(e, status.HTTP_400_BAD_REQUEST)),
+                param=openai_error_param(e),
+                code=error_status_code(e, status.HTTP_400_BAD_REQUEST),
             )
         else:
             error_msg: Final = f"{e}"
             raise ProxyException(
                 message=getattr(e, "message", error_msg),
-                type=getattr(e, "type", "None"),
-                param=getattr(e, "param", "None"),
+                type=openai_error_type(e, error_status_code(e, 500)),
+                param=openai_error_param(e),
                 openai_code=getattr(e, "code", None),
-                code=getattr(e, "status_code", 500),
+                code=error_status_code(e, 500),
             )
 
 
@@ -11736,16 +11741,16 @@ async def create_assistant(
         if isinstance(e, HTTPException):
             raise ProxyException(
                 message=getattr(e, "message", str(e.detail)),
-                type=getattr(e, "type", "None"),
-                param=getattr(e, "param", "None"),
-                code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
+                type=openai_error_type(e, error_status_code(e, status.HTTP_400_BAD_REQUEST)),
+                param=openai_error_param(e),
+                code=error_status_code(e, status.HTTP_400_BAD_REQUEST),
             )
         else:
             error_msg: Final = f"{e}"
             raise ProxyException(
                 message=getattr(e, "message", error_msg),
-                type=getattr(e, "type", "None"),
-                param=getattr(e, "param", "None"),
+                type=openai_error_type(e, error_status_code(e, 500)),
+                param=openai_error_param(e),
                 code=getattr(e, "code", getattr(e, "status_code", 500)),
             )
 
@@ -11825,16 +11830,16 @@ async def delete_assistant(
         if isinstance(e, HTTPException):
             raise ProxyException(
                 message=getattr(e, "message", str(e.detail)),
-                type=getattr(e, "type", "None"),
-                param=getattr(e, "param", "None"),
-                code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
+                type=openai_error_type(e, error_status_code(e, status.HTTP_400_BAD_REQUEST)),
+                param=openai_error_param(e),
+                code=error_status_code(e, status.HTTP_400_BAD_REQUEST),
             )
         else:
             error_msg: Final = f"{e}"
             raise ProxyException(
                 message=getattr(e, "message", error_msg),
-                type=getattr(e, "type", "None"),
-                param=getattr(e, "param", "None"),
+                type=openai_error_type(e, error_status_code(e, 500)),
+                param=openai_error_param(e),
                 code=getattr(e, "code", getattr(e, "status_code", 500)),
             )
 
@@ -11914,16 +11919,16 @@ async def create_threads(
         if isinstance(e, HTTPException):
             raise ProxyException(
                 message=getattr(e, "message", str(e.detail)),
-                type=getattr(e, "type", "None"),
-                param=getattr(e, "param", "None"),
-                code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
+                type=openai_error_type(e, error_status_code(e, status.HTTP_400_BAD_REQUEST)),
+                param=openai_error_param(e),
+                code=error_status_code(e, status.HTTP_400_BAD_REQUEST),
             )
         else:
             error_msg: Final = f"{e}"
             raise ProxyException(
                 message=getattr(e, "message", error_msg),
-                type=getattr(e, "type", "None"),
-                param=getattr(e, "param", "None"),
+                type=openai_error_type(e, error_status_code(e, 500)),
+                param=openai_error_param(e),
                 code=getattr(e, "code", getattr(e, "status_code", 500)),
             )
 
@@ -12001,16 +12006,16 @@ async def get_thread(
         if isinstance(e, HTTPException):
             raise ProxyException(
                 message=getattr(e, "message", str(e.detail)),
-                type=getattr(e, "type", "None"),
-                param=getattr(e, "param", "None"),
-                code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
+                type=openai_error_type(e, error_status_code(e, status.HTTP_400_BAD_REQUEST)),
+                param=openai_error_param(e),
+                code=error_status_code(e, status.HTTP_400_BAD_REQUEST),
             )
         else:
             error_msg: Final = f"{e}"
             raise ProxyException(
                 message=getattr(e, "message", error_msg),
-                type=getattr(e, "type", "None"),
-                param=getattr(e, "param", "None"),
+                type=openai_error_type(e, error_status_code(e, 500)),
+                param=openai_error_param(e),
                 code=getattr(e, "code", getattr(e, "status_code", 500)),
             )
 
@@ -12092,16 +12097,16 @@ async def add_messages(
         if isinstance(e, HTTPException):
             raise ProxyException(
                 message=getattr(e, "message", str(e.detail)),
-                type=getattr(e, "type", "None"),
-                param=getattr(e, "param", "None"),
-                code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
+                type=openai_error_type(e, error_status_code(e, status.HTTP_400_BAD_REQUEST)),
+                param=openai_error_param(e),
+                code=error_status_code(e, status.HTTP_400_BAD_REQUEST),
             )
         else:
             error_msg: Final = f"{e}"
             raise ProxyException(
                 message=getattr(e, "message", error_msg),
-                type=getattr(e, "type", "None"),
-                param=getattr(e, "param", "None"),
+                type=openai_error_type(e, error_status_code(e, 500)),
+                param=openai_error_param(e),
                 code=getattr(e, "code", getattr(e, "status_code", 500)),
             )
 
@@ -12179,16 +12184,16 @@ async def get_messages(
         if isinstance(e, HTTPException):
             raise ProxyException(
                 message=getattr(e, "message", str(e.detail)),
-                type=getattr(e, "type", "None"),
-                param=getattr(e, "param", "None"),
-                code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
+                type=openai_error_type(e, error_status_code(e, status.HTTP_400_BAD_REQUEST)),
+                param=openai_error_param(e),
+                code=error_status_code(e, status.HTTP_400_BAD_REQUEST),
             )
         else:
             error_msg: Final = f"{e}"
             raise ProxyException(
                 message=getattr(e, "message", error_msg),
-                type=getattr(e, "type", "None"),
-                param=getattr(e, "param", "None"),
+                type=openai_error_type(e, error_status_code(e, 500)),
+                param=openai_error_param(e),
                 code=getattr(e, "code", getattr(e, "status_code", 500)),
             )
 
@@ -12301,16 +12306,16 @@ async def run_thread(
         if isinstance(e, HTTPException):
             raise ProxyException(
                 message=getattr(e, "message", str(e.detail)),
-                type=getattr(e, "type", "None"),
-                param=getattr(e, "param", "None"),
-                code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
+                type=openai_error_type(e, error_status_code(e, status.HTTP_400_BAD_REQUEST)),
+                param=openai_error_param(e),
+                code=error_status_code(e, status.HTTP_400_BAD_REQUEST),
             )
         else:
             error_msg: Final = f"{e}"
             raise ProxyException(
                 message=getattr(e, "message", error_msg),
-                type=getattr(e, "type", "None"),
-                param=getattr(e, "param", "None"),
+                type=openai_error_type(e, error_status_code(e, 500)),
+                param=openai_error_param(e),
                 code=getattr(e, "code", getattr(e, "status_code", 500)),
             )
 
@@ -13980,7 +13985,7 @@ async def model_streaming_metrics(
         raise ProxyException(
             message=CommonProxyErrors.db_not_connected_error.value,
             type="internal_error",
-            param="None",
+            param=None,
             code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         )
 
@@ -14114,7 +14119,7 @@ async def model_metrics(
         raise ProxyException(
             message="Prisma Client is not initialized",
             type="internal_error",
-            param="None",
+            param=None,
             code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         )
     startTime = startTime or datetime.now() - timedelta(days=DAYS_IN_A_MONTH)
@@ -14229,7 +14234,7 @@ async def model_metrics_slow_responses(
         raise ProxyException(
             message="Prisma Client is not initialized",
             type="internal_error",
-            param="None",
+            param=None,
             code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         )
     if api_key is None or api_key == "undefined":
@@ -14318,7 +14323,7 @@ async def model_metrics_exceptions(
         raise ProxyException(
             message="Prisma Client is not initialized",
             type="internal_error",
-            param="None",
+            param=None,
             code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         )
 
@@ -15247,7 +15252,7 @@ async def async_queue_request(
             raise ProxyException(
                 message=getattr(e, "detail", f"Authentication Error({e})"),
                 type=ProxyErrorTypes.auth_error,
-                param=getattr(e, "param", "None"),
+                param=openai_error_param(e),
                 code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
             )
         elif isinstance(e, ProxyException):
@@ -15255,7 +15260,7 @@ async def async_queue_request(
         raise ProxyException(
             message="Authentication Error, " + str(e),
             type=ProxyErrorTypes.auth_error,
-            param=getattr(e, "param", "None"),
+            param=openai_error_param(e),
             code=status.HTTP_400_BAD_REQUEST,
         )
 
@@ -15419,7 +15424,7 @@ async def login_v2(request: Request):
             raise ProxyException(
                 message=getattr(e, "detail", str(e)),
                 type=ProxyErrorTypes.auth_error,
-                param=getattr(e, "param", "None"),
+                param=openai_error_param(e),
                 code=getattr(e, "status_code", status.HTTP_500_INTERNAL_SERVER_ERROR),
             )
         else:
@@ -15427,7 +15432,7 @@ async def login_v2(request: Request):
             raise ProxyException(
                 message=error_msg,
                 type=ProxyErrorTypes.auth_error,
-                param="None",
+                param=None,
                 code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
@@ -15494,7 +15499,7 @@ async def login_v3(request: Request):
             raise ProxyException(
                 message=getattr(e, "detail", str(e)),
                 type=ProxyErrorTypes.auth_error,
-                param=getattr(e, "param", "None"),
+                param=openai_error_param(e),
                 code=getattr(e, "status_code", status.HTTP_500_INTERNAL_SERVER_ERROR),
             )
         else:
@@ -15502,7 +15507,7 @@ async def login_v3(request: Request):
             raise ProxyException(
                 message=error_msg,
                 type=ProxyErrorTypes.auth_error,
-                param="None",
+                param=None,
                 code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
@@ -15566,7 +15571,7 @@ async def login_v3_exchange(request: Request):
         raise ProxyException(
             message=str(e),
             type=ProxyErrorTypes.auth_error,
-            param="None",
+            param=None,
             code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         )
 
@@ -16465,7 +16470,7 @@ async def update_config(
             raise ProxyException(
                 message=getattr(e, "detail", f"Authentication Error({e})"),
                 type=ProxyErrorTypes.auth_error,
-                param=getattr(e, "param", "None"),
+                param=openai_error_param(e),
                 code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
             )
         elif isinstance(e, ProxyException):
@@ -16473,7 +16478,7 @@ async def update_config(
         raise ProxyException(
             message="Authentication Error, " + str(e),
             type=ProxyErrorTypes.auth_error,
-            param=getattr(e, "param", "None"),
+            param=openai_error_param(e),
             code=status.HTTP_400_BAD_REQUEST,
         )
 
@@ -17464,7 +17469,7 @@ async def get_config(
             raise ProxyException(
                 message=getattr(e, "detail", f"Authentication Error({e})"),
                 type=ProxyErrorTypes.auth_error,
-                param=getattr(e, "param", "None"),
+                param=openai_error_param(e),
                 code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
             )
         elif isinstance(e, ProxyException):
@@ -17472,7 +17477,7 @@ async def get_config(
         raise ProxyException(
             message="Authentication Error, " + str(e),
             type=ProxyErrorTypes.auth_error,
-            param=getattr(e, "param", "None"),
+            param=openai_error_param(e),
             code=status.HTTP_400_BAD_REQUEST,
         )
 

--- a/tests/test_litellm/proxy/auth/test_auth_exception_handler.py
+++ b/tests/test_litellm/proxy/auth/test_auth_exception_handler.py
@@ -30,7 +30,10 @@ from litellm._logging import verbose_proxy_logger
 from litellm.constants import INVALID_VIRTUAL_KEY_ERROR_MARKER
 from litellm.exceptions import BudgetExceededError
 from litellm.proxy._types import ProxyErrorTypes, ProxyException, UserAPIKeyAuth
-from litellm.proxy.auth.auth_exception_handler import UserAPIKeyAuthExceptionHandler
+from litellm.proxy.auth.auth_exception_handler import (
+    UserAPIKeyAuthExceptionHandler,
+    _as_proxy_exception,
+)
 
 
 class _EngineHttp500:
@@ -871,3 +874,32 @@ async def test_handle_authentication_error_traceback_only_for_unexpected_errors(
     assert records[0].levelname == expect_level
     expected_logger_name = "LiteLLM Proxy.stdout" if expect_level == "WARNING" else "LiteLLM Proxy"
     assert records[0].name == expected_logger_name
+
+
+@pytest.mark.parametrize(
+    "auth_failure,expected_type",
+    [
+        pytest.param(
+            HTTPException(status_code=401, detail="Authentication Error, invalid key"),
+            ProxyErrorTypes.auth_error.value,
+            id="http_exception",
+        ),
+        pytest.param(
+            httpx.ConnectError("All connection attempts failed"),
+            ProxyErrorTypes.no_db_connection.value,
+            id="database_unavailable",
+        ),
+        pytest.param(
+            Exception("Invalid proxy server token passed"),
+            ProxyErrorTypes.auth_error.value,
+            id="bare_exception",
+        ),
+    ],
+)
+def test_auth_failure_error_body_is_openai_shaped(auth_failure, expected_type):
+    """Every auth rejection must serialize as an OpenAI error object: a real
+    `type` string and a JSON null `param`, never the literal string "None"."""
+    body = json.loads(json.dumps({"error": _as_proxy_exception(auth_failure).to_dict()}))
+
+    assert body["error"]["type"] == expected_type
+    assert body["error"]["param"] is None

--- a/tests/test_litellm/proxy/auth/test_handle_jwt.py
+++ b/tests/test_litellm/proxy/auth/test_handle_jwt.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import re
 import time
 from collections.abc import Mapping, Sequence
@@ -30,6 +31,7 @@ from litellm.proxy.auth.handle_jwt import (
     JWTAuthManager,
     JWTHandler,
     NoMatchingJWTPublicKeyError,
+    jwks_unavailable_exception,
 )
 
 
@@ -6734,3 +6736,13 @@ async def test_sync_user_role_and_teams_singular_claim_only_recognized_under_fla
     }
     assert mock_patch.call_args.kwargs["teams_ids_to_add_user_to"] == []
     assert user.teams == []
+
+
+def test_jwks_unavailable_exception_is_openai_shaped():
+    """An unreachable JWKS endpoint must answer with a real `type` string and a
+    JSON null `param`, never the literal string "None"."""
+    body = json.loads(json.dumps({"error": jwks_unavailable_exception(JWKSUnreachableError("jwks down")).to_dict()}))
+
+    assert body["error"]["type"] == ProxyErrorTypes.auth_provider_unavailable.value
+    assert body["error"]["param"] is None
+    assert body["error"]["code"] == "503"

--- a/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
+++ b/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
@@ -1090,6 +1090,18 @@ async def test_health_services_endpoint_rejects_unknown_service():
 
 
 @pytest.mark.asyncio
+async def test_health_services_endpoint_rejection_is_openai_shaped():
+    """A caller mistake here must serialize as an OpenAI error object: a real
+    `type` string and a JSON null `param`, never the literal string "None"."""
+    with pytest.raises(ProxyException) as exc_info:
+        await health_services_endpoint(service="totally_unknown_service_xyz")
+
+    body = json.loads(json.dumps({"error": exc_info.value.to_dict()}))
+    assert body["error"]["type"] == "auth_error"
+    assert body["error"]["param"] is None
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "role",
     [

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -12507,3 +12507,14 @@ def test_disabling_docs_does_not_disable_other_routes(monkeypatch):
 
     assert client.get("/redoc").status_code == 404
     assert client.get("/health/liveliness").status_code == 200
+
+
+def test_assistants_error_body_is_openai_shaped(client_no_auth):
+    """A failed /v1/assistants call must answer with an OpenAI error object: a
+    real `type` string and a JSON null `param`, never the literal string "None"."""
+    response = client_no_auth.get("/v1/assistants")
+
+    assert response.status_code >= 400
+    error = response.json()["error"]
+    assert error["type"] == "internal_server_error"
+    assert error["param"] is None


### PR DESCRIPTION
## TLDR

Problem this solves:

- `proxy_server.py` answers `"type": "None"` on 63 error sites
- Auth rejections and health checks ship `"param": "None"` too
- Those are four-character strings, not OpenAI error types
- `param` is typed nullable, so a string is plain wrong there

How it solves it:

- Calls the shared helpers #39536 added, no second convention
- `type` falls back to what the HTTP status stands for
- A missing `param` serializes as JSON `null`
- Covers proxy_server routes, auth rejections, health services
- Still outstanding: spend tracking and management endpoints

## User Flow

Before: a developer whose app talks to the gateway gets errors no OpenAI SDK can classify, so every failure on these routes lands in their catch-all branch

1. They send `POST https://litellm-domain/v1/chat/completions` with no `Authorization` header
2. HTTP 401 comes back as `{"error":{"message":"Authentication Error, No api key passed in.","type":"auth_error","param":"None","code":"401"}}`, so their handler reads `param` as the four-character string `None` where it expected a JSON `null` and renders "problem with field None"
3. They send `POST https://litellm-domain/v1/audio/transcriptions` with `model=no-such-audio-model`
4. HTTP 400 comes back with `"type":"None"`, so their branch on `invalid_request_error` never fires and the request is reported as an unknown error with no guidance
5. They send `GET https://litellm-domain/v1/assistants?custom_llm_provider=openai` at a gateway with no assistants provider configured
6. HTTP 500 comes back with `"type":"None"` and `"param":"None"`, so their retry logic cannot tell a server fault from a bad request
7. They check `GET https://litellm-domain/health/services?service=bogus_service` and get HTTP 400 with a real `"type":"auth_error"` but `"param":"None"` again

After: the same requests come back with a real OpenAI error type and a JSON null param, so the handler they already wrote classifies them

1. They send `POST https://litellm-domain/v1/chat/completions` with no `Authorization` header
2. HTTP 401 comes back as `{"error":{"message":"Authentication Error, No api key passed in.","type":"auth_error","param":null,"code":"401"}}`, so their handler reads `param` as `null` and correctly reports that no single field was named
3. They send `POST https://litellm-domain/v1/audio/transcriptions` with `model=no-such-audio-model`
4. HTTP 400 comes back with `"type":"invalid_request_error"`, so their branch fires and the caller sees a "fix your request" message
5. They send `GET https://litellm-domain/v1/assistants?custom_llm_provider=openai` at a gateway with no assistants provider configured
6. HTTP 500 comes back with `"type":"internal_server_error"` and `"param":null`, so their retry logic can tell a server fault from a bad request
7. `GET https://litellm-domain/health/services?service=bogus_service` still returns HTTP 400 with `"type":"auth_error"`, now with `"param":null`

## Relevant issues

## Linear ticket

Part of LIT-6829

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both legs run the same proxy, two uvicorn workers each, against the same Postgres, and differ only in the commit they were booted from. `bede8b5ea4` is this PR's merge base, the commit it branches from on #39536; `32074cf4de` is this PR's tip.

Config used on both legs:

```yaml
model_list:
  - model_name: gpt-4o-mini
    litellm_params:
      model: openai/gpt-4o-mini
      api_key: os.environ/OPENAI_API_KEY

general_settings:
  master_key: sk-1234
  enable_jwt_auth: true
  pass_through_endpoints:
    - path: "/unreachable-upstream"
      target: "http://127.0.0.1:1/nope"
      headers:
        content-type: application/json

litellm_settings:
  drop_params: true
```

Boot on each leg (ports differ, `<port>` is 20091 before and 46742 after):

```bash
./.venv/bin/python litellm/proxy/proxy_cli.py --config lit6829_config.yaml --port <port> --num_workers 2
```

### Before (bede8b5ea4)

#### Assistants with no assistants provider configured

1. Run the request

```bash
curl -sS -X GET "http://127.0.0.1:20091/v1/assistants?custom_llm_provider=openai" -H 'Authorization: Bearer sk-1234'
```

2. Observe `type` and `param` as the string `None`

```json
{"error":{"message":"'custom_llm_provider' must be set. Either via:\n `Router(assistants_config={'custom_llm_provider': ..})` \nor\n `router.arun_thread(custom_llm_provider=..)`","type":"None","param":"None","code":"500"}}
```

#### Audio transcription with an unknown model

1. Run the request

```bash
curl -sS -X POST "http://127.0.0.1:20091/v1/audio/transcriptions" -H 'Authorization: Bearer sk-1234' -F 'model=no-such-audio-model' -F 'file=@/etc/hosts'
```

2. Observe `type` and `param` as the string `None`

```json
{"error":{"message":"{'error': '/audio/transcriptions: Invalid model name passed in model=no-such-audio-model. Call `/v1/models` to view available models for your key.'}","type":"None","param":"None","code":"400"}}
```

#### Health services with an unknown service

1. Run the request

```bash
curl -sS -X GET "http://127.0.0.1:20091/health/services?service=bogus_service" -H 'Authorization: Bearer sk-1234'
```

2. Observe a real `type` but `param` as the string `None`

```json
{"error":{"message":"{'error': \"Service must be in list. Service=bogus_service not in typing.Union[typing.Literal['slack_budget_alerts', 'langfuse', 'langfuse_otel', 'slack', 'ms_teams', 'openmeter', 'webhook', 'email', 'braintrust', 'datadog', 'datadog_llm_observability', 'generic_api', 'arize', 'galileo', 'newrelic', 'sqs'], str]\"}","type":"auth_error","param":"None","code":"400"}}
```

#### Chat completion with no API key

1. Run the request

```bash
curl -sS -X POST "http://127.0.0.1:20091/v1/chat/completions" -H 'Content-Type: application/json' -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hi"}]}'
```

2. Observe `param` as the string `None`

```json
{"error":{"message":"Authentication Error, No api key passed in.","type":"auth_error","param":"None","code":"401"}}
```

#### Control: a real chat completion still works

1. Run the request

```bash
curl -sS -X POST "http://127.0.0.1:20091/v1/chat/completions" -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Say OK"}],"max_tokens":5}'
```

2. Observe a real completion from OpenAI

```json
{"id":"chatcmpl-EJyeQ5uib5jz9Y61fpGAHqduCPeVU","created":1788430082,"model":"gpt-4o-mini","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"OK!","role":"assistant"}}],"usage":{"completion_tokens":2,"prompt_tokens":9,"total_tokens":11}}
```

### After (32074cf4de)

#### Assistants with no assistants provider configured

1. Run the request

```bash
curl -sS -X GET "http://127.0.0.1:46742/v1/assistants?custom_llm_provider=openai" -H 'Authorization: Bearer sk-1234'
```

2. Observe a real `type` and a JSON `null` `param`

```json
{"error":{"message":"'custom_llm_provider' must be set. Either via:\n `Router(assistants_config={'custom_llm_provider': ..})` \nor\n `router.arun_thread(custom_llm_provider=..)`","type":"internal_server_error","param":null,"code":"500"}}
```

#### Audio transcription with an unknown model

1. Run the request

```bash
curl -sS -X POST "http://127.0.0.1:46742/v1/audio/transcriptions" -H 'Authorization: Bearer sk-1234' -F 'model=no-such-audio-model' -F 'file=@/etc/hosts'
```

2. Observe a real `type` and a JSON `null` `param`

```json
{"error":{"message":"{'error': '/audio/transcriptions: Invalid model name passed in model=no-such-audio-model. Call `/v1/models` to view available models for your key.'}","type":"invalid_request_error","param":null,"code":"400"}}
```

#### Health services with an unknown service

1. Run the request

```bash
curl -sS -X GET "http://127.0.0.1:46742/health/services?service=bogus_service" -H 'Authorization: Bearer sk-1234'
```

2. Observe the same `type` with a JSON `null` `param`

```json
{"error":{"message":"{'error': \"Service must be in list. Service=bogus_service not in typing.Union[typing.Literal['slack_budget_alerts', 'langfuse', 'langfuse_otel', 'slack', 'ms_teams', 'openmeter', 'webhook', 'email', 'braintrust', 'datadog', 'datadog_llm_observability', 'generic_api', 'arize', 'galileo', 'newrelic', 'sqs'], str]\"}","type":"auth_error","param":null,"code":"400"}}
```

#### Chat completion with no API key

1. Run the request

```bash
curl -sS -X POST "http://127.0.0.1:46742/v1/chat/completions" -H 'Content-Type: application/json' -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hi"}]}'
```

2. Observe a JSON `null` `param`

```json
{"error":{"message":"Authentication Error, No api key passed in.","type":"auth_error","param":null,"code":"401"}}
```

#### Control: a real chat completion still works

1. Run the request

```bash
curl -sS -X POST "http://127.0.0.1:46742/v1/chat/completions" -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Say OK"}],"max_tokens":5}'
```

2. Observe a real completion from OpenAI

```json
{"id":"chatcmpl-EJyhAkxsDATmI2HrPfglA7mjix89e","created":1788430252,"model":"gpt-4o-mini","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"OK!","role":"assistant"}}],"usage":{"completion_tokens":2,"prompt_tokens":9,"total_tokens":11}}
```

Observations from the run:

- `param` was wrong on more routes than `type` was
- `/v1/assistants` answers 500 for a caller's config mistake
- `POST /v1/audio/speech` answers `{"detail": ...}`, not an error object
- Both untouched here, neither caused nor worsened by this PR

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Stacked on #39536, so it merges after that one
- The unreachable-JWKS 503 was not proven on a live proxy
  - It only fires behind JWT auth, which needs an enterprise license
  - The license in the local env fails `is_premium()`, so no run reaches it
  - Reverting that line fails `test_jwks_unavailable_exception_is_openai_shaped`
  - The same one-literal change is proven live on four routes here
- Spend and management routes are #39542, stacked on this one
- Seven nested `code=getattr(e, "code", ...)` reads left as they were

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


