### PR TITLE
fix(mistral): a named tool_choice is dropped, the model picks any tool

### DIFF
--- a/litellm/llms/mistral/chat/transformation.py
+++ b/litellm/llms/mistral/chat/transformation.py
@@ -6,7 +6,7 @@ Why separate file? Make it easy to see how transformation works
 Docs - https://docs.mistral.ai/api/
 """
 
-from collections.abc import AsyncIterator, Coroutine, Iterator
+from collections.abc import AsyncIterator, Coroutine, Iterator, Mapping
 from typing import TYPE_CHECKING, Any, Final, Literal, cast, get_type_hints, overload
 
 import httpx
@@ -112,7 +112,7 @@ class MistralConfig(OpenAIGPTConfig):
         return supported_params
 
     @staticmethod
-    def _map_tool_choice(tool_choice: str | dict[str, object]) -> str | ChatCompletionToolChoiceObjectParam | None:
+    def _map_tool_choice(tool_choice: str | Mapping[str, object]) -> str | ChatCompletionToolChoiceObjectParam | None:
         match tool_choice:
             case "auto" | "none":
                 return tool_choice

--- a/litellm/llms/mistral/chat/transformation.py
+++ b/litellm/llms/mistral/chat/transformation.py
@@ -6,7 +6,7 @@ Why separate file? Make it easy to see how transformation works
 Docs - https://docs.mistral.ai/api/
 """
 
-from collections.abc import AsyncIterator, Coroutine, Iterator, Mapping
+from collections.abc import AsyncIterator, Coroutine, Iterator
 from typing import TYPE_CHECKING, Any, Final, Literal, cast, get_type_hints, overload
 
 import httpx
@@ -22,7 +22,11 @@ from litellm.llms.openai.chat.gpt_transformation import (
 )
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.mistral import MistralThinkingBlock, MistralToolCallMessage
-from litellm.types.llms.openai import AllMessageValues
+from litellm.types.llms.openai import (
+    AllMessageValues,
+    ChatCompletionToolChoiceFunctionParam,
+    ChatCompletionToolChoiceObjectParam,
+)
 from litellm.types.utils import ModelResponse, ModelResponseStream
 from litellm.utils import convert_to_model_response_object
 
@@ -44,7 +48,7 @@ class MistralConfig(OpenAIGPTConfig):
 
     - `tools` (list or null): A list of available tools for the model. Use this to specify functions for which the model can generate JSON inputs.
 
-    - `tool_choice` (string - 'auto'/'any'/'none' or null): Specifies if/how functions are called. If set to none the model won't call a function and will generate a message instead. If set to auto the model can choose to either generate a message or call a function. If set to any the model is forced to call a function. Default - 'auto'.
+    - `tool_choice` (string - 'auto'/'any'/'none', an object naming one function such as {"type": "function", "function": {"name": "my_function"}}, or null): Specifies if/how functions are called. If set to none the model won't call a function and will generate a message instead. If set to auto the model can choose to either generate a message or call a function. If set to any the model is forced to call a function. Default - 'auto'.
 
     - `stop` (string or array of strings): Stop generation if this token is detected. Or if one of these tokens is detected when providing an array
 
@@ -59,7 +63,7 @@ class MistralConfig(OpenAIGPTConfig):
     top_p: int | None = None
     max_tokens: int | None = None
     tools: list | None = None
-    tool_choice: Literal["auto", "any", "none"] | None = None
+    tool_choice: Literal["auto", "any", "none"] | ChatCompletionToolChoiceObjectParam | None = None
     random_seed: int | None = None
     safe_prompt: bool | None = None
     response_format: dict | None = None
@@ -71,7 +75,7 @@ class MistralConfig(OpenAIGPTConfig):
         top_p: int | None = None,
         max_tokens: int | None = None,
         tools: list | None = None,
-        tool_choice: Literal["auto", "any", "none"] | None = None,
+        tool_choice: Literal["auto", "any", "none"] | ChatCompletionToolChoiceObjectParam | None = None,
         random_seed: int | None = None,
         safe_prompt: bool | None = None,
         response_format: dict | None = None,
@@ -107,14 +111,19 @@ class MistralConfig(OpenAIGPTConfig):
 
         return supported_params
 
-    def _map_tool_choice(self, tool_choice: str | Mapping[str, object]) -> str | Mapping[str, object]:
+    @staticmethod
+    def _map_tool_choice(tool_choice: str | dict[str, object]) -> str | ChatCompletionToolChoiceObjectParam | None:
         match tool_choice:
             case "auto" | "none":
                 return tool_choice
-            case {"type": "function", "function": {"name": str()}}:
-                return tool_choice
-            case _:
+            case {"type": "function", "function": {"name": str(name)}} if name:
+                return ChatCompletionToolChoiceObjectParam(
+                    type="function", function=ChatCompletionToolChoiceFunctionParam(name=name)
+                )
+            case str():
                 return "any"
+            case _:
+                return None
 
     @staticmethod
     def _get_mistral_reasoning_system_prompt() -> str:
@@ -166,8 +175,12 @@ class MistralConfig(OpenAIGPTConfig):
                 optional_params["top_p"] = value
             if param == "stop":
                 optional_params["stop"] = value
-            if param == "tool_choice" and isinstance(value, (str, Mapping)):
-                optional_params["tool_choice"] = self._map_tool_choice(tool_choice=value)
+            if (
+                param == "tool_choice"
+                and isinstance(value, (str, dict))
+                and (mapped_tool_choice := self._map_tool_choice(tool_choice=value)) is not None
+            ):
+                optional_params["tool_choice"] = mapped_tool_choice
             if param == "seed":
                 optional_params["extra_body"] = {"random_seed": value}
             if param == "response_format":

