### PR TITLE
test(timeout): time out against the local fake endpoint instead of api.openai.com

### DIFF
--- a/tests/_fake_openai_endpoint_server.py
+++ b/tests/_fake_openai_endpoint_server.py
@@ -207,13 +207,16 @@ async def completions(request: Request) -> Response:
 
 async def embeddings(request: Request) -> Response:
     body = await _parse_body(request)
+    model = _requested_model(body)
+    if model == _SLOW_MODEL:
+        await asyncio.sleep(_SLOW_RESPONSE_SECONDS)
     raw_input = body.get("input", "")
     count = len(raw_input) if isinstance(raw_input, list) else 1
     return JSONResponse(
         {
             "object": "list",
             "data": [{"object": "embedding", "index": i, "embedding": [0.0] * 1536} for i in range(max(count, 1))],
-            "model": _requested_model(body),
+            "model": model,
             "usage": {"prompt_tokens": 5, "total_tokens": 5},
         }
     )

--- a/tests/local_testing/test_embedding.py
+++ b/tests/local_testing/test_embedding.py
@@ -15,6 +15,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import litellm
 from litellm import completion, completion_cost, embedding
+from tests.fake_openai_endpoint import FAKE_OPENAI_API_BASE
 
 litellm.set_verbose = False
 
@@ -269,11 +270,14 @@ def test_openai_azure_embedding_timeouts():
 def test_openai_embedding_timeouts():
     try:
         response = embedding(
-            model="text-embedding-ada-002",
+            model="openai/slow-endpoint",
             input=["good morning from litellm"],
-            timeout=0.00001,
+            api_base=FAKE_OPENAI_API_BASE,
+            api_key="fake-key",
+            timeout=0.5,
         )
         print(response)
+        pytest.fail("Expected timeout error, the request returned instead")
     except openai.APITimeoutError:
         print("Good job got OpenAI timeout error!")
         pass

--- a/tests/local_testing/test_router.py
+++ b/tests/local_testing/test_router.py
@@ -1552,8 +1552,9 @@ def test_router_timeout():
         {
             "model_name": "gpt-3.5-turbo",
             "litellm_params": {
-                "model": "gpt-3.5-turbo",
-                "api_key": "os.environ/OPENAI_API_KEY",
+                "model": "openai/slow-endpoint",
+                "api_base": FAKE_OPENAI_API_BASE,
+                "api_key": "fake-key",
             },
         }
     ]
@@ -1562,7 +1563,7 @@ def test_router_timeout():
     start_time = time.time()
     try:
         res = router.completion(
-            model="gpt-3.5-turbo", messages=messages, timeout=0.0001
+            model="gpt-3.5-turbo", messages=messages, timeout=0.5
         )
         print(res)
         pytest.fail("this should have timed out")

--- a/tests/local_testing/test_timeout.py
+++ b/tests/local_testing/test_timeout.py
@@ -12,6 +12,7 @@ import openai
 import pytest
 
 import litellm
