### PR TITLE
fix(azure): preserve service_tier for chat completions

### DIFF
--- a/litellm/llms/azure/chat/gpt_transformation.py
+++ b/litellm/llms/azure/chat/gpt_transformation.py
@@ -128,6 +128,7 @@ class AzureOpenAIConfig(BaseConfig):
             "modalities",
             "audio",
             "web_search_options",
+            "service_tier",
             "prompt_cache_key",
             "store",
         ]

--- a/tests/test_litellm/llms/azure/chat/test_azure_chat_gpt_transformation.py
+++ b/tests/test_litellm/llms/azure/chat/test_azure_chat_gpt_transformation.py
@@ -5,9 +5,7 @@ from typing import Final
 import pytest
 from pydantic import TypeAdapter
 
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../.."))
-)
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../..")))
 
 import litellm
 from litellm.litellm_core_utils.prompt_templates.common_utils import TOOL_RESULT_IMAGE_BOUNDARY
@@ -53,6 +51,24 @@ class TestAzureOpenAIConfig:
         assert "prompt_cache_key" in supported_params
 
 
+@pytest.mark.parametrize("model", ("gpt-4.1", "gpt-4o", "gpt-5.1"))
+@pytest.mark.parametrize("drop_params", (True, False))
+@pytest.mark.parametrize("service_tier", ("priority", "bogus_tier_xyz", None))
+def test_azure_service_tier_forwarded(model: str, drop_params: bool, service_tier: str | None) -> None:
+    mapped: Final = _MAPPED_PARAMS.validate_python(
+        get_optional_params(
+            model=model,
+            custom_llm_provider="azure",
+            service_tier=service_tier,
+            drop_params=drop_params,
+        )
+    )
+    if service_tier is None:
+        assert "service_tier" not in mapped
+    else:
+        assert mapped["service_tier"] == service_tier
+
+
 def test_map_openai_params_with_preview_api_version():
     config = AzureOpenAIConfig()
     non_default_params = {
@@ -62,9 +78,7 @@ def test_map_openai_params_with_preview_api_version():
     model = "azure/gpt-4-1"
     drop_params = False
     api_version = "preview"
-    assert config.map_openai_params(
-        non_default_params, optional_params, model, drop_params, api_version
-    )
+    assert config.map_openai_params(non_default_params, optional_params, model, drop_params, api_version)
 
 
 def test_transform_request_hoists_tool_message_image():


### PR DESCRIPTION
## TLDR

Problem this solves:

- Azure GPT-4.1/4o requests silently lose `service_tier` with `drop_params`

How it solves it:

- Add `service_tier` to Azure's supported chat parameters
- Test preservation, invalid values, omission, and GPT-5 compatibility

## User Flow

The URL below uses `litellm.example` as a placeholder for the user's proxy

Before: an invalid tier is silently ignored, as reported in #39719

1. Register an Azure GPT-4.1 deployment with `drop_params: true`
2. Send POST `https://litellm.example/v1/chat/completions` using that deployment, a user message, and `"service_tier": "bogus_tier_xyz"`
3. Receive HTTP 200 with `service_tier: "default"` instead of an invalid-value error

After: the invalid tier reaches Azure for validation; live verification is pending

1. Register an Azure GPT-4.1 deployment with `drop_params: true`
2. Send POST `https://litellm.example/v1/chat/completions` using that deployment, a user message, and `"service_tier": "bogus_tier_xyz"`
3. Expect Azure's HTTP 400 invalid-value error instead of silent acceptance

## Relevant issues

Fixes #39719

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is isolated to one specific problem
- [x] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

Local unit coverage: 296 tests passed across Azure chat, OpenAI chat, and GPT-5 transformations

The regression test covers `priority`, an invalid tier, and `None`, with `drop_params` enabled and disabled, for Azure GPT-4.1, GPT-4o, and GPT-5.1

Before the fix, eight regression cases failed; after the fix, all eighteen passed

Ruff checks for `litellm` and `tests`, formatting checks for changed files, and `git diff --check` passed

## Delays in PR merge?

Use the project's [Slack PR review channel](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

Pending live Azure before/after verification at the merge base and final PR commit

No real Azure requests were made locally, and unit tests are not end-to-end proof

## Type

Bug Fix

## Caveats (if any)

### Low

- Live Azure before/after verification is still pending
- Full `make lint` and CI checks remain pending
- Existing TQ003 in the test file remains unchanged
- Priority availability still depends on the Azure deployment

## Final Attestation

- [x] The tests check the right things, including edge cases, and regressions in the respective real-world use cases are not possible after this PR
