### PR TITLE
fix(ui): scroll admin table rows inside the table instead of the page

### DIFF
--- a/tests/e2e/ui/tests/tables/tableScrolling.spec.ts
+++ b/tests/e2e/ui/tests/tables/tableScrolling.spec.ts
@@ -1,0 +1,239 @@
+import { test, expect, type APIRequestContext, type Locator, type Page as PlaywrightPage } from "@playwright/test";
+import { ADMIN_STORAGE_PATH } from "../../constants";
+import { Page } from "../../fixtures/pages";
+import { navigateToPage } from "../../helpers/navigation";
+import { CHAT_MODEL_A, masterKey, sendChatCompletion, waitForSpendLog } from "../../helpers/traffic";
+
+/**
+ * LIT-4738 table scrolling. On the paginated pages the app shell <main> is the only page scroller
+ * and must never overflow: rows scroll inside the table body under a header that stays put, and the
+ * pagination footer sits at the bottom of the page instead of below the fold or inside a clipped
+ * box. Pages that keep plain page scrolling must never paint rows past a fixed-height ancestor.
+ * The viewport is pinned so "more rows than fit" means the same thing on every machine.
+ */
+
+const VIEWPORT = { width: 1280, height: 720 };
+const SEED_ROWS = 40;
+const LOG_ROWS = 20;
+const BODY_SCROLL_PX = 500;
+/** p-8 on Keys and Teams, p-6 on Logs: the footer may sit at most one page padding above the edge. */
+const MAX_FOOTER_GAP_PX = 40;
+
+const uniqueSuffix = (): string => `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+const adminHeaders = (): Record<string, string> => ({
+  Authorization: `Bearer ${masterKey()}`,
+});
+
+/** Keys and Teams render a <main> of their own inside the app shell's, which comes first in document order. */
+const pageScroller = (page: PlaywrightPage): Locator => page.locator("main").first();
+
+/** Tabs keep every panel mounted, so a bare test id can match a hidden table; scope to the visible one. */
+const visibleTestId = (page: PlaywrightPage, id: string): Locator => page.getByTestId(id).filter({ visible: true });
+
+/** The page's data table; Model Hub also renders a plain links table above it, which this skips. */
+const visibleDataTable = (page: PlaywrightPage): Locator => visibleTestId(page, "data-table-root").first();
+
+const visibleRows = (page: PlaywrightPage): Locator => visibleDataTable(page).locator("tbody tr");
+
+interface BoxMetrics {
+  top: number;
+  bottom: number;
+  scrollHeight: number;
+  clientHeight: number;
+  scrollWidth: number;
+  clientWidth: number;
+}
+
+const metrics = (locator: Locator): Promise<BoxMetrics> =>
+  locator.evaluate((el) => {
+    const rect = el.getBoundingClientRect();
+    return {
+      top: rect.top,
+      bottom: rect.bottom,
+      scrollHeight: el.scrollHeight,
+      clientHeight: el.clientHeight,
+      scrollWidth: el.scrollWidth,
+      clientWidth: el.clientWidth,
+    };
+  });
+
+async function postOk(
+  request: APIRequestContext,
+  path: string,
+  data: Record<string, unknown>,
+): Promise<Record<string, any>> {
+  const res = await request.post(path, { headers: adminHeaders(), data });
+  expect(res.ok(), `POST ${path} failed (${res.status()}): ${await res.text()}`).toBe(true);
+  return (await res.json()) as Record<string, any>;
+}
+
+/** One request at a time: a burst of forty management calls starves the proxy's transaction pool. */
+async function oneAtATime<T>(count: number, call: (index: number) => Promise<T>): Promise<T[]> {
+  const results: T[] = [];
+  for (let i = 0; i < count; i++) {
+    results.push(await call(i));
+  }
+  return results;
+}
+
+async function expectRowsAtLeast(page: PlaywrightPage, count: number): Promise<void> {
+  await expect.poll(() => visibleRows(page).count(), { timeout: 30_000 }).toBeGreaterThanOrEqual(count);
+}
+
+async function setRowsPerPage(page: PlaywrightPage, size: "25" | "50" | "100"): Promise<void> {
+  await visibleTestId(page, "pagination-page-size").click();
+  await page.getByRole("option", { name: size, exact: true }).click();
+}
+
+/**
+ * The page scroller stays put, the table body is what scrolls, the header does not move while the
+ * body scrolls, and the pagination footer sits at the bottom of the page.
+ */
+async function expectBodyIsTheOnlyScroller(page: PlaywrightPage): Promise<void> {
+  const scroller = await metrics(pageScroller(page));
+  const body = visibleTestId(page, "data-table-scroller");
+  const bodyBefore = await metrics(body);
+  const headBefore = await metrics(visibleTestId(page, "data-table-head"));
+  const footer = await metrics(visibleDataTable(page));
+
+  expect(scroller.scrollHeight, "page scroller must not overflow vertically").toBe(scroller.clientHeight);
+  expect(scroller.scrollWidth, "page scroller must not overflow horizontally").toBe(scroller.clientWidth);
+  expect(bodyBefore.scrollHeight, "table body must be the element that scrolls").toBeGreaterThan(
+    bodyBefore.clientHeight,
+  );
+  expect(footer.bottom, "pagination footer must be inside the page").toBeLessThanOrEqual(scroller.bottom);
+  expect(scroller.bottom - footer.bottom, "pagination footer must sit at the bottom of the page").toBeLessThanOrEqual(
+    MAX_FOOTER_GAP_PX,
+  );
+
+  await body.evaluate((el, px) => {
+    el.scrollTop = px;
+  }, BODY_SCROLL_PX);
+  await expect.poll(() => body.evaluate((el) => el.scrollTop)).toBeGreaterThan(0);
+  const headAfter = await metrics(visibleTestId(page, "data-table-head"));
+  expect(Math.round(headAfter.top), "header must stay put while the body scrolls").toBe(Math.round(headBefore.top));
+}
+
+/**
+ * Every row must sit inside each ancestor up to the nearest one that really scrolls vertically; a
+ * fixed-height box that neither grows nor scrolls lets rows paint past its bottom edge.
+ */
+const rowsPaintingPastAnAncestor = (page: PlaywrightPage): Promise<string[]> =>
+  visibleDataTable(page)
+    .locator("table")
+    .evaluate((table) => {
+      const scrollsVertically = (el: Element): boolean =>
+        /auto|scroll/.test(getComputedStyle(el).overflowY) && el.scrollHeight > el.clientHeight + 1;
+      const describe = (el: Element): string =>
+        `<${el.tagName.toLowerCase()} class="${el.getAttribute("class") ?? ""}">`;
+      return Array.from(table.querySelectorAll("tbody tr")).flatMap((row, index) => {
+        const rowBottom = row.getBoundingClientRect().bottom;
+        const spills: string[] = [];
+        for (let el = row.parentElement; el && el !== document.body && !scrollsVertically(el); el = el.parentElement) {
+          const bottom = el.getBoundingClientRect().bottom;
+          if (rowBottom > bottom + 1) {
+            spills.push(
+              `row ${index} bottom ${Math.round(rowBottom)} past ${describe(el)} bottom ${Math.round(bottom)}`,
+            );
+          }
+        }
+        return spills;
+      });
+    });
+
+type Cleanup = (request: APIRequestContext) => Promise<unknown>;
+const cleanups: Cleanup[] = [];
+
+test.describe("Admin tables scroll inside the page", () => {
+  test.use({ storageState: ADMIN_STORAGE_PATH, viewport: VIEWPORT });
+
+  test.afterEach(async ({ request }) => {
+    for (const cleanup of cleanups.splice(0)) {
+      // Teardown must never turn a passing test red or mask a real failure.
+      await cleanup(request).catch(() => {});
+    }
+  });
+
+  test("Virtual Keys: rows scroll under a sticky header and the page itself never scrolls", async ({
+    page,
+    request,
+  }) => {
+    const suffix = uniqueSuffix();
+    const created = await oneAtATime(SEED_ROWS, (i) =>
+      postOk(request, "/key/generate", { key_alias: `e2e-scroll-key-${suffix}-${i}` }),
+    );
+    cleanups.push((r) => r.post("/key/delete", { headers: adminHeaders(), data: { keys: created.map((k) => k.key) } }));
+
+    await navigateToPage(page, Page.ApiKeys);
+    await expectRowsAtLeast(page, SEED_ROWS);
+    await expectBodyIsTheOnlyScroller(page);
+  });
+
+  test("Teams: rows scroll under a sticky header and the page itself never scrolls", async ({ page, request }) => {
+    const suffix = uniqueSuffix();
+    const created = await oneAtATime(SEED_ROWS, (i) =>
+      postOk(request, "/team/new", { team_alias: `e2e-scroll-team-${suffix}-${i}` }),
+    );
+    cleanups.push((r) =>
+      r.post("/team/delete", { headers: adminHeaders(), data: { team_ids: created.map((t) => t.team_id) } }),
+    );
+
+    await navigateToPage(page, Page.Teams);
+    await expectRowsAtLeast(page, SEED_ROWS);
+    await expectBodyIsTheOnlyScroller(page);
+  });
+
+  test("Request Logs: rows scroll under a sticky header and the page itself never scrolls", async ({
+    page,
+    request,
+  }) => {
+    const suffix = uniqueSuffix();
+    const ids = await oneAtATime(LOG_ROWS, (i) =>
+      sendChatCompletion(request, { model: CHAT_MODEL_A, prompt: `scroll ${suffix} ${i}` }),
+    );
+    await waitForSpendLog(request, ids[ids.length - 1]);
+
+    await navigateToPage(page, Page.Logs);
+    await expect(visibleTestId(page, "datatable-search")).toBeVisible({ timeout: 20_000 });
+    await setRowsPerPage(page, "25");
+    await expectRowsAtLeast(page, LOG_ROWS);
+    await expectBodyIsTheOnlyScroller(page);
+  });
+
+  test("Tags: no row paints past the box it lives in", async ({ page, request }) => {
+    const suffix = uniqueSuffix();
+    const names = Array.from({ length: SEED_ROWS }, (_, i) => `e2e-scroll-tag-${suffix}-${i}`);
+    await oneAtATime(SEED_ROWS, (i) => postOk(request, "/tag/new", { name: names[i], description: "LIT-4738 scroll" }));
+    cleanups.push((r) =>
+      oneAtATime(SEED_ROWS, (i) => r.post("/tag/delete", { headers: adminHeaders(), data: { name: names[i] } })),
+    );
+
+    await navigateToPage(page, Page.TagManagement);
+    await expectRowsAtLeast(page, SEED_ROWS);
+    expect(await rowsPaintingPastAnAncestor(page)).toEqual([]);
+  });
+
+  test("Model Hub: no row paints past the box it lives in", async ({ page, request }) => {
+    const suffix = uniqueSuffix();
+    const created = await oneAtATime(SEED_ROWS, (i) =>
+      postOk(request, "/model/new", {
+        model_name: `e2e-scroll-model-${suffix}-${i}`,
+        litellm_params: {
+          model: "openai/fake-gpt-4",
+          api_base: `http://127.0.0.1:${process.env.MOCK_LLM_PORT ?? "8090"}/v1`,
+          api_key: "fake-key",
+        },
+      }),
+    );
+    cleanups.push((r) =>
+      oneAtATime(SEED_ROWS, (i) =>
+        r.post("/model/delete", { headers: adminHeaders(), data: { id: created[i].model_info.id } }),
+      ),
+    );
+
+    await navigateToPage(page, Page.ModelHubTable);
+    await expectRowsAtLeast(page, SEED_ROWS);
+    expect(await rowsPaintingPastAnAncestor(page)).toEqual([]);
+  });
+});