+from tests.fake_openai_endpoint import FAKE_OPENAI_API_BASE
 
 
 @pytest.mark.parametrize(
@@ -216,13 +217,16 @@ def test_timeout_streaming():
     litellm.set_verbose = False
     try:
         response = litellm.completion(
-            model="gpt-3.5-turbo",
+            model="openai/slow-endpoint",
             messages=[{"role": "user", "content": "hello, write a 20 pg essay"}],
-            timeout=0.0001,
+            api_base=FAKE_OPENAI_API_BASE,
+            api_key="fake-key",
+            timeout=0.5,
             stream=True,
         )
         for chunk in response:
             print(chunk)
+        pytest.fail("Did not raise error `openai.APITimeoutError`. The stream completed instead")
     except openai.APITimeoutError as e:
         print(
             "Passed: Raised correct exception. Got openai.APITimeoutError\nGood Job", e


### PR DESCRIPTION
## TLDR

Problem this solves:

- Three timeout tests raced DNS ordering against api.openai.com
- They reported flaky red when the last address was IPv6

How it solves it:

- Time out against the local fake endpoint the suite already runs
- Fail the test when the request returns instead of timing out

## User Flow

Test-only change with no runtime surface. Nothing a caller of the proxy or the SDK can do changes with this PR

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Why the old tests could not be stable

They asked api.openai.com to answer within 10 to 100 microseconds. Nothing can, so `socket.create_connection` always exhausted the address list, and it re-raises only the **last** address's error. api.openai.com is dual-stack, the CI container has no usable IPv6, and httpcore maps `socket.timeout` to `ConnectTimeout` but `OSError` to `ConnectError`. So the assertion came down to which family `getaddrinfo` listed last

## Screenshots / Proof of Fix

No proxy route to curl: this is a test-only change, so the proof is the tests being deterministic and still failing when the behaviour they assert is broken. Every run below uses a private fake-endpoint port so a shared instance cannot mask the result

### Before (4990f06acc)

Reproducing the mechanism in a Linux container with CI's resolver config, showing each candidate address and what the whole call raises

1. `python probe.py` (resolve api.openai.com, connect to each address at the test's own timeout, then run the full call)

```
--- getaddrinfo('api.openai.com', 443, 0, SOCK_STREAM) order ---
  [0] IPv4 162.159.140.245
  [1] IPv4 172.66.0.243
  [2] IPv6 2606:4700:7::f3
  [3] IPv6 2a06:98c1:58::f3
  LAST tried family: IPv6

--- connect() to each address individually (timeout 1e-05) ---
  IPv4 162.159.140.245: TimeoutError errno=None timed out
  IPv4 172.66.0.243: TimeoutError errno=None timed out
  IPv6 2606:4700:7::f3: OSError errno=101 Network is unreachable
  IPv6 2a06:98c1:58::f3: OSError errno=101 Network is unreachable

--- socket.create_connection('api.openai.com',443, timeout=1e-05) ---
  RAISED OSError errno=101: [Errno 101] Network is unreachable
```

2. The same thing on CI, from the `local_testing_part1` run on 3cac5e5cd4:

```
E   httpcore.ConnectError: [Errno 99] Cannot assign requested address
FAILED tests/local_testing/test_embedding.py::test_openai_embedding_timeouts
```

### After (c70e4857fa)

#### The three tests are deterministic

1. Run all three five times in a row

```
run 1: exit=0 | 3 passed
run 2: exit=0 | 3 passed
run 3: exit=0 | 3 passed
run 4: exit=0 | 3 passed
run 5: exit=0 | 3 passed
```

#### They still fail if the endpoint stops being slow

2. Set `_SLOW_RESPONSE_SECONDS` to `0.0` so the endpoint answers at once, then rerun

```
FAILED tests/local_testing/test_embedding.py::test_openai_embedding_timeouts
FAILED tests/local_testing/test_router.py::test_router_timeout - Failed: this...
FAILED tests/local_testing/test_timeout.py::test_timeout_streaming - Failed: ...
3 failed, 1 warning in 1.14s
```

#### They still fail if the error is the wrong type

3. Replace the endpoint's delay with a `RuntimeError` so the request fails with something that is not a timeout, then rerun

```
FAILED tests/local_testing/test_embedding.py::test_openai_embedding_timeouts
FAILED tests/local_testing/test_router.py::test_router_timeout - litellm.exce...
FAILED tests/local_testing/test_timeout.py::test_timeout_streaming - Failed: ...
3 failed, 1 warning in 9.27s
```

#### The shared mock still behaves

4. Run the guard suite for the endpoint whose embeddings route this PR touches

```
tests/local_testing/test_fake_openai_endpoint.py .... 16 passed in 1.08s
```

## Type

✅ Test

## Caveats (if any)

### Low

- `test_router_timeout` now takes about 7s, since each router retry waits the real timeout
- These exercise the read-timeout path. Connect-timeout coverage would need a blackholed address and is not added here

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
