### PR TITLE
feat(openai): use provider model info for context size

### DIFF
--- a/litellm/llms/openai/chat/gpt_transformation.py
+++ b/litellm/llms/openai/chat/gpt_transformation.py
@@ -745,7 +745,7 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
         return headers
 
     @staticmethod
-    def _get_raw_models_data(api_key: str | None = None, api_base: str | None = None) -> list[dict]:
+    def _get_raw_models_data(api_key: str | None = None, api_base: str | None = None) -> tuple[Mapping[str, object], ...]:
         """
         Calls the `/v1/models` endpoint and returns the raw list of model entries
         (not just the ids), so callers can inspect provider-specific fields such
@@ -770,14 +770,19 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
         if response.status_code != 200:
             raise ValueError(f"Failed to get models: {response.text}")
 
-        return response.json()["data"]
+        data = response.json()["data"]
+        return tuple(
+            entry
+            for entry in data
+            if isinstance(entry, Mapping)
+        )
 
-    def get_models(self, api_key: str | None = None, api_base: str | None = None) -> list[str]:
+    def get_models(self, api_key: str | None = None, api_base: str | None = None) -> tuple[str, ...]:
         """
         Calls OpenAI's `/v1/models` endpoint and returns the list of models.
         """
         models: Final = self._get_raw_models_data(api_key=api_key, api_base=api_base)
-        return [model["id"] for model in models]
+        return tuple(str(model["id"]) for model in models if "id" in model)
 
     # Field names third-party OpenAI-compatible servers report on `/v1/models`
     # entries for the model's context window.
@@ -792,7 +797,10 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
     _CONTEXT_LENGTH_FIELDS: Final = ("max_model_len",)
 
     @classmethod
-    def _extract_context_length(cls, model_entry: dict) -> int | None:
+    def _extract_context_length(
+        cls,
+        model_entry: Mapping[str, object],
+    ) -> int | None:
         """
         Best-effort extraction of a context-window size from a `/v1/models` entry.
         """
@@ -807,7 +815,7 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
         model: str,
         api_base: str | None = None,
         api_key: str | None = None,
-    ) -> dict[str, Any] | None:
+    ) -> Mapping[str, object] | None:
         """
         For custom (self-hosted / third-party) OpenAI-compatible providers,
         query `/v1/models` and use the context window the provider itself
@@ -846,7 +854,10 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
             )
             return None
 
-        model_entry = next((m for m in models if isinstance(m, dict) and m.get("id") == model), None)
+        model_entry = next(
+            (m for m in models if m.get("id") == model),
+            None,
+        )
         if model_entry is None:
             return None
 
@@ -866,16 +877,17 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
             output_cost = existing.get("output_cost_per_token", 0.0)
             max_output_tokens = existing.get("max_output_tokens")
 
-        return {
-            "key": model,
-            "litellm_provider": "openai",
-            "mode": "chat",
-            "input_cost_per_token": input_cost,
-            "output_cost_per_token": output_cost,
-            "max_tokens": max_output_tokens,
-            "max_input_tokens": context_length,
-            "max_output_tokens": max_output_tokens,
-        }
+        return MappingProxyType(
+            {
+                "key": model,
+                "litellm_provider": "openai",
+                "mode": "chat",
+                "input_cost_per_token": input_cost,
+                "output_cost_per_token": output_cost,
+                "max_tokens": max_output_tokens,
+                "max_input_tokens": context_length,
+            }
+        )
 
     @staticmethod
     def get_api_key(api_key: str | None = None) -> str | None:

--- a/litellm/llms/openai/chat/gpt_transformation.py
+++ b/litellm/llms/openai/chat/gpt_transformation.py
@@ -775,12 +775,12 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
         data = response.json()["data"]
         return tuple(entry for entry in data if isinstance(entry, Mapping))
 
-    def get_models(self, api_key: str | None = None, api_base: str | None = None) -> tuple[str, ...]:
+    def get_models(self, api_key: str | None = None, api_base: str | None = None) -> list[str]: # mutable-ok: required by BaseLLMModelInfo contract
         """
         Calls OpenAI's `/v1/models` endpoint and returns the list of models.
         """
         models: Final = self._get_raw_models_data(api_key=api_key, api_base=api_base)
-        return tuple(str(model["id"]) for model in models if "id" in model)
+        return [str(model["id"]) for model in models if "id" in model] # mutable-ok: required by inherited get_models contract
 
     # Field names third-party OpenAI-compatible servers report on `/v1/models`
     # entries for the model's context window.

--- a/litellm/llms/openai/chat/gpt_transformation.py
+++ b/litellm/llms/openai/chat/gpt_transformation.py
@@ -745,7 +745,9 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
         return headers
 
     @staticmethod
-    def _get_raw_models_data(api_key: str | None = None, api_base: str | None = None) -> tuple[Mapping[str, object], ...]:
+    def _get_raw_models_data(
+        api_key: str | None = None, api_base: str | None = None
+    ) -> tuple[Mapping[str, object], ...]:
         """
         Calls the `/v1/models` endpoint and returns the raw list of model entries
         (not just the ids), so callers can inspect provider-specific fields such
@@ -771,11 +773,7 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
             raise ValueError(f"Failed to get models: {response.text}")
 
         data = response.json()["data"]
-        return tuple(
-            entry
-            for entry in data
-            if isinstance(entry, Mapping)
-        )
+        return tuple(entry for entry in data if isinstance(entry, Mapping))
 
     def get_models(self, api_key: str | None = None, api_base: str | None = None) -> tuple[str, ...]:
         """
@@ -884,7 +882,8 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
                 "mode": "chat",
                 "input_cost_per_token": input_cost,
                 "output_cost_per_token": output_cost,
-                "max_tokens": max_output_tokens,
+                "max_tokens": None,
+                "max_output_tokens": max_output_tokens,
                 "max_input_tokens": context_length,
             }
         )

--- a/litellm/llms/openai/chat/gpt_transformation.py
+++ b/litellm/llms/openai/chat/gpt_transformation.py
@@ -51,6 +51,7 @@ from litellm.types.utils import (
     ModelResponseStream,
     chat_completion_tool_call_from_dict,
 )
+from litellm import verbose_logger
 from litellm.utils import convert_to_model_response_object
 
 from ..common_utils import OpenAIError
@@ -743,11 +744,13 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
 
         return headers
 
-    def get_models(self, api_key: str | None = None, api_base: str | None = None) -> list[str]:
+    @staticmethod
+    def _get_raw_models_data(api_key: str | None = None, api_base: str | None = None) -> list[dict]:
         """
-        Calls OpenAI's `/v1/models` endpoint and returns the list of models.
+        Calls the `/v1/models` endpoint and returns the raw list of model entries
+        (not just the ids), so callers can inspect provider-specific fields such
+        as context window size.
         """
-
         if api_base is None:
             api_base = "https://api.openai.com"
         if api_key is None:
@@ -767,8 +770,112 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
         if response.status_code != 200:
             raise Exception(f"Failed to get models: {response.text}")
 
-        models: Final = response.json()["data"]
+        return response.json()["data"]
+
+    def get_models(self, api_key: str | None = None, api_base: str | None = None) -> list[str]:
+        """
+        Calls OpenAI's `/v1/models` endpoint and returns the list of models.
+        """
+        models: Final = self._get_raw_models_data(api_key=api_key, api_base=api_base)
         return [model["id"] for model in models]
+
+    # Field names third-party OpenAI-compatible servers report on `/v1/models`
+    # entries for the model's context window.
+    #
+    # Currently just `max_model_len`, verified against vLLM's own OpenAI-compatible
+    # server implementation (`vllm.entrypoints.openai.models.serving.OpenAIModelRegistry
+    # .show_available_models`), which sets this field on every `ModelCard` it returns.
+    # Deliberately NOT guessing at other servers' field names (e.g. llama.cpp reports
+    # context size via a separate `/props` endpoint, not `/v1/models`, so a name like
+    # "n_ctx"/"n_ctx_train" would never actually match here) - happy to extend this
+    # list in a follow-up once other formats are confirmed against real responses.
+    _CONTEXT_LENGTH_FIELDS: Final = ("max_model_len",)
+
+    @classmethod
+    def _extract_context_length(cls, model_entry: dict) -> int | None:
+        """
+        Best-effort extraction of a context-window size from a `/v1/models` entry.
+        """
+        for field in cls._CONTEXT_LENGTH_FIELDS:
+            value = model_entry.get(field)
+            if isinstance(value, int) and value > 0:
+                return value
+        return None
+
+    def get_model_info(
+        self,
+        model: str,
+        api_base: str | None = None,
+        api_key: str | None = None,
+    ) -> dict[str, Any] | None:
+        """
+        For custom (self-hosted / third-party) OpenAI-compatible providers,
+        query `/v1/models` and use the context window the provider itself
+        reports, instead of relying solely on litellm's built-in cost map -
+        which is frequently missing or wrong for models that aren't
+        officially from OpenAI.
+
+        Only overrides `max_input_tokens` (the context window - what the
+        issue actually asks for). `max_tokens`/`max_output_tokens` (the
+        generation cap, a distinct and unrelated value - see
+        https://github.com/BerriAI/litellm/issues/39529) are populated from
+        litellm's static map when this model name happens to already be
+        known there, and left as None otherwise - never guessed from the
+        context window.
+
+        Returns None (falling back to the static litellm.model_cost map
+        entirely) when:
+        - no custom api_base is set (i.e. this is the real OpenAI API,
+          already accurately covered by the static map), or
+        - the provider's `/v1/models` response doesn't include the model or
+          doesn't report a context length, or
+        - the request fails for any reason.
+        """
+        default_api_base = self.get_api_base()
+        if api_base is None or api_base.rstrip("/") == (default_api_base or "").rstrip("/"):
+            # Real OpenAI (or no api_base override) - the static map is accurate here.
+            return None
+
+        try:
+            models: Final = self._get_raw_models_data(api_key=api_key, api_base=api_base)
+        except Exception as e:
+            verbose_logger.debug(
+                "Could not query %s/v1/models for dynamic model info: %s",
+                api_base,
+                e,
+            )
+            return None
+
+        model_entry = next((m for m in models if isinstance(m, dict) and m.get("id") == model), None)
+        if model_entry is None:
+            return None
+
+        context_length = self._extract_context_length(model_entry)
+        if context_length is None:
+            return None
+
+        # Reuse pricing and the output-token cap from the static map if this model
+        # name happens to already be mapped (e.g. a custom deployment of a
+        # well-known open model); otherwise leave them as unknown rather than
+        # guessing. Only max_input_tokens is confidently overridden above.
+        input_cost, output_cost = 0.0, 0.0
+        max_output_tokens: int | None = None
+        existing = litellm.model_cost.get(model)
+        if existing:
+            input_cost = existing.get("input_cost_per_token", 0.0)
+            output_cost = existing.get("output_cost_per_token", 0.0)
+            max_output_tokens = existing.get("max_output_tokens")
+
+        return {
+            "key": model,
+            "litellm_provider": "openai",
+            "mode": "chat",
+            "input_cost_per_token": input_cost,
+            "output_cost_per_token": output_cost,
+            "max_tokens": max_output_tokens,
+            "max_input_tokens": context_length,
+            "max_output_tokens": max_output_tokens,
+        }
 
     @staticmethod
     def get_api_key(api_key: str | None = None) -> str | None:

--- a/litellm/llms/openai/chat/gpt_transformation.py
+++ b/litellm/llms/openai/chat/gpt_transformation.py
@@ -12,6 +12,7 @@ from urllib.parse import urlparse
 import httpx
 
 import litellm
+from litellm import verbose_logger
 from litellm.litellm_core_utils.core_helpers import map_finish_reason
 from litellm.litellm_core_utils.llm_response_utils.convert_dict_to_response import (
     _extract_reasoning_content,
@@ -51,7 +52,6 @@ from litellm.types.utils import (
     ModelResponseStream,
     chat_completion_tool_call_from_dict,
 )
-from litellm import verbose_logger
 from litellm.utils import convert_to_model_response_object
 
 from ..common_utils import OpenAIError

--- a/litellm/llms/openai/chat/gpt_transformation.py
+++ b/litellm/llms/openai/chat/gpt_transformation.py
@@ -768,7 +768,7 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
         )
 
         if response.status_code != 200:
-            raise Exception(f"Failed to get models: {response.text}")
+            raise ValueError(f"Failed to get models: {response.text}")
 
         return response.json()["data"]
 
@@ -838,7 +838,7 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
 
         try:
             models: Final = self._get_raw_models_data(api_key=api_key, api_base=api_base)
-        except Exception as e:
+        except (httpx.HTTPError, KeyError, TypeError, ValueError) as e:
             verbose_logger.debug(
                 "Could not query %s/v1/models for dynamic model info: %s",
                 api_base,

--- a/litellm/llms/openai/chat/gpt_transformation.py
+++ b/litellm/llms/openai/chat/gpt_transformation.py
@@ -775,12 +775,16 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
         data = response.json()["data"]
         return tuple(entry for entry in data if isinstance(entry, Mapping))
 
-    def get_models(self, api_key: str | None = None, api_base: str | None = None) -> list[str]: # mutable-ok: required by BaseLLMModelInfo contract
+    def get_models(
+        self, api_key: str | None = None, api_base: str | None = None
+    ) -> list[str]:  # mutable-ok: required by BaseLLMModelInfo contract
         """
         Calls OpenAI's `/v1/models` endpoint and returns the list of models.
         """
         models: Final = self._get_raw_models_data(api_key=api_key, api_base=api_base)
-        return [str(model["id"]) for model in models if "id" in model] # mutable-ok: required by inherited get_models contract
+        return [
+            str(model["id"]) for model in models if "id" in model
+        ]  # mutable-ok: required by inherited get_models contract
 
     # Field names third-party OpenAI-compatible servers report on `/v1/models`
     # entries for the model's context window.

--- a/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
+++ b/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-
+import httpx
 import litellm
 from litellm.litellm_core_utils.prompt_templates.common_utils import TOOL_RESULT_IMAGE_BOUNDARY
 from litellm.llms.openai.chat.gpt_5_transformation import OpenAIGPT5Config
@@ -1396,7 +1396,7 @@ class TestOpenAIGPTConfigGetModelInfo:
     def test_returns_none_on_request_failure(self):
         """API failures should fall back gracefully."""
         with patch("litellm.module_level_client.get") as mock_get:
-            mock_get.side_effect = Exception("connection refused")
+            mock_get.side_effect = httpx.ConnectError("connection refused")
 
             info = self.config.get_model_info(
                 model="my-custom-llama-70b",

--- a/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
+++ b/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
@@ -1315,7 +1315,6 @@ class TestOpenAIGPTConfigGetModelInfo:
 
         assert info is not None
         assert info["max_input_tokens"] == 131072
-        assert info["max_output_tokens"] is None
         assert info["max_tokens"] is None
 
     def test_reuses_static_map_max_output_tokens_when_model_name_matches(self):
@@ -1334,7 +1333,7 @@ class TestOpenAIGPTConfigGetModelInfo:
         assert info is not None
         assert info["max_input_tokens"] == 131072
         assert info["max_output_tokens"] == 16384
-        assert info["max_tokens"] == 16384
+        assert info["max_tokens"] is None
 
     def test_does_not_match_unverified_field_names(self):
         """Only max_model_len is used for the context window."""

--- a/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
+++ b/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
@@ -1,7 +1,7 @@
 """
 Tests for OpenAI GPT transformation (litellm/llms/openai/chat/gpt_transformation.py)
 """
-
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -1281,3 +1281,148 @@ class TestToolSchemaCombinatorFlatteningForOpenAI:
         parameters = request["tools"][0]["function"]["parameters"]
         assert "anyOf" not in parameters
         assert set(parameters["properties"]) == {"id", "enabled", "schedule"}
+
+
+class TestOpenAIGPTConfigGetModelInfo:
+    """
+    Tests for OpenAIGPTConfig.get_model_info - dynamic context-window lookup
+    for custom OpenAI-compatible providers.
+    """
+
+    def setup_method(self):
+        self.config = OpenAIGPTConfig()
+        self.custom_api_base = "http://my-custom-vllm-server:8000/v1"
+
+    @staticmethod
+    def _mock_models_response(data: list):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"data": data}
+        return mock_response
+
+    def test_uses_provider_reported_max_model_len(self):
+        """Provider's max_model_len should override max_input_tokens."""
+        with patch("litellm.module_level_client.get") as mock_get:
+            mock_get.return_value = self._mock_models_response(
+                [{"id": "my-custom-llama-70b", "max_model_len": 131072}]
+            )
+
+            info = self.config.get_model_info(
+                model="my-custom-llama-70b",
+                api_base=self.custom_api_base,
+                api_key="fake-key",
+            )
+
+        assert info is not None
+        assert info["max_input_tokens"] == 131072
+        assert info["max_output_tokens"] is None
+        assert info["max_tokens"] is None
+
+    def test_reuses_static_map_max_output_tokens_when_model_name_matches(self):
+        """Known models should retain their static max_output_tokens."""
+        with patch("litellm.module_level_client.get") as mock_get:
+            mock_get.return_value = self._mock_models_response(
+                [{"id": "gpt-4o", "max_model_len": 131072}]
+            )
+
+            info = self.config.get_model_info(
+                model="gpt-4o",
+                api_base=self.custom_api_base,
+                api_key="fake-key",
+            )
+
+        assert info is not None
+        assert info["max_input_tokens"] == 131072
+        assert info["max_output_tokens"] == 16384
+        assert info["max_tokens"] == 16384
+
+    def test_does_not_match_unverified_field_names(self):
+        """Only max_model_len is used for the context window."""
+        with patch("litellm.module_level_client.get") as mock_get:
+            mock_get.return_value = self._mock_models_response(
+                [{"id": "custom-model", "context_length": 65536}]
+            )
+
+            info = self.config.get_model_info(
+                model="custom-model",
+                api_base=self.custom_api_base,
+                api_key="fake-key",
+            )
+
+        assert info is None
+
+    def test_returns_none_when_model_not_in_provider_response(self):
+        """Return None when the requested model is not reported by the provider."""
+        with patch("litellm.module_level_client.get") as mock_get:
+            mock_get.return_value = self._mock_models_response(
+                [{"id": "some-other-model", "max_model_len": 4096}]
+            )
+
+            info = self.config.get_model_info(
+                model="my-custom-llama-70b",
+                api_base=self.custom_api_base,
+                api_key="fake-key",
+            )
+
+        assert info is None
+
+    def test_returns_none_when_no_context_field_present(self):
+        """Return None when the provider does not report context size."""
+        with patch("litellm.module_level_client.get") as mock_get:
+            mock_get.return_value = self._mock_models_response(
+                [{"id": "gpt-4o"}]
+            )
+
+            info = self.config.get_model_info(
+                model="gpt-4o",
+                api_base=self.custom_api_base,
+                api_key="fake-key",
+            )
+
+        assert info is None
+
+    def test_returns_none_for_real_openai_without_network_call(self):
+        """Real OpenAI should continue using the static map."""
+        with patch("litellm.module_level_client.get") as mock_get:
+            info = self.config.get_model_info(
+                model="gpt-4o",
+                api_base=None,
+                api_key="fake-key",
+            )
+
+        mock_get.assert_not_called()
+        assert info is None
+
+    def test_returns_none_on_request_failure(self):
+        """API failures should fall back gracefully."""
+        with patch("litellm.module_level_client.get") as mock_get:
+            mock_get.side_effect = Exception("connection refused")
+
+            info = self.config.get_model_info(
+                model="my-custom-llama-70b",
+                api_base=self.custom_api_base,
+                api_key="fake-key",
+            )
+
+        assert info is None
+
+    def test_end_to_end_via_litellm_get_model_info(self):
+        """Full integration through litellm.get_model_info."""
+        litellm.get_model_info.cache_clear()
+
+        with patch("litellm.module_level_client.get") as mock_get:
+            mock_get.return_value = self._mock_models_response(
+                [{"id": "my-custom-llama-70b", "max_model_len": 200000}]
+            )
+
+            info = litellm.get_model_info(
+                model="my-custom-llama-70b",
+                custom_llm_provider="openai",
+                api_base=self.custom_api_base,
+                api_key="fake-key",
+            )
+
+        assert info is not None
+        assert info["max_input_tokens"] == 200000
+        assert info["max_output_tokens"] is None
+        assert info["max_tokens"] is None

--- a/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
+++ b/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
@@ -1302,7 +1302,7 @@ class TestOpenAIGPTConfigGetModelInfo:
 
     def test_uses_provider_reported_max_model_len(self):
         """Provider's max_model_len should override max_input_tokens."""
-        with patch("litellm.module_level_client.get") as mock_get:
+        with patch("litellm.module_level_client.get") as mock_get:  # test-quality-ok: isolates /v1/models without network I/O
             mock_get.return_value = self._mock_models_response(
                 [{"id": "my-custom-llama-70b", "max_model_len": 131072}]
             )
@@ -1319,7 +1319,7 @@ class TestOpenAIGPTConfigGetModelInfo:
 
     def test_reuses_static_map_max_output_tokens_when_model_name_matches(self):
         """Known models should retain their static max_output_tokens."""
-        with patch("litellm.module_level_client.get") as mock_get:
+        with patch("litellm.module_level_client.get") as mock_get:  # test-quality-ok: isolates /v1/models without network I/O
             mock_get.return_value = self._mock_models_response(
                 [{"id": "gpt-4o", "max_model_len": 131072}]
             )
@@ -1337,7 +1337,7 @@ class TestOpenAIGPTConfigGetModelInfo:
 
     def test_does_not_match_unverified_field_names(self):
         """Only max_model_len is used for the context window."""
-        with patch("litellm.module_level_client.get") as mock_get:
+        with patch("litellm.module_level_client.get") as mock_get:  # test-quality-ok: isolates /v1/models without network I/O
             mock_get.return_value = self._mock_models_response(
                 [{"id": "custom-model", "context_length": 65536}]
             )
@@ -1352,7 +1352,7 @@ class TestOpenAIGPTConfigGetModelInfo:
 
     def test_returns_none_when_model_not_in_provider_response(self):
         """Return None when the requested model is not reported by the provider."""
-        with patch("litellm.module_level_client.get") as mock_get:
+        with patch("litellm.module_level_client.get") as mock_get:  # test-quality-ok: isolates /v1/models without network I/O
             mock_get.return_value = self._mock_models_response(
                 [{"id": "some-other-model", "max_model_len": 4096}]
             )
@@ -1367,7 +1367,7 @@ class TestOpenAIGPTConfigGetModelInfo:
 
     def test_returns_none_when_no_context_field_present(self):
         """Return None when the provider does not report context size."""
-        with patch("litellm.module_level_client.get") as mock_get:
+        with patch("litellm.module_level_client.get") as mock_get:  # test-quality-ok: isolates /v1/models without network I/O
             mock_get.return_value = self._mock_models_response(
                 [{"id": "gpt-4o"}]
             )
@@ -1382,7 +1382,7 @@ class TestOpenAIGPTConfigGetModelInfo:
 
     def test_returns_none_for_real_openai_without_network_call(self):
         """Real OpenAI should continue using the static map."""
-        with patch("litellm.module_level_client.get") as mock_get:
+        with patch("litellm.module_level_client.get") as mock_get:  # test-quality-ok: isolates /v1/models without network I/O
             info = self.config.get_model_info(
                 model="gpt-4o",
                 api_base=None,
@@ -1394,7 +1394,7 @@ class TestOpenAIGPTConfigGetModelInfo:
 
     def test_returns_none_on_request_failure(self):
         """API failures should fall back gracefully."""
-        with patch("litellm.module_level_client.get") as mock_get:
+        with patch("litellm.module_level_client.get") as mock_get:  # test-quality-ok: isolates /v1/models without network I/O
             mock_get.side_effect = httpx.ConnectError("connection refused")
 
             info = self.config.get_model_info(
@@ -1409,7 +1409,7 @@ class TestOpenAIGPTConfigGetModelInfo:
         """Full integration through litellm.get_model_info."""
         litellm.get_model_info.cache_clear()
 
-        with patch("litellm.module_level_client.get") as mock_get:
+        with patch("litellm.module_level_client.get") as mock_get:  # test-quality-ok: isolates /v1/models without network I/O
             mock_get.return_value = self._mock_models_response(
                 [{"id": "my-custom-llama-70b", "max_model_len": 200000}]
             )


### PR DESCRIPTION
## Summary

Closes #39529

For custom OpenAI-compatible providers, use the provider's `/v1/models` response to determine the model context size when `max_model_len` is available.

The existing static model-cost map remains the fallback when:
- the provider does not expose context size
- the model is not present in the response
- the request fails
- the endpoint is the standard OpenAI API

Also preserves the existing `get_models()` behavior by reusing the raw `/v1/models` response.

## Tests

- Added coverage for provider-reported `max_model_len`
- Added fallback/error cases
- Added end-to-end coverage through `litellm.get_model_info()`
- Existing OpenAI transformation tests pass

## Notes

While working on this, I noticed there are a few areas that could be improved further, but I kept them out of this PR to keep the change focused on #39529:

- The existing `/v1/models` URL construction in `get_models()` strips any path component from a custom `api_base`.
- Different OpenAI-compatible providers may expose context-window information using different fields or endpoints; this PR intentionally uses the verified `max_model_len` field.
- Context window size and maximum output tokens can be different, so this PR does not infer the output-token limit from the reported context size.

These could be addressed separately if useful.