### PR TITLE
fix(ollama): warn when the default prompt template replaces the model…

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -202,6 +202,7 @@ def _handle_ollama_system_message(messages: list, prompt: str, msg_i: int) -> tu
 
 @lru_cache(maxsize=DEFAULT_MAX_LRU_CACHE_SIZE)
 def _emit_ollama_default_template_warning(model: str, logger: Logger) -> None:
+    display_model: Final = re.sub(r"[\x00-\x1f\x7f]", " ", model)
     logger.warning(
         "ollama/%s: the chat messages were flattened into a single text prompt with "
         "'### System:' / '### User:' / '### Assistant:' markers and sent to /api/generate. This is "
@@ -211,8 +212,8 @@ def _emit_ollama_default_template_warning(model: str, logger: Logger) -> None:
         "the model's template, or register a template for this model with "
         "litellm.register_prompt_template() to keep using 'ollama/'. "
         "Docs: https://docs.litellm.ai/docs/providers/ollama",
-        model,
-        model,
+        display_model,
+        display_model,
     )
 
 

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -7,6 +7,8 @@ import re
 import xml.etree.ElementTree as ET
 from collections.abc import Iterator, Mapping, Sequence
 from enum import Enum
+from functools import lru_cache
+from logging import Logger
 from typing import Any, Final, TypedDict, cast, overload
 
 from jinja2.sandbox import ImmutableSandboxedEnvironment
@@ -16,7 +18,7 @@ import litellm.types
 import litellm.types.llms
 from litellm import verbose_logger
 from litellm._uuid import uuid
-from litellm.constants import REDACTED_BY_LITELLM
+from litellm.constants import DEFAULT_MAX_LRU_CACHE_SIZE, REDACTED_BY_LITELLM
 from litellm.litellm_core_utils.url_utils import async_safe_get, safe_get
 from litellm.llms.custom_httpx.http_handler import HTTPHandler, get_async_httpx_client
 from litellm.types.files import get_file_extension_from_mime_type
@@ -198,12 +200,40 @@ def _handle_ollama_system_message(messages: list, prompt: str, msg_i: int) -> tu
     return system_content_str, msg_i
 
 
+@lru_cache(maxsize=DEFAULT_MAX_LRU_CACHE_SIZE)
+def _emit_ollama_default_template_warning(model: str, logger: Logger) -> None:
+    logger.warning(
+        "ollama/%s: the chat messages were flattened into a single text prompt with "
+        "'### System:' / '### User:' / '### Assistant:' markers and sent to /api/generate. This is "
+        "litellm's default template for the 'ollama/' provider, and it replaces the model's own "
+        "chat template, which Ollama applies on /api/chat. A model that was never trained on those "
+        "markers can echo them back as response content. Use 'ollama_chat/%s' to let Ollama apply "
+        "the model's template, or register a template for this model with "
+        "litellm.register_prompt_template() to keep using 'ollama/'. "
+        "Docs: https://docs.litellm.ai/docs/providers/ollama",
+        model,
+        model,
+    )
+
+
+def warn_once_if_ollama_default_template_used(
+    model: str,
+    messages: Sequence[AllMessageValues],
+    logger: Logger = verbose_logger,
+) -> None:
+    roles: Final = frozenset(message.get("role") for message in messages)
+    if len(roles) < 2:
+        return
+    _emit_ollama_default_template_warning(model, logger)
+
+
 def ollama_pt(
     model: str, messages: list
 ) -> (
     str | OllamaVisionModelObject
 ):  # https://github.com/ollama/ollama/blob/af4cf55884ac54b9e637cd71dadfe9b7a5685877/docs/modelfile.md#template
     user_message_types: Final = {"user", "tool", "function"}
+    warn_once_if_ollama_default_template_used(model=model, messages=messages)
     msg_i = 0
     images: Final = []
     prompt = ""

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -135,6 +135,20 @@ class TestOllamaDefaultTemplateWarning:
             "each affected model needs its own warning, since one deployment can route several"
         )
 
+    def test_control_characters_in_the_model_name_cannot_forge_log_lines(self, caplog):
+        messages: Final = [
+            {"role": "system", "content": "You are a helpful assistant"},
+            {"role": "user", "content": "Hello"},
+        ]
+
+        with caplog.at_level(logging.WARNING, logger=verbose_logger.name):
+            ollama_pt(model="llama3.2:1b\nFORGED: standalone log line", messages=messages)
+
+        warnings: Final = self._warnings(caplog)
+        assert len(warnings) == 1
+        assert "\n" not in warnings[0], "a caller-supplied model name must not inject extra log lines"
+        assert "FORGED" in warnings[0]
+
 
 @pytest.mark.asyncio
 async def test_anthropic_bedrock_thinking_blocks_with_none_content():

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -8,8 +8,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import litellm
+from litellm._logging import verbose_logger
 from litellm.litellm_core_utils.prompt_templates.factory import (
     BAD_MESSAGE_ERROR_STR,
+    _emit_ollama_default_template_warning,
     BEDROCK_DOCUMENT_PLACEHOLDER_TEXT,
     BedrockConverseMessagesProcessor,
     BedrockImageProcessor,
@@ -71,6 +73,67 @@ def test_ollama_pt_consecutive_user_messages():
     expected_prompt = "### User:\nHello\n\n### Assistant:\nHow can I help you?\n\n### User:\nHow are you?\n\n### Assistant:\nI'm good, thanks!\n\n### User:\nI am well too.\n\n"
     assert isinstance(result, dict)
     assert result["prompt"] == expected_prompt
+
+
+class TestOllamaDefaultTemplateWarning:
+    """The `ollama/` provider flattens chat messages with hard-coded '### System:' /
+    '### User:' markers, replacing the model's own chat template that Ollama would apply
+    on /api/chat. That substitution is otherwise invisible (HTTP 200, no log line), so the
+    warning is the caller's only signal. It must fire for chat-shaped requests, stay quiet
+    on repeat calls, and never change the prompt that is actually sent.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _reset_warning_cache(self):
+        _emit_ollama_default_template_warning.cache_clear()
+
+    @staticmethod
+    def _warnings(caplog):
+        return [record.message for record in caplog.records if "### System:" in record.message]
+
+    def test_warns_once_and_leaves_prompt_unchanged(self, caplog):
+        messages: Final = [
+            {"role": "system", "content": "You are a helpful assistant"},
+            {"role": "user", "content": "Hello"},
+        ]
+        expected_prompt: Final = "### System:\nYou are a helpful assistant\n\n### User:\nHello\n\n"
+
+        with caplog.at_level(logging.WARNING, logger=verbose_logger.name):
+            first = ollama_pt(model="llama3.2:1b", messages=messages)
+            second = ollama_pt(model="llama3.2:1b", messages=messages)
+
+        warnings = self._warnings(caplog)
+        assert len(warnings) == 1, "the flattening warning must be emitted once per model, not once per request"
+        assert "ollama/llama3.2:1b" in warnings[0]
+        assert "ollama_chat/llama3.2:1b" in warnings[0]
+        assert "litellm.register_prompt_template()" in warnings[0]
+
+        assert first["prompt"] == expected_prompt, "warning must not change the flattened prompt"
+        assert second["prompt"] == expected_prompt
+
+    def test_does_not_warn_for_single_role_prompt(self, caplog):
+        messages: Final = [{"role": "user", "content": "Hello"}]
+
+        with caplog.at_level(logging.WARNING, logger=verbose_logger.name):
+            result = ollama_pt(model="llama3.2:1b", messages=messages)
+
+        assert self._warnings(caplog) == [], "a single-role prompt has no chat template to override"
+        assert result["prompt"] == "### User:\nHello\n\n"
+
+    def test_warns_again_for_a_different_model(self, caplog):
+        messages: Final = [
+            {"role": "system", "content": "You are a helpful assistant"},
+            {"role": "user", "content": "Hello"},
+        ]
+
+        with caplog.at_level(logging.WARNING, logger=verbose_logger.name):
+            ollama_pt(model="llama3.2:1b", messages=messages)
+            ollama_pt(model="qwen2.5-coder:7b", messages=messages)
+
+        warned_models: Final = [warning.split(":")[0] for warning in self._warnings(caplog)]
+        assert warned_models == ["ollama/llama3.2", "ollama/qwen2.5-coder"], (
+            "each affected model needs its own warning, since one deployment can route several"
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/llms/ollama/test_ollama_completion_transformation.py
+++ b/tests/test_litellm/llms/ollama/test_ollama_completion_transformation.py
@@ -1,15 +1,80 @@
 import json
+import logging
 from litellm._uuid import uuid
+from typing import Final
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 
+from litellm._logging import verbose_logger
+from litellm.litellm_core_utils.prompt_templates.factory import (
+    _emit_ollama_default_template_warning,
+)
 from litellm.llms.ollama.completion.transformation import (
     OllamaConfig,
     OllamaTextCompletionResponseIterator,
 )
 from litellm.types.utils import Message, ModelResponse, ModelResponseStream
+
+
+CHAT_MESSAGES: Final = [
+    {"role": "system", "content": "Reply with only the category name."},
+    {"role": "user", "content": "how do I fix a segfault in my C code"},
+]
+
+
+class TestOllamaDefaultTemplateWarning:
+    """`ollama/` only substitutes its default '### System:' / '### User:' template when no
+    prompt template is registered for the model, so the warning about that substitution must
+    follow the same condition: a registered template is the documented way to opt out, and it
+    has to silence the warning too.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _reset_warning_cache(self):
+        _emit_ollama_default_template_warning.cache_clear()
+
+    @staticmethod
+    def _transform(caplog, litellm_params: dict) -> dict:
+        with caplog.at_level(logging.WARNING, logger=verbose_logger.name):
+            return OllamaConfig().transform_request(
+                model="llama3.2:1b",
+                messages=CHAT_MESSAGES,
+                optional_params={},
+                litellm_params=litellm_params,
+                headers={},
+            )
+
+    @staticmethod
+    def _warnings(caplog) -> list:
+        return [record.message for record in caplog.records if "### System:" in record.message]
+
+    def test_default_template_warns(self, caplog):
+        data = self._transform(caplog, litellm_params={})
+
+        assert "### System:" in data["prompt"]
+        assert len(self._warnings(caplog)) == 1
+        assert "ollama_chat/llama3.2:1b" in self._warnings(caplog)[0]
+
+    def test_registered_prompt_template_is_silent(self, caplog):
+        custom_prompt_dict: Final = {
+            "llama3.2:1b": {
+                "roles": {
+                    "system": {"pre_message": "<|system|>\n", "post_message": "<|end|>\n"},
+                    "user": {"pre_message": "<|user|>\n", "post_message": "<|end|>\n"},
+                    "assistant": {"pre_message": "<|assistant|>\n", "post_message": "<|end|>\n"},
+                },
+                "initial_prompt_value": "",
+                "final_prompt_value": "",
+            }
+        }
+
+        data = self._transform(caplog, litellm_params={"custom_prompt_dict": custom_prompt_dict})
+
+        assert "### System:" not in data["prompt"]
+        assert "<|system|>" in data["prompt"]
+        assert self._warnings(caplog) == [], "a registered template opts out of the default, so there is nothing to warn about"
 
 
 class TestOllamaConfig:


### PR DESCRIPTION
## TLDR

Problem this solves:

- `ollama/` replaces the model's own chat template
- Nothing in the request, response, or logs says so
- Callers see broken output and blame the model

How it solves it:

- Warn once per model when the default template is applied
- Name `ollama_chat/` and `register_prompt_template()` as the fixes
- No behavior change: the prompt sent is identical

## User Flow

Before: a developer routing a chat model through `ollama/` gets role markers back as answer text, with nothing anywhere explaining why

1. They send POST https://litellm-domain/v1/chat/completions with `"model": "ollama/llama3.2:1b"`, a system message asking for one category name, and a user question
2. The response comes back 200 with `"content": "### System:\nReasoning: programming, debugging,"` instead of the single category name they asked for
3. They read the proxy logs and find nothing unusual: no warning, no error
4. They conclude the model is too small for the task and go looking for a bigger one

After: the same request returns the same text, but the logs now say what happened and what to change

1. They send the same POST https://litellm-domain/v1/chat/completions
2. The response is unchanged, still `"content": "### System:\nReasoning: programming, debugging,"`
3. The proxy logs now carry one warning saying the messages were flattened into a single text prompt with `### System:` markers, that this replaces the model's own template, and to use `ollama_chat/llama3.2:1b` instead
4. They switch the model to `ollama_chat/llama3.2:1b` and get the single category name they expected

## Relevant issues

Refs #39724

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [[Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live run against a real Ollama host, model `llama3.2:1b`, proxy started on the checkout under test (port 4400). Identical request on both sides: system "Reply with only the category name.", user "how do I fix a segfault in my C code", temperature 0, max_tokens 10.

### Before (c8635ecc67)

1. `curl -sS http://localhost:4400/v1/chat/completions -H 'Content-Type: application/json' -d '{"model":"ollama/llama3.2:1b","messages":[{"role":"system","content":"Reply with only the category name."},{"role":"user","content":"how do I fix a segfault in my C code"}],"temperature":0,"max_tokens":10}'` returns 200 with `"content": "### System\nError\n### User\nhow do"`. The model echoes the injected markers instead of answering.
2. `grep -c "flattened into a single text prompt" proxy.log` returns `0`. The substitution is silent.

### After (d10c2333be)

1. The same curl returns 200 with byte-identical content, `"content": "### System\nError\n### User\nhow do"`. The prompt sent is unchanged, so the output is unchanged.
2. `grep -c "flattened into a single text prompt" proxy.log` returns `1`, and the line reads:

```
LiteLLM:WARNING: factory.py:205 - ollama/llama3.2:1b: the chat messages were flattened into a single text prompt with '### System:' / '### User:' / '### Assistant:' markers and sent to /api/generate. This is litellm's default template for the 'ollama/' provider, and it replaces the model's own chat template, which Ollama applies on /api/chat. A model that was never trained on those markers can echo them back as response content. Use 'ollama_chat/llama3.2:1b' to let Ollama apply the model's template, or register a template for this model with litellm.register_prompt_template() to keep using 'ollama/'. Docs: https://docs.litellm.ai/docs/providers/ollama
```

3. After 3 identical calls, `grep -c "flattened into a single text prompt" proxy.log` still returns `1`. The warning is once per model.
4. The same request with `"model": "ollama_chat/llama3.2:1b"` returns `"content": "**Memory Management Issues**\n-------------------------\n\nA segfault"`, marker-free. That is the path the warning points at.

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Warns per model, not once per process
- Single-role prompts stay silent on purpose
- Docs for this ship separately in `BerriAI/litellm-docs`

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR