### PR TITLE
fix(agents): keep the published agent in public_agent_groups

### DIFF
--- a/litellm/proxy/agent_endpoints/endpoints.py
+++ b/litellm/proxy/agent_endpoints/endpoints.py
@@ -939,35 +939,34 @@ async def make_agent_public(
             if agent is None:
                 raise HTTPException(status_code=404, detail=f"Agent with ID {agent_id} not found")
 
-        if litellm.public_agent_groups is None:
-            litellm.public_agent_groups = []
-        # handle duplicates
-        if not AGENT_REGISTRY.ids_for_agent(agent.agent_id).isdisjoint(litellm.public_agent_groups):
+        # get_config() re-applies the DB's litellm_settings over the in-memory
+        # globals, so read it before deriving the new list and assign the global after
+        config: Final = await proxy_config.get_config()
+
+        current_public_agent_groups: Final = list(litellm.public_agent_groups or [])
+        if not AGENT_REGISTRY.ids_for_agent(agent.agent_id).isdisjoint(current_public_agent_groups):
             raise HTTPException(
                 status_code=400,
                 detail=f"Agent with name {agent.agent_name} already in public agent groups",
             )
-        litellm.public_agent_groups.append(agent.agent_id)
+        updated_public_agent_groups: Final = [*current_public_agent_groups, agent.agent_id]
 
-        # Load existing config
-        config: Final = await proxy_config.get_config()
-
-        # Update config with new settings
         if "litellm_settings" not in config or config["litellm_settings"] is None:
             config["litellm_settings"] = {}
 
-        config["litellm_settings"]["public_agent_groups"] = litellm.public_agent_groups
+        config["litellm_settings"]["public_agent_groups"] = updated_public_agent_groups
 
-        # Save the updated config
         await proxy_config.save_config(new_config=config)
 
+        litellm.public_agent_groups = updated_public_agent_groups
+
         verbose_proxy_logger.debug(
-            "Updated public agent groups to: %s by user: %s", litellm.public_agent_groups, user_api_key_dict.user_id
+            "Updated public agent groups to: %s by user: %s", updated_public_agent_groups, user_api_key_dict.user_id
         )
 
         return {
             "message": "Successfully updated public agent groups",
-            "public_agent_groups": litellm.public_agent_groups,
+            "public_agent_groups": updated_public_agent_groups,
             "updated_by": user_api_key_dict.user_id,
         }
     except HTTPException:

--- a/litellm/proxy/agent_endpoints/endpoints.py
+++ b/litellm/proxy/agent_endpoints/endpoints.py
@@ -939,8 +939,6 @@ async def make_agent_public(
             if agent is None:
                 raise HTTPException(status_code=404, detail=f"Agent with ID {agent_id} not found")
 
-        # get_config() re-applies the DB's litellm_settings over the in-memory
-        # globals, so read it before deriving the new list and assign the global after
         config: Final = await proxy_config.get_config()
 
         current_public_agent_groups: Final = list(litellm.public_agent_groups or [])

--- a/tests/e2e/ui/tests/modelHub/modelHub.spec.ts
+++ b/tests/e2e/ui/tests/modelHub/modelHub.spec.ts
@@ -22,8 +22,7 @@ test.describe("AI Hub (internal admin view)", () => {
     // on the disabled-Next button or the success toast.
     await expect(modal.getByText(/Select All \(\d+\)/)).toBeVisible({ timeout: 5_000 });
 
-    // Step 1: pick the seeded models via "Select All". check() rather than click() because
-    // the modal preselects groups that are already public, and a click would clear them.
+    // Step 1: pick the seeded models via "Select All"
     await modal.getByRole("checkbox", { name: /Select All/ }).check();
 
     // Move to confirm step

--- a/tests/e2e/ui/tests/modelHub/modelHub.spec.ts
+++ b/tests/e2e/ui/tests/modelHub/modelHub.spec.ts
@@ -22,11 +22,14 @@ test.describe("AI Hub (internal admin view)", () => {
     // on the disabled-Next button or the success toast.
     await expect(modal.getByText(/Select All \(\d+\)/)).toBeVisible({ timeout: 5_000 });
 
-    // Step 1: pick the seeded models via "Select All"
-    await modal.getByText(/Select All/i).click();
+    // Step 1: pick the seeded models via "Select All". check() rather than click() because
+    // the modal preselects groups that are already public, and a click would clear them.
+    await modal.getByRole("checkbox", { name: /Select All/ }).check();
 
     // Move to confirm step
-    await modal.getByRole("button", { name: "Next" }).click();
+    const next = modal.getByRole("button", { name: "Next" });
+    await expect(next).toBeEnabled();
+    await next.click();
     await expect(modal.getByText("Confirm Making Models Public")).toBeVisible({ timeout: 5_000 });
 
     // Submit

--- a/tests/test_litellm/proxy/agent_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/agent_endpoints/test_endpoints.py
@@ -1062,3 +1062,72 @@ def test_merged_agent_card_url_has_no_double_slash_without_proxy_base_url(
     interface_url = merged["supportedInterfaces"][0]["url"]
     assert interface_url == f"{base_url.rstrip('/')}/a2a/agent-xyz"
     assert "//a2a" not in interface_url
+
+
+class _DbBackedProxyConfig:
+    """Round-trips `litellm_settings` through the DB overlay the proxy applies on every
+    `get_config()`, which is what re-assigns the `litellm.public_*` globals in production."""
+
+    def __init__(self) -> None:
+        self.stored_litellm_settings: dict = {}
+
+    async def get_config(self) -> dict:
+        from litellm.proxy.proxy_server import ProxyConfig
+
+        config: dict = {"litellm_settings": {}}
+        if not self.stored_litellm_settings:
+            return config
+        return ProxyConfig()._update_config_fields(
+            current_config=config,
+            param_name="litellm_settings",
+            db_param_value=dict(self.stored_litellm_settings),
+        )
+
+    async def save_config(self, new_config: dict) -> None:
+        self.stored_litellm_settings = dict(new_config.get("litellm_settings") or {})
+
+
+def test_make_agent_public_twice_keeps_both_agents_public(monkeypatch):
+    """A second /make_public call must not drop the agent published by the first one."""
+    import litellm
+    from litellm.proxy.agent_endpoints import agent_registry as agent_registry_module
+    from litellm.proxy.agent_endpoints.agent_registry import AgentRegistry
+
+    registry = AgentRegistry()
+    registry.register_agent(_sample_agent_response(agent_id="agent-1", agent_name="Agent One"))
+    registry.register_agent(_sample_agent_response(agent_id="agent-2", agent_name="Agent Two"))
+
+    monkeypatch.setattr(agent_registry_module, "global_agent_registry", registry)
+    monkeypatch.setattr(litellm, "public_agent_groups", None)
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", MagicMock())
+    monkeypatch.setattr("litellm.proxy.proxy_server.proxy_config", _DbBackedProxyConfig())
+
+    first = client.post("/v1/agents/agent-1/make_public", headers={"Authorization": "Bearer test-key"})
+    second = client.post("/v1/agents/agent-2/make_public", headers={"Authorization": "Bearer test-key"})
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert second.json()["public_agent_groups"] == ["agent-1", "agent-2"]
+    assert [agent.agent_id for agent in registry.get_public_agent_list()] == ["agent-1", "agent-2"]
+
+
+def test_make_agent_public_rejects_an_already_public_agent(monkeypatch):
+    """The duplicate guard must still fire when the published list comes back from the DB."""
+    import litellm
+    from litellm.proxy.agent_endpoints import agent_registry as agent_registry_module
+    from litellm.proxy.agent_endpoints.agent_registry import AgentRegistry
+
+    registry = AgentRegistry()
+    registry.register_agent(_sample_agent_response(agent_id="agent-1", agent_name="Agent One"))
+
+    monkeypatch.setattr(agent_registry_module, "global_agent_registry", registry)
+    monkeypatch.setattr(litellm, "public_agent_groups", None)
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", MagicMock())
+    monkeypatch.setattr("litellm.proxy.proxy_server.proxy_config", _DbBackedProxyConfig())
+
+    first = client.post("/v1/agents/agent-1/make_public", headers={"Authorization": "Bearer test-key"})
+    duplicate = client.post("/v1/agents/agent-1/make_public", headers={"Authorization": "Bearer test-key"})
+
+    assert first.status_code == 200
+    assert duplicate.status_code == 400
+    assert "already in public agent groups" in duplicate.json()["detail"]

--- a/tests/test_litellm/proxy/agent_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/agent_endpoints/test_endpoints.py
@@ -1,3 +1,4 @@
+from typing import Final
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -1069,12 +1070,12 @@ class _DbBackedProxyConfig:
     `get_config()`, which is what re-assigns the `litellm.public_*` globals in production."""
 
     def __init__(self) -> None:
-        self.stored_litellm_settings: dict = {}
+        self.stored_litellm_settings: dict[str, object] = {}
 
-    async def get_config(self) -> dict:
+    async def get_config(self) -> dict[str, dict[str, object]]:
         from litellm.proxy.proxy_server import ProxyConfig
 
-        config: dict = {"litellm_settings": {}}
+        config: Final[dict[str, dict[str, object]]] = {"litellm_settings": {}}
         if not self.stored_litellm_settings:
             return config
         return ProxyConfig()._update_config_fields(
@@ -1083,17 +1084,17 @@ class _DbBackedProxyConfig:
             db_param_value=dict(self.stored_litellm_settings),
         )
 
-    async def save_config(self, new_config: dict) -> None:
+    async def save_config(self, new_config: dict[str, dict[str, object]]) -> None:
         self.stored_litellm_settings = dict(new_config.get("litellm_settings") or {})
 
 
-def test_make_agent_public_twice_keeps_both_agents_public(monkeypatch):
+def test_make_agent_public_twice_keeps_both_agents_public(monkeypatch: pytest.MonkeyPatch) -> None:
     """A second /make_public call must not drop the agent published by the first one."""
     import litellm
     from litellm.proxy.agent_endpoints import agent_registry as agent_registry_module
     from litellm.proxy.agent_endpoints.agent_registry import AgentRegistry
 
-    registry = AgentRegistry()
+    registry: Final = AgentRegistry()
     registry.register_agent(_sample_agent_response(agent_id="agent-1", agent_name="Agent One"))
     registry.register_agent(_sample_agent_response(agent_id="agent-2", agent_name="Agent Two"))
 
@@ -1102,8 +1103,8 @@ def test_make_agent_public_twice_keeps_both_agents_public(monkeypatch):
     monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", MagicMock())
     monkeypatch.setattr("litellm.proxy.proxy_server.proxy_config", _DbBackedProxyConfig())
 
-    first = client.post("/v1/agents/agent-1/make_public", headers={"Authorization": "Bearer test-key"})
-    second = client.post("/v1/agents/agent-2/make_public", headers={"Authorization": "Bearer test-key"})
+    first: Final = client.post("/v1/agents/agent-1/make_public", headers={"Authorization": "Bearer test-key"})
+    second: Final = client.post("/v1/agents/agent-2/make_public", headers={"Authorization": "Bearer test-key"})
 
     assert first.status_code == 200
     assert second.status_code == 200
@@ -1111,13 +1112,13 @@ def test_make_agent_public_twice_keeps_both_agents_public(monkeypatch):
     assert [agent.agent_id for agent in registry.get_public_agent_list()] == ["agent-1", "agent-2"]
 
 
-def test_make_agent_public_rejects_an_already_public_agent(monkeypatch):
+def test_make_agent_public_rejects_an_already_public_agent(monkeypatch: pytest.MonkeyPatch) -> None:
     """The duplicate guard must still fire when the published list comes back from the DB."""
     import litellm
     from litellm.proxy.agent_endpoints import agent_registry as agent_registry_module
     from litellm.proxy.agent_endpoints.agent_registry import AgentRegistry
 
-    registry = AgentRegistry()
+    registry: Final = AgentRegistry()
     registry.register_agent(_sample_agent_response(agent_id="agent-1", agent_name="Agent One"))
 
     monkeypatch.setattr(agent_registry_module, "global_agent_registry", registry)
@@ -1125,8 +1126,8 @@ def test_make_agent_public_rejects_an_already_public_agent(monkeypatch):
     monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", MagicMock())
     monkeypatch.setattr("litellm.proxy.proxy_server.proxy_config", _DbBackedProxyConfig())
 
-    first = client.post("/v1/agents/agent-1/make_public", headers={"Authorization": "Bearer test-key"})
-    duplicate = client.post("/v1/agents/agent-1/make_public", headers={"Authorization": "Bearer test-key"})
+    first: Final = client.post("/v1/agents/agent-1/make_public", headers={"Authorization": "Bearer test-key"})
+    duplicate: Final = client.post("/v1/agents/agent-1/make_public", headers={"Authorization": "Bearer test-key"})
 
     assert first.status_code == 200
     assert duplicate.status_code == 400

--- a/tests/test_litellm/proxy/agent_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/agent_endpoints/test_endpoints.py
@@ -1,3 +1,4 @@
+import json
 from typing import Final
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -1067,25 +1068,29 @@ def test_merged_agent_card_url_has_no_double_slash_without_proxy_base_url(
 
 class _DbBackedProxyConfig:
     """Round-trips `litellm_settings` through the DB overlay the proxy applies on every
-    `get_config()`, which is what re-assigns the `litellm.public_*` globals in production."""
+    `get_config()`, which is what re-assigns the `litellm.public_*` globals in production.
 
-    def __init__(self) -> None:
-        self.stored_litellm_settings: dict[str, object] = {}
+    Storage goes through JSON the way the `litellm_config` row does, so every read hands back
+    freshly built values instead of the objects the endpoint still holds a reference to."""
+
+    def __init__(self, stored_litellm_settings: dict[str, object] | None = None) -> None:
+        self.stored_litellm_settings_json: str = json.dumps(stored_litellm_settings or {})
 
     async def get_config(self) -> dict[str, dict[str, object]]:
         from litellm.proxy.proxy_server import ProxyConfig
 
         config: Final[dict[str, dict[str, object]]] = {"litellm_settings": {}}
-        if not self.stored_litellm_settings:
+        db_param_value: Final[dict[str, object]] = json.loads(self.stored_litellm_settings_json)
+        if not db_param_value:
             return config
         return ProxyConfig()._update_config_fields(
             current_config=config,
             param_name="litellm_settings",
-            db_param_value=dict(self.stored_litellm_settings),
+            db_param_value=db_param_value,
         )
 
     async def save_config(self, new_config: dict[str, dict[str, object]]) -> None:
-        self.stored_litellm_settings = dict(new_config.get("litellm_settings") or {})
+        self.stored_litellm_settings_json = json.dumps(new_config.get("litellm_settings") or {})
 
 
 def test_make_agent_public_twice_keeps_both_agents_public(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1112,8 +1117,8 @@ def test_make_agent_public_twice_keeps_both_agents_public(monkeypatch: pytest.Mo
     assert [agent.agent_id for agent in registry.get_public_agent_list()] == ["agent-1", "agent-2"]
 
 
-def test_make_agent_public_rejects_an_already_public_agent(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The duplicate guard must still fire when the published list comes back from the DB."""
+def test_make_agent_public_rejects_an_agent_published_only_in_the_db(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The duplicate guard must fire off the stored list, not just what this process published."""
     import litellm
     from litellm.proxy.agent_endpoints import agent_registry as agent_registry_module
     from litellm.proxy.agent_endpoints.agent_registry import AgentRegistry
@@ -1124,11 +1129,12 @@ def test_make_agent_public_rejects_an_already_public_agent(monkeypatch: pytest.M
     monkeypatch.setattr(agent_registry_module, "global_agent_registry", registry)
     monkeypatch.setattr(litellm, "public_agent_groups", None)
     monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", MagicMock())
-    monkeypatch.setattr("litellm.proxy.proxy_server.proxy_config", _DbBackedProxyConfig())
+    monkeypatch.setattr(
+        "litellm.proxy.proxy_server.proxy_config",
+        _DbBackedProxyConfig({"public_agent_groups": ["agent-1"]}),
+    )
 
-    first: Final = client.post("/v1/agents/agent-1/make_public", headers={"Authorization": "Bearer test-key"})
     duplicate: Final = client.post("/v1/agents/agent-1/make_public", headers={"Authorization": "Bearer test-key"})
 
-    assert first.status_code == 200
     assert duplicate.status_code == 400
     assert "already in public agent groups" in duplicate.json()["detail"]


### PR DESCRIPTION
## TLDR

Problem this solves:

- `modelHub.spec.ts` fails on unrelated PRs, passes on rerun
- Publishing a second agent returns 200 and publishes nothing
- So the Agent Hub test can never pass twice
- The "make models public" test cannot run twice either

How it solves it:

- The agent publish reads config before deriving the new list
- The test checks "Select All" instead of blindly toggling it
- It waits for "Next" to enable before clicking

## User Flow

Before: the second agent an admin publishes to the public Agent Hub gets a 200 back that published nothing

1. They send POST https://litellm-domain/v1/agents with an agent card and get back an `agent_id`
2. They send POST https://litellm-domain/v1/agents with a second card and get back a second `agent_id`
3. They send GET https://litellm-domain/v1/agents and both agents come back with `"is_public": false`
4. They send POST https://litellm-domain/v1/agents/{first_id}/make_public and get 200 with `"public_agent_groups": ["<first id>"]`
5. They send GET https://litellm-domain/v1/agents and the first agent now reads `"is_public": true`
6. They send POST https://litellm-domain/v1/agents/{second_id}/make_public and get 200, but the body still reads `"public_agent_groups": ["<first id>"]` with no sign of the second agent
7. They send GET https://litellm-domain/v1/agents and the second agent still reads `"is_public": false`
8. They send GET https://litellm-domain/public/agent_hub and only the first agent comes back
9. They retry the second publish expecting the "already in public agent groups" 400, and get another 200 listing only the first agent, so nothing tells them it never took

After: both publishes take, and both agents show up on the public Agent Hub

1. They send POST https://litellm-domain/v1/agents with an agent card and get back an `agent_id`
2. They send POST https://litellm-domain/v1/agents with a second card and get back a second `agent_id`
3. They send GET https://litellm-domain/v1/agents and both agents come back with `"is_public": false`
4. They send POST https://litellm-domain/v1/agents/{first_id}/make_public and get 200 with `"public_agent_groups": ["<first id>"]`
5. They send GET https://litellm-domain/v1/agents and the first agent now reads `"is_public": true`
6. They send POST https://litellm-domain/v1/agents/{second_id}/make_public and get 200 with `"public_agent_groups": ["<first id>", "<second id>"]`
7. They send GET https://litellm-domain/v1/agents and the second agent now reads `"is_public": true` too
8. They send GET https://litellm-domain/public/agent_hub and both agents come back
9. They retry the second publish and get 400 "Agent with name ... already in public agent groups", which correctly says it is already public

## Relevant issues

## Linear ticket

Resolves LIT-6830

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The ticket asked whether the two seed endpoints answer before what they wrote is readable, which would make this a product race rather than a test bug. They do not: `POST /v1/mcp/make_public` is readable on the very next GET with no wait. `POST /v1/agents/{id}/make_public` is a product bug of a different kind, a lost update rather than a lag, and it is why "Agent Hub and MCP Hub tabs render their public entries" can never pass twice against one proxy. The other test, "Make models public via the multi-step modal", is a plain test bug: the modal preselects the groups that are already public, so a blind click on "Select All" clears them and leaves "Next" disabled forever. CircleCI's own trace for job 2150613 shows `GET /model_group/info` returning `is_public_model_group: true` for both seeded groups, and all three attempts rendering "Select All (2)" unchecked with "Next" disabled, so that is the state CI hit too. The "Publishing two agents" block below is the product half, "The model hub spec run repeatedly" the test half.

The three sibling publish endpoints all read the config before deriving what they save, and `POST /model_group/make_public` even carries a comment saying why (`get_config()` re-applies the DB's `litellm_settings` over the in-memory globals). `POST /v1/agents/{id}/make_public` was the one that appended first and read after, so its append was thrown away every time the DB already held a `public_agent_groups` key.

Shared setup, one live proxy with a seeded postgres and a mock upstream, brought up by the e2e harness itself. Each leg reboots the proxy from that leg's commit against a freshly seeded database and then runs the identical step list:

```
cd tests/e2e/ui
PROXY_PORT=55326 POSTGRES_PORT=55327 MOCK_LLM_PORT=55328 E2E_KEEP_ALIVE=1 ./run_e2e.sh
BASE=http://127.0.0.1:55326
KEY=sk-1234

mk () {
  curl -s -X POST $BASE/v1/agents -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' \
    -d "{\"agent_name\":\"$1\",\"agent_card_params\":{\"name\":\"$1\",\"description\":\"probe agent\",\"version\":\"1.0.0\",\"url\":\"http://127.0.0.1:9999/\",\"capabilities\":{},\"skills\":[],\"defaultInputModes\":[\"text\"],\"defaultOutputModes\":[\"text\"]}}" \
    | jq -r .agent_id
}

is_public () {
  curl -s $BASE/v1/agents -H "Authorization: Bearer $KEY" \
    | jq -r '.[] | select(.agent_name | startswith("probe-")) | "    \(.agent_name) is_public = \(.litellm_params.is_public)"'
}

A1=$(mk "probe-one"); A2=$(mk "probe-two")
```

### Before (658f5066)

#### Publishing two agents to the public Agent Hub

The first publish takes because the database has no `public_agent_groups` key yet. That publish writes the key, and every publish after it is thrown away:

```
$ is_public   # before publishing anything
    probe-one is_public = false
    probe-two is_public = false

$ curl -s -X POST $BASE/v1/agents/$A1/make_public -H "Authorization: Bearer $KEY" -w '\nHTTP %{http_code}\n'
{"message":"Successfully updated public agent groups","public_agent_groups":["cbc5adb4-ce4c-45f2-bb61-97cce840fe31"],"updated_by":"default_user_id"}
HTTP 200

$ is_public
    probe-one is_public = true
    probe-two is_public = false

$ curl -s -X POST $BASE/v1/agents/$A2/make_public -H "Authorization: Bearer $KEY" -w '\nHTTP %{http_code}\n'
{"message":"Successfully updated public agent groups","public_agent_groups":["cbc5adb4-ce4c-45f2-bb61-97cce840fe31"],"updated_by":"default_user_id"}
HTTP 200

$ is_public
    probe-one is_public = true
    probe-two is_public = false

$ curl -s $BASE/public/agent_hub | jq -c '[.[].name]'
["probe-one"]

$ curl -s -X POST $BASE/v1/agents/$A2/make_public -H "Authorization: Bearer $KEY" -w '\nHTTP %{http_code}\n'   # publishing the same agent twice
{"message":"Successfully updated public agent groups","public_agent_groups":["cbc5adb4-ce4c-45f2-bb61-97cce840fe31"],"updated_by":"default_user_id"}
HTTP 200
```

The second publish answers 200 with a list that does not contain the agent it just published, `is_public` stays `false` for it, the public hub never lists it, and republishing it never reaches the "already in public agent groups" 400.

#### The model hub spec run repeatedly

1. Run the failing test 30 times in a row against the running stack:

```
$ cd tests/e2e/ui
$ for i in $(seq 1 30); do
    CI=1 E2E_UI_BASE_URL=http://127.0.0.1:55326 LITELLM_MASTER_KEY=sk-1234 MOCK_LLM_PORT=55328 \
      npx playwright test tests/modelHub/modelHub.spec.ts:10 --retries=0 --workers=1 --reporter=line
  done
1 passed, 29 failed of 30, first failure at run 2
```

2. The failure is byte-for-byte the one CI reports:

```
TimeoutError: locator.click: Timeout 15000ms exceeded.
  - waiting for getByRole('dialog', { name: 'Make Models Public' }).getByRole('button', { name: 'Next' })
    - locator resolved to <button disabled ...>Next</button>
    - element is not enabled
  at tests/e2e/ui/tests/modelHub/modelHub.spec.ts:29:55
```

3. Run the whole spec file 3 times in a row:

```
$ for i in 1 2 3; do
    CI=1 E2E_UI_BASE_URL=http://127.0.0.1:55326 LITELLM_MASTER_KEY=sk-1234 MOCK_LLM_PORT=55328 \
      npx playwright test tests/modelHub/modelHub.spec.ts --retries=0 --workers=1 --reporter=line
  done
run 1: 1 failed, 3 passed  (Agent Hub and MCP Hub tabs render their public entries)
run 2: 2 failed, 2 passed  (that one plus Make models public via the multi-step modal)
run 3: 2 failed, 2 passed  (same two)
```

### After (b1695e90)

Every leg below ran at `b1695e90`. The one commit since, `15e956db33`, touches `tests/test_litellm/` only, so it cannot change what the proxy serves or what the spec does

#### Publishing two agents to the public Agent Hub

The same step list, on a proxy booted from this PR's tip:

```
$ is_public   # before publishing anything
    probe-one is_public = false
    probe-two is_public = false

$ curl -s -X POST $BASE/v1/agents/$A1/make_public -H "Authorization: Bearer $KEY" -w '\nHTTP %{http_code}\n'
{"message":"Successfully updated public agent groups","public_agent_groups":["8580367f-01fa-412d-8c1e-cdcc73357156"],"updated_by":"default_user_id"}
HTTP 200

$ is_public
    probe-one is_public = true
    probe-two is_public = false

$ curl -s -X POST $BASE/v1/agents/$A2/make_public -H "Authorization: Bearer $KEY" -w '\nHTTP %{http_code}\n'
{"message":"Successfully updated public agent groups","public_agent_groups":["8580367f-01fa-412d-8c1e-cdcc73357156","9ed946fd-1c43-45cb-aab8-f60ff2ccfba7"],"updated_by":"default_user_id"}
HTTP 200

$ is_public
    probe-one is_public = true
    probe-two is_public = true

$ curl -s $BASE/public/agent_hub | jq -c '[.[].name]'
["probe-one","probe-two"]

$ curl -s -X POST $BASE/v1/agents/$A2/make_public -H "Authorization: Bearer $KEY" -w '\nHTTP %{http_code}\n'   # publishing the same agent twice
{"detail":"Agent with name probe-two already in public agent groups"}
HTTP 400
```

#### The model hub spec run repeatedly

1. The same 30 runs of the same test:

```
$ cd tests/e2e/ui
$ for i in $(seq 1 30); do
    CI=1 E2E_UI_BASE_URL=http://127.0.0.1:55326 LITELLM_MASTER_KEY=sk-1234 MOCK_LLM_PORT=55328 \
      npx playwright test tests/modelHub/modelHub.spec.ts:10 --retries=0 --workers=1 --reporter=line
  done
30 passed, 0 failed of 30
```

2. The whole spec file 10 times in a row:

```
$ for i in $(seq 1 10); do
    CI=1 E2E_UI_BASE_URL=http://127.0.0.1:55326 LITELLM_MASTER_KEY=sk-1234 MOCK_LLM_PORT=55328 \
      npx playwright test tests/modelHub/modelHub.spec.ts --retries=0 --workers=1 --reporter=line
  done
every run: 4 passed  (10 passed, 0 failed of 10)
```

3. CI agrees at the PR tip `15e956db33`: `ci/circleci: e2e_ui_testing` passed in [job 2152725](https://circleci.com/gh/BerriAI/litellm/2152725), and so did `ci/circleci: e2e_ui_testing_server_root_path` in [job 2152722](https://circleci.com/gh/BerriAI/litellm/2152722), which runs the same specs behind `SERVER_ROOT_PATH=/litellm`.

#### What the run noticed alongside the verdict

- A repo `.env` leaks into `run_e2e.sh`, breaking Playwright login locally
- `POST /v1/mcp/make_public` is readable on the very next GET
- Deleting a published agent leaves its id on the public list

## Type

🐛 Bug Fix
✅ Test

## Caveats (if any)

### Low

- Two admins publishing agents in the same instant can still lose one
  - Every AI Hub publish endpoint reads the whole config, edits it and saves it back, so the last writer wins
  - Not caused or worsened here: before this PR a lone publish already lost itself, so the concurrent case was strictly worse
  - Left unfixed on purpose: closing it needs a merge-based config writer or a Postgres-side append shared by all four publish endpoints, which is a far wider blast radius than a flake fix earns, so it is tracked as LIT-6844
- What first made CI's two model groups public is still unexplained
  - Nothing in the seed, the config or the harness publishes them
  - The spec no longer cares either way, which is the point of the fix
- Deleting a public agent leaves its id on the public list
  - Nothing user-visible: the Agent Hub only lists agents that still exist
  - Pre-existing, untouched here

## QA runbook

- `tests/e2e/ui/tests/modelHub/modelHub.spec.ts` "Make models public via the multi-step modal" - the modal publishes the seeded model groups whether or not they are already public
  - [ ] Bring the stack up with `cd tests/e2e/ui && E2E_KEEP_ALIVE=1 ./run_e2e.sh`, which seeds postgres, starts the mock upstream, and leaves the proxy running
  - [ ] Open `http://localhost:4000/ui/model_hub_table` as the admin and click "Select Models to Make Public"
  - [ ] In the "Make Models Public" dialog, expect "Select All (N)" unchecked and "Next" greyed out
  - [ ] Check "Select All", expect "Next" to enable, click it, then click "Make Public" and expect the "Successfully made N model group(s) public" toast
  - [ ] Click "Select Models to Make Public" again and expect "Select All" to come back already checked, since those groups are public now
  - [ ] Check "Select All" again, expect it to stay checked and "Next" to stay enabled, and click through to the same success toast
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky
- `tests/e2e/ui/tests/modelHub/modelHub.spec.ts` "Agent Hub and MCP Hub tabs render their public entries" - both hub tabs list the entries the test just published
  - [ ] With the same stack up, POST `/v1/agents` with an agent card, then POST `/v1/agents/{agent_id}/make_public`, both with the master key
  - [ ] Expect that second response to carry the new agent id in `public_agent_groups`
  - [ ] POST `/v1/mcp/server` with a server, then POST `/v1/mcp/make_public` with every already-public server id plus the new one
  - [ ] Open `http://localhost:4000/ui/model_hub_table`, expect an "Agent Hub" and an "MCP Hub" tab next to "Model Hub", and click each
  - [ ] Expect the agent you published under "Available Agents" and the server you published under "Available MCP Servers"
  - [ ] Repeat the whole bullet a second time without restarting the proxy and expect the same result, which is what the agent publish fix buys
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow admin-only publish path fix aligned with other hub publish endpoints; main residual risk is unchanged last-writer-wins on concurrent publishes.
> 
> **Overview**
> Fixes a **lost update** on `POST /v1/agents/{agent_id}/make_public`: the handler now calls `proxy_config.get_config()` **before** building the new `public_agent_groups` list, appends the agent to that DB-backed snapshot, saves, and only then updates `litellm.public_agent_groups`. Previously it mutated the in-memory list first; the subsequent `get_config()` reapplied stored `litellm_settings` and wiped the append, so the second (and later) publish could return 200 without adding the agent.
> 
> Adds proxy unit tests with a JSON round-trip `_DbBackedProxyConfig` to assert two sequential publishes keep both IDs and that duplicate detection uses the stored list when the in-memory global is empty.
> 
> Stabilizes the Model Hub Playwright flow: **check** the "Select All" checkbox (instead of toggling label text when rows are pre-selected) and **wait for Next to be enabled** before advancing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15e956db33829cc82800e36cd89dd23f3d8701b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


