### PR TITLE
test(router): cover get_configured_mode so router_code_coverage passes

### DIFF
--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -12553,3 +12553,33 @@ async def test_prompt_management_factory_marks_injection_for_every_deployment(mo
     bucket = captured.get("litellm_metadata") or captured["metadata"]
     assert captured["model_info"]["id"] == "provisional-dep"
     assert bucket["litellm_gateway_injected_cache"] == ""
+
+
+def test_get_configured_mode_reads_deployment_model_info():
+    router = Router(
+        model_list=[
+            {
+                "model_name": "my-tts",
+                "litellm_params": {"model": "openai/tts-1", "api_key": "fake-key"},
+                "model_info": {"mode": "audio_speech"},
+            }
+        ]
+    )
+
+    assert router.get_configured_mode("my-tts") == "audio_speech"
+
+
+@pytest.mark.parametrize("model_info", [{}, {"mode": ""}, {"mode": "   "}, {"mode": 123}])
+def test_get_configured_mode_returns_none_for_unset_blank_or_unknown(model_info):
+    router = Router(
+        model_list=[
+            {
+                "model_name": "plain-model",
+                "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "fake-key"},
+                "model_info": model_info,
+            }
+        ]
+    )
+
+    assert router.get_configured_mode("plain-model") is None
+    assert router.get_configured_mode("unknown-model") is None

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -12560,7 +12560,7 @@ def test_get_configured_mode_reads_deployment_model_info():
         model_list=[
             {
                 "model_name": "my-tts",
-                "litellm_params": {"model": "openai/tts-1", "api_key": "fake-key"},
+                "litellm_params": {"model": "openai/some-unmapped-mode-model"},
                 "model_info": {"mode": "audio_speech"},
             }
         ]
@@ -12575,7 +12575,7 @@ def test_get_configured_mode_returns_none_for_unset_blank_or_unknown(model_info)
         model_list=[
             {
                 "model_name": "plain-model",
-                "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "fake-key"},
+                "litellm_params": {"model": "openai/some-unmapped-mode-model"},
                 "model_info": model_info,
             }
         ]


### PR DESCRIPTION
## TLDR

Problem this solves:

- `code-quality` workflow fails on staging and every open PR
- `router_code_coverage` gate flags `Router.get_configured_mode` as untested
- 425e3069b9 tested it only indirectly, which the gate does not count

How it solves it:

- Add direct tests for `get_configured_mode` in the router test file
- Covers the configured case plus unset, blank, non-string, and unknown model

## User Flow

Before: a contributor opens any PR against staging and the code-quality check is red for a reason unrelated to their change

1. They push a branch and open a PR
2. The `code-quality` check fails within about a minute with `Exception: 0.29% of functions in router.py are not tested: ['get_configured_mode']`
3. Nothing in their diff can make it pass

After: the same PR gets a green code-quality check

1. They push a branch and open a PR
2. The `code-quality` check runs the router coverage gate and reports 0% untested
3. The check passes

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The deliverable is the CI gate itself, so the proof is the gate's own output, run locally with the same script the workflow runs

### Before (828d561fcc)

1. `python tests/code_coverage_tests/router_code_coverage.py`
2. Output, same as the failing staging run https://github.com/BerriAI/litellm/actions/runs/33801768561/job/100802717099:
   ```
   Exception: 0.29% of functions in router.py are not tested: ['get_configured_mode']
   ```

### After (4e0907fb2d)

1. `python tests/code_coverage_tests/router_code_coverage.py`
2. Output:
   ```
   untested_perc:  0.0
   ```
3. `pytest tests/test_litellm/test_router.py -k get_configured_mode` reports 5 passed

## Type

✅ Test

## Caveats (if any)

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

