### PR TITLE
fix(azure): add service_tier to AzureOpenAIConfig supported params (#39719)

### DIFF
--- a/litellm/llms/azure/chat/gpt_transformation.py
+++ b/litellm/llms/azure/chat/gpt_transformation.py
@@ -130,6 +130,7 @@ class AzureOpenAIConfig(BaseConfig):
             "web_search_options",
             "prompt_cache_key",
             "store",
+            "service_tier",
         ]
 
     @classmethod

--- a/tests/test_litellm/llms/azure/chat/test_azure_chat_gpt_transformation.py
+++ b/tests/test_litellm/llms/azure/chat/test_azure_chat_gpt_transformation.py
@@ -52,6 +52,28 @@ class TestAzureOpenAIConfig:
         supported_params = config.get_supported_openai_params("gpt-4.1")
         assert "prompt_cache_key" in supported_params
 
+    def test_service_tier_supported(self):
+        """Test that 'service_tier' is in supported params for Azure OpenAI models and preserved with drop_params=True."""
+        config: Final = AzureOpenAIConfig()
+        supported_params: Final = config.get_supported_openai_params("gpt-4.1")
+        assert "service_tier" in supported_params
+
+        mapped: Final = config.map_openai_params(
+            non_default_params={"service_tier": "priority"},
+            optional_params={},
+            model="azure/gpt-4.1",
+            drop_params=True,
+        )
+        assert mapped.get("service_tier") == "priority"
+
+        opt: Final = get_optional_params(
+            model="azure/gpt-4o",
+            custom_llm_provider="azure",
+            service_tier="priority",
+            drop_params=True,
+        )
+        assert opt.get("service_tier") == "priority"
+
 
 def test_map_openai_params_with_preview_api_version():
     config = AzureOpenAIConfig()


### PR DESCRIPTION
## Summary

Fixes #39719

Adds `service_tier` to `AzureOpenAIConfig.get_supported_openai_params` so requests targeting Azure OpenAI models in the gpt-4.1 and gpt-4o families do not silently drop `service_tier` when `drop_params=True` is configured.

## Background & Problem

When `drop_params=True` is enabled on the proxy or client, `get_optional_params` and `map_openai_params` filter incoming parameters against the provider config's `get_supported_openai_params()`. 

While OpenAI's base `OpenAIGPTConfig` and `AzureOpenAIGPT5Config` include `service_tier`, `AzureOpenAIConfig` omitted it. As a result, valid parameters like `service_tier: "priority"` or `"flex"` were silently stripped before forwarding to Azure OpenAI for gpt-4.1/gpt-4o deployments.

## Changes

- Added `"service_tier"` to `AzureOpenAIConfig.get_supported_openai_params`.
- Added unit tests in `tests/test_litellm/llms/azure/chat/test_azure_chat_gpt_transformation.py` verifying `service_tier` presence in supported params and asserting that both `map_openai_params` and `get_optional_params` retain `service_tier` when `drop_params=True`.

## Test Plan

- Ran `pytest tests/test_litellm/llms/azure/chat/test_azure_chat_gpt_transformation.py` (21/21 passed).
- Verified type discipline and ruff formatting checks pass.
