### PR TITLE
perf(rust): bound provider connection pools and adopt mimalloc in the bridge

### DIFF
--- a/litellm-rust/Cargo.lock
+++ b/litellm-rust/Cargo.lock
@@ -1405,6 +1405,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "litellm-ai-gateway"
 version = "0.1.0"
 dependencies = [
@@ -1454,6 +1463,7 @@ dependencies = [
  "litellm-ai-gateway",
  "litellm-core",
  "litellm-python-interop",
+ "mimalloc",
  "pyo3",
  "pyo3-async-runtimes",
  "serde",
@@ -1504,6 +1514,15 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
+]
 
 [[package]]
 name = "mime"

--- a/litellm-rust/Cargo.toml
+++ b/litellm-rust/Cargo.toml
@@ -35,6 +35,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "net"]
 tokio-tungstenite = { version = "0.24", default-features = false, features = ["connect", "rustls-tls-native-roots"] }
 futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }
 base64 = "0.22"
+mimalloc = "0.1"
 
 [profile.release]
 opt-level = 3

--- a/litellm-rust/crates/ai-gateway/src/client.rs
+++ b/litellm-rust/crates/ai-gateway/src/client.rs
@@ -2,12 +2,16 @@ use std::sync::OnceLock;
 use std::time::Duration;
 
 const HTTP_CLIENT_TIMEOUT_SECS: u64 = 600;
+const HTTP_CLIENT_POOL_MAX_IDLE_PER_HOST: usize = 64;
+const HTTP_CLIENT_TCP_KEEPALIVE_SECS: u64 = 60;
 
 pub(crate) fn http_client() -> &'static reqwest::Client {
     static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
     CLIENT.get_or_init(|| {
         reqwest::Client::builder()
             .timeout(Duration::from_secs(HTTP_CLIENT_TIMEOUT_SECS))
+            .pool_max_idle_per_host(HTTP_CLIENT_POOL_MAX_IDLE_PER_HOST)
+            .tcp_keepalive(Some(Duration::from_secs(HTTP_CLIENT_TCP_KEEPALIVE_SECS)))
             .build()
             .expect("failed to build reqwest client")
     })

--- a/litellm-rust/crates/core/src/audio_transcription/client.rs
+++ b/litellm-rust/crates/core/src/audio_transcription/client.rs
@@ -1,13 +1,17 @@
 use std::sync::OnceLock;
 use std::time::Duration;
 
-use crate::constants::AUDIO_TRANSCRIPTION_TIMEOUT_SECS;
+use crate::constants::{
+    AUDIO_TRANSCRIPTION_TIMEOUT_SECS, PROVIDER_POOL_MAX_IDLE_PER_HOST, PROVIDER_TCP_KEEPALIVE_SECS,
+};
 
 pub(super) fn http_client() -> &'static reqwest::Client {
     static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
     CLIENT.get_or_init(|| {
         reqwest::Client::builder()
             .timeout(Duration::from_secs(AUDIO_TRANSCRIPTION_TIMEOUT_SECS))
+            .pool_max_idle_per_host(PROVIDER_POOL_MAX_IDLE_PER_HOST)
+            .tcp_keepalive(Some(Duration::from_secs(PROVIDER_TCP_KEEPALIVE_SECS)))
             .build()
             .unwrap_or_else(|_| reqwest::Client::new())
     })

--- a/litellm-rust/crates/core/src/chat_completions/client.rs
+++ b/litellm-rust/crates/core/src/chat_completions/client.rs
@@ -1,7 +1,10 @@
 use std::sync::OnceLock;
 use std::time::Duration;
 
-use crate::constants::{CHAT_COMPLETIONS_CONNECT_TIMEOUT_SECS, CHAT_COMPLETIONS_TIMEOUT_SECS};
+use crate::constants::{
+    CHAT_COMPLETIONS_CONNECT_TIMEOUT_SECS, CHAT_COMPLETIONS_TIMEOUT_SECS,
+    PROVIDER_POOL_MAX_IDLE_PER_HOST, PROVIDER_TCP_KEEPALIVE_SECS,
+};
 
 pub(super) fn http_client() -> &'static reqwest::Client {
     static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
@@ -9,6 +12,8 @@ pub(super) fn http_client() -> &'static reqwest::Client {
         reqwest::Client::builder()
             .timeout(Duration::from_secs(CHAT_COMPLETIONS_TIMEOUT_SECS))
             .connect_timeout(Duration::from_secs(CHAT_COMPLETIONS_CONNECT_TIMEOUT_SECS))
+            .pool_max_idle_per_host(PROVIDER_POOL_MAX_IDLE_PER_HOST)
+            .tcp_keepalive(Some(Duration::from_secs(PROVIDER_TCP_KEEPALIVE_SECS)))
             .build()
             .unwrap_or_else(|_| reqwest::Client::new())
     })

