### PR TITLE
fix(credential): adopt existing credential on name conflict instead of failing (#8)

### DIFF
--- a/terraform/provider/CHANGELOG.md
+++ b/terraform/provider/CHANGELOG.md
@@ -36,6 +36,7 @@ longer signal it.
 
 ### Fixed
 
+- **credential**: `litellm_credential` create now adopts an existing credential on a `credential_name` conflict instead of failing with a 500; `apply` is idempotent again once state loses track of a credential that still exists on the proxy
 - **team**: Read now decodes the `team_info` envelope `/team/info` actually returns, so team attributes refresh from the proxy instead of always falling back to the prior state
 - **key**: Read now unwraps the `info` envelope `/key/info` actually returns; previously reads mapped nothing back into state, so drift on a key was never detected
 - **key**: Updates no longer send an empty `budget_duration`, which the proxy rejects with a 400; any update to a key without a configured `budget_duration` previously failed outright

--- a/terraform/provider/litellm/resource_credential_crud.go
+++ b/terraform/provider/litellm/resource_credential_crud.go
@@ -89,14 +89,24 @@ func resourceLiteLLMCredentialCreate(d *schema.ResourceData, m interface{}) erro
 	err = handleCredentialAPIResponse(resp, nil, client)
 	if err != nil {
 		// If a credential with this name already exists, adopt it instead of
-		// failing. credential_name is the natural key, so we take ownership
-		// and update the existing credential to match the configured values
+		// failing: take ownership and update the existing credential's
+		// values (merged onto whatever it already had - not a full replace)
 		// rather than erroring on the unique-constraint conflict. See
 		// https://github.com/BerriAI/terraform-provider-litellm/issues/8.
 		if err.Error() == "credential_conflict" {
 			log.Printf("[WARN] Credential %q already exists; adopting it and updating to match configuration.", credentialName)
 			d.SetId(credentialName)
-			return resourceLiteLLMCredentialUpdate(d, m)
+			if updateErr := resourceLiteLLMCredentialUpdate(d, m); updateErr != nil {
+				// Adoption failed before this run took ownership of
+				// anything real. Clear the ID so create is reported as
+				// failed outright (matching pre-adoption behavior) instead
+				// of tainting state for a credential this run doesn't own -
+				// state that would otherwise get destroyed on the next
+				// apply.
+				d.SetId("")
+				return fmt.Errorf("failed to adopt existing credential %q: %w", credentialName, updateErr)
+			}
+			return nil
 		}
 		return fmt.Errorf("failed to create credential: %w", err)
 	}
@@ -152,6 +162,7 @@ func resourceLiteLLMCredentialUpdate(d *schema.ResourceData, m interface{}) erro
 	client := m.(*Client)
 	credentialName := d.Id()
 
+	modelID := d.Get("model_id").(string)
 	credentialInfo := d.Get("credential_info").(map[string]interface{})
 	credentialValues := d.Get("credential_values").(map[string]interface{})
 
@@ -167,8 +178,13 @@ func resourceLiteLLMCredentialUpdate(d *schema.ResourceData, m interface{}) erro
 		credValuesMap[k] = v
 	}
 
+	// model_id must travel with the update the same way it does on create,
+	// so the proxy's model-based credential resolution still applies. Without
+	// it, updating (or adopting) a model_id-scoped credential silently loses
+	// that association.
 	credentialRequest := CredentialRequest{
 		CredentialName:   credentialName,
+		ModelID:          modelID,
 		CredentialInfo:   credInfoMap,
 		CredentialValues: credValuesMap,
 	}

