### PR TITLE
fix(cloudzero): infer daily batch schema from every row

### DIFF
--- a/litellm/integrations/cloudzero/cz_stream_api.py
+++ b/litellm/integrations/cloudzero/cz_stream_api.py
@@ -97,7 +97,11 @@ class CloudZeroStreamer:
                 continue
 
         # Convert lists back to DataFrames
-        return {date_key: pl.DataFrame(records) for date_key, records in daily_batches.items() if records}
+        return {
+            date_key: pl.DataFrame(records, infer_schema_length=None)
+            for date_key, records in daily_batches.items()
+            if records
+        }
 
     def _parse_and_convert_timestamp(self, timestamp_str: str) -> datetime:
         """Parse timestamp string and convert to UTC."""

--- a/tests/test_litellm/integrations/cloudzero/test_cz_stream_api.py
+++ b/tests/test_litellm/integrations/cloudzero/test_cz_stream_api.py
@@ -69,6 +69,25 @@ class TestCloudZeroStreamer:
             assert "2025-01-19" in result
             assert len(result["2025-01-19"]) == 1
 
+    def test_group_by_date_infers_schema_from_every_row(self):
+        """Test daily batches retain optional string columns that are null for thousands of leading rows."""
+        streamer = CloudZeroStreamer("test-key", "test-connection")
+        leading_nulls = 10_000
+        rows = [
+            {"time/usage_start": "2025-01-19T10:30:00Z", "team_alias": None}
+            for _ in range(leading_nulls)
+        ]
+        rows.append({"time/usage_start": "2025-01-19T10:30:00Z", "team_alias": "team-alias"})
+        data = pl.DataFrame(rows, schema={"time/usage_start": pl.String, "team_alias": pl.String})
+
+        result = streamer._group_by_date(data)
+
+        batch = result["2025-01-19"]
+        assert len(batch) == leading_nulls + 1
+        assert batch.schema["team_alias"] == pl.String
+        assert batch["team_alias"].null_count() == leading_nulls
+        assert batch.tail(1).item(0, "team_alias") == "team-alias"
+
     def test_parse_and_convert_timestamp_utc(self):
         """Test _parse_and_convert_timestamp method with UTC timestamp."""
         streamer = CloudZeroStreamer("test-key", "test-connection")

--- a/tests/test_litellm/integrations/cloudzero/test_cz_stream_api.py
+++ b/tests/test_litellm/integrations/cloudzero/test_cz_stream_api.py
@@ -74,19 +74,24 @@ class TestCloudZeroStreamer:
         streamer = CloudZeroStreamer("test-key", "test-connection")
         leading_nulls = 10_000
         rows = [
-            {"time/usage_start": "2025-01-19T10:30:00Z", "team_alias": None}
+            {"time/usage_start": "2025-01-19T10:30:00Z", "resource/tag:team_alias": None}
             for _ in range(leading_nulls)
         ]
-        rows.append({"time/usage_start": "2025-01-19T10:30:00Z", "team_alias": "team-alias"})
-        data = pl.DataFrame(rows, schema={"time/usage_start": pl.String, "team_alias": pl.String})
+        rows.append(
+            {"time/usage_start": "2025-01-19T10:30:00Z", "resource/tag:team_alias": "team-alias"}
+        )
+        data = pl.DataFrame(
+            rows,
+            schema={"time/usage_start": pl.String, "resource/tag:team_alias": pl.String},
+        )
 
         result = streamer._group_by_date(data)
 
         batch = result["2025-01-19"]
         assert len(batch) == leading_nulls + 1
-        assert batch.schema["team_alias"] == pl.String
-        assert batch["team_alias"].null_count() == leading_nulls
-        assert batch.tail(1).item(0, "team_alias") == "team-alias"
+        assert batch.schema["resource/tag:team_alias"] == pl.String
+        assert batch["resource/tag:team_alias"].null_count() == leading_nulls
+        assert batch.tail(1).item(0, "resource/tag:team_alias") == "team-alias"
 
     def test_parse_and_convert_timestamp_utc(self):
         """Test _parse_and_convert_timestamp method with UTC timestamp."""


