### PR TITLE
fix(proxy): accept both deferred logging arg shapes on bridged /v1/messages streams

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -3123,10 +3123,15 @@ class ProxyBaseLLMRequestProcessing:
           its inner CustomStreamWrapper's logging_obj, so it stores the same
           (assembled_response, cache_hit) shape; the closure only dispatches
           success logging, matching the route's pre-existing hook surface.
-        - Native anthropic_messages/aresponses iterators store a single
-          ready-made logging coroutine to enqueue.
+        - Everything else on anthropic_messages/aresponses gets a fallback
+          closure that dispatches on the stored args shape, because both
+          producers are plain async generators the arming site cannot tell
+          apart: native iterators store a ready-made (logging_coroutine,)
+          to enqueue, while bridged /v1/messages (AnthropicStreamWrapper's
+          SSE generator) shares its inner CustomStreamWrapper's logging_obj
+          and stores (assembled_response, cache_hit).
 
-        Raw async generators from passthrough routes bypass all three and
+        Raw async generators from passthrough routes bypass all of these and
         would orphan the closure, so they are not armed here.
 
         The router wraps iterators that cannot carry _hidden_params in
@@ -3182,10 +3187,24 @@ class ProxyBaseLLMRequestProcessing:
 
         from litellm.litellm_core_utils.logging_worker import GLOBAL_LOGGING_WORKER
 
