### PR TITLE
feat(sendgrid): support an optional SENDGRID_REPLY_TO_EMAIL on outbound emails

### DIFF
--- a/enterprise/litellm_enterprise/enterprise_callbacks/send_emails/sendgrid_email.py
+++ b/enterprise/litellm_enterprise/enterprise_callbacks/send_emails/sendgrid_email.py
@@ -5,7 +5,7 @@ Docs: https://docs.sendgrid.com/api-reference/mail-send/mail-send
 """
 
 import os
-from typing import List
+from typing import Final, List
 
 from litellm._logging import verbose_logger
 from litellm.llms.custom_httpx.http_handler import (
@@ -25,6 +25,12 @@ class SendGridEmailLogger(BaseEmailLogger):
 
     Required env vars:
     - SENDGRID_API_KEY
+
+    Optional env vars:
+    - SENDGRID_SENDER_EMAIL: Override the sender address. When unset, falls back to
+      the `from_email` argument passed by the caller.
+    - SENDGRID_REPLY_TO_EMAIL: Address recipients reply to. When unset, SendGrid
+      defaults Reply-To to the sender address.
     """
 
     def __init__(self, internal_usage_cache=None, **kwargs):
@@ -34,6 +40,7 @@ class SendGridEmailLogger(BaseEmailLogger):
         )
         self.sendgrid_api_key = os.getenv("SENDGRID_API_KEY")
         self.sendgrid_sender_email = os.getenv("SENDGRID_SENDER_EMAIL")
+        self.sendgrid_reply_to_email = os.getenv("SENDGRID_REPLY_TO_EMAIL")
         verbose_logger.debug("SendGrid Email Logger initialized.")
 
     async def send_email(
@@ -54,8 +61,15 @@ class SendGridEmailLogger(BaseEmailLogger):
             f"Sending email via SendGrid from {sender_email} to {to_email} with subject {subject}"
         )
 
+        reply_to: Final = (
+            {"reply_to": {"email": self.sendgrid_reply_to_email}}
+            if self.sendgrid_reply_to_email
+            else {}
+        )
+
         payload = {
             "from": {"email": sender_email},
+            **reply_to,
             "personalizations": [
                 {
                     "to": [{"email": email} for email in to_email],

--- a/tests/test_litellm/enterprise/enterprise_callbacks/send_emails/test_sendgrid_email.py
+++ b/tests/test_litellm/enterprise/enterprise_callbacks/send_emails/test_sendgrid_email.py
@@ -137,7 +137,6 @@ async def test_send_email_multiple_recipients(mock_env_vars, mock_async_client):
 
 @pytest.mark.asyncio
 async def test_send_email_sets_reply_to_when_configured(monkeypatch, mock_async_client):
-    """SENDGRID_REPLY_TO_EMAIL is sent as the payload's reply_to and leaves from alone."""
     monkeypatch.setenv("SENDGRID_API_KEY", "test_api_key")
     monkeypatch.delenv("SENDGRID_SENDER_EMAIL", raising=False)
     monkeypatch.setenv("SENDGRID_REPLY_TO_EMAIL", "litellm-alerts@example.com")
@@ -159,8 +158,6 @@ async def test_send_email_sets_reply_to_when_configured(monkeypatch, mock_async_
 
 @pytest.mark.asyncio
 async def test_send_email_omits_reply_to_when_not_configured(monkeypatch, mock_async_client):
-    """With SENDGRID_REPLY_TO_EMAIL unset the key is absent, not null, so SendGrid
-    keeps defaulting Reply-To to the sender."""
     monkeypatch.setenv("SENDGRID_API_KEY", "test_api_key")
     monkeypatch.delenv("SENDGRID_REPLY_TO_EMAIL", raising=False)
 

--- a/tests/test_litellm/enterprise/enterprise_callbacks/send_emails/test_sendgrid_email.py
+++ b/tests/test_litellm/enterprise/enterprise_callbacks/send_emails/test_sendgrid_email.py
@@ -133,3 +133,46 @@ async def test_send_email_multiple_recipients(mock_env_vars, mock_async_client):
         {"email": "recipient1@example.com"},
         {"email": "recipient2@example.com"},
     ]
+
+
+@pytest.mark.asyncio
+async def test_send_email_sets_reply_to_when_configured(monkeypatch, mock_async_client):
+    """SENDGRID_REPLY_TO_EMAIL is sent as the payload's reply_to and leaves from alone."""
+    monkeypatch.setenv("SENDGRID_API_KEY", "test_api_key")
+    monkeypatch.delenv("SENDGRID_SENDER_EMAIL", raising=False)
+    monkeypatch.setenv("SENDGRID_REPLY_TO_EMAIL", "litellm-alerts@example.com")
+
+    logger = SendGridEmailLogger()
+    logger.async_httpx_client = mock_async_client
+
+    await logger.send_email(
+        from_email="no-reply@example.com",
+        to_email=["recipient@example.com"],
+        subject="Test Subject",
+        html_body="<p>Test email body</p>",
+    )
+
+    payload = mock_async_client.post.call_args[1]["json"]
+    assert payload["reply_to"] == {"email": "litellm-alerts@example.com"}
+    assert payload["from"] == {"email": "no-reply@example.com"}
+
+
+@pytest.mark.asyncio
+async def test_send_email_omits_reply_to_when_not_configured(monkeypatch, mock_async_client):
+    """With SENDGRID_REPLY_TO_EMAIL unset the key is absent, not null, so SendGrid
+    keeps defaulting Reply-To to the sender."""
+    monkeypatch.setenv("SENDGRID_API_KEY", "test_api_key")
+    monkeypatch.delenv("SENDGRID_REPLY_TO_EMAIL", raising=False)
+
+    logger = SendGridEmailLogger()
+    logger.async_httpx_client = mock_async_client
+
+    await logger.send_email(
+        from_email="no-reply@example.com",
+        to_email=["recipient@example.com"],
+        subject="Test Subject",
+        html_body="<p>Test email body</p>",
+    )
+
+    payload = mock_async_client.post.call_args[1]["json"]
+    assert "reply_to" not in payload


### PR DESCRIPTION
## TLDR

Problem this solves:

- SendGrid emails always invite replies to the sender address
- That sender is usually an unmonitored `no-reply` mailbox
- Admins had no setting to redirect replies anywhere else

How it solves it:

- Adds an optional `SENDGRID_REPLY_TO_EMAIL` environment variable
- When set, the Mail Send payload carries a top-level `reply_to`
- When unset, the request is byte-identical to today's

## User Flow

Before: an admin sending notification emails through SendGrid has every reply land in a no-reply mailbox nobody reads

1. They set `SENDGRID_API_KEY` and `SENDGRID_SENDER_EMAIL=no-reply@example.com`, then restart the proxy
2. They invite a teammate from https://litellm-domain/ui/?page=users
3. The teammate receives a "Welcome to LiteLLM" email from `no-reply@example.com`
4. The teammate presses Reply and their mail client addresses it to `no-reply@example.com`
5. That mailbox is unmonitored, so the reply is lost, and no setting changes this

After: the same admin points replies at a mailbox their team actually reads

1. They additionally set `SENDGRID_REPLY_TO_EMAIL=litellm-alerts@example.com`, then restart the proxy
2. They invite a teammate from https://litellm-domain/ui/?page=users
3. The teammate receives a "Welcome to LiteLLM" email from `no-reply@example.com`
4. The teammate presses Reply and their mail client now addresses it to `litellm-alerts@example.com`
5. The reply reaches a monitored inbox. Admins who leave the new variable unset see no change at all

## Relevant issues

Fixes #37578

## Linear ticket

Resolves LIT-6943

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Shared setup for every case below. The Mail Send endpoint was pointed at a local TLS listener that
records the request body verbatim (a hosts entry for `api.sendgrid.com` plus `SSL_CERT_FILE`
trusting a local CA alongside certifi), so what is shown is the exact payload the proxy transmits,
captured from a running proxy process with no mocking of the HTTP client

```bash
export SENDGRID_API_KEY=SG.xxx
export SENDGRID_SENDER_EMAIL=no-reply@example.com
```

### Before (c8635ecc67)

#### Reply-To configured

1. `export SENDGRID_REPLY_TO_EMAIL=litellm-alerts@example.com`, start the proxy, trigger a user invitation email
2. Payload transmitted to `https://api.sendgrid.com/v3/mail/send`:

```
wire keys : ['from', 'personalizations', 'content']
from      : {'email': 'no-reply@example.com'}
reply_to  : <<KEY ABSENT>>
subject   : LiteLLM: Welcome to LiteLLM Proxy
```

The variable is set but has no effect, so recipients still reply to `no-reply@example.com`

#### Reply-To not configured

1. With `SENDGRID_REPLY_TO_EMAIL` unset, trigger the same email
2. Payload transmitted:

```
wire keys : ['from', 'personalizations', 'content']
reply_to  : <<KEY ABSENT>>
```

### After (7b9910faef)

#### Reply-To configured

1. `export SENDGRID_REPLY_TO_EMAIL=litellm-alerts@example.com`, start the proxy, trigger a user invitation email
2. Payload transmitted to `https://api.sendgrid.com/v3/mail/send`:

```
wire keys : ['from', 'reply_to', 'personalizations', 'content']
from      : {'email': 'no-reply@example.com'}
reply_to  : {'email': 'litellm-alerts@example.com'}
subject   : LiteLLM: Welcome to LiteLLM Proxy
```

`reply_to` is present and `from` is unchanged

#### Reply-To not configured

1. With `SENDGRID_REPLY_TO_EMAIL` unset, trigger the same email
2. Payload transmitted:

```
wire keys : ['from', 'personalizations', 'content']
reply_to  : <<KEY ABSENT>>
```

3. Byte-comparing this payload against the Before run of the same case:

```
baseline keys: ['from', 'personalizations', 'content']
fixed    keys: ['from', 'personalizations', 'content']
IDENTICAL    : True
bytes        : 5998 vs 5998
```

Deployments that do not set the new variable transmit an identical request. The key is absent
rather than `null`, which matters because SendGrid rejects a null `reply_to`

## Type

🆕 New Feature

## Caveats (if any)

### Low

- Covers SendGrid only. Resend and SMTP have the same gap
- No display-name support on the reply-to address
- `reply_to_list` (multi-address form) not supported
- Reply-To rendering checked against SendGrid's API contract, not a delivered message

## Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Optional env-driven email header change with backward-compatible payloads; no auth or data-path impact.
> 
> **Overview**
> Adds optional **`SENDGRID_REPLY_TO_EMAIL`** so SendGrid notification mail can use a monitored inbox for replies while keeping **`from`** on a no-reply address.
> 
> When the variable is set, the Mail Send JSON includes a top-level **`reply_to`**; when it is unset, **`reply_to`** is omitted so the outbound payload stays the same as before. Class docs describe the new env var, and tests cover both configured and omitted **`reply_to`** cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b9910faef65652f942864b8b27c7adeba32537b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->