--- a/terraform/provider/litellm/resource_credential_crud.go
+++ b/terraform/provider/litellm/resource_credential_crud.go
@@ -88,6 +88,16 @@ func resourceLiteLLMCredentialCreate(d *schema.ResourceData, m interface{}) erro
 
 	err = handleCredentialAPIResponse(resp, nil, client)
 	if err != nil {
+		// If a credential with this name already exists, adopt it instead of
+		// failing. credential_name is the natural key, so we take ownership
+		// and update the existing credential to match the configured values
+		// rather than erroring on the unique-constraint conflict. See
+		// https://github.com/BerriAI/terraform-provider-litellm/issues/8.
+		if err.Error() == "credential_conflict" {
+			log.Printf("[WARN] Credential %q already exists; adopting it and updating to match configuration.", credentialName)
+			d.SetId(credentialName)
+			return resourceLiteLLMCredentialUpdate(d, m)
+		}
 		return fmt.Errorf("failed to create credential: %w", err)
 	}
 

--- a/terraform/provider/litellm/resource_credential_crud_test.go
+++ b/terraform/provider/litellm/resource_credential_crud_test.go
@@ -199,3 +199,57 @@ func TestRetryCredentialRead_ConnectionError(t *testing.T) {
 	// Connection error should not be retried (not a "credential_not_found")
 	fmt.Printf("connection error (expected): %v\n", err)
 }
+
+// A credential that already exists in LiteLLM (created out of band, or left
+// behind by a prior apply that dropped state) must be adopted on create
+// instead of failing on the credential_name unique-constraint conflict.
+func TestResourceLiteLLMCredentialCreate_AdoptsOnConflict(t *testing.T) {
+	var createCalls, updateCalls, readCalls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/credentials":
+			atomic.AddInt32(&createCalls, 1)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(`{"error":{"message":"Unique constraint failed on the fields: (` + "`credential_name`" + `)","type":"internal_server_error","code":"500"}}`))
+		case r.Method == http.MethodPatch:
+			atomic.AddInt32(&updateCalls, 1)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{}`))
+		case r.Method == http.MethodGet:
+			atomic.AddInt32(&readCalls, 1)
+			resp := CredentialResponse{CredentialName: "conflict-test", CredentialInfo: map[string]interface{}{}}
+			body, _ := json.Marshal(resp)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write(body)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key", true)
+	d := schema.TestResourceDataRaw(t, resourceLiteLLMCredential().Schema, map[string]interface{}{
+		"credential_name":   "conflict-test",
+		"credential_info":   map[string]interface{}{},
+		"credential_values": map[string]interface{}{"key": "val"},
+	})
+
+	if err := resourceLiteLLMCredentialCreate(d, client); err != nil {
+		t.Fatalf("expected create to adopt the existing credential, got error: %v", err)
+	}
+	if d.Id() != "conflict-test" {
+		t.Fatalf("expected ID %q, got %q", "conflict-test", d.Id())
+	}
+	if atomic.LoadInt32(&createCalls) != 1 {
+		t.Fatalf("expected exactly 1 POST /credentials call, got %d", createCalls)
+	}
+	if atomic.LoadInt32(&updateCalls) != 1 {
+		t.Fatalf("expected the conflict to trigger exactly 1 PATCH (adopt-and-update), got %d", updateCalls)
+	}
+	if atomic.LoadInt32(&readCalls) < 1 {
+		t.Fatalf("expected the post-adopt retry read to run at least once, got %d", readCalls)
+	}
+}

--- a/terraform/provider/litellm/resource_credential_crud_test.go
+++ b/terraform/provider/litellm/resource_credential_crud_test.go
@@ -226,6 +226,9 @@ func conflictServer(t *testing.T, patchStatus int, patchBody string) (*httptest.
 			w.WriteHeader(patchStatus)
 			w.Write([]byte(patchBody))
 		case r.Method == http.MethodGet:
+			if r.URL.Path != "/credentials/by_name/conflict-test" || r.URL.Query().Get("model_id") != "model-1" {
+				t.Errorf("GET went to %q (query %q), want /credentials/by_name/conflict-test?model_id=model-1", r.URL.Path, r.URL.RawQuery)
+			}
 			resp := CredentialResponse{CredentialName: "conflict-test", CredentialInfo: map[string]interface{}{}}
 			body, _ := json.Marshal(resp)
 			w.Header().Set("Content-Type", "application/json")

--- a/terraform/provider/litellm/resource_credential_crud_test.go
+++ b/terraform/provider/litellm/resource_credential_crud_test.go
@@ -3,6 +3,7 @@ package litellm
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
@@ -200,11 +201,13 @@ func TestRetryCredentialRead_ConnectionError(t *testing.T) {
 	fmt.Printf("connection error (expected): %v\n", err)
 }
 
-// A credential that already exists in LiteLLM (created out of band, or left
-// behind by a prior apply that dropped state) must be adopted on create
-// instead of failing on the credential_name unique-constraint conflict.
-func TestResourceLiteLLMCredentialCreate_AdoptsOnConflict(t *testing.T) {
-	var createCalls, updateCalls, readCalls int32
+// conflictServer builds the shared conflict-then-recover mock used by the
+// adoption tests below. patchStatus/patchBody control the PATCH response, so
+// callers can exercise both the success and failure paths.
+func conflictServer(t *testing.T, patchStatus int, patchBody string) (*httptest.Server, *int32, *int32, *[]byte) {
+	t.Helper()
+	var createCalls, patchCalls int32
+	var capturedPatchBody []byte
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodPost && r.URL.Path == "/credentials":
@@ -213,12 +216,16 @@ func TestResourceLiteLLMCredentialCreate_AdoptsOnConflict(t *testing.T) {
 			w.WriteHeader(http.StatusInternalServerError)
 			w.Write([]byte(`{"error":{"message":"Unique constraint failed on the fields: (` + "`credential_name`" + `)","type":"internal_server_error","code":"500"}}`))
 		case r.Method == http.MethodPatch:
-			atomic.AddInt32(&updateCalls, 1)
+			atomic.AddInt32(&patchCalls, 1)
+			if r.URL.Path != "/credentials/conflict-test" {
+				t.Errorf("PATCH went to %q, want /credentials/conflict-test", r.URL.Path)
+			}
+			body, _ := io.ReadAll(r.Body)
+			capturedPatchBody = body
 			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{}`))
+			w.WriteHeader(patchStatus)
+			w.Write([]byte(patchBody))
 		case r.Method == http.MethodGet:
-			atomic.AddInt32(&readCalls, 1)
 			resp := CredentialResponse{CredentialName: "conflict-test", CredentialInfo: map[string]interface{}{}}
 			body, _ := json.Marshal(resp)
 			w.Header().Set("Content-Type", "application/json")
@@ -228,6 +235,61 @@ func TestResourceLiteLLMCredentialCreate_AdoptsOnConflict(t *testing.T) {
 			http.NotFound(w, r)
 		}
 	}))
+	return srv, &createCalls, &patchCalls, &capturedPatchBody
+}
+
+// A credential that already exists in LiteLLM (created out of band, or left
+// behind by a prior apply that dropped state) must be adopted on create
+// instead of failing on the credential_name unique-constraint conflict, and
+// the adopt PATCH must carry model_id so model-based credential resolution
+// still applies (previously dropped - see
+// https://github.com/BerriAI/litellm/pull/39745).
+func TestResourceLiteLLMCredentialCreate_AdoptsOnConflict(t *testing.T) {
+	srv, createCalls, patchCalls, patchBody := conflictServer(t, http.StatusOK, `{}`)
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key", true)
+	d := schema.TestResourceDataRaw(t, resourceLiteLLMCredential().Schema, map[string]interface{}{
+		"credential_name":   "conflict-test",
+		"model_id":          "model-1",
+		"credential_info":   map[string]interface{}{"custom_llm_provider": "bedrock"},
+		"credential_values": map[string]interface{}{"aws_access_key_id": "val"},
+	})
+
+	if err := resourceLiteLLMCredentialCreate(d, client); err != nil {
+		t.Fatalf("expected create to adopt the existing credential, got error: %v", err)
+	}
+	if d.Id() != "conflict-test" {
+		t.Fatalf("expected ID %q, got %q", "conflict-test", d.Id())
+	}
+	if got := atomic.LoadInt32(createCalls); got != 1 {
+		t.Fatalf("expected exactly 1 POST /credentials call, got %d", got)
+	}
+	if got := atomic.LoadInt32(patchCalls); got != 1 {
+		t.Fatalf("expected the conflict to trigger exactly 1 PATCH (adopt-and-update), got %d", got)
+	}
+
+	var sent map[string]interface{}
+	if err := json.Unmarshal(*patchBody, &sent); err != nil {
+		t.Fatalf("PATCH body was not valid JSON: %v (%s)", err, *patchBody)
+	}
+	if sent["credential_name"] != "conflict-test" {
+		t.Errorf("PATCH body credential_name = %v, want conflict-test", sent["credential_name"])
+	}
+	if sent["model_id"] != "model-1" {
+		t.Errorf("PATCH body model_id = %v, want model-1 (adoption must not drop model-based credential resolution)", sent["model_id"])
+	}
+	credInfo, _ := sent["credential_info"].(map[string]interface{})
+	if credInfo["custom_llm_provider"] != "bedrock" {
+		t.Errorf("PATCH body credential_info = %v, want custom_llm_provider=bedrock", sent["credential_info"])
+	}
+}
+
+// If the adopt PATCH itself fails, create must not have set the resource ID
+// for a credential this run doesn't own - otherwise Terraform taints the
+// entry and the *next* apply destroys a credential nobody here created.
+func TestResourceLiteLLMCredentialCreate_FailedAdoptDoesNotTaint(t *testing.T) {
+	srv, createCalls, patchCalls, _ := conflictServer(t, http.StatusInternalServerError, `{"error":{"message":"Internal Server Error"}}`)
 	defer srv.Close()
 
 	client := NewClient(srv.URL, "test-key", true)
@@ -237,19 +299,57 @@ func TestResourceLiteLLMCredentialCreate_AdoptsOnConflict(t *testing.T) {
 		"credential_values": map[string]interface{}{"key": "val"},
 	})
 
