### PR TITLE
fix(auth): scope access-group grants to deployments the key's team can use

### DIFF
--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -76,6 +76,7 @@ from litellm.proxy.common_utils.http_parsing_utils import (
     _safe_get_request_headers,
     _safe_get_request_query_params,
 )
+from litellm.proxy.common_utils.resource_ownership import is_proxy_admin
 from litellm.proxy.common_utils.timezone_utils import get_budget_reset_time
 from litellm.proxy.common_utils.user_api_key_cache import (
     END_USER_RESTRICTED_REGISTRY_OVERFLOW_SENTINEL,
@@ -4271,7 +4272,7 @@ async def can_key_call_model(
     """
     key_models: Final = _resolve_key_models_for_auth_check(valid_token=valid_token)
     try:
-        return _can_object_call_model(
+        _can_object_call_model(
             model=model,
             llm_router=llm_router,
             models=key_models,
@@ -4282,20 +4283,46 @@ async def can_key_call_model(
     except ProxyException:
         # Fallback: check key's access_group_ids
         key_access_group_ids: Final = valid_token.access_group_ids or []
-        if key_access_group_ids:
-            models_from_groups: Final = await _get_models_from_access_groups(
-                access_group_ids=key_access_group_ids,
-            )
-            if models_from_groups:
-                return _can_object_call_model(
-                    model=model,
-                    llm_router=llm_router,
-                    models=models_from_groups,
-                    team_model_aliases=valid_token.team_model_aliases,
-                    team_id=valid_token.team_id,
-                    object_type="key",
-                )
-        raise
+        if not key_access_group_ids:
+            raise
+        models_from_groups: Final = await _get_models_from_access_groups(access_group_ids=key_access_group_ids)
+        if not models_from_groups:
+            raise
+        _can_object_call_model(
+            model=model,
+            llm_router=llm_router,
+            models=models_from_groups,
+            team_model_aliases=valid_token.team_model_aliases,
+            team_id=valid_token.team_id,
+            object_type="key",
+        )
+    _raise_when_key_reaches_only_other_teams_deployments(model=model, llm_router=llm_router, valid_token=valid_token)
+    return True
+
+
+def _raise_when_key_reaches_only_other_teams_deployments(
+    model: str | Sequence[str],
+    llm_router: Router | None,
+    valid_token: UserAPIKeyAuth,
+) -> None:
+    if llm_router is None or is_proxy_admin(valid_token):
+        return
+    requested_models: Final = (model,) if isinstance(model, str) else tuple(model)
+    foreign_model: Final = next(
+        (m for m in requested_models if llm_router.model_owned_by_other_teams(m, valid_token.team_id)),
+        None,
+    )
+    if foreign_model is None:
+        return
+    raise ProxyException(
+        message=(
+            f"key not allowed to access model. This key can only access "
+            f"models={_resolve_key_models_for_auth_check(valid_token=valid_token)}. Tried to access {foreign_model}"
+        ),
+        type=ProxyErrorTypes.get_model_access_error_type_for_object(object_type="key"),
+        param="model",
+        code=status.HTTP_403_FORBIDDEN,
+    )
 
 
 async def can_key_call_resolved_model(

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -4296,11 +4296,11 @@ async def can_key_call_model(
             team_id=valid_token.team_id,
             object_type="key",
         )
-    _raise_when_key_reaches_only_other_teams_deployments(model=model, llm_router=llm_router, valid_token=valid_token)
+    raise_when_key_reaches_only_other_teams_deployments(model=model, llm_router=llm_router, valid_token=valid_token)
     return True
 
 
-def _raise_when_key_reaches_only_other_teams_deployments(
+def raise_when_key_reaches_only_other_teams_deployments(
     model: str | Sequence[str],
     llm_router: Router | None,
     valid_token: UserAPIKeyAuth,
@@ -4316,8 +4316,7 @@ def _raise_when_key_reaches_only_other_teams_deployments(
         return
     raise ProxyException(
         message=(
-            f"key not allowed to access model. This key can only access "
-            f"models={_resolve_key_models_for_auth_check(valid_token=valid_token)}. Tried to access {foreign_model}"
+            f"key not allowed to access model. Tried to access {foreign_model}, which is only deployed for other teams"
         ),
         type=ProxyErrorTypes.get_model_access_error_type_for_object(object_type="key"),
         param="model",
@@ -4340,7 +4339,9 @@ async def can_key_call_resolved_model(
     skip_key_model_check: Final = valid_token.config or (
         isinstance(valid_token.models, list) and SpecialModelNames.all_team_models.value in valid_token.models
     )
-    if not skip_key_model_check:
+    if skip_key_model_check:
+        raise_when_key_reaches_only_other_teams_deployments(model=model, llm_router=llm_router, valid_token=valid_token)
+    else:
         await can_key_call_model(
             model=model,
             llm_model_list=llm_model_list,

--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -1,7 +1,8 @@
 # What is this?
 ## Common checks for /v1/models and `/model/info`
 import copy
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
+from types import MappingProxyType
 from typing import Any, Final
 
 import litellm
@@ -49,7 +50,7 @@ def get_provider_models(provider: str, litellm_params: LiteLLM_Params | None = N
 
 
 def _get_models_from_access_groups(
-    model_access_groups: dict[str, list[str]],
+    model_access_groups: Mapping[str, Sequence[str]],
     all_models: list[str],
     include_model_access_groups: bool | None = False,
     proxy_model_list: Sequence[str] | None = None,
@@ -96,8 +97,8 @@ async def get_mcp_server_ids(
 
 def get_key_models(
     user_api_key_dict: UserAPIKeyAuth,
-    proxy_model_list: list[str],
-    model_access_groups: dict[str, list[str]],
+    proxy_model_list: Sequence[str],
+    model_access_groups: Mapping[str, Sequence[str]],
     include_model_access_groups: bool | None = False,
     only_model_access_groups: bool | None = False,
 ) -> list[str]:
@@ -140,8 +141,8 @@ def get_key_models(
 
 def get_team_models(
     team_models: list[str],
-    proxy_model_list: list[str],
-    model_access_groups: dict[str, list[str]],
+    proxy_model_list: Sequence[str],
+    model_access_groups: Mapping[str, Sequence[str]],
     include_model_access_groups: bool | None = False,
 ) -> list[str]:
     """
@@ -183,12 +184,12 @@ def get_team_models(
 def get_complete_model_list(
     key_models: Sequence[str],
     team_models: Sequence[str],
-    proxy_model_list: list[str],
+    proxy_model_list: Sequence[str],
     user_model: str | None,
     infer_model_from_keys: bool | None,
     return_wildcard_routes: bool | None = False,
     llm_router: Router | None = None,
-    model_access_groups: dict[str, list[str]] = {},
+    model_access_groups: Mapping[str, Sequence[str]] = MappingProxyType({}),
     include_model_access_groups: bool | None = False,
     only_model_access_groups: bool | None = False,
     team_id: str | None = None,

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -59,6 +59,7 @@ from litellm.proxy.auth.auth_checks import (
     get_user_object,
     is_valid_fallback_model,
     jwt_key_mapping_cache_key,
+    raise_when_key_reaches_only_other_teams_deployments,
     resolve_and_validate_end_user_id,
 )
 from litellm.proxy.auth.auth_exception_handler import UserAPIKeyAuthExceptionHandler
@@ -3117,48 +3118,49 @@ async def _enforce_key_and_fallback_model_access(
     Key-level model allowlist and client fallbacks (same as standard auth).
     Not included in common_checks — common_checks enforces team/user/project model access only.
     """
-    config: Final = valid_token.config
+    skip_key_model_check: Final = valid_token.config != {} or (
+        isinstance(valid_token.models, list) and "all-team-models" in valid_token.models
+    )
+    model: Final = _get_model_from_request_context(
+        request_data=request_data,
+        route=route,
+        request=request,
+        llm_router=llm_router,
+    )
 
-    if config != {}:
-        model_list: Final = config.get("model_list", [])
-        new_model_list: Final = model_list
-        verbose_proxy_logger.debug("\n new llm router model list %s", new_model_list)
-    elif isinstance(valid_token.models, list) and "all-team-models" in valid_token.models:
-        pass
-    else:
-        model: Final = _get_model_from_request_context(
-            request_data=request_data,
-            route=route,
-            request=request,
+    if skip_key_model_check:
+        if model is not None:
+            raise_when_key_reaches_only_other_teams_deployments(
+                model=model, llm_router=llm_router, valid_token=valid_token
+            )
+        return
+
+    if model is not None:
+        await can_key_call_model(
+            model=model,
+            llm_model_list=llm_model_list,
+            valid_token=valid_token,
             llm_router=llm_router,
         )
 
-        if model is not None:
-            await can_key_call_model(
-                model=model,
-                llm_model_list=llm_model_list,
-                valid_token=valid_token,
-                llm_router=llm_router,
-            )
+    fallback_names: Final = tuple(
+        name
+        for target in iter_request_fallback_targets(request_data)
+        if (name := _fallback_target_model_name(target)) is not None
+    )
 
-        fallback_names: Final = tuple(
-            name
-            for target in iter_request_fallback_targets(request_data)
-            if (name := _fallback_target_model_name(target)) is not None
+    for _name in dict.fromkeys(fallback_names):  # dedupe, preserve order
+        await can_key_call_model(
+            model=_name,
+            llm_model_list=llm_model_list,
+            valid_token=valid_token,
+            llm_router=llm_router,
         )
-
-        for _name in dict.fromkeys(fallback_names):  # dedupe, preserve order
-            await can_key_call_model(
-                model=_name,
-                llm_model_list=llm_model_list,
-                valid_token=valid_token,
-                llm_router=llm_router,
-            )
-            await is_valid_fallback_model(
-                model=_name,
-                llm_router=llm_router,
-                user_model=None,
-            )
+        await is_valid_fallback_model(
+            model=_name,
+            llm_router=llm_router,
+            user_model=None,
+        )
 
 
 def _fallback_target_model_name(target: object) -> str | None:

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -3128,10 +3128,16 @@ async def _enforce_key_and_fallback_model_access(
         llm_router=llm_router,
     )
 
+    fallback_names: Final = tuple(
+        name
+        for target in iter_request_fallback_targets(request_data)
+        if (name := _fallback_target_model_name(target)) is not None
+    )
+
     if skip_key_model_check:
-        if model is not None:
+        for requested_name in dict.fromkeys((*(() if model is None else (model,)), *fallback_names)):
             raise_when_key_reaches_only_other_teams_deployments(
-                model=model, llm_router=llm_router, valid_token=valid_token
+                model=requested_name, llm_router=llm_router, valid_token=valid_token
             )
         return
 
@@ -3142,12 +3148,6 @@ async def _enforce_key_and_fallback_model_access(
             valid_token=valid_token,
             llm_router=llm_router,
         )
-
-    fallback_names: Final = tuple(
-        name
-        for target in iter_request_fallback_targets(request_data)
-        if (name := _fallback_target_model_name(target)) is not None
-    )
 
     for _name in dict.fromkeys(fallback_names):  # dedupe, preserve order
         await can_key_call_model(

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -13577,7 +13577,7 @@ async def _gather_team_accessible_model_ids(
 ) -> set[str]:
     """Collect model IDs the team can use from router config and DB."""
     team_accessible_model_ids: Final[set[str]] = set()
-    access_groups: Final = llm_router.get_model_access_groups() if llm_router else {}
+    access_groups: Final = llm_router.get_model_access_groups_usable_by_team(team_id) if llm_router else {}
 
     if not team_object.models or SpecialModelNames.all_proxy_models.value in team_object.models:
         model_list: Final = llm_router.get_model_list() if llm_router else []

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -12924,17 +12924,18 @@ def _resolve_model_grant_to_deployment_ids(
     time (see `_check_model_access_helper`), so both expand to every non-team deployment.
     A grant entry naming an access group also grants that group's members, and naming a
     deployed model that shares the name grants the model itself, matching the union the
-    call-time check applies.
+    call-time check applies. Team-owned deployments are never direct access, whatever the
+    grant names: they reach the caller through team membership (`access_via_team_ids`).
     """
     if not models or SpecialModelNames.all_proxy_models.value in models:
         return tuple(llm_router.get_model_ids(exclude_team_models=True))
 
-    access_groups: Final = llm_router.get_model_access_groups()
+    access_groups: Final = llm_router.get_model_access_groups_usable_by_team(None)
     granted_model_names: Final = tuple(name for model in models for name in (model, *access_groups.get(model, ())))
     return tuple(
         model_id
         for name in granted_model_names
-        for deployment in (llm_router.get_model_list(model_name=name) or ())
+        for deployment in llm_router.get_deployments_usable_by_team(name, None)
         if (model_id := deployment.get("model_info", {}).get("id", None)) is not None
     )
 
@@ -14440,9 +14441,7 @@ def _get_v1_model_info_allowed_model_names(
     llm_router: Router,
 ) -> set[str] | None:
     """Return key/team allowlisted public model names, or None if unrestricted."""
-    model_access_groups: Final = access_groups_visible_to_caller(
-        llm_router, user_api_key_dict, user_api_key_dict.team_id
-    )
+    model_access_groups: Final = access_groups_visible_to_caller(llm_router, user_api_key_dict, None)
     proxy_model_list: Final = llm_router.get_model_names()
     key_models: Final = get_key_models(
         user_api_key_dict=user_api_key_dict,

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -650,6 +650,7 @@ from litellm.proxy.utils import (
     _get_redoc_url,
     _is_projected_spend_over_limit,
     _is_valid_team_configs,
+    access_groups_visible_to_caller,
     evict_config_param,
     get_config_param,
     get_custom_url,
@@ -14439,7 +14440,9 @@ def _get_v1_model_info_allowed_model_names(
     llm_router: Router,
 ) -> set[str] | None:
     """Return key/team allowlisted public model names, or None if unrestricted."""
-    model_access_groups: Final = llm_router.get_model_access_groups()
+    model_access_groups: Final = access_groups_visible_to_caller(
+        llm_router, user_api_key_dict, user_api_key_dict.team_id
+    )
     proxy_model_list: Final = llm_router.get_model_names()
     key_models: Final = get_key_models(
         user_api_key_dict=user_api_key_dict,

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -7366,7 +7366,7 @@ async def _get_access_group_models(
     return tuple(dict.fromkeys((*team_group_models, *key_group_models)))
 
 
-def _access_groups_visible_to_caller(
+def access_groups_visible_to_caller(
     llm_router: "Router",
     user_api_key_dict: "UserAPIKeyAuth",
     team_id: str | None,
@@ -7416,7 +7416,7 @@ async def get_available_models_for_user(
     effective_team_id: Final = team_id or user_api_key_dict.team_id
     proxy_model_list: Final[Sequence[str]] = llm_router.get_model_names() if llm_router is not None else ()
     model_access_groups: Final[Mapping[str, Sequence[str]]] = (
-        _access_groups_visible_to_caller(llm_router, user_api_key_dict, effective_team_id)
+        access_groups_visible_to_caller(llm_router, user_api_key_dict, effective_team_id)
         if llm_router is not None
         else MappingProxyType({})
     )

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -110,6 +110,7 @@ from litellm.proxy._types import (
 )
 from litellm.proxy.auth.route_checks import RouteChecks
 from litellm.proxy.common_utils.config_sync_pubsub import publish_config_param_change
+from litellm.proxy.common_utils.resource_ownership import is_proxy_admin
 from litellm.proxy.common_utils.user_api_key_cache import UserApiKeyCache
 from litellm.proxy.db.create_views import (
     create_missing_views,
@@ -7365,6 +7366,16 @@ async def _get_access_group_models(
     return tuple(dict.fromkeys((*team_group_models, *key_group_models)))
 
 
+def _access_groups_visible_to_caller(
+    llm_router: "Router",
+    user_api_key_dict: "UserAPIKeyAuth",
+    team_id: str | None,
+) -> Mapping[str, Sequence[str]]:
+    if is_proxy_admin(user_api_key_dict):
+        return llm_router.get_model_access_groups()
+    return llm_router.get_model_access_groups_usable_by_team(team_id)
+
+
 async def get_available_models_for_user(
     user_api_key_dict: "UserAPIKeyAuth",
     llm_router: Optional["Router"],
@@ -7402,13 +7413,13 @@ async def get_available_models_for_user(
         get_team_models,
     )
 
-    # Get proxy model list and access groups
-    if llm_router is None:
-        proxy_model_list = []
-        model_access_groups = {}
-    else:
-        proxy_model_list = llm_router.get_model_names()
-        model_access_groups = llm_router.get_model_access_groups()
+    effective_team_id: Final = team_id or user_api_key_dict.team_id
+    proxy_model_list: Final[Sequence[str]] = llm_router.get_model_names() if llm_router is not None else ()
+    model_access_groups: Final[Mapping[str, Sequence[str]]] = (
+        _access_groups_visible_to_caller(llm_router, user_api_key_dict, effective_team_id)
+        if llm_router is not None
+        else MappingProxyType({})
+    )
 
     requested_team_object: Final = (
         await _get_validated_team_object(
@@ -7441,8 +7452,6 @@ async def get_available_models_for_user(
         model_access_groups=model_access_groups,
         include_model_access_groups=include_model_access_groups,
     )
-
-    effective_team_id: Final = team_id or user_api_key_dict.team_id
 
     access_group_models: Final = (
         await _get_access_group_models(

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -7369,11 +7369,11 @@ async def _get_access_group_models(
 def access_groups_visible_to_caller(
     llm_router: "Router",
     user_api_key_dict: "UserAPIKeyAuth",
-    team_id: str | None,
+    requested_team_id: str | None,
 ) -> Mapping[str, Sequence[str]]:
-    if is_proxy_admin(user_api_key_dict):
+    if requested_team_id is None and is_proxy_admin(user_api_key_dict):
         return llm_router.get_model_access_groups()
-    return llm_router.get_model_access_groups_usable_by_team(team_id)
+    return llm_router.get_model_access_groups_usable_by_team(requested_team_id or user_api_key_dict.team_id)
 
 
 async def get_available_models_for_user(
@@ -7416,7 +7416,7 @@ async def get_available_models_for_user(
     effective_team_id: Final = team_id or user_api_key_dict.team_id
     proxy_model_list: Final[Sequence[str]] = llm_router.get_model_names() if llm_router is not None else ()
     model_access_groups: Final[Mapping[str, Sequence[str]]] = (
-        access_groups_visible_to_caller(llm_router, user_api_key_dict, effective_team_id)
+        access_groups_visible_to_caller(llm_router, user_api_key_dict, team_id)
         if llm_router is not None
         else MappingProxyType({})
     )

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -11603,8 +11603,9 @@ class Router:
         )
         return MappingProxyType(
             {
-                group: tuple(model_name for model_name in model_names if model_name in usable_model_names)
+                group: usable_group_models
                 for group, model_names in self.get_model_access_groups().items()
+                if (usable_group_models := tuple(name for name in model_names if name in usable_model_names))
             }
         )
 

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -11595,6 +11595,25 @@ class Router:
 
         return access_groups
 
+    def get_model_access_groups_usable_by_team(self, team_id: str | None) -> Mapping[str, Sequence[str]]:
+        usable_model_names: Final = frozenset(
+            deployment["model_name"]
+            for deployment in self.get_model_list() or ()
+            if self._deployment_usable_by_team(deployment, team_id)
+        )
+        return MappingProxyType(
+            {
+                group: tuple(model_name for model_name in model_names if model_name in usable_model_names)
+                for group, model_names in self.get_model_access_groups().items()
+            }
+        )
+
+    def model_owned_by_other_teams(self, model_name: str, team_id: str | None) -> bool:
+        deployments: Final = self.get_model_list(model_name=model_name, team_id=team_id) or ()
+        return len(deployments) > 0 and not any(
+            self._deployment_usable_by_team(deployment, team_id) for deployment in deployments
+        )
+
     def _is_model_access_group_for_wildcard_route(self, model_access_group: str) -> bool:
         """
         Return True if model access group is a wildcard route

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -11609,11 +11609,17 @@ class Router:
             }
         )
 
-    def model_owned_by_other_teams(self, model_name: str, team_id: str | None) -> bool:
-        deployments: Final = self.get_model_list(model_name=model_name, team_id=team_id) or ()
-        return len(deployments) > 0 and not any(
-            self._deployment_usable_by_team(deployment, team_id) for deployment in deployments
+    def get_deployments_usable_by_team(self, model_name: str, team_id: str | None) -> tuple[DeploymentTypedDict, ...]:
+        return tuple(
+            deployment
+            for deployment in self.get_model_list(model_name=model_name, team_id=team_id) or ()
+            if self._deployment_usable_by_team(deployment, team_id)
         )
+
+    def model_owned_by_other_teams(self, model_name: str, team_id: str | None) -> bool:
+        if self.get_deployments_usable_by_team(model_name, team_id):
+            return False
+        return len(self.get_model_list(model_name=model_name) or ()) > 0
 
     def _is_model_access_group_for_wildcard_route(self, model_access_group: str) -> bool:
         """

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -1850,12 +1850,24 @@ def _keys_that_skip_the_key_model_check() -> list[UserAPIKeyAuth]:
 @pytest.mark.asyncio
 @pytest.mark.parametrize("valid_token", _keys_that_skip_the_key_model_check(), ids=["all-team-models-key", "config-key"])
 @pytest.mark.parametrize(
-    ("model", "denied"),
-    [("model_name_team-b_1111", True), ("bedrock-nova", False)],
-    ids=["other-teams-deployment", "global-deployment"],
+    ("model", "fallbacks", "denied"),
+    [
+        ("model_name_team-b_1111", (), True),
+        ("bedrock-nova", (), False),
+        ("bedrock-nova", ("model_name_team-b_1111",), True),
+        ("bedrock-nova", ({"model": "model_name_team-b_1111"},), True),
+        ("bedrock-nova", ("bedrock-nova",), False),
+    ],
+    ids=[
+        "other-teams-deployment",
+        "global-deployment",
+        "other-teams-deployment-as-fallback",
+        "other-teams-deployment-as-fallback-dict",
+        "global-deployment-as-fallback",
+    ],
 )
 async def test_enforce_key_access_keys_skipping_the_model_check_still_stop_at_other_teams_deployments(
-    valid_token, model, denied
+    valid_token, model, fallbacks, denied
 ):
     from litellm.proxy._types import ProxyException
     from litellm.proxy.auth.user_api_key_auth import _enforce_key_and_fallback_model_access
@@ -1865,7 +1877,7 @@ async def test_enforce_key_access_keys_skipping_the_model_check_still_stop_at_ot
     async def enforce() -> None:
         await _enforce_key_and_fallback_model_access(
             valid_token=valid_token,
-            request_data={"model": model},
+            request_data={"model": model, **({"fallbacks": list(fallbacks)} if fallbacks else {})},
             route="/chat/completions",
             request=None,
             llm_model_list=router.model_list,

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -1775,6 +1775,92 @@ def _make_team_scoped_router(team_id: str = "team-a"):
     return Router(model_list=model_list)
 
 
+def _make_router_with_global_and_team_b_deployment():
+    from litellm import Router
+
+    return Router(
+        model_list=[
+            {
+                "model_name": "bedrock-nova",
+                "litellm_params": {"model": "bedrock/us.amazon.nova-micro-v1:0"},
+                "model_info": {"id": "global-nova", "access_groups": ["bedrock-group"]},
+            },
+            {
+                "model_name": "model_name_team-b_1111",
+                "litellm_params": {"model": "bedrock/us.amazon.nova-micro-v1:0"},
+                "model_info": {
+                    "id": "team-b-nova",
+                    "team_id": "team-b",
+                    "team_public_model_name": "team-b-nova",
+                    "access_groups": ["bedrock-group"],
+                },
+            },
+        ]
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "model",
+    ["model_name_team-b_1111", ["bedrock-nova", "model_name_team-b_1111"]],
+)
+async def test_can_key_call_model_teamless_access_group_key_denied_other_teams_deployment(model):
+    from litellm.proxy._types import ProxyErrorTypes, ProxyException, UserAPIKeyAuth
+    from litellm.proxy.auth.auth_checks import can_key_call_model
+
+    router = _make_router_with_global_and_team_b_deployment()
+    teamless_key = UserAPIKeyAuth(api_key="sk-teamless", models=["bedrock-group"], team_id=None)
+
+    with pytest.raises(ProxyException) as exc:
+        await can_key_call_model(
+            model=model,
+            llm_model_list=router.model_list,
+            valid_token=teamless_key,
+            llm_router=router,
+        )
+    assert exc.value.type == ProxyErrorTypes.key_model_access_denied
+    assert exc.value.code == "403"
+    assert "models=['bedrock-group']" in exc.value.message
+    assert "Tried to access model_name_team-b_1111" in exc.value.message
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("valid_token", "model"),
+    [
+        (UserAPIKeyAuth(api_key="sk-teamless", models=["bedrock-group"], team_id=None), "bedrock-nova"),
+        (
+            UserAPIKeyAuth(api_key="sk-team-b", models=["bedrock-group"], team_id="team-b"),
+            "model_name_team-b_1111",
+        ),
+        (
+            UserAPIKeyAuth(
+                api_key="sk-admin",
+                models=["bedrock-group"],
+                team_id=None,
+                user_role=LitellmUserRoles.PROXY_ADMIN,
+            ),
+            "model_name_team-b_1111",
+        ),
+    ],
+    ids=["teamless-key-global-deployment", "owning-team-key", "proxy-admin-key"],
+)
+async def test_can_key_call_model_access_group_allows_usable_deployments(valid_token, model):
+    from litellm.proxy.auth.auth_checks import can_key_call_model
+
+    router = _make_router_with_global_and_team_b_deployment()
+
+    assert (
+        await can_key_call_model(
+            model=model,
+            llm_model_list=router.model_list,
+            valid_token=valid_token,
+            llm_router=router,
+        )
+        is True
+    )
+
+
 def test_can_object_call_model_access_group_with_team_id():
     """
     When team_id is passed, _can_object_call_model should resolve

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Final, Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
 if TYPE_CHECKING:
@@ -1799,29 +1799,105 @@ def _make_router_with_global_and_team_b_deployment():
     )
 
 
+_OTHER_TEAMS_DEPLOYMENT_403: Final = (
+    "key not allowed to access model. Tried to access model_name_team-b_1111, which is only deployed for other teams"
+)
+_OUTSIDE_TEAM_A_GRANT_403: Final = (
+    "key not allowed to access model. This key can only access models=['bedrock-group']. "
+    "Tried to access model_name_team-b_1111"
+)
+
+
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("valid_token", "denial"),
+    [
+        (UserAPIKeyAuth(api_key="sk-teamless", models=["bedrock-group"], team_id=None), _OTHER_TEAMS_DEPLOYMENT_403),
+        (UserAPIKeyAuth(api_key="sk-team-a", models=["bedrock-group"], team_id="team-a"), _OUTSIDE_TEAM_A_GRANT_403),
+        (UserAPIKeyAuth(api_key="sk-unrestricted", models=[], team_id=None), _OTHER_TEAMS_DEPLOYMENT_403),
+    ],
+    ids=["teamless-key", "other-team-key", "unrestricted-key"],
+)
 @pytest.mark.parametrize(
     "model",
     ["model_name_team-b_1111", ["bedrock-nova", "model_name_team-b_1111"]],
 )
-async def test_can_key_call_model_teamless_access_group_key_denied_other_teams_deployment(model):
-    from litellm.proxy._types import ProxyErrorTypes, ProxyException, UserAPIKeyAuth
+async def test_can_key_call_model_denies_other_teams_deployment(valid_token, denial, model):
+    from litellm.proxy._types import ProxyErrorTypes, ProxyException
     from litellm.proxy.auth.auth_checks import can_key_call_model
 
     router = _make_router_with_global_and_team_b_deployment()
-    teamless_key = UserAPIKeyAuth(api_key="sk-teamless", models=["bedrock-group"], team_id=None)
 
     with pytest.raises(ProxyException) as exc:
         await can_key_call_model(
             model=model,
             llm_model_list=router.model_list,
-            valid_token=teamless_key,
+            valid_token=valid_token,
             llm_router=router,
         )
     assert exc.value.type == ProxyErrorTypes.key_model_access_denied
     assert exc.value.code == "403"
-    assert "models=['bedrock-group']" in exc.value.message
-    assert "Tried to access model_name_team-b_1111" in exc.value.message
+    assert exc.value.message == denial
+
+
+def _keys_that_skip_the_key_model_check() -> list[UserAPIKeyAuth]:
+    return [
+        UserAPIKeyAuth(api_key="sk-all-team", models=["all-team-models"], team_id=None, team_models=[]),
+        UserAPIKeyAuth(api_key="sk-config", models=[], team_id=None, config={"model_list": []}),
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("valid_token", _keys_that_skip_the_key_model_check(), ids=["all-team-models-key", "config-key"])
+@pytest.mark.parametrize(
+    ("model", "denied"),
+    [("model_name_team-b_1111", True), ("bedrock-nova", False)],
+    ids=["other-teams-deployment", "global-deployment"],
+)
+async def test_enforce_key_access_keys_skipping_the_model_check_still_stop_at_other_teams_deployments(
+    valid_token, model, denied
+):
+    from litellm.proxy._types import ProxyException
+    from litellm.proxy.auth.user_api_key_auth import _enforce_key_and_fallback_model_access
+
+    router = _make_router_with_global_and_team_b_deployment()
+
+    async def enforce() -> None:
+        await _enforce_key_and_fallback_model_access(
+            valid_token=valid_token,
+            request_data={"model": model},
+            route="/chat/completions",
+            request=None,
+            llm_model_list=router.model_list,
+            llm_router=router,
+        )
+
+    if not denied:
+        await enforce()
+        return
+    with pytest.raises(ProxyException) as exc:
+        await enforce()
+    assert exc.value.code == "403"
+    assert exc.value.message == _OTHER_TEAMS_DEPLOYMENT_403
+
+
+@pytest.mark.asyncio
+async def test_can_key_call_resolved_model_all_team_models_key_denied_other_teams_deployment():
+    from litellm.proxy._types import ProxyException
+    from litellm.proxy.auth.auth_checks import can_key_call_resolved_model
+
+    router = _make_router_with_global_and_team_b_deployment()
+    valid_token = UserAPIKeyAuth(api_key="sk-orphan", models=["all-team-models"], team_models=[])
+
+    with pytest.raises(ProxyException) as exc:
+        await can_key_call_resolved_model(
+            model="model_name_team-b_1111",
+            llm_model_list=router.model_list,
+            valid_token=valid_token,
+            llm_router=router,
+        )
+    assert exc.value.code == "403"
+    assert exc.value.message == _OTHER_TEAMS_DEPLOYMENT_403
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/hooks/test_batch_file_validation.py
+++ b/tests/test_litellm/proxy/hooks/test_batch_file_validation.py
@@ -7,12 +7,19 @@ VERIA-39 regression tests:
   models the caller is not authorized to use.
 """
 
+from typing import Final
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
 
 from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+
+
+def _router_without_other_teams_deployments() -> MagicMock:
+    router: Final = MagicMock()
+    router.model_owned_by_other_teams.return_value = False
+    return router
 
 
 def _models(file_content_as_dict):
@@ -627,7 +634,7 @@ async def test_pre_call_does_not_skip_for_spoofed_provider():
     )
     user = UserAPIKeyAuth(api_key="sk-ok", user_id="alice", models=["*"])
 
-    mock_router = MagicMock()
+    mock_router = _router_without_other_teams_deployments()
     mock_router.model_list = []
     mock_router.resolve_model_name_from_model_id.return_value = "my-openai-model"
 
@@ -699,7 +706,7 @@ async def test_count_input_file_usage_decodes_model_embedded_file_id():
         ) as mock_afile_content,
         patch(
             "litellm.proxy.proxy_server.llm_router",
-            MagicMock(),
+            _router_without_other_teams_deployments(),
         ),
         patch(
             "litellm.proxy.openai_files_endpoints.common_utils.get_credentials_for_model",
@@ -1424,7 +1431,7 @@ async def test_pre_call_enforces_project_otpm_limit_for_batch():
 
     with (
         patch("litellm.proxy.proxy_server.general_settings", {}),
-        patch("litellm.proxy.proxy_server.llm_router", MagicMock()),
+        patch("litellm.proxy.proxy_server.llm_router", _router_without_other_teams_deployments()),
         patch(
             "litellm.proxy.openai_files_endpoints.common_utils.get_credentials_for_model",
             return_value={"custom_llm_provider": "openai"},
@@ -1478,7 +1485,7 @@ async def test_pre_call_enforces_project_itpm_limit_for_batch():
 
     with (
         patch("litellm.proxy.proxy_server.general_settings", {}),
-        patch("litellm.proxy.proxy_server.llm_router", MagicMock()),
+        patch("litellm.proxy.proxy_server.llm_router", _router_without_other_teams_deployments()),
         patch(
             "litellm.proxy.openai_files_endpoints.common_utils.get_credentials_for_model",
             return_value={"custom_llm_provider": "openai"},
@@ -1538,7 +1545,7 @@ async def test_pre_call_enforces_project_otpm_limit_for_non_routing_row_model():
 
     with (
         patch("litellm.proxy.proxy_server.general_settings", {}),
-        patch("litellm.proxy.proxy_server.llm_router", MagicMock()),
+        patch("litellm.proxy.proxy_server.llm_router", _router_without_other_teams_deployments()),
         patch(
             "litellm.proxy.openai_files_endpoints.common_utils.get_credentials_for_model",
             return_value={"custom_llm_provider": "openai"},
@@ -1605,7 +1612,7 @@ async def test_pre_call_charges_each_row_model_against_its_own_project_quota():
 
     with (
         patch("litellm.proxy.proxy_server.general_settings", {}),
-        patch("litellm.proxy.proxy_server.llm_router", MagicMock()),
+        patch("litellm.proxy.proxy_server.llm_router", _router_without_other_teams_deployments()),
         patch(
             "litellm.proxy.openai_files_endpoints.common_utils.get_credentials_for_model",
             return_value={"custom_llm_provider": "openai"},
@@ -2132,7 +2139,7 @@ def _enqueued_batch_patches():
     afile_content_mock = AsyncMock(return_value=mock_content)
     return afile_content_mock, (
         patch("litellm.proxy.proxy_server.general_settings", {}),
-        patch("litellm.proxy.proxy_server.llm_router", MagicMock()),
+        patch("litellm.proxy.proxy_server.llm_router", _router_without_other_teams_deployments()),
         patch(
             "litellm.proxy.openai_files_endpoints.common_utils.get_credentials_for_model",
             return_value={"custom_llm_provider": "openai"},

--- a/tests/test_litellm/proxy/proxy_server/test_routes_model_info.py
+++ b/tests/test_litellm/proxy/proxy_server/test_routes_model_info.py
@@ -180,6 +180,37 @@ def test_v1_model_info_star_wildcard_filter_keeps_provider_expansion(monkeypatch
     assert [model["model_name"] for model in result] == ["openai/gpt-4o"]
 
 
+def test_v1_model_info_allowed_names_expand_access_group_only_to_callers_deployments():
+    from litellm import Router
+    from litellm.proxy._types import UserAPIKeyAuth
+
+    router = Router(
+        model_list=[
+            {
+                "model_name": "bedrock-nova",
+                "litellm_params": {"model": "bedrock/us.amazon.nova-micro-v1:0"},
+                "model_info": {"id": "global-nova", "access_groups": ["bedrock-group"]},
+            },
+            {
+                "model_name": "model_name_team-b_1111",
+                "litellm_params": {"model": "bedrock/us.amazon.nova-micro-v1:0"},
+                "model_info": {
+                    "id": "team-b-nova",
+                    "team_id": "team-b",
+                    "team_public_model_name": "team-b-nova",
+                    "access_groups": ["bedrock-group"],
+                },
+            },
+        ]
+    )
+    teamless_key = UserAPIKeyAuth(api_key="sk-teamless", models=["bedrock-group"], team_id=None, team_models=[])
+    team_b_key = UserAPIKeyAuth(api_key="sk-team-b", models=["bedrock-group"], team_id="team-b", team_models=[])
+
+    allowed_names = proxy_server._get_v1_model_info_allowed_model_names
+    assert allowed_names(user_api_key_dict=teamless_key, llm_router=router) == {"bedrock-nova"}
+    assert allowed_names(user_api_key_dict=team_b_key, llm_router=router) == {"bedrock-nova", "model_name_team-b_1111"}
+
+
 # ---------------------------------------------------------------------------
 # GET /model/info — team BYOK scoping (issue #30983)
 # ---------------------------------------------------------------------------

--- a/tests/test_litellm/proxy/proxy_server/test_team_model_name_translation.py
+++ b/tests/test_litellm/proxy/proxy_server/test_team_model_name_translation.py
@@ -931,7 +931,6 @@ async def test_v1_models_translates_team_model_for_access_group_key(monkeypatch)
     # Default behavior: listing surfaces public names.
     monkeypatch.setattr(ps, "general_settings", {})
 
-    # team X virtual key granted access via the access group
     key = UserAPIKeyAuth(user_id="u", api_key="sk-test", models=["grp-a"], team_id="teamX", team_models=[])
     resp = await ps.model_list(user_api_key_dict=key)
 

--- a/tests/test_litellm/proxy/proxy_server/test_team_model_name_translation.py
+++ b/tests/test_litellm/proxy/proxy_server/test_team_model_name_translation.py
@@ -879,6 +879,7 @@ async def test_v1_models_translates_team_model_for_access_group_key(monkeypatch)
     router = MagicMock()
     router.get_model_names.return_value = ["model_name_teamX_uuid9"]
     router.get_model_access_groups.return_value = {"grp-a": ["model_name_teamX_uuid9"]}
+    router.get_model_access_groups_usable_by_team.return_value = {"grp-a": ["model_name_teamX_uuid9"]}
     router.get_fully_blocked_model_names.return_value = set()
     router.get_configured_token_limits.return_value = (None, None)
     router.model_list = [team_dep]
@@ -889,10 +890,8 @@ async def test_v1_models_translates_team_model_for_access_group_key(monkeypatch)
     # Default behavior: listing surfaces public names.
     monkeypatch.setattr(ps, "general_settings", {})
 
-    # virtual key granted access via the access group (no team membership)
-    key = UserAPIKeyAuth(
-        user_id="u", api_key="sk-test", models=["grp-a"], team_models=[]
-    )
+    # team X virtual key granted access via the access group
+    key = UserAPIKeyAuth(user_id="u", api_key="sk-test", models=["grp-a"], team_id="teamX", team_models=[])
     resp = await ps.model_list(user_api_key_dict=key)
 
     ids = [d["id"] for d in resp["data"]]
@@ -921,6 +920,7 @@ async def test_v1_models_keeps_internal_names_when_public_name_flag_disabled(
     router = MagicMock()
     router.get_model_names.return_value = ["model_name_teamX_uuid9"]
     router.get_model_access_groups.return_value = {"grp-a": ["model_name_teamX_uuid9"]}
+    router.get_model_access_groups_usable_by_team.return_value = {"grp-a": ["model_name_teamX_uuid9"]}
     router.get_fully_blocked_model_names.return_value = set()
     router.get_configured_token_limits.return_value = (None, None)
     router.model_list = [team_dep]
@@ -930,9 +930,7 @@ async def test_v1_models_keeps_internal_names_when_public_name_flag_disabled(
     monkeypatch.setattr(ps, "user_model", None)
     monkeypatch.setattr(ps, "general_settings", {"use_team_public_model_name": False})
 
-    key = UserAPIKeyAuth(
-        user_id="u", api_key="sk-test", models=["grp-a"], team_models=[]
-    )
+    key = UserAPIKeyAuth(user_id="u", api_key="sk-test", models=["grp-a"], team_id="teamX", team_models=[])
     resp = await ps.model_list(user_api_key_dict=key)
 
     ids = [d["id"] for d in resp["data"]]
@@ -956,6 +954,7 @@ async def test_v1_models_translates_team_model_with_metadata(monkeypatch):
     router = MagicMock()
     router.get_model_names.return_value = ["model_name_teamX_uuid9"]
     router.get_model_access_groups.return_value = {"grp-a": ["model_name_teamX_uuid9"]}
+    router.get_model_access_groups_usable_by_team.return_value = {"grp-a": ["model_name_teamX_uuid9"]}
     router.get_fully_blocked_model_names.return_value = set()
     router.get_configured_token_limits.return_value = (None, None)
     router.model_list = [team_dep]
@@ -966,9 +965,7 @@ async def test_v1_models_translates_team_model_with_metadata(monkeypatch):
     monkeypatch.setattr(ps, "user_model", None)
     monkeypatch.setattr(ps, "general_settings", {})
 
-    key = UserAPIKeyAuth(
-        user_id="u", api_key="sk-test", models=["grp-a"], team_models=[]
-    )
+    key = UserAPIKeyAuth(user_id="u", api_key="sk-test", models=["grp-a"], team_id="teamX", team_models=[])
     resp = await ps.model_list(user_api_key_dict=key, include_metadata=True)
 
     assert resp["data"] == [
@@ -1002,6 +999,7 @@ async def test_v1_models_metadata_fallbacks_use_internal_routing_key(monkeypatch
     router = MagicMock()
     router.get_model_names.return_value = ["model_name_teamX_uuid9"]
     router.get_model_access_groups.return_value = {"grp-a": ["model_name_teamX_uuid9"]}
+    router.get_model_access_groups_usable_by_team.return_value = {"grp-a": ["model_name_teamX_uuid9"]}
     router.get_fully_blocked_model_names.return_value = set()
     router.get_configured_token_limits.return_value = (None, None)
     router.model_list = [team_dep]
@@ -1014,9 +1012,7 @@ async def test_v1_models_metadata_fallbacks_use_internal_routing_key(monkeypatch
     monkeypatch.setattr(ps, "user_model", None)
     monkeypatch.setattr(ps, "general_settings", {})
 
-    key = UserAPIKeyAuth(
-        user_id="u", api_key="sk-test", models=["grp-a"], team_models=[]
-    )
+    key = UserAPIKeyAuth(user_id="u", api_key="sk-test", models=["grp-a"], team_id="teamX", team_models=[])
     resp = await ps.model_list(user_api_key_dict=key, include_metadata=True)
 
     assert resp["data"] == [
@@ -1059,6 +1055,7 @@ async def test_v1_models_metadata_does_not_leak_other_team_fallbacks(monkeypatch
     router = MagicMock()
     router.get_model_names.return_value = ["model_name_teamX_uuid9"]
     router.get_model_access_groups.return_value = {"grp-a": ["model_name_teamX_uuid9"]}
+    router.get_model_access_groups_usable_by_team.return_value = {"grp-a": ["model_name_teamX_uuid9"]}
     router.get_fully_blocked_model_names.return_value = set()
     router.get_configured_token_limits.return_value = (None, None)
     router.model_list = [team_x, team_y]
@@ -1073,9 +1070,7 @@ async def test_v1_models_metadata_does_not_leak_other_team_fallbacks(monkeypatch
     monkeypatch.setattr(ps, "user_model", None)
     monkeypatch.setattr(ps, "general_settings", {})
 
-    key = UserAPIKeyAuth(
-        user_id="u", api_key="sk-test", models=["grp-a"], team_models=[]
-    )
+    key = UserAPIKeyAuth(user_id="u", api_key="sk-test", models=["grp-a"], team_id="teamX", team_models=[])
     resp = await ps.model_list(user_api_key_dict=key, include_metadata=True)
 
     assert resp["data"] == [

--- a/tests/test_litellm/proxy/proxy_server/test_team_model_name_translation.py
+++ b/tests/test_litellm/proxy/proxy_server/test_team_model_name_translation.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 import litellm.proxy.proxy_server as ps
+from litellm import Router
 from litellm.proxy._types import (
     LiteLLM_UserTable,
     LitellmUserRoles,
@@ -691,6 +692,46 @@ async def test_populate_team_access_grants_config_access_group_model():
 
     by_id = {m["model_info"]["id"]: m for m in result}
     assert by_id["model-a-id"]["model_info"]["access_via_team_ids"] == [team_id]
+
+
+@pytest.mark.asyncio
+async def test_populate_team_access_direct_grant_expands_group_only_to_non_team_deployments(monkeypatch):
+    router = Router(
+        model_list=[
+            {
+                "model_name": "bedrock-nova",
+                "litellm_params": {"model": "bedrock/us.amazon.nova-micro-v1:0"},
+                "model_info": {"id": "global-nova", "access_groups": ["bedrock-group"]},
+            },
+            {
+                "model_name": "model_name_team-b_1111",
+                "litellm_params": {"model": "bedrock/us.amazon.nova-micro-v1:0"},
+                "model_info": {
+                    "id": "team-b-nova",
+                    "team_id": "team-b",
+                    "team_public_model_name": "team-b-nova",
+                    "access_groups": ["bedrock-group"],
+                },
+            },
+        ]
+    )
+    monkeypatch.setattr(ps, "get_all_team_models", AsyncMock(return_value={}))
+    prisma_client = MagicMock()
+    prisma_client.db.litellm_usertable.find_unique = AsyncMock(
+        return_value=LiteLLM_UserTable(user_id="teamless-user", teams=[], models=["bedrock-group"])
+    )
+
+    result = await ps._populate_team_access_on_models(
+        user_api_key_dict=UserAPIKeyAuth(user_id="teamless-user", models=[], team_models=[]),
+        prisma_client=prisma_client,
+        llm_router=router,
+        all_models=[{**row, "model_info": dict(row["model_info"])} for row in router.model_list],
+    )
+
+    by_id = {m["model_info"]["id"]: m for m in result}
+    assert by_id["global-nova"]["model_info"]["direct_access"] is True
+    assert by_id["team-b-nova"]["model_info"]["direct_access"] is False
+    assert ps._filter_models_to_user_accessible(result) == [by_id["global-nova"]]
 
 
 @pytest.mark.asyncio
@@ -1543,6 +1584,14 @@ async def test_retrieve_model_by_inaccessible_public_name_404s(monkeypatch):
     router.get_deployment_by_model_group_name.assert_not_called()
 
 
+def _deployment_row(model_name: str, model_id: str, access_groups: tuple[str, ...] = ()) -> dict:
+    return {
+        "model_name": model_name,
+        "litellm_params": {"model": "bedrock/us.amazon.nova-micro-v1:0"},
+        "model_info": {"id": model_id, "access_groups": list(access_groups)},
+    }
+
+
 def test_get_direct_access_models_expands_all_proxy_models_sentinel():
     """A user provisioned with 'all-proxy-models' has direct access to every non-team
     deployment. The sentinel must resolve via get_model_ids, not be looked up as a
@@ -1567,16 +1616,13 @@ def test_get_direct_access_models_expands_all_proxy_models_sentinel():
 def test_get_direct_access_models_resolves_explicit_model_names():
     """Without the sentinel, only the user's explicitly listed models resolve to ids;
     the all-proxy-models shortcut must not fire."""
-    router = MagicMock()
-    router.get_model_list.return_value = [{"model_info": {"id": "gpt4o-id"}}]
+    router = Router(model_list=[_deployment_row("gpt-4o", "gpt4o-id"), _deployment_row("sonnet", "sonnet-id")])
 
     user = LiteLLM_UserTable(user_id="u", models=["gpt-4o"], teams=[])
 
     result = ps.get_direct_access_models(user_db_object=user, llm_router=router)
 
     assert result == ("gpt4o-id",)
-    router.get_model_ids.assert_not_called()
-    router.get_model_list.assert_called_once_with(model_name="gpt-4o")
 
 
 def test_get_direct_access_models_empty_models_grants_all_non_team_models():
@@ -1637,12 +1683,7 @@ async def test_populate_team_access_grants_empty_models_user_direct_access(monke
 def test_get_direct_access_models_restricted_key_narrows_unrestricted_user():
     """A key scoped to one model cannot call the rest, so the listing must not show
     every non-team model just because the user record is unrestricted."""
-    router = MagicMock()
-    router.get_model_ids.return_value = ["gpt4o-id", "sonnet-id"]
-    router.get_model_access_groups.return_value = {}
-    router.get_model_list.side_effect = lambda model_name: (
-        [{"model_info": {"id": "gpt4o-id"}}] if model_name == "gpt-4o" else []
-    )
+    router = Router(model_list=[_deployment_row("gpt-4o", "gpt4o-id"), _deployment_row("sonnet", "sonnet-id")])
 
     user = LiteLLM_UserTable(user_id="u", models=[], teams=[])
 
@@ -1651,17 +1692,12 @@ def test_get_direct_access_models_restricted_key_narrows_unrestricted_user():
     assert result == ("gpt4o-id",)
 
 
-def test_get_direct_access_models_all_proxy_models_key_keeps_team_scoped_user_grant():
+def test_get_direct_access_models_all_proxy_models_key_keeps_user_grant():
     """'all-proxy-models' on the key means unrestricted, so it must leave the user's
-    grant alone rather than clipping it to the non-team deployment set."""
-    router = MagicMock()
-    router.get_model_ids.return_value = ["global-id"]
-    router.get_model_access_groups.return_value = {}
-    router.get_model_list.side_effect = lambda model_name: (
-        [{"model_info": {"id": "byok-id"}}] if model_name == "byok-model" else []
-    )
+    grant alone rather than widening it to every non-team deployment."""
+    router = Router(model_list=[_deployment_row("gpt-4o", "gpt4o-id"), _deployment_row("sonnet", "sonnet-id")])
 
-    user = LiteLLM_UserTable(user_id="u", models=["byok-model"], teams=[])
+    user = LiteLLM_UserTable(user_id="u", models=["gpt-4o"], teams=[])
 
     result = ps.get_direct_access_models(
         user_db_object=user,
@@ -1669,18 +1705,19 @@ def test_get_direct_access_models_all_proxy_models_key_keeps_team_scoped_user_gr
         key_models=(ps.SpecialModelNames.all_proxy_models.value,),
     )
 
-    assert result == ("byok-id",)
+    assert result == ("gpt4o-id",)
 
 
 def test_get_direct_access_models_expands_access_group_grant():
     """A grant naming an access group can call the group's members at call time, so the
     listing must resolve the members instead of looking up the group name as a model."""
-    router = MagicMock()
-    router.get_model_access_groups.return_value = {"beta-models": ["gpt-4o", "sonnet"]}
-    router.get_model_list.side_effect = lambda model_name: {
-        "gpt-4o": [{"model_info": {"id": "gpt4o-id"}}],
-        "sonnet": [{"model_info": {"id": "sonnet-id"}}],
-    }.get(model_name, [])
+    router = Router(
+        model_list=[
+            _deployment_row("gpt-4o", "gpt4o-id", access_groups=("beta-models",)),
+            _deployment_row("sonnet", "sonnet-id", access_groups=("beta-models",)),
+            _deployment_row("haiku", "haiku-id"),
+        ]
+    )
 
     user = LiteLLM_UserTable(user_id="u", models=["beta-models"], teams=[])
 
@@ -1704,12 +1741,7 @@ async def test_populate_team_access_hides_models_the_calling_key_cannot_call(mon
         "model_info": {"id": "sonnet-id", "db_model": False},
     }
 
-    router = MagicMock()
-    router.get_model_ids.return_value = ["gpt4o-id", "sonnet-id"]
-    router.get_model_access_groups.return_value = {}
-    router.get_model_list.side_effect = lambda model_name: (
-        [{"model_info": {"id": "gpt4o-id"}}] if model_name == "gpt-4o" else []
-    )
+    router = Router(model_list=[_deployment_row("gpt-4o", "gpt4o-id"), _deployment_row("sonnet", "sonnet-id")])
 
     user_row = LiteLLM_UserTable(
         user_id="u",

--- a/tests/test_litellm/proxy/test_filter_models_by_team_access_group.py
+++ b/tests/test_litellm/proxy/test_filter_models_by_team_access_group.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-
+from litellm import Router
 from litellm.proxy.proxy_server import _filter_models_by_team_id
 
 
@@ -59,7 +59,7 @@ async def test_filter_resolves_access_group_names():
     # Router mock
     mock_router = MagicMock()
     # get_model_access_groups returns {group_name: [model_names]}
-    mock_router.get_model_access_groups.return_value = {
+    mock_router.get_model_access_groups_usable_by_team.return_value = {
         "Group-A": ["gpt-4o", "gpt-5"],
         "Group-B": ["claude-3"],
     }
@@ -114,7 +114,7 @@ async def test_filter_resolves_mix_of_access_groups_and_literal_names():
     all_models = [gpt4o, gpt5, claude, mistral]
 
     mock_router = MagicMock()
-    mock_router.get_model_access_groups.return_value = {
+    mock_router.get_model_access_groups_usable_by_team.return_value = {
         "Group-A": ["gpt-4o", "gpt-5"],
         "Group-B": ["claude-3"],
     }
@@ -159,7 +159,7 @@ async def test_filter_excludes_models_from_other_access_group():
     all_models = [gpt4o, claude, llama]
 
     mock_router = MagicMock()
-    mock_router.get_model_access_groups.return_value = {
+    mock_router.get_model_access_groups_usable_by_team.return_value = {
         "Group-A": ["gpt-4o"],
         "Group-B": ["claude-3", "llama-4"],
     }
@@ -198,7 +198,7 @@ async def test_filter_db_fallback_receives_resolved_model_names():
     all_models = [gpt4o]
 
     mock_router = MagicMock()
-    mock_router.get_model_access_groups.return_value = {
+    mock_router.get_model_access_groups_usable_by_team.return_value = {
         "Group-A": ["gpt-4o", "gpt-5"],
     }
     # get_model_list returns nothing — forces reliance on the DB fallback
@@ -231,3 +231,49 @@ async def test_filter_db_fallback_receives_resolved_model_names():
         "gpt-5",
     }, f"DB query should receive resolved model names, got {queried_names}"
     assert "Group-A" not in queried_names, "Raw access group name should not be in DB query"
+
+
+@pytest.mark.asyncio
+async def test_filter_by_team_id_keeps_other_teams_deployments_out_of_a_shared_access_group():
+    router = Router(
+        model_list=[
+            {
+                "model_name": "bedrock-nova",
+                "litellm_params": {"model": "bedrock/us.amazon.nova-micro-v1:0"},
+                "model_info": {"id": "global-nova", "access_groups": ["bedrock-group"]},
+            },
+            {
+                "model_name": "model_name_team-b_1111",
+                "litellm_params": {"model": "bedrock/us.amazon.nova-micro-v1:0", "api_base": "https://team-b.example"},
+                "model_info": {
+                    "id": "team-b-nova",
+                    "team_id": "team-b",
+                    "team_public_model_name": "team-b-nova",
+                    "access_groups": ["bedrock-group"],
+                },
+            },
+        ]
+    )
+    db_rows = {
+        "bedrock-nova": MagicMock(model_id="global-nova", model_name="bedrock-nova"),
+        "model_name_team-b_1111": MagicMock(model_id="team-b-nova", model_name="model_name_team-b_1111"),
+    }
+
+    async def find_many(where):
+        return [row for name, row in db_rows.items() if name in where["model_name"]["in"]]
+
+    mock_prisma = MagicMock()
+    mock_prisma.db.litellm_teamtable.find_unique = AsyncMock(return_value=_make_team(models=["bedrock-group"], team_id="team-a"))
+    mock_prisma.db.litellm_proxymodeltable.find_many = AsyncMock(side_effect=find_many)
+    all_models = [{**row, "model_info": {**row["model_info"], "access_via_team_ids": []}} for row in router.model_list]
+
+    result = await _filter_models_by_team_id(
+        all_models=all_models,
+        team_id="team-a",
+        prisma_client=mock_prisma,
+        llm_router=router,
+    )
+
+    assert [m["model_info"]["id"] for m in result] == ["global-nova"]
+    queried_names = mock_prisma.db.litellm_proxymodeltable.find_many.call_args[1]["where"]["model_name"]["in"]
+    assert set(queried_names) == {"bedrock-nova"}

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -5166,6 +5166,8 @@ async def test_model_info_v1_oci_secrets_not_leaked():
     mock_user_api_key_dict.api_key = "test-key"
     mock_user_api_key_dict.team_models = []
     mock_user_api_key_dict.models = ["oci-grok-test"]
+    mock_user_api_key_dict.team_id = None
+    mock_user_api_key_dict.user_role = None
 
     # Mock model data with OCI sensitive information
     mock_model_data = {
@@ -5189,6 +5191,7 @@ async def test_model_info_v1_oci_secrets_not_leaked():
     mock_router.model_list = [mock_model_data]
     mock_router.get_model_names.return_value = ["oci-grok-test"]
     mock_router.get_model_access_groups.return_value = {}
+    mock_router.get_model_access_groups_usable_by_team.return_value = {}
 
     # Mock global variables
     with (

--- a/tests/test_litellm/proxy/utils/helpers/test_model_access.py
+++ b/tests/test_litellm/proxy/utils/helpers/test_model_access.py
@@ -4,8 +4,8 @@ import pytest
 from fastapi import HTTPException
 
 import litellm
-from litellm import ModelResponse
-from litellm.proxy._types import UserAPIKeyAuth
+from litellm import ModelResponse, Router
+from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
 from litellm.proxy.utils import (
     create_model_info_response,
     get_available_models_for_user,
@@ -288,6 +288,65 @@ def test_model_dump_with_preserved_fields_no_choices_returns_plain_dump():
 def test_model_dump_with_preserved_fields_error_path_invalid_obj_raises():
     with pytest.raises(AttributeError):
         model_dump_with_preserved_fields(None)
+
+
+def _router_with_global_and_team_b_deployment_in_one_group() -> Router:
+    return Router(
+        model_list=[
+            {
+                "model_name": "bedrock-nova",
+                "litellm_params": {"model": "bedrock/us.amazon.nova-micro-v1:0"},
+                "model_info": {"id": "global-nova", "access_groups": ["bedrock-group"]},
+            },
+            {
+                "model_name": "model_name_team-b_1111",
+                "litellm_params": {"model": "bedrock/us.amazon.nova-micro-v1:0"},
+                "model_info": {
+                    "id": "team-b-nova",
+                    "team_id": "team-b",
+                    "team_public_model_name": "team-b-nova",
+                    "access_groups": ["bedrock-group"],
+                },
+            },
+        ]
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("user_api_key_dict", "expected"),
+    [
+        (
+            UserAPIKeyAuth(api_key="sk-teamless", models=["bedrock-group"], team_id=None, team_models=[]),
+            ["bedrock-nova"],
+        ),
+        (
+            UserAPIKeyAuth(api_key="sk-team-b", models=["bedrock-group"], team_id="team-b", team_models=[]),
+            ["bedrock-nova", "model_name_team-b_1111"],
+        ),
+        (
+            UserAPIKeyAuth(
+                api_key="sk-admin",
+                models=["bedrock-group"],
+                team_id=None,
+                team_models=[],
+                user_role=LitellmUserRoles.PROXY_ADMIN,
+            ),
+            ["bedrock-nova", "model_name_team-b_1111"],
+        ),
+    ],
+    ids=["teamless-key", "owning-team-key", "proxy-admin-key"],
+)
+async def test_get_available_models_for_user_access_group_expands_only_to_usable_deployments(
+    user_api_key_dict, expected
+):
+    result = await get_available_models_for_user(
+        user_api_key_dict=user_api_key_dict,
+        llm_router=_router_with_global_and_team_b_deployment_in_one_group(),
+        general_settings={},
+        user_model=None,
+    )
+    assert sorted(result) == expected
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/utils/helpers/test_model_access.py
+++ b/tests/test_litellm/proxy/utils/helpers/test_model_access.py
@@ -290,7 +290,7 @@ def test_model_dump_with_preserved_fields_error_path_invalid_obj_raises():
         model_dump_with_preserved_fields(None)
 
 
-def _router_with_global_and_team_b_deployment_in_one_group() -> Router:
+def _router_with_global_and_team_b_deployments() -> Router:
     return Router(
         model_list=[
             {
@@ -306,6 +306,16 @@ def _router_with_global_and_team_b_deployment_in_one_group() -> Router:
                     "team_id": "team-b",
                     "team_public_model_name": "team-b-nova",
                     "access_groups": ["bedrock-group"],
+                },
+            },
+            {
+                "model_name": "model_name_team-b_2222",
+                "litellm_params": {"model": "bedrock/us.amazon.nova-lite-v1:0"},
+                "model_info": {
+                    "id": "team-b-lite",
+                    "team_id": "team-b",
+                    "team_public_model_name": "team-b-lite",
+                    "access_groups": ["team-b-only"],
                 },
             },
         ]
@@ -342,11 +352,22 @@ async def test_get_available_models_for_user_access_group_expands_only_to_usable
 ):
     result = await get_available_models_for_user(
         user_api_key_dict=user_api_key_dict,
-        llm_router=_router_with_global_and_team_b_deployment_in_one_group(),
+        llm_router=_router_with_global_and_team_b_deployments(),
         general_settings={},
         user_model=None,
     )
     assert sorted(result) == expected
+
+
+@pytest.mark.asyncio
+async def test_get_available_models_for_user_group_owned_by_another_team_lists_no_deployments():
+    result = await get_available_models_for_user(
+        user_api_key_dict=UserAPIKeyAuth(api_key="sk-teamless", models=["team-b-only"], team_id=None, team_models=[]),
+        llm_router=_router_with_global_and_team_b_deployments(),
+        general_settings={},
+        user_model=None,
+    )
+    assert not {"bedrock-nova", "model_name_team-b_1111", "model_name_team-b_2222"} & set(result)
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/utils/helpers/test_model_access.py
+++ b/tests/test_litellm/proxy/utils/helpers/test_model_access.py
@@ -335,6 +335,10 @@ def _router_with_global_and_team_b_deployments() -> Router:
             ["bedrock-nova", "model_name_team-b_1111"],
         ),
         (
+            UserAPIKeyAuth(api_key="sk-team-a", models=["bedrock-group"], team_id="team-a", team_models=[]),
+            ["bedrock-nova"],
+        ),
+        (
             UserAPIKeyAuth(
                 api_key="sk-admin",
                 models=["bedrock-group"],
@@ -345,7 +349,7 @@ def _router_with_global_and_team_b_deployments() -> Router:
             ["bedrock-nova", "model_name_team-b_1111"],
         ),
     ],
-    ids=["teamless-key", "owning-team-key", "proxy-admin-key"],
+    ids=["teamless-key", "owning-team-key", "other-team-key", "proxy-admin-key"],
 )
 async def test_get_available_models_for_user_access_group_expands_only_to_usable_deployments(
     user_api_key_dict, expected
@@ -357,6 +361,28 @@ async def test_get_available_models_for_user_access_group_expands_only_to_usable
         user_model=None,
     )
     assert sorted(result) == expected
+
+
+@pytest.mark.asyncio
+async def test_get_available_models_for_user_admin_listing_for_a_team_scopes_groups_to_that_team(monkeypatch):
+    from litellm.models.team import LiteLLM_TeamTableCachedObj
+
+    async def _get_team_object(**_kwargs):
+        return LiteLLM_TeamTableCachedObj(team_id="team-a", models=["bedrock-group"])
+
+    monkeypatch.setattr("litellm.proxy.auth.auth_checks.get_team_object", _get_team_object)
+
+    result = await get_available_models_for_user(
+        user_api_key_dict=UserAPIKeyAuth(api_key="sk-admin", user_role=LitellmUserRoles.PROXY_ADMIN, team_models=[]),
+        llm_router=_router_with_global_and_team_b_deployments(),
+        general_settings={},
+        user_model=None,
+        team_id="team-a",
+        prisma_client=MagicMock(),
+        proxy_logging_obj=MagicMock(),
+        user_api_key_cache=MagicMock(),
+    )
+    assert sorted(result) == ["bedrock-nova"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_endpoints.py
+++ b/tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_endpoints.py
@@ -313,6 +313,7 @@ async def test_vector_store_file_list_resolves_single_openai_team_deployment():
     request.headers = {}
 
     llm_router = MagicMock()
+    llm_router.model_owned_by_other_teams.return_value = False
     llm_router.get_deployment_credentials_with_provider.return_value = {
         "api_key": "sk-team-openai",
         "api_base": "https://api.openai.com/v1",
@@ -346,6 +347,7 @@ async def test_vector_store_file_list_wildcard_model_hint_falls_back_to_team_dep
     request.headers = {}
 
     llm_router = MagicMock()
+    llm_router.model_owned_by_other_teams.return_value = False
     llm_router.model_group_alias = {}
     llm_router.get_deployment_credentials_with_provider.side_effect = [
         None,
@@ -409,6 +411,7 @@ async def test_vector_store_file_list_uses_single_team_model_for_router_routing(
     request.headers = {}
 
     llm_router = MagicMock()
+    llm_router.model_owned_by_other_teams.return_value = False
     llm_router.get_model_access_groups.return_value = {}
     llm_router.get_deployment_credentials_with_provider.return_value = None
 
@@ -469,6 +472,7 @@ async def test_vector_store_file_list_does_not_guess_ambiguous_team_deployment()
     request.headers = {}
 
     llm_router = MagicMock()
+    llm_router.model_owned_by_other_teams.return_value = False
     llm_router.get_deployment_credentials_with_provider.side_effect = [
         {
             "api_key": "sk-team-openai-1",
@@ -528,6 +532,7 @@ async def test_vector_store_file_list_requires_explicit_openai_provider_for_team
     request.headers = {}
 
     llm_router = MagicMock()
+    llm_router.model_owned_by_other_teams.return_value = False
     llm_router.get_deployment_credentials_with_provider.return_value = {
         "api_key": "sk-unknown-provider",
         "api_base": "https://example.com/v1",

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -5083,11 +5083,27 @@ def test_get_model_access_groups_usable_by_team_drops_other_teams_deployments():
     }
 
 
+def test_get_deployments_usable_by_team_drops_other_teams_deployments():
+    router = _make_router_with_global_and_team_b_deployments()
+
+    def ids(model_name: str, team_id: str | None) -> list[str]:
+        return [d["model_info"]["id"] for d in router.get_deployments_usable_by_team(model_name, team_id)]
+
+    assert ids("bedrock-nova", None) == ["global-nova"]
+    assert ids("bedrock-nova", "team-a") == ["global-nova"]
+    assert ids("model_name_team-b_1111", None) == []
+    assert ids("model_name_team-b_1111", "team-a") == []
+    assert ids("model_name_team-b_1111", "team-b") == ["team-b-nova"]
+    assert ids("team-b-nova", "team-b") == ["team-b-nova"]
+
+
 def test_model_owned_by_other_teams():
     router = _make_router_with_global_and_team_b_deployments()
 
     assert router.model_owned_by_other_teams("model_name_team-b_1111", None) is True
+    assert router.model_owned_by_other_teams("model_name_team-b_1111", "team-a") is True
     assert router.model_owned_by_other_teams("model_name_team-b_1111", "team-b") is False
+    assert router.model_owned_by_other_teams("bedrock-nova", "team-a") is False
     assert router.model_owned_by_other_teams("bedrock-nova", None) is False
     assert router.model_owned_by_other_teams("bedrock-nova", "team-b") is False
     assert router.model_owned_by_other_teams("team-b-nova", None) is False

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -5040,6 +5040,66 @@ def test_deployment_usable_by_team_helpers():
     )
 
 
+def _make_router_with_global_and_team_b_deployments() -> litellm.Router:
+    return litellm.Router(
+        model_list=[
+            {
+                "model_name": "bedrock-nova",
+                "litellm_params": {"model": "bedrock/us.amazon.nova-micro-v1:0"},
+                "model_info": {"id": "global-nova", "access_groups": ["bedrock-group"]},
+            },
+            {
+                "model_name": "model_name_team-b_1111",
+                "litellm_params": {"model": "bedrock/us.amazon.nova-micro-v1:0"},
+                "model_info": {
+                    "id": "team-b-nova",
+                    "team_id": "team-b",
+                    "team_public_model_name": "team-b-nova",
+                    "access_groups": ["bedrock-group"],
+                },
+            },
+            {
+                "model_name": "model_name_team-b_2222",
+                "litellm_params": {"model": "bedrock/us.amazon.nova-lite-v1:0"},
+                "model_info": {
+                    "id": "team-b-lite",
+                    "team_id": "team-b",
+                    "team_public_model_name": "team-b-lite",
+                    "access_groups": ["team-b-only"],
+                },
+            },
+        ],
+    )
+
+
+def test_get_model_access_groups_usable_by_team_drops_other_teams_deployments():
+    router = _make_router_with_global_and_team_b_deployments()
+
+    assert router.get_model_access_groups_usable_by_team(None) == {
+        "bedrock-group": ("bedrock-nova",),
+        "team-b-only": (),
+    }
+    assert router.get_model_access_groups_usable_by_team("team-a") == {
+        "bedrock-group": ("bedrock-nova",),
+        "team-b-only": (),
+    }
+    assert router.get_model_access_groups_usable_by_team("team-b") == {
+        "bedrock-group": ("bedrock-nova", "model_name_team-b_1111"),
+        "team-b-only": ("model_name_team-b_2222",),
+    }
+
+
+def test_model_owned_by_other_teams():
+    router = _make_router_with_global_and_team_b_deployments()
+
+    assert router.model_owned_by_other_teams("model_name_team-b_1111", None) is True
+    assert router.model_owned_by_other_teams("model_name_team-b_1111", "team-b") is False
+    assert router.model_owned_by_other_teams("bedrock-nova", None) is False
+    assert router.model_owned_by_other_teams("bedrock-nova", "team-b") is False
+    assert router.model_owned_by_other_teams("team-b-nova", None) is False
+    assert router.model_owned_by_other_teams("unknown-model", None) is False
+
+
 def test_get_deployment_credentials_with_provider_skips_other_team_wildcard():
     """
     Global wildcard resolution must skip a team-scoped wildcard deployment for

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -5075,14 +5075,8 @@ def _make_router_with_global_and_team_b_deployments() -> litellm.Router:
 def test_get_model_access_groups_usable_by_team_drops_other_teams_deployments():
     router = _make_router_with_global_and_team_b_deployments()
 
-    assert router.get_model_access_groups_usable_by_team(None) == {
-        "bedrock-group": ("bedrock-nova",),
-        "team-b-only": (),
-    }
-    assert router.get_model_access_groups_usable_by_team("team-a") == {
-        "bedrock-group": ("bedrock-nova",),
-        "team-b-only": (),
-    }
+    assert router.get_model_access_groups_usable_by_team(None) == {"bedrock-group": ("bedrock-nova",)}
+    assert router.get_model_access_groups_usable_by_team("team-a") == {"bedrock-group": ("bedrock-nova",)}
     assert router.get_model_access_groups_usable_by_team("team-b") == {
         "bedrock-group": ("bedrock-nova", "model_name_team-b_1111"),
         "team-b-only": ("model_name_team-b_2222",),


### PR DESCRIPTION
## TLDR

Problem this solves:

- A team-less key granted an access group listed other teams' private deployments in `GET /v1/models`
- Auth let that key call those deployments by internal name, then routing answered 429
- `/v1/model/info` already hid them, so the two listings disagreed
- Keys that skip the key model check (`all-team-models`, keys with a `config`) reached other teams' deployments the same way, and the dashboard model list marked another team's deployment as direct access for a team-less user granted the group
- Those keys could also name another team's deployment in `fallbacks`, and the dashboard model list filtered to one team (`?teamId=`) still listed another team's deployment under it

How it solves it:

- Access groups expand only to deployments the caller's team can use, in `/v1/models`, `/v1/model/info`, and the dashboard model list alike
- A proxy admin still sees every deployment, except when listing a specific team (`?team_id=`), which is scoped to that team
- A group whose every deployment belongs to another team drops out of the caller's allowlist instead of leaving the key unrestricted
- Key auth returns 403 when every deployment behind the requested model, or behind any requested fallback, belongs to another team, for restricted keys and skip-check keys alike

## User Flow

Before: a developer holding a virtual key with no team, granted the `bedrock-group` access group, sees another team's private deployment in the model list and gets a confusing 429 when calling it

1. The proxy admin creates team B with POST https://litellm-domain/team/new and adds a Bedrock deployment scoped to team B with POST https://litellm-domain/model/new (`model_info.team_id` set, public name `team-b-nova`, `model_info.access_groups: ["bedrock-group"]`), next to the global `bedrock-nova` deployment that carries the same access group
2. The admin issues the developer a key with no team via POST https://litellm-domain/key/generate with `{"models": ["bedrock-group"]}`
3. The developer sends GET https://litellm-domain/v1/models with that key and gets `["bedrock-nova", "team-b-nova"]`, team B's private deployment included
4. They send POST https://litellm-domain/v1/chat/completions with `"model": "team-b-nova"` and get 403 `key not allowed to access model. This key can only access models=['bedrock-group']`
5. They send POST https://litellm-domain/v1/chat/completions with team B's internal routing name `model_name_<team_b_id>_<uuid>` (the id the model list shows when `use_team_public_model_name: false` is set) and get 429 `No deployments available for selected model, Try again in 5 seconds`: auth let the call through and only routing refused it
6. GET https://litellm-domain/v1/model/info with the same key shows only `bedrock-nova`, so the two listings disagree
7. A second team-less key granted only `team-b-only`, an access group whose every deployment belongs to team B, lists `team-b-lite` in GET https://litellm-domain/v1/models and gets the same 429 when it calls that deployment's internal name
8. A key on team A, whose team grants `bedrock-group`, lists `team-b-nova` in GET https://litellm-domain/v1/models, another team's private deployment offered to team A (calling it is refused with 403 `team not allowed to access model`, the team-level check catching what the listing did not)
9. A team-less key generated with `{"models": ["all-team-models"]}` calls team B's internal name through POST https://litellm-domain/v1/chat/completions and gets the same 429
10. The admin sends GET https://litellm-domain/v1/models?team_id=<team_a_id> and gets `["bedrock-nova", "team-b-nova"]`, another team's deployment listed under team A
11. A team-less internal user granted `bedrock-group` opens the dashboard model list (GET https://litellm-domain/v2/model/info?include_team_models=true) and sees team B's deployment marked `direct_access: true`
12. The admin filters the dashboard model list to team A (GET https://litellm-domain/v2/model/info?include_team_models=true&teamId=<team_a_id>) and sees team B's deployment listed under team A
13. The `all-team-models` key sends POST https://litellm-domain/v1/chat/completions with `"model": "bedrock-nova"` and `"fallbacks": ["model_name_<team_b_id>_<uuid>"]`: auth accepts team B's deployment as a fallback and only routing would refuse it
14. Anyone holding a team-less access-group key can enumerate other teams' private deployments and keep probing them

After: the same key sees only the deployments it can actually use, and calling another team's deployment is refused up front with a 403

1. The proxy admin creates team B with POST https://litellm-domain/team/new and adds a Bedrock deployment scoped to team B with POST https://litellm-domain/model/new (`model_info.team_id` set, public name `team-b-nova`, `model_info.access_groups: ["bedrock-group"]`), next to the global `bedrock-nova` deployment that carries the same access group
2. The admin issues the developer a key with no team via POST https://litellm-domain/key/generate with `{"models": ["bedrock-group"]}`
3. The developer sends GET https://litellm-domain/v1/models with that key and gets `["bedrock-nova"]` only
4. They send POST https://litellm-domain/v1/chat/completions with `"model": "team-b-nova"` and get the same 403 as before
5. They send POST https://litellm-domain/v1/chat/completions with team B's internal routing name and now get 403 `key not allowed to access model. This key can only access models=['bedrock-group']. Tried to access model_name_<team_b_id>_<uuid>` instead of the 429
6. GET https://litellm-domain/v1/model/info with the same key still shows only `bedrock-nova`, matching `/v1/models`
7. The second team-less key granted only `team-b-only` lists no team B deployment in GET https://litellm-domain/v1/models (only the literal group name `team-b-only`, the way any name the proxy does not recognise is echoed back), gets 403 when it calls team B's internal name, and still cannot call `bedrock-nova` (403, as before)
8. The team A key lists `["bedrock-nova"]` only, gets 403 `key not allowed to access model. Tried to access model_name_<team_b_id>_<uuid>, which is only deployed for other teams` when it calls team B's internal name, and still gets a real completion from `bedrock-nova`
9. The team-less `all-team-models` key gets 403 `key not allowed to access model. Tried to access model_name_<team_b_id>_<uuid>, which is only deployed for other teams` when it calls team B's internal name, and still gets a real completion from `bedrock-nova`
10. The admin's GET https://litellm-domain/v1/models?team_id=<team_a_id> returns `["bedrock-nova"]`, only what team A can use, while the admin's own listing without `team_id` still shows every deployment
11. The team-less internal user's dashboard model list shows only `bedrock-nova` (direct access); team B's deployment is gone from it
12. The admin's dashboard model list filtered to team A shows only `bedrock-nova`, matching what a team A member already saw for their own team
13. The `all-team-models` key naming team B's internal name in `fallbacks` gets 403 `key not allowed to access model. Tried to access model_name_<team_b_id>_<uuid>, which is only deployed for other teams` up front, and the same request with only `bedrock-nova` still gets a real completion
14. A team B key still lists `team-b-nova` and gets a real completion from it, and a proxy admin key still lists and can call every deployment
15. A team-less key can no longer discover or probe other teams' private deployments

## Relevant issues

## Linear ticket

Resolves LIT-6945

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Each leg runs two proxy processes (instance A on `$A`, instance B on `$B`, random local ports) with 2 uvicorn workers each, sharing one Postgres and one Redis, and requests alternate between the two instances. Both instances boot from this config, with `store_model_in_db: true` and a real Bedrock deployment (the small pool limit only keeps the shared local Postgres under its connection cap):

```yaml
model_list:
  - model_name: bedrock-nova
    litellm_params:
      model: bedrock/us.amazon.nova-micro-v1:0
      aws_region_name: us-east-1
    model_info:
      access_groups: ["bedrock-group"]
litellm_settings:
  cache: true
  cache_params:
    type: redis
    host: 127.0.0.1
    port: 6379
    supported_call_types: ["atext_completion"]
general_settings:
  store_model_in_db: true
  database_connection_pool_limit: 2
```

The database is reset between legs, so each leg creates its own team, deployments, and keys; the "setup" case below shows those calls and the ids they returned. For the last case of each leg, instance B is restarted with `use_team_public_model_name: false` added under `general_settings`.

### Before (aea5358c48)

#### setup: team and deployment through instance A, keys through instance B

1. `curl -s $A/team/new -H "Authorization: Bearer $MASTER_KEY" -d '{"team_alias":"team-b"}' | jq -r .team_id`

   ```
   7b86fdd9-8d1d-452b-a790-920ad9b59823
   ```
2. `curl -s $A/model/new -H "Authorization: Bearer $MASTER_KEY" -d '{"model_name":"team-b-nova","litellm_params":{"model":"bedrock/us.amazon.nova-micro-v1:0","aws_region_name":"us-east-1"},"model_info":{"team_id":"7b86fdd9-8d1d-452b-a790-920ad9b59823","access_groups":["bedrock-group"]}}' | jq -c "{model_name, team_id: .model_info.team_id, team_public_model_name: .model_info.team_public_model_name, access_groups: .model_info.access_groups}"`

   ```
   {"model_name":"model_name_7b86fdd9-8d1d-452b-a790-920ad9b59823_0bf1f0d2-2782-401e-870e-e3cd8ed3e14d","team_id":"7b86fdd9-8d1d-452b-a790-920ad9b59823","team_public_model_name":"team-b-nova","access_groups":["bedrock-group"]}
   ```
3. `curl -s $A/model/new -H "Authorization: Bearer $MASTER_KEY" -d '{"model_name":"team-b-lite","litellm_params":{"model":"bedrock/us.amazon.nova-lite-v1:0","aws_region_name":"us-east-1"},"model_info":{"team_id":"7b86fdd9-8d1d-452b-a790-920ad9b59823","access_groups":["team-b-only"]}}' | jq -c "{model_name, team_id: .model_info.team_id, team_public_model_name: .model_info.team_public_model_name, access_groups: .model_info.access_groups}"`

   ```
   {"model_name":"model_name_7b86fdd9-8d1d-452b-a790-920ad9b59823_3518e682-7964-4827-b5e3-ed0dff625800","team_id":"7b86fdd9-8d1d-452b-a790-920ad9b59823","team_public_model_name":"team-b-lite","access_groups":["team-b-only"]}
   ```
4. `curl -s $B/key/generate -H "Authorization: Bearer $MASTER_KEY" -d '{"models":["bedrock-group"],"key_alias":"teamless-bedrock-group"}' | jq -r .key`

   ```
   sk-spY6eZK... (no team_id)
   ```
5. `curl -s $B/key/generate -H "Authorization: Bearer $MASTER_KEY" -d '{"team_id":"7b86fdd9-8d1d-452b-a790-920ad9b59823","key_alias":"team-b-key"}' | jq -r .key`

   ```
   sk-V5Y84Ls...
   ```
6. `curl -s $B/key/generate -H "Authorization: Bearer $MASTER_KEY" -d '{"models":["team-b-only"],"key_alias":"teamless-team-b-only"}' | jq -r .key`

   ```
   sk-25WfR8-... (no team_id)
   ```
7. `curl -s $A/team/new -H "Authorization: Bearer $MASTER_KEY" -d '{"team_alias":"team-a","models":["bedrock-group"]}' | jq -r .team_id`

   ```
   d71ca295-a4c2-4e00-aee8-ae989daf1134
   ```
8. `curl -s $B/key/generate -H "Authorization: Bearer $MASTER_KEY" -d '{"team_id":"d71ca295-a4c2-4e00-aee8-ae989daf1134","key_alias":"team-a-key"}' | jq -r .key`

   ```
   sk-7Py59zC...
   ```
9. `curl -s $B/key/generate -H "Authorization: Bearer $MASTER_KEY" -d '{"models":["all-team-models"],"key_alias":"teamless-all-team-models"}' | jq -r .key`

   ```
   sk-wQ4MBUG... (no team_id)
   ```
10. `curl -s $A/key/generate -H "Authorization: Bearer $MASTER_KEY" -d '{"team_id":"d71ca295-a4c2-4e00-aee8-ae989daf1134","models":["all-team-models"],"key_alias":"team-a-all-team-models"}' | jq -r .key`

   ```
   sk-ddBDPsX... (team A, all-team-models)
   ```
11. `curl -s $A/user/new -H "Authorization: Bearer $MASTER_KEY" -d '{"user_id":"lit6945-user","user_role":"internal_user","models":["bedrock-group"],"auto_create_key":false}' | jq -c "{user_id, models}"`

   ```
   {"user_id":"lit6945-user","models":["bedrock-group"]}
   ```
12. `curl -s $B/key/generate -H "Authorization: Bearer $MASTER_KEY" -d '{"user_id":"lit6945-user","key_alias":"lit6945-user-key"}' | jq -r .key`

   ```
   sk-__BSOEf... (no team_id, user grant bedrock-group)
   ```
13. `curl -s $A/team/member_add -H "Authorization: Bearer $MASTER_KEY" -d '{"team_id":"d71ca295-a4c2-4e00-aee8-ae989daf1134","member":{"user_id":"lit6945-user-a","role":"user"}}' | jq -c "{team_id, members: [.members_with_roles[]?.user_id]}"`

   ```
   {"team_id":"d71ca295-a4c2-4e00-aee8-ae989daf1134","members":["default_user_id","lit6945-user-a"]}
   ```
14. `curl -s $B/key/generate -H "Authorization: Bearer $MASTER_KEY" -d '{"user_id":"lit6945-user-a","team_id":"d71ca295-a4c2-4e00-aee8-ae989daf1134","key_alias":"team-a-member-key"}' | jq -r .key`

   ```
   sk-rWnWfTm... (team A member)
   ```
15. `until curl -s $B/v1/model/info -H "Authorization: Bearer $MASTER_KEY" | jq -e --arg m "model_name_7b86fdd9-8d1d-452b-a790-920ad9b59823_0bf1f0d2-2782-401e-870e-e3cd8ed3e14d" --arg m2 "model_name_7b86fdd9-8d1d-452b-a790-920ad9b59823_3518e682-7964-4827-b5e3-ed0dff625800" '[.data[].model_name] | index($m) and index($m2)' >/dev/null; do sleep 2; done`

   ```
   instance B lists both new deployments after 211s
   ```

#### team-less bedrock-group key lists models

1. `curl -s $B/v1/models -H "Authorization: Bearer $KEY" | jq -c "[.data[].id]"`

   ```
   ["bedrock-nova","team-b-nova"]
   ```
2. `curl -s $A/v1/models -H "Authorization: Bearer $KEY" | jq -c "[.data[].id]"`

   ```
   ["bedrock-nova","team-b-nova"]
   ```
3. `curl -s $A/v1/model/info -H "Authorization: Bearer $KEY" | jq -c "[.data[] | {model_name, team_id: .model_info.team_id}]"`

   ```
   [{"model_name":"bedrock-nova","team_id":null}]
   ```

#### team-less key calls team B's deployment by public name

1. `curl -s $A/v1/chat/completions -H "Authorization: Bearer $KEY" -d '{"model":"team-b-nova",...}'`

   ```
   {"error":{"message":"key not allowed to access model. This key can only access models=['bedrock-group']. Tried to access team-b-nova","type":"key_model_access_denied","param":"model","code":"403"}}
   HTTP 403
   ```

#### team-less key calls team B's deployment by internal name

1. `curl -s $B/v1/chat/completions -H "Authorization: Bearer $KEY" -d '{"model":"model_name_7b86fdd9-8d1d-452b-a790-920ad9b59823_0bf1f0d2-2782-401e-870e-e3cd8ed3e14d",...}'`

   ```
   {"error":{"message":"No deployments available for selected model, Try again in 5 seconds. Passed model=model_name_7b86fdd9-8d1d-452b-a790-920ad9b59823_0bf1f0d2-2782-401e-870e-e3cd8ed3e14d. pre-call-checks=False, cooldown_list=[]","type":"internal_server_error","param":null,"code":"429"}}
   HTTP 429
   ```
2. `curl -s $A/v1/chat/completions -H "Authorization: Bearer $KEY" -d '{"model":"model_name_7b86fdd9-8d1d-452b-a790-920ad9b59823_0bf1f0d2-2782-401e-870e-e3cd8ed3e14d",...}'`

   ```
   {"error":{"message":"No deployments available for selected model, Try again in 5 seconds. Passed model=model_name_7b86fdd9-8d1d-452b-a790-920ad9b59823_0bf1f0d2-2782-401e-870e-e3cd8ed3e14d. pre-call-checks=False, cooldown_list=[]","type":"internal_server_error","param":null,"code":"429"}}
   HTTP 429
   ```

#### team-less key whose only access group belongs to team B

1. `curl -s $A/v1/models -H "Authorization: Bearer $KEY_ONLY" | jq -c "[.data[].id]"`

   ```
   ["team-b-lite"]
   ```
2. `curl -s $B/v1/models -H "Authorization: Bearer $KEY_ONLY" | jq -c "[.data[].id]"`

   ```
   ["team-b-lite"]
   ```
3. `curl -s $A/v1/chat/completions -H "Authorization: Bearer $KEY_ONLY" -d '{"model":"model_name_7b86fdd9-8d1d-452b-a790-920ad9b59823_3518e682-7964-4827-b5e3-ed0dff625800",...}'`

   ```
   {"error":{"message":"No deployments available for selected model, Try again in 5 seconds. Passed model=model_name_7b86fdd9-8d1d-452b-a790-920ad9b59823_3518e682-7964-4827-b5e3-ed0dff625800. pre-call-checks=False, cooldown_list=[]","type":"internal_server_error","param":null,"code":"429"}}
   HTTP 429
   ```
4. `curl -s $B/v1/chat/completions -H "Authorization: Bearer $KEY_ONLY" -d '{"model":"bedrock-nova",...}'`

   ```
   {"error":{"message":"key not allowed to access model. This key can only access models=['team-b-only']. Tried to access bedrock-nova","type":"key_model_access_denied","param":"model","code":"403"}}
   ```

#### team-less key calls the global deployment (real Bedrock call)

1. `curl -s $B/v1/chat/completions -H "Authorization: Bearer $KEY" -d '{"model":"bedrock-nova",...}'`

   ```
   {"model":"bedrock-nova","content":"Hello there!","usage":{"prompt_tokens":5,"completion_tokens":4}}
   ```

#### team B key still lists and calls its own deployment

1. `curl -s $A/v1/models -H "Authorization: Bearer $KEY_B" | jq -c "[.data[].id]"`

   ```
   ["team-b-nova","bedrock-nova","all-proxy-models","team-b-lite"]
   ```
2. `curl -s $B/v1/chat/completions -H "Authorization: Bearer $KEY_B" -d '{"model":"team-b-nova",...}'`

   ```
   {"model":"team-b-nova","content":"Hello, world!","usage":{"prompt_tokens":5,"completion_tokens":5}}
   ```

#### proxy admin can still call every deployment

1. `curl -s $A/v1/chat/completions -H "Authorization: Bearer $MASTER_KEY" -d '{"model":"model_name_7b86fdd9-8d1d-452b-a790-920ad9b59823_0bf1f0d2-2782-401e-870e-e3cd8ed3e14d",...}'`

   ```
   {"model":"model_name_7b86fdd9-8d1d-452b-a790-920ad9b59823_0bf1f0d2-2782-401e-870e-e3cd8ed3e14d","content":"Hello there!","usage":{"prompt_tokens":5,"completion_tokens":4}}
   ```

#### team A key (bedrock-group through its team) lists models and calls team B's deployment

1. `curl -s $A/v1/models -H "Authorization: Bearer $KEY_A" | jq -c "[.data[].id]"`

   ```
   ["bedrock-nova","team-b-nova"]
   ```
2. `curl -s $B/v1/chat/completions -H "Authorization: Bearer $KEY_A" -d '{"model":"model_name_7b86fdd9-8d1d-452b-a790-920ad9b59823_0bf1f0d2-2782-401e-870e-e3cd8ed3e14d",...}'`

   ```
   {"error":{"message":"team not allowed to access model. This team can only access models=['bedrock-group']. Tried to access model_name_7b86fdd9-8d1d-452b-a790-920ad9b59823_0bf1f0d2-2782-401e-870e-e3cd8ed3e14d","type":"team_model_access_denied","param":"model","code":"403"}}
   HTTP 403
   ```
3. `curl -s $A/v1/chat/completions -H "Authorization: Bearer $KEY_A" -d '{"model":"bedrock-nova",...}'`

   ```
   {"model":"bedrock-nova","content":"Hello, world!","usage":{"prompt_tokens":5,"completion_tokens":5}}
   ```

#### team-less all-team-models key calls team B's deployment by internal name

1. `curl -s $A/v1/chat/completions -H "Authorization: Bearer $KEY_ALL" -d '{"model":"model_name_7b86fdd9-8d1d-452b-a790-920ad9b59823_0bf1f0d2-2782-401e-870e-e3cd8ed3e14d",...}'`

   ```
   {"error":{"message":"No deployments available for selected model, Try again in 5 seconds. Passed model=model_name_7b86fdd9-8d1d-452b-a790-920ad9b59823_0bf1f0d2-2782-401e-870e-e3cd8ed3e14d. pre-call-checks=False, cooldown_list=[]","type":"internal_server_error","param":null,"code":"429"}}
   HTTP 429
   ```
2. `curl -s $B/v1/chat/completions -H "Authorization: Bearer $KEY_ALL" -d '{"model":"bedrock-nova",...}'`

   ```
   {"model":"bedrock-nova","content":"Hello there!","usage":{"prompt_tokens":5,"completion_tokens":4}}
   ```

#### keys that skip the key model check name team B's deployment as a fallback

1. `curl -s $B/v1/chat/completions -H "Authorization: Bearer $KEY_ALL" -d '{"model":"bedrock-nova","fallbacks":["model_name_7b86fdd9-8d1d-452b-a790-920ad9b59823_0bf1f0d2-2782-401e-870e-e3cd8ed3e14d"],...}'`

   ```
   {"model":"bedrock-nova","content":"Hello, world!","usage":{"prompt_tokens":5,"completion_tokens":5}}
   ```
2. `curl -s $A/v1/chat/completions -H "Authorization: Bearer $KEY_A_ALL" -d '{"model":"bedrock-nova","fallbacks":["model_name_7b86fdd9-8d1d-452b-a790-920ad9b59823_0bf1f0d2-2782-401e-870e-e3cd8ed3e14d"],...}'`

   ```
   {"model":"bedrock-nova","content":"Hello, world!","usage":{"prompt_tokens":5,"completion_tokens":5}}
   ```

#### team A all-team-models key calls team B's deployment by internal name

1. `curl -s $B/v1/chat/completions -H "Authorization: Bearer $KEY_A_ALL" -d '{"model":"model_name_7b86fdd9-8d1d-452b-a790-920ad9b59823_0bf1f0d2-2782-401e-870e-e3cd8ed3e14d",...}'`

   ```
   {"error":{"message":"team not allowed to access model. This team can only access models=['bedrock-group']. Tried to access model_name_7b86fdd9-8d1d-452b-a790-920ad9b59823_0bf1f0d2-2782-401e-870e-e3cd8ed3e14d","type":"team_model_access_denied","param":"model","code":"403"}}
   HTTP 403
   ```
2. `curl -s $A/v1/chat/completions -H "Authorization: Bearer $KEY_A_ALL" -d '{"model":"bedrock-nova",...}'`

   ```
   {"model":"bedrock-nova","content":"Hello, world!","usage":{"prompt_tokens":5,"completion_tokens":5}}
   ```

#### proxy admin lists the models of team A (?team_id=)

1. `curl -s "$B/v1/models?team_id=$TEAM_A" -H "Authorization: Bearer $MASTER_KEY" | jq -c "[.data[].id]"`

   ```
   ["bedrock-nova","team-b-nova"]
   ```

#### team-less user with a bedrock-group grant opens the dashboard model list

1. `curl -s "$A/v2/model/info?include_team_models=true" -H "Authorization: Bearer $KEY_USER" | jq -c "[.data[] | {model_name, direct_access: .model_info.direct_access}]"`

   ```
   [{"model_name":"bedrock-nova","direct_access":true},{"model_name":"team-b-nova","direct_access":true}]
   ```

#### proxy admin and a team A member filter the dashboard model list by team A (?teamId=)

1. `curl -s "$B/v2/model/info?include_team_models=true&teamId=$TEAM_A" -H "Authorization: Bearer $MASTER_KEY" | jq -c "[.data[] | {model_name, team_id: .model_info.team_id}]"`

   ```
   [{"model_name":"bedrock-nova","team_id":null},{"model_name":"team-b-nova","team_id":"7b86fdd9-8d1d-452b-a790-920ad9b59823"}]
   ```
2. `curl -s "$A/v2/model/info?include_team_models=true&teamId=$TEAM_A" -H "Authorization: Bearer $KEY_USER_A" | jq -c "if .data then [.data[] | {model_name, team_id: .model_info.team_id}] else . end"`

   ```
   [{"model_name":"bedrock-nova","team_id":null}]
   ```

Instance B restarted with `use_team_public_model_name: false` under `general_settings`.

#### legacy internal-name listing, team-less key lists models

1. `curl -s $B/v1/models -H "Authorization: Bearer $KEY" | jq -c "[.data[].id]"`

   ```
   ["bedrock-nova","model_name_7b86fdd9-8d1d-452b-a790-920ad9b59823_0bf1f0d2-2782-401e-870e-e3cd8ed3e14d"]
   ```
2. `curl -s $B/v1/models -H "Authorization: Bearer $KEY_ONLY" | jq -c "[.data[].id]"`

   ```
   ["model_name_7b86fdd9-8d1d-452b-a790-920ad9b59823_3518e682-7964-4827-b5e3-ed0dff625800"]
   ```

### After (f8c1f4bfb9)

#### setup: team and deployment through instance A, keys through instance B

1. `curl -s $A/team/new -H "Authorization: Bearer $MASTER_KEY" -d '{"team_alias":"team-b"}' | jq -r .team_id`

   ```
   99e5919f-d1c2-4383-8bf2-c3d82ec13faf
   ```
2. `curl -s $A/model/new -H "Authorization: Bearer $MASTER_KEY" -d '{"model_name":"team-b-nova","litellm_params":{"model":"bedrock/us.amazon.nova-micro-v1:0","aws_region_name":"us-east-1"},"model_info":{"team_id":"99e5919f-d1c2-4383-8bf2-c3d82ec13faf","access_groups":["bedrock-group"]}}' | jq -c "{model_name, team_id: .model_info.team_id, team_public_model_name: .model_info.team_public_model_name, access_groups: .model_info.access_groups}"`

   ```
   {"model_name":"model_name_99e5919f-d1c2-4383-8bf2-c3d82ec13faf_920349c6-cc4d-4759-9549-c310ac33d6c0","team_id":"99e5919f-d1c2-4383-8bf2-c3d82ec13faf","team_public_model_name":"team-b-nova","access_groups":["bedrock-group"]}
   ```
3. `curl -s $A/model/new -H "Authorization: Bearer $MASTER_KEY" -d '{"model_name":"team-b-lite","litellm_params":{"model":"bedrock/us.amazon.nova-lite-v1:0","aws_region_name":"us-east-1"},"model_info":{"team_id":"99e5919f-d1c2-4383-8bf2-c3d82ec13faf","access_groups":["team-b-only"]}}' | jq -c "{model_name, team_id: .model_info.team_id, team_public_model_name: .model_info.team_public_model_name, access_groups: .model_info.access_groups}"`

   ```
   {"model_name":"model_name_99e5919f-d1c2-4383-8bf2-c3d82ec13faf_25136c5e-c786-43f3-bbb8-f32296feffd4","team_id":"99e5919f-d1c2-4383-8bf2-c3d82ec13faf","team_public_model_name":"team-b-lite","access_groups":["team-b-only"]}
   ```
4. `curl -s $B/key/generate -H "Authorization: Bearer $MASTER_KEY" -d '{"models":["bedrock-group"],"key_alias":"teamless-bedrock-group"}' | jq -r .key`

   ```
   sk-22naSjC... (no team_id)
   ```
5. `curl -s $B/key/generate -H "Authorization: Bearer $MASTER_KEY" -d '{"team_id":"99e5919f-d1c2-4383-8bf2-c3d82ec13faf","key_alias":"team-b-key"}' | jq -r .key`

   ```
   sk-NGNhHKU...
   ```
6. `curl -s $B/key/generate -H "Authorization: Bearer $MASTER_KEY" -d '{"models":["team-b-only"],"key_alias":"teamless-team-b-only"}' | jq -r .key`

   ```
   sk-9qa-mRY... (no team_id)
   ```
7. `curl -s $A/team/new -H "Authorization: Bearer $MASTER_KEY" -d '{"team_alias":"team-a","models":["bedrock-group"]}' | jq -r .team_id`

   ```
   67f40586-1a40-4bd6-9fb7-e9c5deaa2ad5
   ```
8. `curl -s $B/key/generate -H "Authorization: Bearer $MASTER_KEY" -d '{"team_id":"67f40586-1a40-4bd6-9fb7-e9c5deaa2ad5","key_alias":"team-a-key"}' | jq -r .key`

   ```
   sk-sesZA24...
   ```
9. `curl -s $B/key/generate -H "Authorization: Bearer $MASTER_KEY" -d '{"models":["all-team-models"],"key_alias":"teamless-all-team-models"}' | jq -r .key`

   ```
   sk-7Mgyhd8... (no team_id)
   ```
10. `curl -s $A/key/generate -H "Authorization: Bearer $MASTER_KEY" -d '{"team_id":"67f40586-1a40-4bd6-9fb7-e9c5deaa2ad5","models":["all-team-models"],"key_alias":"team-a-all-team-models"}' | jq -r .key`

   ```
   sk-y54F_o_... (team A, all-team-models)
   ```
11. `curl -s $A/user/new -H "Authorization: Bearer $MASTER_KEY" -d '{"user_id":"lit6945-user","user_role":"internal_user","models":["bedrock-group"],"auto_create_key":false}' | jq -c "{user_id, models}"`

   ```
   {"user_id":"lit6945-user","models":["bedrock-group"]}
   ```
12. `curl -s $B/key/generate -H "Authorization: Bearer $MASTER_KEY" -d '{"user_id":"lit6945-user","key_alias":"lit6945-user-key"}' | jq -r .key`

   ```
   sk-AYalAPf... (no team_id, user grant bedrock-group)
   ```
13. `curl -s $A/team/member_add -H "Authorization: Bearer $MASTER_KEY" -d '{"team_id":"67f40586-1a40-4bd6-9fb7-e9c5deaa2ad5","member":{"user_id":"lit6945-user-a","role":"user"}}' | jq -c "{team_id, members: [.members_with_roles[]?.user_id]}"`

   ```
   {"team_id":"67f40586-1a40-4bd6-9fb7-e9c5deaa2ad5","members":["default_user_id","lit6945-user-a"]}
   ```
14. `curl -s $B/key/generate -H "Authorization: Bearer $MASTER_KEY" -d '{"user_id":"lit6945-user-a","team_id":"67f40586-1a40-4bd6-9fb7-e9c5deaa2ad5","key_alias":"team-a-member-key"}' | jq -r .key`

   ```
   sk-Z_LCiVf... (team A member)
   ```
15. `until curl -s $B/v1/model/info -H "Authorization: Bearer $MASTER_KEY" | jq -e --arg m "model_name_99e5919f-d1c2-4383-8bf2-c3d82ec13faf_920349c6-cc4d-4759-9549-c310ac33d6c0" --arg m2 "model_name_99e5919f-d1c2-4383-8bf2-c3d82ec13faf_25136c5e-c786-43f3-bbb8-f32296feffd4" '[.data[].model_name] | index($m) and index($m2)' >/dev/null; do sleep 2; done`

   ```
   instance B lists both new deployments after 202s
   ```

#### team-less bedrock-group key lists models

1. `curl -s $B/v1/models -H "Authorization: Bearer $KEY" | jq -c "[.data[].id]"`

   ```
   ["bedrock-nova"]
   ```
2. `curl -s $A/v1/models -H "Authorization: Bearer $KEY" | jq -c "[.data[].id]"`

   ```
   ["bedrock-nova"]
   ```
3. `curl -s $A/v1/model/info -H "Authorization: Bearer $KEY" | jq -c "[.data[] | {model_name, team_id: .model_info.team_id}]"`

   ```
   [{"model_name":"bedrock-nova","team_id":null}]
   ```

#### team-less key calls team B's deployment by public name

1. `curl -s $A/v1/chat/completions -H "Authorization: Bearer $KEY" -d '{"model":"team-b-nova",...}'`

   ```
   {"error":{"message":"key not allowed to access model. This key can only access models=['bedrock-group']. Tried to access team-b-nova","type":"key_model_access_denied","param":"model","code":"403"}}
   HTTP 403
   ```

#### team-less key calls team B's deployment by internal name

1. `curl -s $B/v1/chat/completions -H "Authorization: Bearer $KEY" -d '{"model":"model_name_99e5919f-d1c2-4383-8bf2-c3d82ec13faf_920349c6-cc4d-4759-9549-c310ac33d6c0",...}'`

   ```
   {"error":{"message":"key not allowed to access model. Tried to access model_name_99e5919f-d1c2-4383-8bf2-c3d82ec13faf_920349c6-cc4d-4759-9549-c310ac33d6c0, which is only deployed for other teams","type":"key_model_access_denied","param":"model","code":"403"}}
   HTTP 403
   ```
2. `curl -s $A/v1/chat/completions -H "Authorization: Bearer $KEY" -d '{"model":"model_name_99e5919f-d1c2-4383-8bf2-c3d82ec13faf_920349c6-cc4d-4759-9549-c310ac33d6c0",...}'`

   ```
   {"error":{"message":"key not allowed to access model. Tried to access model_name_99e5919f-d1c2-4383-8bf2-c3d82ec13faf_920349c6-cc4d-4759-9549-c310ac33d6c0, which is only deployed for other teams","type":"key_model_access_denied","param":"model","code":"403"}}
   HTTP 403
   ```

#### team-less key whose only access group belongs to team B

1. `curl -s $A/v1/models -H "Authorization: Bearer $KEY_ONLY" | jq -c "[.data[].id]"`

   ```
   ["team-b-only"]
   ```
2. `curl -s $B/v1/models -H "Authorization: Bearer $KEY_ONLY" | jq -c "[.data[].id]"`

   ```
   ["team-b-only"]
   ```
3. `curl -s $A/v1/chat/completions -H "Authorization: Bearer $KEY_ONLY" -d '{"model":"model_name_99e5919f-d1c2-4383-8bf2-c3d82ec13faf_25136c5e-c786-43f3-bbb8-f32296feffd4",...}'`

   ```
   {"error":{"message":"key not allowed to access model. Tried to access model_name_99e5919f-d1c2-4383-8bf2-c3d82ec13faf_25136c5e-c786-43f3-bbb8-f32296feffd4, which is only deployed for other teams","type":"key_model_access_denied","param":"model","code":"403"}}
   HTTP 403
   ```
4. `curl -s $B/v1/chat/completions -H "Authorization: Bearer $KEY_ONLY" -d '{"model":"bedrock-nova",...}'`

   ```
   {"error":{"message":"key not allowed to access model. This key can only access models=['team-b-only']. Tried to access bedrock-nova","type":"key_model_access_denied","param":"model","code":"403"}}
   ```

#### team-less key calls the global deployment (real Bedrock call)

1. `curl -s $B/v1/chat/completions -H "Authorization: Bearer $KEY" -d '{"model":"bedrock-nova",...}'`

   ```
   {"model":"bedrock-nova","content":"Hello, friend!","usage":{"prompt_tokens":5,"completion_tokens":5}}
   ```

#### team B key still lists and calls its own deployment

1. `curl -s $A/v1/models -H "Authorization: Bearer $KEY_B" | jq -c "[.data[].id]"`

   ```
   ["bedrock-nova","team-b-lite","team-b-nova","all-proxy-models"]
   ```
2. `curl -s $B/v1/chat/completions -H "Authorization: Bearer $KEY_B" -d '{"model":"team-b-nova",...}'`

   ```
   {"model":"team-b-nova","content":"Hello there!","usage":{"prompt_tokens":5,"completion_tokens":4}}
   ```

#### proxy admin can still call every deployment

1. `curl -s $A/v1/chat/completions -H "Authorization: Bearer $MASTER_KEY" -d '{"model":"model_name_99e5919f-d1c2-4383-8bf2-c3d82ec13faf_920349c6-cc4d-4759-9549-c310ac33d6c0",...}'`

   ```
   {"model":"model_name_99e5919f-d1c2-4383-8bf2-c3d82ec13faf_920349c6-cc4d-4759-9549-c310ac33d6c0","content":"Hello, world!","usage":{"prompt_tokens":5,"completion_tokens":5}}
   ```

#### team A key (bedrock-group through its team) lists models and calls team B's deployment

1. `curl -s $A/v1/models -H "Authorization: Bearer $KEY_A" | jq -c "[.data[].id]"`

   ```
   ["bedrock-nova"]
   ```
2. `curl -s $B/v1/chat/completions -H "Authorization: Bearer $KEY_A" -d '{"model":"model_name_99e5919f-d1c2-4383-8bf2-c3d82ec13faf_920349c6-cc4d-4759-9549-c310ac33d6c0",...}'`

   ```
   {"error":{"message":"key not allowed to access model. Tried to access model_name_99e5919f-d1c2-4383-8bf2-c3d82ec13faf_920349c6-cc4d-4759-9549-c310ac33d6c0, which is only deployed for other teams","type":"key_model_access_denied","param":"model","code":"403"}}
   HTTP 403
   ```
3. `curl -s $A/v1/chat/completions -H "Authorization: Bearer $KEY_A" -d '{"model":"bedrock-nova",...}'`

   ```
   {"model":"bedrock-nova","content":"Hello there!","usage":{"prompt_tokens":5,"completion_tokens":4}}
   ```

#### team-less all-team-models key calls team B's deployment by internal name

1. `curl -s $A/v1/chat/completions -H "Authorization: Bearer $KEY_ALL" -d '{"model":"model_name_99e5919f-d1c2-4383-8bf2-c3d82ec13faf_920349c6-cc4d-4759-9549-c310ac33d6c0",...}'`

   ```
   {"error":{"message":"key not allowed to access model. Tried to access model_name_99e5919f-d1c2-4383-8bf2-c3d82ec13faf_920349c6-cc4d-4759-9549-c310ac33d6c0, which is only deployed for other teams","type":"key_model_access_denied","param":"model","code":"403"}}
   HTTP 403
   ```
2. `curl -s $B/v1/chat/completions -H "Authorization: Bearer $KEY_ALL" -d '{"model":"bedrock-nova",...}'`

   ```
   {"model":"bedrock-nova","content":"Hello there!","usage":{"prompt_tokens":5,"completion_tokens":4}}
   ```

#### keys that skip the key model check name team B's deployment as a fallback

1. `curl -s $B/v1/chat/completions -H "Authorization: Bearer $KEY_ALL" -d '{"model":"bedrock-nova","fallbacks":["model_name_99e5919f-d1c2-4383-8bf2-c3d82ec13faf_920349c6-cc4d-4759-9549-c310ac33d6c0"],...}'`

   ```
   {"error":{"message":"key not allowed to access model. Tried to access model_name_99e5919f-d1c2-4383-8bf2-c3d82ec13faf_920349c6-cc4d-4759-9549-c310ac33d6c0, which is only deployed for other teams","type":"key_model_access_denied","param":"model","code":"403"}}
   ```
2. `curl -s $A/v1/chat/completions -H "Authorization: Bearer $KEY_A_ALL" -d '{"model":"bedrock-nova","fallbacks":["model_name_99e5919f-d1c2-4383-8bf2-c3d82ec13faf_920349c6-cc4d-4759-9549-c310ac33d6c0"],...}'`

   ```
   {"error":{"message":"key not allowed to access model. Tried to access model_name_99e5919f-d1c2-4383-8bf2-c3d82ec13faf_920349c6-cc4d-4759-9549-c310ac33d6c0, which is only deployed for other teams","type":"key_model_access_denied","param":"model","code":"403"}}
   ```

#### team A all-team-models key calls team B's deployment by internal name

1. `curl -s $B/v1/chat/completions -H "Authorization: Bearer $KEY_A_ALL" -d '{"model":"model_name_99e5919f-d1c2-4383-8bf2-c3d82ec13faf_920349c6-cc4d-4759-9549-c310ac33d6c0",...}'`

   ```
   {"error":{"message":"key not allowed to access model. Tried to access model_name_99e5919f-d1c2-4383-8bf2-c3d82ec13faf_920349c6-cc4d-4759-9549-c310ac33d6c0, which is only deployed for other teams","type":"key_model_access_denied","param":"model","code":"403"}}
   HTTP 403
   ```
2. `curl -s $A/v1/chat/completions -H "Authorization: Bearer $KEY_A_ALL" -d '{"model":"bedrock-nova",...}'`

   ```
   {"model":"bedrock-nova","content":"Hello, world!","usage":{"prompt_tokens":5,"completion_tokens":5}}
   ```

#### proxy admin lists the models of team A (?team_id=)

1. `curl -s "$B/v1/models?team_id=$TEAM_A" -H "Authorization: Bearer $MASTER_KEY" | jq -c "[.data[].id]"`

   ```
   ["bedrock-nova"]
   ```

#### team-less user with a bedrock-group grant opens the dashboard model list

1. `curl -s "$A/v2/model/info?include_team_models=true" -H "Authorization: Bearer $KEY_USER" | jq -c "[.data[] | {model_name, direct_access: .model_info.direct_access}]"`

   ```
   [{"model_name":"bedrock-nova","direct_access":true}]
   ```

#### proxy admin and a team A member filter the dashboard model list by team A (?teamId=)

1. `curl -s "$B/v2/model/info?include_team_models=true&teamId=$TEAM_A" -H "Authorization: Bearer $MASTER_KEY" | jq -c "[.data[] | {model_name, team_id: .model_info.team_id}]"`

   ```
   [{"model_name":"bedrock-nova","team_id":null}]
   ```
2. `curl -s "$A/v2/model/info?include_team_models=true&teamId=$TEAM_A" -H "Authorization: Bearer $KEY_USER_A" | jq -c "if .data then [.data[] | {model_name, team_id: .model_info.team_id}] else . end"`

   ```
   [{"model_name":"bedrock-nova","team_id":null}]
   ```

Instance B restarted with `use_team_public_model_name: false` under `general_settings`.

#### legacy internal-name listing, team-less key lists models

1. `curl -s $B/v1/models -H "Authorization: Bearer $KEY" | jq -c "[.data[].id]"`

   ```
   ["bedrock-nova"]
   ```
2. `curl -s $B/v1/models -H "Authorization: Bearer $KEY_ONLY" | jq -c "[.data[].id]"`

   ```
   ["team-b-only"]
   ```

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Foreign public names are not flagged by the new check for skip-check keys: `model_owned_by_other_teams("bedrock-nova", "team-a")` is False by design, so an `all-team-models` or config key naming another team's public name (`team-b-nova`) falls through to routing's error instead of the 403. Restricted keys still get the key model check 403
- View-only admins are scoped like non-admin keys: `is_proxy_admin` matches only `proxy_admin`, so a view-only admin's plain `/v1/models` now shows only global deployments and its foreign internal-name calls 403 where they 429d before; `scope=expand` still lists everything, so no working path is lost
- Direct grants naming a team's public model no longer count as direct access: `_resolve_model_grant_to_deployment_ids` treats team-owned deployments as never direct access, so such a user only sees the row through `access_via_team_ids` when a member. Calling it never worked outside the team, so listing is the only change
- A group owned wholly by another team lists its name as a model id: `_get_models_from_access_groups` echoes names absent from the scoped map, so `models: ["team-b-only"]` lists `["team-b-only"]` and calling it fails at routing (model not found) rather than with the 403. Pre-existing and shared by every listing surface; DB-backed `access_group_ids` listings stay unscoped, though the new 403 still runs after the DB fallback in `can_key_call_model`
- Listing change with no compat flag: the entries that disappear were never callable (429 at the base), so scripts reading `/v1/models` just see fewer ids and there is no switch to restore them
- Access-group scoping is now an uncached scan per listing call: `get_model_access_groups_usable_by_team` filters the cached map by walking `get_model_list()` on every non-admin `/v1/models`, `/v1/model/info`, and dashboard model list call. CodSpeed reports no change but does not benchmark this path
- Files-endpoint credential resolution still expands groups unscoped: `get_team_provider_credentials` builds its allowlist from `get_model_access_groups()`, but `get_deployment_credentials_with_provider` refuses other teams' deployments downstream, so nothing resolves across teams today
- The four `auth_checks.py` lines Codecov reports as uncovered are the restructured DB `access_group_ids` fallback in `can_key_call_model`, unchanged in behavior

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
