### PR TITLE
fix(health): probe test_connection with the credential the request names

### DIFF
--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -115,6 +115,29 @@ _CONFIG_CONNECTION_FIELDS: Final[frozenset[str]] = frozenset(
 )
 
 
+def _request_inherits_config_credentials(
+    config_params: Mapping[str, object],
+    request_params: Mapping[str, object],
+    allow_client_side_credentials: bool,
+) -> bool:
+    """Whether the configuration's credentials are this request's to be probed with.
+
+    The configuration reached here by matching the request's model string, which
+    also matches wildcard routes and unrelated deployments that merely serve the
+    same model, so a request naming a stored credential of its own has already
+    said where its credentials come from and does not borrow that one's. A blank
+    name is no name: ``load_credentials_from_list`` resolves nothing from it, so
+    it must not cost the request the credentials it would otherwise be probed
+    with.
+    """
+    requested_credential: Final = request_params.get("litellm_credential_name")
+    if requested_credential and requested_credential != config_params.get("litellm_credential_name"):
+        return False
+    if allow_client_side_credentials:
+        return True
+    return not any(param in request_params for param in _BANNED_REQUEST_BODY_PARAMS)
+
+
 def _config_base_for_health_check(
     config_params: Mapping[str, object],
     request_params: Mapping[str, object],
@@ -122,25 +145,19 @@ def _config_base_for_health_check(
 ) -> dict[str, object]:
     """Return the configured parameters to merge under a connection-test request.
 
-    A request that sets its own connection fields describes a connection of its
-    own, so the configuration's credentials are not carried into it: they belong
-    to the endpoint the configuration names. Anything the request does not set
-    still comes from the configuration, which is what lets a request name a
-    configured model and test it as configured.
+    A request that sets its own connection fields, or names its own stored
+    credential, describes a connection of its own, so the configuration's
+    credentials are not carried into it: they belong to the endpoint the
+    configuration names. Anything the request does not set still comes from the
+    configuration, which is what lets a request name a configured model and test
+    it as configured.
 
     ``litellm_credential_name`` is dropped alongside the literal credential
     fields: it names a stored credential that ``load_credentials_from_list``
     resolves into the same secrets further down the call, so leaving it in place
     would reintroduce them by reference.
-
-    ``general_settings.allow_client_side_credentials`` is the existing proxy-wide
-    opt-in for callers supplying their own connection parameters. Where an admin
-    has enabled it, a request may pair its own endpoint with the configured
-    credentials, as it could before.
     """
-    if allow_client_side_credentials:
-        return dict(config_params)
-    if not any(param in request_params for param in _BANNED_REQUEST_BODY_PARAMS):
+    if _request_inherits_config_credentials(config_params, request_params, allow_client_side_credentials):
         return dict(config_params)
     return {key: value for key, value in config_params.items() if key not in _CONFIG_CONNECTION_FIELDS}
 
@@ -1959,6 +1976,9 @@ async def test_model_connection(
     Note: 
     - If the model is configured in proxy_config.yaml, credentials (api_key, api_base, etc.) 
       will be automatically loaded from the config (with resolved environment variables).
+    - A request naming a stored credential (`litellm_credential_name`) that the configuration
+      does not name is probed with that credential instead, and inherits no credentials
+      from the configuration its model string happened to match.
     - You can override specific params by including them in the request.
     - You can use `os.environ/VARIABLE_NAME` syntax to reference environment variables,
       which will be resolved automatically (same as in proxy_config.yaml).

--- a/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
+++ b/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
@@ -2678,8 +2678,6 @@ class TestConfigBaseForHealthCheck:
         assert base["api_key"] == "sk-configured"
 
     def test_request_naming_another_credential_does_not_inherit_config_credentials(self):
-        """The model string matched a configuration the request never asked for;
-        naming a credential of its own says where its credentials come from."""
         base = self._base(self.CONFIG, {"model": "openai/gpt-4o", "litellm_credential_name": "Another-cred"})
         assert "api_key" not in base
         assert "api_base" not in base
@@ -2687,8 +2685,6 @@ class TestConfigBaseForHealthCheck:
         assert base["rpm"] == 100
 
     def test_blank_credential_name_names_no_credential(self):
-        """It resolves to nothing downstream, so it must not cost the request the
-        configured credentials it would otherwise be probed with."""
         base = self._base(self.CONFIG, {"model": "openai/gpt-4o", "litellm_credential_name": ""})
         assert base["api_key"] == "sk-configured"
 
@@ -2702,10 +2698,6 @@ class TestConfigBaseForHealthCheck:
 
 
 class TestTestConnectionUsesTheNamedCredential:
-    """A connection test that names a stored credential is probed with that
-    credential, not with the credentials of an unrelated deployment that
-    happens to match the model string it is testing."""
-
     CREDENTIAL_KEY = "sk-credential-key"
     OTHER_DEPLOYMENT_KEY = "sk-other-deployment-key"
     REQUEST = {
@@ -2765,8 +2757,6 @@ class TestTestConnectionUsesTheNamedCredential:
 
     @pytest.mark.asyncio
     async def test_named_credentials_key_is_sent_not_the_matched_deployments_key(self, monkeypatch):
-        """The Add Model page sends a credential name and no key of its own; a
-        wildcard route covering the new model must not supply the key instead."""
         monkeypatch.setattr(litellm, "credential_list", [self._credential(api_key=self.CREDENTIAL_KEY)])
 
         probed = await self._probe_params(
@@ -2794,8 +2784,6 @@ class TestTestConnectionUsesTheNamedCredential:
 
     @pytest.mark.asyncio
     async def test_named_credential_without_an_api_base_leaves_the_provider_default(self, monkeypatch):
-        """A credential that carries only a key must not pick up an endpoint
-        from the matched deployment; the provider's own default applies."""
         monkeypatch.setattr(litellm, "credential_list", [self._credential(api_key=self.CREDENTIAL_KEY)])
 
         probed = await self._probe_params(
@@ -2807,8 +2795,6 @@ class TestTestConnectionUsesTheNamedCredential:
 
     @pytest.mark.asyncio
     async def test_configured_model_named_without_a_credential_still_inherits_its_config(self):
-        """Documented behavior: probing a configured model by name and nothing
-        else keeps using that model's configured credentials."""
         probed = await self._probe_params(
             {
                 "model_name": "grok-4",
@@ -2827,8 +2813,7 @@ class TestTestConnectionUsesTheNamedCredential:
 
     @pytest.mark.asyncio
     async def test_deployment_probed_by_id_keeps_the_endpoint_it_is_configured_with(self, monkeypatch):
-        """The model detail page names the deployment by id and echoes back the
-        credential that deployment already uses; its endpoint still applies."""
+        """The model detail page always echoes back the credential the deployment already uses."""
         from litellm.types.router import Deployment, LiteLLM_Params
 
         monkeypatch.setattr(litellm, "credential_list", [self._credential(api_key=self.CREDENTIAL_KEY)])

--- a/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
+++ b/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
@@ -15,6 +15,7 @@ from prisma.errors import ClientNotConnectedError, HTTPClientClosedError, Prisma
 import litellm
 import litellm.proxy.health_endpoints._health_endpoints as _health_endpoints_module
 from litellm.litellm_core_utils.health_check_helpers import TEST_IMAGE_BASE64
+from litellm.models.credentials import CredentialItem
 from litellm.proxy._types import LitellmUserRoles, ProxyException, UserAPIKeyAuth
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.proxy.health_endpoints._health_endpoints import (
@@ -27,6 +28,7 @@ from litellm.proxy.health_endpoints._health_endpoints import (
 from litellm.proxy.health_endpoints._health_endpoints import (
     test_model_connection as health_test_model_connection,
 )
+from litellm.utils import load_credentials_from_list
 
 # Import shared proxy test helpers from conftest
 from tests.test_litellm.proxy.conftest import create_proxy_test_client
@@ -2674,6 +2676,180 @@ class TestConfigBaseForHealthCheck:
         )
         assert base["litellm_credential_name"] == "OpenAI-prod"
         assert base["api_key"] == "sk-configured"
+
+    def test_request_naming_another_credential_does_not_inherit_config_credentials(self):
+        """The model string matched a configuration the request never asked for;
+        naming a credential of its own says where its credentials come from."""
+        base = self._base(self.CONFIG, {"model": "openai/gpt-4o", "litellm_credential_name": "Another-cred"})
+        assert "api_key" not in base
+        assert "api_base" not in base
+        assert "vertex_credentials" not in base
+        assert base["rpm"] == 100
+
+    def test_blank_credential_name_names_no_credential(self):
+        """It resolves to nothing downstream, so it must not cost the request the
+        configured credentials it would otherwise be probed with."""
+        base = self._base(self.CONFIG, {"model": "openai/gpt-4o", "litellm_credential_name": ""})
+        assert base["api_key"] == "sk-configured"
+
+    def test_opt_in_does_not_put_config_credentials_over_a_named_credential(self):
+        base = self._base(
+            self.CONFIG,
+            {"model": "openai/gpt-4o", "litellm_credential_name": "Another-cred"},
+            allow_client_side_credentials=True,
+        )
+        assert "api_key" not in base
+
+
+class TestTestConnectionUsesTheNamedCredential:
+    """A connection test that names a stored credential is probed with that
+    credential, not with the credentials of an unrelated deployment that
+    happens to match the model string it is testing."""
+
+    CREDENTIAL_KEY = "sk-credential-key"
+    OTHER_DEPLOYMENT_KEY = "sk-other-deployment-key"
+    REQUEST = {
+        "model": "xai/grok-4",
+        "custom_llm_provider": "xai",
+        "litellm_credential_name": "my-xai-cred",
+    }
+
+    @staticmethod
+    def _credential(**values: str) -> CredentialItem:
+        return CredentialItem(credential_name="my-xai-cred", credential_info={}, credential_values=values)
+
+    @staticmethod
+    def _wildcard_deployment(**litellm_params: str) -> dict:
+        return {
+            "model_name": "xai/*",
+            "litellm_params": {"model": "xai/*", **litellm_params},
+            "model_info": {"id": "unrelated-wildcard-deployment"},
+        }
+
+    @staticmethod
+    async def _probe_params(
+        deployment: dict,
+        request_litellm_params: dict,
+        deployment_by_id: object | None = None,
+        request_model_info: dict | None = None,
+    ) -> dict:
+        """Run /health/test_connection and return the params it probed with,
+        resolved the same way the completion path resolves them."""
+        router = MagicMock()
+        router.get_model_list.return_value = [deployment]
+        router.get_deployment.return_value = deployment_by_id
+        ahealth_check = AsyncMock(return_value={"status": "healthy"})
+
+        with (
+            patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
+            patch("litellm.proxy.proxy_server.llm_router", router),
+            patch("litellm.proxy.proxy_server.premium_user", False),
+            patch(
+                "litellm.proxy.management_endpoints.model_management_endpoints."
+                "ModelManagementAuthChecks.can_user_make_model_call",
+                AsyncMock(),
+            ),
+            patch("litellm.proxy.health_endpoints._health_endpoints.litellm.ahealth_check", ahealth_check),
+        ):
+            await health_test_model_connection(
+                request=MagicMock(),
+                mode="chat",
+                litellm_params=request_litellm_params,
+                model_info=request_model_info or {"mode": "chat"},
+                user_api_key_dict=MagicMock(),
+            )
+
+        probed = dict(ahealth_check.call_args.kwargs["model_params"])
+        load_credentials_from_list(probed)
+        return probed
+
+    @pytest.mark.asyncio
+    async def test_named_credentials_key_is_sent_not_the_matched_deployments_key(self, monkeypatch):
+        """The Add Model page sends a credential name and no key of its own; a
+        wildcard route covering the new model must not supply the key instead."""
+        monkeypatch.setattr(litellm, "credential_list", [self._credential(api_key=self.CREDENTIAL_KEY)])
+
+        probed = await self._probe_params(
+            self._wildcard_deployment(api_key=self.OTHER_DEPLOYMENT_KEY),
+            self.REQUEST,
+        )
+
+        assert probed["api_key"] == self.CREDENTIAL_KEY
+        assert self.OTHER_DEPLOYMENT_KEY not in str(probed)
+
+    @pytest.mark.asyncio
+    async def test_named_credentials_api_base_is_used_not_the_matched_deployments(self, monkeypatch):
+        monkeypatch.setattr(
+            litellm,
+            "credential_list",
+            [self._credential(api_key=self.CREDENTIAL_KEY, api_base="https://credential.example/v1")],
+        )
+
+        probed = await self._probe_params(
+            self._wildcard_deployment(api_base="https://other-deployment.example/v1"),
+            self.REQUEST,
+        )
+
+        assert probed["api_base"] == "https://credential.example/v1"
+
+    @pytest.mark.asyncio
+    async def test_named_credential_without_an_api_base_leaves_the_provider_default(self, monkeypatch):
+        """A credential that carries only a key must not pick up an endpoint
+        from the matched deployment; the provider's own default applies."""
+        monkeypatch.setattr(litellm, "credential_list", [self._credential(api_key=self.CREDENTIAL_KEY)])
+
+        probed = await self._probe_params(
+            self._wildcard_deployment(api_base="https://other-deployment.example/v1"),
+            self.REQUEST,
+        )
+
+        assert probed.get("api_base") is None
+
+    @pytest.mark.asyncio
+    async def test_configured_model_named_without_a_credential_still_inherits_its_config(self):
+        """Documented behavior: probing a configured model by name and nothing
+        else keeps using that model's configured credentials."""
+        probed = await self._probe_params(
+            {
+                "model_name": "grok-4",
+                "litellm_params": {
+                    "model": "xai/grok-4",
+                    "api_key": self.OTHER_DEPLOYMENT_KEY,
+                    "api_base": "https://configured.example/v1",
+                },
+                "model_info": {"id": "configured-deployment"},
+            },
+            {"model": "grok-4"},
+        )
+
+        assert probed["api_key"] == self.OTHER_DEPLOYMENT_KEY
+        assert probed["api_base"] == "https://configured.example/v1"
+
+    @pytest.mark.asyncio
+    async def test_deployment_probed_by_id_keeps_the_endpoint_it_is_configured_with(self, monkeypatch):
+        """The model detail page names the deployment by id and echoes back the
+        credential that deployment already uses; its endpoint still applies."""
+        from litellm.types.router import Deployment, LiteLLM_Params
+
+        monkeypatch.setattr(litellm, "credential_list", [self._credential(api_key=self.CREDENTIAL_KEY)])
+
+        probed = await self._probe_params(
+            self._wildcard_deployment(api_key=self.OTHER_DEPLOYMENT_KEY),
+            self.REQUEST,
+            deployment_by_id=Deployment(
+                model_name="grok-4",
+                litellm_params=LiteLLM_Params(
+                    model="xai/grok-4",
+                    api_base="https://configured.example/v1",
+                    litellm_credential_name="my-xai-cred",
+                ),
+                model_info={"id": "configured-deployment"},
+            ),
+            request_model_info={"id": "configured-deployment", "mode": "chat"},
+        )
+
+        assert probed["api_base"] == "https://configured.example/v1"
+        assert probed["api_key"] == self.CREDENTIAL_KEY
 
 
 class TestNoRedisWarning:

--- a/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
+++ b/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
@@ -28,7 +28,6 @@ from litellm.proxy.health_endpoints._health_endpoints import (
 from litellm.proxy.health_endpoints._health_endpoints import (
     test_model_connection as health_test_model_connection,
 )
-from litellm.utils import load_credentials_from_list
 
 # Import shared proxy test helpers from conftest
 from tests.test_litellm.proxy.conftest import create_proxy_test_client
@@ -2700,10 +2699,19 @@ class TestConfigBaseForHealthCheck:
 class TestTestConnectionUsesTheNamedCredential:
     CREDENTIAL_KEY = "sk-credential-key"
     OTHER_DEPLOYMENT_KEY = "sk-other-deployment-key"
+    OTHER_DEPLOYMENT_BASE = "https://other-deployment.example/v1"
     REQUEST = {
         "model": "xai/grok-4",
         "custom_llm_provider": "xai",
         "litellm_credential_name": "my-xai-cred",
+    }
+    COMPLETION = {
+        "id": "chatcmpl-test",
+        "object": "chat.completion",
+        "created": 1700000000,
+        "model": "grok-4",
+        "choices": [{"index": 0, "finish_reason": "stop", "message": {"role": "assistant", "content": "ok"}}],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
     }
 
     @staticmethod
@@ -2718,108 +2726,106 @@ class TestTestConnectionUsesTheNamedCredential:
             "model_info": {"id": "unrelated-wildcard-deployment"},
         }
 
-    @staticmethod
-    async def _probe_params(
+    def _probe(
+        self,
+        monkeypatch,
         deployment: dict,
         request_litellm_params: dict,
         deployment_by_id: object | None = None,
         request_model_info: dict | None = None,
-    ) -> dict:
-        """Run /health/test_connection and return the params it probed with,
-        resolved the same way the completion path resolves them."""
+    ) -> httpx.Request:
+        """Run /health/test_connection and hand back the upstream request it made."""
+        monkeypatch.setattr(litellm, "disable_aiohttp_transport", True)
+        litellm.in_memory_llm_clients_cache.flush_cache()
+
+        app = FastAPI()
+        app.include_router(_health_endpoints_module.router)
+        app.dependency_overrides[user_api_key_auth] = lambda: UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN)
+
         router = MagicMock()
         router.get_model_list.return_value = [deployment]
         router.get_deployment.return_value = deployment_by_id
-        ahealth_check = AsyncMock(return_value={"status": "healthy"})
 
         with (
-            patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
-            patch("litellm.proxy.proxy_server.llm_router", router),
-            patch("litellm.proxy.proxy_server.premium_user", False),
-            patch(
-                "litellm.proxy.management_endpoints.model_management_endpoints."
-                "ModelManagementAuthChecks.can_user_make_model_call",
-                AsyncMock(),
+            patch(  # test-quality-ok: the endpoint reads the proxy-global DB client and 500s when it is None; it has no injection seam
+                "litellm.proxy.proxy_server.prisma_client", MagicMock()
             ),
-            patch("litellm.proxy.health_endpoints._health_endpoints.litellm.ahealth_check", ahealth_check),
+            patch(  # test-quality-ok: the deployment the probe is matched against is a proxy global; it has no injection seam
+                "litellm.proxy.proxy_server.llm_router", router
+            ),
+            respx.mock(assert_all_called=True) as respx_mock,
         ):
-            await health_test_model_connection(
-                request=MagicMock(),
-                mode="chat",
-                litellm_params=request_litellm_params,
-                model_info=request_model_info or {"mode": "chat"},
-                user_api_key_dict=MagicMock(),
+            respx_mock.post(path__regex=r".*/chat/completions").respond(json=self.COMPLETION)
+            response = TestClient(app).post(
+                "/health/test_connection",
+                json={
+                    "mode": "chat",
+                    "litellm_params": request_litellm_params,
+                    "model_info": request_model_info or {"mode": "chat"},
+                },
             )
+            probe = respx_mock.calls.last.request
 
-        probed = dict(ahealth_check.call_args.kwargs["model_params"])
-        load_credentials_from_list(probed)
-        return probed
+        assert response.status_code == 200, response.text
+        assert response.json()["status"] == "success", response.text
+        return probe
 
-    @pytest.mark.asyncio
-    async def test_named_credentials_key_is_sent_not_the_matched_deployments_key(self, monkeypatch):
+    def test_named_credentials_key_is_sent_not_the_matched_deployments_key(self, monkeypatch):
         monkeypatch.setattr(litellm, "credential_list", [self._credential(api_key=self.CREDENTIAL_KEY)])
 
-        probed = await self._probe_params(
+        probe = self._probe(
+            monkeypatch,
             self._wildcard_deployment(api_key=self.OTHER_DEPLOYMENT_KEY),
             self.REQUEST,
         )
 
-        assert probed["api_key"] == self.CREDENTIAL_KEY
-        assert self.OTHER_DEPLOYMENT_KEY not in str(probed)
+        assert probe.headers["authorization"] == f"Bearer {self.CREDENTIAL_KEY}"
 
-    @pytest.mark.asyncio
-    async def test_named_credentials_api_base_is_used_not_the_matched_deployments(self, monkeypatch):
+    def test_named_credentials_api_base_is_used_not_the_matched_deployments(self, monkeypatch):
         monkeypatch.setattr(
             litellm,
             "credential_list",
             [self._credential(api_key=self.CREDENTIAL_KEY, api_base="https://credential.example/v1")],
         )
 
-        probed = await self._probe_params(
-            self._wildcard_deployment(api_base="https://other-deployment.example/v1"),
+        probe = self._probe(
+            monkeypatch,
+            self._wildcard_deployment(api_base=self.OTHER_DEPLOYMENT_BASE),
             self.REQUEST,
         )
 
-        assert probed["api_base"] == "https://credential.example/v1"
+        assert probe.url.host == "credential.example"
 
-    @pytest.mark.asyncio
-    async def test_named_credential_without_an_api_base_leaves_the_provider_default(self, monkeypatch):
+    def test_named_credential_without_an_api_base_leaves_the_provider_default(self, monkeypatch):
         monkeypatch.setattr(litellm, "credential_list", [self._credential(api_key=self.CREDENTIAL_KEY)])
 
-        probed = await self._probe_params(
-            self._wildcard_deployment(api_base="https://other-deployment.example/v1"),
+        probe = self._probe(
+            monkeypatch,
+            self._wildcard_deployment(api_base=self.OTHER_DEPLOYMENT_BASE),
             self.REQUEST,
         )
 
-        assert probed.get("api_base") is None
+        assert probe.url.host == "api.x.ai"
 
-    @pytest.mark.asyncio
-    async def test_configured_model_named_without_a_credential_still_inherits_its_config(self):
-        probed = await self._probe_params(
-            {
-                "model_name": "grok-4",
-                "litellm_params": {
-                    "model": "xai/grok-4",
-                    "api_key": self.OTHER_DEPLOYMENT_KEY,
-                    "api_base": "https://configured.example/v1",
-                },
-                "model_info": {"id": "configured-deployment"},
-            },
-            {"model": "grok-4"},
+    def test_configured_model_named_without_a_credential_still_inherits_its_config(self, monkeypatch):
+        probe = self._probe(
+            monkeypatch,
+            self._wildcard_deployment(api_key=self.OTHER_DEPLOYMENT_KEY, api_base=self.OTHER_DEPLOYMENT_BASE),
+            {"model": "xai/grok-4", "custom_llm_provider": "xai"},
         )
 
-        assert probed["api_key"] == self.OTHER_DEPLOYMENT_KEY
-        assert probed["api_base"] == "https://configured.example/v1"
+        assert probe.headers["authorization"] == f"Bearer {self.OTHER_DEPLOYMENT_KEY}"
+        assert probe.url.host == "other-deployment.example"
 
-    @pytest.mark.asyncio
-    async def test_deployment_probed_by_id_keeps_the_endpoint_it_is_configured_with(self, monkeypatch):
+    def test_deployment_probed_by_id_keeps_the_endpoint_it_is_configured_with(self, monkeypatch):
         """The model detail page always echoes back the credential the deployment already uses."""
         from litellm.types.router import Deployment, LiteLLM_Params
 
         monkeypatch.setattr(litellm, "credential_list", [self._credential(api_key=self.CREDENTIAL_KEY)])
 
-        probed = await self._probe_params(
-            self._wildcard_deployment(api_key=self.OTHER_DEPLOYMENT_KEY),
+        probe = self._probe(
+            monkeypatch,
+            self._wildcard_deployment(api_key=self.OTHER_DEPLOYMENT_KEY, api_base=self.OTHER_DEPLOYMENT_BASE),
             self.REQUEST,
             deployment_by_id=Deployment(
                 model_name="grok-4",
@@ -2833,8 +2839,8 @@ class TestTestConnectionUsesTheNamedCredential:
             request_model_info={"id": "configured-deployment", "mode": "chat"},
         )
 
-        assert probed["api_base"] == "https://configured.example/v1"
-        assert probed["api_key"] == self.CREDENTIAL_KEY
+        assert probe.url.host == "configured.example"
+        assert probe.headers["authorization"] == f"Bearer {self.CREDENTIAL_KEY}"
 
 
 class TestNoRedisWarning:

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -7037,6 +7037,9 @@ export interface paths {
          *     Note:
          *     - If the model is configured in proxy_config.yaml, credentials (api_key, api_base, etc.)
          *       will be automatically loaded from the config (with resolved environment variables).
+         *     - A request naming a stored credential (`litellm_credential_name`) that the configuration
+         *       does not name is probed with that credential instead, and inherits no credentials
+         *       from the configuration its model string happened to match.
          *     - You can override specific params by including them in the request.
          *     - You can use `os.environ/VARIABLE_NAME` syntax to reference environment variables,
          *       which will be resolved automatically (same as in proxy_config.yaml).


### PR DESCRIPTION
## TLDR

Problem this solves:

- Test Connect ignored the LLM Credential you picked
- It borrowed a key from an unrelated matching deployment
- Wildcard routes made this hit almost every new model
- api_base leaked the same way, redirecting the probe

How it solves it:

- Naming a credential now blocks inheriting config credentials
- Only the config that names the same credential still applies
- Naming no credential keeps today's documented inheritance

## User Flow

Before: an admin adding a new xAI model with a saved credential gets an auth error from Test Connect, even though the same model works once saved

1. They open http://litellm-domain/ui/?page=models and start Add Model
2. They pick xAI as the provider and `grok-4` as the model
3. They select their saved credential from the Existing Credentials dropdown, which hides the API key and API base fields
4. They click Test Connect and get an authentication error naming a key they never entered
5. The result panel echoes back the credential they picked, so nothing on screen explains the failure
6. They save the model anyway and it works on the first real request, with no change to the credential

After: the same Test Connect passes, using the credential that was picked

1. They open http://litellm-domain/ui/?page=models and start Add Model
2. They pick xAI as the provider and `grok-4` as the model
3. They select their saved credential from the Existing Credentials dropdown, which hides the API key and API base fields
4. They click Test Connect and it succeeds
5. Saving the model still works on the first real request, as before

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup, both sides. A stand-in upstream on port 54711 and another on port 54712, each answering a chat completion and logging the `Authorization` header it received. xAI points at the first one (`XAI_API_BASE` is set to the 54711 one), so the second is only ever reached by inheriting the wildcard's `api_base`.

`proxy_config.yaml`, one wildcard route standing in for any deployment that matches the model string being added:

```yaml
model_list:
  - model_name: xai/*
    litellm_params:
      model: xai/*
      api_key: sk-WILDCARD-KEY
      api_base: http://127.0.0.1:54712

general_settings:
  master_key: sk-1234
```

Store the credential the Add Model page will select:

```
curl -s -X POST http://127.0.0.1:54000/credentials \
  -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"credential_name":"my-xai-cred",
       "credential_values":{"api_key":"sk-CREDENTIAL-KEY-CORRECT"},
       "credential_info":{"custom_llm_provider":"xai"}}'

{"success":true,"message":"Credential created successfully"}
```

### Before (205a5e9d6)

#### Credential selected for a new model

1. Run the Test Connect the Add Model page sends:

```
curl -s -X POST http://127.0.0.1:54000/health/test_connection \
  -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"litellm_params":{"model":"xai/grok-4","custom_llm_provider":"xai",
       "litellm_credential_name":"my-xai-cred"},
       "model_info":{"mode":"chat"},"mode":"chat"}'

{"status":"success","result":{"api_base":"...:54712",...,"litellm_credential_name":"my-xai-cred",...}}
```

2. Read what actually arrived upstream. The wildcard's key went on the wire and the probe was redirected to the wildcard's endpoint, while the response above named the selected credential:

```
UPSTREAM_HIT upstream=other-deployment path=/chat/completions authorization=Bearer sk-WILDCARD-KEY
```

#### No credential selected

1. Same model, no credential named:

```
curl -s -X POST http://127.0.0.1:54000/health/test_connection \
  -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"litellm_params":{"model":"xai/grok-4","custom_llm_provider":"xai"},
       "model_info":{"mode":"chat"},"mode":"chat"}'

{"status":"success","result":{"api_base":"...:54712",...}}
```

2. The configured key and endpoint are used, which is the documented behavior:

```
UPSTREAM_HIT upstream=other-deployment path=/chat/completions authorization=Bearer sk-WILDCARD-KEY
```

### After (5661b20bb)

#### Credential selected for a new model

1. The same Test Connect:

```
curl -s -X POST http://127.0.0.1:54000/health/test_connection \
  -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"litellm_params":{"model":"xai/grok-4","custom_llm_provider":"xai",
       "litellm_credential_name":"my-xai-cred"},
       "model_info":{"mode":"chat"},"mode":"chat"}'

{"status":"success","result":{...,"litellm_credential_name":"my-xai-cred","max_tokens":16,"cache":{"no-cache":true}}}
```

The borrowed `api_base` is gone from the echoed params.

2. The selected credential's key went on the wire, to xAI's own base rather than the wildcard's endpoint:

```
UPSTREAM_HIT upstream=provider-base path=/chat/completions authorization=Bearer sk-CREDENTIAL-KEY-CORRECT
```

#### No credential selected

1. Same model, no credential named:

```
curl -s -X POST http://127.0.0.1:54000/health/test_connection \
  -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"litellm_params":{"model":"xai/grok-4","custom_llm_provider":"xai"},
       "model_info":{"mode":"chat"},"mode":"chat"}'

{"status":"success","result":{"api_base":"...:54712",...}}
```

2. Unchanged, still the configured key and endpoint:

```
UPSTREAM_HIT upstream=other-deployment path=/chat/completions authorization=Bearer sk-WILDCARD-KEY
```

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- Naming a credential now wins over `allow_client_side_credentials`
- A credential missing a region or api_version no longer borrows one

### Low

- A blank credential name still counts as naming none
- An unknown credential name now fails auth, not "not found"
- Results never echo a credential-resolved api_base, as before
- Wildcard shadowing an exact-model deployment is untouched

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
