### PR TITLE
fix(logging): blocked requests no longer report guardrail_status=success in multi-guardrail configs

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -5865,9 +5865,7 @@ def _get_status_fields(
         "guardrail_failed_to_respond",
         "guardrail_intervened",
     )
-    entries: Final[Sequence[object]] = (
-        guardrail_information if isinstance(guardrail_information, list) else ()
-    )
+    entries: Final[Sequence[object]] = guardrail_information if isinstance(guardrail_information, list) else ()
     guardrail_status: Final[GuardrailStatus] = max(
         (
             GUARDRAIL_STATUS_MAP.get(entry.get("guardrail_status", "not_run"), "not_run")

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -5854,14 +5854,24 @@ def _get_status_fields(
     #########################################################
     # Map - guardrail_information.guardrail_status to guardrail_status
     #########################################################
+    # Aggregate across ALL guardrail entries by severity, not first-wins: a
+    # pre_call guardrail that passed (e.g. a mask) records its entry before a
+    # later guardrail's block, and taking the first non-"not_run" entry would
+    # report a blocked request as "success".
+    GUARDRAIL_STATUS_PRECEDENCE: Final[dict[GuardrailStatus, int]] = {
+        "guardrail_intervened": 3,
+        "guardrail_failed_to_respond": 2,
+        "success": 1,
+        "not_run": 0,
+    }
     guardrail_status: GuardrailStatus = "not_run"
     if guardrail_information and isinstance(guardrail_information, list):
         for information in guardrail_information:
             if isinstance(information, dict):
                 raw_status = information.get("guardrail_status", "not_run")
-                if raw_status != "not_run":
-                    guardrail_status = GUARDRAIL_STATUS_MAP.get(raw_status, "not_run")
-                    break
+                mapped_status = GUARDRAIL_STATUS_MAP.get(raw_status, "not_run")
+                if GUARDRAIL_STATUS_PRECEDENCE[mapped_status] > GUARDRAIL_STATUS_PRECEDENCE[guardrail_status]:
+                    guardrail_status = mapped_status
 
     return StandardLoggingPayloadStatusFields(llm_api_status=llm_api_status, guardrail_status=guardrail_status)
 

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 import time
 import traceback
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from datetime import datetime as dt_object
 from functools import lru_cache
 from types import MappingProxyType, TracebackType
@@ -5866,12 +5866,13 @@ def _get_status_fields(
         "guardrail_intervened",
     )
     entries: Final[Sequence[object]] = guardrail_information if isinstance(guardrail_information, list) else ()
+    raw_statuses: Final[Iterator[object]] = (
+        entry.get("guardrail_status", "not_run") for entry in entries if isinstance(entry, dict)
+    )
+    # A guardrail is free to write any value here, and an unhashable one would
+    # raise TypeError on the mapping lookup and drop the whole payload.
     guardrail_status: Final[GuardrailStatus] = max(
-        (
-            GUARDRAIL_STATUS_MAP.get(entry.get("guardrail_status", "not_run"), "not_run")
-            for entry in entries
-            if isinstance(entry, dict)
-        ),
+        (GUARDRAIL_STATUS_MAP.get(raw_status, "not_run") for raw_status in raw_statuses if isinstance(raw_status, str)),
         key=GUARDRAIL_STATUS_SEVERITY.index,
         default="not_run",
     )

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -5854,24 +5854,29 @@ def _get_status_fields(
     #########################################################
     # Map - guardrail_information.guardrail_status to guardrail_status
     #########################################################
-    # Aggregate across ALL guardrail entries by severity, not first-wins: a
+    # Severity order, least severe first. The status aggregates across ALL
+    # guardrail entries rather than taking the first non-"not_run" one: a
     # pre_call guardrail that passed (e.g. a mask) records its entry before a
-    # later guardrail's block, and taking the first non-"not_run" entry would
-    # report a blocked request as "success".
-    GUARDRAIL_STATUS_PRECEDENCE: Final[dict[GuardrailStatus, int]] = {
-        "guardrail_intervened": 3,
-        "guardrail_failed_to_respond": 2,
-        "success": 1,
-        "not_run": 0,
-    }
-    guardrail_status: GuardrailStatus = "not_run"
-    if guardrail_information and isinstance(guardrail_information, list):
-        for information in guardrail_information:
-            if isinstance(information, dict):
-                raw_status = information.get("guardrail_status", "not_run")
-                mapped_status = GUARDRAIL_STATUS_MAP.get(raw_status, "not_run")
-                if GUARDRAIL_STATUS_PRECEDENCE[mapped_status] > GUARDRAIL_STATUS_PRECEDENCE[guardrail_status]:
-                    guardrail_status = mapped_status
+    # later guardrail's block, and first-wins would report a blocked request
+    # as "success".
+    GUARDRAIL_STATUS_SEVERITY: Final[tuple[GuardrailStatus, ...]] = (
+        "not_run",
+        "success",
+        "guardrail_failed_to_respond",
+        "guardrail_intervened",
+    )
+    entries: Final[Sequence[object]] = (
+        guardrail_information if isinstance(guardrail_information, list) else ()
+    )
+    guardrail_status: Final[GuardrailStatus] = max(
+        (
+            GUARDRAIL_STATUS_MAP.get(entry.get("guardrail_status", "not_run"), "not_run")
+            for entry in entries
+            if isinstance(entry, dict)
+        ),
+        key=GUARDRAIL_STATUS_SEVERITY.index,
+        default="not_run",
+    )
 
     return StandardLoggingPayloadStatusFields(llm_api_status=llm_api_status, guardrail_status=guardrail_status)
 

--- a/tests/guardrails_tests/test_tracing_guardrails.py
+++ b/tests/guardrails_tests/test_tracing_guardrails.py
@@ -865,6 +865,15 @@ def test_guardrail_status_fields_computation():
             "guardrail_intervened",
             id="unknown_status_does_not_mask_blocker",
         ),
+        pytest.param(
+            "failure",
+            [
+                {"guardrail_status": {"unhashable": True}},
+                {"guardrail_status": "guardrail_intervened"},
+            ],
+            "guardrail_intervened",
+            id="unhashable_status_is_skipped",
+        ),
     ],
 )
 def test_guardrail_status_fields_severity_across_entries(

--- a/tests/guardrails_tests/test_tracing_guardrails.py
+++ b/tests/guardrails_tests/test_tracing_guardrails.py
@@ -808,7 +808,68 @@ def test_guardrail_status_fields_computation():
     assert status_fields_no_guardrail.get("guardrail_status") == "not_run"
 
 
-def test_guardrail_status_fields_severity_across_entries():
+@pytest.mark.parametrize(
+    "status, guardrail_information, expected_guardrail_status",
+    [
+        pytest.param(
+            "failure",
+            [
+                {"guardrail_status": "success"},
+                {"guardrail_status": "guardrail_intervened"},
+            ],
+            "guardrail_intervened",
+            id="pre_call_success_before_blocker",
+        ),
+        pytest.param(
+            "failure",
+            [
+                {"guardrail_status": "guardrail_intervened"},
+                {"guardrail_status": "success"},
+            ],
+            "guardrail_intervened",
+            id="blocker_before_success",
+        ),
+        pytest.param(
+            "failure",
+            [
+                {"guardrail_status": "success"},
+                {"guardrail_status": "guardrail_failed_to_respond"},
+            ],
+            "guardrail_failed_to_respond",
+            id="failure_outranks_success",
+        ),
+        pytest.param(
+            "failure",
+            [
+                {"guardrail_status": "guardrail_failed_to_respond"},
+                {"guardrail_status": "guardrail_intervened"},
+            ],
+            "guardrail_intervened",
+            id="intervention_outranks_failure",
+        ),
+        pytest.param(
+            "success",
+            [
+                {"guardrail_status": "success"},
+                {"guardrail_status": "success"},
+            ],
+            "success",
+            id="all_success_stays_success",
+        ),
+        pytest.param(
+            "failure",
+            [
+                {"guardrail_status": "some_new_status"},
+                {"guardrail_status": "blocked"},
+            ],
+            "guardrail_intervened",
+            id="unknown_status_does_not_mask_blocker",
+        ),
+    ],
+)
+def test_guardrail_status_fields_severity_across_entries(
+    status, guardrail_information, expected_guardrail_status
+):
     """
     A blocked request must never be reported as a guardrail success.
 
@@ -820,62 +881,7 @@ def test_guardrail_status_fields_severity_across_entries():
     """
     from litellm.litellm_core_utils.litellm_logging import _get_status_fields
 
-    # pre_call success recorded BEFORE the blocking guardrail's entry
-    masked_then_blocked = [
-        {"guardrail_status": "success"},
-        {"guardrail_status": "guardrail_intervened"},
-    ]
     fields = _get_status_fields(
-        status="failure", guardrail_information=masked_then_blocked, error_str=None
+        status=status, guardrail_information=guardrail_information, error_str=None
     )
-    assert fields.get("guardrail_status") == "guardrail_intervened"
-
-    # order-independence: blocker first, success second
-    blocked_then_success = [
-        {"guardrail_status": "guardrail_intervened"},
-        {"guardrail_status": "success"},
-    ]
-    fields = _get_status_fields(
-        status="failure", guardrail_information=blocked_then_success, error_str=None
-    )
-    assert fields.get("guardrail_status") == "guardrail_intervened"
-
-    # a guardrail failure outranks a sibling's success
-    success_then_failure = [
-        {"guardrail_status": "success"},
-        {"guardrail_status": "guardrail_failed_to_respond"},
-    ]
-    fields = _get_status_fields(
-        status="failure", guardrail_information=success_then_failure, error_str=None
-    )
-    assert fields.get("guardrail_status") == "guardrail_failed_to_respond"
-
-    # an intervention outranks a sibling's failure
-    failure_then_intervened = [
-        {"guardrail_status": "guardrail_failed_to_respond"},
-        {"guardrail_status": "guardrail_intervened"},
-    ]
-    fields = _get_status_fields(
-        status="failure", guardrail_information=failure_then_intervened, error_str=None
-    )
-    assert fields.get("guardrail_status") == "guardrail_intervened"
-
-    # all-success stays success
-    all_success = [
-        {"guardrail_status": "success"},
-        {"guardrail_status": "success"},
-    ]
-    fields = _get_status_fields(
-        status="success", guardrail_information=all_success, error_str=None
-    )
-    assert fields.get("guardrail_status") == "success"
-
-    # an unknown status is ignored rather than masking a later entry
-    unknown_then_blocked = [
-        {"guardrail_status": "some_new_status"},
-        {"guardrail_status": "blocked"},
-    ]
-    fields = _get_status_fields(
-        status="failure", guardrail_information=unknown_then_blocked, error_str=None
-    )
-    assert fields.get("guardrail_status") == "guardrail_intervened"
+    assert fields.get("guardrail_status") == expected_guardrail_status

--- a/tests/guardrails_tests/test_tracing_guardrails.py
+++ b/tests/guardrails_tests/test_tracing_guardrails.py
@@ -806,3 +806,76 @@ def test_guardrail_status_fields_computation():
     )
     assert status_fields_no_guardrail.get("llm_api_status") == "success"
     assert status_fields_no_guardrail.get("guardrail_status") == "not_run"
+
+
+def test_guardrail_status_fields_severity_across_entries():
+    """
+    A blocked request must never be reported as a guardrail success.
+
+    With multiple guardrails on one request (e.g. a pre_call mask that passes,
+    then a post_call guardrail that blocks), entries are recorded in execution
+    order, so the earlier "success" entry must not shadow the later
+    "guardrail_intervened" entry: the aggregate takes the most severe status,
+    regardless of entry order.
+    """
+    from litellm.litellm_core_utils.litellm_logging import _get_status_fields
+
+    # pre_call success recorded BEFORE the blocking guardrail's entry
+    masked_then_blocked = [
+        {"guardrail_status": "success"},
+        {"guardrail_status": "guardrail_intervened"},
+    ]
+    fields = _get_status_fields(
+        status="failure", guardrail_information=masked_then_blocked, error_str=None
+    )
+    assert fields.get("guardrail_status") == "guardrail_intervened"
+
+    # order-independence: blocker first, success second
+    blocked_then_success = [
+        {"guardrail_status": "guardrail_intervened"},
+        {"guardrail_status": "success"},
+    ]
+    fields = _get_status_fields(
+        status="failure", guardrail_information=blocked_then_success, error_str=None
+    )
+    assert fields.get("guardrail_status") == "guardrail_intervened"
+
+    # a guardrail failure outranks a sibling's success
+    success_then_failure = [
+        {"guardrail_status": "success"},
+        {"guardrail_status": "guardrail_failed_to_respond"},
+    ]
+    fields = _get_status_fields(
+        status="failure", guardrail_information=success_then_failure, error_str=None
+    )
+    assert fields.get("guardrail_status") == "guardrail_failed_to_respond"
+
+    # an intervention outranks a sibling's failure
+    failure_then_intervened = [
+        {"guardrail_status": "guardrail_failed_to_respond"},
+        {"guardrail_status": "guardrail_intervened"},
+    ]
+    fields = _get_status_fields(
+        status="failure", guardrail_information=failure_then_intervened, error_str=None
+    )
+    assert fields.get("guardrail_status") == "guardrail_intervened"
+
+    # all-success stays success
+    all_success = [
+        {"guardrail_status": "success"},
+        {"guardrail_status": "success"},
+    ]
+    fields = _get_status_fields(
+        status="success", guardrail_information=all_success, error_str=None
+    )
+    assert fields.get("guardrail_status") == "success"
+
+    # an unknown status is ignored rather than masking a later entry
+    unknown_then_blocked = [
+        {"guardrail_status": "some_new_status"},
+        {"guardrail_status": "blocked"},
+    ]
+    fields = _get_status_fields(
+        status="failure", guardrail_information=unknown_then_blocked, error_str=None
+    )
+    assert fields.get("guardrail_status") == "guardrail_intervened"


### PR DESCRIPTION
## TLDR

Problem this solves:

- With multiple guardrails on one request, a blocked request could be logged as a guardrail success in `StandardLoggingPayload.status_fields`

How it solves it:

- `status_fields.guardrail_status` now aggregates across ALL guardrail entries by severity (`guardrail_intervened` > `guardrail_failed_to_respond` > `success` > `not_run`) instead of taking the first non-`not_run` entry

## User Flow

Before: an operator monitoring guardrail activity through an SLP consumer (DataDog, S3, GCS, OTEL, Langfuse) could miss blocked requests

1. They configure `hide-secrets` in `pre_call` and a blocking guardrail (e.g. bedrock) in `post_call`
2. A request contains a secret and content the blocker rejects
3. `hide-secrets` masks the secret and records its `success` entry first; the blocker then blocks and records `guardrail_intervened`
4. The first-wins reader reports `status_fields.guardrail_status="success"` for the blocked request

After: the same request reports `guardrail_status="guardrail_intervened"`; per-entry detail in `guardrail_information` is unchanged, and a request where every guardrail passes still reports `success`

## Relevant issues

Follow-up to #39398: the pre-call telemetry entry it added is recorded before a later blocking guardrail's entry, which exposed the first-wins aggregation in `_get_status_fields`.

## Linear ticket

Refs LIT-3548

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks currently available locally
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Live A/B on real proxies (real OpenAI `gpt-4o-mini` + real Bedrock ApplyGuardrail word-policy blocker), config `hide-secrets` `pre_call` + `bedrock` `post_call`, StandardLoggingPayload captured by a `CustomLogger` loaded through `litellm_settings.callbacks`:

### Before (base `litellm_internal_staging` @ `7d6781fe6a`)

Blocked request (`http=400`, message contains a secret plus a word the blocker rejects):

```
failure_event {'llm_api_status': 'failure', 'guardrail_status': 'success'}
  entries: [('hide-secrets', 'success'), ('bedrock-blocker', 'guardrail_intervened')]
```

The request was blocked, but `status_fields.guardrail_status` says `success`.

### After (this branch)

Same request, same config:

```
failure_event {'llm_api_status': 'failure', 'guardrail_status': 'guardrail_intervened'}
  entries: [('hide-secrets', 'success'), ('bedrock-blocker', 'guardrail_intervened')]
```

Clean request where every guardrail passes (`http=200`) is unchanged on both sides:

```
success_event {'llm_api_status': 'success', 'guardrail_status': 'success'}
  entries: [('hide-secrets', 'success'), ('bedrock-blocker', 'success')]
```

### Real destination (DataDog Logs, base vs head)

The same blocked request exported through the `datadog` callback to a real DataDog org and read back via the Logs Search API (`service:lit3548-sev-base` / `service:lit3548-sev-head`):

```
base: status_fields: {'guardrail_status': 'success',              'llm_api_status': 'failure'}
head: status_fields: {'guardrail_status': 'guardrail_intervened', 'llm_api_status': 'failure'}
      entries (both): [('hide-secrets', 'success'), ('bedrock-blocker', 'guardrail_intervened')]
```

Also driven at `--num_workers 4` on head: 8/8 blocked requests report `guardrail_intervened`.

DataDog dashboard over the same logs (`@status_fields.guardrail_status` facet, one column per proxy) — base counts the blocked request under `success`, head counts it under `guardrail_intervened` ([live dashboard](https://p.us5.datadoghq.com/sb/9b1eff10-830b-11f0-b7cb-de02bd9ba50c-b1f9624ef0e16e6c7ab3e7ece189e26e)):

![DataDog base vs head guardrail_status](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr39596/dd_sev_dash.png)

## Behavior changes

- `StandardLoggingPayload.status_fields.guardrail_status` with multiple guardrail entries now reports the most severe entry instead of the first non-`not_run` entry. Single-entry requests are unaffected (all five status values map identically). An unrecognized entry status is now skipped instead of terminating the scan with `not_run`.
- A non-string `guardrail_status` written by a custom guardrail is now skipped as well. Previously it raised `TypeError` inside payload building whenever the scan reached it, which silently dropped the entire `StandardLoggingPayload` for that request (verified live: base drops the payload when such an entry is the first non-`not_run` entry; this branch logs it).

## Type

Bug Fix

## Caveats

### Medium

- Per-entry statuses in `guardrail_information` (used by the Guardrails Monitor UI and compliance checks) are not touched by this change; only the aggregate field changes

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

ran /live-pr-risk and found no regressions/backward incompatible risks
