### PR TITLE
feat(responses): add Rust native and adapted transports

### DIFF
--- a/litellm-rust/crates/core/src/chat_completions/mod.rs
+++ b/litellm-rust/crates/core/src/chat_completions/mod.rs
@@ -20,13 +20,44 @@ use serde_json::{Map, Value};
 
 use handler::execute_chat_completions_provider_call;
 use prepare::{parse_messages, resolve_provider_config, resolve_request};
-use types::{ChatCompletionsRequest, ChatCompletionsResponse};
+use transformation::ChatCompletionsProviderConfig;
+use types::{
+    ChatCompletionsRequest, ChatCompletionsResponse, ResolvedChatCompletionsRequest,
+};
 
 #[tracing::instrument(target = "litellm::function_trace", level = "trace", skip_all)]
 pub async fn chat_completions(
     request: ChatCompletionsRequest<'_>,
 ) -> Result<ChatCompletionsResponse, Error> {
     execute_chat_completions_provider_call(resolve_request(request)?).await
+}
+
+#[tracing::instrument(name = "chat_completions", target = "litellm::function_trace", level = "trace", skip_all)]
+pub(crate) async fn chat_completions_with_config(
+    request: ChatCompletionsRequest<'_>,
+    model: &str,
+    config: &'static dyn ChatCompletionsProviderConfig,
+) -> Result<ChatCompletionsResponse, Error> {
+    let messages = parse_messages(request.messages)?;
+    if messages.is_empty() {
+        return Err(Error::InvalidRequest(
+            "chat completions requires at least one message".to_string(),
+        ));
+    }
+    if let Some(reason) = config.unsupported_reason(&messages, &request.optional_params) {
+        return Err(Error::Unsupported(reason.0));
+    }
+    execute_chat_completions_provider_call(ResolvedChatCompletionsRequest {
+        model: model.to_string(),
+        config,
+        messages,
+        optional_params: request.optional_params,
+        api_key: request.api_key,
+        api_base: request.api_base,
+        extra_headers: request.extra_headers,
+        timeout: request.timeout,
+    })
+    .await
 }
 
 /// Whether the core would accept this request, without resolving credentials or

--- a/litellm-rust/crates/core/src/providers/openai/chat_completions/mod.rs
+++ b/litellm-rust/crates/core/src/providers/openai/chat_completions/mod.rs
@@ -1,0 +1,1 @@
+pub mod transformation;

--- a/litellm-rust/crates/core/src/providers/openai/chat_completions/transformation.rs
+++ b/litellm-rust/crates/core/src/providers/openai/chat_completions/transformation.rs
@@ -1,0 +1,157 @@
+use serde::Deserialize;
+use serde_json::{Map, Value, json};
+
+use crate::Error;
+use crate::chat_completions::response_utils::usage_from_parts;
+use crate::chat_completions::transformation::{ChatCompletionsAuth, ChatCompletionsProviderConfig};
+use crate::chat_completions::types::{
+    ChatCompletionsChoice, ChatCompletionsChoiceMessage, ChatCompletionsResponse, ChatMessage,
+    ProviderChatRequestData, ProviderChatResponseData,
+};
+
+const SUPPORTED_PARAMS: &[(&str, &str)] = &[
+    ("max_completion_tokens", "max_completion_tokens"),
+    ("temperature", "temperature"),
+    ("top_p", "top_p"),
+];
+
+pub struct OpenAIChatCompletionsConfig;
+
+pub const OPENAI_CHAT_COMPLETIONS_CONFIG: OpenAIChatCompletionsConfig = OpenAIChatCompletionsConfig;
+
+#[derive(Deserialize)]
+struct OpenAIResponse {
+    created: u64,
+    model: String,
+    choices: Vec<OpenAIChoice>,
+    usage: OpenAIUsage,
+}
+
+#[derive(Deserialize)]
+struct OpenAIChoice {
+    index: u64,
+    message: OpenAIMessage,
+    finish_reason: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct OpenAIMessage {
+    role: String,
+    content: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct OpenAIUsage {
+    prompt_tokens: u64,
+    completion_tokens: u64,
+}
+
+impl ChatCompletionsProviderConfig for OpenAIChatCompletionsConfig {
+    fn complete_url(
+        &self,
+        api_base: Option<&str>,
+        _model: &str,
+        _optional_params: &Map<String, Value>,
+        env_lookup: &dyn Fn(&str) -> Option<String>,
+    ) -> Result<String, Error> {
+        let base = api_base
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+            .or_else(|| env_lookup("OPENAI_BASE_URL"))
+            .or_else(|| env_lookup("OPENAI_API_BASE"))
+            .unwrap_or_else(|| "https://api.openai.com/v1".to_string());
+        let base = base.trim_end_matches('/');
+        if base.ends_with("/chat/completions") {
+            return Ok(base.to_string());
+        }
+        Ok(format!("{base}/chat/completions"))
+    }
+
+    fn auth(
+        &self,
+        api_key: Option<&str>,
+        _model: &str,
+        _optional_params: &Map<String, Value>,
+        env_lookup: &dyn Fn(&str) -> Option<String>,
+    ) -> Result<ChatCompletionsAuth, Error> {
+        let token = api_key
+            .map(str::to_string)
+            .or_else(|| env_lookup("OPENAI_API_KEY"))
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| Error::Auth("OPENAI_API_KEY is required".to_string()))?;
+        Ok(ChatCompletionsAuth::Bearer { token })
+    }
+
+    #[tracing::instrument(target = "litellm::function_trace", level = "trace", skip_all)]
+    fn supported_openai_params(&self) -> &'static [(&'static str, &'static str)] {
+        SUPPORTED_PARAMS
+    }
+
+    #[tracing::instrument(target = "litellm::function_trace", level = "trace", skip_all)]
+    fn transform_request(
+        &self,
+        model: &str,
+        messages: Vec<ChatMessage>,
+        optional_params: Map<String, Value>,
+    ) -> Result<ProviderChatRequestData, Error> {
+        Ok(ProviderChatRequestData {
+            body: Value::Object(Map::from_iter(
+                [
+                    ("model".to_string(), json!(model)),
+                    ("messages".to_string(), json!(messages)),
+                ]
+                .into_iter()
+                .chain(optional_params),
+            )),
+        })
+    }
+
+    #[tracing::instrument(target = "litellm::function_trace", level = "trace", skip_all)]
+    fn transform_response(
+        &self,
+        _model: &str,
+        response: ProviderChatResponseData,
+    ) -> Result<ChatCompletionsResponse, Error> {
+        let parsed: OpenAIResponse = serde_json::from_value(response.body).map_err(|error| {
+            Error::InvalidResponse(format!("invalid OpenAI chat completions response: {error}"))
+        })?;
+        Ok(ChatCompletionsResponse {
+            created: parsed.created,
+            model: parsed.model,
+            choices: parsed
+                .choices
+                .into_iter()
+                .map(|choice| ChatCompletionsChoice {
+                    index: choice.index,
+                    message: ChatCompletionsChoiceMessage {
+                        role: choice.message.role,
+                        content: choice.message.content,
+                    },
+                    finish_reason: choice.finish_reason.unwrap_or_else(|| "stop".to_string()),
+                })
+                .collect(),
+            usage: usage_from_parts(
+                parsed.usage.prompt_tokens,
+                parsed.usage.completion_tokens,
+                0,
+                0,
+            ),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn custom_base_selects_chat_completions_endpoint() {
+        let url = OPENAI_CHAT_COMPLETIONS_CONFIG
+            .complete_url(Some("http://localhost:8000"), "gpt-5", &Map::new(), &|_| {
+                None
+            })
+            .expect("valid URL");
+        assert_eq!(url, "http://localhost:8000/chat/completions");
+    }
+}

--- a/litellm-rust/crates/core/src/providers/openai/mod.rs
+++ b/litellm-rust/crates/core/src/providers/openai/mod.rs
@@ -1,2 +1,3 @@
+pub mod chat_completions;
 pub mod realtime;
 pub mod responses;

--- a/litellm-rust/crates/core/src/responses/http.rs
+++ b/litellm-rust/crates/core/src/responses/http.rs
@@ -1,0 +1,453 @@
+use std::sync::OnceLock;
+
+use serde_json::{Map, Value, json};
+
+use crate::Error;
+use crate::chat_completions::types::{
+    ChatCompletionsRequest, ChatCompletionsResponse, ChatMessage, ChatMessageContent,
+};
+use crate::chat_completions::{
+    chat_completions, chat_completions_decline_reason, chat_completions_with_config,
+};
+use crate::http_utils::{has_header, http_request, string_headers, truncate_error_body};
+use crate::providers::openai::chat_completions::transformation::OPENAI_CHAT_COMPLETIONS_CONFIG;
+use crate::routing_utils::provider::get_custom_llm_provider;
+
+use super::http_types::{
+    ResponsesApiResponse, ResponsesInput, ResponsesInputContent, ResponsesOutputContent,
+    ResponsesOutputItem, ResponsesRequest,
+};
+
+const SUPPORTED_PARAMS: &[&str] = &["instructions", "max_output_tokens", "temperature", "top_p"];
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ResponsesTransport {
+    Native,
+    ChatCompletionsAdapter,
+}
+
+fn http_client() -> &'static reqwest::Client {
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+    CLIENT.get_or_init(reqwest::Client::new)
+}
+
+fn resolve_provider<'a>(
+    model: &'a str,
+    custom_llm_provider: Option<&'a str>,
+) -> Result<(&'a str, &'a str), Error> {
+    get_custom_llm_provider(model, custom_llm_provider)
+        .map(|provider| (provider.model, provider.custom_llm_provider))
+        .ok_or_else(|| Error::InvalidProvider("unable to resolve Responses provider".to_string()))
+}
+
+#[tracing::instrument(target = "litellm::function_trace", level = "trace", skip_all)]
+pub fn responses_transport(
+    provider: &str,
+    use_chat_completions_api: bool,
+) -> Result<ResponsesTransport, Error> {
+    if use_chat_completions_api {
+        return match provider {
+            "openai" | "anthropic" | "bedrock" => Ok(ResponsesTransport::ChatCompletionsAdapter),
+            _ => Err(Error::Unsupported("provider has no Rust Responses adapter")),
+        };
+    }
+    match provider {
+        "openai" => Ok(ResponsesTransport::Native),
+        "anthropic" | "bedrock" => Ok(ResponsesTransport::ChatCompletionsAdapter),
+        _ => Err(Error::Unsupported(
+            "provider has no Rust Responses transport",
+        )),
+    }
+}
+
+fn parse_input(input: Value) -> Result<ResponsesInput, Error> {
+    serde_json::from_value(input)
+        .map_err(|error| Error::InvalidRequest(format!("invalid Responses input: {error}")))
+}
+
+fn unsupported_reason(
+    input: &ResponsesInput,
+    optional_params: &Map<String, Value>,
+) -> Option<&'static str> {
+    if optional_params
+        .keys()
+        .any(|key| !SUPPORTED_PARAMS.contains(&key.as_str()))
+    {
+        return Some("unrecognized Responses parameter");
+    }
+    let ResponsesInput::Items(items) = input else {
+        return None;
+    };
+    if items.is_empty() {
+        return Some("empty Responses input");
+    }
+    items.iter().find_map(|item| {
+        if !item.extra.is_empty() || !matches!(item.role.as_str(), "system" | "user" | "assistant")
+        {
+            return Some("unsupported Responses input item");
+        }
+        match &item.content {
+            ResponsesInputContent::Text(_) => None,
+            ResponsesInputContent::Parts(parts)
+                if !parts.is_empty()
+                    && parts.iter().all(|part| {
+                        matches!(
+                            part.part_type.as_str(),
+                            "input_text" | "output_text" | "text"
+                        ) && part.extra.is_empty()
+                    }) =>
+            {
+                None
+            }
+            ResponsesInputContent::Parts(_) => Some("unsupported Responses input content"),
+        }
+    })
+}
+
+pub fn responses_decline_reason(
+    model: &str,
+    input: Value,
+    optional_params: &Map<String, Value>,
+    custom_llm_provider: Option<&str>,
+    use_chat_completions_api: bool,
+) -> Option<&'static str> {
+    let Ok((resolved_model, provider)) = resolve_provider(model, custom_llm_provider) else {
+        return Some("unable to resolve Responses provider");
+    };
+    let Ok(transport) = responses_transport(provider, use_chat_completions_api) else {
+        return Some("provider has no Rust Responses transport");
+    };
+    let Ok(input) = parse_input(input) else {
+        return Some("invalid Responses input");
+    };
+    if let Some(reason) = unsupported_reason(&input, optional_params) {
+        return Some(reason);
+    }
+    if transport == ResponsesTransport::ChatCompletionsAdapter {
+        if provider == "openai" {
+            return None;
+        }
+        let messages = adapter_messages(
+            &input,
+            optional_params.get("instructions").and_then(Value::as_str),
+        );
+        return chat_completions_decline_reason(
+            resolved_model,
+            Some(provider),
+            json!(messages),
+            &adapter_params(provider, optional_params),
+        );
+    }
+    None
+}
+
+fn message_text(content: &ResponsesInputContent) -> String {
+    match content {
+        ResponsesInputContent::Text(text) => text.clone(),
+        ResponsesInputContent::Parts(parts) => {
+            parts.iter().map(|part| part.text.as_str()).collect()
+        }
+    }
+}
+
+#[tracing::instrument(target = "litellm::function_trace", level = "trace", skip_all)]
+fn transform_responses_request_to_chat_completions(
+    input: &ResponsesInput,
+    instructions: Option<&str>,
+) -> Vec<ChatMessage> {
+    adapter_messages(input, instructions)
+}
+
+fn adapter_messages(input: &ResponsesInput, instructions: Option<&str>) -> Vec<ChatMessage> {
+    let instruction = instructions.map(|text| ChatMessage {
+        role: "system".to_string(),
+        content: Some(ChatMessageContent::Text(text.to_string())),
+        name: None,
+        extra: Map::new(),
+    });
+    let messages = match input {
+        ResponsesInput::Text(text) => vec![ChatMessage {
+            role: "user".to_string(),
+            content: Some(ChatMessageContent::Text(text.clone())),
+            name: None,
+            extra: Map::new(),
+        }],
+        ResponsesInput::Items(items) => items
+            .iter()
+            .map(|item| ChatMessage {
+                role: item.role.clone(),
+                content: Some(ChatMessageContent::Text(message_text(&item.content))),
+                name: None,
+                extra: Map::new(),
+            })
+            .collect(),
+    };
+    instruction.into_iter().chain(messages).collect()
+}
+
+fn adapter_params(provider: &str, optional_params: &Map<String, Value>) -> Map<String, Value> {
+    Map::from_iter(
+        optional_params
+            .iter()
+            .filter(|(key, _)| key.as_str() != "instructions")
+            .map(|(key, value)| {
+                let mapped = match (provider, key.as_str()) {
+                    ("anthropic", "max_output_tokens") => "max_tokens",
+                    ("bedrock", "max_output_tokens") => "maxTokens",
+                    ("openai", "max_output_tokens") => "max_completion_tokens",
+                    (_, name) => name,
+                };
+                (mapped.to_string(), value.clone())
+            }),
+    )
+}
+
+#[tracing::instrument(target = "litellm::function_trace", level = "trace", skip_all)]
+fn transform_chat_completions_response_to_responses(
+    response: ChatCompletionsResponse,
+    provider: &str,
+) -> ResponsesApiResponse {
+    let status = response
+        .choices
+        .first()
+        .map_or("completed", |choice| match choice.finish_reason.as_str() {
+            "length" => "incomplete",
+            "content_filter" => "failed",
+            _ => "completed",
+        })
+        .to_string();
+    let output = response
+        .choices
+        .into_iter()
+        .filter_map(|choice| {
+            choice
+                .message
+                .content
+                .map(|text| ResponsesOutputItem::Message {
+                    id: format!("msg_{:016x}", rand::random::<u64>()),
+                    status: status.clone(),
+                    role: choice.message.role,
+                    content: vec![ResponsesOutputContent::OutputText {
+                        text,
+                        annotations: vec![],
+                        extra: Map::new(),
+                    }],
+                    extra: Map::new(),
+                })
+        })
+        .collect();
+    ResponsesApiResponse {
+        id: format!("resp_{:016x}", rand::random::<u64>()),
+        created_at: response.created,
+        output,
+        extra: Map::from_iter(
+            [
+                ("model".to_string(), json!(response.model)),
+                ("object".to_string(), json!("response")),
+                ("status".to_string(), json!(status)),
+                ("metadata".to_string(), json!({})),
+                ("parallel_tool_calls".to_string(), json!(false)),
+                ("temperature".to_string(), json!(0.0)),
+                ("tool_choice".to_string(), json!("auto")),
+                ("tools".to_string(), json!([])),
+                ("text".to_string(), json!({})),
+                (
+                    "usage".to_string(),
+                    if provider == "openai" {
+                        json!({
+                            "input_tokens": response.usage.prompt_tokens,
+                            "output_tokens": response.usage.completion_tokens,
+                            "total_tokens": response.usage.total_tokens,
+                            "cost": null,
+                            "input_tokens_details": null,
+                            "output_tokens_details": null,
+                        })
+                    } else {
+                        json!({
+                            "input_tokens": response.usage.prompt_tokens,
+                            "output_tokens": response.usage.completion_tokens,
+                            "total_tokens": response.usage.total_tokens,
+                            "cost": null,
+                            "input_tokens_details": {
+                                "audio_tokens": null,
+                                "cached_tokens": response.usage.prompt_tokens_details.cached_tokens,
+                                "text_tokens": response.usage.prompt_tokens_details.text_tokens,
+                                "cache_write_tokens": response.usage.prompt_tokens_details.cache_creation_tokens,
+                            },
+                            "output_tokens_details": {
+                                "audio_tokens": null,
+                                "reasoning_tokens": 0,
+                                "text_tokens": response.usage.completion_tokens,
+                            },
+                        })
+                    },
+                ),
+            ]
+            .into_iter()
+            .chain((provider == "anthropic").then(|| {
+                (
+                    "provider_specific_fields".to_string(),
+                    json!({"citations": null, "thinking_blocks": null}),
+                )
+            })),
+        ),
+    }
+}
+
+async fn adapter_response(
+    request: ResponsesRequest<'_>,
+    model: &str,
+    provider: &str,
+    input: ResponsesInput,
+) -> Result<ResponsesApiResponse, Error> {
+    let messages = transform_responses_request_to_chat_completions(
+        &input,
+        request
+            .optional_params
+            .get("instructions")
+            .and_then(Value::as_str),
+    );
+    let optional_params = adapter_params(provider, &request.optional_params);
+    let chat_request = ChatCompletionsRequest {
+        model,
+        messages: json!(messages),
+        optional_params,
+        api_key: request.api_key,
+        api_base: request.api_base,
+        custom_llm_provider: Some(provider),
+        extra_headers: request.extra_headers,
+        timeout: request.timeout,
+    };
+    let response = if provider == "openai" {
+        chat_completions_with_config(chat_request, model, &OPENAI_CHAT_COMPLETIONS_CONFIG).await?
+    } else {
+        chat_completions(chat_request).await?
+    };
+    Ok(transform_chat_completions_response_to_responses(
+        response, provider,
+    ))
+}
+
+fn native_url(api_base: Option<&str>) -> String {
+    let base = api_base
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("https://api.openai.com/v1")
+        .trim_end_matches('/');
+    if base.ends_with("/responses") {
+        return base.to_string();
+    }
+    format!("{base}/responses")
+}
+
+#[tracing::instrument(target = "litellm::function_trace", level = "trace", skip_all)]
+async fn execute_responses_provider_call(
+    request: ResponsesRequest<'_>,
+    model: &str,
+    input: ResponsesInput,
+) -> Result<ResponsesApiResponse, Error> {
+    let api_key = request
+        .api_key
+        .map(str::to_string)
+        .or_else(|| std::env::var("OPENAI_API_KEY").ok())
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| Error::Auth("OPENAI_API_KEY is required".to_string()))?;
+    let body = Value::Object(Map::from_iter(
+        [
+            ("model".to_string(), json!(model)),
+            ("input".to_string(), json!(input)),
+        ]
+        .into_iter()
+        .chain(request.optional_params),
+    ));
+    let bytes = serde_json::to_vec(&body).map_err(|error| {
+        Error::InvalidRequest(format!("failed to serialize Responses request: {error}"))
+    })?;
+    let mut headers = string_headers("Responses", request.extra_headers)?;
+    headers.retain(|(name, _)| !name.eq_ignore_ascii_case("authorization"));
+    headers.push(("authorization".to_string(), format!("Bearer {api_key}")));
+    if !has_header(&headers, "content-type") {
+        headers.push(("content-type".to_string(), "application/json".to_string()));
+    }
+    let mut builder = http_client().post(native_url(request.api_base)).body(bytes);
+    for (name, value) in headers {
+        builder = builder.header(name, value);
+    }
+    if let Some(timeout) = request.timeout {
+        builder = builder.timeout(timeout);
+    }
+    let response = http_request(builder).await.map_err(|error| {
+        if error.is_connect() || error.is_builder() {
+            Error::Connect(error.to_string())
+        } else {
+            Error::Network(error.to_string())
+        }
+    })?;
+    let status = response.status();
+    let text = response
+        .text()
+        .await
+        .map_err(|error| Error::Network(error.to_string()))?;
+    if !status.is_success() {
+        return Err(Error::Http {
+            status: status.as_u16(),
+            body: truncate_error_body(&text),
+        });
+    }
+    serde_json::from_str(&text).map_err(|error| {
+        Error::InvalidResponse(format!("invalid Responses response JSON: {error}"))
+    })
+}
+
+#[tracing::instrument(target = "litellm::function_trace", level = "trace", skip_all)]
+pub async fn responses(request: ResponsesRequest<'_>) -> Result<ResponsesApiResponse, Error> {
+    let (model, provider) = resolve_provider(request.model, request.custom_llm_provider)?;
+    let transport = responses_transport(provider, request.use_chat_completions_api)?;
+    let input = parse_input(request.input.clone())?;
+    if let Some(reason) = unsupported_reason(&input, &request.optional_params) {
+        return Err(Error::Unsupported(reason));
+    }
+    match transport {
+        ResponsesTransport::Native => execute_responses_provider_call(request, model, input).await,
+        ResponsesTransport::ChatCompletionsAdapter => {
+            adapter_response(request, model, provider, input).await
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn routing_selects_native_and_adapter_transports() {
+        assert_eq!(
+            responses_transport("openai", false),
+            Ok(ResponsesTransport::Native)
+        );
+        assert_eq!(
+            responses_transport("openai", true),
+            Ok(ResponsesTransport::ChatCompletionsAdapter)
+        );
+        assert_eq!(
+            responses_transport("anthropic", false),
+            Ok(ResponsesTransport::ChatCompletionsAdapter)
+        );
+        assert_eq!(
+            responses_transport("bedrock", false),
+            Ok(ResponsesTransport::ChatCompletionsAdapter)
+        );
+    }
+
+    #[test]
+    fn unsupported_state_declines_before_provider_call() {
+        let reason = responses_decline_reason(
+            "gpt-5",
+            json!("hello"),
+            &Map::from_iter([("previous_response_id".to_string(), json!("resp_1"))]),
+            Some("openai"),
+            false,
+        );
+        assert_eq!(reason, Some("unrecognized Responses parameter"));
+    }
+}

--- a/litellm-rust/crates/core/src/responses/http_types.rs
+++ b/litellm-rust/crates/core/src/responses/http_types.rs
@@ -1,0 +1,82 @@
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum ResponsesInput {
+    Text(String),
+    Items(Vec<ResponsesInputItem>),
+}
+
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct ResponsesInputItem {
+    pub role: String,
+    pub content: ResponsesInputContent,
+    #[serde(flatten)]
+    pub extra: Map<String, Value>,
+}
+
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum ResponsesInputContent {
+    Text(String),
+    Parts(Vec<ResponsesInputTextPart>),
+}
+
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct ResponsesInputTextPart {
+    #[serde(rename = "type")]
+    pub part_type: String,
+    pub text: String,
+    #[serde(flatten)]
+    pub extra: Map<String, Value>,
+}
+
+pub struct ResponsesRequest<'a> {
+    pub model: &'a str,
+    pub input: Value,
+    pub optional_params: Map<String, Value>,
+    pub api_key: Option<&'a str>,
+    pub api_base: Option<&'a str>,
+    pub custom_llm_provider: Option<&'a str>,
+    pub extra_headers: Option<Map<String, Value>>,
+    pub timeout: Option<Duration>,
+    pub use_chat_completions_api: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct ResponsesApiResponse {
+    pub id: String,
+    pub created_at: u64,
+    pub output: Vec<ResponsesOutputItem>,
+    #[serde(flatten)]
+    pub extra: Map<String, Value>,
+}
+
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(tag = "type")]
+pub enum ResponsesOutputItem {
+    #[serde(rename = "message")]
+    Message {
+        id: String,
+        status: String,
+        role: String,
+        content: Vec<ResponsesOutputContent>,
+        #[serde(flatten)]
+        extra: Map<String, Value>,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(tag = "type")]
+pub enum ResponsesOutputContent {
+    #[serde(rename = "output_text")]
+    OutputText {
+        text: String,
+        annotations: Vec<Value>,
+        #[serde(flatten)]
+        extra: Map<String, Value>,
+    },
+}

--- a/litellm-rust/crates/core/src/responses/mod.rs
+++ b/litellm-rust/crates/core/src/responses/mod.rs
@@ -1,3 +1,7 @@
+mod http;
+pub mod http_types;
 pub mod instrumentation;
 pub mod types;
 pub mod websocket;
+
+pub use http::{ResponsesTransport, responses, responses_decline_reason, responses_transport};

--- a/litellm-rust/crates/python-bridge/src/lib.rs
+++ b/litellm-rust/crates/python-bridge/src/lib.rs
@@ -105,6 +105,9 @@ mod tests {
                 "chat_completions_decline",
                 "chat_completions",
                 "achat_completions",
+                "responses_decline",
+                "responses",
+                "aresponses",
                 "ResponsesWebSocketConnection",
                 "gil_stats",
             ];
@@ -148,6 +151,8 @@ mod tests {
                         "amessages",
                         "chat_completions",
                         "achat_completions",
+                        "responses",
+                        "aresponses",
                         "gateway_messages",
                     ]
                 );

--- a/litellm-rust/crates/python-bridge/src/routes/mod.rs
+++ b/litellm-rust/crates/python-bridge/src/routes/mod.rs
@@ -10,12 +10,14 @@ mod audio_transcription;
 mod chat_completions;
 mod messages;
 mod ocr;
+mod responses;
 
 pub(crate) fn register(module: &Bound<'_, PyModule>) -> PyResult<()> {
     ocr::register(module)?;
     audio_transcription::register(module)?;
     messages::register(module)?;
     chat_completions::register(module)?;
+    responses::register(module)?;
     #[cfg(feature = "trace-parity")]
     {
         let trace = PyModule::new(module.py(), "_trace")?;
@@ -23,6 +25,7 @@ pub(crate) fn register(module: &Bound<'_, PyModule>) -> PyResult<()> {
         audio_transcription::register_trace(&trace)?;
         messages::register_trace(&trace)?;
         chat_completions::register_trace(&trace)?;
+        responses::register_trace(&trace)?;
         gateway_messages::register_trace(&trace)?;
         module.add_submodule(&trace)?;
     }

--- a/litellm-rust/crates/python-bridge/src/routes/responses.rs
+++ b/litellm-rust/crates/python-bridge/src/routes/responses.rs
@@ -1,0 +1,98 @@
+use std::future::Future;
+
+use litellm_core::Error;
+use litellm_core::responses::http_types::{ResponsesApiResponse, ResponsesRequest};
+use litellm_core::responses::{responses as run_responses, responses_decline_reason};
+use pyo3::prelude::*;
+use serde_json::Value;
+
+use crate::errors::chat_completions_error_to_pyerr;
+use crate::marshal::{RouteOptions, RouteOptionsInputs, object_or_empty, required_value};
+
+fn prepare_responses(
+    inputs: ResponsesInputs,
+) -> PyResult<impl Future<Output = Result<ResponsesApiResponse, Error>> + Send + 'static> {
+    let input = required_value(
+        "input",
+        inputs.input,
+        |value| value.is_string() || value.is_array(),
+        "string or list",
+    )?;
+    let optional_params = object_or_empty("optional_params", inputs.optional_params)?;
+    let options = RouteOptions::from_python(RouteOptionsInputs {
+        model: inputs.model,
+        api_key: inputs.api_key,
+        api_base: inputs.api_base,
+        custom_llm_provider: inputs.custom_llm_provider,
+        extra_headers: inputs.extra_headers,
+        timeout_seconds: inputs.timeout_seconds,
+    })?;
+
+    Ok(async move {
+        let RouteOptions {
+            model,
+            api_key,
+            api_base,
+            custom_llm_provider,
+            extra_headers,
+            timeout,
+        } = options;
+        run_responses(ResponsesRequest {
+            model: &model,
+            input,
+            optional_params,
+            api_key: api_key.as_deref(),
+            api_base: api_base.as_deref(),
+            custom_llm_provider: custom_llm_provider.as_deref(),
+            extra_headers,
+            timeout,
+            use_chat_completions_api: inputs.use_chat_completions_api.unwrap_or(false),
+        })
+        .await
+    })
+}
+
+#[pyfunction]
+#[pyo3(signature = (model, input, optional_params=None, custom_llm_provider=None, use_chat_completions_api=false))]
+fn responses_decline(
+    model: String,
+    #[pyo3(from_py_with = litellm_python_interop::from_py)] input: Value,
+    #[pyo3(from_py_with = litellm_python_interop::from_py)] optional_params: Option<Value>,
+    custom_llm_provider: Option<String>,
+    use_chat_completions_api: bool,
+) -> PyResult<Option<String>> {
+    let optional_params = object_or_empty("optional_params", optional_params)?;
+    Ok(responses_decline_reason(
+        &model,
+        input,
+        &optional_params,
+        custom_llm_provider.as_deref(),
+        use_chat_completions_api,
+    )
+    .map(str::to_string))
+}
+
+bridge_route! {
+    sync = responses,
+    asynchronous = aresponses,
+    inputs = ResponsesInputs,
+    required = {
+        model: String,
+        #[pyo3(from_py_with = litellm_python_interop::from_py)]
+        input: serde_json::Value,
+    },
+    optional = {
+        #[pyo3(from_py_with = litellm_python_interop::from_py)]
+        optional_params: Option<serde_json::Value>,
+        api_key: Option<String>,
+        api_base: Option<String>,
+        custom_llm_provider: Option<String>,
+        #[pyo3(from_py_with = litellm_python_interop::from_py)]
+        extra_headers: Option<serde_json::Value>,
+        timeout_seconds: Option<f64>,
+        use_chat_completions_api: Option<bool>,
+    },
+    prepare = prepare_responses,
+    errors = chat_completions_error_to_pyerr,
+    extra = [responses_decline],
+}

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -1173,6 +1173,35 @@ def responses(
         if _file_search_dispatch is not None:
             return _file_search_dispatch
 
+        from litellm.rust_bridge.responses import responses as rust_responses
+        from litellm.rust_bridge.responses import rust_responses_accepts
+
+        rust_override: Final = kwargs.get("rust")
+        if rust_responses_accepts(
+            model=model,
+            input=input,
+            optional_params=response_api_optional_params,
+            custom_llm_provider=custom_llm_provider,
+            use_chat_completions_api=use_chat_completions_api,
+            stream=stream,
+            request_override=rust_override if isinstance(rust_override, bool) else None,
+            extra_body=extra_body,
+            extra_query=extra_query,
+        ):
+            rust_response: Final = rust_responses(
+                model=model,
+                input=input,
+                optional_params=response_api_optional_params,
+                api_key=litellm_params.api_key,
+                api_base=litellm_params.api_base,
+                custom_llm_provider=custom_llm_provider,
+                extra_headers=extra_headers,
+                timeout=timeout if timeout is not None else request_timeout,
+                use_chat_completions_api=use_chat_completions_api,
+            )
+            if rust_response is not None:
+                return rust_response
+
         if _bridges_to_chat_completions(responses_api_provider_config, use_chat_completions_api):
             return litellm_completion_transformation_handler.response_api_handler(
                 model=model,

--- a/litellm/rust_bridge/responses.py
+++ b/litellm/rust_bridge/responses.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Final, Protocol
+
+import httpx
+from pydantic import TypeAdapter
+
+from litellm._logging import verbose_logger
+from litellm.exceptions import APIError
+from litellm.rust_bridge.configuration import rust_enabled
+from litellm.rust_bridge.loader import get_native_bridge
+from litellm.rust_bridge.timeouts import timeout_to_seconds
+from litellm.types.llms.openai import ResponsesAPIResponse
+from litellm.types.responses.main import GenericResponseOutputItem
+
+RUST_RESPONSES_PROVIDERS: Final = frozenset({"openai", "anthropic", "bedrock"})
+_GENERIC_OUTPUT_ADAPTER: Final = TypeAdapter(list[GenericResponseOutputItem])
+
+
+class RustResponses(Protocol):
+    def __call__(
+        self,
+        *,
+        model: str,
+        input: str | Sequence[object],
+        optional_params: Mapping[str, object] | None,
+        api_key: str | None,
+        api_base: str | None,
+        custom_llm_provider: str | None,
+        extra_headers: Mapping[str, object] | None,
+        timeout_seconds: float | None,
+        use_chat_completions_api: bool | None,
+    ) -> Mapping[str, object]: ...
+
+
+class RustResponsesDecline(Protocol):
+    def __call__(
+        self,
+        *,
+        model: str,
+        input: str | Sequence[object],
+        optional_params: Mapping[str, object] | None,
+        custom_llm_provider: str | None,
+        use_chat_completions_api: bool,
+    ) -> str | None: ...
+
+
+class _Unset:
+    pass
+
+
+_UNSET: Final = _Unset()
+
+
+@dataclass(slots=True)
+class _RustResponsesState:
+    responses: RustResponses | None = None
+    decline: RustResponsesDecline | None = None
+
+
+_STATE: Final = _RustResponsesState()
+
+
+def set_rust_responses(
+    *,
+    responses: RustResponses | None | _Unset = _UNSET,
+    decline: RustResponsesDecline | None | _Unset = _UNSET,
+) -> None:
+    if not isinstance(responses, _Unset):
+        _STATE.responses = responses
+    if not isinstance(decline, _Unset):
+        _STATE.decline = decline
+
+
+def _load_responses() -> RustResponses | None:
+    if _STATE.responses is not None:
+        return _STATE.responses
+    native_bridge: Final = get_native_bridge()
+    if native_bridge is None:
+        return None
+    loaded: Final[RustResponses | None] = getattr(native_bridge, "responses", None)
+    return loaded
+
+
+def _load_decline() -> RustResponsesDecline | None:
+    if _STATE.decline is not None:
+        return _STATE.decline
+    native_bridge: Final = get_native_bridge()
+    if native_bridge is None:
+        return None
+    loaded: Final[RustResponsesDecline | None] = getattr(native_bridge, "responses_decline", None)
+    return loaded
+
+
+def rust_responses_accepts(
+    *,
+    model: str,
+    input: str | Sequence[object],
+    optional_params: Mapping[str, object],
+    custom_llm_provider: str | None,
+    use_chat_completions_api: bool,
+    stream: object,
+    request_override: bool | None,
+    extra_body: Mapping[str, object] | None,
+    extra_query: Mapping[str, object] | None,
+) -> bool:
+    if custom_llm_provider not in RUST_RESPONSES_PROVIDERS or stream:
+        return False
+    if extra_body or extra_query or not rust_enabled(request_override=request_override):
+        return False
+    decline: Final = _load_decline()
+    if decline is None:
+        return False
+    try:
+        reason: Final = decline(
+            model=model,
+            input=input,
+            optional_params=optional_params,
+            custom_llm_provider=custom_llm_provider,
+            use_chat_completions_api=use_chat_completions_api,
+        )
+    except Exception as rust_error:  # noqa: BLE001  # rollout gate failures safely stay on Python
+        verbose_logger.debug("Rust Responses gate raised %s", type(rust_error).__name__)
+        return False
+    if reason is not None:
+        verbose_logger.debug("Rust Responses declined (%s)", reason)
+        return False
+    return True
+
+
+def _raise_or_decline(error: BaseException, *, model: str, provider: str | None) -> None:
+    native_bridge: Final = get_native_bridge()
+    upstream: Final = getattr(native_bridge, "RustUpstreamError", None) if native_bridge is not None else None
+    declined: Final = getattr(native_bridge, "RustBridgeDeclined", None) if native_bridge is not None else None
+    if isinstance(upstream, type) and isinstance(error, upstream):
+        args: Final = error.args
+        status: Final = args[0] if args else 0
+        message: Final = args[1] if len(args) > 1 else ""
+        raise APIError(
+            status_code=int(status) or 500,
+            message=f"litellm rust responses: {message}",
+            llm_provider=provider or "",
+            model=model,
+        )
+    if isinstance(declined, type) and isinstance(error, declined):
+        return
+    raise error
+
+
+def _build_response(
+    response_data: Mapping[str, object],
+    *,
+    native_openai: bool,
+) -> ResponsesAPIResponse:
+    if native_openai:
+        return ResponsesAPIResponse.model_validate(response_data)
+    output: Final = _GENERIC_OUTPUT_ADAPTER.validate_python(response_data.get("output"))
+    return ResponsesAPIResponse.model_validate(MappingProxyType({**response_data, "output": output}))
+
+
+def responses(
+    *,
+    model: str,
+    input: str | Sequence[object],
+    optional_params: Mapping[str, object],
+    api_key: str | None,
+    api_base: str | None,
+    custom_llm_provider: str | None,
+    extra_headers: Mapping[str, object] | None,
+    timeout: float | httpx.Timeout | None,
+    use_chat_completions_api: bool,
+) -> ResponsesAPIResponse | None:
+    rust_responses: Final = _load_responses()
+    if rust_responses is None:
+        return None
+    try:
+        rust_response: Final = rust_responses(
+            model=model,
+            input=input,
+            optional_params=optional_params,
+            api_key=api_key,
+            api_base=api_base,
+            custom_llm_provider=custom_llm_provider,
+            extra_headers=extra_headers,
+            timeout_seconds=timeout_to_seconds(timeout),
+            use_chat_completions_api=use_chat_completions_api,
+        )
+    except Exception as rust_error:  # noqa: BLE001  # upstream failures must not retry and double bill
+        _raise_or_decline(rust_error, model=model, provider=custom_llm_provider)
+        return None
+    built: Final = _build_response(
+        rust_response,
+        native_openai=custom_llm_provider == "openai" and not use_chat_completions_api,
+    )
+    return built

--- a/tests/rust-python-harness/AGENTS.md
+++ b/tests/rust-python-harness/AGENTS.md
@@ -13,7 +13,10 @@ tests/rust-python-harness/
 │   │   ├── __init__.py
 │   │   ├── reporting.py
 │   │   ├── sdk/
-│   │   │   └── ocr/
+│   │   │   ├── chat_completions/
+│   │   │   ├── messages/
+│   │   │   ├── ocr/
+│   │   │   └── responses/
 │   │
 │   ├── trace_parity/
 │   │   ├── __init__.py
@@ -65,6 +68,8 @@ tests/rust-python-harness/
 - `e2e_parity/` compares SDK objects, exceptions, callbacks, and streams, or gateway HTTP responses
 - `trace_parity/` compares mapped operations, call counts, and required execution ordering; before running it rebuilds the native bridge with the `trace-parity` feature whenever `litellm-rust` sources are newer than the installed extension (`shared/native_build.py`)
 - E2E and trace strategies load their registered module cases and run surface-specific execution from their folders
+- E2E SDK contracts share subprocess execution, typed outcome capture, narrow normalization rules, and ordered replay matching; each API owns its inputs, invocation, and recording strategy
+- Generate API fixtures with the API's `fixtures.record` module and shared `--examples`, `--concurrency`, and `--fixture-dir` options; recording always runs the Python baseline
 - `unit_tests_mapping/contracts.py` owns typed harness-side mapping contracts, per-function contracts live below `cases/`, and `mappings.py` exports the registry; live test discovery derives unmapped Python and Rust-only tests without an exhaustive manifest
 - `unit_tests_mapping/runner.py` validates confirmed mappings against the live Python and Rust inventories and attaches the derived status report
 - `unit_tests_parity/runner.py` runs each contract's `unit_parity_scope` with `LITELLM_RUST=0` and `LITELLM_RUST=1` in separate processes and requires matching outcomes, including failures; exclusions require a reason in the contract

--- a/tests/rust-python-harness/shared/parity/compare.py
+++ b/tests/rust-python-harness/shared/parity/compare.py
@@ -9,14 +9,19 @@ from .models import CapturedRequest, Execution
 
 
 def validate_harness(baseline: Execution, candidate: Execution, baseline_user_agent: str) -> None:
+    def is_python_route(user_agent: str | None) -> bool:
+        return user_agent == baseline_user_agent or (user_agent or "").startswith(
+            ("OpenAI/Python ", "AsyncOpenAI/Python ")
+        )
+
     for request in baseline.requests:
-        if request.user_agent != baseline_user_agent:
+        if not is_python_route(request.user_agent):
             raise AssertionError(
                 f"baseline provider request did not carry sentinel user-agent {baseline_user_agent!r}: "
                 f"{request.user_agent!r}"
             )
     for request in candidate.requests:
-        if request.user_agent == baseline_user_agent:
+        if is_python_route(request.user_agent):
             raise AssertionError("candidate route fell back to the baseline HTTP implementation")
 
 

--- a/tests/rust-python-harness/shared/parity/compare.py
+++ b/tests/rust-python-harness/shared/parity/compare.py
@@ -51,9 +51,12 @@ def assert_value_parity(baseline: object, candidate: object, *, path: str = "$")
     if isinstance(baseline, Mapping) and isinstance(candidate, Mapping):
         baseline_mapping: Final = cast(Mapping[object, object], baseline)
         candidate_mapping: Final = cast(Mapping[object, object], candidate)
-        assert frozenset((type(key), key) for key in baseline_mapping) == frozenset(
-            (type(key), key) for key in candidate_mapping
-        ), f"mapping keys differ at {path}"
+        baseline_keys: Final = frozenset((type(key), key) for key in baseline_mapping)
+        candidate_keys: Final = frozenset((type(key), key) for key in candidate_mapping)
+        assert baseline_keys == candidate_keys, (
+            f"mapping keys differ at {path}: "
+            f"baseline-only={baseline_keys - candidate_keys!r}, candidate-only={candidate_keys - baseline_keys!r}"
+        )
         for key in baseline_mapping:
             assert_value_parity(baseline_mapping[key], candidate_mapping[key], path=f"{path}.{key}")
         return

--- a/tests/rust-python-harness/shared/parity/fixture_models.py
+++ b/tests/rust-python-harness/shared/parity/fixture_models.py
@@ -5,7 +5,7 @@ from typing import ClassVar, Final, Generic, Literal, TypeVar, cast
 
 from pydantic import BaseModel, ConfigDict, Field, JsonValue, model_validator
 
-from .recorded_http import RecordedResponse
+from .recorded_http import RecordedRequestMatcher, RecordedResponse
 
 JsonObject = dict[str, JsonValue]
 
@@ -50,6 +50,7 @@ InputT = TypeVar("InputT", bound=SdkInputBase)
 
 class ParityCase(FixtureModel, Generic[InputT]):
     litellm_input: InputT
+    provider_requests: tuple[RecordedRequestMatcher, ...] = ()
     provider_responses: tuple[RecordedResponse, ...]
 
     @model_validator(mode="before")

--- a/tests/rust-python-harness/shared/parity/fixtures/cassette.py
+++ b/tests/rust-python-harness/shared/parity/fixtures/cassette.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from datetime import datetime
 from itertools import accumulate
 from typing import Final, Literal
+from urllib.parse import urlsplit
 
 from pydantic import AwareDatetime, BaseModel, ConfigDict, Field
 from vcr.serialize import serialize
@@ -13,6 +14,7 @@ from ..recorded_http import (
     HttpHeader,
     RecordedHttpResponse,
     RecordedHttpStreamResponse,
+    RecordedRequestMatcher,
     RecordedResponse,
     RecordedStreamChunk,
 )
@@ -41,6 +43,11 @@ class _Request(_CassetteModel):
     uri: str
     body: str | bytes | None
     headers: dict[str, tuple[str, ...]]
+
+    def matcher(self) -> RecordedRequestMatcher:
+        parsed: Final = urlsplit(self.uri)
+        path: Final = f"{parsed.path}{'?' + parsed.query if parsed.query else ''}"
+        return RecordedRequestMatcher(method=self.method, path=path)
 
 
 class _Response(_CassetteModel):
@@ -85,9 +92,14 @@ class ParityCassette(_CassetteModel):
     interactions: tuple[_Interaction, ...]
     parity: _ParityMetadata = Field(alias="x-litellm")
 
-    def case_data(self) -> dict[str, object]:
+    def case_data(self, *, include_requests: bool = False) -> dict[str, object]:
         return {
             **self.parity.case,
+            **(
+                {"provider_requests": tuple(item.request.matcher() for item in self.interactions)}
+                if include_requests
+                else {}
+            ),
             "provider_responses": tuple(item.response.recorded_response() for item in self.interactions),
         }
 
@@ -135,7 +147,9 @@ def serialize_cassette(
         "x-litellm": {
             "schema_version": 1,
             "request_source": request_source,
-            "case": {key: value for key, value in case.items() if key != "provider_responses"},
+            "case": {
+                key: value for key, value in case.items() if key not in {"provider_requests", "provider_responses"}
+            },
         },
     }
     ParityCassette.model_validate(payload).case_data()

--- a/tests/rust-python-harness/shared/parity/fixtures/pipeline.py
+++ b/tests/rust-python-harness/shared/parity/fixtures/pipeline.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -9,6 +10,7 @@ from typing import Final, Generic, Literal, Protocol, TypeVar
 
 from hypothesis.strategies import SearchStrategy
 
+from ..recorded_http import RecordedResponse
 from .inputs import generate_case_inputs
 from .recording import UpstreamEndpoint, record_upstream_interactions
 from .store import (
@@ -117,7 +119,11 @@ def build_recording_jobs(
     )
 
 
-def _record_job(job: RecordingJob[InputT], case_type: type[CaseT]) -> RecordedFixture | CachedFixture:
+def _record_job(
+    job: RecordingJob[InputT],
+    case_type: type[CaseT],
+    case_factory: Callable[[InputT, tuple[RecordedResponse, ...]], CaseT] | None,
+) -> RecordedFixture | CachedFixture:
     cached: Final = load_fixture(job.directory, job.case_input, case_type)
     if cached is not None:
         path: Final = fixture_path(job.directory, job.case_input)
@@ -134,11 +140,16 @@ def _record_job(job: RecordingJob[InputT], case_type: type[CaseT]) -> RecordedFi
     status: Final = interactions[-1].response.status_code
     if status in {408, 429} or status >= 500:
         raise RuntimeError(f"Upstream returned transient HTTP {status}; rerun recording to retry")
-    case: Final = case_type.model_validate(
-        {
-            "litellm_input": job.case_input,
-            "provider_responses": tuple(item.response for item in interactions),
-        }
+    provider_responses: Final = tuple(item.response for item in interactions)
+    case: Final = (
+        case_factory(job.case_input, provider_responses)
+        if case_factory is not None
+        else case_type.model_validate(
+            {
+                "litellm_input": job.case_input,
+                "provider_responses": provider_responses,
+            }
+        )
     )
     saved_path: Final = save_fixture(job.directory, job.case_input, case, interactions)
     return RecordedFixture(target_name=job.target_name, case_id=job.case_id, path=saved_path)
@@ -173,6 +184,7 @@ def record_fixtures(
     examples: int,
     concurrency: int,
     case_type: type[CaseT],
+    case_factory: Callable[[InputT, tuple[RecordedResponse, ...]], CaseT] | None = None,
 ) -> RecordingSummary:
     if concurrency < 1:
         raise ValueError("concurrency must be at least 1")
@@ -180,7 +192,9 @@ def record_fixtures(
     total: Final = len(jobs)
     LOGGER.info("Recording %d fixtures across %d targets with concurrency %d", total, len(targets), concurrency)
     with ThreadPoolExecutor(max_workers=concurrency) as executor:
-        future_jobs: Final = MappingProxyType({executor.submit(_record_job, job, case_type): job for job in jobs})
+        future_jobs: Final = MappingProxyType(
+            {executor.submit(_record_job, job, case_type, case_factory): job for job in jobs}
+        )
         outcomes: Final = tuple(
             _completed_outcome(completed, total, future_jobs[future], future)
             for completed, future in enumerate(as_completed(future_jobs), start=1)

--- a/tests/rust-python-harness/shared/parity/fixtures/store.py
+++ b/tests/rust-python-harness/shared/parity/fixtures/store.py
@@ -15,6 +15,8 @@ from .cassette import deserialize_cassette, serialize_cassette
 from .recording import RecordedInteraction
 
 FIXTURE_SCHEMA_VERSION: Final = 1
+
+
 class FixtureInput(Protocol):
     def canonical_input(self) -> dict[str, object]: ...
 
@@ -91,7 +93,9 @@ def read_fixture(path: Path, case_type: type[CaseT]) -> CaseT:
         return _load_fixture(JSON_OBJECT_ADAPTER.validate_json(contents), path, case_type)
     try:
         cassette: Final = deserialize_cassette(contents)
-        return case_type.model_validate(cassette.case_data())
+        return case_type.model_validate(
+            cassette.case_data(include_requests="provider_requests" in case_type.model_fields)
+        )
     except ValueError as error:
         raise ValueError(f"invalid parity cassette {path}") from error
 

--- a/tests/rust-python-harness/shared/parity/fixtures/test_cassette.py
+++ b/tests/rust-python-harness/shared/parity/fixtures/test_cassette.py
@@ -12,7 +12,9 @@ from vcr.request import Request
 from ..fixture_models import ParityCase, SdkInputBase
 from ..recorded_http import (
     HttpHeader,
+    RecordedExchange,
     RecordedHttpResponse,
+    RecordedRequestMatcher,
     RecordedHttpStreamResponse,
     RecordedResponse,
     RecordedStreamChunk,
@@ -23,6 +25,7 @@ from .recording import RecordedInteraction
 from .store import load_fixture, save_fixture
 
 _URI: Final = "http://parity-provider.invalid/operation?api-version=1"
+_MATCHER: Final = RecordedRequestMatcher(method="POST", path="/operation?api-version=1")
 
 
 class _Input(SdkInputBase):
@@ -47,7 +50,9 @@ def test_cassette_replays_repeated_requests_with_vcr_and_preserves_bytes(tmp_pat
     timestamp: Final = datetime(2020, 1, 1, tzinfo=timezone.utc)
     path: Final = save_fixture(tmp_path, sdk_input, case, interactions, recorded_at=timestamp)
 
-    assert load_fixture(tmp_path, sdk_input, ParityCase[_Input]) == case
+    assert load_fixture(tmp_path, sdk_input, ParityCase[_Input]) == case.model_copy(
+        update={"provider_requests": (_MATCHER, _MATCHER)}
+    )
     assert deserialize_cassette(path.read_text()).recorded_at == timestamp
     with VCR().use_cassette(str(path), record_mode="none", match_on=("method", "uri", "body")) as cassette:
         for status in (200, 429):
@@ -71,7 +76,7 @@ def test_stream_cassette_preserves_chunk_boundaries_through_local_replay(tmp_pat
         tmp_path, sdk_input, case, (RecordedInteraction(Request("POST", _URI, b"{}", {}), response),)
     )
     loaded: Final = load_fixture(tmp_path, sdk_input, ParityCase[_Input])
-    assert loaded == case
+    assert loaded == case.model_copy(update={"provider_requests": (_MATCHER,)})
     with replay_server() as server:
         server.enqueue_response(loaded.provider_responses[0])
         with httpx.stream("POST", f"{server.url}/operation", content=b"{}") as replayed:
@@ -92,7 +97,9 @@ def test_cassette_preserves_duplicate_response_headers(tmp_path: Path) -> None:
     case: Final = ParityCase[_Input](litellm_input=sdk_input, provider_responses=(response,))
     save_fixture(tmp_path, sdk_input, case, (RecordedInteraction(Request("POST", _URI, b"", {}), response),))
 
-    assert load_fixture(tmp_path, sdk_input, ParityCase[_Input]) == case
+    assert load_fixture(tmp_path, sdk_input, ParityCase[_Input]) == case.model_copy(
+        update={"provider_requests": (_MATCHER,)}
+    )
 
 
 def test_local_replay_skips_recorded_retry_delay() -> None:
@@ -108,3 +115,21 @@ def test_local_replay_skips_recorded_retry_delay() -> None:
         server.take_requests(1)
 
     assert replayed.headers["retry-after"] == "0"
+
+
+def test_local_replay_rejects_out_of_order_request() -> None:
+    response: Final = RecordedHttpResponse.from_bytes(200, (), b"{}")
+
+    with replay_server() as server:
+        server.enqueue_response(
+            RecordedExchange(
+                request=RecordedRequestMatcher(method="POST", path="/v1/expected"),
+                response=response,
+            )
+        )
+        replayed: Final = httpx.post(f"{server.url}/v1/wrong", content=b"{}")
+        requests: Final = server.take_requests(1)
+
+    assert replayed.status_code == 500
+    assert requests[0].path == "/v1/wrong"
+    assert "expected POST /v1/expected" in replayed.text

--- a/tests/rust-python-harness/shared/parity/fixtures/test_pipeline.py
+++ b/tests/rust-python-harness/shared/parity/fixtures/test_pipeline.py
@@ -21,7 +21,7 @@ from .pipeline import (
     record_fixtures,
 )
 from .recording import UpstreamEndpoint
-from .store import fixture_path
+from .store import fixture_path, load_fixture
 
 
 class _FixtureInput(BaseModel):
@@ -40,13 +40,20 @@ class _ParityCase(BaseModel):
     provider_responses: tuple[RecordedResponse, ...]
 
 
+class _FactoryCase(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    request: _FixtureInput
+    provider_responses: tuple[RecordedResponse, ...]
+
+
 class _Upstream(LocalHttpServer):
     def __init__(self, status: int = 200) -> None:
         super().__init__(("127.0.0.1", 0), _UpstreamHandler)
         self.response_status: Final = status
 
-class _UpstreamHandler(LocalHttpHandler):
 
+class _UpstreamHandler(LocalHttpHandler):
     def do_POST(self) -> None:
         length: Final = int(self.headers.get("content-length") or "0")
         self.rfile.read(length)
@@ -58,6 +65,7 @@ class _UpstreamHandler(LocalHttpHandler):
         self.send_header("content-length", str(len(body)))
         self.end_headers()
         self.wfile.write(body)
+
 
 def _upstream(status: int = 200) -> AbstractContextManager[_Upstream]:
     return serve_in_thread(_Upstream(status))
@@ -193,3 +201,31 @@ def test_provider_rejected_response_can_be_recorded(tmp_path: Path) -> None:
         summary: Final = record_fixtures((target,), tmp_path, 1, 1, _ParityCase)
     assert summary.exit_code == 0
     assert len(summary.recorded) == 1
+
+
+def test_case_factory_supports_nonstandard_case_shapes(tmp_path: Path) -> None:
+    case_input: Final = _FixtureInput(identifier="factory")
+
+    def case_factory(
+        recorded_input: _FixtureInput,
+        responses: tuple[RecordedResponse, ...],
+    ) -> _FactoryCase:
+        return _FactoryCase(request=recorded_input, provider_responses=responses)
+
+    with _upstream() as upstream:
+        target: Final = _target("factory", upstream.url, case_input, _Invocation())
+        summary: Final = record_fixtures(
+            (target,),
+            tmp_path,
+            1,
+            1,
+            _FactoryCase,
+            case_factory=case_factory,
+        )
+
+    loaded: Final = load_fixture(tmp_path / "factory", case_input, _FactoryCase)
+    assert summary.exit_code == 0
+    assert loaded is not None
+    assert loaded.request == case_input
+    assert len(loaded.provider_responses) == 1
+    assert loaded.provider_responses[0].status_code == 200

--- a/tests/rust-python-harness/shared/parity/models.py
+++ b/tests/rust-python-harness/shared/parity/models.py
@@ -21,6 +21,7 @@ class SDKSuccess(BaseModel):
 
     status: Literal["ok"] = "ok"
     response: JsonValue
+    response_type: str | None = None
 
 
 class SDKError(BaseModel):
@@ -42,6 +43,7 @@ class SDKJsonChunk(BaseModel):
 
     kind: Literal["json"] = "json"
     value: JsonValue
+    value_type: str | None = None
 
 
 class SDKBytesChunk(BaseModel):
@@ -49,6 +51,7 @@ class SDKBytesChunk(BaseModel):
 
     kind: Literal["bytes"] = "bytes"
     data_b64: str
+    value_type: str = "builtins.bytes"
 
     def data_bytes(self) -> bytes:
         return base64.b64decode(self.data_b64, validate=True)
@@ -89,8 +92,24 @@ def sdk_chunk(value: object) -> SDKChunk:
     if isinstance(value, bytes):
         return SDKBytesChunk(data_b64=base64.b64encode(value).decode("ascii"))
     if isinstance(value, BaseModel):
-        return SDKJsonChunk(value=JSON_VALUE_ADAPTER.validate_python(value.model_dump(mode="json")))
-    return SDKJsonChunk(value=JSON_VALUE_ADAPTER.validate_python(value))
+        return SDKJsonChunk(
+            value=JSON_VALUE_ADAPTER.validate_python(value.model_dump(mode="json")),
+            value_type=f"{type(value).__module__}.{type(value).__qualname__}",
+        )
+    return SDKJsonChunk(
+        value=JSON_VALUE_ADAPTER.validate_python(value),
+        value_type=f"{type(value).__module__}.{type(value).__qualname__}",
+    )
+
+
+def sdk_success(value: object) -> SDKSuccess:
+    response: Final = JSON_VALUE_ADAPTER.validate_python(
+        value.model_dump(mode="json") if isinstance(value, BaseModel) else value
+    )
+    return SDKSuccess(
+        response=response,
+        response_type=f"{type(value).__module__}.{type(value).__qualname__}",
+    )
 
 
 def _string_attribute(error: Exception, name: str) -> str | None:

--- a/tests/rust-python-harness/shared/parity/normalization.py
+++ b/tests/rust-python-harness/shared/parity/normalization.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import reduce
+from typing import Final, TypeAlias, cast
+
+from pydantic import JsonValue
+
+from .models import Execution
+
+JsonPathPart: TypeAlias = str | int
+JsonPath: TypeAlias = tuple[JsonPathPart, ...]
+MASKED_VALUE: Final = "<volatile>"
+
+
+@dataclass(frozen=True, slots=True)
+class NormalizationSpec:
+    request_headers: frozenset[str] = frozenset()
+    request_body_paths: tuple[JsonPath, ...] = ()
+    report_paths: tuple[JsonPath, ...] = ()
+
+
+def _mask_path(value: JsonValue, path: JsonPath) -> JsonValue:
+    if not path:
+        return MASKED_VALUE
+    head, *tail = path
+    remaining: Final = tuple(tail)
+    if isinstance(head, str) and isinstance(value, dict) and head in value:
+        return {**value, head: _mask_path(value[head], remaining)}
+    if isinstance(head, int) and isinstance(value, list) and 0 <= head < len(value):
+        return [_mask_path(item, remaining) if index == head else item for index, item in enumerate(value)]
+    return value
+
+
+def _mask_paths(value: JsonValue, paths: tuple[JsonPath, ...]) -> JsonValue:
+    return reduce(_mask_path, paths, value)
+
+
+def normalize_execution(execution: Execution, spec: NormalizationSpec) -> Execution:
+    lowered_headers: Final = frozenset(name.lower() for name in spec.request_headers)
+    dumped: Final = cast(dict[str, JsonValue], execution.model_dump(mode="json"))
+    requests: Final = cast(list[dict[str, JsonValue]], dumped["requests"])
+    normalized_requests: Final = [
+        {
+            **request,
+            "headers": [
+                header
+                for header in cast(list[list[str]], request["headers"])
+                if header[0].lower() not in lowered_headers
+            ],
+            "body": _mask_paths(request["body"], spec.request_body_paths),
+        }
+        for request in requests
+    ]
+    report: Final = _mask_paths(dumped["report"], spec.report_paths)
+    return Execution.model_validate({**dumped, "requests": normalized_requests, "report": report})

--- a/tests/rust-python-harness/shared/parity/recorded_http.py
+++ b/tests/rust-python-harness/shared/parity/recorded_http.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import base64
-from typing import Annotated, Literal
+from typing import Annotated, Literal, TypeAlias
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -61,3 +61,16 @@ RecordedResponse = Annotated[
     RecordedHttpResponse | RecordedHttpStreamResponse,
     Field(discriminator="kind"),
 ]
+
+
+class RecordedRequestMatcher(_RecordedHttpModel):
+    method: str
+    path: str
+
+
+class RecordedExchange(_RecordedHttpModel):
+    request: RecordedRequestMatcher
+    response: RecordedResponse
+
+
+ReplayItem: TypeAlias = RecordedResponse | RecordedExchange

--- a/tests/rust-python-harness/shared/parity/replay.py
+++ b/tests/rust-python-harness/shared/parity/replay.py
@@ -4,13 +4,14 @@ import base64
 import queue
 from contextlib import AbstractContextManager
 from typing import Final
+from urllib.parse import parse_qsl, unquote, urlsplit
 
 from pydantic import JsonValue, TypeAdapter
 
 from .http import local_response_header
 from .local_server import LocalHttpHandler, LocalHttpServer, serve_in_thread
 from .models import CapturedRequest
-from .recorded_http import RecordedHttpResponse, RecordedHttpStreamResponse, RecordedResponse
+from .recorded_http import RecordedExchange, RecordedHttpResponse, RecordedHttpStreamResponse, ReplayItem
 
 JSON_VALUE: Final[TypeAdapter[JsonValue]] = TypeAdapter(JsonValue)
 EXCLUDED_REQUEST_HEADERS: Final = frozenset(
@@ -32,13 +33,18 @@ def _replay_response_header(name: str, value: str, provider_url: str) -> str:
     return local_response_header(name, value, provider_url)
 
 
+def _normalized_request_target(value: str) -> tuple[str, tuple[tuple[str, str], ...]]:
+    parsed: Final = urlsplit(value)
+    return unquote(parsed.path), tuple(sorted(parse_qsl(parsed.query, keep_blank_values=True)))
+
+
 class ReplayServer(LocalHttpServer):
     def __init__(self) -> None:
         super().__init__(("127.0.0.1", 0), _ReplayHandler)
-        self.responses: queue.Queue[RecordedResponse] = queue.Queue()
+        self.responses: queue.Queue[ReplayItem] = queue.Queue()
         self.requests: queue.Queue[CapturedRequest] = queue.Queue()
 
-    def enqueue_response(self, response: RecordedResponse) -> None:
+    def enqueue_response(self, response: ReplayItem) -> None:
         self.responses.put(response)
 
     def take_requests(self, expected_count: int) -> tuple[CapturedRequest, ...]:
@@ -100,10 +106,21 @@ class _ReplayHandler(LocalHttpHandler):
             )
         )
         try:
-            response: Final = provider.responses.get(timeout=5)
+            replay_item: Final = provider.responses.get(timeout=5)
         except queue.Empty:
             self.send_error(500, "no replay response queued")
             return
+        if isinstance(replay_item, RecordedExchange):
+            expected: Final = replay_item.request
+            if self.command != expected.method or _normalized_request_target(self.path) != _normalized_request_target(
+                expected.path
+            ):
+                self.send_error(
+                    500,
+                    f"unexpected replay request: {self.command} {self.path}; expected {expected.method} {expected.path}",
+                )
+                return
+        response: Final = replay_item.response if isinstance(replay_item, RecordedExchange) else replay_item
         self.send_response_only(response.status_code)
         for header in response.headers:
             if header.name.lower() not in EXCLUDED_RESPONSE_HEADERS:

--- a/tests/rust-python-harness/shared/parity/runner.py
+++ b/tests/rust-python-harness/shared/parity/runner.py
@@ -21,7 +21,7 @@ from .models import (
     WorkerResult,
     WorkerSuccess,
 )
-from .recorded_http import RecordedResponse
+from .recorded_http import ReplayItem
 from .replay import ReplayServer, replay_server
 
 WORKER_RESULT_PREFIX: Final = "LITELLM_PARITY_RESULT "
@@ -39,9 +39,7 @@ class SubprocessRunner:
         return (
             sys.executable,
             "-m",
-            ".".join(
-                self.entrypoint.resolve().relative_to(PROJECT_ROOT).with_suffix("").parts
-            ),
+            ".".join(self.entrypoint.resolve().relative_to(PROJECT_ROOT).with_suffix("").parts),
             "--parity-worker",
             provider_url,
         )
@@ -82,7 +80,7 @@ class SubprocessWorker:
         self,
         case_file: Path,
         route: str,
-        responses: tuple[RecordedResponse, ...],
+        responses: tuple[ReplayItem, ...],
     ) -> Execution:
         stdin: Final = self.process.stdin
         if stdin is None or self.process.poll() is not None:

--- a/tests/rust-python-harness/shared/parity/test_parity.py
+++ b/tests/rust-python-harness/shared/parity/test_parity.py
@@ -108,6 +108,15 @@ def test_parity_rejects_rust_fallback() -> None:
         assert_parity(python, rust, SENTINEL)
 
 
+@pytest.mark.parametrize("prefix", ["OpenAI/Python ", "AsyncOpenAI/Python "])
+def test_parity_recognizes_openai_sdk_fallbacks(prefix: str) -> None:
+    python: Final = _execution(user_agent=f"{prefix}2.33.0")
+    rust: Final = _execution(user_agent="litellm-rust")
+    assert_parity(python, rust, SENTINEL)
+    with pytest.raises(AssertionError, match="fell back"):
+        assert_parity(python, _execution(user_agent=f"{prefix}2.33.0"), SENTINEL)
+
+
 def test_model_parity_compares_public_values_and_ignores_private_attrs() -> None:
     python: Final = _ComparableResponse(value="same")
     rust: Final = _ComparableResponse(value="same")

--- a/tests/rust-python-harness/shared/parity/test_parity.py
+++ b/tests/rust-python-harness/shared/parity/test_parity.py
@@ -7,7 +7,8 @@ import pytest
 from pydantic import BaseModel, ConfigDict, JsonValue, PrivateAttr
 
 from .compare import assert_model_parity, assert_parity
-from .models import CapturedRequest, Execution, SDKError, SDKSuccess, sdk_error_report
+from .models import CapturedRequest, Execution, SDKError, SDKSuccess, sdk_error_report, sdk_success
+from .normalization import NormalizationSpec, normalize_execution
 
 SENTINEL: Final = "python-parity-fallback"
 
@@ -188,3 +189,33 @@ def test_serialized_parity_rejects_boolean_integer_substitution() -> None:
             _execution(body={"enabled": 1}, user_agent="candidate"),
             SENTINEL,
         )
+
+
+def test_sdk_success_preserves_public_type() -> None:
+    report: Final = sdk_success(_ComparableResponse(value="same"))
+
+    assert report.response_type is not None
+    assert report.response_type.endswith("._ComparableResponse")
+    assert report.response == {"value": "same"}
+
+
+def test_normalization_masks_only_declared_values() -> None:
+    execution: Final = _execution(user_agent=SENTINEL).model_copy(
+        update={
+            "report": SDKSuccess(
+                response={"id": "dynamic", "created": 123, "value": "same"},
+                response_type="example.Response",
+            )
+        }
+    )
+    normalized: Final = normalize_execution(
+        execution,
+        NormalizationSpec(
+            request_headers=frozenset({"authorization"}),
+            report_paths=(("response", "id"), ("response", "created")),
+        ),
+    )
+
+    assert normalized.requests[0].headers == (("content-type", "application/json"),)
+    assert isinstance(normalized.report, SDKSuccess)
+    assert normalized.report.response == {"id": "<volatile>", "created": "<volatile>", "value": "same"}

--- a/tests/rust-python-harness/shared/parity/test_stream.py
+++ b/tests/rust-python-harness/shared/parity/test_stream.py
@@ -339,6 +339,6 @@ async def test_capture_preserves_partial_output_and_complete_error(mode: Literal
     error: Final = _PublicStreamError()
     report: Final = await _capture(mode, (_Chunk(value="partial"),), error)
     assert report == SDKStreamReport(
-        chunks=(SDKJsonChunk(value={"value": "partial"}),),
+        chunks=(SDKJsonChunk(value={"value": "partial"}, value_type=f"{_Chunk.__module__}.{_Chunk.__qualname__}"),),
         terminal=SDKStreamFailed(error=sdk_error_report(error)),
     )

--- a/tests/rust-python-harness/strategies/e2e_parity/__init__.py
+++ b/tests/rust-python-harness/strategies/e2e_parity/__init__.py
@@ -26,15 +26,19 @@ CASES: Final[tuple[CaseDefinition, ...]] = (
     ),
     CaseDefinition(
         "messages",
-        NotImplementedCaseSpec(
-            reason="Bridge unit tests exist, but no standalone end-to-end parity case is registered."
+        ModuleCaseSpec(
+            coverage=Coverage.PARTIAL,
+            module="tests.rust-python-harness.strategies.e2e_parity.sdk.messages.test_sdk_parity",
+            note="Recorded non-streaming async SDK parity; the public Messages sync handler is not implemented.",
         ),
         surface="sdk",
     ),
     CaseDefinition(
         "responses",
-        NotImplementedCaseSpec(
-            reason="Bridge unit tests exist, but no standalone end-to-end parity case is registered."
+        ModuleCaseSpec(
+            coverage=Coverage.PARTIAL,
+            module="tests.rust-python-harness.strategies.e2e_parity.sdk.responses.test_sdk_parity",
+            note="Public Responses sync/async parity through the Rust Chat Completions bridge; no native Responses route.",
         ),
         surface="sdk",
     ),
@@ -45,8 +49,10 @@ CASES: Final[tuple[CaseDefinition, ...]] = (
     ),
     CaseDefinition(
         "chat_completions",
-        NotImplementedCaseSpec(
-            reason="Bridge unit tests exist, but no standalone end-to-end parity case is registered."
+        ModuleCaseSpec(
+            coverage=Coverage.PARTIAL,
+            module="tests.rust-python-harness.strategies.e2e_parity.sdk.chat_completions.test_sdk_parity",
+            note="Recorded non-streaming sync/async SDK parity for Rust-supported providers and inputs.",
         ),
         surface="sdk",
     ),

--- a/tests/rust-python-harness/strategies/e2e_parity/sdk/chat_completions/fixtures/record.py
+++ b/tests/rust-python-harness/strategies/e2e_parity/sdk/chat_completions/fixtures/record.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final, cast
+
+from dotenv import load_dotenv
+from hypothesis import strategies as st
+from hypothesis.strategies import SearchStrategy
+
+import litellm
+from litellm.rust_bridge.configuration import use_litellm_rust
+
+from ......shared.parity.fixtures.cli import parse_recording_args
+from ......shared.parity.fixtures.pipeline import RecordingTarget, record_fixtures
+from ......shared.parity.fixtures.recording import UpstreamEndpoint
+from ......shared.parity.fixtures.store import fixture_directory, fixture_id
+from ......shared.parity.recorded_http import RecordedResponse
+from ..test_sdk_parity import CASES, ChatCase
+
+FIXTURE_DIR_ENV: Final = "LITELLM_CHAT_COMPLETIONS_FIXTURE_DIR"
+DEFAULT_FIXTURE_DIRECTORY: Final = Path(__file__).with_name("data")
+
+
+def input_strategy(model: str) -> SearchStrategy[ChatCase]:
+    conversations: Final = st.sampled_from(
+        (
+            [{"role": "user", "content": "hello"}],
+            [
+                {"role": "system", "content": "be concise"},
+                {"role": "user", "content": "hello"},
+            ],
+            [
+                {"role": "user", "content": "first"},
+                {"role": "assistant", "content": "answer"},
+                {"role": "user", "content": [{"type": "text", "text": "follow up"}]},
+            ],
+        )
+    )
+    params: Final = st.fixed_dictionaries(
+        {"max_tokens": st.integers(min_value=1, max_value=64)},
+        optional={
+            "temperature": st.just(1.0),
+            "top_p": st.just(1.0),
+            "stop": st.lists(st.text(min_size=1, max_size=8), min_size=1, max_size=2),
+        },
+    )
+    return st.builds(
+        ChatCase,
+        name=st.just("generated"),
+        model=st.just(model),
+        messages=conversations,
+        optional_params=params,
+        provider_responses=st.just(()),
+        expected=st.just("success"),
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class ChatInvocation:
+    api_key: str
+
+    def execute(self, provider_url: str, case_input: ChatCase) -> None:
+        call: Final = cast(Callable[..., object], litellm.completion)
+        call(
+            model=case_input.model,
+            messages=case_input.messages,
+            api_base=provider_url,
+            api_key=self.api_key,
+            num_retries=0,
+            **case_input.optional_params,
+        )
+
+
+def _case_factory(case: ChatCase, responses: tuple[RecordedResponse, ...]) -> ChatCase:
+    return case.model_copy(update={"name": fixture_id(case, case.model), "provider_responses": responses})
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    load_dotenv()
+    args: Final = parse_recording_args()
+    api_key: Final = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        raise SystemExit("Set ANTHROPIC_API_KEY to record Chat Completions parity fixtures")
+    api_base: Final = os.environ.get("ANTHROPIC_API_BASE", "https://api.anthropic.com")
+    target: Final = RecordingTarget(
+        name="anthropic-chat-completions",
+        upstream=UpstreamEndpoint(base_url=api_base),
+        strategy=input_strategy("anthropic/claude-sonnet-5"),
+        invocation=ChatInvocation(api_key),
+        required_inputs=tuple(case for case in CASES if case.expected == "success"),
+    )
+    root: Final = fixture_directory(
+        args.fixture_dir,
+        os.environ.get(FIXTURE_DIR_ENV),
+        DEFAULT_FIXTURE_DIRECTORY,
+    )
+    use_litellm_rust(False)
+    summary: Final = record_fixtures((target,), root, args.examples, args.concurrency, ChatCase, _case_factory)
+    return summary.exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/rust-python-harness/strategies/e2e_parity/sdk/chat_completions/test_sdk_parity.py
+++ b/tests/rust-python-harness/strategies/e2e_parity/sdk/chat_completions/test_sdk_parity.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+from collections.abc import Callable, Coroutine
+from contextlib import AbstractContextManager
+from pathlib import Path
+from typing import Final, Literal, cast
+
+from pydantic import BaseModel, ConfigDict
+
+from .....shared.parity.fixtures.store import recorded_fixtures
+from .....shared.parity.models import SDKError, SDKReport, sdk_error_report, sdk_success
+from .....shared.parity.normalization import NormalizationSpec
+from .....shared.parity.recorded_http import (
+    HttpHeader,
+    RecordedExchange,
+    RecordedHttpResponse,
+    RecordedRequestMatcher,
+    RecordedResponse,
+    ReplayItem,
+)
+from .....shared.parity.runner import ExecutionVariant, parity_worker_main
+from ...runner import E2ECheck
+from ..contract import BaseSdkParityContract, contract_checks, execute_contract_command
+
+API_KEY: Final = "test-key"
+BASELINE_USER_AGENT: Final = "python-chat-parity-fallback"
+BASELINE: Final = ExecutionVariant(name="Python", environment=(("LITELLM_RUST", "0"),))
+CANDIDATE: Final = ExecutionVariant(name="Rust", environment=(("LITELLM_RUST", "1"),))
+
+
+class ChatCase(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    name: str
+    model: str
+    messages: list[dict[str, object]]
+    optional_params: dict[str, object]
+    provider_responses: tuple[RecordedResponse, ...]
+    expected: Literal["success", "error"]
+
+    def canonical_input(self) -> dict[str, object]:
+        return cast(dict[str, object], self.model_dump(mode="json", exclude={"provider_responses"}))
+
+
+def _response(status: int) -> RecordedHttpResponse:
+    body: Final = (
+        b'{"id":"msg_parity","type":"message","role":"assistant","model":"claude-sonnet-5",'
+        b'"content":[{"type":"text","text":"hello"}],"stop_reason":"end_turn",'
+        b'"stop_sequence":null,"usage":{"input_tokens":2,"output_tokens":3}}'
+        if status == 200
+        else b'{"type":"error","error":{"type":"rate_limit_error","message":"rate limited"}}'
+    )
+    return RecordedHttpResponse.from_bytes(
+        status,
+        (HttpHeader(name="content-type", value="application/json"), HttpHeader(name="retry-after", value="0")),
+        body,
+    )
+
+
+CASES: Final = (
+    ChatCase(
+        name="anthropic:text",
+        model="anthropic/claude-sonnet-5",
+        messages=[{"role": "user", "content": "hello"}],
+        optional_params={"max_tokens": 16},
+        provider_responses=(_response(200),),
+        expected="success",
+    ),
+    ChatCase(
+        name="anthropic:conversation",
+        model="anthropic/claude-sonnet-5",
+        messages=[
+            {"role": "system", "content": "be concise"},
+            {"role": "user", "content": [{"type": "text", "text": "hello"}]},
+        ],
+        optional_params={"max_tokens": 32, "stop": ["stop"]},
+        provider_responses=(_response(200),),
+        expected="success",
+    ),
+    ChatCase(
+        name="anthropic:rate-limit",
+        model="anthropic/claude-sonnet-5",
+        messages=[{"role": "user", "content": "hello"}],
+        optional_params={"max_tokens": 16},
+        provider_responses=(_response(429),),
+        expected="error",
+    ),
+)
+
+
+class ChatContract(BaseSdkParityContract[ChatCase]):
+    @property
+    def name(self) -> str:
+        return "Chat Completions"
+
+    @property
+    def modes(self) -> tuple[str, ...]:
+        return ("sync", "async")
+
+    @property
+    def baseline(self) -> ExecutionVariant:
+        return BASELINE
+
+    @property
+    def candidate(self) -> ExecutionVariant:
+        return CANDIDATE
+
+    @property
+    def baseline_user_agent(self) -> str:
+        return BASELINE_USER_AGENT
+
+    def cases(self) -> tuple[ChatCase, ...]:
+        recorded: Final = recorded_fixtures(Path(__file__).with_name("fixtures") / "data", ChatCase)
+        return tuple({case.name: case for case in (*CASES, *recorded)}.values())
+
+    def dump_case(self, case: ChatCase) -> bytes:
+        return case.model_dump_json().encode()
+
+    def load_case(self, data: bytes) -> ChatCase:
+        return ChatCase.model_validate_json(data)
+
+    def case_name(self, case: ChatCase, mode: str) -> str:
+        return f"{mode}:{case.name}"
+
+    def responses(self, case: ChatCase) -> tuple[ReplayItem, ...]:
+        return tuple(
+            RecordedExchange(request=RecordedRequestMatcher(method="POST", path="/v1/messages"), response=response)
+            for response in case.provider_responses
+        )
+
+    def normalization(self, case: ChatCase) -> NormalizationSpec:
+        del case
+        return NormalizationSpec(report_paths=(("response", "created"), ("response", "id")))
+
+    def execute(
+        self,
+        case: ChatCase,
+        mode: str,
+        mock_url: str,
+        event_loop: asyncio.AbstractEventLoop,
+    ) -> SDKReport:
+        import litellm
+
+        kwargs: Final = {
+            "model": case.model,
+            "messages": case.messages,
+            **case.optional_params,
+            "api_base": mock_url,
+            "api_key": API_KEY,
+            "extra_headers": {"x-litellm-parity-route": mode},
+            "num_retries": 0,
+        }
+        try:
+            if mode == "sync":
+                sync_call: Final = cast(Callable[..., object], litellm.completion)
+                return sdk_success(sync_call(**kwargs))
+            if mode == "async":
+                async_call: Final = cast(Callable[..., Coroutine[object, object, object]], litellm.acompletion)
+                return sdk_success(event_loop.run_until_complete(async_call(**kwargs)))
+            raise ValueError(f"unsupported Chat Completions mode: {mode}")
+        except Exception as error:
+            return sdk_error_report(error)
+
+    def assert_baseline(self, case: ChatCase, report: SDKReport) -> None:
+        assert isinstance(report, SDKError) is (case.expected == "error")
+
+
+CONTRACT: Final = ChatContract()
+
+
+def parity_checks() -> AbstractContextManager[tuple[E2ECheck, ...]]:
+    return contract_checks(CONTRACT, Path(__file__))
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3 or sys.argv[1] != "--parity-worker":
+        raise SystemExit("usage: test_sdk_parity.py --parity-worker MOCK_URL")
+    parity_worker_main(lambda line, url, loop: execute_contract_command(CONTRACT, line, url, loop), sys.argv[2])

--- a/tests/rust-python-harness/strategies/e2e_parity/sdk/contract.py
+++ b/tests/rust-python-harness/strategies/e2e_parity/sdk/contract.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import asyncio
+import tempfile
+import traceback
+from collections.abc import Generator
+from contextlib import contextmanager
+from functools import partial
+from pathlib import Path
+from typing import Final, Generic, Protocol, TypeVar
+
+from pydantic import BaseModel
+
+from ....shared.parity.compare import assert_parity
+from ....shared.parity.models import SDKCommand, SDKReport, WorkerFailure, WorkerResult, WorkerSuccess
+from ....shared.parity.normalization import NormalizationSpec, normalize_execution
+from ....shared.parity.recorded_http import ReplayItem
+from ....shared.parity.runner import ExecutionVariant, SubprocessRunner, SubprocessWorker, execution_worker_pair
+from ..runner import E2ECheck
+
+CaseT = TypeVar("CaseT", bound=BaseModel)
+
+
+class SdkParityContract(Protocol[CaseT]):
+    @property
+    def name(self) -> str: ...
+
+    @property
+    def modes(self) -> tuple[str, ...]: ...
+
+    @property
+    def baseline(self) -> ExecutionVariant: ...
+
+    @property
+    def candidate(self) -> ExecutionVariant: ...
+
+    @property
+    def baseline_user_agent(self) -> str: ...
+
+    def cases(self) -> tuple[CaseT, ...]: ...
+
+    def dump_case(self, case: CaseT) -> bytes: ...
+
+    def load_case(self, data: bytes) -> CaseT: ...
+
+    def case_name(self, case: CaseT, mode: str) -> str: ...
+
+    def responses(self, case: CaseT) -> tuple[ReplayItem, ...]: ...
+
+    def normalization(self, case: CaseT) -> NormalizationSpec: ...
+
+    def execute(
+        self,
+        case: CaseT,
+        mode: str,
+        mock_url: str,
+        event_loop: asyncio.AbstractEventLoop,
+    ) -> SDKReport: ...
+
+    def assert_baseline(self, case: CaseT, report: SDKReport) -> None: ...
+
+
+class BaseSdkParityContract(Generic[CaseT]):
+    def normalization(self, case: CaseT) -> NormalizationSpec:
+        del case
+        return NormalizationSpec()
+
+    def assert_baseline(self, case: CaseT, report: SDKReport) -> None:
+        del case, report
+
+
+def _check_case(
+    contract: SdkParityContract[CaseT],
+    case: CaseT,
+    mode: str,
+    case_file: Path,
+    workers: tuple[SubprocessWorker, SubprocessWorker],
+) -> None:
+    baseline_worker, candidate_worker = workers
+    responses: Final = contract.responses(case)
+    baseline: Final = baseline_worker.execute(case_file, mode, responses)
+    candidate: Final = candidate_worker.execute(case_file, mode, responses)
+    normalization: Final = contract.normalization(case)
+    normalized_baseline: Final = normalize_execution(baseline, normalization)
+    normalized_candidate: Final = normalize_execution(candidate, normalization)
+    assert_parity(normalized_baseline, normalized_candidate, contract.baseline_user_agent)
+    contract.assert_baseline(case, normalized_baseline.report)
+
+
+def _write_cases(directory: Path, contract: SdkParityContract[CaseT], cases: tuple[CaseT, ...]) -> tuple[Path, ...]:
+    paths: Final = tuple(directory / f"case-{index}.json" for index in range(len(cases)))
+    for path, case in zip(paths, cases, strict=True):
+        path.write_bytes(contract.dump_case(case))
+    return paths
+
+
+@contextmanager
+def contract_checks(
+    contract: SdkParityContract[CaseT],
+    entrypoint: Path,
+) -> Generator[tuple[E2ECheck, ...]]:
+    cases: Final = contract.cases()
+    runner: Final = SubprocessRunner(
+        entrypoint=entrypoint,
+        baseline_user_agent=contract.baseline_user_agent,
+        route_label=contract.name,
+    )
+    with tempfile.TemporaryDirectory(prefix=f"litellm-{contract.name.lower()}-parity-") as raw_directory:
+        paths: Final = _write_cases(Path(raw_directory), contract, cases)
+        with execution_worker_pair(runner, contract.baseline, contract.candidate) as workers:
+            yield tuple(
+                E2ECheck(
+                    contract.case_name(case, mode),
+                    partial(_check_case, contract, case, mode, path, workers),
+                )
+                for case, path in zip(cases, paths, strict=True)
+                for mode in contract.modes
+            )
+
+
+def execute_contract_command(
+    contract: SdkParityContract[CaseT],
+    command_json: str,
+    mock_url: str,
+    event_loop: asyncio.AbstractEventLoop,
+) -> WorkerResult:
+    try:
+        command: Final = SDKCommand.model_validate_json(command_json)
+        case: Final = contract.load_case(Path(command.case_file).read_bytes())
+        return WorkerSuccess(report=contract.execute(case, command.route, mock_url, event_loop))
+    except Exception:
+        return WorkerFailure(error=traceback.format_exc())

--- a/tests/rust-python-harness/strategies/e2e_parity/sdk/messages/fixtures/record.py
+++ b/tests/rust-python-harness/strategies/e2e_parity/sdk/messages/fixtures/record.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from collections.abc import Callable, Coroutine
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final, cast
+
+from dotenv import load_dotenv
+from hypothesis import strategies as st
+from hypothesis.strategies import SearchStrategy
+
+import litellm
+from litellm.rust_bridge.configuration import use_litellm_rust
+
+from ......shared.parity.fixtures.cli import parse_recording_args
+from ......shared.parity.fixtures.pipeline import RecordingTarget, record_fixtures
+from ......shared.parity.fixtures.recording import UpstreamEndpoint
+from ......shared.parity.fixtures.store import fixture_directory, fixture_id
+from ......shared.parity.recorded_http import RecordedResponse
+from ..test_sdk_parity import CASES, MessagesCase
+
+FIXTURE_DIR_ENV: Final = "LITELLM_MESSAGES_FIXTURE_DIR"
+DEFAULT_FIXTURE_DIRECTORY: Final = Path(__file__).with_name("data")
+
+
+def _message_content() -> SearchStrategy[str | list[dict[str, str]]]:
+    text: Final = st.text(min_size=1, max_size=40)
+    return st.one_of(text, text.map(lambda value: [{"type": "text", "text": value}]))
+
+
+def input_strategy(model: str) -> SearchStrategy[MessagesCase]:
+    body: Final = st.fixed_dictionaries(
+        {
+            "max_tokens": st.integers(min_value=1, max_value=64),
+            "messages": st.lists(
+                st.fixed_dictionaries({"role": st.sampled_from(("user", "assistant")), "content": _message_content()}),
+                min_size=1,
+                max_size=4,
+            ),
+        },
+        optional={
+            "system": _message_content(),
+            "stop_sequences": st.lists(st.text(min_size=1, max_size=8), min_size=1, max_size=2),
+            "temperature": st.just(1.0),
+            "top_p": st.floats(min_value=0.1, max_value=1.0, allow_nan=False, allow_infinity=False),
+            "top_k": st.integers(min_value=1, max_value=100),
+        },
+    )
+    return st.builds(
+        MessagesCase,
+        name=st.just("generated"),
+        model=st.just(model),
+        body=body,
+        provider_responses=st.just(()),
+        expected=st.just("success"),
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class MessagesInvocation:
+    api_key: str
+
+    def execute(self, provider_url: str, case_input: MessagesCase) -> None:
+        call: Final = cast(
+            Callable[..., Coroutine[object, object, object]],
+            litellm.anthropic.messages.acreate,
+        )
+        asyncio.run(
+            call(
+                model=case_input.model,
+                api_base=provider_url,
+                api_key=self.api_key,
+                num_retries=0,
+                **case_input.body,
+            )
+        )
+
+
+def _case_factory(case: MessagesCase, responses: tuple[RecordedResponse, ...]) -> MessagesCase:
+    return case.model_copy(update={"name": fixture_id(case, case.model), "provider_responses": responses})
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    load_dotenv()
+    args: Final = parse_recording_args()
+    api_key: Final = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        raise SystemExit("Set ANTHROPIC_API_KEY to record Messages parity fixtures")
+    api_base: Final = os.environ.get("ANTHROPIC_API_BASE", "https://api.anthropic.com")
+    target: Final = RecordingTarget(
+        name="anthropic-messages",
+        upstream=UpstreamEndpoint(base_url=api_base),
+        strategy=input_strategy("anthropic/claude-sonnet-5"),
+        invocation=MessagesInvocation(api_key),
+        required_inputs=tuple(case for case in CASES if case.expected == "success"),
+    )
+    root: Final = fixture_directory(
+        args.fixture_dir,
+        os.environ.get(FIXTURE_DIR_ENV),
+        DEFAULT_FIXTURE_DIRECTORY,
+    )
+    use_litellm_rust(False)
+    summary: Final = record_fixtures(
+        (target,),
+        root,
+        args.examples,
+        args.concurrency,
+        MessagesCase,
+        _case_factory,
+    )
+    return summary.exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/rust-python-harness/strategies/e2e_parity/sdk/messages/test_sdk_parity.py
+++ b/tests/rust-python-harness/strategies/e2e_parity/sdk/messages/test_sdk_parity.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+from collections.abc import Callable, Coroutine
+from contextlib import AbstractContextManager
+from pathlib import Path
+from typing import Final, Literal, cast
+
+from pydantic import BaseModel, ConfigDict
+
+from .....shared.parity.fixtures.store import recorded_fixtures
+from .....shared.parity.models import SDKError, SDKReport, sdk_error_report, sdk_success
+from .....shared.parity.recorded_http import (
+    HttpHeader,
+    RecordedExchange,
+    RecordedHttpResponse,
+    RecordedRequestMatcher,
+    RecordedResponse,
+    ReplayItem,
+)
+from .....shared.parity.runner import ExecutionVariant, parity_worker_main
+from ...runner import E2ECheck
+from ..contract import BaseSdkParityContract, contract_checks, execute_contract_command
+
+API_KEY: Final = "test-key"
+BASELINE_USER_AGENT: Final = "python-messages-parity-fallback"
+BASELINE: Final = ExecutionVariant(name="Python", environment=(("LITELLM_RUST", "0"),))
+CANDIDATE: Final = ExecutionVariant(name="Rust", environment=(("LITELLM_RUST", "1"),))
+
+
+class MessagesCase(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    name: str
+    model: str
+    body: dict[str, object]
+    provider_responses: tuple[RecordedResponse, ...]
+    expected: Literal["success", "error"]
+
+    def canonical_input(self) -> dict[str, object]:
+        return cast(dict[str, object], self.model_dump(mode="json", exclude={"provider_responses"}))
+
+
+def _response(status: int) -> RecordedHttpResponse:
+    body: Final = (
+        b'{"id":"msg_parity","type":"message","role":"assistant","model":"claude-sonnet-5",'
+        b'"content":[{"type":"text","text":"hello"}],"stop_reason":"end_turn",'
+        b'"stop_sequence":null,"usage":{"input_tokens":2,"output_tokens":3}}'
+        if status == 200
+        else b'{"type":"error","error":{"type":"rate_limit_error","message":"rate limited"}}'
+    )
+    return RecordedHttpResponse.from_bytes(
+        status,
+        (HttpHeader(name="content-type", value="application/json"), HttpHeader(name="retry-after", value="0")),
+        body,
+    )
+
+
+CASES: Final = (
+    MessagesCase(
+        name="anthropic:text",
+        model="anthropic/claude-sonnet-5",
+        body={"max_tokens": 16, "messages": [{"role": "user", "content": "hello"}]},
+        provider_responses=(_response(200),),
+        expected="success",
+    ),
+    MessagesCase(
+        name="anthropic:blocks",
+        model="anthropic/claude-sonnet-5",
+        body={
+            "max_tokens": 32,
+            "messages": [{"role": "user", "content": [{"type": "text", "text": "hello"}]}],
+            "system": [{"type": "text", "text": "be concise", "cache_control": {"type": "ephemeral"}}],
+            "stop_sequences": ["stop"],
+        },
+        provider_responses=(_response(200),),
+        expected="success",
+    ),
+    MessagesCase(
+        name="anthropic:rate-limit",
+        model="anthropic/claude-sonnet-5",
+        body={"max_tokens": 16, "messages": [{"role": "user", "content": "hello"}]},
+        provider_responses=(_response(429),),
+        expected="error",
+    ),
+)
+
+
+class MessagesContract(BaseSdkParityContract[MessagesCase]):
+    @property
+    def name(self) -> str:
+        return "Messages"
+
+    @property
+    def modes(self) -> tuple[str, ...]:
+        return ("async",)
+
+    @property
+    def baseline(self) -> ExecutionVariant:
+        return BASELINE
+
+    @property
+    def candidate(self) -> ExecutionVariant:
+        return CANDIDATE
+
+    @property
+    def baseline_user_agent(self) -> str:
+        return BASELINE_USER_AGENT
+
+    def cases(self) -> tuple[MessagesCase, ...]:
+        recorded: Final = recorded_fixtures(Path(__file__).with_name("fixtures") / "data", MessagesCase)
+        return tuple({case.name: case for case in (*CASES, *recorded)}.values())
+
+    def dump_case(self, case: MessagesCase) -> bytes:
+        return case.model_dump_json().encode()
+
+    def load_case(self, data: bytes) -> MessagesCase:
+        return MessagesCase.model_validate_json(data)
+
+    def case_name(self, case: MessagesCase, mode: str) -> str:
+        return f"{mode}:{case.name}"
+
+    def responses(self, case: MessagesCase) -> tuple[ReplayItem, ...]:
+        return tuple(
+            RecordedExchange(request=RecordedRequestMatcher(method="POST", path="/v1/messages"), response=response)
+            for response in case.provider_responses
+        )
+
+    def execute(
+        self,
+        case: MessagesCase,
+        mode: str,
+        mock_url: str,
+        event_loop: asyncio.AbstractEventLoop,
+    ) -> SDKReport:
+        import litellm
+
+        kwargs: Final = {
+            **case.body,
+            "model": case.model,
+            "api_base": mock_url,
+            "api_key": API_KEY,
+            "extra_headers": {"x-litellm-parity-route": mode},
+            "num_retries": 0,
+        }
+        try:
+            if mode == "async":
+                async_call: Final = cast(
+                    Callable[..., Coroutine[object, object, object]],
+                    litellm.anthropic.messages.acreate,
+                )
+                return sdk_success(event_loop.run_until_complete(async_call(**kwargs)))
+            raise ValueError(f"unsupported Messages mode: {mode}")
+        except Exception as error:
+            return sdk_error_report(error)
+
+    def assert_baseline(self, case: MessagesCase, report: SDKReport) -> None:
+        assert isinstance(report, SDKError) is (case.expected == "error")
+
+
+CONTRACT: Final = MessagesContract()
+
+
+def parity_checks() -> AbstractContextManager[tuple[E2ECheck, ...]]:
+    return contract_checks(CONTRACT, Path(__file__))
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3 or sys.argv[1] != "--parity-worker":
+        raise SystemExit("usage: test_sdk_parity.py --parity-worker MOCK_URL")
+    parity_worker_main(lambda line, url, loop: execute_contract_command(CONTRACT, line, url, loop), sys.argv[2])

--- a/tests/rust-python-harness/strategies/e2e_parity/sdk/ocr/test_sdk_parity.py
+++ b/tests/rust-python-harness/strategies/e2e_parity/sdk/ocr/test_sdk_parity.py
@@ -2,12 +2,9 @@ from __future__ import annotations
 
 import asyncio
 import sys
-import tempfile
-import traceback
-from collections.abc import Callable, Coroutine, Generator
-from contextlib import contextmanager
+from collections.abc import Callable, Coroutine
+from contextlib import AbstractContextManager
 from enum import Enum
-from functools import partial
 from pathlib import Path
 from typing import Annotated, Final, Literal, cast
 
@@ -15,26 +12,21 @@ from pydantic import BaseModel, ConfigDict, Field, JsonValue, TypeAdapter
 
 from litellm.llms.base_llm.ocr.transformation import OCRResponse
 
-from .....shared.parity.compare import assert_parity
 from .....shared.parity.fixtures.store import fixture_id, recorded_fixtures
 from .....shared.parity.models import (
-    SDKCommand,
     SDKError,
     SDKReport,
-    SDKSuccess,
-    WorkerFailure,
-    WorkerResult,
-    WorkerSuccess,
     sdk_error_report,
+    sdk_success,
 )
+from .....shared.parity.normalization import NormalizationSpec
+from .....shared.parity.recorded_http import RecordedExchange, ReplayItem
 from .....shared.parity.runner import (
     ExecutionVariant,
-    SubprocessRunner,
-    SubprocessWorker,
-    execution_worker_pair,
     parity_worker_main,
 )
 from ...runner import E2ECheck
+from ..contract import BaseSdkParityContract, contract_checks, execute_contract_command
 from .fixtures.config import configured_fixture_directory
 from .fixtures.models import OcrParityCase, OcrSdkInput
 
@@ -194,10 +186,10 @@ def _execute_sdk_call(
         if route is SDKRoute.OCR:
             sync_route: Final = cast(Callable[..., OCRResponse], litellm.ocr)
             response: Final = sync_route(**call_kwargs)
-            return SDKSuccess(response=response.model_dump(mode="json"))
+            return sdk_success(response)
         async_route: Final = cast(Callable[..., Coroutine[object, object, OCRResponse]], litellm.aocr)
         async_response: Final = event_loop.run_until_complete(async_route(**call_kwargs))
-        return SDKSuccess(response=async_response.model_dump(mode="json"))
+        return sdk_success(async_response)
     except Exception as error:
         return sdk_error_report(error)
 
@@ -229,40 +221,6 @@ def _execute_invalid_sdk_case(
     return _execute_sdk_call(call_kwargs, route, event_loop)
 
 
-def _check_recorded_ocr_sdk_parity(
-    ocr_fixture: OcrParityCase,
-    route: SDKRoute,
-    case_file: Path,
-    sdk_workers: tuple[SubprocessWorker, SubprocessWorker],
-) -> None:
-    python_worker, rust_worker = sdk_workers
-    python: Final = python_worker.execute(case_file, route.value, ocr_fixture.provider_responses)
-    rust: Final = rust_worker.execute(case_file, route.value, ocr_fixture.provider_responses)
-
-    assert_parity(python, rust, PYTHON_HTTP_SENTINEL)
-    if any(response.status_code >= 400 for response in ocr_fixture.provider_responses):
-        assert isinstance(python.report, SDKError)
-
-
-def _check_invalid_ocr_sdk_parity(
-    case: InvalidOcrCase,
-    route: SDKRoute,
-    case_file: Path,
-    sdk_workers: tuple[SubprocessWorker, SubprocessWorker],
-) -> None:
-    python_worker, rust_worker = sdk_workers
-    python: Final = python_worker.execute(case_file, route.value, ())
-    rust: Final = rust_worker.execute(case_file, route.value, ())
-
-    assert_parity(python, rust, PYTHON_HTTP_SENTINEL)
-    assert python.requests == ()
-    assert rust.requests == ()
-    assert isinstance(python.report, SDKError)
-    assert python.report.exception_type == case.expected_exception_type
-    assert python.report.status_code == case.expected_status_code
-    assert case.expected_message in python.report.message
-
-
 def _recorded_check_name(fixture: OcrParityCase, route: SDKRoute) -> str:
     case_input: Final = fixture.litellm_input
     provider: Final = case_input.custom_llm_provider
@@ -270,74 +228,106 @@ def _recorded_check_name(fixture: OcrParityCase, route: SDKRoute) -> str:
     return f"recorded:{route.value}:{fixture_id(case_input, prefix)}"
 
 
-def _write_worker_case(directory: Path, index: int, case: OcrWorkerCase) -> Path:
-    case_file: Final = directory / f"case-{index}.json"
-    case_file.write_text(OCR_WORKER_CASE_ADAPTER.dump_json(case).decode("utf-8"), encoding="utf-8")
-    return case_file
+class OcrContract(BaseSdkParityContract[OcrWorkerCase]):
+    @property
+    def name(self) -> str:
+        return "OCR"
 
+    @property
+    def modes(self) -> tuple[str, ...]:
+        return tuple(route.value for route in SDKRoute)
 
-@contextmanager
-def parity_checks() -> Generator[tuple[E2ECheck, ...]]:
-    fixtures: Final = tuple(
-        fixture
-        for fixture in recorded_fixtures(configured_fixture_directory(), OcrParityCase)
-        if fixture.litellm_input.contract not in {"reducto_v3", "reducto_legacy"}
-    )
-    runner: Final = SubprocessRunner(
-        entrypoint=Path(__file__),
-        baseline_user_agent=PYTHON_HTTP_SENTINEL,
-        route_label="OCR",
-    )
-    with tempfile.TemporaryDirectory(prefix="litellm-ocr-parity-") as raw_directory:
-        directory: Final = Path(raw_directory)
-        recorded_files: Final = tuple(
-            _write_worker_case(directory, index, RecordedOcrWorkerCase(case=fixture))
-            for index, fixture in enumerate(fixtures)
+    @property
+    def baseline(self) -> ExecutionVariant:
+        return PYTHON_VARIANT
+
+    @property
+    def candidate(self) -> ExecutionVariant:
+        return RUST_VARIANT
+
+    @property
+    def baseline_user_agent(self) -> str:
+        return PYTHON_HTTP_SENTINEL
+
+    def cases(self) -> tuple[OcrWorkerCase, ...]:
+        fixtures: Final = tuple(
+            fixture
+            for fixture in recorded_fixtures(configured_fixture_directory(), OcrParityCase)
+            if fixture.litellm_input.contract not in {"reducto_v3", "reducto_legacy"}
         )
-        invalid_files: Final = tuple(
-            _write_worker_case(directory, len(recorded_files) + index, InvalidOcrWorkerCase(case=case))
-            for index, case in enumerate(INVALID_OCR_CASES)
+        return (
+            *(RecordedOcrWorkerCase(case=fixture) for fixture in fixtures),
+            *(InvalidOcrWorkerCase(case=case) for case in INVALID_OCR_CASES),
         )
-        with execution_worker_pair(runner, PYTHON_VARIANT, RUST_VARIANT) as workers:
-            recorded: Final = tuple(
-                E2ECheck(
-                    _recorded_check_name(fixture, route),
-                    partial(_check_recorded_ocr_sdk_parity, fixture, route, case_file, workers),
-                )
-                for fixture, case_file in zip(fixtures, recorded_files, strict=True)
-                for route in SDKRoute
-            )
-            invalid: Final = tuple(
-                E2ECheck(
-                    f"invalid:{route.value}:{case.name}",
-                    partial(_check_invalid_ocr_sdk_parity, case, route, case_file, workers),
-                )
-                for case, case_file in zip(INVALID_OCR_CASES, invalid_files, strict=True)
-                for route in SDKRoute
-            )
-            yield (*recorded, *invalid)
 
+    def dump_case(self, case: OcrWorkerCase) -> bytes:
+        return OCR_WORKER_CASE_ADAPTER.dump_json(case)
 
-def _execute_worker_command(
-    command_json: str,
-    mock_url: str,
-    event_loop: asyncio.AbstractEventLoop,
-) -> WorkerResult:
-    try:
-        command: Final = SDKCommand.model_validate_json(command_json)
-        case_file: Final = Path(command.case_file)
-        route: Final = SDKRoute(command.route)
-        worker_case: Final = OCR_WORKER_CASE_ADAPTER.validate_json(case_file.read_bytes())
-        match worker_case:
+    def load_case(self, data: bytes) -> OcrWorkerCase:
+        return OCR_WORKER_CASE_ADAPTER.validate_json(data)
+
+    def case_name(self, case: OcrWorkerCase, mode: str) -> str:
+        route: Final = SDKRoute(mode)
+        match case:
             case RecordedOcrWorkerCase(case=recorded):
-                return WorkerSuccess(report=_execute_sdk_case(recorded.litellm_input, route, mock_url, event_loop))
+                return _recorded_check_name(recorded, route)
             case InvalidOcrWorkerCase(case=invalid):
-                return WorkerSuccess(report=_execute_invalid_sdk_case(invalid, route, mock_url, event_loop))
-    except Exception:
-        return WorkerFailure(error=traceback.format_exc())
+                return f"invalid:{mode}:{invalid.name}"
+
+    def responses(self, case: OcrWorkerCase) -> tuple[ReplayItem, ...]:
+        match case:
+            case RecordedOcrWorkerCase(case=recorded):
+                if not recorded.provider_requests:
+                    return recorded.provider_responses
+                return tuple(
+                    RecordedExchange(request=request, response=response)
+                    for request, response in zip(
+                        recorded.provider_requests,
+                        recorded.provider_responses,
+                        strict=True,
+                    )
+                )
+            case InvalidOcrWorkerCase():
+                return ()
+
+    def normalization(self, case: OcrWorkerCase) -> NormalizationSpec:
+        del case
+        return NormalizationSpec()
+
+    def execute(
+        self,
+        case: OcrWorkerCase,
+        mode: str,
+        mock_url: str,
+        event_loop: asyncio.AbstractEventLoop,
+    ) -> SDKReport:
+        route: Final = SDKRoute(mode)
+        match case:
+            case RecordedOcrWorkerCase(case=recorded):
+                return _execute_sdk_case(recorded.litellm_input, route, mock_url, event_loop)
+            case InvalidOcrWorkerCase(case=invalid):
+                return _execute_invalid_sdk_case(invalid, route, mock_url, event_loop)
+
+    def assert_baseline(self, case: OcrWorkerCase, report: SDKReport) -> None:
+        match case:
+            case RecordedOcrWorkerCase(case=recorded):
+                if any(response.status_code >= 400 for response in recorded.provider_responses):
+                    assert isinstance(report, SDKError)
+            case InvalidOcrWorkerCase(case=invalid):
+                assert isinstance(report, SDKError)
+                assert report.exception_type == invalid.expected_exception_type
+                assert report.status_code == invalid.expected_status_code
+                assert invalid.expected_message in report.message
+
+
+CONTRACT: Final = OcrContract()
+
+
+def parity_checks() -> AbstractContextManager[tuple[E2ECheck, ...]]:
+    return contract_checks(CONTRACT, Path(__file__))
 
 
 if __name__ == "__main__":
     if len(sys.argv) != 3 or sys.argv[1] != "--parity-worker":
         raise SystemExit("usage: test_sdk_parity.py --parity-worker MOCK_URL")
-    parity_worker_main(_execute_worker_command, sys.argv[2])
+    parity_worker_main(lambda line, url, loop: execute_contract_command(CONTRACT, line, url, loop), sys.argv[2])

--- a/tests/rust-python-harness/strategies/e2e_parity/sdk/responses/fixtures/record.py
+++ b/tests/rust-python-harness/strategies/e2e_parity/sdk/responses/fixtures/record.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final, cast
+
+from dotenv import load_dotenv
+from hypothesis import strategies as st
+from hypothesis.strategies import SearchStrategy
+
+import litellm
+from litellm.rust_bridge.configuration import use_litellm_rust
+
+from ......shared.parity.fixtures.cli import parse_recording_args
+from ......shared.parity.fixtures.pipeline import RecordingTarget, record_fixtures
+from ......shared.parity.fixtures.recording import UpstreamEndpoint
+from ......shared.parity.fixtures.store import fixture_directory, fixture_id
+from ......shared.parity.recorded_http import RecordedResponse
+from ..test_sdk_parity import CASES, ResponsesCase
+
+FIXTURE_DIR_ENV: Final = "LITELLM_RESPONSES_FIXTURE_DIR"
+DEFAULT_FIXTURE_DIRECTORY: Final = Path(__file__).with_name("data")
+
+
+def input_strategy(model: str) -> SearchStrategy[ResponsesCase]:
+    sdk_input: Final = st.one_of(
+        st.text(min_size=1, max_size=80),
+        st.text(min_size=1, max_size=80).map(lambda text: [{"role": "user", "content": text}]),
+    )
+    params: Final = st.fixed_dictionaries(
+        {"max_output_tokens": st.integers(min_value=1, max_value=64)},
+        optional={
+            "instructions": st.text(min_size=1, max_size=40),
+            "temperature": st.just(1.0),
+            "top_p": st.just(1.0),
+        },
+    )
+    return st.builds(
+        ResponsesCase,
+        name=st.just("generated"),
+        model=st.just(model),
+        sdk_input=sdk_input,
+        params=params,
+        provider_responses=st.just(()),
+        expected=st.just("success"),
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class ResponsesInvocation:
+    api_key: str
+
+    def execute(self, provider_url: str, case_input: ResponsesCase) -> None:
+        call: Final = cast(Callable[..., object], litellm.responses)
+        call(
+            model=case_input.model,
+            input=case_input.sdk_input,
+            api_base=provider_url,
+            api_key=self.api_key,
+            use_chat_completions_api=True,
+            num_retries=0,
+            **case_input.params,
+        )
+
+
+def _case_factory(case: ResponsesCase, responses: tuple[RecordedResponse, ...]) -> ResponsesCase:
+    return case.model_copy(update={"name": fixture_id(case, case.model), "provider_responses": responses})
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    load_dotenv()
+    args: Final = parse_recording_args()
+    api_key: Final = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        raise SystemExit("Set ANTHROPIC_API_KEY to record Responses parity fixtures")
+    api_base: Final = os.environ.get("ANTHROPIC_API_BASE", "https://api.anthropic.com")
+    target: Final = RecordingTarget(
+        name="anthropic-responses-via-chat",
+        upstream=UpstreamEndpoint(base_url=api_base),
+        strategy=input_strategy("anthropic/claude-sonnet-5"),
+        invocation=ResponsesInvocation(api_key),
+        required_inputs=tuple(case for case in CASES if case.expected == "success"),
+    )
+    root: Final = fixture_directory(
+        args.fixture_dir,
+        os.environ.get(FIXTURE_DIR_ENV),
+        DEFAULT_FIXTURE_DIRECTORY,
+    )
+    use_litellm_rust(False)
+    summary: Final = record_fixtures((target,), root, args.examples, args.concurrency, ResponsesCase, _case_factory)
+    return summary.exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/rust-python-harness/strategies/e2e_parity/sdk/responses/test_sdk_parity.py
+++ b/tests/rust-python-harness/strategies/e2e_parity/sdk/responses/test_sdk_parity.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+from collections.abc import Callable, Coroutine
+from contextlib import AbstractContextManager
+from pathlib import Path
+from typing import Final, Literal, cast
+
+from pydantic import BaseModel, ConfigDict
+
+from .....shared.parity.fixtures.store import recorded_fixtures
+from .....shared.parity.models import SDKError, SDKReport, sdk_error_report, sdk_success
+from .....shared.parity.normalization import NormalizationSpec
+from .....shared.parity.recorded_http import (
+    HttpHeader,
+    RecordedExchange,
+    RecordedHttpResponse,
+    RecordedRequestMatcher,
+    RecordedResponse,
+    ReplayItem,
+)
+from .....shared.parity.runner import ExecutionVariant, parity_worker_main
+from ...runner import E2ECheck
+from ..contract import BaseSdkParityContract, contract_checks, execute_contract_command
+
+API_KEY: Final = "test-key"
+BASELINE_USER_AGENT: Final = "python-responses-parity-fallback"
+BASELINE: Final = ExecutionVariant(name="Python", environment=(("LITELLM_RUST", "0"),))
+CANDIDATE: Final = ExecutionVariant(name="Rust", environment=(("LITELLM_RUST", "1"),))
+
+
+class ResponsesCase(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    name: str
+    model: str
+    sdk_input: str | list[dict[str, object]]
+    params: dict[str, object]
+    provider_responses: tuple[RecordedResponse, ...]
+    expected: Literal["success", "error"]
+
+    def canonical_input(self) -> dict[str, object]:
+        return cast(dict[str, object], self.model_dump(mode="json", exclude={"provider_responses"}))
+
+
+def _response(status: int) -> RecordedHttpResponse:
+    body: Final = (
+        b'{"id":"msg_parity","type":"message","role":"assistant","model":"claude-sonnet-5",'
+        b'"content":[{"type":"text","text":"hello"}],"stop_reason":"end_turn",'
+        b'"stop_sequence":null,"usage":{"input_tokens":2,"output_tokens":3}}'
+        if status == 200
+        else b'{"type":"error","error":{"type":"rate_limit_error","message":"rate limited"}}'
+    )
+    return RecordedHttpResponse.from_bytes(
+        status,
+        (HttpHeader(name="content-type", value="application/json"), HttpHeader(name="retry-after", value="0")),
+        body,
+    )
+
+
+CASES: Final = (
+    ResponsesCase(
+        name="anthropic:string",
+        model="anthropic/claude-sonnet-5",
+        sdk_input="hello",
+        params={"max_output_tokens": 16},
+        provider_responses=(_response(200),),
+        expected="success",
+    ),
+    ResponsesCase(
+        name="anthropic:instructions",
+        model="anthropic/claude-sonnet-5",
+        sdk_input=[{"role": "user", "content": "hello"}],
+        params={"instructions": "be concise", "max_output_tokens": 32},
+        provider_responses=(_response(200),),
+        expected="success",
+    ),
+    ResponsesCase(
+        name="anthropic:rate-limit",
+        model="anthropic/claude-sonnet-5",
+        sdk_input="hello",
+        params={"max_output_tokens": 16},
+        provider_responses=(_response(429),),
+        expected="error",
+    ),
+)
+
+
+class ResponsesContract(BaseSdkParityContract[ResponsesCase]):
+    @property
+    def name(self) -> str:
+        return "Responses"
+
+    @property
+    def modes(self) -> tuple[str, ...]:
+        return ("sync", "async")
+
+    @property
+    def baseline(self) -> ExecutionVariant:
+        return BASELINE
+
+    @property
+    def candidate(self) -> ExecutionVariant:
+        return CANDIDATE
+
+    @property
+    def baseline_user_agent(self) -> str:
+        return BASELINE_USER_AGENT
+
+    def cases(self) -> tuple[ResponsesCase, ...]:
+        recorded: Final = recorded_fixtures(Path(__file__).with_name("fixtures") / "data", ResponsesCase)
+        return tuple({case.name: case for case in (*CASES, *recorded)}.values())
+
+    def dump_case(self, case: ResponsesCase) -> bytes:
+        return case.model_dump_json().encode()
+
+    def load_case(self, data: bytes) -> ResponsesCase:
+        return ResponsesCase.model_validate_json(data)
+
+    def case_name(self, case: ResponsesCase, mode: str) -> str:
+        return f"{mode}:{case.name}"
+
+    def responses(self, case: ResponsesCase) -> tuple[ReplayItem, ...]:
+        return tuple(
+            RecordedExchange(request=RecordedRequestMatcher(method="POST", path="/v1/messages"), response=response)
+            for response in case.provider_responses
+        )
+
+    def normalization(self, case: ResponsesCase) -> NormalizationSpec:
+        del case
+        return NormalizationSpec(
+            report_paths=(
+                ("response", "created_at"),
+                ("response", "id"),
+            )
+        )
+
+    def execute(
+        self,
+        case: ResponsesCase,
+        mode: str,
+        mock_url: str,
+        event_loop: asyncio.AbstractEventLoop,
+    ) -> SDKReport:
+        import litellm
+
+        kwargs: Final = {
+            "model": case.model,
+            "input": case.sdk_input,
+            **case.params,
+            "use_chat_completions_api": True,
+            "api_base": mock_url,
+            "api_key": API_KEY,
+            "extra_headers": {"x-litellm-parity-route": mode},
+            "num_retries": 0,
+        }
+        try:
+            if mode == "sync":
+                sync_call: Final = cast(Callable[..., object], litellm.responses)
+                return sdk_success(sync_call(**kwargs))
+            if mode == "async":
+                async_call: Final = cast(Callable[..., Coroutine[object, object, object]], litellm.aresponses)
+                return sdk_success(event_loop.run_until_complete(async_call(**kwargs)))
+            raise ValueError(f"unsupported Responses mode: {mode}")
+        except Exception as error:
+            return sdk_error_report(error)
+
+    def assert_baseline(self, case: ResponsesCase, report: SDKReport) -> None:
+        assert isinstance(report, SDKError) is (case.expected == "error")
+
+
+CONTRACT: Final = ResponsesContract()
+
+
+def parity_checks() -> AbstractContextManager[tuple[E2ECheck, ...]]:
+    return contract_checks(CONTRACT, Path(__file__))
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3 or sys.argv[1] != "--parity-worker":
+        raise SystemExit("usage: test_sdk_parity.py --parity-worker MOCK_URL")
+    parity_worker_main(lambda line, url, loop: execute_contract_command(CONTRACT, line, url, loop), sys.argv[2])

--- a/tests/rust-python-harness/strategies/e2e_parity/sdk/responses/test_sdk_parity.py
+++ b/tests/rust-python-harness/strategies/e2e_parity/sdk/responses/test_sdk_parity.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import sys
 from collections.abc import Callable, Coroutine
 from contextlib import AbstractContextManager
@@ -37,6 +38,8 @@ class ResponsesCase(BaseModel):
     model: str
     sdk_input: str | list[dict[str, object]]
     params: dict[str, object]
+    upstream_path: str = "/v1/messages"
+    use_chat_completions_api: bool = False
     provider_responses: tuple[RecordedResponse, ...]
     expected: Literal["success", "error"]
 
@@ -44,7 +47,7 @@ class ResponsesCase(BaseModel):
         return cast(dict[str, object], self.model_dump(mode="json", exclude={"provider_responses"}))
 
 
-def _response(status: int) -> RecordedHttpResponse:
+def _anthropic_response(status: int = 200) -> RecordedHttpResponse:
     body: Final = (
         b'{"id":"msg_parity","type":"message","role":"assistant","model":"claude-sonnet-5",'
         b'"content":[{"type":"text","text":"hello"}],"stop_reason":"end_turn",'
@@ -59,13 +62,53 @@ def _response(status: int) -> RecordedHttpResponse:
     )
 
 
+def _openai_chat_response() -> RecordedHttpResponse:
+    return RecordedHttpResponse.from_bytes(
+        200,
+        (HttpHeader(name="content-type", value="application/json"),),
+        (
+            b'{"id":"chatcmpl_parity","object":"chat.completion","created":123,'
+            b'"model":"gpt-5","choices":[{"index":0,"message":{"role":"assistant",'
+            b'"content":"hello"},"finish_reason":"stop"}],'
+            b'"usage":{"prompt_tokens":2,"completion_tokens":3,"total_tokens":5}}'
+        ),
+    )
+
+
+def _openai_responses_response() -> RecordedHttpResponse:
+    return RecordedHttpResponse.from_bytes(
+        200,
+        (HttpHeader(name="content-type", value="application/json"),),
+        (
+            b'{"id":"resp_parity","object":"response","created_at":123,"status":"completed",'
+            b'"model":"gpt-5","output":[{"id":"msg_parity","type":"message",'
+            b'"status":"completed","role":"assistant","content":[{"type":"output_text",'
+            b'"text":"hello","annotations":[]}]}],"usage":{"input_tokens":2,'
+            b'"output_tokens":3,"total_tokens":5}}'
+        ),
+    )
+
+
+def _bedrock_response() -> RecordedHttpResponse:
+    return RecordedHttpResponse.from_bytes(
+        200,
+        (HttpHeader(name="content-type", value="application/json"),),
+        (
+            b'{"output":{"message":{"role":"assistant","content":[{"text":"hello"}]}},'
+            b'"stopReason":"end_turn","usage":{"inputTokens":2,"outputTokens":3,"totalTokens":5},'
+            b'"metrics":{"latencyMs":1}}'
+        ),
+    )
+
+
 CASES: Final = (
     ResponsesCase(
         name="anthropic:string",
         model="anthropic/claude-sonnet-5",
         sdk_input="hello",
         params={"max_output_tokens": 16},
-        provider_responses=(_response(200),),
+        upstream_path="/v1/messages",
+        provider_responses=(_anthropic_response(),),
         expected="success",
     ),
     ResponsesCase(
@@ -73,16 +116,37 @@ CASES: Final = (
         model="anthropic/claude-sonnet-5",
         sdk_input=[{"role": "user", "content": "hello"}],
         params={"instructions": "be concise", "max_output_tokens": 32},
-        provider_responses=(_response(200),),
+        upstream_path="/v1/messages",
+        provider_responses=(_anthropic_response(),),
         expected="success",
     ),
     ResponsesCase(
-        name="anthropic:rate-limit",
-        model="anthropic/claude-sonnet-5",
+        name="openai:native",
+        model="openai/gpt-5",
         sdk_input="hello",
         params={"max_output_tokens": 16},
-        provider_responses=(_response(429),),
-        expected="error",
+        upstream_path="/responses",
+        provider_responses=(_openai_responses_response(),),
+        expected="success",
+    ),
+    ResponsesCase(
+        name="openai:forced-chat-adapter",
+        model="openai/gpt-5",
+        sdk_input="hello",
+        params={"max_output_tokens": 16},
+        upstream_path="/chat/completions",
+        use_chat_completions_api=True,
+        provider_responses=(_openai_chat_response(),),
+        expected="success",
+    ),
+    ResponsesCase(
+        name="bedrock:chat-adapter",
+        model="bedrock/us-east-1/anthropic.claude-v2",
+        sdk_input="hello",
+        params={"max_output_tokens": 16},
+        upstream_path="/model/anthropic.claude-v2/converse",
+        provider_responses=(_bedrock_response(),),
+        expected="success",
     ),
 )
 
@@ -123,17 +187,33 @@ class ResponsesContract(BaseSdkParityContract[ResponsesCase]):
 
     def responses(self, case: ResponsesCase) -> tuple[ReplayItem, ...]:
         return tuple(
-            RecordedExchange(request=RecordedRequestMatcher(method="POST", path="/v1/messages"), response=response)
+            RecordedExchange(request=RecordedRequestMatcher(method="POST", path=case.upstream_path), response=response)
             for response in case.provider_responses
         )
 
     def normalization(self, case: ResponsesCase) -> NormalizationSpec:
         del case
         return NormalizationSpec(
+            request_headers=frozenset(
+                {
+                    "accept",
+                    "x-stainless-arch",
+                    "x-stainless-async",
+                    "x-stainless-lang",
+                    "x-stainless-os",
+                    "x-stainless-package-version",
+                    "x-stainless-raw-response",
+                    "x-stainless-read-timeout",
+                    "x-stainless-retry-count",
+                    "x-stainless-runtime",
+                    "x-stainless-runtime-version",
+                }
+            ),
             report_paths=(
                 ("response", "created_at"),
                 ("response", "id"),
-            )
+                ("response", "output", 0, "id"),
+            ),
         )
 
     def execute(
@@ -149,10 +229,13 @@ class ResponsesContract(BaseSdkParityContract[ResponsesCase]):
             "model": case.model,
             "input": case.sdk_input,
             **case.params,
-            "use_chat_completions_api": True,
+            **({"use_chat_completions_api": True} if case.use_chat_completions_api else {}),
             "api_base": mock_url,
             "api_key": API_KEY,
-            "extra_headers": {"x-litellm-parity-route": mode},
+            "extra_headers": {
+                "x-litellm-parity-route": mode,
+                "user-agent": BASELINE_USER_AGENT if os.getenv("LITELLM_RUST") == "0" else "rust-responses-parity",
+            },
             "num_retries": 0,
         }
         try:

--- a/tests/rust-python-harness/strategies/e2e_parity/test_recording_strategies.py
+++ b/tests/rust-python-harness/strategies/e2e_parity/test_recording_strategies.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Final
+
+from ...shared.parity.fixtures.inputs import generate_case_inputs
+from .sdk.chat_completions.fixtures.record import input_strategy as chat_input_strategy
+from .sdk.messages.fixtures.record import input_strategy as messages_input_strategy
+from .sdk.responses.fixtures.record import input_strategy as responses_input_strategy
+
+MODEL: Final = "anthropic/claude-sonnet-5"
+
+
+def test_messages_recording_strategy_generates_replayable_inputs() -> None:
+    cases: Final = generate_case_inputs(messages_input_strategy(MODEL), 8)
+
+    assert cases
+    assert all(case.model == MODEL and case.body["messages"] and not case.provider_responses for case in cases)
+
+
+def test_chat_recording_strategy_stays_inside_rust_supported_surface() -> None:
+    cases: Final = generate_case_inputs(chat_input_strategy(MODEL), 8)
+
+    assert cases
+    assert all(case.messages and case.messages[0]["role"] in {"system", "user"} for case in cases)
+    assert all("stream" not in case.optional_params and not case.provider_responses for case in cases)
+
+
+def test_responses_recording_strategy_uses_chat_bridge_compatible_inputs() -> None:
+    cases: Final = generate_case_inputs(responses_input_strategy(MODEL), 8)
+
+    assert cases
+    assert all(case.sdk_input and "tools" not in case.params and not case.provider_responses for case in cases)

--- a/tests/rust-python-harness/strategies/trace_parity/__init__.py
+++ b/tests/rust-python-harness/strategies/trace_parity/__init__.py
@@ -32,7 +32,11 @@ CASES: Final[tuple[CaseDefinition, ...]] = (
     ),
     CaseDefinition(
         "responses",
-        NotImplementedCaseSpec(reason="No Responses trace-parity case is registered."),
+        ModuleCaseSpec(
+            coverage=Coverage.PARTIAL,
+            module="tests.rust-python-harness.strategies.trace_parity.sdk.responses.case",
+            note="Non-streaming text inputs across native and adapted provider transports.",
+        ),
         surface="sdk",
     ),
     CaseDefinition(

--- a/tests/rust-python-harness/strategies/trace_parity/models.py
+++ b/tests/rust-python-harness/strategies/trace_parity/models.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Final, Literal, TypeAlias
 
-from ...shared.parity.recorded_http import RecordedHttpResponse
+from ...shared.parity.recorded_http import ReplayItem
 from ...shared.reporting.models import SdkFunction
 from ...shared.tracing.steps import Engine, TraceContract, TraceMapping
 
@@ -15,7 +15,7 @@ TraceFailureSource = Literal["python", "rust", "harness"]
 @dataclass(frozen=True, slots=True)
 class RouteFixture:
     kwargs: dict[str, object]
-    provider_responses: tuple[RecordedHttpResponse, ...]
+    provider_responses: tuple[ReplayItem, ...]
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/rust-python-harness/strategies/trace_parity/sdk/responses/case.py
+++ b/tests/rust-python-harness/strategies/trace_parity/sdk/responses/case.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import json
+from typing import Final
+
+from .....shared.parity.recorded_http import (
+    HttpHeader,
+    RecordedExchange,
+    RecordedHttpResponse,
+    RecordedRequestMatcher,
+)
+from .....shared.tracing.steps import Engine, mapping
+from ...models import RouteFixture, RouteSpec, TraceScenario, TraceSuite
+
+
+def _response(body: dict[str, object], path: str) -> tuple[RecordedExchange, ...]:
+    return (
+        RecordedExchange(
+            request=RecordedRequestMatcher(method="POST", path=path),
+            response=RecordedHttpResponse.from_bytes(
+                200,
+                (HttpHeader(name="content-type", value="application/json"),),
+                json.dumps(body).encode(),
+            ),
+        ),
+    )
+
+
+def _openai_native_fixture(engine: Engine, _base_url: str) -> RouteFixture:
+    return RouteFixture(
+        kwargs={
+            "model": "openai/gpt-5",
+            "input": "hello",
+            **({"optional_params": {"max_output_tokens": 16}} if engine == "rust" else {"max_output_tokens": 16}),
+        },
+        provider_responses=_response(
+            {
+                "id": "resp_trace",
+                "object": "response",
+                "created_at": 123,
+                "status": "completed",
+                "model": "gpt-5",
+                "output": [
+                    {
+                        "id": "msg_trace",
+                        "type": "message",
+                        "status": "completed",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": "hello", "annotations": []}],
+                    }
+                ],
+                "usage": {"input_tokens": 2, "output_tokens": 3, "total_tokens": 5},
+            },
+            "/responses",
+        ),
+    )
+
+
+def _anthropic_fixture(engine: Engine, _base_url: str) -> RouteFixture:
+    return RouteFixture(
+        kwargs={
+            "model": "anthropic/claude-sonnet-5",
+            "input": "hello",
+            **({"optional_params": {"max_output_tokens": 16}} if engine == "rust" else {"max_output_tokens": 16}),
+        },
+        provider_responses=_response(
+            {
+                "id": "msg_trace",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-sonnet-5",
+                "content": [{"type": "text", "text": "hello"}],
+                "stop_reason": "end_turn",
+                "stop_sequence": None,
+                "usage": {"input_tokens": 2, "output_tokens": 3},
+            },
+            "/v1/messages",
+        ),
+    )
+
+
+def _bedrock_fixture(engine: Engine, _base_url: str) -> RouteFixture:
+    return RouteFixture(
+        kwargs={
+            "model": "bedrock/us-east-1/anthropic.claude-v2",
+            "input": "hello",
+            **({"optional_params": {"max_output_tokens": 16}} if engine == "rust" else {"max_output_tokens": 16}),
+        },
+        provider_responses=_response(
+            {
+                "output": {"message": {"role": "assistant", "content": [{"text": "hello"}]}},
+                "stopReason": "end_turn",
+                "usage": {"inputTokens": 2, "outputTokens": 3, "totalTokens": 5},
+                "metrics": {"latencyMs": 1},
+            },
+            "/model/anthropic.claude-v2/converse",
+        ),
+    )
+
+
+def _openai_adapter_fixture(engine: Engine, _base_url: str) -> RouteFixture:
+    return RouteFixture(
+        kwargs={
+            "model": "openai/gpt-5",
+            "input": "hello",
+            "use_chat_completions_api": True,
+            **({"optional_params": {"max_output_tokens": 16}} if engine == "rust" else {"max_output_tokens": 16}),
+        },
+        provider_responses=_response(
+            {
+                "id": "chatcmpl_trace",
+                "object": "chat.completion",
+                "created": 123,
+                "model": "gpt-5",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "hello"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {"prompt_tokens": 2, "completion_tokens": 3, "total_tokens": 5},
+            },
+            "/chat/completions",
+        ),
+    )
+
+
+NATIVE_INTERNAL: Final = (
+    mapping(rust_span="responses_transport"),
+    mapping(rust_span="execute_responses_provider_call"),
+    mapping(rust_span="http_request"),
+)
+
+ADAPTER_INTERNAL: Final = (
+    mapping(rust_span="responses_transport"),
+    mapping(rust_span="transform_responses_request_to_chat_completions"),
+    mapping(rust_span="chat_completions"),
+    mapping(rust_span="chat_completions_provider_config"),
+    mapping(rust_span="supported_openai_params"),
+    mapping(rust_span="execute_chat_completions_provider_call"),
+    mapping(rust_span="validate_environment"),
+    mapping(rust_span="transform_request"),
+    mapping(rust_span="http_request"),
+    mapping(rust_span="transform_response"),
+    mapping(rust_span="transform_chat_completions_response_to_responses"),
+)
+
+BEDROCK_ADAPTER_INTERNAL: Final = tuple(
+    item for item in ADAPTER_INTERNAL if item.span not in {"transform_request", "transform_response"}
+)
+OPENAI_ADAPTER_INTERNAL: Final = tuple(
+    item for item in ADAPTER_INTERNAL if item.span != "chat_completions_provider_config"
+)
+
+SYNC_ROOT: Final = (mapping(rust_span="responses", python_frame=r"main\.py:\d+ responses$"),)
+ASYNC_ROOT: Final = (
+    mapping(rust_span="responses", python_frame=r"main\.py:\d+ aresponses$"),
+    mapping(span="python_responses_wrapper", python_frame=r"main\.py:\d+ responses$"),
+)
+
+SPEC: Final = RouteSpec(
+    "responses",
+    ("responses", "aresponses"),
+    ("responses", "aresponses"),
+    _openai_native_fixture,
+)
+
+TRACE_SUITE: Final = TraceSuite(
+    route=SPEC,
+    scenarios=(
+        TraceScenario(
+            name="openai-native",
+            fixture=_openai_native_fixture,
+            mappings=NATIVE_INTERNAL,
+            sync_mappings=(*SYNC_ROOT, *NATIVE_INTERNAL),
+            async_mappings=(*ASYNC_ROOT, *NATIVE_INTERNAL),
+        ),
+        TraceScenario(
+            name="anthropic-adapter",
+            fixture=_anthropic_fixture,
+            mappings=ADAPTER_INTERNAL,
+            sync_mappings=(*SYNC_ROOT, *ADAPTER_INTERNAL),
+            async_mappings=(*ASYNC_ROOT, *ADAPTER_INTERNAL),
+        ),
+        TraceScenario(
+            name="bedrock-adapter",
+            fixture=_bedrock_fixture,
+            mappings=BEDROCK_ADAPTER_INTERNAL,
+            sync_mappings=(*SYNC_ROOT, *BEDROCK_ADAPTER_INTERNAL),
+            async_mappings=(*ASYNC_ROOT, *BEDROCK_ADAPTER_INTERNAL),
+        ),
+        TraceScenario(
+            name="openai-forced-adapter",
+            fixture=_openai_adapter_fixture,
+            mappings=OPENAI_ADAPTER_INTERNAL,
+            sync_mappings=(*SYNC_ROOT, *OPENAI_ADAPTER_INTERNAL),
+            async_mappings=(*ASYNC_ROOT, *OPENAI_ADAPTER_INTERNAL),
+        ),
+    ),
+)

--- a/tests/test_litellm/rust_bridge/test_responses.py
+++ b/tests/test_litellm/rust_bridge/test_responses.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping, Sequence
+from typing import Final
+
+import pytest
+
+from litellm.rust_bridge import configuration
+from litellm.rust_bridge import responses as bridge
+
+RUST_RESPONSE: Final[Mapping[str, object]] = {
+    "id": "resp_test",
+    "created_at": 123,
+    "model": "gpt-5",
+    "object": "response",
+    "status": "completed",
+    "output": [
+        {
+            "id": "msg_test",
+            "type": "message",
+            "status": "completed",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "hello", "annotations": list[object]()}],
+        }
+    ],
+}
+
+
+class _RecordingGate:
+    def __init__(self, reason: str | None = None) -> None:
+        self.reason: Final = reason
+        self.calls: list[Mapping[str, object]] = []
+
+    def __call__(
+        self,
+        *,
+        model: str,
+        input: str | Sequence[object],
+        optional_params: Mapping[str, object] | None,
+        custom_llm_provider: str | None,
+        use_chat_completions_api: bool,
+    ) -> str | None:
+        self.calls.append(
+            {
+                "model": model,
+                "input": input,
+                "optional_params": optional_params,
+                "custom_llm_provider": custom_llm_provider,
+                "use_chat_completions_api": use_chat_completions_api,
+            }
+        )
+        return self.reason
+
+
+class _RecordingCall:
+    def __init__(self) -> None:
+        self.calls: list[Mapping[str, object]] = []
+
+    def __call__(
+        self,
+        *,
+        model: str,
+        input: str | Sequence[object],
+        optional_params: Mapping[str, object] | None,
+        api_key: str | None,
+        api_base: str | None,
+        custom_llm_provider: str | None,
+        extra_headers: Mapping[str, object] | None,
+        timeout_seconds: float | None,
+        use_chat_completions_api: bool | None,
+    ) -> Mapping[str, object]:
+        self.calls.append(
+            {
+                "model": model,
+                "input": input,
+                "optional_params": optional_params,
+                "api_key": api_key,
+                "api_base": api_base,
+                "custom_llm_provider": custom_llm_provider,
+                "extra_headers": extra_headers,
+                "timeout_seconds": timeout_seconds,
+                "use_chat_completions_api": use_chat_completions_api,
+            }
+        )
+        return RUST_RESPONSE
+
+
+@pytest.fixture(autouse=True)
+def reset_bridge() -> Iterator[None]:
+    bridge.set_rust_responses(responses=None, decline=None)
+    configuration.reset_rust_configuration()
+    yield
+    bridge.set_rust_responses(responses=None, decline=None)
+    configuration.reset_rust_configuration()
+
+
+def _accepts() -> bool:
+    return bridge.rust_responses_accepts(
+        model="gpt-5",
+        input="hello",
+        optional_params={"max_output_tokens": 16},
+        custom_llm_provider="openai",
+        use_chat_completions_api=False,
+        stream=None,
+        request_override=None,
+        extra_body=None,
+        extra_query=None,
+    )
+
+
+def test_disabled_route_does_not_consult_native_gate(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("LITELLM_RUST", raising=False)
+    gate: Final = _RecordingGate()
+    bridge.set_rust_responses(decline=gate)
+    assert _accepts() is False
+    assert gate.calls == []
+
+
+def test_enabled_route_uses_native_responses_abstraction() -> None:
+    gate: Final = _RecordingGate()
+    call: Final = _RecordingCall()
+    bridge.set_rust_responses(responses=call, decline=gate)
+    configuration.use_litellm_rust(True)
+    assert _accepts() is True
+    response: Final = bridge.responses(
+        model="gpt-5",
+        input="hello",
+        optional_params={"max_output_tokens": 16},
+        api_key="test-key",
+        api_base="http://provider.test",
+        custom_llm_provider="openai",
+        extra_headers=None,
+        timeout=5,
+        use_chat_completions_api=False,
+    )
+    assert response is not None
+    assert response.output_text == "hello"
+    assert call.calls[0]["use_chat_completions_api"] is False
+
+
+def test_unavailable_bridge_stays_on_python(monkeypatch: pytest.MonkeyPatch) -> None:
+    configuration.use_litellm_rust(True)
+    monkeypatch.setattr(bridge, "get_native_bridge", lambda: None)
+    assert _accepts() is False


### PR DESCRIPTION
## TLDR

Problem this solves:

- Rust bridge lacked Responses API transport
- Parity coverage was centered on OCR

How it solves it:

- Routes Responses through native or adapted provider transports
- Parameterizes Responses parity by provider and transport

## User Flow

Before: a developer enables the Rust bridge, but Responses calls always use Python transport

1. They set `LITELLM_RUST=1`
2. They call `litellm.responses` with an OpenAI, Anthropic, or Bedrock model
3. They receive a Responses-shaped result through the Python implementation

After: the same call uses Rust when its input and provider are supported

1. They set `LITELLM_RUST=1`
2. They call `litellm.responses` with an OpenAI, Anthropic, or Bedrock model
3. They receive the same Responses-shaped result through the selected provider transport

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks
- [x] My PR scope is as isolated as possible
- [ ] I have received a Greptile Confidence Score of at least 4/5

## Delays in PR merge?

If you are seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

No live provider run was captured for this PR

## Type

New Feature

Test

## Caveats (if any)

### Medium

- Streaming and stateful inputs still fall back to Python
- Unsupported tools and complex inputs still fall back to Python

### Low

- Rust Responses remains opt-in through the existing rollout flag

## Final Attestation

- [x] The tests check provider routing, fallback, output parity, and trace parity