### PR TITLE
fix(responses): authorize previous_response_id on the WebSocket surface

### DIFF
--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -308,27 +308,28 @@ def _collect_ws_project_quota_callbacks() -> tuple[ProjectQuotaCallback, ...]:
     )
 
 
-def _collect_ws_response_id_authorizer() -> ResponseIdAuthorizer | None:
-    """Duck-type discover the proxy hook that owns Responses id authorization, so
+def _collect_ws_response_id_authorizers() -> tuple[ResponseIdAuthorizer, ...]:
+    """Duck-type discover the proxy hooks that own Responses id authorization, so
     the WebSocket surface refuses a ``previous_response_id`` the connection's key
     does not own through the very same step the HTTP routes run.
 
     Uses duck-typing on ``litellm.callbacks`` (rather than importing the proxy
     hook directly) to avoid a layering violation (SDK importing from the proxy
-    layer). Without the proxy there is no key to authorize and no hook to find.
+    layer). Every match is returned rather than the first, because config-loaded
+    callbacks are registered ahead of the proxy hooks: taking the first match
+    would let an unrelated callback answering to the same method name silently
+    stand in for the hook that owns this check. Without the proxy there is no key
+    to authorize and no hook to find.
     """
     import litellm as _litellm
 
     callbacks: Final = cast(  # cast-ok: callback registry is inspected before protocol use
         Sequence[object], _litellm.callbacks
     )
-    return next(
-        (
-            cast(ResponseIdAuthorizer, callback)  # cast-ok: required callback method is callable
-            for callback in callbacks
-            if callable(getattr(callback, "response_id_ownership_refusal", None))
-        ),
-        None,
+    return tuple(
+        cast(ResponseIdAuthorizer, callback)  # cast-ok: required callback method is callable
+        for callback in callbacks
+        if callable(getattr(callback, "response_id_ownership_refusal", None))
     )
 
 
@@ -6454,7 +6455,7 @@ class BaseLLMHTTPHandler:
         - Forwards events over the websocket connection
         """
         _ws_quota_callbacks: Final = _collect_ws_project_quota_callbacks()
-        _ws_response_id_authorizer: Final = _collect_ws_response_id_authorizer()
+        _ws_response_id_authorizers: Final = _collect_ws_response_id_authorizers()
 
         if responses_api_provider_config is None or not responses_api_provider_config.supports_native_websocket():
             from litellm.responses.streaming_iterator import (
@@ -6473,7 +6474,7 @@ class BaseLLMHTTPHandler:
                 custom_llm_provider=custom_llm_provider,
                 first_message=first_message,
                 quota_callbacks=_ws_quota_callbacks,
-                response_id_authorizer=_ws_response_id_authorizer,
+                response_id_authorizers=_ws_response_id_authorizers,
                 **kwargs,
             )
             await handler.run()
@@ -6596,7 +6597,7 @@ class BaseLLMHTTPHandler:
                     output_guardrail_callbacks=_ws_output_guardrail_callbacks,
                     quota_callbacks=_ws_quota_callbacks,
                     authorized_model=model,
-                    response_id_authorizer=_ws_response_id_authorizer,
+                    response_id_authorizers=_ws_response_id_authorizers,
                 )
                 await streaming.bidirectional_forward()
 

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -87,6 +87,7 @@ from litellm.responses.streaming_iterator import (
     BaseResponsesAPIStreamingIterator,
     MockResponsesAPIStreamingIterator,
     ProjectQuotaCallback,
+    ResponseIdAuthorizer,
     ResponsesAPIStreamingIterator,
     ResponsesWebSocketStreaming,
     SyncResponsesAPIStreamingIterator,
@@ -304,6 +305,30 @@ def _collect_ws_project_quota_callbacks() -> tuple[ProjectQuotaCallback, ...]:
         cast(ProjectQuotaCallback, callback)  # cast-ok: required callback method is callable
         for callback in callbacks
         if callable(getattr(callback, "enforce_project_io_token_quota_for_frame", None))
+    )
+
+
+def _collect_ws_response_id_authorizer() -> ResponseIdAuthorizer | None:
+    """Duck-type discover the proxy hook that owns Responses id authorization, so
+    the WebSocket surface refuses a ``previous_response_id`` the connection's key
+    does not own through the very same step the HTTP routes run.
+
+    Uses duck-typing on ``litellm.callbacks`` (rather than importing the proxy
+    hook directly) to avoid a layering violation (SDK importing from the proxy
+    layer). Without the proxy there is no key to authorize and no hook to find.
+    """
+    import litellm as _litellm
+
+    callbacks: Final = cast(  # cast-ok: callback registry is inspected before protocol use
+        Sequence[object], _litellm.callbacks
+    )
+    return next(
+        (
+            cast(ResponseIdAuthorizer, callback)  # cast-ok: required callback method is callable
+            for callback in callbacks
+            if callable(getattr(callback, "response_id_ownership_refusal", None))
+        ),
+        None,
     )
 
 
@@ -6429,6 +6454,7 @@ class BaseLLMHTTPHandler:
         - Forwards events over the websocket connection
         """
         _ws_quota_callbacks: Final = _collect_ws_project_quota_callbacks()
+        _ws_response_id_authorizer: Final = _collect_ws_response_id_authorizer()
 
         if responses_api_provider_config is None or not responses_api_provider_config.supports_native_websocket():
             from litellm.responses.streaming_iterator import (
@@ -6447,6 +6473,7 @@ class BaseLLMHTTPHandler:
                 custom_llm_provider=custom_llm_provider,
                 first_message=first_message,
                 quota_callbacks=_ws_quota_callbacks,
+                response_id_authorizer=_ws_response_id_authorizer,
                 **kwargs,
             )
             await handler.run()
@@ -6569,6 +6596,7 @@ class BaseLLMHTTPHandler:
                     output_guardrail_callbacks=_ws_output_guardrail_callbacks,
                     quota_callbacks=_ws_quota_callbacks,
                     authorized_model=model,
+                    response_id_authorizer=_ws_response_id_authorizer,
                 )
                 await streaming.bidirectional_forward()
 

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2742,6 +2742,25 @@ class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
             "UI username/password login. Default is False."
         ),
     )
+    disable_responses_id_security: bool | None = Field(
+        None,
+        description=(
+            "If True, disables ownership enforcement on Responses API ids. "
+            "Keys may then retrieve, cancel, delete, and chain from any response id, "
+            "including ids belonging to another user or team and ids this proxy never issued. "
+            "WARNING: this removes tenant isolation on /v1/responses"
+        ),
+    )
+    allow_unmanaged_response_ids: bool | None = Field(
+        None,
+        description=(
+            "If True, lets keys address Responses API ids that this proxy did not issue "
+            "(raw provider ids, or ids issued before response-id encryption was configured). "
+            "Such an id carries no owner, so no ownership check can run on it; ids this proxy "
+            "did issue keep full ownership enforcement. Off by default, in which case an "
+            "unrecognized response id is rejected with 403"
+        ),
+    )
     disable_budget_reservation: bool | None = Field(
         None,
         description=(

--- a/litellm/proxy/hooks/responses_id_security.py
+++ b/litellm/proxy/hooks/responses_id_security.py
@@ -99,12 +99,12 @@ class ResponsesIDSecurity(CustomLogger):
         )
         if not isinstance(addressed_id, str) or not addressed_id:
             return data
-        authorized_id: Final = self._authorize_response_id(addressed_id, user_api_key_dict)
+        authorized_id: Final = self.authorize_response_id(addressed_id, user_api_key_dict)
         data[addressed_id_field] = authorized_id
         data[_ADDRESSED_RESPONSE_ID_KEY] = addressed_id
         return data
 
-    def _authorize_response_id(
+    def authorize_response_id(
         self,
         response_id: str,
         user_api_key_dict: "UserAPIKeyAuth",
@@ -118,6 +118,22 @@ class ResponsesIDSecurity(CustomLogger):
             return response_id
 
         raise HTTPException(status_code=403, detail=_UNMANAGED_RESPONSE_ID_DETAIL)
+
+    def response_id_ownership_refusal(
+        self,
+        response_id: str,
+        user_api_key_dict: "UserAPIKeyAuth",
+    ) -> str | None:
+        """Report the same authorization step the HTTP routes run as a value.
+
+        The WebSocket surface answers a refused frame with an error frame rather
+        than a status code, so it needs the refusal text instead of an exception.
+        """
+        try:
+            self.authorize_response_id(response_id, user_api_key_dict)
+        except HTTPException as exc:
+            return str(exc.detail)
+        return None
 
     def _unmanaged_response_ids_allowed(self, user_api_key_dict: "UserAPIKeyAuth") -> bool:
         general_settings: Final = self._general_settings_reader()

--- a/litellm/proxy/hooks/responses_id_security.py
+++ b/litellm/proxy/hooks/responses_id_security.py
@@ -5,7 +5,7 @@ This hook uses the DBSpendUpdateWriter to batch-write response IDs to the databa
 instead of writing immediately on each request.
 """
 
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Callable, Mapping
 from typing import TYPE_CHECKING, Any, Final, cast
 
 from fastapi import HTTPException
@@ -31,6 +31,29 @@ if TYPE_CHECKING:
 _RESPONSES_API_PROVIDER_PREFIX: Final = "/openai"
 _RESPONSES_API_CREATE_ROUTES: Final = frozenset({"/v1/responses", "/responses"})
 
+_AUTHORIZED_RESPONSE_ID_KEY: Final = "_litellm_authorized_response_id"
+_UNMANAGED_RESPONSE_ID_DETAIL: Final = (
+    "Forbidden. This response id was not issued by this proxy, so the proxy cannot tell who owns it. "
+    "To let keys address responses this proxy did not issue, set "
+    "general_settings::allow_unmanaged_response_ids to True in the config.yaml file."
+)
+_PROXY_ADMIN_ROLES: Final = frozenset({LitellmUserRoles.PROXY_ADMIN, LitellmUserRoles.PROXY_ADMIN.value})
+
+
+def _proxy_general_settings() -> Mapping[str, Any]:
+    from litellm.proxy.proxy_server import general_settings
+
+    return general_settings
+
+
+def _proxy_signing_key() -> str | None:
+    import os
+
+    from litellm.proxy.proxy_server import master_key
+
+    salt_key: Final = os.getenv("LITELLM_SALT_KEY", None)
+    return master_key if salt_key is None else salt_key
+
 
 def _is_responses_api_create_route(request_route: str | None) -> bool:
     if request_route is None:
@@ -44,8 +67,13 @@ def _is_responses_api_create_route(request_route: str | None) -> bool:
 
 
 class ResponsesIDSecurity(CustomLogger):
-    def __init__(self):
-        pass
+    def __init__(
+        self,
+        general_settings_reader: Callable[[], Mapping[str, Any]] = _proxy_general_settings,
+        signing_key_reader: Callable[[], str | None] = _proxy_signing_key,
+    ) -> None:
+        self._general_settings_reader: Final = general_settings_reader
+        self._signing_key_reader: Final = signing_key_reader
 
     async def async_pre_call_hook(
         self,
@@ -64,22 +92,42 @@ class ResponsesIDSecurity(CustomLogger):
         }
         if call_type not in responses_api_call_types:
             return None
-        if call_type == "aresponses":
-            # check 'previous_response_id' if present in the data
-            previous_response_id: Final = data.get("previous_response_id")
-            if previous_response_id and self._is_encrypted_response_id(previous_response_id):
-                original_response_id, user_id, team_id = self._decrypt_response_id(previous_response_id)
-                self.check_user_access_to_response_id(user_id, team_id, user_api_key_dict)
-                data["previous_response_id"] = original_response_id
-        elif call_type in {"aget_responses", "adelete_responses", "acancel_responses", "alist_input_items"}:
-            response_id: Final = data.get("response_id")
-
-            if response_id and self._is_encrypted_response_id(response_id):
-                original_response_id, user_id, team_id = self._decrypt_response_id(response_id)
-
-                self.check_user_access_to_response_id(user_id, team_id, user_api_key_dict)
-                data["response_id"] = original_response_id
+        addressed_id_field: Final = "previous_response_id" if call_type == "aresponses" else "response_id"
+        addressed_id: Final = data.get(addressed_id_field)
+        if not isinstance(addressed_id, str) or not addressed_id:
+            return data
+        if data.get(_AUTHORIZED_RESPONSE_ID_KEY) == addressed_id:
+            return data
+        authorized_id: Final = self._authorize_response_id(addressed_id, user_api_key_dict)
+        data[addressed_id_field] = authorized_id
+        data[_AUTHORIZED_RESPONSE_ID_KEY] = authorized_id
         return data
+
+    def _authorize_response_id(
+        self,
+        response_id: str,
+        user_api_key_dict: "UserAPIKeyAuth",
+    ) -> str:
+        if self._is_encrypted_response_id(response_id):
+            original_response_id, user_id, team_id = self._decrypt_response_id(response_id)
+            self.check_user_access_to_response_id(user_id, team_id, user_api_key_dict)
+            return original_response_id
+
+        if self._unmanaged_response_ids_allowed(user_api_key_dict):
+            return response_id
+
+        raise HTTPException(status_code=403, detail=_UNMANAGED_RESPONSE_ID_DETAIL)
+
+    def _unmanaged_response_ids_allowed(self, user_api_key_dict: "UserAPIKeyAuth") -> bool:
+        general_settings: Final = self._general_settings_reader()
+
+        if general_settings.get("disable_responses_id_security", False):
+            return True
+        if general_settings.get("allow_unmanaged_response_ids", False):
+            return True
+        if self._get_signing_key() is None:
+            return True
+        return user_api_key_dict.user_role in _PROXY_ADMIN_ROLES
 
     def check_user_access_to_response_id(
         self,
@@ -87,7 +135,7 @@ class ResponsesIDSecurity(CustomLogger):
         response_id_team_id: str | None,
         user_api_key_dict: "UserAPIKeyAuth",
     ) -> bool:
