### PR TITLE
test(e2e): match the Internal Users search placeholder shipped by #39604

### DIFF
--- a/tests/e2e/ui/tests/users/searchUsers.spec.ts
+++ b/tests/e2e/ui/tests/users/searchUsers.spec.ts
@@ -17,7 +17,7 @@ test.describe("Internal Users Search", () => {
   test("narrows the table to the matching email, and restores it when cleared", async ({ page }) => {
     await goToInternalUsers(page);
 
-    const search = page.getByPlaceholder("Search by email…");
+    const search = page.getByPlaceholder("Search by email or ID…");
     await expect(search).toBeVisible();
 
     await search.fill("noteam@");


### PR DESCRIPTION
## TLDR

Problem this solves:

- `ci/circleci: e2e_ui_testing` is red on every branch since #39604
- searchUsers.spec still looks for the old `Search by email…` placeholder
- The Internal Users search box now reads `Search by email or ID…`

How it solves it:

- Point the spec's locator at the placeholder the dashboard ships
- Nothing else changes: same user flow, same assertions

## User Flow

Before: a contributor opens a PR and gets a red e2e_ui_testing they did nothing to cause

1. They push a branch off litellm_internal_staging and open a PR at https://github.com/BerriAI/litellm/pulls, with or without UI changes
2. CircleCI starts `e2e_ui_testing` on it, and the job page at https://app.circleci.com/pipelines/github/BerriAI/litellm shows `Internal Users Search › narrows the table to the matching email, and restores it when cleared` failing all three attempts with `expect(locator).toBeVisible() failed: element(s) not found` for `getByPlaceholder('Search by email…')`
3. The PR's checks list shows `ci/circleci: e2e_ui_testing` as failed, and they have to explain to the reviewer that the red is unrelated before handing off

After: the same PR gets a green e2e_ui_testing

1. They push a branch off litellm_internal_staging and open a PR at https://github.com/BerriAI/litellm/pulls, with or without UI changes
2. CircleCI starts `e2e_ui_testing` on it, and the job page shows the Internal Users Search spec typing `noteam@` into the box that reads `Search by email or ID…`, seeing one `noteam@test.local` row, then seeing `admin@test.local` again once the box is cleared, and the job finishes green
3. The PR's checks list shows `ci/circleci: e2e_ui_testing` as passed, and they hand off with nothing to explain

## Relevant issues

## Linear ticket

Resolves LIT-6919

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Stack: the `tests/e2e/ui/run_e2e.sh` steps kept alive on random ports (docker postgres:16 on :34602, a fresh `npm run build` of the dashboard copied into the proxy's static UI dir, prisma db push, the mock LLM on :50560, the proxy on :22604 with `tests/e2e/ui/fixtures/config.yml`, `fixtures/seed.sql`). The dashboard build is the same on both sides because this PR only touches the spec, so the two runs differ only in the spec file, exactly as CI would see it

### Before (ab0478f068)

1. `cd tests/e2e/ui && E2E_UI_BASE_URL=http://127.0.0.1:22604 npx playwright test --config playwright.config.ts tests/users/searchUsers.spec.ts --reporter=list`
2. Output:

```
Running 3 tests using 3 workers

  ✓  1 [chromium] › tests/users/searchUsers.spec.ts:31:7 › Internal Users Search › filters the table down to one user by user ID (1.7s)
  ✓  2 [chromium] › tests/users/searchUsers.spec.ts:42:7 › Internal Users Search › shows no users when the SSO ID matches nobody (3.2s)
  ✘  3 [chromium] › tests/users/searchUsers.spec.ts:17:7 › Internal Users Search › narrows the table to the matching email, and restores it when cleared (11.2s)


  1) [chromium] › tests/users/searchUsers.spec.ts:17:7 › Internal Users Search › narrows the table to the matching email, and restores it when cleared

    Error: expect(locator).toBeVisible() failed

    Locator: getByPlaceholder('Search by email…')
    Expected: visible
    Timeout: 10000ms
    Error: element(s) not found

    Call log:
      - Expect "toBeVisible" with timeout 10000ms
      - waiting for getByPlaceholder('Search by email…')


      19 |
      20 |     const search = page.getByPlaceholder("Search by email…");
    > 21 |     await expect(search).toBeVisible();
         |                          ^
      22 |
      23 |     await search.fill("noteam@");
      24 |     await expect(userRows(page)).toHaveCount(1, { timeout: 30_000 });
        at /Users/mateo/Development/litellm-wt-lit-6919/tests/e2e/ui/tests/users/searchUsers.spec.ts:21:26


  1 failed
    [chromium] › tests/users/searchUsers.spec.ts:17:7 › Internal Users Search › narrows the table to the matching email, and restores it when cleared
  2 passed (15.4s)
exit=1
```

### After (c1a607f90f)

1. `cd tests/e2e/ui && E2E_UI_BASE_URL=http://127.0.0.1:22604 npx playwright test --config playwright.config.ts tests/users/searchUsers.spec.ts --reporter=list`
2. Output:

```
Running 3 tests using 3 workers

  ✓  3 [chromium] › tests/users/searchUsers.spec.ts:42:7 › Internal Users Search › shows no users when the SSO ID matches nobody (1.2s)
  ✓  2 [chromium] › tests/users/searchUsers.spec.ts:31:7 › Internal Users Search › filters the table down to one user by user ID (1.8s)
  ✓  1 [chromium] › tests/users/searchUsers.spec.ts:17:7 › Internal Users Search › narrows the table to the matching email, and restores it when cleared (2.1s)

  3 passed (5.9s)
```

3. `ci/circleci: e2e_ui_testing` on this PR passed at c1a607f90f: https://app.circleci.com/workflow/eada98dd-4c37-4617-a058-64d89d271ec4/job/c239353c-da17-4f25-8842-0f2e4ed89d15

## Type

✅ Test

## Caveats (if any)

### Low

- The locator still pins the placeholder copy, so the next wording change must update this spec too, same as the dashboard unit test does. Left as is because the alternatives are worse: a looser `/Search by email/` regex would also match the member search modal's `Search by email` box, a `data-testid` locator breaks the suite's user-observable locator rule, and the dashboard unit test pins the same copy, so a wording change already fails in the PR that makes it

## QA runbook

- tests/e2e/ui/tests/users/searchUsers.spec.ts › Internal Users Search › narrows the table to the matching email, and restores it when cleared - typing part of an email into the Internal Users search box narrows the table to that user, and clearing it brings everyone back
  - [ ] Bring the UI e2e stack up with `E2E_KEEP_ALIVE=1 tests/e2e/ui/run_e2e.sh` (seeds admin@test.local and noteam@test.local, among others)
  - [ ] Open http://localhost:4000/ui/?page=users and log in with `sk-1234`; the search box above the table reads `Search by email or ID…`
  - [ ] Type `noteam@` into it and expect the table to shrink to the single `noteam@test.local` row
  - [ ] Clear the box and expect the `admin@test.local` row to come back
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] c1a607f90f passes /live-pr-risk
