### PR TITLE
[feat](proxy) Integrate LiteLLM Rate Limiting with `llm-d` flow control

### DIFF
--- a/litellm/proxy/hooks/parallel_request_limiter_v3.py
+++ b/litellm/proxy/hooks/parallel_request_limiter_v3.py
@@ -22,6 +22,7 @@ from typing import (
     TypedDict,
 )
 
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from typing_extensions import NotRequired, ReadOnly
 
 from litellm import DualCache
@@ -447,6 +448,34 @@ class RateLimitResponseWithDescriptors(TypedDict):
     response: RateLimitResponse
 
 
+class RateLimitDemotionPolicy(BaseModel):
+    """
+    Soft rate limiting: tag requests that approach or exceed their rate
+    limits for downstream priority demotion instead of only rejecting them.
+
+    ``demotion_headers`` are merged into the request's ``extra_headers`` so
+    they reach the upstream inference server, e.g. llm-d's inference gateway
+    schedules a request carrying ``x-llm-d-inference-objective: best_effort``
+    at best-effort priority. ``demote_at`` is the saturation fraction
+    (used/limit, max across the caller's checked windows) at or above which
+    an admitted request is tagged preemptively. ``over_limit_action:
+    "demote"`` converts the 429 on an over-limit request into a demotion:
+    the request is forwarded carrying the headers, holds no parallel slot or
+    token reservation, and its actual usage is still charged to the windows
+    post-call.
+
+    Configured globally under ``general_settings.rate_limit_demotion`` or
+    per virtual key via ``metadata.rate_limit_demotion``; a key-level policy
+    replaces the global one.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    demote_at: float | None = Field(default=None, gt=0.0)
+    over_limit_action: Literal["reject", "demote"] = "reject"
+    demotion_headers: Mapping[str, str] = Field(default_factory=dict)
+
+
 class _RateLimitDescriptorSink(Protocol):
     def append(self, descriptor: RateLimitDescriptor, /) -> None: ...
 
@@ -580,6 +609,43 @@ def _parse_output_cap_value(raw_value: object) -> int | None:
         return int(float(raw_value))
     except (ValueError, OverflowError):
         return None
+
+
+def _general_settings_rate_limit_demotion() -> object:
+    from litellm.proxy.proxy_server import general_settings
+
+    return general_settings.get("rate_limit_demotion")
+
+
+def _resolve_demotion_policy(user_api_key_dict: UserAPIKeyAuth) -> RateLimitDemotionPolicy | None:
+    metadata: Final = user_api_key_dict.metadata or {}
+    raw: Final = metadata.get("rate_limit_demotion") or _general_settings_rate_limit_demotion()
+    if raw is None:
+        return None
+    try:
+        return RateLimitDemotionPolicy.model_validate(raw)
+    except ValidationError as e:
+        verbose_proxy_logger.warning("Ignoring invalid rate_limit_demotion config, keeping hard 429 behavior: %s", e)
+        return None
+
+
+def _max_rate_limit_saturation(response: RateLimitResponse | None) -> float | None:
+    if response is None:
+        return None
+    used_fractions: Final = tuple(
+        (status["current_limit"] - status["limit_remaining"]) / status["current_limit"]
+        for status in response["statuses"]
+        if status["current_limit"] > 0
+    )
+    return max(used_fractions, default=None)
+
+
+def _apply_demotion_headers(
+    data: Mapping[str, object], policy: RateLimitDemotionPolicy
+) -> dict[str, object]:  # mutable-ok: async_pre_call_hook's contract returns the replacement request dict
+    existing: Final = data.get("extra_headers")
+    existing_headers: Final[Mapping[str, object]] = existing if isinstance(existing, Mapping) else {}
+    return {**data, "extra_headers": {**existing_headers, **policy.demotion_headers}}
 
 
 class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
@@ -3401,6 +3467,12 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
         """
         Pre-call hook to check rate limits before making the API call.
         Supports dynamic rate limiting based on deployment health.
