### PR TITLE
fix(batches): register ownership for every batch create path

### DIFF
--- a/enterprise/litellm_enterprise/proxy/hooks/managed_files.py
+++ b/enterprise/litellm_enterprise/proxy/hooks/managed_files.py
@@ -46,6 +46,7 @@ from litellm.proxy._types import (
     UserAPIKeyAuth,
 )
 from litellm.proxy.openai_files_endpoints.common_utils import (
+    BATCH_CREATE_HIDDEN_PARAM,
     FILE_LIST_CONTINUATION_CHUNK_SIZE,
     MAX_FILE_LIST_LIMIT,
     _is_base64_encoded_unified_file_id,
@@ -1321,7 +1322,7 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
             ## Check if unified_file_id is in the response
             unified_file_id = response._hidden_params.get("unified_file_id")  # managed file id
             unified_batch_id = response._hidden_params.get("unified_batch_id")  # managed batch id
-            is_batch_create: Final = unified_file_id is not None
+            is_batch_create: Final = response._hidden_params.get(BATCH_CREATE_HIDDEN_PARAM) is True
             model_id = cast(Optional[str], response._hidden_params.get("model_id"))
             model_name = cast(Optional[str], response._hidden_params.get("model_name"))
 
@@ -1410,10 +1411,7 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
                     litellm_parent_otel_span=user_api_key_dict.parent_otel_span,
                 )
 
-            # Only record batch creation metric on actual create (not retrieve/cancel).
-            # unified_file_id in _hidden_params is only set by the create_batch endpoint.
-            original_unified_file_id = response._hidden_params.get("unified_file_id")
-            if original_unified_file_id:
+            if is_batch_create:
                 prom_logger = self._get_prometheus_logger()
                 if prom_logger:
                     batch_provider = ""

--- a/litellm/proxy/batches_endpoints/endpoints.py
+++ b/litellm/proxy/batches_endpoints/endpoints.py
@@ -25,6 +25,7 @@ from litellm.proxy.common_utils.openai_endpoint_utils import (
     get_custom_llm_provider_from_request_query,
 )
 from litellm.proxy.openai_files_endpoints.common_utils import (
+    BATCH_CREATE_HIDDEN_PARAM,
     _is_base64_encoded_unified_file_id,
     add_internal_model_credentials,
     apply_team_provider_credentials,
@@ -346,6 +347,8 @@ async def create_batch(
                     custom_llm_provider=custom_llm_provider,
                     **_create_batch_data,
                 )
+
+        response._hidden_params[BATCH_CREATE_HIDDEN_PARAM] = True
 
         ### CALL HOOKS ### - modify outgoing data
         response = await proxy_logging_obj.post_call_success_hook(

--- a/litellm/proxy/openai_files_endpoints/common_utils.py
+++ b/litellm/proxy/openai_files_endpoints/common_utils.py
@@ -37,6 +37,8 @@ MAX_FILE_LIST_LIMIT: Final = 10000
 
 FILE_LIST_CONTINUATION_CHUNK_SIZE: Final = 500
 
+BATCH_CREATE_HIDDEN_PARAM: Final = "batch_create"
+
 
 def validate_file_list_limit(limit: int | None) -> None:
     """Reject a ``limit`` outside the range OpenAI documents for GET /v1/files."""

--- a/tests/enterprise/litellm_enterprise/proxy/hooks/test_managed_files.py
+++ b/tests/enterprise/litellm_enterprise/proxy/hooks/test_managed_files.py
@@ -10,6 +10,7 @@ from litellm_enterprise.proxy.hooks.managed_files import _PROXY_LiteLLMManagedFi
 from litellm.caching import DualCache
 from litellm.proxy._types import CallTypes
 from litellm.proxy.openai_files_endpoints.common_utils import (
+    BATCH_CREATE_HIDDEN_PARAM,
     _is_base64_encoded_unified_file_id,
     encode_file_id_with_model,
 )
@@ -3185,7 +3186,7 @@ def _batch_response(batch_id, output_file_id=None, is_create=False):
         output_file_id=output_file_id,
     )
     if is_create:
-        batch._hidden_params["unified_file_id"] = "unified-input-file-id"
+        batch._hidden_params[BATCH_CREATE_HIDDEN_PARAM] = True
     return batch
 
 
@@ -3411,11 +3412,8 @@ async def test_provider_format_file_without_ownership_row_stays_accessible():
 
 
 @pytest.mark.asyncio
-async def test_post_call_batch_create_stores_ownership_row():
-    """
-    Batch creation (response hidden params carry the unified input file id)
-    must write an ownership row attributed to the creating key.
-    """
+@pytest.mark.parametrize("batch_id", [MODEL_ENCODED_BATCH_ID, RAW_PROVIDER_BATCH_ID])
+async def test_post_call_batch_create_stores_ownership_row(batch_id):
     from litellm.proxy._types import UserAPIKeyAuth
 
     prisma_client = AsyncMock()
@@ -3432,13 +3430,11 @@ async def test_post_call_batch_create_stores_ownership_row():
         user_api_key_dict=UserAPIKeyAuth(
             user_id="user_a", team_id="team_a", parent_otel_span=MagicMock()
         ),
-        response=_batch_response(MODEL_ENCODED_BATCH_ID, is_create=True),
+        response=_batch_response(batch_id, is_create=True),
     )
 
     upsert_call = prisma_client.db.litellm_managedobjecttable.upsert.await_args
