### PR TITLE
test(responses): bound the background stream cancel e2e so an upstream stall skips fast

### DIFF
--- a/tests/openai_endpoints_tests/test_e2e_openai_responses_api.py
+++ b/tests/openai_endpoints_tests/test_e2e_openai_responses_api.py
@@ -162,7 +162,7 @@ def test_cancel_streaming_response():
     started = time.monotonic()
     stream = client.responses.create(
         model="gpt-5.5",
-        input="just respond with the word 'ping'",
+        input="count from 1 to 500, one number per line",
         stream=True,
         background=True,
         timeout=BACKGROUND_STREAM_ADMISSION_DEADLINE_SECONDS,
@@ -189,13 +189,7 @@ def test_cancel_streaming_response():
         )
     assert response_id is not None, f"no response event within {elapsed:.0f}s of streaming a background response"
 
-    try:
-        cancel_response = client.responses.cancel(response_id)
-    except BadRequestError as e:
-        if "Cannot cancel a completed response" not in str(e):
-            raise
-        print("response completed before cancel=", e)
-        return
+    cancel_response = client.responses.cancel(response_id)
     print("CANCEL streaming response=", cancel_response)
     assert cancel_response.status == "cancelled"
 

--- a/tests/openai_endpoints_tests/test_e2e_openai_responses_api.py
+++ b/tests/openai_endpoints_tests/test_e2e_openai_responses_api.py
@@ -1,6 +1,10 @@
+import time
+
 import httpx
-from openai import OpenAI, BadRequestError, NotFoundError, APIStatusError
 import pytest
+from openai import APIStatusError, BadRequestError, NotFoundError, OpenAI
+
+BACKGROUND_STREAM_ADMISSION_DEADLINE_SECONDS = 90
 
 
 def generate_key():
@@ -154,42 +158,46 @@ def test_cancel_response():
 
 
 def test_cancel_streaming_response():
-    try:
-        client = get_test_client()
-        from litellm.types.llms.openai import ResponsesAPIResponse
+    client = get_test_client()
+    started = time.monotonic()
+    stream = client.responses.create(
+        model="gpt-5.5",
+        input="just respond with the word 'ping'",
+        stream=True,
+        background=True,
+        timeout=BACKGROUND_STREAM_ADMISSION_DEADLINE_SECONDS,
+    )
 
-        stream = client.responses.create(
-            model="gpt-5.5",
-            input="just respond with the word 'ping'",
-            stream=True,
-            background=True,
-        )
-
-        collected_chunks = []
-        response_id = None
+    keepalive_events = 0
+    response_id = None
+    with stream:
         for chunk in stream:
             print("stream chunk=", chunk)
-            collected_chunks.append(chunk)
-            # Extract response ID from the first chunk that has it
-            if (
-                response_id is None
-                and hasattr(chunk, "response")
-                and hasattr(chunk.response, "id")
-            ):
+            if chunk.type == "keepalive":
+                keepalive_events += 1
+            elif getattr(chunk, "response", None) is not None:
                 response_id = chunk.response.id
+                break
+            if time.monotonic() - started > BACKGROUND_STREAM_ADMISSION_DEADLINE_SECONDS:
+                break
 
-        assert len(collected_chunks) > 0
+    elapsed = time.monotonic() - started
+    if response_id is None and keepalive_events:
+        pytest.skip(
+            f"OpenAI held the background stream in keepalive for {elapsed:.0f}s "
+            f"({keepalive_events} keepalive events) without creating the response"
+        )
+    assert response_id is not None, f"no response event within {elapsed:.0f}s of streaming a background response"
 
-        # cancel the response if we got a response ID
-        if response_id:
-            cancel_response = client.responses.cancel(response_id)
-            print("CANCEL streaming response=", cancel_response)
-            assert hasattr(cancel_response, "id")
-    except Exception as e:
-        if "Cannot cancel a completed response" in str(e):
-            pass
-        else:
-            raise e
+    try:
+        cancel_response = client.responses.cancel(response_id)
+    except BadRequestError as e:
+        if "Cannot cancel a completed response" not in str(e):
+            raise
+        print("response completed before cancel=", e)
+        return
+    print("CANCEL streaming response=", cancel_response)
+    assert cancel_response.status == "cancelled"
 
 
 def test_cancel_invalid_response_id():

--- a/tests/openai_endpoints_tests/test_e2e_openai_responses_api.py
+++ b/tests/openai_endpoints_tests/test_e2e_openai_responses_api.py
@@ -1,10 +1,13 @@
 import time
+from collections.abc import Iterator
+from typing import Final
 
 import httpx
 import pytest
-from openai import APIStatusError, BadRequestError, NotFoundError, OpenAI
+from openai import APIStatusError, BadRequestError, NotFoundError, OpenAI, Stream
+from openai.types.responses import ResponseStreamEvent
 
-BACKGROUND_STREAM_ADMISSION_DEADLINE_SECONDS = 90
+BACKGROUND_STREAM_ADMISSION_DEADLINE_SECONDS: Final = 90
 
 
 def generate_key():
@@ -157,10 +160,25 @@ def test_cancel_response():
             raise e
 
 
+def admitted_response_id(chunk: ResponseStreamEvent) -> str | None:
+    response: Final = getattr(chunk, "response", None)
+    return None if response is None else response.id
+
+
+def events_until_admission(stream: Stream[ResponseStreamEvent], started: float) -> Iterator[ResponseStreamEvent]:
+    for chunk in stream:
+        print("stream chunk=", chunk)
+        yield chunk
+        if admitted_response_id(chunk) is not None:
+            return
+        if time.monotonic() - started > BACKGROUND_STREAM_ADMISSION_DEADLINE_SECONDS:
+            return
+
+
 def test_cancel_streaming_response():
