### PR TITLE
fix(openai): default stream usage on PrivateLink and regional api.openai.com hosts

### DIFF
--- a/litellm/llms/openai/common_utils.py
+++ b/litellm/llms/openai/common_utils.py
@@ -11,6 +11,7 @@ import time
 import uuid
 from collections.abc import AsyncIterator, Iterator, Mapping
 from typing import TYPE_CHECKING, Any, Final, Literal, NamedTuple, Optional
+from urllib.parse import urlsplit
 
 import httpx
 import openai
@@ -41,6 +42,14 @@ def _get_client_init_params(cls: type) -> tuple[str, ...]:
 
 _OPENAI_INIT_PARAMS: Final[tuple[str, ...]] = _get_client_init_params(OpenAI)
 _AZURE_OPENAI_INIT_PARAMS: Final[tuple[str, ...]] = _get_client_init_params(AzureOpenAI)
+
+
+_OPENAI_API_HOST: Final[str] = "api.openai.com"
+
+
+def is_openai_backed_api_base(api_base: str) -> bool:
+    hostname: Final = urlsplit(api_base).hostname
+    return hostname is not None and (hostname == _OPENAI_API_HOST or hostname.endswith(f".{_OPENAI_API_HOST}"))
 
 
 class OpenAIError(BaseLLMException):

--- a/litellm/llms/openai/openai.py
+++ b/litellm/llms/openai/openai.py
@@ -2,7 +2,6 @@ import time
 import types
 from collections.abc import AsyncIterator, Callable, Coroutine, Iterable, Iterator, Mapping
 from typing import TYPE_CHECKING, Any, Final, Literal, Optional, cast
-from urllib.parse import urlparse
 
 import httpx
 
@@ -55,6 +54,7 @@ from .common_utils import (
     OpenAIError,
     build_output_token_limit_response,
     drop_params_from_unprocessable_entity_error,
+    is_openai_backed_api_base,
     is_output_token_limit_error,
 )
 from .workload_identity import resolve_openai_workload_identity_config
@@ -1190,10 +1190,8 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         """
         if stream_options is not None:
             return {"stream_options": stream_options}
-        else:
-            # by default litellm will include usage for openai endpoints
-            if api_base is None or urlparse(api_base).hostname == "api.openai.com":
-                return {"stream_options": {"include_usage": True}}
+        if api_base is None or is_openai_backed_api_base(api_base):
+            return {"stream_options": {"include_usage": True}}
         return {}
 
     # Embedding

--- a/tests/test_litellm/llms/openai/test_openai.py
+++ b/tests/test_litellm/llms/openai/test_openai.py
@@ -1,0 +1,52 @@
+import pytest
+
+from litellm.llms.openai.openai import OpenAIChatCompletion
+
+
+@pytest.mark.parametrize(
+    "api_base",
+    [
+        None,
+        "https://api.openai.com/v1",
+        "https://api.openai.com:443/v1",
+        "https://southcentralus.privatelink.api.openai.com/v1",
+        "https://eu.api.openai.com/v1",
+        "https://us.api.openai.com/v1",
+        "HTTPS://API.OPENAI.COM/v1/",
+    ],
+)
+def test_get_stream_options_defaults_include_usage_on_every_openai_backed_host(api_base):
+    """
+    PrivateLink and regional hostnames reach the real OpenAI backend, so a stream with no caller
+    stream_options must ask for the usage chunk exactly as the default base does. Regression guard
+    for LIT-6875: spend for those deployments fell back to local token counting.
+    """
+    assert OpenAIChatCompletion().get_stream_options(stream_options=None, api_base=api_base) == {
+        "stream_options": {"include_usage": True}
+    }
+
+
+@pytest.mark.parametrize(
+    "api_base",
+    [
+        "https://my-gateway.example/v1",
+        "https://api.openai.com.evil.example/v1",
+        "https://notapi.openai.com/v1",
+        "https://gateway.example/v1?upstream=api.openai.com",
+        "https://openai.internal.example/api.openai.com/v1",
+    ],
+)
+def test_get_stream_options_leaves_foreign_hosts_without_a_usage_default(api_base):
+    """Only the host decides: an OpenAI-compatible backend elsewhere may not support stream_options at all."""
+    assert OpenAIChatCompletion().get_stream_options(stream_options=None, api_base=api_base) == {}
+
+
+@pytest.mark.parametrize(
+    "api_base",
+    ["https://southcentralus.privatelink.api.openai.com/v1", "https://my-gateway.example/v1"],
+)
+def test_get_stream_options_passes_caller_stream_options_through_on_any_host(api_base):
+    caller_options = {"include_usage": False}
+    assert OpenAIChatCompletion().get_stream_options(stream_options=caller_options, api_base=api_base) == {
+        "stream_options": caller_options
+    }

--- a/tests/test_litellm/llms/openai/test_openai_common_utils.py
+++ b/tests/test_litellm/llms/openai/test_openai_common_utils.py
@@ -7,7 +7,7 @@ import pytest
 
 import litellm
 from litellm.litellm_core_utils.token_counter import token_counter
-from litellm.llms.openai.common_utils import BaseOpenAILLM
+from litellm.llms.openai.common_utils import BaseOpenAILLM, is_openai_backed_api_base
 
 # Test parameters for different API functions
 API_FUNCTION_PARAMS = [
@@ -392,3 +392,22 @@ async def test_async_genuine_bad_request_still_raises(provider, stream):
 
     with pytest.raises(litellm.BadRequestError):
         await _call_and_drain()
+
+
+@pytest.mark.parametrize(
+    ("api_base", "expected"),
+    [
+        ("https://api.openai.com/v1", True),
+        ("https://api.openai.com:443/v1/", True),
+        ("https://southcentralus.privatelink.api.openai.com/v1", True),
+        ("https://eu.api.openai.com/v1", True),
+        ("HTTPS://API.OPENAI.COM/v1", True),
+        ("https://my-gateway.example/v1", False),
+        ("https://api.openai.com.evil.example/v1", False),
+        ("https://notapi.openai.com/v1", False),
+        ("https://gateway.example/v1?upstream=api.openai.com", False),
+        ("not a url", False),
+    ],
+)
+def test_is_openai_backed_api_base_decides_by_hostname_only(api_base, expected):
+    assert is_openai_backed_api_base(api_base) is expected


### PR DESCRIPTION
## TLDR

Problem this solves:

- Streaming usage default only fires when the host is exactly `api.openai.com`
- PrivateLink (`<region>.privatelink.api.openai.com`) and regional (`eu.`, `us.`) hosts miss it
- SDK streams to those hosts get locally counted usage: no reasoning or cached tokens, spend far under

How it solves it:

- Shared `is_openai_backed_api_base` helper: hostname is `api.openai.com` or a subdomain of it
- `get_stream_options` keys on that helper, same rule PR #39587 uses for the Responses bridge
- Non-OpenAI hosts and lookalikes still get no default, caller-sent `stream_options` still passes through

## User Flow

Before: a developer streaming through a PrivateLink or regional OpenAI host with the LiteLLM SDK sees a fraction of the real spend in their cost tracking

1. They call `litellm.completion(model="openai/gpt-5.6", api_base="https://<region>.privatelink.api.openai.com/v1", stream=True, reasoning_effort="high", messages=[...])` with a success callback (a custom logger, Langfuse, or similar) recording usage and cost
2. The stream completes with the answer
3. The callback receives prompt 58, completion 3, reasoning 0 tokens and a `response_cost` of $0.000292: the tokens were counted locally, so the reasoning tokens OpenAI billed are missing

After: the same call is logged with OpenAI's own usage

1. Same call
2. The stream completes with the answer
3. The callback receives OpenAI's usage (prompt 57, completion 253, reasoning 241) and a `response_cost` of $0.005288, the same shape the call gets with `api_base` left unset

## Relevant issues

Sibling of PR #39587 (the Responses bridge hostname rule)

## Linear ticket

Resolves LIT-6875

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Setup shared by both legs. PrivateLink hostnames only resolve inside a customer VPC, so the deployment keeps the genuine hostname (the only thing the streaming usage default reads) and the client process gets `HTTP_PROXY` pointed at a small local HTTP forwarder that relays every request byte for byte to `api.openai.com`, the same shape a PrivateLink endpoint has. Real OpenAI key, real cost. The train prompt with `reasoning_effort: high` is the discriminator: local token counting can never produce reasoning tokens

`sdk_probe.py` (the end user's own client, prints what its success callback receives):

```python
import json
import sys
import time

import litellm
from litellm.integrations.custom_logger import CustomLogger

PROMPT = ("A train leaves at 9:17 and travels 412 km at 96 km/h, stops 25 minutes, then travels 138 km at 72 km/h. "
          "What time does it arrive? Answer with only the time in HH:MM.")


class SpendCapture(CustomLogger):
    def log_success_event(self, kwargs, response_obj, start_time, end_time):
        complete = kwargs.get("complete_streaming_response")
        usage = getattr(complete, "usage", None)
        details = getattr(usage, "completion_tokens_details", None)
        prompt_details = getattr(usage, "prompt_tokens_details", None)
        print(json.dumps({
            "callback": "log_success_event",
            "prompt_tokens": getattr(usage, "prompt_tokens", None),
            "completion_tokens": getattr(usage, "completion_tokens", None),
            "total_tokens": getattr(usage, "total_tokens", None),
            "reasoning_tokens": getattr(details, "reasoning_tokens", None),
            "cached_tokens": getattr(prompt_details, "cached_tokens", None),
            "response_cost": kwargs.get("response_cost"),
        }))


litellm.callbacks = [SpendCapture()]
api_base = sys.argv[1] if len(sys.argv) > 1 else None
chunks = []
for chunk in litellm.completion(model="openai/gpt-5.6", api_base=api_base, stream=True, reasoning_effort="high",
                                messages=[{"role": "user", "content": PROMPT}]):
    chunks.append(chunk)
text = "".join(c.choices[0].delta.content or "" for c in chunks if c.choices)
print(json.dumps({"api_base": api_base, "answer": text.strip(), "chunks": len(chunks), "response_id": chunks[0].id}))
time.sleep(3)
```

Proxy cases use two proxies (`--num_workers 2`, own Postgres each) with this config:

```yaml
model_list:
  - model_name: gpt-5.6-privatelink
    litellm_params:
      model: openai/gpt-5.6
      api_base: http://southcentralus.privatelink.api.openai.com/v1
      api_key: os.environ/OPENAI_API_KEY
  - model_name: gpt-5.6-default
    litellm_params:
      model: openai/gpt-5.6
      api_key: os.environ/OPENAI_API_KEY

general_settings:
  master_key: sk-lit6875
```

### Before (7d6781fe6a)

#### SDK stream through the PrivateLink host

1. `HTTP_PROXY=http://127.0.0.1:41311 NO_PROXY=127.0.0.1,localhost python sdk_probe.py http://southcentralus.privatelink.api.openai.com/v1`
2. Output: the answer arrives, the callback gets locally counted usage and 1/18th of the real spend

```
{"api_base": "http://southcentralus.privatelink.api.openai.com/v1", "answer": "15:55", "chunks": 5, "response_id": "chatcmpl-EK7Pm1xLUMfQaXxmAjjpcPn2LVDhc"}
{"callback": "log_success_event", "prompt_tokens": 58, "completion_tokens": 3, "total_tokens": 61, "reasoning_tokens": 0, "cached_tokens": null, "response_cost": 0.000292}
```

#### SDK stream with api_base unset (control)

1. `python sdk_probe.py`
2. Output: the callback gets OpenAI's usage with reasoning tokens

```
{"api_base": null, "answer": "15:54", "chunks": 6, "response_id": "chatcmpl-EK7PxkNieSFrMzQ6Ppf4dsRS4gx6S"}
{"callback": "log_success_event", "prompt_tokens": 57, "completion_tokens": 178, "total_tokens": 235, "reasoning_tokens": 166, "cached_tokens": 0, "response_cost": 0.0037880000000000006}
```

#### Proxy POST /v1/chat/completions on the PrivateLink deployment (unchanged by this PR)

1. `curl -N http://localhost:55930/v1/chat/completions -H "Authorization: Bearer sk-lit6875" -H "Content-Type: application/json" -d @req_privatelink_stream.json` (`{"model": "gpt-5.6-privatelink", "stream": true, "reasoning_effort": "high", "messages": [...]}`) -> 200, answer `15:55`
2. `curl http://localhost:55930/spend/logs?request_id=<chatcmpl id from the stream> -H "Authorization: Bearer sk-lit6875"` -> the proxy already records OpenAI's usage here (it asks for usage itself on this route)

```
{"request_id": "chatcmpl-EK6Zadi9Q0Ca9nR3ZHsCnLAxY10Vr", "call_type": "acompletion", "model": "openai/gpt-5.6", "prompt_tokens": 57, "completion_tokens": 333, "total_tokens": 390, "reasoning_tokens": 321, "spend": 0.006888}
```

#### Proxy POST /v1/messages on the PrivateLink deployment (unchanged by this PR)

1. `curl -N http://localhost:55930/v1/messages -H "x-api-key: sk-lit6875" -H "anthropic-version: 2023-06-01" -H "Content-Type: application/json" -d @req_privatelink_messages.json` (`{"model": "gpt-5.6-privatelink", "max_tokens": 4096, "stream": true, "thinking": {"type": "enabled", "budget_tokens": 2048}, "messages": [...]}`) -> 200, answer `15:55`
2. `curl http://localhost:55930/spend/logs -H "Authorization: Bearer sk-lit6875"`, the row for that call:

```
{"request_id": "chatcmpl-09aa40d4-f957-4f7a-ae1c-45c669cabf9b", "call_type": "anthropic_messages", "model": "openai/gpt-5.6", "prompt_tokens": 57, "completion_tokens": 206, "total_tokens": 263, "reasoning_tokens": 197, "spend": 0.004347999999999999}
```

#### Proxy POST /v1/responses on the PrivateLink deployment (unchanged by this PR)

1. `curl -N http://localhost:55930/v1/responses -H "Authorization: Bearer sk-lit6875" -H "Content-Type: application/json" -d @req_privatelink_responses.json` (`{"model": "gpt-5.6-privatelink", "stream": true, "reasoning": {"effort": "high"}, "input": "..."}`) -> 200, answer `15:55`, `response.completed` carries `"output_tokens_details": {"reasoning_tokens": 404}`
2. `curl http://localhost:55930/spend/logs -H "Authorization: Bearer sk-lit6875"`, the row for that call:

```
{"request_id": "resp_bGl0ZWxsbTpjdXN0b21fbGxtX3Byb3ZpZGVyOm9wZW5haTttb2RlbF9pZDo4YWUyM2I3M2RkN2ViYTNhMmJjNGJhOGI0MWIwMTRiNmVjM2Y5ZGViZDk5MzQ4ZDU5YmY5ODVmY2ZlY2VmMDEzO3Jlc3BvbnNlX2lkOnJlc3BfMGQzMzIwMjNlYjI4YzQyZjAwNmE5OWM2NmNkZjY0ODdkMDgzMGJhNGFmNGRlNTQ1M2Y=", "call_type": "aresponses", "model": "openai/gpt-5.6", "prompt_tokens": 57, "completion_tokens": 413, "total_tokens": 470, "reasoning_tokens": 404, "spend": 0.008488}
```

### After (1e75668a25)

#### SDK stream through the PrivateLink host

1. `HTTP_PROXY=http://127.0.0.1:41311 NO_PROXY=127.0.0.1,localhost python sdk_probe.py http://southcentralus.privatelink.api.openai.com/v1`
2. Output: the answer arrives, the callback gets OpenAI's usage with reasoning tokens and the real spend

```
{"api_base": "http://southcentralus.privatelink.api.openai.com/v1", "answer": "15:55", "chunks": 6, "response_id": "chatcmpl-EK7Q6ds6UR6fdjTaLJMn4kSjOmX29"}
{"callback": "log_success_event", "prompt_tokens": 57, "completion_tokens": 253, "total_tokens": 310, "reasoning_tokens": 241, "cached_tokens": 0, "response_cost": 0.005288}
```

#### SDK stream with api_base unset (control)

1. `python sdk_probe.py`
2. Output: unchanged, OpenAI's usage

```
{"api_base": null, "answer": "15:55", "chunks": 6, "response_id": "chatcmpl-EK7QEDLEpTbiSJ9H7dyugmq7BUhkx"}
{"callback": "log_success_event", "prompt_tokens": 57, "completion_tokens": 290, "total_tokens": 347, "reasoning_tokens": 278, "cached_tokens": 0, "response_cost": 0.006028}
```

#### Proxy POST /v1/chat/completions on the PrivateLink deployment (unchanged by this PR)

1. Same curl against the after proxy on port 36273 -> 200, answer `15:55`
2. `curl http://localhost:36273/spend/logs?request_id=<chatcmpl id from the stream> -H "Authorization: Bearer sk-lit6875"`

```
{"request_id": "chatcmpl-EK6ZzbRmVIfr6y0xkTli7WKG244OV", "call_type": "acompletion", "model": "openai/gpt-5.6", "prompt_tokens": 57, "completion_tokens": 262, "total_tokens": 319, "reasoning_tokens": 250, "spend": 0.005468}
```

#### Proxy POST /v1/messages on the PrivateLink deployment (unchanged by this PR)

1. Same curl against the after proxy on port 36273 -> 200, answer `15:55`
2. `curl http://localhost:36273/spend/logs -H "Authorization: Bearer sk-lit6875"`, the row for that call:

```
{"request_id": "chatcmpl-a11f078d-a1c9-4312-94ce-6b500961a225", "call_type": "anthropic_messages", "model": "openai/gpt-5.6", "prompt_tokens": 57, "completion_tokens": 207, "total_tokens": 264, "reasoning_tokens": 198, "spend": 0.004367999999999999}
```

#### Proxy POST /v1/responses on the PrivateLink deployment (unchanged by this PR)

1. Same curl against the after proxy on port 36273 -> 200, answer `15:55`, `response.completed` carries `"output_tokens_details": {"reasoning_tokens": 315}`
2. `curl http://localhost:36273/spend/logs -H "Authorization: Bearer sk-lit6875"`, the row for that call:

```
{"request_id": "resp_bGl0ZWxsbTpjdXN0b21fbGxtX3Byb3ZpZGVyOm9wZW5haTttb2RlbF9pZDo4YWUyM2I3M2RkN2ViYTNhMmJjNGJhOGI0MWIwMTRiNmVjM2Y5ZGViZDk5MzQ4ZDU5YmY5ODVmY2ZlY2VmMDEzO3Jlc3BvbnNlX2lkOnJlc3BfMGUyNDdkYjdkYmFjNDJiYTAwNmE5OWM4N2IzYmEwODdkMDgyYjA4ZmQ3YTNhMTRmNmU=", "call_type": "aresponses", "model": "openai/gpt-5.6", "prompt_tokens": 57, "completion_tokens": 324, "total_tokens": 381, "reasoning_tokens": 315, "spend": 0.006708}
```

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Proxy routes are unaffected: all three unified endpoints already ask for usage before this default runs
  - `/v1/chat/completions` since a770b437d53, `/v1/messages` and `/v1/responses` in their bridges
  - The ticket's original proxy User Flow did not reproduce; this PR changes SDK callers and proxies with `always_include_stream_usage: false`
- `litellm/main.py` keeps its private `_is_openai_backed_api_base` from PR #39587; switch it to the shared helper once both land
- Observed on both legs, not caused here: the `/v1/messages` bridge streams `message_delta` usage as zeros for OpenAI models while the spend row is right
- Regional `eu.`/`us.` hosts were not driven live; they share the PrivateLink code path
  - The org key has no data-residency project, so OpenAI rejects it before any stream, on base and head alike
- SDK callers on PrivateLink hosts now receive the trailing usage chunk api.openai.com callers already get: one choice with an empty delta, `finish_reason` null, `usage` set (probed on the tip, both hosts identical)
- Sibling gap, out of scope here: OpenAI workload identity federation still matches the exact `api.openai.com` hostname in `litellm/llms/openai/workload_identity.py`, so it is skipped on PrivateLink and regional hosts; tracked in LIT-6902
- CircleCI `local_testing_part1` and `local_testing_part2` are red on three `bedrock/cohere.command-r-plus-v1:0` tests that Bedrock now rejects as end of life
  - `test_completion_bedrock_httpx_models` (both variants) and `test_parallel_streaming_requests`; staging's own pipeline 89035 fails the same three, tracked in LIT-6876

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 1e75668a25 passes /live-pr-risk
