### PR TITLE
feat(rust-interop): count GIL acquisitions alongside releases

### DIFF
--- a/litellm-rust/crates/python-bridge/src/diagnostics.rs
+++ b/litellm-rust/crates/python-bridge/src/diagnostics.rs
@@ -1,4 +1,4 @@
-use litellm_python_interop::release_count;
+use litellm_python_interop::{acquisition_count, release_count};
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
@@ -6,6 +6,7 @@ use pyo3::types::PyDict;
 fn gil_stats(py: Python<'_>) -> PyResult<Py<PyAny>> {
     let stats = PyDict::new(py);
     stats.set_item("releases", release_count())?;
+    stats.set_item("acquisitions", acquisition_count())?;
     Ok(stats.into_any().unbind())
 }
 
@@ -20,4 +21,55 @@ pub(crate) fn register(module: &Bound<'_, PyModule>) -> PyResult<()> {
     #[cfg(feature = "panic-test")]
     module.add_function(wrap_pyfunction!(_panic_for_test, module)?)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    fn stat(py: Python<'_>, key: &str) -> u64 {
+        gil_stats(py)
+            .expect("stats should build")
+            .into_bound(py)
+            .cast_into::<PyDict>()
+            .expect("stats should be a dict")
+            .get_item(key)
+            .expect("key should resolve")
+            .expect("key should be present")
+            .extract()
+            .expect("stat should be an integer")
+    }
+
+    #[test]
+    fn gil_stats_reports_both_interop_counters() {
+        Python::initialize();
+        Python::attach(|py| {
+            assert_eq!(stat(py, "releases"), release_count());
+            assert_eq!(stat(py, "acquisitions"), acquisition_count());
+        });
+    }
+
+    #[test]
+    fn gil_stats_counts_a_sync_route_run_on_both_counters() {
+        Python::initialize();
+        Python::attach(|py| {
+            let releases_before = stat(py, "releases");
+            let acquisitions_before = stat(py, "acquisitions");
+
+            crate::execution::run_sync(
+                py,
+                async {
+                    tokio::time::sleep(Duration::from_millis(120)).await;
+                    Ok(true)
+                },
+                crate::errors::core_error_to_pyerr,
+            )
+            .expect("sync route should complete");
+
+            assert!(stat(py, "releases") > releases_before);
+            assert!(stat(py, "acquisitions") > acquisitions_before);
+        });
+    }
 }

--- a/litellm-rust/crates/python-bridge/src/execution.rs
+++ b/litellm-rust/crates/python-bridge/src/execution.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use futures_util::FutureExt;
 use litellm_core::error::Error;
-use litellm_python_interop::{Pythonized, panic_to_pyerr, release_gil};
+use litellm_python_interop::{Pythonized, attach, panic_to_pyerr, release_gil};
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 use serde::Serialize;
@@ -99,7 +99,7 @@ where
     loop {
         tokio::select! {
             result = &mut future => return result,
-            _ = signal_checks.tick() => Python::attach(|py| py.check_signals())?,
+            _ = signal_checks.tick() => attach(|py| py.check_signals())?,
         }
     }
 }

--- a/litellm-rust/crates/python-interop/src/gil.rs
+++ b/litellm-rust/crates/python-interop/src/gil.rs
@@ -2,7 +2,17 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use pyo3::prelude::*;
 
+static GIL_ACQUISITIONS: AtomicU64 = AtomicU64::new(0);
 static GIL_RELEASES: AtomicU64 = AtomicU64::new(0);
+
+/// Runs work attached to the interpreter and records the acquisition.
+pub fn attach<T, F>(f: F) -> T
+where
+    F: for<'py> FnOnce(Python<'py>) -> T,
+{
+    GIL_ACQUISITIONS.fetch_add(1, Ordering::Relaxed);
+    Python::attach(f)
+}
 
 /// Runs work detached from the interpreter and records the release.
 ///
@@ -14,6 +24,10 @@ where
 {
     GIL_RELEASES.fetch_add(1, Ordering::Relaxed);
     py.detach(f)
+}
+
+pub fn acquisition_count() -> u64 {
+    GIL_ACQUISITIONS.load(Ordering::Relaxed)
 }
 
 pub fn release_count() -> u64 {

--- a/litellm-rust/crates/python-interop/src/lib.rs
+++ b/litellm-rust/crates/python-interop/src/lib.rs
@@ -1,5 +1,5 @@
 mod gil;
 mod marshal;
 
-pub use gil::{release_count, release_gil};
+pub use gil::{acquisition_count, attach, release_count, release_gil};
 pub use marshal::{Pythonized, from_py, panic_to_pyerr, to_py};

--- a/litellm-rust/crates/python-interop/tests/interop.rs
+++ b/litellm-rust/crates/python-interop/tests/interop.rs
@@ -2,7 +2,9 @@ use pyo3::Python;
 use rstest::{fixture, rstest};
 use serde_json::{Value, json};
 
-use litellm_python_interop::{from_py, release_count, release_gil, to_py};
+use litellm_python_interop::{
+    acquisition_count, attach, from_py, release_count, release_gil, to_py,
+};
 
 struct InitializedPython;
 
@@ -41,4 +43,13 @@ fn release_gil_runs_work_and_records_it(#[from(initialized_python)] python: &Ini
 
     assert_eq!(result, 42);
     assert_eq!(release_count(), before + 1);
+}
+
+#[rstest]
+fn attach_runs_work_and_records_it(#[from(initialized_python)] python: &InitializedPython) {
+    let before = acquisition_count();
+    let result = python.attach(|_| attach(|_| 42));
+
+    assert_eq!(result, 42);
+    assert_eq!(acquisition_count(), before + 1);
 }


### PR DESCRIPTION
## TLDR

Problem this solves:

- `gil_stats()` only reported GIL releases, so sync traffic was the only visible half
- GIL acquisitions (async delivery, the 50ms signal tick) attached invisibly

How it solves it:

- litellm-python-interop gains a `GIL_ACQUISITIONS` counter with `acquisition_count()` and a counted `attach` helper mirroring `release_gil`
- `gil_stats()` now returns both `releases` and `acquisitions`

## Changes

- `crates/python-interop/src/gil.rs`: `GIL_ACQUISITIONS` static, `acquisition_count()`, and `attach()` which counts an acquisition then runs `Python::attach(f)`
- `crates/python-interop/src/lib.rs`: export the new items alongside the existing ones
- `crates/python-bridge/src/execution.rs`: the 50ms signal-check tick in `wait_for_sync_result` now routes through the counted helper, behavior unchanged. It is the only production `Python::attach` call site in compiled bridge code; everything else is test or bench code
- `crates/python-bridge/src/diagnostics.rs`: `gil_stats` sets an additive `acquisitions` key next to `releases`

## Tests

- `attach_runs_work_and_records_it` (interop): the acquisition counter increments across an attach and the work runs
- `gil_stats_reports_both_interop_counters` (bridge): both keys are present and equal the interop counters
- `gil_stats_counts_a_sync_route_run_on_both_counters` (bridge): a sync route run with a 120ms future moves both counters (one release, at least one signal-tick acquisition)

### Proof

`cargo test -p litellm-python-bridge -p litellm-python-interop` at 6747e63c05:

```
test diagnostics::tests::gil_stats_reports_both_interop_counters ... ok
test diagnostics::tests::gil_stats_counts_a_sync_route_run_on_both_counters ... ok
test attach_runs_work_and_records_it ... ok
```

Full workspace: `cargo fmt` clean, `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo test --workspace` all tests pass

## Relevant issues

None

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally (cargo test above)
- [x] My PR passes all required CI/CD checks (fmt, clippy, and workspace tests verified locally)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Type

New Feature

## Caveats (if any)

### Low

- `routes/runtime.rs` is a stale, uncompiled copy of the execution module (not declared in `routes/mod.rs`) and was left untouched
- The wheel smoke script reads `releases` with `.get()`, so the added key stays backward compatible with no CI change

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR