### PR TITLE
chore(rust): gate workspace against lock-across-await and undocumented unsafe

### DIFF
--- a/litellm-rust/Cargo.toml
+++ b/litellm-rust/Cargo.toml
@@ -36,6 +36,14 @@ tokio-tungstenite = { version = "0.24", default-features = false, features = ["c
 futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }
 base64 = "0.22"
 
+[workspace.lints.rust]
+unsafe_op_in_unsafe_fn = "warn"
+
+[workspace.lints.clippy]
+await_holding_lock = "deny"
+await_holding_refcell_ref = "deny"
+undocumented_unsafe_blocks = "warn"
+
 [profile.release]
 opt-level = 3
 lto = "thin"

--- a/litellm-rust/crates/ai-gateway/Cargo.toml
+++ b/litellm-rust/crates/ai-gateway/Cargo.toml
@@ -43,3 +43,6 @@ python-config = ["dep:pyo3"]
 [dev-dependencies]
 futures-channel = "0.3"
 tower = { version = "0.5.3", features = ["util"] }
+
+[lints]
+workspace = true

--- a/litellm-rust/crates/core/Cargo.toml
+++ b/litellm-rust/crates/core/Cargo.toml
@@ -33,3 +33,6 @@ bedrock-auth = [
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+
+[lints]
+workspace = true

--- a/litellm-rust/crates/python-bridge/Cargo.toml
+++ b/litellm-rust/crates/python-bridge/Cargo.toml
@@ -35,3 +35,6 @@ tokio-tungstenite.workspace = true
 [[bench]]
 name = "serialization"
 harness = false
+
+[lints]
+workspace = true

--- a/litellm-rust/crates/python-interop/Cargo.toml
+++ b/litellm-rust/crates/python-interop/Cargo.toml
@@ -13,3 +13,6 @@ serde.workspace = true
 [dev-dependencies]
 rstest.workspace = true
 serde_json.workspace = true
+
+[lints]
+workspace = true


### PR DESCRIPTION
## Responsibility

One change only: add a `[workspace.lints]` table to `litellm-rust/Cargo.toml` and inherit it (`[lints] workspace = true`) into all four crates. No code changes — the base already passes.

## What is gated

| Lint | Level | Why it matters here |
|---|---|---|
| `clippy::await_holding_lock` | deny | A `std::sync::Mutex`/`RwLock` guard held across `.await` blocks its Tokio worker for the whole suspension. With a shared multi-thread runtime inside the Python process this is one lock-ordering mistake away from a permanent stall (worker blocked on the mutex; mutex holder parked on the same worker). Async-aware locking belongs to `tokio::sync`, where holding across `.await` is designed for. |
| `clippy::await_holding_refcell_ref` | deny | Same failure mode: a `RefCell` borrow resumed on an arbitrary worker thread after suspension. |
| `clippy::undocumented_unsafe_blocks` | warn | Every future `unsafe` block must carry a `// SAFETY:` justification. The workspace currently contains **zero** unsafe blocks, so this gates only what comes next — the planned buffer-protocol / free-threaded-CPython (`gil_used = false` is already set) work will need audited unsafe. |
| `unsafe_op_in_unsafe_fn` (rustc) | warn | Forces `unsafe {}` inside `unsafe fn` bodies so each unsafe operation is individually visible. |

Because CI runs `cargo clippy --workspace --all-targets -- -D warnings`, `warn`-level lints are enforced as hard errors there — the table is a gate, not advice.

## Why now

The bridge embeds a Tokio runtime in the CPython process; its correctness under concurrency rests on three invariants that are currently convention only: never hold a blocking lock across `.await`, never hold a GIL-adjacent lock while calling back into Python, and audit every `unsafe`. This makes the first and third machine-enforced at zero runtime cost, before the streaming (#39577) and concurrency-limits (#39579) work grows the async surface further.

## Verification

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean (would fail if any guard-across-await existed)
- `cargo clippy -p litellm-core --all-targets --features bedrock-auth --locked -- -D warnings` — clean
- `cargo test --workspace --locked` — all suites green, 0 failures

## Merge-order note

Touches only the 5 manifest files, so no overlap with #39577 / #39579 hot files (`core/messages/*`, bridge `lib.rs`). Safe to land in any order.