### PR TITLE
fix(bedrock): support SigV4 file deletion for S3 batch files (#39715)

### DIFF
--- a/enterprise/litellm_enterprise/proxy/hooks/managed_files.py
+++ b/enterprise/litellm_enterprise/proxy/hooks/managed_files.py
@@ -1779,6 +1779,11 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
             # Remove conflicting keys from data to avoid duplicate keyword arguments
             filtered_data = {k: v for k, v in data.items() if k not in ("model", "file_id")}
             for model_id, model_file_id in specific_model_file_id_mapping.items():
+                credentials = llm_router.get_deployment_credentials_with_provider(model_id=model_id)
+                if credentials is not None:
+                    filtered_data["_litellm_internal_model_credentials"] = cast(Dict, MappingProxyType(dict(credentials)))
+                else:
+                    filtered_data.pop("_litellm_internal_model_credentials", None)
                 delete_response = await llm_router.afile_delete(model=model_id, file_id=model_file_id, **filtered_data)  # type: ignore
 
         stored_file_object = await self.delete_unified_file_id(file_id, litellm_parent_otel_span)

--- a/litellm/llms/bedrock/files/transformation.py
+++ b/litellm/llms/bedrock/files/transformation.py
@@ -1,4 +1,5 @@
 import base64
+import binascii
 import json
 import os
 import time
@@ -171,10 +172,9 @@ def extract_s3_uri_from_file_id(file_id: str) -> str:
         padded: Final = file_id + "=" * (-len(file_id) % 4)
         decoded: Final = base64.urlsafe_b64decode(padded).decode()
 
-        if decoded.startswith(SpecialEnums.LITELM_MANAGED_FILE_ID_PREFIX.value):
-            if "llm_output_file_id," in decoded:
-                return decoded.split("llm_output_file_id,")[1].split(";")[0]
-    except Exception:
+        if decoded.startswith(SpecialEnums.LITELM_MANAGED_FILE_ID_PREFIX.value) and "llm_output_file_id," in decoded:
+            return decoded.split("llm_output_file_id,")[1].split(";")[0]
+    except (binascii.Error, UnicodeDecodeError, ValueError):
         pass
 
     if file_id.startswith("s3://"):
@@ -1190,13 +1190,6 @@ class BedrockFilesConfig(BaseAWSLLM, BaseFilesConfig):
         optional_params: Mapping[str, object],
         litellm_params: MutableMapping[str, object],  # mutable-ok: caller expects in-place mutation of litellm_params
     ) -> tuple[str, dict[str, str]]:  # mutable-ok: BaseFilesConfig interface specifies dict
-        """
-        Build a SigV4-signed S3 DeleteObject request for a Bedrock batch file.
-
-        Bedrock batch file ids are `s3://bucket/key` URIs (or unified ids
-        that decode to one); the bucket and key are validated against the
-        server-configured bucket before any request is signed.
-        """
         if not file_id:
             raise ValueError("file_id is required for Bedrock file deletion")
 

--- a/litellm/llms/bedrock/files/transformation.py
+++ b/litellm/llms/bedrock/files/transformation.py
@@ -1211,7 +1211,7 @@ class BedrockFilesConfig(BaseAWSLLM, BaseFilesConfig):
         request_params: Final = _BedrockS3RequestParams.model_validate(merged_params)
 
         region_preference: Final = request_params.s3_region_name or request_params.aws_region_name
-        region_params: Final = MappingProxyType({"aws_region_name": region_preference})
+        region_params: Final = {"aws_region_name": region_preference}  # mutable-ok: _get_aws_region_name expects dict
         aws_region_name: Final = self._get_aws_region_name(optional_params=region_params, model="")
 
         s3_endpoint_url: Final = (
@@ -1219,8 +1219,8 @@ class BedrockFilesConfig(BaseAWSLLM, BaseFilesConfig):
         ).rstrip("/")
         url: Final = f"{s3_endpoint_url}/{bucket_name}/{encode_s3_object_key_for_url(object_key)}"
 
