### PR TITLE
fix(bedrock): cap reasoning effort thinking budget

### DIFF
--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -114,6 +114,11 @@ UNSUPPORTED_BEDROCK_CONVERSE_BETA_PATTERNS: Final = [
     "compact-2026-01-12",  # The compact beta feature is not currently supported on the Converse and ConverseStream APIs
 ]
 
+DROP_UNFITTING_REASONING_EFFORT_WARNING: Final = (
+    "Dropping `thinking` mapped from reasoning_effort=%s for model=%s: max_tokens=%s "
+    "is too small to fit the minimum thinking budget."
+)
+
 
 class AmazonConverseConfig(BaseConfig):
     """
@@ -418,7 +423,13 @@ class AmazonConverseConfig(BaseConfig):
             }
         }
 
-    def _handle_reasoning_effort_parameter(self, model: str, reasoning_effort: str, optional_params: dict) -> None:
+    def _handle_reasoning_effort_parameter(
+        self,
+        model: str,
+        reasoning_effort: str,
+        optional_params: dict,
+        max_tokens: int | None,
+    ) -> None:
         """
         Handle the reasoning_effort parameter based on the model type.
 
@@ -447,8 +458,19 @@ class AmazonConverseConfig(BaseConfig):
                 optional_params.pop("thinking", None)
                 optional_params.pop("output_config", None)
             else:
-                optional_params["thinking"] = mapped_thinking
-                if AnthropicConfig._is_adaptive_thinking_model(model, "bedrock"):
+                fitted_thinking: Final = AnthropicConfig.cap_thinking_budget_to_max_tokens(mapped_thinking, max_tokens)
+                if fitted_thinking is None:
+                    litellm.verbose_logger.warning(
+                        DROP_UNFITTING_REASONING_EFFORT_WARNING,
+                        reasoning_effort,
+                        model,
+                        max_tokens,
+                    )
+                    optional_params.pop("thinking", None)
+                    optional_params.pop("output_config", None)
+                else:
+                    optional_params["thinking"] = fitted_thinking
+                if fitted_thinking is not None and AnthropicConfig._is_adaptive_thinking_model(model, "bedrock"):
                     mapped_effort = REASONING_EFFORT_TO_OUTPUT_CONFIG_EFFORT.get(reasoning_effort)
                     if mapped_effort is None:
                         AnthropicConfig._raise_invalid_reasoning_effort(
@@ -872,6 +894,11 @@ class AmazonConverseConfig(BaseConfig):
         drop_params: bool,
     ) -> dict:
         is_thinking_enabled: Final = self.is_thinking_enabled(non_default_params)
+        resolved_max_tokens: Final = (
+            non_default_params.get("max_completion_tokens")
+            if non_default_params.get("max_completion_tokens") is not None
+            else non_default_params.get("max_tokens")
+        )
 
         for param, value in non_default_params.items():
             if param == "response_format" and isinstance(value, dict):
@@ -883,7 +910,7 @@ class AmazonConverseConfig(BaseConfig):
                     is_thinking_enabled=is_thinking_enabled,
                 )
             if param == "max_tokens" or param == "max_completion_tokens":
-                optional_params["maxTokens"] = value
+                optional_params["maxTokens"] = resolved_max_tokens
             if param == "stream":
                 optional_params["stream"] = value
             if param == "stop":
@@ -926,14 +953,13 @@ class AmazonConverseConfig(BaseConfig):
                     and value.get("type") == "adaptive"
                     and not AnthropicConfig._is_adaptive_thinking_model(model, "bedrock")
                 ):
-                    max_tokens = non_default_params.get("max_completion_tokens") or non_default_params.get("max_tokens")
                     legacy_thinking = AnthropicConfig._map_reasoning_effort(
                         reasoning_effort="medium",
                         model=model,
                         custom_llm_provider="bedrock",
                     )
                     capped = (
-                        AnthropicConfig.cap_thinking_budget_to_max_tokens(legacy_thinking, max_tokens)
+                        AnthropicConfig.cap_thinking_budget_to_max_tokens(legacy_thinking, resolved_max_tokens)
                         if legacy_thinking is not None
                         else None
                     )
@@ -948,7 +974,10 @@ class AmazonConverseConfig(BaseConfig):
                     )
             elif param == "reasoning_effort" and isinstance(value, str):
                 self._handle_reasoning_effort_parameter(
-                    model=model, reasoning_effort=value, optional_params=optional_params
+                    model=model,
+                    reasoning_effort=value,
+                    optional_params=optional_params,
+                    max_tokens=resolved_max_tokens,
                 )
             elif param == "output_config" and isinstance(value, dict):
                 mapped_output_config = dict(value)

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -467,7 +467,6 @@ class AmazonConverseConfig(BaseConfig):
                         max_tokens,
                     )
                     optional_params.pop("thinking", None)
-                    optional_params.pop("output_config", None)
                 else:
                     optional_params["thinking"] = fitted_thinking
                 if fitted_thinking is not None and AnthropicConfig._is_adaptive_thinking_model(model, "bedrock"):
@@ -894,10 +893,14 @@ class AmazonConverseConfig(BaseConfig):
         drop_params: bool,
     ) -> dict:
         is_thinking_enabled: Final = self.is_thinking_enabled(non_default_params)
+        max_tokens: Final = non_default_params.get("max_tokens")
+        max_completion_tokens: Final = non_default_params.get("max_completion_tokens")
         resolved_max_tokens: Final = (
-            non_default_params.get("max_completion_tokens")
-            if non_default_params.get("max_completion_tokens") is not None
-            else non_default_params.get("max_tokens")
+            min(max_tokens, max_completion_tokens)
+            if isinstance(max_tokens, int) and isinstance(max_completion_tokens, int)
+            else max_completion_tokens
+            if max_completion_tokens is not None
+            else max_tokens
         )
 
         for param, value in non_default_params.items():

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -507,12 +507,12 @@ def test_reasoning_effort_budget_fits_max_tokens_for_anthropic_converse(
     "params,expected_max_tokens,expects_thinking",
     [
         (
-            {"reasoning_effort": "medium", "max_tokens": 1024, "max_completion_tokens": 4096},
+            {"reasoning_effort": "medium", "max_tokens": 4096, "max_completion_tokens": 8192},
             4096,
             True,
         ),
         (
-            {"reasoning_effort": "medium", "max_completion_tokens": 4096, "max_tokens": 1024},
+            {"reasoning_effort": "medium", "max_completion_tokens": 8192, "max_tokens": 4096},
             4096,
             True,
         ),
@@ -528,10 +528,10 @@ def test_reasoning_effort_budget_fits_max_tokens_for_anthropic_converse(
         ),
     ],
 )