-	if err := resourceLiteLLMCredentialCreate(d, client); err != nil {
-		t.Fatalf("expected create to adopt the existing credential, got error: %v", err)
+	err := resourceLiteLLMCredentialCreate(d, client)
+	if err == nil {
+		t.Fatal("expected an error when the adopt PATCH fails, got nil")
 	}
-	if d.Id() != "conflict-test" {
-		t.Fatalf("expected ID %q, got %q", "conflict-test", d.Id())
+	if got := atomic.LoadInt32(createCalls); got != 1 {
+		t.Fatalf("expected exactly 1 POST /credentials call, got %d", got)
 	}
-	if atomic.LoadInt32(&createCalls) != 1 {
-		t.Fatalf("expected exactly 1 POST /credentials call, got %d", createCalls)
+	if got := atomic.LoadInt32(patchCalls); got != 1 {
+		t.Fatalf("expected exactly 1 PATCH attempt, got %d", got)
 	}
-	if atomic.LoadInt32(&updateCalls) != 1 {
-		t.Fatalf("expected the conflict to trigger exactly 1 PATCH (adopt-and-update), got %d", updateCalls)
+	if d.Id() != "" {
+		t.Fatalf("resource ID must stay empty after a failed adopt, got %q (a tainted entry would be destroyed on the next apply)", d.Id())
 	}
-	if atomic.LoadInt32(&readCalls) < 1 {
-		t.Fatalf("expected the post-adopt retry read to run at least once, got %d", readCalls)
+}
+
+// A non-conflict failure (a plain 500, for example) must return the original
+// error and never attempt to adopt anything.
+func TestResourceLiteLLMCredentialCreate_NonConflictErrorDoesNotAdopt(t *testing.T) {
+	var createCalls, patchCalls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/credentials":
+			atomic.AddInt32(&createCalls, 1)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(`{"error":{"message":"Internal Server Error","type":"internal_server_error"}}`))
+		case r.Method == http.MethodPatch:
+			atomic.AddInt32(&patchCalls, 1)
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key", true)
+	d := schema.TestResourceDataRaw(t, resourceLiteLLMCredential().Schema, map[string]interface{}{
+		"credential_name":   "some-cred",
+		"credential_info":   map[string]interface{}{},
+		"credential_values": map[string]interface{}{"key": "val"},
+	})
+
+	err := resourceLiteLLMCredentialCreate(d, client)
+	if err == nil {
+		t.Fatal("expected an error for a non-conflict failure, got nil")
+	}
+	if got := atomic.LoadInt32(&patchCalls); got != 0 {
+		t.Fatalf("expected no PATCH attempt for a non-conflict error, got %d", got)
+	}
+	if d.Id() != "" {
+		t.Fatalf("resource ID must stay empty on a non-conflict failure, got %q", d.Id())
 	}
 }

--- a/terraform/provider/litellm/utils.go
+++ b/terraform/provider/litellm/utils.go
@@ -202,6 +202,28 @@ func isCredentialNotFoundError(errResp ErrorResponse) bool {
 	return false
 }
 
+// isCredentialConflictError checks if the error response indicates a credential
+// name collision. LiteLLM surfaces this as a 500 carrying the underlying Prisma
+// unique-constraint message on credential_name. See
+// https://github.com/BerriAI/terraform-provider-litellm/issues/8.
+func isCredentialConflictError(errResp ErrorResponse) bool {
+	if msg, ok := errResp.Error.Message.(string); ok {
+		if strings.Contains(msg, "Unique constraint failed") && strings.Contains(msg, "credential_name") {
+			return true
+		}
+	}
+
+	if msgMap, ok := errResp.Error.Message.(map[string]interface{}); ok {
+		if errStr, ok := msgMap["error"].(string); ok {
+			if strings.Contains(errStr, "Unique constraint failed") && strings.Contains(errStr, "credential_name") {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
 // handleCredentialAPIResponse handles API responses specifically for credential operations
 func handleCredentialAPIResponse(resp *http.Response, result interface{}, client *Client) error {
 	bodyBytes, err := io.ReadAll(resp.Body)
@@ -218,6 +240,9 @@ func handleCredentialAPIResponse(resp *http.Response, result interface{}, client
 		if err := json.Unmarshal(bodyBytes, &errResp); err == nil {
 			if isCredentialNotFoundError(errResp) {
 				return fmt.Errorf("credential_not_found")
+			}
+			if isCredentialConflictError(errResp) {
+				return fmt.Errorf("credential_conflict")
 			}
 		}
 		return fmt.Errorf("API request failed: Status: %s, Response: %s",

--- a/terraform/provider/litellm/utils.go
+++ b/terraform/provider/litellm/utils.go
@@ -221,6 +221,13 @@ func isCredentialConflictError(errResp ErrorResponse) bool {
 		}
 	}
 
+	// Check Detail.Error field for LiteLLM proxy error format
+	if errResp.Detail.Error != "" {
+		if strings.Contains(errResp.Detail.Error, "Unique constraint failed") && strings.Contains(errResp.Detail.Error, "credential_name") {
+			return true
+		}
+	}
+
 	return false
 }
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- `litellm_credential` create 500s when a credential of that name already exists
- Lost or dropped Terraform state can never re-adopt that credential

How it solves it:

- Detects the `credential_name` unique-constraint conflict returned by create
- Adopts the existing credential and updates it to match config instead of erroring
- The resource ID only sticks once that adopt update actually succeeds, and the adopt request now carries `model_id` so model-based credential resolution isn't skipped (both fixed after review - see Caveats)

## User Flow

Before: an operator applying Terraform over a credential that already exists in LiteLLM gets a hard failure instead of taking ownership of it

1. They configure a `litellm_credential` resource named `aws_bedrock` and run `terraform apply`
2. Terraform sends `POST http://localhost:4000/credentials` with `credential_name: "aws_bedrock"`
3. A credential named `aws_bedrock` already exists (created out of band, or left behind after a `terraform state rm`), so the proxy returns `500 Internal Server Error` with `Unique constraint failed on the fields: (credential_name)`
4. `terraform apply` aborts with `Error: failed to create credential: ...Unique constraint failed...`, and the operator has no supported way to make the apply succeed short of deleting the credential first

After: the same apply takes ownership of the existing credential and finishes cleanly

1. They configure the same `litellm_credential` resource named `aws_bedrock` and run `terraform apply`
2. Terraform sends the same `POST http://localhost:4000/credentials`, gets the same conflict back, but now follows up with `PATCH http://localhost:4000/credentials/aws_bedrock` carrying the configured values
3. `terraform apply` reports `litellm_credential.aws_bedrock: Creation complete [id=aws_bedrock]`
4. Running `terraform apply` again reports `No changes. Your infrastructure matches the configuration.`

## Relevant issues

Fixes https://github.com/BerriAI/terraform-provider-litellm/issues/8

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, `go test ./...` (ran the full `terraform/provider` suite, all green)
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Shared setup: `ghcr.io/berriai/litellm-database:v1.87.1`, Postgres 16, Terraform v1.13.4, one configured model so `model_id`-based resolution has something real to resolve against. Local provider build installed at the commit named in each heading.

### Before (c8635ecc67bb)

1. Ran `terraform apply` — created `litellm_credential.conflict_test` (`credential_name = "conflict-test"`): `Creation complete after 0s [id=conflict-test]`
2. Ran `terraform state rm litellm_credential.conflict_test` (credential still exists in LiteLLM, now untracked in state)
3. Ran `terraform apply` again on the same unfixed binary:
   ```
   Error: failed to create credential: API request failed: Status: 500 Internal Server Error, Response: {"error":{"code":"500","message":"Unique constraint failed on the fields: (`credential_name`)","param":"None","type":"internal_server_error"}}
   ```

### After (d0fb841c8480)

1. Ran `terraform apply` creating `litellm_credential.conflict_test` with `model_id` set to a real model's internal ID: `Creation complete after 0s [id=conflict-test-v2]`
2. Ran `terraform state rm` (credential still exists in LiteLLM, still associated with that `model_id`, now untracked in state)
3. Ran `terraform apply` again: `Creation complete after 0s [id=conflict-test-v2]` - no error. Proxy logs confirm the full sequence: `POST /credentials` → 500 (conflict) → `PATCH /credentials/conflict-test-v2` → 200 → `GET /credentials/by_name/conflict-test-v2?model_id=<id>` → 200, proving `model_id` traveled with the adopt PATCH instead of being dropped
4. Ran `terraform apply` again: `No changes. Your infrastructure matches the configuration.` - idempotent

## Type

🐛 Bug Fix
✅ Test

## Caveats (if any)

### Medium

- Adopts (and overwrites) an existing credential of the same name rather than refusing outright; `terraform import` remains available for explicit adoption instead
- The adopt update merges onto whatever the existing credential already had rather than fully replacing it, and `credential_values` is intentionally never read back into state; a field present out-of-band but absent from config can persist invisibly

### Fixed after initial review

Greptile flagged two real gaps in the first version of this PR, both fixed in the current commit: the resource ID was set before the adopt update could fail, which would have tainted state for a credential this run doesn't own and destroyed it on the next apply; and the adopt path dropped `model_id`, skipping the proxy's model-based credential resolution. Both now have dedicated regression tests and were re-verified end-to-end against a live proxy.

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR