### PR TITLE
fix(team): include an org admin's direct team memberships from other orgs in /team/list

### DIFF
--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -5220,20 +5220,22 @@ async def _authorize_and_filter_teams(
     Authorize the /team/list request and return filtered teams.
 
     - Proxy admins: all teams (or filtered by user_id if provided).
-    - Org admins: teams from their orgs (scoped to user_id if provided).
-    - Own query (user_id matches caller): teams the user is a member of.
+    - Org admins: teams from their orgs (scoped to the target user_id if provided).
+    - Own query (user_id matches caller): every team the user is a member of,
+      across all orgs — even if the caller is also an org admin somewhere.
     - Others: 401.
     """
     is_proxy_admin: Final = _user_has_admin_view(user_api_key_dict)
+    is_own_query: Final = (
+        user_id is not None and user_api_key_dict.user_id is not None and user_api_key_dict.user_id == user_id
+    )
     allowed_org_ids: list[str] | None = None
 
     if not is_proxy_admin:
-        is_own_query: Final = (
-            user_id is not None and user_api_key_dict.user_id is not None and user_api_key_dict.user_id == user_id
-        )
-
-        # Check if user is an org admin (even for own queries, so they see org teams)
-        if user_api_key_dict.user_id is not None:
+        # Check if user is an org admin — that authorizes queries beyond their
+        # own memberships. Own queries don't need it: they are always allowed
+        # and return the caller's memberships across all orgs (issue #39394).
+        if user_api_key_dict.user_id is not None and not is_own_query:
             caller_user: Final = await get_user_object(
                 user_id=user_api_key_dict.user_id,
                 prisma_client=prisma_client,
@@ -5258,7 +5260,10 @@ async def _authorize_and_filter_teams(
                 },
             )
 
-    if allowed_org_ids is not None:
+    # An own query must NOT be limited to the caller's administered orgs: a user
+    # who is org_admin of one org can also be a plain member of teams in other
+    # orgs, and those direct memberships must be returned too (issue #39394).
+    if allowed_org_ids is not None and not is_own_query:
         # Org admin: query DB for teams in their orgs
         org_teams: Final = await _raw_team_db(TeamRepository(prisma_client)).find_many(
             where={"organization_id": {"in": allowed_org_ids}},
@@ -5273,7 +5278,8 @@ async def _authorize_and_filter_teams(
             if team.members_with_roles and any(m.get("user_id") == user_id for m in team.members_with_roles)
         ]
     elif user_id:
-        # Regular user: fetch all and filter by membership (Prisma can't filter JSON arrays)
+        # Own query (or proxy admin filtering by user): fetch all and filter by
+        # membership (Prisma can't filter JSON arrays)
         response: Final = await _raw_team_db(TeamRepository(prisma_client)).find_many(
             include={"litellm_model_table": True}
         )

--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
@@ -13527,3 +13527,204 @@ async def test_team_member_update_skips_invalidation_when_no_budget_fields_sent(
 
     assert await real_cache.async_get_cache(key="team-1_member-1") == "still-fresh-membership"
     assert real_spend_counter_cache.in_memory_cache.get_cache(key="spend:team_member:member-1:team-1") == 1.5
+
+
+# ---------------------------------------------------------------------------
+# /team/list (v1) — _authorize_and_filter_teams
+# Regression tests for https://github.com/BerriAI/litellm/issues/39394:
+# a user who is org_admin of any org must still see teams they are a plain
+# member of in other orgs when querying their own user_id.
+# ---------------------------------------------------------------------------
+
+
+def _make_team_row(team_id: str, organization_id: Optional[str], member_ids: list) -> MagicMock:
+    """Build a mock prisma LiteLLM_TeamTable row for /team/list tests."""
+    row = MagicMock()
+    row.team_id = team_id
+    row.organization_id = organization_id
+    row.members_with_roles = [{"user_id": uid, "role": "user"} for uid in member_ids]
+    row.model_dump.return_value = {
+        "team_id": team_id,
+        "team_alias": f"alias-{team_id}",
+        "organization_id": organization_id,
+        "members_with_roles": row.members_with_roles,
+    }
+    return row
+
+
+def _make_teams_prisma_mock(all_team_rows: list) -> MagicMock:
+    """Mock prisma client whose litellm_teamtable.find_many honors the
+    organization_id where-clause used by _authorize_and_filter_teams."""
+    mock_prisma = MagicMock()
+
+    async def fake_find_many(**kwargs):
+        where = kwargs.get("where") or {}
+        org_filter = where.get("organization_id")
+        if org_filter is not None:
+            return [t for t in all_team_rows if t.organization_id in org_filter["in"]]
+        return list(all_team_rows)
+
+    mock_prisma.db.litellm_teamtable.find_many = AsyncMock(side_effect=fake_find_many)
+    mock_prisma.db.litellm_teammembership.find_many = AsyncMock(return_value=[])
+    mock_prisma.db.litellm_verificationtoken.find_many = AsyncMock(return_value=[])
+    return mock_prisma
+
+
+def _make_org_membership_user(user_id: str, org_roles: dict) -> LiteLLM_UserTable:
+    """org_roles: {organization_id: user_role}"""
+    now = datetime.now(timezone.utc)
+    return LiteLLM_UserTable(
+        user_id=user_id,
+        organization_memberships=[
+            LiteLLM_OrganizationMembershipTable(
+                user_id=user_id,
+                organization_id=org_id,
+                user_role=role,
+                spend=0.0,
+                created_at=now,
+                updated_at=now,
+            )
+            for org_id, role in org_roles.items()
+        ],
+    )
+
+
+_MIXED_ROLE_TEAMS: Final = [
+    # ("team_id", "organization_id", [member user_ids])
+    ("team_a1", "org_A", ["mixed_user"]),
+    ("team_a2", "org_A", ["other_user"]),
+    ("team_b1", "org_B", ["mixed_user"]),
+    ("team_b2", "org_B", ["other_user"]),
+]
+
+
+async def _run_authorize_and_filter_teams(
+    caller_user: Optional[LiteLLM_UserTable],
+    user_api_key_dict: UserAPIKeyAuth,
+    user_id: Optional[str],
+    mock_prisma: MagicMock,
+):
+    from litellm.proxy.management_endpoints.team_endpoints import (
+        _authorize_and_filter_teams,
+    )
+
+    with patch(  # test-quality-ok: no live DB here; matches this file's established convention for endpoint-logic unit tests
+        "litellm.proxy.management_endpoints.team_endpoints.get_user_object",
+        new_callable=AsyncMock,
+        return_value=caller_user,
+    ):
+        return await _authorize_and_filter_teams(
+            user_api_key_dict=user_api_key_dict,
+            user_id=user_id,
+            prisma_client=mock_prisma,
+            user_api_key_cache=MagicMock(),
+            proxy_logging_obj=MagicMock(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_team_list_org_admin_own_query_includes_member_teams_in_other_orgs():
+    """
+    Mixed-role user: org_admin of org_A, plain member of a team in org_B.
+    An own query must return BOTH the org_A team they belong to and the
+    org_B team they are a direct member of (issue #39394 — previously the
+    org_admin branch dropped the org_B membership entirely).
+    """
+    teams = [_make_team_row(*t) for t in _MIXED_ROLE_TEAMS]
+    mock_prisma = _make_teams_prisma_mock(teams)
+    caller = _make_org_membership_user("mixed_user", {"org_A": "org_admin"})
+    key = UserAPIKeyAuth(user_id="mixed_user", user_role=LitellmUserRoles.INTERNAL_USER)
+
+    result = await _run_authorize_and_filter_teams(caller, key, "mixed_user", mock_prisma)
+
+    assert {t.team_id for t in result} == {"team_a1", "team_b1"}
+
+
+@pytest.mark.asyncio
+async def test_team_list_pure_member_own_query_unchanged():
+    """A user with no org_admin role anywhere still gets all their member teams."""
+    teams = [_make_team_row(*t) for t in _MIXED_ROLE_TEAMS]
+    mock_prisma = _make_teams_prisma_mock(teams)
+    caller = _make_org_membership_user("mixed_user", {"org_A": "internal_user"})
+    key = UserAPIKeyAuth(user_id="mixed_user", user_role=LitellmUserRoles.INTERNAL_USER)
+
+    result = await _run_authorize_and_filter_teams(caller, key, "mixed_user", mock_prisma)
+
+    assert {t.team_id for t in result} == {"team_a1", "team_b1"}
+
+
+@pytest.mark.asyncio
+async def test_team_list_org_admin_bare_query_unchanged():
+    """An org admin listing without user_id still sees every team in their orgs."""
+    teams = [_make_team_row(*t) for t in _MIXED_ROLE_TEAMS]
+    mock_prisma = _make_teams_prisma_mock(teams)
+    caller = _make_org_membership_user("mixed_user", {"org_A": "org_admin"})
+    key = UserAPIKeyAuth(user_id="mixed_user", user_role=LitellmUserRoles.INTERNAL_USER)
+
+    result = await _run_authorize_and_filter_teams(caller, key, None, mock_prisma)
+
+    assert {t.team_id for t in result} == {"team_a1", "team_a2"}
+
+
+@pytest.mark.asyncio
+async def test_team_list_org_admin_other_user_query_stays_scoped_to_their_orgs():
+    """An org admin querying ANOTHER user's teams stays scoped to the orgs
+    they administer — the fix must not widen cross-org visibility."""
+    teams = [_make_team_row(*t) for t in _MIXED_ROLE_TEAMS]
+    mock_prisma = _make_teams_prisma_mock(teams)
+    caller = _make_org_membership_user("mixed_user", {"org_A": "org_admin"})
+    key = UserAPIKeyAuth(user_id="mixed_user", user_role=LitellmUserRoles.INTERNAL_USER)
+
+    result = await _run_authorize_and_filter_teams(caller, key, "other_user", mock_prisma)
+
+    # other_user is a member of team_a2 (org_A, administered) and team_b2
+    # (org_B, not administered) — only the org_A team may be returned.
+    assert {t.team_id for t in result} == {"team_a2"}
+
+
+@pytest.mark.asyncio
+async def test_team_list_non_admin_other_user_query_still_rejected():
+    """A non-admin querying another user's teams is still rejected with 401."""
+    teams = [_make_team_row(*t) for t in _MIXED_ROLE_TEAMS]
+    mock_prisma = _make_teams_prisma_mock(teams)
+    caller = _make_org_membership_user("mixed_user", {"org_A": "internal_user"})
+    key = UserAPIKeyAuth(user_id="mixed_user", user_role=LitellmUserRoles.INTERNAL_USER)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _run_authorize_and_filter_teams(caller, key, "other_user", mock_prisma)
+    assert exc_info.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_team_list_endpoint_organization_id_filter_applies_to_mixed_role_user():
+    """
+    GET /team/list?user_id=<caller>&organization_id=org_B for the mixed-role
+    user returns exactly their org_B membership (the issue's second repro
+    line returned [] before the fix). Also verifies the organization_id
+    filter still applies on top of the widened own-query scope.
+    """
+    from litellm.proxy.management_endpoints.team_endpoints import list_team
+
+    teams = [_make_team_row(*t) for t in _MIXED_ROLE_TEAMS]
+    mock_prisma = _make_teams_prisma_mock(teams)
+    caller = _make_org_membership_user("mixed_user", {"org_A": "org_admin"})
+    key = UserAPIKeyAuth(user_id="mixed_user", user_role=LitellmUserRoles.INTERNAL_USER)
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
+        patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
+        patch("litellm.proxy.proxy_server.proxy_logging_obj", MagicMock()),
+        patch(  # test-quality-ok: no live DB here; matches this file's established convention for endpoint-logic unit tests
+            "litellm.proxy.management_endpoints.team_endpoints.get_user_object",
+            new_callable=AsyncMock,
+            return_value=caller,
+        ),
+    ):
+        result = await list_team(
+            http_request=MagicMock(),
+            user_id="mixed_user",
+            organization_id="org_B",
+            user_api_key_dict=key,
+        )
+
+    assert [t.team_id for t in result] == ["team_b1"]


