### PR TITLE
fix(proxy): invalidate end-user spend counter and cache on budget reset (#39726)

### DIFF
--- a/litellm/proxy/common_utils/reset_budget_job.py
+++ b/litellm/proxy/common_utils/reset_budget_job.py
@@ -189,7 +189,7 @@ def _enduser_cache_keys(row: _EndUserRow) -> tuple[str, ...]:
 def _enduser_carried_spend(row: _EndUserRow, caps: Mapping[str, float]) -> float:
     if not caps:
         return 0.0
-    effective_budget_id = row.budget_id or litellm.max_end_user_budget_id
+    effective_budget_id: Final[str | None] = row.budget_id or litellm.max_end_user_budget_id
     return _carried_spend(row.spend, caps.get(effective_budget_id) if effective_budget_id is not None else None)
 
 

--- a/litellm/proxy/common_utils/reset_budget_job.py
+++ b/litellm/proxy/common_utils/reset_budget_job.py
@@ -38,6 +38,7 @@ from litellm.proxy.common_utils.timezone_utils import (
     get_budget_reset_settings,
 )
 from litellm.proxy.common_utils.user_api_key_cache import (
+    end_user_cache_key,
     model_access_group_cache_key,
     model_access_group_spend_counter_key,
     tag_cache_key,
@@ -175,6 +176,21 @@ def _model_access_group_counter_key(row: _ModelAccessGroupRow) -> str:
 
 def _model_access_group_cache_keys(row: _ModelAccessGroupRow) -> tuple[str, ...]:
     return (model_access_group_cache_key(row.access_group_name),)
+
+
+def _enduser_counter_key(row: _EndUserRow) -> str:
+    return f"spend:end_user:{row.user_id}"
+
+
+def _enduser_cache_keys(row: _EndUserRow) -> tuple[str, ...]:
+    return (end_user_cache_key(row.user_id),)
+
+
+def _enduser_carried_spend(row: _EndUserRow, caps: Mapping[str, float]) -> float:
+    if not caps:
+        return 0.0
+    effective_budget_id = row.budget_id or litellm.max_end_user_budget_id
+    return _carried_spend(row.spend, caps.get(effective_budget_id) if effective_budget_id is not None else None)
 
 
 def _budget_link_where(
@@ -650,6 +666,7 @@ class ResetBudgetJob:
             if _rollover_enabled()
             else {}  # mutable-ok: empty sentinel immediately frozen by MappingProxyType
         )
+        endusers: Final[tuple[_EndUserRow, ...]] = await self._collect_endusers_to_reset(budget_ids)
         return _BudgetCascade(
             budgets=tuple(budgets_to_reset),
             budget_ids=budget_ids,
@@ -661,7 +678,7 @@ class ResetBudgetJob:
                 for b in budgets_to_reset
                 if b.budget_id is not None and b.budget_duration is not None
             ),
-            endusers=await self._collect_endusers_to_reset(budget_ids),
+            endusers=endusers,
             counter_resets=(
                 *(
                     (_team_membership_counter_key(row), _row_carried_spend(row, rollover_caps))
@@ -674,6 +691,10 @@ class ResetBudgetJob:
                     (_model_access_group_counter_key(row), _row_carried_spend(row, rollover_caps))
                     for row in model_access_groups
                 ),
+                *(
+                    (_enduser_counter_key(row), _enduser_carried_spend(row, rollover_caps))
+                    for row in endusers
+                ),
             ),
             rollover_caps=rollover_caps,
             cache_keys=(
@@ -682,6 +703,7 @@ class ResetBudgetJob:
                 *(key for row in orgs for key in _org_cache_keys(row)),
                 *(key for row in tags for key in _tag_cache_keys(row)),
                 *(key for row in model_access_groups for key in _model_access_group_cache_keys(row)),
+                *(key for row in endusers for key in _enduser_cache_keys(row)),
             ),
         )
 

--- a/litellm/proxy/common_utils/reset_budget_job.py
+++ b/litellm/proxy/common_utils/reset_budget_job.py
@@ -691,10 +691,7 @@ class ResetBudgetJob:
                     (_model_access_group_counter_key(row), _row_carried_spend(row, rollover_caps))
                     for row in model_access_groups
                 ),
-                *(
-                    (_enduser_counter_key(row), _enduser_carried_spend(row, rollover_caps))
-                    for row in endusers
-                ),
+                *((_enduser_counter_key(row), _enduser_carried_spend(row, rollover_caps)) for row in endusers),
             ),
             rollover_caps=rollover_caps,
             cache_keys=(

--- a/litellm/proxy/db/spend_counter_reseed.py
+++ b/litellm/proxy/db/spend_counter_reseed.py
@@ -26,6 +26,7 @@ from litellm.proxy._types import Litellm_EntityType
 from litellm.repositories.organization_repository import OrganizationRepository
 from litellm.repositories.table_repositories import (
     BudgetWindowSpendRepository,
+    EndUserRepository,
     SpendLogsRepository,
     TeamMembershipRepository,
 )
@@ -36,6 +37,8 @@ from litellm.repositories.verification_token_repository import (
 )
 
 if TYPE_CHECKING:
+    from prisma.types import LiteLLM_EndUserTableWhereUniqueInput
+
     from litellm.caching.dual_cache import DualCache
     from litellm.proxy.utils import PrismaClient
 
@@ -46,6 +49,8 @@ _WINDOW_SPEND_ENTITY_TYPES: Final[Mapping[str, str]] = MappingProxyType(
         "Team": Litellm_EntityType.TEAM.value,
     }
 )
+
+END_USER_COUNTER_PREFIX: Final = "spend:end_user:"
 
 _WINDOW_SPEND_LOG_FIELDS: Final[Mapping[str, str]] = MappingProxyType(
     {
@@ -74,6 +79,10 @@ class SpendCounterReseed:
     End-user and tag spend counters intentionally do not reseed here. Their
     auth paths already load the corresponding objects via get_end_user_object()
     and get_tag_objects_batch(); callers pass those values as fallback_spend.
+    end_user_from_db is the one end-user read, used only as the budget floor when
+    a counter sits below that cached spend: a worker that did not run the budget
+    reset still caches the pre-reset end-user object, and LiteLLM_EndUserTable
+    is the row the reset zeroed.
     """
 
     _locks: ClassVar["OrderedDict[str, asyncio.Lock]"] = OrderedDict()
@@ -129,7 +138,7 @@ class SpendCounterReseed:
             elif counter_key.startswith("spend:user:"):
                 user_id = counter_key[len("spend:user:") :]
                 row = await UserRepository(prisma_client).table.find_unique(where={"user_id": user_id})
-            elif counter_key.startswith("spend:end_user:") or counter_key.startswith("spend:tag:"):
+            elif counter_key.startswith(END_USER_COUNTER_PREFIX) or counter_key.startswith("spend:tag:"):
                 return None
             elif counter_key.startswith("spend:org:"):
                 org_id: Final = counter_key[len("spend:org:") :]
@@ -142,6 +151,20 @@ class SpendCounterReseed:
         if row is None:
             return None
         return float(getattr(row, "spend", 0.0) or 0.0)
+
+    @staticmethod
+    async def end_user_from_db(prisma_client: Optional["PrismaClient"], counter_key: str) -> float | None:
+        if prisma_client is None or not counter_key.startswith(END_USER_COUNTER_PREFIX):
+            return None
+        where: Final[LiteLLM_EndUserTableWhereUniqueInput] = {"user_id": counter_key[len(END_USER_COUNTER_PREFIX) :]}
+        try:
+            row: Final = await EndUserRepository(prisma_client).table.find_unique(where=where)
+        except Exception:  # noqa: BLE001  # a failed floor read falls back to the cached spend, like from_db
+            verbose_proxy_logger.exception("SpendCounterReseed.end_user_from_db: failed for %s", counter_key)
+            return None
+        if row is None:
+            return None
+        return float(row.spend or 0.0)
 
     @staticmethod
     def _is_key_or_team_window_counter(counter_key: str) -> bool:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -423,7 +423,7 @@ from litellm.proxy.db.proxy_worker_heartbeat import (
     PROXY_WORKER_HEARTBEAT_INTERVAL_SECONDS,
     ProxyWorkerHeartbeat,
 )
-from litellm.proxy.db.spend_counter_reseed import SpendCounterReseed
+from litellm.proxy.db.spend_counter_reseed import END_USER_COUNTER_PREFIX, SpendCounterReseed
 from litellm.proxy.discovery_endpoints import ui_discovery_endpoints_router
 from litellm.proxy.fine_tuning_endpoints.endpoints import router as fine_tuning_router
 from litellm.proxy.fine_tuning_endpoints.endpoints import set_fine_tuning_config
@@ -2580,6 +2580,29 @@ async def reseed_spend_counter_from_db(counter_key: str) -> None:
     await _repair_stale_spend_counter(counter_key=counter_key, db_spend=db_spend)
 
 
+async def _floor_spend_from_db(
+    counter_key: str,
+    window_entity_type: str | None,
+    window_entity_id: str | None,
+    window_duration: str | None,
+    window_start: datetime | None,
+) -> float | None:
+    if counter_key.startswith(END_USER_COUNTER_PREFIX):
+        return await SpendCounterReseed.end_user_from_db(prisma_client=prisma_client, counter_key=counter_key)
+    entity_spend: Final = await SpendCounterReseed.from_db(prisma_client=prisma_client, counter_key=counter_key)
+    if entity_spend is not None:
+        return entity_spend
+    if window_entity_type is None or window_entity_id is None or window_start is None:
+        return None
+    return await SpendCounterReseed.window_from_db(
+        prisma_client=prisma_client,
+        entity_type=window_entity_type,
+        entity_id=window_entity_id,
+        window_duration=window_duration,
+        window_start=window_start,
+    )
+
+
 async def _authoritative_floor_spend(
     counter_key: str,
     window_entity_type: str | None = None,
@@ -2592,20 +2615,13 @@ async def _authoritative_floor_spend(
     if cached is not None:
         return float(cached)
 
-    db_spend = await SpendCounterReseed.from_db(prisma_client=prisma_client, counter_key=counter_key)
-    if (
-        db_spend is None
-        and window_entity_type is not None
-        and window_entity_id is not None
-        and window_start is not None
-    ):
-        db_spend = await SpendCounterReseed.window_from_db(
-            prisma_client=prisma_client,
-            entity_type=window_entity_type,
-            entity_id=window_entity_id,
-            window_duration=window_duration,
-            window_start=window_start,
-        )
+    db_spend: Final = await _floor_spend_from_db(
+        counter_key=counter_key,
+        window_entity_type=window_entity_type,
+        window_entity_id=window_entity_id,
+        window_duration=window_duration,
+        window_start=window_start,
+    )
     if db_spend is None:
         return None
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -2477,7 +2477,8 @@ async def get_current_spend(
     authoritative source depends on the counter: primary key/team/user/org
     counters read the DB row; per-window counters (``window_start`` supplied)
     read the maintained window-spend row and only aggregate spend logs when
-    that row is missing or stale; end-user/tag counters have no DB row, so the caller's
+    that row is missing or stale; end-user counters read ``LiteLLM_EndUserTable``, the
+    row the budget reset zeroes; tag counters have no DB row, so the caller's
     ``fallback_spend`` (loaded fresh in auth) is authoritative. The DB read is
     skipped for healthy primary counters (counter at or above recorded spend)
     and cached in-process for a few seconds, so a persistently stale counter
@@ -2511,8 +2512,8 @@ async def get_current_spend(
                 await _repair_stale_spend_counter(counter_key=counter_key, db_spend=authoritative)
                 return authoritative
         elif fallback_spend > current:
-            # end-user / tag counters have no DB row; fallback_spend is the
-            # authoritative recorded value loaded in auth.
+            # nothing to read (tag counters, an end user without a row or a DB client, a
+            # failed read); fallback_spend is the authoritative recorded value loaded in auth.
             return fallback_spend
 
     # Opt-in hard guarantee: when the spend backing this admit decision came

--- a/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
+++ b/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
@@ -3054,6 +3054,38 @@ def test_budget_cascade_carries_enduser_overage_when_rollover_enabled(
     } in enduser_writes
 
 
+def test_budget_cascade_carries_default_tier_enduser_counter_when_rollover_enabled(
+    rollover_enabled, reset_budget_job, mock_prisma_client, monkeypatch
+):
+    """An end user on the default budget (no budget_id on its row) 5 over the cap
+    keeps a counter of 5 in the next window and loses its cached object."""
+    import litellm
+
+    counter_cache: Final = _make_counter_invalidation_job(monkeypatch)
+    monkeypatch.setattr(litellm, "max_end_user_budget_id", "default-enduser-budget")
+    mock_prisma_client.data["budget"] = [
+        _budget_row(budget_id="default-enduser-budget", budget_duration="1d", max_budget=10.0)
+    ]
+    implicit_enduser: Final = type(
+        "EndUserRow",
+        (),
+        {
+            "spend": 15.0,
+            "user_id": "enduser-implicit",
+            "budget_id": None,
+            "model_dump": lambda self=None: {"spend": 15.0, "user_id": "enduser-implicit", "budget_id": None, "blocked": False},
+        },
+    )
+    mock_prisma_client.db.litellm_endusertable.set_find_many_results([implicit_enduser])
+
+    asyncio.run(reset_budget_job.reset_budget_for_litellm_budget_table())
+
+    counter_cache.in_memory_cache.set_cache.assert_any_call(key="spend:end_user:enduser-implicit", value=5.0, ttl=60)
+    counter_cache.redis_cache.async_set_cache.assert_any_await(key="spend:end_user:enduser-implicit", value=5.0, ttl=60)
+    deleted: Final = {call.kwargs.get("key") for call in counter_cache.user_api_key_cache.async_delete_cache.await_args_list}
+    assert "end_user_id:enduser-implicit" in deleted
+
+
 def _replay_spend_writes(writes, spend):
     """Apply the queued update_many statements in order, the way the DB
     transaction executes them, and return the row's final spend."""

--- a/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
+++ b/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
@@ -1495,6 +1495,32 @@ def test_budget_table_reset_invalidates_every_tag_not_just_the_first(reset_budge
     assert deleted == {"tag:tenant-a", "tag:tenant-b", "tag:tenant-c"}
 
 
+def test_budget_table_reset_invalidates_enduser_counter_and_cache(reset_budget_job, mock_prisma_client, monkeypatch):
+    """When an end user's budget resets, its Redis spend counter is zeroed and its management cache is evicted."""
+    counter_cache = _make_counter_invalidation_job(monkeypatch)
+    budget = _budget_row(budget_id="budget-1")
+    mock_prisma_client.data["budget"] = [budget]
+    test_enduser = type(
+        "LiteLLM_EndUserTable",
+        (),
+        {
+            "spend": 20.0,
+            "litellm_budget_table": budget,
+            "budget_id": "budget-1",
+            "user_id": "customer-42",
+        },
+    )
+    mock_prisma_client.data["enduser"] = [test_enduser]
+
+    asyncio.run(reset_budget_job.reset_budget_for_litellm_budget_table())
+
+    counter_cache.in_memory_cache.set_cache.assert_any_call(key="spend:end_user:customer-42", value=0.0, ttl=60)
+    counter_cache.redis_cache.async_set_cache.assert_any_await(key="spend:end_user:customer-42", value=0.0, ttl=60)
+    deleted = {call.kwargs.get("key") for call in counter_cache.user_api_key_cache.async_delete_cache.await_args_list}
+    assert "end_user_id:customer-42" in deleted
+
+
+
 def test_budget_table_reset_commits_even_when_cache_eviction_fails(reset_budget_job, mock_prisma_client, monkeypatch):
     """Eviction runs after the commit, so a broken cache cannot undo the write."""
     counter_cache = _make_counter_invalidation_job(monkeypatch)

--- a/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
+++ b/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
@@ -4,7 +4,7 @@ import sys
 import types
 from datetime import datetime, timedelta, timezone
 from datetime import time as dt_time
-from typing import Any, Dict, List
+from typing import Any, Dict, Final, List
 from unittest.mock import AsyncMock, MagicMock
 
 import httpx
@@ -1497,10 +1497,10 @@ def test_budget_table_reset_invalidates_every_tag_not_just_the_first(reset_budge
 
 def test_budget_table_reset_invalidates_enduser_counter_and_cache(reset_budget_job, mock_prisma_client, monkeypatch):
     """When an end user's budget resets, its Redis spend counter is zeroed and its management cache is evicted."""
-    counter_cache = _make_counter_invalidation_job(monkeypatch)
-    budget = _budget_row(budget_id="budget-1")
+    counter_cache: Final = _make_counter_invalidation_job(monkeypatch)
+    budget: Final = _budget_row(budget_id="budget-1")
     mock_prisma_client.data["budget"] = [budget]
-    test_enduser = type(
+    test_enduser: Final = type(
         "LiteLLM_EndUserTable",
         (),
         {
@@ -1516,7 +1516,7 @@ def test_budget_table_reset_invalidates_enduser_counter_and_cache(reset_budget_j
 
     counter_cache.in_memory_cache.set_cache.assert_any_call(key="spend:end_user:customer-42", value=0.0, ttl=60)
     counter_cache.redis_cache.async_set_cache.assert_any_await(key="spend:end_user:customer-42", value=0.0, ttl=60)
-    deleted = {call.kwargs.get("key") for call in counter_cache.user_api_key_cache.async_delete_cache.await_args_list}
+    deleted: Final = {call.kwargs.get("key") for call in counter_cache.user_api_key_cache.async_delete_cache.await_args_list}
     assert "end_user_id:customer-42" in deleted
 
 

--- a/tests/test_litellm/proxy/db/test_spend_counter_reseed.py
+++ b/tests/test_litellm/proxy/db/test_spend_counter_reseed.py
@@ -18,7 +18,7 @@ from litellm.proxy.db.spend_counter_reseed import SpendCounterReseed
 WINDOW_START = datetime(2026, 8, 1, tzinfo=timezone.utc)
 
 
-class _FakeWindowSpendTable:
+class _FakeFindUniqueTable:
     def __init__(self, row: SimpleNamespace | None, error: Exception | None = None) -> None:
         self._row = row
         self._error = error
@@ -47,10 +47,13 @@ class _FakePrismaClient:
         row: SimpleNamespace | None = None,
         spend_logs_total: float = 0.0,
         error: Exception | None = None,
+        end_user_row: SimpleNamespace | None = None,
+        end_user_error: Exception | None = None,
     ) -> None:
         self.db = SimpleNamespace(
-            litellm_budgetwindowspend=_FakeWindowSpendTable(row=row, error=error),
+            litellm_budgetwindowspend=_FakeFindUniqueTable(row=row, error=error),
             litellm_spendlogs=_FakeSpendLogsTable(total=spend_logs_total),
+            litellm_endusertable=_FakeFindUniqueTable(row=end_user_row, error=end_user_error),
         )
 
 
@@ -248,3 +251,65 @@ async def test_coalesced_window_seeds_a_cold_counter_from_the_row():
     assert result == 4.5
     assert cache.in_memory_cache.get_cache(key=counter_key) == 4.5
     assert prisma.db.litellm_spendlogs.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_end_user_from_db_reads_the_end_user_row_by_user_id():
+    prisma = _FakePrismaClient(end_user_row=SimpleNamespace(user_id="customer-42", spend=0.0))
+
+    result = await SpendCounterReseed.end_user_from_db(
+        prisma_client=prisma, counter_key="spend:end_user:customer-42"
+    )
+
+    assert result == 0.0
+    assert prisma.db.litellm_endusertable.where_clauses == [{"user_id": "customer-42"}]
+
+
+@pytest.mark.asyncio
+async def test_end_user_from_db_returns_the_recorded_spend():
+    prisma = _FakePrismaClient(end_user_row=SimpleNamespace(user_id="customer-42", spend=12.5))
+
+    assert (
+        await SpendCounterReseed.end_user_from_db(prisma_client=prisma, counter_key="spend:end_user:customer-42")
+        == 12.5
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("counter_key", ["spend:key:hashed", "spend:team:t1", "spend:tag:t1"])
+async def test_end_user_from_db_ignores_other_counter_kinds_without_touching_the_db(counter_key):
+    prisma = _FakePrismaClient(end_user_row=SimpleNamespace(user_id="x", spend=5.0))
+
+    assert await SpendCounterReseed.end_user_from_db(prisma_client=prisma, counter_key=counter_key) is None
+    assert prisma.db.litellm_endusertable.where_clauses == []
+
+
+@pytest.mark.asyncio
+async def test_end_user_from_db_returns_none_without_a_row_a_client_or_on_db_error():
+    assert (
+        await SpendCounterReseed.end_user_from_db(prisma_client=None, counter_key="spend:end_user:customer-42")
+        is None
+    )
+    assert (
+        await SpendCounterReseed.end_user_from_db(
+            prisma_client=_FakePrismaClient(end_user_row=None), counter_key="spend:end_user:customer-42"
+        )
+        is None
+    )
+    assert (
+        await SpendCounterReseed.end_user_from_db(
+            prisma_client=_FakePrismaClient(end_user_error=RuntimeError("db down")),
+            counter_key="spend:end_user:customer-42",
+        )
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_from_db_still_never_reads_the_end_user_row():
+    """A cold end-user counter keeps seeding from the cached end-user object the auth
+    path already loaded; the row is read only as the budget floor."""
+    prisma = _FakePrismaClient(end_user_row=SimpleNamespace(user_id="customer-42", spend=5.0))
+
+    assert await SpendCounterReseed.from_db(prisma_client=prisma, counter_key="spend:end_user:customer-42") is None
+    assert prisma.db.litellm_endusertable.where_clauses == []

--- a/tests/test_litellm/proxy/db/test_spend_counter_reseed.py
+++ b/tests/test_litellm/proxy/db/test_spend_counter_reseed.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
+from typing import Final
 
 import pytest
 
@@ -255,9 +256,9 @@ async def test_coalesced_window_seeds_a_cold_counter_from_the_row():
 
 @pytest.mark.asyncio
 async def test_end_user_from_db_reads_the_end_user_row_by_user_id():
-    prisma = _FakePrismaClient(end_user_row=SimpleNamespace(user_id="customer-42", spend=0.0))
+    prisma: Final = _FakePrismaClient(end_user_row=SimpleNamespace(user_id="customer-42", spend=0.0))
 
-    result = await SpendCounterReseed.end_user_from_db(
+    result: Final = await SpendCounterReseed.end_user_from_db(
         prisma_client=prisma, counter_key="spend:end_user:customer-42"
     )
 
@@ -267,7 +268,7 @@ async def test_end_user_from_db_reads_the_end_user_row_by_user_id():
 
 @pytest.mark.asyncio
 async def test_end_user_from_db_returns_the_recorded_spend():
-    prisma = _FakePrismaClient(end_user_row=SimpleNamespace(user_id="customer-42", spend=12.5))
+    prisma: Final = _FakePrismaClient(end_user_row=SimpleNamespace(user_id="customer-42", spend=12.5))
 
     assert (
         await SpendCounterReseed.end_user_from_db(prisma_client=prisma, counter_key="spend:end_user:customer-42")
@@ -278,7 +279,7 @@ async def test_end_user_from_db_returns_the_recorded_spend():
 @pytest.mark.asyncio
 @pytest.mark.parametrize("counter_key", ["spend:key:hashed", "spend:team:t1", "spend:tag:t1"])
 async def test_end_user_from_db_ignores_other_counter_kinds_without_touching_the_db(counter_key):
-    prisma = _FakePrismaClient(end_user_row=SimpleNamespace(user_id="x", spend=5.0))
+    prisma: Final = _FakePrismaClient(end_user_row=SimpleNamespace(user_id="x", spend=5.0))
 
     assert await SpendCounterReseed.end_user_from_db(prisma_client=prisma, counter_key=counter_key) is None
     assert prisma.db.litellm_endusertable.where_clauses == []
@@ -309,7 +310,7 @@ async def test_end_user_from_db_returns_none_without_a_row_a_client_or_on_db_err
 async def test_from_db_still_never_reads_the_end_user_row():
     """A cold end-user counter keeps seeding from the cached end-user object the auth
     path already loaded; the row is read only as the budget floor."""
-    prisma = _FakePrismaClient(end_user_row=SimpleNamespace(user_id="customer-42", spend=5.0))
+    prisma: Final = _FakePrismaClient(end_user_row=SimpleNamespace(user_id="customer-42", spend=5.0))
 
     assert await SpendCounterReseed.from_db(prisma_client=prisma, counter_key="spend:end_user:customer-42") is None
     assert prisma.db.litellm_endusertable.where_clauses == []

--- a/tests/test_litellm/proxy/proxy_server/test_spend_counters.py
+++ b/tests/test_litellm/proxy/proxy_server/test_spend_counters.py
@@ -223,21 +223,90 @@ async def test_get_current_spend_floor_caches_db_read(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_get_current_spend_floors_end_user_tag_against_fallback(monkeypatch):
-    """End-user and tag counters have no DB row (from_db returns None). When the
-    counter is stale-low, enforcement falls back to the caller's recorded spend
-    (loaded fresh in auth) instead of trusting the stale counter."""
+    """Tag counters have no DB row (from_db returns None), and an end-user counter has
+    none to read without a DB client. When such a counter is stale-low, enforcement
+    falls back to the caller's recorded spend (loaded fresh in auth) instead of
+    trusting the stale counter."""
     fake_cache = _make_spend_counter_cache(redis_get_value=2.0)
     monkeypatch.setattr(ps, "spend_counter_cache", fake_cache)
+    monkeypatch.setattr(ps, "prisma_client", None)
     monkeypatch.setattr(ps.SpendCounterReseed, "from_db", AsyncMock(return_value=None))
 
+    for counter_key in ("spend:end_user:e1", "spend:tag:t1"):
+        result = await ps.get_current_spend(
+            counter_key=counter_key,
+            fallback_spend=20.0,
+            max_budget=10.0,
+        )
+
+        assert result == 20.0
+    # no DB row to repair against, so the shared counter is left untouched
+    fake_cache.redis_cache.async_set_max.assert_not_called()
+
+
+def _make_prisma_with_end_user_row(spend: float | None):
+    prisma = MagicMock()
+    prisma.db.litellm_endusertable.find_unique = AsyncMock(
+        return_value=None if spend is None else MagicMock(spend=spend)
+    )
+    return prisma
+
+
+@pytest.mark.asyncio
+async def test_get_current_spend_end_user_floor_admits_after_a_reset_on_a_stale_worker(monkeypatch):
+    """The reset job zeroes LiteLLM_EndUserTable.spend and the shared counter, but it
+    evicts the cached end-user object only on the worker that ran the reset. Every
+    other worker still passes the pre-reset spend as fallback_spend, and that stale
+    copy must not out-vote the reset row."""
+    fake_cache = _make_spend_counter_cache(redis_get_value=0.0)
+    monkeypatch.setattr(ps, "spend_counter_cache", fake_cache)
+    prisma = _make_prisma_with_end_user_row(spend=0.0)
+    monkeypatch.setattr(ps, "prisma_client", prisma)
+
     result = await ps.get_current_spend(
-        counter_key="spend:end_user:e1",
+        counter_key="spend:end_user:customer-42",
+        fallback_spend=0.000032,
+        max_budget=0.00003,
+        fallback_authoritative=True,
+    )
+
+    assert result == 0.0
+    prisma.db.litellm_endusertable.find_unique.assert_awaited_once_with(where={"user_id": "customer-42"})
+    fake_cache.redis_cache.async_set_max.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_current_spend_end_user_floor_repairs_a_stale_low_counter(monkeypatch):
+    """After a Redis restart the end-user counter can sit below the recorded spend;
+    the row wins and the shared counter is raised so other workers stop admitting on
+    the stale value."""
+    fake_cache = _make_spend_counter_cache(redis_get_value=2.0)
+    monkeypatch.setattr(ps, "spend_counter_cache", fake_cache)
+    monkeypatch.setattr(ps, "prisma_client", _make_prisma_with_end_user_row(spend=12.0))
+
+    result = await ps.get_current_spend(
+        counter_key="spend:end_user:customer-42",
+        fallback_spend=12.0,
+        max_budget=10.0,
+    )
+
+    assert result == 12.0
+    fake_cache.redis_cache.async_set_max.assert_awaited_once_with(key="spend:end_user:customer-42", value=12.0)
+
+
+@pytest.mark.asyncio
+async def test_get_current_spend_end_user_without_a_row_keeps_the_cached_spend(monkeypatch):
+    fake_cache = _make_spend_counter_cache(redis_get_value=0.0)
+    monkeypatch.setattr(ps, "spend_counter_cache", fake_cache)
+    monkeypatch.setattr(ps, "prisma_client", _make_prisma_with_end_user_row(spend=None))
+
+    result = await ps.get_current_spend(
+        counter_key="spend:end_user:customer-42",
         fallback_spend=20.0,
         max_budget=10.0,
     )
 
     assert result == 20.0
-    # no DB row to repair against, so the shared counter is left untouched
     fake_cache.redis_cache.async_set_max.assert_not_called()
 
 

--- a/tests/test_litellm/proxy/proxy_server/test_spend_counters.py
+++ b/tests/test_litellm/proxy/proxy_server/test_spend_counters.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime
+from typing import Final
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -233,7 +234,7 @@ async def test_get_current_spend_floors_end_user_tag_against_fallback(monkeypatc
     monkeypatch.setattr(ps.SpendCounterReseed, "from_db", AsyncMock(return_value=None))
 
     for counter_key in ("spend:end_user:e1", "spend:tag:t1"):
-        result = await ps.get_current_spend(
+        result: Final = await ps.get_current_spend(
             counter_key=counter_key,
             fallback_spend=20.0,
             max_budget=10.0,
@@ -245,7 +246,7 @@ async def test_get_current_spend_floors_end_user_tag_against_fallback(monkeypatc
 
 
 def _make_prisma_with_end_user_row(spend: float | None):
-    prisma = MagicMock()
+    prisma: Final = MagicMock()
     prisma.db.litellm_endusertable.find_unique = AsyncMock(
         return_value=None if spend is None else MagicMock(spend=spend)
     )
@@ -258,9 +259,9 @@ async def test_get_current_spend_end_user_floor_admits_after_a_reset_on_a_stale_
     evicts the cached end-user object only on the worker that ran the reset. Every
     other worker still passes the pre-reset spend as fallback_spend, and that stale
     copy must not out-vote the reset row."""
-    fake_cache = _make_spend_counter_cache(redis_get_value=0.0)
+    fake_cache: Final = _make_spend_counter_cache(redis_get_value=0.0)
     monkeypatch.setattr(ps, "spend_counter_cache", fake_cache)
-    prisma = _make_prisma_with_end_user_row(spend=0.0)
+    prisma: Final = _make_prisma_with_end_user_row(spend=0.0)
     monkeypatch.setattr(ps, "prisma_client", prisma)
 
     result = await ps.get_current_spend(
@@ -280,11 +281,11 @@ async def test_get_current_spend_end_user_floor_repairs_a_stale_low_counter(monk
     """After a Redis restart the end-user counter can sit below the recorded spend;
     the row wins and the shared counter is raised so other workers stop admitting on
     the stale value."""
-    fake_cache = _make_spend_counter_cache(redis_get_value=2.0)
+    fake_cache: Final = _make_spend_counter_cache(redis_get_value=2.0)
     monkeypatch.setattr(ps, "spend_counter_cache", fake_cache)
     monkeypatch.setattr(ps, "prisma_client", _make_prisma_with_end_user_row(spend=12.0))
 
-    result = await ps.get_current_spend(
+    result: Final = await ps.get_current_spend(
         counter_key="spend:end_user:customer-42",
         fallback_spend=12.0,
         max_budget=10.0,
@@ -296,11 +297,11 @@ async def test_get_current_spend_end_user_floor_repairs_a_stale_low_counter(monk
 
 @pytest.mark.asyncio
 async def test_get_current_spend_end_user_without_a_row_keeps_the_cached_spend(monkeypatch):
-    fake_cache = _make_spend_counter_cache(redis_get_value=0.0)
+    fake_cache: Final = _make_spend_counter_cache(redis_get_value=0.0)
     monkeypatch.setattr(ps, "spend_counter_cache", fake_cache)
     monkeypatch.setattr(ps, "prisma_client", _make_prisma_with_end_user_row(spend=None))
 
-    result = await ps.get_current_spend(
+    result: Final = await ps.get_current_spend(
         counter_key="spend:end_user:customer-42",
         fallback_spend=20.0,
         max_budget=10.0,

--- a/tests/test_litellm/proxy/proxy_server/test_spend_counters.py
+++ b/tests/test_litellm/proxy/proxy_server/test_spend_counters.py
@@ -223,24 +223,24 @@ async def test_get_current_spend_floor_caches_db_read(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_get_current_spend_floors_end_user_tag_against_fallback(monkeypatch):
+@pytest.mark.parametrize("counter_key", ("spend:end_user:e1", "spend:tag:t1"))
+async def test_get_current_spend_floors_end_user_tag_against_fallback(monkeypatch, counter_key):
     """Tag counters have no DB row (from_db returns None), and an end-user counter has
     none to read without a DB client. When such a counter is stale-low, enforcement
     falls back to the caller's recorded spend (loaded fresh in auth) instead of
     trusting the stale counter."""
-    fake_cache = _make_spend_counter_cache(redis_get_value=2.0)
+    fake_cache: Final = _make_spend_counter_cache(redis_get_value=2.0)
     monkeypatch.setattr(ps, "spend_counter_cache", fake_cache)
     monkeypatch.setattr(ps, "prisma_client", None)
     monkeypatch.setattr(ps.SpendCounterReseed, "from_db", AsyncMock(return_value=None))
 
-    for counter_key in ("spend:end_user:e1", "spend:tag:t1"):
-        result: Final = await ps.get_current_spend(
-            counter_key=counter_key,
-            fallback_spend=20.0,
-            max_budget=10.0,
-        )
+    result: Final = await ps.get_current_spend(
+        counter_key=counter_key,
+        fallback_spend=20.0,
+        max_budget=10.0,
+    )
 
-        assert result == 20.0
+    assert result == 20.0
     # no DB row to repair against, so the shared counter is left untouched
     fake_cache.redis_cache.async_set_max.assert_not_called()
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- An end-user budget reset zeroes the DB spend but not the cached spend counter
- Requests keep getting HTTP 429 after the window rolls over, until the caches expire
- The reset job evicts the cached end-user object only on its own worker
- Every other worker or replica keeps enforcing the pre-reset spend for another cache TTL

How it solves it:

- The reset zeroes `spend:end_user:<id>` in memory and Redis and evicts the cached end-user object
- Rollover carry now applies to explicit and default end-user budgets alike
- Enforcement floors a cached end-user spend on `LiteLLM_EndUserTable.spend` when the shared counter sits below it
- That floor read only runs in that mismatch and is cached in-process for 5s, like the key and team floors
- Regression tests cover the reset, the eviction, the stale-worker floor, and the DB-free cold counter path

## User Flow

Before: a developer whose app tags requests with an end-user id keeps getting budget-exceeded errors after that end user's budget window has already rolled over

1. The proxy admin creates the default end-user budget with POST https://litellm-domain/budget/new and body `{"budget_id": "default-end-user-budget", "max_budget": 0.00008, "budget_duration": "30s"}`, then sets `max_end_user_budget_id: default-end-user-budget` under `litellm_settings`
2. The developer sends POST https://litellm-domain/v1/chat/completions requests with header `x-litellm-end-user-id: customer-42`, spread across the proxy's replicas; the first five return HTTP 200 and use up the $0.00008 budget, the sixth returns HTTP 429 `Budget has been exceeded`
3. They wait for the 30-second budget window to roll over
4. They send five requests in the new window, spread across the replicas the same way, and every one returns HTTP 429 even though the window has reset
5. Only after they stop sending requests for a full 60 seconds does the next request return HTTP 200

After: the same developer's requests go through as soon as the budget window rolls over, whichever replica or worker serves them

1. The proxy admin creates the default end-user budget with POST https://litellm-domain/budget/new and body `{"budget_id": "default-end-user-budget", "max_budget": 0.00008, "budget_duration": "30s"}`, then sets `max_end_user_budget_id: default-end-user-budget` under `litellm_settings`
2. The developer sends POST https://litellm-domain/v1/chat/completions requests with header `x-litellm-end-user-id: customer-42`, spread across the proxy's replicas; the first five return HTTP 200 and use up the $0.00008 budget, the sixth returns HTTP 429 `Budget has been exceeded`
3. They wait for the 30-second budget window to roll over
4. They send five requests in the new window, spread across the replicas the same way, and every one returns HTTP 200 with a completion, charged against the fresh window
5. GET https://litellm-domain/customer/info?end_user_id=customer-42 shows the spend accruing again from 0 in the new window, and the next rollover clears it the same way

## Relevant issues

Fixes #39726

## Linear ticket

Resolves LIT-6977

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both legs run the same rig: two proxy replicas booted from the leg's commit, each with `--num_workers 2`, sharing one fresh Postgres database (a dedicated `postgres:16-alpine` container) and one Redis (`redis:7-alpine`), with requests alternating between replica A and replica B so state written through one worker is enforced by another. Every chat completion is a real Anthropic call to `claude-haiku-4-5` with `max_tokens: 1` (about $0.000016 each). The reset job interval is pinned to 5-6s so a 30s budget window rolls over quickly. The master key is shown as `sk-***`. Before ran on replica A `:49495` and B `:50692`, After on A `:35452` and B `:44694`.

Config used by both legs (only the Redis port differs):

```yaml
model_list:
  - model_name: claude-haiku-4-5
    litellm_params:
      model: anthropic/claude-haiku-4-5
      api_key: os.environ/ANTHROPIC_API_KEY
litellm_settings:
  max_end_user_budget_id: default-end-user-budget
  cache: true
  cache_params:
    type: redis
    host: 127.0.0.1
    port: <redis port>
    supported_call_types: []
general_settings:
  proxy_budget_rescheduler_min_time: 5
  proxy_budget_rescheduler_max_time: 6
```

Chat request used in every step below (the port and the end-user header vary per step; the nonce keeps the prompt unique):

```
curl -s -w '\nHTTP %{http_code}' http://127.0.0.1:<port>/v1/chat/completions -H 'Authorization: Bearer sk-***' -H 'x-litellm-end-user-id: <end user>' -H 'Content-Type: application/json' -d '{"model":"claude-haiku-4-5","messages":[{"role":"user","content":"hi <nonce>"}],"max_tokens":1}'
```

Chat responses are trimmed to `id`, `content`, `usage`, and the HTTP status; `/customer/info` and `/budget/info` responses to the fields that matter.

### Before (c8635ecc67)

#### Default end-user budget across a rollover, two replicas

1. The admin creates the default end-user budget (30s window, $0.00008):

    ```
    $ curl -s http://127.0.0.1:49495/budget/new -H 'Authorization: Bearer sk-***' -H 'Content-Type: application/json' -d '{"budget_id":"default-end-user-budget","max_budget":0.00008,"budget_duration":"30s"}'
    {"budget_id": "default-end-user-budget", "max_budget": 8e-05, "budget_duration": "30s", "budget_reset_at": "2026-09-05T00:36:30Z"}
    ```

2. The developer sends chat requests for `customer-42`, alternating replica A and B, until the budget is used up:

    ```
    request 1 via A at 00:36:15  {"id": "chatcmpl-3c4f1cfc-1d7a-4b72-a81d-7b252fdab1df", "content": "#", "usage": {"prompt_tokens": 11, "completion_tokens": 1}}  HTTP 200
    request 2 via B at 00:36:17  {"id": "chatcmpl-4dd5b077-4458-440b-8ada-3aebaec55ec4", "content": "Hey", "usage": {"prompt_tokens": 11, "completion_tokens": 1}}  HTTP 200
    request 3 via A at 00:36:19  {"id": "chatcmpl-5bffe746-5320-457b-81ec-fa6d44b26e74", "content": "Hello", "usage": {"prompt_tokens": 11, "completion_tokens": 1}}  HTTP 200
    request 4 via B at 00:36:21  {"id": "chatcmpl-b4ef1294-32ec-4a50-9926-9f5f51f58ce1", "content": "#", "usage": {"prompt_tokens": 11, "completion_tokens": 1}}  HTTP 200
    request 5 via A at 00:36:23  {"id": "chatcmpl-7924588f-7d74-46e3-b4ec-4782e5a90b16", "content": "#", "usage": {"prompt_tokens": 11, "completion_tokens": 1}}  HTTP 200
    request 6 via B at 00:36:25  {"error": {"message": "Budget has been exceeded! EndUser=customer-42 Current cost: 9.5e-05, Max budget: 8e-05", "type": "budget_exceeded", "param": null, "code": "429"}}  HTTP 429
    ```

3. The window rolls over (the reset job runs every 5-6s), and the admin view shows the reset:

    ```
    $ curl -s http://127.0.0.1:49495/budget/info -H 'Authorization: Bearer sk-***' -H 'Content-Type: application/json' -d '{"budgets":["default-end-user-budget"]}'
    {"budget_id": "default-end-user-budget", "max_budget": 8e-05, "budget_duration": "30s", "budget_reset_at": "2026-09-05T00:37:00Z"}     # was 2026-09-05T00:36:30Z, observed at 00:36:52
    $ curl -s 'http://127.0.0.1:49495/customer/info?end_user_id=customer-42' -H 'Authorization: Bearer sk-***'
    {"user_id": "customer-42", "spend": 1.6e-05, "budget_id": null, "blocked": false}
    ```

4. Five requests in the new window, alternating A and B, and every one is rejected with the pre-reset spend:

    ```
    post-rollover request 1 via A at 00:36:53  {"error": {"message": "Budget has been exceeded! EndUser=customer-42 Current cost: 9.5e-05, Max budget: 8e-05", "type": "budget_exceeded", "param": null, "code": "429"}}  HTTP 429
    post-rollover request 2 via B at 00:36:54  {"error": {"message": "Budget has been exceeded! EndUser=customer-42 Current cost: 9.5e-05, Max budget: 8e-05", "type": "budget_exceeded", "param": null, "code": "429"}}  HTTP 429
    post-rollover request 3 via A at 00:36:55  {"error": {"message": "Budget has been exceeded! EndUser=customer-42 Current cost: 9.5e-05, Max budget: 8e-05", "type": "budget_exceeded", "param": null, "code": "429"}}  HTTP 429
    post-rollover request 4 via B at 00:36:56  {"error": {"message": "Budget has been exceeded! EndUser=customer-42 Current cost: 9.5e-05, Max budget: 8e-05", "type": "budget_exceeded", "param": null, "code": "429"}}  HTTP 429
    post-rollover request 5 via A at 00:36:57  {"error": {"message": "Budget has been exceeded! EndUser=customer-42 Current cost: 9.5e-05, Max budget: 8e-05", "type": "budget_exceeded", "param": null, "code": "429"}}  HTTP 429
    ```

5. 12s later nothing was charged in the new window:

    ```
    $ curl -s 'http://127.0.0.1:50692/customer/info?end_user_id=customer-42' -H 'Authorization: Bearer sk-***'
    {"user_id": "customer-42", "spend": 0.0, "budget_id": null, "blocked": false}
    ```

#### Explicit end-user budget (`budget_id` on the customer) across a rollover

1. The admin creates a second 30s budget ($0.00003) and pins a customer to it:

    ```
    $ curl -s http://127.0.0.1:49495/budget/new -H 'Authorization: Bearer sk-***' -H 'Content-Type: application/json' -d '{"budget_id":"explicit-eu-budget","max_budget":0.00003,"budget_duration":"30s"}'
    {"budget_id": "explicit-eu-budget", "max_budget": 3e-05, "budget_duration": "30s", "budget_reset_at": "2026-09-05T00:38:00Z"}
    $ curl -s http://127.0.0.1:50692/customer/new -H 'Authorization: Bearer sk-***' -H 'Content-Type: application/json' -d '{"user_id":"customer-explicit","budget_id":"explicit-eu-budget"}'
    {"user_id": "customer-explicit", "spend": 0.0, "budget_id": "explicit-eu-budget", "blocked": false}
    ```

2. Chat requests for `customer-explicit` until the budget is used up:

    ```
    request 1 via A at 00:37:57  {"id": "chatcmpl-442295a8-fe3e-44b9-bbbf-7f842dca487f", "content": "#", "usage": {"prompt_tokens": 11, "completion_tokens": 1}}  HTTP 200
    request 2 via B at 00:38:00  {"id": "chatcmpl-823742b4-59d5-48c8-9e3f-0aae0b20cdfb", "content": "Hey", "usage": {"prompt_tokens": 11, "completion_tokens": 1}}  HTTP 200
    request 3 via A at 00:38:04  {"error": {"message": "ExceededBudget: End User=customer-explicit over budget. Spend=3.2e-05, Budget=3e-05", "type": "budget_exceeded", "param": null, "code": "429"}}  HTTP 429
    ```

3. The window rolls over (`budget_reset_at` 2026-09-05T00:38:00Z -> 2026-09-05T00:38:30Z, observed at 00:38:28)

4. The first two requests in the new window are still rejected:

    ```
    first request in the new window via A at 00:38:29   {"error": {"message": "ExceededBudget: End User=customer-explicit over budget. Spend=3.2e-05, Budget=3e-05", "type": "budget_exceeded", "param": null, "code": "429"}}  HTTP 429
    second request in the new window via B at 00:38:29  {"error": {"message": "ExceededBudget: End User=customer-explicit over budget. Spend=3.2e-05, Budget=3e-05", "type": "budget_exceeded", "param": null, "code": "429"}}  HTTP 429
    ```

#### New window keeps counting and spend re-accrues

1. About 90s after the last `customer-42` request (so the 60s cache has expired on every worker), the default budget rolls over again (`budget_reset_at` 2026-09-05T00:38:30Z -> 2026-09-05T00:39:00Z) and three back-to-back requests go through:

    ```
    new window, request 1 via A at 00:38:31  {"id": "chatcmpl-29ae703c-241e-4d47-b7c7-d37112a10f3c", "content": "#", "usage": {"prompt_tokens": 11, "completion_tokens": 1}}  HTTP 200
    new window, request 2 via B at 00:38:32  {"id": "chatcmpl-4028b834-fa2b-4422-a071-595d81169881", "content": "#", "usage": {"prompt_tokens": 11, "completion_tokens": 1}}  HTTP 200
    new window, request 3 via A at 00:38:33  {"id": "chatcmpl-f27f982a-b497-47c8-b0f4-ea72a057c982", "content": "#", "usage": {"prompt_tokens": 11, "completion_tokens": 1}}  HTTP 200
    ```

2. 12s later the spend for the new window is visible:

    ```
    $ curl -s 'http://127.0.0.1:50692/customer/info?end_user_id=customer-42' -H 'Authorization: Bearer sk-***'
    {"user_id": "customer-42", "spend": 4.8e-05, "budget_id": null, "blocked": false}
    ```

### After (89086db282)

The commits since (b4fd63f621, 4ffd2ffb25) only correct two comments in `proxy_server.py` and annotate or parametrize test locals, so they cannot change behavior and the run above stands.

#### Default end-user budget across a rollover, two replicas

1. The admin creates the default end-user budget (30s window, $0.00008):

    ```
    $ curl -s http://127.0.0.1:35452/budget/new -H 'Authorization: Bearer sk-***' -H 'Content-Type: application/json' -d '{"budget_id":"default-end-user-budget","max_budget":0.00008,"budget_duration":"30s"}'
    {"budget_id": "default-end-user-budget", "max_budget": 8e-05, "budget_duration": "30s", "budget_reset_at": "2026-09-05T00:41:00Z"}
    ```

2. The developer sends chat requests for `customer-42`, alternating replica A and B, until the budget is used up:

    ```
    request 1 via A at 00:40:42  {"id": "chatcmpl-83f0e770-b459-45ff-9910-bf2090978ef2", "content": "#", "usage": {"prompt_tokens": 11, "completion_tokens": 1}}  HTTP 200
    request 2 via B at 00:40:44  {"id": "chatcmpl-648beffd-cba9-48c3-855a-8f9c2966ba6e", "content": "#", "usage": {"prompt_tokens": 11, "completion_tokens": 1}}  HTTP 200
    request 3 via A at 00:40:45  {"id": "chatcmpl-5a382b32-c582-46c4-8144-78df6ffa737c", "content": "#", "usage": {"prompt_tokens": 11, "completion_tokens": 1}}  HTTP 200
    request 4 via B at 00:40:47  {"id": "chatcmpl-6ed57532-34b2-4414-810f-c43ef3eb8248", "content": "#", "usage": {"prompt_tokens": 11, "completion_tokens": 1}}  HTTP 200
    request 5 via A at 00:40:49  {"id": "chatcmpl-9eeed1b8-580c-4076-893c-cf88aa370f3f", "content": "#", "usage": {"prompt_tokens": 11, "completion_tokens": 1}}  HTTP 200
    request 6 via B at 00:40:51  {"error": {"message": "Budget has been exceeded! EndUser=customer-42 Current cost: 9.5e-05, Max budget: 8e-05", "type": "budget_exceeded", "param": null, "code": "429"}}  HTTP 429
    ```

3. The window rolls over, and the admin view shows the reset:

    ```
    $ curl -s http://127.0.0.1:35452/budget/info -H 'Authorization: Bearer sk-***' -H 'Content-Type: application/json' -d '{"budgets":["default-end-user-budget"]}'
    {"budget_id": "default-end-user-budget", "max_budget": 8e-05, "budget_duration": "30s", "budget_reset_at": "2026-09-05T00:41:30Z"}     # was 2026-09-05T00:41:00Z, observed at 00:41:20
    $ curl -s 'http://127.0.0.1:35452/customer/info?end_user_id=customer-42' -H 'Authorization: Bearer sk-***'
    {"user_id": "customer-42", "spend": 0.0, "budget_id": null, "blocked": false}
    ```

4. Five requests in the new window, alternating A and B, and every one goes through:

    ```
    post-rollover request 1 via A at 00:41:20  {"id": "chatcmpl-303b6d31-b5a0-4e16-8946-b6d3cf228d64", "content": "#", "usage": {"prompt_tokens": 11, "completion_tokens": 1}}  HTTP 200
    post-rollover request 2 via B at 00:41:22  {"id": "chatcmpl-10cbab68-006f-45cf-bfda-af07f12853f8", "content": "#", "usage": {"prompt_tokens": 11, "completion_tokens": 1}}  HTTP 200
    post-rollover request 3 via A at 00:41:24  {"id": "chatcmpl-e6f18663-7bdb-41ca-aaef-f10a4e8dc1b7", "content": "Hello", "usage": {"prompt_tokens": 11, "completion_tokens": 1}}  HTTP 200
    post-rollover request 4 via B at 00:41:25  {"id": "chatcmpl-401b5c96-ef3b-4c4f-9e48-fbb9e63e89a8", "content": "#", "usage": {"prompt_tokens": 11, "completion_tokens": 1}}  HTTP 200
    post-rollover request 5 via A at 00:41:27  {"id": "chatcmpl-9e60e0a1-fc59-4149-9a9a-9c39f63d7228", "content": "#", "usage": {"prompt_tokens": 11, "completion_tokens": 1}}  HTTP 200
    ```

5. 12s later the new window's spend is accruing from 0:

    ```
    $ curl -s 'http://127.0.0.1:44694/customer/info?end_user_id=customer-42' -H 'Authorization: Bearer sk-***'
    {"user_id": "customer-42", "spend": 6.4e-05, "budget_id": null, "blocked": false}
    ```

#### Explicit end-user budget (`budget_id` on the customer) across a rollover

1. The admin creates a second 30s budget ($0.00003) and pins a customer to it:

    ```
    $ curl -s http://127.0.0.1:35452/budget/new -H 'Authorization: Bearer sk-***' -H 'Content-Type: application/json' -d '{"budget_id":"explicit-eu-budget","max_budget":0.00003,"budget_duration":"30s"}'
    {"budget_id": "explicit-eu-budget", "max_budget": 3e-05, "budget_duration": "30s", "budget_reset_at": "2026-09-05T00:45:00Z"}
    $ curl -s http://127.0.0.1:44694/customer/new -H 'Authorization: Bearer sk-***' -H 'Content-Type: application/json' -d '{"user_id":"customer-explicit","budget_id":"explicit-eu-budget"}'
    {"user_id": "customer-explicit", "spend": 0.0, "budget_id": "explicit-eu-budget", "blocked": false}
    ```

2. Chat requests for `customer-explicit` until the budget is used up:

    ```
    request 1 via A at 00:44:33  {"id": "chatcmpl-4adabc20-3e19-47c6-b260-3cf2b4231a4e", "content": "#", "usage": {"prompt_tokens": 11, "completion_tokens": 1}}  HTTP 200
    request 2 via B at 00:44:36  {"id": "chatcmpl-b73693cf-6eec-48fe-be38-26b1f55ce573", "content": "#", "usage": {"prompt_tokens": 11, "completion_tokens": 1}}  HTTP 200
    request 3 via A at 00:44:40  {"error": {"message": "ExceededBudget: End User=customer-explicit over budget. Spend=3.2e-05, Budget=3e-05", "type": "budget_exceeded", "param": null, "code": "429"}}  HTTP 429
    ```

3. The window rolls over (`budget_reset_at` 2026-09-05T00:45:00Z -> 2026-09-05T00:45:30Z, observed at 00:45:04)

4. The first two requests in the new window go through:

    ```
    first request in the new window via A at 00:45:04   {"id": "chatcmpl-deb88624-f0db-407a-b2be-ddf9ba9a4a00", "content": "Hello", "usage": {"prompt_tokens": 11, "completion_tokens": 1}}  HTTP 200
    second request in the new window via B at 00:45:05  {"id": "chatcmpl-4665aff6-f62a-4050-82fc-ddcc3c64915f", "content": "#", "usage": {"prompt_tokens": 11, "completion_tokens": 1}}  HTTP 200
    ```

#### New window keeps counting and spend re-accrues

1. The default budget rolls over again (`budget_reset_at` 2026-09-05T00:45:30Z -> 2026-09-05T00:46:00Z) and three back-to-back requests go through:

    ```
    new window, request 1 via A at 00:45:30  {"id": "chatcmpl-57fba407-d929-4aeb-b743-1d0cdeb422ff", "content": "#", "usage": {"prompt_tokens": 11, "completion_tokens": 1}}  HTTP 200
    new window, request 2 via B at 00:45:31  {"id": "chatcmpl-11c5a222-e9c1-40fe-8f4c-c5132d7301db", "content": "#", "usage": {"prompt_tokens": 11, "completion_tokens": 1}}  HTTP 200
    new window, request 3 via A at 00:45:32  {"id": "chatcmpl-032f3d53-3f6e-4445-a80d-02014a6d3556", "content": "#", "usage": {"prompt_tokens": 11, "completion_tokens": 1}}  HTTP 200
    ```

2. 12s later the spend for the new window is visible:

    ```
    $ curl -s 'http://127.0.0.1:44694/customer/info?end_user_id=customer-42' -H 'Authorization: Bearer sk-***'
    {"user_id": "customer-42", "spend": 4.8e-05, "budget_id": null, "blocked": false}
    ```

Observations from the run:

- Before leg: a batched spend write landed after the reset
  - `/customer/info` briefly showed pre-reset spend in the new window
  - timing-dependent and pre-existing; this PR leaves it alone
- Default and explicit end-user budgets return different 429 messages
  - pre-existing; this PR leaves it alone
- `/customer/info` spend lags the counter by the batch write interval
  - pre-existing on both legs; this PR leaves it alone

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- With `fail_closed_budget_enforcement` on, end-user checks now floor on the DB row too
  - one primary-key read per worker per 5s while the counter trails the cached spend
- A reset drops a pre-reset reservation, like every other entity in the cascade
  - pre-existing; the reseeded floor is the just-reset DB value
- Rollover carry for end users (`budget_rollover: true`) is unit-tested, not exercised live
- A stale-low Redis reload during the spend batch-write lag can under-enforce for one flush interval
  - the cached end user runs ahead of the row until the next flush, like keys and teams already do

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes budget enforcement and reset side effects for end users across workers and Redis; behavior is well-tested but touches multi-replica cache/counter consistency on a customer-facing path.
> 
> **Overview**
> Fixes end-user budgets staying blocked after a window rollover because Redis/in-memory `spend:end_user:<id>` counters and per-worker cached end-user objects were not aligned with `LiteLLM_EndUserTable` after the reset job ran.
> 
> The budget reset cascade now treats end users like keys/teams/tags: it resets `spend:end_user:<id>` (including rollover carry for explicit and default `max_end_user_budget_id` budgets), and evicts the end-user management cache key. **`get_current_spend`** can floor enforcement on **`LiteLLM_EndUserTable.spend`** via new **`SpendCounterReseed.end_user_from_db`** (cold reseed still uses auth `fallback_spend`; the row read is only for stale-low / post-reset mismatch). **`_floor_spend_from_db`** centralizes that path alongside existing entity/window floors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ffd2ffb25017c861a350f24a27b6441ceeb2fd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

- [x] 89086db282 passes /live-pr-risk
