### PR TITLE
fix(router): pin JWT-authenticated callers by user id in deployment_affinity

### DIFF
--- a/litellm/router_utils/pre_call_checks/deployment_affinity_check.py
+++ b/litellm/router_utils/pre_call_checks/deployment_affinity_check.py
@@ -533,9 +533,9 @@ class DeploymentAffinityCheck(CustomLogger):
             return typed_healthy_deployments
 
         verbose_router_logger.debug(
-            "DeploymentAffinityCheck: api-key affinity hit -> deployment=%s user_key=%s",
+            "DeploymentAffinityCheck: caller affinity hit -> deployment=%s user_key=%s",
             model_id,
-            self._shorten_for_logs(user_key),
+            self._shorten_for_logs(self._hash_user_key(user_key)),
         )
         return [deployment]
 
@@ -626,7 +626,7 @@ class DeploymentAffinityCheck(CustomLogger):
                         deployment_model_name,
                         model_id,
                         self.ttl_seconds,
-                        self._shorten_for_logs(user_key),
+                        self._shorten_for_logs(self._hash_user_key(user_key)),
                     )
                 else:
                     verbose_router_logger.debug(

--- a/litellm/router_utils/pre_call_checks/deployment_affinity_check.py
+++ b/litellm/router_utils/pre_call_checks/deployment_affinity_check.py
@@ -82,6 +82,7 @@ class DeploymentAffinityCheck(CustomLogger):
     """
 
     CACHE_KEY_PREFIX = "deployment_affinity:v1"
+    USER_ID_AFFINITY_PREFIX: Final = "user_id:"
 
     def __init__(
         self,
@@ -254,15 +255,6 @@ class DeploymentAffinityCheck(CustomLogger):
         return f"{cls.CACHE_KEY_PREFIX}:session:{model_group}:{hashed_user_key}:{session_id}"
 
     @staticmethod
-    def _get_user_key_from_metadata_dict(metadata: dict) -> str | None:
-        # NOTE: affinity is keyed on the *API key hash* provided by the proxy (not the
-        # OpenAI `user` parameter, which is an end-user identifier).
-        user_key: Final = metadata.get("user_api_key_hash")
-        if user_key is None:
-            return None
-        return str(user_key)
-
-    @staticmethod
     def _get_session_id_from_metadata_dict(metadata: dict) -> str | None:
         session_id: Final = metadata.get("session_id")
         if session_id is None or metadata.get(SESSION_ID_GENERATED_METADATA_KEY):
@@ -285,22 +277,30 @@ class DeploymentAffinityCheck(CustomLogger):
         return metadata_dicts
 
     @staticmethod
-    def _get_user_key_from_request_kwargs(request_kwargs: dict) -> str | None:
+    def _first_metadata_value(metadata_dicts: Sequence[dict], key: str) -> str | None:
+        value: Final = next((metadata[key] for metadata in metadata_dicts if metadata.get(key) is not None), None)
+        return None if value is None else str(value)
+
+    @classmethod
+    def _get_user_key_from_request_kwargs(cls, request_kwargs: dict) -> str | None:
         """
         Extract a stable affinity key from request kwargs.
 
-        Source (proxy): `metadata.user_api_key_hash`
+        Source (proxy): `metadata.user_api_key_hash` for virtual-key callers. JWT-authenticated
+        callers carry no key hash, so their `metadata.user_api_key_user_id` stands in for it,
+        namespaced under `USER_ID_AFFINITY_PREFIX` so a user id can never alias a key hash.
 
         Note: the OpenAI `user` parameter is an end-user identifier and is intentionally
         not used for deployment affinity.
         """
-        # Check metadata dicts (Proxy usage)
-        for metadata in DeploymentAffinityCheck._iter_metadata_dicts(request_kwargs):
-            user_key = DeploymentAffinityCheck._get_user_key_from_metadata_dict(metadata=metadata)
-            if user_key is not None:
-                return user_key
-
-        return None
+        metadata_dicts: Final = cls._iter_metadata_dicts(request_kwargs)
+        user_api_key_hash: Final = cls._first_metadata_value(metadata_dicts, "user_api_key_hash")
+        if user_api_key_hash is not None:
+            return user_api_key_hash
+        user_id: Final = cls._first_metadata_value(metadata_dicts, "user_api_key_user_id")
+        if user_id is None:
+            return None
+        return f"{cls.USER_ID_AFFINITY_PREFIX}{user_id}"
 
     @staticmethod
     def _get_session_id_from_request_kwargs(request_kwargs: dict) -> str | None:

--- a/tests/test_litellm/router_utils/pre_call_checks/test_deployment_affinity_check.py
+++ b/tests/test_litellm/router_utils/pre_call_checks/test_deployment_affinity_check.py
@@ -998,3 +998,210 @@ async def test_model_group_affinity_config_overrides_global():
     )
     # All deployments returned (user-key affinity disabled for this group)
     assert len(filtered) == 2
+
+
+def _jwt_metadata(user_id: str) -> dict:
+    return {"user_api_key_hash": None, "user_api_key_user_id": user_id}
+
+
+def _two_deployments(model_group: str) -> list[dict]:
+    return [
+        {
+            "model_name": model_group,
+            "litellm_params": {"model": "openai/gpt-5.4-mini"},
+            "model_info": {"id": "openai-deployment-a"},
+        },
+        {
+            "model_name": model_group,
+            "litellm_params": {"model": "openai/gpt-5.4-mini"},
+            "model_info": {"id": "openai-deployment-b"},
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_async_jwt_user_affinity_routes_to_same_deployment():
+    """
+    JWT-authenticated proxy requests carry no `user_api_key_hash`, only `user_api_key_user_id`.
+    They must still pin to one deployment per user.
+    """
+    model_group = "gpt-5.4-mini"
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": model_group,
+                "litellm_params": {"model": "openai/gpt-5.4-mini", "api_key": "mock-api-key-a"},
+                "model_info": {"id": "openai-deployment-a"},
+            },
+            {
+                "model_name": model_group,
+                "litellm_params": {"model": "openai/gpt-5.4-mini", "api_key": "mock-api-key-b"},
+                "model_info": {"id": "openai-deployment-b"},
+            },
+        ],
+        optional_pre_call_checks=["deployment_affinity"],
+    )
+
+    choice_calls = {"count": 0}
+
+    def deterministic_choice(seq):
+        choice_calls["count"] += 1
+        if choice_calls["count"] == 1:
+            return seq[0]
+        return seq[1] if len(seq) > 1 else seq[0]
+
+    with patch(  # test-quality-ok: simple-shuffle has no injectable RNG; forcing the other pick is what proves the pin overrides the strategy
+        "litellm.router_strategy.simple_shuffle.random.choice",
+        side_effect=deterministic_choice,
+    ):
+        first_response = await router.acompletion(
+            model=model_group,
+            messages=[{"role": "user", "content": "Reply with the single word ok"}],
+            mock_response="ok",
+            metadata=_jwt_metadata("jwt-user-alice"),
+        )
+        second_response = await router.acompletion(
+            model=model_group,
+            messages=[{"role": "user", "content": "Reply with the single word ok"}],
+            mock_response="ok",
+            metadata=_jwt_metadata("jwt-user-alice"),
+        )
+
+    first_model_id = first_response._hidden_params["model_id"]
+    assert first_model_id in ("openai-deployment-a", "openai-deployment-b")
+    assert second_response._hidden_params["model_id"] == first_model_id
+
+
+@pytest.mark.asyncio
+async def test_proxy_jwt_auth_metadata_pins_per_user():
+    """
+    The metadata the proxy stamps for a JWT caller (`UserAPIKeyAuth(api_key=None, user_id=<sub>)`)
+    must claim a pin and be read back by the filter, and another JWT user must not inherit it.
+    """
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.proxy.litellm_pre_call_utils import LiteLLMProxyRequestSetup
+
+    model_group = "gpt-5.4-mini"
+    healthy_deployments = _two_deployments(model_group)
+    callback = DeploymentAffinityCheck(
+        cache=DualCache(),
+        ttl_seconds=60,
+        enable_user_key_affinity=True,
+        enable_responses_api_affinity=False,
+    )
+
+    def proxy_request(user_id: str) -> dict:
+        return LiteLLMProxyRequestSetup.add_user_api_key_auth_to_request_metadata(
+            data={"model": model_group, "messages": [{"role": "user", "content": "hi"}], "metadata": {}},
+            user_api_key_dict=UserAPIKeyAuth(api_key=None, user_id=user_id),
+            _metadata_variable_name="metadata",
+        )
+
+    alice_request = proxy_request("jwt-user-alice")
+    assert alice_request["metadata"]["user_api_key_hash"] is None
+
+    await callback.async_pre_call_deployment_hook(
+        kwargs={
+            **alice_request,
+            "metadata": {**alice_request["metadata"], "deployment_model_name": model_group},
+            "model_info": {"id": "openai-deployment-b"},
+        },
+        call_type=None,
+    )
+
+    alice_pinned = await callback.async_filter_deployments(
+        model=model_group,
+        healthy_deployments=healthy_deployments,
+        messages=None,
+        request_kwargs=alice_request,
+        parent_otel_span=None,
+    )
+    assert [deployment["model_info"]["id"] for deployment in alice_pinned] == ["openai-deployment-b"]
+
+    bob_filtered = await callback.async_filter_deployments(
+        model=model_group,
+        healthy_deployments=healthy_deployments,
+        messages=None,
+        request_kwargs=proxy_request("jwt-user-bob"),
+        parent_otel_span=None,
+    )
+    assert bob_filtered == healthy_deployments
+
+
+@pytest.mark.asyncio
+async def test_jwt_user_id_never_reads_a_virtual_key_pin():
+    """
+    A JWT user id that happens to equal a virtual key's 64-hex hash must not read that key's pin.
+    """
+    model_group = "gpt-5.4-mini"
+    healthy_deployments = _two_deployments(model_group)
+    callback = DeploymentAffinityCheck(
+        cache=DualCache(),
+        ttl_seconds=60,
+        enable_user_key_affinity=True,
+        enable_responses_api_affinity=False,
+    )
+    key_hash = "a" * 64
+
+    await callback.async_pre_call_deployment_hook(
+        kwargs={
+            "metadata": {"user_api_key_hash": key_hash, "deployment_model_name": model_group},
+            "model_info": {"id": "openai-deployment-b"},
+        },
+        call_type=None,
+    )
+
+    key_pinned = await callback.async_filter_deployments(
+        model=model_group,
+        healthy_deployments=healthy_deployments,
+        messages=None,
+        request_kwargs={"metadata": {"user_api_key_hash": key_hash}},
+        parent_otel_span=None,
+    )
+    assert [deployment["model_info"]["id"] for deployment in key_pinned] == ["openai-deployment-b"]
+
+    lookalike_jwt_user = await callback.async_filter_deployments(
+        model=model_group,
+        healthy_deployments=healthy_deployments,
+        messages=None,
+        request_kwargs={"metadata": _jwt_metadata(key_hash)},
+        parent_otel_span=None,
+    )
+    assert lookalike_jwt_user == healthy_deployments
+
+
+@pytest.mark.asyncio
+async def test_virtual_key_hash_wins_over_user_id_for_affinity():
+    """
+    A virtual-key caller with a user id pins on the key hash, so two keys owned by one user
+    keep independent pins.
+    """
+    model_group = "gpt-5.4-mini"
+    healthy_deployments = _two_deployments(model_group)
+    callback = DeploymentAffinityCheck(
+        cache=DualCache(),
+        ttl_seconds=60,
+        enable_user_key_affinity=True,
+        enable_responses_api_affinity=False,
+    )
+
+    await callback.async_pre_call_deployment_hook(
+        kwargs={
+            "metadata": {
+                "user_api_key_hash": "key-one",
+                "user_api_key_user_id": "shared-user",
+                "deployment_model_name": model_group,
+            },
+            "model_info": {"id": "openai-deployment-b"},
+        },
+        call_type=None,
+    )
+
+    other_key_same_user = await callback.async_filter_deployments(
+        model=model_group,
+        healthy_deployments=healthy_deployments,
+        messages=None,
+        request_kwargs={"metadata": {"user_api_key_hash": "key-two", "user_api_key_user_id": "shared-user"}},
+        parent_otel_span=None,
+    )
+    assert other_key_same_user == healthy_deployments

--- a/tests/test_litellm/router_utils/pre_call_checks/test_deployment_affinity_check.py
+++ b/tests/test_litellm/router_utils/pre_call_checks/test_deployment_affinity_check.py
@@ -1,10 +1,11 @@
 import asyncio
+import itertools
+import json
+from collections.abc import Sequence
+from typing import Final
 from unittest.mock import AsyncMock, patch
 
 import pytest
-
-
-import json
 
 import litellm
 from litellm.caching.dual_cache import DualCache
@@ -102,11 +103,10 @@ async def test_async_user_key_affinity_routes_to_same_deployment():
 
     # Deterministic routing: first selection uses seq[0], second selection attempts seq[1]
     # unless the list has been filtered to length=1 by deployment affinity.
-    choice_calls = {"count": 0}
+    choice_calls: Final = itertools.count(1)
 
-    def deterministic_choice(seq):
-        choice_calls["count"] += 1
-        if choice_calls["count"] == 1:
+    def deterministic_choice(seq: Sequence[dict[str, object]]) -> dict[str, object]:
+        if next(choice_calls) == 1:
             return seq[0]
         return seq[1] if len(seq) > 1 else seq[0]
 
@@ -1000,7 +1000,7 @@ async def test_model_group_affinity_config_overrides_global():
     assert len(filtered) == 2
 
 
-def _jwt_metadata(user_id: str) -> dict:
+def _jwt_metadata(user_id: str) -> dict[str, str | None]:
     return {"user_api_key_hash": None, "user_api_key_user_id": user_id}
 
 
@@ -1090,7 +1090,7 @@ async def test_proxy_jwt_auth_metadata_pins_per_user():
         enable_responses_api_affinity=False,
     )
 
-    def proxy_request(user_id: str) -> dict:
+    def proxy_request(user_id: str) -> dict[str, object]:
         return LiteLLMProxyRequestSetup.add_user_api_key_auth_to_request_metadata(
             data={"model": model_group, "messages": [{"role": "user", "content": "hi"}], "metadata": {}},
             user_api_key_dict=UserAPIKeyAuth(api_key=None, user_id=user_id),
@@ -1098,12 +1098,14 @@ async def test_proxy_jwt_auth_metadata_pins_per_user():
         )
 
     alice_request = proxy_request("jwt-user-alice")
-    assert alice_request["metadata"]["user_api_key_hash"] is None
+    alice_metadata = alice_request["metadata"]
+    assert isinstance(alice_metadata, dict)
+    assert alice_metadata["user_api_key_hash"] is None
 
     await callback.async_pre_call_deployment_hook(
         kwargs={
             **alice_request,
-            "metadata": {**alice_request["metadata"], "deployment_model_name": model_group},
+            "metadata": {**alice_metadata, "deployment_model_name": model_group},
             "model_info": {"id": "openai-deployment-b"},
         },
         call_type=None,


### PR DESCRIPTION
## TLDR

Problem this solves:

- JWT-authenticated requests carry no key hash, so `deployment_affinity` never pinned them
- Every call from one JWT user bounced between deployments while virtual keys pinned fine

How it solves it:

- The affinity key falls back to the caller's user id when there is no key hash
- User-id pins live in their own namespace, so they can never read a key's pin
- Affinity log lines show the hashed pin key, so JWT callers stay distinguishable

## User Flow

Before: a developer whose app authenticates with a JWT from their IdP lands on a different deployment on almost every call, so deployment affinity does nothing for them

1. The proxy admin lists two deployments under one model group with `model_group_affinity_config: {gpt-5.4-mini: ["deployment_affinity"]}` and turns on JWT auth (`enable_jwt_auth: true`, `litellm_jwtauth.user_id_jwt_field: sub`)
2. The developer sends POST https://litellm-domain/v1/chat/completions with `Authorization: Bearer <their JWT>` and `{"model": "gpt-5.4-mini", "messages": [...]}`
3. 200 comes back with `x-litellm-model-id: openai-deployment-a`
4. They repeat the same call seven more times with the same JWT and the header reads a, b, a, a, a, b, a, a
5. A teammate who calls with a virtual key (`sk-...`) instead repeats the same eight calls and gets `openai-deployment-b` every time

After: the same JWT caller sticks to one deployment for the affinity TTL, exactly like a virtual-key caller does

1. The proxy admin lists two deployments under one model group with `model_group_affinity_config: {gpt-5.4-mini: ["deployment_affinity"]}` and turns on JWT auth (`enable_jwt_auth: true`, `litellm_jwtauth.user_id_jwt_field: sub`)
2. The developer sends POST https://litellm-domain/v1/chat/completions with `Authorization: Bearer <their JWT>` and `{"model": "gpt-5.4-mini", "messages": [...]}`
3. 200 comes back with `x-litellm-model-id: openai-deployment-a`
4. They repeat the same call seven more times with the same JWT and every response reads `openai-deployment-a`
5. A teammate who calls with a virtual key (`sk-...`) instead repeats the same eight calls and still gets one deployment every time, and a second JWT user (different `sub`) gets their own independent pin
6. A JWT whose user id happens to equal some virtual key's hash never inherits that key's pin

## Relevant issues

## Linear ticket

Resolves LIT-6867

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Topology on both sides: two proxy processes (`--port 29550 --num_workers 2` and `--port 52583 --num_workers 2`) booted from the same config, sharing one fresh Postgres database and one Redis (`router_settings.redis_host`), so a pin written through one worker has to be read back through the other three. Every loop below alternates the two ports (odd calls hit 29550, even calls 52583). All affinity pins in Redis are deleted before each side boots. Before boots the two instances with `litellm/router_utils/pre_call_checks/deployment_affinity_check.py` at the merge base 2c30fe16b0 (the only non-test file this PR changes) and After boots them at the PR tip 1b42b81f4e. Real OpenAI calls throughout.

Auth: JWT auth against a local IdP serving a JWKS at http://127.0.0.1:41425/keys with RS256 user tokens (`sub` = `jwt-user-alice`, `jwt-user-bob`, `jwt-user-carol`, `jwt-user-dave`, `jwt-user-erin`, `jwt-user-frank`; `iss=lit6867-local-idp`), env `JWT_PUBLIC_KEY_URL=http://127.0.0.1:41425/keys` and `JWT_ISSUER=lit6867-local-idp`, plus one virtual key generated from the master key as the control.

Config (`database_connection_pool_limit: 1` only because the QA box's Postgres is shared):

```yaml
model_list:
  - model_name: gpt-5.4-mini
    litellm_params:
      model: openai/gpt-5.4-mini
      api_key: os.environ/OPENAI_API_KEY
    model_info:
      id: openai-deployment-a
  - model_name: gpt-5.4-mini
    litellm_params:
      model: openai/gpt-5.4-mini
      api_key: os.environ/OPENAI_API_KEY
    model_info:
      id: openai-deployment-b

  - model_name: gpt-5.4-mini-noaff
    litellm_params:
      model: openai/gpt-5.4-mini
      api_key: os.environ/OPENAI_API_KEY
    model_info:
      id: openai-noaff-deployment-a
  - model_name: gpt-5.4-mini-noaff
    litellm_params:
      model: openai/gpt-5.4-mini
      api_key: os.environ/OPENAI_API_KEY
    model_info:
      id: openai-noaff-deployment-b

  - model_name: gpt-5.4-mini-sess
    litellm_params:
      model: openai/gpt-5.4-mini
      api_key: os.environ/OPENAI_API_KEY
    model_info:
      id: openai-sess-deployment-a
  - model_name: gpt-5.4-mini-sess
    litellm_params:
      model: openai/gpt-5.4-mini
      api_key: os.environ/OPENAI_API_KEY
    model_info:
      id: openai-sess-deployment-b

router_settings:
  redis_host: 127.0.0.1
  redis_port: 6379
  routing_strategy: simple-shuffle
  model_group_affinity_config:
    gpt-5.4-mini: ["deployment_affinity"]
    gpt-5.4-mini-sess: ["deployment_affinity", "session_affinity"]

general_settings:
  database_connection_pool_limit: 1
  enable_jwt_auth: true
  litellm_jwtauth:
    user_id_jwt_field: sub
    user_id_upsert: true
```

The loop, run once per endpoint with the matching body; only `TOKEN`, `ENDPOINT`, and `BODY` change between cases:

```sh
for i in $(seq 1 8); do
  PORT=$(( i % 2 == 1 ? 29550 : 52583 ))
  curl -s -D - -o /dev/null "http://127.0.0.1:$PORT$ENDPOINT" \
    -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' -d "$BODY" \
    | grep -i '^HTTP/\|^x-litellm-model-id:'
done
```

```
/v1/chat/completions  {"model":"gpt-5.4-mini","messages":[{"role":"user","content":"Reply with the single word ok"}],"max_tokens":16}
/v1/responses         {"model":"gpt-5.4-mini","input":"Reply with the single word ok","max_output_tokens":16}
/v1/messages          {"model":"gpt-5.4-mini","max_tokens":16,"messages":[{"role":"user","content":"Reply with the single word ok"}]}
```

Each observed line below folds the 8 (or 4) responses of one loop into one row: the HTTP status of every call in order, then the `x-litellm-model-id` header of every call in order with the `openai-deployment-` / `openai-noaff-deployment-` / `openai-sess-deployment-` prefix dropped, so `a b a a` means the first call landed on deployment a, the second on b, and so on.

### Before (2c30fe16b0)

#### JWT user alice, 8 calls per endpoint

1. `TOKEN=<alice JWT>`, then the loop once per endpoint
2. Observed:

```
alice /v1/chat/completions (ports 29550,52583 alternating): HTTP 200 200 200 200 200 200 200 200, x-litellm-model-id = a b a a a b a a
alice /v1/responses (ports 29550,52583 alternating): HTTP 200 200 200 200 200 200 200 200, x-litellm-model-id = b a b a a a b b
alice /v1/messages (ports 29550,52583 alternating): HTTP 200 200 200 200 200 200 200 200, x-litellm-model-id = b a b b b a a a
```

#### JWT user bob, 8 calls per endpoint

1. `TOKEN=<bob JWT>`, then the loop once per endpoint
2. Observed:

```
bob /v1/chat/completions (ports 29550,52583 alternating): HTTP 200 200 200 200 200 200 200 200, x-litellm-model-id = a b a a a b b a
bob /v1/responses (ports 29550,52583 alternating): HTTP 200 200 200 200 200 200 200 200, x-litellm-model-id = b b a b a a b a
bob /v1/messages (ports 29550,52583 alternating): HTTP 200 200 200 200 200 200 200 200, x-litellm-model-id = b a a b a b a b
```

#### Virtual key control, 8 calls per endpoint

1. `TOKEN=<sk-... virtual key>`, then the loop once per endpoint
2. Observed:

```
key /v1/chat/completions (ports 29550,52583 alternating): HTTP 200 200 200 200 200 200 200 200, x-litellm-model-id = b b b b b b b b
key /v1/responses (ports 29550,52583 alternating): HTTP 200 200 200 200 200 200 200 200, x-litellm-model-id = b b b b b b b b
key /v1/messages (ports 29550,52583 alternating): HTTP 200 200 200 200 200 200 200 200, x-litellm-model-id = b b b b b b b b
```

#### Model group without deployment_affinity, 8 chat calls

1. `TOKEN=<alice JWT>`, the chat loop with `"model":"gpt-5.4-mini-noaff"`
2. Observed:

```
alice model=gpt-5.4-mini-noaff (ports 29550,52583 alternating): HTTP 200 200 200 200 200 200 200 200, x-litellm-model-id = a b a b b a b b
```

#### Session affinity, four JWT users sharing one session id, 4 chat calls each

1. For each of the alice, bob, carol, and dave JWTs: the chat loop with `"model":"gpt-5.4-mini-sess"`, `-H 'x-litellm-session-id: lit6867-shared-session'`, and `seq 1 4`
2. Observed:

```
alice model=gpt-5.4-mini-sess x-litellm-session-id=lit6867-shared-session (ports 29550,52583 alternating): HTTP 200 200 200 200, x-litellm-model-id = b b b b
bob model=gpt-5.4-mini-sess x-litellm-session-id=lit6867-shared-session (ports 29550,52583 alternating): HTTP 200 200 200 200, x-litellm-model-id = b b b b
carol model=gpt-5.4-mini-sess x-litellm-session-id=lit6867-shared-session (ports 29550,52583 alternating): HTTP 200 200 200 200, x-litellm-model-id = b b b b
dave model=gpt-5.4-mini-sess x-litellm-session-id=lit6867-shared-session (ports 29550,52583 alternating): HTTP 200 200 200 200, x-litellm-model-id = b b b b
```

3. All four users share one pin on the session id, so bob, carol, and dave inherit whatever alice's first call chose

#### Four more JWT users on their first request, 4 chat calls each

1. For each of the carol, dave, erin, and frank JWTs (never seen by the proxy before this step): the chat loop with `seq 1 4`
2. Observed:

```
carol /v1/chat/completions (ports 29550,52583 alternating): HTTP 200 200 200 200, x-litellm-model-id = b b a b
dave /v1/chat/completions (ports 29550,52583 alternating): HTTP 200 200 200 200, x-litellm-model-id = b a b a
erin /v1/chat/completions (ports 29550,52583 alternating): HTTP 200 200 200 200, x-litellm-model-id = a b b b
frank /v1/chat/completions (ports 29550,52583 alternating): HTTP 200 200 200 200, x-litellm-model-id = a b a a
```

### After (1b42b81f4e)

Commit 9c7c7a05ac landed after this run; it only types the unit test helpers, so it cannot change proxy behavior and the proof above stands at 1b42b81f4e

#### JWT user alice, 8 calls per endpoint

1. `TOKEN=<alice JWT>`, then the loop once per endpoint
2. Observed:

```
alice /v1/chat/completions (ports 29550,52583 alternating): HTTP 200 200 200 200 200 200 200 200, x-litellm-model-id = a a a a a a a a
alice /v1/responses (ports 29550,52583 alternating): HTTP 200 200 200 200 200 200 200 200, x-litellm-model-id = a a a a a a a a
alice /v1/messages (ports 29550,52583 alternating): HTTP 200 200 200 200 200 200 200 200, x-litellm-model-id = a a a a a a a a
```

#### JWT user bob, 8 calls per endpoint

1. `TOKEN=<bob JWT>`, then the loop once per endpoint
2. Observed:

```
bob /v1/chat/completions (ports 29550,52583 alternating): HTTP 200 200 200 200 200 200 200 200, x-litellm-model-id = b b b b b b b b
bob /v1/responses (ports 29550,52583 alternating): HTTP 200 200 200 200 200 200 200 200, x-litellm-model-id = b b b b b b b b
bob /v1/messages (ports 29550,52583 alternating): HTTP 200 200 200 200 200 200 200 200, x-litellm-model-id = b b b b b b b b
```

#### Virtual key control, 8 calls per endpoint

1. `TOKEN=<sk-... virtual key>`, then the loop once per endpoint
2. Observed:

```
key /v1/chat/completions (ports 29550,52583 alternating): HTTP 200 200 200 200 200 200 200 200, x-litellm-model-id = b b b b b b b b
key /v1/responses (ports 29550,52583 alternating): HTTP 200 200 200 200 200 200 200 200, x-litellm-model-id = b b b b b b b b
key /v1/messages (ports 29550,52583 alternating): HTTP 200 200 200 200 200 200 200 200, x-litellm-model-id = b b b b b b b b
```

#### Model group without deployment_affinity, 8 chat calls

1. `TOKEN=<alice JWT>`, the chat loop with `"model":"gpt-5.4-mini-noaff"`
2. Observed:

```
alice model=gpt-5.4-mini-noaff (ports 29550,52583 alternating): HTTP 200 200 200 200 200 200 200 200, x-litellm-model-id = b a a a a b a a
```

#### Session affinity, four JWT users sharing one session id, 4 chat calls each

1. For each of the alice, bob, carol, and dave JWTs: the chat loop with `"model":"gpt-5.4-mini-sess"`, `-H 'x-litellm-session-id: lit6867-shared-session'`, and `seq 1 4`
2. Observed:

```
alice model=gpt-5.4-mini-sess x-litellm-session-id=lit6867-shared-session (ports 29550,52583 alternating): HTTP 200 200 200 200, x-litellm-model-id = b b b b
bob model=gpt-5.4-mini-sess x-litellm-session-id=lit6867-shared-session (ports 29550,52583 alternating): HTTP 200 200 200 200, x-litellm-model-id = a a a a
carol model=gpt-5.4-mini-sess x-litellm-session-id=lit6867-shared-session (ports 29550,52583 alternating): HTTP 200 200 200 200, x-litellm-model-id = b b b b
dave model=gpt-5.4-mini-sess x-litellm-session-id=lit6867-shared-session (ports 29550,52583 alternating): HTTP 200 200 200 200, x-litellm-model-id = b b b b
```

3. Each user now has their own pin on the same session id: bob landed on a while alice, carol, and dave landed on b, so one JWT user can no longer steer or read another user's session pin

#### Four more JWT users on their first request, 4 chat calls each

1. For each of the carol, dave, erin, and frank JWTs (never seen by the proxy before this step): the chat loop with `seq 1 4`
2. Observed:

```
carol /v1/chat/completions (ports 29550,52583 alternating): HTTP 200 200 200 200, x-litellm-model-id = a a a a
dave /v1/chat/completions (ports 29550,52583 alternating): HTTP 200 200 200 200, x-litellm-model-id = a a a a
erin /v1/chat/completions (ports 29550,52583 alternating): HTTP 200 200 200 200, x-litellm-model-id = a a a a
frank /v1/chat/completions (ports 29550,52583 alternating): HTTP 200 200 200 200, x-litellm-model-id = a a a a
```

### Observations from the run

- JWT session pins move from one shared bucket to per-user buckets; this PR causes it, intended
- Deleting a pin in Redis leaves each worker's in-memory copy; pre-existing, untouched here
- The complexity router still keys JWT session pins as unscoped; pre-existing, untouched here

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Session affinity pins for JWT callers move from the shared "unscoped" bucket to a per-user one, so an in-flight JWT session re-pins once after upgrade
- A JWT that resolves to a team but no user id is still not pinned, since nothing on the request identifies the caller
- CircleCI local_testing reds are the retired Bedrock Cohere model (LIT-6876), red on staging too
- [x] 1b42b81f4e passes /live-pr-risk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes router routing pins for JWT auth and session affinity keying; behavior is covered by new tests but upgrades can re-pin in-flight JWT sessions once.
> 
> **Overview**
> **Deployment affinity** now pins **JWT-authenticated proxy callers** who lack `user_api_key_hash`, using `metadata.user_api_key_user_id` as the affinity key with a `user_id:` prefix so it cannot collide with virtual-key hashes. Virtual keys still win when both hash and user id are present; session affinity for JWT users inherits the same caller key (per-user session buckets instead of shared `unscoped`).
> 
> Refactors affinity metadata extraction via `_first_metadata_value` and tightens debug logs to show **hashed** pin keys (“caller affinity” wording).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c7c7a05ac92aebf1694ba087501f4b7c0c1416d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->