### PR TITLE
refactor(auth): add shared SDK authentication foundation

### DIFF
--- a/litellm-rust/crates/core/src/auth/credentials.rs
+++ b/litellm-rust/crates/core/src/auth/credentials.rs
@@ -1,0 +1,150 @@
+use std::fmt;
+use std::sync::Arc;
+use std::time::Instant;
+
+use tokio::sync::Mutex;
+
+use reqwest::header::HeaderName;
+
+use super::OperationFuture;
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct SecretString(String);
+
+impl SecretString {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    pub fn expose(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for SecretString {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("[redacted]")
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CredentialProvenance {
+    CallerSupplied,
+    ForwardedHeader(HeaderName),
+    EnvironmentVariable(String),
+    ExternalProvider,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TokenLease {
+    pub token: SecretString,
+    pub expires_at: Instant,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TokenCredential {
+    KnownExpiry(TokenLease),
+    NoStore(SecretString),
+}
+
+pub trait Clock: Send + Sync {
+    fn now(&self) -> Instant;
+}
+
+pub struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now(&self) -> Instant {
+        Instant::now()
+    }
+}
+
+pub trait TokenProvider: Send + Sync {
+    fn token(&self) -> OperationFuture<'_, TokenCredential>;
+}
+
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+pub enum AzureCredentialMethod {
+    ClientSecret,
+    ClientCertificate,
+    SystemManagedIdentity,
+    UserManagedIdentity,
+    WorkloadIdentity,
+    ExternalOidc,
+    DefaultChain,
+    DeveloperCli,
+    DeploymentEnvironment,
+    UsernamePassword,
+    ConfiguredClass,
+}
+
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+pub enum GoogleCredentialMethod {
+    ServiceAccount,
+    AuthorizedUser,
+    ApplicationDefault,
+    MetadataServer,
+    WorkloadIdentityFile,
+    WorkloadIdentityUrl,
+    WorkloadIdentityExecutable,
+    AwsWorkloadIdentity,
+    ImpersonatedServiceAccount,
+}
+
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+pub enum CloudCredentialMethod {
+    Azure(AzureCredentialMethod),
+    Google(GoogleCredentialMethod),
+    CallerToken,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct CredentialIdentity {
+    pub method: CloudCredentialMethod,
+    pub principal: Option<String>,
+    pub tenant: Option<String>,
+    pub audience: Option<String>,
+    pub scopes: Vec<String>,
+}
+
+pub struct ExpiryAwareTokenProvider {
+    inner: Arc<dyn TokenProvider>,
+    clock: Arc<dyn Clock>,
+    cached: Mutex<Option<TokenLease>>,
+}
+
+impl ExpiryAwareTokenProvider {
+    pub fn new(inner: Arc<dyn TokenProvider>, clock: Arc<dyn Clock>) -> Self {
+        Self {
+            inner,
+            clock,
+            cached: Mutex::new(None),
+        }
+    }
+}
+
+impl TokenProvider for ExpiryAwareTokenProvider {
+    fn token(&self) -> OperationFuture<'_, TokenCredential> {
+        Box::pin(async move {
+            let mut cached = self.cached.lock().await;
+            if let Some(lease) = cached.as_ref()
+                && lease.expires_at > self.clock.now()
+            {
+                return Ok(TokenCredential::KnownExpiry(lease.clone()));
+            }
+            match self.inner.token().await? {
+                TokenCredential::KnownExpiry(lease) if lease.expires_at > self.clock.now() => {
+                    *cached = Some(lease.clone());
+                    Ok(TokenCredential::KnownExpiry(lease))
+                }
+                TokenCredential::KnownExpiry(_) => Err(crate::Error::Auth(
+                    "credential provider returned an expired token".into(),
+                )),
+                TokenCredential::NoStore(token) => {
+                    *cached = None;
+                    Ok(TokenCredential::NoStore(token))
+                }
+            }
+        })
+    }
+}

--- a/litellm-rust/crates/core/src/auth/mod.rs
+++ b/litellm-rust/crates/core/src/auth/mod.rs
@@ -1,3 +1,17 @@
+mod credentials;
+mod providers;
+
+pub use credentials::{
+    AzureCredentialMethod, Clock, CloudCredentialMethod, CredentialIdentity, CredentialProvenance,
+    ExpiryAwareTokenProvider, GoogleCredentialMethod, SecretString, SystemClock, TokenCredential,
+    TokenLease, TokenProvider,
+};
+pub use providers::{
+    BearerAuthorizationProvider, BearerCredentialAdapter, CredentialAdapter,
+    CredentialAdapterRegistry, CredentialCandidate, CredentialKind, CredentialSpec,
+    StaticHeaderAuthorizationProvider, StaticHeaderCredentialAdapter,
+};
+
 use std::collections::HashSet;
 use std::future::Future;
 use std::pin::Pin;
@@ -148,6 +162,7 @@ pub struct AuthorizationPreparation {
     pub authorizer: Arc<dyn RequestAuthorizer>,
     pub visible_headers: HeaderMap,
     pub remove_headers: Vec<HeaderName>,
+    pub provenance: Option<CredentialProvenance>,
 }
 
 pub struct FixedAuthorization {
@@ -185,6 +200,7 @@ impl AuthorizationProvider for FixedAuthorization {
                 authorizer: self.authorizer.clone(),
                 visible_headers: self.visible_headers.clone(),
                 remove_headers: self.remove_headers.clone(),
+                provenance: None,
             })
         })
     }
@@ -199,6 +215,7 @@ impl AuthorizationProvider for NoAuthorization {
                 authorizer: Arc::new(NoAuthorization),
                 visible_headers: HeaderMap::new(),
                 remove_headers: Vec::new(),
+                provenance: None,
             })
         })
     }

--- a/litellm-rust/crates/core/src/auth/providers.rs
+++ b/litellm-rust/crates/core/src/auth/providers.rs
@@ -1,0 +1,353 @@
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderName, HeaderValue};
+
+use super::{
+    AuthorizationInput, AuthorizationMutation, AuthorizationPreparation, AuthorizationProvider,
+    Clock, CredentialProvenance, OperationFuture, RequestAuthorizer, SecretString, TokenCredential,
+    TokenProvider,
+};
+use crate::Error;
+
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+pub enum CredentialKind {
+    StaticHeader,
+    Bearer,
+}
+
+pub enum CredentialSpec {
+    StaticHeader {
+        name: HeaderName,
+        value: SecretString,
+        conflicts: Vec<HeaderName>,
+    },
+    Bearer {
+        provider: Arc<dyn TokenProvider>,
+        conflicts: Vec<HeaderName>,
+    },
+}
+
+impl CredentialSpec {
+    pub fn kind(&self) -> CredentialKind {
+        match self {
+            Self::StaticHeader { .. } => CredentialKind::StaticHeader,
+            Self::Bearer { .. } => CredentialKind::Bearer,
+        }
+    }
+}
+
+type CredentialFactory =
+    Box<dyn FnOnce() -> OperationFuture<'static, Option<CredentialSpec>> + Send + 'static>;
+
+pub struct CredentialCandidate {
+    provenance: CredentialProvenance,
+    kind: CredentialKind,
+    factory: CredentialFactory,
+}
+
+impl CredentialCandidate {
+    pub fn new(
+        provenance: CredentialProvenance,
+        kind: CredentialKind,
+        factory: impl FnOnce() -> OperationFuture<'static, CredentialSpec> + Send + 'static,
+    ) -> Self {
+        Self {
+            provenance,
+            kind,
+            factory: Box::new(move || {
+                let future = factory();
+                Box::pin(async move { future.await.map(Some) })
+            }),
+        }
+    }
+
+    pub fn discover(
+        provenance: CredentialProvenance,
+        kind: CredentialKind,
+        factory: impl FnOnce() -> OperationFuture<'static, Option<CredentialSpec>> + Send + 'static,
+    ) -> Self {
+        Self {
+            provenance,
+            kind,
+            factory: Box::new(factory),
+        }
+    }
+}
+
+pub trait CredentialAdapter: Send + Sync {
+    fn kind(&self) -> CredentialKind;
+
+    fn build(
+        &self,
+        spec: CredentialSpec,
+        provenance: CredentialProvenance,
+        clock: Arc<dyn Clock>,
+    ) -> Result<Arc<dyn AuthorizationProvider>, Error>;
+}
+
+pub struct CredentialAdapterRegistry {
+    adapters: HashMap<CredentialKind, Arc<dyn CredentialAdapter>>,
+    clock: Arc<dyn Clock>,
+}
+
+impl CredentialAdapterRegistry {
+    pub fn with_builtin_adapters(clock: Arc<dyn Clock>) -> Self {
+        let adapters: [Arc<dyn CredentialAdapter>; 2] = [
+            Arc::new(StaticHeaderCredentialAdapter),
+            Arc::new(BearerCredentialAdapter),
+        ];
+        Self {
+            adapters: adapters
+                .into_iter()
+                .map(|adapter| (adapter.kind(), adapter))
+                .collect(),
+            clock,
+        }
+    }
+
+    pub fn new(
+        adapters: impl IntoIterator<Item = Arc<dyn CredentialAdapter>>,
+        clock: Arc<dyn Clock>,
+    ) -> Result<Self, Error> {
+        let adapters: Vec<_> = adapters.into_iter().collect();
+        let unique: HashSet<_> = adapters.iter().map(|adapter| adapter.kind()).collect();
+        if unique.len() != adapters.len() {
+            return Err(Error::Auth("duplicate credential adapter".into()));
+        }
+        Ok(Self {
+            adapters: adapters
+                .into_iter()
+                .map(|adapter| (adapter.kind(), adapter))
+                .collect(),
+            clock,
+        })
+    }
+
+    pub fn resolve(
+        &self,
+        candidates: impl IntoIterator<Item = CredentialCandidate>,
+    ) -> OperationFuture<'_, Arc<dyn AuthorizationProvider>> {
+        let candidates: Vec<_> = candidates.into_iter().collect();
+        Box::pin(async move {
+            for candidate in candidates {
+                let expected_kind = candidate.kind;
+                let provenance = candidate.provenance;
+                let Some(spec) = (candidate.factory)().await? else {
+                    continue;
+                };
+                if spec.kind() != expected_kind {
+                    return Err(Error::Auth(
+                        "credential factory returned the wrong credential kind".into(),
+                    ));
+                }
+                let adapter = self
+                    .adapters
+                    .get(&expected_kind)
+                    .ok_or_else(|| Error::Auth("unsupported credential kind".into()))?;
+                return adapter.build(spec, provenance, self.clock.clone());
+            }
+            Err(Error::Auth("missing credential".into()))
+        })
+    }
+}
+
+#[derive(Clone)]
+struct HeaderSnapshot {
+    name: HeaderName,
+    value: HeaderValue,
+    declared: Vec<HeaderName>,
+    conflicts: Vec<HeaderName>,
+}
+
+impl HeaderSnapshot {
+    fn new(
+        name: HeaderName,
+        value: SecretString,
+        conflicts: Vec<HeaderName>,
+    ) -> Result<Self, Error> {
+        let mut header = HeaderValue::from_str(value.expose())
+            .map_err(|_| Error::Auth("credential cannot be used in an HTTP header".into()))?;
+        header.set_sensitive(true);
+        let declared = std::iter::once(name.clone())
+            .chain(conflicts.iter().cloned())
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect();
+        Ok(Self {
+            name,
+            value: header,
+            declared,
+            conflicts,
+        })
+    }
+
+    fn preparation(self: Arc<Self>, provenance: CredentialProvenance) -> AuthorizationPreparation {
+        AuthorizationPreparation {
+            authorizer: self.clone(),
+            visible_headers: HeaderMap::from_iter([(self.name.clone(), self.value.clone())]),
+            remove_headers: self.conflicts.clone(),
+            provenance: Some(provenance),
+        }
+    }
+}
+
+impl RequestAuthorizer for HeaderSnapshot {
+    fn declared_headers(&self) -> &[HeaderName] {
+        &self.declared
+    }
+
+    fn authorize<'a>(
+        &'a self,
+        _: AuthorizationInput<'a>,
+    ) -> OperationFuture<'a, AuthorizationMutation> {
+        Box::pin(async move {
+            Ok(AuthorizationMutation {
+                set_headers: vec![(self.name.clone(), self.value.clone())],
+                remove_headers: self.conflicts.clone(),
+            })
+        })
+    }
+}
+
+pub struct StaticHeaderAuthorizationProvider {
+    name: HeaderName,
+    value: SecretString,
+    conflicts: Vec<HeaderName>,
+    provenance: CredentialProvenance,
+}
+
+impl StaticHeaderAuthorizationProvider {
+    pub fn new(
+        name: HeaderName,
+        value: SecretString,
+        conflicts: Vec<HeaderName>,
+        provenance: CredentialProvenance,
+    ) -> Self {
+        Self {
+            name,
+            value,
+            conflicts,
+            provenance,
+        }
+    }
+}
+
+impl AuthorizationProvider for StaticHeaderAuthorizationProvider {
+    fn prepare(&self) -> OperationFuture<'_, AuthorizationPreparation> {
+        Box::pin(async move {
+            HeaderSnapshot::new(
+                self.name.clone(),
+                self.value.clone(),
+                self.conflicts.clone(),
+            )
+            .map(Arc::new)
+            .map(|snapshot| snapshot.preparation(self.provenance.clone()))
+        })
+    }
+}
+
+pub struct BearerAuthorizationProvider {
+    provider: Arc<dyn TokenProvider>,
+    clock: Arc<dyn Clock>,
+    conflicts: Vec<HeaderName>,
+    provenance: CredentialProvenance,
+}
+
+impl BearerAuthorizationProvider {
+    pub fn new(
+        provider: Arc<dyn TokenProvider>,
+        clock: Arc<dyn Clock>,
+        conflicts: Vec<HeaderName>,
+        provenance: CredentialProvenance,
+    ) -> Self {
+        Self {
+            provider,
+            clock,
+            conflicts,
+            provenance,
+        }
+    }
+}
+
+impl AuthorizationProvider for BearerAuthorizationProvider {
+    fn prepare(&self) -> OperationFuture<'_, AuthorizationPreparation> {
+        Box::pin(async move {
+            let token = match self.provider.token().await? {
+                TokenCredential::KnownExpiry(lease) if lease.expires_at > self.clock.now() => {
+                    lease.token
+                }
+                TokenCredential::KnownExpiry(_) => {
+                    return Err(Error::Auth(
+                        "credential provider returned an expired token".into(),
+                    ));
+                }
+                TokenCredential::NoStore(token) => token,
+            };
+            if token.expose().trim().is_empty() {
+                return Err(Error::Auth(
+                    "credential provider returned an empty token".into(),
+                ));
+            }
+            let value = SecretString::new(format!("Bearer {}", token.expose()));
+            HeaderSnapshot::new(AUTHORIZATION, value, self.conflicts.clone())
+                .map(Arc::new)
+                .map(|snapshot| snapshot.preparation(self.provenance.clone()))
+        })
+    }
+}
+
+pub struct StaticHeaderCredentialAdapter;
+
+impl CredentialAdapter for StaticHeaderCredentialAdapter {
+    fn kind(&self) -> CredentialKind {
+        CredentialKind::StaticHeader
+    }
+
+    fn build(
+        &self,
+        spec: CredentialSpec,
+        provenance: CredentialProvenance,
+        _: Arc<dyn Clock>,
+    ) -> Result<Arc<dyn AuthorizationProvider>, Error> {
+        match spec {
+            CredentialSpec::StaticHeader {
+                name,
+                value,
+                conflicts,
+            } => Ok(Arc::new(StaticHeaderAuthorizationProvider::new(
+                name, value, conflicts, provenance,
+            ))),
+            CredentialSpec::Bearer { .. } => Err(Error::Auth(
+                "static header adapter received a bearer credential".into(),
+            )),
+        }
+    }
+}
+
+pub struct BearerCredentialAdapter;
+
+impl CredentialAdapter for BearerCredentialAdapter {
+    fn kind(&self) -> CredentialKind {
+        CredentialKind::Bearer
+    }
+
+    fn build(
+        &self,
+        spec: CredentialSpec,
+        provenance: CredentialProvenance,
+        clock: Arc<dyn Clock>,
+    ) -> Result<Arc<dyn AuthorizationProvider>, Error> {
+        match spec {
+            CredentialSpec::Bearer {
+                provider,
+                conflicts,
+            } => Ok(Arc::new(BearerAuthorizationProvider::new(
+                provider, clock, conflicts, provenance,
+            ))),
+            CredentialSpec::StaticHeader { .. } => Err(Error::Auth(
+                "bearer adapter received a static header credential".into(),
+            )),
+        }
+    }
+}

--- a/litellm-rust/crates/core/src/auth/tests.rs
+++ b/litellm-rust/crates/core/src/auth/tests.rs
@@ -370,3 +370,449 @@ async fn deadline_and_cancellation_cover_post_callback_credential_preparation() 
         "upstream network error: Request cancelled"
     );
 }
+
+struct FixedClock(Instant);
+
+impl Clock for FixedClock {
+    fn now(&self) -> Instant {
+        self.0
+    }
+}
+
+struct RotatingTokenProvider {
+    calls: AtomicUsize,
+    credential: Arc<dyn Fn(usize) -> TokenCredential + Send + Sync>,
+}
+
+#[tokio::test]
+async fn discovery_continues_past_unavailable_sources() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let unavailable_calls = calls.clone();
+    let selected_calls = calls.clone();
+    let registry =
+        CredentialAdapterRegistry::with_builtin_adapters(Arc::new(FixedClock(Instant::now())));
+    let provider = registry
+        .resolve([
+            CredentialCandidate::discover(
+                CredentialProvenance::EnvironmentVariable("MISSING".into()),
+                CredentialKind::Bearer,
+                move || {
+                    Box::pin(async move {
+                        unavailable_calls.fetch_add(1, Ordering::SeqCst);
+                        Ok(None)
+                    })
+                },
+            ),
+            CredentialCandidate::discover(
+                CredentialProvenance::ExternalProvider,
+                CredentialKind::Bearer,
+                move || {
+                    Box::pin(async move {
+                        selected_calls.fetch_add(1, Ordering::SeqCst);
+                        Ok(Some(CredentialSpec::Bearer {
+                            provider: Arc::new(RotatingTokenProvider {
+                                calls: AtomicUsize::new(0),
+                                credential: Arc::new(|_| {
+                                    TokenCredential::NoStore(SecretString::new("discovered"))
+                                }),
+                            }),
+                            conflicts: Vec::new(),
+                        }))
+                    })
+                },
+            ),
+        ])
+        .await
+        .unwrap();
+
+    let prepared = provider.prepare().await.unwrap();
+    assert_eq!(calls.load(Ordering::SeqCst), 2);
+    assert_eq!(
+        prepared.provenance,
+        Some(CredentialProvenance::ExternalProvider)
+    );
+}
+
+#[tokio::test]
+async fn expiry_aware_provider_reuses_only_live_leases() {
+    let now = Instant::now();
+    let inner = Arc::new(RotatingTokenProvider {
+        calls: AtomicUsize::new(0),
+        credential: Arc::new(move |_| {
+            TokenCredential::KnownExpiry(TokenLease {
+                token: SecretString::new("cached"),
+                expires_at: now + Duration::from_secs(60),
+            })
+        }),
+    });
+    let provider = ExpiryAwareTokenProvider::new(inner.clone(), Arc::new(FixedClock(now)));
+
+    provider.token().await.unwrap();
+    provider.token().await.unwrap();
+
+    assert_eq!(inner.calls.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn cloud_credential_inventory_covers_azure_google_and_caller_tokens() {
+    let methods = [
+        CloudCredentialMethod::Azure(AzureCredentialMethod::ClientSecret),
+        CloudCredentialMethod::Azure(AzureCredentialMethod::ClientCertificate),
+        CloudCredentialMethod::Azure(AzureCredentialMethod::SystemManagedIdentity),
+        CloudCredentialMethod::Azure(AzureCredentialMethod::UserManagedIdentity),
+        CloudCredentialMethod::Azure(AzureCredentialMethod::WorkloadIdentity),
+        CloudCredentialMethod::Azure(AzureCredentialMethod::ExternalOidc),
+        CloudCredentialMethod::Azure(AzureCredentialMethod::DefaultChain),
+        CloudCredentialMethod::Azure(AzureCredentialMethod::DeveloperCli),
+        CloudCredentialMethod::Azure(AzureCredentialMethod::DeploymentEnvironment),
+        CloudCredentialMethod::Azure(AzureCredentialMethod::UsernamePassword),
+        CloudCredentialMethod::Azure(AzureCredentialMethod::ConfiguredClass),
+        CloudCredentialMethod::Google(GoogleCredentialMethod::ServiceAccount),
+        CloudCredentialMethod::Google(GoogleCredentialMethod::AuthorizedUser),
+        CloudCredentialMethod::Google(GoogleCredentialMethod::ApplicationDefault),
+        CloudCredentialMethod::Google(GoogleCredentialMethod::MetadataServer),
+        CloudCredentialMethod::Google(GoogleCredentialMethod::WorkloadIdentityFile),
+        CloudCredentialMethod::Google(GoogleCredentialMethod::WorkloadIdentityUrl),
+        CloudCredentialMethod::Google(GoogleCredentialMethod::WorkloadIdentityExecutable),
+        CloudCredentialMethod::Google(GoogleCredentialMethod::AwsWorkloadIdentity),
+        CloudCredentialMethod::Google(GoogleCredentialMethod::ImpersonatedServiceAccount),
+        CloudCredentialMethod::CallerToken,
+    ];
+    assert_eq!(methods.len(), 21);
+}
+
+impl TokenProvider for RotatingTokenProvider {
+    fn token(&self) -> OperationFuture<'_, TokenCredential> {
+        Box::pin(async move {
+            let call = self.calls.fetch_add(1, Ordering::SeqCst) + 1;
+            Ok((self.credential)(call))
+        })
+    }
+}
+
+async fn prepared_and_final_header(
+    provider: &dyn AuthorizationProvider,
+    name: HeaderName,
+    initial: HeaderMap,
+) -> (
+    HeaderValue,
+    HeaderValue,
+    HeaderMap,
+    Option<CredentialProvenance>,
+) {
+    let preparation = provider.prepare().await.unwrap();
+    let mut visible = initial.clone();
+    apply_preparation(&mut visible, &preparation).unwrap();
+    let mutation = preparation
+        .authorizer
+        .authorize(AuthorizationInput {
+            method: &Method::GET,
+            url: &Url::parse("https://example.com/").unwrap(),
+            headers: &visible,
+            body: None,
+        })
+        .await
+        .unwrap();
+    let mut final_headers = visible.clone();
+    for removed in mutation.remove_headers {
+        final_headers.remove(removed);
+    }
+    for (set_name, value) in mutation.set_headers {
+        final_headers.insert(set_name, value);
+    }
+    (
+        visible[&name].clone(),
+        final_headers[&name].clone(),
+        final_headers,
+        preparation.provenance,
+    )
+}
+
+#[test]
+fn secret_debug_output_is_always_redacted() {
+    let secret = SecretString::new("private-token");
+    let credential = TokenCredential::NoStore(secret.clone());
+    assert_eq!(format!("{secret:?}"), "[redacted]");
+    assert!(!format!("{credential:?}").contains("private-token"));
+}
+
+#[tokio::test]
+async fn static_and_bearer_snapshots_remove_conflicting_credentials() {
+    let api_key = HeaderName::from_static("x-api-key");
+    let initial = HeaderMap::from_iter([
+        (AUTHORIZATION, HeaderValue::from_static("Bearer stale")),
+        (api_key.clone(), HeaderValue::from_static("stale-key")),
+    ]);
+    let static_provider = StaticHeaderAuthorizationProvider::new(
+        api_key.clone(),
+        SecretString::new("fresh-key"),
+        vec![AUTHORIZATION],
+        CredentialProvenance::CallerSupplied,
+    );
+    let (visible, final_value, final_headers, provenance) =
+        prepared_and_final_header(&static_provider, api_key.clone(), initial.clone()).await;
+    assert_eq!(visible, "fresh-key");
+    assert_eq!(visible, final_value);
+    assert!(visible.is_sensitive());
+    assert!(!final_headers.contains_key(AUTHORIZATION));
+    assert_eq!(provenance, Some(CredentialProvenance::CallerSupplied));
+
+    let token_provider = Arc::new(RotatingTokenProvider {
+        calls: AtomicUsize::new(0),
+        credential: Arc::new(|call| {
+            TokenCredential::NoStore(SecretString::new(format!("token-{call}")))
+        }),
+    });
+    let bearer = BearerAuthorizationProvider::new(
+        token_provider.clone(),
+        Arc::new(SystemClock),
+        vec![api_key.clone()],
+        CredentialProvenance::ExternalProvider,
+    );
+    let (visible, final_value, final_headers, provenance) =
+        prepared_and_final_header(&bearer, AUTHORIZATION, initial).await;
+    assert_eq!(visible, "Bearer token-1");
+    assert_eq!(visible, final_value);
+    assert!(!final_headers.contains_key(api_key));
+    assert_eq!(provenance, Some(CredentialProvenance::ExternalProvider));
+    assert_eq!(token_provider.calls.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn no_store_token_is_acquired_once_per_operation_and_never_during_authorization() {
+    let token_provider = Arc::new(RotatingTokenProvider {
+        calls: AtomicUsize::new(0),
+        credential: Arc::new(|call| {
+            TokenCredential::NoStore(SecretString::new(format!("token-{call}")))
+        }),
+    });
+    let bearer = BearerAuthorizationProvider::new(
+        token_provider.clone(),
+        Arc::new(SystemClock),
+        Vec::new(),
+        CredentialProvenance::ExternalProvider,
+    );
+    for expected in ["Bearer token-1", "Bearer token-2"] {
+        let (visible, final_value, _, _) =
+            prepared_and_final_header(&bearer, AUTHORIZATION, HeaderMap::new()).await;
+        assert_eq!(visible, expected);
+        assert_eq!(final_value, expected);
+    }
+    assert_eq!(token_provider.calls.load(Ordering::SeqCst), 2);
+}
+
+#[tokio::test]
+async fn known_expiry_is_checked_with_the_injected_clock() {
+    let now = Instant::now();
+    let valid = Arc::new(RotatingTokenProvider {
+        calls: AtomicUsize::new(0),
+        credential: Arc::new(move |_| {
+            TokenCredential::KnownExpiry(TokenLease {
+                token: SecretString::new("valid"),
+                expires_at: now + Duration::from_secs(1),
+            })
+        }),
+    });
+    let valid_bearer = BearerAuthorizationProvider::new(
+        valid,
+        Arc::new(FixedClock(now)),
+        Vec::new(),
+        CredentialProvenance::ExternalProvider,
+    );
+    assert_eq!(
+        valid_bearer.prepare().await.unwrap().visible_headers[AUTHORIZATION],
+        "Bearer valid"
+    );
+
+    let expired = Arc::new(RotatingTokenProvider {
+        calls: AtomicUsize::new(0),
+        credential: Arc::new(move |_| {
+            TokenCredential::KnownExpiry(TokenLease {
+                token: SecretString::new("expired"),
+                expires_at: now,
+            })
+        }),
+    });
+    let expired_bearer = BearerAuthorizationProvider::new(
+        expired,
+        Arc::new(FixedClock(now)),
+        Vec::new(),
+        CredentialProvenance::ExternalProvider,
+    );
+    assert!(
+        matches!(expired_bearer.prepare().await, Err(Error::Auth(message)) if message.contains("expired"))
+    );
+}
+
+struct CountingCredentialAdapter {
+    kind: CredentialKind,
+    builds: Arc<AtomicUsize>,
+}
+
+impl CredentialAdapter for CountingCredentialAdapter {
+    fn kind(&self) -> CredentialKind {
+        self.kind
+    }
+
+    fn build(
+        &self,
+        spec: CredentialSpec,
+        provenance: CredentialProvenance,
+        clock: Arc<dyn Clock>,
+    ) -> Result<Arc<dyn AuthorizationProvider>, Error> {
+        self.builds.fetch_add(1, Ordering::SeqCst);
+        match spec {
+            CredentialSpec::StaticHeader {
+                name,
+                value,
+                conflicts,
+            } => Ok(Arc::new(StaticHeaderAuthorizationProvider::new(
+                name, value, conflicts, provenance,
+            ))),
+            CredentialSpec::Bearer {
+                provider,
+                conflicts,
+            } => Ok(Arc::new(BearerAuthorizationProvider::new(
+                provider, clock, conflicts, provenance,
+            ))),
+        }
+    }
+}
+
+#[tokio::test]
+async fn declared_credential_precedence_selects_before_constructing_or_invoking_losers() {
+    let static_builds = Arc::new(AtomicUsize::new(0));
+    let bearer_builds = Arc::new(AtomicUsize::new(0));
+    let losing_factory_calls = Arc::new(AtomicUsize::new(0));
+    let registry = CredentialAdapterRegistry::new(
+        [
+            Arc::new(CountingCredentialAdapter {
+                kind: CredentialKind::StaticHeader,
+                builds: static_builds.clone(),
+            }) as Arc<dyn CredentialAdapter>,
+            Arc::new(CountingCredentialAdapter {
+                kind: CredentialKind::Bearer,
+                builds: bearer_builds.clone(),
+            }),
+        ],
+        Arc::new(SystemClock),
+    )
+    .unwrap();
+    let losing_calls = losing_factory_calls.clone();
+    let selected = CredentialCandidate::new(
+        CredentialProvenance::CallerSupplied,
+        CredentialKind::StaticHeader,
+        || {
+            Box::pin(async {
+                Ok(CredentialSpec::StaticHeader {
+                    name: HeaderName::from_static("x-api-key"),
+                    value: SecretString::new("winner"),
+                    conflicts: vec![AUTHORIZATION],
+                })
+            })
+        },
+    );
+    let losing = CredentialCandidate::new(
+        CredentialProvenance::EnvironmentVariable("TOKEN".into()),
+        CredentialKind::Bearer,
+        move || {
+            losing_calls.fetch_add(1, Ordering::SeqCst);
+            Box::pin(async { Err(Error::Auth("loser was constructed".into())) })
+        },
+    );
+    let provider = registry.resolve([selected, losing]).await.unwrap();
+    assert_eq!(
+        provider.prepare().await.unwrap().visible_headers["x-api-key"],
+        "winner"
+    );
+    assert_eq!(losing_factory_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(static_builds.load(Ordering::SeqCst), 1);
+    assert_eq!(bearer_builds.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn builtin_registry_dispatches_static_header_and_bearer_specs() {
+    let registry = CredentialAdapterRegistry::with_builtin_adapters(Arc::new(SystemClock));
+    let static_provider = registry
+        .resolve([CredentialCandidate::new(
+            CredentialProvenance::CallerSupplied,
+            CredentialKind::StaticHeader,
+            || {
+                Box::pin(async {
+                    Ok(CredentialSpec::StaticHeader {
+                        name: HeaderName::from_static("x-api-key"),
+                        value: SecretString::new("static"),
+                        conflicts: vec![AUTHORIZATION],
+                    })
+                })
+            },
+        )])
+        .await
+        .unwrap();
+    assert_eq!(
+        static_provider.prepare().await.unwrap().visible_headers["x-api-key"],
+        "static"
+    );
+
+    let token_provider = Arc::new(RotatingTokenProvider {
+        calls: AtomicUsize::new(0),
+        credential: Arc::new(|_| TokenCredential::NoStore(SecretString::new("bearer"))),
+    });
+    let bearer_provider = registry
+        .resolve([CredentialCandidate::new(
+            CredentialProvenance::ExternalProvider,
+            CredentialKind::Bearer,
+            move || {
+                Box::pin(async {
+                    Ok(CredentialSpec::Bearer {
+                        provider: token_provider,
+                        conflicts: vec![HeaderName::from_static("x-api-key")],
+                    })
+                })
+            },
+        )])
+        .await
+        .unwrap();
+    assert_eq!(
+        bearer_provider.prepare().await.unwrap().visible_headers[AUTHORIZATION],
+        "Bearer bearer"
+    );
+}
+
+#[tokio::test]
+async fn concurrent_operations_keep_each_bearer_snapshot_isolated() {
+    let token_provider = Arc::new(RotatingTokenProvider {
+        calls: AtomicUsize::new(0),
+        credential: Arc::new(|call| {
+            TokenCredential::NoStore(SecretString::new(format!("token-{call}")))
+        }),
+    });
+    let bearer = Arc::new(BearerAuthorizationProvider::new(
+        token_provider.clone(),
+        Arc::new(SystemClock),
+        Vec::new(),
+        CredentialProvenance::ExternalProvider,
+    ));
+    let operations = (0..16).map(|_| {
+        let bearer = bearer.clone();
+        tokio::spawn(async move {
+            let (visible, final_value, _, _) =
+                prepared_and_final_header(bearer.as_ref(), AUTHORIZATION, HeaderMap::new()).await;
+            (
+                visible.to_str().unwrap().to_owned(),
+                final_value.to_str().unwrap().to_owned(),
+            )
+        })
+    });
+    let results = futures_util::future::join_all(operations).await;
+    let snapshots: HashSet<_> = results
+        .into_iter()
+        .map(|result| {
+            let (visible, final_value) = result.unwrap();
+            assert_eq!(visible, final_value);
+            visible
+        })
+        .collect();
+    assert_eq!(snapshots.len(), 16);
+    assert_eq!(token_provider.calls.load(Ordering::SeqCst), 16);
+}

--- a/litellm-rust/crates/python-bridge/src/auth.rs
+++ b/litellm-rust/crates/python-bridge/src/auth.rs
@@ -1,0 +1,351 @@
+use std::num::NonZeroUsize;
+use std::sync::Mutex;
+
+use litellm_core::auth::{OperationFuture, SecretString, TokenCredential, TokenProvider};
+use litellm_python_interop::callback_runtime::{
+    AsyncContext, CallbackRuntime, CallbackZero, Direct, SyncContext,
+};
+use pyo3::prelude::*;
+
+use crate::constants::AUTH_CALLBACK_CAPACITY;
+
+#[pyclass(frozen)]
+struct AuthCallbackRuntime(CallbackRuntime);
+
+pub(crate) fn register(module: &Bound<'_, PyModule>) -> PyResult<()> {
+    let capacity = NonZeroUsize::new(AUTH_CALLBACK_CAPACITY)
+        .expect("auth callback capacity is a positive constant");
+    module.add(
+        "__auth_callback_runtime__",
+        AuthCallbackRuntime(CallbackRuntime::new(module, capacity)?),
+    )
+}
+
+enum PythonTokenSession {
+    Sync {
+        callback: CallbackZero<String, Direct>,
+        context: SyncContext,
+    },
+    Async {
+        callback: CallbackZero<String, Direct>,
+        context: AsyncContext,
+    },
+}
+
+pub struct PythonTokenProvider {
+    session: tokio::sync::Mutex<PythonTokenSession>,
+    original_error: Mutex<Option<PyErr>>,
+}
+
+impl PythonTokenProvider {
+    pub fn new(
+        module: &Bound<'_, PyModule>,
+        callable: Py<PyAny>,
+        py: Python<'_>,
+        asynchronous: bool,
+    ) -> PyResult<Self> {
+        let runtime = module
+            .getattr("__auth_callback_runtime__")?
+            .extract::<PyRef<'_, AuthCallbackRuntime>>()?
+            .0
+            .clone();
+        let callback = CallbackZero::new(callable.bind(py).clone())?;
+        let session = if asynchronous {
+            PythonTokenSession::Async {
+                callback,
+                context: runtime.async_context(py)?,
+            }
+        } else {
+            PythonTokenSession::Sync {
+                callback,
+                context: runtime.sync_context(py)?,
+            }
+        };
+        Ok(Self {
+            session: tokio::sync::Mutex::new(session),
+            original_error: Mutex::new(None),
+        })
+    }
+
+    pub fn take_original_error(&self) -> Option<PyErr> {
+        self.original_error
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take()
+    }
+
+    async fn resolve(&self) -> Result<String, litellm_core::Error> {
+        let result = match &mut *self.session.lock().await {
+            PythonTokenSession::Sync { callback, context } => callback.call(context).await,
+            PythonTokenSession::Async { callback, context } => callback.call(context).await,
+        };
+        match result {
+            Ok(token) => Ok(token),
+            Err(error) => {
+                *self
+                    .original_error
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(error);
+                Err(litellm_core::Error::Auth(
+                    "caller-supplied token provider failed".into(),
+                ))
+            }
+        }
+    }
+}
+
+impl TokenProvider for PythonTokenProvider {
+    fn token(&self) -> OperationFuture<'_, TokenCredential> {
+        Box::pin(async move {
+            self.resolve()
+                .await
+                .map(|token| TokenCredential::NoStore(SecretString::new(token)))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::CString;
+    use std::sync::Arc;
+
+    use pyo3::exceptions::PyRuntimeError;
+    use pyo3::types::{PyDict, PyModule};
+
+    use super::*;
+    use crate::execution;
+
+    #[pyclass]
+    struct AuthHarness {
+        module: Py<PyModule>,
+    }
+
+    #[pymethods]
+    impl AuthHarness {
+        fn resolve_sync(&self, py: Python<'_>, callable: Py<PyAny>) -> PyResult<Py<PyAny>> {
+            let provider = Arc::new(PythonTokenProvider::new(
+                self.module.bind(py),
+                callable,
+                py,
+                false,
+            )?);
+            execution::run_sync(py, resolve_token(provider), |error| error)
+        }
+
+        fn resolve_async<'py>(
+            &self,
+            py: Python<'py>,
+            callable: Py<PyAny>,
+        ) -> PyResult<Bound<'py, PyAny>> {
+            let provider = Arc::new(PythonTokenProvider::new(
+                self.module.bind(py),
+                callable,
+                py,
+                true,
+            )?);
+            execution::run_async(py, resolve_token(provider), |error| error)
+        }
+    }
+
+    async fn resolve_token(provider: Arc<PythonTokenProvider>) -> PyResult<String> {
+        match provider.token().await {
+            Ok(TokenCredential::NoStore(token)) => Ok(token.expose().to_owned()),
+            Ok(TokenCredential::KnownExpiry(_)) => Err(PyRuntimeError::new_err(
+                "Python token providers must return no-store credentials",
+            )),
+            Err(error) => Err(provider
+                .take_original_error()
+                .unwrap_or_else(|| PyRuntimeError::new_err(error.to_string()))),
+        }
+    }
+
+    fn test_module(py: Python<'_>) -> Bound<'_, PyModule> {
+        let module = PyModule::new(py, "auth_test").expect("module should be created");
+        litellm_python_interop::callback_runtime::register(&module)
+            .expect("callback runtime should register");
+        register(&module).expect("auth runtime should register");
+        module
+            .add(
+                "harness",
+                AuthHarness {
+                    module: module.clone().unbind(),
+                },
+            )
+            .expect("harness should register");
+        module
+    }
+
+    #[test]
+    fn sync_provider_is_zero_argument_context_bound_and_preserves_errors() {
+        Python::initialize();
+        Python::attach(|py| {
+            let module = test_module(py);
+            let locals = PyDict::new(py);
+            locals
+                .set_item("auth", &module)
+                .expect("module should enter Python locals");
+            let code = CString::new(
+                r#"
+import contextvars
+import gc
+import threading
+import traceback
+import weakref
+from concurrent.futures import ThreadPoolExecutor
+
+scope = contextvars.ContextVar("scope")
+scope.set("caller-context")
+caller_thread = threading.get_ident()
+calls = 0
+
+def token(*args):
+    global calls
+    calls += 1
+    assert args == ()
+    assert scope.get() == "caller-context"
+    assert threading.get_ident() == caller_thread
+    return "sync-secret"
+
+assert auth.harness.resolve_sync(token) == "sync-secret"
+assert calls == 1
+
+class RetainedToken:
+    def __call__(self):
+        return "retained"
+
+retained = RetainedToken()
+reference = weakref.ref(retained)
+assert auth.harness.resolve_sync(retained) == "retained"
+del retained
+gc.collect()
+assert reference() is None
+
+def resolve_one(index):
+    expected = f"worker-{index}"
+    scope.set(expected)
+    caller = threading.get_ident()
+    invocation_count = 0
+
+    def concurrent_token(*args):
+        nonlocal invocation_count
+        invocation_count += 1
+        assert args == ()
+        assert scope.get() == expected
+        assert threading.get_ident() == caller
+        return expected
+
+    assert auth.harness.resolve_sync(concurrent_token) == expected
+    assert invocation_count == 1
+    return expected
+
+with ThreadPoolExecutor(max_workers=8) as executor:
+    assert list(executor.map(resolve_one, range(16))) == [
+        f"worker-{index}" for index in range(16)
+    ]
+
+original = LookupError("original-token-error")
+def fail():
+    raise original
+
+try:
+    auth.harness.resolve_sync(fail)
+except BaseException as error:
+    assert error is original
+    assert "fail" in "".join(traceback.format_tb(error.__traceback__))
+else:
+    raise AssertionError("original exception was not raised")
+"#,
+            )
+            .expect("Python source should not contain null bytes");
+            py.run(&code, Some(&locals), Some(&locals))
+                .expect("sync provider behavior should hold");
+        });
+    }
+
+    #[test]
+    fn async_providers_preserve_context_lifetime_concurrency_and_operation_count() {
+        Python::initialize();
+        Python::attach(|py| {
+            let module = test_module(py);
+            let locals = PyDict::new(py);
+            locals
+                .set_item("auth", &module)
+                .expect("module should enter Python locals");
+            let code = CString::new(
+                r#"
+import asyncio
+import contextvars
+import gc
+import weakref
+
+scope = contextvars.ContextVar("scope")
+
+class Token:
+    def __init__(self, expected):
+        self.expected = expected
+        self.calls = 0
+
+    def __call__(self, *args):
+        self.calls += 1
+        assert args == ()
+        assert scope.get() == self.expected
+        asyncio.get_running_loop()
+        return f"token-{self.expected}"
+
+async def resolve_one(index):
+    expected = f"context-{index}"
+    scope.set(expected)
+    provider = Token(expected)
+    value = await auth.harness.resolve_async(provider)
+    assert provider.calls == 1
+    return value
+
+async def exercise():
+    values = await asyncio.gather(*(resolve_one(index) for index in range(32)))
+    assert values == [f"token-context-{index}" for index in range(32)]
+
+    scope.set("repeat")
+    repeated = Token("repeat")
+    assert await auth.harness.resolve_async(repeated) == "token-repeat"
+    assert await auth.harness.resolve_async(repeated) == "token-repeat"
+    assert repeated.calls == 2
+
+    scope.set("lifetime")
+    retained = Token("lifetime")
+    reference = weakref.ref(retained)
+    pending = auth.harness.resolve_async(retained)
+    del retained
+    gc.collect()
+    assert reference() is not None
+    assert await pending == "token-lifetime"
+    for _ in range(3):
+        gc.collect()
+        await asyncio.sleep(0)
+    assert reference() is None
+
+    original = RuntimeError("async-original-token-error")
+    def fail():
+        raise original
+    try:
+        await auth.harness.resolve_async(fail)
+    except BaseException as error:
+        assert error is original
+    else:
+        raise AssertionError("original async exception was not raised")
+
+    try:
+        await auth.harness.resolve_async(lambda: 42)
+    except TypeError as error:
+        assert str(error) == "hook result does not match its typed contract"
+    else:
+        raise AssertionError("invalid token result was accepted")
+
+asyncio.run(exercise())
+"#,
+            )
+            .expect("Python source should not contain null bytes");
+            py.run(&code, Some(&locals), Some(&locals))
+                .expect("async provider behavior should hold");
+        });
+    }
+}

--- a/litellm-rust/crates/python-bridge/src/constants.rs
+++ b/litellm-rust/crates/python-bridge/src/constants.rs
@@ -1,1 +1,2 @@
 pub(crate) const OCR_CALLBACK_CAPACITY: usize = 1024;
+pub(crate) const AUTH_CALLBACK_CAPACITY: usize = 1024;

--- a/litellm-rust/crates/python-bridge/src/lib.rs
+++ b/litellm-rust/crates/python-bridge/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod auth;
 mod callback_bindings;
 #[cfg(test)]
 #[path = "../tests/callbacks/mod.rs"]
@@ -161,6 +162,7 @@ mod _native {
 
         litellm_python_interop::callback_runtime::register(module)?;
         super::callback_bindings::register(module)?;
+        super::auth::register(module)?;
         super::ocr_callbacks::register(module)?;
         super::errors::register(module)?;
         let ready_endpoints = PyDict::new(module.py());

--- a/litellm-rust/crates/python-interop/src/callback_runtime/invoke.py
+++ b/litellm-rust/crates/python-interop/src/callback_runtime/invoke.py
@@ -13,6 +13,15 @@ def invoke_direct(callback: Callable[[object], object], payload: object) -> obje
     return result
 
 
+def invoke_direct_zero(callback: Callable[[], object]) -> object:
+    result: Final = callback()
+    if inspect.isawaitable(result):
+        if inspect.iscoroutine(result):
+            result.close()
+        raise TypeError("direct hook returned an awaitable")
+    return result
+
+
 class Invocation:
     def __init__(
         self,
@@ -20,11 +29,13 @@ class Invocation:
         payload: object,
         returns_awaitable: bool,
         admission: object,
+        zero_arguments: bool = False,
     ) -> None:
         self.callback = callback
         self.payload = payload
         self.returns_awaitable = returns_awaitable
         self.admission: object | None = admission
+        self.zero_arguments = zero_arguments
         self.task: asyncio.Task[object] | None = None
         self.cancelled = False
 
@@ -34,8 +45,10 @@ class Invocation:
             if self.cancelled:
                 raise asyncio.CancelledError()
             if not self.returns_awaitable:
+                if self.zero_arguments:
+                    return invoke_direct_zero(self.callback)
                 return invoke_direct(self.callback, self.payload)
-            result: Final = self.callback(self.payload)
+            result: Final = self.callback() if self.zero_arguments else self.callback(self.payload)
             if not inspect.isawaitable(result):
                 raise TypeError("awaitable hook returned a non-awaitable")
             return await cast(Awaitable[object], result)

--- a/litellm-rust/crates/python-interop/src/callback_runtime/mod.rs
+++ b/litellm-rust/crates/python-interop/src/callback_runtime/mod.rs
@@ -35,11 +35,45 @@ pub trait CallbackContext<M: ReturnMode>: Send {
         callable: Py<PyAny>,
         payload: Py<PyAny>,
     ) -> impl Future<Output = PyResult<Py<PyAny>>> + Send;
+    fn invoke_zero(
+        &mut self,
+        callable: Py<PyAny>,
+    ) -> impl Future<Output = PyResult<Py<PyAny>>> + Send;
 }
 
 pub struct Callback<I, O, M> {
     callable: Py<PyAny>,
     signature: PhantomData<fn(I) -> (O, M)>,
+}
+
+pub struct CallbackZero<O, M> {
+    callable: Py<PyAny>,
+    signature: PhantomData<fn() -> (O, M)>,
+}
+
+impl<O, M> CallbackZero<O, M>
+where
+    O: DeserializeOwned + Send,
+    M: ReturnMode,
+{
+    pub fn new(callable: Bound<'_, PyAny>) -> PyResult<Self> {
+        if !callable.is_callable() {
+            return Err(PyTypeError::new_err("hook binding must be callable"));
+        }
+        Ok(Self {
+            callable: callable.unbind(),
+            signature: PhantomData,
+        })
+    }
+
+    pub async fn call<C: CallbackContext<M>>(&mut self, context: &mut C) -> PyResult<O> {
+        let callable = Python::attach(|py| self.callable.clone_ref(py));
+        let result = context.invoke_zero(callable).await?;
+        Python::attach(|py| {
+            from_py(result.bind(py))
+                .map_err(|_| PyTypeError::new_err("hook result does not match its typed contract"))
+        })
+    }
 }
 
 impl<I, O, M> Callback<I, O, M>
@@ -86,6 +120,7 @@ pub fn register(module: &Bound<'_, PyModule>) -> PyResult<()> {
 struct RuntimeState {
     invocation: Py<PyAny>,
     direct: Py<PyAny>,
+    direct_zero: Py<PyAny>,
     capacity: Arc<Semaphore>,
 }
 
@@ -103,6 +138,7 @@ impl CallbackRuntime {
         Ok(Self(Arc::new(RuntimeState {
             invocation: shim.getattr("Invocation")?.unbind(),
             direct: shim.getattr("invoke_direct")?.unbind(),
+            direct_zero: shim.getattr("invoke_direct_zero")?.unbind(),
             capacity: Arc::new(Semaphore::new(max_in_flight.get())),
         })))
     }
@@ -152,6 +188,19 @@ impl CallbackContext<Direct> for SyncContext {
                 .call_method1(py, "run", (&self.runtime.0.direct, callable, payload))
         })
     }
+
+    async fn invoke_zero(&mut self, callable: Py<PyAny>) -> PyResult<Py<PyAny>> {
+        if thread::current().id() != self.caller {
+            return Err(PyRuntimeError::new_err(
+                "synchronous callbacks must run on the caller thread",
+            ));
+        }
+        let _permit = self.runtime.admit()?;
+        Python::attach(|py| {
+            self.context
+                .call_method1(py, "run", (&self.runtime.0.direct_zero, callable))
+        })
+    }
 }
 
 pub struct AsyncContext {
@@ -167,6 +216,25 @@ struct Admission {
 
 impl<M: ReturnMode> CallbackContext<M> for AsyncContext {
     async fn invoke(&mut self, callable: Py<PyAny>, payload: Py<PyAny>) -> PyResult<Py<PyAny>> {
+        self.invoke_with_arguments(callable, payload, M::AWAITABLE, false)
+            .await
+    }
+
+    async fn invoke_zero(&mut self, callable: Py<PyAny>) -> PyResult<Py<PyAny>> {
+        let payload = Python::attach(|py| py.None());
+        self.invoke_with_arguments(callable, payload, M::AWAITABLE, true)
+            .await
+    }
+}
+
+impl AsyncContext {
+    async fn invoke_with_arguments(
+        &mut self,
+        callable: Py<PyAny>,
+        payload: Py<PyAny>,
+        returns_awaitable: bool,
+        zero_arguments: bool,
+    ) -> PyResult<Py<PyAny>> {
         if self.interrupted {
             return Err(PyRuntimeError::new_err("callback session was cancelled"));
         }
@@ -177,8 +245,9 @@ impl<M: ReturnMode> CallbackContext<M> for AsyncContext {
                 (
                     callable,
                     payload,
-                    M::AWAITABLE,
+                    returns_awaitable,
                     Admission { _permit: permit },
+                    zero_arguments,
                 ),
             )?;
             let cancellation = CancelOnDrop {


### PR DESCRIPTION
## TLDR

Problem this solves:

- Cloud credential lifecycle rules were implicit

How it solves it:

- Add shared discovery, expiry, and isolation contracts

## User Flow

Before: the SDK request can violate this layer contract.

1. They configure Azure or Google credentials and send concurrent calls.
2. Selection and reuse remain provider-specific.

After: the same request follows one predictable contract.

1. They configure the same credentials and send the same calls.
2. Discovery, expiry, precedence, and isolation are shared.

## Relevant issues

- Stack root: #39928

## Linear ticket


## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] Focused tests covering this change pass locally
- [ ] All required CI/CD checks pass
- [x] This PR is isolated to one stack responsibility
- [ ] Greptile Confidence Score is at least 4/5

## Stack

`39928 -> 39913 -> 39923 -> 39941 -> 39939 -> 39484 -> 39986 -> 39646 -> 39987 -> 39782 -> 39765`

Layer 10 of 11.

## Screenshots / Proof of Fix

### After (`e1aa27990a32e8fc8a62e7d25bfb8afef69eb69d`)

1. Credential discovery, expiry, cancellation, and concurrency tests: passed
2. `UV_PYTHON=3.12 make check`: passed
3. Final stack Rust workspace and strict Clippy: passed

No paid-provider calls were used for deterministic validation.

## Type

New Feature; Refactoring

## Caveats (if any)

### Medium

- The registry inventories methods but not every cloud exchange; live smokes were unavailable.

## Final Attestation

- [x] Tests cover this layer intended contracts and edge cases