-        from litellm.proxy.proxy_server import general_settings
+        general_settings: Final = self._general_settings_reader()
 
         if (
             user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN.value
@@ -180,15 +228,7 @@ class ResponsesIDSecurity(CustomLogger):
         return response_id, None, None
 
     def _get_signing_key(self) -> str | None:
-        """Get the signing key for encryption/decryption."""
-        import os
-
-        from litellm.proxy.proxy_server import master_key
-
-        salt_key = os.getenv("LITELLM_SALT_KEY", None)
-        if salt_key is None:
-            salt_key = master_key
-        return salt_key
+        return self._signing_key_reader()
 
     def _encrypt_response_id(
         self,
@@ -260,7 +300,7 @@ class ResponsesIDSecurity(CustomLogger):
         This method adds response IDs to an in-memory queue, which are then
         batch-processed by the DBSpendUpdateWriter during regular database update cycles.
         """
-        from litellm.proxy.proxy_server import general_settings
+        general_settings: Final = self._general_settings_reader()
 
         if general_settings.get("disable_responses_id_security", False):
             return response
@@ -274,7 +314,7 @@ class ResponsesIDSecurity(CustomLogger):
     async def async_post_call_streaming_iterator_hook(
         self, user_api_key_dict: "UserAPIKeyAuth", response: Any, request_data: dict
     ) -> AsyncGenerator[BaseLiteLLMOpenAIResponseObject, None]:
-        from litellm.proxy.proxy_server import general_settings
+        general_settings: Final = self._general_settings_reader()
 
         # Create a request-scoped cache for consistent encryption across streaming chunks.
         request_encryption_cache: Final[dict[str, str]] = {}

--- a/litellm/proxy/hooks/responses_id_security.py
+++ b/litellm/proxy/hooks/responses_id_security.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 _RESPONSES_API_PROVIDER_PREFIX: Final = "/openai"
 _RESPONSES_API_CREATE_ROUTES: Final = frozenset({"/v1/responses", "/responses"})
 
-_AUTHORIZED_RESPONSE_ID_KEY: Final = "_litellm_authorized_response_id"
+_ADDRESSED_RESPONSE_ID_KEY: Final = "_litellm_addressed_response_id"
 _UNMANAGED_RESPONSE_ID_DETAIL: Final = (
     "Forbidden. This response id was not issued by this proxy, so the proxy cannot tell who owns it. "
     "To let keys address responses this proxy did not issue, set "
@@ -93,14 +93,15 @@ class ResponsesIDSecurity(CustomLogger):
         if call_type not in responses_api_call_types:
             return None
         addressed_id_field: Final = "previous_response_id" if call_type == "aresponses" else "response_id"
-        addressed_id: Final = data.get(addressed_id_field)
+        retained_id: Final = data.get(_ADDRESSED_RESPONSE_ID_KEY)
+        addressed_id: Final = (
+            retained_id if isinstance(retained_id, str) and retained_id else data.get(addressed_id_field)
+        )
         if not isinstance(addressed_id, str) or not addressed_id:
-            return data
-        if data.get(_AUTHORIZED_RESPONSE_ID_KEY) == addressed_id:
             return data
         authorized_id: Final = self._authorize_response_id(addressed_id, user_api_key_dict)
         data[addressed_id_field] = authorized_id
-        data[_AUTHORIZED_RESPONSE_ID_KEY] = authorized_id
+        data[_ADDRESSED_RESPONSE_ID_KEY] = addressed_id
         return data
 
     def _authorize_response_id(

--- a/litellm/responses/streaming_iterator.py
+++ b/litellm/responses/streaming_iterator.py
@@ -1542,38 +1542,60 @@ async def _enforce_frame_project_quota(
         )
 
 
-def _frame_previous_response_id(raw_message: str) -> str | None:
-    """Read ``previous_response_id`` off a ``response.create`` frame, handling both
-    wire shapes:
+def _frame_previous_response_ids(raw_message: str) -> tuple[str, ...]:
+    """Read every ``previous_response_id`` a ``response.create`` frame carries, across
+    both wire shapes:
       flat:   {"type": "response.create", "previous_response_id": "..."}
       nested: {"type": "response.create", "response": {"previous_response_id": "..."}}
+
+    A frame may carry both placements at once, and the native relay forwards the frame
+    to the provider close to verbatim, so every placement is reported rather than only
+    the one this proxy would itself read. ``_enforce_authorized_model`` defends the
+    ``model`` field across both placements for the same reason.
     """
     try:
         msg_obj: Final = _load_json_value(raw_message)
     except (json.JSONDecodeError, TypeError):
-        return None
+        return ()
     if not _is_json_object(msg_obj) or msg_obj.get("type") != "response.create":
-        return None
+        return ()
     nested: Final = msg_obj.get("response")
-    params: Final[Mapping[str, object]] = nested if _is_json_object(nested) and nested else msg_obj
-    return _optional_str(params.get("previous_response_id"))
+    nested_params: Final[Mapping[str, object]] = nested if _is_json_object(nested) else {}
+    return tuple(
+        dict.fromkeys(
+            candidate
+            for candidate in (
+                _optional_str(msg_obj.get("previous_response_id")),
+                _optional_str(nested_params.get("previous_response_id")),
+            )
+            if candidate is not None
+        )
+    )
 
 
-def _previous_response_id_refusal(
-    authorizer: ResponseIdAuthorizer | None,
+def _previous_response_ids_refusal(
+    authorizers: Sequence[ResponseIdAuthorizer],
     user_api_key_dict: UserAPIKeyAuth | None,
-    previous_response_id: str,
+    previous_response_ids: Sequence[str],
 ) -> str | None:
     """Run the shared Responses id authorization step, the one the HTTP routes run,
-    against an id this connection was not itself handed.
+    against ids this connection was not itself handed.
 
-    Returns the refusal message when the connection's key may not address the id,
-    and None when it may. Without an authorizer or an authenticated key there is
-    no proxy in front of this socket and nothing to authorize against.
+    Returns the first refusal message when the connection's key may not address one
+    of the ids, and None when it may address all of them. Every discovered authorizer
+    is consulted, so an unrelated callback answering to the same method name can only
+    add refusals, never shadow the proxy hook that owns this check. Without an
+    authorizer or an authenticated key there is no proxy in front of this socket and
+    nothing to authorize against.
     """
-    if authorizer is None or user_api_key_dict is None:
+    if not authorizers or user_api_key_dict is None:
         return None
-    return authorizer.response_id_ownership_refusal(previous_response_id, user_api_key_dict)
+    refusals: Final = (
+        authorizer.response_id_ownership_refusal(previous_response_id, user_api_key_dict)
+        for previous_response_id in previous_response_ids
+        for authorizer in authorizers
+    )
+    return next((refusal for refusal in refusals if refusal is not None), None)
 
 
 RESPONSES_WS_LOGGED_EVENT_TYPES: Final = [
@@ -1612,7 +1634,7 @@ class ResponsesWebSocketStreaming:
         output_guardrail_callbacks: list[PresidioGuardrailCallback] | None = None,
         quota_callbacks: Sequence[ProjectQuotaCallback] | None = None,
         authorized_model: str | None = None,
-        response_id_authorizer: ResponseIdAuthorizer | None = None,
+        response_id_authorizers: Sequence[ResponseIdAuthorizer] | None = None,
     ):
         self.websocket = websocket
         self.backend_ws = backend_ws
@@ -1628,7 +1650,9 @@ class ResponsesWebSocketStreaming:
         # Model name authorized at connection time; enforced on every
         # response.create frame to prevent deployment-substitution attacks.
         self.authorized_model: str | None = authorized_model
-        self.response_id_authorizer: ResponseIdAuthorizer | None = response_id_authorizer
+        self.response_id_authorizers: tuple[ResponseIdAuthorizer, ...] = (
+            tuple(response_id_authorizers) if response_id_authorizers else ()
+        )
         # Response ids this connection handed the client. A connection carries
         # exactly one authenticated key, so continuing one of these needs no
         # further authorization; any other id does.
@@ -2073,11 +2097,17 @@ class ResponsesWebSocketStreaming:
 
     def _unauthorized_previous_response_id(self, message: str) -> str | None:
         """Return why this connection's key may not continue the frame's
-        ``previous_response_id``, or None when it may."""
-        previous_response_id: Final = _frame_previous_response_id(message)
-        if previous_response_id is None or previous_response_id in self._issued_response_ids:
-            return None
-        return _previous_response_id_refusal(self.response_id_authorizer, self.user_api_key_dict, previous_response_id)
+        ``previous_response_id``, or None when it may.
+
+        The frame reaches the provider close to verbatim, so every placement the
+        frame carries is checked, not only the one this proxy would read itself.
+        """
+        unowned_ids: Final = tuple(
+            previous_response_id
+            for previous_response_id in _frame_previous_response_ids(message)
+            if previous_response_id not in self._issued_response_ids
+        )
+        return _previous_response_ids_refusal(self.response_id_authorizers, self.user_api_key_dict, unowned_ids)
 
     async def _enforce_or_reject_frame(self, message: str) -> bool:
         """Run the per-frame ownership and project quota checks.
@@ -2193,7 +2223,7 @@ class ManagedResponsesWebSocketHandler:
         custom_llm_provider: str | None = None,
         first_message: str | None = None,
         quota_callbacks: Sequence[ProjectQuotaCallback] | None = None,
-        response_id_authorizer: ResponseIdAuthorizer | None = None,
+        response_id_authorizers: Sequence[ResponseIdAuthorizer] | None = None,
         **kwargs: object,
     ) -> None:
         self.websocket = websocket
@@ -2212,7 +2242,9 @@ class ManagedResponsesWebSocketHandler:
         self._connection_provider = self._resolve_provider(model) or custom_llm_provider
         self.first_message = first_message
         self.quota_callbacks: tuple[ProjectQuotaCallback, ...] = tuple(quota_callbacks) if quota_callbacks else ()
-        self.response_id_authorizer: ResponseIdAuthorizer | None = response_id_authorizer
+        self.response_id_authorizers: tuple[ResponseIdAuthorizer, ...] = (
+            tuple(response_id_authorizers) if response_id_authorizers else ()
+        )
         # Carry through safe pass-through kwargs (e.g. extra_headers)
         self.extra_kwargs: dict[str, object] = {k: v for k, v in kwargs.items() if k not in _MANAGED_WS_SKIP_KWARGS}
         # In-memory session history: response_id → full accumulated message list.
@@ -2465,8 +2497,8 @@ class ManagedResponsesWebSocketHandler:
         # No history on this connection, so the id was issued elsewhere: it goes
         # through the same authorization step the HTTP routes run before the
         # session is reconstructed from anywhere else.
-        refusal: Final = _previous_response_id_refusal(
-            self.response_id_authorizer, self.user_api_key_dict, previous_response_id
+        refusal: Final = _previous_response_ids_refusal(
+            self.response_id_authorizers, self.user_api_key_dict, (previous_response_id,)
         )
         if refusal is not None:
             return refusal

--- a/litellm/responses/streaming_iterator.py
+++ b/litellm/responses/streaming_iterator.py
@@ -63,6 +63,14 @@ class ProjectQuotaCallback(Protocol):
     ) -> None: ...
 
 
+class ResponseIdAuthorizer(Protocol):
+    def response_id_ownership_refusal(
+        self,
+        response_id: str,
+        user_api_key_dict: UserAPIKeyAuth,
+    ) -> str | None: ...
+
+
 @lru_cache(maxsize=1)
 def _get_openai_response_types():
     from litellm.types.llms import openai as openai_types
@@ -1534,6 +1542,40 @@ async def _enforce_frame_project_quota(
         )
 
 
+def _frame_previous_response_id(raw_message: str) -> str | None:
+    """Read ``previous_response_id`` off a ``response.create`` frame, handling both
+    wire shapes:
+      flat:   {"type": "response.create", "previous_response_id": "..."}
+      nested: {"type": "response.create", "response": {"previous_response_id": "..."}}
+    """
+    try:
+        msg_obj: Final = _load_json_value(raw_message)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not _is_json_object(msg_obj) or msg_obj.get("type") != "response.create":
+        return None
+    nested: Final = msg_obj.get("response")
+    params: Final[Mapping[str, object]] = nested if _is_json_object(nested) and nested else msg_obj
+    return _optional_str(params.get("previous_response_id"))
+
+
+def _previous_response_id_refusal(
+    authorizer: ResponseIdAuthorizer | None,
+    user_api_key_dict: UserAPIKeyAuth | None,
+    previous_response_id: str,
+) -> str | None:
+    """Run the shared Responses id authorization step, the one the HTTP routes run,
+    against an id this connection was not itself handed.
+
+    Returns the refusal message when the connection's key may not address the id,
+    and None when it may. Without an authorizer or an authenticated key there is
+    no proxy in front of this socket and nothing to authorize against.
+    """
+    if authorizer is None or user_api_key_dict is None:
+        return None
+    return authorizer.response_id_ownership_refusal(previous_response_id, user_api_key_dict)
+
+
 RESPONSES_WS_LOGGED_EVENT_TYPES: Final = [
     "response.created",
     "response.completed",
@@ -1570,6 +1612,7 @@ class ResponsesWebSocketStreaming:
         output_guardrail_callbacks: list[PresidioGuardrailCallback] | None = None,
         quota_callbacks: Sequence[ProjectQuotaCallback] | None = None,
         authorized_model: str | None = None,
+        response_id_authorizer: ResponseIdAuthorizer | None = None,
     ):
         self.websocket = websocket
         self.backend_ws = backend_ws
@@ -1585,6 +1628,11 @@ class ResponsesWebSocketStreaming:
         # Model name authorized at connection time; enforced on every
         # response.create frame to prevent deployment-substitution attacks.
         self.authorized_model: str | None = authorized_model
+        self.response_id_authorizer: ResponseIdAuthorizer | None = response_id_authorizer
+        # Response ids this connection handed the client. A connection carries
+        # exactly one authenticated key, so continuing one of these needs no
+        # further authorization; any other id does.
+        self._issued_response_ids: frozenset[str] = frozenset()
 
     def _should_store_event(self, event_obj: _MutableJsonObject) -> bool:
         return event_obj.get("type") in RESPONSES_WS_LOGGED_EVENT_TYPES
@@ -1602,6 +1650,20 @@ class ResponsesWebSocketStreaming:
 
         if self._should_store_event(event_obj):
             self.messages.append(event_obj)
+
+    def _record_issued_response_id(self, event: str) -> None:
+        """Remember a response id this connection handed the client, so the client
+        can keep continuing its own conversation without re-authorizing every frame."""
+        try:
+            event_obj: Final = _load_json_object(event)
+        except (json.JSONDecodeError, TypeError):
+            return
+        response_obj: Final = event_obj.get("response")
+        if not _is_json_object(response_obj):
+            return
+        response_id: Final = _optional_str(response_obj.get("id"))
+        if response_id is not None:
+            self._issued_response_ids = self._issued_response_ids | {response_id}
 
     def _collect_input_from_client_event(self, message: object) -> None:
         """Extract user input content from response.create for logging."""
@@ -1690,6 +1752,7 @@ class ResponsesWebSocketStreaming:
                 # Log the output-masked form so PII redacted by apply_to_output
                 # guardrails does not appear in success logs.
                 self._store_event(output_masked_str)
+                self._record_issued_response_id(output_masked_str)
 
                 await self.websocket.send_text(output_masked_str)
 
@@ -1992,32 +2055,48 @@ class ResponsesWebSocketStreaming:
 
         return json.dumps(evt_obj) if modified else response_str
 
+    async def _send_error_frame(self, error_type: str, message: str) -> None:
+        try:
+            await self.websocket.send_text(
+                json.dumps(  # mutable-ok: WebSocket wire payload requires JSON objects
+                    {  # mutable-ok: WebSocket wire payload requires JSON objects
+                        "type": "error",
+                        "error": {  # mutable-ok: nested WebSocket error object
+                            "type": error_type,
+                            "message": message,
+                        },
+                    }
+                )
+            )
+        except Exception:  # noqa: BLE001, S110  # client may already be gone
+            pass
+
+    def _unauthorized_previous_response_id(self, message: str) -> str | None:
+        """Return why this connection's key may not continue the frame's
+        ``previous_response_id``, or None when it may."""
+        previous_response_id: Final = _frame_previous_response_id(message)
+        if previous_response_id is None or previous_response_id in self._issued_response_ids:
+            return None
+        return _previous_response_id_refusal(self.response_id_authorizer, self.user_api_key_dict, previous_response_id)
+
     async def _enforce_or_reject_frame(self, message: str) -> bool:
-        """Run the per-frame project quota check.
+        """Run the per-frame ownership and project quota checks.
 
         On rejection, sends an ``error`` event to the client and reports that
         the frame must be dropped instead of forwarded, so the connection
-        stays open for the client to retry once the window resets.
+        stays open for the client to retry with an id it owns or once the
+        rate-limit window resets.
         """
+        ownership_refusal: Final = self._unauthorized_previous_response_id(message)
+        if ownership_refusal is not None:
+            await self._send_error_frame("permission_denied", ownership_refusal)
+            return False
         try:
             await _enforce_frame_project_quota(
                 self.quota_callbacks, self.user_api_key_dict, self.authorized_model, message
             )
         except RateLimitError as e:
-            try:
-                await self.websocket.send_text(
-                    json.dumps(  # mutable-ok: WebSocket wire payload requires JSON objects
-                        {  # mutable-ok: WebSocket wire payload requires JSON objects
-                            "type": "error",
-                            "error": {  # mutable-ok: nested WebSocket error object
-                                "type": "rate_limit_exceeded",
-                                "message": str(e),
-                            },
-                        }
-                    )
-                )
-            except Exception:  # noqa: BLE001, S110  # client may already be gone
-                pass
+            await self._send_error_frame("rate_limit_exceeded", str(e))
             return False
         return True
 
@@ -2114,6 +2193,7 @@ class ManagedResponsesWebSocketHandler:
         custom_llm_provider: str | None = None,
         first_message: str | None = None,
         quota_callbacks: Sequence[ProjectQuotaCallback] | None = None,
+        response_id_authorizer: ResponseIdAuthorizer | None = None,
         **kwargs: object,
     ) -> None:
         self.websocket = websocket
@@ -2132,6 +2212,7 @@ class ManagedResponsesWebSocketHandler:
         self._connection_provider = self._resolve_provider(model) or custom_llm_provider
         self.first_message = first_message
         self.quota_callbacks: tuple[ProjectQuotaCallback, ...] = tuple(quota_callbacks) if quota_callbacks else ()
+        self.response_id_authorizer: ResponseIdAuthorizer | None = response_id_authorizer
         # Carry through safe pass-through kwargs (e.g. extra_headers)
         self.extra_kwargs: dict[str, object] = {k: v for k, v in kwargs.items() if k not in _MANAGED_WS_SKIP_KWARGS}
         # In-memory session history: response_id → full accumulated message list.
@@ -2358,16 +2439,20 @@ class ManagedResponsesWebSocketHandler:
         previous_response_id: str | None,
         current_messages: list[dict[str, object]],
         prior_history: list[dict[str, object]],
-    ) -> None:
-        """Prepend in-memory turn history, or fall back to DB-based reconstruction."""
+    ) -> str | None:
+        """Prepend in-memory turn history, or fall back to DB-based reconstruction.
+
+        Returns the ownership refusal message when the connection's key may not
+        address an id this connection never issued, and None otherwise.
+        """
         if not previous_response_id:
-            return
+            return None
         if self._is_warmup_response_id(previous_response_id):
             verbose_logger.debug(
                 "ManagedResponsesWS: ignoring synthetic warmup previous_response_id=%s",
                 previous_response_id,
             )
-            return
+            return None
         if prior_history:
             call_kwargs["input"] = prior_history + current_messages
             verbose_logger.debug(
@@ -2375,15 +2460,25 @@ class ManagedResponsesWebSocketHandler:
                 len(prior_history),
                 previous_response_id,
             )
-        else:
-            verbose_logger.debug(
-                "ManagedResponsesWS: no in-memory history for previous_response_id=%s; "
-                "falling back to DB-based session reconstruction",
-                previous_response_id,
-            )
-            # Fall back to DB-based session reconstruction (may work for
-            # cross-connection multi-turn when spend logs are committed)
-            call_kwargs["previous_response_id"] = previous_response_id
+            return None
+
+        # No history on this connection, so the id was issued elsewhere: it goes
+        # through the same authorization step the HTTP routes run before the
+        # session is reconstructed from anywhere else.
+        refusal: Final = _previous_response_id_refusal(
+            self.response_id_authorizer, self.user_api_key_dict, previous_response_id
+        )
+        if refusal is not None:
+            return refusal
+        verbose_logger.debug(
+            "ManagedResponsesWS: no in-memory history for previous_response_id=%s; "
+            "falling back to DB-based session reconstruction",
+            previous_response_id,
+        )
+        # Fall back to DB-based session reconstruction (may work for
+        # cross-connection multi-turn when spend logs are committed)
+        call_kwargs["previous_response_id"] = previous_response_id
+        return None
 
     @staticmethod
     def _resolve_provider(model: str | None) -> str | None:
@@ -2563,7 +2658,13 @@ class ManagedResponsesWebSocketHandler:
         # Fetch history once; reused in both _apply_history and _save_turn_history
         prior_history: Final = self._get_history_messages(previous_response_id) if previous_response_id else []
 
-        self._apply_history(call_kwargs, previous_response_id, current_messages, prior_history)
+        ownership_refusal: Final = self._apply_history(
+            call_kwargs, previous_response_id, current_messages, prior_history
+        )
+        if ownership_refusal is not None:
+            await self._send_error(ownership_refusal, error_type="permission_denied")
+            return
+
         self._inject_credentials(call_kwargs, model=model)
         self._update_proxy_request(call_kwargs, requested_model or self.model_group or model)
         call_kwargs.update(self.extra_kwargs)

--- a/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
@@ -22,6 +22,7 @@ from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler, HTTPHandler
 from litellm.llms.custom_httpx.llm_http_handler import (
     BaseLLMHTTPHandler,
     _collect_ws_project_quota_callbacks,
+    _collect_ws_response_id_authorizer,
     _google_genai_streaming_hidden_params,
     _has_pre_call_deployment_hook,
     _rust_responses_websocket_enabled,
@@ -2765,6 +2766,28 @@ def test_only_callbacks_that_can_charge_a_frame_are_collected_for_ws_quota(monke
 
     monkeypatch.setattr(litellm, "callbacks", [plain, quota, decoy])
     assert _collect_ws_project_quota_callbacks() == (quota,)
+
+
+def test_websocket_surface_finds_the_proxy_hook_that_authorizes_response_ids(monkeypatch):
+    """The WebSocket surface must reach the same authorization step the HTTP routes run,
+    and it finds it by duck-typing the callback registry rather than importing the proxy
+    hook into the SDK layer."""
+    from litellm.integrations.custom_logger import CustomLogger
+    from litellm.proxy.hooks.responses_id_security import ResponsesIDSecurity
+
+    class _PlainLogger(CustomLogger):
+        pass
+
+    class _NotCallableAttribute:
+        response_id_ownership_refusal = "not a method"
+
+    plain, decoy, hook = _PlainLogger(), _NotCallableAttribute(), ResponsesIDSecurity()
+
+    monkeypatch.setattr(litellm, "callbacks", [plain, decoy])
+    assert _collect_ws_response_id_authorizer() is None
+
+    monkeypatch.setattr(litellm, "callbacks", [plain, decoy, hook])
+    assert _collect_ws_response_id_authorizer() is hook
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
@@ -22,7 +22,7 @@ from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler, HTTPHandler
 from litellm.llms.custom_httpx.llm_http_handler import (
     BaseLLMHTTPHandler,
     _collect_ws_project_quota_callbacks,
-    _collect_ws_response_id_authorizer,
+    _collect_ws_response_id_authorizers,
     _google_genai_streaming_hidden_params,
     _has_pre_call_deployment_hook,
     _rust_responses_websocket_enabled,
@@ -2784,10 +2784,18 @@ def test_websocket_surface_finds_the_proxy_hook_that_authorizes_response_ids(mon
     plain, decoy, hook = _PlainLogger(), _NotCallableAttribute(), ResponsesIDSecurity()
 
     monkeypatch.setattr(litellm, "callbacks", [plain, decoy])
-    assert _collect_ws_response_id_authorizer() is None
+    assert _collect_ws_response_id_authorizers() == ()
 
     monkeypatch.setattr(litellm, "callbacks", [plain, decoy, hook])
-    assert _collect_ws_response_id_authorizer() is hook
+    assert _collect_ws_response_id_authorizers() == (hook,)
+
+    class _Impostor:
+        def response_id_ownership_refusal(self, response_id, user_api_key_dict):
+            return None
+
+    impostor = _Impostor()
+    monkeypatch.setattr(litellm, "callbacks", [impostor, hook])
+    assert _collect_ws_response_id_authorizers() == (impostor, hook)
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/responses/test_responses_websocket_all_providers.py
+++ b/tests/test_litellm/responses/test_responses_websocket_all_providers.py
@@ -2619,3 +2619,309 @@ class TestNativeWebSocketUrlConstruction:
         mock_config.get_websocket_url.assert_called_once()
         _, call_kwargs = mock_config.get_websocket_url.call_args
         assert call_kwargs["litellm_params"]["api_version"] == "2025-04-01-preview"
+
+
+_WS_FABRICATED_STRANGER_ID = "resp_fabricatedidthisconnectionneverissued"
+_WS_FABRICATED_PROVIDER_ID = "resp_fabricatedproviderid00000000000000000"
+_WS_UNIT_TEST_SALT_KEY = "lit6843-unit-test-salt-key"
+
+
+def _ws_auth(user_id="owner-user", team_id="owner-team"):
+    from litellm.proxy._types import UserAPIKeyAuth
+
+    return UserAPIKeyAuth(user_id=user_id, team_id=team_id)
+
+
+def _ws_id_authorizer(general_settings=None):
+    """The real proxy hook, so these tests fail if the WebSocket surface ever stops
+    routing through the same authorization step the HTTP routes run."""
+    from litellm.proxy.hooks.responses_id_security import ResponsesIDSecurity
+
+    return ResponsesIDSecurity(
+        general_settings_reader=lambda: general_settings or {},
+        signing_key_reader=lambda: _WS_UNIT_TEST_SALT_KEY,
+    )
+
+
+class _CountingAuthorizer:
+    """Wraps the real hook to prove when the surface does not need to consult it."""
+
+    def __init__(self, inner):
+        self.inner = inner
+        self.calls = 0
+
+    def response_id_ownership_refusal(self, response_id, user_api_key_dict):
+        self.calls += 1
+        return self.inner.response_id_ownership_refusal(response_id, user_api_key_dict)
+
+
+def _managed_handler(monkeypatch, **kwargs):
+    from unittest.mock import AsyncMock, MagicMock
+
+    from litellm.litellm_core_utils.litellm_logging import Logging
+    from litellm.responses.streaming_iterator import ManagedResponsesWebSocketHandler
+
+    monkeypatch.setenv("LITELLM_SALT_KEY", _WS_UNIT_TEST_SALT_KEY)
+    mock_websocket = MagicMock()
+    mock_websocket.send_text = AsyncMock()
+    handler = ManagedResponsesWebSocketHandler(
+        websocket=mock_websocket,
+        model="test-model",
+        logging_obj=Logging(
+            model="test-model",
+            messages=[],
+            stream=True,
+            call_type="aresponses",
+            start_time=0,
+            litellm_call_id="test-id",
+            function_id="test-func",
+        ),
+        **kwargs,
+    )
+    return handler, mock_websocket
+
+
+def _capture_aresponses(monkeypatch):
+    import litellm
+
+    captured = {}
+
+    async def fake_aresponses(*args, **kwargs):
+        captured.update(kwargs)
+        captured["called"] = True
+
+        async def _empty():
+            return
+            yield
+
+        return _empty()
+
+    monkeypatch.setattr(litellm, "aresponses", fake_aresponses)
+    return captured
+
+
+class TestWebSocketPreviousResponseIdOwnership:
+    """A response.create frame carries previous_response_id straight off the wire, on a
+    surface the connection-level pre-call hook chain never reaches again. Continuing an
+    id this connection was never handed must run the same authorization step the HTTP
+    routes run, on both the managed handler and the native-provider relay."""
+
+    @pytest.mark.asyncio
+    async def test_managed_handler_refuses_an_id_this_connection_never_issued(self, monkeypatch):
+        captured = _capture_aresponses(monkeypatch)
+        handler, mock_websocket = _managed_handler(
+            monkeypatch,
+            user_api_key_dict=_ws_auth(),
+            response_id_authorizer=_ws_id_authorizer(),
+        )
+
+        await handler._process_response_create(
+            json.dumps(
+                {
+                    "type": "response.create",
+                    "input": "what did the other key say?",
+                    "previous_response_id": _WS_FABRICATED_STRANGER_ID,
+                }
+            )
+        )
+
+        assert captured.get("called") is not True
+        error_event = json.loads(mock_websocket.send_text.call_args[0][0])
+        assert error_event["error"]["type"] == "permission_denied"
+
+    @pytest.mark.asyncio
+    async def test_managed_handler_never_consults_the_authorizer_for_its_own_turn(self, monkeypatch):
+        captured = _capture_aresponses(monkeypatch)
+        authorizer = _CountingAuthorizer(_ws_id_authorizer())
+        handler, _ = _managed_handler(
+            monkeypatch,
+            user_api_key_dict=_ws_auth(),
+            response_id_authorizer=authorizer,
+        )
+        handler._store_history(_WS_FABRICATED_PROVIDER_ID, [{"role": "user", "content": "turn one"}])
+
+        await handler._process_response_create(
+            json.dumps(
+                {
+                    "type": "response.create",
+                    "input": "turn two",
+                    "previous_response_id": _WS_FABRICATED_PROVIDER_ID,
+                }
+            )
+        )
+
+        assert captured.get("called") is True
+        assert authorizer.calls == 0
+
+    @pytest.mark.asyncio
+    async def test_managed_handler_forwards_the_id_when_the_escape_hatch_is_on(self, monkeypatch):
+        captured = _capture_aresponses(monkeypatch)
+        handler, _ = _managed_handler(
+            monkeypatch,
+            user_api_key_dict=_ws_auth(),
+            response_id_authorizer=_ws_id_authorizer({"allow_unmanaged_response_ids": True}),
+        )
+
+        await handler._process_response_create(
+            json.dumps(
+                {
+                    "type": "response.create",
+                    "input": "continue please",
+                    "previous_response_id": _WS_FABRICATED_STRANGER_ID,
+                }
+            )
+        )
+
+        assert captured["previous_response_id"] == _WS_FABRICATED_STRANGER_ID
+
+    @pytest.mark.asyncio
+    async def test_managed_handler_without_a_proxy_authorizer_still_forwards(self, monkeypatch):
+        """Direct SDK use has no proxy in front of the socket, so there is no key to
+        authorize and nothing to refuse."""
+        captured = _capture_aresponses(monkeypatch)
+        handler, _ = _managed_handler(monkeypatch)
+
+        await handler._process_response_create(
+            json.dumps(
+                {
+                    "type": "response.create",
+                    "input": "continue please",
+                    "previous_response_id": _WS_FABRICATED_STRANGER_ID,
+                }
+            )
+        )
+
+        assert captured["previous_response_id"] == _WS_FABRICATED_STRANGER_ID
+
+    @pytest.mark.asyncio
+    async def test_native_relay_refuses_an_id_this_connection_never_issued(self, monkeypatch):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from litellm.responses.streaming_iterator import ResponsesWebSocketStreaming
+
+        monkeypatch.setenv("LITELLM_SALT_KEY", _WS_UNIT_TEST_SALT_KEY)
+        mock_backend_ws = MagicMock()
+        mock_backend_ws.send = AsyncMock()
+        mock_websocket = MagicMock()
+        mock_websocket.send_text = AsyncMock()
+        handler = ResponsesWebSocketStreaming(
+            websocket=mock_websocket,
+            backend_ws=mock_backend_ws,
+            logging_obj=MagicMock(),
+            user_api_key_dict=_ws_auth(),
+            authorized_model="gpt-4o",
+            response_id_authorizer=_ws_id_authorizer(),
+        )
+
+        allowed = await handler._enforce_or_reject_frame(
+            json.dumps(
+                {
+                    "type": "response.create",
+                    "input": "what did the other key say?",
+                    "previous_response_id": _WS_FABRICATED_STRANGER_ID,
+                }
+            )
+        )
+
+        assert allowed is False
+        mock_backend_ws.send.assert_not_called()
+        error_event = json.loads(mock_websocket.send_text.call_args[0][0])
+        assert error_event["error"]["type"] == "permission_denied"
+
+    @pytest.mark.asyncio
+    async def test_native_relay_allows_continuing_an_id_it_handed_this_client(self, monkeypatch):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from litellm.responses.streaming_iterator import ResponsesWebSocketStreaming
+
+        monkeypatch.setenv("LITELLM_SALT_KEY", _WS_UNIT_TEST_SALT_KEY)
+        authorizer = _CountingAuthorizer(_ws_id_authorizer())
+        mock_backend_ws = MagicMock()
+        mock_backend_ws.send = AsyncMock()
+        handler = ResponsesWebSocketStreaming(
+            websocket=MagicMock(),
+            backend_ws=mock_backend_ws,
+            logging_obj=MagicMock(),
+            user_api_key_dict=_ws_auth(),
+            authorized_model="gpt-4o",
+            response_id_authorizer=authorizer,
+        )
+        handler._record_issued_response_id(
+            json.dumps(
+                {
+                    "type": "response.completed",
+                    "response": {"id": _WS_FABRICATED_PROVIDER_ID},
+                }
+            )
+        )
+
+        allowed = await handler._enforce_or_reject_frame(
+            json.dumps(
+                {
+                    "type": "response.create",
+                    "input": "turn two",
+                    "previous_response_id": _WS_FABRICATED_PROVIDER_ID,
+                }
+            )
+        )
+
+        assert allowed is True
+        assert authorizer.calls == 0
+
+    @pytest.mark.asyncio
+    async def test_native_relay_allows_the_frame_when_the_escape_hatch_is_on(self, monkeypatch):
+        from unittest.mock import MagicMock
+
+        from litellm.responses.streaming_iterator import ResponsesWebSocketStreaming
+
+        monkeypatch.setenv("LITELLM_SALT_KEY", _WS_UNIT_TEST_SALT_KEY)
+        handler = ResponsesWebSocketStreaming(
+            websocket=MagicMock(),
+            backend_ws=MagicMock(),
+            logging_obj=MagicMock(),
+            user_api_key_dict=_ws_auth(),
+            authorized_model="gpt-4o",
+            response_id_authorizer=_ws_id_authorizer({"allow_unmanaged_response_ids": True}),
+        )
+
+        allowed = await handler._enforce_or_reject_frame(
+            json.dumps(
+                {
+                    "type": "response.create",
+                    "input": "continue please",
+                    "previous_response_id": _WS_FABRICATED_STRANGER_ID,
+                }
+            )
+        )
+
+        assert allowed is True
+
+    @pytest.mark.parametrize(
+        "frame, expected",
+        [
+            (
+                {"type": "response.create", "previous_response_id": _WS_FABRICATED_STRANGER_ID},
+                _WS_FABRICATED_STRANGER_ID,
+            ),
+            (
+                {
+                    "type": "response.create",
+                    "response": {"previous_response_id": _WS_FABRICATED_STRANGER_ID},
+                },
+                _WS_FABRICATED_STRANGER_ID,
+            ),
+            ({"type": "response.create", "input": "hi"}, None),
+            ({"type": "response.cancel", "previous_response_id": _WS_FABRICATED_STRANGER_ID}, None),
+            ({"type": "response.create", "previous_response_id": {"forged": "object"}}, None),
+        ],
+    )
+    def test_previous_response_id_is_read_from_both_wire_shapes(self, frame, expected):
+        from litellm.responses.streaming_iterator import _frame_previous_response_id
+
+        assert _frame_previous_response_id(json.dumps(frame)) == expected
+
+    def test_malformed_frames_read_as_carrying_no_previous_response_id(self):
+        from litellm.responses.streaming_iterator import _frame_previous_response_id
+
+        assert _frame_previous_response_id("not json at all") is None
+        assert _frame_previous_response_id(json.dumps(["not", "an", "object"])) is None

--- a/tests/test_litellm/responses/test_responses_websocket_all_providers.py
+++ b/tests/test_litellm/responses/test_responses_websocket_all_providers.py
@@ -2655,6 +2655,29 @@ class _CountingAuthorizer:
         return self.inner.response_id_ownership_refusal(response_id, user_api_key_dict)
 
 
+def _native_streaming(monkeypatch, **kwargs):
+    from unittest.mock import AsyncMock, MagicMock
+
+    from litellm.responses.streaming_iterator import ResponsesWebSocketStreaming
+
+    monkeypatch.setenv("LITELLM_SALT_KEY", _WS_UNIT_TEST_SALT_KEY)
+    mock_backend_ws = MagicMock()
+    mock_backend_ws.send = AsyncMock()
+    mock_websocket = MagicMock()
+    mock_websocket.send_text = AsyncMock()
+    return ResponsesWebSocketStreaming(
+        websocket=mock_websocket,
+        backend_ws=mock_backend_ws,
+        logging_obj=MagicMock(),
+        authorized_model="gpt-4o",
+        **kwargs,
+    )
+
+
+def _sent_error_type(mock_websocket):
+    return json.loads(mock_websocket.send_text.call_args[0][0])["error"]["type"]
+
+
 def _managed_handler(monkeypatch, **kwargs):
     from unittest.mock import AsyncMock, MagicMock
 
@@ -2712,7 +2735,7 @@ class TestWebSocketPreviousResponseIdOwnership:
         handler, mock_websocket = _managed_handler(
             monkeypatch,
             user_api_key_dict=_ws_auth(),
-            response_id_authorizer=_ws_id_authorizer(),
+            response_id_authorizers=[_ws_id_authorizer()],
         )
 
         await handler._process_response_create(
@@ -2736,7 +2759,7 @@ class TestWebSocketPreviousResponseIdOwnership:
         handler, _ = _managed_handler(
             monkeypatch,
             user_api_key_dict=_ws_auth(),
-            response_id_authorizer=authorizer,
+            response_id_authorizers=[authorizer],
         )
         handler._store_history(_WS_FABRICATED_PROVIDER_ID, [{"role": "user", "content": "turn one"}])
 
@@ -2759,7 +2782,7 @@ class TestWebSocketPreviousResponseIdOwnership:
         handler, _ = _managed_handler(
             monkeypatch,
             user_api_key_dict=_ws_auth(),
-            response_id_authorizer=_ws_id_authorizer({"allow_unmanaged_response_ids": True}),
+            response_id_authorizers=[_ws_id_authorizer({"allow_unmanaged_response_ids": True})],
         )
 
         await handler._process_response_create(
@@ -2810,7 +2833,7 @@ class TestWebSocketPreviousResponseIdOwnership:
             logging_obj=MagicMock(),
             user_api_key_dict=_ws_auth(),
             authorized_model="gpt-4o",
-            response_id_authorizer=_ws_id_authorizer(),
+            response_id_authorizers=[_ws_id_authorizer()],
         )
 
         allowed = await handler._enforce_or_reject_frame(
@@ -2844,7 +2867,7 @@ class TestWebSocketPreviousResponseIdOwnership:
             logging_obj=MagicMock(),
             user_api_key_dict=_ws_auth(),
             authorized_model="gpt-4o",
-            response_id_authorizer=authorizer,
+            response_id_authorizers=[authorizer],
         )
         handler._record_issued_response_id(
             json.dumps(
@@ -2881,7 +2904,7 @@ class TestWebSocketPreviousResponseIdOwnership:
             logging_obj=MagicMock(),
             user_api_key_dict=_ws_auth(),
             authorized_model="gpt-4o",
-            response_id_authorizer=_ws_id_authorizer({"allow_unmanaged_response_ids": True}),
+            response_id_authorizers=[_ws_id_authorizer({"allow_unmanaged_response_ids": True})],
         )
 
         allowed = await handler._enforce_or_reject_frame(
@@ -2901,27 +2924,127 @@ class TestWebSocketPreviousResponseIdOwnership:
         [
             (
                 {"type": "response.create", "previous_response_id": _WS_FABRICATED_STRANGER_ID},
-                _WS_FABRICATED_STRANGER_ID,
+                (_WS_FABRICATED_STRANGER_ID,),
             ),
             (
                 {
                     "type": "response.create",
                     "response": {"previous_response_id": _WS_FABRICATED_STRANGER_ID},
                 },
-                _WS_FABRICATED_STRANGER_ID,
+                (_WS_FABRICATED_STRANGER_ID,),
             ),
-            ({"type": "response.create", "input": "hi"}, None),
-            ({"type": "response.cancel", "previous_response_id": _WS_FABRICATED_STRANGER_ID}, None),
-            ({"type": "response.create", "previous_response_id": {"forged": "object"}}, None),
+            (
+                {
+                    "type": "response.create",
+                    "previous_response_id": _WS_FABRICATED_STRANGER_ID,
+                    "response": {"input": "continue please"},
+                },
+                (_WS_FABRICATED_STRANGER_ID,),
+            ),
+            (
+                {
+                    "type": "response.create",
+                    "previous_response_id": _WS_FABRICATED_STRANGER_ID,
+                    "response": {"previous_response_id": _WS_FABRICATED_PROVIDER_ID},
+                },
+                (_WS_FABRICATED_STRANGER_ID, _WS_FABRICATED_PROVIDER_ID),
+            ),
+            (
+                {
+                    "type": "response.create",
+                    "previous_response_id": _WS_FABRICATED_STRANGER_ID,
+                    "response": {"previous_response_id": _WS_FABRICATED_STRANGER_ID},
+                },
+                (_WS_FABRICATED_STRANGER_ID,),
+            ),
+            ({"type": "response.create", "input": "hi"}, ()),
+            ({"type": "response.cancel", "previous_response_id": _WS_FABRICATED_STRANGER_ID}, ()),
+            ({"type": "response.create", "previous_response_id": {"forged": "object"}}, ()),
         ],
     )
-    def test_previous_response_id_is_read_from_both_wire_shapes(self, frame, expected):
-        from litellm.responses.streaming_iterator import _frame_previous_response_id
+    def test_previous_response_ids_are_read_from_every_wire_placement(self, frame, expected):
+        from litellm.responses.streaming_iterator import _frame_previous_response_ids
 
-        assert _frame_previous_response_id(json.dumps(frame)) == expected
+        assert _frame_previous_response_ids(json.dumps(frame)) == expected
 
     def test_malformed_frames_read_as_carrying_no_previous_response_id(self):
-        from litellm.responses.streaming_iterator import _frame_previous_response_id
+        from litellm.responses.streaming_iterator import _frame_previous_response_ids
 
-        assert _frame_previous_response_id("not json at all") is None
-        assert _frame_previous_response_id(json.dumps(["not", "an", "object"])) is None
+        assert _frame_previous_response_ids("not json at all") == ()
+        assert _frame_previous_response_ids(json.dumps(["not", "an", "object"])) == ()
+
+    @pytest.mark.asyncio
+    async def test_native_relay_refuses_a_stranger_id_hidden_beside_a_nested_response(self, monkeypatch):
+        """A frame carrying a top-level ``previous_response_id`` next to a non-empty
+        ``response`` object reaches the provider socket verbatim, so the id is refused
+        even though this proxy would read the nested placement for its own call."""
+        streaming = _native_streaming(
+            monkeypatch,
+            user_api_key_dict=_ws_auth(),
+            response_id_authorizers=[_ws_id_authorizer()],
+        )
+
+        allowed = await streaming._enforce_or_reject_frame(
+            json.dumps(
+                {
+                    "type": "response.create",
+                    "previous_response_id": _WS_FABRICATED_STRANGER_ID,
+                    "response": {"input": "continue please"},
+                }
+            )
+        )
+
+        assert allowed is False
+        streaming.backend_ws.send.assert_not_called()
+        assert _sent_error_type(streaming.websocket) == "permission_denied"
+
+    @pytest.mark.asyncio
+    async def test_managed_handler_never_forwards_a_stranger_id_beside_a_nested_response(self, monkeypatch):
+        """The managed handler rebuilds the upstream call from the nested params, so a
+        top-level ``previous_response_id`` sibling is dropped rather than forwarded."""
+        captured = _capture_aresponses(monkeypatch)
+        handler, _ = _managed_handler(
+            monkeypatch,
+            user_api_key_dict=_ws_auth(),
+            response_id_authorizers=[_ws_id_authorizer()],
+        )
+
+        await handler._process_response_create(
+            json.dumps(
+                {
+                    "type": "response.create",
+                    "previous_response_id": _WS_FABRICATED_STRANGER_ID,
+                    "response": {"input": "continue please"},
+                }
+            )
+        )
+
+        assert captured.get("called") is True
+        assert "previous_response_id" not in captured
+
+    @pytest.mark.asyncio
+    async def test_a_callback_answering_to_the_same_name_cannot_shadow_the_proxy_hook(self, monkeypatch):
+        """Config-loaded callbacks are registered ahead of the proxy hooks, so the
+        surface consults every discovered authorizer rather than only the first."""
+
+        class _PermissiveImpostor:
+            def response_id_ownership_refusal(self, response_id, user_api_key_dict):
+                return None
+
+        streaming = _native_streaming(
+            monkeypatch,
+            user_api_key_dict=_ws_auth(),
+            response_id_authorizers=[_PermissiveImpostor(), _ws_id_authorizer()],
+        )
+
+        allowed = await streaming._enforce_or_reject_frame(
+            json.dumps(
+                {
+                    "type": "response.create",
+                    "previous_response_id": _WS_FABRICATED_STRANGER_ID,
+                }
+            )
+        )
+
+        assert allowed is False
+        streaming.backend_ws.send.assert_not_called()

--- a/tests/test_litellm/test_responses_id_security.py
+++ b/tests/test_litellm/test_responses_id_security.py
@@ -733,3 +733,183 @@ class TestAsyncPostCallSuccessHook:
         )
 
         assert result == mock_response
+
+
+
+_FABRICATED_PROVIDER_RESPONSE_ID = "resp_fabricatedprovideridaaaaaaaaaaaaaaaa"
+_FABRICATED_UNMANAGED_ID = "resp_fabricatedunmanagedidbbbbbbbbbbbbbbbb"
+_UNIT_TEST_SALT_KEY = "lit6837-unit-test-salt-key"
+_ADDRESSED_ID_FIELD_BY_CALL_TYPE = {
+    "aresponses": "previous_response_id",
+    "aget_responses": "response_id",
+    "adelete_responses": "response_id",
+    "acancel_responses": "response_id",
+    "alist_input_items": "response_id",
+}
+
+
+@pytest.fixture
+def salt_key_env(monkeypatch):
+    """Give the encrypt/decrypt helpers a real salt key so ids round-trip for real."""
+    monkeypatch.setenv("LITELLM_SALT_KEY", _UNIT_TEST_SALT_KEY)
+    return _UNIT_TEST_SALT_KEY
+
+
+def _hook(general_settings=None, signing_key=_UNIT_TEST_SALT_KEY):
+    settings = general_settings if general_settings is not None else {}
+    return ResponsesIDSecurity(
+        general_settings_reader=lambda: settings,
+        signing_key_reader=lambda: signing_key,
+    )
+
+
+def _auth(user_id="owner-user", team_id="owner-team", user_role=None):
+    from litellm.proxy._types import UserAPIKeyAuth
+
+    return UserAPIKeyAuth(user_id=user_id, team_id=team_id, user_role=user_role)
+
+
+def _issue_managed_id(hook, owner, provider_response_id=_FABRICATED_PROVIDER_RESPONSE_ID):
+    """Mint an id exactly the way the proxy hands one to a client on create."""
+    issued = hook._encrypt_response_id(
+        ResponsesAPIResponse(
+            id=provider_response_id, created_at=1234567890, output=[], status="completed"
+        ),
+        owner,
+    )
+    return issued.id
+
+
+class TestUnrecognizedResponseIdIsRejected:
+    """An id this proxy never issued carries no owner, so it must not reach the provider."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("call_type", sorted(_ADDRESSED_ID_FIELD_BY_CALL_TYPE))
+    async def test_unmanaged_id_is_rejected_and_not_forwarded(self, mock_cache, salt_key_env, call_type):
+        field = _ADDRESSED_ID_FIELD_BY_CALL_TYPE[call_type]
+        data = {field: _FABRICATED_UNMANAGED_ID}
+
+        with pytest.raises(HTTPException) as exc_info:
+            await _hook().async_pre_call_hook(
+                user_api_key_dict=_auth(),
+                cache=mock_cache,
+                data=data,
+                call_type=call_type,
+            )
+
+        assert exc_info.value.status_code == 403
+        assert "allow_unmanaged_response_ids" in exc_info.value.detail
+        assert data[field] == _FABRICATED_UNMANAGED_ID
+
+    @pytest.mark.asyncio
+    async def test_owner_can_still_address_the_id_the_proxy_issued_it(self, mock_cache, salt_key_env):
+        hook = _hook()
+        owner = _auth()
+        data = {"response_id": _issue_managed_id(hook, owner)}
+
+        result = await hook.async_pre_call_hook(
+            user_api_key_dict=owner,
+            cache=mock_cache,
+            data=data,
+            call_type="aget_responses",
+        )
+
+        assert result["response_id"] == _FABRICATED_PROVIDER_RESPONSE_ID
+
+    @pytest.mark.asyncio
+    async def test_stranger_cannot_address_an_id_issued_to_someone_else(self, mock_cache, salt_key_env):
+        hook = _hook()
+        issued_id = _issue_managed_id(hook, _auth())
+        data = {"response_id": issued_id}
+
+        with pytest.raises(HTTPException) as exc_info:
+            await hook.async_pre_call_hook(
+                user_api_key_dict=_auth(user_id="stranger-user", team_id="stranger-team"),
+                cache=mock_cache,
+                data=data,
+                call_type="aget_responses",
+            )
+
+        assert exc_info.value.status_code == 403
+        assert data["response_id"] == issued_id
+
+    @pytest.mark.asyncio
+    async def test_unmanaged_previous_response_id_cannot_seed_a_new_response(self, mock_cache, salt_key_env):
+        data = {"model": "gpt-fake", "previous_response_id": _FABRICATED_UNMANAGED_ID}
+
+        with pytest.raises(HTTPException) as exc_info:
+            await _hook().async_pre_call_hook(
+                user_api_key_dict=_auth(),
+                cache=mock_cache,
+                data=data,
+                call_type="aresponses",
+            )
+
+        assert exc_info.value.status_code == 403
+        assert data["previous_response_id"] == _FABRICATED_UNMANAGED_ID
+
+    @pytest.mark.asyncio
+    async def test_re_entering_the_hook_on_the_same_request_does_not_reject(self, mock_cache, salt_key_env):
+        """The rate-limit fallback retry runs pre-call twice over one already-rewritten dict."""
+        hook = _hook()
+        owner = _auth()
+        data = {"model": "gpt-fake", "previous_response_id": _issue_managed_id(hook, owner)}
+
+        first = await hook.async_pre_call_hook(
+            user_api_key_dict=owner, cache=mock_cache, data=data, call_type="aresponses"
+        )
+        second = await hook.async_pre_call_hook(
+            user_api_key_dict=owner, cache=mock_cache, data=first, call_type="aresponses"
+        )
+
+        assert second["previous_response_id"] == _FABRICATED_PROVIDER_RESPONSE_ID
+
+
+class TestUnmanagedResponseIdEscapeHatches:
+    """Deployments that pass provider ids through on purpose must keep working."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "general_settings",
+        [{"allow_unmanaged_response_ids": True}, {"disable_responses_id_security": True}],
+    )
+    async def test_opted_in_settings_forward_the_id_untouched(self, mock_cache, salt_key_env, general_settings):
+        data = {"response_id": _FABRICATED_UNMANAGED_ID}
+
+        result = await _hook(general_settings=general_settings).async_pre_call_hook(
+            user_api_key_dict=_auth(),
+            cache=mock_cache,
+            data=data,
+            call_type="aget_responses",
+        )
+
+        assert result["response_id"] == _FABRICATED_UNMANAGED_ID
+
+    @pytest.mark.asyncio
+    async def test_proxy_without_a_signing_key_forwards_the_id_untouched(self, mock_cache, monkeypatch):
+        monkeypatch.delenv("LITELLM_SALT_KEY", raising=False)
+        data = {"response_id": _FABRICATED_UNMANAGED_ID}
+
+        result = await _hook(signing_key=None).async_pre_call_hook(
+            user_api_key_dict=_auth(),
+            cache=mock_cache,
+            data=data,
+            call_type="aget_responses",
+        )
+
+        assert result["response_id"] == _FABRICATED_UNMANAGED_ID
+
+    @pytest.mark.asyncio
+    async def test_proxy_admin_may_address_an_unmanaged_id(self, mock_cache, salt_key_env):
+        from litellm.proxy._types import LitellmUserRoles
+
+        data = {"response_id": _FABRICATED_UNMANAGED_ID}
+
+        result = await _hook().async_pre_call_hook(
+            user_api_key_dict=_auth(user_role=LitellmUserRoles.PROXY_ADMIN),
+            cache=mock_cache,
+            data=data,
+            call_type="aget_responses",
+        )
+
+        assert result["response_id"] == _FABRICATED_UNMANAGED_ID

--- a/tests/test_litellm/test_responses_id_security.py
+++ b/tests/test_litellm/test_responses_id_security.py
@@ -913,3 +913,62 @@ class TestUnmanagedResponseIdEscapeHatches:
         )
 
         assert result["response_id"] == _FABRICATED_UNMANAGED_ID
+
+
+class TestClientSuppliedRetainedIdCannotBypassAuthorization:
+    """The retained-id key travels in the request body, so it is re-authorized, never trusted."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("call_type", sorted(_ADDRESSED_ID_FIELD_BY_CALL_TYPE))
+    async def test_forged_retained_id_is_still_authorized(self, mock_cache, salt_key_env, call_type):
+        field = _ADDRESSED_ID_FIELD_BY_CALL_TYPE[call_type]
+        data = {
+            field: _FABRICATED_UNMANAGED_ID,
+            "_litellm_addressed_response_id": _FABRICATED_UNMANAGED_ID,
+        }
+
+        with pytest.raises(HTTPException) as exc_info:
+            await _hook().async_pre_call_hook(
+                user_api_key_dict=_auth(),
+                cache=mock_cache,
+                data=data,
+                call_type=call_type,
+            )
+
+        assert exc_info.value.status_code == 403
+        assert data[field] == _FABRICATED_UNMANAGED_ID
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("forged", [{"nested": "value"}, ["list"], 42, "", None])
+    async def test_non_string_retained_id_falls_back_to_the_addressed_field(self, mock_cache, salt_key_env, forged):
+        data = {"response_id": _FABRICATED_UNMANAGED_ID, "_litellm_addressed_response_id": forged}
+
+        with pytest.raises(HTTPException) as exc_info:
+            await _hook().async_pre_call_hook(
+                user_api_key_dict=_auth(),
+                cache=mock_cache,
+                data=data,
+                call_type="aget_responses",
+            )
+
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_stranger_forging_their_own_id_never_reaches_someone_elses_response(
+        self, mock_cache, salt_key_env
+    ):
+        hook = _hook()
+        stranger = _auth(user_id="stranger-user", team_id="stranger-team")
+        stranger_id = _issue_managed_id(hook, stranger, provider_response_id="resp_strangerownprovideridcccccccc")
+        victim_provider_id = "resp_victimprovideriddddddddddddddddddddd"
+        data = {"response_id": victim_provider_id, "_litellm_addressed_response_id": stranger_id}
+
+        result = await hook.async_pre_call_hook(
+            user_api_key_dict=stranger,
+            cache=mock_cache,
+            data=data,
+            call_type="aget_responses",
+        )
+
+        assert result["response_id"] == "resp_strangerownprovideridcccccccc"
+        assert result["response_id"] != victim_provider_id

--- a/tests/test_litellm/test_responses_id_security.py
+++ b/tests/test_litellm/test_responses_id_security.py
@@ -972,3 +972,39 @@ class TestClientSuppliedRetainedIdCannotBypassAuthorization:
 
         assert result["response_id"] == "resp_strangerownprovideridcccccccc"
         assert result["response_id"] != victim_provider_id
+
+
+class TestResponseIdOwnershipRefusalIsTheSameStep:
+    """The WebSocket surface answers with an error frame, not a status code, so it reads
+    the very same authorization step as a value. Its verdicts must not drift from the
+    exception the HTTP routes raise."""
+
+    def test_refusal_text_matches_the_exception_the_http_routes_raise(self, salt_key_env):
+        hook = _hook()
+
+        with pytest.raises(HTTPException) as exc_info:
+            hook.authorize_response_id(_FABRICATED_UNMANAGED_ID, _auth())
+
+        assert hook.response_id_ownership_refusal(_FABRICATED_UNMANAGED_ID, _auth()) == exc_info.value.detail
+
+    def test_owner_addressing_an_id_the_proxy_issued_is_not_refused(self, salt_key_env):
+        hook = _hook()
+        owner = _auth()
+
+        assert hook.response_id_ownership_refusal(_issue_managed_id(hook, owner), owner) is None
+
+    def test_stranger_addressing_someone_elses_issued_id_is_refused(self, salt_key_env):
+        hook = _hook()
+        issued_id = _issue_managed_id(hook, _auth())
+        stranger = _auth(user_id="stranger-user", team_id="stranger-team")
+
+        assert hook.response_id_ownership_refusal(issued_id, stranger) is not None
+
+    @pytest.mark.parametrize(
+        "general_settings",
+        [{"allow_unmanaged_response_ids": True}, {"disable_responses_id_security": True}],
+    )
+    def test_escape_hatches_refuse_nothing(self, salt_key_env, general_settings):
+        hook = _hook(general_settings=general_settings)
+
+        assert hook.response_id_ownership_refusal(_FABRICATED_UNMANAGED_ID, _auth()) is None

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -25529,6 +25529,11 @@ export interface components {
              */
             allow_cli_sso_verification_uri_complete?: boolean | null;
             /**
+             * Allow Unmanaged Response Ids
+             * @description If True, lets keys address Responses API ids that this proxy did not issue (raw provider ids, or ids issued before response-id encryption was configured). Such an id carries no owner, so no ownership check can run on it; ids this proxy did issue keep full ownership enforcement. Off by default, in which case an unrecognized response id is rejected with 403
+             */
+            allow_unmanaged_response_ids?: boolean | null;
+            /**
              * Allowed Routes
              * @description Proxy API Endpoints you want users to be able to access
              */
@@ -25642,6 +25647,11 @@ export interface components {
              * @description If True and SSO is configured (MICROSOFT_CLIENT_ID, GOOGLE_CLIENT_ID, GENERIC_CLIENT_ID, or SAML_IDP_METADATA_URL/XML), disables username/password login on /login, /v2/login, and /v3/login so SSO is the only way to reach the Admin UI. An admin locked out of the UI can still administer the proxy over the API with the master key; unset this setting and restart the proxy to restore UI username/password login. Default is False.
              */
             disable_password_login_when_sso_enabled?: boolean | null;
+            /**
+             * Disable Responses Id Security
+             * @description If True, disables ownership enforcement on Responses API ids. Keys may then retrieve, cancel, delete, and chain from any response id, including ids belonging to another user or team and ids this proxy never issued. WARNING: this removes tenant isolation on /v1/responses
+             */
+            disable_responses_id_security?: boolean | null;
             /**
              * Enable Public Model Hub
              * @description Public model hub for users to see what models they have access to, supported openai params, etc.


### PR DESCRIPTION
## TLDR

Problem this solves:

- WebSocket `/v1/responses` never checked who owns `previous_response_id`
- A key could continue a conversation belonging to a different key
- The HTTP routes already refuse this; the socket did not
- Both WebSocket handlers leaked it, native relay and managed alike

How it solves it:

- Both handlers now run the same authorization step the HTTP routes run
- A connection's own turns still continue without re-authorizing anything
- Both escape hatches behave identically on the socket and on HTTP
- No second per-surface check: one shared step, found by duck-typing
- Every placement of the id in a frame is authorized, not just one of them
- Every discovered authorizer is consulted, so no callback can stand in for the hook

## Base branch

This branches off #39548 (`litellm_responses_id_ownership_unrecognized`), not staging, because #39548 is what creates the single shared authorization step. Branching off staging would mean either duplicating that step or conflicting with it, and the ticket explicitly asks for one step both surfaces share. The cost is that this PR can only merge after #39548 does.

## User Flow

Before: a developer's key can pick up and continue a Responses conversation created by a completely different key, and read what that conversation said

1. Alice's app opens `ws://litellm-domain/v1/responses?model=gpt-5.6` with her own key, sends a `response.create` frame, and gets a normal event stream back ending in a response id
2. Bob, a different user on a different team with his own key, opens the same `ws://litellm-domain/v1/responses?model=gpt-5.6`
3. Bob sends a `response.create` frame carrying Alice's response id as `previous_response_id`
4. The gateway answers with a normal stream, and the model's reply contains content from Alice's turn
5. Bob repeats step 3 against a model that has no native WebSocket, so the socket is served by the gateway's own handler, and gets the same result
6. Bob sends the same `previous_response_id` to `POST https://litellm-domain/v1/responses` and gets `403 Forbidden`, so the refusal he hits on HTTP is the one the socket skips
7. Another user could read the contents of a conversation created by someone else's key, on either kind of WebSocket connection

After: the same replay is refused on the socket the way it already was on HTTP, and Alice's own multi-turn session is untouched

1. Alice's app opens `ws://litellm-domain/v1/responses?model=gpt-5.6` with her own key, sends a `response.create` frame, and gets a normal event stream back ending in a response id
2. Bob, a different user on a different team with his own key, opens the same `ws://litellm-domain/v1/responses?model=gpt-5.6`
3. Bob sends a `response.create` frame carrying Alice's response id as `previous_response_id`
4. The gateway answers with a single `error` frame of type `permission_denied`, nothing is sent to the provider, and the socket stays open for Bob to send a frame he is allowed to send
5. Bob repeats step 3 against a model that has no native WebSocket and gets the same `permission_denied` error frame
6. Bob sends the same `previous_response_id` to `POST https://litellm-domain/v1/responses` and still gets `403 Forbidden`, so both surfaces now answer the same way
7. Alice keeps chaining turns on her own open connection exactly as before, each new frame carrying the id her last turn returned
8. Another user can no longer read a conversation created by someone else's key over either kind of WebSocket connection

## Relevant issues

## Linear ticket

Resolves LIT-6843

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Two proxies on the same machine and the same database, one at the merge base and one at the PR tip, each with two keys belonging to different users on different teams. `gpt-5.6` is served by the native-provider relay and `xai-ws` (grok-4.6) by the gateway's own handler, so both WebSocket paths are covered. `ws_client.py` is a plain `websockets` client: it connects, sends one `response.create` frame, prints the event types, the response id and the assistant text, and dumps any error frame. The tip proxy was restarted on a fresh port between batches of legs to keep only two proxies resident at a time, so the After legs below name 33871 or 33873 and the escape-hatch legs name 33872; all three run the same tip and the same config.

```yaml
# config.yaml (both proxies; the escape-hatch proxy adds allow_unmanaged_response_ids: true)
model_list:
  - model_name: gpt-5.6
    litellm_params:
      model: openai/gpt-5.6
      api_key: os.environ/OPENAI_API_KEY
  - model_name: xai-ws
    litellm_params:
      model: xai/grok-4.6
      api_key: os.environ/XAI_API_KEY
general_settings:
  master_key: os.environ/LITELLM_MASTER_KEY
```

### Before (0266b45818)

#### Owner's own conversation, native relay, one connection

1. `python ws_client.py --url ws://127.0.0.1:29776/v1/responses --key $OWNER --model gpt-5.6 --input "Remember this: my secret project codeword is BLUEHERON. Reply with just OK." --followup "What is my secret project codeword? Answer with just the word."`
2. Turn 1 returns `'OK'`, turn 2 chains on turn 1's id and returns `'BLUEHERON'`

#### A different key replays that response id, native relay

1. `python ws_client.py --url ws://127.0.0.1:29776/v1/responses --key $STRANGER --model gpt-5.6 --input "What is my secret project codeword? Answer with just the word." --previous-response-id <owner's id>`
2. `assistant text: 'BLUEHERON'`, so the stranger's key read the owner's conversation

#### Owner's own conversation, managed handler, one connection

1. Same as above with `--model xai-ws`
2. Turn 1 returns `'OK'`, turn 2 returns `'BLUEHERON'`

#### A different key replays that response id, managed handler

1. Same replay with `--model xai-ws` and the stranger's key
2. `assistant text: 'BLUEHERON'`, so the managed handler leaks it too

#### The owning key replays its own id on a new connection, both handlers

1. Same replay with the owner's key on a fresh connection, once per model
2. `assistant text: 'BLUEHERON'` on both, so cross-connection continuation works

### After (e9d268ae89)

#### Owner's own conversation, native relay, one connection

1. `python ws_client.py --url ws://127.0.0.1:33871/v1/responses --key $OWNER --model gpt-5.6 --input "Remember this: my secret project codeword is BLUEHERON. Reply with just OK." --followup "What is my secret project codeword? Answer with just the word."`
2. Turn 1 returns `'OK'`, turn 2 chains on turn 1's id and returns `'BLUEHERON'`, unchanged

#### A different key replays that response id, native relay

1. `python ws_client.py --url ws://127.0.0.1:33871/v1/responses --key $STRANGER --model gpt-5.6 --input "What is my secret project codeword? Answer with just the word." --previous-response-id <owner's id>`
2. ```json
   {"type": "error", "error": {"type": "permission_denied", "message": "Forbidden. This response id was not issued by this proxy, so the proxy cannot tell who owns it. To let keys address responses this proxy did not issue, set general_settings::allow_unmanaged_response_ids to True in the config.yaml file."}}
   ```

#### Owner's own conversation, managed handler, one connection

1. Same as above with `--model xai-ws`
2. Turn 1 returns `'OK'`, turn 2 returns `'BLUEHERON'`, unchanged

#### A different key replays that response id, managed handler

1. Same replay with `--model xai-ws` and the stranger's key
2. The same `permission_denied` error frame, and nothing reaches the provider

#### The owning key replays its own id on a new connection, both handlers

1. Same replay with the owner's key on a fresh connection, once per model, against a proxy at this same tip on port 33873
2. The same `permission_denied` error frame on both. This is the Severe caveat below, not the intended outcome

#### Frames that carry the id in more than one place, native relay

1. Same replay with the stranger's key, in a frame that carries the id at the top level and also carries a nested `response` object
2. The same `permission_denied` error frame, and the frame never leaves the proxy
3. At the previous tip (993e283cc4) that frame was forwarded instead: the gate read only the nested placement whenever that object was present, so the top-level id went upstream unauthorized. What came back there was the provider's own `400 invalid_request_error` naming `response` as an unknown parameter, so this particular shape was not extracting anything from OpenAI today. It was still a gate that disagreed with what the relay forwards, which is the bug: the same file already defends the `model` field across both placements for exactly this reason

#### Frames that carry the id in more than one place, managed handler

1. Same replay with the stranger's key, body nested inside `response` and the id left at the top level
2. `assistant text: 'Unknown.'`, so nothing from the owner's conversation reached the model
3. This handler re-parses the frame rather than forwarding it, and its parser reads the nested placement only, so a top-level id there is dropped before any provider call. Worth knowing because it means a client using that shape silently loses continuation, which predates this PR and is left alone here

#### HTTP surface, same proxy, same ids

1. `curl -s -o /dev/null -w 'HTTP %{http_code}\n' -X POST http://127.0.0.1:33873/v1/responses -H "Authorization: Bearer $STRANGER" -d '{"model":"gpt-5.6","input":"...","previous_response_id":"<owner id>"}'` -> `HTTP 403`
2. The same call with the owner's key -> `HTTP 403`, matching what the socket now answers

#### Escape hatch on, both handlers and both surfaces

1. Second proxy at this same tip with `allow_unmanaged_response_ids: true`, same replay by the stranger over WebSocket -> `assistant text: 'BLUEHERON'` on `gpt-5.6` and on `xai-ws`
2. The owner's own cross-connection replay -> `'BLUEHERON'` on both models
3. `curl -X POST http://127.0.0.1:33872/v1/responses` with the stranger's key and the same id -> `HTTP 200` returning `BLUEHERON`
4. So the hatch forwards on the socket exactly the way it forwards on HTTP, for everyone

## Type

🐛 Bug Fix

## Caveats (if any)

### Severe

- The owning key can no longer continue its own response on a new connection
  - Measured on both handlers at this tip: the owner's own key, replaying the id its own stream just handed it, gets the same `permission_denied` error frame the stranger gets
  - Cause is not a migration window: the WebSocket surface has never stamped ownership onto the ids it hands out, so no WebSocket id is attributable to anyone, ever
  - Continuing turns on the same open connection is unaffected, which is the common client shape, so the blast radius is narrower than the HTTP equivalent in #39548
  - `allow_unmanaged_response_ids: true` is NOT a workaround for this. It restores the owner's flow only by restoring the forwarding, which is the hole itself; anyone who turns it on to get their flow back has turned this fix off for every key. Verified above: with the hatch on, the stranger's replay succeeds again on both handlers and on HTTP
  - The fix that keeps both properties is to stamp ownership onto the ids at the WebSocket boundary the way the HTTP create route already does, so the owner's id resolves to their key and a stranger's does not. That is deliberately not in this PR: it is the same open question #39548 is blocked on, and building a second copy of it here risks throwing it away
- Same-shaped break already exists on the HTTP routes at this base, documented in #39548

### Low

- BerriAI/litellm-docs#1161 documents `allow_unmanaged_response_ids` and the default 403. The behavior matches, but the WebSocket surface has no status code to return, so it answers an `error` frame of type `permission_denied` carrying that same message. That page needs one line saying so once the ruling on the caveat above lands
- `ci/circleci: e2e_openai_endpoints` is red at this tip on `test_anthropic_with_responses_api`, which sends a fabricated `previous_response_id` over the HTTP route. It fails identically at the base commit, so it is inherited from #39548 rather than introduced here, and it is direct evidence that the default refusal breaks a flow this repo's own e2e suite exercises
- `ci/circleci: local_testing_part1` (`test_openai_embedding_timeouts`) and `osv-scan` are the known staging-wide reds, also present at the base

### Out of scope, found while sweeping this surface

- The `openai` passthrough WebSocket route relays frames to the provider verbatim under the proxy's own upstream key with no frame inspection at all, so nothing on that route is gated. Separate surface, pre-existing, and it wants its own ticket rather than a second check bolted on here
- On the native relay, frames other than `response.create` are relayed without inspection, while the HTTP retrieve, cancel and delete routes are all gated. Whether the provider's socket protocol defines such a frame naming another response was not verified, so this is named rather than claimed

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


