### PR TITLE
fix(passthrough): log the URL model and declared provider on Gemini and Vertex failures

### DIFF
--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -35,6 +35,7 @@ from litellm.litellm_core_utils.core_helpers import (
 from litellm.litellm_core_utils.service_tier_utils import (
     get_service_tier_from_standard_logging_payload,
 )
+from litellm.llms.openai_like.json_loader import JSONProviderRegistry
 from litellm.proxy._types import (
     LiteLLM_DeletedVerificationToken,
     LiteLLM_TeamTable,
@@ -2486,6 +2487,12 @@ class PrometheusLogger(CustomLogger):
         return False
 
     @staticmethod
+    def _is_known_provider(provider: object) -> bool:
+        return isinstance(provider, str) and (
+            provider in litellm.provider_list or JSONProviderRegistry.exists(provider)
+        )
+
+    @staticmethod
     def _extract_api_provider_from_request_data(request_data: dict) -> str | None:
         """
         Best-effort provider for the client-side failure path.
@@ -2497,17 +2504,21 @@ class PrometheusLogger(CustomLogger):
         the provider the request itself declares (e.g. a Gemini pass-through
         route), and finally infer it from the requested model name (e.g. ``gpt-4o-mini`` ->
         ``openai``) since the proxy's failure ``request_data`` usually carries
-        only the client-supplied model. Return ``None`` when it cannot be
+        only the client-supplied model. Declared values outside the known
+        provider set are ignored, since the request body can carry any string
+        and this label must stay bounded. Return ``None`` when it cannot be
         determined so the label emits empty rather than a guess.
         """
         litellm_params: Final = request_data.get("litellm_params") or {}
-        provider = litellm_params.get("custom_llm_provider")
-        if provider:
-            return provider
         standard_logging_object: Final = request_data.get("standard_logging_object") or {}
-        provider = standard_logging_object.get("custom_llm_provider") or request_data.get("custom_llm_provider")
-        if provider:
-            return provider
+        declared_providers: Final = (
+            litellm_params.get("custom_llm_provider"),
+            standard_logging_object.get("custom_llm_provider"),
+            request_data.get("custom_llm_provider"),
+        )
+        known_provider: Final = next((p for p in declared_providers if PrometheusLogger._is_known_provider(p)), None)
+        if known_provider:
+            return known_provider
         model: Final = litellm_params.get("model") or request_data.get("model")
         if not model:
             return None

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -2493,8 +2493,9 @@ class PrometheusLogger(CustomLogger):
         A request can fail before a deployment is resolved, so the provider is
         not always known. Prefer the resolved ``custom_llm_provider`` on
         ``litellm_params``, then any provider recovered onto a partial
-        ``standard_logging_object`` (e.g. a stream that broke mid-flight), and
-        finally infer it from the requested model name (e.g. ``gpt-4o-mini`` ->
+        ``standard_logging_object`` (e.g. a stream that broke mid-flight), then
+        the provider the request itself declares (e.g. a Gemini pass-through
+        route), and finally infer it from the requested model name (e.g. ``gpt-4o-mini`` ->
         ``openai``) since the proxy's failure ``request_data`` usually carries
         only the client-supplied model. Return ``None`` when it cannot be
         determined so the label emits empty rather than a guess.
@@ -2504,7 +2505,7 @@ class PrometheusLogger(CustomLogger):
         if provider:
             return provider
         standard_logging_object: Final = request_data.get("standard_logging_object") or {}
-        provider = standard_logging_object.get("custom_llm_provider")
+        provider = standard_logging_object.get("custom_llm_provider") or request_data.get("custom_llm_provider")
         if provider:
             return provider
         model: Final = litellm_params.get("model") or request_data.get("model")

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/gemini_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/gemini_passthrough_logging_handler.py
@@ -1,4 +1,3 @@
-import re
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Final
 
@@ -8,6 +7,7 @@ import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.llms.gemini.videos.transformation import GeminiVideoConfig
+from litellm.llms.vertex_ai.common_utils import get_vertex_model_id_from_url
 from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
     ModelResponseIterator as GeminiModelResponseIterator,
 )
@@ -200,11 +200,7 @@ class GeminiPassthroughLoggingHandler:
 
     @staticmethod
     def extract_model_from_url(url: str) -> str:
-        pattern: Final = r"/models/([^:]+)"
-        match: Final = re.search(pattern, url)
-        if match:
-            return match.group(1)
-        return "unknown"
+        return get_vertex_model_id_from_url(url) or "unknown"
 
     @staticmethod
     def _create_gemini_response_logging_payload_for_generate_content(

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/vertex_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/vertex_passthrough_logging_handler.py
@@ -9,7 +9,11 @@ import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.constants import VERTEX_BATCH_PREDICTION_JOBS_ROUTE
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
-from litellm.llms.vertex_ai.common_utils import get_vertex_location_from_url, get_vertex_model_id_from_url
+from litellm.llms.vertex_ai.common_utils import (
+    get_vertex_location_from_url,
+    get_vertex_model_id_from_url,
+    get_vertex_project_id_from_url,
+)
 from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
     ModelResponseIterator as VertexModelResponseIterator,
 )
@@ -563,9 +567,16 @@ class VertexPassthroughLoggingHandler:
         return None
 
     @staticmethod
-    def is_google_ai_host(url: str) -> bool:
-        hostname: Final = urlparse(url).hostname
-        return hostname is not None and hostname.endswith((GEMINI_API_HOST_SUFFIX, VERTEX_API_HOST_SUFFIX))
+    def is_google_ai_url(url: str) -> bool:
+        parsed_url: Final = urlparse(url)
+        if parsed_url.hostname is not None and parsed_url.hostname.endswith(
+            (GEMINI_API_HOST_SUFFIX, VERTEX_API_HOST_SUFFIX)
+        ):
+            return True
+        return (
+            get_vertex_project_id_from_url(parsed_url.path) is not None
+            and get_vertex_location_from_url(parsed_url.path) is not None
+        )
 
     @staticmethod
     def custom_llm_provider_from_url(url: str) -> str:

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/vertex_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/vertex_passthrough_logging_handler.py
@@ -35,6 +35,8 @@ from litellm.types.utils import (
 )
 
 vertex_search_api_config: Final = VertexSearchAPIVectorStoreConfig()
+GEMINI_API_HOST_SUFFIX: Final = "generativelanguage.googleapis.com"
+VERTEX_API_HOST_SUFFIX: Final = "aiplatform.googleapis.com"
 if TYPE_CHECKING:
     from litellm.types.utils import LiteLLMBatch
 
@@ -561,9 +563,14 @@ class VertexPassthroughLoggingHandler:
         return None
 
     @staticmethod
+    def is_google_ai_host(url: str) -> bool:
+        hostname: Final = urlparse(url).hostname
+        return hostname is not None and hostname.endswith((GEMINI_API_HOST_SUFFIX, VERTEX_API_HOST_SUFFIX))
+
+    @staticmethod
     def custom_llm_provider_from_url(url: str) -> str:
         parsed_url: Final = urlparse(url)
-        if parsed_url.hostname and parsed_url.hostname.endswith("generativelanguage.googleapis.com"):
+        if parsed_url.hostname and parsed_url.hostname.endswith(GEMINI_API_HOST_SUFFIX):
             return litellm.LlmProviders.GEMINI.value
         return litellm.LlmProviders.VERTEX_AI.value
 

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/vertex_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/vertex_passthrough_logging_handler.py
@@ -1,5 +1,4 @@
 import asyncio
-import re
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Final, cast
 from urllib.parse import urlparse
@@ -10,7 +9,7 @@ import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.constants import VERTEX_BATCH_PREDICTION_JOBS_ROUTE
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
-from litellm.llms.vertex_ai.common_utils import get_vertex_location_from_url
+from litellm.llms.vertex_ai.common_utils import get_vertex_location_from_url, get_vertex_model_id_from_url
 from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
     ModelResponseIterator as VertexModelResponseIterator,
 )
@@ -507,11 +506,7 @@ class VertexPassthroughLoggingHandler:
 
     @staticmethod
     def extract_model_from_url(url: str) -> str:
-        pattern: Final = r"/models/([^:]+)"
-        match: Final = re.search(pattern, url)
-        if match:
-            return match.group(1)
-        return "unknown"
+        return get_vertex_model_id_from_url(url) or "unknown"
 
     @staticmethod
     def extract_model_name_from_vertex_path(vertex_model_path: str) -> str:

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/vertex_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/vertex_passthrough_logging_handler.py
@@ -126,7 +126,7 @@ class VertexPassthroughLoggingHandler:
                 start_time=start_time,
                 end_time=end_time,
                 logging_obj=logging_obj,
-                custom_llm_provider=VertexPassthroughLoggingHandler._get_custom_llm_provider_from_url(url_route),
+                custom_llm_provider=VertexPassthroughLoggingHandler.custom_llm_provider_from_url(url_route),
                 vertex_location=vertex_location,
             )
 
@@ -377,7 +377,7 @@ class VertexPassthroughLoggingHandler:
                 response_json=response_json,
             )
 
-        custom_llm_provider: Final = VertexPassthroughLoggingHandler._get_custom_llm_provider_from_url(url_route)
+        custom_llm_provider: Final = VertexPassthroughLoggingHandler.custom_llm_provider_from_url(url_route)
 
         litellm_embedding_response.model = model
         logging_obj.model = model
@@ -449,7 +449,7 @@ class VertexPassthroughLoggingHandler:
             start_time=start_time,
             end_time=end_time,
             logging_obj=litellm_logging_obj,
-            custom_llm_provider=VertexPassthroughLoggingHandler._get_custom_llm_provider_from_url(url_route),
+            custom_llm_provider=VertexPassthroughLoggingHandler.custom_llm_provider_from_url(url_route),
             vertex_location=vertex_location,
         )
 
@@ -509,6 +509,15 @@ class VertexPassthroughLoggingHandler:
         return get_vertex_model_id_from_url(url) or "unknown"
 
     @staticmethod
+    def model_from_url_route(url_route: str) -> str | None:
+        model: Final = get_vertex_model_id_from_url(url_route)
+        if model is None:
+            return "vertex_ai/search_api" if ":search" in url_route else None
+        if "rawPredict" in url_route or "streamRawPredict" in url_route:
+            return f"vertex_ai/{model}"
+        return model
+
+    @staticmethod
     def extract_model_name_from_vertex_path(vertex_model_path: str) -> str:
         """
         Extract the actual model name from a Vertex AI model path.
@@ -552,7 +561,7 @@ class VertexPassthroughLoggingHandler:
         return None
 
     @staticmethod
-    def _get_custom_llm_provider_from_url(url: str) -> str:
+    def custom_llm_provider_from_url(url: str) -> str:
         parsed_url: Final = urlparse(url)
         if parsed_url.hostname and parsed_url.hostname.endswith("generativelanguage.googleapis.com"):
             return litellm.LlmProviders.GEMINI.value

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -58,6 +58,7 @@ from litellm.llms.base_llm.managed_resources.utils import (
     resolve_passthrough_managed_id_provider,
 )
 from litellm.llms.custom_httpx.http_handler import get_async_httpx_client
+from litellm.llms.vertex_ai.common_utils import get_vertex_model_id_from_url
 from litellm.passthrough import BasePassthroughUtils
 from litellm.proxy._types import (
     ConfigFieldInfo,
@@ -730,12 +731,23 @@ def _carry_guardrail_logging_info(request_data: dict, guardrail_data: dict | Non
     metadata.setdefault("standard_logging_guardrail_information", list(entries))
 
 
+def _passthrough_model_from_url(url: httpx.URL | None, custom_llm_provider: str | None) -> str | None:
+    if url is None:
+        return None
+    url_route: Final = str(url)
+    tracked_google_route: Final = pass_through_endpoint_logging.is_gemini_route(
+        url_route, custom_llm_provider
+    ) or pass_through_endpoint_logging.is_vertex_route(url_route)
+    return get_vertex_model_id_from_url(url_route) if tracked_google_route else None
+
+
 def _build_passthrough_failure_request_payload(
     parsed_body: dict | None,
     kwargs: dict | None,
     logging_obj: LiteLLMLoggingObj | None,
     custom_llm_provider: str | None,
     upstream_usage: UpstreamReportedUsage | None = None,
+    url: httpx.URL | None = None,
 ) -> dict:
     """Build the ``request_data`` dict passed to ``post_call_failure_hook``.
 
@@ -752,8 +764,8 @@ def _build_passthrough_failure_request_payload(
         request_payload.update(kwargs)
     if logging_obj is not None:
         request_payload["litellm_logging_obj"] = logging_obj
-    if "model" not in request_payload and parsed_body and isinstance(parsed_body, dict):
-        request_payload["model"] = parsed_body.get("model", "")
+    if "model" not in request_payload:
+        request_payload["model"] = _passthrough_model_from_url(url, custom_llm_provider) or ""
     if "custom_llm_provider" not in request_payload and custom_llm_provider:
         request_payload["custom_llm_provider"] = custom_llm_provider
     if upstream_usage is not None:
@@ -1302,6 +1314,7 @@ async def pass_through_request(
                     logging_obj=logging_obj,
                     custom_llm_provider=custom_llm_provider,
                     upstream_usage=upstream_usage,
+                    url=url,
                 ),
             )
 
@@ -1393,6 +1406,7 @@ async def pass_through_request(
                     logging_obj=logging_obj,
                     custom_llm_provider=custom_llm_provider,
                     upstream_usage=upstream_usage,
+                    url=url,
                 ),
             )
 
@@ -1492,6 +1506,7 @@ async def pass_through_request(
             logging_obj=logging_obj,
             custom_llm_provider=custom_llm_provider,
             upstream_usage=upstream_usage,
+            url=url,
         )
         failure_request_payload["response_body"] = response_body
         await _log_passthrough_upstream_failure(
@@ -1697,19 +1712,13 @@ async def pass_through_request(
         # Monitoring: Trigger post_call_failure_hook
         # for pass through endpoint failure
         #########################################################
-        request_payload: Final[dict] = _parsed_body or {}
-        # add user_api_key_dict, litellm_call_id, passthrough_logging_payloa for logging
-        if kwargs:
-            for key, value in kwargs.items():
-                request_payload[key] = value
-        if logging_obj is not None:
-            request_payload["litellm_logging_obj"] = logging_obj
-
-        if "model" not in request_payload and _parsed_body and isinstance(_parsed_body, dict):
-            request_payload["model"] = _parsed_body.get("model", "")
-        if "custom_llm_provider" not in request_payload and custom_llm_provider:
-            request_payload["custom_llm_provider"] = custom_llm_provider
-
+        request_payload: Final = _build_passthrough_failure_request_payload(
+            parsed_body=_parsed_body,
+            kwargs=kwargs,
+            logging_obj=logging_obj,
+            custom_llm_provider=custom_llm_provider,
+            url=url,
+        )
         _carry_guardrail_logging_info(request_payload, post_call_guardrail_data)
 
         await proxy_logging_obj.post_call_failure_hook(

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -99,6 +99,7 @@ from litellm.types.passthrough_endpoints.pass_through_endpoints import (
 )
 from litellm.types.utils import TRUSTED_CALLBACK_VARS_FIELD, Usage
 
+from .llm_provider_handlers.vertex_passthrough_logging_handler import VertexPassthroughLoggingHandler
 from .streaming_handler import PassThroughStreamingHandler
 from .success_handler import PassThroughEndpointLogging
 from .upstream_usage_headers import (
@@ -735,8 +736,18 @@ def _passthrough_google_provider(url_route: str, custom_llm_provider: str | None
     if pass_through_endpoint_logging.is_gemini_route(url_route, custom_llm_provider):
         return "gemini"
     if pass_through_endpoint_logging.is_vertex_route(url_route):
-        return "vertex_ai"
+        return VertexPassthroughLoggingHandler.custom_llm_provider_from_url(url_route)
     return None
+
+
+def _passthrough_google_model(url_route: str, google_provider: str | None) -> str | None:
+    match google_provider:
+        case "gemini":
+            return get_vertex_model_id_from_url(url_route)
+        case "vertex_ai":
+            return VertexPassthroughLoggingHandler.model_from_url_route(url_route)
+        case _:
+            return None
 
 
 def _build_passthrough_failure_request_payload(
@@ -765,7 +776,7 @@ def _build_passthrough_failure_request_payload(
     url_route: Final = str(url) if url is not None else ""
     google_provider: Final = _passthrough_google_provider(url_route, custom_llm_provider)
     if "model" not in request_payload:
-        request_payload["model"] = (get_vertex_model_id_from_url(url_route) if google_provider else None) or ""
+        request_payload["model"] = _passthrough_google_model(url_route, google_provider) or ""
     resolved_provider: Final = custom_llm_provider or google_provider
     if "custom_llm_provider" not in request_payload and resolved_provider:
         request_payload["custom_llm_provider"] = resolved_provider

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -731,14 +731,12 @@ def _carry_guardrail_logging_info(request_data: dict, guardrail_data: dict | Non
     metadata.setdefault("standard_logging_guardrail_information", list(entries))
 
 
-def _passthrough_model_from_url(url: httpx.URL | None, custom_llm_provider: str | None) -> str | None:
-    if url is None:
-        return None
-    url_route: Final = str(url)
-    tracked_google_route: Final = pass_through_endpoint_logging.is_gemini_route(
-        url_route, custom_llm_provider
-    ) or pass_through_endpoint_logging.is_vertex_route(url_route)
-    return get_vertex_model_id_from_url(url_route) if tracked_google_route else None
+def _passthrough_google_provider(url_route: str, custom_llm_provider: str | None) -> str | None:
+    if pass_through_endpoint_logging.is_gemini_route(url_route, custom_llm_provider):
+        return "gemini"
+    if pass_through_endpoint_logging.is_vertex_route(url_route):
+        return "vertex_ai"
+    return None
 
 
 def _build_passthrough_failure_request_payload(
@@ -764,10 +762,13 @@ def _build_passthrough_failure_request_payload(
         request_payload.update(kwargs)
     if logging_obj is not None:
         request_payload["litellm_logging_obj"] = logging_obj
+    url_route: Final = str(url) if url is not None else ""
+    google_provider: Final = _passthrough_google_provider(url_route, custom_llm_provider)
     if "model" not in request_payload:
-        request_payload["model"] = _passthrough_model_from_url(url, custom_llm_provider) or ""
-    if "custom_llm_provider" not in request_payload and custom_llm_provider:
-        request_payload["custom_llm_provider"] = custom_llm_provider
+        request_payload["model"] = (get_vertex_model_id_from_url(url_route) if google_provider else None) or ""
+    resolved_provider: Final = custom_llm_provider or google_provider
+    if "custom_llm_provider" not in request_payload and resolved_provider:
+        request_payload["custom_llm_provider"] = resolved_provider
     if upstream_usage is not None:
         request_payload["response_cost"] = upstream_usage.response_cost or 0.0
         request_payload["combined_usage_object"] = Usage(total_tokens=upstream_usage.total_tokens or 0)
@@ -1352,6 +1353,7 @@ async def pass_through_request(
                                 kwargs=kwargs,
                                 logging_obj=logging_obj,
                                 custom_llm_provider=custom_llm_provider,
+                                url=url,
                             ),
                         ),
                         managed_id_provider=_managed_id_provider,
@@ -1444,6 +1446,7 @@ async def pass_through_request(
                                 kwargs=kwargs,
                                 logging_obj=logging_obj,
                                 custom_llm_provider=custom_llm_provider,
+                                url=url,
                             ),
                         ),
                         managed_id_provider=_managed_id_provider,

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -735,7 +735,9 @@ def _carry_guardrail_logging_info(request_data: dict, guardrail_data: dict | Non
 def _passthrough_google_provider(url_route: str, custom_llm_provider: str | None) -> str | None:
     if pass_through_endpoint_logging.is_gemini_route(url_route, custom_llm_provider):
         return "gemini"
-    if pass_through_endpoint_logging.is_vertex_route(url_route):
+    if pass_through_endpoint_logging.is_vertex_route(url_route) or VertexPassthroughLoggingHandler.is_google_ai_host(
+        url_route
+    ):
         return VertexPassthroughLoggingHandler.custom_llm_provider_from_url(url_route)
     return None
 

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -732,12 +732,15 @@ def _carry_guardrail_logging_info(request_data: dict, guardrail_data: dict | Non
     metadata.setdefault("standard_logging_guardrail_information", list(entries))
 
 
+_GOOGLE_PASSTHROUGH_PROVIDERS: Final = frozenset(
+    (litellm.LlmProviders.GEMINI.value, litellm.LlmProviders.VERTEX_AI.value)
+)
+
+
 def _passthrough_google_provider(url_route: str, custom_llm_provider: str | None) -> str | None:
-    if pass_through_endpoint_logging.is_gemini_route(url_route, custom_llm_provider):
-        return "gemini"
-    if pass_through_endpoint_logging.is_vertex_route(url_route) or VertexPassthroughLoggingHandler.is_google_ai_host(
-        url_route
-    ):
+    if custom_llm_provider in _GOOGLE_PASSTHROUGH_PROVIDERS:
+        return custom_llm_provider
+    if VertexPassthroughLoggingHandler.is_google_ai_url(url_route):
         return VertexPassthroughLoggingHandler.custom_llm_provider_from_url(url_route)
     return None
 

--- a/tests/test_litellm/integrations/test_prometheus_labels.py
+++ b/tests/test_litellm/integrations/test_prometheus_labels.py
@@ -235,6 +235,24 @@ def test_extract_api_provider_from_request_data_failure_path():
     assert extract({"model": "some-unknown-model-xyz"}) is None
 
 
+def test_extract_api_provider_prefers_declared_provider_over_model_name_inference():
+    from litellm.integrations.prometheus import PrometheusLogger
+
+    extract = PrometheusLogger._extract_api_provider_from_request_data
+
+    assert extract({"model": "gemini-3.8-flash"}) == "vertex_ai"
+    assert extract({"model": "gemini-3.8-flash", "custom_llm_provider": "gemini"}) == "gemini"
+    assert (
+        extract(
+            {
+                "custom_llm_provider": "gemini",
+                "standard_logging_object": {"custom_llm_provider": "vertex_ai"},
+            }
+        )
+        == "vertex_ai"
+    )
+
+
 def test_extract_api_provider_swallows_unknown_model_but_logs_unexpected_errors():
     """
     get_llm_provider raises BadRequestError for a model that maps to no

--- a/tests/test_litellm/integrations/test_prometheus_labels.py
+++ b/tests/test_litellm/integrations/test_prometheus_labels.py
@@ -242,6 +242,7 @@ def test_extract_api_provider_prefers_declared_provider_over_model_name_inferenc
 
     assert extract({"model": "gemini-3.8-flash"}) == "vertex_ai"
     assert extract({"model": "gemini-3.8-flash", "custom_llm_provider": "gemini"}) == "gemini"
+    assert extract({"model": "gemini-3.8-flash", "custom_llm_provider": "vertex_ai"}) == "vertex_ai"
     assert (
         extract(
             {
@@ -251,6 +252,41 @@ def test_extract_api_provider_prefers_declared_provider_over_model_name_inferenc
         )
         == "vertex_ai"
     )
+
+
+@pytest.mark.parametrize(
+    "declared_provider",
+    ["client-supplied-value", "", {"nested": "object"}, 42],
+)
+def test_extract_api_provider_ignores_declared_values_outside_the_known_provider_set(declared_provider: object):
+    from litellm.integrations.prometheus import PrometheusLogger
+
+    extract = PrometheusLogger._extract_api_provider_from_request_data
+
+    assert extract({"model": "gpt-4o-mini", "custom_llm_provider": declared_provider}) == "openai"
+    assert extract({"model": "gpt-4o-mini", "litellm_params": {"custom_llm_provider": declared_provider}}) == "openai"
+    assert extract({"model": "no-such-model", "custom_llm_provider": declared_provider}) is None
+    assert (
+        extract(
+            {
+                "litellm_params": {"custom_llm_provider": declared_provider},
+                "standard_logging_object": {"custom_llm_provider": "azure"},
+            }
+        )
+        == "azure"
+    )
+
+
+def test_extract_api_provider_keeps_registered_custom_providers(monkeypatch: pytest.MonkeyPatch):
+    import litellm
+    from litellm.integrations.prometheus import PrometheusLogger
+
+    extract = PrometheusLogger._extract_api_provider_from_request_data
+    assert extract({"custom_llm_provider": "my-custom-llm"}) is None
+
+    monkeypatch.setattr(litellm, "provider_list", [*litellm.provider_list, "my-custom-llm"])
+    assert extract({"custom_llm_provider": "my-custom-llm"}) == "my-custom-llm"
+    assert extract({"litellm_params": {"custom_llm_provider": "my-custom-llm"}}) == "my-custom-llm"
 
 
 def test_extract_api_provider_swallows_unknown_model_but_logs_unexpected_errors():

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -5821,6 +5821,10 @@ _VERTEX_SEARCH_TARGET = (
     "https://discoveryengine.googleapis.com/v1/projects/p/locations/global"
     "/dataStores/default/servingConfigs/default:search"
 )
+_RELAYED_GEMINI_COUNT_TOKENS_TARGET = "http://127.0.0.1:30732/v1beta/models/gemini-3.8-flash:countTokens"
+_RELAYED_VERTEX_COUNT_TOKENS_TARGET = (
+    "http://127.0.0.1:30732/v1/projects/p/locations/us-east5/publishers/google/models/gemini-3.8-flash:countTokens"
+)
 
 
 async def _run_passthrough_failure(
@@ -5899,6 +5903,8 @@ def _upstream_400_as_event_stream(target: str) -> httpx.Response:
         (_VERTEX_FLASH_TARGET, None, True, "vertex_ai"),
         (_GEMINI_FLASH_TARGET.replace(":generateContent", ":countTokens"), "gemini", False, "gemini"),
         (_VERTEX_FLASH_TARGET.replace(":generateContent", ":countTokens"), None, False, "vertex_ai"),
+        (_RELAYED_GEMINI_COUNT_TOKENS_TARGET, "gemini", False, "gemini"),
+        (_RELAYED_VERTEX_COUNT_TOKENS_TARGET, None, False, "vertex_ai"),
     ],
 )
 async def test_passthrough_upstream_error_logs_model_from_url(
@@ -6017,7 +6023,10 @@ async def test_passthrough_mid_stream_drop_logs_model_from_url(
             "",
             "vertex_ai",
         ),
+        ({"contents": []}, _RELAYED_GEMINI_COUNT_TOKENS_TARGET, "gemini", "gemini-3.8-flash", "gemini"),
+        ({"contents": []}, _RELAYED_VERTEX_COUNT_TOKENS_TARGET, None, "gemini-3.8-flash", "vertex_ai"),
         ({"contents": []}, "https://api.example.com/v1/models/gpt-x:countTokens", None, "", None),
+        ({"contents": []}, "https://api.example.com/v1/models/gpt-x:predict", None, "", None),
         ({"contents": []}, "https://api.example.com/v1/models/gpt-x:thing", None, "", None),
         (None, None, None, "", None),
     ],

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -5897,6 +5897,8 @@ def _upstream_400_as_event_stream(target: str) -> httpx.Response:
         (_GEMINI_FLASH_TARGET, "gemini", True, "gemini"),
         (_VERTEX_FLASH_TARGET, None, False, "vertex_ai"),
         (_VERTEX_FLASH_TARGET, None, True, "vertex_ai"),
+        (_GEMINI_FLASH_TARGET.replace(":generateContent", ":countTokens"), "gemini", False, "gemini"),
+        (_VERTEX_FLASH_TARGET.replace(":generateContent", ":countTokens"), None, False, "vertex_ai"),
     ],
 )
 async def test_passthrough_upstream_error_logs_model_from_url(
@@ -5986,6 +5988,36 @@ async def test_passthrough_mid_stream_drop_logs_model_from_url(
             "",
             "vertex_ai",
         ),
+        (
+            {"contents": []},
+            _GEMINI_FLASH_TARGET.replace(":generateContent", ":countTokens"),
+            "gemini",
+            "gemini-3.8-flash",
+            "gemini",
+        ),
+        (
+            {"contents": []},
+            _VERTEX_FLASH_TARGET.replace(":generateContent", ":countTokens"),
+            None,
+            "gemini-3.8-flash",
+            "vertex_ai",
+        ),
+        (
+            {"contents": []},
+            "https://aiplatform.googleapis.com/v1/projects/p/locations/global"
+            "/publishers/google/models/gemini-3.8-flash:countTokens",
+            None,
+            "gemini-3.8-flash",
+            "vertex_ai",
+        ),
+        (
+            {},
+            "https://us-central1-aiplatform.googleapis.com/v1/projects/p/locations/us-central1/cachedContents",
+            None,
+            "",
+            "vertex_ai",
+        ),
+        ({"contents": []}, "https://api.example.com/v1/models/gpt-x:countTokens", None, "", None),
         ({"contents": []}, "https://api.example.com/v1/models/gpt-x:thing", None, "", None),
         (None, None, None, "", None),
     ],

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
+import respx
 from fastapi import Request, UploadFile
 from starlette.datastructures import FormData, Headers, QueryParams
 from starlette.datastructures import UploadFile as StarletteUploadFile
@@ -21,6 +22,7 @@ from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
     HttpPassThroughEndpointHelpers,
     InitPassThroughEndpointHelpers,
     LITELLM_PASS_THROUGH_CUSTOM_BODY_STATE_KEY,
+    _build_passthrough_failure_request_payload,
     _registered_pass_through_routes,
     create_pass_through_route,
     initialize_pass_through_endpoints,
@@ -344,53 +346,18 @@ async def test_pass_through_request_failure_handler():
 
     Critical Test: When a users pass through endpoint request fails, we must log the failure code, exception in litellm spend logs.
     """
-    with patch("litellm.proxy.proxy_server.proxy_logging_obj") as mock_proxy_logging:
-        with patch("litellm.llms.custom_httpx.http_handler.get_async_httpx_client") as mock_get_client:
-            with patch(
-                "litellm.proxy.pass_through_endpoints.pass_through_endpoints.ProxyBaseLLMRequestProcessing"
-            ) as mock_processing:
-                # Setup mock for post_call_failure_hook and pre_call_hook
-                mock_proxy_logging.post_call_failure_hook = AsyncMock()
-                mock_proxy_logging.pre_call_hook = AsyncMock()
+    request_failure = httpx.HTTPError("Request failed")
+    user_api_key_dict = UserAPIKeyAuth(api_key="sk-test")
 
-                # Setup mock for httpx client
-                mock_client = MagicMock()
-                mock_client.client = MagicMock()
-                mock_client.client.request = AsyncMock(side_effect=httpx.HTTPError("Request failed"))
-                mock_get_client.return_value = mock_client
+    failure = await _run_passthrough_failure(
+        "http://test.com", None, request_failure, user_api_key_dict=user_api_key_dict
+    )
 
-                # Mock headers for custom headers
-                mock_processing.get_custom_headers.return_value = {}
-
-                # Create mock request
-                mock_request = MagicMock(spec=Request)
-                mock_request.method = "POST"
-                mock_request.body = AsyncMock(return_value=b'{"test": "data"}')
-                mock_request.headers = Headers({})
-
-                # Create a simple empty QueryParams
-                mock_request.query_params = QueryParams({})
-
-                # Create mock user API key dict
-                mock_user_api_key_dict = MagicMock()
-
-                # Call the function with a target that will trigger an HTTPError
-                with pytest.raises(ProxyException):
-                    await pass_through_request(
-                        request=mock_request,
-                        target="http://test.com",
-                        custom_headers={},
-                        user_api_key_dict=mock_user_api_key_dict,
-                    )
-
-                # Assert post_call_failure_hook was called
-                mock_proxy_logging.post_call_failure_hook.assert_called_once()
-
-                # Verify the arguments to post_call_failure_hook
-                call_args = mock_proxy_logging.post_call_failure_hook.call_args[1]
-                assert call_args["user_api_key_dict"] == mock_user_api_key_dict
-                assert isinstance(call_args["original_exception"], TypeError)  # Now expecting TypeError
-                assert "traceback_str" in call_args
+    assert failure["user_api_key_dict"] is user_api_key_dict
+    assert failure["original_exception"] is request_failure
+    assert "traceback_str" in failure
+    assert failure["request_data"]["contents"] == "not a list"
+    assert failure["request_data"]["model"] == ""
 
 
 @pytest.mark.asyncio
@@ -5837,3 +5804,110 @@ def test_passthrough_client_cannot_forge_session_id_omission(client_metadata_key
         )
         == "per-call-random-trace-id"
     )
+
+
+_GEMINI_FLASH_TARGET = "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.8-flash:generateContent"
+_VERTEX_FLASH_TARGET = (
+    "https://us-east5-aiplatform.googleapis.com/v1/projects/p/locations/us-east5"
+    "/publishers/google/models/gemini-3.8-flash:generateContent"
+)
+
+
+async def _run_passthrough_failure(
+    target: str,
+    custom_llm_provider: str | None,
+    upstream: httpx.Response | Exception,
+    stream: bool = False,
+    user_api_key_dict: UserAPIKeyAuth | None = None,
+) -> dict:
+    with (
+        pytest.MonkeyPatch.context() as transport_patch,
+        patch("litellm.proxy.proxy_server.proxy_logging_obj") as mock_proxy_logging,
+        respx.mock(assert_all_called=False) as upstream_mock,
+    ):
+        transport_patch.setattr(litellm, "disable_aiohttp_transport", True)
+        litellm.in_memory_llm_clients_cache.flush_cache()
+        upstream_route = upstream_mock.route(method="POST")
+        if isinstance(upstream, Exception):
+            upstream_route.mock(side_effect=upstream)
+        else:
+            upstream_route.mock(return_value=upstream)
+        mock_proxy_logging.pre_call_hook = AsyncMock(side_effect=lambda **kwargs: kwargs["data"])
+        mock_proxy_logging.post_call_failure_hook = AsyncMock()
+        mock_proxy_logging.post_call_response_headers_hook = AsyncMock(return_value=None)
+        mock_request = MagicMock(spec=Request)
+        mock_request.method = "POST"
+        mock_request.url = target.replace("https://", "http://test-proxy.com/")
+        mock_request.body = AsyncMock(return_value=b'{"contents": "not a list"}')
+        mock_request.headers = Headers({"content-type": "application/json"})
+        mock_request.query_params = QueryParams({})
+        try:
+            await pass_through_request(
+                request=mock_request,
+                target=target,
+                custom_headers={},
+                user_api_key_dict=user_api_key_dict or UserAPIKeyAuth(api_key="sk-test"),
+                custom_llm_provider=custom_llm_provider,
+                stream=stream,
+            )
+        except ProxyException:
+            pass
+        litellm.in_memory_llm_clients_cache.flush_cache()
+        mock_proxy_logging.post_call_failure_hook.assert_called_once()
+        return mock_proxy_logging.post_call_failure_hook.call_args.kwargs
+
+
+def _upstream_400(target: str) -> httpx.Response:
+    return httpx.Response(
+        status_code=400,
+        headers={"content-type": "application/json"},
+        content=json.dumps({"error": {"code": 400, "status": "INVALID_ARGUMENT"}}).encode(),
+        request=httpx.Request("POST", target),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "target, custom_llm_provider, stream",
+    [
+        (_GEMINI_FLASH_TARGET, "gemini", False),
+        (_GEMINI_FLASH_TARGET, "gemini", True),
+        (_VERTEX_FLASH_TARGET, None, False),
+    ],
+)
+async def test_passthrough_upstream_error_logs_model_from_url(
+    target: str, custom_llm_provider: str | None, stream: bool
+):
+    failure = await _run_passthrough_failure(target, custom_llm_provider, _upstream_400(target), stream=stream)
+    assert failure["request_data"]["model"] == "gemini-3.8-flash"
+
+
+@pytest.mark.asyncio
+async def test_passthrough_internal_failure_logs_model_from_url():
+    failure = await _run_passthrough_failure(
+        _GEMINI_FLASH_TARGET, "gemini", httpx.ReadTimeout("upstream timed out")
+    )
+    assert failure["request_data"]["model"] == "gemini-3.8-flash"
+
+
+@pytest.mark.parametrize(
+    "parsed_body, url, custom_llm_provider, expected_model",
+    [
+        ({"model": "from-body"}, _GEMINI_FLASH_TARGET, "gemini", "from-body"),
+        ({"contents": []}, _GEMINI_FLASH_TARGET, "gemini", "gemini-3.8-flash"),
+        ({"contents": []}, _VERTEX_FLASH_TARGET, None, "gemini-3.8-flash"),
+        ({"contents": []}, "https://api.example.com/v1/models/gpt-x:thing", None, ""),
+        (None, None, None, ""),
+    ],
+)
+def test_build_passthrough_failure_request_payload_model_precedence(
+    parsed_body: dict | None, url: str | None, custom_llm_provider: str | None, expected_model: str
+):
+    request_payload = _build_passthrough_failure_request_payload(
+        parsed_body=parsed_body,
+        kwargs=None,
+        logging_obj=None,
+        custom_llm_provider=custom_llm_provider,
+        url=httpx.URL(url) if url else None,
+    )
+    assert request_payload["model"] == expected_model

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -13,6 +13,7 @@ import httpx
 import pytest
 import respx
 from fastapi import Request, UploadFile
+from fastapi.responses import StreamingResponse
 from starlette.datastructures import FormData, Headers, QueryParams
 from starlette.datastructures import UploadFile as StarletteUploadFile
 
@@ -5842,7 +5843,7 @@ async def _run_passthrough_failure(
         mock_request.headers = Headers({"content-type": "application/json"})
         mock_request.query_params = QueryParams({})
         try:
-            await pass_through_request(
+            received = await pass_through_request(
                 request=mock_request,
                 target=target,
                 custom_headers={},
@@ -5850,8 +5851,12 @@ async def _run_passthrough_failure(
                 custom_llm_provider=custom_llm_provider,
                 stream=stream,
             )
-        except ProxyException:
+            if isinstance(received, StreamingResponse):
+                async for _ in received.body_iterator:
+                    pass
+        except (ProxyException, httpx.HTTPError):
             pass
+        await asyncio.sleep(0)
         litellm.in_memory_llm_clients_cache.flush_cache()
         mock_proxy_logging.post_call_failure_hook.assert_called_once()
         return mock_proxy_logging.post_call_failure_hook.call_args.kwargs
@@ -5868,18 +5873,20 @@ def _upstream_400(target: str) -> httpx.Response:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "target, custom_llm_provider, stream",
+    "target, custom_llm_provider, stream, expected_provider",
     [
-        (_GEMINI_FLASH_TARGET, "gemini", False),
-        (_GEMINI_FLASH_TARGET, "gemini", True),
-        (_VERTEX_FLASH_TARGET, None, False),
+        (_GEMINI_FLASH_TARGET, "gemini", False, "gemini"),
+        (_GEMINI_FLASH_TARGET, "gemini", True, "gemini"),
+        (_VERTEX_FLASH_TARGET, None, False, "vertex_ai"),
+        (_VERTEX_FLASH_TARGET, None, True, "vertex_ai"),
     ],
 )
 async def test_passthrough_upstream_error_logs_model_from_url(
-    target: str, custom_llm_provider: str | None, stream: bool
+    target: str, custom_llm_provider: str | None, stream: bool, expected_provider: str
 ):
     failure = await _run_passthrough_failure(target, custom_llm_provider, _upstream_400(target), stream=stream)
     assert failure["request_data"]["model"] == "gemini-3.8-flash"
+    assert failure["request_data"]["custom_llm_provider"] == expected_provider
 
 
 @pytest.mark.asyncio
@@ -5888,20 +5895,55 @@ async def test_passthrough_internal_failure_logs_model_from_url():
         _GEMINI_FLASH_TARGET, "gemini", httpx.ReadTimeout("upstream timed out")
     )
     assert failure["request_data"]["model"] == "gemini-3.8-flash"
+    assert failure["request_data"]["custom_llm_provider"] == "gemini"
+
+
+def _upstream_dropping_stream(target: str) -> httpx.Response:
+    return httpx.Response(
+        status_code=200,
+        headers={"content-type": "text/event-stream"},
+        stream=_UpstreamDroppingMidStream(),
+        request=httpx.Request("POST", target),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "target, custom_llm_provider, expected_provider",
+    [
+        (_GEMINI_FLASH_TARGET.replace(":generateContent", ":streamGenerateContent?alt=sse"), "gemini", "gemini"),
+        (_VERTEX_FLASH_TARGET.replace(":generateContent", ":streamGenerateContent?alt=sse"), None, "vertex_ai"),
+    ],
+)
+async def test_passthrough_mid_stream_drop_logs_model_from_url(
+    target: str, custom_llm_provider: str | None, expected_provider: str
+):
+    failure = await _run_passthrough_failure(
+        target, custom_llm_provider, _upstream_dropping_stream(target), stream=True
+    )
+    assert isinstance(failure["original_exception"], httpx.ReadError)
+    assert failure["request_data"]["model"] == "gemini-3.8-flash"
+    assert failure["request_data"]["custom_llm_provider"] == expected_provider
 
 
 @pytest.mark.parametrize(
-    "parsed_body, url, custom_llm_provider, expected_model",
+    "parsed_body, url, custom_llm_provider, expected_model, expected_provider",
     [
-        ({"model": "from-body"}, _GEMINI_FLASH_TARGET, "gemini", "from-body"),
-        ({"contents": []}, _GEMINI_FLASH_TARGET, "gemini", "gemini-3.8-flash"),
-        ({"contents": []}, _VERTEX_FLASH_TARGET, None, "gemini-3.8-flash"),
-        ({"contents": []}, "https://api.example.com/v1/models/gpt-x:thing", None, ""),
-        (None, None, None, ""),
+        ({"model": "from-body"}, _GEMINI_FLASH_TARGET, "gemini", "from-body", "gemini"),
+        ({"contents": []}, _GEMINI_FLASH_TARGET, "gemini", "gemini-3.8-flash", "gemini"),
+        ({"contents": []}, _VERTEX_FLASH_TARGET, None, "gemini-3.8-flash", "vertex_ai"),
+        ({"contents": []}, _VERTEX_FLASH_TARGET, "anthropic", "gemini-3.8-flash", "anthropic"),
+        ({"custom_llm_provider": "from-body"}, _VERTEX_FLASH_TARGET, None, "gemini-3.8-flash", "from-body"),
+        ({"contents": []}, "https://api.example.com/v1/models/gpt-x:thing", None, "", None),
+        (None, None, None, "", None),
     ],
 )
-def test_build_passthrough_failure_request_payload_model_precedence(
-    parsed_body: dict | None, url: str | None, custom_llm_provider: str | None, expected_model: str
+def test_build_passthrough_failure_request_payload_model_and_provider_precedence(
+    parsed_body: dict | None,
+    url: str | None,
+    custom_llm_provider: str | None,
+    expected_model: str,
+    expected_provider: str | None,
 ):
     request_payload = _build_passthrough_failure_request_payload(
         parsed_body=parsed_body,
@@ -5911,3 +5953,4 @@ def test_build_passthrough_failure_request_payload_model_precedence(
         url=httpx.URL(url) if url else None,
     )
     assert request_payload["model"] == expected_model
+    assert request_payload.get("custom_llm_provider") == expected_provider

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -17,32 +17,33 @@ from fastapi.responses import StreamingResponse
 from starlette.datastructures import FormData, Headers, QueryParams
 from starlette.datastructures import UploadFile as StarletteUploadFile
 
-
+import litellm
+from litellm.integrations.custom_logger import CustomLogger
+from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+from litellm.proxy._types import ProxyException, UserAPIKeyAuth
+from litellm.proxy.pass_through_endpoints.llm_provider_handlers.vertex_passthrough_logging_handler import (
+    VertexPassthroughLoggingHandler,
+)
 from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
     DEFAULT_PASS_THROUGH_REQUEST_TIMEOUT_SECONDS,
+    LITELLM_PASS_THROUGH_CUSTOM_BODY_STATE_KEY,
     HttpPassThroughEndpointHelpers,
     InitPassThroughEndpointHelpers,
-    LITELLM_PASS_THROUGH_CUSTOM_BODY_STATE_KEY,
     _build_passthrough_failure_request_payload,
     _registered_pass_through_routes,
     create_pass_through_route,
     initialize_pass_through_endpoints,
     pass_through_request,
-    resolve_pass_through_request_timeout,
     resolve_llm_passthrough_timeout,
+    resolve_pass_through_request_timeout,
     websocket_passthrough_request,
-)
-from litellm.integrations.custom_logger import CustomLogger
-from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
-from litellm.proxy._types import ProxyException, UserAPIKeyAuth
-from litellm.types.passthrough_endpoints.pass_through_endpoints import (
-    LITELLM_PASS_THROUGH_RAW_BODY_STATE_KEY,
 )
 from litellm.proxy.pass_through_endpoints.success_handler import (
     PassThroughEndpointLogging,
 )
-
-import litellm
+from litellm.types.passthrough_endpoints.pass_through_endpoints import (
+    LITELLM_PASS_THROUGH_RAW_BODY_STATE_KEY,
+)
 
 MESSAGE_START_SSE_FRAME = b'event: message_start\ndata: {"type": "message_start"}\n\n'
 
@@ -5812,6 +5813,14 @@ _VERTEX_FLASH_TARGET = (
     "https://us-east5-aiplatform.googleapis.com/v1/projects/p/locations/us-east5"
     "/publishers/google/models/gemini-3.8-flash:generateContent"
 )
+_VERTEX_CLAUDE_RAW_PREDICT_TARGET = (
+    "https://us-east5-aiplatform.googleapis.com/v1/projects/p/locations/us-east5"
+    "/publishers/anthropic/models/claude-opus-5:rawPredict"
+)
+_VERTEX_SEARCH_TARGET = (
+    "https://discoveryengine.googleapis.com/v1/projects/p/locations/global"
+    "/dataStores/default/servingConfigs/default:search"
+)
 
 
 async def _run_passthrough_failure(
@@ -5871,6 +5880,15 @@ def _upstream_400(target: str) -> httpx.Response:
     )
 
 
+def _upstream_400_as_event_stream(target: str) -> httpx.Response:
+    return httpx.Response(
+        status_code=400,
+        headers={"content-type": "text/event-stream"},
+        content=b'data: {"error": {"code": 400, "status": "INVALID_ARGUMENT"}}\n\n',
+        request=httpx.Request("POST", target),
+    )
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "target, custom_llm_provider, stream, expected_provider",
@@ -5890,10 +5908,26 @@ async def test_passthrough_upstream_error_logs_model_from_url(
 
 
 @pytest.mark.asyncio
-async def test_passthrough_internal_failure_logs_model_from_url():
+@pytest.mark.parametrize(
+    "target, custom_llm_provider, expected_provider",
+    [
+        (_GEMINI_FLASH_TARGET, "gemini", "gemini"),
+        (_VERTEX_FLASH_TARGET, None, "vertex_ai"),
+    ],
+)
+async def test_passthrough_detected_stream_upstream_error_logs_model_from_url(
+    target: str, custom_llm_provider: str | None, expected_provider: str
+):
     failure = await _run_passthrough_failure(
-        _GEMINI_FLASH_TARGET, "gemini", httpx.ReadTimeout("upstream timed out")
+        target, custom_llm_provider, _upstream_400_as_event_stream(target), stream=False
     )
+    assert failure["request_data"]["model"] == "gemini-3.8-flash"
+    assert failure["request_data"]["custom_llm_provider"] == expected_provider
+
+
+@pytest.mark.asyncio
+async def test_passthrough_internal_failure_logs_model_from_url():
+    failure = await _run_passthrough_failure(_GEMINI_FLASH_TARGET, "gemini", httpx.ReadTimeout("upstream timed out"))
     assert failure["request_data"]["model"] == "gemini-3.8-flash"
     assert failure["request_data"]["custom_llm_provider"] == "gemini"
 
@@ -5908,6 +5942,7 @@ def _upstream_dropping_stream(target: str) -> httpx.Response:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("stream", [True, False])
 @pytest.mark.parametrize(
     "target, custom_llm_provider, expected_provider",
     [
@@ -5916,10 +5951,10 @@ def _upstream_dropping_stream(target: str) -> httpx.Response:
     ],
 )
 async def test_passthrough_mid_stream_drop_logs_model_from_url(
-    target: str, custom_llm_provider: str | None, expected_provider: str
+    target: str, custom_llm_provider: str | None, expected_provider: str, stream: bool
 ):
     failure = await _run_passthrough_failure(
-        target, custom_llm_provider, _upstream_dropping_stream(target), stream=True
+        target, custom_llm_provider, _upstream_dropping_stream(target), stream=stream
     )
     assert isinstance(failure["original_exception"], httpx.ReadError)
     assert failure["request_data"]["model"] == "gemini-3.8-flash"
@@ -5934,6 +5969,23 @@ async def test_passthrough_mid_stream_drop_logs_model_from_url(
         ({"contents": []}, _VERTEX_FLASH_TARGET, None, "gemini-3.8-flash", "vertex_ai"),
         ({"contents": []}, _VERTEX_FLASH_TARGET, "anthropic", "gemini-3.8-flash", "anthropic"),
         ({"custom_llm_provider": "from-body"}, _VERTEX_FLASH_TARGET, None, "gemini-3.8-flash", "from-body"),
+        ({"contents": []}, _GEMINI_FLASH_TARGET, None, "gemini-3.8-flash", "gemini"),
+        ({}, _VERTEX_CLAUDE_RAW_PREDICT_TARGET, None, "vertex_ai/claude-opus-5", "vertex_ai"),
+        (
+            {},
+            _VERTEX_CLAUDE_RAW_PREDICT_TARGET.replace(":rawPredict", ":streamRawPredict"),
+            None,
+            "vertex_ai/claude-opus-5",
+            "vertex_ai",
+        ),
+        ({}, _VERTEX_SEARCH_TARGET, None, "vertex_ai/search_api", "vertex_ai"),
+        (
+            {},
+            "https://us-east5-aiplatform.googleapis.com/v1/projects/p/locations/us-east5/batchPredictionJobs",
+            None,
+            "",
+            "vertex_ai",
+        ),
         ({"contents": []}, "https://api.example.com/v1/models/gpt-x:thing", None, "", None),
         (None, None, None, "", None),
     ],
@@ -5954,3 +6006,20 @@ def test_build_passthrough_failure_request_payload_model_and_provider_precedence
     )
     assert request_payload["model"] == expected_model
     assert request_payload.get("custom_llm_provider") == expected_provider
+
+
+@pytest.mark.parametrize(
+    "url_route, expected_model",
+    [
+        (_VERTEX_FLASH_TARGET, "gemini-3.8-flash"),
+        (_VERTEX_FLASH_TARGET.replace(":generateContent", ":streamGenerateContent?alt=sse"), "gemini-3.8-flash"),
+        (_VERTEX_FLASH_TARGET.replace(":generateContent", ":predict"), "gemini-3.8-flash"),
+        (_VERTEX_FLASH_TARGET.replace(":generateContent", ":embedContent"), "gemini-3.8-flash"),
+        (_VERTEX_CLAUDE_RAW_PREDICT_TARGET, "vertex_ai/claude-opus-5"),
+        (_VERTEX_CLAUDE_RAW_PREDICT_TARGET.replace(":rawPredict", ":streamRawPredict"), "vertex_ai/claude-opus-5"),
+        (_VERTEX_SEARCH_TARGET, "vertex_ai/search_api"),
+        ("https://us-east5-aiplatform.googleapis.com/v1/projects/p/locations/us-east5/batchPredictionJobs", None),
+    ],
+)
+def test_vertex_failure_model_name_matches_success_handler_naming(url_route: str, expected_model: str | None):
+    assert VertexPassthroughLoggingHandler.model_from_url_route(url_route) == expected_model


### PR DESCRIPTION
## TLDR

Problem this solves:

- Failed Gemini and Vertex pass-through calls log an empty model
- Spend rows, failure hooks, and the failure metric all miss it, including streams the network drops after the response started
- Vertex failure rows also miss the provider, while successes on the same routes carry both

How it solves it:

- Failure payload names the model the way the success handler does on Gemini and Vertex routes: from the URL, with the `vertex_ai/` prefix on `rawPredict` and `streamRawPredict` and `vertex_ai/search_api` on `:search`, and on any other Gemini or Vertex URL that carries `/models/<name>` (`countTokens`, for one) even though the success handler does not track that method
- Provider is the one the route declares (`gemini` on `/gemini/*`), else it comes from the URL's host or its `/projects/<p>/locations/<l>/` path, so `gemini` and `vertex_ai` match the success handler on `/gemini/*`, `/vertex_ai/*`, and config-defined routes, on every method and behind a custom `GEMINI_API_BASE` or Vertex base too
- The same payload now reaches the failure path for streams that break mid-body, for connections that die before any response, and for upstream errors served as an event stream
- Failure metric honors a declared provider only when it names a registered provider, so the `api_provider` label stays bounded to known values and falls back to inference otherwise
- The Vertex logging handler reuses the shared URL parser instead of its own copy of the regex
- Regression tests per route and failure kind, model naming per Vertex method, and provider precedence including declared values outside the provider set

## User Flow

Before: a developer whose app calls Gemini or Vertex through the proxy's pass-through routes sees every failed call logged under an empty model, so per-model failure dashboards and the spend table never line up with the successes

1. They send POST https://litellm-domain/gemini/v1beta/models/gemini-3.8-flash:streamGenerateContent?alt=sse with `x-goog-api-key: <their proxy key>` and a bad body `{"contents":"not a list"}`
2. Google rejects it, the proxy returns 400 `INVALID_ARGUMENT` with an `x-litellm-call-id` header
3. They send the same bad body to POST https://litellm-domain/gemini/v1beta/models/gemini-3.8-flash:generateContent, to POST https://litellm-domain/vertex_ai/v1/projects/{project}/locations/{location}/publishers/google/models/gemini-3.8-flash:generateContent, and to the same Vertex path with `:streamGenerateContent?alt=sse`, and all three come back 400 the same way
4. They stream a long answer from POST https://litellm-domain/gemini/v1beta/models/gemini-3.8-flash:streamGenerateContent?alt=sse and the connection between the proxy and Google drops after the first chunk: the client got a 200 and one chunk, then `transfer closed with outstanding read data remaining`
5. They send a valid body to POST https://litellm-domain/gemini/v1beta/models/gemini-3.8-flash:generateContent while the connection to Google dies before any response arrives, and the proxy returns 500 `Server disconnected`
6. They send a valid body to POST https://litellm-domain/gemini/v1beta/models/gemini-3.8-flash:generateContent and to POST https://litellm-domain/vertex_ai/v1/projects/{project}/locations/{location}/publishers/google/models/gemini-2.5-flash:generateContent (the model their Vertex location serves) and get a 200 with the answer from both
7. The same GET https://litellm-domain/spend/logs?request_id=<x-litellm-call-id> lookups now show `"model": "gemini-3.8-flash"` on all six failures, the way the two successful calls name theirs, with `"custom_llm_provider": "gemini"` on the four Gemini failures and `"vertex_ai"` on the two Vertex failures, so a per-model filter shows failures and successes side by side
8. GET https://litellm-domain/metrics/ shows `litellm_proxy_failed_requests_metric_total{..., api_provider="gemini", requested_model="gemini-3.8-flash", route="/gemini/v1beta/models/gemini-3.8-flash:streamGenerateContent", ...}` on all four Gemini failure counters (the two 400s, the dropped stream, and the closed connection) and `api_provider="vertex_ai"` with the same model on both Vertex routes
9. They send the same bad body to POST https://litellm-domain/gemini/v1beta/models/gemini-3.8-flash:countTokens, get the same 400, and its spend row now reads `"model": "gemini-3.8-flash"` with `"custom_llm_provider": "gemini"` where it used to read `"model": ""`; the Vertex `:countTokens` route names its model and `vertex_ai` the same way
10. A POST https://litellm-domain/vertex_ai/v1/projects/{project}/locations/{location}/publishers/anthropic/models/claude-does-not-exist:rawPredict that Google answers with 404 shows up as `"model": "vertex_ai/claude-does-not-exist"` with `"custom_llm_provider": "vertex_ai"`, the same naming successful `rawPredict` calls get, and a POST https://litellm-domain/v1/chat/completions carrying `"custom_llm_provider": "client-supplied-value"` in the body still labels the failure metric `api_provider="None"`, as it did before this PR, since a body value that names no registered provider never becomes a label

## Relevant issues

## Linear ticket

Resolves LIT-6922

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup: two QA legs, each booting its own proxy from its own worktree with `--num_workers 2`, its own Postgres database on one local cluster, its own `PROMETHEUS_MULTIPROC_DIR`, and this config (one deployment so the Prometheus label keeps the model name readable, `default_vertex_config` pointing at the QA project, Prometheus enabled)

```yaml
model_list:
  - model_name: gemini-3.8-flash
    litellm_params:
      model: gemini/gemini-3.8-flash
      api_key: os.environ/GEMINI_API_KEY
default_vertex_config:
  vertex_project: os.environ/VERTEXAI_PROJECT
  vertex_location: os.environ/VERTEXAI_LOCATION
  vertex_credentials: os.environ/GOOGLE_APPLICATION_CREDENTIALS
litellm_settings:
  callbacks: ["prometheus"]
general_settings:
  master_key: sk-lit6922-master
```

Both proxies boot with `GEMINI_API_BASE=http://127.0.0.1:<relay port>`, a small local HTTP relay that forwards every Gemini request to https://generativelanguage.googleapis.com unchanged, so Google still authenticates, answers, and bills each call. The relay is only there to inject two network faults on request: a prompt containing `DROP_AFTER_FIRST_CHUNK` makes it close the socket right after forwarding Google's first response chunk, and one containing `CLOSE_BEFORE_RESPONSE` makes it close before forwarding anything. Vertex calls go straight to Google

Shared payloads: `BAD='{"contents":"not a list"}'` (Google rejects it with a real 400), `GOOD='{"contents":[{"role":"user","parts":[{"text":"Reply with the single word: pong"}]}]}'`, `DROP='{"contents":[{"role":"user","parts":[{"text":"Count from 1 to 60, one number per line. DROP_AFTER_FIRST_CHUNK"}]}]}'`, and `CLOSE='{"contents":[{"role":"user","parts":[{"text":"Reply with the single word: pong. CLOSE_BEFORE_RESPONSE"}]}]}'`. Each case prints the HTTP status, curl's exit code, the `x-litellm-call-id` header, and the start of the body. The spend rows come from `/spend/logs?request_id=<x-litellm-call-id>` for each call id once the batch writer flushed (about 30 seconds), then straight from the leg's database, and the metrics from `/metrics/` with the key, team, and user labels stripped for readability. `$BASE` is the leg's proxy, `$KEY` is `sk-lit6922-master`, `$PROJECT` and `$LOCATION` are the QA project's values. Spend columns are `status | model | custom_llm_provider | call_type | request_id`

### Before (aea5358c48)

#### Gemini stream 400

1. `curl -sS -o body -D headers -w "http %{http_code}\n" -X POST "$BASE/gemini/v1beta/models/gemini-3.8-flash:streamGenerateContent?alt=sse" -H "x-goog-api-key: $KEY" -H "content-type: application/json" -d "$BAD"`
2. `http 400, curl exit 0, body bytes 536`, `x-litellm-call-id: 2156717d-06af-43d6-9b7e-c50f5a93bb32`, body `{ "error": { "code": 400, "message": "Invalid value at 'contents' (type.googleapis.com/google.ai.generativelanguage.v1beta.Content), \"not a list\"", "status": "INVALID_ARGUMENT", ...`

#### Gemini non-stream 400

1. `curl -sS -o body -D headers -w "http %{http_code}\n" -X POST "$BASE/gemini/v1beta/models/gemini-3.8-flash:generateContent" -H "x-goog-api-key: $KEY" -H "content-type: application/json" -d "$BAD"`
2. `http 400, curl exit 0, body bytes 536`, `x-litellm-call-id: 0f3a0581-8a4b-43ee-9267-5ef656e9d7ec`, body `{ "error": { "code": 400, "message": "Invalid value at 'contents' (type.googleapis.com/google.ai.generativelanguage.v1beta.Content), \"not a list\"", "status": "INVALID_ARGUMENT", ...`

#### Vertex non-stream 400

1. `curl -sS -o body -D headers -w "http %{http_code}\n" -X POST "$BASE/vertex_ai/v1/projects/$PROJECT/locations/$LOCATION/publishers/google/models/gemini-3.8-flash:generateContent" -H "Authorization: Bearer $KEY" -H "content-type: application/json" -d "$BAD"`
2. `http 400, curl exit 0, body bytes 518`, `x-litellm-call-id: ac23944e-7794-4412-a01f-28bd14477c03`, body `{ "error": { "code": 400, "message": "Invalid value at 'contents' (type.googleapis.com/google.cloud.aiplatform.v1.Content), \"not a list\"", "status": "INVALID_ARGUMENT", "details"...`

#### Vertex stream 400

1. `curl -sS -o body -D headers -w "http %{http_code}\n" -X POST "$BASE/vertex_ai/v1/projects/$PROJECT/locations/$LOCATION/publishers/google/models/gemini-3.8-flash:streamGenerateContent?alt=sse" -H "Authorization: Bearer $KEY" -H "content-type: application/json" -d "$BAD"`
2. `http 400, curl exit 0, body bytes 518`, `x-litellm-call-id: 9d55e276-922b-4fef-82f3-3a5ffdd9b89c`, body `{ "error": { "code": 400, "message": "Invalid value at 'contents' (type.googleapis.com/google.cloud.aiplatform.v1.Content), \"not a list\"", "status": "INVALID_ARGUMENT", "details"...`

#### Gemini 200 stream dropped by the network after the first chunk

1. `curl -sS -o body -D headers -w "http %{http_code}\n" -X POST "$BASE/gemini/v1beta/models/gemini-3.8-flash:streamGenerateContent?alt=sse" -H "x-goog-api-key: $KEY" -H "content-type: application/json" -d "$DROP"`
2. `http 200, curl exit 18, body bytes 404`, client saw `curl: (18) transfer closed with outstanding read data remaining`, `x-litellm-call-id: 2536f4ae-b185-4bf6-a5b1-dc6794640cee`, body `data: {"candidates": [{"content": {"parts": [{"text": "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n1"}],"role": "model"},"index": 0}],"usageMetadata": {"promptTokenCount": 22,"candidatesTokenCo...`

#### Gemini connection closed before any response (LiteLLM-internal failure path)

1. `curl -sS -o body -D headers -w "http %{http_code}\n" -X POST "$BASE/gemini/v1beta/models/gemini-3.8-flash:generateContent" -H "x-goog-api-key: $KEY" -H "content-type: application/json" -d "$CLOSE"`
2. `http 500, curl exit 0, body bytes 85`, `x-litellm-call-id: 197c5d59-b176-4fd3-a69d-116ef4e4c274`, body `{"error":{"message":"Server disconnected","type":"None","param":"None","code":"500"}}...`

#### Gemini 200 control

1. `curl -sS -o body -D headers -w "http %{http_code}\n" -X POST "$BASE/gemini/v1beta/models/gemini-3.8-flash:generateContent" -H "x-goog-api-key: $KEY" -H "content-type: application/json" -d "$GOOD"`
2. `http 200, curl exit 0, body bytes 1225`, `x-litellm-call-id: f3b12f33-d2fd-4922-964b-ffd978a1b534`, body `{ "candidates": [ { "content": { "parts": [ { "text": "pong", "thoughtSignature": "Et8DCtwDARFNMg+/CsNEtkX/nF8Xoa72jGAtOishKevJd9kWGwoPATYaYu3CQhesB1+wl04jOl+J5Sc9px8r8LiOjxlT+mOnb...`

#### Vertex 200 control

1. `curl -sS -o body -D headers -w "http %{http_code}\n" -X POST "$BASE/vertex_ai/v1/projects/$PROJECT/locations/$LOCATION/publishers/google/models/gemini-2.5-flash:generateContent" -H "Authorization: Bearer $KEY" -H "content-type: application/json" -d "$GOOD"`
2. `http 200, curl exit 0, body bytes 754`, `x-litellm-call-id: 7ff1cae6-aa9a-4136-a624-1861b480662f`, body `{ "candidates": [ { "content": { "role": "model", "parts": [ { "text": "pong" } ] }, "finishReason": "STOP", "avgLogprobs": -4.2958879470825195 } ], "usageMetadata": { "promptToken...`

#### Spend rows by x-litellm-call-id

1. `sleep 30; for id in <the call ids above>; do curl -sS "$BASE/spend/logs?request_id=$id" -H "Authorization: Bearer $KEY" | jq -r '.[] | [.status, .model, .custom_llm_provider, .call_type, .request_id] | join(" | ")'; done`
2. Output, one row per leg in the order above (leg name added on the left):

```
gemini_stream: failure |  | gemini | pass_through_endpoint | 2156717d-06af-43d6-9b7e-c50f5a93bb32
gemini_nonstream: failure |  | gemini | pass_through_endpoint | 0f3a0581-8a4b-43ee-9267-5ef656e9d7ec
vertex: failure |  |  | pass_through_endpoint | ac23944e-7794-4412-a01f-28bd14477c03
vertex_stream: failure |  |  | pass_through_endpoint | 9d55e276-922b-4fef-82f3-3a5ffdd9b89c
gemini_drop: failure |  | gemini | pass_through_endpoint | 2536f4ae-b185-4bf6-a5b1-dc6794640cee
gemini_close: failure |  | gemini | pass_through_endpoint | 197c5d59-b176-4fd3-a69d-116ef4e4c274
gemini_ok: success | gemini-3.8-flash | gemini | pass_through_endpoint | f3b12f33-d2fd-4922-964b-ffd978a1b534
vertex_ok: success | gemini-2.5-flash | vertex_ai | pass_through_endpoint | 7ff1cae6-aa9a-4136-a624-1861b480662f
```

#### Every spend row the run wrote (psql on the leg's database, same columns)

1. `psql "$DATABASE_URL" -At -F " | " -c "select status, model, custom_llm_provider, call_type, request_id from \"LiteLLM_SpendLogs\" where \"startTime\" >= '$RUN_START' order by \"startTime\""`

```
failure |  | gemini | pass_through_endpoint | 2156717d-06af-43d6-9b7e-c50f5a93bb32
failure |  | gemini | pass_through_endpoint | 0f3a0581-8a4b-43ee-9267-5ef656e9d7ec
failure |  |  | pass_through_endpoint | ac23944e-7794-4412-a01f-28bd14477c03
failure |  |  | pass_through_endpoint | 9d55e276-922b-4fef-82f3-3a5ffdd9b89c
failure |  | gemini | pass_through_endpoint | 2536f4ae-b185-4bf6-a5b1-dc6794640cee
failure |  | gemini | pass_through_endpoint | 197c5d59-b176-4fd3-a69d-116ef4e4c274
success | gemini-3.8-flash | gemini | pass_through_endpoint | f3b12f33-d2fd-4922-964b-ffd978a1b534
success | gemini-2.5-flash | vertex_ai | pass_through_endpoint | 7ff1cae6-aa9a-4136-a624-1861b480662f
```

#### Prometheus

1. `curl -sSL "$BASE/metrics/" -H "Authorization: Bearer $KEY" | grep -E '^litellm_proxy_(failed|total)_requests_metric_total' | sed -E 's/,?(hashed_api_key|api_key_alias|user_email|end_user|org_id|org_alias|team_alias|user|team)="[^"]*"//g; s/\{,/{/'`
2. Output:

```
litellm_proxy_failed_requests_metric_total{api_provider="None",client_ip="None",exception_class="HTTPException",exception_status="400",model_id="None",requested_model="",route="/gemini/v1beta/models/gemini-3.8-flash:generateContent",user_agent="None"} 1.0
litellm_proxy_failed_requests_metric_total{api_provider="None",client_ip="None",exception_class="HTTPException",exception_status="400",model_id="None",requested_model="",route="/vertex_ai/v1/projects/$PROJECT/locations/$LOCATION/publishers/google/models/gemini-3.8-flash:generateContent",user_agent="None"} 1.0
litellm_proxy_failed_requests_metric_total{api_provider="None",client_ip="None",exception_class="HTTPException",exception_status="400",model_id="None",requested_model="",route="/vertex_ai/v1/projects/$PROJECT/locations/$LOCATION/publishers/google/models/gemini-3.8-flash:streamGenerateContent",user_agent="None"} 1.0
litellm_proxy_failed_requests_metric_total{api_provider="None",client_ip="None",exception_class="ReadError",exception_status="None",model_id="None",requested_model="",route="/gemini/v1beta/models/gemini-3.8-flash:generateContent",user_agent="None"} 1.0
litellm_proxy_failed_requests_metric_total{api_provider="None",client_ip="None",exception_class="HTTPException",exception_status="400",model_id="None",requested_model="",route="/gemini/v1beta/models/gemini-3.8-flash:streamGenerateContent",user_agent="None"} 1.0
litellm_proxy_failed_requests_metric_total{api_provider="None",client_ip="None",exception_class="ReadError",exception_status="None",model_id="None",requested_model="",route="/gemini/v1beta/models/gemini-3.8-flash:streamGenerateContent",user_agent="None"} 1.0
litellm_proxy_total_requests_metric_total{api_provider="None",client_ip="None",model_id="None",requested_model="",route="/gemini/v1beta/models/gemini-3.8-flash:generateContent",status_code="400",user_agent="None"} 1.0
litellm_proxy_total_requests_metric_total{api_provider="None",client_ip="None",model_id="None",requested_model="",route="/vertex_ai/v1/projects/$PROJECT/locations/$LOCATION/publishers/google/models/gemini-3.8-flash:generateContent",status_code="400",user_agent="None"} 1.0
litellm_proxy_total_requests_metric_total{api_provider="None",client_ip="None",model_id="None",requested_model="",route="/vertex_ai/v1/projects/$PROJECT/locations/$LOCATION/publishers/google/models/gemini-3.8-flash:streamGenerateContent",status_code="400",user_agent="None"} 1.0
litellm_proxy_total_requests_metric_total{api_provider="None",client_ip="None",model_id="None",requested_model="",route="/gemini/v1beta/models/gemini-3.8-flash:generateContent",status_code="None",user_agent="None"} 1.0
litellm_proxy_total_requests_metric_total{api_provider="vertex_ai",client_ip="None",model_id="",requested_model="",route="/vertex_ai/v1/projects/$PROJECT/locations/$LOCATION/publishers/google/models/gemini-2.5-flash:generateContent",status_code="200",user_agent="None"} 1.0
litellm_proxy_total_requests_metric_total{api_provider="None",client_ip="None",model_id="None",requested_model="",route="/gemini/v1beta/models/gemini-3.8-flash:streamGenerateContent",status_code="400",user_agent="None"} 1.0
litellm_proxy_total_requests_metric_total{api_provider="None",client_ip="None",model_id="None",requested_model="",route="/gemini/v1beta/models/gemini-3.8-flash:streamGenerateContent",status_code="None",user_agent="None"} 1.0
litellm_proxy_total_requests_metric_total{api_provider="gemini",client_ip="None",model_id="",requested_model="",route="/gemini/v1beta/models/gemini-3.8-flash:generateContent",status_code="200",user_agent="None"} 1.0
```


### After (f80801985a)

#### Gemini stream 400

1. `curl -sS -o body -D headers -w "http %{http_code}\n" -X POST "$BASE/gemini/v1beta/models/gemini-3.8-flash:streamGenerateContent?alt=sse" -H "x-goog-api-key: $KEY" -H "content-type: application/json" -d "$BAD"`
2. `http 400, curl exit 0, body bytes 536`, `x-litellm-call-id: a5b1e078-faee-45d0-aff3-23b4cc4293af`, body `{ "error": { "code": 400, "message": "Invalid value at 'contents' (type.googleapis.com/google.ai.generativelanguage.v1beta.Content), \"not a list\"", "status": "INVALID_ARGUMENT", ...`

#### Gemini non-stream 400

1. `curl -sS -o body -D headers -w "http %{http_code}\n" -X POST "$BASE/gemini/v1beta/models/gemini-3.8-flash:generateContent" -H "x-goog-api-key: $KEY" -H "content-type: application/json" -d "$BAD"`
2. `http 400, curl exit 0, body bytes 536`, `x-litellm-call-id: 9c088e82-05d6-4fd2-b0b2-35c91a14c31d`, body `{ "error": { "code": 400, "message": "Invalid value at 'contents' (type.googleapis.com/google.ai.generativelanguage.v1beta.Content), \"not a list\"", "status": "INVALID_ARGUMENT", ...`

#### Vertex non-stream 400

1. `curl -sS -o body -D headers -w "http %{http_code}\n" -X POST "$BASE/vertex_ai/v1/projects/$PROJECT/locations/$LOCATION/publishers/google/models/gemini-3.8-flash:generateContent" -H "Authorization: Bearer $KEY" -H "content-type: application/json" -d "$BAD"`
2. `http 400, curl exit 0, body bytes 518`, `x-litellm-call-id: 2b995681-20ee-4b30-abae-42953cc680dc`, body `{ "error": { "code": 400, "message": "Invalid value at 'contents' (type.googleapis.com/google.cloud.aiplatform.v1.Content), \"not a list\"", "status": "INVALID_ARGUMENT", "details"...`

#### Vertex stream 400

1. `curl -sS -o body -D headers -w "http %{http_code}\n" -X POST "$BASE/vertex_ai/v1/projects/$PROJECT/locations/$LOCATION/publishers/google/models/gemini-3.8-flash:streamGenerateContent?alt=sse" -H "Authorization: Bearer $KEY" -H "content-type: application/json" -d "$BAD"`
2. `http 400, curl exit 0, body bytes 518`, `x-litellm-call-id: 05c6515f-8fe8-4ffc-b8a8-bca59ce2c82d`, body `{ "error": { "code": 400, "message": "Invalid value at 'contents' (type.googleapis.com/google.cloud.aiplatform.v1.Content), \"not a list\"", "status": "INVALID_ARGUMENT", "details"...`

#### Gemini 200 stream dropped by the network after the first chunk

1. `curl -sS -o body -D headers -w "http %{http_code}\n" -X POST "$BASE/gemini/v1beta/models/gemini-3.8-flash:streamGenerateContent?alt=sse" -H "x-goog-api-key: $KEY" -H "content-type: application/json" -d "$DROP"`
2. `http 200, curl exit 18, body bytes 412`, client saw `curl: (18) transfer closed with outstanding read data remaining`, `x-litellm-call-id: 29c6ad87-8077-49ff-87a5-09d965668ad0`, body `data: {"candidates": [{"content": {"parts": [{"text": "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12"}],"role": "model"},"index": 0}],"usageMetadata": {"promptTokenCount": 22,"candidatesTo...`

#### Gemini connection closed before any response (LiteLLM-internal failure path)

1. `curl -sS -o body -D headers -w "http %{http_code}\n" -X POST "$BASE/gemini/v1beta/models/gemini-3.8-flash:generateContent" -H "x-goog-api-key: $KEY" -H "content-type: application/json" -d "$CLOSE"`
2. `http 500, curl exit 0, body bytes 85`, `x-litellm-call-id: 7aac6f5c-005d-4db0-bd44-bb72706cd012`, body `{"error":{"message":"Server disconnected","type":"None","param":"None","code":"500"}}...`

#### Gemini 200 control

1. `curl -sS -o body -D headers -w "http %{http_code}\n" -X POST "$BASE/gemini/v1beta/models/gemini-3.8-flash:generateContent" -H "x-goog-api-key: $KEY" -H "content-type: application/json" -d "$GOOD"`
2. `http 200, curl exit 0, body bytes 1038`, `x-litellm-call-id: d39d5eb1-c18f-47fb-b885-8f65f7270708`, body `{ "candidates": [ { "content": { "parts": [ { "text": "pong", "thoughtSignature": "Er0CCroCARFNMg+0wq2u1HQGtlAg8XG/dluBEtzgFcUffUQao25IkG/Na6oT45n7V9hyr4ECIUXgHnlKec8HzlLKLWjo/RWxZ...`

#### Vertex 200 control

1. `curl -sS -o body -D headers -w "http %{http_code}\n" -X POST "$BASE/vertex_ai/v1/projects/$PROJECT/locations/$LOCATION/publishers/google/models/gemini-2.5-flash:generateContent" -H "Authorization: Bearer $KEY" -H "content-type: application/json" -d "$GOOD"`
2. `http 200, curl exit 0, body bytes 754`, `x-litellm-call-id: a8420901-eddf-4427-868d-857c675f3105`, body `{ "candidates": [ { "content": { "role": "model", "parts": [ { "text": "pong" } ] }, "finishReason": "STOP", "avgLogprobs": -4.1555628776550293 } ], "usageMetadata": { "promptToken...`

#### Spend rows by x-litellm-call-id

1. `sleep 30; for id in <the call ids above>; do curl -sS "$BASE/spend/logs?request_id=$id" -H "Authorization: Bearer $KEY" | jq -r '.[] | [.status, .model, .custom_llm_provider, .call_type, .request_id] | join(" | ")'; done`
2. Output, one row per leg in the order above (leg name added on the left):

```
gemini_stream: failure | gemini-3.8-flash | gemini | pass_through_endpoint | a5b1e078-faee-45d0-aff3-23b4cc4293af
gemini_nonstream: failure | gemini-3.8-flash | gemini | pass_through_endpoint | 9c088e82-05d6-4fd2-b0b2-35c91a14c31d
vertex: failure | gemini-3.8-flash | vertex_ai | pass_through_endpoint | 2b995681-20ee-4b30-abae-42953cc680dc
vertex_stream: failure | gemini-3.8-flash | vertex_ai | pass_through_endpoint | 05c6515f-8fe8-4ffc-b8a8-bca59ce2c82d
gemini_drop: failure | gemini-3.8-flash | gemini | pass_through_endpoint | 29c6ad87-8077-49ff-87a5-09d965668ad0
gemini_close: failure | gemini-3.8-flash | gemini | pass_through_endpoint | 7aac6f5c-005d-4db0-bd44-bb72706cd012
gemini_ok: success | gemini-3.8-flash | gemini | pass_through_endpoint | d39d5eb1-c18f-47fb-b885-8f65f7270708
vertex_ok: success | gemini-2.5-flash | vertex_ai | pass_through_endpoint | a8420901-eddf-4427-868d-857c675f3105
```

#### Every spend row the run wrote (psql on the leg's database, same columns)

1. `psql "$DATABASE_URL" -At -F " | " -c "select status, model, custom_llm_provider, call_type, request_id from \"LiteLLM_SpendLogs\" where \"startTime\" >= '$RUN_START' order by \"startTime\""`

```
failure | gemini-3.8-flash | gemini | pass_through_endpoint | a5b1e078-faee-45d0-aff3-23b4cc4293af
failure | gemini-3.8-flash | gemini | pass_through_endpoint | 9c088e82-05d6-4fd2-b0b2-35c91a14c31d
failure | gemini-3.8-flash | vertex_ai | pass_through_endpoint | 2b995681-20ee-4b30-abae-42953cc680dc
failure | gemini-3.8-flash | vertex_ai | pass_through_endpoint | 05c6515f-8fe8-4ffc-b8a8-bca59ce2c82d
failure | gemini-3.8-flash | gemini | pass_through_endpoint | 29c6ad87-8077-49ff-87a5-09d965668ad0
failure | gemini-3.8-flash | gemini | pass_through_endpoint | 7aac6f5c-005d-4db0-bd44-bb72706cd012
success | gemini-3.8-flash | gemini | pass_through_endpoint | d39d5eb1-c18f-47fb-b885-8f65f7270708
success | gemini-2.5-flash | vertex_ai | pass_through_endpoint | a8420901-eddf-4427-868d-857c675f3105
```

#### Prometheus

1. `curl -sSL "$BASE/metrics/" -H "Authorization: Bearer $KEY" | grep -E '^litellm_proxy_(failed|total)_requests_metric_total' | sed -E 's/,?(hashed_api_key|api_key_alias|user_email|end_user|org_id|org_alias|team_alias|user|team)="[^"]*"//g; s/\{,/{/'`
2. Output:

```
litellm_proxy_failed_requests_metric_total{api_provider="gemini",client_ip="None",exception_class="HTTPException",exception_status="400",model_id="None",requested_model="gemini-3.8-flash",route="/gemini/v1beta/models/gemini-3.8-flash:streamGenerateContent",user_agent="None"} 1.0
litellm_proxy_failed_requests_metric_total{api_provider="gemini",client_ip="None",exception_class="HTTPException",exception_status="400",model_id="None",requested_model="gemini-3.8-flash",route="/gemini/v1beta/models/gemini-3.8-flash:generateContent",user_agent="None"} 1.0
litellm_proxy_failed_requests_metric_total{api_provider="vertex_ai",client_ip="None",exception_class="HTTPException",exception_status="400",model_id="None",requested_model="gemini-3.8-flash",route="/vertex_ai/v1/projects/$PROJECT/locations/$LOCATION/publishers/google/models/gemini-3.8-flash:generateContent",user_agent="None"} 1.0
litellm_proxy_failed_requests_metric_total{api_provider="vertex_ai",client_ip="None",exception_class="HTTPException",exception_status="400",model_id="None",requested_model="gemini-3.8-flash",route="/vertex_ai/v1/projects/$PROJECT/locations/$LOCATION/publishers/google/models/gemini-3.8-flash:streamGenerateContent",user_agent="None"} 1.0
litellm_proxy_failed_requests_metric_total{api_provider="gemini",client_ip="None",exception_class="ReadError",exception_status="None",model_id="None",requested_model="gemini-3.8-flash",route="/gemini/v1beta/models/gemini-3.8-flash:streamGenerateContent",user_agent="None"} 1.0
litellm_proxy_failed_requests_metric_total{api_provider="gemini",client_ip="None",exception_class="ReadError",exception_status="None",model_id="None",requested_model="gemini-3.8-flash",route="/gemini/v1beta/models/gemini-3.8-flash:generateContent",user_agent="None"} 1.0
litellm_proxy_total_requests_metric_total{api_provider="gemini",client_ip="None",model_id="None",requested_model="gemini-3.8-flash",route="/gemini/v1beta/models/gemini-3.8-flash:streamGenerateContent",status_code="400",user_agent="None"} 1.0
litellm_proxy_total_requests_metric_total{api_provider="gemini",client_ip="None",model_id="None",requested_model="gemini-3.8-flash",route="/gemini/v1beta/models/gemini-3.8-flash:generateContent",status_code="400",user_agent="None"} 1.0
litellm_proxy_total_requests_metric_total{api_provider="vertex_ai",client_ip="None",model_id="None",requested_model="gemini-3.8-flash",route="/vertex_ai/v1/projects/$PROJECT/locations/$LOCATION/publishers/google/models/gemini-3.8-flash:generateContent",status_code="400",user_agent="None"} 1.0
litellm_proxy_total_requests_metric_total{api_provider="vertex_ai",client_ip="None",model_id="None",requested_model="gemini-3.8-flash",route="/vertex_ai/v1/projects/$PROJECT/locations/$LOCATION/publishers/google/models/gemini-3.8-flash:streamGenerateContent",status_code="400",user_agent="None"} 1.0
litellm_proxy_total_requests_metric_total{api_provider="gemini",client_ip="None",model_id="None",requested_model="gemini-3.8-flash",route="/gemini/v1beta/models/gemini-3.8-flash:streamGenerateContent",status_code="None",user_agent="None"} 1.0
litellm_proxy_total_requests_metric_total{api_provider="gemini",client_ip="None",model_id="None",requested_model="gemini-3.8-flash",route="/gemini/v1beta/models/gemini-3.8-flash:generateContent",status_code="None",user_agent="None"} 1.0
litellm_proxy_total_requests_metric_total{api_provider="gemini",client_ip="None",model_id="",requested_model="",route="/gemini/v1beta/models/gemini-3.8-flash:generateContent",status_code="200",user_agent="None"} 1.0
litellm_proxy_total_requests_metric_total{api_provider="vertex_ai",client_ip="None",model_id="",requested_model="",route="/vertex_ai/v1/projects/$PROJECT/locations/$LOCATION/publishers/google/models/gemini-2.5-flash:generateContent",status_code="200",user_agent="None"} 1.0
```


#### Other routes on the same two rigs: rawPredict naming, countTokens, and a client-declared provider

Same six calls on both legs, in this order. Spend columns are `status | model | custom_llm_provider | call_type | api_base | request_id`, Prometheus is the failed-request counter only (the total-request counter carries the same labels). The fourth call fails upstream with a 404 (the rig's relay `GEMINI_API_BASE` serves `/chat/completions` no `/v1beta` prefix), which puts the rig's single `gemini-3.8-flash` deployment on that worker's cooldown list, so the sixth call, the `/chat/completions` control, came back 429 on the before leg and 404 on this after leg: the two calls were 3.9 s apart, inside the 5 s default cooldown, but on this leg both worker pids wrote metrics (two counter files in the multiprocess dir) and cooldown state is per-worker memory without Redis, so the control landed on the worker that had not seen the fourth call's failure; both rows are shown as they were logged

1. `curl -sS -o body -D headers -w "http %{http_code}\n" -X POST "$BASE/anthropic/v1/messages" -H "x-api-key: $KEY" -H "content-type: application/json" -d '{"model":"claude-does-not-exist","max_tokens":16,"messages":[{"role":"user","content":"hi"}]}'` -> `http 400, curl exit 0, body bytes 151`
2. `curl -sS -o body -D headers -w "http %{http_code}\n" -X POST "$BASE/vertex_ai/v1/projects/$PROJECT/locations/$LOCATION/publishers/anthropic/models/claude-does-not-exist:rawPredict" -H "Authorization: Bearer $KEY" -H "content-type: application/json" -d '{"anthropic_version":"vertex-2023-10-16","max_tokens":16,"messages":[{"role":"user","content":"hi"}]}'` -> `http 404, curl exit 0, body bytes 464`
3. `curl -sS -o body -D headers -w "http %{http_code}\n" -X POST "$BASE/gemini/v1beta/models/gemini-3.8-flash:countTokens" -H "x-goog-api-key: $KEY" -H "content-type: application/json" -d '{"contents":"not a list"}'` -> `http 400, curl exit 0, body bytes 536`
4. `curl -sS -o body -D headers -w "http %{http_code}\n" -X POST "$BASE/v1/chat/completions" -H "Authorization: Bearer $KEY" -H "content-type: application/json" -d '{"model":"gemini-3.8-flash","messages":[{"role":"user","content":"hi"}],"temperature":99}'` -> `http 404, curl exit 0, body bytes 199`
5. `curl -sS -o body -D headers -w "http %{http_code}\n" -X POST "$BASE/v1/chat/completions" -H "Authorization: Bearer $KEY" -H "content-type: application/json" -d '{"model":"model-that-does-not-exist","messages":[{"role":"user","content":"hi"}],"custom_llm_provider":"client-supplied-value"}'` -> `http 400, curl exit 0, body bytes 395`
6. `curl -sS -o body -D headers -w "http %{http_code}\n" -X POST "$BASE/v1/chat/completions" -H "Authorization: Bearer $KEY" -H "content-type: application/json" -d '{"model":"gemini-3.8-flash","messages":[{"role":"user","content":"Reply with the single word: pong"}],"max_tokens":20}'` -> `http 404, curl exit 0, body bytes 199`

Before (aea5358c48) spend rows:

```
anthropic_404: failure | claude-does-not-exist |  | pass_through_endpoint |  | 81289939-02b6-4e3a-bfc4-f63cd696092c
vertex_anthropic_404: failure |  |  | pass_through_endpoint |  | 85862cb9-4c9b-4525-8e75-4dfe151ba8da
gemini_counttokens_400: failure |  | gemini | pass_through_endpoint |  | b79dba89-1fe2-4557-92a2-f917568b9426
chat_400: failure | gemini/gemini-3.8-flash | gemini |  | http://127.0.0.1:30732/models/gemini-3.8-flash:generateContent | 8ba5d787-9ea9-4785-80c2-d4d604ebb5ab
chat_unknown_model: failure | model-that-does-not-exist | client-supplied-value |  |  | 0c3bb243-c04b-49a7-918b-3000ea25ce21
chat_ok: failure | gemini-3.8-flash |  |  |  | 29d34770-3f54-4498-b19c-c367db9ff20c
```

After (f80801985a) spend rows:

```
anthropic_404: failure | claude-does-not-exist |  | pass_through_endpoint |  | 3e9d8c3b-bf91-4258-98a5-8b052c494743
vertex_anthropic_404: failure | vertex_ai/claude-does-not-exist | vertex_ai | pass_through_endpoint |  | c5864935-c842-4816-b5d5-739d74abdee1
gemini_counttokens_400: failure | gemini-3.8-flash | gemini | pass_through_endpoint |  | ba6dbfed-6a26-473f-9b1b-1fece287d029
chat_400: failure | gemini/gemini-3.8-flash | gemini |  | http://127.0.0.1:30732/models/gemini-3.8-flash:generateContent | c3a6781d-80dd-47cb-b435-54fb7ae2b226
chat_unknown_model: failure | model-that-does-not-exist | client-supplied-value |  |  | c247902d-f7cf-48db-9904-6aa0066f461a
chat_ok: failure | gemini/gemini-3.8-flash | gemini |  | http://127.0.0.1:30732/models/gemini-3.8-flash:generateContent | ea0b010e-d0d4-489a-8ddf-fd156005ecd8
```

Before (aea5358c48) counters:

```
litellm_proxy_failed_requests_metric_total{api_provider="gemini",client_ip="127.0.0.1",exception_class="Gemini.NotFoundError",exception_status="404",model_id="626391a28c6be8e777002b149cdfb9bf3f26bc2e39c1afae47eb4e5ef005ee55",requested_model="gemini-3.8-flash",route="/v1/chat/completions",user_agent="curl/8.7.1"} 1.0
litellm_proxy_failed_requests_metric_total{api_provider="None",client_ip="127.0.0.1",exception_class="ProxyModelNotFoundError",exception_status="400",model_id="None",requested_model="other",route="/v1/chat/completions",user_agent="curl/8.7.1"} 1.0
litellm_proxy_failed_requests_metric_total{api_provider="vertex_ai",client_ip="127.0.0.1",exception_class="RouterRateLimitError",exception_status="None",model_id="None",requested_model="gemini-3.8-flash",route="/v1/chat/completions",user_agent="curl/8.7.1"} 1.0
litellm_proxy_failed_requests_metric_total{api_provider="None",client_ip="None",exception_class="HTTPException",exception_status="400",model_id="None",requested_model="other",route="/anthropic/v1/messages",user_agent="None"} 1.0
litellm_proxy_failed_requests_metric_total{api_provider="None",client_ip="None",exception_class="HTTPException",exception_status="404",model_id="None",requested_model="",route="/vertex_ai/v1/projects/$PROJECT/locations/$LOCATION/publishers/anthropic/models/claude-does-not-exist:rawPredict",user_agent="None"} 1.0
litellm_proxy_failed_requests_metric_total{api_provider="None",client_ip="None",exception_class="HTTPException",exception_status="400",model_id="None",requested_model="",route="/gemini/v1beta/models/gemini-3.8-flash:countTokens",user_agent="None"} 1.0
```

After (f80801985a) counters:

```
litellm_proxy_failed_requests_metric_total{api_provider="gemini",client_ip="127.0.0.1",exception_class="Gemini.NotFoundError",exception_status="404",model_id="626391a28c6be8e777002b149cdfb9bf3f26bc2e39c1afae47eb4e5ef005ee55",requested_model="gemini-3.8-flash",route="/v1/chat/completions",user_agent="curl/8.7.1"} 2.0
litellm_proxy_failed_requests_metric_total{api_provider="gemini",client_ip="None",exception_class="HTTPException",exception_status="400",model_id="None",requested_model="gemini-3.8-flash",route="/gemini/v1beta/models/gemini-3.8-flash:streamGenerateContent",user_agent="None"} 1.0
litellm_proxy_failed_requests_metric_total{api_provider="gemini",client_ip="None",exception_class="HTTPException",exception_status="400",model_id="None",requested_model="gemini-3.8-flash",route="/gemini/v1beta/models/gemini-3.8-flash:generateContent",user_agent="None"} 1.0
litellm_proxy_failed_requests_metric_total{api_provider="vertex_ai",client_ip="None",exception_class="HTTPException",exception_status="400",model_id="None",requested_model="gemini-3.8-flash",route="/vertex_ai/v1/projects/$PROJECT/locations/$LOCATION/publishers/google/models/gemini-3.8-flash:generateContent",user_agent="None"} 1.0
litellm_proxy_failed_requests_metric_total{api_provider="vertex_ai",client_ip="None",exception_class="HTTPException",exception_status="400",model_id="None",requested_model="gemini-3.8-flash",route="/vertex_ai/v1/projects/$PROJECT/locations/$LOCATION/publishers/google/models/gemini-3.8-flash:streamGenerateContent",user_agent="None"} 1.0
litellm_proxy_failed_requests_metric_total{api_provider="gemini",client_ip="None",exception_class="ReadError",exception_status="None",model_id="None",requested_model="gemini-3.8-flash",route="/gemini/v1beta/models/gemini-3.8-flash:streamGenerateContent",user_agent="None"} 1.0
litellm_proxy_failed_requests_metric_total{api_provider="gemini",client_ip="None",exception_class="ReadError",exception_status="None",model_id="None",requested_model="gemini-3.8-flash",route="/gemini/v1beta/models/gemini-3.8-flash:generateContent",user_agent="None"} 1.0
litellm_proxy_failed_requests_metric_total{api_provider="None",client_ip="None",exception_class="HTTPException",exception_status="400",model_id="None",requested_model="other",route="/anthropic/v1/messages",user_agent="None"} 1.0
litellm_proxy_failed_requests_metric_total{api_provider="vertex_ai",client_ip="None",exception_class="HTTPException",exception_status="404",model_id="None",requested_model="other",route="/vertex_ai/v1/projects/$PROJECT/locations/$LOCATION/publishers/anthropic/models/claude-does-not-exist:rawPredict",user_agent="None"} 1.0
litellm_proxy_failed_requests_metric_total{api_provider="gemini",client_ip="None",exception_class="HTTPException",exception_status="400",model_id="None",requested_model="gemini-3.8-flash",route="/gemini/v1beta/models/gemini-3.8-flash:countTokens",user_agent="None"} 1.0
litellm_proxy_failed_requests_metric_total{api_provider="None",client_ip="127.0.0.1",exception_class="ProxyModelNotFoundError",exception_status="400",model_id="None",requested_model="other",route="/v1/chat/completions",user_agent="curl/8.7.1"} 1.0
```


Surprises seen on both legs, none caused or worsened by this PR:

- Success counter also has empty `requested_model` and `model_id`: leaves alone (LIT-1761, LIT-1745)
- Failure rows carry an empty `api_base`, the success row is populated: leaves alone
- On the before leg one of the two workers served every request (a single counter file in the multiprocess registry); on the after leg both workers served requests, which is why the `/chat/completions` control in the next section differs between legs: leaves alone

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- A declared provider that names a registered provider still beats inference on the failure metric (`model=gpt-5.5` with `custom_llm_provider=anthropic` labels `anthropic`); the label set stays bounded to registered providers
- A config-defined pass-through route to a non-Google host whose paths look like `/models/x:predict` still gets `vertex_ai` on its success rows (`is_vertex_route` is host-blind there) while its failures log no provider, since only a declared provider, a Google host, or a `/projects/<p>/locations/<l>/` path counts as Google on the failure side
- A Vertex URL without `/projects/<p>/locations/<l>/` (express mode) behind a custom api base logs model `""` and no provider on failure for the same reason; on the Google host it is named like any other Vertex URL
- Google routes whose URL carries no `/models/<name>` (`batchPredictionJobs`, `cachedContents`, `tuningJobs`, endpoint-style `:predict`) log model `""` with provider `vertex_ai` or `gemini` on failure; their successes log the body's raw model path (`batchPredictionJobs`) or `unknown`
- On methods the success handler does not track (`countTokens`, `batchGenerateContent`) a failure now names the URL's model while the matching success still logs `unknown`, so those per-model filters show failures only until the success side names them too
- Buffered 4xx on pass-through never reaches `async_log_failure_event` (early return in `_handle_logging_proxy_only_error`, by design), so this PR changes only the `post_call_failure_hook` payload (spend row, Prometheus, UI); Langfuse/Datadog-style callbacks see nothing new
- On the Prometheus label a client body value in `litellm_params` still beats the URL-derived provider on pass-through routes, now bounded to registered providers; the spend row keeps the URL-derived provider
- Daily aggregate buckets split at deploy time: pass-through failure spend moves from the `""` model/provider bucket to per-model buckets with no backfill

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] f80801985a passes /live-pr-risk
