### PR TITLE
fix(datadog_llm_obs): keep the guardrail audit record under message redaction

### DIFF
--- a/litellm/integrations/datadog/datadog_llm_obs.py
+++ b/litellm/integrations/datadog/datadog_llm_obs.py
@@ -19,7 +19,7 @@ import httpx
 import litellm
 from litellm._logging import verbose_logger
 from litellm._uuid import uuid
-from litellm.constants import REDACTED_BY_LITELLM
+from litellm.constants import REDACTED_BY_LITELLM, REDACTED_BY_LITELM_STRING
 from litellm.integrations.custom_batch_logger import CustomBatchLogger
 from litellm.integrations.datadog.datadog_handler import (
     get_datadog_base_url_from_env,
@@ -46,6 +46,8 @@ from litellm.llms.custom_httpx.http_handler import (
 from litellm.proxy.spend_tracking.savings import extract_cache_creation_tokens, extract_cache_read_tokens
 from litellm.types.integrations.datadog_llm_obs import *
 from litellm.types.utils import (
+    AUDIT_GUARDRAIL_FIELDS,
+    PROMPT_CARRYING_GUARDRAIL_FIELDS,
     PROMPT_QUOTING_ROUTING_DECISION_FIELDS,
     CallTypes,
     StandardLoggingGuardrailInformation,
@@ -59,6 +61,8 @@ _MAX_PARSED_TOOL_ARGUMENT_CHARS: Final = 256 * 1024
 _SAFE_REDACTED_MESSAGE_ROLES: Final = frozenset(
     {"agent", "assistant", "developer", "function", "model", "system", "tool", "user"}
 )
+
+_CLASSIFIED_GUARDRAIL_FIELDS: Final = AUDIT_GUARDRAIL_FIELDS | PROMPT_CARRYING_GUARDRAIL_FIELDS
 
 _PROMPT_CARRYING_METADATA_FIELDS: Final = frozenset(
     {
@@ -105,6 +109,39 @@ def _router_span_fields(
             and value is not None
             and not (redact_prompt_text and record_field in PROMPT_QUOTING_ROUTING_DECISION_FIELDS)
         }
+    )
+
+
+def _guardrail_entry_without_prompt_carriers(entry: Mapping[str, object]) -> Mapping[str, object]:
+    """One guardrail record kept as its audit fields, with the prompt-quoting ones marked redacted.
+
+    Built as an allow-list rather than a deny-list: a key neither set classifies is dropped, so a
+    guardrail that records its own extra detail cannot put the caller's prompt on a redacted span.
+    """
+    return {  # mutable-ok: a fresh record built per entry, handed straight to the span serializer
+        field: REDACTED_BY_LITELM_STRING if field in PROMPT_CARRYING_GUARDRAIL_FIELDS else value
+        for field, value in entry.items()
+        if field in _CLASSIFIED_GUARDRAIL_FIELDS
+    }
+
+
+def _guardrail_information_without_prompt_carriers(
+    guardrail_information: object,
+) -> tuple[Mapping[str, object], ...] | None:
+    """The guardrail records reduced to what a redacted span may carry.
+
+    Redaction removes the prompt, not the record that a guardrail ran: the name, mode, status,
+    timings and masked-entity counts are what an operator reads to answer whether a guardrail
+    caught anything on a request, and none of them reproduce the prompt. Field-level rather than
+    dropping the list, which is what `_sanitize_guardrail_information_for_spend_logs` already does
+    for spend logs.
+    """
+    if guardrail_information is None:
+        return None
+    if not isinstance(guardrail_information, (list, tuple)):
+        return ()
+    return tuple(
+        _guardrail_entry_without_prompt_carriers(entry) for entry in guardrail_information if isinstance(entry, Mapping)
     )
 
 
@@ -872,7 +909,9 @@ class DataDogLLMObsLogger(CustomBatchLogger):
             "cache_key": standard_logging_payload.get("cache_key", "unknown"),
             "saved_cache_cost": standard_logging_payload.get("saved_cache_cost", 0),
             "guardrail_information": (
-                None if redact_prompt_text else standard_logging_payload.get("guardrail_information", None)
+                _guardrail_information_without_prompt_carriers(standard_logging_payload.get("guardrail_information"))
+                if redact_prompt_text
+                else standard_logging_payload.get("guardrail_information", None)
             ),
             "is_streamed_request": self._get_stream_value_from_payload(standard_logging_payload),
             "latency_metrics": dict(self._get_latency_metrics(standard_logging_payload)),

--- a/litellm/integrations/datadog/datadog_llm_obs.py
+++ b/litellm/integrations/datadog/datadog_llm_obs.py
@@ -50,7 +50,6 @@ from litellm.types.utils import (
     PROMPT_CARRYING_GUARDRAIL_FIELDS,
     PROMPT_QUOTING_ROUTING_DECISION_FIELDS,
     CallTypes,
-    StandardLoggingGuardrailInformation,
     StandardLoggingPayload,
     StandardLoggingPayloadErrorInformation,
 )
@@ -112,6 +111,20 @@ def _router_span_fields(
     )
 
 
+def _guardrail_entries(guardrail_information: object) -> tuple[Mapping[str, object], ...]:
+    """The guardrail records as a sequence, whatever shape the payload carries.
+
+    `guardrail_information` is typed as a list, but a guardrail that writes the metadata key itself
+    can leave a single record there; Prometheus normalizes the same shape at
+    `_guardrail_overhead_seconds`.
+    """
+    if isinstance(guardrail_information, Mapping):
+        return (guardrail_information,)
+    if isinstance(guardrail_information, (list, tuple)):
+        return tuple(entry for entry in guardrail_information if isinstance(entry, Mapping))
+    return ()
+
+
 def _guardrail_entry_without_prompt_carriers(entry: Mapping[str, object]) -> Mapping[str, object]:
     """One guardrail record kept as its audit fields, with the prompt-quoting ones marked redacted.
 
@@ -138,11 +151,7 @@ def _guardrail_information_without_prompt_carriers(
     """
     if guardrail_information is None:
         return None
-    if not isinstance(guardrail_information, (list, tuple)):
-        return ()
-    return tuple(
-        _guardrail_entry_without_prompt_carriers(entry) for entry in guardrail_information if isinstance(entry, Mapping)
-    )
+    return tuple(_guardrail_entry_without_prompt_carriers(entry) for entry in _guardrail_entries(guardrail_information))
 
 
 def _metadata_without_prompt_carriers(standard_logging_metadata: Mapping[str, Any]) -> Mapping[str, Any]:
@@ -943,14 +952,12 @@ class DataDogLLMObsLogger(CustomBatchLogger):
             latency_metrics["litellm_overhead_time_ms"] = litellm_overhead_ms
 
         # Guardrail overhead latency
-        guardrail_info: Final[list[StandardLoggingGuardrailInformation] | None] = standard_logging_payload.get(
-            "guardrail_information"
-        )
-        if guardrail_info is not None:
+        guardrail_info: Final = _guardrail_entries(standard_logging_payload.get("guardrail_information"))
+        if guardrail_info:
             total_duration = 0.0
             for info in guardrail_info:
-                _guardrail_duration_seconds: float | None = info.get("duration")
-                if _guardrail_duration_seconds is not None:
+                _guardrail_duration_seconds = info.get("duration")
+                if isinstance(_guardrail_duration_seconds, (int, float, str)):
                     total_duration += float(_guardrail_duration_seconds)
 
             if total_duration > 0:

--- a/litellm/proxy/spend_tracking/spend_tracking_utils.py
+++ b/litellm/proxy/spend_tracking/spend_tracking_utils.py
@@ -35,6 +35,7 @@ from litellm.proxy._types import SpendLogsMetadata, SpendLogsPayload, SpendLogsR
 from litellm.proxy.spend_tracking.spend_log_error_logger import spend_log_error
 from litellm.proxy.utils import PrismaClient, hash_token
 from litellm.types.utils import (
+    PROMPT_CARRYING_GUARDRAIL_FIELDS,
     CallTypes,
     CostBreakdown,
     StandardLoggingGuardrailInformation,
@@ -1066,13 +1067,6 @@ def _sanitize_guardrail_information_for_spend_logs(
     return [_redact_prompt_fields_in_guardrail_entry(entry) for entry in entries if isinstance(entry, dict)]
 
 
-_PROMPT_CARRYING_GUARDRAIL_FIELDS: Final = (
-    "guardrail_request",
-    "guardrail_response",
-    "match_details",
-    "classification",
-)
-
 _NUMERIC_COMPRESSION_STAT_KEYS: Final = (
     "tokens_before",
     "tokens_after",
@@ -1107,7 +1101,7 @@ def _redact_prompt_fields_in_guardrail_entry(
     preserved_stats: Final = _numeric_compression_stats_from_guardrail_response(entry.get("guardrail_response"))
     redacted: Final[StandardLoggingGuardrailInformation] = {
         **entry,
-        **{key: REDACTED_BY_LITELM_STRING for key in _PROMPT_CARRYING_GUARDRAIL_FIELDS if key in entry},
+        **{key: REDACTED_BY_LITELM_STRING for key in PROMPT_CARRYING_GUARDRAIL_FIELDS if key in entry},
     }
     if preserved_stats is None:
         return redacted

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3076,6 +3076,50 @@ class GuardrailMode(TypedDict, total=False):
 
 GuardrailStatus = Literal["success", "guardrail_intervened", "guardrail_failed_to_respond", "not_run"]
 
+# Fields on a guardrail record whose values can quote the caller's prompt: the payload sent to the
+# guardrail, the provider response that echoes it back, and the two first-party hooks that inline
+# prompt substrings (``block_code_execution`` and ``litellm_content_filter``). Every other field
+# reports what the guardrail decided without reproducing the prompt, so redaction replaces these
+# four and keeps the rest of the record.
+PROMPT_CARRYING_GUARDRAIL_FIELDS: Final[frozenset[str]] = frozenset(
+    {
+        "guardrail_request",
+        "guardrail_response",
+        "match_details",
+        "classification",
+    }
+)
+
+# The rest of the record: what the guardrail is, what it decided, how long it took and what it cost.
+# None of these reproduce the prompt, so a redacted record keeps them and stays explainable.
+# `test_every_guardrail_field_is_classified` fails if a field is added to the record without being
+# placed in one set or the other, so a new field is dropped from redacted records rather than
+# shipped unexamined.
+AUDIT_GUARDRAIL_FIELDS: Final[frozenset[str]] = frozenset(
+    {
+        "guardrail_name",
+        "guardrail_provider",
+        "guardrail_mode",
+        "guardrail_status",
+        "start_time",
+        "end_time",
+        "duration",
+        "masked_entity_count",
+        "guardrail_id",
+        "policy_template",
+        "detection_method",
+        "confidence_score",
+        "patterns_checked",
+        "alert_recipients",
+        "risk_score",
+        "violation_categories",
+        "guardrail_action",
+        "guardrail_usage",
+        "guardrail_cost",
+        "guardrail_cost_in_spend",
+    }
+)
+
 
 class StandardLoggingGuardrailInformation(TypedDict, total=False):
     guardrail_name: str | None

--- a/tests/test_litellm/integrations/datadog/test_datadog_llm_obs.py
+++ b/tests/test_litellm/integrations/datadog/test_datadog_llm_obs.py
@@ -20,6 +20,8 @@ import pytest
 import litellm
 from litellm.integrations.datadog.datadog_llm_obs import DataDogLLMObsLogger
 from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
+from litellm.types.guardrails import GuardrailEventHooks
+from litellm.types.utils import StandardLoggingGuardrailInformation
 
 TOOL_DEFINITION: dict[str, Any] = {
     "type": "function",
@@ -637,29 +639,32 @@ def test_redaction_drops_every_prompt_carrying_metadata_record(logger: DataDogLL
     assert unredacted["meta"]["metadata"]["guardrail_information"] is not None
 
 
-_AUDIT_RECORD: Final[dict[str, Any]] = {
-    "guardrail_name": "bedrock-pii",
-    "guardrail_provider": "bedrock",
-    "guardrail_mode": "pre_call",
-    "guardrail_status": "guardrail_intervened",
-    "guardrail_response": {"action": "MASK", "match": "alice@acme.com"},
-    "match_details": [{"pattern": "email", "match": "alice@acme.com"}],
-    "classification": "the user asked for alice@acme.com",
-    "masked_entity_count": {"EMAIL": 2},
-    "violation_categories": ["pii"],
-    "duration": 0.01,
-}
+_AUDIT_RECORD: Final[StandardLoggingGuardrailInformation] = StandardLoggingGuardrailInformation(
+    guardrail_name="bedrock-pii",
+    guardrail_provider="bedrock",
+    guardrail_mode=GuardrailEventHooks.pre_call,
+    guardrail_status="guardrail_intervened",
+    guardrail_response={"action": "MASK", "match": "alice@acme.com"},
+    match_details=[{"pattern": "email", "match": "alice@acme.com"}],
+    classification="the user asked for alice@acme.com",
+    masked_entity_count={"EMAIL": 2},
+    violation_categories=["pii"],
+    duration=0.01,
+)
+
+
+def _payload_with_guardrail_record(guardrail_information: object) -> dict[str, Any]:
+    payload = build_payload()
+    payload["standard_logging_object"]["guardrail_information"] = guardrail_information
+    return payload
 
 
 def test_redaction_keeps_the_guardrail_audit_record(logger: DataDogLLMObsLogger) -> None:
     """Redaction removes the prompt, not the operator's record that a guardrail intervened."""
-
-    def payload() -> dict[str, Any]:
-        built = build_payload()
-        built["standard_logging_object"]["guardrail_information"] = [dict(_AUDIT_RECORD)]
-        return built
-
-    redacted = _span_json(_redacting_logger(turn_off_message_logging=True), payload())
+    redacted = _span_json(
+        _redacting_logger(turn_off_message_logging=True),
+        _payload_with_guardrail_record([dict(_AUDIT_RECORD)]),
+    )
     record = redacted["meta"]["metadata"]["guardrail_information"][0]
 
     for field in ("guardrail_request", "guardrail_response", "match_details", "classification"):
@@ -678,8 +683,7 @@ def test_a_caller_supplied_redaction_header_cannot_blank_the_guardrail_record(
     logger: DataDogLLMObsLogger,
 ) -> None:
     """Any key may redact its own prompts with the header; none may erase what a guardrail caught."""
-    payload = build_payload()
-    payload["standard_logging_object"]["guardrail_information"] = [dict(_AUDIT_RECORD)]
+    payload = _payload_with_guardrail_record([dict(_AUDIT_RECORD)])
     payload["litellm_params"] = {"metadata": {"headers": {"x-litellm-enable-message-redaction": "true"}}}
 
     span = _span_json(logger, payload)
@@ -693,12 +697,10 @@ def test_a_caller_supplied_redaction_header_cannot_blank_the_guardrail_record(
 
 def test_a_guardrails_own_extra_field_never_reaches_a_redacted_span(logger: DataDogLLMObsLogger) -> None:
     """A guardrail may record whatever it likes; only classified fields survive redaction."""
-    payload = build_payload()
-    payload["standard_logging_object"]["guardrail_information"] = [
-        {**_AUDIT_RECORD, "matched_text": "the caller asked about alice@acme.com"}
-    ]
-
-    span = _span_json(_redacting_logger(turn_off_message_logging=True), payload)
+    span = _span_json(
+        _redacting_logger(turn_off_message_logging=True),
+        _payload_with_guardrail_record([{**_AUDIT_RECORD, "matched_text": "the caller asked about alice@acme.com"}]),
+    )
     record = span["meta"]["metadata"]["guardrail_information"][0]
 
     assert "matched_text" not in record
@@ -706,39 +708,56 @@ def test_a_guardrails_own_extra_field_never_reaches_a_redacted_span(logger: Data
     assert "alice@acme.com" not in safe_dumps(span["meta"]["metadata"])
 
 
-def test_odd_guardrail_shapes_never_raise() -> None:
+def test_a_lone_guardrail_record_survives_redaction(logger: DataDogLLMObsLogger) -> None:
+    """A guardrail that writes the metadata key itself leaves one record, not a list of them."""
+    span = _span_json(
+        _redacting_logger(turn_off_message_logging=True),
+        _payload_with_guardrail_record(dict(_AUDIT_RECORD)),
+    )
+    metadata = span["meta"]["metadata"]
+
+    assert metadata["guardrail_information"] == [
+        {
+            "guardrail_name": "bedrock-pii",
+            "guardrail_provider": "bedrock",
+            "guardrail_mode": "pre_call",
+            "guardrail_status": "guardrail_intervened",
+            "guardrail_response": "REDACTED_BY_LITELM",
+            "match_details": "REDACTED_BY_LITELM",
+            "classification": "REDACTED_BY_LITELM",
+            "masked_entity_count": {"EMAIL": 2},
+            "violation_categories": ["pii"],
+            "duration": 0.01,
+        }
+    ]
+    assert metadata["latency_metrics"]["guardrail_overhead_time_ms"] == 10.0
+
+
+@pytest.mark.parametrize("guardrail_information", [None, [], 5, "abc", [None, "x"], {}])
+def test_odd_guardrail_shapes_still_produce_a_span(
+    guardrail_information: object,
+) -> None:
     """The redacted branch replaced an expression that could not fail, so it must not start failing."""
-    from litellm.integrations.datadog.datadog_llm_obs import (
-        _guardrail_information_without_prompt_carriers,
+    span = _span_json(
+        _redacting_logger(turn_off_message_logging=True),
+        _payload_with_guardrail_record(guardrail_information),
     )
 
-    assert _guardrail_information_without_prompt_carriers(None) is None
-    assert _guardrail_information_without_prompt_carriers([]) == ()
-    assert _guardrail_information_without_prompt_carriers(5) == ()
-    assert _guardrail_information_without_prompt_carriers("abc") == ()
-    assert (
-        _guardrail_information_without_prompt_carriers([None, "x", dict(_AUDIT_RECORD)])
-        == (_guardrail_information_without_prompt_carriers([dict(_AUDIT_RECORD)]) or ())[:1]
-    )
+    assert span["meta"]["input"]["messages"] == [{"role": "user", "content": "redacted-by-litellm"}]
+    assert span["meta"]["metadata"]["guardrail_information"] in (None, [], [{}])
 
 
-def test_every_guardrail_field_is_classified() -> None:
-    """Redaction is derived from a declaration, not a list at the call site, so every field has to
-    be classified as quoting the prompt or reporting what the guardrail decided. A field added
-    without a decision fails here rather than silently shipping the prompt on a redacted span."""
-    from litellm.types.utils import (
-        AUDIT_GUARDRAIL_FIELDS,
-        PROMPT_CARRYING_GUARDRAIL_FIELDS,
-        StandardLoggingGuardrailInformation,
-    )
+def test_a_redacted_span_carries_every_declared_guardrail_field() -> None:
+    """A field added to the record without a redaction decision would be dropped, so it fails here."""
+    declared = dict.fromkeys(StandardLoggingGuardrailInformation.__annotations__, "alice@acme.com")
+    payload = _payload_with_guardrail_record([{**declared, "duration": 0.01}])
 
-    declared = set(StandardLoggingGuardrailInformation.__annotations__)
-    classified = PROMPT_CARRYING_GUARDRAIL_FIELDS | AUDIT_GUARDRAIL_FIELDS
-    assert declared == classified, (
-        "classify new guardrail-record fields in litellm/types/utils.py: "
-        f"unclassified={declared - classified}, stale={classified - declared}"
-    )
-    assert not (PROMPT_CARRYING_GUARDRAIL_FIELDS & AUDIT_GUARDRAIL_FIELDS)
+    span = _span_json(_redacting_logger(turn_off_message_logging=True), payload)
+    record = span["meta"]["metadata"]["guardrail_information"][0]
+
+    assert set(record) == set(declared)
+    for field in ("guardrail_request", "guardrail_response", "match_details", "classification"):
+        assert record[field] == "REDACTED_BY_LITELM"
 
 
 def test_tool_definitions_accept_the_bare_anthropic_shape(logger: DataDogLLMObsLogger) -> None:

--- a/tests/test_litellm/integrations/datadog/test_datadog_llm_obs.py
+++ b/tests/test_litellm/integrations/datadog/test_datadog_llm_obs.py
@@ -12,7 +12,7 @@ spelling of prompt-cache counts (`prompt_tokens_details.cached_tokens`).
 import json
 import os
 from datetime import datetime, timedelta
-from typing import Any
+from typing import Any, Final
 from unittest.mock import patch
 
 import pytest
@@ -631,8 +631,114 @@ def test_redaction_drops_every_prompt_carrying_metadata_record(logger: DataDogLL
     for record in sensitive_metadata:
         assert record not in redacted["meta"]["metadata"]
         assert record in unredacted["meta"]["metadata"]
-    assert redacted["meta"]["metadata"]["guardrail_information"] is None
+    assert redacted["meta"]["metadata"]["guardrail_information"] == [
+        {"guardrail_name": "g", "guardrail_request": "REDACTED_BY_LITELM"}
+    ]  # the record survives; only the field quoting the prompt is replaced
     assert unredacted["meta"]["metadata"]["guardrail_information"] is not None
+
+
+_AUDIT_RECORD: Final[dict[str, Any]] = {
+    "guardrail_name": "bedrock-pii",
+    "guardrail_provider": "bedrock",
+    "guardrail_mode": "pre_call",
+    "guardrail_status": "guardrail_intervened",
+    "guardrail_response": {"action": "MASK", "match": "alice@acme.com"},
+    "match_details": [{"pattern": "email", "match": "alice@acme.com"}],
+    "classification": "the user asked for alice@acme.com",
+    "masked_entity_count": {"EMAIL": 2},
+    "violation_categories": ["pii"],
+    "duration": 0.01,
+}
+
+
+def test_redaction_keeps_the_guardrail_audit_record(logger: DataDogLLMObsLogger) -> None:
+    """Redaction removes the prompt, not the operator's record that a guardrail intervened."""
+
+    def payload() -> dict[str, Any]:
+        built = build_payload()
+        built["standard_logging_object"]["guardrail_information"] = [dict(_AUDIT_RECORD)]
+        return built
+
+    redacted = _span_json(_redacting_logger(turn_off_message_logging=True), payload())
+    record = redacted["meta"]["metadata"]["guardrail_information"][0]
+
+    for field in ("guardrail_request", "guardrail_response", "match_details", "classification"):
+        assert record.get(field, "REDACTED_BY_LITELM") == "REDACTED_BY_LITELM"
+    assert record["guardrail_name"] == "bedrock-pii"
+    assert record["guardrail_provider"] == "bedrock"
+    assert record["guardrail_mode"] == "pre_call"
+    assert record["guardrail_status"] == "guardrail_intervened"
+    assert record["masked_entity_count"] == {"EMAIL": 2}
+    assert record["violation_categories"] == ["pii"]
+    assert record["duration"] == 0.01
+    assert "alice@acme.com" not in safe_dumps(redacted["meta"]["metadata"])
+
+
+def test_a_caller_supplied_redaction_header_cannot_blank_the_guardrail_record(
+    logger: DataDogLLMObsLogger,
+) -> None:
+    """Any key may redact its own prompts with the header; none may erase what a guardrail caught."""
+    payload = build_payload()
+    payload["standard_logging_object"]["guardrail_information"] = [dict(_AUDIT_RECORD)]
+    payload["litellm_params"] = {"metadata": {"headers": {"x-litellm-enable-message-redaction": "true"}}}
+
+    span = _span_json(logger, payload)
+    record = span["meta"]["metadata"]["guardrail_information"][0]
+
+    assert span["meta"]["input"]["messages"] == [{"role": "user", "content": "redacted-by-litellm"}]
+    assert record["guardrail_status"] == "guardrail_intervened"
+    assert record["masked_entity_count"] == {"EMAIL": 2}
+    assert "alice@acme.com" not in safe_dumps(span["meta"]["metadata"])
+
+
+def test_a_guardrails_own_extra_field_never_reaches_a_redacted_span(logger: DataDogLLMObsLogger) -> None:
+    """A guardrail may record whatever it likes; only classified fields survive redaction."""
+    payload = build_payload()
+    payload["standard_logging_object"]["guardrail_information"] = [
+        {**_AUDIT_RECORD, "matched_text": "the caller asked about alice@acme.com"}
+    ]
+
+    span = _span_json(_redacting_logger(turn_off_message_logging=True), payload)
+    record = span["meta"]["metadata"]["guardrail_information"][0]
+
+    assert "matched_text" not in record
+    assert record["guardrail_status"] == "guardrail_intervened"
+    assert "alice@acme.com" not in safe_dumps(span["meta"]["metadata"])
+
+
+def test_odd_guardrail_shapes_never_raise() -> None:
+    """The redacted branch replaced an expression that could not fail, so it must not start failing."""
+    from litellm.integrations.datadog.datadog_llm_obs import (
+        _guardrail_information_without_prompt_carriers,
+    )
+
+    assert _guardrail_information_without_prompt_carriers(None) is None
+    assert _guardrail_information_without_prompt_carriers([]) == ()
+    assert _guardrail_information_without_prompt_carriers(5) == ()
+    assert _guardrail_information_without_prompt_carriers("abc") == ()
+    assert (
+        _guardrail_information_without_prompt_carriers([None, "x", dict(_AUDIT_RECORD)])
+        == (_guardrail_information_without_prompt_carriers([dict(_AUDIT_RECORD)]) or ())[:1]
+    )
+
+
+def test_every_guardrail_field_is_classified() -> None:
+    """Redaction is derived from a declaration, not a list at the call site, so every field has to
+    be classified as quoting the prompt or reporting what the guardrail decided. A field added
+    without a decision fails here rather than silently shipping the prompt on a redacted span."""
+    from litellm.types.utils import (
+        AUDIT_GUARDRAIL_FIELDS,
+        PROMPT_CARRYING_GUARDRAIL_FIELDS,
+        StandardLoggingGuardrailInformation,
+    )
+
+    declared = set(StandardLoggingGuardrailInformation.__annotations__)
+    classified = PROMPT_CARRYING_GUARDRAIL_FIELDS | AUDIT_GUARDRAIL_FIELDS
+    assert declared == classified, (
+        "classify new guardrail-record fields in litellm/types/utils.py: "
+        f"unclassified={declared - classified}, stale={classified - declared}"
+    )
+    assert not (PROMPT_CARRYING_GUARDRAIL_FIELDS & AUDIT_GUARDRAIL_FIELDS)
 
 
 def test_tool_definitions_accept_the_bare_anthropic_shape(logger: DataDogLLMObsLogger) -> None:


### PR DESCRIPTION
## TLDR

Problem this solves:

- Message redaction blanked the guardrail record on Datadog spans
- Operators could no longer tell what a guardrail caught
- Any API key could erase its own guardrail record with one header

How it solves it:

- Replace only the four guardrail fields that can quote the prompt
- Keep name, mode, status, timings and masked-entity counts
- Reuse the field list the spend-log redaction already applies

## User Flow

Before: a compliance engineer who turned message logging off cannot answer "did a guardrail catch anything on that request"

1. The proxy admin sets `turn_off_message_logging: true` and turns on a PII guardrail
2. A developer sends POST https://litellm-domain/v1/chat/completions with `mail alice@acme.com and bob@acme.com`
3. The guardrail masks both addresses and the request succeeds
4. The engineer opens the request in Datadog LLM Observability and sees `guardrail_information: null`
5. Nothing on the span says which guardrail ran, whether it intervened, or how many entities it masked
6. Any developer holding an ordinary key can produce the same blank record on demand, by adding `x-litellm-enable-message-redaction: true` to their own request

After: the same span still hides the prompt and now carries the guardrail record

1. The proxy admin sets `turn_off_message_logging: true` and turns on a PII guardrail
2. A developer sends the same POST https://litellm-domain/v1/chat/completions
3. The guardrail masks both addresses and the request succeeds
4. The engineer opens the request in Datadog LLM Observability and sees the guardrail entry with `guardrail_name: presidio-pii`, `guardrail_status`, its timings, and `masked_entity_count: {"EMAIL_ADDRESS": 2}`
5. The prompt is still `redacted-by-litellm`, and the guardrail's own copy of it reads `REDACTED_BY_LITELM`
6. A developer sending `x-litellm-enable-message-redaction: true` still hides their own prompt and no longer removes the guardrail record

## Relevant issues

## Linear ticket

Refs LIT-6728

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Both cases are end to end against real Datadog LLM Observability (us5) with a real OpenAI call and a real Presidio guardrail; the spans are read back through Datadog's own LLM Obs search API. Nothing is mocked.

Shared setup:

```yaml
model_list:
  - model_name: gpt-4o
    litellm_params:
      model: openai/gpt-4.1-mini
      api_key: os.environ/OPENAI_API_KEY
guardrails:
  - guardrail_name: "presidio-pii"
    litellm_params:
      guardrail: presidio
      mode: "pre_call"
      default_on: true
litellm_settings:
  callbacks: ["datadog_llm_observability"]
  turn_off_message_logging: true    # case 1 only; case 2 runs with this false
general_settings:
  master_key: sk-1234
```

Read-back command used in every step below:

```bash
curl -sS -X POST "https://api.us5.datadoghq.com/api/unstable/llm-obs/v1/spans/events/search" \
  -H "DD-API-KEY: $DD_API_KEY" -H "DD-APPLICATION-KEY: $DD_APP_KEY" \
  -H 'Content-Type: application/json' \
  -d '{"data":{"type":"spans","attributes":{"filter":{"from":"now-15m","to":"now","query":"env:<env>"},"page":{"limit":2},"sort":"-timestamp"}}}'
```

### Before (aec083cdac, `litellm_internal_staging` with #39402 as merged)

#### Case 1: operator sets turn_off_message_logging

1. Send the request

```bash
curl -sS http://127.0.0.1:20403/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H 'Content-Type: application/json' \
  -d '{"model":"gpt-4o","messages":[{"role":"user","content":"mail alice@acme.com and bob@acme.com"}],"max_tokens":12}'
# http 200
```

2. Read the span back from Datadog

```
spans: 1
 input:                     {"value": "redacted-by-litellm", "messages": [{"content": "redacted-by-litellm", "role": "user"}]}
 guardrail_information:     null
 applied_guardrails:        ["presidio-pii"]
 guardrail_overhead_time_ms: 88.551
```

The span records that 88 ms went to guardrails and gives no way to find out which one, whether it intervened, or what it masked.

#### Case 2: ordinary key sends the redaction header

1. Mint an ordinary virtual key and confirm it is not an admin

```bash
curl -sS http://127.0.0.1:20403/key/generate -H "Authorization: Bearer sk-1234" \
  -H 'Content-Type: application/json' -d '{"models":["gpt-4o"],"key_alias":"ordinary-caller-39402"}'
curl -sS http://127.0.0.1:20403/key/list    -H "Authorization: Bearer $KEY" -o /dev/null -w "%{http_code}\n"   # 403
curl -sS http://127.0.0.1:20403/config/update -H "Authorization: Bearer $KEY" -d '{}' -o /dev/null -w "%{http_code}\n"  # 401
```

2. Send a request with the redaction header, with `turn_off_message_logging: false` in the config

```bash
curl -sS http://127.0.0.1:20403/v1/responses \
  -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' \
  -H 'x-litellm-enable-message-redaction: true' \
  -d '{"model":"gpt-4o","input":"mail alice@acme.com and bob@acme.com","max_output_tokens":16}'
# http 200
```

3. Read the span back from Datadog

```
spans: 1
 input:                 {"value": "redacted-by-litellm", "messages": [{"content": "redacted-by-litellm", "role": "user"}]}
 key_alias:             ordinary-caller-39402
 guardrail_information: null
```

### After (64fc74bec9, this PR)

#### Case 1: operator sets turn_off_message_logging

1. Send the same request

```bash
curl -sS http://127.0.0.1:20402/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H 'Content-Type: application/json' \
  -d '{"model":"gpt-4o","messages":[{"role":"user","content":"mail alice@acme.com and bob@acme.com"}],"max_tokens":12}'
# http 200
```

2. Read the span back from Datadog

```json
{
  "input": {"value": "redacted-by-litellm", "messages": [{"content": "redacted-by-litellm", "role": "user"}]},
  "metadata": {
    "applied_guardrails": ["presidio-pii"],
    "guardrail_information": [
      {"guardrail_name": "presidio-pii", "guardrail_provider": "presidio", "guardrail_mode": "pre_call",
       "guardrail_status": "success", "guardrail_response": "REDACTED_BY_LITELM",
       "masked_entity_count": {"EMAIL_ADDRESS": 2},
       "start_time": 1788555468.743473, "end_time": 1788555468.80831, "duration": 0.064839},
      {"guardrail_name": "presidio-pii", "guardrail_provider": "presidio", "guardrail_mode": "post_call",
       "guardrail_status": "success", "guardrail_response": "REDACTED_BY_LITELM",
       "start_time": 1788555470.004475, "end_time": 1788555470.031875, "duration": 0.027402}
    ],
    "latency_metrics": {"guardrail_overhead_time_ms": 92.241}
  }
}
```

The prompt is still gone. The record of what the guardrail did is back.

#### Case 2: ordinary key sends the redaction header

1. Send the same request with the same ordinary key and the same header

```bash
curl -sS http://127.0.0.1:20402/v1/responses \
  -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' \
  -H 'x-litellm-enable-message-redaction: true' \
  -d '{"model":"gpt-4o","input":"mail alice@acme.com and bob@acme.com","max_output_tokens":16}'
# http 200
```

2. Read the span back from Datadog

```
spans: 1
 input:                 {"value": "redacted-by-litellm", "messages": [{"content": "redacted-by-litellm", "role": "user"}]}
 key_alias:             ordinary-caller-39402
 guardrail_information: [{"guardrail_name": "presidio-pii", "guardrail_provider": "presidio",
                          "guardrail_mode": "pre_call", "guardrail_status": "success",
                          "guardrail_response": "REDACTED_BY_LITELM",
                          "masked_entity_count": {"EMAIL_ADDRESS": 2},
                          "start_time": 1788555528.537273, "end_time": 1788555528.58951, "duration": 0.052238},
                         {"guardrail_name": "presidio-pii", "guardrail_mode": "post_call", ...}]
```

The key still redacts its own prompt and can no longer erase what the guardrail caught.

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- Span field changes from `null` to an array under redaction
  - Only for the redacted case; the unredacted span is unchanged
  - This restores the shape that shipped before #39402
  - A Datadog monitor written against `null` in the last day would see the type change
  - No in-repo consumer reads this span field

### Low

- Four other metadata records stay dropped under redaction
  - `requester_metadata`, `prompt_management_metadata`, `mcp_tool_call_metadata`, `vector_store_request_metadata`
  - Those carry caller text, tool arguments and retrieved passages, so dropping them is correct
- `routing_decision` is still re-emitted flattened, not restored nested
  - Deliberately left alone; the router already strips its prompt-quoting fields upstream
  - It is a routing telemetry record, not an enforcement audit record

### Reviewer notes

- A redacted span can carry two different redaction markers at once
  - The message body reads `redacted-by-litellm` and the guardrail's own copy of the prompt reads `REDACTED_BY_LITELM`
  - Two different constants that already existed; this PR reuses the one the spend-log path uses for the same field, rather than introducing a third
- Datadog spans still do not carry the numeric guardrail compression stats that spend logs keep
  - Pre-existing on both sides of this diff and out of scope here
- A guardrail record left as a single mapping rather than a list is normalized before redaction and before latency extraction
  - `guardrail_information` is typed as a list, and Prometheus already normalizes the same shape at `_guardrail_overhead_seconds`
  - Before this PR that shape raised inside `_get_latency_metrics` and the span was dropped, on both sides of the diff
  - No first-party guardrail produces it today, so it is covered by unit tests rather than a live leg

## Testing

- `tests/test_litellm/integrations/datadog/test_datadog_llm_obs.py` — 68 passed
- Mutation check: reverting `datadog_llm_obs.py` to the merge-base version fails 5 of the new tests, and dropping the single-record normalization alone fails one more
- Live: real Datadog LLM Observability (us5), real OpenAI call, real Presidio guardrail, both triggers, before and after
- Live regression legs re-run on this head: unredacted-span A/B base vs head identical, `guardrail_overhead_time_ms` still computed on both sides; spend-log sanitizer output byte-identical base vs head; 4 workers with 8-way concurrency (16/16 200s, one span shape, no prompt text); paused-Postgres fault leg (3/3 200s, no malformed records)

ran /live-pr-risk and found no regressions/backward incompatible risks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only redaction behavior change: redacted spans expose guardrail audit metadata instead of null, with stricter field filtering; spend-log sanitizer uses the same constant with no logic change beyond import.
> 
> **Overview**
> When **message redaction** is on (`turn_off_message_logging`, per-request header, etc.), Datadog LLM Observability spans no longer drop **`guardrail_information` entirely**. They now **redact only the four prompt-carrying fields** (`guardrail_request`, `guardrail_response`, `match_details`, `classification`) to `REDACTED_BY_LITELM`, while **keeping audit fields** such as name, provider, mode, status, timings, and masked-entity counts.
> 
> **`PROMPT_CARRYING_GUARDRAIL_FIELDS`** and **`AUDIT_GUARDRAIL_FIELDS`** are defined in `litellm/types/utils.py` and reused by the Datadog logger and spend-log sanitizer (replacing a local duplicate). Redacted spans use an **allow-list**: unclassified guardrail keys are stripped so custom fields cannot leak prompts.
> 
> **`_guardrail_entries`** normalizes list vs single-dict `guardrail_information` for redaction and **`guardrail_overhead_time_ms`** computation. New unit tests cover audit survival, header redaction, odd shapes, and full field coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64fc74bec9e1e62c1b373d54ae6c15d5e31eaa87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->