### PR TITLE
feat(baseten): add baseten/zai-org/GLM-5.3 to model pricing registry (#39342)

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -24467,6 +24467,24 @@
         "mode": "chat",
         "output_cost_per_token": 7.5e-07
     },
+    "baseten/zai-org/GLM-5.3": {
+        "cache_read_input_token_cost": 1.4e-07,
+        "input_cost_per_token": 1.4e-06,
+        "litellm_provider": "baseten",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 4.4e-06,
+        "source": "https://docs.baseten.co/inference/model-apis/overview",
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": false
+    },
     "baseten/zai-org/GLM-5": {
         "input_cost_per_token": 9.5e-07,
         "litellm_provider": "baseten",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -24467,6 +24467,24 @@
         "mode": "chat",
         "output_cost_per_token": 7.5e-07
     },
+    "baseten/zai-org/GLM-5.3": {
+        "cache_read_input_token_cost": 1.4e-07,
+        "input_cost_per_token": 1.4e-06,
+        "litellm_provider": "baseten",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 4.4e-06,
+        "source": "https://docs.baseten.co/inference/model-apis/overview",
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": false
+    },
     "baseten/zai-org/GLM-5": {
         "input_cost_per_token": 9.5e-07,
         "litellm_provider": "baseten",

--- a/tests/test_litellm/llms/baseten/chat/test_baseten_completions.py
+++ b/tests/test_litellm/llms/baseten/chat/test_baseten_completions.py
@@ -54,5 +54,62 @@ class TestBasetenModelAPI:
         assert api_key == "test-key"
 
 
+class TestBasetenGLM53:
+    """Test baseten/zai-org/GLM-5.3 pricing, context window, and capability registry"""
+
+    def test_glm_5_3_model_info(self, local_model_cost_map):
+        """Verify get_model_info resolves cleanly with correct pricing and context window limits"""
+        import litellm
+
+        info = litellm.get_model_info("zai-org/GLM-5.3", custom_llm_provider="baseten")
+        assert info["key"] == "baseten/zai-org/GLM-5.3"
+        assert info["litellm_provider"] == "baseten"
+        assert info["mode"] == "chat"
+        assert info["input_cost_per_token"] == 1.4e-06
+        assert info["cache_read_input_token_cost"] == 1.4e-07
+        assert info["output_cost_per_token"] == 4.4e-06
+        assert info["max_input_tokens"] == 1048576
+        assert info["max_output_tokens"] == 262144
+        assert info["max_tokens"] == 262144
+        assert info["supports_function_calling"] is True
+        assert info["supports_parallel_function_calling"] is True
+        assert info["supports_prompt_caching"] is True
+        assert info["supports_reasoning"] is True
+        assert info["supports_response_schema"] is True
+        assert info["supports_tool_choice"] is True
+        assert info["supports_vision"] is False
+
+    def test_glm_5_3_cost_per_token(self, local_model_cost_map):
+        """Verify cost_per_token returns exact expected cost"""
+        import litellm
+
+        prompt_cost, completion_cost = litellm.cost_per_token(
+            "baseten/zai-org/GLM-5.3", prompt_tokens=1000, completion_tokens=500
+        )
+        assert prompt_cost == pytest.approx(0.0014)
+        assert completion_cost == pytest.approx(0.0022)
+        assert prompt_cost + completion_cost == pytest.approx(0.0036)
+
+    def test_glm_5_3_prompt_caching_cost(self, local_model_cost_map):
+        """Verify prompt caching cost calculation for cached tokens"""
+        import litellm
+        from litellm.types.utils import PromptTokensDetailsWrapper, Usage
+
+        usage = Usage(
+            prompt_tokens=1000,
+            completion_tokens=500,
+            prompt_tokens_details=PromptTokensDetailsWrapper(cached_tokens=400),
+        )
+        prompt_cost, completion_cost = litellm.cost_per_token(
+            "baseten/zai-org/GLM-5.3", usage_object=usage
+        )
+        # 600 un-cached * 1.4e-06 + 400 cached * 1.4e-07
+        expected_prompt_cost = (600 * 1.4e-06) + (400 * 1.4e-07)
+        expected_completion_cost = 500 * 4.4e-06
+        assert prompt_cost == pytest.approx(expected_prompt_cost)
+        assert completion_cost == pytest.approx(expected_completion_cost)
+
+
 if __name__ == "__main__":
     pytest.main([__file__])
+

--- a/tests/test_litellm/llms/baseten/chat/test_baseten_completions.py
+++ b/tests/test_litellm/llms/baseten/chat/test_baseten_completions.py
@@ -103,7 +103,6 @@ class TestBasetenGLM53:
         prompt_cost, completion_cost = litellm.cost_per_token(
             "baseten/zai-org/GLM-5.3", usage_object=usage
         )
-        # 600 un-cached * 1.4e-06 + 400 cached * 1.4e-07
         expected_prompt_cost = (600 * 1.4e-06) + (400 * 1.4e-07)
         expected_completion_cost = 500 * 4.4e-06
         assert prompt_cost == pytest.approx(expected_prompt_cost)


### PR DESCRIPTION
Closes #39342

## Summary
Adds baseten/zai-org/GLM-5.3 to LiteLLM's model pricing and capability registry across both model_prices_and_context_window.json and litellm/model_prices_and_context_window_backup.json according to upstream Baseten specifications.

### Key Changes
- Pricing & Context Registry for baseten/zai-org/GLM-5.3
- Schema validation verified via generate_model_prices_schema.py --check
- Automated unit tests added in test_baseten_completions.py

## Tests
- python ci_cd/generate_model_prices_schema.py --check (passed)
- python -m pytest tests/test_litellm/test_model_prices_schema.py --basetemp=./tmp_pytest (21 passed)
- python -m pytest tests/test_litellm/llms/baseten/chat/test_baseten_completions.py --basetemp=./tmp_pytest (5 passed)

## Type of Change
- [x] New feature / model registry addition
- [x] Tests added