--- a/litellm/llms/mistral/chat/transformation.py
+++ b/litellm/llms/mistral/chat/transformation.py
@@ -6,7 +6,7 @@ Why separate file? Make it easy to see how transformation works
 Docs - https://docs.mistral.ai/api/
 """
 
-from collections.abc import AsyncIterator, Coroutine, Iterator
+from collections.abc import AsyncIterator, Coroutine, Iterator, Mapping
 from typing import TYPE_CHECKING, Any, Final, Literal, cast, get_type_hints, overload
 
 import httpx
@@ -107,13 +107,14 @@ class MistralConfig(OpenAIGPTConfig):
 
         return supported_params
 
-    def _map_tool_choice(self, tool_choice: str) -> str:
-        if tool_choice == "auto" or tool_choice == "none":
-            return tool_choice
-        elif tool_choice == "required":
-            return "any"
-        else:  # openai 'tool_choice' object param not supported by Mistral API
-            return "any"
+    def _map_tool_choice(self, tool_choice: str | Mapping[str, object]) -> str | Mapping[str, object]:
+        match tool_choice:
+            case "auto" | "none":
+                return tool_choice
+            case {"type": "function", "function": {"name": str()}}:
+                return tool_choice
+            case _:
+                return "any"
 
     @staticmethod
     def _get_mistral_reasoning_system_prompt() -> str:
@@ -165,7 +166,7 @@ class MistralConfig(OpenAIGPTConfig):
                 optional_params["top_p"] = value
             if param == "stop":
                 optional_params["stop"] = value
-            if param == "tool_choice" and isinstance(value, str):
+            if param == "tool_choice" and isinstance(value, (str, Mapping)):
                 optional_params["tool_choice"] = self._map_tool_choice(tool_choice=value)
             if param == "seed":
                 optional_params["extra_body"] = {"random_seed": value}

--- a/tests/test_litellm/llms/mistral/test_mistral_chat_transformation.py
+++ b/tests/test_litellm/llms/mistral/test_mistral_chat_transformation.py
@@ -1,10 +1,15 @@
-from typing import List, cast
+from collections.abc import Mapping
+from typing import Final, List, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from litellm.litellm_core_utils.prompt_templates.common_utils import TOOL_RESULT_IMAGE_BOUNDARY
-from litellm.types.llms.openai import AllMessageValues
+from litellm.types.llms.openai import (
+    AllMessageValues,
+    ChatCompletionToolChoiceObjectParam,
+    ChatCompletionToolParam,
+)
 
 
 from litellm.llms.mistral.chat.transformation import (
@@ -844,3 +849,47 @@ def test_mistral_transform_request_hoists_tool_message_image():
         {"type": "text", "text": TOOL_RESULT_IMAGE_BOUNDARY},
         {"type": "image_url", "image_url": {"url": data_uri}},
     ]
+
+
+class TestMistralToolChoice:
+    """Mistral's tool_choice is either an enum or a named function object: https://docs.mistral.ai/api/"""
+
+    NAMED_TOOL_CHOICE: Final[ChatCompletionToolChoiceObjectParam] = {
+        "type": "function",
+        "function": {"name": "get_weather"},
+    }
+    TOOLS: Final[list[ChatCompletionToolParam]] = [
+        {
+            "type": "function",
+            "function": {"name": "get_weather", "parameters": {"type": "object", "properties": {}}},
+        }
+    ]
+
+    def _transform(self, tool_choice: str | Mapping[str, object]) -> dict[str, object]:
+        config: Final = MistralConfig()
+        optional_params: Final = config.map_openai_params(
+            non_default_params={"tool_choice": tool_choice, "tools": self.TOOLS},
+            optional_params={},
+            model="mistral-large-latest",
+            drop_params=False,
+        )
+        return config.transform_request(
+            model="mistral-large-latest",
+            messages=[{"role": "user", "content": "what is the weather in Madrid"}],
+            optional_params=optional_params,
+            litellm_params={},
+            headers={},
+        )
+
+    def test_named_function_is_forwarded_to_mistral(self) -> None:
+        assert self._transform(self.NAMED_TOOL_CHOICE)["tool_choice"] == self.NAMED_TOOL_CHOICE
+
+    @pytest.mark.parametrize(
+        "tool_choice, expected",
+        [("auto", "auto"), ("none", "none"), ("required", "any")],
+    )
+    def test_enum_tool_choice_is_mapped(self, tool_choice: str, expected: str) -> None:
+        assert self._transform(tool_choice)["tool_choice"] == expected
+
+    def test_object_shapes_mistral_does_not_accept_fall_back_to_any(self) -> None:
+        assert self._transform({"type": "allowed_tools", "allowed_tools": {"mode": "auto"}})["tool_choice"] == "any"

--- a/tests/test_litellm/llms/mistral/test_mistral_chat_transformation.py
+++ b/tests/test_litellm/llms/mistral/test_mistral_chat_transformation.py
@@ -1,15 +1,11 @@
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from typing import Final, List, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from litellm.litellm_core_utils.prompt_templates.common_utils import TOOL_RESULT_IMAGE_BOUNDARY
-from litellm.types.llms.openai import (
-    AllMessageValues,
-    ChatCompletionToolChoiceObjectParam,
-    ChatCompletionToolParam,
-)
+from litellm.types.llms.openai import AllMessageValues, ChatCompletionToolParam
 
 
 from litellm.llms.mistral.chat.transformation import (
@@ -854,21 +850,17 @@ def test_mistral_transform_request_hoists_tool_message_image():
 class TestMistralToolChoice:
     """Mistral's tool_choice is either an enum or a named function object: https://docs.mistral.ai/api/"""
 
-    NAMED_TOOL_CHOICE: Final[ChatCompletionToolChoiceObjectParam] = {
-        "type": "function",
-        "function": {"name": "get_weather"},
-    }
-    TOOLS: Final[list[ChatCompletionToolParam]] = [
+    TOOLS: Final[Sequence[ChatCompletionToolParam]] = [
         {
             "type": "function",
             "function": {"name": "get_weather", "parameters": {"type": "object", "properties": {}}},
         }
     ]
 
-    def _transform(self, tool_choice: str | Mapping[str, object]) -> dict[str, object]:
+    def _transform(self, tool_choice: str | Mapping[str, object]) -> Mapping[str, object]:
         config: Final = MistralConfig()
         optional_params: Final = config.map_openai_params(
-            non_default_params={"tool_choice": tool_choice, "tools": self.TOOLS},
+            non_default_params={"tool_choice": tool_choice, "tools": list(self.TOOLS)},
             optional_params={},
             model="mistral-large-latest",
             drop_params=False,
@@ -882,7 +874,20 @@ class TestMistralToolChoice:
         )
 
     def test_named_function_is_forwarded_to_mistral(self) -> None:
-        assert self._transform(self.NAMED_TOOL_CHOICE)["tool_choice"] == self.NAMED_TOOL_CHOICE
+        request: Final = self._transform({"type": "function", "function": {"name": "get_weather"}})
+
+        assert request["tool_choice"] == {"type": "function", "function": {"name": "get_weather"}}
+
+    def test_keys_mistral_forbids_are_not_replayed(self) -> None:
+        request: Final = self._transform(
+            {
+                "type": "function",
+                "function": {"name": "get_weather", "strict": True},
+                "cache_control": {"type": "ephemeral"},
+            }
+        )
+
+        assert request["tool_choice"] == {"type": "function", "function": {"name": "get_weather"}}
 
     @pytest.mark.parametrize(
         "tool_choice, expected",
@@ -891,5 +896,13 @@ class TestMistralToolChoice:
     def test_enum_tool_choice_is_mapped(self, tool_choice: str, expected: str) -> None:
         assert self._transform(tool_choice)["tool_choice"] == expected
 
-    def test_object_shapes_mistral_does_not_accept_fall_back_to_any(self) -> None:
-        assert self._transform({"type": "allowed_tools", "allowed_tools": {"mode": "auto"}})["tool_choice"] == "any"
+    @pytest.mark.parametrize(
+        "tool_choice",
+        [
+            {"type": "function", "function": {}},
+            {"type": "function", "function": {"name": ""}},
+            {"type": "function", "function": {"name": 123}},
+        ],
+    )
+    def test_function_objects_without_a_usable_name_are_left_out(self, tool_choice: Mapping[str, object]) -> None:
+        assert "tool_choice" not in self._transform(tool_choice)


### PR DESCRIPTION
## TLDR

Problem this solves:

- Mistral takes a named function as `tool_choice`
- LiteLLM mapped only the enum, dropping the object
- The pinned tool never reached Mistral, silently
- Also affected `codestral` and Mistral on `vertex_ai`

How it solves it:

- Rebuild the pin as `{type, function: {name}}` and send it
- Keep the enum mapping and every other shape unchanged
- Cover both shapes with regression tests

## User Flow

Before: a developer building an agent that must always start by calling one specific tool gets a chat answer instead of that tool call, so the agent loop stalls on the first turn

1. They send POST http://localhost:4000/v1/chat/completions with `"model": "mistral-large"`, one message `Say hello and nothing else.`, a `get_weather` tool, and `"tool_choice": {"type": "function", "function": {"name": "get_weather"}}`
2. They get back 200 with `"finish_reason": "stop"` and `"content": "Hello!"`, and no `tool_calls` on the message
3. The same body sent to https://api.mistral.ai/v1/chat/completions with a Mistral key comes back with `"finish_reason": "tool_calls"`, so the gateway and the provider disagree on the same request
4. Their agent, which expects a `get_weather` call on the first turn, has nothing to execute and stops

After: the same request comes back with the forced tool call, so the agent loop proceeds

1. They send POST http://localhost:4000/v1/chat/completions with `"model": "mistral-large"`, one message `Say hello and nothing else.`, a `get_weather` tool, and `"tool_choice": {"type": "function", "function": {"name": "get_weather"}}`
2. They get back 200 with `"finish_reason": "tool_calls"` and a `get_weather` tool call on the message
3. The same body sent to https://api.mistral.ai/v1/chat/completions with a Mistral key comes back the same way, so the gateway and the provider agree
4. Their agent executes `get_weather` and continues

## Relevant issues

Fixes #39736

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Config the proxy ran with, on both sides:

```yaml
model_list:
  - model_name: mistral-large
    litellm_params:
      model: mistral/mistral-large-latest
      api_key: os.environ/MISTRAL_API_KEY

litellm_settings:
  drop_params: false
```

Env vars: `MISTRAL_API_KEY` (redacted), `LITELLM_MASTER_KEY=sk-1234`

Started with `python litellm/proxy/proxy_cli.py --config config.yaml --detailed_debug`. Case 1 pins the tool the way the OpenAI spec does. Case 2 pins it with extra keys alongside, which is what a client that annotates or round-trips its `tool_choice` sends.

### Before (c8635ecc67bb6db47525a48374ad6009bf28801f)

#### case 1

1. Send the request below:

```bash
curl -sS -X POST http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "mistral-large",
    "temperature": 0,
    "messages": [{"role": "user", "content": "Say hello and nothing else."}],
    "tools": [{"type": "function", "function": {"name": "get_weather", "description": "Get the weather for a city", "parameters": {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}}}],
    "tool_choice": {"type": "function", "function": {"name": "get_weather"}}
  }'
```

2. The response comes back as:

```json
{
    "id": "360851a1644b48c4ad2822ac604eeeb1",
    "created": 1788532675,
    "model": "mistral-large",
    "object": "chat.completion",
    "choices": [
        {
            "finish_reason": "stop",
            "index": 0,
            "message": {
                "content": "Hello!",
                "role": "assistant"
            },
            "provider_specific_fields": {}
        }
    ],
    "usage": {
        "completion_tokens": 3,
        "prompt_tokens": 70,
        "total_tokens": 73,
        "prompt_tokens_details": {
            "cached_tokens": 0
        },
        "service_tier": "standard"
    }
}
```

3. The proxy log shows the body that left the gateway, with no `tool_choice` at all:

```
-d '{'model': 'mistral-large-latest', 'messages': [...], 'temperature': 0, 'tools': [{'type': 'function', 'function': {'name': 'get_weather', ...}}]}'
```

#### case 2

1. Send the request below:

```bash
curl -sS -X POST http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "mistral-large",
    "temperature": 0,
    "messages": [{"role": "user", "content": "Say hello and nothing else."}],
    "tools": [{"type": "function", "function": {"name": "get_weather", "description": "Get the weather for a city", "parameters": {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}}}],
    "tool_choice": {"type": "function", "function": {"name": "get_weather", "strict": true}, "cache_control": {"type": "ephemeral"}}
  }'
```

2. The response comes back as:

```json
{
    "id": "b95437f5a3394a4cbd4d76c5a88b7f1a",
    "created": 1788532676,
    "model": "mistral-large",
    "object": "chat.completion",
    "choices": [
        {
            "finish_reason": "stop",
            "index": 0,
            "message": {
                "content": "Hello!",
                "role": "assistant"
            },
            "provider_specific_fields": {}
        }
    ],
    "usage": {
        "completion_tokens": 3,
        "prompt_tokens": 70,
        "total_tokens": 73,
        "prompt_tokens_details": {
            "cached_tokens": 0
        },
        "service_tier": "standard"
    }
}
```

3. The proxy log shows the body that left the gateway, with no `tool_choice` at all:

```
-d '{'model': 'mistral-large-latest', 'messages': [...], 'temperature': 0, 'tools': [{'type': 'function', 'function': {'name': 'get_weather', ...}}]}'
```

### After (7987a1fae5aa008e9d16d5f78c11aca0a0df7fda)

#### case 1

1. Send the request below:

```bash
curl -sS -X POST http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "mistral-large",
    "temperature": 0,
    "messages": [{"role": "user", "content": "Say hello and nothing else."}],
    "tools": [{"type": "function", "function": {"name": "get_weather", "description": "Get the weather for a city", "parameters": {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}}}],
    "tool_choice": {"type": "function", "function": {"name": "get_weather"}}
  }'
```

2. The response comes back as:

```json
{
    "id": "ae5a9b249bdb458fba9319ccbacfa999",
    "created": 1788533197,
    "model": "mistral-large",
    "object": "chat.completion",
    "choices": [
        {
            "finish_reason": "tool_calls",
            "index": 0,
            "message": {
                "role": "assistant",
                "tool_calls": [
                    {
                        "index": 0,
                        "function": {
                            "arguments": "{\"city\": \"London\"}",
                            "name": "get_weather"
                        },
                        "id": "OIG4p9T2J",
                        "type": "function"
                    }
                ],
                "content": null
            },
            "provider_specific_fields": {}
        }
    ],
    "usage": {
        "completion_tokens": 12,
        "prompt_tokens": 75,
        "total_tokens": 87,
        "prompt_tokens_details": {
            "cached_tokens": 0
        },
        "service_tier": "standard"
    }
}
```

3. The proxy log shows the body that left the gateway, carrying the pin the caller asked for:

```
-d '{'model': 'mistral-large-latest', 'messages': [...], 'temperature': 0, 'tools': [{'type': 'function', 'function': {'name': 'get_weather', ...}}], 'tool_choice': {'type': 'function', 'function': {'name': 'get_weather'}}}'
```

#### case 2

1. Send the request below:

```bash
curl -sS -X POST http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "mistral-large",
    "temperature": 0,
    "messages": [{"role": "user", "content": "Say hello and nothing else."}],
    "tools": [{"type": "function", "function": {"name": "get_weather", "description": "Get the weather for a city", "parameters": {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}}}],
    "tool_choice": {"type": "function", "function": {"name": "get_weather", "strict": true}, "cache_control": {"type": "ephemeral"}}
  }'
```

2. The response comes back as:

```json
{
    "id": "461f760b42d647f1a43a7559bcfbf844",
    "created": 1788533198,
    "model": "mistral-large",
    "object": "chat.completion",
    "choices": [
        {
            "finish_reason": "tool_calls",
            "index": 0,
            "message": {
                "role": "assistant",
                "tool_calls": [
                    {
                        "index": 0,
                        "function": {
                            "arguments": "{\"city\": \"London\"}",
                            "name": "get_weather"
                        },
                        "id": "YVO0ZGTEv",
                        "type": "function"
                    }
                ],
                "content": null
            },
            "provider_specific_fields": {}
        }
    ],
    "usage": {
        "completion_tokens": 12,
        "prompt_tokens": 75,
        "total_tokens": 87,
        "prompt_tokens_details": {
            "cached_tokens": 0
        },
        "service_tier": "standard"
    }
}
```

3. The proxy log shows the body that left the gateway, carrying only the type and the function name, with the extra keys Mistral forbids left out:

```
-d '{'model': 'mistral-large-latest', 'messages': [...], 'temperature': 0, 'tools': [{'type': 'function', 'function': {'name': 'get_weather', ...}}], 'tool_choice': {'type': 'function', 'function': {'name': 'get_weather'}}}'
```

## Type

Bug Fix

## Caveats (if any)

### Low

- Function objects with no usable name are still left out, unchanged
- Only the name is forwarded, since Mistral forbids unknown fields
- `required` still maps to `any`, unchanged behavior
- An unrecognized `tool_choice` string still maps to `any`, unchanged
- Five providers hand-roll this same shape check; a shared helper is follow-up work

