### PR TITLE
chore(release): bump tornado and pypdf on stable/1.97.x and cut 1.97.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "litellm"
-version = "1.97.1"
+version = "1.97.2"
 description = "Library to easily interface with LLM API providers"
 readme = "README.md"
 requires-python = ">=3.10, <3.15"
@@ -305,7 +305,7 @@ members = ["enterprise", "litellm-proxy-extras"]
 profile = "black"
 
 [tool.commitizen]
-version = "1.97.1"
+version = "1.97.2"
 version_files = [
     "pyproject.toml:^version",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-08-31T16:43:05.76676Z"
+exclude-newer = "2026-08-31T16:43:35.965228Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -7478,14 +7478,14 @@ wheels = [
 
 [[package]]
 name = "pypdf"
-version = "6.15.0"
+version = "6.16.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/17/17/ee75a92718ec7212de831e71454d702225aa5e474a805cce169806044453/pypdf-6.15.0.tar.gz", hash = "sha256:d39c4d955a76409284a905e2d65b40076d77ab76129e0faaeeb6612403ecfc79", size = 6993794, upload-time = "2026-08-06T13:06:49.929Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/5a/df92d1c1ef8806ca28f20f978ee059894868d93de797a7e2edebe7fe1a43/pypdf-6.16.1.tar.gz", hash = "sha256:c4d1b43ddae921387321cf63936cd16a7743b91d2da92f165c149a195c972ba9", size = 7003737, upload-time = "2026-08-14T12:24:04.531Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/72/ce3067ac31e214a66388159f8462ddb8c13dd00170f24d555a1f1ae8ee91/pypdf-6.15.0-py3-none-any.whl", hash = "sha256:14e001d6504822cb1ca9c7ed9a69bccb320f59b320730f55af804361abe4d5ee", size = 378123, upload-time = "2026-08-06T13:06:47.709Z" },
+    { url = "https://files.pythonhosted.org/packages/33/a1/724b18d6757ab7253a8fecd3a430eb8d980ed26872ba16651e7b5ddfc63f/pypdf-6.16.1-py3-none-any.whl", hash = "sha256:63fec31c4092ae50b6729beedcb469055b60d20c834bde1c402df241f371f644", size = 382924, upload-time = "2026-08-14T12:24:02.854Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-08-31T16:43:35.965228Z"
+exclude-newer = "2026-08-31T16:44:10.929964Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -4194,7 +4194,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.97.1"
+version = "1.97.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-08-29T22:00:06.180243Z"
+exclude-newer = "2026-08-31T16:43:05.76676Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -9333,19 +9333,19 @@ wheels = [
 
 [[package]]
 name = "tornado"
-version = "6.5.7"
+version = "6.5.8"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/64/24/95ec527ad67b76d59299e5465b3935d05e4294b7e0290a3924b7487df30b/tornado-6.5.7.tar.gz", hash = "sha256:66c513a76cda70d53907bc27cf1447557699c2e95aa48ba27a442ff61c3ddfc2", size = 519252, upload-time = "2026-06-08T17:34:51.232Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/d3/343e5bb989d6515b1646cf3d40135d73f3d5e45339bded401b56cdac24dd/tornado-6.5.8.tar.gz", hash = "sha256:9452e1b208a8bd771e2cb1f2ff564985b9b214bdebbe622793e1799e0a6bd23f", size = 520493, upload-time = "2026-08-07T02:12:42.971Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/dc/c7043cab6fed8ae159fc1923ce829ada35c4dbd797d408a43858ffaf9639/tornado-6.5.7-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:148b2eb15c2c765a50796172c1e499649b35f30d2e3c3d3e15913cfa56bfb163", size = 448543, upload-time = "2026-06-08T17:34:38.052Z" },
-    { url = "https://files.pythonhosted.org/packages/92/4f/090b1431e5a43df696feceffc268c5383cc079ecb5f08ce58f917109aafe/tornado-6.5.7-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:9da38de27f1da3b78a966f0dae12b5a1ea9afe72ca805d84ff06508272ddf100", size = 446707, upload-time = "2026-06-08T17:34:39.594Z" },
-    { url = "https://files.pythonhosted.org/packages/37/d8/ef374952fd5da67d4463122c2b8e5a96536ec10b4b339254c6dcde81d01c/tornado-6.5.7-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8d759e71906ee783f8867b93bf26a265743da4c1e2f4a018464c1ba019862972", size = 449774, upload-time = "2026-06-08T17:34:41.204Z" },
-    { url = "https://files.pythonhosted.org/packages/35/37/d434c73f4c6e014b745b9b37085f34f40c022f007efff3d7fe65991899f3/tornado-6.5.7-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a46347a18f23fb92b396beebe0fb78f61dda0cc302445202c16203d8a18848b", size = 450745, upload-time = "2026-06-08T17:34:42.531Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/2b/56b9aff361d7f1ab728a805ec7d7ea835f8807afa9f5cc690ea0e630efb9/tornado-6.5.7-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7778b30bef919231265e91c69963ce0f49a1e9c07ac900bbe75b19ce2575ba92", size = 450578, upload-time = "2026-06-08T17:34:43.787Z" },
-    { url = "https://files.pythonhosted.org/packages/02/30/a7444fb23aa76860a14198fab96ac79f1866b0a6e19e26c4381b0938e50f/tornado-6.5.7-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e726f0c75da7726eec023aa62751ff8878bd2737e34fbdd33b1ae5897d2200f5", size = 449985, upload-time = "2026-06-08T17:34:45.326Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/42/5f0e56c01e8d9d36f4e23f367b85ae6cae0c1ecddd5e6977d8388ad27488/tornado-6.5.7-cp39-abi3-win32.whl", hash = "sha256:f8de3bf12d3efdd0cbe7c8887868198f8a91415e3f29fcf258d9b8eb7b1d9ae4", size = 451047, upload-time = "2026-06-08T17:34:46.784Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/a4/b393076ffb21b469eec5b328a0534cf03a3b90bfc6b1f09507cdd075d938/tornado-6.5.7-cp39-abi3-win_amd64.whl", hash = "sha256:de942f843533a039ef9fa3d9c88c7cd8a7c94553fb5ad0154270989b3d99a2c4", size = 451485, upload-time = "2026-06-08T17:34:48.248Z" },
-    { url = "https://files.pythonhosted.org/packages/71/2e/7b1c769803121b809112cf9a00681c472eae1d80e32d7ec0e0bd61d0d0e1/tornado-6.5.7-cp39-abi3-win_arm64.whl", hash = "sha256:ff934fce95643af5f11efdae618eaa73d469dc588641e5c8d19295a0c65c4796", size = 450506, upload-time = "2026-06-08T17:34:49.702Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/d5/007086fd8df5489338e204f65adce33fd4f21a4999dbb2b9cff2f897b5f4/tornado-6.5.8-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:cc6aa787d7cfab7c3d35189dc7a56fbd2399a569624c730c6b55b3d6531d0403", size = 449487, upload-time = "2026-08-07T02:12:28.682Z" },
+    { url = "https://files.pythonhosted.org/packages/70/c8/5a24a99495903f594f6a199dd7beead1cbc0a13e2cb9102727bcaaf2a997/tornado-6.5.8-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:9715b5eb79735b2bcd454ce216a9275b7c0470e64ea1bf5742f78b2f72b26eeb", size = 447649, upload-time = "2026-08-07T02:12:30.306Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/de/f2e733f386b85962d1b1dc82cd63d169b5b4580062b35397eac9244a41fe/tornado-6.5.8-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:547d63f450d570c14fe0e8db2cfb14c9bbd1c2503b4a6612586267955aa47b58", size = 450707, upload-time = "2026-08-07T02:12:31.95Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/94/20efeee9a01c141e9ac47c397f81679dfda24b32768fc4fff24e76d36c2c/tornado-6.5.8-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7e2360a0ffbe145eca8af0b19cb7203d79b1a98dd4cccdd6b368f6f49c2e3808", size = 451677, upload-time = "2026-08-07T02:12:33.512Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ec/a96ccb8ccf0de2b7bc2c5fa1608a4803735018242e90c4882365a9fd418f/tornado-6.5.8-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:5d242290bdf7ab3151bc1065fdd75c0dcc21cbc7b49f22a4c56329c2d6566d22", size = 451510, upload-time = "2026-08-07T02:12:35.346Z" },
+    { url = "https://files.pythonhosted.org/packages/29/b5/93185859245ad3f00e62175f29607346788b696369347f0146e0421286bb/tornado-6.5.8-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7b94ff0e128fe0542f3bd331fb44d06260fc4ac16881545159f34ef08aad4195", size = 450917, upload-time = "2026-08-07T02:12:36.963Z" },
+    { url = "https://files.pythonhosted.org/packages/97/cf/fe33cf062834487d34d1559746a4a12521033c22645b6d74d4bca702e018/tornado-6.5.8-cp39-abi3-win32.whl", hash = "sha256:67832909c4779c64942380cb5f044a5c6163d00831472d80e25e115de9917836", size = 451952, upload-time = "2026-08-07T02:12:38.512Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e1/468ad54333e92ccb62627e62cb88e5fc14a2171daa67ed47b1b8542d5b86/tornado-6.5.8-cp39-abi3-win_amd64.whl", hash = "sha256:11881db6b7c168494be2c2d12e65931451bdf7ee718535418ae1d8855dd5a0ee", size = 452391, upload-time = "2026-08-07T02:12:39.971Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/3e/cd5e4f06e34cde33b8ef66cf36aa2b5ad46354cc1af7d2136bbe365fee1d/tornado-6.5.8-cp39-abi3-win_arm64.whl", hash = "sha256:68a7468c7e289f8514d7d664101753903217eff1bb6822c6b5994a0b5f5bcb26", size = 451411, upload-time = "2026-08-07T02:12:41.469Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-08-31T16:44:10.929964Z"
+exclude-newer = "2026-08-31T17:37:04.565876Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -2364,14 +2364,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.58"
+version = "3.1.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/26/d6/5f358ff283325580c2003a6d953aea18cfe10ae87b46f5ebc80fa3a386dc/gitpython-3.1.58.tar.gz", hash = "sha256:621416df10ef3fd0e19fabf9172ddeed0fa704d353d04f194eec56a625a95b22", size = 228498, upload-time = "2026-08-04T15:05:49.47Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/61/3285044215fb596bf093e39ccb96ece0a1076a8ca57a61e069a6a33cdb1b/gitpython-3.1.61.tar.gz", hash = "sha256:f51c24d8c0f733a195447385f5774a5dfe8767f5acfd7994a33755644c6ecc95", size = 231680, upload-time = "2026-08-28T11:01:13.761Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/0c/9d8752098bc442f0726e64aa6135940b3a96809915d1aa4206c1bb97881d/gitpython-3.1.58-py3-none-any.whl", hash = "sha256:d331e722577f0fd7fc1f857419b3ecc07af66282b933d2a4d95f84a042fdd50f", size = 220183, upload-time = "2026-08-04T15:05:48.025Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/5e/49cc172da4d0578644ba37cec5cb365b1fefc603b26edea9bcac1c7f830a/gitpython-3.1.61-py3-none-any.whl", hash = "sha256:8ab28c9da863cdd9e7d7694ec46cf3e6c9a12d8a30a1acd3447aec11975d530c", size = 222118, upload-time = "2026-08-28T11:01:12.262Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## TLDR

Problem this solves:

- stable/1.97.x pins tornado, pypdf and gitpython behind current
- image scanners flag both on the published v1.97.1 image
- the refreshed lock only ships if the line cuts a new patch

How it solves it:

- lock-only bumps to newer patches inside each existing range
- no pyproject range moves, so the install contract is unchanged
- cuts 1.97.2 so the image actually picks the lock up

## User Flow

Before: an operator scanning the published image sees fixable findings against two Python packages

1. They pull `docker.litellm.ai/berriai/litellm:v1.97.1`
2. They run their image scanner against it
3. The report lists tornado 6.5.7 and pypdf 6.15.0, each with a fix available in a newer patch of the same series
4. Auditing the lock rather than the image turns up gitpython 3.1.58 as well, which the image scanner does not flag because gitpython never reaches the image

After: the same scan on the next patch comes back clean for both packages

1. They pull the image built from v1.97.2
2. They run the same scan
3. tornado resolves at 6.5.8 and pypdf at 6.16.1, and neither package appears in the report
4. Auditing the lock directly, gitpython now resolves at 3.1.61 and the only entries left across all 442 locked third-party packages are two with no upstream release to move to

## Relevant issues

Routine dependency maintenance on the 1.97 line. Both packages had a newer patch release available inside the range `pyproject.toml` already allows, so this regenerates `uv.lock` against those two pins and leaves everything else where it was. The moved set was checked package by package after each regeneration and is exactly one package per commit, so nothing else on the line drifts. `litellm_internal_staging` already resolves at or above both targets, so upgrading from this patch to a later release does not walk either package backwards

The version bump to 1.97.2 is mechanical: `v1.97.1` is published on DockerHub and carries a git tag and a `release/v1.97.1` branch, so the tip version has shipped and the line needs a new one for the refreshed lock to reach anybody

## Linear ticket

## Pre-Submission checklist

- [ ] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

There is no code change here to write a test against; the diff is `uv.lock` plus the version string. The proof below is a real image build off this branch scanned end to end, which is what a reviewer actually cares about for a lock change

## Screenshots / Proof of Fix

Built the non_root image from this branch (`21da7394dc`) and from the line tip (`474d7e50f0`) with the same Dockerfile, then compared them. Both builds are clean and the runtime behaviour is identical

```
$ docker build -f docker/Dockerfile.non_root -t litellm-1972-verify:local .
...
=> => naming to docker.io/library/litellm-1972-verify:local
```

The image resolves both packages at the pinned versions:

```
$ docker run --rm --entrypoint python litellm-1972-verify:local -c \
    "import importlib.metadata as m; print('tornado', m.version('tornado')); print('pypdf', m.version('pypdf'))"
tornado 6.5.8
pypdf 6.16.1
```

PDF text extraction, the one place litellm calls into pypdf, behaves the same on both images. The script builds a one-page PDF in memory and runs it back through `extract_text_from_pdf`:

```
$ docker run --rm -v /tmp/pdfcheck.py:/tmp/pdfcheck.py:ro --entrypoint python litellm-1972-verify:local /tmp/pdfcheck.py
pypdf    6.16.1
tornado  6.5.8
extracted: 'LiteLLM 1.97.2 pypdf integration check'
RESULT: pypdf text extraction through litellm works on 6.16.1

$ docker run --rm -v /tmp/pdfcheck.py:/tmp/pdfcheck.py:ro --entrypoint python litellm-1971-baseline:local /tmp/pdfcheck.py
pypdf    6.15.0
tornado  6.5.7
extracted: 'LiteLLM 1.97.2 pypdf integration check'
RESULT: pypdf text extraction through litellm works on 6.15.0
```

The proxy boots from the image and serves:

```
$ docker run -d --name litellm-1972-smoke -p 4097:4000 -e LITELLM_MASTER_KEY=sk-1234 litellm-1972-verify:local
$ curl -s -w '\nHTTP %{http_code}\n' http://localhost:4097/health/liveliness
"I'm alive!"
HTTP 200
$ curl -s -w '\nHTTP %{http_code}\n' http://localhost:4097/health/readiness
{"status":"healthy","db":"Not connected"}
HTTP 200
```

A package audit of the two images side by side shows six entries clearing on the newer image and nothing new appearing. What is left over is identical on both and belongs to the Wolfi base layer, so it is outside this repo

The gitpython bump landed after those images were built, so it is worth saying why they were not rebuilt: gitpython only arrives through the `mlflow` extra, which the Dockerfile does not install. Exporting the resolved set for the exact extras the Dockerfile syncs gives the same 189 pinned packages before and after that commit, so the image is bit-for-bit unaffected

```
$ uv export --frozen --no-default-groups --no-emit-project \
    --extra proxy --extra proxy-runtime --extra extra_proxy --extra semantic-router --extra saml \
    | grep -E '^[a-zA-Z0-9]' | sed 's/ .*//' > after.txt
$ diff before.txt after.txt && echo "identical: $(wc -l < after.txt) pinned deps"
identical:      189 pinned deps
```

Auditing every one of the 442 locked third-party packages against OSV by exact version, the branch comes back with two entries, both on packages that are not in the image and neither of which has a release to move to yet

## Type

🚄 Infrastructure

## Changes

- `chore(deps): bump tornado to 6.5.8`
- `chore(deps): bump pypdf to 6.16.1`
- `chore(deps): bump gitpython to 3.1.61`
- `bump: version 1.97.1 -> 1.97.2`
- `chore: refresh uv.lock for 1.97.2`

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
