### PR TITLE
test(router): cover configured mode lookup

### DIFF
--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -7358,6 +7358,71 @@ def test_get_configured_token_limits_coerces_numeric_strings():
     assert router.get_configured_token_limits("quoted-limits-model") == (32000, 8000)
 
 
+def test_get_configured_mode_reads_deployment_model_info():
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "chat-model",
+                "litellm_params": {"model": "openai/some-unmapped-model"},
+                "model_info": {"mode": "chat"},
+            }
+        ]
+    )
+
+    assert router.get_configured_mode("chat-model") == "chat"
+
+
+def test_get_configured_mode_returns_none_for_unset_or_unknown():
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "no-mode-model",
+                "litellm_params": {"model": "openai/some-unmapped-model"},
+            }
+        ]
+    )
+
+    assert router.get_configured_mode("no-mode-model") is None
+    assert router.get_configured_mode("not-a-real-model") is None
+
+
+def test_get_configured_mode_skips_wildcard_pattern_matching():
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "bedrock/*",
+                "litellm_params": {"model": "bedrock/*"},
+                "model_info": {"mode": "chat"},
+            }
+        ]
+    )
+
+    with patch.object(
+        router.pattern_router, "route", side_effect=AssertionError("pattern route called")
+    ):
+        assert (
+            router.get_configured_mode("bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0")
+            is None
+        )
+
+
+def test_get_configured_mode_treats_malformed_values_as_absent():
+    malformed = ["", "   ", 12345, ["chat"], {"mode": "chat"}, True]
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": f"bad-mode-{i}",
+                "litellm_params": {"model": "openai/some-unmapped-model"},
+                "model_info": {"mode": bad},
+            }
+            for i, bad in enumerate(malformed)
+        ]
+    )
+
+    for i in range(len(malformed)):
+        assert router.get_configured_mode(f"bad-mode-{i}") is None
+
+
 def test_get_configured_display_name_reads_deployment_model_info():
     router = litellm.Router(
         model_list=[


### PR DESCRIPTION
## TLDR

Problem this solves:

- Router coverage CI fails after #39619
- `get_configured_mode` is only tested indirectly

How it solves it:

- Adds direct coverage for configured mode lookup
- Covers missing, malformed, and wildcard cases

## User Flow

Before: a LiteLLM contributor sees the Router coverage check fail after merging #39619

1. They open the `code-quality` check for `litellm_internal_staging`
2. The Router coverage step fails and names `get_configured_mode` as untested

After: the same Router coverage check recognizes direct tests and passes

1. They open the `code-quality` check for this pull request
2. The Router coverage step reports `untested_perc: 0.0`

## Relevant issues

Follow-up to #39619

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

### Before (828d561f)

1. Run `.venv/bin/python tests/code_coverage_tests/router_code_coverage.py`
2. It raises `Exception: 0.29% of functions in router.py are not tested: ['get_configured_mode']`

### After (a264c62b)

1. Run `.venv/bin/python tests/code_coverage_tests/router_code_coverage.py`
2. It exits successfully with `untested_perc: 0.0`

## Type

✅ Test

## Caveats (if any)

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production code modifications.
> 
> **Overview**
> Adds **direct unit tests** for `Router.get_configured_mode` in `test_router.py`, addressing Router coverage CI that flagged the method as untested after #39619.
> 
> The new cases assert it returns deployment `model_info.mode` for a concrete model name, returns `None` for missing deployments or unset mode, **does not invoke wildcard pattern routing** (patched `pattern_router.route`), and treats non-string or blank/malformed `mode` values as absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a264c62b04ea357ce68bbd686bdf98aa81294bde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->