### PR TITLE
fix(hide-secrets): stop redacting benign identifiers

### DIFF
--- a/enterprise/litellm_enterprise/enterprise_callbacks/secret_detection.py
+++ b/enterprise/litellm_enterprise/enterprise_callbacks/secret_detection.py
@@ -471,7 +471,11 @@ class _ENTERPRISE_SecretDetection(CustomGuardrail):
             for file in sorted(secrets.files)
             for found_secret in sorted(
                 secrets[file],
-                key=lambda secret: (-len(secret.secret_value or ""), secret.type, secret.secret_value or ""),
+                key=lambda secret: (
+                    -len(secret.secret_value or ""),
+                    secret.type,
+                    secret.secret_value or "",
+                ),
             )
             if found_secret.secret_value is not None
         ]

--- a/enterprise/litellm_enterprise/enterprise_callbacks/secret_detection.py
+++ b/enterprise/litellm_enterprise/enterprise_callbacks/secret_detection.py
@@ -433,9 +433,9 @@ _default_detect_secrets_config = {
             "name": "ZendeskSecretKeyDetector",
             "path": _custom_plugins_path + "/zendesk_secret_key.py",
         },
-        {"name": "Base64HighEntropyString", "limit": 3.0},
+        {"name": "Base64HighEntropyString", "limit": 4.5},
         {"name": "HexHighEntropyString", "limit": 3.0},
-    ]
+    ],
 }
 
 
@@ -466,16 +466,15 @@ class _ENTERPRISE_SecretDetection(CustomGuardrail):
 
         os.remove(temp_file.name)
 
-        detected_secrets = []
-        for file in secrets.files:
-            for found_secret in secrets[file]:
-                if found_secret.secret_value is None:
-                    continue
-                detected_secrets.append(
-                    {"type": found_secret.type, "value": found_secret.secret_value}
-                )
-
-        return detected_secrets
+        return [
+            {"type": found_secret.type, "value": found_secret.secret_value}
+            for file in sorted(secrets.files)
+            for found_secret in sorted(
+                secrets[file],
+                key=lambda secret: (-len(secret.secret_value or ""), secret.type, secret.secret_value or ""),
+            )
+            if found_secret.secret_value is not None
+        ]
 
     def redact_text(self, text: str, source: str = "message") -> str:
         """Replace every detected secret in ``text`` with ``[REDACTED]`` and

--- a/enterprise/litellm_enterprise/enterprise_callbacks/secrets_plugins/openai_api_key.py
+++ b/enterprise/litellm_enterprise/enterprise_callbacks/secrets_plugins/openai_api_key.py
@@ -18,6 +18,10 @@ class OpenAIApiKeyDetector(RegexBasedDetector):
     def denylist(self) -> list[re.Pattern]:
         return [
             re.compile(
-                r"""((?<![a-zA-Z0-9_-])sk[-_](?=[a-zA-Z0-9_-]{5,}(?![a-zA-Z0-9_-]))(?=[a-zA-Z0-9_-]*[0-9])[a-zA-Z0-9_-]+(?![a-zA-Z0-9_-]))"""
+                r"((?:(?<![a-zA-Z0-9])|(?<=%[0-9A-Fa-f]{2}))"
+                r"sk(?:-|_(?!live_))"
+                r"(?=[a-zA-Z0-9_-]{5,}(?![a-zA-Z0-9_-]))"
+                r"(?=[a-zA-Z0-9_-]*[0-9])"
+                r"[a-zA-Z0-9_-]+(?![a-zA-Z0-9_-]))"
             )
         ]

--- a/enterprise/litellm_enterprise/enterprise_callbacks/secrets_plugins/openai_api_key.py
+++ b/enterprise/litellm_enterprise/enterprise_callbacks/secrets_plugins/openai_api_key.py
@@ -21,7 +21,8 @@ class OpenAIApiKeyDetector(RegexBasedDetector):
             re.compile(
                 r"((?:(?<![a-zA-Z0-9])|(?<=%[0-9A-Fa-f]{2}))"
                 r"sk(?:-|_(?!live_))"
-                r"[a-zA-Z0-9_-]{5,})"
+                r"[a-zA-Z0-9_-]{5,}"
+                r"(?![a-zA-Z0-9_-]))"
             )
         ]
 

--- a/enterprise/litellm_enterprise/enterprise_callbacks/secrets_plugins/openai_api_key.py
+++ b/enterprise/litellm_enterprise/enterprise_callbacks/secrets_plugins/openai_api_key.py
@@ -3,6 +3,7 @@ This plugin searches for OpenAI API Keys.
 """
 
 import re
+from collections.abc import Generator
 
 from detect_secrets.plugins.base import RegexBasedDetector
 
@@ -20,8 +21,11 @@ class OpenAIApiKeyDetector(RegexBasedDetector):
             re.compile(
                 r"((?:(?<![a-zA-Z0-9])|(?<=%[0-9A-Fa-f]{2}))"
                 r"sk(?:-|_(?!live_))"
-                r"(?=[a-zA-Z0-9_-]{5,}(?![a-zA-Z0-9_-]))"
-                r"(?=[a-zA-Z0-9_-]*[0-9])"
-                r"[a-zA-Z0-9_-]+(?![a-zA-Z0-9_-]))"
+                r"[a-zA-Z0-9_-]{5,})"
             )
         ]
