### PR TITLE
docs: fix ghost parameter and typos in docstrings

### DIFF
--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -4260,11 +4260,7 @@ class PrometheusLogger(CustomLogger):
     @staticmethod
     def _mount_metrics_endpoint():
         """
-        Mount the Prometheus metrics endpoint with optional authentication.
-
-        Args:
-            require_auth (bool, optional): Whether to require authentication for the metrics endpoint.
-                                        Defaults to False.
+        Mount the Prometheus metrics endpoint (no authentication).
         """
         from prometheus_client import REGISTRY
 

--- a/litellm/llms/together_ai/rerank/handler.py
+++ b/litellm/llms/together_ai/rerank/handler.py
@@ -1,7 +1,7 @@
 """
 Re rank api
 
-LiteLLM supports the re rank API format, no paramter transformation occurs
+LiteLLM supports the re rank API format, no parameter transformation occurs
 """
 
 from typing import Any, Final

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -7745,7 +7745,7 @@ def add_dummy_tool(custom_llm_provider: str) -> list[ChatCompletionToolParam]:
     """
     Prevent Anthropic from raising error when tool_use block exists but no tools are provided.
 
-    Relevent Issues: https://github.com/BerriAI/litellm/issues/5388, https://github.com/BerriAI/litellm/issues/5747
+    Relevant Issues: https://github.com/BerriAI/litellm/issues/5388, https://github.com/BerriAI/litellm/issues/5747
     """
     return [
         ChatCompletionToolParam(


### PR DESCRIPTION
## Title
docs: fix ghost parameter and typos in docstrings

## Description
1. `PrometheusLogger._mount_metrics_endpoint` is a `@staticmethod` with no parameters, but its docstring documents a `require_auth` parameter and "optional authentication" — the body unconditionally mounts `/metrics` and logs "(no authentication)". The docstring now states the actual behavior.
2. `litellm/llms/together_ai/rerank/handler.py`: `paramter` → `parameter`.
3. `litellm/utils.py` `add_dummy_tool` docstring: `Relevent Issues` → `Relevant Issues`.

## Relevant issues
None

## Type
📖 Documentation Fix?
