### PR TITLE
fix(proxy): hydrate cached key end-user rate limits

### DIFF
--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -2595,6 +2595,18 @@ async def _run_centralized_common_checks(
     end_user_object: Final[LiteLLM_EndUserTable | None] = (
         None if isinstance(end_user_result, BaseException) else end_user_result
     )
+    if user_api_key_auth_obj.end_user_id is not None and end_user_object is not None:
+        end_user_params: Final = {"end_user_id": user_api_key_auth_obj.end_user_id}
+        if end_user_object.litellm_budget_table is not None:
+            _apply_budget_limits_to_end_user_params(
+                end_user_params=end_user_params,
+                budget_info=end_user_object.litellm_budget_table,
+                end_user_id=user_api_key_auth_obj.end_user_id,
+            )
+        update_valid_token_with_end_user_params(
+            valid_token=user_api_key_auth_obj,
+            end_user_params=end_user_params,
+        )
     global_proxy_spend: float | None = None if isinstance(global_spend_result, BaseException) else global_spend_result
 
     if user_api_key_auth_obj.org_id is None and team_object is not None and team_object.organization_id is not None:

--- a/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
+++ b/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
@@ -4247,6 +4247,73 @@ async def test_centralized_common_checks_propagates_end_user_budget_error():
 
 
 @pytest.mark.asyncio
+async def test_centralized_checks_hydrates_cached_key_end_user_rate_limits():
+    """A cached virtual key must carry its customer's budget rate limits into the limiter."""
+    import litellm.proxy.proxy_server as _proxy_server_mod
+
+    token = UserAPIKeyAuth(api_key="sk-test", end_user_id="customer-1")
+    end_user_object = LiteLLM_EndUserTable(
+        user_id="customer-1",
+        blocked=False,
+        spend=0.0,
+        litellm_budget_table=LiteLLM_BudgetTable(rpm_limit=5, tpm_limit=20),
+    )
+    attrs = _proxy_attrs_for_centralized_checks(user_custom_auth=None)
+    originals = {a: getattr(_proxy_server_mod, a, None) for a in attrs}
+    try:
+        for k, v in attrs.items():
+            setattr(_proxy_server_mod, k, v)
+        with (
+            patch(
+                "litellm.proxy.auth.user_api_key_auth.get_end_user_object",
+                new_callable=AsyncMock,
+                return_value=end_user_object,
+            ),
+            patch(
+                "litellm.proxy.auth.user_api_key_auth.common_checks",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "litellm.proxy.auth.user_api_key_auth._reserve_budget_after_common_checks",
+                new_callable=AsyncMock,
+            ),
+        ):
+            await _run_centralized_common_checks(
+                user_api_key_auth_obj=token,
+                request=_chat_request(),
+                request_data={"model": "gpt-4o-mini", "user": "customer-1"},
+                route="/chat/completions",
+            )
+    finally:
+        for k, v in originals.items():
+            setattr(_proxy_server_mod, k, v)
+
+    assert token.end_user_rpm_limit == 5
+    assert token.end_user_tpm_limit == 20
+
+    from litellm.caching.caching import DualCache
+    from litellm.proxy.hooks.parallel_request_limiter_v3 import (
+        _PROXY_MaxParallelRequestsHandler_v3,
+    )
+    from litellm.proxy.utils import InternalUsageCache
+
+    limiter = _PROXY_MaxParallelRequestsHandler_v3(
+        internal_usage_cache=InternalUsageCache(DualCache())
+    )
+    descriptors = limiter._create_rate_limit_descriptors(
+        user_api_key_dict=token,
+        data={"model": "gpt-4o-mini"},
+        rpm_limit_type=None,
+        tpm_limit_type=None,
+        model_has_failures=False,
+    )
+    end_user_descriptor = next(descriptor for descriptor in descriptors if descriptor["key"] == "end_user")
+    assert end_user_descriptor["value"] == "customer-1"
+    assert end_user_descriptor["rate_limit"]["requests_per_unit"] == 5
+    assert end_user_descriptor["rate_limit"]["tokens_per_unit"] == 20
+
+
+@pytest.mark.asyncio
 async def test_centralized_common_checks_reserves_request_end_user_budget():
     """Regression: reservation runs before user_api_key_auth() copies the
     request end-user onto the token, so centralized checks must pass the


### PR DESCRIPTION
## TLDR

Problem this solves:

- Cached virtual keys lose customer RPM and TPM limits

How it solves it:

- Hydrates the authenticated key from the customer budget before limiting

## User Flow

Before: a proxy admin sets a per-customer request limit, but a cached key keeps serving requests above that limit

1. The app sends POST https://litellm-domain/v1/chat/completions using a shared virtual key and `"user": "customer-1"`
2. The customer budget has `rpm_limit: 5`
3. Requests after the first cache fill are accepted without the customer limit

After: the same cached-key request carries the customer limit into rate limiting

1. The app sends the same POST request with `"user": "customer-1"`
2. The customer budget still has `rpm_limit: 5`
3. Requests above the configured per-customer limit are rejected

## Relevant issues

Fixes #39713

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The focused auth tests pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR is isolated to this proxy rate-limit bug
- [ ] I have received a Greptile Confidence Score of at least 4/5

## Screenshots / Proof of Fix

Focused provider-free tests cover cached-key hydration and the v3 end-user descriptor. Live provider-backed proxy proof remains to be added before review

## Type

🐛 Bug Fix

## Final Attestation

- [x] The regression test proves customer RPM and TPM limits reach the v3 limiter for a cached key