### PR TITLE
fix(ocr): match Rust SDK behavior with Python

### DIFF
--- a/litellm-rust/crates/ai-gateway/src/audio_transcription/hooks.rs
+++ b/litellm-rust/crates/ai-gateway/src/audio_transcription/hooks.rs
@@ -1,9 +1,9 @@
+use litellm_core::Error;
 use litellm_core::audio_transcription::{
     AudioTranscriptionRequest as CoreAudioTranscriptionRequest, ProviderAudioTranscriptionRequest,
     prepare_audio_transcription_provider_call,
 };
 use litellm_core::call_lifecycle::{CallLifecycleContext, CallLifecycleHooks, CallLifecycleTiming};
-use litellm_core::error::Error;
 use serde_json::{Map, Value, json};
 use std::future::Future;
 use std::pin::Pin;

--- a/litellm-rust/crates/ai-gateway/src/error.rs
+++ b/litellm-rust/crates/ai-gateway/src/error.rs
@@ -1,0 +1,5 @@
+use litellm_core::Error;
+
+pub(crate) fn invalid_json_response(operation: &'static str, error: serde_json::Error) -> Error {
+    Error::InvalidResponse(format!("invalid {operation} response JSON: {error}"))
+}

--- a/litellm-rust/crates/ai-gateway/src/io/realtime.rs
+++ b/litellm-rust/crates/ai-gateway/src/io/realtime.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 
 use futures_util::stream::{SplitSink, SplitStream};
 use futures_util::{Sink, SinkExt, Stream, StreamExt};
-use litellm_core::error::Error;
+use litellm_core::Error;
 use litellm_core::realtime::transformation::RealtimeProviderConfig;
 use litellm_core::realtime::types::RealtimeEvent;
 use tokio::net::TcpStream;

--- a/litellm-rust/crates/ai-gateway/src/lib.rs
+++ b/litellm-rust/crates/ai-gateway/src/lib.rs
@@ -15,6 +15,7 @@
 
 pub mod audio_transcription;
 mod client;
+mod error;
 pub mod io;
 pub mod ocr;
 

--- a/litellm-rust/crates/ai-gateway/src/ocr/common_utils.rs
+++ b/litellm-rust/crates/ai-gateway/src/ocr/common_utils.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, Instant};
 
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
-use litellm_core::error::Error;
+use litellm_core::Error;
 use litellm_core::ocr::transformation::OcrProviderConfig;
 use reqwest::Url;
 use serde_json::{Map, Value};
@@ -19,19 +19,11 @@ use litellm_core::providers::vertex_ai::ocr::transformation::{
 };
 
 use crate::client::http_client;
+use crate::error::invalid_json_response;
 
-const ERROR_BODY_MAX_CHARS: usize = 256;
 const AZURE_DOCUMENT_INTELLIGENCE_POLL_TIMEOUT_SECS: u64 = 120;
 const DEFAULT_MAX_IMAGE_URL_DOWNLOAD_SIZE_MB: f64 = 50.0;
 const MAX_SAFE_FETCH_REDIRECTS: usize = 10;
-
-pub(super) fn truncate_error_body(body: &str) -> String {
-    if body.chars().count() <= ERROR_BODY_MAX_CHARS {
-        return body.to_string();
-    }
-    let truncated: String = body.chars().take(ERROR_BODY_MAX_CHARS).collect();
-    format!("{truncated}... (truncated)")
-}
 
 #[tracing::instrument(target = "litellm::function_trace", level = "trace", skip_all)]
 pub(super) fn ocr_provider_config(
@@ -265,14 +257,13 @@ pub(super) async fn convert_document_url_to_data_uri(document: Value) -> Result<
         let body = response.text().await.unwrap_or_default();
         return Err(Error::Http {
             status: status.as_u16(),
-            body: truncate_error_body(&body),
+            body,
         });
     }
     let content_type = response
         .headers()
         .get(reqwest::header::CONTENT_TYPE)
         .and_then(|value| value.to_str().ok())