-    client = get_test_client()
-    started = time.monotonic()
-    stream = client.responses.create(
+    client: Final = get_test_client()
+    started: Final = time.monotonic()
+    stream: Final = client.responses.create(
         model="gpt-5.5",
         input="count from 1 to 500, one number per line",
         stream=True,
@@ -168,20 +186,12 @@ def test_cancel_streaming_response():
         timeout=BACKGROUND_STREAM_ADMISSION_DEADLINE_SECONDS,
     )
 
-    keepalive_events = 0
-    response_id = None
     with stream:
-        for chunk in stream:
-            print("stream chunk=", chunk)
-            if chunk.type == "keepalive":
-                keepalive_events += 1
-            elif getattr(chunk, "response", None) is not None:
-                response_id = chunk.response.id
-                break
-            if time.monotonic() - started > BACKGROUND_STREAM_ADMISSION_DEADLINE_SECONDS:
-                break
+        events: Final = tuple(events_until_admission(stream, started))
 
-    elapsed = time.monotonic() - started
+    elapsed: Final = time.monotonic() - started
+    keepalive_events: Final = sum(1 for chunk in events if chunk.type == "keepalive")
+    response_id: Final = next((rid for rid in map(admitted_response_id, events) if rid is not None), None)
     if response_id is None and keepalive_events:
         pytest.skip(
             f"OpenAI held the background stream in keepalive for {elapsed:.0f}s "
@@ -189,7 +199,7 @@ def test_cancel_streaming_response():
         )
     assert response_id is not None, f"no response event within {elapsed:.0f}s of streaming a background response"
 
-    cancel_response = client.responses.cancel(response_id)
+    cancel_response: Final = client.responses.cancel(response_id)
     print("CANCEL streaming response=", cancel_response)
     assert cancel_response.status == "cancelled"
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- `e2e_openai_endpoints` fails whenever OpenAI holds a background stream in keepalives
- `test_cancel_streaming_response` drained that stream for 301s, then hit a generic APIError
- on a good day it cancelled a completed response and swallowed the 400, verifying nothing

How it solves it:

- cancel at the first event that carries a response id
- 90s admission deadline via the SDK timeout plus a clock check
- a keepalive-only stall skips, naming elapsed seconds and keepalive count
- ask for a long generation so completion never beats the cancel
- assert the cancel comes back `status: cancelled`

## User Flow

Before: the `e2e_openai_endpoints` CircleCI job fails after five minutes whenever OpenAI holds the background stream in keepalives, and on a healthy day it passes without ever verifying a cancel

1. The job sends POST http://0.0.0.0:4000/v1/responses with `"model": "gpt-5.5"`, `"stream": true`, `"background": true`
2. On a stalled day the stream carries only `{"type": "keepalive", "sequence_number": N, "model": "gpt-5.5"}` frames, one about every 30 seconds, for five minutes
3. Around 301 seconds `response.created` and `response.queued` arrive with a `resp_...` id, then an error event, and the client raises `openai.APIError: litellm.APIError: An error occurred while processing the request.`, failing the test
4. On a healthy day the stream instead runs through `response.completed` in 5-8 seconds, then POST http://0.0.0.0:4000/v1/responses/{id}/cancel returns 400 `Cannot cancel a completed response`, which the test swallows, so it passes having verified nothing

After: the same job cancels the response as soon as it has an id and passes in about two seconds, and a stalled upstream stream ends in a skip that names the stall instead of a five-minute failure

1. The job sends the same POST http://0.0.0.0:4000/v1/responses with `"stream": true`, `"background": true`, now asking for a 500-line generation
2. `response.created` arrives after about a second with a `resp_...` id and the client closes the stream
3. POST http://0.0.0.0:4000/v1/responses/{id}/cancel returns 200 with `"status": "cancelled"` and the test passes
4. On a stalled day the client stops after 90 seconds of keepalive frames and the test is skipped with `OpenAI held the background stream in keepalive for 90s (3 keepalive events) without creating the response`

## Relevant issues

## Linear ticket

Resolves LIT-6888

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup: a proxy from this branch's worktree booted with the CI job's own config, `python litellm/proxy/proxy_cli.py --config litellm/proxy/example_config_yaml/oai_misc_config.yaml --port 23850 --num_workers 2`, no database, master key `sk-1234`, real OpenAI calls. The test file at each commit runs as is except for the two substitutions a no-DB proxy needs (`http://0.0.0.0:4000` -> `http://127.0.0.1:23850`, key generation replaced by the master key), copied to a scratch path. Its `-s` output is filtered down to each chunk's event type since every chunk prints a 477-character id; the first chunk shares pytest's node-id line so it is not in the filtered output

### Before (4b1e24eae9)

1. `pytest <copy of the test file> -k cancel_streaming -s --durations=1`: the stream drains through `response.completed` and no `CANCEL streaming response=` line is printed because the 400 was swallowed, so the test passes without verifying a cancel

```
stream chunk type=response.queued status=queued
stream chunk type=response.in_progress status=in_progress
stream chunk type=response.output_item.added
stream chunk type=response.output_item.done
stream chunk type=response.output_item.added status=in_progress
stream chunk type=response.content_part.added
stream chunk type=response.output_text.delta
stream chunk type=response.output_text.done
stream chunk type=response.content_part.done
stream chunk type=response.output_item.done status=completed
stream chunk type=response.completed status=completed
7.71s call     test_lit6888_base_e2e.py::test_cancel_streaming_response
======================= 1 passed, 7 deselected in 8.21s ========================
```

2. The same drain-then-cancel flow with curl: `curl -sN http://127.0.0.1:23850/v1/responses -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"gpt-5.5","input":"count from 1 to 500, one number per line","stream":true,"background":true}'` read to the end, then `curl -X POST http://127.0.0.1:23850/v1/responses/{id}/cancel` with the id from `response.created`

```
stream drained in 11.9s, 330 events, last: response.completed status=completed
POST /v1/responses/{id}/cancel ->
HTTP 400 error.message= litellm.BadRequestError: OpenAIException - {   "error": {     "message": "Cannot cancel a completed response.",     "type": "invalid_request_error",     "param": null,     "code": null   } }. Received
```

3. The stalled day, from the CircleCI runs the ticket came from (jobs 2153249, 2151489, 2144178): 9-10 `keepalive` chunks about 30s apart, then `response.created`, `response.queued`, and the failure

```
FAILED tests/openai_endpoints_tests/test_e2e_openai_responses_api.py::test_cancel_streaming_response - openai.APIError: litellm.APIError: An error occurred while processing the request.
301.17s call     tests/openai_endpoints_tests/test_e2e_openai_responses_api.py::test_cancel_streaming_response
```

### After (0904a9223b)

1. `pytest <copy of the test file> -k cancel_streaming -s --durations=1`, three runs in a row: the cancel lands on the queued response and comes back `cancelled`

```
===== run 1 =====
CANCEL streaming response= status=cancelled
3.02s call     test_lit6888_local_e2e.py::test_cancel_streaming_response
======================= 1 passed, 7 deselected in 4.72s ========================
===== run 2 =====
CANCEL streaming response= status=cancelled
2.21s call     test_lit6888_local_e2e.py::test_cancel_streaming_response
======================= 1 passed, 7 deselected in 3.24s ========================
===== run 3 =====
CANCEL streaming response= status=cancelled
2.57s call     test_lit6888_local_e2e.py::test_cancel_streaming_response
======================= 1 passed, 7 deselected in 4.34s ========================
```

2. The same flow with curl, same `POST /v1/responses` body as above, cancelling the moment the first `data:` line arrives, three runs

```
===== curl run 1: cancel the moment the first event arrives =====
first event after 1.6s: response.created status=queued id_len=477
POST /v1/responses/{id}/cancel ->
HTTP 200 {"object": "response", "status": "cancelled", "model": "gpt-5.5-2026-04-23", "id_len": 229}
total 5.3s
===== curl run 2: cancel the moment the first event arrives =====
first event after 1.0s: response.created status=queued id_len=477
POST /v1/responses/{id}/cancel ->
HTTP 200 {"object": "response", "status": "cancelled", "model": "gpt-5.5-2026-04-23", "id_len": 229}
total 3.5s
===== curl run 3: cancel the moment the first event arrives =====
first event after 1.3s: response.created status=queued id_len=477
POST /v1/responses/{id}/cancel ->
HTTP 200 {"object": "response", "status": "cancelled", "model": "gpt-5.5-2026-04-23", "id_len": 229}
total 5.9s
```

## Type

🐛 Bug Fix
✅ Test

## Caveats (if any)

### Low

- Skip path never fired live: the upstream stall did not recur
  - Only an upstream keepalive stall reaches it; a synthetic stream would be a mock
  - Each step is evidenced: the SDK parses keepalive frames to `type='keepalive'`, the deadline runs per chunk
- A stalled day shows as a skip, not a failure
  - A silent proxy stall still fails: the 90s read timeout raises instead
- `test_cancel_response` still swallows "Cannot cancel a completed response", untouched
- Cancel returns a shorter 229-char id than the stream's 477
  - Retrieve accepts it; the queued event's base64 id is LIT-6832
- `code-quality` and `local_testing_part1/2` fail on staging too, not from this PR
  - LIT-6904 tracks `code-quality`; the other two are Bedrock cohere flakes

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to an e2e OpenAI Responses cancel scenario; no production or proxy behavior is modified.
> 
> **Overview**
> **Hardens `test_cancel_streaming_response`** so the OpenAI Responses background-stream cancel e2e finishes quickly and fails predictably when upstream stalls.
> 
> The test now **stops reading the stream as soon as an event exposes a response id** (via `admitted_response_id` / `events_until_admission`), uses a **90s SDK timeout and monotonic deadline**, and **`pytest.skip`s** when only `keepalive` frames arrive without admission. The prompt is switched to a **long generation** so completion is less likely to beat cancel, and the test **asserts `cancel_response.status == "cancelled"`** instead of draining the stream and swallowing “Cannot cancel a completed response”.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0904a9223bb4e01c2ad9d6ceb56529fe4637b4b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

- [x] 0904a9223b passes /live-pr-risk
