### PR TITLE
fix(prompt-templates): treat initial_prompt_value and final_prompt_value as optional

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -5165,8 +5165,8 @@ def response_schema_prompt(model: str, response_schema: dict) -> str:
     if custom_prompt_details is not None:
         return custom_prompt(
             role_dict=custom_prompt_details["roles"],
-            initial_prompt_value=custom_prompt_details["initial_prompt_value"],
-            final_prompt_value=custom_prompt_details["final_prompt_value"],
+            initial_prompt_value=custom_prompt_details.get("initial_prompt_value", ""),
+            final_prompt_value=custom_prompt_details.get("final_prompt_value", ""),
             messages=response_schema_as_message,
         )
     else:

--- a/litellm/llms/anthropic/completion/transformation.py
+++ b/litellm/llms/anthropic/completion/transformation.py
@@ -239,8 +239,8 @@ class AnthropicTextConfig(BaseConfig):
             model_prompt_details: Final = custom_prompt_dict[model]
             prompt = custom_prompt(
                 role_dict=model_prompt_details["roles"],
-                initial_prompt_value=model_prompt_details["initial_prompt_value"],
-                final_prompt_value=model_prompt_details["final_prompt_value"],
+                initial_prompt_value=model_prompt_details.get("initial_prompt_value", ""),
+                final_prompt_value=model_prompt_details.get("final_prompt_value", ""),
                 messages=messages,
             )
         else:

--- a/litellm/llms/codestral/completion/handler.py
+++ b/litellm/llms/codestral/completion/handler.py
@@ -263,8 +263,8 @@ class CodestralTextCompletion:
             model_prompt_details: Final = custom_prompt_dict[model]
             prompt = custom_prompt(
                 role_dict=model_prompt_details["roles"],
-                initial_prompt_value=model_prompt_details["initial_prompt_value"],
-                final_prompt_value=model_prompt_details["final_prompt_value"],
+                initial_prompt_value=model_prompt_details.get("initial_prompt_value", ""),
+                final_prompt_value=model_prompt_details.get("final_prompt_value", ""),
                 messages=messages,
             )
         else:

--- a/litellm/llms/ollama/completion/transformation.py
+++ b/litellm/llms/ollama/completion/transformation.py
@@ -360,8 +360,8 @@ class OllamaConfig(BaseConfig):
             model_prompt_details: Final = custom_prompt_dict[model]
             ollama_prompt = custom_prompt(
                 role_dict=model_prompt_details["roles"],
-                initial_prompt_value=model_prompt_details["initial_prompt_value"],
-                final_prompt_value=model_prompt_details["final_prompt_value"],
+                initial_prompt_value=model_prompt_details.get("initial_prompt_value", ""),
+                final_prompt_value=model_prompt_details.get("final_prompt_value", ""),
                 messages=messages,
             )
         elif text_completion_request:  # handle `/completions` requests

