### PR TITLE
test(proxy-extras): fake run_prisma instead of subprocess.run in the migrate deploy harness

### DIFF
--- a/tests/litellm-proxy-extras/test_litellm_proxy_extras_utils.py
+++ b/tests/litellm-proxy-extras/test_litellm_proxy_extras_utils.py
@@ -763,7 +763,7 @@ class _MigrateDeployHarness:
             "_resolve_specific_migration",
             staticmethod(self.resolved.append),
         )
-        monkeypatch.setattr(utils_module.subprocess, "run", self._fake_run)
+        monkeypatch.setattr(utils_module.prisma_toolchain, "run_prisma", self._fake_run)
         monkeypatch.setattr(utils_module.time, "sleep", lambda seconds: None)
 
         self.baseline_succeeds = True

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -7362,14 +7362,14 @@ def test_get_configured_mode_reads_deployment_model_info():
     router = litellm.Router(
         model_list=[
             {
-                "model_name": "chat-model",
-                "litellm_params": {"model": "openai/some-unmapped-model"},
-                "model_info": {"mode": "chat"},
+                "model_name": "tts-model",
+                "litellm_params": {"model": "openai/some-unmapped-tts-model"},
+                "model_info": {"mode": "audio_speech"},
             }
         ]
     )
 
-    assert router.get_configured_mode("chat-model") == "chat"
+    assert router.get_configured_mode("tts-model") == "audio_speech"
 
 
 def test_get_configured_mode_returns_none_for_unset_or_unknown():

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -12701,33 +12701,3 @@ async def test_prompt_management_factory_marks_injection_for_every_deployment(mo
     bucket = captured.get("litellm_metadata") or captured["metadata"]
     assert captured["model_info"]["id"] == "provisional-dep"
     assert bucket["litellm_gateway_injected_cache"] == ""
-
-
-def test_get_configured_mode_reads_deployment_model_info():
-    router = Router(
-        model_list=[
-            {
-                "model_name": "my-tts",
-                "litellm_params": {"model": "openai/some-unmapped-mode-model"},
-                "model_info": {"mode": "audio_speech"},
-            }
-        ]
-    )
-
-    assert router.get_configured_mode("my-tts") == "audio_speech"
-
-
-@pytest.mark.parametrize("model_info", [{}, {"mode": ""}, {"mode": "   "}, {"mode": 123}])
-def test_get_configured_mode_returns_none_for_unset_blank_or_unknown(model_info):
-    router = Router(
-        model_list=[
-            {
-                "model_name": "plain-model",
-                "litellm_params": {"model": "openai/some-unmapped-mode-model"},
-                "model_info": model_info,
-            }
-        ]
-    )
-
-    assert router.get_configured_mode("plain-model") is None
-    assert router.get_configured_mode("unknown-model") is None


### PR DESCRIPTION
## TLDR

Problem this solves:

- `TestMigrateDeployAttemptAccounting` (5 tests) fails at `litellm_internal_staging` HEAD
- Its harness fakes `subprocess.run`, but `run_prisma` moved to `subprocess.Popen` in #39466
- The fake is never hit, so the tests shell out to the real `prisma` CLI
- The `proxy-extras` shard of `test-unit.yml` has been red on staging since that merge

How it solves it:

- Point the harness at `prisma_toolchain.run_prisma`, the seam the newer tests already fake
- One line changed, every existing assertion left as is

## User Flow

Before: a contributor checks the unit test workflow on `litellm_internal_staging` and finds the proxy-extras shard red

1. They open https://github.com/BerriAI/litellm/actions/runs/33813384975 (staging HEAD `a5b3bc887a`) and see `proxy-extras / Run tests` as the only failing job
2. The job log lists 4 `TestMigrateDeployAttemptAccounting` failures with `Database migration failed and cannot be auto-recovered` and `assert 0 == 4`, because the real Prisma CLI ran against no database
3. Running the same file on a laptop without `prisma` on PATH fails all 5 with `FileNotFoundError: 'prisma'`

After: the same shard is green again

1. They open the unit test workflow run for this PR and see `proxy-extras / Run tests` pass
2. The job log shows all 5 `TestMigrateDeployAttemptAccounting` tests passing without spawning Prisma
3. Running the file on a laptop passes with or without `prisma` on PATH

## Relevant issues

Follow-up to #39466

Carries #39659 so the test-tree ruff check passes: staging has had a duplicate `test_get_configured_mode_reads_deployment_model_info` in `tests/test_litellm/test_router.py` (F811) since #39630 and #39634 both merged on 2026-09-03, and that PR removes it. Once #39659 lands, this PR's diff collapses back to the one harness line

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

This PR only changes a test harness, so the proof is the test run itself plus the CI shard. There is no proxy behavior to curl

Why the shard was red on staging, not silently green: `.github/workflows/test-unit.yml` runs `tests/litellm-proxy-extras` as the `proxy-extras` shard with no allow-list and no xfail. It was green at `f7691a3d85` (run 33808859083, the merge right before #39466) and failed at `c053fac7b7` (run 33808864253, the #39466 merge) and on every staging push since. Only 4 of the 5 fail there because the CI runner has `prisma` on PATH, so the fifth test, `test_repeated_recovery_of_one_migration_still_gives_up`, passes by accident: the real CLI fails against no database, which satisfies its `pytest.raises(RuntimeError)` and its `<=` bound on zero deploy calls

### Before (a5b3bc887a)

1. `PYTHONPATH=$PWD:$PWD/litellm-proxy-extras python -m pytest tests/litellm-proxy-extras/test_litellm_proxy_extras_utils.py -k TestMigrateDeployAttemptAccounting -q`
2. Output: `5 failed, 52 deselected`, each with `FileNotFoundError: [Errno 2] No such file or directory: 'prisma'` raised from `subprocess.Popen`

### After (c550641d44)

1. Same command
2. Output: `5 passed, 52 deselected`
3. `PYTHONPATH=$PWD:$PWD/litellm-proxy-extras python -m pytest tests/litellm-proxy-extras -q` gives `57 passed`
4. `ruff check --config ruff-tests.toml tests` gives `All checks passed!`, where the merge base fails with the F811 above

## Type

✅ Test

## Caveats (if any)

### Low

- `test_repeated_recovery_of_one_migration_still_gives_up` still passes when the fake is bypassed; its bound is `<=` and zero deploy calls satisfies it. Left as is to keep this PR to the seam fix
- The file is already not `ruff format` clean on staging. Left as is so the diff stays one line
- The two `test(router)` commits and the merge commit come from #39659, not this PR. If #39659 changes before it merges, this branch needs a fresh merge of it

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
