### PR TITLE
test(bedrock): drop EOL cohere.command-r-plus-v1:0 from local_testing

### DIFF
--- a/tests/local_testing/test_completion.py
+++ b/tests/local_testing/test_completion.py
@@ -2879,7 +2879,6 @@ def response_format_tests(response: litellm.ModelResponse):
     "model",
     [
         "bedrock/mistral.mistral-large-2407-v1:0",
-        "bedrock/cohere.command-r-plus-v1:0",
         "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
         "mistral.mistral-7b-instruct-v0:2",
         "meta.llama3-8b-instruct-v1:0",

--- a/tests/local_testing/test_streaming.py
+++ b/tests/local_testing/test_streaming.py
@@ -1168,7 +1168,6 @@ async def test_completion_replicate_llama3_streaming(sync_mode):
     "model, region",
     [
         # ["bedrock/ai21.jamba-instruct-v1:0", "us-east-1"],
-        # ["bedrock/cohere.command-r-plus-v1:0", None],
         ["us.anthropic.claude-sonnet-4-5-20250929-v1:0", None],
         # ["mistral.mistral-7b-instruct-v0:2", None],
         # ["meta.llama3-8b-instruct-v1:0", None],
@@ -1271,7 +1270,7 @@ def test_bedrock_claude_3_streaming():
     "model",
     [
         "claude-haiku-4-5-20251001",
-        "cohere.command-r-plus-v1:0",  # bedrock
+        "bedrock/mistral.mistral-7b-instruct-v0:2",
         "gpt-3.5-turbo",
     ],
 )


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bedrock retired `cohere.command-r-plus-v1:0` on 2026-08-19 (end of life)
- Three `local_testing` cases still pin it, so CircleCI is red on plain staging
- Bedrock lists no Cohere command chat model anymore, so nothing to swap to

How it solves it:

- Drops the Cohere case from `test_completion_bedrock_httpx_models`
- Swaps the parallel-streaming Bedrock entry to `mistral.mistral-7b-instruct-v0:2` (invoke route, ACTIVE)
- Removes the already-commented Cohere line in `test_bedrock_httpx_streaming`

## User Flow

Before: a maintainer pushes a green-looking change and CircleCI turns red on three Bedrock Cohere cases that no longer exist upstream

1. They push a commit to a `litellm_*` branch with the `run-ci` label and open the CircleCI workflow
2. `local_testing_part1` runs `test_completion_bedrock_httpx_models[True-bedrock/cohere.command-r-plus-v1:0]` and `[False-...]`, which send POST https://bedrock-runtime.us-west-2.amazonaws.com/model/cohere.command-r-plus-v1:0/invoke
3. Bedrock answers HTTP 404 `{"message":"This model version has reached the end of its life. Please refer to the AWS documentation for more details."}`, so both cases fail with `litellm.NotFoundError: BedrockException - ...`
4. `local_testing_part2` runs `test_parallel_streaming_requests[cohere.command-r-plus-v1:0-False]`, hits the same endpoint, and fails the same way
5. The maintainer has to read the failure list to tell these three from real regressions on every pipeline

After: the same push runs both jobs green because the suites only call Bedrock models Bedrock still serves

1. They push a commit to a `litellm_*` branch with the `run-ci` label and open the CircleCI workflow
2. `local_testing_part1` runs `test_completion_bedrock_httpx_models` over Mistral Large, Claude Sonnet 4.5, Mistral 7B, and Llama 3 8B, each answering HTTP 200 with a chat completion
3. `local_testing_part2` runs `test_parallel_streaming_requests[bedrock/mistral.mistral-7b-instruct-v0:2-...]`, which sends POST https://bedrock-runtime.us-west-2.amazonaws.com/model/mistral.mistral-7b-instruct-v0:2/invoke-with-response-stream and streams tokens back inside the test's 10s budget
4. Both jobs finish green, so a red job again means a real regression

## Relevant issues

## Linear ticket

Resolves LIT-6876

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Auth for every call below is the CI Bedrock account's bearer token (`AWS_BEARER_TOKEN_BEDROCK` in `.env`), region us-west-2, real Bedrock calls

### Before (4b1e24eae9)

#### CircleCI on plain staging (pipeline 2026-09-03 17:36Z)

1. `local_testing_part1` job 2153032: `tests/local_testing/test_completion.py::test_completion_bedrock_httpx_models[False-bedrock/cohere.command-r-plus-v1:0]` and `[True-bedrock/cohere.command-r-plus-v1:0]` FAILED
2. `local_testing_part2` job 2153031: `tests/local_testing/test_streaming.py::test_parallel_streaming_requests[cohere.command-r-plus-v1:0-False]` FAILED
3. All three with `litellm.NotFoundError: BedrockException - {"message":"This model version has reached the end of its life. Please refer to the AWS documentation for more details."}`

#### What Bedrock itself says about the pinned model

1. `curl -s -w '\nHTTP %{http_code}\n' -X POST https://bedrock-runtime.us-west-2.amazonaws.com/model/cohere.command-r-plus-v1:0/invoke -H "Authorization: Bearer $AWS_BEARER_TOKEN_BEDROCK" -H 'content-type: application/json' -d '{"message":"Hey! how'"'"'s it going?","max_tokens":20}'
2. Output: `{"message":"This model version has reached the end of its life. Please refer to the AWS documentation for more details."}` then `HTTP 404`
3. `aws bedrock list-foundation-models --by-provider cohere --region us-west-2` (same in us-east-1) lists only `cohere.embed-v4:0`, `cohere.embed-english-v3`, `cohere.embed-multilingual-v3`, and `cohere.rerank-v3-5:0`: no Cohere command chat model is left to swap to

### After (f87b9097ea)

#### The replacement model on the same endpoint shape

1. `curl -s -w '\nHTTP %{http_code}\n' -X POST https://bedrock-runtime.us-west-2.amazonaws.com/model/mistral.mistral-7b-instruct-v0:2/invoke -H "Authorization: Bearer $AWS_BEARER_TOKEN_BEDROCK" -H 'content-type: application/json' -d '{"prompt":"<s>[INST] Hey! how'"'"'s it going? [/INST]","max_tokens":20}'
2. Output: `{"outputs":[{"text":" Hello! I'm just a computer program, so I don't have feelings or the ability","stop_reason":"length"}]}` then `HTTP 200`
3. `aws bedrock list-foundation-models --region us-west-2` shows `mistral.mistral-7b-instruct-v0:2 ACTIVE ON_DEMAND` (as are `mistral.mistral-large-2407-v1:0`, `meta.llama3-8b-instruct-v1:0`, and the Claude 4.5 inference profiles the other cases use)

#### The two changed tests against real Bedrock

1. `AWS_CONFIG_FILE=/dev/null AWS_SHARED_CREDENTIALS_FILE=/dev/null .venv/bin/python -m pytest "tests/local_testing/test_completion.py::test_completion_bedrock_httpx_models" "tests/local_testing/test_streaming.py::test_parallel_streaming_requests" -p no:cacheprovider -q --timeout=300`
2. Output: `14 passed, 17 warnings in 23.77s` (8 completion cases across the four remaining Bedrock models, 6 parallel-streaming cases including `bedrock/mistral.mistral-7b-instruct-v0:2` sync and async)

#### CircleCI at this tip

1. [local_testing_part1, job 2153460](https://app.circleci.com/pipelines/github/BerriAI/litellm/89040/workflows/76f10252-e25a-4754-9324-ac640c9ea3b3/jobs/2153460): 695 passed, 74 skipped, 0 failed; all eight `test_completion_bedrock_httpx_models[...]` cases pass
2. [local_testing_part2, job 2153442](https://app.circleci.com/pipelines/github/BerriAI/litellm/89040/workflows/76f10252-e25a-4754-9324-ac640c9ea3b3/jobs/2153442): 211 passed, 26 skipped, 0 failed; both `test_parallel_streaming_requests[bedrock/mistral.mistral-7b-instruct-v0:2-*]` cases pass

## Type

✅ Test

## Caveats (if any)

### Low

- Bedrock's Cohere chat invoke transformation now has no live model to exercise; `test_transform_request_cohere_command` in `tests/llm_translation/test_unit_test_bedrock_invoke.py` still covers its request transform offline
- Both cost-map Cohere entries already carry `deprecation_date: 2026-08-19`, left as is
- The empty AWS config in the local pytest command works around LIT-6890, a separate converse-route bug

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to model IDs in local_testing; no production or library behavior is modified.
> 
> **Overview**
> Updates **local Bedrock integration tests** so CI no longer calls `cohere.command-r-plus-v1:0`, which Bedrock retired (404 end-of-life).
> 
> In `test_completion_bedrock_httpx_models`, the Cohere model is dropped from the parametrized model list; the suite still exercises Mistral Large, Claude Sonnet 4.5, Mistral 7B, and Llama 3 8B over the httpx invoke path.
> 
> In `test_streaming.py`, the commented Cohere case is removed from `test_bedrock_httpx_streaming`, and `test_parallel_streaming_requests` now uses **`bedrock/mistral.mistral-7b-instruct-v0:2`** instead of the bare Cohere id so parallel streaming still hits a live Bedrock model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f87b9097eaffdde471df332c323a1a59be9c2014. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

- [x] f87b9097ea passes /live-pr-risk
