### PR TITLE
feat(dashboard): configure classifier vision input

### DIFF
--- a/ui/litellm-dashboard/src/components/add_model/ClassificationMethodConfig.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/ClassificationMethodConfig.tsx
@@ -15,6 +15,7 @@ import { RestrictedSection, restrictedBy } from "./TierRestrictions";
 import HeuristicScoringConfig from "./HeuristicScoringConfig";
 import ClassifierReasoningEffortSelect from "./ClassifierReasoningEffortSelect";
 import ClassifierCircuitBreakerConfig from "./ClassifierCircuitBreakerConfig";
+import ClassifierVisionConfig from "./ClassifierVisionConfig";
 import type { ReasoningEffort } from "./complexity_router_tiers";
 import { useComplexityScorerDefaults } from "@/app/(dashboard)/hooks/autoRouter/useComplexityScorerDefaults";
 import {
@@ -315,12 +316,13 @@ const ClassificationMethodConfig: React.FC<ClassificationMethodConfigProps> = ({
       timeout_ms: value.classifier_llm_config?.timeout_ms ?? DEFAULT_CLASSIFIER_TIMEOUT_MS,
       classification_rubric: selectedRubric,
     };
-    onChange({
+    const nextValue: ComplexityRouterConfigValue = {
       ...value,
       ...(selectedRubric && { classifier_llm_config: rubricConfig }),
       classification_prompt: classificationPrompt,
       classification_examples: classificationExamples,
-    });
+    };
+    onChange(nextValue);
   };
 
   const handleClassifierModelChange = (model: string) => {
@@ -574,6 +576,10 @@ const ClassificationMethodConfig: React.FC<ClassificationMethodConfigProps> = ({
             </span>
           </div>
           <ClassifierCircuitBreakerConfig
+            value={value.classifier_llm_config ?? { model: "", timeout_ms: DEFAULT_CLASSIFIER_TIMEOUT_MS }}
+            onChange={(classifier_llm_config) => onChange({ ...value, classifier_llm_config })}
+          />
+          <ClassifierVisionConfig
             value={value.classifier_llm_config ?? { model: "", timeout_ms: DEFAULT_CLASSIFIER_TIMEOUT_MS }}
             onChange={(classifier_llm_config) => onChange({ ...value, classifier_llm_config })}
           />

--- a/ui/litellm-dashboard/src/components/add_model/ClassifierVisionConfig.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/ClassifierVisionConfig.tsx
@@ -1,0 +1,79 @@
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import React from "react";
+
+import type { ClassifierLLMConfigWire } from "./build_complexity_router_config";
+
+export const DEFAULT_CLASSIFIER_VISION_ENABLED = false;
+export const DEFAULT_CLASSIFIER_VISION_MAX_IMAGES = 1;
+
+const MAX_IMAGES_ID = "classifier-vision-max-images";
+
+interface ClassifierVisionConfigProps {
+  value: ClassifierLLMConfigWire;
+  onChange: (value: ClassifierLLMConfigWire) => void;
+}
+
+const ClassifierVisionConfig: React.FC<ClassifierVisionConfigProps> = ({ value, onChange }) => {
+  const [draftMaxImages, setDraftMaxImages] = React.useState<string | null>(null);
+  const enabled = value.vision?.enabled ?? DEFAULT_CLASSIFIER_VISION_ENABLED;
+
+  const handleMaxImagesChange = (raw: string): void => {
+    setDraftMaxImages(raw);
+    const parsed = Number(raw);
+    if (raw.trim() === "" || !Number.isFinite(parsed)) return;
+    onChange({
+      ...value,
+      vision: { ...value.vision, enabled, max_images: Math.max(1, Math.round(parsed)) },
+    });
+  };
+
+  return (
+    <div className="space-y-2 rounded-md border border-border p-3">
+      <div className="flex items-center gap-2">
+        <Switch
+          checked={enabled}
+          onCheckedChange={(visionEnabled): void => {
+            if (!visionEnabled) {
+              const { vision: _vision, ...withoutVision } = value;
+              onChange(withoutVision);
+              return;
+            }
+            onChange({
+              ...value,
+              vision: {
+                ...value.vision,
+                enabled: true,
+                max_images: value.vision?.max_images ?? DEFAULT_CLASSIFIER_VISION_MAX_IMAGES,
+              },
+            });
+          }}
+          aria-label="Use images for classification"
+        />
+        <strong className="font-semibold">Use images for classification</strong>
+      </div>
+      <span className="block text-xs text-muted-foreground">
+        Send inline image data to the classifier so it can choose a tier from what the image shows.
+      </span>
+      {enabled && (
+        <div>
+          <Label htmlFor={MAX_IMAGES_ID} className="block mb-1 font-semibold">
+            Maximum images per request
+          </Label>
+          <Input
+            id={MAX_IMAGES_ID}
+            type="text"
+            inputMode="numeric"
+            value={draftMaxImages ?? String(value.vision?.max_images ?? DEFAULT_CLASSIFIER_VISION_MAX_IMAGES)}
+            onChange={(event) => handleMaxImagesChange(event.target.value)}
+            onBlur={() => setDraftMaxImages(null)}
+            className="w-full"
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ClassifierVisionConfig;

--- a/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, renderWithProviders, screen, within } from "../../../tests/test-utils";
 import userEvent from "@testing-library/user-event";
+import React from "react";
 import { vi } from "vitest";
 import ComplexityRouterConfig, { ComplexityRouterConfigValue } from "./ComplexityRouterConfig";
 vi.mock(
@@ -1688,5 +1689,85 @@ describe("ComplexityRouterConfig tier editing", () => {
     renderWithProviders(<ComplexityRouterConfig {...baseProps} onEditingTiersChange={vi.fn()} />);
     expect(screen.getByLabelText("Display name for the Simple tier")).toBeInTheDocument();
     expect(screen.queryByText("Display names rename the built-in tiers", { exact: false })).not.toBeInTheDocument();
+  });
+});
+
+describe("classifier vision settings", () => {
+  const llmValue: ComplexityRouterConfigValue = {
+    ...defaultValue,
+    classifier_type: "llm",
+    classifier_llm_config: { model: "gpt-3.5-turbo", timeout_ms: 3000 },
+  };
+
+  const VisionFixture = ({ onChange = vi.fn() }: { onChange?: ReturnType<typeof vi.fn> }) => {
+    const [value, setValue] = React.useState(llmValue);
+    return (
+      <ComplexityRouterConfig
+        modelInfo={mockModelInfo}
+        value={value}
+        onChange={(nextValue) => {
+          setValue(nextValue);
+          onChange(nextValue);
+        }}
+      />
+    );
+  };
+
+  it("starts off and reveals the default cap when enabled", () => {
+    renderWithProviders(<VisionFixture />);
+    fireEvent.click(screen.getByText("Advanced: Classification Method"));
+
+    const vision = screen.getByRole("switch", { name: "Use images for classification" });
+    expect(vision).not.toBeChecked();
+    expect(screen.queryByLabelText("Maximum images per request")).not.toBeInTheDocument();
+
+    fireEvent.click(vision);
+
+    expect(screen.getByLabelText("Maximum images per request")).toHaveValue("1");
+  });
+
+  it("writes the switch and a clamped image cap into the classifier config", () => {
+    const onChange = vi.fn();
+    renderWithProviders(<VisionFixture onChange={onChange} />);
+    fireEvent.click(screen.getByText("Advanced: Classification Method"));
+
+    fireEvent.click(screen.getByRole("switch", { name: "Use images for classification" }));
+    expect(onChange).toHaveBeenLastCalledWith({
+      ...llmValue,
+      classifier_llm_config: { ...llmValue.classifier_llm_config, vision: { enabled: true, max_images: 1 } },
+    });
+
+    fireEvent.change(screen.getByLabelText("Maximum images per request"), { target: { value: "1.7" } });
+    expect(onChange).toHaveBeenLastCalledWith({
+      ...llmValue,
+      classifier_llm_config: { ...llmValue.classifier_llm_config, vision: { enabled: true, max_images: 2 } },
+    });
+  });
+
+  it("keeps the image cap draft empty until a valid value is entered", () => {
+    const onChange = vi.fn();
+    renderWithProviders(<VisionFixture onChange={onChange} />);
+    fireEvent.click(screen.getByText("Advanced: Classification Method"));
+    fireEvent.click(screen.getByRole("switch", { name: "Use images for classification" }));
+    onChange.mockClear();
+
+    const input = screen.getByLabelText("Maximum images per request");
+    fireEvent.change(input, { target: { value: "" } });
+
+    expect(input).toHaveValue("");
+    expect(onChange).not.toHaveBeenCalled();
+
+    fireEvent.change(input, { target: { value: "0" } });
+    expect(onChange).toHaveBeenLastCalledWith({
+      ...llmValue,
+      classifier_llm_config: { ...llmValue.classifier_llm_config, vision: { enabled: true, max_images: 1 } },
+    });
+  });
+
+  it("is absent when the classifier is heuristic", () => {
+    renderWithProviders(<ComplexityRouterConfig modelInfo={mockModelInfo} value={defaultValue} onChange={vi.fn()} />);
+    fireEvent.click(screen.getByText("Advanced: Classification Method"));
+
+    expect(screen.queryByText("Use images for classification")).not.toBeInTheDocument();
   });
 });

--- a/ui/litellm-dashboard/src/components/add_model/build_complexity_router_config.test.ts
+++ b/ui/litellm-dashboard/src/components/add_model/build_complexity_router_config.test.ts
@@ -1170,12 +1170,13 @@ describe("buildComplexityRouterConfig stall escalation", () => {
   });
 
   it("emits the toggle and both knobs when it is on", () => {
-    const config = buildComplexityRouterConfig({
+    const params = {
       ...baseParams,
       stallEscalationEnabled: true,
       stallEscalationWindow: 8,
       stallEscalationRepeatThreshold: 4,
-    });
+    };
+    const config = buildComplexityRouterConfig(params);
     expect(config.stall_escalation_enabled).toBe(true);
     expect(config.stall_escalation_window).toBe(8);
     expect(config.stall_escalation_repeat_threshold).toBe(4);
@@ -1205,5 +1206,40 @@ describe("dryRunRejection", () => {
   it("lets a valid verdict through, including the fail-open one a transport failure returns", () => {
     expect(dryRunRejection({ valid: true })).toBeNull();
     expect(dryRunRejection({ valid: true, error: null })).toBeNull();
+  });
+});
+
+describe("classifier vision wire payload", () => {
+  const vision = { enabled: true, max_images: 3 };
+  const classifierLlmConfig = { model: "classifier", timeout_ms: 3000, vision };
+
+  it("keeps vision through the standard-tier payload", () => {
+    const params = { ...baseParams, classifierType: "llm" as const, classifierLlmConfig };
+    const payload = buildComplexityRouterConfig(params);
+
+    expect(payload.classifier_llm_config).toMatchObject({ vision });
+  });
+
+  it("keeps vision through the custom-tier payload", () => {
+    const customTierSet = {
+      tiers: [
+        { id: "simple", name: "simple", definition: "small talk", models: ["gpt-4o-mini"] },
+        { id: "complex", name: "complex", definition: "hard work", models: ["gpt-4o"] },
+      ],
+      fallback_tier_id: "simple",
+    };
+    const payload = buildComplexityRouterConfig({ ...baseParams, customTierSet, classifierLlmConfig });
+
+    expect(payload.classifier_llm_config).toMatchObject({ vision });
+  });
+
+  it("keeps an untouched classifier config free of vision", () => {
+    const payload = buildComplexityRouterConfig({
+      ...baseParams,
+      classifierType: "llm",
+      classifierLlmConfig: { model: "classifier", timeout_ms: 3000 },
+    });
+
+    expect(payload.classifier_llm_config).not.toHaveProperty("vision");
   });
 });

--- a/ui/litellm-dashboard/src/components/add_model/build_complexity_router_config.ts
+++ b/ui/litellm-dashboard/src/components/add_model/build_complexity_router_config.ts
@@ -1,8 +1,5 @@
-import { KeywordTierRule } from "./KeywordTierRules";
-
-type ClassifierLLMConfigWire = ClassifierLLMConfig & { vision?: { enabled?: boolean; max_images?: number } };
-
 import type { ModelGroup } from "../llm_calls/fetch_models";
+import { KeywordTierRule } from "./KeywordTierRules";
 import {
   type CustomTierSet,
   type TierRow,
@@ -41,6 +38,9 @@ import {
   heuristicScoringRoleFor,
   usesLlmClassifier,
 } from "./ComplexityRouterConfig";
+
+export type ClassifierVisionConfig = { enabled?: boolean; max_images?: number };
+export type ClassifierLLMConfigWire = ClassifierLLMConfig & { vision?: ClassifierVisionConfig };
 
 /**
  * Drop an empty system_prompt so the payload carries an override only when there is one. The
@@ -124,7 +124,7 @@ export interface BuildComplexityRouterConfigParams {
   planModeMinTier: string | undefined;
   tierLabels: ComplexityTierLabels | undefined;
   classifierType: ClassifierType;
-  classifierLlmConfig: ClassifierLLMConfig | undefined;
+  classifierLlmConfig: ClassifierLLMConfigWire | undefined;
   classifierContextWindowSize: number | undefined;
   classifierContextBudgetChars: number | undefined;
   classifierContextIncludeAssistantTurns: boolean | undefined;

--- a/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.test.tsx
+++ b/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.test.tsx
@@ -1036,3 +1036,60 @@ describe("EditAutoRouterModal with a stored custom tier set", () => {
     expect(savedConfig().tier_model_configs).toEqual(CUSTOM_STORED.tier_model_configs);
   });
 });
+
+describe("EditAutoRouterModal classifier vision", () => {
+  beforeEach(() => {
+    modelPatchUpdateCall.mockClear();
+  });
+
+  const STORED_CONFIG = {
+    tiers: { SIMPLE: ["gpt-4o-mini"], MEDIUM: ["gpt-4o-mini"], COMPLEX: ["gpt-4o-mini"], REASONING: ["gpt-4o-mini"] },
+    classifier_type: "llm",
+    classifier_llm_config: {
+      model: "gpt-4o-mini",
+      timeout_ms: 3000,
+      vision: { enabled: true, max_images: 2 },
+    },
+  };
+
+  const renderModal = () =>
+    renderWithProviders(
+      <EditAutoRouterModal
+        isVisible
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+        modelData={{
+          ...MODEL_DATA,
+          litellm_params: { ...MODEL_DATA.litellm_params, complexity_router_config: STORED_CONFIG },
+        }}
+        accessToken="token"
+        userRole="Admin"
+      />,
+    );
+
+  it("hydrates and keeps a stored vision setting through an untouched save", async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await user.click(await screen.findByText("Advanced: Classification Method"));
+    expect(screen.getByRole("switch", { name: "Use images for classification" })).toBeChecked();
+    expect(screen.getByLabelText("Maximum images per request")).toHaveValue("2");
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => expect(modelPatchUpdateCall).toHaveBeenCalled());
+    expect(savedConfig().classifier_llm_config).toMatchObject({ vision: { enabled: true, max_images: 2 } });
+  });
+
+  it("removes vision when the operator turns it off", async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await user.click(await screen.findByText("Advanced: Classification Method"));
+    await user.click(screen.getByRole("switch", { name: "Use images for classification" }));
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => expect(modelPatchUpdateCall).toHaveBeenCalled());
+    expect(savedConfig().classifier_llm_config).not.toHaveProperty("vision");
+  });
+});


### PR DESCRIPTION
## TLDR

Problem this solves:

- Classifier image input is API-only and hard to discover
- Dashboard users cannot enable it or set its image cap

How it solves it:

- Adds classifier image-input controls to the advanced form
- Keeps the image cap hidden until image classification is on
- Persists the setting on new and existing auto routers

## User Flow

Before: an operator can create or edit an auto router in the dashboard, but cannot configure classifier image input

1. They open https://litellm-domain/ui/?page=models and select Auto Routers
2. They add or edit an auto router, open Advanced: Classification Method, and choose an LLM classifier
3. There is no control for classifier image input, so they must leave the dashboard and edit config.yaml or call the management API

After: the operator can enable image classification and set its request cap where they configure the classifier

1. They open https://litellm-domain/ui/?page=models and select Auto Routers
2. They add or edit an auto router, open Advanced: Classification Method, and choose an LLM classifier
3. They turn on Send images to the classifier and enter a maximum image count
4. They save and reopen the auto router, and the switch plus count retain their values

## Relevant issues

## Linear ticket

Resolves LIT-6994

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required local checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Captured against a live proxy on :4010 and the dashboard dev server on :3011, driven headlessly. The control sits in Advanced: Classification Method, directly under the classifier circuit breaker, and only renders for an LLM classifier.

### Off by default, no cap shown

The switch starts off and the image cap is not rendered, so an existing router keeps its current behavior and its payload is unchanged

![Vision control off](https://raw.githubusercontent.com/BerriAI/litellm/675866ec691ad3f7ff681039eed77b13e3c6a295/pr39840/vision_control_off.png)

### On, with the per-request cap

Turning it on reveals the cap, defaulted to 1 and set to 2 here

![Vision control on](https://raw.githubusercontent.com/BerriAI/litellm/675866ec691ad3f7ff681039eed77b13e3c6a295/pr39840/vision_control_on.png)

### In context, beside the sibling classifier controls

![Classifier panel in context](https://raw.githubusercontent.com/BerriAI/litellm/675866ec691ad3f7ff681039eed77b13e3c6a295/pr39840/classifier_panel_in_context.png)

### A stored setting hydrates back into the edit form

A router created through the API with `vision: {enabled: true, max_images: 2}` was reopened in the dashboard. The switch reads on and the cap reads 2, which is the create/store/hydrate round trip

![Edit modal hydrated](https://raw.githubusercontent.com/BerriAI/litellm/675866ec691ad3f7ff681039eed77b13e3c6a295/pr39840/edit_modal_hydrated.png)

Reproduce it:

1. Run a proxy with `STORE_MODEL_IN_DB=True` and a few chat models, then `npm run dev` in `ui/litellm-dashboard`
2. Open the dashboard, select Auto-Routers, then Add Auto Router
3. Pick Custom Configuration, open Advanced: Classification Method, choose LLM Classifier and a classifier model
4. Turn on Use images for classification and set Maximum images per request to 2
5. Save, reopen the router, and confirm the switch is on and the count is still 2
6. Turn the switch off, save, and confirm `classifier_llm_config` carries no `vision` key in GET /v2/model/info

## Type

🆕 New Feature

## Caveats (if any)

### Low

- This PR depends on #39825; it should merge first
- The control configures only inline data-URI images, matching the parent feature
- Safe HTTPS image fetching is tracked separately in LIT-7000