--- a/litellm/llms/petals/completion/handler.py
+++ b/litellm/llms/petals/completion/handler.py
@@ -44,8 +44,8 @@ def completion(
         model_prompt_details: Final = litellm.custom_prompt_dict[model]
         prompt = custom_prompt(
             role_dict=model_prompt_details["roles"],
-            initial_prompt_value=model_prompt_details["initial_prompt_value"],
-            final_prompt_value=model_prompt_details["final_prompt_value"],
+            initial_prompt_value=model_prompt_details.get("initial_prompt_value", ""),
+            final_prompt_value=model_prompt_details.get("final_prompt_value", ""),
             messages=messages,
         )
     else:

--- a/litellm/llms/predibase/chat/transformation.py
+++ b/litellm/llms/predibase/chat/transformation.py
@@ -261,8 +261,8 @@ class PredibaseConfig(BaseConfig):
             model_prompt_details: Final = custom_prompt_dict[model]
             prompt = custom_prompt(
                 role_dict=model_prompt_details["roles"],
-                initial_prompt_value=model_prompt_details["initial_prompt_value"],
-                final_prompt_value=model_prompt_details["final_prompt_value"],
+                initial_prompt_value=model_prompt_details.get("initial_prompt_value", ""),
+                final_prompt_value=model_prompt_details.get("final_prompt_value", ""),
                 messages=messages,
             )
         else:

--- a/litellm/llms/vllm/completion/handler.py
+++ b/litellm/llms/vllm/completion/handler.py
@@ -58,8 +58,8 @@ def completion(
         model_prompt_details: Final = custom_prompt_dict[model]
         prompt = custom_prompt(
             role_dict=model_prompt_details["roles"],
-            initial_prompt_value=model_prompt_details["initial_prompt_value"],
-            final_prompt_value=model_prompt_details["final_prompt_value"],
+            initial_prompt_value=model_prompt_details.get("initial_prompt_value", ""),
+            final_prompt_value=model_prompt_details.get("final_prompt_value", ""),
             messages=messages,
         )
     else:
@@ -146,8 +146,8 @@ def batch_completions(model: str, messages: list, optional_params=None, custom_p
         for message in messages:
             prompt = custom_prompt(
                 role_dict=model_prompt_details["roles"],
-                initial_prompt_value=model_prompt_details["initial_prompt_value"],
-                final_prompt_value=model_prompt_details["final_prompt_value"],
+                initial_prompt_value=model_prompt_details.get("initial_prompt_value", ""),
+                final_prompt_value=model_prompt_details.get("final_prompt_value", ""),
                 messages=message,
             )
             prompts.append(prompt)

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_custom_prompt_optional_keys.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_custom_prompt_optional_keys.py
@@ -1,0 +1,198 @@
+"""Every consumer of ``custom_prompt_dict`` must treat the two prompt-value keys as optional.
+
+``litellm.completion()`` only stores ``initial_prompt_value`` / ``final_prompt_value`` when the
+caller passes a truthy value, and ``custom_prompt()`` already defaults both to ``""``. A template
+that sets ``roles`` alone therefore has to render, not raise ``KeyError``.
+"""
+
+import sys
+import types
+
+import pytest
+
+import litellm
+from litellm.litellm_core_utils.prompt_templates.factory import response_schema_prompt
+from litellm.llms.anthropic.completion.transformation import AnthropicTextConfig
+from litellm.llms.codestral.completion.handler import CodestralTextCompletion
+from litellm.llms.ollama.completion.transformation import OllamaConfig
+from litellm.llms.petals.completion import handler as petals_handler
+from litellm.llms.predibase.chat.transformation import PredibaseConfig
+from litellm.llms.vllm.completion import handler as vllm_handler
+from litellm.types.utils import ModelResponse, TextCompletionResponse
+
+MODEL = "partial-template-model"
+ROLES = {"user": {"pre_message": "[INST] ", "post_message": " [/INST]"}}
+MESSAGES = [{"role": "user", "content": "hi"}]
+RENDERED_MESSAGES = "[INST] hi [/INST]"
+
+RESPONSE_SCHEMA = {"type": "object"}
+RENDERED_SCHEMA = f"[INST] {RESPONSE_SCHEMA} [/INST]"
+
+INITIAL = "<start>"
+FINAL = "<end>"
+
+PARTIAL_TEMPLATE = {"roles": ROLES}
+FULL_TEMPLATE = {"roles": ROLES, "initial_prompt_value": INITIAL, "final_prompt_value": FINAL}
+
+
+class _PromptCaptured(Exception):
+    """Raised by the test doubles below to stop a provider call once it has built its prompt."""
+
+    def __init__(self, prompt):
+        super().__init__(prompt)
+        self.prompt = prompt
+
+
+class _CapturingLogging:
+    """Stands in for the logging object providers call with the prompt they are about to send."""
+
+    def pre_call(self, input, api_key, additional_args=None, **kwargs):
+        raise _PromptCaptured(input)
+
+    def post_call(self, *args, **kwargs):
+        pass
+
+
+def _captured_prompt(call):
+    with pytest.raises(_PromptCaptured) as excinfo:
+        call()
+    return excinfo.value.prompt
+
+
+@pytest.fixture(autouse=True)
+def stub_vllm_import(monkeypatch):
+    """``vllm`` is an optional heavyweight dependency; its handler only needs the two names."""
+
+    class _SamplingParams:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    class _LLM:
+        def __init__(self, model):
+            self.model = model
+
+        def generate(self, prompts, sampling_params):
+            raise _PromptCaptured(prompts)
+
+    stub = types.ModuleType("vllm")
+    stub.LLM = _LLM
+    stub.SamplingParams = _SamplingParams
+
+    monkeypatch.setitem(sys.modules, "vllm", stub)
+    monkeypatch.setattr(vllm_handler, "llm", None)
+
+
+def _render_ollama(template, monkeypatch):
+    request = OllamaConfig().transform_request(
+        model=MODEL,
+        messages=MESSAGES,
+        optional_params={},
+        litellm_params={"custom_prompt_dict": {MODEL: template}},
+        headers={},
+    )
+    return request["prompt"]
+
+
+def _render_predibase(template, monkeypatch):
+    request = PredibaseConfig().transform_request(
+        model=MODEL,
+        messages=MESSAGES,
+        optional_params={},
+        litellm_params={"custom_prompt_dict": {MODEL: template}},
+        headers={},
+    )
+    return request["inputs"]
+
+
+def _render_anthropic_text(template, monkeypatch):
+    monkeypatch.setattr(litellm, "custom_prompt_dict", {MODEL: template})
+    return AnthropicTextConfig()._get_anthropic_text_prompt_from_messages(messages=MESSAGES, model=MODEL)
+
+
+def _render_response_schema_prompt(template, monkeypatch):
+    monkeypatch.setattr(litellm, "custom_prompt_dict", {f"{MODEL}/response_schema_prompt": template})
+    return response_schema_prompt(model=MODEL, response_schema=RESPONSE_SCHEMA)
+
+
+def _render_petals(template, monkeypatch):
+    monkeypatch.setattr(litellm, "custom_prompt_dict", {MODEL: template})
+    return _captured_prompt(
+        lambda: petals_handler.completion(
+            model=MODEL,
+            messages=MESSAGES,
+            api_base="http://petals.invalid",
+            model_response=ModelResponse(),
+            print_verbose=lambda *args, **kwargs: None,
+            encoding=None,
+            logging_obj=_CapturingLogging(),
+            optional_params={},
+        )
+    )
+
+
+def _render_codestral(template, monkeypatch):
+    return _captured_prompt(
+        lambda: CodestralTextCompletion().completion(
+            model=MODEL,
+            messages=MESSAGES,
+            api_base="http://codestral.invalid",
+            custom_prompt_dict={MODEL: template},
+            model_response=TextCompletionResponse(),
+            print_verbose=lambda *args, **kwargs: None,
+            encoding=None,
+            api_key="sk-not-used",
+            logging_obj=_CapturingLogging(),
+            optional_params={},
+            timeout=1.0,
+        )
+    )
+
+
+def _render_vllm_completion(template, monkeypatch):
+    return _captured_prompt(
+        lambda: vllm_handler.completion(
+            model=MODEL,
+            messages=MESSAGES,
+            model_response=ModelResponse(),
+            print_verbose=lambda *args, **kwargs: None,
+            encoding=None,
+            logging_obj=_CapturingLogging(),
+            optional_params={},
+            custom_prompt_dict={MODEL: template},
+        )
+    )
+
+
+def _render_vllm_batch(template, monkeypatch):
+    prompts = _captured_prompt(
+        lambda: vllm_handler.batch_completions(
+            model=MODEL,
+            messages=[MESSAGES],
+            optional_params={},
+            custom_prompt_dict={MODEL: template},
+        )
+    )
+    assert len(prompts) == 1
+    return prompts[0]
+
+
+CALL_SITES = [
+    pytest.param(_render_ollama, RENDERED_MESSAGES, id="ollama"),
+    pytest.param(_render_petals, RENDERED_MESSAGES, id="petals"),
+    pytest.param(_render_vllm_completion, RENDERED_MESSAGES, id="vllm-completion"),
+    pytest.param(_render_vllm_batch, RENDERED_MESSAGES, id="vllm-batch-completions"),
+    pytest.param(_render_predibase, RENDERED_MESSAGES, id="predibase"),
+    pytest.param(_render_codestral, RENDERED_MESSAGES, id="codestral"),
+    pytest.param(_render_anthropic_text, RENDERED_MESSAGES, id="anthropic-text"),
+    pytest.param(_render_response_schema_prompt, RENDERED_SCHEMA, id="response-schema-prompt"),
+]
+
+
+@pytest.mark.parametrize(("render", "rendered_body"), CALL_SITES)
+def test_template_without_the_optional_prompt_values_renders(render, rendered_body, monkeypatch):
+    assert render(PARTIAL_TEMPLATE, monkeypatch) == rendered_body
+
+
+@pytest.mark.parametrize(("render", "rendered_body"), CALL_SITES)
+def test_template_with_the_optional_prompt_values_still_applies_them(render, rendered_body, monkeypatch):
+    assert render(FULL_TEMPLATE, monkeypatch) == INITIAL + rendered_body + FINAL

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_custom_prompt_optional_keys.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_custom_prompt_optional_keys.py
@@ -1,10 +1,3 @@
-"""Every consumer of ``custom_prompt_dict`` must treat the two prompt-value keys as optional.
-
-``litellm.completion()`` only stores ``initial_prompt_value`` / ``final_prompt_value`` when the
-caller passes a truthy value, and ``custom_prompt()`` already defaults both to ``""``. A template
-that sets ``roles`` alone therefore has to render, not raise ``KeyError``.
-"""
-
 import sys
 import types
 
@@ -36,16 +29,12 @@ FULL_TEMPLATE = {"roles": ROLES, "initial_prompt_value": INITIAL, "final_prompt_
 
 
 class _PromptCaptured(Exception):
-    """Raised by the test doubles below to stop a provider call once it has built its prompt."""
-
     def __init__(self, prompt):
         super().__init__(prompt)
         self.prompt = prompt
 
 
 class _CapturingLogging:
-    """Stands in for the logging object providers call with the prompt they are about to send."""
-
     def pre_call(self, input, api_key, additional_args=None, **kwargs):
         raise _PromptCaptured(input)
 
@@ -61,8 +50,6 @@ def _captured_prompt(call):
 
 @pytest.fixture(autouse=True)
 def stub_vllm_import(monkeypatch):
-    """``vllm`` is an optional heavyweight dependency; its handler only needs the two names."""
-
     class _SamplingParams:
         def __init__(self, **kwargs):
             self.kwargs = kwargs


### PR DESCRIPTION
## TLDR

Problem this solves:

- A custom prompt template that omits two optional keys crashes
- The 500 says connection failed and names no config key
- Seven providers crash where five render the same template

How it solves it:

- Read both keys with a default, like the five that work
- Templates that set every key render exactly as before
- Tests cover all seven call sites, partial and full templates

## User Flow

Before: a developer running a gateway in front of Ollama adds a prompt template to one model, and every request to that model comes back as a 500 that reads like a network failure

1. They add a `roles` mapping to that model's entry in their gateway config, leaving the other template fields unset because the docs mark them optional, and restart the gateway
2. The gateway starts cleanly, with no warning or error about the template
3. They send POST https://gateway-domain/v1/chat/completions with `"model": "llama-partial-template"`, a system message and one user message
4. They get back HTTP 500 with `{"error":{"message":"litellm.APIConnectionError: 'initial_prompt_value'","type":"internal_server_error","param":null,"code":"500"}}`
5. Reading that as a connection problem, they curl their model host directly and it answers fine
6. Nothing in the error names a config field to add, so the model stays unusable on every endpoint

After: the same config and the same request return a normal completion, rendered in the format the developer asked for

1. They add a `roles` mapping to that model's entry in their gateway config, leaving the other template fields unset, and restart the gateway
2. The gateway starts cleanly, with no warning or error about the template
3. They send POST https://gateway-domain/v1/chat/completions with `"model": "llama-partial-template"`, a system message and one user message
4. They get back HTTP 200 and a normal completion, with their role markers applied and nothing prepended or appended
5. Adding the two optional fields later changes the prompt exactly as documented, so nothing they already had breaks

## Relevant issues

Fixes #39759

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [[Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live run against a real Ollama host serving `llama3.1:8b`, with the proxy started on the checkout under test on port 4444. One model entry, whose template sets `roles` and neither of the two optional prompt values:

```yaml
model_list:
  - model_name: llama-partial-template
    litellm_params:
      model: ollama/llama3.1:8b
      api_base: http://ollama-host:11434
      roles: {"system": {"pre_message": "[INST] <<SYS>>\n", "post_message": "\n<</SYS>>\n [/INST]\n"}, "user": {"pre_message": "[INST] ", "post_message": " [/INST]"}, "assistant": {"pre_message": "", "post_message": ""}}
```

```bash
PYTHONPATH=. LITELLM_MASTER_KEY=sk-proof-local \
  python litellm/proxy/proxy_cli.py --config proof-config.yaml --port 4444
```

### Before (7276caecd4)

1. Send the request:

```bash
curl -sS -w "\nHTTP %{http_code}\n" http://localhost:4444/v1/chat/completions \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" \
  -d '{"model":"llama-partial-template","messages":[{"role":"system","content":"Answer in one word."},{"role":"user","content":"what colour is the sky on a clear day"}],"temperature":0,"max_tokens":8}'
```

```
{"error":{"message":"litellm.APIConnectionError: 'initial_prompt_value'","type":"internal_server_error","param":null,"code":"500"}}
HTTP 500
```

2. `grep -c "KeyError: 'initial_prompt_value'" proxy.log` returns `3`, all from that one request, and the proxy log shows the request never reached Ollama:

```
  File "litellm/llms/ollama/completion/transformation.py", line 363, in transform_request
    initial_prompt_value=model_prompt_details["initial_prompt_value"],
                         ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'initial_prompt_value'
```

### After (7e4dc1d935)

1. Send the same request against the same Ollama host:

```bash
curl -sS -w "\nHTTP %{http_code}\n" http://localhost:4444/v1/chat/completions \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" \
  -d '{"model":"llama-partial-template","messages":[{"role":"system","content":"Answer in one word."},{"role":"user","content":"what colour is the sky on a clear day"}],"temperature":0,"max_tokens":8}'
```

```
{"id":"chatcmpl-e478e9de-c330-4bac-b6a1-8d58d752e25c","created":1788536659,"model":"llama-partial-template","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"Blue","role":"assistant"}}],"usage":{"completion_tokens":2,"prompt_tokens":43,"total_tokens":45}}
HTTP 200
```

2. `grep -c "KeyError: 'initial_prompt_value'" proxy.log` returns `0`. The template rendered and the model answered.

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- A template with no `roles` key still raises `KeyError: 'roles'`
- `custom_prompt()` gives `role_dict` no default, so that stays required

### Low

- `bos_token` and `eos_token` are stored but no provider reads them
- Fixing either of those is a separate change

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR