### PR TITLE
ci(rust): add an experimental free-threaded (3.14t) wheel lane

### DIFF
--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -126,3 +126,80 @@ jobs:
 
       - name: Test native route wheel
         run: python tests/test_litellm/rust_bridge/native_route_wheel_test.py dist/*.whl
+
+  # EXPERIMENTAL: build and smoke-test the native module on a free-threaded
+  # (no-GIL) CPython. This lane is a signal, not a gate.
+  free-threaded-wheel:
+    continue-on-error: true
+    name: free-threaded wheel (3.14t, experimental)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    env:
+      CARGO_TERM_COLOR: always
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          persist-credentials: false
+
+      - name: Set up free-threaded Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.14t"
+
+      - name: Set up Rust
+        run: rustup toolchain install
+
+      - name: Build free-threaded wheel
+        run: |
+          python -m pip install maturin==1.15.0
+          maturin build --profile release -i python --no-default-features --features freethreaded,extension-module -o dist
+
+      - name: Assert free-threaded wheel tag
+        run: >-
+          python -c 'import glob, sys; wheels = glob.glob("dist/*.whl");
+          assert wheels and all("cp314t" in w and "t-" in w for w in wheels), wheels'
+
+      - name: Smoke-test free-threaded native module
+        run: |
+          python -m pip install --no-deps dist/*.whl
+          python - <<'EOF'
+          import importlib.util
+          import sys
+          import sysconfig
+          import tempfile
+          import zipfile
+          from pathlib import Path
+
+          wheel = next(Path("dist").glob("*.whl"))
+          with tempfile.TemporaryDirectory() as temporary_directory, zipfile.ZipFile(wheel) as archive:
+              member = next(
+                  member
+                  for member in archive.namelist()
+                  if member.startswith("litellm/rust_bridge/_native.") and member.endswith(".so")
+              )
+              native = Path(temporary_directory) / Path(member).name
+              native.write_bytes(archive.read(member))
+
+              spec = importlib.util.spec_from_file_location("litellm.rust_bridge._native", native)
+              module = importlib.util.module_from_spec(spec)
+              spec.loader.exec_module(module)
+
+          assert sys.version_info[:2] == (3, 14), sys.version
+          assert sysconfig.get_config_var("Py_GIL_DISABLED") == 1, sys.version
+          info = module.build_info()
+          assert info["gil_disabled"] is True, info
+          stats = module.gil_stats()
+          assert isinstance(stats["releases"], int), stats
+          decline = module.chat_completions_decline(
+              "gpt-4o-mini", [{"role": "user", "content": "hi"}]
+          )
+          assert decline is None or isinstance(decline, str), decline
+          print(f"free-threaded smoke ok on {sys.version}: gil_stats={dict(stats)}")
+          EOF
+
+      - name: Test native route wheel
+        run: python tests/test_litellm/rust_bridge/native_route_wheel_test.py dist/*.whl

--- a/litellm-rust/crates/python-bridge/Cargo.toml
+++ b/litellm-rust/crates/python-bridge/Cargo.toml
@@ -12,6 +12,9 @@ crate-type = ["cdylib"]
 [features]
 default = ["abi3"]
 abi3 = ["pyo3/abi3-py310"]
+# Free-threaded stable ABI (cp3XXt wheels), following the cryptography project's
+# pyo3 setup; deliberately omits the abi3-py310 GIL-wheel pin.
+freethreaded = ["pyo3/abi3", "pyo3/abi3t"]
 extension-module = ["pyo3/extension-module"]
 panic-test = []
 


### PR DESCRIPTION
## Summary

Add an experimental CI lane that builds and smoke-tests the `_native` PyO3 module on a free-threaded (no-GIL) CPython 3.14t. The module already declares `#[pymodule(gil_used = false)]` and exposes `build_info()["gil_disabled"]`, but nothing ever built or tested it on a free-threaded interpreter. This lane is a **signal, not a gate** (`continue-on-error: true`).

Stacked on #39640 — merge after it.

## Changes

- **`litellm-rust/crates/python-bridge/Cargo.toml`**: new `freethreaded` feature, modeled on the cryptography project's pyo3 setup:
  ```toml
  freethreaded = ["pyo3/abi3", "pyo3/abi3t"]
  ```
  Verified against pyo3 0.29.2 in the cargo registry: `abi3` and `abi3t` are the exact feature names (there is no `abi3-py313t`; the only pinned variant is `abi3t-py315`). Deliberately does **not** include `abi3-py310` (the GIL-wheel pin), so the build is `--no-default-features --features freethreaded,extension-module`.
- **`.github/workflows/test-rust.yml`**: new `free-threaded-wheel` job (modeled on `release-wheel`), `continue-on-error: true` with an experimental-lane comment:
  - `actions/setup-python@v5.6.0` with `python-version: "3.14t"` (t-suffix free-threaded support verified against the action's docs; added in v5.6.0, which is the version already pinned in this workflow)
  - `pip install maturin==1.15.0` then `maturin build --profile release -i python --no-default-features --features freethreaded,extension-module -o dist`
  - wheel-tag assertion: filename must contain `cp314t` and the `t-` marker before the platform tag
  - smoke: `pip install --no-deps` the wheel, then import the extracted extension via `importlib` (repo precedent from `smoke_test_native_wheel.py`) and assert `build_info()["gil_disabled"] is True`, run `gil_stats()`, and call `chat_completions_decline(...)`
  - run the existing `native_route_wheel_test.py` against the t-wheel (it passed locally on 3.14t, so it was kept rather than dropped)

## Validation

All done locally on a real `uv python install 3.14t` (CPython 3.14.5+freethreaded) interpreter:

- `cargo check -p litellm-python-bridge --no-default-features --features freethreaded` — compiles (on a GIL interpreter pyo3 falls back to plain `Stable(Abi3)`, which is why the check works anywhere)
- `cargo fmt --check` — clean
- Full `maturin build --profile release --no-default-features --features freethreaded,extension-module` with maturin 1.15.0 against 3.14t — produced `litellm-1.101.0-cp314-cp314t-macosx_11_0_arm64.whl`
- Wheel installs with `pip install --no-deps` on 3.14t; module imports; `build_info()` → `gil_disabled=True`, `gil_stats()` and `chat_completions_decline()` run
- `python tests/test_litellm/rust_bridge/native_route_wheel_test.py dist/*.whl` — **passes on 3.14t** (all routes, sync + async, 429 mapping, SIGINT cancellation)
- Workflow YAML parsed with `yaml.safe_load`

## Notes

- pyo3 0.29.2 semantics (verified in `pyo3-build-config-0.29.2/src/impl_.rs`): true stable `abi3t` targets require Python ≥ 3.15 (`MINIMUM_SUPPORTED_VERSION_ABI3T = 3.15`). On a 3.14t interpreter the `abi3`+`abi3t` features resolve to a **version-specific free-threaded** build — wheel tag `cp314-cp314t`, `Py_GIL_DISABLED` set (`gil_disabled=True`), `Py_LIMITED_API` unset (`build_info()["abi3"]` is `False`). The same feature graph yields true free-threaded stable-ABI (`abi3t`) wheels on 3.15t+ interpreters, so the lane is forward-compatible.
- Smoke import uses `importlib.util.spec_from_file_location` on the extracted `.so` (matching the existing wheel smoke scripts) instead of a bare `import litellm.rust_bridge._native`, so the lane doesn't depend on litellm's Python-side dependencies being installable on 3.14t.
- `maturin` CLI `--features` overrides the pyproject `[tool.maturin] features`; `extension-module` is included explicitly in the invocation (verified by the produced tag).