### PR TITLE
fix(jwt): invalidate JWT key mapping cache on /key/regenerate

### DIFF
--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -142,6 +142,8 @@ class _PrismaDictableRow(Protocol):
 
 class _PrismaJWTKeyMappingRow(Protocol):
     token: str
+    jwt_claim_name: str
+    jwt_claim_value: str
 
 
 class _PrismaModelDumpRow(Protocol):
@@ -3464,6 +3466,23 @@ async def _fetch_key_object_from_db_with_reconnect(
                     proxy_logging_obj=proxy_logging_obj,
                 )
         raise
+
+
+def jwt_key_mapping_cache_key(jwt_claim_name: str, jwt_claim_value: str) -> str:
+    """Cache key under which ``_resolve_jwt_to_virtual_key`` stores a JWT-claim-to-key mapping."""
+    return f"jwt_key_mapping:{jwt_claim_name}:{jwt_claim_value}"
+
+
+@log_db_metrics
+async def get_jwt_key_mapping_cache_keys_for_token(
+    hashed_token: str,
+    prisma_client: PrismaClient,
+) -> tuple[str, ...]:
+    """Cache keys of every JWT claim mapped to the given virtual key."""
+    mappings: Final = await _jwt_key_mapping_table(JWTKeyMappingRepository(prisma_client)).find_many(
+        where={"token": hashed_token}
+    )
+    return tuple(jwt_key_mapping_cache_key(m.jwt_claim_name, m.jwt_claim_value) for m in mappings)
 
 
 @log_db_metrics

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -58,6 +58,7 @@ from litellm.proxy.auth.auth_checks import (
     get_team_object,
     get_user_object,
     is_valid_fallback_model,
+    jwt_key_mapping_cache_key,
     resolve_and_validate_end_user_id,
 )
 from litellm.proxy.auth.auth_exception_handler import UserAPIKeyAuthExceptionHandler
@@ -970,7 +971,7 @@ async def _resolve_jwt_to_virtual_key(
             )
         return None
 
-    cache_key: Final = f"jwt_key_mapping:{virtual_key_claim_field}:{claim_value}"
+    cache_key: Final = jwt_key_mapping_cache_key(virtual_key_claim_field, str(claim_value))
     cached_mapping: Final = await user_api_key_cache.async_get_cache(cache_key)
 
     if cached_mapping == _JWT_PROXY_ADMIN_SENTINEL:

--- a/litellm/proxy/management_endpoints/jwt_key_mapping_endpoints.py
+++ b/litellm/proxy/management_endpoints/jwt_key_mapping_endpoints.py
@@ -170,18 +170,20 @@ async def update_jwt_key_mapping(
         if old_mapping is None:
             raise HTTPException(status_code=404, detail="Mapping not found")
 
-        old_cache_key: Final = jwt_key_mapping_cache_key(old_mapping.jwt_claim_name, old_mapping.jwt_claim_value)
-        await evict_and_broadcast(cache_keys=(old_cache_key,), user_api_key_cache=user_api_key_cache)
-
         updated_mapping: Final = await _mapping_table(prisma_client).update(where={"id": data.id}, data=update_data)
 
         if updated_mapping is None:
             raise HTTPException(status_code=404, detail="Mapping not found")
 
+        # Evict only after the write commits: a concurrent request between an
+        # early eviction and the commit would re-cache the old mapping and keep
+        # it authorized until TTL.
+        old_cache_key: Final = jwt_key_mapping_cache_key(old_mapping.jwt_claim_name, old_mapping.jwt_claim_value)
         new_cache_key: Final = jwt_key_mapping_cache_key(
             updated_mapping.jwt_claim_name, updated_mapping.jwt_claim_value
         )
-        await evict_and_broadcast(cache_keys=(new_cache_key,), user_api_key_cache=user_api_key_cache)
+        cache_keys: Final = (old_cache_key,) if old_cache_key == new_cache_key else (old_cache_key, new_cache_key)
+        await evict_and_broadcast(cache_keys=cache_keys, user_api_key_cache=user_api_key_cache)
 
         return _to_response(updated_mapping)
     except HTTPException:
@@ -221,10 +223,12 @@ async def delete_jwt_key_mapping(
         if old_mapping is None:
             raise HTTPException(status_code=404, detail="Mapping not found")
 
+        await _mapping_table(prisma_client).delete(where={"id": data.id})
+
+        # Evict only after the row is gone, else a concurrent request can
+        # re-cache the deleted mapping and keep it authorized until TTL.
         cache_key: Final = jwt_key_mapping_cache_key(old_mapping.jwt_claim_name, old_mapping.jwt_claim_value)
         await evict_and_broadcast(cache_keys=(cache_key,), user_api_key_cache=user_api_key_cache)
-
-        await _mapping_table(prisma_client).delete(where={"id": data.id})
         return {"status": "success"}
     except HTTPException:
         raise

--- a/litellm/proxy/management_endpoints/jwt_key_mapping_endpoints.py
+++ b/litellm/proxy/management_endpoints/jwt_key_mapping_endpoints.py
@@ -13,7 +13,9 @@ from litellm.proxy._types import (
     UserAPIKeyAuth,
     hash_token,
 )
+from litellm.proxy.auth.auth_checks import jwt_key_mapping_cache_key
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+from litellm.proxy.common_utils.auth_cache_invalidation_pubsub import evict_and_broadcast
 from litellm.proxy.management_endpoints.common_utils import _user_has_admin_view
 from litellm.repositories.table_repositories import JWTKeyMappingRepository
 
@@ -118,9 +120,8 @@ async def create_jwt_key_mapping(
 
         new_mapping: Final = await _mapping_table(prisma_client).create(data=create_data)
 
-        # Invalidate cache
-        cache_key: Final = f"jwt_key_mapping:{data.jwt_claim_name}:{data.jwt_claim_value}"
-        await user_api_key_cache.async_delete_cache(cache_key)
+        cache_key: Final = jwt_key_mapping_cache_key(data.jwt_claim_name, data.jwt_claim_value)
+        await evict_and_broadcast(cache_keys=(cache_key,), user_api_key_cache=user_api_key_cache)
 
         return _to_response(new_mapping)
     except HTTPException:
@@ -169,17 +170,18 @@ async def update_jwt_key_mapping(
         if old_mapping is None:
             raise HTTPException(status_code=404, detail="Mapping not found")
 
-        cache_key = f"jwt_key_mapping:{old_mapping.jwt_claim_name}:{old_mapping.jwt_claim_value}"
-        await user_api_key_cache.async_delete_cache(cache_key)
+        old_cache_key: Final = jwt_key_mapping_cache_key(old_mapping.jwt_claim_name, old_mapping.jwt_claim_value)
+        await evict_and_broadcast(cache_keys=(old_cache_key,), user_api_key_cache=user_api_key_cache)
 
         updated_mapping: Final = await _mapping_table(prisma_client).update(where={"id": data.id}, data=update_data)
 
         if updated_mapping is None:
             raise HTTPException(status_code=404, detail="Mapping not found")
 
-        # Invalidate new cache key if claim fields changed
-        cache_key = f"jwt_key_mapping:{updated_mapping.jwt_claim_name}:{updated_mapping.jwt_claim_value}"
-        await user_api_key_cache.async_delete_cache(cache_key)
+        new_cache_key: Final = jwt_key_mapping_cache_key(
+            updated_mapping.jwt_claim_name, updated_mapping.jwt_claim_value
+        )
+        await evict_and_broadcast(cache_keys=(new_cache_key,), user_api_key_cache=user_api_key_cache)
 
         return _to_response(updated_mapping)
     except HTTPException:
@@ -219,8 +221,8 @@ async def delete_jwt_key_mapping(
         if old_mapping is None:
             raise HTTPException(status_code=404, detail="Mapping not found")
 
-        cache_key: Final = f"jwt_key_mapping:{old_mapping.jwt_claim_name}:{old_mapping.jwt_claim_value}"
-        await user_api_key_cache.async_delete_cache(cache_key)
+        cache_key: Final = jwt_key_mapping_cache_key(old_mapping.jwt_claim_name, old_mapping.jwt_claim_value)
+        await evict_and_broadcast(cache_keys=(cache_key,), user_api_key_cache=user_api_key_cache)
 
         await _mapping_table(prisma_client).delete(where={"id": data.id})
         return {"status": "success"}

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -54,6 +54,7 @@ from litellm.proxy._types import Litellm_EntityType, LiteLLM_VerificationToken, 
 from litellm.proxy.auth.auth_checks import (
     _delete_cache_key_object,
     can_team_access_model,
+    get_jwt_key_mapping_cache_keys_for_token,
     get_org_object,
     get_project_object,
     get_team_object,
@@ -65,6 +66,7 @@ from litellm.proxy.auth.auth_utils import (
 )
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.proxy.common_utils.auth_cache_invalidation_pubsub import (
+    evict_and_broadcast,
     publish_auth_cache_invalidation,
 )
 from litellm.proxy.common_utils.callback_config_validation import logging_metadata_config_error
@@ -4975,6 +4977,13 @@ async def _execute_virtual_key_regeneration(
     update_data.update(non_default_values)
     jsonified_update_data: Final[Mapping[str, object]] = prisma_client.jsonify_object(data=update_data)
 
+    # Snapshot before the token update: the FK cascade rewrites mapping rows to the new hash,
+    # but their cached jwt_key_mapping entries still point at the old token (LIT-5379).
+    jwt_mapping_cache_keys: Final = await get_jwt_key_mapping_cache_keys_for_token(
+        hashed_token=hashed_api_key,
+        prisma_client=prisma_client,
+    )
+
     # If grace period set, insert deprecated key so old key remains valid
     await _insert_deprecated_key(
         prisma_client=prisma_client,
@@ -4999,6 +5008,8 @@ async def _execute_virtual_key_regeneration(
             user_api_key_cache=user_api_key_cache,
             proxy_logging_obj=proxy_logging_obj,
         )
+
+    await evict_and_broadcast(cache_keys=jwt_mapping_cache_keys, user_api_key_cache=user_api_key_cache)
 
     # After credential invalidation, so a failure here can never keep the old key alive.
     await sync_key_regeneration_access_group_membership(

--- a/tests/proxy_unit_tests/test_jwt_key_mapping.py
+++ b/tests/proxy_unit_tests/test_jwt_key_mapping.py
@@ -1333,3 +1333,86 @@ def test_jwt_client_id_field_does_not_raise_on_duplicate():
         virtual_key_claim_field="new_field",
     )
     assert auth.virtual_key_claim_field == "new_field"
+
+
+# ──────────────────────────────────────────────
+# Tests: cache eviction must happen AFTER the DB write commits
+# ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_delete_evicts_cache_after_row_is_gone():
+    """A JWT request racing the delete must not keep the removed mapping authorized.
+
+    The DB delete simulates a concurrent request re-caching the mapping mid-write.
+    If the endpoint evicts before the delete commits, that repopulated entry
+    survives until TTL and the deleted mapping stays usable.
+    """
+    from litellm.proxy._types import DeleteJWTKeyMappingRequest
+    from litellm.proxy.auth.auth_checks import jwt_key_mapping_cache_key
+
+    cache_key = jwt_key_mapping_cache_key("email", "user@example.com")
+    user_api_key_cache = DualCache()
+    await user_api_key_cache.async_set_cache(key=cache_key, value="hashed_token")
+
+    mock_prisma = _mock_prisma()
+    mock_prisma.db.litellm_jwtkeymapping.find_unique.return_value = _mock_mapping()
+
+    async def concurrent_reader_repopulates(**kwargs):
+        await user_api_key_cache.async_set_cache(key=cache_key, value="hashed_token")
+        return _mock_mapping()
+
+    mock_prisma.db.litellm_jwtkeymapping.delete.side_effect = concurrent_reader_repopulates
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),  # test-quality-ok: proxy_server module global is the endpoint's only injection point
+        patch("litellm.proxy.proxy_server.user_api_key_cache", user_api_key_cache),  # test-quality-ok: proxy_server module global is the endpoint's only injection point
+    ):
+        result = await delete_jwt_key_mapping(
+            data=DeleteJWTKeyMappingRequest(id="mapping-1"),
+            user_api_key_dict=_make_admin_auth(),
+        )
+
+    assert result == {"status": "success"}
+    assert await user_api_key_cache.async_get_cache(cache_key) is None
+
+
+@pytest.mark.asyncio
+async def test_update_evicts_old_and_new_cache_keys_after_write():
+    """Renaming a mapping's claim must leave neither claim serving stale cache.
+
+    The DB update simulates a concurrent request re-caching the OLD mapping
+    mid-write. Both the old claim's entry (would restore the pre-rename token)
+    and the new claim's __NO_MAPPING__ sentinel (would 403 the renamed claim)
+    must be gone once the endpoint returns.
+    """
+    from litellm.proxy._types import UpdateJWTKeyMappingRequest
+    from litellm.proxy.auth.auth_checks import jwt_key_mapping_cache_key
+
+    old_cache_key = jwt_key_mapping_cache_key("email", "user@example.com")
+    new_cache_key = jwt_key_mapping_cache_key("email", "renamed@example.com")
+    user_api_key_cache = DualCache()
+    await user_api_key_cache.async_set_cache(key=old_cache_key, value="hashed_token")
+    await user_api_key_cache.async_set_cache(key=new_cache_key, value="__NO_MAPPING__")
+
+    mock_prisma = _mock_prisma()
+    mock_prisma.db.litellm_jwtkeymapping.find_unique.return_value = _mock_mapping()
+
+    async def concurrent_reader_repopulates(**kwargs):
+        await user_api_key_cache.async_set_cache(key=old_cache_key, value="hashed_token")
+        return _mock_mapping(claim_value="renamed@example.com")
+
+    mock_prisma.db.litellm_jwtkeymapping.update.side_effect = concurrent_reader_repopulates
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),  # test-quality-ok: proxy_server module global is the endpoint's only injection point
+        patch("litellm.proxy.proxy_server.user_api_key_cache", user_api_key_cache),  # test-quality-ok: proxy_server module global is the endpoint's only injection point
+    ):
+        result = await update_jwt_key_mapping(
+            data=UpdateJWTKeyMappingRequest(id="mapping-1", jwt_claim_value="renamed@example.com"),
+            user_api_key_dict=_make_admin_auth(),
+        )
+
+    assert result.jwt_claim_value == "renamed@example.com"
+    assert await user_api_key_cache.async_get_cache(old_cache_key) is None
+    assert await user_api_key_cache.async_get_cache(new_cache_key) is None

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -11945,24 +11945,24 @@ async def test_regenerate_evicts_jwt_key_mapping_cache_so_next_jwt_call_gets_new
 
     publish_mock = AsyncMock()
     with (
-        patch(
+        patch(  # test-quality-ok: deterministic token; same pattern as sibling regenerate tests
             "litellm.proxy.management_endpoints.key_management_endpoints.get_new_token",
             new_callable=AsyncMock,
             return_value="sk-newtoken1234ab12",
         ),
-        patch(
+        patch(  # test-quality-ok: grace-period path not under test; same pattern as sibling regenerate tests
             "litellm.proxy.management_endpoints.key_management_endpoints._insert_deprecated_key",
             new_callable=AsyncMock,
         ),
-        patch(
+        patch(  # test-quality-ok: key-object eviction is separate from the mapping eviction under test
             "litellm.proxy.management_endpoints.key_management_endpoints._delete_cache_key_object",
             new_callable=AsyncMock,
         ),
-        patch(
+        patch(  # test-quality-ok: background rotation hook is irrelevant to cache eviction
             "litellm.proxy.management_endpoints.key_management_endpoints.KeyManagementEventHooks.async_key_rotated_hook",
             new_callable=AsyncMock,
         ),
-        patch(
+        patch(  # test-quality-ok: captures the cross-worker broadcast without a redis instance
             "litellm.proxy.common_utils.auth_cache_invalidation_pubsub.publish_auth_cache_invalidation",
             publish_mock,
         ),
@@ -11998,7 +11998,7 @@ async def test_regenerate_evicts_jwt_key_mapping_cache_so_next_jwt_call_gets_new
     jwt_handler.litellm_jwtauth = LiteLLM_JWTAuth(
         virtual_key_claim_field="sub", virtual_key_mapping_cache_ttl=300
     )
-    with patch(
+    with patch(  # test-quality-ok: DB-backed resolve; fake asserts it receives the rotated hash
         "litellm.proxy.auth.resolvers.store.IdentityStore.resolve",
         new_callable=AsyncMock,
         side_effect=fake_resolve,

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -11913,6 +11913,109 @@ async def test_execute_virtual_key_regeneration_allows_within_limit_duration(mon
 
 
 @pytest.mark.asyncio
+async def test_regenerate_evicts_jwt_key_mapping_cache_so_next_jwt_call_gets_new_token():
+    """
+    LIT-5379: /key/regenerate rewrites the JWT mapping row to the new token (FK
+    cascade) but left the jwt_key_mapping cache entry pointing at the old hash,
+    so JWT calls kept resolving the dead token until the cache TTL expired.
+    Regenerate must evict the entry locally, broadcast the eviction to other
+    workers, and the very next JWT resolve must return the rotated token.
+    """
+    from litellm.caching.caching import DualCache
+    from litellm.proxy._types import LiteLLM_JWTAuth
+    from litellm.proxy.auth.auth_method import AuthMethod
+    from litellm.proxy.auth.resolvers.models import CredentialRef
+    from litellm.proxy.auth.resolvers.store import IdentityStore
+    from litellm.proxy.auth.user_api_key_auth import _resolve_jwt_to_virtual_key
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        _execute_virtual_key_regeneration,
+    )
+
+    stale_cache_key = "jwt_key_mapping:sub:user1"
+    existing_key = _make_regenerate_existing_key()
+    mock_prisma_client = _make_regenerate_mock_prisma()
+    mock_prisma_client.db.litellm_jwtkeymapping.find_many = AsyncMock(
+        return_value=[MagicMock(jwt_claim_name="sub", jwt_claim_value="user1")]
+    )
+    mock_prisma_client.db.litellm_jwtkeymapping.find_first = AsyncMock(
+        return_value=MagicMock(token="new-hashed-token")
+    )
+    user_api_key_cache = DualCache()
+    await user_api_key_cache.async_set_cache(key=stale_cache_key, value="abc123")
+
+    publish_mock = AsyncMock()
+    with (
+        patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints.get_new_token",
+            new_callable=AsyncMock,
+            return_value="sk-newtoken1234ab12",
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints._insert_deprecated_key",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints._delete_cache_key_object",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints.KeyManagementEventHooks.async_key_rotated_hook",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "litellm.proxy.common_utils.auth_cache_invalidation_pubsub.publish_auth_cache_invalidation",
+            publish_mock,
+        ),
+    ):
+        await _execute_virtual_key_regeneration(
+            prisma_client=mock_prisma_client,
+            key_in_db=existing_key,
+            hashed_api_key="abc123",
+            key="abc123",
+            data=None,
+            user_api_key_dict=_make_regenerate_user_api_key_dict(),
+            litellm_changed_by=None,
+            user_api_key_cache=user_api_key_cache,
+            proxy_logging_obj=MagicMock(),
+        )
+
+    assert await user_api_key_cache.async_get_cache(stale_cache_key) is None
+    publish_mock.assert_any_await(cache_key=stale_cache_key)
+    mock_prisma_client.db.litellm_jwtkeymapping.find_many.assert_awaited_once_with(where={"token": "abc123"})
+
+    rotated_key = UserAPIKeyAuth(token="new-hashed-token", user_id="user-1")
+    rotated_principal = IdentityStore._principal_from_key(
+        rotated_key,
+        auth_method=AuthMethod.API_KEY,
+        credential_ref=CredentialRef(token_id="new-hashed-token"),
+    )
+
+    async def fake_resolve(hashed_token):
+        assert hashed_token == "new-hashed-token", f"JWT resolved stale token {hashed_token!r} after regenerate"
+        return rotated_principal
+
+    jwt_handler = MagicMock()
+    jwt_handler.litellm_jwtauth = LiteLLM_JWTAuth(
+        virtual_key_claim_field="sub", virtual_key_mapping_cache_ttl=300
+    )
+    with patch(
+        "litellm.proxy.auth.resolvers.store.IdentityStore.resolve",
+        new_callable=AsyncMock,
+        side_effect=fake_resolve,
+    ):
+        resolved = await _resolve_jwt_to_virtual_key(
+            jwt_claims={"sub": "user1"},
+            jwt_handler=jwt_handler,
+            prisma_client=mock_prisma_client,
+            user_api_key_cache=user_api_key_cache,
+            parent_otel_span=None,
+            proxy_logging_obj=MagicMock(),
+        )
+    assert isinstance(resolved, UserAPIKeyAuth)
+    assert resolved.token == "new-hashed-token"
+
+
+@pytest.mark.asyncio
 async def test_execute_virtual_key_regeneration_rejects_over_limit_max_budget(monkeypatch):
     """Regenerate must reject max_budget exceeding upperbound — proves the fix covers non-duration fields."""
     from litellm.proxy._types import RegenerateKeyRequest


### PR DESCRIPTION
## TLDR

Problem this solves:

- /key/regenerate moves the JWT mapping to the new token in the DB
- but the mapping lookup cache still points at the old token
- so JWT calls fail 401 for up to 5 minutes after a rotation

How it solves it:

- regenerate snapshots the key's mapping cache entries before the token update
- then evicts them locally and broadcasts the eviction to all workers
- /jwt/key/mapping create/update/delete now broadcast their evictions too
- update/delete evict after the DB write commits, closing a stale-repopulation race
- the cache key format is shared through one helper so writer and invalidator can't drift

## User Flow

Before: after an admin rotates their key, a developer's JWT requests fail for up to 5 minutes

1. A developer sends POST https://litellm-domain/v1/chat/completions with their company JWT as the bearer token and gets a 200 completion back
2. An admin rotates that developer's key with POST https://litellm-domain/key/{key}/regenerate and receives a new sk-... key
3. The developer sends the same POST /v1/chat/completions with the same JWT and gets 401 "Invalid proxy server token passed ... not found in db"
4. Every retry keeps returning that 401 until roughly 5 minutes pass, then requests start working again

After: the same rotation is invisible to the developer

1. A developer sends POST https://litellm-domain/v1/chat/completions with their company JWT as the bearer token and gets a 200 completion back
2. An admin rotates that developer's key with POST https://litellm-domain/key/{key}/regenerate and receives a new sk-... key
3. The developer sends the same POST /v1/chat/completions with the same JWT and immediately gets a 200 completion, now billed against the rotated key

## Relevant issues

## Linear ticket

Resolves LIT-5379

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup: proxy config enables JWT auth with `virtual_key_claim_field: sub` and one model, `gpt-5.6` (real OpenAI). A local JWKS is served with `python -m http.server 8471` and `JWT_PUBLIC_KEY_URL=http://localhost:8471/jwks.json`; the client JWT is RS256 with `sub: qa-lit-5379-user` and a 1h exp. Before ran on port 4172, After on 4171

### Before (300d335255)

1. Create a key and register the JWT mapping

```
curl -s http://localhost:4172/key/generate -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"key_alias": "qa-lit-5379-before", "models": ["gpt-5.6"]}'
# -> "key": "sk-5w6xdaiPDQWpnacPmS3kCw"

curl -s http://localhost:4172/jwt/key/mapping/new -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"jwt_claim_name": "sub", "jwt_claim_value": "qa-lit-5379-user", "key": "sk-5w6xdaiPDQWpnacPmS3kCw"}'
# -> {"id": "5773ea3e-b2d1-4d95-aa9b-a591793fe0cc", ...}
```

2. First JWT call succeeds against real OpenAI (and caches the mapping)

```
curl -s http://localhost:4172/v1/chat/completions -H "Authorization: Bearer $JWT" -H 'Content-Type: application/json' \
  -d '{"model":"gpt-5.6","messages":[{"role":"user","content":"Reply with exactly: call-1-ok"}]}'
# -> "model": "gpt-5.6", "content": "call-1-ok"
```

3. Regenerate the key, then immediately repeat the exact same JWT call: it fails

```
curl -s http://localhost:4172/key/sk-5w6xdaiPDQWpnacPmS3kCw/regenerate -X POST -H 'Authorization: Bearer sk-1234'
# -> new key: sk-Kj3bBqWzQ3W5swvDv-PQjQ

curl -s http://localhost:4172/v1/chat/completions -H "Authorization: Bearer $JWT" -H 'Content-Type: application/json' \
  -d '{"model":"gpt-5.6","messages":[{"role":"user","content":"Reply with exactly: call-2-after-regenerate-ok"}]}'
# -> {"error":{"message":"Authentication Error, Invalid proxy server token passed. key=d1f438697cf5ee252c174e6d4a14bf073252268755440d0775bfd988b31c6e16, not found in db. Create key via `/key/generate` call.","type":"token_not_found_in_db","param":"key","code":"401"}}
```

### After (49cac6fc5b)

1. Create a key and register the JWT mapping

```
curl -s http://localhost:4171/key/generate -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"key_alias": "qa-lit-5379-mapping-key-v3", "models": ["gpt-5.6"]}'
# -> "key": "sk-Wwnp-xDVFQUI4l2O4nx_9Q"

curl -s http://localhost:4171/jwt/key/mapping/new -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"jwt_claim_name": "sub", "jwt_claim_value": "qa-lit-5379-user", "key": "sk-Wwnp-xDVFQUI4l2O4nx_9Q"}'
# -> {"id": "8ac8a7d7-7365-48b6-8aab-4e46e4a76989", ...}
```

2. First JWT call succeeds against real OpenAI (and caches the mapping)

```
curl -s http://localhost:4171/v1/chat/completions -H "Authorization: Bearer $JWT" -H 'Content-Type: application/json' \
  -d '{"model":"gpt-5.6","messages":[{"role":"user","content":"Reply with exactly: call-1-ok"}]}'
# -> "model": "gpt-5.6", "content": "call-1-ok"
```

3. Regenerate the key, then immediately repeat the exact same JWT call: it now succeeds with no wait

```
curl -s http://localhost:4171/key/sk-Wwnp-xDVFQUI4l2O4nx_9Q/regenerate -X POST -H 'Authorization: Bearer sk-1234'
# -> new key: sk-A4CBzr1sK8KcZyHc7Yj0EQ, new token_id: a390a18220fa1020e973886aed61e6b2571b9140109b5f7969789547e925e46e

curl -s http://localhost:4171/v1/chat/completions -H "Authorization: Bearer $JWT" -H 'Content-Type: application/json' \
  -d '{"model":"gpt-5.6","messages":[{"role":"user","content":"Reply with exactly: call-2-after-regenerate-ok"}]}'
# -> "model": "gpt-5.6", "content": "call-2-after-regenerate-ok"
```

4. The old credential is dead and the spend landed on the rotated key

```
curl -s -o /dev/null -w "%{http_code}\n" http://localhost:4171/v1/chat/completions -H "Authorization: Bearer sk-Wwnp-xDVFQUI4l2O4nx_9Q" \
  -H 'Content-Type: application/json' -d '{"model":"gpt-5.6","messages":[{"role":"user","content":"ping"}]}'
# -> 401

curl -s "http://localhost:4171/key/info?key=sk-A4CBzr1sK8KcZyHc7Yj0EQ" -H 'Authorization: Bearer sk-1234'
# -> alias: qa-lit-5379-mapping-key-v3 | spend: 0.000268
```

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- multi-worker deployments without redis: other workers still hold the stale entry until TTL, same limitation as existing key object eviction

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth cache invalidation and JWT-to-virtual-key resolution; incorrect eviction timing or keys could briefly allow stale mappings or break JWT auth after key rotation.
> 
> **Overview**
> Fixes **LIT-5379**: after `/key/regenerate`, JWT auth could keep using a cached claim→**old** token hash for minutes even though the DB mapping already pointed at the new key.
> 
> **Key regenerate** now loads every `jwt_key_mapping:*` cache key tied to the virtual key **before** the token row is updated, then **evicts and pub/sub-broadcasts** those keys after the write (alongside existing key-object cache cleanup).
> 
> **JWT mapping create/update/delete** stop doing local-only deletes and use the same **`jwt_key_mapping_cache_key`** helper as auth resolution so keys cannot drift. **Update and delete** evict **after** the DB commit so a concurrent JWT lookup cannot repopulate stale entries between eviction and the write.
> 
> Tests cover post-commit eviction races and regenerate → immediate JWT resolve to the rotated token.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49cac6fc5b59d10b017d4686c39dd601ae2d0af5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->