-        async def _on_deferred_native_stream_complete(
-            logging_coroutine: Coroutine[object, object, object],
-        ) -> None:
-            GLOBAL_LOGGING_WORKER.ensure_initialized_and_enqueue(async_coroutine=logging_coroutine)
+        _captured_native_logging_obj: Final = logging_obj
+
+        async def _on_deferred_native_stream_complete(*args: object) -> None:
+            match args:
+                case (Coroutine() as logging_coroutine,):
+                    GLOBAL_LOGGING_WORKER.ensure_initialized_and_enqueue(async_coroutine=logging_coroutine)
+                case (assembled_response, cache_hit):
+                    await _as_success_dispatcher(_captured_native_logging_obj).dispatch_success_handlers(
+                        assembled_response,
+                        cache_hit=cache_hit,
+                        start_time=None,
+                        end_time=None,
+                        prefer_async_handlers=True,
+                    )
+                case _:
+                    verbose_proxy_logger.warning(
+                        "deferred stream logging dropped: unexpected args shape %s", tuple(map(type, args))
+                    )
 
         logging_obj._on_deferred_stream_complete = _on_deferred_native_stream_complete
 

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -7719,3 +7719,76 @@ def test_log_llm_api_exception_traceback_only_for_unexpected_errors(exc, expect_
     records = [r for r in caplog.records if "_handle_llm_api_exception(): Exception occured" in r.getMessage()]
     assert len(records) == 1
     assert (records[0].exc_info is not None) is expect_traceback
+
+
+class _RecordingDeferredLoggingObj:
+    def __init__(self) -> None:
+        self.dispatched: list[tuple[object, object]] = []
+        self._on_deferred_stream_complete: Callable | None = None
+        self._deferred_stream_complete_args: tuple | None = None
+
+    async def dispatch_success_handlers(
+        self,
+        result: object = None,
+        start_time: object = None,
+        end_time: object = None,
+        cache_hit: object = None,
+        prefer_async_handlers: bool = False,
+    ) -> None:
+        self.dispatched.append((result, cache_hit))
+
+
+class TestArmDeferredStreamDispatchFallback:
+    """The anthropic_messages fallback closure must accept both stored args shapes.
+
+    A bridged /v1/messages stream (non-Anthropic model behind the Anthropic
+    adapter) is a plain async generator, so arming falls through to the
+    fallback closure, but its inner CustomStreamWrapper stores
+    (assembled_response, cache_hit). Before the fix the 1-arg closure raised
+    TypeError on fire, which reached clients as a trailing SSE error frame and
+    dropped the request's spend log.
+    """
+
+    def _arm(self, logging_obj: _RecordingDeferredLoggingObj) -> None:
+        async def bridged_sse_stream() -> AsyncGenerator[bytes, None]:
+            yield b"event: message_stop\n\n"
+
+        ProxyBaseLLMRequestProcessing(data={})._arm_deferred_stream_dispatch(
+            response=bridged_sse_stream(),
+            route_type="anthropic_messages",
+            user_api_key_dict=ProxyUserAPIKeyAuth(),
+            logging_obj=logging_obj,
+        )
+        assert logging_obj._on_deferred_stream_complete is not None
+
+    @pytest.mark.asyncio
+    async def test_bridged_messages_args_shape_dispatches_success_logging(self):
+        logging_obj = _RecordingDeferredLoggingObj()
+        self._arm(logging_obj)
+
+        assembled_response: Final = object()
+        logging_obj._deferred_stream_complete_args = (assembled_response, False)
+        ProxyLogging._fire_deferred_stream_logging({"litellm_logging_obj": logging_obj})
+
+        for _ in range(3):
+            await asyncio.sleep(0)
+        assert logging_obj.dispatched == [(assembled_response, False)]
+        assert logging_obj._on_deferred_stream_complete is None
+        assert logging_obj._deferred_stream_complete_args is None
+
+    @pytest.mark.asyncio
+    async def test_native_coroutine_shape_still_enqueues_to_logging_worker(self):
+        logging_obj = _RecordingDeferredLoggingObj()
+        self._arm(logging_obj)
+
+        ran: Final = asyncio.Event()
+
+        async def native_logging_coroutine() -> None:
+            ran.set()
+
+        callback = logging_obj._on_deferred_stream_complete
+        assert callback is not None
+        await callback(native_logging_coroutine())
+
+        await asyncio.wait_for(ran.wait(), timeout=5)
+        assert logging_obj.dispatched == []


### PR DESCRIPTION
## TLDR

When a post-call guardrail is active, streaming /v1/messages on a non-Anthropic model (e.g. Gemini) crashed litellm's end-of-stream logging callback: clients got a junk 500 error frame after every response and the request was billed $0. The PR makes that callback accept both argument shapes the two stream types produce, so streams end cleanly and spend logging works again.

Problem this solves:

- Streaming /v1/messages on a non-Anthropic model with post-call guardrails active
- Every response ends with a spurious 500 error frame after message_stop
- The request's spend log records $0 despite delivered tokens

How it solves it:

- The end-of-stream logging callback now accepts both stored argument shapes
- Bridged streams dispatch success logging; native streams enqueue their coroutine unchanged

## User Flow

Before: a developer streams Anthropic-format chat from a Gemini model through a proxy that has a post-call guardrail, and every response ends with an error frame and is never billed

1. They send POST http://localhost:4000/v1/messages with `"model": "gemini-2.5-flash"`, `"stream": true` and a harmless prompt
2. The answer streams back fine, but after `event: message_stop` one more frame arrives: `data: {"error": {"message": "..._on_deferred_native_stream_complete() takes 1 positional argument but 2 were given", "code": "500"}}`
3. On http://localhost:4000/ui/?page=logs that request shows $0 spend and no token counts

After: the same request ends cleanly and is billed

1. They send the same POST http://localhost:4000/v1/messages with `"stream": true`
2. The stream ends at `event: message_stop` with no extra frame
3. http://localhost:4000/ui/?page=logs shows the request with real token counts and non-zero spend

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Setup, shared by both runs: proxy from source on localhost:4000 (`litellm --config litellm-config.yml --debug`, master key sk-1234), a `gemini-2.5-flash` deployment, and one Model Armor guardrail created via the management API so post-call guardrails are active:

```bash
curl -X POST http://localhost:4000/guardrails -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{
  "guardrail": {
    "guardrail_name": "model-armor-qa",
    "litellm_params": {"guardrail": "model_armor", "mode": ["pre_call", "post_call"], "template_id": "litellm-prod", "project_id": "vertex-check-481318", "location": "us-west1", "default_on": true}
  }
}'
```

### Before (5a821b593c)

#### Benign streaming /v1/messages ends with an error frame and is not billed

1. Stream a harmless prompt:

```bash
curl -N http://localhost:4000/v1/messages -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model": "gemini-2.5-flash", "max_tokens": 100, "stream": true, "messages": [{"role": "user", "content": "Say hi in exactly three words."}]}'
```

2. The content arrives, then a trailing error frame after `message_stop`:

```
event: message_delta
data: {"type": "message_delta", "delta": {"stop_reason": "max_tokens"}, "usage": {"input_tokens": 7, "output_tokens": 96}}

event: message_stop
data: {"type": "message_stop"}

data: {"error": {"message": "ProxyBaseLLMRequestProcessing._arm_deferred_stream_dispatch.<locals>._on_deferred_native_stream_complete() takes 1 positional argument but 2 were given", "type": "None", "param": "None", "code": "500"}}
```

3. The spend log row for it records nothing despite the 96 delivered tokens:

```
2026-09-03T20:42:52  gemini-2.5-flash spend= 0.0 tokens= 0
```

#### Guardrail block on the streamed response also picks up the trailing frame

1. Stream a prompt whose answer contains a credit card number (Model Armor SDP blocks it):

```bash
curl -N http://localhost:4000/v1/messages -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model": "gemini-2.5-flash", "max_tokens": 200, "stream": true, "messages": [{"role": "user", "content": "What is the standard Visa test card number used in payment sandbox docs? Reply with just the 16 digits, no spaces."}]}'
```

2. The block itself works, but the same broken frame is appended after it:

```
event: error
data: {"type": "error", "error": {"type": "guardrail_error", "message": "Streaming response blocked by Model Armor"}}

data: {"error": {"message": "ProxyBaseLLMRequestProcessing._arm_deferred_stream_dispatch.<locals>._on_deferred_native_stream_complete() takes 1 positional argument but 2 were given", "type": "None", "param": "None", "code": "500"}}
```

### After (67cee9d824)

#### Benign streaming /v1/messages ends cleanly and is billed

1. Same request:

```bash
curl -N http://localhost:4000/v1/messages -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model": "gemini-2.5-flash", "max_tokens": 100, "stream": true, "messages": [{"role": "user", "content": "Say hi in exactly three words."}]}'
```

2. Stream ends at `message_stop` with no extra frame:

```
event: message_delta
data: {"type": "message_delta", "delta": {"stop_reason": "max_tokens"}, "usage": {"input_tokens": 7, "output_tokens": 96}}

event: message_stop
data: {"type": "message_stop"}
```

3. The spend log row now bills the request:

```
2026-09-03T21:08:08  anthropic_messages gemini-2.5-flash spend= 0.0002421 tokens= 103
```

#### Guardrail block on the streamed response stays intact, no trailing frame

1. Same credit card prompt as Before

2. Output is only the guardrail refusal:

```
event: error
data: {"type": "error", "error": {"type": "guardrail_error", "message": "Streaming response blocked by Model Armor"}}
```

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- The fallback closure dispatches on the stored args shape at fire time, because both producers reach the arming site as plain async generators it cannot statically tell apart

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes proxy streaming spend/logging at stream teardown when guardrails are active; scope is narrow but affects billing and client-visible SSE tails on `/v1/messages`.
> 
> **Overview**
> Fixes **end-of-stream deferred logging** for streaming **`anthropic_messages`** / **`aresponses`** when **post-call guardrails** defer spend logging. Bridged **`/v1/messages`** streams (non-Anthropic models behind the adapter) are plain async generators, so arming uses the same fallback closure as native iterators—but they store **`(assembled_response, cache_hit)`** on the logging object, not a single logging coroutine.
> 
> The fallback **`_on_deferred_native_stream_complete`** now takes **`*args`** and **`match`**es on shape: enqueue a one-tuple coroutine to **`GLOBAL_LOGGING_WORKER`** (unchanged native path), or **`dispatch_success_handlers`** for the bridged tuple. Unexpected shapes log a warning and drop logging instead of raising.
> 
> Adds unit tests that arm via a synthetic bridged SSE generator and assert both the bridged tuple and native coroutine paths behave correctly when **`ProxyLogging._fire_deferred_stream_logging`** runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67cee9d82460a1bf5b89e90ae43afb13a66cc2e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->