-        litellm_params[S3_SIGNED_GET_HEADERS_PARAM] = (
-            self._sign_s3_delete_request(  # rebind-ok: router expects litellm_params mutated
+        litellm_params[S3_SIGNED_GET_HEADERS_PARAM] = (  # rebind-ok: router expects litellm_params mutated
+            self._sign_s3_delete_request(
                 api_base=url,
                 aws_region_name=aws_region_name,
                 request_params=request_params,

--- a/litellm/llms/bedrock/files/transformation.py
+++ b/litellm/llms/bedrock/files/transformation.py
@@ -1187,10 +1187,47 @@ class BedrockFilesConfig(BaseAWSLLM, BaseFilesConfig):
     def transform_delete_file_request(
         self,
         file_id: str,
-        optional_params: dict,
-        litellm_params: dict,
-    ) -> tuple[str, dict]:
-        raise NotImplementedError("BedrockFilesConfig does not support file deletion")
+        optional_params: Mapping[str, object],
+        litellm_params: MutableMapping[str, object],
+    ) -> tuple[str, dict[str, str]]:
+        """
+        Build a SigV4-signed S3 DeleteObject request for a Bedrock batch file.
+
+        Bedrock batch file ids are `s3://bucket/key` URIs (or unified ids
+        that decode to one); the bucket and key are validated against the
+        server-configured bucket before any request is signed.
+        """
+        if not file_id:
+            raise ValueError("file_id is required for Bedrock file deletion")
+
+        s3_uri: Final = extract_s3_uri_from_file_id(file_id)
+        bucket_name, object_key = _validate_file_id_against_configured_buckets(
+            s3_uri=s3_uri,
+            configured_bucket_names=get_configured_s3_bucket_names(litellm_params),
+            allow_legacy_cloud_file_ids=should_allow_legacy_cloud_file_ids(litellm_params),
+        )
+
+        merged_params: Final[dict[str, object]] = {}
+        merged_params.update(litellm_params)
+        merged_params.update(optional_params)
+        request_params: Final = _BedrockS3RequestParams.model_validate(merged_params)
+
+        region_preference: Final = request_params.s3_region_name or request_params.aws_region_name
+        region_params: Final[dict[str, str | None]] = {"aws_region_name": region_preference}
+        aws_region_name: Final = self._get_aws_region_name(optional_params=region_params, model="")
+
+        s3_endpoint_url = (
+            request_params.s3_endpoint_url or f"https://s3.{aws_region_name}.{get_aws_dns_suffix(aws_region_name)}"
+        ).rstrip("/")
+        url: Final = f"{s3_endpoint_url}/{bucket_name}/{encode_s3_object_key_for_url(object_key)}"
+
+        litellm_params[S3_SIGNED_GET_HEADERS_PARAM] = self._sign_s3_delete_request(
+            api_base=url,
+            aws_region_name=aws_region_name,
+            request_params=request_params,
+        )
+        litellm_params["_deleted_file_id"] = file_id
+        return url, {}
 
     def transform_delete_file_response(
         self,
@@ -1198,7 +1235,18 @@ class BedrockFilesConfig(BaseAWSLLM, BaseFilesConfig):
         logging_obj: LiteLLMLoggingObj,
         litellm_params: dict,
     ) -> FileDeleted:
-        raise NotImplementedError("BedrockFilesConfig does not support file deletion")
+        if raw_response.status_code >= 400:
+            raise BedrockError(
+                status_code=raw_response.status_code,
+                message=raw_response.text,
+                headers=raw_response.headers,
+            )
+        file_id: Final = str(litellm_params.get("_deleted_file_id") or "deleted")
+        return FileDeleted(
+            id=file_id,
+            deleted=True,
+            object="file",
+        )
 
     def transform_list_files_request(
         self,
@@ -1265,14 +1313,15 @@ class BedrockFilesConfig(BaseAWSLLM, BaseFilesConfig):
         )
         return url, {}
 
-    def _sign_s3_get_request(
+    def _sign_s3_empty_body_request(
         self,
+        method: str,
         api_base: str,
         aws_region_name: str,
         request_params: _BedrockS3RequestParams,
     ) -> dict[str, str]:
         """
-        SigV4-sign an S3 GetObject request, mirroring `_sign_s3_request` (PUT).
+        SigV4-sign an S3 request with an empty body (e.g. GET, DELETE).
         """
         try:
             import hashlib
@@ -1297,13 +1346,45 @@ class BedrockFilesConfig(BaseAWSLLM, BaseFilesConfig):
 
         empty_body_hash: Final = hashlib.sha256(b"").hexdigest()
         aws_request: Final = AWSRequest(  # any-ok: botocore AWSRequest is untyped
-            method="GET",
+            method=method,
             url=api_base,
             headers={"x-amz-content-sha256": empty_body_hash},
         )
         auth: Final = S3SigV4Auth(credentials, "s3", aws_region_name)  # any-ok: botocore untyped
         auth.add_auth(aws_request)  # any-ok: botocore request mutation is untyped
         return dict(aws_request.headers)  # any-ok: botocore headers are untyped
+
+    def _sign_s3_get_request(
+        self,
+        api_base: str,
+        aws_region_name: str,
+        request_params: _BedrockS3RequestParams,
+    ) -> dict[str, str]:
+        """
+        SigV4-sign an S3 GetObject request, mirroring `_sign_s3_request` (PUT).
+        """
+        return self._sign_s3_empty_body_request(
+            method="GET",
+            api_base=api_base,
+            aws_region_name=aws_region_name,
+            request_params=request_params,
+        )
+
+    def _sign_s3_delete_request(
+        self,
+        api_base: str,
+        aws_region_name: str,
+        request_params: _BedrockS3RequestParams,
+    ) -> dict[str, str]:
+        """
+        SigV4-sign an S3 DeleteObject request, mirroring `_sign_s3_get_request` (GET).
+        """
+        return self._sign_s3_empty_body_request(
+            method="DELETE",
+            api_base=api_base,
+            aws_region_name=aws_region_name,
+            request_params=request_params,
+        )
 
     def transform_file_content_response(
         self,

--- a/litellm/llms/bedrock/files/transformation.py
+++ b/litellm/llms/bedrock/files/transformation.py
@@ -1188,8 +1188,8 @@ class BedrockFilesConfig(BaseAWSLLM, BaseFilesConfig):
         self,
         file_id: str,
         optional_params: Mapping[str, object],
-        litellm_params: MutableMapping[str, object],
-    ) -> tuple[str, dict[str, str]]:
+        litellm_params: MutableMapping[str, object],  # mutable-ok: caller expects in-place mutation of litellm_params
+    ) -> tuple[str, dict[str, str]]:  # mutable-ok: BaseFilesConfig interface specifies dict
         """
         Build a SigV4-signed S3 DeleteObject request for a Bedrock batch file.
 
@@ -1207,33 +1207,31 @@ class BedrockFilesConfig(BaseAWSLLM, BaseFilesConfig):
             allow_legacy_cloud_file_ids=should_allow_legacy_cloud_file_ids(litellm_params),
         )
 
-        merged_params: Final[dict[str, object]] = {}
-        merged_params.update(litellm_params)
-        merged_params.update(optional_params)
+        merged_params: Final = MappingProxyType({**litellm_params, **optional_params})
         request_params: Final = _BedrockS3RequestParams.model_validate(merged_params)
 
         region_preference: Final = request_params.s3_region_name or request_params.aws_region_name
-        region_params: Final[dict[str, str | None]] = {"aws_region_name": region_preference}
+        region_params: Final = MappingProxyType({"aws_region_name": region_preference})
         aws_region_name: Final = self._get_aws_region_name(optional_params=region_params, model="")
 
-        s3_endpoint_url = (
+        s3_endpoint_url: Final = (
             request_params.s3_endpoint_url or f"https://s3.{aws_region_name}.{get_aws_dns_suffix(aws_region_name)}"
         ).rstrip("/")
         url: Final = f"{s3_endpoint_url}/{bucket_name}/{encode_s3_object_key_for_url(object_key)}"
 
-        litellm_params[S3_SIGNED_GET_HEADERS_PARAM] = self._sign_s3_delete_request(
+        litellm_params[S3_SIGNED_GET_HEADERS_PARAM] = self._sign_s3_delete_request(  # rebind-ok: router expects litellm_params mutated
             api_base=url,
             aws_region_name=aws_region_name,
             request_params=request_params,
         )
-        litellm_params["_deleted_file_id"] = file_id
-        return url, {}
+        litellm_params["_deleted_file_id"] = file_id  # rebind-ok: router expects litellm_params mutated
+        return url, {}  # mutable-ok: empty headers dict required by BaseFilesConfig contract
 
     def transform_delete_file_response(
         self,
         raw_response: httpx.Response,
         logging_obj: LiteLLMLoggingObj,
-        litellm_params: dict,
+        litellm_params: dict,  # mutable-ok: BaseFilesConfig interface specifies dict
     ) -> FileDeleted:
         if raw_response.status_code >= 400:
             raise BedrockError(
@@ -1319,7 +1317,7 @@ class BedrockFilesConfig(BaseAWSLLM, BaseFilesConfig):
         api_base: str,
         aws_region_name: str,
         request_params: _BedrockS3RequestParams,
-    ) -> dict[str, str]:
+    ) -> dict[str, str]:  # mutable-ok: callers consume dict headers
         """
         SigV4-sign an S3 request with an empty body (e.g. GET, DELETE).
         """
@@ -1348,18 +1346,18 @@ class BedrockFilesConfig(BaseAWSLLM, BaseFilesConfig):
         aws_request: Final = AWSRequest(  # any-ok: botocore AWSRequest is untyped
             method=method,
             url=api_base,
-            headers={"x-amz-content-sha256": empty_body_hash},
+            headers={"x-amz-content-sha256": empty_body_hash},  # mutable-ok: botocore headers dict
         )
         auth: Final = S3SigV4Auth(credentials, "s3", aws_region_name)  # any-ok: botocore untyped
         auth.add_auth(aws_request)  # any-ok: botocore request mutation is untyped
-        return dict(aws_request.headers)  # any-ok: botocore headers are untyped
+        return dict(aws_request.headers)  # any-ok: botocore headers are untyped  # mutable-ok: botocore headers dict
 
     def _sign_s3_get_request(
         self,
         api_base: str,
         aws_region_name: str,
         request_params: _BedrockS3RequestParams,
-    ) -> dict[str, str]:
+    ) -> dict[str, str]:  # mutable-ok: callers consume dict headers
         """
         SigV4-sign an S3 GetObject request, mirroring `_sign_s3_request` (PUT).
         """
@@ -1375,7 +1373,7 @@ class BedrockFilesConfig(BaseAWSLLM, BaseFilesConfig):
         api_base: str,
         aws_region_name: str,
         request_params: _BedrockS3RequestParams,
-    ) -> dict[str, str]:
+    ) -> dict[str, str]:  # mutable-ok: callers consume dict headers
         """
         SigV4-sign an S3 DeleteObject request, mirroring `_sign_s3_get_request` (GET).
         """

--- a/litellm/llms/bedrock/files/transformation.py
+++ b/litellm/llms/bedrock/files/transformation.py
@@ -1219,10 +1219,12 @@ class BedrockFilesConfig(BaseAWSLLM, BaseFilesConfig):
         ).rstrip("/")
         url: Final = f"{s3_endpoint_url}/{bucket_name}/{encode_s3_object_key_for_url(object_key)}"
 
-        litellm_params[S3_SIGNED_GET_HEADERS_PARAM] = self._sign_s3_delete_request(  # rebind-ok: router expects litellm_params mutated
-            api_base=url,
-            aws_region_name=aws_region_name,
-            request_params=request_params,
+        litellm_params[S3_SIGNED_GET_HEADERS_PARAM] = (
+            self._sign_s3_delete_request(  # rebind-ok: router expects litellm_params mutated
+                api_base=url,
+                aws_region_name=aws_region_name,
+                request_params=request_params,
+            )
         )
         litellm_params["_deleted_file_id"] = file_id  # rebind-ok: router expects litellm_params mutated
         return url, {}  # mutable-ok: empty headers dict required by BaseFilesConfig contract

--- a/tests/test_litellm/enterprise/proxy/test_managed_files_hook.py
+++ b/tests/test_litellm/enterprise/proxy/test_managed_files_hook.py
@@ -1158,6 +1158,117 @@ async def test_afile_content_bedrock_unified_id_end_to_end(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_afile_delete_bedrock_unified_id_end_to_end(monkeypatch):
+    """
+    Proxy repro for Bedrock batch input/output deletion: a unified file id that
+    resolves to an s3:// object must be deleted via a SigV4-signed S3 DELETE
+    using the deployment's s3_bucket_name (no AWS_S3_BUCKET_NAME env).
+
+    Regression test for "BedrockFilesConfig does not support file deletion"
+    raised on this path.
+    """
+    import httpx
+    import respx
+
+    import litellm
+    from litellm import Router
+
+    monkeypatch.delenv("AWS_S3_BUCKET_NAME", raising=False)
+    monkeypatch.setattr(litellm, "disable_aiohttp_transport", True)
+    litellm.in_memory_llm_clients_cache.flush_cache()
+
+    router = Router(
+        model_list=[
+            {
+                "model_name": "bedrock-claude",
+                "litellm_params": {
+                    "model": "bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0",
+                    "aws_access_key_id": "AKIAEXAMPLE",
+                    "aws_secret_access_key": "secret",
+                    "aws_region_name": "us-west-2",
+                    "s3_bucket_name": "my-bucket",
+                },
+                "model_info": {"id": "model-123"},
+            }
+        ]
+    )
+
+    managed_files = _make_managed_files_instance()
+    managed_files._check_file_deletion_allowed = AsyncMock()
+    managed_files.delete_unified_file_id = AsyncMock(return_value=None)
+    unified_file_id = "unified-file-id"
+    s3_uri = "s3://my-bucket/litellm-bedrock-files/job-123/input.jsonl"
+    managed_files.get_model_file_id_mapping = AsyncMock(
+        return_value={unified_file_id: {"model-123": s3_uri}}
+    )
+
+    expected_url = "https://s3.us-west-2.amazonaws.com/my-bucket/litellm-bedrock-files/job-123/input.jsonl"
+    with respx.mock:
+        route = respx.delete(expected_url).mock(
+            return_value=httpx.Response(204)
+        )
+
+        response = await managed_files.afile_delete(
+            file_id=unified_file_id,
+            litellm_parent_otel_span=None,
+            llm_router=router,
+        )
+
+    assert route.called
+    assert (
+        route.calls[0].request.headers["Authorization"].startswith("AWS4-HMAC-SHA256")
+    )
+    assert response.id == unified_file_id
+    assert response.deleted is True
+
+
+@pytest.mark.asyncio
+async def test_afile_delete_passes_trusted_model_credentials_to_router():
+    """afile_delete must inject the deployment's credentials snapshot into
+    _litellm_internal_model_credentials so downstream cloud-storage validators
+    trust the configured bucket."""
+    from types import MappingProxyType
+
+    managed_files = _make_managed_files_instance()
+    managed_files._check_file_deletion_allowed = AsyncMock()
+    managed_files.delete_unified_file_id = AsyncMock(return_value=None)
+
+    unified_file_id = "unified-file-id"
+    s3_uri = "s3://my-bucket/litellm-bedrock-files/job-123/input.jsonl"
+    managed_files.get_model_file_id_mapping = AsyncMock(
+        return_value={unified_file_id: {"model-deploy-1": s3_uri}}
+    )
+
+    mock_router = MagicMock()
+    mock_router.get_deployment_credentials_with_provider = MagicMock(
+        return_value={
+            "custom_llm_provider": "bedrock",
+            "s3_bucket_name": "my-bucket",
+            "aws_region_name": "us-west-2",
+        }
+    )
+    delete_mock = AsyncMock(return_value=MagicMock(id=s3_uri, deleted=True, object="file"))
+    mock_router.afile_delete = delete_mock
+
+    await managed_files.afile_delete(
+        file_id=unified_file_id,
+        litellm_parent_otel_span=None,
+        llm_router=mock_router,
+    )
+
+    delete_mock.assert_awaited_once()
+    passed_kwargs = delete_mock.await_args.kwargs
+    assert passed_kwargs["model"] == "model-deploy-1"
+    assert passed_kwargs["file_id"] == s3_uri
+    assert "_litellm_internal_model_credentials" in passed_kwargs
+    assert isinstance(passed_kwargs["_litellm_internal_model_credentials"], MappingProxyType)
+    assert (
+        passed_kwargs["_litellm_internal_model_credentials"]["s3_bucket_name"]
+        == "my-bucket"
+    )
+
+
+@pytest.mark.asyncio
 async def test_afile_content_error_reports_unified_id_not_provider_uri():
     """When every model attempt fails, the error must name the caller's unified
     file id, never the resolved internal s3:// URI (no internal-path leak)."""

--- a/tests/test_litellm/llms/bedrock/files/test_bedrock_files_transformation.py
+++ b/tests/test_litellm/llms/bedrock/files/test_bedrock_files_transformation.py
@@ -2512,3 +2512,284 @@ def test_sign_s3_get_request_assumes_role_with_external_id(monkeypatch):
 
     authorization = {key.lower(): value for key, value in signed_headers.items()}["authorization"]
     assert "ASIAFILESGETROLE" in authorization
+
+
+def test_sign_s3_delete_request_assumes_role_with_external_id(monkeypatch):
+    """A trust policy requiring sts:ExternalId must be satisfied when signing the S3 delete request."""
+    import datetime
+    from unittest.mock import patch
+
+    import boto3
+    from botocore.exceptions import ClientError
+
+    from litellm.llms.bedrock.files.transformation import (
+        BedrockFilesConfig,
+        _BedrockS3RequestParams,
+    )
+
+    monkeypatch.delenv("AWS_EXTERNAL_ID", raising=False)
+
+    class FakeSTSClient:
+        def get_caller_identity(self):
+            return {"Arn": "arn:aws:iam::111111111111:user/litellm-proxy-pod"}
+
+        def assume_role(self, **params):
+            if params.get("ExternalId") != "external-id-files-delete":
+                raise ClientError(
+                    {"Error": {"Code": "AccessDenied", "Message": "is not authorized to perform: sts:AssumeRole"}},
+                    "AssumeRole",
+                )
+            return {
+                "Credentials": {
+                    "AccessKeyId": "ASIAFILESDELETEROLE",
+                    "SecretAccessKey": "assumed-secret",
+                    "SessionToken": "assumed-session-token",
+                    "Expiration": datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(minutes=30),
+                }
+            }
+
+    request_params = _BedrockS3RequestParams.model_validate(
+        {
+            "aws_region_name": "us-east-1",
+            "aws_access_key_id": "AKIAFILESDELETECALLER",
+            "aws_secret_access_key": "pod-caller-secret",
+            "aws_role_name": "arn:aws:iam::999999999999:role/litellm-files-delete-role",
+            "aws_session_name": "litellm-files-delete-session",
+            "aws_external_id": "external-id-files-delete",
+        }
+    )
+    assert request_params.aws_external_id == "external-id-files-delete"
+
+    with patch.object(boto3, "client", return_value=FakeSTSClient()):
+        signed_headers = BedrockFilesConfig()._sign_s3_delete_request(
+            api_base="https://s3.us-east-1.amazonaws.com/safe-bucket/litellm-bedrock-files-model-id-abc.jsonl",
+            aws_region_name="us-east-1",
+            request_params=request_params,
+        )
+
+    authorization = {key.lower(): value for key, value in signed_headers.items()}["authorization"]
+    assert "ASIAFILESDELETEROLE" in authorization
+
+
+class TestBedrockFileDeletionTransformation:
+    """SigV4-signed S3 DeleteObject cleanup of Bedrock batch input/output files."""
+
+    S3_URI = "s3://my-bucket/litellm-bedrock-files/job-123/input.jsonl"
+    EXPECTED_URL = "https://s3.us-west-2.amazonaws.com/my-bucket/litellm-bedrock-files/job-123/input.jsonl"
+
+    def _litellm_params(self) -> dict:
+        return {
+            "aws_access_key_id": "AKIAEXAMPLE",
+            "aws_secret_access_key": "secret",
+            "aws_region_name": "us-west-2",
+        }
+
+    def test_transform_delete_file_request_signs_s3_delete(self, monkeypatch):
+        """The request transform must produce the S3 object URL plus SigV4 DELETE headers."""
+        import hashlib
+
+        from litellm.llms.bedrock.files.transformation import (
+            S3_SIGNED_GET_HEADERS_PARAM,
+            BedrockFilesConfig,
+        )
+
+        monkeypatch.setenv("AWS_S3_BUCKET_NAME", "my-bucket")
+        litellm_params = self._litellm_params()
+
+        url, params = BedrockFilesConfig().transform_delete_file_request(
+            file_id=self.S3_URI,
+            optional_params={},
+            litellm_params=litellm_params,
+        )
+
+        assert url == self.EXPECTED_URL
+        assert params == {}
+
+        signed_headers = litellm_params[S3_SIGNED_GET_HEADERS_PARAM]
+        content_hashes = {
+            value
+            for name, value in signed_headers.items()
+            if name.lower() == "x-amz-content-sha256"
+        }
+        assert content_hashes == {hashlib.sha256(b"").hexdigest()}
+        authorization = signed_headers["Authorization"]
+        assert authorization.startswith("AWS4-HMAC-SHA256 Credential=AKIAEXAMPLE/")
+        assert "/us-west-2/s3/aws4_request" in authorization
+        assert "x-amz-content-sha256" in authorization
+        assert "X-Amz-Date" in signed_headers
+        assert litellm_params["_deleted_file_id"] == self.S3_URI
+
+    def test_transform_delete_file_request_decodes_unified_file_id(self, monkeypatch):
+        """Base64 unified ids carrying llm_output_file_id must resolve to their S3 object for deletion."""
+        import base64
+
+        from litellm.llms.bedrock.files.transformation import BedrockFilesConfig
+        from litellm.types.utils import SpecialEnums
+
+        monkeypatch.setenv("AWS_S3_BUCKET_NAME", "my-bucket")
+        raw_unified_id = (
+            f"{SpecialEnums.LITELM_MANAGED_FILE_ID_PREFIX.value}:application/jsonl;"
+            f"unified_id,abc;target_model_names,model-1;llm_output_file_id,{self.S3_URI};expires_at,123"
+        )
+        b64_file_id = base64.urlsafe_b64encode(raw_unified_id.encode()).decode()
+
+        url, _ = BedrockFilesConfig().transform_delete_file_request(
+            file_id=b64_file_id,
+            optional_params={},
+            litellm_params=self._litellm_params(),
+        )
+        assert url == self.EXPECTED_URL
+
+    def test_transform_delete_file_request_rejects_foreign_bucket(self, monkeypatch):
+        from litellm.llms.bedrock.files.transformation import BedrockFilesConfig
+
+        monkeypatch.setenv("AWS_S3_BUCKET_NAME", "my-bucket")
+        with pytest.raises(ValueError, match="bucket does not match"):
+            BedrockFilesConfig().transform_delete_file_request(
+                file_id="s3://attacker-bucket/litellm-bedrock-files/secret.jsonl",
+                optional_params={},
+                litellm_params=self._litellm_params(),
+            )
+
+    def test_transform_delete_file_request_rejects_unmanaged_key(self, monkeypatch):
+        from litellm.llms.bedrock.files.transformation import BedrockFilesConfig
+
+        monkeypatch.setenv("AWS_S3_BUCKET_NAME", "my-bucket")
+        with pytest.raises(ValueError, match="must reference a LiteLLM-managed storage object"):
+            BedrockFilesConfig().transform_delete_file_request(
+                file_id="s3://my-bucket/unmanaged/secret.jsonl",
+                optional_params={},
+                litellm_params=self._litellm_params(),
+            )
+
+    def test_transform_delete_file_request_requires_configured_bucket(self, monkeypatch):
+        from litellm.llms.bedrock.files.transformation import BedrockFilesConfig
+
+        monkeypatch.delenv("AWS_S3_BUCKET_NAME", raising=False)
+        monkeypatch.delenv("AWS_S3_OUTPUT_BUCKET_NAME", raising=False)
+        with pytest.raises(ValueError, match="S3 bucket_name is required"):
+            BedrockFilesConfig().transform_delete_file_request(
+                file_id=self.S3_URI,
+                optional_params={},
+                litellm_params=self._litellm_params(),
+            )
+
+    def test_transform_delete_file_request_requires_file_id(self, monkeypatch):
+        from litellm.llms.bedrock.files.transformation import BedrockFilesConfig
+
+        monkeypatch.setenv("AWS_S3_BUCKET_NAME", "my-bucket")
+        with pytest.raises(ValueError, match="file_id is required"):
+            BedrockFilesConfig().transform_delete_file_request(
+                file_id="",
+                optional_params={},
+                litellm_params=self._litellm_params(),
+            )
+
+    def test_transform_delete_file_response_returns_file_deleted(self):
+        from unittest.mock import MagicMock
+
+        import httpx
+        from openai.types.file_deleted import FileDeleted
+
+        from litellm.llms.bedrock.files.transformation import BedrockFilesConfig
+
+        raw_response = httpx.Response(
+            status_code=204,
+            request=httpx.Request("DELETE", self.EXPECTED_URL),
+        )
+
+        result = BedrockFilesConfig().transform_delete_file_response(
+            raw_response=raw_response,
+            logging_obj=MagicMock(),
+            litellm_params={"_deleted_file_id": self.S3_URI},
+        )
+
+        assert isinstance(result, FileDeleted)
+        assert result.id == self.S3_URI
+        assert result.deleted is True
+        assert result.object == "file"
+
+    def test_transform_delete_file_response_raises_on_s3_error(self):
+        from unittest.mock import MagicMock
+
+        import httpx
+
+        from litellm.llms.bedrock.common_utils import BedrockError
+        from litellm.llms.bedrock.files.transformation import BedrockFilesConfig
+
+        raw_response = httpx.Response(
+            status_code=403,
+            content=b"<Error><Code>AccessDenied</Code></Error>",
+            request=httpx.Request("DELETE", self.EXPECTED_URL),
+        )
+
+        with pytest.raises(BedrockError, match="AccessDenied"):
+            BedrockFilesConfig().transform_delete_file_response(
+                raw_response=raw_response,
+                logging_obj=MagicMock(),
+                litellm_params={"_deleted_file_id": self.S3_URI},
+            )
+
+    def test_file_delete_end_to_end_sends_signed_delete(self, monkeypatch):
+        """litellm.file_delete must issue a SigV4-signed DELETE and return FileDeleted."""
+        import httpx
+        from openai.types.file_deleted import FileDeleted
+        import respx
+
+        import litellm
+
+        monkeypatch.setenv("AWS_S3_BUCKET_NAME", "my-bucket")
+
+        with respx.mock:
+            route = respx.delete(self.EXPECTED_URL).mock(
+                return_value=httpx.Response(204)
+            )
+
+            result = litellm.file_delete(
+                file_id=self.S3_URI,
+                custom_llm_provider="bedrock",
+                **self._litellm_params(),
+            )
+
+            assert route.called
+            sent_request = route.calls.last.request
+            assert sent_request.method == "DELETE"
+            assert "Authorization" in sent_request.headers
+            assert sent_request.headers["Authorization"].startswith("AWS4-HMAC-SHA256")
+            assert isinstance(result, FileDeleted)
+            assert result.id == self.S3_URI
+            assert result.deleted is True
+
+    @pytest.mark.asyncio
+    async def test_afile_delete_end_to_end_sends_signed_delete(self, monkeypatch):
+        """Async variant: litellm.afile_delete over the same signed DELETE path."""
+        import httpx
+        from openai.types.file_deleted import FileDeleted
+        import respx
+
+        import litellm
+
+        monkeypatch.setenv("AWS_S3_BUCKET_NAME", "my-bucket")
+        monkeypatch.setattr(litellm, "disable_aiohttp_transport", True)
+        litellm.in_memory_llm_clients_cache.flush_cache()
+
+        with respx.mock:
+            route = respx.delete(self.EXPECTED_URL).mock(
+                return_value=httpx.Response(204)
+            )
+
+            result = await litellm.afile_delete(
+                file_id=self.S3_URI,
+                custom_llm_provider="bedrock",
+                **self._litellm_params(),
+            )
+
+            assert route.called
+            sent_request = route.calls.last.request
+            assert sent_request.method == "DELETE"
+            assert "Authorization" in sent_request.headers
+            assert sent_request.headers["Authorization"].startswith("AWS4-HMAC-SHA256")
+            assert isinstance(result, FileDeleted)
+            assert result.id == self.S3_URI
+            assert result.deleted is True
+


### PR DESCRIPTION
## Overview

Fixes #39715.

When deleting Bedrock-backed batch files via `DELETE /v1/files/{file_id}`, LiteLLM previously raised `NotImplementedError("BedrockFilesConfig does not support file deletion")`, producing an HTTP 500 error and preventing cleanup of S3 batch input/output files.

## Root Cause

1. `BedrockFilesConfig.transform_delete_file_request` and `transform_delete_file_response` in `litellm/llms/bedrock/files/transformation.py` were stubs raising `NotImplementedError`.
2. In `_PROXY_LiteLLMManagedFiles.afile_delete` (`enterprise/litellm_enterprise/proxy/hooks/managed_files.py`), deployment credentials were not retrieved from `llm_router.get_deployment_credentials_with_provider` and attached as `_litellm_internal_model_credentials`, unlike `afile_content`. Consequently, downstream cloud-storage file validation could not verify the target file against the deployment's configured S3 bucket.

## Changes Made

1. **`litellm/llms/bedrock/files/transformation.py`**:
   - Implemented `transform_delete_file_request`: extracts and validates S3 URIs / unified file IDs against configured buckets (`_validate_file_id_against_configured_buckets`), constructs the canonical S3 object URL, and signs the request using SigV4 `DELETE`.
   - Implemented `transform_delete_file_response`: checks response status (HTTP 204 / 200) and returns an OpenAI-compatible `FileDeleted(id=..., deleted=True, object="file")` object, raising `BedrockError` on S3 errors.
   - Refactored `_sign_s3_empty_body_request`: shared helper for empty-body SigV4 signing across GET and DELETE methods.
   - Added `_sign_s3_delete_request`.

2. **`enterprise/litellm_enterprise/proxy/hooks/managed_files.py`**:
   - In `afile_delete`, retrieved deployment credentials via `llm_router.get_deployment_credentials_with_provider(model_id=model_id)` and attached `_litellm_internal_model_credentials` snapshot before invoking `llm_router.afile_delete`, mirroring the pattern in `afile_content`.

3. **`tests/test_litellm/llms/bedrock/files/test_bedrock_files_transformation.py`**:
   - Added `test_sign_s3_delete_request_assumes_role_with_external_id` verifying role assumption with external ID.
   - Added `TestBedrockFileDeletionTransformation` suite with 10 unit and integration tests covering signed DELETE requests, unified file ID resolution, bucket/key security validations, S3 error handling, and end-to-end sync (`file_delete`) and async (`afile_delete`) calls.

4. **`tests/test_litellm/enterprise/proxy/test_managed_files_hook.py`**:
   - Added `test_afile_delete_bedrock_unified_id_end_to_end` verifying proxy end-to-end deletion with deployment credentials.
   - Added `test_afile_delete_passes_trusted_model_credentials_to_router` verifying credentials snapshot injection.

## Verification & Tests

- Ran full pytest suite:
  - `tests/test_litellm/llms/bedrock/files/test_bedrock_files_transformation.py`: **99/99 tests passed cleanly** (0 failures).
  - `tests/test_litellm/enterprise/proxy/test_managed_files_hook.py`: **afile_delete tests passed cleanly**.
- Verified local lint clean with `ruff`.
