### PR TITLE
fix: label .webm as audio/webm in audio transcription

### DIFF
--- a/litellm/litellm_core_utils/audio_utils/utils.py
+++ b/litellm/litellm_core_utils/audio_utils/utils.py
@@ -4,7 +4,9 @@ Utils used for litellm.transcription() and litellm.atranscription()
 
 import hashlib
 import os
+from collections.abc import Mapping
 from dataclasses import dataclass
+from types import MappingProxyType
 from typing import Final
 
 from litellm.types.files import (
@@ -15,6 +17,13 @@ from litellm.types.files import (
     get_file_mime_type_from_extension,
 )
 from litellm.types.utils import FileTypes
+
+# webm is an audio/video container; get_file_mime_type_from_extension returns
+# "video/webm", but this helper only ever handles audio for transcription, so a
+# .webm upload is audio. Labeling it video/webm makes Vertex Gemini
+# transcription return an empty transcript.
+# https://github.com/BerriAI/litellm/issues/38963
+_AUDIO_CONTAINER_MIME_OVERRIDES: Final[Mapping[str, str]] = MappingProxyType({"webm": "audio/webm"})
 
 
 @dataclass
@@ -121,7 +130,9 @@ def process_audio_file(audio_file: FileTypes) -> ProcessedAudioFile:
         try:
             # Extract extension from filename
             extension: Final = filename.split(".")[-1].lower() if "." in filename else "wav"
-            content_type = get_file_mime_type_from_extension(extension)
+            content_type = _AUDIO_CONTAINER_MIME_OVERRIDES.get(extension) or get_file_mime_type_from_extension(
+                extension
+            )
         except ValueError:
             # If extension is not recognized, fallback to audio/wav
             content_type = "audio/wav"

--- a/tests/test_litellm/litellm_core_utils/audio_utils/test_utils.py
+++ b/tests/test_litellm/litellm_core_utils/audio_utils/test_utils.py
@@ -1,0 +1,20 @@
+from litellm.litellm_core_utils.audio_utils.utils import process_audio_file
+
+
+def test_process_audio_file_labels_webm_as_audio():
+    # Regression for https://github.com/BerriAI/litellm/issues/38963: webm is an
+    # audio/video container and process_audio_file is audio-only, so a .webm
+    # upload must be audio/webm. video/webm makes Vertex Gemini transcription
+    # return an empty transcript
+    processed = process_audio_file(("speech.webm", b"\x1aE\xdf\xa3"))
+    assert processed.content_type == "audio/webm"
+
+
+def test_process_audio_file_keeps_known_audio_extension():
+    processed = process_audio_file(("speech.wav", b"RIFF"))
+    assert processed.content_type == "audio/wav"
+
+
+def test_process_audio_file_unknown_extension_falls_back_to_wav():
+    processed = process_audio_file(("recording.unknownext", b"x"))
+    assert processed.content_type == "audio/wav"


### PR DESCRIPTION
## TLDR

Problem this solves:

- webm audio transcription returns an empty transcript on Vertex Gemini

How it solves it:

- label .webm uploads as audio/webm, not video/webm, in the audio-only helper

## User Flow

Before: a user transcribing a browser-recorded .webm file gets an empty transcript back

1. They send POST https://litellm-domain/v1/audio/transcriptions with `file=@speech.webm` and `model=gemini-3.5-transcribe-preview`
2. The response is 200 with `{"text": "", "usage": {"input_token_details": {"audio_tokens": 0}}}`, so the app shows nothing transcribed

After: the same request returns the real transcript

1. They send the same POST https://litellm-domain/v1/audio/transcriptions with `file=@speech.webm` and `model=gemini-3.5-transcribe-preview`
2. The response is 200 with a non-empty `text` and non-zero `audio_tokens`, so the app shows the transcription

## Relevant issues

Fixes #38963

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally: `pytest tests/test_litellm/litellm_core_utils/audio_utils/test_utils.py -v`
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

`process_audio_file` produces the value that is sent as `inlineData.mimeType` to Vertex Gemini, so the fix is visible in that value. I don't have paid `gemini-3.5-transcribe-preview` access to capture the live transcript, so I'm showing the exact mimeType before and after at the two commit hashes. On the reporter's setup this flips the transcript from empty to populated

### Before (8fc0663)

1. `python -c "from litellm.litellm_core_utils.audio_utils.utils import process_audio_file as p; print(p(('speech.webm', b'x')).content_type)"`
2. prints `video/webm`, which is what gets sent as `inlineData.mimeType`, so Gemini treats an audio-only webm as a video with no track and returns an empty transcript

### After (409de2f)

1. `python -c "from litellm.litellm_core_utils.audio_utils.utils import process_audio_file as p; print(p(('speech.webm', b'x')).content_type)"`
2. prints `audio/webm`, so Gemini receives audio and transcribes it