### PR TITLE
fix(proxy): send the plaintext key, not the hashed token id, in the key-created email

### DIFF
--- a/litellm/proxy/hooks/key_management_event_hooks.py
+++ b/litellm/proxy/hooks/key_management_event_hooks.py
@@ -497,7 +497,9 @@ class KeyManagementEventHooks:
                 event="key_created",
                 event_group=Litellm_EntityType.KEY,
                 event_message="API Key Created",
-                token=response.get("token", ""),
+                # `token` is remapped to the hashed token_id in generate_key_fn; the
+                # email renders this field as the key, so send the plaintext `key`.
+                token=response.get("key", "") or response.get("token", ""),
                 spend=response.get("spend", 0.0),
                 max_budget=response.get("max_budget", 0.0),
                 user_id=response.get("user_id", None),

--- a/tests/test_litellm/proxy/hooks/test_key_management_event_hooks.py
+++ b/tests/test_litellm/proxy/hooks/test_key_management_event_hooks.py
@@ -5,6 +5,8 @@ Validates that email and secret manager operations are independent and non-block
 """
 
 import asyncio
+import sys
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -540,3 +542,40 @@ class TestKeyUpdatedAuditLogObjectId:
         audit_row = await self._run_updated_hook_and_capture_audit_log(request_key=hashed_key)
 
         assert audit_row.object_id == hashed_key
+
+
+@pytest.mark.asyncio
+async def test_v0_key_created_email_sends_plaintext_key_not_hashed_token():
+    """
+    /key/generate remaps `token` to the hashed token_id before the hook runs.
+    The v0 email renders `token` as the key, so it must carry the plaintext key.
+    """
+    mock_slack_alerting = MagicMock()
+    mock_slack_alerting.send_key_created_or_user_invited_email = AsyncMock()
+    mock_proxy_server = SimpleNamespace(
+        general_settings={"alerting": ["email"]},
+        proxy_logging_obj=SimpleNamespace(slack_alerting_instance=mock_slack_alerting),
+    )
+
+    with patch.dict(
+        sys.modules,
+        {
+            "litellm.proxy.proxy_server": mock_proxy_server,
+            # Force the ImportError branch so this exercises the v0 email path.
+            "litellm_enterprise.enterprise_callbacks.send_emails.base_email": None,
+        },
+    ):
+        await KeyManagementEventHooks._send_key_created_email(
+            {
+                "key": "sk-plaintext-key",
+                "token": "hashed-token-id",
+                "token_id": "hashed-token-id",
+                "user_id": "user-123",
+            }
+        )
+        await asyncio.sleep(0)  # let the scheduled email task run
+
+    mock_slack_alerting.send_key_created_or_user_invited_email.assert_called_once()
+    webhook_event = mock_slack_alerting.send_key_created_or_user_invited_email.call_args.kwargs["webhook_event"]
+    assert webhook_event.event == "key_created"
+    assert webhook_event.token == "sk-plaintext-key"


### PR DESCRIPTION
## TLDR

Problem this solves:

- Key-created invite email contains the hashed token id
- Users get an email with no usable key
- Only fix today is regenerating the key

How it solves it:

- Email now carries the plaintext `sk-...` value
- One-line change on the v0 email path

## User Flow

Before: an admin creates a key for a teammate with `send_invite_email: true`, and the teammate gets an email whose "key" is unusable

1. The admin sends POST https://litellm-domain/key/generate with `{"user_id": "teammate@corp.com", "send_invite_email": true}`
2. The response comes back 200 with `"key": "sk-abc123..."` (the real key) and `"token": "8f1c..."` (a 64-char hex string)
3. The teammate receives the "API Key Created" email, which shows the 64-char hex string where the key should be
4. The teammate sends POST https://litellm-domain/v1/chat/completions with `Authorization: Bearer 8f1c...` and gets 401 Invalid proxy server token passed
5. The admin has to fall back to POST https://litellm-domain/key/regenerate and hand the key over by some other channel

After: the same email contains the key the teammate can actually use

1. The admin sends POST https://litellm-domain/key/generate with `{"user_id": "teammate@corp.com", "send_invite_email": true}`
2. The response comes back 200 with `"key": "sk-abc123..."` and `"token": "8f1c..."`
3. The teammate receives the "API Key Created" email, which now shows `sk-abc123...`
4. The teammate sends POST https://litellm-domain/v1/chat/completions with `Authorization: Bearer sk-abc123...` and gets a normal 200 completion
5. No regenerate step is needed

## Relevant issues

Fixes #39315

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

I don't have an SMTP-backed proxy to capture a real delivered email, so the evidence here is the unit test that pins the field the email template renders. It fails at the merge base and passes at the PR tip. Same command both times.

Shared setup: repo venv, `prisma` installed (the proxy conftest imports it).

### Before

The new test applied on top of the merge-base source, so only the test is new and the buggy line is untouched.

1. `python -m pytest tests/test_litellm/proxy/hooks/test_key_management_event_hooks.py -q -p no:randomly`
2. Output:

```
>       assert webhook_event.token == "sk-plaintext-key"
E       AssertionError: assert 'hashed-token-id' == 'sk-plaintext-key'
E
E         - sk-plaintext-key
E         + hashed-token-id

tests/test_litellm/proxy/hooks/test_key_management_event_hooks.py:581: AssertionError
FAILED tests/test_litellm/proxy/hooks/test_key_management_event_hooks.py::test_v0_key_created_email_sends_plaintext_key_not_hashed_token
1 failed, 11 passed, 1 warning in 4.09s
```

The value handed to the email is the hashed token id, which is exactly what the reporter received in their inbox.

### After

1. `python -m pytest tests/test_litellm/proxy/hooks/test_key_management_event_hooks.py -q -p no:randomly`
2. Output:

```
............                                                             [100%]
12 passed, 1 warning in 27.65s
```

Lint on the touched files:

1. `ruff check litellm/proxy/hooks/key_management_event_hooks.py` -> `All checks passed!`
2. `ruff check --config ruff-tests.toml tests/test_litellm/proxy/hooks/test_key_management_event_hooks.py` -> `All checks passed!`
3. `ruff format --check litellm/proxy/hooks/key_management_event_hooks.py` -> `1 file already formatted`
4. `python scripts/test_quality_gate.py --base origin/litellm_internal_staging` -> `OK: every TQ rule is within its test-suite ceiling`

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Root cause is the `token` remap in `generate_key_fn`
- That remap stays; this fixes the symptom at the email
- Enterprise email path untouched, it already reads `virtual_key`

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
