### PR TITLE
feat(model_prices): add missing Databricks Foundation Model API models and refresh Gemini 2.5 rates

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -17340,10 +17340,10 @@
         "supports_vision": false
     },
     "databricks/databricks-gemini-2-5-flash": {
-        "cache_creation_input_token_cost": 3.7499e-07,
-        "cache_read_input_token_cost": 3.752e-08,
-        "input_cost_per_token": 3.7499e-07,
-        "input_dbu_cost_per_token": 5.3570000000000005e-06,
+        "cache_creation_input_token_cost": 3.0002e-07,
+        "cache_read_input_token_cost": 3.0002e-08,
+        "input_cost_per_token": 3.0002e-07,
+        "input_dbu_cost_per_token": 4.285999999999999e-06,
         "litellm_provider": "databricks",
         "max_input_tokens": 1048576,
         "max_output_tokens": 65535,
@@ -17352,18 +17352,18 @@
             "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
         },
         "mode": "chat",
-        "output_cost_per_token": 3.12501e-06,
-        "output_dbu_cost_per_token": 4.4643e-05,
+        "output_cost_per_token": 2.49998e-06,
+        "output_dbu_cost_per_token": 3.5714e-05,
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_function_calling": true,
         "supports_prompt_caching": true,
         "supports_tool_choice": true
     },
     "databricks/databricks-gemini-2-5-pro": {
-        "cache_creation_input_token_cost": 1.56247e-06,
-        "cache_read_input_token_cost": 1.5624e-07,
-        "input_cost_per_token": 1.56247e-06,
-        "input_dbu_cost_per_token": 2.2321000000000002e-05,
+        "cache_creation_input_token_cost": 1.24999e-06,
+        "cache_read_input_token_cost": 1.2499900000000002e-07,
+        "input_cost_per_token": 1.24999e-06,
+        "input_dbu_cost_per_token": 1.7857e-05,
         "litellm_provider": "databricks",
         "max_input_tokens": 1048576,
         "max_output_tokens": 65536,
@@ -17372,8 +17372,8 @@
             "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
         },
         "mode": "chat",
-        "output_cost_per_token": 1.249997e-05,
-        "output_dbu_cost_per_token": 0.000178571,
+        "output_cost_per_token": 9.99999e-06,
+        "output_dbu_cost_per_token": 0.000142857,
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_function_calling": true,
         "supports_prompt_caching": true,
@@ -58692,42 +58692,28 @@
         "max_input_tokens": 1048576
     },
     "databricks/databricks-gemini-3-7-flash": {
-        "cache_creation_input_token_cost": 1.87502e-06,
-        "cache_read_input_token_cost": 1.8753e-07,
-        "input_cost_per_token": 1.87502e-06,
-        "input_dbu_cost_per_token": 2.6786e-05,
         "litellm_provider": "databricks",
         "max_output_tokens": 65536,
         "max_tokens": 65536,
         "metadata": {
-            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+            "notes": "Databricks DBU rates not yet published for this model; endpoint metadata only."
         },
         "mode": "chat",
-        "output_cost_per_token": 9.37503e-06,
-        "output_dbu_cost_per_token": 0.000133929,
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_function_calling": true,
-        "supports_prompt_caching": true,
         "supports_tool_choice": true,
         "max_input_tokens": 1048576
     },
     "databricks/databricks-gemini-3-8-flash": {
-        "cache_creation_input_token_cost": 1.87502e-06,
-        "cache_read_input_token_cost": 1.8753e-07,
-        "input_cost_per_token": 1.87502e-06,
-        "input_dbu_cost_per_token": 2.6786e-05,
         "litellm_provider": "databricks",
         "max_output_tokens": 65536,
         "max_tokens": 65536,
         "metadata": {
-            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+            "notes": "Databricks DBU rates not yet published for this model; endpoint metadata only."
         },
         "mode": "chat",
-        "output_cost_per_token": 9.37503e-06,
-        "output_dbu_cost_per_token": 0.000133929,
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_function_calling": true,
-        "supports_prompt_caching": true,
         "supports_tool_choice": true,
         "max_input_tokens": 1048576
     },