-def test_max_completion_tokens_wins_for_reasoning_effort_anthropic_converse(
+def test_restrictive_token_alias_wins_for_reasoning_effort_anthropic_converse(
     params, expected_max_tokens, expects_thinking
 ):
-    """The completion-token alias controls both output and thinking limits regardless of input order."""
+    """The smaller output-token alias controls both limits regardless of input order."""
     config = AmazonConverseConfig()
     model = "bedrock/converse/us.anthropic.claude-haiku-4-5-20251001-v1:0"
 
@@ -547,6 +547,35 @@ def test_max_completion_tokens_wins_for_reasoning_effort_anthropic_converse(
         assert optional_params["thinking"] == {"type": "enabled", "budget_tokens": 2048}
     else:
         assert "thinking" not in optional_params
+
+
+@pytest.mark.parametrize("output_config_first", [True, False])
+def test_unfitting_reasoning_effort_preserves_explicit_output_config(output_config_first):
+    """Dropping generated thinking must not delete an independent structured-output configuration."""
+    config = AmazonConverseConfig()
+    model = "bedrock/converse/us.anthropic.claude-haiku-4-5-20251001-v1:0"
+    output_config = {"format": {"type": "json_schema", "schema": {"type": "object"}}}
+    params = {
+        "output_config": output_config,
+        "reasoning_effort": "medium",
+        "max_tokens": 1024,
+    }
+    if not output_config_first:
+        params = {
+            "reasoning_effort": "medium",
+            "max_tokens": 1024,
+            "output_config": output_config,
+        }
+
+    optional_params = config.map_openai_params(
+        non_default_params=params,
+        optional_params={},
+        model=model,
+        drop_params=False,
+    )
+
+    assert "thinking" not in optional_params
+    assert optional_params["output_config"] == output_config
 
 
 def test_reasoning_effort_without_max_tokens_synthesizes_valid_limit():

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -462,6 +462,143 @@ def test_reasoning_effort_none_omits_thinking_for_anthropic_converse(model):
     assert "thinking" not in optional_params
 
 
+@pytest.mark.parametrize("reasoning_first", [True, False])
+@pytest.mark.parametrize(
+    "token_param,max_tokens,expected_budget",
+    [
+        ("max_tokens", 4096, 2048),
+        ("max_tokens", 2048, 2047),
+        ("max_tokens", 1025, 1024),
+        ("max_completion_tokens", 2048, 2047),
+    ],
+)
+def test_reasoning_effort_budget_fits_max_tokens_for_anthropic_converse(
+    reasoning_first, token_param, max_tokens, expected_budget
+):
+    """Mapped reasoning budgets must stay below either output-token alias,
+    independently of caller parameter insertion order."""
+    config = AmazonConverseConfig()
+    model = "bedrock/converse/us.anthropic.claude-haiku-4-5-20251001-v1:0"
+    params = {"reasoning_effort": "medium", token_param: max_tokens}
+    if not reasoning_first:
+        params = {token_param: max_tokens, "reasoning_effort": "medium"}
+
+    optional_params = config.map_openai_params(
+        non_default_params=params,
+        optional_params={},
+        model=model,
+        drop_params=False,
+    )
+    request = config.transform_request(
+        model=model,
+        messages=[{"role": "user", "content": "hi"}],
+        optional_params=optional_params,
+        litellm_params={},
+        headers={},
+    )
+
+    assert request["inferenceConfig"]["maxTokens"] == max_tokens
+    thinking = request["additionalModelRequestFields"]["thinking"]
+    assert thinking == {"type": "enabled", "budget_tokens": expected_budget}
+    assert thinking["budget_tokens"] < max_tokens
+
+
+@pytest.mark.parametrize(
+    "params,expected_max_tokens,expects_thinking",
+    [
+        (
+            {"reasoning_effort": "medium", "max_tokens": 1024, "max_completion_tokens": 4096},
+            4096,
+            True,
+        ),
+        (
+            {"reasoning_effort": "medium", "max_completion_tokens": 4096, "max_tokens": 1024},
+            4096,
+            True,
+        ),
+        (
+            {"reasoning_effort": "medium", "max_tokens": 4096, "max_completion_tokens": 1024},
+            1024,
+            False,
+        ),
+        (
+            {"reasoning_effort": "medium", "max_completion_tokens": 1024, "max_tokens": 4096},
+            1024,
+            False,
+        ),
+    ],
+)
+def test_max_completion_tokens_wins_for_reasoning_effort_anthropic_converse(
+    params, expected_max_tokens, expects_thinking
+):
+    """The completion-token alias controls both output and thinking limits regardless of input order."""
+    config = AmazonConverseConfig()
+    model = "bedrock/converse/us.anthropic.claude-haiku-4-5-20251001-v1:0"
+
+    optional_params = config.map_openai_params(
+        non_default_params=params,
+        optional_params={},
+        model=model,
+        drop_params=False,
+    )
+
+    assert optional_params["maxTokens"] == expected_max_tokens
+    if expects_thinking:
+        assert optional_params["thinking"] == {"type": "enabled", "budget_tokens": 2048}
+    else:
+        assert "thinking" not in optional_params
+
+
+def test_reasoning_effort_without_max_tokens_synthesizes_valid_limit():
+    """Legacy thinking without an output limit receives enough completion-token headroom."""
+    from litellm.constants import DEFAULT_MAX_TOKENS
+
+    config = AmazonConverseConfig()
+
+    optional_params = config.map_openai_params(
+        non_default_params={"reasoning_effort": "medium"},
+        optional_params={},
+        model="bedrock/converse/us.anthropic.claude-haiku-4-5-20251001-v1:0",
+        drop_params=False,
+    )
+
+    assert optional_params["thinking"] == {"type": "enabled", "budget_tokens": 2048}
+    assert optional_params["maxTokens"] == 2048 + DEFAULT_MAX_TOKENS
+
+
+@pytest.mark.parametrize("token_param", ["max_tokens", "max_completion_tokens"])
+def test_reasoning_effort_dropped_when_max_tokens_cannot_fit_anthropic_converse(
+    token_param, caplog
+):
+    """Mapped thinking is dropped when the output limit cannot fit Anthropic's
+    minimum budget without rejecting the request."""
+    config = AmazonConverseConfig()
+    model = "bedrock/converse/us.anthropic.claude-haiku-4-5-20251001-v1:0"
+
+    with caplog.at_level("WARNING"):
+        optional_params = config.map_openai_params(
+            non_default_params={"reasoning_effort": "medium", token_param: 1024},
+            optional_params={},
+            model=model,
+            drop_params=False,
+        )
+    request = config.transform_request(
+        model=model,
+        messages=[{"role": "user", "content": "hi"}],
+        optional_params=optional_params,
+        litellm_params={},
+        headers={},
+    )
+
+    assert request["inferenceConfig"]["maxTokens"] == 1024
+    assert "additionalModelRequestFields" not in request
+    expected_warning = (
+        "Dropping `thinking` mapped from reasoning_effort=medium for "
+        f"model={model}: max_tokens=1024 is too small to fit the minimum thinking budget."
+    )
+    assert expected_warning in [record.getMessage() for record in caplog.records]
+
+
 @pytest.mark.parametrize(
     "model,effort,expected_effort",
     [
@@ -491,6 +628,40 @@ def test_reasoning_effort_sets_output_config_for_adaptive_models_converse(
 
     assert optional_params["thinking"]["type"] == "adaptive"
     assert optional_params["output_config"] == {"effort": expected_effort}
+
+
+def test_adaptive_reasoning_effort_preserved_with_explicit_small_limit():
+    """Adaptive thinking has no fixed budget and remains enabled with an explicit small output limit."""
+    config = AmazonConverseConfig()
+
+    optional_params = config.map_openai_params(
+        non_default_params={"reasoning_effort": "medium", "max_tokens": 1024},
+        optional_params={},
+        model="bedrock/converse/us.anthropic.claude-opus-4-7",
+        drop_params=False,
+    )
+
+    assert optional_params["maxTokens"] == 1024
+    assert optional_params["thinking"] == {"type": "adaptive", "display": "summarized"}
+    assert optional_params["output_config"] == {"effort": "medium"}
+
+
+def test_gpt_oss_reasoning_effort_preserved_with_explicit_limit():
+    """GPT-OSS reasoning remains a passthrough field when an output limit is supplied."""
+    config = AmazonConverseConfig()
+    model = "bedrock/converse/openai.gpt-oss-120b-1:0"
+
+    optional_params = config.map_openai_params(
+        non_default_params={"reasoning_effort": "high", "max_tokens": 1024},
+        optional_params={},
+        model=model,
+        drop_params=False,
+    )
+    inference_params, additional_request_params, _, _ = config._prepare_request_params(optional_params, model)
+
+    assert inference_params["maxTokens"] == 1024
+    assert additional_request_params["reasoning_effort"] == "high"
+    assert "thinking" not in additional_request_params
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## TLDR

Problem this solves:

Bedrock Converse requires the thinking budget to remain below the output-token limit. Reasoning effort mapping could generate an equal or larger budget, causing Bedrock to reject otherwise valid requests

How it solves it:

- Resolves conflicting output-token aliases to the smaller ceiling
- Caps generated legacy thinking budgets below the resolved output limit
- Omits generated thinking with a diagnostic warning when Anthropic's minimum budget cannot fit
- Preserves adaptive Claude, GPT-OSS, OpenAI GPT-5, and Nova reasoning paths

## User Flow

Before: a developer sends a Bedrock Converse request with reasoning effort set to medium and max tokens set to 2048. LiteLLM sends both maxTokens and budget_tokens as 2048, and Bedrock rejects the request

After: LiteLLM sends maxTokens as 2048 and budget_tokens as 2047. For limits of 1024 or lower, LiteLLM omits generated thinking instead of sending an invalid pair

## Relevant issues

Fixes #39627

## Linear ticket

None

## Pre-Submission checklist

- [x] I have added meaningful tests that exercise the affected request-mapping paths
- [x] The focused Bedrock Converse and Nova test suites pass locally
- [ ] Required CI checks pass on this pull request
- [x] The change is isolated to Bedrock Converse mapping and its existing test module
- [ ] Greptile review score is at least 4/5

## Screenshots / Proof of Fix

Not included because this checkout has no configured Bedrock deployment for a live provider request. Request serialization tests cover the rejected boundary and corrected payload shapes

## Type

Bug Fix

## Caveats

The change applies only to thinking generated from reasoning effort. Explicit caller-supplied thinking remains unchanged

## Final Attestation

- [x] I reviewed the affected model branches and added boundary, alias-precedence, and request-serialization coverage
