### PR TITLE
test(proxy-extras): repoint the migrate-deploy harness at the run_prisma seam

### DIFF
--- a/tests/litellm-proxy-extras/test_litellm_proxy_extras_utils.py
+++ b/tests/litellm-proxy-extras/test_litellm_proxy_extras_utils.py
@@ -763,7 +763,7 @@ class _MigrateDeployHarness:
             "_resolve_specific_migration",
             staticmethod(self.resolved.append),
         )
-        monkeypatch.setattr(utils_module.subprocess, "run", self._fake_run)
+        monkeypatch.setattr(utils_module.prisma_toolchain, "run_prisma", self._fake_run)
         monkeypatch.setattr(utils_module.time, "sleep", lambda seconds: None)
 
         self.baseline_succeeds = True


### PR DESCRIPTION
## TLDR

Problem this solves:

- proxy-extras / Run tests has been red on litellm_internal_staging since #39466
- Four TestMigrateDeployAttemptAccounting tests fail on every PR and staging commit
- The harness fakes the old subprocess.run seam, so the real prisma CLI escapes it

How it solves it:

- Repoints the harness at prisma_toolchain.run_prisma, the seam #39466 moved deploy to
- Same one-line change #39466 itself applied to the file's two other test classes

## User Flow

Before: every contributor's PR shows a red proxy-extras check they did not cause

1. A contributor opens any PR against litellm_internal_staging and waits for checks
2. proxy-extras / Run tests fails: 4 TestMigrateDeployAttemptAccounting tests error with "Could not find a schema.prisma file" from a real `prisma migrate deploy` the test never meant to run
3. The same failure shows on staging's own commits, so re-running never helps and the contributor cannot tell whether their change is safe

After: the check is green again and only fails for real regressions

1. A contributor opens any PR against litellm_internal_staging and waits for checks
2. proxy-extras / Run tests passes; the four accounting tests exercise the scripted deploy outcomes in milliseconds, with no real prisma process spawned

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

Root cause: #39466 moved every prisma invocation in `_setup_database_v2` from `subprocess.run` to the new `prisma_toolchain.run_prisma` process-group wrapper, and updated `TestResolveAllMigrationsLedger` and `TestPartitionedSpendLogsPushGuard` to patch the new seam, but `_MigrateDeployHarness` still patches `utils_module.subprocess.run`. Its scripted deploy outcomes are never consulted, a real `prisma migrate deploy` runs against the harness's empty tmp dir, and the tests fail on the resulting "Could not find a schema.prisma file" error (or hang for minutes wherever the CLI can bootstrap)

### Before (a53c550951, staging tip)

1. CI on staging's own commits, e.g. https://github.com/BerriAI/litellm/commit/942a46ffd7 -> proxy-extras / Run tests: the four TestMigrateDeployAttemptAccounting tests fail with `RuntimeError: Database migration failed and cannot be auto-recovered`, stderr showing `Error: Could not find a schema.prisma file that is required for this command.` and `deploy_calls == []` proving the fake was never invoked
2. Locally at the same commit, `pytest "tests/litellm-proxy-extras/test_litellm_proxy_extras_utils.py::TestMigrateDeployAttemptAccounting"` spawns real prisma processes and ran past a 10 minute timeout before being killed

### After (this PR's tip)

1. `pytest tests/litellm-proxy-extras/test_litellm_proxy_extras_utils.py -q` -> `57 passed in 5.83s`, no prisma process spawned
2. proxy-extras / Run tests on this PR's checks goes green

## Type

✅ Test

## Caveats (if any)

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
