### PR TITLE
fix(rate_limiter): render the 429 reset time in UTC, as its label claims

### DIFF
--- a/litellm/proxy/hooks/batch_rate_limiter.py
+++ b/litellm/proxy/hooks/batch_rate_limiter.py
@@ -585,7 +585,7 @@ class _PROXY_BatchRateLimiter(CustomLogger):
         requested_model: str | None = None,
     ) -> NoReturn:
         """Raise :class:`ProxyRateLimitError` (a 429) for batch rate limit exceeded."""
-        from datetime import datetime
+        from datetime import datetime, timezone
 
         # Find the descriptor for this status. Matching on (key, value) is
         # required, not key alone: a batch can carry several project ITPM/OTPM
@@ -612,7 +612,9 @@ class _PROXY_BatchRateLimiter(CustomLogger):
         now: Final = datetime.now().timestamp()
         window_size: Final = self.parallel_request_limiter.window_size
         reset_time: Final = now + window_size
-        reset_time_formatted: Final = datetime.fromtimestamp(reset_time).strftime("%Y-%m-%d %H:%M:%S UTC")
+        reset_time_formatted: Final = datetime.fromtimestamp(reset_time, tz=timezone.utc).strftime(
+            "%Y-%m-%d %H:%M:%S UTC"
+        )
 
         remaining_display: Final = max(0, status["limit_remaining"])
         current_limit: Final = status["current_limit"]

--- a/litellm/proxy/hooks/parallel_request_limiter_v3.py
+++ b/litellm/proxy/hooks/parallel_request_limiter_v3.py
@@ -12,7 +12,7 @@ import uuid
 from collections.abc import Awaitable, Callable, Mapping, Sequence, Set
 from contextvars import ContextVar
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -3054,7 +3054,9 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
 
                 now = self._get_current_time().timestamp()
                 reset_time = now + self.window_size
-                reset_time_formatted = datetime.fromtimestamp(reset_time).strftime("%Y-%m-%d %H:%M:%S UTC")
+                reset_time_formatted = datetime.fromtimestamp(reset_time, tz=timezone.utc).strftime(
+                    "%Y-%m-%d %H:%M:%S UTC"
+                )
 
                 remaining_display = max(0, status["limit_remaining"])
                 rate_limit_type = status["rate_limit_type"]

--- a/tests/test_litellm/proxy/hooks/test_rate_limit_reset_time.py
+++ b/tests/test_litellm/proxy/hooks/test_rate_limit_reset_time.py
@@ -1,0 +1,131 @@
+"""Regression tests for #39816: the 429 body labels its reset time UTC."""
+
+import os
+import sys
+import time
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../../.."))
+
+from litellm.proxy.hooks.batch_rate_limiter import BatchFileUsage, _PROXY_BatchRateLimiter
+from litellm.proxy.hooks.parallel_request_limiter_v3 import (
+    _PROXY_MaxParallelRequestsHandler_v3,
+)
+
+WINDOW_SIZE = 60
+FIXED_EPOCH = datetime(2026, 9, 4, 21, 53, 21, tzinfo=timezone.utc).timestamp()
+EXPECTED_RESET = "2026-09-04 21:54:21 UTC"
+
+needs_tzset = pytest.mark.skipif(
+    not hasattr(time, "tzset"), reason="switching the process timezone needs time.tzset(), absent on Windows"
+)
+
+
+@contextmanager
+def a_proxy_running_in(tz: str):
+    previous = os.environ.get("TZ")
+    os.environ["TZ"] = tz
+    time.tzset()
+    try:
+        yield
+    finally:
+        if previous is None:
+            del os.environ["TZ"]
+        else:
+            os.environ["TZ"] = previous
+        time.tzset()
+
+
+def _reset_time_reported_by(detail: str) -> str:
+    return detail.split("Limit resets at: ")[-1]
+
+
+def _over_limit_response():
+    return {
+        "overall_code": "OVER_LIMIT",
+        "statuses": [
+            {
+                "code": "OVER_LIMIT",
+                "descriptor_key": "api_key",
+                "limit_remaining": 0,
+                "rate_limit_type": "requests",
+                "current_limit": 2,
+            }
+        ],
+    }
+
+
+def _descriptors():
+    return [{"key": "api_key", "value": "sk-test", "rate_limit": None}]
+
+
+def _parallel_limiter():
+    limiter = _PROXY_MaxParallelRequestsHandler_v3(
+        internal_usage_cache=MagicMock(),
+        time_provider=lambda: datetime.fromtimestamp(FIXED_EPOCH),
+    )
+    limiter.window_size = WINDOW_SIZE
+    return limiter
+
+
+class TestParallelLimiterReportsUTC:
+    @needs_tzset
+    @pytest.mark.parametrize("tz", ["Asia/Kolkata", "Europe/Paris", "America/Los_Angeles"])
+    def test_a_non_utc_proxy_still_reports_utc(self, tz):
+        with a_proxy_running_in(tz):
+            limiter = _parallel_limiter()
+            with pytest.raises(Exception) as exc_info:
+                limiter._handle_rate_limit_error(
+                    response=_over_limit_response(),
+                    descriptors=_descriptors(),
+                    requested_model="gpt-4o-mini",
+                )
+
+        assert _reset_time_reported_by(str(exc_info.value)) == EXPECTED_RESET
+
+    def test_the_reset_time_is_one_window_ahead(self):
+        limiter = _parallel_limiter()
+        with pytest.raises(Exception) as exc_info:
+            limiter._handle_rate_limit_error(
+                response=_over_limit_response(),
+                descriptors=_descriptors(),
+                requested_model="gpt-4o-mini",
+            )
+
+        expected = datetime.fromtimestamp(FIXED_EPOCH + WINDOW_SIZE, tz=timezone.utc)
+        assert _reset_time_reported_by(str(exc_info.value)) == expected.strftime("%Y-%m-%d %H:%M:%S UTC")
+
+
+class TestBatchLimiterReportsUTC:
+    @needs_tzset
+    @pytest.mark.parametrize("tz", ["Asia/Kolkata", "America/Los_Angeles"])
+    def test_a_non_utc_proxy_still_reports_utc(self, tz):
+        parallel_request_limiter = MagicMock()
+        parallel_request_limiter.window_size = WINDOW_SIZE
+        limiter = _PROXY_BatchRateLimiter(
+            internal_usage_cache=MagicMock(),
+            parallel_request_limiter=parallel_request_limiter,
+        )
+
+        with a_proxy_running_in(tz):
+            before = datetime.now(timezone.utc)
+            with pytest.raises(Exception) as exc_info:
+                limiter._raise_rate_limit_error(
+                    status=_over_limit_response()["statuses"][0],
+                    descriptors=_descriptors(),
+                    batch_usage=BatchFileUsage(total_tokens=10, request_count=1),
+                    limit_type="requests",
+                    requested_model="gpt-4o-mini",
+                )
+            after = datetime.now(timezone.utc)
+
+        reported = _reset_time_reported_by(str(exc_info.value))
+        window = {
+            datetime.fromtimestamp(t.timestamp() + WINDOW_SIZE, tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+            for t in (before, after)
+        }
+        assert reported in window

--- a/tests/test_litellm/proxy/hooks/test_rate_limit_reset_time.py
+++ b/tests/test_litellm/proxy/hooks/test_rate_limit_reset_time.py
@@ -11,6 +11,7 @@ import pytest
 
 sys.path.insert(0, os.path.abspath("../../../.."))
 
+from litellm.proxy.common_utils.proxy_rate_limit_error import ProxyRateLimitError
 from litellm.proxy.hooks.batch_rate_limiter import BatchFileUsage, _PROXY_BatchRateLimiter
 from litellm.proxy.hooks.parallel_request_limiter_v3 import (
     _PROXY_MaxParallelRequestsHandler_v3,
@@ -78,7 +79,7 @@ class TestParallelLimiterReportsUTC:
     def test_a_non_utc_proxy_still_reports_utc(self, tz):
         with a_proxy_running_in(tz):
             limiter = _parallel_limiter()
-            with pytest.raises(Exception) as exc_info:
+            with pytest.raises(ProxyRateLimitError) as exc_info:
                 limiter._handle_rate_limit_error(
                     response=_over_limit_response(),
                     descriptors=_descriptors(),
@@ -89,7 +90,7 @@ class TestParallelLimiterReportsUTC:
 
     def test_the_reset_time_is_one_window_ahead(self):
         limiter = _parallel_limiter()
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(ProxyRateLimitError) as exc_info:
             limiter._handle_rate_limit_error(
                 response=_over_limit_response(),
                 descriptors=_descriptors(),
@@ -113,7 +114,7 @@ class TestBatchLimiterReportsUTC:
 
         with a_proxy_running_in(tz):
             before = datetime.now(timezone.utc)
-            with pytest.raises(Exception) as exc_info:
+            with pytest.raises(ProxyRateLimitError) as exc_info:
                 limiter._raise_rate_limit_error(
                     status=_over_limit_response()["statuses"][0],
                     descriptors=_descriptors(),

--- a/tests/test_litellm/proxy/hooks/test_rate_limit_reset_time.py
+++ b/tests/test_litellm/proxy/hooks/test_rate_limit_reset_time.py
@@ -1,15 +1,11 @@
 """Regression tests for #39816: the 429 body labels its reset time UTC."""
 
-import os
-import sys
 import time
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
 import pytest
-
-sys.path.insert(0, os.path.abspath("../../../.."))
 
 from litellm.proxy.common_utils.proxy_rate_limit_error import ProxyRateLimitError
 from litellm.proxy.hooks.batch_rate_limiter import BatchFileUsage, _PROXY_BatchRateLimiter
@@ -27,17 +23,13 @@ needs_tzset = pytest.mark.skipif(
 
 
 @contextmanager
-def a_proxy_running_in(tz: str):
-    previous = os.environ.get("TZ")
-    os.environ["TZ"] = tz
+def a_proxy_running_in(tz: str, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("TZ", tz)
     time.tzset()
     try:
         yield
     finally:
-        if previous is None:
-            del os.environ["TZ"]
-        else:
-            os.environ["TZ"] = previous
+        monkeypatch.undo()
         time.tzset()
 
 
@@ -76,8 +68,8 @@ def _parallel_limiter():
 class TestParallelLimiterReportsUTC:
     @needs_tzset
     @pytest.mark.parametrize("tz", ["Asia/Kolkata", "Europe/Paris", "America/Los_Angeles"])
-    def test_a_non_utc_proxy_still_reports_utc(self, tz):
-        with a_proxy_running_in(tz):
+    def test_a_non_utc_proxy_still_reports_utc(self, tz, monkeypatch):
+        with a_proxy_running_in(tz, monkeypatch):
             limiter = _parallel_limiter()
             with pytest.raises(ProxyRateLimitError) as exc_info:
                 limiter._handle_rate_limit_error(
@@ -104,7 +96,7 @@ class TestParallelLimiterReportsUTC:
 class TestBatchLimiterReportsUTC:
     @needs_tzset
     @pytest.mark.parametrize("tz", ["Asia/Kolkata", "America/Los_Angeles"])
-    def test_a_non_utc_proxy_still_reports_utc(self, tz):
+    def test_a_non_utc_proxy_still_reports_utc(self, tz, monkeypatch):
         parallel_request_limiter = MagicMock()
         parallel_request_limiter.window_size = WINDOW_SIZE
         limiter = _PROXY_BatchRateLimiter(
@@ -112,7 +104,7 @@ class TestBatchLimiterReportsUTC:
             parallel_request_limiter=parallel_request_limiter,
         )
 
-        with a_proxy_running_in(tz):
+        with a_proxy_running_in(tz, monkeypatch):
             before = datetime.now(timezone.utc)
             with pytest.raises(ProxyRateLimitError) as exc_info:
                 limiter._raise_rate_limit_error(


### PR DESCRIPTION
## TLDR

Problem this solves:

- The 429 body's reset time is local, labelled UTC
- A proxy on a non-UTC TZ is off by its offset
- Clients parsing that field back off for the wrong duration

How it solves it:

- Render the timestamp in UTC, matching the label

## User Flow

Before: a client on a proxy outside UTC reads the 429 body and waits hours instead of a minute

1. An operator runs the proxy in Paris (`TZ=Europe/Paris`, UTC+2) and issues a key with `rpm_limit: 2`
2. A client sends three POSTs to https://litellm-domain/v1/chat/completions inside one minute
3. The first two return 200, the third returns 429
4. The 429 body reads `Current limit: 2, Remaining: 0. Limit resets at: 2026-09-04 23:54:18 UTC`, but the request was sent at 21:53:21 UTC
5. A client that schedules its retry off that field sleeps about two hours, though the limit clears in a minute

After: the reset time in the body matches the clock it claims

1. Same proxy in Paris, same key with `rpm_limit: 2`
2. The client sends the same three POSTs
3. The first two return 200, the third returns 429
4. The 429 body now reads `Limit resets at: 2026-09-04 21:54:18 UTC`, one window after the request
5. A client scheduling off that field retries after a minute and succeeds

## Relevant issues

Fixes #39816

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## One note on the issue's pointers

The issue names `_handle_rate_limit_exceeded` at `parallel_request_limiter_v3.py:3018`. The method is `_handle_rate_limit_error` and the line is 3032 on current staging. The batch site and the diagnosis are both exactly as reported.

## Screenshots / Proof of Fix

I do not have a proxy deployment to bill against, and this failure needs no provider call: the wrong timestamp is built when the limiter refuses the request, before any model is reached. So the proof drives the real limiter and prints what the 429 body carries. My machine runs `Asia/Kolkata` (UTC+5:30), which stands in for the reporter's `Europe/Paris`.

Shared setup, `proof.py`:

```python
FIXED = datetime(2026, 9, 4, 21, 53, 21, tzinfo=timezone.utc).timestamp()

limiter = _PROXY_MaxParallelRequestsHandler_v3(
    internal_usage_cache=MagicMock(),
    time_provider=lambda: datetime.fromtimestamp(FIXED),
)
limiter.window_size = 60

limiter._handle_rate_limit_error(response=over_limit, descriptors=descriptors, requested_model="gpt-4o-mini")
```

### Before (98d46ee59d)

1. `python proof.py`
2. ```
   machine local tz  : India Standard Time
   true reset (UTC)  : 2026-09-04 21:54:21 UTC
   429 body says     : 2026-09-05 03:24:21 UTC
   ```
3. The body is 5h30m ahead, exactly the local offset, while claiming UTC

### After (f9b1caf8c1)

1. `python proof.py`
2. ```
   machine local tz  : India Standard Time
   true reset (UTC)  : 2026-09-04 21:54:21 UTC
   429 body says     : 2026-09-04 21:54:21 UTC
   ```
3. The body matches the label

For a reviewer with a live proxy, the end-to-end steps are the User Flow above: run the proxy under `TZ=Europe/Paris`, issue a key with `rpm_limit: 2`, send three chat completions inside a minute, and read the `Limit resets at:` field of the 429 against the time you sent the request.

## Type

🐛 Bug Fix

## QA runbook

- tests/test_litellm/proxy/hooks/test_rate_limit_reset_time.py::TestParallelLimiterReportsUTC::test_the_reset_time_is_one_window_ahead - the 429 body reports one window past the request, rendered in UTC
  - [ ] Run the proxy with a key limited to `rpm_limit: 2` on a host whose TZ is not UTC
  - [ ] Send three POSTs to /v1/chat/completions inside one minute and keep the 429 from the third
  - [ ] Expect its `Limit resets at:` to be the send time plus the window in UTC, not shifted by the host offset
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/test_litellm/proxy/hooks/test_rate_limit_reset_time.py::TestParallelLimiterReportsUTC::test_a_non_utc_proxy_still_reports_utc - the same body stays UTC across three host timezones
  - [ ] Repeat the run above under TZ=Asia/Kolkata, TZ=Europe/Paris, and TZ=America/Los_Angeles
  - [ ] Expect the same UTC reset time from all three, differing only by when you sent the request
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/test_litellm/proxy/hooks/test_rate_limit_reset_time.py::TestBatchLimiterReportsUTC::test_a_non_utc_proxy_still_reports_utc - the batch limiter's 429 carries the same UTC reset time
  - [ ] On a non-UTC host, submit batches past the key's limit until one is refused
  - [ ] Expect its `Limit resets at:` in UTC rather than the host's local clock
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

## Caveats (if any)

### Medium

- `prometheus_api.py:166` has the same defect, left out to keep scope isolated
  - It builds a local `isoformat()` and appends `+00:00`, so that field lies the same way
  - Happy to fold it in or file it separately, whichever you prefer

### Low

- The three timezone cases need `time.tzset()`, so they skip on Windows and run on CI
- On a UTC runner the offset tests cannot fail, so the window test carries the regression there
- The `retry-after` header was already correct, so only clients reading the body were affected

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
