### PR TITLE
feat(providers): add AI Token King (aitokenking) OpenAI-compatible provider with pricing

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -933,7 +933,7 @@ openai_compatible_providers: Final[list] = [
     "docker_model_runner",
     "ragflow",
     "pinstripes",  # Pinstripes - JSON-configured provider
-    "aitokenking",  # AI Token King - JSON-configured provider
+    "aitokenking",
     "darkbloom",
     "meta",  # Meta Model API (Muse Spark) - JSON-configured provider
     "cognition",

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -848,6 +848,7 @@ openai_compatible_endpoints: Final[list] = [
     "https://serverless.tensormesh.ai/v1",
     "https://api.stima.tech/v1",
     "https://nano-gpt.com/api/v1",
+    "https://api.aitokenking.com.tw/api/v1",
     "https://api.poe.com/v1",
     "https://llm.chutes.ai/v1/",
     "https://api.v0.dev/v1",
@@ -932,6 +933,7 @@ openai_compatible_providers: Final[list] = [
     "docker_model_runner",
     "ragflow",
     "pinstripes",  # Pinstripes - JSON-configured provider
+    "aitokenking",  # AI Token King - JSON-configured provider
     "darkbloom",
     "meta",  # Meta Model API (Muse Spark) - JSON-configured provider
     "cognition",

--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -200,5 +200,16 @@
       "temperature_max": 1.99
     },
     "supported_endpoints": ["/v1/chat/completions"]
+  },
+  "aitokenking": {
+    "base_url": "https://api.aitokenking.com.tw/api/v1",
+    "api_key_env": "AITOKENKING_API_KEY",
+    "api_base_env": "AITOKENKING_API_BASE",
+    "param_mappings": {
+      "max_completion_tokens": "max_tokens"
+    },
+    "supported_endpoints": [
+      "/v1/chat/completions"
+    ]
   }
 }

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -58456,5 +58456,389 @@
         "supported_endpoints": [
             "/v1/audio/transcriptions"
         ]
+    },
+    "aitokenking/claude-fable-5": {
+        "input_cost_per_token": 1e-05,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 5e-05,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/claude-opus-4.6": {
+        "input_cost_per_token": 5e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-05,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/claude-opus-4.7": {
+        "input_cost_per_token": 5e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-05,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/claude-opus-4.8": {
+        "input_cost_per_token": 5e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-05,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/claude-opus-5": {
+        "input_cost_per_token": 5e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-05,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/claude-sonnet-4.6": {
+        "input_cost_per_token": 3e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-05,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/claude-sonnet-5": {
+        "input_cost_per_token": 2e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 1e-05,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/deepseek-v3.2": {
+        "input_cost_per_token": 5.699999999999999e-07,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 1.71e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/deepseek-v4-flash": {
+        "input_cost_per_token": 1.4e-07,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 2.8e-07,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/deepseek-v4-pro": {
+        "input_cost_per_token": 1.74e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 3.48e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/dola-seed-2-0-mini": {
+        "input_cost_per_token": 2.0000000000000002e-07,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 8.000000000000001e-07,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/dola-seed-2-0-mini-white": {
+        "input_cost_per_token": 2.0000000000000002e-07,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 8.000000000000001e-07,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/dola-seed-2-1-turbo": {
+        "input_cost_per_token": 5e-07,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/dola-seed-2.0-code": {
+        "input_cost_per_token": 5e-07,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 3e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/dola-seed-2.0-lite": {
+        "input_cost_per_token": 5e-07,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 4e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/dola-seed-2.0-pro": {
+        "input_cost_per_token": 1e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 6e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/gemini-3-flash-preview": {
+        "input_cost_per_token": 5e-07,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1048576,
+        "mode": "chat",
+        "output_cost_per_token": 3e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/gemini-3.1-pro-preview": {
+        "input_cost_per_token": 4e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1048576,
+        "mode": "chat",
+        "output_cost_per_token": 1.8e-05,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/glm-5": {
+        "input_cost_per_token": 1e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 200000,
+        "mode": "chat",
+        "output_cost_per_token": 3.2000000000000003e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/glm-5-turbo": {
+        "input_cost_per_token": 1.2e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 200000,
+        "mode": "chat",
+        "output_cost_per_token": 4e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/glm-5.1": {
+        "input_cost_per_token": 1.4e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 200000,
+        "mode": "chat",
+        "output_cost_per_token": 4.4e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/glm-5.2": {
+        "input_cost_per_token": 1.4e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 4.4e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/glm-5.3": {
+        "input_cost_per_token": 1.4e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1048576,
+        "mode": "chat",
+        "output_cost_per_token": 4.4e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/glm-5v-turbo": {
+        "input_cost_per_token": 1.2e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 200000,
+        "mode": "chat",
+        "output_cost_per_token": 4e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/gpt-5-nano": {
+        "input_cost_per_token": 5.0000000000000004e-08,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 400000,
+        "mode": "chat",
+        "output_cost_per_token": 4.0000000000000003e-07,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/gpt-5.4": {
+        "input_cost_per_token": 5e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1050000,
+        "mode": "chat",
+        "output_cost_per_token": 2.25e-05,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/gpt-5.5": {
+        "input_cost_per_token": 5e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1050000,
+        "mode": "chat",
+        "output_cost_per_token": 3e-05,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/gpt-5.6-luna": {
+        "input_cost_per_token": 2e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1050000,
+        "mode": "chat",
+        "output_cost_per_token": 9e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/gpt-5.6-sol": {
+        "input_cost_per_token": 1e-05,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1050000,
+        "mode": "chat",
+        "output_cost_per_token": 4.5e-05,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/gpt-5.6-terra": {
+        "input_cost_per_token": 5e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1050000,
+        "mode": "chat",
+        "output_cost_per_token": 2.25e-05,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/kimi-k2.5": {
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 256000,
+        "mode": "chat",
+        "output_cost_per_token": 3e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/kimi-k2.6": {
+        "input_cost_per_token": 8.58e-07,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 256000,
+        "mode": "chat",
+        "output_cost_per_token": 3.566e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/kimi-k2.7-code": {
+        "input_cost_per_token": 9.499999999999999e-07,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 256000,
+        "mode": "chat",
+        "output_cost_per_token": 4e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/kimi-k2.7-code-highspeed": {
+        "input_cost_per_token": 1.8999999999999998e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 256000,
+        "mode": "chat",
+        "output_cost_per_token": 8e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/kimi-k3": {
+        "input_cost_per_token": 3e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-05,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/minimax-m2.5": {
+        "input_cost_per_token": 3e-07,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 200000,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/minimax-m2.7": {
+        "input_cost_per_token": 3e-07,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 200000,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/minimax-m3": {
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 2.4e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/qwen3-max": {
+        "input_cost_per_token": 1.2e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 256000,
+        "mode": "chat",
+        "output_cost_per_token": 6e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/qwen3-max-white": {
+        "input_cost_per_token": 2.4e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 256000,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-05,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/qwen3-vl-flash": {
+        "input_cost_per_token": 7.5e-08,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 256000,
+        "mode": "chat",
+        "output_cost_per_token": 6e-07,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/qwen3-vl-plus": {
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 256000,
+        "mode": "chat",
+        "output_cost_per_token": 4.8e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/qwen3.5-plus": {
+        "input_cost_per_token": 5e-07,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 3e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/qwen3.5-plus-white": {
+        "input_cost_per_token": 4.0000000000000003e-07,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 2.4e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/qwen3.6-plus": {
+        "input_cost_per_token": 5e-07,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 3e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/qwen3.7-max": {
+        "input_cost_per_token": 2.5e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 7.5e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/qwen3.7-plus": {
+        "input_cost_per_token": 4.0000000000000003e-07,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 1.6000000000000001e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/qwen3.8-max": {
+        "input_cost_per_token": 2e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 6e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
     }
 }

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3906,6 +3906,7 @@ class LlmProviders(str, Enum):
     TENSORMESH = "tensormesh"
     LIBERTAI = "libertai"
     PINSTRIPES = "pinstripes"
+    AITOKENKING = "aitokenking"
     COGNITION = "cognition"
     SCX_AI = "scx-ai"
     DARKBLOOM = "darkbloom"

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -58456,5 +58456,389 @@
         "supported_endpoints": [
             "/v1/audio/transcriptions"
         ]
+    },
+    "aitokenking/claude-fable-5": {
+        "input_cost_per_token": 1e-05,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 5e-05,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/claude-opus-4.6": {
+        "input_cost_per_token": 5e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-05,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/claude-opus-4.7": {
+        "input_cost_per_token": 5e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-05,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/claude-opus-4.8": {
+        "input_cost_per_token": 5e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-05,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/claude-opus-5": {
+        "input_cost_per_token": 5e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-05,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/claude-sonnet-4.6": {
+        "input_cost_per_token": 3e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-05,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/claude-sonnet-5": {
+        "input_cost_per_token": 2e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 1e-05,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/deepseek-v3.2": {
+        "input_cost_per_token": 5.699999999999999e-07,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 1.71e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/deepseek-v4-flash": {
+        "input_cost_per_token": 1.4e-07,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 2.8e-07,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/deepseek-v4-pro": {
+        "input_cost_per_token": 1.74e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 3.48e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/dola-seed-2-0-mini": {
+        "input_cost_per_token": 2.0000000000000002e-07,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 8.000000000000001e-07,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/dola-seed-2-0-mini-white": {
+        "input_cost_per_token": 2.0000000000000002e-07,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 8.000000000000001e-07,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/dola-seed-2-1-turbo": {
+        "input_cost_per_token": 5e-07,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/dola-seed-2.0-code": {
+        "input_cost_per_token": 5e-07,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 3e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/dola-seed-2.0-lite": {
+        "input_cost_per_token": 5e-07,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 4e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/dola-seed-2.0-pro": {
+        "input_cost_per_token": 1e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 6e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/gemini-3-flash-preview": {
+        "input_cost_per_token": 5e-07,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1048576,
+        "mode": "chat",
+        "output_cost_per_token": 3e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/gemini-3.1-pro-preview": {
+        "input_cost_per_token": 4e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1048576,
+        "mode": "chat",
+        "output_cost_per_token": 1.8e-05,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/glm-5": {
+        "input_cost_per_token": 1e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 200000,
+        "mode": "chat",
+        "output_cost_per_token": 3.2000000000000003e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/glm-5-turbo": {
+        "input_cost_per_token": 1.2e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 200000,
+        "mode": "chat",
+        "output_cost_per_token": 4e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/glm-5.1": {
+        "input_cost_per_token": 1.4e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 200000,
+        "mode": "chat",
+        "output_cost_per_token": 4.4e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/glm-5.2": {
+        "input_cost_per_token": 1.4e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 4.4e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/glm-5.3": {
+        "input_cost_per_token": 1.4e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1048576,
+        "mode": "chat",
+        "output_cost_per_token": 4.4e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/glm-5v-turbo": {
+        "input_cost_per_token": 1.2e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 200000,
+        "mode": "chat",
+        "output_cost_per_token": 4e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/gpt-5-nano": {
+        "input_cost_per_token": 5.0000000000000004e-08,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 400000,
+        "mode": "chat",
+        "output_cost_per_token": 4.0000000000000003e-07,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/gpt-5.4": {
+        "input_cost_per_token": 5e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1050000,
+        "mode": "chat",
+        "output_cost_per_token": 2.25e-05,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/gpt-5.5": {
+        "input_cost_per_token": 5e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1050000,
+        "mode": "chat",
+        "output_cost_per_token": 3e-05,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/gpt-5.6-luna": {
+        "input_cost_per_token": 2e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1050000,
+        "mode": "chat",
+        "output_cost_per_token": 9e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/gpt-5.6-sol": {
+        "input_cost_per_token": 1e-05,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1050000,
+        "mode": "chat",
+        "output_cost_per_token": 4.5e-05,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/gpt-5.6-terra": {
+        "input_cost_per_token": 5e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1050000,
+        "mode": "chat",
+        "output_cost_per_token": 2.25e-05,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/kimi-k2.5": {
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 256000,
+        "mode": "chat",
+        "output_cost_per_token": 3e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/kimi-k2.6": {
+        "input_cost_per_token": 8.58e-07,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 256000,
+        "mode": "chat",
+        "output_cost_per_token": 3.566e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/kimi-k2.7-code": {
+        "input_cost_per_token": 9.499999999999999e-07,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 256000,
+        "mode": "chat",
+        "output_cost_per_token": 4e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/kimi-k2.7-code-highspeed": {
+        "input_cost_per_token": 1.8999999999999998e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 256000,
+        "mode": "chat",
+        "output_cost_per_token": 8e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/kimi-k3": {
+        "input_cost_per_token": 3e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-05,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/minimax-m2.5": {
+        "input_cost_per_token": 3e-07,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 200000,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/minimax-m2.7": {
+        "input_cost_per_token": 3e-07,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 200000,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/minimax-m3": {
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 2.4e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/qwen3-max": {
+        "input_cost_per_token": 1.2e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 256000,
+        "mode": "chat",
+        "output_cost_per_token": 6e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/qwen3-max-white": {
+        "input_cost_per_token": 2.4e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 256000,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-05,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/qwen3-vl-flash": {
+        "input_cost_per_token": 7.5e-08,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 256000,
+        "mode": "chat",
+        "output_cost_per_token": 6e-07,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/qwen3-vl-plus": {
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 256000,
+        "mode": "chat",
+        "output_cost_per_token": 4.8e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/qwen3.5-plus": {
+        "input_cost_per_token": 5e-07,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 3e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/qwen3.5-plus-white": {
+        "input_cost_per_token": 4.0000000000000003e-07,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 2.4e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/qwen3.6-plus": {
+        "input_cost_per_token": 5e-07,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 3e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/qwen3.7-max": {
+        "input_cost_per_token": 2.5e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 7.5e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/qwen3.7-plus": {
+        "input_cost_per_token": 4.0000000000000003e-07,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 1.6000000000000001e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
+    },
+    "aitokenking/qwen3.8-max": {
+        "input_cost_per_token": 2e-06,
+        "litellm_provider": "aitokenking",
+        "max_input_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 6e-06,
+        "source": "https://www.aitokenking.com.tw/assets/docs/zh/index.html"
     }
 }

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -3026,6 +3026,23 @@
         "rerank": false,
         "a2a": false
       }