+
+        With a :class:`RateLimitDemotionPolicy` in effect, an over-limit
+        request is demoted (forwarded carrying the policy's headers) instead
+        of rejected when ``over_limit_action`` is ``"demote"``, and an
+        admitted request at or above ``demote_at`` saturation is tagged with
+        the same headers preemptively.
         """
         verbose_proxy_logger.debug("Inside Rate Limit Pre-Call Hook")
 
@@ -3418,6 +3490,50 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
                 data=data,
                 call_type=call_type,
             )
+
+        demotion_policy: Final = _resolve_demotion_policy(user_api_key_dict)
+        if demotion_policy is None:
+            await self._enforce_pre_call_rate_limits(
+                user_api_key_dict=user_api_key_dict,
+                data=data,
+                call_type=call_type,
+            )
+            return None
+
+        try:
+            await self._enforce_pre_call_rate_limits(
+                user_api_key_dict=user_api_key_dict,
+                data=data,
+                call_type=call_type,
+            )
+        except ProxyRateLimitError:
+            if demotion_policy.over_limit_action != "demote":
+                raise
+            # Every raise site releases its own slots and refunds counters,
+            # but a combined-TPM reservation refunded by the project
+            # ITPM/OTPM path leaves stash.reserved_* populated, and the
+            # success-path reconciliation does not consult
+            # reservation_released for combined TPM. Zero them so the
+            # demoted request settles at exactly +actual usage.
+            stash.reserved_tokens = 0
+            stash.reserved_scopes = frozenset()
+            stash.reserved_model = None
+            return _apply_demotion_headers(data, demotion_policy)
+
+        if demotion_policy.demote_at is None:
+            return None
+        saturation: Final = _max_rate_limit_saturation(stash.rate_limit_response)
+        if saturation is None or saturation < demotion_policy.demote_at:
+            return None
+        return _apply_demotion_headers(data, demotion_policy)
+
+    async def _enforce_pre_call_rate_limits(
+        self,
+        user_api_key_dict: UserAPIKeyAuth,
+        data: dict,  # mutable-ok: enforcement writes the implicit output cap into the request body in place
+        call_type: str,
+    ) -> None:
+        stash: Final = claim_request_stash_for_data(data)
 
         # Get rate limit types from metadata
         metadata: Final = user_api_key_dict.metadata or {}

--- a/litellm/proxy/hooks/parallel_request_limiter_v3.py
+++ b/litellm/proxy/hooks/parallel_request_limiter_v3.py
@@ -450,19 +450,14 @@ class RateLimitResponseWithDescriptors(TypedDict):
 
 class RateLimitDemotionPolicy(BaseModel):
     """
-    Soft rate limiting: tag requests that approach or exceed their rate
-    limits for downstream priority demotion instead of only rejecting them.
-
-    ``demotion_headers`` are merged into the request's ``extra_headers`` so
-    they reach the upstream inference server, e.g. llm-d's inference gateway
-    schedules a request carrying ``x-llm-d-inference-objective: best_effort``
-    at best-effort priority. ``demote_at`` is the saturation fraction
-    (used/limit, max across the caller's checked windows) at or above which
-    an admitted request is tagged preemptively. ``over_limit_action:
-    "demote"`` converts the 429 on an over-limit request into a demotion:
-    the request is forwarded carrying the headers, holds no parallel slot or
-    token reservation, and its actual usage is still charged to the windows
-    post-call.
+    Soft rate limiting: tag admitted requests that approach their rate
+    limits for downstream priority demotion. ``demote_at`` is the saturation
+    fraction (used/limit, max across the caller's checked windows) at or
+    above which ``demotion_headers`` are merged into the request's
+    ``extra_headers`` so they reach the upstream inference server, e.g.
+    llm-d's inference gateway schedules a request carrying
+    ``x-llm-d-inference-objective: best_effort`` at best-effort priority.
+    Over-limit requests are rejected with a 429 as usual.
 
     Configured globally under ``general_settings.rate_limit_demotion`` or
     per virtual key via ``metadata.rate_limit_demotion``; a key-level policy
@@ -471,9 +466,8 @@ class RateLimitDemotionPolicy(BaseModel):
 
     model_config = ConfigDict(frozen=True, extra="forbid")
 
-    demote_at: float | None = Field(default=None, gt=0.0)
-    over_limit_action: Literal["reject", "demote"] = "reject"
-    demotion_headers: Mapping[str, str] = Field(default_factory=dict)
+    demote_at: float = Field(gt=0.0)
+    demotion_headers: Mapping[str, str]
 
 
 class _RateLimitDescriptorSink(Protocol):
@@ -625,7 +619,7 @@ def _resolve_demotion_policy(user_api_key_dict: UserAPIKeyAuth) -> RateLimitDemo
     try:
         return RateLimitDemotionPolicy.model_validate(raw)
     except ValidationError as e:
-        verbose_proxy_logger.warning("Ignoring invalid rate_limit_demotion config, keeping hard 429 behavior: %s", e)
+        verbose_proxy_logger.warning("Ignoring invalid rate_limit_demotion config, demotion disabled: %s", e)
         return None
 
 
@@ -3468,11 +3462,9 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
         Pre-call hook to check rate limits before making the API call.
         Supports dynamic rate limiting based on deployment health.
 
-        With a :class:`RateLimitDemotionPolicy` in effect, an over-limit
-        request is demoted (forwarded carrying the policy's headers) instead
-        of rejected when ``over_limit_action`` is ``"demote"``, and an
-        admitted request at or above ``demote_at`` saturation is tagged with
-        the same headers preemptively.
+        With a :class:`RateLimitDemotionPolicy` in effect, an admitted
+        request at or above ``demote_at`` saturation is tagged with the
+        policy's headers.
         """
         verbose_proxy_logger.debug("Inside Rate Limit Pre-Call Hook")
 
@@ -3491,36 +3483,14 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
                 call_type=call_type,
             )
 
+        await self._enforce_pre_call_rate_limits(
+            user_api_key_dict=user_api_key_dict,
+            data=data,
+            call_type=call_type,
+        )
+
         demotion_policy: Final = _resolve_demotion_policy(user_api_key_dict)
         if demotion_policy is None:
-            await self._enforce_pre_call_rate_limits(
-                user_api_key_dict=user_api_key_dict,
-                data=data,
-                call_type=call_type,
-            )
-            return None
-
-        try:
-            await self._enforce_pre_call_rate_limits(
-                user_api_key_dict=user_api_key_dict,
-                data=data,
-                call_type=call_type,
-            )
-        except ProxyRateLimitError:
-            if demotion_policy.over_limit_action != "demote":
-                raise
-            # Every raise site releases its own slots and refunds counters,
-            # but a combined-TPM reservation refunded by the project
-            # ITPM/OTPM path leaves stash.reserved_* populated, and the
-            # success-path reconciliation does not consult
-            # reservation_released for combined TPM. Zero them so the
-            # demoted request settles at exactly +actual usage.
-            stash.reserved_tokens = 0
-            stash.reserved_scopes = frozenset()
-            stash.reserved_model = None
-            return _apply_demotion_headers(data, demotion_policy)
-
-        if demotion_policy.demote_at is None:
             return None
         saturation: Final = _max_rate_limit_saturation(stash.rate_limit_response)
         if saturation is None or saturation < demotion_policy.demote_at:

--- a/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py
+++ b/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py
@@ -6004,3 +6004,222 @@ async def test_success_hook_leaves_stash_untouched_for_non_batch_responses():
         data={}, user_api_key_dict=user, response=ModelResponse(usage=Usage(total_tokens=5))
     )
     assert get_request_stash().batch_enqueued_reservation == reservation
+
+
+DEMOTION_HEADER = "x-llm-d-inference-objective"
+
+
+def _demotion_auth(rpm_limit: int, policy: Optional[dict] = None) -> UserAPIKeyAuth:
+    metadata = {"rate_limit_demotion": policy} if policy is not None else {}
+    return UserAPIKeyAuth(
+        api_key=hash_token("sk-demotion"), rpm_limit=rpm_limit, metadata=metadata
+    )
+
+
+def _demotion_handler() -> _PROXY_MaxParallelRequestsHandler:
+    return _PROXY_MaxParallelRequestsHandler(
+        internal_usage_cache=InternalUsageCache(DualCache())
+    )
+
+
+@pytest.mark.asyncio
+async def test_over_limit_request_demoted_instead_of_429():
+    """
+    With over_limit_action=demote, an over-limit request is forwarded with the
+    policy's headers merged into extra_headers instead of raising a 429, and
+    under-limit requests are untouched.
+    """
+    user_api_key_dict = _demotion_auth(
+        rpm_limit=1,
+        policy={
+            "over_limit_action": "demote",
+            "demotion_headers": {DEMOTION_HEADER: "best_effort"},
+        },
+    )
+    handler = _demotion_handler()
+    local_cache = DualCache()
+
+    first = await handler.async_pre_call_hook(
+        user_api_key_dict=user_api_key_dict, cache=local_cache, data={}, call_type=""
+    )
+    assert first is None
+
+    second = await handler.async_pre_call_hook(
+        user_api_key_dict=user_api_key_dict,
+        cache=local_cache,
+        data={"extra_headers": {"x-existing": "kept"}},
+        call_type="",
+    )
+    assert second is not None
+    assert second["extra_headers"] == {
+        "x-existing": "kept",
+        DEMOTION_HEADER: "best_effort",
+    }
+
+
+@pytest.mark.asyncio
+async def test_saturation_at_demote_at_threshold_tags_admitted_request():
+    """
+    demote_at tags admitted requests once used/limit reaches the threshold;
+    requests below it pass through untagged.
+    """
+    user_api_key_dict = _demotion_auth(
+        rpm_limit=10,
+        policy={
+            "demote_at": 0.5,
+            "demotion_headers": {DEMOTION_HEADER: "best_effort"},
+        },
+    )
+    handler = _demotion_handler()
+    local_cache = DualCache()
+
+    for _ in range(4):
+        result = await handler.async_pre_call_hook(
+            user_api_key_dict=user_api_key_dict,
+            cache=local_cache,
+            data={},
+            call_type="",
+        )
+        assert result is None
+
+    fifth = await handler.async_pre_call_hook(
+        user_api_key_dict=user_api_key_dict, cache=local_cache, data={}, call_type=""
+    )
+    assert fifth is not None
+    assert fifth["extra_headers"] == {DEMOTION_HEADER: "best_effort"}
+
+
+@pytest.mark.asyncio
+async def test_over_limit_still_raises_429_when_action_is_reject():
+    """
+    A policy carrying only demote_at keeps the default over_limit_action of
+    reject: the over-limit request still 429s even though the request before
+    it was tagged.
+    """
+    user_api_key_dict = _demotion_auth(
+        rpm_limit=1,
+        policy={
+            "demote_at": 0.5,
+            "demotion_headers": {DEMOTION_HEADER: "best_effort"},
+        },
+    )
+    handler = _demotion_handler()
+    local_cache = DualCache()
+
+    first = await handler.async_pre_call_hook(
+        user_api_key_dict=user_api_key_dict, cache=local_cache, data={}, call_type=""
+    )
+    assert first is not None
+    assert first["extra_headers"] == {DEMOTION_HEADER: "best_effort"}
+
+    with pytest.raises(HTTPException) as exc_info:
+        await handler.async_pre_call_hook(
+            user_api_key_dict=user_api_key_dict,
+            cache=local_cache,
+            data={},
+            call_type="",
+        )
+    assert exc_info.value.status_code == 429
+
+
+@pytest.mark.asyncio
+async def test_invalid_demotion_policy_keeps_hard_429():
+    """
+    An invalid policy (unknown field) is ignored entirely, so over-limit
+    requests keep failing closed with a 429.
+    """
+    user_api_key_dict = _demotion_auth(
+        rpm_limit=1,
+        policy={
+            "over_limit_action": "demote",
+            "demotion_headers": {DEMOTION_HEADER: "best_effort"},
+            "unknown_field": True,
+        },
+    )
+    handler = _demotion_handler()
+    local_cache = DualCache()
+
+    await handler.async_pre_call_hook(
+        user_api_key_dict=user_api_key_dict, cache=local_cache, data={}, call_type=""
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        await handler.async_pre_call_hook(
+            user_api_key_dict=user_api_key_dict,
+            cache=local_cache,
+            data={},
+            call_type="",
+        )
+    assert exc_info.value.status_code == 429
+
+
+@pytest.mark.asyncio
+async def test_demotion_policy_from_general_settings(monkeypatch):
+    """
+    A policy under general_settings.rate_limit_demotion applies to keys
+    without their own metadata policy.
+    """
+    from litellm.proxy import proxy_server
+
+    monkeypatch.setitem(
+        proxy_server.general_settings,
+        "rate_limit_demotion",
+        {
+            "over_limit_action": "demote",
+            "demotion_headers": {DEMOTION_HEADER: "best_effort"},
+        },
+    )
+    user_api_key_dict = _demotion_auth(rpm_limit=1)
+    handler = _demotion_handler()
+    local_cache = DualCache()
+
+    await handler.async_pre_call_hook(
+        user_api_key_dict=user_api_key_dict, cache=local_cache, data={}, call_type=""
+    )
+    demoted = await handler.async_pre_call_hook(
+        user_api_key_dict=user_api_key_dict, cache=local_cache, data={}, call_type=""
+    )
+    assert demoted is not None
+    assert demoted["extra_headers"] == {DEMOTION_HEADER: "best_effort"}
+
+
+@pytest.mark.asyncio
+async def test_demoted_over_limit_request_holds_no_reservation_state():
+    """
+    When enforcement raises after a combined-TPM reservation was refunded
+    (the project ITPM/OTPM over-limit path), the demoted request must not
+    keep stale reserved_* stash fields, or post-call reconciliation would
+    settle its counters below actual usage.
+    """
+    from litellm.proxy.common_utils.proxy_rate_limit_error import ProxyRateLimitError
+
+    user_api_key_dict = _demotion_auth(
+        rpm_limit=100,
+        policy={
+            "over_limit_action": "demote",
+            "demotion_headers": {DEMOTION_HEADER: "best_effort"},
+        },
+    )
+    handler = _demotion_handler()
+    local_cache = DualCache()
+
+    async def fake_enforce(**kwargs):
+        stash = get_or_create_request_stash()
+        stash.reserved_tokens = 25
+        stash.reserved_scopes = frozenset({("api_key", "value")})
+        stash.reserved_model = "gpt-4o"
+        stash.reservation_released = True
+        raise ProxyRateLimitError(detail="over limit")
+
+    handler._enforce_pre_call_rate_limits = fake_enforce
+
+    demoted = await handler.async_pre_call_hook(
+        user_api_key_dict=user_api_key_dict, cache=local_cache, data={}, call_type=""
+    )
+    assert demoted is not None
+    assert demoted["extra_headers"] == {DEMOTION_HEADER: "best_effort"}
+
+    stash = get_request_stash()
+    assert stash is not None
+    assert stash.reserved_tokens == 0
+    assert stash.reserved_scopes == frozenset()
+    assert stash.reserved_model is None

--- a/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py
+++ b/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py
@@ -6006,6 +6006,7 @@ async def test_success_hook_leaves_stash_untouched_for_non_batch_responses():
     assert get_request_stash().batch_enqueued_reservation == reservation
 
 
+
 DEMOTION_HEADER = "x-llm-d-inference-objective"
 
 
@@ -6023,45 +6024,11 @@ def _demotion_handler() -> _PROXY_MaxParallelRequestsHandler:
 
 
 @pytest.mark.asyncio
-async def test_over_limit_request_demoted_instead_of_429():
-    """
-    With over_limit_action=demote, an over-limit request is forwarded with the
-    policy's headers merged into extra_headers instead of raising a 429, and
-    under-limit requests are untouched.
-    """
-    user_api_key_dict = _demotion_auth(
-        rpm_limit=1,
-        policy={
-            "over_limit_action": "demote",
-            "demotion_headers": {DEMOTION_HEADER: "best_effort"},
-        },
-    )
-    handler = _demotion_handler()
-    local_cache = DualCache()
-
-    first = await handler.async_pre_call_hook(
-        user_api_key_dict=user_api_key_dict, cache=local_cache, data={}, call_type=""
-    )
-    assert first is None
-
-    second = await handler.async_pre_call_hook(
-        user_api_key_dict=user_api_key_dict,
-        cache=local_cache,
-        data={"extra_headers": {"x-existing": "kept"}},
-        call_type="",
-    )
-    assert second is not None
-    assert second["extra_headers"] == {
-        "x-existing": "kept",
-        DEMOTION_HEADER: "best_effort",
-    }
-
-
-@pytest.mark.asyncio
 async def test_saturation_at_demote_at_threshold_tags_admitted_request():
     """
-    demote_at tags admitted requests once used/limit reaches the threshold;
-    requests below it pass through untagged.
+    demote_at tags admitted requests once used/limit reaches the threshold,
+    merging the policy's headers into existing extra_headers; requests below
+    the threshold pass through untagged.
     """
     user_api_key_dict = _demotion_auth(
         rpm_limit=10,
@@ -6083,18 +6050,23 @@ async def test_saturation_at_demote_at_threshold_tags_admitted_request():
         assert result is None
 
     fifth = await handler.async_pre_call_hook(
-        user_api_key_dict=user_api_key_dict, cache=local_cache, data={}, call_type=""
+        user_api_key_dict=user_api_key_dict,
+        cache=local_cache,
+        data={"extra_headers": {"x-existing": "kept"}},
+        call_type="",
     )
     assert fifth is not None
-    assert fifth["extra_headers"] == {DEMOTION_HEADER: "best_effort"}
+    assert fifth["extra_headers"] == {
+        "x-existing": "kept",
+        DEMOTION_HEADER: "best_effort",
+    }
 
 
 @pytest.mark.asyncio
-async def test_over_limit_still_raises_429_when_action_is_reject():
+async def test_over_limit_still_raises_429_with_demotion_policy():
     """
-    A policy carrying only demote_at keeps the default over_limit_action of
-    reject: the over-limit request still 429s even though the request before
-    it was tagged.
+    Demotion only tags admitted requests: the request before the limit is
+    tagged, the one over it still 429s.
     """
     user_api_key_dict = _demotion_auth(
         rpm_limit=1,
@@ -6123,15 +6095,15 @@ async def test_over_limit_still_raises_429_when_action_is_reject():
 
 
 @pytest.mark.asyncio
-async def test_invalid_demotion_policy_keeps_hard_429():
+async def test_invalid_demotion_policy_is_ignored():
     """
-    An invalid policy (unknown field) is ignored entirely, so over-limit
-    requests keep failing closed with a 429.
+    An invalid policy (unknown field) is ignored entirely: a request at full
+    saturation passes through untagged and over-limit requests still 429.
     """
     user_api_key_dict = _demotion_auth(
         rpm_limit=1,
         policy={
-            "over_limit_action": "demote",
+            "demote_at": 0.5,
             "demotion_headers": {DEMOTION_HEADER: "best_effort"},
             "unknown_field": True,
         },
@@ -6139,9 +6111,11 @@ async def test_invalid_demotion_policy_keeps_hard_429():
     handler = _demotion_handler()
     local_cache = DualCache()
 
-    await handler.async_pre_call_hook(
+    first = await handler.async_pre_call_hook(
         user_api_key_dict=user_api_key_dict, cache=local_cache, data={}, call_type=""
     )
+    assert first is None
+
     with pytest.raises(HTTPException) as exc_info:
         await handler.async_pre_call_hook(
             user_api_key_dict=user_api_key_dict,
@@ -6164,7 +6138,7 @@ async def test_demotion_policy_from_general_settings(monkeypatch):
         proxy_server.general_settings,
         "rate_limit_demotion",
         {
-            "over_limit_action": "demote",
+            "demote_at": 0.5,
             "demotion_headers": {DEMOTION_HEADER: "best_effort"},
         },
     )
@@ -6172,54 +6146,8 @@ async def test_demotion_policy_from_general_settings(monkeypatch):
     handler = _demotion_handler()
     local_cache = DualCache()
 
-    await handler.async_pre_call_hook(
+    tagged = await handler.async_pre_call_hook(
         user_api_key_dict=user_api_key_dict, cache=local_cache, data={}, call_type=""
     )
-    demoted = await handler.async_pre_call_hook(
-        user_api_key_dict=user_api_key_dict, cache=local_cache, data={}, call_type=""
-    )
-    assert demoted is not None
-    assert demoted["extra_headers"] == {DEMOTION_HEADER: "best_effort"}
-
-
-@pytest.mark.asyncio
-async def test_demoted_over_limit_request_holds_no_reservation_state():
-    """
-    When enforcement raises after a combined-TPM reservation was refunded
-    (the project ITPM/OTPM over-limit path), the demoted request must not
-    keep stale reserved_* stash fields, or post-call reconciliation would
-    settle its counters below actual usage.
-    """
-    from litellm.proxy.common_utils.proxy_rate_limit_error import ProxyRateLimitError
-
-    user_api_key_dict = _demotion_auth(
-        rpm_limit=100,
-        policy={
-            "over_limit_action": "demote",
-            "demotion_headers": {DEMOTION_HEADER: "best_effort"},
-        },
-    )
-    handler = _demotion_handler()
-    local_cache = DualCache()
-
-    async def fake_enforce(**kwargs):
-        stash = get_or_create_request_stash()
-        stash.reserved_tokens = 25
-        stash.reserved_scopes = frozenset({("api_key", "value")})
-        stash.reserved_model = "gpt-4o"
-        stash.reservation_released = True
-        raise ProxyRateLimitError(detail="over limit")
-
-    handler._enforce_pre_call_rate_limits = fake_enforce
-
-    demoted = await handler.async_pre_call_hook(
-        user_api_key_dict=user_api_key_dict, cache=local_cache, data={}, call_type=""
-    )
-    assert demoted is not None
-    assert demoted["extra_headers"] == {DEMOTION_HEADER: "best_effort"}
-
-    stash = get_request_stash()
-    assert stash is not None
-    assert stash.reserved_tokens == 0
-    assert stash.reserved_scopes == frozenset()
-    assert stash.reserved_model is None
+    assert tagged is not None
+    assert tagged["extra_headers"] == {DEMOTION_HEADER: "best_effort"}


### PR DESCRIPTION
## TLDR

<!-- Fill in the bullets below and keep each one short and concrete: one line per bullet, roughly 10 words max -->

Problem this solves:

- Companies running self-hosted models [e.g. inference provider like Together AI, model company like Mistral AI] offer features "Provisioned Throughput" and "Priority Tier", where for a fixed number of TPMs, a certain user's traffic is prioritized. Above the limits, the requests fall back to best-effort tier

- Inference frameworks like llm-d often support  **"flow control"**, which allows the `llm-d-router` to queue requests when the vllm servers are overloaded. Many MaaS providers using llm-d leverage this flow control feature to enable things like free tiers, batch apis, standard vs premium traffic. In all cases, the GW in front of llm-d injects headers into the request (`x-llm-d-inference-objective` and `x-llm-d-fairness-id`)

- My goal is to make this functionality work with litellm + llm-d, where administrators can configure hard caps (litellm returns 429) and soft caps (litellm forwards the request to llm-d with `priority: best-effort`). this can allow administrators running self-managed inference clusters

In a follow on PR, I plan to enable and end-to-end reference architecture of provisioned throughput (akin to https://www.together.ai/provisioned-throughput).

How it solves it:

- Create a configuration where users can express a soft rate limit [demote_at]
- When token consumption gets within demote_at percent of the hard rate limit, inject the headers specified in the configuration

Then, inference systems like llm-d can process the request if there is capacity in the inference cluster. If there is no capacity, llm-d's flow control feature will queue the request to some TTL, after which it returns 429.

In this way, administrators can enable a soft-cap with best effort processing in the self-managed cluster.

## User Flow

<!-- Two ordered lists, Before and After, walking the same end user through the same task, written strictly from that user's seat
     Read the linked issue, ticket, or customer thread first so the flow reflects the real application and the routes its users actually hit; don't invent a generic scenario
     Lead each list with one plain sentence saying where the flow fails (Before) or succeeds (After), then number the steps
     Every step is something the user does or observes: the HTTP method and full URL they hit, what they sent, and what visibly came back (status code, error text, the shape of an ID). UI steps name the page URL and what is on screen
     No LiteLLM internals: never name functions, files, DB tables, config classes, hooks, callbacks, or code paths. "The upload hands back an ID that looks like OpenAI's own `file-abc123` instead of the scrambled one the gateway returned" is right, "no managed-file row was registered" is wrong
     Keep the two lists step-for-step identical until they diverge, so the changed step is obvious
     If the bug had a security or authorization consequence, end each list with what another user could or could no longer do
     Regenerate this section whenever new commits change the PR's behavior, so it never describes an older revision

Example:

Before: a developer whose app streams chat completions gets no token counts back, so their cost dashboard reads zero

1. They send POST https://litellm-domain/v1/chat/completions with `"stream": true` and no `stream_options`
2. The last SSE chunk arrives with `"usage": null`, so their app records 0 prompt and 0 completion tokens
3. They open https://litellm-domain/ui/?page=logs and see the request logged at $0 spend

After: the same request comes back with real token counts, so the dashboard shows real spend

1. The proxy admin sets `always_include_stream_usage: true` and restarts the proxy
2. The developer sends the same POST https://litellm-domain/v1/chat/completions with `"stream": true` and no `stream_options`
3. The last SSE chunk now carries a `usage` object with real prompt and completion token counts
4. https://litellm-domain/ui/?page=logs shows that request at non-zero spend
-->

## Relevant issues

<!-- e.g., "Fixes #000" -->

## Linear ticket

<!-- if you are an internal contributor, add "Resolves " followed by the Linear ticket e.g., "Resolves LIT-1234" to link the Linear ticket to the GitHub PR. If you don't have one, leave the section blank rather than guessing -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [ ] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected
     The proof must be completely e2e with no mocks, using actual LLM calls costing real $$$ if applicable. `pytest` commands are not enough
     Show ONLY the latest run: capture Before at the merge base and After at the PR's current tip, and when new commits change behavior, replace this whole section with the fresh run instead of stacking it on top of older ones. The run must be up to date. As soon as a new commit is made and it makes this PR description's after sha stale (it's no longer tip of PR), you must re-run the QA
     Structure the section exactly as below: Before and After one heading level below this section, each naming the commit hash it was captured at, one lower-level heading per case inside each, the same case names in the same order on both sides, and numbered steps (command, observed output) under every case, never loose prose; shared setup (config, payloads) goes above Before, and with a single case, drop the case headings and number the steps directly

### Before (<hash>)

#### <case 1>

1. ...
2. ...

#### <case 2>

1. ...

### After (<hash>)

#### <case 1>

1. ...
2. ...

#### <case 2>

1. ...

     For bug fixes: Before shows the reproduction, After shows the same steps passing
     For new features: Before shows the capability missing, After shows it working end-to-end
     If the change applies to all three LLM endpoints (/v1/responses, /v1/chat/completions, /v1/messages), make each endpoint its own case, not just one
     For UI changes: before/after screenshots under the same headings -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Caveats (if any)

<!-- Group caveats under severity subheadings (### Severe, ### High, ### Medium, ### Low), with
     short bullet points inside each, just like the TLDR: one line per bullet, roughly 10 words max
     Call out known limitations, follow-up work, or anything a reviewer should watch out for
     Include only the tiers that have caveats; drop the empty ones
     - Severe: inherent to what the PR deliberately ships, there even when the code works as intended:
       it can degrade or take down a running deployment (e.g. a slow or table-locking boot migration),
       rewrite data by design, break an existing workflow on purpose, or change auth behavior. An
       operator must plan around it before rollout
     - High: an unintended hole: a correctness, security, data-loss, or backward-compatibility bug,
       unsafe to ship as is
     - Medium: a real gap someone can hit, but with a workaround or a narrow blast radius
     - Low: anything else worth noting: naming, cleanup, an edge case nobody hits
     Nest bullets as deep as helps: hierarchy beats one long line when it makes things clearer to a
     human reader
     Leave this section empty if there are none -->

## QA runbook

<!-- Only needed when your PR edits tests/e2e; delete this section otherwise

For each e2e test you added or changed, list the manual steps a reviewer can follow to reproduce it by hand against a live proxy, mapping 1:1 to what the test asserts: one top-level bullet per test giving its pytest node id followed by what it proves in plain words, then a nested "- [ ]" checklist where each item is a concrete action (route, request body, expected response) and the final item is the sanity-check step shown in the examples. Note environment prerequisites (provider credentials, config flags) and any nuances a manual run will hit. See PRs #32914 and #32963 for full examples

Example checklists:

- tests/e2e/quota_management/ratelimit/test_rate_limit_e2e.py::TestKeyRateLimits::test_rpm_limit_blocks_over_limit - a key allowed 2 requests a minute serves exactly 2 and refuses the 3rd
  - [ ] Generate a limited key: curl -X POST http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -d '{"rpm_limit": 2}'
  - [ ] Send three /v1/chat/completions requests with that key inside one minute
  - [ ] Expect the first two to return 200 and the third to return 429 naming the rpm limit
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/management/test_management_e2e.py::TestModelRoutes::test_model_create_appears_in_ui - a deployment created through the API shows up on the Admin UI models page
  - [ ] POST /model/new with the master key, a bedrock model, and aws_region_name (needs STORE_MODEL_IN_DB=True and AWS credentials)
  - [ ] Open http://localhost:4000/ui/?page=models and expect a deployment row showing the returned model id
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky
-->

## Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