-    assert upsert_call.kwargs["where"] == {
-        "unified_object_id": MODEL_ENCODED_BATCH_ID
-    }
+    assert upsert_call.kwargs["where"] == {"unified_object_id": batch_id}
     create_data = upsert_call.kwargs["data"]["create"]
     assert create_data["created_by"] == "user_a"
     assert create_data["team_id"] == "team_a"

--- a/tests/test_litellm/enterprise/proxy/test_managed_files_hook.py
+++ b/tests/test_litellm/enterprise/proxy/test_managed_files_hook.py
@@ -15,6 +15,7 @@ from typing import Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from litellm.proxy._types import LitellmUserRoles, ProxyException, UserAPIKeyAuth
+from litellm.proxy.openai_files_endpoints.common_utils import BATCH_CREATE_HIDDEN_PARAM
 from litellm.types.llms.openai import FileListPage, OpenAIFileObject
 from litellm.types.utils import LiteLLMBatch
 
@@ -1540,6 +1541,11 @@ async def test_batch_create_hook_persists_creating_key_and_tags():
     managed_files = _make_managed_files_instance()
     creator = UserAPIKeyAuth(api_key="sk-the-creator", user_id="alice", parent_otel_span=None)
     create_response = _make_batch_response(status="validating", output_file_id=None)
+    create_response._hidden_params = {
+        BATCH_CREATE_HIDDEN_PARAM: True,
+        "model_id": "model-deploy-xyz",
+        "model_name": "azure/gpt-4",
+    }
 
     await managed_files.async_post_call_success_hook(
         data={"litellm_metadata": {"tags": ["env:prod", "team:ml"], "user_api_key": creator.api_key}},
@@ -1552,6 +1558,52 @@ async def test_batch_create_hook_persists_creating_key_and_tags():
     assert stored["persist_attribution"] is True
     assert stored["request_tags"] == ("env:prod", "team:ml")
     assert stored["user_api_key_dict"] is creator
+
+
+@pytest.mark.asyncio
+async def test_batch_create_hook_records_created_metric_once():
+    managed_files = _make_managed_files_instance()
+    prometheus_logger = MagicMock()
+    managed_files._get_prometheus_logger = MagicMock(return_value=prometheus_logger)
+    create_response = _make_batch_response(status="validating", output_file_id=None)
+    create_response._hidden_params = {
+        BATCH_CREATE_HIDDEN_PARAM: True,
+        "model_id": "model-deploy-xyz",
+        "model_name": "azure/gpt-4",
+    }
+
+    await managed_files.async_post_call_success_hook(
+        data={},
+        user_api_key_dict=UserAPIKeyAuth(api_key="sk-the-creator", user_id="alice", parent_otel_span=None),
+        response=create_response,
+    )
+
+    prometheus_logger.record_managed_batch_created.assert_called_once()
+    recorded = prometheus_logger.record_managed_batch_created.call_args.kwargs
+    assert recorded["model"] == "azure/gpt-4"
+    assert recorded["api_provider"] == "azure"
+    assert recorded["user"] == "alice"
+
+
+@pytest.mark.asyncio
+async def test_batch_retrieve_hook_does_not_record_created_metric():
+    managed_files = _make_managed_files_instance()
+    prometheus_logger = MagicMock()
+    managed_files._get_prometheus_logger = MagicMock(return_value=prometheus_logger)
+    retrieve_response = _make_batch_response(status="in_progress", output_file_id=None)
+    retrieve_response._hidden_params = {
+        "unified_batch_id": "some-unified-batch-id",
+        "model_id": "model-deploy-xyz",
+        "model_name": "azure/gpt-4",
+    }
+
+    await managed_files.async_post_call_success_hook(
+        data={},
+        user_api_key_dict=UserAPIKeyAuth(api_key="sk-the-poller", user_id="bob", parent_otel_span=None),
+        response=retrieve_response,
+    )
+
+    prometheus_logger.record_managed_batch_created.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
@@ -29,6 +29,7 @@ added to this layer raises instead of silently passing - the inventory of seams
 cannot drift without a test failure.
 """
 
+import base64
 import json
 from contextlib import ExitStack
 from dataclasses import dataclass
@@ -36,7 +37,7 @@ from typing import Any, Dict, Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
+from litellm_enterprise.proxy.hooks.managed_files import _PROXY_LiteLLMManagedFiles
 
 import litellm
 import litellm.proxy.batches_endpoints.endpoints as endpoints
@@ -44,7 +45,6 @@ import litellm.proxy.proxy_server as proxy_server
 from litellm.proxy._types import ProxyException, UserAPIKeyAuth
 from litellm.proxy.common_request_processing import ProxyBaseLLMRequestProcessing
 from litellm.proxy.openai_files_endpoints.common_utils import (
-    BATCH_CREATE_HIDDEN_PARAM,
     encode_file_id_with_model,
 )
 from litellm.proxy.utils import ProxyLogging
@@ -990,6 +990,27 @@ async def test_create__uses_acreate_batch_route_type(harness, openai_env_creds):
     assert harness.pre_call.call_args.kwargs["route_type"] == "acreate_batch"
 
 
+def install_managed_files_hook(harness: Harness) -> AsyncMock:
+    prisma_client = AsyncMock()
+    managed_files = _PROXY_LiteLLMManagedFiles(MagicMock(async_set_cache=AsyncMock()), prisma_client=prisma_client)
+    harness.logging.post_call_success_hook = AsyncMock(side_effect=managed_files.async_post_call_success_hook)
+    harness.router.model_list = []
+    return prisma_client
+
+
+TEAM_A_KEY = UserAPIKeyAuth(api_key="sk-team-a", user_id="user_a", team_id="team_a")
+
+
+def assert_ownership_registered_for_team_a(prisma_client: AsyncMock, batch_id: str) -> None:
+    upsert = prisma_client.db.litellm_managedobjecttable.upsert
+    upsert.assert_awaited_once()
+    assert upsert.await_args.kwargs["where"] == {"unified_object_id": batch_id}
+    created = upsert.await_args.kwargs["data"]["create"]
+    assert created["created_by"] == "user_a"
+    assert created["team_id"] == "team_a"
+    prisma_client.db.litellm_managedobjecttable.update_many.assert_not_awaited()
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "body",
@@ -1000,52 +1021,34 @@ async def test_create__uses_acreate_batch_route_type(harness, openai_env_creds):
     ],
     ids=["model_encoded_file_id", "model_param", "provider_fallback"],
 )
-async def test_create__marks_hook_response_as_batch_create(harness, openai_env_creds, body):
+async def test_create__registers_ownership_for_creator(harness, openai_env_creds, body):
     set_body(harness, {**body, "endpoint": "/v1/chat/completions", "completion_window": "24h"})
+    prisma_client = install_managed_files_hook(harness)
 
-    await call_create(harness)
+    resp = await call_create(harness, user=TEAM_A_KEY)
 
-    hook_response = harness.logging.post_call_success_hook.call_args.kwargs["response"]
-    assert hook_response._hidden_params[BATCH_CREATE_HIDDEN_PARAM] is True
-
-
-@pytest.mark.asyncio
-async def test_create__loadbalancing_marks_hook_response_as_batch_create(harness):
-    set_body(
-        harness,
-        {
-            "input_file_id": "file-plain",
-            "endpoint": "/v1/chat/completions",
-            "completion_window": "24h",
-            "model": "lb-model",
-        },
-    )
-    harness.is_known_model.return_value = True
-    with patch.object(litellm, "enable_loadbalancing_on_batch_endpoints", True):
-        await call_create(harness)
-
-    hook_response = harness.logging.post_call_success_hook.call_args.kwargs["response"]
-    assert hook_response._hidden_params[BATCH_CREATE_HIDDEN_PARAM] is True
+    assert_ownership_registered_for_team_a(prisma_client, resp.id)
 
 
 @pytest.mark.asyncio
-async def test_create__unified_file_id_marks_hook_response_as_batch_create(harness):
+async def test_create__unified_file_id_registers_ownership_for_creator(harness):
+    unified_input_file_id = base64.urlsafe_b64encode(
+        b"litellm_proxy:application/octet-stream;unified_id,input-uuid;target_model_names,gpt-4o-mini"
+    ).decode()
     set_body(
         harness,
         {
-            "input_file_id": "litellm_proxy_unified_id",
+            "input_file_id": unified_input_file_id,
             "endpoint": "/v1/chat/completions",
             "completion_window": "24h",
         },
     )
-    with (
-        patch.object(endpoints, "_is_base64_encoded_unified_file_id", return_value="unified-xyz"),
-        patch.object(endpoints, "get_models_from_unified_file_id", return_value=["gpt-4o-mini"]),
-    ):
-        await call_create(harness)
+    prisma_client = install_managed_files_hook(harness)
 
-    hook_response = harness.logging.post_call_success_hook.call_args.kwargs["response"]
-    assert hook_response._hidden_params[BATCH_CREATE_HIDDEN_PARAM] is True
+    resp = await call_create(harness, user=TEAM_A_KEY)
+
+    assert harness.router_acreate.call_count == 1
+    assert_ownership_registered_for_team_a(prisma_client, resp.id)
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
@@ -44,6 +44,7 @@ import litellm.proxy.proxy_server as proxy_server
 from litellm.proxy._types import ProxyException, UserAPIKeyAuth
 from litellm.proxy.common_request_processing import ProxyBaseLLMRequestProcessing
 from litellm.proxy.openai_files_endpoints.common_utils import (
+    BATCH_CREATE_HIDDEN_PARAM,
     encode_file_id_with_model,
 )
 from litellm.proxy.utils import ProxyLogging
@@ -987,6 +988,64 @@ async def test_create__uses_acreate_batch_route_type(harness, openai_env_creds):
     await call_create(harness)
 
     assert harness.pre_call.call_args.kwargs["route_type"] == "acreate_batch"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "body",
+    [
+        {"input_file_id": AZURE_FILE_ID},
+        {"input_file_id": "file-plain", "model": "vertex-model"},
+        {"input_file_id": "file-plain"},
+    ],
+    ids=["model_encoded_file_id", "model_param", "provider_fallback"],
+)
+async def test_create__marks_hook_response_as_batch_create(harness, openai_env_creds, body):
+    set_body(harness, {**body, "endpoint": "/v1/chat/completions", "completion_window": "24h"})
+
+    await call_create(harness)
+
+    hook_response = harness.logging.post_call_success_hook.call_args.kwargs["response"]
+    assert hook_response._hidden_params[BATCH_CREATE_HIDDEN_PARAM] is True
+
+
+@pytest.mark.asyncio
+async def test_create__loadbalancing_marks_hook_response_as_batch_create(harness):
+    set_body(
+        harness,
+        {
+            "input_file_id": "file-plain",
+            "endpoint": "/v1/chat/completions",
+            "completion_window": "24h",
+            "model": "lb-model",
+        },
+    )
+    harness.is_known_model.return_value = True
+    with patch.object(litellm, "enable_loadbalancing_on_batch_endpoints", True):
+        await call_create(harness)
+
+    hook_response = harness.logging.post_call_success_hook.call_args.kwargs["response"]
+    assert hook_response._hidden_params[BATCH_CREATE_HIDDEN_PARAM] is True
+
+
+@pytest.mark.asyncio
+async def test_create__unified_file_id_marks_hook_response_as_batch_create(harness):
+    set_body(
+        harness,
+        {
+            "input_file_id": "litellm_proxy_unified_id",
+            "endpoint": "/v1/chat/completions",
+            "completion_window": "24h",
+        },
+    )
+    with (
+        patch.object(endpoints, "_is_base64_encoded_unified_file_id", return_value="unified-xyz"),
+        patch.object(endpoints, "get_models_from_unified_file_id", return_value=["gpt-4o-mini"]),
+    ):
+        await call_create(harness)
+
+    hook_response = harness.logging.post_call_success_hook.call_args.kwargs["response"]
+    assert hook_response._hidden_params[BATCH_CREATE_HIDDEN_PARAM] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## TLDR

Problem this solves:

- Batches created from a model-encoded file id, a `model` param, or `?provider=` never got an ownership record
- Those batches were missing from `GET /v1/batches` for the key that created them
- Only the managed (`target_model_names`) path was recording ownership

How it solves it:

- The create endpoint marks its response as a create before the hooks run
- The managed files hook records ownership from that marker, not from the input id format
- The batch-created metric keys on the same marker, so it now covers every create path

## User Flow

Before: a developer creates a batch through the gateway and it never shows up in their batch list

1. They upload their JSONL with POST https://litellm-domain/v1/files?model=openai-batch and get back an id like `file-bGl0ZWxs...`
2. They send POST https://litellm-domain/v1/batches with that `input_file_id`, and get back `{"id": "batch_bGl0ZWxs...", "status": "validating"}`
3. They send GET https://litellm-domain/v1/batches with the same key and get `{"object": "list", "data": []}`
4. The same thing happens when they instead pass `"model": "openai-batch"` in the create body, or send POST https://litellm-domain/v1/batches?provider=openai with a plain `file-abc123` id

After: the same batch is listed for the key that created it

1. They upload their JSONL with POST https://litellm-domain/v1/files?model=openai-batch and get back an id like `file-bGl0ZWxs...`
2. They send POST https://litellm-domain/v1/batches with that `input_file_id`, and get back `{"id": "batch_bGl0ZWxs...", "status": "validating"}`
3. They send GET https://litellm-domain/v1/batches with the same key and `data` contains `batch_bGl0ZWxs...`
4. The `model` body param and `?provider=openai` variants list the same way

## Relevant issues

## Linear ticket

Resolves LIT-4489

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Setup shared by both runs: a proxy with a Postgres database, `STORE_MODEL_IN_DB=True`, the enterprise license set, one deployment `openai-batch` (`openai/gpt-4o-mini`), `files_settings` for openai, and a key generated for `user_a` on `team_a` with `models: []`. `input.jsonl` is a one-line chat completion request against `gpt-4o-mini`. Every run hits the real OpenAI batch API and cancels the batch at the end

<details>
<summary>proxy config</summary>

```yaml
model_list:
  - model_name: openai-batch
    litellm_params:
      model: openai/gpt-4o-mini
      api_key: os.environ/OPENAI_API_KEY
general_settings:
  master_key: sk-1234
  store_model_in_db: true
litellm_settings:
  drop_params: true
  telemetry: false
files_settings:
  - custom_llm_provider: openai
    api_key: os.environ/OPENAI_API_KEY
```

</details>

The same script drives every case: upload, create, retrieve, list, then query `LiteLLM_ManagedObjectTable` for the returned batch id, then cancel

<details>
<summary>script</summary>

```bash
PORT=4171; KEY=<key for user_a on team_a>; H="Authorization: Bearer $KEY"
# model-encoded: upload with ?model=, create with no model param
FILE_ID=$(curl -s -X POST "localhost:$PORT/v1/files?model=openai-batch" -H "$H" -F purpose=batch -F file=@input.jsonl | jq -r .id)
BODY="{\"input_file_id\":\"$FILE_ID\",\"endpoint\":\"/v1/chat/completions\",\"completion_window\":\"24h\"}"
# model param: upload with custom_llm_provider=openai, create with "model" in the body
# provider fallback: upload with custom_llm_provider=openai, create with ?provider=openai and no model
BATCH_ID=$(curl -s -X POST "localhost:$PORT/v1/batches" -H "$H" -H "Content-Type: application/json" -d "$BODY" | jq -r .id)
curl -s "localhost:$PORT/v1/batches/$BATCH_ID" -H "$H" | jq -c '{id, status}'
curl -s "localhost:$PORT/v1/batches" -H "$H" | jq -c '[.data[].id]'
psql -c "select unified_object_id, created_by, team_id, (api_key is not null) as has_api_key, status from \"LiteLLM_ManagedObjectTable\" where unified_object_id='$BATCH_ID'"
curl -s -X POST "localhost:$PORT/v1/batches/$BATCH_ID/cancel" -H "$H" | jq -r .status
```

</details>

### Before (300d335255)

#### input_file_id encoded with the model (upload with ?model=openai-batch)

1. Ran the script above for this case: upload, create, retrieve, list, ownership query, cancel
2. Observed:

```text
upload (?model=openai-batch) -> file_id=file-bGl0ZWxsbTpmaWxlLVNVZVBIV1c1d0RZbjZ4RkRITjFub2s7bW9kZWwsb3BlbmFpLWJhdGNo
create body: {"input_file_id":"file-bGl0ZWxsbTpmaWxlLVNVZVBIV1c1d0RZbjZ4RkRITjFub2s7bW9kZWwsb3BlbmFpLWJhdGNo","endpoint":"/v1/chat/completions","completion_window":"24h"}
create -> batch_id=batch_bGl0ZWxsbTpiYXRjaF82YTliMzM4N2FmYmM4MTkwYmYwODk0ODU2OWI4NjI0NTttb2RlbCxvcGVuYWktYmF0Y2g status=validating
retrieve -> id=batch_bGl0ZWxsbTpiYXRjaF82YTliMzM4N2FmYmM4MTkwYmYwODk0ODU2OWI4NjI0NTttb2RlbCxvcGVuYWktYmF0Y2g status=validating
list -> ids=['bGl0ZWxsbV9wcm94eTttb2RlbF9pZDo4Y2U1ODcxNTY1ZDcyODYyOTg0YTc0YjQwNzYwYzA4NDhlMjMyNTg0MjJlOWJmNDQxNDYwM2FlZjE4NTVkYWFlO2xsbV9iYXRjaF9pZDpiYXRjaF82YTliMzM3MDM1ODA4MTkwYTNhOWVhMTIzYzgxODc4Mw']
list contains created batch: False
DB rows in LiteLLM_ManagedObjectTable for this batch id:
 unified_object_id | model_object_id | created_by | team_id | has_api_key | status | file_purpose 
-------------------+-----------------+------------+---------+-------------+--------+--------------
(0 rows)
cancel -> status=cancelling
```

#### model passed in the create body (upload with custom_llm_provider=openai)

1. Ran the script above for this case: upload, create, retrieve, list, ownership query, cancel
2. Observed:

```text
upload (custom_llm_provider=openai) -> file_id=file-YQeC97RVGn8dU55HQcCiAh
create body: {"input_file_id":"file-YQeC97RVGn8dU55HQcCiAh","endpoint":"/v1/chat/completions","completion_window":"24h","model":"openai-batch"}
create -> batch_id=batch_bGl0ZWxsbTpiYXRjaF82YTliMzM4OGVjYWM4MTkwODgwN2I0MTQ0MTg1NTA5NDttb2RlbCxvcGVuYWktYmF0Y2g status=validating
retrieve -> id=batch_bGl0ZWxsbTpiYXRjaF82YTliMzM4OGVjYWM4MTkwODgwN2I0MTQ0MTg1NTA5NDttb2RlbCxvcGVuYWktYmF0Y2g status=validating
list -> ids=['bGl0ZWxsbV9wcm94eTttb2RlbF9pZDo4Y2U1ODcxNTY1ZDcyODYyOTg0YTc0YjQwNzYwYzA4NDhlMjMyNTg0MjJlOWJmNDQxNDYwM2FlZjE4NTVkYWFlO2xsbV9iYXRjaF9pZDpiYXRjaF82YTliMzM3MDM1ODA4MTkwYTNhOWVhMTIzYzgxODc4Mw']
list contains created batch: False
DB rows in LiteLLM_ManagedObjectTable for this batch id:
 unified_object_id | model_object_id | created_by | team_id | has_api_key | status | file_purpose 
-------------------+-----------------+------------+---------+-------------+--------+--------------
(0 rows)
cancel -> status=cancelling
```

#### ?provider=openai with a plain provider file id and no model

1. Ran the script above for this case: upload, create, retrieve, list, ownership query, cancel
2. Observed:

```text
upload (custom_llm_provider=openai) -> file_id=file-JB4mErcnVkaavhyYEzZAU4
create (?provider=openai, no model) -> batch_id=batch_6a9b338a9b408190900850a6875a419f
retrieve -> id=batch_6a9b338a9b408190900850a6875a419f status=validating
list (unfiltered) contains created batch: False
DB rows for this batch id:
 unified_object_id | created_by | team_id | has_api_key | status 
-------------------+------------+---------+-------------+--------
(0 rows)
cancel -> status=cancelling
```

#### managed input file (upload with target_model_names=openai-batch), unchanged

1. Ran the script above for this case: upload, create, retrieve, list, ownership query, cancel
2. Observed:

```text
upload (target_model_names=openai-batch) -> file_id=bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9vY3Rl...
create -> batch_id=bGl0ZWxsbV9wcm94eTttb2RlbF9pZDo4Y2U1ODcx... status=validating
retrieve -> status=validating
list contains created batch: True
DB row:
    unified_object_id     | created_by | team_id | has_api_key |   status   
--------------------------+------------+---------+-------------+------------
 bGl0ZWxsbV9wcm94eTttb2Rl | user_a     | team_a  | t           | validating
(1 row)
cancel -> status=cancelling
```

#### retrieve and cancel of a batch with no ownership record do not create one, unchanged

1. Ran the script above for this case: upload, create, retrieve, list, ownership query, cancel
2. Observed:

```text
created: batch_bGl0ZWxsbTpiYXRjaF82YTliMzM3MWM3YWM4MTkwOGYzMGNkNTFiYTgyMWJlZjttb2RlbCxvcGVuYWktYmF0Y2g
rows after create: 0
rows after simulating a pre-fix legacy batch (row deleted): 0
GET as owner -> HTTP 200
rows after retrieve: 0
cancel -> cancelling
rows after cancel: 0
```


### After (928c3adde8)

#### input_file_id encoded with the model (upload with ?model=openai-batch)

1. Ran the script above for this case: upload, create, retrieve, list, ownership query, cancel
2. Observed:

```text
upload (?model=openai-batch) -> file_id=file-bGl0ZWxsbTpmaWxlLVZmakRGUTlXWFcxQXZvWm9WQURRaXE7bW9kZWwsb3BlbmFpLWJhdGNo
create body: {"input_file_id":"file-bGl0ZWxsbTpmaWxlLVZmakRGUTlXWFcxQXZvWm9WQURRaXE7bW9kZWwsb3BlbmFpLWJhdGNo","endpoint":"/v1/chat/completions","completion_window":"24h"}
create -> batch_id=batch_bGl0ZWxsbTpiYXRjaF82YTliMzg3ZDNhNTA4MTkwOWU5MmI0ZWY1ZjAwOWRkYzttb2RlbCxvcGVuYWktYmF0Y2g status=validating
retrieve -> id=batch_bGl0ZWxsbTpiYXRjaF82YTliMzg3ZDNhNTA4MTkwOWU5MmI0ZWY1ZjAwOWRkYzttb2RlbCxvcGVuYWktYmF0Y2g status=validating
list -> ids=['batch_bGl0ZWxsbTpiYXRjaF82YTliMzg3ZDNhNTA4MTkwOWU5MmI0ZWY1ZjAwOWRkYzttb2RlbCxvcGVuYWktYmF0Y2g']
list contains created batch: True
DB rows in LiteLLM_ManagedObjectTable for this batch id:
                                       unified_object_id                                       |                                        model_object_id                                        | created_by | team_id | has_api_key |   status   | file_purpose 
-----------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------+------------+---------+-------------+------------+--------------
 batch_bGl0ZWxsbTpiYXRjaF82YTliMzg3ZDNhNTA4MTkwOWU5MmI0ZWY1ZjAwOWRkYzttb2RlbCxvcGVuYWktYmF0Y2g | batch_bGl0ZWxsbTpiYXRjaF82YTliMzg3ZDNhNTA4MTkwOWU5MmI0ZWY1ZjAwOWRkYzttb2RlbCxvcGVuYWktYmF0Y2g | user_a     | team_a  | t           | validating | batch
(1 row)
cancel -> status=cancelling
```

#### model passed in the create body (upload with custom_llm_provider=openai)

1. Ran the script above for this case: upload, create, retrieve, list, ownership query, cancel
2. Observed:

```text
upload (custom_llm_provider=openai) -> file_id=file-Ut1jo6TPKAjh7UZgFYfaXn
create body: {"input_file_id":"file-Ut1jo6TPKAjh7UZgFYfaXn","endpoint":"/v1/chat/completions","completion_window":"24h","model":"openai-batch"}
create -> batch_id=batch_bGl0ZWxsbTpiYXRjaF82YTliMzg3ZjBkNzA4MTkwODlkMDdmNGRmZWIzYjFmYzttb2RlbCxvcGVuYWktYmF0Y2g status=validating
retrieve -> id=batch_bGl0ZWxsbTpiYXRjaF82YTliMzg3ZjBkNzA4MTkwODlkMDdmNGRmZWIzYjFmYzttb2RlbCxvcGVuYWktYmF0Y2g status=validating
list -> ids=['batch_bGl0ZWxsbTpiYXRjaF82YTliMzg3ZjBkNzA4MTkwODlkMDdmNGRmZWIzYjFmYzttb2RlbCxvcGVuYWktYmF0Y2g', 'batch_bGl0ZWxsbTpiYXRjaF82YTliMzg3ZDNhNTA4MTkwOWU5MmI0ZWY1ZjAwOWRkYzttb2RlbCxvcGVuYWktYmF0Y2g']
list contains created batch: True
DB rows in LiteLLM_ManagedObjectTable for this batch id:
                                       unified_object_id                                       |                                        model_object_id                                        | created_by | team_id | has_api_key |   status   | file_purpose 
-----------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------+------------+---------+-------------+------------+--------------
 batch_bGl0ZWxsbTpiYXRjaF82YTliMzg3ZjBkNzA4MTkwODlkMDdmNGRmZWIzYjFmYzttb2RlbCxvcGVuYWktYmF0Y2g | batch_bGl0ZWxsbTpiYXRjaF82YTliMzg3ZjBkNzA4MTkwODlkMDdmNGRmZWIzYjFmYzttb2RlbCxvcGVuYWktYmF0Y2g | user_a     | team_a  | t           | validating | batch
(1 row)
cancel -> status=cancelling
```

#### ?provider=openai with a plain provider file id and no model

1. Ran the script above for this case: upload, create, retrieve, list, ownership query, cancel
2. Observed:

```text
upload (custom_llm_provider=openai) -> file_id=file-JGFjTyZ2DXUhW7FMrEUEiH
create (?provider=openai, no model) -> batch_id=batch_6a9b3880c90c8190a089ab8bca0899fd
retrieve -> id=batch_6a9b3880c90c8190a089ab8bca0899fd status=validating
list (unfiltered) contains created batch: True
DB rows for this batch id:
           unified_object_id            | created_by | team_id | has_api_key |   status   
----------------------------------------+------------+---------+-------------+------------
 batch_6a9b3880c90c8190a089ab8bca0899fd | user_a     | team_a  | t           | validating
(1 row)
cancel -> status=cancelling
```

#### managed input file (upload with target_model_names=openai-batch), unchanged

1. Ran the script above for this case: upload, create, retrieve, list, ownership query, cancel
2. Observed:

```text
upload (target_model_names=openai-batch) -> file_id=bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9vY3Rl...
create -> batch_id=bGl0ZWxsbV9wcm94eTttb2RlbF9pZDo4Y2U1ODcx... status=validating
retrieve -> status=validating
list contains created batch: True
DB row:
    unified_object_id     | created_by | team_id | has_api_key |   status   
--------------------------+------------+---------+-------------+------------
 bGl0ZWxsbV9wcm94eTttb2Rl | user_a     | team_a  | t           | validating
(1 row)
cancel -> status=cancelling
```

#### retrieve and cancel of a batch with no ownership record do not create one, unchanged

1. Ran the script above for this case: upload, create, retrieve, list, ownership query, cancel
2. Observed:

```text
created: batch_bGl0ZWxsbTpiYXRjaF82YTliMzg4NDM2ZTg4MTkwYjhiNGZiYjMxOWQzMmMzNTttb2RlbCxvcGVuYWktYmF0Y2g
rows after create: 1
rows after simulating a pre-fix legacy batch (row deleted): 0
GET as owner -> HTTP 200
rows after retrieve: 0
cancel -> cancelling
rows after cancel: 0
```


## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Batches created before this fix have no ownership record and stay unlisted until re-created
- The batch-created metric now fires for the model-encoded, `model` param and `?provider=` paths too