--- a/tests/e2e/ui/tests/tables/tableScrolling.spec.ts
+++ b/tests/e2e/ui/tests/tables/tableScrolling.spec.ts
@@ -4,37 +4,23 @@ import { Page } from "../../fixtures/pages";
 import { navigateToPage } from "../../helpers/navigation";
 import { CHAT_MODEL_A, masterKey, sendChatCompletion, waitForSpendLog } from "../../helpers/traffic";
 
-/**
- * LIT-4738 table scrolling. On the paginated pages the app shell <main> is the only page scroller
- * and must never overflow: rows scroll inside the table body under a header that stays put, and the
- * pagination footer sits at the bottom of the page instead of below the fold or inside a clipped
- * box. Pages that keep plain page scrolling must never paint rows past a fixed-height ancestor.
- * The viewport is pinned so "more rows than fit" means the same thing on every machine.
- */
-
 const VIEWPORT = { width: 1280, height: 720 };
 const SEED_ROWS = 40;
 const LOG_ROWS = 20;
 const BODY_SCROLL_PX = 500;
-/** p-8 on Keys and Teams, p-6 on Logs: the footer may sit at most one page padding above the edge. */
 const MAX_FOOTER_GAP_PX = 40;
 
-const uniqueSuffix = (): string => `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+interface GeneratedKey {
+  key: string;
+}
 
-const adminHeaders = (): Record<string, string> => ({
-  Authorization: `Bearer ${masterKey()}`,
-});
+interface CreatedTeam {
+  team_id: string;
+}
 
-/** Keys and Teams render a <main> of their own inside the app shell's, which comes first in document order. */
-const pageScroller = (page: PlaywrightPage): Locator => page.locator("main").first();
-
-/** Tabs keep every panel mounted, so a bare test id can match a hidden table; scope to the visible one. */
-const visibleTestId = (page: PlaywrightPage, id: string): Locator => page.getByTestId(id).filter({ visible: true });
-
-/** The page's data table; Model Hub also renders a plain links table above it, which this skips. */
-const visibleDataTable = (page: PlaywrightPage): Locator => visibleTestId(page, "data-table-root").first();
-
-const visibleRows = (page: PlaywrightPage): Locator => visibleDataTable(page).locator("tbody tr");
+interface CreatedModel {
+  model_info: { id: string };
+}
 
 interface BoxMetrics {
   top: number;
@@ -44,6 +30,18 @@ interface BoxMetrics {
   scrollWidth: number;
   clientWidth: number;
 }
+
+const uniqueSuffix = (): string => `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+const adminHeaders = (): Record<string, string> => ({ Authorization: `Bearer ${masterKey()}` });
+
+const appShellMain = (page: PlaywrightPage): Locator => page.locator("main").first();
+
+const visibleTestId = (page: PlaywrightPage, id: string): Locator => page.getByTestId(id).filter({ visible: true });
+
+const visibleDataTable = (page: PlaywrightPage): Locator => visibleTestId(page, "data-table-root").first();
+
+const visibleRows = (page: PlaywrightPage): Locator => visibleDataTable(page).locator("tbody tr");
 
 const metrics = (locator: Locator): Promise<BoxMetrics> =>
   locator.evaluate((el) => {
@@ -58,24 +56,17 @@ const metrics = (locator: Locator): Promise<BoxMetrics> =>
     };
   });
 
-async function postOk(
-  request: APIRequestContext,
-  path: string,
-  data: Record<string, unknown>,
-): Promise<Record<string, any>> {
+async function postOk<T>(request: APIRequestContext, path: string, data: Record<string, unknown>): Promise<T> {
   const res = await request.post(path, { headers: adminHeaders(), data });
   expect(res.ok(), `POST ${path} failed (${res.status()}): ${await res.text()}`).toBe(true);
-  return (await res.json()) as Record<string, any>;
+  return (await res.json()) as T;
 }
 
-/** One request at a time: a burst of forty management calls starves the proxy's transaction pool. */
-async function oneAtATime<T>(count: number, call: (index: number) => Promise<T>): Promise<T[]> {
-  const results: T[] = [];
-  for (let i = 0; i < count; i++) {
-    results.push(await call(i));
-  }
-  return results;
-}
+const oneAtATime = <T>(count: number, call: (index: number) => Promise<T>): Promise<readonly T[]> =>
+  Array.from({ length: count }, (_, i) => i).reduce<Promise<readonly T[]>>(
+    async (previous, i) => [...(await previous), await call(i)],
+    Promise.resolve([]),
+  );
 
 async function expectRowsAtLeast(page: PlaywrightPage, count: number): Promise<void> {
   await expect.poll(() => visibleRows(page).count(), { timeout: 30_000 }).toBeGreaterThanOrEqual(count);
@@ -86,12 +77,8 @@ async function setRowsPerPage(page: PlaywrightPage, size: "25" | "50" | "100"): 
   await page.getByRole("option", { name: size, exact: true }).click();
 }
 
-/**
- * The page scroller stays put, the table body is what scrolls, the header does not move while the
- * body scrolls, and the pagination footer sits at the bottom of the page.
- */
 async function expectBodyIsTheOnlyScroller(page: PlaywrightPage): Promise<void> {
-  const scroller = await metrics(pageScroller(page));
+  const scroller = await metrics(appShellMain(page));
   const body = visibleTestId(page, "data-table-scroller");
   const bodyBefore = await metrics(body);
   const headBefore = await metrics(visibleTestId(page, "data-table-head"));
@@ -115,73 +102,61 @@ async function expectBodyIsTheOnlyScroller(page: PlaywrightPage): Promise<void> 
   expect(Math.round(headAfter.top), "header must stay put while the body scrolls").toBe(Math.round(headBefore.top));
 }
 
-/**
- * Every row must sit inside each ancestor up to the nearest one that really scrolls vertically; a
- * fixed-height box that neither grows nor scrolls lets rows paint past its bottom edge.
- */
 const rowsPaintingPastAnAncestor = (page: PlaywrightPage): Promise<string[]> =>
   visibleDataTable(page)
     .locator("table")
     .evaluate((table) => {
       const scrollsVertically = (el: Element): boolean =>
         /auto|scroll/.test(getComputedStyle(el).overflowY) && el.scrollHeight > el.clientHeight + 1;
+      const boxesUpToTheScroller = (el: Element | null): Element[] =>
+        el === null || el === document.body || scrollsVertically(el)
+          ? []
+          : [el, ...boxesUpToTheScroller(el.parentElement)];
       const describe = (el: Element): string =>
         `<${el.tagName.toLowerCase()} class="${el.getAttribute("class") ?? ""}">`;
       return Array.from(table.querySelectorAll("tbody tr")).flatMap((row, index) => {
         const rowBottom = row.getBoundingClientRect().bottom;
-        const spills: string[] = [];
-        for (let el = row.parentElement; el && el !== document.body && !scrollsVertically(el); el = el.parentElement) {
-          const bottom = el.getBoundingClientRect().bottom;
-          if (rowBottom > bottom + 1) {
-            spills.push(
-              `row ${index} bottom ${Math.round(rowBottom)} past ${describe(el)} bottom ${Math.round(bottom)}`,
-            );
-          }
-        }
-        return spills;
+        return boxesUpToTheScroller(row.parentElement)
+          .filter((box) => rowBottom > box.getBoundingClientRect().bottom + 1)
+          .map(
+            (box) =>
+              `row ${index} bottom ${Math.round(rowBottom)} past ${describe(box)} bottom ${Math.round(box.getBoundingClientRect().bottom)}`,
+          );
       });
     });
 
-type Cleanup = (request: APIRequestContext) => Promise<unknown>;
-const cleanups: Cleanup[] = [];
-
 test.describe("Admin tables scroll inside the page", () => {
   test.use({ storageState: ADMIN_STORAGE_PATH, viewport: VIEWPORT });
-
-  test.afterEach(async ({ request }) => {
-    for (const cleanup of cleanups.splice(0)) {
-      // Teardown must never turn a passing test red or mask a real failure.
-      await cleanup(request).catch(() => {});
-    }
-  });
 
   test("Virtual Keys: rows scroll under a sticky header and the page itself never scrolls", async ({
     page,
     request,
   }) => {
     const suffix = uniqueSuffix();
-    const created = await oneAtATime(SEED_ROWS, (i) =>
-      postOk(request, "/key/generate", { key_alias: `e2e-scroll-key-${suffix}-${i}` }),
+    const keys = await oneAtATime(SEED_ROWS, (i) =>
+      postOk<GeneratedKey>(request, "/key/generate", { key_alias: `e2e-scroll-key-${suffix}-${i}` }),
     );
-    cleanups.push((r) => r.post("/key/delete", { headers: adminHeaders(), data: { keys: created.map((k) => k.key) } }));
-
-    await navigateToPage(page, Page.ApiKeys);
-    await expectRowsAtLeast(page, SEED_ROWS);
-    await expectBodyIsTheOnlyScroller(page);
+    try {
+      await navigateToPage(page, Page.ApiKeys);
+      await expectRowsAtLeast(page, SEED_ROWS);
+      await expectBodyIsTheOnlyScroller(page);
+    } finally {
+      await request.post("/key/delete", { headers: adminHeaders(), data: { keys: keys.map((k) => k.key) } });
+    }
   });
 
   test("Teams: rows scroll under a sticky header and the page itself never scrolls", async ({ page, request }) => {
     const suffix = uniqueSuffix();
-    const created = await oneAtATime(SEED_ROWS, (i) =>
-      postOk(request, "/team/new", { team_alias: `e2e-scroll-team-${suffix}-${i}` }),
+    const teams = await oneAtATime(SEED_ROWS, (i) =>
+      postOk<CreatedTeam>(request, "/team/new", { team_alias: `e2e-scroll-team-${suffix}-${i}` }),
     );
-    cleanups.push((r) =>
-      r.post("/team/delete", { headers: adminHeaders(), data: { team_ids: created.map((t) => t.team_id) } }),
-    );
-
-    await navigateToPage(page, Page.Teams);
-    await expectRowsAtLeast(page, SEED_ROWS);
-    await expectBodyIsTheOnlyScroller(page);
+    try {
+      await navigateToPage(page, Page.Teams);
+      await expectRowsAtLeast(page, SEED_ROWS);
+      await expectBodyIsTheOnlyScroller(page);
+    } finally {
+      await request.post("/team/delete", { headers: adminHeaders(), data: { team_ids: teams.map((t) => t.team_id) } });
+    }
   });
 
   test("Request Logs: rows scroll under a sticky header and the page itself never scrolls", async ({
@@ -204,20 +179,24 @@ test.describe("Admin tables scroll inside the page", () => {
   test("Tags: no row paints past the box it lives in", async ({ page, request }) => {
     const suffix = uniqueSuffix();
     const names = Array.from({ length: SEED_ROWS }, (_, i) => `e2e-scroll-tag-${suffix}-${i}`);
-    await oneAtATime(SEED_ROWS, (i) => postOk(request, "/tag/new", { name: names[i], description: "LIT-4738 scroll" }));
-    cleanups.push((r) =>
-      oneAtATime(SEED_ROWS, (i) => r.post("/tag/delete", { headers: adminHeaders(), data: { name: names[i] } })),
+    await oneAtATime(SEED_ROWS, (i) =>
+      postOk<unknown>(request, "/tag/new", { name: names[i], description: "LIT-4738 scroll" }),
     );
-
-    await navigateToPage(page, Page.TagManagement);
-    await expectRowsAtLeast(page, SEED_ROWS);
-    expect(await rowsPaintingPastAnAncestor(page)).toEqual([]);
+    try {
+      await navigateToPage(page, Page.TagManagement);
+      await expectRowsAtLeast(page, SEED_ROWS);
+      expect(await rowsPaintingPastAnAncestor(page)).toEqual([]);
+    } finally {
+      await oneAtATime(SEED_ROWS, (i) =>
+        request.post("/tag/delete", { headers: adminHeaders(), data: { name: names[i] } }),
+      );
+    }
   });
 
   test("Model Hub: no row paints past the box it lives in", async ({ page, request }) => {
     const suffix = uniqueSuffix();
-    const created = await oneAtATime(SEED_ROWS, (i) =>
-      postOk(request, "/model/new", {
+    const models = await oneAtATime(SEED_ROWS, (i) =>
+      postOk<CreatedModel>(request, "/model/new", {
         model_name: `e2e-scroll-model-${suffix}-${i}`,
         litellm_params: {
           model: "openai/fake-gpt-4",
@@ -226,14 +205,14 @@ test.describe("Admin tables scroll inside the page", () => {
         },
       }),
     );
-    cleanups.push((r) =>
-      oneAtATime(SEED_ROWS, (i) =>
-        r.post("/model/delete", { headers: adminHeaders(), data: { id: created[i].model_info.id } }),
-      ),
-    );
-
-    await navigateToPage(page, Page.ModelHubTable);
-    await expectRowsAtLeast(page, SEED_ROWS);
-    expect(await rowsPaintingPastAnAncestor(page)).toEqual([]);
+    try {
+      await navigateToPage(page, Page.ModelHubTable);
+      await expectRowsAtLeast(page, SEED_ROWS);
+      expect(await rowsPaintingPastAnAncestor(page)).toEqual([]);
+    } finally {
+      await oneAtATime(SEED_ROWS, (i) =>
+        request.post("/model/delete", { headers: adminHeaders(), data: { id: models[i].model_info.id } }),
+      );
+    }
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/tag-management/_components/TagTable.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/tag-management/_components/TagTable.tsx
@@ -41,6 +41,7 @@ const TagTable: React.FC<TagTableProps> = ({ data, onEdit, onDelete, onSelectTag
       data={data}
       columns={columns}
       getRowId={(tag, index) => tag.name || String(index)}
+      fillHeight
       sortingMode="client"
       sorting={sorting}
       onSortingChange={setSorting}

--- a/ui/litellm-dashboard/src/app/(dashboard)/tag-management/_components/index.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/tag-management/_components/index.tsx
@@ -126,7 +126,7 @@ const TagManagement: React.FC<TagProps> = ({ accessToken, userID, userRole }) =>
   }, [accessToken]);
 
   return (
-    <div className="mx-4 h-[75vh]">
+    <div className="mx-4 h-full">
       {selectedTagId ? (
         <TagInfoView
           tagId={selectedTagId}
@@ -139,7 +139,7 @@ const TagManagement: React.FC<TagProps> = ({ accessToken, userID, userRole }) =>
           editTag={editTag}
         />
       ) : (
-        <div className="mt-2 h-[75vh] w-full gap-2 p-8">
+        <div className="flex h-full w-full flex-col p-8 pt-10">
           <div className="mt-2 mb-4 flex w-full items-center justify-between">
             <h1>Tag Management</h1>
             <div className="flex items-center space-x-2">
@@ -162,23 +162,21 @@ const TagManagement: React.FC<TagProps> = ({ accessToken, userID, userRole }) =>
             </p>
           </div>
 
-          <Button className="mb-4" onClick={() => setIsCreateModalVisible(true)}>
+          <Button className="mb-4 self-start" onClick={() => setIsCreateModalVisible(true)}>
             + Create New Tag
           </Button>
 
-          <div className="mt-2 grid h-[75vh] w-full grid-cols-1 gap-2 pt-2 pb-2">
-            <div>
-              <TagTable
-                data={tags}
-                isLoading={isLoadingTags}
-                onEdit={(tag) => {
-                  setSelectedTagId(tag.name);
-                  setEditTag(true);
-                }}
-                onDelete={handleDelete}
-                onSelectTag={setSelectedTagId}
-              />
-            </div>
+          <div className="mt-2 flex min-h-0 flex-1 flex-col">
+            <TagTable
+              data={tags}
+              isLoading={isLoadingTags}
+              onEdit={(tag) => {
+                setSelectedTagId(tag.name);
+                setEditTag(true);
+              }}
+              onDelete={handleDelete}
+              onSelectTag={setSelectedTagId}
+            />
           </div>
 
           {/* Create Tag Modal */}

--- a/ui/litellm-dashboard/src/app/(dashboard)/vector-stores/_components/index.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/vector-stores/_components/index.tsx
@@ -137,8 +137,8 @@ const VectorStoreManagement: React.FC<VectorStoreProps> = ({ accessToken, userID
       />
     </div>
   ) : (
-    <div className="mx-4 h-[75vh]">
-      <div className="gap-2 p-8 h-[75vh] w-full mt-2">
+    <div className="mx-4">
+      <div className="gap-2 p-8 w-full mt-2">
         <div className="flex justify-between mt-2 w-full items-center mb-4">
           <h1 className="text-xl font-semibold tracking-tight text-foreground">Vector Store Management</h1>
           <div className="flex items-center space-x-2">

--- a/ui/litellm-dashboard/src/components/AIHub/ModelHubTable.tsx
+++ b/ui/litellm-dashboard/src/components/AIHub/ModelHubTable.tsx
@@ -400,7 +400,7 @@ const ModelHubTable: React.FC<ModelHubTableProps> = ({ accessToken, publicPage, 
   }
 
   return (
-    <div className="mx-4 h-[75vh]">
+    <div className="mx-4">
       {publicPage == false ? (
         <div className="w-full m-2 mt-2 p-8">
           {/* Header with Title, Description and URL */}

--- a/ui/litellm-dashboard/src/components/Teams.tsx
+++ b/ui/litellm-dashboard/src/components/Teams.tsx
@@ -559,6 +559,7 @@ const Teams: React.FC<TeamProps> = ({ accessToken, userID, userRole, premiumUser
     {
       key: "your-teams",
       label: "Your Teams",
+      className: "flex min-h-0 flex-1 flex-col",
       children: (
         <>
           <TeamsTable
@@ -608,6 +609,7 @@ const Teams: React.FC<TeamProps> = ({ accessToken, userID, userRole, premiumUser
     {
       key: "available-teams",
       label: "Available Teams",
+      className: "min-h-0 flex-1 overflow-y-auto",
       children: <AvailableTeamsPanel accessToken={accessToken} userID={userID} />,
     },
     ...(isProxyAdminRole(userRole || "")
@@ -615,6 +617,7 @@ const Teams: React.FC<TeamProps> = ({ accessToken, userID, userRole, premiumUser
           {
             key: "default-settings",
             label: "Default Team Settings",
+            className: "min-h-0 flex-1 overflow-y-auto",
             children: <TeamSSOSettings accessToken={accessToken} userID={userID || ""} userRole={userRole || ""} />,
           },
         ]
@@ -622,7 +625,7 @@ const Teams: React.FC<TeamProps> = ({ accessToken, userID, userRole, premiumUser
   ];
 
   return (
-    <main className={selectedTeamId ? "px-12 py-6" : "p-8"}>
+    <main className={selectedTeamId ? "px-12 py-6" : "flex h-full flex-col p-8"}>
       {selectedTeamId ? (
         <TeamInfoView
           teamId={selectedTeamId}
@@ -642,7 +645,7 @@ const Teams: React.FC<TeamProps> = ({ accessToken, userID, userRole, premiumUser
           premiumUser={premiumUser}
         />
       ) : (
-        <Tabs defaultValue={tabItems[0].key} className="gap-6">
+        <Tabs defaultValue={tabItems[0].key} className="min-h-0 flex-1 gap-6">
           <PageHeader
             icon={<Users />}
             title="Teams"
@@ -674,7 +677,7 @@ const Teams: React.FC<TeamProps> = ({ accessToken, userID, userRole, premiumUser
             )}
           />
           {tabItems.map((item) => (
-            <TabsContent key={item.key} value={item.key}>
+            <TabsContent key={item.key} value={item.key} className={item.className}>
               {item.children}
             </TabsContent>
           ))}

--- a/ui/litellm-dashboard/src/components/TeamsPage/TeamsTable.tsx
+++ b/ui/litellm-dashboard/src/components/TeamsPage/TeamsTable.tsx
@@ -164,7 +164,7 @@ export function TeamsTable({ userRole, userID, onSelectTeam, onEditTeam, onDelet
       isLoading={isLoading}
       loadingMessage="Loading teams..."
       noDataMessage="No teams found"
-      maxBodyHeight="calc(75vh - 210px)"
+      fillHeight
       size="compact"
       toolbar={(table) => (
         <>

--- a/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.tsx
+++ b/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.tsx
@@ -256,7 +256,7 @@ export function VirtualKeysTable({ headerActions }: VirtualKeysTableProps) {
   }
 
   return (
-    <div className="flex h-full flex-col gap-6 overflow-hidden">
+    <div className="flex min-h-0 flex-1 flex-col gap-6">
       <PageHeader
         icon={<KeyRound />}
         title="Virtual Keys"
@@ -283,7 +283,7 @@ export function VirtualKeysTable({ headerActions }: VirtualKeysTableProps) {
         isLoading={isLoading}
         loadingMessage="Loading keys..."
         noDataMessage="No keys found"
-        maxBodyHeight="calc(75vh - 210px)"
+        fillHeight
         size="compact"
         toolbar={(table) => (
           <>

--- a/ui/litellm-dashboard/src/components/shared/DataTable/DataTable.test.tsx
+++ b/ui/litellm-dashboard/src/components/shared/DataTable/DataTable.test.tsx
@@ -613,8 +613,12 @@ describe("DataTable layout", () => {
 
   it("makes the header sticky and constrains body height when maxBodyHeight is set", () => {
     render(<DataTable data={CHARLIE_ALICE_BOB} columns={nameEmailColumns} maxBodyHeight={240} />);
-    expect(screen.getByTestId("data-table-head")).toHaveClass("sticky");
-    expect(screen.getByTestId("data-table-scroller")).toHaveStyle({ maxHeight: "240px" });
+    const scroller = screen.getByTestId("data-table-scroller");
+    expect(scroller).toHaveStyle({ maxHeight: "240px" });
+    expect(scroller).toHaveClass("overflow-auto");
+    // As in fill mode: the Table primitive's own overflow container would otherwise capture the sticky header.
+    expect(scroller).toHaveClass("[&_[data-slot=table-container]]:overflow-visible");
+    expect(screen.getByTestId("data-table-head")).toHaveClass("sticky", "bg-background");
   });
 
   it("caps fillHeight at the parent's height instead of stretching to it, so a short table stays short", () => {

--- a/ui/litellm-dashboard/src/components/shared/DataTable/DataTable.test.tsx
+++ b/ui/litellm-dashboard/src/components/shared/DataTable/DataTable.test.tsx
@@ -616,7 +616,6 @@ describe("DataTable layout", () => {
     const scroller = screen.getByTestId("data-table-scroller");
     expect(scroller).toHaveStyle({ maxHeight: "240px" });
     expect(scroller).toHaveClass("overflow-auto");
-    // As in fill mode: the Table primitive's own overflow container would otherwise capture the sticky header.
     expect(scroller).toHaveClass("[&_[data-slot=table-container]]:overflow-visible");
     expect(screen.getByTestId("data-table-head")).toHaveClass("sticky", "bg-background");
   });

--- a/ui/litellm-dashboard/src/components/shared/DataTable/DataTable.tsx
+++ b/ui/litellm-dashboard/src/components/shared/DataTable/DataTable.tsx
@@ -59,18 +59,28 @@ const noop = () => {};
 /**
  * Height-filling mode. The table still sizes to its rows; the parent's height is only a ceiling, so
  * a short table keeps its footer under the last row and a long one scrolls its rows instead of the
- * page. `table-container` is the Table primitive's own overflow-x wrapper; left as a scroll box it
- * captures the sticky header and the header scrolls away with the rows. And rows pass under that
- * header, which the semi-transparent header row tint alone would not hide.
+ * page.
  */
 const FILL_CLASSES = {
   outer: "flex max-h-full min-h-0 flex-col",
   frame: "flex min-h-0 flex-col",
-  body: "min-h-0 [&_[data-slot=table-container]]:overflow-visible",
+  body: "min-h-0",
+} as const;
+
+const NO_FILL_CLASSES = { outer: "", frame: "", body: "" } as const;
+
+/**
+ * Sticky header, in both fill and maxBodyHeight mode. `table-container` is the Table primitive's own
+ * overflow-x wrapper; left as a scroll box it captures the sticky header and the header scrolls away
+ * with the rows. And rows pass under that header, which the semi-transparent header row tint alone
+ * would not hide.
+ */
+const STICKY_CLASSES = {
+  body: "[&_[data-slot=table-container]]:overflow-visible",
   header: "bg-background",
 } as const;
 
-const NO_FILL_CLASSES = { outer: "", frame: "", body: "", header: "" } as const;
+const NO_STICKY_CLASSES = { body: "", header: "" } as const;
 
 function columnDefId<TData, TValue>(column: ColumnDef<TData, TValue>): string | undefined {
   if ("id" in column && typeof column.id === "string") {
@@ -533,6 +543,7 @@ export function DataTable<TData extends RowData, TValue>(props: DataTableProps<T
   const visibleColumnCount = table.getVisibleLeafColumns().length;
   const stickyHeader = maxBodyHeight !== undefined || fillHeight;
   const fill = fillHeight ? FILL_CLASSES : NO_FILL_CLASSES;
+  const sticky = stickyHeader ? STICKY_CLASSES : NO_STICKY_CLASSES;
   const tableStyle = enableColumnResizing ? { width: table.getTotalSize(), minWidth: "100%" } : undefined;
 
   const renderPagination = (): React.ReactNode => {
@@ -593,13 +604,13 @@ export function DataTable<TData extends RowData, TValue>(props: DataTableProps<T
         {toolbar !== undefined && <div className="shrink-0 border-b border-border px-4 py-3">{toolbar(table)}</div>}
         <div
           data-testid="data-table-scroller"
-          className={cn(stickyHeader ? "overflow-auto" : "overflow-x-auto", fill.body)}
+          className={cn(stickyHeader ? "overflow-auto" : "overflow-x-auto", sticky.body, fill.body)}
           style={maxBodyHeight !== undefined ? { maxHeight: maxBodyHeight } : undefined}
         >
           <TableRoot className={enableColumnResizing ? "table-fixed" : ""} style={tableStyle}>
             <TableHeader
               data-testid="data-table-head"
-              className={cn(stickyHeader ? "sticky top-0 z-sticky" : "", fill.header)}
+              className={cn(stickyHeader ? "sticky top-0 z-sticky" : "", sticky.header)}
             >
               {table.getHeaderGroups().map((headerGroup) => (
                 <TableRow key={headerGroup.id} className="bg-muted/50">

--- a/ui/litellm-dashboard/src/components/shared/DataTable/DataTable.tsx
+++ b/ui/litellm-dashboard/src/components/shared/DataTable/DataTable.tsx
@@ -69,12 +69,6 @@ const FILL_CLASSES = {
 
 const NO_FILL_CLASSES = { outer: "", frame: "", body: "" } as const;
 
-/**
- * Sticky header, in both fill and maxBodyHeight mode. `table-container` is the Table primitive's own
- * overflow-x wrapper; left as a scroll box it captures the sticky header and the header scrolls away
- * with the rows. And rows pass under that header, which the semi-transparent header row tint alone
- * would not hide.
- */
 const STICKY_CLASSES = {
   body: "[&_[data-slot=table-container]]:overflow-visible",
   header: "bg-background",

--- a/ui/litellm-dashboard/src/components/team/TeamVirtualKeysTable.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamVirtualKeysTable.tsx
@@ -443,7 +443,7 @@ export function TeamVirtualKeysTable({ teamId, teamAlias, organization }: TeamVi
   }, []);
 
   return (
-    <div className="w-full h-full overflow-hidden">
+    <div className="w-full">
       {selectedKey ? (
         <KeyInfoView
           keyId={selectedKey.token}
@@ -453,7 +453,7 @@ export function TeamVirtualKeysTable({ teamId, teamAlias, organization }: TeamVi
           onDelete={refetch}
         />
       ) : (
-        <div className="py-4 flex-1 overflow-hidden">
+        <div className="py-4">
           <DataTable
             data={displayKeys}
             columns={columns}
@@ -471,7 +471,6 @@ export function TeamVirtualKeysTable({ teamId, teamAlias, organization }: TeamVi
             columnResizeMode="onChange"
             isLoading={isLoading || isFetching}
             loadingMessage="Loading keys..."
-            maxBodyHeight="75vh"
             size="compact"
             toolbar={(table) => (
               <>

--- a/ui/litellm-dashboard/src/components/user_dashboard.tsx
+++ b/ui/litellm-dashboard/src/components/user_dashboard.tsx
@@ -216,24 +216,22 @@ const UserDashboard: React.FC<UserDashboardProps> = ({
   const canCreateKey = userRole !== "Admin Viewer" && userRole !== "proxy_admin_viewer";
 
   return (
-    <main className="h-[75vh] p-8">
-      <div className="flex h-full flex-col">
-        <VirtualKeysTable
-          headerActions={
-            canCreateKey ? (
-              <CreateKey
-                key={selectedTeam ? selectedTeam.team_id : null}
-                team={selectedTeam as Team | null}
-                teams={teams as Team[]}
-                data={keys}
-                addKey={addKey}
-                autoOpenCreate={autoOpenCreate}
-                prefillData={prefillData}
-              />
-            ) : undefined
-          }
-        />
-      </div>
+    <main className="flex h-full flex-col p-8">
+      <VirtualKeysTable
+        headerActions={
+          canCreateKey ? (
+            <CreateKey
+              key={selectedTeam ? selectedTeam.team_id : null}
+              team={selectedTeam as Team | null}
+              teams={teams as Team[]}
+              data={keys}
+              addKey={addKey}
+              autoOpenCreate={autoOpenCreate}
+              prefillData={prefillData}
+            />
+          ) : undefined
+        }
+      />
     </main>
   );
 };

--- a/ui/litellm-dashboard/src/components/view_logs/RequestLogsTable.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/RequestLogsTable.tsx
@@ -86,6 +86,7 @@ export function RequestLogsTable({
       data={data}
       columns={columns}
       getRowId={(row) => row.request_id}
+      fillHeight
       sortingMode="server"
       sorting={sorting}
       onSortingChange={onSortingChange}

--- a/ui/litellm-dashboard/src/components/view_logs/index.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/index.tsx
@@ -27,6 +27,9 @@ const AUDIT_LOGS_TAB: LogsTab = { id: "audit logs", label: "Audit Logs" };
 const DELETED_KEYS_TAB: LogsTab = { id: "deleted keys", label: "Deleted Keys" };
 const DELETED_TEAMS_TAB: LogsTab = { id: "deleted teams", label: "Deleted Teams" };
 
+const tabContentClassName = (tabId: LogsTabId): string =>
+  tabId === REQUEST_LOGS_TAB.id ? "flex min-h-0 flex-1 flex-col" : "min-h-0 flex-1 overflow-y-auto";
+
 export default function SpendLogsTable({ accessToken, token, userRole, userID, premiumUser }: SpendLogsTableProps) {
   const [activeTab, setActiveTab] = useState<LogsTabId>(REQUEST_LOGS_TAB.id);
   const canViewAuditLogs = useCan("viewAuditLogs");
@@ -78,8 +81,8 @@ export default function SpendLogsTable({ accessToken, token, userRole, userID, p
   };
 
   return (
-    <div className="box-border w-full overflow-x-hidden p-6">
-      <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as LogsTabId)}>
+    <div className="flex h-full w-full flex-col p-6">
+      <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as LogsTabId)} className="min-h-0 flex-1">
         <TabsList variant="line">
           {tabs.map((tab) => (
             <TabsTrigger key={tab.id} value={tab.id} className="flex-none">
@@ -88,7 +91,7 @@ export default function SpendLogsTable({ accessToken, token, userRole, userID, p
           ))}
         </TabsList>
         {tabs.map((tab) => (
-          <TabsContent key={tab.id} value={tab.id} keepMounted>
+          <TabsContent key={tab.id} value={tab.id} keepMounted className={tabContentClassName(tab.id)}>
             {renderPanel(tab.id)}
           </TabsContent>
         ))}


### PR DESCRIPTION
## TLDR

Problem this solves:

- Keys, Teams and Logs tables scroll the page, not the rows
- Sticky header scrolls away with the rows in `maxBodyHeight` mode
- Keys page clips its pagination footer inside a 75vh box
- Tags and Model Hub rows paint past their fixed 75vh boxes

How it solves it:

- Keys, Teams, Logs and Tags use `DataTable` fill mode in a flex chain
- `DataTable` keeps the sticky header inside the scroller in both height modes
- Model Hub, Vector Stores and team detail keys drop the 75vh boxes and flow

## User Flow

Before: an admin with more keys than fit on screen cannot scroll the key rows, only the page, and the sticky header goes with them

1. They open http://localhost:4000/ui/?page=api-keys with 200 keys and a 1280x720 window
2. The page has grown past the window, so the page scrollbar moves the whole page, header and all
3. Scrolling the rows themselves moves the column header off screen, so they lose track of which column is which
4. The "Rows per page" footer is cut off at the bottom of a fixed-height box and cannot be reached
5. On http://localhost:4000/ui/?page=logs the same happens and the horizontal scrollbar for the 16 log columns sits at the very bottom of a page that itself scrolls
6. On http://localhost:4000/ui/?page=tag-management and http://localhost:4000/ui/?page=model-hub-table the rows run past the bottom of their box and over whatever comes next

After: the same admin scrolls the rows inside the table under a header that stays put, and the page never grows past the window

1. They open http://localhost:4000/ui/?page=api-keys with 200 keys and a 1280x720 window
2. The page fits the window with no page scrollbar; the table body scrolls its rows on its own
3. Scrolling the rows keeps the column header pinned at the top of the table
4. The "Rows per page" footer sits at the bottom of the page and is always reachable
5. On http://localhost:4000/ui/?page=logs the rows scroll inside the table too, and the horizontal scrollbar for the 16 columns is inside the table body
6. On http://localhost:4000/ui/?page=tag-management the rows scroll inside the table, and on http://localhost:4000/ui/?page=model-hub-table the rows sit inside a box that grows with them while the page scrolls as a whole

## Relevant issues

## Linear ticket

Refs LIT-4738

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Setup shared by both runs: the proxy from this checkout on port 4744 with `litellm/proxy/dev_config.yaml` (master key `sk-1234`), the dev database that already holds 42 logs from the last 24 hours, 19 tags and 40 model groups, plus 60 keys and 60 teams seeded for the run

```bash
for i in $(seq 1 60); do
  curl -s http://localhost:4744/key/generate -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
    -d "{\"key_alias\":\"lit4738d-key-$i\"}"
  curl -s http://localhost:4744/team/new -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
    -d "{\"team_alias\":\"lit4738d-team-$i\"}"
done
```

Each page was then opened in headless Chromium at 1280x720, logged in at http://localhost:4744/ui/login as `admin` / `sk-1234`, with Logs set to 50 rows per page. The numbers are the app shell `<main>` (the page scroller), the table body scroller and the column header's `getBoundingClientRect().top` before and after scrolling the body by 500px. In this dev setup the debug and no-Redis banners leave `<main>` 472px tall, which is why the row counts that fit are small. The keys and teams were deleted afterwards with `POST /key/delete` and `POST /team/delete`

### Before (a53c550951)

#### Virtual Keys, http://localhost:4744/ui/?page=api-keys, 50 rows

1. `main.scrollHeight=540 clientHeight=472`: the page scrolls
2. `table body scrollHeight=2982 clientHeight=330`
3. Pagination footer bottom edge at 860px on a 720px window: below the fold, inside a clipped box
4. Header top 476px, after scrolling the body by 500px: -24px, the header scrolled away

#### Teams, http://localhost:4744/ui/?page=teams, 50 rows

1. `main.scrollHeight=644 clientHeight=472`: the page scrolls
2. `table body scrollHeight=2782 clientHeight=330`
3. Pagination footer bottom edge at 860px on a 720px window
4. Header top 476px, after scrolling the body by 500px: -24px, the header scrolled away

#### Request Logs, http://localhost:4744/ui/?page=logs, 42 rows

1. `main.scrollHeight=1739 clientHeight=472`: the page scrolls
2. `table body scrollHeight=1437 clientHeight=1437`: the body does not scroll at all
3. Pagination footer bottom edge at 1752px on a 720px window
4. Header top 261px before and after, because the body cannot scroll (`scrollTop` stays 0)

#### Tags, http://localhost:4744/ui/?page=tag-management, 19 rows

1. 31 row-to-ancestor overlaps, first: `row 7 bottom 829 past <div class="mt-2 h-[75vh] w-full gap-2 p-8"> bottom 796`
2. Last: `row 18 bottom 1280 past <div class="mx-4 h-[75vh]"> bottom 796`

#### Model Hub, http://localhost:4744/ui/?page=model-hub-table, 40 rows

1. 40 row-to-ancestor overlaps, first: `row 0 bottom 1167 past <div class="mx-4 h-[75vh]"> bottom 796`
2. Last: `row 39 bottom 3319 past <div class="mx-4 h-[75vh]"> bottom 796`

#### Models + Endpoints, http://localhost:4744/ui/?page=models, 40 rows (a `maxBodyHeight` table, untouched by this PR except through `DataTable`)

1. `table body scrollHeight=1912 clientHeight=600`: the body scrolls
2. Header top 623px, after scrolling the body by 500px: 123px, the header scrolled away with the rows

#### Team detail Virtual Keys tab, http://localhost:4744/ui/teams?team=<team id>, 30 keys in the team

1. `main.scrollHeight=972 clientHeight=472`: the page scrolls
2. `table body scrollHeight=1502 clientHeight=540`: and the table body scrolls too, a scroller inside a scroller
3. Table bottom edge at 1148px, inside a 75vh box that only fits 540px of rows

#### New e2e spec against the harness stack

1. `PROXY_PORT=4745 POSTGRES_PORT=5533 MOCK_LLM_PORT=8191 E2E_KEEP_ALIVE=1 ./run_e2e.sh`, then `npx playwright test tests/tables/tableScrolling.spec.ts` with the merge-base UI build served
2. `5 failed`: Keys and Teams on "pagination footer must sit at the bottom of the page" (52px below the table, the 75vh box leaves dead space), Logs on "page scroller must not overflow vertically" (`scrollHeight` 1159 vs `clientHeight` 664), Tags with 105 and Model Hub with 44 rows painting past a `h-[75vh]` box

### After (ff97e71652)

#### Virtual Keys, http://localhost:4744/ui/?page=api-keys, 50 rows

1. `main.scrollHeight=472 clientHeight=472`: the page does not scroll, `scrollWidth=1000 clientWidth=1000`
2. `table body scrollHeight=2982 clientHeight=158`: the rows scroll inside the table
3. Table bottom edge (footer included) at 688px, `main` bottom at 720px: the 32px page padding, nothing clipped
4. Header top 476px, after scrolling the body by 500px: 476px

#### Teams, http://localhost:4744/ui/?page=teams, 50 rows

1. `main.scrollHeight=472 clientHeight=472`: the page does not scroll
2. `table body scrollHeight=2782 clientHeight=158`
3. Table bottom edge at 688px, `main` bottom at 720px
4. Header top 476px, after scrolling the body by 500px: 476px

#### Request Logs, http://localhost:4744/ui/?page=logs, 42 rows

1. `main.scrollHeight=472 clientHeight=472 scrollWidth=1000 clientWidth=1000`: the page scrolls neither way
2. `table body scrollHeight=1437 clientHeight=170 scrollWidth=1880 clientWidth=950`: rows and the 16 columns both scroll inside the table
3. Table bottom edge at 696px, `main` bottom at 720px: the 24px page padding
4. Header top 472px, after scrolling the body by 500px: 472px

#### Tags, http://localhost:4744/ui/?page=tag-management, 19 rows

1. `main.scrollHeight=472 clientHeight=472`, 0 row-to-ancestor overlaps: the rows scroll inside the table

#### Model Hub, http://localhost:4744/ui/?page=model-hub-table, 40 rows

1. `main.scrollHeight=3172 clientHeight=472` (the page scrolls as a whole, as before), 0 row-to-ancestor overlaps

#### Models + Endpoints, http://localhost:4744/ui/?page=models, 40 rows (a `maxBodyHeight` table, untouched by this PR except through `DataTable`)

1. `table body scrollHeight=1912 clientHeight=600`
2. Header top 623px, after scrolling the body by 500px: 623px

#### Team detail Virtual Keys tab, http://localhost:4744/ui/teams?team=<team id>, 30 keys in the team

1. `main.scrollHeight=1934 clientHeight=472`: the team page scrolls as a whole, like its other tabs
2. `table body scrollHeight=1502 clientHeight=1502`: no inner scroller, all 30 rows are in the page flow
3. Table bottom edge at 2110px with no `overflow: hidden` ancestor cutting it off

#### New e2e spec against the harness stack

1. Same stack, same command, with the PR's UI build served at dc9f40c11f
2. `5 passed (11.2s)`
3. Run again at ff97e71652, where the spec was typed and de-mutated and the app change is comment-only: 4 passed, Tags blocked by a harness session flake (the page's own `GET /tag/list` came back 401 with `role=unknown`, as did `/v2/team/list` and `/policies/list` in that run), not re-run

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- Team detail Virtual Keys tab now flows with the page scroller instead of a 75vh box
  - The team page scrolls as a whole for every tab, so a bounded chain there would have changed all of them
- Teams page "Available Teams" and "Default Team Settings" tabs scroll inside the tab, like the Budgets page

### Low

- Paginated tables still on `maxBodyHeight` and left for a follow-up: `AllModelsTable`, `TopModelView`, `TopKeyView`, `KeyModelUsageView`, `EntityUsage`
  - They get the sticky header fix from `DataTable` in this PR but still scroll the page when the page grows
- Other fixed `vh` boxes untouched: `APIReferenceView` (`h-[80vh]`), `general_settings.tsx` router settings tabs (`h-[75vh]`), `old-usage`
- Model Hub and Vector Stores keep plain page scrolling, they only lose the 75vh boxes

## QA runbook

- tests/e2e/ui/tests/tables/tableScrolling.spec.ts "Virtual Keys: rows scroll under a sticky header and the page itself never scrolls" - with 40 extra keys the Keys page keeps the page scroller flat, scrolls the rows inside the table, keeps the header pinned and the footer at the bottom
  - [ ] Seed rows: run `curl -X POST http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"key_alias":"scroll-key-N"}'` 40 times with N from 1 to 40
  - [ ] Open http://localhost:4000/ui/?page=api-keys in a 1280x720 window and wait for at least 40 rows
  - [ ] In devtools run `document.querySelector("main").scrollHeight === document.querySelector("main").clientHeight` and expect `true`, and the same for `scrollWidth` vs `clientWidth`
  - [ ] Run `document.querySelector("[data-testid=data-table-scroller]").scrollHeight > document.querySelector("[data-testid=data-table-scroller]").clientHeight` and expect `true`
  - [ ] Expect the table's bottom edge (`[data-testid=data-table-root]`) to sit within 40px of the bottom of `main` and not below it
  - [ ] Scroll the table body down by 500px and expect the column header's `getBoundingClientRect().top` to be unchanged
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky
- tests/e2e/ui/tests/tables/tableScrolling.spec.ts "Teams: rows scroll under a sticky header and the page itself never scrolls" - the same checks on the Teams page with 40 extra teams
  - [ ] Seed rows: run `curl -X POST http://localhost:4000/team/new -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"team_alias":"scroll-team-N"}'` 40 times
  - [ ] Open http://localhost:4000/ui/?page=teams in a 1280x720 window and wait for at least 40 rows
  - [ ] Run the same four devtools checks as for Virtual Keys and expect the same answers
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky
- tests/e2e/ui/tests/tables/tableScrolling.spec.ts "Request Logs: rows scroll under a sticky header and the page itself never scrolls" - the same checks on the Logs page after 20 chat completions and 25 rows per page
  - [ ] Send 20 `POST /v1/chat/completions` requests for `fake-openai-gpt-4` with the master key and wait until `GET /spend/logs?request_id=<last id>` returns the row
  - [ ] Open http://localhost:4000/ui/?page=logs in a 1280x720 window, set "Rows per page" to 25 and wait for at least 20 rows
  - [ ] Run the same four devtools checks as for Virtual Keys and expect the same answers, including no horizontal page scroll even though the table itself scrolls sideways
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky
- tests/e2e/ui/tests/tables/tableScrolling.spec.ts "Tags: no row paints past the box it lives in" - with 40 tags no row's bottom edge crosses any ancestor box up to the nearest vertical scroller
  - [ ] Seed rows: run `curl -X POST http://localhost:4000/tag/new -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"name":"scroll-tag-N","description":"scroll"}'` 40 times
  - [ ] Open http://localhost:4000/ui/?page=tag-management in a 1280x720 window and wait for at least 40 rows
  - [ ] For every `tbody tr`, walk its ancestors up to the first one whose computed `overflow-y` is `auto` or `scroll` and that actually overflows, and expect the row's `getBoundingClientRect().bottom` never to exceed the ancestor's
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky
- tests/e2e/ui/tests/tables/tableScrolling.spec.ts "Model Hub: no row paints past the box it lives in" - the same ancestor check on the Model Hub with 40 extra model groups
  - [ ] Seed rows: run `curl -X POST http://localhost:4000/model/new -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model_name":"scroll-model-N","litellm_params":{"model":"openai/fake-gpt-4","api_base":"http://127.0.0.1:8090/v1","api_key":"fake-key"}}'` 40 times (needs `store_model_in_db: true`)
  - [ ] Open http://localhost:4000/ui/?page=model-hub-table in a 1280x720 window and wait for at least 40 rows in the models table
  - [ ] Run the same ancestor walk as for Tags and expect no row past any ancestor
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

https://claude.ai/code/session_018yW93iDaEMhoQUXcYjus7D
