### PR TITLE
feat: add NeuronPool OpenAI-compatible provider + catalog pricing

### DIFF
--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -200,5 +200,14 @@
       "temperature_max": 1.99
     },
     "supported_endpoints": ["/v1/chat/completions"]
+  },
+  "neuronpool": {
+    "base_url": "https://neuronpool.damnknee.workers.dev/v1",
+    "api_key_env": "NEURONPOOL_API_KEY",
+    "api_base_env": "NEURONPOOL_API_BASE",
+    "param_mappings": {
+      "max_completion_tokens": "max_tokens"
+    },
+    "supported_endpoints": ["/v1/chat/completions", "/v1/embeddings"]
   }
 }

--- a/neuronpool_model_prices.json
+++ b/neuronpool_model_prices.json
@@ -1,0 +1,95 @@
+{
+  "neuronpool/llama-3.2-1b-instruct": {
+    "input_cost_per_token": 5e-9,
+    "output_cost_per_token": 1e-8,
+    "litellm_provider": "neuronpool",
+    "max_input_tokens": 131072,
+    "max_output_tokens": 4096,
+    "max_tokens": 4096,
+    "mode": "chat",
+    "supports_function_calling": true,
+    "supports_response_schema": true,
+    "supports_system_messages": true
+  },
+  "neuronpool/llama-3.1-8b-instruct": {
+    "input_cost_per_token": 2e-8,
+    "output_cost_per_token": 3e-8,
+    "litellm_provider": "neuronpool",
+    "max_input_tokens": 131072,
+    "max_output_tokens": 4096,
+    "max_tokens": 4096,
+    "mode": "chat",
+    "supports_function_calling": true,
+    "supports_response_schema": true,
+    "supports_system_messages": true
+  },
+  "neuronpool/qwen2.5-7b-instruct": {
+    "input_cost_per_token": 2e-8,
+    "output_cost_per_token": 3e-8,
+    "litellm_provider": "neuronpool",
+    "max_input_tokens": 32768,
+    "max_output_tokens": 4096,
+    "max_tokens": 4096,
+    "mode": "chat",
+    "supports_function_calling": true,
+    "supports_response_schema": true,
+    "supports_system_messages": true
+  },
+  "neuronpool/gemma-3-12b-it": {
+    "input_cost_per_token": 4e-8,
+    "output_cost_per_token": 6e-8,
+    "litellm_provider": "neuronpool",
+    "max_input_tokens": 131072,
+    "max_output_tokens": 4096,
+    "max_tokens": 4096,
+    "mode": "chat",
+    "supports_function_calling": true,
+    "supports_response_schema": true,
+    "supports_system_messages": true
+  },
+  "neuronpool/qwen3-30b-a3b": {
+    "input_cost_per_token": 6e-8,
+    "output_cost_per_token": 9e-8,
+    "litellm_provider": "neuronpool",
+    "max_input_tokens": 32768,
+    "max_output_tokens": 4096,
+    "max_tokens": 4096,
+    "mode": "chat",
+    "supports_function_calling": true,
+    "supports_response_schema": true,
+    "supports_system_messages": true
+  },
+  "neuronpool/gpt-oss-20b": {
+    "input_cost_per_token": 1.5e-8,
+    "output_cost_per_token": 7e-8,
+    "litellm_provider": "neuronpool",
+    "max_input_tokens": 131072,
+    "max_output_tokens": 4096,
+    "max_tokens": 4096,
+    "mode": "chat",
+    "supports_function_calling": true,
+    "supports_response_schema": true,
+    "supports_system_messages": true
+  },
+  "neuronpool/neuronpool-tiny-chat": {
+    "input_cost_per_token": 1e-9,
+    "output_cost_per_token": 2e-9,
+    "litellm_provider": "neuronpool",
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "max_tokens": 4096,
+    "mode": "chat",
+    "supports_function_calling": true,
+    "supports_response_schema": true,
+    "supports_system_messages": true
+  },
+  "neuronpool/nomic-embed-text": {
+    "input_cost_per_token": 5e-9,
+    "output_cost_per_token": 0,
+    "litellm_provider": "neuronpool",
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "max_tokens": 8192,
+    "mode": "embedding"
+  }
+}

--- a/tests/test_litellm/llms/openai_like/test_neuronpool_provider.py
+++ b/tests/test_litellm/llms/openai_like/test_neuronpool_provider.py
@@ -1,0 +1,85 @@
+"""NeuronPool OpenAI-compatible JSON provider."""
+
+from pathlib import Path
+
+import litellm
+
+
+class TestNeuronpoolProviderConfig:
+    def test_json_config_exists(self):
+        from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+
+        assert JSONProviderRegistry.exists("neuronpool")
+        cfg = JSONProviderRegistry.get("neuronpool")
+        assert cfg is not None
+        assert cfg.base_url == "https://neuronpool.damnknee.workers.dev/v1"
+        assert cfg.api_key_env == "NEURONPOOL_API_KEY"
+        assert cfg.api_base_env == "NEURONPOOL_API_BASE"
+        assert cfg.param_mappings.get("max_completion_tokens") == "max_tokens"
+        assert "/v1/chat/completions" in cfg.supported_endpoints
+        assert "/v1/embeddings" in cfg.supported_endpoints
+
+    def test_prefixed_model_resolves(self):
+        from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+
+        model, provider, _, api_base = get_llm_provider(
+            model="neuronpool/gpt-oss-20b",
+            custom_llm_provider=None,
+            api_base=None,
+            api_key=None,
+        )
+        assert model == "gpt-oss-20b"
+        assert provider == "neuronpool"
+        assert api_base == "https://neuronpool.damnknee.workers.dev/v1"
+
+    def test_api_base_override(self):
+        from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+
+        _, provider, api_key, api_base = get_llm_provider(
+            model="neuronpool/neuronpool-tiny-chat",
+            custom_llm_provider=None,
+            api_base="http://127.0.0.1:8787/v1",
+            api_key="sk-test",
+        )
+        assert provider == "neuronpool"
+        assert api_base == "http://127.0.0.1:8787/v1"
+        assert api_key == "sk-test"
+
+
+class TestNeuronpoolSidecarPrices:
+    CHAT_MODELS = (
+        "neuronpool/llama-3.2-1b-instruct",
+        "neuronpool/llama-3.1-8b-instruct",
+        "neuronpool/qwen2.5-7b-instruct",
+        "neuronpool/gemma-3-12b-it",
+        "neuronpool/qwen3-30b-a3b",
+        "neuronpool/gpt-oss-20b",
+        "neuronpool/neuronpool-tiny-chat",
+    )
+
+    @staticmethod
+    def _load_sidecar():
+        path = Path(__file__).parents[4] / "neuronpool_model_prices.json"
+        import json
+
+        with open(path) as f:
+            return json.load(f)
+
+    def test_sidecar_chat_entries(self):
+        prices = self._load_sidecar()
+        for model in self.CHAT_MODELS:
+            info = prices.get(model)
+            assert info is not None, f"{model} missing from neuronpool_model_prices.json"
+            assert info["litellm_provider"] == "neuronpool"
+            assert info["mode"] == "chat"
+            assert info["input_cost_per_token"] > 0
+            assert info["output_cost_per_token"] > 0
+            assert info["max_output_tokens"] == 4096
+
+    def test_sidecar_embedding_entry(self):
+        prices = self._load_sidecar()
+        info = prices["neuronpool/nomic-embed-text"]
+        assert info["litellm_provider"] == "neuronpool"
+        assert info["mode"] == "embedding"
+        assert info["input_cost_per_token"] > 0
+        assert info["output_cost_per_token"] == 0


### PR DESCRIPTION
Adds NeuronPool as an OpenAI-compatible `custom_llm_provider`.

## Changes
- `litellm/llms/openai_like/providers.json`: `neuronpool` with `NEURONPOOL_API_KEY` / optional `NEURONPOOL_API_BASE`, chat + embeddings
- `neuronpool_model_prices.json`: catalog-generated `model_prices_and_context_window.json` entries (USD per token). Please merge these 8 keys into `model_prices_and_context_window.json` and delete the sidecar file — that prices file is ~2.1MB and was not rewritten in this PR to keep the diff reviewable.

After merge:
```python
import os, litellm
os.environ["NEURONPOOL_API_KEY"] = "sk-neuronpool-…"
litellm.completion(model="neuronpool/gpt-oss-20b", messages=[{"role":"user","content":"ping"}])
```

Until then, `openai/gpt-oss-20b` + `api_base=https://neuronpool.damnknee.workers.dev/v1` works.

Re-checked 2026-09-04 13:55 UTC: live Worker `GET /v1/models` is **200** (`gpt-oss-20b`, `llama-3.2-1b-instruct`, `neuronpool-tiny-chat`). Chat against prod still needs a pool or public host. Draft remains until the cla-assistant.io web CLA is signed (cannot be signed from this box).