### PR TITLE
fix(bedrock): forward per-call timeout to injected clients and make timeout tests deterministic

### DIFF
--- a/litellm/llms/bedrock/chat/converse_handler.py
+++ b/litellm/llms/bedrock/chat/converse_handler.py
@@ -242,6 +242,7 @@ class BedrockConverseLLM(BaseAWSLLM):
                 url=api_base,
                 headers=headers,
                 data=data,
+                timeout=timeout,
                 logging_obj=logging_obj,
             )
             response.raise_for_status()
@@ -585,6 +586,7 @@ class BedrockConverseLLM(BaseAWSLLM):
                 url=proxy_endpoint_url,
                 headers=prepped.headers,
                 data=data,
+                timeout=timeout,
                 logging_obj=logging_obj,
             )
             response.raise_for_status()

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -566,17 +566,22 @@ class AsyncHTTPHandler:
         client_alias: str | None = None,  # name for client in logs
         ssl_verify: VerifyTypes | None = None,
         shared_session: Optional["ClientSession"] = None,
+        client: httpx.AsyncClient | None = None,
     ):
         self.timeout = timeout
         self.event_hooks = event_hooks
         self.ssl_verify = ssl_verify
         self.shared_session = shared_session
-        self._owns_client = True
-        self._client = self.create_client(
-            timeout=timeout,
-            event_hooks=event_hooks,
-            ssl_verify=ssl_verify,
-            shared_session=shared_session,
+        self._owns_client = client is None
+        self._client = (
+            self.create_client(
+                timeout=timeout,
+                event_hooks=event_hooks,
+                ssl_verify=ssl_verify,
+                shared_session=shared_session,
+            )
+            if client is None
+            else client
         )
         self.client_alias = client_alias
 

--- a/tests/_fake_openai_endpoint_server.py
+++ b/tests/_fake_openai_endpoint_server.py
@@ -12,7 +12,11 @@ gets back a well-formed chat/text/embedding/moderation response with realistic
 ``usage`` so cost tracking and spend accounting still exercise their real code
 paths. The one behavioral special case mirrors the old hosted mock: a request
 whose ``model`` is ``429`` returns HTTP 429 so rate-limit and cooldown tests
-still have something to trip on.
+still have something to trip on, and a model named ``slow-endpoint`` sleeps past
+any short client deadline so timeout tests get a deterministic timeout. The Azure
+deployment, Anthropic ``/v1/messages`` and Bedrock ``converse`` URL shapes are
+served too, so provider timeout tests can point ``api_base`` here instead of
+racing a real provider.
 """
 
 from __future__ import annotations
@@ -21,7 +25,8 @@ import asyncio
 import json
 import time
 import uuid
-from typing import AsyncIterator, Final
+from collections.abc import AsyncIterator
+from typing import Final
 
 import uvicorn
 from starlette.applications import Starlette
@@ -63,6 +68,11 @@ def _usage() -> dict[str, int]:
 def _requested_model(body: dict[str, object]) -> str:
     model = body.get("model")
     return model if isinstance(model, str) else "mock-model"
+
+
+async def _sleep_if_slow(model: str) -> None:
+    if model == _SLOW_MODEL:
+        await asyncio.sleep(_SLOW_RESPONSE_SECONDS)
 
 
 def _wants_stream(body: dict[str, object]) -> bool:
@@ -136,19 +146,26 @@ async def _chat_completion_stream(model: str, with_usage: bool) -> AsyncIterator
     yield "data: [DONE]\n\n"
 
 
-async def chat_completions(request: Request) -> Response:
-    body = await _parse_body(request)
-    model = _requested_model(body)
+async def _chat_completion_response(model: str, body: dict[str, object]) -> Response:
     if model == _RATE_LIMIT_MODEL:
         return _rate_limit_response(model)
-    if model == _SLOW_MODEL:
-        await asyncio.sleep(_SLOW_RESPONSE_SECONDS)
+    await _sleep_if_slow(model)
     if _wants_stream(body):
         return StreamingResponse(
             _chat_completion_stream(model, _wants_stream_usage(body)),
             media_type="text/event-stream",
         )
     return JSONResponse(_chat_completion_body(model))
+
+
+async def chat_completions(request: Request) -> Response:
+    body = await _parse_body(request)
+    return await _chat_completion_response(_requested_model(body), body)
+
+
+async def azure_chat_completions(request: Request) -> Response:
+    body = await _parse_body(request)
+    return await _chat_completion_response(request.path_params["deployment"], body)
 
 
 def _text_completion_body(model: str) -> dict[str, object]:
@@ -195,8 +212,7 @@ async def completions(request: Request) -> Response:
     model = _requested_model(body)
     if model == _RATE_LIMIT_MODEL:
         return _rate_limit_response(model)
-    if model == _SLOW_MODEL:
-        await asyncio.sleep(_SLOW_RESPONSE_SECONDS)
+    await _sleep_if_slow(model)
     if _wants_stream(body):
         return StreamingResponse(
             _text_completion_stream(model, _wants_stream_usage(body)),
@@ -205,11 +221,8 @@ async def completions(request: Request) -> Response:
     return JSONResponse(_text_completion_body(model))
 
 
-async def embeddings(request: Request) -> Response:
-    body = await _parse_body(request)
-    model = _requested_model(body)
-    if model == _SLOW_MODEL:
-        await asyncio.sleep(_SLOW_RESPONSE_SECONDS)
+async def _embeddings_response(model: str, body: dict[str, object]) -> Response:
+    await _sleep_if_slow(model)
     raw_input = body.get("input", "")
     count = len(raw_input) if isinstance(raw_input, list) else 1
     return JSONResponse(
@@ -220,6 +233,76 @@ async def embeddings(request: Request) -> Response:
             "usage": {"prompt_tokens": 5, "total_tokens": 5},
         }
     )
+
+
+async def embeddings(request: Request) -> Response:
+    body = await _parse_body(request)
+    return await _embeddings_response(_requested_model(body), body)
+
+
+async def azure_embeddings(request: Request) -> Response:
+    body = await _parse_body(request)
+    return await _embeddings_response(request.path_params["deployment"], body)
+
+
+def _anthropic_message_body(model: str) -> dict[str, object]:
+    return {
+        "id": f"msg_{uuid.uuid4().hex[:24]}",
+        "type": "message",
+        "role": "assistant",
+        "model": model,
+        "content": [{"type": "text", "text": _CANNED_CONTENT}],
+        "stop_reason": "end_turn",
+        "stop_sequence": None,
+        "usage": {"input_tokens": _PROMPT_TOKENS, "output_tokens": _COMPLETION_TOKENS},
+    }
+
+
+async def _anthropic_message_stream(model: str) -> AsyncIterator[str]:
+    def event(name: str, payload: dict[str, object]) -> str:
+        return f"event: {name}\ndata: {json.dumps({'type': name} | payload)}\n\n"
+
+    opening = _anthropic_message_body(model) | {
+        "content": [],
+        "stop_reason": None,
+        "usage": {"input_tokens": _PROMPT_TOKENS, "output_tokens": 0},
+    }
+    yield event("message_start", {"message": opening})
+    yield event("content_block_start", {"index": 0, "content_block": {"type": "text", "text": ""}})
+    yield event("content_block_delta", {"index": 0, "delta": {"type": "text_delta", "text": _CANNED_CONTENT}})
+    yield event("content_block_stop", {"index": 0})
+    yield event(
+        "message_delta",
+        {"delta": {"stop_reason": "end_turn", "stop_sequence": None}, "usage": {"output_tokens": _COMPLETION_TOKENS}},
+    )
+    yield event("message_stop", {})
+
+
+async def anthropic_messages(request: Request) -> Response:
+    body = await _parse_body(request)
+    model = _requested_model(body)
+    await _sleep_if_slow(model)
+    if _wants_stream(body):
+        return StreamingResponse(_anthropic_message_stream(model), media_type="text/event-stream")
+    return JSONResponse(_anthropic_message_body(model))
+
+
+def _bedrock_converse_body() -> dict[str, object]:
+    return {
+        "output": {"message": {"role": "assistant", "content": [{"text": _CANNED_CONTENT}]}},
+        "stopReason": "end_turn",
+        "usage": {
+            "inputTokens": _PROMPT_TOKENS,
+            "outputTokens": _COMPLETION_TOKENS,
+            "totalTokens": _PROMPT_TOKENS + _COMPLETION_TOKENS,
+        },
+        "metrics": {"latencyMs": 1},
+    }
+
+
+async def bedrock_converse(request: Request) -> Response:
+    await _sleep_if_slow(request.path_params["model_id"])
+    return JSONResponse(_bedrock_converse_body())
 
 
 async def triton_embeddings(_request: Request) -> Response:
@@ -286,6 +369,12 @@ app = Starlette(
         Route("/v1/completions", completions, methods=["POST"]),
         Route("/embeddings", embeddings, methods=["POST"]),
         Route("/v1/embeddings", embeddings, methods=["POST"]),
+        Route("/openai/deployments/{deployment}/chat/completions", azure_chat_completions, methods=["POST"]),
+        Route("/openai/deployments/{deployment}/embeddings", azure_embeddings, methods=["POST"]),
+        Route("/openai/v1/chat/completions", chat_completions, methods=["POST"]),
+        Route("/openai/v1/embeddings", embeddings, methods=["POST"]),
+        Route("/v1/messages", anthropic_messages, methods=["POST"]),
+        Route("/model/{model_id}/converse", bedrock_converse, methods=["POST"]),
         Route("/triton/embeddings", triton_embeddings, methods=["POST"]),
         Route("/moderations", moderations, methods=["POST"]),
         Route("/v1/moderations", moderations, methods=["POST"]),

--- a/tests/local_testing/test_embedding.py
+++ b/tests/local_testing/test_embedding.py
@@ -250,11 +250,15 @@ async def test_azure_ai_embedding_image(sync_mode):
 def test_openai_azure_embedding_timeouts():
     try:
         response = embedding(
-            model="azure/text-embedding-ada-002",
+            model="azure/slow-endpoint",
             input=["good morning from litellm"],
-            timeout=0.00001,
+            api_base=FAKE_OPENAI_API_BASE,
+            api_key="fake-key",
+            api_version="2024-10-21",
+            timeout=0.5,
         )
         print(response)
+        pytest.fail("Expected timeout error, the request returned instead")
     except openai.APITimeoutError:
         print("Good job got timeout error!")
         pass

--- a/tests/local_testing/test_fake_openai_endpoint.py
+++ b/tests/local_testing/test_fake_openai_endpoint.py
@@ -94,6 +94,77 @@ def test_slow_model_blocks_past_client_timeout():
         )
 
 
+_CHAT_BODY: Final = {"messages": [{"role": "user", "content": "hi"}], "max_tokens": 5}
+_SLOW_PROVIDER_ROUTES: Final = (
+    ("/openai/deployments/slow-endpoint/chat/completions", _CHAT_BODY),
+    ("/openai/deployments/slow-endpoint/embeddings", {"input": "hi"}),
+    ("/v1/messages", _CHAT_BODY | {"model": "slow-endpoint"}),
+    ("/model/slow-endpoint/converse", _CHAT_BODY),
+)
+
+
+@pytest.mark.parametrize("path, body", _SLOW_PROVIDER_ROUTES)
+def test_slow_model_blocks_past_client_timeout_on_provider_routes(path, body):
+    base: Final = ensure_fake_openai_endpoint()
+    with pytest.raises(httpx.TimeoutException):
+        httpx.post(f"{base}{path}", json=body, timeout=0.5)
+
+
+def test_azure_deployment_route_answers_as_the_path_deployment():
+    base: Final = ensure_fake_openai_endpoint()
+    response: Final = httpx.post(
+        f"{base}/openai/deployments/my-deployment/chat/completions", json=_CHAT_BODY, timeout=10
+    )
+    assert response.status_code == 200
+    assert response.json()["model"] == "my-deployment"
+    assert response.json()["choices"][0]["message"]["content"]
+
+
+def test_azure_deployment_embeddings_route_shape():
+    base: Final = ensure_fake_openai_endpoint()
+    response: Final = httpx.post(
+        f"{base}/openai/deployments/my-embedding/embeddings", json={"input": ["a", "b"]}, timeout=10
+    )
+    assert response.status_code == 200
+    assert response.json()["model"] == "my-embedding"
+    assert len(response.json()["data"]) == 2
+
+
+def test_anthropic_messages_route_shape():
+    base: Final = ensure_fake_openai_endpoint()
+    response: Final = httpx.post(f"{base}/v1/messages", json=_CHAT_BODY | {"model": "claude-x"}, timeout=10)
+    assert response.status_code == 200
+    body: Final = response.json()
+    assert body["type"] == "message"
+    assert body["model"] == "claude-x"
+    assert body["content"][0]["text"]
+    assert body["usage"] == {"input_tokens": 20, "output_tokens": 20}
+
+
+def test_anthropic_messages_route_streams_a_complete_message():
+    base: Final = ensure_fake_openai_endpoint()
+    response: Final = httpx.post(
+        f"{base}/v1/messages", json=_CHAT_BODY | {"model": "claude-x", "stream": True}, timeout=10
+    )
+    assert response.status_code == 200
+    events: Final = re.findall(r"^event: (\S+)$", response.text, flags=re.MULTILINE)
+    assert events[0] == "message_start"
+    assert events[-1] == "message_stop"
+    assert "content_block_delta" in events
+
+
+def test_bedrock_converse_route_shape():
+    base: Final = ensure_fake_openai_endpoint()
+    response: Final = httpx.post(
+        f"{base}/model/anthropic.claude-haiku-4-5-20251001-v1:0/converse", json=_CHAT_BODY, timeout=10
+    )
+    assert response.status_code == 200
+    body: Final = response.json()
+    assert body["output"]["message"]["content"][0]["text"]
+    assert body["stopReason"] == "end_turn"
+    assert body["usage"]["totalTokens"] == 40
+
+
 def test_remote_env_base_resolves_to_local(monkeypatch):
     monkeypatch.setenv(
         "FAKE_OPENAI_API_BASE",

--- a/tests/local_testing/test_timeout.py
+++ b/tests/local_testing/test_timeout.py
@@ -1,11 +1,7 @@
 #### What this tests ####
 #    This tests the timeout decorator
 
-import os
-import traceback
-
-import time
-from litellm._uuid import uuid
+from typing import Final
 
 import httpx
 import openai
@@ -13,6 +9,32 @@ import pytest
 
 import litellm
 from tests.fake_openai_endpoint import FAKE_OPENAI_API_BASE
+
+_ESSAY_MESSAGES: Final = [{"role": "user", "content": "hello, write a 20 pg essay"}]
+_TIMEOUT_SECONDS: Final = 0.5
+
+
+def _slow_openai_deployment(model_name: str) -> dict:
+    return {
+        "model_name": model_name,
+        "litellm_params": {
+            "model": "openai/slow-endpoint",
+            "api_base": FAKE_OPENAI_API_BASE,
+            "api_key": "fake-key",
+        },
+    }
+
+
+def _slow_azure_deployment(model_name: str) -> dict:
+    return {
+        "model_name": model_name,
+        "litellm_params": {
+            "model": "azure/slow-endpoint",
+            "api_base": FAKE_OPENAI_API_BASE,
+            "api_key": "fake-key",
+            "api_version": "2024-10-21",
+        },
+    }
 
 
 @pytest.mark.parametrize(
@@ -45,201 +67,73 @@ async def test_httpx_timeout(model, provider, sync_mode):
 
 
 def test_timeout():
-    # this Will Raise a timeout
     litellm.set_verbose = False
-    try:
-        response = litellm.completion(
-            model="gpt-3.5-turbo",
-            timeout=0.01,
-            messages=[{"role": "user", "content": "hello, write a 20 pg essay"}],
+    with pytest.raises(openai.APITimeoutError):
+        litellm.completion(
+            model="openai/slow-endpoint",
+            messages=_ESSAY_MESSAGES,
+            api_base=FAKE_OPENAI_API_BASE,
+            api_key="fake-key",
+            timeout=_TIMEOUT_SECONDS,
         )
-    except openai.APITimeoutError as e:
-        print(
-            "Passed: Raised correct exception. Got openai.APITimeoutError\nGood Job", e
-        )
-        print(type(e))
-        pass
-    except Exception as e:
-        pytest.fail(
-            f"Did not raise error `openai.APITimeoutError`. Instead raised error type: {type(e)}, Error: {e}"
-        )
-
-
-# test_timeout()
 
 
 def test_bedrock_timeout():
-    # this Will Raise a timeout
     litellm.set_verbose = True
-    try:
-        response = litellm.completion(
-            model="bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
-            timeout=0.01,
-            messages=[{"role": "user", "content": "hello, write a 20 pg essay"}],
-        )
-        pytest.fail("Did not raise error `openai.APITimeoutError`")
-    except openai.APITimeoutError as e:
-        print(
-            "Passed: Raised correct exception. Got openai.APITimeoutError\nGood Job", e
-        )
-        print(type(e))
-        pass
-    except Exception as e:
-        pytest.fail(
-            f"Did not raise error `openai.APITimeoutError`. Instead raised error type: {type(e)}, Error: {e}"
+    with pytest.raises(openai.APITimeoutError):
+        litellm.completion(
+            model="bedrock/converse/slow-endpoint",
+            messages=_ESSAY_MESSAGES,
+            api_base=FAKE_OPENAI_API_BASE,
+            aws_access_key_id="fake-access-key",
+            aws_secret_access_key="fake-secret-key",
+            aws_region_name="us-east-1",
+            timeout=_TIMEOUT_SECONDS,
         )
 
 
-def test_hanging_request_azure():
-    """
-    Test that a slow Azure request properly raises APITimeoutError via the Router.
-
-    Uses a mock to simulate a slow HTTP response so the timeout fires reliably,
-    rather than racing against real network latency.
-    """
+@pytest.mark.asyncio
+async def test_hanging_request_azure():
     litellm.set_verbose = True
-    import asyncio
-    from unittest.mock import AsyncMock, patch
-
-    try:
-        router = litellm.Router(
-            model_list=[
-                {
-                    "model_name": "azure-gpt",
-                    "litellm_params": {
-                        "model": "azure/gpt-4.1-mini",
-                        "api_base": os.environ["AZURE_AI_API_BASE"],
-                        "api_key": os.environ["AZURE_AI_API_KEY"],
-                    },
-                },
-                {
-                    "model_name": "openai-gpt",
-                    "litellm_params": {"model": "gpt-3.5-turbo"},
-                },
-            ],
-            num_retries=0,
+    router = litellm.Router(
+        model_list=[_slow_azure_deployment("azure-gpt"), _slow_openai_deployment("openai-gpt")],
+        num_retries=0,
+    )
+    with pytest.raises(openai.APITimeoutError):
+        await router.acompletion(
+            model="azure-gpt",
+            messages=[{"role": "user", "content": "what color is red"}],
+            timeout=_TIMEOUT_SECONDS,
         )
-
-        encoded = litellm.utils.encode(model="gpt-3.5-turbo", text="blue")[0]
-
-        original_send = httpx.AsyncClient.send
-
-        async def _slow_send(self, request, *args, **kwargs):
-            await asyncio.sleep(5)
-            return await original_send(self, request, *args, **kwargs)
-
-        async def _test():
-            with patch.object(httpx.AsyncClient, "send", new=_slow_send):
-                response = await router.acompletion(
-                    model="azure-gpt",
-                    messages=[
-                        {
-                            "role": "user",
-                            "content": f"what color is red {uuid.uuid4()}",
-                        }
-                    ],
-                    logit_bias={encoded: 100},
-                    timeout=0.01,
-                )
-                print(response)
-                return response
-
-        response = asyncio.run(_test())
-
-        if response.choices[0].message.content is not None:
-            pytest.fail("Got a response, expected a timeout")
-    except openai.APITimeoutError as e:
-        print(
-            "Passed: Raised correct exception. Got openai.APITimeoutError\nGood Job", e
-        )
-        print(type(e))
-        pass
-    except Exception as e:
-        pytest.fail(
-            f"Did not raise error `openai.APITimeoutError`. Instead raised error type: {type(e)}, Error: {e}"
-        )
-
-
-# test_hanging_request_azure()
 
 
 def test_hanging_request_openai():
     litellm.set_verbose = True
-    try:
-        router = litellm.Router(
-            model_list=[
-                {
-                    "model_name": "azure-gpt",
-                    "litellm_params": {
-                        "model": "azure/gpt-4.1-mini",
-                        "api_base": os.environ["AZURE_AI_API_BASE"],
-                        "api_key": os.environ["AZURE_AI_API_KEY"],
-                    },
-                },
-                {
-                    "model_name": "openai-gpt",
-                    "litellm_params": {"model": "gpt-3.5-turbo"},
-                },
-            ],
-            num_retries=0,
-        )
-
-        encoded = litellm.utils.encode(model="gpt-3.5-turbo", text="blue")[0]
-        response = router.completion(
+    router = litellm.Router(
+        model_list=[_slow_azure_deployment("azure-gpt"), _slow_openai_deployment("openai-gpt")],
+        num_retries=0,
+    )
+    with pytest.raises(openai.APITimeoutError):
+        router.completion(
             model="openai-gpt",
             messages=[{"role": "user", "content": "what color is red"}],
-            logit_bias={encoded: 100},
-            timeout=0.01,
+            timeout=_TIMEOUT_SECONDS,
         )
-        print(response)
-
-        if response.choices[0].message.content is not None:
-            pytest.fail("Got a response, expected a timeout")
-    except openai.APITimeoutError as e:
-        print(
-            "Passed: Raised correct exception. Got openai.APITimeoutError\nGood Job", e
-        )
-        print(type(e))
-        pass
-    except Exception as e:
-        pytest.fail(
-            f"Did not raise error `openai.APITimeoutError`. Instead raised error type: {type(e)}, Error: {e}"
-        )
-
-
-# test_hanging_request_openai()
-
-# test_timeout()
 
 
 def test_timeout_streaming():
-    # this Will Raise a timeout
     litellm.set_verbose = False
-    try:
+    with pytest.raises(openai.APITimeoutError):
         response = litellm.completion(
             model="openai/slow-endpoint",
-            messages=[{"role": "user", "content": "hello, write a 20 pg essay"}],
+            messages=_ESSAY_MESSAGES,
             api_base=FAKE_OPENAI_API_BASE,
             api_key="fake-key",
-            timeout=0.5,
+            timeout=_TIMEOUT_SECONDS,
             stream=True,
         )
         for chunk in response:
             print(chunk)
-        pytest.fail("Did not raise error `openai.APITimeoutError`. The stream completed instead")
-    except openai.APITimeoutError as e:
-        print(
-            "Passed: Raised correct exception. Got openai.APITimeoutError\nGood Job", e
-        )
-        print(type(e))
-        pass
-    except Exception as e:
-        pytest.fail(
-            f"Did not raise error `openai.APITimeoutError`. Instead raised error type: {type(e)}, Error: {e}"
-        )
-
-
-# test_timeout_streaming()
 
 
 @pytest.mark.skip(reason="local test")
@@ -273,32 +167,22 @@ def test_timeout_ollama():
 @pytest.mark.asyncio
 async def test_anthropic_timeout(streaming, sync_mode):
     litellm.set_verbose = False
-
-    try:
+    request: Final = {
+        "model": "anthropic/slow-endpoint",
+        "messages": _ESSAY_MESSAGES,
+        "api_base": FAKE_OPENAI_API_BASE,
+        "api_key": "fake-key",
+        "timeout": _TIMEOUT_SECONDS,
+        "stream": streaming,
+    }
+    with pytest.raises(openai.APITimeoutError):
         if sync_mode:
-            response = litellm.completion(
-                model="claude-sonnet-4-5-20250929",
-                timeout=0.01,
-                messages=[{"role": "user", "content": "hello, write a 20 pg essay"}],
-                stream=streaming,
-            )
+            response = litellm.completion(**request)
             if isinstance(response, litellm.CustomStreamWrapper):
-                for chunk in response:
+                for _ in response:
                     pass
         else:
-            response = await litellm.acompletion(
-                model="claude-sonnet-4-5-20250929",
-                timeout=0.01,
-                messages=[{"role": "user", "content": "hello, write a 20 pg essay"}],
-                stream=streaming,
-            )
+            response = await litellm.acompletion(**request)
             if isinstance(response, litellm.CustomStreamWrapper):
-                async for chunk in response:
+                async for _ in response:
                     pass
-        pytest.fail("Did not raise error `openai.APITimeoutError`")
-    except openai.APITimeoutError as e:
-        print(
-            "Passed: Raised correct exception. Got openai.APITimeoutError\nGood Job", e
-        )
-        print(type(e))
-        pass

--- a/tests/local_testing/test_timeout.py
+++ b/tests/local_testing/test_timeout.py
@@ -8,13 +8,14 @@ import openai
 import pytest
 
 import litellm
+from litellm.types.router import DeploymentTypedDict
 from tests.fake_openai_endpoint import FAKE_OPENAI_API_BASE
 
 _ESSAY_MESSAGES: Final = [{"role": "user", "content": "hello, write a 20 pg essay"}]
 _TIMEOUT_SECONDS: Final = 0.5
 
 
-def _slow_openai_deployment(model_name: str) -> dict:
+def _slow_openai_deployment(model_name: str) -> DeploymentTypedDict:
     return {
         "model_name": model_name,
         "litellm_params": {
@@ -25,7 +26,7 @@ def _slow_openai_deployment(model_name: str) -> dict:
     }
 
 
-def _slow_azure_deployment(model_name: str) -> dict:
+def _slow_azure_deployment(model_name: str) -> DeploymentTypedDict:
     return {
         "model_name": model_name,
         "litellm_params": {
@@ -124,16 +125,16 @@ def test_hanging_request_openai():
 def test_timeout_streaming():
     litellm.set_verbose = False
     with pytest.raises(openai.APITimeoutError):
-        response = litellm.completion(
-            model="openai/slow-endpoint",
-            messages=_ESSAY_MESSAGES,
-            api_base=FAKE_OPENAI_API_BASE,
-            api_key="fake-key",
-            timeout=_TIMEOUT_SECONDS,
-            stream=True,
+        tuple(
+            litellm.completion(
+                model="openai/slow-endpoint",
+                messages=_ESSAY_MESSAGES,
+                api_base=FAKE_OPENAI_API_BASE,
+                api_key="fake-key",
+                timeout=_TIMEOUT_SECONDS,
+                stream=True,
+            )
         )
-        for chunk in response:
-            print(chunk)
 
 
 @pytest.mark.skip(reason="local test")
@@ -162,6 +163,12 @@ def test_timeout_ollama():
 # test_timeout_ollama()
 
 
+async def _consume_async_response(response: litellm.ModelResponse | litellm.CustomStreamWrapper) -> None:
+    if isinstance(response, litellm.CustomStreamWrapper):
+        async for _ in response:
+            pass
+
+
 @pytest.mark.parametrize("streaming", [True, False])
 @pytest.mark.parametrize("sync_mode", [True, False])
 @pytest.mark.asyncio
@@ -175,14 +182,9 @@ async def test_anthropic_timeout(streaming, sync_mode):
         "timeout": _TIMEOUT_SECONDS,
         "stream": streaming,
     }
-    with pytest.raises(openai.APITimeoutError):
-        if sync_mode:
-            response = litellm.completion(**request)
-            if isinstance(response, litellm.CustomStreamWrapper):
-                for _ in response:
-                    pass
-        else:
-            response = await litellm.acompletion(**request)
-            if isinstance(response, litellm.CustomStreamWrapper):
-                async for _ in response:
-                    pass
+    if sync_mode:
+        with pytest.raises(openai.APITimeoutError):
+            tuple(litellm.completion(**request))
+    else:
+        with pytest.raises(openai.APITimeoutError):
+            await _consume_async_response(await litellm.acompletion(**request))

--- a/tests/test_litellm/llms/custom_httpx/test_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_http_handler.py
@@ -6,6 +6,7 @@ import pathlib
 import ssl
 import threading
 import weakref
+from typing import Final
 from unittest.mock import MagicMock, patch
 
 import certifi
@@ -753,6 +754,23 @@ async def _read_http_request(reader: asyncio.StreamReader) -> None:
     )
     while len(body) < content_length:
         body += await reader.read(content_length - len(body))
+
+
+@pytest.mark.asyncio
+async def test_async_handler_leaves_injected_client_lifecycle_to_caller():
+    def respond(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text="ok", request=request)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(respond)) as client:
+        handler: Final = AsyncHTTPHandler(client=client)
+        response: Final = await handler.post("https://transport.test/v1/compress", json={"messages": []})
+        assert response.status_code == 200
+        assert response.text == "ok"
+        await handler.close()
+        assert not client.is_closed
+
+    assert client.is_closed
+    assert handler.client is client
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -5,11 +5,13 @@ import contextlib
 import copy
 import json
 import os
-from collections.abc import Mapping
+from collections.abc import Awaitable, Callable, Mapping
+from types import MappingProxyType
 from dataclasses import dataclass
 from typing import Final
 
 import httpx
+import openai
 import pytest
 import respx
 from fastapi.testclient import TestClient
@@ -20,6 +22,7 @@ from unittest.mock import MagicMock, patch
 
 import litellm
 from litellm import main as litellm_main
+from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler, HTTPHandler
 from litellm.integrations.custom_logger import CustomLogger
 from litellm.litellm_core_utils.core_helpers import get_litellm_metadata_from_kwargs
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLogging
@@ -3259,3 +3262,161 @@ def test_stream_chunk_builder_leaves_xai_reported_cost_to_the_calculator(monkeyp
     assert getattr(response.usage, "cost", None) == pytest.approx(0.42)
     assert response._hidden_params.get("response_cost") is None
     assert logging_obj._response_cost_calculator(result=response) == pytest.approx(0.63)
+
+
+_TRANSPORT_TIMEOUT_SECONDS: Final = 0.5
+_TRANSPORT_TIMEOUT_MESSAGES: Final = [{"role": "user", "content": "hello"}]
+_FAKE_AWS_PARAMS: Final = MappingProxyType(
+    {
+        "aws_access_key_id": "fake-access-key",
+        "aws_secret_access_key": "fake-secret-key",
+        "aws_region_name": "us-east-1",
+    }
+)
+
+
+def _timing_out_transport(seen_timeouts: list[object]) -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_timeouts.append(request.extensions.get("timeout"))
+        raise httpx.ReadTimeout("mock transport deadline", request=request)
+
+    return httpx.MockTransport(handler)
+
+
+def _assert_deadline_reached_transport(seen_timeouts: list[object]) -> None:
+    assert seen_timeouts, "the request never reached the transport"
+    read_timeouts: Final = [t["read"] for t in seen_timeouts if isinstance(t, dict)]
+    assert read_timeouts == [_TRANSPORT_TIMEOUT_SECONDS] * len(seen_timeouts)
+
+
+@dataclass(frozen=True, slots=True)
+class _TransportTimeoutCase:
+    name: str
+    model: str
+    make_client: Callable[[httpx.MockTransport], object]
+    extra_kwargs: Mapping[str, object] = MappingProxyType({})
+    stream: bool = False
+    embedding: bool = False
+
+
+def _openai_client(transport: httpx.MockTransport) -> openai.OpenAI:
+    return openai.OpenAI(api_key="sk-test", http_client=httpx.Client(transport=transport))
+
+
+def _azure_client(transport: httpx.MockTransport) -> openai.AzureOpenAI:
+    return openai.AzureOpenAI(
+        api_key="sk-test",
+        api_version="2024-10-21",
+        azure_endpoint="http://azure.invalid",
+        http_client=httpx.Client(transport=transport),
+    )
+
+
+def _http_handler(transport: httpx.MockTransport) -> HTTPHandler:
+    return HTTPHandler(client=httpx.Client(transport=transport))
+
+
+_SYNC_TRANSPORT_TIMEOUT_CASES: Final = (
+    _TransportTimeoutCase("openai", "openai/gpt-4.1-mini", _openai_client),
+    _TransportTimeoutCase("openai-stream", "openai/gpt-4.1-mini", _openai_client, stream=True),
+    _TransportTimeoutCase("openai-embedding", "openai/text-embedding-3-small", _openai_client, embedding=True),
+    _TransportTimeoutCase("azure", "azure/gpt-4.1-mini", _azure_client),
+    _TransportTimeoutCase("anthropic", "anthropic/claude-sonnet-4-5-20250929", _http_handler),
+    _TransportTimeoutCase("anthropic-stream", "anthropic/claude-sonnet-4-5-20250929", _http_handler, stream=True),
+    _TransportTimeoutCase(
+        "bedrock",
+        "bedrock/converse/anthropic.claude-haiku-4-5-20251001-v1:0",
+        _http_handler,
+        extra_kwargs=_FAKE_AWS_PARAMS,
+    ),
+)
+
+
+@pytest.mark.parametrize("case", _SYNC_TRANSPORT_TIMEOUT_CASES, ids=lambda case: case.name)
+def test_completion_timeout_reaches_the_transport_and_maps_to_timeout(case: _TransportTimeoutCase):
+    seen_timeouts: list[object] = []
+    client: Final = case.make_client(_timing_out_transport(seen_timeouts))
+    with pytest.raises(litellm.Timeout):
+        if case.embedding:
+            litellm.embedding(
+                model=case.model,
+                input="hello",
+                api_key="sk-test",
+                client=client,
+                timeout=_TRANSPORT_TIMEOUT_SECONDS,
+                max_retries=0,
+                **case.extra_kwargs,
+            )
+        else:
+            response = litellm.completion(
+                model=case.model,
+                messages=_TRANSPORT_TIMEOUT_MESSAGES,
+                api_key="sk-test",
+                client=client,
+                timeout=_TRANSPORT_TIMEOUT_SECONDS,
+                max_retries=0,
+                stream=case.stream,
+                **case.extra_kwargs,
+            )
+            if isinstance(response, litellm.CustomStreamWrapper):
+                for _ in response:
+                    pass
+    _assert_deadline_reached_transport(seen_timeouts)
+
+
+async def _async_openai_client(transport: httpx.MockTransport) -> openai.AsyncOpenAI:
+    return openai.AsyncOpenAI(api_key="sk-test", http_client=httpx.AsyncClient(transport=transport))
+
+
+async def _async_http_handler(transport: httpx.MockTransport) -> AsyncHTTPHandler:
+    handler: Final = AsyncHTTPHandler()
+    await handler.client.aclose()
+    handler.client = httpx.AsyncClient(transport=transport)
+    return handler
+
+
+@dataclass(frozen=True, slots=True)
+class _AsyncTransportTimeoutCase:
+    name: str
+    model: str
+    make_client: Callable[[httpx.MockTransport], Awaitable[object]]
+    extra_kwargs: Mapping[str, object] = MappingProxyType({})
+    stream: bool = False
+
+
+_ASYNC_TRANSPORT_TIMEOUT_CASES: Final = (
+    _AsyncTransportTimeoutCase("openai", "openai/gpt-4.1-mini", _async_openai_client),
+    _AsyncTransportTimeoutCase("openai-stream", "openai/gpt-4.1-mini", _async_openai_client, stream=True),
+    _AsyncTransportTimeoutCase("anthropic", "anthropic/claude-sonnet-4-5-20250929", _async_http_handler),
+    _AsyncTransportTimeoutCase(
+        "anthropic-stream", "anthropic/claude-sonnet-4-5-20250929", _async_http_handler, stream=True
+    ),
+    _AsyncTransportTimeoutCase(
+        "bedrock",
+        "bedrock/converse/anthropic.claude-haiku-4-5-20251001-v1:0",
+        _async_http_handler,
+        extra_kwargs=_FAKE_AWS_PARAMS,
+    ),
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("case", _ASYNC_TRANSPORT_TIMEOUT_CASES, ids=lambda case: case.name)
+async def test_acompletion_timeout_reaches_the_transport_and_maps_to_timeout(case: _AsyncTransportTimeoutCase):
+    seen_timeouts: list[object] = []
+    client: Final = await case.make_client(_timing_out_transport(seen_timeouts))
+    with pytest.raises(litellm.Timeout):
+        response = await litellm.acompletion(
+            model=case.model,
+            messages=_TRANSPORT_TIMEOUT_MESSAGES,
+            api_key="sk-test",
+            client=client,
+            timeout=_TRANSPORT_TIMEOUT_SECONDS,
+            max_retries=0,
+            stream=case.stream,
+            **case.extra_kwargs,
+        )
+        if isinstance(response, litellm.CustomStreamWrapper):
+            async for _ in response:
+                pass
+    _assert_deadline_reached_transport(seen_timeouts)

--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -3275,18 +3275,10 @@ _FAKE_AWS_PARAMS: Final = MappingProxyType(
 )
 
 
-def _timing_out_transport(seen_timeouts: list[object]) -> httpx.MockTransport:
-    def handler(request: httpx.Request) -> httpx.Response:
-        seen_timeouts.append(request.extensions.get("timeout"))
-        raise httpx.ReadTimeout("mock transport deadline", request=request)
-
-    return httpx.MockTransport(handler)
-
-
-def _assert_deadline_reached_transport(seen_timeouts: list[object]) -> None:
-    assert seen_timeouts, "the request never reached the transport"
-    read_timeouts: Final = [t["read"] for t in seen_timeouts if isinstance(t, dict)]
-    assert read_timeouts == [_TRANSPORT_TIMEOUT_SECONDS] * len(seen_timeouts)
+def _assert_deadline_and_timeout(request: httpx.Request) -> httpx.Response:
+    timeout: Final = request.extensions.get("timeout")
+    assert isinstance(timeout, dict) and timeout.get("read") == _TRANSPORT_TIMEOUT_SECONDS
+    raise httpx.ReadTimeout("mock transport deadline", request=request)
 
 
 @dataclass(frozen=True, slots=True)
@@ -3334,8 +3326,8 @@ _SYNC_TRANSPORT_TIMEOUT_CASES: Final = (
 
 @pytest.mark.parametrize("case", _SYNC_TRANSPORT_TIMEOUT_CASES, ids=lambda case: case.name)
 def test_completion_timeout_reaches_the_transport_and_maps_to_timeout(case: _TransportTimeoutCase):
-    seen_timeouts: list[object] = []
-    client: Final = case.make_client(_timing_out_transport(seen_timeouts))
+    handler: Final = MagicMock(side_effect=_assert_deadline_and_timeout)
+    client: Final = case.make_client(httpx.MockTransport(handler))
     if case.embedding:
         with pytest.raises(litellm.Timeout):
             litellm.embedding(
@@ -3361,7 +3353,7 @@ def test_completion_timeout_reaches_the_transport_and_maps_to_timeout(case: _Tra
                     **case.extra_kwargs,
                 )
             )
-    _assert_deadline_reached_transport(seen_timeouts)
+    handler.assert_called()
 
 
 async def _async_openai_client(transport: httpx.MockTransport) -> openai.AsyncOpenAI:
@@ -3369,10 +3361,7 @@ async def _async_openai_client(transport: httpx.MockTransport) -> openai.AsyncOp
 
 
 async def _async_http_handler(transport: httpx.MockTransport) -> AsyncHTTPHandler:
-    handler: Final = AsyncHTTPHandler()
-    await handler.client.aclose()
-    handler.client = httpx.AsyncClient(transport=transport)
-    return handler
+    return AsyncHTTPHandler(client=httpx.AsyncClient(transport=transport))
 
 
 @dataclass(frozen=True, slots=True)
@@ -3409,8 +3398,8 @@ async def _consume_async_timeout_response(response: litellm.ModelResponse | lite
 @pytest.mark.asyncio
 @pytest.mark.parametrize("case", _ASYNC_TRANSPORT_TIMEOUT_CASES, ids=lambda case: case.name)
 async def test_acompletion_timeout_reaches_the_transport_and_maps_to_timeout(case: _AsyncTransportTimeoutCase):
-    seen_timeouts: list[object] = []
-    client: Final = await case.make_client(_timing_out_transport(seen_timeouts))
+    handler: Final = MagicMock(side_effect=_assert_deadline_and_timeout)
+    client: Final = await case.make_client(httpx.MockTransport(handler))
     with pytest.raises(litellm.Timeout):
         await _consume_async_timeout_response(
             await litellm.acompletion(
@@ -3424,4 +3413,4 @@ async def test_acompletion_timeout_reaches_the_transport_and_maps_to_timeout(cas
                 **case.extra_kwargs,
             )
         )
-    _assert_deadline_reached_transport(seen_timeouts)
+    handler.assert_called()

--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -3336,8 +3336,8 @@ _SYNC_TRANSPORT_TIMEOUT_CASES: Final = (
 def test_completion_timeout_reaches_the_transport_and_maps_to_timeout(case: _TransportTimeoutCase):
     seen_timeouts: list[object] = []
     client: Final = case.make_client(_timing_out_transport(seen_timeouts))
-    with pytest.raises(litellm.Timeout):
-        if case.embedding:
+    if case.embedding:
+        with pytest.raises(litellm.Timeout):
             litellm.embedding(
                 model=case.model,
                 input="hello",
@@ -3347,20 +3347,20 @@ def test_completion_timeout_reaches_the_transport_and_maps_to_timeout(case: _Tra
                 max_retries=0,
                 **case.extra_kwargs,
             )
-        else:
-            response = litellm.completion(
-                model=case.model,
-                messages=_TRANSPORT_TIMEOUT_MESSAGES,
-                api_key="sk-test",
-                client=client,
-                timeout=_TRANSPORT_TIMEOUT_SECONDS,
-                max_retries=0,
-                stream=case.stream,
-                **case.extra_kwargs,
+    else:
+        with pytest.raises(litellm.Timeout):
+            tuple(
+                litellm.completion(
+                    model=case.model,
+                    messages=_TRANSPORT_TIMEOUT_MESSAGES,
+                    api_key="sk-test",
+                    client=client,
+                    timeout=_TRANSPORT_TIMEOUT_SECONDS,
+                    max_retries=0,
+                    stream=case.stream,
+                    **case.extra_kwargs,
+                )
             )
-            if isinstance(response, litellm.CustomStreamWrapper):
-                for _ in response:
-                    pass
     _assert_deadline_reached_transport(seen_timeouts)
 
 
@@ -3400,23 +3400,28 @@ _ASYNC_TRANSPORT_TIMEOUT_CASES: Final = (
 )
 
 
+async def _consume_async_timeout_response(response: litellm.ModelResponse | litellm.CustomStreamWrapper) -> None:
+    if isinstance(response, litellm.CustomStreamWrapper):
+        async for _ in response:
+            pass
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("case", _ASYNC_TRANSPORT_TIMEOUT_CASES, ids=lambda case: case.name)
 async def test_acompletion_timeout_reaches_the_transport_and_maps_to_timeout(case: _AsyncTransportTimeoutCase):
     seen_timeouts: list[object] = []
     client: Final = await case.make_client(_timing_out_transport(seen_timeouts))
     with pytest.raises(litellm.Timeout):
-        response = await litellm.acompletion(
-            model=case.model,
-            messages=_TRANSPORT_TIMEOUT_MESSAGES,
-            api_key="sk-test",
-            client=client,
-            timeout=_TRANSPORT_TIMEOUT_SECONDS,
-            max_retries=0,
-            stream=case.stream,
-            **case.extra_kwargs,
+        await _consume_async_timeout_response(
+            await litellm.acompletion(
+                model=case.model,
+                messages=_TRANSPORT_TIMEOUT_MESSAGES,
+                api_key="sk-test",
+                client=client,
+                timeout=_TRANSPORT_TIMEOUT_SECONDS,
+                max_retries=0,
+                stream=case.stream,
+                **case.extra_kwargs,
+            )
         )
-        if isinstance(response, litellm.CustomStreamWrapper):
-            async for _ in response:
-                pass
     _assert_deadline_reached_transport(seen_timeouts)


### PR DESCRIPTION
## TLDR

Problem this solves:

- Five timeout tests still raced real providers with 10us to 10ms deadlines
- Whether they passed depended on DNS ordering, not on litellm
- test_hanging_request_azure monkeypatched httpx.AsyncClient.send
- No test pinned that the caller's timeout actually reaches the transport
- Bedrock dropped the per-call timeout when the caller injected a client

How it solves it:

- Fake endpoint server now serves Azure, Anthropic and Bedrock URL shapes
- slow-endpoint sleeps on every route, so timeouts fire deterministically
- The five tests point api_base at the fake server with a 0.5s deadline
- MockTransport unit tests assert the deadline reaches httpx for four providers
- Bedrock converse passes timeout on the post call for injected clients

## User Flow

Before: a developer who passes their own HTTP client to a Bedrock call gets no timeout

1. They call `litellm.completion(model="bedrock/converse/...", client=HTTPHandler(client=httpx.Client()), timeout=0.5, ...)`
2. The request keeps waiting past 0.5s and comes back whenever the model answers, 3s later against the fake server, up to the injected client's own default against a real one
3. Their retry and fallback logic never sees the Timeout it was written for

After: the same call honors the deadline

1. They call `litellm.completion(model="bedrock/converse/...", client=HTTPHandler(client=httpx.Client()), timeout=0.5, ...)`
2. After 0.5s the call raises `litellm.Timeout: Connection timed out after 0.5 seconds.`
3. Their retry and fallback logic sees the Timeout and reroutes

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 5/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Setup: the merge base's `tests/_fake_openai_endpoint_server.py` runs on `:8192` and this PR's copy on `:8193`, both started with `python tests/_fake_openai_endpoint_server.py --host 127.0.0.1 --port <port>`. The Bedrock case runs this script against the PR's server on both sides, swapping only `litellm/llms/bedrock/chat/converse_handler.py`

```python
import time, httpx, litellm
from litellm.llms.custom_httpx.http_handler import HTTPHandler
start = time.monotonic()
try:
    r = litellm.completion(
        model="bedrock/converse/slow-endpoint", messages=[{"role": "user", "content": "hi"}],
        api_base="http://127.0.0.1:8193", aws_access_key_id="fake", aws_secret_access_key="fake", aws_region_name="us-east-1",
        client=HTTPHandler(client=httpx.Client()), timeout=0.5,
    )
    print(f"returned after {time.monotonic() - start:.1f}s: {r.choices[0].message.content!r}")
except litellm.Timeout as e:
    print(f"litellm.Timeout after {time.monotonic() - start:.1f}s: {e}")
```

### Before (4b1e24eae9)

#### Provider routes on the fake endpoint server

1. `curl -s -w " [%{http_code}]" -X POST http://127.0.0.1:8192/openai/deployments/my-deployment/chat/completions -H "Content-Type: application/json" -d '{"messages":[{"role":"user","content":"hi"}]}'`
2. `Not Found [404]`
3. `curl -s -w " [%{http_code}]" -X POST http://127.0.0.1:8192/v1/messages -H "Content-Type: application/json" -d '{"model":"claude-x","messages":[{"role":"user","content":"hi"}],"max_tokens":5}'`
4. `Not Found [404]`
5. `curl -s -w " [%{http_code}]" -X POST http://127.0.0.1:8192/model/anthropic.claude-haiku-4-5-20251001-v1:0/converse -H "Content-Type: application/json" -d '{"messages":[{"role":"user","content":"hi"}]}'`
6. `Not Found [404]`

#### Bedrock timeout with an injected client

1. `python bedrock_injected_timeout.py`
2. `returned after 3.1s: 'Hello! This is a mock response from the fake OpenAI endpoint.'`

### After (ea8cb33d64)

#### Provider routes on the fake endpoint server

1. `curl -s -w " [%{http_code}]" -X POST http://127.0.0.1:8193/openai/deployments/my-deployment/chat/completions -H "Content-Type: application/json" -d '{"messages":[{"role":"user","content":"hi"}]}'`
2. `{"id":"chatcmpl-422bbacedc6d4264abedfbc2","object":"chat.completion","created":1788460567,"model":"my-deployment","choices":[{"index":0,"message":{"role":"assistant","content":"Hello! This is a mock r... [200]`
3. `curl -s -w " [%{http_code}]" -X POST http://127.0.0.1:8193/v1/messages -H "Content-Type: application/json" -d '{"model":"claude-x","messages":[{"role":"user","content":"hi"}],"max_tokens":5}'`
4. `{"id":"msg_13a5e5f182dc4acf96193965","type":"message","role":"assistant","model":"claude-x","content":[{"type":"text","text":"Hello! This is a mock response from the fake OpenAI endpoint."}],"stop_rea... [200]`
5. `curl -s -w " [%{http_code}]" -X POST http://127.0.0.1:8193/model/anthropic.claude-haiku-4-5-20251001-v1:0/converse -H "Content-Type: application/json" -d '{"messages":[{"role":"user","content":"hi"}]}'`
6. `{"output":{"message":{"role":"assistant","content":[{"text":"Hello! This is a mock response from the fake OpenAI endpoint."}]}},"stopReason":"end_turn","usage":{"inputTokens":20,"outputTokens":20,"tot... [200]`
7. `curl -s --max-time 0.5 -X POST http://127.0.0.1:8193/openai/deployments/slow-endpoint/chat/completions -H "Content-Type: application/json" -d '{"messages":[{"role":"user","content":"hi"}]}'; echo "exit=$?"`
8. `exit=28`
9. `curl -s --max-time 0.5 -X POST http://127.0.0.1:8193/v1/messages -H "Content-Type: application/json" -d '{"model":"slow-endpoint","messages":[{"role":"user","content":"hi"}],"max_tokens":5}'; echo "exit=$?"`
10. `exit=28`
11. `curl -s --max-time 0.5 -X POST http://127.0.0.1:8193/model/slow-endpoint/converse -H "Content-Type: application/json" -d '{"messages":[{"role":"user","content":"hi"}]}'; echo "exit=$?"`
12. `exit=28`

#### Bedrock timeout with an injected client

1. `python bedrock_injected_timeout.py`
2. `litellm.Timeout after 0.5s: litellm.Timeout: Connection timed out after 0.5 seconds.`

## Type

🐛 Bug Fix
✅ Test

## Caveats (if any)

### Medium

- Bedrock converse streaming with an injected client still uses that client's default timeout: `make_call` and `make_sync_call` take no timeout

### Low

- The fake server does not serve `converse-stream` (AWS binary event stream), so no Bedrock streaming timeout test moved over
- `tests/e2e/router/reliability_support.py` still gives its timeout deployments a 1ms deadline against the real provider; that harness runs its own stack and is out of scope here

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR



## Current validation

Head: `c651e8b4c600b27b5f10b86d66554c4300c88c73`

The timeout and HTTP handler suite passed 84 tests, including injected async-client ownership. Removing the two Bedrock timeout-forwarding arguments made exactly the sync and async Bedrock regression cases fail; the other ten transport cases passed. The production code was restored after this mutation check. Repository checks passed

The async HTTP handler now accepts an optional caller-owned client, matching the existing sync handler injection behavior. Greptile independently posted 5/5 at this head. [Buildkite #10703](https://buildkite.com/berriai-1/e2e-tests/builds/10703) passed; its gate selected no E2E suites for these unit-test changes. Earlier CI links and proof are historical, not validation of this head
