### PR TITLE
fix(anthropic_messages): key bridged streaming spend rows on the streamed msg_ id

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -429,6 +429,7 @@ class Logging(LiteLLMLoggingBaseClass):
     custom_pricing: bool = False
     stream_options = None
     litellm_request_debug: bool = False
+    streamed_anthropic_message_id: str | None = None
 
     def __init__(
         self,
@@ -2136,7 +2137,7 @@ class Logging(LiteLLMLoggingBaseClass):
             self.model_call_details["cache_hit"] = cache_hit
 
             if self.call_type == CallTypes.anthropic_messages.value:
-                result = self._handle_anthropic_messages_response_logging(result=result)
+                result = self._anthropic_messages_logged_response(result=result)
             elif (
                 self.call_type == CallTypes.generate_content.value
                 or self.call_type == CallTypes.agenerate_content.value
@@ -3805,6 +3806,23 @@ class Logging(LiteLLMLoggingBaseClass):
                 )
             )
         return None
+
+    def record_streamed_anthropic_message_id(self, message_id: str) -> None:
+        self.streamed_anthropic_message_id = message_id
+
+    def _anthropic_messages_logged_response(self, result: Any) -> ModelResponse:
+        """
+        The ModelResponse a /v1/messages spend_logs row is built from.
+
+        A streaming call bridged onto the Responses API is the one case where the `msg_` id the
+        caller was served is minted locally rather than issued upstream, so it is absent from the
+        response the row would otherwise be keyed on and has to be carried over here.
+        """
+        logged: Final = self._handle_anthropic_messages_response_logging(result=result)
+        streamed_message_id: Final = self.streamed_anthropic_message_id
+        if streamed_message_id is None:
+            return logged
+        return logged.model_copy(update={"id": streamed_message_id})
 
     def _handle_anthropic_messages_response_logging(self, result: Any) -> ModelResponse:
         """

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/handler.py
@@ -21,6 +21,7 @@ from litellm.llms.anthropic.experimental_pass_through.context_management import 
 )
 from litellm.llms.anthropic.experimental_pass_through.utils import (
     is_reasoning_auto_summary_enabled,
+    litellm_logging_obj_from_kwargs,
     local_model_name,
 )
 from litellm.types.llms.anthropic_messages.anthropic_response import (
@@ -621,6 +622,7 @@ class LiteLLMMessagesToCompletionTransformationHandler:
                 tool_name_mapping=tool_name_mapping,
                 polyfill_result=polyfill_result,
                 is_async=True,
+                litellm_logging_obj=litellm_logging_obj_from_kwargs(kwargs),
             )
             if transformed_stream is not None:
                 return transformed_stream
@@ -755,6 +757,7 @@ class LiteLLMMessagesToCompletionTransformationHandler:
                 tool_name_mapping=tool_name_mapping,
                 polyfill_result=polyfill_result,
                 is_async=False,
+                litellm_logging_obj=litellm_logging_obj_from_kwargs(kwargs),
             )
             if transformed_stream is not None:
                 return transformed_stream

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
@@ -31,6 +31,7 @@ from litellm.types.llms.anthropic import (
 from litellm.types.utils import AdapterCompletionStreamWrapper, Delta
 
 if TYPE_CHECKING:
+    from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObject
     from litellm.types.utils import ModelResponseStream
 
 
@@ -287,12 +288,16 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
         applied_edits: list[AppliedEdit] | None = None,
         compaction_block: CompactionBlock | None = None,
         iterations_usage: list[UsageIteration] | None = None,
+        litellm_logging_obj: "LiteLLMLoggingObject | None" = None,
     ):
         # Wrap the upstream stream so chunks that carry both content and a
         # finish_reason (fake-streamed providers) are split into two — see
         # _CombinedChunkSplitter.
         super().__init__(_CombinedChunkSplitter(completion_stream))
         self.model = model
+        self._message_id: str = f"msg_{uuid.uuid4()}"
+        if litellm_logging_obj is not None:
+            litellm_logging_obj.record_streamed_anthropic_message_id(self._message_id)
         # Mapping of truncated tool names to original names (for OpenAI's 64-char limit)
         self.tool_name_mapping = tool_name_mapping or {}
         # Polyfill applied_edits on final message_delta.
@@ -507,7 +512,7 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
                     {
                         "type": "message_start",
                         "message": {
-                            "id": f"msg_{uuid.uuid4()}",
+                            "id": self._message_id,
                             "type": "message",
                             "role": "assistant",
                             "content": [],
@@ -741,7 +746,7 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
                     {
                         "type": "message_start",
                         "message": {
-                            "id": f"msg_{uuid.uuid4()}",
+                            "id": self._message_id,
                             "type": "message",
                             "role": "assistant",
                             "content": [],

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -174,6 +174,7 @@ from litellm.types.utils import Choices, ModelResponse, StreamingChoices, Usage
 from .streaming_iterator import AnthropicStreamWrapper
 
 if TYPE_CHECKING:
+    from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObject
     from litellm.types.llms.anthropic import ContentBlockContentBlockDict
 
 ToolResultContent: TypeAlias = str | list[ToolMessageContentPart]
@@ -264,6 +265,7 @@ class AnthropicAdapter:
         tool_name_mapping: dict[str, str] | None = None,
         polyfill_result: PolyfillResult | None = None,
         is_async: bool = True,
+        litellm_logging_obj: "LiteLLMLoggingObject | None" = None,
     ) -> AsyncIterator[bytes] | Iterator[bytes] | None:
         """
         Translate OpenAI streaming response to Anthropic format.
@@ -290,6 +292,7 @@ class AnthropicAdapter:
             applied_edits=applied_edits,
             compaction_block=compaction_block,
             iterations_usage=iterations_usage,
+            litellm_logging_obj=litellm_logging_obj,
         )
         # Return the SSE-wrapped version for proper event formatting.
         if is_async:

--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/handler.py
@@ -5,7 +5,7 @@ Used when the target model is an OpenAI or Azure model.
 """
 
 from collections.abc import AsyncIterator, Coroutine, Mapping
-from typing import TYPE_CHECKING, Any, Final, TypeAlias
+from typing import Any, Final, TypeAlias
 
 import litellm
 from litellm.types.llms.anthropic import (
@@ -20,23 +20,13 @@ from litellm.types.llms.anthropic_messages.anthropic_response import (
 )
 from litellm.types.llms.openai import ResponsesAPIResponse
 
-from ..utils import local_model_name
+from ..utils import litellm_logging_obj_from_kwargs, local_model_name
 from .streaming_iterator import AnthropicResponsesStreamWrapper
 from .transformation import LiteLLMAnthropicToResponsesAPIAdapter
-
-if TYPE_CHECKING:
-    from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObject
 
 AnthropicRequestMessages: TypeAlias = list[AllAnthropicMessageValues] | list[dict[str, object]]
 
 _ADAPTER: Final = LiteLLMAnthropicToResponsesAPIAdapter()
-
-
-def _litellm_logging_obj(responses_kwargs: Mapping[str, object]) -> "LiteLLMLoggingObject | None":
-    from litellm.litellm_core_utils.litellm_logging import Logging
-
-    candidate: Final = responses_kwargs.get("litellm_logging_obj")
-    return candidate if isinstance(candidate, Logging) else None
 
 
 def _forwarded_kwargs(extra_kwargs: Mapping[str, object] | None) -> Mapping[str, object]:
@@ -198,7 +188,7 @@ class LiteLLMMessagesToResponsesAPIHandler:
             wrapper: Final = AnthropicResponsesStreamWrapper(
                 responses_stream=result,
                 model=local_model_name(model, kwargs.get("custom_llm_provider")),
-                litellm_logging_obj=_litellm_logging_obj(responses_kwargs),
+                litellm_logging_obj=litellm_logging_obj_from_kwargs(responses_kwargs),
             )
             return wrapper.async_anthropic_sse_wrapper()
 
@@ -280,7 +270,7 @@ class LiteLLMMessagesToResponsesAPIHandler:
             wrapper: Final = AnthropicResponsesStreamWrapper(
                 responses_stream=result,
                 model=local_model_name(model, kwargs.get("custom_llm_provider")),
-                litellm_logging_obj=_litellm_logging_obj(responses_kwargs),
+                litellm_logging_obj=litellm_logging_obj_from_kwargs(responses_kwargs),
             )
             return wrapper.async_anthropic_sse_wrapper()
 

--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/handler.py
@@ -5,7 +5,7 @@ Used when the target model is an OpenAI or Azure model.
 """
 
 from collections.abc import AsyncIterator, Coroutine, Mapping
-from typing import Any, Final, TypeAlias
+from typing import TYPE_CHECKING, Any, Final, TypeAlias
 
 import litellm
 from litellm.types.llms.anthropic import (
@@ -24,9 +24,19 @@ from ..utils import local_model_name
 from .streaming_iterator import AnthropicResponsesStreamWrapper
 from .transformation import LiteLLMAnthropicToResponsesAPIAdapter
 
+if TYPE_CHECKING:
+    from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObject
+
 AnthropicRequestMessages: TypeAlias = list[AllAnthropicMessageValues] | list[dict[str, object]]
 
 _ADAPTER: Final = LiteLLMAnthropicToResponsesAPIAdapter()
+
+
+def _litellm_logging_obj(responses_kwargs: Mapping[str, object]) -> "LiteLLMLoggingObject | None":
+    from litellm.litellm_core_utils.litellm_logging import Logging
+
+    candidate: Final = responses_kwargs.get("litellm_logging_obj")
+    return candidate if isinstance(candidate, Logging) else None
 
 
 def _forwarded_kwargs(extra_kwargs: Mapping[str, object] | None) -> Mapping[str, object]:
@@ -186,7 +196,9 @@ class LiteLLMMessagesToResponsesAPIHandler:
 
         if stream:
             wrapper: Final = AnthropicResponsesStreamWrapper(
-                responses_stream=result, model=local_model_name(model, kwargs.get("custom_llm_provider"))
+                responses_stream=result,
+                model=local_model_name(model, kwargs.get("custom_llm_provider")),
+                litellm_logging_obj=_litellm_logging_obj(responses_kwargs),
             )
             return wrapper.async_anthropic_sse_wrapper()
 
@@ -266,7 +278,9 @@ class LiteLLMMessagesToResponsesAPIHandler:
 
         if stream:
             wrapper: Final = AnthropicResponsesStreamWrapper(
-                responses_stream=result, model=local_model_name(model, kwargs.get("custom_llm_provider"))
+                responses_stream=result,
+                model=local_model_name(model, kwargs.get("custom_llm_provider")),
+                litellm_logging_obj=_litellm_logging_obj(responses_kwargs),
             )
             return wrapper.async_anthropic_sse_wrapper()
 

--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/streaming_iterator.py
@@ -4,13 +4,16 @@ import json
 import traceback
 from collections import deque
 from collections.abc import AsyncIterator, Mapping
-from typing import Any, Final
+from typing import TYPE_CHECKING, Any, Final
 
 from litellm import verbose_logger
 from litellm._uuid import uuid
 from litellm.types.llms.anthropic_messages.anthropic_response import AnthropicUsage
 
 from .transformation import LiteLLMAnthropicToResponsesAPIAdapter
+
+if TYPE_CHECKING:
+    from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObject
 
 
 class AnthropicResponsesStreamWrapper:
@@ -31,10 +34,13 @@ class AnthropicResponsesStreamWrapper:
         self,
         responses_stream: Any,
         model: str,
+        litellm_logging_obj: "LiteLLMLoggingObject | None" = None,
     ) -> None:
         self.responses_stream = responses_stream
         self.model = model
         self._message_id: str = f"msg_{uuid.uuid4()}"
+        if litellm_logging_obj is not None:
+            litellm_logging_obj.record_streamed_anthropic_message_id(self._message_id)
         self._current_block_index: int = -1
         # Map item_id -> content_block_index so we can stop the right block later
         self._item_id_to_block_index: dict[str, int] = {}

--- a/litellm/llms/anthropic/experimental_pass_through/utils.py
+++ b/litellm/llms/anthropic/experimental_pass_through/utils.py
@@ -1,10 +1,13 @@
 import os
 from collections.abc import Mapping
 from types import MappingProxyType
-from typing import Final
+from typing import TYPE_CHECKING, Final
 
 import litellm
 from litellm.types.utils import ModelInfo
+
+if TYPE_CHECKING:
+    from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObject
 
 OPENAI_MAX_PROMPT_CACHE_KEY_LENGTH: Final = 64
 
@@ -22,6 +25,14 @@ def prompt_cache_key_from_user_id(user_id: object) -> str | None:
     if user_id is None:
         return None
     return str(user_id)[:OPENAI_MAX_PROMPT_CACHE_KEY_LENGTH] or None
