### PR TITLE
feat(auth): bridge Python token providers into Rust

### DIFF
--- a/litellm-rust/Cargo.lock
+++ b/litellm-rust/Cargo.lock
@@ -1439,6 +1439,7 @@ dependencies = [
 name = "litellm-core"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "aws-config",
  "aws-credential-types",
  "aws-sdk-sts",

--- a/litellm-rust/Cargo.lock
+++ b/litellm-rust/Cargo.lock
@@ -1463,6 +1463,7 @@ dependencies = [
 name = "litellm-python-bridge"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "criterion",
  "futures-util",
  "litellm-ai-gateway",

--- a/litellm-rust/crates/ai-gateway/src/trace_parity.rs
+++ b/litellm-rust/crates/ai-gateway/src/trace_parity.rs
@@ -47,10 +47,10 @@ pub async fn messages_request(
         .header(CONTENT_TYPE, "application/json")
         .body(Body::from(body.to_string()))
         .map_err(|error| Error::InvalidRequest(error.to_string()))?;
-    let response = routes::app(state)
-        .oneshot(request)
-        .await
-        .map_err(|error| match error {})?;
+    let response = match routes::app(state).oneshot(request).await {
+        Ok(response) => response,
+        Err(error) => match error {},
+    };
     let status: StatusCode = response.status();
     let bytes = to_bytes(response.into_body(), usize::MAX)
         .await

--- a/litellm-rust/crates/core/Cargo.toml
+++ b/litellm-rust/crates/core/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+async-trait = "0.1"
 base64.workspace = true
 rand.workspace = true
 reqwest.workspace = true
@@ -13,6 +14,7 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+tokio = { workspace = true, features = ["sync", "rt"] }
 tracing-subscriber = { workspace = true, optional = true }
 sha2.workspace = true
 aws-config = { version = "1.9.0", default-features = false, features = ["rustls", "rt-tokio"], optional = true }

--- a/litellm-rust/crates/core/src/auth.rs
+++ b/litellm-rust/crates/core/src/auth.rs
@@ -103,9 +103,15 @@ pub struct TokenLease {
     pub expires_at: Instant,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TokenCredential {
+    Cached(TokenLease),
+    NoStore(SecretString),
+}
+
 #[async_trait]
 pub trait TokenProvider: Send + Sync {
-    async fn token(&self) -> Result<TokenLease, AuthError>;
+    async fn token(&self) -> Result<TokenCredential, AuthError>;
 }
 
 #[derive(Clone, PartialEq, Eq, Hash)]
@@ -201,7 +207,7 @@ impl TokenCache {
         let cache = self.clone();
         tokio::spawn(async move {
             let _guard = guard;
-            if let Ok(lease) = provider.token().await
+            if let Ok(TokenCredential::Cached(lease)) = provider.token().await
                 && lease.expires_at > cache.clock.now()
             {
                 *entry.lease.write().await = Some(lease);
@@ -221,7 +227,10 @@ impl TokenCache {
         {
             return Ok(lease.token.clone());
         }
-        let lease = provider.token().await?;
+        let lease = match provider.token().await? {
+            TokenCredential::Cached(lease) => lease,
+            TokenCredential::NoStore(token) => return Ok(token),
+        };
         if lease.expires_at <= self.clock.now() {
             return Err(AuthError::new(
                 AuthErrorKind::CredentialUnavailable,
@@ -393,12 +402,24 @@ mod tests {
 
     #[async_trait]
     impl TokenProvider for CountingProvider {
-        async fn token(&self) -> Result<TokenLease, AuthError> {
+        async fn token(&self) -> Result<TokenCredential, AuthError> {
             let call = self.calls.fetch_add(1, Ordering::SeqCst) + 1;
-            Ok(TokenLease {
+            Ok(TokenCredential::Cached(TokenLease {
                 token: SecretString::new(format!("token-{call}")),
                 expires_at: self.clock.now() + Duration::from_secs(60),
-            })
+            }))
+        }
+    }
+
+    struct NoStoreProvider(AtomicUsize);
+
+    #[async_trait]
+    impl TokenProvider for NoStoreProvider {
+        async fn token(&self) -> Result<TokenCredential, AuthError> {
+            let call = self.0.fetch_add(1, Ordering::SeqCst) + 1;
+            Ok(TokenCredential::NoStore(SecretString::new(format!(
+                "token-{call}"
+            ))))
         }
     }
 
@@ -421,6 +442,28 @@ mod tests {
             assert_eq!(request.await.unwrap().expose(), "token-1");
         }
         assert_eq!(provider.calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn no_store_credentials_are_resolved_for_each_request() {
+        let clock = Arc::new(TestClock(StdMutex::new(Instant::now())));
+        let cache = Arc::new(TokenCache::new(Duration::from_secs(10), clock));
+        let provider = Arc::new(NoStoreProvider(AtomicUsize::new(0)));
+        let key = TokenCacheKey::fingerprint([b"provider".as_slice()]);
+
+        assert_eq!(
+            cache
+                .token(key.clone(), provider.clone())
+                .await
+                .unwrap()
+                .expose(),
+            "token-1"
+        );
+        assert_eq!(
+            cache.token(key, provider.clone()).await.unwrap().expose(),
+            "token-2"
+        );
+        assert_eq!(provider.0.load(Ordering::SeqCst), 2);
     }
 
     #[test]

--- a/litellm-rust/crates/core/src/auth.rs
+++ b/litellm-rust/crates/core/src/auth.rs
@@ -1,0 +1,432 @@
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
+use reqwest::{Method, Url};
+use sha2::{Digest, Sha256};
+use thiserror::Error as ThisError;
+use tokio::sync::{Mutex, RwLock};
+
+use crate::Error;
+
+pub trait Environment: Send + Sync {
+    fn get(&self, name: &str) -> Option<String>;
+}
+
+impl<F> Environment for F
+where
+    F: Fn(&str) -> Option<String> + Send + Sync,
+{
+    fn get(&self, name: &str) -> Option<String> {
+        self(name)
+    }
+}
+
+pub trait Clock: Send + Sync {
+    fn now(&self) -> Instant;
+}
+
+#[derive(Debug)]
+pub struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now(&self) -> Instant {
+        Instant::now()
+    }
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct SecretString(String);
+
+impl SecretString {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    pub fn expose(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for SecretString {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("[redacted]")
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AuthErrorKind {
+    MissingCredential,
+    InvalidConfiguration,
+    CredentialUnavailable,
+    ExternalProviderFailed,
+    InvalidHeader,
+    SigningFailed,
+    UnsupportedMode,
+    CrossOriginReplay,
+}
+
+#[derive(Clone, Debug, ThisError, PartialEq, Eq)]
+#[error("{message}")]
+pub struct AuthError {
+    pub kind: AuthErrorKind,
+    pub code: &'static str,
+    message: String,
+}
+
+impl AuthError {
+    pub fn new(kind: AuthErrorKind, code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            code,
+            message: message.into(),
+        }
+    }
+}
+
+impl From<AuthError> for Error {
+    fn from(error: AuthError) -> Self {
+        match error.kind {
+            AuthErrorKind::UnsupportedMode => Error::Unsupported(error.code),
+            AuthErrorKind::CrossOriginReplay => Error::InvalidResponse(error.to_string()),
+            _ => Error::Auth(error.to_string()),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TokenLease {
+    pub token: SecretString,
+    pub expires_at: Instant,
+}
+
+#[async_trait]
+pub trait TokenProvider: Send + Sync {
+    async fn token(&self) -> Result<TokenLease, AuthError>;
+}
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct TokenCacheKey([u8; 32]);
+
+impl TokenCacheKey {
+    pub fn fingerprint<'a>(parts: impl IntoIterator<Item = &'a [u8]>) -> Self {
+        let mut hasher = Sha256::new();
+        for part in parts {
+            hasher.update(part.len().to_le_bytes());
+            hasher.update(part);
+        }
+        Self(hasher.finalize().into())
+    }
+}
+
+impl fmt::Debug for TokenCacheKey {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("TokenCacheKey([redacted])")
+    }
+}
+
+struct TokenEntry {
+    lease: RwLock<Option<TokenLease>>,
+    refresh: Arc<Mutex<()>>,
+}
+
+impl TokenEntry {
+    fn new() -> Self {
+        Self {
+            lease: RwLock::new(None),
+            refresh: Arc::new(Mutex::new(())),
+        }
+    }
+}
+
+pub struct TokenCache {
+    entries: Mutex<HashMap<TokenCacheKey, Arc<TokenEntry>>>,
+    refresh_before: Duration,
+    clock: Arc<dyn Clock>,
+}
+
+impl fmt::Debug for TokenCache {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("TokenCache")
+            .field("refresh_before", &self.refresh_before)
+            .finish_non_exhaustive()
+    }
+}
+
+impl TokenCache {
+    pub fn new(refresh_before: Duration, clock: Arc<dyn Clock>) -> Self {
+        Self {
+            entries: Mutex::new(HashMap::new()),
+            refresh_before,
+            clock,
+        }
+    }
+
+    async fn entry(&self, key: TokenCacheKey) -> Arc<TokenEntry> {
+        let mut entries = self.entries.lock().await;
+        entries
+            .entry(key)
+            .or_insert_with(|| Arc::new(TokenEntry::new()))
+            .clone()
+    }
+
+    pub async fn token(
+        self: &Arc<Self>,
+        key: TokenCacheKey,
+        provider: Arc<dyn TokenProvider>,
+    ) -> Result<SecretString, AuthError> {
+        let entry = self.entry(key).await;
+        let now = self.clock.now();
+        let cached = entry.lease.read().await.clone();
+        if let Some(lease) = cached.as_ref() {
+            if lease.expires_at.saturating_duration_since(now) > self.refresh_before {
+                return Ok(lease.token.clone());
+            }
+            if lease.expires_at > now {
+                self.refresh_stale(entry, provider);
+                return Ok(lease.token.clone());
+            }
+        }
+        self.refresh_invalid(entry, provider).await
+    }
+
+    fn refresh_stale(self: &Arc<Self>, entry: Arc<TokenEntry>, provider: Arc<dyn TokenProvider>) {
+        let Ok(guard) = entry.refresh.clone().try_lock_owned() else {
+            return;
+        };
+        let cache = self.clone();
+        tokio::spawn(async move {
+            let _guard = guard;
+            if let Ok(lease) = provider.token().await
+                && lease.expires_at > cache.clock.now()
+            {
+                *entry.lease.write().await = Some(lease);
+            }
+        });
+    }
+
+    async fn refresh_invalid(
+        &self,
+        entry: Arc<TokenEntry>,
+        provider: Arc<dyn TokenProvider>,
+    ) -> Result<SecretString, AuthError> {
+        let _guard = entry.refresh.lock().await;
+        let now = self.clock.now();
+        if let Some(lease) = entry.lease.read().await.as_ref()
+            && lease.expires_at > now
+        {
+            return Ok(lease.token.clone());
+        }
+        let lease = provider.token().await?;
+        if lease.expires_at <= self.clock.now() {
+            return Err(AuthError::new(
+                AuthErrorKind::CredentialUnavailable,
+                "expired_token",
+                "credential provider returned an expired token",
+            ));
+        }
+        let token = lease.token.clone();
+        *entry.lease.write().await = Some(lease);
+        Ok(token)
+    }
+
+    pub async fn invalidate(&self, key: &TokenCacheKey) {
+        if let Some(entry) = self.entries.lock().await.get(key).cloned() {
+            *entry.lease.write().await = None;
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct AuthRuntime {
+    pub environment: Arc<dyn Environment>,
+    pub clock: Arc<dyn Clock>,
+    pub tokens: Arc<TokenCache>,
+}
+
+pub struct AuthInput<'a> {
+    pub explicit_api_key: Option<&'a str>,
+    pub forwarded_headers: &'a HeaderMap,
+    pub external_token_provider: Option<Arc<dyn TokenProvider>>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ReplayPolicy {
+    Never,
+    SameOrigin,
+}
+
+pub struct AuthorizeRequest<'a> {
+    pub method: &'a Method,
+    pub url: &'a Url,
+    pub headers: HeaderMap,
+    pub serialized_body: Option<&'a [u8]>,
+}
+
+#[async_trait]
+pub trait RequestAuthorizer: Send + Sync {
+    async fn authorize(&self, request: AuthorizeRequest<'_>) -> Result<HeaderMap, AuthError>;
+}
+
+#[async_trait]
+pub trait Authenticator: Send + Sync {
+    async fn authenticate(
+        &self,
+        input: AuthInput<'_>,
+        runtime: &AuthRuntime,
+    ) -> Result<AuthSession, AuthError>;
+}
+
+pub trait AuthenticatedProvider: Sync {
+    fn authenticator(&self) -> &dyn Authenticator;
+}
+
+pub struct AuthSession {
+    authorizer: Arc<dyn RequestAuthorizer>,
+    replay: ReplayPolicy,
+    origin: Option<(String, String, u16)>,
+}
+
+impl AuthSession {
+    pub fn new(authorizer: Arc<dyn RequestAuthorizer>, replay: ReplayPolicy) -> Self {
+        Self {
+            authorizer,
+            replay,
+            origin: None,
+        }
+    }
+
+    pub fn bind(mut self, url: &Url) -> Self {
+        self.origin = request_origin(url);
+        self
+    }
+
+    pub async fn authorize_primary(
+        &self,
+        request: AuthorizeRequest<'_>,
+    ) -> Result<HeaderMap, AuthError> {
+        self.authorizer.authorize(request).await
+    }
+
+    pub async fn authorize_follow_up(
+        &self,
+        request: AuthorizeRequest<'_>,
+    ) -> Result<HeaderMap, AuthError> {
+        if self.replay != ReplayPolicy::SameOrigin || self.origin != request_origin(request.url) {
+            return Err(AuthError::new(
+                AuthErrorKind::CrossOriginReplay,
+                "cross_origin_auth_replay",
+                "refusing to replay provider credentials to another origin",
+            ));
+        }
+        self.authorizer.authorize(request).await
+    }
+}
+
+fn request_origin(url: &Url) -> Option<(String, String, u16)> {
+    Some((
+        url.scheme().to_string(),
+        url.host_str()?.to_ascii_lowercase(),
+        url.port_or_known_default()?,
+    ))
+}
+
+pub struct StaticHeaderAuthorizer {
+    name: HeaderName,
+    value: SecretString,
+    conflicts: Vec<HeaderName>,
+}
+
+impl StaticHeaderAuthorizer {
+    pub fn new(name: HeaderName, value: SecretString, conflicts: Vec<HeaderName>) -> Self {
+        Self {
+            name,
+            value,
+            conflicts,
+        }
+    }
+}
+
+#[async_trait]
+impl RequestAuthorizer for StaticHeaderAuthorizer {
+    async fn authorize(&self, request: AuthorizeRequest<'_>) -> Result<HeaderMap, AuthError> {
+        let mut headers = request.headers;
+        for name in &self.conflicts {
+            headers.remove(name);
+        }
+        let mut value = HeaderValue::from_str(self.value.expose()).map_err(|_| {
+            AuthError::new(
+                AuthErrorKind::InvalidHeader,
+                "invalid_credential_header",
+                "credential contains bytes that cannot be used in an HTTP header",
+            )
+        })?;
+        value.set_sensitive(true);
+        headers.insert(self.name.clone(), value);
+        Ok(headers)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex as StdMutex;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+
+    struct TestClock(StdMutex<Instant>);
+
+    impl Clock for TestClock {
+        fn now(&self) -> Instant {
+            *self.0.lock().unwrap()
+        }
+    }
+
+    struct CountingProvider {
+        calls: AtomicUsize,
+        clock: Arc<TestClock>,
+    }
+
+    #[async_trait]
+    impl TokenProvider for CountingProvider {
+        async fn token(&self) -> Result<TokenLease, AuthError> {
+            let call = self.calls.fetch_add(1, Ordering::SeqCst) + 1;
+            Ok(TokenLease {
+                token: SecretString::new(format!("token-{call}")),
+                expires_at: self.clock.now() + Duration::from_secs(60),
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn invalid_requests_share_one_refresh() {
+        let clock = Arc::new(TestClock(StdMutex::new(Instant::now())));
+        let cache = Arc::new(TokenCache::new(Duration::from_secs(10), clock.clone()));
+        let provider = Arc::new(CountingProvider {
+            calls: AtomicUsize::new(0),
+            clock,
+        });
+        let key = TokenCacheKey::fingerprint([b"provider".as_slice(), b"principal".as_slice()]);
+        let requests = (0..8).map(|_| {
+            let cache = cache.clone();
+            let provider = provider.clone();
+            let key = key.clone();
+            tokio::spawn(async move { cache.token(key, provider).await.unwrap() })
+        });
+        for request in requests {
+            assert_eq!(request.await.unwrap().expose(), "token-1");
+        }
+        assert_eq!(provider.calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn debug_output_redacts_secrets_and_cache_keys() {
+        assert_eq!(format!("{:?}", SecretString::new("secret")), "[redacted]");
+        let key = TokenCacheKey::fingerprint([b"secret".as_slice()]);
+        assert!(!format!("{key:?}").contains("secret"));
+    }
+}

--- a/litellm-rust/crates/core/src/auth.rs
+++ b/litellm-rust/crates/core/src/auth.rs
@@ -58,6 +58,28 @@ impl fmt::Debug for SecretString {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AuthHeaderKind {
+    Bearer,
+    Header(&'static str),
+}
+
+impl AuthHeaderKind {
+    pub fn header_name(self) -> &'static str {
+        match self {
+            Self::Bearer => "authorization",
+            Self::Header(name) => name,
+        }
+    }
+
+    pub fn header_value(self, credential: &SecretString) -> SecretString {
+        match self {
+            Self::Bearer => SecretString::new(format!("Bearer {}", credential.expose())),
+            Self::Header(_) => credential.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum AuthErrorKind {
     MissingCredential,
     InvalidConfiguration,
@@ -377,6 +399,50 @@ impl RequestAuthorizer for StaticHeaderAuthorizer {
         value.set_sensitive(true);
         headers.insert(self.name.clone(), value);
         Ok(headers)
+    }
+}
+
+pub struct BearerTokenAuthorizer {
+    provider: Arc<dyn TokenProvider>,
+    clock: Arc<dyn Clock>,
+    conflicts: Vec<HeaderName>,
+}
+
+impl BearerTokenAuthorizer {
+    pub fn new(
+        provider: Arc<dyn TokenProvider>,
+        clock: Arc<dyn Clock>,
+        conflicts: Vec<HeaderName>,
+    ) -> Self {
+        Self {
+            provider,
+            clock,
+            conflicts,
+        }
+    }
+}
+
+#[async_trait]
+impl RequestAuthorizer for BearerTokenAuthorizer {
+    async fn authorize(&self, request: AuthorizeRequest<'_>) -> Result<HeaderMap, AuthError> {
+        let token = match self.provider.token().await? {
+            TokenCredential::Cached(lease) if lease.expires_at > self.clock.now() => lease.token,
+            TokenCredential::Cached(_) => {
+                return Err(AuthError::new(
+                    AuthErrorKind::CredentialUnavailable,
+                    "expired_token",
+                    "credential provider returned an expired token",
+                ));
+            }
+            TokenCredential::NoStore(token) => token,
+        };
+        StaticHeaderAuthorizer::new(
+            reqwest::header::AUTHORIZATION,
+            AuthHeaderKind::Bearer.header_value(&token),
+            self.conflicts.clone(),
+        )
+        .authorize(request)
+        .await
     }
 }
 

--- a/litellm-rust/crates/core/src/auth.rs
+++ b/litellm-rust/crates/core/src/auth.rs
@@ -112,9 +112,9 @@ impl AuthError {
 impl From<AuthError> for Error {
     fn from(error: AuthError) -> Self {
         match error.kind {
-            AuthErrorKind::UnsupportedMode => Error::Unsupported(error.code),
-            AuthErrorKind::CrossOriginReplay => Error::InvalidResponse(error.to_string()),
-            _ => Error::Auth(error.to_string()),
+            AuthErrorKind::UnsupportedMode => Error::unsupported(error.code),
+            AuthErrorKind::CrossOriginReplay => Error::invalid_response(error.to_string()),
+            _ => Error::authentication(error.to_string()),
         }
     }
 }

--- a/litellm-rust/crates/core/src/error.rs
+++ b/litellm-rust/crates/core/src/error.rs
@@ -1,5 +1,49 @@
 use thiserror::Error as ThisError;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ErrorCode {
+    Unsupported,
+    InvalidRequest,
+    Authentication,
+    Routing,
+    Transport,
+    Upstream,
+    InvalidResponse,
+    Internal,
+}
+
+impl ErrorCode {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Unsupported => "unsupported",
+            Self::InvalidRequest => "invalid_request",
+            Self::Authentication => "authentication",
+            Self::Routing => "routing",
+            Self::Transport => "transport",
+            Self::Upstream => "upstream",
+            Self::InvalidResponse => "invalid_response",
+            Self::Internal => "internal",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ProviderState {
+    NotStarted,
+    MayHaveStarted,
+    ResponseReceived,
+}
+
+impl ProviderState {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::NotStarted => "not_started",
+            Self::MayHaveStarted => "may_have_started",
+            Self::ResponseReceived => "response_received",
+        }
+    }
+}
+
 #[derive(Debug, ThisError, PartialEq, Eq)]
 pub enum Error {
     #[error("expected {expected}, got {actual}")]
@@ -34,6 +78,20 @@ pub enum Error {
     /// keep a reference implementation treat this as "fall back", not "fail".
     #[error("unsupported by the rust path: {0}")]
     Unsupported(&'static str),
+}
+
+impl Error {
+    pub fn unsupported(message: &'static str) -> Self {
+        Self::Unsupported(message)
+    }
+
+    pub fn invalid_response(message: String) -> Self {
+        Self::InvalidResponse(message)
+    }
+
+    pub fn authentication(message: String) -> Self {
+        Self::Auth(message)
+    }
 }
 
 pub fn json_type_name(value: &serde_json::Value) -> &'static str {

--- a/litellm-rust/crates/core/src/lib.rs
+++ b/litellm-rust/crates/core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod audio_transcription;
+pub mod auth;
 pub mod caching;
 pub mod call_lifecycle;
 pub mod chat_completions;

--- a/litellm-rust/crates/core/src/lib.rs
+++ b/litellm-rust/crates/core/src/lib.rs
@@ -16,4 +16,4 @@ pub mod responses;
 pub mod router;
 pub mod routing_utils;
 
-pub use error::Error;
+pub use error::{Error, ErrorCode, ProviderState};

--- a/litellm-rust/crates/python-bridge/Cargo.toml
+++ b/litellm-rust/crates/python-bridge/Cargo.toml
@@ -21,6 +21,7 @@ trace-parity = [
 ]
 
 [dependencies]
+async-trait = "0.1"
 futures-util.workspace = true
 tracing = { workspace = true, optional = true }
 litellm-core = { workspace = true, features = ["bedrock-auth"] }

--- a/litellm-rust/crates/python-bridge/src/errors.rs
+++ b/litellm-rust/crates/python-bridge/src/errors.rs
@@ -1,99 +1,163 @@
-use litellm_core::error::Error;
-use pyo3::exceptions::{PyRuntimeError, PyValueError};
+use litellm_core::error::{Error, ErrorCode, ProviderState};
 use pyo3::prelude::*;
+use pyo3::types::PyNone;
 
 pyo3::create_exception!(
     _native,
-    RustBridgeDeclined,
+    RustPreparationError,
     pyo3::exceptions::PyException,
-    "The route declined before calling the provider, so the host may retry on its own path."
+    "Rust stopped before provider execution and the host may use another implementation."
 );
 
 pyo3::create_exception!(
     _native,
-    RustUpstreamError,
+    RustExecutionError,
     pyo3::exceptions::PyException,
-    "The provider call was already issued and failed. Args are (status, message); status is 0 when there was no HTTP response."
+    "Rust owns provider execution and the host must not retry through another implementation."
 );
 
-pub(crate) fn core_error_to_pyerr(err: Error) -> PyErr {
-    match err {
-        Error::Auth(message) => PyValueError::new_err(message),
-        Error::InvalidProvider(_)
+pub(crate) fn core_error_to_pyerr(error: Error) -> PyErr {
+    match error {
+        Error::InvalidType { .. }
+        | Error::MissingField(_)
+        | Error::InvalidProvider(_)
         | Error::InvalidRequest(_)
-        | Error::InvalidType { .. }
-        | Error::MissingField(_) => PyValueError::new_err(err.to_string()),
-        other => PyRuntimeError::new_err(other.to_string()),
+        | Error::Auth(_)
+        | Error::Connect(_)
+        | Error::Routing(_)
+        | Error::Unsupported(_) => structured_error::<RustPreparationError>(
+            error_code(&error),
+            error.to_string(),
+            None,
+            ProviderState::NotStarted,
+        ),
+        Error::Http { status, .. } => structured_error::<RustExecutionError>(
+            ErrorCode::Upstream,
+            format!("upstream request failed with status {status}"),
+            Some(status),
+            ProviderState::ResponseReceived,
+        ),
+        Error::Network(_) => structured_error::<RustExecutionError>(
+            ErrorCode::Transport,
+            "upstream network error".to_string(),
+            None,
+            ProviderState::MayHaveStarted,
+        ),
+        Error::InvalidResponse(message) => structured_error::<RustExecutionError>(
+            ErrorCode::InvalidResponse,
+            format!("invalid response: {message}"),
+            None,
+            ProviderState::ResponseReceived,
+        ),
     }
 }
 
-/// Map a core error for a route whose host keeps a Python implementation.
-///
-/// The distinction the host needs is whether the provider was already called.
-/// Everything raised before the request goes out is safe for the host to retry
-/// on its own path; anything after it is not, because the provider has already
-/// done the work and billed for it.
-pub(crate) fn chat_completions_error_to_pyerr(err: Error) -> PyErr {
-    match err {
-        Error::Unsupported(_)
-        | Error::Auth(_)
-        | Error::InvalidProvider(_)
-        | Error::InvalidRequest(_)
-        | Error::InvalidType { .. }
-        | Error::MissingField(_)
-        | Error::Routing(_)
-        // Nothing reached the provider, so serving it on Python cannot double
-        // bill and is the only way the caller gets an answer at all.
-        | Error::Connect(_) => RustBridgeDeclined::new_err(err.to_string()),
-        Error::Http { status, body } => {
-            RustUpstreamError::new_err((status, format!("{status}: {body}")))
+fn error_code(error: &Error) -> ErrorCode {
+    match error {
+        Error::InvalidType { .. } | Error::MissingField(_) | Error::InvalidRequest(_) => {
+            ErrorCode::InvalidRequest
         }
-        Error::Network(message) | Error::InvalidResponse(message) => {
-            RustUpstreamError::new_err((0u16, message))
-        }
+        Error::InvalidProvider(_) | Error::Unsupported(_) => ErrorCode::Unsupported,
+        Error::Auth(_) => ErrorCode::Authentication,
+        Error::Connect(_) | Error::Network(_) => ErrorCode::Transport,
+        Error::Routing(_) => ErrorCode::Routing,
+        Error::Http { .. } => ErrorCode::Upstream,
+        Error::InvalidResponse(_) => ErrorCode::InvalidResponse,
     }
+}
+
+fn structured_error<E>(
+    code: ErrorCode,
+    message: String,
+    status_code: Option<u16>,
+    provider_state: ProviderState,
+) -> PyErr
+where
+    E: pyo3::type_object::PyTypeInfo,
+{
+    let error = Python::attach(|py| PyErr::from_type(py.get_type::<E>(), (message.clone(),)));
+    Python::attach(|py| {
+        let value = error.value(py);
+        value
+            .setattr("code", code.as_str())
+            .expect("exception attributes are writable");
+        value
+            .setattr("message", message)
+            .expect("exception attributes are writable");
+        match status_code {
+            Some(status) => value
+                .setattr("status_code", status)
+                .expect("exception attributes are writable"),
+            None => value
+                .setattr("status_code", PyNone::get(py))
+                .expect("exception attributes are writable"),
+        }
+        value
+            .setattr("provider_state", provider_state.as_str())
+            .expect("exception attributes are writable");
+    });
+    error
 }
 
 pub(crate) fn register(module: &Bound<'_, PyModule>) -> PyResult<()> {
     let py = module.py();
-    module.add("RustBridgeDeclined", py.get_type::<RustBridgeDeclined>())?;
-    module.add("RustUpstreamError", py.get_type::<RustUpstreamError>())
+    let preparation = py.get_type::<RustPreparationError>();
+    let execution = py.get_type::<RustExecutionError>();
+    module.add("RustPreparationError", &preparation)?;
+    module.add("RustExecutionError", &execution)?;
+    module.add("RustBridgeDeclined", preparation)?;
+    module.add("RustUpstreamError", execution)
 }
 
-pub(crate) fn ocr_error_to_pyerr(err: Error) -> PyErr {
-    match err {
-        Error::MissingField("document_url" | "image_url") => {
-            PyValueError::new_err("Document URL is required")
-        }
-        Error::Http { status, body } => RustUpstreamError::new_err((status, body)),
-        other => core_error_to_pyerr(other),
-    }
+pub(crate) fn ocr_error_to_pyerr(error: Error) -> PyErr {
+    core_error_to_pyerr(error)
+}
+
+pub(crate) fn chat_completions_error_to_pyerr(error: Error) -> PyErr {
+    core_error_to_pyerr(error)
 }
 
 #[cfg(test)]
-mod ocr_error_tests {
+mod tests {
     use super::*;
 
     #[test]
-    fn ocr_errors_preserve_python_validation_and_provider_details() {
+    fn errors_expose_structured_ownership_fields() {
         Python::initialize();
         Python::attach(|py| {
-            for field in ["document_url", "image_url"] {
-                let mapped = ocr_error_to_pyerr(Error::MissingField(field));
-                assert!(mapped.is_instance_of::<PyValueError>(py));
-                assert_eq!(mapped.value(py).to_string(), "Document URL is required");
-            }
-            let mapped = ocr_error_to_pyerr(Error::Http {
+            let preparation =
+                core_error_to_pyerr(Error::InvalidRequest("invalid document".to_string()));
+            assert!(preparation.is_instance_of::<RustPreparationError>(py));
+            assert_eq!(
+                preparation
+                    .value(py)
+                    .getattr("code")
+                    .and_then(|item| item.extract::<String>())
+                    .expect("code is a string"),
+                "invalid_request"
+            );
+
+            let execution = core_error_to_pyerr(Error::Http {
                 status: 429,
-                body: r#"{"message":"rate limited"}"#.to_string(),
+                body: "secret body".to_string(),
             });
-            assert!(mapped.is_instance_of::<RustUpstreamError>(py));
-            let args: (u16, String) = mapped
-                .value(py)
-                .getattr("args")
-                .and_then(|args| args.extract())
-                .expect("OCR failures retain status and unprefixed provider message");
-            assert_eq!(args, (429, r#"{"message":"rate limited"}"#.to_string()));
+            assert!(execution.is_instance_of::<RustExecutionError>(py));
+            let value = execution.value(py);
+            assert_eq!(
+                value
+                    .getattr("status_code")
+                    .and_then(|item| item.extract::<u16>())
+                    .expect("status is an integer"),
+                429
+            );
+            assert_eq!(
+                value
+                    .getattr("provider_state")
+                    .and_then(|item| item.extract::<String>())
+                    .expect("provider state is a string"),
+                "response_received"
+            );
+            assert!(!value.to_string().contains("secret body"));
         });
     }
 }

--- a/litellm-rust/crates/python-bridge/src/lib.rs
+++ b/litellm-rust/crates/python-bridge/src/lib.rs
@@ -4,7 +4,7 @@ mod execution;
 #[cfg(feature = "trace-parity")]
 mod function_trace;
 mod marshal;
-mod python_token_provider;
+pub mod python_token_provider;
 mod routes;
 
 use litellm_ai_gateway::io::responses_ws::ResponsesWebSocketConnection as RustResponsesWebSocketConnection;

--- a/litellm-rust/crates/python-bridge/src/lib.rs
+++ b/litellm-rust/crates/python-bridge/src/lib.rs
@@ -94,6 +94,8 @@ mod tests {
             let module = pyo3::wrap_pymodule!(_native)(py).into_bound(py);
 
             let expected = [
+                "RustPreparationError",
+                "RustExecutionError",
                 "RustBridgeDeclined",
                 "RustUpstreamError",
                 "ocr",

--- a/litellm-rust/crates/python-bridge/src/lib.rs
+++ b/litellm-rust/crates/python-bridge/src/lib.rs
@@ -4,6 +4,7 @@ mod execution;
 #[cfg(feature = "trace-parity")]
 mod function_trace;
 mod marshal;
+mod python_token_provider;
 mod routes;
 
 use litellm_ai_gateway::io::responses_ws::ResponsesWebSocketConnection as RustResponsesWebSocketConnection;

--- a/litellm-rust/crates/python-bridge/src/python_token_provider.rs
+++ b/litellm-rust/crates/python-bridge/src/python_token_provider.rs
@@ -1,0 +1,161 @@
+use std::time::{Duration, Instant, SystemTime};
+
+use async_trait::async_trait;
+use litellm_core::auth::{AuthError, AuthErrorKind, SecretString, TokenLease, TokenProvider};
+use pyo3::exceptions::{PyRuntimeError, PyTypeError};
+use pyo3::prelude::*;
+use pyo3::types::{PyAny, PyTuple};
+use pyo3_async_runtimes::TaskLocals;
+
+pub(crate) struct PythonTokenProvider {
+    callable: Py<PyAny>,
+    locals: Option<TaskLocals>,
+}
+
+impl PythonTokenProvider {
+    pub(crate) fn capture(py: Python<'_>, callable: Py<PyAny>) -> PyResult<Self> {
+        if !callable.bind(py).is_callable() {
+            return Err(PyTypeError::new_err("token provider must be callable"));
+        }
+        let locals = pyo3_async_runtimes::tokio::get_current_locals(py).ok();
+        Ok(Self { callable, locals })
+    }
+
+    pub(crate) async fn resolve(&self) -> PyResult<TokenLease> {
+        let callable = Python::attach(|py| self.callable.clone_ref(py));
+        let result = tokio::task::spawn_blocking(move || Python::attach(|py| callable.call0(py)))
+            .await
+            .map_err(|error| {
+                PyRuntimeError::new_err(format!("token provider task failed: {error}"))
+            })??;
+
+        if let Some(token) = Python::attach(|py| parse_token_result(result.bind(py)))? {
+            return Ok(token);
+        }
+
+        let locals = self.locals.as_ref().ok_or_else(|| {
+            PyTypeError::new_err("awaitable token providers require an async LiteLLM entrypoint")
+        })?;
+        let future = Python::attach(|py| {
+            if !result.bind(py).hasattr("__await__")? {
+                return Err(PyTypeError::new_err(
+                    "token provider must return a string, (string, expiry), or awaitable",
+                ));
+            }
+            pyo3_async_runtimes::into_future_with_locals(locals, result.into_bound(py))
+        })?;
+        let awaited = future.await?;
+        Python::attach(|py| {
+            parse_token_result(awaited.bind(py))?.ok_or_else(|| {
+                PyTypeError::new_err("awaitable token provider returned an invalid value")
+            })
+        })
+    }
+}
+
+fn parse_token_result(value: &Bound<'_, PyAny>) -> PyResult<Option<TokenLease>> {
+    if let Ok(token) = value.extract::<String>() {
+        if token.trim().is_empty() {
+            return Err(PyTypeError::new_err(
+                "token provider returned an empty token",
+            ));
+        }
+        return Ok(Some(TokenLease {
+            token: SecretString::new(token),
+            expires_at: Instant::now() + Duration::from_secs(1),
+        }));
+    }
+    let Ok(tuple) = value.cast::<PyTuple>() else {
+        return Ok(None);
+    };
+    if tuple.len() != 2 {
+        return Ok(None);
+    }
+    let token = tuple.get_item(0)?.extract::<String>()?;
+    let expires_at = tuple.get_item(1)?.extract::<f64>()?;
+    if token.trim().is_empty() || !expires_at.is_finite() {
+        return Err(PyTypeError::new_err(
+            "token provider returned an invalid token lease",
+        ));
+    }
+    let now_epoch = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs_f64();
+    Ok(Some(TokenLease {
+        token: SecretString::new(token),
+        expires_at: Instant::now() + Duration::from_secs_f64((expires_at - now_epoch).max(0.0)),
+    }))
+}
+
+#[async_trait]
+impl TokenProvider for PythonTokenProvider {
+    async fn token(&self) -> Result<TokenLease, AuthError> {
+        self.resolve().await.map_err(|_| {
+            AuthError::new(
+                AuthErrorKind::ExternalProviderFailed,
+                "python_token_provider_failed",
+                "Python token provider failed",
+            )
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::CString;
+
+    use pyo3::types::PyDict;
+
+    use super::*;
+
+    fn assert_send_sync<T: Send + Sync>() {}
+
+    #[test]
+    fn owned_python_provider_is_send_and_sync() {
+        assert_send_sync::<PythonTokenProvider>();
+    }
+
+    #[test]
+    fn synchronous_provider_returns_secret_lease() {
+        Python::initialize();
+        let provider = Python::attach(|py| {
+            let locals = PyDict::new(py);
+            py.run(
+                &CString::new("provider = lambda: 'secret-token'").unwrap(),
+                None,
+                Some(&locals),
+            )?;
+            PythonTokenProvider::capture(py, locals.get_item("provider")?.unwrap().unbind())
+        })
+        .unwrap();
+        let lease = pyo3_async_runtimes::tokio::get_runtime()
+            .block_on(provider.resolve())
+            .unwrap();
+        assert_eq!(lease.token.expose(), "secret-token");
+        assert_eq!(format!("{:?}", lease.token), "[redacted]");
+    }
+
+    #[test]
+    fn original_python_exception_is_preserved_by_resolve() {
+        Python::initialize();
+        let provider = Python::attach(|py| {
+            let locals = PyDict::new(py);
+            py.run(
+                &CString::new("def provider():\n    raise LookupError('credential missing')")
+                    .unwrap(),
+                None,
+                Some(&locals),
+            )?;
+            PythonTokenProvider::capture(py, locals.get_item("provider")?.unwrap().unbind())
+        })
+        .unwrap();
+        let error = pyo3_async_runtimes::tokio::get_runtime()
+            .block_on(provider.resolve())
+            .unwrap_err();
+        Python::attach(|py| {
+            assert!(error.is_instance_of::<pyo3::exceptions::PyLookupError>(py));
+            assert_eq!(error.value(py).to_string(), "credential missing");
+        });
+    }
+}

--- a/litellm-rust/crates/python-bridge/src/python_token_provider.rs
+++ b/litellm-rust/crates/python-bridge/src/python_token_provider.rs
@@ -9,13 +9,13 @@ use pyo3::prelude::*;
 use pyo3::types::{PyAny, PyTuple};
 use pyo3_async_runtimes::TaskLocals;
 
-pub(crate) struct PythonTokenProvider {
+pub struct PythonTokenProvider {
     callable: Py<PyAny>,
     locals: Option<TaskLocals>,
 }
 
 impl PythonTokenProvider {
-    pub(crate) fn capture(py: Python<'_>, callable: Py<PyAny>) -> PyResult<Self> {
+    pub fn capture(py: Python<'_>, callable: Py<PyAny>) -> PyResult<Self> {
         if !callable.bind(py).is_callable() {
             return Err(PyTypeError::new_err("token provider must be callable"));
         }
@@ -23,7 +23,7 @@ impl PythonTokenProvider {
         Ok(Self { callable, locals })
     }
 
-    pub(crate) async fn resolve(&self) -> PyResult<TokenCredential> {
+    pub async fn resolve(&self) -> PyResult<TokenCredential> {
         let callable = Python::attach(|py| self.callable.clone_ref(py));
         let result = tokio::task::spawn_blocking(move || Python::attach(|py| callable.call0(py)))
             .await

--- a/litellm-rust/crates/python-bridge/src/python_token_provider.rs
+++ b/litellm-rust/crates/python-bridge/src/python_token_provider.rs
@@ -1,7 +1,9 @@
 use std::time::{Duration, Instant, SystemTime};
 
 use async_trait::async_trait;
-use litellm_core::auth::{AuthError, AuthErrorKind, SecretString, TokenLease, TokenProvider};
+use litellm_core::auth::{
+    AuthError, AuthErrorKind, SecretString, TokenCredential, TokenLease, TokenProvider,
+};
 use pyo3::exceptions::{PyRuntimeError, PyTypeError};
 use pyo3::prelude::*;
 use pyo3::types::{PyAny, PyTuple};
@@ -21,7 +23,7 @@ impl PythonTokenProvider {
         Ok(Self { callable, locals })
     }
 
-    pub(crate) async fn resolve(&self) -> PyResult<TokenLease> {
+    pub(crate) async fn resolve(&self) -> PyResult<TokenCredential> {
         let callable = Python::attach(|py| self.callable.clone_ref(py));
         let result = tokio::task::spawn_blocking(move || Python::attach(|py| callable.call0(py)))
             .await
@@ -53,17 +55,14 @@ impl PythonTokenProvider {
     }
 }
 
-fn parse_token_result(value: &Bound<'_, PyAny>) -> PyResult<Option<TokenLease>> {
+fn parse_token_result(value: &Bound<'_, PyAny>) -> PyResult<Option<TokenCredential>> {
     if let Ok(token) = value.extract::<String>() {
         if token.trim().is_empty() {
             return Err(PyTypeError::new_err(
                 "token provider returned an empty token",
             ));
         }
-        return Ok(Some(TokenLease {
-            token: SecretString::new(token),
-            expires_at: Instant::now() + Duration::from_secs(1),
-        }));
+        return Ok(Some(TokenCredential::NoStore(SecretString::new(token))));
     }
     let Ok(tuple) = value.cast::<PyTuple>() else {
         return Ok(None);
@@ -82,15 +81,15 @@ fn parse_token_result(value: &Bound<'_, PyAny>) -> PyResult<Option<TokenLease>> 
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs_f64();
-    Ok(Some(TokenLease {
+    Ok(Some(TokenCredential::Cached(TokenLease {
         token: SecretString::new(token),
         expires_at: Instant::now() + Duration::from_secs_f64((expires_at - now_epoch).max(0.0)),
-    }))
+    })))
 }
 
 #[async_trait]
 impl TokenProvider for PythonTokenProvider {
-    async fn token(&self) -> Result<TokenLease, AuthError> {
+    async fn token(&self) -> Result<TokenCredential, AuthError> {
         self.resolve().await.map_err(|_| {
             AuthError::new(
                 AuthErrorKind::ExternalProviderFailed,
@@ -117,7 +116,7 @@ mod tests {
     }
 
     #[test]
-    fn synchronous_provider_returns_secret_lease() {
+    fn synchronous_provider_returns_uncached_secret() {
         Python::initialize();
         let provider = Python::attach(|py| {
             let locals = PyDict::new(py);
@@ -129,11 +128,14 @@ mod tests {
             PythonTokenProvider::capture(py, locals.get_item("provider")?.unwrap().unbind())
         })
         .unwrap();
-        let lease = pyo3_async_runtimes::tokio::get_runtime()
+        let credential = pyo3_async_runtimes::tokio::get_runtime()
             .block_on(provider.resolve())
             .unwrap();
-        assert_eq!(lease.token.expose(), "secret-token");
-        assert_eq!(format!("{:?}", lease.token), "[redacted]");
+        let TokenCredential::NoStore(token) = credential else {
+            panic!("plain tokens must not be cached")
+        };
+        assert_eq!(token.expose(), "secret-token");
+        assert_eq!(format!("{token:?}"), "[redacted]");
     }
 
     #[test]

--- a/litellm/llms/anthropic/chat/handler.py
+++ b/litellm/llms/anthropic/chat/handler.py
@@ -465,6 +465,7 @@ class AnthropicChatCompletion(BaseLLM):
                     timeout=timeout,
                     on_response=log_rust_post_call,
                     python_fallback=python_fallback,
+                    request_override=rust_chat_completions_bridge.rust_request_override(litellm_params),
                 )
             rust_response: Final = rust_chat_completions_bridge.chat_completions(
                 model=model,
@@ -477,6 +478,7 @@ class AnthropicChatCompletion(BaseLLM):
                 extra_headers=headers,
                 timeout=timeout,
                 on_response=log_rust_post_call,
+                request_override=rust_chat_completions_bridge.rust_request_override(litellm_params),
             )
             if rust_response is not None:
                 return rust_response

--- a/litellm/llms/bedrock/audio_transcription/__init__.py
+++ b/litellm/llms/bedrock/audio_transcription/__init__.py
@@ -53,8 +53,6 @@ class BedrockAudioTranscriptionRustDispatch:
             optional_params=optional_params,
             timeout=timeout,
         )
-        if rust_response is None:
-            raise RuntimeError("Rust audio transcription bridge is unavailable")
         return TranscriptionResponse(**rust_response)
 
     async def async_audio_transcriptions(
@@ -79,6 +77,4 @@ class BedrockAudioTranscriptionRustDispatch:
             optional_params=optional_params,
             timeout=timeout,
         )
-        if rust_response is None:
-            raise RuntimeError("Rust audio transcription bridge is unavailable")
         return TranscriptionResponse(**rust_response)

--- a/litellm/llms/bedrock/chat/converse_handler.py
+++ b/litellm/llms/bedrock/chat/converse_handler.py
@@ -452,6 +452,7 @@ class BedrockConverseLLM(BaseAWSLLM):
                         api_key=api_key,
                         skip_pre_call_logging=True,
                     ),
+                    request_override=rust_chat_completions_bridge.rust_request_override(litellm_params),
                 )
             rust_response: Final = rust_chat_completions_bridge.chat_completions(
                 model=model,
@@ -464,6 +465,7 @@ class BedrockConverseLLM(BaseAWSLLM):
                 extra_headers=headers,
                 timeout=timeout,
                 on_response=log_rust_post_call,
+                request_override=rust_chat_completions_bridge.rust_request_override(litellm_params),
             )
             if rust_response is not None:
                 return rust_response

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -83,6 +83,7 @@ from litellm.llms.custom_httpx.http_handler import (
     HTTPHandler,
     _get_httpx_client,
     get_async_httpx_client,
+    get_shared_realtime_ssl_context,
 )
 from litellm.responses.streaming_iterator import (
     BaseResponsesAPIStreamingIterator,
@@ -159,20 +160,6 @@ from litellm.utils import (
     ProviderConfigManager,
     async_pre_call_deployment_hook,
 )
-
-
-def _rust_responses_websocket_enabled(
-    custom_llm_provider: str | None,
-    litellm_params: GenericLiteLLMParams,
-) -> bool:
-    from litellm.rust_bridge.configuration import rust_enabled
-
-    raw_request_override: Final = litellm_params.get("rust")
-    request_override: Final = raw_request_override if isinstance(raw_request_override, bool) else None
-    return custom_llm_provider == "openai" and rust_enabled(request_override=request_override)
-
-
-from .http_handler import get_shared_realtime_ssl_context
 
 if TYPE_CHECKING:
     import tiktoken
@@ -2399,12 +2386,8 @@ class BaseLLMHTTPHandler:
         request_body: dict,
         timeout: float | httpx.Timeout | None,
     ) -> AnthropicMessagesResponse | None:
-        if custom_llm_provider not in ("azure_ai", "anthropic"):
-            return None
         raw_request_override: Final = litellm_params.get("rust")
         request_override: Final = raw_request_override if isinstance(raw_request_override, bool) else None
-        if has_agentic_hook:
-            return None
 
         from litellm.rust_bridge import messages as rust_messages_bridge
 
@@ -2418,6 +2401,7 @@ class BaseLLMHTTPHandler:
             extra_headers=headers,
             timeout=timeout,
             request_override=request_override,
+            eligible=custom_llm_provider in ("azure_ai", "anthropic") and not has_agentic_hook,
         )
         if rust_response is None:
             return None
@@ -6504,19 +6488,19 @@ class BaseLLMHTTPHandler:
 
             @asynccontextmanager
             async def _backend_connection():
-                if _rust_responses_websocket_enabled(custom_llm_provider, litellm_params):
-                    from litellm.rust_bridge import responses_websocket as rust_responses_websocket
+                from litellm.rust_bridge import responses_websocket as rust_responses_websocket
 
-                    raw_rust_override: Final = litellm_params.get("rust")
-                    rust_backend: Final = await rust_responses_websocket.connect(
-                        url=ws_url,
-                        headers={str(key): str(value) for key, value in headers.items()},
-                        timeout=timeout,
-                        request_override=raw_rust_override if isinstance(raw_rust_override, bool) else None,
-                    )
-                    if rust_backend is not None:
-                        yield rust_backend
-                        return
+                raw_rust_override: Final = litellm_params.get("rust")
+                rust_backend: Final = await rust_responses_websocket.connect(
+                    url=ws_url,
+                    headers={str(key): str(value) for key, value in headers.items()},
+                    timeout=timeout,
+                    request_override=raw_rust_override if isinstance(raw_rust_override, bool) else None,
+                    eligible=custom_llm_provider == "openai",
+                )
+                if rust_backend is not None:
+                    yield rust_backend
+                    return
 
                 async with websockets.connect(
                     ws_url,

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -2401,34 +2401,24 @@ class BaseLLMHTTPHandler:
     ) -> AnthropicMessagesResponse | None:
         if custom_llm_provider not in ("azure_ai", "anthropic"):
             return None
-        from litellm.rust_bridge.configuration import rust_enabled
-
         raw_request_override: Final = litellm_params.get("rust")
         request_override: Final = raw_request_override if isinstance(raw_request_override, bool) else None
-        if not rust_enabled(request_override=request_override):
-            return None
         if has_agentic_hook:
             return None
 
         from litellm.rust_bridge import messages as rust_messages_bridge
 
         upstream_body: Final = {key: value for key, value in request_body.items() if key != "stream"}
-        try:
-            rust_response: Final = await rust_messages_bridge.amessages(
-                model=model,
-                body=upstream_body,
-                api_key=api_key,
-                api_base=api_base,
-                custom_llm_provider=custom_llm_provider,
-                extra_headers=headers,
-                timeout=timeout,
-            )
-        except Exception as rust_error:  # noqa: BLE001  # rollout-safety fallback: any Rust bridge failure must fall back to the Python path
-            verbose_logger.debug(
-                "Rust Anthropic messages bridge raised %s; falling back to Python path",
-                type(rust_error).__name__,
-            )
-            return None
+        rust_response: Final = await rust_messages_bridge.amessages(
+            model=model,
+            body=upstream_body,
+            api_key=api_key,
+            api_base=api_base,
+            custom_llm_provider=custom_llm_provider,
+            extra_headers=headers,
+            timeout=timeout,
+            request_override=request_override,
+        )
         if rust_response is None:
             return None
 
@@ -6517,10 +6507,12 @@ class BaseLLMHTTPHandler:
                 if _rust_responses_websocket_enabled(custom_llm_provider, litellm_params):
                     from litellm.rust_bridge import responses_websocket as rust_responses_websocket
 
+                    raw_rust_override: Final = litellm_params.get("rust")
                     rust_backend: Final = await rust_responses_websocket.connect(
                         url=ws_url,
                         headers={str(key): str(value) for key, value in headers.items()},
                         timeout=timeout,
+                        request_override=raw_rust_override if isinstance(raw_rust_override, bool) else None,
                     )
                     if rust_backend is not None:
                         yield rust_backend

--- a/litellm/ocr/main.py
+++ b/litellm/ocr/main.py
@@ -52,14 +52,6 @@ class _PreparedOCRRequest:
     litellm_logging_obj: LiteLLMLoggingObj
 
 
-@dataclass
-class _PreparedRustOCRCall:
-    api_key: str | None
-    api_base: str | None
-    headers: dict[str, object]
-    optional_params: dict[str, object]
-
-
 _RUST_OCR_PROVIDERS: Final = {
     "mistral",
     "azure_ai",
@@ -194,10 +186,9 @@ def _rust_ocr_supported(prepared_request: _PreparedOCRRequest) -> bool:
     return prepared_request.custom_llm_provider in _RUST_OCR_PROVIDERS
 
 
-def _rust_ocr_enabled(prepared_request: _PreparedOCRRequest) -> bool:
+def _rust_request_override(prepared_request: _PreparedOCRRequest) -> bool | None:
     raw_request_override: Final = prepared_request.litellm_params.get("rust")
-    request_override: Final = raw_request_override if isinstance(raw_request_override, bool) else None
-    return rust_ocr_bridge.rust_ocr_enabled(request_override=request_override)
+    return raw_request_override if isinstance(raw_request_override, bool) else None
 
 
 def _rust_bridge_optional_params(
@@ -242,7 +233,7 @@ def _rust_bridge_api_base(
 def _prepare_rust_ocr_call(
     prepared_request: _PreparedOCRRequest,
     resolve_api_key: Callable[[str], str | None],
-) -> _PreparedRustOCRCall:
+) -> rust_ocr_bridge.RustOCRRequest:
     provider_config: Final = prepared_request.provider_config
     api_key_env_var: Final = provider_config.get_api_key_env_var()
     resolved_api_key: Final = prepared_request.api_key or (
@@ -276,11 +267,15 @@ def _prepare_rust_ocr_call(
             "headers": resolved_headers,
         },
     )
-    return _PreparedRustOCRCall(
+    return rust_ocr_bridge.RustOCRRequest(
+        model=prepared_request.model,
+        document=prepared_request.document,
         api_key=resolved_api_key,
         api_base=rust_api_base,
-        headers=cast(dict[str, object], resolved_headers),
+        custom_llm_provider=prepared_request.custom_llm_provider,
+        extra_headers=cast(dict[str, object], resolved_headers),
         optional_params=rust_optional_params,
+        timeout=prepared_request.effective_timeout,
     )
 
 
@@ -288,21 +283,15 @@ def _run_rust_ocr(
     prepared_request: _PreparedOCRRequest,
     resolve_api_key: Callable[[str], str | None],
 ) -> OCRResponse | None:
-    if rust_ocr_bridge.load_rust_ocr() is None:
-        return None
-    prepared: Final = _prepare_rust_ocr_call(
-        prepared_request=prepared_request,
-        resolve_api_key=resolve_api_key,
-    )
     rust_response: Final = rust_ocr_bridge.ocr(
+        prepare=lambda: _prepare_rust_ocr_call(
+            prepared_request=prepared_request,
+            resolve_api_key=resolve_api_key,
+        ),
         model=prepared_request.model,
-        document=prepared_request.document,
-        api_key=prepared.api_key,
-        api_base=prepared.api_base,
-        custom_llm_provider=prepared_request.custom_llm_provider,
-        extra_headers=prepared.headers,
-        optional_params=prepared.optional_params,
-        timeout=prepared_request.effective_timeout,
+        provider=prepared_request.custom_llm_provider,
+        request_override=_rust_request_override(prepared_request),
+        eligible=_rust_ocr_supported(prepared_request),
     )
     if rust_response is None:
         return None
@@ -313,21 +302,15 @@ async def _run_rust_aocr(
     prepared_request: _PreparedOCRRequest,
     resolve_api_key: Callable[[str], str | None],
 ) -> OCRResponse | None:
-    if rust_ocr_bridge.load_rust_aocr() is None:
-        return None
-    prepared: Final = _prepare_rust_ocr_call(
-        prepared_request=prepared_request,
-        resolve_api_key=resolve_api_key,
-    )
     rust_response: Final = await rust_ocr_bridge.aocr(
+        prepare=lambda: _prepare_rust_ocr_call(
+            prepared_request=prepared_request,
+            resolve_api_key=resolve_api_key,
+        ),
         model=prepared_request.model,
-        document=prepared_request.document,
-        api_key=prepared.api_key,
-        api_base=prepared.api_base,
-        custom_llm_provider=prepared_request.custom_llm_provider,
-        extra_headers=prepared.headers,
-        optional_params=prepared.optional_params,
-        timeout=prepared_request.effective_timeout,
+        provider=prepared_request.custom_llm_provider,
+        request_override=_rust_request_override(prepared_request),
+        eligible=_rust_ocr_supported(prepared_request),
     )
     if rust_response is None:
         return None
@@ -428,17 +411,14 @@ async def aocr(
         custom_llm_provider = prepared.custom_llm_provider
         completion_kwargs.update({"model": model, "custom_llm_provider": custom_llm_provider})
 
-        if _rust_ocr_supported(prepared) and _rust_ocr_enabled(prepared):
-            from litellm.secret_managers.main import get_secret_str
+        from litellm.secret_managers.main import get_secret_str
 
-            rust_response: Final = await _run_rust_aocr(
-                prepared_request=prepared,
-                resolve_api_key=get_secret_str,
-            )
-            if rust_response is None:
-                verbose_logger.debug("Async Rust OCR bridge unavailable; falling back to Python path")
-            else:
-                return rust_response
+        rust_response: Final = await _run_rust_aocr(
+            prepared_request=prepared,
+            resolve_api_key=get_secret_str,
+        )
+        if rust_response is not None:
+            return rust_response
 
         response = base_llm_http_handler.ocr(
             model=prepared.model,
@@ -700,17 +680,14 @@ def ocr(
         custom_llm_provider = prepared.custom_llm_provider
         completion_kwargs.update({"model": model, "custom_llm_provider": custom_llm_provider})
 
-        if _rust_ocr_supported(prepared) and _rust_ocr_enabled(prepared):
-            from litellm.secret_managers.main import get_secret_str
+        from litellm.secret_managers.main import get_secret_str
 
-            rust_response: Final = _run_rust_ocr(
-                prepared_request=prepared,
-                resolve_api_key=get_secret_str,
-            )
-            if rust_response is None:
-                verbose_logger.debug("Rust OCR bridge unavailable; falling back to Python path")
-            else:
-                return rust_response
+        rust_response: Final = _run_rust_ocr(
+            prepared_request=prepared,
+            resolve_api_key=get_secret_str,
+        )
+        if rust_response is not None:
+            return rust_response
 
         response: Final = base_llm_http_handler.ocr(
             model=prepared.model,

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -558,6 +558,38 @@ async def aresponses(
             kwargs.pop("prompt_id", None)
             kwargs["_async_prompt_merged_params"] = merged_optional_params
 
+        from litellm.rust_bridge import responses as rust_responses_bridge
+
+        raw_rust_override: Final = kwargs.get("rust")
+        rust_model, _, _, _ = litellm.get_llm_provider(
+            model=model,
+            custom_llm_provider=custom_llm_provider,
+            api_base=local_vars.get("base_url", None),
+        )
+        rust_model = _strip_responses_routing_prefix(rust_model)
+        rust_response: Final = await rust_responses_bridge.aresponses(
+            prepare=lambda: {
+                **{key: value for key, value in local_vars.items() if key != "kwargs"},
+                **kwargs,
+                "input": input,
+                "model": rust_model,
+                "custom_llm_provider": custom_llm_provider,
+            },
+            model=rust_model,
+            provider=custom_llm_provider or "",
+            request_override=raw_rust_override if isinstance(raw_rust_override, bool) else None,
+        )
+        if rust_response is not None:
+            response = ResponsesAPIResponse.model_validate(rust_response)
+            response = ResponsesAPIRequestUtils._update_responses_api_response_id_with_model_id(
+                responses_api_response=response,
+                litellm_metadata=kwargs.get("litellm_metadata", {}),
+                custom_llm_provider=custom_llm_provider,
+            )
+            response._hidden_params["custom_llm_provider"] = custom_llm_provider
+            return response
+        kwargs["_rust_responses_checked"] = True
+
         func: Final = partial(
             responses,
             input=input,
@@ -1015,6 +1047,7 @@ def responses(
         litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id", None)
         _is_async: Final = kwargs.pop("aresponses", False) is True
+        rust_responses_checked: Final = kwargs.pop("_rust_responses_checked", False) is True
         use_chat_completions_api = _pop_use_chat_completions_api_kw(kwargs)
 
         client_headers: Final = kwargs.get("headers")
@@ -1072,6 +1105,32 @@ def responses(
             litellm_params=litellm_params,
             local_vars=local_vars,
         )
+
+        if not rust_responses_checked:
+            from litellm.rust_bridge import responses as rust_responses_bridge
+
+            raw_rust_override: Final = kwargs.get("rust")
+            rust_response: Final = rust_responses_bridge.responses(
+                prepare=lambda: {
+                    **{key: value for key, value in local_vars.items() if key != "kwargs"},
+                    **kwargs,
+                    "input": input,
+                    "model": model,
+                    "custom_llm_provider": custom_llm_provider,
+                },
+                model=model,
+                provider=custom_llm_provider or "",
+                request_override=raw_rust_override if isinstance(raw_rust_override, bool) else None,
+            )
+            if rust_response is not None:
+                response = ResponsesAPIResponse.model_validate(rust_response)
+                response = ResponsesAPIRequestUtils._update_responses_api_response_id_with_model_id(
+                    responses_api_response=response,
+                    litellm_metadata=kwargs.get("litellm_metadata", {}),
+                    custom_llm_provider=custom_llm_provider,
+                )
+                response._hidden_params["custom_llm_provider"] = custom_llm_provider
+                return response
 
         #########################################################
         # Update input and tools with provider-specific file IDs if managed files are used

--- a/litellm/rust_bridge/bindings.py
+++ b/litellm/rust_bridge/bindings.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Final, Generic, TypeVar
+from typing import Final, Generic, TypeVar, cast
 
 from litellm.rust_bridge.loader import get_native_bridge
 
@@ -15,6 +15,13 @@ class _Unset:
 _UNSET: Final = _Unset()
 
 
+class Unchanged:
+    pass
+
+
+UNCHANGED: Final = Unchanged()
+
+
 class NativeBinding(Generic[BindingT]):
     """Resolve one native attribute with an explicit, resettable test override."""
 
@@ -22,6 +29,13 @@ class NativeBinding(Generic[BindingT]):
         self._attribute: Final = attribute
         self._validate: Final = validate
         self._override: BindingT | None | _Unset = _UNSET
+
+    @classmethod
+    def callable(cls, attribute: str) -> NativeBinding[BindingT]:
+        return cls(
+            attribute,
+            validate=lambda value: cast(BindingT, value) if callable(value) else None,
+        )
 
     def load(self) -> BindingT | None:
         if not isinstance(self._override, _Unset):

--- a/litellm/rust_bridge/chat_completions.py
+++ b/litellm/rust_bridge/chat_completions.py
@@ -14,20 +14,24 @@ from __future__ import annotations
 
 import json
 from collections.abc import Awaitable, Callable, Mapping, Sequence
-from dataclasses import dataclass
 from typing import TYPE_CHECKING, Final, Protocol
 
 import httpx
 from pydantic import TypeAdapter, ValidationError
 
 from litellm._logging import verbose_logger
-from litellm.exceptions import APIError
 from litellm.litellm_core_utils.llm_response_utils.convert_dict_to_response import (
     convert_to_model_response_object,
 )
 from litellm.llms.bedrock.request_metadata import bedrock_request_metadata_is_owned
+from litellm.rust_bridge.bindings import UNCHANGED, Unchanged
 from litellm.rust_bridge.configuration import rust_enabled
-from litellm.rust_bridge.loader import get_native_bridge
+from litellm.rust_bridge.runtime import (
+    BridgeErrorContext,
+    RustBridge,
+    RustEndpoint,
+    async_none,
+)
 from litellm.rust_bridge.timeouts import timeout_to_seconds
 from litellm.types.utils import ModelResponse
 
@@ -126,67 +130,42 @@ def response_logger(
     return log
 
 
-class _Unset:
-    pass
-
-
-_UNSET: Final[_Unset] = _Unset()
-
-
-@dataclass(slots=True)
-class _RustChatCompletionsState:
-    chat_completions: RustChatCompletions | None = None
-    achat_completions: RustAchatCompletions | None = None
-    decline: RustChatCompletionsDecline | None = None
-
-
-_STATE: Final[_RustChatCompletionsState] = _RustChatCompletionsState()
+_CHAT: Final[RustEndpoint[RustChatCompletions, RustAchatCompletions]] = RustEndpoint.native(
+    route="chat completions",
+    sync="chat_completions",
+    asynchronous="achat_completions",
+    enabled=rust_enabled,
+)
+_CHAT_PREFLIGHT: Final[RustBridge[RustChatCompletionsDecline]] = RustBridge.native(
+    route="chat completions preflight",
+    attribute="chat_completions_decline",
+    enabled=rust_enabled,
+)
 
 
 def set_rust_chat_completions(
     *,
-    chat_completions: RustChatCompletions | None | _Unset = _UNSET,
-    achat_completions: RustAchatCompletions | None | _Unset = _UNSET,
-    decline: RustChatCompletionsDecline | None | _Unset = _UNSET,
+    chat_completions: RustChatCompletions | None | Unchanged = UNCHANGED,
+    achat_completions: RustAchatCompletions | None | Unchanged = UNCHANGED,
+    decline: RustChatCompletionsDecline | None | Unchanged = UNCHANGED,
 ) -> None:
     """Inject the native callables, so tests can supply a double instead of
     patching module attributes."""
-    if not isinstance(chat_completions, _Unset):
-        _STATE.chat_completions = chat_completions
-    if not isinstance(achat_completions, _Unset):
-        _STATE.achat_completions = achat_completions
-    if not isinstance(decline, _Unset):
-        _STATE.decline = decline
-
-
-def load_rust_chat_completions() -> RustChatCompletions | None:
-    if _STATE.chat_completions is not None:
-        return _STATE.chat_completions
-    native_bridge: Final = get_native_bridge()
-    if native_bridge is None:
-        return None
-    loaded: RustChatCompletions | None = getattr(native_bridge, "chat_completions", None)
-    return loaded
-
-
-def load_rust_achat_completions() -> RustAchatCompletions | None:
-    if _STATE.achat_completions is not None:
-        return _STATE.achat_completions
-    native_bridge: Final = get_native_bridge()
-    if native_bridge is None:
-        return None
-    loaded: RustAchatCompletions | None = getattr(native_bridge, "achat_completions", None)
-    return loaded
-
-
-def _load_rust_decline() -> RustChatCompletionsDecline | None:
-    if _STATE.decline is not None:
-        return _STATE.decline
-    native_bridge: Final = get_native_bridge()
-    if native_bridge is None:
-        return None
-    loaded: RustChatCompletionsDecline | None = getattr(native_bridge, "chat_completions_decline", None)
-    return loaded
+    if not isinstance(chat_completions, Unchanged):
+        if chat_completions is None:
+            _CHAT.sync.reset()
+        else:
+            _CHAT.sync.override(chat_completions)
+    if not isinstance(achat_completions, Unchanged):
+        if achat_completions is None:
+            _CHAT.asynchronous.reset()
+        else:
+            _CHAT.asynchronous.override(achat_completions)
+    if not isinstance(decline, Unchanged):
+        if decline is None:
+            _CHAT_PREFLIGHT.reset()
+        else:
+            _CHAT_PREFLIGHT.override(decline)
 
 
 def _anthropic_user_id_reaches_the_body(litellm_params: Mapping[str, object] | None) -> bool:
@@ -227,6 +206,11 @@ def _litellm_metadata_reaches_the_provider(
             return False
 
 
+def rust_request_override(litellm_params: Mapping[str, object] | None) -> bool | None:
+    raw_request_override: Final = litellm_params.get("rust") if litellm_params is not None else None
+    return raw_request_override if isinstance(raw_request_override, bool) else None
+
+
 def rust_chat_completions_accepts(
     *,
     model: str,
@@ -247,82 +231,17 @@ def rust_chat_completions_accepts(
         return False
     if stream:
         return False
-    request_override: Final = litellm_params.get("rust") if litellm_params is not None else None
-    if not rust_enabled(request_override=request_override if isinstance(request_override, bool) else None):
-        return False
     if _litellm_metadata_reaches_the_provider(custom_llm_provider, litellm_params):
         verbose_logger.debug("Rust chat completions declined (litellm metadata user_id); using the Python path")
         return False
-    decline: Final = _load_rust_decline()
-    if decline is None:
-        return False
-    try:
-        reason: Final = decline(
+    return _CHAT_PREFLIGHT.accepts(
+        request_override=rust_request_override(litellm_params),
+        check=lambda decline: decline(
             model=model,
             messages=messages,
             optional_params=optional_params,
             custom_llm_provider=custom_llm_provider,
-        )
-    except Exception as rust_error:  # noqa: BLE001  # rollout-safety fallback: any Rust bridge failure must fall back to the Python path
-        verbose_logger.debug(
-            "Rust chat completions gate raised %s; staying on the Python path",
-            type(rust_error).__name__,
-        )
-        return False
-    if reason is not None:
-        verbose_logger.debug("Rust chat completions declined (%s); using the Python path", reason)
-        return False
-    return True
-
-
-def _rust_bridge_exceptions() -> tuple[type[BaseException], type[BaseException]] | None:
-    """`(declined, upstream_failed)` from the native module, or None when absent."""
-    native_bridge: Final = get_native_bridge()
-    if native_bridge is None:
-        return None
-    declined: Final = getattr(native_bridge, "RustBridgeDeclined", None)
-    upstream: Final = getattr(native_bridge, "RustUpstreamError", None)
-    if declined is None or upstream is None:
-        return None
-    return declined, upstream
-
-
-def _reraise_or_decline(
-    rust_error: BaseException,
-    *,
-    model: str,
-    custom_llm_provider: str | None,
-) -> None:
-    """Re-raise a failure the provider already saw, or return so the caller declines.
-
-    A request that never reached the provider is safe to serve on the Python
-    path. One that did is not: the provider has already done the work, so a
-    second attempt bills for it twice. Those surface as an `APIError` carrying
-    the upstream status, which LiteLLM's exception mapping already understands.
-    """
-    exceptions: Final = _rust_bridge_exceptions()
-    if exceptions is None:
-        verbose_logger.debug(
-            "Rust chat completions bridge raised %s; falling back to Python path",
-            type(rust_error).__name__,
-        )
-        return
-    declined, upstream_failed = exceptions
-    if isinstance(rust_error, upstream_failed):
-        args: Final = rust_error.args
-        status: Final = args[0] if args else 0
-        message: Final = args[1] if len(args) > 1 else ""
-        raise APIError(
-            status_code=int(status) or 500,
-            message=f"litellm rust chat completions: {message}",
-            llm_provider=custom_llm_provider or "",
-            model=model,
-        )
-    if not isinstance(rust_error, declined):
-        raise rust_error
-    verbose_logger.debug(
-        "Rust chat completions declined before calling the provider (%s); using the Python path",
-        rust_error,
+        ),
     )
 
 
@@ -352,12 +271,14 @@ def chat_completions(
     extra_headers: Mapping[str, object] | None,
     timeout: float | httpx.Timeout | None,
     on_response: ResponseObserver,
+    request_override: bool | None,
 ) -> ModelResponse | None:
-    rust_chat_completions: Final = load_rust_chat_completions()
-    if rust_chat_completions is None:
-        return None
-    try:
-        rust_response: Final = rust_chat_completions(
+    def adapt(rust_response: Mapping[str, object]) -> ModelResponse:
+        on_response(rust_response)
+        return _build_model_response(rust_response, model_response)
+
+    return _CHAT.invoke(
+        call=lambda rust_chat_completions: rust_chat_completions(
             model=model,
             messages=messages,
             optional_params=optional_params,
@@ -366,12 +287,12 @@ def chat_completions(
             custom_llm_provider=custom_llm_provider,
             extra_headers=extra_headers,
             timeout_seconds=timeout_to_seconds(timeout),
-        )
-    except Exception as rust_error:  # noqa: BLE001  # rollout safety: the helper re-raises anything the provider already saw
-        _reraise_or_decline(rust_error, model=model, custom_llm_provider=custom_llm_provider)
-        return None
-    on_response(rust_response)
-    return _build_model_response(rust_response, model_response)
+        ),
+        fallback=lambda: None,
+        adapt=adapt,
+        context=BridgeErrorContext(provider=custom_llm_provider or "", model=model),
+        request_override=request_override,
+    )
 
 
 async def achat_completions(
@@ -386,12 +307,14 @@ async def achat_completions(
     extra_headers: Mapping[str, object] | None,
     timeout: float | httpx.Timeout | None,
     on_response: ResponseObserver,
+    request_override: bool | None,
 ) -> ModelResponse | None:
-    rust_achat_completions: Final = load_rust_achat_completions()
-    if rust_achat_completions is None:
-        return None
-    try:
-        rust_response: Final = await rust_achat_completions(
+    def adapt(rust_response: Mapping[str, object]) -> ModelResponse:
+        on_response(rust_response)
+        return _build_model_response(rust_response, model_response)
+
+    return await _CHAT.ainvoke(
+        call=lambda rust_achat_completions: rust_achat_completions(
             model=model,
             messages=messages,
             optional_params=optional_params,
@@ -400,12 +323,12 @@ async def achat_completions(
             custom_llm_provider=custom_llm_provider,
             extra_headers=extra_headers,
             timeout_seconds=timeout_to_seconds(timeout),
-        )
-    except Exception as rust_error:  # noqa: BLE001  # rollout safety: the helper re-raises anything the provider already saw
-        _reraise_or_decline(rust_error, model=model, custom_llm_provider=custom_llm_provider)
-        return None
-    on_response(rust_response)
-    return _build_model_response(rust_response, model_response)
+        ),
+        fallback=async_none,
+        adapt=adapt,
+        context=BridgeErrorContext(provider=custom_llm_provider or "", model=model),
+        request_override=request_override,
+    )
 
 
 async def achat_completions_or_fallback(
@@ -421,6 +344,7 @@ async def achat_completions_or_fallback(
     timeout: float | httpx.Timeout | None,
     on_response: ResponseObserver,
     python_fallback: Callable[[], Awaitable[object]],
+    request_override: bool | None,
 ) -> object:
     """Await the Rust path, falling back to the caller's own Python path when
     the bridge is unavailable or the call fails.
@@ -430,18 +354,24 @@ async def achat_completions_or_fallback(
     already returned a coroutine by the time a Rust failure surfaces, and so
     cannot fall back on its own.
     """
-    response: Final = await achat_completions(
-        model=model,
-        messages=messages,
-        optional_params=optional_params,
-        model_response=model_response,
-        api_key=api_key,
-        api_base=api_base,
-        custom_llm_provider=custom_llm_provider,
-        extra_headers=extra_headers,
-        timeout=timeout,
-        on_response=on_response,
+
+    def adapt(rust_response: Mapping[str, object]) -> object:
+        on_response(rust_response)
+        return _build_model_response(rust_response, model_response)
+
+    return await _CHAT.ainvoke(
+        call=lambda rust_achat_completions: rust_achat_completions(
+            model=model,
+            messages=messages,
+            optional_params=optional_params,
+            api_key=api_key,
+            api_base=api_base,
+            custom_llm_provider=custom_llm_provider,
+            extra_headers=extra_headers,
+            timeout_seconds=timeout_to_seconds(timeout),
+        ),
+        fallback=python_fallback,
+        adapt=adapt,
+        context=BridgeErrorContext(provider=custom_llm_provider or "", model=model),
+        request_override=request_override,
     )
-    if response is not None:
-        return response
-    return await python_fallback()

--- a/litellm/rust_bridge/messages.py
+++ b/litellm/rust_bridge/messages.py
@@ -81,6 +81,7 @@ def messages(
     extra_headers: dict[str, object] | None,
     timeout: float | httpx.Timeout | None,
     request_override: bool | None = None,
+    eligible: bool = True,
 ) -> dict[str, object] | None:
     return _MESSAGES.invoke(
         call=lambda rust_messages: rust_messages(
@@ -96,6 +97,7 @@ def messages(
         adapt=identity,
         context=BridgeErrorContext(provider=custom_llm_provider or "", model=model),
         request_override=request_override,
+        eligible=eligible,
     )
 
 
@@ -109,6 +111,7 @@ async def amessages(
     extra_headers: dict[str, object] | None,
     timeout: float | httpx.Timeout | None,
     request_override: bool | None = None,
+    eligible: bool = True,
 ) -> dict[str, object] | None:
     return await _MESSAGES.ainvoke(
         call=lambda rust_amessages: rust_amessages(
@@ -124,4 +127,5 @@ async def amessages(
         adapt=identity,
         context=BridgeErrorContext(provider=custom_llm_provider or "", model=model),
         request_override=request_override,
+        eligible=eligible,
     )

--- a/litellm/rust_bridge/messages.py
+++ b/litellm/rust_bridge/messages.py
@@ -3,11 +3,18 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable
-from dataclasses import dataclass
-from typing import Final, Protocol, cast
+from typing import Final, Protocol
 
 import httpx
 
+from litellm.rust_bridge.bindings import UNCHANGED, Unchanged
+from litellm.rust_bridge.configuration import rust_enabled
+from litellm.rust_bridge.runtime import (
+    BridgeErrorContext,
+    RustEndpoint,
+    async_none,
+    identity,
+)
 from litellm.rust_bridge.timeouts import timeout_to_seconds
 
 
@@ -39,53 +46,29 @@ class RustAmessages(Protocol):
         raise NotImplementedError
 
 
-class _Unset:
-    pass
-
-
-_UNSET: Final[_Unset] = _Unset()
-
-
-@dataclass(slots=True)
-class _RustMessagesState:
-    messages: RustMessages | None = None
-    amessages: RustAmessages | None = None
-
-
-_STATE: Final[_RustMessagesState] = _RustMessagesState()
+_MESSAGES: Final[RustEndpoint[RustMessages, RustAmessages]] = RustEndpoint.native(
+    route="messages",
+    sync="messages",
+    asynchronous="amessages",
+    enabled=rust_enabled,
+)
 
 
 def set_rust_messages(
     *,
-    messages: RustMessages | None | _Unset = _UNSET,
-    amessages: RustAmessages | None | _Unset = _UNSET,
+    messages: RustMessages | None | Unchanged = UNCHANGED,
+    amessages: RustAmessages | None | Unchanged = UNCHANGED,
 ) -> None:
-    if not isinstance(messages, _Unset):
-        _STATE.messages = messages
-    if not isinstance(amessages, _Unset):
-        _STATE.amessages = amessages
-
-
-def load_rust_messages() -> RustMessages | None:
-    if _STATE.messages is not None:
-        return _STATE.messages
-    from litellm.rust_bridge import get_native_bridge
-
-    native_bridge: Final = get_native_bridge()
-    if native_bridge is None:
-        return None
-    return cast(RustMessages, getattr(native_bridge, "messages", None))
-
-
-def load_rust_amessages() -> RustAmessages | None:
-    if _STATE.amessages is not None:
-        return _STATE.amessages
-    from litellm.rust_bridge import get_native_bridge
-
-    native_bridge: Final = get_native_bridge()
-    if native_bridge is None:
-        return None
-    return cast(RustAmessages, getattr(native_bridge, "amessages", None))
+    if not isinstance(messages, Unchanged):
+        if messages is None:
+            _MESSAGES.sync.reset()
+        else:
+            _MESSAGES.sync.override(messages)
+    if not isinstance(amessages, Unchanged):
+        if amessages is None:
+            _MESSAGES.asynchronous.reset()
+        else:
+            _MESSAGES.asynchronous.override(amessages)
 
 
 def messages(
@@ -97,18 +80,22 @@ def messages(
     custom_llm_provider: str | None,
     extra_headers: dict[str, object] | None,
     timeout: float | httpx.Timeout | None,
+    request_override: bool | None = None,
 ) -> dict[str, object] | None:
-    rust_messages: Final = load_rust_messages()
-    if rust_messages is None:
-        return None
-    return rust_messages(
-        model=model,
-        body=body,
-        api_key=api_key,
-        api_base=api_base,
-        custom_llm_provider=custom_llm_provider,
-        extra_headers=extra_headers,
-        timeout_seconds=timeout_to_seconds(timeout),
+    return _MESSAGES.invoke(
+        call=lambda rust_messages: rust_messages(
+            model=model,
+            body=body,
+            api_key=api_key,
+            api_base=api_base,
+            custom_llm_provider=custom_llm_provider,
+            extra_headers=extra_headers,
+            timeout_seconds=timeout_to_seconds(timeout),
+        ),
+        fallback=lambda: None,
+        adapt=identity,
+        context=BridgeErrorContext(provider=custom_llm_provider or "", model=model),
+        request_override=request_override,
     )
 
 
@@ -121,16 +108,20 @@ async def amessages(
     custom_llm_provider: str | None,
     extra_headers: dict[str, object] | None,
     timeout: float | httpx.Timeout | None,
+    request_override: bool | None = None,
 ) -> dict[str, object] | None:
-    rust_amessages: Final = load_rust_amessages()
-    if rust_amessages is None:
-        return None
-    return await rust_amessages(
-        model=model,
-        body=body,
-        api_key=api_key,
-        api_base=api_base,
-        custom_llm_provider=custom_llm_provider,
-        extra_headers=extra_headers,
-        timeout_seconds=timeout_to_seconds(timeout),
+    return await _MESSAGES.ainvoke(
+        call=lambda rust_amessages: rust_amessages(
+            model=model,
+            body=body,
+            api_key=api_key,
+            api_base=api_base,
+            custom_llm_provider=custom_llm_provider,
+            extra_headers=extra_headers,
+            timeout_seconds=timeout_to_seconds(timeout),
+        ),
+        fallback=async_none,
+        adapt=identity,
+        context=BridgeErrorContext(provider=custom_llm_provider or "", model=model),
+        request_override=request_override,
     )

--- a/litellm/rust_bridge/ocr.py
+++ b/litellm/rust_bridge/ocr.py
@@ -2,16 +2,36 @@
 
 from __future__ import annotations
 
-from collections.abc import Awaitable
-from typing import Final, Protocol, cast  # noqa: TID251  # native extension exposes dynamically typed callables
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass
+from typing import Final, Protocol
 
 import httpx
 
 from litellm.rust_bridge import configuration as _configuration
+from litellm.rust_bridge.bindings import UNCHANGED, Unchanged
+from litellm.rust_bridge.runtime import (
+    BridgeErrorContext,
+    RustEndpoint,
+    async_none,
+    identity,
+)
 from litellm.rust_bridge.timeouts import timeout_to_seconds as _timeout_to_seconds
 
 rust_ocr_enabled = _configuration.rust_ocr_enabled
 rust = _configuration.rust
+
+
+@dataclass(frozen=True, slots=True)
+class RustOCRRequest:
+    model: str
+    document: dict[str, object]
+    api_key: str | None
+    api_base: str | None
+    custom_llm_provider: str | None
+    extra_headers: dict[str, object] | None
+    optional_params: dict[str, object]
+    timeout: float | httpx.Timeout | None
 
 
 class RustOcr(Protocol):
@@ -44,98 +64,88 @@ class RustAocr(Protocol):
         raise NotImplementedError
 
 
-class _Unset:
-    pass
-
-
-_UNSET: Final[_Unset] = _Unset()
-
-
-_rust_ocr_impl: RustOcr | None = None
-_rust_aocr_impl: RustAocr | None = None
+_OCR: Final[RustEndpoint[RustOcr, RustAocr]] = RustEndpoint.native(
+    route="ocr",
+    sync="ocr",
+    asynchronous="aocr",
+    enabled=_configuration.rust_ocr_enabled,
+)
 
 
 def set_rust_ocr(
     *,
-    ocr: RustOcr | None | _Unset = _UNSET,
-    aocr: RustAocr | None | _Unset = _UNSET,
+    ocr: RustOcr | None | Unchanged = UNCHANGED,
+    aocr: RustAocr | None | Unchanged = UNCHANGED,
 ) -> None:
-    global _rust_ocr_impl, _rust_aocr_impl
-    if not isinstance(ocr, _Unset):
-        _rust_ocr_impl = ocr
-    if not isinstance(aocr, _Unset):
-        _rust_aocr_impl = aocr
-
-
-def load_rust_ocr() -> RustOcr | None:
-    if _rust_ocr_impl is not None:
-        return _rust_ocr_impl
-    from litellm.rust_bridge import get_native_bridge
-
-    native_bridge: Final = get_native_bridge()
-    if native_bridge is None:
-        return None
-    return cast(RustOcr, native_bridge.ocr)
-
-
-def load_rust_aocr() -> RustAocr | None:
-    if _rust_aocr_impl is not None:
-        return _rust_aocr_impl
-    from litellm.rust_bridge import get_native_bridge
-
-    native_bridge: Final = get_native_bridge()
-    if native_bridge is None:
-        return None
-    return cast(RustAocr, getattr(native_bridge, "aocr", None))
+    if not isinstance(ocr, Unchanged):
+        if ocr is None:
+            _OCR.sync.reset()
+        else:
+            _OCR.sync.override(ocr)
+    if not isinstance(aocr, Unchanged):
+        if aocr is None:
+            _OCR.asynchronous.reset()
+        else:
+            _OCR.asynchronous.override(aocr)
 
 
 def ocr(
     *,
+    prepare: Callable[[], RustOCRRequest],
     model: str,
-    document: dict[str, object],
-    api_key: str | None,
-    api_base: str | None,
-    custom_llm_provider: str | None,
-    extra_headers: dict[str, object] | None,
-    optional_params: dict[str, object],
-    timeout: float | httpx.Timeout | None,
-) -> dict[str, object] | None:
-    rust_ocr: Final = load_rust_ocr()
-    if rust_ocr is None:
-        return None
-    return rust_ocr(
-        model=model,
-        document=document,
-        api_key=api_key,
-        api_base=api_base,
-        custom_llm_provider=custom_llm_provider,
-        extra_headers=extra_headers,
-        optional_params=optional_params,
-        timeout_seconds=_timeout_to_seconds(timeout),
+    provider: str,
+    request_override: bool | None,
+    eligible: bool,
+) -> Mapping[str, object] | None:
+    return _OCR.invoke(
+        call=lambda rust_ocr: _call_ocr(rust_ocr, prepare()),
+        fallback=lambda: None,
+        adapt=identity,
+        context=BridgeErrorContext(provider=provider, model=model),
+        request_override=request_override,
+        eligible=eligible,
     )
 
 
 async def aocr(
     *,
+    prepare: Callable[[], RustOCRRequest],
     model: str,
-    document: dict[str, object],
-    api_key: str | None,
-    api_base: str | None,
-    custom_llm_provider: str | None,
-    extra_headers: dict[str, object] | None,
-    optional_params: dict[str, object],
-    timeout: float | httpx.Timeout | None,
-) -> dict[str, object] | None:
-    rust_aocr: Final = load_rust_aocr()
-    if rust_aocr is None:
-        return None
-    return await rust_aocr(
-        model=model,
-        document=document,
-        api_key=api_key,
-        api_base=api_base,
-        custom_llm_provider=custom_llm_provider,
-        extra_headers=extra_headers,
-        optional_params=optional_params,
-        timeout_seconds=_timeout_to_seconds(timeout),
+    provider: str,
+    request_override: bool | None,
+    eligible: bool,
+) -> Mapping[str, object] | None:
+    return await _OCR.ainvoke(
+        call=lambda rust_aocr: _call_aocr(rust_aocr, prepare()),
+        fallback=async_none,
+        adapt=identity,
+        context=BridgeErrorContext(provider=provider, model=model),
+        request_override=request_override,
+        eligible=eligible,
+    )
+
+
+def _call_ocr(rust_ocr: RustOcr, request: RustOCRRequest) -> Mapping[str, object]:
+    return rust_ocr(
+        model=request.model,
+        document=request.document,
+        api_key=request.api_key,
+        api_base=request.api_base,
+        custom_llm_provider=request.custom_llm_provider,
+        extra_headers=request.extra_headers,
+        optional_params=request.optional_params,
+        timeout_seconds=_timeout_to_seconds(request.timeout),
+    )
+
+
+def _call_aocr(rust_aocr: RustAocr, request: RustOCRRequest) -> Awaitable[Mapping[str, object]]:
+    return rust_aocr(
+        model=request.model,
+        document=request.document,
+        api_key=request.api_key,
+        api_base=request.api_base,
+        custom_llm_provider=request.custom_llm_provider,
+        extra_headers=request.extra_headers,
+        optional_params=request.optional_params,
+        timeout_seconds=_timeout_to_seconds(request.timeout),
     )

--- a/litellm/rust_bridge/responses.py
+++ b/litellm/rust_bridge/responses.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Final, Protocol
+
+from litellm.rust_bridge.configuration import rust_enabled
+from litellm.rust_bridge.runtime import BridgeErrorContext, RustEndpoint, async_none, identity
+
+
+class RustResponses(Protocol):
+    def __call__(self, request: Mapping[str, object]) -> Mapping[str, object]: ...
+
+
+class RustAresponses(Protocol):
+    def __call__(self, request: Mapping[str, object]) -> Awaitable[Mapping[str, object]]: ...
+
+
+_RESPONSES: Final[RustEndpoint[RustResponses, RustAresponses]] = RustEndpoint.native(
+    route="responses",
+    sync="responses",
+    asynchronous="aresponses",
+    enabled=rust_enabled,
+)
+
+
+def responses(
+    *,
+    prepare: Callable[[], Mapping[str, object]],
+    model: str,
+    provider: str,
+    request_override: bool | None = None,
+) -> Mapping[str, object] | None:
+    return _RESPONSES.invoke(
+        call=lambda rust_responses: rust_responses(prepare()),
+        fallback=lambda: None,
+        adapt=identity,
+        context=BridgeErrorContext(provider=provider, model=model),
+        request_override=request_override,
+    )
+
+
+async def aresponses(
+    *,
+    prepare: Callable[[], Mapping[str, object]],
+    model: str,
+    provider: str,
+    request_override: bool | None = None,
+) -> Mapping[str, object] | None:
+    return await _RESPONSES.ainvoke(
+        call=lambda rust_aresponses: rust_aresponses(prepare()),
+        fallback=async_none,
+        adapt=identity,
+        context=BridgeErrorContext(provider=provider, model=model),
+        request_override=request_override,
+    )

--- a/litellm/rust_bridge/responses_websocket.py
+++ b/litellm/rust_bridge/responses_websocket.py
@@ -2,13 +2,18 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import Final, Protocol
 
 import httpx
 from websockets.exceptions import ConnectionClosedOK
 
-from litellm.rust_bridge.loader import get_native_bridge
+from litellm.rust_bridge.bindings import UNCHANGED, Unchanged
+from litellm.rust_bridge.configuration import rust_enabled
+from litellm.rust_bridge.runtime import (
+    BridgeErrorContext,
+    RustBridge,
+    async_none,
+)
 from litellm.rust_bridge.timeouts import timeout_to_seconds
 
 
@@ -30,39 +35,22 @@ class RustResponsesWebSocketConnection(Protocol):
     ) -> RustResponsesWebSocket: ...
 
 
-class _Unset:
-    pass
-
-
-_UNSET: Final[_Unset] = _Unset()
-
-
-@dataclass(slots=True)
-class _RustResponsesWebSocketState:
-    connection: RustResponsesWebSocketConnection | None = None
-
-
-_STATE: Final[_RustResponsesWebSocketState] = _RustResponsesWebSocketState()
+_RESPONSES_WEBSOCKET: Final[RustBridge[RustResponsesWebSocketConnection]] = RustBridge.native(
+    route="responses websocket",
+    attribute="ResponsesWebSocketConnection",
+    enabled=rust_enabled,
+)
 
 
 def set_rust_responses_websocket(
     *,
-    connection: RustResponsesWebSocketConnection | None | _Unset = _UNSET,
+    connection: RustResponsesWebSocketConnection | None | Unchanged = UNCHANGED,
 ) -> None:
-    if not isinstance(connection, _Unset):
-        _STATE.connection = connection
-
-
-def load_rust_responses_websocket() -> RustResponsesWebSocketConnection | None:
-    if _STATE.connection is not None:
-        return _STATE.connection
-    native_bridge: Final = get_native_bridge()
-    if native_bridge is None:
-        return None
-    connection_type: Final[RustResponsesWebSocketConnection | None] = getattr(
-        native_bridge, "ResponsesWebSocketConnection", None
-    )
-    return connection_type
+    if not isinstance(connection, Unchanged):
+        if connection is None:
+            _RESPONSES_WEBSOCKET.reset()
+        else:
+            _RESPONSES_WEBSOCKET.override(connection)
 
 
 class _ConnectionAdapter:
@@ -87,16 +75,16 @@ async def connect(
     url: str,
     headers: dict[str, str],
     timeout: float | httpx.Timeout | None,
+    request_override: bool | None = None,
 ) -> _ConnectionAdapter | None:
-    connection_type: Final = load_rust_responses_websocket()
-    if connection_type is None:
-        return None
-    try:
-        connection: Final = await connection_type.connect(
+    return await _RESPONSES_WEBSOCKET.ainvoke(
+        call=lambda connection_type: connection_type.connect(
             url=url,
             headers=headers,
             timeout_seconds=timeout_to_seconds(timeout),
-        )
-    except Exception:  # noqa: BLE001  # bridge failures must fall back to Python
-        return None
-    return _ConnectionAdapter(connection)
+        ),
+        fallback=async_none,
+        adapt=_ConnectionAdapter,
+        context=BridgeErrorContext(provider="openai", model="responses websocket"),
+        request_override=request_override,
+    )

--- a/litellm/rust_bridge/responses_websocket.py
+++ b/litellm/rust_bridge/responses_websocket.py
@@ -76,6 +76,7 @@ async def connect(
     headers: dict[str, str],
     timeout: float | httpx.Timeout | None,
     request_override: bool | None = None,
+    eligible: bool = True,
 ) -> _ConnectionAdapter | None:
     return await _RESPONSES_WEBSOCKET.ainvoke(
         call=lambda connection_type: connection_type.connect(
@@ -87,4 +88,5 @@ async def connect(
         adapt=_ConnectionAdapter,
         context=BridgeErrorContext(provider="openai", model="responses websocket"),
         request_override=request_override,
+        eligible=eligible,
     )

--- a/litellm/rust_bridge/runtime.py
+++ b/litellm/rust_bridge/runtime.py
@@ -1,20 +1,29 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
-from typing import Final, Generic, NoReturn, TypeAlias, TypeVar
+from typing import Final, Generic, NoReturn, Protocol, TypeAlias, TypeVar
 
 from litellm.exceptions import APIError
-from litellm.rust_bridge.bindings import native_exception_types
+from litellm.rust_bridge.bindings import (
+    UNCHANGED,
+    NativeBinding,
+    Unchanged,
+    native_exception_types,
+)
 
+BindingT = TypeVar("BindingT")
 NativeT = TypeVar("NativeT")
 ResultT = TypeVar("ResultT")
+SyncBindingT = TypeVar("SyncBindingT")
+AsyncBindingT = TypeVar("AsyncBindingT")
 
 
-class FallbackMode(Enum):
-    PYTHON = "python"
-    RUST_REQUIRED = "rust_required"
+class PythonFallbackReason(Enum):
+    RUST_DISABLED = "rust_disabled"
+    RUST_UNAVAILABLE = "rust_unavailable"
+    RUST_DECLINED = "rust_declined"
 
 
 @dataclass(frozen=True, slots=True)
@@ -23,153 +32,410 @@ class RustHandled(Generic[ResultT]):
 
 
 @dataclass(frozen=True, slots=True)
-class RustDeclined:
-    reason: str
+class PythonFallback:
+    reason: PythonFallbackReason
+    detail: str | None = None
 
 
-@dataclass(frozen=True, slots=True)
-class RustUnavailable:
-    pass
-
-
-RustAttempt: TypeAlias = RustHandled[ResultT] | RustDeclined | RustUnavailable
+RustDispatchResult: TypeAlias = RustHandled[ResultT] | PythonFallback
 
 
 @dataclass(frozen=True, slots=True)
 class BridgeErrorContext:
-    route: str
     provider: str
     model: str
 
 
-def invoke(
-    *,
-    native_call: Callable[[], NativeT] | None,
-    fallback: Callable[[], ResultT],
-    adapt: Callable[[NativeT], ResultT],
-    mode: FallbackMode,
-    context: BridgeErrorContext,
-) -> ResultT:
-    result: Final = attempt(native_call=native_call, adapt=adapt, context=context)
-    if isinstance(result, RustHandled):
-        return result.value
-    if mode is FallbackMode.PYTHON:
-        return fallback()
-    _raise_required(result, context)
+class RustEnablement(Protocol):
+    def __call__(self, *, request_override: bool | None = None) -> bool: ...
 
 
-async def ainvoke(
-    *,
-    native_call: Callable[[], Awaitable[NativeT]] | None,
-    fallback: Callable[[], Awaitable[ResultT]],
-    adapt: Callable[[NativeT], ResultT],
-    mode: FallbackMode,
-    context: BridgeErrorContext,
-) -> ResultT:
-    result: Final = await aattempt(native_call=native_call, adapt=adapt, context=context)
-    if isinstance(result, RustHandled):
-        return result.value
-    if mode is FallbackMode.PYTHON:
-        return await fallback()
-    _raise_required(result, context)
+@dataclass(frozen=True, slots=True)
+class RustBridge(Generic[BindingT]):
+    route: str
+    load: Callable[[], BindingT | None]
+    enabled: RustEnablement
+    _native_binding: NativeBinding[BindingT] | None = field(default=None, repr=False)
+
+    @classmethod
+    def native(
+        cls,
+        *,
+        route: str,
+        attribute: str,
+        enabled: RustEnablement,
+    ) -> RustBridge[BindingT]:
+        binding: NativeBinding[BindingT] = NativeBinding.callable(attribute)
+        return cls(
+            route=route,
+            load=binding.load,
+            enabled=enabled,
+            _native_binding=binding,
+        )
+
+    def override(self, value: BindingT | None) -> None:
+        if self._native_binding is None:
+            raise RuntimeError("only native Rust bridges support binding overrides")
+        self._native_binding.override(value)
+
+    def reset(self) -> None:
+        if self._native_binding is None:
+            raise RuntimeError("only native Rust bridges support binding resets")
+        self._native_binding.reset()
+
+    def _attempt(
+        self,
+        *,
+        call: Callable[[BindingT], NativeT],
+        adapt: Callable[[NativeT], ResultT],
+        context: BridgeErrorContext,
+        request_override: bool | None = None,
+        eligible: bool = True,
+    ) -> RustDispatchResult[ResultT]:
+        binding_or_fallback: Final = self._binding_or_python_fallback(
+            request_override=request_override,
+            eligible=eligible,
+        )
+        if isinstance(binding_or_fallback, PythonFallback):
+            return binding_or_fallback
+        return self._attempt_call(
+            call=lambda: call(binding_or_fallback),
+            adapt=adapt,
+            context=context,
+        )
+
+    async def _aattempt(
+        self,
+        *,
+        call: Callable[[BindingT], Awaitable[NativeT]],
+        adapt: Callable[[NativeT], ResultT],
+        context: BridgeErrorContext,
+        request_override: bool | None = None,
+        eligible: bool = True,
+    ) -> RustDispatchResult[ResultT]:
+        binding_or_fallback: Final = self._binding_or_python_fallback(
+            request_override=request_override,
+            eligible=eligible,
+        )
+        if isinstance(binding_or_fallback, PythonFallback):
+            return binding_or_fallback
+        return await self._attempt_acall(
+            call=lambda: call(binding_or_fallback),
+            adapt=adapt,
+            context=context,
+        )
+
+    def invoke(
+        self,
+        *,
+        call: Callable[[BindingT], NativeT],
+        fallback: Callable[[], ResultT],
+        adapt: Callable[[NativeT], ResultT],
+        context: BridgeErrorContext,
+        request_override: bool | None = None,
+        eligible: bool = True,
+    ) -> ResultT:
+        result: Final = self._attempt(
+            call=call,
+            adapt=adapt,
+            context=context,
+            request_override=request_override,
+            eligible=eligible,
+        )
+        match result:
+            case RustHandled(value=value):
+                return value
+            case PythonFallback():
+                return fallback()
+
+    async def ainvoke(
+        self,
+        *,
+        call: Callable[[BindingT], Awaitable[NativeT]],
+        fallback: Callable[[], Awaitable[ResultT]],
+        adapt: Callable[[NativeT], ResultT],
+        context: BridgeErrorContext,
+        request_override: bool | None = None,
+        eligible: bool = True,
+    ) -> ResultT:
+        result: Final = await self._aattempt(
+            call=call,
+            adapt=adapt,
+            context=context,
+            request_override=request_override,
+            eligible=eligible,
+        )
+        match result:
+            case RustHandled(value=value):
+                return value
+            case PythonFallback():
+                return await fallback()
+
+    def require(
+        self,
+        *,
+        call: Callable[[BindingT], NativeT],
+        adapt: Callable[[NativeT], ResultT],
+        context: BridgeErrorContext,
+        request_override: bool | None = None,
+        eligible: bool = True,
+    ) -> ResultT:
+        result: Final = self._attempt(
+            call=call,
+            adapt=adapt,
+            context=context,
+            request_override=request_override,
+            eligible=eligible,
+        )
+        match result:
+            case RustHandled(value=value):
+                return value
+            case PythonFallback():
+                self._raise_required(result)
+
+    async def arequire(
+        self,
+        *,
+        call: Callable[[BindingT], Awaitable[NativeT]],
+        adapt: Callable[[NativeT], ResultT],
+        context: BridgeErrorContext,
+        request_override: bool | None = None,
+        eligible: bool = True,
+    ) -> ResultT:
+        result: Final = await self._aattempt(
+            call=call,
+            adapt=adapt,
+            context=context,
+            request_override=request_override,
+            eligible=eligible,
+        )
+        match result:
+            case RustHandled(value=value):
+                return value
+            case PythonFallback():
+                self._raise_required(result)
+
+    def accepts(
+        self,
+        *,
+        check: Callable[[BindingT], str | None],
+        request_override: bool | None = None,
+        eligible: bool = True,
+    ) -> bool:
+        binding_or_fallback: Final = self._binding_or_python_fallback(
+            request_override=request_override,
+            eligible=eligible,
+        )
+        if isinstance(binding_or_fallback, PythonFallback):
+            return False
+        try:
+            reason: Final = check(binding_or_fallback)
+        except Exception:  # noqa: BLE001  # preflight performs no provider I/O, so Python handoff is safe
+            return False
+        return reason is None
+
+    def _binding_or_python_fallback(
+        self,
+        *,
+        request_override: bool | None,
+        eligible: bool,
+    ) -> BindingT | PythonFallback:
+        if not eligible or not self.enabled(request_override=request_override):
+            return PythonFallback(PythonFallbackReason.RUST_DISABLED)
+        binding: Final = self.load()
+        if binding is None:
+            return PythonFallback(PythonFallbackReason.RUST_UNAVAILABLE)
+        return binding
+
+    def _attempt_call(
+        self,
+        *,
+        call: Callable[[], NativeT],
+        adapt: Callable[[NativeT], ResultT],
+        context: BridgeErrorContext,
+    ) -> RustDispatchResult[ResultT]:
+        exceptions: Final = native_exception_types()
+        if exceptions is None:
+            return RustHandled(adapt(call()))
+        declined, upstream = exceptions
+        try:
+            value: Final = call()
+        except declined as error:
+            return PythonFallback(PythonFallbackReason.RUST_DECLINED, _error_message(error))
+        except upstream as error:
+            self._raise_upstream(error, context)
+        return RustHandled(adapt(value))
+
+    async def _attempt_acall(
+        self,
+        *,
+        call: Callable[[], Awaitable[NativeT]],
+        adapt: Callable[[NativeT], ResultT],
+        context: BridgeErrorContext,
+    ) -> RustDispatchResult[ResultT]:
+        exceptions: Final = native_exception_types()
+        if exceptions is None:
+            return RustHandled(adapt(await call()))
+        declined, upstream = exceptions
+        try:
+            value: Final = await call()
+        except declined as error:
+            return PythonFallback(PythonFallbackReason.RUST_DECLINED, _error_message(error))
+        except upstream as error:
+            self._raise_upstream(error, context)
+        return RustHandled(adapt(value))
+
+    def _raise_required(self, fallback: PythonFallback) -> NoReturn:
+        detail: Final = f": {fallback.detail}" if fallback.detail else ""
+        reason: Final = _required_reason(fallback.reason)
+        raise RuntimeError(f"Rust {self.route} bridge {reason}{detail}")
+
+    def _raise_upstream(self, error: BaseException, context: BridgeErrorContext) -> NoReturn:
+        args: Final[tuple[object, ...]] = error.args
+        attribute_status: Final = getattr(error, "status_code", None)
+        attribute_message: Final = getattr(error, "message", None)
+        status_value: Final = attribute_status if isinstance(attribute_status, int) else (args[0] if args else 0)
+        message_value: Final = (
+            attribute_message if isinstance(attribute_message, str) else (args[1] if len(args) > 1 else str(error))
+        )
+        status: Final = status_value if isinstance(status_value, int) else 0
+        message: Final = message_value if isinstance(message_value, str) else str(message_value)
+        raise APIError(
+            status_code=status or 500,
+            message=f"litellm rust {self.route}: {message}",
+            llm_provider=context.provider,
+            model=context.model,
+        ) from error
 
 
-def attempt(
-    *,
-    native_call: Callable[[], NativeT] | None,
-    adapt: Callable[[NativeT], ResultT],
-    context: BridgeErrorContext,
-) -> RustAttempt[ResultT]:
-    if native_call is None:
-        return RustUnavailable()
-    exceptions: Final = native_exception_types()
-    if exceptions is None:
-        return RustHandled(adapt(native_call()))
-    declined, upstream = exceptions
-    try:
-        value: Final = native_call()
-    except declined as error:
-        return RustDeclined(reason=_decline_reason(error))
-    except upstream as error:
-        _raise_upstream(error, context)
-    return RustHandled(adapt(value))
+@dataclass(frozen=True, slots=True)
+class RustEndpoint(Generic[SyncBindingT, AsyncBindingT]):
+    sync: RustBridge[SyncBindingT]
+    asynchronous: RustBridge[AsyncBindingT]
+
+    @classmethod
+    def native(
+        cls,
+        *,
+        route: str,
+        sync: str,
+        asynchronous: str,
+        enabled: RustEnablement,
+    ) -> RustEndpoint[SyncBindingT, AsyncBindingT]:
+        return cls(
+            sync=RustBridge.native(route=route, attribute=sync, enabled=enabled),
+            asynchronous=RustBridge.native(
+                route=route,
+                attribute=asynchronous,
+                enabled=enabled,
+            ),
+        )
+
+    def override(
+        self,
+        *,
+        sync: SyncBindingT | None | Unchanged = UNCHANGED,
+        asynchronous: AsyncBindingT | None | Unchanged = UNCHANGED,
+    ) -> None:
+        if not isinstance(sync, Unchanged):
+            self.sync.override(sync)
+        if not isinstance(asynchronous, Unchanged):
+            self.asynchronous.override(asynchronous)
+
+    def reset(self) -> None:
+        self.sync.reset()
+        self.asynchronous.reset()
+
+    def invoke(
+        self,
+        *,
+        call: Callable[[SyncBindingT], NativeT],
+        fallback: Callable[[], ResultT],
+        adapt: Callable[[NativeT], ResultT],
+        context: BridgeErrorContext,
+        request_override: bool | None = None,
+        eligible: bool = True,
+    ) -> ResultT:
+        return self.sync.invoke(
+            call=call,
+            fallback=fallback,
+            adapt=adapt,
+            context=context,
+            request_override=request_override,
+            eligible=eligible,
+        )
+
+    async def ainvoke(
+        self,
+        *,
+        call: Callable[[AsyncBindingT], Awaitable[NativeT]],
+        fallback: Callable[[], Awaitable[ResultT]],
+        adapt: Callable[[NativeT], ResultT],
+        context: BridgeErrorContext,
+        request_override: bool | None = None,
+        eligible: bool = True,
+    ) -> ResultT:
+        return await self.asynchronous.ainvoke(
+            call=call,
+            fallback=fallback,
+            adapt=adapt,
+            context=context,
+            request_override=request_override,
+            eligible=eligible,
+        )
+
+    def require(
+        self,
+        *,
+        call: Callable[[SyncBindingT], NativeT],
+        adapt: Callable[[NativeT], ResultT],
+        context: BridgeErrorContext,
+        request_override: bool | None = None,
+        eligible: bool = True,
+    ) -> ResultT:
+        return self.sync.require(
+            call=call,
+            adapt=adapt,
+            context=context,
+            request_override=request_override,
+            eligible=eligible,
+        )
+
+    async def arequire(
+        self,
+        *,
+        call: Callable[[AsyncBindingT], Awaitable[NativeT]],
+        adapt: Callable[[NativeT], ResultT],
+        context: BridgeErrorContext,
+        request_override: bool | None = None,
+        eligible: bool = True,
+    ) -> ResultT:
+        return await self.asynchronous.arequire(
+            call=call,
+            adapt=adapt,
+            context=context,
+            request_override=request_override,
+            eligible=eligible,
+        )
 
 
-async def aattempt(
-    *,
-    native_call: Callable[[], Awaitable[NativeT]] | None,
-    adapt: Callable[[NativeT], ResultT],
-    context: BridgeErrorContext,
-) -> RustAttempt[ResultT]:
-    if native_call is None:
-        return RustUnavailable()
-    exceptions: Final = native_exception_types()
-    if exceptions is None:
-        return RustHandled(adapt(await native_call()))
-    declined, upstream = exceptions
-    try:
-        value: Final = await native_call()
-    except declined as error:
-        return RustDeclined(reason=_decline_reason(error))
-    except upstream as error:
-        _raise_upstream(error, context)
-    return RustHandled(adapt(value))
-
-
-def call(operation: Callable[[], ResultT], context: BridgeErrorContext) -> ResultT:
-    exceptions: Final = native_exception_types()
-    if exceptions is None:
-        return operation()
-    upstream: Final = exceptions[1]
-    try:
-        return operation()
-    except upstream as error:
-        _raise_upstream(error, context)
-
-
-async def acall(operation: Callable[[], Awaitable[ResultT]], context: BridgeErrorContext) -> ResultT:
-    exceptions: Final = native_exception_types()
-    if exceptions is None:
-        return await operation()
-    upstream: Final = exceptions[1]
-    try:
-        return await operation()
-    except upstream as error:
-        _raise_upstream(error, context)
-
-
-def _decline_reason(error: BaseException) -> str:
+def _error_message(error: BaseException) -> str:
     reason: Final[object] = error.args[0] if error.args else str(error)
     return reason if isinstance(reason, str) else str(reason)
 
 
-def _raise_required(
-    result: RustDeclined | RustUnavailable,
-    context: BridgeErrorContext,
-) -> NoReturn:
-    raise RuntimeError(f"Rust {context.route} bridge {_required_reason(result)}")
-
-
-def _required_reason(result: RustDeclined | RustUnavailable) -> str:
-    match result:
-        case RustUnavailable():
+def _required_reason(reason: PythonFallbackReason) -> str:
+    match reason:
+        case PythonFallbackReason.RUST_DISABLED:
+            return "is disabled"
+        case PythonFallbackReason.RUST_UNAVAILABLE:
             return "is unavailable"
-        case RustDeclined(reason=reason):
-            return f"declined the request: {reason}"
+        case PythonFallbackReason.RUST_DECLINED:
+            return "declined the request"
 
 
-def _raise_upstream(error: BaseException, context: BridgeErrorContext) -> NoReturn:
-    args: Final[tuple[object, ...]] = error.args
-    status_value: Final = args[0] if args else 0
-    message_value: Final = args[1] if len(args) > 1 else str(error)
-    status: Final = status_value if isinstance(status_value, int) else 0
-    message: Final = message_value if isinstance(message_value, str) else str(message_value)
-    raise APIError(
-        status_code=status or 500,
-        message=f"litellm rust {context.route}: {message}",
-        llm_provider=context.provider,
-        model=context.model,
-    ) from error
+def always_enabled(*, request_override: bool | None = None) -> bool:
+    return True
 
 
 def identity(value: ResultT) -> ResultT:

--- a/litellm/rust_bridge/transcription.py
+++ b/litellm/rust_bridge/transcription.py
@@ -1,11 +1,17 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable
-from dataclasses import dataclass
-from typing import Final, Protocol, cast
+from typing import Final, Protocol
 
 import httpx
 
+from litellm.rust_bridge.bindings import UNCHANGED, Unchanged
+from litellm.rust_bridge.runtime import (
+    BridgeErrorContext,
+    RustEndpoint,
+    always_enabled,
+    identity,
+)
 from litellm.rust_bridge.timeouts import timeout_to_seconds
 
 
@@ -39,62 +45,30 @@ class RustAtranscription(Protocol):
         raise NotImplementedError
 
 
-class _Unset:
-    pass
-
-
-_UNSET: Final[_Unset] = _Unset()
-
-
-@dataclass
-class _RustTranscriptionState:
-    transcription: RustTranscription | None = None
-    atranscription: RustAtranscription | None = None
-
-
-_STATE: Final = _RustTranscriptionState()
+_TRANSCRIPTION: Final[RustEndpoint[RustTranscription, RustAtranscription]] = RustEndpoint.native(
+    route="audio transcription",
+    sync="transcription",
+    asynchronous="atranscription",
+    enabled=always_enabled,
+)
 
 
 def configure_rust_transcription(
     enabled: bool = True,
     *,
-    transcription: RustTranscription | None | _Unset = _UNSET,
-    atranscription: RustAtranscription | None | _Unset = _UNSET,
+    transcription: RustTranscription | None | Unchanged = UNCHANGED,
+    atranscription: RustAtranscription | None | Unchanged = UNCHANGED,
 ) -> None:
-    if not isinstance(transcription, _Unset):
-        _STATE.transcription = transcription
-    if not isinstance(atranscription, _Unset):
-        _STATE.atranscription = atranscription
-
-
-def load_rust_transcription() -> RustTranscription | None:
-    if _STATE.transcription is not None:
-        return _STATE.transcription
-    from litellm.rust_bridge import get_native_bridge
-
-    native_bridge: Final = get_native_bridge()
-    return (
-        None
-        if native_bridge is None
-        else cast(  # cast-ok: native extension protocol is runtime-defined
-            RustTranscription, getattr(native_bridge, "transcription", None)
-        )
-    )
-
-
-def load_rust_atranscription() -> RustAtranscription | None:
-    if _STATE.atranscription is not None:
-        return _STATE.atranscription
-    from litellm.rust_bridge import get_native_bridge
-
-    native_bridge: Final = get_native_bridge()
-    return (
-        None
-        if native_bridge is None
-        else cast(  # cast-ok: native extension protocol is runtime-defined
-            RustAtranscription, getattr(native_bridge, "atranscription", None)
-        )
-    )
+    if not isinstance(transcription, Unchanged):
+        if transcription is None:
+            _TRANSCRIPTION.sync.reset()
+        else:
+            _TRANSCRIPTION.sync.override(transcription)
+    if not isinstance(atranscription, Unchanged):
+        if atranscription is None:
+            _TRANSCRIPTION.asynchronous.reset()
+        else:
+            _TRANSCRIPTION.asynchronous.override(atranscription)
 
 
 def transcription(
@@ -107,19 +81,20 @@ def transcription(
     extra_headers: dict[str, object] | None,
     optional_params: dict[str, object],
     timeout: float | httpx.Timeout | None,
-) -> dict[str, object] | None:
-    rust_transcription: Final = load_rust_transcription()
-    if rust_transcription is None:
-        return None
-    return rust_transcription(
-        model=model,
-        audio=audio,
-        api_key=api_key,
-        api_base=api_base,
-        custom_llm_provider=custom_llm_provider,
-        extra_headers=extra_headers,
-        optional_params=optional_params,
-        timeout_seconds=timeout_to_seconds(timeout),
+) -> dict[str, object]:
+    return _TRANSCRIPTION.require(
+        call=lambda rust_transcription: rust_transcription(
+            model=model,
+            audio=audio,
+            api_key=api_key,
+            api_base=api_base,
+            custom_llm_provider=custom_llm_provider,
+            extra_headers=extra_headers,
+            optional_params=optional_params,
+            timeout_seconds=timeout_to_seconds(timeout),
+        ),
+        adapt=identity,
+        context=BridgeErrorContext(provider=custom_llm_provider or "", model=model),
     )
 
 
@@ -133,17 +108,18 @@ async def atranscription(
     extra_headers: dict[str, object] | None,
     optional_params: dict[str, object],
     timeout: float | httpx.Timeout | None,
-) -> dict[str, object] | None:
-    rust_atranscription: Final = load_rust_atranscription()
-    if rust_atranscription is None:
-        return None
-    return await rust_atranscription(
-        model=model,
-        audio=audio,
-        api_key=api_key,
-        api_base=api_base,
-        custom_llm_provider=custom_llm_provider,
-        extra_headers=extra_headers,
-        optional_params=optional_params,
-        timeout_seconds=timeout_to_seconds(timeout),
+) -> dict[str, object]:
+    return await _TRANSCRIPTION.arequire(
+        call=lambda rust_atranscription: rust_atranscription(
+            model=model,
+            audio=audio,
+            api_key=api_key,
+            api_base=api_base,
+            custom_llm_provider=custom_llm_provider,
+            extra_headers=extra_headers,
+            optional_params=optional_params,
+            timeout_seconds=timeout_to_seconds(timeout),
+        ),
+        adapt=identity,
+        context=BridgeErrorContext(provider=custom_llm_provider or "", model=model),
     )

--- a/tests/test_litellm/anthropic_interface/test_rust_bridge_messages.py
+++ b/tests/test_litellm/anthropic_interface/test_rust_bridge_messages.py
@@ -8,7 +8,7 @@ import pytest
 
 import litellm
 from litellm.llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
-from litellm.rust_bridge import configuration
+from litellm.rust_bridge import bindings, configuration
 from litellm.types.llms.anthropic_messages.anthropic_response import (
     AnthropicMessagesResponse,
 )
@@ -123,7 +123,7 @@ def test_load_rust_messages_returns_injected_impl():
     bridge = RecordingMessages()
     litellm.rust(True)
     rust_messages.set_rust_messages(messages=bridge)
-    assert rust_messages.load_rust_messages() is bridge
+    assert rust_messages._MESSAGES.sync.load() is bridge
 
 
 def test_bare_rust_still_toggles_ocr():
@@ -140,17 +140,16 @@ def test_load_rust_amessages_returns_injected_impl():
     bridge = RecordingAsyncMessages()
     litellm.rust(True)
     rust_messages.set_rust_messages(amessages=bridge)
-    assert rust_messages.load_rust_amessages() is bridge
+    assert rust_messages._MESSAGES.asynchronous.load() is bridge
 
 
 def test_messages_wrapper_returns_none_when_bridge_absent(monkeypatch):
     monkeypatch.setattr(
-        importlib.import_module("litellm.rust_bridge"),
+        bindings,
         "get_native_bridge",
         lambda: None,
     )
     litellm.rust(True)
-    assert rust_messages.load_rust_messages() is None
     result = rust_messages.messages(
         model="claude",
         body=REQUEST_BODY,
@@ -248,14 +247,14 @@ async def test_gate_invokes_rust_and_marks_response_header():
 
 
 @pytest.mark.asyncio
-async def test_gate_falls_back_to_python_when_bridge_raises():
+async def test_gate_does_not_handoff_on_unknown_bridge_failure():
     bridge = RaisingAsyncMessages()
     litellm.rust(True)
     rust_messages.set_rust_messages(amessages=bridge)
 
-    response = await _gate()
+    with pytest.raises(RuntimeError, match="upstream request failed"):
+        await _gate()
 
-    assert response is None
     assert bridge.calls == 1
 
 
@@ -405,7 +404,7 @@ async def test_fake_stream_wraps_rust_response_as_anthropic_sse():
 @pytest.mark.asyncio
 async def test_gate_falls_back_when_bridge_unavailable(monkeypatch):
     monkeypatch.setattr(
-        importlib.import_module("litellm.rust_bridge"),
+        bindings,
         "get_native_bridge",
         lambda: None,
     )

--- a/tests/test_litellm/anthropic_interface/test_rust_bridge_messages.py
+++ b/tests/test_litellm/anthropic_interface/test_rust_bridge_messages.py
@@ -8,7 +8,7 @@ import pytest
 
 import litellm
 from litellm.llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
-from litellm.rust_bridge import bindings, configuration
+from litellm.rust_bridge import configuration
 from litellm.types.llms.anthropic_messages.anthropic_response import (
     AnthropicMessagesResponse,
 )
@@ -99,15 +99,6 @@ class ExplodingAsyncMessages:
         raise AssertionError("bridge must not be called")
 
 
-class RaisingAsyncMessages:
-    def __init__(self) -> None:
-        self.calls = 0
-
-    async def __call__(self, **kwargs: object) -> dict[str, object]:
-        self.calls += 1
-        raise RuntimeError("upstream request failed with status 400: bad request")
-
-
 @pytest.fixture(autouse=True)
 def _reset_rust_flag():
     rust_messages.set_rust_messages(messages=None, amessages=None)
@@ -117,49 +108,6 @@ def _reset_rust_flag():
     rust_messages.set_rust_messages(messages=None, amessages=None)
     configuration.reset_rust_configuration()
     rust_bridge_loader._cached_bridge = rust_bridge_loader._BRIDGE_SENTINEL
-
-
-def test_load_rust_messages_returns_injected_impl():
-    bridge = RecordingMessages()
-    litellm.rust(True)
-    rust_messages.set_rust_messages(messages=bridge)
-    assert rust_messages._MESSAGES.sync.load() is bridge
-
-
-def test_bare_rust_still_toggles_ocr():
-    from litellm.rust_bridge.ocr import rust_ocr_enabled
-
-    litellm.rust(True)
-    assert rust_ocr_enabled() is True
-
-    litellm.rust(False)
-    assert rust_ocr_enabled() is False
-
-
-def test_load_rust_amessages_returns_injected_impl():
-    bridge = RecordingAsyncMessages()
-    litellm.rust(True)
-    rust_messages.set_rust_messages(amessages=bridge)
-    assert rust_messages._MESSAGES.asynchronous.load() is bridge
-
-
-def test_messages_wrapper_returns_none_when_bridge_absent(monkeypatch):
-    monkeypatch.setattr(
-        bindings,
-        "get_native_bridge",
-        lambda: None,
-    )
-    litellm.rust(True)
-    result = rust_messages.messages(
-        model="claude",
-        body=REQUEST_BODY,
-        api_key="k",
-        api_base="b",
-        custom_llm_provider="azure_ai",
-        extra_headers={},
-        timeout=30.0,
-    )
-    assert result is None
 
 
 def test_messages_wrapper_forwards_args_and_converts_timeout():
@@ -247,50 +195,32 @@ async def test_gate_invokes_rust_and_marks_response_header():
 
 
 @pytest.mark.asyncio
-async def test_gate_does_not_handoff_on_unknown_bridge_failure():
-    bridge = RaisingAsyncMessages()
-    litellm.rust(True)
-    rust_messages.set_rust_messages(amessages=bridge)
-
-    with pytest.raises(RuntimeError, match="upstream request failed"):
-        await _gate()
-
-    assert bridge.calls == 1
-
-
-@pytest.mark.asyncio
-async def test_gate_skips_rust_when_flag_absent():
-    bridge = ExplodingAsyncMessages()
-    rust_messages.set_rust_messages(amessages=bridge)
-
-    response = await _gate(litellm_params=GenericLiteLLMParams(api_key="sk-azure"))
-
-    assert response is None
-    assert bridge.calls == 0
-
-
-@pytest.mark.asyncio
-async def test_gate_uses_process_enable_without_request_override():
+@pytest.mark.parametrize(
+    ("enablement", "expected_calls"),
+    (
+        pytest.param("disabled", 0, id="disabled"),
+        pytest.param("request-false", 0, id="request-false-over-process"),
+        pytest.param("process", 1, id="process-override"),
+        pytest.param("environment", 1, id="environment"),
+    ),
+)
+async def test_gate_respects_shared_enablement(
+    monkeypatch: pytest.MonkeyPatch,
+    enablement: str,
+    expected_calls: int,
+) -> None:
     bridge = RecordingAsyncMessages()
     rust_messages.set_rust_messages(amessages=bridge)
-    litellm.rust(True)
+    if enablement in {"request-false", "process"}:
+        litellm.rust(True)
+    if enablement == "environment":
+        monkeypatch.setenv("LITELLM_RUST", "1")
+    params = GenericLiteLLMParams(api_key="sk-azure", rust=False if enablement == "request-false" else None)
 
-    response = await _gate(litellm_params=GenericLiteLLMParams(api_key="sk-azure"))
+    response = await _gate(litellm_params=params)
 
-    assert response is not None
-    assert bridge.calls[0]["custom_llm_provider"] == "azure_ai"
-
-
-@pytest.mark.asyncio
-async def test_gate_skips_rust_when_flag_false():
-    bridge = ExplodingAsyncMessages()
-    litellm.rust(True)
-    rust_messages.set_rust_messages(amessages=bridge)
-
-    response = await _gate(litellm_params=GenericLiteLLMParams(api_key="sk-azure", rust=False))
-
-    assert response is None
-    assert bridge.calls == 0
+    assert len(bridge.calls) == expected_calls
+    assert (response["id"] if response is not None else None) == ("msg_123" if expected_calls else None)
 
 
 @pytest.mark.asyncio
@@ -311,36 +241,6 @@ async def test_gate_invokes_rust_for_native_anthropic_provider():
     assert response["_hidden_params"]["additional_headers"] == {"x-litellm-rust": "true"}
     assert bridge.calls[0]["custom_llm_provider"] == "anthropic"
     assert bridge.calls[0]["api_key"] == "sk-ant"
-
-
-@pytest.mark.asyncio
-async def test_gate_invokes_rust_when_env_var_set(monkeypatch):
-    bridge = RecordingAsyncMessages()
-    rust_messages.set_rust_messages(amessages=bridge)
-    monkeypatch.setenv("LITELLM_RUST", "1")
-
-    response = await _gate(
-        custom_llm_provider="anthropic",
-        litellm_params=GenericLiteLLMParams(api_key="sk-ant"),
-    )
-
-    assert response is not None
-    assert bridge.calls[0]["custom_llm_provider"] == "anthropic"
-
-
-@pytest.mark.asyncio
-async def test_gate_env_var_falsey_does_not_enable(monkeypatch):
-    bridge = ExplodingAsyncMessages()
-    rust_messages.set_rust_messages(amessages=bridge)
-    monkeypatch.setenv("LITELLM_RUST", "0")
-
-    response = await _gate(
-        custom_llm_provider="anthropic",
-        litellm_params=GenericLiteLLMParams(api_key="sk-ant"),
-    )
-
-    assert response is None
-    assert bridge.calls == 0
 
 
 @pytest.mark.asyncio
@@ -399,17 +299,3 @@ async def test_fake_stream_wraps_rust_response_as_anthropic_sse():
     assert b"event: content_block_delta" in joined
     assert b"hello world" in joined
     assert b"event: message_stop" in joined
-
-
-@pytest.mark.asyncio
-async def test_gate_falls_back_when_bridge_unavailable(monkeypatch):
-    monkeypatch.setattr(
-        bindings,
-        "get_native_bridge",
-        lambda: None,
-    )
-    litellm.rust(True)
-
-    response = await _gate()
-
-    assert response is None

--- a/tests/test_litellm/ocr/test_rust_bridge.py
+++ b/tests/test_litellm/ocr/test_rust_bridge.py
@@ -1,8 +1,6 @@
 """Tests for the optional Rust-backed OCR path."""
 
-import builtins
 import importlib
-import types
 from typing import Any, Final
 from unittest.mock import Mock
 
@@ -243,163 +241,10 @@ def fake_async_bridge():
     return bridge
 
 
-def test_rust_toggles_flag():
-    assert rust_bridge.rust_ocr_enabled() is False
-    litellm.rust(True)
-    assert rust_bridge.rust_ocr_enabled() is True
-    litellm.rust(False)
-    assert rust_bridge.rust_ocr_enabled() is False
-
-
-def test_env_var_enables_rust_ocr(monkeypatch):
-    monkeypatch.setenv("LITELLM_USE_RUST_OCR", "1")
-    with pytest.warns(DeprecationWarning, match="LITELLM_USE_RUST_OCR is deprecated"):
-        assert rust_bridge.rust_ocr_enabled() is True
-
-
 def test_explicit_false_overrides_process_enable():
     litellm.rust(True)
 
     assert ocr_main._rust_request_override(build_prepared_request(litellm_params={"rust": False})) is False
-
-
-def test_load_rust_ocr_returns_injected_impl():
-    bridge = RecordingBridge()
-    litellm.rust(True)
-    rust_bridge.set_rust_ocr(ocr=bridge)
-    assert rust_bridge._OCR.sync.load() is bridge
-
-
-def test_native_bridge_loader_returns_none_when_extension_absent(monkeypatch):
-    real_import = builtins.__import__
-
-    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
-        if name == "litellm.rust_bridge" and "_native" in fromlist:
-            raise ImportError
-        return real_import(name, globals, locals, fromlist, level)
-
-    monkeypatch.setattr(builtins, "__import__", fake_import)
-
-    assert rust_bridge_loader.get_native_bridge() is None
-
-
-def test_native_bridge_loader_caches_absent_extension(monkeypatch):
-    real_import = builtins.__import__
-    attempts = 0
-
-    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
-        nonlocal attempts
-        if name == "litellm.rust_bridge" and "_native" in fromlist:
-            attempts += 1
-            raise ImportError
-        return real_import(name, globals, locals, fromlist, level)
-
-    monkeypatch.setattr(builtins, "__import__", fake_import)
-
-    assert rust_bridge_loader.get_native_bridge() is None
-    assert rust_bridge_loader.get_native_bridge() is None
-    assert attempts == 1
-
-
-def test_native_bridge_loader_reset_forces_relookup(monkeypatch):
-    real_import = builtins.__import__
-    attempts = 0
-
-    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
-        nonlocal attempts
-        if name == "litellm.rust_bridge" and "_native" in fromlist:
-            attempts += 1
-            raise ImportError
-        return real_import(name, globals, locals, fromlist, level)
-
-    monkeypatch.setattr(builtins, "__import__", fake_import)
-
-    assert rust_bridge_loader.get_native_bridge() is None
-    rust_bridge_loader.reset_native_bridge_cache()
-    assert rust_bridge_loader.get_native_bridge() is None
-    assert attempts == 2
-
-
-def test_native_bridge_available_reflects_loader(monkeypatch):
-    fake_module = types.ModuleType("litellm.rust_bridge._native")
-    monkeypatch.setattr(rust_bridge_loader, "get_native_bridge", lambda: fake_module)
-
-    assert rust_bridge_loader.native_bridge_available() is True
-
-
-def test_load_rust_aocr_returns_injected_impl():
-    bridge = RecordingAsyncBridge()
-    litellm.rust(True)
-    rust_bridge.set_rust_ocr(aocr=bridge)
-    assert rust_bridge._OCR.asynchronous.load() is bridge
-
-
-def test_toggle_without_ocr_arg_preserves_injected_impl():
-    """The public flag must not clobber an internal test binding."""
-    bridge = RecordingBridge()
-    async_bridge = RecordingAsyncBridge()
-    litellm.rust(True)
-    rust_bridge.set_rust_ocr(ocr=bridge, aocr=async_bridge)
-
-    litellm.rust(False)
-    assert rust_bridge._OCR.sync.load() is bridge
-    assert rust_bridge._OCR.asynchronous.load() is async_bridge
-    litellm.rust(True)
-    assert rust_bridge._OCR.sync.load() is bridge
-    assert rust_bridge._OCR.asynchronous.load() is async_bridge
-
-
-def test_explicit_ocr_none_clears_injected_impl(monkeypatch):
-    monkeypatch.setattr(
-        bindings,
-        "get_native_bridge",
-        lambda: None,
-    )
-    bridge = RecordingBridge()
-    async_bridge = RecordingAsyncBridge()
-    litellm.rust(True)
-    rust_bridge.set_rust_ocr(ocr=bridge, aocr=async_bridge)
-
-    rust_bridge.set_rust_ocr(ocr=None, aocr=None)
-    assert rust_bridge._OCR.sync.load() is None
-    assert rust_bridge._OCR.asynchronous.load() is None
-
-
-def test_load_rust_ocr_none_when_extension_absent(monkeypatch):
-    """With no injected impl and no compiled wheel, the loader returns None so the
-    caller degrades to the Python path instead of raising ImportError."""
-    monkeypatch.setattr(
-        bindings,
-        "get_native_bridge",
-        lambda: None,
-    )
-    litellm.rust(True)  # no impl injected; extension isn't built in CI
-    assert rust_bridge._OCR.sync.load() is None
-    assert rust_bridge._OCR.asynchronous.load() is None
-
-
-def test_load_rust_ocr_uses_compiled_extension(monkeypatch):
-    """With no injected impl but a packaged ``litellm.rust_bridge._native`` importable,
-    the loader returns the extension's ``ocr`` callable. The native wheel isn't
-    built in CI, so stand in a fake module via the bridge loader."""
-    fake_module = types.ModuleType("litellm.rust_bridge._native")
-    fake_module.ocr = lambda **kwargs: dict(FAKE_OCR_RESPONSE)  # type: ignore[attr-defined]
-    fake_module.aocr = lambda **kwargs: dict(FAKE_OCR_RESPONSE)  # type: ignore[attr-defined]
-    monkeypatch.setattr(
-        bindings,
-        "get_native_bridge",
-        lambda: fake_module,
-    )
-
-    litellm.rust(True)  # enabled, no impl injected -> import the extension
-    assert rust_bridge._OCR.sync.load() is fake_module.ocr
-    assert rust_bridge._OCR.asynchronous.load() is fake_module.aocr
-
-
-def test_timeout_to_seconds_handles_float_timeout_and_none():
-    assert rust_bridge._timeout_to_seconds(12.5) == 12.5
-    assert rust_bridge._timeout_to_seconds(None) is None
-    assert rust_bridge._timeout_to_seconds(httpx.Timeout(30.0, read=42.0)) == 42.0
 
 
 def test_bridge_wrapper_forwards_prepared_args_and_wraps_response():

--- a/tests/test_litellm/ocr/test_rust_bridge.py
+++ b/tests/test_litellm/ocr/test_rust_bridge.py
@@ -3,14 +3,15 @@
 import builtins
 import importlib
 import types
-from typing import Any
+from typing import Any, Final
+from unittest.mock import Mock
 
 import httpx
 import pytest
 
 import litellm
 from litellm.llms.base_llm.ocr.transformation import OCRResponse
-from litellm.rust_bridge import configuration
+from litellm.rust_bridge import bindings, configuration
 
 # `litellm/__init__.py` does `from .ocr.main import *`, which binds the `ocr`
 # function onto `litellm.ocr` and shadows the submodule, so import the modules
@@ -259,14 +260,14 @@ def test_env_var_enables_rust_ocr(monkeypatch):
 def test_explicit_false_overrides_process_enable():
     litellm.rust(True)
 
-    assert ocr_main._rust_ocr_enabled(build_prepared_request(litellm_params={"rust": False})) is False
+    assert ocr_main._rust_request_override(build_prepared_request(litellm_params={"rust": False})) is False
 
 
 def test_load_rust_ocr_returns_injected_impl():
     bridge = RecordingBridge()
     litellm.rust(True)
     rust_bridge.set_rust_ocr(ocr=bridge)
-    assert rust_bridge.load_rust_ocr() is bridge
+    assert rust_bridge._OCR.sync.load() is bridge
 
 
 def test_native_bridge_loader_returns_none_when_extension_absent(monkeypatch):
@@ -330,7 +331,7 @@ def test_load_rust_aocr_returns_injected_impl():
     bridge = RecordingAsyncBridge()
     litellm.rust(True)
     rust_bridge.set_rust_ocr(aocr=bridge)
-    assert rust_bridge.load_rust_aocr() is bridge
+    assert rust_bridge._OCR.asynchronous.load() is bridge
 
 
 def test_toggle_without_ocr_arg_preserves_injected_impl():
@@ -341,16 +342,16 @@ def test_toggle_without_ocr_arg_preserves_injected_impl():
     rust_bridge.set_rust_ocr(ocr=bridge, aocr=async_bridge)
 
     litellm.rust(False)
-    assert rust_bridge.load_rust_ocr() is bridge
-    assert rust_bridge.load_rust_aocr() is async_bridge
+    assert rust_bridge._OCR.sync.load() is bridge
+    assert rust_bridge._OCR.asynchronous.load() is async_bridge
     litellm.rust(True)
-    assert rust_bridge.load_rust_ocr() is bridge
-    assert rust_bridge.load_rust_aocr() is async_bridge
+    assert rust_bridge._OCR.sync.load() is bridge
+    assert rust_bridge._OCR.asynchronous.load() is async_bridge
 
 
 def test_explicit_ocr_none_clears_injected_impl(monkeypatch):
     monkeypatch.setattr(
-        importlib.import_module("litellm.rust_bridge"),
+        bindings,
         "get_native_bridge",
         lambda: None,
     )
@@ -360,21 +361,21 @@ def test_explicit_ocr_none_clears_injected_impl(monkeypatch):
     rust_bridge.set_rust_ocr(ocr=bridge, aocr=async_bridge)
 
     rust_bridge.set_rust_ocr(ocr=None, aocr=None)
-    assert rust_bridge.load_rust_ocr() is None
-    assert rust_bridge.load_rust_aocr() is None
+    assert rust_bridge._OCR.sync.load() is None
+    assert rust_bridge._OCR.asynchronous.load() is None
 
 
 def test_load_rust_ocr_none_when_extension_absent(monkeypatch):
     """With no injected impl and no compiled wheel, the loader returns None so the
     caller degrades to the Python path instead of raising ImportError."""
     monkeypatch.setattr(
-        importlib.import_module("litellm.rust_bridge"),
+        bindings,
         "get_native_bridge",
         lambda: None,
     )
     litellm.rust(True)  # no impl injected; extension isn't built in CI
-    assert rust_bridge.load_rust_ocr() is None
-    assert rust_bridge.load_rust_aocr() is None
+    assert rust_bridge._OCR.sync.load() is None
+    assert rust_bridge._OCR.asynchronous.load() is None
 
 
 def test_load_rust_ocr_uses_compiled_extension(monkeypatch):
@@ -385,14 +386,14 @@ def test_load_rust_ocr_uses_compiled_extension(monkeypatch):
     fake_module.ocr = lambda **kwargs: dict(FAKE_OCR_RESPONSE)  # type: ignore[attr-defined]
     fake_module.aocr = lambda **kwargs: dict(FAKE_OCR_RESPONSE)  # type: ignore[attr-defined]
     monkeypatch.setattr(
-        importlib.import_module("litellm.rust_bridge"),
+        bindings,
         "get_native_bridge",
         lambda: fake_module,
     )
 
     litellm.rust(True)  # enabled, no impl injected -> import the extension
-    assert rust_bridge.load_rust_ocr() is fake_module.ocr
-    assert rust_bridge.load_rust_aocr() is fake_module.aocr
+    assert rust_bridge._OCR.sync.load() is fake_module.ocr
+    assert rust_bridge._OCR.asynchronous.load() is fake_module.aocr
 
 
 def test_timeout_to_seconds_handles_float_timeout_and_none():
@@ -408,14 +409,20 @@ def test_bridge_wrapper_forwards_prepared_args_and_wraps_response():
 
     rust_bridge.set_rust_ocr(ocr=bridge)
     response = rust_bridge.ocr(
+        prepare=lambda: rust_bridge.RustOCRRequest(
+            model="mistral-ocr-latest",
+            document=DOCUMENT,
+            api_key="sk-test",
+            api_base="https://proxy.internal",
+            custom_llm_provider="mistral",
+            extra_headers={"Authorization": "Bearer sk-test", "x-trace-id": "trace-1"},
+            optional_params={"include_image_base64": True, "pages": [0]},
+            timeout=12.5,
+        ),
         model="mistral-ocr-latest",
-        document=DOCUMENT,
-        api_key="sk-test",
-        api_base="https://proxy.internal",
-        custom_llm_provider="mistral",
-        extra_headers={"Authorization": "Bearer sk-test", "x-trace-id": "trace-1"},
-        optional_params={"include_image_base64": True, "pages": [0]},
-        timeout=12.5,
+        provider="mistral",
+        request_override=True,
+        eligible=True,
     )
 
     assert response == FAKE_OCR_RESPONSE
@@ -443,14 +450,20 @@ async def test_bridge_wrapper_forwards_prepared_async_args_and_wraps_response():
 
     rust_bridge.set_rust_ocr(aocr=bridge)
     response = await rust_bridge.aocr(
+        prepare=lambda: rust_bridge.RustOCRRequest(
+            model="mistral-ocr-maas",
+            document=DOCUMENT,
+            api_key=None,
+            api_base=None,
+            custom_llm_provider="vertex_ai",
+            extra_headers=None,
+            optional_params={"vertex_project": "project-1"},
+            timeout=httpx.Timeout(30.0, read=42.0),
+        ),
         model="mistral-ocr-maas",
-        document=DOCUMENT,
-        api_key=None,
-        api_base=None,
-        custom_llm_provider="vertex_ai",
-        extra_headers=None,
-        optional_params={"vertex_project": "project-1"},
-        timeout=httpx.Timeout(30.0, read=42.0),
+        provider="vertex_ai",
+        request_override=True,
+        eligible=True,
     )
 
     assert response == FAKE_OCR_RESPONSE
@@ -808,23 +821,27 @@ def test_ocr_passes_default_request_timeout_to_rust(fake_bridge):
     assert fake_bridge.calls[0]["timeout_seconds"] == float(request_timeout)
 
 
-def test_ocr_does_not_route_to_rust_when_disabled():
-    """With the flag off, the bridge must not be consulted even if an impl exists."""
-    bridge = RecordingBridge()
-    litellm.rust(False)
-    rust_bridge.set_rust_ocr(ocr=bridge)
+def test_ocr_disabled_never_loads_or_prepares_rust(monkeypatch: pytest.MonkeyPatch):
+    def fail() -> None:
+        pytest.fail("disabled OCR must not load or prepare Rust")
 
-    assert rust_bridge.rust_ocr_enabled() is False
-    # The impl stays available for injection, but the disabled flag gates usage,
-    # so ocr() never reaches the Rust path (asserted via the enabled-path test).
-    assert bridge.calls == []
+    python_ocr: Final = Mock(return_value=OCRResponse(pages=[], model="mistral-ocr-latest", object="ocr"))
+    litellm.rust(False)
+    monkeypatch.setattr(bindings, "get_native_bridge", fail)
+    monkeypatch.setattr(ocr_main, "_prepare_rust_ocr_call", fail)
+    monkeypatch.setattr(ocr_main.base_llm_http_handler, "ocr", python_ocr)
+
+    response: Final = litellm.ocr(model=MODEL, document=DOCUMENT, api_key="sk-test")
+
+    assert isinstance(response, OCRResponse)
+    python_ocr.assert_called_once()
 
 
 def test_ocr_falls_back_to_python_when_bridge_unavailable(monkeypatch):
     """Rust enabled but no bridge available (no injected impl, no compiled wheel):
     ocr() must degrade to the Python HTTP handler instead of raising."""
-    monkeypatch.setattr(rust_bridge, "load_rust_ocr", lambda: None)
-    litellm.rust(True)  # enabled, but load_rust_ocr() returns None in CI
+    rust_bridge._OCR.sync.override(None)
+    litellm.rust(True)
 
     captured = {}
 

--- a/tests/test_litellm/responses/test_rust_bridge_http.py
+++ b/tests/test_litellm/responses/test_rust_bridge_http.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from collections.abc import Generator, Mapping
+
+import pytest
+
+import litellm
+from litellm.rust_bridge import responses
+from litellm.types.llms.openai import ResponsesAPIResponse
+
+
+def _response_payload() -> dict[str, object]:
+    return {
+        "id": "resp_rust",
+        "object": "response",
+        "created_at": 1,
+        "status": "completed",
+        "model": "gpt-5",
+        "output": [],
+    }
+
+
+class RecordingResponses:
+    def __init__(self) -> None:
+        self.requests: list[dict[str, object]] = []
+
+    def __call__(self, request: Mapping[str, object]) -> dict[str, object]:
+        self.requests.append(dict(request))
+        return _response_payload()
+
+
+class RecordingAresponses:
+    def __init__(self) -> None:
+        self.requests: list[dict[str, object]] = []
+
+    async def __call__(self, request: Mapping[str, object]) -> dict[str, object]:
+        self.requests.append(dict(request))
+        return _response_payload()
+
+
+@pytest.fixture(autouse=True)
+def reset_responses_endpoint() -> Generator[None]:
+    responses._RESPONSES.reset()
+    yield
+    responses._RESPONSES.reset()
+
+
+def test_top_level_responses_uses_shared_rust_handoff() -> None:
+    binding = RecordingResponses()
+    responses._RESPONSES.override(sync=binding)
+
+    result = litellm.responses(model="openai/gpt-5", input="hello", rust=True)
+
+    assert isinstance(result, ResponsesAPIResponse)
+    assert result.model == "gpt-5"
+    assert binding.requests[0]["input"] == "hello"
+    assert binding.requests[0]["model"] == "gpt-5"
+
+
+@pytest.mark.asyncio
+async def test_top_level_aresponses_uses_shared_rust_handoff_once() -> None:
+    binding = RecordingAresponses()
+    responses._RESPONSES.override(asynchronous=binding)
+
+    result = await litellm.aresponses(model="openai/gpt-5", input="hello", rust=True)
+
+    assert isinstance(result, ResponsesAPIResponse)
+    assert result.model == "gpt-5"
+    assert len(binding.requests) == 1
+    assert binding.requests[0]["input"] == "hello"
+    assert binding.requests[0]["model"] == "gpt-5"

--- a/tests/test_litellm/responses/test_rust_bridge_websocket.py
+++ b/tests/test_litellm/responses/test_rust_bridge_websocket.py
@@ -76,14 +76,14 @@ async def test_adapter_raises_clean_close_when_rust_connection_ends() -> None:
 
 @pytest.mark.asyncio
 async def test_bridge_unavailable_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(responses_websocket, "_STATE", responses_websocket._RustResponsesWebSocketState())
-    monkeypatch.setattr(responses_websocket, "get_native_bridge", lambda: None)
+    responses_websocket._RESPONSES_WEBSOCKET.override(None)
 
     assert (
         await responses_websocket.connect(
             url="wss://example.test/responses",
             headers={},
             timeout=None,
+            request_override=True,
         )
         is None
     )
@@ -99,6 +99,7 @@ async def test_enabled_bridge_connects_and_adapts_socket(
         url="wss://example.test/responses",
         headers={"Authorization": "Bearer key"},
         timeout=1.0,
+        request_override=True,
     )
 
     assert connection is not None

--- a/tests/test_litellm/responses/test_rust_bridge_websocket.py
+++ b/tests/test_litellm/responses/test_rust_bridge_websocket.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from litellm.llms.custom_httpx.llm_http_handler import _rust_responses_websocket_enabled
 from litellm.rust_bridge import configuration, responses_websocket
-from litellm.types.router import GenericLiteLLMParams
 
 
 class _FakeNativeConnection:
@@ -48,22 +46,20 @@ def reset_responses_websocket():
     configuration.reset_rust_configuration()
 
 
-def test_rust_websocket_bridge_is_disabled_without_flag() -> None:
-    assert not _rust_responses_websocket_enabled("openai", GenericLiteLLMParams())
-    assert not _rust_responses_websocket_enabled("anthropic", GenericLiteLLMParams(rust=True))
-    assert _rust_responses_websocket_enabled("openai", GenericLiteLLMParams(rust=True))
-
-
-def test_explicit_false_overrides_process_enable() -> None:
+@pytest.mark.asyncio
+async def test_explicit_false_overrides_process_enable() -> None:
     configuration.rust(True)
+    responses_websocket.set_rust_responses_websocket(connection=_FakeNativeBridge)
 
-    assert not _rust_responses_websocket_enabled("openai", GenericLiteLLMParams(rust=False))
+    assert await responses_websocket.connect(url="wss://example.test", headers={}, timeout=None, request_override=False) is None
 
 
-def test_process_enable_applies_without_request_override() -> None:
+@pytest.mark.asyncio
+async def test_ineligible_provider_does_not_use_rust() -> None:
     configuration.rust(True)
+    responses_websocket.set_rust_responses_websocket(connection=_FakeNativeBridge)
 
-    assert _rust_responses_websocket_enabled("openai", GenericLiteLLMParams())
+    assert await responses_websocket.connect(url="wss://example.test", headers={}, timeout=None, eligible=False) is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/rust_bridge/native_route_wheel_test.py
+++ b/tests/test_litellm/rust_bridge/native_route_wheel_test.py
@@ -10,6 +10,8 @@ import sys
 import tempfile
 import threading
 import zipfile
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
 from http.client import HTTPMessage
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -25,6 +27,123 @@ ANTHROPIC_RESPONSE: Final = (
     b'"stop_reason":"end_turn","stop_sequence":null,'
     b'"usage":{"input_tokens":2,"output_tokens":3}}'
 )
+
+
+def assert_ocr_request(path: str, headers: HTTPMessage, body: dict[str, object]) -> None:
+    assert path == "/v1/ocr"
+    assert headers.get("authorization") == "Bearer sk-native"
+    assert body == {
+        "model": "mistral-ocr-latest",
+        "document": {"type": "document_url", "document_url": "https://example.com/document.pdf"},
+        "include_image_base64": True,
+    }
+
+
+def assert_transcription_request(path: str, headers: HTTPMessage, body: dict[str, object]) -> None:
+    assert path == "/model/mistral.voxtral-mini-3b-2507/converse"
+    assert headers.get("authorization", "").startswith("AWS4-HMAC-SHA256 ")
+    assert headers.get("x-amz-date")
+    messages: Final = body["messages"]
+    assert isinstance(messages, list)
+    assert messages[0]["content"][0]["audio"]["source"]["bytes"] == "AQI="
+    assert "The audio language is en" in messages[0]["content"][1]["text"]
+
+
+def assert_messages_request(path: str, headers: HTTPMessage, body: dict[str, object]) -> None:
+    assert path == "/v1/messages"
+    assert headers.get("x-api-key") == "sk-native"
+    assert body == {
+        "model": "claude-sonnet-4-5",
+        "max_tokens": 16,
+        "messages": [{"role": "user", "content": "hello-from-messages"}],
+    }
+
+
+def assert_chat_completions_request(path: str, headers: HTTPMessage, body: dict[str, object]) -> None:
+    assert path == "/v1/messages"
+    assert headers.get("x-api-key") == "sk-native"
+    assert body == {
+        "model": "claude-sonnet-4-5",
+        "max_tokens": 17,
+        "messages": [{"role": "user", "content": [{"type": "text", "text": "hello-from-chat"}]}],
+    }
+
+
+@dataclass(frozen=True, slots=True)
+class RouteCase:
+    name: str
+    request_kwargs: Mapping[str, object]
+    assert_request: Callable[[str, HTTPMessage, dict[str, object]], None]
+    success_value: Callable[[dict[str, object]], object]
+    expected_success: str
+    native_upstream_error: bool
+
+
+ROUTE_CASES: Final = (
+    RouteCase(
+        name="ocr",
+        request_kwargs={
+            "model": "mistral-ocr-latest",
+            "document": {"type": "document_url", "document_url": "https://example.com/document.pdf"},
+            "api_key": "sk-native",
+            "custom_llm_provider": "mistral",
+            "optional_params": {"include_image_base64": True},
+        },
+        assert_request=assert_ocr_request,
+        success_value=lambda response: response["pages"][0]["markdown"],
+        expected_success="native-ocr",
+        native_upstream_error=True,
+    ),
+    RouteCase(
+        name="transcription",
+        request_kwargs={
+            "model": "mistral.voxtral-mini-3b-2507",
+            "audio": {"data": "AQI=", "format": "wav", "filename": "audio.wav"},
+            "custom_llm_provider": "bedrock",
+            "optional_params": {
+                "aws_access_key_id": "native-access-key",
+                "aws_secret_access_key": "native-secret-key",
+                "aws_region_name": "us-east-1",
+                "language": "en",
+            },
+        },
+        assert_request=assert_transcription_request,
+        success_value=lambda response: response["text"],
+        expected_success="native-transcription",
+        native_upstream_error=False,
+    ),
+    RouteCase(
+        name="messages",
+        request_kwargs={
+            "model": "claude-sonnet-4-5",
+            "body": {
+                "model": "claude-sonnet-4-5",
+                "max_tokens": 16,
+                "messages": [{"role": "user", "content": "hello-from-messages"}],
+            },
+            "api_key": "sk-native",
+            "custom_llm_provider": "anthropic",
+        },
+        assert_request=assert_messages_request,
+        success_value=lambda response: response["content"][0]["text"],
+        expected_success="native-message",
+        native_upstream_error=False,
+    ),
+    RouteCase(
+        name="chat_completions",
+        request_kwargs={
+            "model": "anthropic/claude-sonnet-4-5",
+            "messages": [{"role": "user", "content": "hello-from-chat"}],
+            "optional_params": {"max_tokens": 17},
+            "api_key": "sk-native",
+        },
+        assert_request=assert_chat_completions_request,
+        success_value=lambda response: response["choices"][0]["message"]["content"],
+        expected_success="native-message",
+        native_upstream_error=True,
+    ),
+)
+ROUTE_CASE_BY_NAME: Final = {case.name: case for case in ROUTE_CASES}
 
 
 class NativeRouteHandler(BaseHTTPRequestHandler):
@@ -73,35 +192,14 @@ def assert_native_request(
     headers: HTTPMessage,
     body: object,
 ) -> None:
-    if route not in {"ocr", "transcription", "messages", "chat_completions"}:
+    case: Final = ROUTE_CASE_BY_NAME.get(route or "")
+    if case is None:
         raise AssertionError(f"unexpected route marker: {route!r}")
     if outcome not in {"success", "429", "hang"}:
         raise AssertionError(f"unexpected outcome marker: {outcome!r}")
     if not isinstance(body, dict):
         raise TypeError(f"{route} sent {type(body).__name__}, expected a JSON object")
-    if route == "ocr":
-        assert path == "/v1/ocr"
-        assert headers.get("authorization") == "Bearer sk-native"
-        assert body["model"] == "mistral-ocr-latest"
-        assert body["document"]["document_url"] == "https://example.com/document.pdf"
-        assert body["include_image_base64"] is True
-        return
-    if route == "transcription":
-        assert path == "/model/mistral.voxtral-mini-3b-2507/converse"
-        assert headers.get("authorization", "").startswith("AWS4-HMAC-SHA256 ")
-        assert headers.get("x-amz-date")
-        assert body["messages"][0]["content"][0]["audio"]["source"]["bytes"] == "AQI="
-        assert "The audio language is en" in body["messages"][0]["content"][1]["text"]
-        return
-    assert path == "/v1/messages"
-    assert headers.get("x-api-key") == "sk-native"
-    assert body["model"] == "claude-sonnet-4-5"
-    if route == "messages":
-        assert body["max_tokens"] == 16
-        assert body["messages"][0]["content"] == "hello-from-messages"
-        return
-    assert body["max_tokens"] == 17
-    assert body["messages"][0]["content"] == [{"type": "text", "text": "hello-from-chat"}]
+    case.assert_request(path, headers, body)
 
 
 def native_response(status: int, route: str | None) -> bytes:
@@ -124,75 +222,29 @@ def load_native(native_path: Path) -> object:
 
 
 def route_kwargs(route: str, api_base: str, outcome: str) -> dict[str, object]:
+    case: Final = ROUTE_CASE_BY_NAME.get(route)
+    if case is None:
+        raise AssertionError(f"unknown route: {route}")
     common: Final = {
         "api_base": api_base,
         "extra_headers": {"x-test-outcome": outcome, "x-test-route": route},
         "timeout_seconds": 3.0,
     }
-    if route == "ocr":
-        return common | {
-            "model": "mistral-ocr-latest",
-            "document": {"type": "document_url", "document_url": "https://example.com/document.pdf"},
-            "api_key": "sk-native",
-            "custom_llm_provider": "mistral",
-            "optional_params": {"include_image_base64": True},
-        }
-    if route == "transcription":
-        return common | {
-            "model": "mistral.voxtral-mini-3b-2507",
-            "audio": {"data": "AQI=", "format": "wav", "filename": "audio.wav"},
-            "custom_llm_provider": "bedrock",
-            "optional_params": {
-                "aws_access_key_id": "native-access-key",
-                "aws_secret_access_key": "native-secret-key",
-                "aws_region_name": "us-east-1",
-                "language": "en",
-            },
-        }
-    if route == "messages":
-        return common | {
-            "model": "claude-sonnet-4-5",
-            "body": {
-                "model": "claude-sonnet-4-5",
-                "max_tokens": 16,
-                "messages": [{"role": "user", "content": "hello-from-messages"}],
-            },
-            "api_key": "sk-native",
-            "custom_llm_provider": "anthropic",
-        }
-    if route == "chat_completions":
-        return common | {
-            "model": "anthropic/claude-sonnet-4-5",
-            "messages": [{"role": "user", "content": "hello-from-chat"}],
-            "optional_params": {"max_tokens": 17},
-            "api_key": "sk-native",
-        }
-    raise AssertionError(f"unknown route: {route}")
+    return common | dict(case.request_kwargs)
 
 
 def assert_success(route: str, response: object) -> None:
+    case: Final = ROUTE_CASE_BY_NAME[route]
     if not isinstance(response, dict):
         raise TypeError(f"{route} returned {type(response).__name__}, expected dict")
-    actual: Final = success_value(route, response)
-    expected: Final = (
-        "native-ocr" if route == "ocr" else "native-transcription" if route == "transcription" else "native-message"
-    )
-    if actual != expected:
-        raise AssertionError(f"{route} returned {actual!r}, expected {expected!r}")
-
-
-def success_value(route: str, response: dict[object, object]) -> object:
-    if route == "ocr":
-        return response["pages"][0]["markdown"]
-    if route == "transcription":
-        return response["text"]
-    if route == "messages":
-        return response["content"][0]["text"]
-    return response["choices"][0]["message"]["content"]
+    actual: Final = case.success_value(response)
+    if actual != case.expected_success:
+        raise AssertionError(f"{route} returned {actual!r}, expected {case.expected_success!r}")
 
 
 def assert_rate_limit(native: object, route: str, error: BaseException) -> None:
-    if route in {"ocr", "chat_completions"}:
+    case: Final = ROUTE_CASE_BY_NAME[route]
+    if case.native_upstream_error:
         upstream_error: Final = native.RustUpstreamError
         if not isinstance(error, upstream_error) or error.args[0] != 429:
             raise AssertionError(f"{route} returned the wrong 429 error: {error!r}")
@@ -202,37 +254,32 @@ def assert_rate_limit(native: object, route: str, error: BaseException) -> None:
 
 
 def exercise_sync(native: object, api_base: str) -> None:
-    for route in ("ocr", "transcription", "messages", "chat_completions"):
-        function: Final = getattr(native, route)
-        assert_success(route, function(**route_kwargs(route, api_base, "success")))
+    for case in ROUTE_CASES:
+        function: Final = getattr(native, case.name)
+        assert_success(case.name, function(**route_kwargs(case.name, api_base, "success")))
         try:
-            function(**route_kwargs(route, api_base, "429"))
+            function(**route_kwargs(case.name, api_base, "429"))
         except (RuntimeError, native.RustUpstreamError) as error:
-            assert_rate_limit(native, route, error)
+            assert_rate_limit(native, case.name, error)
         else:
-            raise AssertionError(f"{route} accepted a 429 response")
+            raise AssertionError(f"{case.name} accepted a 429 response")
 
 
 async def exercise_async(native: object, api_base: str) -> None:
-    for route in ("ocr", "transcription", "messages", "chat_completions"):
-        function: Final = getattr(native, f"a{route}")
-        assert_success(route, await function(**route_kwargs(route, api_base, "success")))
+    for case in ROUTE_CASES:
+        function: Final = getattr(native, f"a{case.name}")
+        assert_success(case.name, await function(**route_kwargs(case.name, api_base, "success")))
         try:
-            await function(**route_kwargs(route, api_base, "429"))
+            await function(**route_kwargs(case.name, api_base, "429"))
         except (RuntimeError, native.RustUpstreamError) as error:
-            assert_rate_limit(native, route, error)
+            assert_rate_limit(native, case.name, error)
         else:
-            raise AssertionError(f"a{route} accepted a 429 response")
+            raise AssertionError(f"a{case.name} accepted a 429 response")
 
 
 async def exercise_async_concurrency(native: object, api_base: str) -> None:
     responses: Final = await asyncio.wait_for(
-        asyncio.gather(
-            *(
-                native.amessages(**route_kwargs("messages", api_base, "success"))
-                for _ in range(32)
-            )
-        ),
+        asyncio.gather(*(native.amessages(**route_kwargs("messages", api_base, "success")) for _ in range(32))),
         timeout=15,
     )
     for response in responses:

--- a/tests/test_litellm/rust_bridge/native_route_wheel_test.py
+++ b/tests/test_litellm/rust_bridge/native_route_wheel_test.py
@@ -243,13 +243,14 @@ def assert_success(route: str, response: object) -> None:
 
 
 def assert_rate_limit(native: object, route: str, error: BaseException) -> None:
-    case: Final = ROUTE_CASE_BY_NAME[route]
-    if case.native_upstream_error:
-        upstream_error: Final = native.RustUpstreamError
-        if not isinstance(error, upstream_error) or error.args[0] != 429:
-            raise AssertionError(f"{route} returned the wrong 429 error: {error!r}")
-        return
-    if not isinstance(error, RuntimeError) or "429" not in str(error):
+    execution_error: Final = native.RustExecutionError
+    if (
+        not isinstance(error, execution_error)
+        or getattr(error, "code", None) != "upstream"
+        or getattr(error, "status_code", None) != 429
+        or getattr(error, "provider_state", None) != "response_received"
+        or "native-rate-limit" in str(error)
+    ):
         raise AssertionError(f"{route} returned the wrong 429 error: {error!r}")
 
 
@@ -259,7 +260,7 @@ def exercise_sync(native: object, api_base: str) -> None:
         assert_success(case.name, function(**route_kwargs(case.name, api_base, "success")))
         try:
             function(**route_kwargs(case.name, api_base, "429"))
-        except (RuntimeError, native.RustUpstreamError) as error:
+        except native.RustExecutionError as error:
             assert_rate_limit(native, case.name, error)
         else:
             raise AssertionError(f"{case.name} accepted a 429 response")
@@ -271,7 +272,7 @@ async def exercise_async(native: object, api_base: str) -> None:
         assert_success(case.name, await function(**route_kwargs(case.name, api_base, "success")))
         try:
             await function(**route_kwargs(case.name, api_base, "429"))
-        except (RuntimeError, native.RustUpstreamError) as error:
+        except native.RustExecutionError as error:
             assert_rate_limit(native, case.name, error)
         else:
             raise AssertionError(f"a{case.name} accepted a 429 response")

--- a/tests/test_litellm/rust_bridge/test_bindings.py
+++ b/tests/test_litellm/rust_bridge/test_bindings.py
@@ -6,48 +6,91 @@ import pytest
 from litellm.rust_bridge import bindings
 
 
-def test_binding_distinguishes_disable_from_reset(monkeypatch) -> None:
-    native = SimpleNamespace(route=lambda: "native")
-    monkeypatch.setattr(bindings, "get_native_bridge", lambda: native)
-    binding: bindings.NativeBinding[object] = bindings.NativeBinding("route", validate=lambda value: value)
-
-    assert binding.load() is native.route
-
-    binding.override(None)
-    assert binding.load() is None
-
-    replacement = object()
-    binding.override(replacement)
-    assert binding.load() is replacement
-
-    binding.reset()
-    assert binding.load() is native.route
-
-
-@pytest.mark.parametrize(("value", "expected"), ((3, 3), ("invalid", None), (None, None)))
-def test_binding_validates_native_attribute(
-    monkeypatch: pytest.MonkeyPatch, value: object, expected: int | None
+@pytest.mark.parametrize(
+    ("native", "expected"),
+    (
+        pytest.param(None, None, id="extension-unavailable"),
+        pytest.param(SimpleNamespace(), None, id="attribute-missing"),
+        pytest.param(SimpleNamespace(route="invalid"), None, id="attribute-invalid"),
+        pytest.param(SimpleNamespace(route=3), 3, id="attribute-valid"),
+    ),
+)
+def test_binding_loads_only_valid_native_attributes(
+    monkeypatch: pytest.MonkeyPatch,
+    native: object | None,
+    expected: int | None,
 ) -> None:
-    native: Final = SimpleNamespace(route=value)
     monkeypatch.setattr(bindings, "get_native_bridge", lambda: native)
-    binding: Final = bindings.NativeBinding("route", validate=lambda item: item if isinstance(item, int) else None)
+    binding: Final = bindings.NativeBinding("route", validate=lambda value: value if isinstance(value, int) else None)
 
     assert binding.load() == expected
 
 
-@pytest.mark.parametrize("value", (None, 3, "not callable"))
+@pytest.mark.parametrize(
+    "value",
+    (
+        pytest.param(None, id="missing"),
+        pytest.param(3, id="integer"),
+        pytest.param("not callable", id="string"),
+    ),
+)
 def test_callable_binding_rejects_non_callables(monkeypatch: pytest.MonkeyPatch, value: object) -> None:
     monkeypatch.setattr(bindings, "get_native_bridge", lambda: SimpleNamespace(route=value))
-
-    binding: bindings.NativeBinding[object] = bindings.NativeBinding.callable("route")
+    binding: Final[bindings.NativeBinding[object]] = bindings.NativeBinding.callable("route")
 
     assert binding.load() is None
 
 
-def test_callable_binding_resolves_callable(monkeypatch: pytest.MonkeyPatch) -> None:
-    native = SimpleNamespace(route=lambda: "native")
+def test_callable_binding_resolves_override_and_reset(monkeypatch: pytest.MonkeyPatch) -> None:
+    native_route: Final = lambda: "native"
+    replacement: Final = lambda: "replacement"
+    monkeypatch.setattr(bindings, "get_native_bridge", lambda: SimpleNamespace(route=native_route))
+    binding: Final[bindings.NativeBinding[object]] = bindings.NativeBinding.callable("route")
+
+    assert binding.load() is native_route
+    binding.override(None)
+    assert binding.load() is None
+    binding.override(replacement)
+    assert binding.load() is replacement
+    binding.reset()
+    assert binding.load() is native_route
+
+
+class _Declined(Exception):
+    pass
+
+
+class _Upstream(Exception):
+    pass
+
+
+@pytest.mark.parametrize(
+    ("native", "expected"),
+    (
+        pytest.param(None, None, id="extension-unavailable"),
+        pytest.param(SimpleNamespace(), None, id="exceptions-missing"),
+        pytest.param(
+            SimpleNamespace(RustBridgeDeclined=_Declined(), RustUpstreamError=_Upstream),
+            None,
+            id="declined-not-type",
+        ),
+        pytest.param(
+            SimpleNamespace(RustBridgeDeclined=_Declined, RustUpstreamError=_Upstream()),
+            None,
+            id="upstream-not-type",
+        ),
+        pytest.param(
+            SimpleNamespace(RustBridgeDeclined=_Declined, RustUpstreamError=_Upstream),
+            (_Declined, _Upstream),
+            id="valid-exceptions",
+        ),
+    ),
+)
+def test_native_exception_types_require_both_exception_classes(
+    monkeypatch: pytest.MonkeyPatch,
+    native: object | None,
+    expected: tuple[type[BaseException], type[BaseException]] | None,
+) -> None:
     monkeypatch.setattr(bindings, "get_native_bridge", lambda: native)
 
-    binding: bindings.NativeBinding[object] = bindings.NativeBinding.callable("route")
-
-    assert binding.load() is native.route
+    assert bindings.native_exception_types() == expected

--- a/tests/test_litellm/rust_bridge/test_bindings.py
+++ b/tests/test_litellm/rust_bridge/test_bindings.py
@@ -33,3 +33,21 @@ def test_binding_validates_native_attribute(
     binding: Final = bindings.NativeBinding("route", validate=lambda item: item if isinstance(item, int) else None)
 
     assert binding.load() == expected
+
+
+@pytest.mark.parametrize("value", (None, 3, "not callable"))
+def test_callable_binding_rejects_non_callables(monkeypatch: pytest.MonkeyPatch, value: object) -> None:
+    monkeypatch.setattr(bindings, "get_native_bridge", lambda: SimpleNamespace(route=value))
+
+    binding: bindings.NativeBinding[object] = bindings.NativeBinding.callable("route")
+
+    assert binding.load() is None
+
+
+def test_callable_binding_resolves_callable(monkeypatch: pytest.MonkeyPatch) -> None:
+    native = SimpleNamespace(route=lambda: "native")
+    monkeypatch.setattr(bindings, "get_native_bridge", lambda: native)
+
+    binding: bindings.NativeBinding[object] = bindings.NativeBinding.callable("route")
+
+    assert binding.load() is native.route

--- a/tests/test_litellm/rust_bridge/test_chat_completions.py
+++ b/tests/test_litellm/rust_bridge/test_chat_completions.py
@@ -163,11 +163,7 @@ def test_gate_forwards_enablement_to_preflight(
     if enablement == "environment":
         monkeypatch.setenv("LITELLM_RUST", "true")
     litellm_params: Final = (
-        {"rust": True}
-        if enablement == "request-true"
-        else {"rust": False}
-        if enablement == "request-false"
-        else {}
+        {"rust": True} if enablement == "request-true" else {"rust": False} if enablement == "request-false" else {}
     )
 
     assert accepts(litellm_params=litellm_params) is expected
@@ -218,11 +214,14 @@ def test_gate_short_circuits_python_only_requests(
     bridge.set_rust_chat_completions(decline=gate)
     monkeypatch.setattr(litellm, "bedrock_request_metadata_fields", bedrock_metadata_fields)
 
-    assert accepts(
-        custom_llm_provider=provider,
-        litellm_params=litellm_params,
-        stream=stream,
-    ) is False
+    assert (
+        accepts(
+            custom_llm_provider=provider,
+            litellm_params=litellm_params,
+            stream=stream,
+        )
+        is False
+    )
     assert gate.calls == []
 
 

--- a/tests/test_litellm/rust_bridge/test_chat_completions.py
+++ b/tests/test_litellm/rust_bridge/test_chat_completions.py
@@ -10,8 +10,8 @@ from __future__ import annotations
 import pytest
 
 import litellm
+from litellm.rust_bridge import bindings, configuration
 from litellm.rust_bridge import chat_completions as bridge
-from litellm.rust_bridge import configuration
 from litellm.types.utils import ModelResponse
 
 RUST_RESPONSE = {
@@ -54,7 +54,7 @@ class _FakeNative:
 
 def _fake_native_bridge(monkeypatch):
     """Expose the bridge's exception classes without the compiled extension."""
-    monkeypatch.setattr(bridge, "get_native_bridge", lambda: _FakeNative())
+    monkeypatch.setattr(bindings, "get_native_bridge", lambda: _FakeNative())
 
 
 def _hide_native_bridge(monkeypatch):
@@ -63,7 +63,7 @@ def _hide_native_bridge(monkeypatch):
     There is no injection seam for "the .so is absent", so the loader itself is
     replaced; every other case here uses `set_rust_chat_completions`.
     """
-    monkeypatch.setattr(bridge, "get_native_bridge", lambda: None)
+    monkeypatch.setattr(bindings, "get_native_bridge", lambda: None)
 
 
 @pytest.fixture(autouse=True)
@@ -244,6 +244,7 @@ def _call_kwargs(model_response: ModelResponse) -> dict:
         "extra_headers": {},
         "timeout": 30.0,
         "on_response": lambda _rust_response: None,
+        "request_override": True,
     }
 
 

--- a/tests/test_litellm/rust_bridge/test_chat_completions.py
+++ b/tests/test_litellm/rust_bridge/test_chat_completions.py
@@ -1,11 +1,7 @@
-"""Tests for the Rust chat completions bridge.
-
-The native callables are dependency-injected through
-``set_rust_chat_completions`` rather than patched, so these run without the
-compiled extension present.
-"""
-
 from __future__ import annotations
+
+from collections.abc import Generator, Mapping, Sequence
+from typing import Final
 
 import pytest
 
@@ -14,7 +10,7 @@ from litellm.rust_bridge import bindings, configuration
 from litellm.rust_bridge import chat_completions as bridge
 from litellm.types.utils import ModelResponse
 
-RUST_RESPONSE = {
+RUST_RESPONSE: Final[dict[str, object]] = {
     "created": 1_700_000_000,
     "model": "claude-sonnet-4-5-20260101",
     "choices": [
@@ -35,368 +31,320 @@ RUST_RESPONSE = {
         },
     },
 }
-
-MESSAGES = [{"role": "user", "content": "hi"}]
-
-
-class _FakeDeclined(Exception):
-    """Stands in for the native `RustBridgeDeclined`."""
-
-
-class _FakeUpstream(Exception):
-    """Stands in for the native `RustUpstreamError`; args are (status, message)."""
-
-
-class _FakeNative:
-    RustBridgeDeclined = _FakeDeclined
-    RustUpstreamError = _FakeUpstream
-
-
-def _fake_native_bridge(monkeypatch):
-    """Expose the bridge's exception classes without the compiled extension."""
-    monkeypatch.setattr(bindings, "get_native_bridge", lambda: _FakeNative())
-
-
-def _hide_native_bridge(monkeypatch):
-    """Simulate a wheel built without the compiled extension.
-
-    There is no injection seam for "the .so is absent", so the loader itself is
-    replaced; every other case here uses `set_rust_chat_completions`.
-    """
-    monkeypatch.setattr(bindings, "get_native_bridge", lambda: None)
+MESSAGES: Final[tuple[dict[str, str], ...]] = ({"role": "user", "content": "hi"},)
+OPTIONAL_PARAMS: Final[dict[str, object]] = {"max_tokens": 16}
 
 
 @pytest.fixture(autouse=True)
-def reset_bridge():
-    """Every test starts with no injected callables, and leaves none behind."""
-    bridge.set_rust_chat_completions(chat_completions=None, achat_completions=None, decline=None)
+def reset_bridge(monkeypatch: pytest.MonkeyPatch) -> Generator[None]:
+    monkeypatch.delenv("LITELLM_RUST", raising=False)
     configuration.reset_rust_configuration()
+    bridge.set_rust_chat_completions(chat_completions=None, achat_completions=None, decline=None)
     yield
-    bridge.set_rust_chat_completions(chat_completions=None, achat_completions=None, decline=None)
     configuration.reset_rust_configuration()
+    bridge.set_rust_chat_completions(chat_completions=None, achat_completions=None, decline=None)
 
 
-class _RecordingDecline:
-    """A stand-in for the native gate that records what it was asked."""
+class RecordingDecline:
+    def __init__(self, reason: str | None = None) -> None:
+        self.reason: Final = reason
+        self.calls: list[dict[str, object]] = []
 
-    def __init__(self, reason: str | None = None):
-        self.reason = reason
-        self.calls: list[dict] = []
-
-    def __call__(self, **kwargs):
-        self.calls.append(kwargs)
+    def __call__(
+        self,
+        model: str,
+        messages: Sequence[object],
+        optional_params: Mapping[str, object] | None,
+        custom_llm_provider: str | None,
+    ) -> str | None:
+        self.calls.append(
+            {
+                "model": model,
+                "messages": messages,
+                "optional_params": optional_params,
+                "custom_llm_provider": custom_llm_provider,
+            }
+        )
         return self.reason
 
 
-class _RecordingCall:
-    def __init__(self, result=None, error: Exception | None = None):
-        self.result = result if result is not None else dict(RUST_RESPONSE)
-        self.error = error
-        self.calls: list[dict] = []
+class RecordingCall:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
 
-    def __call__(self, **kwargs):
-        self.calls.append(kwargs)
-        if self.error is not None:
-            raise self.error
-        return self.result
-
-
-class _RecordingAsyncCall(_RecordingCall):
-    async def __call__(self, **kwargs):
-        return _RecordingCall.__call__(self, **kwargs)
-
-
-def _accepts(**overrides) -> bool:
-    kwargs = {
-        "model": "claude-sonnet-4-5",
-        "messages": MESSAGES,
-        "optional_params": {"max_tokens": 16},
-        "custom_llm_provider": "anthropic",
-        "litellm_params": {"rust": True},
-        "stream": None,
-    }
-    kwargs.update(overrides)
-    return bridge.rust_chat_completions_accepts(**kwargs)
-
-
-class TestGate:
-    def test_declines_when_the_deployment_did_not_opt_in(self, monkeypatch):
-        monkeypatch.delenv("LITELLM_RUST", raising=False)
-        gate = _RecordingDecline()
-        bridge.set_rust_chat_completions(decline=gate)
-        assert _accepts(litellm_params={}) is False
-        assert _accepts(litellm_params=None) is False
-        assert _accepts(litellm_params={"rust": False}) is False
-        assert gate.calls == [], "the gate must not be consulted before opt-in"
-
-    def test_accepts_when_the_deployment_opted_in_and_the_core_agrees(self, monkeypatch):
-        monkeypatch.delenv("LITELLM_RUST", raising=False)
-        gate = _RecordingDecline()
-        bridge.set_rust_chat_completions(decline=gate)
-        assert _accepts() is True
-        assert gate.calls[0]["model"] == "claude-sonnet-4-5"
-        assert gate.calls[0]["custom_llm_provider"] == "anthropic"
-
-    def test_explicit_false_overrides_process_enable(self):
-        bridge.set_rust_chat_completions(decline=_RecordingDecline())
-        configuration.rust(True)
-
-        assert _accepts(litellm_params={"rust": False}) is False
-
-    def test_process_enable_applies_without_request_override(self):
-        bridge.set_rust_chat_completions(decline=_RecordingDecline())
-        configuration.rust(True)
-
-        assert _accepts(litellm_params={}) is True
-
-    def test_the_env_var_opts_in_without_a_per_model_flag(self, monkeypatch):
-        monkeypatch.setenv("LITELLM_RUST", "true")
-        bridge.set_rust_chat_completions(decline=_RecordingDecline())
-        assert _accepts(litellm_params={}) is True
-
-    def test_declines_streaming_and_providers_off_the_path(self, monkeypatch):
-        monkeypatch.delenv("LITELLM_RUST", raising=False)
-        gate = _RecordingDecline()
-        bridge.set_rust_chat_completions(decline=gate)
-        assert _accepts(stream=True) is False
-        assert _accepts(custom_llm_provider="openai") is False
-        assert _accepts(custom_llm_provider=None) is False
-        assert gate.calls == []
-
-    def test_declines_an_anthropic_request_carrying_a_litellm_metadata_user_id(self, monkeypatch):
-        """`AnthropicConfig.transform_request` copies a valid `user_id` into the Messages body.
-
-        It does that inside the function the Rust route replaces, and the core is
-        handed `optional_params` only, so accepting here would send the request
-        to Anthropic with the abuse-detection attribution silently missing.
-        """
-        monkeypatch.delenv("LITELLM_RUST", raising=False)
-        gate = _RecordingDecline()
-        bridge.set_rust_chat_completions(decline=gate)
-        assert _accepts(litellm_params={"rust": True, "metadata": {"user_id": "u-123"}}) is False
-        assert gate.calls == [], "the core must not be consulted for a request it cannot see the key of"
-
-        # Bedrock's Converse transform reads no `user_id`, and an Anthropic request
-        # whose metadata carries none is one Python would not attribute either.
-        assert (
-            _accepts(
-                custom_llm_provider="bedrock",
-                model="bedrock/us-east-1/anthropic.claude-v2",
-                litellm_params={"rust": True, "metadata": {"user_id": "u-123"}},
-            )
-            is True
+    def __call__(
+        self,
+        model: str,
+        messages: Sequence[object],
+        optional_params: Mapping[str, object] | None,
+        api_key: str | None,
+        api_base: str | None,
+        custom_llm_provider: str | None,
+        extra_headers: Mapping[str, object] | None,
+        timeout_seconds: float | None,
+    ) -> Mapping[str, object]:
+        self.calls.append(
+            {
+                "model": model,
+                "messages": messages,
+                "optional_params": optional_params,
+                "api_key": api_key,
+                "api_base": api_base,
+                "custom_llm_provider": custom_llm_provider,
+                "extra_headers": extra_headers,
+                "timeout_seconds": timeout_seconds,
+            }
         )
-        assert _accepts(litellm_params={"rust": True, "metadata": {"trace_id": "t-1"}}) is True
-        assert _accepts(litellm_params={"rust": True, "metadata": {"user_id": None}}) is True
-        assert _accepts(litellm_params={"rust": True, "metadata": None}) is True
+        return RUST_RESPONSE
 
-    def test_declines_a_bedrock_request_while_the_proxy_owns_request_metadata(self, monkeypatch):
-        """`AmazonConverseConfig` resolves proxy-owned `requestMetadata` onto the
-        Converse body from `litellm_params`, and owning that field also means
-        evicting a caller-supplied one. The core can do neither, so an operator
-        who armed `bedrock_request_metadata_fields` keeps the Python path.
-        """
-        monkeypatch.delenv("LITELLM_RUST", raising=False)
-        gate = _RecordingDecline()
-        bridge.set_rust_chat_completions(decline=gate)
-        bedrock = {
-            "custom_llm_provider": "bedrock",
-            "model": "bedrock/us-east-1/anthropic.claude-v2",
+
+class RecordingAsyncCall(RecordingCall):
+    async def __call__(
+        self,
+        model: str,
+        messages: Sequence[object],
+        optional_params: Mapping[str, object] | None,
+        api_key: str | None,
+        api_base: str | None,
+        custom_llm_provider: str | None,
+        extra_headers: Mapping[str, object] | None,
+        timeout_seconds: float | None,
+    ) -> Mapping[str, object]:
+        return super().__call__(
+            model,
+            messages,
+            optional_params,
+            api_key,
+            api_base,
+            custom_llm_provider,
+            extra_headers,
+            timeout_seconds,
+        )
+
+
+def accepts(
+    *,
+    model: str = "claude-sonnet-4-5",
+    messages: Sequence[object] = MESSAGES,
+    optional_params: Mapping[str, object] = OPTIONAL_PARAMS,
+    custom_llm_provider: str | None = "anthropic",
+    litellm_params: Mapping[str, object] | None = None,
+    stream: object = None,
+) -> bool:
+    return bridge.rust_chat_completions_accepts(
+        model=model,
+        messages=messages,
+        optional_params=optional_params,
+        custom_llm_provider=custom_llm_provider,
+        litellm_params=litellm_params,
+        stream=stream,
+    )
+
+
+@pytest.mark.parametrize(
+    ("enablement", "expected"),
+    (
+        pytest.param("request-true", True, id="request-true"),
+        pytest.param("request-false", False, id="request-false-over-process"),
+        pytest.param("process", True, id="process-override"),
+        pytest.param("environment", True, id="environment"),
+        pytest.param("disabled", False, id="disabled"),
+    ),
+)
+def test_gate_forwards_enablement_to_preflight(
+    monkeypatch: pytest.MonkeyPatch,
+    enablement: str,
+    expected: bool,
+) -> None:
+    gate: Final = RecordingDecline()
+    bridge.set_rust_chat_completions(decline=gate)
+    if enablement in {"request-false", "process"}:
+        configuration.rust(True)
+    if enablement == "environment":
+        monkeypatch.setenv("LITELLM_RUST", "true")
+    litellm_params: Final = (
+        {"rust": True}
+        if enablement == "request-true"
+        else {"rust": False}
+        if enablement == "request-false"
+        else {}
+    )
+
+    assert accepts(litellm_params=litellm_params) is expected
+    assert gate.calls == (
+        [
+            {
+                "model": "claude-sonnet-4-5",
+                "messages": MESSAGES,
+                "optional_params": OPTIONAL_PARAMS,
+                "custom_llm_provider": "anthropic",
+            }
+        ]
+        if expected
+        else []
+    )
+
+
+@pytest.mark.parametrize(
+    ("provider", "litellm_params", "stream", "bedrock_metadata_fields"),
+    (
+        pytest.param("openai", {"rust": True}, None, None, id="unsupported-provider"),
+        pytest.param(None, {"rust": True}, None, None, id="missing-provider"),
+        pytest.param("anthropic", {"rust": True}, True, None, id="streaming"),
+        pytest.param(
+            "anthropic",
+            {"rust": True, "metadata": {"user_id": "u-123"}},
+            None,
+            None,
+            id="anthropic-user-id",
+        ),
+        pytest.param(
+            "bedrock",
+            {"rust": True},
+            None,
+            ["user_api_key_team_id"],
+            id="bedrock-owned-request-metadata",
+        ),
+    ),
+)
+def test_gate_short_circuits_python_only_requests(
+    monkeypatch: pytest.MonkeyPatch,
+    provider: str | None,
+    litellm_params: Mapping[str, object],
+    stream: object,
+    bedrock_metadata_fields: list[str] | None,
+) -> None:
+    gate: Final = RecordingDecline()
+    bridge.set_rust_chat_completions(decline=gate)
+    monkeypatch.setattr(litellm, "bedrock_request_metadata_fields", bedrock_metadata_fields)
+
+    assert accepts(
+        custom_llm_provider=provider,
+        litellm_params=litellm_params,
+        stream=stream,
+    ) is False
+    assert gate.calls == []
+
+
+@pytest.mark.parametrize(
+    ("provider", "litellm_params"),
+    (
+        pytest.param("anthropic", {"rust": True}, id="anthropic"),
+        pytest.param("anthropic", {"rust": True, "metadata": {"trace_id": "t-1"}}, id="metadata-unrelated"),
+        pytest.param("anthropic", {"rust": True, "metadata": {"user_id": None}}, id="user-id-none"),
+        pytest.param("anthropic", {"rust": True, "metadata": None}, id="metadata-none"),
+        pytest.param("bedrock", {"rust": True}, id="bedrock-unowned-metadata"),
+    ),
+)
+def test_gate_accepts_requests_supported_by_preflight(
+    monkeypatch: pytest.MonkeyPatch,
+    provider: str,
+    litellm_params: Mapping[str, object],
+) -> None:
+    gate: Final = RecordingDecline()
+    bridge.set_rust_chat_completions(decline=gate)
+    monkeypatch.setattr(litellm, "bedrock_request_metadata_fields", None)
+
+    assert accepts(custom_llm_provider=provider, litellm_params=litellm_params) is True
+    assert gate.calls == [
+        {
+            "model": "claude-sonnet-4-5",
+            "messages": MESSAGES,
+            "optional_params": OPTIONAL_PARAMS,
+            "custom_llm_provider": provider,
         }
-
-        monkeypatch.setattr(litellm, "bedrock_request_metadata_fields", ["user_api_key_team_id"])
-        assert _accepts(**bedrock) is False
-        assert gate.calls == [], "the core must not be consulted for a field it cannot write"
-        assert _accepts() is True, "arming Bedrock attribution must not decline Anthropic"
-
-        monkeypatch.setattr(litellm, "bedrock_request_metadata_fields", None)
-        assert _accepts(**bedrock) is True, "the decline follows the operator's opt-in alone"
-
-    def test_declines_when_the_core_declines(self, monkeypatch):
-        monkeypatch.delenv("LITELLM_RUST", raising=False)
-        bridge.set_rust_chat_completions(decline=_RecordingDecline("streaming"))
-        assert _accepts() is False
-
-    def test_declines_when_the_bridge_is_unavailable(self, monkeypatch):
-        monkeypatch.delenv("LITELLM_RUST", raising=False)
-        _hide_native_bridge(monkeypatch)
-        assert _accepts() is False
-
-    def test_declines_when_the_gate_itself_raises(self, monkeypatch):
-        monkeypatch.delenv("LITELLM_RUST", raising=False)
-
-        def exploding(**_kwargs):
-            raise RuntimeError("boom")
-
-        bridge.set_rust_chat_completions(decline=exploding)
-        assert _accepts() is False
+    ]
 
 
-def _call_kwargs(model_response: ModelResponse) -> dict:
+def call_kwargs(model_response: ModelResponse, observed: list[Mapping[str, object]]) -> dict[str, object]:
     return {
         "model": "claude-sonnet-4-5",
         "messages": MESSAGES,
-        "optional_params": {"max_tokens": 16},
+        "optional_params": OPTIONAL_PARAMS,
         "model_response": model_response,
         "api_key": "sk-test",
         "api_base": None,
         "custom_llm_provider": "anthropic",
-        "extra_headers": {},
+        "extra_headers": {"x-request-id": "req-1"},
         "timeout": 30.0,
-        "on_response": lambda _rust_response: None,
+        "on_response": observed.append,
         "request_override": True,
     }
 
 
-class TestSyncCall:
-    def test_builds_a_model_response_and_stamps_the_rust_header(self):
-        native = _RecordingCall()
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", (pytest.param("sync", id="sync"), pytest.param("async", id="async")))
+async def test_call_builds_model_response_and_forwards_exact_request(mode: str) -> None:
+    observed: list[Mapping[str, object]] = []
+    model_response: Final = ModelResponse()
+    original_id: Final = model_response.id
+    if mode == "sync":
+        native: RecordingCall = RecordingCall()
         bridge.set_rust_chat_completions(chat_completions=native)
-        model_response = ModelResponse()
-        original_id = model_response.id
+        result: Final = bridge.chat_completions(**call_kwargs(model_response, observed))
+    else:
+        native = RecordingAsyncCall()
+        bridge.set_rust_chat_completions(achat_completions=native)
+        result = await bridge.achat_completions(**call_kwargs(model_response, observed))
 
-        result = bridge.chat_completions(**_call_kwargs(model_response))
-
-        assert result is not None
-        assert result.choices[0].message.content == "hello from rust"
-        assert result.choices[0].finish_reason == "stop"
-        assert result.model == "claude-sonnet-4-5-20260101"
-        assert result.usage.prompt_tokens == 11
-        assert result.usage.completion_tokens == 4
-        assert result.usage.total_tokens == 15
-        assert result._hidden_params["additional_headers"] == {"x-litellm-rust": "true"}
-        assert result.id == original_id, "the rust path must keep the chatcmpl id litellm already minted"
-
-    def test_passes_the_timeout_through_as_seconds(self):
-        native = _RecordingCall()
-        bridge.set_rust_chat_completions(chat_completions=native)
-        bridge.chat_completions(**_call_kwargs(ModelResponse()))
-        assert native.calls[0]["timeout_seconds"] == 30.0
-
-    def test_falls_back_when_the_bridge_is_unavailable(self, monkeypatch):
-        _hide_native_bridge(monkeypatch)
-        assert bridge.chat_completions(**_call_kwargs(ModelResponse())) is None
-
-    def test_falls_back_when_the_core_declines_before_calling_the_provider(self, monkeypatch):
-        _fake_native_bridge(monkeypatch)
-        bridge.set_rust_chat_completions(chat_completions=_RecordingCall(error=_FakeDeclined("streaming")))
-        assert bridge.chat_completions(**_call_kwargs(ModelResponse())) is None
-
-
-class TestAsyncCall:
-    @pytest.mark.asyncio
-    async def test_builds_a_model_response(self):
-        bridge.set_rust_chat_completions(achat_completions=_RecordingAsyncCall())
-        result = await bridge.achat_completions(**_call_kwargs(ModelResponse()))
-        assert result is not None
-        assert result.choices[0].message.content == "hello from rust"
-        assert result._hidden_params["additional_headers"] == {"x-litellm-rust": "true"}
-
-    @pytest.mark.asyncio
-    async def test_falls_back_when_the_bridge_is_unavailable(self, monkeypatch):
-        _hide_native_bridge(monkeypatch)
-        assert await bridge.achat_completions(**_call_kwargs(ModelResponse())) is None
-
-    @pytest.mark.asyncio
-    async def test_falls_back_when_the_core_declines_before_calling_the_provider(self, monkeypatch):
-        _fake_native_bridge(monkeypatch)
-        bridge.set_rust_chat_completions(achat_completions=_RecordingAsyncCall(error=_FakeDeclined("streaming")))
-        assert await bridge.achat_completions(**_call_kwargs(ModelResponse())) is None
+    assert result is not None
+    assert result.id == original_id
+    assert result.model == "claude-sonnet-4-5-20260101"
+    assert result.choices[0].message.content == "hello from rust"
+    assert result.choices[0].finish_reason == "stop"
+    assert (
+        result.usage.prompt_tokens,
+        result.usage.completion_tokens,
+        result.usage.total_tokens,
+    ) == (11, 4, 15)
+    assert result._hidden_params["additional_headers"] == {"x-litellm-rust": "true"}
+    assert native.calls == [
+        {
+            "model": "claude-sonnet-4-5",
+            "messages": MESSAGES,
+            "optional_params": OPTIONAL_PARAMS,
+            "api_key": "sk-test",
+            "api_base": None,
+            "custom_llm_provider": "anthropic",
+            "extra_headers": {"x-request-id": "req-1"},
+            "timeout_seconds": 30.0,
+        }
+    ]
+    assert observed == [RUST_RESPONSE]
 
 
-class TestAsyncFallbackWrapper:
-    @pytest.mark.asyncio
-    async def test_returns_the_rust_response_without_running_the_fallback(self):
-        bridge.set_rust_chat_completions(achat_completions=_RecordingAsyncCall())
-        ran = []
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("native_available", "expected", "expected_fallback_calls"),
+    (
+        pytest.param(True, "hello from rust", 0, id="native-success"),
+        pytest.param(False, "python", 1, id="bridge-unavailable"),
+    ),
+)
+async def test_async_fallback_wrapper_selects_exactly_one_path(
+    monkeypatch: pytest.MonkeyPatch,
+    native_available: bool,
+    expected: str,
+    expected_fallback_calls: int,
+) -> None:
+    observed: list[Mapping[str, object]] = []
+    fallback_calls = 0
+    if native_available:
+        bridge.set_rust_chat_completions(achat_completions=RecordingAsyncCall())
+    else:
+        monkeypatch.setattr(bindings, "get_native_bridge", lambda: None)
 
-        async def fallback():
-            ran.append(True)
-            return "python"
+    async def fallback() -> str:
+        nonlocal fallback_calls
+        fallback_calls += 1
+        return "python"
 
-        result = await bridge.achat_completions_or_fallback(**_call_kwargs(ModelResponse()), python_fallback=fallback)
-        assert result.choices[0].message.content == "hello from rust"
-        assert ran == []
+    result: Final = await bridge.achat_completions_or_fallback(
+        **call_kwargs(ModelResponse(), observed),
+        python_fallback=fallback,
+    )
+    actual: Final = result.choices[0].message.content if isinstance(result, ModelResponse) else result
 
-    @pytest.mark.asyncio
-    async def test_runs_the_fallback_when_the_core_declines(self, monkeypatch):
-        _fake_native_bridge(monkeypatch)
-        bridge.set_rust_chat_completions(achat_completions=_RecordingAsyncCall(error=_FakeDeclined("streaming")))
-
-        async def fallback():
-            return "python"
-
-        result = await bridge.achat_completions_or_fallback(**_call_kwargs(ModelResponse()), python_fallback=fallback)
-        assert result == "python"
-
-    @pytest.mark.asyncio
-    async def test_runs_the_fallback_when_the_bridge_is_unavailable(self, monkeypatch):
-        _hide_native_bridge(monkeypatch)
-
-        async def fallback():
-            return "python"
-
-        result = await bridge.achat_completions_or_fallback(**_call_kwargs(ModelResponse()), python_fallback=fallback)
-        assert result == "python"
-
-
-class TestFailureClassification:
-    """A failure the provider already saw must not be retried on the Python
-    path: it would bill the customer for the same work twice."""
-
-    @pytest.fixture(autouse=True)
-    def _native_exceptions(self, monkeypatch):
-        _fake_native_bridge(monkeypatch)
-
-    def test_a_decline_falls_back_because_nothing_was_sent(self):
-        bridge.set_rust_chat_completions(chat_completions=_RecordingCall(error=_FakeDeclined("streaming")))
-        assert bridge.chat_completions(**_call_kwargs(ModelResponse())) is None
-
-    def test_an_upstream_failure_is_surfaced_with_its_status(self):
-        from litellm.exceptions import APIError
-
-        bridge.set_rust_chat_completions(chat_completions=_RecordingCall(error=_FakeUpstream(429, "429: rate limited")))
-        with pytest.raises(APIError) as raised:
-            bridge.chat_completions(**_call_kwargs(ModelResponse()))
-        assert raised.value.status_code == 429
-        assert "rate limited" in str(raised.value)
-
-    def test_a_transport_failure_with_no_response_surfaces_as_a_500(self):
-        from litellm.exceptions import APIError
-
-        bridge.set_rust_chat_completions(chat_completions=_RecordingCall(error=_FakeUpstream(0, "connection reset")))
-        with pytest.raises(APIError) as raised:
-            bridge.chat_completions(**_call_kwargs(ModelResponse()))
-        assert raised.value.status_code == 500
-
-    def test_an_unrecognized_error_is_not_swallowed(self):
-        bridge.set_rust_chat_completions(chat_completions=_RecordingCall(error=RuntimeError("something else")))
-        with pytest.raises(RuntimeError):
-            bridge.chat_completions(**_call_kwargs(ModelResponse()))
-
-    @pytest.mark.asyncio
-    async def test_the_async_wrapper_does_not_fall_back_on_an_upstream_failure(self):
-        from litellm.exceptions import APIError
-
-        bridge.set_rust_chat_completions(achat_completions=_RecordingAsyncCall(error=_FakeUpstream(500, "500: boom")))
-        ran = []
-
-        async def fallback():
-            ran.append(True)
-            return "python"
-
-        with pytest.raises(APIError):
-            await bridge.achat_completions_or_fallback(**_call_kwargs(ModelResponse()), python_fallback=fallback)
-        assert ran == [], "a request the provider already served must not be re-issued"
-
-    @pytest.mark.asyncio
-    async def test_the_async_wrapper_falls_back_on_a_decline(self):
-        bridge.set_rust_chat_completions(
-            achat_completions=_RecordingAsyncCall(error=_FakeDeclined("blank message text"))
-        )
-
-        async def fallback():
-            return "python"
-
-        result = await bridge.achat_completions_or_fallback(**_call_kwargs(ModelResponse()), python_fallback=fallback)
-        assert result == "python"
+    assert actual == expected
+    assert fallback_calls == expected_fallback_calls
+    assert observed == ([RUST_RESPONSE] if native_available else [])

--- a/tests/test_litellm/rust_bridge/test_configuration.py
+++ b/tests/test_litellm/rust_bridge/test_configuration.py
@@ -1,44 +1,36 @@
 from __future__ import annotations
 
-import os
-import subprocess
-import sys
+import warnings
 from collections.abc import Generator
 from concurrent.futures import ThreadPoolExecutor
-from typing import Final
 
 import pytest
 
 from litellm.rust_bridge import configuration
-from litellm.rust_bridge import ocr as rust_ocr
 
 
 @pytest.fixture(autouse=True)
-def _isolated_configuration(  # pyright: ignore[reportUnusedFunction]  # pytest discovers fixtures dynamically
-    monkeypatch: pytest.MonkeyPatch,
-) -> Generator[None]:
+def isolated_configuration(monkeypatch: pytest.MonkeyPatch) -> Generator[None]:
     configuration.reset_rust_configuration()
     monkeypatch.delenv("LITELLM_RUST", raising=False)
     monkeypatch.delenv("LITELLM_USE_RUST_OCR", raising=False)
-    rust_ocr.set_rust_ocr(ocr=None, aocr=None)
     yield
     configuration.reset_rust_configuration()
-    rust_ocr.set_rust_ocr(ocr=None, aocr=None)
 
 
 @pytest.mark.parametrize(
     ("request_override", "process", "environment", "legacy_environment", "release_default", "expected"),
     (
-        (False, True, True, True, True, False),
-        (True, False, False, False, False, True),
-        (None, False, True, True, True, False),
-        (None, True, False, False, False, True),
-        (None, None, False, True, True, False),
-        (None, None, True, False, False, True),
-        (None, None, None, False, True, False),
-        (None, None, None, True, False, True),
-        (None, None, None, None, False, False),
-        (None, None, None, None, True, True),
+        pytest.param(False, True, True, True, True, False, id="request-false-wins"),
+        pytest.param(True, False, False, False, False, True, id="request-true-wins"),
+        pytest.param(None, False, True, True, True, False, id="process-false-wins"),
+        pytest.param(None, True, False, False, False, True, id="process-true-wins"),
+        pytest.param(None, None, False, True, True, False, id="environment-false-wins"),
+        pytest.param(None, None, True, False, False, True, id="environment-true-wins"),
+        pytest.param(None, None, None, False, True, False, id="legacy-false-wins"),
+        pytest.param(None, None, None, True, False, True, id="legacy-true-wins"),
+        pytest.param(None, None, None, None, False, False, id="release-default-false"),
+        pytest.param(None, None, None, None, True, True, id="release-default-true"),
     ),
 )
 def test_resolution_precedence(
@@ -61,12 +53,47 @@ def test_resolution_precedence(
     )
 
 
-def test_release_default_remains_disabled() -> None:
-    assert configuration.DEFAULT_RUST_ENABLED is False
+@pytest.mark.parametrize(
+    ("environment_name", "value", "expected", "deprecated"),
+    tuple(
+        pytest.param(environment_name, value, expected, environment_name == "LITELLM_USE_RUST_OCR", id=case_id)
+        for environment_name, prefix in (
+            ("LITELLM_RUST", "global"),
+            ("LITELLM_USE_RUST_OCR", "legacy"),
+        )
+        for value, expected, case_id in (
+            ("1", True, f"{prefix}-one"),
+            ("TRUE", True, f"{prefix}-true"),
+            (" yes ", True, f"{prefix}-yes-trimmed"),
+            ("on", True, f"{prefix}-on"),
+            ("0", False, f"{prefix}-zero"),
+            ("false", False, f"{prefix}-false"),
+            ("", False, f"{prefix}-empty"),
+            ("sometimes", False, f"{prefix}-invalid"),
+        )
+    ),
+)
+def test_environment_values(
+    monkeypatch: pytest.MonkeyPatch,
+    environment_name: str,
+    value: str,
+    expected: bool,
+    deprecated: bool,
+) -> None:
+    monkeypatch.setenv(environment_name, value)
+
+    if deprecated:
+        with pytest.warns(DeprecationWarning, match="LITELLM_USE_RUST_OCR is deprecated"):
+            assert configuration.rust_enabled() is expected
+        return
+    assert configuration.rust_enabled() is expected
+
+
+def test_release_default_is_disabled() -> None:
     assert configuration.rust_enabled() is False
 
 
-def test_process_override_wins_over_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_request_and_process_overrides_precede_environment(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LITELLM_RUST", "0")
     configuration.rust(True)
 
@@ -74,27 +101,14 @@ def test_process_override_wins_over_environment(monkeypatch: pytest.MonkeyPatch)
     assert configuration.rust_enabled(request_override=False) is False
 
 
-def test_global_environment_accepts_explicit_false(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("LITELLM_RUST", "off")
-
-    assert configuration.rust_enabled() is False
-
-
-@pytest.mark.parametrize("value", ("", " ", "sometimes", "2"))
-def test_invalid_environment_value_disables_rust(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
-    monkeypatch.setenv("LITELLM_RUST", value)
+def test_global_environment_precedes_legacy_without_warning(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LITELLM_RUST", "0")
     monkeypatch.setenv("LITELLM_USE_RUST_OCR", "1")
 
-    assert configuration.rust_enabled() is False
-    assert configuration.rust_ocr_enabled() is False
-
-
-@pytest.mark.parametrize("value", ("", " ", "sometimes", "2"))
-def test_invalid_legacy_environment_value_disables_rust(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
-    monkeypatch.setenv("LITELLM_USE_RUST_OCR", value)
-
-    with pytest.warns(DeprecationWarning, match="LITELLM_USE_RUST_OCR is deprecated"):
+    with warnings.catch_warnings(record=True) as caught:
         assert configuration.rust_enabled() is False
+
+    assert caught == []
 
 
 def test_process_override_and_reset_apply_to_existing_threads(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -108,46 +122,3 @@ def test_process_override_and_reset_apply_to_existing_threads(monkeypatch: pytes
         configuration.reset_rust_configuration()
         assert executor.submit(configuration.rust_enabled).result() is True
         assert executor.submit(configuration.rust_ocr_enabled).result() is True
-
-
-def test_explicit_override_precedes_invalid_environment(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("LITELLM_RUST", "sometimes")
-
-    assert configuration.rust_enabled(request_override=False) is False
-    configuration.rust(True)
-    assert configuration.rust_enabled() is True
-
-
-def test_legacy_ocr_environment_is_deprecated_and_global(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("LITELLM_USE_RUST_OCR", "1")
-
-    with pytest.warns(DeprecationWarning, match="LITELLM_USE_RUST_OCR is deprecated"):
-        assert configuration.rust_enabled() is True
-    with pytest.warns(DeprecationWarning, match="LITELLM_USE_RUST_OCR is deprecated"):
-        assert configuration.rust_ocr_enabled() is True
-
-
-def test_global_environment_precedes_legacy_ocr_environment(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("LITELLM_RUST", "0")
-    monkeypatch.setenv("LITELLM_USE_RUST_OCR", "1")
-
-    assert configuration.rust_enabled() is False
-
-
-@pytest.mark.parametrize("environment_name", ("LITELLM_RUST", "LITELLM_USE_RUST_OCR"))
-@pytest.mark.parametrize(("value", "expected"), (("1", "True"), ("0", "False")))
-def test_environment_controls_startup(environment_name: str, value: str, expected: str) -> None:
-    environment: Final = {**os.environ, environment_name: value}
-    result: Final = subprocess.run(
-        (
-            sys.executable,
-            "-c",
-            "from litellm.rust_bridge.configuration import rust_enabled; print(rust_enabled())",
-        ),
-        check=True,
-        capture_output=True,
-        text=True,
-        env=environment,
-    )
-
-    assert result.stdout.strip() == expected

--- a/tests/test_litellm/rust_bridge/test_loader.py
+++ b/tests/test_litellm/rust_bridge/test_loader.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import builtins
+from collections.abc import Generator
+from types import ModuleType
+
+import pytest
+
+from litellm.rust_bridge import loader
+
+
+@pytest.fixture(autouse=True)
+def reset_loader_cache() -> Generator[None]:
+    loader.reset_native_bridge_cache()
+    yield
+    loader.reset_native_bridge_cache()
+
+
+def test_absent_extension_is_cached_until_reset(monkeypatch: pytest.MonkeyPatch) -> None:
+    real_import = builtins.__import__
+    attempts = 0
+
+    def unavailable_import(
+        name: str,
+        globals: dict[str, object] | None = None,
+        locals: dict[str, object] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> object:
+        nonlocal attempts
+        if name == "litellm.rust_bridge" and "_native" in fromlist:
+            attempts += 1
+            raise ImportError
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", unavailable_import)
+
+    assert loader.get_native_bridge() is None
+    assert loader.get_native_bridge() is None
+    assert attempts == 1
+    loader.reset_native_bridge_cache()
+    assert loader.get_native_bridge() is None
+    assert attempts == 2
+
+
+@pytest.mark.parametrize(
+    ("native", "expected"),
+    (
+        pytest.param(None, False, id="unavailable"),
+        pytest.param(ModuleType("litellm.rust_bridge._native"), True, id="available"),
+    ),
+)
+def test_native_bridge_available(
+    monkeypatch: pytest.MonkeyPatch,
+    native: ModuleType | None,
+    expected: bool,
+) -> None:
+    monkeypatch.setattr(loader, "get_native_bridge", lambda: native)
+
+    assert loader.native_bridge_available() is expected

--- a/tests/test_litellm/rust_bridge/test_responses.py
+++ b/tests/test_litellm/rust_bridge/test_responses.py
@@ -1,47 +1,51 @@
-from unittest.mock import Mock
+from __future__ import annotations
+
+from collections.abc import Generator, Mapping
 
 import pytest
 
-import litellm
-from litellm.rust_bridge import responses
+from litellm.rust_bridge import configuration, responses
 
 
 @pytest.fixture(autouse=True)
-def reset_responses_endpoint():
+def reset_responses_bridge(monkeypatch: pytest.MonkeyPatch) -> Generator[None]:
+    monkeypatch.delenv("LITELLM_RUST", raising=False)
+    configuration.reset_rust_configuration()
     responses._RESPONSES.reset()
     yield
+    configuration.reset_rust_configuration()
     responses._RESPONSES.reset()
 
 
-def test_unavailable_responses_bridge_does_not_prepare_request() -> None:
-    prepare = Mock(side_effect=AssertionError("unavailable Rust must not prepare a request"))
-    responses._RESPONSES.override(sync=None)
-    litellm.rust(True)
+class RecordingPrepare:
+    def __init__(self) -> None:
+        self.calls = 0
 
-    result = responses.responses(
-        prepare=prepare,
-        model="gpt-5",
-        provider="openai",
-        request_override=True,
-    )
-
-    assert result is None
-    prepare.assert_not_called()
+    def __call__(self) -> Mapping[str, object]:
+        self.calls += 1
+        return {"model": "gpt-5"}
 
 
 @pytest.mark.asyncio
-async def test_unavailable_async_responses_bridge_does_not_prepare_request(
-) -> None:
-    prepare = Mock(side_effect=AssertionError("unavailable Rust must not prepare a request"))
-    responses._RESPONSES.override(asynchronous=None)
-    litellm.rust(True)
-
-    result = await responses.aresponses(
-        prepare=prepare,
-        model="gpt-5",
-        provider="openai",
-        request_override=True,
-    )
+@pytest.mark.parametrize("mode", (pytest.param("sync", id="sync"), pytest.param("async", id="async")))
+async def test_unavailable_bridge_does_not_prepare_request(mode: str) -> None:
+    prepare = RecordingPrepare()
+    if mode == "sync":
+        responses._RESPONSES.override(sync=None)
+        result = responses.responses(
+            prepare=prepare,
+            model="gpt-5",
+            provider="openai",
+            request_override=True,
+        )
+    else:
+        responses._RESPONSES.override(asynchronous=None)
+        result = await responses.aresponses(
+            prepare=prepare,
+            model="gpt-5",
+            provider="openai",
+            request_override=True,
+        )
 
     assert result is None
-    prepare.assert_not_called()
+    assert prepare.calls == 0

--- a/tests/test_litellm/rust_bridge/test_responses.py
+++ b/tests/test_litellm/rust_bridge/test_responses.py
@@ -1,0 +1,47 @@
+from unittest.mock import Mock
+
+import pytest
+
+import litellm
+from litellm.rust_bridge import responses
+
+
+@pytest.fixture(autouse=True)
+def reset_responses_endpoint():
+    responses._RESPONSES.reset()
+    yield
+    responses._RESPONSES.reset()
+
+
+def test_unavailable_responses_bridge_does_not_prepare_request() -> None:
+    prepare = Mock(side_effect=AssertionError("unavailable Rust must not prepare a request"))
+    responses._RESPONSES.override(sync=None)
+    litellm.rust(True)
+
+    result = responses.responses(
+        prepare=prepare,
+        model="gpt-5",
+        provider="openai",
+        request_override=True,
+    )
+
+    assert result is None
+    prepare.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_unavailable_async_responses_bridge_does_not_prepare_request(
+) -> None:
+    prepare = Mock(side_effect=AssertionError("unavailable Rust must not prepare a request"))
+    responses._RESPONSES.override(asynchronous=None)
+    litellm.rust(True)
+
+    result = await responses.aresponses(
+        prepare=prepare,
+        model="gpt-5",
+        provider="openai",
+        request_override=True,
+    )
+
+    assert result is None
+    prepare.assert_not_called()

--- a/tests/test_litellm/rust_bridge/test_runtime.py
+++ b/tests/test_litellm/rust_bridge/test_runtime.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from types import SimpleNamespace
+from typing import Final
 
 import pytest
 
@@ -18,11 +20,14 @@ class RustUpstreamError(Exception):
 
 @pytest.fixture(autouse=True)
 def native_exceptions(monkeypatch: pytest.MonkeyPatch) -> None:
-    native = SimpleNamespace(
-        RustBridgeDeclined=RustBridgeDeclined,
-        RustUpstreamError=RustUpstreamError,
+    monkeypatch.setattr(
+        bindings,
+        "get_native_bridge",
+        lambda: SimpleNamespace(
+            RustBridgeDeclined=RustBridgeDeclined,
+            RustUpstreamError=RustUpstreamError,
+        ),
     )
-    monkeypatch.setattr(bindings, "get_native_bridge", lambda: native)
 
 
 def context() -> runtime.BridgeErrorContext:
@@ -33,129 +38,277 @@ def enabled(*, request_override: bool | None = None) -> bool:
     return request_override is not False
 
 
-def test_disabled_route_does_not_load_or_call_rust() -> None:
-    bridge = runtime.RustBridge[object](
-        route="messages",
-        load=lambda: pytest.fail("disabled route must not load Rust"),
-        enabled=enabled,
-    )
+@dataclass(frozen=True, slots=True)
+class FallbackCase:
+    request_override: bool | None = None
+    eligible: bool = True
+    binding_available: bool = True
+    declined: bool = False
+    expected_events: tuple[str, ...] = ()
 
-    value = bridge.invoke(
-        call=lambda _binding: pytest.fail("disabled route must not call Rust"),
-        fallback=lambda: "python",
+
+FALLBACK_CASES: Final = (
+    pytest.param(
+        FallbackCase(request_override=False, expected_events=("python",)),
+        id="request-disabled",
+    ),
+    pytest.param(
+        FallbackCase(eligible=False, expected_events=("python",)),
+        id="request-ineligible",
+    ),
+    pytest.param(
+        FallbackCase(binding_available=False, expected_events=("load", "python")),
+        id="bridge-unavailable",
+    ),
+    pytest.param(
+        FallbackCase(declined=True, expected_events=("load", "rust", "python")),
+        id="bridge-declined",
+    ),
+)
+
+
+@pytest.mark.parametrize("case", FALLBACK_CASES)
+def test_invoke_falls_back_only_before_provider_success(case: FallbackCase) -> None:
+    events: list[str] = []
+
+    def load() -> object | None:
+        events.append("load")
+        return object() if case.binding_available else None
+
+    def call(_binding: object) -> int:
+        events.append("rust")
+        if case.declined:
+            raise RustBridgeDeclined("unsupported")
+        return 3
+
+    bridge: Final = runtime.RustBridge(route="messages", load=load, enabled=enabled)
+    result: Final = bridge.invoke(
+        call=call,
+        fallback=lambda: events.append("python") or "fallback",
         adapt=str,
         context=context(),
-        request_override=False,
+        request_override=case.request_override,
+        eligible=case.eligible,
     )
 
-    assert value == "python"
-
-
-def test_unavailable_route_hands_off_to_python() -> None:
-    bridge = runtime.RustBridge[object](route="messages", load=lambda: None, enabled=enabled)
-
-    value = bridge.invoke(
-        call=lambda _binding: pytest.fail("unavailable route must not call Rust"),
-        fallback=lambda: "python",
-        adapt=str,
-        context=context(),
-    )
-
-    assert value == "python"
-
-
-def test_decline_hands_off_to_python() -> None:
-    calls: list[str] = []
-
-    def decline(_binding: object) -> object:
-        calls.append("rust")
-        raise RustBridgeDeclined("unsupported")
-
-    bridge = runtime.RustBridge(route="messages", load=object, enabled=enabled)
-    value = bridge.invoke(
-        call=decline,
-        fallback=lambda: calls.append("python") or "fallback",
-        adapt=str,
-        context=context(),
-    )
-
-    assert value == "fallback"
-    assert calls == ["rust", "python"]
-
-
-def test_upstream_failure_never_hands_off() -> None:
-    def fail(_binding: object) -> object:
-        raise RustUpstreamError(429, "rate limited")
-
-    bridge = runtime.RustBridge(route="messages", load=object, enabled=enabled)
-    with pytest.raises(APIError, match="rate limited") as caught:
-        bridge.invoke(
-            call=fail,
-            fallback=lambda: pytest.fail("fallback must not run"),
-            adapt=str,
-            context=context(),
-        )
-
-    assert caught.value.status_code == 429
-
-
-def test_unknown_failure_never_hands_off() -> None:
-    bridge = runtime.RustBridge(route="messages", load=object, enabled=enabled)
-
-    with pytest.raises(RuntimeError, match="unknown"):
-        bridge.invoke(
-            call=lambda _binding: (_ for _ in ()).throw(RuntimeError("unknown")),
-            fallback=lambda: pytest.fail("fallback must not run"),
-            adapt=str,
-            context=context(),
-        )
+    assert result == "fallback"
+    assert tuple(events) == case.expected_events
 
 
 @pytest.mark.asyncio
-async def test_async_route_handles_native_success() -> None:
-    async def native(_binding: object) -> int:
+@pytest.mark.parametrize("case", FALLBACK_CASES)
+async def test_ainvoke_matches_sync_fallback_contract(case: FallbackCase) -> None:
+    events: list[str] = []
+
+    def load() -> object | None:
+        events.append("load")
+        return object() if case.binding_available else None
+
+    async def call(_binding: object) -> int:
+        events.append("rust")
+        if case.declined:
+            raise RustBridgeDeclined("unsupported")
+        return 3
+
+    async def fallback() -> str:
+        events.append("python")
+        return "fallback"
+
+    bridge: Final = runtime.RustBridge(route="messages", load=load, enabled=enabled)
+    result: Final = await bridge.ainvoke(
+        call=call,
+        fallback=fallback,
+        adapt=str,
+        context=context(),
+        request_override=case.request_override,
+        eligible=case.eligible,
+    )
+
+    assert result == "fallback"
+    assert tuple(events) == case.expected_events
+
+
+def test_invoke_adapts_native_success_without_fallback() -> None:
+    bridge: Final = runtime.RustBridge(route="messages", load=object, enabled=enabled)
+
+    result: Final = bridge.invoke(
+        call=lambda _binding: 3,
+        fallback=lambda: pytest.fail("fallback must not run"),
+        adapt=lambda value: f"adapted-{value}",
+        context=context(),
+    )
+
+    assert result == "adapted-3"
+
+
+@pytest.mark.asyncio
+async def test_ainvoke_adapts_native_success_without_fallback() -> None:
+    async def call(_binding: object) -> int:
         return 3
 
     async def fallback() -> str:
         pytest.fail("fallback must not run")
 
-    bridge = runtime.RustBridge(route="messages", load=object, enabled=enabled)
-    value = await bridge.ainvoke(
-        call=native,
+    bridge: Final = runtime.RustBridge(route="messages", load=object, enabled=enabled)
+    result: Final = await bridge.ainvoke(
+        call=call,
         fallback=fallback,
-        adapt=str,
+        adapt=lambda value: f"adapted-{value}",
         context=context(),
     )
 
-    assert value == "3"
+    assert result == "adapted-3"
 
 
-def test_required_route_rejects_unavailable_bridge() -> None:
-    bridge = runtime.RustBridge[object](route="messages", load=lambda: None, enabled=enabled)
+@pytest.mark.parametrize(
+    ("error", "expected_status", "expected_message"),
+    (
+        pytest.param(RustUpstreamError(429, "rate limited"), 429, "rate limited", id="provider-status"),
+        pytest.param(RustUpstreamError(0, "connection reset"), 500, "connection reset", id="transport-failure"),
+    ),
+)
+def test_upstream_failure_maps_to_api_error_without_fallback(
+    error: RustUpstreamError,
+    expected_status: int,
+    expected_message: str,
+) -> None:
+    bridge: Final = runtime.RustBridge(route="messages", load=object, enabled=enabled)
 
-    with pytest.raises(RuntimeError, match="unavailable"):
-        bridge.require(
-            call=lambda _binding: pytest.fail("unavailable route must not call Rust"),
+    with pytest.raises(APIError, match=expected_message) as caught:
+        bridge.invoke(
+            call=lambda _binding: (_ for _ in ()).throw(error),
+            fallback=lambda: pytest.fail("fallback must not run"),
             adapt=str,
             context=context(),
         )
 
+    assert caught.value.status_code == expected_status
+    assert caught.value.llm_provider == "anthropic"
+    assert caught.value.model == "model"
 
-def test_native_endpoint_resolves_overrides_and_resets(monkeypatch: pytest.MonkeyPatch) -> None:
-    def native_sync() -> str:
-        return "native"
+
+@pytest.mark.asyncio
+async def test_async_upstream_failure_maps_to_api_error_without_fallback() -> None:
+    async def fail(_binding: object) -> object:
+        raise RustUpstreamError(503, "overloaded")
+
+    async def fallback() -> object:
+        pytest.fail("fallback must not run")
+
+    bridge: Final = runtime.RustBridge(route="messages", load=object, enabled=enabled)
+
+    with pytest.raises(APIError, match="overloaded") as caught:
+        await bridge.ainvoke(call=fail, fallback=fallback, adapt=str, context=context())
+
+    assert caught.value.status_code == 503
+
+
+def test_unknown_failure_is_preserved_without_fallback() -> None:
+    error: Final = RuntimeError("unknown")
+    bridge: Final = runtime.RustBridge(route="messages", load=object, enabled=enabled)
+
+    with pytest.raises(RuntimeError, match="unknown") as caught:
+        bridge.invoke(
+            call=lambda _binding: (_ for _ in ()).throw(error),
+            fallback=lambda: pytest.fail("fallback must not run"),
+            adapt=str,
+            context=context(),
+        )
+
+    assert caught.value is error
+
+
+@pytest.mark.parametrize(
+    ("request_override", "binding_available", "declined", "expected_message"),
+    (
+        pytest.param(False, True, False, "Rust messages bridge is disabled", id="disabled"),
+        pytest.param(None, False, False, "Rust messages bridge is unavailable", id="unavailable"),
+        pytest.param(
+            None,
+            True,
+            True,
+            "Rust messages bridge declined the request: unsupported",
+            id="declined",
+        ),
+    ),
+)
+def test_require_explains_why_rust_did_not_handle_request(
+    request_override: bool | None,
+    binding_available: bool,
+    declined: bool,
+    expected_message: str,
+) -> None:
+    def call(_binding: object) -> object:
+        if declined:
+            raise RustBridgeDeclined("unsupported")
+        return object()
+
+    bridge: Final = runtime.RustBridge(
+        route="messages",
+        load=object if binding_available else lambda: None,
+        enabled=enabled,
+    )
+
+    with pytest.raises(RuntimeError, match=f"^{expected_message}$"):
+        bridge.require(
+            call=call,
+            adapt=str,
+            context=context(),
+            request_override=request_override,
+        )
+
+
+@pytest.mark.parametrize(
+    ("state", "expected", "expected_events"),
+    (
+        pytest.param("disabled", False, (), id="disabled"),
+        pytest.param("ineligible", False, (), id="ineligible"),
+        pytest.param("unavailable", False, ("load",), id="unavailable"),
+        pytest.param("declined", False, ("load", "check"), id="declined"),
+        pytest.param("check-error", False, ("load", "check"), id="check-error"),
+        pytest.param("accepted", True, ("load", "check"), id="accepted"),
+    ),
+)
+def test_accepts_only_eligible_supported_requests(
+    state: str,
+    expected: bool,
+    expected_events: tuple[str, ...],
+) -> None:
+    events: list[str] = []
+
+    def load() -> object | None:
+        events.append("load")
+        return None if state == "unavailable" else object()
+
+    def check(_binding: object) -> str | None:
+        events.append("check")
+        if state == "check-error":
+            raise RuntimeError("boom")
+        return "unsupported" if state == "declined" else None
+
+    bridge: Final = runtime.RustBridge(route="preflight", load=load, enabled=enabled)
+
+    assert bridge.accepts(
+        check=check,
+        request_override=False if state == "disabled" else None,
+        eligible=state != "ineligible",
+    ) is expected
+    assert tuple(events) == expected_events
+
+
+def test_native_endpoint_applies_partial_overrides_and_reset(monkeypatch: pytest.MonkeyPatch) -> None:
+    native_sync: Final = lambda: "native"
 
     async def native_async() -> str:
         return "native async"
 
-    native = SimpleNamespace(
-        sync_route=native_sync,
-        async_route=native_async,
-        RustBridgeDeclined=RustBridgeDeclined,
-        RustUpstreamError=RustUpstreamError,
+    replacement_sync: Final = lambda: "replacement"
+    monkeypatch.setattr(
+        bindings,
+        "get_native_bridge",
+        lambda: SimpleNamespace(sync_route=native_sync, async_route=native_async),
     )
-    monkeypatch.setattr(bindings, "get_native_bridge", lambda: native)
-    endpoint: runtime.RustEndpoint[object, object] = runtime.RustEndpoint.native(
+    endpoint: Final[runtime.RustEndpoint[object, object]] = runtime.RustEndpoint.native(
         route="test",
         sync="sync_route",
         asynchronous="async_route",
@@ -164,12 +317,12 @@ def test_native_endpoint_resolves_overrides_and_resets(monkeypatch: pytest.Monke
 
     assert endpoint.sync.load() is native_sync
     assert endpoint.asynchronous.load() is native_async
-
-    replacement = object()
-    endpoint.override(sync=replacement, asynchronous=None)
-    assert endpoint.sync.load() is replacement
+    endpoint.override(sync=replacement_sync)
+    assert endpoint.sync.load() is replacement_sync
+    assert endpoint.asynchronous.load() is native_async
+    endpoint.override(asynchronous=None)
+    assert endpoint.sync.load() is replacement_sync
     assert endpoint.asynchronous.load() is None
-
     endpoint.reset()
     assert endpoint.sync.load() is native_sync
     assert endpoint.asynchronous.load() is native_async

--- a/tests/test_litellm/rust_bridge/test_runtime.py
+++ b/tests/test_litellm/rust_bridge/test_runtime.py
@@ -26,21 +26,56 @@ def native_exceptions(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def context() -> runtime.BridgeErrorContext:
-    return runtime.BridgeErrorContext(route="messages", provider="anthropic", model="model")
+    return runtime.BridgeErrorContext(provider="anthropic", model="model")
 
 
-def test_invoke_tags_native_decline_before_running_fallback() -> None:
+def enabled(*, request_override: bool | None = None) -> bool:
+    return request_override is not False
+
+
+def test_disabled_route_does_not_load_or_call_rust() -> None:
+    bridge = runtime.RustBridge[object](
+        route="messages",
+        load=lambda: pytest.fail("disabled route must not load Rust"),
+        enabled=enabled,
+    )
+
+    value = bridge.invoke(
+        call=lambda _binding: pytest.fail("disabled route must not call Rust"),
+        fallback=lambda: "python",
+        adapt=str,
+        context=context(),
+        request_override=False,
+    )
+
+    assert value == "python"
+
+
+def test_unavailable_route_hands_off_to_python() -> None:
+    bridge = runtime.RustBridge[object](route="messages", load=lambda: None, enabled=enabled)
+
+    value = bridge.invoke(
+        call=lambda _binding: pytest.fail("unavailable route must not call Rust"),
+        fallback=lambda: "python",
+        adapt=str,
+        context=context(),
+    )
+
+    assert value == "python"
+
+
+def test_decline_hands_off_to_python() -> None:
     calls: list[str] = []
 
-    def decline() -> object:
+    def decline(_binding: object) -> object:
         calls.append("rust")
         raise RustBridgeDeclined("unsupported")
 
-    value = runtime.invoke(
-        native_call=decline,
+    bridge = runtime.RustBridge(route="messages", load=object, enabled=enabled)
+    value = bridge.invoke(
+        call=decline,
         fallback=lambda: calls.append("python") or "fallback",
         adapt=str,
-        mode=runtime.FallbackMode.PYTHON,
         context=context(),
     )
 
@@ -48,48 +83,93 @@ def test_invoke_tags_native_decline_before_running_fallback() -> None:
     assert calls == ["rust", "python"]
 
 
-def test_invoke_translates_upstream_without_fallback() -> None:
-    def fail() -> object:
+def test_upstream_failure_never_hands_off() -> None:
+    def fail(_binding: object) -> object:
         raise RustUpstreamError(429, "rate limited")
 
+    bridge = runtime.RustBridge(route="messages", load=object, enabled=enabled)
     with pytest.raises(APIError, match="rate limited") as caught:
-        runtime.invoke(
-            native_call=fail,
+        bridge.invoke(
+            call=fail,
             fallback=lambda: pytest.fail("fallback must not run"),
             adapt=str,
-            mode=runtime.FallbackMode.PYTHON,
             context=context(),
         )
 
     assert caught.value.status_code == 429
 
 
+def test_unknown_failure_never_hands_off() -> None:
+    bridge = runtime.RustBridge(route="messages", load=object, enabled=enabled)
+
+    with pytest.raises(RuntimeError, match="unknown"):
+        bridge.invoke(
+            call=lambda _binding: (_ for _ in ()).throw(RuntimeError("unknown")),
+            fallback=lambda: pytest.fail("fallback must not run"),
+            adapt=str,
+            context=context(),
+        )
+
+
 @pytest.mark.asyncio
-async def test_ainvoke_handles_native_success() -> None:
-    async def native() -> int:
+async def test_async_route_handles_native_success() -> None:
+    async def native(_binding: object) -> int:
         return 3
 
     async def fallback() -> str:
         pytest.fail("fallback must not run")
 
-    assert (
-        await runtime.ainvoke(
-            native_call=native,
-            fallback=fallback,
-            adapt=str,
-            mode=runtime.FallbackMode.PYTHON,
-            context=context(),
-        )
-        == "3"
+    bridge = runtime.RustBridge(route="messages", load=object, enabled=enabled)
+    value = await bridge.ainvoke(
+        call=native,
+        fallback=fallback,
+        adapt=str,
+        context=context(),
     )
 
+    assert value == "3"
 
-def test_required_mode_rejects_unavailable_bridge() -> None:
-    with pytest.raises(RuntimeError, match="is unavailable"):
-        runtime.invoke(
-            native_call=None,
-            fallback=lambda: pytest.fail("fallback must not run"),
+
+def test_required_route_rejects_unavailable_bridge() -> None:
+    bridge = runtime.RustBridge[object](route="messages", load=lambda: None, enabled=enabled)
+
+    with pytest.raises(RuntimeError, match="unavailable"):
+        bridge.require(
+            call=lambda _binding: pytest.fail("unavailable route must not call Rust"),
             adapt=str,
-            mode=runtime.FallbackMode.RUST_REQUIRED,
             context=context(),
         )
+
+
+def test_native_endpoint_resolves_overrides_and_resets(monkeypatch: pytest.MonkeyPatch) -> None:
+    def native_sync() -> str:
+        return "native"
+
+    async def native_async() -> str:
+        return "native async"
+
+    native = SimpleNamespace(
+        sync_route=native_sync,
+        async_route=native_async,
+        RustBridgeDeclined=RustBridgeDeclined,
+        RustUpstreamError=RustUpstreamError,
+    )
+    monkeypatch.setattr(bindings, "get_native_bridge", lambda: native)
+    endpoint: runtime.RustEndpoint[object, object] = runtime.RustEndpoint.native(
+        route="test",
+        sync="sync_route",
+        asynchronous="async_route",
+        enabled=enabled,
+    )
+
+    assert endpoint.sync.load() is native_sync
+    assert endpoint.asynchronous.load() is native_async
+
+    replacement = object()
+    endpoint.override(sync=replacement, asynchronous=None)
+    assert endpoint.sync.load() is replacement
+    assert endpoint.asynchronous.load() is None
+
+    endpoint.reset()
+    assert endpoint.sync.load() is native_sync
+    assert endpoint.asynchronous.load() is native_async

--- a/tests/test_litellm/rust_bridge/test_runtime.py
+++ b/tests/test_litellm/rust_bridge/test_runtime.py
@@ -288,11 +288,14 @@ def test_accepts_only_eligible_supported_requests(
 
     bridge: Final = runtime.RustBridge(route="preflight", load=load, enabled=enabled)
 
-    assert bridge.accepts(
-        check=check,
-        request_override=False if state == "disabled" else None,
-        eligible=state != "ineligible",
-    ) is expected
+    assert (
+        bridge.accepts(
+            check=check,
+            request_override=False if state == "disabled" else None,
+            eligible=state != "ineligible",
+        )
+        is expected
+    )
     assert tuple(events) == expected_events
 
 

--- a/tests/test_litellm/rust_bridge/test_timeouts.py
+++ b/tests/test_litellm/rust_bridge/test_timeouts.py
@@ -1,0 +1,16 @@
+import httpx
+import pytest
+
+from litellm.rust_bridge.timeouts import timeout_to_seconds
+
+
+@pytest.mark.parametrize(
+    ("timeout", "expected"),
+    (
+        pytest.param(None, None, id="none"),
+        pytest.param(12.5, 12.5, id="float"),
+        pytest.param(httpx.Timeout(30.0, read=42.0), 42.0, id="httpx-read-timeout"),
+    ),
+)
+def test_timeout_to_seconds(timeout: float | httpx.Timeout | None, expected: float | None) -> None:
+    assert timeout_to_seconds(timeout) == expected

--- a/tests/test_litellm/rust_bridge/test_verify_linux_native_wheel.py
+++ b/tests/test_litellm/rust_bridge/test_verify_linux_native_wheel.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 import zipfile
 from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
 from pathlib import Path
 from types import MappingProxyType, ModuleType
 from typing import Final, Protocol, cast
@@ -124,74 +125,120 @@ def _run_verifier(
     )
 
 
-def test_accepts_expected_release_wheel_tags(tmp_path: Path) -> None:
+def test_accepts_expected_release_wheel_tags(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     wheel: Final = _write_wheel(tmp_path, filename_tag=_EXPECTED_TAG)
 
     assert _run_verifier(wheel) == 0
+    captured: Final = capsys.readouterr()
+    summary: Final = (tmp_path / "summary.md").read_text()
+    assert captured.err == ""
+    assert "| Validation | Expected | Result |" in summary
+    assert "| Yes | X |" not in summary
 
 
-def test_rejects_cp312_version_specific_wheel(tmp_path: Path) -> None:
-    tag: Final = "cp312-cp312-linux_x86_64"
-    wheel: Final = _write_wheel(tmp_path, filename_tag=tag, metadata_tags=(tag,))
-
-    assert _run_verifier(wheel) == 1
-
-
-def test_rejects_non_linux_platform_tag(tmp_path: Path) -> None:
-    tag: Final = "cp310-abi3-win_amd64"
-    wheel: Final = _write_wheel(tmp_path, filename_tag=tag, metadata_tags=(tag,))
-
-    assert _run_verifier(wheel) == 1
+@dataclass(frozen=True, slots=True)
+class _InvalidWheelCase:
+    filename_tag: str = _EXPECTED_TAG
+    metadata_tags: tuple[str, ...] | None = (_EXPECTED_TAG,)
+    dist_info: str = _DIST_INFO
+    duplicate_wheel: bool = False
+    exposes_panic: bool = False
+    expected_error: str = ""
 
 
 @pytest.mark.parametrize(
-    "metadata_tags",
-    (None, ("cp312-cp312-linux_x86_64",)),
-    ids=("missing", "mismatched"),
+    "case",
+    (
+        pytest.param(
+            _InvalidWheelCase(
+                filename_tag="cp312-cp312-linux_x86_64",
+                metadata_tags=("cp312-cp312-linux_x86_64",),
+                expected_error="unexpected Python tag: expected cp310, found cp312",
+            ),
+            id="version-specific-python",
+        ),
+        pytest.param(
+            _InvalidWheelCase(
+                filename_tag="cp310-abi3-win_amd64",
+                metadata_tags=("cp310-abi3-win_amd64",),
+                expected_error="unexpected platform tag: expected linux_x86_64, found win_amd64",
+            ),
+            id="non-linux-platform",
+        ),
+        pytest.param(
+            _InvalidWheelCase(
+                metadata_tags=None,
+                expected_error="required dist-info file counts are invalid",
+            ),
+            id="metadata-tag-missing",
+        ),
+        pytest.param(
+            _InvalidWheelCase(
+                metadata_tags=("cp312-cp312-linux_x86_64",),
+                expected_error=(
+                    "WHEEL tags do not match filename: expected cp310-abi3-linux_x86_64, "
+                    "found cp312-cp312-linux_x86_64"
+                ),
+            ),
+            id="metadata-tag-mismatched",
+        ),
+        pytest.param(
+            _InvalidWheelCase(
+                dist_info="decoy-1.0.0.dist-info",
+                expected_error="unexpected dist-info directories: expected litellm-1.100.0.dist-info",
+            ),
+            id="wrong-dist-info-directory",
+        ),
+        pytest.param(
+            _InvalidWheelCase(
+                metadata_tags=(_EXPECTED_TAG, _EXPECTED_TAG),
+                expected_error=(
+                    "WHEEL tags do not match filename: expected cp310-abi3-linux_x86_64, "
+                    "found cp310-abi3-linux_x86_64, cp310-abi3-linux_x86_64"
+                ),
+            ),
+            id="duplicate-metadata-tag",
+        ),
+        pytest.param(
+            _InvalidWheelCase(
+                duplicate_wheel=True,
+                expected_error="required dist-info file counts are invalid",
+            ),
+            id="duplicate-metadata-file",
+        ),
+        pytest.param(
+            _InvalidWheelCase(
+                exposes_panic=True,
+                expected_error="production native module exposes _panic_for_test",
+            ),
+            id="panic-hook-exposed",
+        ),
+    ),
 )
-def test_rejects_missing_or_mismatched_wheel_metadata_tag(
+def test_rejects_invalid_wheel_with_specific_diagnostic(
     tmp_path: Path,
-    metadata_tags: tuple[str, ...] | None,
+    capsys: pytest.CaptureFixture[str],
+    case: _InvalidWheelCase,
 ) -> None:
-    wheel: Final = _write_wheel(tmp_path, filename_tag=_EXPECTED_TAG, metadata_tags=metadata_tags)
-
-    assert _run_verifier(wheel) == 1
-
-
-def test_rejects_wheel_metadata_from_wrong_dist_info_directory(
-    tmp_path: Path,
-) -> None:
-    wheel: Final = _write_wheel(
-        tmp_path,
-        filename_tag=_EXPECTED_TAG,
-        dist_info="decoy-1.0.0.dist-info",
-    )
-
-    assert _run_verifier(wheel) == 1
-
-
-def test_rejects_duplicate_wheel_metadata_tags(tmp_path: Path) -> None:
-    wheel: Final = _write_wheel(
-        tmp_path,
-        filename_tag=_EXPECTED_TAG,
-        metadata_tags=(_EXPECTED_TAG, _EXPECTED_TAG),
-    )
-
-    assert _run_verifier(wheel) == 1
-
-
-def test_rejects_duplicate_wheel_metadata_file(tmp_path: Path) -> None:
-    with pytest.warns(UserWarning, match="Duplicate name"):
-        wheel: Final = _write_wheel(
+    if case.duplicate_wheel:
+        with pytest.warns(UserWarning, match="Duplicate name"):
+            wheel: Final = _write_wheel(
+                tmp_path,
+                filename_tag=case.filename_tag,
+                metadata_tags=case.metadata_tags,
+                dist_info=case.dist_info,
+                duplicate_wheel=True,
+            )
+    else:
+        wheel = _write_wheel(
             tmp_path,
-            filename_tag=_EXPECTED_TAG,
-            duplicate_wheel=True,
+            filename_tag=case.filename_tag,
+            metadata_tags=case.metadata_tags,
+            dist_info=case.dist_info,
         )
 
-    assert _run_verifier(wheel) == 1
-
-
-def test_rejects_production_module_exposing_panic_hook(tmp_path: Path) -> None:
-    wheel: Final = _write_wheel(tmp_path, filename_tag=_EXPECTED_TAG)
-
-    assert _run_verifier(wheel, exposes_panic=True) == 1
+    assert _run_verifier(wheel, exposes_panic=case.exposes_panic) == 1
+    captured: Final = capsys.readouterr()
+    summary: Final = (tmp_path / "summary.md").read_text()
+    assert case.expected_error in captured.err
+    assert "| Yes | X |" in summary

--- a/tests/test_litellm/rust_bridge/test_verify_linux_native_wheel.py
+++ b/tests/test_litellm/rust_bridge/test_verify_linux_native_wheel.py
@@ -176,8 +176,7 @@ class _InvalidWheelCase:
             _InvalidWheelCase(
                 metadata_tags=("cp312-cp312-linux_x86_64",),
                 expected_error=(
-                    "WHEEL tags do not match filename: expected cp310-abi3-linux_x86_64, "
-                    "found cp312-cp312-linux_x86_64"
+                    "WHEEL tags do not match filename: expected cp310-abi3-linux_x86_64, found cp312-cp312-linux_x86_64"
                 ),
             ),
             id="metadata-tag-mismatched",

--- a/tests/test_litellm/test_audio_transcription_rust_bridge.py
+++ b/tests/test_litellm/test_audio_transcription_rust_bridge.py
@@ -1,10 +1,9 @@
 import importlib
+from collections.abc import Generator
 
 import pytest
 
 import litellm
-from litellm.llms.bedrock.audio_transcription import BedrockAudioTranscriptionRustDispatch
-from litellm.rust_bridge import bindings
 
 rust_bridge = importlib.import_module("litellm.rust_bridge.transcription")
 
@@ -24,11 +23,25 @@ class SyncBridge:
         optional_params: dict[str, object],
         timeout_seconds: float | None,
     ) -> dict[str, object]:
-        self.calls.append({"model": model, "audio": audio, "optional_params": optional_params})
+        self.calls.append(
+            {
+                "model": model,
+                "audio": audio,
+                "api_key": api_key,
+                "api_base": api_base,
+                "custom_llm_provider": custom_llm_provider,
+                "extra_headers": extra_headers,
+                "optional_params": optional_params,
+                "timeout_seconds": timeout_seconds,
+            }
+        )
         return {"text": "hello"}
 
 
 class AsyncBridge:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
     async def __call__(
         self,
         model: str,
@@ -40,7 +53,26 @@ class AsyncBridge:
         optional_params: dict[str, object],
         timeout_seconds: float | None,
     ) -> dict[str, object]:
+        self.calls.append(
+            {
+                "model": model,
+                "audio": audio,
+                "api_key": api_key,
+                "api_base": api_base,
+                "custom_llm_provider": custom_llm_provider,
+                "extra_headers": extra_headers,
+                "optional_params": optional_params,
+                "timeout_seconds": timeout_seconds,
+            }
+        )
         return {"text": "async"}
+
+
+@pytest.fixture(autouse=True)
+def reset_transcription_bridge() -> Generator[None]:
+    rust_bridge._TRANSCRIPTION.reset()
+    yield
+    rust_bridge._TRANSCRIPTION.reset()
 
 
 def test_enabled_sync_bridge_receives_audio() -> None:
@@ -57,12 +89,24 @@ def test_enabled_sync_bridge_receives_audio() -> None:
         timeout=5.0,
     )
     assert result == {"text": "hello"}
-    assert bridge.calls[0]["audio"] == {"data": "AQI=", "format": "wav", "filename": "audio.wav"}
+    assert bridge.calls == [
+        {
+            "model": "mistral.voxtral-mini-3b-2507",
+            "audio": {"data": "AQI=", "format": "wav", "filename": "audio.wav"},
+            "api_key": None,
+            "api_base": None,
+            "custom_llm_provider": "bedrock",
+            "extra_headers": None,
+            "optional_params": {"temperature": 0},
+            "timeout_seconds": 5.0,
+        }
+    ]
 
 
 @pytest.mark.asyncio
 async def test_enabled_async_bridge() -> None:
-    rust_bridge.configure_rust_transcription(True, atranscription=AsyncBridge())
+    bridge = AsyncBridge()
+    rust_bridge.configure_rust_transcription(True, atranscription=bridge)
     result = await rust_bridge.atranscription(
         model="mistral.voxtral-mini-3b-2507",
         audio={"data": "AQI=", "format": "wav", "filename": "audio.wav"},
@@ -74,46 +118,18 @@ async def test_enabled_async_bridge() -> None:
         timeout=None,
     )
     assert result == {"text": "async"}
-
-
-def test_loader_returns_none_without_native_extension(monkeypatch: pytest.MonkeyPatch) -> None:
-    rust_bridge.configure_rust_transcription(transcription=None, atranscription=None)
-    monkeypatch.setattr(bindings, "get_native_bridge", lambda: None)
-    assert rust_bridge._TRANSCRIPTION.sync.load() is None
-    assert rust_bridge._TRANSCRIPTION.asynchronous.load() is None
-
-
-def test_dispatch_sync_path_requires_bridge(monkeypatch: pytest.MonkeyPatch) -> None:
-    rust_bridge._TRANSCRIPTION.sync.override(None)
-
-    with pytest.raises(RuntimeError, match="bridge is unavailable"):
-        BedrockAudioTranscriptionRustDispatch().audio_transcriptions(
-            model="bedrock/mistral.voxtral-mini-3b-2507",
-            audio_file=("audio.wav", b"audio", "audio/wav"),
-            api_key=None,
-            api_base=None,
-            custom_llm_provider="bedrock",
-            extra_headers=None,
-            optional_params={},
-            timeout=5,
-        )
-
-
-@pytest.mark.asyncio
-async def test_dispatch_async_path_requires_bridge(monkeypatch: pytest.MonkeyPatch) -> None:
-    rust_bridge._TRANSCRIPTION.asynchronous.override(None)
-
-    with pytest.raises(RuntimeError, match="bridge is unavailable"):
-        await BedrockAudioTranscriptionRustDispatch().async_audio_transcriptions(
-            model="bedrock/mistral.voxtral-mini-3b-2507",
-            audio_file=("audio.wav", b"audio", "audio/wav"),
-            api_key=None,
-            api_base=None,
-            custom_llm_provider="bedrock",
-            extra_headers=None,
-            optional_params={},
-            timeout=5,
-        )
+    assert bridge.calls == [
+        {
+            "model": "mistral.voxtral-mini-3b-2507",
+            "audio": {"data": "AQI=", "format": "wav", "filename": "audio.wav"},
+            "api_key": None,
+            "api_base": None,
+            "custom_llm_provider": "bedrock",
+            "extra_headers": None,
+            "optional_params": {},
+            "timeout_seconds": None,
+        }
+    ]
 
 
 def test_bedrock_transcription_uses_rust_only_path() -> None:

--- a/tests/test_litellm/test_audio_transcription_rust_bridge.py
+++ b/tests/test_litellm/test_audio_transcription_rust_bridge.py
@@ -4,6 +4,7 @@ import pytest
 
 import litellm
 from litellm.llms.bedrock.audio_transcription import BedrockAudioTranscriptionRustDispatch
+from litellm.rust_bridge import bindings
 
 rust_bridge = importlib.import_module("litellm.rust_bridge.transcription")
 
@@ -77,13 +78,13 @@ async def test_enabled_async_bridge() -> None:
 
 def test_loader_returns_none_without_native_extension(monkeypatch: pytest.MonkeyPatch) -> None:
     rust_bridge.configure_rust_transcription(transcription=None, atranscription=None)
-    monkeypatch.setattr("litellm.rust_bridge.get_native_bridge", lambda: None)
-    assert rust_bridge.load_rust_transcription() is None
-    assert rust_bridge.load_rust_atranscription() is None
+    monkeypatch.setattr(bindings, "get_native_bridge", lambda: None)
+    assert rust_bridge._TRANSCRIPTION.sync.load() is None
+    assert rust_bridge._TRANSCRIPTION.asynchronous.load() is None
 
 
 def test_dispatch_sync_path_requires_bridge(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(rust_bridge, "transcription", lambda **_: None)
+    rust_bridge._TRANSCRIPTION.sync.override(None)
 
     with pytest.raises(RuntimeError, match="bridge is unavailable"):
         BedrockAudioTranscriptionRustDispatch().audio_transcriptions(
@@ -100,10 +101,7 @@ def test_dispatch_sync_path_requires_bridge(monkeypatch: pytest.MonkeyPatch) -> 
 
 @pytest.mark.asyncio
 async def test_dispatch_async_path_requires_bridge(monkeypatch: pytest.MonkeyPatch) -> None:
-    async def unavailable(**_: object) -> None:
-        return None
-
-    monkeypatch.setattr(rust_bridge, "atranscription", unavailable)
+    rust_bridge._TRANSCRIPTION.asynchronous.override(None)
 
     with pytest.raises(RuntimeError, match="bridge is unavailable"):
         await BedrockAudioTranscriptionRustDispatch().async_audio_transcriptions(


### PR DESCRIPTION
## TLDR

Problem this solves:

- Python credential providers cannot enter Rust auth
- Awaitable providers need safe runtime conversion
- Unknown expiries must not create fake leases

How it solves it:

- Stores providers as owned Python references
- Converts awaitables into Send Rust futures
- Marks plain token results as no-store

## User Flow

Before: custom Python token providers require the Python request path

1. A developer configures a callable token provider
2. They call a Rust-backed provider endpoint
3. The native path cannot carry that provider

After: the same token provider can authenticate the native request

1. A developer configures the same callable token provider
2. They call the same Rust-backed provider endpoint
3. Sync or async token results authenticate the request

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The focused bridge tests pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is isolated to Python interop
- [ ] I have received a Greptile Confidence Score of at least 4/5

## Delays in PR merge?

If you are seeing a delay in PR merge, ping the LiteLLM Team on Slack (#pr-review)

## Screenshots / Proof of Fix

### Before (fea1a0b9db)

1. No native route accepts an owned Python token provider

### After (2e99333e4a)

1. No live provider run was captured because this is bridge infrastructure

## Type

New Feature

## Caveats (if any)

### Low

- OCR wiring lands in the following stacked PR

## Final Attestation

- [x] Tests cover ownership, no-store behavior, redaction, and exception preservation
