### PR TITLE
fix(proxy): stop labelling management and health rejections as auth failures

### DIFF
--- a/litellm/proxy/common_utils/openai_error_payload.py
+++ b/litellm/proxy/common_utils/openai_error_payload.py
@@ -6,7 +6,9 @@ from collections.abc import Mapping
 from types import MappingProxyType
 from typing import Final
 
-from fastapi import status
+from fastapi import HTTPException, status
+
+from litellm.proxy._types import ProxyException
 
 _OPENAI_ERROR_TYPE_BY_STATUS: Final[Mapping[int, str]] = MappingProxyType(
     {
@@ -46,3 +48,27 @@ def openai_error_param(exc: object) -> str | None:
     serializes as JSON ``null``."""
     carried: Final = attribute_of(exc, "param")
     return carried if isinstance(carried, str) else None
+
+
+def proxy_exception_for(exc: Exception, default_status_code: int) -> ProxyException:
+    """The answer a route's blanket ``except Exception`` owes its caller.
+
+    Such a handler has no idea what failed, so it reads the type off the exception
+    instead of asserting one, and keeps the status each branch already answered with:
+    an ``HTTPException`` carries its own, anything else gets the route's default."""
+    if isinstance(exc, ProxyException):
+        return exc
+    if isinstance(exc, HTTPException):
+        carried_status: Final = error_status_code(exc, default_status_code)
+        return ProxyException(
+            message=str(attribute_of(exc, "detail", exc)),
+            type=openai_error_type(exc, carried_status),
+            param=openai_error_param(exc),
+            code=carried_status,
+        )
+    return ProxyException(
+        message=str(exc),
+        type=openai_error_type(exc, default_status_code),
+        param=openai_error_param(exc),
+        code=default_status_code,
+    )

--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -30,8 +30,6 @@ from litellm.proxy._types import (
     EnterpriseLicenseData,
     Litellm_EntityType,
     LitellmUserRoles,
-    ProxyErrorTypes,
-    ProxyException,
     SpecialModelNames,
     UserAPIKeyAuth,
     WebhookEvent,
@@ -40,7 +38,7 @@ from litellm.proxy.auth.auth_utils import (
     _BANNED_REQUEST_BODY_PARAMS,  # pyright: ignore[reportPrivateUsage]  # one canonical list, shared with the request-body check
 )
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
-from litellm.proxy.common_utils.openai_error_payload import openai_error_param
+from litellm.proxy.common_utils.openai_error_payload import proxy_exception_for
 from litellm.proxy.db.exception_handler import PrismaDBExceptionHandler
 from litellm.proxy.db.proxy_worker_heartbeat import count_live_proxy_workers
 from litellm.proxy.health_check import (
@@ -526,21 +524,7 @@ async def health_services_endpoint(
     except Exception as e:
         verbose_proxy_logger.error("litellm.proxy.proxy_server.health_services_endpoint(): Exception occured - %s", e)
         verbose_proxy_logger.debug(traceback.format_exc())
-        if isinstance(e, HTTPException):
-            raise ProxyException(
-                message=getattr(e, "detail", f"Authentication Error({e})"),
-                type=ProxyErrorTypes.auth_error,
-                param=openai_error_param(e),
-                code=getattr(e, "status_code", status.HTTP_500_INTERNAL_SERVER_ERROR),
-            )
-        elif isinstance(e, ProxyException):
-            raise e
-        raise ProxyException(
-            message="Authentication Error, " + str(e),
-            type=ProxyErrorTypes.auth_error,
-            param=openai_error_param(e),
-            code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-        )
+        raise proxy_exception_for(e, default_status_code=status.HTTP_500_INTERNAL_SERVER_ERROR) from e
 
 
 def _convert_health_check_to_dict(check) -> dict:

--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -29,7 +29,7 @@ from litellm.proxy._types import *
 from litellm.proxy.auth.auth_checks import get_team_object, get_user_object
 from litellm.proxy.auth.password_policy import validate_password_policy
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
-from litellm.proxy.common_utils.openai_error_payload import openai_error_param
+from litellm.proxy.common_utils.openai_error_payload import proxy_exception_for
 from litellm.proxy.common_utils.user_api_key_cache import (
     object_permission_cache_key,
     user_object_permission_id_cache_key,
@@ -1646,21 +1646,7 @@ async def user_update(
     except Exception as e:
         verbose_proxy_logger.exception("litellm.proxy.proxy_server.user_update(): Exception occured - %s", e)
         verbose_proxy_logger.debug(traceback.format_exc())
-        if isinstance(e, HTTPException):
-            raise ProxyException(
-                message=getattr(e, "detail", f"Authentication Error({e})"),
-                type=ProxyErrorTypes.auth_error,
-                param=openai_error_param(e),
-                code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
-            )
-        elif isinstance(e, ProxyException):
-            raise e
-        raise ProxyException(
-            message="Authentication Error, " + str(e),
-            type=ProxyErrorTypes.auth_error,
-            param=openai_error_param(e),
-            code=status.HTTP_400_BAD_REQUEST,
-        )
+        raise proxy_exception_for(e, default_status_code=status.HTTP_400_BAD_REQUEST) from e
 
 
 async def bulk_update_processed_users(

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -76,7 +76,10 @@ from litellm.proxy.common_utils.config_sync_pubsub import (
     coordination_redis_cache,
     publish_config_change,
 )
-from litellm.proxy.common_utils.openai_error_payload import openai_error_param
+from litellm.proxy.common_utils.openai_error_payload import (
+    openai_error_param,
+    proxy_exception_for,
+)
 from litellm.proxy.common_utils.rbac_utils import check_org_admin_can_generate_keys
 from litellm.proxy.common_utils.timezone_utils import get_budget_reset_time
 from litellm.proxy.common_utils.user_api_key_cache import UserApiKeyCache
@@ -3037,21 +3040,7 @@ async def update_key_fn(
         # update based on remaining passed in values
     except Exception as e:
         verbose_proxy_logger.exception("litellm.proxy.proxy_server.update_key_fn(): Exception occured - %s", e)
-        if isinstance(e, HTTPException):
-            raise ProxyException(
-                message=getattr(e, "detail", f"Authentication Error({e})"),
-                type=ProxyErrorTypes.auth_error,
-                param=openai_error_param(e),
-                code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
-            )
-        elif isinstance(e, ProxyException):
-            raise e
-        raise ProxyException(
-            message="Authentication Error, " + str(e),
-            type=ProxyErrorTypes.auth_error,
-            param=openai_error_param(e),
-            code=status.HTTP_400_BAD_REQUEST,
-        )
+        raise proxy_exception_for(e, default_status_code=status.HTTP_400_BAD_REQUEST) from e
 
 
 @router.post(

--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -58,7 +58,7 @@ from litellm.proxy.common_utils.encrypt_decrypt_utils import (
     decrypt_value_helper,
     encrypt_value_helper,
 )
-from litellm.proxy.common_utils.openai_error_payload import openai_error_param
+from litellm.proxy.common_utils.openai_error_payload import proxy_exception_for
 from litellm.proxy.common_utils.user_api_key_cache import UserApiKeyCache
 from litellm.proxy.management_endpoints.common_utils import _is_user_team_admin
 from litellm.proxy.management_endpoints.team_endpoints import (
@@ -1697,21 +1697,7 @@ async def delete_model(
 
     except Exception as e:
         verbose_proxy_logger.exception("Failed to delete model. Due to error - %s", e)
-        if isinstance(e, HTTPException):
-            raise ProxyException(
-                message=getattr(e, "detail", f"Authentication Error({e})"),
-                type=ProxyErrorTypes.auth_error,
-                param=openai_error_param(e),
-                code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
-            )
-        elif isinstance(e, ProxyException):
-            raise e
-        raise ProxyException(
-            message="Authentication Error, " + str(e),
-            type=ProxyErrorTypes.auth_error,
-            param=openai_error_param(e),
-            code=status.HTTP_400_BAD_REQUEST,
-        )
+        raise proxy_exception_for(e, default_status_code=status.HTTP_400_BAD_REQUEST) from e
 
 
 async def delete_team_model_alias(
@@ -1921,21 +1907,7 @@ async def add_new_model(
 
     except Exception as e:
         verbose_proxy_logger.exception("litellm.proxy.proxy_server.add_new_model(): Exception occured - %s", e)
-        if isinstance(e, HTTPException):
-            raise ProxyException(
-                message=getattr(e, "detail", f"Authentication Error({e})"),
-                type=ProxyErrorTypes.auth_error,
-                param=openai_error_param(e),
-                code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
-            )
-        elif isinstance(e, ProxyException):
-            raise e
-        raise ProxyException(
-            message="Authentication Error, " + str(e),
-            type=ProxyErrorTypes.auth_error,
-            param=openai_error_param(e),
-            code=status.HTTP_400_BAD_REQUEST,
-        )
+        raise proxy_exception_for(e, default_status_code=status.HTTP_400_BAD_REQUEST) from e
 
 
 #### MODEL MANAGEMENT ####
@@ -2084,21 +2056,7 @@ async def update_model(
             return model_response
     except Exception as e:
         verbose_proxy_logger.exception("litellm.proxy.proxy_server.update_model(): Exception occured - %s", e)
-        if isinstance(e, HTTPException):
-            raise ProxyException(
-                message=getattr(e, "detail", f"Authentication Error({e})"),
-                type=ProxyErrorTypes.auth_error,
-                param=openai_error_param(e),
-                code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
-            )
-        elif isinstance(e, ProxyException):
-            raise e
-        raise ProxyException(
-            message="Authentication Error, " + str(e),
-            type=ProxyErrorTypes.auth_error,
-            param=openai_error_param(e),
-            code=status.HTTP_400_BAD_REQUEST,
-        )
+        raise proxy_exception_for(e, default_status_code=status.HTTP_400_BAD_REQUEST) from e
 
 
 @router.post(

--- a/litellm/proxy/management_endpoints/organization_endpoints.py
+++ b/litellm/proxy/management_endpoints/organization_endpoints.py
@@ -32,7 +32,7 @@ from litellm._uuid import uuid
 from litellm.proxy._types import *
 from litellm.proxy.auth.auth_checks import can_user_call_model, get_user_object
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
-from litellm.proxy.common_utils.openai_error_payload import openai_error_param
+from litellm.proxy.common_utils.openai_error_payload import proxy_exception_for
 from litellm.proxy.common_utils.timezone_utils import get_budget_reset_time
 from litellm.proxy.management_endpoints.budget_management_endpoints import (
     new_budget,
@@ -1269,21 +1269,7 @@ async def organization_member_add(
         )
     except Exception as e:
         verbose_proxy_logger.exception("Error adding member to organization: %s", e)
-        if isinstance(e, HTTPException):
-            raise ProxyException(
-                message=getattr(e, "detail", f"Authentication Error({e})"),
-                type=ProxyErrorTypes.auth_error,
-                param=openai_error_param(e),
-                code=getattr(e, "status_code", status.HTTP_500_INTERNAL_SERVER_ERROR),
-            )
-        elif isinstance(e, ProxyException):
-            raise e
-        raise ProxyException(
-            message="Authentication Error, " + str(e),
-            type=ProxyErrorTypes.auth_error,
-            param=openai_error_param(e),
-            code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-        )
+        raise proxy_exception_for(e, default_status_code=status.HTTP_500_INTERNAL_SERVER_ERROR) from e
 
 
 async def find_member_if_email(user_email: str, prisma_client: PrismaClient) -> LiteLLM_UserTable:

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -92,7 +92,7 @@ from litellm.proxy.auth.auth_utils import (
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.proxy.common_utils.callback_utils import encrypt_callback_vars
 from litellm.proxy.common_utils.json_merge_patch import apply_json_merge_patch
-from litellm.proxy.common_utils.openai_error_payload import openai_error_param
+from litellm.proxy.common_utils.openai_error_payload import proxy_exception_for
 from litellm.proxy.common_utils.user_api_key_cache import UserApiKeyCache
 from litellm.proxy.management_endpoints.common_daily_activity import (
     get_daily_activity_aggregated,
@@ -4458,21 +4458,7 @@ async def team_info(
             e,
             traceback.format_exc(),
         )
-        if isinstance(e, HTTPException):
-            raise ProxyException(
-                message=getattr(e, "detail", f"Authentication Error({e})"),
-                type=ProxyErrorTypes.auth_error,
-                param=openai_error_param(e),
-                code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
-            )
-        elif isinstance(e, ProxyException):
-            raise e
-        raise ProxyException(
-            message="Authentication Error, " + str(e),
-            type=ProxyErrorTypes.auth_error,
-            param=openai_error_param(e),
-            code=status.HTTP_400_BAD_REQUEST,
-        )
+        raise proxy_exception_for(e, default_status_code=status.HTTP_400_BAD_REQUEST) from e
 
 
 @router.get(

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -116,6 +116,7 @@ from litellm.proxy.common_utils.openai_error_payload import (
     error_status_code,
     openai_error_param,
     openai_error_type,
+    proxy_exception_for,
 )
 from litellm.proxy.common_utils.realtime_utils import _realtime_request_body
 from litellm.router_utils.add_retry_fallback_headers import (
@@ -15248,21 +15249,7 @@ async def async_queue_request(
         await proxy_logging_obj.post_call_failure_hook(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
-        if isinstance(e, HTTPException):
-            raise ProxyException(
-                message=getattr(e, "detail", f"Authentication Error({e})"),
-                type=ProxyErrorTypes.auth_error,
-                param=openai_error_param(e),
-                code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
-            )
-        elif isinstance(e, ProxyException):
-            raise e
-        raise ProxyException(
-            message="Authentication Error, " + str(e),
-            type=ProxyErrorTypes.auth_error,
-            param=openai_error_param(e),
-            code=status.HTTP_400_BAD_REQUEST,
-        )
+        raise proxy_exception_for(e, default_status_code=status.HTTP_400_BAD_REQUEST) from e
 
 
 @app.get("/fallback/login", tags=["experimental"], include_in_schema=False)
@@ -16466,21 +16453,7 @@ async def update_config(
     except Exception as e:
         verbose_proxy_logger.error("litellm.proxy.proxy_server.update_config(): Exception occured - %s", e)
         verbose_proxy_logger.debug(traceback.format_exc())
-        if isinstance(e, HTTPException):
-            raise ProxyException(
-                message=getattr(e, "detail", f"Authentication Error({e})"),
-                type=ProxyErrorTypes.auth_error,
-                param=openai_error_param(e),
-                code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
-            )
-        elif isinstance(e, ProxyException):
-            raise e
-        raise ProxyException(
-            message="Authentication Error, " + str(e),
-            type=ProxyErrorTypes.auth_error,
-            param=openai_error_param(e),
-            code=status.HTTP_400_BAD_REQUEST,
-        )
+        raise proxy_exception_for(e, default_status_code=status.HTTP_400_BAD_REQUEST) from e
 
 
 ### CONFIG GENERAL SETTINGS
@@ -17465,21 +17438,7 @@ async def get_config(
         }
     except Exception as e:
         verbose_proxy_logger.exception("litellm.proxy.proxy_server.get_config(): Exception occured - %s", e)
-        if isinstance(e, HTTPException):
-            raise ProxyException(
-                message=getattr(e, "detail", f"Authentication Error({e})"),
-                type=ProxyErrorTypes.auth_error,
-                param=openai_error_param(e),
-                code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
-            )
-        elif isinstance(e, ProxyException):
-            raise e
-        raise ProxyException(
-            message="Authentication Error, " + str(e),
-            type=ProxyErrorTypes.auth_error,
-            param=openai_error_param(e),
-            code=status.HTTP_400_BAD_REQUEST,
-        )
+        raise proxy_exception_for(e, default_status_code=status.HTTP_400_BAD_REQUEST) from e
 
 
 @router.get(

--- a/tests/test_litellm/proxy/common_utils/test_openai_error_payload.py
+++ b/tests/test_litellm/proxy/common_utils/test_openai_error_payload.py
@@ -8,6 +8,7 @@ from litellm.proxy.common_utils.openai_error_payload import (
     error_status_code,
     openai_error_param,
     openai_error_type,
+    proxy_exception_for,
 )
 
 
@@ -115,3 +116,88 @@ def test_a_status_carried_by_an_exception_drives_the_type_it_reports():
     exc = HTTPException(status_code=403, detail="blocked by policy")
 
     assert openai_error_type(exc, error_status_code(exc, 400)) == "permission_error"
+
+
+@pytest.mark.parametrize(
+    "raised_status, expected_type",
+    [
+        (400, "invalid_request_error"),
+        (404, "invalid_request_error"),
+        (403, "permission_error"),
+        (422, "invalid_request_error"),
+        (500, "internal_server_error"),
+    ],
+)
+def test_a_blanket_handler_keeps_the_status_its_route_answered_with(raised_status, expected_type):
+    """The handler wraps whatever the route raised, so the status the caller sees must be the
+    one the route chose, and the type must follow that status rather than the route's default."""
+    wrapped = proxy_exception_for(
+        HTTPException(status_code=raised_status, detail={"message": "boom"}),
+        default_status_code=400,
+    )
+
+    assert (wrapped.code, wrapped.type) == (str(raised_status), expected_type)
+
+
+@pytest.mark.parametrize("default_status_code, expected_type", [(400, "invalid_request_error"), (500, "internal_server_error")])
+def test_an_exception_carrying_no_status_falls_back_to_the_routes_default(default_status_code, expected_type):
+    wrapped = proxy_exception_for(ValueError("boom"), default_status_code=default_status_code)
+
+    assert (wrapped.code, wrapped.type) == (str(default_status_code), expected_type)
+
+
+def test_a_proxy_exception_passes_through_with_the_type_it_already_named():
+    """Re-wrapping one would overwrite a type the raising code chose deliberately, which is
+    what the ``elif isinstance(e, ProxyException): raise e`` branch existed to prevent."""
+    raised = ProxyException(
+        message="Budget has been exceeded",
+        type=ProxyErrorTypes.budget_exceeded.value,
+        param="max_budget",
+        code=400,
+    )
+
+    assert proxy_exception_for(raised, default_status_code=500) is raised
+
+
+def test_a_rejection_is_never_labelled_an_auth_failure():
+    """The bug: every management route's blanket handler asserted auth_error, so a 404 for a
+    team that does not exist told a client its credentials were the problem."""
+    wrapped = proxy_exception_for(
+        HTTPException(status_code=404, detail={"message": "Team not found, passed team id: no-such-team."}),
+        default_status_code=400,
+    )
+
+    assert wrapped.type != ProxyErrorTypes.auth_error.value
+    assert "Authentication Error" not in wrapped.message
+
+
+def test_the_message_is_what_the_route_raised_without_an_invented_prefix():
+    assert proxy_exception_for(ValueError("boom"), default_status_code=400).message == "boom"
+
+
+def test_an_http_exceptions_detail_survives_the_wrapping():
+    wrapped = proxy_exception_for(
+        HTTPException(status_code=400, detail={"error": "Invalid budget_duration 'not-a-duration'."}),
+        default_status_code=400,
+    )
+
+    assert "Invalid budget_duration" in wrapped.message
+
+
+def test_a_carried_type_survives_the_wrapping():
+    """A litellm exception already names its type; deriving one from the status would lose it."""
+
+    class _Carrier(Exception):
+        type = "context_window_exceeded"
+        status_code = 400
+
+    assert proxy_exception_for(_Carrier("boom"), default_status_code=500).type == "context_window_exceeded"
+
+
+@pytest.mark.parametrize("exc", [HTTPException(status_code=404, detail="nope"), ValueError("boom")])
+def test_the_wrapped_error_serializes_as_an_openai_error_object(exc):
+    body = json.loads(json.dumps({"error": proxy_exception_for(exc, default_status_code=400).to_dict()}))
+
+    assert body["error"]["param"] is None
+    assert isinstance(body["error"]["type"], str)
+    assert body["error"]["type"] != "None"

--- a/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
+++ b/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
@@ -1092,12 +1092,17 @@ async def test_health_services_endpoint_rejects_unknown_service():
 @pytest.mark.asyncio
 async def test_health_services_endpoint_rejection_is_openai_shaped():
     """A caller mistake here must serialize as an OpenAI error object: a real
-    `type` string and a JSON null `param`, never the literal string "None"."""
+    `type` string and a JSON null `param`, never the literal string "None".
+
+    The type names what actually went wrong, too. This route answered 400 with
+    `auth_error` on a valid admin key, blaming the caller's credentials for a
+    service name it mistyped."""
     with pytest.raises(ProxyException) as exc_info:
         await health_services_endpoint(service="totally_unknown_service_xyz")
 
     body = json.loads(json.dumps({"error": exc_info.value.to_dict()}))
-    assert body["error"]["type"] == "auth_error"
+    assert body["error"]["type"] == "invalid_request_error"
+    assert body["error"]["code"] == "400"
     assert body["error"]["param"] is None
 
 

--- a/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
@@ -4305,3 +4305,22 @@ async def test_user_update_hashes_and_persists_strong_password(_admin_prisma, mo
     written_data = mock_prisma_client.update_data.call_args.kwargs["data"]
     assert written_data.get("password") is not None
     assert written_data["password"] != strong_password
+
+
+@pytest.mark.asyncio
+async def test_user_update_reports_a_bad_budget_duration_as_a_request_error(_admin_prisma):
+    """/user/update answered 400 with type=auth_error for an unparseable budget_duration on a
+    valid admin key, pointing the caller at its credentials instead of the field it sent."""
+    from litellm.proxy._types import ProxyErrorTypes
+    from litellm.proxy.management_endpoints.internal_user_endpoints import user_update
+
+    with pytest.raises(ProxyException) as exc_info:
+        await user_update(
+            data=UpdateUserRequest(user_id="target-user", budget_duration="not-a-duration"),
+            user_api_key_dict=UserAPIKeyAuth(user_id="admin-1", user_role=LitellmUserRoles.PROXY_ADMIN),
+        )
+
+    assert exc_info.value.code == "400"
+    assert exc_info.value.type == "invalid_request_error"
+    assert exc_info.value.type != ProxyErrorTypes.auth_error.value
+    assert "Invalid budget_duration" in exc_info.value.message

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -17555,3 +17555,29 @@ def test_key_health_failure_body_is_openai_shaped():
     assert error["type"] == "internal_server_error"
     assert error["param"] is None
     assert error["code"] == "500"
+
+
+@pytest.mark.asyncio
+async def test_update_key_reports_a_bad_budget_duration_as_a_request_error():
+    """/key/update answered 400 with type=auth_error for an unparseable budget_duration on a
+    valid admin key, so the client could not tell a rejected field from a rejected key."""
+    from fastapi import Request
+
+    from litellm.proxy._types import ProxyErrorTypes
+    from litellm.proxy.management_endpoints.key_management_endpoints import update_key_fn
+
+    mock_prisma = MagicMock()
+
+    with patch(  # test-quality-ok: the endpoint reads proxy_server.prisma_client itself; no parameter to inject
+        "litellm.proxy.proxy_server.prisma_client", mock_prisma
+    ):
+        with pytest.raises(ProxyException) as exc_info:
+            await update_key_fn(
+                request=MagicMock(spec=Request),
+                data=UpdateKeyRequest(key="sk-whatever", budget_duration="not-a-duration"),
+                user_api_key_dict=UserAPIKeyAuth(user_id="admin-1", user_role=LitellmUserRoles.PROXY_ADMIN),
+            )
+
+    assert exc_info.value.code == "400"
+    assert exc_info.value.type == "invalid_request_error"
+    assert exc_info.value.type != ProxyErrorTypes.auth_error.value

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -4654,3 +4654,48 @@ class TestBlockModelResponseSerialization:
         assert body["model_id"] == "m-block-1"
         assert body["blocked"] is blocked
         assert body["litellm_params"] == {"model": "openai/gpt-4o-mini", "api_key": "encrypted-value"}
+
+
+@pytest.mark.asyncio
+async def test_delete_model_reports_an_unknown_model_id_as_a_request_error():
+    """/model/delete answered 400 with type=auth_error for a model id that is not in the db,
+    on a valid admin key, so the type told the client nothing about what it got wrong."""
+    from litellm.proxy._types import ModelInfoDelete, ProxyErrorTypes, ProxyException
+    from litellm.proxy.management_endpoints.model_management_endpoints import delete_model
+
+    mock_prisma = MagicMock()
+    mock_prisma.db.litellm_proxymodeltable.find_unique = AsyncMock(return_value=None)
+
+    with patch(  # test-quality-ok: the endpoint reads proxy_server.prisma_client itself; no parameter to inject
+        "litellm.proxy.proxy_server.prisma_client", mock_prisma
+    ):
+        with pytest.raises(ProxyException) as exc_info:
+            await delete_model(
+                model_info=ModelInfoDelete(id="no-such-model"),
+                user_api_key_dict=UserAPIKeyAuth(user_id="admin-1", user_role=LitellmUserRoles.PROXY_ADMIN),
+            )
+
+    assert exc_info.value.code == "400"
+    assert exc_info.value.type == "invalid_request_error"
+    assert exc_info.value.type != ProxyErrorTypes.auth_error.value
+
+
+def test_a_real_authorization_failure_on_the_model_routes_keeps_its_auth_error_type():
+    """The other half of the fix: /model/new's credential check is a genuine authorization
+    failure, so the handler must hand its ProxyException back untouched rather than relabel it."""
+    from fastapi import status
+
+    from litellm.proxy._types import ProxyErrorTypes, ProxyException
+    from litellm.proxy.common_utils.openai_error_payload import proxy_exception_for
+
+    with pytest.raises(ProxyException) as exc_info:
+        ModelManagementAuthChecks.can_user_attach_credential(
+            litellm_params=LiteLLM_Params(model="gpt-4o", litellm_credential_name="shared-cred"),
+            user_api_key_dict=UserAPIKeyAuth(user_id="someone", user_role=LitellmUserRoles.INTERNAL_USER),
+        )
+
+    wrapped = proxy_exception_for(exc_info.value, default_status_code=status.HTTP_400_BAD_REQUEST)
+
+    assert wrapped is exc_info.value
+    assert wrapped.code == "403"
+    assert wrapped.type == ProxyErrorTypes.auth_error.value

--- a/tests/test_litellm/proxy/management_endpoints/test_organization_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_organization_endpoints.py
@@ -1063,3 +1063,42 @@ async def test_find_member_if_email_missing_row_raises_documented_400():
             "non-existent user_email in LiteLLM_UserTable. Use 'user_id' instead."
         )
     }
+
+
+@pytest.mark.asyncio
+async def test_organization_member_add_reports_an_unknown_org_as_a_request_error():
+    """/organization/member_add answered 404 with type=auth_error on a valid admin key. The
+    404 the route raised must survive the handler's 500 default, and the type must follow it."""
+    from fastapi import Request
+
+    from litellm.proxy._types import (
+        LitellmUserRoles,
+        OrganizationMemberAddRequest,
+        OrgMember,
+        ProxyErrorTypes,
+        ProxyException,
+        UserAPIKeyAuth,
+    )
+    from litellm.proxy.management_endpoints.organization_endpoints import (
+        organization_member_add,
+    )
+
+    mock_prisma = MagicMock()
+    mock_prisma.db.litellm_organizationtable.find_unique = AsyncMock(return_value=None)
+
+    with patch(  # test-quality-ok: the endpoint reads proxy_server.prisma_client itself; no parameter to inject
+        "litellm.proxy.proxy_server.prisma_client", mock_prisma
+    ):
+        with pytest.raises(ProxyException) as exc_info:
+            await organization_member_add(
+                data=OrganizationMemberAddRequest(
+                    organization_id="no-such-org",
+                    member=OrgMember(role="internal_user", user_id="someone"),
+                ),
+                http_request=MagicMock(spec=Request),
+                user_api_key_dict=UserAPIKeyAuth(user_id="admin-1", user_role=LitellmUserRoles.PROXY_ADMIN),
+            )
+
+    assert exc_info.value.code == "404"
+    assert exc_info.value.type == "invalid_request_error"
+    assert exc_info.value.type != ProxyErrorTypes.auth_error.value

--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
@@ -13519,3 +13519,31 @@ async def test_team_member_update_skips_invalidation_when_no_budget_fields_sent(
 
     assert await real_cache.async_get_cache(key="team-1_member-1") == "still-fresh-membership"
     assert real_spend_counter_cache.in_memory_cache.get_cache(key="spend:team_member:member-1:team-1") == 1.5
+
+
+@pytest.mark.asyncio
+async def test_team_info_reports_a_missing_team_as_a_request_error_not_an_auth_error():
+    """/team/info answered 404 with type=auth_error on a valid admin key, so a client
+    branching on the type retried the credentials instead of the team id."""
+    from fastapi import Request
+
+    from litellm.proxy._types import ProxyErrorTypes, ProxyException
+    from litellm.proxy.management_endpoints import team_endpoints
+
+    mock_prisma = MagicMock()
+    mock_prisma.db.litellm_teamtable.find_unique = AsyncMock(return_value=None)
+
+    with patch(  # test-quality-ok: the endpoint reads proxy_server.prisma_client itself; no parameter to inject
+        "litellm.proxy.proxy_server.prisma_client", mock_prisma
+    ):
+        with pytest.raises(ProxyException) as exc_info:
+            await team_endpoints.team_info(
+                http_request=MagicMock(spec=Request),
+                team_id="no-such-team",
+                user_api_key_dict=UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN),
+            )
+
+    assert exc_info.value.code == "404"
+    assert exc_info.value.type == "invalid_request_error"
+    assert exc_info.value.type != ProxyErrorTypes.auth_error.value
+    assert "Authentication Error" not in exc_info.value.message

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -12518,3 +12518,48 @@ def test_assistants_error_body_is_openai_shaped(client_no_auth):
     error = response.json()["error"]
     assert error["type"] == "internal_server_error"
     assert error["param"] is None
+
+
+@pytest.mark.asyncio
+async def test_update_config_reports_an_unsupported_router_setting_as_a_request_error():
+    """/config/update answered 400 with type=auth_error for a router setting it does not
+    support, on a valid admin key, so the type blamed the credentials for a body mistake."""
+    from fastapi import Request
+
+    from litellm.proxy._types import ConfigYAML, ProxyErrorTypes, ProxyException
+    from litellm.proxy.proxy_server import update_config
+
+    body = {"router_settings": {"not_a_router_setting": True}}
+    request = MagicMock(spec=Request)
+    request.json = AsyncMock(return_value=body)
+
+    with pytest.raises(ProxyException) as exc_info:
+        await update_config(
+            config_info=ConfigYAML(**body),
+            request=request,
+            user_api_key_dict=UserAPIKeyAuth(user_id="admin-1", user_role=LitellmUserRoles.PROXY_ADMIN),
+        )
+
+    assert exc_info.value.code == "400"
+    assert exc_info.value.type == "invalid_request_error"
+    assert exc_info.value.type != ProxyErrorTypes.auth_error.value
+
+
+@pytest.mark.asyncio
+async def test_update_config_reports_a_non_admin_caller_as_a_permission_error():
+    """A real authorization failure keeps an auth-family type, and 403 is `permission_error`
+    in OpenAI's contract, which `auth_error` never was."""
+    from fastapi import Request
+
+    from litellm.proxy._types import ConfigYAML, ProxyException
+    from litellm.proxy.proxy_server import update_config
+
+    with pytest.raises(ProxyException) as exc_info:
+        await update_config(
+            config_info=ConfigYAML(),
+            request=MagicMock(spec=Request),
+            user_api_key_dict=UserAPIKeyAuth(user_id="viewer-1", user_role=LitellmUserRoles.INTERNAL_USER),
+        )
+
+    assert exc_info.value.code == "403"
+    assert exc_info.value.type == "permission_error"


### PR DESCRIPTION
## TLDR

Problem this solves:

- Management routes label every rejection `type: auth_error`
- `/team/info` says `auth_error` for a team that does not exist
- `/user/update` says `auth_error` for a bad `budget_duration`
- `auth_error` is not an OpenAI error type at all
- Clients branching on `type` retry the key, not the field

How it solves it:

- Blanket handlers read the type off the exception
- Every status each branch answered with is kept
- Deliberate `ProxyException`s pass through with their own type
- Genuine auth and SSO sites keep `auth_error`, untouched

## User Flow

Before: a platform admin scripting the management API with a valid admin key gets every rejection labelled an auth failure, so the client re-authenticates in a loop instead of fixing the request

1. They call `GET https://litellm-domain/team/info?team_id=no-such-team-6842` with `Authorization: Bearer <admin key>`
2. It comes back `404` with `{"error":{"message":"Team not found, passed team id: no-such-team-6842.","type":"auth_error","param":null,"code":"404"}}`
3. Their client branches on `error.type`, reads `auth_error`, refreshes the admin key, and retries the same bad team id, looping until it gives up
4. They call `POST https://litellm-domain/user/update` with `{"user_id":"u6842repro","budget_duration":"not-a-duration"}` and get `400` with `"type":"auth_error"` and a message prefixed `Authentication Error, `
5. The same happens on `POST /key/update`, `POST /organization/member_add`, `POST /model/new`, `POST /model/update`, `POST /model/delete`, `GET /health/services`, `POST /queue/chat/completions` and `POST /config/update`
6. They send a genuinely bad key to `GET https://litellm-domain/team/info` and get `401` with an auth-flavoured type as well, so nothing in the response body tells them which of the two problems they actually have

After: the same calls come back with the type that matches what went wrong, so the client fixes the field and only retries credentials when the credentials are the problem

1. They call `GET https://litellm-domain/team/info?team_id=no-such-team-6842` with `Authorization: Bearer <admin key>`
2. It comes back `404` with `{"error":{"message":"Team not found, passed team id: no-such-team-6842.","type":"invalid_request_error","param":null,"code":"404"}}`, and the message no longer carries the `Authentication Error, ` prefix
3. Their client reads `invalid_request_error`, stops retrying the key, and surfaces the bad team id to the operator
4. They call `POST https://litellm-domain/user/update` with the same bad `budget_duration` and get `400` with `"type":"invalid_request_error"`
5. The other routes answer the same way, each keeping the status it already returned: a `404` or `400` or `422` now says `invalid_request_error`, a `500` says `internal_server_error`, a `403` says `permission_error`
6. They send a genuinely bad key to `GET https://litellm-domain/team/info` and still get `401` with `"type":"token_not_found_in_db"`, and `POST https://litellm-domain/login` with a wrong password still answers `401` with `"type":"auth_error"`, so a real credential failure is now distinguishable from a bad team id

## Scope

92 sites across 14 files pin `ProxyErrorTypes.auth_error`. This PR changes 22 of them, in the 11 blanket `except Exception` blocks that guard a management or health route, and deliberately leaves the other 70.

Changed, one line each, all now going through a shared `proxy_exception_for` helper:

| Route | Handler default | Status seen | Type before | Type after |
|---|---|---|---|---|
| `POST /user/update` | 400 | 400 | auth_error | invalid_request_error |
| `POST /key/update` | 400 | 400 | auth_error | invalid_request_error |
| `GET /team/info` | 400 | 404 | auth_error | invalid_request_error |
| `POST /organization/member_add` | 500 | 404 | auth_error | invalid_request_error |
| `POST /model/delete` | 400 | 400 | auth_error | invalid_request_error |
| `POST /model/update` | 400 | 400 | auth_error | invalid_request_error |
| `POST /model/new` | 400 | 500 | auth_error | internal_server_error |
| `GET /health/services` | 500 | 400 | auth_error | invalid_request_error |
| `POST /queue/chat/completions` | 400 | 400 | auth_error | invalid_request_error |
| `POST /config/update` | 400 | 400 | auth_error | invalid_request_error |
| `GET /get/config/callbacks` | 400 | 400 | auth_error | invalid_request_error |

Left alone on purpose:

| Left alone | Sites | Reason |
|---|---|---|
| `litellm/proxy/auth/` | 21 | real credential and JWT failures |
| `management_endpoints/ui_sso.py` | 36 | real SSO login failures |
| `proxy_server.py` login and onboarding | 9 | real login failures |
| `model_management_endpoints.py` 403 checks | 3 | real authorization denials |
| `utils.py` `handle_exception_on_proxy` | 1 | PR #39555 owns that handler |

The last row is why the diff stops where it does: the shared handler is being fixed separately, so touching it here would collide.

`list_keys` and `key_aliases` in `key_management_endpoints.py` are the near miss. Both wrap their body in the same blanket `except Exception`, and both still hardcode `message="Authentication Error, " + str(e)` while passing the caught exception's own status through, so a 400 there answers `internal_server_error` with an auth-flavoured message. Neither is one of the 92 `auth_error` sites, so neither is in this ticket's scope, and folding them in would widen the diff and force the whole QA to run again. They are worth their own follow-up.

## Base branch

This branches off `litellm_openai_error_payload_spend_management` (PR #39542), not off `litellm_internal_staging`, and can only merge once #39521, #39536, #39540 and #39542 land ahead of it. Two reasons: `litellm/proxy/common_utils/openai_error_payload.py`, which the fix extends, does not exist on staging yet, and #39540 and #39542 rewrite the `param=` line directly above every one of the 22 `type=` lines this PR replaces. Branching off staging would have meant a duplicate copy of that module plus 22 guaranteed conflicts.

## Relevant issues

## Linear ticket

Resolves LIT-6842

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Two live proxies, same config, same cases, same order, differing only in the commit they booted from.
Each ran two uvicorn workers against its own Postgres database, and every call below uses a valid
admin key.

Boot on either side:

```bash
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --port <port> --num_workers 2 --use_v2_migration_resolver
```

Before ran on port 21550, After on port 31620.

### Before (f9051a16bb)

#### 1. Sanity: a real provider call succeeds

1. Run:

```bash
curl -sS -X POST 'http://127.0.0.1:21550/v1/chat/completions' -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"model":"anthropic-haiku-4-5","messages":[{"role":"user","content":"say lit6842 and nothing else"}],"max_tokens":16}'
```

2. Observed, HTTP 200:

```json
{"id":"chatcmpl-f62b3ddf-1008-442e-9c59-035d62f33319","model":"anthropic-haiku-4-5","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"lit6842","role":"assistant"}}],"usage":{"completion_tokens":6,"prompt_tokens":15,"total_tokens":21}}
```

#### 2. `GET /team/info`, team that does not exist

1. Run:

```bash
curl -sS -X GET 'http://127.0.0.1:21550/team/info?team_id=no-such-team-6842' -H 'Authorization: Bearer sk-1234'
```

2. Observed, HTTP 404:

```json
{"error":{"message":"{'message': 'Team not found, passed team id: no-such-team-6842.'}","type":"auth_error","param":null,"code":"404"}}
```

#### 3. `POST /user/update`, unparseable `budget_duration`

1. Run:

```bash
curl -sS -X POST 'http://127.0.0.1:21550/user/update' -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"user_id":"u6842repro","budget_duration":"not-a-duration"}'
```

2. Observed, HTTP 400:

```json
{"error":{"message":"{'error': \"Invalid budget_duration 'not-a-duration'. Use a format like '1h', '24h', '7d', or '30d'.\"}","type":"auth_error","param":null,"code":"400"}}
```

#### 4. `POST /key/update`, unparseable `budget_duration`

1. Run:

```bash
curl -sS -X POST 'http://127.0.0.1:21550/key/update' -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"key":"<a key from /key/generate on that leg>","budget_duration":"not-a-duration"}'
```

2. Observed, HTTP 400:

```json
{"error":{"message":"{'error': \"Invalid budget_duration 'not-a-duration'. Use a format like '1h', '24h', '7d', or '30d'.\"}","type":"auth_error","param":null,"code":"400"}}
```

#### 5. `POST /organization/member_add`, organization that does not exist

1. Run:

```bash
curl -sS -X POST 'http://127.0.0.1:21550/organization/member_add' -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"organization_id":"no-such-org-6842","member":{"role":"internal_user","user_email":"lit6842@example.com"}}'
```

2. Observed, HTTP 404:

```json
{"error":{"message":"{'error': 'Organization not found for organization_id=no-such-org-6842'}","type":"auth_error","param":null,"code":"404"}}
```

#### 6. `POST /model/delete`, model id that does not exist

1. Run:

```bash
curl -sS -X POST 'http://127.0.0.1:21550/model/delete' -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"id":"no-such-model-6842"}'
```

2. Observed, HTTP 400:

```json
{"error":{"message":"{'error': 'Model with id=no-such-model-6842 not found in db'}","type":"auth_error","param":null,"code":"400"}}
```

#### 7. `POST /model/update`, model id that does not exist

1. Run:

```bash
curl -sS -X POST 'http://127.0.0.1:21550/model/update' -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"model_name":"lit6842-ghost","litellm_params":{"model":"openai/gpt-4o-mini"},"model_info":{"id":"no-such-model-6842"}}'
```

2. Observed, HTTP 400:

```json
{"error":{"message":"Authentication Error, model not found","type":"auth_error","param":null,"code":"400"}}
```

#### 8. `POST /model/new`, same `model_info.id` twice, so the db write fails

1. Run:

```bash
curl -sS -X POST 'http://127.0.0.1:21550/model/new' -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"model_name":"lit6842-dup","litellm_params":{"model":"openai/gpt-4o-mini"},"model_info":{"id":"lit6842-fixed-id"}}'
```

2. Observed, HTTP 500:

```json
{"error":{"message":"{'error': 'Failed to add model to db. Check your server logs for more details.'}","type":"auth_error","param":null,"code":"500"}}
```

#### 9. `GET /health/services`, service name that is not in the list

1. Run:

```bash
curl -sS -X GET 'http://127.0.0.1:21550/health/services?service=not-a-service' -H 'Authorization: Bearer sk-1234'
```

2. Observed, HTTP 400:

```json
{"error":{"message":"{'error': \"Service must be in list. Service=not-a-service not in typing.Union[typing.Literal['slack_budget_alerts', 'langfuse', ...], str]\"}","type":"auth_error","param":null,"code":"400"}}
```

#### 10. `POST /queue/chat/completions`, no `priority`

1. Run:

```bash
curl -sS -X POST 'http://127.0.0.1:21550/queue/chat/completions' -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"model":"anthropic-haiku-4-5","messages":[{"role":"user","content":"hi"}]}'
```

2. Observed, HTTP 400:

```json
{"error":{"message":"Authentication Error, Router.schedule_acompletion() missing 1 required positional argument: 'priority'","type":"auth_error","param":null,"code":"400"}}
```

#### 11. `POST /queue/chat/completions`, valid `priority`, model that does not exist

1. Run:

```bash
curl -sS -X POST 'http://127.0.0.1:21550/queue/chat/completions' -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"model":"no-such-model-6842","messages":[{"role":"user","content":"hi"}],"priority":0}'
```

2. Observed, HTTP 400:

```json
{"error":{"message":"Authentication Error, litellm.BadRequestError: You passed in model=no-such-model-6842. There are no healthy deployments for this model. Received Model Group=no-such-model-6842\nAvailable Model Group Fallbacks=None","type":"auth_error","param":null,"code":"400"}}
```

#### 12. `POST /config/update`, `success_callback` that is not a list of strings

1. Run:

```bash
curl -sS -X POST 'http://127.0.0.1:21550/config/update' -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"litellm_settings":{"success_callback":[{"not":"a-string"}]}}'
```

2. Observed, HTTP 400:

```json
{"error":{"message":"Authentication Error, unhashable type: 'dict'","type":"auth_error","param":null,"code":"400"}}
```

#### 13. `GET /get/config/callbacks`, after a scalar `success_callback` is stored

1. Run:

```bash
curl -sS -X POST 'http://127.0.0.1:21550/config/update' -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"litellm_settings":{"success_callback":5}}'
curl -sS -X GET 'http://127.0.0.1:21550/get/config/callbacks' -H 'Authorization: Bearer sk-1234'
```

2. Observed, HTTP 400:

```json
{"error":{"message":"Authentication Error, 'int' object is not iterable","type":"auth_error","param":null,"code":"400"}}
```

#### 14. Auth control: `GET /team/info` with a key that does not exist

1. Run:

```bash
curl -sS -X GET 'http://127.0.0.1:21550/team/info?team_id=whatever' -H 'Authorization: Bearer sk-not-a-real-key-6842'
```

2. Observed, HTTP 401:

```json
{"error":{"message":"Authentication Error, Invalid proxy server token passed. Received API Key = sk-...6842, Key Hash (Token) =249e3414...","type":"token_not_found_in_db","param":"key","code":"401"}}
```

#### 15. Auth control: `POST /login` with the wrong password

1. Run:

```bash
curl -sS -X POST 'http://127.0.0.1:21550/login' -d 'username=admin&password=definitely-wrong-6842'
```

2. Observed, HTTP 401:

```json
{"error":{"message":"Invalid credentials used to access UI.\nCheck 'UI_USERNAME', 'UI_PASSWORD' in .env file","type":"auth_error","param":"invalid_credentials","code":"401"}}
```

### After (0c38a256ee)

#### 1. Sanity: a real provider call succeeds

1. Run:

```bash
curl -sS -X POST 'http://127.0.0.1:31620/v1/chat/completions' -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"model":"anthropic-haiku-4-5","messages":[{"role":"user","content":"say lit6842 and nothing else"}],"max_tokens":16}'
```

2. Observed, HTTP 200:

```json
{"id":"chatcmpl-b9411883-0ab9-4228-a511-597574650218","model":"anthropic-haiku-4-5","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"lit6842","role":"assistant"}}],"usage":{"completion_tokens":6,"prompt_tokens":15,"total_tokens":21}}
```

#### 2. `GET /team/info`, team that does not exist

1. Run:

```bash
curl -sS -X GET 'http://127.0.0.1:31620/team/info?team_id=no-such-team-6842' -H 'Authorization: Bearer sk-1234'
```

2. Observed, HTTP 404:

```json
{"error":{"message":"{'message': 'Team not found, passed team id: no-such-team-6842.'}","type":"invalid_request_error","param":null,"code":"404"}}
```

#### 3. `POST /user/update`, unparseable `budget_duration`

1. Run:

```bash
curl -sS -X POST 'http://127.0.0.1:31620/user/update' -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"user_id":"u6842repro","budget_duration":"not-a-duration"}'
```

2. Observed, HTTP 400:

```json
{"error":{"message":"{'error': \"Invalid budget_duration 'not-a-duration'. Use a format like '1h', '24h', '7d', or '30d'.\"}","type":"invalid_request_error","param":null,"code":"400"}}
```

#### 4. `POST /key/update`, unparseable `budget_duration`

1. Run:

```bash
curl -sS -X POST 'http://127.0.0.1:31620/key/update' -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"key":"<a key from /key/generate on that leg>","budget_duration":"not-a-duration"}'
```

2. Observed, HTTP 400:

```json
{"error":{"message":"{'error': \"Invalid budget_duration 'not-a-duration'. Use a format like '1h', '24h', '7d', or '30d'.\"}","type":"invalid_request_error","param":null,"code":"400"}}
```

#### 5. `POST /organization/member_add`, organization that does not exist

1. Run:

```bash
curl -sS -X POST 'http://127.0.0.1:31620/organization/member_add' -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"organization_id":"no-such-org-6842","member":{"role":"internal_user","user_email":"lit6842@example.com"}}'
```

2. Observed, HTTP 404:

```json
{"error":{"message":"{'error': 'Organization not found for organization_id=no-such-org-6842'}","type":"invalid_request_error","param":null,"code":"404"}}
```

#### 6. `POST /model/delete`, model id that does not exist

1. Run:

```bash
curl -sS -X POST 'http://127.0.0.1:31620/model/delete' -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"id":"no-such-model-6842"}'
```

2. Observed, HTTP 400:

```json
{"error":{"message":"{'error': 'Model with id=no-such-model-6842 not found in db'}","type":"invalid_request_error","param":null,"code":"400"}}
```

#### 7. `POST /model/update`, model id that does not exist

1. Run:

```bash
curl -sS -X POST 'http://127.0.0.1:31620/model/update' -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"model_name":"lit6842-ghost","litellm_params":{"model":"openai/gpt-4o-mini"},"model_info":{"id":"no-such-model-6842"}}'
```

2. Observed, HTTP 400:

```json
{"error":{"message":"model not found","type":"invalid_request_error","param":null,"code":"400"}}
```

#### 8. `POST /model/new`, same `model_info.id` twice, so the db write fails

1. Run:

```bash
curl -sS -X POST 'http://127.0.0.1:31620/model/new' -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"model_name":"lit6842-dup","litellm_params":{"model":"openai/gpt-4o-mini"},"model_info":{"id":"lit6842-fixed-id"}}'
```

2. Observed, HTTP 500:

```json
{"error":{"message":"{'error': 'Failed to add model to db. Check your server logs for more details.'}","type":"internal_server_error","param":null,"code":"500"}}
```

#### 9. `GET /health/services`, service name that is not in the list

1. Run:

```bash
curl -sS -X GET 'http://127.0.0.1:31620/health/services?service=not-a-service' -H 'Authorization: Bearer sk-1234'
```

2. Observed, HTTP 400:

```json
{"error":{"message":"{'error': \"Service must be in list. Service=not-a-service not in typing.Union[typing.Literal['slack_budget_alerts', 'langfuse', ...], str]\"}","type":"invalid_request_error","param":null,"code":"400"}}
```

#### 10. `POST /queue/chat/completions`, no `priority`

1. Run:

```bash
curl -sS -X POST 'http://127.0.0.1:31620/queue/chat/completions' -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"model":"anthropic-haiku-4-5","messages":[{"role":"user","content":"hi"}]}'
```

2. Observed, HTTP 400:

```json
{"error":{"message":"Router.schedule_acompletion() missing 1 required positional argument: 'priority'","type":"invalid_request_error","param":null,"code":"400"}}
```

#### 11. `POST /queue/chat/completions`, valid `priority`, model that does not exist

1. Run:

```bash
curl -sS -X POST 'http://127.0.0.1:31620/queue/chat/completions' -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"model":"no-such-model-6842","messages":[{"role":"user","content":"hi"}],"priority":0}'
```

2. Observed, HTTP 400:

```json
{"error":{"message":"litellm.BadRequestError: You passed in model=no-such-model-6842. There are no healthy deployments for this model. Received Model Group=no-such-model-6842\nAvailable Model Group Fallbacks=None","type":"invalid_request_error","param":null,"code":"400"}}
```

#### 12. `POST /config/update`, `success_callback` that is not a list of strings

1. Run:

```bash
curl -sS -X POST 'http://127.0.0.1:31620/config/update' -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"litellm_settings":{"success_callback":[{"not":"a-string"}]}}'
```

2. Observed, HTTP 400:

```json
{"error":{"message":"unhashable type: 'dict'","type":"invalid_request_error","param":null,"code":"400"}}
```

#### 13. `GET /get/config/callbacks`, after a scalar `success_callback` is stored

1. Run:

```bash
curl -sS -X POST 'http://127.0.0.1:31620/config/update' -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"litellm_settings":{"success_callback":5}}'
curl -sS -X GET 'http://127.0.0.1:31620/get/config/callbacks' -H 'Authorization: Bearer sk-1234'
```

2. Observed, HTTP 400:

```json
{"error":{"message":"'int' object is not iterable","type":"invalid_request_error","param":null,"code":"400"}}
```

#### 14. Auth control: `GET /team/info` with a key that does not exist

1. Run:

```bash
curl -sS -X GET 'http://127.0.0.1:31620/team/info?team_id=whatever' -H 'Authorization: Bearer sk-not-a-real-key-6842'
```

2. Observed, HTTP 401:

```json
{"error":{"message":"Authentication Error, Invalid proxy server token passed. Received API Key = sk-...6842, Key Hash (Token) =249e3414...","type":"token_not_found_in_db","param":"key","code":"401"}}
```

#### 15. Auth control: `POST /login` with the wrong password

1. Run:

```bash
curl -sS -X POST 'http://127.0.0.1:31620/login' -d 'username=admin&password=definitely-wrong-6842'
```

2. Observed, HTTP 401:

```json
{"error":{"message":"Invalid credentials used to access UI.\nCheck 'UI_USERNAME', 'UI_PASSWORD' in .env file","type":"auth_error","param":"invalid_credentials","code":"401"}}
```

Notes from the two legs:

- Every changed route kept its exact status and message body
- The `Authentication Error, ` message prefix is gone where it lied
- `/model/new` duplicate-id answers 500, arguably should be a 409
- `/queue/chat/completions` still leaks a raw Python `TypeError` text
- `/config/update` stores a scalar `success_callback` that breaks reads

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- Clients keying on `type == "auth_error"` see these 11 routes change
- Every status code and message body stays exactly as it was
- The Admin UI and `litellm/proxy/client/` never branch on either type

### Low

- A 404 answers `invalid_request_error`, not the docs' `not_found_error`
- Both beat `auth_error`, and OpenAI's contract has no `not_found_error`
- Changing that mapping would alter #39536, #39540, #39542 and #39555 too
- An exception carrying its own `type` is reported verbatim at the route's default status
- Only `litellm.RateLimitError` does that today, and it beats `auth_error`
- `POST /queue/chat/completions` still fails on a missing `priority`, pre-existing and untouched
- `POST /config/update` stores a scalar `success_callback` that then breaks reads, pre-existing
- Three CircleCI jobs are red at the tip, none caused by this diff
- `litellm_router_testing` fails on `test_router_timeout`, which fails on staging too
- `local_testing_part1` fails on an embedding-timeout test that fails on the base commit
- Its other failure waits 10s for a logging callback, a timing flake
- `e2e_ui_testing` fails on the Playwright step on the base commit as well
- `osv-scan` flags a gitpython advisory that PR #39553 owns

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
