### PR TITLE
fix(proxy): drop anthropic-beta on the Vertex passthrough count-tokens route

### DIFF
--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -1730,6 +1730,16 @@ def get_vertex_ai_allowed_incoming_headers(request: Request) -> dict:
     return headers
 
 
+def _is_vertex_anthropic_count_tokens_route(endpoint: str) -> bool:
+    return endpoint.rsplit("/", 1)[-1].split(":", 1)[0] == "count-tokens"
+
+
+def _upstream_headers_for_vertex_route(endpoint: str, headers: Mapping[str, str]) -> Mapping[str, str]:
+    if not _is_vertex_anthropic_count_tokens_route(endpoint):
+        return headers
+    return MappingProxyType({name: value for name, value in headers.items() if name.lower() != "anthropic-beta"})
+
+
 def get_vertex_pass_through_handler(
     call_type: Literal["discovery", "aiplatform"],  # noqa: UP037  # ruff reports quoted Literal values here
 ) -> BaseVertexAIPassThroughHandler:
@@ -2128,7 +2138,7 @@ async def _base_vertex_proxy_route(
     endpoint_func: Final = create_pass_through_route(
         endpoint=endpoint,
         target=target,
-        custom_headers=headers,
+        custom_headers=_upstream_headers_for_vertex_route(endpoint, headers),
         is_streaming_request=is_streaming_request,
     )  # dynamically construct pass-through endpoint based on incoming path
 

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_vertex_passthrough_load_balancing.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_vertex_passthrough_load_balancing.py
@@ -5,6 +5,7 @@ import pytest
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
     _base_vertex_proxy_route,
+    _upstream_headers_for_vertex_route,
 )
 from litellm.types.router import DeploymentTypedDict
 
@@ -346,6 +347,93 @@ async def test_vertex_passthrough_forwards_anthropic_beta_header():
 
         # Verify that headers_passed_through is False (since we have credentials)
         assert headers_passed_through is False
