### PR TITLE
fix(bedrock): preserve tool reference results

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -3795,7 +3795,12 @@ def _build_bedrock_tool_result_content_blocks(
     if isinstance(message_content, str):
         return [BedrockToolResultContentBlock(text=message_content)], False
     if isinstance(message_content, list):
-        return _parse_bedrock_tool_result_content_list(message_content), False
+        parsed_content: Final = _parse_bedrock_tool_result_content_list(message_content)
+        if parsed_content:
+            return parsed_content, False
+        if any(content.get("type") == "tool_reference" for content in message_content):
+            return [BedrockToolResultContentBlock(text="")], False
+        return parsed_content, False
     return [], False
 
 

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -2,7 +2,7 @@ import base64
 import json
 import logging
 import os
-from typing import Final
+from typing import Final, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -53,6 +53,48 @@ def test_ollama_pt_simple_messages():
     assert isinstance(result, dict)
     assert result["prompt"] == expected_prompt
     assert result["images"] == []
+
+
+def test_bedrock_converse_tool_reference_result_keeps_empty_result():
+    messages = [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "toolu_01",
+                    "type": "function",
+                    "function": {"name": "ToolSearch", "arguments": "{}"},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "toolu_01",
+            "content": [{"type": "tool_reference", "tool_name": "mcp__deferred__search"}],
+        },
+    ]
+
+    translated: Final[list[dict[str, object]]] = cast(
+        list[dict[str, object]], _bedrock_converse_messages_pt(messages=messages, model="", llm_provider="")
+    )
+
+    assert translated[1]["content"] == [{"toolResult": {"content": [{"text": ""}], "toolUseId": "toolu_01"}}]
+
+
+def test_bedrock_converse_tool_reference_result_preserves_text_content():
+    message = {
+        "role": "tool",
+        "tool_call_id": "toolu_01",
+        "content": [
+            {"type": "text", "text": "loaded"},
+            {"type": "tool_reference", "tool_name": "mcp__deferred__search"},
+        ],
+    }
+
+    result: Final[dict[str, object]] = cast(dict[str, object], _convert_to_bedrock_tool_call_result(message))
+
+    assert result == {"toolResult": {"content": [{"text": "loaded"}], "toolUseId": "toolu_01"}}
 
 
 def test_ollama_pt_consecutive_user_messages():


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bedrock rejects reference-only ToolSearch results

How it solves it:

- Sends an empty tool result block
- Keeps textual tool results unchanged

## User Flow

Before: Claude Code stops when a deferred MCP tool is loaded

1. A developer sends POST https://litellm-domain/v1/messages through a Bedrock deployment
2. Claude Code returns a ToolSearch result with a tool_reference block
3. The next request returns HTTP 400 with an invalid input variant

After: the same deferred-tool handoff keeps the session running

1. A developer sends the same POST https://litellm-domain/v1/messages through a Bedrock deployment
2. Claude Code returns the same ToolSearch result with a tool_reference block
3. The next request carries an empty tool result and can reach the configured model

## Relevant issues

Fixes #39741

## Linear ticket


## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The focused test file passes locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR scope is isolated to this translation
- [ ] I have received a Greptile Confidence Score of at least 4/5

## Screenshots / Proof of Fix

### Before (c8635ecc67)

1. A provider-free Bedrock Converse translation produced toolResult.content: [] for a reference-only ToolSearch result

### After (d8135c5d7b)

1. The same translation produces toolResult.content: [{"text": ""}]
2. `uv run pytest tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py -q` passes: 106 passed
3. Live Bedrock provider testing was not run locally

## Type

🐛 Bug Fix

## Caveats

### Low

- Provider acceptance remains for CI or maintainers

## Final Attestation

- [x] The tests cover reference-only and mixed text results