### PR TITLE
fix: treat gpt-6 names as the gpt-5 request family in OpenAI and Azure configs

### DIFF
--- a/litellm/llms/azure/chat/gpt_5_transformation.py
+++ b/litellm/llms/azure/chat/gpt_5_transformation.py
@@ -7,6 +7,7 @@ from litellm.exceptions import UnsupportedParamsError
 from litellm.llms.openai.chat.gpt_5_transformation import (
     OpenAIGPT5Config,
     _get_effort_level,
+    is_gpt_reasoning_series_name,
 )
 from litellm.types.llms.openai import AllMessageValues
 
@@ -35,26 +36,7 @@ class AzureOpenAIGPT5Config(AzureOpenAIConfig, OpenAIGPT5Config):
 
     @classmethod
     def is_model_gpt_5_model(cls, model: str) -> bool:
-        """Check if the Azure model string refers to a gpt-5 variant.
-
-        Accepts both explicit gpt-5 model names and the ``gpt5_series/`` prefix
-        used for manual routing.
-        """
-        # The gpt-5-chat* family (gpt-5-chat, gpt-5-chat-latest, gpt-5-chat-2025-08-07,
-        # …) are regular chat models: they support temperature and tool_choice but NOT
-        # reasoning_effort.  They must NOT be routed through the GPT-5 reasoning path.
-        #
-        # Versioned chat models such as gpt-5.3-chat and gpt-5.1-chat ARE reasoning
-        # models and must stay on the GPT-5 path.  The distinguishing feature is that
-        # the gpt-5-chat family has a literal "-chat" immediately after "gpt-5"
-        # (i.e. "gpt-5-chat…"), while versioned chat models interpose a minor version
-        # number (i.e. "gpt-5.<digit>-chat").
-        #
-        # Using a startswith("gpt-5-chat") prefix check on the normalized name (rather
-        # than a substring check) makes this boundary explicit and avoids any ambiguity
-        # if future model names coincidentally contain "gpt-5-chat" as an interior run.
-        _normalized: Final = model.split("/")[-1]  # strip provider prefix, e.g. "azure/"
-        return ("gpt-5" in model and not _normalized.startswith("gpt-5-chat")) or "gpt5_series" in model
+        return is_gpt_reasoning_series_name(model) or "gpt5_series" in model
 
     def get_supported_openai_params(self, model: str) -> list[str]:
         """Get supported parameters for Azure OpenAI GPT-5 models.

--- a/litellm/llms/azure/chat/gpt_transformation.py
+++ b/litellm/llms/azure/chat/gpt_transformation.py
@@ -14,6 +14,7 @@ from litellm.litellm_core_utils.prompt_templates.factory import (
     convert_to_azure_openai_messages,
 )
 from litellm.llms.base_llm.chat.transformation import BaseLLMException
+from litellm.llms.openai.chat.gpt_5_transformation import GPT_REASONING_SERIES_MARKERS
 from litellm.types.llms.azure import (
     API_VERSION_MONTH_SUPPORTED_RESPONSE_FORMAT,
     API_VERSION_YEAR_SUPPORTED_RESPONSE_FORMAT,
@@ -139,7 +140,7 @@ class AzureOpenAIConfig(BaseConfig):
         name family needs the rename, including the ``gpt-5-chat*`` models that are excluded from
         the reasoning path by https://github.com/BerriAI/litellm/issues/13781.
         """
-        return "gpt-5" in model or "gpt5_series" in model
+        return any(marker in model for marker in GPT_REASONING_SERIES_MARKERS) or "gpt5_series" in model
 
     def _is_response_format_supported_model(self, model: str) -> bool:
         """

--- a/litellm/llms/openai/chat/gpt_5_transformation.py
+++ b/litellm/llms/openai/chat/gpt_5_transformation.py
@@ -61,6 +61,14 @@ def _get_effort_level(value: str | dict | None) -> str | None:
     return None
 
 
+GPT_REASONING_SERIES_MARKERS: Final = ("gpt-5", "gpt-6")
+
+
+def is_gpt_reasoning_series_name(model: str) -> bool:
+    normalized: Final = model.split("/")[-1]
+    return any(marker in model for marker in GPT_REASONING_SERIES_MARKERS) and not normalized.startswith("gpt-5-chat")
+
+
 class OpenAIGPT5Config(OpenAIGPTConfig):
     """Configuration for gpt-5 models including GPT-5-Codex variants.
 
@@ -73,21 +81,7 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
 
     @classmethod
     def is_model_gpt_5_model(cls, model: str) -> bool:
-        # The gpt-5-chat* family (gpt-5-chat, gpt-5-chat-latest, gpt-5-chat-2025-08-07,
-        # …) are regular chat models: they support temperature and tool_choice but NOT
-        # reasoning_effort.  They must NOT be routed through the GPT-5 reasoning path.
-        #
-        # Versioned chat models such as gpt-5.3-chat and gpt-5.1-chat ARE reasoning
-        # models and must stay on the GPT-5 path.  The distinguishing feature is that
-        # the gpt-5-chat family has a literal "-chat" immediately after "gpt-5"
-        # (i.e. "gpt-5-chat…"), while versioned chat models interpose a minor version
-        # number (i.e. "gpt-5.<digit>-chat").
-        #
-        # Using a startswith("gpt-5-chat") prefix check on the normalized name (rather
-        # than a substring check) makes this boundary explicit and avoids any ambiguity
-        # if future model names coincidentally contain "gpt-5-chat" as an interior run.
-        _normalized: Final = model.split("/")[-1]  # strip provider prefix, e.g. "openai/"
-        return "gpt-5" in model and not _normalized.startswith("gpt-5-chat")
+        return is_gpt_reasoning_series_name(model)
 
     @classmethod
     def is_model_gpt_5_search_model(cls, model: str) -> bool:
@@ -122,6 +116,8 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
     def is_model_gpt_5_4_plus_model(cls, model: str) -> bool:
         """Check if the model is gpt-5.4 or newer (5.4, 5.5, 5.6, etc., including pro)."""
         model_name: Final = model.split("/")[-1]
+        if model_name.startswith("gpt-6"):
+            return True
         if not model_name.startswith("gpt-5."):
             return False
         try:

--- a/litellm/llms/openai/responses/transformation.py
+++ b/litellm/llms/openai/responses/transformation.py
@@ -15,6 +15,7 @@ from litellm.litellm_core_utils.llm_response_utils.convert_dict_to_response impo
 )
 from litellm.litellm_core_utils.url_utils import encode_url_path_segment
 from litellm.llms.base_llm.responses.transformation import BaseResponsesAPIConfig
+from litellm.llms.openai.chat.gpt_5_transformation import is_gpt_reasoning_series_name
 from litellm.responses.litellm_completion_transformation.custom_tools import TOOL_CALL_ITEM_ID_PREFIX_BY_TYPE
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.openai import *
@@ -88,7 +89,7 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
         parts: Final = model.split("/")
         if len(parts) > 1 and parts[0] not in ("openai",):
             return False
-        return "gpt-5" in model and "gpt-5-chat" not in model
+        return is_gpt_reasoning_series_name(model)
 
     @staticmethod
     def _supports_reasoning_effort_none(model: str) -> bool:

--- a/tests/test_litellm/llms/azure/chat/test_azure_gpt5_transformation.py
+++ b/tests/test_litellm/llms/azure/chat/test_azure_gpt5_transformation.py
@@ -336,3 +336,15 @@ class TestAzureResolvesTheDeclaredDefaultEffort:
             drop_params=True,
         )
         assert ("temperature" in mapped) is temperature_survives
+
+
+def test_azure_gpt_6_astra_takes_the_reasoning_series_request_shape():
+    params = litellm.get_optional_params(
+        model="gpt-6-astra",
+        custom_llm_provider="azure",
+        max_tokens=100,
+        reasoning_effort="max",
+    )
+    assert params["max_completion_tokens"] == 100
+    assert "max_tokens" not in params
+    assert params["reasoning_effort"] == "max"

--- a/tests/test_litellm/llms/openai/responses/test_openai_responses_transformation.py
+++ b/tests/test_litellm/llms/openai/responses/test_openai_responses_transformation.py
@@ -1718,6 +1718,8 @@ class TestResponsesSurfaceSharesTheEffortRule:
             ("gpt-5.6-sol", None, False),
             ("gpt-5.6-terra", "none", True),
             ("gpt-5.6-terra", "medium", False),
+            ("gpt-6-astra", None, False),
+            ("gpt-6-astra", "low", False),
         ],
     )
     def test_temperature_follows_the_resolved_effort(

--- a/tests/test_litellm/llms/openai/test_gpt5_transformation.py
+++ b/tests/test_litellm/llms/openai/test_gpt5_transformation.py
@@ -1505,3 +1505,17 @@ class TestACatalogueOlderThanTheCodeDoesNotStripTemperature:
             drop_params=True,
         )
         assert "temperature" not in mapped
