### PR TITLE
fix(openai): bridge gpt-5.4+ tool calls to /v1/responses on every api.openai.com host

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -26,6 +26,7 @@ from copy import deepcopy
 from functools import partial
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Final, Literal, Optional, Protocol, Union, cast, get_args
+from urllib.parse import urlsplit
 
 from litellm._logging import _redact_string
 from litellm._uuid import uuid
@@ -984,6 +985,12 @@ def mock_completion(
 
 
 _OPENAI_DEFAULT_API_BASE: Final = "https://api.openai.com/v1"
+_OPENAI_API_HOST: Final = "api.openai.com"
+
+
+def _is_openai_backed_api_base(api_base: str) -> bool:
+    hostname: Final = urlsplit(api_base).hostname
+    return hostname is not None and (hostname == _OPENAI_API_HOST or hostname.endswith(f".{_OPENAI_API_HOST}"))
 
 
 def _resolve_openai_api_base(api_base: str | None) -> str:
@@ -1053,7 +1060,7 @@ def responses_api_bridge_check(
     #   natively by Chat Completions with reasoning on, so custom-only requests stay on
     #   chat and keep their native custom tool_call response shape.
     # - The UNSET-effort arm only fires against endpoints known to enforce that
-    #   constraint (the default OpenAI endpoint, or Azure OpenAI where api_base is
+    #   constraint (any api.openai.com host, or Azure OpenAI where api_base is
     #   always set): chat-only OpenAI-compatible backends registered under the openai
     #   provider with a custom api_base and gpt-5.4+ model names serve tools without
     #   reasoning fine and have no /responses route, so they keep pre-existing
@@ -1068,14 +1075,15 @@ def responses_api_bridge_check(
         reasoning_active = reasoning_effort.get("effort") != "none" or reasoning_effort.get("summary") is not None
     else:
         reasoning_active = reasoning_effort != "none"
-    # The reasoning+tools constraint is enforced only by the real OpenAI endpoint (and Azure OpenAI).
-    # Resolve the effective base arg>global>env>default exactly as the chat handler does, so a custom
-    # base set via litellm.api_base or OPENAI_BASE_URL/OPENAI_API_BASE isn't misread as the default and
-    # bridged to a /responses route it lacks. A whitespace-only base collapses to the default too.
-    resolved_api_base: Final = _resolve_openai_api_base(api_base)
-    on_constraint_enforcing_endpoint: Final = custom_llm_provider == "azure" or resolved_api_base.strip() in (
-        "",
-        _OPENAI_DEFAULT_API_BASE,
+    # The reasoning+tools constraint is enforced by the real OpenAI backend behind any api.openai.com
+    # host (the default URL or a PrivateLink hostname such as <region>.privatelink.api.openai.com) and
+    # by Azure OpenAI. Resolve the effective base arg>global>env>default exactly as the chat handler
+    # does, so a custom base set via litellm.api_base or OPENAI_BASE_URL/OPENAI_API_BASE isn't misread
+    # as the default and bridged to a /responses route it lacks. A whitespace-only base collapses to
+    # the default too.
+    resolved_api_base: Final = _resolve_openai_api_base(api_base).strip()
+    on_constraint_enforcing_endpoint: Final = (
+        custom_llm_provider == "azure" or resolved_api_base == "" or _is_openai_backed_api_base(resolved_api_base)
     )
     if (
         custom_llm_provider in ("openai", "azure")

--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -1133,6 +1133,82 @@ def test_responses_api_bridge_check_custom_api_base_via_env_with_unset_effort_st
     assert model_info.get("mode") != "responses"
 
 
+@pytest.mark.parametrize(
+    "api_base",
+    [
+        "https://southcentralus.privatelink.api.openai.com/v1",
+        "https://privatelink.corp.api.openai.com/v1",
+        "https://api.openai.com:443/v1",
+        "https://api.openai.com/v1/",
+        "HTTPS://API.OPENAI.COM/v1",
+    ],
+)
+def test_responses_api_bridge_check_openai_backed_custom_api_base_with_unset_effort_routes_to_responses(api_base):
+    """
+    A custom api_base whose host is api.openai.com or a subdomain of it (a PrivateLink hostname, a
+    port-qualified or trailing-slash default) still reaches the real OpenAI backend, which rejects
+    function tools with reasoning on Chat Completions, so the unset-effort arm must bridge exactly as
+    it does for the literal default URL. Regression guard for GH #39353.
+    """
+    from litellm.main import responses_api_bridge_check
+
+    model_info, model = responses_api_bridge_check(
+        model="gpt-5.6",
+        custom_llm_provider="openai",
+        tools=[{"type": "function", "function": {"name": "get_capital"}}],
+        reasoning_effort=None,
+        api_base=api_base,
+        )
+
+    assert model == "gpt-5.6"
+    assert model_info.get("mode") == "responses"
+
+
+@pytest.mark.parametrize(
+    "api_base",
+    [
+        "https://api.openai.com.evil.example/v1",
+        "https://notapi.openai.com/v1",
+        "https://gateway.example/v1?upstream=api.openai.com",
+        "https://openai.internal.example/api.openai.com/v1",
+    ],
+)
+def test_responses_api_bridge_check_lookalike_custom_api_base_with_unset_effort_stays_chat(api_base):
+    """Only the host decides: api.openai.com appearing elsewhere in the URL is still a foreign backend."""
+    from litellm.main import responses_api_bridge_check
+
+    model_info, model = responses_api_bridge_check(
+        model="gpt-5.6",
+        custom_llm_provider="openai",
+        tools=[{"type": "function", "function": {"name": "get_capital"}}],
+        reasoning_effort=None,
+        api_base=api_base,
+        )
+
+    assert model == "gpt-5.6"
+    assert model_info.get("mode") != "responses"
+
+
+def test_responses_api_bridge_check_privatelink_api_base_via_env_with_unset_effort_routes_to_responses(monkeypatch):
+    """A PrivateLink base set through OPENAI_BASE_URL resolves the way the chat handler's does and still bridges."""
+    import litellm
+    from litellm.main import responses_api_bridge_check
+
+    monkeypatch.setattr(litellm, "api_base", None)
+    monkeypatch.delenv("OPENAI_API_BASE", raising=False)
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://southcentralus.privatelink.api.openai.com/v1")
+    model_info, model = responses_api_bridge_check(
+        model="gpt-5.6",
+        custom_llm_provider="openai",
+        tools=[{"type": "function", "function": {"name": "get_capital"}}],
+        reasoning_effort=None,
+        api_base=None,
+        )
+
+    assert model == "gpt-5.6"
+    assert model_info.get("mode") == "responses"
+
+
 def test_responses_api_bridge_check_custom_api_base_with_explicit_effort_still_routes():
     """Explicit reasoning_effort keeps its pre-existing bridging behavior on any api_base."""
     from litellm.main import responses_api_bridge_check


### PR DESCRIPTION
## TLDR

Problem this solves:

- gpt-5.4+ tool calls with unset `reasoning_effort` must go to `/v1/responses`
- The auto-bridge only fired for the literal `https://api.openai.com/v1` base
- PrivateLink hosts like `<region>.privatelink.api.openai.com` stayed on Chat Completions
- OpenAI then rejected every such request with a 400

How it solves it:

- Gate on the resolved base URL's hostname instead of the exact string
- `api.openai.com` and any subdomain of it bridge; port and trailing slash no longer matter
- Every other custom base still stays on Chat Completions, Azure is unchanged
- Regression tests for PrivateLink hosts, lookalike hosts, and the env-var path

## User Flow

Before: a platform team that reaches OpenAI through a PrivateLink hostname gets a 400 on every gpt-5.4+ tool-calling request that leaves `reasoning_effort` unset

1. The proxy admin adds an OpenAI deployment with `model: openai/gpt-5.6` and `api_base: https://<region>.privatelink.api.openai.com/v1`, then starts the proxy (the run below uses `https://api.openai.com:443/v1`, the same backend under a non-default URL, because the PrivateLink host only resolves inside their network)
2. A developer sends POST http://litellm-domain/v1/chat/completions with `"model": "gpt-5.6-privatelink"`, one `get_weather` function tool, and no `reasoning_effort`
3. HTTP 400 comes back: `Function tools with reasoning_effort are not supported for gpt-5.6 in /v1/chat/completions. To use function tools, use /v1/responses or set reasoning_effort to 'none'`
4. The same request against a deployment on the default `https://api.openai.com/v1` returns HTTP 200 with a `get_weather` tool call, so only the PrivateLink deployment is broken

After: the same request on the PrivateLink deployment returns the tool call

1. The proxy admin adds the same deployment with `api_base: https://<region>.privatelink.api.openai.com/v1` and starts the proxy
2. The developer sends the same POST http://litellm-domain/v1/chat/completions with `"model": "gpt-5.6-privatelink"`, one `get_weather` function tool, and no `reasoning_effort`
3. HTTP 200 comes back with `"finish_reason": "tool_calls"` and a `get_weather` call whose arguments are `{"city":"Paris"}`
4. The default-base deployment answers exactly as before, and a deployment on a non-OpenAI host such as `https://my-gateway.example/v1` still goes to Chat Completions untouched

## Relevant issues

Fixes #39353

## Linear ticket

Resolves LIT-6811

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup. Every proxy below boots from its own worktree and venv with no database, `--num_workers 2`, and real OpenAI calls (`OPENAI_API_KEY` from `.env`). A real PrivateLink hostname only resolves inside the customer's network, so the "PrivateLink-style" deployment uses `https://api.openai.com:443/v1`: the same backend under a URL that is not the literal default, which is exactly what the old gate compared against. PrivateLink-shaped hostnames are pinned by the unit tests

`repro_config.yaml`:

```yaml
model_list:
  - model_name: gpt-5.6-privatelink
    litellm_params:
      model: openai/gpt-5.6
      api_base: https://api.openai.com:443/v1
      api_key: os.environ/OPENAI_API_KEY
  - model_name: gpt-5.6-default
    litellm_params:
      model: openai/gpt-5.6
      api_key: os.environ/OPENAI_API_KEY

general_settings:
  master_key: sk-lit6811
```

`req_privatelink.json` (`req_default.json` is identical except `"model": "gpt-5.6-default"`, and `req_privatelink_stream.json` adds `"stream": true`):

```json
{
  "model": "gpt-5.6-privatelink",
  "messages": [{"role": "user", "content": "What is the weather in Paris right now? Use the tool."}],
  "tools": [{
    "type": "function",
    "function": {
      "name": "get_weather",
      "description": "Get the current weather for a city",
      "parameters": {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}
    }
  }]
}
```

`req_messages_privatelink.json`:

```json
{
  "model": "gpt-5.6-privatelink",
  "max_tokens": 1024,
  "messages": [{"role": "user", "content": "What is the weather in Paris right now? Use the tool."}],
  "tools": [{
    "name": "get_weather",
    "description": "Get the current weather for a city",
    "input_schema": {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}
  }]
}
```

Proxy:

```bash
set -a && source .env && set +a && python litellm/proxy/proxy_cli.py --config repro_config.yaml --port $PORT --num_workers 2 --detailed_debug
```

### Before (4990f06accc)

Legs: `--num_workers 2`, no database, own worktree and venv, port 49061 (cases 1 to 3) and a second rig booted the same way on port 37456 (case 4). Each case ran twice so both workers answered; the first run is quoted

#### PrivateLink-style deployment, /v1/chat/completions

1. `curl -s -w "\nHTTP %{http_code}\n" http://localhost:49061/v1/chat/completions -H "Authorization: Bearer sk-lit6811" -H "Content-Type: application/json" -d @req_privatelink.json`
2. Observed:

```
{"error":{"message":"litellm.BadRequestError: OpenAIException - Function tools with reasoning_effort are not supported for gpt-5.6 in /v1/chat/completions. To use function tools, use /v1/responses or set reasoning_effort to 'none'.. Received Model Group=gpt-5.6-privatelink\nAvailable Model Group Fallbacks=None","type":"invalid_request_error","param":"reasoning_effort","code":"400"}}
HTTP 400
```

#### Default api_base (control), /v1/chat/completions

1. `curl -s -w "\nHTTP %{http_code}\n" http://localhost:49061/v1/chat/completions -H "Authorization: Bearer sk-lit6811" -H "Content-Type: application/json" -d @req_default.json`
2. Observed:

```
{"id":"chatcmpl-2bab23dc-f313-4dc4-ba01-813802567d87","model":"gpt-5.6-default","object":"chat.completion","choices":[{"finish_reason":"tool_calls","index":0,"message":{"role":"assistant","tool_calls":[{"index":0,"function":{"arguments":"{\"city\":\"Paris\"}","name":"get_weather"},"id":"call_fat7xFu5ZhMOL4yUXvEWujam","type":"function"}],"content":null}}]}
HTTP 200
```

#### PrivateLink-style deployment, /v1/messages (unchanged surface)

1. `curl -s -w "\nHTTP %{http_code}\n" http://localhost:49061/v1/messages -H "Authorization: Bearer sk-lit6811" -H "Content-Type: application/json" -d @req_messages_privatelink.json`
2. Observed:

```
{"id":"resp_bGl0ZWxsbTpjdXN0b21fbGxtX3Byb3ZpZGVyOm9wZW5haTttb2RlbF9pZDo2ODNjZmU3NTAzYTE2NDJmYTVhZGY0ZmFjMmI2ZDU2MWFiZTg1ZmNmMDE0ZGNjNTg2MzNlNDc0ZjUwZjNjMDUyO3Jlc3BvbnNlX2lkOnJlc3BfMDIxOGFjYjcyOTYyNjY2MTAwNmE5OWFhMzcxNTJjODdkMDg3MmVmZDM5M2JjM2NkMDg=","type":"message","role":"assistant","model":"gpt-5.6-privatelink","stop_sequence":null,"content":[{"type":"tool_use","id":"call_0LIF9dcrtPxtWPIbtATuWXoo","name":"get_weather","input":{"city":"Paris"},"provider_specific_fields":null}],"stop_reason":"tool_use"}
HTTP 200
```

#### PrivateLink-style deployment, /v1/chat/completions with `"stream": true`

1. `curl -s -w "\nHTTP %{http_code}\n" http://localhost:37456/v1/chat/completions -H "Authorization: Bearer sk-lit6811" -H "Content-Type: application/json" -d @req_privatelink_stream.json`
2. Observed:

```
{"error":{"message":"litellm.BadRequestError: OpenAIException - Function tools with reasoning_effort are not supported for gpt-5.6 in /v1/chat/completions. To use function tools, use /v1/responses or set reasoning_effort to 'none'.. Received Model Group=gpt-5.6-privatelink\nAvailable Model Group Fallbacks=None","type":"invalid_request_error","param":"reasoning_effort","code":"400"}}
HTTP 400
```

### After (7a5e4b9ba4f)

Legs: `--num_workers 2`, no database, own worktree and venv, port 43355 (cases 1 to 3) and a second rig booted the same way on port 32604 (case 4). Each case ran twice so both workers answered; the first run is quoted

#### PrivateLink-style deployment, /v1/chat/completions

1. `curl -s -w "\nHTTP %{http_code}\n" http://localhost:43355/v1/chat/completions -H "Authorization: Bearer sk-lit6811" -H "Content-Type: application/json" -d @req_privatelink.json`
2. Observed:

```
{"id":"chatcmpl-5e3efc59-7ce7-47c1-9819-0deb5c62ecac","model":"gpt-5.6-privatelink","object":"chat.completion","choices":[{"finish_reason":"tool_calls","index":0,"message":{"role":"assistant","tool_calls":[{"index":0,"function":{"arguments":"{\"city\":\"Paris\"}","name":"get_weather"},"id":"call_XOgfPvAfFJN0BbQM8B6NPKrl","type":"function"}],"content":null}}]}
HTTP 200
```

#### Default api_base (control), /v1/chat/completions

1. `curl -s -w "\nHTTP %{http_code}\n" http://localhost:43355/v1/chat/completions -H "Authorization: Bearer sk-lit6811" -H "Content-Type: application/json" -d @req_default.json`
2. Observed:

```
{"id":"chatcmpl-ab5b14a5-648b-4bf1-baf1-e8a824ee49a5","model":"gpt-5.6-default","object":"chat.completion","choices":[{"finish_reason":"tool_calls","index":0,"message":{"role":"assistant","tool_calls":[{"index":0,"function":{"arguments":"{\"city\":\"Paris\"}","name":"get_weather"},"id":"call_CHTl9fS8tyHFOpVyQ9ADQzxt","type":"function"}],"content":null}}]}
HTTP 200
```

#### PrivateLink-style deployment, /v1/messages (unchanged surface)

1. `curl -s -w "\nHTTP %{http_code}\n" http://localhost:43355/v1/messages -H "Authorization: Bearer sk-lit6811" -H "Content-Type: application/json" -d @req_messages_privatelink.json`
2. Observed:

```
{"id":"resp_bGl0ZWxsbTpjdXN0b21fbGxtX3Byb3ZpZGVyOm9wZW5haTttb2RlbF9pZDo2ODNjZmU3NTAzYTE2NDJmYTVhZGY0ZmFjMmI2ZDU2MWFiZTg1ZmNmMDE0ZGNjNTg2MzNlNDc0ZjUwZjNjMDUyO3Jlc3BvbnNlX2lkOnJlc3BfMDBiYjY1NWI3NDhlZWMzZTAwNmE5OWE5ZWRjODU4ODdkMGE3MzNhZGI0ODg5MTYyZTM=","type":"message","role":"assistant","model":"gpt-5.6-privatelink","stop_sequence":null,"content":[{"type":"tool_use","id":"call_BlvUqP0QSOzroB1Sh3BWiHx3","name":"get_weather","input":{"city":"Paris"},"provider_specific_fields":null}],"stop_reason":"tool_use"}
HTTP 200
```

#### PrivateLink-style deployment, /v1/chat/completions with `"stream": true`

1. `curl -s -w "\nHTTP %{http_code}\n" http://localhost:32604/v1/chat/completions -H "Authorization: Bearer sk-lit6811" -H "Content-Type: application/json" -d @req_privatelink_stream.json`
2. Observed:

```
data: {"id":"chatcmpl-352f3219-1c7a-4068-ba33-f4f8524f731e","model":"gpt-5.6-privatelink","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"id":"call_f2mbHXIORv3xeoSf5CdNQQ7T","function":{"arguments":"","name":"get_weather"},"type":"function","index":0}]}}]}
data: {"id":"chatcmpl-352f3219-1c7a-4068-ba33-f4f8524f731e","model":"gpt-5.6-privatelink","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"function":{"arguments":"{\""},"type":"function","index":0}]}}]}
data: {"id":"chatcmpl-352f3219-1c7a-4068-ba33-f4f8524f731e","model":"gpt-5.6-privatelink","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"function":{"arguments":"city"},"type":"function","index":0}]}}]}
data: {"id":"chatcmpl-352f3219-1c7a-4068-ba33-f4f8524f731e","model":"gpt-5.6-privatelink","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"function":{"arguments":"\":\""},"type":"function","index":0}]}}]}
data: {"id":"chatcmpl-352f3219-1c7a-4068-ba33-f4f8524f731e","model":"gpt-5.6-privatelink","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"function":{"arguments":"Paris"},"type":"function","index":0}]}}]}
data: {"id":"chatcmpl-352f3219-1c7a-4068-ba33-f4f8524f731e","model":"gpt-5.6-privatelink","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"function":{"arguments":"\"}"},"type":"function","index":0}]}}]}
data: {"id":"chatcmpl-352f3219-1c7a-4068-ba33-f4f8524f731e","object":"chat.completion.chunk","model":"gpt-5.6-privatelink","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}
data: [DONE]
HTTP 200
```

Observations from the run:

- `/v1/messages` already bridged to `/v1/responses` before this PR; unaffected
- Both workers answered every case identically
- Explicit `reasoning_effort` (`low`, `none`) behaves the same before and after
- A non-OpenAI host stays on Chat Completions before and after
- `/v1/messages` answers with a `resp_...` id, not `msg_...`; pre-existing, unchanged

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- The e2e run stands in `https://api.openai.com:443/v1` for a PrivateLink host
  - A real `<region>.privatelink.api.openai.com` only resolves inside the customer's network
  - The unit tests pin the PrivateLink-shaped hostnames directly
- Only `api.openai.com` and its subdomains count as OpenAI-backed; `notapi.openai.com` and lookalike hosts stay on Chat Completions
- A `:443` or trailing-slash default URL now bridges too, where it used to stay on Chat Completions
  - Explicit `reasoning_effort` is untouched: `"none"` still keeps the request on Chat Completions
- The streaming usage default (`stream_options.include_usage`) still keys on the exact `api.openai.com` host, so PrivateLink and regional hosts get no usage chunk unless the caller sets it; pre-existing and tracked separately in LIT-6875

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 7a5e4b9ba4f passes /live-pr-risk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request-routing logic for GPT-5.4+ tool calls on custom `api_base` values; misclassification could bridge to `/responses` on backends that lack it or leave PrivateLink deployments on Chat Completions and 400.
> 
> **Overview**
> **Fixes routing for gpt-5.4+ function-tool requests when `api_base` is not the literal default URL.** The unset-`reasoning_effort` bridge to `/v1/responses` now keys off the resolved base URL’s **hostname** (`api.openai.com` or any subdomain), not an exact string match to `https://api.openai.com/v1`.
> 
> PrivateLink-style bases (e.g. `*.privatelink.api.openai.com`), port-qualified defaults, and trailing slashes are treated like the real OpenAI backend and bridge as before. Third-party OpenAI-compatible gateways whose host is not `api.openai.com` still stay on Chat Completions. Azure behavior is unchanged.
> 
> Adds `_is_openai_backed_api_base()` via `urlsplit`, strips the resolved base before the check, and expands unit tests for OpenAI-backed hosts, lookalike URLs, and `OPENAI_BASE_URL`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a5e4b9ba4f6d7d61122dd32b7e9c923cbd18bcf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
