### PR TITLE
fix(bedrock): drop system message from Voxtral audio transcription request

### DIFF
--- a/litellm-rust/crates/core/src/providers/bedrock/audio_transcription.rs
+++ b/litellm-rust/crates/core/src/providers/bedrock/audio_transcription.rs
@@ -70,6 +70,12 @@ impl AudioTranscriptionProviderConfig for BedrockAudioTranscriptionConfig {
         if let Some(temperature) = optional_params.get("temperature") {
             inference_config.insert("temperature".to_string(), temperature.clone());
         }
+        // Bedrock's Converse API rejects a `system` block on any request that
+        // also carries an audio content block (HTTP 400: "Found system
+        // messages ... and audio chunks ... This is not allowed prior to the
+        // tokenizer version 13."). Voxtral takes the transcription
+        // instruction from the user turn's `text` block above, so no system
+        // prompt is needed here.
         Ok(AudioTranscriptionRequestData {
             body: json!({
                 "messages": [{
@@ -79,7 +85,6 @@ impl AudioTranscriptionProviderConfig for BedrockAudioTranscriptionConfig {
                         {"text": instruction}
                     ]
                 }],
-                "system": [{"text": "You are a transcription assistant."}],
                 "inferenceConfig": inference_config,
             }),
         })
@@ -179,9 +184,30 @@ mod tests {
                         {"text": "Transcribe the audio. Respond with only the transcript. The audio language is en. Additional context: Speaker names"}
                     ]
                 }],
-                "system": [{"text": "You are a transcription assistant."}],
                 "inferenceConfig": {"maxTokens": 4096, "temperature": 0}
             })
+        );
+    }
+
+    #[test]
+    fn request_omits_system_message_alongside_audio_content() {
+        // Regression test: Bedrock's Converse API 400s on a `system` block
+        // combined with an audio content block ("Found system messages ...
+        // and audio chunks ... This is not allowed prior to the tokenizer
+        // version 13."). Confirmed against live Bedrock that dropping
+        // `system` while keeping everything else identical makes the
+        // request succeed.
+        let result = BEDROCK_AUDIO_TRANSCRIPTION_CONFIG
+            .transform_transcription_request(
+                "mistral.voxtral-mini-3b-2507",
+                json!({"data": "AQI=", "format": "wav", "filename": "sample.wav"}),
+                Map::new(),
+            )
+            .expect("request");
+        assert!(
+            result.body.get("system").is_none(),
+            "request body must not carry a `system` block alongside an audio content block: {}",
+            result.body
         );
     }
 

--- a/litellm-rust/crates/core/src/providers/bedrock/audio_transcription.rs
+++ b/litellm-rust/crates/core/src/providers/bedrock/audio_transcription.rs
@@ -70,12 +70,8 @@ impl AudioTranscriptionProviderConfig for BedrockAudioTranscriptionConfig {
         if let Some(temperature) = optional_params.get("temperature") {
             inference_config.insert("temperature".to_string(), temperature.clone());
         }
-        // Bedrock's Converse API rejects a `system` block on any request that
-        // also carries an audio content block (HTTP 400: "Found system
-        // messages ... and audio chunks ... This is not allowed prior to the
-        // tokenizer version 13."). Voxtral takes the transcription
-        // instruction from the user turn's `text` block above, so no system
-        // prompt is needed here.
+        // Bedrock 400s if `system` accompanies audio content; Voxtral gets
+        // its instruction from the `text` block above instead.
         Ok(AudioTranscriptionRequestData {
             body: json!({
                 "messages": [{
@@ -191,12 +187,7 @@ mod tests {
 
     #[test]
     fn request_omits_system_message_alongside_audio_content() {
-        // Regression test: Bedrock's Converse API 400s on a `system` block
-        // combined with an audio content block ("Found system messages ...
-        // and audio chunks ... This is not allowed prior to the tokenizer
-        // version 13."). Confirmed against live Bedrock that dropping
-        // `system` while keeping everything else identical makes the
-        // request succeed.
+        // Regression test: Bedrock 400s if `system` accompanies audio content.
         let result = BEDROCK_AUDIO_TRANSCRIPTION_CONFIG
             .transform_transcription_request(
                 "mistral.voxtral-mini-3b-2507",

--- a/tests/test_litellm/test_audio_transcription_rust_bridge.py
+++ b/tests/test_litellm/test_audio_transcription_rust_bridge.py
@@ -149,37 +149,3 @@ async def test_bedrock_atranscription_uses_rust_only_path() -> None:
         rust_bridge.configure_rust_transcription(transcription=None, atranscription=None)
 
     assert response.text == "rust"
-
-
-def test_bedrock_transcription_dispatch_adds_no_system_message() -> None:
-    """Guard the Python/Rust dispatch boundary for the Bedrock Voxtral fix.
-
-    Bedrock's Converse API rejects a request that carries both a `system`
-    block and an audio content block. The fix removes that `system` block
-    from the request the Rust transform builds (see
-    litellm-rust/crates/core/src/providers/bedrock/audio_transcription.rs),
-    since this dispatch layer mocks the whole bridge callable and never sees
-    that internal JSON. This test instead pins the boundary Python does
-    control: it must not hand the bridge a `system` message (directly or via
-    optional_params) that could reintroduce the same conflict from this side.
-    """
-    captured: dict[str, object] = {}
-
-    def capture(**kwargs: object) -> dict[str, object]:
-        captured.update(kwargs)
-        return {"text": "ok"}
-
-    rust_bridge.configure_rust_transcription(transcription=capture, atranscription=None)
-    try:
-        litellm.transcription(
-            model="bedrock/mistral.voxtral-mini-3b-2507",
-            file=("audio.wav", b"audio", "audio/wav"),
-            language="en",
-        )
-    finally:
-        rust_bridge.configure_rust_transcription(transcription=None, atranscription=None)
-
-    assert "system" not in captured
-    optional_params = captured.get("optional_params")
-    assert isinstance(optional_params, dict)
-    assert "system" not in optional_params

--- a/tests/test_litellm/test_audio_transcription_rust_bridge.py
+++ b/tests/test_litellm/test_audio_transcription_rust_bridge.py
@@ -149,3 +149,37 @@ async def test_bedrock_atranscription_uses_rust_only_path() -> None:
         rust_bridge.configure_rust_transcription(transcription=None, atranscription=None)
 
     assert response.text == "rust"
+
+
+def test_bedrock_transcription_dispatch_adds_no_system_message() -> None:
+    """Guard the Python/Rust dispatch boundary for the Bedrock Voxtral fix.
+
+    Bedrock's Converse API rejects a request that carries both a `system`
+    block and an audio content block. The fix removes that `system` block
+    from the request the Rust transform builds (see
+    litellm-rust/crates/core/src/providers/bedrock/audio_transcription.rs),
+    since this dispatch layer mocks the whole bridge callable and never sees
+    that internal JSON. This test instead pins the boundary Python does
+    control: it must not hand the bridge a `system` message (directly or via
+    optional_params) that could reintroduce the same conflict from this side.
+    """
+    captured: dict[str, object] = {}
+
+    def capture(**kwargs: object) -> dict[str, object]:
+        captured.update(kwargs)
+        return {"text": "ok"}
+
+    rust_bridge.configure_rust_transcription(transcription=capture, atranscription=None)
+    try:
+        litellm.transcription(
+            model="bedrock/mistral.voxtral-mini-3b-2507",
+            file=("audio.wav", b"audio", "audio/wav"),
+            language="en",
+        )
+    finally:
+        rust_bridge.configure_rust_transcription(transcription=None, atranscription=None)
+
+    assert "system" not in captured
+    optional_params = captured.get("optional_params")
+    assert isinstance(optional_params, dict)
+    assert "system" not in optional_params


### PR DESCRIPTION
## TLDR

Problem this solves:
- Bedrock Voxtral transcription (#33990) 400s on every real request
- Bedrock rejects a system message combined with an audio content block

How it solves it:
- Removes the hardcoded system message from the Bedrock Voxtral request body
- Updates and adds Rust tests asserting the corrected request shape

## User Flow

Before: a developer using LiteLLM to transcribe audio through Amazon Bedrock's Voxtral model gets an error on every single request, so Bedrock cannot be used for speech-to-text at all.

1. They send a POST to `https://<their-litellm-proxy>/v1/audio/transcriptions` with `model` set to the Bedrock Voxtral model and an audio file attached.
2. The response comes back as an HTTP 400 whose error message says "Found system messages ... and audio chunks ... This is not allowed prior to the tokenizer version 13."
3. No transcript is ever produced. Every request to this model fails the same way, so the feature is unusable end to end.

After: the same request returns a real transcript of what was said in the audio.

1. They send the same POST to `https://<their-litellm-proxy>/v1/audio/transcriptions` with the same model and the same audio file.
2. The response comes back as HTTP 200 with a `text` field containing an accurate transcript of the audio.
3. The feature now works as expected for this model.

## Relevant issues

#33990 — introduced the Rust-core Bedrock Voxtral audio-transcription path this PR fixes; the hardcoded `system` message it added is what causes the 400 described above. No separate issue was filed for the bug itself.

## Linear ticket

_(none)_

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/test_audio_transcription_rust_bridge.py -v` (7 passed) and `cargo test --workspace` (all green)
- [x] My PR passes all required CI/CD checks — `cargo fmt --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings` (plus the `bedrock-auth` and `server` feature variants CI runs separately), and `make lint` all pass clean locally
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (5/5, after the two findings from the initial 4/5 review were fixed)

## Screenshots / Proof of Fix

Setup: both runs call `litellm.transcription()` directly (no proxy, no mocks) against real Amazon Bedrock, using the same real audio file already checked into the repo (`tests/gettysburg.wav`, the Gettysburg Address). The native Rust bridge was rebuilt from source at each commit before its run.

```python
import litellm

with open("tests/gettysburg.wav", "rb") as f:
    litellm.transcription(
        model="bedrock/mistral.voxtral-mini-3b-2507",
        file=f,
        aws_region_name="us-east-1",
    )
```

### Before (c8635ecc67)

1. Run the script above against a native bridge built from this commit.
2. It raises: `RuntimeError: upstream request failed with status 400: {"message":"The model returned the following errors: {\"error\":{\"code\":\"validation_error\",\"message\":\"ErrorEvent { error: APIError { type: \\\"BadRequestError\\\", code: Some(400), message: \\\"Found system messages at indexes [0] and audio chunks i... (truncated)`

### After (f015c67f13)

1. Run the identical script against a native bridge built from this branch's tip.
2. It returns in 3.95s: `text: 'Four score and seven years ago, our fathers brought forth on this continent a new nation, conceived in liberty and dedicated to the proposition that all men are created equal. Now we are engaged in a great civil war, testing whether that nation, or any nation so conceived and so dedicated, can long endure.'`

## Type

🐛 Bug Fix

## Caveats (if any)

### Low
- Scope is limited to the Bedrock Voxtral transcription request body; no other provider or route is touched.

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