@@ -58814,7 +58800,9 @@
         "output_dbu_cost_per_token": 0.002571429,
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_prompt_caching": true,
-        "max_output_tokens": 128000
+        "max_output_tokens": 128000,
+        "cache_creation_input_token_cost": 2.999997e-05,
+        "cache_read_input_token_cost": 2.999997e-05
     },
     "databricks/databricks-gpt-5-6-luna": {
         "cache_creation_input_token_cost": 1.24999e-06,
@@ -58917,8 +58905,8 @@
         "cache_read_input_token_cost": 1.7003e-07
     },
     "databricks/databricks-qwen3-embedding-0-6b": {
-        "cache_creation_input_token_cost": 1.2999e-07,
-        "cache_read_input_token_cost": 1.2999e-07,
+        "cache_creation_input_token_cost": 2.002e-08,
+        "cache_read_input_token_cost": 2.002e-08,
         "input_cost_per_token": 2.002e-08,
         "input_dbu_cost_per_token": 2.86e-07,
         "litellm_provider": "databricks",
@@ -58946,7 +58934,9 @@
         "output_dbu_cost_per_token": 1.7143000000000002e-05,
         "source": "https://www.databricks.com/product/pricing/foundation-model-serving",
         "max_input_tokens": 262144,
-        "max_output_tokens": 25000
+        "max_output_tokens": 25000,
+        "cache_creation_input_token_cost": 1.5001e-07,
+        "cache_read_input_token_cost": 1.5001e-07
     },
     "databricks/databricks-qwen35-122b-a10b": {
         "input_cost_per_token": 2.2001e-07,
@@ -58961,6 +58951,8 @@
         "output_dbu_cost_per_token": 3.1429e-05,
         "source": "https://www.databricks.com/product/pricing/foundation-model-serving",
         "max_input_tokens": 262144,
-        "max_output_tokens": 25000
+        "max_output_tokens": 25000,
+        "cache_creation_input_token_cost": 2.2001e-07,
+        "cache_read_input_token_cost": 2.2001e-07
     }
 }

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -17340,10 +17340,10 @@
         "supports_vision": false
     },
     "databricks/databricks-gemini-2-5-flash": {
-        "cache_creation_input_token_cost": 3.0002e-07,
-        "cache_read_input_token_cost": 3.0002e-08,
-        "input_cost_per_token": 3.0001999999999996e-07,
-        "input_dbu_cost_per_token": 4.285999999999999e-06,
+        "cache_creation_input_token_cost": 3.7499e-07,
+        "cache_read_input_token_cost": 3.752e-08,
+        "input_cost_per_token": 3.7499e-07,
+        "input_dbu_cost_per_token": 5.3570000000000005e-06,
         "litellm_provider": "databricks",
         "max_input_tokens": 1048576,
         "max_output_tokens": 65535,
@@ -17352,18 +17352,18 @@
             "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
         },
         "mode": "chat",
-        "output_cost_per_token": 2.49998e-06,
-        "output_dbu_cost_per_token": 3.5714e-05,
+        "output_cost_per_token": 3.12501e-06,
+        "output_dbu_cost_per_token": 4.4643e-05,
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_function_calling": true,
         "supports_prompt_caching": true,
         "supports_tool_choice": true
     },
     "databricks/databricks-gemini-2-5-pro": {
-        "cache_creation_input_token_cost": 1.24999e-06,
-        "cache_read_input_token_cost": 1.24999e-07,
-        "input_cost_per_token": 1.24999e-06,
-        "input_dbu_cost_per_token": 1.7857e-05,
+        "cache_creation_input_token_cost": 1.56247e-06,
+        "cache_read_input_token_cost": 1.5624e-07,
+        "input_cost_per_token": 1.56247e-06,
+        "input_dbu_cost_per_token": 2.2321000000000002e-05,
         "litellm_provider": "databricks",
         "max_input_tokens": 1048576,
         "max_output_tokens": 65536,
@@ -17372,8 +17372,8 @@
             "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
         },
         "mode": "chat",
-        "output_cost_per_token": 9.999990000000002e-06,
-        "output_dbu_cost_per_token": 0.000142857,
+        "output_cost_per_token": 1.249997e-05,
+        "output_dbu_cost_per_token": 0.000178571,
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_function_calling": true,
         "supports_prompt_caching": true,
@@ -17510,10 +17510,10 @@
         "max_output_tokens": 131072,
         "max_tokens": 131072,
         "metadata": {
-            "notes": "Databricks has not published pay-per-token DBU rates for this model yet (not on the foundation-model-serving pricing page as of 2026-08-27), so cost fields are omitted until rates are published."
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
         },
         "mode": "chat",
-        "source": "https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/supported-models",
+        "source": "https://www.databricks.com/product/pricing/foundation-model-serving",
         "supported_modalities": [
             "text",
             "image"
@@ -17525,7 +17525,13 @@
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "input_cost_per_token": 1.5001e-07,
+        "input_dbu_cost_per_token": 2.1429999999999996e-06,
+        "output_cost_per_token": 5.0001e-07,
+        "output_dbu_cost_per_token": 7.143e-06,
+        "cache_creation_input_token_cost": 1.5001e-07,
+        "cache_read_input_token_cost": 3.003e-08
     },
     "databricks/databricks-gpt-5": {
         "cache_creation_input_token_cost": 1.24999e-06,
@@ -58573,5 +58579,388 @@
         "supported_endpoints": [
             "/v1/audio/transcriptions"
         ]
+    },
+    "databricks/databricks-claude-fable-5-1": {
+        "litellm_provider": "databricks",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "metadata": {
+            "notes": "Costs per token are the published Global DBU rates times $0.070 per DBU. The '*_dbu_cost_per_token' fields are provided for reference; cost calculation reads the dollar '*_cost_per_token' fields."
+        },
+        "mode": "chat",
+        "prompt_cache_min_tokens": 512,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_adaptive_thinking": true,
+        "supports_assistant_prefill": false,
+        "supports_function_calling": true,
+        "supports_mid_conversation_system": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_sampling_params": false,
+        "supports_tool_choice": true,
+        "supports_vision": false,
+        "thinking_always_on": true,
+        "input_cost_per_token": 1.000006e-05,
+        "input_dbu_cost_per_token": 0.000142858,
+        "output_cost_per_token": 5.000002e-05,
+        "output_dbu_cost_per_token": 0.000714286,
+        "cache_creation_input_token_cost": 1.250004e-05,
+        "cache_read_input_token_cost": 2.5004e-07
+    },
+    "databricks/databricks-gemini-3-1-flash-image": {
+        "litellm_provider": "databricks",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_tool_choice": true,
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "image"
+        ],
+        "supports_vision": true
+    },
+    "databricks/databricks-gemini-3-5-flash": {
+        "cache_creation_input_token_cost": 1.87502e-06,
+        "cache_read_input_token_cost": 1.8753e-07,
+        "input_cost_per_token": 1.87502e-06,
+        "input_dbu_cost_per_token": 2.6786e-05,
+        "litellm_provider": "databricks",
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 1.124998e-05,
+        "output_dbu_cost_per_token": 0.000160714,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_tool_choice": true,
+        "max_input_tokens": 1048576
+    },
+    "databricks/databricks-gemini-3-5-flash-lite": {
+        "cache_creation_input_token_cost": 3.7499e-07,
+        "cache_read_input_token_cost": 3.752e-08,
+        "input_cost_per_token": 3.7499e-07,
+        "input_dbu_cost_per_token": 5.3570000000000005e-06,
+        "litellm_provider": "databricks",
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 3.12501e-06,
+        "output_dbu_cost_per_token": 4.4643e-05,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_tool_choice": true,
+        "max_input_tokens": 1048576
+    },
+    "databricks/databricks-gemini-3-6-flash": {
+        "cache_creation_input_token_cost": 1.87502e-06,
+        "cache_read_input_token_cost": 1.8753e-07,
+        "input_cost_per_token": 1.87502e-06,
+        "input_dbu_cost_per_token": 2.6786e-05,
+        "litellm_provider": "databricks",
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 9.37503e-06,
+        "output_dbu_cost_per_token": 0.000133929,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_tool_choice": true,
+        "max_input_tokens": 1048576
+    },
+    "databricks/databricks-gemini-3-7-flash": {
+        "cache_creation_input_token_cost": 1.87502e-06,
+        "cache_read_input_token_cost": 1.8753e-07,
+        "input_cost_per_token": 1.87502e-06,
+        "input_dbu_cost_per_token": 2.6786e-05,
+        "litellm_provider": "databricks",
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 9.37503e-06,
+        "output_dbu_cost_per_token": 0.000133929,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_tool_choice": true,
+        "max_input_tokens": 1048576
+    },
+    "databricks/databricks-gemini-3-8-flash": {
+        "cache_creation_input_token_cost": 1.87502e-06,
+        "cache_read_input_token_cost": 1.8753e-07,
+        "input_cost_per_token": 1.87502e-06,
+        "input_dbu_cost_per_token": 2.6786e-05,
+        "litellm_provider": "databricks",
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 9.37503e-06,
+        "output_dbu_cost_per_token": 0.000133929,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_tool_choice": true,
+        "max_input_tokens": 1048576
+    },
+    "databricks/databricks-gemini-3-pro-image": {
+        "litellm_provider": "databricks",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_tool_choice": true,
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "image"
+        ],
+        "supports_vision": true
+    },
+    "databricks/databricks-glm-5-3": {
+        "cache_creation_input_token_cost": 1.4e-06,
+        "cache_read_input_token_cost": 2.5998e-07,
+        "input_cost_per_token": 1.4e-06,
+        "input_dbu_cost_per_token": 2e-05,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Billing reads the per-token dollar fields; the '*_dbu_cost_per_token' fields are the published Databricks rates, kept for reference."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 4.39999e-06,
+        "output_dbu_cost_per_token": 6.2857e-05,
+        "source": "https://www.databricks.com/product/pricing/foundation-model-serving",
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": false
+    },
+    "databricks/databricks-gpt-5-5": {
+        "cache_creation_input_token_cost": 5.00003e-06,
+        "cache_read_input_token_cost": 5.0001e-07,
+        "input_cost_per_token": 5.00003e-06,
+        "input_dbu_cost_per_token": 7.1429e-05,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 272000,
+        "max_tokens": 128000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 2.999997e-05,
+        "output_dbu_cost_per_token": 0.00042857100000000004,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_prompt_caching": true,
+        "max_output_tokens": 128000
+    },
+    "databricks/databricks-gpt-5-5-pro": {
+        "input_cost_per_token": 2.999997e-05,
+        "input_dbu_cost_per_token": 0.00042857100000000004,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 272000,
+        "max_tokens": 128000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 0.00018000003,
+        "output_dbu_cost_per_token": 0.002571429,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_prompt_caching": true,
+        "max_output_tokens": 128000
+    },
+    "databricks/databricks-gpt-5-6-luna": {
+        "cache_creation_input_token_cost": 1.24999e-06,
+        "cache_read_input_token_cost": 1.0003e-07,
+        "input_cost_per_token": 1.00002e-06,
+        "input_dbu_cost_per_token": 1.4286e-05,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 272000,
+        "max_tokens": 128000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 5.99998e-06,
+        "output_dbu_cost_per_token": 8.5714e-05,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_prompt_caching": true,
+        "max_output_tokens": 128000
+    },
+    "databricks/databricks-gpt-5-6-sol": {
+        "cache_creation_input_token_cost": 5.00003e-06,
+        "cache_read_input_token_cost": 3.9998e-07,
+        "input_cost_per_token": 4.00001e-06,
+        "input_dbu_cost_per_token": 5.7143e-05,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 272000,
+        "max_tokens": 128000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 1.999998e-05,
+        "output_dbu_cost_per_token": 0.000285714,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_prompt_caching": true,
+        "max_output_tokens": 128000
+    },
+    "databricks/databricks-gpt-5-6-terra": {
+        "cache_creation_input_token_cost": 3.12501e-06,
+        "cache_read_input_token_cost": 2.4997e-07,
+        "input_cost_per_token": 2.49998e-06,
+        "input_dbu_cost_per_token": 3.5714e-05,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 272000,
+        "max_tokens": 128000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 1.500002e-05,
+        "output_dbu_cost_per_token": 0.000214286,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_prompt_caching": true,
+        "max_output_tokens": 128000
+    },
+    "databricks/databricks-grok-4-6": {
+        "cache_creation_input_token_cost": 2.49998e-06,
+        "cache_read_input_token_cost": 6.2503e-07,
+        "input_cost_per_token": 2.49998e-06,
+        "input_dbu_cost_per_token": 3.5714e-05,
+        "litellm_provider": "databricks",
+        "max_tokens": 128000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 7.50001e-06,
+        "output_dbu_cost_per_token": 0.000107143,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_prompt_caching": true,
+        "max_input_tokens": 500000,
+        "max_output_tokens": 128000
+    },
+    "databricks/databricks-inkling": {
+        "litellm_provider": "databricks",
+        "max_tokens": 131072,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Billing reads the per-token dollar fields; the '*_dbu_cost_per_token' fields are the published Databricks rates, kept for reference."
+        },
+        "mode": "chat",
+        "source": "https://www.databricks.com/product/pricing/foundation-model-serving",
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": false,
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 131072,
+        "input_cost_per_token": 1.00002e-06,
+        "input_dbu_cost_per_token": 1.4286e-05,
+        "output_cost_per_token": 4.04999e-06,
+        "output_dbu_cost_per_token": 5.7857e-05,
+        "cache_creation_input_token_cost": 1.00002e-06,
+        "cache_read_input_token_cost": 1.7003e-07
+    },
+    "databricks/databricks-qwen3-embedding-0-6b": {
+        "cache_creation_input_token_cost": 1.2999e-07,
+        "cache_read_input_token_cost": 1.2999e-07,
+        "input_cost_per_token": 2.002e-08,
+        "input_dbu_cost_per_token": 2.86e-07,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 32768,
+        "max_tokens": 32768,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070, based on databricks Llama 3.1 70B conversion. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "embedding",
+        "output_cost_per_token": 0.0,
+        "output_dbu_cost_per_token": 0.0,
+        "output_vector_size": 1024,
+        "source": "https://www.databricks.com/product/pricing/foundation-model-serving"
+    },
+    "databricks/databricks-qwen3-next-80b-a3b-instruct": {
+        "input_cost_per_token": 1.5001e-07,
+        "input_dbu_cost_per_token": 2.1429999999999996e-06,
+        "litellm_provider": "databricks",
+        "max_tokens": 25000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 1.20001e-06,
+        "output_dbu_cost_per_token": 1.7143000000000002e-05,
+        "source": "https://www.databricks.com/product/pricing/foundation-model-serving",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 25000
+    },
+    "databricks/databricks-qwen35-122b-a10b": {
+        "input_cost_per_token": 2.2001e-07,
+        "input_dbu_cost_per_token": 3.143e-06,
+        "litellm_provider": "databricks",
+        "max_tokens": 25000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 2.20003e-06,
+        "output_dbu_cost_per_token": 3.1429e-05,
+        "source": "https://www.databricks.com/product/pricing/foundation-model-serving",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 25000
     }
 }

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -17340,10 +17340,10 @@
         "supports_vision": false
     },
     "databricks/databricks-gemini-2-5-flash": {
-        "cache_creation_input_token_cost": 3.7499e-07,
-        "cache_read_input_token_cost": 3.752e-08,
-        "input_cost_per_token": 3.7499e-07,
-        "input_dbu_cost_per_token": 5.3570000000000005e-06,
+        "cache_creation_input_token_cost": 3.0002e-07,
+        "cache_read_input_token_cost": 3.0002e-08,
+        "input_cost_per_token": 3.0002e-07,
+        "input_dbu_cost_per_token": 4.285999999999999e-06,
         "litellm_provider": "databricks",
         "max_input_tokens": 1048576,
         "max_output_tokens": 65535,
@@ -17352,18 +17352,18 @@
             "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
         },
         "mode": "chat",
-        "output_cost_per_token": 3.12501e-06,
-        "output_dbu_cost_per_token": 4.4643e-05,
+        "output_cost_per_token": 2.49998e-06,
+        "output_dbu_cost_per_token": 3.5714e-05,
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_function_calling": true,
         "supports_prompt_caching": true,
         "supports_tool_choice": true
     },
     "databricks/databricks-gemini-2-5-pro": {
-        "cache_creation_input_token_cost": 1.56247e-06,
-        "cache_read_input_token_cost": 1.5624e-07,
-        "input_cost_per_token": 1.56247e-06,
-        "input_dbu_cost_per_token": 2.2321000000000002e-05,
+        "cache_creation_input_token_cost": 1.24999e-06,
+        "cache_read_input_token_cost": 1.2499900000000002e-07,
+        "input_cost_per_token": 1.24999e-06,
+        "input_dbu_cost_per_token": 1.7857e-05,
         "litellm_provider": "databricks",
         "max_input_tokens": 1048576,
         "max_output_tokens": 65536,
@@ -17372,8 +17372,8 @@
             "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
         },
         "mode": "chat",
-        "output_cost_per_token": 1.249997e-05,
-        "output_dbu_cost_per_token": 0.000178571,
+        "output_cost_per_token": 9.99999e-06,
+        "output_dbu_cost_per_token": 0.000142857,
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_function_calling": true,
         "supports_prompt_caching": true,