--- a/litellm-rust/crates/core/src/constants.rs
+++ b/litellm-rust/crates/core/src/constants.rs
@@ -32,6 +32,18 @@ pub(crate) const CHAT_COMPLETIONS_CONNECT_TIMEOUT_SECS: u64 = 10;
 
 pub(crate) const AUDIO_TRANSCRIPTION_TIMEOUT_SECS: u64 = 600;
 
+/// Idle connections retained per host in the shared provider clients.
+/// reqwest defaults to `usize::MAX`, so a burst of concurrent calls to one
+/// provider host leaves every connection idle in the pool until its timeout;
+/// this bounds file descriptors while keeping enough warm connections for
+/// TLS-handshake-free reuse.
+pub(crate) const PROVIDER_POOL_MAX_IDLE_PER_HOST: usize = 64;
+
+/// TCP keep-alive probe interval for provider sockets. Detects half-open
+/// peers (NAT/LB reaping, vanished upstreams) during long-lived streaming
+/// responses that otherwise sit silent for the whole request timeout.
+pub(crate) const PROVIDER_TCP_KEEPALIVE_SECS: u64 = 60;
+
 /// `object` field every non-streaming chat completion response carries.
 pub const CHAT_COMPLETION_OBJECT: &str = "chat.completion";
 

--- a/litellm-rust/crates/core/src/messages/client.rs
+++ b/litellm-rust/crates/core/src/messages/client.rs
@@ -1,7 +1,10 @@
 use std::sync::OnceLock;
 use std::time::Duration;
 
-use crate::constants::{MESSAGES_CONNECT_TIMEOUT_SECS, MESSAGES_TIMEOUT_SECS};
+use crate::constants::{
+    MESSAGES_CONNECT_TIMEOUT_SECS, MESSAGES_TIMEOUT_SECS, PROVIDER_POOL_MAX_IDLE_PER_HOST,
+    PROVIDER_TCP_KEEPALIVE_SECS,
+};
 
 pub(super) fn http_client() -> &'static reqwest::Client {
     static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
@@ -9,6 +12,8 @@ pub(super) fn http_client() -> &'static reqwest::Client {
         reqwest::Client::builder()
             .timeout(Duration::from_secs(MESSAGES_TIMEOUT_SECS))
             .connect_timeout(Duration::from_secs(MESSAGES_CONNECT_TIMEOUT_SECS))
+            .pool_max_idle_per_host(PROVIDER_POOL_MAX_IDLE_PER_HOST)
+            .tcp_keepalive(Some(Duration::from_secs(PROVIDER_TCP_KEEPALIVE_SECS)))
             .build()
             .unwrap_or_else(|_| reqwest::Client::new())
     })

--- a/litellm-rust/crates/python-bridge/Cargo.toml
+++ b/litellm-rust/crates/python-bridge/Cargo.toml
@@ -17,6 +17,7 @@ panic-test = []
 
 [dependencies]
 futures-util.workspace = true
+mimalloc.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 litellm-core = { workspace = true, features = ["bedrock-auth"] }

--- a/litellm-rust/crates/python-bridge/Cargo.toml
+++ b/litellm-rust/crates/python-bridge/Cargo.toml
@@ -13,11 +13,12 @@ crate-type = ["cdylib"]
 default = ["abi3"]
 abi3 = ["pyo3/abi3-py310"]
 extension-module = ["pyo3/extension-module"]
+mimalloc = ["dep:mimalloc"]
 panic-test = []
 
 [dependencies]
 futures-util.workspace = true
-mimalloc.workspace = true
+mimalloc = { workspace = true, optional = true }
 tracing.workspace = true
 tracing-subscriber.workspace = true
 litellm-core = { workspace = true, features = ["bedrock-auth"] }

--- a/litellm-rust/crates/python-bridge/src/lib.rs
+++ b/litellm-rust/crates/python-bridge/src/lib.rs
@@ -11,6 +11,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyAny;
 use serde_json::Value;
 
+#[cfg(feature = "mimalloc")]
 #[global_allocator]
 static ALLOCATOR: mimalloc::MiMalloc = mimalloc::MiMalloc;
 

--- a/litellm-rust/crates/python-bridge/src/lib.rs
+++ b/litellm-rust/crates/python-bridge/src/lib.rs
@@ -11,6 +11,9 @@ use pyo3::prelude::*;
 use pyo3::types::PyAny;
 use serde_json::Value;
 
+#[global_allocator]
+static ALLOCATOR: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 use crate::errors::core_error_to_pyerr;
 use crate::marshal::{marshal_headers, optional_timeout};
 


### PR DESCRIPTION
## Responsibility

Host-resource characteristics of the native bridge, no behavior change:
1. **Bound the provider connection pools** of the four shared `reqwest` clients (core `messages` / `chat_completions` / `audio_transcription`, `ai-gateway`).
2. **Add an opt-in `mimalloc` cargo feature** to the `python-bridge` cdylib — off by default — kept available so allocator-on vs allocator-off builds can be **benchmarked against real workloads later**, before any proposal to enable it in wheels.

