### PR TITLE
fix(realtime): relay the upstream websocket close to the client instead of hanging

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1820,6 +1820,7 @@ class Logging(LiteLLMLoggingBaseClass):
             and litellm_params.get(CallTypes.aanthropic_messages.value, False) is not True
             and litellm_params.get(CallTypes.agenerate_content.value, False) is not True
             and litellm_params.get(CallTypes.agenerate_content_stream.value, False) is not True
+            and litellm_params.get(CallTypes.arealtime.value, False) is not True
         )
 
     def _is_assembled_stream_success(self, result=None) -> bool:

--- a/litellm/litellm_core_utils/realtime_errors.py
+++ b/litellm/litellm_core_utils/realtime_errors.py
@@ -29,3 +29,11 @@ def websocket_close_reason(message: str, fallback: str) -> str:
     if len(encoded) <= WEBSOCKET_CLOSE_REASON_MAX_BYTES:
         return message
     return encoded[:WEBSOCKET_CLOSE_REASON_MAX_BYTES].decode("utf-8", errors="ignore")
+
+
+def client_close_code(upstream_code: int) -> int:
+    from websockets.frames import EXTERNAL_CLOSE_CODES, CloseCode
+
+    if upstream_code in EXTERNAL_CLOSE_CODES or 3000 <= upstream_code < 5000:
+        return upstream_code
+    return int(CloseCode.INTERNAL_ERROR)

--- a/litellm/litellm_core_utils/realtime_streaming.py
+++ b/litellm/litellm_core_utils/realtime_streaming.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Final, NoReturn, Protocol, TypedDict, cas
 from typing_extensions import ReadOnly
 
 import litellm
