### PR TITLE
fix(prompt-templates): treat initial/final prompt values as optional

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -5165,8 +5165,8 @@ def response_schema_prompt(model: str, response_schema: dict) -> str:
     if custom_prompt_details is not None:
         return custom_prompt(
             role_dict=custom_prompt_details["roles"],
-            initial_prompt_value=custom_prompt_details["initial_prompt_value"],
-            final_prompt_value=custom_prompt_details["final_prompt_value"],
+            initial_prompt_value=custom_prompt_details.get("initial_prompt_value", ""),
+            final_prompt_value=custom_prompt_details.get("final_prompt_value", ""),
             messages=response_schema_as_message,
         )
     else:

--- a/litellm/llms/anthropic/completion/transformation.py
+++ b/litellm/llms/anthropic/completion/transformation.py
@@ -239,8 +239,8 @@ class AnthropicTextConfig(BaseConfig):
             model_prompt_details: Final = custom_prompt_dict[model]
             prompt = custom_prompt(
                 role_dict=model_prompt_details["roles"],
-                initial_prompt_value=model_prompt_details["initial_prompt_value"],
-                final_prompt_value=model_prompt_details["final_prompt_value"],
+                initial_prompt_value=model_prompt_details.get("initial_prompt_value", ""),
+                final_prompt_value=model_prompt_details.get("final_prompt_value", ""),
                 messages=messages,
             )
         else:

--- a/litellm/llms/codestral/completion/handler.py
+++ b/litellm/llms/codestral/completion/handler.py
@@ -263,8 +263,8 @@ class CodestralTextCompletion:
             model_prompt_details: Final = custom_prompt_dict[model]
             prompt = custom_prompt(
                 role_dict=model_prompt_details["roles"],
-                initial_prompt_value=model_prompt_details["initial_prompt_value"],
-                final_prompt_value=model_prompt_details["final_prompt_value"],
+                initial_prompt_value=model_prompt_details.get("initial_prompt_value", ""),
+                final_prompt_value=model_prompt_details.get("final_prompt_value", ""),
                 messages=messages,
             )
         else:

--- a/litellm/llms/ollama/completion/transformation.py
+++ b/litellm/llms/ollama/completion/transformation.py
@@ -360,8 +360,8 @@ class OllamaConfig(BaseConfig):
             model_prompt_details: Final = custom_prompt_dict[model]
             ollama_prompt = custom_prompt(
                 role_dict=model_prompt_details["roles"],
-                initial_prompt_value=model_prompt_details["initial_prompt_value"],
-                final_prompt_value=model_prompt_details["final_prompt_value"],
+                initial_prompt_value=model_prompt_details.get("initial_prompt_value", ""),
+                final_prompt_value=model_prompt_details.get("final_prompt_value", ""),
                 messages=messages,
             )
         elif text_completion_request:  # handle `/completions` requests

