### PR TITLE
fix(proxy): report mid-stream failures in band and terminate the stream with [DONE]

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -3644,7 +3644,7 @@ class ProxyBaseLLMRequestProcessing:
 
                 await release_budget_reservation_on_cancel(getattr(user_api_key_dict, "budget_reservation", None))
             raise
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001  # the status line is already sent; every failure must be reported in band
             verbose_proxy_logger.exception(
                 "litellm.proxy.proxy_server.async_data_generator(): Exception occured - %s", e
             )
@@ -3660,11 +3660,8 @@ class ProxyBaseLLMRequestProcessing:
                 e,
             )
 
-            # The status line is already committed by the time this generator
-            # runs, so re-raising (even an HTTPException from a guardrail) only
-            # truncates the body. Report every failure in band instead; a
-            # failure on the first chunk still surfaces with the right HTTP
-            # status because `create_response` inspects the first frame.
+            # Re-raising (even an HTTPException from a guardrail) cannot change
+            # the committed status; it only truncates the body. Report in band.
             if isinstance(e, HTTPException):
                 proxy_exception = proxy_exception_from_http_exception(e, headers={})
             else:

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -3660,15 +3660,21 @@ class ProxyBaseLLMRequestProcessing:
                 e,
             )
 
+            # The status line is already committed by the time this generator
+            # runs, so re-raising (even an HTTPException from a guardrail) only
+            # truncates the body. Report every failure in band instead; a
+            # failure on the first chunk still surfaces with the right HTTP
+            # status because `create_response` inspects the first frame.
             if isinstance(e, HTTPException):
-                raise e
-            stream_error_status: Final = _error_status_code(e, status.HTTP_500_INTERNAL_SERVER_ERROR)
-            proxy_exception: Final = ProxyException(
-                message=redact_internal_details_from_client_message(getattr(e, "message", str(e))),
-                type=_openai_error_type(e, stream_error_status),
-                param=_openai_error_param(e),
-                code=stream_error_status,
-            )
+                proxy_exception = proxy_exception_from_http_exception(e, headers={})
+            else:
+                stream_error_status: Final = _error_status_code(e, status.HTTP_500_INTERNAL_SERVER_ERROR)
+                proxy_exception = ProxyException(
+                    message=redact_internal_details_from_client_message(getattr(e, "message", str(e))),
+                    type=_openai_error_type(e, stream_error_status),
+                    param=_openai_error_param(e),
+                    code=stream_error_status,
+                )
             stream_completed = True
             yield serialize_error(proxy_exception)
         finally:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -328,6 +328,7 @@ from litellm.proxy.common_request_processing import (
     _should_return_raw_model_name,
     create_response,
     open_sse_before_first_byte,
+    sse_error_payload,
     ttft_keepalive_interval,
 )
 from litellm.proxy.common_utils.auth_cache_invalidation_pubsub import (
@@ -8870,25 +8871,34 @@ async def async_data_generator(
             e,
         )
 
+        # Only include the error message, not the traceback.
+        # The traceback is already logged above via verbose_proxy_logger.exception().
+        # Including it in the SSE response leaks internal details to clients.
+        #
+        # This generator runs after `create_response` has already committed the
+        # 200 status line, so raising here (including an HTTPException from a
+        # post-call guardrail) cannot become an HTTP error status: Starlette
+        # abandons the body iterator and the client sees a truncated stream
+        # with no error and no [DONE]. Errors are therefore always reported in
+        # band as an SSE error frame, followed by the [DONE] terminator so
+        # OpenAI-compatible clients stop reading cleanly. A failure on the very
+        # first chunk still becomes a JSON error response with the right status
+        # because `create_response` inspects the first frame for an error code.
         if isinstance(e, HTTPException):
-            raise e
-        elif isinstance(e, StreamingCallbackError):
-            error_msg = str(e)
+            _, error_obj = sse_error_payload(e)
         else:
-            # Only include the error message, not the traceback.
-            # The traceback is already logged above via verbose_proxy_logger.exception().
-            # Including it in the SSE response leaks internal details to clients.
-            error_msg = str(e)
-
-        proxy_exception: Final = ProxyException(
-            message=getattr(e, "message", error_msg),
-            type=getattr(e, "type", "None"),
-            param=getattr(e, "param", "None"),
-            code=getattr(e, "status_code", 500),
-        )
-        error_returned: Final = json.dumps({"error": proxy_exception.to_dict()})
+            proxy_exception: Final = ProxyException(
+                message=getattr(e, "message", str(e)),
+                type=getattr(e, "type", "None"),
+                param=getattr(e, "param", "None"),
+                code=getattr(e, "status_code", 500),
+            )
+            error_obj = proxy_exception.to_dict()
+        error_returned: Final = json.dumps({"error": error_obj})
         stream_completed = True
         yield f"data: {error_returned}\n\n"
+        if not request_data.get("_litellm_skip_openai_stream_done"):
+            yield "data: [DONE]\n\n"
     finally:
         await ProxyBaseLLMRequestProcessing._finalize_streaming_generator_cleanup(
             request=request,

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -8859,7 +8859,7 @@ async def async_data_generator(
         if not stream_completed:
             client_disconnected = True
         raise
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001  # the status line is already sent; every failure must be reported in band
         verbose_proxy_logger.exception("litellm.proxy.proxy_server.async_data_generator(): Exception occured - %s", e)
         await proxy_logging_obj.post_call_failure_hook(
             user_api_key_dict=user_api_key_dict,
@@ -8871,19 +8871,9 @@ async def async_data_generator(
             e,
         )
 
-        # Only include the error message, not the traceback.
-        # The traceback is already logged above via verbose_proxy_logger.exception().
-        # Including it in the SSE response leaks internal details to clients.
-        #
-        # This generator runs after `create_response` has already committed the
-        # 200 status line, so raising here (including an HTTPException from a
-        # post-call guardrail) cannot become an HTTP error status: Starlette
-        # abandons the body iterator and the client sees a truncated stream
-        # with no error and no [DONE]. Errors are therefore always reported in
-        # band as an SSE error frame, followed by the [DONE] terminator so
-        # OpenAI-compatible clients stop reading cleanly. A failure on the very
-        # first chunk still becomes a JSON error response with the right status
-        # because `create_response` inspects the first frame for an error code.
+        # Raising here (even an HTTPException from a guardrail) cannot change the
+        # committed 200; Starlette would just drop the connection. Send the
+        # sanitized error frame (message only, no traceback) and terminate.
         if isinstance(e, HTTPException):
             _, error_obj = sse_error_payload(e)
         else:

--- a/tests/test_litellm/proxy/proxy_server/test_streaming_helpers.py
+++ b/tests/test_litellm/proxy/proxy_server/test_streaming_helpers.py
@@ -683,6 +683,90 @@ async def test_async_data_generator_yields_sse_chunks_and_done(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_async_data_generator_midstream_failure_ends_with_error_frame_and_done(monkeypatch):
+    """A failure after the first chunk cannot become an HTTP status any more; the
+    client must get a sanitized error frame and then [DONE], never a bare EOF."""
+    _patch_logging_flags(monkeypatch)
+    audited = []
+
+    async def _record_failure(*, user_api_key_dict, original_exception, request_data, **kwargs):
+        audited.append(original_exception)
+
+    monkeypatch.setattr(ps.proxy_logging_obj, "post_call_failure_hook", _record_failure)
+
+    boom = RuntimeError("upstream died mid-stream")
+    out = []
+    async for line in async_data_generator(
+        response=_async_iter_raises(boom),
+        user_api_key_dict=_user_auth(),
+        request_data={"model": "gpt-4"},
+    ):
+        out.append(line)
+
+    assert audited == [boom]
+    assert isinstance(out[0], bytes)
+    assert json.loads(out[-2].removeprefix("data: "))["error"]["code"] == "500"
+    assert out[-1] == "data: [DONE]\n\n"
+
+
+@pytest.mark.asyncio
+async def test_async_data_generator_midstream_http_exception_becomes_error_frame(monkeypatch):
+    """A post-call guardrail raising HTTPException after chunks were already sent
+    used to be re-raised inside the body iterator, which Starlette turns into a
+    dropped connection: no status change, no error frame, no [DONE]. The status
+    and detail must instead travel in band."""
+    from fastapi import HTTPException
+
+    _patch_logging_flags(monkeypatch)
+
+    async def _noop_failure(*args, **kwargs):
+        pass
+
+    monkeypatch.setattr(ps.proxy_logging_obj, "post_call_failure_hook", _noop_failure)
+
+    blocked = HTTPException(
+        status_code=400,
+        detail={"error": "Content blocked: keyword 'kumquat' detected", "guardrail": "keyword-block"},
+    )
+    out = []
+    async for line in async_data_generator(
+        response=_async_iter_raises(blocked),
+        user_api_key_dict=_user_auth(),
+        request_data={"model": "gpt-4"},
+    ):
+        out.append(line)
+
+    error = json.loads(out[-2].removeprefix("data: "))["error"]
+    assert error["code"] == "400"
+    assert error["message"] == "Content blocked: keyword 'kumquat' detected"
+    assert error["provider_specific_fields"]["guardrail"] == "keyword-block"
+    assert out[-1] == "data: [DONE]\n\n"
+
+
+@pytest.mark.asyncio
+async def test_async_data_generator_midstream_failure_honors_skip_done(monkeypatch):
+    """Google GenAI ?alt=sse streams never carry [DONE]; the error path must
+    respect the same opt-out as the success path."""
+    _patch_logging_flags(monkeypatch)
+
+    async def _noop_failure(*args, **kwargs):
+        pass
+
+    monkeypatch.setattr(ps.proxy_logging_obj, "post_call_failure_hook", _noop_failure)
+
+    out = []
+    async for line in async_data_generator(
+        response=_async_iter_raises(RuntimeError("boom")),
+        user_api_key_dict=_user_auth(),
+        request_data={"model": "gemini", "_litellm_skip_openai_stream_done": True},
+    ):
+        out.append(line)
+
+    assert out[-1].startswith('data: {"error":')
+    assert "[DONE]" not in out[-1]
+
+
+@pytest.mark.asyncio
 async def test_async_data_generator_uses_response_fallback_metadata(monkeypatch):
     _patch_logging_flags(monkeypatch)
 

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -3415,6 +3415,50 @@ class TestStreamCloseOnDisconnect:
         assert "/etc/litellm/secrets/db.yaml" not in message
         assert "Traceback (most recent call last)" not in message
 
+    async def test_async_streaming_data_generator_http_exception_after_first_chunk_is_serialized(
+        self,
+    ):
+        """An HTTPException raised once chunks are already on the wire (for example a
+        post-call guardrail block) used to be re-raised out of the body iterator, which
+        the ASGI server turns into a dropped connection with no error and no terminator.
+        It has to reach serialize_error with its status and detail intact instead."""
+
+        class BlockedMidStream:
+            def __init__(self):
+                self._sent = False
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                if not self._sent:
+                    self._sent = True
+                    return {"choices": [{"delta": {"content": "partial"}}]}
+                raise HTTPException(
+                    status_code=400,
+                    detail={"error": "Content blocked: keyword 'kumquat' detected", "guardrail": "keyword-block"},
+                )
+
+        ProxyLogging._callback_capabilities_cache.clear()
+        captured: list = []
+        frames = [
+            frame
+            async for frame in ProxyBaseLLMRequestProcessing.async_streaming_data_generator(
+                response=BlockedMidStream(),
+                user_api_key_dict=ProxyUserAPIKeyAuth(api_key="sk-test"),
+                request_data={"model": "mock-model"},
+                proxy_logging_obj=ProxyLogging(user_api_key_cache=MagicMock()),
+                serialize_chunk=lambda c: "data: x\n\n",
+                serialize_error=lambda e: captured.append(e) or "data: error\n\n",
+            )
+        ]
+
+        assert frames == ["data: x\n\n", "data: error\n\n"]
+        assert len(captured) == 1
+        assert captured[0].code == "400"
+        assert captured[0].message == "Content blocked: keyword 'kumquat' detected"
+        assert captured[0].provider_specific_fields["guardrail"] == "keyword-block"
+
     @staticmethod
     def _request_that_disconnects() -> Request:
         async def receive():


### PR DESCRIPTION
## TLDR

Problem this solves:

- A mid-stream failure after chunks were sent leaves the client with a truncated 200
- `HTTPException` raised mid-stream (guardrail block) is re-raised inside the body iterator: connection drops, no error frame, no `[DONE]`
- Other mid-stream failures emit an error frame but never `[DONE]`, so OpenAI-compatible clients keep waiting or misread the end
- Clients that only read `choices[].delta` record the turn as a successful empty completion

How it solves it:

- Serialize mid-stream `HTTPException` through the existing sanitized SSE error payload instead of re-raising
- Always follow a mid-stream error frame with `data: [DONE]` (respects the Google GenAI `alt=sse` opt-out)
- Applies to both `async_data_generator` (chat completions) and `ProxyBaseLLMRequestProcessing.async_streaming_data_generator`

## User Flow

Before: a developer streaming chat completions through a proxy with a post-call guardrail gets a stream that just stops, with no error to show the user

1. They send `POST https://litellm-domain/v1/chat/completions` with `"stream": true`
2. Two `data:` chunks arrive with the first tokens
3. The guardrail blocks the response; the connection closes with `HTTP 200`, no error frame and no `data: [DONE]` (`curl: (18) transfer closed with outstanding read data remaining`)
4. Their app records an empty assistant message with `finish_reason` absent, and the user sees nothing

After: the same request ends with a readable error and a clean terminator

1. They send `POST https://litellm-domain/v1/chat/completions` with `"stream": true`
2. Two `data:` chunks arrive with the first tokens
3. A `data: {"error": {"message": "Content blocked: ...", "code": "400", ...}}` frame arrives carrying the guardrail detail
4. `data: [DONE]` arrives and the connection closes normally (`curl` exit 0); the app surfaces the error to the user

## Relevant issues

None filed; found while diagnosing empty completions behind an Open WebUI -> LiteLLM 1.98.0 -> Bedrock deployment.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally: `tests/test_litellm/proxy/proxy_server/test_streaming_helpers.py` (84 passed), `tests/test_litellm/proxy/test_common_request_processing.py` (321 passed), `tests/test_litellm/proxy/proxy_server/` (1123 passed)
- [x] `ruff check` / `ruff format --check` clean on the changed source files
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] Greptile confidence score >= 4/5

## Screenshots / Proof of Fix

Setup: local proxy pointed at a real OpenAI-compatible upstream (`openai/openai.gpt-5.6-sol`, Bedrock via another LiteLLM), with a custom post-call guardrail that lets two chunks through and then raises. Same request for every case:

```bash
curl -sS -N -i -H 'Authorization: Bearer $KEY' -H 'Content-Type: application/json' \
  --data '{"model":"gpt-5.6","stream":true,"messages":[{"role":"user","content":"Count from 1 to 30, one number per line."}]}' \
  http://127.0.0.1:$PORT/v1/chat/completions -w '\n--- curl exit=%{exitcode} http=%{http_code} bytes=%{size_download}\n'
```

`custom_guardrail.py`:

```python
class MidStreamBlock(CustomGuardrail):
    async def async_post_call_streaming_iterator_hook(self, user_api_key_dict, response, request_data):
        seen = 0
        async for chunk in response:
            seen += 1
            if seen > 2 and os.environ.get("E2E_FAILURE") == "runtime":
                raise RuntimeError("upstream connection reset mid-stream")
            if seen > 2:
                raise HTTPException(status_code=400, detail={"error": "Content blocked: keyword 'kumquat' detected", "guardrail": "mid-stream-block"})
            yield chunk
```

### Before (16db51e2cf)

#### Guardrail raises HTTPException mid-stream

1. Run the curl above
2. Observed (response body after headers):

```
data: {"id":"chatcmpl-cea547dc-af05-4571-8002-ff4267bb038b","created":1788531169,"model":"gpt-5.6","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"1","role":"assistant"}}],"provider_specific_fields":{}}

data: {"id":"chatcmpl-cea547dc-af05-4571-8002-ff4267bb038b","created":1788531169,"model":"gpt-5.6","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"\n"}}],"provider_specific_fields":{}}

curl: (18) transfer closed with outstanding read data remaining

--- curl exit=18 http=200 bytes=444
```

#### Generic exception mid-stream (`E2E_FAILURE=runtime`)

1. Run the curl above
2. Observed:

```
data: {"id":"chatcmpl-5ffeef6e-4bea-42ee-aa63-2e06aef5d09e","created":1788531313,"model":"gpt-5.6","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"1","role":"assistant"}}],"provider_specific_fields":{}}

data: {"id":"chatcmpl-5ffeef6e-4bea-42ee-aa63-2e06aef5d09e","created":1788531313,"model":"gpt-5.6","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"\n"}}],"provider_specific_fields":{}}

data: {"error": {"message": "upstream connection reset mid-stream", "type": "None", "param": "None", "code": "500"}}


--- curl exit=0 http=200 bytes=562
```

### After (5a99934e5d)

#### Guardrail raises HTTPException mid-stream

1. Run the curl above
2. Observed:

```
data: {"id":"chatcmpl-d2275d77-4671-47cb-8c69-2ea9273a9c5d","created":1788531241,"model":"gpt-5.6","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"1","role":"assistant"}}],"provider_specific_fields":{}}

data: {"id":"chatcmpl-d2275d77-4671-47cb-8c69-2ea9273a9c5d","created":1788531241,"model":"gpt-5.6","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"\n"}}],"provider_specific_fields":{}}

data: {"error": {"message": "Content blocked: keyword 'kumquat' detected", "type": "invalid_request_error", "param": null, "code": "400", "provider_specific_fields": {"error": "Content blocked: keyword 'kumquat' detected", "guardrail": "mid-stream-block", "guardrail_name": "mid-stream-block", "guardrail_mode": "post_call"}}}

data: [DONE]


--- curl exit=0 http=200 bytes=786
```

#### Generic exception mid-stream (`E2E_FAILURE=runtime`)

1. Run the curl above
2. Observed:

```
data: {"id":"chatcmpl-bd68516f-ec50-47cd-91e0-0ebd7cd74da2","created":1788531314,"model":"gpt-5.6","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"1","role":"assistant"}}],"provider_specific_fields":{}}

data: {"id":"chatcmpl-bd68516f-ec50-47cd-91e0-0ebd7cd74da2","created":1788531314,"model":"gpt-5.6","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"\n"}}],"provider_specific_fields":{}}

data: {"error": {"message": "upstream connection reset mid-stream", "type": "None", "param": "None", "code": "500"}}

data: [DONE]


--- curl exit=0 http=200 bytes=576
```

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Clients that treated the missing `[DONE]` as the terminator now also receive `[DONE]`; this matches the first-chunk error path which already emitted it
- Proof covers `/v1/chat/completions`; `/v1/responses` and `/v1/messages` share `async_streaming_data_generator` but were not re-run end to end