-from litellm._logging import _redact_string, verbose_logger
+from litellm._logging import redact_internal_details_from_client_message, verbose_logger
 from litellm.litellm_core_utils.logging_worker import GLOBAL_LOGGING_WORKER
 from litellm.llms.base_llm.realtime.transformation import BaseRealtimeConfig
 from litellm.types.llms.openai import (
@@ -1567,8 +1567,8 @@ class RealTimeStreaming:
             await asyncio.gather(forward_task, client_task, return_exceptions=True)
 
     async def _close_client(self, close: BackendClose) -> None:
-        redacted_message: Final = _redact_string(close.message)
-        redacted_reason: Final = _redact_string(close.reason)
+        redacted_message: Final = redact_internal_details_from_client_message(close.message)
+        redacted_reason: Final = redact_internal_details_from_client_message(close.reason)
         try:
             if close.code != 1000:
                 await self.websocket.send_text(realtime_error_event(redacted_message, error_type="server_error"))

--- a/litellm/litellm_core_utils/realtime_streaming.py
+++ b/litellm/litellm_core_utils/realtime_streaming.py
@@ -1135,7 +1135,7 @@ class RealTimeStreaming:
             return BackendClose(code=1011, reason="proxy failed while relaying the upstream websocket")
 
     def _backend_refused_session(self, close: BackendClose) -> bool:
-        return close.code != 1000 and not self._backend_sent_frames and not self.messages
+        return close.code != 1000 and not self._backend_sent_frames
 
     async def log_backend_refusal(self, error: Exception) -> None:
         if not self.logging_obj:

--- a/litellm/litellm_core_utils/realtime_streaming.py
+++ b/litellm/litellm_core_utils/realtime_streaming.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Final, NoReturn, Protocol, TypedDict, cas
 from typing_extensions import ReadOnly
 
 import litellm
-from litellm._logging import verbose_logger
+from litellm._logging import _redact_string, verbose_logger
 from litellm.litellm_core_utils.logging_worker import GLOBAL_LOGGING_WORKER
 from litellm.llms.base_llm.realtime.transformation import BaseRealtimeConfig
 from litellm.types.llms.openai import (
@@ -1567,12 +1567,14 @@ class RealTimeStreaming:
             await asyncio.gather(forward_task, client_task, return_exceptions=True)
 
     async def _close_client(self, close: BackendClose) -> None:
+        redacted_message: Final = _redact_string(close.message)
+        redacted_reason: Final = _redact_string(close.reason)
         try:
             if close.code != 1000:
-                await self.websocket.send_text(realtime_error_event(close.message, error_type="server_error"))
+                await self.websocket.send_text(realtime_error_event(redacted_message, error_type="server_error"))
             await self.websocket.close(
                 code=client_close_code(close.code),
-                reason=websocket_close_reason(close.reason, fallback=close.message),
+                reason=websocket_close_reason(redacted_reason, fallback=redacted_message),
             )
         except Exception as e:  # noqa: BLE001  # the client may already be gone; the session is over either way
             verbose_logger.debug("Could not relay the upstream close to the client: %s", e)

--- a/litellm/litellm_core_utils/realtime_streaming.py
+++ b/litellm/litellm_core_utils/realtime_streaming.py
@@ -1297,13 +1297,22 @@ class RealTimeStreaming:
         item["content"] = new_content
         return item
 
+    async def _receive_client_message(self) -> str | None:
+        try:
+            return await self.websocket.receive_text()
+        except Exception as e:  # noqa: BLE001  # whatever the client socket raises, the client is gone
+            verbose_logger.debug("Client disconnected: %s", e)
+            return None
+
     async def client_ack_messages(self) -> ClientLoopExit:
         import websockets
 
         client_event: _ClientEventFrame
         try:
             while True:
-                message = await self.websocket.receive_text()
+                message = await self._receive_client_message()
+                if message is None:
+                    return ClientLoopExit.CLIENT_DISCONNECTED
 
                 ## GUARDRAIL: intercept conversation.item.create for text-based injection.
                 guardrail_turn_detection_injected = False

--- a/litellm/litellm_core_utils/realtime_streaming.py
+++ b/litellm/litellm_core_utils/realtime_streaming.py
@@ -3,6 +3,7 @@ import json
 import traceback
 from collections.abc import Coroutine, Mapping, Sequence
 from dataclasses import dataclass
+from enum import Enum, auto
 from typing import TYPE_CHECKING, Any, Final, NoReturn, Protocol, TypedDict, cast
 
 from typing_extensions import ReadOnly
@@ -44,6 +45,11 @@ class BackendClose:
         if not self.reason:
             return f"upstream websocket closed with code {self.code}"
         return f"upstream websocket closed with code {self.code}: {self.reason}"
+
+
+class ClientLoopExit(Enum):
+    CLIENT_DISCONNECTED = auto()
+    BACKEND_CLOSED = auto()
 
 
 def backend_close_from(error: "ConnectionClosed") -> BackendClose:
@@ -1291,7 +1297,9 @@ class RealTimeStreaming:
         item["content"] = new_content
         return item
 
-    async def client_ack_messages(self):
+    async def client_ack_messages(self) -> ClientLoopExit:
+        import websockets
+
         client_event: _ClientEventFrame
         try:
             while True:
@@ -1529,16 +1537,21 @@ class RealTimeStreaming:
                 if guardrail_turn_detection_injected and sent:
                     self._guardrail_turn_detection_update_sent = True
 
+        except websockets.exceptions.ConnectionClosed as e:
+            verbose_logger.debug("Backend closed while forwarding a client message: %s", e)
+            return ClientLoopExit.BACKEND_CLOSED
         except Exception as e:
             verbose_logger.debug("Error in client ack messages: %s", e)
+            return ClientLoopExit.CLIENT_DISCONNECTED
 
     async def bidirectional_forward(self) -> None:
         forward_task: Final = asyncio.create_task(self.backend_to_client_send_messages())
         client_task: Final = asyncio.create_task(self.client_ack_messages())
         try:
             await asyncio.wait((forward_task, client_task), return_when=asyncio.FIRST_COMPLETED)
-            if not client_task.done():
-                await self._close_client(forward_task.result())
+            if client_task.done() and client_task.result() is ClientLoopExit.CLIENT_DISCONNECTED:
+                return
+            await self._close_client(await forward_task)
         finally:
             forward_task.cancel()
             client_task.cancel()

--- a/litellm/litellm_core_utils/realtime_streaming.py
+++ b/litellm/litellm_core_utils/realtime_streaming.py
@@ -35,6 +35,9 @@ else:
     CLIENT_CONNECTION_CLASS = Any
 
 
+REALTIME_SESSION_SUCCESS_LOGGED_KEY: Final = "realtime_session_success_logged"
+
+
 @dataclass(frozen=True, slots=True)
 class BackendClose:
     code: int
@@ -421,6 +424,7 @@ class RealTimeStreaming:
             self._logging_worker.ensure_initialized_and_enqueue(
                 self.logging_obj.dispatch_success_handlers(self.messages, prefer_async_handlers=True)
             )
+            self.logging_obj.model_call_details[REALTIME_SESSION_SUCCESS_LOGGED_KEY] = True
 
     async def _send_to_backend(self, message: str) -> bool:
         """Send a message to the backend WebSocket.

--- a/litellm/litellm_core_utils/realtime_streaming.py
+++ b/litellm/litellm_core_utils/realtime_streaming.py
@@ -1,7 +1,9 @@
 import asyncio
 import json
-from collections.abc import Mapping, Sequence
-from typing import TYPE_CHECKING, Any, Final, Protocol, TypedDict, cast
+import traceback
+from collections.abc import Coroutine, Mapping, Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Final, NoReturn, Protocol, TypedDict, cast
 
 from typing_extensions import ReadOnly
 
@@ -19,9 +21,11 @@ from litellm.types.llms.openai import (
 from litellm.types.realtime import ALL_DELTA_TYPES
 
 from .litellm_logging import Logging as LiteLLMLogging
+from .realtime_errors import client_close_code, realtime_error_event, websocket_close_reason
 
 if TYPE_CHECKING:
     from websockets.asyncio.client import ClientConnection
+    from websockets.exceptions import ConnectionClosed
 
     from litellm.types.guardrails import GuardrailEventHooks
 
@@ -30,8 +34,22 @@ else:
     CLIENT_CONNECTION_CLASS = Any
 
 
-class _ClientWebSocketExceptions(Protocol):
-    ConnectionClosed: type[Exception]
+@dataclass(frozen=True, slots=True)
+class BackendClose:
+    code: int
+    reason: str
+
+    @property
+    def message(self) -> str:
+        if not self.reason:
+            return f"upstream websocket closed with code {self.code}"
+        return f"upstream websocket closed with code {self.code}: {self.reason}"
+
+
+def backend_close_from(error: "ConnectionClosed") -> BackendClose:
+    if error.rcvd is None:
+        return BackendClose(code=1006, reason=str(error))
+    return BackendClose(code=error.rcvd.code, reason=error.rcvd.reason)
 
 
 class _ASGIScope(TypedDict, total=False):
@@ -69,10 +87,13 @@ class _ScopedWebSocket(Protocol):
 
 
 class _ClientWebSocket(_ScopedWebSocket, Protocol):
-    exceptions: _ClientWebSocketExceptions
-
     async def send_text(self, data: str) -> None: ...
     async def receive_text(self) -> str: ...
+    async def close(self, code: int = 1000, reason: str | None = None) -> None: ...
+
+
+class _LoggingWorker(Protocol):
+    def ensure_initialized_and_enqueue(self, async_coroutine: Coroutine[object, object, None]) -> None: ...
 
 
 def _decode_json_object(payload: str) -> Mapping[str, object]:
@@ -108,11 +129,14 @@ class RealTimeStreaming:
         backend_uses_beta_protocol: bool | None = None,
         force_transcription_model: str | None = None,
         event_normalizer: RealtimeEventNormalizer | None = None,
+        logging_worker: _LoggingWorker = GLOBAL_LOGGING_WORKER,
     ):
         self.websocket: _ClientWebSocket = websocket
         self.backend_ws = backend_ws
         self.logging_obj = logging_obj
+        self._logging_worker = logging_worker
         self.messages: list[OpenAIRealtimeEvents] = []
+        self._backend_sent_frames: bool = False
         self.input_message: dict = {}
         self.input_messages: list[dict[str, str]] = []
         self.session_tools: list[dict] = []
@@ -388,7 +412,7 @@ class RealTimeStreaming:
             # Route through the bounded logging worker (per-coroutine timeout +
             # concurrency cap) instead of a bare create_task, so a slow callback
             # can't leave suspended tasks pinning each call's response in memory.
-            GLOBAL_LOGGING_WORKER.ensure_initialized_and_enqueue(
+            self._logging_worker.ensure_initialized_and_enqueue(
                 self.logging_obj.dispatch_success_handlers(self.messages, prefer_async_handlers=True)
             )
 
@@ -1035,60 +1059,84 @@ class RealTimeStreaming:
             return True
         return False
 
-    async def backend_to_client_send_messages(self):
+    async def _relay_backend_messages(self) -> NoReturn:
+        while True:
+            try:
+                raw_response = await self.backend_ws.recv(decode=False)
+            except TypeError:
+                raw_response = await self.backend_ws.recv()
+            self._backend_sent_frames = True
+
+            if isinstance(raw_response, bytes):
+                try:
+                    raw_response = raw_response.decode("utf-8")
+                except UnicodeDecodeError:
+                    verbose_logger.warning("Received non-UTF-8 binary frame from backend, skipping.")
+                    continue
+
+            if self.provider_config:
+                try:
+                    await self._handle_provider_config_message(raw_response)
+                except Exception as e:
+                    verbose_logger.exception("Error processing backend message, skipping: %s", e)
+                    continue
+            else:
+                event = self._parse_backend_event(raw_response)
+                if event is None:
+                    await self.websocket.send_text(raw_response)
+                    continue
+
+                if self._should_drop_event_from_client(event):
+                    continue
+
+                if await self._handle_raw_backend_message(event, raw_response):
+                    continue
+
+                event = self._normalize_event_for_ga_client(event)
+                self.store_message(event)
+
+                if not self._client_wants_beta:
+                    await self.websocket.send_text(json.dumps(event))
+                    continue
+
+                translated = self._translate_event_to_beta(event)
+                if translated is None:
+                    continue
+                await self.websocket.send_text(json.dumps(translated))
+
+    async def backend_to_client_send_messages(self) -> BackendClose:
         import websockets
 
         try:
-            while True:
-                try:
-                    raw_response = await self.backend_ws.recv(decode=False)
-                except TypeError:
-                    raw_response = await self.backend_ws.recv()
-
-                if isinstance(raw_response, bytes):
-                    try:
-                        raw_response = raw_response.decode("utf-8")
-                    except UnicodeDecodeError:
-                        verbose_logger.warning("Received non-UTF-8 binary frame from backend, skipping.")
-                        continue
-
-                if self.provider_config:
-                    try:
-                        await self._handle_provider_config_message(raw_response)
-                    except Exception as e:
-                        verbose_logger.exception("Error processing backend message, skipping: %s", e)
-                        continue
-                else:
-                    event = self._parse_backend_event(raw_response)
-                    if event is None:
-                        await self.websocket.send_text(raw_response)
-                        continue
-
-                    if self._should_drop_event_from_client(event):
-                        continue
-
-                    if await self._handle_raw_backend_message(event, raw_response):
-                        continue
-
-                    event = self._normalize_event_for_ga_client(event)
-                    self.store_message(event)
-
-                    if not self._client_wants_beta:
-                        await self.websocket.send_text(json.dumps(event))
-                        continue
-
-                    translated = self._translate_event_to_beta(event)
-                    if translated is None:
-                        continue
-                    await self.websocket.send_text(json.dumps(translated))
-
+            await self._relay_backend_messages()
         except websockets.exceptions.ConnectionClosed as e:
             verbose_logger.exception("Connection closed in backend to client send messages - %s", e)
-        except Exception as e:
-            verbose_logger.exception("Error in backend to client send messages: %s", e)
-        finally:
+            close: Final = backend_close_from(e)
+            self._flush_unbilled_transcription_usage()
+            if self._backend_refused_session(close):
+                await self.log_backend_refusal(e)
+            else:
+                await self.log_messages()
+            return close
+        except asyncio.CancelledError:
             self._flush_unbilled_transcription_usage()
             await self.log_messages()
+            raise
+        except Exception as e:
+            verbose_logger.exception("Error in backend to client send messages: %s", e)
+            self._flush_unbilled_transcription_usage()
+            await self.log_messages()
+            return BackendClose(code=1011, reason="proxy failed while relaying the upstream websocket")
+
+    def _backend_refused_session(self, close: BackendClose) -> bool:
+        return close.code != 1000 and not self._backend_sent_frames and not self.messages
+
+    async def log_backend_refusal(self, error: Exception) -> None:
+        if not self.logging_obj:
+            return
+        self._logging_worker.ensure_initialized_and_enqueue(
+            self.logging_obj.dispatch_failure_handlers(error, traceback.format_exc(), prefer_async_handlers=True)
+        )
 
     @staticmethod
     def _detect_beta_header(websocket: _ScopedWebSocket) -> bool:
@@ -1484,20 +1532,28 @@ class RealTimeStreaming:
         except Exception as e:
             verbose_logger.debug("Error in client ack messages: %s", e)
 
-    async def bidirectional_forward(self):
+    async def bidirectional_forward(self) -> None:
         forward_task: Final = asyncio.create_task(self.backend_to_client_send_messages())
+        client_task: Final = asyncio.create_task(self.client_ack_messages())
         try:
-            await self.client_ack_messages()
-        except self.websocket.exceptions.ConnectionClosed:
-            verbose_logger.debug("Connection closed")
-            forward_task.cancel()
+            await asyncio.wait((forward_task, client_task), return_when=asyncio.FIRST_COMPLETED)
+            if not client_task.done():
+                await self._close_client(forward_task.result())
         finally:
-            if not forward_task.done():
-                forward_task.cancel()
-                try:
-                    await forward_task
-                except asyncio.CancelledError:
-                    pass
+            forward_task.cancel()
+            client_task.cancel()
+            await asyncio.gather(forward_task, client_task, return_exceptions=True)
+
+    async def _close_client(self, close: BackendClose) -> None:
+        try:
+            if close.code != 1000:
+                await self.websocket.send_text(realtime_error_event(close.message, error_type="server_error"))
+            await self.websocket.close(
+                code=client_close_code(close.code),
+                reason=websocket_close_reason(close.reason, fallback=close.message),
+            )
+        except Exception as e:  # noqa: BLE001  # the client may already be gone; the session is over either way
+            verbose_logger.debug("Could not relay the upstream close to the client: %s", e)
 
 
 def client_sent_openai_beta_realtime_header(websocket: _ScopedWebSocket) -> bool:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -11453,6 +11453,16 @@ def _realtime_query_params_template(model: str | None, intent: str | None) -> tu
     return tuple(params)
 
 
+async def _release_realtime_budget_reservation(user_api_key_dict: UserAPIKeyAuth) -> None:
+    from litellm.proxy.spend_tracking.budget_reservation import (
+        release_or_invalidate_budget_reservation,
+    )
+
+    await release_or_invalidate_budget_reservation(
+        budget_reservation=user_api_key_dict.budget_reservation,
+    )
+
+
 @app.websocket("/openai/v1/realtime")
 @app.websocket("/v1/realtime")
 @app.websocket("/realtime")
@@ -11592,6 +11602,8 @@ async def realtime_websocket_endpoint(
             )
         except Exception:  # noqa: BLE001  # the lower layer may have closed the socket already; closing twice is not an error
             verbose_proxy_logger.debug("Could not close realtime client websocket; it is already gone")
+    finally:
+        await _release_realtime_budget_reservation(user_api_key_dict)
 
 
 ######################################################################

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -11471,15 +11471,17 @@ async def _reject_realtime_session(
     reason: str,
     error_message: str | None = None,
 ) -> None:
-    await _release_realtime_budget_reservation(user_api_key_dict)
-    if error_message is not None:
-        try:
-            await websocket.send_text(
-                json.dumps({"type": "error", "error": {"type": "guardrail_error", "message": error_message}})
-            )
-        except Exception:  # noqa: BLE001  # best-effort notice: a dead client socket must not skip the close below
-            verbose_proxy_logger.debug("Could not send realtime pre-call error event to client; closing anyway")
-    await websocket.close(code=code, reason=reason)
+    try:
+        if error_message is not None:
+            try:
+                await websocket.send_text(
+                    json.dumps({"type": "error", "error": {"type": "guardrail_error", "message": error_message}})
+                )
+            except Exception:  # noqa: BLE001  # best-effort notice: a dead client socket must not skip the close below
+                verbose_proxy_logger.debug("Could not send realtime pre-call error event to client; closing anyway")
+        await websocket.close(code=code, reason=reason)
+    finally:
+        await _release_realtime_budget_reservation(user_api_key_dict)
 
 
 @app.websocket("/openai/v1/realtime")

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -11463,6 +11463,25 @@ async def _release_realtime_budget_reservation(user_api_key_dict: UserAPIKeyAuth
     )
 
 
+async def _reject_realtime_session(
+    websocket: WebSocket,
+    user_api_key_dict: UserAPIKeyAuth,
+    *,
+    code: int,
+    reason: str,
+    error_message: str | None = None,
+) -> None:
+    await _release_realtime_budget_reservation(user_api_key_dict)
+    if error_message is not None:
+        try:
+            await websocket.send_text(
+                json.dumps({"type": "error", "error": {"type": "guardrail_error", "message": error_message}})
+            )
+        except Exception:  # noqa: BLE001  # best-effort notice: a dead client socket must not skip the close below
+            verbose_proxy_logger.debug("Could not send realtime pre-call error event to client; closing anyway")
+    await websocket.close(code=code, reason=reason)
+
+
 @app.websocket("/openai/v1/realtime")
 @app.websocket("/v1/realtime")
 @app.websocket("/realtime")
@@ -11488,7 +11507,9 @@ async def realtime_websocket_endpoint(
         if intent == "transcription":
             route_model = "gpt-realtime-whisper"
         else:
-            await websocket.close(code=1008, reason="model query parameter is required")
+            await _reject_realtime_session(
+                websocket, user_api_key_dict, code=1008, reason="model query parameter is required"
+            )
             return
     assert route_model is not None
     try:
@@ -11499,7 +11520,7 @@ async def realtime_websocket_endpoint(
             llm_router=llm_router,
         )
     except ProxyException as e:
-        await websocket.close(code=1008, reason=e.message[:120])
+        await _reject_realtime_session(websocket, user_api_key_dict, code=1008, reason=e.message[:120])
         return
     await websocket.accept(**accept_kwargs)
 
@@ -11558,21 +11579,9 @@ async def realtime_websocket_endpoint(
         )
     except Exception as e:
         verbose_proxy_logger.exception("Realtime pre-call error")
-        try:
-            await websocket.send_text(
-                json.dumps(
-                    {
-                        "type": "error",
-                        "error": {
-                            "type": "guardrail_error",
-                            "message": str(e),
-                        },
-                    }
-                )
-            )
-        except Exception:
-            pass
-        await websocket.close(code=1011, reason="Pre-call error")
+        await _reject_realtime_session(
+            websocket, user_api_key_dict, code=1011, reason="Pre-call error", error_message=str(e)
+        )
         return
 
     # Phase 2: route to upstream LLM.

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -11603,7 +11603,12 @@ async def realtime_websocket_endpoint(
         except Exception:  # noqa: BLE001  # the lower layer may have closed the socket already; closing twice is not an error
             verbose_proxy_logger.debug("Could not close realtime client websocket; it is already gone")
     finally:
-        await _release_realtime_budget_reservation(user_api_key_dict)
+        from litellm.litellm_core_utils.realtime_streaming import (
+            REALTIME_SESSION_SUCCESS_LOGGED_KEY,
+        )
+
+        if not litellm_logging_obj.model_call_details.get(REALTIME_SESSION_SUCCESS_LOGGED_KEY):
+            await _release_realtime_budget_reservation(user_api_key_dict)
 
 
 ######################################################################

--- a/litellm/proxy/spend_tracking/budget_reservation.py
+++ b/litellm/proxy/spend_tracking/budget_reservation.py
@@ -389,11 +389,13 @@ async def release_or_invalidate_budget_reservation(
     if budget_reservation is None or budget_reservation.get("finalized") is True:
         return
     try:
-        await release_budget_reservation(budget_reservation=budget_reservation)
+        await asyncio.shield(release_budget_reservation(budget_reservation=budget_reservation))
     except Exception:  # noqa: BLE001  # a cleanup failure must not pin the counter; drop it directly instead
         verbose_proxy_logger.exception("Failed to release budget reservation; invalidating counters")
         try:
             await invalidate_budget_reservation_counters(budget_reservation=budget_reservation)
+        except Exception:  # noqa: BLE001  # nothing left to try; the finalized stamp below keeps it from being reprocessed
+            verbose_proxy_logger.exception("Failed to invalidate budget reservation counters after release failed")
         finally:
             budget_reservation["finalized"] = True
 

--- a/litellm/proxy/spend_tracking/budget_reservation.py
+++ b/litellm/proxy/spend_tracking/budget_reservation.py
@@ -373,6 +373,31 @@ async def invalidate_budget_reservation_counters(
         await _invalidate_spend_counter(counter_key=counter_key)
 
 
+async def release_or_invalidate_budget_reservation(
+    budget_reservation: dict | None,  # mutable-ok: stamps finalized on the caller's shared reservation dict
+) -> None:
+    """Reconcile a still-open reservation on a terminal path that settles no cost.
+
+    A failed or upstream-refused request never runs the success cost callback, so
+    its pre-call reservation stays open and keeps the spend counter pinned above
+    real spend until the counter's TTL expires, 429ing later requests on the same
+    key. Release it to zero; if the release itself fails (e.g. the counter store is
+    unreachable) drop the reserved counters directly and mark the reservation
+    finalized so nothing reprocesses it. Idempotent: the finalized guard makes a
+    second call a no-op once success or failure handling already reconciled.
+    """
+    if budget_reservation is None or budget_reservation.get("finalized") is True:
+        return
+    try:
+        await release_budget_reservation(budget_reservation=budget_reservation)
+    except Exception:  # noqa: BLE001  # a cleanup failure must not pin the counter; drop it directly instead
+        verbose_proxy_logger.exception("Failed to release budget reservation; invalidating counters")
+        try:
+            await invalidate_budget_reservation_counters(budget_reservation=budget_reservation)
+        finally:
+            budget_reservation["finalized"] = True
+
+
 async def _get_budget_counters(
     request_body: dict,
     valid_token: UserAPIKeyAuth,

--- a/litellm/realtime_api/main.py
+++ b/litellm/realtime_api/main.py
@@ -27,7 +27,7 @@ from litellm.types.realtime import (
     RealtimeTranscriptionSessionRequest,
 )
 from litellm.types.router import GenericLiteLLMParams
-from litellm.types.utils import LlmProviders
+from litellm.types.utils import CallTypes, LlmProviders
 from litellm.utils import ProviderConfigManager
 
 from ..litellm_core_utils.get_litellm_params import get_litellm_params
@@ -355,7 +355,7 @@ async def _arealtime(
     user: Final = kwargs.get("user", None)
     litellm_params: Final = GenericLiteLLMParams(**kwargs)
 
-    litellm_params_dict: Final = get_litellm_params(**kwargs)
+    litellm_params_dict: Final = {**get_litellm_params(**kwargs), CallTypes.arealtime.value: True}
 
     model, _custom_llm_provider, dynamic_api_key, dynamic_api_base = get_llm_provider(
         model=model,

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -996,6 +996,35 @@ async def test_anthropic_messages_marks_litellm_params_async():
 
 
 @pytest.mark.asyncio
+async def test_arealtime_marks_litellm_params_async(monkeypatch):
+    """LIT-6973: ``_arealtime`` must plant ``_arealtime`` in ``litellm_params`` so
+    ``_is_sync_litellm_request`` classifies the session async and a failed session
+    reaches a CustomLogger's failure hook once, through the async path only, even
+    though the sync ``failure_handler`` still runs ahead of the async one."""
+    captured = {}
+    async_logged = asyncio.Event()
+
+    class CaptureLogger(CustomLogger):
+        async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
+            captured["litellm_params"] = kwargs.get("litellm_params", {})
+            async_logged.set()
+
+    logger = CaptureLogger()
+    logger.log_failure_event = MagicMock()
+    monkeypatch.setattr(litellm, "callbacks", [logger])
+    monkeypatch.setattr(litellm, "failure_callback", [])
+    monkeypatch.setattr(litellm, "_async_failure_callback", [])
+    monkeypatch.setattr(litellm, "success_callback", [])
+    monkeypatch.setattr(litellm, "_async_success_callback", [])
+    with pytest.raises(ValueError, match="Unsupported model"):
+        await litellm._arealtime(model="anthropic/claude-x", websocket=MagicMock())
+    await asyncio.wait_for(async_logged.wait(), timeout=10)
+    logger.log_failure_event.assert_not_called()
+    assert captured["litellm_params"].get("_arealtime") is True
+    assert LitellmLogging._is_sync_litellm_request(captured["litellm_params"]) is False
+
+
+@pytest.mark.asyncio
 async def test_agenerate_content_marks_litellm_params_async():
     """LIT-4475: the async ``agenerate_content`` entrypoint must plant
     ``agenerate_content`` in ``litellm_params`` so ``_is_sync_litellm_request``
@@ -1180,6 +1209,7 @@ def test_is_sync_litellm_request():
     assert LitellmLogging._is_sync_litellm_request({}) is True
     assert LitellmLogging._is_sync_litellm_request({"acompletion": True}) is False
     assert LitellmLogging._is_sync_litellm_request({"allm_passthrough_route": True}) is False
+    assert LitellmLogging._is_sync_litellm_request({"_arealtime": True}) is False
     assert LitellmLogging._is_sync_litellm_request({"aanthropic_messages": True}) is False
     assert LitellmLogging._is_sync_litellm_request({"agenerate_content": True}) is False
     assert LitellmLogging._is_sync_litellm_request({"agenerate_content_stream": True}) is False

--- a/tests/test_litellm/litellm_core_utils/test_realtime_errors.py
+++ b/tests/test_litellm/litellm_core_utils/test_realtime_errors.py
@@ -1,8 +1,10 @@
 import json
 
+import pytest
 
 from litellm.litellm_core_utils.realtime_errors import (
     WEBSOCKET_CLOSE_REASON_MAX_BYTES,
+    client_close_code,
     realtime_error_event,
     websocket_close_reason,
 )
@@ -42,3 +44,11 @@ def test_websocket_close_reason_truncates_multibyte_message_by_bytes():
     assert len(reason.encode("utf-8")) <= WEBSOCKET_CLOSE_REASON_MAX_BYTES
     assert reason == "あ" * (WEBSOCKET_CLOSE_REASON_MAX_BYTES // 3)
     assert "�" not in reason
+
+
+@pytest.mark.parametrize(
+    ("upstream_code", "expected"),
+    [(1000, 1000), (1008, 1008), (1011, 1011), (4001, 4001), (1005, 1011), (1006, 1011), (1015, 1011), (2999, 1011)],
+)
+def test_client_close_code_only_forwards_codes_a_server_may_send(upstream_code, expected):
+    assert client_close_code(upstream_code) == expected

--- a/tests/test_litellm/litellm_core_utils/test_realtime_streaming.py
+++ b/tests/test_litellm/litellm_core_utils/test_realtime_streaming.py
@@ -1,8 +1,13 @@
+import asyncio
 import json
+from collections.abc import Coroutine
+from dataclasses import dataclass
+from typing import Final
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from websockets.exceptions import ConnectionClosed
+from websockets.frames import Close
 
 import litellm
 
@@ -2941,13 +2946,11 @@ async def test_log_messages_routes_async_logging_through_bounded_worker():
     realtime turn leaves a suspended task pinning its response in memory -> an
     unbounded leak. Regression for that fix."""
     logging_obj = MagicMock()
-    streaming = RealTimeStreaming(MagicMock(), MagicMock(), logging_obj)
+    mock_worker = MagicMock()
+    streaming = RealTimeStreaming(MagicMock(), MagicMock(), logging_obj, logging_worker=mock_worker)
     streaming.messages = [{"type": "session.created"}]
 
-    with (
-        patch("litellm.litellm_core_utils.realtime_streaming.GLOBAL_LOGGING_WORKER") as mock_worker,
-        patch("litellm.litellm_core_utils.realtime_streaming.asyncio.create_task") as mock_create_task,
-    ):
+    with patch("litellm.litellm_core_utils.realtime_streaming.asyncio.create_task") as mock_create_task:
         await streaming.log_messages()
 
         mock_worker.ensure_initialized_and_enqueue.assert_called_once()
@@ -3111,3 +3114,159 @@ async def test_session_close_flush_noop_without_unbilled_usage():
         isinstance(message, dict) and message.get("type") == "conversation.item.input_audio_transcription.completed"
         for message in streaming.messages
     )
+
+
+
+_UPSTREAM_REFUSAL: Final = "Publisher model `publishers/google/models/gemini-live-2.5-flash` was not found"
+
+
+class _InlineLoggingWorker:
+    def __init__(self) -> None:
+        self.enqueued: tuple[Coroutine[object, object, None], ...] = ()
+
+    def ensure_initialized_and_enqueue(self, async_coroutine: Coroutine[object, object, None]) -> None:
+        self.enqueued = (*self.enqueued, async_coroutine)
+
+    async def drain(self) -> None:
+        for coroutine in self.enqueued:
+            await coroutine
+
+
+class _RecordingLogging:
+    def __init__(self) -> None:
+        self.logged_sessions: tuple[tuple[dict, ...], ...] = ()
+        self.logged_failures: tuple[Exception, ...] = ()
+
+    async def dispatch_success_handlers(self, result: list[dict], prefer_async_handlers: bool = False) -> None:
+        self.logged_sessions = (*self.logged_sessions, tuple(result))
+
+    async def dispatch_failure_handlers(
+        self, exception: Exception, traceback_exception: str, prefer_async_handlers: bool = False
+    ) -> None:
+        self.logged_failures = (*self.logged_failures, exception)
+
+
+@dataclass(frozen=True, slots=True)
+class _RelaySession:
+    streaming: RealTimeStreaming
+    logging: _RecordingLogging
+    worker: _InlineLoggingWorker
+
+    async def run(self) -> None:
+        await asyncio.wait_for(self.streaming.bidirectional_forward(), timeout=2)
+        await self.worker.drain()
+
+
+async def _wait_forever() -> str:
+    await asyncio.Event().wait()
+    raise AssertionError("unreachable")
+
+
+def _client_ws_that_never_sends() -> MagicMock:
+    client_ws: Final = MagicMock()
+    client_ws.headers = {}
+    client_ws.receive_text = AsyncMock(side_effect=_wait_forever)
+    client_ws.send_text = AsyncMock()
+    client_ws.close = AsyncMock()
+    return client_ws
+
+
+def _backend_ws_closing_with(*frames: bytes | Exception) -> MagicMock:
+    backend_ws: Final = MagicMock()
+    backend_ws.recv = AsyncMock(side_effect=list(frames))
+    return backend_ws
+
+
+def _relay_session(client_ws: MagicMock, backend_ws: MagicMock) -> _RelaySession:
+    logging: Final = _RecordingLogging()
+    worker: Final = _InlineLoggingWorker()
+    streaming: Final = RealTimeStreaming(
+        client_ws, backend_ws, logging, model="gpt-realtime", logging_worker=worker
+    )
+    return _RelaySession(streaming=streaming, logging=logging, worker=worker)
+
+
+def _error_events_sent_to(client_ws: MagicMock) -> list[dict]:
+    events: Final = (json.loads(call.args[0]) for call in client_ws.send_text.await_args_list)
+    return [event for event in events if event.get("type") == "error"]
+
+
+@pytest.mark.asyncio
+async def test_bidirectional_forward_relays_upstream_policy_close_to_client():
+    client_ws: Final = _client_ws_that_never_sends()
+    upstream_close: Final = ConnectionClosed(Close(1008, _UPSTREAM_REFUSAL), None)
+    session: Final = _relay_session(client_ws, _backend_ws_closing_with(upstream_close))
+
+    await session.run()
+
+    (error_event,) = _error_events_sent_to(client_ws)
+    assert error_event["error"]["type"] == "server_error"
+    assert "1008" in error_event["error"]["message"]
+    assert _UPSTREAM_REFUSAL in error_event["error"]["message"]
+    client_ws.close.assert_awaited_once_with(code=1008, reason=_UPSTREAM_REFUSAL)
+
+
+@pytest.mark.asyncio
+async def test_bidirectional_forward_maps_abnormal_upstream_close_to_internal_error():
+    client_ws: Final = _client_ws_that_never_sends()
+    session: Final = _relay_session(client_ws, _backend_ws_closing_with(ConnectionClosed(None, None)))
+
+    await session.run()
+
+    (error_event,) = _error_events_sent_to(client_ws)
+    assert "1006" in error_event["error"]["message"]
+    client_ws.close.assert_awaited_once()
+    assert client_ws.close.await_args.kwargs["code"] == 1011
+
+
+@pytest.mark.asyncio
+async def test_bidirectional_forward_relays_normal_upstream_close_without_error_event():
+    client_ws: Final = _client_ws_that_never_sends()
+    session: Final = _relay_session(client_ws, _backend_ws_closing_with(ConnectionClosed(Close(1000, ""), None)))
+
+    await session.run()
+
+    assert _error_events_sent_to(client_ws) == []
+    client_ws.close.assert_awaited_once()
+    assert client_ws.close.await_args.kwargs["code"] == 1000
+
+
+@pytest.mark.asyncio
+async def test_upstream_refusal_before_any_frame_logs_a_failure_not_a_success():
+    upstream_close: Final = ConnectionClosed(Close(1008, _UPSTREAM_REFUSAL), None)
+    session: Final = _relay_session(_client_ws_that_never_sends(), _backend_ws_closing_with(upstream_close))
+
+    await session.run()
+
+    assert session.logging.logged_failures == (upstream_close,)
+    assert session.logging.logged_sessions == ()
+
+
+@pytest.mark.asyncio
+async def test_upstream_close_after_relayed_events_still_logs_the_session_as_success():
+    client_ws: Final = _client_ws_that_never_sends()
+    session_created: Final = json.dumps({"type": "session.created", "session": {"id": "sess_1"}}).encode()
+    upstream_close: Final = ConnectionClosed(Close(1008, _UPSTREAM_REFUSAL), None)
+    session: Final = _relay_session(client_ws, _backend_ws_closing_with(session_created, upstream_close))
+
+    await session.run()
+
+    (logged_session,) = session.logging.logged_sessions
+    assert [event["type"] for event in logged_session] == ["session.created"]
+    assert session.logging.logged_failures == ()
+    client_ws.close.assert_awaited_once_with(code=1008, reason=_UPSTREAM_REFUSAL)
+
+
+@pytest.mark.asyncio
+async def test_client_hanging_up_first_ends_the_session_without_a_relayed_close():
+    client_ws: Final = _client_ws_that_never_sends()
+    client_ws.receive_text = AsyncMock(side_effect=RuntimeError("client went away"))
+    backend_ws: Final = MagicMock()
+    backend_ws.recv = AsyncMock(side_effect=_wait_forever)
+    session: Final = _relay_session(client_ws, backend_ws)
+
+    await session.run()
+
+    assert session.logging.logged_sessions == ((),)
+    assert session.logging.logged_failures == ()
+    client_ws.close.assert_not_awaited()

--- a/tests/test_litellm/litellm_core_utils/test_realtime_streaming.py
+++ b/tests/test_litellm/litellm_core_utils/test_realtime_streaming.py
@@ -3031,12 +3031,12 @@ async def test_session_close_flushes_unbilled_transcription_usage():
     messages before log_messages runs, and never forwarded to the client."""
     from typing import Final
 
-    from litellm.types.realtime import RealtimeInputAudioTranscriptionUsage
+    from litellm.types.realtime import RealtimeInputAudioTranscriptionUsage, RealtimeResponseTypedDict
 
     client_ws: Final = MagicMock()
     client_ws.send_text = AsyncMock()
     backend_ws: Final = MagicMock()
-    backend_ws.recv = AsyncMock(side_effect=ConnectionClosed(None, None))
+    backend_ws.recv = AsyncMock(side_effect=[b'{"serverContent": {}}', ConnectionClosed(None, None)])
     logging_obj: Final = MagicMock()
     logging_obj.async_success_handler = AsyncMock()
     logging_obj.success_handler = MagicMock()
@@ -3048,7 +3048,24 @@ async def test_session_close_flushes_unbilled_transcription_usage():
         "total_tokens": 171,
         "input_token_details": {"text_tokens": 0, "audio_tokens": 153},
     }
+    transcript_frame: Final[RealtimeResponseTypedDict] = {
+        "response": {
+            "type": "conversation.item.input_audio_transcription.completed",
+            "event_id": "event_1",
+            "transcript": "ahoy",
+            "item_id": "item_1",
+            "content_index": 0,
+        },
+        "current_output_item_id": None,
+        "current_response_id": None,
+        "current_delta_chunks": None,
+        "current_conversation_id": None,
+        "current_item_chunks": None,
+        "current_delta_type": None,
+        "session_configuration_request": None,
+    }
     provider_config: Final = MagicMock()
+    provider_config.transform_realtime_response = MagicMock(return_value=transcript_frame)
     provider_config.unbilled_usage_on_session_close = MagicMock(return_value=usage)
 
     streaming: Final = RealTimeStreaming(
@@ -3080,7 +3097,9 @@ async def test_session_close_flushes_unbilled_transcription_usage():
     )
     assert len(flushed) == 1
     assert flushed[0] in logged_snapshots[0]
-    assert not client_ws.send_text.called
+    forwarded: Final = tuple(json.loads(call.args[0]) for call in client_ws.send_text.await_args_list)
+    assert [event.get("transcript") for event in forwarded] == ["ahoy"]
+    assert all("usage" not in event for event in forwarded)
 
 
 @pytest.mark.asyncio
@@ -3239,6 +3258,20 @@ async def test_bidirectional_forward_relays_normal_upstream_close_without_error_
 async def test_upstream_refusal_before_any_frame_logs_a_failure_not_a_success():
     upstream_close: Final = ConnectionClosed(Close(1008, _UPSTREAM_REFUSAL), None)
     session: Final = _relay_session(_client_ws_that_never_sends(), _backend_ws_closing_with(upstream_close))
+
+    await session.run()
+
+    assert session.logging.logged_failures == (upstream_close,)
+    assert session.logging.logged_sessions == ()
+
+
+@pytest.mark.asyncio
+async def test_upstream_refusal_after_a_synthetic_session_created_still_logs_a_failure():
+    """LIT-6973: deferred Gemini Live setup stores a synthetic ``session.created`` before
+    the relay starts. It is not an upstream frame, so a refusal after it is still a refusal."""
+    upstream_close: Final = ConnectionClosed(Close(1008, _UPSTREAM_REFUSAL), None)
+    session: Final = _relay_session(_client_ws_that_never_sends(), _backend_ws_closing_with(upstream_close))
+    session.streaming.store_message(json.dumps({"type": "session.created", "session": {"id": "sess_synthetic"}}))
 
     await session.run()
 

--- a/tests/test_litellm/litellm_core_utils/test_realtime_streaming.py
+++ b/tests/test_litellm/litellm_core_utils/test_realtime_streaming.py
@@ -3307,3 +3307,18 @@ async def test_client_hanging_up_first_ends_the_session_without_a_relayed_close(
     assert session.logging.logged_sessions == ((),)
     assert session.logging.logged_failures == ()
     client_ws.close.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_client_hanging_up_with_a_websockets_close_is_not_mistaken_for_the_backend_closing():
+    client_ws: Final = _client_ws_that_never_sends()
+    client_ws.receive_text = AsyncMock(side_effect=ConnectionClosed(None, None))
+    backend_ws: Final = MagicMock()
+    backend_ws.recv = AsyncMock(side_effect=_wait_forever)
+    session: Final = _relay_session(client_ws, backend_ws)
+
+    await session.run()
+
+    assert session.logging.logged_sessions == ((),)
+    assert session.logging.logged_failures == ()
+    client_ws.close.assert_not_awaited()

--- a/tests/test_litellm/litellm_core_utils/test_realtime_streaming.py
+++ b/tests/test_litellm/litellm_core_utils/test_realtime_streaming.py
@@ -3134,8 +3134,12 @@ class _InlineLoggingWorker:
 
 class _RecordingLogging:
     def __init__(self) -> None:
+        self.model_call_details: dict[str, object] = {}
         self.logged_sessions: tuple[tuple[dict, ...], ...] = ()
         self.logged_failures: tuple[Exception, ...] = ()
+
+    def pre_call(self, input: str | dict, api_key: str) -> None:
+        return None
 
     async def dispatch_success_handlers(self, result: list[dict], prefer_async_handlers: bool = False) -> None:
         self.logged_sessions = (*self.logged_sessions, tuple(result))
@@ -3255,6 +3259,39 @@ async def test_upstream_close_after_relayed_events_still_logs_the_session_as_suc
     assert [event["type"] for event in logged_session] == ["session.created"]
     assert session.logging.logged_failures == ()
     client_ws.close.assert_awaited_once_with(code=1008, reason=_UPSTREAM_REFUSAL)
+
+
+@pytest.mark.asyncio
+async def test_upstream_closing_while_a_client_message_is_forwarded_still_reaches_the_client():
+    upstream_close: Final = ConnectionClosed(Close(1008, _UPSTREAM_REFUSAL), None)
+    backend_closed: Final = asyncio.Event()
+    client_messages: Final = iter((json.dumps({"type": "response.create"}),))
+
+    async def receive_text() -> str:
+        message = next(client_messages, None)
+        return message if message is not None else await _wait_forever()
+
+    async def send_to_backend(_message: str) -> None:
+        backend_closed.set()
+        raise upstream_close
+
+    async def recv_from_backend() -> bytes:
+        await backend_closed.wait()
+        raise upstream_close
+
+    client_ws: Final = _client_ws_that_never_sends()
+    client_ws.receive_text = receive_text
+    backend_ws: Final = MagicMock()
+    backend_ws.send = send_to_backend
+    backend_ws.recv = recv_from_backend
+    session: Final = _relay_session(client_ws, backend_ws)
+
+    await session.run()
+
+    (error_event,) = _error_events_sent_to(client_ws)
+    assert _UPSTREAM_REFUSAL in error_event["error"]["message"]
+    client_ws.close.assert_awaited_once_with(code=1008, reason=_UPSTREAM_REFUSAL)
+    assert session.logging.logged_failures == (upstream_close,)
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/litellm_core_utils/test_realtime_streaming.py
+++ b/tests/test_litellm/litellm_core_utils/test_realtime_streaming.py
@@ -14,6 +14,7 @@ import litellm
 
 from litellm.integrations.custom_guardrail import CustomGuardrail
 from litellm.litellm_core_utils.realtime_streaming import (
+    REALTIME_SESSION_SUCCESS_LOGGED_KEY,
     RealTimeStreaming,
     client_sent_openai_beta_realtime_header,
 )
@@ -3380,3 +3381,34 @@ async def test_client_hanging_up_with_a_websockets_close_is_not_mistaken_for_the
     assert session.logging.logged_sessions == ((),)
     assert session.logging.logged_failures == ()
     client_ws.close.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_success_logging_stamps_the_reservation_ownership_marker():
+    """LIT-6973: only the success path enqueues the cost callback that settles the
+    session's budget reservation, so it stamps REALTIME_SESSION_SUCCESS_LOGGED_KEY on
+    the shared logging object. The proxy endpoint reads that stamp to decide whether to
+    release the reservation itself, so a logged-as-success session must carry it."""
+    client_ws: Final = _client_ws_that_never_sends()
+    session_created: Final = json.dumps({"type": "session.created", "session": {"id": "sess_1"}}).encode()
+    upstream_close: Final = ConnectionClosed(Close(1000, ""), None)
+    session: Final = _relay_session(client_ws, _backend_ws_closing_with(session_created, upstream_close))
+
+    await session.run()
+
+    assert session.logging.logged_sessions != ()
+    assert session.logging.model_call_details.get(REALTIME_SESSION_SUCCESS_LOGGED_KEY) is True
+
+
+@pytest.mark.asyncio
+async def test_refused_session_does_not_stamp_the_reservation_ownership_marker():
+    """A refused session logs a failure, not a success, so it must not stamp
+    REALTIME_SESSION_SUCCESS_LOGGED_KEY. If it did, the proxy endpoint would skip its
+    own reservation release and the refused session's reservation would stay pinned."""
+    upstream_close: Final = ConnectionClosed(Close(1008, _UPSTREAM_REFUSAL), None)
+    session: Final = _relay_session(_client_ws_that_never_sends(), _backend_ws_closing_with(upstream_close))
+
+    await session.run()
+
+    assert session.logging.logged_failures == (upstream_close,)
+    assert REALTIME_SESSION_SUCCESS_LOGGED_KEY not in session.logging.model_call_details

--- a/tests/test_litellm/litellm_core_utils/test_realtime_streaming.py
+++ b/tests/test_litellm/litellm_core_utils/test_realtime_streaming.py
@@ -3230,6 +3230,24 @@ async def test_bidirectional_forward_relays_upstream_policy_close_to_client():
 
 
 @pytest.mark.asyncio
+async def test_upstream_close_reason_with_a_secret_is_redacted_before_reaching_the_client():
+    """LIT-6973: the relayed close mirrors the handshake path and scrubs credential
+    patterns, so an upstream error echoing a token never reaches the client verbatim."""
+    secret: Final = "sk-live-abcdef0123456789abcdef0123"
+    client_ws: Final = _client_ws_that_never_sends()
+    upstream_close: Final = ConnectionClosed(Close(1008, f"auth failed for {secret}"), None)
+    session: Final = _relay_session(client_ws, _backend_ws_closing_with(upstream_close))
+
+    await session.run()
+
+    (error_event,) = _error_events_sent_to(client_ws)
+    assert secret not in error_event["error"]["message"]
+    relayed_reason: Final = client_ws.close.await_args.kwargs["reason"]
+    assert secret not in relayed_reason
+    assert "REDACTED" in relayed_reason
+
+
+@pytest.mark.asyncio
 async def test_bidirectional_forward_maps_abnormal_upstream_close_to_internal_error():
     client_ws: Final = _client_ws_that_never_sends()
     session: Final = _relay_session(client_ws, _backend_ws_closing_with(ConnectionClosed(None, None)))

--- a/tests/test_litellm/litellm_core_utils/test_realtime_streaming.py
+++ b/tests/test_litellm/litellm_core_utils/test_realtime_streaming.py
@@ -3229,21 +3229,28 @@ async def test_bidirectional_forward_relays_upstream_policy_close_to_client():
     client_ws.close.assert_awaited_once_with(code=1008, reason=_UPSTREAM_REFUSAL)
 
 
+@pytest.mark.parametrize(
+    "leaked_detail",
+    (
+        pytest.param("sk-live-abcdef0123456789abcdef0123", id="credential"),
+        pytest.param("vertex-int.svc.cluster.local", id="internal-hostname"),
+        pytest.param("/etc/litellm/service-account.json", id="filesystem-path"),
+    ),
+)
 @pytest.mark.asyncio
-async def test_upstream_close_reason_with_a_secret_is_redacted_before_reaching_the_client():
-    """LIT-6973: the relayed close mirrors the handshake path and scrubs credential
-    patterns, so an upstream error echoing a token never reaches the client verbatim."""
-    secret: Final = "sk-live-abcdef0123456789abcdef0123"
+async def test_upstream_close_details_are_scrubbed_before_reaching_the_client(leaked_detail: str):
+    """LIT-6973: the relayed close goes through the proxy's client-facing redaction, so an upstream
+    error echoing a credential, an internal host, or a server path never reaches the client verbatim."""
     client_ws: Final = _client_ws_that_never_sends()
-    upstream_close: Final = ConnectionClosed(Close(1008, f"auth failed for {secret}"), None)
+    upstream_close: Final = ConnectionClosed(Close(1008, f"upstream rejected: {leaked_detail}"), None)
     session: Final = _relay_session(client_ws, _backend_ws_closing_with(upstream_close))
 
     await session.run()
 
     (error_event,) = _error_events_sent_to(client_ws)
-    assert secret not in error_event["error"]["message"]
+    assert leaked_detail not in error_event["error"]["message"]
     relayed_reason: Final = client_ws.close.await_args.kwargs["reason"]
-    assert secret not in relayed_reason
+    assert leaked_detail not in relayed_reason
     assert "REDACTED" in relayed_reason
 
 

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -9533,7 +9533,11 @@ def _lit6973_fake_realtime_ws() -> MagicMock:
 
 
 async def _lit6973_drive_realtime_session(
-    reservation: dict, *, backend_logged_success: bool, phase_one_exit: str | None = None
+    reservation: dict,
+    *,
+    backend_logged_success: bool,
+    phase_one_exit: str | None = None,
+    websocket: MagicMock | None = None,
 ) -> MagicMock:
     """Drive realtime_websocket_endpoint through one of its reservation-settling exits.
 
@@ -9574,7 +9578,7 @@ async def _lit6973_drive_realtime_session(
     pre_call: Final = AsyncMock(
         side_effect=pre_call_error, return_value=({"model": "vertex_ai/gemini-live-2.5-flash"}, logging_obj)
     )
-    ws: Final = _lit6973_fake_realtime_ws()
+    ws: Final = websocket if websocket is not None else _lit6973_fake_realtime_ws()
     can_call = patch.object(ps, "can_key_call_resolved_model", new=AsyncMock(side_effect=model_access_error))  # test-quality-ok: no HTTP boundary; fakes in-process auth to reach the exit under test
     pre = patch.object(ps.ProxyBaseLLMRequestProcessing, "common_processing_pre_call_logic", new=pre_call)  # test-quality-ok: fakes phase-1 wiring; assertion checks observable reservation state
     route = patch.object(ps, "route_request", new=AsyncMock(return_value=fake_llm_call()))  # test-quality-ok: fakes the relay whose success/refusal outcome the endpoint reads off the logging object
@@ -9633,6 +9637,45 @@ async def test_realtime_session_denied_model_access_releases_the_budget_reservat
 
     assert reservation["finalized"] is True
     ws.close.assert_awaited_once_with(code=1008, reason="key cannot access model")
+
+
+@pytest.mark.asyncio
+async def test_rejected_realtime_session_closes_the_client_before_releasing_the_reservation():
+    """The counter release can block on a slow or unreachable store, and a
+    rejected client must not sit behind it: the relay's own failure path closes
+    the client first and releases in its finally, so the pre-relay rejection
+    has to close first as well. The fake close checks the reservation is still
+    open when the client is closed."""
+    reservation: Final = {"reserved_cost": 0.55, "input_cost": 0.0, "finalized": False, "entries": []}
+    ws: Final = _lit6973_fake_realtime_ws()
+
+    async def close_while_reservation_is_still_open(**_: object) -> None:
+        assert reservation["finalized"] is False, "client was closed only after the reservation release"
+
+    ws.close = AsyncMock(side_effect=close_while_reservation_is_still_open)
+
+    await _lit6973_drive_realtime_session(
+        reservation, backend_logged_success=False, phase_one_exit="pre_call", websocket=ws
+    )
+
+    ws.close.assert_awaited_once_with(code=1011, reason="Pre-call error")
+    assert reservation["finalized"] is True
+
+
+@pytest.mark.asyncio
+async def test_rejected_realtime_session_releases_the_reservation_when_the_client_is_already_gone():
+    """A client that hung up before the rejection makes the close raise; the
+    reservation must still be released, or the key stays pinned."""
+    reservation: Final = {"reserved_cost": 0.55, "input_cost": 0.0, "finalized": False, "entries": []}
+    ws: Final = _lit6973_fake_realtime_ws()
+    ws.close = AsyncMock(side_effect=RuntimeError("client already disconnected"))
+
+    with pytest.raises(RuntimeError, match="client already disconnected"):
+        await _lit6973_drive_realtime_session(
+            reservation, backend_logged_success=False, phase_one_exit="model_access", websocket=ws
+        )
+
+    assert reservation["finalized"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -9521,6 +9521,89 @@ def test_realtime_websocket_route_aliases_registered():
         )
 
 
+def _lit6973_fake_realtime_ws() -> MagicMock:
+    ws = MagicMock()
+    ws.headers = {}
+    ws.scope = {"headers": [], "type": "websocket"}
+    ws.url = "ws://testserver/v1/realtime"
+    ws.accept = AsyncMock()
+    ws.send_text = AsyncMock()
+    ws.close = AsyncMock()
+    return ws
+
+
+async def _lit6973_drive_refused_realtime_session(reservation: dict) -> None:
+    """Drive realtime_websocket_endpoint through a session the upstream refused.
+
+    route_request resolves normally because the relay handles the refusal
+    internally (sends the error event, closes the client), so neither the
+    success cost callback nor a failure hook runs on _ProxyDBLogger. The
+    endpoint itself must reconcile the pre-call budget reservation, so the
+    real release runs (entries is empty, so it touches no counter store) and
+    the caller asserts on the observable reservation state afterwards."""
+    from litellm.proxy import proxy_server as ps
+
+    user_api_key_dict: Final = UserAPIKeyAuth(api_key="sk-test", token="hashed-token")
+    user_api_key_dict.budget_reservation = reservation
+
+    completed: Final = asyncio.get_running_loop().create_future()
+    completed.set_result(None)
+
+    pre_call: Final = AsyncMock(return_value=({"model": "vertex_ai/gemini-live-2.5-flash"}, MagicMock()))
+    can_call = patch.object(ps, "can_key_call_resolved_model", new=AsyncMock())  # test-quality-ok: no HTTP boundary; fakes in-process auth to reach the finally under test
+    pre = patch.object(ps.ProxyBaseLLMRequestProcessing, "common_processing_pre_call_logic", new=pre_call)  # test-quality-ok: fakes phase-1 wiring; assertion checks observable reservation state
+    route = patch.object(ps, "route_request", new=AsyncMock(return_value=completed))  # test-quality-ok: fakes the relay that already handled the refusal so the session returns normally
+    with can_call, pre, route:
+        await ps.realtime_websocket_endpoint(
+            websocket=_lit6973_fake_realtime_ws(),
+            model="vertex_ai/gemini-live-2.5-flash",
+            intent=None,
+            guardrails=None,
+            user_api_key_dict=user_api_key_dict,
+        )
+
+
+@pytest.mark.asyncio
+async def test_refused_realtime_session_releases_the_budget_reservation():
+    """LIT-6973: reclassifying a refused realtime session as a failure removed the
+    success-path reservation release, so the pre-call reservation stayed open and
+    pinned the key/team/user spend counters, locking the key after a couple of
+    refusals. The endpoint must reconcile it: the reservation ends up finalized."""
+    reservation: Final = {"reserved_cost": 0.55, "input_cost": 0.0, "finalized": False, "entries": []}
+
+    await _lit6973_drive_refused_realtime_session(reservation)
+
+    assert reservation["finalized"] is True
+
+
+@pytest.mark.asyncio
+async def test_release_or_invalidate_falls_back_to_invalidating_the_counters():
+    """If releasing the reservation itself fails (e.g. the counter store is down),
+    the reserved counters must be invalidated directly so the estimate does not
+    stay pinned, and the reservation is finalized so nothing reprocesses it."""
+    from litellm.proxy import proxy_server as ps
+    from litellm.proxy.spend_tracking import budget_reservation as br
+
+    reservation: Final = {
+        "reserved_cost": 0.55,
+        "input_cost": 0.0,
+        "finalized": False,
+        "entries": [{"counter_key": "spend:key:hashed-token"}],
+    }
+    invalidated: Final[list[str]] = []
+
+    async def _record(counter_key: str) -> None:
+        invalidated.append(counter_key)
+
+    failing_release = patch.object(br, "release_budget_reservation", new=AsyncMock(side_effect=RuntimeError("counter store down")))  # test-quality-ok: forces the failure branch; assertion observes which counter key got invalidated
+    sink = patch.object(ps, "_invalidate_spend_counter", new=_record)  # test-quality-ok: fakes the counter-store sink so the invalidated key is observable
+    with failing_release, sink:
+        await br.release_or_invalidate_budget_reservation(budget_reservation=reservation)
+
+    assert invalidated == ["spend:key:hashed-token"]
+    assert reservation["finalized"] is True
+
+
 class TestTransformRequestBannedParams:
     """
     /utils/transform_request applies the same banned-param check as LLM endpoints.

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -9532,8 +9532,15 @@ def _lit6973_fake_realtime_ws() -> MagicMock:
     return ws
 
 
-async def _lit6973_drive_realtime_session(reservation: dict, *, backend_logged_success: bool) -> None:
-    """Drive realtime_websocket_endpoint to just before its budget-reservation finally.
+async def _lit6973_drive_realtime_session(
+    reservation: dict, *, backend_logged_success: bool, phase_one_exit: str | None = None
+) -> MagicMock:
+    """Drive realtime_websocket_endpoint through one of its reservation-settling exits.
+
+    phase_one_exit picks a rejection before the relay: "model_access" makes the
+    key/model check raise ProxyException, "pre_call" makes pre-call processing
+    (rate limits, guardrails) raise. Neither reaches route_request, so no success
+    log can own the reservation and the endpoint has to release it on that exit.
 
     route_request resolves normally in both cases: the relay owns the session
     once route_request returns. A successful session enqueues its success cost
@@ -9556,18 +9563,30 @@ async def _lit6973_drive_realtime_session(reservation: dict, *, backend_logged_s
         if backend_logged_success:
             logging_obj.model_call_details[REALTIME_SESSION_SUCCESS_LOGGED_KEY] = True
 
-    pre_call: Final = AsyncMock(return_value=({"model": "vertex_ai/gemini-live-2.5-flash"}, logging_obj))
-    can_call = patch.object(ps, "can_key_call_resolved_model", new=AsyncMock())  # test-quality-ok: no HTTP boundary; fakes in-process auth to reach the finally under test
+    from litellm.proxy._types import ProxyException
+
+    model_access_error: Final = (
+        ProxyException(message="key cannot access model", type="auth_error", param="model", code=401)
+        if phase_one_exit == "model_access"
+        else None
+    )
+    pre_call_error: Final = Exception("Rate limit exceeded") if phase_one_exit == "pre_call" else None
+    pre_call: Final = AsyncMock(
+        side_effect=pre_call_error, return_value=({"model": "vertex_ai/gemini-live-2.5-flash"}, logging_obj)
+    )
+    ws: Final = _lit6973_fake_realtime_ws()
+    can_call = patch.object(ps, "can_key_call_resolved_model", new=AsyncMock(side_effect=model_access_error))  # test-quality-ok: no HTTP boundary; fakes in-process auth to reach the exit under test
     pre = patch.object(ps.ProxyBaseLLMRequestProcessing, "common_processing_pre_call_logic", new=pre_call)  # test-quality-ok: fakes phase-1 wiring; assertion checks observable reservation state
     route = patch.object(ps, "route_request", new=AsyncMock(return_value=fake_llm_call()))  # test-quality-ok: fakes the relay whose success/refusal outcome the endpoint reads off the logging object
     with can_call, pre, route:
         await ps.realtime_websocket_endpoint(
-            websocket=_lit6973_fake_realtime_ws(),
+            websocket=ws,
             model="vertex_ai/gemini-live-2.5-flash",
             intent=None,
             guardrails=None,
             user_api_key_dict=user_api_key_dict,
         )
+    return ws
 
 
 @pytest.mark.asyncio
@@ -9581,6 +9600,39 @@ async def test_refused_realtime_session_releases_the_budget_reservation():
     await _lit6973_drive_realtime_session(reservation, backend_logged_success=False)
 
     assert reservation["finalized"] is True
+
+
+@pytest.mark.asyncio
+async def test_realtime_session_rejected_in_pre_call_releases_the_budget_reservation():
+    """A rate-limit or guardrail rejection happens before route_request, so the
+    relay never runs and no success log can own the reservation. The endpoint
+    must release it on that exit too, or the key stays pinned at the reserved
+    amount and its next requests 429 with budget_exceeded while /key/info shows
+    spend 0 (reproduced live with rpm_limit=1). The client still gets the
+    pre-call error event and the 1011 close it got before."""
+    reservation: Final = {"reserved_cost": 0.55, "input_cost": 0.0, "finalized": False, "entries": []}
+
+    ws: Final = await _lit6973_drive_realtime_session(
+        reservation, backend_logged_success=False, phase_one_exit="pre_call"
+    )
+
+    assert reservation["finalized"] is True
+    assert json.loads(ws.send_text.await_args.args[0])["error"]["message"] == "Rate limit exceeded"
+    ws.close.assert_awaited_once_with(code=1011, reason="Pre-call error")
+
+
+@pytest.mark.asyncio
+async def test_realtime_session_denied_model_access_releases_the_budget_reservation():
+    """The key/model access check rejects before the socket is even accepted;
+    that exit skipped the release as well, pinning the reservation."""
+    reservation: Final = {"reserved_cost": 0.55, "input_cost": 0.0, "finalized": False, "entries": []}
+
+    ws: Final = await _lit6973_drive_realtime_session(
+        reservation, backend_logged_success=False, phase_one_exit="model_access"
+    )
+
+    assert reservation["finalized"] is True
+    ws.close.assert_awaited_once_with(code=1008, reason="key cannot access model")
 
 
 @pytest.mark.asyncio
@@ -9622,6 +9674,23 @@ async def test_release_or_invalidate_falls_back_to_invalidating_the_counters():
         await br.release_or_invalidate_budget_reservation(budget_reservation=reservation)
 
     assert invalidated == ["spend:key:hashed-token"]
+    assert reservation["finalized"] is True
+
+
+@pytest.mark.asyncio
+async def test_release_or_invalidate_finalizes_even_when_the_invalidate_fallback_fails():
+    """Both counter-store calls failing must not raise out of the realtime
+    endpoint's finally (it would mask the session's own outcome) and must still
+    stamp finalized so nothing retries the same reservation."""
+    from litellm.proxy.spend_tracking import budget_reservation as br
+
+    reservation: Final = {"reserved_cost": 0.55, "input_cost": 0.0, "finalized": False, "entries": []}
+    failing_release = patch.object(br, "release_budget_reservation", new=AsyncMock(side_effect=RuntimeError("counter store down")))  # test-quality-ok: forces the fallback branch
+    failing_invalidate = patch.object(br, "invalidate_budget_reservation_counters", new=AsyncMock(side_effect=RuntimeError("still down")))  # test-quality-ok: forces the fallback itself to fail
+
+    with failing_release, failing_invalidate:
+        await br.release_or_invalidate_budget_reservation(budget_reservation=reservation)
+
     assert reservation["finalized"] is True
 
 

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -9532,27 +9532,34 @@ def _lit6973_fake_realtime_ws() -> MagicMock:
     return ws
 
 
-async def _lit6973_drive_refused_realtime_session(reservation: dict) -> None:
-    """Drive realtime_websocket_endpoint through a session the upstream refused.
+async def _lit6973_drive_realtime_session(reservation: dict, *, backend_logged_success: bool) -> None:
+    """Drive realtime_websocket_endpoint to just before its budget-reservation finally.
 
-    route_request resolves normally because the relay handles the refusal
-    internally (sends the error event, closes the client), so neither the
-    success cost callback nor a failure hook runs on _ProxyDBLogger. The
-    endpoint itself must reconcile the pre-call budget reservation, so the
-    real release runs (entries is empty, so it touches no counter store) and
-    the caller asserts on the observable reservation state afterwards."""
+    route_request resolves normally in both cases: the relay owns the session
+    once route_request returns. A successful session enqueues its success cost
+    callback and stamps REALTIME_SESSION_SUCCESS_LOGGED_KEY on the shared logging
+    object; a refused one does neither. The endpoint keys its reservation cleanup
+    off that stamp, so backend_logged_success reproduces both branches. The fake
+    logging object carries a real model_call_details dict so the stamp is
+    observable, and the reservation has empty entries so the real release touches
+    no counter store."""
+    from litellm.litellm_core_utils.realtime_streaming import REALTIME_SESSION_SUCCESS_LOGGED_KEY
     from litellm.proxy import proxy_server as ps
 
     user_api_key_dict: Final = UserAPIKeyAuth(api_key="sk-test", token="hashed-token")
     user_api_key_dict.budget_reservation = reservation
 
-    completed: Final = asyncio.get_running_loop().create_future()
-    completed.set_result(None)
+    logging_obj: Final = MagicMock()
+    logging_obj.model_call_details = {}
 
-    pre_call: Final = AsyncMock(return_value=({"model": "vertex_ai/gemini-live-2.5-flash"}, MagicMock()))
+    async def fake_llm_call() -> None:
+        if backend_logged_success:
+            logging_obj.model_call_details[REALTIME_SESSION_SUCCESS_LOGGED_KEY] = True
+
+    pre_call: Final = AsyncMock(return_value=({"model": "vertex_ai/gemini-live-2.5-flash"}, logging_obj))
     can_call = patch.object(ps, "can_key_call_resolved_model", new=AsyncMock())  # test-quality-ok: no HTTP boundary; fakes in-process auth to reach the finally under test
     pre = patch.object(ps.ProxyBaseLLMRequestProcessing, "common_processing_pre_call_logic", new=pre_call)  # test-quality-ok: fakes phase-1 wiring; assertion checks observable reservation state
-    route = patch.object(ps, "route_request", new=AsyncMock(return_value=completed))  # test-quality-ok: fakes the relay that already handled the refusal so the session returns normally
+    route = patch.object(ps, "route_request", new=AsyncMock(return_value=fake_llm_call()))  # test-quality-ok: fakes the relay whose success/refusal outcome the endpoint reads off the logging object
     with can_call, pre, route:
         await ps.realtime_websocket_endpoint(
             websocket=_lit6973_fake_realtime_ws(),
@@ -9565,15 +9572,29 @@ async def _lit6973_drive_refused_realtime_session(reservation: dict) -> None:
 
 @pytest.mark.asyncio
 async def test_refused_realtime_session_releases_the_budget_reservation():
-    """LIT-6973: reclassifying a refused realtime session as a failure removed the
-    success-path reservation release, so the pre-call reservation stayed open and
-    pinned the key/team/user spend counters, locking the key after a couple of
-    refusals. The endpoint must reconcile it: the reservation ends up finalized."""
+    """LIT-6973: a refused realtime session enqueues no success cost callback, so
+    the pre-call reservation would stay open and pin the key/team/user spend
+    counters, locking the key after a couple of refusals. The endpoint sees no
+    success stamp and reconciles it: the reservation ends up finalized."""
     reservation: Final = {"reserved_cost": 0.55, "input_cost": 0.0, "finalized": False, "entries": []}
 
-    await _lit6973_drive_refused_realtime_session(reservation)
+    await _lit6973_drive_realtime_session(reservation, backend_logged_success=False)
 
     assert reservation["finalized"] is True
+
+
+@pytest.mark.asyncio
+async def test_successful_realtime_session_leaves_the_reservation_for_the_cost_callback():
+    """A billable realtime session settles its reservation through the enqueued
+    success cost callback, not the endpoint. The endpoint must not finalize it in
+    its finally, or it would reconcile the reservation to zero before the cost
+    callback applies real spend, so billable sessions stop counting against budget.
+    With the success stamp present, the endpoint leaves the reservation untouched."""
+    reservation: Final = {"reserved_cost": 0.55, "input_cost": 0.0, "finalized": False, "entries": []}
+
+    await _lit6973_drive_realtime_session(reservation, backend_logged_success=True)
+
+    assert reservation["finalized"] is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## TLDR

Problem this solves:

- Upstream realtime socket refused or closed: the client hangs forever
- The refused session was logged as a $0 success

How it solves it:

- The backend relay reports the upstream close instead of swallowing it
- The client gets an `error` event, then a close with the upstream code and reason
- A session refused before any frame goes through the failure handlers, not success
- A close seen while forwarding a client message reaches the client too
- The relayed close message and reason go through the proxy's client-facing redaction, so a credential, internal hostname, private IP, or server path echoed by the upstream never reaches the client
- The session is flagged async in its logging params, so loggers with a sync failure hook (Langfuse, OpenTelemetry, MLflow, Literal AI, DeepEval, New Relic) get the failure once, not twice
- The refusal check keys off frames actually received from upstream, so the synthetic `session.created` of deferred Gemini setup (`LITELLM_GEMINI_LIVE_DEFER_SETUP`) and the transcription usage flushed at close no longer turn a refused session back into a $0 success
- The endpoint releases the pre-call budget reservation of a refused or failed session, and of one it rejected before the relay started (a rate limit, a guardrail, a model the key cannot call), so it no longer leaves the key, team, and user spend counters pinned above real spend (which 429s the key's next requests until the counter TTL expires); a successful session stamps a marker at the point its success log is dispatched, and the endpoint leaves those reservations to the cost callback so real spend settles exactly once

## User Flow

Before: a developer whose voice app goes through the proxy to a Vertex Live model that the configured region does not serve gets a socket that never says anything

1. Their app opens `wss://litellm-domain/v1/realtime?model=vertex_ai/gemini-live-2.5-flash` with `Authorization: Bearer <virtual key>` and the handshake completes in under a second
2. Nothing comes back: no `session.created`, no `error` event, and the socket stays open
3. Their receive call sits there until their own timeout fires (60s in the run below) and they tear the socket down themselves, with nothing to show the user
4. `GET https://litellm-domain/spend/logs?api_key=<virtual key>` lists the session as `"status": "success"`, `"spend": 0.0`, `"total_tokens": 0`, and https://litellm-domain/ui/?page=logs shows it as a successful realtime call

After: the same connection is closed about a second later with the upstream's own reason, so the app can surface the error and try another region

1. Their app opens `wss://litellm-domain/v1/realtime?model=vertex_ai/gemini-live-2.5-flash` with `Authorization: Bearer <virtual key>` and the handshake completes in under a second
2. About a second later they receive `{"type": "error", "error": {"type": "server_error", "message": "upstream websocket closed with code 1008: Publisher model `projects/<project>/locations/us-east5/publishers/google/models/gemini-live-2.5-flash` was not found"}}`
3. The socket is then closed with code 1008 and that same reason, so their receive call returns instead of hanging
4. `GET https://litellm-domain/spend/logs?api_key=<virtual key>` returns no row for the refused session, and logging callbacks get exactly one failure event for it instead of a success
5. Their next request on that key goes through as usual: neither the refused session nor one the proxy rejected before it started (a rate limit or a guardrail) leaves a budget reservation behind, so `POST https://litellm-domain/v1/chat/completions` returns 200 rather than a 429 budget error

## Relevant issues

## Linear ticket

Resolves LIT-6973

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup: one proxy instance per leg booted with `--num_workers 2 --detailed_debug --use_v2_migration_resolver` from the commit named in its heading (Before on port 44289, After on port 26632), both on the same fresh Postgres, with this config (the Vertex project id is redacted as `<project>` throughout)

```yaml
model_list:
  - model_name: vertex_ai/gemini-live-2.5-flash
    litellm_params:
      model: vertex_ai/gemini-live-2.5-flash
      vertex_project: <project>
  - model_name: vertex_ai/gemini-live-2.5-flash-native-audio
    litellm_params:
      model: vertex_ai/gemini-live-2.5-flash-native-audio
      vertex_project: <project>
      vertex_location: global

general_settings:
  store_model_in_db: true
```

`VERTEXAI_LOCATION=us-east5` is set in the proxy's environment, a region where neither Live model is published, so Vertex refuses each session with close code 1008. Each case creates a virtual key with `POST /key/generate`, connects a plain `websockets` client to `ws://127.0.0.1:<port>/v1/realtime?model=<model>` with `Authorization: Bearer <key>`, prints every event until the server closes the socket or 60s pass, then reads `GET /spend/logs?api_key=<key>`

Each leg runs `run_leg.sh`, which mints a virtual key, runs `realtime_client.py` (a plain `websockets` client that prints every event until the socket closes or the wait elapses), then reads `GET /spend/logs?api_key=<key>`:

<details><summary><code>run_leg.sh</code> and <code>realtime_client.py</code></summary>

```zsh
# run_leg.sh <port> <model> <wait_s> <tag>
KEY=$(curl -s -X POST "http://127.0.0.1:${PORT}/key/generate" -H "Authorization: Bearer $MASTER" \
  -H 'Content-Type: application/json' -d "{\"key_alias\": \"lit6973-${TAG}\"}" | jq -r .key)
python realtime_client.py "ws://127.0.0.1:${PORT}" "${KEY}" "${MODEL}" "${WAIT}"
sleep 3
curl -s "http://127.0.0.1:${PORT}/spend/logs?api_key=${KEY}" -H "Authorization: Bearer $MASTER"
```

```python
# realtime_client.py <base> <key> <model> <wait_s>
async with websockets.connect(f"{base}/v1/realtime?model={model}",
                              additional_headers={"Authorization": f"Bearer {key}"}) as ws:
    print(f"handshake ok after {time.monotonic()-started:.2f}s; waiting up to {wait_s:.0f}s for the first server event")
    try:
        while True:
            raw = await asyncio.wait_for(ws.recv(), timeout=wait_s - (time.monotonic()-started))
            print(f"[{time.monotonic()-started:.2f}s] event: {json.dumps(json.loads(raw))[:400]}")
    except asyncio.TimeoutError:
        print(f"TIMEOUT: nothing arrived in {wait_s:.0f}s, socket still open (close_code={ws.close_code})")
        return 2
    except websockets.exceptions.ConnectionClosed as e:
        rcvd = e.rcvd
        print(f"[{time.monotonic()-started:.2f}s] CLOSED by server: code={rcvd.code if rcvd else None} reason={rcvd.reason if rcvd else None!r}")
        return 0
```

</details>



### Before (639b3f4f62)

#### vertex_ai/gemini-live-2.5-flash with VERTEXAI_LOCATION=us-east5

```
--- before2_flash: create virtual key ---
key created: sk-k6oJt...
--- before2_flash: realtime client (vertex_ai/gemini-live-2.5-flash, wait 60s) ---
connecting ws://127.0.0.1:44289/v1/realtime?model=vertex_ai/gemini-live-2.5-flash
handshake ok after 0.38s; waiting up to 60s for the first server event
TIMEOUT: nothing arrived in 60s, socket still open (close_code=None)
client exit: 2
--- before2_flash: spend logs for this key ---
rows: 1
{"request_id": "cd6e45ee-a17b-4dbb-9e00-991714d2f0d7", "call_type": "_arealtime", "model": "vertex_ai/gemini-live-2.5-flash", "spend": 0.0, "status": "success", "total_tokens": 0, "startTime": "2026-09-05T02:29:04.801000Z", "endTime": "2026-09-05T02:29:05.649000Z"}
```

#### vertex_ai/gemini-live-2.5-flash-native-audio with vertex_location: global

```
--- before2_native: create virtual key ---
key created: sk-A3H2w...
--- before2_native: realtime client (vertex_ai/gemini-live-2.5-flash-native-audio, wait 60s) ---
connecting ws://127.0.0.1:44289/v1/realtime?model=vertex_ai/gemini-live-2.5-flash-native-audio
handshake ok after 0.07s; waiting up to 60s for the first server event
TIMEOUT: nothing arrived in 60s, socket still open (close_code=None)
client exit: 2
--- before2_native: spend logs for this key ---
rows: 1
{"request_id": "d0b57ab1-2339-4f81-9bce-3d133a1dda38", "call_type": "_arealtime", "model": "vertex_ai/gemini-live-2.5-flash-native-audio", "spend": 0.0, "status": "success", "total_tokens": 0, "startTime": "2026-09-05T02:30:07.760000Z", "endTime": "2026-09-05T02:30:08.182000Z"}
```

### After (37722eba68)

#### vertex_ai/gemini-live-2.5-flash with VERTEXAI_LOCATION=us-east5

```
--- after_flash: create virtual key ---
key created: sk-lM_Dj...
--- after_flash: realtime client (vertex_ai/gemini-live-2.5-flash, wait 60s) ---
connecting ws://127.0.0.1:26632/v1/realtime?model=vertex_ai/gemini-live-2.5-flash
handshake ok after 2.25s; waiting up to 60s for the first server event
[3.41s] event: {"type": "error", "error": {"type": "server_error", "message": "upstream websocket closed with code 1008: Publisher model `projects/<project>/locations/us-east5/publishers/google/models/gemini-live-2.5-flash` was not fo"}}
[3.49s] CLOSED by server: code=1008 reason='Publisher model `projects/<project>/locations/us-east5/publishers/google/models/gemini-live-2.5-flash` was not fo'
client exit: 0
--- after_flash: spend logs for this key ---
rows: 0
```

#### vertex_ai/gemini-live-2.5-flash-native-audio with vertex_location: global

```
--- after_native: create virtual key ---
key created: sk-blQIV...
--- after_native: realtime client (vertex_ai/gemini-live-2.5-flash-native-audio, wait 60s) ---
connecting ws://127.0.0.1:26632/v1/realtime?model=vertex_ai/gemini-live-2.5-flash-native-audio
handshake ok after 0.44s; waiting up to 60s for the first server event
[0.99s] event: {"type": "error", "error": {"type": "server_error", "message": "upstream websocket closed with code 1008: Publisher model `projects/<project>/locations/global/publishers/google/models/gemini-live-2.5-flash-native-audio`"}}
[1.04s] CLOSED by server: code=1008 reason='Publisher model `projects/<project>/locations/global/publishers/google/models/gemini-live-2.5-flash-native-audio`'
client exit: 0
--- after_native: spend logs for this key ---
rows: 0
```

### Logging split at the tip (37722eba68)

To show the callbacks and spend rows on the tip, two-worker proxies at 37722eba68 ran a file-logging `CustomLogger` that appends one row per success or failure, next to the Prometheus callback. A refused Vertex session ran against the port 26632 proxy from the After legs, and a normal `openai/gpt-realtime` session that asks for a short text response and closes after `response.done` ran against a fresh proxy on port 38307. The refused one writes no spend row and one failure event with the failure Prometheus counters; the normal one writes one success spend row ($0.000128 for 11 tokens, read 14s after the close because `PROXY_BATCH_WRITE_AT` flushes spend logs every 10s) and one success event with the success counters, `/key/info` shows the same $0.000128, and its reservation is left to that success callback rather than released by the endpoint. The Prometheus grep for the refused Flash session also picks up the native-audio failure counters from the refusal leg that ran just before it on the same proxy.

#### Refused session (vertex_ai/gemini-live-2.5-flash, VERTEXAI_LOCATION=us-east5)

```
=== fixed/refuse: model=vertex_ai/gemini-live-2.5-flash port=26632 ===
key: sk-oUPYF...
connecting ws://127.0.0.1:26632/v1/realtime?model=vertex_ai/gemini-live-2.5-flash
handshake ok after 0.59s; waiting up to 20s
[1.24s] event 1: {"type": "error", "error": {"type": "server_error", "message": "upstream websocket closed with code 1008: Publisher model `projects/<project>/locations/us-east5/publishers/google/models/gemini-live-2.5-flash` was not fo"}}
[1.31s] CLOSED by server after 1 events: code=1008 reason='Publisher model `projects/<project>/locations/us-east5/publishers/google/models/gemini-live-2.5-flash` was not fo'
client exit: 0
--- spend logs for this key ---
rows: 0
--- custom logger rows written during this scenario ---
{"kind": "failure", "pid": 44347, "call_type": "_arealtime", "model": "gemini-live-2.5-flash", "litellm_call_id": "f9d0d1e8-0d37-456f-9290-982446cef4fc", "exception": "ConnectionClosedError(Close(code=1008, reason='Publisher model `projects/<project>/locations/us-east5/publishers/google/models/gemini-live-2.5-flash` was not fo'), Close(code=1008, reason='P", "response_type": "NoneType", "response_len": null, "slo_status": "failure", "slo_response_cost": 0.0, "slo_error_str": "received 1008 (policy violation) Publisher model `projects/<project>/locations/us-east5/publishers/google/models/gemini-live-2.5-flash` was not fo; th", "ts": 1788601090.602794}
--- prometheus lines naming this model ---
litellm_deployment_failure_responses_total{model="vertex_ai/gemini-live-2.5-flash-native-audio"} 1.0
litellm_deployment_failure_responses_total{model="vertex_ai/gemini-live-2.5-flash"} 1.0
litellm_llm_api_failed_requests_metric_total{model="gemini-live-2.5-flash-native-audio"} 1.0
litellm_llm_api_failed_requests_metric_total{model="gemini-live-2.5-flash"} 1.0
```

#### Normal session (openai/gpt-realtime, text response, client closed after response.done)

```
=== fixed/openai-billed: model=gpt-realtime port=38307 ===
key: sk-Nny-m...
connecting ws://127.0.0.1:38307/v1/realtime?model=gpt-realtime
handshake ok after 2.73s; waiting up to 45s for response.done
[3.89s] event 1: {"type": "session.created", "event_id": "event_EKhqREBYRshnyGdTppx6L", "session": {"type": "realtime", "object": "realtime.session", "id": "sess_EKhqRLxLY9LSa3rponvGd", "model": "gpt-realtime", "output_modalities": ["audio"], "instructions": "Your knowledge cutoff is 2023-10. You are a helpful, witt
[3.90s] sent response.create (text only)
[3.98s] event 2: {"type": "response.created", "event_id": "event_EKhqRqvtYzkAJ560DZjSN", "response": {"object": "realtime.response", "id": "resp_EKhqRgmUpFY1rl0UpG8Tm", "status": "in_progress", "status_details": null, "output": [], "conversation_id": "conv_EKhqR18aE2L7pvMTvx3m3", "output_modalities": ["text"], "max_
[4.19s] event 3: {"type": "response.output_item.added", "event_id": "event_EKhqRGNSqTdYjRBqhJqJb", "response_id": "resp_EKhqRgmUpFY1rl0UpG8Tm", "output_index": 0, "item": {"id": "item_EKhqRtcpY6CK6oFPtwTiP", "type": "message", "status": "in_progress", "role": "assistant", "content": []}}
[4.19s] event 4: {"type": "conversation.item.added", "event_id": "event_EKhqRu9pB7iCv28zIQ0vM", "previous_item_id": null, "item": {"id": "item_EKhqRtcpY6CK6oFPtwTiP", "type": "message", "status": "in_progress", "role": "assistant", "content": []}}
[4.19s] event 5: {"type": "response.content_part.added", "event_id": "event_EKhqRSzW4bIOpkbZW8dWz", "response_id": "resp_EKhqRgmUpFY1rl0UpG8Tm", "item_id": "item_EKhqRtcpY6CK6oFPtwTiP", "output_index": 0, "content_index": 0, "part": {"type": "text", "text": ""}}
[4.24s] event 11: {"type": "response.output_text.done", "event_id": "event_EKhqRxTnx68Cm8T19n6Sa", "response_id": "resp_EKhqRgmUpFY1rl0UpG8Tm", "item_id": "item_EKhqRtcpY6CK6oFPtwTiP", "output_index": 0, "content_index": 0, "text": "hello from litellm"}
[4.24s] event 12: {"type": "response.content_part.done", "event_id": "event_EKhqRA1ZNGGMtXCpTAGg3", "response_id": "resp_EKhqRgmUpFY1rl0UpG8Tm", "item_id": "item_EKhqRtcpY6CK6oFPtwTiP", "output_index": 0, "content_index": 0, "part": {"type": "text", "text": "hello from litellm"}}
[4.25s] event 13: {"type": "conversation.item.done", "event_id": "event_EKhqRUIu9IJTiqlSCgI6X", "previous_item_id": null, "item": {"id": "item_EKhqRtcpY6CK6oFPtwTiP", "type": "message", "status": "completed", "role": "assistant", "content": [{"type": "output_text", "text": "hello from litellm"}]}}
[4.25s] event 14: {"type": "response.output_item.done", "event_id": "event_EKhqRSggsNtCa41ywGYLn", "response_id": "resp_EKhqRgmUpFY1rl0UpG8Tm", "output_index": 0, "item": {"id": "item_EKhqRtcpY6CK6oFPtwTiP", "type": "message", "status": "completed", "role": "assistant", "content": [{"type": "output_text", "text": "he
[4.25s] event 15: {"type": "response.done", "event_id": "event_EKhqRKI7zMi3WpGWWcgPG", "response": {"object": "realtime.response", "id": "resp_EKhqRgmUpFY1rl0UpG8Tm", "status": "completed", "status_details": null, "output": [{"id": "item_EKhqRtcpY6CK6oFPtwTiP", "type": "message", "status": "completed", "role": "assis
[4.25s] response.done after 5 delta events; text='hello from litellm'
usage: {"total_tokens": 11, "input_tokens": 4, "output_tokens": 7, "input_token_details": {"text_tokens": 4, "audio_tokens": 0, "image_tokens": 0, "cached_tokens": 0, "cached_tokens_details": {"text_tokens": 0, "audio_tokens": 0, "image_tokens": 0}}, "output_token_details": {"text_tokens": 7, "audio_tokens": 0}}
[4.26s] CLIENT CLOSED after 15 events (close_code=1000)
client exit: 0
sleeping 14s, past the 10s PROXY_BATCH_WRITE_AT spend log flush
--- spend logs for this key ---
rows: 1
{"call_type": "_arealtime", "model": "openai/gpt-realtime", "spend": 0.000128, "status": "success", "prompt_tokens": 4, "completion_tokens": 7, "total_tokens": 11}
--- key info ---
{"spend": 0.000128, "max_budget": null}
--- custom logger rows written during this scenario ---
{"kind": "success", "pid": 57980, "call_type": "_arealtime", "model": "gpt-realtime", "litellm_call_id": "35856cd3-4a32-44ba-8f59-49f8201ad30c", "exception": "None", "response_type": "list", "response_len": 4, "slo_status": "success", "slo_response_cost": 0.000128, "slo_error_str": "", "ts": 1788603807.9403882}
--- prometheus lines naming this model ---
litellm_deployment_success_responses_total{model="gpt-realtime"} 1.0
litellm_proxy_total_requests_metric_total{model="gpt-realtime"} 1.0
litellm_requests_metric_total{model="gpt-realtime"} 1.0
```

### Budget reservation after a refused session

Every proxied request takes a pre-call budget reservation on the key, team, and user spend counters that the success cost callback later settles. A refused session runs neither that callback nor a failure hook on the DB logger, so with the failure reclassification alone (the previous tip of this PR, 74613f9bd4) the reservation stayed open: two refusals on a key with `max_budget: 0.8` pinned its counter at the budget and the next request on the key got a 429 even though `/key/info` showed `spend: 0.0`. The endpoint now releases the reservation of every session that never dispatched a success log. A successful session stamps `realtime_session_success_logged` on the shared logging object at the moment its success handlers are enqueued, and the endpoint skips those, leaving the reservation to the cost callback (which is enqueued, not awaited, so a blanket release would have zeroed it first and the callback would have skipped the already-finalized reservation, undercounting real spend; that regression is pinned by `test_successful_realtime_session_leaves_the_reservation_for_the_cost_callback`). Same two-worker proxy, same client, a fresh key with `max_budget: 0.8` each time, two refused `vertex_ai/gemini-live-2.5-flash-native-audio` sessions, then a chat completion on the same key.

#### Previous tip (74613f9bd4): the key is locked out

```
key created: sk-qyu0y...
--- tip: realtime attempt 1 ---
[2.13s] CLOSED by server: code=1008 reason='Publisher model `projects/<project>/locations/global/publishers/google/models/gemini-live-2.5-flash-native-audio`'
--- tip: realtime attempt 2 ---
[0.23s] CLOSED by server: code=1008 reason='Publisher model `projects/<project>/locations/global/publishers/google/models/gemini-live-2.5-flash-native-audio`'
--- tip: POST /v1/chat/completions on the same key ---
{"error":{"message":"Budget has been exceeded! Key=lit6973-lockout2-tip-1788589853  Current cost: 0.8, Max budget: 0.8","type":"budget_exceeded","param":null,"code":"429"}}
HTTP 429
--- tip: key info ---
{'spend': 0.0, 'max_budget': 0.8}
```

#### After (37722eba68): the key keeps working

```
key created: sk-4-PsQ...
--- fixed: realtime attempt 1 ---
[0.97s] CLOSED by server: code=1008 reason='Publisher model `projects/<project>/locations/global/publishers/google/models/gemini-live-2.5-flash-native-audio`'
--- fixed: realtime attempt 2 ---
[0.24s] CLOSED by server: code=1008 reason='Publisher model `projects/<project>/locations/global/publishers/google/models/gemini-live-2.5-flash-native-audio`'
--- fixed: POST /v1/chat/completions on the same key ---
{"id":"chatcmpl-EKh9EiIX8oSPeSBxPBSg9K7ZoGtGW","created":1788601128,"model":"gpt-5.6","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"Hi! How can I help?","role":"assistant","provider_specific_fields":{"refusal":nu
HTTP 200
--- fixed: key info ---
{'spend': 0.0, 'max_budget': 0.8}
```

### Budget reservation after a pre-call rejection

The release above only covered sessions that reached the relay. The endpoint has three exits before that point (no model given, a model the key cannot call, and a pre-call rejection such as a rate limit or a guardrail), and each returned without releasing the reservation auth had taken, so a rejected session pinned the key exactly like a refused one did. All three now go through one helper that sends the client the same error event and close it got before and then releases the reservation in a `finally`: the close comes first so a slow counter store never delays the rejection, and a client that already hung up still gets its reservation released. Only the pre-call rejection reserves anything in practice: a connection without `?model=` never takes a reservation, and a key that cannot call the model is refused by auth before the reservation step, so the endpoint-side release on those two exits is defensive and pinned by unit tests, while the rate-limit exit is what the run below shows. Same two-worker proxy and client, a fresh key with `max_budget: 0.05` and `rpm_limit: 1`; each worker holds its own rpm counter, so back-to-back `gpt-realtime` attempts run until one lands on a worker that already served the key that minute and is rejected pre-call, then eight chat completions on the same key right away (the in-memory spend counter expires after 60s, so a probe that waits for the rpm window to roll over cannot see the pinned reservation). Calls that land on the worker that rejected the session are the ones that can see the leak: with it they fail at auth with `budget_exceeded` while `/key/info` shows spend 0; without it every call is rate-limited the same way as on the other worker, which is the rpm limit doing its job. The Before leg for this section runs at 1fe87e8e25, the tip just before the pre-call fix, rather than at the merge base: `git diff 639b3f4f62 1fe87e8e25 -- litellm/proxy/proxy_server.py` only adds the refused-session release, so the three pre-relay exits there are the merge base's and the leg isolates the pre-call change.

#### Before (1fe87e8e25): calls behind the rejected attempt fail with budget_exceeded

```
key created: sk-bIcqq... (max_budget 0.05, rpm_limit 1)
--- before: realtime attempt 1 (gpt-realtime, client hangs up after 3s; two workers each hold their own rpm counter) ---
connecting ws://127.0.0.1:55709/v1/realtime?model=gpt-realtime
handshake ok after 0.65s; waiting up to 3s for the first server event
[1.13s] event: {"type": "session.created", "event_id": "event_EKh6n8cUcdlb7pANCi4A0", "session": {"type": "realtime", "object": "realtime.session", "id": "sess_EKh6n4LFlfzTVMnHUVFKJ", "model": "gpt-realtime", "output_modalities": ["audio"], "instructions": "Your knowledge cutoff is 2023-10. You are a helpful, witt
TIMEOUT: nothing arrived in 3s, socket still open (close_code=None)
--- before: realtime attempt 2 (gpt-realtime, client hangs up after 3s; two workers each hold their own rpm counter) ---
connecting ws://127.0.0.1:55709/v1/realtime?model=gpt-realtime
handshake ok after 0.32s; waiting up to 3s for the first server event
[0.32s] event: {"type": "error", "error": {"type": "guardrail_error", "message": "429: Rate limit exceeded for api_key: 31b7f763d05299c32e4f10224f5c2400fe1d18beeb1e4192fff2bdd832385a73. Limit type: requests. Current limit: 1, Remaining: 0. Limit resets at: 2026-09-05 02:37:20 UTC"}}
[0.32s] CLOSED by server: code=1011 reason='Pre-call error'
(attempt 2 was rejected pre-call by the rpm limit)
--- before: 8x POST /v1/chat/completions (gpt-5.6) on the same key, right away (the in-memory spend counter expires after 60s) ---
call 1: HTTP 200 ok: Hi! How can I help?
call 2: HTTP 429 budget_exceeded: Budget has been exceeded! Key=31b7f763d05299c32e4f10224f5c2400fe1d18beeb1e4192fff2bdd832385a73 Current cost: 0
call 3: HTTP 429 throttling_error: Rate limit exceeded for api_key: 31b7f763d05299c32e4f10224f5c2400fe1d18beeb1e4192fff2bdd832385a73. Limit type:
call 4: HTTP 429 budget_exceeded: Budget has been exceeded! Key=31b7f763d05299c32e4f10224f5c2400fe1d18beeb1e4192fff2bdd832385a73 Current cost: 0
call 5: HTTP 429 budget_exceeded: Budget has been exceeded! Key=31b7f763d05299c32e4f10224f5c2400fe1d18beeb1e4192fff2bdd832385a73 Current cost: 0
call 6: HTTP 429 budget_exceeded: Budget has been exceeded! Key=31b7f763d05299c32e4f10224f5c2400fe1d18beeb1e4192fff2bdd832385a73 Current cost: 0
call 7: HTTP 429 budget_exceeded: Budget has been exceeded! Key=31b7f763d05299c32e4f10224f5c2400fe1d18beeb1e4192fff2bdd832385a73 Current cost: 0
call 8: HTTP 429 throttling_error: Rate limit exceeded for api_key: 31b7f763d05299c32e4f10224f5c2400fe1d18beeb1e4192fff2bdd832385a73. Limit type:
before: budget_exceeded rejections: 5 of 8 (each worker holds its own spend counter, so only calls landing on the worker that rejected the session can see a leaked reservation; rpm 1 per worker also rejects repeat calls, and those are not the leak)
--- before: key info ---
{'spend': 0.0, 'max_budget': 0.05, 'rpm_limit': 1}
```

#### After (37722eba68): only the rpm limit rejects, no budget_exceeded

```
key created: sk-Mma9_... (max_budget 0.05, rpm_limit 1)
--- fixed: realtime attempt 1 (gpt-realtime, client hangs up after 3s; two workers each hold their own rpm counter) ---
connecting ws://127.0.0.1:26632/v1/realtime?model=gpt-realtime
handshake ok after 0.08s; waiting up to 3s for the first server event
[0.32s] event: {"type": "session.created", "event_id": "event_EKh9Ru8BMknUnpfNKDudY", "session": {"type": "realtime", "object": "realtime.session", "id": "sess_EKh9RK4gsYgsIj8kp3iHV", "model": "gpt-realtime", "output_modalities": ["audio"], "instructions": "Your knowledge cutoff is 2023-10. You are a helpful, witt
TIMEOUT: nothing arrived in 3s, socket still open (close_code=None)
--- fixed: realtime attempt 2 (gpt-realtime, client hangs up after 3s; two workers each hold their own rpm counter) ---
connecting ws://127.0.0.1:26632/v1/realtime?model=gpt-realtime
handshake ok after 0.25s; waiting up to 3s for the first server event
[0.25s] event: {"type": "error", "error": {"type": "guardrail_error", "message": "429: Rate limit exceeded for api_key: f6f19287f8e73131e724e6db75ce11f21ea26e0713d3fb37347d516b0eb7fbdf. Limit type: requests. Current limit: 1, Remaining: 0. Limit resets at: 2026-09-05 02:40:04 UTC"}}
[0.25s] CLOSED by server: code=1011 reason='Pre-call error'
(attempt 2 was rejected pre-call by the rpm limit)
--- fixed: 8x POST /v1/chat/completions (gpt-5.6) on the same key, right away (the in-memory spend counter expires after 60s) ---
call 1: HTTP 200 ok: Hi! How can I help?
call 2: HTTP 429 throttling_error: Rate limit exceeded for api_key: f6f19287f8e73131e724e6db75ce11f21ea26e0713d3fb37347d516b0eb7fbdf. Limit type:
call 3: HTTP 429 throttling_error: Rate limit exceeded for api_key: f6f19287f8e73131e724e6db75ce11f21ea26e0713d3fb37347d516b0eb7fbdf. Limit type:
call 4: HTTP 429 throttling_error: Rate limit exceeded for api_key: f6f19287f8e73131e724e6db75ce11f21ea26e0713d3fb37347d516b0eb7fbdf. Limit type:
call 5: HTTP 429 throttling_error: Rate limit exceeded for api_key: f6f19287f8e73131e724e6db75ce11f21ea26e0713d3fb37347d516b0eb7fbdf. Limit type:
call 6: HTTP 429 throttling_error: Rate limit exceeded for api_key: f6f19287f8e73131e724e6db75ce11f21ea26e0713d3fb37347d516b0eb7fbdf. Limit type:
call 7: HTTP 429 throttling_error: Rate limit exceeded for api_key: f6f19287f8e73131e724e6db75ce11f21ea26e0713d3fb37347d516b0eb7fbdf. Limit type:
call 8: HTTP 429 throttling_error: Rate limit exceeded for api_key: f6f19287f8e73131e724e6db75ce11f21ea26e0713d3fb37347d516b0eb7fbdf. Limit type:
fixed: budget_exceeded rejections: 0 of 8 (each worker holds its own spend counter, so only calls landing on the worker that rejected the session can see a leaked reservation; rpm 1 per worker also rejects repeat calls, and those are not the leak)
--- fixed: key info ---
{'spend': 0.000228, 'max_budget': 0.05, 'rpm_limit': 1}
```

Observations from the run:

- Vertex truncates its own close reason at 123 bytes; unchanged by this PR
- The relayed close message and reason pass through `redact_internal_details_from_client_message`, the proxy's client-facing redaction (credentials, private IPs, internal hostnames, filesystem paths, embedded tracebacks); the Vertex refusal text carries none of those, so its output above is unchanged
- Both legs ran two uvicorn workers; behavior matched on every connection

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- A session the upstream refused before sending any frame, or one the proxy rejected before the relay started (a rate limit, a guardrail, a model the key cannot call), writes no `/spend/logs` row and does not show up on the Logs page; the refusal is captured by failure callbacks (one failure event, shown above), the Prometheus failure counters, and the proxy error log instead. LIT-6973 accepts "no spend row, or an errored one" for a session that never started
- The relayed close reason still carries the model's provider path (e.g. `projects/<project>/locations/...` for Vertex); the redaction strips credentials, internal hostnames, private IPs and server filesystem paths, and leaves the provider resource path just like every HTTP error the proxy already returns to clients
- Upstream close codes a server may not send (1005, 1006, 1015, anything under 3000 outside the RFC 6455 list) reach the client as 1011; the original code stays in the error event's message
- An upstream error after the first frame was relayed is still logged as a successful session, matching existing realtime logging (the refusal check keys off whether any frame was received)
- A proxy-side relay crash mid-session is logged as a success and the client is closed with 1011; unchanged from before this PR, which scopes to sessions the upstream refused
- A proxy-side error inside the client receive loop (a client frame the relay cannot process, a provider transform that raises) ends the session the way a client hang-up does, with no error event and no explicit close from the relay; pre-existing and out of scope here, tracked in LIT-7068
- A deployment that refuses every session is not cooled down (the router reads no status code off the close); unchanged from before, where refusals counted as successes and never cooled down either
- Sync-only `CustomLogger` hooks no longer fire for realtime sessions: a subclass that overrides only `log_success_event` / `log_failure_event` sees no realtime sessions after this PR and needs `async_log_success_event` / `async_log_failure_event`, which every other proxy call type already requires and every built-in logger implements; plain-function and legacy sync callbacks are affected the same way
- An upstream that rejects the websocket handshake itself (an HTTP 4xx before the upgrade) still closes the client with 1011: the `InvalidStatusCode` branches in the OpenAI realtime handler and the endpoint never fire under websockets 15, which raises `InvalidStatus` instead, and a live version would have passed the HTTP status as the close code, which the protocol rejects. Pre-existing and needs its own status-to-close-code mapping, tracked in LIT-7058
- The Responses API websocket relay has the same upstream-close hang and never releases its budget reservation on its failure exits; separate endpoint, out of scope here and the last relay in the class, tracked in LIT-7044

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 37722eba68 passes /live-pr-risk
