### PR TITLE
fix(proxy): give each spend-log queue monitor its own flush event

### DIFF
--- a/litellm/proxy/db/db_spend_update_writer.py
+++ b/litellm/proxy/db/db_spend_update_writer.py
@@ -940,7 +940,7 @@ class DBSpendUpdateWriter:
 
             await enqueue_spend_logs(prisma_client, (payload,))
             if payload.get("call_type") in RESPONSES_SESSION_CALL_TYPES:
-                request_spend_log_flush()
+                request_spend_log_flush(prisma_client)
         else:
             verbose_proxy_logger.debug("prisma_client is None. Skipping writing spend logs to db.")
 

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -3519,7 +3519,7 @@ class _StaleReadEngine:
 class PrismaClient:
     spend_log_transactions: list = []
     _spend_log_transactions_lock = asyncio.Lock()
-    spend_log_flush_requested: ClassVar[asyncio.Event] = asyncio.Event()
+    spend_log_flush_requested: "asyncio.Event | None" = None
     spend_log_queue_bytes: ClassVar[int] = 0
     spend_logs_queue_monitor_task: "asyncio.Task[None] | None" = None
     tool_usage_transactions: list["ToolUsageTransaction"] = []
@@ -6245,23 +6245,27 @@ async def enqueue_spend_logs(
         )
 
 
-def request_spend_log_flush() -> None:
-    """Wake the queue monitor now rather than leaving the rows for its next poll.
+def request_spend_log_flush(prisma_client: PrismaClient) -> None:
+    """Wake this client's queue monitor now rather than leaving the rows for its next poll.
 
     The Responses API hands the client an id it can chain from straight away, and that
     lookup reads the DB, so the row cannot sit in this worker's queue for a poll interval.
     Repeated requests coalesce into the monitor's next pass, so the batching holds.
+    A request made before the monitor is running is dropped, and loses nothing: the
+    monitor reads the queue on its first pass, before it ever waits on a request.
     """
-    PrismaClient.spend_log_flush_requested.set()
+    flush_requested: Final = prisma_client.spend_log_flush_requested
+    if flush_requested is not None:
+        flush_requested.set()
 
 
-async def _wait_for_spend_log_flush_request(interval: float) -> bool:
+async def _wait_for_spend_log_flush_request(flush_requested: asyncio.Event, interval: float) -> bool:
     """Wait out ``interval``, returning early and True when a flush was requested."""
     try:
-        await asyncio.wait_for(PrismaClient.spend_log_flush_requested.wait(), timeout=interval)
+        await asyncio.wait_for(flush_requested.wait(), timeout=interval)
     except asyncio.TimeoutError:
         return False
-    PrismaClient.spend_log_flush_requested.clear()
+    flush_requested.clear()
     return True
 
 
@@ -6681,6 +6685,8 @@ async def _monitor_spend_logs_queue(
     max_backoff: Final = 30.0  # Maximum backoff interval in seconds
     backoff_multiplier: Final = 1.5  # Exponential backoff multiplier
     current_interval = base_interval
+    flush_requested: Final = asyncio.Event()
+    prisma_client.spend_log_flush_requested = flush_requested  # rebind-ok: the client owns its monitor's flush signal
 
     verbose_proxy_logger.info(
         "Starting spend logs queue monitor (threshold: %s, poll_interval: %ss)", threshold, base_interval
@@ -6719,7 +6725,7 @@ async def _monitor_spend_logs_queue(
                 # Exponential backoff when no logs to process
                 current_interval = min(current_interval * backoff_multiplier, max_backoff)
 
-            if await _wait_for_spend_log_flush_request(current_interval):
+            if await _wait_for_spend_log_flush_request(flush_requested, current_interval):
                 current_interval = base_interval
         except Exception as e:
             spend_log_error("Error in spend logs queue monitor: %s", str(e), exc=e)

--- a/tests/test_litellm/proxy/db/test_db_spend_update_writer.py
+++ b/tests/test_litellm/proxy/db/test_db_spend_update_writer.py
@@ -2941,11 +2941,9 @@ async def test_insert_spend_log_asks_for_an_immediate_flush_on_responses_calls(c
     A `previous_response_id` chained straight off the previous turn reads the DB, so a
     Responses row cannot sit in this worker's queue until the monitor's next poll.
     """
