### PR TITLE
feat(helm): render nodeSelector, tolerations, and affinity on the componentized chart migrations Job

### DIFF
--- a/helm/litellm/templates/migrations-job.yaml
+++ b/helm/litellm/templates/migrations-job.yaml
@@ -77,4 +77,16 @@ spec:
       volumes:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.migrationJob.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.migrationJob.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.migrationJob.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/helm/litellm/tests/migration_job_tests.yaml
+++ b/helm/litellm/tests/migration_job_tests.yaml
@@ -1,4 +1,4 @@
-suite: test migrations Job ServiceAccount resolution and pod hardening
+suite: test migrations Job ServiceAccount resolution, pod hardening, and scheduling
 templates:
   - migrations-job.yaml
 values:
@@ -188,3 +188,69 @@ tests:
     asserts:
       - notExists:
           path: spec.activeDeadlineSeconds
+
+  - it: renders no scheduling fields by default
+    asserts:
+      - isNull:
+          path: spec.template.spec.nodeSelector
+      - isNull:
+          path: spec.template.spec.tolerations
+      - isNull:
+          path: spec.template.spec.affinity
+
+  - it: renders nodeSelector, tolerations, and affinity from the migrationJob values
+    set:
+      migrationJob.nodeSelector:
+        intent: no-csi-nodes
+      migrationJob.tolerations:
+        - key: intent
+          operator: Equal
+          value: no-csi-nodes
+          effect: NoSchedule
+      migrationJob.affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: intent
+                    operator: In
+                    values:
+                      - no-csi-nodes
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector
+          value:
+            intent: no-csi-nodes
+      - equal:
+          path: spec.template.spec.tolerations
+          value:
+            - key: intent
+              operator: Equal
+              value: no-csi-nodes
+              effect: NoSchedule
+      - equal:
+          path: spec.template.spec.affinity
+          value:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: intent
+                        operator: In
+                        values:
+                          - no-csi-nodes
+
+  - it: does not inherit the gateway's scheduling values
+    set:
+      gateway.nodeSelector:
+        intent: no-csi-nodes
+      gateway.tolerations:
+        - key: intent
+          operator: Equal
+          value: no-csi-nodes
+          effect: NoSchedule
+    asserts:
+      - isNull:
+          path: spec.template.spec.nodeSelector
+      - isNull:
+          path: spec.template.spec.tolerations

--- a/helm/litellm/values.yaml
+++ b/helm/litellm/values.yaml
@@ -152,6 +152,13 @@ migrationJob:
   # the writable scratch space a read-only root filesystem needs.
   volumes: []
   volumeMounts: []
+  # Scheduling for the Job pod, same shape as gateway.nodeSelector /
+  # gateway.tolerations / gateway.affinity. The Job does not inherit the other
+  # components' scheduling values: a migration usually needs a larger node
+  # than the gateway, so pin it here explicitly.
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
   image:
     repository: ghcr.io/berriai/litellm-migrations
     tag: ""              # defaults to .Chart.AppVersion


### PR DESCRIPTION
## TLDR

Problem this solves:

- The componentized chart's migrations Job ignores node placement
- `gateway`, `backend`, and `ui` take `nodeSelector`; `migrationJob` has no such key
- The Job pod can land on any node, including ones too small for it

How it solves it:

- Add `migrationJob.nodeSelector`, `migrationJob.tolerations`, and `migrationJob.affinity` to `helm/litellm`
- Render them on the Job pod the same way the three Deployments do
- Chart tests pin the default, the rendered values, and that the Job does not inherit `gateway.*`

## User Flow

Before: an operator pins every LiteLLM pod to their `intent: no-csi-nodes` node pool, and the migrations Job is the one pod that still schedules anywhere

1. They set `nodeSelector: {intent: no-csi-nodes}` under `gateway`, `backend`, `ui`, and `migrationJob` in their values file for the componentized chart at `helm/litellm`
2. They run `helm template litellm helm/litellm -f values.yaml`
3. The gateway, backend, and ui Deployments render `nodeSelector: {intent: no-csi-nodes}`; the `litellm-litellm-migrations` Job renders no `nodeSelector`, `tolerations`, or `affinity` at all, and `values.yaml` has no such keys under `migrationJob` to set
4. They run `helm upgrade --install litellm helm/litellm -f values.yaml -n litellm`; the pre-upgrade migrations Job is created without a node selector, so its pod (4 CPU / 12Gi in their values) can land on any node in the cluster instead of the pool they sized for it

After: the same values file pins the migrations Job to the pool too

1. They set `nodeSelector: {intent: no-csi-nodes}` under `gateway`, `backend`, `ui`, and `migrationJob` in their values file for the componentized chart at `helm/litellm`
2. They run `helm template litellm helm/litellm -f values.yaml`
3. All three Deployments and the `litellm-litellm-migrations` Job render `nodeSelector: {intent: no-csi-nodes}`; `migrationJob.tolerations` and `migrationJob.affinity` render on the Job the same way, and all three keys are documented under `migrationJob` in `values.yaml`
4. They run `helm upgrade --install litellm helm/litellm -f values.yaml -n litellm`; the migrations Job pod carries the node selector, so it can only be placed on the `intent: no-csi-nodes` pool

## Relevant issues

## Linear ticket

Resolves LIT-7015

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `helm unittest helm/litellm -f 'tests/*.yaml'` (13 suites, 121 tests)
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup: a values file shaped like an operator's real one, with the same `intent: no-csi-nodes` selector on every component, plus tolerations and affinity on the Job to show all three fields

```bash
cat > pin-values.yaml <<'YAML'
database:
  writer:
    host: postgres.example.com
    dbname: litellm
backend:
  nodeSelector:
    intent: no-csi-nodes
gateway:
  nodeSelector:
    intent: no-csi-nodes
ui:
  nodeSelector:
    intent: no-csi-nodes
migrationJob:
  enabled: true
  nodeSelector:
    intent: no-csi-nodes
  tolerations:
    - key: intent
      operator: Equal
      value: no-csi-nodes
      effect: NoSchedule
  affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
          - matchExpressions:
              - key: intent
                operator: In
                values:
                  - no-csi-nodes
YAML

cat > scheduling_per_pod.py <<'PY'
import sys
import yaml

for doc in yaml.safe_load_all(sys.stdin):
    if not doc or doc.get("kind") not in ("Deployment", "Job"):
        continue
    spec = doc["spec"]["template"]["spec"]
    tolerations = spec.get("tolerations") or []
    print(f'{doc["kind"]:<11} {doc["metadata"]["name"]:<30} nodeSelector={spec.get("nodeSelector")} tolerations={len(tolerations)} affinity={spec.get("affinity")}')
PY
```

Live cluster leg: a one-node kind cluster (`kind create cluster --name lit7015`), the same values file, `helm upgrade --install litellm <chart> -f pin-values.yaml -n <ns> --create-namespace --timeout 40s` on each side (the pre-install hook times out on purpose because there is no database, and the Job it created stays behind for inspection)

### Before (41c8c2f410)

1. `helm template litellm helm/litellm -f pin-values.yaml | python3 scheduling_per_pod.py`

   ```
   Deployment  litellm-litellm-backend        nodeSelector={'intent': 'no-csi-nodes'} tolerations=0 affinity=None
   Deployment  litellm-litellm-gateway        nodeSelector={'intent': 'no-csi-nodes'} tolerations=0 affinity=None
   Deployment  litellm-litellm-ui             nodeSelector={'intent': 'no-csi-nodes'} tolerations=0 affinity=None
   Job         litellm-litellm-migrations     nodeSelector=None tolerations=0 affinity=None
   ```

2. `helm template litellm helm/litellm -f pin-values.yaml -s templates/migrations-job.yaml | python3 -c 'import sys,yaml; print(sorted(yaml.safe_load(sys.stdin)["spec"]["template"]["spec"].keys()))'`

   ```
   ['automountServiceAccountToken', 'containers', 'restartPolicy', 'serviceAccountName']
   ```

3. Live cluster: the Job renders without scheduling fields, so the pod is assigned to the unlabeled node right away, and once that node carries the pool taint the pod cannot schedule at all because the chart renders no tolerations

   ```
   $ kubectl -n base get job litellm-litellm-migrations -o jsonpath='nodeSelector={.spec.template.spec.nodeSelector} tolerations={.spec.template.spec.tolerations} affinity={.spec.template.spec.affinity}'
   nodeSelector= tolerations= affinity=
   $ kubectl -n base get pod -l app.kubernetes.io/component=migrations -o custom-columns='NAME:.metadata.name,STATUS:.status.phase,NODE:.spec.nodeName'
   NAME                               STATUS    NODE
   litellm-litellm-migrations-p8ktf   Pending   lit7015-control-plane
   $ kubectl -n base get events --field-selector involvedObject.kind=Pod -o custom-columns='REASON:.reason,MESSAGE:.message'
   Scheduled   Successfully assigned base/litellm-litellm-migrations-p8ktf to lit7015-control-plane
   $ kubectl taint node lit7015-control-plane intent=no-csi-nodes:NoSchedule && kubectl -n base delete pod -l app.kubernetes.io/component=migrations
   $ kubectl -n base get events --field-selector involvedObject.kind=Pod -o custom-columns='REASON:.reason,MESSAGE:.message' | tail -1
   FailedScheduling   0/1 nodes are available: 1 node(s) had untolerated taint(s). preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling.
   ```

### After (2674934e45)

The tip is 3b9568bcdd, a merge of `litellm_internal_staging` into this branch to pick up its CI fixes; it touches nothing under `helm/`, so it cannot change the rendered chart and the run above stands

1. `helm template litellm helm/litellm -f pin-values.yaml | python3 scheduling_per_pod.py`

   ```
   Deployment  litellm-litellm-backend        nodeSelector={'intent': 'no-csi-nodes'} tolerations=0 affinity=None
   Deployment  litellm-litellm-gateway        nodeSelector={'intent': 'no-csi-nodes'} tolerations=0 affinity=None
   Deployment  litellm-litellm-ui             nodeSelector={'intent': 'no-csi-nodes'} tolerations=0 affinity=None
   Job         litellm-litellm-migrations     nodeSelector={'intent': 'no-csi-nodes'} tolerations=1 affinity={'nodeAffinity': {'requiredDuringSchedulingIgnoredDuringExecution': {'nodeSelectorTerms': [{'matchExpressions': [{'key': 'intent', 'operator': 'In', 'values': ['no-csi-nodes']}]}]}}}
   ```

2. `helm template litellm helm/litellm -f pin-values.yaml -s templates/migrations-job.yaml | python3 -c 'import sys,yaml; d=yaml.safe_load(sys.stdin)["spec"]["template"]["spec"]; print(yaml.safe_dump({k: d.get(k) for k in ("nodeSelector","tolerations","affinity")}, sort_keys=False))'`

   ```yaml
   nodeSelector:
     intent: no-csi-nodes
   tolerations:
   - effect: NoSchedule
     key: intent
     operator: Equal
     value: no-csi-nodes
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
         - matchExpressions:
           - key: intent
             operator: In
             values:
             - no-csi-nodes
   ```

3. `helm lint helm/litellm --set database.writer.host=h --set database.writer.dbname=d` reports `1 chart(s) linted, 0 chart(s) failed`, and `helm unittest helm/litellm -f 'tests/*.yaml'` reports 13 suites and 121 tests passing. With the template change reverted and the new tests kept, the positive render test fails, so the tests do catch a regression

4. Live cluster: the Job carries all three fields, the API server accepts them, the pod stays Pending until a node matches the selector, and once the node is labeled and tainted as the pool the pod is assigned there (the toleration is honored)

   ```
   $ kubectl -n head get job litellm-litellm-migrations -o jsonpath='nodeSelector={.spec.template.spec.nodeSelector} tolerations={.spec.template.spec.tolerations} affinity={.spec.template.spec.affinity}'
   nodeSelector={"intent":"no-csi-nodes"} tolerations=[{"effect":"NoSchedule","key":"intent","operator":"Equal","value":"no-csi-nodes"}] affinity={"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"intent","operator":"In","values":["no-csi-nodes"]}]}]}}}
   $ kubectl -n head get pod -l app.kubernetes.io/component=migrations -o custom-columns='NAME:.metadata.name,STATUS:.status.phase,NODE:.spec.nodeName'
   NAME                               STATUS    NODE
   litellm-litellm-migrations-dkz27   Pending   <none>
   $ kubectl -n head get events --field-selector involvedObject.kind=Pod -o custom-columns='REASON:.reason,MESSAGE:.message'
   FailedScheduling   0/1 nodes are available: 1 node(s) didn't match Pod's node affinity/selector. preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling.
   $ kubectl label node lit7015-control-plane intent=no-csi-nodes && kubectl taint node lit7015-control-plane intent=no-csi-nodes:NoSchedule
   $ kubectl -n head get pod -l app.kubernetes.io/component=migrations -o custom-columns='NAME:.metadata.name,STATUS:.status.phase,NODE:.spec.nodeName'
   NAME                               STATUS    NODE
   litellm-litellm-migrations-dkz27   Pending   lit7015-control-plane
   $ kubectl -n head get events --field-selector involvedObject.kind=Pod -o custom-columns='REASON:.reason,MESSAGE:.message' | grep Scheduled
   Scheduled          Successfully assigned head/litellm-litellm-migrations-dkz27 to lit7015-control-plane
   ```

## Type

🆕 New Feature

## Caveats (if any)

### Low

- The Job does not inherit `gateway.nodeSelector`; set `migrationJob.nodeSelector` explicitly
  - Same scoping as every other component in this chart; the classic `litellm-helm` chart uses top-level keys instead
- A `nodeSelector` matching no node leaves the hook Job Pending
  - `helm upgrade` then fails at its `--timeout` before touching running pods

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 2674934e45 passes /live-pr-risk
