### PR TITLE
fix(codestral): add min_tokens to CodestralTextCompletionConfig supported params (#39854)

### DIFF
--- a/litellm/llms/codestral/completion/transformation.py
+++ b/litellm/llms/codestral/completion/transformation.py
@@ -45,6 +45,7 @@ class CodestralTextCompletionConfig(OpenAITextCompletionConfig):
             "top_p",
             "max_tokens",
             "max_completion_tokens",
+            "min_tokens",
             "stream",
             "seed",
             "stop",

--- a/tests/test_litellm/llms/codestral/completion/test_transformation.py
+++ b/tests/test_litellm/llms/codestral/completion/test_transformation.py
@@ -1,0 +1,31 @@
+import litellm
+from litellm.llms.codestral.completion.transformation import (
+    CodestralTextCompletionConfig,
+)
+
+
+def test_codestral_supported_openai_params_includes_min_tokens():
+    config = CodestralTextCompletionConfig()
+    supported_params = config.get_supported_openai_params(model="codestral-latest")
+    assert "min_tokens" in supported_params
+    assert "max_tokens" in supported_params
+    assert "suffix" in supported_params
+
+
+def test_codestral_map_openai_params_min_tokens():
+    config = CodestralTextCompletionConfig()
+    mapped = config.map_openai_params(
+        non_default_params={"min_tokens": 10},
+        optional_params={},
+        model="codestral-latest",
+        drop_params=False,
+    )
+    assert mapped == {"min_tokens": 10}
+
+
+def test_get_supported_openai_params_for_text_completion_codestral():
+    supported = litellm.get_supported_openai_params(
+        model="codestral/codestral-latest",
+        custom_llm_provider="text-completion-codestral",
+    )
+    assert "min_tokens" in supported


### PR DESCRIPTION
## TLDR

Problem this solves:
- `CodestralTextCompletionConfig.get_supported_openai_params` omitted `min_tokens`, even though it is handled in `map_openai_params`.

How it solves it:
- Added `"min_tokens"` to `CodestralTextCompletionConfig.get_supported_openai_params`.
- Added unit tests covering parameter support and mapping in `tests/test_litellm/llms/codestral/completion/test_transformation.py`.

## User Flow

Before: a developer using Codestral FIM text completions has `min_tokens` omitted from supported parameters and silently dropped when `drop_params=True`.

1. The user inspects `litellm.get_supported_openai_params(model="codestral/codestral-latest", custom_llm_provider="text-completion-codestral")`.
2. `min_tokens` is missing from the returned list.
3. Requests sending `min_tokens` have the parameter stripped when `drop_params=True`.

After: `min_tokens` is recognized as supported and forwarded.

1. The user inspects `litellm.get_supported_openai_params(model="codestral/codestral-latest", custom_llm_provider="text-completion-codestral")`.
2. `min_tokens` is present in the returned list.
3. Requests sending `min_tokens` retain the parameter through `map_openai_params`.

## Relevant issues

Fixes #39854

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally: `pytest tests/test_litellm/llms/codestral/completion/test_transformation.py -v` (3 passed)
- [x] My PR passes all required CI/CD checks (e.g., lint, formatting)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Type

🐛 Bug Fix

## Caveats (if any)

### Low
- None