@@ -58692,42 +58692,28 @@
         "max_input_tokens": 1048576
     },
     "databricks/databricks-gemini-3-7-flash": {
-        "cache_creation_input_token_cost": 1.87502e-06,
-        "cache_read_input_token_cost": 1.8753e-07,
-        "input_cost_per_token": 1.87502e-06,
-        "input_dbu_cost_per_token": 2.6786e-05,
         "litellm_provider": "databricks",
         "max_output_tokens": 65536,
         "max_tokens": 65536,
         "metadata": {
-            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+            "notes": "Databricks DBU rates not yet published for this model; endpoint metadata only."
         },
         "mode": "chat",
-        "output_cost_per_token": 9.37503e-06,
-        "output_dbu_cost_per_token": 0.000133929,
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_function_calling": true,
-        "supports_prompt_caching": true,
         "supports_tool_choice": true,
         "max_input_tokens": 1048576
     },
     "databricks/databricks-gemini-3-8-flash": {
-        "cache_creation_input_token_cost": 1.87502e-06,
-        "cache_read_input_token_cost": 1.8753e-07,
-        "input_cost_per_token": 1.87502e-06,
-        "input_dbu_cost_per_token": 2.6786e-05,
         "litellm_provider": "databricks",
         "max_output_tokens": 65536,
         "max_tokens": 65536,
         "metadata": {
-            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+            "notes": "Databricks DBU rates not yet published for this model; endpoint metadata only."
         },
         "mode": "chat",
-        "output_cost_per_token": 9.37503e-06,
-        "output_dbu_cost_per_token": 0.000133929,
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_function_calling": true,
-        "supports_prompt_caching": true,
         "supports_tool_choice": true,
         "max_input_tokens": 1048576
     },
@@ -58814,7 +58800,9 @@
         "output_dbu_cost_per_token": 0.002571429,
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_prompt_caching": true,
-        "max_output_tokens": 128000
+        "max_output_tokens": 128000,
+        "cache_creation_input_token_cost": 2.999997e-05,
+        "cache_read_input_token_cost": 2.999997e-05
     },
     "databricks/databricks-gpt-5-6-luna": {
         "cache_creation_input_token_cost": 1.24999e-06,
@@ -58917,8 +58905,8 @@
         "cache_read_input_token_cost": 1.7003e-07
     },
     "databricks/databricks-qwen3-embedding-0-6b": {
-        "cache_creation_input_token_cost": 1.2999e-07,
-        "cache_read_input_token_cost": 1.2999e-07,
+        "cache_creation_input_token_cost": 2.002e-08,
+        "cache_read_input_token_cost": 2.002e-08,
         "input_cost_per_token": 2.002e-08,
         "input_dbu_cost_per_token": 2.86e-07,
         "litellm_provider": "databricks",
@@ -58946,7 +58934,9 @@
         "output_dbu_cost_per_token": 1.7143000000000002e-05,
         "source": "https://www.databricks.com/product/pricing/foundation-model-serving",
         "max_input_tokens": 262144,
-        "max_output_tokens": 25000
+        "max_output_tokens": 25000,
+        "cache_creation_input_token_cost": 1.5001e-07,
+        "cache_read_input_token_cost": 1.5001e-07
     },
     "databricks/databricks-qwen35-122b-a10b": {
         "input_cost_per_token": 2.2001e-07,
@@ -58961,6 +58951,8 @@
         "output_dbu_cost_per_token": 3.1429e-05,
         "source": "https://www.databricks.com/product/pricing/foundation-model-serving",
         "max_input_tokens": 262144,
-        "max_output_tokens": 25000
+        "max_output_tokens": 25000,
+        "cache_creation_input_token_cost": 2.2001e-07,
+        "cache_read_input_token_cost": 2.2001e-07
     }
 }

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -17340,10 +17340,10 @@
         "supports_vision": false
     },
     "databricks/databricks-gemini-2-5-flash": {
-        "cache_creation_input_token_cost": 3.0002e-07,
-        "cache_read_input_token_cost": 3.0002e-08,
-        "input_cost_per_token": 3.0001999999999996e-07,
-        "input_dbu_cost_per_token": 4.285999999999999e-06,
+        "cache_creation_input_token_cost": 3.7499e-07,
+        "cache_read_input_token_cost": 3.752e-08,
+        "input_cost_per_token": 3.7499e-07,
+        "input_dbu_cost_per_token": 5.3570000000000005e-06,
         "litellm_provider": "databricks",
         "max_input_tokens": 1048576,
         "max_output_tokens": 65535,
@@ -17352,18 +17352,18 @@
             "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
         },
         "mode": "chat",
-        "output_cost_per_token": 2.49998e-06,
-        "output_dbu_cost_per_token": 3.5714e-05,
+        "output_cost_per_token": 3.12501e-06,
+        "output_dbu_cost_per_token": 4.4643e-05,
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_function_calling": true,
         "supports_prompt_caching": true,
         "supports_tool_choice": true
     },
     "databricks/databricks-gemini-2-5-pro": {
-        "cache_creation_input_token_cost": 1.24999e-06,
-        "cache_read_input_token_cost": 1.24999e-07,
-        "input_cost_per_token": 1.24999e-06,
-        "input_dbu_cost_per_token": 1.7857e-05,
+        "cache_creation_input_token_cost": 1.56247e-06,
+        "cache_read_input_token_cost": 1.5624e-07,
+        "input_cost_per_token": 1.56247e-06,
+        "input_dbu_cost_per_token": 2.2321000000000002e-05,
         "litellm_provider": "databricks",
         "max_input_tokens": 1048576,
         "max_output_tokens": 65536,
@@ -17372,8 +17372,8 @@
             "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
         },
         "mode": "chat",
-        "output_cost_per_token": 9.999990000000002e-06,
-        "output_dbu_cost_per_token": 0.000142857,
+        "output_cost_per_token": 1.249997e-05,
+        "output_dbu_cost_per_token": 0.000178571,
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_function_calling": true,
         "supports_prompt_caching": true,
@@ -17510,10 +17510,10 @@
         "max_output_tokens": 131072,
         "max_tokens": 131072,
         "metadata": {
-            "notes": "Databricks has not published pay-per-token DBU rates for this model yet (not on the foundation-model-serving pricing page as of 2026-08-27), so cost fields are omitted until rates are published."
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
         },
         "mode": "chat",
-        "source": "https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/supported-models",
+        "source": "https://www.databricks.com/product/pricing/foundation-model-serving",
         "supported_modalities": [
             "text",
             "image"
@@ -17525,7 +17525,13 @@
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "input_cost_per_token": 1.5001e-07,
+        "input_dbu_cost_per_token": 2.1429999999999996e-06,
+        "output_cost_per_token": 5.0001e-07,
+        "output_dbu_cost_per_token": 7.143e-06,
+        "cache_creation_input_token_cost": 1.5001e-07,
+        "cache_read_input_token_cost": 3.003e-08
     },
     "databricks/databricks-gpt-5": {
         "cache_creation_input_token_cost": 1.24999e-06,
@@ -58573,5 +58579,388 @@
         "supported_endpoints": [
             "/v1/audio/transcriptions"
         ]
+    },
+    "databricks/databricks-claude-fable-5-1": {
+        "litellm_provider": "databricks",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "metadata": {
+            "notes": "Costs per token are the published Global DBU rates times $0.070 per DBU. The '*_dbu_cost_per_token' fields are provided for reference; cost calculation reads the dollar '*_cost_per_token' fields."
+        },
+        "mode": "chat",
+        "prompt_cache_min_tokens": 512,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_adaptive_thinking": true,
+        "supports_assistant_prefill": false,
+        "supports_function_calling": true,
+        "supports_mid_conversation_system": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_sampling_params": false,
+        "supports_tool_choice": true,
+        "supports_vision": false,
+        "thinking_always_on": true,
+        "input_cost_per_token": 1.000006e-05,
+        "input_dbu_cost_per_token": 0.000142858,
+        "output_cost_per_token": 5.000002e-05,
+        "output_dbu_cost_per_token": 0.000714286,
+        "cache_creation_input_token_cost": 1.250004e-05,
+        "cache_read_input_token_cost": 2.5004e-07
+    },
+    "databricks/databricks-gemini-3-1-flash-image": {
+        "litellm_provider": "databricks",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_tool_choice": true,
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "image"
+        ],
+        "supports_vision": true
+    },
+    "databricks/databricks-gemini-3-5-flash": {
+        "cache_creation_input_token_cost": 1.87502e-06,
+        "cache_read_input_token_cost": 1.8753e-07,
+        "input_cost_per_token": 1.87502e-06,
+        "input_dbu_cost_per_token": 2.6786e-05,
+        "litellm_provider": "databricks",
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 1.124998e-05,
+        "output_dbu_cost_per_token": 0.000160714,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_tool_choice": true,
+        "max_input_tokens": 1048576
+    },
+    "databricks/databricks-gemini-3-5-flash-lite": {
+        "cache_creation_input_token_cost": 3.7499e-07,
+        "cache_read_input_token_cost": 3.752e-08,
+        "input_cost_per_token": 3.7499e-07,
+        "input_dbu_cost_per_token": 5.3570000000000005e-06,
+        "litellm_provider": "databricks",
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 3.12501e-06,
+        "output_dbu_cost_per_token": 4.4643e-05,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_tool_choice": true,
+        "max_input_tokens": 1048576
+    },
+    "databricks/databricks-gemini-3-6-flash": {
+        "cache_creation_input_token_cost": 1.87502e-06,
+        "cache_read_input_token_cost": 1.8753e-07,
+        "input_cost_per_token": 1.87502e-06,
+        "input_dbu_cost_per_token": 2.6786e-05,
+        "litellm_provider": "databricks",
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 9.37503e-06,
+        "output_dbu_cost_per_token": 0.000133929,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_tool_choice": true,
+        "max_input_tokens": 1048576
+    },
+    "databricks/databricks-gemini-3-7-flash": {
+        "cache_creation_input_token_cost": 1.87502e-06,
+        "cache_read_input_token_cost": 1.8753e-07,
+        "input_cost_per_token": 1.87502e-06,
+        "input_dbu_cost_per_token": 2.6786e-05,
+        "litellm_provider": "databricks",
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 9.37503e-06,
+        "output_dbu_cost_per_token": 0.000133929,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_tool_choice": true,
+        "max_input_tokens": 1048576
+    },
+    "databricks/databricks-gemini-3-8-flash": {
+        "cache_creation_input_token_cost": 1.87502e-06,
+        "cache_read_input_token_cost": 1.8753e-07,
+        "input_cost_per_token": 1.87502e-06,
+        "input_dbu_cost_per_token": 2.6786e-05,
+        "litellm_provider": "databricks",
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 9.37503e-06,
+        "output_dbu_cost_per_token": 0.000133929,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_tool_choice": true,
+        "max_input_tokens": 1048576
+    },
+    "databricks/databricks-gemini-3-pro-image": {
+        "litellm_provider": "databricks",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_tool_choice": true,
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "image"
+        ],
+        "supports_vision": true
+    },
+    "databricks/databricks-glm-5-3": {
+        "cache_creation_input_token_cost": 1.4e-06,
+        "cache_read_input_token_cost": 2.5998e-07,
+        "input_cost_per_token": 1.4e-06,
+        "input_dbu_cost_per_token": 2e-05,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Billing reads the per-token dollar fields; the '*_dbu_cost_per_token' fields are the published Databricks rates, kept for reference."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 4.39999e-06,
+        "output_dbu_cost_per_token": 6.2857e-05,
+        "source": "https://www.databricks.com/product/pricing/foundation-model-serving",
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": false
+    },
+    "databricks/databricks-gpt-5-5": {
+        "cache_creation_input_token_cost": 5.00003e-06,
+        "cache_read_input_token_cost": 5.0001e-07,
+        "input_cost_per_token": 5.00003e-06,
+        "input_dbu_cost_per_token": 7.1429e-05,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 272000,
+        "max_tokens": 128000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 2.999997e-05,
+        "output_dbu_cost_per_token": 0.00042857100000000004,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_prompt_caching": true,
+        "max_output_tokens": 128000
+    },
+    "databricks/databricks-gpt-5-5-pro": {
+        "input_cost_per_token": 2.999997e-05,
+        "input_dbu_cost_per_token": 0.00042857100000000004,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 272000,
+        "max_tokens": 128000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 0.00018000003,
+        "output_dbu_cost_per_token": 0.002571429,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_prompt_caching": true,
+        "max_output_tokens": 128000
+    },
+    "databricks/databricks-gpt-5-6-luna": {
+        "cache_creation_input_token_cost": 1.24999e-06,
+        "cache_read_input_token_cost": 1.0003e-07,
+        "input_cost_per_token": 1.00002e-06,
+        "input_dbu_cost_per_token": 1.4286e-05,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 272000,
+        "max_tokens": 128000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 5.99998e-06,
+        "output_dbu_cost_per_token": 8.5714e-05,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_prompt_caching": true,
+        "max_output_tokens": 128000
+    },
+    "databricks/databricks-gpt-5-6-sol": {
+        "cache_creation_input_token_cost": 5.00003e-06,
+        "cache_read_input_token_cost": 3.9998e-07,
+        "input_cost_per_token": 4.00001e-06,
+        "input_dbu_cost_per_token": 5.7143e-05,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 272000,
+        "max_tokens": 128000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 1.999998e-05,
+        "output_dbu_cost_per_token": 0.000285714,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_prompt_caching": true,
+        "max_output_tokens": 128000
+    },
+    "databricks/databricks-gpt-5-6-terra": {
+        "cache_creation_input_token_cost": 3.12501e-06,
+        "cache_read_input_token_cost": 2.4997e-07,
+        "input_cost_per_token": 2.49998e-06,
+        "input_dbu_cost_per_token": 3.5714e-05,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 272000,
+        "max_tokens": 128000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 1.500002e-05,
+        "output_dbu_cost_per_token": 0.000214286,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_prompt_caching": true,
+        "max_output_tokens": 128000
+    },
+    "databricks/databricks-grok-4-6": {
+        "cache_creation_input_token_cost": 2.49998e-06,
+        "cache_read_input_token_cost": 6.2503e-07,
+        "input_cost_per_token": 2.49998e-06,
+        "input_dbu_cost_per_token": 3.5714e-05,
+        "litellm_provider": "databricks",
+        "max_tokens": 128000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 7.50001e-06,
+        "output_dbu_cost_per_token": 0.000107143,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_prompt_caching": true,
+        "max_input_tokens": 500000,
+        "max_output_tokens": 128000
+    },
+    "databricks/databricks-inkling": {
+        "litellm_provider": "databricks",
+        "max_tokens": 131072,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Billing reads the per-token dollar fields; the '*_dbu_cost_per_token' fields are the published Databricks rates, kept for reference."
+        },
+        "mode": "chat",
+        "source": "https://www.databricks.com/product/pricing/foundation-model-serving",
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": false,
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 131072,
+        "input_cost_per_token": 1.00002e-06,
+        "input_dbu_cost_per_token": 1.4286e-05,
+        "output_cost_per_token": 4.04999e-06,
+        "output_dbu_cost_per_token": 5.7857e-05,
+        "cache_creation_input_token_cost": 1.00002e-06,
+        "cache_read_input_token_cost": 1.7003e-07
+    },
+    "databricks/databricks-qwen3-embedding-0-6b": {
+        "cache_creation_input_token_cost": 1.2999e-07,
+        "cache_read_input_token_cost": 1.2999e-07,
+        "input_cost_per_token": 2.002e-08,
+        "input_dbu_cost_per_token": 2.86e-07,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 32768,
+        "max_tokens": 32768,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070, based on databricks Llama 3.1 70B conversion. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "embedding",
+        "output_cost_per_token": 0.0,
+        "output_dbu_cost_per_token": 0.0,
+        "output_vector_size": 1024,
+        "source": "https://www.databricks.com/product/pricing/foundation-model-serving"
+    },
+    "databricks/databricks-qwen3-next-80b-a3b-instruct": {
+        "input_cost_per_token": 1.5001e-07,
+        "input_dbu_cost_per_token": 2.1429999999999996e-06,
+        "litellm_provider": "databricks",
+        "max_tokens": 25000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 1.20001e-06,
+        "output_dbu_cost_per_token": 1.7143000000000002e-05,
+        "source": "https://www.databricks.com/product/pricing/foundation-model-serving",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 25000
+    },
+    "databricks/databricks-qwen35-122b-a10b": {
+        "input_cost_per_token": 2.2001e-07,
+        "input_dbu_cost_per_token": 3.143e-06,
+        "litellm_provider": "databricks",
+        "max_tokens": 25000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 2.20003e-06,
+        "output_dbu_cost_per_token": 3.1429e-05,
+        "source": "https://www.databricks.com/product/pricing/foundation-model-serving",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 25000
     }
 }

