### PR TITLE
fix(bedrock): clamp reasoning_effort thinking budget to max_tokens on…

### DIFF
--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -439,7 +439,7 @@ class AmazonConverseConfig(BaseConfig):
             reasoning_config: Final = self._transform_reasoning_effort_to_reasoning_config(reasoning_effort)
             optional_params.update(reasoning_config)
         else:
-            mapped_thinking: Final = AnthropicConfig._map_reasoning_effort(
+            mapped_thinking = AnthropicConfig._map_reasoning_effort(
                 reasoning_effort=reasoning_effort,
                 model=model,
                 custom_llm_provider="bedrock",

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -418,7 +418,9 @@ class AmazonConverseConfig(BaseConfig):
             }
         }
 
-    def _handle_reasoning_effort_parameter(self, model: str, reasoning_effort: str, optional_params: dict) -> None:
+    def _handle_reasoning_effort_parameter(
+        self, model: str, reasoning_effort: str, optional_params: dict, max_tokens: int | None = None
+    ) -> None:
         """
         Handle the reasoning_effort parameter based on the model type.
 
@@ -443,6 +445,8 @@ class AmazonConverseConfig(BaseConfig):
                 custom_llm_provider="bedrock",
                 llm_provider="bedrock_converse",
             )
+            if mapped_thinking is not None:
+                mapped_thinking = AnthropicConfig.cap_thinking_budget_to_max_tokens(mapped_thinking, max_tokens)
             if mapped_thinking is None:
                 optional_params.pop("thinking", None)
                 optional_params.pop("output_config", None)
@@ -948,7 +952,10 @@ class AmazonConverseConfig(BaseConfig):
                     )
             elif param == "reasoning_effort" and isinstance(value, str):
                 self._handle_reasoning_effort_parameter(
-                    model=model, reasoning_effort=value, optional_params=optional_params
+                    model=model,
+                    reasoning_effort=value,
+                    optional_params=optional_params,
+                    max_tokens=non_default_params.get("max_completion_tokens") or non_default_params.get("max_tokens"),
                 )
             elif param == "output_config" and isinstance(value, dict):
                 mapped_output_config = dict(value)

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -465,19 +465,15 @@ def test_reasoning_effort_none_omits_thinking_for_anthropic_converse(model):
 @pytest.mark.parametrize(
     "max_tokens,expect_thinking,expect_budget_below_max_tokens",
     [
-        (1024, False, None),  # at/below Bedrock's min thinking budget -> thinking dropped entirely
-        (2048, True, True),   # medium's default budget (2048) equals max_tokens -> must be clamped below it
-        (4096, True, False),  # budget already fits comfortably under max_tokens -> left unchanged
+        (1024, False, None),
+        (2048, True, True),
+        (4096, True, False),
     ],
 )
 def test_reasoning_effort_thinking_budget_clamped_to_max_tokens_converse(
-    max_tokens, expect_thinking, expect_budget_below_max_tokens
-):
-    """Regression #39627: a deployment-level reasoning_effort must not send a
-    thinking.budget_tokens that is >= max_tokens on Bedrock Converse. Bedrock
-    requires maxTokens strictly greater than thinking.budget_tokens, so the
-    mapped budget must be clamped the same way the adaptive-downgrade branch
-    already clamps it, or dropped when even the 1024 minimum can't fit."""
+    max_tokens: int, expect_thinking: bool, expect_budget_below_max_tokens: bool | None
+) -> None:
+    """Regression #39627."""
     config = AmazonConverseConfig()
 
     optional_params = config.map_openai_params(

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -463,6 +463,40 @@ def test_reasoning_effort_none_omits_thinking_for_anthropic_converse(model):
 
 
 @pytest.mark.parametrize(
+    "max_tokens,expect_thinking,expect_budget_below_max_tokens",
+    [
+        (1024, False, None),  # at/below Bedrock's min thinking budget -> thinking dropped entirely
+        (2048, True, True),   # medium's default budget (2048) equals max_tokens -> must be clamped below it
+        (4096, True, False),  # budget already fits comfortably under max_tokens -> left unchanged
+    ],
+)
+def test_reasoning_effort_thinking_budget_clamped_to_max_tokens_converse(
+    max_tokens, expect_thinking, expect_budget_below_max_tokens
+):
+    """Regression #39627: a deployment-level reasoning_effort must not send a
+    thinking.budget_tokens that is >= max_tokens on Bedrock Converse. Bedrock
+    requires maxTokens strictly greater than thinking.budget_tokens, so the
+    mapped budget must be clamped the same way the adaptive-downgrade branch
+    already clamps it, or dropped when even the 1024 minimum can't fit."""
+    config = AmazonConverseConfig()
+
+    optional_params = config.map_openai_params(
+        non_default_params={"max_tokens": max_tokens, "reasoning_effort": "medium"},
+        optional_params={},
+        model="us.anthropic.claude-haiku-4-5-20251001-v1:0",
+        drop_params=False,
+    )
+
+    if not expect_thinking:
+        assert optional_params.get("thinking") is None
+        return
+
+    thinking = optional_params["thinking"]
+    budget = thinking["budget_tokens"]
+    assert budget < max_tokens if expect_budget_below_max_tokens else budget == 2048
+
+
+@pytest.mark.parametrize(
     "model,effort,expected_effort",
     [
         ("bedrock/converse/us.anthropic.claude-opus-4-7", "low", "low"),


### PR DESCRIPTION
Fixes #39627. _handle_reasoning_effort_parameter assigned the mapped thinking budget without capping it against max_tokens, so any request with max_tokens <= the mapped budget (e.g. medium's 2048) got a 400 from Bedrock. Now routes through AnthropicConfig.cap_thinking_budget_to_max_tokens, matching the existing adaptive-downgrade branch and the /v1/messages fix in 71a9516.

## TLDR

Problem this solves:
- Bedrock Converse 400s on any small max_tokens request with reasoning_effort set
- Caller never asked for thinking, error is confusing and undocumented

How it solves it:
- Clamps the mapped thinking budget below max_tokens before sending it
- Drops thinking entirely when even the 1024 minimum can't fit

## User Flow

Before: a developer whose proxy deployment sets reasoning_effort: medium gets a 400 on any short-answer request, even though they never asked for thinking

1. They send POST https://litellm-domain/v1/chat/completions with "model": "claude-haiku-4-5", one user message, "max_tokens": 2048, no reasoning_effort or thinking in the body
2. They get HTTP 400: `max_tokens` must be greater than `thinking.budget_tokens`
3. They retry with "max_tokens": 4096 and it works, so the endpoint looks broken only below some invisible threshold

After: the same request returns a normal completion

1. They send the same POST https://litellm-domain/v1/chat/completions with "max_tokens": 2048
2. They get HTTP 200 with a normal completion
3. A request at "max_tokens": 1024 also returns 200 instead of a 400

## Relevant issues

Fixes #39627

## Linear ticket



## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

No live Bedrock credentials were available to run this end-to-end against the real API. The reproduction below exercises the exact request-mapping code path that produces the 400 — `AmazonConverseConfig.map_openai_params` with `reasoning_effort="medium"` — unmocked, showing the malformed `thinking`/`maxTokens` pair before the fix and the corrected pair after. Happy to run a live call if a maintainer can share Bedrock access, or if someone wants to verify against a live proxy.

### Before (c8635ecc67bb6db47525a48374ad6009bf28801f)

1. Run:

LITELLM_LOCAL_MODEL_COST_MAP=True python -c "
from litellm.llms.bedrock.chat.converse_transformation import AmazonConverseConfig
for mt in (1024, 2048, 4096):
p = AmazonConverseConfig().map_openai_params(
non_default_params={'max_tokens': mt, 'reasoning_effort': 'medium'},
optional_params={},
model='us.anthropic.claude-haiku-4-5-20251001-v1:0',
drop_params=False,
)
print(f'max_tokens={mt:5} maxTokens={p.get("maxTokens")} thinking={p.get("thinking")}')
"

2. Observed output:

max_tokens= 1024 maxTokens=1024 thinking={'type': 'enabled', 'budget_tokens': 2048}
max_tokens= 2048 maxTokens=2048 thinking={'type': 'enabled', 'budget_tokens': 2048}
max_tokens= 4096 maxTokens=4096 thinking={'type': 'enabled', 'budget_tokens': 2048}

3. Rows 1 and 2 show `budget_tokens >= maxTokens`, which Bedrock rejects with `max_tokens must be greater than thinking.budget_tokens` (400).

### After (dc29b96933)

1. Run the same command as above.
2. Observed output:

max_tokens= 1024 maxTokens=1024 thinking=None
max_tokens= 2048 maxTokens=2048 thinking={'type': 'enabled', 'budget_tokens': 2047}
max_tokens= 4096 maxTokens=4096 thinking={'type': 'enabled', 'budget_tokens': 2048}

3. `thinking` is now either dropped (max_tokens too small) or strictly below `maxTokens`, so Bedrock accepts all three requests.

## Type

🐛 Bug Fix

## Caveats



## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR