### PR TITLE
fix(judge): stop the JSON-fence regex backtracking on an unclosed fence

### DIFF
--- a/litellm/litellm_core_utils/llm_judge.py
+++ b/litellm/litellm_core_utils/llm_judge.py
@@ -15,7 +15,11 @@ if TYPE_CHECKING:
     from litellm.types.llms.openai import AllMessageValues
     from litellm.types.utils import ModelResponse
 
-JSON_FENCE_RE: Final = re.compile(r"```(?:json)?\s*(.*?)\s*```", re.DOTALL | re.IGNORECASE)
+# No `\s*` around the capture: under DOTALL a dot matches a space too, so each
+# `\s*` overlaps the `.*?` beside it, and a reply that opens a fence without closing
+# one can be split between them in cubic-many ways -- a failing match walks all of
+# them. The only caller strips the capture, which is what those `\s*` were doing.
+JSON_FENCE_RE: Final = re.compile(r"```(?:json)?(.*?)```", re.DOTALL | re.IGNORECASE)
 
 
 def default_router_provider() -> Router | None:

--- a/tests/test_litellm/litellm_core_utils/test_llm_judge.py
+++ b/tests/test_litellm/litellm_core_utils/test_llm_judge.py
@@ -1,6 +1,8 @@
 """Unit tests for the shared LLM-judge primitives: verdict parsing, router resolution, dispatch."""
 
 import json
+import time
+from typing import Final
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -25,6 +27,39 @@ from litellm.litellm_core_utils.llm_judge import (
 )
 def test_parse_json_verdict_tolerates_fences_and_prose(raw, expected):
     assert parse_json_verdict(raw)["preference"] == expected
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ('```json   {"preference": "A"}   ```', "A"),
+        ('```\n\n  {"preference": "B"}  \n\n```', "B"),
+        ('```json{"preference": "tie"}```', "tie"),
+    ],
+)
+def test_parse_json_verdict_still_trims_padding_inside_the_fence(raw, expected):
+    """Whitespace between the fence and the JSON is dropped, however it is spelled."""
+    assert parse_json_verdict(raw)["preference"] == expected
+
+
+def test_parse_json_verdict_is_not_quadratic_in_an_unclosed_fence():
+    """A judge reply that opens a fence and never closes it must not burn the event loop.
+
+    The judge is fed the end user's own text, so the reply it produces is steerable by
+    that user. The fence regex used to put a `\\s*` on each side of its capture; under
+    DOTALL those overlap the capture, and a failing match walks cubic-many ways to split
+    the whitespace run between them -- 4KB of padding took over a minute of CPU, on the
+    loop, inside an async guardrail hook. The budget below is ~500x the fixed cost and
+    ~1/14th the unfixed one, so it separates the two without depending on runner speed.
+    """
+    reply: Final = "```" + " " * 4000 + "no closing fence"
+
+    start: Final = time.perf_counter()
+    with pytest.raises((json.JSONDecodeError, ValueError)):
+        parse_json_verdict(reply)
+    elapsed: Final = time.perf_counter() - start
+
+    assert elapsed < 5.0, f"parsing a 4KB unclosed fence took {elapsed:.1f}s"
 
 
 def test_parse_json_verdict_rejects_non_object():


### PR DESCRIPTION
## TLDR

Problem this solves:

