### PR TITLE
fix(ui): clamp server-paginated DataTable page index when rowCount shrinks

### DIFF
--- a/ui/litellm-dashboard/src/components/shared/DataTable/DataTable.test.tsx
+++ b/ui/litellm-dashboard/src/components/shared/DataTable/DataTable.test.tsx
@@ -1,4 +1,4 @@
-import type { ColumnDef, ExpandedState } from "@tanstack/react-table";
+import type { ColumnDef, ExpandedState, OnChangeFn, PaginationState } from "@tanstack/react-table";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";
@@ -273,6 +273,71 @@ describe("DataTable pagination", () => {
 
     await user.click(screen.getByTestId("pagination-next"));
     expect(onPaginationChange).toHaveBeenCalledTimes(1);
+  });
+
+  type ServerPageHarnessProps = {
+    rowCount: number;
+    isLoading?: boolean;
+    initialPageIndex: number;
+    onChange: (next: PaginationState) => void;
+  };
+
+  function ServerPageHarness({ rowCount, isLoading = false, initialPageIndex, onChange }: ServerPageHarnessProps) {
+    const [pagination, setPagination] = useState<PaginationState>({ pageIndex: initialPageIndex, pageSize: 10 });
+    const handleChange: OnChangeFn<PaginationState> = (updater) => {
+      const next = typeof updater === "function" ? updater(pagination) : updater;
+      onChange(next);
+      setPagination(next);
+    };
+    return (
+      <DataTable
+        data={[]}
+        columns={nameCellColumns}
+        paginationMode="server"
+        pagination={pagination}
+        onPaginationChange={handleChange}
+        rowCount={rowCount}
+        isLoading={isLoading}
+      />
+    );
+  }
+
+  it("server mode snaps to the last page when rowCount no longer reaches the current page", async () => {
+    const onChange = vi.fn();
+    render(<ServerPageHarness rowCount={15} initialPageIndex={2} onChange={onChange} />);
+
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith({ pageIndex: 1, pageSize: 10 }));
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("pagination-range")).toHaveTextContent("Showing 11-15 of 15");
+    expect(screen.getByText("Page 2 of 2")).toBeInTheDocument();
+    expect(screen.getByTestId("pagination-next")).toBeDisabled();
+  });
+
+  it("server mode falls back to the first page when rowCount drops to zero", async () => {
+    const onChange = vi.fn();
+    render(<ServerPageHarness rowCount={0} initialPageIndex={2} onChange={onChange} />);
+
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith({ pageIndex: 0, pageSize: 10 }));
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("pagination-range")).toHaveTextContent("No results");
+    expect(screen.getByText("Page 1 of 1")).toBeInTheDocument();
+    expect(screen.getByTestId("pagination-first")).toBeDisabled();
+    expect(screen.getByTestId("pagination-prev")).toBeDisabled();
+  });
+
+  it("server mode leaves the page index alone while loading and clamps once the response lands", async () => {
+    const onChange = vi.fn();
+    const { rerender } = render(<ServerPageHarness rowCount={0} isLoading initialPageIndex={2} onChange={onChange} />);
+
+    expect(screen.getByText("Page 3 of 1")).toBeInTheDocument();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(onChange).not.toHaveBeenCalled();
+
+    rerender(<ServerPageHarness rowCount={15} initialPageIndex={2} onChange={onChange} />);
+
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith({ pageIndex: 1, pageSize: 10 }));
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("Page 2 of 2")).toBeInTheDocument();
   });
 });
 

--- a/ui/litellm-dashboard/src/components/shared/DataTable/DataTable.tsx
+++ b/ui/litellm-dashboard/src/components/shared/DataTable/DataTable.tsx
@@ -16,6 +16,7 @@ import {
   getSortedRowModel,
   type Header,
   type OnChangeFn,
+  type PaginationState,
   type Row,
   type RowData,
   type RowSelectionState,
@@ -26,7 +27,7 @@ import {
 } from "@tanstack/react-table";
 import { SearchX } from "lucide-react";
 import * as React from "react";
-import { Fragment, useState } from "react";
+import { Fragment, useEffect, useState } from "react";
 
 import { Skeleton } from "@/components/ui/skeleton";
 import {
@@ -417,6 +418,21 @@ function useControllable<T>(
   return { value: internal, onChange: setInternal };
 }
 
+function useServerPageClamp(
+  active: boolean,
+  rowCount: number | undefined,
+  pagination: { value: PaginationState; onChange: OnChangeFn<PaginationState> },
+): void {
+  const { pageIndex, pageSize } = pagination.value;
+  const { onChange } = pagination;
+  useEffect(() => {
+    if (!active || rowCount === undefined) return;
+    const lastPageIndex = Math.max(Math.ceil(rowCount / pageSize) - 1, 0);
+    if (pageIndex <= lastPageIndex) return;
+    onChange({ pageIndex: lastPageIndex, pageSize });
+  }, [active, rowCount, pageIndex, pageSize, onChange]);
+}
+
 function useDataTableInstance<TData extends RowData, TValue>(
   props: DataTableResolvedProps<TData, TValue>,
 ): Table<TData> {
@@ -433,6 +449,7 @@ function useDataTableInstance<TData extends RowData, TValue>(
     pagination,
     onPaginationChange,
     rowCount,
+    isLoading = false,
     pageSizeOptions = DEFAULT_PAGE_SIZE_OPTIONS,
     filterMode = "none",
     columnFilters,
@@ -457,6 +474,7 @@ function useDataTableInstance<TData extends RowData, TValue>(
     pageIndex: 0,
     pageSize: pageSizeOptions[0] ?? 25,
   });
+  useServerPageClamp(paginationMode === "server" && !isLoading, rowCount, paginationState);
   const filterState = useControllable<ColumnFiltersState>(
     columnFilters,
     onColumnFiltersChange,


### PR DESCRIPTION
## TLDR

Problem this solves:

- Server-paginated tables keep a page index the server no longer has
- Footer reads "Page 2 of 1" and "Showing 26-25 of 25" over an empty body
- Previous and First stay enabled, Next and Last disabled, so the user is stranded
- All 13 server-mode tables share the bug since none of them clamp

How it solves it:

- The shared DataTable snaps the page index to the last valid page when rowCount shrinks
- Loading responses are ignored so an in-flight fetch never bounces the user to page 1
- One fix in the shared table, no per-table clamps needed

## User Flow

Before: an admin who deletes the last keys on the final page of the Virtual Keys table is stranded on a page that no longer exists

1. They open http://localhost:4000/ui/?page=api-keys, filter by a team with 30 keys and 25 rows per page, and click Next
2. The footer reads "Showing 26-30 of 30" and "Page 2 of 2" with 5 keys listed
3. They delete those 5 keys through POST http://localhost:4000/key/delete and the response lists the 5 deleted keys
4. They refresh the page, which still has page 2 in the URL
5. The table shows "No keys found" with the footer reading "Showing 26-25 of 25" and "Page 2 of 1", Previous and First enabled, Next and Last disabled

After: the same refresh lands the admin on the page that actually holds their keys

1. They open http://localhost:4000/ui/?page=api-keys, filter by a team with 30 keys and 25 rows per page, and click Next
2. The footer reads "Showing 26-30 of 30" and "Page 2 of 2" with 5 keys listed
3. They delete those 5 keys through POST http://localhost:4000/key/delete and the response lists the 5 deleted keys
4. They refresh the page, which still has page 2 in the URL
5. The table drops to page 1 on its own: the URL loses the page parameter, the footer reads "Showing 1-25 of 25" and "Page 1 of 1", all 25 remaining keys are listed, and every pager button is disabled

## Relevant issues

Related to #39682, whose reviewer flagged the same stale-page problem in the per-user usage table. That table's own clamp becomes redundant once this lands

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Setup shared by both runs: a proxy on http://localhost:4611 with master key `sk-1234`, the dashboard dev server on http://localhost:3001, and a team seeded with 30 keys

```bash
PROXY=http://localhost:4611
TEAM=$(curl -s -X POST $PROXY/team/new -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"team_alias":"clamp-repro-team"}' | jq -r .team_id)
for i in $(seq -w 1 30); do
  curl -s -X POST $PROXY/key/generate -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d "{\"team_id\":\"$TEAM\",\"key_alias\":\"clamp-repro-$i\"}" > /dev/null
done
curl -s "$PROXY/key/list?team_id=$TEAM&page=2&size=25&return_full_object=true" -H "Authorization: Bearer sk-1234" \
  | jq -c '{n:(.keys|length), total_count, total_pages, current_page}'
```

```
{"n":5,"total_count":30,"total_pages":2,"current_page":2}
```

Deleting the 5 keys on page 2, then asking the server for page 2 again, is the state both runs start from:

```bash
curl -s -X POST $PROXY/key/delete -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"key_aliases":["clamp-repro-01","clamp-repro-02","clamp-repro-03","clamp-repro-04","clamp-repro-05"]}' | jq -c '.deleted_keys|length'
curl -s "$PROXY/key/list?team_id=$TEAM&page=2&size=25&return_full_object=true" -H "Authorization: Bearer sk-1234" \
  | jq -c '{n:(.keys|length), total_count, total_pages, current_page}'
```

```
5
{"n":0,"total_count":25,"total_pages":1,"current_page":2}
```

### Before (f74bc9427b)

1. Open `http://localhost:3001/api-keys?filter_team=$TEAM&page=2&page_size=25` in the browser
2. Network: one call to `/key/list?...&page=2&size=25` returning 200 with zero keys
3. Table body: "No keys found"
4. Footer: "Showing 26-25 of 25" and "Page 2 of 1"
5. Pager: First enabled, Previous enabled, Next disabled, Last disabled
6. Screenshot:

   ![Virtual Keys stuck on Page 2 of 1 before the fix](https://raw.githubusercontent.com/BerriAI/litellm/litellm_datatable_server_page_clamp_screenshots/clamp-before-stuck-page2.png)

### After (d05d2a6f05)

1. Open `http://localhost:3001/api-keys?filter_team=$TEAM&page=2&page_size=25` in the browser
2. Network: `/key/list?...&page=2&size=25` returns 200 with zero keys, immediately followed by `/key/list?...&page=1&size=25` returning 200 with 25 keys
3. URL settles on `http://localhost:3001/api-keys/?filter_team=$TEAM&page_size=25` (page parameter cleared)
4. Table body: 25 rows, `clamp-repro-30` down to `clamp-repro-06`
5. Footer: "Showing 1-25 of 25" and "Page 1 of 1"
6. Pager: First, Previous, Next and Last all disabled
7. Screenshot:

   ![Virtual Keys snapped to Page 1 of 1 after the fix](https://raw.githubusercontent.com/BerriAI/litellm/litellm_datatable_server_page_clamp_screenshots/clamp-after-page2-autoclamp.png)

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- A table whose query gets disabled mid-session while on a later page will snap to page 1, since react-query reports a disabled query as not loading. Today no server-mode table can hit that outside of logout
- #39682 can drop its per-component `total_pages` clamp once this merges
- The team keys tab is covered too: switching teams kept the old page index and rendered "Showing 151-5 of 5". Found by code reading, not separately QA'd here

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