+
+
+def litellm_logging_obj_from_kwargs(kwargs: Mapping[str, object]) -> "LiteLLMLoggingObject | None":
+    """The logging object the bridged call logs through, when the caller supplied one."""
+    from litellm.litellm_core_utils.litellm_logging import Logging
+
+    candidate: Final = kwargs.get("litellm_logging_obj")
+    return candidate if isinstance(candidate, Logging) else None
 
 
 def local_model_name(model: str, custom_llm_provider: object) -> str:

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_streaming_iterator_message_id.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_streaming_iterator_message_id.py
@@ -1,0 +1,111 @@
+"""
+Streaming ``/v1/messages`` against a model that is neither Anthropic nor OpenAI is served by
+translating the call onto ``/v1/chat/completions``, and the ``msg_`` id the caller is streamed
+is minted right here. It is the only request id such a caller ever sees, so the spend row has
+to be keyed on that same value rather than on the provider's own completion id.
+"""
+
+import datetime
+import json
+
+import pytest
+import respx
+
+import litellm
+from litellm.llms.anthropic.experimental_pass_through.adapters.handler import (
+    LiteLLMMessagesToCompletionTransformationHandler,
+)
+from litellm.llms.anthropic.experimental_pass_through.adapters.streaming_iterator import (
+    AnthropicStreamWrapper,
+)
+
+MESSAGES = [{"role": "user", "content": "hello"}]
+
+GROQ_CHAT_URL = "https://api.groq.com/openai/v1/chat/completions"
+
+CHAT_SSE_BODY = (
+    b'data: {"id":"chatcmpl-lit6825","object":"chat.completion.chunk","created":1,'
+    b'"model":"kimi-k2","choices":[{"index":0,"delta":{"role":"assistant","content":"hi"},'
+    b'"finish_reason":null}]}\n\n'
+    b'data: {"id":"chatcmpl-lit6825","object":"chat.completion.chunk","created":1,'
+    b'"model":"kimi-k2","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],'
+    b'"usage":{"prompt_tokens":3,"completion_tokens":4,"total_tokens":7}}\n\n'
+    b"data: [DONE]\n\n"
+)
+
+
+def _logging_obj(call_id: str):
+    from litellm.litellm_core_utils.litellm_logging import Logging
+
+    return Logging(
+        model="kimi-k2",
+        messages=MESSAGES,
+        stream=True,
+        call_type="anthropic_messages",
+        start_time=datetime.datetime.now(datetime.timezone.utc),
+        litellm_call_id=call_id,
+        function_id="1234",
+    )
+
+
+def _streamed_message_id(raw_events: list[bytes]) -> str:
+    events = [json.loads(chunk.decode().split("data: ", 1)[1]) for chunk in raw_events]
+    message_start = next(e for e in events if e["type"] == "message_start")
+    return message_start["message"]["id"]
+
+
+@pytest.fixture(autouse=True)
+def _intercept_groq(respx_mock: respx.MockRouter, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("GROQ_API_KEY", "gsk-lit6825-test")
+    monkeypatch.setenv("DISABLE_AIOHTTP_TRANSPORT", "True")
+    litellm.in_memory_llm_clients_cache.flush_cache()
+    respx_mock.post(GROQ_CHAT_URL).respond(
+        status_code=200,
+        headers={"Content-Type": "text/event-stream"},
+        content=CHAT_SSE_BODY,
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_streaming_hands_the_logging_object_the_message_id_the_caller_is_streamed():
+    logging_obj = _logging_obj("6825beef-0000-4000-8000-000000000010")
+
+    sse = await LiteLLMMessagesToCompletionTransformationHandler.async_anthropic_messages_handler(
+        max_tokens=1024,
+        messages=MESSAGES,
+        model="groq/kimi-k2",
+        stream=True,
+        custom_llm_provider="groq",
+        litellm_logging_obj=logging_obj,
+    )
+    streamed_id = _streamed_message_id([chunk async for chunk in sse])
+
+    assert streamed_id.startswith("msg_")
+    assert logging_obj.streamed_anthropic_message_id == streamed_id
+
+
+def test_sync_streaming_hands_the_logging_object_the_message_id_the_caller_is_streamed():
+    logging_obj = _logging_obj("6825beef-0000-4000-8000-000000000011")
+
+    sse = LiteLLMMessagesToCompletionTransformationHandler.anthropic_messages_handler(
+        max_tokens=1024,
+        messages=MESSAGES,
+        model="groq/kimi-k2",
+        stream=True,
+        custom_llm_provider="groq",
+        litellm_logging_obj=logging_obj,
+    )
+    streamed_id = _streamed_message_id(list(sse))
+
+    assert streamed_id.startswith("msg_")
+    assert logging_obj.streamed_anthropic_message_id == streamed_id
+
+
+def test_concurrent_streams_are_keyed_on_their_own_message_id():
+    """Two callers streaming at once must not be handed, or logged under, one another's id."""
+    first = AnthropicStreamWrapper(completion_stream=iter([]), model="kimi-k2")
+    second = AnthropicStreamWrapper(completion_stream=iter([]), model="kimi-k2")
+
+    assert first._message_id != second._message_id
+    assert _streamed_message_id(list(first.anthropic_sse_wrapper())) == first._message_id
+    assert _streamed_message_id(list(second.anthropic_sse_wrapper())) == second._message_id

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_handler.py
@@ -100,7 +100,7 @@ async def test_streaming_message_start_reports_the_provider_local_model(requeste
 
 @pytest.mark.asyncio
 async def test_streaming_hands_the_logging_object_the_message_id_the_caller_is_streamed(
-    respx_mock: respx.MockRouter, monkeypatch
+    respx_mock: respx.MockRouter, monkeypatch: pytest.MonkeyPatch
 ):
     """
     The bridge mints the ``msg_`` id itself, and it is the only request id a streaming
@@ -110,7 +110,6 @@ async def test_streaming_hands_the_logging_object_the_message_id_the_caller_is_s
 
     monkeypatch.setenv("OPENAI_API_KEY", "sk-lit6825-test")
     monkeypatch.setenv("DISABLE_AIOHTTP_TRANSPORT", "True")
-    monkeypatch.setattr(litellm, "disable_aiohttp_transport", True)
     litellm.in_memory_llm_clients_cache.flush_cache()
     respx_mock.post("https://api.openai.com/v1/responses").respond(
         status_code=200,

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_handler.py
@@ -1,9 +1,11 @@
+import datetime
 import json
 import os
 import sys
 from unittest.mock import AsyncMock, patch
 
 import pytest
+import respx
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../../..")))
 
@@ -14,6 +16,18 @@ from litellm.llms.anthropic.experimental_pass_through.responses_adapters.handler
 )
 
 MESSAGES = [{"role": "user", "content": "hello"}]
+
+RESPONSES_SSE_BODY = (
+    b"event: response.created\n"
+    b'data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_lit6825",'
+    b'"object":"response","created_at":1,"status":"in_progress","model":"gpt-5.6-luna","output":[],'
+    b'"parallel_tool_calls":true,"tool_choice":"auto","tools":[]}}\n\n'
+    b"event: response.completed\n"
+    b'data: {"type":"response.completed","sequence_number":1,"response":{"id":"resp_lit6825",'
+    b'"object":"response","created_at":1,"status":"completed","model":"gpt-5.6-luna","output":[],'
+    b'"parallel_tool_calls":true,"tool_choice":"auto","tools":[],'
+    b'"usage":{"input_tokens":3,"output_tokens":4,"total_tokens":7}}}\n\n'
+)
 
 
 def test_build_responses_kwargs_derives_prompt_cache_key_from_user_id():
@@ -82,3 +96,48 @@ async def test_streaming_message_start_reports_the_provider_local_model(requeste
 
     message_start = next(e for e in events if e["type"] == "message_start")
     assert message_start["message"]["model"] == expected_reported_model
+
+
+@pytest.mark.asyncio
+async def test_streaming_hands_the_logging_object_the_message_id_the_caller_is_streamed(
+    respx_mock: respx.MockRouter, monkeypatch
+):
+    """
+    The bridge mints the ``msg_`` id itself, and it is the only request id a streaming
+    /v1/messages caller ever sees, so the spend row has to be keyed on that same value.
+    """
+    from litellm.litellm_core_utils.litellm_logging import Logging
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-lit6825-test")
+    monkeypatch.setenv("DISABLE_AIOHTTP_TRANSPORT", "True")
+    monkeypatch.setattr(litellm, "disable_aiohttp_transport", True)
+    litellm.in_memory_llm_clients_cache.flush_cache()
+    respx_mock.post("https://api.openai.com/v1/responses").respond(
+        status_code=200,
+        headers={"Content-Type": "text/event-stream"},
+        content=RESPONSES_SSE_BODY,
+    )
+
+    logging_obj = Logging(
+        model="gpt-5.6-luna",
+        messages=MESSAGES,
+        stream=True,
+        call_type="anthropic_messages",
+        start_time=datetime.datetime.now(datetime.timezone.utc),
+        litellm_call_id="6825beef-0000-4000-8000-000000000003",
+        function_id="1234",
+    )
+
+    sse = await LiteLLMMessagesToResponsesAPIHandler.async_anthropic_messages_handler(
+        max_tokens=1024,
+        messages=MESSAGES,
+        model="openai/gpt-5.6-luna",
+        stream=True,
+        custom_llm_provider="openai",
+        litellm_logging_obj=logging_obj,
+    )
+    events = [json.loads(chunk.decode().split("data: ", 1)[1]) async for chunk in sse]
+
+    message_start = next(e for e in events if e["type"] == "message_start")
+    assert message_start["message"]["id"].startswith("msg_")
+    assert logging_obj.streamed_anthropic_message_id == message_start["message"]["id"]

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
@@ -3462,6 +3462,138 @@ def test_get_spend_logs_id_prefers_the_response_id_over_the_standard_logging_id(
     )
 
 
+@pytest.mark.asyncio
+async def test_spend_log_request_id_is_the_message_id_a_bridged_streaming_caller_was_streamed():
+    """A streaming /v1/messages call against a non-Anthropic model is served a msg_ id the
+    adapter mints itself, and it is the only request id that call ever shows the caller, so
+    GET /spend/logs?request_id=msg_... has to land on the row."""
+    from litellm.litellm_core_utils.litellm_logging import Logging
+    from litellm.llms.anthropic.experimental_pass_through.responses_adapters.streaming_iterator import (
+        AnthropicResponsesStreamWrapper,
+    )
+    from litellm.types.llms.openai import (
+        ResponseAPIUsage,
+        ResponseCompletedEvent,
+        ResponsesAPIResponse,
+    )
+
+    logging_obj = Logging(
+        model="gpt-5.6",
+        messages=[{"role": "user", "content": "hi"}],
+        stream=True,
+        call_type="anthropic_messages",
+        start_time=datetime.datetime.now(timezone.utc),
+        litellm_call_id="6825cafe-0000-4000-8000-000000000001",
+        function_id="1234",
+    )
+    logging_obj.optional_params = {}
+
+    completed_response = ResponsesAPIResponse(
+        id="resp_01Lit6825Bridged",
+        object="response",
+        created_at=1767225600,
+        model="gpt-5.6",
+        status="completed",
+        output=[
+            {
+                "id": "msg_bridged_output",
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{"type": "output_text", "text": "epsilon", "annotations": []}],
+            }
+        ],
+        usage=ResponseAPIUsage(input_tokens=12, output_tokens=5, total_tokens=17),
+    )
+
+    async def _responses_stream():
+        yield {"type": "response.created"}
+        yield {"type": "response.output_text.delta", "item_id": "msg_bridged_output", "delta": "epsilon"}
+        yield ResponseCompletedEvent(type="response.completed", response=completed_response)
+
+    wrapper = AnthropicResponsesStreamWrapper(
+        responses_stream=_responses_stream(),
+        model="gpt-5.6",
+        litellm_logging_obj=logging_obj,
+    )
+    sse_frames = [frame.decode() async for frame in wrapper.async_anthropic_sse_wrapper()]
+
+    message_start_frames = [f for f in sse_frames if f.startswith("event: message_start\n")]
+    assert len(message_start_frames) == 1
+    streamed_message_id = json.loads(message_start_frames[0].split("data: ", 1)[1])["message"]["id"]
+    assert streamed_message_id.startswith("msg_")
+
+    _, _, logged_response = logging_obj._success_handler_helper_fn(
+        result=ResponseCompletedEvent(type="response.completed", response=completed_response),
+        start_time=datetime.datetime.now(timezone.utc),
+        end_time=datetime.datetime.now(timezone.utc),
+    )
+
+    assert logged_response.id == streamed_message_id
+    payload = get_logging_payload(
+        kwargs={
+            "call_type": "anthropic_messages",
+            "model": "gpt-5.6",
+            "litellm_call_id": "6825cafe-0000-4000-8000-000000000001",
+            "litellm_params": {"metadata": {"user_api_key": "test-key"}},
+        },
+        response_obj=logged_response,
+        start_time=datetime.datetime.now(timezone.utc),
+        end_time=datetime.datetime.now(timezone.utc),
+    )
+    assert payload["request_id"] == streamed_message_id
+
+
+@pytest.mark.asyncio
+async def test_spend_log_request_id_is_untouched_when_no_message_id_was_streamed():
+    """Only the bridged streaming adapter mints a msg_ id of its own, so every other
+    /v1/messages call must keep the id its own response carried."""
+    from litellm.litellm_core_utils.litellm_logging import Logging
+    from litellm.types.llms.openai import (
+        ResponseAPIUsage,
+        ResponseCompletedEvent,
+        ResponsesAPIResponse,
+    )
+
+    logging_obj = Logging(
+        model="gpt-5.6",
+        messages=[{"role": "user", "content": "hi"}],
+        stream=False,
+        call_type="anthropic_messages",
+        start_time=datetime.datetime.now(timezone.utc),
+        litellm_call_id="6825cafe-0000-4000-8000-000000000002",
+        function_id="1234",
+    )
+    logging_obj.optional_params = {}
+
+    completed_response = ResponsesAPIResponse(
+        id="resp_01Lit6825Unbridged",
+        object="response",
+        created_at=1767225600,
+        model="gpt-5.6",
+        status="completed",
+        output=[
+            {
+                "id": "msg_unbridged_output",
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{"type": "output_text", "text": "epsilon", "annotations": []}],
+            }
+        ],
+        usage=ResponseAPIUsage(input_tokens=12, output_tokens=5, total_tokens=17),
+    )
+
+    _, _, logged_response = logging_obj._success_handler_helper_fn(
+        result=ResponseCompletedEvent(type="response.completed", response=completed_response),
+        start_time=datetime.datetime.now(timezone.utc),
+        end_time=datetime.datetime.now(timezone.utc),
+    )
+
+    assert logged_response.id
+    assert not logged_response.id.startswith("msg_")
+
+
 def test_batch_cost_row_does_not_collide_with_the_batch_creation_row():
     """Creating a batch writes a row keyed by the batch's own id, so keying the cost row
     the same way makes the insert a duplicate of it. request_id is the primary key and the


### PR DESCRIPTION
## TLDR

Problem this solves:

- Streaming `/v1/messages` on a non-Anthropic model is unfindable in spend logs
- The `msg_` id the caller is streamed never reaches the spend row
- Both bridges are affected: Responses API and chat completions
- Users can only match those calls by timestamp

How it solves it:

- Each bridge publishes the `msg_` id it mints for the stream
- The `/v1/messages` spend row is keyed on that same id

## User Flow

Before: a developer whose app streams Anthropic-format messages through the gateway to a non-Anthropic model cannot look up what those calls cost

1. Their app sends `POST https://litellm-domain/v1/messages` with `"model": "gpt-5.6"`, `"stream": true`
2. The first SSE frame is `event: message_start` carrying `"id": "msg_909435cc-414b-450f-8fc1-7895c2c28389"`, and their app records that id alongside the conversation
3. Their app sends the same request with `"model": "gemini-3.8-flash"` and records the `msg_1af8a566-95a5-4a6e-b592-e16652115ce6` it is streamed back
4. Later they send `GET https://litellm-domain/spend/logs?request_id=msg_909435cc-414b-450f-8fc1-7895c2c28389` and get back `[]`, and the same lookup on the Gemini id also returns `[]`
5. They open `https://litellm-domain/ui/?page=logs`, search either id, and the page reports no matching rows
6. They find the calls by scrolling to their timestamps, where each is listed under an id that never appeared in the stream they were served
7. With nothing linking the two ids, the only way to attribute the cost is to match on wall-clock time

After: the same lookups return the calls

1. Their app sends `POST https://litellm-domain/v1/messages` with `"model": "gpt-5.6"`, `"stream": true`
2. The first SSE frame is `event: message_start` carrying `"id": "msg_bf222347-3d88-4e43-a8c1-deb0ab256274"`, and their app records that id alongside the conversation
3. Their app sends the same request with `"model": "gemini-3.8-flash"` and records the `msg_1ee28980-8b5a-40ba-bf4f-89ad6616917c` it is streamed back
4. Later they send `GET https://litellm-domain/spend/logs?request_id=msg_bf222347-3d88-4e43-a8c1-deb0ab256274` and get back that call's row with its model and spend, and the lookup on the Gemini id returns its row too
5. They open `https://litellm-domain/ui/?page=logs`, search either id, and the page shows exactly that one call
6. Each call is listed under the same `msg_` id their app recorded, so cost attribution needs no timestamp matching

## Relevant issues

## Linear ticket

Resolves LIT-6825

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup, identical on both sides: one Postgres, and a proxy booted with 2 uvicorn workers on its own port from the commit under test, against real OpenAI, Gemini and Anthropic keys.

```yaml
model_list:
  - model_name: gpt-5.6
    litellm_params:
      model: openai/gpt-5.6
      api_key: os.environ/OPENAI_API_KEY
  - model_name: claude-haiku-4-5
    litellm_params:
      model: anthropic/claude-haiku-4-5
      api_key: os.environ/ANTHROPIC_API_KEY
  - model_name: gemini-3.8-flash
    litellm_params:
      model: gemini/gemini-3.8-flash
      api_key: os.environ/GEMINI_API_KEY

general_settings:
  master_key: sk-lit6825

litellm_settings:
  drop_params: true
```

```bash
python litellm/proxy/proxy_cli.py --config config.yaml --port $PORT --num_workers 2 --use_v2_migration_resolver
```

`gpt-5.6` reaches the Responses API bridge and `gemini-3.8-flash` reaches the chat completions bridge, so cases 1 and 2 cover both. Every case sends one request, notes the id the caller was served, waits for the spend row to flush, then looks that id up. `$PORT` is 51482 for Before and 53675 for After.

Spend-log responses are shown with each row trimmed to `request_id`, `call_type`, `model` and `spend` so the rows stay readable.

### Before (658f50663d)

#### Case 1: streaming /v1/messages, Responses API bridge

1. Stream the request:

```bash
curl -sS -N http://127.0.0.1:51482/v1/messages \
  -H "Authorization: Bearer sk-lit6825" -H "Content-Type: application/json" \
  -d '{"model":"gpt-5.6","max_tokens":32,"stream":true,"messages":[{"role":"user","content":"Reply with exactly: bridged"}]}'
```

```
event: message_start
data: {"type": "message_start", "message": {"id": "msg_909435cc-414b-450f-8fc1-7895c2c28389", "type": "message", "role": "assistant", "content": [], "model": "gpt-5.6", "stop_reason": null, "stop_sequence": null, "usage": {"input_tokens": 0, "output_tokens": 0, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}}}
```

2. Look that id up:

```bash
curl -sS "http://127.0.0.1:51482/spend/logs?request_id=msg_909435cc-414b-450f-8fc1-7895c2c28389" \
  -H "Authorization: Bearer sk-lit6825"
```

```
[]
```

#### Case 2: streaming /v1/messages, chat completions bridge

1. Stream the request:

```bash
curl -sS -N http://127.0.0.1:51482/v1/messages \
  -H "Authorization: Bearer sk-lit6825" -H "Content-Type: application/json" \
  -d '{"model":"gemini-3.8-flash","max_tokens":32,"stream":true,"messages":[{"role":"user","content":"Reply with exactly: gemini"}]}'
```

```
event: message_start
data: {"type": "message_start", "message": {"id": "msg_1af8a566-95a5-4a6e-b592-e16652115ce6", "type": "message", "role": "assistant", "content": [], "model": "gemini-3.8-flash", "stop_reason": null, "stop_sequence": null, "usage": {"input_tokens": 0, "output_tokens": 0, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}}}
```

2. Look that id up:

```bash
curl -sS "http://127.0.0.1:51482/spend/logs?request_id=msg_1af8a566-95a5-4a6e-b592-e16652115ce6" \
  -H "Authorization: Bearer sk-lit6825"
```

```
[]
```

#### Case 3: non-streaming /v1/messages on a non-Anthropic model

1. Send the request and note the id it returns:

```bash
curl -sS http://127.0.0.1:51482/v1/messages \
  -H "Authorization: Bearer sk-lit6825" -H "Content-Type: application/json" \
  -d '{"model":"gpt-5.6","max_tokens":32,"messages":[{"role":"user","content":"Reply with exactly: sync"}]}'
```

```
"id": "resp_bGl0ZWxsbTpjdXN0b21fbGxtX3Byb3ZpZGVyOm9wZW5haTttb2RlbF9pZDphZTIyN2Q0MjEzNThhOGM4YWUzMDYxMjVjYjllZDcyOWQ1NzcwNjM3NjA2ZGJmOTcwM2VlNTU5YWRhYzkwMDhkO3Jlc3BvbnNlX2lkOnJlc3BfMDBmOTUwYjM3ZGIxYzFmMzAwNmE5OTU0ZTRlZTA0ODdkMGExM2FiMjYxYjdjNTIwYzc="
```

2. Look that id up:

```bash
curl -sS "http://127.0.0.1:51482/spend/logs?request_id=resp_bGl0ZWxsbTpjdXN0b21fbGxtX3Byb3ZpZGVyOm9wZW5haTttb2RlbF9pZDphZTIyN2Q0MjEzNThhOGM4YWUzMDYxMjVjYjllZDcyOWQ1NzcwNjM3NjA2ZGJmOTcwM2VlNTU5YWRhYzkwMDhkO3Jlc3BvbnNlX2lkOnJlc3BfMDBmOTUwYjM3ZGIxYzFmMzAwNmE5OTU0ZTRlZTA0ODdkMGExM2FiMjYxYjdjNTIwYzc=" \
  -H "Authorization: Bearer sk-lit6825"
```

```
[]
```

#### Case 4: streaming /v1/messages on an Anthropic model

1. Stream the request and note the id it is served: `msg_011CegQ7zgKy5RHTTmFgzrdp`

```bash
curl -sS -N http://127.0.0.1:51482/v1/messages \
  -H "Authorization: Bearer sk-lit6825" -H "Content-Type: application/json" \
  -d '{"model":"claude-haiku-4-5","max_tokens":32,"stream":true,"messages":[{"role":"user","content":"Reply with exactly: native"}]}'
```

2. Look that id up:

```bash
curl -sS "http://127.0.0.1:51482/spend/logs?request_id=msg_011CegQ7zgKy5RHTTmFgzrdp" \
  -H "Authorization: Bearer sk-lit6825"
```

```
[]
```

#### Case 5: streaming /v1/chat/completions

1. Stream the request and note the id it is served: `chatcmpl-EJzZpZ8uGZ95VT1CIKR62mcs5uNfi`

```bash
curl -sS -N http://127.0.0.1:51482/v1/chat/completions \
  -H "Authorization: Bearer sk-lit6825" -H "Content-Type: application/json" \
  -d '{"model":"gpt-5.6","stream":true,"messages":[{"role":"user","content":"Reply with exactly: chat"}]}'
```

2. Look that id up:

```bash
curl -sS "http://127.0.0.1:51482/spend/logs?request_id=chatcmpl-EJzZpZ8uGZ95VT1CIKR62mcs5uNfi" \
  -H "Authorization: Bearer sk-lit6825"
```

```
{"request_id": "chatcmpl-EJzZpZ8uGZ95VT1CIKR62mcs5uNfi", "call_type": "acompletion", "model": "openai/gpt-5.6", "spend": 0.000124}
```

#### Case 6: streaming /v1/responses

1. Stream the request and note the id it is served: `resp_coPiJeOvh-8oVViggc-4jeDB7Lose...` (truncated)

```bash
curl -sS -N http://127.0.0.1:51482/v1/responses \
  -H "Authorization: Bearer sk-lit6825" -H "Content-Type: application/json" \
  -d '{"model":"gpt-5.6","stream":true,"input":"Reply with exactly: responses"}'
```

2. Look that id up:

```bash
curl -sS "http://127.0.0.1:51482/spend/logs?request_id=resp_coPiJeOvh-8oVViggc-4jeDB7Lose..." \
  -H "Authorization: Bearer sk-lit6825"
```

```
[]
```

#### Case 7: Admin UI logs search for the two streamed msg_ ids

1. Search the Responses API bridge id, the way the Admin UI logs page does:

```bash
curl -sS "http://127.0.0.1:51482/spend/logs/ui?page=1&page_size=5&start_date=2026-09-03%2000:00:00&end_date=2026-09-04%2000:00:00&request_id=msg_909435cc-414b-450f-8fc1-7895c2c28389" \
  -H "Authorization: Bearer sk-lit6825"
```

```
total: 0
```

2. Search the chat completions bridge id:

```bash
curl -sS "http://127.0.0.1:51482/spend/logs/ui?page=1&page_size=5&start_date=2026-09-03%2000:00:00&end_date=2026-09-04%2000:00:00&request_id=msg_1af8a566-95a5-4a6e-b592-e16652115ce6" \
  -H "Authorization: Bearer sk-lit6825"
```

```
total: 0
```

#### Case 8: five concurrent streaming /v1/messages on the chat completions bridge

1. Fire five streams at once and collect the id each was served:

```bash
for i in 1 2 3 4 5; do
  curl -sS -N http://127.0.0.1:51482/v1/messages \
    -H "Authorization: Bearer sk-lit6825" -H "Content-Type: application/json" \
    -d "{\"model\":\"gemini-3.8-flash\",\"max_tokens\":32,\"stream\":true,\"messages\":[{\"role\":\"user\",\"content\":\"Reply with exactly: conc$i\"}]}" &
done; wait
```

```
concurrent stream #1 => msg_418d619b-cd49-4d8d-aabb-1165af11bba8
concurrent stream #2 => msg_1e3c9dcb-c536-459e-9003-da896ebe026e
concurrent stream #3 => msg_3407e5f5-1c42-4d92-8eb5-4ee47e672b2f
concurrent stream #4 => msg_d69070a9-02ed-4d1d-9542-be8c7d80bc08
concurrent stream #5 => msg_6ec6e860-effb-43e4-aa37-99acc500edda
```

2. Look each id up:

```
msg_418d619b-cd49-4d8d-aabb-1165af11bba8 -> []
msg_1e3c9dcb-c536-459e-9003-da896ebe026e -> []
msg_3407e5f5-1c42-4d92-8eb5-4ee47e672b2f -> []
msg_d69070a9-02ed-4d1d-9542-be8c7d80bc08 -> []
msg_6ec6e860-effb-43e4-aa37-99acc500edda -> []
```

### After (fc4c961f98)

#### Case 1: streaming /v1/messages, Responses API bridge

1. Stream the request:

```bash
curl -sS -N http://127.0.0.1:53675/v1/messages \
  -H "Authorization: Bearer sk-lit6825" -H "Content-Type: application/json" \
  -d '{"model":"gpt-5.6","max_tokens":32,"stream":true,"messages":[{"role":"user","content":"Reply with exactly: bridged"}]}'
```

```
event: message_start
data: {"type": "message_start", "message": {"id": "msg_bf222347-3d88-4e43-a8c1-deb0ab256274", "type": "message", "role": "assistant", "content": [], "model": "gpt-5.6", "stop_reason": null, "stop_sequence": null, "usage": {"input_tokens": 0, "output_tokens": 0, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}}}
```

2. Look that id up:

```bash
curl -sS "http://127.0.0.1:53675/spend/logs?request_id=msg_bf222347-3d88-4e43-a8c1-deb0ab256274" \
  -H "Authorization: Bearer sk-lit6825"
```

```
{"request_id": "msg_bf222347-3d88-4e43-a8c1-deb0ab256274", "call_type": "anthropic_messages", "model": "openai/gpt-5.6", "spend": 0.000168}
```

#### Case 2: streaming /v1/messages, chat completions bridge

1. Stream the request:

```bash
curl -sS -N http://127.0.0.1:53675/v1/messages \
  -H "Authorization: Bearer sk-lit6825" -H "Content-Type: application/json" \
  -d '{"model":"gemini-3.8-flash","max_tokens":32,"stream":true,"messages":[{"role":"user","content":"Reply with exactly: gemini"}]}'
```

```
event: message_start
data: {"type": "message_start", "message": {"id": "msg_1ee28980-8b5a-40ba-bf4f-89ad6616917c", "type": "message", "role": "assistant", "content": [], "model": "gemini-3.8-flash", "stop_reason": null, "stop_sequence": null, "usage": {"input_tokens": 0, "output_tokens": 0, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}}}
```

2. Look that id up:

```bash
curl -sS "http://127.0.0.1:53675/spend/logs?request_id=msg_1ee28980-8b5a-40ba-bf4f-89ad6616917c" \
  -H "Authorization: Bearer sk-lit6825"
```

```
{"request_id": "msg_1ee28980-8b5a-40ba-bf4f-89ad6616917c", "call_type": "anthropic_messages", "model": "gemini/gemini-3.8-flash", "spend": 0.00011025}
```

#### Case 3: non-streaming /v1/messages on a non-Anthropic model

1. Send the request and note the id it returns:

```bash
curl -sS http://127.0.0.1:53675/v1/messages \
  -H "Authorization: Bearer sk-lit6825" -H "Content-Type: application/json" \
  -d '{"model":"gpt-5.6","max_tokens":32,"messages":[{"role":"user","content":"Reply with exactly: sync"}]}'
```

```
"id": "resp_bGl0ZWxsbTpjdXN0b21fbGxtX3Byb3ZpZGVyOm9wZW5haTttb2RlbF9pZDphZTIyN2Q0MjEzNThhOGM4YWUzMDYxMjVjYjllZDcyOWQ1NzcwNjM3NjA2ZGJmOTcwM2VlNTU5YWRhYzkwMDhkO3Jlc3BvbnNlX2lkOnJlc3BfMDEyYzNhYWY3YTQ0MzM1YjAwNmE5OTU0ZTNkNDA4ODdkMGI2NDY0YjdiN2MzMTcxMDQ="
```

2. Look that id up:

```bash
curl -sS "http://127.0.0.1:53675/spend/logs?request_id=resp_bGl0ZWxsbTpjdXN0b21fbGxtX3Byb3ZpZGVyOm9wZW5haTttb2RlbF9pZDphZTIyN2Q0MjEzNThhOGM4YWUzMDYxMjVjYjllZDcyOWQ1NzcwNjM3NjA2ZGJmOTcwM2VlNTU5YWRhYzkwMDhkO3Jlc3BvbnNlX2lkOnJlc3BfMDEyYzNhYWY3YTQ0MzM1YjAwNmE5OTU0ZTNkNDA4ODdkMGI2NDY0YjdiN2MzMTcxMDQ=" \
  -H "Authorization: Bearer sk-lit6825"
```

```
[]
```

#### Case 4: streaming /v1/messages on an Anthropic model

1. Stream the request and note the id it is served: `msg_011CegQ7qkoQkzyuvcXwkBwT`

```bash
curl -sS -N http://127.0.0.1:53675/v1/messages \
  -H "Authorization: Bearer sk-lit6825" -H "Content-Type: application/json" \
  -d '{"model":"claude-haiku-4-5","max_tokens":32,"stream":true,"messages":[{"role":"user","content":"Reply with exactly: native"}]}'
```

2. Look that id up:

```bash
curl -sS "http://127.0.0.1:53675/spend/logs?request_id=msg_011CegQ7qkoQkzyuvcXwkBwT" \
  -H "Authorization: Bearer sk-lit6825"
```

```
[]
```

#### Case 5: streaming /v1/chat/completions

1. Stream the request and note the id it is served: `chatcmpl-EJzZnUr4cx2yiMAG5I0h3KVh81mdE`

```bash
curl -sS -N http://127.0.0.1:53675/v1/chat/completions \
  -H "Authorization: Bearer sk-lit6825" -H "Content-Type: application/json" \
  -d '{"model":"gpt-5.6","stream":true,"messages":[{"role":"user","content":"Reply with exactly: chat"}]}'
```

2. Look that id up:

```bash
curl -sS "http://127.0.0.1:53675/spend/logs?request_id=chatcmpl-EJzZnUr4cx2yiMAG5I0h3KVh81mdE" \
  -H "Authorization: Bearer sk-lit6825"
```

```
{"request_id": "chatcmpl-EJzZnUr4cx2yiMAG5I0h3KVh81mdE", "call_type": "acompletion", "model": "openai/gpt-5.6", "spend": 0.000124}
```

#### Case 6: streaming /v1/responses

1. Stream the request and note the id it is served: `resp_mRNYsJbqg1eavPI75nVbPaqFbMs1ye...` (truncated)

```bash
curl -sS -N http://127.0.0.1:53675/v1/responses \
  -H "Authorization: Bearer sk-lit6825" -H "Content-Type: application/json" \
  -d '{"model":"gpt-5.6","stream":true,"input":"Reply with exactly: responses"}'
```

2. Look that id up:

```bash
curl -sS "http://127.0.0.1:53675/spend/logs?request_id=resp_mRNYsJbqg1eavPI75nVbPaqFbMs1ye..." \
  -H "Authorization: Bearer sk-lit6825"
```

```
[]
```

#### Case 7: Admin UI logs search for the two streamed msg_ ids

1. Search the Responses API bridge id, the way the Admin UI logs page does:

```bash
curl -sS "http://127.0.0.1:53675/spend/logs/ui?page=1&page_size=5&start_date=2026-09-03%2000:00:00&end_date=2026-09-04%2000:00:00&request_id=msg_bf222347-3d88-4e43-a8c1-deb0ab256274" \
  -H "Authorization: Bearer sk-lit6825"
```

```
total: 1
{"request_id": "msg_bf222347-3d88-4e43-a8c1-deb0ab256274", "call_type": "anthropic_messages", "model": "openai/gpt-5.6", "spend": 0.000168}
```

2. Search the chat completions bridge id:

```bash
curl -sS "http://127.0.0.1:53675/spend/logs/ui?page=1&page_size=5&start_date=2026-09-03%2000:00:00&end_date=2026-09-04%2000:00:00&request_id=msg_1ee28980-8b5a-40ba-bf4f-89ad6616917c" \
  -H "Authorization: Bearer sk-lit6825"
```

```
total: 1
{"request_id": "msg_1ee28980-8b5a-40ba-bf4f-89ad6616917c", "call_type": "anthropic_messages", "model": "gemini/gemini-3.8-flash", "spend": 0.00011025}
```

#### Case 8: five concurrent streaming /v1/messages on the chat completions bridge

1. Fire five streams at once and collect the id each was served:

```bash
for i in 1 2 3 4 5; do
  curl -sS -N http://127.0.0.1:53675/v1/messages \
    -H "Authorization: Bearer sk-lit6825" -H "Content-Type: application/json" \
    -d "{\"model\":\"gemini-3.8-flash\",\"max_tokens\":32,\"stream\":true,\"messages\":[{\"role\":\"user\",\"content\":\"Reply with exactly: conc$i\"}]}" &
done; wait
```

```
concurrent stream #1 => msg_440a9da0-6d54-4734-bd97-369c5ca33798
concurrent stream #2 => msg_dc9d0448-b647-4f88-a5e6-0b38e797f18a
concurrent stream #3 => msg_4088a21d-64c6-46f6-bedd-e254566611f0
concurrent stream #4 => msg_b00b9348-c76d-43d3-b700-6cd767cda256
concurrent stream #5 => msg_2f7de6e3-945f-4f54-a0d3-a4d2a8957794
```

2. Look each id up:

```
msg_440a9da0-6d54-4734-bd97-369c5ca33798 -> rows: 1   {"request_id": "msg_440a9da0-6d54-4734-bd97-369c5ca33798", "call_type": "anthropic_messages", "model": "gemini/gemini-3.8-flash", "spend": 0.000114}
msg_dc9d0448-b647-4f88-a5e6-0b38e797f18a -> rows: 1   {"request_id": "msg_dc9d0448-b647-4f88-a5e6-0b38e797f18a", "call_type": "anthropic_messages", "model": "gemini/gemini-3.8-flash", "spend": 0.000114}
msg_4088a21d-64c6-46f6-bedd-e254566611f0 -> rows: 1   {"request_id": "msg_4088a21d-64c6-46f6-bedd-e254566611f0", "call_type": "anthropic_messages", "model": "gemini/gemini-3.8-flash", "spend": 0.000114}
msg_b00b9348-c76d-43d3-b700-6cd767cda256 -> rows: 1   {"request_id": "msg_b00b9348-c76d-43d3-b700-6cd767cda256", "call_type": "anthropic_messages", "model": "gemini/gemini-3.8-flash", "spend": 0.000114}
msg_2f7de6e3-945f-4f54-a0d3-a4d2a8957794 -> rows: 1   {"request_id": "msg_2f7de6e3-945f-4f54-a0d3-a4d2a8957794", "call_type": "anthropic_messages", "model": "gemini/gemini-3.8-flash", "spend": 0.000114}
```

What the run noticed, unchanged by this PR:

- Bridged non-streaming `/v1/messages` returns an unfindable `resp_` id
- Anthropic-native streaming `/v1/messages` is unfindable too
- Streaming `/v1/responses` is unfindable by its own id
- All three behave the same before and after
- Concurrent streams already got distinct ids before this PR

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Branched off `litellm_internal_staging`, not off PR #39511
  - The fix stands alone: it overrides whatever id the base produces
  - Stacking would park this behind an approval this branch does not control
  - `git merge-tree` reports no conflict between the two branches
  - The merged tree passes both PRs' test files
- Cases 3, 4 and 6 stay unfindable, identically before and after
  - Those rows are keyed on ids this branch never mints, so PR #39511 owns them
  - Covering them here would duplicate that branch and collide with it on merge
- Bridged non-streaming `/v1/messages` still hands the caller a `resp_` id
  - Nothing is minted locally on that path, so there is no id to carry over
  - Changing what the caller is served is a client-visible break, not a logging fix

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] fc4c961f98 passes /live-pr-risk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Alters how spend log `request_id` is derived for bridged streaming `/v1/messages` calls; impact is limited to that path and only when a streamed message id was recorded.
> 
> **Overview**
> Fixes spend log lookups for **streaming** `/v1/messages` when the call is bridged to chat completions or the Responses API: the client only ever sees a locally minted `msg_` id in `message_start`, but spend rows were keyed on the upstream completion/response id.
> 
> The streaming adapters now generate **one** `msg_` id per stream (replacing per-chunk random ids), pass the caller’s `litellm_logging_obj` into the wrappers, and call `record_streamed_anthropic_message_id` at stream start. On success logging for `anthropic_messages`, `_anthropic_messages_logged_response` copies that id onto the logged `ModelResponse` so `request_id` matches what the client recorded. A small `litellm_logging_obj_from_kwargs` helper wires logging through both bridge handlers.
> 
> Tests cover async/sync bridging, concurrent streams, and end-to-end spend payload `request_id` alignment; non-bridged paths without a recorded id are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc4c961f98790c3ad9589da255af0b345212641d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->