### PR TITLE
feat(router): add zero-setup Auto configuration

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -860,6 +860,7 @@ class LiteLLMRoutes(enum.Enum):
         # proxy admin, or team admin naming their own team via team_id
         "/auto_router/test_routing",
         "/auto_router/validate_complexity_router_config",
+        "/auto_router/recommendation",
         # Agent registry - reads are role-scoped and writes are proxy-admin-gated
         # inside agent_endpoints/endpoints.py
         *agent_management_routes,

--- a/litellm/proxy/management_endpoints/auto_router_endpoints.py
+++ b/litellm/proxy/management_endpoints/auto_router_endpoints.py
@@ -3,6 +3,7 @@ AUTO ROUTER MANAGEMENT ENDPOINTS
 
 POST /auto_router/test_routing - Route one request through an unsaved complexity-router config
 POST /auto_router/validate_complexity_router_config - Dry-run the complexity-router write gate without saving
+GET /auto_router/recommendation - Build an editable config from the caller's available model groups
 """
 
 from collections.abc import Mapping, Sequence
@@ -10,7 +11,7 @@ from datetime import datetime, timedelta, timezone
 from itertools import chain, groupby
 from operator import attrgetter
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Annotated, Final, Protocol
+from typing import TYPE_CHECKING, Annotated, Final, Literal, Protocol
 from uuid import uuid4
 
 from pydantic import BaseModel, ConfigDict, TypeAdapter, field_validator
@@ -40,6 +41,10 @@ from litellm.proxy.litellm_pre_call_utils import (
 from litellm.repositories.base_repository import SupportsModelDump
 from litellm.repositories.team_repository import TeamRepository
 from litellm.router_strategy.complexity_router import ComplexityRouter
+from litellm.router_strategy.complexity_router.auto_setup import (
+    AutoSetupDeployment,
+    AutoSetupDeploymentPricing,
+)
 from litellm.router_utils.auto_router_model_naming import (
     StrategyRouterDependencyRole,
     classify_strategy_router_model,
@@ -52,6 +57,8 @@ from litellm.types.management_endpoints.auto_router_endpoints import (
     AutoRouterBenchmarkTotals,
     AutoRouterCacheBucket,
     AutoRouterCacheStats,
+    AutoRouterExcludedModelGroup,
+    AutoRouterRecommendationResponse,
     AutoRouterRoutingTestRequest,
     AutoRouterRoutingTestResponse,
     ComplexityRouterConfigValidationRequest,
@@ -332,6 +339,197 @@ async def validate_complexity_router_config(
 
     error: Final = validate_complexity_router_config_write(data.complexity_router_config)
     return ComplexityRouterConfigValidationResponse(valid=error is None, error=error)
+
+
+_MODEL_REFERENCE_MAPPING: Final = TypeAdapter(dict[str, object])
+_EMPTY_MODEL_REFERENCE: Final[Mapping[str, object]] = MappingProxyType({})
+
+
+def _deployment_model_refs(raw_deployment: object) -> tuple[str, ...]:
+    deployment: Final = _MODEL_REFERENCE_MAPPING.validate_python(raw_deployment)
+    litellm_params: Final = _MODEL_REFERENCE_MAPPING.validate_python(
+        deployment.get("litellm_params", _EMPTY_MODEL_REFERENCE)
+    )
+    model_info: Final = _MODEL_REFERENCE_MAPPING.validate_python(deployment.get("model_info", _EMPTY_MODEL_REFERENCE))
+    return tuple(
+        value
+        for value in (
+            litellm_params.get("model"),
+            litellm_params.get("base_model"),
+            model_info.get("base_model"),
+        )
+        if isinstance(value, str) and value
+    )
+
+
+_AUTO_SETUP_PRICING_FIELDS: Final = (
+    "input_cost_per_token",
+    "output_cost_per_token",
+    "cache_read_input_token_cost",
+    "input_cost_per_token_above_128k_tokens",
+    "output_cost_per_token_above_128k_tokens",
+    "cache_read_input_token_cost_above_128k_tokens",
+    "input_cost_per_token_above_200k_tokens",
+    "output_cost_per_token_above_200k_tokens",
+    "cache_read_input_token_cost_above_200k_tokens",
+)
+_AUTO_SETUP_UNSUPPORTED_PRICING_FIELDS: Final = (
+    "tiered_pricing",
+    "off_peak_pricing",
+    "input_cost_per_query",
+    "input_cost_per_second",
+    "output_cost_per_second",
+    "input_cost_per_character",
+    "output_cost_per_character",
+)
+
+
+def _deployment_pricing(raw_deployment: object) -> AutoSetupDeploymentPricing | None:
+    deployment: Final = _MODEL_REFERENCE_MAPPING.validate_python(raw_deployment)
+    litellm_params: Final = _MODEL_REFERENCE_MAPPING.validate_python(
+        deployment.get("litellm_params", _EMPTY_MODEL_REFERENCE)
+    )
+    if any(
+        litellm_params.get(field) not in (None, False, 0, 0.0, {}) for field in _AUTO_SETUP_UNSUPPORTED_PRICING_FIELDS
+    ):
+        return None
+    published: Mapping[str, object] | None = None
+    published_raw: Mapping[str, object] | None = None
+    model_cost: Final = _MODEL_REFERENCE_MAPPING.validate_python(litellm.model_cost)
+    refs = _deployment_model_refs(raw_deployment)
+    for ref in (*refs[1:], *refs[:1]):
+        try:
+            candidate = litellm.get_model_info(model=ref)
+        except Exception:  # noqa: BLE001 -- unrecognized deployment aliases are expected; base_model may still resolve
+            continue
+        key = candidate.get("key")
+        raw = model_cost.get(key)
+        if isinstance(raw, Mapping) and ("input_cost_per_token" in raw or "output_cost_per_token" in raw):
+            published = candidate
+            published_raw = _MODEL_REFERENCE_MAPPING.validate_python(raw)
+            break
+    if published_raw is not None and any(
+        published_raw.get(field) not in (None, False, 0, 0.0, {}) for field in _AUTO_SETUP_UNSUPPORTED_PRICING_FIELDS
+    ):
+        return None
+    values: dict[str, object] = {}
+    for field in _AUTO_SETUP_PRICING_FIELDS:
+        custom = litellm_params.get(field)
+        value = custom if custom is not None else published_raw.get(field) if published_raw is not None else None
+        if value is None and field in {"input_cost_per_token", "output_cost_per_token"} and published is not None:
+            value = published.get(field)
+        if value is not None:
+            values[field] = value
+    if "input_cost_per_token" not in values or "output_cost_per_token" not in values:
+        return None
+    try:
+        return AutoSetupDeploymentPricing.model_validate(values)
+    except (TypeError, ValueError):
+        return None
+
+
+def _available_model_deployments(
+    llm_router: "Router", model_names: Sequence[str], team_id: str | None
+) -> Mapping[str, tuple[AutoSetupDeployment, ...]]:
+    return MappingProxyType(
+        {
+            model_name: tuple(
+                AutoSetupDeployment(
+                    model_refs=_deployment_model_refs(deployment),
+                    pricing=_deployment_pricing(deployment),
+                )
+                for deployment in (llm_router.get_model_list(model_name=model_name, team_id=team_id) or ())
+                if _deployment_model_refs(deployment)
+            )
+            for model_name in model_names
+        }
+    )
+
+
+@router.get(
+    "/auto_router/recommendation",
+    tags=["model management"],  # mutable-ok: fastapi's decorator signature types tags as a list
+    dependencies=[Depends(user_api_key_auth)],  # mutable-ok: fastapi's decorator signature types dependencies as a list
+    response_model=AutoRouterRecommendationResponse,
+    status_code=status.HTTP_200_OK,
+)
+async def get_auto_router_recommendation(
+    user_api_key_dict: Annotated[UserAPIKeyAuth, Depends(user_api_key_auth)],
+    quality_level: Annotated[
+        Literal["economy", "balanced", "high", "max"],
+        Query(description="How close every admitted model must be to the best available quality score"),
+    ] = "balanced",
+    team_id: Annotated[str | None, Query(description="Team whose model access the recommendation must use")] = None,
+) -> AutoRouterRecommendationResponse:
+    """Build an editable four-tier router from only the model groups this caller can use."""
+
+    from litellm.proxy.proxy_server import (
+        general_settings,
+        llm_router,
+        prisma_client,
+        proxy_logging_obj,
+        user_api_key_cache,
+        user_model,
+    )
+    from litellm.proxy.utils import get_available_models_for_user
+    from litellm.router_strategy.complexity_router.auto_setup import (
+        analyze_auto_setup_inventory,
+        build_auto_setup_config,
+        load_auto_router_snapshot,
+    )
+
+    await _authorize_router_dry_run(user_api_key_dict=user_api_key_dict, team_id=team_id)
+    if llm_router is None:
+        raise HTTPException(
+            status_code=500,
+            detail={"error": CommonProxyErrors.no_llm_router.value},  # mutable-ok: HTTPException detail is JSON-shaped
+        )
+    available_models: Final = await get_available_models_for_user(
+        user_api_key_dict=user_api_key_dict,
+        llm_router=llm_router,
+        general_settings=general_settings,
+        user_model=user_model,
+        prisma_client=prisma_client,
+        proxy_logging_obj=proxy_logging_obj,
+        team_id=team_id,
+        user_api_key_cache=user_api_key_cache,
+    )
+    snapshot: Final = load_auto_router_snapshot()
+    available_deployments: Final = _available_model_deployments(llm_router, available_models, team_id)
+    _, exclusions = analyze_auto_setup_inventory(snapshot, available_deployments)
+    try:
+        config: Final = build_auto_setup_config(
+            snapshot=snapshot,
+            available_model_deployments=available_deployments,
+            quality_level=quality_level,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail={  # mutable-ok: HTTPException detail is a JSON-shaped error payload
+                "error": f"Could not build an Auto setup: {exc}"
+            },
+        ) from exc
+    matched: Final = tuple(
+        dict.fromkeys(
+            model
+            for tier_models in config.tiers.values()
+            for model in ((tier_models,) if isinstance(tier_models, str) else tier_models)
+        )
+    )
+    return AutoRouterRecommendationResponse(
+        quality_level=quality_level,
+        snapshot_id=snapshot.snapshot_id,
+        snapshot_generated_at=snapshot.generated_at,
+        available_model_group_count=len(available_deployments),
+        matched_model_groups=matched,
+        excluded_model_groups=tuple(
+            AutoRouterExcludedModelGroup(model_group=item.model_group, reason=item.reason) for item in exclusions
+        ),
+        complexity_router_config=RequestComplexityRouterConfig.model_validate(
+            config.model_dump(mode="json", exclude_none=True)
+        ),
+    )
 
 
 @router.post(

--- a/litellm/router_strategy/complexity_router/README.md
+++ b/litellm/router_strategy/complexity_router/README.md
@@ -68,6 +68,35 @@ still resolve to a deployment in `model_list`; this configuration does not creat
             - abc
 ```
 
+### Zero-setup Auto configuration
+
+The dashboard's Add Router flow can generate the four tiers from the model groups the
+current admin or team can actually use. Auto setup asks for one product choice: Quality
+level (Economy, Balanced, High, or Max).
+
+The quality level is a gate, not an optimization weight. For every complexity tier,
+LiteLLM finds the best available model's conservative LiveBench quality score and admits
+only models within the selected maximum regret: 15 percentage points for Economy, 7 for
+Balanced, 3 for High, and 1 for Max. Auto then chooses the lowest estimated cost per
+completed task among the admitted models. If none of those models has comparable token
+pricing, Auto chooses the highest conservative quality score instead of failing setup.
+This means Max still sends trivial work to a smaller model when that model is within one
+point of the best available quality for trivial work.
+
+Cost is estimated dollars per completed task, not input or output token price. LiteLLM
+combines the benchmark request's token mix and completion probability with the configured
+deployment's input, cache-read, and output rates. When a model group has multiple
+deployments, Auto uses the most conservative estimate.
+
+Auto selects one model group for each tier and returns a normal, editable `heuristic_v2`
+configuration. It does not add a request-time policy, collect live latency observations,
+or change how the complexity router runs after creation. Existing routers, manual
+configurations, and LiteLLM's deployment-level routing are therefore unchanged.
+
+The bundled benchmark data is a versioned snapshot. Creating or regenerating a router uses
+the snapshot shipped with that LiteLLM version; the saved router contains only the four
+selected tiers and ordinary complexity-router settings.
+
 ### Heuristic v2
 
 Set `classifier_type: heuristic_v2` to classify with the bundled calibrated

--- a/litellm/router_strategy/complexity_router/artifacts/auto_router_snapshot_v0.json
+++ b/litellm/router_strategy/complexity_router/artifacts/auto_router_snapshot_v0.json
@@ -1,0 +1,4578 @@
+{
+  "activation_scope": {
+    "setup_mode": "auto"
+  },
+  "artifact_sha256": "e191b5f7225e4da7a178eb5fe8780bcea24fb0166be23e2069338c6fe5522cd5",
+  "complexity_policy": {
+    "cumulative_shares": {
+      "complex": 1.0,
+      "simple": 0.5,
+      "standard": 0.75,
+      "trivial": 0.25
+    },
+    "method": "relative_quantiles"
+  },
+  "definitions": {
+    "cost": "Provider-adjustable estimate of dollars per completed task using the benchmark trajectory's observed token mix and completion rate.",
+    "quality": "Mean LiveBench subtask score within the inferred complexity bucket.",
+    "quality_lower_bound": "Mean subtask score minus 1.96 standard errors, floored at zero."
+  },
+  "generated_at": "2026-09-03T20:00:00Z",
+  "limitations": [
+    "The snapshot is an offline setup prior; it does not change runtime routing, endpoint health checks, or deployment selection.",
+    "LiveBench cost per completion treats partial benchmark credit as a fractional completion.",
+    "LiveBench input-token means are model-level, not complexity-bucket-specific; output-token means are weighted inside each bucket.",
+    "Provider-adjusted completion cost scales the observed request cost by the benchmark token mix and source prices; cache discounts and non-token charges can make it approximate.",
+    "LiteLLM recomputes every quality gate after intersecting the snapshot with the user's configured, routable models.",
+    "Benchmark variants include their measured reasoning effort; setup preserves required effort parameters when the provider supports them."
+  ],
+  "models": {
+    "claude-fable-5-1-max-effort": {
+      "benchmark_model_id": "claude-fable-5-1-max-effort",
+      "identity": {
+        "benchmark_model_id": "claude-fable-5-1-max-effort",
+        "family_id": "claude-fable-5-1",
+        "is_routable": true,
+        "litellm_model_keys": [
+          "anthropic.claude-fable-5-1",
+          "azure_ai/claude-fable-5-1",
+          "claude-fable-5-1",
+          "eu.anthropic.claude-fable-5-1",
+          "global.anthropic.claude-fable-5-1",
+          "us.anthropic.claude-fable-5-1",
+          "vertex_ai/claude-fable-5-1"
+        ],
+        "reasoning_effort": "max",
+        "required_parameters": {
+          "reasoning_effort": "max"
+        }
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "claude-fable-5-1-max-effort",
+          "completion_probability": 0.6645920535714286,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 4.002891945931923,
+          "mean_input_tokens": 1263.0,
+          "mean_output_tokens": 33199.25892857143,
+          "mean_request_cost_usd": 2.6602901785714286,
+          "quality_lower_bound": 0.6092130921684613,
+          "quality_score": 0.6661216666666666,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1e-05,
+          "source_output_cost_per_token": 5e-05,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "claude-fable-5-1-max-effort",
+          "completion_probability": 0.9034262716763007,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.38505754057873887,
+          "mean_input_tokens": 1263.0,
+          "mean_output_tokens": 6685.56936416185,
+          "mean_request_cost_usd": 0.34787109826589596,
+          "quality_lower_bound": 0.8425995986019852,
+          "quality_score": 0.9008116666666667,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1e-05,
+          "source_output_cost_per_token": 5e-05,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "claude-fable-5-1-max-effort",
+          "completion_probability": 0.8514491354466859,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 1.7827805688792642,
+          "mean_input_tokens": 1263.0,
+          "mean_output_tokens": 29926.971181556197,
+          "mean_request_cost_usd": 1.5179469740634004,
+          "quality_lower_bound": 0.7415937065851377,
+          "quality_score": 0.8288983333333334,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1e-05,
+          "source_output_cost_per_token": 5e-05,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "claude-fable-5-1-max-effort",
+          "completion_probability": 0.9792262322946175,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.11767196890092387,
+          "mean_input_tokens": 1263.0,
+          "mean_output_tokens": 2217.8895184135977,
+          "mean_request_cost_usd": 0.11522747875354107,
+          "quality_lower_bound": 0.9581461039814795,
+          "quality_score": 0.9790199999999999,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1e-05,
+          "source_output_cost_per_token": 5e-05,
+          "subtask_count": 5
+        }
+      }
+    },
+    "claude-fable-5-max-effort": {
+      "benchmark_model_id": "claude-fable-5-max-effort",
+      "identity": {
+        "benchmark_model_id": "claude-fable-5-max-effort",
+        "family_id": "claude-fable-5",
+        "is_routable": true,
+        "litellm_model_keys": [
+          "anthropic.claude-fable-5",
+          "azure_ai/claude-fable-5",
+          "claude-fable-5",
+          "deepinfra/anthropic/claude-fable-5",
+          "eu.anthropic.claude-fable-5",
+          "global.anthropic.claude-fable-5",
+          "us.anthropic.claude-fable-5",
+          "vertex_ai/claude-fable-5"
+        ],
+        "reasoning_effort": "max",
+        "required_parameters": {
+          "reasoning_effort": "max"
+        }
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "claude-fable-5-max-effort",
+          "completion_probability": 0.6632416964285713,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 5.214221760086114,
+          "mean_input_tokens": 1264.0,
+          "mean_output_tokens": 28035.73214285714,
+          "mean_request_cost_usd": 3.4582892857142857,
+          "quality_lower_bound": 0.5788725616068174,
+          "quality_score": 0.65567,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1e-05,
+          "source_output_cost_per_token": 5e-05,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "claude-fable-5-max-effort",
+          "completion_probability": 0.9089316184971098,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.43912636553478873,
+          "mean_input_tokens": 1264.0,
+          "mean_output_tokens": 7711.205202312139,
+          "mean_request_cost_usd": 0.399135838150289,
+          "quality_lower_bound": 0.8497278750259674,
+          "quality_score": 0.9057400000000001,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1e-05,
+          "source_output_cost_per_token": 5e-05,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "claude-fable-5-max-effort",
+          "completion_probability": 0.8486,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 1.8625221673806187,
+          "mean_input_tokens": 1264.0,
+          "mean_output_tokens": 31176.20172910663,
+          "mean_request_cost_usd": 1.580536311239193,
+          "quality_lower_bound": 0.7532045960680842,
+          "quality_score": 0.8290166666666666,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1e-05,
+          "source_output_cost_per_token": 5e-05,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "claude-fable-5-max-effort",
+          "completion_probability": 0.9678941643059489,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.1611368906253183,
+          "mean_input_tokens": 1264.0,
+          "mean_output_tokens": 3032.813031161473,
+          "mean_request_cost_usd": 0.15596345609065154,
+          "quality_lower_bound": 0.946566900924344,
+          "quality_score": 0.967098,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1e-05,
+          "source_output_cost_per_token": 5e-05,
+          "subtask_count": 5
+        }
+      }
+    },
+    "claude-opus-4-5-20251101-thinking-64k-high-effort": {
+      "benchmark_model_id": "claude-opus-4-5-20251101-thinking-64k-high-effort",
+      "identity": {
+        "benchmark_model_id": "claude-opus-4-5-20251101-thinking-64k-high-effort",
+        "family_id": "claude-opus-4-5-20251101",
+        "is_routable": true,
+        "litellm_model_keys": [
+          "claude-opus-4-5-20251101"
+        ],
+        "reasoning_effort": "high",
+        "required_parameters": {
+          "reasoning_effort": "high"
+        }
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "claude-opus-4-5-20251101-thinking-64k-high-effort",
+          "completion_probability": 0.4981249107142857,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 1.2955334819023985,
+          "mean_input_tokens": 79045.0,
+          "mean_output_tokens": 12867.42857142857,
+          "mean_request_cost_usd": 0.6453375,
+          "quality_lower_bound": 0.34521477211231855,
+          "quality_score": 0.47735666666666665,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 5e-06,
+          "source_output_cost_per_token": 2.5e-05,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "claude-opus-4-5-20251101-thinking-64k-high-effort",
+          "completion_probability": 0.8110766184971099,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.3623535990181607,
+          "mean_input_tokens": 79045.0,
+          "mean_output_tokens": 11546.271676300577,
+          "mean_request_cost_usd": 0.2938965317919075,
+          "quality_lower_bound": 0.769244886726077,
+          "quality_score": 0.8051866666666667,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 5e-06,
+          "source_output_cost_per_token": 2.5e-05,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "claude-opus-4-5-20251101-thinking-64k-high-effort",
+          "completion_probability": 0.7115781268011527,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.9657541234098289,
+          "mean_input_tokens": 79045.0,
+          "mean_output_tokens": 26907.109510086455,
+          "mean_request_cost_usd": 0.6872095100864554,
+          "quality_lower_bound": 0.646597808452617,
+          "quality_score": 0.7009949999999999,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 5e-06,
+          "source_output_cost_per_token": 2.5e-05,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "claude-opus-4-5-20251101-thinking-64k-high-effort",
+          "completion_probability": 0.9735590651558073,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.22691398212248595,
+          "mean_input_tokens": 79045.0,
+          "mean_output_tokens": 8763.036827195467,
+          "mean_request_cost_usd": 0.22091416430594898,
+          "quality_lower_bound": 0.9585884810652954,
+          "quality_score": 0.9749399999999999,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 5e-06,
+          "source_output_cost_per_token": 2.5e-05,
+          "subtask_count": 5
+        }
+      }
+    },
+    "claude-opus-4-6-thinking-auto-high-effort": {
+      "benchmark_model_id": "claude-opus-4-6-thinking-auto-high-effort",
+      "identity": {
+        "benchmark_model_id": "claude-opus-4-6-thinking-auto-high-effort",
+        "family_id": "claude-opus-4-6",
+        "is_routable": true,
+        "litellm_model_keys": [
+          "azure_ai/claude-opus-4-6",
+          "claude-opus-4-6",
+          "perplexity/anthropic/claude-opus-4-6",
+          "vertex_ai/claude-opus-4-6"
+        ],
+        "reasoning_effort": "high",
+        "required_parameters": {
+          "reasoning_effort": "high"
+        }
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "claude-opus-4-6-thinking-auto-high-effort",
+          "completion_probability": 0.5440302678571428,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 0.9723904214231778,
+          "mean_input_tokens": 1935.0,
+          "mean_output_tokens": 9021.285714285714,
+          "mean_request_cost_usd": 0.5290098214285714,
+          "quality_lower_bound": 0.4365895928124619,
+          "quality_score": 0.5346133333333333,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 5e-06,
+          "source_output_cost_per_token": 2.5e-05,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "claude-opus-4-6-thinking-auto-high-effort",
+          "completion_probability": 0.8525172832369942,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.2008007702995054,
+          "mean_input_tokens": 1935.0,
+          "mean_output_tokens": 6637.777456647399,
+          "mean_request_cost_usd": 0.17118612716763007,
+          "quality_lower_bound": 0.7932421041561762,
+          "quality_score": 0.8487183333333332,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 5e-06,
+          "source_output_cost_per_token": 2.5e-05,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "claude-opus-4-6-thinking-auto-high-effort",
+          "completion_probability": 0.6912953602305476,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.7138626149321894,
+          "mean_input_tokens": 1935.0,
+          "mean_output_tokens": 19158.79538904899,
+          "mean_request_cost_usd": 0.49348991354466853,
+          "quality_lower_bound": 0.6303728077430275,
+          "quality_score": 0.6842783333333333,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 5e-06,
+          "source_output_cost_per_token": 2.5e-05,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "claude-opus-4-6-thinking-auto-high-effort",
+          "completion_probability": 0.9707262039660056,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.09611682034141958,
+          "mean_input_tokens": 1935.0,
+          "mean_output_tokens": 3658.555240793201,
+          "mean_request_cost_usd": 0.09330311614730878,
+          "quality_lower_bound": 0.9611363710759814,
+          "quality_score": 0.9749399999999999,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 5e-06,
+          "source_output_cost_per_token": 2.5e-05,
+          "subtask_count": 5
+        }
+      }
+    },
+    "claude-opus-4-7-xhigh-effort": {
+      "benchmark_model_id": "claude-opus-4-7-xhigh-effort",
+      "identity": {
+        "benchmark_model_id": "claude-opus-4-7-xhigh-effort",
+        "family_id": "claude-opus-4-7",
+        "is_routable": true,
+        "litellm_model_keys": [
+          "anthropic.claude-opus-4-7",
+          "au.anthropic.claude-opus-4-7",
+          "azure_ai/claude-opus-4-7",
+          "claude-opus-4-7",
+          "deepinfra/anthropic/claude-opus-4-7",
+          "eu.anthropic.claude-opus-4-7",
+          "global.anthropic.claude-opus-4-7",
+          "jp.anthropic.claude-opus-4-7",
+          "perplexity/anthropic/claude-opus-4-7",
+          "us.anthropic.claude-opus-4-7",
+          "vertex_ai/claude-opus-4-7"
+        ],
+        "reasoning_effort": "xhigh",
+        "required_parameters": {
+          "reasoning_effort": "xhigh"
+        }
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "claude-opus-4-7-xhigh-effort",
+          "completion_probability": 0.5536358928571429,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 1.765312974843897,
+          "mean_input_tokens": 1285.0,
+          "mean_output_tokens": 13627.535714285714,
+          "mean_request_cost_usd": 0.977340625,
+          "quality_lower_bound": 0.46192477930777903,
+          "quality_score": 0.5435150000000001,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 5e-06,
+          "source_output_cost_per_token": 2.5e-05,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "claude-opus-4-7-xhigh-effort",
+          "completion_probability": 0.8623095664739884,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.21927367996237826,
+          "mean_input_tokens": 1285.0,
+          "mean_output_tokens": 7290.829479768786,
+          "mean_request_cost_usd": 0.18908179190751448,
+          "quality_lower_bound": 0.7956674213700154,
+          "quality_score": 0.8572016666666666,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 5e-06,
+          "source_output_cost_per_token": 2.5e-05,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "claude-opus-4-7-xhigh-effort",
+          "completion_probability": 0.754466484149856,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.8121505178745887,
+          "mean_input_tokens": 1285.0,
+          "mean_output_tokens": 24074.011527377523,
+          "mean_request_cost_usd": 0.6127403458213256,
+          "quality_lower_bound": 0.6611835790578724,
+          "quality_score": 0.7416183333333333,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 5e-06,
+          "source_output_cost_per_token": 2.5e-05,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "claude-opus-4-7-xhigh-effort",
+          "completion_probability": 0.9749749858356941,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.047679003430232555,
+          "mean_input_tokens": 1285.0,
+          "mean_output_tokens": 1772.3966005665723,
+          "mean_request_cost_usd": 0.04648583569405099,
+          "quality_lower_bound": 0.947439528242222,
+          "quality_score": 0.9728220000000001,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 5e-06,
+          "source_output_cost_per_token": 2.5e-05,
+          "subtask_count": 5
+        }
+      }
+    },
+    "claude-opus-4-8-max-effort": {
+      "benchmark_model_id": "claude-opus-4-8-max-effort",
+      "identity": {
+        "benchmark_model_id": "claude-opus-4-8-max-effort",
+        "family_id": "claude-opus-4-8",
+        "is_routable": true,
+        "litellm_model_keys": [
+          "anthropic.claude-opus-4-8",
+          "au.anthropic.claude-opus-4-8",
+          "azure_ai/claude-opus-4-8",
+          "bedrock/us-gov-east-1/anthropic.claude-opus-4-8",
+          "bedrock/us-gov-west-1/anthropic.claude-opus-4-8",
+          "claude-opus-4-8",
+          "deepinfra/anthropic/claude-opus-4-8",
+          "eu.anthropic.claude-opus-4-8",
+          "global.anthropic.claude-opus-4-8",
+          "jp.anthropic.claude-opus-4-8",
+          "us-gov.anthropic.claude-opus-4-8",
+          "us.anthropic.claude-opus-4-8",
+          "vertex_ai/claude-opus-4-8"
+        ],
+        "reasoning_effort": "max",
+        "required_parameters": {
+          "reasoning_effort": "max"
+        }
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "claude-opus-4-8-max-effort",
+          "completion_probability": 0.5508146428571429,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 3.7899521877012035,
+          "mean_input_tokens": 1089.0,
+          "mean_output_tokens": 52024.40178571428,
+          "mean_request_cost_usd": 2.087561160714286,
+          "quality_lower_bound": 0.4441463198800639,
+          "quality_score": 0.5437283333333333,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 5e-06,
+          "source_output_cost_per_token": 2.5e-05,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "claude-opus-4-8-max-effort",
+          "completion_probability": 0.8584239306358381,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.42221953473814827,
+          "mean_input_tokens": 1089.0,
+          "mean_output_tokens": 14227.748554913294,
+          "mean_request_cost_usd": 0.36244335260115607,
+          "quality_lower_bound": 0.7881699970577629,
+          "quality_score": 0.8577533333333333,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 5e-06,
+          "source_output_cost_per_token": 2.5e-05,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "claude-opus-4-8-max-effort",
+          "completion_probability": 0.7663756484149855,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 1.1457071695113437,
+          "mean_input_tokens": 1089.0,
+          "mean_output_tokens": 34808.821325648416,
+          "mean_request_cost_usd": 0.8780420749279538,
+          "quality_lower_bound": 0.6434622480125556,
+          "quality_score": 0.7433983333333334,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 5e-06,
+          "source_output_cost_per_token": 2.5e-05,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "claude-opus-4-8-max-effort",
+          "completion_probability": 0.9763922379603399,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.15555792693028503,
+          "mean_input_tokens": 1089.0,
+          "mean_output_tokens": 5988.869688385269,
+          "mean_request_cost_usd": 0.151885552407932,
+          "quality_lower_bound": 0.9576762334934847,
+          "quality_score": 0.9749800000000001,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 5e-06,
+          "source_output_cost_per_token": 2.5e-05,
+          "subtask_count": 5
+        }
+      }
+    },
+    "claude-opus-5-max-effort": {
+      "benchmark_model_id": "claude-opus-5-max-effort",
+      "identity": {
+        "benchmark_model_id": "claude-opus-5-max-effort",
+        "family_id": "claude-opus-5",
+        "is_routable": true,
+        "litellm_model_keys": [
+          "anthropic.claude-opus-5",
+          "au.anthropic.claude-opus-5",
+          "azure_ai/claude-opus-5",
+          "claude-opus-5",
+          "deepinfra/anthropic/claude-opus-5",
+          "eu.anthropic.claude-opus-5",
+          "global.anthropic.claude-opus-5",
+          "jp.anthropic.claude-opus-5",
+          "openrouter/anthropic/claude-opus-5",
+          "us.anthropic.claude-opus-5",
+          "vertex_ai/claude-opus-5"
+        ],
+        "reasoning_effort": "max",
+        "required_parameters": {
+          "reasoning_effort": "max"
+        }
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "claude-opus-5-max-effort",
+          "completion_probability": 0.6257910714285714,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 3.0495230322762903,
+          "mean_input_tokens": 1263.0,
+          "mean_output_tokens": 25342.026785714286,
+          "mean_request_cost_usd": 1.9083642857142855,
+          "quality_lower_bound": 0.5271982605289206,
+          "quality_score": 0.6398033333333334,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 5e-06,
+          "source_output_cost_per_token": 2.5e-05,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "claude-opus-5-max-effort",
+          "completion_probability": 0.8770323699421967,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.11491162393410251,
+          "mean_input_tokens": 1263.0,
+          "mean_output_tokens": 3759.791907514451,
+          "mean_request_cost_usd": 0.10078121387283237,
+          "quality_lower_bound": 0.8101252023432568,
+          "quality_score": 0.8775550000000001,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 5e-06,
+          "source_output_cost_per_token": 2.5e-05,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "claude-opus-5-max-effort",
+          "completion_probability": 0.7873195100864554,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.8529217089305349,
+          "mean_input_tokens": 1263.0,
+          "mean_output_tokens": 26427.57925072046,
+          "mean_request_cost_usd": 0.6715219020172911,
+          "quality_lower_bound": 0.6461502379455998,
+          "quality_score": 0.7567566666666666,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 5e-06,
+          "source_output_cost_per_token": 2.5e-05,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "claude-opus-5-max-effort",
+          "completion_probability": 0.9708111299435027,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.04746918777279668,
+          "mean_input_tokens": 1263.0,
+          "mean_output_tokens": 1760.8502824858756,
+          "mean_request_cost_usd": 0.04608361581920904,
+          "quality_lower_bound": 0.947379644845522,
+          "quality_score": 0.973158,
+          "question_count": 354,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 5e-06,
+          "source_output_cost_per_token": 2.5e-05,
+          "subtask_count": 5
+        }
+      }
+    },
+    "claude-sonnet-4-6-thinking-auto-medium-effort": {
+      "benchmark_model_id": "claude-sonnet-4-6-thinking-auto-medium-effort",
+      "identity": {
+        "benchmark_model_id": "claude-sonnet-4-6-thinking-auto-medium-effort",
+        "family_id": "claude-sonnet-4-6",
+        "is_routable": true,
+        "litellm_model_keys": [
+          "anthropic.claude-sonnet-4-6",
+          "au.anthropic.claude-sonnet-4-6",
+          "azure_ai/claude-sonnet-4-6",
+          "claude-sonnet-4-6",
+          "deepinfra/anthropic/claude-sonnet-4-6",
+          "eu.anthropic.claude-sonnet-4-6",
+          "global.anthropic.claude-sonnet-4-6",
+          "jp.anthropic.claude-sonnet-4-6",
+          "snowflake/claude-sonnet-4-6",
+          "us.anthropic.claude-sonnet-4-6",
+          "vertex_ai/claude-sonnet-4-6"
+        ],
+        "reasoning_effort": "medium",
+        "required_parameters": {
+          "reasoning_effort": "medium"
+        }
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "claude-sonnet-4-6-thinking-auto-medium-effort",
+          "completion_probability": 0.5017582142857143,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 0.568415493233437,
+          "mean_input_tokens": 1328.0,
+          "mean_output_tokens": 10821.42857142857,
+          "mean_request_cost_usd": 0.2852071428571429,
+          "quality_lower_bound": 0.37703186770250874,
+          "quality_score": 0.488105,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 3e-06,
+          "source_output_cost_per_token": 1.5e-05,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "claude-sonnet-4-6-thinking-auto-medium-effort",
+          "completion_probability": 0.8169103468208092,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.163557543653307,
+          "mean_input_tokens": 1328.0,
+          "mean_output_tokens": 8698.040462427745,
+          "mean_request_cost_usd": 0.13361184971098267,
+          "quality_lower_bound": 0.738825421457911,
+          "quality_score": 0.8124633333333332,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 3e-06,
+          "source_output_cost_per_token": 1.5e-05,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "claude-sonnet-4-6-thinking-auto-medium-effort",
+          "completion_probability": 0.7594697694524495,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.5803005820722565,
+          "mean_input_tokens": 1328.0,
+          "mean_output_tokens": 28800.21902017291,
+          "mean_request_cost_usd": 0.4407207492795389,
+          "quality_lower_bound": 0.6238595808835384,
+          "quality_score": 0.7377216666666667,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 3e-06,
+          "source_output_cost_per_token": 1.5e-05,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "claude-sonnet-4-6-thinking-auto-medium-effort",
+          "completion_probability": 0.9084040793201132,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.06498087858468846,
+          "mean_input_tokens": 1328.0,
+          "mean_output_tokens": 3861.886685552408,
+          "mean_request_cost_usd": 0.059028895184135975,
+          "quality_lower_bound": 0.8446427881887083,
+          "quality_score": 0.9310579999999999,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 3e-06,
+          "source_output_cost_per_token": 1.5e-05,
+          "subtask_count": 5
+        }
+      }
+    },
+    "claude-sonnet-5-xhigh-effort": {
+      "benchmark_model_id": "claude-sonnet-5-xhigh-effort",
+      "identity": {
+        "benchmark_model_id": "claude-sonnet-5-xhigh-effort",
+        "family_id": "claude-sonnet-5",
+        "is_routable": true,
+        "litellm_model_keys": [
+          "anthropic.claude-sonnet-5",
+          "au.anthropic.claude-sonnet-5",
+          "azure_ai/claude-sonnet-5",
+          "bedrock/us-gov-east-1/anthropic.claude-sonnet-5",
+          "bedrock/us-gov-west-1/anthropic.claude-sonnet-5",
+          "claude-sonnet-5",
+          "deepinfra/anthropic/claude-sonnet-5",
+          "eu.anthropic.claude-sonnet-5",
+          "global.anthropic.claude-sonnet-5",
+          "jp.anthropic.claude-sonnet-5",
+          "us-gov.anthropic.claude-sonnet-5",
+          "us.anthropic.claude-sonnet-5",
+          "vertex_ai/claude-sonnet-5"
+        ],
+        "reasoning_effort": "xhigh",
+        "required_parameters": {
+          "reasoning_effort": "xhigh"
+        }
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "claude-sonnet-5-xhigh-effort",
+          "completion_probability": 0.5406266964285714,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 1.535564958590551,
+          "mean_input_tokens": 1214.0,
+          "mean_output_tokens": 20245.16964285714,
+          "mean_request_cost_usd": 0.8301674107142858,
+          "quality_lower_bound": 0.4851509363965742,
+          "quality_score": 0.5578083333333334,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 3e-06,
+          "source_output_cost_per_token": 1.5e-05,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "claude-sonnet-5-xhigh-effort",
+          "completion_probability": 0.8347309248554914,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.2661630950266414,
+          "mean_input_tokens": 1214.0,
+          "mean_output_tokens": 14554.774566473989,
+          "mean_request_cost_usd": 0.22217456647398845,
+          "quality_lower_bound": 0.7827287342273122,
+          "quality_score": 0.828,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 3e-06,
+          "source_output_cost_per_token": 1.5e-05,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "claude-sonnet-5-xhigh-effort",
+          "completion_probability": 0.759424409221902,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.7553995751446368,
+          "mean_input_tokens": 1214.0,
+          "mean_output_tokens": 37832.74351585015,
+          "mean_request_cost_usd": 0.5736688760806916,
+          "quality_lower_bound": 0.6481641669625048,
+          "quality_score": 0.7392083333333334,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 3e-06,
+          "source_output_cost_per_token": 1.5e-05,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "claude-sonnet-5-xhigh-effort",
+          "completion_probability": 0.9709627478753541,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.07604438047164719,
+          "mean_input_tokens": 1214.0,
+          "mean_output_tokens": 4835.838526912181,
+          "mean_request_cost_usd": 0.07383626062322945,
+          "quality_lower_bound": 0.955519401260248,
+          "quality_score": 0.973274,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 3e-06,
+          "source_output_cost_per_token": 1.5e-05,
+          "subtask_count": 5
+        }
+      }
+    },
+    "deepseek-v4-flash": {
+      "benchmark_model_id": "deepseek-v4-flash",
+      "identity": {
+        "benchmark_model_id": "deepseek-v4-flash",
+        "family_id": "deepseek-v4-flash",
+        "is_routable": true,
+        "litellm_model_keys": [
+          "azure_ai/deepseek-v4-flash",
+          "dashscope/deepseek-v4-flash",
+          "deepinfra/deepseek-ai/DeepSeek-V4-Flash",
+          "deepseek-v4-flash",
+          "deepseek/deepseek-v4-flash",
+          "fireworks_ai/accounts/fireworks/models/deepseek-v4-flash",
+          "fireworks_ai/deepseek-v4-flash",
+          "libertai/deepseek-v4-flash",
+          "novita/deepseek/deepseek-v4-flash",
+          "pinstripes/ps/deepseek-v4-flash",
+          "qwen_ai_platform/deepseek-v4-flash",
+          "qwencloud/deepseek-v4-flash",
+          "tencent/deepseek-v4-flash",
+          "tensormesh/deepseek-ai/DeepSeek-V4-Flash",
+          "wandb/deepseek-ai/DeepSeek-V4-Flash"
+        ],
+        "reasoning_effort": null,
+        "required_parameters": {}
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "deepseek-v4-flash",
+          "completion_probability": 0.44839553571428575,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 0.03171128009987993,
+          "mean_input_tokens": 148772.0,
+          "mean_output_tokens": 35092.94642857143,
+          "mean_request_cost_usd": 0.01421919642857143,
+          "quality_lower_bound": 0.3364896272529753,
+          "quality_score": 0.43319166666666664,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.4e-07,
+          "source_output_cost_per_token": 2.8e-07,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "deepseek-v4-flash",
+          "completion_probability": 0.7174954335260115,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.013094683650279621,
+          "mean_input_tokens": 148772.0,
+          "mean_output_tokens": 33093.257225433525,
+          "mean_request_cost_usd": 0.009395375722543352,
+          "quality_lower_bound": 0.603384170578614,
+          "quality_score": 0.70219,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.4e-07,
+          "source_output_cost_per_token": 2.8e-07,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "deepseek-v4-flash",
+          "completion_probability": 0.5660231988472622,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.02837889405353749,
+          "mean_input_tokens": 148772.0,
+          "mean_output_tokens": 56471.58501440922,
+          "mean_request_cost_usd": 0.016063112391930836,
+          "quality_lower_bound": 0.5055896074804485,
+          "quality_score": 0.599025,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.4e-07,
+          "source_output_cost_per_token": 2.8e-07,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "deepseek-v4-flash",
+          "completion_probability": 0.9624647875354108,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.004025900568615041,
+          "mean_input_tokens": 148772.0,
+          "mean_output_tokens": 13668.025495750708,
+          "mean_request_cost_usd": 0.0038747875354107645,
+          "quality_lower_bound": 0.9258556425341127,
+          "quality_score": 0.957196,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.4e-07,
+          "source_output_cost_per_token": 2.8e-07,
+          "subtask_count": 5
+        }
+      }
+    },
+    "deepseek-v4-flash-0731": {
+      "benchmark_model_id": "deepseek-v4-flash-0731",
+      "identity": {
+        "benchmark_model_id": "deepseek-v4-flash-0731",
+        "family_id": "deepseek-v4-flash-0731",
+        "is_routable": true,
+        "litellm_model_keys": [
+          "azure_ai/DeepSeek-V4-Flash-0731",
+          "dashscope/deepseek-v4-flash-0731",
+          "deepinfra/deepseek-ai/DeepSeek-V4-Flash-0731",
+          "fireworks_ai/accounts/fireworks/models/deepseek-v4-flash-0731",
+          "fireworks_ai/deepseek-v4-flash-0731",
+          "novita/deepseek/deepseek-v4-flash-0731",
+          "perplexity/perplexity/deepseek-v4-flash-0731",
+          "qwen_ai_platform/deepseek-v4-flash-0731",
+          "qwencloud/deepseek-v4-flash-0731",
+          "scaleway/deepseek-v4-flash-0731",
+          "together_ai/deepseek-ai/DeepSeek-V4-Flash-0731",
+          "wandb/deepseek-ai/DeepSeek-V4-Flash-0731"
+        ],
+        "reasoning_effort": null,
+        "required_parameters": {}
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "deepseek-v4-flash-0731",
+          "completion_probability": 0.5157110714285714,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 0.4394054395075869,
+          "mean_input_tokens": 475485.0,
+          "mean_output_tokens": 35149.83928571428,
+          "mean_request_cost_usd": 0.22660624999999998,
+          "quality_lower_bound": 0.40376896581503474,
+          "quality_score": 0.509,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.4e-07,
+          "source_output_cost_per_token": 2.8e-07,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "deepseek-v4-flash-0731",
+          "completion_probability": 0.8456412427745664,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.0060579263531826775,
+          "mean_input_tokens": 475485.0,
+          "mean_output_tokens": 17953.242774566475,
+          "mean_request_cost_usd": 0.005122832369942197,
+          "quality_lower_bound": 0.7696517274404475,
+          "quality_score": 0.84598,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.4e-07,
+          "source_output_cost_per_token": 2.8e-07,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "deepseek-v4-flash-0731",
+          "completion_probability": 0.7028492219020173,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.012699646412453419,
+          "mean_input_tokens": 475485.0,
+          "mean_output_tokens": 31513.616714697408,
+          "mean_request_cost_usd": 0.008925936599423631,
+          "quality_lower_bound": 0.6365405113412037,
+          "quality_score": 0.7135733333333333,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.4e-07,
+          "source_output_cost_per_token": 2.8e-07,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "deepseek-v4-flash-0731",
+          "completion_probability": 0.9622267988668556,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.001468206744000269,
+          "mean_input_tokens": 475485.0,
+          "mean_output_tokens": 4956.988668555241,
+          "mean_request_cost_usd": 0.0014127478753541078,
+          "quality_lower_bound": 0.9283932717105589,
+          "quality_score": 0.960822,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.4e-07,
+          "source_output_cost_per_token": 2.8e-07,
+          "subtask_count": 5
+        }
+      }
+    },
+    "deepseek-v4-flash-vision-exp": {
+      "benchmark_model_id": "deepseek-v4-flash-vision-exp",
+      "identity": {
+        "benchmark_model_id": "deepseek-v4-flash-vision-exp",
+        "family_id": "deepseek-v4-flash-vision-exp",
+        "is_routable": true,
+        "litellm_model_keys": [
+          "deepseek-v4-flash-vision-exp",
+          "deepseek/deepseek-v4-flash-vision-exp",
+          "novita/deepseek/deepseek-v4-flash-vision-exp"
+        ],
+        "reasoning_effort": null,
+        "required_parameters": {}
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "deepseek-v4-flash-vision-exp",
+          "completion_probability": 0.5963680357142858,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 0.1042448619785062,
+          "mean_input_tokens": 469904.0,
+          "mean_output_tokens": 59667.0625,
+          "mean_request_cost_usd": 0.06216830357142857,
+          "quality_lower_bound": 0.5460797677435435,
+          "quality_score": 0.6141033333333333,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 2.2e-07,
+          "source_output_cost_per_token": 6.6e-07,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "deepseek-v4-flash-vision-exp",
+          "completion_probability": 0.8144626589595376,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.04363811907904243,
+          "mean_input_tokens": 469904.0,
+          "mean_output_tokens": 53819.75433526011,
+          "mean_request_cost_usd": 0.03554161849710982,
+          "quality_lower_bound": 0.7162153297521393,
+          "quality_score": 0.813615,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 2.2e-07,
+          "source_output_cost_per_token": 6.6e-07,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "deepseek-v4-flash-vision-exp",
+          "completion_probability": 0.7541906340057636,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.06818042434558261,
+          "mean_input_tokens": 469904.0,
+          "mean_output_tokens": 77868.80115273775,
+          "mean_request_cost_usd": 0.05142103746397694,
+          "quality_lower_bound": 0.6937983800511365,
+          "quality_score": 0.7546849999999999,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 2.2e-07,
+          "source_output_cost_per_token": 6.6e-07,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "deepseek-v4-flash-vision-exp",
+          "completion_probability": 0.9480639376770538,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.015498709656001796,
+          "mean_input_tokens": 469904.0,
+          "mean_output_tokens": 22238.339943342777,
+          "mean_request_cost_usd": 0.014693767705382438,
+          "quality_lower_bound": 0.9176876013540679,
+          "quality_score": 0.9568619999999999,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 2.2e-07,
+          "source_output_cost_per_token": 6.6e-07,
+          "subtask_count": 5
+        }
+      }
+    },
+    "deepseek-v4-pro": {
+      "benchmark_model_id": "deepseek-v4-pro",
+      "identity": {
+        "benchmark_model_id": "deepseek-v4-pro",
+        "family_id": "deepseek-v4-pro",
+        "is_routable": true,
+        "litellm_model_keys": [
+          "azure_ai/deepseek-v4-pro",
+          "dashscope/deepseek-v4-pro",
+          "deepinfra/deepseek-ai/DeepSeek-V4-Pro",
+          "deepseek-v4-pro",
+          "deepseek/deepseek-v4-pro",
+          "fireworks_ai/accounts/fireworks/models/deepseek-v4-pro",
+          "fireworks_ai/deepseek-v4-pro",
+          "novita/deepseek/deepseek-v4-pro",
+          "openrouter/deepseek/deepseek-v4-pro",
+          "qwen_ai_platform/deepseek-v4-pro",
+          "qwencloud/deepseek-v4-pro",
+          "tencent/deepseek-v4-pro",
+          "together_ai/deepseek-ai/DeepSeek-V4-Pro",
+          "wandb/deepseek-ai/DeepSeek-V4-Pro"
+        ],
+        "reasoning_effort": null,
+        "required_parameters": {}
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "deepseek-v4-pro",
+          "completion_probability": 0.4920608928571429,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 0.12317544903160577,
+          "mean_input_tokens": 96617.0,
+          "mean_output_tokens": 38234.75892857143,
+          "mean_request_cost_usd": 0.06060982142857143,
+          "quality_lower_bound": 0.38016323574171296,
+          "quality_score": 0.4806566666666667,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 4.35e-07,
+          "source_output_cost_per_token": 8.7e-07,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "deepseek-v4-pro",
+          "completion_probability": 0.808614421965318,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.037665943874090765,
+          "mean_input_tokens": 96617.0,
+          "mean_output_tokens": 34550.06647398844,
+          "mean_request_cost_usd": 0.03045722543352601,
+          "quality_lower_bound": 0.7292064176433101,
+          "quality_score": 0.805635,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 4.35e-07,
+          "source_output_cost_per_token": 8.7e-07,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "deepseek-v4-pro",
+          "completion_probability": 0.6979290201729106,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.06925305608767511,
+          "mean_input_tokens": 96617.0,
+          "mean_output_tokens": 55181.81844380403,
+          "mean_request_cost_usd": 0.048333717579250715,
+          "quality_lower_bound": 0.6217235810903863,
+          "quality_score": 0.6848133333333334,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 4.35e-07,
+          "source_output_cost_per_token": 8.7e-07,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "deepseek-v4-pro",
+          "completion_probability": 0.9716701416430594,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.012856284713601382,
+          "mean_input_tokens": 96617.0,
+          "mean_output_tokens": 14192.331444759207,
+          "mean_request_cost_usd": 0.012492067988668556,
+          "quality_lower_bound": 0.9522556444359002,
+          "quality_score": 0.972156,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 4.35e-07,
+          "source_output_cost_per_token": 8.7e-07,
+          "subtask_count": 5
+        }
+      }
+    },
+    "deepseek-v4-pro-0813": {
+      "benchmark_model_id": "deepseek-v4-pro-0813",
+      "identity": {
+        "benchmark_model_id": "deepseek-v4-pro-0813",
+        "family_id": "deepseek-v4-pro-0813",
+        "is_routable": true,
+        "litellm_model_keys": [
+          "deepinfra/deepseek-ai/DeepSeek-V4-Pro-0813",
+          "fireworks_ai/accounts/fireworks/models/deepseek-v4-pro-0813",
+          "novita/deepseek/deepseek-v4-pro-0813",
+          "openrouter/deepseek/deepseek-v4-pro-0813",
+          "together_ai/deepseek-ai/DeepSeek-V4-Pro-0813"
+        ],
+        "reasoning_effort": null,
+        "required_parameters": {}
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "deepseek-v4-pro-0813",
+          "completion_probability": 0.5697092857142857,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 0.08776797815427166,
+          "mean_input_tokens": 254323.0,
+          "mean_output_tokens": 42679.21428571428,
+          "mean_request_cost_usd": 0.05000223214285714,
+          "quality_lower_bound": 0.4943714005386736,
+          "quality_score": 0.5668333333333333,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 4.35e-07,
+          "source_output_cost_per_token": 8.7e-07,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "deepseek-v4-pro-0813",
+          "completion_probability": 0.8487423121387284,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.03819422168482955,
+          "mean_input_tokens": 254323.0,
+          "mean_output_tokens": 36823.35260115607,
+          "mean_request_cost_usd": 0.03241705202312139,
+          "quality_lower_bound": 0.7850763286351601,
+          "quality_score": 0.8482799999999999,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 4.35e-07,
+          "source_output_cost_per_token": 8.7e-07,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "deepseek-v4-pro-0813",
+          "completion_probability": 0.7896948991354468,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.06167011642368867,
+          "mean_input_tokens": 254323.0,
+          "mean_output_tokens": 55109.19020172911,
+          "mean_request_cost_usd": 0.048700576368876085,
+          "quality_lower_bound": 0.6654041601132071,
+          "quality_score": 0.76577,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 4.35e-07,
+          "source_output_cost_per_token": 8.7e-07,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "deepseek-v4-pro-0813",
+          "completion_probability": 0.9773373087818696,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.012087533779340973,
+          "mean_input_tokens": 254323.0,
+          "mean_output_tokens": 13390.767705382435,
+          "mean_request_cost_usd": 0.011813597733711049,
+          "quality_lower_bound": 0.9652508853504652,
+          "quality_score": 0.978196,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 4.35e-07,
+          "source_output_cost_per_token": 8.7e-07,
+          "subtask_count": 5
+        }
+      }
+    },
+    "gemini-3.1-pro-preview-high": {
+      "benchmark_model_id": "gemini-3.1-pro-preview-high",
+      "identity": {
+        "benchmark_model_id": "gemini-3.1-pro-preview-high",
+        "family_id": "gemini-3.1-pro-preview",
+        "is_routable": true,
+        "litellm_model_keys": [
+          "gemini-3.1-pro-preview",
+          "gemini/gemini-3.1-pro-preview",
+          "openrouter/google/gemini-3.1-pro-preview",
+          "vertex_ai/gemini-3.1-pro-preview"
+        ],
+        "reasoning_effort": "high",
+        "required_parameters": {
+          "reasoning_effort": "high"
+        }
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "gemini-3.1-pro-preview-high",
+          "completion_probability": 0.57950375,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 0.9058612649184755,
+          "mean_input_tokens": 99082.0,
+          "mean_output_tokens": 16052.05357142857,
+          "mean_request_cost_usd": 0.52495,
+          "quality_lower_bound": 0.40345610903956064,
+          "quality_score": 0.5499133333333334,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 2e-06,
+          "source_output_cost_per_token": 1.2e-05,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "gemini-3.1-pro-preview-high",
+          "completion_probability": 0.8252704046242775,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.11967070803487916,
+          "mean_input_tokens": 99082.0,
+          "mean_output_tokens": 8070.121387283237,
+          "mean_request_cost_usd": 0.09876069364161849,
+          "quality_lower_bound": 0.7734428742199247,
+          "quality_score": 0.8217166666666667,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 2e-06,
+          "source_output_cost_per_token": 1.2e-05,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "gemini-3.1-pro-preview-high",
+          "completion_probability": 0.7975139193083574,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.3724329493241841,
+          "mean_input_tokens": 99082.0,
+          "mean_output_tokens": 24624.538904899135,
+          "mean_request_cost_usd": 0.2970204610951009,
+          "quality_lower_bound": 0.7542212833788828,
+          "quality_score": 0.8009816666666666,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 2e-06,
+          "source_output_cost_per_token": 1.2e-05,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "gemini-3.1-pro-preview-high",
+          "completion_probability": 0.9773355524079321,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.0712105483066712,
+          "mean_input_tokens": 99082.0,
+          "mean_output_tokens": 5727.711048158641,
+          "mean_request_cost_usd": 0.06959660056657223,
+          "quality_lower_bound": 0.9680781539505636,
+          "quality_score": 0.980234,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 2e-06,
+          "source_output_cost_per_token": 1.2e-05,
+          "subtask_count": 5
+        }
+      }
+    },
+    "gemini-3.5-flash-high": {
+      "benchmark_model_id": "gemini-3.5-flash-high",
+      "identity": {
+        "benchmark_model_id": "gemini-3.5-flash-high",
+        "family_id": "gemini-3.5-flash",
+        "is_routable": true,
+        "litellm_model_keys": [
+          "deepinfra/google/gemini-3.5-flash",
+          "gemini-3.5-flash",
+          "gemini/gemini-3.5-flash",
+          "vertex_ai/gemini-3.5-flash"
+        ],
+        "reasoning_effort": "high",
+        "required_parameters": {
+          "reasoning_effort": "high"
+        }
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "gemini-3.5-flash-high",
+          "completion_probability": 0.5744925,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 0.716755285254874,
+          "mean_input_tokens": 108280.0,
+          "mean_output_tokens": 17270.8125,
+          "mean_request_cost_usd": 0.4117705357142857,
+          "quality_lower_bound": 0.44704592118475794,
+          "quality_score": 0.5572033333333334,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.5e-06,
+          "source_output_cost_per_token": 9e-06,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "gemini-3.5-flash-high",
+          "completion_probability": 0.8276601445086705,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.1168008244985926,
+          "mean_input_tokens": 108280.0,
+          "mean_output_tokens": 10581.202312138728,
+          "mean_request_cost_usd": 0.096671387283237,
+          "quality_lower_bound": 0.773030678034419,
+          "quality_score": 0.8204416666666666,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.5e-06,
+          "source_output_cost_per_token": 9e-06,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "gemini-3.5-flash-high",
+          "completion_probability": 0.7037670893371758,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.3734288238372025,
+          "mean_input_tokens": 108280.0,
+          "mean_output_tokens": 29073.49855907781,
+          "mean_request_cost_usd": 0.262806916426513,
+          "quality_lower_bound": 0.6095857754421493,
+          "quality_score": 0.7054900000000001,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.5e-06,
+          "source_output_cost_per_token": 9e-06,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "gemini-3.5-flash-high",
+          "completion_probability": 0.9688377903682719,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.055806475174513294,
+          "mean_input_tokens": 108280.0,
+          "mean_output_tokens": 5935.501416430595,
+          "mean_request_cost_usd": 0.05406742209631728,
+          "quality_lower_bound": 0.9531187660114996,
+          "quality_score": 0.9703519999999999,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.5e-06,
+          "source_output_cost_per_token": 9e-06,
+          "subtask_count": 5
+        }
+      }
+    },
+    "gemini-3.5-flash-lite-high": {
+      "benchmark_model_id": "gemini-3.5-flash-lite-high",
+      "identity": {
+        "benchmark_model_id": "gemini-3.5-flash-lite-high",
+        "family_id": "gemini-3.5-flash-lite",
+        "is_routable": true,
+        "litellm_model_keys": [
+          "gemini-3.5-flash-lite",
+          "gemini/gemini-3.5-flash-lite",
+          "vertex_ai/gemini-3.5-flash-lite"
+        ],
+        "reasoning_effort": "high",
+        "required_parameters": {
+          "reasoning_effort": "high"
+        }
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "gemini-3.5-flash-lite-high",
+          "completion_probability": 0.49490589285714287,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 0.24637079271564255,
+          "mean_input_tokens": 112072.0,
+          "mean_output_tokens": 15345.464285714286,
+          "mean_request_cost_usd": 0.12193035714285715,
+          "quality_lower_bound": 0.3746970230436221,
+          "quality_score": 0.48975166666666664,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 3e-07,
+          "source_output_cost_per_token": 2.5e-06,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "gemini-3.5-flash-lite-high",
+          "completion_probability": 0.668675,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.031234662803737268,
+          "mean_input_tokens": 112072.0,
+          "mean_output_tokens": 8239.135838150289,
+          "mean_request_cost_usd": 0.020885838150289018,
+          "quality_lower_bound": 0.4962706700104881,
+          "quality_score": 0.6511566666666667,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 3e-07,
+          "source_output_cost_per_token": 2.5e-06,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "gemini-3.5-flash-lite-high",
+          "completion_probability": 0.4910134005763689,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.09241253386148097,
+          "mean_input_tokens": 112072.0,
+          "mean_output_tokens": 17868.78386167147,
+          "mean_request_cost_usd": 0.04537579250720461,
+          "quality_lower_bound": 0.34552349534955934,
+          "quality_score": 0.526715,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 3e-07,
+          "source_output_cost_per_token": 2.5e-06,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "gemini-3.5-flash-lite-high",
+          "completion_probability": 0.9348442776203966,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.016427271233884436,
+          "mean_input_tokens": 112072.0,
+          "mean_output_tokens": 6090.844192634561,
+          "mean_request_cost_usd": 0.015356940509915014,
+          "quality_lower_bound": 0.9069738182941612,
+          "quality_score": 0.9343920000000001,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 3e-07,
+          "source_output_cost_per_token": 2.5e-06,
+          "subtask_count": 5
+        }
+      }
+    },
+    "gemini-3.6-flash-high": {
+      "benchmark_model_id": "gemini-3.6-flash-high",
+      "identity": {
+        "benchmark_model_id": "gemini-3.6-flash-high",
+        "family_id": "gemini-3.6-flash",
+        "is_routable": true,
+        "litellm_model_keys": [
+          "gemini-3.6-flash",
+          "gemini/gemini-3.6-flash",
+          "vertex_ai/gemini-3.6-flash"
+        ],
+        "reasoning_effort": "high",
+        "required_parameters": {
+          "reasoning_effort": "high"
+        }
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "gemini-3.6-flash-high",
+          "completion_probability": 0.5544942857142857,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 0.8991196289540533,
+          "mean_input_tokens": 188079.0,
+          "mean_output_tokens": 20419.866071428572,
+          "mean_request_cost_usd": 0.4985566964285714,
+          "quality_lower_bound": 0.3831639512582842,
+          "quality_score": 0.5280516666666667,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.5e-06,
+          "source_output_cost_per_token": 7.5e-06,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "gemini-3.6-flash-high",
+          "completion_probability": 0.8339710115606936,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.09242984943163318,
+          "mean_input_tokens": 188079.0,
+          "mean_output_tokens": 10086.052023121387,
+          "mean_request_cost_usd": 0.07708381502890173,
+          "quality_lower_bound": 0.7862437005368376,
+          "quality_score": 0.8313566666666667,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.5e-06,
+          "source_output_cost_per_token": 7.5e-06,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "gemini-3.6-flash-high",
+          "completion_probability": 0.6757371181556195,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.2864337111126976,
+          "mean_input_tokens": 188079.0,
+          "mean_output_tokens": 25336.28242074928,
+          "mean_request_cost_usd": 0.19355389048991356,
+          "quality_lower_bound": 0.5777227110111925,
+          "quality_score": 0.6809850000000001,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.5e-06,
+          "source_output_cost_per_token": 7.5e-06,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "gemini-3.6-flash-high",
+          "completion_probability": 0.9745049575070821,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.04192351604395637,
+          "mean_input_tokens": 188079.0,
+          "mean_output_tokens": 5360.696883852691,
+          "mean_request_cost_usd": 0.04085467422096318,
+          "quality_lower_bound": 0.9592649709496708,
+          "quality_score": 0.9803139999999999,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.5e-06,
+          "source_output_cost_per_token": 7.5e-06,
+          "subtask_count": 5
+        }
+      }
+    },
+    "gemini-3.7-flash-high": {
+      "benchmark_model_id": "gemini-3.7-flash-high",
+      "identity": {
+        "benchmark_model_id": "gemini-3.7-flash-high",
+        "family_id": "gemini-3.7-flash",
+        "is_routable": true,
+        "litellm_model_keys": [
+          "deepinfra/google/gemini-3.7-flash",
+          "gemini-3.7-flash",
+          "gemini/gemini-3.7-flash",
+          "vertex_ai/gemini-3.7-flash"
+        ],
+        "reasoning_effort": "high",
+        "required_parameters": {
+          "reasoning_effort": "high"
+        }
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "gemini-3.7-flash-high",
+          "completion_probability": 0.6033091964285714,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 0.5173201729804798,
+          "mean_input_tokens": 285829.0,
+          "mean_output_tokens": 25333.008928571428,
+          "mean_request_cost_usd": 0.31210401785714287,
+          "quality_lower_bound": 0.5068762110807983,
+          "quality_score": 0.6021866666666666,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 7.5e-07,
+          "source_output_cost_per_token": 3.75e-06,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "gemini-3.7-flash-high",
+          "completion_probability": 0.8639628323699421,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.05808227272675574,
+          "mean_input_tokens": 285829.0,
+          "mean_output_tokens": 13189.598265895953,
+          "mean_request_cost_usd": 0.05018092485549133,
+          "quality_lower_bound": 0.8047468229043783,
+          "quality_score": 0.8612716666666667,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 7.5e-07,
+          "source_output_cost_per_token": 3.75e-06,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "gemini-3.7-flash-high",
+          "completion_probability": 0.7951507492795389,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.22283850186854895,
+          "mean_input_tokens": 285829.0,
+          "mean_output_tokens": 46784.64841498559,
+          "mean_request_cost_usd": 0.17719020172910663,
+          "quality_lower_bound": 0.6998404208779329,
+          "quality_score": 0.779095,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 7.5e-07,
+          "source_output_cost_per_token": 3.75e-06,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "gemini-3.7-flash-high",
+          "completion_probability": 0.9801684135977338,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.024636455346966592,
+          "mean_input_tokens": 285829.0,
+          "mean_output_tokens": 6352.821529745042,
+          "mean_request_cost_usd": 0.02414787535410765,
+          "quality_lower_bound": 0.9698314889558245,
+          "quality_score": 0.984234,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 7.5e-07,
+          "source_output_cost_per_token": 3.75e-06,
+          "subtask_count": 5
+        }
+      }
+    },
+    "gemini-3.8-flash-high": {
+      "benchmark_model_id": "gemini-3.8-flash-high",
+      "identity": {
+        "benchmark_model_id": "gemini-3.8-flash-high",
+        "family_id": "gemini-3.8-flash",
+        "is_routable": true,
+        "litellm_model_keys": [
+          "gemini-3.8-flash",
+          "gemini/gemini-3.8-flash",
+          "vertex_ai/gemini-3.8-flash"
+        ],
+        "reasoning_effort": "high",
+        "required_parameters": {
+          "reasoning_effort": "high"
+        }
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "gemini-3.8-flash-high",
+          "completion_probability": 0.6069597321428571,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 1.0221141700239293,
+          "mean_input_tokens": 607424.0,
+          "mean_output_tokens": 56890.017857142855,
+          "mean_request_cost_usd": 0.6203821428571429,
+          "quality_lower_bound": 0.46610797022905415,
+          "quality_score": 0.59472,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 7.5e-07,
+          "source_output_cost_per_token": 3.75e-06,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "gemini-3.8-flash-high",
+          "completion_probability": 0.8384017919075144,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.1581553011230906,
+          "mean_input_tokens": 607424.0,
+          "mean_output_tokens": 35167.41329479769,
+          "mean_request_cost_usd": 0.13259768786127168,
+          "quality_lower_bound": 0.7479820892243612,
+          "quality_score": 0.8371833333333334,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 7.5e-07,
+          "source_output_cost_per_token": 3.75e-06,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "gemini-3.8-flash-high",
+          "completion_probability": 0.7372122190201729,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.35172343321268257,
+          "mean_input_tokens": 607424.0,
+          "mean_output_tokens": 68687.04034582133,
+          "mean_request_cost_usd": 0.2592948126801153,
+          "quality_lower_bound": 0.518237967153724,
+          "quality_score": 0.7214366666666666,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 7.5e-07,
+          "source_output_cost_per_token": 3.75e-06,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "gemini-3.8-flash-high",
+          "completion_probability": 0.977336373937677,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.06112004606148399,
+          "mean_input_tokens": 607424.0,
+          "mean_output_tokens": 15842.821529745042,
+          "mean_request_cost_usd": 0.059734844192634556,
+          "quality_lower_bound": 0.9602156860944612,
+          "quality_score": 0.9803520000000001,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 7.5e-07,
+          "source_output_cost_per_token": 3.75e-06,
+          "subtask_count": 5
+        }
+      }
+    },
+    "glm-5.2": {
+      "benchmark_model_id": "glm-5.2",
+      "identity": {
+        "benchmark_model_id": "glm-5.2",
+        "family_id": "glm-5.2",
+        "is_routable": true,
+        "litellm_model_keys": [
+          "cloudflare/@cf/zai-org/glm-5.2",
+          "dashscope/glm-5.2",
+          "deepinfra/zai-org/GLM-5.2",
+          "novita/zai-org/glm-5.2",
+          "perplexity/perplexity/glm-5.2",
+          "qwen_ai_platform/glm-5.2",
+          "qwencloud/glm-5.2",
+          "scaleway/glm-5.2",
+          "scx-ai/GLM-5.2",
+          "together_ai/zai-org/GLM-5.2",
+          "wandb/zai-org/GLM-5.2",
+          "zai/glm-5.2"
+        ],
+        "reasoning_effort": null,
+        "required_parameters": {}
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "glm-5.2",
+          "completion_probability": 0.5269902678571429,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 0.9582778958204534,
+          "mean_input_tokens": 229433.0,
+          "mean_output_tokens": 26255.053571428572,
+          "mean_request_cost_usd": 0.505003125,
+          "quality_lower_bound": 0.4491256039182908,
+          "quality_score": 0.5292666666666667,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.4e-06,
+          "source_output_cost_per_token": 4.4e-06,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "glm-5.2",
+          "completion_probability": 0.7812604624277457,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.09705821465623285,
+          "mean_input_tokens": 229433.0,
+          "mean_output_tokens": 16941.52023121387,
+          "mean_request_cost_usd": 0.07582774566473989,
+          "quality_lower_bound": 0.7088720546635146,
+          "quality_score": 0.7714249999999999,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.4e-06,
+          "source_output_cost_per_token": 4.4e-06,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "glm-5.2",
+          "completion_probability": 0.7204891066282422,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.21812351935756738,
+          "mean_input_tokens": 229433.0,
+          "mean_output_tokens": 35125.20172910663,
+          "mean_request_cost_usd": 0.15715561959654178,
+          "quality_lower_bound": 0.6503549332056257,
+          "quality_score": 0.7146266666666667,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.4e-06,
+          "source_output_cost_per_token": 4.4e-06,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "glm-5.2",
+          "completion_probability": 0.960338073654391,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.044066457474518976,
+          "mean_input_tokens": 229433.0,
+          "mean_output_tokens": 9503.614730878187,
+          "mean_request_cost_usd": 0.042318696883852695,
+          "quality_lower_bound": 0.9415584583178681,
+          "quality_score": 0.9563119999999999,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.4e-06,
+          "source_output_cost_per_token": 4.4e-06,
+          "subtask_count": 5
+        }
+      }
+    },
+    "glm-5.3": {
+      "benchmark_model_id": "glm-5.3",
+      "identity": {
+        "benchmark_model_id": "glm-5.3",
+        "family_id": "glm-5.3",
+        "is_routable": true,
+        "litellm_model_keys": [
+          "friendliai/zai-org/GLM-5.3",
+          "novita/zai-org/glm-5.3",
+          "together_ai/zai-org/GLM-5.3",
+          "zai/glm-5.3"
+        ],
+        "reasoning_effort": null,
+        "required_parameters": {}
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "glm-5.3",
+          "completion_probability": 0.5717091964285714,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 1.3760382986917519,
+          "mean_input_tokens": 243253.0,
+          "mean_output_tokens": 90499.80357142857,
+          "mean_request_cost_usd": 0.7866937500000001,
+          "quality_lower_bound": 0.49798510274288055,
+          "quality_score": 0.585265,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.4e-06,
+          "source_output_cost_per_token": 4.4e-06,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "glm-5.3",
+          "completion_probability": 0.8432406647398845,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.2735818911125524,
+          "mean_input_tokens": 243253.0,
+          "mean_output_tokens": 52143.132947976876,
+          "mean_request_cost_usd": 0.23069537572254334,
+          "quality_lower_bound": 0.8070017266219552,
+          "quality_score": 0.8443766666666667,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.4e-06,
+          "source_output_cost_per_token": 4.4e-06,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "glm-5.3",
+          "completion_probability": 0.7022139193083573,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.6404002688409565,
+          "mean_input_tokens": 243253.0,
+          "mean_output_tokens": 101607.55043227665,
+          "mean_request_cost_usd": 0.4496979827089338,
+          "quality_lower_bound": 0.6770506562429186,
+          "quality_score": 0.7044583333333333,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.4e-06,
+          "source_output_cost_per_token": 4.4e-06,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "glm-5.3",
+          "completion_probability": 0.9678918980169972,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.0685497268325098,
+          "mean_input_tokens": 243253.0,
+          "mean_output_tokens": 14965.790368271955,
+          "mean_request_cost_usd": 0.06634872521246458,
+          "quality_lower_bound": 0.9524140844470205,
+          "quality_score": 0.964978,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.4e-06,
+          "source_output_cost_per_token": 4.4e-06,
+          "subtask_count": 5
+        }
+      }
+    },
+    "glm-5.3-flash": {
+      "benchmark_model_id": "glm-5.3-flash",
+      "identity": {
+        "benchmark_model_id": "glm-5.3-flash",
+        "family_id": "glm-5.3-flash",
+        "is_routable": true,
+        "litellm_model_keys": [
+          "friendliai/zai-org/GLM-5.3-Flash",
+          "together_ai/zai-org/GLM-5.3-Flash",
+          "zai/glm-5.3-flash"
+        ],
+        "reasoning_effort": null,
+        "required_parameters": {}
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "glm-5.3-flash",
+          "completion_probability": 0.5312167857142857,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 0.08444897731421191,
+          "mean_input_tokens": 128845.0,
+          "mean_output_tokens": 40219.96428571428,
+          "mean_request_cost_usd": 0.04486071428571429,
+          "quality_lower_bound": 0.4821901387445875,
+          "quality_score": 0.5438916666666667,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.5e-07,
+          "source_output_cost_per_token": 5e-07,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "glm-5.3-flash",
+          "completion_probability": 0.803259710982659,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.012833186280785237,
+          "mean_input_tokens": 128845.0,
+          "mean_output_tokens": 20343.670520231215,
+          "mean_request_cost_usd": 0.010308381502890174,
+          "quality_lower_bound": 0.7526212593040512,
+          "quality_score": 0.7971966666666667,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.5e-07,
+          "source_output_cost_per_token": 5e-07,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "glm-5.3-flash",
+          "completion_probability": 0.5699900864553314,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.06498773223013737,
+          "mean_input_tokens": 128845.0,
+          "mean_output_tokens": 73521.76657060519,
+          "mean_request_cost_usd": 0.03704236311239193,
+          "quality_lower_bound": 0.48108917724919115,
+          "quality_score": 0.5927183333333333,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.5e-07,
+          "source_output_cost_per_token": 5e-07,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "glm-5.3-flash",
+          "completion_probability": 0.9513683286118981,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.0038063559086596067,
+          "mean_input_tokens": 128845.0,
+          "mean_output_tokens": 7133.589235127479,
+          "mean_request_cost_usd": 0.0036212464589235127,
+          "quality_lower_bound": 0.937061284213534,
+          "quality_score": 0.951764,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.5e-07,
+          "source_output_cost_per_token": 5e-07,
+          "subtask_count": 5
+        }
+      }
+    },
+    "gpt-5.2-2025-12-11-high": {
+      "benchmark_model_id": "gpt-5.2-2025-12-11-high",
+      "identity": {
+        "benchmark_model_id": "gpt-5.2-2025-12-11-high",
+        "family_id": "gpt-5.2-2025-12-11",
+        "is_routable": true,
+        "litellm_model_keys": [
+          "azure/gpt-5.2-2025-12-11",
+          "gpt-5.2-2025-12-11"
+        ],
+        "reasoning_effort": "high",
+        "required_parameters": {
+          "reasoning_effort": "high"
+        }
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "gpt-5.2-2025-12-11-high",
+          "completion_probability": 0.5131926785714286,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 0.9776107483996368,
+          "mean_input_tokens": 50836.0,
+          "mean_output_tokens": 32058.866071428572,
+          "mean_request_cost_usd": 0.5017026785714286,
+          "quality_lower_bound": 0.4450192465475368,
+          "quality_score": 0.5147416666666667,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.75e-06,
+          "source_output_cost_per_token": 1.4e-05,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "gpt-5.2-2025-12-11-high",
+          "completion_probability": 0.8127038150289017,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.10011894926348755,
+          "mean_input_tokens": 50836.0,
+          "mean_output_tokens": 6148.106936416185,
+          "mean_request_cost_usd": 0.08136705202312139,
+          "quality_lower_bound": 0.7699878737605818,
+          "quality_score": 0.8092583333333333,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.75e-06,
+          "source_output_cost_per_token": 1.4e-05,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "gpt-5.2-2025-12-11-high",
+          "completion_probability": 0.7702856195965417,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.26096573855927013,
+          "mean_input_tokens": 50836.0,
+          "mean_output_tokens": 14263.556195965419,
+          "mean_request_cost_usd": 0.20101815561959652,
+          "quality_lower_bound": 0.6435898983631713,
+          "quality_score": 0.7465216666666666,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.75e-06,
+          "source_output_cost_per_token": 1.4e-05,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "gpt-5.2-2025-12-11-high",
+          "completion_probability": 0.9702548441926345,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.032578981907034385,
+          "mean_input_tokens": 50836.0,
+          "mean_output_tokens": 2224.844192634561,
+          "mean_request_cost_usd": 0.03160991501416431,
+          "quality_lower_bound": 0.9562658651509364,
+          "quality_score": 0.9741959999999998,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.75e-06,
+          "source_output_cost_per_token": 1.4e-05,
+          "subtask_count": 5
+        }
+      }
+    },
+    "gpt-5.2-codex": {
+      "benchmark_model_id": "gpt-5.2-codex",
+      "identity": {
+        "benchmark_model_id": "gpt-5.2-codex",
+        "family_id": "gpt-5.2-codex",
+        "is_routable": true,
+        "litellm_model_keys": [
+          "azure/gpt-5.2-codex",
+          "chatgpt/gpt-5.2-codex",
+          "gpt-5.2-codex",
+          "openrouter/openai/gpt-5.2-codex"
+        ],
+        "reasoning_effort": null,
+        "required_parameters": {}
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "gpt-5.2-codex",
+          "completion_probability": 0.5134417857142858,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 0.5030990089987945,
+          "mean_input_tokens": 37004.0,
+          "mean_output_tokens": 14726.267857142857,
+          "mean_request_cost_usd": 0.25831205357142856,
+          "quality_lower_bound": 0.3796292105491461,
+          "quality_score": 0.5173,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.75e-06,
+          "source_output_cost_per_token": 1.4e-05,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "gpt-5.2-codex",
+          "completion_probability": 0.7947631502890173,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.1359313613809764,
+          "mean_input_tokens": 37004.0,
+          "mean_output_tokens": 7626.621387283237,
+          "mean_request_cost_usd": 0.10803323699421966,
+          "quality_lower_bound": 0.7274478995993964,
+          "quality_score": 0.7884699999999999,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.75e-06,
+          "source_output_cost_per_token": 1.4e-05,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "gpt-5.2-codex",
+          "completion_probability": 0.7303905475504323,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.2566082051874501,
+          "mean_input_tokens": 37004.0,
+          "mean_output_tokens": 13292.466858789625,
+          "mean_request_cost_usd": 0.18742420749279537,
+          "quality_lower_bound": 0.6556912811110588,
+          "quality_score": 0.72872,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.75e-06,
+          "source_output_cost_per_token": 1.4e-05,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "gpt-5.2-codex",
+          "completion_probability": 0.9645891218130311,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.046269902645509856,
+          "mean_input_tokens": 37004.0,
+          "mean_output_tokens": 3145.0311614730876,
+          "mean_request_cost_usd": 0.044631444759206794,
+          "quality_lower_bound": 0.9423117932813272,
+          "quality_score": 0.9641959999999999,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.75e-06,
+          "source_output_cost_per_token": 1.4e-05,
+          "subtask_count": 5
+        }
+      }
+    },
+    "gpt-5.4-mini-xhigh": {
+      "benchmark_model_id": "gpt-5.4-mini-xhigh",
+      "identity": {
+        "benchmark_model_id": "gpt-5.4-mini-xhigh",
+        "family_id": "gpt-5.4-mini",
+        "is_routable": true,
+        "litellm_model_keys": [
+          "azure/gpt-5.4-mini",
+          "azure_ai/gpt-5.4-mini",
+          "gpt-5.4-mini"
+        ],
+        "reasoning_effort": "xhigh",
+        "required_parameters": {
+          "reasoning_effort": "xhigh"
+        }
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "gpt-5.4-mini-xhigh",
+          "completion_probability": 0.45826428571428574,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 1.1086728650030395,
+          "mean_input_tokens": 70674.0,
+          "mean_output_tokens": 104505.23214285714,
+          "mean_request_cost_usd": 0.5080651785714286,
+          "quality_lower_bound": 0.34943884542827364,
+          "quality_score": 0.45387833333333333,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 7.5e-07,
+          "source_output_cost_per_token": 4.5e-06,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "gpt-5.4-mini-xhigh",
+          "completion_probability": 0.7355458083832336,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.23784162886902593,
+          "mean_input_tokens": 70674.0,
+          "mean_output_tokens": 38723.94610778443,
+          "mean_request_cost_usd": 0.1749434131736527,
+          "quality_lower_bound": 0.6573537305842576,
+          "quality_score": 0.7271216666666667,
+          "question_count": 334,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 7.5e-07,
+          "source_output_cost_per_token": 4.5e-06,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "gpt-5.4-mini-xhigh",
+          "completion_probability": 0.545162363112392,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.47478333663016814,
+          "mean_input_tokens": 70674.0,
+          "mean_output_tokens": 57220.109510086455,
+          "mean_request_cost_usd": 0.25883400576368876,
+          "quality_lower_bound": 0.4915611374028915,
+          "quality_score": 0.5752016666666667,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 7.5e-07,
+          "source_output_cost_per_token": 4.5e-06,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "gpt-5.4-mini-xhigh",
+          "completion_probability": 0.9559675,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.05001269537263177,
+          "mean_input_tokens": 70674.0,
+          "mean_output_tokens": 10567.4375,
+          "mean_request_cost_usd": 0.047810511363636364,
+          "quality_lower_bound": 0.913999334114345,
+          "quality_score": 0.9561959999999999,
+          "question_count": 352,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 7.5e-07,
+          "source_output_cost_per_token": 4.5e-06,
+          "subtask_count": 5
+        }
+      }
+    },
+    "gpt-5.4-nano-xhigh": {
+      "benchmark_model_id": "gpt-5.4-nano-xhigh",
+      "identity": {
+        "benchmark_model_id": "gpt-5.4-nano-xhigh",
+        "family_id": "gpt-5.4-nano",
+        "is_routable": true,
+        "litellm_model_keys": [
+          "azure/gpt-5.4-nano",
+          "azure_ai/gpt-5.4-nano",
+          "gpt-5.4-nano"
+        ],
+        "reasoning_effort": "xhigh",
+        "required_parameters": {
+          "reasoning_effort": "xhigh"
+        }
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "gpt-5.4-nano-xhigh",
+          "completion_probability": 0.48983830275229356,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 0.4235539250688885,
+          "mean_input_tokens": 180305.0,
+          "mean_output_tokens": 140958.14220183485,
+          "mean_request_cost_usd": 0.2074729357798165,
+          "quality_lower_bound": 0.3746452256531407,
+          "quality_score": 0.48795666666666665,
+          "question_count": 218,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 2.0000000000000002e-07,
+          "source_output_cost_per_token": 1.25e-06,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "gpt-5.4-nano-xhigh",
+          "completion_probability": 0.7734114285714286,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.03996286705037176,
+          "mean_input_tokens": 180305.0,
+          "mean_output_tokens": 24587.35119047619,
+          "mean_request_cost_usd": 0.030907738095238096,
+          "quality_lower_bound": 0.646704615489165,
+          "quality_score": 0.7700783333333333,
+          "question_count": 336,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 2.0000000000000002e-07,
+          "source_output_cost_per_token": 1.25e-06,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "gpt-5.4-nano-xhigh",
+          "completion_probability": 0.7026975,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.07862014091495734,
+          "mean_input_tokens": 180305.0,
+          "mean_output_tokens": 43917.84411764706,
+          "mean_request_cost_usd": 0.055246176470588236,
+          "quality_lower_bound": 0.6036385132310647,
+          "quality_score": 0.6786633333333333,
+          "question_count": 340,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 2.0000000000000002e-07,
+          "source_output_cost_per_token": 1.25e-06,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "gpt-5.4-nano-xhigh",
+          "completion_probability": 0.9438919602272726,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.013677653605205743,
+          "mean_input_tokens": 180305.0,
+          "mean_output_tokens": 10273.84090909091,
+          "mean_request_cost_usd": 0.012910227272727271,
+          "quality_lower_bound": 0.8768336208515851,
+          "quality_score": 0.93505,
+          "question_count": 352,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 2.0000000000000002e-07,
+          "source_output_cost_per_token": 1.25e-06,
+          "subtask_count": 5
+        }
+      }
+    },
+    "gpt-5.4-xhigh": {
+      "benchmark_model_id": "gpt-5.4-xhigh",
+      "identity": {
+        "benchmark_model_id": "gpt-5.4-xhigh",
+        "family_id": "gpt-5.4",
+        "is_routable": true,
+        "litellm_model_keys": [
+          "azure/eu/gpt-5.4",
+          "azure/gpt-5.4",
+          "azure/us/gpt-5.4",
+          "azure_ai/gpt-5.4",
+          "bedrock_mantle/openai.gpt-5.4",
+          "bedrock_mantle/us-gov-east-1/openai.gpt-5.4",
+          "bedrock_mantle/us-gov-west-1/openai.gpt-5.4",
+          "chatgpt/gpt-5.4",
+          "gpt-5.4"
+        ],
+        "reasoning_effort": "xhigh",
+        "required_parameters": {
+          "reasoning_effort": "xhigh"
+        }
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "gpt-5.4-xhigh",
+          "completion_probability": 0.5931269642857142,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 1.2505701471408646,
+          "mean_input_tokens": 76993.0,
+          "mean_output_tokens": 40433.607142857145,
+          "mean_request_cost_usd": 0.7417468749999999,
+          "quality_lower_bound": 0.49226355376413256,
+          "quality_score": 0.5819433333333334,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 2.5e-06,
+          "source_output_cost_per_token": 1.5e-05,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "gpt-5.4-xhigh",
+          "completion_probability": 0.856749710982659,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.2511781656306905,
+          "mean_input_tokens": 76993.0,
+          "mean_output_tokens": 14192.835260115608,
+          "mean_request_cost_usd": 0.21519682080924857,
+          "quality_lower_bound": 0.7908750479160342,
+          "quality_score": 0.858365,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 2.5e-06,
+          "source_output_cost_per_token": 1.5e-05,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "gpt-5.4-xhigh",
+          "completion_probability": 0.7865786743515849,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.4406923355369697,
+          "mean_input_tokens": 76993.0,
+          "mean_output_tokens": 22982.64265129683,
+          "mean_request_cost_usd": 0.3466391930835735,
+          "quality_lower_bound": 0.6700680818124257,
+          "quality_score": 0.7634283333333333,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 2.5e-06,
+          "source_output_cost_per_token": 1.5e-05,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "gpt-5.4-xhigh",
+          "completion_probability": 0.974505269121813,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.06593190774567793,
+          "mean_input_tokens": 76993.0,
+          "mean_output_tokens": 4226.402266288952,
+          "mean_request_cost_usd": 0.06425099150141643,
+          "quality_lower_bound": 0.9591866862403164,
+          "quality_score": 0.980236,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 2.5e-06,
+          "source_output_cost_per_token": 1.5e-05,
+          "subtask_count": 5
+        }
+      }
+    },
+    "gpt-5.5-xhigh": {
+      "benchmark_model_id": "gpt-5.5-xhigh",
+      "identity": {
+        "benchmark_model_id": "gpt-5.5-xhigh",
+        "family_id": "gpt-5.5",
+        "is_routable": true,
+        "litellm_model_keys": [
+          "azure/eu/gpt-5.5",
+          "azure/gpt-5.5",
+          "azure/us/gpt-5.5",
+          "azure_ai/gpt-5.5",
+          "bedrock_mantle/openai.gpt-5.5",
+          "gpt-5.5"
+        ],
+        "reasoning_effort": "xhigh",
+        "required_parameters": {
+          "reasoning_effort": "xhigh"
+        }
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "gpt-5.5-xhigh",
+          "completion_probability": 0.6128254464285714,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 1.4552500894204172,
+          "mean_input_tokens": 95929.0,
+          "mean_output_tokens": 13643.669642857143,
+          "mean_request_cost_usd": 0.8918142857142856,
+          "quality_lower_bound": 0.5116450006539032,
+          "quality_score": 0.5971316666666667,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 5e-06,
+          "source_output_cost_per_token": 3e-05,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "gpt-5.5-xhigh",
+          "completion_probability": 0.8795956936416185,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.23943935618607748,
+          "mean_input_tokens": 95929.0,
+          "mean_output_tokens": 6866.916184971098,
+          "mean_request_cost_usd": 0.21060982658959537,
+          "quality_lower_bound": 0.8255203002596379,
+          "quality_score": 0.8804416666666667,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 5e-06,
+          "source_output_cost_per_token": 3e-05,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "gpt-5.5-xhigh",
+          "completion_probability": 0.8272242363112392,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.5132128101336504,
+          "mean_input_tokens": 95929.0,
+          "mean_output_tokens": 14024.801152737753,
+          "mean_request_cost_usd": 0.4245420749279539,
+          "quality_lower_bound": 0.7103400163692298,
+          "quality_score": 0.8007049999999999,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 5e-06,
+          "source_output_cost_per_token": 3e-05,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "gpt-5.5-xhigh",
+          "completion_probability": 0.9773358640226628,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.0654670400159351,
+          "mean_input_tokens": 95929.0,
+          "mean_output_tokens": 2075.6175637393767,
+          "mean_request_cost_usd": 0.06398328611898017,
+          "quality_lower_bound": 0.9666846166236629,
+          "quality_score": 0.982156,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 5e-06,
+          "source_output_cost_per_token": 3e-05,
+          "subtask_count": 5
+        }
+      }
+    },
+    "gpt-5.6-luna-max": {
+      "benchmark_model_id": "gpt-5.6-luna-max",
+      "identity": {
+        "benchmark_model_id": "gpt-5.6-luna-max",
+        "family_id": "gpt-5.6-luna",
+        "is_routable": true,
+        "litellm_model_keys": [
+          "azure/eu/gpt-5.6-luna",
+          "azure/gpt-5.6-luna",
+          "azure/us/gpt-5.6-luna",
+          "bedrock_mantle/openai.gpt-5.6-luna",
+          "bedrock_mantle/us-gov-west-1/openai.gpt-5.6-luna",
+          "global.openai.gpt-5.6-luna",
+          "gpt-5.6-luna",
+          "us.openai.gpt-5.6-luna"
+        ],
+        "reasoning_effort": "max",
+        "required_parameters": {
+          "reasoning_effort": "max"
+        }
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "gpt-5.6-luna-max",
+          "completion_probability": 0.5075175892857142,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 0.5125596456280457,
+          "mean_input_tokens": 126025.0,
+          "mean_output_tokens": 26003.875,
+          "mean_request_cost_usd": 0.26013303571428575,
+          "quality_lower_bound": 0.4270514639974168,
+          "quality_score": 0.5046116666666667,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1e-06,
+          "source_output_cost_per_token": 6e-06,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "gpt-5.6-luna-max",
+          "completion_probability": 0.8208309537572255,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.11211393670540613,
+          "mean_input_tokens": 126025.0,
+          "mean_output_tokens": 15104.64161849711,
+          "mean_request_cost_usd": 0.09202658959537573,
+          "quality_lower_bound": 0.7438523378026773,
+          "quality_score": 0.8184216666666666,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1e-06,
+          "source_output_cost_per_token": 6e-06,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "gpt-5.6-luna-max",
+          "completion_probability": 0.6961538328530259,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.2442125605912569,
+          "mean_input_tokens": 126025.0,
+          "mean_output_tokens": 28042.953890489913,
+          "mean_request_cost_usd": 0.17000951008645532,
+          "quality_lower_bound": 0.5904135803038684,
+          "quality_score": 0.6972016666666666,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1e-06,
+          "source_output_cost_per_token": 6e-06,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "gpt-5.6-luna-max",
+          "completion_probability": 0.9610485552407931,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.026980681570241947,
+          "mean_input_tokens": 126025.0,
+          "mean_output_tokens": 4264.776203966006,
+          "mean_request_cost_usd": 0.02592974504249292,
+          "quality_lower_bound": 0.9399069564413016,
+          "quality_score": 0.965314,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1e-06,
+          "source_output_cost_per_token": 6e-06,
+          "subtask_count": 5
+        }
+      }
+    },
+    "gpt-5.6-sol-max": {
+      "benchmark_model_id": "gpt-5.6-sol-max",
+      "identity": {
+        "benchmark_model_id": "gpt-5.6-sol-max",
+        "family_id": "gpt-5.6-sol",
+        "is_routable": true,
+        "litellm_model_keys": [
+          "azure/eu/gpt-5.6-sol",
+          "azure/gpt-5.6-sol",
+          "azure/us/gpt-5.6-sol",
+          "bedrock_mantle/openai.gpt-5.6-sol",
+          "global.openai.gpt-5.6-sol",
+          "gpt-5.6-sol",
+          "us.openai.gpt-5.6-sol"
+        ],
+        "reasoning_effort": "max",
+        "required_parameters": {
+          "reasoning_effort": "max"
+        }
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "gpt-5.6-sol-max",
+          "completion_probability": 0.6268932142857143,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 2.1494226631215954,
+          "mean_input_tokens": 181163.0,
+          "mean_output_tokens": 19990.16964285714,
+          "mean_request_cost_usd": 1.347458482142857,
+          "quality_lower_bound": 0.5167214885397204,
+          "quality_score": 0.6125200000000001,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 5e-06,
+          "source_output_cost_per_token": 3e-05,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "gpt-5.6-sol-max",
+          "completion_probability": 0.880358034682081,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.18762597508606915,
+          "mean_input_tokens": 181163.0,
+          "mean_output_tokens": 5341.254335260116,
+          "mean_request_cost_usd": 0.16517803468208092,
+          "quality_lower_bound": 0.8273048746226402,
+          "quality_score": 0.8803166666666667,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 5e-06,
+          "source_output_cost_per_token": 3e-05,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "gpt-5.6-sol-max",
+          "completion_probability": 0.8410204034582132,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.5463669630359826,
+          "mean_input_tokens": 181163.0,
+          "mean_output_tokens": 14979.57925072046,
+          "mean_request_cost_usd": 0.4595057636887608,
+          "quality_lower_bound": 0.7208052023135284,
+          "quality_score": 0.815135,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 5e-06,
+          "source_output_cost_per_token": 3e-05,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "gpt-5.6-sol-max",
+          "completion_probability": 0.9801698583569405,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.03514393469872078,
+          "mean_input_tokens": 181163.0,
+          "mean_output_tokens": 1091.4589235127478,
+          "mean_request_cost_usd": 0.03444702549575071,
+          "quality_lower_bound": 0.9673442623054106,
+          "quality_score": 0.986196,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 5e-06,
+          "source_output_cost_per_token": 3e-05,
+          "subtask_count": 5
+        }
+      }
+    },
+    "gpt-5.6-terra-max": {
+      "benchmark_model_id": "gpt-5.6-terra-max",
+      "identity": {
+        "benchmark_model_id": "gpt-5.6-terra-max",
+        "family_id": "gpt-5.6-terra",
+        "is_routable": true,
+        "litellm_model_keys": [
+          "azure/eu/gpt-5.6-terra",
+          "azure/gpt-5.6-terra",
+          "azure/us/gpt-5.6-terra",
+          "bedrock_mantle/openai.gpt-5.6-terra",
+          "bedrock_mantle/us-gov-west-1/openai.gpt-5.6-terra",
+          "global.openai.gpt-5.6-terra",
+          "gpt-5.6-terra",
+          "us.openai.gpt-5.6-terra"
+        ],
+        "reasoning_effort": "max",
+        "required_parameters": {
+          "reasoning_effort": "max"
+        }
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "gpt-5.6-terra-max",
+          "completion_probability": 0.5834180357142857,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 1.1240867780117232,
+          "mean_input_tokens": 179096.0,
+          "mean_output_tokens": 23456.026785714286,
+          "mean_request_cost_usd": 0.6558124999999999,
+          "quality_lower_bound": 0.49669654030324234,
+          "quality_score": 0.5770166666666666,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 2.5e-06,
+          "source_output_cost_per_token": 1.5e-05,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "gpt-5.6-terra-max",
+          "completion_probability": 0.8655536705202311,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.1936266061380672,
+          "mean_input_tokens": 179096.0,
+          "mean_output_tokens": 10917.664739884392,
+          "mean_request_cost_usd": 0.1675942196531792,
+          "quality_lower_bound": 0.8003444518177206,
+          "quality_score": 0.8676066666666666,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 2.5e-06,
+          "source_output_cost_per_token": 1.5e-05,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "gpt-5.6-terra-max",
+          "completion_probability": 0.7859406340057637,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.4724568735713442,
+          "mean_input_tokens": 179096.0,
+          "mean_output_tokens": 24230.195965417868,
+          "mean_request_cost_usd": 0.3713230547550432,
+          "quality_lower_bound": 0.6492688041714549,
+          "quality_score": 0.759505,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 2.5e-06,
+          "source_output_cost_per_token": 1.5e-05,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "gpt-5.6-terra-max",
+          "completion_probability": 0.9702548441926345,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.04259387358760568,
+          "mean_input_tokens": 179096.0,
+          "mean_output_tokens": 2698.9943342776205,
+          "mean_request_cost_usd": 0.04132691218130312,
+          "quality_lower_bound": 0.9450457607873226,
+          "quality_score": 0.972196,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 2.5e-06,
+          "source_output_cost_per_token": 1.5e-05,
+          "subtask_count": 5
+        }
+      }
+    },
+    "grok-4.3": {
+      "benchmark_model_id": "grok-4.3",
+      "identity": {
+        "benchmark_model_id": "grok-4.3",
+        "family_id": "grok-4.3",
+        "is_routable": true,
+        "litellm_model_keys": [
+          "azure_ai/grok-4.3",
+          "bedrock_mantle/us-gov-west-1/xai.grok-4.3",
+          "bedrock_mantle/xai.grok-4.3",
+          "xai/grok-4.3"
+        ],
+        "reasoning_effort": null,
+        "required_parameters": {}
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "grok-4.3",
+          "completion_probability": 0.3911605357142857,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 0.1859165423038312,
+          "mean_input_tokens": 28676.0,
+          "mean_output_tokens": 8196.919642857143,
+          "mean_request_cost_usd": 0.07272321428571428,
+          "quality_lower_bound": 0.1928600724905164,
+          "quality_score": 0.33866,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.25e-06,
+          "source_output_cost_per_token": 2.5e-06,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "grok-4.3",
+          "completion_probability": 0.7115991907514451,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.04420760014121088,
+          "mean_input_tokens": 28676.0,
+          "mean_output_tokens": 12122.017341040462,
+          "mean_request_cost_usd": 0.03145809248554913,
+          "quality_lower_bound": 0.6205897812643891,
+          "quality_score": 0.6990183333333334,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.25e-06,
+          "source_output_cost_per_token": 2.5e-06,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "grok-4.3",
+          "completion_probability": 0.5932957636887608,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.07347079856706272,
+          "mean_input_tokens": 28676.0,
+          "mean_output_tokens": 16539.824207492795,
+          "mean_request_cost_usd": 0.04358991354466859,
+          "quality_lower_bound": 0.4608146638371801,
+          "quality_score": 0.5840483333333333,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.25e-06,
+          "source_output_cost_per_token": 2.5e-06,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "grok-4.3",
+          "completion_probability": 0.9631723796033994,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.018345890446716372,
+          "mean_input_tokens": 28676.0,
+          "mean_output_tokens": 6897.121813031162,
+          "mean_request_cost_usd": 0.01767025495750708,
+          "quality_lower_bound": 0.9484369021216132,
+          "quality_score": 0.964274,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.25e-06,
+          "source_output_cost_per_token": 2.5e-06,
+          "subtask_count": 5
+        }
+      }
+    },
+    "grok-4.5": {
+      "benchmark_model_id": "grok-4.5",
+      "identity": {
+        "benchmark_model_id": "grok-4.5",
+        "family_id": "grok-4.5",
+        "is_routable": true,
+        "litellm_model_keys": [
+          "xai/grok-4.5"
+        ],
+        "reasoning_effort": null,
+        "required_parameters": {}
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "grok-4.5",
+          "completion_probability": 0.5800740178571429,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 0.44104901021713827,
+          "mean_input_tokens": 61244.0,
+          "mean_output_tokens": 11605.785714285714,
+          "mean_request_cost_usd": 0.25584107142857143,
+          "quality_lower_bound": 0.46374943910594013,
+          "quality_score": 0.58254,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 2e-06,
+          "source_output_cost_per_token": 6e-06,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "grok-4.5",
+          "completion_probability": 0.811312225433526,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.07142037040328908,
+          "mean_input_tokens": 61244.0,
+          "mean_output_tokens": 9533.430635838151,
+          "mean_request_cost_usd": 0.05794421965317919,
+          "quality_lower_bound": 0.7272533331201472,
+          "quality_score": 0.8118366666666667,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 2e-06,
+          "source_output_cost_per_token": 6e-06,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "grok-4.5",
+          "completion_probability": 0.7420084149855908,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.14598706555911886,
+          "mean_input_tokens": 61244.0,
+          "mean_output_tokens": 17874.28530259366,
+          "mean_request_cost_usd": 0.10832363112391932,
+          "quality_lower_bound": 0.7117838299783479,
+          "quality_score": 0.73581,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 2e-06,
+          "source_output_cost_per_token": 6e-06,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "grok-4.5",
+          "completion_probability": 0.9858362039660057,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.03284308646047252,
+          "mean_input_tokens": 61244.0,
+          "mean_output_tokens": 5315.070821529745,
+          "mean_request_cost_usd": 0.03237790368271955,
+          "quality_lower_bound": 0.9768668617803176,
+          "quality_score": 0.988118,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 2e-06,
+          "source_output_cost_per_token": 6e-06,
+          "subtask_count": 5
+        }
+      }
+    },
+    "grok-4.6": {
+      "benchmark_model_id": "grok-4.6",
+      "identity": {
+        "benchmark_model_id": "grok-4.6",
+        "family_id": "grok-4.6",
+        "is_routable": true,
+        "litellm_model_keys": [
+          "bedrock_mantle/xai.grok-4.6",
+          "global.xai.grok-4.6",
+          "us.xai.grok-4.6",
+          "xai/grok-4.6"
+        ],
+        "reasoning_effort": null,
+        "required_parameters": {}
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "grok-4.6",
+          "completion_probability": 0.5838919642857142,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 1.042706805778344,
+          "mean_input_tokens": 103562.0,
+          "mean_output_tokens": 42293.61607142857,
+          "mean_request_cost_usd": 0.6088281249999999,
+          "quality_lower_bound": 0.47971095349363424,
+          "quality_score": 0.584845,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 2e-06,
+          "source_output_cost_per_token": 6e-06,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "grok-4.6",
+          "completion_probability": 0.8525547398843931,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.06858237773893723,
+          "mean_input_tokens": 103562.0,
+          "mean_output_tokens": 9404.699421965317,
+          "mean_request_cost_usd": 0.05847023121387283,
+          "quality_lower_bound": 0.7905754736095916,
+          "quality_score": 0.8513383333333332,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 2e-06,
+          "source_output_cost_per_token": 6e-06,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "grok-4.6",
+          "completion_probability": 0.7832739481268012,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.14293474305698176,
+          "mean_input_tokens": 103562.0,
+          "mean_output_tokens": 18029.959654178674,
+          "mean_request_cost_usd": 0.11195706051873199,
+          "quality_lower_bound": 0.7217334335863789,
+          "quality_score": 0.772135,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 2e-06,
+          "source_output_cost_per_token": 6e-06,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "grok-4.6",
+          "completion_probability": 0.9801704815864023,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.027443049307084175,
+          "mean_input_tokens": 103562.0,
+          "mean_output_tokens": 4337.402266288952,
+          "mean_request_cost_usd": 0.02689886685552408,
+          "quality_lower_bound": 0.9709424951201708,
+          "quality_score": 0.9841179999999999,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 2e-06,
+          "source_output_cost_per_token": 6e-06,
+          "subtask_count": 5
+        }
+      }
+    },
+    "grok-build-0.1": {
+      "benchmark_model_id": "grok-build-0.1",
+      "identity": {
+        "benchmark_model_id": "grok-build-0.1",
+        "family_id": "grok-build-0.1",
+        "is_routable": true,
+        "litellm_model_keys": [
+          "xai/grok-build-0.1"
+        ],
+        "reasoning_effort": null,
+        "required_parameters": {}
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "grok-build-0.1",
+          "completion_probability": 0.5007589285714286,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 0.16789248462155656,
+          "mean_input_tokens": 58770.0,
+          "mean_output_tokens": 3706.3125,
+          "mean_request_cost_usd": 0.08407366071428571,
+          "quality_lower_bound": 0.40526678365842894,
+          "quality_score": 0.49343000000000004,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1e-06,
+          "source_output_cost_per_token": 2e-06,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "grok-build-0.1",
+          "completion_probability": 0.7306932658959537,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.0021711109969323223,
+          "mean_input_tokens": 58770.0,
+          "mean_output_tokens": 346.33815028901734,
+          "mean_request_cost_usd": 0.0015864161849710983,
+          "quality_lower_bound": 0.6537908769552934,
+          "quality_score": 0.7247816666666668,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1e-06,
+          "source_output_cost_per_token": 2e-06,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "grok-build-0.1",
+          "completion_probability": 0.6712209221902017,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.0034918518733508376,
+          "mean_input_tokens": 58770.0,
+          "mean_output_tokens": 392.149855907781,
+          "mean_request_cost_usd": 0.002343804034582133,
+          "quality_lower_bound": 0.6338637172183715,
+          "quality_score": 0.6733516666666667,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1e-06,
+          "source_output_cost_per_token": 2e-06,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "grok-build-0.1",
+          "completion_probability": 0.8640225495750707,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.001605573981058883,
+          "mean_input_tokens": 58770.0,
+          "mean_output_tokens": 504.35977337110484,
+          "mean_request_cost_usd": 0.0013872521246458924,
+          "quality_lower_bound": 0.762820104079826,
+          "quality_score": 0.886196,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1e-06,
+          "source_output_cost_per_token": 2e-06,
+          "subtask_count": 5
+        }
+      }
+    },
+    "inkling-xhigh": {
+      "benchmark_model_id": "inkling-xhigh",
+      "identity": {
+        "benchmark_model_id": "inkling-xhigh",
+        "family_id": "inkling",
+        "is_routable": true,
+        "litellm_model_keys": [
+          "deepinfra/thinkingmachines/Inkling",
+          "fireworks_ai/accounts/fireworks/models/inkling",
+          "together_ai/thinkingmachines/Inkling"
+        ],
+        "reasoning_effort": "xhigh",
+        "required_parameters": {
+          "reasoning_effort": "xhigh"
+        }
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "inkling-xhigh",
+          "completion_probability": 0.5181458035714286,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 1.4951820821256014,
+          "mean_input_tokens": 355617.0,
+          "mean_output_tokens": 21542.08035714286,
+          "mean_request_cost_usd": 0.7747223214285714,
+          "quality_lower_bound": 0.4138507462718552,
+          "quality_score": 0.5172866666666667,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.87e-06,
+          "source_output_cost_per_token": 4.68e-06,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "inkling-xhigh",
+          "completion_probability": 0.7680871098265897,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.11300124240785248,
+          "mean_input_tokens": 355617.0,
+          "mean_output_tokens": 18236.104046242774,
+          "mean_request_cost_usd": 0.08679479768786127,
+          "quality_lower_bound": 0.6879611199462832,
+          "quality_score": 0.7613733333333333,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.87e-06,
+          "source_output_cost_per_token": 4.68e-06,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "inkling-xhigh",
+          "completion_probability": 0.7140415273775216,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.2479303486614995,
+          "mean_input_tokens": 355617.0,
+          "mean_output_tokens": 37184.04610951008,
+          "mean_request_cost_usd": 0.17703256484149854,
+          "quality_lower_bound": 0.687140938325973,
+          "quality_score": 0.7128933333333333,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.87e-06,
+          "source_output_cost_per_token": 4.68e-06,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "inkling-xhigh",
+          "completion_probability": 0.967659150141643,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.053020097447278515,
+          "mean_input_tokens": 355617.0,
+          "mean_output_tokens": 10843.40509915014,
+          "mean_request_cost_usd": 0.05130538243626063,
+          "quality_lower_bound": 0.9304917509052512,
+          "quality_score": 0.9624520000000001,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.87e-06,
+          "source_output_cost_per_token": 4.68e-06,
+          "subtask_count": 5
+        }
+      }
+    },
+    "kimi-k2.6-thinking": {
+      "benchmark_model_id": "kimi-k2.6-thinking",
+      "identity": {
+        "benchmark_model_id": "kimi-k2.6-thinking",
+        "family_id": "kimi-k2.6-thinking",
+        "is_routable": false,
+        "litellm_model_keys": [],
+        "reasoning_effort": null,
+        "required_parameters": {}
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "kimi-k2.6-thinking",
+          "completion_probability": 0.5166251785714285,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 0.5609214818286675,
+          "mean_input_tokens": 77968.0,
+          "mean_output_tokens": 57596.44642857143,
+          "mean_request_cost_usd": 0.2897861607142857,
+          "quality_lower_bound": 0.4058833919145738,
+          "quality_score": 0.5106033333333334,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 9.499999999999999e-07,
+          "source_output_cost_per_token": 4e-06,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "kimi-k2.6-thinking",
+          "completion_probability": 0.8051175722543352,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.08119734639697186,
+          "mean_input_tokens": 77968.0,
+          "mean_output_tokens": 16125.323699421966,
+          "mean_request_cost_usd": 0.06537341040462427,
+          "quality_lower_bound": 0.7560695680528867,
+          "quality_score": 0.7977683333333333,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 9.499999999999999e-07,
+          "source_output_cost_per_token": 4e-06,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "kimi-k2.6-thinking",
+          "completion_probability": 0.6083687608069164,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.22809804231052794,
+          "mean_input_tokens": 77968.0,
+          "mean_output_tokens": 34513.3083573487,
+          "mean_request_cost_usd": 0.1387677233429395,
+          "quality_lower_bound": 0.5571036212027963,
+          "quality_score": 0.6188066666666666,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 9.499999999999999e-07,
+          "source_output_cost_per_token": 4e-06,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "kimi-k2.6-thinking",
+          "completion_probability": 0.9537279036827195,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.04589029570706512,
+          "mean_input_tokens": 77968.0,
+          "mean_output_tokens": 10861.0,
+          "mean_request_cost_usd": 0.04376685552407932,
+          "quality_lower_bound": 0.9187096389430004,
+          "quality_score": 0.9489000000000001,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 9.499999999999999e-07,
+          "source_output_cost_per_token": 4e-06,
+          "subtask_count": 5
+        }
+      }
+    },
+    "kimi-k2.7-code": {
+      "benchmark_model_id": "kimi-k2.7-code",
+      "identity": {
+        "benchmark_model_id": "kimi-k2.7-code",
+        "family_id": "kimi-k2.7-code",
+        "is_routable": true,
+        "litellm_model_keys": [
+          "azure_ai/kimi-k2.7-code",
+          "cloudflare/@cf/moonshotai/kimi-k2.7-code",
+          "dashscope/kimi-k2.7-code",
+          "deepinfra/moonshotai/Kimi-K2.7-Code",
+          "moonshot/kimi-k2.7-code",
+          "novita/moonshotai/kimi-k2.7-code",
+          "perplexity/perplexity/kimi-k2.7-code",
+          "qwen_ai_platform/kimi-k2.7-code",
+          "qwencloud/kimi-k2.7-code",
+          "together_ai/moonshotai/Kimi-K2.7-Code",
+          "wandb/moonshotai/Kimi-K2.7-Code"
+        ],
+        "reasoning_effort": null,
+        "required_parameters": {}
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "kimi-k2.7-code",
+          "completion_probability": 0.4841655357142857,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 0.34182431702262395,
+          "mean_input_tokens": 138127.0,
+          "mean_output_tokens": 18838.375,
+          "mean_request_cost_usd": 0.16549955357142856,
+          "quality_lower_bound": 0.37480180324054907,
+          "quality_score": 0.48329,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 9.499999999999999e-07,
+          "source_output_cost_per_token": 4e-06,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "kimi-k2.7-code",
+          "completion_probability": 0.8078912716763005,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.04676665198251439,
+          "mean_input_tokens": 138127.0,
+          "mean_output_tokens": 9274.193641618496,
+          "mean_request_cost_usd": 0.03778236994219653,
+          "quality_lower_bound": 0.7212085060481994,
+          "quality_score": 0.8057466666666667,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 9.499999999999999e-07,
+          "source_output_cost_per_token": 4e-06,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "kimi-k2.7-code",
+          "completion_probability": 0.5314083285302593,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.16695183680534825,
+          "mean_input_tokens": 138127.0,
+          "mean_output_tokens": 21883.36311239193,
+          "mean_request_cost_usd": 0.08871959654178674,
+          "quality_lower_bound": 0.44675198640057223,
+          "quality_score": 0.5578233333333333,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 9.499999999999999e-07,
+          "source_output_cost_per_token": 4e-06,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "kimi-k2.7-code",
+          "completion_probability": 0.949009716713881,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.018192812468927278,
+          "mean_input_tokens": 138127.0,
+          "mean_output_tokens": 4238.611898016997,
+          "mean_request_cost_usd": 0.01726515580736544,
+          "quality_lower_bound": 0.9224390330931338,
+          "quality_score": 0.94655,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 9.499999999999999e-07,
+          "source_output_cost_per_token": 4e-06,
+          "subtask_count": 5
+        }
+      }
+    },
+    "kimi-k3": {
+      "benchmark_model_id": "kimi-k3",
+      "identity": {
+        "benchmark_model_id": "kimi-k3",
+        "family_id": "kimi-k3",
+        "is_routable": true,
+        "litellm_model_keys": [
+          "deepinfra/moonshotai/Kimi-K3",
+          "fireworks_ai/accounts/fireworks/models/kimi-k3",
+          "fireworks_ai/kimi-k3",
+          "moonshot/kimi-k3",
+          "novita/moonshotai/kimi-k3",
+          "perplexity/perplexity/kimi-k3",
+          "together_ai/moonshotai/Kimi-K3"
+        ],
+        "reasoning_effort": null,
+        "required_parameters": {}
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "kimi-k3",
+          "completion_probability": 0.6189532142857143,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 1.124973962375416,
+          "mean_input_tokens": 261769.0,
+          "mean_output_tokens": 21180.14285714286,
+          "mean_request_cost_usd": 0.69630625,
+          "quality_lower_bound": 0.5482513236653435,
+          "quality_score": 0.6231166666666667,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 3e-06,
+          "source_output_cost_per_token": 1.5e-05,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "kimi-k3",
+          "completion_probability": 0.8686992196531792,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.1579575841136204,
+          "mean_input_tokens": 261769.0,
+          "mean_output_tokens": 8959.508670520232,
+          "mean_request_cost_usd": 0.13721763005780346,
+          "quality_lower_bound": 0.8085757607273537,
+          "quality_score": 0.86872,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 3e-06,
+          "source_output_cost_per_token": 1.5e-05,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "kimi-k3",
+          "completion_probability": 0.7081506051873199,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.5183363932174508,
+          "mean_input_tokens": 261769.0,
+          "mean_output_tokens": 24097.619596541786,
+          "mean_request_cost_usd": 0.36706023054755044,
+          "quality_lower_bound": 0.6428725660808584,
+          "quality_score": 0.73807,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 3e-06,
+          "source_output_cost_per_token": 1.5e-05,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "kimi-k3",
+          "completion_probability": 0.9745038243626062,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.05638490830737281,
+          "mean_input_tokens": 261769.0,
+          "mean_output_tokens": 3586.1784702549576,
+          "mean_request_cost_usd": 0.05494730878186969,
+          "quality_lower_bound": 0.9619821635145729,
+          "quality_score": 0.980274,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 3e-06,
+          "source_output_cost_per_token": 1.5e-05,
+          "subtask_count": 5
+        }
+      }
+    },
+    "minimax-m3": {
+      "benchmark_model_id": "minimax-m3",
+      "identity": {
+        "benchmark_model_id": "minimax-m3",
+        "family_id": "minimax-m3",
+        "is_routable": true,
+        "litellm_model_keys": [
+          "deepinfra/MiniMaxAI/MiniMax-M3",
+          "fireworks_ai/accounts/fireworks/models/minimax-m3",
+          "fireworks_ai/minimax-m3",
+          "minimax/MiniMax-M3",
+          "novita/minimax/minimax-m3",
+          "tencent/minimax-m3",
+          "together_ai/MiniMaxAI/MiniMax-M3",
+          "wandb/MiniMaxAI/MiniMax-M3"
+        ],
+        "reasoning_effort": null,
+        "required_parameters": {}
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "minimax-m3",
+          "completion_probability": 0.4698001785714286,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 0.3130633806698212,
+          "mean_input_tokens": 331869.0,
+          "mean_output_tokens": 21959.29464285714,
+          "mean_request_cost_usd": 0.14707723214285712,
+          "quality_lower_bound": 0.34031296465295013,
+          "quality_score": 0.4576766666666667,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 3e-07,
+          "source_output_cost_per_token": 1.2e-06,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "minimax-m3",
+          "completion_probability": 0.7468859537572256,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.018624923352274145,
+          "mean_input_tokens": 331869.0,
+          "mean_output_tokens": 11361.606936416185,
+          "mean_request_cost_usd": 0.013910693641618498,
+          "quality_lower_bound": 0.6614243653944405,
+          "quality_score": 0.7399033333333334,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 3e-07,
+          "source_output_cost_per_token": 1.2e-06,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "minimax-m3",
+          "completion_probability": 0.6209699711815563,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.04868696171064159,
+          "mean_input_tokens": 331869.0,
+          "mean_output_tokens": 24863.097982708932,
+          "mean_request_cost_usd": 0.03023314121037464,
+          "quality_lower_bound": 0.5416649902386224,
+          "quality_score": 0.6333833333333333,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 3e-07,
+          "source_output_cost_per_token": 1.2e-06,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "minimax-m3",
+          "completion_probability": 0.887155552407932,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.00874328882093201,
+          "mean_input_tokens": 331869.0,
+          "mean_output_tokens": 6359.99716713881,
+          "mean_request_cost_usd": 0.007756657223796033,
+          "quality_lower_bound": 0.8279299263482481,
+          "quality_score": 0.9090959999999999,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 3e-07,
+          "source_output_cost_per_token": 1.2e-06,
+          "subtask_count": 5
+        }
+      }
+    },
+    "muse-spark-1.1-xhigh": {
+      "benchmark_model_id": "muse-spark-1.1-xhigh",
+      "identity": {
+        "benchmark_model_id": "muse-spark-1.1-xhigh",
+        "family_id": "muse-spark-1.1",
+        "is_routable": true,
+        "litellm_model_keys": [
+          "meta/muse-spark-1.1"
+        ],
+        "reasoning_effort": "xhigh",
+        "required_parameters": {
+          "reasoning_effort": "xhigh"
+        }
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "muse-spark-1.1-xhigh",
+          "completion_probability": 0.5784514285714285,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 1.0169169346234774,
+          "mean_input_tokens": 200083.0,
+          "mean_output_tokens": 16822.95535714286,
+          "mean_request_cost_usd": 0.5882370535714285,
+          "quality_lower_bound": 0.48299424590997,
+          "quality_score": 0.5848166666666667,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.25e-06,
+          "source_output_cost_per_token": 4.25e-06,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "muse-spark-1.1-xhigh",
+          "completion_probability": 0.7987732658959537,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.06071665890850331,
+          "mean_input_tokens": 200083.0,
+          "mean_output_tokens": 11166.248554913294,
+          "mean_request_cost_usd": 0.04849884393063584,
+          "quality_lower_bound": 0.7024593150732495,
+          "quality_score": 0.7945683333333333,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.25e-06,
+          "source_output_cost_per_token": 4.25e-06,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "muse-spark-1.1-xhigh",
+          "completion_probability": 0.7545689337175793,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.11754979521105281,
+          "mean_input_tokens": 200083.0,
+          "mean_output_tokens": 20359.317002881846,
+          "mean_request_cost_usd": 0.08869942363112392,
+          "quality_lower_bound": 0.6977158499604186,
+          "quality_score": 0.7415600000000001,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.25e-06,
+          "source_output_cost_per_token": 4.25e-06,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "muse-spark-1.1-xhigh",
+          "completion_probability": 0.9348429461756373,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.02963064556813349,
+          "mean_input_tokens": 200083.0,
+          "mean_output_tokens": 6420.943342776204,
+          "mean_request_cost_usd": 0.027700000000000002,
+          "quality_lower_bound": 0.8858440022350587,
+          "quality_score": 0.9521560000000001,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.25e-06,
+          "source_output_cost_per_token": 4.25e-06,
+          "subtask_count": 5
+        }
+      }
+    },
+    "muse-spark-1.2-xhigh": {
+      "benchmark_model_id": "muse-spark-1.2-xhigh",
+      "identity": {
+        "benchmark_model_id": "muse-spark-1.2-xhigh",
+        "family_id": "muse-spark-1.2",
+        "is_routable": true,
+        "litellm_model_keys": [
+          "meta/muse-spark-1.2"
+        ],
+        "reasoning_effort": "xhigh",
+        "required_parameters": {
+          "reasoning_effort": "xhigh"
+        }
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "muse-spark-1.2-xhigh",
+          "completion_probability": 0.582939642857143,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 2.2446638986761065,
+          "mean_input_tokens": 290641.0,
+          "mean_output_tokens": 23626.616071428572,
+          "mean_request_cost_usd": 1.3085035714285715,
+          "quality_lower_bound": 0.49583582646379193,
+          "quality_score": 0.5833516666666667,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.25e-06,
+          "source_output_cost_per_token": 4.25e-06,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "muse-spark-1.2-xhigh",
+          "completion_probability": 0.8213769075144509,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.08752468055455027,
+          "mean_input_tokens": 290641.0,
+          "mean_output_tokens": 16915.2225433526,
+          "mean_request_cost_usd": 0.0718907514450867,
+          "quality_lower_bound": 0.7563657200849929,
+          "quality_score": 0.8214283333333333,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.25e-06,
+          "source_output_cost_per_token": 4.25e-06,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "muse-spark-1.2-xhigh",
+          "completion_probability": 0.8302047838616714,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.14910282543392475,
+          "mean_input_tokens": 290641.0,
+          "mean_output_tokens": 29126.155619596542,
+          "mean_request_cost_usd": 0.12378587896253601,
+          "quality_lower_bound": 0.7605464624006388,
+          "quality_score": 0.8168583333333334,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.25e-06,
+          "source_output_cost_per_token": 4.25e-06,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "muse-spark-1.2-xhigh",
+          "completion_probability": 0.954674730878187,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.03149434519589871,
+          "mean_input_tokens": 290641.0,
+          "mean_output_tokens": 7074.43909348442,
+          "mean_request_cost_usd": 0.03006685552407932,
+          "quality_lower_bound": 0.9246072037939199,
+          "quality_score": 0.964118,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.25e-06,
+          "source_output_cost_per_token": 4.25e-06,
+          "subtask_count": 5
+        }
+      }
+    },
+    "muse-spark-1.3-xhigh": {
+      "benchmark_model_id": "muse-spark-1.3-xhigh",
+      "identity": {
+        "benchmark_model_id": "muse-spark-1.3-xhigh",
+        "family_id": "muse-spark-1.3",
+        "is_routable": true,
+        "litellm_model_keys": [
+          "meta/muse-spark-1.3"
+        ],
+        "reasoning_effort": "xhigh",
+        "required_parameters": {
+          "reasoning_effort": "xhigh"
+        }
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "muse-spark-1.3-xhigh",
+          "completion_probability": 0.6317361607142856,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 0.7427179491890616,
+          "mean_input_tokens": 246887.0,
+          "mean_output_tokens": 33075.49107142857,
+          "mean_request_cost_usd": 0.46920178571428567,
+          "quality_lower_bound": 0.5469604828322624,
+          "quality_score": 0.635605,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.25e-06,
+          "source_output_cost_per_token": 4.25e-06,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "muse-spark-1.3-xhigh",
+          "completion_probability": 0.8717929768786128,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.11119831208269634,
+          "mean_input_tokens": 246887.0,
+          "mean_output_tokens": 22561.56936416185,
+          "mean_request_cost_usd": 0.09694190751445086,
+          "quality_lower_bound": 0.8175533481544565,
+          "quality_score": 0.8708016666666666,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.25e-06,
+          "source_output_cost_per_token": 4.25e-06,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "muse-spark-1.3-xhigh",
+          "completion_probability": 0.8538526801152737,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.236816088515293,
+          "mean_input_tokens": 246887.0,
+          "mean_output_tokens": 47238.42074927954,
+          "mean_request_cost_usd": 0.20220605187319884,
+          "quality_lower_bound": 0.7725155351503601,
+          "quality_score": 0.8366733333333333,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.25e-06,
+          "source_output_cost_per_token": 4.25e-06,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "muse-spark-1.3-xhigh",
+          "completion_probability": 0.9801704815864023,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.05304216893759997,
+          "mean_input_tokens": 246887.0,
+          "mean_output_tokens": 12139.243626062324,
+          "mean_request_cost_usd": 0.05199036827195467,
+          "quality_lower_bound": 0.9578201313476288,
+          "quality_score": 0.980118,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.25e-06,
+          "source_output_cost_per_token": 4.25e-06,
+          "subtask_count": 5
+        }
+      }
+    },
+    "nemotron-3-ultra-550b-a55b": {
+      "benchmark_model_id": "nemotron-3-ultra-550b-a55b",
+      "identity": {
+        "benchmark_model_id": "nemotron-3-ultra-550b-a55b",
+        "family_id": "nemotron-3-ultra-550b-a55b",
+        "is_routable": true,
+        "litellm_model_keys": [
+          "together_ai/nvidia/nemotron-3-ultra-550b-a55b"
+        ],
+        "reasoning_effort": null,
+        "required_parameters": {}
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "nemotron-3-ultra-550b-a55b",
+          "completion_probability": 0.49212125,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 1.9619067092568285,
+          "mean_input_tokens": 527415.0,
+          "mean_output_tokens": 50084.11607142857,
+          "mean_request_cost_usd": 0.9654959821428571,
+          "quality_lower_bound": 0.3272957964397429,
+          "quality_score": 0.47136666666666666,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 6e-07,
+          "source_output_cost_per_token": 2.4e-06,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "nemotron-3-ultra-550b-a55b",
+          "completion_probability": 0.731813352601156,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.11781526781482156,
+          "mean_input_tokens": 527415.0,
+          "mean_output_tokens": 35688.52023121387,
+          "mean_request_cost_usd": 0.08621878612716763,
+          "quality_lower_bound": 0.6666168118964786,
+          "quality_score": 0.7245983333333333,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 6e-07,
+          "source_output_cost_per_token": 2.4e-06,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "nemotron-3-ultra-550b-a55b",
+          "completion_probability": 0.6731204899135447,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.23389751572539627,
+          "mean_input_tokens": 527415.0,
+          "mean_output_tokens": 65048.64841498559,
+          "mean_request_cost_usd": 0.15744121037463976,
+          "quality_lower_bound": 0.46327769300356714,
+          "quality_score": 0.64712,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 6e-07,
+          "source_output_cost_per_token": 2.4e-06,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "nemotron-3-ultra-550b-a55b",
+          "completion_probability": 0.9527845609065155,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.048535238667516814,
+          "mean_input_tokens": 527415.0,
+          "mean_output_tokens": 19155.81586402266,
+          "mean_request_cost_usd": 0.04624362606232294,
+          "quality_lower_bound": 0.9080300638083402,
+          "quality_score": 0.949568,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 6e-07,
+          "source_output_cost_per_token": 2.4e-06,
+          "subtask_count": 5
+        }
+      }
+    },
+    "ox-alpha-max": {
+      "benchmark_model_id": "ox-alpha-max",
+      "identity": {
+        "benchmark_model_id": "ox-alpha-max",
+        "family_id": "ox-alpha-max",
+        "is_routable": false,
+        "litellm_model_keys": [],
+        "reasoning_effort": null,
+        "required_parameters": {}
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "ox-alpha-max",
+          "completion_probability": 0.5142372321428571,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 0.0,
+          "mean_input_tokens": 157093.0,
+          "mean_output_tokens": 28606.26785714286,
+          "mean_request_cost_usd": 0.0,
+          "quality_lower_bound": 0.4728252881130144,
+          "quality_score": 0.5206316666666667,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 0.0,
+          "source_output_cost_per_token": 0.0,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "ox-alpha-max",
+          "completion_probability": 0.7770376300578036,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.0,
+          "mean_input_tokens": 157093.0,
+          "mean_output_tokens": 12741.991329479768,
+          "mean_request_cost_usd": 0.0,
+          "quality_lower_bound": 0.7494282022616836,
+          "quality_score": 0.776335,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 0.0,
+          "source_output_cost_per_token": 0.0,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "ox-alpha-max",
+          "completion_probability": 0.5649118443804034,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.0,
+          "mean_input_tokens": 157093.0,
+          "mean_output_tokens": 46579.43804034582,
+          "mean_request_cost_usd": 0.0,
+          "quality_lower_bound": 0.4806994442892879,
+          "quality_score": 0.59645,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 0.0,
+          "source_output_cost_per_token": 0.0,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "ox-alpha-max",
+          "completion_probability": 0.9225666288951841,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.0,
+          "mean_input_tokens": 157093.0,
+          "mean_output_tokens": 9465.28895184136,
+          "mean_request_cost_usd": 0.0,
+          "quality_lower_bound": 0.8110446370636408,
+          "quality_score": 0.9130179999999999,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 0.0,
+          "source_output_cost_per_token": 0.0,
+          "subtask_count": 5
+        }
+      }
+    },
+    "qwen3.6-27b": {
+      "benchmark_model_id": "qwen3.6-27b",
+      "identity": {
+        "benchmark_model_id": "qwen3.6-27b",
+        "family_id": "qwen3.6-27b",
+        "is_routable": true,
+        "litellm_model_keys": [
+          "deepinfra/Qwen/Qwen3.6-27B",
+          "groq/qwen/qwen3.6-27b",
+          "libertai/qwen3.6-27b",
+          "novita/qwen/qwen3.6-27b",
+          "wandb/Qwen/Qwen3.6-27B"
+        ],
+        "reasoning_effort": null,
+        "required_parameters": {}
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "qwen3.6-27b",
+          "completion_probability": 0.4286572321428571,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 0.669680507715018,
+          "mean_input_tokens": 69253.0,
+          "mean_output_tokens": 15090.24107142857,
+          "mean_request_cost_usd": 0.28706339285714283,
+          "quality_lower_bound": 0.33700489570364733,
+          "quality_score": 0.42367166666666667,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 6e-07,
+          "source_output_cost_per_token": 3.6000000000000003e-06,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "qwen3.6-27b",
+          "completion_probability": 0.703061387283237,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.10038919796016793,
+          "mean_input_tokens": 69253.0,
+          "mean_output_tokens": 19451.719653179192,
+          "mean_request_cost_usd": 0.07057976878612716,
+          "quality_lower_bound": 0.6166994304085625,
+          "quality_score": 0.6917033333333333,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 6e-07,
+          "source_output_cost_per_token": 3.6000000000000003e-06,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "qwen3.6-27b",
+          "completion_probability": 0.5682338616714697,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.2490187123609404,
+          "mean_input_tokens": 69253.0,
+          "mean_output_tokens": 39007.14409221902,
+          "mean_request_cost_usd": 0.14150086455331412,
+          "quality_lower_bound": 0.5143997318861502,
+          "quality_score": 0.57763,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 6e-07,
+          "source_output_cost_per_token": 3.6000000000000003e-06,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "qwen3.6-27b",
+          "completion_probability": 0.9223329461756374,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.08040824423766153,
+          "mean_input_tokens": 69253.0,
+          "mean_output_tokens": 20543.645892351276,
+          "mean_request_cost_usd": 0.07416317280453258,
+          "quality_lower_bound": 0.8421442118714418,
+          "quality_score": 0.9207259999999999,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 6e-07,
+          "source_output_cost_per_token": 3.6000000000000003e-06,
+          "subtask_count": 5
+        }
+      }
+    },
+    "qwen3.6-plus": {
+      "benchmark_model_id": "qwen3.6-plus",
+      "identity": {
+        "benchmark_model_id": "qwen3.6-plus",
+        "family_id": "qwen3.6-plus",
+        "is_routable": true,
+        "litellm_model_keys": [
+          "openrouter/qwen/qwen3.6-plus",
+          "together_ai/Qwen/Qwen3.6-Plus"
+        ],
+        "reasoning_effort": null,
+        "required_parameters": {}
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "qwen3.6-plus",
+          "completion_probability": 0.46088214285714285,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 1.129401497128953,
+          "mean_input_tokens": 143850.0,
+          "mean_output_tokens": 38367.169642857145,
+          "mean_request_cost_usd": 0.5205209821428571,
+          "quality_lower_bound": 0.34601770650322305,
+          "quality_score": 0.4546333333333334,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 5e-07,
+          "source_output_cost_per_token": 3e-06,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "qwen3.6-plus",
+          "completion_probability": 0.7679975144508671,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.08555354940409925,
+          "mean_input_tokens": 143850.0,
+          "mean_output_tokens": 21747.976878612717,
+          "mean_request_cost_usd": 0.06570491329479769,
+          "quality_lower_bound": 0.7053422746386699,
+          "quality_score": 0.7607316666666667,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 5e-07,
+          "source_output_cost_per_token": 3e-06,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "qwen3.6-plus",
+          "completion_probability": 0.6323061671469741,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.1911054834997674,
+          "mean_input_tokens": 143850.0,
+          "mean_output_tokens": 39980.47550432276,
+          "mean_request_cost_usd": 0.1208371757925072,
+          "quality_lower_bound": 0.5972042015012469,
+          "quality_score": 0.6347383333333333,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 5e-07,
+          "source_output_cost_per_token": 3e-06,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "qwen3.6-plus",
+          "completion_probability": 0.9525485269121814,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.05245686069602515,
+          "mean_input_tokens": 143850.0,
+          "mean_output_tokens": 16598.81586402266,
+          "mean_request_cost_usd": 0.049967705382436264,
+          "quality_lower_bound": 0.9238234129000658,
+          "quality_score": 0.953352,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 5e-07,
+          "source_output_cost_per_token": 3e-06,
+          "subtask_count": 5
+        }
+      }
+    },
+    "qwen3.7-max": {
+      "benchmark_model_id": "qwen3.7-max",
+      "identity": {
+        "benchmark_model_id": "qwen3.7-max",
+        "family_id": "qwen3.7-max",
+        "is_routable": true,
+        "litellm_model_keys": [
+          "dashscope/qwen3.7-max",
+          "deepinfra/Qwen/Qwen3.7-Max",
+          "novita/qwen/qwen3.7-max",
+          "qwen_ai_platform/qwen3.7-max",
+          "qwencloud/qwen3.7-max",
+          "together_ai/Qwen/Qwen3.7-Max"
+        ],
+        "reasoning_effort": null,
+        "required_parameters": {}
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "qwen3.7-max",
+          "completion_probability": 0.5137053571428571,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 0.5703545667854351,
+          "mean_input_tokens": 60711.0,
+          "mean_output_tokens": 13038.776785714286,
+          "mean_request_cost_usd": 0.29299419642857144,
+          "quality_lower_bound": 0.38837958384914156,
+          "quality_score": 0.49846166666666664,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 2.5e-06,
+          "source_output_cost_per_token": 7.5e-06,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "qwen3.7-max",
+          "completion_probability": 0.7953434393063584,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.06788574957784442,
+          "mean_input_tokens": 60711.0,
+          "mean_output_tokens": 6887.526011560693,
+          "mean_request_cost_usd": 0.05399248554913295,
+          "quality_lower_bound": 0.7376394401453119,
+          "quality_score": 0.7878633333333332,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 2.5e-06,
+          "source_output_cost_per_token": 7.5e-06,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "qwen3.7-max",
+          "completion_probability": 0.7227305475504323,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.2668490255694562,
+          "mean_input_tokens": 60711.0,
+          "mean_output_tokens": 25459.671469740635,
+          "mean_request_cost_usd": 0.19285994236311238,
+          "quality_lower_bound": 0.6702814450728942,
+          "quality_score": 0.7448049999999999,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 2.5e-06,
+          "source_output_cost_per_token": 7.5e-06,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "qwen3.7-max",
+          "completion_probability": 0.9723798016997167,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.05084514622240281,
+          "mean_input_tokens": 60711.0,
+          "mean_output_tokens": 6446.4617563739375,
+          "mean_request_cost_usd": 0.04944079320113315,
+          "quality_lower_bound": 0.9632810438479041,
+          "quality_score": 0.971196,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 2.5e-06,
+          "source_output_cost_per_token": 7.5e-06,
+          "subtask_count": 5
+        }
+      }
+    },
+    "qwen3.8-27b": {
+      "benchmark_model_id": "qwen3.8-27b",
+      "identity": {
+        "benchmark_model_id": "qwen3.8-27b",
+        "family_id": "qwen3.8-27b",
+        "is_routable": true,
+        "litellm_model_keys": [
+          "deepinfra/Qwen/Qwen3.8-27B",
+          "groq/qwen/qwen3.8-27b",
+          "wandb/Qwen/Qwen3.8-27B"
+        ],
+        "reasoning_effort": null,
+        "required_parameters": {}
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "qwen3.8-27b",
+          "completion_probability": 0.5802166071428572,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 0.5496661807028348,
+          "mean_input_tokens": 196281.0,
+          "mean_output_tokens": 38947.21428571428,
+          "mean_request_cost_usd": 0.31892544642857146,
+          "quality_lower_bound": 0.5129117470838801,
+          "quality_score": 0.5934633333333333,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 2.65e-07,
+          "source_output_cost_per_token": 6.5e-07,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "qwen3.8-27b",
+          "completion_probability": 0.7913420231213874,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.019906916011630783,
+          "mean_input_tokens": 196281.0,
+          "mean_output_tokens": 23844.335260115608,
+          "mean_request_cost_usd": 0.015753179190751445,
+          "quality_lower_bound": 0.6845274259530726,
+          "quality_score": 0.7853766666666667,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 2.65e-07,
+          "source_output_cost_per_token": 6.5e-07,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "qwen3.8-27b",
+          "completion_probability": 0.7230061383285302,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.035701882386432286,
+          "mean_input_tokens": 196281.0,
+          "mean_output_tokens": 38962.04322766571,
+          "mean_request_cost_usd": 0.025812680115273778,
+          "quality_lower_bound": 0.6808797772846128,
+          "quality_score": 0.7364366666666667,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 2.65e-07,
+          "source_output_cost_per_token": 6.5e-07,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "qwen3.8-27b",
+          "completion_probability": 0.9525499716713881,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.011706166129774697,
+          "mean_input_tokens": 196281.0,
+          "mean_output_tokens": 17012.773371104817,
+          "mean_request_cost_usd": 0.01115070821529745,
+          "quality_lower_bound": 0.9245333868375888,
+          "quality_score": 0.9493919999999999,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 2.65e-07,
+          "source_output_cost_per_token": 6.5e-07,
+          "subtask_count": 5
+        }
+      }
+    },
+    "qwen3.8-flash-next": {
+      "benchmark_model_id": "qwen3.8-flash-next",
+      "identity": {
+        "benchmark_model_id": "qwen3.8-flash-next",
+        "family_id": "qwen3.8-flash-next",
+        "is_routable": false,
+        "litellm_model_keys": [],
+        "reasoning_effort": null,
+        "required_parameters": {}
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "qwen3.8-flash-next",
+          "completion_probability": 0.5916786607142858,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 0.10951362505075977,
+          "mean_input_tokens": 332407.0,
+          "mean_output_tokens": 60165.330357142855,
+          "mean_request_cost_usd": 0.064796875,
+          "quality_lower_bound": 0.5193786665291859,
+          "quality_score": 0.6031333333333334,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.6e-07,
+          "source_output_cost_per_token": 4.6999999999999995e-07,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "qwen3.8-flash-next",
+          "completion_probability": 0.8224643352601155,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.02584506888328626,
+          "mean_input_tokens": 332407.0,
+          "mean_output_tokens": 44882.65895953757,
+          "mean_request_cost_usd": 0.02125664739884393,
+          "quality_lower_bound": 0.7364134603197254,
+          "quality_score": 0.8229766666666666,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.6e-07,
+          "source_output_cost_per_token": 4.6999999999999995e-07,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "qwen3.8-flash-next",
+          "completion_probability": 0.7165268299711816,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.05980819821649269,
+          "mean_input_tokens": 332407.0,
+          "mean_output_tokens": 90352.99423631123,
+          "mean_request_cost_usd": 0.04285417867435159,
+          "quality_lower_bound": 0.6721467035011582,
+          "quality_score": 0.7380116666666666,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.6e-07,
+          "source_output_cost_per_token": 4.6999999999999995e-07,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "qwen3.8-flash-next",
+          "completion_probability": 0.9605768838526912,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.012248010549845461,
+          "mean_input_tokens": 332407.0,
+          "mean_output_tokens": 24863.96883852691,
+          "mean_request_cost_usd": 0.01176515580736544,
+          "quality_lower_bound": 0.9240803336709251,
+          "quality_score": 0.9587260000000001,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 1.6e-07,
+          "source_output_cost_per_token": 4.6999999999999995e-07,
+          "subtask_count": 5
+        }
+      }
+    },
+    "qwen3.8-max": {
+      "benchmark_model_id": "qwen3.8-max",
+      "identity": {
+        "benchmark_model_id": "qwen3.8-max",
+        "family_id": "qwen3.8-max",
+        "is_routable": true,
+        "litellm_model_keys": [
+          "dashscope/qwen3.8-max",
+          "deepinfra/Qwen/Qwen3.8-Max",
+          "novita/qwen/qwen3.8-max",
+          "qwen_ai_platform/qwen3.8-max",
+          "qwencloud/qwen3.8-max",
+          "scx-ai/Qwen3.8-Max"
+        ],
+        "reasoning_effort": null,
+        "required_parameters": {}
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "qwen3.8-max",
+          "completion_probability": 0.6026175,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 1.0621928207243518,
+          "mean_input_tokens": 220544.0,
+          "mean_output_tokens": 27467.803571428572,
+          "mean_request_cost_usd": 0.6400959821428571,
+          "quality_lower_bound": 0.5407724411526618,
+          "quality_score": 0.6165166666666667,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 2e-06,
+          "source_output_cost_per_token": 6e-06,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "qwen3.8-max",
+          "completion_probability": 0.8357982080924855,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.12897158501834355,
+          "mean_input_tokens": 220544.0,
+          "mean_output_tokens": 17630.895953757226,
+          "mean_request_cost_usd": 0.10779421965317919,
+          "quality_lower_bound": 0.7495593962802758,
+          "quality_score": 0.836235,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 2e-06,
+          "source_output_cost_per_token": 6e-06,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "qwen3.8-max",
+          "completion_probability": 0.7880367146974063,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.2582985023079646,
+          "mean_input_tokens": 220544.0,
+          "mean_output_tokens": 33121.06628242075,
+          "mean_request_cost_usd": 0.20354870317002882,
+          "quality_lower_bound": 0.7440344791041409,
+          "quality_score": 0.7852100000000001,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 2e-06,
+          "source_output_cost_per_token": 6e-06,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "qwen3.8-max",
+          "completion_probability": 0.9695463172804532,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.06643655212704988,
+          "mean_input_tokens": 220544.0,
+          "mean_output_tokens": 10575.076487252125,
+          "mean_request_cost_usd": 0.06441331444759207,
+          "quality_lower_bound": 0.9512541704600264,
+          "quality_score": 0.971274,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 2e-06,
+          "source_output_cost_per_token": 6e-06,
+          "subtask_count": 5
+        }
+      }
+    },
+    "smaug-agentic": {
+      "benchmark_model_id": "smaug-agentic",
+      "identity": {
+        "benchmark_model_id": "smaug-agentic",
+        "family_id": "smaug-agentic",
+        "is_routable": false,
+        "litellm_model_keys": [],
+        "reasoning_effort": null,
+        "required_parameters": {}
+      },
+      "quality_by_complexity": {
+        "complex": {
+          "benchmark_model_id": "smaug-agentic",
+          "completion_probability": 0.6316240178571428,
+          "complexity": "complex",
+          "cost_per_completed_task_usd": 1.1112291458427248,
+          "mean_input_tokens": 180602.0,
+          "mean_output_tokens": 20301.1875,
+          "mean_request_cost_usd": 0.7018790178571429,
+          "quality_lower_bound": 0.5608808746166866,
+          "quality_score": 0.6380966666666666,
+          "question_count": 224,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 3e-06,
+          "source_output_cost_per_token": 1.5e-05,
+          "subtask_count": 6
+        },
+        "simple": {
+          "benchmark_model_id": "smaug-agentic",
+          "completion_probability": 0.8630814739884394,
+          "complexity": "simple",
+          "cost_per_completed_task_usd": 0.15925327915813411,
+          "mean_input_tokens": 180602.0,
+          "mean_output_tokens": 8966.745664739885,
+          "mean_request_cost_usd": 0.1374485549132948,
+          "quality_lower_bound": 0.7993092701785569,
+          "quality_score": 0.85933,
+          "question_count": 346,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 3e-06,
+          "source_output_cost_per_token": 1.5e-05,
+          "subtask_count": 6
+        },
+        "standard": {
+          "benchmark_model_id": "smaug-agentic",
+          "completion_probability": 0.7065554755043227,
+          "complexity": "standard",
+          "cost_per_completed_task_usd": 0.4412840229265045,
+          "mean_input_tokens": 180602.0,
+          "mean_output_tokens": 20441.167146974065,
+          "mean_request_cost_usd": 0.31179164265129683,
+          "quality_lower_bound": 0.6326602100432919,
+          "quality_score": 0.7396249999999999,
+          "question_count": 347,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 3e-06,
+          "source_output_cost_per_token": 1.5e-05,
+          "subtask_count": 6
+        },
+        "trivial": {
+          "benchmark_model_id": "smaug-agentic",
+          "completion_probability": 0.9745049575070821,
+          "complexity": "trivial",
+          "cost_per_completed_task_usd": 0.05537554115149625,
+          "mean_input_tokens": 180602.0,
+          "mean_output_tokens": 3513.3739376770536,
+          "mean_request_cost_usd": 0.053963739376770535,
+          "quality_lower_bound": 0.9592649709496708,
+          "quality_score": 0.9803139999999999,
+          "question_count": 353,
+          "source_id": "livebench-2026-06-25",
+          "source_input_cost_per_token": 3e-06,
+          "source_output_cost_per_token": 1.5e-05,
+          "subtask_count": 5
+        }
+      }
+    }
+  },
+  "provenance": {
+    "inputs": [
+      {
+        "bytes": 2133018,
+        "path": "litellm/model_prices_and_context_window.json",
+        "sha256": "a5ad23f7a2d98249588a2f21a305f8e3741bba450fd6216bde505cb9c4bee98a",
+        "source_id": "litellm-model-registry-2026-09-03"
+      },
+      {
+        "bytes": 725,
+        "path": "livebench/categories_2026_06_25.json",
+        "sha256": "dad300ad18655b69db720e1b88fc5a5eac06c5b2f0e52c2bf50f10ff057674f3",
+        "source_id": "livebench-2026-06-25"
+      },
+      {
+        "bytes": 23394,
+        "path": "livebench/cost_2026_06_25.csv",
+        "sha256": "6ae57254eaefe9c84008e909d118f37e53271009cf97569d43506b2ae8c9b29e",
+        "source_id": "livebench-2026-06-25"
+      },
+      {
+        "bytes": 8939,
+        "path": "livebench/table_2026_06_25.csv",
+        "sha256": "b8e6339f7fafe6df8f6ecc8b0abe3dc529b5737a6c7edd3e24ffcb36e02fd118",
+        "source_id": "livebench-2026-06-25"
+      }
+    ],
+    "manifest_sha256": "32def689d0fcb59afc8ca06fbc0d2f015c1268cb34dd4aaba991e1150ca437e8",
+    "source_revisions": {
+      "litellm-model-registry-2026-09-03": "828d561fcc2704eaf90617be8cdc058fccbd8508",
+      "livebench-2026-06-25": "62240f848c977d4202c1029191ac663498745f2f"
+    }
+  },
+  "quality_tiers": {
+    "balanced": {
+      "label": "Balanced",
+      "maximum_quality_regret": 0.07
+    },
+    "economy": {
+      "label": "Economy",
+      "maximum_quality_regret": 0.15
+    },
+    "high": {
+      "label": "High",
+      "maximum_quality_regret": 0.03
+    },
+    "max": {
+      "label": "Max",
+      "maximum_quality_regret": 0.01
+    }
+  },
+  "schema_version": "3.0",
+  "snapshot_id": "2026-09-03-v0",
+  "task_complexities": {
+    "livebench-2026-06-25": {
+      "AMPS_Hard": "trivial",
+      "code_completion": "simple",
+      "code_generation": "simple",
+      "connections": "trivial",
+      "consecutive_events": "standard",
+      "integrals_with_game": "standard",
+      "javascript": "complex",
+      "logic_with_navigation": "standard",
+      "math_comp": "trivial",
+      "olympiad": "simple",
+      "paraphrase": "standard",
+      "plot_unscrambling": "complex",
+      "python": "complex",
+      "simplify": "complex",
+      "spatial": "trivial",
+      "story_generation": "standard",
+      "summarize": "standard",
+      "tablejoin": "complex",
+      "tablereformat": "trivial",
+      "theory_of_mind": "simple",
+      "typescript": "complex",
+      "typos": "simple",
+      "zebra_puzzle": "simple"
+    }
+  }
+}

--- a/litellm/router_strategy/complexity_router/auto_setup.py
+++ b/litellm/router_strategy/complexity_router/auto_setup.py
@@ -1,0 +1,405 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from functools import lru_cache
+from importlib.resources import files
+from types import MappingProxyType
+from typing import Final, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, model_validator
+
+from .config import ComplexityRouterConfig
+
+SnapshotComplexity = Literal["trivial", "simple", "standard", "complex"]
+AutoSetupQualityLevel = Literal["economy", "balanced", "high", "max"]
+
+_SNAPSHOT_FILENAME: Final = "auto_router_snapshot_v0.json"
+_TIER_COMPLEXITIES: Final[Mapping[str, SnapshotComplexity]] = MappingProxyType(
+    {
+        "SIMPLE": "trivial",
+        "MEDIUM": "simple",
+        "COMPLEX": "standard",
+        "REASONING": "complex",
+    }
+)
+_VERSION_SEPARATOR: Final = re.compile(r"(?<=\d)\.(?=\d)")
+_SNAPSHOT_PAYLOAD_ADAPTER: Final = TypeAdapter(dict[str, object])
+
+
+class SnapshotQualityTier(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    label: str
+    maximum_quality_regret: float = Field(ge=0, le=1)
+
+
+class SnapshotIdentity(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    benchmark_model_id: str
+    family_id: str
+    is_routable: bool
+    litellm_model_keys: tuple[str, ...]
+    reasoning_effort: str | None
+    required_parameters: Mapping[str, object]
+
+
+class SnapshotQualityProfile(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    benchmark_model_id: str
+    complexity: SnapshotComplexity
+    completion_probability: float = Field(ge=0, le=1)
+    cost_per_completed_task_usd: float | None = Field(default=None, ge=0)
+    mean_input_tokens: float = Field(ge=0)
+    mean_output_tokens: float = Field(ge=0)
+    mean_request_cost_usd: float | None = Field(default=None, ge=0)
+    quality_lower_bound: float = Field(ge=0, le=1)
+    quality_score: float = Field(ge=0, le=1)
+    question_count: int = Field(gt=0)
+    source_input_cost_per_token: float = Field(ge=0)
+    source_output_cost_per_token: float = Field(ge=0)
+    source_id: str
+    subtask_count: int = Field(gt=0)
+
+
+class SnapshotModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    benchmark_model_id: str
+    identity: SnapshotIdentity
+    quality_by_complexity: Mapping[SnapshotComplexity, SnapshotQualityProfile]
+
+
+class AutoRouterSnapshot(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    activation_scope: Mapping[str, object]
+    artifact_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    complexity_policy: Mapping[str, object]
+    definitions: Mapping[str, str]
+    generated_at: str
+    limitations: tuple[str, ...]
+    models: Mapping[str, SnapshotModel]
+    provenance: Mapping[str, object]
+    quality_tiers: Mapping[AutoSetupQualityLevel, SnapshotQualityTier]
+    schema_version: Literal["3.0"]
+    snapshot_id: str
+    task_complexities: Mapping[str, Mapping[str, SnapshotComplexity]]
+
+    @model_validator(mode="after")
+    def _validate_policy(self) -> AutoRouterSnapshot:
+        if frozenset(self.quality_tiers) != frozenset(("economy", "balanced", "high", "max")):
+            raise ValueError("Auto Router snapshot must define economy, balanced, high, and max quality levels")
+        if self.activation_scope.get("setup_mode") != "auto":
+            raise ValueError("Auto Router snapshot is not scoped to Auto setup")
+        expected_complexities: Final = frozenset(_TIER_COMPLEXITIES.values())
+        seen_aliases: dict[str, str] = {}
+        for model_id, model in self.models.items():
+            if model_id != model.benchmark_model_id or model.identity.benchmark_model_id != model_id:
+                raise ValueError(f"Auto Router snapshot model identity mismatch for {model_id}")
+            if frozenset(model.quality_by_complexity) != expected_complexities:
+                raise ValueError(f"Auto Router snapshot model {model_id} lacks complete quality evidence")
+            if model.identity.is_routable != bool(model.identity.litellm_model_keys):
+                raise ValueError(f"Auto Router snapshot routability mismatch for {model_id}")
+            for complexity in expected_complexities:
+                quality = model.quality_by_complexity[complexity]
+                if quality.benchmark_model_id != model_id or quality.complexity != complexity:
+                    raise ValueError(f"Auto Router snapshot quality identity mismatch for {model_id}/{complexity}")
+            for alias in model.identity.litellm_model_keys:
+                normalized = _normalized_model_key(alias)
+                owner = seen_aliases.setdefault(normalized, model.identity.family_id)
+                if owner != model.identity.family_id:
+                    raise ValueError(f"Auto Router snapshot alias {alias!r} maps to multiple model families")
+        regrets = tuple(
+            self.quality_tiers[name].maximum_quality_regret for name in ("economy", "balanced", "high", "max")
+        )
+        if regrets != tuple(sorted(regrets, reverse=True)):
+            raise ValueError("Auto Router snapshot quality regret must tighten from economy through max")
+        return self
+
+
+class AutoSetupDeploymentPricing(BaseModel):
+    """The token rates LiteLLM will actually bill for one configured deployment."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    input_cost_per_token: float = Field(ge=0)
+    output_cost_per_token: float = Field(ge=0)
+    cache_read_input_token_cost: float | None = Field(default=None, ge=0)
+    input_cost_per_token_above_128k_tokens: float | None = Field(default=None, ge=0)
+    output_cost_per_token_above_128k_tokens: float | None = Field(default=None, ge=0)
+    cache_read_input_token_cost_above_128k_tokens: float | None = Field(default=None, ge=0)
+    input_cost_per_token_above_200k_tokens: float | None = Field(default=None, ge=0)
+    output_cost_per_token_above_200k_tokens: float | None = Field(default=None, ge=0)
+    cache_read_input_token_cost_above_200k_tokens: float | None = Field(default=None, ge=0)
+
+
+class AutoSetupDeployment(BaseModel):
+    """One deployment inside a model group, kept separate so mixed groups fail closed."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    model_refs: tuple[str, ...] = Field(min_length=1)
+    pricing: AutoSetupDeploymentPricing | None = None
+
+
+AutoSetupExclusionReason = Literal["no_benchmark_match", "mixed_model_group"]
+
+
+@dataclass(frozen=True, slots=True)
+class AutoSetupInventoryExclusion:
+    model_group: str
+    reason: AutoSetupExclusionReason
+
+
+@dataclass(frozen=True, slots=True)
+class _AvailableProfile:
+    model_name: str
+    benchmark_model_id: str
+    cost_per_completed_task_usd: float | None
+    quality: SnapshotQualityProfile
+    required_parameters: Mapping[str, object]
+
+
+@dataclass(frozen=True, slots=True)
+class _ResolvedGroup:
+    model_name: str
+    matches: tuple[SnapshotModel, ...]
+    deployments: tuple[AutoSetupDeployment, ...]
+
+
+def _canonical_json(value: object) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+@lru_cache(maxsize=1)
+def load_auto_router_snapshot() -> AutoRouterSnapshot:
+    raw: Final = _SNAPSHOT_PAYLOAD_ADAPTER.validate_json(
+        files("litellm.router_strategy.complexity_router")
+        .joinpath("artifacts", _SNAPSHOT_FILENAME)
+        .read_text(encoding="utf-8")
+    )
+    expected = raw.get("artifact_sha256")
+    if not isinstance(expected, str):
+        raise TypeError("Auto Router snapshot must carry an artifact_sha256")
+    unsigned: Final = {  # mutable-ok: json.dumps requires a transient concrete JSON object
+        key: value for key, value in raw.items() if key != "artifact_sha256"
+    }
+    actual: Final = hashlib.sha256(_canonical_json(unsigned).encode("utf-8")).hexdigest()
+    if expected != actual:
+        raise ValueError(f"Auto Router snapshot hash mismatch: expected {expected}, calculated {actual}")
+    return AutoRouterSnapshot.model_validate(raw)
+
+
+def _normalized_model_key(value: str) -> str:
+    return _VERSION_SEPARATOR.sub("-", value.strip().casefold())
+
+
+def _matching_snapshot_models(snapshot: AutoRouterSnapshot, model_refs: Sequence[str]) -> tuple[SnapshotModel, ...]:
+    normalized_refs: Final = frozenset(_normalized_model_key(ref) for ref in model_refs)
+    return tuple(
+        model
+        for model in snapshot.models.values()
+        if model.identity.is_routable
+        and normalized_refs.intersection(_normalized_model_key(key) for key in model.identity.litellm_model_keys)
+    )
+
+
+def _resolve_groups(
+    snapshot: AutoRouterSnapshot,
+    available_model_deployments: Mapping[str, Sequence[AutoSetupDeployment]],
+) -> tuple[tuple[_ResolvedGroup, ...], tuple[AutoSetupInventoryExclusion, ...]]:
+    resolved: list[_ResolvedGroup] = []
+    excluded: list[AutoSetupInventoryExclusion] = []
+    for model_name, deployments_value in available_model_deployments.items():
+        deployments = tuple(deployments_value)
+        if not deployments:
+            excluded.append(AutoSetupInventoryExclusion(model_name, "no_benchmark_match"))
+            continue
+        match_sets = [
+            {model.benchmark_model_id: model for model in _matching_snapshot_models(snapshot, deployment.model_refs)}
+            for deployment in deployments
+        ]
+        if any(len({model.identity.family_id for model in matches.values()}) > 1 for matches in match_sets):
+            excluded.append(AutoSetupInventoryExclusion(model_name, "mixed_model_group"))
+            continue
+        if any(not matches for matches in match_sets):
+            excluded.append(AutoSetupInventoryExclusion(model_name, "no_benchmark_match"))
+            continue
+        common_ids = set(match_sets[0]).intersection(*(set(matches) for matches in match_sets[1:]))
+        if not common_ids:
+            excluded.append(AutoSetupInventoryExclusion(model_name, "mixed_model_group"))
+            continue
+        resolved.append(
+            _ResolvedGroup(
+                model_name=model_name,
+                matches=tuple(match_sets[0][model_id] for model_id in sorted(common_ids)),
+                deployments=deployments,
+            )
+        )
+    return tuple(resolved), tuple(excluded)
+
+
+def analyze_auto_setup_inventory(
+    snapshot: AutoRouterSnapshot,
+    available_model_deployments: Mapping[str, Sequence[AutoSetupDeployment]],
+) -> tuple[tuple[str, ...], tuple[AutoSetupInventoryExclusion, ...]]:
+    """Return identity-safe groups and explicit reasons for every excluded group."""
+
+    groups, exclusions = _resolve_groups(snapshot, available_model_deployments)
+    return tuple(group.model_name for group in groups), exclusions
+
+
+def _rate_for_input_size(
+    pricing: AutoSetupDeploymentPricing,
+    field: Literal["input", "output", "cache"],
+    input_tokens: float,
+) -> float:
+    base = {
+        "input": pricing.input_cost_per_token,
+        "output": pricing.output_cost_per_token,
+        "cache": pricing.cache_read_input_token_cost,
+    }[field]
+    if field == "cache" and base is None:
+        base = pricing.input_cost_per_token
+    if input_tokens > 200_000:
+        above_200k = {
+            "input": pricing.input_cost_per_token_above_200k_tokens,
+            "output": pricing.output_cost_per_token_above_200k_tokens,
+            "cache": pricing.cache_read_input_token_cost_above_200k_tokens,
+        }[field]
+        if above_200k is not None:
+            return above_200k
+    if input_tokens > 128_000:
+        above_128k = {
+            "input": pricing.input_cost_per_token_above_128k_tokens,
+            "output": pricing.output_cost_per_token_above_128k_tokens,
+            "cache": pricing.cache_read_input_token_cost_above_128k_tokens,
+        }[field]
+        if above_128k is not None:
+            return above_128k
+    if base is None:
+        raise ValueError(f"Auto setup pricing lacks a base {field} rate")
+    return base
+
+
+def _quality_completion_cost(
+    profile: SnapshotQualityProfile,
+    deployments: Sequence[AutoSetupDeployment],
+) -> float | None:
+    source_bill = (
+        profile.mean_input_tokens * profile.source_input_cost_per_token
+        + profile.mean_output_tokens * profile.source_output_cost_per_token
+    )
+    if source_bill <= 0 or profile.completion_probability <= 0 or profile.mean_request_cost_usd is None:
+        return None
+    costs: list[float] = []
+    for deployment in deployments:
+        pricing = deployment.pricing
+        if pricing is None:
+            return None
+        deployed_bill = profile.mean_input_tokens * _rate_for_input_size(
+            pricing, "input", profile.mean_input_tokens
+        ) + profile.mean_output_tokens * _rate_for_input_size(pricing, "output", profile.mean_input_tokens)
+        adjusted_request_cost = profile.mean_request_cost_usd * deployed_bill / source_bill
+        costs.append(adjusted_request_cost / profile.completion_probability)
+    return max(costs, default=None)
+
+
+def _available_profiles(
+    snapshot: AutoRouterSnapshot,
+    available_model_deployments: Mapping[str, Sequence[AutoSetupDeployment]],
+    complexity: SnapshotComplexity,
+) -> tuple[_AvailableProfile, ...]:
+    profiles: Final[list[_AvailableProfile]] = []  # mutable-ok: local accumulator is frozen into the returned tuple
+    groups, _ = _resolve_groups(snapshot, available_model_deployments)
+    for group in groups:
+        best = min(
+            group.matches,
+            key=lambda model: (
+                -model.quality_by_complexity[complexity].quality_lower_bound,
+                (
+                    model.quality_by_complexity[complexity].cost_per_completed_task_usd
+                    if model.quality_by_complexity[complexity].cost_per_completed_task_usd is not None
+                    else math.inf
+                ),
+                model.benchmark_model_id,
+            ),
+        )
+        cost = _quality_completion_cost(best.quality_by_complexity[complexity], group.deployments)
+        profiles.append(
+            _AvailableProfile(
+                model_name=group.model_name,
+                benchmark_model_id=best.benchmark_model_id,
+                cost_per_completed_task_usd=cost,
+                quality=best.quality_by_complexity[complexity],
+                required_parameters=best.identity.required_parameters,
+            )
+        )
+    return tuple(profiles)
+
+
+def _cost_rank(profiles: Sequence[_AvailableProfile]) -> tuple[_AvailableProfile, ...]:
+    return tuple(
+        sorted(
+            profiles,
+            key=lambda profile: (
+                profile.cost_per_completed_task_usd is None,
+                profile.cost_per_completed_task_usd if profile.cost_per_completed_task_usd is not None else math.inf,
+                -profile.quality.quality_lower_bound,
+                profile.model_name,
+            ),
+        )
+    )
+
+
+def build_auto_setup_config(
+    *,
+    snapshot: AutoRouterSnapshot,
+    available_model_deployments: Mapping[str, Sequence[AutoSetupDeployment]],
+    quality_level: AutoSetupQualityLevel,
+) -> ComplexityRouterConfig:
+    """Recompute quality gates and rankings over only the caller's available groups."""
+
+    maximum_regret: Final = snapshot.quality_tiers[quality_level].maximum_quality_regret
+    tiers: Final[dict[str, list[str]]] = {}  # mutable-ok: Pydantic config assembly is local to this builder
+    tier_model_configs: Final[  # mutable-ok: Pydantic config assembly is local to this builder
+        dict[str, list[dict[str, object]]]
+    ] = {}  # mutable-ok: Pydantic config assembly is local to this builder
+    for tier_name, complexity in _TIER_COMPLEXITIES.items():
+        profiles = _available_profiles(snapshot, available_model_deployments, complexity)
+        if not profiles:
+            raise ValueError(f"None of the available model groups has {complexity} evidence in this snapshot")
+        best_quality = max(profile.quality.quality_lower_bound for profile in profiles)
+        floor = max(0.0, best_quality - maximum_regret)
+        admitted = tuple(profile for profile in profiles if profile.quality.quality_lower_bound >= floor)
+        selected = _cost_rank(admitted)[0]
+        tiers[tier_name] = [selected.model_name]
+        parameterized: list[dict[str, object]] = (
+            [  # mutable-ok: Pydantic validates and owns these JSON-shaped rows
+                {  # mutable-ok: each row is a Pydantic input payload
+                    "model_name": selected.model_name,
+                    "litellm_params": dict(  # mutable-ok: Pydantic needs a concrete JSON-shaped params object
+                        selected.required_parameters
+                    ),
+                }
+            ]
+            if selected.required_parameters
+            else []
+        )
+        if parameterized:
+            tier_model_configs[tier_name] = parameterized
+
+    return ComplexityRouterConfig.model_validate(
+        {  # mutable-ok: top-level Pydantic input must be a JSON-shaped mapping
+            "tiers": tiers,
+            "tier_model_configs": tier_model_configs,
+            "classifier_type": "heuristic_v2",
+        }
+    )

--- a/litellm/types/management_endpoints/auto_router_endpoints.py
+++ b/litellm/types/management_endpoints/auto_router_endpoints.py
@@ -9,6 +9,7 @@ from typing import Final, Literal, TypeAlias
 
 from pydantic import BaseModel, Field, computed_field, field_validator, model_validator
 
+from litellm.router_strategy.complexity_router.auto_setup import AutoSetupQualityLevel
 from litellm.router_strategy.complexity_router.config import ComplexityRouterConfig
 from litellm.types.utils import StandardLoggingRoutingDecision
 
@@ -42,6 +43,25 @@ class ComplexityRouterConfigValidationRequest(BaseModel):
 class ComplexityRouterConfigValidationResponse(BaseModel):
     valid: bool
     error: str | None = None
+
+
+class AutoRouterExcludedModelGroup(BaseModel):
+    """A caller-visible reason Auto setup did not use an available model group."""
+
+    model_group: str
+    reason: Literal["no_benchmark_match", "mixed_model_group"]
+
+
+class AutoRouterRecommendationResponse(BaseModel):
+    """An editable complexity-router config generated from the caller's usable model groups."""
+
+    quality_level: AutoSetupQualityLevel
+    snapshot_id: str
+    snapshot_generated_at: str
+    available_model_group_count: int = Field(ge=0)
+    matched_model_groups: tuple[str, ...]
+    excluded_model_groups: tuple[AutoRouterExcludedModelGroup, ...] = ()
+    complexity_router_config: RequestComplexityRouterConfig
 
 
 class AutoRouterRoutingTestRequest(BaseModel):

