### PR TITLE
fix(s3-v2): add missing log placeholder and fix stale docstrings

### DIFF
--- a/litellm/integrations/s3_v2.py
+++ b/litellm/integrations/s3_v2.py
@@ -425,7 +425,6 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
         Args:
             start_time (datetime): The start time of the logging event.
             standard_logging_payload (Optional[StandardLoggingPayload]): The payload to be logged.
-            s3_path (Optional[str]): The S3 path prefix.
 
         Returns:
             Optional[s3BatchLoggingElement]: The created s3BatchLoggingElement, or None if payload is None.
@@ -605,7 +604,7 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
             response: Final = await self.async_httpx_client.get(url, headers=signed_headers)
 
             if response.status_code != 200:
-                verbose_logger.exception("S3 object not found, saw response=", response.text)
+                verbose_logger.exception("S3 object not found, saw response=%s", response.text)
                 return None
 
             # Parse JSON response
@@ -625,8 +624,7 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
         Allows fetching a dict of the proxy server request from s3 or GCS bucket.
 
         Args:
-            request_id: The unique request ID to search for
-            start_time: The start time of the request (datetime or ISO string)
+            object_key: The object key to fetch from cold storage
 
         Returns:
             Optional[dict]: The request data dictionary or None if not found


### PR DESCRIPTION
## Title
fix(s3-v2): add missing log placeholder and fix stale docstrings

## Description
Three small fixes in `litellm/integrations/s3_v2.py`:

1. `verbose_logger.exception("S3 object not found, saw response=", response.text)` passes `response.text` as an unused logging argument (no `%s` placeholder), so the response body is never logged and logging emits an "arguments not converted" error. Every sibling call in the file uses the `%s` form.
2. `create_s3_batch_logging_element` documented an `s3_path` parameter that doesn't exist in the signature.
3. `get_proxy_server_request_from_cold_storage_with_object_key` documented `request_id`/`start_time` from the older request-id-based variant; the actual parameter is `object_key`.

## Relevant issues
None

## Type
🐛 Bug Fix? Test?
Fix + docstring cleanup, no behavior change beyond the log line now including the response body.

## Testing
Existing test suite covers the s3 logger mocks; docstring-only changes besides the log placeholder.
