### PR TITLE
fix(pricing): add baseten/zai-org/GLM-5.3 to the model pricing registry

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -27065,6 +27065,27 @@
         "mode": "chat",
         "output_cost_per_token": 3.15e-06
     },
+    "baseten/zai-org/GLM-5.3": {
+        "cache_read_input_token_cost": 1.4e-07,
+        "input_cost_per_token": 1.4e-06,
+        "litellm_provider": "baseten",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 4.4e-06,
+        "source": "https://www.baseten.co/pricing/",
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
     "baseten/zai-org/GLM-4.7": {
         "input_cost_per_token": 6e-07,
         "litellm_provider": "baseten",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -27065,6 +27065,27 @@
         "mode": "chat",
         "output_cost_per_token": 3.15e-06
     },
+    "baseten/zai-org/GLM-5.3": {
+        "cache_read_input_token_cost": 1.4e-07,
+        "input_cost_per_token": 1.4e-06,
+        "litellm_provider": "baseten",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 4.4e-06,
+        "source": "https://www.baseten.co/pricing/",
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
     "baseten/zai-org/GLM-4.7": {
         "input_cost_per_token": 6e-07,
         "litellm_provider": "baseten",

--- a/tests/test_litellm/test_baseten_glm_5_3_model_metadata.py
+++ b/tests/test_litellm/test_baseten_glm_5_3_model_metadata.py
@@ -1,0 +1,154 @@
+import json
+from pathlib import Path
+
+import pytest
+
+import litellm
+from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+from litellm.types.utils import PromptTokensDetailsWrapper, Usage
+from litellm.utils import supports_function_calling, supports_prompt_caching
+
+REPO_ROOT = Path(__file__).parents[2]
+MAIN_PATH = REPO_ROOT / "model_prices_and_context_window.json"
+BACKUP_PATH = REPO_ROOT / "litellm" / "model_prices_and_context_window_backup.json"
+
+MODEL = "baseten/zai-org/GLM-5.3"
+
+INPUT_COST = 1.4e-06
+CACHED_INPUT_COST = 1.4e-07
+OUTPUT_COST = 4.4e-06
+
+
+def _load(path):
+    with open(path) as f:
+        return json.load(f)
+
+
+@pytest.fixture
+def local_model_cost_map(monkeypatch):
+    """Force get_model_info to resolve against the in-repo cost map instead of the
+    remote one fetched at import time, which still carries the pre-merge registry."""
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    monkeypatch.setattr(litellm, "model_cost", litellm.get_model_cost_map(url=""))
+    litellm.get_model_info.cache_clear()
+    yield
+    litellm.get_model_info.cache_clear()
+
+
+def test_baseten_glm_5_3_specs():
+    info = _load(MAIN_PATH).get(MODEL)
+    assert info is not None, f"{MODEL} missing from model_prices_and_context_window.json"
+
+    assert info["litellm_provider"] == "baseten"
+    assert info["mode"] == "chat"
+
+    assert info["input_cost_per_token"] == INPUT_COST
+    assert info["output_cost_per_token"] == OUTPUT_COST
+    assert info["cache_read_input_token_cost"] == CACHED_INPUT_COST
+
+    assert info["max_input_tokens"] == 1048576
+    assert info["max_output_tokens"] == 262144
+    assert info["max_tokens"] == 262144
+
+    assert info["supports_function_calling"] is True
+    assert info["supports_prompt_caching"] is True
+    assert info["supports_response_schema"] is True
+    assert info["supports_tool_choice"] is True
+    assert info["supported_modalities"] == ["text"]
+    assert info["supported_output_modalities"] == ["text"]
+
+    routed_model, provider, _, _ = get_llm_provider(model=MODEL)
+    assert routed_model == "zai-org/GLM-5.3"
+    assert provider == "baseten"
+
+
+def test_baseten_glm_5_3_capabilities_are_visible_to_callers(local_model_cost_map):
+    """The entry advertises prompt caching and tool calling, so the helpers every
+    caller checks before sending a request must say so too."""
+    assert supports_prompt_caching(model=MODEL) is True
+    assert supports_function_calling(model=MODEL) is True
+
+    info = litellm.get_model_info(model="zai-org/GLM-5.3", custom_llm_provider="baseten")
+    assert info["max_input_tokens"] == 1048576
+    assert info["max_output_tokens"] == 262144
+
+
+def test_cached_prompt_tokens_bill_at_the_cached_rate(local_model_cost_map):
+    """A cache hit reports its reused tokens under prompt_tokens_details, and those
+    tokens cost a tenth of the input rate, not the full rate and not nothing."""
+    usage = Usage(
+        prompt_tokens=21010,
+        completion_tokens=100,
+        total_tokens=21110,
+        prompt_tokens_details=PromptTokensDetailsWrapper(cached_tokens=20992),
+    )
+
+    prompt_cost, completion_cost = litellm.cost_per_token(
+        model=MODEL, usage_object=usage, custom_llm_provider="baseten"
+    )
+
+    assert prompt_cost == pytest.approx(18 * INPUT_COST + 20992 * CACHED_INPUT_COST)
+    assert completion_cost == pytest.approx(100 * OUTPUT_COST)
+
+
+def test_backup_matches_main():
+    """Ensure the bundled (backup) cost map stays in sync with the canonical file.
+
+    Both keys are asserted present first: comparing two ``.get`` results alone passes
+    just as happily when neither file has the entry at all, which is the exact state
+    this test exists to catch.
+    """
+    main_cost = _load(MAIN_PATH)
+    backup_cost = _load(BACKUP_PATH)
+
+    assert MODEL in main_cost, f"{MODEL} missing from model_prices_and_context_window.json"
+    assert MODEL in backup_cost, f"{MODEL} missing from model_prices_and_context_window_backup.json"
+    assert backup_cost[MODEL] == main_cost[MODEL], f"{MODEL} differs between main and backup model cost maps"
+
+
+def test_entry_advertises_only_what_the_baseten_path_accepts(local_model_cost_map):
+    """The entry must not claim a capability whose request parameter BasetenConfig
+    refuses.
+
+    ``BasetenConfig.get_supported_openai_params`` returns one hardcoded list for every
+    Baseten model, and it carries neither ``parallel_tool_calls`` nor
+    ``reasoning_effort``. Baseten's own Model API does take ``reasoning_effort``, but
+    litellm's Baseten path drops it (``drop_params=True``) or raises
+    ``UnsupportedParamsError`` (``drop_params=False``), so declaring
+    ``supports_parallel_function_calling``, ``supports_reasoning`` or
+    ``reasoning_effort_levels`` here would advertise a level the gateway then refuses to
+    send. Wiring those params through the Baseten config is separate work; until it
+    lands, the registry stays honest.
+    """
+    supported = litellm.get_supported_openai_params(model="zai-org/GLM-5.3", custom_llm_provider="baseten")
+    assert supported is not None
+
+    entry = _load(MAIN_PATH)[MODEL]
+
+    capability_to_param = {
+        "supports_function_calling": "tools",
+        "supports_tool_choice": "tool_choice",
+        "supports_response_schema": "response_format",
+        "supports_parallel_function_calling": "parallel_tool_calls",
+        "supports_reasoning": "reasoning_effort",
+    }
+    for capability, param in capability_to_param.items():
+        if entry.get(capability):
+            assert param in supported, f"{MODEL} advertises {capability} but baseten drops/rejects {param}"
+
+    assert "reasoning_effort_levels" not in entry, (
+        "reasoning_effort_levels advertises accepted reasoning_effort values, which the Baseten path does not accept"
+    )
+    assert "thinking_always_on" not in entry, (
+        "thinking_always_on is only read by AnthropicModelInfo._is_always_on_thinking_model, "
+        "which no Baseten route reaches"
+    )
+
+    with pytest.raises(litellm.UnsupportedParamsError):
+        litellm.utils.get_optional_params(
+            model="zai-org/GLM-5.3",
+            custom_llm_provider="baseten",
+            parallel_tool_calls=True,
+            reasoning_effort="high",
+            drop_params=False,
+        )


### PR DESCRIPTION
## TLDR

Problem this solves:

- `baseten/zai-org/GLM-5.3` is missing from the registry
- `get_model_info` raises "This model isn't mapped yet"
- Operators must hand-maintain pricing that drifts from Baseten

How it solves it:

- Adds the entry to both registry JSON files
- Uses Baseten's published prices and Model API limits
- Declares only capabilities the Baseten path actually sends
- Adds a regression test so neither can drift

## User Flow

Before: a proxy admin routing to Baseten GLM-5.3 gets no built-in pricing or limits, so the gateway cannot cost the traffic

1. They add a deployment with `model: baseten/zai-org/GLM-5.3` and `api_key: os.environ/BASETEN_API_KEY`, then start the proxy
2. They send POST http://localhost:4000/v1/chat/completions with `"model": "zai-org/GLM-5.3"`
3. Asking LiteLLM about the model comes back with `This model isn't mapped yet. model=zai-org/GLM-5.3, custom_llm_provider=baseten`
4. To get spend numbers at all, they copy Baseten's prices and token limits into the deployment config, and re-copy them every time Baseten changes a rate

After: the same deployment resolves Baseten's prices and limits from the registry, with no local override

1. They add the same deployment with `model: baseten/zai-org/GLM-5.3` and `api_key: os.environ/BASETEN_API_KEY`, then start the proxy
2. They send the same POST http://localhost:4000/v1/chat/completions with `"model": "zai-org/GLM-5.3"`
3. Asking LiteLLM about the model returns $1.40/M input, $0.14/M cached input, $4.40/M output, a 1,048,576 token context and a 262,144 token max output
4. They delete the local pricing override and pick up future rate changes through a normal LiteLLM upgrade

## Relevant issues

Fixes #39342

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Where the numbers come from

Every field was read off Baseten's own pages, not inferred:

- Input $1.40/M, output $4.40/M, and **cached input $0.14/M** all come from the GLM-5.3 row of https://www.baseten.co/pricing/, which prints a separate "Cache Input" column per model. The cached rate is that published number, cross-checked against the page directly. It is **not** derived by applying a flat percentage to the input rate: Baseten's discount is not uniform, and the same table lists GLM 4.7 at $0.60 input against $0.12 cached input, a 20% ratio rather than GLM-5.3's 10%. A percentage assumption would have produced the wrong number for a sibling model on the same page.
- 1,048,576 token context and 262,144 token max output come from https://docs.baseten.co/inference/model-apis/overview.
- The slug `zai-org/GLM-5.3` is the Model API id from the same docs.

## Capabilities this entry does and does not claim

The issue's suggested metadata included reasoning with `low`/`high`/`max` and parallel function calling. Those are left off on purpose, because LiteLLM's Baseten path cannot send either one.

`BasetenConfig.get_supported_openai_params` (`litellm/llms/baseten/chat.py`) returns a single hardcoded list for every Baseten model, and it contains neither `reasoning_effort` nor `parallel_tool_calls`. A request naming them is silently dropped under `drop_params=True` and rejected with `UnsupportedParamsError` otherwise, shown in the run below. Baseten's API itself does accept `reasoning_effort` (https://docs.baseten.co/inference/model-apis/reasoning lists `none`/`low`/`high`/`max` for GLM 5.3), so this is a gap in the provider config rather than in Baseten. Closing that gap means editing the shared supported-params list for every Baseten model and proving it against a live account, which is a different change from a registry entry; the registry should not promise it in advance.

`thinking_always_on` is omitted for the same reason. It is read only by `AnthropicModelInfo._is_always_on_thinking_model`, and it means the model rejects `thinking.type=disabled` on the Anthropic request path, which no Baseten route reaches. All 22 other entries carrying it are Claude models.

What the entry does claim maps 1:1 onto params the Baseten config sends: `supports_function_calling` -> `tools`, `supports_tool_choice` -> `tool_choice`, `supports_response_schema` -> `response_format`. `supports_prompt_caching` is billing metadata backed by the `cache_read_input_token_cost` above. A test asserts that pairing, so no flag can be added back without the matching param appearing in the Baseten config.

## Screenshots / Proof of Fix

I do not have a Baseten account, so I could not put a billable call through a live proxy. The defect is entirely in the static registry, so what I can show is the exact lookup that fails today and succeeds after the change, run against the checkout with `LITELLM_LOCAL_MODEL_COST_MAP=True` so it reads the in-repo files instead of the published ones.

Shared setup, `probe.py` at the repo root:

```python
import json, litellm

FIELDS = (
    "input_cost_per_token",
    "cache_read_input_token_cost",
    "output_cost_per_token",
    "max_input_tokens",
    "max_output_tokens",
    "supports_function_calling",
    "supports_prompt_caching",
    "supports_response_schema",
    "supports_tool_choice",
)

print("model key present:", "baseten/zai-org/GLM-5.3" in litellm.model_cost)
try:
    info = litellm.get_model_info(model="zai-org/GLM-5.3", custom_llm_provider="baseten")
    print(json.dumps({k: info[k] for k in FIELDS}, indent=2))
except Exception as exc:
    print(f"{type(exc).__name__}: {exc}")

print("advertises reasoning:", bool(litellm.model_cost.get("baseten/zai-org/GLM-5.3", {}).get("supports_reasoning")))
print("baseten accepts reasoning_effort:", "reasoning_effort" in litellm.get_supported_openai_params(model="zai-org/GLM-5.3", custom_llm_provider="baseten"))
print("baseten accepts parallel_tool_calls:", "parallel_tool_calls" in litellm.get_supported_openai_params(model="zai-org/GLM-5.3", custom_llm_provider="baseten"))
try:
    litellm.utils.get_optional_params(model="zai-org/GLM-5.3", custom_llm_provider="baseten", parallel_tool_calls=True, reasoning_effort="high", drop_params=False)
    print("sending both params: accepted")
except Exception as exc:
    print(f"sending both params: {type(exc).__name__}: {str(exc).splitlines()[0]}")
```

### Before (342e4470c4)

#### registry lookup

1. `LITELLM_LOCAL_MODEL_COST_MAP=True python probe.py`

```console
model key present: False
Exception: This model isn't mapped yet. model=zai-org/GLM-5.3, custom_llm_provider=baseten. Add it here - https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json.
advertises reasoning: False
baseten accepts reasoning_effort: False
baseten accepts parallel_tool_calls: False
sending both params: UnsupportedParamsError: litellm.UnsupportedParamsError: baseten does not support parameters: ['parallel_tool_calls', 'reasoning_effort'], for model=zai-org/GLM-5.3. To drop these, set `litellm.drop_params=True` or for proxy:
```

#### tests

1. `python -m pytest tests/test_litellm/test_baseten_glm_5_3_model_metadata.py -q -p no:randomly` with the new test file applied on top of the merge-base registry, so only the tests are new
2. Output:

```
FAILED tests/test_litellm/test_baseten_glm_5_3_model_metadata.py::test_backup_matches_main
FAILED tests/test_litellm/test_baseten_glm_5_3_model_metadata.py::test_baseten_glm_5_3_capabilities_are_visible_to_callers
FAILED tests/test_litellm/test_baseten_glm_5_3_model_metadata.py::test_baseten_glm_5_3_specs
FAILED tests/test_litellm/test_baseten_glm_5_3_model_metadata.py::test_cached_prompt_tokens_bill_at_the_cached_rate
FAILED tests/test_litellm/test_baseten_glm_5_3_model_metadata.py::test_entry_advertises_only_what_the_baseten_path_accepts
5 failed in 7.66s
```

All five fail, including `test_backup_matches_main`: it now asserts the key is present in each file before comparing them, so it can no longer pass by finding the entry absent from both.

### After (7b9c94441c)

#### registry lookup

1. `LITELLM_LOCAL_MODEL_COST_MAP=True python probe.py`

```console
model key present: True
{
  "input_cost_per_token": 1.4e-06,
  "cache_read_input_token_cost": 1.4e-07,
  "output_cost_per_token": 4.4e-06,
  "max_input_tokens": 1048576,
  "max_output_tokens": 262144,
  "supports_function_calling": true,
  "supports_prompt_caching": true,
  "supports_response_schema": true,
  "supports_tool_choice": true
}
advertises reasoning: False
baseten accepts reasoning_effort: False
baseten accepts parallel_tool_calls: False
sending both params: UnsupportedParamsError: litellm.UnsupportedParamsError: baseten does not support parameters: ['parallel_tool_calls', 'reasoning_effort'], for model=zai-org/GLM-5.3. To drop these, set `litellm.drop_params=True` or for proxy:
```

The lookup now resolves, and what it advertises lines up with what the Baseten path will send.

#### tests

1. `python -m pytest tests/test_litellm/test_baseten_glm_5_3_model_metadata.py tests/test_litellm/test_model_prices_schema.py tests/test_litellm/llms/baseten -q -p no:randomly`
2. Output: `28 passed in 9.91s`

3. `python -m pytest tests/test_litellm/router_utils/test_reasoning_effort_capability.py tests/test_litellm/test_utils.py -q -p no:randomly`
4. Output: `369 passed in 69.26s`

#### registry integrity

1. `cmp model_prices_and_context_window.json litellm/model_prices_and_context_window_backup.json` -> no output, the two files are byte-identical
2. `python ci_cd/generate_model_prices_schema.py --check` -> `model_prices_and_context_window.schema.json is in sync and model_prices_and_context_window.json validates against it`

#### lint

1. `ruff check --config ruff-tests.toml tests/test_litellm/test_baseten_glm_5_3_model_metadata.py` -> `All checks passed!`
2. `ruff format --check --config ruff-tests.toml tests/test_litellm/test_baseten_glm_5_3_model_metadata.py` -> `1 file already formatted`

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- No reasoning or parallel-tool-calling metadata, unlike the issue's suggestion
  - Baseten's API takes `reasoning_effort`; `BasetenConfig` does not forward it
  - Wiring it up is provider-config work, tracked separately from this entry

### Low

- Prices and limits come from Baseten's public pages, not a live account
- No billable end-to-end call; the defect is a static registry miss

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
