### PR TITLE
fix(proxy): apply end-user limits on cached virtual keys

### DIFF
--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -1909,14 +1909,12 @@ async def _user_api_key_auth_builder(
                 if e.code == 401 or e.code == "401":
                     e.message = f"Authentication Error, Invalid proxy server token passed. Received API Key = {abbreviated_api_key}, Key Hash (Token) ={api_key}. Unable to find token in cache or `LiteLLM_VerificationTokenTable`"
                 raise e
-            # update end-user params on valid token
-            # These can change per request - it's important to update them here
+
+        if valid_token is not None:
             valid_token.end_user_id = end_user_params.get("end_user_id")
             valid_token.end_user_tpm_limit = end_user_params.get("end_user_tpm_limit")
             valid_token.end_user_rpm_limit = end_user_params.get("end_user_rpm_limit")
             valid_token.allowed_model_region = end_user_params.get("allowed_model_region")
-
-        if valid_token is not None:
             valid_token = _update_key_budget_with_temp_budget_increase(valid_token)
 
         user_obj: LiteLLM_UserTable | None = None

--- a/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
+++ b/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
@@ -3,6 +3,7 @@ import json
 from contextlib import contextmanager
 from datetime import datetime, timedelta
 from types import SimpleNamespace
+from typing import Final
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 
@@ -6246,6 +6247,134 @@ async def test_auth_does_not_rewrite_cached_key_object_back_into_cache():
     finally:
         for k, v in originals.items():
             setattr(_proxy_server_mod, k, v)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("existing_customer", [False, True], ids=["default-budget", "customer-budget"])
+@pytest.mark.parametrize("rpm_limit,tpm_limit", [(2, None), (None, 22)], ids=["rpm", "tpm"])
+async def test_end_user_rate_limits_survive_key_cache_hits(
+    monkeypatch: pytest.MonkeyPatch, existing_customer: bool, rpm_limit: int | None, tpm_limit: int | None
+) -> None:
+    from fastapi import Request
+
+    from litellm.proxy.common_utils.proxy_rate_limit_error import ProxyRateLimitError
+    from litellm.proxy.common_utils.user_api_key_cache import UserApiKeyCache
+    from litellm.proxy.hooks.parallel_request_limiter_v3 import _PROXY_MaxParallelRequestsHandler_v3
+    from litellm.proxy.utils import InternalUsageCache, ProxyLogging, hash_token
+
+    api_key: Final = "sk-end-user-rate-limit-cache-test"
+    hashed_key: Final = hash_token(api_key)
+    budget: Final = LiteLLM_BudgetTable(budget_id="customer-tier", rpm_limit=rpm_limit, tpm_limit=tpm_limit)
+    key_cache: Final = UserApiKeyCache()
+    usage_cache: Final = DualCache()
+    prisma_client: Final = MagicMock()
+    prisma_client.get_data = AsyncMock(return_value=UserAPIKeyAuth(token=hashed_key))
+    prisma_client.db.litellm_endusertable.find_unique = AsyncMock(return_value=None)
+    prisma_client.db.litellm_endusertable.find_many = AsyncMock(return_value=[])
+    prisma_client.db.litellm_budgettable.find_unique = AsyncMock(return_value=budget)
+    proxy_logging: Final = ProxyLogging(user_api_key_cache=key_cache)
+
+    monkeypatch.setattr(litellm, "max_end_user_budget_id", None if existing_customer else budget.budget_id)
+    monkeypatch.setattr(litellm, "validate_end_user_id_in_db", False)
+    monkeypatch.setattr(litellm, "max_budget", 0)
+    monkeypatch.setattr(litellm.proxy.proxy_server, "prisma_client", prisma_client)
+    monkeypatch.setattr(litellm.proxy.proxy_server, "user_api_key_cache", key_cache)
+    monkeypatch.setattr(litellm.proxy.proxy_server, "proxy_logging_obj", proxy_logging)
+    monkeypatch.setattr(litellm.proxy.proxy_server, "master_key", "sk-test-master")
+    monkeypatch.setattr(litellm.proxy.proxy_server, "general_settings", {})
+    monkeypatch.setattr(litellm.proxy.proxy_server, "llm_model_list", [])
+    monkeypatch.setattr(litellm.proxy.proxy_server, "llm_router", None)
+    monkeypatch.setattr(litellm.proxy.proxy_server, "open_telemetry_logger", None)
+    monkeypatch.setattr(litellm.proxy.proxy_server, "user_custom_auth", None)
+    monkeypatch.setattr(litellm.proxy.proxy_server, "jwt_handler", None)
+    monkeypatch.delenv("LITELLM_TPM_TOKEN_RESERVATION_ENABLED", raising=False)
+    limiter: Final = _PROXY_MaxParallelRequestsHandler_v3(
+        internal_usage_cache=InternalUsageCache(usage_cache),
+        time_provider=lambda: datetime(2026, 1, 1),
+    )
+
+    async def authenticate(customer_id: str | None) -> UserAPIKeyAuth:
+        return await _user_api_key_auth_builder(
+            request=Request(
+                scope={
+                    "type": "http",
+                    "path": "/v1/chat/completions",
+                    "method": "POST",
+                    "headers": [],
+                    "query_string": b"",
+                }
+            ),
+            api_key=f"Bearer {api_key}",
+            azure_api_key_header="",
+            anthropic_api_key_header=None,
+            google_ai_studio_api_key_header=None,
+            azure_apim_header=None,
+            request_data={
+                "model": "gpt-5.4-mini",
+                "messages": [{"role": "user", "content": "Hi"}],
+                "max_tokens": 10,
+                **({"user": customer_id} if customer_id is not None else {}),
+            },
+        )
+
+    for customer_id in ("customer-a", "customer-b"):
+        if existing_customer:
+            await key_cache.async_set_cache(
+                key=f"end_user_id:{customer_id}",
+                value=LiteLLM_EndUserTable(
+                    user_id=customer_id, blocked=False, litellm_budget_table=budget, allowed_model_region="eu"
+                ),
+                model_type=LiteLLM_EndUserTable,
+            )
+
+        for _ in range(2):
+            auth: Final = await authenticate(customer_id)
+            assert (
+                await limiter.async_pre_call_hook(
+                    user_api_key_dict=auth,
+                    cache=usage_cache,
+                    data={"model": "gpt-5.4-mini", "messages": [{"role": "user", "content": "Hi"}], "max_tokens": 10},
+                    call_type="acompletion",
+                )
+                is None
+            )
+
+        over_limit_auth: Final = await authenticate(customer_id)
+        with pytest.raises(ProxyRateLimitError, match=f"Rate limit exceeded for end_user: {customer_id}") as exc:
+            await limiter.async_pre_call_hook(
+                user_api_key_dict=over_limit_auth,
+                cache=usage_cache,
+                data={"model": "gpt-5.4-mini", "messages": [{"role": "user", "content": "Hi"}], "max_tokens": 10},
+                call_type="acompletion",
+            )
+        assert exc.value.status_code == 429
+        assert exc.value.headers["rate_limit_type"] == ("requests" if rpm_limit is not None else "tokens")
+        assert over_limit_auth.end_user_id == customer_id
+        assert over_limit_auth.end_user_rpm_limit == rpm_limit
+        assert over_limit_auth.end_user_tpm_limit == tpm_limit
+        assert over_limit_auth.allowed_model_region == ("eu" if existing_customer else None)
+
+    for customer_id in (None, "unlimited-customer"):
+        if customer_id is not None:
+            monkeypatch.setattr(litellm, "max_end_user_budget_id", None)
+        unlimited_auth: Final = await authenticate(customer_id)
+        assert unlimited_auth.end_user_rpm_limit is None
+        assert unlimited_auth.end_user_tpm_limit is None
+        assert unlimited_auth.allowed_model_region is None
+        assert (
+            await limiter.async_pre_call_hook(
+                user_api_key_dict=unlimited_auth, cache=usage_cache, data={}, call_type="acompletion"
+            )
+            is None
+        )
+
+    cached_key: Final = await key_cache.async_get_cache(key=hashed_key, model_type=UserAPIKeyAuth)
+    assert cached_key is not None
+    assert cached_key.end_user_id is None
+    assert cached_key.end_user_rpm_limit is None
+    assert cached_key.end_user_tpm_limit is None
+    assert cached_key.allowed_model_region is None
+    prisma_client.get_data.assert_awaited_once()
 
 
 class TestJWTAuthUserEmail:


### PR DESCRIPTION
## TLDR

Problem this solves:

- Cached virtual keys lose default end-user rate limits
- Unregistered end users bypass RPM and TPM limits

How it solves it:

- Apply end-user fields after virtual-key resolution
- Test cached keys with real auth and limiter instances

## User Flow

Before: an application uses a cached virtual key, but the configured default end-user limit does not block excess requests

1. The admin creates a default end-user budget with RPM 2 and restarts the proxy
2. The admin creates a non-admin virtual key
3. The application sends one request without an end-user ID, which warms the key cache
4. The application sends three requests for one new end user within a minute
5. All three requests return 200, so the configured customer limit is bypassed

After: the same application and cached key enforce the configured default end-user limit

1. The admin creates a default end-user budget with RPM 2 and restarts the proxy
2. The admin creates a non-admin virtual key
3. The application sends one request without an end-user ID, which warms the key cache
4. The application sends three requests for one new end user within a minute
5. The first two requests return 200 and the third returns 429 naming that end user

## Relevant issues

Fixes #39713

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible
- [ ] I have received a Greptile Confidence Score of at least 4/5

## Delays in PR merge?

If review is delayed, I will ask in the LiteLLM Slack `#pr-review` channel

## Screenshots / Proof of Fix

Shared setup:

1. I ran one LiteLLM worker against PostgreSQL 16.15 with a 600-second virtual-key cache TTL
2. I configured `qwen-flash` through DashScope and made real provider calls
3. I created a default end-user budget with RPM 2 for the three endpoint cases
4. I generated one unrestricted non-admin virtual key
5. I sent a successful chat completion without an end-user ID to warm that key's cache
6. I used fresh end-user IDs that were absent from PostgreSQL before and after every case
7. I sent each customer's three requests sequentially inside one rate-limit window
8. Credentials and virtual keys are redacted

The request-specific customer fields were:

```text
// POST http://127.0.0.1:4001/v1/chat/completions
{"model":"qwen-flash","user":"customer-a","messages":[{"role":"user","content":"Reply OK"}],"max_tokens":4}

// POST http://127.0.0.1:4001/v1/responses
{"model":"qwen-flash","safety_identifier":"customer-a","input":"Reply OK","max_output_tokens":4}

// POST http://127.0.0.1:4001/v1/messages
{"model":"qwen-flash","metadata":{"user_id":"customer-a"},"messages":[{"role":"user","content":"Reply OK"}],"max_tokens":4}
```

### Before (29ac88ebc6bb93bda02138699c5ebe08bdd4e8cc)

#### Chat Completions RPM

1. I sent the chat-completions payload three times for each of two fresh customers
2. Customer A returned `200, 200, 200`
3. Customer B returned `200, 200, 200`

#### Responses API RPM

1. I sent the Responses payload three times for each of two fresh customers
2. Customer A returned `200, 200, 200`
3. Customer B returned `200, 200, 200`

#### Messages API RPM

1. I sent the Messages payload three times for each of two fresh customers
2. Customer A returned `200, 200, 200`
3. Customer B returned `200, 200, 200`

#### Chat Completions TPM

1. I replaced the default budget with TPM 22 and used `"Hi"` plus `"max_tokens": 10`
2. The live request reserved 19 tokens, 9 prompt tokens and a 10-token output allowance
3. Customer A returned `200, 200, 200`
4. Customer B returned `200, 200, 200`

The Before runs made 26 successful real provider calls, including two cache-warm calls

### After (b85e19dcfeb69a02e1d147d1bcf772123cda3f21)

#### Chat Completions RPM

1. I sent the same chat-completions payload three times for each of two fresh customers
2. Customer A returned `200, 200, 429`
3. Customer B returned `200, 200, 429`
4. Each 429 named the right end user and reported `Limit type: requests`, limit 2, remaining 0

#### Responses API RPM

1. I sent the same Responses payload three times for each of two fresh customers
2. Customer A returned `200, 200, 429`
3. Customer B returned `200, 200, 429`
4. Each 429 named the right end user and reported `Limit type: requests`, limit 2, remaining 0

#### Messages API RPM

1. I sent the same Messages payload three times for each of two fresh customers
2. Customer A returned `200, 200, 429`
3. Customer B returned `200, 200, 429`
4. Each 429 named the right end user and reported `Limit type: requests`, limit 2, remaining 0

#### Chat Completions TPM

1. I used the same TPM 22 budget and the same `"Hi"` plus `"max_tokens": 10` payload
2. The live request again reserved 19 tokens
3. Customer A returned `200, 429, 429`
4. Customer B returned `200, 429, 429`
5. Each 429 named the right end user and reported `Limit type: tokens`, limit 22, remaining 3

The After runs made 16 successful real provider calls, including two cache-warm calls. Rejected requests did not reach the provider. The live run used the pre-rebase commit `c97a490110fae2e72545a9db2867a42bb9f90fd0`; its stable patch ID exactly matches the rebased PR commit above

## Type

Bug Fix

## Caveats (if any)

### Low

- The Redis-dependent local test remains for CI

## Final Attestation

- [x] The tests check the right behavior and regression paths
