### PR TITLE
feat(organization): expose PATCH /v2/organization/{organization_id} in the OpenAPI schema

### DIFF
--- a/litellm/proxy/management_endpoints/organization_endpoints.py
+++ b/litellm/proxy/management_endpoints/organization_endpoints.py
@@ -764,7 +764,6 @@ async def handle_update_object_permission(
     tags=["organization management"],
     dependencies=[Depends(user_api_key_auth)],
     response_model=LiteLLM_OrganizationTableWithMembers,
-    include_in_schema=False,
 )
 async def update_organization_v2(
     organization_id: str,

--- a/tests/test_litellm/proxy/management_endpoints/test_organization_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_organization_endpoints.py
@@ -726,6 +726,20 @@ async def _run_update_organization_v2(
     return mock_prisma_client
 
 
+def test_v2_update_route_is_public_in_openapi():
+    """PATCH /v2/organization/{organization_id} is a public route: hiding it again (include_in_schema=False)
+    would drop it from openapi.json, /docs, and the generated UI API types."""
+    from fastapi import FastAPI
+
+    from litellm.proxy.management_endpoints.organization_endpoints import router
+
+    app = FastAPI()
+    app.include_router(router)
+    v2_path = app.openapi()["paths"].get("/v2/organization/{organization_id}")
+    assert v2_path is not None
+    assert "patch" in v2_path
+
+
 @pytest.mark.asyncio
 async def test_v2_update_clears_tpm_limit_and_metadata(monkeypatch):
     """A cleared tpm_limit is written to the budget row as None; a cleared metadata is written as {}."""

--- a/tests/test_litellm/proxy/management_endpoints/test_organization_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_organization_endpoints.py
@@ -729,13 +729,9 @@ async def _run_update_organization_v2(
 def test_v2_update_route_is_public_in_openapi():
     """PATCH /v2/organization/{organization_id} is a public route: hiding it again (include_in_schema=False)
     would drop it from openapi.json, /docs, and the generated UI API types."""
-    from fastapi import FastAPI
+    from litellm.proxy.proxy_server import get_openapi_schema
 
-    from litellm.proxy.management_endpoints.organization_endpoints import router
-
-    app = FastAPI()
-    app.include_router(router)
-    v2_path = app.openapi()["paths"].get("/v2/organization/{organization_id}")
+    v2_path = get_openapi_schema()["paths"].get("/v2/organization/{organization_id}")
     assert v2_path is not None
     assert "patch" in v2_path
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- `PATCH /v2/organization/{organization_id}` exists but is hidden from OpenAPI
- API users can't discover it and fall back to the quirkier legacy `/organization/update`
- The legacy endpoint only just learned to clear limits with null (#39670)

How it solves it:

- Drops `include_in_schema=False` from the v2 route
- The endpoint now shows in `/docs`, `openapi.json`, and generated clients
- A test pins the route as public so it can't silently vanish again

## User Flow

Before: a developer scripting org management can't find a PATCH endpoint with merge-patch semantics

1. They open https://litellm-domain/docs and search for organization endpoints
2. Only POST /organization/new, PATCH /organization/update and friends appear; no /v2/organization/{organization_id}
3. GET https://litellm-domain/openapi.json confirms the v2 path is absent, so their generated client has no method for it

After: the v2 endpoint is documented and discoverable

1. They open https://litellm-domain/docs and find PATCH /v2/organization/{organization_id} under organization management, with typed request and response schemas
2. GET https://litellm-domain/openapi.json lists the path, so generated clients pick it up
3. They send PATCH https://litellm-domain/v2/organization/{organization_id} with `{"organization_alias": "renamed"}` and get HTTP 200 with the updated org

## Relevant issues

## Linear ticket

Resolves LIT-5769

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup: proxy running `litellm/proxy/dev_config.yaml` on localhost:4187 against local Postgres, master key `sk-1234`

### Before (62087c5d5f)

1. `curl -s http://localhost:4187/openapi.json | jq '.paths | has("/v2/organization/{organization_id}")'` prints `false`

### After (3e4a884b25, tip 0eb2363074 only reroutes the test through the production OpenAPI generator)

1. `curl -s http://localhost:4187/openapi.json | jq '.paths | has("/v2/organization/{organization_id}")'` prints `true`
2. `curl -s http://localhost:4187/openapi.json | jq -c '.paths["/v2/organization/{organization_id}"] | {ops: keys, summary: .patch.summary, tags: .patch.tags}'` prints `{"ops":["patch"],"summary":"Update Organization V2","tags":["organization management"]}`
3. The endpoint still works: `curl -s -w '\nHTTP %{http_code}\n' -X PATCH "http://localhost:4187/v2/organization/$ORG_ID" -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"organization_alias":"v2-public-qa-renamed"}' | tail -1` prints `HTTP 200`, and `GET /organization/info` shows the new alias

## Type

🆕 New Feature

## Caveats (if any)

### Medium

- Publishing the route freezes its contract; #39793 tightens its input validation and should land first

### Low

- `ui/litellm-dashboard` schema.d.ts is unchanged: the UI type generator already includes hidden routes

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
