### PR TITLE
fix(guardrails): remove the module-global translation mapping that leaked between tests

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/unified_guardrail/unified_guardrail.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/unified_guardrail/unified_guardrail.py
@@ -121,9 +121,6 @@ def _a2a_jsonrpc_error_chunk(exc: HTTPException, request_id: str | None) -> Mapp
     }
 
 
-endpoint_guardrail_translation_mappings = None
-
-
 def _ensure_litellm_metadata(data: dict, user_api_key_dict: UserAPIKeyAuth) -> None:
     """Populate data['litellm_metadata'] from user_api_key_dict if absent."""
     if "litellm_metadata" not in data:
@@ -164,7 +161,6 @@ class UnifiedLLMGuardrails(CustomLogger):
         Use this if you want to MODIFY the input
         """
 
-        global endpoint_guardrail_translation_mappings
         from litellm.proxy.common_utils.callback_utils import (
             add_guardrail_to_applied_guardrails_header,
         )
@@ -186,18 +182,15 @@ class UnifiedLLMGuardrails(CustomLogger):
             )
             return data
 
-        if endpoint_guardrail_translation_mappings is None:
-            endpoint_guardrail_translation_mappings = load_guardrail_translation_mappings()
+        mappings: Final = load_guardrail_translation_mappings()
 
         try:
-            if CallTypes(call_type) not in endpoint_guardrail_translation_mappings:
+            if CallTypes(call_type) not in mappings:
                 return data
         except ValueError:
             return data  # handle unmapped call types
 
-        endpoint_translation: Final = _as_endpoint_translation(
-            endpoint_guardrail_translation_mappings[CallTypes(call_type)]()
-        )
+        endpoint_translation: Final = _as_endpoint_translation(mappings[CallTypes(call_type)]())
 
         _ensure_litellm_metadata(data, user_api_key_dict)
 
@@ -222,8 +215,6 @@ class UnifiedLLMGuardrails(CustomLogger):
 
         This can NOT modify the input, only used to reject or accept a call before going to LLM API
         """
-        global endpoint_guardrail_translation_mappings
-
         verbose_proxy_logger.debug("Running UnifiedLLMGuardrails moderation hook")
 
         guardrail_to_apply: Final[CustomGuardrail] = data.pop("guardrail_to_apply", None)
@@ -241,14 +232,11 @@ class UnifiedLLMGuardrails(CustomLogger):
             )
             return data
 
-        if endpoint_guardrail_translation_mappings is None:
-            endpoint_guardrail_translation_mappings = load_guardrail_translation_mappings()
-        if call_type is not None and CallTypes(call_type) not in endpoint_guardrail_translation_mappings:
+        mappings: Final = load_guardrail_translation_mappings()
+        if call_type is not None and CallTypes(call_type) not in mappings:
             return data
 
-        endpoint_translation: Final = _as_endpoint_translation(
-            endpoint_guardrail_translation_mappings[CallTypes(call_type)]()
-        )
+        endpoint_translation: Final = _as_endpoint_translation(mappings[CallTypes(call_type)]())
 
         _ensure_litellm_metadata(data, user_api_key_dict)
 
@@ -271,7 +259,6 @@ class UnifiedLLMGuardrails(CustomLogger):
 
         Uses Enkrypt AI guardrails to check the response for policy violations, PII, and injection attacks
         """
-        global endpoint_guardrail_translation_mappings
         # Local import avoids a module-level cyclic import with
         # litellm.integrations.custom_guardrail.
         from litellm.integrations.custom_guardrail import ModifyResponseException
@@ -319,10 +306,9 @@ class UnifiedLLMGuardrails(CustomLogger):
             )
             return response
 
-        if endpoint_guardrail_translation_mappings is None:
-            endpoint_guardrail_translation_mappings = load_guardrail_translation_mappings()
+        mappings: Final = load_guardrail_translation_mappings()
 
-        if CallTypes(call_type) not in endpoint_guardrail_translation_mappings:
+        if CallTypes(call_type) not in mappings:
             verbose_proxy_logger.warning(
                 "Guardrail '%s' selected for route '%s' but call type '%s' has no guardrail translation handler; "
                 "skipping post-call scanning.",
@@ -332,9 +318,7 @@ class UnifiedLLMGuardrails(CustomLogger):
             )
             return response
 
-        endpoint_translation: Final = _as_endpoint_translation(
-            endpoint_guardrail_translation_mappings[CallTypes(call_type)]()
-        )
+        endpoint_translation: Final = _as_endpoint_translation(mappings[CallTypes(call_type)]())
 
         try:
             response = await endpoint_translation.process_output_response(
@@ -906,8 +890,6 @@ class UnifiedLLMGuardrails(CustomLogger):
         sampling_rate=1 means every chunk, sampling_rate=5 means every 5th chunk, etc.
         """
 
-        global endpoint_guardrail_translation_mappings
-
         # Local import avoids a module-level cyclic import with
         # litellm.integrations.custom_guardrail.
         from litellm.integrations.custom_guardrail import ModifyResponseException
@@ -978,9 +960,7 @@ class UnifiedLLMGuardrails(CustomLogger):
                 yield item
             return
 
-        # Initialize translation mappings if needed
-        if endpoint_guardrail_translation_mappings is None:
-            endpoint_guardrail_translation_mappings = load_guardrail_translation_mappings()
+        mappings: Final = load_guardrail_translation_mappings()
 
         # Streaming text transformation (incremental_diff) diverges enough from the
         # block_only path that it runs as its own iterator. It requires a route we
@@ -989,7 +969,7 @@ class UnifiedLLMGuardrails(CustomLogger):
         if streaming_transform_mode == "incremental_diff":
             transform_call_type: Final = self._resolve_transform_call_type(
                 user_api_key_dict=user_api_key_dict,
-                mappings=endpoint_guardrail_translation_mappings,
+                mappings=mappings,
             )
             if transform_call_type is not None:
                 async for transformed_item in self._run_incremental_transform_stream(
@@ -1000,7 +980,7 @@ class UnifiedLLMGuardrails(CustomLogger):
                     call_type=transform_call_type,
                     sampling_rate=sampling_rate,
                     end_of_stream_only=end_of_stream_only,
-                    mappings=endpoint_guardrail_translation_mappings,
+                    mappings=mappings,
                 ):
                     yield transformed_item
                 return
@@ -1037,7 +1017,7 @@ class UnifiedLLMGuardrails(CustomLogger):
                 call_type = _infer_call_type(call_type=None, completion_response=item)
 
             # If call type not supported, just pass through all chunks
-            if call_type is None or CallTypes(call_type) not in endpoint_guardrail_translation_mappings:
+            if call_type is None or CallTypes(call_type) not in mappings:
                 yield item
                 async for remaining_item in response:
                     yield remaining_item
@@ -1049,7 +1029,7 @@ class UnifiedLLMGuardrails(CustomLogger):
             # moderation runs below.
             if end_of_stream_only:
                 if not buffer_until_moderated:
-                    endpoint_translation = endpoint_guardrail_translation_mappings[CallTypes(call_type)]()
+                    endpoint_translation = mappings[CallTypes(call_type)]()
                     stream_has_ended = hasattr(
                         endpoint_translation, "_check_streaming_has_ended"
                     ) and endpoint_translation._check_streaming_has_ended(responses_so_far)
@@ -1063,7 +1043,7 @@ class UnifiedLLMGuardrails(CustomLogger):
 
             # Process chunk based on sampling rate
             if chunk_counter % sampling_rate == 0:
