### PR TITLE
fix(router): validate context_window_fallbacks at init

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -951,6 +951,7 @@ class Router:
                 self.fallbacks = [{"*": _fallbacks}]
 
         self.context_window_fallbacks = context_window_fallbacks or litellm.context_window_fallbacks
+        self.validate_fallbacks(fallback_param=self.context_window_fallbacks)
 
         _content_policy_fallbacks: Final = content_policy_fallbacks or litellm.content_policy_fallbacks
         self.validate_fallbacks(fallback_param=_content_policy_fallbacks)

--- a/tests/router_unit_tests/test_router_helper_utils.py
+++ b/tests/router_unit_tests/test_router_helper_utils.py
@@ -2825,3 +2825,11 @@ def test_upsert_deployment_clears_stale_budget_config(monkeypatch):
 
     router.upsert_deployment(deployment=unbudgeted)
     assert budget_limiter._get_budget_config_for_deployment(model_id) is None
+
+
+def test_context_window_fallbacks_validated_at_init(model_list):
+    """Malformed context_window_fallbacks must fail fast like the sibling params (#39655)."""
+    import pytest
+
+    with pytest.raises(ValueError, match="not a dictionary"):
+        Router(model_list=model_list, context_window_fallbacks=["garbage"])


### PR DESCRIPTION
## TLDR

`fallbacks` and `content_policy_fallbacks` are validated at Router init, but `context_window_fallbacks` was assigned raw. A typo like `['garbage']` passed startup, then turned a recoverable `ContextWindowExceededError` into `AttributeError` at fallback time. One line: run the same `validate_fallbacks` the siblings use.

## Test plan

- Added `test_context_window_fallbacks_validated_at_init`: red without the fix, green with it.
- Full `test_router_helper_utils.py`: 137 passed; the 4 failures (image/moderation/print) are identical on the clean tree.
- `ruff check` count identical to baseline; `ruff format --check` clean.

## Relevant issues

Fixes #39655