--- a/tests/test_litellm/proxy/management_endpoints/test_auto_router_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_auto_router_endpoints.py
@@ -18,6 +18,7 @@ from litellm.proxy._types import (
     UserAPIKeyAuth,
 )
 from litellm.proxy.management_endpoints.auto_router_endpoints import (
+    get_auto_router_recommendation,
     preview_auto_router_routing,
 )
 from litellm.router import Router
@@ -102,6 +103,134 @@ async def _route_body(body: Mapping[str, object], monkeypatch: pytest.MonkeyPatc
 
 async def _route(prompt: str, monkeypatch: pytest.MonkeyPatch, **config_overrides: object):
     return await _route_body({"prompt": prompt}, monkeypatch, **config_overrides)
+
+
+@pytest.mark.asyncio
+async def test_recommendation_uses_caller_groups_and_returns_an_editable_complexity_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import litellm.proxy.management_endpoints.auto_router_endpoints as endpoint_module
+    import litellm.proxy.utils as proxy_utils
+    from litellm.proxy import proxy_server
+
+    model_list = [
+        {
+            "model_name": "small-group",
+            "litellm_params": {"model": "gpt-5.4-nano", "api_key": "fake"},
+        },
+        {
+            "model_name": "smart-group",
+            "litellm_params": {"model": "gpt-5.6-sol", "api_key": "fake"},
+        },
+        {
+            "model_name": "unavailable-group",
+            "litellm_params": {"model": "gpt-5.5", "api_key": "fake"},
+        },
+    ]
+    monkeypatch.setattr(proxy_server, "llm_router", Router(model_list=model_list))
+    available = AsyncMock(return_value=["small-group", "smart-group", "small-group"])
+    monkeypatch.setattr(proxy_utils, "get_available_models_for_user", available)
+    authorize = AsyncMock()
+    monkeypatch.setattr(endpoint_module, "_authorize_router_dry_run", authorize)
+
+    response = await get_auto_router_recommendation(
+        user_api_key_dict=ADMIN,
+        quality_level="economy",
+    )
+
+    authorize.assert_awaited_once_with(user_api_key_dict=ADMIN, team_id=None)
+    assert set(response.matched_model_groups) <= {"small-group", "smart-group"}
+    assert response.available_model_group_count == 2
+    assert response.excluded_model_groups == ()
+    assert "unavailable-group" not in response.matched_model_groups
+    assert response.complexity_router_config.classifier_type == "heuristic_v2"
+    assert all(len(models) == 1 for models in response.complexity_router_config.tiers.values())
+    assert "auto_setup" not in response.complexity_router_config.model_dump(mode="json", exclude_none=True)
+
+
+def test_auto_setup_pricing_honors_custom_token_rates_and_rejects_non_token_charges() -> None:
+    from litellm.proxy.management_endpoints.auto_router_endpoints import (
+        _deployment_pricing,  # pyright: ignore[reportPrivateUsage] -- direct contract test for fail-closed pricing
+    )
+
+    custom = _deployment_pricing(
+        {
+            "litellm_params": {
+                "model": "custom/provider-model",
+                "input_cost_per_token": 0.000001,
+                "output_cost_per_token": 0.000002,
+            }
+        }
+    )
+    unsupported = _deployment_pricing(
+        {
+            "litellm_params": {
+                "model": "gpt-5.4-nano",
+                "input_cost_per_query": 0.01,
+            }
+        }
+    )
+
+    assert custom is not None
+    assert custom.input_cost_per_token == pytest.approx(0.000001)
+    assert custom.output_cost_per_token == pytest.approx(0.000002)
+    assert unsupported is None
+
+
+def test_auto_setup_pricing_resolves_an_explicit_base_model_before_a_deployment_alias() -> None:
+    import litellm
+    from litellm.proxy.management_endpoints.auto_router_endpoints import (
+        _deployment_pricing,  # pyright: ignore[reportPrivateUsage] -- direct contract test for provider aliases
+    )
+
+    pricing = _deployment_pricing(
+        {"litellm_params": {"model": "azure/my-private-deployment", "base_model": "gpt-5.4-nano"}}
+    )
+    published = litellm.get_model_info(model="gpt-5.4-nano")
+
+    assert pricing is not None
+    assert pricing.input_cost_per_token == pytest.approx(published["input_cost_per_token"])
+    assert pricing.output_cost_per_token == pytest.approx(published["output_cost_per_token"])
+
+
+@pytest.mark.asyncio
+async def test_recommendation_excludes_mixed_and_unmatched_but_keeps_unpriced_groups(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import litellm.proxy.management_endpoints.auto_router_endpoints as endpoint_module
+    import litellm.proxy.utils as proxy_utils
+    from litellm.proxy import proxy_server
+
+    model_list = [
+        {"model_name": "safe", "litellm_params": {"model": "gpt-5.6-sol", "api_key": "fake"}},
+        {"model_name": "mixed", "litellm_params": {"model": "gpt-5.6-sol", "api_key": "fake"}},
+        {"model_name": "mixed", "litellm_params": {"model": "gpt-5.4-nano", "api_key": "fake"}},
+        {"model_name": "unknown", "litellm_params": {"model": "openai/not-a-real-model", "api_key": "fake"}},
+        {
+            "model_name": "unpriced",
+            "litellm_params": {"model": "perplexity/anthropic/claude-opus-4-6", "api_key": "fake"},
+        },
+    ]
+    monkeypatch.setattr(proxy_server, "llm_router", Router(model_list=model_list))
+    monkeypatch.setattr(
+        proxy_utils,
+        "get_available_models_for_user",
+        AsyncMock(return_value=["safe", "mixed", "unknown", "unpriced"]),
+    )
+    monkeypatch.setattr(endpoint_module, "_authorize_router_dry_run", AsyncMock())
+
+    response = await get_auto_router_recommendation(
+        user_api_key_dict=ADMIN,
+        quality_level="max",
+    )
+
+    assert response.available_model_group_count == 4
+    assert set(response.matched_model_groups) <= {"safe", "unpriced"}
+    assert response.matched_model_groups
+    assert {(item.model_group, item.reason) for item in response.excluded_model_groups} == {
+        ("mixed", "mixed_model_group"),
+        ("unknown", "no_benchmark_match"),
+    }
 
 
 AGENTIC_MESSAGES = [

--- a/tests/test_litellm/router_strategy/test_complexity_router_auto_setup.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router_auto_setup.py
@@ -1,0 +1,355 @@
+import math
+import random
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from litellm.router_strategy.complexity_router.auto_setup import (
+    AutoRouterSnapshot,
+    AutoSetupDeployment,
+    AutoSetupDeploymentPricing,
+    _quality_completion_cost,  # pyright: ignore[reportPrivateUsage] -- regression test for deployment-aware setup ranking
+    analyze_auto_setup_inventory,
+    build_auto_setup_config,
+    load_auto_router_snapshot,
+)
+from litellm.router_strategy.complexity_router.complexity_router import ComplexityRouter
+from litellm.router_strategy.complexity_router.config import ComplexityTier
+
+
+def _available_refs(*model_names: str) -> dict[str, tuple[AutoSetupDeployment, ...]]:
+    return {
+        model_name: (
+            AutoSetupDeployment(
+                model_refs=(model_name,),
+                pricing=(
+                    AutoSetupDeploymentPricing(input_cost_per_token=0.0000002, output_cost_per_token=0.00000125)
+                    if model_name == "gpt-5.4-nano"
+                    else AutoSetupDeploymentPricing(input_cost_per_token=0.000005, output_cost_per_token=0.00003)
+                ),
+            ),
+        )
+        for model_name in model_names
+    }
+
+
+def _registry_deployment(model_ref: str) -> AutoSetupDeployment:
+    from litellm.proxy.management_endpoints.auto_router_endpoints import (
+        _deployment_pricing,  # pyright: ignore[reportPrivateUsage] -- exercises the endpoint's production registry resolver
+    )
+
+    raw = {"model_name": model_ref, "litellm_params": {"model": model_ref}, "model_info": {}}
+    return AutoSetupDeployment(model_refs=(model_ref,), pricing=_deployment_pricing(raw))
+
+
+def test_snapshot_is_verified_and_quality_gate_is_recomputed_for_available_models() -> None:
+    snapshot = load_auto_router_snapshot()
+    available = _available_refs("gpt-5.6-sol", "gpt-5.4-nano")
+
+    economy = build_auto_setup_config(
+        snapshot=snapshot,
+        available_model_deployments=available,
+        quality_level="economy",
+    )
+    maximum = build_auto_setup_config(
+        snapshot=snapshot,
+        available_model_deployments=available,
+        quality_level="max",
+    )
+    nano_only = build_auto_setup_config(
+        snapshot=snapshot,
+        available_model_deployments=_available_refs("gpt-5.4-nano"),
+        quality_level="max",
+    )
+
+    assert snapshot.artifact_sha256 == "e191b5f7225e4da7a178eb5fe8780bcea24fb0166be23e2069338c6fe5522cd5"
+    assert economy.tiers["SIMPLE"] == ["gpt-5.4-nano"]
+    assert maximum.tiers["SIMPLE"] == ["gpt-5.6-sol"]
+    assert nano_only.tiers["SIMPLE"] == ["gpt-5.4-nano"]
+
+
+def test_auto_setup_emits_a_plain_static_complexity_router_config() -> None:
+    config = build_auto_setup_config(
+        snapshot=load_auto_router_snapshot(),
+        available_model_deployments=_available_refs("gpt-5.6-sol", "gpt-5.4-nano"),
+        quality_level="economy",
+    )
+
+    payload = config.model_dump(mode="json", exclude_none=True)
+    assert payload["classifier_type"] == "heuristic_v2"
+    assert "auto_setup" not in payload
+    assert all(len(models) == 1 for models in config.tiers.values())
+
+
+def test_every_snapshot_alias_builds_all_four_quality_setups_even_without_price() -> None:
+    snapshot = load_auto_router_snapshot()
+    aliases = tuple(
+        alias
+        for model in snapshot.models.values()
+        if model.identity.is_routable
+        for alias in model.identity.litellm_model_keys
+    )
+    assert len(aliases) == 283
+    priced = {alias: _registry_deployment(alias) for alias in aliases}
+    unsupported = tuple(alias for alias, deployment in priced.items() if deployment.pricing is None)
+    assert unsupported == (
+        "perplexity/anthropic/claude-opus-4-6",
+        "perplexity/anthropic/claude-opus-4-7",
+        "chatgpt/gpt-5.2-codex",
+        "chatgpt/gpt-5.4",
+    )
+
+    for alias, deployment in priced.items():
+        eligible, excluded = analyze_auto_setup_inventory(snapshot, {alias: (deployment,)})
+        assert eligible == (alias,)
+        assert excluded == ()
+        for quality_level in ("economy", "balanced", "high", "max"):
+            config = build_auto_setup_config(
+                snapshot=snapshot,
+                available_model_deployments={alias: (deployment,)},
+                quality_level=quality_level,
+            )
+            assert set(config.tiers) == {"SIMPLE", "MEDIUM", "COMPLEX", "REASONING"}
+            assert all(models == [alias] for models in config.tiers.values())
+
+
+def test_full_priced_inventory_builds_deterministically_for_every_choice() -> None:
+    snapshot = load_auto_router_snapshot()
+    deployments = {
+        f"group-{index:03d}": (_registry_deployment(alias),)
+        for index, alias in enumerate(
+            dict.fromkeys(
+                alias
+                for model in snapshot.models.values()
+                if model.identity.is_routable
+                for alias in model.identity.litellm_model_keys
+            )
+        )
+        if _registry_deployment(alias).pricing is not None
+    }
+    assert len(deployments) == 279
+
+    selected_tiers: dict[str, dict[str, set[str]]] = {}
+    for quality_level in ("economy", "balanced", "high", "max"):
+        config = build_auto_setup_config(
+            snapshot=snapshot,
+            available_model_deployments=deployments,
+            quality_level=quality_level,
+        )
+        repeated = build_auto_setup_config(
+            snapshot=snapshot,
+            available_model_deployments=dict(reversed(tuple(deployments.items()))),
+            quality_level=quality_level,
+        )
+        assert config.model_dump(mode="json") == repeated.model_dump(mode="json")
+        assert all(len(models) == 1 for models in config.tiers.values())
+        assert all(set(models).issubset(deployments) for models in config.tiers.values())
+        selected_tiers[quality_level] = {tier: set(models) for tier, models in config.tiers.items()}
+
+    assert set(selected_tiers) == {"economy", "balanced", "high", "max"}
+
+
+def test_seeded_mixed_inventories_never_select_unknown_or_unsafe_groups() -> None:
+    snapshot = load_auto_router_snapshot()
+    priced_aliases = [
+        alias
+        for model in snapshot.models.values()
+        if model.identity.is_routable
+        for alias in model.identity.litellm_model_keys
+        if _registry_deployment(alias).pricing is not None
+    ]
+    rng = random.Random(20260903)
+    for inventory_index in range(100):
+        chosen = rng.sample(priced_aliases, rng.randint(1, min(30, len(priced_aliases))))
+        inventory = {
+            f"known-{inventory_index}-{index}": (_registry_deployment(alias),) for index, alias in enumerate(chosen)
+        }
+        inventory.update(
+            {
+                f"unknown-{inventory_index}-{index}": (
+                    AutoSetupDeployment(
+                        model_refs=(f"unknown/provider-{inventory_index}-{index}",),
+                        pricing=AutoSetupDeploymentPricing(
+                            input_cost_per_token=0.000001,
+                            output_cost_per_token=0.000002,
+                        ),
+                    ),
+                )
+                for index in range(rng.randint(0, 10))
+            }
+        )
+        for quality_level in ("economy", "balanced", "high", "max"):
+            config = build_auto_setup_config(
+                snapshot=snapshot,
+                available_model_deployments=inventory,
+                quality_level=quality_level,
+            )
+            selected = {model_name for models in config.tiers.values() for model_name in models}
+            assert selected
+            assert all(model_name.startswith("known-") for model_name in selected)
+
+
+def test_mixed_or_partially_unmatched_model_groups_fail_closed() -> None:
+    snapshot = load_auto_router_snapshot()
+    pricing = AutoSetupDeploymentPricing(input_cost_per_token=0.000001, output_cost_per_token=0.000002)
+    inventory = {
+        "mixed": (
+            AutoSetupDeployment(model_refs=("gpt-5.6-sol",), pricing=pricing),
+            AutoSetupDeployment(model_refs=("gpt-5.4-nano",), pricing=pricing),
+        ),
+        "partial": (
+            AutoSetupDeployment(model_refs=("gpt-5.6-sol",), pricing=pricing),
+            AutoSetupDeployment(model_refs=("unknown/model",), pricing=pricing),
+        ),
+        "ambiguous-single-deployment": (
+            AutoSetupDeployment(model_refs=("gpt-5.6-sol", "gpt-5.4-nano"), pricing=pricing),
+        ),
+        "safe": (AutoSetupDeployment(model_refs=("gpt-5.6-sol",), pricing=pricing),),
+    }
+
+    eligible, excluded = analyze_auto_setup_inventory(snapshot, inventory)
+
+    assert eligible == ("safe",)
+    assert {(item.model_group, item.reason) for item in excluded} == {
+        ("mixed", "mixed_model_group"),
+        ("partial", "no_benchmark_match"),
+        ("ambiguous-single-deployment", "mixed_model_group"),
+    }
+    config = build_auto_setup_config(
+        snapshot=snapshot,
+        available_model_deployments=inventory,
+        quality_level="economy",
+    )
+    assert all(models == ["safe"] for models in config.tiers.values())
+
+
+def test_missing_cost_falls_back_to_quality_instead_of_blocking_setup() -> None:
+    raw = load_auto_router_snapshot().model_dump(mode="json")
+    quality_profiles = raw["models"]["gpt-5.4-nano-xhigh"]["quality_by_complexity"].values()
+    for profile in quality_profiles:
+        profile["mean_request_cost_usd"] = None
+        profile["cost_per_completed_task_usd"] = None
+    raw["models"]["gpt-5.4-nano-xhigh"]["quality_by_complexity"]["trivial"]["completion_probability"] = 0
+
+    snapshot = AutoRouterSnapshot.model_validate(raw)
+    eligible, excluded = analyze_auto_setup_inventory(snapshot, _available_refs("gpt-5.4-nano"))
+
+    assert eligible == ("gpt-5.4-nano",)
+    assert excluded == ()
+    generated = build_auto_setup_config(
+        snapshot=snapshot,
+        available_model_deployments=_available_refs("gpt-5.4-nano"),
+        quality_level="max",
+    )
+    assert all(models == ["gpt-5.4-nano"] for models in generated.tiers.values())
+
+
+def test_multiple_unpriced_models_choose_the_highest_quality_inside_the_gate() -> None:
+    inventory = {
+        model_name: (AutoSetupDeployment(model_refs=(model_name,), pricing=None),)
+        for model_name in ("gpt-5.6-sol", "gpt-5.4-nano")
+    }
+
+    generated = build_auto_setup_config(
+        snapshot=load_auto_router_snapshot(),
+        available_model_deployments=inventory,
+        quality_level="max",
+    )
+
+    assert generated.tiers["SIMPLE"] == ["gpt-5.6-sol"]
+
+
+def test_provider_repricing_and_multi_deployment_groups_are_conservative() -> None:
+    snapshot = load_auto_router_snapshot()
+    cheap = AutoSetupDeployment(
+        model_refs=("gpt-5.6-sol",),
+        pricing=AutoSetupDeploymentPricing(input_cost_per_token=0.000001, output_cost_per_token=0.000002),
+    )
+    expensive = AutoSetupDeployment(
+        model_refs=("gpt-5.6-sol",),
+        pricing=AutoSetupDeploymentPricing(input_cost_per_token=0.00001, output_cost_per_token=0.00002),
+    )
+    profile = snapshot.models["gpt-5.6-sol-max"].quality_by_complexity["trivial"]
+    cheap_cost = _quality_completion_cost(profile, (cheap,))
+    expensive_cost = _quality_completion_cost(profile, (expensive,))
+    mixed_cost = _quality_completion_cost(profile, (cheap, expensive))
+
+    assert cheap_cost is not None
+    assert expensive_cost is not None
+    assert mixed_cost is not None
+    assert math.isclose(expensive_cost, cheap_cost * 10)
+    assert math.isclose(mixed_cost, expensive_cost)
+
+    config = build_auto_setup_config(
+        snapshot=snapshot,
+        available_model_deployments={"cheap": (cheap,), "expensive": (expensive,), "mixed-price": (cheap, expensive)},
+        quality_level="economy",
+    )
+    assert config.tiers["SIMPLE"] == ["cheap"]
+
+
+@pytest.mark.parametrize(
+    ("mutation", "error"),
+    (
+        ("missing_complexity", "lacks complete quality evidence"),
+        ("identity_mismatch", "model identity mismatch"),
+        ("routability_mismatch", "routability mismatch"),
+        ("quality_mismatch", "quality identity mismatch"),
+    ),
+)
+def test_snapshot_semantic_validation_rejects_inconsistent_artifacts(mutation: str, error: str) -> None:
+    raw = load_auto_router_snapshot().model_dump(mode="json")
+    model_id = "claude-fable-5-1-max-effort"
+    model = raw["models"][model_id]
+    if mutation == "missing_complexity":
+        del model["quality_by_complexity"]["trivial"]
+    elif mutation == "identity_mismatch":
+        model["benchmark_model_id"] = "wrong"
+    elif mutation == "routability_mismatch":
+        model["identity"]["is_routable"] = not model["identity"]["is_routable"]
+    else:
+        model["quality_by_complexity"]["trivial"]["benchmark_model_id"] = "wrong"
+
+    with pytest.raises(ValidationError, match=error):
+        AutoRouterSnapshot.model_validate(raw)
+
+
+def test_auto_setup_result_has_no_runtime_only_configuration() -> None:
+    generated = build_auto_setup_config(
+        snapshot=load_auto_router_snapshot(),
+        available_model_deployments=_available_refs("gpt-5.6-sol"),
+        quality_level="max",
+    )
+    payload = generated.model_dump(mode="json", exclude_none=True)
+
+    assert "auto_setup" not in payload
+    assert payload["adaptive"] is False
+    assert payload["classifier_type"] == "heuristic_v2"
+
+
+@pytest.mark.asyncio
+async def test_generated_single_model_tiers_use_the_existing_router_selection_path() -> None:
+    generated = build_auto_setup_config(
+        snapshot=load_auto_router_snapshot(),
+        available_model_deployments=_available_refs("gpt-5.6-sol", "gpt-5.4-nano"),
+        quality_level="economy",
+    )
+    router_instance = MagicMock()
+    automatic = ComplexityRouter(
+        model_name="auto",
+        litellm_router_instance=router_instance,
+        complexity_router_config=generated.model_dump(mode="json"),
+    )
+    manual = ComplexityRouter(
+        model_name="manual",
+        litellm_router_instance=router_instance,
+        complexity_router_config={"tiers": {"SIMPLE": ["first", "second"]}},
+    )
+
+    assert await automatic._pick_model_for_tier(ComplexityTier.SIMPLE, None, None, {}) == "gpt-5.4-nano"
+    with patch(  # test-quality-ok: pinning random choice is required to prove manual routers retain their existing selection path
+        "litellm.router_strategy.complexity_router.complexity_router.random.choice", return_value="second"
+    ) as pick:
+        assert await manual._pick_model_for_tier(ComplexityTier.SIMPLE, None, None, {}) == "second"
+    pick.assert_called_once_with(["first", "second"])

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/autoRouter/useAutoRouterRecommendation.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/autoRouter/useAutoRouterRecommendation.ts
@@ -1,0 +1,32 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { getAutoRouterRecommendation, type AutoRouterRecommendationResponse } from "@/components/networking";
+import type { AutoSetupQualityLevel } from "@/components/add_model/build_complexity_router_config";
+import { createQueryKeys } from "../common/queryKeysFactory";
+
+const recommendationKeys = createQueryKeys("autoRouterRecommendation");
+
+interface UseAutoRouterRecommendationParams {
+  accessToken: string;
+  qualityLevel: AutoSetupQualityLevel;
+  teamId?: string;
+  enabled: boolean;
+}
+
+export const useAutoRouterRecommendation = ({
+  accessToken,
+  qualityLevel,
+  teamId,
+  enabled,
+}: UseAutoRouterRecommendationParams) => {
+  const filters = { qualityLevel, ...(teamId ? { teamId } : {}) };
+  const queryOptions = {
+    queryKey: recommendationKeys.list({
+      filters,
+    }),
+    queryFn: () => getAutoRouterRecommendation(accessToken, qualityLevel, teamId),
+    enabled: enabled && Boolean(accessToken),
+    staleTime: 30 * 1000,
+  };
+  return useQuery<AutoRouterRecommendationResponse>(queryOptions);
+};

--- a/ui/litellm-dashboard/src/components/add_model/AutoSetupControls.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/AutoSetupControls.tsx
@@ -1,0 +1,130 @@
+import type { AutoRouterRecommendationResponse } from "@/components/networking";
+import { Button } from "@/components/ui/button";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { UiLoadingSpinner } from "@/components/ui/ui-loading-spinner";
+import type { AutoSetupQualityLevel } from "./build_complexity_router_config";
+
+const QUALITY_OPTIONS = [
+  { value: "economy", label: "Economy" },
+  { value: "balanced", label: "Balanced" },
+  { value: "high", label: "High" },
+  { value: "max", label: "Max" },
+];
+
+const QUALITY_DESCRIPTION: Record<AutoSetupQualityLevel, string> = {
+  economy: "Allows models up to 15 points below the smartest available option",
+  balanced: "Keeps models within 7 points of the smartest available option",
+  high: "Keeps models within 3 points of the smartest available option",
+  max: "Keeps models within 1 point of the smartest available option",
+};
+
+interface AutoSetupControlsProps {
+  qualityLevel: AutoSetupQualityLevel;
+  onQualityLevelChange: (value: AutoSetupQualityLevel) => void;
+  recommendation?: AutoRouterRecommendationResponse;
+  recommendationEnabled: boolean;
+  recommendationPending: boolean;
+  recommendationFailed: boolean;
+  recommendationError: unknown;
+  requiresTeamScope: boolean;
+  onRetry: () => void;
+  onBack: () => void;
+}
+
+const recommendationErrorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : "Could not build Auto setup";
+
+const readyMessage = (recommendation: AutoRouterRecommendationResponse): string => {
+  const count = recommendation.matched_model_groups.length;
+  const total = recommendation.available_model_group_count;
+  return `Uses ${count} of ${total} available model${total === 1 ? "" : "s"} across four complexity levels`;
+};
+
+export default function AutoSetupControls({
+  qualityLevel,
+  onQualityLevelChange,
+  recommendation,
+  recommendationEnabled,
+  recommendationPending,
+  recommendationFailed,
+  recommendationError,
+  requiresTeamScope,
+  onRetry,
+  onBack,
+}: AutoSetupControlsProps) {
+  const excludedCount = recommendation?.excluded_model_groups.length ?? 0;
+
+  return (
+    <div className="space-y-4" data-testid="auto-setup-controls">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <div className="font-medium text-foreground">Configure automatically</div>
+          <div className="text-xs text-muted-foreground">
+            Choose the outcome you want. LiteLLM will build the model tiers for you
+          </div>
+          {recommendation && excludedCount > 0 && (
+            <div className="text-xs text-muted-foreground">
+              {excludedCount} model{excludedCount === 1 ? " was" : "s were"} left out because Auto setup could not
+              compare {excludedCount === 1 ? "it" : "them"} safely
+            </div>
+          )}
+        </div>
+        <Button type="button" variant="ghost" className="h-auto shrink-0 px-0" onClick={onBack}>
+          Back
+        </Button>
+      </div>
+      <div>
+        <div>
+          <label className="mb-2 block text-sm font-medium text-foreground">Quality level</label>
+          <Select
+            items={QUALITY_OPTIONS}
+            value={qualityLevel}
+            onValueChange={(value: AutoSetupQualityLevel | null) => value && onQualityLevelChange(value)}
+          >
+            <SelectTrigger data-testid="auto-quality-selector" className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="economy">Economy</SelectItem>
+              <SelectItem value="balanced">Balanced</SelectItem>
+              <SelectItem value="high">High</SelectItem>
+              <SelectItem value="max">Max</SelectItem>
+            </SelectContent>
+          </Select>
+          <div className="mt-1 text-xs text-muted-foreground">
+            {QUALITY_DESCRIPTION[qualityLevel]}. Auto picks the lowest estimated completion cost inside that range, or
+            the smartest option when price is unavailable
+          </div>
+          <div className="mt-1 text-xs text-muted-foreground">
+            Quality uses uncertainty-adjusted public benchmark scores for each complexity level
+          </div>
+        </div>
+      </div>
+      {recommendationPending && recommendation === undefined && (
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <UiLoadingSpinner className="size-3" /> Building your router...
+        </div>
+      )}
+      {!recommendationEnabled && requiresTeamScope && (
+        <div className="text-xs text-muted-foreground">Select a team to build its Auto setup</div>
+      )}
+      {recommendationFailed && recommendation === undefined && (
+        <div className="text-xs text-destructive">
+          {recommendationErrorMessage(recommendationError)}.{" "}
+          <button type="button" className="underline" onClick={onRetry}>
+            Retry
+          </button>
+        </div>
+      )}
+      {recommendation && (
+        <div className="space-y-2 rounded-lg border border-border bg-muted/40 p-3" data-testid="auto-setup-summary">
+          <div className="text-sm font-medium text-foreground">Recommended setup</div>
+          <div className="text-xs text-muted-foreground">
+            {readyMessage(recommendation)}. Each tier is the lowest-cost model with comparable pricing that meets your
+            selected quality level
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
@@ -11,6 +11,7 @@ import { testAutoRouterRouting } from "../networking";
 import { ModelGroup } from "@/components/llm_calls/fetch_models";
 import { AutoRouterPreset, getRequiredModelsInPreset } from "@/lib/autorouter_presets";
 import { BUNDLED_PRESETS, LOADED_PRESETS_QUERY, useAutoRouterPresets } from "../../../tests/mocks/autoRouterPresets";
+import { EMPTY_RECOMMENDATION_QUERY, useAutoRouterRecommendation } from "../../../tests/mocks/autoRouterRecommendation";
 vi.mock(
   "@/app/(dashboard)/hooks/autoRouter/useComplexityScorerDefaults",
   async () => await import("../../../tests/mocks/complexityScorerDefaults"),
@@ -18,6 +19,10 @@ vi.mock(
 vi.mock(
   "@/app/(dashboard)/hooks/autoRouter/useAutoRouterPresets",
   async () => await import("../../../tests/mocks/autoRouterPresets"),
+);
+vi.mock(
+  "@/app/(dashboard)/hooks/autoRouter/useAutoRouterRecommendation",
+  async () => await import("../../../tests/mocks/autoRouterRecommendation"),
 );
 
 const getAllPresets = (): AutoRouterPreset[] => BUNDLED_PRESETS;
@@ -37,7 +42,16 @@ const ALL_FAMILY_MODELS: ModelGroup[] = [
 const ANTHROPIC_ONLY_MODEL = ANTHROPIC_TIERS.COMPLEX[0];
 
 const openTemplateDropdown = (): void => {
+  if (!screen.queryByTestId("template-selector")) {
+    fireEvent.click(screen.getByRole("button", { name: "Back" }));
+  }
   fireEvent.click(screen.getByTestId("template-selector"));
+};
+
+const openAutoSetup = (): void => {
+  if (!screen.queryByTestId("auto-quality-selector")) {
+    fireEvent.click(screen.getByTestId("configure-automatically-button"));
+  }
 };
 
 // Detailed Configuration is collapsed by default, so any test reaching into it (a tier select, an
@@ -141,10 +155,102 @@ describe("AddAutoRouterTab", () => {
     testQueryClient.clear();
     mockFetchAvailableModels.mockResolvedValue([]);
     mockFetchAllModelDeployments.mockResolvedValue([]);
+    vi.mocked(useAutoRouterRecommendation).mockReturnValue(EMPTY_RECOMMENDATION_QUERY);
   });
 
-  // Detailed Configuration starts collapsed so the modal opens onto just Name + Template; a caller
-  // opts into the full tier/classifier form rather than always seeing it up front.
+  it("keeps the manual form and adds Configure automatically above it", () => {
+    renderWithProviders(<Harness />);
+
+    expect(screen.getByTestId("configure-automatically-button")).toBeInTheDocument();
+    expect(screen.getByTestId("template-selector")).toBeInTheDocument();
+    expect(screen.getByTestId("detailed-configuration-toggle")).toBeInTheDocument();
+    expect(screen.queryByTestId("auto-quality-selector")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /add auto router/i })).toBeDisabled();
+    expect(useAutoRouterRecommendation).toHaveBeenCalledWith(expect.objectContaining({ enabled: false }));
+  });
+
+  it("shows the quality choice after Configure automatically is selected", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Harness />);
+
+    await user.click(screen.getByTestId("configure-automatically-button"));
+
+    expect(screen.getByTestId("auto-quality-selector")).toBeInTheDocument();
+    expect(screen.queryByTestId("auto-objective-selector")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("template-selector")).not.toBeInTheDocument();
+    expect(useAutoRouterRecommendation).toHaveBeenCalledWith(
+      expect.objectContaining({ qualityLevel: "balanced", enabled: true }),
+    );
+  });
+
+  it("returns to the original manual form from automatic setup", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Harness />);
+
+    await user.click(screen.getByTestId("configure-automatically-button"));
+    await user.click(screen.getByRole("button", { name: "Back" }));
+
+    expect(screen.getByTestId("template-selector")).toBeInTheDocument();
+    expect(screen.getByTestId("configure-automatically-button")).toBeInTheDocument();
+    expect(screen.queryByTestId("auto-quality-selector")).not.toBeInTheDocument();
+  });
+
+  it("submits the editable static config generated for the caller's available model groups", async () => {
+    const user = userEvent.setup();
+    mockFetchAvailableModels.mockResolvedValue([{ model_group: "smart-group", mode: "chat" }]);
+    const recommendationQuery = {
+      data: {
+        quality_level: "max",
+        snapshot_id: "snapshot-test",
+        snapshot_generated_at: "2026-09-03T00:00:00Z",
+        available_model_group_count: 2,
+        matched_model_groups: ["smart-group"],
+        excluded_model_groups: [{ model_group: "unknown-group", reason: "no_benchmark_match" }],
+        complexity_router_config: {
+          tiers: {
+            SIMPLE: ["smart-group"],
+            MEDIUM: ["smart-group"],
+            COMPLEX: ["smart-group"],
+            REASONING: ["smart-group"],
+          },
+          classifier_type: "heuristic_v2",
+          classification_mode: "per_request",
+          session_affinity: false,
+          deployment_affinity: false,
+          modality_routing: false,
+          modality_pin_override: false,
+        },
+      },
+      isPending: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    };
+    vi.mocked(useAutoRouterRecommendation).mockReturnValue(recommendationQuery);
+
+    renderWithProviders(<Harness />);
+    await user.click(screen.getByTestId("configure-automatically-button"));
+    await screen.findByText(/Uses 1 of 2 available models/);
+    expect(screen.getByText(/1 model was left out because Auto setup could not compare it safely/)).toBeInTheDocument();
+    await user.type(screen.getByPlaceholderText(/smart_router/i), "max-speed-router");
+    await user.click(screen.getByRole("button", { name: /add auto router/i }));
+
+    await waitFor(() => expect(handleAddAutoRouterSubmit).toHaveBeenCalled());
+    const submitted = vi.mocked(handleAddAutoRouterSubmit).mock.calls.at(-1)?.[0].complexity_router_config;
+    expect(submitted).toMatchObject({
+      tiers: {
+        SIMPLE: ["smart-group"],
+        MEDIUM: ["smart-group"],
+        COMPLEX: ["smart-group"],
+        REASONING: ["smart-group"],
+      },
+      classifier_type: "heuristic_v2",
+    });
+    expect(submitted).not.toHaveProperty("auto_setup");
+  });
+
+  // Detailed Configuration starts collapsed after manual setup is selected; a caller opts into the
+  // full tier/classifier form rather than always seeing it up front.
   it("keeps Detailed Configuration collapsed until a caller opens it", () => {
     renderWithProviders(<Harness />);
 
@@ -155,12 +261,28 @@ describe("AddAutoRouterTab", () => {
     expect(screen.getByText("Complexity Tier Configuration")).toBeInTheDocument();
   });
 
-  // Nothing is filled in, so there is nothing to submit. The button reports that itself instead of
-  // accepting a click and answering with a toast.
-  it("offers no submit at all until every tier has a model", async () => {
+  it("offers no submit until every tier has a model", async () => {
     renderWithProviders(<Harness />);
 
     expect(screen.getByRole("button", { name: /add auto router/i })).toBeDisabled();
+  });
+
+  it("blocks an implicit form submit while Auto setup is still building", async () => {
+    vi.mocked(getMissingTiersError).mockReturnValue(null);
+    vi.mocked(useAutoRouterRecommendation).mockReturnValue({
+      ...EMPTY_RECOMMENDATION_QUERY,
+      isPending: true,
+    });
+    renderWithProviders(<Harness />);
+
+    openAutoSetup();
+    fireEvent.change(screen.getByPlaceholderText(/smart_router/i), { target: { value: "early-router" } });
+    fireEvent.submit(screen.getByRole("form", { name: "Add auto router" }));
+
+    await waitFor(() =>
+      expect(toast.fromError).toHaveBeenCalledWith("Building the best setup for your available models"),
+    );
+    expect(handleAddAutoRouterSubmit).not.toHaveBeenCalled();
   });
 
   it("still flags the router name once the config no longer blocks the submit", async () => {
@@ -354,22 +476,20 @@ describe("AddAutoRouterTab", () => {
   });
 
   it("blocks the submit when a team admin has not picked a team", async () => {
-    const user = userEvent.setup();
     vi.mocked(getMissingTiersError).mockReturnValue(null);
 
     renderWithProviders(
       <AddAutoRouterTab handleOk={vi.fn()} accessToken="token" userRole="Internal User" createScope="team-required" />,
     );
 
-    await user.type(screen.getByPlaceholderText(/smart_router/i), "team-scoped-router");
-    await user.click(screen.getByRole("button", { name: /add auto router/i }));
-
-    expect(await screen.findByText("Please select a team to continue")).toBeInTheDocument();
+    openAutoSetup();
+    expect(screen.getByText("Select a team to build its Auto setup")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /add auto router/i })).toBeDisabled();
     expect(handleAddAutoRouterSubmit).not.toHaveBeenCalled();
   });
 
   // The shared dropdown emits null on clear while this form's schema wants a string, so the
-  // form maps null back to "": the user sees the pick-a-team message, not a zod type error.
+  // form maps null back to "": Auto setup returns to its explicit pick-a-team state.
   it("treats a team picked and then cleared like no team at all", async () => {
     const user = userEvent.setup();
     vi.mocked(getMissingTiersError).mockReturnValue(null);
@@ -378,12 +498,12 @@ describe("AddAutoRouterTab", () => {
       <AddAutoRouterTab handleOk={vi.fn()} accessToken="token" userRole="Internal User" createScope="team-required" />,
     );
 
+    openAutoSetup();
     await user.type(screen.getByPlaceholderText(/smart_router/i), "team-scoped-router");
     await user.selectOptions(screen.getByTestId("team-dropdown"), "team-1");
     await user.click(screen.getByTestId("team-dropdown-clear"));
-    await user.click(screen.getByRole("button", { name: /add auto router/i }));
-
-    expect(await screen.findByText("Please select a team to continue")).toBeInTheDocument();
+    expect(screen.getByText("Select a team to build its Auto setup")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /add auto router/i })).toBeDisabled();
     expect(handleAddAutoRouterSubmit).not.toHaveBeenCalled();
   });
 
@@ -755,8 +875,8 @@ describe("AddAutoRouterTab", () => {
 
       renderWithProviders(<Harness />);
 
-      expect(await screen.findByText("Could not load available models.")).toBeInTheDocument();
       openTemplateDropdown();
+      expect(await screen.findByText("Could not load available models.")).toBeInTheDocument();
       const anthropicOption = optionByLabel("Anthropic Family")!;
       expect(isOptionDisabled(anthropicOption)).toBe(true);
       expect(anthropicOption).toHaveTextContent(/Cannot verify these models are available/);
@@ -1232,6 +1352,7 @@ describe("preset catalog fetch states", () => {
     } as never);
     renderWithProviders(<Harness />);
 
+    openTemplateDropdown();
     expect(screen.getByText("Loading templates...")).toBeInTheDocument();
   });
 
@@ -1245,9 +1366,8 @@ describe("preset catalog fetch states", () => {
     } as never);
     renderWithProviders(<Harness />);
 
-    expect(await screen.findByText(/Could not load templates/)).toBeInTheDocument();
-
     openTemplateDropdown();
+    expect(await screen.findByText(/Could not load templates/)).toBeInTheDocument();
     const options = screen.queryAllByRole("option");
     expect(options).toHaveLength(1);
     expect(options[0]).toHaveTextContent("Custom Configuration");

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useWatch } from "react-hook-form";
 import { ChevronDown, ChevronRight } from "lucide-react";
@@ -30,10 +30,12 @@ import ComplexityRouterConfig, {
   DEFAULT_DEPLOYMENT_AFFINITY,
   DEFAULT_TIER_DISTANCE_PENALTY,
 } from "./ComplexityRouterConfig";
+import { getRecommendationBlockedReason, type SetupMode } from "./auto_setup_policy";
 import { KeywordTierRule } from "./KeywordTierRules";
 import { DEFAULT_ESCALATION_KEYWORDS } from "./EscalationKeywords";
 import { DEFAULT_MATCH_THRESHOLD } from "./SemanticKeywordMatching";
 import {
+  AutoSetupQualityLevel,
   BuildComplexityRouterConfigParams,
   buildComplexityRouterConfig,
   getKeywordTierRulesError,
@@ -63,7 +65,9 @@ import {
   AutoRouterPreset,
 } from "@/lib/autorouter_presets";
 import { useAutoRouterPresets } from "@/app/(dashboard)/hooks/autoRouter/useAutoRouterPresets";
+import { useAutoRouterRecommendation } from "@/app/(dashboard)/hooks/autoRouter/useAutoRouterRecommendation";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import AutoSetupControls from "./AutoSetupControls";
 
 interface AddAutoRouterTabProps {
   handleOk: () => void;
@@ -181,6 +185,9 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
   const watchedName = useWatch({ control: form.control, name: "auto_router_name" });
   const watchedTeamId = useWatch({ control: form.control, name: "team_id" });
   const [modelAccessGroups, setModelAccessGroups] = useState<string[]>([]);
+  const [setupMode, setSetupMode] = useState<SetupMode>("manual");
+  const [qualityLevel, setQualityLevel] = useState<AutoSetupQualityLevel>("balanced");
+  const appliedRecommendationKey = useRef<string | null>(null);
 
   const [complexityRouterConfig, setComplexityRouterConfig] = useState<ComplexityRouterConfigValue>({
     tiers: { SIMPLE: [], MEDIUM: [], COMPLEX: [], REASONING: [] },
@@ -267,6 +274,21 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
     [modelInfo],
   );
 
+  const recommendationEnabled = setupMode === "auto" && (!requiresTeamScope || Boolean(watchedTeamId));
+  const recommendationParams = {
+    accessToken,
+    qualityLevel,
+    teamId: requiresTeamScope ? watchedTeamId : undefined,
+    enabled: recommendationEnabled,
+  };
+  const {
+    data: recommendation,
+    isPending: recommendationPending,
+    isError: recommendationFailed,
+    error: recommendationError,
+    refetch: refetchRecommendation,
+  } = useAutoRouterRecommendation(recommendationParams);
+
   // A preset's models can only be trusted against a successfully loaded list. Selection and the
   // greyed-out state derive from this one function, so a preset that cannot be selected can never
   // have been applied: while loading we withhold selection rather than let a caller pick a preset
@@ -302,7 +324,7 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
     [sortedPresetOptions],
   );
 
-  const applyPrefill = (prefill: PresetPrefill) => {
+  const applyPrefill = React.useCallback((prefill: PresetPrefill) => {
     setEditingTiers(false);
     setComplexityRouterConfig(prefill.complexityRouterConfig);
     setCustomTechnicalKeywords(prefill.customTechnicalKeywords);
@@ -311,7 +333,36 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
     setEmbeddingModel(prefill.embeddingModel);
     setMatchThreshold(prefill.matchThreshold);
     setEscalationKeywords(prefill.escalationKeywords);
+  }, []);
+
+  const chooseAutoSetup = () => {
+    appliedRecommendationKey.current = null;
+    setDetailsExpanded(false);
+    setSetupMode("auto");
   };
+
+  const returnToManualSetup = () => {
+    appliedRecommendationKey.current = null;
+    setSelectedPreset(undefined);
+    applyPrefill(buildEmptyPrefill());
+    setDetailsExpanded(false);
+    setSetupMode("manual");
+  };
+
+  useEffect(() => {
+    if (!recommendation || setupMode !== "auto") return;
+    const key = [
+      recommendation.snapshot_id,
+      qualityLevel,
+      watchedTeamId ?? "",
+      ...recommendation.matched_model_groups,
+    ].join(":");
+    if (appliedRecommendationKey.current === key) return;
+    appliedRecommendationKey.current = key;
+    setSelectedPreset(undefined);
+    applyPrefill(buildPresetPrefill(recommendation.complexity_router_config, availability));
+    setDetailsExpanded(false);
+  }, [recommendation, setupMode, qualityLevel, watchedTeamId, availability, applyPrefill]);
 
   const handlePresetChange = (presetKey: string | undefined) => {
     if (!presetKey || presetKey === "custom") {
@@ -342,13 +393,23 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
     defaultModel: complexityRouterConfig.default_model,
   };
 
-  const submitBlockedReason = getSubmitBlockedReason(
-    complexityRouterConfig,
-    keywordTierRules,
-    referencedModelsParams,
-    groupsOnlyAvailability,
-    modelInfo,
-  );
+  const recommendationStatus = {
+    setupMode,
+    recommendationEnabled,
+    recommendationPending,
+    recommendationFailed,
+    hasRecommendation: recommendation !== undefined,
+  };
+  const recommendationBlockedReason = getRecommendationBlockedReason(recommendationStatus);
+  const submitBlockedReason =
+    recommendationBlockedReason ??
+    getSubmitBlockedReason(
+      complexityRouterConfig,
+      keywordTierRules,
+      referencedModelsParams,
+      groupsOnlyAvailability,
+      modelInfo,
+    );
 
   const complexityRouterConfigParams: BuildComplexityRouterConfigParams = {
     tiers: complexityRouterConfig.tiers,
@@ -396,13 +457,15 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
     // disagree about why. The handler needs it in its own right: the form fires this on Enter
     // regardless of the button's disabled state.
     const blockedReason =
+      recommendationBlockedReason ??
       getSubmitBlockedReason(
         complexityRouterConfig,
         keywordTierRules,
         referencedModelsParams,
         groupsOnlyAvailability,
         modelInfo,
-      ) ?? getSemanticConfigError({ semanticMatchingEnabled, embeddingModel, keywordTierRules });
+      ) ??
+      getSemanticConfigError({ semanticMatchingEnabled, embeddingModel, keywordTierRules });
     if (blockedReason) {
       setShowValidationErrors(true);
       toast.fromError(blockedReason);
@@ -498,7 +561,7 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
     <TooltipProvider>
       <Card>
         <CardContent>
-          <form onSubmit={form.handleSubmit(() => handleAutoRouterSubmit())} noValidate>
+          <form aria-label="Add auto router" onSubmit={form.handleSubmit(() => handleAutoRouterSubmit())} noValidate>
             <FieldGroup>
               <FormField
                 control={form.control}
@@ -507,71 +570,6 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
               >
                 {({ ref, ...field }) => <Input {...field} ref={ref} placeholder="e.g., smart_router, auto_router_1" />}
               </FormField>
-
-              <div>
-                <label className="block text-sm font-medium text-foreground mb-2">Template</label>
-                <Select
-                  items={templateItems}
-                  value={selectedPreset ?? null}
-                  onValueChange={(presetKey: string | null) => handlePresetChange(presetKey ?? undefined)}
-                >
-                  <SelectTrigger data-testid="template-selector" className="w-full">
-                    <SelectValue placeholder="Choose a template or select Custom to define your own" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {sortedPresetOptions.map(({ preset, availability: presetState }) => {
-                      const disabledHint = presetDisabledHint(presetState);
-                      const hintClass = isPresetHintAlarming(presetState)
-                        ? "text-destructive"
-                        : "text-muted-foreground";
-                      const matchedHint =
-                        presetState.kind === "available" && presetState.viaDeployments
-                          ? "Matches your deployments"
-                          : null;
-
-                      return (
-                        <SelectItem
-                          key={preset.key}
-                          value={preset.key}
-                          label={preset.label}
-                          disabled={disabledHint !== null}
-                          title={disabledHint ?? preset.description}
-                        >
-                          <div>
-                            <div className="font-medium">{preset.label}</div>
-                            <div className="text-xs text-muted-foreground">{preset.description}</div>
-                            {disabledHint && <div className={`text-xs mt-1 ${hintClass}`}>{disabledHint}</div>}
-                            {matchedHint && <div className="text-xs mt-1 text-success">{matchedHint}</div>}
-                          </div>
-                        </SelectItem>
-                      );
-                    })}
-                    <SelectItem value="custom" label="Custom Configuration">
-                      <div>
-                        <div className="font-medium">Custom Configuration</div>
-                        <div className="text-xs text-muted-foreground">Define your auto router from scratch</div>
-                      </div>
-                    </SelectItem>
-                  </SelectContent>
-                </Select>
-                {modelsUnverifiable && (
-                  <div className="text-xs mt-1 text-destructive">
-                    Could not load available models.{" "}
-                    <button type="button" className="underline" onClick={() => refetchModels()}>
-                      Retry
-                    </button>
-                  </div>
-                )}
-                {presetsPending && <div className="text-xs mt-1 text-muted-foreground">Loading templates...</div>}
-                {presetsUnavailable && (
-                  <div className="text-xs mt-1 text-destructive">
-                    Could not load templates, so only Custom Configuration is shown.{" "}
-                    <button type="button" className="underline" onClick={() => void refetchPresets()}>
-                      Retry
-                    </button>
-                  </div>
-                )}
-              </div>
 
               {requiresTeamScope && (
                 <FormField
@@ -588,6 +586,91 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
                 </FormField>
               )}
 
+              {setupMode === "auto" ? (
+                <AutoSetupControls
+                  qualityLevel={qualityLevel}
+                  onQualityLevelChange={setQualityLevel}
+                  recommendation={recommendation}
+                  recommendationEnabled={recommendationEnabled}
+                  recommendationPending={recommendationPending}
+                  recommendationFailed={recommendationFailed}
+                  recommendationError={recommendationError}
+                  requiresTeamScope={requiresTeamScope}
+                  onRetry={() => void refetchRecommendation()}
+                  onBack={returnToManualSetup}
+                />
+              ) : (
+                <div>
+                  <div className="mb-2 flex items-center justify-between gap-3">
+                    <label className="block text-sm font-medium text-foreground">Template</label>
+                    <Button type="button" data-testid="configure-automatically-button" onClick={chooseAutoSetup}>
+                      Configure automatically
+                    </Button>
+                  </div>
+                  <Select
+                    items={templateItems}
+                    value={selectedPreset ?? null}
+                    onValueChange={(presetKey: string | null) => handlePresetChange(presetKey ?? undefined)}
+                  >
+                    <SelectTrigger data-testid="template-selector" className="w-full">
+                      <SelectValue placeholder="Choose a template or select Custom to define your own" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {sortedPresetOptions.map(({ preset, availability: presetState }) => {
+                        const disabledHint = presetDisabledHint(presetState);
+                        const hintClass = isPresetHintAlarming(presetState)
+                          ? "text-destructive"
+                          : "text-muted-foreground";
+                        const matchedHint =
+                          presetState.kind === "available" && presetState.viaDeployments
+                            ? "Matches your deployments"
+                            : null;
+
+                        return (
+                          <SelectItem
+                            key={preset.key}
+                            value={preset.key}
+                            label={preset.label}
+                            disabled={disabledHint !== null}
+                            title={disabledHint ?? preset.description}
+                          >
+                            <div>
+                              <div className="font-medium">{preset.label}</div>
+                              <div className="text-xs text-muted-foreground">{preset.description}</div>
+                              {disabledHint && <div className={`text-xs mt-1 ${hintClass}`}>{disabledHint}</div>}
+                              {matchedHint && <div className="text-xs mt-1 text-success">{matchedHint}</div>}
+                            </div>
+                          </SelectItem>
+                        );
+                      })}
+                      <SelectItem value="custom" label="Custom Configuration">
+                        <div>
+                          <div className="font-medium">Custom Configuration</div>
+                          <div className="text-xs text-muted-foreground">Define your auto router from scratch</div>
+                        </div>
+                      </SelectItem>
+                    </SelectContent>
+                  </Select>
+                  {modelsUnverifiable && (
+                    <div className="text-xs mt-1 text-destructive">
+                      Could not load available models.{" "}
+                      <button type="button" className="underline" onClick={() => refetchModels()}>
+                        Retry
+                      </button>
+                    </div>
+                  )}
+                  {presetsPending && <div className="text-xs mt-1 text-muted-foreground">Loading templates...</div>}
+                  {presetsUnavailable && (
+                    <div className="text-xs mt-1 text-destructive">
+                      Could not load templates, so only Custom Configuration is shown.{" "}
+                      <button type="button" className="underline" onClick={() => void refetchPresets()}>
+                        Retry
+                      </button>
+                    </div>
+                  )}
+                </div>
+              )}
+
               <div className="border border-border rounded-lg">
                 <button
                   type="button"
@@ -601,11 +684,13 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
                     ) : (
                       <ChevronRight className="size-3 text-muted-foreground" />
                     )}
-                    Detailed Configuration
+                    {setupMode === "auto" ? "Review and edit configuration" : "Detailed Configuration"}
                   </span>
                   {!detailsExpanded && (
                     <span className="text-xs text-muted-foreground line-clamp-2">
-                      {tierConfigSummary(complexityRouterConfig)}
+                      {setupMode === "auto"
+                        ? "View the generated model tiers and routing rules"
+                        : tierConfigSummary(complexityRouterConfig)}
                     </span>
                   )}
                 </button>
@@ -676,27 +761,31 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
                   <TooltipContent>Get help on our github</TooltipContent>
                 </Tooltip>
                 <div className="flex gap-2">
-                  <BlockedReasonTooltip reason={submitBlockedReason}>
+                  {setupMode === "manual" && (
+                    <BlockedReasonTooltip reason={submitBlockedReason}>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        data-testid="auto-router-test-routing-btn"
+                        disabled={submitBlockedReason !== null || isSubmitting}
+                        onClick={() => setIsRoutingTestVisible(true)}
+                      >
+                        Test Routing
+                      </Button>
+                    </BlockedReasonTooltip>
+                  )}
+                  {setupMode === "manual" && (
                     <Button
                       type="button"
                       variant="outline"
-                      data-testid="auto-router-test-routing-btn"
-                      disabled={submitBlockedReason !== null || isSubmitting}
-                      onClick={() => setIsRoutingTestVisible(true)}
+                      data-testid="auto-router-test-connect-btn"
+                      onClick={handleTestConnection}
+                      disabled={isTestingConnection}
                     >
-                      Test Routing
+                      {isTestingConnection && <UiLoadingSpinner className="size-4" />}
+                      Test Connection
                     </Button>
-                  </BlockedReasonTooltip>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    data-testid="auto-router-test-connect-btn"
-                    onClick={handleTestConnection}
-                    disabled={isTestingConnection}
-                  >
-                    {isTestingConnection && <UiLoadingSpinner className="size-4" />}
-                    Test Connection
-                  </Button>
+                  )}
                   <BlockedReasonTooltip reason={submitBlockedReason}>
                     <Button
                       type="button"

--- a/ui/litellm-dashboard/src/components/add_model/auto_setup_policy.ts
+++ b/ui/litellm-dashboard/src/components/add_model/auto_setup_policy.ts
@@ -1,0 +1,25 @@
+export type SetupMode = "auto" | "manual";
+
+export interface RecommendationStatus {
+  setupMode: SetupMode;
+  recommendationEnabled: boolean;
+  recommendationPending: boolean;
+  recommendationFailed: boolean;
+  hasRecommendation: boolean;
+}
+
+export const getRecommendationBlockedReason = ({
+  setupMode,
+  recommendationEnabled,
+  recommendationPending,
+  recommendationFailed,
+  hasRecommendation,
+}: RecommendationStatus): string | null => {
+  if (setupMode !== "auto") return null;
+  if (!recommendationEnabled) return "Select a team so Auto can use that team's available models";
+  if (recommendationPending && !hasRecommendation) return "Building the best setup for your available models";
+  if (recommendationFailed && !hasRecommendation) {
+    return "Auto setup could not build a router for your available models";
+  }
+  return null;
+};

--- a/ui/litellm-dashboard/src/components/add_model/build_complexity_router_config.ts
+++ b/ui/litellm-dashboard/src/components/add_model/build_complexity_router_config.ts
@@ -200,6 +200,8 @@ export interface ComplexityRouterConfigPayload {
   tier_model_configs?: Record<string, { model_name: string; litellm_params: TierModelParams }[]>;
 }
 
+export type AutoSetupQualityLevel = "economy" | "balanced" | "high" | "max";
+
 export const serializeTierLabels = (tierLabels: ComplexityTierLabels | undefined): ComplexityTierLabels | undefined => {
   const renamed = TIER_KEYS.map((tier) => [tier, tierLabels?.[tier]?.trim() ?? ""] as const).filter(
     ([tier, label]) => label !== "" && label !== TIER_DESCRIPTIONS[tier].label,

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -89,7 +89,7 @@ import type {
   CoordinationRedisTestResponse,
 } from "@/app/(dashboard)/caching/_components/coordination_redis_settings/types";
 import { MCP_TOOLS_PREVIEW_FORBIDDEN_MESSAGE } from "./mcp_tools/constants";
-import type { ComplexityRouterConfigPayload } from "./add_model/build_complexity_router_config";
+import type { AutoSetupQualityLevel, ComplexityRouterConfigPayload } from "./add_model/build_complexity_router_config";
 import type { AutoRouterPresetsResponse } from "@/lib/autorouter_presets";
 import type { VectorStoreIndex } from "@/app/(dashboard)/vector-stores/_components/IndexesTab";
 import type { RoutingDecision } from "./view_logs/LogDetailsDrawer/RoutingDecisionCard";
@@ -2416,6 +2416,32 @@ export interface AutoRouterRoutingTestRequest {
   router_name?: string;
   team_id?: string;
 }
+
+export interface AutoRouterRecommendationResponse {
+  quality_level: AutoSetupQualityLevel;
+  snapshot_id: string;
+  snapshot_generated_at: string;
+  available_model_group_count: number;
+  matched_model_groups: string[];
+  excluded_model_groups: Array<{
+    model_group: string;
+    reason: "no_benchmark_match" | "mixed_model_group";
+  }>;
+  complexity_router_config: ComplexityRouterConfigPayload;
+}
+
+export const getAutoRouterRecommendation = async (
+  accessToken: string,
+  qualityLevel: AutoSetupQualityLevel,
+  teamId?: string,
+): Promise<AutoRouterRecommendationResponse> =>
+  await apiClient.get<AutoRouterRecommendationResponse>("/auto_router/recommendation", {
+    accessToken,
+    query: {
+      quality_level: qualityLevel,
+      ...(teamId ? { team_id: teamId } : {}),
+    },
+  });
 
 export interface AutoRouterRoutingTestResult {
   routed_model: string;

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -1225,6 +1225,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/auto_router/recommendation": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Auto Router Recommendation
+         * @description Build an editable four-tier router from only the model groups this caller can use.
+         */
+        get: operations["get_auto_router_recommendation_auto_router_recommendation_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/auto_router/shadow_eval": {
         parameters: {
             query?: never;
@@ -23419,6 +23439,19 @@ export interface components {
             tier_definitions: components["schemas"]["TierDefinition"][];
         };
         /**
+         * AutoRouterExcludedModelGroup
+         * @description A caller-visible reason Auto setup did not use an available model group.
+         */
+        AutoRouterExcludedModelGroup: {
+            /** Model Group */
+            model_group: string;
+            /**
+             * Reason
+             * @enum {string}
+             */
+            reason: "no_benchmark_match" | "mixed_model_group";
+        };
+        /**
          * AutoRouterPresetConfig
          * @description The complexity_router_config a preset prefills.
          *
@@ -23460,6 +23493,31 @@ export interface components {
             REASONING: string[];
             /** Simple */
             SIMPLE: string[];
+        };
+        /**
+         * AutoRouterRecommendationResponse
+         * @description An editable complexity-router config generated from the caller's usable model groups.
+         */
+        AutoRouterRecommendationResponse: {
+            /** Available Model Group Count */
+            available_model_group_count: number;
+            complexity_router_config: components["schemas"]["RequestComplexityRouterConfig"];
+            /**
+             * Excluded Model Groups
+             * @default []
+             */
+            excluded_model_groups: components["schemas"]["AutoRouterExcludedModelGroup"][];
+            /** Matched Model Groups */
+            matched_model_groups: string[];
+            /**
+             * Quality Level
+             * @enum {string}
+             */
+            quality_level: "economy" | "balanced" | "high" | "max";
+            /** Snapshot Generated At */
+            snapshot_generated_at: string;
+            /** Snapshot Id */
+            snapshot_id: string;
         };
         /**
          * AutoRouterRoutingTestRequest
@@ -41141,6 +41199,40 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AutoRouterClassifierDefaultPromptResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_auto_router_recommendation_auto_router_recommendation_get: {
+        parameters: {
+            query?: {
+                /** @description How close every admitted model must be to the best available quality score */
+                quality_level?: "economy" | "balanced" | "high" | "max";
+                /** @description Team whose model access the recommendation must use */
+                team_id?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AutoRouterRecommendationResponse"];
                 };
             };
             /** @description Validation Error */

--- a/ui/litellm-dashboard/tests/mocks/autoRouterRecommendation.ts
+++ b/ui/litellm-dashboard/tests/mocks/autoRouterRecommendation.ts
@@ -1,0 +1,20 @@
+import { vi } from "vitest";
+import type { AutoRouterRecommendationResponse } from "@/components/networking";
+
+interface AutoRouterRecommendationQuery {
+  data: AutoRouterRecommendationResponse | undefined;
+  isPending: boolean;
+  isError: boolean;
+  error: unknown;
+  refetch: ReturnType<typeof vi.fn>;
+}
+
+export const EMPTY_RECOMMENDATION_QUERY: AutoRouterRecommendationQuery = {
+  data: undefined,
+  isPending: false,
+  isError: false,
+  error: null,
+  refetch: vi.fn(),
+};
+
+export const useAutoRouterRecommendation = vi.fn((): AutoRouterRecommendationQuery => EMPTY_RECOMMENDATION_QUERY);


### PR DESCRIPTION
## TLDR

Problem this solves:

- Adding a complexity router requires several manual choices
- Users should be able to get a sensible setup from models they already have access to

How it solves it:

- Adds **Configure automatically** above the existing template/manual form
- Asks for one choice: **Quality level** (Economy, Balanced, High, or Max)
- Builds four editable tiers from model groups already available to the caller
- Returns and saves a normal static `heuristic_v2` config
- Does not add runtime latency learning, a hidden Auto policy, or new request-time behavior

## What "best" means

For each complexity level, LiteLLM finds the best uncertainty-adjusted LiveBench score among the user's available benchmark-matched models. The selected quality level sets the maximum allowed gap from that model:

| Quality level | Maximum gap from best available |
| --- | ---: |
| Economy | 15 percentage points |
| Balanced | 7 percentage points |
| High | 3 percentage points |
| Max | 1 percentage point |

Quality uses the conservative lower bound `mean score - 1.96 * standard error`, floored at zero. The gate is recomputed independently for SIMPLE, MEDIUM, COMPLEX, and REASONING.

Inside the gate, Auto chooses the lowest estimated dollars per completed task. This is not nominal price per token: it reprices the benchmark's observed input/output token mix with each configured deployment's current rates and divides by measured completion probability. Multi-deployment groups use the conservative highest estimate. If none of the admitted models has comparable pricing, Auto chooses the highest conservative quality score instead of failing setup.

This makes Max mean “stay essentially as smart as the best model I can use.” A smaller model can still handle trivial work when its trivial-task quality is within one point of the best available option.

## User flow

1. Open **Models + Endpoints → Auto-Routers → Add Auto Router**
2. Click **Configure automatically** above the existing Template selector
3. Choose **Quality level**
4. Review the generated SIMPLE, MEDIUM, COMPLEX, and REASONING tiers
5. Optionally edit any generated setting, then create the router through the existing flow

Back returns to the unchanged manual/template flow. The automatic view explains the selected quality gap and shows how many configured model groups were used or safely excluded.

## API

`GET /auto_router/recommendation?quality_level=max[&team_id=...]`

The authenticated management endpoint:

- Uses the same admin/team authorization boundary as the existing router dry-run endpoints
- Intersects the snapshot with model groups the caller can actually use
- Fails closed on unknown and mixed-family model groups
- Returns an editable `RequestComplexityRouterConfig` plus snapshot and exclusion metadata
- Does not create or mutate a router

The returned config has one selected model group per tier and `classifier_type: heuristic_v2`. It has no `auto_setup` field, callback, latency cache, response telemetry, or routing metadata additions. After creation it behaves exactly like a manually configured complexity router.

## Data boundary

Benchmark production stays in the internal pipeline; LiteLLM only bundles the reviewed immutable snapshot.

- LiteLLM head: `c6a742baca`
- Internal pipeline: `BerriAI/litellm-auto-router-data-pipeline@57480eb`
- Snapshot schema: `3.0`, scoped to `setup_mode: auto`
- Included evidence: pinned LiveBench quality/completion-cost profiles plus exact LiteLLM model identities
- Explicitly excluded from this PR/artifact: TerminalBench, runtime response latency, task-completion-speed routing, and the Cost/Speed/Balanced objective selector

The preserved latency implementation is being published as a separate draft PR stacked on this branch.

## Validation completed locally

- 723 complexity-router regression tests passed
- 149 management-endpoint tests passed; 15 focused Auto Setup tests passed (164 combined)
- 348 targeted dashboard tests passed with no TypeScript errors
- Dashboard production build passed
- Python Ruff and focused basedpyright checks passed
- Internal pipeline: 15 tests, deterministic rebuild, content-hash validation, and whitespace checks passed
- All 283 routable snapshot aliases exercised across all 4 quality levels (1,132 generated setups)
- Full 279-priceable-alias inventory exercised deterministically across all 4 quality levels
- 100 seeded inventories with up to 30 known models plus unknown groups exercised across all 4 quality levels
- Mixed-family, partially unmatched, ambiguous, custom-priced, multi-deployment, missing-price, and unsupported non-token-pricing cases covered
- Fresh OpenAPI TypeScript definitions generated from the proxy app
- Final diff audited: no runtime-latency hook, objective, policy, callback, telemetry, or metadata changes remain

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The focused backend and dashboard test files pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

### Before

- Add Auto Router exposes template/manual configuration only
- `/auto_router/recommendation` does not exist

### After

- Add Auto Router keeps the existing form and adds **Configure automatically** above Template
- The automatic view asks only for Quality level
- The authenticated recommendation endpoint returns four editable static tiers using only the caller's available model groups
- Back returns to the unchanged manual form

## Type

New Feature

## Caveats / release gates

- This remains a snapshot; new models and evaluations require a reviewed refresh
- LiveBench is one public evaluation family, so the UI describes benchmark-backed quality rather than universal intelligence
- The pinned `new-livebench` results repository has no standalone declared license; confirm redistribution permission or replace that source before release
- Independent product benchmarks should validate tier quality and selection distribution before broad claims

## Final Attestation

- [x] Tests cover the implemented behavior and known inventory/pricing edge cases
- [ ] Required CI is green
- [ ] Independent benchmark results have been reviewed
