### PR TITLE
fix(anthropic): never carry cache_control on translated thinking blocks

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -524,18 +524,20 @@ class LiteLLMAnthropicMessagesAdapter:
                                 self._add_cache_control_if_applicable(content, tool_call, model)
                                 tool_calls.append(tool_call)
                             elif content.get("type") == "thinking":
+                                # Anthropic's schema has no cache_control on thinking or
+                                # redacted_thinking blocks, and anthropic_messages_pt replays
+                                # these verbatim at content[0], so carrying one here (or
+                                # inventing an empty one) is a guaranteed 400 on the way back.
                                 thinking_block = ChatCompletionThinkingBlock(
                                     type="thinking",
                                     thinking=content.get("thinking") or "",
                                     signature=content.get("signature") or "",
-                                    cache_control=content.get("cache_control", {}),
                                 )
                                 thinking_blocks.append(thinking_block)
                             elif content.get("type") == "redacted_thinking":
                                 redacted_thinking_block = ChatCompletionRedactedThinkingBlock(
                                     type="redacted_thinking",
                                     data=content.get("data") or "",
-                                    cache_control=content.get("cache_control", {}),
                                 )
                                 thinking_blocks.append(redacted_thinking_block)
 

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -1,5 +1,5 @@
 import base64
-from typing import Any, cast
+from typing import Any, Final, cast
 
 import pytest
 
@@ -4640,19 +4640,17 @@ def test_a_bedrock_target_still_takes_output_config_not_the_declared_gate():
     ],
 )
 def test_thinking_blocks_never_carry_cache_control_back_to_anthropic(client_cache_control):
-    """Anthropic's schema has no `cache_control` on thinking blocks, and
-    `anthropic_messages_pt` replays them verbatim at content[0], so any value that
-    survives this translation is a `messages.N.content.0.thinking.cache_control:
-    Extra inputs are not permitted` 400 on the way back out.
-
-    Both directions of the round trip are asserted because the adapter used to default
-    the key to `{}`, which manufactured the 400 for clients that never sent one at all.
-    """
+    """A cache_control surviving the round trip is a `messages.N.content.0.thinking.
+    cache_control: Extra inputs are not permitted` 400 from Anthropic, whether the client
+    sent one or the adapter invented an empty one."""
     from litellm.llms.anthropic.chat.transformation import AnthropicConfig
 
-    thinking_block = {"type": "thinking", "thinking": "let me think", "signature": "sig_abc"}
-    if client_cache_control is not None:
-        thinking_block["cache_control"] = client_cache_control
+    thinking_block: Final = {
+        "type": "thinking",
+        "thinking": "let me think",
+        "signature": "sig_abc",
+        **({"cache_control": client_cache_control} if client_cache_control is not None else {}),
+    }
 
     openai_request, _ = LiteLLMAnthropicMessagesAdapter().translate_anthropic_to_openai(
         {
@@ -4686,6 +4684,8 @@ def test_thinking_blocks_never_carry_cache_control_back_to_anthropic(client_cach
 def test_redacted_thinking_blocks_never_carry_cache_control():
     """`redacted_thinking` carries no signature and is always replayed, so it hits the
     same Anthropic 400 as `thinking` if it picks up a cache_control on the way through."""
+    from litellm.llms.anthropic.chat.transformation import AnthropicConfig
+
     openai_request, _ = LiteLLMAnthropicMessagesAdapter().translate_anthropic_to_openai(
         {
             "model": "claude-sonnet-5",
@@ -4703,6 +4703,14 @@ def test_redacted_thinking_blocks_never_carry_cache_control():
         }
     )
 
-    translated_blocks = openai_request["messages"][1]["thinking_blocks"]
-    assert [b["type"] for b in translated_blocks] == ["redacted_thinking"]
-    assert "cache_control" not in translated_blocks[0]
+    outbound: Final = AnthropicConfig().transform_request(
+        model="claude-sonnet-5",
+        messages=openai_request["messages"],
+        optional_params={"max_tokens": 4096},
+        litellm_params={},
+        headers={},
+    )
+
+    replayed: Final = outbound["messages"][1]["content"][0]
+    assert replayed["type"] == "redacted_thinking"
+    assert "cache_control" not in replayed

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -4630,3 +4630,79 @@ def test_a_bedrock_target_still_takes_output_config_not_the_declared_gate():
     assert openai_request["output_config"] == {"effort": "max"}
     assert "reasoning_effort" not in openai_request
     assert openai_request["thinking"] == {"type": "adaptive", "display": "omitted"}
+
+
+@pytest.mark.parametrize(
+    "client_cache_control",
+    [
+        pytest.param(None, id="client_sent_none"),
+        pytest.param({"type": "ephemeral"}, id="client_sent_one"),
+    ],
+)
+def test_thinking_blocks_never_carry_cache_control_back_to_anthropic(client_cache_control):
+    """Anthropic's schema has no `cache_control` on thinking blocks, and
+    `anthropic_messages_pt` replays them verbatim at content[0], so any value that
+    survives this translation is a `messages.N.content.0.thinking.cache_control:
+    Extra inputs are not permitted` 400 on the way back out.
+
+    Both directions of the round trip are asserted because the adapter used to default
+    the key to `{}`, which manufactured the 400 for clients that never sent one at all.
+    """
+    from litellm.llms.anthropic.chat.transformation import AnthropicConfig
+
+    thinking_block = {"type": "thinking", "thinking": "let me think", "signature": "sig_abc"}
+    if client_cache_control is not None:
+        thinking_block["cache_control"] = client_cache_control
+
+    openai_request, _ = LiteLLMAnthropicMessagesAdapter().translate_anthropic_to_openai(
+        {
+            "model": "claude-sonnet-5",
+            "max_tokens": 4096,
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "hi"}]},
+                {"role": "assistant", "content": [thinking_block, {"type": "text", "text": "hello"}]},
+                {"role": "user", "content": [{"type": "text", "text": "and now?"}]},
+            ],
+        }
+    )
+
+    translated_blocks = openai_request["messages"][1]["thinking_blocks"]
+    assert [b["type"] for b in translated_blocks] == ["thinking"]
+    assert "cache_control" not in translated_blocks[0]
+
+    outbound = AnthropicConfig().transform_request(
+        model="claude-sonnet-5",
+        messages=openai_request["messages"],
+        optional_params={"max_tokens": 4096},
+        litellm_params={},
+        headers={},
+    )
+
+    replayed = outbound["messages"][1]["content"][0]
+    assert replayed["type"] == "thinking"
+    assert "cache_control" not in replayed
+
+
+def test_redacted_thinking_blocks_never_carry_cache_control():
+    """`redacted_thinking` carries no signature and is always replayed, so it hits the
+    same Anthropic 400 as `thinking` if it picks up a cache_control on the way through."""
+    openai_request, _ = LiteLLMAnthropicMessagesAdapter().translate_anthropic_to_openai(
+        {
+            "model": "claude-sonnet-5",
+            "max_tokens": 4096,
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "hi"}]},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "redacted_thinking", "data": "abc", "cache_control": {"type": "ephemeral"}},
+                        {"type": "text", "text": "hello"},
+                    ],
+                },
+            ],
+        }
+    )
+
+    translated_blocks = openai_request["messages"][1]["thinking_blocks"]
+    assert [b["type"] for b in translated_blocks] == ["redacted_thinking"]
+    assert "cache_control" not in translated_blocks[0]


### PR DESCRIPTION
## TLDR

Problem this solves:

- Anthropic 400s any replayed assistant turn carrying a thinking block
- Error names `content.0.thinking.cache_control`, even when the client sent none
- Broke most sampled Claude Code turns in shadow eval

How it solves it:

- Stop putting `cache_control` on translated thinking blocks
- Anthropic's schema has no such field, so nothing is lost

## User Flow

Before: a shadow eval over Claude Code `/v1/messages` traffic loses most of its sampled turns to a provider error, so the quality result never fills in

1. An admin starts a shadow eval against the key their Claude Code users run through
2. Claude Code sends POST https://litellm-domain/v1/messages with extended thinking on, so its assistant turns carry thinking blocks
3. The admin opens https://litellm-domain/ui/?page=cost-optimization and sees the job's error count climbing much faster than its judged count
4. The failure banner reads `messages.5.content.0.thinking.cache_control: Extra inputs are not permitted`, with the block index always `content.0`
5. The job finishes with too few verdicts to read a win rate

After: the same turns go through, so the job fills in with verdicts

1. An admin starts a shadow eval against the same key
2. Claude Code sends the same POST https://litellm-domain/v1/messages with extended thinking on
3. https://litellm-domain/ui/?page=cost-optimization shows the judged count climbing instead of the error count
4. No `content.0.thinking.cache_control` failures appear
5. The job reports a win rate over a representative sample of the traffic

## Relevant issues

Supersedes #39777, which fixed the same line but only for the empty-value case. A client that genuinely marks a thinking block still 400s there, because Anthropic rejects the field itself rather than a particular value.

## Linear ticket

Resolves LIT-6965

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

The round trip that shadow eval performs on a sampled `/v1/messages` turn: the anthropic-shaped request is translated to chat shape, then transformed back out to the Anthropic wire. Both hops run the real functions from the checked-out tree, and the resulting body is sent to a live Anthropic model.

Shared setup, a proxy pointed at a real Anthropic deployment:

```yaml
model_list:
  - model_name: claude-bridge
    litellm_params:
      model: anthropic/claude-sonnet-5
      api_key: os.environ/ANTHROPIC_API_KEY
```

Mint a genuine thinking block first, because Anthropic verifies the signature cryptographically and litellm drops unsignable blocks before they would ever reach this code:

```bash
curl -s $PROXY/v1/messages -H "Authorization: Bearer sk-1234" -H "content-type: application/json" \
  -d '{"model":"claude-bridge","max_tokens":2048,"thinking":{"type":"adaptive","display":"summarized"},"messages":[{"role":"user","content":"what is 17 * 23? think step by step"}]}' \
  > turn1_response.json
```

Then replay it as history through both hops, with no `cache_control` anywhere in the request, and send the wire body straight to Anthropic:

```python
import json
from litellm.llms.anthropic.experimental_pass_through.adapters.transformation import LiteLLMAnthropicMessagesAdapter
from litellm.llms.anthropic.chat.transformation import AnthropicConfig

turn1 = json.load(open("turn1_response.json"))
anthropic_request = {
    "model": "claude-sonnet-5", "max_tokens": 1024, "thinking": {"type": "adaptive"},
    "messages": [
        {"role": "user", "content": "what is 17 * 23? think step by step"},
        {"role": "assistant", "content": turn1["content"]},
        {"role": "user", "content": "now multiply that by 2"},
    ],
}
openai_request, _ = LiteLLMAnthropicMessagesAdapter().translate_anthropic_to_openai(anthropic_request)
wire_body = AnthropicConfig().transform_request(
    model="claude-sonnet-5", messages=openai_request["messages"],
    optional_params={"max_tokens": 1024}, litellm_params={}, headers={},
)
print("thinking block keys sent to Anthropic:", sorted(wire_body["messages"][1]["content"][0].keys()))
```

```bash
curl -s -w "
HTTP %{http_code}
" https://api.anthropic.com/v1/messages \
  -H "x-api-key: $ANTHROPIC_API_KEY" -H "anthropic-version: 2023-06-01" -H "content-type: application/json" \
  -d @turn2_wire_body.json
```

### Before (2849aee57d)

`thinking block keys sent to Anthropic: ['cache_control', 'signature', 'thinking', 'type']`, from a request that never mentioned `cache_control`:

```json
{"type": "thinking", "thinking": "Breaking 17×23 into ...", "signature": "EvgCCpABCBEYAipAg4mT...", "cache_control": {}}
```

Sent to Anthropic:

```
{"error":{"message":"{\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"messages.1.content.0.thinking.cache_control: Extra inputs are not permitted\"},\"request_id\":\"req_011CejCqE5ywJDTDTfcDjYWA\"}. Received Model Group=claude-sonnet-5
Available Model Group Fallbacks=None","type":"None","param":"None","code":"400"}}
HTTP 400
```

### After (d659a12cd0)

`thinking block keys sent to Anthropic: ['signature', 'thinking', 'type']`

Sent to Anthropic:

```
{"model":"claude-sonnet-5","id":"msg_011CejCuPHyo8k4y5L3PPH4y","type":"message","role":"assistant","content":[{"type":"thinking","thinking":"","signature":"EoECCpABCBEYAipAWY4xKibqA2Nrhw90..."},{"type":"text","text":"# Calculating 391 × 2

**Step 1: Break down 391**

$$391 = 300 + 90 + 1$$

**Step 2: Multiply each part by 2**

- $300 	imes 2 = 600$
- $90 	imes 2 = 180$
- $1 	imes 2 = 2$

**Step 3: Add the results**

$$600 + 180 + 2 = 782$$

### Answer: **391 × 2 = 782**"}],"stop_reason":"end_turn","usage":{"input_tokens":301,"output_tokens":161,"output_tokens_details":{"thinking_tokens":11}}}
HTTP 200
```

## Type

🐛 Bug Fix

## Caveats

### Low

- A client marking a thinking block for caching loses that mark
  - Anthropic rejects the field outright, so it never took effect
  - No other destination reads it: Bedrock's thinking-block path ignores `cache_control`, Databricks strips thinking blocks entirely
- Auto prompt caching is unaffected
  - The breakpoint counter walks message `content`, and translated thinking blocks sit outside it
- Unblocking these turns means they now bill
  - A shadow eval job that used to 400 for free will spend against its budget, and may stop earlier than before

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow adapter change in experimental pass-through translation with regression tests; prompt caching on supported block types is unaffected.
> 
> **Overview**
> Fixes Anthropic **400** errors when `/v1/messages` traffic with extended thinking is translated to chat format and replayed (e.g. shadow eval, Claude Code history). The adapter no longer sets **`cache_control`** on **`thinking`** and **`redacted_thinking`** blocks when mapping assistant content—previously it forwarded client values or defaulted to `{}`, and Anthropic rejects that field on replay (`messages.N.content.0.thinking.cache_control: Extra inputs are not permitted`).
> 
> **`cache_control`** on text, tools, and other block types is unchanged. New round-trip tests cover both client-supplied and adapter-invented **`cache_control`** for thinking and redacted thinking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 208ab99a30590992d687fe5983be9e3cc8f429df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->