### PR TITLE
feat(chatgpt): register GPT-5.5 and GPT-5.6 models

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -26693,6 +26693,66 @@
         "max_tokens": 8191,
         "mode": "embedding"
     },
+    "chatgpt/gpt-5.5": {
+        "litellm_provider": "chatgpt",
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true
+    },
+    "chatgpt/gpt-5.6-luna": {
+        "litellm_provider": "chatgpt",
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true
+    },
+    "chatgpt/gpt-5.6-sol": {
+        "litellm_provider": "chatgpt",
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true
+    },
+    "chatgpt/gpt-5.6-terra": {
+        "litellm_provider": "chatgpt",
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true
+    },
     "chatgpt/gpt-5.4": {
         "litellm_provider": "chatgpt",
         "max_input_tokens": 1050000,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -26693,6 +26693,66 @@
         "max_tokens": 8191,
         "mode": "embedding"
     },
+    "chatgpt/gpt-5.5": {
+        "litellm_provider": "chatgpt",
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true
+    },
+    "chatgpt/gpt-5.6-luna": {
+        "litellm_provider": "chatgpt",
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true
+    },
+    "chatgpt/gpt-5.6-sol": {
+        "litellm_provider": "chatgpt",
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true
+    },
+    "chatgpt/gpt-5.6-terra": {
+        "litellm_provider": "chatgpt",
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true
+    },
     "chatgpt/gpt-5.4": {
         "litellm_provider": "chatgpt",
         "max_input_tokens": 1050000,

--- a/tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py
+++ b/tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py
@@ -5,6 +5,7 @@ Source: litellm/llms/chatgpt/responses/transformation.py
 """
 
 import json
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import httpx
@@ -18,10 +19,21 @@ from litellm.utils import ProviderConfigManager
 from litellm.llms.chatgpt.responses.transformation import ChatGPTResponsesAPIConfig
 
 
+REPO_ROOT = Path(__file__).resolve().parents[5]
+MODEL_COST_MAP_PATHS = (
+    REPO_ROOT / "model_prices_and_context_window.json",
+    REPO_ROOT / "litellm" / "model_prices_and_context_window_backup.json",
+)
+
+
 class TestChatGPTResponsesAPITransformation:
     @pytest.mark.parametrize(
         "model_name",
         [
+            "chatgpt/gpt-5.5",
+            "chatgpt/gpt-5.6-luna",
+            "chatgpt/gpt-5.6-sol",
+            "chatgpt/gpt-5.6-terra",
             "chatgpt/gpt-5.4",
             "chatgpt/gpt-5.4-pro",
             "chatgpt/gpt-5.3-chat-latest",
@@ -39,6 +51,27 @@ class TestChatGPTResponsesAPITransformation:
         assert config is not None
         assert isinstance(config, ChatGPTResponsesAPIConfig)
         assert config.custom_llm_provider == LlmProviders.CHATGPT
+
+    @pytest.mark.parametrize("model_cost_map_path", MODEL_COST_MAP_PATHS)
+    @pytest.mark.parametrize(
+        "model_name",
+        [
+            "chatgpt/gpt-5.5",
+            "chatgpt/gpt-5.6-luna",
+            "chatgpt/gpt-5.6-sol",
+            "chatgpt/gpt-5.6-terra",
+        ],
+    )
+    def test_chatgpt_responses_model_metadata(self, model_name, model_cost_map_path):
+        with model_cost_map_path.open() as model_cost_map_file:
+            model_info = json.load(model_cost_map_file)[model_name]
+
+        assert model_info["litellm_provider"] == "chatgpt"
+        assert model_info["mode"] == "responses"
+        assert model_info["supported_endpoints"] == [
+            "/v1/chat/completions",
+            "/v1/responses",
+        ]
 
     @patch("litellm.llms.chatgpt.responses.transformation.Authenticator")
     def test_chatgpt_responses_endpoint_url(self, mock_authenticator_class):

--- a/tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py
+++ b/tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py
@@ -5,25 +5,19 @@ Source: litellm/llms/chatgpt/responses/transformation.py
 """
 
 import json
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
 
 
+import litellm
 from litellm.llms.openai.common_utils import OpenAIError
+from litellm.main import responses_api_bridge_check
 from litellm.types.router import GenericLiteLLMParams
 from litellm.types.utils import LlmProviders
 from litellm.utils import ProviderConfigManager
 from litellm.llms.chatgpt.responses.transformation import ChatGPTResponsesAPIConfig
-
-
-REPO_ROOT = Path(__file__).resolve().parents[5]
-MODEL_COST_MAP_PATHS = (
-    REPO_ROOT / "model_prices_and_context_window.json",
-    REPO_ROOT / "litellm" / "model_prices_and_context_window_backup.json",
-)
 
 
 class TestChatGPTResponsesAPITransformation:
@@ -52,7 +46,6 @@ class TestChatGPTResponsesAPITransformation:
         assert isinstance(config, ChatGPTResponsesAPIConfig)
         assert config.custom_llm_provider == LlmProviders.CHATGPT
 
-    @pytest.mark.parametrize("model_cost_map_path", MODEL_COST_MAP_PATHS)
     @pytest.mark.parametrize(
         "model_name",
         [
@@ -62,9 +55,8 @@ class TestChatGPTResponsesAPITransformation:
             "chatgpt/gpt-5.6-terra",
         ],
     )
-    def test_chatgpt_responses_model_metadata(self, model_name, model_cost_map_path):
-        with model_cost_map_path.open() as model_cost_map_file:
-            model_info = json.load(model_cost_map_file)[model_name]
+    def test_chatgpt_responses_model_metadata(self, model_name, local_model_cost_map):
+        model_info = litellm.get_model_info(model_name)
 
         assert model_info["litellm_provider"] == "chatgpt"
         assert model_info["mode"] == "responses"
@@ -72,6 +64,33 @@ class TestChatGPTResponsesAPITransformation:
             "/v1/chat/completions",
             "/v1/responses",
         ]
+        assert model_info["max_input_tokens"] == 1050000
+        assert model_info["max_output_tokens"] == 128000
+
+    @pytest.mark.parametrize(
+        "model_name",
+        [
+            "gpt-5.5",
+            "gpt-5.6-luna",
+            "gpt-5.6-sol",
+            "gpt-5.6-terra",
+        ],
+    )
+    def test_chatgpt_models_bridge_chat_completions_to_responses(
+        self, model_name, local_model_cost_map
+    ):
+        """A chat completions request for these models must take the Responses bridge.
+
+        `gpt-5.6-*` also exists as an openai chat model, so an unregistered
+        chatgpt model resolves to mode "chat" here and never reaches the bridge.
+        """
+        model_info, resolved_model = responses_api_bridge_check(
+            model=model_name,
+            custom_llm_provider="chatgpt",
+        )
+
+        assert model_info["mode"] == "responses"
+        assert resolved_model == model_name
 
     @patch("litellm.llms.chatgpt.responses.transformation.Authenticator")
     def test_chatgpt_responses_endpoint_url(self, mock_authenticator_class):


### PR DESCRIPTION
## TLDR

Problem this solves:

- ChatGPT subscription routing misses GPT-5.5 and GPT-5.6
- Callers must register the metadata themselves first

How it solves it:

- Registers the four model IDs as Responses deployments
- Covers them in the existing ChatGPT tests

## User Flow

Before: a developer on a ChatGPT subscription cannot call the GPT-5.6 models by name; the request comes back as an error page instead of an answer.

1. They add `chatgpt/gpt-5.6-luna` to `model_list` and start the proxy
2. They open https://litellm-domain/v1/models and see the model with no context window or endpoint metadata
3. They send POST https://litellm-domain/v1/chat/completions with `{"model": "chatgpt/gpt-5.6-luna", "messages": [{"role": "user", "content": "Reply with the word: pong"}]}`
4. The response is an error, not the answer: `ChatgptException - <html> ...` (the request never goes out as a Responses request)
5. To get an answer they must first describe the model themselves in their own code, then send the same request again

After: the same request returns the answer, with no extra setup.

1. They add `chatgpt/gpt-5.6-luna` to `model_list` and start the proxy
2. They open https://litellm-domain/v1/models and see a 1,050,000 token context window and `/v1/chat/completions` + `/v1/responses`
3. They send the same POST https://litellm-domain/v1/chat/completions
4. The response is `200` with the assistant content `pong`

## Relevant issues

Re-applies the model entries from #35720 (by @woojung3), which is a month stale and no longer merges cleanly. Happy to close this one if that branch gets rebased instead.

Not a fix for #37039 (`Unknown items in responses API response: []`); that bug is orthogonal and still open.

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Shared setup, run with a real ChatGPT subscription `auth.json` and `LITELLM_LOCAL_MODEL_COST_MAP=True` so the repo's cost map is the one under test. `qa.py` never calls `register_model()`:

```python
import litellm

for model in ["chatgpt/gpt-5.5", "chatgpt/gpt-5.6-luna", "chatgpt/gpt-5.6-sol", "chatgpt/gpt-5.6-terra"]:
    try:
        info = litellm.get_model_info(model)
        print(f"get_model_info({model}) -> mode={info['mode']} endpoints={info['supported_endpoints']}")
    except Exception as e:
        print(f"get_model_info({model}) -> {type(e).__name__}: {str(e)[:120]}")

r = litellm.completion(
    model="chatgpt/gpt-5.6-luna",
    messages=[{"role": "user", "content": "Reply with the word: pong"}],
)
print("completion(chatgpt/gpt-5.6-luna) ->", repr(r.choices[0].message.content))
```

Both runs also apply the same local workaround for the unrelated open bug #37039, so the only difference between them is this PR's cost map entries.

### Before (336891bbc7)

#### Model metadata and a live call

1. `LITELLM_LOCAL_MODEL_COST_MAP=True python qa.py`

```text
get_model_info(chatgpt/gpt-5.5) -> Exception: This model isn't mapped yet. model=chatgpt/gpt-5.5, custom_llm_provider=chatgpt.
get_model_info(chatgpt/gpt-5.6-luna) -> Exception: This model isn't mapped yet. model=chatgpt/gpt-5.6-luna, custom_llm_provider=chatgpt.
get_model_info(chatgpt/gpt-5.6-sol) -> Exception: This model isn't mapped yet. model=chatgpt/gpt-5.6-sol, custom_llm_provider=chatgpt.
get_model_info(chatgpt/gpt-5.6-terra) -> Exception: This model isn't mapped yet. model=chatgpt/gpt-5.6-terra, custom_llm_provider=chatgpt.
completion(chatgpt/gpt-5.6-luna) -> APIError: litellm.APIError: APIError: ChatgptException - <html> ...
```

### After (b35ad37219)

#### Model metadata and a live call

1. `LITELLM_LOCAL_MODEL_COST_MAP=True python qa.py`

```text
get_model_info(chatgpt/gpt-5.5) -> mode=responses endpoints=['/v1/chat/completions', '/v1/responses']
get_model_info(chatgpt/gpt-5.6-luna) -> mode=responses endpoints=['/v1/chat/completions', '/v1/responses']
get_model_info(chatgpt/gpt-5.6-sol) -> mode=responses endpoints=['/v1/chat/completions', '/v1/responses']
get_model_info(chatgpt/gpt-5.6-terra) -> mode=responses endpoints=['/v1/chat/completions', '/v1/responses']
completion(chatgpt/gpt-5.6-luna) -> 'pong'
```

2. `pytest tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py -q`

```text
31 passed, 2 warnings in 0.28s
```

The 8 new assertions fail at 336891bbc7 and pass here, so they track the runtime catalog rather than the JSON files.
