### PR TITLE
refactor(ocr): complete native OCR provider ownership

### DIFF
--- a/litellm-rust/crates/ai-gateway/src/ocr/prepare.rs
+++ b/litellm-rust/crates/ai-gateway/src/ocr/prepare.rs
@@ -36,6 +36,7 @@ pub(crate) fn prepare_ocr_call(request: OcrRequest<'_>) -> PreparedOcrCall {
             optional_params,
             timeout,
             litellm_call_id,
+            context: Default::default(),
         }),
         hooks: OcrLifecycleHooks::new(
             CustomLoggerRunner::new(callbacks),

--- a/litellm-rust/crates/core/src/auth/mod.rs
+++ b/litellm-rust/crates/core/src/auth/mod.rs
@@ -101,6 +101,10 @@ impl OperationControl {
 pub enum OutboundBody {
     Bodyless,
     JsonObject(serde_json::Map<String, Value>),
+    Encoded {
+        bytes: Vec<u8>,
+        content_type: HeaderValue,
+    },
 }
 
 #[derive(Clone, Debug)]
@@ -278,6 +282,12 @@ where
     Callback: FnOnce(OutboundRequestView) -> CallbackFuture,
     CallbackFuture: Future<Output = Result<BodyDecision, Error>>,
 {
+    let mut request = request;
+    if let OutboundBody::Encoded { content_type, .. } = &request.body {
+        request
+            .headers
+            .insert(reqwest::header::CONTENT_TYPE, content_type.clone());
+    }
     validate_destination(origin, &request)?;
     let decision = control
         .run(callback(OutboundRequestView {
@@ -293,6 +303,10 @@ where
         OutboundBody::JsonObject(value) => Some(serde_json::to_vec(&value).map_err(|error| {
             Error::InvalidRequest(format!("failed to encode request: {error}"))
         })?),
+        OutboundBody::Encoded {
+            bytes,
+            content_type: _,
+        } => Some(bytes),
     };
     let preparation = control.run(authorization.prepare()).await?;
     let mut headers = request.headers;
@@ -380,6 +394,9 @@ fn resolve_body(body: OutboundBody, decision: BodyDecision) -> Result<OutboundBo
                 .ok_or_else(|| {
                     Error::InvalidRequest("callback replacement must be a JSON object".into())
                 }),
+            OutboundBody::Encoded { .. } => Err(Error::InvalidRequest(
+                "callback cannot replace an encoded operation body".into(),
+            )),
         },
     }
 }

--- a/litellm-rust/crates/core/src/auth/mod.rs
+++ b/litellm-rust/crates/core/src/auth/mod.rs
@@ -57,7 +57,7 @@ impl OperationCancellation {
         self.state.cancelled.load(Ordering::Acquire)
     }
 
-    async fn cancelled(&self) {
+    pub async fn cancelled(&self) {
         let notified = self.state.notify.notified();
         if self.is_cancelled() {
             return;

--- a/litellm-rust/crates/core/src/ocr/common_utils.rs
+++ b/litellm-rust/crates/core/src/ocr/common_utils.rs
@@ -1,18 +1,15 @@
 use std::net::IpAddr;
-use std::time::{Duration, Instant};
 
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use reqwest::Url;
 use serde_json::Value;
 
-use super::client::http_client;
 use crate::Error;
 use crate::http_utils::truncate_error_body;
 
 const DEFAULT_MAX_IMAGE_URL_DOWNLOAD_SIZE_MB: f64 = 50.0;
 const MAX_SAFE_FETCH_REDIRECTS: usize = 10;
-const AZURE_DOCUMENT_INTELLIGENCE_POLL_TIMEOUT_SECS: u64 = 120;
 
 fn document_url_field(document: &Value) -> Result<Option<(&str, &str)>, Error> {
     let Some(object) = document.as_object() else {
@@ -227,107 +224,6 @@ pub(super) async fn convert_document_url_to_data_uri(document: Value) -> Result<
         .ok_or_else(|| Error::InvalidRequest("OCR document must be an object".to_string()))?;
     transformed.insert(field.to_string(), Value::String(data_uri));
     Ok(Value::Object(transformed))
-}
-
-fn same_origin(left: &str, right: &str) -> bool {
-    let Ok(left) = reqwest::Url::parse(left) else {
-        return false;
-    };
-    let Ok(right) = reqwest::Url::parse(right) else {
-        return false;
-    };
-    left.scheme() == right.scheme()
-        && left.host_str() == right.host_str()
-        && left.port_or_known_default() == right.port_or_known_default()
-}
-
-fn poll_interval_secs(response: &reqwest::Response) -> u64 {
-    response
-        .headers()
-        .get(reqwest::header::RETRY_AFTER)
-        .and_then(|value| value.to_str().ok())
-        .and_then(|value| value.parse::<u64>().ok())
-        .unwrap_or(2)
-}
-
-fn operation_status(response_json: &Value) -> Result<&str, Error> {
-    let status = response_json
-        .get("status")
-        .and_then(Value::as_str)
-        .ok_or(Error::MissingField("status"))?;
-    match status {
-        "succeeded" => Ok("succeeded"),
-        "running" | "notStarted" => Ok("running"),
-        "failed" => {
-            let message = response_json
-                .get("error")
-                .and_then(|error| error.get("message"))
-                .and_then(Value::as_str)
-                .unwrap_or("Unknown error");
-            Err(Error::InvalidResponse(format!(
-                "Azure Document Intelligence analysis failed: {message}"
-            )))
-        }
-        other => Err(Error::InvalidResponse(format!(
-            "Unknown operation status: {other}"
-        ))),
-    }
-}
-
-pub(super) async fn poll_document_intelligence(
-    operation_url: &str,
-    original_url: &str,
-    headers: &[(String, String)],
-    timeout: Option<Duration>,
-) -> Result<Value, Error> {
-    if !same_origin(operation_url, original_url) {
-        return Err(Error::InvalidResponse(
-            "Azure Document Intelligence: rejected cross-origin polling URL".to_string(),
-        ));
-    }
-
-    let start = Instant::now();
-    let timeout = timeout.unwrap_or(Duration::from_secs(
-        AZURE_DOCUMENT_INTELLIGENCE_POLL_TIMEOUT_SECS,
-    ));
-    loop {
-        if start.elapsed() > timeout {
-            return Err(Error::Network(format!(
-                "Azure Document Intelligence operation polling timed out after {} seconds",
-                timeout.as_secs()
-            )));
-        }
-
-        let mut request_builder = http_client().get(operation_url);
-        for (key, value) in headers {
-            if key.eq_ignore_ascii_case("ocp-apim-subscription-key") {
-                request_builder = request_builder.header(key, value);
-            }
-        }
-        let response = request_builder
-            .send()
-            .await
-            .map_err(|err| Error::Network(err.to_string()))?;
-        let poll_interval = poll_interval_secs(&response);
-        let status = response.status();
-        let text = response
-            .text()
-            .await
-            .map_err(|err| Error::Network(err.to_string()))?;
-        if !status.is_success() {
-            return Err(Error::Http {
-                status: status.as_u16(),
-                body: truncate_error_body(&text),
-            });
-        }
-        let response_json: Value = serde_json::from_str(&text).map_err(|err| {
-            Error::InvalidResponse(format!("invalid Azure DI poll response JSON: {err}"))
-        })?;
-        if operation_status(&response_json)? == "succeeded" {
-            return Ok(response_json);
-        }
-        tokio::time::sleep(Duration::from_secs(poll_interval)).await;
-    }
 }
 
 #[cfg(test)]

--- a/litellm-rust/crates/core/src/ocr/handler.rs
+++ b/litellm-rust/crates/core/src/ocr/handler.rs
@@ -7,14 +7,13 @@ use reqwest::{
 use serde_json::Value;
 
 use super::client::http_client;
-use super::common_utils::poll_document_intelligence;
 use super::observers::{OcrObserver, OcrPostCall, OcrPreCall};
 use super::transformation::OcrResponseHandling;
 use super::types::{OcrRequestData, ProviderOcrRequest};
 use crate::Error;
 use crate::auth::{
-    BodyDecision, NoAuthorization, OperationControl, OutboundBody, OutboundOperation,
-    OutboundOperationKind, send_once,
+    BodyDecision, OperationControl, OutboundBody, OutboundOperation, OutboundOperationKind,
+    send_once,
 };
 use crate::constants::OCR_TIMEOUT_SECS;
 use crate::http_utils::truncate_error_body;
@@ -29,21 +28,44 @@ pub struct OcrHttpResponse {
 pub async fn send_ocr_request(
     origin: &Url,
     request: OutboundOperation,
-    event: &OcrPreCall,
+    model: &str,
     observer: &mut impl OcrObserver,
+    authorization: &dyn crate::auth::AuthorizationProvider,
     control: &OperationControl,
 ) -> Result<OcrHttpResponse, Error> {
     let response = send_once(
         http_client(),
         origin,
         request,
-        |_| async {
-            if observer.pre_call(event).await.is_err() {
-                tracing::warn!("OCR pre-call observer failed");
+        |view| {
+            let observer = &mut *observer;
+            async move {
+                let data = match view.body {
+                    OutboundBody::JsonObject(body) => Value::Object(body),
+                    OutboundBody::Bodyless => Value::Null,
+                };
+                let event = OcrPreCall {
+                    model: model.to_string(),
+                    request: OcrRequestData { data, files: None },
+                    api_base: view.url.to_string(),
+                    headers: view
+                        .headers
+                        .iter()
+                        .filter_map(|(name, value)| {
+                            value
+                                .to_str()
+                                .ok()
+                                .map(|value| (name.to_string(), value.to_string()))
+                        })
+                        .collect(),
+                };
+                if observer.pre_call(&event).await.is_err() {
+                    tracing::warn!("OCR pre-call observer failed");
+                }
+                Ok(BodyDecision::Unchanged)
             }
-            Ok(BodyDecision::Unchanged)
         },
-        &NoAuthorization,
+        authorization,
         control,
     )
     .await?;
@@ -87,15 +109,6 @@ pub async fn execute_ocr_provider_call(
         headers.append(name, value);
     }
 
-    let event = OcrPreCall {
-        model: request.model().to_string(),
-        request: OcrRequestData {
-            data: request.body().clone(),
-            files: None,
-        },
-        api_base: request.url().to_string(),
-        headers: request.upstream_headers.iter().cloned().collect(),
-    };
     let body =
         request.body().as_object().cloned().ok_or_else(|| {
             Error::InvalidRequest("OCR provider body must be a JSON object".into())
@@ -110,12 +123,14 @@ pub async fn execute_ocr_provider_call(
         body: OutboundBody::JsonObject(body),
         operation: OutboundOperationKind::Submission,
     };
+    let control = OperationControl::with_timeout(timeout);
     let response = send_ocr_request(
         &url,
         operation,
-        &event,
+        request.model(),
         observer,
-        &OperationControl::with_timeout(timeout),
+        request.authorization.as_ref(),
+        &control,
     )
     .await?;
 
@@ -134,11 +149,14 @@ pub async fn execute_ocr_provider_call(
                         .to_string(),
                 )
             })?;
-        let response_json = poll_document_intelligence(
-            &operation_url,
-            request.url(),
+        let response_json = poll_document_intelligence_with_auth(
+            operation_url,
+            url,
+            request.model(),
             &request.upstream_headers,
-            request.timeout,
+            request.authorization.as_ref(),
+            observer,
+            &control,
         )
         .await?;
         return Ok(request
@@ -154,4 +172,82 @@ pub async fn execute_ocr_provider_call(
         .config
         .transform_ocr_response(request.model(), response_json)?
         .into_json())
+}
+
+async fn poll_document_intelligence_with_auth(
+    operation_url: String,
+    origin: Url,
+    model: &str,
+    headers: &[(String, String)],
+    authorization: &dyn crate::auth::AuthorizationProvider,
+    observer: &mut impl OcrObserver,
+    control: &OperationControl,
+) -> Result<Value, Error> {
+    let url = Url::parse(&operation_url)
+        .map_err(|_| Error::InvalidResponse("invalid OCR operation URL".into()))?;
+    loop {
+        let mut request_headers = HeaderMap::new();
+        for (name, value) in headers {
+            request_headers.append(
+                name.parse::<HeaderName>().map_err(|_| {
+                    Error::InvalidRequest("invalid OCR provider header name".into())
+                })?,
+                value.parse::<HeaderValue>().map_err(|_| {
+                    Error::InvalidRequest("invalid OCR provider header value".into())
+                })?,
+            );
+        }
+        let response = send_ocr_request(
+            &origin,
+            OutboundOperation {
+                method: Method::GET,
+                url: url.clone(),
+                headers: request_headers,
+                body: OutboundBody::Bodyless,
+                operation: OutboundOperationKind::Poll,
+            },
+            model,
+            observer,
+            authorization,
+            control,
+        )
+        .await?;
+        let data: Value = serde_json::from_str(&response.body)
+            .map_err(|_| Error::InvalidResponse("invalid OCR polling response JSON".into()))?;
+        match data
+            .get("status")
+            .and_then(Value::as_str)
+            .map(str::to_ascii_lowercase)
+            .as_deref()
+        {
+            Some("succeeded") => return Ok(data),
+            Some("failed" | "canceled" | "cancelled") => {
+                return Err(Error::InvalidResponse(
+                    "Azure Document Intelligence operation failed".into(),
+                ));
+            }
+            Some("notstarted" | "running") => {}
+            _ => {
+                return Err(Error::InvalidResponse(
+                    "Azure Document Intelligence returned an invalid operation status".into(),
+                ));
+            }
+        }
+        let delay = response
+            .headers
+            .get("retry-after")
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| value.parse::<f64>().ok())
+            .filter(|value| value.is_finite() && *value >= 0.0)
+            .and_then(|value| Duration::try_from_secs_f64(value).ok())
+            .unwrap_or(Duration::from_secs(1));
+        tokio::select! {
+            _ = control.cancellation.cancelled() => {
+                return Err(Error::Network("Request cancelled".into()));
+            }
+            result = tokio::time::timeout_at(control.deadline.into(), tokio::time::sleep(delay)) => {
+                result.map_err(|_| Error::Network("Request timed out".into()))?;
+            }
+        }
+    }
 }

--- a/litellm-rust/crates/core/src/ocr/handler.rs
+++ b/litellm-rust/crates/core/src/ocr/handler.rs
@@ -9,7 +9,7 @@ use serde_json::Value;
 use super::client::http_client;
 use super::observers::{OcrObserver, OcrPostCall, OcrPreCall};
 use super::transformation::OcrResponseHandling;
-use super::types::{OcrRequestData, ProviderOcrRequest};
+use super::types::{OcrRequestData, PendingOcrUpload, ProviderOcrRequest};
 use crate::Error;
 use crate::auth::{
     BodyDecision, OperationControl, OutboundBody, OutboundOperation, OutboundOperationKind,
@@ -17,6 +17,7 @@ use crate::auth::{
 };
 use crate::constants::OCR_TIMEOUT_SECS;
 use crate::http_utils::truncate_error_body;
+use crate::provider_callbacks::CallbackDecision;
 
 pub struct OcrHttpResponse {
     pub status: StatusCode,
@@ -25,14 +26,19 @@ pub struct OcrHttpResponse {
 }
 
 #[tracing::instrument(target = "litellm::function_trace", level = "trace", skip_all)]
-pub async fn send_ocr_request(
+pub async fn send_ocr_request<Observer>(
     origin: &Url,
     request: OutboundOperation,
     model: &str,
-    observer: &mut impl OcrObserver,
+    request_context: &crate::request_context::LiteLlmRequestContext,
+    observer: &mut Observer,
     authorization: &dyn crate::auth::AuthorizationProvider,
     control: &OperationControl,
-) -> Result<OcrHttpResponse, Error> {
+) -> Result<OcrHttpResponse, Error>
+where
+    Observer: OcrObserver,
+    Observer::Error: std::fmt::Display,
+{
     let response = send_once(
         http_client(),
         origin,
@@ -43,8 +49,14 @@ pub async fn send_ocr_request(
                 let data = match view.body {
                     OutboundBody::JsonObject(body) => Value::Object(body),
                     OutboundBody::Bodyless => Value::Null,
+                    OutboundBody::Encoded { .. } => Value::Null,
                 };
                 let event = OcrPreCall {
+                    call_id: request_context.litellm_call_id.clone(),
+                    trace_id: request_context.trace_id.clone(),
+                    requested_model: request_context.request_model.clone(),
+                    attribution: request_context.attribution.clone(),
+                    capabilities: request_context.capabilities.clone(),
                     model: model.to_string(),
                     request: OcrRequestData { data, files: None },
                     api_base: view.url.to_string(),
@@ -59,10 +71,11 @@ pub async fn send_ocr_request(
                         })
                         .collect(),
                 };
-                if observer.pre_call(&event).await.is_err() {
-                    tracing::warn!("OCR pre-call observer failed");
+                match observer.pre_call(&event).await.map_err(callback_error)? {
+                    CallbackDecision::Unchanged => Ok(BodyDecision::Unchanged),
+                    CallbackDecision::Replace { payload } => Ok(BodyDecision::Replace(payload)),
+                    CallbackDecision::Reject { message, .. } => Ok(BodyDecision::Reject(message)),
                 }
-                Ok(BodyDecision::Unchanged)
             }
         },
         authorization,
@@ -79,23 +92,54 @@ pub async fn send_ocr_request(
         });
     }
     let event = OcrPostCall {
-        original_response: body,
+        call_id: request_context.litellm_call_id.clone(),
+        trace_id: request_context.trace_id.clone(),
+        requested_model: request_context.request_model.clone(),
+        attribution: request_context.attribution.clone(),
+        capabilities: request_context.capabilities.clone(),
+        original_response: body.clone(),
     };
-    if observer.post_call(&event).await.is_err() {
-        tracing::warn!("OCR post-call observer failed");
-    }
+    let body = match observer.post_call(&event).await.map_err(callback_error)? {
+        CallbackDecision::Unchanged => body,
+        CallbackDecision::Replace {
+            payload: Value::String(replacement),
+        } => replacement,
+        CallbackDecision::Replace { payload } => {
+            serde_json::to_string(&payload).map_err(|error| {
+                Error::InvalidResponse(format!("OCR callback response is invalid: {error}"))
+            })?
+        }
+        CallbackDecision::Reject { message, .. } => return Err(Error::InvalidResponse(message)),
+    };
     Ok(OcrHttpResponse {
         status,
         headers,
-        body: event.original_response,
+        body,
     })
 }
 
 #[tracing::instrument(target = "litellm::function_trace", level = "trace", skip_all)]
-pub async fn execute_ocr_provider_call(
-    request: ProviderOcrRequest,
-    observer: &mut impl OcrObserver,
-) -> Result<Value, Error> {
+pub async fn execute_ocr_provider_call<Observer>(
+    mut request: ProviderOcrRequest,
+    observer: &mut Observer,
+) -> Result<Value, Error>
+where
+    Observer: OcrObserver,
+    Observer::Error: std::fmt::Display,
+{
+    if let Some(upload) = request.pending_upload.take() {
+        let file_id = execute_ocr_upload(&request, upload, observer).await?;
+        let document = serde_json::json!({
+            "type": "document_url",
+            "document_url": file_id,
+        });
+        request.body = Some(
+            request
+                .config
+                .transform_ocr_request(request.model(), document, request.optional_params.clone())?
+                .data,
+        );
+    }
     let url = Url::parse(request.url())
         .map_err(|error| Error::InvalidRequest(format!("invalid OCR provider URL: {error}")))?;
     let mut headers = HeaderMap::new();
@@ -128,6 +172,7 @@ pub async fn execute_ocr_provider_call(
         &url,
         operation,
         request.model(),
+        &request.context,
         observer,
         request.authorization.as_ref(),
         &control,
@@ -149,16 +194,9 @@ pub async fn execute_ocr_provider_call(
                         .to_string(),
                 )
             })?;
-        let response_json = poll_document_intelligence_with_auth(
-            operation_url,
-            url,
-            request.model(),
-            &request.upstream_headers,
-            request.authorization.as_ref(),
-            observer,
-            &control,
-        )
-        .await?;
+        let response_json =
+            poll_document_intelligence_with_auth(operation_url, url, &request, observer, &control)
+                .await?;
         return Ok(request
             .config
             .transform_ocr_response(request.model(), response_json)?
@@ -174,20 +212,76 @@ pub async fn execute_ocr_provider_call(
         .into_json())
 }
 
-async fn poll_document_intelligence_with_auth(
+async fn execute_ocr_upload<Observer>(
+    request: &ProviderOcrRequest,
+    upload: PendingOcrUpload,
+    observer: &mut Observer,
+) -> Result<String, Error>
+where
+    Observer: OcrObserver,
+    Observer::Error: std::fmt::Display,
+{
+    let url = Url::parse(&upload.url)
+        .map_err(|error| Error::InvalidRequest(format!("invalid OCR upload URL: {error}")))?;
+    let boundary = "litellm-rust-ocr-boundary";
+    let mut body = format!(
+        "--{boundary}\r\nContent-Disposition: form-data; name=\"file\"; filename=\"document\"\r\nContent-Type: {}\r\n\r\n",
+        upload.mime_type
+    )
+    .into_bytes();
+    body.extend_from_slice(&upload.bytes);
+    body.extend_from_slice(format!("\r\n--{boundary}--\r\n").as_bytes());
+    let content_type = format!("multipart/form-data; boundary={boundary}")
+        .parse()
+        .expect("static multipart content type is valid");
+    let control = OperationControl::with_timeout(
+        request
+            .timeout
+            .unwrap_or(Duration::from_secs(OCR_TIMEOUT_SECS)),
+    );
+    let response = send_ocr_request(
+        &url,
+        OutboundOperation {
+            method: Method::POST,
+            url: url.clone(),
+            headers: HeaderMap::new(),
+            body: OutboundBody::Encoded {
+                bytes: body,
+                content_type,
+            },
+            operation: OutboundOperationKind::Upload,
+        },
+        request.model(),
+        &request.context,
+        observer,
+        request.authorization.as_ref(),
+        &control,
+    )
+    .await?;
+    let payload: Value = serde_json::from_str(&response.body)
+        .map_err(|error| Error::InvalidResponse(format!("invalid OCR upload JSON: {error}")))?;
+    Ok(
+        crate::providers::reducto::ocr::transformation::extract_upload_file_id(&payload)?
+            .to_string(),
+    )
+}
+
+async fn poll_document_intelligence_with_auth<Observer>(
     operation_url: String,
     origin: Url,
-    model: &str,
-    headers: &[(String, String)],
-    authorization: &dyn crate::auth::AuthorizationProvider,
-    observer: &mut impl OcrObserver,
+    request: &ProviderOcrRequest,
+    observer: &mut Observer,
     control: &OperationControl,
-) -> Result<Value, Error> {
+) -> Result<Value, Error>
+where
+    Observer: OcrObserver,
+    Observer::Error: std::fmt::Display,
+{
     let url = Url::parse(&operation_url)
         .map_err(|_| Error::InvalidResponse("invalid OCR operation URL".into()))?;
     loop {
         let mut request_headers = HeaderMap::new();
-        for (name, value) in headers {
+        for (name, value) in &request.upstream_headers {
             request_headers.append(
                 name.parse::<HeaderName>().map_err(|_| {
                     Error::InvalidRequest("invalid OCR provider header name".into())
@@ -206,9 +300,10 @@ async fn poll_document_intelligence_with_auth(
                 body: OutboundBody::Bodyless,
                 operation: OutboundOperationKind::Poll,
             },
-            model,
+            request.model(),
+            &request.context,
             observer,
-            authorization,
+            request.authorization.as_ref(),
             control,
         )
         .await?;
@@ -250,4 +345,8 @@ async fn poll_document_intelligence_with_auth(
             }
         }
     }
+}
+
+fn callback_error(error: impl std::fmt::Display) -> Error {
+    Error::InvalidResponse(format!("OCR callback failed: {error}"))
 }

--- a/litellm-rust/crates/core/src/ocr/mod.rs
+++ b/litellm-rust/crates/core/src/ocr/mod.rs
@@ -28,10 +28,14 @@ pub async fn ocr(request: OcrRequest<'_>) -> Result<Value, Error> {
     level = "trace",
     skip_all
 )]
-pub async fn ocr_with_observer(
+pub async fn ocr_with_observer<Observer>(
     request: OcrRequest<'_>,
-    observer: &mut impl OcrObserver,
-) -> Result<Value, Error> {
+    observer: &mut Observer,
+) -> Result<Value, Error>
+where
+    Observer: OcrObserver,
+    Observer::Error: std::fmt::Display,
+{
     let prepared = prepare_ocr_call(request);
     let provider_request = prepare_ocr_provider_call(prepared).await?;
     execute_ocr_provider_call(provider_request, observer).await
@@ -43,11 +47,15 @@ pub fn ocr_admitted(model: &str, provider: &str, request_format: Option<&str>) -
     })
 }
 
-pub async fn ocr_with_token_provider(
+pub async fn ocr_with_token_provider<Observer>(
     request: OcrRequest<'_>,
     token_provider: std::sync::Arc<dyn crate::auth::TokenProvider>,
-    observer: &mut impl OcrObserver,
-) -> Result<Value, Error> {
+    observer: &mut Observer,
+) -> Result<Value, Error>
+where
+    Observer: OcrObserver,
+    Observer::Error: std::fmt::Display,
+{
     let prepared = prepare_ocr_call(request);
     let provider_request =
         prepare_ocr_provider_call_with_token(prepared, Some(token_provider)).await?;

--- a/litellm-rust/crates/core/src/ocr/mod.rs
+++ b/litellm-rust/crates/core/src/ocr/mod.rs
@@ -7,7 +7,9 @@ pub mod transformation;
 pub mod types;
 
 pub use handler::execute_ocr_provider_call;
-pub use prepare::{prepare_ocr_call, prepare_ocr_provider_call};
+pub use prepare::{
+    prepare_ocr_call, prepare_ocr_provider_call, prepare_ocr_provider_call_with_token,
+};
 pub use types::{OcrRequest, PreparedOcrRequest, ProviderOcrRequest};
 
 use serde_json::Value;
@@ -39,6 +41,17 @@ pub fn ocr_admitted(model: &str, provider: &str, request_format: Option<&str>) -
     prepare::ocr_provider_config(provider, model).is_some_and(|config| {
         request_format != Some("native") || config.supported_ocr_params().contains(&"req_format")
     })
+}
+
+pub async fn ocr_with_token_provider(
+    request: OcrRequest<'_>,
+    token_provider: std::sync::Arc<dyn crate::auth::TokenProvider>,
+    observer: &mut impl OcrObserver,
+) -> Result<Value, Error> {
+    let prepared = prepare_ocr_call(request);
+    let provider_request =
+        prepare_ocr_provider_call_with_token(prepared, Some(token_provider)).await?;
+    execute_ocr_provider_call(provider_request, observer).await
 }
 
 #[cfg(test)]

--- a/litellm-rust/crates/core/src/ocr/observers.rs
+++ b/litellm-rust/crates/core/src/ocr/observers.rs
@@ -3,10 +3,18 @@ use std::convert::Infallible;
 
 use serde::Serialize;
 
+use crate::provider_callbacks::CallbackDecision;
+use crate::request_context::{RequestAttribution, RequestCapabilities};
+
 use super::types::OcrRequestData;
 
 #[derive(Serialize)]
 pub struct OcrPreCall {
+    pub call_id: Option<String>,
+    pub trace_id: Option<String>,
+    pub requested_model: Option<String>,
+    pub attribution: RequestAttribution,
+    pub capabilities: RequestCapabilities,
     pub model: String,
     pub request: OcrRequestData,
     pub api_base: String,
@@ -15,6 +23,11 @@ pub struct OcrPreCall {
 
 #[derive(Serialize)]
 pub struct OcrPostCall {
+    pub call_id: Option<String>,
+    pub trace_id: Option<String>,
+    pub requested_model: Option<String>,
+    pub attribution: RequestAttribution,
+    pub capabilities: RequestCapabilities,
     pub original_response: String,
 }
 
@@ -24,8 +37,8 @@ macro_rules! ocr_observer_catalog {
         $consumer! {
             $($options)*
             {
-                pre_call: PreCall($crate::ocr::observers::OcrPreCall) -> () = direct;
-                post_call: PostCall($crate::ocr::observers::OcrPostCall) -> () = direct;
+                pre_call: PreCall($crate::ocr::observers::OcrPreCall) -> $crate::provider_callbacks::CallbackDecision = direct;
+                post_call: PostCall($crate::ocr::observers::OcrPostCall) -> $crate::provider_callbacks::CallbackDecision = direct;
             }
         }
     };
@@ -38,11 +51,11 @@ pub struct NoopOcrObserver;
 impl OcrObserver for NoopOcrObserver {
     type Error = Infallible;
 
-    async fn pre_call(&mut self, _input: &OcrPreCall) -> Result<(), Infallible> {
-        Ok(())
+    async fn pre_call(&mut self, _input: &OcrPreCall) -> Result<CallbackDecision, Infallible> {
+        Ok(CallbackDecision::Unchanged)
     }
 
-    async fn post_call(&mut self, _input: &OcrPostCall) -> Result<(), Infallible> {
-        Ok(())
+    async fn post_call(&mut self, _input: &OcrPostCall) -> Result<CallbackDecision, Infallible> {
+        Ok(CallbackDecision::Unchanged)
     }
 }

--- a/litellm-rust/crates/core/src/ocr/prepare.rs
+++ b/litellm-rust/crates/core/src/ocr/prepare.rs
@@ -10,11 +10,12 @@ use crate::auth::{
 use crate::http_utils::string_headers;
 use crate::ocr::common_utils::convert_document_url_to_data_uri;
 use crate::ocr::transformation::{OcrAuthStrategy, OcrProviderConfig};
-use crate::ocr::types::{OcrRequest, PreparedOcrRequest, ProviderOcrRequest};
+use crate::ocr::types::{OcrRequest, PendingOcrUpload, PreparedOcrRequest, ProviderOcrRequest};
 use crate::providers::azure_ai::ocr::transformation::{
     AZURE_AI_OCR_CONFIG, AZURE_DOCUMENT_INTELLIGENCE_OCR_CONFIG,
 };
 use crate::providers::mistral::ocr::transformation::MISTRAL_OCR_CONFIG;
+use crate::providers::reducto::ocr::transformation as reducto;
 use crate::providers::vertex_ai::ocr::transformation as vertex_ai;
 use crate::providers::vertex_ai::ocr::transformation::{
     VERTEX_AI_DEEPSEEK_OCR_CONFIG, VERTEX_AI_OCR_CONFIG,
@@ -28,6 +29,7 @@ pub(crate) fn ocr_provider_config(
 ) -> Option<&'static dyn OcrProviderConfig> {
     match provider {
         "mistral" => Some(&MISTRAL_OCR_CONFIG),
+        "reducto" => reducto::config_for_model(model),
         "azure_ai" if is_azure_document_intelligence_model(model) => {
             Some(&AZURE_DOCUMENT_INTELLIGENCE_OCR_CONFIG)
         }
@@ -49,6 +51,13 @@ pub fn prepare_ocr_call(request: OcrRequest<'_>) -> PreparedOcrRequest {
         .litellm_call_id
         .map(str::to_string)
         .unwrap_or_else(new_ocr_call_id);
+    let mut context = request.context;
+    context
+        .litellm_call_id
+        .get_or_insert_with(|| call_id.clone());
+    context
+        .request_model
+        .get_or_insert_with(|| request.model.to_string());
     let provider_info = get_custom_llm_provider(request.model, request.custom_llm_provider)
         .unwrap_or(CustomLlmProvider {
             model: request.model,
@@ -58,18 +67,22 @@ pub fn prepare_ocr_call(request: OcrRequest<'_>) -> PreparedOcrRequest {
     let custom_llm_provider = provider_info.custom_llm_provider.to_string();
     let config = ocr_provider_config(&custom_llm_provider, &model)
         .ok_or_else(|| Error::InvalidProvider(custom_llm_provider.clone()));
+    let mut provider_params = request.optional_params;
+    provider_params.retain(|name, _| {
+        !matches!(
+            name.as_str(),
+            "callbacks"
+                | "litellm_logging_obj"
+                | "litellm_call_id"
+                | "max_retries"
+                | "metadata"
+                | "num_retries"
+                | "tags"
+        )
+    });
     let optional_params = match &config {
-        Ok(config) => {
-            let supported = config.supported_ocr_params();
-            config.map_ocr_params(
-                &request
-                    .optional_params
-                    .into_iter()
-                    .filter(|(name, _)| supported.contains(&name.as_str()))
-                    .collect(),
-            )
-        }
-        Err(_) => request.optional_params,
+        Ok(config) => config.map_ocr_params(&provider_params),
+        Err(_) => provider_params,
     };
 
     PreparedOcrRequest {
@@ -83,6 +96,7 @@ pub fn prepare_ocr_call(request: OcrRequest<'_>) -> PreparedOcrRequest {
         extra_headers: request.extra_headers,
         optional_params,
         timeout: request.timeout,
+        context,
     }
 }
 
@@ -121,18 +135,39 @@ pub async fn prepare_ocr_provider_call_with_token(
     } else {
         request.document
     };
-    let body = config
-        .transform_ocr_request(&request.model, document, request.optional_params)?
-        .data;
+    let pending_upload = if request.custom_llm_provider == "reducto" {
+        match reducto::extract_document_source(&document)? {
+            reducto::ReductoDocumentSource::FileId(_) => None,
+            reducto::ReductoDocumentSource::Upload { bytes, mime_type } => Some(PendingOcrUpload {
+                url: reducto::upload_url(request.api_base.as_deref()),
+                bytes,
+                mime_type,
+            }),
+        }
+    } else {
+        None
+    };
+    let body = if pending_upload.is_none() {
+        Some(
+            config
+                .transform_ocr_request(&request.model, document, request.optional_params.clone())?
+                .data,
+        )
+    } else {
+        None
+    };
     Ok(ProviderOcrRequest {
         model,
         custom_llm_provider,
         config,
         url,
         body,
+        pending_upload,
+        optional_params: request.optional_params,
         upstream_headers,
         authorization,
         timeout: request.timeout,
+        context: request.context,
     })
 }
 

--- a/litellm-rust/crates/core/src/ocr/prepare.rs
+++ b/litellm-rust/crates/core/src/ocr/prepare.rs
@@ -1,10 +1,15 @@
+use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::Error;
+use crate::auth::{
+    AuthorizationProvider, BearerAuthorizationProvider, CredentialProvenance, SecretString,
+    StaticHeaderAuthorizationProvider, SystemClock, TokenProvider,
+};
 use crate::http_utils::string_headers;
 use crate::ocr::common_utils::convert_document_url_to_data_uri;
-use crate::ocr::transformation::OcrProviderConfig;
+use crate::ocr::transformation::{OcrAuthStrategy, OcrProviderConfig};
 use crate::ocr::types::{OcrRequest, PreparedOcrRequest, ProviderOcrRequest};
 use crate::providers::azure_ai::ocr::transformation::{
     AZURE_AI_OCR_CONFIG, AZURE_DOCUMENT_INTELLIGENCE_OCR_CONFIG,
@@ -85,17 +90,28 @@ pub fn prepare_ocr_call(request: OcrRequest<'_>) -> PreparedOcrRequest {
 pub async fn prepare_ocr_provider_call(
     request: PreparedOcrRequest,
 ) -> Result<ProviderOcrRequest, Error> {
+    prepare_ocr_provider_call_with_token(request, None).await
+}
+
+#[tracing::instrument(target = "litellm::function_trace", level = "trace", skip_all)]
+pub async fn prepare_ocr_provider_call_with_token(
+    request: PreparedOcrRequest,
+    token_provider: Option<Arc<dyn TokenProvider>>,
+) -> Result<ProviderOcrRequest, Error> {
     let config = request.config?;
     let env_lookup = |key: &str| std::env::var(key).ok();
-    let upstream_headers = config.validate_environment(
-        string_headers("OCR", request.extra_headers)?,
-        request.api_key.as_deref(),
-        &env_lookup,
-    )?;
     let url = config.complete_url(
         request.api_base.as_deref(),
         &request.model,
         &request.optional_params,
+        &env_lookup,
+    )?;
+    let mut upstream_headers = string_headers("OCR", request.extra_headers)?;
+    let authorization = select_authorization(
+        config,
+        &mut upstream_headers,
+        request.api_key.as_deref(),
+        token_provider,
         &env_lookup,
     )?;
     let model = request.model.clone();
@@ -115,8 +131,98 @@ pub async fn prepare_ocr_provider_call(
         url,
         body,
         upstream_headers,
+        authorization,
         timeout: request.timeout,
     })
+}
+
+fn select_authorization(
+    config: &dyn OcrProviderConfig,
+    headers: &mut Vec<(String, String)>,
+    api_key: Option<&str>,
+    token_provider: Option<Arc<dyn TokenProvider>>,
+    env_lookup: &dyn Fn(&str) -> Option<String>,
+) -> Result<Arc<dyn AuthorizationProvider>, Error> {
+    let strategy = config.auth_strategy();
+    let selected_header = strategy.header_name();
+    if let Some(value) = take_header(headers, selected_header) {
+        return Ok(static_authorization(
+            strategy,
+            value,
+            CredentialProvenance::ForwardedHeader(
+                selected_header
+                    .parse()
+                    .expect("provider auth header is valid"),
+            ),
+        ));
+    }
+
+    match config.resolve_api_key(api_key, env_lookup) {
+        Ok(key) => {
+            let value = match strategy {
+                OcrAuthStrategy::Bearer => format!("Bearer {key}"),
+                OcrAuthStrategy::Header(_) => key,
+            };
+            return Ok(static_authorization(
+                strategy,
+                value,
+                CredentialProvenance::CallerSupplied,
+            ));
+        }
+        Err(Error::Auth(_)) => {}
+        Err(error) => return Err(error),
+    }
+
+    if strategy != OcrAuthStrategy::Bearer
+        && let Some(value) = take_header(headers, "authorization")
+    {
+        return Ok(static_authorization(
+            OcrAuthStrategy::Bearer,
+            value,
+            CredentialProvenance::ForwardedHeader(reqwest::header::AUTHORIZATION),
+        ));
+    }
+    let provider = token_provider.ok_or_else(|| Error::Auth("missing OCR credential".into()))?;
+    Ok(Arc::new(BearerAuthorizationProvider::new(
+        provider,
+        Arc::new(SystemClock),
+        auth_conflicts(OcrAuthStrategy::Bearer),
+        CredentialProvenance::ExternalProvider,
+    )))
+}
+
+fn static_authorization(
+    strategy: OcrAuthStrategy,
+    value: String,
+    provenance: CredentialProvenance,
+) -> Arc<dyn AuthorizationProvider> {
+    Arc::new(StaticHeaderAuthorizationProvider::new(
+        strategy
+            .header_name()
+            .parse()
+            .expect("provider auth header is valid"),
+        SecretString::new(value),
+        auth_conflicts(strategy),
+        provenance,
+    ))
+}
+
+fn auth_conflicts(strategy: OcrAuthStrategy) -> Vec<reqwest::header::HeaderName> {
+    match strategy {
+        OcrAuthStrategy::Bearer => vec![
+            "ocp-apim-subscription-key"
+                .parse()
+                .expect("Azure subscription header is valid"),
+        ],
+        OcrAuthStrategy::Header(_) => vec![reqwest::header::AUTHORIZATION],
+    }
+}
+
+fn take_header(headers: &mut Vec<(String, String)>, name: &str) -> Option<String> {
+    let index = headers
+        .iter()
+        .position(|(candidate, _)| candidate.eq_ignore_ascii_case(name))?;
+    Some(headers.remove(index).1)
 }
 
 fn new_ocr_call_id() -> String {

--- a/litellm-rust/crates/core/src/ocr/tests.rs
+++ b/litellm-rust/crates/core/src/ocr/tests.rs
@@ -11,6 +11,8 @@ use crate::ocr::observers::{OcrObserver, OcrPostCall, OcrPreCall};
 use crate::ocr::prepare::ocr_provider_config;
 use crate::ocr::transformation::OcrResponseHandling;
 use crate::ocr::{OcrRequest, ocr, ocr_with_observer};
+use crate::provider_callbacks::CallbackDecision;
+use crate::request_context::{LiteLlmRequestContext, RequestAttribution, RequestCapabilities};
 
 struct ProviderObserver {
     events: Arc<Mutex<Vec<&'static str>>>,
@@ -21,34 +23,40 @@ struct ProviderObserver {
 impl OcrObserver for ProviderObserver {
     type Error = &'static str;
 
-    async fn pre_call(&mut self, input: &OcrPreCall) -> Result<(), Self::Error> {
+    async fn pre_call(&mut self, input: &OcrPreCall) -> Result<CallbackDecision, Self::Error> {
+        assert_eq!(input.call_id.as_deref(), Some("observer-test"));
+        assert_eq!(input.trace_id.as_deref(), Some("trace-test"));
+        assert_eq!(
+            input.requested_model.as_deref(),
+            Some("mistral/original-model")
+        );
+        assert_eq!(
+            input.attribution.user_api_key_team_id.as_deref(),
+            Some("team-1")
+        );
+        assert_eq!(input.capabilities.execution_mode.as_deref(), Some("async"));
         assert_eq!(input.model, "mistral-ocr-4-1");
         assert_eq!(
             input.request.data["document"]["document_url"],
             "https://example.com/document.pdf"
         );
         assert!(input.api_base.ends_with("/v1/ocr"));
-        assert!(
-            input
-                .headers
-                .values()
-                .any(|value| value == "Bearer test-key")
-        );
+        assert!(!input.headers.contains_key("authorization"));
         self.events.lock().unwrap().push("pre");
         if self.reject {
             Err("observer failure")
         } else {
-            Ok(())
+            Ok(CallbackDecision::Unchanged)
         }
     }
 
-    async fn post_call(&mut self, input: &OcrPostCall) -> Result<(), Self::Error> {
+    async fn post_call(&mut self, input: &OcrPostCall) -> Result<CallbackDecision, Self::Error> {
         self.events.lock().unwrap().push("post");
         self.raw_response = Some(input.original_response.clone());
         if self.reject {
             Err("observer failure")
         } else {
-            Ok(())
+            Ok(CallbackDecision::Unchanged)
         }
     }
 }
@@ -64,10 +72,23 @@ fn observer_request(api_base: &str) -> OcrRequest<'_> {
         optional_params: Map::new(),
         timeout: Some(Duration::from_secs(2)),
         litellm_call_id: Some("observer-test"),
+        context: LiteLlmRequestContext {
+            litellm_call_id: Some("observer-test".into()),
+            trace_id: Some("trace-test".into()),
+            request_model: Some("mistral/original-model".into()),
+            attribution: RequestAttribution {
+                user_api_key_team_id: Some("team-1".into()),
+                ..Default::default()
+            },
+            capabilities: RequestCapabilities {
+                execution_mode: Some("async".into()),
+                ..Default::default()
+            },
+        },
     }
 }
 
-async fn observer_case(status: u16, body: &'static str, reject: bool) {
+async fn observer_case(status: u16, body: &'static str) {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let url = format!("http://{}/v1", listener.local_addr().unwrap());
     let events = Arc::new(Mutex::new(Vec::new()));
@@ -86,7 +107,7 @@ async fn observer_case(status: u16, body: &'static str, reject: bool) {
     let mut observer = ProviderObserver {
         events: Arc::clone(&events),
         raw_response: None,
-        reject,
+        reject: false,
     };
     let result = ocr_with_observer(observer_request(&url), &mut observer).await;
     tokio::time::timeout(Duration::from_secs(2), server)
@@ -109,12 +130,143 @@ async fn observer_case(status: u16, body: &'static str, reject: bool) {
 }
 
 #[tokio::test]
-async fn provider_observers_surround_http_and_cannot_replace_its_outcome() {
-    for reject in [false, true] {
-        observer_case(200, r#"{"pages":[{"index":0,"markdown":"ok"}]}"#, reject).await;
-        observer_case(200, "invalid-json", reject).await;
-        observer_case(401, r#"{"error":"rejected"}"#, reject).await;
+async fn provider_observers_surround_http() {
+    observer_case(200, r#"{"pages":[{"index":0,"markdown":"ok"}]}"#).await;
+    observer_case(200, "invalid-json").await;
+    observer_case(401, r#"{"error":"rejected"}"#).await;
+}
+
+#[tokio::test]
+async fn provider_pre_call_failure_is_terminal_before_http() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let url = format!("http://{}/v1", listener.local_addr().unwrap());
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let mut observer = ProviderObserver {
+        events: Arc::clone(&events),
+        raw_response: None,
+        reject: true,
+    };
+
+    let result = ocr_with_observer(observer_request(&url), &mut observer).await;
+
+    assert!(
+        matches!(result, Err(Error::InvalidResponse(message)) if message.contains("observer failure"))
+    );
+    assert_eq!(*events.lock().unwrap(), ["pre"]);
+    assert!(
+        tokio::time::timeout(Duration::from_millis(50), listener.accept())
+            .await
+            .is_err()
+    );
+}
+
+struct ReplacingObserver;
+
+impl OcrObserver for ReplacingObserver {
+    type Error = &'static str;
+
+    async fn pre_call(&mut self, _input: &OcrPreCall) -> Result<CallbackDecision, Self::Error> {
+        Ok(CallbackDecision::Replace {
+            payload: json!({
+                "model": "mistral-ocr-4-1",
+                "document": {
+                    "type": "document_url",
+                    "document_url": "https://example.com/replaced.pdf"
+                }
+            }),
+        })
     }
+
+    async fn post_call(&mut self, _input: &OcrPostCall) -> Result<CallbackDecision, Self::Error> {
+        Ok(CallbackDecision::Replace {
+            payload: json!({"pages":[{"index":0,"markdown":"replaced"}]}),
+        })
+    }
+}
+
+#[tokio::test]
+async fn provider_callback_replacement_reaches_wire_and_response_parser() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let url = format!("http://{}/v1", listener.local_addr().unwrap());
+    let server = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        let request = read_http_request(&mut socket).await;
+        assert!(request.contains("https://example.com/replaced.pdf"));
+        assert!(
+            request
+                .to_ascii_lowercase()
+                .contains("authorization: bearer test-key")
+        );
+        let body = r#"{"pages":[{"index":0,"markdown":"original"}]}"#;
+        let response = format!(
+            "HTTP/1.1 200 OK\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+            body.len()
+        );
+        socket.write_all(response.as_bytes()).await.unwrap();
+    });
+    let result = ocr_with_observer(observer_request(&url), &mut ReplacingObserver)
+        .await
+        .unwrap();
+    server.await.unwrap();
+    assert_eq!(result["pages"][0]["markdown"], "replaced");
+}
+
+#[tokio::test]
+async fn reducto_upload_and_submission_are_distinct_authorized_operations() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let api_base = format!("http://{}", listener.local_addr().unwrap());
+    let server = tokio::spawn(async move {
+        let (mut upload, _) = listener.accept().await.unwrap();
+        let upload_request = read_http_request(&mut upload).await;
+        assert!(upload_request.starts_with("POST /upload "));
+        assert!(upload_request.contains("%PDF-1.4"));
+        assert!(
+            upload_request
+                .to_ascii_lowercase()
+                .contains("authorization: bearer test-key")
+        );
+        let upload_body = r#"{"file_id":"reducto://uploaded.pdf"}"#;
+        let response = format!(
+            "HTTP/1.1 200 OK\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{upload_body}",
+            upload_body.len()
+        );
+        upload.write_all(response.as_bytes()).await.unwrap();
+
+        let (mut submission, _) = listener.accept().await.unwrap();
+        let submission_request = read_http_request(&mut submission).await;
+        assert!(submission_request.starts_with("POST /parse "));
+        assert!(submission_request.contains("reducto://uploaded.pdf"));
+        assert!(
+            submission_request
+                .to_ascii_lowercase()
+                .contains("authorization: bearer test-key")
+        );
+        let submission_body = r#"{"result":{"chunks":[]},"usage":{"num_pages":1}}"#;
+        let response = format!(
+            "HTTP/1.1 200 OK\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{submission_body}",
+            submission_body.len()
+        );
+        submission.write_all(response.as_bytes()).await.unwrap();
+    });
+    let result = ocr(OcrRequest {
+        model: "reducto/parse-v3",
+        document: json!({
+            "type": "document_url",
+            "document_url": "data:application/pdf;base64,JVBERi0xLjQ="
+        }),
+        api_key: Some("test-key"),
+        api_base: Some(&api_base),
+        custom_llm_provider: None,
+        extra_headers: None,
+        optional_params: Map::new(),
+        timeout: Some(Duration::from_secs(2)),
+        litellm_call_id: Some("reducto-operation-test"),
+        context: Default::default(),
+    })
+    .await
+    .unwrap();
+    server.await.unwrap();
+    assert_eq!(result["usage_info"]["pages_processed"], 1);
 }
 
 #[tokio::test]
@@ -274,6 +426,7 @@ async fn ocr_does_not_duplicate_authorization_header_when_header_is_supplied() {
         optional_params: Map::new(),
         timeout: Some(Duration::from_secs(5)),
         litellm_call_id: None,
+        context: Default::default(),
     })
     .await
     .expect("ocr request succeeds");
@@ -340,6 +493,7 @@ async fn document_intelligence_poll_uses_resolved_subscription_key() {
         optional_params: Map::new(),
         timeout: Some(Duration::from_secs(5)),
         litellm_call_id: None,
+        context: Default::default(),
     })
     .await
     .expect("document intelligence request succeeds");

--- a/litellm-rust/crates/core/src/ocr/transformation.rs
+++ b/litellm-rust/crates/core/src/ocr/transformation.rs
@@ -29,13 +29,7 @@ pub trait OcrProviderConfig: Sync {
 
     #[tracing::instrument(target = "litellm::function_trace", level = "trace", skip_all)]
     fn map_ocr_params(&self, non_default_params: &Map<String, Value>) -> Map<String, Value> {
-        let mut mapped_params = Map::new();
-        for (param, value) in non_default_params {
-            if self.supported_ocr_params().contains(&param.as_str()) {
-                mapped_params.insert(param.clone(), value.clone());
-            }
-        }
-        mapped_params
+        non_default_params.clone()
     }
 
     fn transform_ocr_request(
@@ -73,25 +67,6 @@ pub trait OcrProviderConfig: Sync {
         api_key: Option<&str>,
         env_lookup: &dyn Fn(&str) -> Option<String>,
     ) -> Result<String, Error>;
-
-    #[tracing::instrument(target = "litellm::function_trace", level = "trace", skip_all)]
-    fn validate_environment(
-        &self,
-        headers: Vec<(String, String)>,
-        api_key: Option<&str>,
-        env_lookup: &dyn Fn(&str) -> Option<String>,
-    ) -> Result<Vec<(String, String)>, Error> {
-        let strategy = self.auth_strategy();
-        if crate::http_utils::has_header(&headers, strategy.header_name()) {
-            return Ok(headers);
-        }
-        let api_key = self.resolve_api_key(api_key, env_lookup)?;
-        let auth_header = match strategy {
-            OcrAuthStrategy::Bearer => ("Authorization".to_string(), format!("Bearer {api_key}")),
-            OcrAuthStrategy::Header(name) => (name.to_string(), api_key),
-        };
-        Ok(std::iter::once(auth_header).chain(headers).collect())
-    }
 
     fn auth_strategy(&self) -> OcrAuthStrategy {
         OcrAuthStrategy::Bearer

--- a/litellm-rust/crates/core/src/ocr/types.rs
+++ b/litellm-rust/crates/core/src/ocr/types.rs
@@ -1,3 +1,4 @@
+use std::sync::Arc;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
@@ -50,6 +51,7 @@ pub struct ProviderOcrRequest {
     pub(super) url: String,
     pub(super) body: Value,
     pub(super) upstream_headers: Vec<(String, String)>,
+    pub(super) authorization: Arc<dyn crate::auth::AuthorizationProvider>,
     pub(super) timeout: Option<Duration>,
 }
 

--- a/litellm-rust/crates/core/src/ocr/types.rs
+++ b/litellm-rust/crates/core/src/ocr/types.rs
@@ -7,6 +7,7 @@ use serde_json::{Map, Value};
 use crate::Error;
 use crate::call_lifecycle::{CallLifecycleContext, CallLifecycleRequest};
 use crate::ocr::transformation::OcrProviderConfig;
+use crate::request_context::LiteLlmRequestContext;
 
 pub struct OcrRequest<'a> {
     pub model: &'a str,
@@ -18,6 +19,7 @@ pub struct OcrRequest<'a> {
     pub optional_params: Map<String, Value>,
     pub timeout: Option<Duration>,
     pub litellm_call_id: Option<&'a str>,
+    pub context: LiteLlmRequestContext,
 }
 
 pub struct PreparedOcrRequest {
@@ -31,6 +33,7 @@ pub struct PreparedOcrRequest {
     pub extra_headers: Option<Map<String, Value>>,
     pub optional_params: Map<String, Value>,
     pub timeout: Option<Duration>,
+    pub context: LiteLlmRequestContext,
 }
 
 impl CallLifecycleRequest for PreparedOcrRequest {
@@ -49,10 +52,19 @@ pub struct ProviderOcrRequest {
     pub(super) custom_llm_provider: String,
     pub(super) config: &'static dyn OcrProviderConfig,
     pub(super) url: String,
-    pub(super) body: Value,
+    pub(super) body: Option<Value>,
+    pub(super) pending_upload: Option<PendingOcrUpload>,
+    pub(super) optional_params: Map<String, Value>,
     pub(super) upstream_headers: Vec<(String, String)>,
     pub(super) authorization: Arc<dyn crate::auth::AuthorizationProvider>,
     pub(super) timeout: Option<Duration>,
+    pub(super) context: LiteLlmRequestContext,
+}
+
+pub struct PendingOcrUpload {
+    pub url: String,
+    pub bytes: Vec<u8>,
+    pub mime_type: String,
 }
 
 impl ProviderOcrRequest {
@@ -69,11 +81,14 @@ impl ProviderOcrRequest {
     }
 
     pub fn body(&self) -> &Value {
-        &self.body
+        self.body.as_ref().expect("OCR body is prepared")
     }
 
     pub fn with_body(self, body: Value) -> Self {
-        Self { body, ..self }
+        Self {
+            body: Some(body),
+            ..self
+        }
     }
 }
 

--- a/litellm-rust/crates/core/src/providers/azure_ai/ocr/transformation.rs
+++ b/litellm-rust/crates/core/src/providers/azure_ai/ocr/transformation.rs
@@ -99,68 +99,6 @@ pub fn resolve_document_intelligence_endpoint(
     )
 }
 
-fn prepend_auth_header(
-    headers: Vec<(String, String)>,
-    name: &str,
-    value: String,
-) -> Vec<(String, String)> {
-    std::iter::once((name.to_string(), value))
-        .chain(headers)
-        .collect()
-}
-
-pub fn validate_azure_ai_environment(
-    headers: Vec<(String, String)>,
-    api_key: Option<&str>,
-    azure_ad_token: Option<&str>,
-    env_lookup: &dyn Fn(&str) -> Option<String>,
-) -> Result<Vec<(String, String)>, Error> {
-    if crate::http_utils::has_header(&headers, "Authorization")
-        || crate::http_utils::has_header(&headers, "Api-Key")
-    {
-        return Ok(headers);
-    }
-    if let Ok(api_key) = resolve_azure_ai_api_key(api_key, env_lookup) {
-        return Ok(prepend_auth_header(headers, "Api-Key", api_key));
-    }
-    non_empty(azure_ad_token)
-        .map(|token| prepend_auth_header(headers, "Authorization", format!("Bearer {token}")))
-        .ok_or_else(|| {
-            Error::Auth(
-                "Missing Azure AI credentials - set AZURE_AI_API_KEY or provide azure_ad_token"
-                    .to_string(),
-            )
-        })
-}
-
-pub fn validate_document_intelligence_environment(
-    headers: Vec<(String, String)>,
-    api_key: Option<&str>,
-    azure_ad_token: Option<&str>,
-    env_lookup: &dyn Fn(&str) -> Option<String>,
-) -> Result<Vec<(String, String)>, Error> {
-    if crate::http_utils::has_header(&headers, "Authorization")
-        || crate::http_utils::has_header(&headers, "Ocp-Apim-Subscription-Key")
-    {
-        return Ok(headers);
-    }
-    if let Ok(api_key) = resolve_document_intelligence_api_key(api_key, env_lookup) {
-        return Ok(prepend_auth_header(
-            headers,
-            "Ocp-Apim-Subscription-Key",
-            api_key,
-        ));
-    }
-    non_empty(azure_ad_token)
-        .map(|token| prepend_auth_header(headers, "Authorization", format!("Bearer {token}")))
-        .ok_or_else(|| {
-            Error::Auth(
-                "Missing Azure Document Intelligence credentials - set AZURE_DOCUMENT_INTELLIGENCE_API_KEY or provide azure_ad_token"
-                    .to_string(),
-            )
-        })
-}
-
 fn encode_model_id(model: &str) -> Result<String, Error> {
     let model_id = model.rsplit('/').next().unwrap_or(model);
     if matches!(model_id, "." | "..") {
@@ -557,15 +495,14 @@ impl OcrProviderConfig for AzureDocumentIntelligenceOcrConfig {
 
     #[tracing::instrument(target = "litellm::function_trace", level = "trace", skip_all)]
     fn map_ocr_params(&self, non_default_params: &Map<String, Value>) -> Map<String, Value> {
-        map_document_intelligence_ocr_params(non_default_params).unwrap_or_else(|_| {
-            non_default_params
-                .iter()
-                .filter(|(name, _)| {
-                    AZURE_DOCUMENT_INTELLIGENCE_SUPPORTED_OCR_PARAMS.contains(&name.as_str())
-                })
-                .map(|(name, value)| (name.clone(), value.clone()))
-                .collect()
-        })
+        let mut mapped = map_document_intelligence_ocr_params(non_default_params)
+            .unwrap_or_else(|_| non_default_params.clone());
+        for (name, value) in non_default_params {
+            if !AZURE_DOCUMENT_INTELLIGENCE_SUPPORTED_OCR_PARAMS.contains(&name.as_str()) {
+                mapped.insert(name.clone(), value.clone());
+            }
+        }
+        mapped
     }
 
     #[tracing::instrument(target = "litellm::function_trace", level = "trace", skip_all)]
@@ -660,13 +597,6 @@ mod tests {
     #[fixture]
     fn document_intelligence_config() -> AzureDocumentIntelligenceOcrConfig {
         AzureDocumentIntelligenceOcrConfig
-    }
-
-    fn header_value<'a>(headers: &'a [(String, String)], name: &str) -> Option<&'a str> {
-        headers
-            .iter()
-            .find(|(header_name, _)| header_name.eq_ignore_ascii_case(name))
-            .map(|(_, value)| value.as_str())
     }
 
     #[fixture]
@@ -886,7 +816,10 @@ mod tests {
 
         assert_eq!(
             AZURE_DOCUMENT_INTELLIGENCE_OCR_CONFIG.map_ocr_params(&params),
-            Map::from_iter([("features".to_string(), json!(expected))])
+            Map::from_iter([
+                ("features".to_string(), json!(expected)),
+                ("unsupported".to_string(), json!(true)),
+            ])
         );
     }
 
@@ -1101,35 +1034,6 @@ mod tests {
         .expect("url builds");
 
         assert!(!url.contains("req_format"));
-    }
-
-    #[test]
-    fn document_intelligence_validate_environment_uses_subscription_key() {
-        let headers =
-            validate_document_intelligence_environment(Vec::new(), Some("my-key"), None, &|_| None)
-                .expect("api key authenticates");
-
-        assert_eq!(
-            header_value(&headers, "Ocp-Apim-Subscription-Key"),
-            Some("my-key")
-        );
-    }
-
-    #[test]
-    fn document_intelligence_validate_environment_falls_back_to_entra_token() {
-        let headers = validate_document_intelligence_environment(
-            Vec::new(),
-            None,
-            Some("entra-token"),
-            &|_| None,
-        )
-        .expect("Entra token authenticates");
-
-        assert_eq!(
-            header_value(&headers, "Authorization"),
-            Some("Bearer entra-token")
-        );
-        assert_eq!(header_value(&headers, "Ocp-Apim-Subscription-Key"), None);
     }
 
     #[test]
@@ -1371,17 +1275,5 @@ mod tests {
         .expect("api base resolves");
 
         assert_eq!(resolved, "https://generic-azure-ai.example.com");
-    }
-
-    #[test]
-    fn azure_ai_ocr_authenticates_with_entra_token() {
-        let headers =
-            validate_azure_ai_environment(Vec::new(), None, Some("entra-token"), &|_| None)
-                .expect("Entra token authenticates");
-
-        assert_eq!(
-            header_value(&headers, "Authorization"),
-            Some("Bearer entra-token")
-        );
     }
 }

--- a/litellm-rust/crates/core/src/providers/mistral/ocr/transformation.rs
+++ b/litellm-rust/crates/core/src/providers/mistral/ocr/transformation.rs
@@ -239,11 +239,11 @@ mod tests {
     }
 
     #[test]
-    fn map_ocr_params_drops_unknown_params() {
+    fn map_ocr_params_preserves_provider_extensions() {
         let params = json!({"extract_header": true, "unsupported_param": "value"});
         let mapped = map_ocr_params(params.as_object().unwrap());
         assert_eq!(mapped.get("extract_header"), Some(&json!(true)));
-        assert!(!mapped.contains_key("unsupported_param"));
+        assert_eq!(mapped.get("unsupported_param"), Some(&json!("value")));
     }
 
     #[test]

--- a/litellm-rust/crates/core/src/providers/reducto/ocr/tests.rs
+++ b/litellm-rust/crates/core/src/providers/reducto/ocr/tests.rs
@@ -189,14 +189,4 @@ fn test_parse_v3_uses_programmatic_api_key_over_env() {
     let key = resolve_api_key(Some("passed-key"), &|_| Some("env-reducto-key".to_string()))
         .expect("explicit key should resolve");
     assert_eq!(key, "passed-key");
-
-    let headers = REDUCTO_PARSE_V3_CONFIG
-        .validate_environment(Vec::new(), Some("passed-key"), &|_| {
-            Some("env-reducto-key".to_string())
-        })
-        .expect("headers should validate");
-    assert_eq!(
-        headers,
-        vec![("Authorization".to_string(), "Bearer passed-key".to_string())]
-    );
 }

--- a/litellm-rust/crates/core/src/providers/vertex_ai/ocr/transformation.rs
+++ b/litellm-rust/crates/core/src/providers/vertex_ai/ocr/transformation.rs
@@ -262,11 +262,7 @@ impl OcrProviderConfig for VertexAiDeepSeekOcrConfig {
 
     #[tracing::instrument(target = "litellm::function_trace", level = "trace", skip_all)]
     fn map_ocr_params(&self, non_default_params: &Map<String, Value>) -> Map<String, Value> {
-        non_default_params
-            .iter()
-            .filter(|(name, _)| DEEPSEEK_SUPPORTED_OCR_PARAMS.contains(&name.as_str()))
-            .map(|(name, value)| (name.clone(), value.clone()))
-            .collect()
+        non_default_params.clone()
     }
 
     #[tracing::instrument(target = "litellm::function_trace", level = "trace", skip_all)]

--- a/litellm-rust/crates/core/src/request_context.rs
+++ b/litellm-rust/crates/core/src/request_context.rs
@@ -1,11 +1,11 @@
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq, serde::Serialize)]
 pub struct RequestAttribution {
     pub user_api_key_hash: Option<String>,
     pub user_api_key_user_id: Option<String>,
     pub user_api_key_team_id: Option<String>,
 }
 
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq, serde::Serialize)]
 pub struct RequestCapabilities {
     pub execution_mode: Option<String>,
     pub stream: bool,
@@ -18,7 +18,7 @@ pub struct RequestCapabilities {
     pub requires_connection: bool,
 }
 
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq, serde::Serialize)]
 pub struct LiteLlmRequestContext {
     pub litellm_call_id: Option<String>,
     pub trace_id: Option<String>,

--- a/litellm-rust/crates/python-bridge/src/auth.rs
+++ b/litellm-rust/crates/python-bridge/src/auth.rs
@@ -49,15 +49,14 @@ impl PythonTokenProvider {
             .extract::<PyRef<'_, AuthCallbackRuntime>>()?
             .0
             .clone();
-        let callback = CallbackZero::new(callable.bind(py).clone())?;
         let session = if asynchronous {
             PythonTokenSession::Async {
-                callback,
+                callback: CallbackZero::new(callable.bind(py).clone())?,
                 context: runtime.async_context(py)?,
             }
         } else {
             PythonTokenSession::Sync {
-                callback,
+                callback: CallbackZero::new(callable.bind(py).clone())?,
                 context: runtime.sync_context(py)?,
             }
         };

--- a/litellm-rust/crates/python-bridge/src/lib.rs
+++ b/litellm-rust/crates/python-bridge/src/lib.rs
@@ -158,7 +158,7 @@ mod _native {
 
     #[pymodule_init]
     fn init(module: &Bound<'_, PyModule>) -> PyResult<()> {
-        use pyo3::types::PyDict;
+        use pyo3::types::{PyDict, PySet};
 
         litellm_python_interop::callback_runtime::register(module)?;
         super::callback_bindings::register(module)?;
@@ -166,6 +166,7 @@ mod _native {
         super::ocr_callbacks::register(module)?;
         super::errors::register(module)?;
         let ready_endpoints = PyDict::new(module.py());
+        ready_endpoints.set_item("ocr", PySet::new(module.py(), ["callbacks"])?)?;
         module.add("ready_endpoints", ready_endpoints)?;
         super::routes::register(module)?;
         module.add_class::<super::ResponsesWebSocketConnection>()?;
@@ -215,6 +216,17 @@ mod tests {
                 .filter(|name| !name.starts_with('_'))
                 .collect();
             assert_eq!(public_names, expected);
+            let ready = module
+                .getattr("ready_endpoints")
+                .expect("readiness map is exported");
+            assert_eq!(
+                ready
+                    .get_item("ocr")
+                    .expect("OCR readiness is published")
+                    .extract::<std::collections::HashSet<String>>()
+                    .expect("OCR capabilities are strings"),
+                std::collections::HashSet::from(["callbacks".to_string()])
+            );
 
             #[cfg(not(feature = "trace-parity"))]
             assert!(!module.hasattr("_trace").expect("module lookup should work"));

--- a/litellm-rust/crates/python-bridge/src/marshal.rs
+++ b/litellm-rust/crates/python-bridge/src/marshal.rs
@@ -84,11 +84,16 @@ pub(crate) struct NativeRequestOptions {
     bedrock: Option<NativeBedrockOptions>,
     anthropic: Option<NativeAnthropicOptions>,
     vertex: Option<NativeVertexOptions>,
+    auth_provider: Option<Py<PyAny>>,
 }
 
 impl NativeRequestOptions {
     pub(crate) fn provider(&self, default: &'static str) -> &str {
         self.custom_llm_provider.as_deref().unwrap_or(default)
+    }
+
+    pub(crate) fn take_auth_provider(&mut self) -> Option<Py<PyAny>> {
+        self.auth_provider.take()
     }
 }
 
@@ -205,6 +210,7 @@ class Options:
     bedrock: object = None
     anthropic: object = None
     vertex: object = None
+    auth_provider: object = None
 
 @dataclass(frozen=True)
 class BedrockOptions:

--- a/litellm-rust/crates/python-bridge/src/ocr_callbacks.rs
+++ b/litellm-rust/crates/python-bridge/src/ocr_callbacks.rs
@@ -1,6 +1,7 @@
 use std::num::NonZeroUsize;
 
 use litellm_core::ocr::observers::{OcrObserver, OcrPostCall, OcrPreCall};
+use litellm_core::provider_callbacks::CallbackDecision;
 use litellm_python_interop::callback_runtime::{AsyncContext, CallbackRuntime, SyncContext};
 use pyo3::prelude::*;
 
@@ -63,18 +64,18 @@ impl OcrObserver for PythonOcrObserver {
     type Error = PyErr;
 
     #[tracing::instrument(target = "litellm::function_trace", level = "trace", skip_all)]
-    async fn pre_call(&mut self, input: &OcrPreCall) -> PyResult<()> {
+    async fn pre_call(&mut self, input: &OcrPreCall) -> PyResult<CallbackDecision> {
         match self {
-            Self::Disabled => Ok(()),
+            Self::Disabled => Ok(CallbackDecision::Unchanged),
             Self::Sync(session) => session.pre_call(input).await,
             Self::Async(session) => session.pre_call(input).await,
         }
     }
 
     #[tracing::instrument(target = "litellm::function_trace", level = "trace", skip_all)]
-    async fn post_call(&mut self, input: &OcrPostCall) -> PyResult<()> {
+    async fn post_call(&mut self, input: &OcrPostCall) -> PyResult<CallbackDecision> {
         match self {
-            Self::Disabled => Ok(()),
+            Self::Disabled => Ok(CallbackDecision::Unchanged),
             Self::Sync(session) => session.post_call(input).await,
             Self::Async(session) => session.post_call(input).await,
         }

--- a/litellm-rust/crates/python-bridge/src/routes/ocr.rs
+++ b/litellm-rust/crates/python-bridge/src/routes/ocr.rs
@@ -2,7 +2,7 @@ use crate::errors::ocr_error_to_pyerr;
 use crate::marshal::{NativeRequestContext, NativeRequestOptions, required_value};
 use crate::ocr_callbacks::PythonOcrObserver;
 use litellm_core::Error;
-use litellm_core::ocr::{OcrRequest, ocr_with_observer};
+use litellm_core::ocr::{OcrRequest, ocr_with_observer, ocr_with_token_provider};
 use litellm_core::request_context::LiteLlmRequestContext;
 use litellm_core::request_options::RequestOptions;
 use pyo3::prelude::*;
@@ -19,7 +19,7 @@ struct OcrInputs {
 
 fn prepare_ocr(
     input: OcrInputs,
-    options: NativeRequestOptions,
+    mut options: NativeRequestOptions,
     context: NativeRequestContext,
     callback_adapter: Option<Py<PyAny>>,
     python_context: crate::execution::PythonCallContext<'_>,
@@ -36,6 +36,20 @@ fn prepare_ocr(
         return Err(crate::errors::RustBridgeDeclined::new_err(decline.reason()));
     }
     let py = python_context.py;
+    let token_provider = options
+        .take_auth_provider()
+        .map(|callable| {
+            py.import("litellm.rust_bridge._native").and_then(|module| {
+                crate::auth::PythonTokenProvider::new(
+                    &module,
+                    callable,
+                    py,
+                    python_context.asynchronous,
+                )
+                .map(std::sync::Arc::new)
+            })
+        })
+        .transpose()?;
     let document = if input
         .document
         .bind(py)
@@ -56,21 +70,22 @@ fn prepare_ocr(
     let options: RequestOptions = options.into();
     let mut observer = PythonOcrObserver::new(callback_adapter, python_context)?;
     Ok(async move {
-        ocr_with_observer(
-            OcrRequest {
-                model: &input.model,
-                document,
-                api_key: options.api_key.as_deref(),
-                api_base: options.api_base.as_deref(),
-                custom_llm_provider: options.custom_llm_provider.as_deref(),
-                extra_headers: options.extra_headers,
-                optional_params: input.optional_params,
-                timeout: options.timeout,
-                litellm_call_id: call_id.as_deref(),
-            },
-            &mut observer,
-        )
-        .await
+        let request = OcrRequest {
+            model: &input.model,
+            document,
+            api_key: options.api_key.as_deref(),
+            api_base: options.api_base.as_deref(),
+            custom_llm_provider: options.custom_llm_provider.as_deref(),
+            extra_headers: options.extra_headers,
+            optional_params: input.optional_params,
+            timeout: options.timeout,
+            litellm_call_id: call_id.as_deref(),
+            context,
+        };
+        match token_provider {
+            Some(provider) => ocr_with_token_provider(request, provider, &mut observer).await,
+            None => ocr_with_observer(request, &mut observer).await,
+        }
     })
 }
 

--- a/litellm/llms/base_llm/ocr/transformation.py
+++ b/litellm/llms/base_llm/ocr/transformation.py
@@ -144,10 +144,6 @@ class BaseOCRConfig:
         """
         return None
 
-    def supports_rust_bridge(self) -> bool:
-        """Whether the Rust OCR bridge may serve this config when it is enabled for the provider."""
-        return True
-
     def get_health_check_document(self) -> DocumentType:
         return {  # mutable-ok: litellm.aocr rejects any document that is not a dict
             "type": "document_url",

--- a/litellm/llms/cohere/ocr/transformation.py
+++ b/litellm/llms/cohere/ocr/transformation.py
@@ -144,9 +144,6 @@ class CohereParseConfig(BaseOCRConfig):
     def get_api_key_env_var(self) -> str | None:
         return COHERE_API_KEY_ENV_VAR
 
-    def supports_rust_bridge(self) -> bool:
-        return False
-
     def get_health_check_document(self) -> DocumentType:
         return {  # mutable-ok: litellm.aocr rejects any document that is not a dict
             "type": "image_url",

--- a/litellm/ocr/main.py
+++ b/litellm/ocr/main.py
@@ -62,6 +62,72 @@ class _PreparedOCRRequest:
     execution_mode: str = "sync"
 
 
+@dataclass(frozen=True, slots=True)
+class _NativeOCRRequest:
+    model: str
+    document: Mapping[str, object]
+    api_key: str | None
+    api_base: str | None
+    custom_llm_provider: str | None
+    extra_headers: dict[str, object] | None  # mutable-ok: preserves the public SDK header contract
+    kwargs: Mapping[str, object]
+    effective_timeout: float | httpx.Timeout
+    litellm_logging_obj: LiteLLMLoggingObj
+    execution_mode: str
+
+
+def _native_provider(model: str, explicit: str | None) -> str:
+    if explicit:
+        return explicit
+    provider, separator, _ = model.partition("/")
+    return provider if separator else "mistral"
+
+
+def _native_model(model: str, provider: str) -> str:
+    prefix: Final = f"{provider}/"
+    return model.removeprefix(prefix)
+
+
+def _python_fallback_document(document: Mapping[str, object]) -> Mapping[str, object]:
+    """Materialize local files only after native dispatch selected Python."""
+    if document.get("type") != "file":
+        return document
+    owned_document: Final = dict(  # mutable-ok: legacy file conversion owns and rewrites this copy
+        document
+    )
+    return convert_file_document_to_url_document(owned_document)
+
+
+def _native_ocr_request(
+    *,
+    model: str,
+    document: Mapping[str, object],
+    api_key: str | None,
+    api_base: str | None,
+    timeout: float | httpx.Timeout | None,
+    custom_llm_provider: str | None,
+    extra_headers: dict[str, object] | None,  # mutable-ok: preserves the public SDK header contract
+    kwargs: Mapping[str, object],
+    execution_mode: str,
+) -> _NativeOCRRequest:
+    logging_value: Final = kwargs["litellm_logging_obj"]
+    if not isinstance(logging_value, LiteLLMLoggingObj):
+        raise TypeError("litellm_logging_obj must be a LiteLLM Logging instance")
+    logging_obj: Final = logging_value
+    return _NativeOCRRequest(
+        model=model,
+        document=document,
+        api_key=api_key,
+        api_base=api_base,
+        custom_llm_provider=custom_llm_provider,
+        extra_headers=extra_headers,
+        kwargs=dict(kwargs),  # mutable-ok: fallback receives an isolated request snapshot
+        effective_timeout=timeout or request_timeout,
+        litellm_logging_obj=logging_obj,
+        execution_mode=execution_mode,
+    )
+
+
 def _prepare_ocr_request(
     model: str,
     document: Mapping[str, object],
@@ -244,6 +310,101 @@ def _prepare_rust_ocr_call(
     )
 
 
+def _prepare_native_ocr_call(
+    request: _NativeOCRRequest,
+) -> PreparedNativeCall[rust_ocr_bridge.NativeOCRRequest]:
+    provider: Final = _native_provider(request.model, request.custom_llm_provider)
+    model: Final = _native_model(request.model, provider)
+    litellm_params: Final = dict(  # mutable-ok: request context helper consumes a mapping snapshot
+        GenericLiteLLMParams.model_validate(request.kwargs)
+    )
+    internal_params: Final = set(GenericLiteLLMParams.model_fields) | {  # mutable-ok: local classification set
+        "litellm_logging_obj",
+        "litellm_call_id",
+    }
+    optional_params: Final = {  # mutable-ok: native request owns provider extension fields
+        name: value for name, value in request.kwargs.items() if name not in internal_params
+    }
+    vertex_params: Final = {  # mutable-ok: combines typed routing fields without mutating either source
+        **litellm_params,
+        **optional_params,
+    }
+    request_format: Final = optional_params.get(OCR_REQUEST_FORMAT_PARAM)
+    auth_provider = request.kwargs.get("azure_ad_token_provider")
+    if not callable(auth_provider):
+        auth_provider = None
+    request.litellm_logging_obj.update_from_kwargs(
+        kwargs=dict(request.kwargs),  # mutable-ok: logger owns its request-state snapshot
+        model=model,
+        optional_params=optional_params,
+        litellm_params={  # mutable-ok: logger contract requires its call context as a dict
+            "litellm_call_id": litellm_params.get("litellm_call_id"),
+            "api_base": request.api_base,
+        },
+        custom_llm_provider=provider,
+    )
+    return PreparedNativeCall(
+        request=rust_ocr_bridge.NativeOCRRequest(
+            model=model,
+            document=request.document,
+            optional_params=optional_params,
+        ),
+        options=NativeRequestOptions(
+            vertex=vertex_options(vertex_params),
+            api_key=request.api_key,
+            api_base=request.api_base,
+            custom_llm_provider=provider,
+            extra_headers=request.extra_headers,
+            timeout_seconds=timeout_to_seconds(request.effective_timeout),
+            auth_provider=auth_provider,
+        ),
+        context=request_context(
+            logging_obj=request.litellm_logging_obj,
+            request_model=request.model,
+            litellm_params=litellm_params,
+            capabilities=NativeRequestCapabilities(
+                execution_mode=request.execution_mode,
+                input_source_kind=str(request.document.get("type") or "unknown"),
+                request_format=request_format if isinstance(request_format, str) else None,
+                native_response_format=request_format == "native",
+            ),
+        ),
+        callback_adapter=ProviderLoggingAdapter(
+            request.litellm_logging_obj,
+            "OCR document processing",
+            request.api_key,
+        ),
+    )
+
+
+def _run_native_ocr(
+    request: _NativeOCRRequest,
+    fallback: Callable[[], OCRResponse | Coroutine[object, object, OCRResponse]],
+) -> OCRResponse | Coroutine[object, object, OCRResponse]:
+    provider: Final = _native_provider(request.model, request.custom_llm_provider)
+    return rust_ocr_bridge.dispatch_ocr(
+        prepare=lambda: _prepare_native_ocr_call(request),
+        fallback=fallback,
+        adapt=OCRResponse.model_validate,
+        model=_native_model(request.model, provider),
+        provider=provider,
+    )
+
+
+async def _run_native_aocr(
+    request: _NativeOCRRequest,
+    fallback: Callable[[], Coroutine[object, object, OCRResponse]],
+) -> OCRResponse:
+    provider: Final = _native_provider(request.model, request.custom_llm_provider)
+    return await rust_ocr_bridge.adispatch_ocr(
+        prepare=lambda: _prepare_native_ocr_call(request),
+        fallback=fallback,
+        adapt=OCRResponse.model_validate,
+        model=_native_model(request.model, provider),
+        provider=provider,
+    )
+
+
 @dataclass
 class _OCROperation:
     request: _PreparedOCRRequest
@@ -382,7 +543,7 @@ async def aocr(
         "kwargs": kwargs,
     }
     try:
-        prepared: Final = _prepare_ocr_request(
+        native_request: Final = _native_ocr_request(
             model=model,
             document=document,
             api_key=api_key,
@@ -393,13 +554,26 @@ async def aocr(
             kwargs=kwargs,
             execution_mode="async",
         )
-        model = prepared.model
-        custom_llm_provider = prepared.custom_llm_provider
+        custom_llm_provider = _native_provider(model, custom_llm_provider)
+        model = _native_model(model, custom_llm_provider)
         completion_kwargs.update({"model": model, "custom_llm_provider": custom_llm_provider})
-
-        from litellm.secret_managers.main import get_secret_str
+        prepared: _PreparedOCRRequest | None = None
 
         async def python_fallback() -> OCRResponse:
+            nonlocal prepared
+            prepared = prepared or _prepare_ocr_request(
+                model=native_request.model,
+                document=native_request.document,
+                api_key=native_request.api_key,
+                api_base=native_request.api_base,
+                timeout=native_request.effective_timeout,
+                custom_llm_provider=native_request.custom_llm_provider,
+                extra_headers=native_request.extra_headers,
+                kwargs=dict(  # mutable-ok: Python fallback owns its single mutable preparation copy
+                    native_request.kwargs
+                ),
+                execution_mode="async",
+            )
             fallback_document: Final = _python_fallback_document(prepared.document)
             pending: Final = base_llm_http_handler.ocr(
                 model=prepared.model,
@@ -420,9 +594,8 @@ async def aocr(
                 raise ValueError(f"Got an unexpected None response from the OCR API: {response}")
             return response
 
-        return await _run_rust_aocr(
-            prepared_request=prepared,
-            resolve_api_key=get_secret_str,
+        return await _run_native_aocr(
+            request=native_request,
             fallback=python_fallback,
         )
     except Exception as e:
@@ -649,7 +822,7 @@ def ocr(
     try:
         _is_async: Final = kwargs.pop("aocr", False) is True
         completion_kwargs["aocr"] = _is_async
-        prepared: Final = _prepare_ocr_request(
+        native_request: Final = _native_ocr_request(
             model=model,
             document=document,
             api_key=api_key,
@@ -658,14 +831,28 @@ def ocr(
             custom_llm_provider=custom_llm_provider,
             extra_headers=extra_headers,
             timeout=timeout,
+            execution_mode="async" if _is_async else "sync",
         )
-        model = prepared.model
-        custom_llm_provider = prepared.custom_llm_provider
+        custom_llm_provider = _native_provider(model, custom_llm_provider)
+        model = _native_model(model, custom_llm_provider)
         completion_kwargs.update({"model": model, "custom_llm_provider": custom_llm_provider})
-
-        from litellm.secret_managers.main import get_secret_str
+        prepared: _PreparedOCRRequest | None = None
 
         def python_fallback() -> OCRResponse | Coroutine[object, object, OCRResponse]:
+            nonlocal prepared
+            prepared = prepared or _prepare_ocr_request(
+                model=native_request.model,
+                document=native_request.document,
+                api_key=native_request.api_key,
+                api_base=native_request.api_base,
+                timeout=native_request.effective_timeout,
+                custom_llm_provider=native_request.custom_llm_provider,
+                extra_headers=native_request.extra_headers,
+                kwargs=dict(  # mutable-ok: Python fallback owns its single mutable preparation copy
+                    native_request.kwargs
+                ),
+                execution_mode=native_request.execution_mode,
+            )
             fallback_document: Final = _python_fallback_document(prepared.document)
             return base_llm_http_handler.ocr(
                 model=prepared.model,
@@ -682,9 +869,8 @@ def ocr(
                 litellm_params=prepared.litellm_params,
             )
 
-        return _run_rust_ocr(
-            prepared_request=prepared,
-            resolve_api_key=get_secret_str,
+        return _run_native_ocr(
+            request=native_request,
             fallback=python_fallback,
         )
     except Exception as e:

--- a/litellm/rust_bridge/callback_adapters.py
+++ b/litellm/rust_bridge/callback_adapters.py
@@ -48,6 +48,31 @@ class ProviderPostCall(ProviderEvent):
     ended_at: float
 
 
+class OcrPreCall(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    call_id: str | None
+    trace_id: str | None
+    requested_model: str | None
+    attribution: Mapping[str, JsonValue]
+    capabilities: Mapping[str, JsonValue]
+    model: str
+    request: Mapping[str, JsonValue]
+    api_base: str
+    headers: Mapping[str, str]
+
+
+class OcrPostCall(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    call_id: str | None
+    trace_id: str | None
+    requested_model: str | None
+    attribution: Mapping[str, JsonValue]
+    capabilities: Mapping[str, JsonValue]
+    original_response: str
+
+
 class ProviderError(ProviderEvent):
     message: str
     stage: str
@@ -89,8 +114,17 @@ class ProviderLoggingAdapter:
     api_key: str | None
 
     def pre_call(self, payload: object, /) -> CallbackDecision:
-        event: Final = ProviderPreCall.model_validate(payload)
-        request: Final = dict(event.request)  # mutable-ok: Python hooks may mutate their owned request copy
+        event: Final = (
+            ProviderPreCall.model_validate(payload)
+            if isinstance(payload, Mapping) and "provider" in payload
+            else OcrPreCall.model_validate(payload)
+        )
+        request_payload: Final = event.request.get("data") if isinstance(event, OcrPreCall) else event.request
+        if not isinstance(request_payload, Mapping):
+            raise TypeError("OCR callback request data must be a mapping")
+        request: Final = dict(  # mutable-ok: legacy hook contract permits in-place request mutation
+            request_payload
+        )
         additional_args: Final[PreCallArguments] = {
             "complete_input_dict": request,
             "api_base": event.api_base,
@@ -98,16 +132,21 @@ class ProviderLoggingAdapter:
         }
         self.logging_obj.pre_call(input=self.input, api_key=self.api_key, additional_args=additional_args)
         mutated: Final = additional_args["complete_input_dict"]
-        if dict(mutated) != dict(event.request):  # mutable-ok: compare hook-owned mapping snapshots
+        if dict(mutated) != dict(request_payload):  # mutable-ok: compare hook-owned mapping snapshots
             return {  # mutable-ok: callback decisions are fixed-shape wire dictionaries
                 "action": "replace",
-                "payload": dict(mutated),
+                "payload": dict(mutated),  # mutable-ok: callback wire payload owns its mapping
             }
         return _unchanged()
 
     def post_call(self, payload: object, /) -> CallbackDecision:
-        event: Final = ProviderPostCall.model_validate(payload)
-        response: Final = event.response if isinstance(event.response, str) else json.dumps(event.response)
+        event: Final = (
+            ProviderPostCall.model_validate(payload)
+            if isinstance(payload, Mapping) and "response" in payload
+            else OcrPostCall.model_validate(payload)
+        )
+        raw_response: Final = event.response if isinstance(event, ProviderPostCall) else event.original_response
+        response: Final = raw_response if isinstance(raw_response, str) else json.dumps(raw_response)
         self.logging_obj.post_call(original_response=response, input=self.input, api_key=self.api_key)
         return _unchanged()
 

--- a/litellm/rust_bridge/ocr.py
+++ b/litellm/rust_bridge/ocr.py
@@ -39,7 +39,7 @@ def supports_callback_adapter(*, asynchronous: bool = False) -> bool:
     native: Final = get_native_bridge()
     return (
         native is not None
-        and hasattr(native, "__python_callback_runtime__")
+        and hasattr(native, "__callback_runtime__")
         and native_route_ready("ocr", frozenset({"callbacks"}))
     )
 

--- a/litellm/rust_bridge/request.py
+++ b/litellm/rust_bridge/request.py
@@ -95,6 +95,7 @@ class NativeRequestOptions:
     bedrock: NativeBedrockOptions | None = None
     anthropic: NativeAnthropicOptions | None = None
     vertex: NativeVertexOptions | None = None
+    auth_provider: object | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/rust-python-harness/strategies/e2e_parity/__init__.py
+++ b/tests/rust-python-harness/strategies/e2e_parity/__init__.py
@@ -17,10 +17,7 @@ CASES: Final[tuple[CaseDefinition, ...]] = (
         ModuleCaseSpec(
             coverage=Coverage.PARTIAL,
             module="tests.rust-python-harness.strategies.e2e_parity.sdk.ocr.test_sdk_parity",
-            note=(
-                "Recorded sync/async SDK parity; invalid-model provider errors differ, "
-                "and Reducto lacks a Rust contract."
-            ),
+            note="Recorded sync/async SDK parity; invalid-model provider errors differ.",
         ),
         surface="sdk",
     ),

--- a/tests/rust-python-harness/strategies/e2e_parity/sdk/ocr/conftest.py
+++ b/tests/rust-python-harness/strategies/e2e_parity/sdk/ocr/conftest.py
@@ -18,14 +18,7 @@ def ocr_fixture_id(fixture: OcrParityCase) -> str:
 
 
 def ocr_fixture_marks(fixture: OcrParityCase) -> tuple[pytest.MarkDecorator, ...]:
-    if fixture.litellm_input.contract not in {"reducto_v3", "reducto_legacy"}:
-        return ()
-    return (
-        pytest.mark.xfail(
-            reason="Reducto does not have a Rust OCR contract",
-            strict=False,
-        ),
-    )
+    return ()
 
 
 def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:

--- a/tests/rust-python-harness/strategies/e2e_parity/sdk/ocr/test_fixture_models.py
+++ b/tests/rust-python-harness/strategies/e2e_parity/sdk/ocr/test_fixture_models.py
@@ -490,14 +490,12 @@ def test_vertex_deepseek_request_maps_both_document_types_to_image_content(
         ReductoParseLegacySdkInput(model="reducto/parse-legacy", document=_reducto_document()),
     ),
 )
-def test_reducto_parity_cases_are_non_strict_xfails(
+def test_reducto_parity_cases_are_enabled(
     sdk_input: ReductoParseV3SdkInput | ReductoParseLegacySdkInput,
 ) -> None:
     marks: Final = ocr_fixture_marks(OcrParityCase(litellm_input=sdk_input, provider_responses=()))
 
-    assert len(marks) == 1
-    assert marks[0].mark.name == "xfail"
-    assert marks[0].mark.kwargs["strict"] is False
+    assert marks == ()
 
 
 def test_supported_parity_cases_have_no_marks() -> None:

--- a/tests/rust-python-harness/strategies/e2e_parity/sdk/ocr/test_fixture_store.py
+++ b/tests/rust-python-harness/strategies/e2e_parity/sdk/ocr/test_fixture_store.py
@@ -51,14 +51,8 @@ def test_recorded_fixture_parametrization_applies_case_specific_marks() -> None:
         for parameter in parameters
         if parameter.values[0].litellm_input.contract in {"reducto_v3", "reducto_legacy"}
     )
-    supported_parameters: Final = tuple(parameter for parameter in parameters if parameter not in reducto_parameters)
-
     assert reducto_parameters
-    assert supported_parameters
-    assert all(len(parameter.marks) == 1 for parameter in reducto_parameters)
-    assert all(parameter.marks[0].name == "xfail" for parameter in reducto_parameters)
-    assert all(parameter.marks[0].kwargs["strict"] is False for parameter in reducto_parameters)
-    assert all(parameter.marks == () for parameter in supported_parameters)
+    assert all(parameter.marks == () for parameter in parameters)
 
 
 def test_legacy_fixture_migration_preserves_responses_and_labels_reconstructed_requests(tmp_path: Path) -> None:

--- a/tests/rust-python-harness/strategies/e2e_parity/sdk/ocr/test_sdk_parity.py
+++ b/tests/rust-python-harness/strategies/e2e_parity/sdk/ocr/test_sdk_parity.py
@@ -278,11 +278,7 @@ def _write_worker_case(directory: Path, index: int, case: OcrWorkerCase) -> Path
 
 @contextmanager
 def parity_checks() -> Generator[tuple[E2ECheck, ...]]:
-    fixtures: Final = tuple(
-        fixture
-        for fixture in recorded_fixtures(configured_fixture_directory(), OcrParityCase)
-        if fixture.litellm_input.contract not in {"reducto_v3", "reducto_legacy"}
-    )
+    fixtures: Final = recorded_fixtures(configured_fixture_directory(), OcrParityCase)
     runner: Final = SubprocessRunner(
         entrypoint=Path(__file__),
         baseline_user_agent=PYTHON_HTTP_SENTINEL,

--- a/tests/test_litellm/ocr/live_callback_smoke.py
+++ b/tests/test_litellm/ocr/live_callback_smoke.py
@@ -2,7 +2,6 @@ import asyncio
 import os
 import sys
 from typing import Final
-from unittest.mock import patch
 
 from callback_support import CallbackRecorder, OcrArguments, call_ocr, verify_installed_package
 
@@ -62,5 +61,4 @@ if __name__ == "__main__":
     else:
         native: Final = get_native_bridge()
         assert native is not None
-        with patch.object(native, "ready_endpoints", {"ocr": frozenset({"callbacks"})}, create=True):
-            asyncio.run(smoke(baseline=False))
+        asyncio.run(smoke(baseline=False))

--- a/tests/test_litellm/ocr/sdk_callback_contract.py
+++ b/tests/test_litellm/ocr/sdk_callback_contract.py
@@ -6,7 +6,6 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Final
-from unittest.mock import patch
 
 from callback_support import (
     DOCUMENT,
@@ -24,10 +23,9 @@ from pydantic import TypeAdapter
 
 import litellm
 from litellm.litellm_core_utils.logging_worker import GLOBAL_LOGGING_WORKER
-from litellm.rust_bridge import get_native_bridge
 from litellm.rust_bridge.bindings import NativeBinding
-from litellm.rust_bridge.ocr import supports_callback_adapter
 from litellm.rust_bridge.callback_adapters import PreCallArguments
+from litellm.rust_bridge.ocr import supports_callback_adapter
 
 
 @dataclass(frozen=True, slots=True)
@@ -93,11 +91,16 @@ async def exercise(asynchronous: bool, rust: bool, case: str, *, native_expected
             assert all(event.model == "mistral-ocr-4-1" for event in events)
             assert events[0].input == "OCR document processing"
             pre_arguments: Final = TypeAdapter(PreCallArguments).validate_json(events[0].additional_args)
-            assert pre_arguments["complete_input_dict"] == {"model": "mistral-ocr-4-1", "document": DOCUMENT}
+            assert pre_arguments["complete_input_dict"] == {
+                "model": "mistral-ocr-4-1",
+                "document": DOCUMENT,
+            }, pre_arguments
             assert pre_arguments["api_base"] == upstream.api_base + "/ocr"
-            assert {key.lower(): value for key, value in pre_arguments["headers"].items()}[
-                "authorization"
-            ] == "Bearer test-key"
+            pre_headers: Final = {key.lower(): value for key, value in pre_arguments["headers"].items()}
+            if native:
+                assert "authorization" not in pre_headers
+            else:
+                assert pre_headers["authorization"] == "Bearer test-key"
             for event in events[: len(prefix)]:
                 assert event.context == context
                 assert event.native_provider_hook is native
@@ -264,12 +267,9 @@ async def verify_unavailable() -> None:
 
 
 async def verify_foundation() -> None:
-    assert_native_unavailable()
-    native: Final = get_native_bridge()
-    assert native is not None
-    with patch.object(native, "ready_endpoints", {"ocr": frozenset({"callbacks"})}, create=True):
-        await verify_parity()
-    assert_native_unavailable()
+    assert supports_callback_adapter()
+    assert NativeBinding(lambda native: native.ocr, route="ocr").load() is not None
+    await verify_parity()
 
 
 if __name__ == "__main__":

--- a/tests/test_litellm/ocr/test_rust_bridge.py
+++ b/tests/test_litellm/ocr/test_rust_bridge.py
@@ -166,9 +166,6 @@ class FakeOCRConfig:
     def get_api_key_env_var(self) -> str:
         return self.api_key_env_var
 
-    def supports_rust_bridge(self) -> bool:
-        return True
-
     def validate_environment(
         self,
         *,
@@ -677,6 +674,26 @@ def test_ocr_routes_azure_ai_to_rust_when_enabled(fake_bridge):
     assert len(fake_bridge.calls) == 1
     assert fake_bridge.calls[0]["model"] == "pixtral-12b-2409"
     assert fake_bridge.calls[0]["custom_llm_provider"] == "azure_ai"
+
+
+def test_native_ocr_does_not_load_python_provider_configuration(monkeypatch, fake_bridge):
+    monkeypatch.setattr(
+        ocr_main.ProviderConfigManager,
+        "get_provider_ocr_config",
+        lambda **_kwargs: pytest.fail("native OCR must not load Python provider configuration"),
+    )
+
+    response = litellm.ocr(
+        model=MODEL,
+        document=DOCUMENT,
+        api_key="sk-test",
+        unknown_provider_extension={"enabled": True},
+    )
+
+    assert isinstance(response, OCRResponse)
+    assert fake_bridge.calls[0]["optional_params"]["unknown_provider_extension"] == {
+        "enabled": True
+    }
 
 
 def test_ocr_rust_path_keeps_file_document_opaque_until_native_admission(fake_bridge):


### PR DESCRIPTION
## TLDR

Problem this solves:

- Python still selected and prepared native OCR providers

How it solves it:

- Move OCR provider decisions and operations into Rust

## User Flow

Before: the SDK request can violate this layer contract.

1. They enable Rust and submit a supported OCR document.
2. Python resolves and shapes the provider request first.

After: the same request follows one predictable contract.

1. They enable Rust and submit the same document.
2. Rust admits, loads, maps, authorizes, executes, and parses it.

## Relevant issues

- Stack root: #39928

## Linear ticket


## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] Focused tests covering this change pass locally
- [ ] All required CI/CD checks pass
- [x] This PR is isolated to one stack responsibility
- [ ] Greptile Confidence Score is at least 4/5

## Stack

`39928 -> 39913 -> 39923 -> 39941 -> 39939 -> 39484 -> 39986 -> 40054 -> 40055 -> 40056 -> 39765`

Layer 11 of 11.

## Screenshots / Proof of Fix

### After (`6d58335ced7d0cf22ee9d42d192d03985b47751b`)

1. Installed-wheel sync/async callback contract; full Rust workspace: passed
2. `UV_PYTHON=3.12 make check`: passed
3. Final stack Rust workspace and strict Clippy: passed

No paid-provider calls were used for deterministic validation.

## Type

New Feature; Refactoring

## Caveats (if any)

### Medium

- Live Azure, Google, Mistral, and Reducto smokes were unavailable; #40056 documents exchange gaps.

## Final Attestation

- [x] Tests cover this layer intended contracts and edge cases