### PR DESCRIPTION
## TLDR

Problem this solves:

- CloudZero exports fail when optional tags appear after 100 rows
- One affected day prevents every day from exporting

How it solves it:

- Infer each daily batch schema from every row
- Preserve optional team and key metadata columns

## User Flow

Before: an administrator exporting accumulated usage sees a 500 error and no data reaches CloudZero

1. They open `http://localhost:4000/ui/logging-and-alerts/` and select CloudZero Cost Tracking
2. They select Export Data Now, confirm Export, and see an error toast
3. They send `POST http://localhost:4000/cloudzero/export` with `{"limit":1000,"operation":"replace_hourly"}`
4. The response is HTTP 500 with a Polars schema error, and no CloudZero request is received

After: the same export succeeds and sends all daily batches with available tags

1. They open `http://localhost:4000/ui/logging-and-alerts/` and select CloudZero Cost Tracking
2. They select Export Data Now, confirm Export, and see a success toast
3. They send `POST http://localhost:4000/cloudzero/export` with `{"limit":1000,"operation":"replace_hourly"}`
4. The response is HTTP 200 and CloudZero receives the daily batches, including rows with team tags

## Relevant issues

## Linear ticket

Resolves LIT-6651

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile Confidence Score of at least 4/5

## Screenshots / Proof of Fix

Shared setup: both runs used the same live proxy configuration, PostgreSQL data, real model calls, and `POST /cloudzero/export` request. The after run reached the hosted CloudZero AnyCost API using an authorized connection and was confirmed in the CloudZero UI. The after run includes the regression-test follow-up commit `c051082e55`.

Confidential account, user, and connection identifiers are masked in the screenshots while the export result and hosted ingestion status remain visible

### Before (fafd294878)

#### Live export

1. `curl -sS -w '\nHTTP %{http_code}\n' http://localhost:4000/cloudzero/export -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"limit":1000,"operation":"replace_hourly"}'`
2. HTTP 500: `could not append value: "Platform Team" of type: str to the builder`
3. No request reached the CloudZero destination
4. UI screenshot: base export flow shows the error toast and confirmation dialog at [base-03-result.png](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr39871/evidence/pr-39871/base-03-result.png)

### After (c051082e55)

#### Live export

1. Run the same curl command against the fixed proxy
2. HTTP 200: `CloudZero export completed successfully`
3. The destination receives daily batches with 2 tagged records and 103 records containing the row-103 team tag
4. UI screenshot: fixed export flow shows `Data successfully exported to CloudZero` at [fixed-03-result.png](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr39871/evidence/pr-39871/fixed-03-result.png)
5. Hosted CloudZero connection screenshot shows `Status: Healthy`, recent ingestion, and the exported connection activity:

![Hosted CloudZero connection](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr39871/evidence/pr-39871/cloudzero-connection-evidence.png)

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- Single-day exports can still drop tags that first appear after row 100
- LIT-6652 tracks the separate transform inference gap

### Low

- A time-bounded export can fail after an unbounded export on one connection
- This is a pre-existing prepared-statement binding issue

## Final Attestation

- [x] The tests check the affected edge case and preserve the existing export behavior

ran /live-pr-risk and found no regressions/backward incompatible risks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow Polars schema-inference change in CloudZero daily batching, covered by a targeted regression test; no auth or data-model changes.
> 
> **Overview**
> Fixes CloudZero exports that **HTTP 500** when optional tag columns (e.g. `resource/tag:team_alias`) only get non-null values after Polars’ default schema scan (~100 rows). A single bad day could block the whole export.
> 
> **`_group_by_date`** now rebuilds each daily batch with `pl.DataFrame(..., infer_schema_length=None)` so schema is inferred from **all** rows in that day, keeping optional string metadata columns and avoiding append/type errors when sending batches.
> 
> Adds a regression test with **10,000** leading null tag rows and one populated row to assert the column stays `String` and the tag value is preserved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c051082e55bba9e9db3856605d3c13545aa9074e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->




