### PR TITLE
fix(ui): aggregate session token usage in the logs table

### DIFF
--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -173,6 +173,9 @@ class _SessionSpendRow(TypedDict):
     session_cache_hit_count: ReadOnly[int]
     session_llm_count: ReadOnly[int]
     session_agent_count: ReadOnly[int]
+    session_total_prompt_tokens: ReadOnly[int]
+    session_total_completion_tokens: ReadOnly[int]
+    session_total_tokens: ReadOnly[int]
     session_models: ReadOnly[Sequence[str]]
 
 
@@ -188,6 +191,9 @@ class _SessionSpendStats(NamedTuple):
     session_cache_hit_count: int
     session_llm_count: int
     session_agent_count: int
+    session_total_prompt_tokens: int
+    session_total_completion_tokens: int
+    session_total_tokens: int
     session_models: Sequence[str]
     session_models_truncated: bool
 
@@ -4287,8 +4293,8 @@ async def _build_ui_spend_logs_response(
     Build the paginated response for the UI spend-logs endpoint.
 
     When ``enrich_session_counts`` is ``True`` (the default for the v1/UI
-    endpoint), each row is enriched with ``session_total_count`` plus spend
-    and call-type aggregates so the frontend knows which sessions are
+    endpoint), each row is enriched with ``session_total_count`` plus spend,
+    token and call-type aggregates so the frontend knows which sessions are
     expandable (multi-call sessions).  One ``GROUP BY (session_id, api_key)``
     query serves every referenced session, keyed per api key so two callers
     reusing a session id never see each other's totals.  Rows without a