--- a/tests/test_litellm/llms/databricks/test_databricks_cost_calculator.py
+++ b/tests/test_litellm/llms/databricks/test_databricks_cost_calculator.py
@@ -65,6 +65,18 @@ PUBLISHED_DBU_PER_MILLION: Final = {
     "databricks/databricks-deepseek-v4-flash-0731": ("2.000", "4.000", "2.000", "0.400"),
     "databricks/databricks-deepseek-v4-pro-0813": ("18.857", "56.571", "18.857", "1.886"),
     "databricks/databricks-glm-5-2": ("20.000", "62.857", "20.000", "3.714"),
+    "databricks/databricks-gpt-5-6-sol": ("57.143", "285.714", "71.429", "5.714"),
+    "databricks/databricks-gpt-5-6-terra": ("35.714", "214.286", "44.643", "3.571"),
+    "databricks/databricks-gpt-5-6-luna": ("14.286", "85.714", "17.857", "1.429"),
+    "databricks/databricks-gpt-5-5": ("71.429", "428.571", "71.429", "7.143"),
+    "databricks/databricks-claude-fable-5-1": ("142.858", "714.286", "178.572", "3.572"),
+    "databricks/databricks-gemini-3-6-flash": ("26.786", "133.929", "26.786", "2.679"),
+    "databricks/databricks-gemini-3-5-flash": ("26.786", "160.714", "26.786", "2.679"),
+    "databricks/databricks-gemini-3-5-flash-lite": ("5.357", "44.643", "5.357", "0.536"),
+    "databricks/databricks-glm-5-3": ("20.000", "62.857", "20.000", "3.714"),
+    "databricks/databricks-inkling": ("14.286", "57.857", "14.286", "2.429"),
+    "databricks/databricks-grok-4-6": ("35.714", "107.143", "35.714", "8.929"),
+    "databricks/databricks-glm-5-3-flash": ("2.143", "7.143", "2.143", "0.429"),
 }
 PROMOTIONAL_DISCOUNT: Final = 0.80
 PROMOTION_EXPIRES: Final = "2027-01-31"