### PR DESCRIPTION
## TLDR

Problem this solves:

- Org admins lost their plain team memberships in other orgs on `/team/list`
- Dashboard key-creation team picker showed those users an incomplete team list

How it solves it:

- Own queries (`user_id` = caller) now return memberships across all orgs
- Org-admin scoping still applies when listing without `user_id` or for other users

## User Flow

Before: a user who is org admin of org A and a plain member of a team in org B cannot see that team

1. They send GET https://litellm-domain/team/list?user_id=&lt;their-own-id&gt; with their virtual key
2. The response contains only teams inside org A — the org B team they belong to is missing
3. They send GET https://litellm-domain/team/list?user_id=&lt;their-own-id&gt;&organization_id=&lt;org-B&gt; and get back `[]`
4. GET https://litellm-domain/user/info shows the org B team in `teams`, so the membership clearly exists
5. On https://litellm-domain/ui the key-creation team picker never offers the org B team

After: the same request returns every team they belong to

1. They send GET https://litellm-domain/team/list?user_id=&lt;their-own-id&gt; with their virtual key
2. The response contains the org A teams they belong to and the org B team they are a member of
3. They send GET https://litellm-domain/team/list?user_id=&lt;their-own-id&gt;&organization_id=&lt;org-B&gt; and get back exactly the org B team
4. GET https://litellm-domain/user/info agrees with `/team/list`
5. On https://litellm-domain/ui the key-creation team picker offers the org B team
6. Listing without `user_id` still returns all teams of the orgs they administer, and querying another user's teams is still limited to those orgs — no one can see more of other users than before

