### PR TITLE
fix(proxy): stop answering with the literal string "None" on the spend and management routes

### DIFF
--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -29,6 +29,7 @@ from litellm.proxy._types import *
 from litellm.proxy.auth.auth_checks import get_team_object, get_user_object
 from litellm.proxy.auth.password_policy import validate_password_policy
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+from litellm.proxy.common_utils.openai_error_payload import openai_error_param
 from litellm.proxy.common_utils.user_api_key_cache import (
     object_permission_cache_key,
     user_object_permission_id_cache_key,
@@ -1649,7 +1650,7 @@ async def user_update(
             raise ProxyException(
                 message=getattr(e, "detail", f"Authentication Error({e})"),
                 type=ProxyErrorTypes.auth_error,
-                param=getattr(e, "param", "None"),
+                param=openai_error_param(e),
                 code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
             )
         elif isinstance(e, ProxyException):
@@ -1657,7 +1658,7 @@ async def user_update(
         raise ProxyException(
             message="Authentication Error, " + str(e),
             type=ProxyErrorTypes.auth_error,
-            param=getattr(e, "param", "None"),
+            param=openai_error_param(e),
             code=status.HTTP_400_BAD_REQUEST,
         )
 

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -76,6 +76,7 @@ from litellm.proxy.common_utils.config_sync_pubsub import (
     coordination_redis_cache,
     publish_config_change,
 )
+from litellm.proxy.common_utils.openai_error_payload import openai_error_param
 from litellm.proxy.common_utils.rbac_utils import check_org_admin_can_generate_keys
 from litellm.proxy.common_utils.timezone_utils import get_budget_reset_time
 from litellm.proxy.common_utils.user_api_key_cache import UserApiKeyCache
@@ -3040,7 +3041,7 @@ async def update_key_fn(
             raise ProxyException(
                 message=getattr(e, "detail", f"Authentication Error({e})"),
                 type=ProxyErrorTypes.auth_error,
-                param=getattr(e, "param", "None"),
+                param=openai_error_param(e),
                 code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
             )
         elif isinstance(e, ProxyException):
@@ -3048,7 +3049,7 @@ async def update_key_fn(
         raise ProxyException(
             message="Authentication Error, " + str(e),
             type=ProxyErrorTypes.auth_error,
-            param=getattr(e, "param", "None"),
+            param=openai_error_param(e),
             code=status.HTTP_400_BAD_REQUEST,
         )
 
@@ -5955,7 +5956,7 @@ async def list_keys(
             raise ProxyException(
                 message=getattr(e, "detail", f"error({e})"),
                 type=ProxyErrorTypes.internal_server_error,
-                param=getattr(e, "param", "None"),
+                param=openai_error_param(e),
                 code=getattr(e, "status_code", fastapi.status.HTTP_500_INTERNAL_SERVER_ERROR),
             )
         elif isinstance(e, ProxyException):
@@ -5963,7 +5964,7 @@ async def list_keys(
         raise ProxyException(
             message="Authentication Error, " + str(e),
             type=ProxyErrorTypes.internal_server_error,
-            param=getattr(e, "param", "None"),
+            param=openai_error_param(e),
             code=fastapi.status.HTTP_500_INTERNAL_SERVER_ERROR,
         )
 
@@ -6111,7 +6112,7 @@ async def key_aliases(
             raise ProxyException(
                 message=getattr(e, "detail", f"error({e})"),
                 type=ProxyErrorTypes.internal_server_error,
-                param=getattr(e, "param", "None"),
+                param=openai_error_param(e),
                 code=getattr(e, "status_code", status.HTTP_500_INTERNAL_SERVER_ERROR),
             )
         elif isinstance(e, ProxyException):
@@ -6119,7 +6120,7 @@ async def key_aliases(
         raise ProxyException(
             message="Authentication Error, " + str(e),
             type=ProxyErrorTypes.internal_server_error,
-            param=getattr(e, "param", "None"),
+            param=openai_error_param(e),
             code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         )
 
@@ -6851,7 +6852,7 @@ async def key_health(
         raise ProxyException(
             message=f"Key health check failed: {e}",
             type=ProxyErrorTypes.internal_server_error,
-            param=getattr(e, "param", "None"),
+            param=openai_error_param(e),
             code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         )
 

--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -58,6 +58,7 @@ from litellm.proxy.common_utils.encrypt_decrypt_utils import (
     decrypt_value_helper,
     encrypt_value_helper,
 )
+from litellm.proxy.common_utils.openai_error_payload import openai_error_param
 from litellm.proxy.common_utils.user_api_key_cache import UserApiKeyCache
 from litellm.proxy.management_endpoints.common_utils import _is_user_team_admin
 from litellm.proxy.management_endpoints.team_endpoints import (
@@ -1700,7 +1701,7 @@ async def delete_model(
             raise ProxyException(
                 message=getattr(e, "detail", f"Authentication Error({e})"),
                 type=ProxyErrorTypes.auth_error,
-                param=getattr(e, "param", "None"),
+                param=openai_error_param(e),
                 code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
             )
         elif isinstance(e, ProxyException):
@@ -1708,7 +1709,7 @@ async def delete_model(
         raise ProxyException(
             message="Authentication Error, " + str(e),
             type=ProxyErrorTypes.auth_error,
-            param=getattr(e, "param", "None"),
+            param=openai_error_param(e),
             code=status.HTTP_400_BAD_REQUEST,
         )
 
@@ -1924,7 +1925,7 @@ async def add_new_model(
             raise ProxyException(
                 message=getattr(e, "detail", f"Authentication Error({e})"),
                 type=ProxyErrorTypes.auth_error,
-                param=getattr(e, "param", "None"),
+                param=openai_error_param(e),
                 code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
             )
         elif isinstance(e, ProxyException):
@@ -1932,7 +1933,7 @@ async def add_new_model(
         raise ProxyException(
             message="Authentication Error, " + str(e),
             type=ProxyErrorTypes.auth_error,
-            param=getattr(e, "param", "None"),
+            param=openai_error_param(e),
             code=status.HTTP_400_BAD_REQUEST,
         )
 
@@ -2087,7 +2088,7 @@ async def update_model(
             raise ProxyException(
                 message=getattr(e, "detail", f"Authentication Error({e})"),
                 type=ProxyErrorTypes.auth_error,
-                param=getattr(e, "param", "None"),
+                param=openai_error_param(e),
                 code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
             )
         elif isinstance(e, ProxyException):
@@ -2095,7 +2096,7 @@ async def update_model(
         raise ProxyException(
             message="Authentication Error, " + str(e),
             type=ProxyErrorTypes.auth_error,
-            param=getattr(e, "param", "None"),
+            param=openai_error_param(e),
             code=status.HTTP_400_BAD_REQUEST,
         )
 

--- a/litellm/proxy/management_endpoints/organization_endpoints.py
+++ b/litellm/proxy/management_endpoints/organization_endpoints.py
@@ -32,6 +32,7 @@ from litellm._uuid import uuid
 from litellm.proxy._types import *
 from litellm.proxy.auth.auth_checks import can_user_call_model, get_user_object
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+from litellm.proxy.common_utils.openai_error_payload import openai_error_param
 from litellm.proxy.common_utils.timezone_utils import get_budget_reset_time
 from litellm.proxy.management_endpoints.budget_management_endpoints import (
     new_budget,
@@ -1272,7 +1273,7 @@ async def organization_member_add(
             raise ProxyException(
                 message=getattr(e, "detail", f"Authentication Error({e})"),
                 type=ProxyErrorTypes.auth_error,
-                param=getattr(e, "param", "None"),
+                param=openai_error_param(e),
                 code=getattr(e, "status_code", status.HTTP_500_INTERNAL_SERVER_ERROR),
             )
         elif isinstance(e, ProxyException):
@@ -1280,7 +1281,7 @@ async def organization_member_add(
         raise ProxyException(
             message="Authentication Error, " + str(e),
             type=ProxyErrorTypes.auth_error,
-            param=getattr(e, "param", "None"),
+            param=openai_error_param(e),
             code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         )
 

--- a/litellm/proxy/management_endpoints/team_callback_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_callback_endpoints.py
@@ -35,6 +35,7 @@ from litellm.proxy.common_utils.callback_utils import (
     encrypt_callback_vars,
     is_sensitive_callback_key,
 )
+from litellm.proxy.common_utils.openai_error_payload import openai_error_param
 from litellm.proxy.litellm_pre_call_utils import (
     _get_validated_callback_metadata,
     convert_key_logging_metadata_to_callback,
@@ -387,7 +388,7 @@ async def add_team_callbacks(
         raise ProxyException(
             message="Internal Server Error, " + str(e),
             type=ProxyErrorTypes.internal_server_error.value,
-            param=getattr(e, "param", "None"),
+            param=openai_error_param(e),
             code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         )
 
@@ -530,7 +531,7 @@ async def delete_team_callback(
         raise ProxyException(
             message="Internal Server Error, " + str(e),
             type=ProxyErrorTypes.internal_server_error.value,
-            param=getattr(e, "param", "None"),
+            param=openai_error_param(e),
             code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         )
     else:
@@ -671,7 +672,7 @@ async def disable_team_logging(
         raise ProxyException(
             message="Internal Server Error, " + str(e),
             type=ProxyErrorTypes.internal_server_error.value,
-            param=getattr(e, "param", "None"),
+            param=openai_error_param(e),
             code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         )
 
@@ -765,7 +766,7 @@ async def get_team_callbacks(
             raise ProxyException(
                 message=getattr(e, "detail", f"Internal Server Error({e})"),
                 type=ProxyErrorTypes.internal_server_error.value,
-                param=getattr(e, "param", "None"),
+                param=openai_error_param(e),
                 code=getattr(e, "status_code", status.HTTP_500_INTERNAL_SERVER_ERROR),
             )
         elif isinstance(e, ProxyException):
@@ -773,6 +774,6 @@ async def get_team_callbacks(
         raise ProxyException(
             message="Internal Server Error, " + str(e),
             type=ProxyErrorTypes.internal_server_error.value,
-            param=getattr(e, "param", "None"),
+            param=openai_error_param(e),
             code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         )

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -92,6 +92,7 @@ from litellm.proxy.auth.auth_utils import (
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.proxy.common_utils.callback_utils import encrypt_callback_vars
 from litellm.proxy.common_utils.json_merge_patch import apply_json_merge_patch
+from litellm.proxy.common_utils.openai_error_payload import openai_error_param
 from litellm.proxy.common_utils.user_api_key_cache import UserApiKeyCache
 from litellm.proxy.management_endpoints.common_daily_activity import (
     get_daily_activity_aggregated,
@@ -4461,7 +4462,7 @@ async def team_info(
             raise ProxyException(
                 message=getattr(e, "detail", f"Authentication Error({e})"),
                 type=ProxyErrorTypes.auth_error,
-                param=getattr(e, "param", "None"),
+                param=openai_error_param(e),
                 code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
             )
         elif isinstance(e, ProxyException):
@@ -4469,7 +4470,7 @@ async def team_info(
         raise ProxyException(
             message="Authentication Error, " + str(e),
             type=ProxyErrorTypes.auth_error,
-            param=getattr(e, "param", "None"),
+            param=openai_error_param(e),
             code=status.HTTP_400_BAD_REQUEST,
         )
 

--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -27,6 +27,11 @@ from litellm.constants import LITTELM_INTERNAL_HEALTH_SERVICE_ACCOUNT_NAME
 from litellm.proxy._types import *
 from litellm.proxy._types import ProviderBudgetResponse, ProviderBudgetResponseObject
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+from litellm.proxy.common_utils.openai_error_payload import (
+    error_status_code,
+    openai_error_param,
+    openai_error_type,
+)
 
 # NOTE: Avoid module-level import from common_utils: proxy_server imports this
 # module while common_utils may pull proxy_server during init, which can leave
@@ -447,7 +452,7 @@ async def view_spend_tags(
             raise ProxyException(
                 message=getattr(e, "detail", f"/spend/tags Error({e})"),
                 type="internal_error",
-                param=getattr(e, "param", "None"),
+                param=openai_error_param(e),
                 code=getattr(e, "status_code", status.HTTP_500_INTERNAL_SERVER_ERROR),
             )
         elif isinstance(e, ProxyException):
@@ -455,7 +460,7 @@ async def view_spend_tags(
         raise ProxyException(
             message="/spend/tags Error" + str(e),
             type="internal_error",
-            param=getattr(e, "param", "None"),
+            param=openai_error_param(e),
             code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         )
 
@@ -1875,7 +1880,7 @@ async def global_get_all_tag_names():
             raise ProxyException(
                 message=getattr(e, "detail", f"/spend/all_tag_names Error({e})"),
                 type="internal_error",
-                param=getattr(e, "param", "None"),
+                param=openai_error_param(e),
                 code=getattr(e, "status_code", status.HTTP_500_INTERNAL_SERVER_ERROR),
             )
         elif isinstance(e, ProxyException):
@@ -1883,7 +1888,7 @@ async def global_get_all_tag_names():
         raise ProxyException(
             message="/spend/all_tag_names Error" + str(e),
             type="internal_error",
-            param=getattr(e, "param", "None"),
+            param=openai_error_param(e),
             code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         )
 
@@ -1957,7 +1962,7 @@ async def global_view_spend_tags(
             raise ProxyException(
                 message=getattr(e, "detail", f"/spend/tags Error({error_str})"),
                 type="internal_error",
-                param=getattr(e, "param", "None"),
+                param=openai_error_param(e),
                 code=getattr(e, "status_code", status.HTTP_500_INTERNAL_SERVER_ERROR),
             )
         elif isinstance(e, ProxyException):
@@ -1965,7 +1970,7 @@ async def global_view_spend_tags(
         raise ProxyException(
             message="/spend/tags Error" + error_str,
             type="internal_error",
-            param=getattr(e, "param", "None"),
+            param=openai_error_param(e),
             code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         )
 
@@ -2175,16 +2180,16 @@ async def calculate_spend(request: SpendCalculateRequest):
         if isinstance(e, HTTPException):
             raise ProxyException(
                 message=getattr(e, "detail", str(e)),
-                type=getattr(e, "type", "None"),
-                param=getattr(e, "param", "None"),
-                code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
+                type=openai_error_type(e, error_status_code(e, status.HTTP_400_BAD_REQUEST)),
+                param=openai_error_param(e),
+                code=error_status_code(e, status.HTTP_400_BAD_REQUEST),
             )
         error_msg: Final = f"{e}"
         raise ProxyException(
             message=getattr(e, "message", error_msg),
-            type=getattr(e, "type", "None"),
-            param=getattr(e, "param", "None"),
-            code=getattr(e, "status_code", 500),
+            type=openai_error_type(e, error_status_code(e, 500)),
+            param=openai_error_param(e),
+            code=error_status_code(e, 500),
         )
 
 
@@ -2300,7 +2305,7 @@ async def ui_view_spend_logs(
         raise ProxyException(
             message="Prisma Client is not initialized",
             type="internal_error",
-            param="None",
+            param=None,
             code=status.HTTP_401_UNAUTHORIZED,
         )
 
@@ -2358,7 +2363,7 @@ async def ui_view_spend_logs(
                 raise ProxyException(
                     message="Start date and end date are required",
                     type="bad_request",
-                    param="None",
+                    param=None,
                     code=status.HTTP_400_BAD_REQUEST,
                 )
             formats: Final = ["%Y-%m-%d %H:%M:%S", "%Y-%m-%d"] if is_v2 else ["%Y-%m-%d %H:%M:%S"]
@@ -3118,7 +3123,7 @@ async def view_spend_logs(
             raise ProxyException(
                 message=getattr(e, "detail", f"/spend/logs Error({e})"),
                 type="internal_error",
-                param=getattr(e, "param", "None"),
+                param=openai_error_param(e),
                 code=getattr(e, "status_code", status.HTTP_500_INTERNAL_SERVER_ERROR),
             )
         elif isinstance(e, ProxyException):
@@ -3126,7 +3131,7 @@ async def view_spend_logs(
         raise ProxyException(
             message="/spend/logs Error" + str(e),
             type="internal_error",
-            param=getattr(e, "param", "None"),
+            param=openai_error_param(e),
             code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         )
 
@@ -3153,7 +3158,7 @@ async def global_spend_reset():
         raise ProxyException(
             message="Prisma Client is not initialized",
             type="internal_error",
-            param="None",
+            param=None,
             code=status.HTTP_401_UNAUTHORIZED,
         )
 
@@ -3184,7 +3189,7 @@ async def global_spend_refresh():
         raise ProxyException(
             message="Prisma Client is not initialized",
             type="internal_error",
-            param="None",
+            param=None,
             code=status.HTTP_401_UNAUTHORIZED,
         )
 
@@ -3255,7 +3260,7 @@ async def global_spend_for_internal_user(
         raise ProxyException(
             message="Prisma Client is not initialized",
             type="internal_error",
-            param="None",
+            param=None,
             code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         )
     try:
@@ -3316,7 +3321,7 @@ async def global_spend_logs(
             raise ProxyException(
                 message="Prisma Client is not initialized",
                 type="internal_error",
-                param="None",
+                param=None,
                 code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
@@ -3360,7 +3365,7 @@ async def global_spend_logs(
             raise ProxyException(
                 message=getattr(e, "detail", f"/global/spend/logs Error({error_str})"),
                 type="internal_error",
-                param=getattr(e, "param", "None"),
+                param=openai_error_param(e),
                 code=getattr(e, "status_code", status.HTTP_500_INTERNAL_SERVER_ERROR),
             )
         elif isinstance(e, ProxyException):
@@ -3368,7 +3373,7 @@ async def global_spend_logs(
         raise ProxyException(
             message="/global/spend/logs Error" + error_str,
             type="internal_error",
-            param=getattr(e, "param", "None"),
+            param=openai_error_param(e),
             code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         )
 
@@ -3408,7 +3413,7 @@ async def global_spend():
             raise ProxyException(
                 message=getattr(e, "detail", f"/global/spend Error({error_str})"),
                 type="internal_error",
-                param=getattr(e, "param", "None"),
+                param=openai_error_param(e),
                 code=getattr(e, "status_code", status.HTTP_500_INTERNAL_SERVER_ERROR),
             )
         elif isinstance(e, ProxyException):
@@ -3416,7 +3421,7 @@ async def global_spend():
         raise ProxyException(
             message="/global/spend Error" + error_str,
             type="internal_error",
-            param=getattr(e, "param", "None"),
+            param=openai_error_param(e),
             code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         )
 

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -17535,3 +17535,23 @@ def test_key_generation_check_blank_team_id_uses_personal_permissions(monkeypatc
         )
         is True
     )
+
+
+def test_key_health_failure_body_is_openai_shaped():
+    """A /key/health failure must answer with an OpenAI error object whose `param`
+    is JSON null, never the literal string "None"."""
+    import litellm.proxy.proxy_server as ps
+
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        api_key="hashed-key", metadata={"logging": ["not-a-callback-object"]}
+    )
+    try:
+        response = client.post("/key/health", headers={"Authorization": "Bearer sk-test"})
+    finally:
+        app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+    assert response.status_code == 500
+    error = response.json()["error"]
+    assert error["type"] == "internal_server_error"
+    assert error["param"] is None
+    assert error["code"] == "500"

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -5980,3 +5980,25 @@ def test_scoped_spend_report_range_at_max_allowed(client, monkeypatch):
         mock_prisma.db.query_raw.assert_awaited_once()
     finally:
         app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+
+def test_spend_calculate_rejection_body_is_openai_shaped(client):
+    """A /spend/calculate rejection must answer with an OpenAI error object: a real
+    `type` string and a JSON null `param`, never the literal string "None"."""
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin_user", api_key="hashed-k"
+    )
+    try:
+        response = client.post(
+            "/spend/calculate",
+            json={},
+            headers={"Authorization": "Bearer sk-test"},
+        )
+    finally:
+        app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+    assert response.status_code == 400
+    error = response.json()["error"]
+    assert error["type"] == "invalid_request_error"
+    assert error["param"] is None
+    assert error["code"] == "400"


### PR DESCRIPTION
## TLDR

Problem this solves:

- Spend and management routes ship `"param": "None"` on errors
- `/spend/calculate` ships `"type": "None"` on top of that
- Those are four-character strings, not OpenAI error types
- `param` is typed nullable, so a string is plain wrong there

How it solves it:

- Calls the shared helpers #39536 added, no second convention
- `type` falls back to what the HTTP status stands for
- A missing `param` serializes as JSON `null`
- Covers spend tracking and all six management endpoint files
- Last of the stack: no `"None"` error payloads left anywhere

## User Flow

Before: a developer building an admin dashboard on the gateway gets errors no OpenAI SDK can classify, so every failure on the spend and management routes lands in their catch-all branch

1. They send `POST https://litellm-domain/spend/calculate` with `{}` while wiring up a cost preview
2. HTTP 400 comes back as `{"error":{"message":"Bad Request - Either 'model' or 'completion_response' must be provided","type":"None","param":"None","code":"400"}}`, so their branch on `invalid_request_error` never fires and the page shows "unknown error"
3. They send `GET https://litellm-domain/spend/logs?start_date=notadate&end_date=alsonot` after a date picker lets a typo through
4. HTTP 500 comes back with `"param":"None"`, so their handler renders "problem with field None" instead of a general failure
5. They send `GET https://litellm-domain/key/list?expires=garbage` from the keys table's filter dropdown
6. HTTP 400 comes back with `"param":"None"` again, same misleading field callout
7. They send `POST https://litellm-domain/model/delete` with `{"id":"nope"}` from a row that another admin already removed
8. HTTP 400 comes back with `"param":"None"`
9. They send `GET https://litellm-domain/team/info?team_id=nope` from a stale bookmark
10. HTTP 404 comes back with `"param":"None"`, so even a plain not-found reads as a field-level complaint

After: the same requests come back with a real OpenAI error type and a JSON null param, so the handler they already wrote classifies them

1. They send `POST https://litellm-domain/spend/calculate` with `{}` while wiring up a cost preview
2. HTTP 400 comes back as `{"error":{"message":"Bad Request - Either 'model' or 'completion_response' must be provided","type":"invalid_request_error","param":null,"code":"400"}}`, so their branch fires and the page says to fix the request
3. They send `GET https://litellm-domain/spend/logs?start_date=notadate&end_date=alsonot` after a date picker lets a typo through
4. HTTP 500 comes back with `"param":null`, so their handler reports a general failure with no field named
5. They send `GET https://litellm-domain/key/list?expires=garbage` from the keys table's filter dropdown
6. HTTP 400 comes back with `"param":null`, and the message alone tells them which values are supported
7. They send `POST https://litellm-domain/model/delete` with `{"id":"nope"}` from a row that another admin already removed
8. HTTP 400 comes back with `"param":null`
9. They send `GET https://litellm-domain/team/info?team_id=nope` from a stale bookmark
10. HTTP 404 comes back with `"param":null`, so the not-found reads as a not-found

## Relevant issues

## Linear ticket

Resolves LIT-6829

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both legs run the same proxy, two uvicorn workers each, against the same Postgres, and differ only in the commit they were booted from. `32074cf4de` is this PR's merge base (the head of #39540); `f9051a16bb` is this PR's tip.

Config used on both legs:

```yaml
model_list:
  - model_name: gpt-4o-mini
    litellm_params:
      model: openai/gpt-4o-mini
      api_key: os.environ/OPENAI_API_KEY

general_settings:
  master_key: sk-1234
  enable_jwt_auth: true
  pass_through_endpoints:
    - path: "/unreachable-upstream"
      target: "http://127.0.0.1:1/nope"
      headers:
        content-type: application/json

litellm_settings:
  drop_params: true
```

Boot on each leg (ports differ, `<port>` is 27413 before and 31877 after):

```bash
./.venv/bin/python litellm/proxy/proxy_cli.py --config lit6829_config.yaml --port <port> --num_workers 2
```

### Before (32074cf4de)

#### Pricing a request with an empty body

1. Run the request

```bash
curl -sS -X POST http://127.0.0.1:27413/spend/calculate -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{}'
```

2. Observe `type` and `param` as the string `None`

```json
{"error":{"message":"Bad Request - Either 'model' or 'completion_response' must be provided","type":"None","param":"None","code":"400"}}
```

#### Listing spend logs with an unparseable date

1. Run the request

```bash
curl -sS 'http://127.0.0.1:27413/spend/logs?start_date=notadate&end_date=alsonot' -H 'Authorization: Bearer sk-1234'
```

2. Observe `param` as the string `None`

```json
{"error":{"message":"/spend/logs Errortime data 'notadate' does not match format '%Y-%m-%d'","type":"internal_error","param":"None","code":"500"}}
```

#### Listing keys with an unsupported expires filter

1. Run the request

```bash
curl -sS 'http://127.0.0.1:27413/key/list?expires=garbage' -H 'Authorization: Bearer sk-1234'
```

2. Observe `param` as the string `None`

```json
{"error":{"message":"{'error': \"Invalid expires value. Supported: 'active', 'expired'.\"}","type":"internal_server_error","param":"None","code":"400"}}
```

#### Deleting a model that does not exist

1. Run the request

```bash
curl -sS -X POST http://127.0.0.1:27413/model/delete -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"id":"nope"}'
```

2. Observe `param` as the string `None`

```json
{"error":{"message":"{'error': 'Model with id=nope not found in db'}","type":"auth_error","param":"None","code":"400"}}
```

#### Fetching a team that does not exist

1. Run the request

```bash
curl -sS 'http://127.0.0.1:27413/team/info?team_id=nope' -H 'Authorization: Bearer sk-1234'
```

2. Observe `param` as the string `None`

```json
{"error":{"message":"{'message': 'Team not found, passed team id: nope.'}","type":"auth_error","param":"None","code":"404"}}
```

#### Control: a real chat completion still works

1. Run the request

```bash
curl -sS -X POST http://127.0.0.1:27413/v1/chat/completions -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"say ok"}]}'
```

2. Observe a real OpenAI answer

```json
{"id":"chatcmpl-EJz51xFJUHQaPC4uP8VXYnmkBfrY9","created":1788431731,"model":"gpt-4o-mini","object":"chat.completion","system_fingerprint":"fp_cdd4b75452","choices":[{"finish_reason":"stop","index":0,"message":{"content":"Ok!","role":"assistant","provider_specific_fields":{"refusal":null},"annotations":[]},"provider_specific_fields":{}}],"usage":{"completion_tokens":2,"prompt_tokens":9,"total_tokens":11,"completion_tokens_details":{"accepted_prediction_tokens":0,"audio_tokens":0,"reasoning_tokens":0,"rejected_prediction_tokens":0},"prompt_tokens_details":{"audio_tokens":0,"cached_tokens":0}},"service_tier":"default"}
```

### After (f9051a16bb)

#### Pricing a request with an empty body

1. Run the request

```bash
curl -sS -X POST http://127.0.0.1:31877/spend/calculate -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{}'
```

2. Observe a real type and a JSON null param

```json
{"error":{"message":"Bad Request - Either 'model' or 'completion_response' must be provided","type":"invalid_request_error","param":null,"code":"400"}}
```

#### Listing spend logs with an unparseable date

1. Run the request

```bash
curl -sS 'http://127.0.0.1:31877/spend/logs?start_date=notadate&end_date=alsonot' -H 'Authorization: Bearer sk-1234'
```

2. Observe a JSON null param

```json
{"error":{"message":"/spend/logs Errortime data 'notadate' does not match format '%Y-%m-%d'","type":"internal_error","param":null,"code":"500"}}
```

#### Listing keys with an unsupported expires filter

1. Run the request

```bash
curl -sS 'http://127.0.0.1:31877/key/list?expires=garbage' -H 'Authorization: Bearer sk-1234'
```

2. Observe a JSON null param

```json
{"error":{"message":"{'error': \"Invalid expires value. Supported: 'active', 'expired'.\"}","type":"internal_server_error","param":null,"code":"400"}}
```

#### Deleting a model that does not exist

1. Run the request

```bash
curl -sS -X POST http://127.0.0.1:31877/model/delete -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"id":"nope"}'
```

2. Observe a JSON null param

```json
{"error":{"message":"{'error': 'Model with id=nope not found in db'}","type":"auth_error","param":null,"code":"400"}}
```

#### Fetching a team that does not exist

1. Run the request

```bash
curl -sS 'http://127.0.0.1:31877/team/info?team_id=nope' -H 'Authorization: Bearer sk-1234'
```

2. Observe a JSON null param

```json
{"error":{"message":"{'message': 'Team not found, passed team id: nope.'}","type":"auth_error","param":null,"code":"404"}}
```

#### Control: a real chat completion still works

1. Run the request

```bash
curl -sS -X POST http://127.0.0.1:31877/v1/chat/completions -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"say ok"}]}'
```

2. Observe a real OpenAI answer

```json
{"id":"chatcmpl-EJz57u13zHkjOCfCh7arwntcubm1S","created":1788431737,"model":"gpt-4o-mini","object":"chat.completion","system_fingerprint":"fp_cdd4b75452","choices":[{"finish_reason":"stop","index":0,"message":{"content":"Ok!","role":"assistant","provider_specific_fields":{"refusal":null},"annotations":[]},"provider_specific_fields":{}}],"usage":{"completion_tokens":2,"prompt_tokens":9,"total_tokens":11,"completion_tokens_details":{"accepted_prediction_tokens":0,"audio_tokens":0,"reasoning_tokens":0,"rejected_prediction_tokens":0},"prompt_tokens_details":{"audio_tokens":0,"cached_tokens":0}},"service_tier":"default"}
```

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Stacked on #39540, so it merges after that one
- Routes pinning `auth_error` or `internal_error` keep those types
  - Those are LiteLLM's own `ProxyErrorTypes`, not OpenAI's canon
  - Rewriting them would change what clients match on today
  - Tracked in LIT-6839; only `param` changes here, which was plainly wrong
- `/global/spend/report` omits `param` and `code` entirely
- `/v1/audio/speech` answers FastAPI's `{"detail": ...}` shape instead
- Both are separate shapes, untouched here and unchanged by this PR

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

