### PR TITLE
fix(lowest-latency): treat tpm=0/rpm=0 as blocked, not unlimited

### DIFF
--- a/litellm/router_strategy/lowest_latency.py
+++ b/litellm/router_strategy/lowest_latency.py
@@ -412,18 +412,34 @@ class LowestLatencyLoggingHandler(CustomLogger):
             if _deployment is None:
                 continue  # skip to next one
 
-            _deployment_tpm = (
-                _deployment.get("tpm", None)
-                or _deployment.get("litellm_params", {}).get("tpm", None)
-                or _deployment.get("model_info", {}).get("tpm", None)
-                or float("inf")
+            # NOTE: levels are filtered with `is not None`, not truthiness. A configured
+            # `0` means "block this deployment"; an `or`-chain treats it as unset and
+            # falls through to `float("inf")`, the opposite of the configured intent.
+            # Matches the extraction in `lowest_tpm_rpm_v2.py`. See issue #39744.
+            _deployment_tpm = next(
+                (
+                    limit
+                    for limit in (
+                        _deployment.get("tpm"),
+                        _deployment.get("litellm_params", {}).get("tpm"),
+                        _deployment.get("model_info", {}).get("tpm"),
+                    )
+                    if limit is not None
+                ),
+                float("inf"),
             )
 
-            _deployment_rpm = (
-                _deployment.get("rpm", None)
-                or _deployment.get("litellm_params", {}).get("rpm", None)
-                or _deployment.get("model_info", {}).get("rpm", None)
-                or float("inf")
+            _deployment_rpm = next(
+                (
+                    limit
+                    for limit in (
+                        _deployment.get("rpm"),
+                        _deployment.get("litellm_params", {}).get("rpm"),
+                        _deployment.get("model_info", {}).get("rpm"),
+                    )
+                    if limit is not None
+                ),
+                float("inf"),
             )
             item_latency = item_map.get("latency", [])
             item_ttft_latency = item_map.get("time_to_first_token", [])

--- a/tests/test_litellm/router_strategy/test_lowest_latency_zero_limits.py
+++ b/tests/test_litellm/router_strategy/test_lowest_latency_zero_limits.py
@@ -1,0 +1,77 @@
+#### What this tests ####
+#    lowest-latency routing must treat an explicitly configured tpm=0 / rpm=0
+#    as "this deployment is blocked", not as "unlimited". The limits were read
+#    through an `or`-chain, and `or` treats 0 as falsy, so a configured 0 fell
+#    through to float("inf") -- the exact opposite of the configured intent.
+#    Issue #39744.
+
+import pytest
+
+from litellm.caching.caching import DualCache
+from litellm.router_strategy.lowest_latency import LowestLatencyLoggingHandler
+
+MODEL_GROUP = "gpt-4o"
+DEPLOYMENT_ID = "disabled-deployment"
+
+
+def _deployment(*, level: str, limit_key: str, value: int) -> dict:
+    """Build a deployment carrying `limit_key` at one of the three lookup levels."""
+    deployment = {
+        "model_name": MODEL_GROUP,
+        "litellm_params": {"model": "azure/gpt-4o"},
+        "model_info": {"id": DEPLOYMENT_ID},
+    }
+    if level == "top_level":
+        deployment[limit_key] = value
+    elif level == "litellm_params":
+        deployment["litellm_params"][limit_key] = value
+    elif level == "model_info":
+        deployment["model_info"][limit_key] = value
+    else:  # pragma: no cover - guards against a typo in the parametrize list
+        raise ValueError(f"unknown level {level!r}")
+    return deployment
+
+
+def _select(deployment: dict):
+    handler = LowestLatencyLoggingHandler(router_cache=DualCache(), routing_args={})
+    return handler._get_available_deployments(
+        model_group=MODEL_GROUP,
+        healthy_deployments=[deployment],
+        messages=[{"role": "user", "content": "hello there, this is a prompt"}],
+        request_count_dict={},
+    )
+
+
+@pytest.mark.parametrize("level", ["top_level", "litellm_params", "model_info"])
+@pytest.mark.parametrize("limit_key", ["tpm", "rpm"])
+def test_zero_limit_blocks_deployment(level: str, limit_key: str):
+    """A deployment configured with tpm=0 or rpm=0 must never be selected."""
+    selected = _select(_deployment(level=level, limit_key=limit_key, value=0))
+
+    assert selected is None, (
+        f"deployment with {limit_key}=0 at {level} was selected; 0 was treated as unlimited instead of blocked"
+    )
+
+
+@pytest.mark.parametrize("level", ["top_level", "litellm_params", "model_info"])
+@pytest.mark.parametrize("limit_key", ["tpm", "rpm"])
+def test_nonzero_limit_still_allows_deployment(level: str, limit_key: str):
+    """Control: a generous limit at the same level must still be selectable."""
+    selected = _select(_deployment(level=level, limit_key=limit_key, value=1_000_000))
+
+    assert selected is not None, f"deployment with {limit_key}=1000000 at {level} was wrongly excluded"
+    assert selected["model_info"]["id"] == DEPLOYMENT_ID
+
+
+def test_unset_limits_are_unlimited():
+    """Control: with no tpm/rpm configured at all, the deployment stays selectable."""
+    selected = _select(
+        {
+            "model_name": MODEL_GROUP,
+            "litellm_params": {"model": "azure/gpt-4o"},
+            "model_info": {"id": DEPLOYMENT_ID},
+        }
+    )
+
+    assert selected is not None
+    assert selected["model_info"]["id"] == DEPLOYMENT_ID


### PR DESCRIPTION
## Summary

`LowestLatencyLoggingHandler._get_available_deployments()` read each deployment's TPM/RPM limit through an `or`-chain across the three levels a limit can be configured at:

```python
_deployment_tpm = (
    _deployment.get("tpm", None)
    or _deployment.get("litellm_params", {}).get("tpm", None)
    or _deployment.get("model_info", {}).get("tpm", None)
    or float("inf")
)
```

`or` treats `0` as falsy. A deployment explicitly configured with `tpm: 0` or `rpm: 0` — a legitimate way to take a deployment out of rotation without removing it from the model list — makes every operand falsy, so the expression falls through to `float("inf")`: the deployment is treated as having **unlimited** capacity instead of **zero**, the exact opposite of the configured intent, and keeps receiving traffic.

The sibling strategy in `lowest_tpm_rpm_v2.py` already extracts the same three-level fallback correctly with explicit `is None` checks, which is what makes this an unintended inconsistency rather than deliberate behaviour.

Fixes #39744

## The fix

Filter the three levels on `is not None` instead of truthiness, so a configured `0` wins and only a genuinely unset limit reaches `float("inf")`:

```python
_deployment_tpm = next(
    (
        limit
        for limit in (
            _deployment.get("tpm"),
            _deployment.get("litellm_params", {}).get("tpm"),
            _deployment.get("model_info", {}).get("tpm"),
        )
        if limit is not None
    ),
    float("inf"),
)
```

Behaviour is unchanged for every deployment that does not set a limit to `0`.

## Tests

New `tests/test_litellm/router_strategy/test_lowest_latency_zero_limits.py`, written before the fix and confirmed to fail against unpatched staging:

- `test_zero_limit_blocks_deployment` — parametrized over `{tpm, rpm} × {top-level, litellm_params, model_info}`. All **6 fail without the fix** (the deployment is selected) and pass with it.
- `test_nonzero_limit_still_allows_deployment` — same matrix with a generous limit; passes in both, so the 6 failures above are the zero-handling and not a broken fixture.
- `test_unset_limits_are_unlimited` — no limit configured at all stays selectable.

Verification run:

- [x] `pytest tests/test_litellm/router_strategy/test_lowest_latency_zero_limits.py` → 13 passed (6 failed before the fix)
- [x] `pytest tests/test_litellm/router_strategy/` → **505 passed**
- [x] `pytest tests/local_testing/test_lowest_latency_routing.py` → **23 passed** (the main routing suite for this strategy)
- [x] `pytest tests/test_litellm/test_lowest_latency_zero_tokens.py` → 2 passed
- [x] `ruff check --config ruff-strict.toml` and `ruff format --check` on both files → **zero delta vs staging**
- [x] `basedpyright` on `lowest_latency.py` → +4 `reportUnknown*` from the generator expression, well inside budget (`reportUnknownVariableType` 24226/29829, `reportUnknownArgumentType` 40579/44358 codebase-wide)

## Note on `tpm: 0` vs `rpm: 0`

Worth flagging for reviewers, though it is pre-existing and not changed here: the exclusion check is

```python
if item_tpm + input_tokens > _deployment_tpm or item_rpm + 1 > _deployment_rpm:
```

`rpm: 0` blocks unconditionally (`0 + 1 > 0`), but `tpm: 0` only blocks once the request actually has input tokens (`input_tokens > 0`). A zero-token request against a `tpm: 0` deployment would still pass the TPM half of the check. The tests here send a real message so both are deterministic. Happy to tighten that comparison in a follow-up if maintainers consider `tpm: 0` a hard block.

## Model evals

Not run. This is a routing-eligibility fix and does not change model outputs.

## Assistance

Claude Code was used to write the failing tests first, implement the fix, and run the verification above. The human submitter reviewed the changed lines and the results.
