### PR TITLE
fix(cost): apply off_peak_pricing in the dashscope cost calculator

### DIFF
--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -428,7 +428,7 @@ def _coerce_off_peak_rate(value: object, default: float) -> float:
     return default
 
 
-def _apply_off_peak_pricing(
+def apply_off_peak_pricing(
     model_info: ModelInfo,
     current_time: datetime | None,
     prompt_base_cost: float,
@@ -462,7 +462,7 @@ def _apply_off_peak_to_base_costs(
     has no field for them.
     """
     prompt, completion, cache_creation, cache_creation_above_1hr, cache_read = base_costs
-    off_peak_prompt, off_peak_completion, off_peak_cache_read = _apply_off_peak_pricing(
+    off_peak_prompt, off_peak_completion, off_peak_cache_read = apply_off_peak_pricing(
         model_info, current_time, prompt, completion, cache_read
     )
     return (off_peak_prompt, off_peak_completion, cache_creation, cache_creation_above_1hr, off_peak_cache_read)

--- a/litellm/llms/dashscope/cost_calculator.py
+++ b/litellm/llms/dashscope/cost_calculator.py
@@ -7,11 +7,13 @@ cached, cache-creation, output, reasoning) is billed at that one tier's rate.
 See https://help.aliyun.com/zh/model-studio/billing-for-model-studio
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
+from datetime import datetime
 from typing import Final
 
 from litellm.litellm_core_utils.llm_cost_calc.tiered_pricing import select_tier_for_input, tier_rate
 from litellm.litellm_core_utils.llm_cost_calc.utils import (
+    apply_off_peak_pricing,
     parse_completion_tokens_details,
     parse_prompt_tokens_details,
 )
@@ -30,6 +32,19 @@ class TokenBreakdown:
     @property
     def total_input_tokens(self) -> int:
         return self.text_tokens + self.cached_tokens + self.cache_creation_tokens
+
+
+@dataclass(frozen=True, slots=True)
+class TokenRates:
+    input_rate: float
+    cache_read_rate: float
+    cache_creation_rate: float
+    output_rate: float
+    reasoning_rate: float | None
+
+    @property
+    def billed_reasoning_rate(self) -> float:
+        return self.output_rate if self.reasoning_rate is None else self.reasoning_rate
 
 
 def _extract_token_breakdown(usage: Usage) -> TokenBreakdown:
@@ -57,69 +72,75 @@ def _flat_rate(model_info: ModelInfo, cost_key: str, fallback_cost_key: str) -> 
     return float(value)
 
 
-def _calculate_prompt_cost(
-    breakdown: TokenBreakdown,
-    model_info: ModelInfo,
-    tier: dict | None,
-) -> float:
-    if tier is not None:
-        return (
-            (breakdown.text_tokens * tier_rate(tier, "input_cost_per_token"))
-            + (breakdown.cached_tokens * tier_rate(tier, "cache_read_input_token_cost", "input_cost_per_token"))
-            + (
-                breakdown.cache_creation_tokens
-                * tier_rate(tier, "cache_creation_input_token_cost", "input_cost_per_token")
-            )
-        )
-
-    input_cost: Final = float(model_info.get("input_cost_per_token") or 0.0)
-    cache_read_cost: Final = _flat_rate(model_info, "cache_read_input_token_cost", "input_cost_per_token")
-    cache_creation_cost: Final = _flat_rate(model_info, "cache_creation_input_token_cost", "input_cost_per_token")
-
-    return (
-        (breakdown.text_tokens * input_cost)
-        + (breakdown.cached_tokens * cache_read_cost)
-        + (breakdown.cache_creation_tokens * cache_creation_cost)
+def _flat_rates(model_info: ModelInfo) -> TokenRates:
+    reasoning_rate: Final = model_info.get("output_cost_per_reasoning_token")
+    return TokenRates(
+        input_rate=float(model_info.get("input_cost_per_token") or 0.0),
+        cache_read_rate=_flat_rate(model_info, "cache_read_input_token_cost", "input_cost_per_token"),
+        cache_creation_rate=_flat_rate(model_info, "cache_creation_input_token_cost", "input_cost_per_token"),
+        output_rate=float(model_info.get("output_cost_per_token") or 0.0),
+        reasoning_rate=None if reasoning_rate is None else float(reasoning_rate),
     )
 
 
-def _calculate_completion_cost(
-    breakdown: TokenBreakdown,
-    model_info: ModelInfo,
-    tier: dict | None,
-) -> float:
+def _tier_rates(model_info: ModelInfo, tier: dict) -> TokenRates:
     # A tier that declares output rates keeps the request on them, all-or-nothing. A tier table
     # spelling out only input rates would serve every completion for free, so there the model's
     # own output rates stand in
-    tier_declares_output: Final = tier is not None and "output_cost_per_token" in tier
-    output_cost: Final = (
-        tier_rate(tier, "output_cost_per_token")
-        if tier_declares_output
-        else float(model_info.get("output_cost_per_token") or 0.0)
+    flat_rates: Final = _flat_rates(model_info)
+    tier_declares_output: Final = "output_cost_per_token" in tier
+    tier_declares_reasoning: Final = "output_cost_per_reasoning_token" in tier
+    return TokenRates(
+        input_rate=tier_rate(tier, "input_cost_per_token"),
+        cache_read_rate=tier_rate(tier, "cache_read_input_token_cost", "input_cost_per_token"),
+        cache_creation_rate=tier_rate(tier, "cache_creation_input_token_cost", "input_cost_per_token"),
+        output_rate=tier_rate(tier, "output_cost_per_token") if tier_declares_output else flat_rates.output_rate,
+        reasoning_rate=(
+            tier_rate(tier, "output_cost_per_reasoning_token")
+            if tier_declares_reasoning
+            else None
+            if tier_declares_output
+            else flat_rates.reasoning_rate
+        ),
     )
-    tier_declares_reasoning: Final = tier is not None and "output_cost_per_reasoning_token" in tier
-    model_reasoning_rate: Final = None if tier_declares_output else model_info.get("output_cost_per_reasoning_token")
-    reasoning_cost: Final = (
-        tier_rate(tier, "output_cost_per_reasoning_token", "output_cost_per_token")
-        if tier_declares_reasoning
-        else float(model_reasoning_rate)
-        if model_reasoning_rate is not None
-        else output_cost
+
+
+def _off_peak_rates(model_info: ModelInfo, current_time: datetime | None, rates: TokenRates) -> TokenRates:
+    input_rate, output_rate, cache_read_rate = apply_off_peak_pricing(
+        model_info, current_time, rates.input_rate, rates.output_rate, rates.cache_read_rate
     )
+    return replace(rates, input_rate=input_rate, output_rate=output_rate, cache_read_rate=cache_read_rate)
 
-    return (breakdown.completion_tokens * output_cost) + (breakdown.reasoning_tokens * reasoning_cost)
+
+def _bill(breakdown: TokenBreakdown, rates: TokenRates) -> tuple[float, float]:
+    prompt_cost: Final = (
+        (breakdown.text_tokens * rates.input_rate)
+        + (breakdown.cached_tokens * rates.cache_read_rate)
+        + (breakdown.cache_creation_tokens * rates.cache_creation_rate)
+    )
+    completion_cost: Final = (breakdown.completion_tokens * rates.output_rate) + (
+        breakdown.reasoning_tokens * rates.billed_reasoning_rate
+    )
+    return prompt_cost, completion_cost
 
 
-def cost_per_token(model: str, usage: Usage, custom_llm_provider: str = "dashscope") -> tuple[float, float]:
+def cost_per_token(
+    model: str,
+    usage: Usage,
+    custom_llm_provider: str = "dashscope",
+    current_time: datetime | None = None,
+) -> tuple[float, float]:
     """
     Calculate cost per token for Dashscope models.
 
-    Supports both tiered and flat pricing with cached and reasoning tokens.
+    Supports both tiered and flat pricing with cached and reasoning tokens, and swaps in the
+    model's off_peak_pricing rates while one of its windows is open.
 
     Args:
         model: Model name without provider prefix
         usage: LiteLLM Usage block
         custom_llm_provider: The provider id the request resolved to; dashscope or one of its brand aliases
+        current_time: The moment the request is billed at; defaults to now, UTC
 
     Returns:
         Tuple[float, float] - (prompt_cost_in_usd, completion_cost_in_usd)
@@ -133,8 +154,7 @@ def cost_per_token(model: str, usage: Usage, custom_llm_provider: str = "dashsco
         if tiered_pricing
         else None
     )
+    standard_rates: Final = _flat_rates(model_info) if tier is None else _tier_rates(model_info, tier)
+    rates: Final = _off_peak_rates(model_info, current_time, standard_rates)
 
-    prompt_cost: Final = _calculate_prompt_cost(breakdown=breakdown, model_info=model_info, tier=tier)
-    completion_cost: Final = _calculate_completion_cost(breakdown=breakdown, model_info=model_info, tier=tier)
-
-    return prompt_cost, completion_cost
+    return _bill(breakdown, rates)

--- a/tests/test_litellm/llms/dashscope/test_dashscope_cost_calculator.py
+++ b/tests/test_litellm/llms/dashscope/test_dashscope_cost_calculator.py
@@ -10,11 +10,11 @@ Tests the cost calculation for Dashscope models including:
 
 import math
 import os
+from datetime import datetime, timezone
 
 import pytest
 
 # Add the project root to Python path
-
 import litellm
 from litellm.llms.dashscope.cost_calculator import (
     cost_per_token as dashscope_cost_per_token,
@@ -526,3 +526,139 @@ class TestDashscopeCostCalculator:
 
         assert prompt_cost == 0.0
         assert math.isclose(completion_cost, 500 * 1.6e-06, rel_tol=1e-10)
+
+    OFF_PEAK_WINDOW = "14:00-00:00"
+    INSIDE_WINDOW = datetime(2026, 9, 3, 17, 25, tzinfo=timezone.utc)
+    OUTSIDE_WINDOW = datetime(2026, 9, 3, 9, 0, tzinfo=timezone.utc)
+
+    def _register_off_peak_flat_model(self, model_key: str, off_peak_pricing: dict) -> None:
+        litellm.model_cost[model_key] = {
+            "litellm_provider": "dashscope",
+            "mode": "chat",
+            "input_cost_per_token": 2.4e-06,
+            "output_cost_per_token": 4.8e-06,
+            "cache_read_input_token_cost": 2e-07,
+            "cache_creation_input_token_cost": 3e-06,
+            "off_peak_pricing": off_peak_pricing,
+        }
+
+    def test_dashscope_off_peak_window_swaps_in_the_off_peak_rates(self):
+        """
+        Regression (LIT-6782): a deployment configured with off_peak_pricing kept billing the
+        standard dashscope rates inside its window, while the same block on a deepseek
+        deployment billed the off-peak rates.
+        """
+        self._register_off_peak_flat_model(
+            "dashscope/deepseek-off-peak-test",
+            {
+                "hours_utc": self.OFF_PEAK_WINDOW,
+                "input_cost_per_token": 1.2e-06,
+                "output_cost_per_token": 2.4e-06,
+                "cache_read_input_token_cost": 1e-07,
+            },
+        )
+        usage = Usage(
+            prompt_tokens=1000,
+            completion_tokens=200,
+            prompt_tokens_details=PromptTokensDetailsWrapper(cached_tokens=300, cache_creation_tokens=100),
+        )
+
+        prompt_cost, completion_cost = dashscope_cost_per_token(
+            model="deepseek-off-peak-test", usage=usage, current_time=self.INSIDE_WINDOW
+        )
+
+        assert math.isclose(prompt_cost, (600 * 1.2e-06) + (300 * 1e-07) + (100 * 3e-06), rel_tol=1e-10)
+        assert math.isclose(completion_cost, 200 * 2.4e-06, rel_tol=1e-10)
+
+        peak_prompt_cost, peak_completion_cost = dashscope_cost_per_token(
+            model="deepseek-off-peak-test", usage=usage, current_time=self.OUTSIDE_WINDOW
+        )
+
+        assert math.isclose(peak_prompt_cost, (600 * 2.4e-06) + (300 * 2e-07) + (100 * 3e-06), rel_tol=1e-10)
+        assert math.isclose(peak_completion_cost, 200 * 4.8e-06, rel_tol=1e-10)
+
+    def test_dashscope_off_peak_window_overrides_the_selected_tier(self):
+        """An open off-peak window bills the whole request at the flat off-peak rates, whichever tier
+        the input volume selected."""
+        self._register_tiered_model(
+            "dashscope/qwen-tiered-off-peak-test",
+            [
+                {"range": [0, 1000], "input_cost_per_token": 4e-07, "output_cost_per_token": 1.6e-06},
+                {"range": [1000, 2000], "input_cost_per_token": 8e-07, "output_cost_per_token": 3.2e-06},
+            ],
+        )
+        litellm.model_cost["dashscope/qwen-tiered-off-peak-test"]["off_peak_pricing"] = {
+            "hours_utc": self.OFF_PEAK_WINDOW,
+            "input_cost_per_token": 1e-07,
+            "output_cost_per_token": 4e-07,
+        }
+        usage = Usage(prompt_tokens=1500, completion_tokens=300)
+
+        prompt_cost, completion_cost = dashscope_cost_per_token(
+            model="qwen-tiered-off-peak-test", usage=usage, current_time=self.INSIDE_WINDOW
+        )
+
+        assert math.isclose(prompt_cost, 1500 * 1e-07, rel_tol=1e-10)
+        assert math.isclose(completion_cost, 300 * 4e-07, rel_tol=1e-10)
+
+        peak_prompt_cost, peak_completion_cost = dashscope_cost_per_token(
+            model="qwen-tiered-off-peak-test", usage=usage, current_time=self.OUTSIDE_WINDOW
+        )
+
+        assert math.isclose(peak_prompt_cost, 1500 * 8e-07, rel_tol=1e-10)
+        assert math.isclose(peak_completion_cost, 300 * 3.2e-06, rel_tol=1e-10)
+
+    def test_dashscope_off_peak_rates_left_unset_keep_the_standard_rates(self):
+        """A block that only overrides the input rate leaves output and cache reads on the standard
+        rates, and an explicit reasoning rate is never swapped out."""
+        self._register_off_peak_flat_model(
+            "dashscope/qwen-partial-off-peak-test",
+            {"hours_utc": self.OFF_PEAK_WINDOW, "input_cost_per_token": 1.2e-06},
+        )
+        litellm.model_cost["dashscope/qwen-partial-off-peak-test"]["output_cost_per_reasoning_token"] = 9e-06
+        usage = Usage(
+            prompt_tokens=1000,
+            completion_tokens=200,
+            prompt_tokens_details=PromptTokensDetailsWrapper(cached_tokens=300),
+            completion_tokens_details=CompletionTokensDetailsWrapper(reasoning_tokens=50),
+        )
+
+        prompt_cost, completion_cost = dashscope_cost_per_token(
+            model="qwen-partial-off-peak-test", usage=usage, current_time=self.INSIDE_WINDOW
+        )
+
+        assert math.isclose(prompt_cost, (700 * 1.2e-06) + (300 * 2e-07), rel_tol=1e-10)
+        assert math.isclose(completion_cost, (150 * 4.8e-06) + (50 * 9e-06), rel_tol=1e-10)
+
+    def test_dashscope_off_peak_output_rate_covers_reasoning_without_a_dedicated_rate(self):
+        """Reasoning tokens on a model with no dedicated reasoning rate follow the off-peak output
+        rate, the same way they follow the standard output rate outside the window."""
+        self._register_off_peak_flat_model(
+            "dashscope/qwen-reasoning-off-peak-test",
+            {"hours_utc": self.OFF_PEAK_WINDOW, "output_cost_per_token": 2.4e-06},
+        )
+        usage = Usage(
+            prompt_tokens=100,
+            completion_tokens=200,
+            completion_tokens_details=CompletionTokensDetailsWrapper(reasoning_tokens=50),
+        )
+
+        _, completion_cost = dashscope_cost_per_token(
+            model="qwen-reasoning-off-peak-test", usage=usage, current_time=self.INSIDE_WINDOW
+        )
+
+        assert math.isclose(completion_cost, 200 * 2.4e-06, rel_tol=1e-10)
+
+    def test_dashscope_off_peak_defaults_to_the_current_time(self):
+        """The proxy's cost dispatch passes no clock, so an all-day window has to apply on the
+        default current time."""
+        self._register_off_peak_flat_model(
+            "dashscope/qwen-all-day-off-peak-test",
+            {"hours_utc": "00:00-00:00", "input_cost_per_token": 1.2e-06, "output_cost_per_token": 2.4e-06},
+        )
+        usage = Usage(prompt_tokens=1000, completion_tokens=200)
+
+        prompt_cost, completion_cost = dashscope_cost_per_token(model="qwen-all-day-off-peak-test", usage=usage)
+
+        assert math.isclose(prompt_cost, 1000 * 1.2e-06, rel_tol=1e-10)
+        assert math.isclose(completion_cost, 200 * 2.4e-06, rel_tol=1e-10)


### PR DESCRIPTION
## TLDR

Problem this solves:

- `off_peak_pricing` on a dashscope deployment never changed the bill
- The dashscope cost calculator only read its tier and flat rates
- The same block on a deepseek deployment already billed off-peak rates

How it solves it:

- The dashscope calculator resolves one rate card, then swaps in the off-peak rates
- Off-peak input, output, and cache-read rates replace the tier or flat rates
- Reasoning tokens follow the off-peak output rate unless a dedicated reasoning rate exists
- `apply_off_peak_pricing` goes public so provider calculators share the generic path's helper

## User Flow

Before: a proxy admin puts an off-peak window on a dashscope deployment and every request inside it still bills the standard rate

1. They add `off_peak_pricing` (`hours_utc: "14:00-00:00"`, `input_cost_per_token: 1.2e-6`, `output_cost_per_token: 2.4e-6`, `cache_read_input_token_cost: 1.0e-7`) under `model_info` of a `dashscope/deepseek-v4-pro` deployment and restart the proxy
2. Inside the window they send POST http://localhost:4000/v1/chat/completions with `{"model": "dashscope-deepseek-v4-pro", "messages": [{"role": "user", "content": "Reply with the single word: pong"}], "max_tokens": 20}`
3. The 200 response reports 12 prompt and 21 completion tokens and `x-litellm-response-cost: 0.0001296`, which is the standard 2.4e-6 / 4.8e-6 rates
4. The same request to a `deepseek/deepseek-v4-pro` deployment carrying the identical block comes back priced at 1.2e-6 / 2.4e-6, so only the dashscope deployment ignores its window

After: the same request inside the window bills the off-peak rates

1. They add the same `off_peak_pricing` block under `model_info` of the `dashscope/deepseek-v4-pro` deployment and restart the proxy
2. Inside the window they send the same POST http://localhost:4000/v1/chat/completions
3. The 200 response reports its token counts and an `x-litellm-response-cost` priced at 1.2e-6 / 2.4e-6, the off-peak rates (0.0000648 for 12 prompt and 21 completion tokens)
4. The `deepseek/deepseek-v4-pro` deployment bills the same off-peak rates as before, so both deployments now agree

## Relevant issues

## Linear ticket

Resolves LIT-6782

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup: two DB-less proxies (`LITELLM_LOCAL_MODEL_COST_MAP=True`, `LITELLM_MASTER_KEY=sk-lit6782`, DashScope and DeepSeek keys in `.env`), one per commit, each booted with `python litellm/proxy/proxy_cli.py --config config.yaml --port $PORT --num_workers 2 --detailed_debug` (2 uvicorn workers each, two `Started server process` lines per proxy log), run at 18:01 UTC on 2026-09-03, inside the 14:00-00:00 UTC window. Every deployment gets the same request twice per leg (round 1, round 2) so both workers answer. The deepseek deployment is the control that already billed off-peak, and the last qwen-flash deployment carries no off-peak block, so its price must not move

```yaml
model_list:
  - model_name: dashscope-deepseek-v4-pro
    litellm_params:
      model: dashscope/deepseek-v4-pro
      api_key: os.environ/DASHSCOPE_API_KEY
      api_base: os.environ/DASHSCOPE_API_BASE
    model_info:
      off_peak_pricing:
        hours_utc: "14:00-00:00"
        input_cost_per_token: 1.2e-6
        output_cost_per_token: 2.4e-6
        cache_read_input_token_cost: 1.0e-7
  - model_name: deepseek-deepseek-v4-pro
    litellm_params:
      model: deepseek/deepseek-v4-pro
      api_key: os.environ/DEEPSEEK_API_KEY
    model_info:
      off_peak_pricing:
        hours_utc: "14:00-00:00"
        input_cost_per_token: 1.2e-6
        output_cost_per_token: 2.4e-6
        cache_read_input_token_cost: 1.0e-7
  - model_name: dashscope-qwen-flash-tiered-offpeak
    litellm_params:
      model: dashscope/qwen-flash
      api_key: os.environ/DASHSCOPE_API_KEY
      api_base: os.environ/DASHSCOPE_API_BASE
    model_info:
      off_peak_pricing:
        hours_utc: "14:00-00:00"
        input_cost_per_token: 2.5e-8
        output_cost_per_token: 2.0e-7
  - model_name: dashscope-qwen-flash-tiered
    litellm_params:
      model: dashscope/qwen-flash
      api_key: os.environ/DASHSCOPE_API_KEY
      api_base: os.environ/DASHSCOPE_API_BASE
general_settings:
  master_key: sk-lit6782
```

The request, with `<deployment>` swapped for each model name below:

```
curl -s -D - http://localhost:$PORT/v1/chat/completions -H "Authorization: Bearer sk-lit6782" -H "Content-Type: application/json" -d '{"model":"<deployment>","messages":[{"role":"user","content":"Reply with the single word: pong"}],"max_tokens":20}'
```

### Before (2c30fe16b0c)

#### dashscope deployment inside the off-peak window

1. The curl with `"model":"dashscope-deepseek-v4-pro"`
2. Round 1: `HTTP/1.1 200 OK`, `x-litellm-response-cost: 0.0001296`, usage `prompt_tokens: 12, completion_tokens: 21`: that is 12 x 2.4e-6 + 21 x 4.8e-6, the standard rates (off-peak would be 0.0000648)
3. Round 2: `HTTP/1.1 200 OK`, `x-litellm-response-cost: 0.0001296` at 12 / 21 again

#### deepseek control inside the same window

1. The curl with `"model":"deepseek-deepseek-v4-pro"`
2. Round 1: `HTTP/1.1 200 OK`, `x-litellm-response-cost: 0.0001572`, usage `prompt_tokens: 91, completion_tokens: 20`: that is 91 x 1.2e-6 + 20 x 2.4e-6, the off-peak rates
3. Round 2: `HTTP/1.1 200 OK`, `x-litellm-response-cost: 0.0001572` at 91 / 20 again

#### dashscope tiered model with an off-peak block

1. The curl with `"model":"dashscope-qwen-flash-tiered-offpeak"`
2. Round 1: `HTTP/1.1 200 OK`, `x-litellm-response-cost: 1.15e-06`, usage `prompt_tokens: 15, completion_tokens: 1`: that is 15 x 5e-8 + 1 x 4e-7, the first tier's standard rates (off-peak would be 5.75e-07)
3. Round 2: `HTTP/1.1 200 OK`, `x-litellm-response-cost: 1.15e-06` at 15 / 1 again

#### dashscope tiered model without an off-peak block (regression control)

1. The curl with `"model":"dashscope-qwen-flash-tiered"`
2. Round 1: `HTTP/1.1 200 OK`, `x-litellm-response-cost: 1.15e-06`, usage `prompt_tokens: 15, completion_tokens: 1`: the first tier's rates
3. Round 2: `HTTP/1.1 200 OK`, `x-litellm-response-cost: 1.15e-06` at 15 / 1 again

### After (b9e030ddd66)

#### dashscope deployment inside the off-peak window

1. The curl with `"model":"dashscope-deepseek-v4-pro"`
2. Round 1: `HTTP/1.1 200 OK`, `x-litellm-response-cost: 6.48e-05`, usage `prompt_tokens: 12, completion_tokens: 21`: that is 12 x 1.2e-6 + 21 x 2.4e-6, the off-peak rates
3. Round 2: `HTTP/1.1 200 OK`, `x-litellm-response-cost: 6.48e-05` at 12 / 21 again

#### deepseek control inside the same window

1. The curl with `"model":"deepseek-deepseek-v4-pro"`
2. Round 1: `HTTP/1.1 200 OK`, `x-litellm-response-cost: 0.0001356`, usage `prompt_tokens: 91, completion_tokens: 11`: that is 91 x 1.2e-6 + 11 x 2.4e-6, the off-peak rates as before (the model answered with fewer tokens this time)
3. Round 2: `HTTP/1.1 200 OK`, `x-litellm-response-cost: 0.0001428` at 91 / 14: off-peak again

#### dashscope tiered model with an off-peak block

1. The curl with `"model":"dashscope-qwen-flash-tiered-offpeak"`
2. Round 1: `HTTP/1.1 200 OK`, `x-litellm-response-cost: 5.75e-07`, usage `prompt_tokens: 15, completion_tokens: 1`: that is 15 x 2.5e-8 + 1 x 2e-7, the off-peak rates replacing the tier
3. Round 2: `HTTP/1.1 200 OK`, `x-litellm-response-cost: 5.75e-07` at 15 / 1 again

#### dashscope tiered model without an off-peak block (regression control)

1. The curl with `"model":"dashscope-qwen-flash-tiered"`
2. Round 1: `HTTP/1.1 200 OK`, `x-litellm-response-cost: 1.15e-06`, usage `prompt_tokens: 15, completion_tokens: 1`: unchanged from the before leg
3. Round 2: `HTTP/1.1 200 OK`, `x-litellm-response-cost: 1.15e-06` at 15 / 1 again

Verdict: PASS

Observations from the run:

- deepseek-v4-pro on DashScope reports reasoning tokens; billed at the output rate on both legs, unchanged here

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Fireworks and Perplexity calculators skip off-peak the same way; tracked in LIT-6874
- Cache-creation tokens keep the standard rate; the off-peak block has no field for them, matching the generic path
- Reasoning tokens on a model that declares `output_cost_per_reasoning_token` keep that standard rate during the window, the same as the generic path; the block has no reasoning field, tracked in LIT-6887

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] b9e030ddd662cb7abb98b8fa5139efb14d57cb6c passes /live-pr-risk
  - CircleCI local_testing_part1 and local_testing_part2 at this tip are red only on bedrock/cohere.command-r-plus-v1:0, which Bedrock now answers as end of life (LIT-6876, fleet-wide, not reached by this diff)
