### PR TITLE
test(base_utils): cover the empty-string branch of _text_blocks

### DIFF
--- a/tests/test_litellm/llms/base_llm/test_base_utils.py
+++ b/tests/test_litellm/llms/base_llm/test_base_utils.py
@@ -99,6 +99,17 @@ class TestHoistDeveloperMessagesIntoLeadingSystemMessage:
             )
         ) == [{"role": "system", "content": "Rules"}]
 
+    def test_empty_string_message_adds_no_block_when_the_run_merges_as_blocks(self):
+        messages = [
+            {"role": "system", "content": ""},
+            {"role": "developer", "content": [{"type": "text", "text": "Rules"}]},
+            {"role": "user", "content": "Hi"},
+        ]
+        assert list(hoist_developer_messages_into_leading_system_message(messages)) == [
+            {"role": "system", "content": [{"type": "text", "text": "Rules"}]},
+            {"role": "user", "content": "Hi"},
+        ]
+
     def test_two_cached_string_messages_keep_one_breakpoint_each(self):
         messages = [
             {"role": "system", "content": "A", "cache_control": {"type": "ephemeral", "ttl": "5m"}},


### PR DESCRIPTION
Follow-up for #39852 (the internal copy of #39282).

Codecov reported one uncovered line in `base_utils.py`: the empty-string branch of `_text_blocks`. The existing empty-string test only exercises the plain-text join, so this adds a case that merges an empty system message with a developer message carrying list content, which goes through the block path.

Earlier revision of this PR also merged `litellm_internal_staging` in to clear the conflict on #39852, but that can't come from a fork: the "Block fork dependency changes" check rejects any `uv.lock` diff, and the lint gate measures the whole staging delta against this branch's head. Dropped that part; the conflict is a single add/add on `tests/test_litellm/llms/openai/test_openai.py` (staging added the `get_stream_options` tests, this branch added the developer-role tests, both sets fit in one module) and needs to be resolved from the canonical repo. Until then the `pull_request` workflows won't run on #39852 because GitHub can't build a merge ref for a conflicting PR.