### PR TITLE
test(router): drop duplicate get_configured_mode test failing ruff F811

### DIFF
--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -7362,14 +7362,14 @@ def test_get_configured_mode_reads_deployment_model_info():
     router = litellm.Router(
         model_list=[
             {
-                "model_name": "chat-model",
-                "litellm_params": {"model": "openai/some-unmapped-model"},
-                "model_info": {"mode": "chat"},
+                "model_name": "tts-model",
+                "litellm_params": {"model": "openai/some-unmapped-tts-model"},
+                "model_info": {"mode": "audio_speech"},
             }
         ]
     )
 
-    assert router.get_configured_mode("chat-model") == "chat"
+    assert router.get_configured_mode("tts-model") == "audio_speech"
 
 
 def test_get_configured_mode_returns_none_for_unset_or_unknown():

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -12701,33 +12701,3 @@ async def test_prompt_management_factory_marks_injection_for_every_deployment(mo
     bucket = captured.get("litellm_metadata") or captured["metadata"]
     assert captured["model_info"]["id"] == "provisional-dep"
     assert bucket["litellm_gateway_injected_cache"] == ""
-
-
-def test_get_configured_mode_reads_deployment_model_info():
-    router = Router(
-        model_list=[
-            {
-                "model_name": "my-tts",
-                "litellm_params": {"model": "openai/some-unmapped-mode-model"},
-                "model_info": {"mode": "audio_speech"},
-            }
-        ]
-    )
-
-    assert router.get_configured_mode("my-tts") == "audio_speech"
-
-
-@pytest.mark.parametrize("model_info", [{}, {"mode": ""}, {"mode": "   "}, {"mode": 123}])
-def test_get_configured_mode_returns_none_for_unset_blank_or_unknown(model_info):
-    router = Router(
-        model_list=[
-            {
-                "model_name": "plain-model",
-                "litellm_params": {"model": "openai/some-unmapped-mode-model"},
-                "model_info": model_info,
-            }
-        ]
-    )
-
-    assert router.get_configured_mode("plain-model") is None
-    assert router.get_configured_mode("unknown-model") is None


### PR DESCRIPTION
## TLDR

Problem this solves:

- #39630 and #39634 each added `test_get_configured_mode_reads_deployment_model_info`
- The staging tip now defines it twice, so ruff F811 fails the required `lint` check
- Every PR synced past 321636ef5d is blocked from merging

How it solves it:

- Delete the #39630 pair (lines 12706-12733), keep the four #39634 tests
- Read the kept mode test back as `audio_speech`, not `chat`, so a hardcoded `chat` cannot pass
- Six mutations of `get_configured_mode` are all killed by the four survivors

## User Flow

Before: a contributor who syncs their branch with today's staging tip opens a PR and the required `lint` check goes red on a test file they never touched

1. They merge `litellm_internal_staging` (any tip at or after 321636ef5d) into their branch and push
2. They open a PR against `litellm_internal_staging` at https://github.com/BerriAI/litellm/compare/litellm_internal_staging...their-branch
3. The `lint` check on the PR's Checks tab fails with `F811 Redefinition of unused test_get_configured_mode_reads_deployment_model_info from line 7361` at `tests/test_litellm/test_router.py:12706`
4. The merge button stays disabled because `lint` is a required check on the base branch ruleset

After: the same PR's `lint` check passes and the merge button unlocks once reviews land

1. They merge `litellm_internal_staging` (now carrying this fix) into their branch and push
2. They open the same PR against `litellm_internal_staging`
3. The `lint` check on the PR's Checks tab passes with `All checks passed!`
4. The merge button is available as soon as the required reviews are in

## Relevant issues

None

## Linear ticket

Resolves LIT-6913

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests (this PR only deletes a duplicated pair; the surviving four tests are mutation-checked above)
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The command is the exact "Run Ruff linting (test tree)" step of the required `lint` job in `.github/workflows/test-linting.yml`, run from a worktree bootstrapped with `make bootstrap`

### Before (a0958d5c21)

1. `uv run --no-sync ruff check --config ruff-tests.toml tests`
2. Observed:

```
F811 Redefinition of unused `test_get_configured_mode_reads_deployment_model_info` from line 7361
     --> tests/test_litellm/test_router.py:12706:5
help: Remove definition: `test_get_configured_mode_reads_deployment_model_info`
Found 1 error.
exit=1
```

### After (1d71e306cc)

1. `uv run --no-sync ruff check --config ruff-tests.toml tests`
2. Observed:

```
All checks passed!
exit=0
```

3. The same step in CI, the required `lint` check at this tip: https://github.com/BerriAI/litellm/actions/runs/33814011773/job/100841977670 (green)
4. The four surviving tests and the router coverage gate: `uv run --no-sync pytest tests/test_litellm/test_router.py -k get_configured_mode -q` reports `4 passed, 425 deselected`, and `uv run --no-sync python tests/code_coverage_tests/router_code_coverage.py` reports `untested_perc: 0.0`
5. Mutation check: six hand-applied mutations of `Router.get_configured_mode` (return the raw value without the type guard, drop `.strip()`, drop `isinstance`, fall back to wildcard pattern routing, always return `None`, answer `chat` for any non-blank mode), each run against the four surviving tests, all six KILLED with `1 failed, 3 passed`, `router.py` restored clean after each. With the kept read test still using `chat` (the first commit, ea12510f1a) the hardcoded-`chat` mutation survived with `4 passed`, which is why that test now reads back `audio_speech`

## Type

✅ Test

## Caveats (if any)

### Low

- `make check` never runs the test-tree ruff step CI runs, so this class only shows in CI (tracked in LIT-6917)

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 1d71e306cc passes /live-pr-risk