-        .and_then(|value| value.split(';').next())
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .unwrap_or("application/octet-stream")
@@ -380,12 +371,11 @@ pub(super) async fn poll_document_intelligence(
         if !status.is_success() {
             return Err(Error::Http {
                 status: status.as_u16(),
-                body: truncate_error_body(&text),
+                body: text,
             });
         }
-        let response_json: Value = serde_json::from_str(&text).map_err(|err| {
-            Error::InvalidResponse(format!("invalid Azure DI poll response JSON: {err}"))
-        })?;
+        let response_json: Value = serde_json::from_str(&text)
+            .map_err(|error| invalid_json_response("Azure DI poll", error))?;
         if operation_status(&response_json)? == "succeeded" {
             return Ok(response_json);
         }
@@ -442,33 +432,6 @@ mod tests {
             .unwrap();
 
         assert_eq!(transformed, document);
-    }
-
-    #[test]
-    fn truncate_error_body_passes_short_strings_through() {
-        let body = "Unauthorized";
-        assert_eq!(truncate_error_body(body), "Unauthorized");
-    }
-
-    #[test]
-    fn truncate_error_body_caps_long_payloads() {
-        let body = "x".repeat(306);
-        let truncated = truncate_error_body(&body);
-
-        assert!(truncated.ends_with("... (truncated)"));
-        let prefix_chars = truncated
-            .strip_suffix("... (truncated)")
-            .expect("truncated marker present")
-            .chars()
-            .count();
-        assert_eq!(prefix_chars, 256);
-    }
-
-    #[test]
-    fn truncate_error_body_does_not_split_multibyte_chars() {
-        let body = "é".repeat(266);
-        let truncated = truncate_error_body(&body);
-        assert!(truncated.is_char_boundary(truncated.len()));
     }
 
     #[test]

--- a/litellm-rust/crates/ai-gateway/src/ocr/handler.rs
+++ b/litellm-rust/crates/ai-gateway/src/ocr/handler.rs
@@ -1,12 +1,13 @@
-use litellm_core::error::Error;
+use litellm_core::Error;
 use litellm_core::http_utils::http_request;
 use litellm_core::ocr::transformation::OcrResponseHandling;
 use serde_json::Value;
 
-use super::common_utils::{poll_document_intelligence, truncate_error_body};
+use super::common_utils::poll_document_intelligence;
 use super::hooks::OcrLifecycleHooks;
 use super::types::PreparedOcrRequest;
 use crate::client::http_client;
+use crate::error::invalid_json_response;
 
 #[tracing::instrument(target = "litellm::function_trace", level = "trace", skip_all)]
 pub(crate) async fn execute_ocr_provider_call(
@@ -16,7 +17,9 @@ pub(crate) async fn execute_ocr_provider_call(
     let request = hooks.prepare_provider_request(request).await?;
     let mut request_builder = http_client().post(&request.url).json(&request.body);
     for (key, value) in &request.upstream_headers {
-        request_builder = request_builder.header(key, value);
+        if !key.eq_ignore_ascii_case("content-type") {
+            request_builder = request_builder.header(key, value);
+        }
     }
     if let Some(duration) = request.timeout {
         request_builder = request_builder.timeout(duration);
@@ -66,12 +69,12 @@ pub(crate) async fn execute_ocr_provider_call(
     if !status.is_success() {
         return Err(Error::Http {
             status: status.as_u16(),
-            body: truncate_error_body(&text),
+            body: text,
         });
     }
 
-    let response_json: Value = serde_json::from_str(&text)
-        .map_err(|err| Error::InvalidResponse(format!("invalid OCR response JSON: {err}")))?;
+    let response_json: Value =
+        serde_json::from_str(&text).map_err(|error| invalid_json_response("OCR", error))?;
 
     Ok(request
         .config

--- a/litellm-rust/crates/ai-gateway/src/ocr/hooks.rs
+++ b/litellm-rust/crates/ai-gateway/src/ocr/hooks.rs
@@ -1,5 +1,5 @@
+use litellm_core::Error;
 use litellm_core::call_lifecycle::{CallLifecycleContext, CallLifecycleHooks, CallLifecycleTiming};
-use litellm_core::error::Error;
 use litellm_core::providers::reducto::ocr::transformation::{
     build_upload_request, extract_document_source, extract_upload_file_id,
 };
@@ -7,9 +7,10 @@ use serde_json::{Map, Value, json};
 use std::future::Future;
 use std::pin::Pin;
 
-use super::common_utils::{convert_document_url_to_data_uri, string_headers, truncate_error_body};
+use super::common_utils::{convert_document_url_to_data_uri, string_headers};
 use super::types::{PreparedOcrRequest, ProviderOcrRequest};
 use crate::client::http_client;
+use crate::error::invalid_json_response;
 use crate::integrations::custom_guardrail::{
     CustomGuardrailRunner, GuardrailContext, GuardrailError, GuardrailRequest,
 };
@@ -233,12 +234,11 @@ async fn upload_reducto_document(
     if !status.is_success() {
         return Err(Error::Http {
             status: status.as_u16(),
-            body: truncate_error_body(&body),
+            body,
         });
     }
-    let response_json: Value = serde_json::from_str(&body).map_err(|error| {
-        Error::InvalidResponse(format!("invalid Reducto upload response JSON: {error}"))
-    })?;
+    let response_json: Value = serde_json::from_str(&body)
+        .map_err(|error| invalid_json_response("Reducto upload", error))?;
     let file_id = extract_upload_file_id(&response_json)?;
     Ok(json!({"type": "document_url", "document_url": file_id}))
 }

--- a/litellm-rust/crates/ai-gateway/src/ocr/prepare.rs
+++ b/litellm-rust/crates/ai-gateway/src/ocr/prepare.rs
@@ -113,7 +113,7 @@ fn new_ocr_call_id() -> String {
 
 #[cfg(test)]
 mod tests {
-    use litellm_core::error::Error;
+    use litellm_core::Error;
     use serde_json::{Map, json};
 
     use super::{OcrRequest, prepare_ocr_call};

--- a/litellm-rust/crates/ai-gateway/src/python/config.rs
+++ b/litellm-rust/crates/ai-gateway/src/python/config.rs
@@ -6,7 +6,7 @@
 //! (and recorded in [`crate::gil`]); the realtime hot path never touches Python.
 //!
 //! Compiled only under the `python-config` feature.
-use litellm_core::error::Error;
+use litellm_core::Error;
 use litellm_core::router::{Deployment, Router};
 use pyo3::prelude::*;
 

--- a/litellm-rust/crates/ai-gateway/src/routes/realtime/service.rs
+++ b/litellm-rust/crates/ai-gateway/src/routes/realtime/service.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 use crate::io::realtime_pool::{RealtimePool, upstream_key};
 use futures_util::{Sink, Stream};
-use litellm_core::error::Error;
+use litellm_core::Error;
 use litellm_core::realtime::types::RealtimeEvent;
 use litellm_core::router::Router;
 

--- a/litellm-rust/crates/ai-gateway/tests/ocr_lifecycle.rs
+++ b/litellm-rust/crates/ai-gateway/tests/ocr_lifecycle.rs
@@ -10,7 +10,7 @@ use litellm_ai_gateway::integrations::custom_logger::{
 };
 use litellm_ai_gateway::integrations::types::RequestMetadata;
 use litellm_ai_gateway::ocr::{OcrRequest, ocr};
-use litellm_core::error::Error;
+use litellm_core::Error;
 use serde_json::{Map, Value, json};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
@@ -257,7 +257,7 @@ async fn reducto_during_call_guardrail_blocks_before_upload() {
 }
 
 #[tokio::test]
-async fn reducto_upload_error_body_is_truncated() {
+async fn reducto_upload_error_body_is_preserved() {
     let listener = TcpListener::bind("127.0.0.1:0")
         .await
         .expect("test listener binds");
@@ -286,9 +286,7 @@ async fn reducto_upload_error_body_is_truncated() {
 
     let error = ocr(request).await.expect_err("upload should fail");
 
-    assert!(
-        matches!(error, Error::Http { status: 500, body } if body.chars().count() < 300 && body.ends_with("... (truncated)"))
-    );
+    assert!(matches!(error, Error::Http { status: 500, body } if body == "x".repeat(300)));
     server.await.expect("server task completes");
 }
 
@@ -530,6 +528,11 @@ async fn ocr_does_not_duplicate_authorization_header_when_header_is_supplied() {
         .filter(|line| line.to_ascii_lowercase().starts_with("authorization:"))
         .count();
     assert_eq!(authorization_count, 1, "{request}");
+    let content_type_count = request
+        .lines()
+        .filter(|line| line.to_ascii_lowercase().starts_with("content-type:"))
+        .count();
+    assert_eq!(content_type_count, 1, "{request}");
     assert!(
         request.contains("authorization: Bearer sk-from-python")
             || request.contains("Authorization: Bearer sk-from-python"),

--- a/litellm-rust/crates/core/src/providers/azure_ai/ocr/transformation.rs
+++ b/litellm-rust/crates/core/src/providers/azure_ai/ocr/transformation.rs
@@ -603,6 +603,12 @@ impl OcrProviderConfig for AzureDocumentIntelligenceOcrConfig {
         transform_document_intelligence_response(model, response_json, false)
     }
 
+    #[tracing::instrument(
+        name = "transform_ocr_response",
+        target = "litellm::function_trace",
+        level = "trace",
+        skip_all
+    )]
     fn transform_ocr_response_with_params(
         &self,
         model: &str,

--- a/litellm-rust/crates/core/src/providers/vertex_ai/ocr/transformation.rs
+++ b/litellm-rust/crates/core/src/providers/vertex_ai/ocr/transformation.rs
@@ -12,6 +12,12 @@ const VERTEXAI_API_KEY_ENV: &str = "VERTEXAI_API_KEY";
 const VERTEXAI_PROJECT_ENV: &str = "VERTEXAI_PROJECT";
 const VERTEXAI_LOCATION_ENV: &str = "VERTEXAI_LOCATION";
 const VERTEX_LOCATION_ENV: &str = "VERTEX_LOCATION";
+const VERTEX_ROUTING_PARAMS: &[&str] = &[
+    "vertex_project",
+    "vertex_ai_project",
+    "vertex_location",
+    "vertex_ai_location",
+];
 
 #[rustfmt::skip]
 const DEEPSEEK_SUPPORTED_OCR_PARAMS: &[&str] = &[
@@ -219,7 +225,11 @@ impl OcrProviderConfig for VertexAiOcrConfig {
         document: Value,
         optional_params: Map<String, Value>,
     ) -> Result<OcrRequestData, Error> {
-        MISTRAL_OCR_CONFIG.transform_ocr_request(model, document, optional_params)
+        let provider_params = optional_params
+            .into_iter()
+            .filter(|(name, _)| !VERTEX_ROUTING_PARAMS.contains(&name.as_str()))
+            .collect();
+        MISTRAL_OCR_CONFIG.transform_ocr_request(model, document, provider_params)
     }
 
     fn transform_ocr_response(
@@ -408,6 +418,26 @@ mod tests {
 
         assert_eq!(body["model"], "mistral-ocr-maas");
         assert_eq!(body["document"]["image_url"], "data:image/png;base64,abc");
+    }
+
+    #[test]
+    fn vertex_mistral_routing_params_are_not_sent_to_provider() {
+        let body = VERTEX_AI_OCR_CONFIG
+            .transform_ocr_request(
+                "mistral-ocr-maas",
+                json!({"type": "image_url", "image_url": "data:image/png;base64,abc"}),
+                Map::from_iter([
+                    ("vertex_project".to_string(), json!("proj-1")),
+                    ("vertex_location".to_string(), json!("europe-west4")),
+                    ("include_blocks".to_string(), json!(true)),
+                ]),
+            )
+            .expect("request transforms")
+            .data;
+
+        assert_eq!(body["include_blocks"], true);
+        assert!(body.get("vertex_project").is_none());
+        assert!(body.get("vertex_location").is_none());
     }
 
     #[test]

--- a/litellm/ocr/main.py
+++ b/litellm/ocr/main.py
@@ -10,7 +10,7 @@ import re
 from collections.abc import Callable, Coroutine, Mapping
 from dataclasses import dataclass
 from io import IOBase
-from typing import Any, Final, cast
+from typing import Any, Final, NoReturn, cast
 
 import httpx
 
@@ -29,6 +29,7 @@ from litellm.llms.base_llm.ocr.transformation import (
 )
 from litellm.llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
 from litellm.rust_bridge import ocr as rust_ocr_bridge
+from litellm.rust_bridge.bindings import native_exception_types
 from litellm.types.router import GenericLiteLLMParams
 from litellm.utils import ProviderConfigManager, client
 
@@ -239,6 +240,19 @@ def _rust_bridge_api_base(
     return None
 
 
+def _raise_rust_ocr_upstream(error: Exception, provider_config: BaseOCRConfig) -> NoReturn:
+    exception_types: Final = native_exception_types()
+    if exception_types is None or not isinstance(error, exception_types[1]):
+        raise error
+    args: Final[tuple[object, ...]] = error.args
+    status_value: Final = args[0] if args else 500
+    message_value: Final = args[1] if len(args) > 1 else str(error)
+    status: Final = status_value if isinstance(status_value, int) else 500
+    message: Final = message_value if isinstance(message_value, str) else str(message_value)
+    get_error_class: Final[Callable[..., Exception]] = cast(Callable[..., Exception], provider_config.get_error_class)
+    raise get_error_class(error_message=message, status_code=status, headers={}) from error
+
+
 def _prepare_rust_ocr_call(
     prepared_request: _PreparedOCRRequest,
     resolve_api_key: Callable[[str], str | None],
@@ -294,16 +308,19 @@ def _run_rust_ocr(
         prepared_request=prepared_request,
         resolve_api_key=resolve_api_key,
     )
-    rust_response: Final = rust_ocr_bridge.ocr(
-        model=prepared_request.model,
-        document=prepared_request.document,
-        api_key=prepared.api_key,
-        api_base=prepared.api_base,
-        custom_llm_provider=prepared_request.custom_llm_provider,
-        extra_headers=prepared.headers,
-        optional_params=prepared.optional_params,
-        timeout=prepared_request.effective_timeout,
-    )
+    try:
+        rust_response: Final = rust_ocr_bridge.ocr(
+            model=prepared_request.model,
+            document=prepared_request.document,
+            api_key=prepared.api_key,
+            api_base=prepared.api_base,
+            custom_llm_provider=prepared_request.custom_llm_provider,
+            extra_headers=prepared.headers,
+            optional_params=prepared.optional_params,
+            timeout=prepared_request.effective_timeout,
+        )
+    except Exception as error:
+        _raise_rust_ocr_upstream(error, prepared_request.provider_config)
     if rust_response is None:
         return None
     return OCRResponse.model_validate(rust_response)
@@ -319,16 +336,19 @@ async def _run_rust_aocr(
         prepared_request=prepared_request,
         resolve_api_key=resolve_api_key,
     )
-    rust_response: Final = await rust_ocr_bridge.aocr(
-        model=prepared_request.model,
-        document=prepared_request.document,
-        api_key=prepared.api_key,
-        api_base=prepared.api_base,
-        custom_llm_provider=prepared_request.custom_llm_provider,
-        extra_headers=prepared.headers,
-        optional_params=prepared.optional_params,
-        timeout=prepared_request.effective_timeout,
-    )
+    try:
+        rust_response: Final = await rust_ocr_bridge.aocr(
+            model=prepared_request.model,
+            document=prepared_request.document,
+            api_key=prepared.api_key,
+            api_base=prepared.api_base,
+            custom_llm_provider=prepared_request.custom_llm_provider,
+            extra_headers=prepared.headers,
+            optional_params=prepared.optional_params,
+            timeout=prepared_request.effective_timeout,
+        )
+    except Exception as error:
+        _raise_rust_ocr_upstream(error, prepared_request.provider_config)
     if rust_response is None:
         return None
     return OCRResponse.model_validate(rust_response)


### PR DESCRIPTION
## TLDR

Problem this solves:

- Rust OCR SDK results differed from Python
- Provider errors lost Python exception behavior

How it solves it:

- Aligns provider requests, responses, errors, and traces
- Preserves complete upstream error details

## User Flow

Before: a developer enabling the Rust core can receive different OCR behavior from the Python core

1. They call `litellm.ocr` or `litellm.aocr` with the Rust core enabled
2. Some provider requests contain different headers or routing fields
3. Some responses and provider errors differ from the Python core

After: the same OCR calls match the Python core

1. They call `litellm.ocr` or `litellm.aocr` with the Rust core enabled
2. Provider requests contain the same headers and provider fields
3. Responses and provider errors match the Python core

## Relevant issues

Stacked on #39689

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible
- [ ] I have received a Greptile Confidence Score of at least 4/5

## Delays in PR merge?

If you're seeing a delay in this PR being merged, ping the LiteLLM Team on Slack

## Screenshots / Proof of Fix

Not included because this changes the internal SDK execution path and has no proxy HTTP flow

## Type

Bug Fix

## Caveats (if any)

## Final Attestation

- [x] The tests check the right things, including the edge cases, and cover the affected real-world behavior