- A judge reply that opens a ``` fence and never closes one makes the verdict parser backtrack cubically
- 4 KB of padding costs ~63 s of CPU, spent on the event loop inside an async guardrail hook
- One such request stalls the whole proxy: `/health/liveliness` went from 0.67 s to 62 s

How it solves it:

- Drop the two `\s*` around the capture in `JSON_FENCE_RE`; under `DOTALL` they overlap the `.*?` between them
- The one call site already does `group(1).strip()`, which is all those `\s*` were doing, so the parsed value is unchanged

## User Flow

`LLMAsAJudgeGuardrail` feeds the end user's own request and response text to a judge model and parses the reply with `parse_json_verdict`. A user who gets that judge to answer with a fenced block followed by a few kilobytes of filler — and no closing fence — pays nothing and costs the proxy a minute of CPU per request. No operator setting is involved; `shadow_eval_logger` parses judge replies the same way.

Before: one request with the judge guardrail enabled occupies the proxy for a minute

1. The user sends POST https://litellm-domain/v1/chat/completions with `"guardrails": ["judge-guard"]`
2. The response does come back 200 — the guardrail fails open on the parse error — but only after ~63 s
3. While it runs, every other request on that worker waits, including `/health/liveliness`

After: the same request is served in ~23 ms and nothing else is held up

1. Same POST
2. 200 in 0.023 s
3. `/health/liveliness` answers in 0.003 s while the guardrailed request is in flight

## Relevant issues

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

### How it was found

Every regex litellm compiles **at runtime** was recorded by hooking `re.compile` and importing all 2,450 modules under `litellm/` and `enterprise/` — 1,255 distinct patterns, which includes the f-string-built ones a source scan cannot see (a source-only scan finds 419). All 1,255 went through `regexploit`. This was the **only** pattern it rates catastrophic:

```
Pattern: ```(?:json)?\s*(.*?)\s*```
Worst-case complexity: 3 ⭐⭐⭐ (cubic)
Repeated character: [SPACE]
```

Under `re.DOTALL` a dot matches a space, so both `\s*` overlap the `.*?` beside them. When no closing fence follows, the match fails and the engine walks every way to split the whitespace run across the three quantifiers.

### Shared setup

A mock OpenAI-compatible server whose `judge` model answers `"```" + " " * 4000 + "no closing fence"`, and a proxy started from this config against it:

```yaml
model_list:
  - model_name: echo
    litellm_params: {model: openai/echo, api_base: "http://127.0.0.1:4711/v1", api_key: fake}
  - model_name: judge
    litellm_params: {model: openai/judge, api_base: "http://127.0.0.1:4711/v1", api_key: fake}

guardrails:
  - guardrail_name: judge-guard
    litellm_params:
      guardrail: llm_as_a_judge
      mode: post_call
      judge_model: judge
      on_failure: log
      criteria:
        - {name: helpfulness, description: is the answer helpful, weight: 100}

general_settings:
  master_key: sk-qa-1234
```

Each case is the same request:

```
curl -X POST http://127.0.0.1:PORT/v1/chat/completions \
  -H "Authorization: Bearer sk-qa-1234" -H "Content-Type: application/json" \
  -d '{"model":"echo","messages":[{"role":"user","content":"hi"}],"guardrails":["judge-guard"]}'
```

The proxy log confirms the guardrail is the code path being exercised, on both builds:

```
LiteLLM:WARNING: llm_as_a_judge guardrail: judge call failed, failing open.
Error: Expecting value: line 1 column 1 (char 0)
```

### Before (29ac88ebc6)

```
  request 200 in 63.032301s
  request 200 in 61.228240s
  request 200 in 63.560311s
```

One request in flight is enough to stall an unrelated endpoint on the same worker:

```
  /health/liveliness   (idle)        200 in  0.673035s
  /health/liveliness   (one request) 200 in 61.998911s
```

### After (this PR)

```
  request 200 in 0.023662s
  request 200 in 0.024268s
  request 200 in 0.031521s

  /health/liveliness   (idle)        200 in 0.706049s
  /health/liveliness   (one request) 200 in 0.003382s
```

### The regex itself

| input | before | after |
|---|---|---|
| 1 KB unclosed fence | 1.613 s | 0.000036 s |
| 4 KB unclosed fence | 72.087 s | 0.000126 s |
| 1 MB unclosed fence | — | 0.016 s |

### The parsed value does not change

The only use of `JSON_FENCE_RE` is `fenced.group(1).strip()`. A differential run over **460,009** inputs — every combination of fence, quote, brace, newline and space fragments up to length 5, plus 60,000 random ones and realistic judge replies — produced **0 mismatches** between the old and new patterns at that call site.

### Tests

`tests/test_litellm/litellm_core_utils/test_llm_judge.py`:

- `test_parse_json_verdict_is_not_quadratic_in_an_unclosed_fence` — fails on base with `assert 64.14306463487446 < 5.0`, passes here. The budget is ~500x the fixed cost and ~1/14th the unfixed one, so it separates the two without depending on runner speed.
- `test_parse_json_verdict_still_trims_padding_inside_the_fence` — three positive controls (`json` tag with spaces, blank lines inside the fence, no padding at all). These pass on **both** builds; they are there to show the trimming behaviour is unchanged.

Full files pass locally: `test_llm_judge.py` + `test_llm_as_a_judge.py` → 57 passed; `test_shadow_eval_logger.py` → 129 passed.