### PR TITLE
fix(organization): reject negative limits and unparseable budget_duration on PATCH /v2/organization

### DIFF
--- a/litellm/proxy/management_endpoints/common_utils.py
+++ b/litellm/proxy/management_endpoints/common_utils.py
@@ -22,7 +22,7 @@ def validate_finite_spend(spend: float | None) -> None:
         )
 
 
-def validate_budget_duration(budget_duration: str | None) -> None:
+def validate_budget_duration(budget_duration: str | None, status_code: int = 400) -> None:
     """Reject budget durations that can't be parsed, are non-positive, or
     overflow date math, so a bad value can't be persisted and later crash the
     budget reset job.
@@ -44,7 +44,7 @@ def validate_budget_duration(budget_duration: str | None) -> None:
         get_budget_reset_time(budget_duration=budget_duration)
     except (ValueError, OverflowError):
         raise HTTPException(
-            status_code=400,
+            status_code=status_code,
             detail={
                 "error": f"Invalid budget_duration '{budget_duration}'. Use a format like '1h', '24h', '7d', or '30d'."
             },

--- a/litellm/proxy/management_endpoints/organization_endpoints.py
+++ b/litellm/proxy/management_endpoints/organization_endpoints.py
@@ -41,6 +41,7 @@ from litellm.proxy.management_endpoints.common_daily_activity import get_daily_a
 from litellm.proxy.management_endpoints.common_utils import (
     _set_object_metadata_field,
     _user_has_admin_view,
+    validate_budget_duration,
 )
 from litellm.proxy.management_helpers.object_permission_utils import (
     handle_update_object_permission_common,
@@ -807,6 +808,17 @@ async def update_organization_v2(
             status_code=422,
             detail={"error": f"soft_budget must be a non-negative finite number. Received: {data.soft_budget}"},
         )
+    for limit_name, limit_value in (
+        ("tpm_limit", data.tpm_limit),
+        ("rpm_limit", data.rpm_limit),
+        ("max_parallel_requests", data.max_parallel_requests),
+    ):
+        if limit_value is not None and limit_value < 0:
+            raise HTTPException(
+                status_code=422,
+                detail={"error": f"{limit_name} must be non-negative. Received: {limit_value}"},
+            )
+    validate_budget_duration(data.budget_duration, status_code=422)
     if data.model_max_budget:
         from litellm.proxy.management_endpoints.key_management_endpoints import (
             validate_model_max_budget,

--- a/tests/test_litellm/proxy/management_endpoints/test_organization_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_organization_endpoints.py
@@ -821,7 +821,8 @@ async def test_v2_rejects_negative_integer_limits(monkeypatch: pytest.MonkeyPatc
     from litellm.proxy._types import LitellmUserRoles, OrganizationUpdateRequestV2, UserAPIKeyAuth
     from litellm.proxy.management_endpoints.organization_endpoints import update_organization_v2
 
-    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", AsyncMock())
+    prisma_mock = AsyncMock()
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", prisma_mock)
 
     auth = UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin-1")
     with pytest.raises(HTTPException) as exc:
@@ -832,6 +833,9 @@ async def test_v2_rejects_negative_integer_limits(monkeypatch: pytest.MonkeyPatc
         )
     assert exc.value.status_code == 422
     assert field in str(exc.value.detail)
+    prisma_mock.db.tx.assert_not_called()
+    prisma_mock.db.litellm_budgettable.update.assert_not_awaited()
+    prisma_mock.db.litellm_organizationtable.update.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -841,7 +845,8 @@ async def test_v2_rejects_unparseable_budget_duration(monkeypatch: pytest.Monkey
     from litellm.proxy._types import LitellmUserRoles, OrganizationUpdateRequestV2, UserAPIKeyAuth
     from litellm.proxy.management_endpoints.organization_endpoints import update_organization_v2
 
-    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", AsyncMock())
+    prisma_mock = AsyncMock()
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", prisma_mock)
 
     auth = UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin-1")
     with pytest.raises(HTTPException) as exc:
@@ -852,6 +857,9 @@ async def test_v2_rejects_unparseable_budget_duration(monkeypatch: pytest.Monkey
         )
     assert exc.value.status_code == 422
     assert "budget_duration" in str(exc.value.detail)
+    prisma_mock.db.tx.assert_not_called()
+    prisma_mock.db.litellm_budgettable.update.assert_not_awaited()
+    prisma_mock.db.litellm_organizationtable.update.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/management_endpoints/test_organization_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_organization_endpoints.py
@@ -815,6 +815,46 @@ async def test_v2_rejects_negative_max_budget(monkeypatch):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("field", ["tpm_limit", "rpm_limit", "max_parallel_requests"])
+async def test_v2_rejects_negative_integer_limits(monkeypatch: pytest.MonkeyPatch, field: str):
+    """v2 rejects negative tpm/rpm/parallel-request limits with a 422 instead of persisting them to the budget row."""
+    from litellm.proxy._types import LitellmUserRoles, OrganizationUpdateRequestV2, UserAPIKeyAuth
+    from litellm.proxy.management_endpoints.organization_endpoints import update_organization_v2
+
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", AsyncMock())
+
+    auth = UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin-1")
+    with pytest.raises(HTTPException) as exc:
+        await update_organization_v2(
+            organization_id="org-1",
+            data=OrganizationUpdateRequestV2.model_validate({field: -1}),
+            user_api_key_dict=auth,
+        )
+    assert exc.value.status_code == 422
+    assert field in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_v2_rejects_unparseable_budget_duration(monkeypatch: pytest.MonkeyPatch):
+    """v2 rejects a budget_duration the parser can't read with a 422 instead of persisting it alongside a silent
+    next-midnight fallback reset."""
+    from litellm.proxy._types import LitellmUserRoles, OrganizationUpdateRequestV2, UserAPIKeyAuth
+    from litellm.proxy.management_endpoints.organization_endpoints import update_organization_v2
+
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", AsyncMock())
+
+    auth = UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin-1")
+    with pytest.raises(HTTPException) as exc:
+        await update_organization_v2(
+            organization_id="org-1",
+            data=OrganizationUpdateRequestV2.model_validate({"budget_duration": "bogus"}),
+            user_api_key_dict=auth,
+        )
+    assert exc.value.status_code == 422
+    assert "budget_duration" in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
 async def test_v2_rejects_caller_without_org_access(monkeypatch):
     """v2 runs the real _verify_org_access guard: a non-admin without ORG_ADMIN on the org gets 403 and no write."""
     from litellm.proxy._types import LitellmUserRoles, OrganizationUpdateRequestV2, UserAPIKeyAuth


### PR DESCRIPTION
## TLDR

Problem this solves:

- `PATCH /v2/organization/{id}` accepted negative `tpm_limit`, `rpm_limit`, `max_parallel_requests`
- It also persisted unparseable `budget_duration` values like `"bogus"`
- Both returned 200 and wrote the garbage to the budget row

How it solves it:

- Negative integer limits now return 422 before any DB write
- `budget_duration` is validated with the shared `validate_budget_duration` helper
- Valid updates and explicit null clears behave exactly as before

## User Flow

Before: an admin who fat-fingers a limit gets a 200 and a silently broken budget

1. They send PATCH https://litellm-domain/v2/organization/{organization_id} with `{"tpm_limit": -5}`
2. The response is HTTP 200 and the org's TPM limit is now -5
3. They send PATCH https://litellm-domain/v2/organization/{organization_id} with `{"budget_duration": "bogus"}`
4. The response is HTTP 200; GET https://litellm-domain/organization/info?organization_id={id} shows `budget_duration: "bogus"` with no reset time scheduled

After: the same requests are rejected with a clear error and nothing is written

1. They send PATCH https://litellm-domain/v2/organization/{organization_id} with `{"tpm_limit": -5}`
2. The response is HTTP 422 with `tpm_limit must be non-negative. Received: -5`
3. They send PATCH https://litellm-domain/v2/organization/{organization_id} with `{"budget_duration": "bogus"}`
4. The response is HTTP 422 with `Invalid budget_duration 'bogus'. Use a format like '1h', '24h', '7d', or '30d'.`
5. GET https://litellm-domain/organization/info?organization_id={id} shows the original limits untouched

## Relevant issues

## Linear ticket

Resolves LIT-5769

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup: proxy running `litellm/proxy/dev_config.yaml` on localhost:4187 against local Postgres, master key `sk-1234`. Each side creates its own org first:

```bash
ORG=$(curl -s -X POST http://localhost:4187/organization/new \
  -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"organization_alias":"v2-validation-qa","tpm_limit":1000,"budget_duration":"7d"}')
ORG_ID=$(echo "$ORG" | jq -r .organization_id)
echo "$ORG" | jq -c '{organization_id, tpm_limit: .litellm_budget_table.tpm_limit, budget_duration: .litellm_budget_table.budget_duration}'
```

```
{"organization_id":"...","tpm_limit":1000,"budget_duration":"7d"}
```

### Before (62087c5d5f)

#### Negative limits

1. `curl -s -w '\nHTTP %{http_code}\n' -X PATCH "http://localhost:4187/v2/organization/$ORG_ID" -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"tpm_limit": -5}' | tail -1` prints `HTTP 200`
2. Same for `{"rpm_limit": -1}` and `{"max_parallel_requests": -3}`: both `HTTP 200`

#### Unparseable budget_duration

1. `curl -s -w '\nHTTP %{http_code}\n' -X PATCH "http://localhost:4187/v2/organization/$ORG_ID" -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"budget_duration": "bogus"}' | tail -1` prints `HTTP 200`
2. `curl -s "http://localhost:4187/organization/info?organization_id=$ORG_ID" -H 'Authorization: Bearer sk-1234' | jq -c '.litellm_budget_table | {tpm_limit, rpm_limit, max_parallel_requests, budget_duration, budget_reset_at}'`
3. `{"tpm_limit":-5,"rpm_limit":-1,"max_parallel_requests":-3,"budget_duration":"bogus","budget_reset_at":null}`

### After (976ff0a785, tip 7a717740dd only strengthens tests with no runtime change)

#### Negative limits

1. `curl -s -w '\nHTTP %{http_code}\n' -X PATCH "http://localhost:4187/v2/organization/$ORG_ID" -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"tpm_limit": -5}'`
2. `{"detail":{"error":"tpm_limit must be non-negative. Received: -5"}}` then `HTTP 422`
3. `{"rpm_limit": -1}` and `{"max_parallel_requests": -3}` also return `HTTP 422` naming the field
4. A valid `{"tpm_limit": 500}` still returns `HTTP 200`

#### Unparseable budget_duration

1. `curl -s -w '\nHTTP %{http_code}\n' -X PATCH "http://localhost:4187/v2/organization/$ORG_ID" -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"budget_duration": "bogus"}'`
2. `{"detail":{"error":"Invalid budget_duration 'bogus'. Use a format like '1h', '24h', '7d', or '30d'."}}` then `HTTP 422`
3. `curl -s "http://localhost:4187/organization/info?organization_id=$ORG_ID" -H 'Authorization: Bearer sk-1234' | jq -c '.litellm_budget_table | {tpm_limit, rpm_limit, max_parallel_requests, budget_duration}'` shows the original values: `{"tpm_limit":1000,"rpm_limit":null,"max_parallel_requests":null,"budget_duration":"7d"}` (then `tpm_limit: 500` after the valid update above)
4. An explicit null clear `{"budget_duration": null}` still returns `HTTP 200` with `{"budget_duration":null,"budget_reset_at":null}`

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Requests sending these invalid values got 200 before; now 422
- The endpoint is UI-internal (hidden from OpenAPI), so blast radius is small
- `validate_budget_duration` gained an optional `status_code` param; default 400 unchanged for existing callers

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
