### PR TITLE
fix(auth): normalize provider credential resolution

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
@@ -658,8 +658,8 @@ def anthropic_messages_handler(
         custom_llm_provider=custom_llm_provider,
         litellm_params=litellm_params,
         logging_obj=litellm_logging_obj,
-        api_key=api_key,
-        api_base=api_base,
+        api_key=dynamic_api_key,
+        api_base=dynamic_api_base,
         stream=stream,
         kwargs=kwargs,
     )

--- a/litellm/llms/azure/common_utils.py
+++ b/litellm/llms/azure/common_utils.py
@@ -333,7 +333,7 @@ def get_azure_ad_token(
         scope = "https://cognitiveservices.azure.com/.default"
 
     # Try to get token provider from Entra ID
-    if azure_ad_token_provider is None and tenant_id and client_id and client_secret:
+    if azure_ad_token_provider is None and azure_ad_token is None and tenant_id and client_id and client_secret:
         verbose_logger.debug("Using Azure AD Token Provider from Entra ID for Azure Auth")
         azure_ad_token_provider = get_azure_ad_token_from_entra_id(
             tenant_id=tenant_id,
@@ -343,7 +343,7 @@ def get_azure_ad_token(
         )
 
     # Try to get token provider from username and password
-    if azure_ad_token_provider is None and azure_username and azure_password and client_id:
+    if azure_ad_token_provider is None and azure_ad_token is None and azure_username and azure_password and client_id:
         verbose_logger.debug("Using Azure Username and Password for Azure Auth")
         azure_ad_token_provider = get_azure_ad_token_from_username_password(
             azure_username=azure_username,
@@ -714,9 +714,15 @@ class BaseAzureLLM(BaseOpenAILLM):
     def _base_validate_azure_environment(headers: dict, litellm_params: GenericLiteLLMParams | None) -> dict:
         litellm_params = litellm_params or GenericLiteLLMParams()
 
-        # Check if api-key is already in headers; if so, use it
-        if "api-key" in headers:
-            return headers
+        forwarded_api_key: Final = next(
+            (value for name, value in headers.items() if name.lower() == "api-key" and str(value).strip()),
+            None,
+        )
+        non_auth_headers: Final = {
+            name: value for name, value in headers.items() if name.lower() not in {"api-key", "authorization"}
+        }
+        if forwarded_api_key is not None:
+            return {**non_auth_headers, "api-key": forwarded_api_key}
 
         api_key: Final = (
             litellm_params.api_key
@@ -727,16 +733,15 @@ class BaseAzureLLM(BaseOpenAILLM):
         )
 
         if api_key:
-            headers["api-key"] = api_key
-            return headers
+            return {**non_auth_headers, "api-key": api_key}
 
         ### Fallback to Azure AD token-based authentication if no API key is available
         ### Retrieves Azure AD token and adds it to the Authorization header
         azure_ad_token: Final = get_azure_ad_token(litellm_params)
         if azure_ad_token:
-            headers["Authorization"] = f"Bearer {azure_ad_token}"
+            return {**non_auth_headers, "Authorization": f"Bearer {azure_ad_token}"}
 
-        return headers
+        return non_auth_headers
 
     @staticmethod
     def _get_base_azure_url(

--- a/litellm/llms/azure/common_utils.py
+++ b/litellm/llms/azure/common_utils.py
@@ -718,11 +718,11 @@ class BaseAzureLLM(BaseOpenAILLM):
             (value for name, value in headers.items() if name.lower() == "api-key" and str(value).strip()),
             None,
         )
-        non_auth_headers: Final = {
-            name: value for name, value in headers.items() if name.lower() not in {"api-key", "authorization"}
-        }
+        non_auth_headers: Final = MappingProxyType(
+            {name: value for name, value in headers.items() if name.lower() not in ("api-key", "authorization")}
+        )
         if forwarded_api_key is not None:
-            return {**non_auth_headers, "api-key": forwarded_api_key}
+            return MappingProxyType({**non_auth_headers, "api-key": forwarded_api_key}).copy()
 
         api_key: Final = (
             litellm_params.api_key
@@ -733,15 +733,15 @@ class BaseAzureLLM(BaseOpenAILLM):
         )
 
         if api_key:
-            return {**non_auth_headers, "api-key": api_key}
+            return MappingProxyType({**non_auth_headers, "api-key": api_key}).copy()
 
         ### Fallback to Azure AD token-based authentication if no API key is available
         ### Retrieves Azure AD token and adds it to the Authorization header
         azure_ad_token: Final = get_azure_ad_token(litellm_params)
         if azure_ad_token:
-            return {**non_auth_headers, "Authorization": f"Bearer {azure_ad_token}"}
+            return MappingProxyType({**non_auth_headers, "Authorization": f"Bearer {azure_ad_token}"}).copy()
 
-        return non_auth_headers
+        return non_auth_headers.copy()
 
     @staticmethod
     def _get_base_azure_url(

--- a/litellm/llms/azure_ai/anthropic/messages_transformation.py
+++ b/litellm/llms/azure_ai/anthropic/messages_transformation.py
@@ -2,6 +2,7 @@
 Azure Anthropic messages transformation config - extends AnthropicMessagesConfig with Azure authentication
 """
 
+from types import MappingProxyType
 from typing import Any, Final
 
 from litellm.llms.anthropic.experimental_pass_through.messages.transformation import (
@@ -57,16 +58,18 @@ class AzureAnthropicMessagesConfig(AnthropicMessagesConfig):
             None,
         )
         if azure_api_key is not None:
-            headers = {
-                **{
+            non_auth_headers: Final = MappingProxyType(
+                {
                     name: value
                     for name, value in headers.items()
-                    if name.lower() not in {"api-key", "x-api-key", "authorization"}
-                },
-                "x-api-key": azure_api_key,
-            }
+                    if name.lower() not in ("api-key", "x-api-key", "authorization")
+                }
+            )
+            headers = MappingProxyType({**non_auth_headers, "x-api-key": azure_api_key}).copy()
         elif any(name.lower() == "authorization" for name in headers):
-            headers = {name: value for name, value in headers.items() if name.lower() != "x-api-key"}
+            headers = MappingProxyType(
+                {name: value for name, value in headers.items() if name.lower() != "x-api-key"}
+            ).copy()
 
         # Set anthropic-version header
         if "anthropic-version" not in headers:

--- a/litellm/llms/azure_ai/anthropic/messages_transformation.py
+++ b/litellm/llms/azure_ai/anthropic/messages_transformation.py
@@ -52,10 +52,21 @@ class AzureAnthropicMessagesConfig(AnthropicMessagesConfig):
         # Use Azure authentication logic
         headers = BaseAzureLLM._base_validate_azure_environment(headers=headers, litellm_params=litellm_params_obj)
 
-        # Azure Anthropic uses x-api-key header (not api-key)
-        # Convert api-key to x-api-key if present
-        if "api-key" in headers and "x-api-key" not in headers:
-            headers["x-api-key"] = headers.pop("api-key")
+        azure_api_key: Final = next(
+            (value for name, value in headers.items() if name.lower() == "api-key"),
+            None,
+        )
+        if azure_api_key is not None:
+            headers = {
+                **{
+                    name: value
+                    for name, value in headers.items()
+                    if name.lower() not in {"api-key", "x-api-key", "authorization"}
+                },
+                "x-api-key": azure_api_key,
+            }
+        elif any(name.lower() == "authorization" for name in headers):
+            headers = {name: value for name, value in headers.items() if name.lower() != "x-api-key"}
 
         # Set anthropic-version header
         if "anthropic-version" not in headers:

--- a/litellm/llms/azure_ai/anthropic/transformation.py
+++ b/litellm/llms/azure_ai/anthropic/transformation.py
@@ -2,6 +2,7 @@
 Azure Anthropic transformation config - extends AnthropicConfig with Azure authentication
 """
 
+from types import MappingProxyType
 from typing import Final
 
 from litellm.llms.anthropic.chat.transformation import AnthropicConfig
@@ -80,14 +81,14 @@ class AzureAnthropicConfig(AnthropicConfig):
             None,
         )
         if azure_api_key is not None:
-            headers = {
-                **{
+            non_auth_headers: Final = MappingProxyType(
+                {
                     name: value
                     for name, value in headers.items()
-                    if name.lower() not in {"api-key", "x-api-key", "authorization"}
-                },
-                "x-api-key": azure_api_key,
-            }
+                    if name.lower() not in ("api-key", "x-api-key", "authorization")
+                }
+            )
+            headers = MappingProxyType({**non_auth_headers, "x-api-key": azure_api_key}).copy()
 
         # Get tools and other anthropic-specific setup
         tools: Final = optional_params.get("tools")
@@ -114,7 +115,9 @@ class AzureAnthropicConfig(AnthropicConfig):
         # Merge headers - Azure auth (api-key or Authorization) takes precedence
         headers = {**anthropic_headers, **headers}
         if "Authorization" in headers:
-            headers = {name: value for name, value in headers.items() if name.lower() != "x-api-key"}
+            headers = MappingProxyType(
+                {name: value for name, value in headers.items() if name.lower() != "x-api-key"}
+            ).copy()
 
         # Ensure anthropic-version header is set
         if "anthropic-version" not in headers:

--- a/litellm/llms/azure_ai/anthropic/transformation.py
+++ b/litellm/llms/azure_ai/anthropic/transformation.py
@@ -75,6 +75,20 @@ class AzureAnthropicConfig(AnthropicConfig):
         # Use Azure authentication logic
         headers = BaseAzureLLM._base_validate_azure_environment(headers=headers, litellm_params=litellm_params_obj)
 
+        azure_api_key: Final = next(
+            (value for name, value in headers.items() if name.lower() == "api-key"),
+            None,
+        )
+        if azure_api_key is not None:
+            headers = {
+                **{
+                    name: value
+                    for name, value in headers.items()
+                    if name.lower() not in {"api-key", "x-api-key", "authorization"}
+                },
+                "x-api-key": azure_api_key,
+            }
+
         # Get tools and other anthropic-specific setup
         tools: Final = optional_params.get("tools")
         prompt_caching_set: Final = self.is_cache_control_set(messages=messages)
@@ -99,6 +113,8 @@ class AzureAnthropicConfig(AnthropicConfig):
         )
         # Merge headers - Azure auth (api-key or Authorization) takes precedence
         headers = {**anthropic_headers, **headers}
+        if "Authorization" in headers:
+            headers = {name: value for name, value in headers.items() if name.lower() != "x-api-key"}
 
         # Ensure anthropic-version header is set
         if "anthropic-version" not in headers:

--- a/litellm/llms/azure_ai/chat/transformation.py
+++ b/litellm/llms/azure_ai/chat/transformation.py
@@ -81,15 +81,21 @@ class AzureAIStudioConfig(OpenAIConfig):
         api_key: str | None = None,
         api_base: str | None = None,
     ) -> dict:
+        non_auth_headers: Final = {
+            name: value for name, value in headers.items() if name.lower() not in {"api-key", "authorization"}
+        }
         if api_key:
             if api_base and self._should_use_api_key_header(api_base):
-                headers["api-key"] = api_key
+                headers = {**non_auth_headers, "api-key": api_key}
             else:
-                headers["Authorization"] = f"Bearer {api_key}"
+                headers = {**non_auth_headers, "Authorization": f"Bearer {api_key}"}
         else:
             # No api_key provided — fall back to Azure AD token-based auth
             litellm_params_obj = GenericLiteLLMParams(**(litellm_params if isinstance(litellm_params, dict) else {}))
-            headers = BaseAzureLLM._base_validate_azure_environment(headers=headers, litellm_params=litellm_params_obj)
+            headers = BaseAzureLLM._base_validate_azure_environment(
+                headers=headers,
+                litellm_params=litellm_params_obj,
+            )
 
         headers["Content-Type"] = "application/json"
 

--- a/litellm/llms/azure_ai/chat/transformation.py
+++ b/litellm/llms/azure_ai/chat/transformation.py
@@ -1,6 +1,7 @@
 import copy
 import enum
 import re
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Final, cast
 from urllib.parse import urlparse
 
@@ -81,14 +82,14 @@ class AzureAIStudioConfig(OpenAIConfig):
         api_key: str | None = None,
         api_base: str | None = None,
     ) -> dict:
-        non_auth_headers: Final = {
-            name: value for name, value in headers.items() if name.lower() not in {"api-key", "authorization"}
-        }
+        non_auth_headers: Final = MappingProxyType(
+            {name: value for name, value in headers.items() if name.lower() not in ("api-key", "authorization")}
+        )
         if api_key:
             if api_base and self._should_use_api_key_header(api_base):
-                headers = {**non_auth_headers, "api-key": api_key}
+                headers = MappingProxyType({**non_auth_headers, "api-key": api_key}).copy()
             else:
-                headers = {**non_auth_headers, "Authorization": f"Bearer {api_key}"}
+                headers = MappingProxyType({**non_auth_headers, "Authorization": f"Bearer {api_key}"}).copy()
         else:
             # No api_key provided — fall back to Azure AD token-based auth
             litellm_params_obj = GenericLiteLLMParams(**(litellm_params if isinstance(litellm_params, dict) else {}))

--- a/litellm/llms/bedrock/base_aws_llm.py
+++ b/litellm/llms/bedrock/base_aws_llm.py
@@ -827,11 +827,17 @@ class BaseAWSLLM:
         import boto3
 
         verbose_logger.debug(
-            "IN Web Identity Token: %s | Role Name: %s | Session Name: %s",
-            aws_web_identity_token,
+            "Using web identity token [set=%s] | Role Name: %s | Session Name: %s",
+            bool(aws_web_identity_token),
             aws_role_name,
             aws_session_name,
         )
+
+        if aws_external_id is not None:
+            raise AwsAuthError(
+                message="aws_external_id is not supported with web identity authentication.",
+                status_code=400,
+            )
 
         # get_secret() expands environment-variable references (an os.environ/<VAR>
         # prefix, or a bare name matching an environment variable). Config-sourced
@@ -924,10 +930,6 @@ class BaseAWSLLM:
             "DurationSeconds": 3600,
             "Policy": json.dumps(bedrock_session_policy, separators=(",", ":")),
         }
-
-        # Add ExternalId parameter if provided
-        if aws_external_id is not None:
-            assume_role_params["ExternalId"] = aws_external_id
 
         try:
             sts_response: Final = sts_client.assume_role_with_web_identity(**assume_role_params)

--- a/litellm/llms/mistral/audio_transcription/transformation.py
+++ b/litellm/llms/mistral/audio_transcription/transformation.py
@@ -4,6 +4,7 @@ Support for Mistral Voxtral audio transcription via ``/v1/audio/transcriptions``
 API reference: https://docs.mistral.ai/api/#tag/audio/operation/audio_transcriptions_v1_audio_transcriptions_post
 """
 
+from types import MappingProxyType
 from typing import Final
 
 import httpx
@@ -86,10 +87,10 @@ class MistralAudioTranscriptionConfig(BaseAudioTranscriptionConfig):
             "Authorization": f"Bearer {api_key}",
             "accept": "application/json",
         }
-        non_auth_headers: Final = {
-            name: value for name, value in (headers or {}).items() if name.lower() != "authorization"
-        }
-        return {**non_auth_headers, **default_headers}
+        non_auth_headers: Final = MappingProxyType(
+            {name: value for name, value in headers.items() if name.lower() != "authorization"}
+        )
+        return MappingProxyType({**non_auth_headers, **default_headers}).copy()
 
     def transform_audio_transcription_request(
         self,

--- a/litellm/llms/mistral/audio_transcription/transformation.py
+++ b/litellm/llms/mistral/audio_transcription/transformation.py
@@ -77,15 +77,19 @@ class MistralAudioTranscriptionConfig(BaseAudioTranscriptionConfig):
         api_key: str | None = None,
         api_base: str | None = None,
     ) -> dict:
-        if api_key is None:
+        if api_key is None or not api_key.strip():
             api_key = get_secret_str("MISTRAL_API_KEY")
+        if api_key is None or not api_key.strip():
+            raise ValueError("Missing MISTRAL_API_KEY - set it in the environment or pass api_key to transcription")
 
         default_headers: Final = {
             "Authorization": f"Bearer {api_key}",
             "accept": "application/json",
         }
-        default_headers.update(headers or {})
-        return default_headers
+        non_auth_headers: Final = {
+            name: value for name, value in (headers or {}).items() if name.lower() != "authorization"
+        }
+        return {**non_auth_headers, **default_headers}
 
     def transform_audio_transcription_request(
         self,

--- a/litellm/llms/reducto/ocr/transformation.py
+++ b/litellm/llms/reducto/ocr/transformation.py
@@ -1,3 +1,4 @@
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Final
 
 import httpx
@@ -55,7 +56,9 @@ class _BaseReductoOCRConfig(BaseOCRConfig):
                 "Missing REDUCTO_API_KEY - set it in the environment or pass api_key to litellm.ocr()/litellm.aocr()"
             )
 
-        non_auth_headers: Final = {name: value for name, value in headers.items() if name.lower() != "authorization"}
+        non_auth_headers: Final = MappingProxyType(
+            {name: value for name, value in headers.items() if name.lower() != "authorization"}
+        )
         return {
             **non_auth_headers,
             "Authorization": f"Bearer {resolved_key}",

--- a/litellm/llms/reducto/ocr/transformation.py
+++ b/litellm/llms/reducto/ocr/transformation.py
@@ -22,6 +22,9 @@ if TYPE_CHECKING:
 
 
 class _BaseReductoOCRConfig(BaseOCRConfig):
+    def get_api_key_env_var(self) -> str | None:
+        return "REDUCTO_API_KEY"
+
     def map_ocr_params(
         self,
         non_default_params: dict,
@@ -52,10 +55,11 @@ class _BaseReductoOCRConfig(BaseOCRConfig):
                 "Missing REDUCTO_API_KEY - set it in the environment or pass api_key to litellm.ocr()/litellm.aocr()"
             )
 
+        non_auth_headers: Final = {name: value for name, value in headers.items() if name.lower() != "authorization"}
         return {
+            **non_auth_headers,
             "Authorization": f"Bearer {resolved_key}",
             "Content-Type": "application/json",
-            **headers,
         }
 
     def get_complete_url(

--- a/tests/test_litellm/llms/azure/test_azure_common_utils.py
+++ b/tests/test_litellm/llms/azure/test_azure_common_utils.py
@@ -2132,3 +2132,29 @@ def test_an_azure_client_litellm_built_its_own_http_client_for_is_still_closed(m
     closer.reap()
 
     assert wrapper.is_closed() is True
+
+
+def test_static_azure_ad_token_is_not_replaced_by_inferred_service_principal(monkeypatch):
+    from litellm.llms.azure.common_utils import get_azure_ad_token
+
+    monkeypatch.setenv("AZURE_TENANT_ID", "tenant")
+    monkeypatch.setenv("AZURE_CLIENT_ID", "client")
+    monkeypatch.setenv("AZURE_CLIENT_SECRET", "secret")
+
+    assert get_azure_ad_token({"azure_ad_token": "static-token"}) == "static-token"
+
+
+def test_azure_auth_header_matching_is_case_insensitive_and_keeps_one_identity():
+    from litellm.llms.azure.common_utils import BaseAzureLLM
+    from litellm.types.router import GenericLiteLLMParams
+
+    headers = BaseAzureLLM._base_validate_azure_environment(
+        headers={
+            "API-Key": "forwarded",
+            "authorization": "Bearer conflicting",
+            "x-trace": "trace",
+        },
+        litellm_params=GenericLiteLLMParams(api_key="configured"),
+    )
+
+    assert headers == {"api-key": "forwarded", "x-trace": "trace"}

--- a/tests/test_litellm/llms/azure_ai/chat/test_azure_ai_transformation.py
+++ b/tests/test_litellm/llms/azure_ai/chat/test_azure_ai_transformation.py
@@ -68,6 +68,29 @@ def test_is_azure_openai_model_without_api_base_keeps_azure_ai():
     """Metadata lookups (get_model_info, supports_* checks) carry no api_base and must not flip the provider."""
     config = AzureAIStudioConfig()
     assert config._is_azure_openai_model(model="azure_ai/gpt-4o", api_base=None) is False
+
+
+def test_validate_environment_replaces_conflicting_auth_headers_case_insensitively():
+    config = AzureAIStudioConfig()
+
+    headers = config.validate_environment(
+        headers={
+            "Authorization": "Bearer forwarded",
+            "API-Key": "forwarded-key",
+            "x-trace": "trace",
+        },
+        model="azure_ai/gpt-4o",
+        messages=[{"role": "user", "content": "hello"}],
+        optional_params={},
+        litellm_params={},
+        api_key="configured-key",
+        api_base="https://resource.services.ai.azure.com",
+    )
+
+    assert headers["api-key"] == "configured-key"
+    assert headers["x-trace"] == "trace"
+    assert not any(name.lower() == "authorization" for name in headers)
+    assert sum(name.lower() == "api-key" for name in headers) == 1
     assert config._is_azure_openai_model(model="azure_ai/gpt-4o", api_base="https://my-res.openai.azure.com") is True
 
 

--- a/tests/test_litellm/llms/azure_ai/claude/test_azure_anthropic_transformation.py
+++ b/tests/test_litellm/llms/azure_ai/claude/test_azure_anthropic_transformation.py
@@ -19,6 +19,21 @@ class TestAzureAnthropicConfig:
         config = AzureAnthropicConfig()
         assert config.custom_llm_provider == "azure_ai"
 
+    def test_api_key_auth_emits_only_x_api_key(self):
+        config = AzureAnthropicConfig()
+
+        result = config.validate_environment(
+            headers={"Authorization": "Bearer forwarded"},
+            model="claude-sonnet-4-5",
+            messages=[{"role": "user", "content": "Hello"}],
+            optional_params={},
+            litellm_params={"api_key": "configured-key"},
+            api_key="configured-key",
+        )
+
+        assert result["x-api-key"] == "configured-key"
+        assert not any(name.lower() in {"api-key", "authorization"} for name in result)
+
     def test_validate_environment_with_dict_litellm_params(self):
         """Test validate_environment with dict litellm_params"""
         config = AzureAnthropicConfig()

--- a/tests/test_litellm/llms/azure_ai/claude/test_azure_anthropic_transformation.py
+++ b/tests/test_litellm/llms/azure_ai/claude/test_azure_anthropic_transformation.py
@@ -5,7 +5,7 @@ sys.path.insert(
     0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../.."))
 )
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -118,8 +118,7 @@ class TestAzureAnthropicConfig:
             call_args = mock_validate.call_args
             assert call_args[1]["litellm_params"].api_key == "provided-api-key"
 
-    def test_validate_environment_preserves_api_key_header(self):
-        """Test that api-key header is preserved as-is (Azure handles the header internally)"""
+    def test_validate_environment_converts_api_key_header(self):
         config = AzureAnthropicConfig()
         headers = {}
         model = "claude-sonnet-4-5"
@@ -140,9 +139,8 @@ class TestAzureAnthropicConfig:
                     litellm_params=litellm_params,
                 )
 
-                # Verify api-key header is preserved as-is
-                assert "api-key" in result
-                assert result["api-key"] == "test-api-key"
+                assert result["x-api-key"] == "test-api-key"
+                assert "api-key" not in result
 
     def test_validate_environment_sets_anthropic_version(self):
         """Test that anthropic-version header is set"""
@@ -217,8 +215,8 @@ class TestAzureAnthropicConfig:
         See: https://github.com/BerriAI/litellm/issues/XXXX
         """
         config = AzureAnthropicConfig()
-
         messages = [{"role": "user", "content": "Hello"}]
+
         optional_params = {
             "max_tokens": 100,
         }
@@ -260,8 +258,8 @@ class TestAzureAnthropicConfig:
     def test_context_management_compact_beta_header(self):
         """Test that context_management with compact adds the correct beta header for Azure AI"""
         config = AzureAnthropicConfig()
-
         messages = [{"role": "user", "content": "Hello"}]
+
         optional_params = {
             "context_management": {"edits": [{"type": "compact_20260112"}]},
             "max_tokens": 100,
@@ -289,7 +287,6 @@ class TestAzureAnthropicConfig:
         """Test that compact beta header is added to headers for Azure AI"""
         config = AzureAnthropicConfig()
 
-        messages = [{"role": "user", "content": "Hello"}]
         optional_params = {
             "context_management": {"edits": [{"type": "compact_20260112"}]},
             "max_tokens": 100,
@@ -428,7 +425,6 @@ class TestAzureAnthropicConfig:
         """Test that context_management with both compact and other edits adds both beta headers"""
         config = AzureAnthropicConfig()
 
-        messages = [{"role": "user", "content": "Hello"}]
         optional_params = {
             "context_management": {
                 "edits": [

--- a/tests/test_litellm/llms/bedrock/test_base_aws_llm.py
+++ b/tests/test_litellm/llms/bedrock/test_base_aws_llm.py
@@ -46,6 +46,22 @@ def test_base_aws_llm_instances_share_process_wide_iam_cache():
     assert first.iam_cache is BaseAWSLLM._shared_iam_cache
 
 
+def test_web_identity_rejects_external_id_without_logging_token(caplog):
+    token = "secret-web-identity-token"
+
+    with pytest.raises(AwsAuthError, match="not supported with web identity"):
+        BaseAWSLLM()._auth_with_web_identity_token(
+            aws_web_identity_token=token,
+            aws_role_name="arn:aws:iam::123456789012:role/test",
+            aws_session_name="session",
+            aws_region_name="us-east-1",
+            aws_sts_endpoint=None,
+            aws_external_id="external",
+        )
+
+    assert token not in caplog.text
+
+
 def test_static_access_key_credentials_use_iam_cache_across_calls():
     """Static access-key path hits shared iam_cache; second identical call does not refetch."""
     base = BaseAWSLLM()

--- a/tests/test_litellm/llms/mistral/audio_transcription/test_mistral_audio_transcription_transformation.py
+++ b/tests/test_litellm/llms/mistral/audio_transcription/test_mistral_audio_transcription_transformation.py
@@ -88,6 +88,37 @@ def test_mistral_audio_transcription_validate_environment():
     assert headers["accept"] == "application/json"
 
 
+def test_mistral_audio_transcription_rejects_missing_key(monkeypatch):
+    monkeypatch.delenv("MISTRAL_API_KEY", raising=False)
+
+    with pytest.raises(ValueError, match="Missing MISTRAL_API_KEY"):
+        MistralAudioTranscriptionConfig().validate_environment(
+            headers={},
+            model="voxtral-mini-latest",
+            messages=[],
+            optional_params={},
+            litellm_params={},
+            api_key=" ",
+        )
+
+
+def test_mistral_audio_transcription_configured_key_replaces_forwarded_auth():
+    headers = MistralAudioTranscriptionConfig().validate_environment(
+        headers={"authorization": "Bearer forwarded", "x-trace": "trace"},
+        model="voxtral-mini-latest",
+        messages=[],
+        optional_params={},
+        litellm_params={},
+        api_key="configured",
+    )
+
+    assert headers == {
+        "Authorization": "Bearer configured",
+        "accept": "application/json",
+        "x-trace": "trace",
+    }
+
+
 def test_mistral_audio_transcription_supported_params():
     config = MistralAudioTranscriptionConfig()
     params = config.get_supported_openai_params("voxtral-mini-latest")

--- a/tests/test_litellm/llms/reducto/test_upload.py
+++ b/tests/test_litellm/llms/reducto/test_upload.py
@@ -11,6 +11,25 @@ from litellm.llms.reducto.common import (
     upload_bytes_async,
     upload_bytes_sync,
 )
+from litellm.llms.reducto.ocr.transformation import ReductoParseV3Config
+
+
+def test_reducto_exposes_api_key_environment_variable():
+    assert ReductoParseV3Config().get_api_key_env_var() == "REDUCTO_API_KEY"
+
+
+def test_reducto_configured_key_replaces_forwarded_auth():
+    headers = ReductoParseV3Config().validate_environment(
+        headers={"authorization": "Bearer forwarded", "x-trace": "trace"},
+        model="parse-v3",
+        api_key="configured",
+    )
+
+    assert headers == {
+        "Authorization": "Bearer configured",
+        "Content-Type": "application/json",
+        "x-trace": "trace",
+    }
 
 
 @pytest.fixture()
@@ -42,9 +61,7 @@ async def test_parse_v3_rejects_plain_http_urls(disable_aiohttp_transport):
 
 
 @pytest.mark.asyncio
-async def test_parse_v3_image_data_uri_upload_uses_image_mime(
-    disable_aiohttp_transport, respx_mock
-):
+async def test_parse_v3_image_data_uri_upload_uses_image_mime(disable_aiohttp_transport, respx_mock):
     upload_route = respx_mock.post("https://custom.reducto.test/upload").respond(
         json={"file_id": "reducto://uploaded-image.png"}
     )
@@ -85,9 +102,7 @@ async def test_parse_v3_image_data_uri_upload_uses_image_mime(
 
 
 @pytest.mark.asyncio
-async def test_parse_v3_uses_programmatic_api_key_over_env(
-    disable_aiohttp_transport, respx_mock
-):
+async def test_parse_v3_uses_programmatic_api_key_over_env(disable_aiohttp_transport, respx_mock):
     upload_route = respx_mock.post("https://platform.reducto.ai/upload").respond(
         json={"file_id": "reducto://uploaded.pdf"}
     )
@@ -98,9 +113,7 @@ async def test_parse_v3_uses_programmatic_api_key_over_env(
                 "chunks": [
                     {
                         "content": "Programmatic auth",
-                        "blocks": [
-                            {"content": "Programmatic auth", "bbox": {"page": 1}}
-                        ],
+                        "blocks": [{"content": "Programmatic auth", "bbox": {"page": 1}}],
                     }
                 ]
             },


### PR DESCRIPTION
## TLDR

Problem this solves:

- Routes could send conflicting provider credentials
- Blank keys could become invalid bearer headers
- Azure Messages ignored resolved environment credentials

How it solves it:

- Normalizes auth headers case-insensitively
- Selects one provider identity per request
- Fixes credential precedence and secret logging

## User Flow

Before: a developer configures one provider identity, but another header can override or accompany it

1. They call POST /v1/chat/completions, /v1/messages, /v1/audio/transcriptions, or /v1/ocr
2. They supply a deployment credential and optional forwarded headers
3. The upstream request can contain conflicting credentials or an empty bearer value

After: the same request uses exactly one normalized provider identity

1. They call the same endpoint with the same deployment configuration
2. They supply the same credential and optional forwarded headers
3. The upstream receives one valid credential and preserves non-auth headers

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The focused Python tests pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR scope is isolated to credential resolution
- [ ] I have received a Greptile Confidence Score of at least 4/5

## Delays in PR merge?

If you are seeing a delay in PR merge, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

### Before (d71fe43c1a)

1. No live provider run was captured because cloud credentials were unavailable

### After (7dc8df7eda)

1. No live provider run was captured because cloud credentials were unavailable

## Type

Bug Fix

## Caveats (if any)

### Severe

- Conflicting forwarded auth no longer overrides deployment credentials
- Blank Bedrock keys now use configured fallback credentials

## Final Attestation

- [x] The tests check corrected credential behavior and edge cases
