### PR TITLE
chore(rust): use fat LTO for release builds

### DIFF
--- a/litellm-rust/Cargo.toml
+++ b/litellm-rust/Cargo.toml
@@ -38,7 +38,7 @@ base64 = "0.22"
 
 [profile.release]
 opt-level = 3
-lto = "thin"
+lto = "fat"
 codegen-units = 1
 panic = "unwind"
 debug = false


### PR DESCRIPTION
## Summary
- Switch `litellm-rust/Cargo.toml` `[profile.release]` from `lto = "thin"` to `lto = "fat"`.
- One-line change; every researched peer project shipping Rust extensions (polars, pydantic-core, orjson, tokenizers) releases with fat LTO.

## Measurements (macOS arm64, local, `cargo build --release -p litellm-python-bridge`)

| Profile | `target/release/lib_native.dylib` | Delta |
|---|---|---|
| thin LTO (before) | 11,358,544 bytes (~10.83 MB) | — |
| fat LTO (after) | 10,127,936 bytes (~9.66 MB) | **−1,230,608 bytes (−10.8%)** |

Fat LTO produced a *smaller* cdylib locally (better cross-crate dead-code elimination), so the 20 MB native blob cap in CI is not a concern from this change; the wheel job should still be watched.

Sanity: `cargo test --workspace` passes (283 passed, 0 failed, 2 ignored).

## Notes
- Codspeed A/B to follow.
- Wheel-size cap (20MB assertion in `verify_linux_native_wheel.py`) should be watched on the release-wheel job.