-                endpoint_translation = endpoint_guardrail_translation_mappings[CallTypes(call_type)]()
+                endpoint_translation = mappings[CallTypes(call_type)]()
                 scan_key = endpoint_translation.get_streaming_scan_key(responses_so_far)
                 if _is_redundant_scan(scan_key, last_scan_key):
                     verbose_proxy_logger.debug(
@@ -1143,14 +1123,14 @@ class UnifiedLLMGuardrails(CustomLogger):
                 yield item
 
         # Stream has ended - do final processing with all collected chunks
-        if call_type is not None and CallTypes(call_type) in endpoint_guardrail_translation_mappings:
+        if call_type is not None and CallTypes(call_type) in mappings:
             verbose_proxy_logger.debug(
                 "Processing final streaming response with all %s chunks for guardrail %s",
                 len(responses_so_far),
                 guardrail_to_apply.guardrail_name,
             )
 
-            endpoint_translation = endpoint_guardrail_translation_mappings[CallTypes(call_type)]()
+            endpoint_translation = mappings[CallTypes(call_type)]()
 
             # When buffering, snapshot the original chunks before moderation.
             # A shallow copy suffices: end-of-stream

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
@@ -5527,10 +5527,6 @@ async def test_streaming_end_of_stream_block_emits_error_frame_instead_of_trunca
     error frame instead. The finish chunk is withheld while the end-of-stream
     scan runs, so on a block it is dropped rather than relayed before the
     frame."""
-    from litellm.llms import load_guardrail_translation_mappings
-    from litellm.proxy.guardrails.guardrail_hooks.unified_guardrail import (
-        unified_guardrail as unified_module,
-    )
     from litellm.proxy.guardrails.guardrail_hooks.unified_guardrail.unified_guardrail import (
         UnifiedLLMGuardrails,
     )
@@ -5569,20 +5565,16 @@ async def test_streaming_end_of_stream_block_emits_error_frame_instead_of_trunca
         yield _chunk("the forbidden ")
         yield _chunk("topic answer", finish_reason="stop")
 
-    unified_module.endpoint_guardrail_translation_mappings = load_guardrail_translation_mappings()
-    try:
-        with patch.object(guardrail, "make_bedrock_api_request", new_callable=AsyncMock) as mock_api:
-            mock_api.side_effect = guardrail._get_http_exception_for_blocked_guardrail(blocked_response)
+    with patch.object(guardrail, "make_bedrock_api_request", new_callable=AsyncMock) as mock_api:
+        mock_api.side_effect = guardrail._get_http_exception_for_blocked_guardrail(blocked_response)
 
-            out = []
-            async for item in UnifiedLLMGuardrails().async_post_call_streaming_iterator_hook(
-                user_api_key_dict=UserAPIKeyAuth(api_key="test", request_route="/v1/chat/completions"),
-                response=_mock_stream(),
-                request_data={"guardrail_to_apply": guardrail, "model": "gpt-4"},
-            ):
-                out.append(item)
-    finally:
-        unified_module.endpoint_guardrail_translation_mappings = None
+        out = []
+        async for item in UnifiedLLMGuardrails().async_post_call_streaming_iterator_hook(
+            user_api_key_dict=UserAPIKeyAuth(api_key="test", request_route="/v1/chat/completions"),
+            response=_mock_stream(),
+            request_data={"guardrail_to_apply": guardrail, "model": "gpt-4"},
+        ):
+            out.append(item)
 
     assert len(out) == 2
     assert isinstance(out[0], ModelResponseStream)

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/unified_guardrails/test_unified_guardrail.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/unified_guardrails/test_unified_guardrail.py
@@ -75,19 +75,29 @@ class _NoopTranslation(BaseTranslation):
         return response
 
 
+def _patch_translation_mappings(monkeypatch, mappings):
+    """Point the unified guardrail at ``mappings`` for one test, restored by pytest.
+
+    Every override goes through this one seam: competing writers to the same state
+    are what leaked a stale handler map into unrelated test files (LIT-6834).
+    """
+    monkeypatch.setattr(unified_module, "load_guardrail_translation_mappings", lambda: mappings)
+
+
 @pytest.fixture(autouse=True)
-def _inject_mcp_handler_mapping():
+def _inject_mcp_handler_mapping(monkeypatch):
     """Inject MCP handler mapping so the unified guardrail can run inside tests."""
-    unified_module.endpoint_guardrail_translation_mappings = {
-        CallTypes.call_mcp_tool: MCPGuardrailTranslationHandler,
-        CallTypes.anthropic_messages: _NoopTranslation,
-        CallTypes.ocr: OCRHandler,
-        CallTypes.aocr: OCRHandler,
-        CallTypes.responses: OpenAIResponsesHandler,
-        CallTypes.aresponses: OpenAIResponsesHandler,
-    }
-    yield
-    unified_module.endpoint_guardrail_translation_mappings = None
+    _patch_translation_mappings(
+        monkeypatch,
+        {
+            CallTypes.call_mcp_tool: MCPGuardrailTranslationHandler,
+            CallTypes.anthropic_messages: _NoopTranslation,
+            CallTypes.ocr: OCRHandler,
+            CallTypes.aocr: OCRHandler,
+            CallTypes.responses: OpenAIResponsesHandler,
+            CallTypes.aresponses: OpenAIResponsesHandler,
+        },
+    )
 
 
 class TestUnifiedLLMGuardrails:
@@ -396,7 +406,7 @@ class TestUnifiedLLMGuardrails:
 
     class TestAsyncPostCallStreamingIteratorHook:
         @pytest.mark.asyncio
-        async def test_streaming_content_not_lost_on_sampled_chunks(self):
+        async def test_streaming_content_not_lost_on_sampled_chunks(self, monkeypatch):
             """
             Verify that every chunk's content is preserved in the output stream.
 
@@ -442,10 +452,7 @@ class TestUnifiedLLMGuardrails:
 
                     return responses_so_far
 
-            # Override the mapping to use our content-clearing translation
-            unified_module.endpoint_guardrail_translation_mappings = {
-                CallTypes.acompletion: _ContentClearingTranslation,
-            }
+            _patch_translation_mappings(monkeypatch, {CallTypes.acompletion: _ContentClearingTranslation})
 
             handler = UnifiedLLMGuardrails()
             guardrail = RecordingGuardrail()
@@ -885,12 +892,8 @@ class TestStreamingTransform:
     completions streaming surface."""
 
     @pytest.fixture(autouse=True)
-    def _use_openai_handler_mapping(self):
-        unified_module.endpoint_guardrail_translation_mappings = {
-            CallTypes.acompletion: OpenAIChatCompletionsHandler,
-        }
-        yield
-        unified_module.endpoint_guardrail_translation_mappings = None
+    def _use_openai_handler_mapping(self, monkeypatch):
+        _patch_translation_mappings(monkeypatch, {CallTypes.acompletion: OpenAIChatCompletionsHandler})
 
     @pytest.mark.asyncio
     async def test_block_only_drops_text_rewrites(self):
@@ -1719,6 +1722,10 @@ class TestAppliedGuardrailsReflectsExecution:
     decision and marks itself only when it actually ran (LIT-4650). Ordinary
     guardrails are still auto-marked by the hook after dispatch."""
 
+    @pytest.fixture(autouse=True)
+    def _use_texts_only_mapping(self, monkeypatch):
+        _patch_translation_mappings(monkeypatch, {CallTypes.pass_through: _TextsOnlyTranslation})
+
     @staticmethod
     def _data(guardrail):
         return {
@@ -1728,7 +1735,6 @@ class TestAppliedGuardrailsReflectsExecution:
         }
 
     async def _run(self, guardrail):
-        unified_module.endpoint_guardrail_translation_mappings = {CallTypes.pass_through: _TextsOnlyTranslation}
         data = self._data(guardrail)
         await UnifiedLLMGuardrails().async_pre_call_hook(
             user_api_key_dict=None,
@@ -1830,10 +1836,8 @@ class TestStreamingHttpErrorFrames:
     silently truncates the SSE stream (PR #38722 defect 1)."""
 
     @pytest.fixture(autouse=True)
-    def _use_real_mappings(self):
-        unified_module.endpoint_guardrail_translation_mappings = load_guardrail_translation_mappings()
-        yield
-        unified_module.endpoint_guardrail_translation_mappings = None
+    def _use_real_mappings(self, monkeypatch):
+        _patch_translation_mappings(monkeypatch, load_guardrail_translation_mappings())
 
     @pytest.mark.asyncio
     async def test_chat_eos_block_emits_data_error_frame(self):
@@ -1938,10 +1942,8 @@ class TestStreamingGuardrailInformationBucket:
     guardrail_information write was diverted and /spend/logs showed null."""
 
     @pytest.fixture(autouse=True)
-    def _use_real_mappings(self):
-        unified_module.endpoint_guardrail_translation_mappings = load_guardrail_translation_mappings()
-        yield
-        unified_module.endpoint_guardrail_translation_mappings = None
+    def _use_real_mappings(self, monkeypatch):
+        _patch_translation_mappings(monkeypatch, load_guardrail_translation_mappings())
 
     @pytest.mark.asyncio
     async def test_chat_eos_scan_writes_guardrail_information_to_metadata(self):
@@ -2038,11 +2040,7 @@ class TestStreamingScanDedup:
 
     @pytest.fixture(autouse=True)
     def _use_real_mappings(self, monkeypatch):
-        monkeypatch.setattr(
-            unified_module,
-            "endpoint_guardrail_translation_mappings",
-            load_guardrail_translation_mappings(),
-        )
+        _patch_translation_mappings(monkeypatch, load_guardrail_translation_mappings())
 
     @pytest.mark.asyncio
     async def test_chat_terminal_chunk_on_sampled_index_is_scanned_once(self):

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/unified_guardrails/test_unified_guardrail.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/unified_guardrails/test_unified_guardrail.py
@@ -2237,3 +2237,55 @@ class TestStreamingScanDedup:
 
         assert out == chunks
         assert [scan["texts"] for scan in guardrail.scans] == [["abc"]]
+
+
+class TestTranslationMappingsAreReadLive:
+    """The hooks must read the handler map on every call, never memoize it on the module.
+
+    A second module-level cache is what let one test's handler map outlive its own
+    teardown and decide how unrelated files translated their streams (LIT-6834).
+    """
+
+    @staticmethod
+    def _ocr_request(guardrail):
+        return {
+            "guardrail_to_apply": guardrail,
+            "model": "mistral/mistral-ocr-latest",
+            "document": {
+                "type": "document_url",
+                "document_url": "https://arxiv.org/pdf/2201.04234",
+            },
+        }
+
+    async def _run_pre_call(self, guardrail):
+        await UnifiedLLMGuardrails().async_pre_call_hook(
+            user_api_key_dict=UserAPIKeyAuth(api_key="test-key"),
+            cache=DualCache(),
+            data=self._ocr_request(guardrail),
+            call_type=CallTypes.aocr.value,
+        )
+
+    @pytest.mark.asyncio
+    async def test_remapping_between_calls_changes_which_handler_runs(self, monkeypatch):
+        _patch_translation_mappings(monkeypatch, {CallTypes.completion: _NoopTranslation})
+        unmapped = RecordingGuardrail()
+        await self._run_pre_call(unmapped)
+        assert unmapped.apply_calls == []
+
+        _patch_translation_mappings(monkeypatch, {CallTypes.aocr: OCRHandler})
+        mapped = RecordingGuardrail()
+        await self._run_pre_call(mapped)
+        assert [call["input_type"] for call in mapped.apply_calls] == ["request"]
+
+    @pytest.mark.asyncio
+    async def test_module_exposes_no_second_assignable_handler_map(self, monkeypatch):
+        _patch_translation_mappings(monkeypatch, {CallTypes.aocr: OCRHandler})
+        guardrail = RecordingGuardrail()
+        await self._run_pre_call(guardrail)
+
+        assert len(guardrail.apply_calls) == 1
+        assert not [
+            name
+            for name, value in vars(unified_module).items()
+            if isinstance(value, dict) and CallTypes.aocr in value
+        ]

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_passthrough_post_call_guardrails.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_passthrough_post_call_guardrails.py
@@ -292,8 +292,8 @@ class TestUnifiedGuardrailCallTypeResolution:
 
         with patch.object(
             unified_guardrail_module,
-            "endpoint_guardrail_translation_mappings",
-            {CallTypes.pass_through: mock_handler_class},
+            "load_guardrail_translation_mappings",
+            lambda: {CallTypes.pass_through: mock_handler_class},
         ):
             result = await unified.async_post_call_success_hook(
                 data=data,

--- a/tests/test_litellm/proxy/test_blocked_response_usage.py
+++ b/tests/test_litellm/proxy/test_blocked_response_usage.py
@@ -68,12 +68,10 @@ async def test_success_hook_attaches_original_response_on_block():
     user_api_key_dict = UserAPIKeyAuth(api_key="test", request_route="/chat/completions")
     data = {"guardrail_to_apply": guardrail, "model": "gpt-4o"}
 
-    # Inject our translation for the inferred call type (the module global is
-    # cached across tests, so patch it directly rather than the loader).
     with patch.object(
         ug,
-        "endpoint_guardrail_translation_mappings",
-        {
+        "load_guardrail_translation_mappings",
+        lambda: {
             CallTypes.acompletion: lambda: translation,
             CallTypes.completion: lambda: translation,
         },


### PR DESCRIPTION
## TLDR

Problem this solves:

- `proxy-endpoints / Run tests` goes red at random on guardrail streaming tests
- A plain rerun of the same commit passes, so the red means nothing
- The guardrail translation mappings lived in a second, writable module global
- Tests assigned to it directly, and one teardown restored an already-stale value
- The stale test double then survived into every later test on that xdist worker

How it solves it:

- Deleted that duplicate global; the loader in `litellm/llms` keeps the only cache
- Each call site now reads the loader into a local
- Tests get one seam to patch, so pytest owns every restore
- A regression test goes red the moment a second cache comes back

## User Flow

Before: an engineer's PR goes red on a guardrail streaming test that has nothing to do with their change, and a rerun of the same commit turns it green.

1. They push a commit touching nothing near the guardrails code and open a PR
2. They open the run at `https://github.com/BerriAI/litellm/actions/runs/<run id>` and see `proxy-endpoints / Run tests` red
3. The log names a failing test such as `test_mid_stream_block_emits_clean_anthropic_sse`, with `AssertionError: block message missing from stream`
4. They read their own diff, find nothing that touches streaming or guardrails, and press Re-run failed jobs
5. The same commit now passes, so they merge and learn to treat that job's red as noise

After: the same PR gets the same answer from that job on every run, so a red is worth reading.

1. They push a commit touching nothing near the guardrails code and open a PR
2. They open the run at `https://github.com/BerriAI/litellm/actions/runs/<run id>` and see `proxy-endpoints / Run tests` green
3. There is nothing to re-run, and a future red in that job points at a real failure

## Relevant issues

## Linear ticket

Resolves LIT-6834

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The symptom is a CI job, so the proof is that job's own tests: the ordering that turned it red now stays green, run locally with the exact same command on both sides, and the `proxy-endpoints` shard's real xdist settings on top of it.

Shared setup, run from a worktree at each hash:

```
make bootstrap
uv pip install --python .venv/bin/python detect-secrets   # CI installs this via --group ci
```

`$U` and `$A` below are the two files involved:

```
U=tests/test_litellm/proxy/guardrails/guardrail_hooks/unified_guardrails/test_unified_guardrail.py
A=tests/test_litellm/proxy/guardrails/guardrail_hooks/unified_guardrails/test_anthropic_streaming_block.py
```

### Before (658f50663d)

#### Case 1: one poisoning test, then one victim

1. Run the pair in that order:

```
.venv/bin/python -m pytest \
  "$U::TestStreamingScanDedup::test_chat_terminal_chunk_on_sampled_index_is_scanned_once" \
  "$A::test_mid_stream_block_emits_clean_anthropic_sse" \
  -q --no-header -p no:cacheprovider --tb=line -rf
```

2. The victim fails. The block never reaches the stream:

```
E   AssertionError: block message missing from stream: 'event: message_start\ndata: {...}\n\n
    ... event: content_block_delta\ndata: {"type": "content_block_delta", "index": 0,
    "delta": {"type": "text_delta", "text": "answer."}}\n\n'
    assert 'Blocked by policy: this response was withheld.' in '...'

FAILED tests/test_litellm/proxy/guardrails/guardrail_hooks/unified_guardrails/test_anthropic_streaming_block.py::test_mid_stream_block_emits_clean_anthropic_sse
1 failed, 1 passed, 1 warning in 2.47s
```

#### Case 2: the victim alone (control)

1. Run only the victim:

```
.venv/bin/python -m pytest "$A::test_mid_stream_block_emits_clean_anthropic_sse" \
  -q --no-header -p no:cacheprovider --tb=line -rf
```

2. It passes, so the test itself is fine:

```
1 passed, 1 warning in 2.26s
```

#### Case 3: the whole poisoning class, then the whole victim file

1. Run both in that order:

```
.venv/bin/python -m pytest "$U::TestStreamingScanDedup" "$A" \
  -q --no-header -p no:cacheprovider --tb=line -rf
```

2. Four of the file's tests fail:

```
FAILED .../test_anthropic_streaming_block.py::test_end_of_stream_block_emits_clean_anthropic_sse
FAILED .../test_anthropic_streaming_block.py::test_end_of_stream_only_block_does_not_append_after_message_stop
FAILED .../test_anthropic_streaming_block.py::test_mid_stream_block_after_prior_chunks_continues_message
FAILED .../test_anthropic_streaming_block.py::test_mid_stream_block_emits_clean_anthropic_sse
4 failed, 18 passed, 1 warning in 5.28s
```

#### Case 4: the guardrails tree under the shard's real xdist settings, three times

1. Run it the way `proxy-endpoints` does (`-n 4 --dist=loadscope --reruns 2`):

```
for i in 1 2 3; do
  .venv/bin/python -m pytest tests/test_litellm/proxy/guardrails \
    -q --no-header -p no:cacheprovider -n 4 --dist=loadscope --reruns 2 --reruns-delay 1 --tb=line -rf
done
```

2. One of the three goes red, on a different file than case 1 picked, and the reruns do not save it:

```
run 1: 3210 passed, 1 xfailed, 14 warnings in 15.35s
run 2: FAILED .../test_generic_guardrail_api.py::TestGenericGuardrailAPIStreamingViaUnified::test_streaming_blocked_content_raises
       FAILED .../test_generic_guardrail_api.py::TestGenericGuardrailAPIStreamingViaUnified::test_streaming_default_uses_sampled_cadence
       FAILED .../test_generic_guardrail_api.py::TestGenericGuardrailAPIStreamingViaUnified::test_streaming_end_of_stream_only_calls_guardrail_once
       FAILED .../test_generic_guardrail_api.py::TestGenericGuardrailAPIStreamingViaUnified::test_streaming_safe_content_yields_all_chunks
       FAILED .../test_generic_guardrail_api.py::TestGenericGuardrailAPIStreamingViaUnified::test_streaming_sampling_rate_override
       5 failed, 3205 passed, 1 xfailed, 15 warnings, 10 rerun in 23.13s
run 3: 3210 passed, 1 xfailed, 14 warnings in 17.17s
```

### After (e33f6911e3)

#### Case 1: one poisoning test, then one victim

1. Same command:

```
.venv/bin/python -m pytest \
  "$U::TestStreamingScanDedup::test_chat_terminal_chunk_on_sampled_index_is_scanned_once" \
  "$A::test_mid_stream_block_emits_clean_anthropic_sse" \
  -q --no-header -p no:cacheprovider --tb=line -rf
```

2. Both pass:

```
2 passed, 1 warning in 2.95s
```

#### Case 2: the victim alone (control)

1. Same command:

```
.venv/bin/python -m pytest "$A::test_mid_stream_block_emits_clean_anthropic_sse" \
  -q --no-header -p no:cacheprovider --tb=line -rf
```

2. Still passes:

```
1 passed, 1 warning in 6.02s
```

#### Case 3: the whole poisoning class, then the whole victim file

1. Same command:

```
.venv/bin/python -m pytest "$U::TestStreamingScanDedup" "$A" \
  -q --no-header -p no:cacheprovider --tb=line -rf
```

2. Nothing fails:

```
22 passed, 1 warning in 4.99s
```

#### Case 4: the guardrails tree under the shard's real xdist settings, three times

1. Same command:

```
for i in 1 2 3; do
  .venv/bin/python -m pytest tests/test_litellm/proxy/guardrails \
    -q --no-header -p no:cacheprovider -n 4 --dist=loadscope --reruns 2 --reruns-delay 1 --tb=line -rf
done
```

2. All three are clean, with no reruns spent:

```
run 1: 3212 passed, 1 xfailed, 13 warnings in 17.96s
run 2: 3212 passed, 1 xfailed, 14 warnings in 19.26s
run 3: 3212 passed, 1 xfailed, 14 warnings in 27.60s
```

#### Case 5: the whole proxy-endpoints shard, twice

1. Run all 31 paths the shard runs, with its workers and reruns:

```
PATHS=$(python3 -c "import yaml,sys; w=yaml.safe_load(open('.github/workflows/test-unit.yml')); \
  print([e for e in w['jobs']['unit']['strategy']['matrix']['include'] if e['shard']=='proxy-endpoints'][0]['test-path'])")
.venv/bin/python -m pytest ${=PATHS} \
  -q --no-header -p no:cacheprovider -n 4 --dist=loadscope --reruns 2 --reruns-delay 1 --maxfail=10 --tb=line -rf
```

2. No guardrail streaming failures in either run. What is left is one local-environment failure, covered under Caveats:

```
run 1: FAILED .../ui_crud_endpoints/test_proxy_setting_endpoints.py::TestProxySettingEndpoints::test_get_sso_settings_empty_database
       1 failed, 8937 passed, 3 skipped, 1 xfailed, 152 warnings, 2 rerun in 56.62s
run 2: FAILED .../ui_crud_endpoints/test_proxy_setting_endpoints.py::TestProxySettingEndpoints::test_get_sso_settings_empty_database
       1 failed, 8937 passed, 3 skipped, 1 xfailed, 150 warnings, 2 rerun in 92.03s
```

#### Case 6: the regression test, checked against the bug coming back

1. Put the deleted module global back on top of the fix, run the new tests, then undo it:

```
python3 - <<'EOF'
from pathlib import Path
p = Path("litellm/proxy/guardrails/guardrail_hooks/unified_guardrail/unified_guardrail.py")
src = p.read_text()
src = src.replace(
    "        mappings: Final = load_guardrail_translation_mappings()",
    "        global endpoint_guardrail_translation_mappings\n"
    "        if endpoint_guardrail_translation_mappings is None:\n"
    "            endpoint_guardrail_translation_mappings = load_guardrail_translation_mappings()\n"
    "        mappings = endpoint_guardrail_translation_mappings",
)
anchor = "from litellm.llms import load_guardrail_translation_mappings"
p.write_text(src.replace(anchor, anchor + "\n\nendpoint_guardrail_translation_mappings = None", 1))
EOF

.venv/bin/python -m pytest "$U::TestTranslationMappingsAreReadLive" \
  -q --no-header -p no:cacheprovider --tb=line -rf
git checkout -- litellm/proxy/guardrails/guardrail_hooks/unified_guardrail/unified_guardrail.py
```

2. Both go red, so the fix cannot be undone without the suite saying so:

```
FAILED .../test_unified_guardrail.py::TestTranslationMappingsAreReadLive::test_module_exposes_no_second_assignable_handler_map
FAILED .../test_unified_guardrail.py::TestTranslationMappingsAreReadLive::test_remapping_between_calls_changes_which_handler_runs
2 failed, 1 warning in 3.24s
```

3. Without the global, the same two pass:

```
2 passed, 1 warning in 5.46s
```

Notes from the run, things a reviewer cannot see from the diff:

- The test double leaked across files, not just classes
- `conftest.py` re-sorts every test by bare function name globally
- That sort destroys file locality, which is what makes it random
- A second, unrelated order dependence exists in the spend queue
- Only one of the four guardrail test files ever gets blamed per run

## Type

🐛 Bug Fix
✅ Test

## Caveats (if any)

### Low

- There is no live before/after proxy run here, because there is nothing for a user to observe
  - The loader in `litellm/llms` already cached the mappings, so the deleted global only ever held a copy
  - A base-vs-head run over 12 guardrail scenarios (pre_call, during_call, post_call, three streaming modes, `/v1/messages`, `/v1/responses`) came back identical on status and body
  - All 34 guardrail calls it made were identical in signature on both sides
  - The job's own tests are the observable, and Cases 1 to 6 above are the before/after
- A second order dependence remains in the same job, tracked as LIT-6838
  - `test_monitor_spend_logs_queue_flushes_as_soon_as_one_is_requested` fails about 1 run in 6
  - Same job, same shape, different cause: an event bound at import time
  - Nothing to do with guardrails, so folding it in would cost this PR its one-problem scope
- `test_get_sso_settings_empty_database` fails only with a real Google client id in the local `.env`
  - CI has no such value, and `proxy-endpoints / Run tests` is green on this branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor removes duplicate caching only; handler resolution still goes through the existing `litellm.llms` loader with no intended behavior change for live proxy traffic.
> 
> **Overview**
> Fixes **flaky `proxy-endpoints` guardrail tests** (LIT-6834) by removing a second, writable module-level cache of guardrail translation handlers on `unified_guardrail.py`.
> 
> **Production behavior:** Pre-call, moderation, post-call, and streaming hooks now call `load_guardrail_translation_mappings()` into a local `mappings` on every invocation instead of memoizing on the unified module. Runtime routing is unchanged because `litellm.llms` already owns the real cache.
> 
> **Tests:** Suites stop assigning `endpoint_guardrail_translation_mappings` on the unified module (which could leak stale handler maps across pytest-xdist workers). They patch `load_guardrail_translation_mappings` via a shared `_patch_translation_mappings` helper, and **`TestTranslationMappingsAreReadLive`** asserts remapping between calls works and no second assignable handler dict exists on the module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e33f6911e3e23c268dcad2b15655c889a43eaa51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->