### PR TITLE
fix(spend): fall back from null response ids

### DIFF
--- a/litellm/proxy/spend_tracking/spend_tracking_utils.py
+++ b/litellm/proxy/spend_tracking/spend_tracking_utils.py
@@ -216,7 +216,7 @@ def get_spend_logs_id(call_type: str, response_obj: dict, kwargs: dict) -> str |
         kwargs.get("litellm_call_id"),
     )
     resolved_id: Final = next(
-        (candidate for candidate in candidate_ids if isinstance(candidate, str) and candidate), None
+        (candidate for candidate in candidate_ids if isinstance(candidate, str) and candidate not in ("", "None")), None
     )
     if resolved_id is not None and call_type == CallTypes.aretrieve_batch.value:
         return f"{resolved_id}{BATCH_COST_REQUEST_ID_SUFFIX}"

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
@@ -3399,6 +3399,19 @@ def test_get_spend_logs_id_prefers_the_response_id_over_the_standard_logging_id(
     )
 
 
+def test_get_spend_logs_id_falls_back_when_the_standard_logging_id_is_none():
+    ids = [
+        get_spend_logs_id(
+            "acompletion",
+            {"id": None},
+            {"litellm_call_id": call_id, "standard_logging_object": {"id": "None"}},
+        )
+        for call_id in ("call-id-1", "call-id-2")
+    ]
+
+    assert ids == ["call-id-1", "call-id-2"]
+
+
 @pytest.mark.asyncio
 async def test_spend_log_request_id_is_the_message_id_a_bridged_streaming_caller_was_streamed():
     """A streaming /v1/messages call against a non-Anthropic model is served a msg_ id the


### PR DESCRIPTION
## TLDR

Problem this solves:

- Null provider IDs collapse spend logs onto `"None"`
- Later requests disappear as duplicate rows

How it solves it:

- Ignore the serialized `"None"` ID sentinel
- Fall back to each request's unique call ID

## User Flow

Before: an operator sends successful requests, but only the first request appears in Request Logs

1. They send POST https://litellm-domain/v1/chat/completions to a model whose provider returns `"id": null`
2. They repeat the same request and receive another 200 response
3. They open https://litellm-domain/ui/?page=logs and see one row with Request ID `None`

After: every successful request appears with a unique, searchable Request ID

1. They send POST https://litellm-domain/v1/chat/completions to the same model
2. They repeat the same request and receive another 200 response
3. They open https://litellm-domain/ui/?page=logs and see one distinct row per request

## Relevant issues

Fixes #39749

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Live proxy verification is pending because it requires a configured provider that returns `id: null` and a database-backed proxy. The focused resolver tests passed without credentials or network access

## Type

Bug Fix

## Caveats (if any)

## Final Attestation

- [x] The tests check the right things, including the distinct-ID regression case
