### PR TITLE
fix(datadog_llm_obs): keep guardrail_cost_by_unit on redacted spans

### DIFF
--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3096,7 +3096,7 @@ PROMPT_CARRYING_GUARDRAIL_FIELDS: Final[frozenset[str]] = frozenset(
 
 # The rest of the record: what the guardrail is, what it decided, how long it took and what it cost.
 # None of these reproduce the prompt, so a redacted record keeps them and stays explainable.
-# `test_every_guardrail_field_is_classified` fails if a field is added to the record without being
+# `test_a_redacted_span_carries_every_declared_guardrail_field` fails if a field is added to the record without being
 # placed in one set or the other, so a new field is dropped from redacted records rather than
 # shipped unexamined.
 AUDIT_GUARDRAIL_FIELDS: Final[frozenset[str]] = frozenset(
@@ -3120,6 +3120,7 @@ AUDIT_GUARDRAIL_FIELDS: Final[frozenset[str]] = frozenset(
         "guardrail_action",
         "guardrail_usage",
         "guardrail_cost",
+        "guardrail_cost_by_unit",
         "guardrail_cost_in_spend",
     }
 )


### PR DESCRIPTION
## TLDR

Problem this solves:

- Every fresh PR's `integrations / Run tests` job fails on staging since 01:24Z
- `guardrail_cost_by_unit` was never classified for redacted Datadog spans
- Redacted Datadog LLM Observability spans silently drop the per-counter guardrail cost

How it solves it:

- Classifies `guardrail_cost_by_unit` as an audit field, kept under redaction
- Points the block comment at the test that actually enforces the classification

#39196 added `guardrail_cost_by_unit` to the guardrail record and #39702 added the allow-list that decides what a redacted Datadog span keeps, plus a test that fails for any record field with no decision. Each PR's CI ran on a merge ref that predated the other, so staging only broke once both had landed

## User Flow

Before: an operator who redacts prompts in Datadog LLM Observability sees each guardrail's total cost on the span but never its per-counter split

1. The proxy admin runs the proxy with `callbacks: ["datadog_llm_obs"]`, `turn_off_message_logging: true`, and a Bedrock guardrail that has pricing configured
2. A developer sends POST https://litellm-domain/v1/chat/completions with a prompt the guardrail evaluates and gets a 200 back
3. The operator opens that request's span at https://app.datadoghq.com/llm/traces and expands the guardrail entry under the span's metadata
4. The entry shows `guardrail_cost` and `guardrail_usage`, and the prompt-carrying fields read `REDACTED_BY_LITELM`, but `guardrail_cost_by_unit` is absent, so the cost cannot be reconciled per usage counter

After: the same span carries the per-counter cost split next to the total

1. The proxy admin runs the proxy with `callbacks: ["datadog_llm_obs"]`, `turn_off_message_logging: true`, and a Bedrock guardrail that has pricing configured
2. A developer sends POST https://litellm-domain/v1/chat/completions with a prompt the guardrail evaluates and gets a 200 back
3. The operator opens that request's span at https://app.datadoghq.com/llm/traces and expands the guardrail entry under the span's metadata
4. The entry now shows `guardrail_cost_by_unit` with one cost per usage counter alongside `guardrail_cost` and `guardrail_usage`, while the prompt-carrying fields still read `REDACTED_BY_LITELM`

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests (the regression test already exists: `test_a_redacted_span_carries_every_declared_guardrail_field` from #39702 is what fails before this PR and passes after it)
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The observable surface is the span JSON the Datadog logger serializes, which the existing test builds through the real logger with redaction on, so the run below is that serializer's output plus the CI job every PR now hits

### Before (853fed824e)

1. Any PR opened or pushed after 01:24Z runs `integrations / Run tests` on a merge ref carrying both #39196 and #39702, and fails, e.g. #39553 at b5e5212f3b ([job](https://github.com/BerriAI/litellm/actions/runs/33936422830/job/101225135210)):

```
FAILED tests/test_litellm/integrations/datadog/test_datadog_llm_obs.py::test_a_redacted_span_carries_every_declared_guardrail_field - AssertionError: assert {'guardrail_name', 'end_time', 'guardrail_usage', ..., 'guardrail_cost', 'risk_score', 'guardrail_provider', 'violation_categories', 'patterns_checked'} == {..., 'guardrail_cost_by_unit', ...}
= 1 failed, 3411 passed, 3 skipped, 210 warnings, 2 subtests passed, 3 rerun in 164.77s (0:02:44) =
```

2. The same serializer at staging's tip locally:

```
$ uv run pytest tests/test_litellm/integrations/datadog/test_datadog_llm_obs.py -k redacted_span_carries_every_declared -q
FAILED tests/test_litellm/integrations/datadog/test_datadog_llm_obs.py::test_a_redacted_span_carries_every_declared_guardrail_field
1 failed, 67 deselected in 0.81s
```

### After (d4fd658891)

1. This PR's own `integrations / Run tests` jobs pass: `integrations / Run tests` shards on this PR: [default](https://github.com/BerriAI/litellm/actions/runs/33937228263/job/101227400304), [3.10](https://github.com/BerriAI/litellm/actions/runs/33937228263/job/101227400329), [3.11](https://github.com/BerriAI/litellm/actions/runs/33937228263/job/101227400345), [3.13](https://github.com/BerriAI/litellm/actions/runs/33937228263/job/101227400269), [3.14](https://github.com/BerriAI/litellm/actions/runs/33937228263/job/101227400321), all passing

2. The same serializer at this tip locally, whole Datadog file:

```
$ uv run pytest tests/test_litellm/integrations/datadog/test_datadog_llm_obs.py -q
68 passed, 31 warnings in 1.86s
```

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Verified at the span-serializer and CI level, not against a live Datadog intake; the redacted record is the same object either way
- #39702's CI passed because its merge ref predated #39196 landing; without a merge queue the ruleset cannot catch this pairing
- Low: the non-required CircleCI job `proxy_store_model_in_db_tests` is red on this PR at `tests/store_model_in_db_tests/test_openai_error_handling.py::test_chat_completion_bad_model_with_spend_logs` (`assert '' == 'non-existent-model'`). It is red on 10 of the 15 `run-ci` PRs updated today and is tracked as its own fix in #39842, so it is unrelated to this change

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single allow-list entry for observability redaction; no auth, spend logic, or prompt-field handling changes.
> 
> **Overview**
> Adds **`guardrail_cost_by_unit`** to **`AUDIT_GUARDRAIL_FIELDS`** in `litellm/types/utils.py`, so Datadog LLM Observability redaction treats per-counter guardrail cost as non-prompt audit data and **keeps it on redacted spans** alongside totals like `guardrail_cost` and `guardrail_usage`.
> 
> Updates the guardrail field-classification comment to reference **`test_a_redacted_span_carries_every_declared_guardrail_field`**, which enforces that every declared guardrail field is either prompt-carrying or audit. Without this entry, redacted span serialization dropped `guardrail_cost_by_unit` and CI failed once that field existed on the guardrail record.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4fd658891dde94b12518541da20feda35b2c6c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

- [x] d4fd658891 passes /live-pr-risk: the only consumer of `AUDIT_GUARDRAIL_FIELDS` is `_CLASSIFIED_GUARDRAIL_FIELDS` feeding the redaction filter in datadog_llm_obs.py; `PROMPT_CARRYING_GUARDRAIL_FIELDS` and the spend-log redaction in spend_tracking_utils.py are untouched; the field's three producers (guardrail_cost.py, bedrock_guardrails.py, usage_tracking.py) and their tests are unchanged; on this tip tests/test_litellm/integrations/datadog/test_datadog_llm_obs.py goes from the one failing test at base to 68 passed; not verified live: Datadog intake of the redacted span, which already receives this field on unredacted spans
