### PR TITLE
fix(key): recover from a cascade-deleted key instead of forcing every team_id change (#12)

### DIFF
--- a/terraform/provider/CHANGELOG.md
+++ b/terraform/provider/CHANGELOG.md
@@ -36,7 +36,7 @@ longer signal it.
 
 ### Fixed
 
-- **key**: `team_id` is now `ForceNew`; changing a key's team replaces the key instead of issuing an in-place update against a token already cascade-deleted along with its old team
+- **key**: an update that changes `team_id` and 404s because the key was already cascade-deleted along with its previous team now recovers by recreating the key under the new team, instead of failing outright. A `team_id` change between two teams that both still exist, or drift correction on a key that still exists, both remain a plain in-place update - unaffected
 - **team**: Read now decodes the `team_info` envelope `/team/info` actually returns, so team attributes refresh from the proxy instead of always falling back to the prior state
 - **key**: Read now unwraps the `info` envelope `/key/info` actually returns; previously reads mapped nothing back into state, so drift on a key was never detected
 - **key**: Updates no longer send an empty `budget_duration`, which the proxy rejects with a 400; any update to a key without a configured `budget_duration` previously failed outright

--- a/terraform/provider/CHANGELOG.md
+++ b/terraform/provider/CHANGELOG.md
@@ -36,6 +36,7 @@ longer signal it.
 
 ### Fixed
 
+- **key**: `team_id` is now `ForceNew`; changing a key's team replaces the key instead of issuing an in-place update against a token already cascade-deleted along with its old team
 - **team**: Read now decodes the `team_info` envelope `/team/info` actually returns, so team attributes refresh from the proxy instead of always falling back to the prior state
 - **key**: Read now unwraps the `info` envelope `/key/info` actually returns; previously reads mapped nothing back into state, so drift on a key was never detected
 - **key**: Updates no longer send an empty `budget_duration`, which the proxy rejects with a 400; any update to a key without a configured `budget_duration` previously failed outright

--- a/terraform/provider/litellm/resource_key.go
+++ b/terraform/provider/litellm/resource_key.go
@@ -46,6 +46,12 @@ func resourceKey() *schema.Resource {
 			"team_id": {
 				Type:     schema.TypeString,
 				Optional: true,
+				// A LiteLLM key belongs to a team. Deleting/recreating the team
+				// cascade-deletes its keys, so changing team_id must replace the
+				// key (in dependency order) rather than issue an in-place update
+				// against a token that no longer exists. See
+				// https://github.com/BerriAI/terraform-provider-litellm/issues/12.
+				ForceNew: true,
 			},
 			"max_parallel_requests": {
 				Type:     schema.TypeInt,

--- a/terraform/provider/litellm/resource_key.go
+++ b/terraform/provider/litellm/resource_key.go
@@ -148,12 +148,12 @@ func resourceKey() *schema.Resource {
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-			"allowed_routes": {
+			"allowed_passthrough_routes": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-			"allowed_passthrough_routes": {
+			"allowed_routes": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
@@ -241,9 +241,12 @@ func resourceKeyUpdate(ctx context.Context, d *schema.ResourceData, m interface{
 		// cascade-deletes its keys. If team_id is what changed and the update
 		// 404s because the key itself is already gone, there is nothing left
 		// to update - recreate it fresh under the new team instead of failing.
-		// Scoped to a team_id change specifically, so an unrelated update
-		// against a key that vanished for some other reason still fails
-		// loudly rather than being silently "fixed". See
+		// Gated on a team_id change so a plain update against a key gone for
+		// an unrelated reason still fails loudly. That gate can't fully tell
+		// "gone because of this team_id's own cascade" apart from "gone for
+		// an unrelated reason, coincidentally alongside a team_id edit in the
+		// same apply" - the latter also recovers here, same as the previous
+		// unconditional-ForceNew behavior did for every team_id change. See
 		// https://github.com/BerriAI/terraform-provider-litellm/issues/12.
 		if d.HasChange("team_id") && isKeyUpdateNotFoundError(err) {
 			log.Printf("[WARN] Key %q no longer exists (likely cascade-deleted along with its previous team); recreating under the new team_id.", d.Id())
@@ -256,9 +259,11 @@ func resourceKeyUpdate(ctx context.Context, d *schema.ResourceData, m interface{
 }
 
 // isKeyUpdateNotFoundError reports whether err is the specific error
-// /key/update returns when the key no longer exists. Client.UpdateKey wraps
-// Client.sendRequest's plain formatted error rather than a typed one, so
-// match on it the same way the credential helpers in utils.go match theirs.
+// /key/update returns when the key no longer exists. Unlike the credential
+// helpers in utils.go, which match against a parsed ErrorResponse because
+// handleCredentialAPIResponse unmarshals the body first, Client.sendRequest
+// (which UpdateKey uses) never parses its error body - it returns a plain
+// formatted string - so this matches on that string directly instead.
 func isKeyUpdateNotFoundError(err error) bool {
 	if err == nil {
 		return false

--- a/terraform/provider/litellm/resource_key.go
+++ b/terraform/provider/litellm/resource_key.go
@@ -3,6 +3,8 @@ package litellm
 import (
 	"context"
 	"fmt"
+	"log"
+	"strings"
 
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -46,12 +48,6 @@ func resourceKey() *schema.Resource {
 			"team_id": {
 				Type:     schema.TypeString,
 				Optional: true,
-				// A LiteLLM key belongs to a team. Deleting/recreating the team
-				// cascade-deletes its keys, so changing team_id must replace the
-				// key (in dependency order) rather than issue an in-place update
-				// against a token that no longer exists. See
-				// https://github.com/BerriAI/terraform-provider-litellm/issues/12.
-				ForceNew: true,
 			},
 			"max_parallel_requests": {
 				Type:     schema.TypeInt,
@@ -241,10 +237,34 @@ func resourceKeyUpdate(ctx context.Context, d *schema.ResourceData, m interface{
 
 	_, err := c.UpdateKey(key)
 	if err != nil {
+		// A LiteLLM key belongs to a team, and deleting/recreating the team
+		// cascade-deletes its keys. If team_id is what changed and the update
+		// 404s because the key itself is already gone, there is nothing left
+		// to update - recreate it fresh under the new team instead of failing.
+		// Scoped to a team_id change specifically, so an unrelated update
+		// against a key that vanished for some other reason still fails
+		// loudly rather than being silently "fixed". See
+		// https://github.com/BerriAI/terraform-provider-litellm/issues/12.
+		if d.HasChange("team_id") && isKeyUpdateNotFoundError(err) {
+			log.Printf("[WARN] Key %q no longer exists (likely cascade-deleted along with its previous team); recreating under the new team_id.", d.Id())
+			return resourceKeyCreate(ctx, d, m)
+		}
 		return diag.FromErr(fmt.Errorf("error updating key: %s", err))
 	}
 
 	return resourceKeyRead(ctx, d, m)
+}
+
+// isKeyUpdateNotFoundError reports whether err is the specific error
+// /key/update returns when the key no longer exists. Client.UpdateKey wraps
+// Client.sendRequest's plain formatted error rather than a typed one, so
+// match on it the same way the credential helpers in utils.go match theirs.
+func isKeyUpdateNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "404") && strings.Contains(msg, "Key not found")
 }
 
 func resourceKeyDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/terraform/provider/litellm/resource_key_test.go
+++ b/terraform/provider/litellm/resource_key_test.go
@@ -254,3 +254,17 @@ func TestGetKeyUnwrapsInfoEnvelope(t *testing.T) {
 		t.Errorf("RPMLimit not parsed: %+v", key.RPMLimit)
 	}
 }
+
+// A LiteLLM key belongs to a team, and deleting/recreating the team
+// cascade-deletes its keys. team_id must be ForceNew so a team change
+// replaces the key (in dependency order) instead of updating a token that
+// no longer exists.
+func TestResourceKeyTeamIDForcesNew(t *testing.T) {
+	s, ok := resourceKey().Schema["team_id"]
+	if !ok {
+		t.Fatal("resourceKey().Schema has no team_id attribute")
+	}
+	if !s.ForceNew {
+		t.Fatal("team_id must be ForceNew=true; an in-place update targets a key already cascade-deleted with its old team")
+	}
+}

--- a/terraform/provider/litellm/resource_key_test.go
+++ b/terraform/provider/litellm/resource_key_test.go
@@ -3,12 +3,15 @@ package litellm
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func newKeyResourceData(t *testing.T, raw map[string]interface{}) *schema.ResourceData {
@@ -255,16 +258,202 @@ func TestGetKeyUnwrapsInfoEnvelope(t *testing.T) {
 	}
 }
 
-// A LiteLLM key belongs to a team, and deleting/recreating the team
-// cascade-deletes its keys. team_id must be ForceNew so a team change
-// replaces the key (in dependency order) instead of updating a token that
-// no longer exists.
-func TestResourceKeyTeamIDForcesNew(t *testing.T) {
-	s, ok := resourceKey().Schema["team_id"]
-	if !ok {
-		t.Fatal("resourceKey().Schema has no team_id attribute")
+// newKeyUpdateResourceData builds a *schema.ResourceData reflecting a real
+// state -> config diff for team_id (unlike schema.TestResourceDataRaw, which
+// has no notion of prior state), so d.HasChange("team_id") behaves the same
+// way it does during a real Update call.
+func newKeyUpdateResourceData(t *testing.T, id, oldTeamID, newTeamID string) *schema.ResourceData {
+	t.Helper()
+
+	oldState := &terraform.InstanceState{
+		ID: id,
+		Attributes: map[string]string{
+			"team_id": oldTeamID,
+		},
 	}
-	if !s.ForceNew {
-		t.Fatal("team_id must be ForceNew=true; an in-place update targets a key already cascade-deleted with its old team")
+
+	d, err := schema.InternalMap(resourceKey().Schema).Data(oldState, &terraform.InstanceDiff{
+		Attributes: map[string]*terraform.ResourceAttrDiff{
+			"team_id": {Old: oldTeamID, New: newTeamID},
+		},
+	})
+	if err != nil {
+		t.Fatalf("schema.InternalMap(...).Data returned error: %v", err)
+	}
+	return d
+}
+
+func TestIsKeyUpdateNotFoundError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil error", nil, false},
+		{"exact proxy message", fmt.Errorf(`API request failed with status code 404: {"error":{"message":"Key not found.","type":"not_found_error","param":"key","code":"404"}}`), true},
+		{"different 404 message", fmt.Errorf(`API request failed with status code 404: {"error":{"message":"Model not found.","type":"not_found_error"}}`), false},
+		{"500 error", fmt.Errorf(`API request failed with status code 500: {"error":{"message":"Internal Server Error"}}`), false},
+		{"connection error, no status code", fmt.Errorf("error making request: connection refused"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isKeyUpdateNotFoundError(tc.err); got != tc.want {
+				t.Errorf("isKeyUpdateNotFoundError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// Reassigning a key between two teams that both still exist is a working
+// in-place /key/update; a team_id change must not force a destroy/recreate
+// when the update actually succeeds.
+func TestResourceKeyUpdate_TeamReassignmentStaysInPlace(t *testing.T) {
+	var generateCalls, updateCalls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/key/generate":
+			atomic.AddInt32(&generateCalls, 1)
+			w.Write([]byte(`{"key": "sk-new", "token_id": "new-token"}`))
+		case "/key/update":
+			atomic.AddInt32(&updateCalls, 1)
+			w.Write([]byte(`{"key": "hash-1"}`))
+		case "/key/info":
+			w.Write([]byte(`{"key": "hash-1", "info": {"team_id": "team-b"}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key", true)
+	d := newKeyUpdateResourceData(t, "hash-1", "team-a", "team-b")
+
+	diags := resourceKeyUpdate(context.Background(), d, client)
+	if diags.HasError() {
+		t.Fatalf("update returned error: %v", diags)
+	}
+	if got := atomic.LoadInt32(&updateCalls); got != 1 {
+		t.Errorf("expected exactly 1 POST /key/update call, got %d", got)
+	}
+	if got := atomic.LoadInt32(&generateCalls); got != 0 {
+		t.Errorf("expected no /key/generate call for a benign team reassignment, got %d", got)
+	}
+	if d.Id() != "hash-1" {
+		t.Errorf("resource ID changed unexpectedly: got %q, want hash-1", d.Id())
+	}
+}
+
+// When the key was already cascade-deleted along with its old team,
+// /key/update 404s; the update must recover by recreating the key under the
+// new team rather than failing outright.
+func TestResourceKeyUpdate_RecreatesWhenCascadeDeleted(t *testing.T) {
+	var generateCalls, updateCalls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/key/generate":
+			atomic.AddInt32(&generateCalls, 1)
+			w.Write([]byte(`{"key": "sk-new", "token_id": "new-token"}`))
+		case "/key/update":
+			atomic.AddInt32(&updateCalls, 1)
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"error":{"message":"Key not found.","type":"not_found_error","param":"key","code":"404"}}`))
+		case "/key/info":
+			w.Write([]byte(`{"key": "new-token", "info": {"team_id": "team-b"}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key", true)
+	d := newKeyUpdateResourceData(t, "stale-token", "team-a", "team-b")
+
+	diags := resourceKeyUpdate(context.Background(), d, client)
+	if diags.HasError() {
+		t.Fatalf("update returned error: %v", diags)
+	}
+	if got := atomic.LoadInt32(&updateCalls); got != 1 {
+		t.Errorf("expected 1 POST /key/update attempt before recovering, got %d", got)
+	}
+	if got := atomic.LoadInt32(&generateCalls); got != 1 {
+		t.Errorf("expected the cascade-delete 404 to trigger exactly 1 /key/generate recreate, got %d", got)
+	}
+	if d.Id() != "new-token" {
+		t.Errorf("expected the key to be recreated with a new ID, got %q", d.Id())
+	}
+}
+
+// A "key not found" 404 must not be swallowed when nothing about team_id
+// actually changed - an unrelated update against a key gone for some other
+// reason should still fail loudly instead of being silently "recovered".
+func TestResourceKeyUpdate_NotFoundWithoutTeamChangeFailsLoudly(t *testing.T) {
+	var generateCalls, updateCalls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/key/generate":
+			atomic.AddInt32(&generateCalls, 1)
+			w.Write([]byte(`{"key": "sk-new", "token_id": "new-token"}`))
+		case "/key/update":
+			atomic.AddInt32(&updateCalls, 1)
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"error":{"message":"Key not found.","type":"not_found_error","param":"key","code":"404"}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key", true)
+	// team_id is unchanged (old == new); some other attribute is what
+	// triggered this update.
+	d := newKeyUpdateResourceData(t, "gone-token", "team-a", "team-a")
+
+	diags := resourceKeyUpdate(context.Background(), d, client)
+	if !diags.HasError() {
+		t.Fatal("expected an error when team_id did not change, got none")
+	}
+	if got := atomic.LoadInt32(&generateCalls); got != 0 {
+		t.Errorf("expected no recreate attempt when team_id is unchanged, got %d /key/generate calls", got)
+	}
+	if d.Id() != "gone-token" {
+		t.Errorf("resource ID should be untouched on a hard failure, got %q", d.Id())
+	}
+}
+
+// A non-"key not found" failure (a generic 500, for example) must never
+// trigger the recovery path, matched or not to a team_id change.
+func TestResourceKeyUpdate_NonMatchingErrorDoesNotRecreate(t *testing.T) {
+	var generateCalls, updateCalls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/key/generate":
+			atomic.AddInt32(&generateCalls, 1)
+			w.Write([]byte(`{"key": "sk-new", "token_id": "new-token"}`))
+		case "/key/update":
+			atomic.AddInt32(&updateCalls, 1)
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(`{"error":{"message":"Internal Server Error","type":"internal_server_error"}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key", true)
+	d := newKeyUpdateResourceData(t, "hash-1", "team-a", "team-b")
+
+	diags := resourceKeyUpdate(context.Background(), d, client)
+	if !diags.HasError() {
+		t.Fatal("expected an error for a non-'key not found' failure, got none")
+	}
+	if got := atomic.LoadInt32(&generateCalls); got != 0 {
+		t.Errorf("expected no recreate attempt for an unrelated error, got %d /key/generate calls", got)
+	}
+	if d.Id() != "hash-1" {
+		t.Errorf("resource ID should be untouched on a hard failure, got %q", d.Id())
 	}
 }


### PR DESCRIPTION
## TLDR

Problem this solves:

- Recreating a team leaves its keys pointed at a team that no longer exists
- `terraform apply` fails outright instead of moving the key to the new team

How it solves it:

- Attempts the normal in-place `/key/update` first, same as any other field
- Only when that 404s because the key was cascade-deleted with its old team, and `team_id` is what changed, recovers by recreating the key under the new team
- Every currently-working case (reassigning a key between two live teams, drift correction on a key that still exists) is untouched - only the previously-hard-failing case now succeeds

**Note:** this replaces an earlier version of this PR that made `team_id` unconditionally `ForceNew`. Review (including Greptile) found that approach forced a destroy/recreate on cases that were never broken - see "Changed after initial review" below.

## User Flow

Before: an operator who replaces a team (forced recreation, or any change that requires it) hits a hard failure trying to keep that team's key in sync

1. They have a `litellm_team` and a `litellm_key` whose `team_id` points at it, already applied
2. They run `terraform apply -replace=litellm_team.example`
3. Terraform destroys the old team, which cascade-deletes the key on the proxy, then creates the new team
4. Terraform sends `POST http://localhost:4000/key/update` for the existing key with the new `team_id`, and the proxy returns `404` (`{"error":{"message":"Key not found.",...}}`) because that key no longer exists
5. `terraform apply` aborts with `Error: error updating key: API request failed with status code 404: ...`, leaving the key resource stuck

After: the same replacement recovers by recreating the key, and the apply finishes cleanly - with no change to the plan shape (still `~ update in place` on the key line, not `-/+ replace`)

1. They have the same `litellm_team` and `litellm_key`, already applied
2. They run the same `terraform apply -replace=litellm_team.example`
3. Terraform sends the same `POST http://localhost:4000/key/update`, gets the same `404`, but now follows up with `POST http://localhost:4000/key/generate` under the new `team_id`
4. `terraform apply` reports `Apply complete!` with no error, and a `terraform plan` immediately after shows no drift

## Relevant issues

Fixes https://github.com/BerriAI/terraform-provider-litellm/issues/12

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, `go test ./...` (ran the full `terraform/provider` suite, all green)
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Shared setup: `ghcr.io/berriai/litellm-database:v1.87.1`, Postgres 16, Terraform v1.13.4; two teams `a`/`b` and a `litellm_key` referencing one of them, local provider build installed at the commit named in each heading.

### Before (c8635ecc67bb)

#### Cascade-delete (the reported bug)

1. Ran `terraform apply` — created team `a` and a key on team `a`
2. Ran `terraform apply -replace=litellm_team.a`: the team was destroyed and recreated, then the key update failed:
   ```
   Error: error updating key: API request failed with status code 404: {"error":{"message":"Key not found.","type":"not_found_error","param":"key","code":"404"}}
   ```

### After (94a34c629bb2)

#### Benign reassignment (team `a` → team `b`, both still exist)

1. Starting from a key on team `a`, changed config to `team_id = litellm_team.b.id` and ran `terraform apply`
2. Plan showed `~ update in place` (no `ForceNew` noise); apply reported `Modifications complete`, same resource ID before and after, and a follow-up `terraform plan` showed `No changes` - confirming this case was never broken and stays a plain update

#### Cascade-delete (the reported bug)

1. Forced team `b`'s replacement: `terraform apply -replace=litellm_team.b`
2. Team `b` destroyed and recreated; the key `Modifying...` step silently recreated the key under the hood (`Modifications complete after 0s [id=<new-id>]`, a different ID than before) - no error
3. Follow-up `terraform plan`: `No changes. Your infrastructure matches the configuration.`

## Type

🐛 Bug Fix
✅ Test

## Caveats (if any)

### Medium

- When the cascade-delete recovery fires, the plan said `~ update in place` but the actual apply destroyed and recreated the key, re-minting its value. This is not visible in the plan for that specific key line - though the team's own destroy/replace, which is what triggers this, is fully visible in the same plan
- If `key` is supplied in config it's forwarded unchanged and this doesn't apply; the re-mint only affects proxy-generated values, and only when the key was already gone

### Low

- The same cascade-delete class of bug likely exists for other parent references that can be destroyed independently of the key (e.g. `organization_id`, `user_id`), not just `team_id`. Not addressed here - flagging so the same fix can be extended once a maintainer weighs in on whether they want that

### Changed after initial review

The original version of this PR made `team_id` unconditionally `ForceNew`. Greptile ("Unexpected key rotation") and independent review both found this over-broad: reassigning a key between two teams that both still exist was a working in-place update before that change, and `ForceNew` also fires on drift (not just intentional edits) - a separate fix already in this branch's history makes `team_id` drift visible for the first time, so an out-of-band team reassignment would have been "corrected" destructively on the next apply. The current version only recovers when the update actually 404s on a gone key, so neither of those previously-working cases is affected.

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR