### PR TITLE
feat(rust-bridge): extend native messages streaming beyond Anthropic

### DIFF
--- a/litellm-rust/crates/core/src/messages/handler.rs
+++ b/litellm-rust/crates/core/src/messages/handler.rs
@@ -1,10 +1,10 @@
-use crate::constants::ANTHROPIC_MESSAGES_PROVIDER;
 use crate::error::Error;
 use crate::http_utils::http_request;
 
 use super::client::http_client;
 use super::common_utils::truncate_error_body;
 use super::prepare::prepare_provider_request;
+use super::transformation::AnthropicMessagesProviderConfig;
 use super::types::{AnthropicMessagesResponse, MessagesRequest};
 
 #[tracing::instrument(target = "litellm::function_trace", level = "trace", skip_all)]
@@ -42,15 +42,25 @@ pub(super) async fn execute_messages_provider_call(
     request.config.transform_response(&request.model, response)
 }
 
+/// The streaming-capability gate. A provider whose config does not opt into
+/// streaming declines ([`Error::Unsupported`]) before any request goes out, so
+/// hosts treat it as "fall back", not "fail".
+pub(super) fn ensure_streaming_supported(
+    config: &dyn AnthropicMessagesProviderConfig,
+) -> Result<(), Error> {
+    if config.supports_streaming() {
+        return Ok(());
+    }
+    Err(Error::Unsupported(
+        "streaming messages is not supported for this provider",
+    ))
+}
+
 pub(super) async fn execute_messages_provider_stream(
     request: MessagesRequest<'_>,
 ) -> Result<reqwest::Response, Error> {
     let mut request = prepare_provider_request(request)?;
-    if request.provider != ANTHROPIC_MESSAGES_PROVIDER {
-        return Err(Error::InvalidRequest(
-            "streaming messages is not supported for this provider".to_string(),
-        ));
-    }
+    ensure_streaming_supported(request.config)?;
     // The streaming entrypoints only make sense for `stream: true`; force it so
     // a host cannot accidentally ask for SSE and receive a buffered JSON body.
     if let Some(body) = request.body.as_object_mut() {

--- a/litellm-rust/crates/core/src/messages/prepare.rs
+++ b/litellm-rust/crates/core/src/messages/prepare.rs
@@ -46,7 +46,6 @@ pub(super) fn prepare_provider_request(
     let url = config.complete_url(request.api_base, &model, &env_lookup)?;
 
     Ok(ProviderMessagesRequest {
-        provider: provider.to_string(),
         model,
         config,
         url,

--- a/litellm-rust/crates/core/src/messages/tests.rs
+++ b/litellm-rust/crates/core/src/messages/tests.rs
@@ -9,8 +9,12 @@ use crate::error::Error;
 use super::common_utils::{
     has_bearer_auth, has_header, messages_provider_config, string_headers, truncate_error_body,
 };
+use super::handler::ensure_streaming_supported;
 use super::messages;
+use super::transformation::AnthropicMessagesProviderConfig;
 use super::types::MessagesRequest;
+use crate::providers::anthropic::messages::transformation::ANTHROPIC_MESSAGES_CONFIG;
+use crate::providers::azure_ai::messages::transformation::AZURE_ANTHROPIC_MESSAGES_CONFIG;
 
 async fn read_http_request(socket: &mut TcpStream) -> String {
     let mut request = Vec::new();
@@ -58,6 +62,37 @@ fn provider_config_resolves_anthropic_and_azure_ai() {
     assert!(messages_provider_config("anthropic").is_some());
     assert!(messages_provider_config("azure_ai").is_some());
     assert!(messages_provider_config("openai").is_none());
+}
+
+#[test]
+fn streaming_gate_accepts_opted_in_providers_and_declines_the_rest() {
+    struct NonStreamingConfig;
+
+    impl AnthropicMessagesProviderConfig for NonStreamingConfig {
+        fn complete_url(
+            &self,
+            _api_base: Option<&str>,
+            _model: &str,
+            _env_lookup: &dyn Fn(&str) -> Option<String>,
+        ) -> Result<String, crate::error::Error> {
+            unreachable!("the streaming gate must not touch the config's URLs")
+        }
+
+        fn resolve_api_key(
+            &self,
+            _api_key: Option<&str>,
+            _env_lookup: &dyn Fn(&str) -> Option<String>,
+        ) -> Result<String, crate::error::Error> {
+            unreachable!("the streaming gate must not resolve credentials")
+        }
+    }
+
+    assert!(ensure_streaming_supported(&ANTHROPIC_MESSAGES_CONFIG).is_ok());
+    assert!(ensure_streaming_supported(&AZURE_ANTHROPIC_MESSAGES_CONFIG).is_ok());
+    assert!(matches!(
+        ensure_streaming_supported(&NonStreamingConfig).expect_err("default config declines"),
+        Error::Unsupported(_)
+    ));
 }
 
 #[test]
@@ -508,6 +543,97 @@ async fn messages_stream_frames_yields_complete_frames_and_forces_stream_flag() 
     let (_, body) = request.split_once("\r\n\r\n").expect("has body");
     let sent_body: Value = serde_json::from_str(body).expect("body is json");
     assert_eq!(sent_body["stream"], Value::Bool(true));
+}
+
+#[tokio::test]
+async fn messages_stream_frames_streams_azure_ai_through_the_anthropic_endpoint() {
+    use futures_util::StreamExt;
+
+    use super::messages_stream_frames;
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("binds");
+    let addr = listener.local_addr().expect("addr");
+
+    let server = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.expect("accepts request");
+        let request = read_http_request(&mut socket).await;
+        let body = concat!(
+            "event: message_start\ndata: {\"type\":\"message_start\"}\n\n",
+            "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n",
+        );
+        let response = format!(
+            "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+            body.len()
+        );
+        socket
+            .write_all(response.as_bytes())
+            .await
+            .expect("writes response head");
+        socket
+            .write_all(body.as_bytes())
+            .await
+            .expect("writes body");
+        request
+    });
+
+    let mut stream = messages_stream_frames(MessagesRequest {
+        model: "claude-sonnet-4-5",
+        body: json!({
+            "model": "claude-sonnet-4-5",
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": "hi"}]
+        }),
+        api_key: Some("sk-azure"),
+        api_base: Some(&format!("http://{addr}")),
+        custom_llm_provider: Some("azure_ai"),
+        extra_headers: None,
+        timeout: Some(Duration::from_secs(5)),
+    })
+    .await
+    .expect("azure_ai stream request succeeds");
+
+    let mut frames = Vec::new();
+    while let Some(frame) = stream.next().await {
+        frames.push(String::from_utf8(frame.expect("frame decodes")).expect("frame is utf8"));
+    }
+    assert_eq!(
+        frames,
+        vec![
+            "event: message_start\ndata: {\"type\":\"message_start\"}\n\n",
+            "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n",
+        ]
+    );
+
+    let request = server.await.expect("server task completes");
+    let (head, body) = request.split_once("\r\n\r\n").expect("has body");
+    assert!(head.starts_with("POST /anthropic/v1/messages "), "{head}");
+    let head_lower = head.to_ascii_lowercase();
+    assert!(head_lower.contains("x-api-key: sk-azure"), "{head}");
+    let sent_body: Value = serde_json::from_str(body).expect("body is json");
+    assert_eq!(sent_body["stream"], Value::Bool(true));
+}
+
+#[tokio::test]
+async fn messages_stream_declines_unsupported_provider_before_the_call() {
+    use super::messages_stream_frames;
+
+    let err = match messages_stream_frames(MessagesRequest {
+        model: "gpt-4o",
+        body: json!({"model": "gpt-4o", "max_tokens": 8, "messages": []}),
+        api_key: Some("sk"),
+        // Nothing listens here: a decline must return before any connection.
+        api_base: Some("http://127.0.0.1:1"),
+        custom_llm_provider: Some("openai"),
+        extra_headers: None,
+        timeout: Some(Duration::from_millis(50)),
+    })
+    .await
+    {
+        Err(err) => err,
+        Ok(_) => panic!("unsupported provider must decline before the stream"),
+    };
+
+    assert!(matches!(err, Error::InvalidProvider(provider) if provider == "openai"));
 }
 
 #[tokio::test]

--- a/litellm-rust/crates/core/src/messages/transformation.rs
+++ b/litellm-rust/crates/core/src/messages/transformation.rs
@@ -45,6 +45,13 @@ pub trait AnthropicMessagesProviderConfig: Sync {
         ]
     }
 
+    /// Whether this provider serves the SSE streaming variant of the route.
+    /// Opt-in: a config that does not override this declines streaming so the
+    /// host falls back to its own implementation instead of failing.
+    fn supports_streaming(&self) -> bool {
+        false
+    }
+
     #[tracing::instrument(target = "litellm::function_trace", level = "trace", skip_all)]
     fn transform_request(
         &self,

--- a/litellm-rust/crates/core/src/messages/types.rs
+++ b/litellm-rust/crates/core/src/messages/types.rs
@@ -16,7 +16,6 @@ pub struct MessagesRequest<'a> {
 }
 
 pub(super) struct ProviderMessagesRequest {
-    pub(super) provider: String,
     pub(super) model: String,
     pub(super) config: &'static dyn AnthropicMessagesProviderConfig,
     pub(super) url: String,

--- a/litellm-rust/crates/core/src/providers/anthropic/messages/transformation.rs
+++ b/litellm-rust/crates/core/src/providers/anthropic/messages/transformation.rs
@@ -68,6 +68,10 @@ impl AnthropicMessagesProviderConfig for AnthropicMessagesConfig {
     fn auth_strategy(&self) -> MessagesAuthStrategy {
         MessagesAuthStrategy::Header("x-api-key")
     }
+
+    fn supports_streaming(&self) -> bool {
+        true
+    }
 }
 
 #[cfg(test)]

--- a/litellm-rust/crates/core/src/providers/azure_ai/messages/transformation.rs
+++ b/litellm-rust/crates/core/src/providers/azure_ai/messages/transformation.rs
@@ -164,6 +164,10 @@ impl AnthropicMessagesProviderConfig for AzureAnthropicMessagesConfig {
         self.anthropic.auth_strategy()
     }
 
+    fn supports_streaming(&self) -> bool {
+        self.anthropic.supports_streaming()
+    }
+
     fn accepts_bearer_auth(&self) -> bool {
         true
     }

--- a/litellm-rust/crates/python-bridge/src/errors.rs
+++ b/litellm-rust/crates/python-bridge/src/errors.rs
@@ -33,7 +33,7 @@ pub(crate) fn core_error_to_pyerr(err: Error) -> PyErr {
 /// Everything raised before the request goes out is safe for the host to retry
 /// on its own path; anything after it is not, because the provider has already
 /// done the work and billed for it.
-pub(crate) fn chat_completions_error_to_pyerr(err: Error) -> PyErr {
+pub(crate) fn fallback_error_to_pyerr(err: Error) -> PyErr {
     match err {
         Error::Unsupported(_)
         | Error::Auth(_)

--- a/litellm-rust/crates/python-bridge/src/routes/chat_completions.rs
+++ b/litellm-rust/crates/python-bridge/src/routes/chat_completions.rs
@@ -8,7 +8,7 @@ use litellm_core::chat_completions::{
 use pyo3::prelude::*;
 use serde_json::Value;
 
-use crate::errors::chat_completions_error_to_pyerr;
+use crate::errors::fallback_error_to_pyerr;
 use crate::marshal::{RouteOptions, RouteOptionsInputs, object_or_empty, required_value};
 
 fn prepare_chat_completions(
@@ -86,6 +86,6 @@ bridge_route! {
         timeout_seconds: Option<f64>,
     },
     prepare = prepare_chat_completions,
-    errors = chat_completions_error_to_pyerr,
+    errors = fallback_error_to_pyerr,
     extra = [chat_completions_decline],
 }

--- a/litellm-rust/crates/python-bridge/src/routes/messages_stream.rs
+++ b/litellm-rust/crates/python-bridge/src/routes/messages_stream.rs
@@ -17,7 +17,7 @@ use pyo3::types::{PyAny, PyBytes};
 use serde_json::Value;
 use tokio::sync::Mutex;
 
-use crate::errors::core_error_to_pyerr;
+use crate::errors::{core_error_to_pyerr, fallback_error_to_pyerr};
 use crate::marshal::{RouteOptions, RouteOptionsInputs, required_value};
 
 /// One complete SSE frame, converted to `bytes` on the attached thread that
@@ -115,6 +115,10 @@ fn amessages_stream<'py>(
             extra_headers,
             timeout,
         } = options;
+        // Only the request start maps through the fallback contract: declines
+        // (unsupported provider, bad request) happen before the provider is
+        // called, so the host may retry on its own path. Failures surfaced by
+        // `__anext__` are mid-stream and keep `core_error_to_pyerr`.
         let frames = messages_stream_frames(MessagesRequest {
             model: &model,
             body,
@@ -125,7 +129,7 @@ fn amessages_stream<'py>(
             timeout,
         })
         .await
-        .map_err(core_error_to_pyerr)?;
+        .map_err(fallback_error_to_pyerr)?;
         Ok(MessagesStream {
             frames: Arc::new(Mutex::new(Some(frames))),
         })
@@ -187,12 +191,12 @@ mod tests {
     }
 
     /// An SSE upstream that sends `body` in chunks separated by short delays
-    /// so frames span network chunk boundaries.
+    /// so frames span network chunk boundaries. Returns the captured request.
     async fn streaming_upstream(
         listener: TcpListener,
         status_line: &'static str,
         body: &'static str,
-    ) {
+    ) -> String {
         let (mut socket, _) = listener.accept().await.expect("accepts request");
         let request = read_http_request(&mut socket).await;
         assert!(
@@ -217,6 +221,7 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(10)).await;
             socket.write_all(chunk).await.expect("writes body chunk");
         }
+        request
     }
 
     fn register_stream_module(py: Python<'_>) -> Bound<'_, PyModule> {
@@ -233,6 +238,18 @@ mod tests {
         locals
             .set_item("url", url)
             .expect("URL should enter Python locals");
+        locals
+            .set_item(
+                "Declined",
+                py.get_type::<crate::errors::RustBridgeDeclined>(),
+            )
+            .expect("declined exception should enter Python locals");
+        locals
+            .set_item(
+                "UpstreamError",
+                py.get_type::<crate::errors::RustUpstreamError>(),
+            )
+            .expect("upstream exception should enter Python locals");
         let source = CString::new(code).expect("Python source should not contain null bytes");
         py.run(&source, Some(&locals), Some(&locals))
             .expect("Python stream exercise should pass");
@@ -324,8 +341,9 @@ async def exercise():
             api_base=url,
             custom_llm_provider="anthropic",
         )
-    except RuntimeError as error:
-        assert "429" in str(error), str(error)
+    except UpstreamError as error:
+        assert not isinstance(error, Declined), "a provider 429 is not a decline"
+        assert error.args[0] == 429, error.args
     else:
         raise AssertionError("upstream error should surface from the awaitable")
 
@@ -338,6 +356,100 @@ asyncio.run(exercise())
             .block_on(async { tokio::time::timeout(Duration::from_secs(5), server).await })
             .expect("server should finish")
             .expect("server task should not panic");
+    }
+
+    #[test]
+    fn stream_route_streams_azure_ai_through_the_anthropic_endpoint() {
+        Python::initialize();
+        let runtime = pyo3_async_runtimes::tokio::get_runtime();
+        let listener = runtime
+            .block_on(TcpListener::bind("127.0.0.1:0"))
+            .expect("listener should bind");
+        let address = listener
+            .local_addr()
+            .expect("listener should have an address");
+        let body = concat!(
+            "event: message_start\ndata: {\"type\":\"message_start\"}\n\n",
+            "event: content_block_delta\ndata: {\"delta\":\"hi\"}\n\n",
+            "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n",
+        );
+        let server = runtime.spawn(streaming_upstream(listener, "HTTP/1.1 200 OK", body));
+
+        Python::attach(|py| {
+            let module = register_stream_module(py);
+            run_async_code(
+                py,
+                &module,
+                &format!("http://{address}"),
+                r#"
+import asyncio
+
+async def exercise():
+    stream = await runtime.amessages_stream(
+        model="claude-sonnet-4-5",
+        body={"model": "claude-sonnet-4-5", "max_tokens": 8, "messages": []},
+        api_key="sk-azure",
+        api_base=url,
+        custom_llm_provider="azure_ai",
+    )
+    frames = [chunk async for chunk in stream]
+    assert frames == [
+        b'event: message_start\ndata: {"type":"message_start"}\n\n',
+        b'event: content_block_delta\ndata: {"delta":"hi"}\n\n',
+        b'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+    ], frames
+
+asyncio.run(exercise())
+"#,
+            );
+        });
+
+        let request = runtime
+            .block_on(async { tokio::time::timeout(Duration::from_secs(5), server).await })
+            .expect("server should finish")
+            .expect("server task should not panic");
+        let head = request
+            .split_once("\r\n\r\n")
+            .expect("request should have a body")
+            .0
+            .to_ascii_lowercase();
+        assert!(
+            head.starts_with("post /anthropic/v1/messages "),
+            "azure_ai must stream through the anthropic endpoint: {head}"
+        );
+        assert!(head.contains("x-api-key: sk-azure"), "{head}");
+    }
+
+    #[test]
+    fn stream_route_declines_unsupported_provider_before_any_request() {
+        Python::initialize();
+        Python::attach(|py| {
+            let module = register_stream_module(py);
+            run_async_code(
+                py,
+                &module,
+                "http://127.0.0.1:1",
+                r#"
+import asyncio
+
+async def exercise():
+    try:
+        await runtime.amessages_stream(
+            model="gpt-4o",
+            body={"model": "gpt-4o", "max_tokens": 8, "messages": []},
+            api_key="sk",
+            api_base=url,
+            custom_llm_provider="openai",
+        )
+    except Declined as error:
+        assert not isinstance(error, UpstreamError), str(error)
+    else:
+        raise AssertionError("unsupported provider must decline from the awaitable")
+
+asyncio.run(exercise())
+"#,
+            );
+        });
     }
 
     #[test]

--- a/tests/test_litellm/anthropic_interface/test_rust_bridge_messages.py
+++ b/tests/test_litellm/anthropic_interface/test_rust_bridge_messages.py
@@ -480,6 +480,29 @@ async def test_stream_gate_returns_sse_frames_and_keeps_stream_flag():
 
 
 @pytest.mark.asyncio
+async def test_stream_gate_routes_azure_ai_to_the_native_stream():
+    bridge = RecordingAsyncMessagesStream()
+    rust_messages_stream.set_rust_amessages_stream(amessages_stream=bridge)
+
+    response = await _stream_gate(
+        custom_llm_provider="azure_ai",
+        litellm_params=GenericLiteLLMParams(api_key="sk-azure", rust=True),
+        api_key="sk-azure",
+        api_base="https://resource.services.ai.azure.com/anthropic",
+        headers={"x-api-key": "sk-azure", "anthropic-version": "2023-06-01"},
+    )
+
+    assert response is not None
+    assert response._hidden_params["additional_headers"] == {"x-litellm-rust": "true"}
+    chunks = [chunk async for chunk in response]
+    assert chunks == list(FAKE_SSE_FRAMES)
+    call = bridge.calls[0]
+    assert call["custom_llm_provider"] == "azure_ai"
+    assert call["api_key"] == "sk-azure"
+    assert call["body"]["stream"] is True
+
+
+@pytest.mark.asyncio
 async def test_stream_gate_falls_back_to_python_when_bridge_raises():
     bridge = RaisingAsyncMessagesStream()
     rust_messages_stream.set_rust_amessages_stream(amessages_stream=bridge)


### PR DESCRIPTION
## TLDR

Problem this solves:

- #39577's native SSE streaming only accepted the `anthropic` provider; `azure_ai` raised and fell back to Python
- An unsupported provider surfaced as a generic error instead of a decline the host can act on

How it solves it:

- Streaming capability is now a provider trait method; `anthropic` and `azure_ai` opt in
- Providers that can't stream decline with `RustBridgeDeclined` before any request goes out, so Python falls back per provider
- The Python gate's existing `("azure_ai", "anthropic")` allowlist now routes both to the native stream

## User Flow

Before: a user streaming Anthropic Messages through an Azure AI deployment pays the Python SSE path even with the Rust bridge enabled

1. They enable the Rust bridge (`litellm.use_litellm_rust(True)` or `LITELLM_RUST=1`) and point a `claude-sonnet-4-5` model at an Azure AI Foundry deployment
2. They send POST /v1/messages with `"stream": true`
3. The native route rejects the provider, the bridge raises, and the request silently re-runs on the Python path, so no error is visible but no Rust benefit either

After: the same request streams natively end to end

1. Same setup and same POST /v1/messages with `"stream": true`
2. The native route resolves the `azure_ai` provider config, forces `stream: true`, and posts to `<api_base>/anthropic/v1/messages` with the `x-api-key` header
3. SSE frames flow back per chunk through the native async iterator, same as `anthropic` already did in #39577

## Changes

- `core`: `AnthropicMessagesProviderConfig::supports_streaming()` trait method, opt-in with a declining default
- `core`: `execute_messages_provider_stream` gates on the trait instead of hard-checking the provider name, and returns `Error::Unsupported` (a decline) rather than `InvalidRequest`
- `core`: dropped the now-unused `provider` field from `ProviderMessagesRequest`
- `bridge`: renamed `chat_completions_error_to_pyerr` to `fallback_error_to_pyerr` and wired it into `amessages_stream`'s request start, so pre-flight failures raise `RustBridgeDeclined` and provider-side HTTP failures raise `RustUpstreamError` (mid-stream failures in `__anext__` keep the old mapping, since the provider was already called there)
- `python`: no gate code change needed; `_maybe_rust_anthropic_messages_stream` already allowlists `("azure_ai", "anthropic")` and falls back on any bridge exception, which now includes declines

## Relevant issues

Stacked on #39577 — merge after it.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g. lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

No Azure or Anthropic credentials were available in this environment for a live-$$$ run, so the proof here is the Rust and Python suites exercising the full HTTP round trip against local mock upstreams. A live run a maintainer can do:

### Before (490d7dd983)

#### azure_ai native stream

1. Build the native wheel from `litellm-rust/`, install it, and run the proxy with `LITELLM_RUST=1` and an Azure AI Foundry model config
2. `curl -X POST http://localhost:4000/v1/messages -H "Authorization: Bearer sk-..." -d '{"model":"claude-sonnet-4-5","max_tokens":64,"stream":true,"messages":[{"role":"user","content":"hi"}]}'`
3. Frames arrive, but the debug log shows `Rust Anthropic messages stream bridge raised ValueError; falling back to Python path`, so the whole call re-ran on Python

### After (9dd20901db)

#### azure_ai native stream

1. Same setup and same curl
2. Frames arrive and the response carries `x-litellm-rust: true` in hidden params, with no fallback log line, because the native route served `<api_base>/anthropic/v1/messages` directly

Local suite runs (mock upstreams, full HTTP round trips):

### Rust (`cd litellm-rust`)

1. `cargo fmt --check` passes
2. `cargo clippy --workspace --all-targets -- -D warnings` passes clean
3. `cargo test --workspace` passes: all suites green, including the new `messages_stream_frames_streams_azure_ai_through_the_anthropic_endpoint`, `messages_stream_declines_unsupported_provider_before_the_call`, `streaming_gate_accepts_opted_in_providers_and_declines_the_rest`, `stream_route_streams_azure_ai_through_the_anthropic_endpoint`, and `stream_route_declines_unsupported_provider_before_any_request`

### Python

1. `uv run pytest tests/test_litellm/anthropic_interface/test_rust_bridge_messages.py tests/test_litellm/rust_bridge -q` passes 100 tests, including the new `test_stream_gate_routes_azure_ai_to_the_native_stream`

## Type

🆕 New Feature

## Caveats (if any)

### Low

- Providers without a messages transformation on this branch (bedrock, vertex_ai, openai, ...) still decline at provider resolution; the Python gate never routes them to Rust, so nothing changes for them
- `supports_streaming()` defaults to false on purpose: a future messages provider config must consciously opt into streaming
- Pre-existing, not from this PR: `tests/test_litellm/anthropic_interface/test_rust_bridge_messages.py` has two ruff findings (`UP035`/`F401` on the unused `AsyncIterator` import, present on the base commit) and that suite needs the `proxy` extra installed (`uv sync --extra proxy --group dev`) because the streaming iterator imports `orjson`

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