-    from litellm.proxy.utils import PrismaClient
-
     db_writer = DBSpendUpdateWriter()
     prisma = _tool_usage_prisma()
-    PrismaClient.spend_log_flush_requested.clear()
+    prisma.spend_log_flush_requested = asyncio.Event()
 
     await db_writer._insert_spend_log_to_db(
         payload={"request_id": "req-1", "call_type": call_type},
@@ -2953,8 +2951,7 @@ async def test_insert_spend_log_asks_for_an_immediate_flush_on_responses_calls(c
     )
 
     assert prisma.spend_log_transactions == [{"request_id": "req-1", "call_type": call_type}]
-    assert PrismaClient.spend_log_flush_requested.is_set() is expects_flush
-    PrismaClient.spend_log_flush_requested.clear()
+    assert prisma.spend_log_flush_requested.is_set() is expects_flush
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/utils/prisma_and_spend/test_spend_functions.py
+++ b/tests/test_litellm/proxy/utils/prisma_and_spend/test_spend_functions.py
@@ -621,15 +621,47 @@ def test_monitor_spend_logs_queue_flush_survives_an_earlier_event_loop(
     asyncio.run(_flush_once_under_a_monitor())
 
 
-def test_request_spend_log_flush_is_a_no_op_before_the_monitor_starts(mock_prisma_client: Any) -> None:
-    """A Responses row enqueued before the monitor's first pass must not fail the request."""
+@pytest.mark.asyncio
+async def test_flush_requested_before_the_monitor_starts_costs_the_row_nothing(
+    mock_prisma_client: Any,
+    make_spend_log_row: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A Responses row enqueued before the monitor exists still reaches the DB on its first
+    pass, so dropping that early request delays nothing.
+    """
+    import litellm.constants as constants_mod
+    import litellm.proxy.utils as utils_mod
     from litellm.proxy.utils import request_spend_log_flush
 
+    monkeypatch.setattr(constants_mod, "SPEND_LOG_QUEUE_POLL_INTERVAL", 30.0, raising=False)
     mock_prisma_client.spend_log_flush_requested = None
+    mock_prisma_client.tool_usage_transactions = []
+    mock_prisma_client.spend_log_transactions = [make_spend_log_row(request_id="r1")]
+
+    flushed: Final = asyncio.Event()
+
+    async def _fake_job(*args: Any, **kwargs: Any) -> None:
+        flushed.set()
+
+    monkeypatch.setattr(utils_mod, "update_spend_logs_job", _fake_job)
 
     request_spend_log_flush(mock_prisma_client)
-
     assert mock_prisma_client.spend_log_flush_requested is None
+
+    monitor: Final = asyncio.create_task(
+        _monitor_spend_logs_queue(
+            prisma_client=mock_prisma_client,
+            db_writer_client=None,
+            proxy_logging_obj=MagicMock(),
+        )
+    )
+    try:
+        await asyncio.wait_for(flushed.wait(), timeout=5.0)
+    finally:
+        monitor.cancel()
+        with suppress(asyncio.CancelledError):
+            await monitor
 
 
 def test_raise_failed_update_spend_exception_emits_failure_handler() -> None:

--- a/tests/test_litellm/proxy/utils/prisma_and_spend/test_spend_functions.py
+++ b/tests/test_litellm/proxy/utils/prisma_and_spend/test_spend_functions.py
@@ -538,10 +538,9 @@ async def test_monitor_spend_logs_queue_flushes_as_soon_as_one_is_requested(
     """
     import litellm.constants as constants_mod
     import litellm.proxy.utils as utils_mod
-    from litellm.proxy.utils import PrismaClient, request_spend_log_flush
+    from litellm.proxy.utils import request_spend_log_flush
 
     monkeypatch.setattr(constants_mod, "SPEND_LOG_QUEUE_POLL_INTERVAL", 30.0, raising=False)
-    PrismaClient.spend_log_flush_requested.clear()
     mock_prisma_client.spend_log_transactions = []
     mock_prisma_client.tool_usage_transactions = []
 
@@ -562,16 +561,75 @@ async def test_monitor_spend_logs_queue_flushes_as_soon_as_one_is_requested(
     try:
         await asyncio.sleep(0.05)
         assert not flushed.is_set()
+        assert isinstance(mock_prisma_client.spend_log_flush_requested, asyncio.Event)
 
         mock_prisma_client.spend_log_transactions.append(make_spend_log_row(request_id="r1"))
-        request_spend_log_flush()
+        request_spend_log_flush(mock_prisma_client)
 
         await asyncio.wait_for(flushed.wait(), timeout=5.0)
     finally:
         monitor.cancel()
         with suppress(asyncio.CancelledError):
             await monitor
-        PrismaClient.spend_log_flush_requested.clear()
+
+
+def test_monitor_spend_logs_queue_flush_survives_an_earlier_event_loop(
+    mock_prisma_client: Any,
+    make_spend_log_row: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A second monitor, started in a fresh event loop, is still woken by a flush request,
+    so a worker whose first loop is gone keeps flushing Responses rows instead of stalling.
+    """
+    import litellm.constants as constants_mod
+    import litellm.proxy.utils as utils_mod
+    from litellm.proxy.utils import request_spend_log_flush
+
+    monkeypatch.setattr(constants_mod, "SPEND_LOG_QUEUE_POLL_INTERVAL", 30.0, raising=False)
+    mock_prisma_client.tool_usage_transactions = []
+
+    async def _flush_once_under_a_monitor() -> None:
+        flushed: Final = asyncio.Event()
+
+        async def _fake_job(*args: Any, **kwargs: Any) -> None:
+            flushed.set()
+
+        monkeypatch.setattr(utils_mod, "update_spend_logs_job", _fake_job)
+        mock_prisma_client.spend_log_transactions = []
+
+        monitor: Final = asyncio.create_task(
+            _monitor_spend_logs_queue(
+                prisma_client=mock_prisma_client,
+                db_writer_client=None,
+                proxy_logging_obj=MagicMock(),
+            )
+        )
+        try:
+            await asyncio.sleep(0.05)
+            assert not flushed.is_set()
+
+            mock_prisma_client.spend_log_transactions.append(make_spend_log_row(request_id="r1"))
+            request_spend_log_flush(mock_prisma_client)
+
+            await asyncio.wait_for(flushed.wait(), timeout=5.0)
+        finally:
+            monitor.cancel()
+            with suppress(asyncio.CancelledError):
+                await monitor
+
+    asyncio.run(_flush_once_under_a_monitor())
+    asyncio.run(_flush_once_under_a_monitor())
+
+
+def test_request_spend_log_flush_is_a_no_op_before_the_monitor_starts(mock_prisma_client: Any) -> None:
+    """A Responses row enqueued before the monitor's first pass must not fail the request."""
+    from litellm.proxy.utils import request_spend_log_flush
+
+    mock_prisma_client.spend_log_flush_requested = None
+
+    request_spend_log_flush(mock_prisma_client)
+
+    assert mock_prisma_client.spend_log_flush_requested is None
 
 
 def test_raise_failed_update_spend_exception_emits_failure_handler() -> None:


### PR DESCRIPTION
## TLDR

Problem this solves:

- A spend-log test fails based on what ran before it
- Its flush signal is one object shared process-wide
- That object sticks to the first event loop awaiting it
- Reruns stay in the same worker, so all three fail

How it solves it:

- Each running monitor now makes its own flush signal
- It is created inside the loop that awaits it
- Callers reach it through the client they already hold
- Tests stop resetting a process-wide object by hand

## User Flow

Before: an engineer running the `proxy-endpoints` tests locally gets a red on a spend-log test their change never touched, and a plain rerun of the same commit turns it green

1. They set the repo up the documented way, copying `.env.example` to `.env`, which sets `DATABASE_URL`
2. They run the shard the way CI runs it: `pytest <the 31 proxy-endpoints paths> -n 4 --dist=loadscope --reruns 2`
3. Roughly one run in three, `test_monitor_spend_logs_queue_flushes_as_soon_as_one_is_requested` fails with a `TimeoutError`, and its captured log carries `RuntimeError: <asyncio.locks.Event object at 0x...> is bound to a different event loop`
4. Both automatic reruns fail the same way, so the run exits 1
5. They rerun the identical command at the identical commit and everything passes, so there is nothing in their diff to look at
6. They learn to rerun reds on that file instead of reading them, which is how a real failure there gets waved off

After: the same command gives the same answer every time, so a red on that test means something is actually broken

1. They set the repo up the documented way, copying `.env.example` to `.env`, which sets `DATABASE_URL`
2. They run the shard the way CI runs it: `pytest <the 31 proxy-endpoints paths> -n 4 --dist=loadscope --reruns 2`
3. `test_monitor_spend_logs_queue_flushes_as_soon_as_one_is_requested` passes, whatever ran before it on the same worker
4. The run exits 0
5. Rerunning the identical command at the identical commit gives the identical result
6. A red on that test now points at their own diff, so it is worth reading

## Relevant issues

## Linear ticket

Resolves LIT-6838

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The symptom is a test that only fails next to other tests, so the proof is those tests, run the way the shard runs them: a forced ordering that fails at the merge base and passes here, then the whole shard under its real xdist settings, 12 runs a side.

Shared setup, done once:

```
git -C ~/Development/litellm fetch origin
git -C ~/Development/litellm worktree add -d ~/Development/litellm-worktrees/lit6838_base 658f50663d
git -C ~/Development/litellm worktree add ~/Development/litellm-worktrees/lit6838 litellm_fix_spend_log_flush_event_loop_binding
cd ~/Development/litellm-worktrees/lit6838 && make bootstrap
uv pip install --python .venv/bin/python detect-secrets   # CI installs this via --group ci
```

Both sides run on that one interpreter, so only the tree under test differs:

```
export VENV=~/Development/litellm-worktrees/lit6838/.venv/bin/python
export BASE=~/Development/litellm-worktrees/lit6838_base
export HEAD=~/Development/litellm-worktrees/lit6838
export SPEND=tests/test_litellm/proxy/utils/prisma_and_spend/test_spend_functions.py
export HEALTH=tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
```

Every command below exports `DATABASE_URL`, because that is the precondition: the queue monitor only starts when a database is configured, and it is the monitor's wait that binds the shared event. A developer following the repo's own setup has it, since `.env.example` ships a `DATABASE_URL` line and LiteLLM loads `.env` on import. Any local Postgres does, and nothing here writes to it. GitHub Actions sets no `DATABASE_URL`, which is why this has never gone red there; see Caveats.

```
export DATABASE_URL="postgresql://mateo@127.0.0.1:5432/litellm"
```

### Before (658f50663d)

#### Case 1: one test that starts the proxy, then the spend-log test

1. Run the pair in that order:

```
cd $BASE && PYTHONPATH=$BASE:$BASE/enterprise $VENV -m pytest \
  "$HEALTH::test_health_liveliness_endpoint" \
  "$SPEND::test_monitor_spend_logs_queue_flushes_as_soon_as_one_is_requested" \
  -q --no-header -p no:cacheprovider --tb=line -rf
```

2. The spend-log test times out, and the monitor's own log says why:

```
04:28:26 - LiteLLM Proxy:ERROR: spend_log_error_logger.py:81 - Error in spend logs queue monitor: <asyncio.locks.Event object at 0x11456d490 [unset]> is bound to a different event loop
Traceback (most recent call last):
  File ".../lit6838_base/litellm/proxy/utils.py", line 6722, in _monitor_spend_logs_queue
    if await _wait_for_spend_log_flush_request(current_interval):
  File ".../lit6838_base/litellm/proxy/utils.py", line 6261, in _wait_for_spend_log_flush_request
    await asyncio.wait_for(PrismaClient.spend_log_flush_requested.wait(), timeout=interval)
  File ".../python3.12/asyncio/locks.py", line 209, in wait
    fut = self._get_loop().create_future()
  File ".../python3.12/asyncio/mixins.py", line 20, in _get_loop
    raise RuntimeError(f'{self!r} is bound to a different event loop')
RuntimeError: <asyncio.locks.Event object at 0x11456d490 [unset]> is bound to a different event loop
.../python3.12/asyncio/timeouts.py:115: TimeoutError

FAILED tests/test_litellm/proxy/utils/prisma_and_spend/test_spend_functions.py::test_monitor_spend_logs_queue_flushes_as_soon_as_one_is_requested
1 failed, 1 passed, 2 warnings in 8.21s
```

#### Case 2: the spend-log test alone (control)

1. Run only it:

```
cd $BASE && PYTHONPATH=$BASE:$BASE/enterprise $VENV -m pytest \
  "$SPEND::test_monitor_spend_logs_queue_flushes_as_soon_as_one_is_requested" \
  -q --no-header -p no:cacheprovider --tb=line -rf
```

2. It passes, so the test itself is fine:

```
1 passed, 1 warning in 5.55s
```

#### Case 3: both whole files, in that order

1. Run them:

```
cd $BASE && PYTHONPATH=$BASE:$BASE/enterprise $VENV -m pytest "$HEALTH" "$SPEND" \
  -q --no-header -p no:cacheprovider --tb=line -rf
```

2. The same one test fails out of 149:

```
FAILED tests/test_litellm/proxy/utils/prisma_and_spend/test_spend_functions.py::test_monitor_spend_logs_queue_flushes_as_soon_as_one_is_requested
1 failed, 148 passed, 6 warnings in 17.10s
```

#### Case 4: the whole proxy-endpoints shard under its real settings, 12 runs

1. Run all 31 paths the shard runs, with its workers and reruns, 12 times:

```
PATHS=$(python3 -c "import yaml; w=yaml.safe_load(open('.github/workflows/test-unit.yml')); \
  print([e for e in w['jobs']['unit']['strategy']['matrix']['include'] if e['shard']=='proxy-endpoints'][0]['test-path'])")
cd $BASE
for i in $(seq 1 12); do
  PYTHONPATH=$BASE:$BASE/enterprise $VENV -m pytest ${=PATHS} \
    -q --no-header -p no:cacheprovider -n 4 --dist=loadscope --reruns 2 --reruns-delay 1 --tb=line -rf
done
```

2. 4 of the 12 go red on that one test, and the two reruns never save it:

```
run  1: 8936 passed, 3 skipped, 1 xfailed, 151 warnings in 47.14s
run  2: FAILED .../test_spend_functions.py::test_monitor_spend_logs_queue_flushes_as_soon_as_one_is_requested
        1 failed, 8935 passed, 3 skipped, 1 xfailed, 149 warnings, 2 rerun in 60.80s
run  3: 8936 passed, 3 skipped, 1 xfailed, 149 warnings in 30.20s
run  4: 8936 passed, 3 skipped, 1 xfailed, 151 warnings in 35.67s
run  5: FAILED .../test_spend_functions.py::test_monitor_spend_logs_queue_flushes_as_soon_as_one_is_requested
        1 failed, 8935 passed, 3 skipped, 1 xfailed, 151 warnings, 2 rerun in 52.20s
run  6: 8936 passed, 3 skipped, 1 xfailed, 151 warnings in 34.15s
run  7: FAILED .../test_spend_functions.py::test_monitor_spend_logs_queue_flushes_as_soon_as_one_is_requested
        1 failed, 8935 passed, 3 skipped, 1 xfailed, 149 warnings, 2 rerun in 39.10s
run  8: 8936 passed, 3 skipped, 1 xfailed, 151 warnings in 31.53s
run  9: 8936 passed, 3 skipped, 1 xfailed, 151 warnings in 31.21s
run 10: 8936 passed, 3 skipped, 1 xfailed, 152 warnings in 32.91s
run 11: 8936 passed, 3 skipped, 1 xfailed, 152 warnings in 33.21s
run 12: FAILED .../test_spend_functions.py::test_monitor_spend_logs_queue_flushes_as_soon_as_one_is_requested
        1 failed, 8935 passed, 3 skipped, 1 xfailed, 150 warnings, 2 rerun in 40.44s
```

#### Case 5: the two new tests, checked against the bug coming back

1. Ask for the two tests the fix adds:

```
cd $BASE && PYTHONPATH=$BASE:$BASE/enterprise $VENV -m pytest \
  "$SPEND::test_monitor_spend_logs_queue_flush_survives_an_earlier_event_loop" \
  "$SPEND::test_flush_requested_before_the_monitor_starts_costs_the_row_nothing" \
  -q --no-header -p no:cacheprovider --tb=line -rf
```

2. Neither exists here, so nothing guards this behavior at the merge base:

```
ERROR: not found: .../test_spend_functions.py::test_flush_requested_before_the_monitor_starts_costs_the_row_nothing
(no match in any of [<Module test_spend_functions.py>])
1 warning in 0.14s
```

### After (29bcb0eeb9)

#### Case 1: one test that starts the proxy, then the spend-log test

1. Same command, against the branch:

```
cd $HEAD && PYTHONPATH=$HEAD:$HEAD/enterprise $VENV -m pytest \
  "$HEALTH::test_health_liveliness_endpoint" \
  "$SPEND::test_monitor_spend_logs_queue_flushes_as_soon_as_one_is_requested" \
  -q --no-header -p no:cacheprovider --tb=line -rf
```

2. Both pass:

```
2 passed, 2 warnings in 2.68s
```

#### Case 2: the spend-log test alone (control)

1. Same command:

```
cd $HEAD && PYTHONPATH=$HEAD:$HEAD/enterprise $VENV -m pytest \
  "$SPEND::test_monitor_spend_logs_queue_flushes_as_soon_as_one_is_requested" \
  -q --no-header -p no:cacheprovider --tb=line -rf
```

2. Still passes:

```
1 passed, 1 warning in 1.98s
```

#### Case 3: both whole files, in that order

1. Same command:

```
cd $HEAD && PYTHONPATH=$HEAD:$HEAD/enterprise $VENV -m pytest "$HEALTH" "$SPEND" \
  -q --no-header -p no:cacheprovider --tb=line -rf
```

2. Nothing fails, and the count is 151 because this PR adds two tests:

```
151 passed, 6 warnings in 9.58s
```

#### Case 4: the whole proxy-endpoints shard under its real settings, 12 runs

1. Same command:

```
cd $HEAD
for i in $(seq 1 12); do
  PYTHONPATH=$HEAD:$HEAD/enterprise $VENV -m pytest ${=PATHS} \
    -q --no-header -p no:cacheprovider -n 4 --dist=loadscope --reruns 2 --reruns-delay 1 --tb=line -rf
done
```

2. 0 of the 12 touch the spend-log test, against 4 of 12 at the base. Run 2 is a different shard order dependence, in the guardrail translation mappings rather than anything this branch touches; it is filed as LIT-6848 and covered under Caveats:

```
run  1: 8938 passed, 3 skipped, 1 xfailed, 150 warnings in 47.67s
run  2: FAILED .../openai/test_openai_moderation_streaming.py::test_openai_moderation_guardrail_streaming_harmful_content
        FAILED .../openai/test_openai_moderation_streaming.py::test_openai_moderation_streaming_default_uses_sampled_cadence
        FAILED .../openai/test_openai_moderation_streaming.py::test_openai_moderation_streaming_end_of_stream_only_opt_in_calls_moderation_once
        FAILED .../openai/test_openai_moderation_streaming.py::test_openai_moderation_streaming_end_of_stream_request_data_passthrough
        FAILED .../openai/test_openai_moderation_streaming.py::test_openai_moderation_streaming_sampled_when_end_of_stream_only_disabled
        5 failed, 8933 passed, 3 skipped, 1 xfailed, 150 warnings, 10 rerun in 68.18s
run  3: 8938 passed, 3 skipped, 1 xfailed, 151 warnings in 40.22s
run  4: 8938 passed, 3 skipped, 1 xfailed, 151 warnings in 39.91s
run  5: 8938 passed, 3 skipped, 1 xfailed, 152 warnings in 34.06s
run  6: 8938 passed, 3 skipped, 1 xfailed, 152 warnings in 53.63s
run  7: 8938 passed, 3 skipped, 1 xfailed, 151 warnings in 40.49s
run  8: 8938 passed, 3 skipped, 1 xfailed, 152 warnings in 42.41s
run  9: 8938 passed, 3 skipped, 1 xfailed, 151 warnings in 43.61s
run 10: 8938 passed, 3 skipped, 1 xfailed, 151 warnings in 37.56s
run 11: 8938 passed, 3 skipped, 1 xfailed, 150 warnings in 50.47s
run 12: 8938 passed, 3 skipped, 1 xfailed, 149 warnings in 43.58s
```

#### Case 5: the two new tests, checked against the bug coming back

1. Put a process-wide event back on top of the fix, run the two new tests, then undo it:

```
cd $HEAD && python3 - <<'EOF'
from pathlib import Path
p = Path("litellm/proxy/utils.py")
src = p.read_text()
src = src.replace("    flush_requested: Final = asyncio.Event()\n",
                  "    flush_requested: Final = _module_level_flush_event\n", 1)
anchor = "async def _monitor_spend_logs_queue(\n"
p.write_text(src.replace(anchor, "_module_level_flush_event = asyncio.Event()\n\n\n" + anchor, 1))
EOF

PYTHONPATH=$HEAD:$HEAD/enterprise $VENV -m pytest \
  "$SPEND::test_monitor_spend_logs_queue_flush_survives_an_earlier_event_loop" \
  "$SPEND::test_flush_requested_before_the_monitor_starts_costs_the_row_nothing" \
  -q --no-header -p no:cacheprovider --tb=line -rf
git checkout -- litellm/proxy/utils.py
```

2. The loop-survival test goes red with the original error, so the fix cannot be undone quietly:

```
RuntimeError: <asyncio.locks.Event object at 0x1150e9400 [unset]> is bound to a different event loop
.../python3.12/asyncio/timeouts.py:115: TimeoutError

FAILED tests/test_litellm/proxy/utils/prisma_and_spend/test_spend_functions.py::test_monitor_spend_logs_queue_flush_survives_an_earlier_event_loop
1 failed, 1 passed, 1 warning in 6.74s
```

3. Now break the other half of the claim instead: a request made before the monitor starts is dropped, which only costs nothing because the monitor drains the queue before it ever waits. Move the wait to the top of the loop body and that stops being true:

```
cd $HEAD && python3 - <<'EOF'
from pathlib import Path
p = Path("litellm/proxy/utils.py")
src = p.read_text()
wait = ("            if await _wait_for_spend_log_flush_request(flush_requested, current_interval):\n"
        "                current_interval = base_interval\n")
head = "        try:\n            # Check queue sizes with lock protection"
p.write_text(src.replace(wait, "", 1).replace(head, "        try:\n" + wait + "            # Check queue sizes with lock protection", 1))
EOF

PYTHONPATH=$HEAD:$HEAD/enterprise $VENV -m pytest \
  "$SPEND::test_monitor_spend_logs_queue_flush_survives_an_earlier_event_loop" \
  "$SPEND::test_flush_requested_before_the_monitor_starts_costs_the_row_nothing" \
  -q --no-header -p no:cacheprovider --tb=line -rf
git checkout -- litellm/proxy/utils.py
```

4. The early-request test goes red, because the row now waits out a whole poll interval:

```
E   asyncio.exceptions.CancelledError
E   TimeoutError
.../python3.12/asyncio/timeouts.py:115: TimeoutError

FAILED tests/test_litellm/proxy/utils/prisma_and_spend/test_spend_functions.py::test_flush_requested_before_the_monitor_starts_costs_the_row_nothing
1 failed, 1 passed, 1 warning in 6.80s
```

5. With the fix back in place, both pass:

```
2 passed, 1 warning in 1.79s
```

Notes from the run, things a reviewer cannot see from the diff:

- The shared event only binds when a database is configured
- The unit workflows set no `DATABASE_URL`, so CI never bound it
- 311 `proxy-endpoints` job logs since 2026-08-22 carry zero occurrences
- The monitor swallows the error into its error logger
- A silenced monitor looks exactly like a slow one
- Reruns stay in the same worker, so all three attempts fail
- `PrismaClient._spend_log_transactions_lock` is the same shape, unfixed
- The conftest sorts every test by bare name, across all files

## Type

🐛 Bug Fix

✅ Test

## Caveats (if any)

### Low

- Branched off staging, not #39543: different files, no dependency
  - Stacking would only make this wait on that review
- The ticket blamed a CI red; CI never actually hit this
  - No `DATABASE_URL` there, so the monitor never starts
  - Real for local runs, and a landmine if CI ever gets a database
- A flush requested before the monitor starts is now dropped
  - It loses nothing: the monitor reads the queue on its first pass
  - Case 5 step 3 above pins that, so a later reorder cannot break it quietly
- `request_spend_log_flush` gained a parameter, so its signature changed
  - Internal helper, no docs reference it, shipped only in v1.100.0-rc.1
- Two monitors on one client would leave the older one polling
  - Nothing starts a second monitor today; it still flushes on its own interval
- `PrismaClient._spend_log_transactions_lock` is a class-level `asyncio.Lock`
  - Same import-time binding, but `acquire()` only binds when contended
  - Fixing it means redesigning who owns the class-level queue, so out of scope here
- Run 2 of the 12 above is an unrelated flake, filed as LIT-6848
  - Five moderation tests fail together with "got 0 moderation calls"
  - The unified guardrail hook passes chunks through silently on a missing call type
  - `litellm.llms.endpoint_guardrail_translation_mappings` caches a discovery that swallows import errors
  - Adding or renaming any test reshuffles the conftest's global name sort, which is how it surfaced here

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to internal spend-log flush signaling and test stability; behavior for Responses flush urgency is preserved when the monitor is running.
> 
> **Overview**
> Replaces the process-wide **`asyncio.Event`** used to wake the spend-log queue monitor with a **per-monitor event** created inside `_monitor_spend_logs_queue` and stored on the **`PrismaClient`** instance (`spend_log_flush_requested`, initially `None`).
> 
> **`request_spend_log_flush`** now takes **`prisma_client`** and only signals when that client’s event exists; Responses API spend inserts pass the client through from **`_insert_spend_log_to_db`**. Early flush requests before the monitor starts are ignored, which is safe because the monitor drains the queue on its first loop iteration before waiting.
> 
> Tests stop touching a shared class-level event and add coverage for **fresh event loops** and **pre-monitor flush** behavior, addressing flaky **`RuntimeError: ... is bound to a different event loop`** under parallel pytest workers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29bcb0eeb9b085492764cdd970bc4b28340f554b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->