@@ -4356,7 +4362,10 @@ async def _build_ui_spend_logs_response(
                            COUNT(*) FILTER (
                                WHERE call_type NOT IN {_MCP_CALL_TYPES_SQL} AND call_type != {_AGENT_CALL_TYPE_SQL}
                            )::int AS session_llm_count,
-                           COUNT(*) FILTER (WHERE call_type = {_AGENT_CALL_TYPE_SQL})::int AS session_agent_count
+                           COUNT(*) FILTER (WHERE call_type = {_AGENT_CALL_TYPE_SQL})::int AS session_agent_count,
+                           COALESCE(SUM(prompt_tokens), 0)::bigint AS session_total_prompt_tokens,
+                           COALESCE(SUM(completion_tokens), 0)::bigint AS session_total_completion_tokens,
+                           COALESCE(SUM(total_tokens), 0)::bigint AS session_total_tokens
                     FROM "LiteLLM_SpendLogs"
                     WHERE session_id = ANY($1::text[])
                       AND api_key = ANY($2::text[])
@@ -4389,6 +4398,9 @@ async def _build_ui_spend_logs_response(
                     session_cache_hit_count=int(row.get("session_cache_hit_count") or 0),
                     session_llm_count=int(row.get("session_llm_count") or 0),
                     session_agent_count=int(row.get("session_agent_count") or 0),
+                    session_total_prompt_tokens=int(row.get("session_total_prompt_tokens") or 0),
+                    session_total_completion_tokens=int(row.get("session_total_completion_tokens") or 0),
+                    session_total_tokens=int(row.get("session_total_tokens") or 0),
                     session_models=models[:_SESSION_MODELS_LIMIT],
                     session_models_truncated=len(models) > _SESSION_MODELS_LIMIT,
                 )
@@ -4418,6 +4430,9 @@ async def _build_ui_spend_logs_response(
                 row_dict["session_cache_hit_count"] = session_stats.session_cache_hit_count
                 row_dict["session_llm_count"] = session_stats.session_llm_count
                 row_dict["session_agent_count"] = session_stats.session_agent_count
+                row_dict["session_total_prompt_tokens"] = session_stats.session_total_prompt_tokens
+                row_dict["session_total_completion_tokens"] = session_stats.session_total_completion_tokens
+                row_dict["session_total_tokens"] = session_stats.session_total_tokens
                 row_dict["session_models"] = session_stats.session_models
                 row_dict["session_models_truncated"] = session_stats.session_models_truncated
             enriched.append(row_dict)

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -4235,6 +4235,91 @@ async def test_build_ui_spend_logs_response_sums_multi_round_session_spend():
 
 
 @pytest.mark.asyncio
+async def test_build_ui_spend_logs_response_sums_multi_round_session_tokens():
+    """
+    Regression test for LIT-4929: the logs table showed the summed session cost but
+    only the last call's token usage.  Every row of a multi-round session must carry
+    the session-wide prompt, completion and total token sums from the aggregate
+    query, while rows outside a session carry none of them.
+    """
+    from litellm.proxy.spend_tracking.spend_management_endpoints import (
+        _build_ui_spend_logs_response,
+    )
+
+    session_id = "sess-multi-round-tokens"
+    api_key = "hashed-key-xyz"
+    dict_rows = [
+        {
+            "request_id": "req-1",
+            "session_id": session_id,
+            "call_type": "completion",
+            "api_key": api_key,
+            "total_tokens": 10,
+            "prompt_tokens": 7,
+            "completion_tokens": 3,
+        },
+        {
+            "request_id": "req-2",
+            "session_id": session_id,
+            "call_type": "completion",
+            "api_key": api_key,
+            "total_tokens": 50,
+            "prompt_tokens": 35,
+            "completion_tokens": 15,
+        },
+        {
+            "request_id": "req-3",
+            "session_id": None,
+            "call_type": "completion",
+            "api_key": api_key,
+            "total_tokens": 5,
+            "prompt_tokens": 4,
+            "completion_tokens": 1,
+        },
+    ]
+
+    mock_prisma = MagicMock()
+    mock_prisma.db.query_raw = AsyncMock(
+        return_value=[
+            {
+                "session_id": session_id,
+                "api_key": api_key,
+                "session_total_count": 2,
+                "session_total_spend": 0.06,
+                "mcp_tool_call_count": 0,
+                "mcp_tool_call_spend": 0.0,
+                "session_total_prompt_tokens": 42,
+                "session_total_completion_tokens": 18,
+                "session_total_tokens": 60,
+            }
+        ]
+    )
+
+    result = await _build_ui_spend_logs_response(
+        prisma_client=mock_prisma,
+        data=dict_rows,
+        total_records=3,
+        page=1,
+        page_size=50,
+        total_pages=1,
+        enrich_session_counts=True,
+    )
+
+    rows = result["data"]
+    session_rows = rows[:2]
+    assert [row["session_total_tokens"] for row in session_rows] == [60, 60]
+    assert [row["session_total_prompt_tokens"] for row in session_rows] == [42, 42]
+    assert [row["session_total_completion_tokens"] for row in session_rows] == [18, 18]
+    assert [(row["total_tokens"], row["prompt_tokens"], row["completion_tokens"]) for row in session_rows] == [
+        (10, 7, 3),
+        (50, 35, 15),
+    ]
+
+    token_keys = ("session_total_tokens", "session_total_prompt_tokens", "session_total_completion_tokens")
+    assert all(key not in rows[2] for key in token_keys)
+
+
+@pytest.mark.asyncio
 async def test_build_ui_spend_logs_response_session_cache_hit_count():
     """
     Each row of a session must carry session_cache_hit_count aggregated across

--- a/ui/litellm-dashboard/src/components/view_logs/RequestLogsTableColumns.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/RequestLogsTableColumns.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
@@ -76,43 +76,37 @@ describe("Cost column", () => {
 });
 
 describe("Tokens column", () => {
-  it("shows the summed session token usage, not the representative call's tokens, for a multi-round session", () => {
-    renderRows([
-      logEntry({
-        request_id: "req-session-tokens",
-        total_tokens: 10,
-        prompt_tokens: 7,
-        completion_tokens: 3,
-        session_id: "sess-1",
-        session_total_count: 3,
-        session_total_tokens: 60,
-        session_total_prompt_tokens: 42,
-        session_total_completion_tokens: 18,
-      }),
-    ]);
+  const sessionRow: Partial<LogEntry> = {
+    request_id: "req-session-tokens",
+    total_tokens: 10,
+    prompt_tokens: 7,
+    completion_tokens: 3,
+    session_id: "sess-1",
+    session_total_count: 3,
+  };
 
-    const tokensCell = screen.getByText("60").closest("td")!;
-    expect(within(tokensCell).getByText("(42+18)")).toBeInTheDocument();
-    expect(within(tokensCell).getByText("session total")).toBeInTheDocument();
+  it("shows the summed session token usage, not the representative call's tokens, for a multi-round session", () => {
+    const aggregatedRow: Partial<LogEntry> = {
+      ...sessionRow,
+      session_total_tokens: 60,
+      session_total_prompt_tokens: 42,
+      session_total_completion_tokens: 18,
+    };
+    renderRows([logEntry(aggregatedRow)]);
+
+    const tokensCell = screen.getByRole("cell", { name: /\(42\+18\)/ });
+    expect(tokensCell).toHaveTextContent("60");
+    expect(tokensCell).toHaveTextContent("session total");
     expect(screen.queryByText("10")).not.toBeInTheDocument();
     expect(screen.queryByText("(7+3)")).not.toBeInTheDocument();
   });
 
   it("falls back to the call's own tokens with no session label when the backend sent no session token sums", () => {
-    renderRows([
-      logEntry({
-        request_id: "req-no-token-aggregate",
-        total_tokens: 10,
-        prompt_tokens: 7,
-        completion_tokens: 3,
-        session_id: "sess-2",
-        session_total_count: 3,
-      }),
-    ]);
+    renderRows([logEntry(sessionRow)]);
 
-    const tokensCell = screen.getByText("10").closest("td")!;
-    expect(within(tokensCell).getByText("(7+3)")).toBeInTheDocument();
-    expect(within(tokensCell).queryByText("session total")).not.toBeInTheDocument();
+    const tokensCell = screen.getByRole("cell", { name: /\(7\+3\)/ });
+    expect(tokensCell).toHaveTextContent("10");
+    expect(tokensCell).not.toHaveTextContent("session total");
   });
 });
 

--- a/ui/litellm-dashboard/src/components/view_logs/RequestLogsTableColumns.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/RequestLogsTableColumns.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
@@ -72,6 +72,47 @@ describe("Cost column", () => {
     expect(screen.getByText("$0.060000")).toBeInTheDocument();
     expect(screen.queryByText("$0.010000")).not.toBeInTheDocument();
     expect(screen.getByText("session total")).toBeInTheDocument();
+  });
+});
+
+describe("Tokens column", () => {
+  it("shows the summed session token usage, not the representative call's tokens, for a multi-round session", () => {
+    renderRows([
+      logEntry({
+        request_id: "req-session-tokens",
+        total_tokens: 10,
+        prompt_tokens: 7,
+        completion_tokens: 3,
+        session_id: "sess-1",
+        session_total_count: 3,
+        session_total_tokens: 60,
+        session_total_prompt_tokens: 42,
+        session_total_completion_tokens: 18,
+      }),
+    ]);
+
+    const tokensCell = screen.getByText("60").closest("td")!;
+    expect(within(tokensCell).getByText("(42+18)")).toBeInTheDocument();
+    expect(within(tokensCell).getByText("session total")).toBeInTheDocument();
+    expect(screen.queryByText("10")).not.toBeInTheDocument();
+    expect(screen.queryByText("(7+3)")).not.toBeInTheDocument();
+  });
+
+  it("falls back to the call's own tokens with no session label when the backend sent no session token sums", () => {
+    renderRows([
+      logEntry({
+        request_id: "req-no-token-aggregate",
+        total_tokens: 10,
+        prompt_tokens: 7,
+        completion_tokens: 3,
+        session_id: "sess-2",
+        session_total_count: 3,
+      }),
+    ]);
+
+    const tokensCell = screen.getByText("10").closest("td")!;
+    expect(within(tokensCell).getByText("(7+3)")).toBeInTheDocument();
+    expect(within(tokensCell).queryByText("session total")).not.toBeInTheDocument();
   });
 });
 

--- a/ui/litellm-dashboard/src/components/view_logs/RequestLogsTableColumns.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/RequestLogsTableColumns.tsx
@@ -263,13 +263,20 @@ export const getRequestLogsTableColumns = ({
     meta: { numeric: true },
     cell: ({ row }) => {
       const log = row.original;
+      const showSessionTotal = (log.session_total_count || 1) > 1 && log.session_total_tokens != null;
+      const total = showSessionTotal ? log.session_total_tokens : log.total_tokens;
+      const prompt = showSessionTotal ? log.session_total_prompt_tokens : log.prompt_tokens;
+      const completion = showSessionTotal ? log.session_total_completion_tokens : log.completion_tokens;
       return (
-        <span className="text-sm">
-          {String(log.total_tokens || "0")}
-          <span className="text-muted-foreground text-xs ml-1">
-            ({String(log.prompt_tokens || "0")}+{String(log.completion_tokens || "0")})
+        <div className="flex flex-col items-end">
+          <span className="text-sm">
+            {String(total || "0")}
+            <span className="text-muted-foreground text-xs ml-1">
+              ({String(prompt || "0")}+{String(completion || "0")})
+            </span>
           </span>
-        </span>
+          {showSessionTotal && <span className="text-[10px] text-muted-foreground">session total</span>}
+        </div>
       );
     },
   },

--- a/ui/litellm-dashboard/src/components/view_logs/columns.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/columns.tsx
@@ -42,6 +42,9 @@ export type LogEntry = {
   request_duration_ms?: number;
   session_total_count?: number;
   session_total_spend?: number;
+  session_total_tokens?: number;
+  session_total_prompt_tokens?: number;
+  session_total_completion_tokens?: number;
   session_cache_hit_count?: number;
   mcp_tool_call_count?: number;
   mcp_tool_call_spend?: number;


### PR DESCRIPTION
## TLDR

Problem this solves:

- Logs table sums a session's cost but not its tokens
- Tokens column showed only the representative call's usage

How it solves it:

- Session aggregate query now also sums prompt, completion and total tokens
- Tokens cell switches to those sums for multi-call sessions, like the Cost cell

## User Flow

Before: an admin reviewing a multi-turn chat session in the logs sees the whole session's cost but only one call's tokens, so they can't tell how many tokens the session used

1. Their app sends two POST https://litellm-domain/v1/chat/completions requests with the same `litellm_session_id`, the first using 16 tokens and the second 80
2. They open https://litellm-domain/ui/?page=logs and find the session row
3. The Cost column shows the summed session cost with a "session total" label under it
4. The Tokens column shows `80 (21+59)`, the last call's usage, with no hint that it is not the session's total
5. They query GET https://litellm-domain/spend/logs/ui?session_id=... directly and each row carries `session_total_spend` but no session token fields

After: the same admin sees the session's total token usage next to its total cost

1. Their app sends the same two POST https://litellm-domain/v1/chat/completions requests with the same `litellm_session_id`
2. They open https://litellm-domain/ui/?page=logs and find the session row
3. The Cost column shows the summed session cost with a "session total" label under it
4. The Tokens column shows `96 (33+63)` with the same "session total" label under it
5. GET https://litellm-domain/spend/logs/ui?session_id=... rows now also carry `session_total_tokens`, `session_total_prompt_tokens` and `session_total_completion_tokens`

## Relevant issues

## Linear ticket

Resolves LIT-4929

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Proxy started from this branch with `litellm/proxy/dev_config.yaml` on port 4929 against the shared dev Postgres. Both runs read back the same session, created once by two real `gpt-5.5` calls

Shared setup

```bash
SESSION=lit-4929-qa-1788458945
FIELDS='{request_id, prompt_tokens, completion_tokens, total_tokens, session_total_count, session_total_prompt_tokens, session_total_completion_tokens, session_total_tokens, spend, session_total_spend}'
```

### Before (7d6781fe6a)

1. Read the session back from the UI logs endpoint

```bash
curl -sG http://localhost:4929/spend/logs/ui --data-urlencode "session_id=$SESSION" --data-urlencode 'start_date=2026-09-03 17:10:32' --data-urlencode 'end_date=2026-09-03 19:10:32' -H 'Authorization: Bearer sk-1234' | jq ".data[] | $FIELDS"
```

2. Both rows carry the summed cost but no session token sums

```json
{
  "request_id": "chatcmpl-EK6A0FAsgWlMv1nxcHUZRzHLHYwSs",
  "prompt_tokens": 21,
  "completion_tokens": 59,
  "total_tokens": 80,
  "session_total_count": 2,
  "session_total_prompt_tokens": null,
  "session_total_completion_tokens": null,
  "session_total_tokens": null,
  "spend": 0.001875,
  "session_total_spend": 0.002055
}
{
  "request_id": "chatcmpl-EK69zgkzOrrk64sEX9huxG4LAkMvu",
  "prompt_tokens": 12,
  "completion_tokens": 4,
  "total_tokens": 16,
  "session_total_count": 2,
  "session_total_prompt_tokens": null,
  "session_total_completion_tokens": null,
  "session_total_tokens": null,
  "spend": 0.00018,
  "session_total_spend": 0.002055
}
```

### After (b3325750ae)

1. Two real calls in one session

```bash
curl -s http://localhost:4929/v1/chat/completions -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"gpt-5.5","litellm_session_id":"'$SESSION'","messages":[{"role":"user","content":"Say hi in one word."}]}' | jq -c .usage
```

```json
{"prompt_tokens":12,"completion_tokens":4,"total_tokens":16}
```

```bash
curl -s http://localhost:4929/v1/chat/completions -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"gpt-5.5","litellm_session_id":"'$SESSION'","messages":[{"role":"user","content":"List five fruits, one per line, then say goodbye in one sentence."}]}' | jq -c .usage
```

```json
{"prompt_tokens":21,"completion_tokens":59,"total_tokens":80}
```

2. Read the session back from the UI logs endpoint

```bash
curl -sG http://localhost:4929/spend/logs/ui --data-urlencode "session_id=$SESSION" --data-urlencode 'start_date=2026-09-03 17:09:05' --data-urlencode 'end_date=2026-09-03 19:09:05' -H 'Authorization: Bearer sk-1234' | jq ".data[] | $FIELDS"
```

3. Both rows now carry the session token sums: 12 + 21 = 33 prompt, 4 + 59 = 63 completion, 16 + 80 = 96 total

```json
{
  "request_id": "chatcmpl-EK6A0FAsgWlMv1nxcHUZRzHLHYwSs",
  "prompt_tokens": 21,
  "completion_tokens": 59,
  "total_tokens": 80,
  "session_total_count": 2,
  "session_total_prompt_tokens": 33,
  "session_total_completion_tokens": 63,
  "session_total_tokens": 96,
  "spend": 0.001875,
  "session_total_spend": 0.002055
}
{
  "request_id": "chatcmpl-EK69zgkzOrrk64sEX9huxG4LAkMvu",
  "prompt_tokens": 12,
  "completion_tokens": 4,
  "total_tokens": 16,
  "session_total_count": 2,
  "session_total_prompt_tokens": 33,
  "session_total_completion_tokens": 63,
  "session_total_tokens": 96,
  "spend": 0.00018,
  "session_total_spend": 0.002055
}
```

4. Open the Admin UI logs page (dashboard dev server pointed at the port 4929 proxy) at http://localhost:3929/?page=logs and find the session row

5. The Tokens column shows `96 (33+63)` with a "session total" label under it, next to the already summed Cost

![Logs table with the session row showing summed cost and tokens](https://raw.githubusercontent.com/BerriAI/litellm/litellm_lit_4929_screenshots/lit_4929_after_logs_closeup.png)

Full page:

![Logs page at full width](https://raw.githubusercontent.com/BerriAI/litellm/litellm_lit_4929_screenshots/lit_4929_after_logs.png)

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Sorting the Tokens column still orders by each call's own tokens, matching how Cost already sorts
- The session drawer is unchanged; only the table's Tokens cell gained the session sums

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

https://claude.ai/code/session_01CNasFqyjnLN3Rqman25vde
