### PR TITLE
fix(logging): finish response metadata before the sync logging thread reads it

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -295,6 +295,9 @@ def _get_provider_request_id(original_exception: Exception) -> str | None:
 # Cache custom pricing keys as frozenset for O(1) lookups instead of looping through 49 keys
 _CUSTOM_PRICING_KEYS: Final[frozenset[str]] = frozenset(CustomPricingLiteLLMParams.model_fields.keys())
 _MODEL_INFO_CUSTOM_PRICING_KEYS: Final[frozenset[str]] = _CUSTOM_PRICING_KEYS | DEPLOYMENT_SCOPED_PRICING_FIELDS
+_UNSERIALIZABLE_METADATA_KEYS: Final[frozenset[str]] = frozenset(
+    ("user_api_key_auth", "user_api_key_budget_reservation")
+)
 
 sentry_sdk_instance = None
 capture_exception = None
@@ -5386,23 +5389,23 @@ class StandardLoggingPayloadSetup:
         Returns:
             dict: Merged metadata with user API key fields taking precedence
         """
-        merged_metadata: Final[dict] = {}
-
-        # Start with metadata (user API key fields) - but skip non-serializable objects
-        if litellm_params.get("metadata") and isinstance(litellm_params.get("metadata"), dict):
-            for key, value in litellm_params["metadata"].items():
-                # Skip non-serializable objects like UserAPIKeyAuth
-                if key in {"user_api_key_auth", "user_api_key_budget_reservation"}:
-                    continue
-                merged_metadata[key] = value
-
-        # Then merge litellm_metadata (model-related fields) - this will NOT overwrite existing keys
-        if litellm_params.get("litellm_metadata") and isinstance(litellm_params.get("litellm_metadata"), dict):
-            for key, value in litellm_params["litellm_metadata"].items():
-                if key not in merged_metadata:  # Don't overwrite existing keys from metadata
-                    merged_metadata[key] = value
-
-        return merged_metadata
+        metadata: Final = litellm_params.get("metadata")
+        litellm_metadata: Final = litellm_params.get("litellm_metadata")
+        user_metadata: Final = MappingProxyType(
+            {
+                key: value
+                for key, value in (tuple(metadata.items()) if isinstance(metadata, dict) else ())
+                if key not in _UNSERIALIZABLE_METADATA_KEYS
+            }
+        )
+        model_metadata: Final = MappingProxyType(
+            {
+                key: value
+                for key, value in (tuple(litellm_metadata.items()) if isinstance(litellm_metadata, dict) else ())
+                if key not in user_metadata
+            }
+        )
+        return {**user_metadata, **model_metadata}
 
     @staticmethod
     def get_standard_logging_metadata(
@@ -5660,7 +5663,7 @@ class StandardLoggingPayloadSetup:
                     additional_logging_headers[key] = additiona_headers[_key]
 
         # Preserve all remaining headers verbatim (e.g. llm_provider-x-request-id)
-        for k, v in additiona_headers.items():
+        for k, v in tuple(additiona_headers.items()):
             if k.lower() not in typed_keys:
                 additional_logging_headers[k] = v
 

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -5394,14 +5394,14 @@ class StandardLoggingPayloadSetup:
         user_metadata: Final = MappingProxyType(
             {
                 key: value
-                for key, value in (tuple(metadata.items()) if isinstance(metadata, dict) else ())
+                for key, value in (dict(metadata) if isinstance(metadata, dict) else {}).items()
                 if key not in _UNSERIALIZABLE_METADATA_KEYS
             }
         )
         model_metadata: Final = MappingProxyType(
             {
                 key: value
-                for key, value in (tuple(litellm_metadata.items()) if isinstance(litellm_metadata, dict) else ())
+                for key, value in (dict(litellm_metadata) if isinstance(litellm_metadata, dict) else {}).items()
                 if key not in user_metadata
             }
         )
@@ -5663,7 +5663,7 @@ class StandardLoggingPayloadSetup:
                     additional_logging_headers[key] = additiona_headers[_key]
 
         # Preserve all remaining headers verbatim (e.g. llm_provider-x-request-id)
-        for k, v in tuple(additiona_headers.items()):
+        for k, v in dict(additiona_headers).items():
             if k.lower() not in typed_keys:
                 additional_logging_headers[k] = v
 

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -5394,18 +5394,18 @@ class StandardLoggingPayloadSetup:
         user_metadata: Final = MappingProxyType(
             {
                 key: value
-                for key, value in (dict(metadata) if isinstance(metadata, dict) else {}).items()
+                for key, value in (metadata.copy().items() if isinstance(metadata, dict) else ())
                 if key not in _UNSERIALIZABLE_METADATA_KEYS
             }
         )
         model_metadata: Final = MappingProxyType(
             {
                 key: value
-                for key, value in (dict(litellm_metadata) if isinstance(litellm_metadata, dict) else {}).items()
+                for key, value in (litellm_metadata.copy().items() if isinstance(litellm_metadata, dict) else ())
                 if key not in user_metadata
             }
         )
-        return {**user_metadata, **model_metadata}
+        return {**user_metadata, **model_metadata}  # mutable-ok: function contract returns a plain dict
 
     @staticmethod
     def get_standard_logging_metadata(
@@ -5663,7 +5663,7 @@ class StandardLoggingPayloadSetup:
                     additional_logging_headers[key] = additiona_headers[_key]
 
         # Preserve all remaining headers verbatim (e.g. llm_provider-x-request-id)
-        for k, v in dict(additiona_headers).items():
+        for k, v in additiona_headers.copy().items():
             if k.lower() not in typed_keys:
                 additional_logging_headers[k] = v
 

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -1196,6 +1196,52 @@ def function_setup(
         raise e
 
 
+def _dispatch_success_logging(
+    logging_obj: LiteLLMLoggingObject,
+    result: object,
+    start_time: datetime.datetime,
+    end_time: datetime.datetime,
+    is_completion_with_fallbacks: bool,
+    is_litellm_internal_call: bool,
+) -> None:
+    # LOG SUCCESS - handle streaming success logging in the _next_ object
+    # Internal sub-calls (e.g. emulated file-search steps) share the
+    # parent's logging obj; skip async logging here so only the outer call bills once.
+    # NOTE: streaming requests return early (before this point) via
+    # CustomStreamWrapper, so this block is non-streaming only.
+    if not is_litellm_internal_call:
+        if getattr(logging_obj, "_defer_async_logging", False):
+
+            def _enqueue_deferred_logging() -> None:
+                asyncio.create_task(
+                    _client_async_logging_helper(
+                        logging_obj=logging_obj,
+                        result=result,
+                        start_time=start_time,
+                        end_time=end_time,
+                        is_completion_with_fallbacks=is_completion_with_fallbacks,
+                    )
+                )
+
+            logging_obj._enqueue_deferred_logging = _enqueue_deferred_logging
+        else:
+            asyncio.create_task(
+                _client_async_logging_helper(
+                    logging_obj=logging_obj,
+                    result=result,
+                    start_time=start_time,
+                    end_time=end_time,
+                    is_completion_with_fallbacks=is_completion_with_fallbacks,
+                )
+            )
+
+    logging_obj.handle_sync_success_callbacks_for_async_calls(
+        result=result,
+        start_time=start_time,
+        end_time=end_time,
+    )
+
+
 async def _client_async_logging_helper(
     logging_obj: LiteLLMLoggingObject,
     result,
@@ -1663,6 +1709,16 @@ def client(original_function):
                 kwargs=kwargs,
             )
 
+            _update_response_metadata: Final = getattr(sys.modules[__name__], "update_response_metadata")
+            _update_response_metadata(
+                result=result,
+                logging_obj=logging_obj,
+                model=model,
+                kwargs=kwargs,
+                start_time=start_time,
+                end_time=end_time,
+            )
+
             # LOG SUCCESS - handle streaming success logging in the _next_ object, remove `handle_success` once it's deprecated
             verbose_logger.info("Wrapper: Completed Call, calling success_handler")
             # Copy the current context to propagate it to the background thread
@@ -1677,15 +1733,6 @@ def client(original_function):
                 end_time,
             )
             # RETURN RESULT
-            update_response_metadata = getattr(sys.modules[__name__], "update_response_metadata")
-            update_response_metadata(
-                result=result,
-                logging_obj=logging_obj,
-                model=model,
-                kwargs=kwargs,
-                start_time=start_time,
-                end_time=end_time,
-            )
             return result
         except Exception as e:
             call_type = original_function.__name__
@@ -1945,48 +1992,20 @@ def client(original_function):
                 args=args,
             )
 
-            # LOG SUCCESS - handle streaming success logging in the _next_ object
-            # Internal sub-calls (e.g. emulated file-search steps) share the
-            # parent's logging obj; skip async logging here so only the outer call bills once.
-            # NOTE: streaming requests return early (before this point) via
-            # CustomStreamWrapper, so this block is non-streaming only.
-            if not _is_litellm_internal_call:
-                if getattr(logging_obj, "_defer_async_logging", False):
-
-                    def _enqueue_deferred_logging() -> None:
-                        asyncio.create_task(
-                            _client_async_logging_helper(
-                                logging_obj=logging_obj,
-                                result=result,
-                                start_time=start_time,
-                                end_time=end_time,
-                                is_completion_with_fallbacks=is_completion_with_fallbacks,
-                            )
-                        )
-
-                    logging_obj._enqueue_deferred_logging = _enqueue_deferred_logging
-                else:
-                    asyncio.create_task(
-                        _client_async_logging_helper(
-                            logging_obj=logging_obj,
-                            result=result,
-                            start_time=start_time,
-                            end_time=end_time,
-                            is_completion_with_fallbacks=is_completion_with_fallbacks,
-                        )
-                    )
-
-            logging_obj.handle_sync_success_callbacks_for_async_calls(
-                result=result,
-                start_time=start_time,
-                end_time=end_time,
-            )
             # REBUILD EMBEDDING CACHING
             if (
                 isinstance(result, EmbeddingResponse)
                 and _caching_handler_response is not None
                 and _caching_handler_response.final_embedding_cached_response is not None
             ):
+                _dispatch_success_logging(
+                    logging_obj=logging_obj,
+                    result=result,
+                    start_time=start_time,
+                    end_time=end_time,
+                    is_completion_with_fallbacks=is_completion_with_fallbacks,
+                    is_litellm_internal_call=_is_litellm_internal_call,
+                )
                 return _llm_caching_handler._combine_cached_embedding_response_with_api_result(
                     _caching_handler_response=_caching_handler_response,
                     embedding_response=result,
@@ -2001,6 +2020,14 @@ def client(original_function):
                 kwargs=kwargs,
                 start_time=start_time,
                 end_time=end_time,
+            )
+            _dispatch_success_logging(
+                logging_obj=logging_obj,
+                result=result,
+                start_time=start_time,
+                end_time=end_time,
+                is_completion_with_fallbacks=is_completion_with_fallbacks,
+                is_litellm_internal_call=_is_litellm_internal_call,
             )
 
             return result

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -1204,11 +1204,6 @@ def _dispatch_success_logging(
     is_completion_with_fallbacks: bool,
     is_litellm_internal_call: bool,
 ) -> None:
-    # LOG SUCCESS - handle streaming success logging in the _next_ object
-    # Internal sub-calls (e.g. emulated file-search steps) share the
-    # parent's logging obj; skip async logging here so only the outer call bills once.
-    # NOTE: streaming requests return early (before this point) via
-    # CustomStreamWrapper, so this block is non-streaming only.
     if not is_litellm_internal_call:
         if getattr(logging_obj, "_defer_async_logging", False):
 

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -3,12 +3,14 @@ import contextlib
 import datetime
 import os
 import sys
+from collections.abc import Callable
 from typing import Final, Literal
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 import time
+from typing import Final
 
 import httpx
 from openai._legacy_response import HttpxBinaryResponseContent
@@ -6945,3 +6947,61 @@ def test_classifier_audit_is_not_added_to_other_calls(logging_obj, call_type, or
     logging_obj.model_call_details["litellm_params"] = {"metadata": {"internal_call_origin": origin}}
     logging_obj.pre_call(input=[], api_key=None, additional_args={"complete_input_dict": {"input": "embedding"}})
     assert logging_obj.classifier_input is None
+
+
+def _run_while_a_thread_grows(target: dict, read: Callable[[], None], reads: int) -> None:
+    import itertools
+    import threading
+
+    stop: Final = threading.Event()
+
+    def grow() -> None:
+        for counter in itertools.count():
+            if stop.is_set():
+                return
+            key: Final = f"late_{counter % 64}"
+            if key in target:
+                del target[key]
+            else:
+                target[key] = counter
+
+    writer: Final = threading.Thread(target=grow, daemon=True)
+    previous_interval: Final = sys.getswitchinterval()
+    sys.setswitchinterval(1e-6)
+    writer.start()
+    try:
+        for _ in range(reads):
+            read()
+    finally:
+        stop.set()
+        writer.join(timeout=5)
+        sys.setswitchinterval(previous_interval)
+
+
+def test_merge_litellm_metadata_survives_a_thread_growing_metadata_mid_merge():
+    from litellm.litellm_core_utils.litellm_logging import StandardLoggingPayloadSetup
+
+    metadata: Final = {f"key_{i}": i for i in range(2000)}
+    litellm_params: Final = {"metadata": metadata, "litellm_metadata": {"model_group": "gpt"}}
+
+    def read() -> None:
+        merged: Final = StandardLoggingPayloadSetup.merge_litellm_metadata(litellm_params)
+        assert merged["key_1999"] == 1999
+        assert merged["model_group"] == "gpt"
+
+    _run_while_a_thread_grows(metadata, read, reads=300)
+
+
+def test_get_additional_headers_survives_a_thread_growing_headers_mid_copy():
+    from litellm.litellm_core_utils.litellm_logging import StandardLoggingPayloadSetup
+
+    headers: Final = {f"llm_provider-x-custom-{i}": str(i) for i in range(2000)}
+    headers["x-ratelimit-remaining-requests"] = "7"
+
+    def read() -> None:
+        copied: Final = StandardLoggingPayloadSetup.get_additional_headers(headers)
+        assert copied is not None
+        assert copied["x_ratelimit_remaining_requests"] == 7
+        assert copied["llm_provider-x-custom-1999"] == "1999"
+
+    _run_while_a_thread_grows(headers, read, reads=300)

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -10,7 +10,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 import time
-from typing import Final
 
 import httpx
 from openai._legacy_response import HttpxBinaryResponseContent

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -1,9 +1,12 @@
 import asyncio
+import contextlib
 import json
 import logging
 import os
+import queue
 import threading
 from datetime import datetime, timedelta, timezone
+from collections.abc import Iterator
 from typing import Final
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -6298,3 +6301,46 @@ async def test_async_mock_completion_streaming_obj_raises_mock_exception_before_
     )
     with pytest.raises(litellm.MockException):
         await _async_mock_stream_snapshots(mock_exception, 51234)
+
+
+
+@contextlib.contextmanager
+def _recording_hidden_params_at_submit(submit_target: str) -> "Iterator[queue.SimpleQueue[dict[str, object]]]":
+    seen: Final = queue.SimpleQueue()
+
+    def record_submit(_fn, *args, **_kwargs):
+        response: Final = next(arg for arg in args if isinstance(arg, litellm.ModelResponse))
+        seen.put(dict(response._hidden_params))
+        return MagicMock()
+
+    with patch(submit_target, side_effect=record_submit):
+        yield seen
+
+
+@pytest.mark.asyncio
+async def test_acompletion_finishes_response_metadata_before_handing_the_response_to_the_logging_thread(monkeypatch):
+    monkeypatch.setattr(litellm, "success_callback", [lambda kwargs, response, start_time, end_time: None])
+    with _recording_hidden_params_at_submit("litellm.litellm_core_utils.litellm_logging.executor.submit") as seen:
+        await litellm.acompletion(
+            model="gpt-5.5",
+            messages=[{"role": "user", "content": "hi"}],
+            mock_response="Hello there!",
+            num_retries=0,
+        )
+    snapshot: Final = seen.get_nowait()
+    assert snapshot["litellm_call_id"]
+    assert snapshot["response_cost"] is not None
+    assert snapshot["api_base"]
+
+
+def test_completion_finishes_response_metadata_before_handing_the_response_to_the_logging_thread():
+    with _recording_hidden_params_at_submit("litellm.utils.executor.submit") as seen:
+        litellm.completion(
+            model="gpt-5.5",
+            messages=[{"role": "user", "content": "hi"}],
+            mock_response="Hello there!",
+        )
+    snapshot: Final = seen.get_nowait()
+    assert snapshot["litellm_call_id"]
+    assert snapshot["response_cost"] is not None
+    assert snapshot["api_base"]


### PR DESCRIPTION
## TLDR

Problem this solves:

- A request's metadata dict can grow while the logging thread iterates it
- Python raises `dictionary changed size during iteration`, so a good completion becomes a 500
- The 500 hides a billed response and invites a costly retry

How it solves it:

- `merge_litellm_metadata` and `get_additional_headers` iterate a shallow copy, never the live dict
- Response metadata (cost, call id, api base) is finalized before the sync logging thread gets the response
- Regression tests grow the dicts from a second thread while the merge runs

## User Flow

Before: a developer sends a normal chat completion with request metadata and sometimes gets a 500 even though the provider answered

1. They send POST http://localhost:4000/v1/chat/completions with `"model": "anthropic-haiku-4-5"`, a one line prompt, and a `"metadata"` object with a few thousand keys
2. The provider returns the completion and the gateway charges the key for it
3. Every so often the response is `500 {"error": {"message": "dictionary changed size during iteration", "type": "None", ...}}` instead of the completion
4. Their app retries and gets billed twice for one answer

After: the same request always comes back as the completion the provider produced

1. They send the same POST http://localhost:4000/v1/chat/completions with the same body
2. The provider returns the completion and the gateway charges the key for it
3. The response is `200` with the completion body and the usual `x-litellm-call-id` and `x-litellm-response-cost` headers
4. Nothing to retry

## Relevant issues

## Linear ticket

Resolves LIT-7042

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Two proxies from two worktrees, same config, same callback, real Anthropic calls. Base is `origin/litellm_internal_staging` at `2f46425732` on port 20042, After is this branch at `a9692d149b` on port 20043

```yaml
# config.yaml
model_list:
  - model_name: anthropic-haiku-4-5
    litellm_params:
      model: anthropic/claude-haiku-4-5
      api_key: os.environ/ANTHROPIC_API_KEY
general_settings:
  master_key: sk-1234
litellm_settings:
  success_callback: ["custom_callbacks.log_success"]
```

```bash
# hammer.sh PORT N KEYS: N concurrent chat completions, each carrying a KEYS-entry metadata dict
port=$1; n=${2:-40}; keys=${3:-20000}
python3 - "$keys" > body.json <<'PY'
import json,sys
n=int(sys.argv[1])
print(json.dumps({"model":"anthropic-haiku-4-5","messages":[{"role":"user","content":"Say hi in one word"}],"max_tokens":5,"metadata":{f"k{i}":i for i in range(n)}}))
PY
for i in $(seq 1 $n); do
  curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:$port/v1/chat/completions \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" --data-binary @body.json &
done | sort | uniq -c
wait
```

The race is a thread interleaving, so 30 concurrent requests on the base proxy did not trip it during this run (0 hits of `dictionary changed size` in 401 base requests across three runs). The deterministic reproduction is the two new `_survives_a_thread_growing_` tests plus the two `finishes_response_metadata` tests, which fail on staging with `RuntimeError: dictionary changed size during iteration` (logging.py:5393 and :5663) and `KeyError: 'litellm_call_id'`, and pass at `a9692d149b`. The live run below shows the customer-facing path is unchanged: same status, same response headers, cost that matches the tokens Anthropic billed

The fallback case swaps in this config, keeps `--num_workers 2` on both sides, and uses `hammer_fb.sh`, the same script with `"model":"haiku-flaky"`. It is the ticket's trigger: a deployment that fails at once and a healthy sibling the router falls back to

```yaml
model_list:
  - model_name: haiku-flaky
    litellm_params:
      model: anthropic/claude-haiku-4-5
      api_key: os.environ/ANTHROPIC_API_KEY
      timeout: 0.001
  - model_name: haiku-backup
    litellm_params:
      model: anthropic/claude-haiku-4-5
      api_key: os.environ/ANTHROPIC_API_KEY
router_settings:
  num_retries: 0
  fallbacks:
    - haiku-flaky: ["haiku-backup"]
general_settings:
  master_key: sk-1234
litellm_settings:
  success_callback: ["custom_callbacks.log_success"]
```

### Before (2f46425732)

#### 30 concurrent completions with a 20000-key metadata dict

1. `./hammer.sh 20042 30 20000`
2. Output: `30 200`
3. `grep -c "dictionary changed size" base3.log` prints `0`

#### Single completion, response headers

1. `curl -s -D - -o /dev/null http://127.0.0.1:20042/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model":"anthropic-haiku-4-5","messages":[{"role":"user","content":"Say hi in one word"}],"max_tokens":5,"metadata":{"team":"qa"}}' | grep -i "^HTTP\|x-litellm"`
2. Output:

```
HTTP/1.1 200 OK
x-litellm-call-id: af1e5f50-0286-4a25-8eb5-a495981e2b08
x-litellm-model-id: 17f5b49e944e32195698f8e39be37262068b5cb388a48c14ca04aa95f4afc956
x-litellm-model-name: anthropic/claude-haiku-4-5
x-litellm-version: 1.102.0
x-litellm-response-cost: 3.2000000000000005e-05
x-litellm-response-cost-input: 1.2e-05
x-litellm-response-cost-output: 2e-05
x-litellm-key-spend: 3.2000000000000005e-05
x-litellm-response-duration-ms: 437.888
x-litellm-overhead-duration-ms: 2.216
x-litellm-callback-duration-ms: 0.0
x-litellm-model-group: anthropic-haiku-4-5
x-litellm-attempted-retries: 0
x-litellm-attempted-fallbacks: 0
```

#### Router fallback under load, 40 concurrent requests x 3, 2 uvicorn workers

1. `for i in 1 2 3; do ./hammer_fb.sh 20042 40 20000; done`
2. Output, all three runs: `40 200`
3. `grep -c "dictionary changed size" base_fb.log` prints `0`
4. Single `haiku-flaky` request returns `200` with `x-litellm-attempted-fallbacks: 1` and `x-litellm-model-group: haiku-backup`

### After (a9692d149b)

#### 30 concurrent completions with a 20000-key metadata dict

1. `./hammer.sh 20043 30 20000`
2. Output: `30 200`
3. `grep -c "dictionary changed size" head2.log` prints `0`

#### Single completion, response headers

1. `curl -s -D - -o /dev/null http://127.0.0.1:20043/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model":"anthropic-haiku-4-5","messages":[{"role":"user","content":"Say hi in one word"}],"max_tokens":5,"metadata":{"team":"qa"}}' | grep -i "^HTTP\|x-litellm"`
2. Output:

```
HTTP/1.1 200 OK
x-litellm-call-id: 31e06942-4777-4cef-addc-97735550af01
x-litellm-model-id: 17f5b49e944e32195698f8e39be37262068b5cb388a48c14ca04aa95f4afc956
x-litellm-model-name: anthropic/claude-haiku-4-5
x-litellm-version: 1.102.0
x-litellm-response-cost: 3.7000000000000005e-05
x-litellm-response-cost-input: 1.2e-05
x-litellm-response-cost-output: 2.5e-05
x-litellm-key-spend: 3.7000000000000005e-05
x-litellm-response-duration-ms: 480.024
x-litellm-overhead-duration-ms: 2.334
x-litellm-callback-duration-ms: 0.0
x-litellm-model-group: anthropic-haiku-4-5
x-litellm-attempted-retries: 0
x-litellm-attempted-fallbacks: 0
```

#### Router fallback under load, 40 concurrent requests x 3, 2 uvicorn workers

1. `for i in 1 2 3; do ./hammer_fb.sh 20043 40 20000; done`
2. Output, all three runs: `40 200`
3. `grep -c "dictionary changed size" head_fb.log` prints `0`
4. Single `haiku-flaky` request returns `200` with `x-litellm-attempted-fallbacks: 1` and `x-litellm-model-group: haiku-backup`

The race did not fire on base in 120 fallback requests either. The deterministic proof remains the four tests named above

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- `x-litellm-callback-duration-ms` now always reads `0.0` on non-streaming responses
  - Before, the header showed the sync callback time only when the logging thread happened to finish first (the same race this PR removes), so it already read `0.0` on many base requests, including the base run above
  - `callback_duration_ms` is still accumulated on the logging object and lands in the standard logging payload

### Low

- `merge_litellm_metadata` still returns a plain `dict`, under a `# mutable-ok`, because callers mutate the merged result

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] a9692d149b passes /live-pr-risk


Link to Devin session: https://app.devin.ai/sessions/dd81e6f2d1634f4084e0df0500dfb586
Open in Devin Desktop: https://app.devin.ai/desktop/session/dd81e6f2d1634f4084e0df0500dfb586?variant=devin
Requested by: @yassin-berriai