@@ -208,7 +220,7 @@ def test_every_model_without_published_cache_dbu_bills_cache_at_its_own_input_ra
         and model not in PUBLISHED_DBU_PER_MILLION
     ]
 
-    assert len(without_published_rates) == 14
+    assert len(without_published_rates) == 18
     for model in without_published_rates:
         info = _model_info(model)
         for field in CACHE_FIELDS:


### PR DESCRIPTION
## Summary

Adds **19 Databricks Foundation Model API models** missing from `model_prices_and_context_window.json` (and the packaged backup), based on the official Databricks [supported models docs](https://docs.databricks.com/aws/en/machine-learning/foundation-models/supported-models) and pricing pages.

### Added models
- **OpenAI**: `databricks-gpt-5-6-sol`, `databricks-gpt-5-6-terra`, `databricks-gpt-5-6-luna`, `databricks-gpt-5-5`, `databricks-gpt-5-5-pro`
- **Google**: `databricks-gemini-3-8-flash`, `databricks-gemini-3-7-flash`, `databricks-gemini-3-6-flash`, `databricks-gemini-3-5-flash`, `databricks-gemini-3-5-flash-lite`, `databricks-gemini-3-1-flash-image`, `databricks-gemini-3-pro-image`
- **Alibaba**: `databricks-qwen35-122b-a10b`, `databricks-qwen3-next-80b-a3b-instruct`, `databricks-qwen3-embedding-0-6b`
- **Zhipu**: `databricks-glm-5-3`, `databricks-glm-5-3-flash` (DBU rates now published on the FMS pricing page)
- **Others**: `databricks-grok-4-6` (xAI), `databricks-inkling` (Thinking Machines), `databricks-claude-fable-5-1` (Anthropic)

### Updates
- `databricks-gemini-2-5-flash` / `databricks-gemini-2-5-pro`: adds cache write/read rates per the official cache-read DBU columns (rates keep the promotional pricing the repo already tracks)
- Adds cache write/read cost fields + `supports_prompt_caching` to newly published models per the official cache DBU columns
- `gemini-3-7-flash` / `gemini-3-8-flash`: endpoint metadata only — Databricks has not published DBU rates for these yet
- Tests: `PUBLISHED_DBU_PER_MILLION` extended with the 12 newly published models; unpublished-cache-rate tripwire 14 → 18

### Pricing methodology
All rates are derived from the official Databricks Foundation Model Serving DBU tables using the LiteLLM convention **USD = DBU × $0.07 per 1M tokens** (`*_dbu_cost_per_token` fields are used in actual cost calculations).

Source pages:
- https://www.databricks.com/product/pricing/foundation-model-serving
- https://www.databricks.com/product/pricing/proprietary-foundation-model-serving
- https://docs.databricks.com/aws/en/machine-learning/foundation-models/supported-models
