### PR TITLE
fix(azure_sentinel): split batches under the 1MB ingestion cap

### DIFF
--- a/litellm/integrations/azure_sentinel/azure_sentinel.py
+++ b/litellm/integrations/azure_sentinel/azure_sentinel.py
@@ -335,7 +335,7 @@ class AzureSentinelLogger(CustomBatchLogger):
             Raises a NON Blocking verbose_logger.exception if an error occurs
         """
         batch_to_send: Final = tuple(self.log_queue)
-        self.log_queue = []
+        self.log_queue = []  # mutable-ok: queue ownership is detached before the async send
         try:
             undelivered: Final = await self._async_send_batch_to_api(
                 log_queue=batch_to_send,
@@ -358,7 +358,7 @@ class AzureSentinelLogger(CustomBatchLogger):
         Sends the batch of audit logs to Azure Monitor Logs Ingestion API
         """
         batch_to_send: Final = tuple(self.audit_log_queue)
-        self.audit_log_queue = []
+        self.audit_log_queue = []  # mutable-ok: queue ownership is detached before the async send
         try:
             undelivered: Final = await self._async_send_batch_to_api(
                 log_queue=batch_to_send,
@@ -382,7 +382,7 @@ class AzureSentinelLogger(CustomBatchLogger):
         queue: list[_QueuedPayload],
         log_type: str,
     ) -> list[_QueuedPayload]:
-        merged: Final = [*undelivered, *queue]
+        merged: Final = [*undelivered, *queue]  # mutable-ok: queue trimming returns a mutable logger queue
         overflow: Final = len(merged) - self.max_queue_size
         if overflow <= 0:
             return merged

--- a/litellm/integrations/azure_sentinel/azure_sentinel.py
+++ b/litellm/integrations/azure_sentinel/azure_sentinel.py
@@ -436,6 +436,7 @@ class AzureSentinelLogger(CustomBatchLogger):
             success_status_codes=frozenset({200, 204}),
             integration_name="Azure Sentinel",
             drop_error_message="Azure Sentinel API Error - Payload too large for a single record",
+            non_success_handler=undelivered_after_http_error,
         )
 
     async def flush_queue(self):

--- a/litellm/integrations/azure_sentinel/azure_sentinel.py
+++ b/litellm/integrations/azure_sentinel/azure_sentinel.py
@@ -16,22 +16,26 @@ import asyncio
 import os
 import time
 import traceback
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from types import MappingProxyType
-from typing import Final
+from typing import Final, TypeVar
 from urllib.parse import urlparse
 
 from litellm._logging import verbose_logger
+from litellm.integrations.batch_utils import send_batch_with_413_split
 from litellm.integrations.custom_batch_logger import CustomBatchLogger
 from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 from litellm.llms.custom_httpx.http_handler import (
     get_async_httpx_client,
     httpxSpecialProvider,
 )
+from litellm.types.integrations.azure_sentinel import AZURE_SENTINEL_MAX_PAYLOAD_SIZE_BYTES
 from litellm.types.utils import StandardAuditLogPayload, StandardLoggingPayload
 
 DEFAULT_AZURE_AUTHORITY_HOST: Final = "https://login.microsoftonline.com"
 DEFAULT_AZURE_MONITOR_SCOPE: Final = "https://monitor.azure.com/.default"
+
+_QueuedPayload = TypeVar("_QueuedPayload", StandardLoggingPayload, StandardAuditLogPayload)
 
 MONITOR_SCOPE_BY_AUTHORITY_HOST: Final[Mapping[str, str]] = MappingProxyType(
     {
@@ -311,67 +315,82 @@ class AzureSentinelLogger(CustomBatchLogger):
         Raises:
             Raises a NON Blocking verbose_logger.exception if an error occurs
         """
-        await self._async_send_batch_to_api(
-            log_queue=self.log_queue,
+        batch_to_send: Final = tuple(self.log_queue)
+        self.log_queue.clear()
+        undelivered: Final = await self._async_send_batch_to_api(
+            log_queue=batch_to_send,
             api_endpoint=self.api_endpoint,
             log_type="logs",
         )
+        if undelivered:
+            self.log_queue = list(undelivered) + self.log_queue
+            self._drop_oldest_over_max_queue_size(self.log_queue, "logs")
 
     async def async_send_audit_batch(self):
         """
         Sends the batch of audit logs to Azure Monitor Logs Ingestion API
         """
-        await self._async_send_batch_to_api(
-            log_queue=self.audit_log_queue,
+        batch_to_send: Final = tuple(self.audit_log_queue)
+        self.audit_log_queue.clear()
+        undelivered: Final = await self._async_send_batch_to_api(
+            log_queue=batch_to_send,
             api_endpoint=self.audit_api_endpoint,
             log_type="audit logs",
+        )
+        if undelivered:
+            self.audit_log_queue = list(undelivered) + self.audit_log_queue
+            self._drop_oldest_over_max_queue_size(self.audit_log_queue, "audit logs")
+
+    def _drop_oldest_over_max_queue_size(self, queue: list[_QueuedPayload], log_type: str) -> None:
+        overflow: Final = len(queue) - self.max_queue_size
+        if overflow <= 0:
+            return
+
+        del queue[:overflow]  # rebind-ok: keeps the retry queue bounded while the destination is unreachable
+        verbose_logger.warning(
+            "Azure Sentinel: %s queue exceeded max_queue_size=%s, dropped %s oldest records",
+            log_type,
+            self.max_queue_size,
+            overflow,
         )
 
     async def _async_send_batch_to_api(
         self,
-        log_queue: list[StandardLoggingPayload | StandardAuditLogPayload],
+        log_queue: tuple[_QueuedPayload, ...],
         api_endpoint: str,
         log_type: str,
-    ) -> None:
+    ) -> tuple[_QueuedPayload, ...]:
+        if not log_queue:
+            return ()
+
+        verbose_logger.debug("Azure Sentinel - about to flush %s %s", len(log_queue), log_type)
         try:
-            if not log_queue:
-                return
-
-            verbose_logger.debug("Azure Sentinel - about to flush %s %s", len(log_queue), log_type)
-
-            # Get OAuth2 token
             bearer_token: Final = await self._get_oauth_token()
+        except Exception as e:
+            verbose_logger.exception("Azure Sentinel Error getting OAuth token - %s", e)
+            return tuple(log_queue)
 
-            # Convert log queue to JSON array format expected by Logs Ingestion API
-            # Each log entry should be a JSON object in the array
-            body: Final = safe_dumps(log_queue)
+        headers: Final = {
+            "Authorization": f"Bearer {bearer_token}",
+            "Content-Type": "application/json",
+        }
 
-            # Set headers for Logs Ingestion API
-            headers: Final = {
-                "Authorization": f"Bearer {bearer_token}",
-                "Content-Type": "application/json",
-            }
-
-            # Send the request
-            response = await self.async_httpx_client.post(url=api_endpoint, data=body.encode("utf-8"), headers=headers)
-
-            if response.status_code not in [200, 204]:
-                verbose_logger.error(
-                    "Azure Sentinel API error: status_code=%s, response=%s",
-                    response.status_code,
-                    response.text,
-                )
-                raise Exception(f"Failed to send logs to Azure Sentinel: {response.status_code} - {response.text}")
-
-            verbose_logger.debug(
-                "Azure Sentinel: Response from API status_code: %s",
-                response.status_code,
+        async def _send_batch(batch: Sequence[_QueuedPayload]):
+            body: Final = safe_dumps(batch)
+            return await self.async_httpx_client.post(
+                url=api_endpoint,
+                data=body.encode("utf-8"),
+                headers=headers,
             )
 
-        except Exception as e:
-            verbose_logger.exception("Azure Sentinel Error sending batch API - %s\n%s", e, traceback.format_exc())
-        finally:
-            log_queue.clear()
+        return await send_batch_with_413_split(
+            batch=log_queue,
+            send_batch=_send_batch,
+            exceeds_limits=lambda batch: len(safe_dumps(batch).encode("utf-8")) > AZURE_SENTINEL_MAX_PAYLOAD_SIZE_BYTES,
+            success_status_codes=frozenset({200, 204}),
+            integration_name="Azure Sentinel",
+            drop_error_message="Azure Sentinel API Error - Payload too large for a single record",
+        )
 
     async def flush_queue(self):
         if self.flush_lock is None:

--- a/litellm/integrations/azure_sentinel/azure_sentinel.py
+++ b/litellm/integrations/azure_sentinel/azure_sentinel.py
@@ -252,7 +252,7 @@ class AzureSentinelLogger(CustomBatchLogger):
             self.log_queue.append(standard_logging_payload)
 
             if len(self.log_queue) >= self.batch_size and not self.logs_awaiting_retry:
-                await self.flush_queue()
+                await self._threshold_send_logs()
 
         except Exception as e:
             verbose_logger.exception("Azure Sentinel Layer Error - %s\n%s", e, traceback.format_exc())
@@ -282,7 +282,7 @@ class AzureSentinelLogger(CustomBatchLogger):
             self.log_queue.append(standard_logging_payload)
 
             if len(self.log_queue) >= self.batch_size and not self.logs_awaiting_retry:
-                await self.flush_queue()
+                await self._threshold_send_logs()
 
         except Exception as e:
             verbose_logger.exception("Azure Sentinel Layer Error - %s\n%s", e, traceback.format_exc())
@@ -305,10 +305,22 @@ class AzureSentinelLogger(CustomBatchLogger):
             self.audit_log_queue.append(audit_log)
 
             if len(self.audit_log_queue) >= self.batch_size and not self.audit_logs_awaiting_retry:
-                await self.flush_queue()
+                await self._threshold_send_audit_logs()
 
         except Exception as e:
             verbose_logger.exception("Azure Sentinel Audit Log Layer Error - %s\n%s", e, traceback.format_exc())
+
+    async def _threshold_send_logs(self) -> None:
+        async with self.flush_lock:
+            if self.logs_awaiting_retry or len(self.log_queue) < self.batch_size:
+                return
+            await self.async_send_batch()
+
+    async def _threshold_send_audit_logs(self) -> None:
+        async with self.flush_lock:
+            if self.audit_logs_awaiting_retry or len(self.audit_log_queue) < self.batch_size:
+                return
+            await self.async_send_audit_batch()
 
     async def async_send_batch(self):
         """

--- a/litellm/integrations/azure_sentinel/azure_sentinel.py
+++ b/litellm/integrations/azure_sentinel/azure_sentinel.py
@@ -157,6 +157,8 @@ class AzureSentinelLogger(CustomBatchLogger):
         asyncio.create_task(self.periodic_flush())
         self.log_queue: list[StandardLoggingPayload] = []
         self.audit_log_queue: list[StandardAuditLogPayload] = []
+        self.logs_awaiting_retry = False
+        self.audit_logs_awaiting_retry = False
 
     @staticmethod
     def _normalize_authority_host(authority_host: str) -> str:
@@ -249,8 +251,8 @@ class AzureSentinelLogger(CustomBatchLogger):
 
             self.log_queue.append(standard_logging_payload)
 
-            if len(self.log_queue) >= self.batch_size:
-                await self.async_send_batch()
+            if len(self.log_queue) >= self.batch_size and not self.logs_awaiting_retry:
+                await self.flush_queue()
 
         except Exception as e:
             verbose_logger.exception("Azure Sentinel Layer Error - %s\n%s", e, traceback.format_exc())
@@ -279,8 +281,8 @@ class AzureSentinelLogger(CustomBatchLogger):
 
             self.log_queue.append(standard_logging_payload)
 
-            if len(self.log_queue) >= self.batch_size:
-                await self.async_send_batch()
+            if len(self.log_queue) >= self.batch_size and not self.logs_awaiting_retry:
+                await self.flush_queue()
 
         except Exception as e:
             verbose_logger.exception("Azure Sentinel Layer Error - %s\n%s", e, traceback.format_exc())
@@ -302,8 +304,8 @@ class AzureSentinelLogger(CustomBatchLogger):
 
             self.audit_log_queue.append(audit_log)
 
-            if len(self.audit_log_queue) >= self.batch_size:
-                await self.async_send_audit_batch()
+            if len(self.audit_log_queue) >= self.batch_size and not self.audit_logs_awaiting_retry:
+                await self.flush_queue()
 
         except Exception as e:
             verbose_logger.exception("Azure Sentinel Audit Log Layer Error - %s\n%s", e, traceback.format_exc())
@@ -316,43 +318,47 @@ class AzureSentinelLogger(CustomBatchLogger):
             Raises a NON Blocking verbose_logger.exception if an error occurs
         """
         batch_to_send: Final = tuple(self.log_queue)
-        self.log_queue.clear()
+        self.log_queue = []
         undelivered: Final = await self._async_send_batch_to_api(
             log_queue=batch_to_send,
             api_endpoint=self.api_endpoint,
             log_type="logs",
         )
-        if undelivered:
-            self.log_queue = list(undelivered) + self.log_queue
-            self._drop_oldest_over_max_queue_size(self.log_queue, "logs")
+        self.logs_awaiting_retry = bool(undelivered)
+        self.log_queue = self._requeue(undelivered, self.log_queue, "logs")
 
     async def async_send_audit_batch(self):
         """
         Sends the batch of audit logs to Azure Monitor Logs Ingestion API
         """
         batch_to_send: Final = tuple(self.audit_log_queue)
-        self.audit_log_queue.clear()
+        self.audit_log_queue = []
         undelivered: Final = await self._async_send_batch_to_api(
             log_queue=batch_to_send,
             api_endpoint=self.audit_api_endpoint,
             log_type="audit logs",
         )
-        if undelivered:
-            self.audit_log_queue = list(undelivered) + self.audit_log_queue
-            self._drop_oldest_over_max_queue_size(self.audit_log_queue, "audit logs")
+        self.audit_logs_awaiting_retry = bool(undelivered)
+        self.audit_log_queue = self._requeue(undelivered, self.audit_log_queue, "audit logs")
 
-    def _drop_oldest_over_max_queue_size(self, queue: list[_QueuedPayload], log_type: str) -> None:
-        overflow: Final = len(queue) - self.max_queue_size
+    def _requeue(
+        self,
+        undelivered: tuple[_QueuedPayload, ...],
+        queue: list[_QueuedPayload],
+        log_type: str,
+    ) -> list[_QueuedPayload]:
+        merged: Final = [*undelivered, *queue]
+        overflow: Final = len(merged) - self.max_queue_size
         if overflow <= 0:
-            return
+            return merged
 
-        del queue[:overflow]  # rebind-ok: keeps the retry queue bounded while the destination is unreachable
         verbose_logger.warning(
             "Azure Sentinel: %s queue exceeded max_queue_size=%s, dropped %s oldest records",
             log_type,
             self.max_queue_size,
             overflow,
         )
+        return merged[overflow:]
 
     async def _async_send_batch_to_api(
         self,

--- a/litellm/integrations/azure_sentinel/azure_sentinel.py
+++ b/litellm/integrations/azure_sentinel/azure_sentinel.py
@@ -22,10 +22,15 @@ from typing import Final, TypeVar
 from urllib.parse import urlparse
 
 from litellm._logging import verbose_logger
-from litellm.integrations.batch_utils import BatchSendCancelled, send_batch_with_413_split
+from litellm.integrations.batch_utils import (
+    BatchSendCancelled,
+    send_batch_with_413_split,
+    undelivered_after_http_error,
+)
 from litellm.integrations.custom_batch_logger import CustomBatchLogger
 from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 from litellm.llms.custom_httpx.http_handler import (
+    MaskedHTTPStatusError,
     get_async_httpx_client,
     httpxSpecialProvider,
 )
@@ -338,15 +343,15 @@ class AzureSentinelLogger(CustomBatchLogger):
                 log_type="logs",
             )
         except BatchSendCancelled as cancelled:
-            self.logs_awaiting_retry = True
             self.log_queue = self._requeue(cancelled.undelivered, self.log_queue, "logs")
-            raise
+            self.logs_awaiting_retry = bool(self.log_queue)
+            raise asyncio.CancelledError() from cancelled
         except asyncio.CancelledError:
-            self.logs_awaiting_retry = True
             self.log_queue = self._requeue(batch_to_send, self.log_queue, "logs")
+            self.logs_awaiting_retry = bool(self.log_queue)
             raise
-        self.logs_awaiting_retry = bool(undelivered)
         self.log_queue = self._requeue(undelivered, self.log_queue, "logs")
+        self.logs_awaiting_retry = bool(undelivered) and bool(self.log_queue)
 
     async def async_send_audit_batch(self):
         """
@@ -361,15 +366,15 @@ class AzureSentinelLogger(CustomBatchLogger):
                 log_type="audit logs",
             )
         except BatchSendCancelled as cancelled:
-            self.audit_logs_awaiting_retry = True
             self.audit_log_queue = self._requeue(cancelled.undelivered, self.audit_log_queue, "audit logs")
-            raise
+            self.audit_logs_awaiting_retry = bool(self.audit_log_queue)
+            raise asyncio.CancelledError() from cancelled
         except asyncio.CancelledError:
-            self.audit_logs_awaiting_retry = True
             self.audit_log_queue = self._requeue(batch_to_send, self.audit_log_queue, "audit logs")
+            self.audit_logs_awaiting_retry = bool(self.audit_log_queue)
             raise
-        self.audit_logs_awaiting_retry = bool(undelivered)
         self.audit_log_queue = self._requeue(undelivered, self.audit_log_queue, "audit logs")
+        self.audit_logs_awaiting_retry = bool(undelivered) and bool(self.audit_log_queue)
 
     def _requeue(
         self,
@@ -402,6 +407,8 @@ class AzureSentinelLogger(CustomBatchLogger):
         verbose_logger.debug("Azure Sentinel - about to flush %s %s", len(log_queue), log_type)
         try:
             bearer_token: Final = await self._get_oauth_token()
+        except MaskedHTTPStatusError as e:
+            return undelivered_after_http_error(log_queue, e.status_code, "Azure Sentinel OAuth token", str(e))
         except Exception as e:
             verbose_logger.exception("Azure Sentinel Error getting OAuth token - %s", e)
             return tuple(log_queue)
@@ -422,7 +429,10 @@ class AzureSentinelLogger(CustomBatchLogger):
         return await send_batch_with_413_split(
             batch=log_queue,
             send_batch=_send_batch,
-            exceeds_limits=lambda batch: len(safe_dumps(batch).encode("utf-8")) > AZURE_SENTINEL_MAX_PAYLOAD_SIZE_BYTES,
+            exceeds_limits=lambda batch: (
+                len(batch) > self.batch_size
+                or len(safe_dumps(batch).encode("utf-8")) > AZURE_SENTINEL_MAX_PAYLOAD_SIZE_BYTES
+            ),
             success_status_codes=frozenset({200, 204}),
             integration_name="Azure Sentinel",
             drop_error_message="Azure Sentinel API Error - Payload too large for a single record",

--- a/litellm/integrations/azure_sentinel/azure_sentinel.py
+++ b/litellm/integrations/azure_sentinel/azure_sentinel.py
@@ -331,11 +331,16 @@ class AzureSentinelLogger(CustomBatchLogger):
         """
         batch_to_send: Final = tuple(self.log_queue)
         self.log_queue = []
-        undelivered: Final = await self._async_send_batch_to_api(
-            log_queue=batch_to_send,
-            api_endpoint=self.api_endpoint,
-            log_type="logs",
-        )
+        try:
+            undelivered: Final = await self._async_send_batch_to_api(
+                log_queue=batch_to_send,
+                api_endpoint=self.api_endpoint,
+                log_type="logs",
+            )
+        except asyncio.CancelledError:
+            self.logs_awaiting_retry = True
+            self.log_queue = self._requeue(batch_to_send, self.log_queue, "logs")
+            raise
         self.logs_awaiting_retry = bool(undelivered)
         self.log_queue = self._requeue(undelivered, self.log_queue, "logs")
 
@@ -345,11 +350,16 @@ class AzureSentinelLogger(CustomBatchLogger):
         """
         batch_to_send: Final = tuple(self.audit_log_queue)
         self.audit_log_queue = []
-        undelivered: Final = await self._async_send_batch_to_api(
-            log_queue=batch_to_send,
-            api_endpoint=self.audit_api_endpoint,
-            log_type="audit logs",
-        )
+        try:
+            undelivered: Final = await self._async_send_batch_to_api(
+                log_queue=batch_to_send,
+                api_endpoint=self.audit_api_endpoint,
+                log_type="audit logs",
+            )
+        except asyncio.CancelledError:
+            self.audit_logs_awaiting_retry = True
+            self.audit_log_queue = self._requeue(batch_to_send, self.audit_log_queue, "audit logs")
+            raise
         self.audit_logs_awaiting_retry = bool(undelivered)
         self.audit_log_queue = self._requeue(undelivered, self.audit_log_queue, "audit logs")
 

--- a/litellm/integrations/azure_sentinel/azure_sentinel.py
+++ b/litellm/integrations/azure_sentinel/azure_sentinel.py
@@ -22,7 +22,7 @@ from typing import Final, TypeVar
 from urllib.parse import urlparse
 
 from litellm._logging import verbose_logger
-from litellm.integrations.batch_utils import send_batch_with_413_split
+from litellm.integrations.batch_utils import BatchSendCancelled, send_batch_with_413_split
 from litellm.integrations.custom_batch_logger import CustomBatchLogger
 from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 from litellm.llms.custom_httpx.http_handler import (
@@ -337,6 +337,10 @@ class AzureSentinelLogger(CustomBatchLogger):
                 api_endpoint=self.api_endpoint,
                 log_type="logs",
             )
+        except BatchSendCancelled as cancelled:
+            self.logs_awaiting_retry = True
+            self.log_queue = self._requeue(cancelled.undelivered, self.log_queue, "logs")
+            raise
         except asyncio.CancelledError:
             self.logs_awaiting_retry = True
             self.log_queue = self._requeue(batch_to_send, self.log_queue, "logs")
@@ -356,6 +360,10 @@ class AzureSentinelLogger(CustomBatchLogger):
                 api_endpoint=self.audit_api_endpoint,
                 log_type="audit logs",
             )
+        except BatchSendCancelled as cancelled:
+            self.audit_logs_awaiting_retry = True
+            self.audit_log_queue = self._requeue(cancelled.undelivered, self.audit_log_queue, "audit logs")
+            raise
         except asyncio.CancelledError:
             self.audit_logs_awaiting_retry = True
             self.audit_log_queue = self._requeue(batch_to_send, self.audit_log_queue, "audit logs")

--- a/litellm/integrations/batch_utils.py
+++ b/litellm/integrations/batch_utils.py
@@ -1,5 +1,6 @@
+import asyncio
 from collections.abc import Awaitable, Callable, Sequence
-from typing import Final, TypeVar
+from typing import Final, Generic, TypeVar
 
 import httpx
 
@@ -7,6 +8,28 @@ from litellm._logging import verbose_logger
 from litellm.llms.custom_httpx.http_handler import MaskedHTTPStatusError
 
 _BatchItem = TypeVar("_BatchItem")
+
+
+class BatchSendCancelled(asyncio.CancelledError, Generic[_BatchItem]):
+    """Cancellation of a batch send, carrying only the records the destination never accepted.
+
+    A batch split under the size cap is delivered in pieces, so requeueing all of it after a
+    cancellation partway through would send the accepted pieces a second time.
+    """
+
+    def __init__(self, undelivered: tuple[_BatchItem, ...]) -> None:
+        super().__init__()
+        self.undelivered: Final = undelivered
+
+
+async def _keep_the_remainder_on_cancel(
+    send: Awaitable[tuple[_BatchItem, ...]],
+    remainder: Sequence[_BatchItem],
+) -> tuple[_BatchItem, ...]:
+    try:
+        return await send
+    except BatchSendCancelled as cancelled:
+        raise BatchSendCancelled((*cancelled.undelivered, *remainder)) from cancelled
 
 
 async def send_batch_with_413_split(
@@ -19,18 +42,23 @@ async def send_batch_with_413_split(
 ) -> tuple[_BatchItem, ...]:
     async def _halve() -> tuple[_BatchItem, ...]:
         midpoint: Final = len(batch) // 2
-        left_undelivered: Final = await send_batch_with_413_split(
-            batch=batch[:midpoint],
-            send_batch=send_batch,
-            exceeds_limits=exceeds_limits,
-            success_status_codes=success_status_codes,
-            integration_name=integration_name,
-            drop_error_message=drop_error_message,
+        left_batch: Final = batch[:midpoint]
+        right_batch: Final = batch[midpoint:]
+        left_undelivered: Final = await _keep_the_remainder_on_cancel(
+            send_batch_with_413_split(
+                batch=left_batch,
+                send_batch=send_batch,
+                exceeds_limits=exceeds_limits,
+                success_status_codes=success_status_codes,
+                integration_name=integration_name,
+                drop_error_message=drop_error_message,
+            ),
+            right_batch,
         )
         if left_undelivered:
-            return left_undelivered + tuple(batch[midpoint:])
+            return (*left_undelivered, *right_batch)
         return await send_batch_with_413_split(
-            batch=batch[midpoint:],
+            batch=right_batch,
             send_batch=send_batch,
             exceeds_limits=exceeds_limits,
             success_status_codes=success_status_codes,
@@ -64,6 +92,8 @@ async def send_batch_with_413_split(
             return await _handle_413()
         verbose_logger.exception("%s Error sending batch API - %s", integration_name, e)
         return tuple(batch)
+    except asyncio.CancelledError as cancelled:
+        raise BatchSendCancelled(tuple(batch)) from cancelled
     except Exception as e:
         verbose_logger.exception("%s Error sending batch API - %s", integration_name, e)
         return tuple(batch)

--- a/litellm/integrations/batch_utils.py
+++ b/litellm/integrations/batch_utils.py
@@ -90,7 +90,7 @@ async def send_batch_with_413_split(
     drop_error_message: str,
     non_success_handler: Callable[
         [Sequence[_BatchItem], int, str, str], tuple[_BatchItem, ...]
-    ] = undelivered_after_http_error,
+    ] = requeue_after_http_error,
 ) -> tuple[_BatchItem, ...]:
     async def _halve() -> tuple[_BatchItem, ...]:
         midpoint: Final = len(batch) // 2

--- a/litellm/integrations/batch_utils.py
+++ b/litellm/integrations/batch_utils.py
@@ -9,6 +9,39 @@ from litellm.llms.custom_httpx.http_handler import MaskedHTTPStatusError
 
 _BatchItem = TypeVar("_BatchItem")
 
+_RETRYABLE_CLIENT_STATUS_CODES: Final = frozenset({408, 429})
+
+
+def is_retryable_status(status_code: int) -> bool:
+    return not 400 <= status_code < 500 or status_code in _RETRYABLE_CLIENT_STATUS_CODES
+
+
+def undelivered_after_http_error(
+    batch: Sequence[_BatchItem],
+    status_code: int,
+    integration_name: str,
+    detail: str,
+) -> tuple[_BatchItem, ...]:
+    """The records to requeue after a non-2xx: all of them on a status a retry can clear, none on
+    a 4xx that would only repeat, since retaining those retries a misconfiguration forever."""
+    if is_retryable_status(status_code):
+        verbose_logger.error(
+            "%s API error: status_code=%s, will retry %s records - %s",
+            integration_name,
+            status_code,
+            len(batch),
+            detail,
+        )
+        return tuple(batch)
+    verbose_logger.error(
+        "%s API error: status_code=%s is not retryable, dropped %s records - %s",
+        integration_name,
+        status_code,
+        len(batch),
+        detail,
+    )
+    return ()
+
 
 class BatchSendCancelled(asyncio.CancelledError, Generic[_BatchItem]):
     """Cancellation of a batch send, carrying only the records the destination never accepted.
@@ -77,7 +110,7 @@ async def send_batch_with_413_split(
 
     try:
         oversized: Final = exceeds_limits(batch)
-    except (TypeError, ValueError) as e:
+    except Exception as e:  # noqa: BLE001  # any record that cannot be serialized is isolated and dropped alone
         if len(batch) > 1:
             return await _halve()
         verbose_logger.exception("%s dropped a record that cannot be serialized - %s", integration_name, e)
@@ -90,8 +123,7 @@ async def send_batch_with_413_split(
     except MaskedHTTPStatusError as e:
         if e.status_code == 413:
             return await _handle_413()
-        verbose_logger.exception("%s Error sending batch API - %s", integration_name, e)
-        return tuple(batch)
+        return undelivered_after_http_error(batch, e.status_code, integration_name, str(e))
     except asyncio.CancelledError as cancelled:
         raise BatchSendCancelled(tuple(batch)) from cancelled
     except Exception as e:
@@ -101,13 +133,7 @@ async def send_batch_with_413_split(
     if response.status_code == 413:
         return await _handle_413()
     if response.status_code not in success_status_codes:
-        verbose_logger.error(
-            "%s API error: status_code=%s, response=%s",
-            integration_name,
-            response.status_code,
-            response.text,
-        )
-        return tuple(batch)
+        return undelivered_after_http_error(batch, response.status_code, integration_name, response.text)
 
     verbose_logger.debug("%s delivered %s records, status_code=%s", integration_name, len(batch), response.status_code)
     return ()

--- a/litellm/integrations/batch_utils.py
+++ b/litellm/integrations/batch_utils.py
@@ -43,6 +43,22 @@ def undelivered_after_http_error(
     return ()
 
 
+def requeue_after_http_error(
+    batch: Sequence[_BatchItem],
+    status_code: int,
+    integration_name: str,
+    detail: str,
+) -> tuple[_BatchItem, ...]:
+    verbose_logger.error(
+        "%s API error: status_code=%s, will retry %s records - %s",
+        integration_name,
+        status_code,
+        len(batch),
+        detail,
+    )
+    return tuple(batch)
+
+
 class BatchSendCancelled(asyncio.CancelledError, Generic[_BatchItem]):
     """Cancellation of a batch send, carrying only the records the destination never accepted.
 
@@ -72,6 +88,9 @@ async def send_batch_with_413_split(
     success_status_codes: frozenset[int],
     integration_name: str,
     drop_error_message: str,
+    non_success_handler: Callable[
+        [Sequence[_BatchItem], int, str, str], tuple[_BatchItem, ...]
+    ] = undelivered_after_http_error,
 ) -> tuple[_BatchItem, ...]:
     async def _halve() -> tuple[_BatchItem, ...]:
         midpoint: Final = len(batch) // 2
@@ -85,6 +104,7 @@ async def send_batch_with_413_split(
                 success_status_codes=success_status_codes,
                 integration_name=integration_name,
                 drop_error_message=drop_error_message,
+                non_success_handler=non_success_handler,
             ),
             right_batch,
         )
@@ -97,6 +117,7 @@ async def send_batch_with_413_split(
             success_status_codes=success_status_codes,
             integration_name=integration_name,
             drop_error_message=drop_error_message,
+            non_success_handler=non_success_handler,
         )
 
     async def _handle_413() -> tuple[_BatchItem, ...]:
@@ -123,7 +144,7 @@ async def send_batch_with_413_split(
     except MaskedHTTPStatusError as e:
         if e.status_code == 413:
             return await _handle_413()
-        return undelivered_after_http_error(batch, e.status_code, integration_name, str(e))
+        return non_success_handler(batch, e.status_code, integration_name, str(e))
     except asyncio.CancelledError as cancelled:
         raise BatchSendCancelled(tuple(batch)) from cancelled
     except Exception as e:
@@ -133,7 +154,7 @@ async def send_batch_with_413_split(
     if response.status_code == 413:
         return await _handle_413()
     if response.status_code not in success_status_codes:
-        return undelivered_after_http_error(batch, response.status_code, integration_name, response.text)
+        return non_success_handler(batch, response.status_code, integration_name, response.text)
 
     verbose_logger.debug("%s delivered %s records, status_code=%s", integration_name, len(batch), response.status_code)
     return ()

--- a/litellm/integrations/batch_utils.py
+++ b/litellm/integrations/batch_utils.py
@@ -17,11 +17,7 @@ async def send_batch_with_413_split(
     integration_name: str,
     drop_error_message: str,
 ) -> tuple[_BatchItem, ...]:
-    async def _handle_413() -> tuple[_BatchItem, ...]:
-        if len(batch) == 1:
-            verbose_logger.error(drop_error_message)
-            return ()
-
+    async def _halve() -> tuple[_BatchItem, ...]:
         midpoint: Final = len(batch) // 2
         left_undelivered: Final = await send_batch_with_413_split(
             batch=batch[:midpoint],
@@ -42,10 +38,24 @@ async def send_batch_with_413_split(
             drop_error_message=drop_error_message,
         )
 
+    async def _handle_413() -> tuple[_BatchItem, ...]:
+        if len(batch) == 1:
+            verbose_logger.error(drop_error_message)
+            return ()
+        return await _halve()
+
     if not batch:
         return ()
-    if len(batch) > 1 and exceeds_limits(batch):
-        return await _handle_413()
+
+    try:
+        oversized: Final = exceeds_limits(batch)
+    except (TypeError, ValueError) as e:
+        if len(batch) > 1:
+            return await _halve()
+        verbose_logger.exception("%s dropped a record that cannot be serialized - %s", integration_name, e)
+        return ()
+    if oversized and len(batch) > 1:
+        return await _halve()
 
     try:
         response: Final = await send_batch(batch)

--- a/litellm/integrations/batch_utils.py
+++ b/litellm/integrations/batch_utils.py
@@ -1,0 +1,73 @@
+from collections.abc import Awaitable, Callable, Sequence
+from typing import Final, TypeVar
+
+import httpx
+
+from litellm._logging import verbose_logger
+from litellm.llms.custom_httpx.http_handler import MaskedHTTPStatusError
+
+_BatchItem = TypeVar("_BatchItem")
+
+
+async def send_batch_with_413_split(
+    batch: Sequence[_BatchItem],
+    send_batch: Callable[[Sequence[_BatchItem]], Awaitable[httpx.Response]],
+    exceeds_limits: Callable[[Sequence[_BatchItem]], bool],
+    success_status_codes: frozenset[int],
+    integration_name: str,
+    drop_error_message: str,
+) -> tuple[_BatchItem, ...]:
+    async def _handle_413() -> tuple[_BatchItem, ...]:
+        if len(batch) == 1:
+            verbose_logger.error(drop_error_message)
+            return ()
+
+        midpoint: Final = len(batch) // 2
+        left_undelivered: Final = await send_batch_with_413_split(
+            batch=batch[:midpoint],
+            send_batch=send_batch,
+            exceeds_limits=exceeds_limits,
+            success_status_codes=success_status_codes,
+            integration_name=integration_name,
+            drop_error_message=drop_error_message,
+        )
+        if left_undelivered:
+            return left_undelivered + tuple(batch[midpoint:])
+        return await send_batch_with_413_split(
+            batch=batch[midpoint:],
+            send_batch=send_batch,
+            exceeds_limits=exceeds_limits,
+            success_status_codes=success_status_codes,
+            integration_name=integration_name,
+            drop_error_message=drop_error_message,
+        )
+
+    if not batch:
+        return ()
+    if len(batch) > 1 and exceeds_limits(batch):
+        return await _handle_413()
+
+    try:
+        response: Final = await send_batch(batch)
+    except MaskedHTTPStatusError as e:
+        if e.status_code == 413:
+            return await _handle_413()
+        verbose_logger.exception("%s Error sending batch API - %s", integration_name, e)
+        return tuple(batch)
+    except Exception as e:
+        verbose_logger.exception("%s Error sending batch API - %s", integration_name, e)
+        return tuple(batch)
+
+    if response.status_code == 413:
+        return await _handle_413()
+    if response.status_code not in success_status_codes:
+        verbose_logger.error(
+            "%s API error: status_code=%s, response=%s",
+            integration_name,
+            response.status_code,
+            response.text,
+        )
+        return tuple(batch)
+
+    verbose_logger.debug("%s delivered %s records, status_code=%s", integration_name, len(batch), response.status_code)
+    return ()

--- a/litellm/integrations/datadog/datadog.py
+++ b/litellm/integrations/datadog/datadog.py
@@ -415,7 +415,7 @@ class DataDogLogger(
         """
         undelivered: Final = await send_batch_with_413_split(
             batch=batch,
-            send_batch=lambda chunk: self.async_send_compressed_data(list(chunk)),
+            send_batch=self.async_send_compressed_data,
             exceeds_limits=self._exceeds_intake_limits,
             success_status_codes=frozenset({202}),
             integration_name="Datadog",
@@ -568,7 +568,7 @@ class DataDogLogger(
         )
         return dd_payload
 
-    async def async_send_compressed_data(self, data: list) -> Response:
+    async def async_send_compressed_data(self, data: Sequence[DatadogPayload]) -> Response:
         """
         Async helper to send compressed data to datadog self.intake_url
 

--- a/litellm/integrations/datadog/datadog.py
+++ b/litellm/integrations/datadog/datadog.py
@@ -29,7 +29,7 @@ from typing_extensions import ReadOnly, TypedDict
 import litellm
 from litellm._logging import verbose_logger
 from litellm._uuid import uuid
-from litellm.integrations.batch_utils import send_batch_with_413_split
+from litellm.integrations.batch_utils import BatchSendCancelled, send_batch_with_413_split
 from litellm.integrations.custom_batch_logger import CustomBatchLogger
 from litellm.integrations.datadog.datadog_handler import (
     get_datadog_base_url_from_env,
@@ -396,6 +396,9 @@ class DataDogLogger(
             if self.is_mock_mode:
                 verbose_logger.debug("[DATADOG MOCK] Batch of %s events successfully mocked", len(batch_to_send))
 
+        except BatchSendCancelled as cancelled:
+            self.log_queue = list(cancelled.undelivered) + self.log_queue
+            raise asyncio.CancelledError() from cancelled
         except Exception as e:
             self.log_queue = batch_to_send + self.log_queue
             verbose_logger.exception("Datadog Error sending batch API - %s\n%s", e, traceback.format_exc())

--- a/litellm/integrations/datadog/datadog.py
+++ b/litellm/integrations/datadog/datadog.py
@@ -29,6 +29,7 @@ from typing_extensions import ReadOnly, TypedDict
 import litellm
 from litellm._logging import verbose_logger
 from litellm._uuid import uuid
+from litellm.integrations.batch_utils import send_batch_with_413_split
 from litellm.integrations.custom_batch_logger import CustomBatchLogger
 from litellm.integrations.datadog.datadog_handler import (
     get_datadog_base_url_from_env,
@@ -43,7 +44,6 @@ from litellm.integrations.datadog.datadog_mock_client import (
 )
 from litellm.litellm_core_utils.dd_tracing import tracer
 from litellm.llms.custom_httpx.http_handler import (
-    MaskedHTTPStatusError,
     _get_httpx_client,
     get_async_httpx_client,
     httpxSpecialProvider,
@@ -413,53 +413,15 @@ class DataDogLogger(
         that could not be delivered because of a non-413 (transient) error, so the caller
         re-queues only those and never the events already accepted by Datadog.
         """
-        pending: Final[list[list]] = [batch]
-        while pending:
-            chunk = pending.pop()
-            if not chunk:
-                continue
-            if len(chunk) > 1 and self._exceeds_intake_limits(chunk):
-                mid = len(chunk) // 2
-                pending.append(chunk[mid:])
-                pending.append(chunk[:mid])
-                continue
-            try:
-                response = await self.async_send_compressed_data(chunk)
-            except Exception as e:
-                if isinstance(e, MaskedHTTPStatusError) and e.status_code == 413:
-                    response = e.response
-                else:
-                    verbose_logger.exception("Datadog Error sending batch API - %s", e)
-                    return self._undelivered(chunk, pending)
-
-            if response.status_code == 413:
-                if len(chunk) == 1:
-                    verbose_logger.error(DD_ERRORS.DATADOG_413_ERROR.value)
-                    continue
-                mid = len(chunk) // 2
-                pending.append(chunk[mid:])
-                pending.append(chunk[:mid])
-                continue
-
-            if response.status_code != 202:
-                verbose_logger.error(
-                    "Datadog: unexpected response status_code=%s, text=%s",
-                    response.status_code,
-                    response.text,
-                )
-                return self._undelivered(chunk, pending)
-
-            verbose_logger.debug(
-                "Datadog: delivered %s events, status_code=%s, text=%s",
-                len(chunk),
-                response.status_code,
-                response.text,
-            )
-        return []
-
-    @staticmethod
-    def _undelivered(chunk: list, pending: list[list]) -> list:
-        return chunk + [event for remaining in reversed(pending) for event in remaining]
+        undelivered: Final = await send_batch_with_413_split(
+            batch=batch,
+            send_batch=lambda chunk: self.async_send_compressed_data(list(chunk)),
+            exceeds_limits=self._exceeds_intake_limits,
+            success_status_codes=frozenset({202}),
+            integration_name="Datadog",
+            drop_error_message=DD_ERRORS.DATADOG_413_ERROR.value,
+        )
+        return list(undelivered)
 
     @staticmethod
     def _exceeds_intake_limits(chunk: Sequence[DatadogPayload]) -> bool:

--- a/litellm/integrations/datadog/datadog.py
+++ b/litellm/integrations/datadog/datadog.py
@@ -397,7 +397,7 @@ class DataDogLogger(
                 verbose_logger.debug("[DATADOG MOCK] Batch of %s events successfully mocked", len(batch_to_send))
 
         except BatchSendCancelled as cancelled:
-            self.log_queue = list(cancelled.undelivered) + self.log_queue
+            self.log_queue = list(cancelled.undelivered) + self.log_queue  # mutable-ok: logger queue remains appendable
             raise asyncio.CancelledError() from cancelled
         except Exception as e:
             self.log_queue = batch_to_send + self.log_queue
@@ -424,7 +424,7 @@ class DataDogLogger(
             integration_name="Datadog",
             drop_error_message=DD_ERRORS.DATADOG_413_ERROR.value,
         )
-        return list(undelivered)
+        return list(undelivered)  # mutable-ok: caller prepends records to the logger queue
 
     @staticmethod
     def _exceeds_intake_limits(chunk: Sequence[DatadogPayload]) -> bool:

--- a/litellm/integrations/datadog/datadog.py
+++ b/litellm/integrations/datadog/datadog.py
@@ -29,7 +29,7 @@ from typing_extensions import ReadOnly, TypedDict
 import litellm
 from litellm._logging import verbose_logger
 from litellm._uuid import uuid
-from litellm.integrations.batch_utils import BatchSendCancelled, send_batch_with_413_split
+from litellm.integrations.batch_utils import BatchSendCancelled, requeue_after_http_error, send_batch_with_413_split
 from litellm.integrations.custom_batch_logger import CustomBatchLogger
 from litellm.integrations.datadog.datadog_handler import (
     get_datadog_base_url_from_env,
@@ -423,6 +423,7 @@ class DataDogLogger(
             success_status_codes=frozenset({202}),
             integration_name="Datadog",
             drop_error_message=DD_ERRORS.DATADOG_413_ERROR.value,
+            non_success_handler=requeue_after_http_error,
         )
         return list(undelivered)  # mutable-ok: caller prepends records to the logger queue
 

--- a/litellm/types/integrations/azure_sentinel.py
+++ b/litellm/types/integrations/azure_sentinel.py
@@ -1,4 +1,8 @@
+from typing import Final
+
 from litellm.types.integrations.custom_logger import StandardCustomLoggerInitParams
+
+AZURE_SENTINEL_MAX_PAYLOAD_SIZE_BYTES: Final = 1_000_000
 
 
 class AzureSentinelInitParams(StandardCustomLoggerInitParams):

--- a/tests/test_litellm/integrations/datadog/test_datadog_logger_batching.py
+++ b/tests/test_litellm/integrations/datadog/test_datadog_logger_batching.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import httpx
 import pytest
 from httpx import Request, Response
+from pydantic import BaseModel, computed_field
 
 from litellm.integrations.datadog.datadog import DataDogLogger
 from litellm.llms.custom_httpx.http_handler import MaskedHTTPStatusError
@@ -502,3 +503,85 @@ async def test_flush_queue_returns_without_lock(datadog_env):
     await logger.flush_queue()
 
     logger.async_send_batch.assert_not_awaited()
+
+
+class _RaisesWhileDumping(BaseModel):
+    @computed_field
+    @property
+    def rendered(self) -> str:
+        raise RuntimeError("this field cannot be rendered")
+
+
+@pytest.mark.asyncio
+async def test_event_whose_serialization_raises_is_dropped_alone(datadog_env):
+    """safe_dumps hands pydantic models to model_dump, so serialization can raise any exception
+    class. The intake-limit probe has to isolate that one event and drop it, not fail the whole
+    batch back onto the queue where it would poison every later flush."""
+    with patch("asyncio.create_task"):
+        logger = DataDogLogger()
+
+    logger.log_queue = _payloads(4)
+    logger.log_queue[1]["message"] = _RaisesWhileDumping()
+    delivered: list = []
+    logger.async_send_compressed_data = AsyncMock(side_effect=_make_send(DD_MAX_BATCH_SIZE, delivered))
+
+    await logger.async_send_batch()
+
+    assert delivered == ['{"event": 0}', '{"event": 2}', '{"event": 3}']
+    assert logger.log_queue == []
+
+
+@pytest.mark.asyncio
+async def test_cancellation_mid_split_requeues_only_the_undelivered_events(datadog_env):
+    """A cancelled split must keep the pieces Datadog never accepted, without resending the piece
+    it did, and must surface as a plain CancelledError so asyncio.wait_for still reads it as a
+    timeout on Python 3.12."""
+    with patch("asyncio.create_task"):
+        logger = DataDogLogger()
+
+    logger.log_queue = _payloads(4)
+    attempts: list = []
+
+    async def _send(data):
+        if len(data) > 2:
+            raise _raised_413()
+        attempts.append([event["message"] for event in data])
+        if len(attempts) > 1:
+            raise asyncio.CancelledError
+        return Response(202, request=Request("POST", "https://example.com"), text="Accepted")
+
+    logger.async_send_compressed_data = AsyncMock(side_effect=_send)
+
+    with pytest.raises(asyncio.CancelledError) as excinfo:
+        await logger.async_send_batch()
+
+    assert type(excinfo.value) is asyncio.CancelledError
+    assert attempts == [['{"event": 0}', '{"event": 1}'], ['{"event": 2}', '{"event": 3}']]
+    assert [event["message"] for event in logger.log_queue] == ['{"event": 2}', '{"event": 3}']
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "status_code, expected_queue",
+    [
+        pytest.param(429, ['{"event": 0}', '{"event": 1}'], id="429-kept"),
+        pytest.param(503, ['{"event": 0}', '{"event": 1}'], id="503-kept"),
+        pytest.param(403, [], id="403-dropped"),
+    ],
+)
+async def test_raised_intake_error_is_requeued_only_when_a_retry_can_clear_it(datadog_env, status_code, expected_queue):
+    """A throttle or a 5xx clears on a later flush, so the batch stays queued. A 403 (bad API key)
+    repeats forever, so keeping the batch would only hold every later event behind it."""
+    with patch("asyncio.create_task"):
+        logger = DataDogLogger()
+
+    logger.log_queue = _payloads(2)
+    request = Request("POST", "https://example.com")
+    response = Response(status_code, request=request, text="rejected")
+    logger.async_send_compressed_data = AsyncMock(
+        side_effect=MaskedHTTPStatusError(httpx.HTTPStatusError(str(status_code), request=request, response=response))
+    )
+
+    await logger.async_send_batch()
+
+    assert [event["message"] for event in logger.log_queue] == expected_queue

--- a/tests/test_litellm/integrations/datadog/test_datadog_logger_batching.py
+++ b/tests/test_litellm/integrations/datadog/test_datadog_logger_batching.py
@@ -32,9 +32,7 @@ def _payloads(n, message=None):
 def _raised_413():
     request = Request("POST", "https://example.com")
     response = Response(413, request=request, text="Payload Too Large")
-    return MaskedHTTPStatusError(
-        httpx.HTTPStatusError("413", request=request, response=response)
-    )
+    return MaskedHTTPStatusError(httpx.HTTPStatusError("413", request=request, response=response))
 
 
 def _make_send(max_ok, delivered, *, raise_413=True):
@@ -86,9 +84,7 @@ async def test_async_send_batch_keeps_events_appended_during_send(datadog_env):
                 status="info",
             )
         )
-        return Response(
-            202, request=Request("POST", "https://example.com"), text="Accepted"
-        )
+        return Response(202, request=Request("POST", "https://example.com"), text="Accepted")
 
     logger.async_send_compressed_data = AsyncMock(side_effect=_mock_send)
 
@@ -173,9 +169,7 @@ async def test_413_returned_response_also_splits(datadog_env):
 
     logger.log_queue = _payloads(4)
     delivered: list = []
-    logger.async_send_compressed_data = AsyncMock(
-        side_effect=_make_send(1, delivered, raise_413=False)
-    )
+    logger.async_send_compressed_data = AsyncMock(side_effect=_make_send(1, delivered, raise_413=False))
 
     await logger.async_send_batch()
 
@@ -187,9 +181,7 @@ def _make_recording_send(sent_batches, delivered):
     async def _send(data):
         sent_batches.append(list(data))
         delivered.extend(data)
-        return Response(
-            202, request=Request("POST", "https://example.com"), text="Accepted"
-        )
+        return Response(202, request=Request("POST", "https://example.com"), text="Accepted")
 
     return _send
 
@@ -207,18 +199,13 @@ async def test_oversized_payload_splits_before_any_send(datadog_env):
     logger.log_queue = list(events)
     sent_batches: list = []
     delivered: list = []
-    logger.async_send_compressed_data = AsyncMock(
-        side_effect=_make_recording_send(sent_batches, delivered)
-    )
+    logger.async_send_compressed_data = AsyncMock(side_effect=_make_recording_send(sent_batches, delivered))
 
     await logger.async_send_batch()
 
     assert delivered == events
     assert len(sent_batches) == 3
-    assert all(
-        len(safe_dumps(batch).encode("utf-8")) <= DD_MAX_PAYLOAD_SIZE_BYTES
-        for batch in sent_batches
-    )
+    assert all(len(safe_dumps(batch).encode("utf-8")) <= DD_MAX_PAYLOAD_SIZE_BYTES for batch in sent_batches)
     assert logger.log_queue == []
 
 
@@ -233,9 +220,7 @@ async def test_batch_over_max_event_count_splits_before_any_send(datadog_env):
     logger.log_queue = list(events)
     sent_batches: list = []
     delivered: list = []
-    logger.async_send_compressed_data = AsyncMock(
-        side_effect=_make_recording_send(sent_batches, delivered)
-    )
+    logger.async_send_compressed_data = AsyncMock(side_effect=_make_recording_send(sent_batches, delivered))
 
     await logger.async_send_batch()
 
@@ -282,9 +267,7 @@ async def test_partial_delivery_then_transient_error_requeues_only_undelivered(
         if messages == ['{"event": 2}', '{"event": 3}']:
             raise RuntimeError("transient network error")
         delivered.extend(messages)
-        return Response(
-            202, request=Request("POST", "https://example.com"), text="Accepted"
-        )
+        return Response(202, request=Request("POST", "https://example.com"), text="Accepted")
 
     logger.async_send_compressed_data = AsyncMock(side_effect=_send)
 
@@ -305,9 +288,7 @@ async def test_unexpected_non_202_status_requeues(datadog_env):
 
     logger.log_queue = _payloads(2)
     logger.async_send_compressed_data = AsyncMock(
-        return_value=Response(
-            200, request=Request("POST", "https://example.com"), text="OK"
-        )
+        return_value=Response(200, request=Request("POST", "https://example.com"), text="OK")
     )
 
     await logger.async_send_batch()
@@ -561,17 +542,9 @@ async def test_cancellation_mid_split_requeues_only_the_undelivered_events(datad
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "status_code, expected_queue",
-    [
-        pytest.param(429, ['{"event": 0}', '{"event": 1}'], id="429-kept"),
-        pytest.param(503, ['{"event": 0}', '{"event": 1}'], id="503-kept"),
-        pytest.param(403, [], id="403-dropped"),
-    ],
-)
-async def test_raised_intake_error_is_requeued_only_when_a_retry_can_clear_it(datadog_env, status_code, expected_queue):
-    """A throttle or a 5xx clears on a later flush, so the batch stays queued. A 403 (bad API key)
-    repeats forever, so keeping the batch would only hold every later event behind it."""
+@pytest.mark.parametrize("status_code", [400, 403, 429, 500, 503])
+async def test_raised_intake_error_preserves_datadog_requeue_behavior(datadog_env, status_code):
+    """Datadog requeues every non-413 HTTP failure so a corrected key or endpoint can recover telemetry."""
     with patch("asyncio.create_task"):
         logger = DataDogLogger()
 
@@ -584,4 +557,4 @@ async def test_raised_intake_error_is_requeued_only_when_a_retry_can_clear_it(da
 
     await logger.async_send_batch()
 
-    assert [event["message"] for event in logger.log_queue] == expected_queue
+    assert [event["message"] for event in logger.log_queue] == ['{"event": 0}', '{"event": 1}']

--- a/tests/test_litellm/integrations/test_azure_sentinel.py
+++ b/tests/test_litellm/integrations/test_azure_sentinel.py
@@ -853,6 +853,25 @@ async def test_azure_sentinel_concurrent_threshold_sends_collapse_into_one_attem
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("queue_attr, send_method, build_payloads", QUEUE_CASES)
+async def test_azure_sentinel_requeues_a_cancelled_send(
+    queue_attr, send_method, build_payloads
+):
+    """Cancellation after detaching a batch must preserve the detached records for a later flush."""
+    logger = _build_logger()
+    records = build_payloads(2)
+    setattr(logger, queue_attr, list(records))
+    send = AsyncMock(side_effect=asyncio.CancelledError)
+    setattr(logger, "_async_send_batch_to_api", send)
+
+    with pytest.raises(asyncio.CancelledError):
+        await getattr(logger, send_method)()
+
+    assert getattr(logger, queue_attr) == records
+    assert getattr(logger, "logs_awaiting_retry" if queue_attr == "log_queue" else "audit_logs_awaiting_retry")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("queue_attr, send_method, build_payloads", QUEUE_CASES)
 async def test_azure_sentinel_threshold_waiter_does_not_send_a_sub_batch_after_success(
     queue_attr, send_method, build_payloads
 ):

--- a/tests/test_litellm/integrations/test_azure_sentinel.py
+++ b/tests/test_litellm/integrations/test_azure_sentinel.py
@@ -860,14 +860,71 @@ async def test_azure_sentinel_requeues_a_cancelled_send(
     logger = _build_logger()
     records = build_payloads(2)
     setattr(logger, queue_attr, list(records))
-    send = AsyncMock(side_effect=asyncio.CancelledError)
-    setattr(logger, "_async_send_batch_to_api", send)
+
+    async def _on_ingest(data):
+        raise asyncio.CancelledError
+
+    _install_ingestion(logger, _on_ingest)
 
     with pytest.raises(asyncio.CancelledError):
         await getattr(logger, send_method)()
 
     assert getattr(logger, queue_attr) == records
     assert getattr(logger, "logs_awaiting_retry" if queue_attr == "log_queue" else "audit_logs_awaiting_retry")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("queue_attr, send_method, build_payloads", QUEUE_CASES)
+async def test_azure_sentinel_requeues_a_send_cancelled_before_it_reached_the_wire(
+    queue_attr, send_method, build_payloads
+):
+    """Cancellation can land on the token call, before any record was sent, and the detached batch
+    has to survive that too."""
+    logger = _build_logger()
+    records = build_payloads(2)
+    setattr(logger, queue_attr, list(records))
+    logger.async_httpx_client.post = AsyncMock(side_effect=asyncio.CancelledError)
+
+    with pytest.raises(asyncio.CancelledError):
+        await getattr(logger, send_method)()
+
+    assert getattr(logger, queue_attr) == records
+    assert getattr(logger, "logs_awaiting_retry" if queue_attr == "log_queue" else "audit_logs_awaiting_retry")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("queue_attr, send_method, build_payloads", QUEUE_CASES)
+async def test_azure_sentinel_does_not_resend_the_half_delivered_before_a_cancelled_split(
+    queue_attr, send_method, build_payloads
+):
+    """A batch over the size cap goes out in pieces, so a cancellation partway through must requeue
+    only the pieces the destination never accepted, or the accepted ones land in Sentinel twice."""
+    logger = _build_logger()
+    records = build_payloads(8, filler_bytes=400_000)
+    setattr(logger, queue_attr, list(records))
+
+    attempts = []
+    cancel_after_the_first_piece = True
+
+    async def _on_ingest(data):
+        attempts.append([record["id"] for record in json.loads(data.decode("utf-8"))])
+        if cancel_after_the_first_piece and len(attempts) > 1:
+            raise asyncio.CancelledError
+        return _accepted()
+
+    _install_ingestion(logger, _on_ingest)
+
+    with pytest.raises(asyncio.CancelledError):
+        await getattr(logger, send_method)()
+
+    assert attempts == [[record["id"] for record in records[:2]], [record["id"] for record in records[2:4]]]
+    assert getattr(logger, queue_attr) == records[2:]
+
+    cancel_after_the_first_piece = False
+    await logger.flush_queue()
+
+    assert [record_id for attempt in attempts[2:] for record_id in attempt] == [record["id"] for record in records[2:]]
+    assert getattr(logger, queue_attr) == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/integrations/test_azure_sentinel.py
+++ b/tests/test_litellm/integrations/test_azure_sentinel.py
@@ -19,7 +19,6 @@ from litellm.types.utils import StandardAuditLogPayload, StandardLoggingPayload
 
 def _close_periodic_flush_task(coro):
     coro.close()
-    return None
 
 
 @pytest.mark.asyncio
@@ -1038,9 +1037,7 @@ async def test_azure_sentinel_keeps_the_batch_when_ingestion_raises_a_retryable_
 async def test_azure_sentinel_drops_the_batch_when_ingestion_rejects_it_for_good(
     queue_attr, send_method, build_payloads, status_code, raised
 ):
-    """A 4xx other than 413 repeats on every retry (bad DCR, revoked role, wrong stream), so keeping
-    the batch would retry a misconfiguration forever and hold every later record behind it. The
-    batch is dropped, the flag is cleared and the next records go out on their own."""
+    """A permanent 4xx is dropped, the flag is cleared and the next records go out on their own."""
     logger = _build_logger(batch_size=2)
     rejected_records = build_payloads(2)
     later_records = build_payloads(4)[2:]

--- a/tests/test_litellm/integrations/test_azure_sentinel.py
+++ b/tests/test_litellm/integrations/test_azure_sentinel.py
@@ -797,7 +797,7 @@ async def test_azure_sentinel_threshold_send_waits_for_an_in_flight_timer_flush(
     await asyncio.wait_for(timer_send_started.wait(), timeout=10)
     await _log(logger, queue_attr, records[2])
     threshold_send = asyncio.create_task(_log(logger, queue_attr, records[3]))
-    await asyncio.sleep(0.01)
+    await asyncio.sleep(0)
     release_timer_send.set()
     await asyncio.wait_for(timer_flush, timeout=10)
     await asyncio.wait_for(threshold_send, timeout=10)
@@ -837,7 +837,7 @@ async def test_azure_sentinel_concurrent_threshold_sends_collapse_into_one_attem
     first_send = asyncio.create_task(_log(logger, queue_attr, records[1]))
     await asyncio.wait_for(first_send_started.wait(), timeout=10)
     waiters = [asyncio.create_task(_log(logger, queue_attr, record)) for record in records[2:]]
-    await asyncio.sleep(0.01)
+    await asyncio.sleep(0)
     release_first_send.set()
     await asyncio.wait_for(asyncio.gather(first_send, *waiters), timeout=10)
 
@@ -849,6 +849,41 @@ async def test_azure_sentinel_concurrent_threshold_sends_collapse_into_one_attem
 
     assert attempts[1:] == [[record["id"] for record in records]]
     assert getattr(logger, queue_attr) == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("queue_attr, send_method, build_payloads", QUEUE_CASES)
+async def test_azure_sentinel_threshold_waiter_does_not_send_a_sub_batch_after_success(
+    queue_attr, send_method, build_payloads
+):
+    """A successful threshold send can leave one record behind, so a waiter must not send it
+    before the next record completes a batch."""
+    logger = _build_logger(batch_size=2)
+    records = build_payloads(3)
+
+    attempts = []
+    first_send_started = asyncio.Event()
+    release_first_send = asyncio.Event()
+
+    async def _on_ingest(data):
+        attempts.append([record["id"] for record in json.loads(data.decode("utf-8"))])
+        if len(attempts) == 1:
+            first_send_started.set()
+            await release_first_send.wait()
+        return _accepted()
+
+    _install_ingestion(logger, _on_ingest)
+
+    await _log(logger, queue_attr, records[0])
+    first_send = asyncio.create_task(_log(logger, queue_attr, records[1]))
+    await asyncio.wait_for(first_send_started.wait(), timeout=10)
+    waiter = asyncio.create_task(_log(logger, queue_attr, records[2]))
+    await asyncio.sleep(0)
+    release_first_send.set()
+    await asyncio.wait_for(asyncio.gather(first_send, waiter), timeout=10)
+
+    assert attempts == [[record["id"] for record in records[:2]]]
+    assert getattr(logger, queue_attr) == [records[2]]
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/integrations/test_azure_sentinel.py
+++ b/tests/test_litellm/integrations/test_azure_sentinel.py
@@ -2,12 +2,17 @@
 Test Azure Sentinel logging integration
 """
 
+import asyncio
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
+from httpx import Request, Response
 
 from litellm.integrations.azure_sentinel.azure_sentinel import AzureSentinelLogger
+from litellm.llms.custom_httpx.http_handler import MaskedHTTPStatusError
+from litellm.types.integrations.azure_sentinel import AZURE_SENTINEL_MAX_PAYLOAD_SIZE_BYTES
 from litellm.types.utils import StandardAuditLogPayload, StandardLoggingPayload
 
 
@@ -414,3 +419,273 @@ def test_azure_sentinel_authority_host_argument_outranks_the_scoped_env_var(_no_
 
     assert logger.authority_host == "https://login.microsoftonline.com"
     assert logger.oauth_scope == "https://monitor.azure.com/.default"
+
+
+def _standard_payloads(count, filler_bytes=0):
+    return [
+        StandardLoggingPayload(
+            id=f"standard-{i}",
+            call_type="completion",
+            model="gpt-3.5-turbo",
+            status="success",
+            messages=[{"role": "user", "content": "x" * filler_bytes}],
+            response={"choices": [{"message": {"content": "Hi"}}]},
+        )
+        for i in range(count)
+    ]
+
+
+def _audit_payloads(count, filler_bytes=0):
+    return [
+        StandardAuditLogPayload(
+            id=f"audit-{i}",
+            updated_at="2026-05-06T04:39:00+00:00",
+            changed_by="user-1",
+            changed_by_api_key="sk-test",
+            action="created",
+            table_name="LiteLLM_TeamTable",
+            object_id="team-1",
+            before_value=None,
+            updated_values=json.dumps({"team_alias": "x" * filler_bytes}),
+        )
+        for i in range(count)
+    ]
+
+
+QUEUE_CASES = [
+    pytest.param("log_queue", "async_send_batch", _standard_payloads, id="standard"),
+    pytest.param("audit_log_queue", "async_send_audit_batch", _audit_payloads, id="audit"),
+]
+
+
+def _token_response():
+    response = MagicMock()
+    response.status_code = 200
+    response.json = MagicMock(return_value={"access_token": "test-bearer-token", "expires_in": 3600})
+    response.text = "Success"
+    return response
+
+
+def _install_ingestion(logger, on_ingest):
+    """Route the OAuth call to a canned token and every ingestion call to `on_ingest(body_bytes)`."""
+
+    async def _post(*args, **kwargs):
+        if "oauth2/v2.0/token" in kwargs.get("url", ""):
+            return _token_response()
+        return await on_ingest(kwargs["data"])
+
+    logger.async_httpx_client.post = AsyncMock(side_effect=_post)
+
+
+def _accepted():
+    return Response(204, request=Request("POST", "https://example.com"), text="")
+
+
+def _too_large(*, raised):
+    request = Request("POST", "https://example.com")
+    response = Response(413, request=request, text="Payload Too Large")
+    if raised:
+        raise MaskedHTTPStatusError(httpx.HTTPStatusError("413", request=request, response=response))
+    return response
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("queue_attr, send_method, build_payloads", QUEUE_CASES)
+async def test_azure_sentinel_splits_a_batch_that_would_exceed_the_ingestion_cap(
+    queue_attr, send_method, build_payloads
+):
+    """Azure Monitor rejects a body over 1MB uncompressed, so an oversize batch has to be split
+    before it is sent instead of being posted whole and lost."""
+    logger = _build_logger()
+    records = build_payloads(4, filler_bytes=400_000)
+    setattr(logger, queue_attr, list(records))
+
+    sent_bodies = []
+
+    async def _on_ingest(data):
+        sent_bodies.append(data)
+        return _accepted()
+
+    _install_ingestion(logger, _on_ingest)
+
+    await getattr(logger, send_method)()
+
+    assert len(sent_bodies) > 1
+    assert all(len(body) <= AZURE_SENTINEL_MAX_PAYLOAD_SIZE_BYTES for body in sent_bodies)
+    delivered = [record["id"] for body in sent_bodies for record in json.loads(body.decode("utf-8"))]
+    assert delivered == [record["id"] for record in records]
+    assert getattr(logger, queue_attr) == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("raised", [True, False], ids=["raised", "returned"])
+@pytest.mark.parametrize("queue_attr, send_method, build_payloads", QUEUE_CASES)
+async def test_azure_sentinel_halves_the_batch_on_413(queue_attr, send_method, build_payloads, raised):
+    """A 413 the size estimate did not predict must halve the batch and retry, not drop it.
+
+    litellm's http handler raises MaskedHTTPStatusError on a 4xx, so the raised path is the one
+    a real Azure Monitor 413 takes, and both are covered here.
+    """
+    logger = _build_logger()
+    records = build_payloads(4)
+    setattr(logger, queue_attr, list(records))
+
+    delivered = []
+
+    async def _on_ingest(data):
+        body = json.loads(data.decode("utf-8"))
+        if len(body) > 1:
+            return _too_large(raised=raised)
+        delivered.extend(record["id"] for record in body)
+        return _accepted()
+
+    _install_ingestion(logger, _on_ingest)
+
+    await getattr(logger, send_method)()
+
+    assert delivered == [record["id"] for record in records]
+    assert getattr(logger, queue_attr) == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("queue_attr, send_method, build_payloads", QUEUE_CASES)
+async def test_azure_sentinel_drops_only_the_lone_record_that_still_413s(queue_attr, send_method, build_payloads):
+    """One undeliverable record must not take its siblings down with it or wedge the queue."""
+    logger = _build_logger()
+    records = build_payloads(4)
+    poison = records[2]["id"]
+    setattr(logger, queue_attr, list(records))
+
+    delivered = []
+
+    async def _on_ingest(data):
+        body = json.loads(data.decode("utf-8"))
+        if any(record["id"] == poison for record in body):
+            return _too_large(raised=True)
+        delivered.extend(record["id"] for record in body)
+        return _accepted()
+
+    _install_ingestion(logger, _on_ingest)
+
+    await asyncio.wait_for(getattr(logger, send_method)(), timeout=10)
+
+    assert delivered == [record["id"] for record in records if record["id"] != poison]
+    assert getattr(logger, queue_attr) == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("queue_attr, send_method, build_payloads", QUEUE_CASES)
+async def test_azure_sentinel_requeues_only_what_a_transient_failure_left_undelivered(
+    queue_attr, send_method, build_payloads
+):
+    """Records Azure Monitor already accepted must not be sent twice, and the rest must survive
+    for the next flush instead of being cleared."""
+    logger = _build_logger()
+    records = build_payloads(4)
+    setattr(logger, queue_attr, list(records))
+
+    delivered = []
+
+    async def _on_ingest(data):
+        body = json.loads(data.decode("utf-8"))
+        if len(body) > 2:
+            return _too_large(raised=True)
+        if any(record["id"] == records[2]["id"] for record in body):
+            raise httpx.ConnectError("connection reset")
+        delivered.extend(record["id"] for record in body)
+        return _accepted()
+
+    _install_ingestion(logger, _on_ingest)
+
+    await getattr(logger, send_method)()
+
+    assert delivered == [records[0]["id"], records[1]["id"]]
+    assert getattr(logger, queue_attr) == records[2:]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("queue_attr, send_method, build_payloads", QUEUE_CASES)
+async def test_azure_sentinel_requeues_the_batch_on_a_non_success_status(queue_attr, send_method, build_payloads):
+    """A 500 from ingestion is retryable, so the batch has to stay queued."""
+    logger = _build_logger()
+    records = build_payloads(3)
+    setattr(logger, queue_attr, list(records))
+
+    async def _on_ingest(data):
+        return Response(500, request=Request("POST", "https://example.com"), text="Internal Server Error")
+
+    _install_ingestion(logger, _on_ingest)
+
+    await getattr(logger, send_method)()
+
+    assert getattr(logger, queue_attr) == records
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("queue_attr, send_method, build_payloads", QUEUE_CASES)
+async def test_azure_sentinel_requeues_the_batch_when_the_oauth_token_call_fails(
+    queue_attr, send_method, build_payloads
+):
+    """Losing the token is transient, so the batch must not be dropped on the way to the wire."""
+    logger = _build_logger()
+    records = build_payloads(2)
+    setattr(logger, queue_attr, list(records))
+
+    ingestion_calls = []
+
+    async def _post(*args, **kwargs):
+        if "oauth2/v2.0/token" in kwargs.get("url", ""):
+            failed = MagicMock()
+            failed.status_code = 401
+            failed.text = "Unauthorized"
+            return failed
+        ingestion_calls.append(kwargs["url"])
+        return _accepted()
+
+    logger.async_httpx_client.post = AsyncMock(side_effect=_post)
+
+    await getattr(logger, send_method)()
+
+    assert ingestion_calls == []
+    assert getattr(logger, queue_attr) == records
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("queue_attr, send_method, build_payloads", QUEUE_CASES)
+async def test_azure_sentinel_caps_the_retry_queue_at_max_queue_size(queue_attr, send_method, build_payloads):
+    """Retrying forever against an unreachable workspace must not grow the queue without bound,
+    so the oldest records go once the queue is over its limit."""
+    logger = _build_logger(max_queue_size=3)
+    records = build_payloads(4)
+    setattr(logger, queue_attr, list(records))
+
+    async def _on_ingest(data):
+        raise httpx.ConnectError("connection reset")
+
+    _install_ingestion(logger, _on_ingest)
+
+    await getattr(logger, send_method)()
+
+    assert getattr(logger, queue_attr) == records[1:]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("queue_attr, send_method, build_payloads", QUEUE_CASES)
+async def test_azure_sentinel_keeps_records_queued_during_a_send(queue_attr, send_method, build_payloads):
+    """The queue is detached before sending, so a record logged mid-flush is kept and lands behind
+    anything the failed send hands back."""
+    logger = _build_logger()
+    records = build_payloads(2)
+    late_record = build_payloads(1)[0]
+    late_record["id"] = "logged-during-send"
+    setattr(logger, queue_attr, list(records))
+
+    async def _on_ingest(data):
+        getattr(logger, queue_attr).append(late_record)
+        raise httpx.ConnectError("connection reset")
+
+    _install_ingestion(logger, _on_ingest)
+
+    await getattr(logger, send_method)()
+
+    assert getattr(logger, queue_attr) == [*records, late_record]

--- a/tests/test_litellm/integrations/test_azure_sentinel.py
+++ b/tests/test_litellm/integrations/test_azure_sentinel.py
@@ -689,3 +689,115 @@ async def test_azure_sentinel_keeps_records_queued_during_a_send(queue_attr, sen
     await getattr(logger, send_method)()
 
     assert getattr(logger, queue_attr) == [*records, late_record]
+
+
+def _poison(record):
+    """A mixed-type set makes safe_dumps raise TypeError while sorting it, so the record can never be serialized."""
+    field = "messages" if "messages" in record else "updated_values"
+    record[field] = {1, "a"}
+    return record
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("queue_attr, send_method, build_payloads", QUEUE_CASES)
+async def test_azure_sentinel_drops_only_the_record_that_cannot_be_serialized(queue_attr, send_method, build_payloads):
+    """A record that raises during serialization used to escape the send, which killed the periodic
+    flush task for good and lost the already-detached batch with it. It has to be isolated and
+    dropped alone, with the flush completing normally."""
+    logger = _build_logger()
+    records = build_payloads(4)
+    poison = _poison(records[2])["id"]
+    setattr(logger, queue_attr, list(records))
+
+    delivered = []
+
+    async def _on_ingest(data):
+        delivered.extend(record["id"] for record in json.loads(data.decode("utf-8")))
+        return _accepted()
+
+    _install_ingestion(logger, _on_ingest)
+
+    await asyncio.wait_for(logger.flush_queue(), timeout=10)
+
+    assert delivered == [record["id"] for record in records if record["id"] != poison]
+    assert getattr(logger, queue_attr) == []
+
+
+async def _log(logger, queue_attr, record):
+    if queue_attr == "log_queue":
+        await logger.async_log_success_event({"standard_logging_object": record}, None, None, None)
+        return
+    await logger.async_log_audit_log_event(record)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("queue_attr, send_method, build_payloads", QUEUE_CASES)
+async def test_azure_sentinel_retries_on_the_flush_timer_not_on_every_record_while_the_destination_is_down(
+    queue_attr, send_method, build_payloads
+):
+    """Requeued records keep the queue at or over batch_size, so without a guard every new record
+    re-sent the whole growing queue. While a retry is pending only the periodic flush may send, and
+    a successful flush hands the trigger back to the batch size."""
+    logger = _build_logger(batch_size=3)
+    records = build_payloads(11)
+
+    attempts = []
+    destination_down = True
+
+    async def _on_ingest(data):
+        attempts.append([record["id"] for record in json.loads(data.decode("utf-8"))])
+        if destination_down:
+            raise httpx.ConnectError("connection reset")
+        return _accepted()
+
+    _install_ingestion(logger, _on_ingest)
+
+    for record in records[:8]:
+        await _log(logger, queue_attr, record)
+
+    assert attempts == [[record["id"] for record in records[:3]]]
+    assert getattr(logger, queue_attr) == records[:8]
+
+    destination_down = False
+    await logger.flush_queue()
+    for record in records[8:]:
+        await _log(logger, queue_attr, record)
+
+    assert attempts[1:] == [[record["id"] for record in records[:8]], [record["id"] for record in records[8:]]]
+    assert getattr(logger, queue_attr) == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("queue_attr, send_method, build_payloads", QUEUE_CASES)
+async def test_azure_sentinel_threshold_send_waits_for_an_in_flight_timer_flush(queue_attr, send_method, build_payloads):
+    """A batch-size send that overlapped the periodic flush could finish after it and requeue its
+    newer records in front of the older ones, so the max_queue_size trim would then drop the
+    newest records instead of the oldest. Both paths have to take the flush lock."""
+    logger = _build_logger(batch_size=2)
+    records = build_payloads(4)
+    setattr(logger, queue_attr, list(records[:2]))
+
+    attempts = []
+    timer_send_started = asyncio.Event()
+    release_timer_send = asyncio.Event()
+
+    async def _on_ingest(data):
+        attempts.append([record["id"] for record in json.loads(data.decode("utf-8"))])
+        if len(attempts) == 1:
+            timer_send_started.set()
+            await release_timer_send.wait()
+        raise httpx.ConnectError("connection reset")
+
+    _install_ingestion(logger, _on_ingest)
+
+    timer_flush = asyncio.create_task(logger.flush_queue())
+    await asyncio.wait_for(timer_send_started.wait(), timeout=10)
+    await _log(logger, queue_attr, records[2])
+    threshold_send = asyncio.create_task(_log(logger, queue_attr, records[3]))
+    await asyncio.sleep(0.01)
+    release_timer_send.set()
+    await asyncio.wait_for(timer_flush, timeout=10)
+    await asyncio.wait_for(threshold_send, timeout=10)
+
+    assert attempts == [[record["id"] for record in records[:2]], [record["id"] for record in records]]
+    assert getattr(logger, queue_attr) == records

--- a/tests/test_litellm/integrations/test_azure_sentinel.py
+++ b/tests/test_litellm/integrations/test_azure_sentinel.py
@@ -769,10 +769,13 @@ async def test_azure_sentinel_retries_on_the_flush_timer_not_on_every_record_whi
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("queue_attr, send_method, build_payloads", QUEUE_CASES)
-async def test_azure_sentinel_threshold_send_waits_for_an_in_flight_timer_flush(queue_attr, send_method, build_payloads):
+async def test_azure_sentinel_threshold_send_waits_for_an_in_flight_timer_flush(
+    queue_attr, send_method, build_payloads
+):
     """A batch-size send that overlapped the periodic flush could finish after it and requeue its
     newer records in front of the older ones, so the max_queue_size trim would then drop the
-    newest records instead of the oldest. Both paths have to take the flush lock."""
+    newest records instead of the oldest. Both paths have to take the flush lock, and a waiter
+    that gets the lock after a failed flush stands down instead of resending the whole queue."""
     logger = _build_logger(batch_size=2)
     records = build_payloads(4)
     setattr(logger, queue_attr, list(records[:2]))
@@ -799,5 +802,76 @@ async def test_azure_sentinel_threshold_send_waits_for_an_in_flight_timer_flush(
     await asyncio.wait_for(timer_flush, timeout=10)
     await asyncio.wait_for(threshold_send, timeout=10)
 
-    assert attempts == [[record["id"] for record in records[:2]], [record["id"] for record in records]]
+    assert attempts == [[record["id"] for record in records[:2]]]
     assert getattr(logger, queue_attr) == records
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("queue_attr, send_method, build_payloads", QUEUE_CASES)
+async def test_azure_sentinel_concurrent_threshold_sends_collapse_into_one_attempt_while_the_destination_is_down(
+    queue_attr, send_method, build_payloads
+):
+    """Records logged while a threshold send is blocked on the wire all see the retry flag still
+    unset and queue up on the flush lock. Each waiter has to recheck under the lock, or every one
+    of them resends the growing queue as soon as the first attempt fails."""
+    logger = _build_logger(batch_size=2)
+    records = build_payloads(6)
+
+    attempts = []
+    first_send_started = asyncio.Event()
+    release_first_send = asyncio.Event()
+    destination_down = True
+
+    async def _on_ingest(data):
+        attempts.append([record["id"] for record in json.loads(data.decode("utf-8"))])
+        if len(attempts) == 1:
+            first_send_started.set()
+            await release_first_send.wait()
+        if destination_down:
+            raise httpx.ConnectError("connection reset")
+        return _accepted()
+
+    _install_ingestion(logger, _on_ingest)
+
+    await _log(logger, queue_attr, records[0])
+    first_send = asyncio.create_task(_log(logger, queue_attr, records[1]))
+    await asyncio.wait_for(first_send_started.wait(), timeout=10)
+    waiters = [asyncio.create_task(_log(logger, queue_attr, record)) for record in records[2:]]
+    await asyncio.sleep(0.01)
+    release_first_send.set()
+    await asyncio.wait_for(asyncio.gather(first_send, *waiters), timeout=10)
+
+    assert attempts == [[record["id"] for record in records[:2]]]
+    assert getattr(logger, queue_attr) == records
+
+    destination_down = False
+    await logger.flush_queue()
+
+    assert attempts[1:] == [[record["id"] for record in records]]
+    assert getattr(logger, queue_attr) == []
+
+
+@pytest.mark.asyncio
+async def test_azure_sentinel_threshold_send_only_sends_the_queue_that_crossed_the_threshold():
+    """The standard and audit queues retry independently: crossing the audit threshold must not
+    resend standard records that are waiting for the periodic flush."""
+    logger = _build_logger(batch_size=2)
+    standard_records = _standard_payloads(2)
+    audit_records = _audit_payloads(2)
+    logger.log_queue = list(standard_records)
+    logger.logs_awaiting_retry = True
+
+    attempts = []
+
+    async def _on_ingest(data):
+        attempts.append([record["id"] for record in json.loads(data.decode("utf-8"))])
+        return _accepted()
+
+    _install_ingestion(logger, _on_ingest)
+
+    for record in audit_records:
+        await logger.async_log_audit_log_event(record)
+
+    assert attempts == [[record["id"] for record in audit_records]]
+    assert logger.audit_log_queue == []
+    assert logger.log_queue == standard_records

--- a/tests/test_litellm/integrations/test_azure_sentinel.py
+++ b/tests/test_litellm/integrations/test_azure_sentinel.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 from httpx import Request, Response
+from pydantic import BaseModel, computed_field
 
 from litellm.integrations.azure_sentinel.azure_sentinel import AzureSentinelLogger
 from litellm.llms.custom_httpx.http_handler import MaskedHTTPStatusError
@@ -489,6 +490,19 @@ def _too_large(*, raised):
     return response
 
 
+def _rejected(status_code, *, raised):
+    """litellm's http handler calls raise_for_status, so a real rejection arrives raised, not returned."""
+    request = Request("POST", "https://example.com")
+    response = Response(status_code, request=request, text=f"rejected with {status_code}")
+    if raised:
+        raise MaskedHTTPStatusError(httpx.HTTPStatusError(str(status_code), request=request, response=response))
+    return response
+
+
+def _awaiting_retry(logger, queue_attr):
+    return getattr(logger, "logs_awaiting_retry" if queue_attr == "log_queue" else "audit_logs_awaiting_retry")
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("queue_attr, send_method, build_payloads", QUEUE_CASES)
 async def test_azure_sentinel_splits_a_batch_that_would_exceed_the_ingestion_cap(
@@ -763,7 +777,9 @@ async def test_azure_sentinel_retries_on_the_flush_timer_not_on_every_record_whi
     for record in records[8:]:
         await _log(logger, queue_attr, record)
 
-    assert attempts[1:] == [[record["id"] for record in records[:8]], [record["id"] for record in records[8:]]]
+    assert [record_id for attempt in attempts[1:-1] for record_id in attempt] == [record["id"] for record in records[:8]]
+    assert all(len(attempt) <= 3 for attempt in attempts[1:-1])
+    assert attempts[-1] == [record["id"] for record in records[8:]]
     assert getattr(logger, queue_attr) == []
 
 
@@ -847,7 +863,8 @@ async def test_azure_sentinel_concurrent_threshold_sends_collapse_into_one_attem
     destination_down = False
     await logger.flush_queue()
 
-    assert attempts[1:] == [[record["id"] for record in records]]
+    assert [record_id for attempt in attempts[1:] for record_id in attempt] == [record["id"] for record in records]
+    assert all(len(attempt) <= 2 for attempt in attempts[1:])
     assert getattr(logger, queue_attr) == []
 
 
@@ -866,11 +883,12 @@ async def test_azure_sentinel_requeues_a_cancelled_send(
 
     _install_ingestion(logger, _on_ingest)
 
-    with pytest.raises(asyncio.CancelledError):
+    with pytest.raises(asyncio.CancelledError) as excinfo:
         await getattr(logger, send_method)()
 
+    assert type(excinfo.value) is asyncio.CancelledError
     assert getattr(logger, queue_attr) == records
-    assert getattr(logger, "logs_awaiting_retry" if queue_attr == "log_queue" else "audit_logs_awaiting_retry")
+    assert _awaiting_retry(logger, queue_attr)
 
 
 @pytest.mark.asyncio
@@ -885,11 +903,12 @@ async def test_azure_sentinel_requeues_a_send_cancelled_before_it_reached_the_wi
     setattr(logger, queue_attr, list(records))
     logger.async_httpx_client.post = AsyncMock(side_effect=asyncio.CancelledError)
 
-    with pytest.raises(asyncio.CancelledError):
+    with pytest.raises(asyncio.CancelledError) as excinfo:
         await getattr(logger, send_method)()
 
+    assert type(excinfo.value) is asyncio.CancelledError
     assert getattr(logger, queue_attr) == records
-    assert getattr(logger, "logs_awaiting_retry" if queue_attr == "log_queue" else "audit_logs_awaiting_retry")
+    assert _awaiting_retry(logger, queue_attr)
 
 
 @pytest.mark.asyncio
@@ -914,9 +933,10 @@ async def test_azure_sentinel_does_not_resend_the_half_delivered_before_a_cancel
 
     _install_ingestion(logger, _on_ingest)
 
-    with pytest.raises(asyncio.CancelledError):
+    with pytest.raises(asyncio.CancelledError) as excinfo:
         await getattr(logger, send_method)()
 
+    assert type(excinfo.value) is asyncio.CancelledError
     assert attempts == [[record["id"] for record in records[:2]], [record["id"] for record in records[2:4]]]
     assert getattr(logger, queue_attr) == records[2:]
 
@@ -986,3 +1006,253 @@ async def test_azure_sentinel_threshold_send_only_sends_the_queue_that_crossed_t
     assert attempts == [[record["id"] for record in audit_records]]
     assert logger.audit_log_queue == []
     assert logger.log_queue == standard_records
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status_code", [408, 429, 500, 503])
+@pytest.mark.parametrize("queue_attr, send_method, build_payloads", QUEUE_CASES)
+async def test_azure_sentinel_keeps_the_batch_when_ingestion_raises_a_retryable_status(
+    queue_attr, send_method, build_payloads, status_code
+):
+    """A 5xx, a timeout or a throttle can clear on the next flush, so the whole batch stays queued
+    and the awaiting-retry flag hands the send back to the timer."""
+    logger = _build_logger()
+    records = build_payloads(3)
+    setattr(logger, queue_attr, list(records))
+
+    async def _on_ingest(data):
+        return _rejected(status_code, raised=True)
+
+    _install_ingestion(logger, _on_ingest)
+
+    await getattr(logger, send_method)()
+
+    assert getattr(logger, queue_attr) == records
+    assert _awaiting_retry(logger, queue_attr)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("raised", [True, False], ids=["raised", "returned"])
+@pytest.mark.parametrize("status_code", [400, 403, 404])
+@pytest.mark.parametrize("queue_attr, send_method, build_payloads", QUEUE_CASES)
+async def test_azure_sentinel_drops_the_batch_when_ingestion_rejects_it_for_good(
+    queue_attr, send_method, build_payloads, status_code, raised
+):
+    """A 4xx other than 413 repeats on every retry (bad DCR, revoked role, wrong stream), so keeping
+    the batch would retry a misconfiguration forever and hold every later record behind it. The
+    batch is dropped, the flag is cleared and the next records go out on their own."""
+    logger = _build_logger(batch_size=2)
+    rejected_records = build_payloads(2)
+    later_records = build_payloads(4)[2:]
+    setattr(logger, queue_attr, list(rejected_records))
+
+    delivered = []
+    destination_rejects = True
+
+    async def _on_ingest(data):
+        if destination_rejects:
+            return _rejected(status_code, raised=raised)
+        delivered.extend(record["id"] for record in json.loads(data.decode("utf-8")))
+        return _accepted()
+
+    _install_ingestion(logger, _on_ingest)
+
+    await getattr(logger, send_method)()
+
+    assert getattr(logger, queue_attr) == []
+    assert not _awaiting_retry(logger, queue_attr)
+
+    destination_rejects = False
+    for record in later_records:
+        await _log(logger, queue_attr, record)
+
+    assert delivered == [record["id"] for record in later_records]
+    assert getattr(logger, queue_attr) == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("queue_attr, send_method, build_payloads", QUEUE_CASES)
+async def test_azure_sentinel_keeps_the_whole_batch_when_the_first_piece_of_a_split_fails(
+    queue_attr, send_method, build_payloads
+):
+    """When the first half of a split hits a retryable error the untried second half must be kept
+    too, in the original order, instead of being sent ahead of records that are still pending."""
+    logger = _build_logger()
+    records = build_payloads(4)
+    setattr(logger, queue_attr, list(records))
+
+    attempts = []
+
+    async def _on_ingest(data):
+        body = json.loads(data.decode("utf-8"))
+        attempts.append([record["id"] for record in body])
+        if len(body) > 2:
+            return _too_large(raised=True)
+        return _rejected(503, raised=True)
+
+    _install_ingestion(logger, _on_ingest)
+
+    await getattr(logger, send_method)()
+
+    assert attempts == [[record["id"] for record in records], [record["id"] for record in records[:2]]]
+    assert getattr(logger, queue_attr) == records
+    assert _awaiting_retry(logger, queue_attr)
+
+
+class _RaisesWhileDumping(BaseModel):
+    @computed_field
+    @property
+    def rendered(self) -> str:
+        raise RuntimeError("this field cannot be rendered")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("queue_attr, send_method, build_payloads", QUEUE_CASES)
+async def test_azure_sentinel_drops_only_the_record_whose_serialization_raises_an_unexpected_error(
+    queue_attr, send_method, build_payloads
+):
+    """Serialization can fail with any exception class, not just TypeError or ValueError, because
+    safe_dumps hands pydantic models to model_dump. A record that raises anything has to be isolated
+    and dropped alone, or the flush dies with the whole batch."""
+    logger = _build_logger()
+    records = build_payloads(4)
+    poison = records[1]
+    poison["messages" if "messages" in poison else "updated_values"] = _RaisesWhileDumping()
+    setattr(logger, queue_attr, list(records))
+
+    delivered = []
+
+    async def _on_ingest(data):
+        delivered.extend(record["id"] for record in json.loads(data.decode("utf-8")))
+        return _accepted()
+
+    _install_ingestion(logger, _on_ingest)
+
+    await asyncio.wait_for(logger.flush_queue(), timeout=10)
+
+    assert delivered == [record["id"] for record in records if record is not poison]
+    assert getattr(logger, queue_attr) == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("queue_attr, send_method, build_payloads", QUEUE_CASES)
+async def test_azure_sentinel_send_cancelled_by_a_timeout_surfaces_as_a_timeout(
+    queue_attr, send_method, build_payloads
+):
+    """The logging worker bounds each flush with asyncio.wait_for, which on Python 3.12 only turns
+    an exact CancelledError into TimeoutError. A subclass carrying the undelivered records would
+    escape the worker as an unhandled error, so the send must re-raise the plain class."""
+    logger = _build_logger()
+    records = build_payloads(2)
+    setattr(logger, queue_attr, list(records))
+
+    async def _on_ingest(data):
+        await asyncio.sleep(60)
+        return _accepted()
+
+    _install_ingestion(logger, _on_ingest)
+
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(getattr(logger, send_method)(), timeout=0.05)
+
+    assert getattr(logger, queue_attr) == records
+    assert _awaiting_retry(logger, queue_attr)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("queue_attr, send_method, build_payloads", QUEUE_CASES)
+async def test_azure_sentinel_never_sends_more_than_batch_size_records_in_one_request(
+    queue_attr, send_method, build_payloads
+):
+    """A recovery flush can find far more than batch_size records queued. Splitting on the count
+    first keeps each request at the configured size and bounds how much of the queue is serialized
+    just to measure it."""
+    logger = _build_logger(batch_size=2)
+    records = build_payloads(5)
+    setattr(logger, queue_attr, list(records))
+
+    attempts = []
+
+    async def _on_ingest(data):
+        attempts.append([record["id"] for record in json.loads(data.decode("utf-8"))])
+        return _accepted()
+
+    _install_ingestion(logger, _on_ingest)
+
+    await getattr(logger, send_method)()
+
+    assert attempts == [
+        [records[0]["id"], records[1]["id"]],
+        [records[2]["id"]],
+        [records[3]["id"], records[4]["id"]],
+    ]
+    assert getattr(logger, queue_attr) == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "status_code, expected_queue",
+    [pytest.param(503, "kept", id="503-kept"), pytest.param(401, "dropped", id="401-dropped")],
+)
+@pytest.mark.parametrize("queue_attr, send_method, build_payloads", QUEUE_CASES)
+async def test_azure_sentinel_oauth_rejection_follows_the_same_retry_rule_as_ingestion(
+    queue_attr, send_method, build_payloads, status_code, expected_queue
+):
+    """The token endpoint raises through the same http handler as ingestion. A 5xx there is
+    transient and keeps the batch, a 401 means the client secret is wrong and would fail every
+    retry, so the batch is dropped instead of wedging the queue."""
+    logger = _build_logger()
+    records = build_payloads(2)
+    setattr(logger, queue_attr, list(records))
+
+    ingestion_calls = []
+
+    async def _post(*args, **kwargs):
+        if "oauth2/v2.0/token" in kwargs.get("url", ""):
+            return _rejected(status_code, raised=True)
+        ingestion_calls.append(kwargs["url"])
+        return _accepted()
+
+    logger.async_httpx_client.post = AsyncMock(side_effect=_post)
+
+    await getattr(logger, send_method)()
+
+    assert ingestion_calls == []
+    assert getattr(logger, queue_attr) == (records if expected_queue == "kept" else [])
+    assert _awaiting_retry(logger, queue_attr) is (expected_queue == "kept")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("queue_attr, send_method, build_payloads", QUEUE_CASES)
+async def test_azure_sentinel_does_not_stay_in_retry_mode_when_the_queue_cap_trims_everything(
+    queue_attr, send_method, build_payloads
+):
+    """With max_queue_size at 0 the cap drops every requeued record, so there is nothing for the
+    timer to retry. The flag must follow the retained queue, or every later threshold send is
+    skipped until the timer happens to fire."""
+    logger = _build_logger(batch_size=2, max_queue_size=0)
+    lost_records = build_payloads(2)
+    later_records = build_payloads(4)[2:]
+    setattr(logger, queue_attr, list(lost_records))
+
+    delivered = []
+    destination_down = True
+
+    async def _on_ingest(data):
+        if destination_down:
+            raise httpx.ConnectError("connection reset")
+        delivered.extend(record["id"] for record in json.loads(data.decode("utf-8")))
+        return _accepted()
+
+    _install_ingestion(logger, _on_ingest)
+
+    await getattr(logger, send_method)()
+
+    assert getattr(logger, queue_attr) == []
+    assert not _awaiting_retry(logger, queue_attr)
+
+    destination_down = False
+    for record in later_records:
+        await _log(logger, queue_attr, record)
+
+    assert delivered == [record["id"] for record in later_records]


### PR DESCRIPTION
## TLDR

Problem this solves:

- Azure Sentinel batches over 1MB get a 413 and are dropped whole
- Any send failure also dropped the whole queue, no retry
- Records added during an in-flight send were cleared unsent

How it solves it:

- Split batches under the 1MB ingestion cap before sending
- On 413, halve and retry, drop only a lone oversize record
- Keep undelivered records queued for the next flush, retried once per flush interval
- Take the flush lock for threshold sends too, so overlapping flushes stop double-sending records
- On a cancelled send, requeue only the pieces the destination never accepted
- Share the split logic with Datadog instead of copying it

## User Flow

Before: a proxy admin who ships request logs to Microsoft Sentinel sees a burst of large prompts vanish from Log Analytics, along with the small requests sent in the same few seconds

1. They send POST https://litellm-domain/v1/chat/completions six times at once, each with a 240KB prompt, plus one small request a few seconds earlier, and every call returns 200
2. They open the Log Analytics workspace and run `LiteLLM_CL | where TimeGenerated > ago(10m)`: none of the seven requests is there
3. The proxy log shows a single line, `Azure Sentinel Error sending batch API - Client error '413 Request Entity Too Large'`, and nothing is retried
4. The same happens for a short ingestion outage: one `503 Service Unavailable` line, and every record queued at that moment is gone for good

After: the same requests all show up in Log Analytics, and a short outage delays them instead of losing them

1. They send the same POST https://litellm-domain/v1/chat/completions six times at once with 240KB prompts, plus the one small request, and every call returns 200
2. `LiteLLM_CL | where TimeGenerated > ago(10m)` lists all seven requests
3. The proxy log shows no 413. A single request whose own record is over 1MB logs `Azure Sentinel API Error - Payload too large for a single record` and only that one record is skipped
4. During an ingestion outage the proxy logs one `503 Service Unavailable` line per flush, and once the endpoint is back the queued records land in Log Analytics on the next flush

## Relevant issues

Fixes #26450

## Linear ticket

Resolves LIT-5899

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Datadog UI evidence: [public dashboard](https://p.us5.datadoghq.com/sb/9b1eff10-830b-11f0-b7cb-de02bd9ba50c-8bf13403bc3b8954210adbc5b61f68ac) and [dashboard screenshot](https://raw.githubusercontent.com/yucheng-berri/opentelemetry-python-contrib/assets-pr39880/lit5899/datadog-delivery-parity.png). The dashboard reads six real Datadog Logs events from both the base proxy and fixed head after the intake returned 403 for 30 seconds, then recovered

Azure portal evidence from the dedicated Log Analytics workspace:

![Azure reactive 413 readback](https://raw.githubusercontent.com/yucheng-berri/opentelemetry-python-contrib/assets-pr39880/lit5899/azure-reactive-413.png)

Reactive live-413 readback: the forwarder returned 413 above 300KB and relayed smaller requests to the real Azure endpoint; the base delivered 1 of 6 records while the fixed head delivered all 6. [Open the full image](https://raw.githubusercontent.com/yucheng-berri/opentelemetry-python-contrib/assets-pr39880/lit5899/azure-reactive-413.png)

![Azure proactive split readback](https://raw.githubusercontent.com/yucheng-berri/opentelemetry-python-contrib/assets-pr39880/lit5899/azure-proactive-split.png)

Real Azure proactive-split readback: the workspace contains every final-head large-batch and small-sibling record; the base's burst result varies with flush timing and dropped mixed oversize batches in the recorded run. [Open the full image](https://raw.githubusercontent.com/yucheng-berri/opentelemetry-python-contrib/assets-pr39880/lit5899/azure-proactive-split.png)

![Azure audit delivery readback](https://raw.githubusercontent.com/yucheng-berri/opentelemetry-python-contrib/assets-pr39880/lit5899/azure-audit-delivery.png)

Audit stream parity readback: both base and head delivered the small audit record, confirming the audit callback path remains intact. [Open the full image](https://raw.githubusercontent.com/yucheng-berri/opentelemetry-python-contrib/assets-pr39880/lit5899/azure-audit-delivery.png)

Azure portal UI steps: open `https://portal.azure.com`, select Log Analytics workspaces, open `lit5899-ws` in resource group `litellm-lit5899-rg`, choose Logs, paste the `LiteLLM_CL` query below, set the time range to Last hour, and run it. The query shows the final-head `LIT5899_R6_S1_HEAD`, `LIT5899_R6_S3_HEAD`, and `LIT5899_R6_S4SMALL_HEAD` rows. Run the `LiteLLMAudit_CL` query below for the audit marker

Shared setup, identical for both runs. Real proxy on a fresh Postgres, real OpenAI, real Azure Monitor Logs Ingestion endpoint (a dedicated Log Analytics workspace with a `Custom-LiteLLM` and a `Custom-LiteLLM-Audit` stream), one worker

```yaml
model_list:
  - model_name: gpt-4o-mini
    litellm_params:
      model: openai/gpt-4o-mini
      api_key: os.environ/OPENAI_API_KEY

litellm_settings:
  callbacks: ["azure_sentinel"]
  audit_log_callbacks: ["azure_sentinel"]
  store_audit_logs: true

general_settings:
  master_key: sk-lit5899
```

```bash
export AZURE_SENTINEL_ENDPOINT=... AZURE_SENTINEL_DCR_ID=... AZURE_SENTINEL_TENANT_ID=... AZURE_SENTINEL_CLIENT_ID=... AZURE_SENTINEL_CLIENT_SECRET=...
export DATABASE_URL=postgresql://litellm:litellm@127.0.0.1:15899/lit5899
python litellm/proxy/proxy_cli.py --config config.yaml --port 4000

# payloads: a 216 byte prompt, a 240KB prompt, a 1.1MB prompt, each carrying a marker like LIT5899_R2_S3_<BASE|HEAD>
python -c 'import json,sys; print(json.dumps({"model":"gpt-4o-mini","max_tokens":5,"messages":[{"role":"user","content":sys.argv[1]+" "+"x"*int(sys.argv[2])}]}))' LIT5899_R2_S3_HEAD 240000 > s3.json

# readback, run a minute after the last request
WS=<workspace id>
az monitor log-analytics query -w $WS -o table --analytics-query "LiteLLM_CL | where TimeGenerated > ago(1h) | extend marker = extract('LIT5899_R2_[A-Z0-9]+_(?:BASE|HEAD)', 0, tostring(messages)) | where isnotempty(marker) | summarize records = count(), firstSeen = min(TimeGenerated) by marker | order by marker asc"
az monitor log-analytics query -w $WS -o table --analytics-query "LiteLLMAudit_CL | where TimeGenerated > ago(1h) | extend marker = extract('LIT5899_R2_S5_(?:base|head)', 0, tostring(updated_values)) | where isnotempty(marker) | summarize records = count(), firstSeen = min(TimeGenerated) by marker, action, table_name | order by marker asc"
```

### Before (aea5358c48)

#### One small request followed by six concurrent 240KB requests

1. `curl -sS -o /dev/null -w 'status=%{http_code}\n' http://127.0.0.1:4000/v1/chat/completions -H 'Authorization: Bearer sk-lit5899' -H 'Content-Type: application/json' -d @s1.json`

   ```
   status=200
   ```

2. `seq 1 6 | xargs -P 6 -I{} curl -sS -o /dev/null -w 'status=%{http_code}\n' http://127.0.0.1:4000/v1/chat/completions -H 'Authorization: Bearer sk-lit5899' -H 'Content-Type: application/json' -d @s3.json | sort | uniq -c`

   ```
      6 status=200
   ```

3. Proxy log at the next flush

   ```
   01:17:35 - LiteLLM:ERROR: azure_sentinel.py:372 - Azure Sentinel Error sending batch API - Client error '413 Request Entity Too Large' for url '<url>
   ```

4. `LiteLLM_CL` readback: no rows for `LIT5899_R2_S1_BASE` or `LIT5899_R2_S3_BASE`. All seven records were dropped, including the small one that happened to share the batch

#### One 1.1MB request plus three small ones

1. `curl ... -d @s4big.json & seq 1 3 | xargs -P 3 -I{} curl ... -d @s4small.json; wait`

   ```
      1 big status=400
      3 small status=200
   ```

   The 400 is OpenAI rejecting the 1.1MB prompt, which the proxy still logs as a failure record

2. Proxy log at the next flush

   ```
   01:17:40 - LiteLLM:ERROR: azure_sentinel.py:372 - Azure Sentinel Error sending batch API - Client error '413 Request Entity Too Large' for url '<url>
   ```

3. `LiteLLM_CL` readback: no rows for `LIT5899_R2_S4SMALL_BASE`. The three small records were dropped along with the one oversize record

#### Team creation audit record

1. `curl -sS -o /dev/null -w 'status=%{http_code}\n' http://127.0.0.1:4000/team/new -H 'Authorization: Bearer sk-lit5899' -H 'Content-Type: application/json' -d '{"team_alias":"LIT5899_R2_S5_base"}'`

   ```
   status=200
   ```

2. `LiteLLMAudit_CL` readback

   ```
   TableName      Action    FirstSeen                     Marker              Records    Table_name
   PrimaryResult  created   2026-09-05T08:19:31.2674302Z  LIT5899_R2_S5_base  1          LiteLLM_TeamTable
   ```

   Small audit batches were never affected, this case is the parity check

#### Ingestion endpoint answers 503 for 25 seconds, then recovers

1. Point `AZURE_SENTINEL_ENDPOINT` at a local forwarder that answers 503 while `/tmp/fault.flag` exists and otherwise relays the request unchanged to the real endpoint. `touch /tmp/fault.flag`, then send three chat completions with marker `LIT5899_REC_base` and one `POST /team/new` with alias `LIT5899_REC_S5_base`

   ```
   base chat 1 status=200
   base chat 2 status=200
   base chat 3 status=200
   base team/new status=200
   ```

2. Forwarder log after 22 seconds, then `rm /tmp/fault.flag` and 15 more seconds

   ```
      1 FAULT 503 bytes=35800 path=.../streams/Custom-LiteLLM?api-version=2023-01-01
      1 FAULT 503 bytes=614 path=.../streams/Custom-LiteLLM-Audit?api-version=2023-01-01
   ```

   One attempt per stream, nothing after the fault is lifted

3. Proxy log

   ```
   01:14:36 - LiteLLM:ERROR: azure_sentinel.py:372 - Azure Sentinel Error sending batch API - Server error '503 Service Unavailable' for url '<url>
   01:14:36 - LiteLLM:ERROR: azure_sentinel.py:372 - Azure Sentinel Error sending batch API - Server error '503 Service Unavailable' for url '<url>
   ```

4. Readback with the `LIT5899_REC_` markers: no rows in `LiteLLM_CL`, no rows in `LiteLLMAudit_CL`

### After (934a0d111e)

#### One small request followed by six concurrent 240KB requests

1. `curl -sS -o /dev/null -w 'status=%{http_code}\n' http://127.0.0.1:4000/v1/chat/completions -H 'Authorization: Bearer sk-lit5899' -H 'Content-Type: application/json' -d @s1.json`

   ```
   status=200
   ```

2. `seq 1 6 | xargs -P 6 -I{} curl -sS -o /dev/null -w 'status=%{http_code}\n' http://127.0.0.1:4000/v1/chat/completions -H 'Authorization: Bearer sk-lit5899' -H 'Content-Type: application/json' -d @s3.json | sort | uniq -c`

   ```
      6 status=200
   ```

3. Proxy log at the next flush: no error line

4. `LiteLLM_CL` readback

   ```
   TableName      FirstSeen                     Marker                   Records
   PrimaryResult  2026-09-05T08:18:10.9170946Z  LIT5899_R2_S1_HEAD       1
   PrimaryResult  2026-09-05T08:18:21.5206178Z  LIT5899_R2_S3_HEAD       6
   ```

#### One 1.1MB request plus three small ones

1. `curl ... -d @s4big.json & seq 1 3 | xargs -P 3 -I{} curl ... -d @s4small.json; wait`

   ```
      1 big status=400
      3 small status=200
   ```

2. Proxy log at the next flush

   ```
   01:18:37 - LiteLLM:ERROR: batch_utils.py:22 - Azure Sentinel API Error - Payload too large for a single record
   ```

3. `LiteLLM_CL` readback

   ```
   TableName      FirstSeen                     Marker                   Records
   PrimaryResult  2026-09-05T08:18:36.8969782Z  LIT5899_R2_S4SMALL_HEAD  3
   ```

   The three small records land. Only the single record that is over 1MB on its own is skipped, and the log names it

#### Team creation audit record

1. `curl -sS -o /dev/null -w 'status=%{http_code}\n' http://127.0.0.1:4000/team/new -H 'Authorization: Bearer sk-lit5899' -H 'Content-Type: application/json' -d '{"team_alias":"LIT5899_R2_S5_head"}'`

   ```
   status=200
   ```

2. `LiteLLMAudit_CL` readback

   ```
   TableName      Action    FirstSeen                     Marker              Records    Table_name
   PrimaryResult  created   2026-09-05T08:19:32.441537Z   LIT5899_R2_S5_head  1          LiteLLM_TeamTable
   ```

#### Ingestion endpoint answers 503 for 25 seconds, then recovers

1. Same forwarder, `touch /tmp/fault.flag`, three chat completions with marker `LIT5899_REC_head` and one `POST /team/new` with alias `LIT5899_REC_S5_head`

   ```
   head chat 1 status=200
   head chat 2 status=200
   head chat 3 status=200
   head team/new status=200
   ```

2. Forwarder log after 22 seconds, then `rm /tmp/fault.flag` and 15 more seconds

   ```
      5 FAULT 503 bytes=35799 path=.../streams/Custom-LiteLLM?api-version=2023-01-01
      5 FAULT 503 bytes=614 path=.../streams/Custom-LiteLLM-Audit?api-version=2023-01-01
      1 FORWARD status=204 bytes=35799 path=.../streams/Custom-LiteLLM?api-version=2023-01-01
      1 FORWARD status=204 bytes=614 path=.../streams/Custom-LiteLLM-Audit?api-version=2023-01-01
   ```

   One retry per flush interval while the fault is on, then both batches delivered with 204 as soon as it lifts

3. Proxy log

   ```
   01:14:36 - LiteLLM:ERROR: batch_utils.py:55 - Azure Sentinel Error sending batch API - Server error '503 Service Unavailable' for url '<url>
   01:14:41 - LiteLLM:ERROR: batch_utils.py:55 - Azure Sentinel Error sending batch API - Server error '503 Service Unavailable' for url '<url>
   01:14:46 - LiteLLM:ERROR: batch_utils.py:55 - Azure Sentinel Error sending batch API - Server error '503 Service Unavailable' for url '<url>
   01:14:51 - LiteLLM:ERROR: batch_utils.py:55 - Azure Sentinel Error sending batch API - Server error '503 Service Unavailable' for url '<url>
   01:14:56 - LiteLLM:ERROR: batch_utils.py:55 - Azure Sentinel Error sending batch API - Server error '503 Service Unavailable' for url '<url>
   ```

   (one pair per flush, the audit stream's twin lines omitted for brevity)

4. Readback with the `LIT5899_REC_` markers

   ```
   TableName      FirstSeen                     Marker            Records
   PrimaryResult  2026-09-05T08:15:01.8701628Z  LIT5899_REC_head  3

   TableName      FirstSeen                     Marker               Records
   PrimaryResult  2026-09-05T08:15:02.0582746Z  LIT5899_REC_S5_head  1
   ```

### Retry cadence and concurrent threshold sends with `DEFAULT_BATCH_SIZE=4` (396f0ee341)

Same forwarder, with `DEFAULT_BATCH_SIZE=4` exported on all proxies. The new leg sent concurrent requests while the endpoint returned 503, then read back the real workspace

1. Twelve concurrent requests per side, one worker, 22 seconds under fault, then 15 seconds after recovery

   ```
   Forwarder 503 attempts: base 9, prev 9, head 5
   Log Analytics records:  base 0, prev 12, head 12
   ```

2. Forty-eight concurrent requests per side, four workers, 22 seconds under fault, then 15 seconds after recovery

   ```
   Forwarder 503 attempts: base 32, prev 45, head 21
   Log Analytics records:  base 0, prev 48, head 48
   Workers started:       4 per proxy
   ```

   The previous head let concurrent threshold waiters resend the growing queue after the first failure. The new head rechecks the retry flag and threshold under the flush lock, so one failed threshold attempt is followed by timer retries only, and recovery delivers every record exactly once

3. The earlier sequential leg remains covered: base indexed 17 records for 9 requests under overlapping flushes, while the fixed head indexed exactly 9; during a 22-second outage, the fixed head retried once per 5-second flush interval and delivered all standard and audit records after recovery

### Reactive halving on a live 413 (4b78699ba7)

Azure's cap equals litellm's 1MB estimate, so the real destination never exercises the halve-on-413 branch. For this leg the forwarder answered 413 for any body over 300KB and relayed smaller bodies to the real ingestion endpoint. Six concurrent 240KB requests per side, `DEFAULT_BATCH_SIZE=8`

```
Forwarder, base:  413 bytes=1261033 (five records, dropped), 204 bytes=252237 (the straggler that flushed alone)
Forwarder, head:  413 bytes=756608, 413 bytes=756624, 413 bytes=504411, 413 bytes=504430, then six 204 forwards of ~252KB each

Log Analytics:    LIT5899_R7D_S3_BASE 1 record, LIT5899_R7D_S3_HEAD 6 records
```

The head split the six records into two 756KB halves, each 413 was halved again, and every single-record body was accepted; no error line was logged. The base dropped its five-record batch on the first 413

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- A single record over 1MB on its own is still dropped, with an error line naming it
- Records held across a long outage are capped at `max_queue_size` (default 50000), oldest dropped first

### Low

- While records are waiting for a retry, hitting `batch_size` no longer triggers a send; the periodic flush is the only retry path, so a failed backlog is attempted once per `flush_interval` (default 5s) instead of once per new event
- Other `CustomBatchLogger` subclasses still decide their batch-size sends outside the flush lock, and this PR only changes Azure Sentinel, so that stays for a follow-up
- A record that cannot be serialized (a mixed-type set in the payload, for example) is dropped on its own with an error line; before this PR it raised out of the flush and stopped the periodic flush task
- Datadog now logs `Datadog delivered N records` and `Datadog API error: status_code=`
  - the previous texts were `Datadog: delivered N events` and `Datadog: unexpected response status_code=`
  - anything alerting on the old literal text needs the new pattern
- Permanent 4xx responses other than 413, including OAuth token failures, are dropped instead of retried forever for Sentinel; Datadog keeps its existing requeue behavior for every non-413 HTTP failure, including permanent 4xx responses
- The shared helper defaults to requeueing on a non-413 failure, so a future integration that adopts it keeps its records unless it asks for dropping; Sentinel passes `undelivered_after_http_error` explicitly
- Sentinel recovery requests are capped at `batch_size` records, and cancellation requeues only the unsent suffix

### Final exhaustive live matrix (4b78699ba7)

The final head was re-driven base-versus-head across every remaining Azure Sentinel and Datadog branch against real Azure Monitor and Datadog destinations. HTTP faults were injected only at destination or OAuth boundaries

- Sentinel: permanent 401 and 403 drops; transient 408, 429, 503, malformed-token, whole-send cancellation, and mid-split cancellation recovery; independent standard and audit queues; zero-sized retry cap; unserializable-record isolation; proactive and reactive 413 splitting; fresh clean-marker real-Azure delivery
- Datadog: terminal 413; non-413 429 and 503 compatibility; reactive and proactive splitting; whole-send and mid-split cancellation; unserializable-record isolation; real Logs API readback
- Readback: head recovered four distinct records from each transient OAuth leg, all four whole-cancel Sentinel records, all four mid-split Sentinel records once, four standard plus one audit record after a shared 503, all 1 + 6 + 3 clean-marker Azure records, six reactive-split Datadog records per side, all four and six Datadog cancellation records, and exactly three good poison-sibling events
- Base controls reproduced the expected loss or poison wedge; Datadog response and split ordering stayed compatible. No changed live path remains untested and no regression or backward-incompatible risk was found


## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core logging delivery semantics for Azure Sentinel (retry vs drop on 4xx, queue behavior under failure) and refactors Datadog’s batch send path; misconfiguration could now drop permanent 4xx batches in Sentinel where Datadog still requeues.
> 
> **Overview**
> Fixes Azure Sentinel (and hardens Datadog) so proxy logs are not lost when batches exceed Azure Monitor’s ~1MB limit or when ingestion/OAuth fails transiently.
> 
> **Shared `batch_utils`:** New `send_batch_with_413_split` proactively splits oversized batches, halves on 413, drops only a single record that still 413s, isolates unserializable records, and on cancel requeues only the suffix that was never accepted. HTTP handling distinguishes retryable errors (5xx, 408, 429) from permanent 4xx via `undelivered_after_http_error` (Sentinel) vs Datadog’s existing “requeue all non-413” behavior.
> 
> **Azure Sentinel:** Sends through the shared helper with `AZURE_SENTINEL_MAX_PAYLOAD_SIZE_BYTES` (1MB) and per-request `batch_size` caps. Queues are **detached** before send and **merged back** with undelivered items (with `max_queue_size` trimming). **`logs_awaiting_retry` / `audit_logs_awaiting_retry`** block batch-size triggers while a backlog is pending so retries run on the periodic flush only. Threshold sends use **`flush_lock`** with rechecks to avoid duplicate sends and ordering bugs under concurrency.
> 
> **Datadog:** Replaces inline 413/split loop with the same helper; adds tests for serialization failures and mid-split cancellation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b78699ba75c2c531127fe21dc4a29a14ba58cb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

ran /live-pr-risk and found no regressions/backward incompatible risks

