### PR TITLE
fix(proxy): no cross-provider credential fallback when the resolved provider is not in the model_config entry

### DIFF
--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -2605,21 +2605,23 @@ def _extract_credential_from_entry(entry: dict, provider: str | None = None) -> 
 
     Entry structure: {"azure": {"litellm_credentials": "name"}, ...}
 
-    When provider is given (e.g. "azure"), tries an exact provider match first.
-    Falls back to the first credential found across all provider keys.
+    When provider is given (e.g. "azure") and the entry has a key for it, that
+    provider's credential is used. When provider is given but the entry has no
+    key for it, the entry does not apply to this request and None is returned,
+    so the deployment keeps its own credentials. Only when no provider could be
+    resolved at all does this fall back to the first credential in the entry.
     """
     if not isinstance(entry, dict):
         return None
 
-    # Prefer exact provider match when provider hint is available
-    if provider and provider in entry:
-        provider_config = entry[provider]
+    if provider:
+        provider_config = entry.get(provider)
         if isinstance(provider_config, dict):
             credential_name = provider_config.get("litellm_credentials")
             if credential_name:
                 return credential_name
+        return None
 
-    # Fall back to first available provider
     for provider_config in entry.values():
         if isinstance(provider_config, dict):
             credential_name = provider_config.get("litellm_credentials")

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -4967,9 +4967,9 @@ def test_extract_credential_provider_hint_prefers_exact_match():
     result = _extract_credential_from_entry(entry)
     assert result in ("openai-cred", "azure-cred")
 
-    # Unknown provider falls back to first available
-    result = _extract_credential_from_entry(entry, provider="bedrock")
-    assert result in ("openai-cred", "azure-cred")
+    # A resolved provider that the entry does not configure gets no credential,
+    # otherwise a bedrock request would be sent with an openai or azure key
+    assert _extract_credential_from_entry(entry, provider="bedrock") is None
 
 
 def test_resolve_provider_hint_from_model_name():
@@ -5963,6 +5963,55 @@ def test_apply_overrides_provider_prefix_in_model_skips_router_lookup(
     assert data["api_base"] == "https://hotel-eastus.openai.azure.com/"
     assert data["api_key"] == "key-hotel-eastus"
     router.get_deployment_by_model_group_name.assert_not_called()
+
+
+def test_apply_overrides_single_provider_default_does_not_leak_to_other_providers(
+    setup_test_credentials,
+):
+    """
+    A team whose defaultconfig only names anthropic must not have that key
+    injected into requests the router resolves to a different provider. Before
+    this fix an unprefixed gpt-4o-mini request on such a team was sent to OpenAI
+    with the team's sk-ant key and got a 401 back.
+    """
+    litellm.credential_list.append(
+        CredentialItem(
+            credential_name="anthropic-team-1",
+            credential_info={},
+            credential_values={"api_key": "sk-ant-key-for-team-1"},
+        )
+    )
+    team_metadata = {
+        "model_config": {"defaultconfig": {"anthropic": {"litellm_credentials": "anthropic-team-1"}}}
+    }
+
+    router = MagicMock()
+    openai_deployment = MagicMock()
+    openai_deployment.litellm_params.model = "openai/gpt-4o-mini"
+    openai_deployment.litellm_params.custom_llm_provider = "openai"
+    anthropic_deployment = MagicMock()
+    anthropic_deployment.litellm_params.model = "anthropic/claude-sonnet-4-6"
+    anthropic_deployment.litellm_params.custom_llm_provider = "anthropic"
+    router.get_deployment_by_model_group_name.side_effect = lambda model_group_name: {
+        "gpt-4o-mini": openai_deployment,
+        "claude-sonnet-4.6": anthropic_deployment,
+    }.get(model_group_name)
+
+    openai_data = {"model": "gpt-4o-mini"}
+    _apply_credential_overrides_from_model_config(
+        data=openai_data,
+        user_api_key_dict=UserAPIKeyAuth(api_key="test-key", team_metadata=team_metadata),
+        llm_router=router,
+    )
+    assert "api_key" not in openai_data
+
+    anthropic_data = {"model": "claude-sonnet-4.6"}
+    _apply_credential_overrides_from_model_config(
+        data=anthropic_data,
+        user_api_key_dict=UserAPIKeyAuth(api_key="test-key", team_metadata=team_metadata),
+        llm_router=router,
+    )
+    assert anthropic_data["api_key"] == "sk-ant-key-for-team-1"
 
 
 def _make_request_mock(path: str, headers: dict) -> MagicMock:


### PR DESCRIPTION
## TLDR

Problem this solves:

- Team `defaultconfig` credential for one provider gets sent to every other provider
- A team keyed only for anthropic makes its openai requests fail with 401

How it solves it:

- A resolved provider missing from the entry now yields no override
- First-entry fallback kept only when no provider could be resolved

## User Flow

Before: a team with its own Anthropic key cannot call any OpenAI model, every request comes back 401 from OpenAI naming an Anthropic key

1. A proxy admin registers a credential and creates a team with `metadata.model_config.defaultconfig.anthropic.litellm_credentials` pointing at it, then gives the team access to `gpt-4o-mini` and `claude-haiku-4-5`
2. A developer on that team sends POST http://localhost:4000/v1/chat/completions with `{"model": "gpt-4o-mini", ...}` using their team key
3. They get HTTP 401 with `OpenAIException - Incorrect API key provided: sk-ant-...`, even though their proxy config has a valid OpenAI key on the `gpt-4o-mini` deployment
4. They send the same request with `{"model": "claude-haiku-4-5", ...}` and it is served with the team's Anthropic credential as intended

After: the same team calls OpenAI models with the deployment's OpenAI key and Anthropic models with its own Anthropic key

1. Same admin setup, nothing changes in config or team metadata
2. The developer sends POST http://localhost:4000/v1/chat/completions with `{"model": "gpt-4o-mini", ...}` using their team key
3. They get HTTP 200 with a normal completion
4. They send the same request with `{"model": "claude-haiku-4-5", ...}` and it is still served with the team's Anthropic credential

## Relevant issues

Related to #27516, which fixed provider resolution for multi-provider `defaultconfig` entries but kept the first-entry fallback for a resolved provider that is not in the entry

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Setup shared by both runs. Proxy started from the checkout with `python litellm/proxy/proxy_cli.py --config proxy_config.yaml --port 4010`, backed by a local Postgres for team management. The Anthropic credential is deliberately invalid: the question is which provider receives it, and a 401 from Anthropic with "API key is invalid" is the signal that Anthropic did

```yaml
model_list:
  - model_name: gpt-4o-mini
    litellm_params:
      model: openai/gpt-4o-mini
      api_key: os.environ/E2E_OPENAI_API_KEY
  - model_name: claude-haiku-4-5
    litellm_params:
      model: anthropic/claude-haiku-4-5-20251001
      api_key: os.environ/E2E_ANTHROPIC_API_KEY

litellm_settings:
  enable_model_config_credential_overrides: true

general_settings:
  master_key: os.environ/E2E_MASTER_KEY
  database_url: os.environ/DATABASE_URL
```

### Before (11a02b9581)

```
$ curl -s -X POST http://localhost:4010/credentials -H "Authorization: Bearer $MASTER_KEY" -H "Content-Type: application/json" -d '{"credential_name":"team-anthropic","credential_values":{"api_key":"sk-ant-team-scoped-not-a-real-key"},"credential_info":{}}'
{"success":true,"message":"Credential created successfully"}
```

```
$ curl -s -X POST http://localhost:4010/team/new -H "Authorization: Bearer $MASTER_KEY" -H "Content-Type: application/json" -d '{"team_alias":"anthropic-keyed-team","models":["gpt-4o-mini","claude-haiku-4-5"],"metadata":{"model_config":{"defaultconfig":{"anthropic":{"litellm_credentials":"team-anthropic"}}}}}'
{"team_id": "02b95fcc-19ba-41a9-bd3e-f0437207bb23", "team_alias": "anthropic-keyed-team", "models": ["gpt-4o-mini", "claude-haiku-4-5"], "metadata": {"model_config": {"defaultconfig": {"anthropic": {"litellm_credentials": "team-anthropic"}}}}}
```

```
$ curl -s -X POST http://localhost:4010/key/generate -H "Authorization: Bearer $MASTER_KEY" -H "Content-Type: application/json" -d '{"team_id":"02b95fcc-19ba-41a9-bd3e-f0437207bb23"}'
{"key": "sk-...redacted..."}
```

```
$ curl -s -w '\nHTTP %{http_code}' -X POST http://localhost:4010/v1/chat/completions -H "Authorization: Bearer $TEAM_KEY" -H "Content-Type: application/json" -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Reply with the single word ok"}],"max_tokens":5}'
{"error": {"message": "litellm.AuthenticationError: AuthenticationError: OpenAIException - Incorrect API key provided: sk-ant-t*********************-key. You can find your API key at https://platform.openai.com/account/api-keys.. Received Mode"}}
HTTP 401
```

```
$ curl -s -w '\nHTTP %{http_code}' -X POST http://localhost:4010/v1/chat/completions -H "Authorization: Bearer $TEAM_KEY" -H "Content-Type: application/json" -d '{"model":"claude-haiku-4-5","messages":[{"role":"user","content":"Reply with the single word ok"}],"max_tokens":5}'
{"error": {"message": "litellm.AuthenticationError: AnthropicException - {\"type\":\"error\",\"error\":{\"type\":\"authentication_error\",\"message\":\"API key is invalid.\"},\"request_id\":null}. Received Model Group=claude-haiku-4-5\nAvailable Model Group Fa"}}
HTTP 401
```

### After (d535120c92)

```
$ curl -s -X POST http://localhost:4010/credentials -H "Authorization: Bearer $MASTER_KEY" -H "Content-Type: application/json" -d '{"credential_name":"team-anthropic","credential_values":{"api_key":"sk-ant-team-scoped-not-a-real-key"},"credential_info":{}}'
{"success":true,"message":"Credential created successfully"}
```

```
$ curl -s -X POST http://localhost:4010/team/new -H "Authorization: Bearer $MASTER_KEY" -H "Content-Type: application/json" -d '{"team_alias":"anthropic-keyed-team","models":["gpt-4o-mini","claude-haiku-4-5"],"metadata":{"model_config":{"defaultconfig":{"anthropic":{"litellm_credentials":"team-anthropic"}}}}}'
{"team_id": "9fba9f4a-2cdb-4281-b693-98eb16787e0b", "team_alias": "anthropic-keyed-team", "models": ["gpt-4o-mini", "claude-haiku-4-5"], "metadata": {"model_config": {"defaultconfig": {"anthropic": {"litellm_credentials": "team-anthropic"}}}}}
```

```
$ curl -s -X POST http://localhost:4010/key/generate -H "Authorization: Bearer $MASTER_KEY" -H "Content-Type: application/json" -d '{"team_id":"9fba9f4a-2cdb-4281-b693-98eb16787e0b"}'
{"key": "sk-...redacted..."}
```

```
$ curl -s -w '
HTTP %{http_code}' -X POST http://localhost:4010/v1/chat/completions -H "Authorization: Bearer $TEAM_KEY" -H "Content-Type: application/json" -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Reply with the single word ok"}],"max_tokens":5}'
{"model": "gpt-4o-mini", "choices": [{"message": "Ok"}]}
HTTP 200
```

```
$ curl -s -w '
HTTP %{http_code}' -X POST http://localhost:4010/v1/chat/completions -H "Authorization: Bearer $TEAM_KEY" -H "Content-Type: application/json" -d '{"model":"claude-haiku-4-5","messages":[{"role":"user","content":"Reply with the single word ok"}],"max_tokens":5}'
{"error": {"message": "litellm.AuthenticationError: AnthropicException - {\"type\":\"error\",\"error\":{\"type\":\"authentication_error\",\"message\":\"API key is invalid.\"},\"request_id\":null}. Received Model Group=claude-haiku-4-5
Available Model Group Fa"}}
HTTP 401
```

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Behaviour change for a resolved provider absent from the entry: previously silently used another provider's credential, now no override

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
