### PR TITLE
fix(cost): bill bedrock_mantle web search at $12 per 1k queries using Bedrock's reported count

### DIFF
--- a/litellm/litellm_core_utils/llm_cost_calc/tool_call_cost_tracking.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/tool_call_cost_tracking.py
@@ -5,6 +5,8 @@ Helper utilities for tracking the cost of built-in tools.
 from collections.abc import Mapping
 from typing import Final, Literal
 
+from pydantic import ValidationError
+
 import litellm
 from litellm.constants import OPENAI_FILE_SEARCH_COST_PER_1K_CALLS
 from litellm.litellm_core_utils.llm_cost_calc.utils import (
@@ -13,6 +15,7 @@ from litellm.litellm_core_utils.llm_cost_calc.utils import (
 from litellm.types.llms.openai import (
     FileSearchTool,
     ResponsesAPIResponse,
+    ResponsesToolUsage,
     WebSearchOptions,
 )
 from litellm.types.utils import (
@@ -30,6 +33,17 @@ from litellm.types.utils import (
 def _output_item_type(output_item: object) -> str | None:
     item_type: Final = output_item.get("type") if isinstance(output_item, dict) else getattr(output_item, "type", None)
     return item_type if isinstance(item_type, str) else None
+
+
+def _reported_web_search_requests(response_object: ResponsesAPIResponse) -> int | None:
+    tool_usage: Final = getattr(response_object, "tool_usage", None)
+    if tool_usage is None:
+        return None
+    try:
+        web_search: Final = ResponsesToolUsage.model_validate(tool_usage).web_search
+    except ValidationError:
+        return None
+    return None if web_search is None else web_search.num_requests
 
 
 def _usage_reports_server_side_web_search_calls(usage: Usage) -> bool:
@@ -182,15 +196,19 @@ class StandardBuiltInToolCostTracking:
 
         Providers that report a request count in usage (gemini, anthropic, xai, vertex) are handled by
         get_cost_for_web_search_request and never reach here. This path prices per call, so it must count
-        the web_search_call items. Chat-completions responses only expose url_citation annotations with no
-        count, so they floor to a single billable search.
+        the web_search_call items, unless the response reports the billable count itself
+        (Bedrock's tool_usage.web_search.num_requests, which excludes open_page fetches). Chat-completions
+        responses only expose url_citation annotations with no count, so they floor to a single billable search.
         """
-        if isinstance(response_object, ResponsesAPIResponse):
-            count = sum(
-                1 for output_item in response_object.output if _output_item_type(output_item) == "web_search_call"
-            )
-            return max(count, 1)
-        return 1
+        if not isinstance(response_object, ResponsesAPIResponse):
+            return 1
+        reported: Final = _reported_web_search_requests(response_object)
+        if reported is not None:
+            return reported
+        count: Final = sum(
+            1 for output_item in response_object.output if _output_item_type(output_item) == "web_search_call"
+        )
+        return max(count, 1)
 
     @staticmethod
     def _handle_file_search_cost(

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -52911,6 +52911,11 @@
         "cache_read_input_token_cost_above_272k_tokens": 1.1e-06,
         "output_cost_per_token": 3.3e-05,
         "output_cost_per_token_above_272k_tokens": 4.95e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.012,
+            "search_context_size_low": 0.012,
+            "search_context_size_medium": 0.012
+        },
         "litellm_provider": "bedrock_mantle",
         "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
@@ -52945,6 +52950,11 @@
         "cache_read_input_token_cost_above_272k_tokens": 4.4e-07,
         "output_cost_per_token": 1.32e-05,
         "output_cost_per_token_above_272k_tokens": 1.98e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.012,
+            "search_context_size_low": 0.012,
+            "search_context_size_medium": 0.012
+        },
         "litellm_provider": "bedrock_mantle",
         "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
@@ -53007,6 +53017,11 @@
         "cache_read_input_token_cost_above_272k_tokens": 4.4e-08,
         "output_cost_per_token": 1.32e-06,
         "output_cost_per_token_above_272k_tokens": 1.98e-06,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.012,
+            "search_context_size_low": 0.012,
+            "search_context_size_medium": 0.012
+        },
         "litellm_provider": "bedrock_mantle",
         "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
@@ -53195,6 +53210,11 @@
         "cache_read_input_token_cost_above_272k_tokens": 1.1e-06,
         "output_cost_per_token": 3.3e-05,
         "output_cost_per_token_above_272k_tokens": 4.95e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.012,
+            "search_context_size_low": 0.012,
+            "search_context_size_medium": 0.012
+        },
         "litellm_provider": "bedrock_mantle",
         "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
@@ -53226,6 +53246,11 @@
         "cache_read_input_token_cost_above_272k_tokens": 5.5e-07,
         "output_cost_per_token": 1.65e-05,
         "output_cost_per_token_above_272k_tokens": 2.475e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.012,
+            "search_context_size_low": 0.012,
+            "search_context_size_medium": 0.012
+        },
         "litellm_provider": "bedrock_mantle",
         "max_input_tokens": 1050000,
         "max_output_tokens": 128000,

--- a/litellm/types/llms/openai.py
+++ b/litellm/types/llms/openai.py
@@ -66,6 +66,7 @@ from pydantic import (
     ConfigDict,
     Discriminator,
     Field,
+    NonNegativeInt,
     PrivateAttr,
     SerializerFunctionWrapHandler,
     field_serializer,
@@ -1319,6 +1320,18 @@ class ResponseAPIUsage(BaseLiteLLMOpenAIResponseObject):
         return v
 
     model_config = {"extra": "allow"}
+
+
+class WebSearchToolUsage(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    num_requests: NonNegativeInt
+
+
+class ResponsesToolUsage(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    web_search: WebSearchToolUsage | None = None
 
 
 ResponsesAPIStatus = Literal["completed", "failed", "in_progress", "cancelled", "queued", "incomplete"]

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -52911,6 +52911,11 @@
         "cache_read_input_token_cost_above_272k_tokens": 1.1e-06,
         "output_cost_per_token": 3.3e-05,
         "output_cost_per_token_above_272k_tokens": 4.95e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.012,
+            "search_context_size_low": 0.012,
+            "search_context_size_medium": 0.012
+        },
         "litellm_provider": "bedrock_mantle",
         "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
@@ -52945,6 +52950,11 @@
         "cache_read_input_token_cost_above_272k_tokens": 4.4e-07,
         "output_cost_per_token": 1.32e-05,
         "output_cost_per_token_above_272k_tokens": 1.98e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.012,
+            "search_context_size_low": 0.012,
+            "search_context_size_medium": 0.012
+        },
         "litellm_provider": "bedrock_mantle",
         "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
@@ -53007,6 +53017,11 @@
         "cache_read_input_token_cost_above_272k_tokens": 4.4e-08,
         "output_cost_per_token": 1.32e-06,
         "output_cost_per_token_above_272k_tokens": 1.98e-06,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.012,
+            "search_context_size_low": 0.012,
+            "search_context_size_medium": 0.012
+        },
         "litellm_provider": "bedrock_mantle",
         "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
@@ -53195,6 +53210,11 @@
         "cache_read_input_token_cost_above_272k_tokens": 1.1e-06,
         "output_cost_per_token": 3.3e-05,
         "output_cost_per_token_above_272k_tokens": 4.95e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.012,
+            "search_context_size_low": 0.012,
+            "search_context_size_medium": 0.012
+        },
         "litellm_provider": "bedrock_mantle",
         "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
@@ -53226,6 +53246,11 @@
         "cache_read_input_token_cost_above_272k_tokens": 5.5e-07,
         "output_cost_per_token": 1.65e-05,
         "output_cost_per_token_above_272k_tokens": 2.475e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.012,
+            "search_context_size_low": 0.012,
+            "search_context_size_medium": 0.012
+        },
         "litellm_provider": "bedrock_mantle",
         "max_input_tokens": 1050000,
         "max_output_tokens": 128000,

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_tool_call_cost_tracking.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_tool_call_cost_tracking.py
@@ -928,3 +928,121 @@ def test_web_search_gate_reads_server_side_tool_usage_details_without_citations(
         standard_built_in_tools_params=None,
     )
     assert cost == 3 * _DEFAULT_WEB_SEARCH_COST_PER_CALL
+
+
+_BEDROCK_MANTLE_WEB_SEARCH_MODELS = (
+    "bedrock_mantle/openai.gpt-5.6-sol",
+    "bedrock_mantle/openai.gpt-5.6-terra",
+    "bedrock_mantle/openai.gpt-5.6-luna",
+    "bedrock_mantle/openai.gpt-5.5",
+    "bedrock_mantle/openai.gpt-5.4",
+)
+
+_BEDROCK_MANTLE_WEB_SEARCH_RATE = 0.012
+
+
+def _bedrock_mantle_responses_with_web_search(model, actions, tool_usage=None):
+    from litellm.types.llms.openai import ResponsesAPIResponse
+
+    payload = {
+        "id": "resp_1",
+        "created_at": 1756900000,
+        "model": model.split("/", 1)[-1],
+        "object": "response",
+        "status": "completed",
+        "output": [
+            {"type": "web_search_call", "id": f"ws_{i}", "status": "completed", "action": action}
+            for i, action in enumerate(actions)
+        ],
+    }
+    return ResponsesAPIResponse.model_validate(
+        payload if tool_usage is None else {**payload, "tool_usage": tool_usage}
+    )
+
+
+def _bedrock_mantle_web_search_cost(model, response):
+    from litellm.types.utils import Usage
+
+    return StandardBuiltInToolCostTracking.get_cost_for_built_in_tools(
+        model=model,
+        response_object=response,
+        usage=Usage(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+        custom_llm_provider="bedrock_mantle",
+        standard_built_in_tools_params=None,
+    )
+
+
+@pytest.mark.parametrize("model", _BEDROCK_MANTLE_WEB_SEARCH_MODELS)
+def test_bedrock_mantle_web_search_billed_per_query(local_model_cost_map, model):
+    """
+    Regression for LIT-6870: the bedrock_mantle GPT ids forward the web_search tool but carried no
+    search_context_cost_per_query, so every Bedrock web search (billed at $12 per 1,000 queries)
+    was costed at $0. Two reported queries must bill 2 x $0.012, whichever model prefix shape the
+    cost path resolves the deployment under.
+    """
+    pricing = litellm.get_model_info(model)["search_context_cost_per_query"]
+    assert pricing == {
+        "search_context_size_low": _BEDROCK_MANTLE_WEB_SEARCH_RATE,
+        "search_context_size_medium": _BEDROCK_MANTLE_WEB_SEARCH_RATE,
+        "search_context_size_high": _BEDROCK_MANTLE_WEB_SEARCH_RATE,
+    }
+
+    response = _bedrock_mantle_responses_with_web_search(
+        model,
+        actions=[{"type": "search", "query": "litellm"}, {"type": "search", "query": "bedrock web search"}],
+        tool_usage={"web_search": {"num_requests": 2}},
+    )
+    for cost_model in (model, model.split("/", 1)[1]):
+        cost = _bedrock_mantle_web_search_cost(cost_model, response)
+        assert cost == pytest.approx(2 * _BEDROCK_MANTLE_WEB_SEARCH_RATE), (
+            f"{cost_model} must bill 2 x ${_BEDROCK_MANTLE_WEB_SEARCH_RATE} for 2 web searches, got ${cost}"
+        )
+
+
+@pytest.mark.parametrize("num_requests", [1, 0])
+def test_web_search_call_count_prefers_provider_reported_num_requests(local_model_cost_map, num_requests):
+    """
+    Regression for LIT-6870: Bedrock bills one query per search and reports the billable count as
+    tool_usage.web_search.num_requests, while its open_page fetches share the web_search_call item
+    type. A search plus an open_page must bill the reported count, never the two items.
+    """
+    model = "bedrock_mantle/openai.gpt-5.6-sol"
+    response = _bedrock_mantle_responses_with_web_search(
+        model,
+        actions=[
+            {"type": "search", "query": "litellm"},
+            {"type": "open_page", "url": "https://docs.litellm.ai/"},
+        ],
+        tool_usage={"web_search": {"num_requests": num_requests}},
+    )
+
+    cost = _bedrock_mantle_web_search_cost(model, response)
+
+    assert cost == pytest.approx(num_requests * _BEDROCK_MANTLE_WEB_SEARCH_RATE), (
+        f"{num_requests} reported web search requests must bill {num_requests} x "
+        f"${_BEDROCK_MANTLE_WEB_SEARCH_RATE}, got ${cost}"
+    )
+
+
+@pytest.mark.parametrize(
+    "tool_usage",
+    [None, {}, {"web_search": None}, {"web_search": {"num_requests": "many"}}, {"web_search": {"num_requests": -1}}],
+)
+def test_web_search_call_count_falls_back_to_items_without_reported_count(local_model_cost_map, tool_usage):
+    """
+    Without a usable reported count (no tool_usage, no web_search block, or a malformed one) the
+    per-call path must keep counting web_search_call items instead of raising or billing zero.
+    """
+    model = "bedrock_mantle/openai.gpt-5.6-sol"
+    response = _bedrock_mantle_responses_with_web_search(
+        model,
+        actions=[{"type": "search", "query": "litellm"}, {"type": "search", "query": "bedrock web search"}],
+        tool_usage=tool_usage,
+    )
+
+    cost = _bedrock_mantle_web_search_cost(model, response)
+
+    assert cost == pytest.approx(2 * _BEDROCK_MANTLE_WEB_SEARCH_RATE), (
+        f"2 web_search_call items with tool_usage={tool_usage!r} must bill 2 x "
+        f"${_BEDROCK_MANTLE_WEB_SEARCH_RATE}, got ${cost}"
+    )

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_tool_call_cost_tracking.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_tool_call_cost_tracking.py
@@ -1,4 +1,5 @@
 import os
+from collections.abc import Mapping, Sequence
 
 import pytest
 
@@ -6,7 +7,7 @@ import litellm
 from litellm.litellm_core_utils.llm_cost_calc.tool_call_cost_tracking import (
     StandardBuiltInToolCostTracking,
 )
-from litellm.types.llms.openai import FileSearchTool, WebSearchOptions
+from litellm.types.llms.openai import FileSearchTool, ResponsesAPIResponse, WebSearchOptions
 from litellm.types.utils import ModelResponse, StandardBuiltInToolsParams
 
 
@@ -941,9 +942,9 @@ _BEDROCK_MANTLE_WEB_SEARCH_MODELS = (
 _BEDROCK_MANTLE_WEB_SEARCH_RATE = 0.012
 
 
-def _bedrock_mantle_responses_with_web_search(model, actions, tool_usage=None):
-    from litellm.types.llms.openai import ResponsesAPIResponse
-
+def _responses_with_web_search(
+    model: str, actions: Sequence[Mapping[str, str]], tool_usage: Mapping[str, object] | None = None
+) -> ResponsesAPIResponse:
     payload = {
         "id": "resp_1",
         "created_at": 1756900000,
@@ -960,26 +961,21 @@ def _bedrock_mantle_responses_with_web_search(model, actions, tool_usage=None):
     )
 
 
-def _bedrock_mantle_web_search_cost(model, response):
+def _web_search_cost(model: str, response: ResponsesAPIResponse, custom_llm_provider: str) -> float:
     from litellm.types.utils import Usage
 
     return StandardBuiltInToolCostTracking.get_cost_for_built_in_tools(
         model=model,
         response_object=response,
         usage=Usage(prompt_tokens=10, completion_tokens=5, total_tokens=15),
-        custom_llm_provider="bedrock_mantle",
+        custom_llm_provider=custom_llm_provider,
         standard_built_in_tools_params=None,
     )
 
 
 @pytest.mark.parametrize("model", _BEDROCK_MANTLE_WEB_SEARCH_MODELS)
 def test_bedrock_mantle_web_search_billed_per_query(local_model_cost_map, model):
-    """
-    Regression for LIT-6870: the bedrock_mantle GPT ids forward the web_search tool but carried no
-    search_context_cost_per_query, so every Bedrock web search (billed at $12 per 1,000 queries)
-    was costed at $0. Two reported queries must bill 2 x $0.012, whichever model prefix shape the
-    cost path resolves the deployment under.
-    """
+    """Two Bedrock-reported web searches bill 2 x $0.012 under the prefixed and the bare model id alike."""
     pricing = litellm.get_model_info(model)["search_context_cost_per_query"]
     assert pricing == {
         "search_context_size_low": _BEDROCK_MANTLE_WEB_SEARCH_RATE,
@@ -987,13 +983,13 @@ def test_bedrock_mantle_web_search_billed_per_query(local_model_cost_map, model)
         "search_context_size_high": _BEDROCK_MANTLE_WEB_SEARCH_RATE,
     }
 
-    response = _bedrock_mantle_responses_with_web_search(
+    response = _responses_with_web_search(
         model,
         actions=[{"type": "search", "query": "litellm"}, {"type": "search", "query": "bedrock web search"}],
         tool_usage={"web_search": {"num_requests": 2}},
     )
     for cost_model in (model, model.split("/", 1)[1]):
-        cost = _bedrock_mantle_web_search_cost(cost_model, response)
+        cost = _web_search_cost(cost_model, response, "bedrock_mantle")
         assert cost == pytest.approx(2 * _BEDROCK_MANTLE_WEB_SEARCH_RATE), (
             f"{cost_model} must bill 2 x ${_BEDROCK_MANTLE_WEB_SEARCH_RATE} for 2 web searches, got ${cost}"
         )
@@ -1001,13 +997,9 @@ def test_bedrock_mantle_web_search_billed_per_query(local_model_cost_map, model)
 
 @pytest.mark.parametrize("num_requests", [1, 0])
 def test_web_search_call_count_prefers_provider_reported_num_requests(local_model_cost_map, num_requests):
-    """
-    Regression for LIT-6870: Bedrock bills one query per search and reports the billable count as
-    tool_usage.web_search.num_requests, while its open_page fetches share the web_search_call item
-    type. A search plus an open_page must bill the reported count, never the two items.
-    """
+    """A search plus an open_page fetch bills tool_usage.web_search.num_requests, never the two items."""
     model = "bedrock_mantle/openai.gpt-5.6-sol"
-    response = _bedrock_mantle_responses_with_web_search(
+    response = _responses_with_web_search(
         model,
         actions=[
             {"type": "search", "query": "litellm"},
@@ -1016,7 +1008,7 @@ def test_web_search_call_count_prefers_provider_reported_num_requests(local_mode
         tool_usage={"web_search": {"num_requests": num_requests}},
     )
 
-    cost = _bedrock_mantle_web_search_cost(model, response)
+    cost = _web_search_cost(model, response, "bedrock_mantle")
 
     assert cost == pytest.approx(num_requests * _BEDROCK_MANTLE_WEB_SEARCH_RATE), (
         f"{num_requests} reported web search requests must bill {num_requests} x "
@@ -1029,20 +1021,33 @@ def test_web_search_call_count_prefers_provider_reported_num_requests(local_mode
     [None, {}, {"web_search": None}, {"web_search": {"num_requests": "many"}}, {"web_search": {"num_requests": -1}}],
 )
 def test_web_search_call_count_falls_back_to_items_without_reported_count(local_model_cost_map, tool_usage):
-    """
-    Without a usable reported count (no tool_usage, no web_search block, or a malformed one) the
-    per-call path must keep counting web_search_call items instead of raising or billing zero.
-    """
+    """Without a usable reported count the per-call path keeps counting web_search_call items."""
     model = "bedrock_mantle/openai.gpt-5.6-sol"
-    response = _bedrock_mantle_responses_with_web_search(
+    response = _responses_with_web_search(
         model,
         actions=[{"type": "search", "query": "litellm"}, {"type": "search", "query": "bedrock web search"}],
         tool_usage=tool_usage,
     )
 
-    cost = _bedrock_mantle_web_search_cost(model, response)
+    cost = _web_search_cost(model, response, "bedrock_mantle")
 
     assert cost == pytest.approx(2 * _BEDROCK_MANTLE_WEB_SEARCH_RATE), (
         f"2 web_search_call items with tool_usage={tool_usage!r} must bill 2 x "
         f"${_BEDROCK_MANTLE_WEB_SEARCH_RATE}, got ${cost}"
     )
+
+
+def test_web_search_call_count_reads_reported_count_beside_other_tool_usage_entries(local_model_cost_map):
+    """OpenAI reports web_search.num_requests next to other tool entries, which must not disable the reported count."""
+    response = _responses_with_web_search(
+        "gpt-5.6",
+        actions=[{"type": "search", "query": "S&P 500 close"}, {"type": "open_page", "url": "https://example.com/"}],
+        tool_usage={
+            "image_gen": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+            "web_search": {"num_requests": 1},
+        },
+    )
+
+    cost = _web_search_cost("gpt-5.6", response, "openai")
+
+    assert cost == pytest.approx(0.01), f"1 reported OpenAI web search must bill 1 x $0.01, not the 2 items, got ${cost}"


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bedrock Mantle web searches on `/v1/responses` are billed at $0
- AWS charges $12 per 1,000 queries, so spend reports undercount
- Counting `web_search_call` items instead would overbill page opens

How it solves it:

- Price the five Bedrock Mantle GPT ids at $0.012 per query
- Bill the count Bedrock reports in `tool_usage.web_search.num_requests`
- Fall back to counting `web_search_call` items when no count is reported
- OpenAI's Responses API reports the same count, so a search plus a page open there now bills the 1 request it reports

## User Flow

Before: a developer running GPT-5.6 through Bedrock Mantle with web search on sees every search billed at $0, so their spend reports miss the $12 per 1,000 queries AWS charges

1. The proxy admin adds `bedrock_mantle/openai.gpt-5.6-sol` to the config as `bedrock-gpt-5.6-sol` and starts the proxy
2. The developer sends POST https://litellm-domain/v1/responses with `"model": "bedrock-gpt-5.6-sol"`, a question that needs current facts, and `"tools": [{"type": "web_search", "external_web_access": false}]`
3. The response is 200; its `output` holds a `web_search_call` with `action.type: "search"`, a second one with `action.type: "open_page"`, and a cited answer, and `tool_usage.web_search.num_requests` reads 1
4. The response headers say `x-litellm-response-cost-tool-usage: 0.0`, and `x-litellm-response-cost` (0.056274625) is the token cost alone
5. They send the same request with `"stream": true`; the `response.completed` event again reports `num_requests: 1`, and the proxy's request log records the call at 0.04365845, again the token cost alone
6. Every search from then on is missing from their spend reports, so LiteLLM and AWS Cost Explorer drift apart by $0.012 per query

After: the same request bills the one search Bedrock reports, so LiteLLM's spend matches the AWS invoice

1. The proxy admin adds `bedrock_mantle/openai.gpt-5.6-sol` to the config as `bedrock-gpt-5.6-sol` and starts the proxy
2. The developer sends POST https://litellm-domain/v1/responses with `"model": "bedrock-gpt-5.6-sol"`, a question that needs current facts, and `"tools": [{"type": "web_search", "external_web_access": false}]`
3. The response is 200; its `output` holds a `web_search_call` with `action.type: "search"`, a second one with `action.type: "open_page"`, and a cited answer, and `tool_usage.web_search.num_requests` reads 1
4. The response headers now say `x-litellm-response-cost-tool-usage: 0.012`, and `x-litellm-response-cost` (0.05517445) is the token cost plus that $0.012
5. They send the same request with `"stream": true`; the `response.completed` event reports `num_requests: 1`, and the proxy's request log records the call at 0.05506995, the token cost plus $0.012
6. Their spend reports now carry one $0.012 query per search Bedrock reports, and the page open is not billed, matching what AWS charges

## Relevant issues

Follow-up to #35987, which started forwarding the `web_search` tool to Bedrock Mantle without pricing it. The costing approach here follows #37995 by @longwind48 (same rate, same preference for Bedrock's reported count); that PR's forwarding half already landed in #35987

## Linear ticket

Resolves LIT-6870

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup for both legs. Each leg runs from a checkout at the named commit, with `AWS_BEARER_TOKEN_BEDROCK` in the environment and `LITELLM_LOCAL_MODEL_COST_MAP=True` so the checkout's own cost map is used (the hosted map does not carry the new rate until this merges). Real Bedrock calls, about $0.05 each

`config.yaml`:

```yaml
model_list:
  - model_name: bedrock-gpt-5.6-sol
    litellm_params:
      model: bedrock_mantle/openai.gpt-5.6-sol
      api_key: os.environ/AWS_BEARER_TOKEN_BEDROCK
      aws_region_name: us-east-1

general_settings:
  master_key: sk-1234
```

`search_request.json` (`search_request_stream.json` is the same plus `"stream": true`):

```json
{
  "model": "bedrock-gpt-5.6-sol",
  "input": "Use web search to find the current CEO of Anthropic and cite the page. Then open the page you found and summarize its first paragraph.",
  "tools": [{"type": "web_search", "external_web_access": false}]
}
```

Start the proxy (port 27049 for Before, 36302 for After):

```bash
LITELLM_LOCAL_MODEL_COST_MAP=True python litellm/proxy/proxy_cli.py --config config.yaml --port $PORT --detailed_debug 2>&1 | tee proxy.log
```

Published Bedrock Mantle prices for `openai.gpt-5.6-sol` used in the streaming reconciliation below: input $5.5/M, cache read $0.55/M, cache write $6.875/M, output $33/M

### Before (4b1e24eae9)

#### POST /v1/responses, non-streaming

1. Send the request and print the cost headers:

   ```bash
   curl -sS http://localhost:27049/v1/responses -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
     -d @search_request.json -D before.headers -o before.body.json
   grep -iE '^(HTTP/|x-litellm-response-cost)' before.headers
   ```

   Observed:

   ```
   HTTP/1.1 200 OK
   x-litellm-response-cost: 0.056274624999999995
   x-litellm-response-cost-original: 0.056274624999999995
   x-litellm-response-cost-discount-amount: 0.0
   x-litellm-response-cost-margin-amount: 0.0
   x-litellm-response-cost-margin-percent: 0.0
   x-litellm-response-cost-input: 0.027367999999999996
   x-litellm-response-cost-output: 0.008976000000000001
   x-litellm-response-cost-cache-creation: 0.019930625
   x-litellm-response-cost-reasoning: 0.005214000000000001
   x-litellm-response-cost-tool-usage: 0.0
   ```

2. Summarize the body:

   ```bash
   python3 -c "import json; r=json.load(open('before.body.json')); print(r['tool_usage']); print([(i['type'], (i.get('action') or {}).get('type'), (i.get('action') or {}).get('query') or (i.get('action') or {}).get('url')) for i in r['output']]); print({k: v for k, v in r['usage'].items() if k != 'cost'})"
   ```

   Observed: Bedrock reports one billable search, the search plus the page open both come back as `web_search_call` items, and the tool usage cost above is still 0.0

   ```
   {'web_search': {'num_requests': 1}}
   [('reasoning', None, None), ('web_search_call', 'search', 'site:anthropic.com Dario Amodei CEO Anthropic'), ('reasoning', None, None), ('web_search_call', 'open_page', 'https://www.anthropic.com/news/pwc-expanded-partnership?via=toools'), ('message', None, None)]
   {'input_tokens': 7875, 'input_tokens_details': {'audio_tokens': None, 'cached_tokens': 0, 'text_tokens': None, 'cache_write_tokens': 2899}, 'output_tokens': 272, 'output_tokens_details': {'audio_tokens': None, 'reasoning_tokens': 158, 'text_tokens': None}, 'total_tokens': 8147}
   ```

#### POST /v1/responses, stream: true

1. Send the streaming request and print the `response.completed` event's tool usage, search items, and usage:

   ```bash
   curl -sS -N http://localhost:27049/v1/responses -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
     -d @search_request_stream.json > before.stream.sse
   python3 -c "
   import json
   for line in open('before.stream.sse'):
       raw = line[5:].strip() if line.startswith('data:') else ''
       if raw and raw != '[DONE]' and json.loads(raw).get('type') == 'response.completed':
           r = json.loads(raw)['response']
           print(r['tool_usage']); print([((i.get('action') or {}).get('type'), (i.get('action') or {}).get('query') or (i.get('action') or {}).get('url')) for i in r['output'] if i['type'] == 'web_search_call']); print({k: v for k, v in r['usage'].items() if k != 'cost'})"
   ```

   Observed:

   ```
   {'web_search': {'num_requests': 1}}
   [('search', 'site:anthropic.com leadership CEO Anthropic Dario Amodei'), ('open_page', 'https://www.anthropic.com/news/statement-dario-amodei-american-ai-leadership?_bh')]
   {'input_tokens': 7560, 'input_tokens_details': {'cached_tokens': 2899, 'cache_write_tokens': 2756}, 'output_tokens': 383, 'output_tokens_details': {'reasoning_tokens': 276}, 'total_tokens': 7943}
   ```

2. Read the cost the proxy logged for the completed stream:

   ```bash
   grep -o 'Model=openai.gpt-5.6-sol; cost=[0-9.]*' proxy.log
   ```

   Observed: `Model=openai.gpt-5.6-sol; cost=0.04365845`

3. Reconcile against the usage above: 1905 fresh input x $5.5/M + 2899 cache read x $0.55/M + 2756 cache write x $6.875/M + 383 output x $33/M = 0.0104775 + 0.00159445 + 0.0189475 + 0.012639 = 0.04365845, exactly the logged cost, so the reported search was billed at $0

### After (339da4183d)

#### POST /v1/responses, non-streaming

1. Send the request and print the cost headers:

   ```bash
   curl -sS http://localhost:36302/v1/responses -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
     -d @search_request.json -D after.headers -o after.body.json
   grep -iE '^(HTTP/|x-litellm-response-cost)' after.headers
   ```

   Observed: the tool usage header now carries $0.012 and the total includes it

   ```
   HTTP/1.1 200 OK
   x-litellm-response-cost: 0.05282869999999999
   x-litellm-response-cost-original: 0.05282869999999999
   x-litellm-response-cost-discount-amount: 0.0
   x-litellm-response-cost-margin-amount: 0.0
   x-litellm-response-cost-margin-percent: 0.0
   x-litellm-response-cost-input: 0.010207999999999998
   x-litellm-response-cost-output: 0.009405
   x-litellm-response-cost-cache-read: 0.00159445
   x-litellm-response-cost-cache-creation: 0.01962125
   x-litellm-response-cost-reasoning: 0.005808000000000001
   x-litellm-response-cost-tool-usage: 0.012
   ```

2. Summarize the body:

   ```bash
   python3 -c "import json; r=json.load(open('after.body.json')); print(r['tool_usage']); print([(i['type'], (i.get('action') or {}).get('type'), (i.get('action') or {}).get('query') or (i.get('action') or {}).get('url')) for i in r['output']]); print({k: v for k, v in r['usage'].items() if k != 'cost'})"
   ```

   Observed: same shape as Before, one reported search plus a page open, and only the reported search is billed (0.012, not 0.024)

   ```
   {'web_search': {'num_requests': 1}}
   [('reasoning', None, None), ('web_search_call', 'search', 'site:anthropic.com leadership CEO Anthropic current CEO'), ('reasoning', None, None), ('web_search_call', 'open_page', 'https://www.anthropic.com/news/statement-dario-amodei-american-ai-leadership?_bhlid=b27e889aa561d31a6e340bf9b825d7c77cd7761e'), ('reasoning', None, None), ('message', None, None)]
   {'input_tokens': 7609, 'input_tokens_details': {'audio_tokens': None, 'cached_tokens': 2899, 'text_tokens': None, 'cache_write_tokens': 2854}, 'output_tokens': 285, 'output_tokens_details': {'audio_tokens': None, 'reasoning_tokens': 176, 'text_tokens': None}, 'total_tokens': 7894}
   ```

3. Reconcile the headers: input 0.010208 + output 0.009405 + cache read 0.00159445 + cache creation 0.01962125 = 0.0408287 in tokens (the reasoning header is a breakdown of output, not an extra charge), plus one $0.012 query = 0.0528287, the total header

#### POST /v1/responses, stream: true

1. Send the streaming request and print the `response.completed` event's tool usage, search items, and usage:

   ```bash
   curl -sS -N http://localhost:36302/v1/responses -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
     -d @search_request_stream.json > after.stream.sse
   python3 -c "
   import json
   for line in open('after.stream.sse'):
       raw = line[5:].strip() if line.startswith('data:') else ''
       if raw and raw != '[DONE]' and json.loads(raw).get('type') == 'response.completed':
           r = json.loads(raw)['response']
           print(r['tool_usage']); print([((i.get('action') or {}).get('type'), (i.get('action') or {}).get('query') or (i.get('action') or {}).get('url')) for i in r['output'] if i['type'] == 'web_search_call']); print({k: v for k, v in r['usage'].items() if k != 'cost'})"
   ```

   Observed:

   ```
   {'web_search': {'num_requests': 1}}
   [('search', 'site:anthropic.com Dario Amodei CEO Anthropic'), ('open_page', 'https://www.anthropic.com/news/pwc-expanded-partnership?via=toools')]
   {'input_tokens': 7924, 'input_tokens_details': {'cached_tokens': 2899, 'cache_write_tokens': 2885}, 'output_tokens': 376, 'output_tokens_details': {'reasoning_tokens': 275}, 'total_tokens': 8300}
   ```

2. Read the cost the proxy logged for the completed stream:

   ```bash
   grep -o 'Model=openai.gpt-5.6-sol; cost=[0-9.]*' proxy.log
   ```

   Observed: `Model=openai.gpt-5.6-sol; cost=0.057606825`

3. Reconcile against the usage above: 2140 fresh input x $5.5/M + 2899 cache read x $0.55/M + 2885 cache write x $6.875/M + 376 output x $33/M = 0.01177 + 0.00159445 + 0.019834375 + 0.012408 = 0.045606825 in tokens, plus one $0.012 query = 0.057606825, exactly the logged cost

### Dependents driven base vs head

The count helper now prefers a provider-reported `tool_usage.web_search.num_requests` on every Responses API response, so each provider on that per-call web search path is a dependent, along with every reader of `search_context_cost_per_query` (`GET /model/info`, the dashboard's model table, the PTU zeroed pricing table). Both sides ran the same single-worker proxy without a database (base 4b1e24eae9 on port 32131, head 339da4183d on port 36302, one after the other because the machine was under memory pressure) with the same config and the same requests, each leg logging which tree it imported:

- `GET /model/info` on the Bedrock Mantle deployment: `search_context_cost_per_query` is None on base and 0.012 on head, and the OpenAI rows are unchanged
- OpenAI `gpt-5.6` on `/v1/responses` with one search: tool usage 0.01 on both sides
- OpenAI `gpt-5.6` with a search plus a page open (two `web_search_call` items, `num_requests` 1): 0.02 on base and 0.01 on head, tracking the count OpenAI reports
- Bedrock Mantle non-streaming and streaming: 0.0 on base and one $0.012 query on head, as shown above

Not driven live: the chat completions branch (still one query per response, unchanged and unit-tested), since LiteLLM rejects `web_search_options` for `gpt-5.6` and OpenAI retired `gpt-4o-search-preview`, and Azure's Responses API, which shares OpenAI's reported-count and fallback branches. The legacy CircleCI suites carry no Bedrock Mantle or web search cost assertions; the `run-ci` label is on so they run at the tip

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- The streaming path logs only the total cost; the tool usage split is visible on the non-streaming headers only
- The rate is $0.012 for all three search context sizes since AWS prices per query only
- Rate source: AWS's published $12 per 1,000 queries, matched by the Cost Explorer reconciliation on #37995
- Providers that report no count keep billing one query per `web_search_call` item, page opens included
- OpenAI's Responses API also reports `tool_usage.web_search.num_requests`, so a search plus a page open there now bills its reported 1 request ($0.01) instead of 2 items ($0.02), trusted without an OpenAI billing reconciliation
- CircleCI `local_testing_part1` and `local_testing_part2` are red at the tip on the 3 `bedrock/cohere.command-r-plus-v1:0` tests that Bedrock retired today ("This model version has reached the end of its life"); the same 3 tests fail on `litellm_internal_staging`'s own pipeline since 18:09 UTC and #39608 drops them, so this PR leaves them alone

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
- [x] 339da4183d passes /live-pr-risk
