### PR TITLE
fix(ui): match organization ID in the organizations search box

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/organizations/OrganizationFilters.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/organizations/OrganizationFilters.test.tsx
@@ -6,7 +6,7 @@ import OrganizationFilters, { FilterState } from "./OrganizationFilters";
 describe("OrganizationFilters", () => {
   const defaultFilters: FilterState = {
     org_id: "",
-    org_alias: "",
+    search: "",
   };
 
   it("should render", () => {
@@ -24,7 +24,7 @@ describe("OrganizationFilters", () => {
       />,
     );
 
-    expect(screen.getByPlaceholderText("Search by Organization Name")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Search by organization name or ID")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /^filters$/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /reset filters/i })).toBeInTheDocument();
   });
@@ -63,12 +63,12 @@ describe("OrganizationFilters", () => {
       />,
     );
 
-    const input = screen.getByPlaceholderText("Search by Organization Name");
+    const input = screen.getByPlaceholderText("Search by organization name or ID");
     fireEvent.change(input, { target: { value: "test" } });
 
     await waitFor(
       () => {
-        expect(onChange).toHaveBeenCalledWith("org_alias", expect.any(String));
+        expect(onChange).toHaveBeenCalledWith("search", expect.any(String));
       },
       { timeout: 500 },
     );
@@ -103,7 +103,7 @@ describe("OrganizationFilters", () => {
 
     const filtersWithActive: FilterState = {
       ...defaultFilters,
-      org_alias: "test org",
+      search: "test org",
     };
 
     const { container } = render(

--- a/ui/litellm-dashboard/src/app/(dashboard)/organizations/OrganizationFilters.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/organizations/OrganizationFilters.tsx
@@ -13,7 +13,7 @@ interface OrganizationFiltersProps {
 
 type FilterState = {
   org_id: string;
-  org_alias: string;
+  search: string;
 };
 
 const OrganizationFilters = ({
@@ -23,16 +23,16 @@ const OrganizationFilters = ({
   onChange,
   onReset,
 }: OrganizationFiltersProps) => {
-  const hasActiveFilters = !!(filters.org_id || filters.org_alias);
+  const hasActiveFilters = !!(filters.org_id || filters.search);
 
   return (
     <div className="flex flex-col space-y-4">
       {/* Search and Filter Controls */}
       <div className="flex flex-wrap items-center gap-3">
         <FilterInput
-          placeholder="Search by Organization Name"
-          value={filters.org_alias}
-          onChange={(value) => onChange("org_alias", value)}
+          placeholder="Search by organization name or ID"
+          value={filters.search}
+          onChange={(value) => onChange("search", value)}
           icon={Search}
           className="w-64"
         />

--- a/ui/litellm-dashboard/src/app/(dashboard)/organizations/_components/OrganizationsPanel.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/organizations/_components/OrganizationsPanel.test.tsx
@@ -1,9 +1,10 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { NuqsTestingAdapter, type UrlUpdateEvent } from "nuqs/adapters/testing";
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type OrganizationsTableComponent from "./OrganizationsTable";
+import type { Organization } from "@/components/networking";
 import type OrganizationInfoViewComponent from "@/components/organization/organization_view";
 
 vi.mock("@/components/vector_store_management/VectorStoreSelector", () => ({
@@ -14,13 +15,54 @@ vi.mock("@/components/mcp_server_management/MCPServerSelector", () => ({
   __esModule: true,
   default: () => null,
 }));
+type AuthState = { accessToken: string | null; userId: string | null; userRole: string | null };
+const SIGNED_OUT: AuthState = { accessToken: null, userId: null, userRole: null };
+const SIGNED_IN: AuthState = { accessToken: "sk-test", userId: "user-1", userRole: "Admin" };
+let authState: AuthState = SIGNED_OUT;
 vi.mock("@/app/(dashboard)/hooks/useAuthorized", () => ({
-  default: () => ({
-    accessToken: null,
-    userId: null,
-    userRole: null,
-  }),
+  default: () => authState,
 }));
+
+const makeOrganization = (organization_id: string, organization_alias: string): Organization => ({
+  organization_id,
+  organization_alias,
+  budget_id: "",
+  metadata: {},
+  models: [],
+  spend: 0,
+  model_spend: {},
+  created_at: "2024-01-01T00:00:00Z",
+  created_by: "user-1",
+  updated_at: "2024-01-01T00:00:00Z",
+  updated_by: "user-1",
+  litellm_budget_table: null,
+  teams: null,
+  users: null,
+  members: null,
+});
+const ALPHA_ORG_ID = "ff9eb074-3f07-4e13-91fb-5337fb10d760";
+const BETA_ORG_ID = "0a1b2c3d-1111-4222-8333-444455556666";
+const SERVER_ORGANIZATIONS: Organization[] = [
+  makeOrganization(ALPHA_ORG_ID, "Alpha Org"),
+  makeOrganization(BETA_ORG_ID, "Beta Org"),
+  makeOrganization("9f8e7d6c-9999-4888-8777-666655554444", "Gamma Org"),
+];
+const matchesServerFilters = (organization: Organization, orgId: string | null, orgAlias: string | null) => {
+  const idMatches = !orgId || organization.organization_id === orgId;
+  const aliasMatches = !orgAlias || organization.organization_alias.toLowerCase().includes(orgAlias.toLowerCase());
+  return idMatches && aliasMatches;
+};
+vi.mock("@/components/networking", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/components/networking")>();
+  return {
+    ...actual,
+    organizationListCall: (_accessToken: string, orgId: string | null = null, orgAlias: string | null = null) =>
+      Promise.resolve(
+        SERVER_ORGANIZATIONS.filter((organization) => matchesServerFilters(organization, orgId, orgAlias)),
+      ),
+    modelAvailableCall: () => Promise.resolve({ data: [] }),
+  };
+});
 type OrganizationsTableProps = React.ComponentProps<typeof OrganizationsTableComponent>;
 type OrganizationInfoViewProps = React.ComponentProps<typeof OrganizationInfoViewComponent>;
 
@@ -80,6 +122,7 @@ const expectQueryString = (queryString: string) =>
   waitFor(() => expect(onUrlUpdate).toHaveBeenLastCalledWith(expect.objectContaining({ queryString })));
 
 beforeEach(() => {
+  authState = SIGNED_OUT;
   capturedTableProps = null;
   mockOrgInfoView.mockClear();
   onUrlUpdate.mockClear();
@@ -166,5 +209,40 @@ describe("OrganizationsPanel - org detail deep link (?org=)", () => {
     expect(mockOrgInfoView).toHaveBeenLastCalledWith(
       expect.objectContaining({ organizationId: "org-plain", editOrg: false }),
     );
+  });
+});
+
+describe("OrganizationsPanel - search by organization name or ID", () => {
+  const renderSignedInPanel = async () => {
+    authState = SIGNED_IN;
+    renderPanel();
+    await waitFor(() => expect(capturedTableProps?.organizations).toHaveLength(SERVER_ORGANIZATIONS.length));
+  };
+
+  const search = (value: string) =>
+    fireEvent.change(screen.getByPlaceholderText("Search by organization name or ID"), { target: { value } });
+
+  const visibleOrganizationIds = () =>
+    capturedTableProps?.organizations.map((organization) => organization.organization_id);
+
+  it.each([
+    ["a full organization_id", ALPHA_ORG_ID, ALPHA_ORG_ID],
+    ["a substring of an organization_id", "5337fb10", ALPHA_ORG_ID],
+    ["an alias substring, ignoring case", "BETA", BETA_ORG_ID],
+  ])("keeps only the organization matching %s and drops the others", async (_label, query, expectedId) => {
+    await renderSignedInPanel();
+
+    search(query);
+
+    await waitFor(() => expect(visibleOrganizationIds()).toEqual([expectedId]));
+  });
+
+  it("shows the search empty state when neither an alias nor an id matches", async () => {
+    await renderSignedInPanel();
+
+    search("no-such-org");
+
+    await waitFor(() => expect(capturedTableProps?.organizations).toEqual([]));
+    expect(capturedTableProps?.searchActive).toBe(true);
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/organizations/_components/OrganizationsPanel.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/organizations/_components/OrganizationsPanel.test.tsx
@@ -18,12 +18,13 @@ vi.mock("@/components/mcp_server_management/MCPServerSelector", () => ({
 type AuthState = { accessToken: string | null; userId: string | null; userRole: string | null };
 const SIGNED_OUT: AuthState = { accessToken: null, userId: null, userRole: null };
 const SIGNED_IN: AuthState = { accessToken: "sk-test", userId: "user-1", userRole: "Admin" };
-let authState: AuthState = SIGNED_OUT;
+const mockUseAuthorized = vi.fn<() => AuthState>(() => SIGNED_OUT);
 vi.mock("@/app/(dashboard)/hooks/useAuthorized", () => ({
-  default: () => authState,
+  default: () => mockUseAuthorized(),
 }));
 
-const makeOrganization = (organization_id: string, organization_alias: string): Organization => ({
+type ServerOrganization = Omit<Organization, "organization_alias"> & { organization_alias: string | null };
+const makeOrganization = (organization_id: string, organization_alias: string | null): ServerOrganization => ({
   organization_id,
   organization_alias,
   budget_id: "",
@@ -42,24 +43,28 @@ const makeOrganization = (organization_id: string, organization_alias: string): 
 });
 const ALPHA_ORG_ID = "ff9eb074-3f07-4e13-91fb-5337fb10d760";
 const BETA_ORG_ID = "0a1b2c3d-1111-4222-8333-444455556666";
-const SERVER_ORGANIZATIONS: Organization[] = [
+const NO_ALIAS_ORG_ID = "7b6a5f4e-0000-4aaa-8bbb-cccddd111222";
+const SERVER_ORGANIZATIONS: readonly ServerOrganization[] = [
   makeOrganization(ALPHA_ORG_ID, "Alpha Org"),
   makeOrganization(BETA_ORG_ID, "Beta Org"),
   makeOrganization("9f8e7d6c-9999-4888-8777-666655554444", "Gamma Org"),
 ];
-const matchesServerFilters = (organization: Organization, orgId: string | null, orgAlias: string | null) => {
+const matchesServerFilters = (organization: ServerOrganization, orgId: string | null, orgAlias: string | null) => {
   const idMatches = !orgId || organization.organization_id === orgId;
-  const aliasMatches = !orgAlias || organization.organization_alias.toLowerCase().includes(orgAlias.toLowerCase());
+  const aliasMatches =
+    !orgAlias || (organization.organization_alias?.toLowerCase().includes(orgAlias.toLowerCase()) ?? false);
   return idMatches && aliasMatches;
 };
+const fakeOrganizationList =
+  (organizations: readonly ServerOrganization[]) =>
+  (_accessToken: string, orgId: string | null = null, orgAlias: string | null = null) =>
+    Promise.resolve(organizations.filter((organization) => matchesServerFilters(organization, orgId, orgAlias)));
+const mockOrganizationListCall = vi.fn(fakeOrganizationList(SERVER_ORGANIZATIONS));
 vi.mock("@/components/networking", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/components/networking")>();
   return {
     ...actual,
-    organizationListCall: (_accessToken: string, orgId: string | null = null, orgAlias: string | null = null) =>
-      Promise.resolve(
-        SERVER_ORGANIZATIONS.filter((organization) => matchesServerFilters(organization, orgId, orgAlias)),
-      ),
+    organizationListCall: (...args: Parameters<typeof mockOrganizationListCall>) => mockOrganizationListCall(...args),
     modelAvailableCall: () => Promise.resolve({ data: [] }),
   };
 });
@@ -90,9 +95,18 @@ const onUrlUpdate = vi.fn<(event: UrlUpdateEvent) => void>();
 interface RenderPanelOptions {
   premiumUser?: boolean;
   searchParams?: string;
+  auth?: AuthState;
+  organizations?: readonly ServerOrganization[];
 }
 
-const renderPanel = ({ premiumUser = true, searchParams = "" }: RenderPanelOptions = {}) => {
+const renderPanel = ({
+  premiumUser = true,
+  searchParams = "",
+  auth = SIGNED_OUT,
+  organizations = SERVER_ORGANIZATIONS,
+}: RenderPanelOptions = {}) => {
+  mockUseAuthorized.mockReturnValue(auth);
+  mockOrganizationListCall.mockImplementation(fakeOrganizationList(organizations));
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
@@ -122,7 +136,6 @@ const expectQueryString = (queryString: string) =>
   waitFor(() => expect(onUrlUpdate).toHaveBeenLastCalledWith(expect.objectContaining({ queryString })));
 
 beforeEach(() => {
-  authState = SIGNED_OUT;
   capturedTableProps = null;
   mockOrgInfoView.mockClear();
   onUrlUpdate.mockClear();
@@ -213,10 +226,9 @@ describe("OrganizationsPanel - org detail deep link (?org=)", () => {
 });
 
 describe("OrganizationsPanel - search by organization name or ID", () => {
-  const renderSignedInPanel = async () => {
-    authState = SIGNED_IN;
-    renderPanel();
-    await waitFor(() => expect(capturedTableProps?.organizations).toHaveLength(SERVER_ORGANIZATIONS.length));
+  const renderSignedInPanel = async (organizations: readonly ServerOrganization[] = SERVER_ORGANIZATIONS) => {
+    renderPanel({ auth: SIGNED_IN, organizations });
+    await waitFor(() => expect(capturedTableProps?.organizations).toHaveLength(organizations.length));
   };
 
   const search = (value: string) =>
@@ -244,5 +256,13 @@ describe("OrganizationsPanel - search by organization name or ID", () => {
 
     await waitFor(() => expect(capturedTableProps?.organizations).toEqual([]));
     expect(capturedTableProps?.searchActive).toBe(true);
+  });
+
+  it("still finds a row by id when the server hands back a null alias", async () => {
+    await renderSignedInPanel([...SERVER_ORGANIZATIONS, makeOrganization(NO_ALIAS_ORG_ID, null)]);
+
+    search(NO_ALIAS_ORG_ID);
+
+    await waitFor(() => expect(visibleOrganizationIds()).toEqual([NO_ALIAS_ORG_ID]));
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/organizations/_components/OrganizationsPanel.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/organizations/_components/OrganizationsPanel.tsx
@@ -3,10 +3,10 @@ import { useUserModels } from "@/app/(dashboard)/hooks/models/useModels";
 import OrganizationFilters, { FilterState } from "@/app/(dashboard)/organizations/OrganizationFilters";
 import { useQueryClient } from "@tanstack/react-query";
 import { parseAsString, useQueryState } from "nuqs";
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import DeleteResourceModal from "@/components/common_components/DeleteResourceModal";
 import { toast } from "@/lib/toast";
-import { organizationDeleteCall } from "@/components/networking";
+import { Organization, organizationDeleteCall } from "@/components/networking";
 import { OrgCreateDialog } from "@/components/organization/org-create/OrgCreateDialog";
 import OrganizationInfoView from "@/components/organization/organization_view";
 import { Button } from "@/components/ui/button";
@@ -19,6 +19,15 @@ interface OrganizationsPanelProps {
   premiumUser: boolean;
 }
 
+const matchesOrganizationSearch = (organization: Organization, search: string): boolean => {
+  const needle = search.trim().toLowerCase();
+  return (
+    needle === "" ||
+    organization.organization_alias.toLowerCase().includes(needle) ||
+    organization.organization_id.toLowerCase().includes(needle)
+  );
+};
+
 const OrganizationsPanel: React.FC<OrganizationsPanelProps> = ({ userRole, accessToken, premiumUser }) => {
   const [selectedOrgId, setSelectedOrgId] = useQueryState("org", parseAsString.withOptions({ history: "push" }));
   const [editOrg, setEditOrg] = useState(false);
@@ -27,16 +36,18 @@ const OrganizationsPanel: React.FC<OrganizationsPanelProps> = ({ userRole, acces
   const [isDeleting, setIsDeleting] = useState(false);
   const [isOrgModalVisible, setIsOrgModalVisible] = useState(false);
   const [showFilters, setShowFilters] = useState(false);
-  const [filters, setFilters] = useState<FilterState>({ org_id: "", org_alias: "" });
+  const [filters, setFilters] = useState<FilterState>({ org_id: "", search: "" });
 
   const queryClient = useQueryClient();
-  const { data: organizations = [], isLoading } = useOrganizations({
-    org_id: filters.org_id,
-    org_alias: filters.org_alias,
-  });
+  const { data: organizations = [], isLoading } = useOrganizations({ org_id: filters.org_id });
   const { data: userModels = [] } = useUserModels();
 
-  const searchActive = Boolean(filters.org_id || filters.org_alias);
+  const visibleOrganizations = useMemo(
+    () => organizations.filter((organization) => matchesOrganizationSearch(organization, filters.search)),
+    [organizations, filters.search],
+  );
+
+  const searchActive = Boolean(filters.org_id || filters.search);
 
   const refetchOrganizations = () => queryClient.invalidateQueries({ queryKey: organizationKeys.lists() });
 
@@ -45,7 +56,7 @@ const OrganizationsPanel: React.FC<OrganizationsPanelProps> = ({ userRole, acces
   };
 
   const handleFilterReset = () => {
-    setFilters({ org_id: "", org_alias: "" });
+    setFilters({ org_id: "", search: "" });
   };
 
   const handleDelete = (orgId: string | null) => {
@@ -129,7 +140,7 @@ const OrganizationsPanel: React.FC<OrganizationsPanelProps> = ({ userRole, acces
             onReset={handleFilterReset}
           />
           <OrganizationsTable
-            organizations={organizations}
+            organizations={visibleOrganizations}
             isLoading={isLoading}
             userRole={userRole}
             searchActive={searchActive}

--- a/ui/litellm-dashboard/src/app/(dashboard)/organizations/_components/OrganizationsPanel.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/organizations/_components/OrganizationsPanel.tsx
@@ -21,10 +21,9 @@ interface OrganizationsPanelProps {
 
 const matchesOrganizationSearch = (organization: Organization, search: string): boolean => {
   const needle = search.trim().toLowerCase();
-  return (
-    needle === "" ||
-    organization.organization_alias.toLowerCase().includes(needle) ||
-    organization.organization_id.toLowerCase().includes(needle)
+  if (needle === "") return true;
+  return [organization.organization_alias, organization.organization_id].some((field) =>
+    field?.toLowerCase().includes(needle),
   );
 };
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Organizations search only matched the name, never the ID column
- Pasting an ID copied from the table showed the empty state
- That empty state already told users to try a name or ID

How it solves it:

- Search box matches organization name or ID, case-insensitive substring
- Placeholder now reads "Search by organization name or ID"
- Filtering runs in the browser over the list the page already loads

## User Flow

Before: an admin copies an organization ID out of the table, pastes it into the search box, and the table goes empty

1. They open http://localhost:4000/ui/organizations/ and see the organizations table with an Organization ID column
2. They click the copy icon next to `ff9eb074-3f07-4e13-91fb-5337fb10d760` and paste it into the search box labelled "Search by Organization Name"
3. The table shows "No matching organizations. No organizations match your search. Try a different name or ID." even though that row was on screen a second ago
4. Typing part of the name still works, typing any part of the ID never does

After: the same paste keeps exactly that organization's row

1. They open http://localhost:4000/ui/organizations/ and see the organizations table with an Organization ID column
2. They click the copy icon next to `ff9eb074-3f07-4e13-91fb-5337fb10d760` and paste it into the search box, now labelled "Search by organization name or ID"
3. The table shows only that organization's row
4. Typing part of the name or part of the ID (for example `5337fb10d760`) narrows the table the same way, in either case

## Relevant issues

## Linear ticket

Refs LIT-4738

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup: the proxy runs from this branch on port 4742 (`python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --port 4742 --detailed_debug --use_v2_migration_resolver`), the Admin UI is built from the same checkout, and the browser logs in at http://localhost:4742/ui/login with username `admin` and password `sk-1234`. The organization used below already exists in the dev database, which this curl confirms:

```
$ curl -s "http://localhost:4742/organization/list" -H "Authorization: Bearer sk-1234" | jq length
15
$ curl -s "http://localhost:4742/organization/list" -H "Authorization: Bearer sk-1234" | jq '.[] | select(.organization_id == "ff9eb074-3f07-4e13-91fb-5337fb10d760") | {organization_id, organization_alias}'
{
  "organization_id": "ff9eb074-3f07-4e13-91fb-5337fb10d760",
  "organization_alias": "qa-lit4688-org4-1784917228"
}
```

Nothing in `/organization/list` changed, so the request the old search box sent is identical at both commits and returns an empty list for an ID because `org_alias` only ever matched names:

```
$ curl -s "http://localhost:4742/organization/list?org_alias=ff9eb074-3f07-4e13-91fb-5337fb10d760" -H "Authorization: Bearer sk-1234"
[]
```

### Before (fa533f709b)

1. Open http://localhost:4742/ui/organizations/ and wait for the table; the search box reads "Search by Organization Name"
2. Paste `ff9eb074-3f07-4e13-91fb-5337fb10d760` into that box
3. Observed: the table is replaced by "No matching organizations. No organizations match your search. Try a different name or ID." (headless run against a UI built from the merge base, `LIT_MODE=before`):

```
mode=before placeholder="Search by Organization Name"
rows before search: 15
rows after pasting full id: 1; empty state shown: true
  row: No matching organizations No organizations match your search. Try a different name or ID.
PROOF_OK (before: empty state reproduced)
```

### After (16d639982b)

1. Open http://localhost:4742/ui/organizations/ and wait for the table; the search box now reads "Search by organization name or ID"
2. Paste `ff9eb074-3f07-4e13-91fb-5337fb10d760` into that box
3. Observed: exactly one row remains, the one with that ID
4. Replace the box contents with the ID fragment `5337fb10d760`
5. Observed: the same single row remains (headless run against a UI built from this commit, `LIT_MODE=after`):

```
mode=after placeholder="Search by organization name or ID"
rows before search: 15
rows after pasting full id: 1; empty state shown: false
  row: ff9eb074-3f07-4e13-91fb-5337fb10d760 qa-lit4688-org4-1784917228 Jul 24, 2026 < $0.0001 $10.00 All Proxy Models TPM: Unlimited RPM: Unlimited 0 Members
rows after typing id fragment "5337fb10d760": 1
  row: ff9eb074-3f07-4e13-91fb-5337fb10d760 qa-lit4688-org4-1784917228 Jul 24, 2026 < $0.0001 $10.00 All Proxy Models TPM: Unlimited RPM: Unlimited 0 Members
PROOF_OK
```

To take the screenshots by hand, run the same proxy on port 4742, log in at http://localhost:4742/ui/login as `admin` / `sk-1234`, open http://localhost:4742/ui/organizations/, paste the ID from the curl above into the search box, and capture the table once with the full ID and once with the fragment `5337fb10d760`.

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- The main search box now filters in the browser; the server-side `org_alias` and `org_id` params of `/organization/list` are untouched
- The hidden "Search by Organization ID" filter still sends `org_id` to the server, exact match, as before
- Teams searches server-side; the organizations list is unpaginated, so browser-side matching sees the same rows the page already shows

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

https://claude.ai/code/session_018yW93iDaEMhoQUXcYjus7D