+
+
+VERTEX_ANTHROPIC_MODELS_PREFIX = "v1/projects/test-project/locations/global/publishers/anthropic/models/"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("model_segment", "expects_anthropic_beta"),
+    [
+        ("count-tokens:rawPredict", False),
+        ("claude-sonnet-4-6:streamRawPredict", True),
+    ],
+)
+async def test_vertex_passthrough_drops_anthropic_beta_only_on_count_tokens(
+    model_segment: str, expects_anthropic_beta: bool
+):
+    with (
+        patch(  # test-quality-ok: the route reads this proxy global at call time, nothing injects it
+            "litellm.proxy.proxy_server.llm_router", None
+        ),
+        patch(  # test-quality-ok: the route reads this proxy global at call time, nothing injects it
+            "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.passthrough_endpoint_router"
+        ) as mock_pt_router,
+        patch(  # test-quality-ok: the route offers no injection point for its header preparation
+            "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints._prepare_vertex_auth_headers",
+            new_callable=AsyncMock,
+        ) as mock_prep_headers,
+        patch(  # test-quality-ok: the upstream call is captured here, the route offers no injection point
+            "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.create_pass_through_route"
+        ) as mock_create_route,
+        patch(  # test-quality-ok: the route calls auth directly rather than through Depends
+            "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.user_api_key_auth",
+            new_callable=AsyncMock,
+        ) as mock_auth,
+        patch(  # test-quality-ok: the route reads the request body for this, a MagicMock request has none
+            "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.is_streaming_request_fn",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+    ):
+        mock_pt_router.get_vertex_credentials.return_value = MagicMock()
+        mock_prep_headers.return_value = (
+            {
+                "anthropic-beta": "tool-search-tool-2025-10-19,web-search-2025-03-05",
+                "content-type": "application/json",
+                "Authorization": "Bearer vertex-access-token",
+            },
+            "https://aiplatform.googleapis.com",
+            False,
+            "test-project",
+            "global",
+        )
+        mock_create_route.return_value = AsyncMock()
+        mock_auth.return_value = UserAPIKeyAuth(api_key="sk-litellm-secret-key")
+
+        await _base_vertex_proxy_route(
+            endpoint=f"{VERTEX_ANTHROPIC_MODELS_PREFIX}{model_segment}",
+            request=MagicMock(),
+            fastapi_response=MagicMock(),
+            get_vertex_pass_through_handler=MagicMock(),
+        )
+
+        upstream_headers = mock_create_route.call_args.kwargs["custom_headers"]
+        assert ("anthropic-beta" in upstream_headers) is expects_anthropic_beta
+        assert upstream_headers["Authorization"] == "Bearer vertex-access-token"
+        assert upstream_headers["content-type"] == "application/json"
+
+
+def test_upstream_headers_for_vertex_route_filters_anthropic_beta_by_route():
+    headers = {
+        "Anthropic-Beta": "effort-2025-11-24",
+        "content-type": "application/json",
+        "Authorization": "Bearer vertex-access-token",
+    }
+
+    count_tokens_headers = _upstream_headers_for_vertex_route(
+        f"{VERTEX_ANTHROPIC_MODELS_PREFIX}count-tokens:rawPredict", headers
+    )
+    model_headers = _upstream_headers_for_vertex_route(
+        f"{VERTEX_ANTHROPIC_MODELS_PREFIX}claude-sonnet-4-6:rawPredict", headers
+    )
+
+    assert dict(count_tokens_headers) == {
+        "content-type": "application/json",
+        "Authorization": "Bearer vertex-access-token",
+    }
+    assert dict(model_headers) == headers
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## TLDR

Problem this solves:

- Vertex passthrough forwards the caller's `anthropic-beta` header on every route
- Vertex's Anthropic count-tokens route rejects beta values the model routes accept
- The reporter's count-tokens calls carry the same betas as their chat calls, so they 400 through LiteLLM
- Every large file Read in Claude Code then stalls on retries before falling back

How it solves it:

- The count-tokens route no longer gets `anthropic-beta` forwarded, on both credential branches
- Vertex count-tokens works with no beta header at all, so nothing is lost
- No value denylist, so the drifting set of rejected betas never needs tracking
- Every other Vertex route keeps forwarding the header exactly as before

## User Flow

Before: a developer running Claude Code in Vertex mode through LiteLLM asks it to read a large file, and the read stalls because the token count call fails

1. They start `claude` with `CLAUDE_CODE_USE_VERTEX=1`, `ANTHROPIC_VERTEX_BASE_URL=https://litellm-domain/vertex-ai/v1`, `ANTHROPIC_AUTH_TOKEN=<their virtual key>`, and `CLAUDE_CODE_SKIP_VERTEX_AUTH=1`
2. They ask it to read a 60 KB text file in full
3. The token count call `POST https://litellm-domain/vertex-ai/v1/projects/{project}/locations/global/publishers/anthropic/models/count-tokens:rawPredict` reaches the gateway with the file contents and `anthropic-beta: effort-2025-11-24,tool-search-tool-2025-10-19,web-search-2025-03-05`, the same header as their chat calls (their Claude Code log shows Vertex rejecting exactly those values on that call)
4. The response is `400` with `Unexpected value(s) tool-search-tool-2025-10-19, web-search-2025-03-05 for the anthropic-beta header`
5. Claude Code retries the count, so the Read sits for 40+ seconds before it gives up on counting and answers
6. Its chat calls to `POST .../publishers/anthropic/models/claude-sonnet-4-6:streamRawPredict` with the identical header keep returning `200`, so only the reads are slow

After: the same read answers right away because the token count call succeeds

1. They start `claude` with `CLAUDE_CODE_USE_VERTEX=1`, `ANTHROPIC_VERTEX_BASE_URL=https://litellm-domain/vertex-ai/v1`, `ANTHROPIC_AUTH_TOKEN=<their virtual key>`, and `CLAUDE_CODE_SKIP_VERTEX_AUTH=1`
2. They ask it to read a 60 KB text file in full
3. The same token count call `POST https://litellm-domain/vertex-ai/v1/projects/{project}/locations/global/publishers/anthropic/models/count-tokens:rawPredict` reaches the gateway with the same `anthropic-beta` header
4. The response is `200` with `{"input_tokens": 15758}`, because the gateway leaves the `anthropic-beta` header off that one upstream call
5. The Read finishes in under a second and Claude Code answers from the file
6. Its chat calls to `POST .../publishers/anthropic/models/claude-sonnet-4-6:streamRawPredict` still carry the full `anthropic-beta` header and return `200` as before

## Relevant issues

Same symptom upstream: https://github.com/anthropics/claude-code/issues/11154

## Linear ticket

Resolves LIT-6642

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Both legs ran the same four cases in the same order against a live proxy booted with 2 uvicorn workers (`--num_workers 2`), one process, no database, real Vertex AI (`claude-sonnet-4-6`, location `global`); only the proxy commit differs. `$BASE` is `http://localhost:<port>/vertex-ai/v1/projects/<project>/locations/global/publishers/anthropic/models`. Case D drives the reporter's exact client, a stock Claude Code 2.1.251 binary in Vertex mode (`CLAUDE_CODE_USE_VERTEX=1`, `CLAUDE_CODE_SKIP_VERTEX_AUTH=1`, `ANTHROPIC_VERTEX_BASE_URL=http://localhost:<port>/vertex-ai/v1`, `ANTHROPIC_AUTH_TOKEN=<virtual key>`, `ANTHROPIC_MODEL=claude-sonnet-4-6`), interactively under tmux with `--debug-file`, and shows the pane plus the client's own request log lines

### Before (4990f06accc)

1. Case A: count-tokens carrying the beta set from the reporter's log, Vertex rejects it with 400
```
$ curl -sS -w '
%{http_code}
' -X POST "$BASE/count-tokens:rawPredict" -H 'Authorization: Bearer $LITELLM_KEY' -H 'content-type: application/json' -H "anthropic-beta: effort-2025-11-24,tool-search-tool-2025-10-19,web-search-2025-03-05" -d '{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"hello"}]}'
{"type":"error","error":{"type":"invalid_request_error","message":"Unexpected value(s) `tool-search-tool-2025-10-19`, `web-search-2025-03-05` for the `anthropic-beta` header. Please consult our documentation at platform.claude.com/docs or try again without the header."},"request_id":"req_vrtx_011CegypVcagp7JYbHxTn6TQ"}
400
```
2. Case B: streamRawPredict with the same beta set, 200
```
$ curl -sS -w '
%{http_code}
' -X POST "$BASE/claude-sonnet-4-6:streamRawPredict" -H 'Authorization: Bearer $LITELLM_KEY' -H 'content-type: application/json' -H "anthropic-beta: effort-2025-11-24,tool-search-tool-2025-10-19,web-search-2025-03-05" -d '{"anthropic_version":"vertex-2023-10-16","max_tokens":16,"stream":true,"messages":[{"role":"user","content":"Say hi"}]}'
event: message_start
data: {"type":"message_start","message":{"model":"claude-sonnet-4-6","id":"msg_vrtx_011CegypXQECnmfskJfqmATF","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"
data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}     }
data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" there! "}           }
data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"👋 How"}   }
data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" are"}}
data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" you doing?"}   }
data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" Is"}   }
data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" there something"}         }
data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" I"}            }
200
```
3. Case C: streamRawPredict with a bogus beta, so the header is visibly still forwarded on model routes, 400 as expected
```
$ curl -sS -w '
%{http_code}
' -X POST "$BASE/claude-sonnet-4-6:streamRawPredict" -H 'Authorization: Bearer $LITELLM_KEY' -H 'content-type: application/json' -H 'anthropic-beta: bogus-beta-2020-01-01' -d '{"anthropic_version":"vertex-2023-10-16","max_tokens":16,"stream":true,"messages":[{"role":"user","content":"Say hi"}]}'
{"type":"error","error":{"type":"invalid_request_error","message":"Unexpected value(s) `bogus-beta-2020-01-01` for the `anthropic-beta` header. Please consult our documentation at platform.claude.com/docs or try again without the header."},"request_id":"req_vrtx_011CegypiLoEFJ5GKo4fQgTK"}
400
```
4. Case D: stock Claude Code 2.1.251 in Vertex mode, prompt `Read medium.txt in full and tell me what its last line says` on a 60 KB file, reads fine because this client does not send those betas on count-tokens (see the closing notes)
```
❯ Read medium.txt in full and tell me what its last line says
  Thought for 2s, read 1 file (ctrl+o to expand)
⏺ The last line is 00999 FINAL LINE MARKER zulu zulu zulu
✻ Churned for 7s · done 11:29 AM
```
```
2026-09-03T18:29:33.858Z [DEBUG] [API REQUEST] /vertex-ai/v1/projects/<project>/locations/global/publishers/anthropic/models/count-tokens:[REDACTED] source=count_tokens
2026-09-03T18:29:34.295Z [INFO] [Stall] tool_dispatch_end tool=Read toolUseId=toolu_vrtx_01XWBZtMPF3ca2N5Cqx2RM3H outcome=ok durationMs=448
```

### After (aaef5d219a)

1. Case A: count-tokens carrying the beta set from the reporter's log, now 200
```
$ curl -sS -w '
%{http_code}
' -X POST "$BASE/count-tokens:rawPredict" -H 'Authorization: Bearer $LITELLM_KEY' -H 'content-type: application/json' -H "anthropic-beta: effort-2025-11-24,tool-search-tool-2025-10-19,web-search-2025-03-05" -d '{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"hello"}]}'
{"input_tokens":8}
200
```
2. Case B: streamRawPredict with the same beta set, still 200
```
$ curl -sS -w '
%{http_code}
' -X POST "$BASE/claude-sonnet-4-6:streamRawPredict" -H 'Authorization: Bearer $LITELLM_KEY' -H 'content-type: application/json' -H "anthropic-beta: effort-2025-11-24,tool-search-tool-2025-10-19,web-search-2025-03-05" -d '{"anthropic_version":"vertex-2023-10-16","max_tokens":16,"stream":true,"messages":[{"role":"user","content":"Say hi"}]}'
event: message_start
data: {"type":"message_start","message":{"model":"claude-sonnet-4-6","id":"msg_vrtx_011CegyvrJwcUKfpvghVZjRh","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"
data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}              }
data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" there"}     }
data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"! "}}
data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"👋 How"}     }
data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" are"}         }
data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" you doing?"}  }
data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" Is"}              }
data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" there something"}     }
data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" I"}            }
200
```
3. Case C: streamRawPredict with a bogus beta, so the header is visibly still forwarded on model routes, still 400, so model routes keep forwarding the header
```
$ curl -sS -w '
%{http_code}
' -X POST "$BASE/claude-sonnet-4-6:streamRawPredict" -H 'Authorization: Bearer $LITELLM_KEY' -H 'content-type: application/json' -H 'anthropic-beta: bogus-beta-2020-01-01' -d '{"anthropic_version":"vertex-2023-10-16","max_tokens":16,"stream":true,"messages":[{"role":"user","content":"Say hi"}]}'
{"type":"error","error":{"type":"invalid_request_error","message":"Unexpected value(s) `bogus-beta-2020-01-01` for the `anthropic-beta` header. Please consult our documentation at platform.claude.com/docs or try again without the header."},"request_id":"req_vrtx_011Cegyw34bjnn3A7stNKiCS"}
400
```
4. Case D: stock Claude Code 2.1.251 in Vertex mode, prompt `Read medium.txt in full and tell me what its last line says` on a 60 KB file, reads fine, same as before
```
❯ Read medium.txt in full and tell me what its last line says
  Thought for 3s, read 1 file (ctrl+o to expand)
⏺ The last line is 00999 FINAL LINE MARKER zulu zulu zulu
✻ Cooked for 14s · done 11:31 AM
```
```
2026-09-03T18:31:00.281Z [DEBUG] [API REQUEST] /vertex-ai/v1/projects/<project>/locations/global/publishers/anthropic/models/count-tokens:[REDACTED] source=count_tokens
2026-09-03T18:31:00.686Z [INFO] [Stall] tool_dispatch_end tool=Read toolUseId=toolu_vrtx_01EJL75yUbDEKuUh58iZe8hc outcome=ok durationMs=421
```

Verdict: PASS. Notes from the run:

- Stock Claude Code 2.1.251 never sends those betas on count-tokens
- Case D passes on both legs; PR leaves it alone
- Reporter's count-tokens betas originate outside the stock client
- ANTHROPIC_CUSTOM_HEADERS cannot add betas to count-tokens either
- Vertex's rejected beta set drifts: effort-2025-11-24 passes today
- Credential-less branch covered by unit tests only, not live
- Tip also verified on /vertex_ai prefix and Gemini countTokens

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- A caller who needs a beta on Vertex count-tokens has no way to opt one in
  - Vertex count-tokens accepts every request with no beta header today, so nobody loses anything
- A stock Claude Code 2.1.251 already filters those betas off its own count-tokens calls, so the header in the reporter's log comes from something in front of the client
  - The fix holds for any caller that sends it, and the reporter's log shows Vertex rejecting exactly those values on that call
- The four red CircleCI jobs at this tip are pre-existing and reproduce on a rerun from failed: three Bedrock `cohere.command-r-plus-v1:0` tests (the model retired, LIT-6876), `test_timeout_streaming` and `test_router_timeout` (red on staging's own runs today), and modelHub.spec.ts `Make models public via the multi-step modal`
  - That spec's fix (#39554, LIT-6830) merged after this branch's merge base, so the branch still carries the pre-fix spec while every other pipeline this week is green on it (36/36); the merge onto staging carries the fix, so no staging merge-in here

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow, route-specific header filtering on Vertex passthrough with no auth or credential changes; only count-tokens upstream calls behave differently.
> 
> **Overview**
> Fixes **Vertex Anthropic passthrough** calls to `count-tokens:rawPredict` failing with 400 when clients send the same `anthropic-beta` header used on chat routes.
> 
> **`_base_vertex_proxy_route`** now runs prepared headers through **`_upstream_headers_for_vertex_route`** before `create_pass_through_route`. That helper detects the count-tokens segment in the endpoint path and **removes `anthropic-beta` (any casing)** from upstream headers only for that route; all other Vertex paths still forward the header unchanged.
> 
> Unit and integration-style tests cover the helper and the route wiring for count-tokens vs model predict endpoints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aaef5d219aa3ed1ba262302705df8805570a6a45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