+
+
+def test_gpt_6_astra_takes_the_reasoning_series_request_shape():
+    params = litellm.get_optional_params(
+        model="gpt-6-astra",
+        custom_llm_provider="openai",
+        max_tokens=100,
+        reasoning_effort="max",
+        verbosity="low",
+    )
+    assert params["max_completion_tokens"] == 100
+    assert "max_tokens" not in params
+    assert params["reasoning_effort"] == "max"
+    assert params["verbosity"] == "low"

--- a/tests/test_litellm/llms/openai/test_is_model_gpt_5_model.py
+++ b/tests/test_litellm/llms/openai/test_is_model_gpt_5_model.py
@@ -41,6 +41,8 @@ from litellm.llms.azure.chat.gpt_5_transformation import AzureOpenAIGPT5Config
 
 # Models that MUST be classified as GPT-5 (routed through GPT-5 reasoning path)
 GPT5_MODELS = [
+    "gpt-6-astra",
+    "openai/gpt-6-astra",
     "gpt-5",
     "gpt-5.1",
     "gpt-5.2",
@@ -120,6 +122,8 @@ class TestOpenAIGPT5ConfigIsModelGpt5Model:
 # /v1/responses bridge (when reasoning_effort is set and tools are passed) on
 # is_model_gpt_5_4_plus_model, so the gpt-5.6 family must land on the True side.
 GPT5_4_PLUS_MODELS = [
+    "gpt-6-astra",
+    "openai/gpt-6-astra",
     "gpt-5.4",
     "gpt-5.5",
     "gpt-5.5-pro",

--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -787,13 +787,11 @@ def test_responses_api_bridge_check_gpt_5_4_tools_plus_reasoning_routes_to_respo
 def test_responses_api_bridge_check_gpt_6_astra_tools_with_default_reasoning_routes_to_responses():
     from litellm.main import responses_api_bridge_check
 
-    with patch("litellm.main._get_model_info_helper") as mock_get_model_info:
-        mock_get_model_info.return_value = {"max_tokens": 128000}
-        model_info, model = responses_api_bridge_check(
-            model="gpt-6-astra",
-            custom_llm_provider="openai",
-            tools=[{"type": "function", "function": {"name": "get_capital"}}],
-        )
+    model_info, model = responses_api_bridge_check(
+        model="gpt-6-astra",
+        custom_llm_provider="openai",
+        tools=[{"type": "function", "function": {"name": "get_capital"}}],
+    )
 
     assert model == "gpt-6-astra"
     assert model_info.get("mode") == "responses"

--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -784,6 +784,21 @@ def test_responses_api_bridge_check_gpt_5_4_tools_plus_reasoning_routes_to_respo
     assert model_info.get("mode") == "responses"
 
 
+def test_responses_api_bridge_check_gpt_6_astra_tools_with_default_reasoning_routes_to_responses():
+    from litellm.main import responses_api_bridge_check
+
+    with patch("litellm.main._get_model_info_helper") as mock_get_model_info:
+        mock_get_model_info.return_value = {"max_tokens": 128000}
+        model_info, model = responses_api_bridge_check(
+            model="gpt-6-astra",
+            custom_llm_provider="openai",
+            tools=[{"type": "function", "function": {"name": "get_capital"}}],
+        )
+
+    assert model == "gpt-6-astra"
+    assert model_info.get("mode") == "responses"
+
+
 def test_responses_api_bridge_check_gpt_5_5_tools_plus_reasoning_routes_to_responses():
     """gpt-5.5+ with both tools and reasoning_effort should route to Responses API."""
     from litellm.main import responses_api_bridge_check


### PR DESCRIPTION
## TLDR

Problem this solves:

- gpt-6-astra fails every `"gpt-5" in model` check, so it gets plain chat handling
- Chat completions 400 on `reasoning_effort`, `max_tokens`, and function tools
- Responses and Messages forward `temperature`, which OpenAI rejects

How it solves it:

- One helper matches gpt-5 and gpt-6 names, still excluding gpt-5-chat
- OpenAI chat, OpenAI Responses, and both Azure configs use it
- gpt-6 names count as gpt-5.4+ for the tools bridge

## User Flow

Before: a developer pointing an app at gpt-6-astra gets a 400 on request shapes that already work for gpt-5.5

1. They POST https://litellm-domain/v1/chat/completions with `"max_tokens": 200` and `"reasoning_effort": "low"` and get a 400 saying `openai does not support parameters: ['reasoning_effort']`
2. They POST https://litellm-domain/v1/chat/completions with a `get_weather` function tool and no reasoning_effort and get a 400 from OpenAI saying function tools with reasoning_effort are not supported in /v1/chat/completions
3. They POST https://litellm-domain/v1/responses with `"temperature": 0` and `"drop_params": true` and get a 400 from OpenAI saying `'temperature' is not supported with this model`
4. They POST https://litellm-domain/v1/messages with the same temperature and drop_params and get the same 400

After: the same four requests return 200

1. They POST https://litellm-domain/v1/chat/completions with `"max_tokens": 200` and `"reasoning_effort": "low"` and get a 200 with content `hello`
2. They POST https://litellm-domain/v1/chat/completions with the `get_weather` function tool and no reasoning_effort and get a 200 carrying a `get_weather` tool call for Paris
3. They POST https://litellm-domain/v1/responses with `"temperature": 0` and `"drop_params": true` and get a 200 with output text `hello`
4. They POST https://litellm-domain/v1/messages with the same temperature and drop_params and get a 200 with text `hello`

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Before is the merge base, which already carries the gpt-6-astra price map from #39622, so both runs price the same way. Every call below hits OpenAI's real gpt-6-astra

Shared setup:

`astra_config.yaml`

```yaml
model_list:
  - model_name: gpt-6-astra
    litellm_params:
      model: openai/gpt-6-astra
      api_key: os.environ/OPENAI_API_KEY

general_settings:
  master_key: sk-1234
```

`chat_params.json`

```json
{"model": "gpt-6-astra", "messages": [{"role": "user", "content": "Reply with one word: hello"}], "max_tokens": 200, "reasoning_effort": "low"}
```

`chat_tools.json`

```json
{"model": "gpt-6-astra", "messages": [{"role": "user", "content": "What is the weather in Paris? Use the tool."}],
 "tools": [{"type": "function", "function": {"name": "get_weather", "parameters": {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}}}]}
```

`responses_temperature.json`

```json
{"model": "gpt-6-astra", "input": "Reply with one word: hello", "temperature": 0, "drop_params": true}
```

`messages_temperature.json`

```json
{"model": "gpt-6-astra", "max_tokens": 200, "messages": [{"role": "user", "content": "Reply with one word: hello"}], "temperature": 0, "drop_params": true}
```

Proxy:

```bash
LITELLM_LOCAL_MODEL_COST_MAP=True python litellm/proxy/proxy_cli.py --config astra_config.yaml --port 4000 --use_v2_migration_resolver
```

### Before (f40f14ae39)

#### Chat completions with max_tokens and reasoning_effort

1. `curl -s http://localhost:4000/v1/chat/completions -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d @chat_params.json`

```json
{"error": {"message": "litellm.UnsupportedParamsError: openai does not support parameters: ['reasoning_effort'], for model=gpt-6-astra. To drop these, set `litellm.drop_params=True` or for proxy:\n\n`litellm_settings:\n drop_params: true`\n. \n If you want to use these params dynamically send allowed_openai_params=['reasoning_effort'] in your request.. Received Model Group=gpt-6-astra\nAvailable Model Group Fallbacks=None", "type": "None", "param": null, "code": "400"}}
```

#### Chat completions with a function tool and default reasoning

1. `curl -s http://localhost:4000/v1/chat/completions -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d @chat_tools.json`

```json
{"error": {"message": "litellm.BadRequestError: OpenAIException - Function tools with reasoning_effort are not supported for gpt-6-astra in /v1/chat/completions. To use function tools, use /v1/responses or set reasoning_effort to 'none'.. Received Model Group=gpt-6-astra\nAvailable Model Group Fallbacks=None", "type": "invalid_request_error", "param": "reasoning_effort", "code": "400"}}
```

#### Responses with temperature

1. `curl -s http://localhost:4000/v1/responses -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d @responses_temperature.json`

```json
{"error": {"message": "litellm.BadRequestError: OpenAIException - {\n  \"error\": {\n    \"message\": \"Unsupported parameter: 'temperature' is not supported with this model.\",\n    \"type\": \"invalid_request_error\",\n    \"param\": \"temperature\",\n    \"code\": null\n  }\n}. Received Model Group=gpt-6-astra\nAvailable Model Group Fallbacks=None", "type": null, "param": null, "code": "400"}}
```

#### Messages with temperature

1. `curl -s http://localhost:4000/v1/messages -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d @messages_temperature.json`

```json
{"error": {"message": "litellm.BadRequestError: OpenAIException - {\n  \"error\": {\n    \"message\": \"Unsupported parameter: 'temperature' is not supported with this model.\",\n    \"type\": \"invalid_request_error\",\n    \"param\": \"temperature\",\n    \"code\": null\n  }\n}. Received Model Group=gpt-6-astra\nAvailable Model Group Fallbacks=None", "type": null, "param": null, "code": "400"}}
```

### After (ab515dbc90)

#### Chat completions with max_tokens and reasoning_effort

1. `curl -s http://localhost:4000/v1/chat/completions -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d @chat_params.json` (id, model, usage, and message fields shown)

```json
{
  "id": "chatcmpl-EK8JFSLZSEN09MmRMrHufA4C2577E",
  "model": "gpt-6-astra",
  "usage": {"completion_tokens": 4, "prompt_tokens": 12, "total_tokens": 16},
  "content": "hello",
  "tool_calls": null
}
```

#### Chat completions with a function tool and default reasoning

1. `curl -s http://localhost:4000/v1/chat/completions -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d @chat_tools.json` (id, model, usage, and message fields shown)

```json
{
  "id": "chatcmpl-f2362822-b25e-460b-b2fe-3a3006583dce",
  "model": "gpt-6-astra",
  "usage": {"completion_tokens": 18, "prompt_tokens": 46, "total_tokens": 64},
  "content": null,
  "tool_calls": [
    {
      "index": 0,
      "function": {"arguments": "{\"city\":\"Paris\"}", "name": "get_weather"},
      "id": "call_skQlKBcCP2TNb1TmSlab3lM8",
      "type": "function"
    }
  ]
}
```

#### Responses with temperature

1. `curl -s http://localhost:4000/v1/responses -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d @responses_temperature.json` (id, model, usage, and output text shown)

```json
{
  "id": "resp_ydlZiGvaC8p71CLgwWGaj_ebwNZbKvZ-lm79ow2GrK6pV7U8tGvIhkPJGzydDVE4nZ_MXs_2JTv_oI-Mgcnw17lfpxRSyvK87wKWRibaDuqNpLk0nyDvCTMyK4To_Vk6stB7x--Td2f6yeM8_gOUltouW_WzuvlzZLlHfDqVaU5sAR2L8Vni0fUjc9je0BhJwlGpOHt5FhV8sv6aHSNwnTC3EzZujGrrVDVc9TcN7IB2ZPMceZggwHX9iT39ew5CVAKHKYXijNwLXLkukrMRDTkTarST9_n233RT5nvcAVCBfLmIhg-wFLGBGv_vZ-76h2T7vsXx7rORySuwt8kIJxP8Ut7zqcRuPepbKCBf9j1PqDS9kT3ZUJHQKANvb7hUPARBX3gBtIYQw9bvAbOX9ElX0pPDydjPpxQ_pl-10dNtHAQXkzRxIyNijg-vWMZNSr2EShOme_anrZ4L-KYlBSxs",
  "model": "gpt-6-astra",
  "usage": {"input_tokens": 12, "output_tokens": 5, "total_tokens": 17},
  "output": [{"type": "message", "text": "hello"}]
}
```

#### Messages with temperature

1. `curl -s http://localhost:4000/v1/messages -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d @messages_temperature.json` (id, model, usage, and content shown)

```json
{
  "id": "resp_bGl0ZWxsbTpjdXN0b21fbGxtX3Byb3ZpZGVyOm9wZW5haTttb2RlbF9pZDozMDdiOWQxZjliZDVlODY5ZjIzOWUwNzg1ZWY1YTNiMWYyN2YyNmZhMTgzYmVmZjZkOWM4MDgxZTAyOTVkOTQ5O3Jlc3BvbnNlX2lkOnJlc3BfMGM4YjZhMDc2ODEyZjRjYjAwNmE5OWQ4MGQ4NGQ4ODdkMDhlZTJjMzMxZWVhOWQ0YjA=",
  "model": "gpt-6-astra",
  "usage": {"input_tokens": 12, "output_tokens": 5},
  "content": [{"type": "text", "text": "hello"}]
}
```

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- OpenAI's chat completions rejects `reasoning_effort: max` for gpt-6-astra (low through xhigh only)
  - The Responses API accepts max, verified live, so the price map's max flag stands
- Bedrock Converse keeps its `openai.gpt-5` checks until the Bedrock model id for Astra is public

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
