### PR TITLE
fix(responses): decode JSON-string tool schemas before sending to the provider

### DIFF
--- a/litellm/llms/openai/responses/transformation.py
+++ b/litellm/llms/openai/responses/transformation.py
@@ -240,9 +240,9 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
     def _tools_with_object_parameters(
         self, model: str, tools: Sequence[ALL_RESPONSES_API_TOOL_PARAMS] | None
     ) -> Sequence[ALL_RESPONSES_API_TOOL_PARAMS] | None:
-        """Callers sometimes hand a tool schema over already JSON-encoded. The Responses
-        validator rejects that with a 400 naming the routed model rather than the tool, so
-        decode it here and refuse anything that is neither an object nor a string encoding one."""
+        """Decode tool schemas handed over already JSON-encoded, which the Responses validator
+        rejects with a 400 naming the routed model rather than the tool. A null or absent schema
+        is left alone because the API accepts both."""
         if tools is None:
             return None
         decoded: Final = [  # mutable-ok: request tools are a JSON list

--- a/litellm/llms/openai/responses/transformation.py
+++ b/litellm/llms/openai/responses/transformation.py
@@ -13,6 +13,7 @@ from litellm.litellm_core_utils.core_helpers import process_response_headers
 from litellm.litellm_core_utils.llm_response_utils.convert_dict_to_response import (
     _safe_convert_created_field,
 )
+from litellm.litellm_core_utils.safe_json_loads import safe_json_loads
 from litellm.litellm_core_utils.url_utils import encode_url_path_segment
 from litellm.llms.base_llm.responses.transformation import BaseResponsesAPIConfig
 from litellm.llms.openai.chat.gpt_5_transformation import is_gpt_reasoning_series_name
@@ -205,29 +206,76 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
         `remove_cache_control_flag_from_messages_and_tools`; mirror that here.
         """
 
-        input = self._validate_input_param(input)
-        tools = response_api_optional_request_params.get("tools")
-        input, tools = self.remove_cache_control_flag_from_input_and_tools(model=model, input=input, tools=tools)
-        sanitized_tools: Final = self._flatten_tool_schema_combinators_for_openai(
-            model=model, tools=tools, litellm_params=litellm_params
+        replay_safe_input, sanitized_tools = self._prepared_input_and_tools(
+            model=model,
+            input=input,
+            tools=response_api_optional_request_params.get("tools"),
+            litellm_params=litellm_params,
         )
         if sanitized_tools is not None:
             response_api_optional_request_params["tools"] = sanitized_tools
-        replay_safe_input: Final = self._drop_foreign_tool_call_item_ids(input)
         final_request_params: Final = dict(
             ResponsesAPIRequestParams(model=model, input=replay_safe_input, **response_api_optional_request_params)
         )
 
         return final_request_params
 
+    def _prepared_input_and_tools(
+        self,
+        model: str,
+        input: str | ResponseInputParam,
+        tools: Sequence[ALL_RESPONSES_API_TOOL_PARAMS] | None,
+        litellm_params: GenericLiteLLMParams,
+    ) -> tuple[str | ResponseInputParam, Sequence[ALL_RESPONSES_API_TOOL_PARAMS] | None]:
+        validated_input: Final = self._validate_input_param(input)
+        stripped_input, stripped_tools = self.remove_cache_control_flag_from_input_and_tools(
+            model=model, input=validated_input, tools=tools
+        )
+        object_schema_tools: Final = self._tools_with_object_parameters(model=model, tools=stripped_tools)
+        sanitized_tools: Final = self._flatten_tool_schema_combinators_for_openai(
+            model=model, tools=object_schema_tools, litellm_params=litellm_params
+        )
+        return self._drop_foreign_tool_call_item_ids(stripped_input), sanitized_tools
+
+    def _tools_with_object_parameters(
+        self, model: str, tools: Sequence[ALL_RESPONSES_API_TOOL_PARAMS] | None
+    ) -> Sequence[ALL_RESPONSES_API_TOOL_PARAMS] | None:
+        """Callers sometimes hand a tool schema over already JSON-encoded. The Responses
+        validator rejects that with a 400 naming the routed model rather than the tool, so
+        decode it here and refuse anything that is neither an object nor a string encoding one."""
+        if tools is None:
+            return None
+        decoded: Final = [  # mutable-ok: request tools are a JSON list
+            self._tool_with_object_parameters(model=model, index=index, tool=tool) for index, tool in enumerate(tools)
+        ]
+        return cast("Sequence[ALL_RESPONSES_API_TOOL_PARAMS]", decoded)  # cast-ok: dict spread keeps each tool's shape
+
+    def _tool_with_object_parameters(self, model: str, index: int, tool: object) -> object:
+        if not isinstance(tool, dict) or tool.get("parameters") is None:
+            return tool
+        parameters: Final = tool["parameters"]
+        if isinstance(parameters, dict):
+            return tool
+        decoded: Final = safe_json_loads(parameters) if isinstance(parameters, str) else None
+        if isinstance(decoded, dict):
+            return {**tool, "parameters": decoded}  # mutable-ok: request tools are JSON dicts
+        raise litellm.BadRequestError(
+            message=(
+                f"Invalid type for 'tools[{index}].parameters': expected an object, "
+                f"but got {type(parameters).__name__} instead."
+            ),
+            model=model,
+            llm_provider=self.custom_llm_provider,
+        )
+
     def remove_cache_control_flag_from_input_and_tools(
         self,
         model: str,  # allows overrides to selectively run this
         input: str | ResponseInputParam,
-        tools: list[ALL_RESPONSES_API_TOOL_PARAMS] | None = None,
+        tools: Sequence[ALL_RESPONSES_API_TOOL_PARAMS] | None = None,
     ) -> tuple[
         str | ResponseInputParam,
-        list[ALL_RESPONSES_API_TOOL_PARAMS] | None,
+        Sequence[ALL_RESPONSES_API_TOOL_PARAMS] | None,
     ]:
         """Sibling of `remove_cache_control_flag_from_messages_and_tools` on
         the chat path. Strips Anthropic-only `cache_control` markers from
@@ -272,9 +320,9 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
     def _flatten_tool_schema_combinators_for_openai(
         self,
         model: str,
-        tools: list[ALL_RESPONSES_API_TOOL_PARAMS] | None,  # mutable-ok: request tools are a JSON list
+        tools: Sequence[ALL_RESPONSES_API_TOOL_PARAMS] | None,
         litellm_params: GenericLiteLLMParams,
-    ) -> list[ALL_RESPONSES_API_TOOL_PARAMS] | None:  # mutable-ok: request tools are a JSON list
+    ) -> Sequence[ALL_RESPONSES_API_TOOL_PARAMS] | None:
         """Flatten top-level schema combinators only where OpenAI's validator rejects them.
 
         OpenAI-compatible backends reusing this config (and the ChatGPT backend
@@ -293,7 +341,7 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
         flattened: Final = [  # mutable-ok: request tools are a JSON list
             self._flattened_tool_or_passthrough(tool) for tool in tools
         ]
-        return cast("list[ALL_RESPONSES_API_TOOL_PARAMS]", flattened)  # cast-ok: dict spread keeps each tool's shape
+        return cast("Sequence[ALL_RESPONSES_API_TOOL_PARAMS]", flattened)  # cast-ok: spread keeps each tool's shape
 
     @staticmethod
     def _flattened_tool_or_passthrough(tool: object) -> object:
@@ -786,15 +834,14 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
         compact_path: Final = parsed_url.path.rstrip("/") + "/compact"
         url: Final = str(parsed_url.copy_with(path=compact_path))
 
-        input = self._validate_input_param(input)
-        tools = response_api_optional_request_params.get("tools")
-        input, tools = self.remove_cache_control_flag_from_input_and_tools(model=model, input=input, tools=tools)
-        sanitized_tools: Final = self._flatten_tool_schema_combinators_for_openai(
-            model=model, tools=tools, litellm_params=litellm_params
+        replay_safe_input, sanitized_tools = self._prepared_input_and_tools(
+            model=model,
+            input=input,
+            tools=response_api_optional_request_params.get("tools"),
+            litellm_params=litellm_params,
         )
         if sanitized_tools is not None:
             response_api_optional_request_params["tools"] = sanitized_tools
-        replay_safe_input: Final = self._drop_foreign_tool_call_item_ids(input)
         data: Final = dict(
             ResponsesAPIRequestParams(model=model, input=replay_safe_input, **response_api_optional_request_params)
         )

--- a/tests/test_litellm/llms/openai/responses/test_openai_responses_transformation.py
+++ b/tests/test_litellm/llms/openai/responses/test_openai_responses_transformation.py
@@ -307,10 +307,8 @@ class TestOpenAIResponsesAPIConfig:
             '{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}',
         ],
     )
-    def test_transform_decodes_json_string_tool_parameters(self, raw_parameters):
-        """A caller that hands the tool schema over already JSON-encoded must still reach the
-        provider with an object, since the Responses validator rejects a string with a 400 that
-        names the routed model rather than the offending tool."""
+    def test_transform_decodes_json_string_tool_parameters(self, raw_parameters: str):
+        """A JSON-encoded schema must reach the provider as an object."""
         result = self.config.transform_responses_api_request(
             model=self.model,
             input="weather in Paris",
@@ -343,9 +341,8 @@ class TestOpenAIResponsesAPIConfig:
         assert data["tools"][0]["parameters"] == {"type": "object"}
 
     @pytest.mark.parametrize("raw_parameters", ['"just a string"', "not json at all", "[1, 2, 3]", 42])
-    def test_transform_rejects_tool_parameters_that_are_not_an_object(self, raw_parameters):
-        """Anything that is neither an object nor a string encoding one is a client error, and
-        litellm names the tool index so the caller can find it."""
+    def test_transform_rejects_tool_parameters_that_are_not_an_object(self, raw_parameters: object):
+        """Neither an object nor a string encoding one is a client error naming the tool index."""
         with pytest.raises(litellm.BadRequestError) as exc_info:
             self.config.transform_responses_api_request(
                 model=self.model,
@@ -362,12 +359,13 @@ class TestOpenAIResponsesAPIConfig:
 
         assert "tools[1].parameters" in str(exc_info.value)
 
-    def test_transform_leaves_object_and_absent_tool_parameters_untouched(self):
-        """Decoding must not disturb the shapes that already work: a real object schema, a tool
-        carrying no parameters at all, and a built-in tool with no function shape."""
+    def test_transform_leaves_object_null_and_absent_tool_parameters_untouched(self):
+        """The API accepts an object schema, an explicit null, an omitted schema and a built-in
+        tool, so decoding must forward all four unchanged rather than raising."""
         schema = {"type": "object", "properties": {"city": {"type": "string"}}}
         tools = [
             {"type": "function", "name": "get_weather", "parameters": schema},
+            {"type": "function", "name": "null_args", "parameters": None},
             {"type": "function", "name": "no_args"},
             {"type": "web_search_preview"},
         ]
@@ -381,8 +379,9 @@ class TestOpenAIResponsesAPIConfig:
         )
 
         assert result["tools"][0]["parameters"] == schema
-        assert "parameters" not in result["tools"][1]
-        assert result["tools"][2] == {"type": "web_search_preview"}
+        assert result["tools"][1]["parameters"] is None
+        assert "parameters" not in result["tools"][2]
+        assert result["tools"][3] == {"type": "web_search_preview"}
 
     def test_transform_compact_drops_foreign_tool_call_item_ids(self):
         """The compact request path replays input the same way, so it must
@@ -949,8 +948,7 @@ class TestAzureResponsesAPIConfig:
         self.logging_obj = MagicMock()
 
     def test_azure_decodes_json_string_tool_parameters(self):
-        """Azure reaches the same wire through `super()`, and it is the provider the report came
-        from, so the decode must hold after Azure un-nests a chat-shaped tool."""
+        """Azure reaches the same wire through `super()`, after un-nesting a chat-shaped tool."""
         result = self.config.transform_responses_api_request(
             model=self.model,
             input="weather in Paris",

--- a/tests/test_litellm/llms/openai/responses/test_openai_responses_transformation.py
+++ b/tests/test_litellm/llms/openai/responses/test_openai_responses_transformation.py
@@ -300,6 +300,90 @@ class TestOpenAIResponsesAPIConfig:
 
         assert result["input"][0]["id"] == "toolu_01Foreign"
 
+    @pytest.mark.parametrize(
+        "raw_parameters",
+        [
+            '{"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}',
+            '{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}',
+        ],
+    )
+    def test_transform_decodes_json_string_tool_parameters(self, raw_parameters):
+        """A caller that hands the tool schema over already JSON-encoded must still reach the
+        provider with an object, since the Responses validator rejects a string with a 400 that
+        names the routed model rather than the offending tool."""
+        result = self.config.transform_responses_api_request(
+            model=self.model,
+            input="weather in Paris",
+            response_api_optional_request_params={
+                "tools": [{"type": "function", "name": "get_weather", "parameters": raw_parameters}]
+            },
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+
+        assert result["tools"][0]["parameters"] == {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+        }
+
+    def test_transform_decodes_json_string_tool_parameters_on_compact_request(self):
+        """The compact request path builds the same wire body, so it must decode too."""
+        _url, data = self.config.transform_compact_response_api_request(
+            model=self.model,
+            input="weather in Paris",
+            response_api_optional_request_params={
+                "tools": [{"type": "function", "name": "get_weather", "parameters": '{"type": "object"}'}]
+            },
+            api_base="https://api.openai.com/v1/responses",
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+
+        assert data["tools"][0]["parameters"] == {"type": "object"}
+
+    @pytest.mark.parametrize("raw_parameters", ['"just a string"', "not json at all", "[1, 2, 3]", 42])
+    def test_transform_rejects_tool_parameters_that_are_not_an_object(self, raw_parameters):
+        """Anything that is neither an object nor a string encoding one is a client error, and
+        litellm names the tool index so the caller can find it."""
+        with pytest.raises(litellm.BadRequestError) as exc_info:
+            self.config.transform_responses_api_request(
+                model=self.model,
+                input="weather in Paris",
+                response_api_optional_request_params={
+                    "tools": [
+                        {"type": "web_search_preview"},
+                        {"type": "function", "name": "get_weather", "parameters": raw_parameters},
+                    ]
+                },
+                litellm_params=GenericLiteLLMParams(),
+                headers={},
+            )
+
+        assert "tools[1].parameters" in str(exc_info.value)
+
+    def test_transform_leaves_object_and_absent_tool_parameters_untouched(self):
+        """Decoding must not disturb the shapes that already work: a real object schema, a tool
+        carrying no parameters at all, and a built-in tool with no function shape."""
+        schema = {"type": "object", "properties": {"city": {"type": "string"}}}
+        tools = [
+            {"type": "function", "name": "get_weather", "parameters": schema},
+            {"type": "function", "name": "no_args"},
+            {"type": "web_search_preview"},
+        ]
+
+        result = self.config.transform_responses_api_request(
+            model=self.model,
+            input="weather in Paris",
+            response_api_optional_request_params={"tools": tools},
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+
+        assert result["tools"][0]["parameters"] == schema
+        assert "parameters" not in result["tools"][1]
+        assert result["tools"][2] == {"type": "web_search_preview"}
+
     def test_transform_compact_drops_foreign_tool_call_item_ids(self):
         """The compact request path replays input the same way, so it must
         apply the same id drop."""
@@ -863,6 +947,21 @@ class TestAzureResponsesAPIConfig:
         self.config = AzureOpenAIResponsesAPIConfig()
         self.model = "gpt-4o"
         self.logging_obj = MagicMock()
+
+    def test_azure_decodes_json_string_tool_parameters(self):
+        """Azure reaches the same wire through `super()`, and it is the provider the report came
+        from, so the decode must hold after Azure un-nests a chat-shaped tool."""
+        result = self.config.transform_responses_api_request(
+            model=self.model,
+            input="weather in Paris",
+            response_api_optional_request_params={
+                "tools": [{"type": "function", "function": {"name": "get_weather", "parameters": '{"type":"object"}'}}]
+            },
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+
+        assert result["tools"][0]["parameters"] == {"type": "object"}
 
     def test_azure_get_complete_url_with_version_types(self):
         """Test Azure get_complete_url with different API version types"""

--- a/type-discipline-budget.json
+++ b/type-discipline-budget.json
@@ -1,9 +1,9 @@
 {
   "LIT001": {
-    "limit": 22324
+    "limit": 22181
   },
   "LIT002": {
-    "limit": 26748
+    "limit": 26745
   },
   "LIT003": {
     "limit": 261
@@ -15,7 +15,7 @@
     "limit": 0
   },
   "LIT006": {
-    "limit": 1038
+    "limit": 1035
   },
   "LIT007": {
     "limit": 0
@@ -30,9 +30,9 @@
     "limit": 16464
   },
   "LIT011": {
-    "limit": 5508
+    "limit": 5506
   },
   "LIT012": {
-    "limit": 4487
+    "limit": 4486
   }
 }

--- a/type-discipline-budget.json
+++ b/type-discipline-budget.json
@@ -1,9 +1,9 @@
 {
   "LIT001": {
-    "limit": 22183
+    "limit": 22324
   },
   "LIT002": {
-    "limit": 26745
+    "limit": 26748
   },
   "LIT003": {
     "limit": 261
@@ -15,7 +15,7 @@
     "limit": 0
   },
   "LIT006": {
-    "limit": 1035
+    "limit": 1038
   },
   "LIT007": {
     "limit": 0
@@ -27,12 +27,12 @@
     "limit": 0
   },
   "LIT010": {
-    "limit": 16468
+    "limit": 16464
   },
   "LIT011": {
-    "limit": 5510
+    "limit": 5508
   },
   "LIT012": {
-    "limit": 4486
+    "limit": 4487
   }
 }


### PR DESCRIPTION
## TLDR

Problem this solves:

- A tool schema sent as a JSON string reached the provider verbatim
- Provider 400 named the routed model, not the offending tool
- Surfaced through the 1M Context auto-router preset on an Azure GPT tier

How it solves it:

- Decode a string `parameters` that parses to an object before the wire
- Reject anything else with a litellm 400 naming `tools[i].parameters`
- One owner for the request and compact-request tool sanitization

## User Flow

Before: a developer whose coding agent defines a tool with a JSON-encoded schema gets an opaque provider error blaming the model tier

1. They send POST https://litellm-domain/v1/messages to their 1M Context auto-router with `tools[0].input_schema` set to the string `"{\"type\":\"object\",...}"`
2. The request classifies SIMPLE and lands on the gpt-5.6-luna tier
3. They get back HTTP 400: `AzureException BadRequestError - Invalid type for 'tools[0].parameters': expected an object, but got a string instead. Received Model Group=gpt-5.6-luna`
4. They read that as a broken preset and file it against the router

After: the same request succeeds, and a genuinely malformed schema gets an error that points at the tool

1. They send the same POST https://litellm-domain/v1/messages with the same string `input_schema`
2. The request classifies SIMPLE and lands on the gpt-5.6-luna tier
3. They get back HTTP 200 with a `tool_use` block for the tool they defined
4. If the string does not decode to an object, they get HTTP 400 `litellm.BadRequestError: Invalid type for 'tools[0].parameters': expected an object, but got str instead` from the gateway itself, before any provider call

## Relevant issues

## Linear ticket

Resolves LIT-6991

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Local proxy on `:4733` from this worktree, real Postgres, deployments `gpt-5.6-luna` / `gpt-5.6-terra` / `gpt-5.6-sol` / `claude-opus-5` registered against a live gateway as upstream, plus `my-1m-router`, an auto-router with the 1M Context preset's tiers. Every run below is a real paid model call. The customer's Azure resource is not reachable from this box (every deployment 404s), so the upstream here is the same model family behind OpenAI's Responses validator, which emits the byte-identical `Invalid type for 'tools[0].parameters'` error. The only variable between Before and After is the source tree

Shared payload: a `get_weather` tool whose schema is the JSON string `"{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\"}},\"required\":[\"city\"]}"`, and a control request with the same schema as an object. Both arms were captured with the same `repro.sh` and `chatbridge.sh`, differing only in the checked-out source

### Before (59d42d36e6)

#### /v1/responses, string parameters

1. `curl -X POST http://127.0.0.1:4733/v1/responses -d '{"model":"gpt-5.6-luna","input":"weather in Paris","tools":[{"type":"function","name":"get_weather","parameters":"<string schema>"}]}'`
2. HTTP 400: `Invalid type for 'tools[0].parameters': expected an object, but got a string instead.`

#### /v1/messages, string input_schema

1. `curl -X POST http://127.0.0.1:4733/v1/messages -d '{"model":"gpt-5.6-luna","max_tokens":64,"messages":[{"role":"user","content":"weather in Paris"}],"tools":[{"name":"get_weather","description":"w","input_schema":"<string schema>"}]}'`
2. HTTP 400: `Invalid type for 'tools[0].parameters': expected an object, but got a string instead.`

#### /v1/messages through the 1M Context auto-router

1. Same body as above with `"model":"my-1m-router"` and content `"hi"` so it classifies SIMPLE
2. HTTP 400: `Invalid type for 'tools[0].parameters': expected an object, but got a string instead.` This is the customer's exact report

#### /v1/chat/completions bridged to Responses, nested string parameters

1. `curl -X POST http://127.0.0.1:4733/v1/chat/completions -d '{"model":"luna-responses-mode","messages":[{"role":"user","content":"weather in Paris"}],"tools":[{"type":"function","function":{"name":"get_weather","parameters":"<string schema>"}}]}'` (deployment declares `model_info.mode: responses`)
2. HTTP 400: `Invalid type for 'tools[0].parameters': expected an object, but got a string instead.` Note the error names the flat `tools[0].parameters` even though the request nested it under `function`, which is how the customer's report ended up with that shape

#### Controls, object schema

1. Same `/v1/responses` and `/v1/messages` requests with the schema as an object
2. HTTP 200 on both, `/v1/messages` returns a `tool_use` block

### After (6140d881f8)

#### /v1/responses, string parameters

1. Identical curl
2. HTTP 200, `id: resp_84m6-zTsfRUQYDA...`, `model: gpt-5.6-luna`, `output: [function_call]`

#### /v1/messages, string input_schema

1. Identical curl
2. HTTP 200, `model: gpt-5.6-luna`, `output: [tool_use]`

#### /v1/messages through the 1M Context auto-router

1. Identical curl
2. HTTP 200, `model: my-1m-router`, `output: [text]`

#### /v1/chat/completions bridged to Responses, nested string parameters

1. Identical curl
2. HTTP 200, `id: chatcmpl-a7d710d8-35...`, `finish_reason: tool_calls`, tool call `get_weather`

#### Controls, object schema

1. Identical curls
2. HTTP 200 on both, unchanged from Before

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Nested Codex namespace `tools` arrays are not walked; only top-level entries decode
- The Anthropic Messages to chat/completions hop (`adapters/transformation.py`) copies `input_schema` the same way and its extra-key merge raises `AttributeError` on a string schema. Same class, different wire shape, not in this report, left as a follow-up
- A non-object schema that used to fail at the provider now fails inside litellm with the same status and wording, but the `type` name is Python's (`str`, `list`) rather than the provider's (`a string`, `an array`)
- `parameters: null` and an omitted schema are forwarded untouched, since the API accepts both; a live probe returned 200 for null, null with `strict: false`, and omitted

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Responses API outbound request shaping for tools, with clear validation and unit tests; no auth or persistence changes.
> 
> **Overview**
> Fixes Responses API requests where function tools carry **`parameters` as a JSON string** (common when agents pass stringified `input_schema`), which previously caused opaque provider 400s blaming the model.
> 
> **OpenAI Responses transformation** now runs tool prep through a shared **`_prepared_input_and_tools`** path for both normal and **`/compact`** requests. Before flattening schema combinators, it **parses string `parameters` into objects** via `safe_json_loads`; object, `null`, and omitted schemas are unchanged. Invalid values raise **`litellm.BadRequestError`** naming **`tools[i].parameters`** before any upstream call. Tool typing is widened to **`Sequence`** for the sanitization helpers.
> 
> Tests cover decode/reject/unchanged cases on standard and compact transforms, plus Azure after chat-shaped tool un-nesting. **`type-discipline-budget.json`** limits are nudged down slightly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6140d881f8c5b34c60949b656b7484fa7d69b06b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
