### PR TITLE
fix(router): preserve zero capacity limits

### DIFF
--- a/litellm/router_strategy/lowest_latency.py
+++ b/litellm/router_strategy/lowest_latency.py
@@ -412,18 +412,30 @@ class LowestLatencyLoggingHandler(CustomLogger):
             if _deployment is None:
                 continue  # skip to next one
 
-            _deployment_tpm = (
-                _deployment.get("tpm", None)
-                or _deployment.get("litellm_params", {}).get("tpm", None)
-                or _deployment.get("model_info", {}).get("tpm", None)
-                or float("inf")
+            _deployment_tpm: Final = next(
+                (
+                    limit
+                    for limit in (
+                        _deployment.get("tpm", None),
+                        _deployment.get("litellm_params", {}).get("tpm", None),
+                        _deployment.get("model_info", {}).get("tpm", None),
+                    )
+                    if limit is not None
+                ),
+                float("inf"),
             )
 
-            _deployment_rpm = (
-                _deployment.get("rpm", None)
-                or _deployment.get("litellm_params", {}).get("rpm", None)
-                or _deployment.get("model_info", {}).get("rpm", None)
-                or float("inf")
+            _deployment_rpm: Final = next(
+                (
+                    limit
+                    for limit in (
+                        _deployment.get("rpm", None),
+                        _deployment.get("litellm_params", {}).get("rpm", None),
+                        _deployment.get("model_info", {}).get("rpm", None),
+                    )
+                    if limit is not None
+                ),
+                float("inf"),
             )
             item_latency = item_map.get("latency", [])
             item_ttft_latency = item_map.get("time_to_first_token", [])

--- a/tests/test_litellm/router_strategy/test_lowest_latency.py
+++ b/tests/test_litellm/router_strategy/test_lowest_latency.py
@@ -9,7 +9,6 @@ from datetime import datetime, timedelta
 
 import pytest
 
-
 import litellm
 from litellm.caching.caching import DualCache
 from litellm.router_strategy.lowest_latency import LowestLatencyLoggingHandler
@@ -58,9 +57,9 @@ def test_sync_embedding_latency_is_json_serializable():
 
     latencies = _recorded_latencies(cache)
     assert latencies, "expected a latency entry to be recorded"
-    assert all(
-        not isinstance(value, timedelta) for value in latencies
-    ), f"raw timedelta leaked into latency list: {latencies}"
+    assert all(not isinstance(value, timedelta) for value in latencies), (
+        f"raw timedelta leaked into latency list: {latencies}"
+    )
     assert latencies[-1] == pytest.approx(2.0)
     # the exact failure mode from production: redis cache sync json.dumps
     json.dumps({"latency": latencies})
@@ -84,9 +83,9 @@ async def test_async_embedding_latency_is_json_serializable():
 
     latencies = _recorded_latencies(cache)
     assert latencies, "expected a latency entry to be recorded"
-    assert all(
-        not isinstance(value, timedelta) for value in latencies
-    ), f"raw timedelta leaked into latency list: {latencies}"
+    assert all(not isinstance(value, timedelta) for value in latencies), (
+        f"raw timedelta leaked into latency list: {latencies}"
+    )
     assert latencies[-1] == pytest.approx(3.0)
     json.dumps({"latency": latencies})
 
@@ -163,3 +162,23 @@ def test_sync_chat_zero_completion_tokens_falls_back_to_seconds():
     assert latencies and latencies[-1] == pytest.approx(2.0)
     assert not isinstance(latencies[-1], timedelta)
     json.dumps({"latency": latencies})
+
+
+@pytest.mark.parametrize("limit_name", ["tpm", "rpm"])
+def test_zero_capacity_excludes_deployment(limit_name: str):
+    handler = LowestLatencyLoggingHandler(router_cache=DualCache())
+    deployment_id = "zero-capacity"
+    deployment = {
+        "model_name": "test-model",
+        "litellm_params": {"model": "openai/test-model", limit_name: 0},
+        "model_info": {"id": deployment_id},
+    }
+
+    selected = handler._get_available_deployments(
+        model_group="test-model",
+        healthy_deployments=[deployment],
+        input="hello",
+        request_count_dict={deployment_id: {"latency": [0.1]}},
+    )
+
+    assert selected is None


### PR DESCRIPTION
## TLDR

Problem this solves:

- Zero TPM or RPM incorrectly means unlimited capacity
- Disabled deployments can continue receiving routed requests

How it solves it:

- Preserve zero while resolving configured capacity limits
- Cover both TPM and RPM with regression tests

## User Flow

Before: an operator sets a deployment's RPM to zero, but requests can still route to it

1. They configure a lowest-latency deployment with `rpm: 0`
2. They send a request for that model group
3. The zero-capacity deployment remains eligible and can receive the request

After: the same zero-RPM deployment is excluded from routing

1. They configure a lowest-latency deployment with `rpm: 0`
2. They send a request for that model group
3. The zero-capacity deployment is excluded from the available deployments

## Relevant issues

Fixes #39744

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

Shared setup uses one lowest-latency deployment with `rpm: 0` and a recorded latency. No provider credentials or external API calls are needed

```python
from litellm.caching.caching import DualCache
from litellm.router_strategy.lowest_latency import LowestLatencyLoggingHandler

deployment = {
    "model_name": "test-model",
    "litellm_params": {"model": "openai/test-model", "rpm": 0},
    "model_info": {"id": "zero-capacity"},
}
handler = LowestLatencyLoggingHandler(router_cache=DualCache())
result = handler._get_available_deployments(
    model_group="test-model",
    healthy_deployments=[deployment],
    input="hello",
    request_count_dict={"zero-capacity": {"latency": [0.1]}},
)
print(result["model_info"]["id"] if result else None)
```

### Before (b75ac5cf52)

1. Run the shared reproduction with `LITELLM_LOCAL_MODEL_COST_MAP=True python reproduce.py`
2. Observe `zero-capacity`, so the zero-RPM deployment remains eligible

### After (163662406f)

1. Run the same reproduction with `LITELLM_LOCAL_MODEL_COST_MAP=True python reproduce.py`
2. Observe `None`, so the zero-RPM deployment is excluded

## Type

🐛 Bug Fix

✅ Test

## Caveats (if any)

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