--- a/litellm/llms/petals/completion/handler.py
+++ b/litellm/llms/petals/completion/handler.py
@@ -44,8 +44,8 @@ def completion(
         model_prompt_details: Final = litellm.custom_prompt_dict[model]
         prompt = custom_prompt(
             role_dict=model_prompt_details["roles"],
-            initial_prompt_value=model_prompt_details["initial_prompt_value"],
-            final_prompt_value=model_prompt_details["final_prompt_value"],
+            initial_prompt_value=model_prompt_details.get("initial_prompt_value", ""),
+            final_prompt_value=model_prompt_details.get("final_prompt_value", ""),
             messages=messages,
         )
     else:

--- a/litellm/llms/predibase/chat/transformation.py
+++ b/litellm/llms/predibase/chat/transformation.py
@@ -261,8 +261,8 @@ class PredibaseConfig(BaseConfig):
             model_prompt_details: Final = custom_prompt_dict[model]
             prompt = custom_prompt(
                 role_dict=model_prompt_details["roles"],
-                initial_prompt_value=model_prompt_details["initial_prompt_value"],
-                final_prompt_value=model_prompt_details["final_prompt_value"],
+                initial_prompt_value=model_prompt_details.get("initial_prompt_value", ""),
+                final_prompt_value=model_prompt_details.get("final_prompt_value", ""),
                 messages=messages,
             )
         else:

--- a/litellm/llms/vllm/completion/handler.py
+++ b/litellm/llms/vllm/completion/handler.py
@@ -58,8 +58,8 @@ def completion(
         model_prompt_details: Final = custom_prompt_dict[model]
         prompt = custom_prompt(
             role_dict=model_prompt_details["roles"],
-            initial_prompt_value=model_prompt_details["initial_prompt_value"],
-            final_prompt_value=model_prompt_details["final_prompt_value"],
+            initial_prompt_value=model_prompt_details.get("initial_prompt_value", ""),
+            final_prompt_value=model_prompt_details.get("final_prompt_value", ""),
             messages=messages,
         )
     else:
@@ -146,8 +146,8 @@ def batch_completions(model: str, messages: list, optional_params=None, custom_p
         for message in messages:
             prompt = custom_prompt(
                 role_dict=model_prompt_details["roles"],
-                initial_prompt_value=model_prompt_details["initial_prompt_value"],
-                final_prompt_value=model_prompt_details["final_prompt_value"],
+                initial_prompt_value=model_prompt_details.get("initial_prompt_value", ""),
+                final_prompt_value=model_prompt_details.get("final_prompt_value", ""),
                 messages=message,
             )
             prompts.append(prompt)

--- a/tests/test_litellm/llms/test_partial_custom_prompt_template.py
+++ b/tests/test_litellm/llms/test_partial_custom_prompt_template.py
@@ -1,0 +1,109 @@
+"""
+Regression tests for partial custom prompt templates.
+
+`initial_prompt_value` and `final_prompt_value` are documented as optional, and
+`litellm.completion()` only stores each key when its value is truthy. Call sites that
+read them back with direct indexing therefore raised `KeyError` for any template that
+set `roles` alone, surfacing as an `APIConnectionError` before a request was ever made.
+
+See https://github.com/BerriAI/litellm/issues/39759
+"""
+
+from typing import Final
+
+import pytest
+
+import litellm
+from litellm.litellm_core_utils.prompt_templates.factory import response_schema_prompt
+from litellm.llms.anthropic.completion.transformation import AnthropicTextConfig
+from litellm.llms.ollama.completion.transformation import OllamaConfig
+from litellm.llms.predibase.chat.transformation import PredibaseConfig
+
+MODEL: Final = "test-model"
+
+ROLES: Final = {
+    "system": {"pre_message": "<<SYS>>\n", "post_message": "\n<</SYS>>\n"},
+    "user": {"pre_message": "[INST] ", "post_message": " [/INST]"},
+    "assistant": {"pre_message": "", "post_message": "</s>"},
+}
+
+MESSAGES: Final = [{"role": "user", "content": "hello"}]
+
+RENDERED_MESSAGES: Final = "[INST] hello [/INST]"
+
+
+def _ollama_prompt(template: dict) -> str:
+    request = OllamaConfig().transform_request(
+        model=MODEL,
+        messages=MESSAGES,
+        optional_params={},
+        litellm_params={"custom_prompt_dict": {MODEL: template}},
+        headers={},
+    )
+    return request["prompt"]
+
+
+@pytest.mark.parametrize(
+    "template, expected",
+    [
+        pytest.param({"roles": ROLES}, RENDERED_MESSAGES, id="roles-only"),
+        pytest.param(
+            {"roles": ROLES, "initial_prompt_value": "BEGIN\n"},
+            f"BEGIN\n{RENDERED_MESSAGES}",
+            id="no-final-prompt-value",
+        ),
+        pytest.param(
+            {"roles": ROLES, "final_prompt_value": "\nEND"},
+            f"{RENDERED_MESSAGES}\nEND",
+            id="no-initial-prompt-value",
+        ),
+    ],
+)
+def test_ollama_renders_partial_custom_prompt_template(template: dict, expected: str) -> None:
+    """An unset optional key renders as the empty string instead of raising KeyError."""
+    assert _ollama_prompt(template) == expected
+
+
+def test_ollama_full_custom_prompt_template_is_unchanged() -> None:
+    """A template that sets every key keeps rendering exactly as before."""
+    template = {
+        "roles": ROLES,
+        "initial_prompt_value": "BEGIN\n",
+        "final_prompt_value": "\nEND",
+    }
+
+    assert _ollama_prompt(template) == f"BEGIN\n{RENDERED_MESSAGES}\nEND"
+
+
+def test_predibase_renders_partial_custom_prompt_template() -> None:
+    request = PredibaseConfig().transform_request(
+        model=MODEL,
+        messages=MESSAGES,
+        optional_params={},
+        litellm_params={"custom_prompt_dict": {MODEL: {"roles": ROLES}}},
+        headers={},
+    )
+
+    assert request["inputs"] == RENDERED_MESSAGES
+
+
+def test_anthropic_text_renders_partial_custom_prompt_template(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(litellm, "custom_prompt_dict", {MODEL: {"roles": ROLES}})
+
+    prompt = AnthropicTextConfig()._get_anthropic_text_prompt_from_messages(
+        messages=MESSAGES,
+        model=MODEL,
+    )
+
+    assert prompt == RENDERED_MESSAGES
+
+
+def test_response_schema_prompt_renders_partial_custom_prompt_template(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(litellm, "custom_prompt_dict", {"response_schema_prompt": {"roles": ROLES}})
+    response_schema: Final = {"type": "object", "properties": {"name": {"type": "string"}}}
+
+    prompt = response_schema_prompt(model=MODEL, response_schema=response_schema)
+
+    assert prompt == f"[INST] {response_schema} [/INST]"


### PR DESCRIPTION
## TLDR

Problem this solves:

- Custom prompt template with only `roles` set 500s every request
- `initial_prompt_value` / `final_prompt_value` are documented as optional
- Error says connection failure, but nothing was ever connected to
- Hits `ollama/`, `petals/`, `vllm/`, `predibase/`, `codestral/`, anthropic text

How it solves it:

- Read both optional keys with `.get(key, "")` instead of direct indexing
- Matches bedrock, sagemaker, replicate, huggingface, watsonx already do
- Matches the `""` defaults `custom_prompt()` itself declares
- Templates that set every key are completely unaffected

## User Flow

Before: a developer running a gateway in front of Ollama customizes one model's prompt format, and every request to that model fails with what looks like a network error

1. They add a custom prompt template to the model, setting only the roles field, since the two surrounding string fields are documented as optional
2. They restart the gateway. It starts cleanly, with no warning about the template
3. They send `POST https://litellm-domain/v1/chat/completions` with `"model": "my-ollama-model"` and one user message
4. They get back HTTP 500 `litellm.APIConnectionError: 'initial_prompt_value'`
5. Ollama's own logs show no request ever arrived, so they spend time checking networking, the Ollama host, and their firewall
6. The only way out is to discover, from provider source, that both "optional" fields must actually be set, commonly to `"\n"`

After: the same request succeeds, and the template renders the way the docs describe

1. They add the same custom prompt template, setting only the roles field
2. They restart the gateway. It starts cleanly
3. They send the same `POST https://litellm-domain/v1/chat/completions` request
4. They get back HTTP 200 with the model's reply
5. Ollama receives the prompt rendered in the model's instruction format, with nothing added before or after it
6. Setting either optional field later still prepends or appends exactly that text

## Relevant issues

Fixes #39759

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Shared setup, identical on both sides: a local Ollama-compatible server on `127.0.0.1`, and one `litellm.completion()` call to `ollama/llama2` pointed at it, passing a custom prompt template that sets `roles` only and leaves both string keys unset. Real HTTP, no mocks and no stubbed transport.

```python
ROLES = {
    "system": {"pre_message": "[INST] <<SYS>>\n", "post_message": "\n<</SYS>>\n [/INST]\n"},
    "user": {"pre_message": "[INST] ", "post_message": " [/INST]"},
    "assistant": {"pre_message": "", "post_message": "</s>"},
}

litellm.completion(
    model="ollama/llama2",
    messages=[{"role": "user", "content": "hello"}],
    api_base=f"http://127.0.0.1:{port}",
    roles=ROLES,
)
```

### Before (f74bc9427b)

1. Run the call above against the local server

```
POST http://127.0.0.1:45305/api/generate  (local Ollama-compatible server)
custom prompt template sets `roles` only; both string keys left unset

HTTP 500 APIConnectionError: litellm.APIConnectionError: 'initial_prompt_value'
  server never received a request: True
```

2. The traceback names the read that fails

```
File "litellm/llms/ollama/completion/transformation.py", line 363, in transform_request
    initial_prompt_value=model_prompt_details["initial_prompt_value"],
KeyError: 'initial_prompt_value'
```

### After (30ec4e4fce)

1. Run the identical call against the local server

```
POST http://127.0.0.1:43163/api/generate  (local Ollama-compatible server)
custom prompt template sets `roles` only; both string keys left unset

HTTP 200 OK
  prompt the server received : '[INST] hello [/INST]'
  content returned to caller : 'hi there'
```

2. Unit tests covering the change

```
$ uv run pytest tests/test_litellm/llms/test_partial_custom_prompt_template.py -q
7 passed

$ uv run pytest tests/test_litellm/llms/ollama/ tests/test_litellm/llms/test_predibase_transformation.py \
    tests/test_litellm/litellm_core_utils/prompt_templates/ -q
364 passed
```

3. Reverting only the source change and rerunning the new test file fails 6 of its 7 tests with the same `KeyError`; the seventh is the guard asserting a fully populated template still renders identically, and it passes on both sides.

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- `vllm`, `petals`, `codestral` got the identical change, untested locally: needs those providers' SDKs
- Behavior is unchanged for any template that sets all three keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J7Jr1zaqrMwsDJqpEfiCpx
