### PR TITLE
test(e2e): repair the wildcard readiness probe and the semantic auto-router spend assertion

### DIFF
--- a/tests/e2e/models.py
+++ b/tests/e2e/models.py
@@ -851,6 +851,15 @@ class ModelListEntry(BaseModel):
     id: str
 
 
+class ModelsListParams(BaseModel):
+    """Query for GET /v1/models. A wildcard route such as ``openai/gpt-5.4*`` is
+    listed only under ``return_wildcard_routes``; without it the route is dropped
+    and only its expansions remain, so a readiness poll for the pattern itself
+    never resolves."""
+
+    return_wildcard_routes: bool = True
+
+
 class ModelsListResponse(BaseModel):
     """GET /v1/models on the data plane: the deployments the gateway can actually
     serve right now. Used to confirm a freshly created model has propagated from

--- a/tests/e2e/proxy_client.py
+++ b/tests/e2e/proxy_client.py
@@ -55,6 +55,7 @@ from models import (
     ModelMode,
     ModelNewBody,
     ModelNewResponse,
+    ModelsListParams,
     ModelsListResponse,
     ModelUpdateBody,
     OcrBody,
@@ -336,7 +337,7 @@ class ProxyClient:
             lambda poll_timeout: self.transport.get(
                 "/v1/models",
                 headers=headers,
-                params=NoBody(),
+                params=ModelsListParams(),
                 response_type=ModelsListResponse,
                 timeout=poll_timeout,
             ),

--- a/tests/e2e/router/test_auto_router_regressions_e2e.py
+++ b/tests/e2e/router/test_auto_router_regressions_e2e.py
@@ -597,9 +597,20 @@ class TestSemanticAutoRouterResponses:
             )
         )
         assert answer.id, "/v1/responses through the semantic auto-router returned no response id"
-        rows: Final = proxy.poll_logs_for_key(key, min_rows=1)
+        rows: Final = proxy.poll_logs_for_key(
+            key,
+            min_rows=2,
+            predicate=lambda logged: any(row.model == EMBEDDING_MODEL for row in logged),
+        )
+        embedding_rows: Final = tuple(row for row in rows if row.model == EMBEDDING_MODEL)
+        assert embedding_rows, (
+            "the routing embedding was not billed to the caller's key; "
+            f"spend logs show {tuple(row.model for row in rows)}"
+        )
         _assert_served_only_by(
-            rows, CHEAP_SERVED | {semantic_auto_router.target}, "semantic auto-router /v1/responses string input"
+            [row for row in rows if row.model != EMBEDDING_MODEL],
+            CHEAP_SERVED | {semantic_auto_router.target},
+            "semantic auto-router /v1/responses string input",
         )
 
 


### PR DESCRIPTION
## TLDR

Two e2e suites have been red in `litellm-e2e` builds 119 through 123. Neither is a product regression — both are test assumptions that an intentional behaviour change invalidated. This repairs them.

Not covered here: `batches/test_batches_e2e.py::test_batch_lifecycle` is failing on the same builds and **is** a real regression (batches created through the model-encoded and model-param paths no longer get a `LiteLLM_ManagedObjectTable` row, so they never appear in `GET /v1/batches`). That is being handled separately.

## 1. Wildcard readiness probe — 6 setup errors in `access_control/test_model_access_group_e2e.py`

#31731 moved `models_to_remove.add(model)` out of the fallback branches of `_get_wildcard_models` and made it unconditional. Before it, a wildcard route with a matching router deployment stayed in the `/v1/models` list, and only the no-router / no-deployment paths removed it.

`ProxyClient._await_model_servable` polls `/v1/models` for an exact id match. The fixture registers `openai/gpt-5.4*` via `/model/new`, so the poll now can never resolve, times out at `model_servable_timeout`, and every test in `TestKeyScopedToAccessGroup` errors in setup:

```
model 'openai/gpt-5.4*' was created but never became servable on the data plane
within 40.0s of first listing ... after /model/new
```

`return_wildcard_routes=True` still re-adds the route, so the probe asks for it. Set unconditionally rather than sniffing for `*` in the name: the flag only ever *adds* wildcard entries, so it is a no-op for a concrete model name, and one code path is easier to keep honest than two.

## 2. Semantic auto-router spend assertion — `test_responses_input_reaches_the_semantic_auto_router`

#39532 bills the routing embedding to the caller's key on purpose. The key's spend logs now legitimately carry an `openai/text-embedding-3-small` row, and `_assert_served_only_by` rejects it:

```
expected every request to be served by one of ['anthropic/claude-haiku-4-5', ...],
spend logs show ('anthropic/claude-haiku-4-5', 'openai/text-embedding-3-small')
```

Adding `EMBEDDING_MODEL` to the allowlist would have fixed the red at the cost of the thing this test exists to prove — that the request actually reached the target deployment. So the embedding row is split off and asserted on its own, which turns the break into coverage for #39532 instead of a hole in it. The poll gains a predicate so it waits for the embedding row rather than racing whichever row is written first.

## Verification

- `uv run ruff check --config ruff-tests.toml tests` — passes (this is the lint gate that covers `tests/`; `ruff.toml` excludes the tree)
- `ModelsListParams().model_dump(by_alias=True, exclude_none=True)` → `{'return_wildcard_routes': True}`
- The suites themselves are AWS-gated and only run in `litellm-e2e`; they have not been run green locally. The next scheduled build is the real check.

## Loose end worth a follow-up

`TestTeamScopedToAccessGroup` registers `openai/gpt-5.6*` through the same helper (with `listed_for=key`) and its probe **passes** today. I have not traced why the team-scoped path still lists its wildcard when the proxy-wide one does not. This change is safe either way, but that asymmetry may itself be a bug.