### PR TITLE
fix(ui): accept any routing group name the backend accepts

### DIFF
--- a/ui/litellm-dashboard/src/components/routing_groups/RoutingGroupModal.test.tsx
+++ b/ui/litellm-dashboard/src/components/routing_groups/RoutingGroupModal.test.tsx
@@ -19,6 +19,13 @@ const EXPECTED_STORED_PAYLOAD: RoutingGroup = {
 
 const SEEDED_CREATE: RoutingGroup = { group_name: "", models: ["gemini-pro"], routing_strategy: "simple-shuffle" };
 
+const EXPECTED_SLASH_AND_SPACE_PAYLOAD: RoutingGroup = {
+  group_name: "team a/fast chat",
+  models: ["gemini-pro"],
+  routing_strategy: "simple-shuffle",
+  routing_strategy_args: null,
+};
+
 const STORED_GROUP: RoutingGroup = {
   group_name: "already-taken",
   models: ["gpt-4o", "claude-sonnet"],
@@ -211,16 +218,28 @@ describe("RoutingGroupModal", () => {
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
-  it("rejects a name with characters outside the allowed set", async () => {
+  it("accepts a name with slashes and spaces, since the backend does", async () => {
     const user = userEvent.setup();
     const { onSubmit } = renderModal({
       initialValue: { group_name: "", models: ["gemini-pro"], routing_strategy: "simple-shuffle" },
     });
 
-    await typeName(user, "bad name");
+    await typeName(user, "team a/fast chat");
     await save(user, "Create Group");
 
-    expect(await screen.findByText("Only letters, numbers, dot, underscore, and dash are allowed")).toBeInTheDocument();
+    expect(onSubmit).toHaveBeenCalledWith(EXPECTED_SLASH_AND_SPACE_PAYLOAD);
+  });
+
+  it("rejects a whitespace-only name as missing", async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderModal({
+      initialValue: { group_name: "", models: ["gemini-pro"], routing_strategy: "simple-shuffle" },
+    });
+
+    await typeName(user, "   ");
+    await save(user, "Create Group");
+
+    expect(await screen.findByText("Group name is required")).toBeInTheDocument();
     expect(onSubmit).not.toHaveBeenCalled();
   });
 

--- a/ui/litellm-dashboard/src/components/routing_groups/RoutingGroupModal.tsx
+++ b/ui/litellm-dashboard/src/components/routing_groups/RoutingGroupModal.tsx
@@ -23,7 +23,6 @@ import { Textarea } from "@/components/ui/textarea";
 import { useZodForm } from "@/lib/forms/useZodForm";
 import {
   GROUP_NAME_MAX_LENGTH,
-  GROUP_NAME_PATTERN,
   STRATEGIES_WITH_ARGS,
   argsForStrategy,
   buildRoutingGroupPayload,
@@ -74,10 +73,10 @@ const RoutingGroupModal: React.FC<RoutingGroupModalProps> = ({
     const shape = {
       group_name: z
         .string()
+        .trim()
         .min(1, "Group name is required")
         .max(GROUP_NAME_MAX_LENGTH, `Must be ${GROUP_NAME_MAX_LENGTH} characters or fewer`)
-        .regex(GROUP_NAME_PATTERN, "Only letters, numbers, dot, underscore, and dash are allowed")
-        .refine((value) => !reservedNames.has(value.trim().toLowerCase()), "A group with this name already exists"),
+        .refine((value) => !reservedNames.has(value.toLowerCase()), "A group with this name already exists"),
       models: z.array(z.string()).min(1, "Select at least one model"),
       routing_strategy: z.string().min(1, "Strategy is required"),
       routing_strategy_args: z.string(),

--- a/ui/litellm-dashboard/src/components/routing_groups/routingGroupPayload.ts
+++ b/ui/litellm-dashboard/src/components/routing_groups/routingGroupPayload.ts
@@ -2,7 +2,6 @@ import type { RoutingGroup } from "./types";
 
 export const STRATEGIES_WITH_ARGS = new Set<string>(["latency-based-routing", "usage-based-routing"]);
 
-export const GROUP_NAME_PATTERN = /^[A-Za-z0-9._-]+$/;
 export const GROUP_NAME_MAX_LENGTH = 64;
 
 export interface RoutingGroupFormValues {


### PR DESCRIPTION
## TLDR

Problem this solves:

- The create routing group form rejected names with slashes or spaces
- The proxy accepts and routes any non-empty name, so only the UI blocked them

How it solves it:

- Drops the client-only character pattern on the group name field
- Trims the name first so a whitespace-only name is still refused as missing

## User Flow

Before: an admin naming a routing group after a team and model family, like `team a/fast chat`, gets stuck at the form

1. They open http://localhost:4000/ui/?page=router-settings, click the Routing Groups tab, then Create Routing Group
2. They type `team a/fast chat` in Group Name, pick `gpt-5.5` under Models, and click Create Group
3. The field turns red with "Only letters, numbers, dot, underscore, and dash are allowed" and nothing is saved
4. Sending the same group straight to POST http://localhost:4000/config/update returns 200 and the name is callable, so the form was the only thing in the way

After: the same name saves from the form and routes traffic

1. They open http://localhost:4000/ui/?page=router-settings, click the Routing Groups tab, then Create Routing Group
2. They type `team a/fast chat` in Group Name, pick `gpt-5.5` under Models, and click Create Group
3. The dialog closes, a toast says the group was created, and it shows in the table
4. POST http://localhost:4000/v1/chat/completions with `"model": "team a/fast chat"` returns 200 with a completion from gpt-5.5

## Relevant issues

## Linear ticket

Resolves LIT-6690

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup: the proxy runs from this branch with `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver` and the Admin UI dev server with `npm run dev` in `ui/litellm-dashboard`. The curl steps below were run against a proxy started from the worktree on port 4173 to stay clear of another session on 4000

### Before (300d335255)

1. Open http://localhost:3000/?page=router-settings, click the Routing Groups tab, then Create Routing Group
2. Type `team a/fast chat` in Group Name, pick `gpt-5.5` under Models, click Create Group
3. Observed: the field shows "Only letters, numbers, dot, underscore, and dash are allowed" and the group is not saved (screenshot to follow)

### After (6f18a4d81e)

1. Open http://localhost:3000/?page=router-settings, click the Routing Groups tab, then Create Routing Group
2. Type `team a/fast chat` in Group Name, pick `gpt-5.5` under Models, click Create Group
3. Observed: the dialog closes and the group appears in the table (screenshot to follow)
4. The same save the form sends, done by hand:

   ```
   curl -s -X POST http://localhost:4173/config/update -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
     -d '{"router_settings":{"routing_groups":[{"group_name":"team a/fast chat","models":["gpt-5.5"],"routing_strategy":"simple-shuffle","routing_strategy_args":null}]}}'
   ```

   ```
   {"message":"Config updated successfully"}
   HTTP 200
   ```

5. Read it back the way the table does:

   ```
   curl -s http://localhost:4173/router/settings -H 'Authorization: Bearer sk-1234' | python3 -c "import sys,json; print(json.dumps(json.load(sys.stdin)['current_values']['routing_groups']))"
   ```

   ```
   [{"group_name": "team a/fast chat", "models": ["gpt-5.5"], "routing_strategy": "simple-shuffle", "routing_strategy_args": null}]
   ```

6. Call the group as a model, real OpenAI traffic:

   ```
   curl -s http://localhost:4173/v1/chat/completions -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
     -d '{"model":"team a/fast chat","messages":[{"role":"user","content":"Reply with the single word: pong"}]}'
   ```

   ```
   {"id":"chatcmpl-EKVOWnwMGYSvrkfQZu9XOvFuVqKEN","created":1788555948,"model":"team a/fast chat","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"pong","role":"assistant","provider_specific_fields":{"refusal":null},"annotations":[]},"provider_specific_fields":{}}],"usage":{"completion_tokens":17,"prompt_tokens":13,"total_tokens":30,"completion_tokens_details":{"accepted_prediction_tokens":0,"audio_tokens":0,"reasoning_tokens":7,"rejected_prediction_tokens":0},"prompt_tokens_details":{"audio_tokens":0,"cached_tokens":0}},"service_tier":"default"}
   HTTP 200
   ```

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- The 64 character cap stays; the proxy has no cap, but the ticket only asked about characters
- `default` is reserved by the proxy; typing it still fails at save with the proxy's error toast, as before

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

https://claude.ai/code/session_01HkaXiD6gssHnx3kqu1rR8C
