### PR TITLE
fix(proxy): expose configured mode for auto-router models

### DIFF
--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -7531,6 +7531,9 @@ def create_model_info_response(
             max_input_tokens = configured_input
         if configured_output is not None:
             max_output_tokens = configured_output
+        configured_mode: Final = llm_router.get_configured_mode(model_id)
+        if isinstance(configured_mode, str):
+            base["mode"] = configured_mode
 
     if max_input_tokens is not None:
         base["max_input_tokens"] = max_input_tokens

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -9981,6 +9981,17 @@ class Router:
             coerce_token_limit(model_info.get("max_output_tokens")),
         )
 
+    def get_configured_mode(self, model_name: str) -> "str | None":
+        """Return the mode explicitly configured for a concrete deployment."""
+        deployment: Final = self.get_deployment_by_model_group_name(model_group_name=model_name)
+        if deployment is None:
+            return None
+
+        mode: Final = deployment.model_info.get("mode")
+        if isinstance(mode, str) and mode.strip():
+            return mode
+        return None
+
     def get_configured_display_name(self, model_name: str) -> "str | None":
         """
         Return the display_name explicitly configured in a concrete deployment's

--- a/litellm/types/proxy/model_listing.py
+++ b/litellm/types/proxy/model_listing.py
@@ -11,8 +11,8 @@ class ModelInfoMetadata(TypedDict):
 
 class ModelInfoResponse(TypedDict):
     """OpenAI-compatible model object. `mode`, `max_input_tokens`, and
-    `max_output_tokens` are attached when the cost map knows them; `metadata`
-    is present only when the endpoint is called with include_metadata=true.
+    `max_output_tokens` are attached when the cost map or deployment config
+    knows them; `metadata` is present only with include_metadata=true.
     """
 
     id: str

--- a/tests/test_litellm/proxy/test_proxy_utils.py
+++ b/tests/test_litellm/proxy/test_proxy_utils.py
@@ -942,6 +942,47 @@ def test_create_model_info_response_uses_deployment_limits_when_not_in_cost_map(
     assert response["max_output_tokens"] == 8000
 
 
+def test_create_model_info_response_uses_deployment_mode_for_auto_router():
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "claude-sonnet",
+                "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "test-key"},
+            },
+            {
+                "model_name": "claude-auto",
+                "litellm_params": {
+                    "model": "auto_router/complexity_router",
+                    "complexity_router_config": {
+                        "tiers": {
+                            "SIMPLE": "claude-sonnet",
+                            "MEDIUM": "claude-sonnet",
+                            "COMPLEX": "claude-sonnet",
+                        }
+                    },
+                    "complexity_router_default_model": "claude-sonnet",
+                },
+                "model_info": {
+                    "mode": "chat",
+                    "max_input_tokens": 1_000_000,
+                    "max_output_tokens": 128_000,
+                },
+            },
+        ]
+    )
+
+    response = create_model_info_response(
+        model_id="claude-auto",
+        provider="openai",
+        llm_router=router,
+        get_model_info=_raise_unmapped,
+    )
+
+    assert response["mode"] == "chat"
+    assert response["max_input_tokens"] == 1_000_000
+    assert response["max_output_tokens"] == 128_000
+
+
 def test_create_model_info_response_deployment_limits_override_cost_map():
     router = MagicMock()
     router.get_configured_token_limits.return_value = (200000, None)


### PR DESCRIPTION
## TLDR

Problem this solves:

- Auto-router model listings omit their configured mode
- Claude Code cannot identify the model as chat-capable

How it solves it:

- Read mode from the matching deployment configuration
- Prefer the explicit configured mode when available

## User Flow

Before: a developer lists an auto-router and cannot see its configured mode

1. They configure `claude-auto` with `model_info.mode: chat`
2. They send `GET http://localhost:40151/v1/models`
3. The response returns 200 with token limits but no `mode`

After: the same listing exposes the auto-router as chat-capable

1. They configure `claude-auto` with `model_info.mode: chat`
2. They send `GET http://localhost:40151/v1/models`
3. The response returns 200 with token limits and `"mode":"chat"`

## Relevant issues

Fixes #39451

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible
- [ ] I have received a Greptile Confidence Score of at least 4/5

## Screenshots / Proof of Fix

Shared setup uses a real local proxy with `claude-auto` configured as an `auto_router/complexity_router`, `model_info.mode: chat`, `max_input_tokens: 1000000`, and `max_output_tokens: 128000`

### Before (92122086ec)

1. Start the proxy from the staging commit with the shared configuration
2. Run `curl -sS -H 'Authorization: Bearer sk-39451-proof' http://127.0.0.1:40151/v1/models`
3. Observe `{"id":"claude-auto","object":"model","created":1677610602,"owned_by":"openai","max_input_tokens":1000000,"max_output_tokens":128000}` with no `mode`

### After (425e3069b9)

1. Start the proxy from the fixed commit with the same configuration
2. Run `curl -sS -H 'Authorization: Bearer sk-39451-proof' http://127.0.0.1:40151/v1/models`
3. Observe `{"id":"claude-auto","object":"model","created":1677610602,"owned_by":"openai","mode":"chat","max_input_tokens":1000000,"max_output_tokens":128000}`

## Type

🐛 Bug Fix

## Caveats (if any)

## Final Attestation

- [x] The tests cover the reported auto-router listing regression

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to model listing metadata on the existing /v1/models path, mirroring the already-shipped deployment token limit override.
> 
> **Overview**
> **Fixes auto-router (and other deployment-only) models missing `mode` on `GET /v1/models`**, even when `model_info.mode` is set in config—matching how deployment token limits already override the cost map.
> 
> Adds `Router.get_configured_mode()` (same O(1) deployment lookup as `get_configured_token_limits`) and uses it in `create_model_info_response` to set `mode` from the deployment when present. Clients like Claude Code can then treat listings as chat-capable when configured.
> 
> Doc on `ModelInfoResponse` notes that `mode` and token limits can come from deployment config, not only the cost map. Regression test covers an `auto_router/complexity_router` deployment with `model_info.mode: chat`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 425e3069b93ec005e3186f5d32fa21ef70effe17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->