## 1. Pool bounds + TCP keep-alive

- `pool_max_idle_per_host(64)`: reqwest's default is `usize::MAX`. After a burst of *N* concurrent calls to one provider host (exactly what the bridge fans out to under load), all *N* TLS connections sit idle in the pool until each one's idle timeout — file descriptors and memory grow with peak concurrency, not steady-state. 64 keeps a warm set for handshake-free reuse while bounding the tail.
- `tcp_keepalive(60s)`: streaming responses can sit silent for minutes. Without keep-alive probes, a half-open peer (NAT/LB idle reaping, vanished upstream) is only discovered at the 600 s full-request timeout. Increasingly relevant with the streaming route in #39577.

Values live in `core/src/constants.rs` (`PROVIDER_POOL_MAX_IDLE_PER_HOST`, `PROVIDER_TCP_KEEPALIVE_SECS`); the gateway client mirrors them locally, matching its existing local-timeout-const convention.

## 2. mimalloc — opt-in cargo feature, default OFF, provided for later benchmarking

`cargo build --features mimalloc` (or `maturin.build-args=--features mimalloc,extension-module`) installs `mimalloc::MiMalloc` as the cdylib's Rust `#[global_allocator]`. Scope: it governs **only allocations made by Rust code inside the extension** — CPython's `pymalloc` heap is untouched.

**Why the feature exists:** the allocator question for this bridge is open, and answering it needs measurements, not defaults. The feature makes both configurations buildable today so we can A/B them later on representative workloads (burst fan-out, large-payload transcription/OCR, streaming) using `MIMALLOC_SHOW_STATS=1`, `heaptrack` for Rust-vs-pymalloc RSS attribution, and `py-spy record --native` — and only then decide whether allocator-on is worth proposing as a wheel default. Hypothesis to test: Rust-side buffering (`serde_json::Value` churn, request/response bodies, WebSocket/SSE buffers) in a long-lived process is glibc malloc's weak spot — arena fragmentation, cross-thread frees migrating between arenas, RSS approximating the all-time high-water mark — which mimalloc's per-thread heaps, sharded free lists, and eager page purging address.

**Why off by default — the verified precedent:**

- **pydantic-core shipped mimalloc Jun 2022 → Aug 2023, then removed it** ([pydantic-core#900](https://github.com/pydantic/pydantic-core/pull/900), "Replace MiMalloc w/ default allocator"), fixing:
  - [pydantic#7167](https://github.com/pydantic/pydantic/issues/7167) — **~1 GiB of reserved virtual memory at import** (mimalloc region reservation), breaking processes constrained by `setrlimit(RLIMIT_AS)`;
  - [pydantic#6620](https://github.com/pydantic/pydantic/issues/6620) — container memory-footprint complaints from exactly our demographic: FastAPI/uvicorn services in ~2 GB Docker limits;
  - preceded by a TLS-linkage fix ([pydantic-core#363](https://github.com/pydantic/pydantic-core/pull/363)) and disabling mimalloc on manylinux cross-compiles ([pydantic-core#893](https://github.com/pydantic/pydantic-core/pull/893)).
- **orjson takes a third path**: its `#[global_allocator]` routes Rust allocations into **CPython's `PyMem_Malloc`** (`src/alloc.rs`), unifying the Rust heap with the Python heap. That is only sound because orjson holds the GIL for its entire call; our bridge detaches and allocates from arbitrary Tokio workers, where `PyMem_Malloc` (GIL-required) would be UB — not an option here.
- litellm wheels land in the same memory-limited container deployments that drove pydantic's removal, so the default stays the system allocator until benchmarks say otherwise. Our wheels are linux x86_64 (no aarch64 cross-compile today), and mimalloc 0.1.52 is far newer than the 0.1.x-era issues above — the feature path is low-risk to benchmark.

## Verification

- `cargo fmt --check` — clean
- `cargo check -p litellm-python-bridge` (no allocator), `--features mimalloc`, `--features extension-module` — all compile
- `cargo clippy --workspace --all-targets --locked -- -D warnings` and the bedrock-auth variant — clean
- `cargo test --workspace --locked` — all suites green
- `Cargo.lock` updated (CI runs `--locked`)

## Merge-order note

Only overlap with the open PRs: `python-bridge/Cargo.toml` + `src/lib.rs` (small) and `Cargo.lock`. Neither #39577 nor #39579 touches the client files. Safe in any order.

## Explicitly out of scope

- Consolidating the four client twins into one shared constructor (better after #39577/#39579 reshape `http_utils`).
- `ocr/common_utils.rs` builds a client per redirect-probe call — noted for a follow-up.
- Zero-copy buffers (`PyBuffer`), which remove allocations rather than taxing them — separate follow-up.
- The benchmark itself: this PR only makes both builds possible; the A/B harness runs later on top of it.