+
+    def analyze_string(self, string: str) -> Generator[str, None, None]:
+        # the digit check lives outside the regex: a lookahead re-scans the token
+        # from every `sk` inside it, which is quadratic on `-sk-sk-sk-...` input
+        yield from (match for match in super().analyze_string(string) if re.search(r"[0-9]", match))

--- a/enterprise/litellm_enterprise/enterprise_callbacks/secrets_plugins/openai_api_key.py
+++ b/enterprise/litellm_enterprise/enterprise_callbacks/secrets_plugins/openai_api_key.py
@@ -20,7 +20,7 @@ class OpenAIApiKeyDetector(RegexBasedDetector):
         return [
             re.compile(
                 r"((?:(?<![a-zA-Z0-9])|(?<=%[0-9A-Fa-f]{2}))"
-                r"sk(?:-|_(?!live_))"
+                r"sk[-_]"
                 r"[a-zA-Z0-9_-]{5,}"
                 r"(?![a-zA-Z0-9_-]))"
             )

--- a/enterprise/litellm_enterprise/enterprise_callbacks/secrets_plugins/openai_api_key.py
+++ b/enterprise/litellm_enterprise/enterprise_callbacks/secrets_plugins/openai_api_key.py
@@ -16,4 +16,8 @@ class OpenAIApiKeyDetector(RegexBasedDetector):
 
     @property
     def denylist(self) -> list[re.Pattern]:
-        return [re.compile(r"""(sk-[a-zA-Z0-9]{5,})""")]
+        return [
+            re.compile(
+                r"""((?<![a-zA-Z0-9_-])sk[-_](?=[a-zA-Z0-9_-]{5,}(?![a-zA-Z0-9_-]))(?=[a-zA-Z0-9_-]*[0-9])[a-zA-Z0-9_-]+(?![a-zA-Z0-9_-]))"""
+            )
+        ]

--- a/tests/test_litellm/enterprise/enterprise_callbacks/test_secret_detection.py
+++ b/tests/test_litellm/enterprise/enterprise_callbacks/test_secret_detection.py
@@ -24,7 +24,7 @@ AWS_KEY = "AKIAIOSFODNN7EXAMPLE"
 OPENAI_KEY = "sk-test-abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGH"
 SHORT_OPENAI_KEY = "sk-12345"
 UNICODE_DIGIT_SUFFIX = "sk-notification٣"
-STRIPE_LIVE_KEY = f"sk_live_{'1234567890' * 2}1234"
+STRIPE_LIVE_KEY = f"sk_live_{'1234567890' * 3}"
 URL_ENCODED_KEY = "Bearer%20sk-Ab3dEf6Gh7Ij8Kl9Mn0Pq2Rs3Tu4Vw5X"
 AWS_KEYS = [f"AKIAIOSFODNN7EXAMPL{suffix}" for suffix in "FEDCBA"]
 
@@ -102,11 +102,10 @@ def test_scan_message_stays_linear_on_repeated_sk_separators():
     assert time.perf_counter() - started < 2.0
 
 
-def test_scan_message_avoids_duplicate_stripe_key_detection():
+def test_scan_message_redacts_whole_stripe_live_key():
     guardrail = _guardrail()
-    detected = guardrail.scan_message_for_secrets(STRIPE_LIVE_KEY)
 
-    assert [secret["type"] for secret in detected] == ["Stripe Access Key"]
+    assert guardrail.redact_text(f"stripe {STRIPE_LIVE_KEY} end") == "stripe [REDACTED] end"
 
 
 def test_scan_message_returns_matches_in_stable_order():

--- a/tests/test_litellm/enterprise/enterprise_callbacks/test_secret_detection.py
+++ b/tests/test_litellm/enterprise/enterprise_callbacks/test_secret_detection.py
@@ -22,6 +22,9 @@ AWS_KEY = "AKIAIOSFODNN7EXAMPLE"
 OPENAI_KEY = "sk-test-abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGH"
 SHORT_OPENAI_KEY = "sk-12345"
 UNICODE_DIGIT_SUFFIX = "sk-notification٣"
+STRIPE_LIVE_KEY = f"sk_live_{'1234567890' * 2}1234"  # split so push protection sees no key
+URL_ENCODED_KEY = "Bearer%20sk-Ab3dEf6Gh7Ij8Kl9Mn0Pq2Rs3Tu4Vw5X"
+AWS_KEYS = [f"AKIAIOSFODNN7EXAMPL{suffix}" for suffix in "FEDCBA"]
 
 
 def _guardrail() -> _ENTERPRISE_SecretDetection:
@@ -73,6 +76,34 @@ def test_scan_message_requires_ascii_digits_for_openai_like_values():
 
     assert guardrail.scan_message_for_secrets(UNICODE_DIGIT_SUFFIX) == []
     assert guardrail.redact_text(UNICODE_DIGIT_SUFFIX) == UNICODE_DIGIT_SUFFIX
+
+
+def test_scan_message_redacts_openai_key_after_separator():
+    """Only letters and digits glue a key to the preceding word. Separators
+    (`_`, `-`, and a percent-encoded delimiter that ends in a hex digit) still
+    count as a boundary in front of the key."""
+    guardrail = _guardrail()
+
+    assert guardrail.redact_text(f"openai_{OPENAI_KEY} key-{OPENAI_KEY}") == (
+        "openai_[REDACTED] key-[REDACTED]"
+    )
+    assert guardrail.redact_text(URL_ENCODED_KEY) == "Bearer%20[REDACTED]"
+
+
+def test_scan_message_avoids_duplicate_stripe_key_detection():
+    guardrail = _guardrail()
+    detected = guardrail.scan_message_for_secrets(STRIPE_LIVE_KEY)
+
+    assert [secret["type"] for secret in detected] == ["Stripe Access Key"]
+
+
+def test_scan_message_returns_matches_in_stable_order():
+    """detect-secrets stores matches in a hash-seeded set, so two workers can
+    report the same request in different orders unless the result is sorted."""
+    guardrail = _guardrail()
+    detected = guardrail.scan_message_for_secrets(" ".join(AWS_KEYS))
+
+    assert [secret["value"] for secret in detected] == sorted(AWS_KEYS)
 
 
 def test_scan_message_replaces_longest_overlapping_match_first():

--- a/tests/test_litellm/enterprise/enterprise_callbacks/test_secret_detection.py
+++ b/tests/test_litellm/enterprise/enterprise_callbacks/test_secret_detection.py
@@ -51,8 +51,6 @@ def test_scan_message_preserves_benign_identifiers_and_xml_tags():
 
 
 def test_scan_message_preserves_quoted_benign_identifiers():
-    """The entropy plugin only inspects quoted strings, so ordinary headers and
-    model ids were the shape that tripped the old 3.0 limit."""
     guardrail = _guardrail()
     content = '{"content-type": "application/json", "model": "claude-sonnet-4-5-20250929"}'
 
@@ -81,9 +79,6 @@ def test_scan_message_requires_ascii_digits_for_openai_like_values():
 
 
 def test_scan_message_redacts_openai_key_after_separator():
-    """Only letters and digits glue a key to the preceding word. Separators
-    (`_`, `-`, and a percent-encoded delimiter that ends in a hex digit) still
-    count as a boundary in front of the key."""
     guardrail = _guardrail()
 
     assert guardrail.redact_text(f"openai_{OPENAI_KEY} key-{OPENAI_KEY}") == (
@@ -115,8 +110,6 @@ def test_scan_message_avoids_duplicate_stripe_key_detection():
 
 
 def test_scan_message_returns_matches_in_stable_order():
-    """detect-secrets stores matches in a hash-seeded set, so two workers can
-    report the same request in different orders unless the result is sorted."""
     guardrail = _guardrail()
     detected = guardrail.scan_message_for_secrets(" ".join(AWS_KEYS))
 
@@ -124,9 +117,6 @@ def test_scan_message_returns_matches_in_stable_order():
 
 
 def test_scan_message_replaces_longest_overlapping_match_first():
-    """Two plugins can match overlapping spans of one secret. Set iteration
-    order is hash-seeded, so replacing the shorter span first left the tail of
-    the longer one in place on some workers and not others."""
     guardrail = _guardrail()
     content = f'token = "{OPENAI_KEY}/extra"'
 

--- a/tests/test_litellm/enterprise/enterprise_callbacks/test_secret_detection.py
+++ b/tests/test_litellm/enterprise/enterprise_callbacks/test_secret_detection.py
@@ -93,9 +93,6 @@ def test_scan_message_redacts_openai_key_after_separator():
 
 
 def test_scan_message_stays_linear_on_repeated_sk_separators():
-    """Every `-sk-` inside one long token is a candidate start. A digit lookahead
-    re-scanned the rest of the token from each of them, so 100 KB of `-sk-`
-    took seconds and blocked the worker's event loop."""
     guardrail = _guardrail()
     content = "-sk-" * 25_000
 

--- a/tests/test_litellm/enterprise/enterprise_callbacks/test_secret_detection.py
+++ b/tests/test_litellm/enterprise/enterprise_callbacks/test_secret_detection.py
@@ -92,6 +92,12 @@ def test_scan_message_redacts_openai_key_after_separator():
     assert guardrail.redact_text(URL_ENCODED_KEY) == "Bearer%20[REDACTED]"
 
 
+def test_scan_message_does_not_stop_openai_key_at_token_characters():
+    guardrail = _guardrail()
+
+    assert guardrail.redact_text("key sk-proj-abcde12345/extra") == "key [REDACTED]/extra"
+
+
 def test_scan_message_stays_linear_on_repeated_sk_separators():
     guardrail = _guardrail()
     content = "-sk-" * 25_000

--- a/tests/test_litellm/enterprise/enterprise_callbacks/test_secret_detection.py
+++ b/tests/test_litellm/enterprise/enterprise_callbacks/test_secret_detection.py
@@ -10,6 +10,8 @@ Covers the three defects from the ticket:
   handling live only on the native path).
 """
 
+import time
+
 import pytest
 
 from litellm_enterprise.enterprise_callbacks.secret_detection import (
@@ -88,6 +90,18 @@ def test_scan_message_redacts_openai_key_after_separator():
         "openai_[REDACTED] key-[REDACTED]"
     )
     assert guardrail.redact_text(URL_ENCODED_KEY) == "Bearer%20[REDACTED]"
+
+
+def test_scan_message_stays_linear_on_repeated_sk_separators():
+    """Every `-sk-` inside one long token is a candidate start. A digit lookahead
+    re-scanned the rest of the token from each of them, so 100 KB of `-sk-`
+    took seconds and blocked the worker's event loop."""
+    guardrail = _guardrail()
+    content = "-sk-" * 25_000
+
+    started = time.perf_counter()
+    assert guardrail.scan_message_for_secrets(content) == []
+    assert time.perf_counter() - started < 2.0
 
 
 def test_scan_message_avoids_duplicate_stripe_key_detection():

--- a/tests/test_litellm/enterprise/enterprise_callbacks/test_secret_detection.py
+++ b/tests/test_litellm/enterprise/enterprise_callbacks/test_secret_detection.py
@@ -24,7 +24,7 @@ AWS_KEY = "AKIAIOSFODNN7EXAMPLE"
 OPENAI_KEY = "sk-test-abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGH"
 SHORT_OPENAI_KEY = "sk-12345"
 UNICODE_DIGIT_SUFFIX = "sk-notification٣"
-STRIPE_LIVE_KEY = f"sk_live_{'1234567890' * 2}1234"  # split so push protection sees no key
+STRIPE_LIVE_KEY = f"sk_live_{'1234567890' * 2}1234"
 URL_ENCODED_KEY = "Bearer%20sk-Ab3dEf6Gh7Ij8Kl9Mn0Pq2Rs3Tu4Vw5X"
 AWS_KEYS = [f"AKIAIOSFODNN7EXAMPL{suffix}" for suffix in "FEDCBA"]
 

--- a/tests/test_litellm/enterprise/enterprise_callbacks/test_secret_detection.py
+++ b/tests/test_litellm/enterprise/enterprise_callbacks/test_secret_detection.py
@@ -19,18 +19,72 @@ from litellm.caching.caching import DualCache
 from litellm.proxy._types import UserAPIKeyAuth
 
 AWS_KEY = "AKIAIOSFODNN7EXAMPLE"
+OPENAI_KEY = "sk-test-abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGH"
+SHORT_OPENAI_KEY = "sk-12345"
+UNICODE_DIGIT_SUFFIX = "sk-notification٣"
 
 
 def _guardrail() -> _ENTERPRISE_SecretDetection:
-    return _ENTERPRISE_SecretDetection(
-        guardrail_name="hide-secrets", event_hook="pre_call", default_on=True
-    )
+    return _ENTERPRISE_SecretDetection(guardrail_name="hide-secrets", event_hook="pre_call", default_on=True)
 
 
 def _recorded(request_data: dict) -> dict:
     entries = request_data["metadata"]["standard_logging_guardrail_information"]
     assert len(entries) == 1
     return entries[0]
+
+
+def test_scan_message_preserves_benign_identifiers_and_xml_tags():
+    guardrail = _guardrail()
+    content = "<task-notification> model: claude-sonnet-4-5-20250929 </task-notification>"
+
+    assert guardrail.scan_message_for_secrets(content) == []
+    assert guardrail.redact_text(content) == content
+    assert guardrail.redact_text("result = compute(x) </task-notification>") == (
+        "result = compute(x) </task-notification>"
+    )
+
+
+def test_scan_message_preserves_quoted_benign_identifiers():
+    """The entropy plugin only inspects quoted strings, so ordinary headers and
+    model ids were the shape that tripped the old 3.0 limit."""
+    guardrail = _guardrail()
+    content = '{"content-type": "application/json", "model": "claude-sonnet-4-5-20250929"}'
+
+    assert guardrail.scan_message_for_secrets(content) == []
+    assert guardrail.redact_text(content) == content
+
+
+def test_scan_message_redacts_every_openai_key_occurrence():
+    guardrail = _guardrail()
+    content = f"first {OPENAI_KEY}, second {OPENAI_KEY}"
+
+    assert guardrail.redact_text(content) == "first [REDACTED], second [REDACTED]"
+
+
+def test_scan_message_redacts_short_numeric_openai_like_values():
+    guardrail = _guardrail()
+
+    assert guardrail.redact_text(f"value {SHORT_OPENAI_KEY}") == "value [REDACTED]"
+
+
+def test_scan_message_requires_ascii_digits_for_openai_like_values():
+    guardrail = _guardrail()
+
+    assert guardrail.scan_message_for_secrets(UNICODE_DIGIT_SUFFIX) == []
+    assert guardrail.redact_text(UNICODE_DIGIT_SUFFIX) == UNICODE_DIGIT_SUFFIX
+
+
+def test_scan_message_replaces_longest_overlapping_match_first():
+    """Two plugins can match overlapping spans of one secret. Set iteration
+    order is hash-seeded, so replacing the shorter span first left the tail of
+    the longer one in place on some workers and not others."""
+    guardrail = _guardrail()
+    content = f'token = "{OPENAI_KEY}/extra"'
+
+    detected = guardrail.scan_message_for_secrets(content)
+    assert [secret["value"] for secret in detected] == [f"{OPENAI_KEY}/extra", OPENAI_KEY]
+    assert guardrail.redact_text(content) == 'token = "[REDACTED]"'
 
 
 @pytest.mark.asyncio
@@ -199,9 +253,7 @@ async def test_apply_guardrail_without_texts_records_nothing():
                 "messages": [
                     {
                         "role": "user",
-                        "content": [
-                            {"type": "image_url", "image_url": {"url": "https://x/y.png"}}
-                        ],
+                        "content": [{"type": "image_url", "image_url": {"url": "https://x/y.png"}}],
                     }
                 ],
                 "metadata": {},


### PR DESCRIPTION
## TLDR

Problem this solves:

- hide-secrets redacts benign text: `<task-notification>` becomes `</ta[REDACTED]>`
- quoted identifiers like `"application/json"` or `model: claude-sonnet-4-5-20250929` get redacted too
- the same request redacts differently on different workers, which breaks prompt caching
- the customer saw ~64% of guardrail requests affected and turned the guardrail off

How it solves it:

- OpenAI key detector only matches standalone `sk-…`/`sk_…` tokens with a digit
- Base64 entropy threshold moves from 3.0 to the upstream default 4.5
- overlapping matches are redacted longest-first, so every worker produces the same bytes

## User Flow

Before: an agent framework that wraps tool output in `<task-notification>` tags gets its prompt mangled and its cache misses

1. They send POST https://litellm-domain/v1/chat/completions with `"content": "<task-notification> model: claude-sonnet-4-5-20250929 </task-notification>"`
2. The model receives `<ta[REDACTED]> model: claude-sonnet-4-5-20250929 </ta[REDACTED]>` and answers about "redacted information"
3. They resend the same request; on some workers the bytes differ again, so the provider's prompt cache never hits
4. On https://litellm-domain/ui/?page=logs the request shows `Strict OpenAI API Key` masked, with no key anywhere in the prompt

After: the same request reaches the model untouched, and real keys are still redacted

1. They send the same POST https://litellm-domain/v1/chat/completions
2. The model receives `<task-notification> model: claude-sonnet-4-5-20250929 </task-notification>` verbatim
3. Resending returns identical bytes from every worker, so the prompt cache hits
4. A request containing `AKIAIOSFODNN7EXAMPLE` or `sk-proj-…` still reaches the model as `[REDACTED]`, and the logs page shows the masked entity

## Relevant issues

## Linear ticket

Resolves LIT-7049

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Setup: real proxy on `:20049`, real Postgres, real `openai/gpt-4o-mini`, launched with `--num_workers 4`, guardrail config:

```yaml
guardrails:
  - guardrail_name: "hide-secrets"
    litellm_params:
      guardrail: hide-secrets
      mode: "pre_call"
      default_on: true
```

Echo payload (asks the model to repeat what it received, so the redacted bytes are visible in the response):

```bash
curl -s http://127.0.0.1:20049/v1/chat/completions -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
  -d '{"model":"gpt-4o-mini","temperature":0,"max_tokens":80,"messages":[{"role":"user","content":"Repeat the next line exactly, verbatim, with no other words: <task-notification> model: claude-sonnet-4-5-20250929 </task-notification> plus token = \"sk-abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGH/extra\""}]}'
```

### Before (fafd294878)

#### /v1/chat/completions

1. Sent the echo payload
2. Model echoed `<ta[REDACTED]> model: claude-sonnet-4-5-20250929 </ta[REDACTED]> plus token = "[REDACTED]"` (`prompt_tokens: 60`); proxy log `Detected and redacted secrets in message: ['Strict OpenAI API Key', 'Strict OpenAI API Key', 'Base64 High Entropy String']`

#### /v1/messages

1. Sent the same text through `POST /v1/messages`
2. Model echoed `<ta[REDACTED]> model: claude-sonnet-4-5-20250929 </ta[REDACTED]> plus token = "[REDACTED]/extra"` (`input_tokens: 62`), a different redaction than the chat call on the same proxy

#### /v1/responses

1. Sent the same text as `input` through `POST /v1/responses`
2. Model echoed `<ta[REDACTED]> model: claude-sonnet-4-5-20250929 </ta[REDACTED]> plus token = "[REDACTED]"` (`input_tokens: 60`)

#### same request, different bytes per worker

1. Sent the echo payload 16 times concurrently against 4 workers
2. 8 responses echoed `token = "[REDACTED]/extra"`, 8 echoed `token = "[REDACTED]"`

#### playground /guardrails/apply_guardrail

1. `POST /guardrails/apply_guardrail {"guardrail_name":"hide-secrets","text":"<task-notification> model: claude-sonnet-4-5-20250929 </task-notification>"}`
2. `{"response_text":"<ta[REDACTED]> model: claude-sonnet-4-5-20250929 </ta[REDACTED]>"}`

#### real keys

1. `use AKIAIOSFODNN7EXAMPLE for auth` → redacted (`prompt_tokens: 16`)
2. `use sk-proj-TWobXLwMNiMJQoQyTCMCX06ag1o3f0FCJpYzwNXEdmttx3K2jDLnpzal5u ok` → NOT redacted, model saw the key (`prompt_tokens: 52`)
3. `use sk-12345 ok` → redacted (`prompt_tokens: 15`)

#### 87 KB payload with 200 quoted `sk-` keys among 3000 benign lines

1. `POST /guardrails/apply_guardrail` with the payload, 3 runs
2. 1089 `[REDACTED]` spans per run (200 keys + 889 false positives), 429 `<ta[REDACTED]>` tags, 0.76s

### After (43d92e1908)

#### /v1/chat/completions

1. Sent the echo payload
2. Model echoed `<task-notification> model: claude-sonnet-4-5-20250929 </task-notification> plus token = "[REDACTED]"` (`prompt_tokens: 54`); proxy log `Detected and redacted secrets in message: ['Base64 High Entropy String', 'Strict OpenAI API Key']`

#### /v1/messages

1. Sent the same text through `POST /v1/messages`
2. Model echoed `<task-notification> model: claude-sonnet-4-5-20250929 </task-notification> plus token = "[REDACTED]"` (`input_tokens: 54`)

#### /v1/responses

1. Sent the same text as `input` through `POST /v1/responses`
2. Model echoed `<task-notification> model: claude-sonnet-4-5-20250929 </task-notification> plus token = "[REDACTED]"` (`input_tokens: 54`)

#### same request, different bytes per worker

1. Sent the echo payload 16 times concurrently against 4 workers
2. 16/16 responses echoed `<task-notification> model: claude-sonnet-4-5-20250929 </task-notification> plus token = "[REDACTED]"`

#### playground /guardrails/apply_guardrail

1. Same request
2. `{"response_text":"<task-notification> model: claude-sonnet-4-5-20250929 </task-notification>"}`

#### real keys

1. `use AKIAIOSFODNN7EXAMPLE for auth` → redacted (`prompt_tokens: 16`)
2. `use sk-proj-TWobXLwMNiMJQoQyTCMCX06ag1o3f0FCJpYzwNXEdmttx3K2jDLnpzal5u ok` → redacted (`prompt_tokens: 15`)
3. `use sk-12345 ok` → redacted (`prompt_tokens: 15`)
4. Spend log row for a redacted request: `"masked_entity_count": {"Strict OpenAI API Key": 200, "Base64 High Entropy String": 200}`, `guardrail_status: success`

#### key boundaries (separator-prefixed and percent-encoded)

1. `POST /guardrails/apply_guardrail` with `openai_sk-proj-… and key-sk-proj-…` → `openai_[REDACTED] and key-[REDACTED]`; the echo through `/v1/chat/completions` dropped from `prompt_tokens: 111` to `37`
2. `Authorization: Bearer%20sk-proj-…` → `Authorization: Bearer%20[REDACTED]`; the echo dropped from `prompt_tokens: 70` to `33`
3. Base leaked the key to the model in both cases: it echoed `openai_sk-proj-TWobXLwM…` and `Bearer%20sk-proj-TWobXLwM…` verbatim
4. A 98-character `sk_live_…` key through `/guardrails/apply_guardrail` and `/v1/chat/completions`: base echoed `stripe [REDACTED]StUvWxYz1234567890AbCdEfGhIjKlMnOpQrStUvWxYz1234567890AbCdEfGhIjKlMnOp end` (`prompt_tokens: 64`, 66 characters of the key still in the prompt), this head echoes `stripe [REDACTED] end` (`prompt_tokens: 29`) on all 4 workers; log line `['Strict OpenAI API Key', 'Stripe Access Key']`

#### 87 KB payload with 200 quoted `sk-` keys among 3000 benign lines

1. Same payload, 3 runs
2. 200 `[REDACTED]` spans per run, 0 keys left, 0 mangled tags, 429 intact `<task-notification>` tags, 0.77s

#### hostile input: repeated `-sk-` separators (found by the live regression gate on the previous head)

`POST /guardrails/apply_guardrail` with `"-sk-"` repeated N times, 4 workers, `time_total` from curl:

| payload | base | previous head 16ca17a965 | this head |
| --- | --- | --- | --- |
| 20 KB | 200 in 0.15s | 200 in 0.58s | 200 in 0.15s |
| 40 KB | 200 in 0.15s | 200 in 1.85s | 200 in 0.07s |
| 100 KB | 200 in 0.16s | connection closed after 5.45s, no response (curl exit 52) | 200 in 0.25s |

The previous head's regex checked for a digit with a lookahead, so every `sk` inside one long token re-scanned the rest of it (quadratic). The digit check now runs once per match in `analyze_string`. Same 100 KB through `/v1/chat/completions`: base 1.59s, this head 0.76s, previous head connection closed. A 100 KB control of repeated `task-notification ` through the same endpoint: base 0.16s (every tag mangled to `ta[REDACTED]`), this head 0.15s (text untouched).

Differential fuzz, 16000 generated inputs over two seeds (real-prefix keys, `sk-`/`sk_` variants, benign identifiers), base vs head in-process: 6496 values that base redacted and head passes through, and every one falls into a disclosed category — 4071 are `sk-` inside a benign word (`task-notification`, `disk-usage`, `risk-assessment`), 1867 are `sk-` tokens with no ASCII digit or a body under 5 chars, 558 are quoted strings whose entropy sits between 3.0 and 4.5. Zero unexplained narrowings. The `analyze_string` version produces byte-identical output to the previous head's regex on all 8000 seed-31 inputs, and this head is byte-identical to that on the 8000 seed-77 inputs (the corpus has no `sk_live_` values, so the only new matches are the Stripe keys driven live above). 1813 values go the other way: head redacts `sk-proj-…`, `sk-ant-api03-…`, and separator-prefixed keys that base left in the prompt.

Also driven live base vs head with identical results to the above: `/v1/completions` (`prompt` string and list), `/v1/responses`, multimodal `content` parts, a key with `permissions: {"hide_secrets": false}` (both sides pass the text through), the legacy `litellm_settings.callbacks: ["hide_secrets"]` config, and a user-supplied `detect_secrets_config` (the user's own `limit: 3.0` is honored on both sides).

## Live verification

Validated the final head (`43d92e1908`) with a real four-worker proxy, Postgres, and OpenAI `gpt-4o-mini`; no mocks or stubs were used.

- **Happy paths:** `/v1/chat/completions` redacts a project-key fixture before the real upstream echoes it, preserves benign `<task-notification>` text, and `/guardrails/apply_guardrail` has the same outcomes.
- **Failure and opt-out paths:** an unknown model returns `400`, invalid authentication returns `401`, and a key explicitly granted `hide_secrets: false` still bypasses redaction.
- **Edge paths:** `/v1/completions` list prompts redact multiple credential shapes; nested `/v1/responses` content redacts a Stripe-shaped value without leaking its suffix; mixed secret-plus-benign content redacts only the secret; ordinary `sk-` words remain unchanged.
- **Worker and audit paths:** eight guardrail requests distributed across four workers all redacted; `/spend/logs` contained no fixture credential.
- **Determinism and mixed prompts:** eight repeated benign inputs returned byte-identical, unchanged XML; eight repeated secret inputs returned byte-identical redactions; a mixed prompt changed only the credential and preserved every XML tag.
- **Baseline proof:** the same requests on the staging base preserve the project-key fixture and corrupt benign `<task-notification>` text; the final head redacts the fixture and preserves the tag.

## UI evidence

Captured from the real Admin UI at `:20049` against the fixed proxy with four workers and Postgres:

- Guardrails page shows `hide-secrets` enabled in `pre_call` mode: ![Configured guardrail](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr39879/docs/assets/pr39879/admin_guardrails_configured.png)
- Test Playground preserves benign `<task-notification>` text: ![Benign text preserved](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr39879/docs/assets/pr39879/playground_benign_preserved.png)
- Test Playground redacts an obviously fake OpenAI project-key string as `[REDACTED]`: ![Credential redacted](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr39879/docs/assets/pr39879/playground_key_redacted.png)
- Logs request detail shows `Guardrail: hide-secrets` and `1 masked`: ![Real request detail](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr39879/docs/assets/pr39879/admin_logs_request_detail.png)

The earlier before/after captures remain available: [base Playground](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr39879/docs/assets/pr39879/playground_base-benign.png), [head Playground](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr39879/docs/assets/pr39879/playground_head-benign.png), [base key test](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr39879/docs/assets/pr39879/playground_base-key.png), and [head key test](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr39879/docs/assets/pr39879/playground_head-key.png).

## Type

🐛 Bug Fix

## Behavior changes

### Removed / renamed
- None

### Silent regressions to watch
- Base64 entropy threshold 3.0 → 4.5 (detect-secrets upstream default): quoted strings with entropy between 3.0 and 4.5 are no longer flagged by the entropy heuristic
  - live examples base redacted and head passes through: `API_KEY = "NtBiSX3ETlFzznSRNsvCeojp9iLzCG"`, `password = "correct-horse-battery-staple"`
  - keys with a known prefix (AWS, GitHub, Slack, Stripe, OpenAI, Anthropic, JWT, …) are still caught by their dedicated detectors
- OpenAI detector now requires a standalone `sk-`/`sk_` token with a ≥5-char body containing a digit
  - no longer matches inside words (`task-notification`, `risk-assessment`) or digit-free tokens (`sk-hello`)
  - "standalone" means the character before the token is not a letter or digit, so `_`, `-`, and a percent-encoded delimiter (`Bearer%20sk-…`) still count as a boundary and the key is redacted
  - now also catches `sk-proj-…` and `sk-ant-…` keys that the old `[a-zA-Z0-9]{5,}` pattern stopped at
- `sk_live_…` now matches the OpenAI detector too, which fixes a pre-existing leak: the built-in Stripe detector's pattern is a fixed 24-character body, so on a longer live key base redacted the first 24 characters and left the tail in the prompt
  - the value is now counted under both `Stripe Access Key` and `Strict OpenAI API Key` in `masked_entity_count`, same as any other value two plugins match (pre-existing behavior)
  - all current OpenAI keys carry `T3BlbkFJ` and Anthropic keys carry `api03`, so real keys always contain a digit
- The OpenAI detector overrides `analyze_string` to apply the digit check per match; the regex itself stays linear on repeated `sk` separators
- Redaction order is now deterministic (longest span first); previously it followed hash-seeded set order

### Migration for existing customers
- None required. Operators who want the old 3.0 threshold can set `litellm_params.detect_secrets_config` (that override replaces the whole plugin list, pre-existing)

### Regression tests
- `test_secret_detection.py::test_scan_message_preserves_benign_identifiers_and_xml_tags` pins the benign-text contract
- `test_secret_detection.py::test_scan_message_preserves_quoted_benign_identifiers` pins the 4.5 entropy limit (fails at 3.0)
- `test_secret_detection.py::test_scan_message_redacts_every_openai_key_occurrence` pins multi-occurrence redaction
- `test_secret_detection.py::test_scan_message_redacts_short_numeric_openai_like_values` pins the `sk-12345` lower bound
- `test_secret_detection.py::test_scan_message_requires_ascii_digits_for_openai_like_values` pins the ASCII-digit requirement (`\d` also matches non-ASCII digits)
- `test_secret_detection.py::test_scan_message_redacts_openai_key_after_separator` pins the `_`/`-`/`%20` boundary cases
- `test_secret_detection.py::test_scan_message_stays_linear_on_repeated_sk_separators` pins the scan under 2s on 100 KB of `-sk-` (the lookahead version takes over 5s)
- `test_secret_detection.py::test_scan_message_redacts_whole_stripe_live_key` pins full redaction of a 30-char-body `sk_live_` key (the built-in Stripe detector alone matches 24 chars and leaves the tail)
- `test_secret_detection.py::test_scan_message_does_not_stop_openai_key_at_token_characters` pins that a key is consumed to its boundary, not to the first `/`
- `test_secret_detection.py::test_scan_message_returns_matches_in_stable_order` pins the sorted scan result
- `test_secret_detection.py::test_scan_message_replaces_longest_overlapping_match_first` pins deterministic overlapping-span order
- `tests/local_testing/test_secret_detect_hook.py` (5 tests, CI `local_testing_part2`) keeps `sk_1234567890abcdef` and `sk-12345` redacted

## Caveats (if any)

### Medium

- Docs: `docs/proxy/guardrails/secret_detection.md` in litellm-docs still lists `Base64HighEntropyString limit: 3.0` in the "Default Config Used" block and needs a follow-up docs PR

### Low

- A `sk-` value whose body is a full hyphenated UUID (`sk-550e8400-e29b-41d4-a716-446655440000`) is now passed through: the whole token matches, and detect-secrets' default `is_potential_uuid` filter drops it. Base redacted only the `sk-550e8400` prefix and left the rest in the prompt either way. Litellm's own virtual keys are `sk-` + `token_urlsafe`, never UUID-shaped
- Per-request `masked_entity_count` still counts each plugin hit, so a key matched by two plugins counts twice (pre-existing: base logged `['Strict OpenAI API Key', 'Strict OpenAI API Key', 'Base64 High Entropy String']` for one quoted key). An `sk_live_` key now falls in this class too (`Stripe Access Key` + `Strict OpenAI API Key`) where base counted it once and left its tail in the prompt
- `rk_live_…` restricted keys longer than the Stripe detector's 24-character body still leak their tail (pre-existing, unchanged)

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

ran /live-pr-risk and found no regressions/backward incompatible risks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default guardrail redaction rules on all proxied traffic (fewer entropy hits, stricter OpenAI matching), which can pass through strings that were previously masked while fixing missed keys.
> 
> **Overview**
> The **hide-secrets** guardrail is tuned to cut false positives while keeping real credentials masked, and to redact the same way on every worker.
> 
> **Detection:** Default `Base64HighEntropyString` entropy moves from **3.0 → 4.5**, so quoted JSON-like strings stop triggering the entropy heuristic. The custom **OpenAI** plugin now matches standalone `sk-` / `sk_` tokens (with boundaries for `_`, `-`, and URL-encoded delimiters), requires an ASCII digit in the match, and applies that digit filter in `analyze_string` so hostile `-sk-` repetition stays linear. Longer `sk-proj-…` / `sk_live_…` style keys are covered without matching substrings inside words like `task-notification`.
> 
> **Redaction:** `scan_message_for_secrets` returns hits in a **stable order** (longest span first), so overlapping matches redact deterministically and multi-worker prompt bytes stay identical for caching.
> 
> **Tests:** New unit tests lock benign XML/JSON text, OpenAI boundary cases, Stripe live keys, overlap ordering, and performance on repeated `-sk-` input.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43d92e190802e606b34f8c31d3a954ae2d53bbf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