+    },
+    "aitokenking": {
+      "display_name": "AI Token King (`aitokenking`)",
+      "url": "https://docs.litellm.ai/docs/providers/aitokenking",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": false,
+        "responses": false,
+        "embeddings": false,
+        "image_generations": false,
+        "audio_transcriptions": false,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "a2a": false
+      }
     }
   },
   "endpoints": {

--- a/tests/test_litellm/llms/openai_like/test_aitokenking_provider.py
+++ b/tests/test_litellm/llms/openai_like/test_aitokenking_provider.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 
 import litellm
+import pytest
 
 BASE_URL = "https://api.aitokenking.com.tw/api/v1"
 
@@ -80,24 +81,6 @@ class TestAITokenKingProviderConfig:
         assert provider == "aitokenking"
         assert api_base == BASE_URL
 
-    def test_aitokenking_router_config(self):
-        from litellm import Router
-
-        router = Router(
-            model_list=[
-                {
-                    "model_name": "atk-chat",
-                    "litellm_params": {
-                        "model": "aitokenking/qwen3.7-max",
-                        "api_key": "test-key",
-                    },
-                }
-            ]
-        )
-
-        assert len(router.model_list) == 1
-        assert router.model_list[0]["model_name"] == "atk-chat"
-
 
 class TestAITokenKingPricing:
     """Cost tracking is the point of shipping the price map with the provider."""
@@ -166,3 +149,57 @@ class TestAITokenKingPricing:
         cost = litellm.completion_cost(completion_response=response, model=model)
         assert abs(cost - expected) < 1e-9
         assert cost > 0
+
+class TestAITokenKingRouting:
+    """Exercises the dispatch path, not just the stored configuration."""
+
+    @staticmethod
+    def _router():
+        from litellm import Router
+
+        return Router(
+            model_list=[
+                {
+                    "model_name": "atk-chat",
+                    "litellm_params": {
+                        "model": "aitokenking/qwen3.7-max",
+                        "api_key": "sk-test",
+                    },
+                }
+            ]
+        )
+
+    @pytest.mark.asyncio
+    async def test_routed_request_targets_the_gateway_with_the_prefix_stripped(self):
+        """The prefix selects the provider; it must not reach the wire."""
+        response = await self._router().acompletion(
+            model="atk-chat",
+            messages=[{"role": "user", "content": "hi"}],
+            mock_response="ok",
+        )
+
+        assert response._hidden_params["api_base"] == BASE_URL
+        assert response.model == "qwen3.7-max"
+
+    @pytest.mark.asyncio
+    async def test_routed_spend_is_costed_off_the_aitokenking_entry(self):
+        """Router registers every deployment, so an unmapped model silently costs 0.0.
+
+        This is the regression the price map exists to prevent: assert the routed
+        response is costed from the aitokenking entry rather than defaulting to zero.
+        """
+        entry = TestAITokenKingPricing._load_price_map()["aitokenking/qwen3.7-max"]
+
+        response = await self._router().acompletion(
+            model="atk-chat",
+            messages=[{"role": "user", "content": "hi"}],
+            mock_response="ok",
+        )
+
+        usage = response.usage
+        expected = (
+            usage.prompt_tokens * entry["input_cost_per_token"]
+            + usage.completion_tokens * entry["output_cost_per_token"]
+        )
+        assert response._hidden_params["response_cost"] == pytest.approx(expected)
+        assert response._hidden_params["response_cost"] > 0

--- a/tests/test_litellm/llms/openai_like/test_aitokenking_provider.py
+++ b/tests/test_litellm/llms/openai_like/test_aitokenking_provider.py
@@ -1,0 +1,168 @@
+"""
+Tests for the AI Token King provider (JSON-configured, OpenAI-compatible gateway).
+"""
+
+import json
+from pathlib import Path
+
+import litellm
+
+BASE_URL = "https://api.aitokenking.com.tw/api/v1"
+
+
+class TestAITokenKingProviderConfig:
+    """AI Token King provider configuration and resolution."""
+
+    def test_aitokenking_in_provider_list(self):
+        from litellm import LlmProviders
+
+        assert hasattr(LlmProviders, "AITOKENKING")
+        assert LlmProviders.AITOKENKING.value == "aitokenking"
+        assert "aitokenking" in litellm.provider_list
+
+    def test_aitokenking_json_config_exists(self):
+        from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+
+        assert JSONProviderRegistry.exists("aitokenking")
+
+        cfg = JSONProviderRegistry.get("aitokenking")
+        assert cfg is not None
+        assert cfg.base_url == BASE_URL
+        assert cfg.api_key_env == "AITOKENKING_API_KEY"
+        assert cfg.api_base_env == "AITOKENKING_API_BASE"
+        assert cfg.param_mappings.get("max_completion_tokens") == "max_tokens"
+        assert cfg.supported_endpoints == ["/v1/chat/completions"]
+
+    def test_aitokenking_in_openai_compatible_providers(self):
+        from litellm.constants import openai_compatible_endpoints, openai_compatible_providers
+
+        assert "aitokenking" in openai_compatible_providers
+        assert BASE_URL in openai_compatible_endpoints
+
+    def test_aitokenking_provider_resolution(self):
+        from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+
+        model, provider, api_key, api_base = get_llm_provider(
+            model="aitokenking/qwen3.7-max",
+            custom_llm_provider=None,
+            api_base=None,
+            api_key=None,
+        )
+
+        assert model == "qwen3.7-max"
+        assert provider == "aitokenking"
+        assert api_base == BASE_URL
+
+    def test_aitokenking_api_base_override(self):
+        from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+
+        model, provider, api_key, api_base = get_llm_provider(
+            model="aitokenking/qwen3.7-max",
+            custom_llm_provider=None,
+            api_base="https://custom.example.com/v1",
+            api_key="sk-test",
+        )
+
+        assert provider == "aitokenking"
+        assert api_base == "https://custom.example.com/v1"
+        assert api_key == "sk-test"
+
+    def test_aitokenking_url_autodetection(self):
+        """Passing the gateway's api_base without a prefix resolves the provider."""
+        from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+
+        model, provider, api_key, api_base = get_llm_provider(
+            model="qwen3.7-max",
+            custom_llm_provider=None,
+            api_base=BASE_URL,
+            api_key=None,
+        )
+        assert provider == "aitokenking"
+        assert api_base == BASE_URL
+
+    def test_aitokenking_router_config(self):
+        from litellm import Router
+
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "atk-chat",
+                    "litellm_params": {
+                        "model": "aitokenking/qwen3.7-max",
+                        "api_key": "test-key",
+                    },
+                }
+            ]
+        )
+
+        assert len(router.model_list) == 1
+        assert router.model_list[0]["model_name"] == "atk-chat"
+
+
+class TestAITokenKingPricing:
+    """Cost tracking is the point of shipping the price map with the provider."""
+
+    @staticmethod
+    def _load_price_map() -> dict:
+        json_path = Path(__file__).parents[4] / "model_prices_and_context_window.json"
+        with open(json_path) as f:
+            return json.load(f)
+
+    def test_price_map_entries_use_provider_prefix(self):
+        model_cost = self._load_price_map()
+        keys = [k for k in model_cost if k.startswith("aitokenking/")]
+        assert len(keys) == 48
+        for k in keys:
+            entry = model_cost[k]
+            assert entry["litellm_provider"] == "aitokenking"
+            assert entry["mode"] == "chat"
+            # A zero price would read as "free" rather than "unknown"; never ship one.
+            assert entry["input_cost_per_token"] > 0
+            assert entry["output_cost_per_token"] > 0
+
+    def test_prefixed_keys_do_not_shadow_upstream_vendor_entries(self):
+        """Some gateway model ids match vendor ids already in the map (e.g. gpt-5.5).
+
+        The gateway resells at its own price, so the entry must live under the
+        provider prefix only — a bare-id entry would overwrite the vendor's price
+        for everyone.
+        """
+        model_cost = self._load_price_map()
+        for bare in ("gpt-5.5", "claude-sonnet-5", "gemini-3.1-pro-preview"):
+            assert f"aitokenking/{bare}" in model_cost
+            assert model_cost[bare]["litellm_provider"] != "aitokenking"
+
+    def test_completion_cost_resolves_for_prefixed_model(self, monkeypatch):
+        from litellm.types.utils import ModelResponse
+
+        model = "aitokenking/qwen3.7-max"
+        entry = self._load_price_map()[model]
+        monkeypatch.setitem(litellm.model_cost, model, entry)
+
+        prompt_tokens, completion_tokens = 100_000, 100_000
+        expected = entry["input_cost_per_token"] * prompt_tokens + entry["output_cost_per_token"] * completion_tokens
+
+        response = ModelResponse(
+            **{
+                "id": "chatcmpl-test",
+                "object": "chat.completion",
+                "created": 0,
+                "model": model,
+                "choices": [
+                    {
+                        "index": 0,
+                        "finish_reason": "stop",
+                        "message": {"role": "assistant", "content": "ok"},
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": prompt_tokens,
+                    "completion_tokens": completion_tokens,
+                    "total_tokens": prompt_tokens + completion_tokens,
+                },
+            }
+        )
+
+        cost = litellm.completion_cost(completion_response=response, model=model)
+        assert abs(cost - expected) < 1e-9
+        assert cost > 0


### PR DESCRIPTION
## TLDR

Problem this solves:

- AI Token King gateway users get `response_cost = 0.0` from Router (unmapped models)
- Only workaround (`openai/<model>` pricing) overwrites 13 real vendor price entries

How it solves it:

- Register `aitokenking` as a JSON-configured OpenAI-compatible provider
- Ship 48 chat-model prices under `aitokenking/*`, no vendor entry touched

## User Flow

Before: a developer routing through the gateway sees zero spend on every call

1. They configure a Router deployment with `model: openai/qwen3.7-max`, `api_base: https://api.aitokenking.com.tw/api/v1` and their gateway key
2. They call `router.completion(...)`; the response comes back fine with real token usage
3. `response_cost` is `0.0`, so their spend dashboard shows $0 even though the gateway billed them
4. If they try `model: aitokenking/qwen3.7-max` instead, LiteLLM rejects it with `LLM Provider NOT provided`

After: the same developer gets real spend with a one-line model string

1. They configure the deployment with `model: aitokenking/qwen3.7-max` and their gateway key; no `api_base` needed
2. The request goes to `https://api.aitokenking.com.tw/api/v1/chat/completions` with the `aitokenking/` prefix stripped and the key in `Authorization`
3. `response_cost` is computed from `aitokenking/qwen3.7-max` in the price map (100k in + 100k out → $1.00)
4. Prices for `gpt-5.5`, `claude-sonnet-5` etc. used elsewhere in the same process are unchanged

## Relevant issues

None filed; this PR is the report.

## Notes for reviewers

- Follows the JSON provider path (`litellm/llms/openai_like/README.md`): no Python logic added. URL autodetection reuses the existing `JSONProviderRegistry.get_by_base_url` fallback.
- Price entries carry only what the gateway publishes (input/output per-token cost, `max_input_tokens`, `source`). `max_output_tokens`, cache tiers and capability flags are omitted on purpose rather than guessed. The gateway's 61 image/video models are excluded because it publishes no per-token price for them; an entry with cost 0 would read as "free".
- Prices measured 2026-08-23 from the gateway's read-only `/models` endpoint; unit (USD per 1M tokens) cross-checked against Anthropic's public list prices for two models.
- Disclosure: I operate this gateway. The change is scoped to the provider namespace and does not alter any other provider's behaviour or pricing.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The test files covering my change pass locally: `tests/test_litellm/llms/openai_like/test_aitokenking_provider.py` (10 passed), `tests/test_litellm/llms/openai_like/test_pinstripes_provider.py`, `tests/test_litellm/test_model_prices_schema.py` (38 passed total); `tests/code_coverage_tests/check_provider_folders_documented.py` passes
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x ] I have received a Greptile Confidence Score of at least 4/5

## Screenshots / Proof of Fix

Verified against the live gateway (see the comment below): `aitokenking/gpt-5-nano` returns `response_cost = 5.05e-06`, matching the price-map entry digit for digit. The mock-server runs kept below show the before/after on a fixed 100k/100k usage so the delta is readable without a live key.

Shared setup: a local mock at `http://127.0.0.1:<port>/v1` that answers `/chat/completions` with `usage: {prompt_tokens: 100000, completion_tokens: 100000}`; `LITELLM_LOCAL_MODEL_COST_MAP=True` so the price map is read from the checkout.

### Before (4990f06)

1. `litellm.completion(model="aitokenking/qwen3.7-max", api_base=<mock>, api_key="test")`
   → `BadRequestError: LLM Provider NOT provided`
2. `Router(model_list=[{model: "openai/qwen3.7-max", api_base: <mock>}]).completion(...)` (today's workaround)
   → `200`, `response_cost = 0.0`
3. `Router(model_list=[{model: "aitokenking/qwen3.7-max", api_base: <mock>}]).completion(...)`
   → `BadRequestError: LLM Provider NOT provided`

### After (cc5c94f)

1. `litellm.completion(model="aitokenking/qwen3.7-max", api_base=<mock>, api_key="test")`
   → `200`, model sent to gateway: `qwen3.7-max`, `response_cost = 1.0`
2. `Router(model_list=[{model: "openai/qwen3.7-max", api_base: <mock>}]).completion(...)` (unchanged, still the old behaviour)
   → `200`, `response_cost = 0.0`
3. `Router(model_list=[{model: "aitokenking/qwen3.7-max", api_base: <mock>}]).completion(...)`
   → `200`, model sent to gateway: `qwen3.7-max`, `response_cost = 1.0` (100k in + 100k out @ $2.5/$7.5 per 1M)

## Type

🆕 New Feature

## Caveats (if any)

### Low

- Only `/v1/chat/completions` is declared; the gateway's other endpoints are not claimed until verified
- Docs page `docs/providers/aitokenking` referenced in `provider_endpoints_support.json` still needs to be added in the docs repo
- Prices are a snapshot (2026-08-23); the gateway's `/models` endpoint is the source to refresh from

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