## Relevant issues

Fixes #39394

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Honest note: I could not run a live proxy + Postgres end-to-end in my environment, so the proof below is the unit-test suite; the new tests mock the prisma layer the same way the neighboring `/team/list` tests in `tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py` do, and they encode the issue's API repro (own query, and own query + `organization_id`) step for step.

### Before (9212208)

The two regression tests reproduce the bug (only the fix stashed, tests kept):

```
$ python -m pytest tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py -k "own_query_includes_member_teams or organization_id_filter_applies_to_mixed"
FAILED ...::test_team_list_endpoint_organization_id_filter_applies_to_mixed_role_user
FAILED ...::test_team_list_org_admin_own_query_includes_member_teams_in_other_orgs
2 failed, 335 deselected in 5.22s
```

### After (this PR)

```
$ python -m pytest tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
337 passed, 94 warnings in 9.31s

$ python -m pytest tests/test_litellm/proxy/management_endpoints/test_org_admin_team_access.py
16 passed, 2 warnings in 4.26s
```

The new regression tests encode the issue's repro directly:

- `test_team_list_org_admin_own_query_includes_member_teams_in_other_orgs` — mixed-role user (org_admin of org A, member of a team in org B) now sees both; asserted set was only the org A team before the fix
- `test_team_list_endpoint_organization_id_filter_applies_to_mixed_role_user` — the issue's second repro line (`?user_id=<U>&organization_id=<B>` returned `[]`) now returns the org B membership, and the `organization_id` filter still applies
- `test_team_list_pure_member_own_query_unchanged` — control case from the issue stays correct
- `test_team_list_org_admin_bare_query_unchanged` — org admin without `user_id` still sees every team in their orgs
- `test_team_list_org_admin_other_user_query_stays_scoped_to_their_orgs` — querying another user is still limited to administered orgs (no widened visibility)
- `test_team_list_non_admin_other_user_query_still_rejected` — non-admins querying other users still get 401

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Own queries by org admins now skip one cached user lookup (no behavior change)

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
