### PR TITLE
feat(openai): honor per-deployment workload identity on non-chat routes

### DIFF
--- a/litellm/batches/batch_utils.py
+++ b/litellm/batches/batch_utils.py
@@ -10,6 +10,7 @@ from litellm._logging import verbose_logger
 from litellm.litellm_core_utils.get_litellm_params import (
     ANTHROPIC_WIF_KWARGS_KEYS,
     AWS_CREDENTIAL_KWARGS_KEYS,
+    OPENAI_WIF_KWARGS_KEYS,
 )
 from litellm.litellm_core_utils.llm_cost_calc.utils import parse_prompt_tokens_details
 from litellm.types.llms.openai import Batch
@@ -513,6 +514,7 @@ def _extract_file_access_credentials(litellm_params: dict | None) -> dict:
             # A federated deployment holds no api_key, so without these the fetch that reads a
             # finished batch's output has nothing to authenticate with and its cost is never billed.
             *sorted(ANTHROPIC_WIF_KWARGS_KEYS),
+            *sorted(OPENAI_WIF_KWARGS_KEYS),
         )
         for key in credential_keys:
             if key in litellm_params:

--- a/litellm/batches/main.py
+++ b/litellm/batches/main.py
@@ -271,6 +271,7 @@ def create_batch(
                 timeout=timeout,
                 max_retries=optional_params.max_retries,
                 _is_async=_is_async,
+                litellm_params=litellm_params,
             )
         elif custom_llm_provider == "azure":
             api_base = optional_params.api_base or litellm.api_base or get_secret_str("AZURE_API_BASE")
@@ -424,6 +425,7 @@ def _handle_retrieve_batch_providers_without_provider_config(
             organization=organization,
             timeout=timeout,
             max_retries=optional_params.max_retries,
+            litellm_params=litellm_params,
         )
     elif custom_llm_provider == "azure":
         api_base = optional_params.api_base or litellm.api_base or get_secret_str("AZURE_API_BASE")
@@ -763,6 +765,7 @@ def list_batches(
                 organization=organization,
                 timeout=timeout,
                 max_retries=optional_params.max_retries,
+                litellm_params=litellm_params,
             )
         elif custom_llm_provider == "azure":
             api_base = optional_params.api_base or litellm.api_base or get_secret_str("AZURE_API_BASE")
@@ -952,6 +955,7 @@ def cancel_batch(
                 organization=organization,
                 timeout=timeout,
                 max_retries=optional_params.max_retries,
+                litellm_params=litellm_params,
             )
         elif custom_llm_provider == "azure":
             api_base = optional_params.api_base or litellm.api_base or get_secret_str("AZURE_API_BASE")

--- a/litellm/files/main.py
+++ b/litellm/files/main.py
@@ -223,6 +223,7 @@ def create_file(
                 max_retries=optional_params.max_retries,
                 organization=openai_creds.organization,
                 create_file_data=_create_file_request,
+                litellm_params=litellm_params_dict,
             )
         elif custom_llm_provider == "azure":
             azure_creds: Final = get_azure_credentials(
@@ -344,6 +345,7 @@ def file_retrieve(
                 timeout=timeout,
                 max_retries=optional_params.max_retries,
                 organization=openai_creds.organization,
+                litellm_params=get_litellm_params(**kwargs),
             )
         elif custom_llm_provider == "azure":
             azure_creds: Final = get_azure_credentials(
@@ -525,6 +527,7 @@ def file_delete(
                 timeout=timeout,
                 max_retries=optional_params.max_retries,
                 organization=openai_creds.organization,
+                litellm_params=litellm_params_dict,
             )
         elif custom_llm_provider == "azure":
             azure_creds: Final = get_azure_credentials(
@@ -727,6 +730,7 @@ def file_list(
                 timeout=timeout,
                 max_retries=optional_params.max_retries,
                 organization=openai_creds.organization,
+                litellm_params=get_litellm_params(**kwargs),
             )
         elif custom_llm_provider == "azure":
             azure_creds: Final = get_azure_credentials(
@@ -927,6 +931,7 @@ def file_content(
                 timeout=timeout,
                 max_retries=optional_params.max_retries,
                 organization=openai_creds.organization,
+                litellm_params=litellm_params_dict,
             )
         elif custom_llm_provider == "azure":
             azure_creds: Final = get_azure_credentials(
@@ -1052,6 +1057,7 @@ def file_content_streaming(
             organization=openai_creds.organization,
             chunk_size=chunk_size,
             client=client,
+            litellm_params=optional_params.model_dump(exclude_none=True),
         )
     else:
         raise litellm.exceptions.BadRequestError(

--- a/litellm/fine_tuning/main.py
+++ b/litellm/fine_tuning/main.py
@@ -239,6 +239,7 @@ def create_fine_tuning_job(
                 client=kwargs.get(
                     "client", None
                 ),  # note, when we add this to `GenericLiteLLMParams` it impacts a lot of other tests + linting
+                litellm_params=optional_params.model_dump(exclude_none=True),
             )
         # Azure OpenAI
         elif custom_llm_provider == "azure":
@@ -436,6 +437,7 @@ def cancel_fine_tuning_job(
                 max_retries=optional_params.max_retries,
                 _is_async=_is_async,
                 client=kwargs.get("client", None),
+                litellm_params=optional_params.model_dump(exclude_none=True),
             )
         # Azure OpenAI
         elif custom_llm_provider == "azure":
@@ -591,6 +593,7 @@ def list_fine_tuning_jobs(
                 max_retries=optional_params.max_retries,
                 _is_async=_is_async,
                 client=kwargs.get("client", None),
+                litellm_params=optional_params.model_dump(exclude_none=True),
             )
         # Azure OpenAI
         elif custom_llm_provider == "azure":
@@ -730,6 +733,7 @@ def retrieve_fine_tuning_job(
                 max_retries=optional_params.max_retries,
                 _is_async=_is_async,
                 client=kwargs.get("client", None),
+                litellm_params=optional_params.model_dump(exclude_none=True),
             )
         # Azure OpenAI
         elif custom_llm_provider == "azure":

--- a/litellm/images/main.py
+++ b/litellm/images/main.py
@@ -491,6 +491,7 @@ def image_generation(
                 aimg_generation=aimg_generation,
                 client=client,
                 headers=headers,
+                litellm_params=litellm_params_dict,
             )
         elif custom_llm_provider == "bedrock":
             if model is None:

--- a/litellm/llms/azure/fine_tuning/handler.py
+++ b/litellm/llms/azure/fine_tuning/handler.py
@@ -1,4 +1,4 @@
-from collections.abc import Coroutine
+from collections.abc import Coroutine, Mapping
 from typing import Any, Final, cast
 
 import httpx
@@ -66,6 +66,7 @@ class AzureOpenAIFineTuningAPI(OpenAIFineTuningAPI, BaseAzureLLM):
         max_retries: int | None,
         organization: str | None,
         client: OpenAI | AsyncOpenAI | AzureOpenAI | AsyncAzureOpenAI | None = None,
+        litellm_params: Mapping[str, object] | None = None,
     ) -> LiteLLMFineTuningJob | Coroutine[Any, Any, LiteLLMFineTuningJob]:
         self._ensure_training_type(create_fine_tuning_job_data)
 
@@ -78,6 +79,7 @@ class AzureOpenAIFineTuningAPI(OpenAIFineTuningAPI, BaseAzureLLM):
             client=client,
             _is_async=_is_async,
             api_version=api_version,
+            litellm_params=litellm_params,
         )
         if openai_client is None:
             raise ValueError(
@@ -109,6 +111,7 @@ class AzureOpenAIFineTuningAPI(OpenAIFineTuningAPI, BaseAzureLLM):
         max_retries: int | None,
         organization: str | None,
         client: OpenAI | AsyncOpenAI | AzureOpenAI | AsyncAzureOpenAI | None = None,
+        litellm_params: Mapping[str, object] | None = None,
     ) -> LiteLLMFineTuningJob | Coroutine[Any, Any, LiteLLMFineTuningJob]:
         openai_client: Final[OpenAI | AsyncOpenAI | AzureOpenAI | AsyncAzureOpenAI | None] = self.get_openai_client(
             api_key=api_key,
@@ -119,6 +122,7 @@ class AzureOpenAIFineTuningAPI(OpenAIFineTuningAPI, BaseAzureLLM):
             client=client,
             _is_async=_is_async,
             api_version=api_version,
+            litellm_params=litellm_params,
         )
         if openai_client is None:
             raise ValueError(
@@ -149,6 +153,7 @@ class AzureOpenAIFineTuningAPI(OpenAIFineTuningAPI, BaseAzureLLM):
         max_retries: int | None,
         organization: str | None,
         client: OpenAI | AsyncOpenAI | AzureOpenAI | AsyncAzureOpenAI | None = None,
+        litellm_params: Mapping[str, object] | None = None,
     ) -> LiteLLMFineTuningJob | Coroutine[Any, Any, LiteLLMFineTuningJob]:
         openai_client: Final[OpenAI | AsyncOpenAI | AzureOpenAI | AsyncAzureOpenAI | None] = self.get_openai_client(
             api_key=api_key,
@@ -159,6 +164,7 @@ class AzureOpenAIFineTuningAPI(OpenAIFineTuningAPI, BaseAzureLLM):
             client=client,
             _is_async=_is_async,
             api_version=api_version,
+            litellm_params=litellm_params,
         )
         if openai_client is None:
             raise ValueError(
@@ -188,14 +194,14 @@ class AzureOpenAIFineTuningAPI(OpenAIFineTuningAPI, BaseAzureLLM):
         client: OpenAI | AsyncOpenAI | AzureOpenAI | AsyncAzureOpenAI | None = None,
         _is_async: bool = False,
         api_version: str | None = None,
-        litellm_params: dict | None = None,
+        litellm_params: Mapping[str, object] | None = None,
     ) -> OpenAI | AsyncOpenAI | AzureOpenAI | AsyncAzureOpenAI | None:
         # Override to use Azure-specific client initialization
         if isinstance(client, OpenAI) or isinstance(client, AsyncOpenAI):
             client = None
 
         return self.get_azure_openai_client(
-            litellm_params=litellm_params or {},
+            litellm_params=dict(litellm_params) if litellm_params is not None else None,
             api_key=api_key,
             api_base=api_base,
             api_version=api_version,

--- a/litellm/llms/openai/completion/handler.py
+++ b/litellm/llms/openai/completion/handler.py
@@ -1,8 +1,6 @@
 import json
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from typing import Final
-
-from openai import AsyncOpenAI, OpenAI
 
 import litellm
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
@@ -13,6 +11,7 @@ from litellm.types.utils import LlmProviders, ModelResponse, TextCompletionRespo
 from litellm.utils import ProviderConfigManager
 
 from ..common_utils import BaseOpenAILLM, OpenAIError
+from ..workload_identity import build_async_openai_client, build_openai_client
 from .transformation import OpenAITextCompletionConfig
 
 
@@ -43,7 +42,7 @@ class OpenAITextCompletion(BaseLLM):
         print_verbose: Callable | None = None,
         api_base: str | None = None,
         acompletion: bool = False,
-        litellm_params=None,
+        litellm_params: Mapping[str, object] | None = None,
         logger_fn=None,
         client=None,
         organization: str | None = None,
@@ -95,6 +94,7 @@ class OpenAITextCompletion(BaseLLM):
                         max_retries=max_retries,
                         client=client,
                         organization=organization,
+                        litellm_params=litellm_params,
                     )
                 else:
                     return self.acompletion(
@@ -109,6 +109,7 @@ class OpenAITextCompletion(BaseLLM):
                         max_retries=max_retries,
                         organization=organization,
                         client=client,
+                        litellm_params=litellm_params,
                     )
             elif optional_params.get("stream", False):
                 return self.streaming(
@@ -123,19 +124,22 @@ class OpenAITextCompletion(BaseLLM):
                     max_retries=max_retries,
                     client=client,
                     organization=organization,
+                    litellm_params=litellm_params,
                 )
             else:
-                if client is None:
-                    openai_client = OpenAI(
+                openai_client: Final = (
+                    client
+                    if client is not None
+                    else build_openai_client(
                         api_key=api_key,
-                        base_url=api_base,
-                        http_client=litellm.client_session,
+                        api_base=api_base,
                         timeout=timeout,
                         max_retries=max_retries,
                         organization=organization,
+                        litellm_params=litellm_params,
+                        http_client=litellm.client_session,
                     )
-                else:
-                    openai_client = client
+                )
 
                 raw_response: Final = openai_client.completions.with_raw_response.create(**data)
                 response: Final = raw_response.parse()
@@ -175,19 +179,22 @@ class OpenAITextCompletion(BaseLLM):
         max_retries: int,
         organization: str | None = None,
         client=None,
+        litellm_params: Mapping[str, object] | None = None,
     ):
         try:
-            if client is None:
-                openai_aclient = AsyncOpenAI(
+            openai_aclient: Final = (
+                client
+                if client is not None
+                else build_async_openai_client(
                     api_key=api_key,
-                    base_url=api_base,
-                    http_client=BaseOpenAILLM._get_async_http_client(),
+                    api_base=api_base,
                     timeout=timeout,
                     max_retries=max_retries,
                     organization=organization,
+                    litellm_params=litellm_params,
+                    http_client=BaseOpenAILLM._get_async_http_client(),
                 )
-            else:
-                openai_aclient = client
+            )
 
             raw_response: Final = await openai_aclient.completions.with_raw_response.create(**data)
             response: Final = raw_response.parse()
@@ -228,18 +235,21 @@ class OpenAITextCompletion(BaseLLM):
         max_retries=None,
         client=None,
         organization=None,
+        litellm_params: Mapping[str, object] | None = None,
     ):
-        if client is None:
-            openai_client = OpenAI(
+        openai_client: Final = (
+            client
+            if client is not None
+            else build_openai_client(
                 api_key=api_key,
-                base_url=api_base,
-                http_client=litellm.client_session,
+                api_base=api_base,
                 timeout=timeout,
                 max_retries=max_retries,
                 organization=organization,
+                litellm_params=litellm_params,
+                http_client=litellm.client_session,
             )
-        else:
-            openai_client = client
+        )
 
         try:
             raw_response: Final = openai_client.completions.with_raw_response.create(**data)
@@ -285,18 +295,21 @@ class OpenAITextCompletion(BaseLLM):
         api_base: str | None = None,
         client=None,
         organization=None,
+        litellm_params: Mapping[str, object] | None = None,
     ):
-        if client is None:
-            openai_client = AsyncOpenAI(
+        openai_client: Final = (
+            client
+            if client is not None
+            else build_async_openai_client(
                 api_key=api_key,
-                base_url=api_base,
-                http_client=litellm.aclient_session,
+                api_base=api_base,
                 timeout=timeout,
                 max_retries=max_retries,
                 organization=organization,
+                litellm_params=litellm_params,
+                http_client=litellm.aclient_session,
             )
-        else:
-            openai_client = client
+        )
 
         raw_response: Final = await openai_client.completions.with_raw_response.create(**data)
         response: Final = raw_response.parse()

--- a/litellm/llms/openai/fine_tuning/handler.py
+++ b/litellm/llms/openai/fine_tuning/handler.py
@@ -6,6 +6,7 @@ from openai import AsyncAzureOpenAI, AsyncOpenAI, AzureOpenAI, OpenAI
 from openai.types.fine_tuning import FineTuningJob
 
 from litellm._logging import verbose_logger
+from litellm.llms.openai.workload_identity import build_async_openai_client, build_openai_client
 from litellm.types.utils import LiteLLMFineTuningJob
 
 _AZURE_STATUS_MAP: Final[Mapping[object, str]] = {
@@ -70,27 +71,27 @@ class OpenAIFineTuningAPI:
         client: OpenAI | AsyncOpenAI | AzureOpenAI | AsyncAzureOpenAI | None = None,
         _is_async: bool = False,
         api_version: str | None = None,
-        litellm_params: dict | None = None,
+        litellm_params: Mapping[str, object] | None = None,
     ) -> OpenAI | AsyncOpenAI | AzureOpenAI | AsyncAzureOpenAI | None:
-        received_args: Final = locals()
-        openai_client: OpenAI | AsyncOpenAI | AzureOpenAI | AsyncAzureOpenAI | None = None
-        if client is None:
-            data: Final = {}
-            for k, v in received_args.items():
-                if k == "self" or k == "client" or k == "_is_async":
-                    pass
-                elif k == "api_base" and v is not None:
-                    data["base_url"] = v
-                elif v is not None:
-                    data[k] = v
-            if _is_async is True:
-                openai_client = AsyncOpenAI(**data)
-            else:
-                openai_client = OpenAI(**data)
-        else:
-            openai_client = client
-
-        return openai_client
+        if client is not None:
+            return client
+        if _is_async:
+            return build_async_openai_client(
+                api_key=api_key,
+                api_base=api_base,
+                timeout=timeout,
+                max_retries=max_retries,
+                organization=organization,
+                litellm_params=litellm_params,
+            )
+        return build_openai_client(
+            api_key=api_key,
+            api_base=api_base,
+            timeout=timeout,
+            max_retries=max_retries,
+            organization=organization,
+            litellm_params=litellm_params,
+        )
 
     async def acreate_fine_tuning_job(
         self,
@@ -112,6 +113,7 @@ class OpenAIFineTuningAPI:
         max_retries: int | None,
         organization: str | None,
         client: OpenAI | AsyncOpenAI | AzureOpenAI | AsyncAzureOpenAI | None = None,
+        litellm_params: Mapping[str, object] | None = None,
     ) -> LiteLLMFineTuningJob | Coroutine[object, object, LiteLLMFineTuningJob]:
         openai_client: Final[OpenAI | AsyncOpenAI | AzureOpenAI | AsyncAzureOpenAI | None] = self.get_openai_client(
             api_key=api_key,
@@ -122,6 +124,7 @@ class OpenAIFineTuningAPI:
             client=client,
             _is_async=_is_async,
             api_version=api_version,
+            litellm_params=litellm_params,
         )
         if openai_client is None:
             raise ValueError(
@@ -160,6 +163,7 @@ class OpenAIFineTuningAPI:
         max_retries: int | None,
         organization: str | None,
         client: OpenAI | AsyncOpenAI | AzureOpenAI | AsyncAzureOpenAI | None = None,
+        litellm_params: Mapping[str, object] | None = None,
     ) -> LiteLLMFineTuningJob | Coroutine[object, object, LiteLLMFineTuningJob]:
         openai_client: Final[OpenAI | AsyncOpenAI | AzureOpenAI | AsyncAzureOpenAI | None] = self.get_openai_client(
             api_key=api_key,
@@ -170,6 +174,7 @@ class OpenAIFineTuningAPI:
             client=client,
             _is_async=_is_async,
             api_version=api_version,
+            litellm_params=litellm_params,
         )
         if openai_client is None:
             raise ValueError(
@@ -208,6 +213,7 @@ class OpenAIFineTuningAPI:
         max_retries: int | None,
         organization: str | None,
         client: OpenAI | AsyncOpenAI | AzureOpenAI | AsyncAzureOpenAI | None = None,
+        litellm_params: Mapping[str, object] | None = None,
         after: str | None = None,
         limit: int | None = None,
     ):
@@ -220,6 +226,7 @@ class OpenAIFineTuningAPI:
             client=client,
             _is_async=_is_async,
             api_version=api_version,
+            litellm_params=litellm_params,
         )
         if openai_client is None:
             raise ValueError(
@@ -259,6 +266,7 @@ class OpenAIFineTuningAPI:
         max_retries: int | None,
         organization: str | None,
         client: OpenAI | AsyncOpenAI | AzureOpenAI | AsyncAzureOpenAI | None = None,
+        litellm_params: Mapping[str, object] | None = None,
     ) -> LiteLLMFineTuningJob | Coroutine[object, object, LiteLLMFineTuningJob]:
         openai_client: Final[OpenAI | AsyncOpenAI | AzureOpenAI | AsyncAzureOpenAI | None] = self.get_openai_client(
             api_key=api_key,
@@ -269,6 +277,7 @@ class OpenAIFineTuningAPI:
             client=client,
             _is_async=_is_async,
             api_version=api_version,
+            litellm_params=litellm_params,
         )
         if openai_client is None:
             raise ValueError(

--- a/litellm/llms/openai/openai.py
+++ b/litellm/llms/openai/openai.py
@@ -57,7 +57,11 @@ from .common_utils import (
     is_openai_backed_api_base,
     is_output_token_limit_error,
 )
-from .workload_identity import resolve_openai_workload_identity_config
+from .workload_identity import (
+    build_async_openai_client,
+    build_openai_client,
+    resolve_openai_workload_identity_config,
+)
 
 openaiOSeriesConfig: Final = OpenAIOSeriesConfig()
 openAIGPT5Config: Final = OpenAIGPT5Config()
@@ -1414,11 +1418,13 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         max_retries=None,
         organization: str | None = None,
         headers: dict | None = None,
+        litellm_params: Mapping[str, object] | None = None,
     ):
         response = None
         try:
             openai_aclient: Final = self._get_openai_client(
                 is_async=True,
+                litellm_params=litellm_params,
                 api_key=api_key,
                 api_base=api_base,
                 timeout=timeout,
@@ -1478,6 +1484,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         aimg_generation=None,
         organization: str | None = None,
         headers: dict | None = None,
+        litellm_params: Mapping[str, object] | None = None,
     ) -> ImageResponse:
         data = {}
         try:
@@ -1499,10 +1506,12 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                     max_retries=max_retries,
                     organization=organization,
                     headers=headers,
+                    litellm_params=litellm_params,
                 )
 
             openai_client: Final[OpenAI] = self._get_openai_client(
                 is_async=False,
+                litellm_params=litellm_params,
                 api_key=api_key,
                 api_base=api_base,
                 timeout=timeout,
@@ -1580,6 +1589,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         aspeech: bool | None = None,
         client=None,
         shared_session: Optional["ClientSession"] = None,
+        litellm_params: Mapping[str, object] | None = None,
     ) -> HttpxBinaryResponseContent:
         if aspeech is not None and aspeech is True:
             return self.async_audio_speech(
@@ -1596,6 +1606,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                 logging_obj=logging_obj,
                 client=client,
                 shared_session=shared_session,
+                litellm_params=litellm_params,
             )
 
         openai_client: Final = self._get_openai_client(
@@ -1606,6 +1617,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
             max_retries=max_retries,
             client=client,
             shared_session=shared_session,
+            litellm_params=litellm_params,
         )
 
         sync_client: Final = cast(OpenAI, openai_client)
@@ -1641,6 +1653,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         logging_obj: LiteLLMLoggingObj,
         client=None,
         shared_session: Optional["ClientSession"] = None,
+        litellm_params: Mapping[str, object] | None = None,
     ) -> HttpxBinaryResponseContent:
         openai_client: Final = cast(
             AsyncOpenAI,
@@ -1652,6 +1665,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                 max_retries=max_retries,
                 client=client,
                 shared_session=shared_session,
+                litellm_params=litellm_params,
             ),
         )
 
@@ -1697,26 +1711,27 @@ class OpenAIFilesAPI(BaseLLM):
         organization: str | None,
         client: OpenAI | AsyncOpenAI | None = None,
         _is_async: bool = False,
+        litellm_params: Mapping[str, object] | None = None,
     ) -> OpenAI | AsyncOpenAI | None:
-        received_args: Final[Mapping[str, object]] = locals()
-        openai_client: OpenAI | AsyncOpenAI | None = None
-        if client is None:
-            data: Final = {}
-            for k, v in received_args.items():
-                if k == "self" or k == "client" or k == "_is_async":
-                    pass
-                elif k == "api_base" and v is not None:
-                    data["base_url"] = v
-                elif v is not None:
-                    data[k] = v
-            if _is_async is True:
-                openai_client = AsyncOpenAI(**data)
-            else:
-                openai_client = OpenAI(**data)
-        else:
-            openai_client = client
-
-        return openai_client
+        if client is not None:
+            return client
+        if _is_async:
+            return build_async_openai_client(
+                api_key=api_key,
+                api_base=api_base,
+                timeout=timeout,
+                max_retries=max_retries,
+                organization=organization,
+                litellm_params=litellm_params,
+            )
+        return build_openai_client(
+            api_key=api_key,
+            api_base=api_base,
+            timeout=timeout,
+            max_retries=max_retries,
+            organization=organization,
+            litellm_params=litellm_params,
+        )
 
     async def acreate_file(
         self,
@@ -1736,6 +1751,7 @@ class OpenAIFilesAPI(BaseLLM):
         max_retries: int | None,
         organization: str | None,
         client: OpenAI | AsyncOpenAI | None = None,
+        litellm_params: Mapping[str, object] | None = None,
     ) -> OpenAIFileObject | Coroutine[None, None, OpenAIFileObject]:
         openai_client: Final[OpenAI | AsyncOpenAI | None] = self.get_openai_client(
             api_key=api_key,
@@ -1745,6 +1761,7 @@ class OpenAIFilesAPI(BaseLLM):
             organization=organization,
             client=client,
             _is_async=_is_async,
+            litellm_params=litellm_params,
         )
         if openai_client is None:
             raise ValueError(
@@ -1778,6 +1795,7 @@ class OpenAIFilesAPI(BaseLLM):
         max_retries: int | None,
         organization: str | None,
         client: OpenAI | AsyncOpenAI | None = None,
+        litellm_params: Mapping[str, object] | None = None,
     ) -> HttpxBinaryResponseContent | Coroutine[None, None, HttpxBinaryResponseContent]:
         openai_client: Final[OpenAI | AsyncOpenAI | None] = self.get_openai_client(
             api_key=api_key,
@@ -1787,6 +1805,7 @@ class OpenAIFilesAPI(BaseLLM):
             organization=organization,
             client=client,
             _is_async=_is_async,
+            litellm_params=litellm_params,
         )
         if openai_client is None:
             raise ValueError(
@@ -1843,6 +1862,7 @@ class OpenAIFilesAPI(BaseLLM):
         organization: str | None,
         chunk_size: int = 1024 * 1024,
         client: OpenAI | AsyncOpenAI | None = None,
+        litellm_params: Mapping[str, object] | None = None,
     ) -> FileContentStreamingResult:
         openai_client: Final[OpenAI | AsyncOpenAI | None] = self.get_openai_client(
             api_key=api_key,
@@ -1852,6 +1872,7 @@ class OpenAIFilesAPI(BaseLLM):
             organization=organization,
             client=client,
             _is_async=_is_async,
+            litellm_params=litellm_params,
         )
         if openai_client is None:
             raise ValueError(
@@ -1906,6 +1927,7 @@ class OpenAIFilesAPI(BaseLLM):
         max_retries: int | None,
         organization: str | None,
         client: OpenAI | AsyncOpenAI | None = None,
+        litellm_params: Mapping[str, object] | None = None,
     ):
         openai_client: Final[OpenAI | AsyncOpenAI | None] = self.get_openai_client(
             api_key=api_key,
@@ -1915,6 +1937,7 @@ class OpenAIFilesAPI(BaseLLM):
             organization=organization,
             client=client,
             _is_async=_is_async,
+            litellm_params=litellm_params,
         )
         if openai_client is None:
             raise ValueError(
@@ -1952,6 +1975,7 @@ class OpenAIFilesAPI(BaseLLM):
         max_retries: int | None,
         organization: str | None,
         client: OpenAI | AsyncOpenAI | None = None,
+        litellm_params: Mapping[str, object] | None = None,
     ):
         openai_client: Final[OpenAI | AsyncOpenAI | None] = self.get_openai_client(
             api_key=api_key,
@@ -1961,6 +1985,7 @@ class OpenAIFilesAPI(BaseLLM):
             organization=organization,
             client=client,
             _is_async=_is_async,
+            litellm_params=litellm_params,
         )
         if openai_client is None:
             raise ValueError(
@@ -2001,6 +2026,7 @@ class OpenAIFilesAPI(BaseLLM):
         organization: str | None,
         purpose: str | None = None,
         client: OpenAI | AsyncOpenAI | None = None,
+        litellm_params: Mapping[str, object] | None = None,
     ):
         openai_client: Final[OpenAI | AsyncOpenAI | None] = self.get_openai_client(
             api_key=api_key,
@@ -2010,6 +2036,7 @@ class OpenAIFilesAPI(BaseLLM):
             organization=organization,
             client=client,
             _is_async=_is_async,
+            litellm_params=litellm_params,
         )
         if openai_client is None:
             raise ValueError(
@@ -2055,26 +2082,27 @@ class OpenAIBatchesAPI(BaseLLM):
         organization: str | None,
         client: OpenAI | AsyncOpenAI | None = None,
         _is_async: bool = False,
+        litellm_params: Mapping[str, object] | None = None,
     ) -> OpenAI | AsyncOpenAI | None:
-        received_args: Final[Mapping[str, object]] = locals()
-        openai_client: OpenAI | AsyncOpenAI | None = None
-        if client is None:
-            data: Final = {}
-            for k, v in received_args.items():
-                if k == "self" or k == "client" or k == "_is_async":
-                    pass
-                elif k == "api_base" and v is not None:
-                    data["base_url"] = v
-                elif v is not None:
-                    data[k] = v
-            if _is_async is True:
-                openai_client = AsyncOpenAI(**data)
-            else:
-                openai_client = OpenAI(**data)
-        else:
-            openai_client = client
-
-        return openai_client
+        if client is not None:
+            return client
+        if _is_async:
+            return build_async_openai_client(
+                api_key=api_key,
+                api_base=api_base,
+                timeout=timeout,
+                max_retries=max_retries,
+                organization=organization,
+                litellm_params=litellm_params,
+            )
+        return build_openai_client(
+            api_key=api_key,
+            api_base=api_base,
+            timeout=timeout,
+            max_retries=max_retries,
+            organization=organization,
+            litellm_params=litellm_params,
+        )
 
     async def acreate_batch(
         self,
@@ -2094,6 +2122,7 @@ class OpenAIBatchesAPI(BaseLLM):
         max_retries: int | None,
         organization: str | None,
         client: OpenAI | AsyncOpenAI | None = None,
+        litellm_params: Mapping[str, object] | None = None,
     ) -> LiteLLMBatch | Coroutine[None, None, LiteLLMBatch]:
         openai_client: Final[OpenAI | AsyncOpenAI | None] = self.get_openai_client(
             api_key=api_key,
@@ -2103,6 +2132,7 @@ class OpenAIBatchesAPI(BaseLLM):
             organization=organization,
             client=client,
             _is_async=_is_async,
+            litellm_params=litellm_params,
         )
         if openai_client is None:
             raise ValueError(
@@ -2138,6 +2168,7 @@ class OpenAIBatchesAPI(BaseLLM):
         max_retries: int | None,
         organization: str | None,
         client: OpenAI | None = None,
+        litellm_params: Mapping[str, object] | None = None,
     ):
         openai_client: Final[OpenAI | AsyncOpenAI | None] = self.get_openai_client(
             api_key=api_key,
@@ -2147,6 +2178,7 @@ class OpenAIBatchesAPI(BaseLLM):
             organization=organization,
             client=client,
             _is_async=_is_async,
+            litellm_params=litellm_params,
         )
         if openai_client is None:
             raise ValueError(
@@ -2181,6 +2213,7 @@ class OpenAIBatchesAPI(BaseLLM):
         max_retries: int | None,
         organization: str | None,
         client: OpenAI | None = None,
+        litellm_params: Mapping[str, object] | None = None,
     ):
         openai_client: Final[OpenAI | AsyncOpenAI | None] = self.get_openai_client(
             api_key=api_key,
@@ -2190,6 +2223,7 @@ class OpenAIBatchesAPI(BaseLLM):
             organization=organization,
             client=client,
             _is_async=_is_async,
+            litellm_params=litellm_params,
         )
         if openai_client is None:
             raise ValueError(
@@ -2230,6 +2264,7 @@ class OpenAIBatchesAPI(BaseLLM):
         after: str | None = None,
         limit: int | None = None,
         client: OpenAI | None = None,
+        litellm_params: Mapping[str, object] | None = None,
     ):
         openai_client: Final[OpenAI | AsyncOpenAI | None] = self.get_openai_client(
             api_key=api_key,
@@ -2239,6 +2274,7 @@ class OpenAIBatchesAPI(BaseLLM):
             organization=organization,
             client=client,
             _is_async=_is_async,
+            litellm_params=litellm_params,
         )
         if openai_client is None:
             raise ValueError(

--- a/litellm/llms/openai/transcriptions/handler.py
+++ b/litellm/llms/openai/transcriptions/handler.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Final, Optional, cast
 
 import httpx
@@ -112,6 +113,7 @@ class OpenAIAudioTranscription(OpenAIChatCompletion):
                 max_retries=max_retries,
                 logging_obj=logging_obj,
                 shared_session=shared_session,
+                litellm_params=litellm_params,
             )
 
         openai_client: Final[OpenAI] = self._get_openai_client(
@@ -121,6 +123,7 @@ class OpenAIAudioTranscription(OpenAIChatCompletion):
             timeout=timeout,
             max_retries=max_retries,
             client=client,
+            litellm_params=litellm_params,
         )
 
         ## LOGGING
@@ -172,6 +175,7 @@ class OpenAIAudioTranscription(OpenAIChatCompletion):
         client=None,
         max_retries=None,
         shared_session: Optional["ClientSession"] = None,
+        litellm_params: Mapping[str, object] | None = None,
     ):
         try:
             openai_aclient: Final[AsyncOpenAI] = self._get_openai_client(
@@ -182,6 +186,7 @@ class OpenAIAudioTranscription(OpenAIChatCompletion):
                 max_retries=max_retries,
                 client=client,
                 shared_session=shared_session,
+                litellm_params=litellm_params,
             )
 
             ## LOGGING

--- a/litellm/llms/openai/workload_identity.py
+++ b/litellm/llms/openai/workload_identity.py
@@ -6,7 +6,11 @@ from functools import lru_cache
 from typing import TYPE_CHECKING, Final
 from urllib.parse import urlparse
 
+import httpx
+from openai import NOT_GIVEN, AsyncOpenAI, NotGiven, OpenAI
+
 import litellm
+from litellm.constants import DEFAULT_MAX_RETRIES
 from litellm.secret_managers.main import get_secret_str, normalize_nonempty_secret_str
 
 from .common_utils import OpenAIError, is_openai_backed_api_base
@@ -79,6 +83,72 @@ def _config_value(litellm_params: Mapping[str, object] | None, param_key: str, e
     if isinstance(param_value, str) and param_value:
         return param_value
     return normalize_nonempty_secret_str(get_secret_str(env_name))
+
+
+def build_openai_client(
+    api_key: str | None,
+    api_base: str | None,
+    timeout: float | httpx.Timeout | NotGiven = NOT_GIVEN,
+    max_retries: int | None = None,
+    organization: str | None = None,
+    litellm_params: Mapping[str, object] | None = None,
+    http_client: httpx.Client | None = None,
+) -> OpenAI:
+    workload_identity_config: Final = resolve_openai_workload_identity_config(
+        api_key=api_key, api_base=api_base, litellm_params=litellm_params
+    )
+    if workload_identity_config is None:
+        return OpenAI(
+            api_key=api_key,
+            base_url=api_base,
+            timeout=timeout,
+            max_retries=_max_retries_or_default(max_retries),
+            organization=organization,
+            http_client=http_client,
+        )
+    return OpenAI(
+        workload_identity=workload_identity_config.to_sdk_workload_identity(),
+        base_url=api_base,
+        timeout=timeout,
+        max_retries=_max_retries_or_default(max_retries),
+        organization=organization,
+        http_client=http_client,
+    )
+
+
+def build_async_openai_client(
+    api_key: str | None,
+    api_base: str | None,
+    timeout: float | httpx.Timeout | NotGiven = NOT_GIVEN,
+    max_retries: int | None = None,
+    organization: str | None = None,
+    litellm_params: Mapping[str, object] | None = None,
+    http_client: httpx.AsyncClient | None = None,
+) -> AsyncOpenAI:
+    workload_identity_config: Final = resolve_openai_workload_identity_config(
+        api_key=api_key, api_base=api_base, litellm_params=litellm_params
+    )
+    if workload_identity_config is None:
+        return AsyncOpenAI(
+            api_key=api_key,
+            base_url=api_base,
+            timeout=timeout,
+            max_retries=_max_retries_or_default(max_retries),
+            organization=organization,
+            http_client=http_client,
+        )
+    return AsyncOpenAI(
+        workload_identity=workload_identity_config.to_sdk_workload_identity(),
+        base_url=api_base,
+        timeout=timeout,
+        max_retries=_max_retries_or_default(max_retries),
+        organization=organization,
+        http_client=http_client,
+    )
+
+
+def _max_retries_or_default(max_retries: int | None) -> int:
+    return DEFAULT_MAX_RETRIES if max_retries is None else max_retries
 
 
 def _targets_openai_api(api_base: str | None) -> bool:

--- a/litellm/llms/openai/workload_identity.py
+++ b/litellm/llms/openai/workload_identity.py
@@ -11,9 +11,10 @@ from openai import NOT_GIVEN, AsyncOpenAI, NotGiven, OpenAI
 
 import litellm
 from litellm.constants import DEFAULT_MAX_RETRIES
+from litellm.litellm_core_utils.get_litellm_params import OPENAI_WIF_KWARGS_KEYS
 from litellm.secret_managers.main import get_secret_str, normalize_nonempty_secret_str
 
-from .common_utils import OpenAIError, is_openai_backed_api_base
+from .common_utils import BaseOpenAILLM, OpenAIError, is_openai_backed_api_base
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -53,7 +54,7 @@ def resolve_openai_workload_identity_config(
     static_api_key: Final = normalize_nonempty_secret_str(api_key) or normalize_nonempty_secret_str(
         get_secret_str("OPENAI_API_KEY")
     )
-    if static_api_key is not None:
+    if static_api_key is not None and not _deployment_identity_outranks(static_api_key, litellm_params):
         return None
     effective_api_base: Final = (
         api_base or litellm.api_base or get_secret_str("OPENAI_BASE_URL") or get_secret_str("OPENAI_API_BASE")
@@ -78,11 +79,26 @@ def get_workload_identity_bearer_token(config: OpenAIWorkloadIdentityConfig) -> 
     return _workload_identity_auth(config).get_token()
 
 
+def _deployment_identity_outranks(static_api_key: str, litellm_params: Mapping[str, object] | None) -> bool:
+    if litellm_params is None:
+        return False
+    carries_identity: Final = any(_param_str(litellm_params, key) is not None for key in OPENAI_WIF_KWARGS_KEYS)
+    return carries_identity and static_api_key in _process_wide_static_keys()
+
+
+def _process_wide_static_keys() -> frozenset[str]:
+    candidates: Final = (get_secret_str("OPENAI_API_KEY"), litellm.api_key, litellm.openai_key)
+    return frozenset(key for key in map(normalize_nonempty_secret_str, candidates) if key is not None)
+
+
+def _param_str(litellm_params: Mapping[str, object], key: str) -> str | None:
+    value: Final = litellm_params.get(key)
+    return value if isinstance(value, str) and value else None
+
+
 def _config_value(litellm_params: Mapping[str, object] | None, param_key: str, env_name: str) -> str | None:
-    param_value: Final = litellm_params.get(param_key) if litellm_params is not None else None
-    if isinstance(param_value, str) and param_value:
-        return param_value
-    return normalize_nonempty_secret_str(get_secret_str(env_name))
+    param_value: Final = _param_str(litellm_params, param_key) if litellm_params is not None else None
+    return param_value or normalize_nonempty_secret_str(get_secret_str(env_name))
 
 
 def build_openai_client(
@@ -97,23 +113,44 @@ def build_openai_client(
     workload_identity_config: Final = resolve_openai_workload_identity_config(
         api_key=api_key, api_base=api_base, litellm_params=litellm_params
     )
+    retries: Final = _max_retries_or_default(max_retries)
     if workload_identity_config is None:
         return OpenAI(
             api_key=api_key,
             base_url=api_base,
             timeout=timeout,
-            max_retries=_max_retries_or_default(max_retries),
+            max_retries=retries,
             organization=organization,
             http_client=http_client,
         )
-    return OpenAI(
+    cache_params: Final = _client_cache_params(
+        is_async=False,
+        workload_identity_config=workload_identity_config,
+        api_base=api_base,
+        timeout=timeout,
+        max_retries=retries,
+        organization=organization,
+    )
+    cached: Final = BaseOpenAILLM.get_cached_openai_client(
+        client_initialization_params=cache_params, client_type="openai"
+    )
+    if isinstance(cached, OpenAI):
+        return cached
+    client: Final = OpenAI(
         workload_identity=workload_identity_config.to_sdk_workload_identity(),
         base_url=api_base,
         timeout=timeout,
-        max_retries=_max_retries_or_default(max_retries),
+        max_retries=retries,
         organization=organization,
         http_client=http_client,
     )
+    BaseOpenAILLM.set_cached_openai_client(
+        openai_client=client,
+        client_type="openai",
+        client_initialization_params=cache_params,
+        litellm_owned_client=BaseOpenAILLM.owns_wrapped_http_client(http_client),
+    )
+    return client
 
 
 def build_async_openai_client(
@@ -128,23 +165,63 @@ def build_async_openai_client(
     workload_identity_config: Final = resolve_openai_workload_identity_config(
         api_key=api_key, api_base=api_base, litellm_params=litellm_params
     )
+    retries: Final = _max_retries_or_default(max_retries)
     if workload_identity_config is None:
         return AsyncOpenAI(
             api_key=api_key,
             base_url=api_base,
             timeout=timeout,
-            max_retries=_max_retries_or_default(max_retries),
+            max_retries=retries,
             organization=organization,
             http_client=http_client,
         )
-    return AsyncOpenAI(
+    cache_params: Final = _client_cache_params(
+        is_async=True,
+        workload_identity_config=workload_identity_config,
+        api_base=api_base,
+        timeout=timeout,
+        max_retries=retries,
+        organization=organization,
+    )
+    cached: Final = BaseOpenAILLM.get_cached_openai_client(
+        client_initialization_params=cache_params, client_type="openai"
+    )
+    if isinstance(cached, AsyncOpenAI):
+        return cached
+    client: Final = AsyncOpenAI(
         workload_identity=workload_identity_config.to_sdk_workload_identity(),
         base_url=api_base,
         timeout=timeout,
-        max_retries=_max_retries_or_default(max_retries),
+        max_retries=retries,
         organization=organization,
         http_client=http_client,
     )
+    BaseOpenAILLM.set_cached_openai_client(
+        openai_client=client,
+        client_type="openai",
+        client_initialization_params=cache_params,
+        litellm_owned_client=BaseOpenAILLM.owns_wrapped_http_client(http_client),
+    )
+    return client
+
+
+def _client_cache_params(
+    is_async: bool,
+    workload_identity_config: OpenAIWorkloadIdentityConfig,
+    api_base: str | None,
+    timeout: float | httpx.Timeout | NotGiven,
+    max_retries: int,
+    organization: str | None,
+) -> dict[str, object]:
+    return {
+        "api_key": None,
+        "is_async": is_async,
+        "workload_identity_config": workload_identity_config,
+        "api_base": api_base,
+        "timeout": timeout,
+        "max_retries": max_retries,
+        "organization": organization,
+    }
 
 
 def _max_retries_or_default(max_retries: int | None) -> int:

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -227,6 +227,7 @@ from .llms.openai.completion.handler import OpenAITextCompletion
 from .llms.openai.image_variations.handler import OpenAIImageVariationsHandler
 from .llms.openai.openai import OpenAIChatCompletion
 from .llms.openai.transcriptions.handler import OpenAIAudioTranscription
+from .llms.openai.workload_identity import build_openai_client
 from .llms.openai_like.chat.handler import OpenAILikeChatHandler
 from .llms.openai_like.embedding.handler import OpenAILikeEmbeddingHandler
 from .llms.ovhcloud.chat.transformation import OVHCloudChatConfig
@@ -7528,12 +7529,9 @@ def moderation(input: str, model: str | None = None, api_key: str | None = None,
     # Extract api_base from kwargs
     api_base: Final = kwargs.get("api_base", None)
 
-    openai_client = kwargs.get("client", None)
-    if openai_client is None:
-        if api_base is not None:
-            openai_client = openai.OpenAI(api_key=api_key, base_url=api_base)
-        else:
-            openai_client = openai.OpenAI(api_key=api_key)
+    openai_client: Final = kwargs.get("client", None) or build_openai_client(
+        api_key=api_key, api_base=api_base, litellm_params=get_litellm_params(**kwargs)
+    )
 
     if model is not None:
         response = openai_client.moderations.create(input=input, model=model)
@@ -7585,6 +7583,7 @@ async def amoderation(
             is_async=True,
             api_key=api_key,
             api_base=optional_params.api_base or _dynamic_api_base,
+            litellm_params=get_litellm_params(**kwargs),
         )
     else:
         _openai_client = openai_client
@@ -8122,6 +8121,7 @@ def speech(
             client=client,  # pass AsyncOpenAI, OpenAI client
             aspeech=aspeech,
             shared_session=shared_session,
+            litellm_params=litellm_params_dict,
         )
     elif custom_llm_provider in AZURE_OPENAI_AUDIO_PROVIDERS:
         # Check if this is Azure Speech Service (Cognitive Services TTS)

--- a/tests/llm_translation/test_text_completion_unit_tests.py
+++ b/tests/llm_translation/test_text_completion_unit_tests.py
@@ -186,7 +186,7 @@ async def test_acompletion_uses_optimized_http_client():
         BaseOpenAILLM, "_get_async_http_client", return_value=mock_http_client
     ) as mock_get_client:
         with patch(
-            "litellm.llms.openai.completion.handler.AsyncOpenAI",
+            "litellm.llms.openai.workload_identity.AsyncOpenAI",
             return_value=mock_async_openai,
         ) as mock_openai_class:
             handler = OpenAITextCompletion()

--- a/tests/test_litellm/batches/test_batch_utils.py
+++ b/tests/test_litellm/batches/test_batch_utils.py
@@ -635,9 +635,7 @@ async def test_calculate_vertex_disable_transform_needs_model_name(monkeypatch):
         lambda content, model: pytest.fail("raw vertex path should not run"),
     )
 
-    result = await bu.calculate_batch_cost_and_usage(
-        file_content_dictionary=[], custom_llm_provider="vertex_ai"
-    )
+    result = await bu.calculate_batch_cost_and_usage(file_content_dictionary=[], custom_llm_provider="vertex_ai")
     assert result.cost == 0.0
     assert result.usage.total_tokens == 0
     assert result.models == []
@@ -1484,7 +1482,9 @@ def test_anthropic_cost_without_model_info_uses_batch_cost_calculator(monkeypatc
         lambda **kw: pytest.fail("anthropic rows must not go through completion_cost"),
     )
 
-    result = bu._aggregate_batch_cost_usage_models(entries=[_anthropic_succeeded_row()], custom_llm_provider="anthropic")
+    result = bu._aggregate_batch_cost_usage_models(
+        entries=[_anthropic_succeeded_row()], custom_llm_provider="anthropic"
+    )
 
     assert result.cost == pytest.approx(0.3)
     assert seen[0]["model"] == "claude-sonnet-4-5-20250929"
@@ -1519,7 +1519,11 @@ async def test_calculate_batch_cost_and_usage_anthropic_end_to_end():
     )
 
     assert result.cost == pytest.approx(1000 * 3e-6 / 2 + 8000 * 3e-7 / 2 + 2000 * 3.75e-6 / 2 + 200 * 15e-6 / 2)
-    assert (result.usage.prompt_tokens, result.usage.completion_tokens, result.usage.total_tokens) == (11000, 200, 11200)
+    assert (result.usage.prompt_tokens, result.usage.completion_tokens, result.usage.total_tokens) == (
+        11000,
+        200,
+        11200,
+    )
     assert result.models == ["claude-sonnet-4-5"]
 
 
@@ -1767,3 +1771,17 @@ class TestFileAccessCredentialsCarryFederation:
         credentials = _extract_file_access_credentials(params)
 
         assert set(credentials) == set(ANTHROPIC_WIF_KWARGS_KEYS)
+
+
+def test_extract_credentials_keeps_openai_workload_identity_params():
+    params = {
+        "openai_identity_provider_id": "idp_deployment",
+        "openai_service_account_id": "user-deployment",
+        "openai_identity_token_file": "/var/run/secrets/token",
+        "model": "gpt-4o",
+    }
+    assert bu._extract_file_access_credentials(params) == {
+        "openai_identity_provider_id": "idp_deployment",
+        "openai_service_account_id": "user-deployment",
+        "openai_identity_token_file": "/var/run/secrets/token",
+    }

--- a/tests/test_litellm/llms/openai/test_openai_workload_identity.py
+++ b/tests/test_litellm/llms/openai/test_openai_workload_identity.py
@@ -602,7 +602,6 @@ class TestDiscoverModels:
         assert models_route.calls.last.request.headers["Authorization"] == "Bearer None"
         assert not exchange_route.called
 
-
     @respx.mock
     def test_empty_static_key_never_borrows_the_env_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("OPENAI_API_KEY", "sk-env-key-that-must-stay-home")
@@ -630,3 +629,380 @@ class TestClientsideBaseOverride:
             )
             is None
         )
+
+
+IMAGES_URL: Final = "https://api.openai.com/v1/images/generations"
+SPEECH_URL: Final = "https://api.openai.com/v1/audio/speech"
+TRANSCRIPTIONS_URL: Final = "https://api.openai.com/v1/audio/transcriptions"
+MODERATIONS_URL: Final = "https://api.openai.com/v1/moderations"
+COMPLETIONS_URL: Final = "https://api.openai.com/v1/completions"
+FILES_URL: Final = "https://api.openai.com/v1/files"
+BATCHES_URL: Final = "https://api.openai.com/v1/batches"
+FINE_TUNING_JOBS_URL: Final = "https://api.openai.com/v1/fine_tuning/jobs"
+IMAGE_BODY: Final = {"created": 1, "data": [{"b64_json": "aGk="}]}
+MODERATION_BODY: Final = {
+    "id": "modr-1",
+    "model": "omni-moderation-latest",
+    "results": [{"flagged": False, "categories": {}, "category_scores": {}}],
+}
+TEXT_COMPLETION_BODY: Final = {
+    "id": "cmpl-1",
+    "object": "text_completion",
+    "created": 1,
+    "model": "gpt-3.5-turbo-instruct",
+    "choices": [{"text": "ok", "index": 0, "finish_reason": "stop", "logprobs": None}],
+    "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+}
+FILE_BODY: Final = {
+    "id": "file-1",
+    "object": "file",
+    "bytes": 2,
+    "created_at": 1,
+    "filename": "in.jsonl",
+    "purpose": "batch",
+    "status": "processed",
+}
+FILE_DELETED_BODY: Final = {"id": "file-1", "object": "file", "deleted": True}
+BATCH_BODY: Final = {
+    "id": "batch-1",
+    "object": "batch",
+    "endpoint": "/v1/chat/completions",
+    "input_file_id": "file-1",
+    "completion_window": "24h",
+    "status": "validating",
+    "created_at": 1,
+}
+FINE_TUNING_JOB_BODY: Final = {
+    "id": "ftjob-1",
+    "object": "fine_tuning.job",
+    "created_at": 1,
+    "error": None,
+    "fine_tuned_model": None,
+    "finished_at": None,
+    "hyperparameters": {"n_epochs": "auto"},
+    "model": "gpt-5.4-nano",
+    "organization_id": "org-1",
+    "result_files": [],
+    "seed": 0,
+    "status": "queued",
+    "trained_tokens": None,
+    "training_file": "file-1",
+    "validation_file": None,
+}
+
+
+def mock_streaming_text_completions() -> respx.Route:
+    events: Final = (
+        {
+            "id": "cmpl-1",
+            "object": "text_completion",
+            "created": 1,
+            "model": "gpt-3.5-turbo-instruct",
+            "choices": [{"text": "ok", "index": 0, "finish_reason": None, "logprobs": None}],
+        },
+        {
+            "id": "cmpl-1",
+            "object": "text_completion",
+            "created": 1,
+            "model": "gpt-3.5-turbo-instruct",
+            "choices": [{"text": "", "index": 0, "finish_reason": "stop", "logprobs": None}],
+        },
+    )
+    body: Final = "".join(f"data: {json.dumps(event)}\n\n" for event in events) + "data: [DONE]\n\n"
+    return respx.post(COMPLETIONS_URL).mock(
+        return_value=httpx.Response(200, content=body, headers={"content-type": "text/event-stream"})
+    )
+
+
+def bearer_of(route: respx.Route) -> str:
+    return route.calls.last.request.headers["Authorization"]
+
+
+class TestDeploymentNonChatSurfaces:
+    @respx.mock
+    def test_image_generation_kwargs_carry_exchanged_bearer(self, deployment_wif: dict[str, str]) -> None:
+        mock_token_exchange("image-bearer")
+        route: Final = respx.post(IMAGES_URL).mock(return_value=httpx.Response(200, json=IMAGE_BODY))
+
+        response: Final = litellm.image_generation(model="openai/gpt-image-2", prompt="a cat", **deployment_wif)
+
+        assert response.data[0].b64_json == "aGk="
+        assert bearer_of(route) == "Bearer image-bearer"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_async_image_generation_kwargs_carry_exchanged_bearer(self, deployment_wif: dict[str, str]) -> None:
+        mock_token_exchange("aimage-bearer")
+        route: Final = respx.post(IMAGES_URL).mock(return_value=httpx.Response(200, json=IMAGE_BODY))
+
+        response: Final = await litellm.aimage_generation(model="openai/gpt-image-2", prompt="a cat", **deployment_wif)
+
+        assert response.data[0].b64_json == "aGk="
+        assert bearer_of(route) == "Bearer aimage-bearer"
+
+    @respx.mock
+    def test_speech_kwargs_carry_exchanged_bearer(self, deployment_wif: dict[str, str]) -> None:
+        mock_token_exchange("speech-bearer")
+        route: Final = respx.post(SPEECH_URL).mock(
+            return_value=httpx.Response(200, content=b"audio", headers={"content-type": "audio/mpeg"})
+        )
+
+        response: Final = litellm.speech(model="openai/gpt-4o-mini-tts", input="hi", voice="alloy", **deployment_wif)
+
+        assert response.content == b"audio"
+        assert bearer_of(route) == "Bearer speech-bearer"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_async_speech_kwargs_carry_exchanged_bearer(self, deployment_wif: dict[str, str]) -> None:
+        mock_token_exchange("aspeech-bearer")
+        route: Final = respx.post(SPEECH_URL).mock(
+            return_value=httpx.Response(200, content=b"audio", headers={"content-type": "audio/mpeg"})
+        )
+
+        response: Final = await litellm.aspeech(
+            model="openai/gpt-4o-mini-tts", input="hi", voice="alloy", **deployment_wif
+        )
+
+        assert response.content == b"audio"
+        assert bearer_of(route) == "Bearer aspeech-bearer"
+
+    @respx.mock
+    def test_transcription_kwargs_carry_exchanged_bearer(self, deployment_wif: dict[str, str], tmp_path: Path) -> None:
+        mock_token_exchange("transcribe-bearer")
+        route: Final = respx.post(TRANSCRIPTIONS_URL).mock(return_value=httpx.Response(200, json={"text": "hi"}))
+        audio: Final = tmp_path / "tone.wav"
+        audio.write_bytes(b"RIFF....WAVE")
+
+        with audio.open("rb") as audio_file:
+            response: Final = litellm.transcription(
+                model="openai/gpt-4o-mini-transcribe", file=audio_file, **deployment_wif
+            )
+
+        assert response.text == "hi"
+        assert bearer_of(route) == "Bearer transcribe-bearer"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_async_transcription_kwargs_carry_exchanged_bearer(
+        self, deployment_wif: dict[str, str], tmp_path: Path
+    ) -> None:
+        mock_token_exchange("atranscribe-bearer")
+        route: Final = respx.post(TRANSCRIPTIONS_URL).mock(return_value=httpx.Response(200, json={"text": "hi"}))
+        audio: Final = tmp_path / "tone.wav"
+        audio.write_bytes(b"RIFF....WAVE")
+
+        with audio.open("rb") as audio_file:
+            response: Final = await litellm.atranscription(
+                model="openai/gpt-4o-mini-transcribe", file=audio_file, **deployment_wif
+            )
+
+        assert response.text == "hi"
+        assert bearer_of(route) == "Bearer atranscribe-bearer"
+
+    @respx.mock
+    def test_moderation_kwargs_carry_exchanged_bearer(self, deployment_wif: dict[str, str]) -> None:
+        mock_token_exchange("moderation-bearer")
+        route: Final = respx.post(MODERATIONS_URL).mock(return_value=httpx.Response(200, json=MODERATION_BODY))
+
+        response: Final = litellm.moderation(input="hi", model="omni-moderation-latest", **deployment_wif)
+
+        assert response.results[0].flagged is False
+        assert bearer_of(route) == "Bearer moderation-bearer"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_async_moderation_kwargs_carry_exchanged_bearer(self, deployment_wif: dict[str, str]) -> None:
+        mock_token_exchange("amoderation-bearer")
+        route: Final = respx.post(MODERATIONS_URL).mock(return_value=httpx.Response(200, json=MODERATION_BODY))
+
+        response: Final = await litellm.amoderation(input="hi", model="omni-moderation-latest", **deployment_wif)
+
+        assert response.results[0].flagged is False
+        assert bearer_of(route) == "Bearer amoderation-bearer"
+
+    @respx.mock
+    def test_text_completion_kwargs_carry_exchanged_bearer(self, deployment_wif: dict[str, str]) -> None:
+        mock_token_exchange("text-bearer")
+        route: Final = respx.post(COMPLETIONS_URL).mock(return_value=httpx.Response(200, json=TEXT_COMPLETION_BODY))
+
+        response: Final = litellm.text_completion(
+            model="text-completion-openai/gpt-3.5-turbo-instruct", prompt="hi", **deployment_wif
+        )
+
+        assert response.choices[0].text == "ok"
+        assert bearer_of(route) == "Bearer text-bearer"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_async_text_completion_kwargs_carry_exchanged_bearer(self, deployment_wif: dict[str, str]) -> None:
+        mock_token_exchange("atext-bearer")
+        route: Final = respx.post(COMPLETIONS_URL).mock(return_value=httpx.Response(200, json=TEXT_COMPLETION_BODY))
+
+        response: Final = await litellm.atext_completion(
+            model="text-completion-openai/gpt-3.5-turbo-instruct", prompt="hi", **deployment_wif
+        )
+
+        assert response.choices[0].text == "ok"
+        assert bearer_of(route) == "Bearer atext-bearer"
+
+    @respx.mock
+    def test_streaming_text_completion_kwargs_carry_exchanged_bearer(self, deployment_wif: dict[str, str]) -> None:
+        mock_token_exchange("text-stream-bearer")
+        route: Final = mock_streaming_text_completions()
+
+        chunks: Final = tuple(
+            litellm.text_completion(
+                model="text-completion-openai/gpt-3.5-turbo-instruct", prompt="hi", stream=True, **deployment_wif
+            )
+        )
+
+        assert chunks[0].choices[0].text == "ok"
+        assert bearer_of(route) == "Bearer text-stream-bearer"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_async_streaming_text_completion_kwargs_carry_exchanged_bearer(
+        self, deployment_wif: dict[str, str]
+    ) -> None:
+        mock_token_exchange("atext-stream-bearer")
+        route: Final = mock_streaming_text_completions()
+
+        stream: Final = await litellm.atext_completion(
+            model="text-completion-openai/gpt-3.5-turbo-instruct", prompt="hi", stream=True, **deployment_wif
+        )
+        chunks: Final = [chunk async for chunk in stream]
+
+        assert chunks[0].choices[0].text == "ok"
+        assert bearer_of(route) == "Bearer atext-stream-bearer"
+
+    @respx.mock
+    @pytest.mark.parametrize(
+        ("method", "url", "response", "invoke"),
+        [
+            pytest.param(
+                "POST",
+                FILES_URL,
+                httpx.Response(200, json=FILE_BODY),
+                lambda p: litellm.create_file(file=("in.jsonl", b"{}"), purpose="batch", **p),
+                id="create_file",
+            ),
+            pytest.param(
+                "GET",
+                f"{FILES_URL}/file-1",
+                httpx.Response(200, json=FILE_BODY),
+                lambda p: litellm.file_retrieve(file_id="file-1", **p),
+                id="file_retrieve",
+            ),
+            pytest.param(
+                "DELETE",
+                f"{FILES_URL}/file-1",
+                httpx.Response(200, json=FILE_DELETED_BODY),
+                lambda p: litellm.file_delete(file_id="file-1", **p),
+                id="file_delete",
+            ),
+            pytest.param(
+                "GET",
+                FILES_URL,
+                httpx.Response(200, json={"object": "list", "data": [FILE_BODY]}),
+                lambda p: litellm.file_list(**p),
+                id="file_list",
+            ),
+            pytest.param(
+                "GET",
+                f"{FILES_URL}/file-1/content",
+                httpx.Response(200, content=b"{}"),
+                lambda p: litellm.file_content(file_id="file-1", **p),
+                id="file_content",
+            ),
+            pytest.param(
+                "POST",
+                BATCHES_URL,
+                httpx.Response(200, json=BATCH_BODY),
+                lambda p: litellm.create_batch(
+                    completion_window="24h", endpoint="/v1/chat/completions", input_file_id="file-1", **p
+                ),
+                id="create_batch",
+            ),
+            pytest.param(
+                "GET",
+                f"{BATCHES_URL}/batch-1",
+                httpx.Response(200, json=BATCH_BODY),
+                lambda p: litellm.retrieve_batch(batch_id="batch-1", **p),
+                id="retrieve_batch",
+            ),
+            pytest.param(
+                "POST",
+                f"{BATCHES_URL}/batch-1/cancel",
+                httpx.Response(200, json=BATCH_BODY),
+                lambda p: litellm.cancel_batch(batch_id="batch-1", **p),
+                id="cancel_batch",
+            ),
+            pytest.param(
+                "GET",
+                BATCHES_URL,
+                httpx.Response(200, json={"object": "list", "data": [BATCH_BODY], "has_more": False}),
+                lambda p: litellm.list_batches(**p),
+                id="list_batches",
+            ),
+            pytest.param(
+                "POST",
+                FINE_TUNING_JOBS_URL,
+                httpx.Response(200, json=FINE_TUNING_JOB_BODY),
+                lambda p: litellm.create_fine_tuning_job(model="gpt-5.4-nano", training_file="file-1", **p),
+                id="create_fine_tuning_job",
+            ),
+            pytest.param(
+                "POST",
+                f"{FINE_TUNING_JOBS_URL}/ftjob-1/cancel",
+                httpx.Response(200, json=FINE_TUNING_JOB_BODY),
+                lambda p: litellm.cancel_fine_tuning_job(fine_tuning_job_id="ftjob-1", **p),
+                id="cancel_fine_tuning_job",
+            ),
+            pytest.param(
+                "GET",
+                FINE_TUNING_JOBS_URL,
+                httpx.Response(200, json={"object": "list", "data": [FINE_TUNING_JOB_BODY], "has_more": False}),
+                lambda p: litellm.list_fine_tuning_jobs(**p),
+                id="list_fine_tuning_jobs",
+            ),
+            pytest.param(
+                "GET",
+                f"{FINE_TUNING_JOBS_URL}/ftjob-1",
+                httpx.Response(200, json=FINE_TUNING_JOB_BODY),
+                lambda p: litellm.retrieve_fine_tuning_job(fine_tuning_job_id="ftjob-1", **p),
+                id="retrieve_fine_tuning_job",
+            ),
+        ],
+    )
+    def test_managed_object_kwargs_carry_exchanged_bearer(
+        self, deployment_wif: dict[str, str], method: str, url: str, response: httpx.Response, invoke
+    ) -> None:
+        mock_token_exchange("managed-bearer")
+        route: Final = respx.route(method=method, url__startswith=url).mock(return_value=response)
+
+        invoke({"custom_llm_provider": "openai", **deployment_wif})
+
+        assert bearer_of(route) == "Bearer managed-bearer"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_async_managed_object_kwargs_carry_exchanged_bearer(self, deployment_wif: dict[str, str]) -> None:
+        mock_token_exchange("amanaged-bearer")
+        files_route: Final = respx.get(url__startswith=FILES_URL).mock(
+            return_value=httpx.Response(200, json={"object": "list", "data": [FILE_BODY]})
+        )
+        batches_route: Final = respx.get(url__startswith=BATCHES_URL).mock(
+            return_value=httpx.Response(200, json={"object": "list", "data": [BATCH_BODY], "has_more": False})
+        )
+        jobs_route: Final = respx.get(url__startswith=FINE_TUNING_JOBS_URL).mock(
+            return_value=httpx.Response(200, json={"object": "list", "data": [FINE_TUNING_JOB_BODY], "has_more": False})
+        )
+
+        await litellm.afile_list(custom_llm_provider="openai", **deployment_wif)
+        await litellm.alist_batches(custom_llm_provider="openai", **deployment_wif)
+        await litellm.alist_fine_tuning_jobs(custom_llm_provider="openai", **deployment_wif)
+
+        assert bearer_of(files_route) == "Bearer amanaged-bearer"
+        assert bearer_of(batches_route) == "Bearer amanaged-bearer"
+        assert bearer_of(jobs_route) == "Bearer amanaged-bearer"

--- a/tests/test_litellm/llms/openai/test_openai_workload_identity.py
+++ b/tests/test_litellm/llms/openai/test_openai_workload_identity.py
@@ -17,6 +17,8 @@ from litellm.llms.openai.responses.transformation import OpenAIResponsesAPIConfi
 from litellm.llms.openai.workload_identity import (
     OpenAIWorkloadIdentityConfig,
     _workload_identity_auth,
+    build_async_openai_client,
+    build_openai_client,
     get_workload_identity_bearer_token,
     resolve_openai_workload_identity_config,
 )
@@ -401,12 +403,35 @@ class TestResolveConfigFromDeployment:
             is None
         )
 
-    def test_env_openai_api_key_beats_litellm_params(
+    def test_deployment_identity_beats_env_openai_api_key(
         self, deployment_wif: dict[str, str], monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setenv("OPENAI_API_KEY", "sk-from-env")
+        config: Final = resolve_openai_workload_identity_config(
+            api_key="sk-from-env", api_base=None, litellm_params=deployment_wif
+        )
+        assert config is not None
+        assert config.service_account_id == deployment_wif["openai_service_account_id"]
+
+    @pytest.mark.parametrize("global_attr", ["api_key", "openai_key"])
+    def test_deployment_identity_beats_litellm_module_key(
+        self, deployment_wif: dict[str, str], monkeypatch: pytest.MonkeyPatch, global_attr: str
+    ) -> None:
+        monkeypatch.setattr(litellm, global_attr, "sk-module-global")
+        config: Final = resolve_openai_workload_identity_config(
+            api_key="sk-module-global", api_base=None, litellm_params=deployment_wif
+        )
+        assert config is not None
+        assert config.identity_provider_id == deployment_wif["openai_identity_provider_id"]
+
+    def test_env_openai_api_key_beats_partial_deployment_identity(
+        self, deployment_wif: dict[str, str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-from-env")
+        unrelated: Final = {key: value for key, value in deployment_wif.items() if not key.startswith("openai_")}
         assert (
-            resolve_openai_workload_identity_config(api_key=None, api_base=None, litellm_params=deployment_wif) is None
+            resolve_openai_workload_identity_config(api_key="sk-from-env", api_base=None, litellm_params=unrelated)
+            is None
         )
 
     def test_foreign_api_base_disables_deployment_wif(self, deployment_wif: dict[str, str]) -> None:
@@ -448,6 +473,23 @@ class TestDeploymentClientConstruction:
         )
         assert first is not second
         assert again is first
+
+    def test_builders_reuse_cached_client_per_identity(self, deployment_wif: dict[str, str]) -> None:
+        other_deployment: Final = {**deployment_wif, "openai_service_account_id": "user-other"}
+        first: Final = build_openai_client(api_key=None, api_base=None, litellm_params=deployment_wif)
+        again: Final = build_openai_client(api_key=None, api_base=None, litellm_params=dict(deployment_wif))
+        other: Final = build_openai_client(api_key=None, api_base=None, litellm_params=other_deployment)
+        async_first: Final = build_async_openai_client(api_key=None, api_base=None, litellm_params=deployment_wif)
+        async_again: Final = build_async_openai_client(api_key=None, api_base=None, litellm_params=deployment_wif)
+        assert again is first
+        assert other is not first
+        assert async_again is async_first
+        assert isinstance(async_first, AsyncOpenAI)
+
+    def test_builders_never_cache_static_key_clients(self) -> None:
+        first: Final = build_openai_client(api_key="sk-static", api_base=None, litellm_params=None)
+        again: Final = build_openai_client(api_key="sk-static", api_base=None, litellm_params=None)
+        assert again is not first
 
     @respx.mock
     def test_completion_kwargs_carry_exchanged_bearer(self, deployment_wif: dict[str, str]) -> None:
@@ -1006,3 +1048,29 @@ class TestDeploymentNonChatSurfaces:
         assert bearer_of(files_route) == "Bearer amanaged-bearer"
         assert bearer_of(batches_route) == "Bearer amanaged-bearer"
         assert bearer_of(jobs_route) == "Bearer amanaged-bearer"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_repeated_managed_object_calls_exchange_the_token_once(self, deployment_wif: dict[str, str]) -> None:
+        exchange_route: Final = mock_token_exchange("once-bearer")
+        files_route: Final = respx.get(url__startswith=FILES_URL).mock(
+            return_value=httpx.Response(200, json={"object": "list", "data": [FILE_BODY]})
+        )
+
+        for _ in range(3):
+            await litellm.afile_list(custom_llm_provider="openai", **deployment_wif)
+
+        assert files_route.call_count == 3
+        assert exchange_route.call_count == 1
+        assert bearer_of(files_route) == "Bearer once-bearer"
+
+    @respx.mock
+    def test_repeated_moderation_calls_exchange_the_token_once(self, deployment_wif: dict[str, str]) -> None:
+        exchange_route: Final = mock_token_exchange("once-bearer")
+        moderation_route: Final = respx.post(MODERATIONS_URL).mock(return_value=httpx.Response(200, json=MODERATION_BODY))
+
+        for _ in range(3):
+            litellm.moderation(input="hi", model="omni-moderation-latest", **deployment_wif)
+
+        assert moderation_route.call_count == 3
+        assert exchange_route.call_count == 1


### PR DESCRIPTION
## TLDR

Problem this solves:

- Keyless federated OpenAI deployments only work for chat, Responses, and embeddings
- Images, audio, moderation, completions, files, batches, fine-tuning still demand `OPENAI_API_KEY`
- Managed batch file access drops the federation trio when stripping credentials

How it solves it:

- Every OpenAI handler builds its client through the shared workload identity resolver
- Deployment `openai_identity_*` params win over env vars on all routes
- Batch file-access credential extraction keeps the trio
- Stacked on #38818; base moves to `litellm_internal_staging` once it lands
- Out of scope: Assistants (sunset), image variations (DALL-E 2), HTTP-handler surfaces

## User Flow

Before: every OpenAI route other than chat, Responses, and embeddings fails on a keyless federated deployment with an api_key error

1. The proxy admin adds OpenAI deployments for `gpt-5.6`, `gpt-image-2`, `gpt-4o-mini-tts`, `gpt-4o-mini-transcribe`, `omni-moderation-latest`, `gpt-3.5-turbo-instruct`, and `gpt-5.4-nano`, each with `openai_identity_provider_id`, `openai_service_account_id`, and `openai_identity_token_file` set and no api key, on a proxy that has no `OPENAI_API_KEY`
2. A developer sends POST `https://litellm-domain/v1/chat/completions` with `gpt-5.6`: 200, the assistant answers `ok`
3. The developer sends POST `https://litellm-domain/v1/images/generations` with `gpt-image-2`: 401 "The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
4. The developer sends POST `https://litellm-domain/v1/audio/speech` with `gpt-4o-mini-tts` and POST `https://litellm-domain/v1/audio/transcriptions` with `gpt-4o-mini-transcribe`: the same 401 on both
5. The developer sends POST `https://litellm-domain/v1/moderations` with `omni-moderation-latest`, POST `https://litellm-domain/v1/completions` with `gpt-3.5-turbo-instruct`, POST `https://litellm-domain/v1/files` (purpose `batch`, model `gpt-5.4-nano`), POST `https://litellm-domain/v1/batches` (model `gpt-5.4-nano`), and GET `https://litellm-domain/v1/fine_tuning/jobs?target_model_names=gpt-5.4-nano`: the same message as a 500 on all five

After: every OpenAI route honors the deployment's federation settings and answers 200

1. The proxy admin adds the same deployments the same way
2. A developer sends POST `https://litellm-domain/v1/chat/completions` with `gpt-5.6`: 200, the assistant answers `ok`
3. The developer sends POST `https://litellm-domain/v1/images/generations` with `gpt-image-2`: 200 with a base64 image in `data[0].b64_json`
4. The developer sends POST `https://litellm-domain/v1/audio/speech` with `gpt-4o-mini-tts`: 200 with an MP3 body, and POST `https://litellm-domain/v1/audio/transcriptions` with `gpt-4o-mini-transcribe`: 200 with the transcript text
5. The developer sends POST `https://litellm-domain/v1/moderations`: 200 with a `flagged` verdict; POST `https://litellm-domain/v1/completions`: 200 with the completion text; POST `https://litellm-domain/v1/files`: 200 with a `file-...` id; POST `https://litellm-domain/v1/batches` with that id: 200 with a `batch_...` id in status `validating`; GET `https://litellm-domain/v1/fine_tuning/jobs?target_model_names=gpt-5.4-nano`: 200 with the job list

## Relevant issues

## Linear ticket

Resolves LIT-6898

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup for both legs. Two worktrees, each its own `.venv` and `.env`, the proxy booted single-instance with `--num_workers 2` on port 21090 and no `OPENAI_API_KEY` anywhere in its environment (the rig env carries only `LITELLM_MASTER_KEY`, `LITELLM_LICENSE`, and the three `WIF_*` values referenced by the config). Before was captured at the merge base `82afbbdba1e`, After at the PR tip

```yaml
model_list:
  - model_name: gpt-5.6
    litellm_params:
      model: openai/gpt-5.6
      openai_identity_provider_id: os.environ/WIF_IDP_ID
      openai_service_account_id: os.environ/WIF_SA_ID
      openai_identity_token_file: os.environ/WIF_TOKEN_FILE
  # gpt-image-2, gpt-4o-mini-tts, gpt-4o-mini-transcribe, omni-moderation-latest,
  # text-completion-openai/gpt-3.5-turbo-instruct, gpt-5.4-nano: same three params each
general_settings:
  master_key: os.environ/LITELLM_MASTER_KEY
```

```bash
python litellm/proxy/proxy_cli.py --config config.yaml --port 21090 --num_workers 2
# batch_input.jsonl: one /v1/chat/completions line for gpt-5.4-nano; tone.wav: a 1 s sine tone
```

Both proxies ran single-instance with `--num_workers 2`: Before parent pid 42648 with spawn_main workers 43638 and 43639 at `82afbbdba1e`, After parent pid 46788 with spawn_main workers 47379 and 47380 at `4ff429652c`. `$U` is `http://localhost:21090`, `$H` is `Authorization: Bearer $LITELLM_MASTER_KEY`

- Before: images and audio answer 401, the other routes 500
- `tone.wav` carries no speech, so the transcript text is empty
- Not covered: Assistants, image variations, image edits, vector stores, containers, videos
- No database; config.yaml deployments only, UI-stored credentials untested here

### Before (82afbbdba1e)

#### chat control: POST /v1/chat/completions (gpt-5.6)

1. Command:

   ```bash
   curl -s "$U/v1/chat/completions" -H "$H" -H 'Content-Type: application/json' -d '{"model":"gpt-5.6","messages":[{"role":"user","content":"Reply with the single word ok"}],"max_tokens":16}'
   ```

2. Observed output:

   ```
   {"content": "ok"}
   http=200
   ```

#### POST /v1/images/generations (gpt-image-2)

1. Command:

   ```bash
   curl -s "$U/v1/images/generations" -H "$H" -H 'Content-Type: application/json' -d '{"model":"gpt-image-2","prompt":"a plain red circle on white","size":"1024x1024","quality":"low","n":1}'
   ```

2. Observed output:

   ```
   {"error": {"message": "litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable. Received Model Group=gpt-image-2\nAvailable Model Group Fallbacks=None", "type": null, "param": null, "code": "401"}}
   http=401
   ```

#### POST /v1/audio/speech (gpt-4o-mini-tts)

1. Command:

   ```bash
   curl -s -o speech.mp3 -w 'http=%{http_code} bytes=%{size_download}\n' "$U/v1/audio/speech" -H "$H" -H 'Content-Type: application/json' -d '{"model":"gpt-4o-mini-tts","input":"hello from litellm","voice":"alloy","response_format":"mp3"}'; file speech.mp3
   ```

2. Observed output:

   ```
   http=401 bytes=337
   speech_before.mp3: JSON data
   "message":"litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable. Received Model Group=gpt-4o-mini-tts\nAvailable Model Group Fallbacks=None"
   ```

#### POST /v1/audio/transcriptions (gpt-4o-mini-transcribe)

1. Command:

   ```bash
   curl -s "$U/v1/audio/transcriptions" -H "$H" -F file=@tone.wav -F model=gpt-4o-mini-transcribe
   ```

2. Observed output:

   ```
   {"error":{"message":"litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable. Received Model Group=gpt-4o-mini-transcribe\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"401"}}
   http=401
   ```

#### POST /v1/moderations (omni-moderation-latest)

1. Command:

   ```bash
   curl -s "$U/v1/moderations" -H "$H" -H 'Content-Type: application/json' -d '{"model":"omni-moderation-latest","input":"hello there"}'
   ```

2. Observed output:

   ```
   {"error": {"message": "The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable", "type": "None", "param": "None", "code": "500"}}
   http=500
   ```

#### POST /v1/completions (gpt-3.5-turbo-instruct)

1. Command:

   ```bash
   curl -s "$U/v1/completions" -H "$H" -H 'Content-Type: application/json' -d '{"model":"gpt-3.5-turbo-instruct","prompt":"Reply with the single word ok","max_tokens":4}'
   ```

2. Observed output:

   ```
   {"error": {"message": "litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable. Received Model Group=gpt-3.5-turbo-instruct\nAvailable Model Group Fallbacks=None", "type": null, "param": null, "code": "500"}}
   http=500
   ```

#### POST /v1/files (purpose=batch, model=gpt-5.4-nano)

1. Command:

   ```bash
   curl -s "$U/v1/files" -H "$H" -F purpose=batch -F file=@batch_input.jsonl -F model=gpt-5.4-nano
   ```

2. Observed output:

   ```
   {"error":{"message":"The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable","type":"None","param":"None","code":"500"}}
   http=500
   ```

#### POST /v1/batches (model=gpt-5.4-nano)

1. Command:

   ```bash
   curl -s "$U/v1/batches" -H "$H" -H 'Content-Type: application/json' -d '{"input_file_id":"<id from the files step>","endpoint":"/v1/chat/completions","completion_window":"24h","model":"gpt-5.4-nano"}'
   ```

2. Observed output:

   ```
   {"error":{"message":"The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable","type":"internal_server_error","param":"None","code":"500"}}
   http=500
   ```

#### GET /v1/fine_tuning/jobs?target_model_names=gpt-5.4-nano

1. Command:

   ```bash
   curl -s "$U/v1/fine_tuning/jobs?target_model_names=gpt-5.4-nano&limit=1" -H "$H"
   ```

2. Observed output:

   ```
   {"error":{"message":"The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable","type":"internal_server_error","param":"None","code":"500"}}
   http=500
   ```

### After (4ff429652c)

#### chat control: POST /v1/chat/completions (gpt-5.6)

1. Command:

   ```bash
   curl -s "$U/v1/chat/completions" -H "$H" -H 'Content-Type: application/json' -d '{"model":"gpt-5.6","messages":[{"role":"user","content":"Reply with the single word ok"}],"max_tokens":16}'
   ```

2. Observed output:

   ```
   {"content": "ok"}
   http=200
   ```

#### POST /v1/images/generations (gpt-image-2)

1. Command:

   ```bash
   curl -s "$U/v1/images/generations" -H "$H" -H 'Content-Type: application/json' -d '{"model":"gpt-image-2","prompt":"a plain red circle on white","size":"1024x1024","quality":"low","n":1}'
   ```

2. Observed output:

   ```
   {"created": 1788599768, "b64_json_len": 1086568}
   http=200
   ```

#### POST /v1/audio/speech (gpt-4o-mini-tts)

1. Command:

   ```bash
   curl -s -o speech.mp3 -w 'http=%{http_code} bytes=%{size_download}\n' "$U/v1/audio/speech" -H "$H" -H 'Content-Type: application/json' -d '{"model":"gpt-4o-mini-tts","input":"hello from litellm","voice":"alloy","response_format":"mp3"}'; file speech.mp3
   ```

2. Observed output:

   ```
   http=200 bytes=41088
   speech_after.mp3: MPEG ADTS, layer III, v2, 128
   ```

#### POST /v1/audio/transcriptions (gpt-4o-mini-transcribe)

1. Command:

   ```bash
   curl -s "$U/v1/audio/transcriptions" -H "$H" -F file=@tone.wav -F model=gpt-4o-mini-transcribe
   ```

2. Observed output:

   ```
   {"text":"","usage":{"type":"tokens","input_tokens":20,"output_tokens":2,"total_tokens":22,"input_token_details":{"audio_tokens":20,"text_tokens":0}}}
   http=200
   ```

#### POST /v1/moderations (omni-moderation-latest)

1. Command:

   ```bash
   curl -s "$U/v1/moderations" -H "$H" -H 'Content-Type: application/json' -d '{"model":"omni-moderation-latest","input":"hello there"}'
   ```

2. Observed output:

   ```
   {"flagged": false, "model": "omni-moderation-latest"}
   http=200
   ```

#### POST /v1/completions (gpt-3.5-turbo-instruct)

1. Command:

   ```bash
   curl -s "$U/v1/completions" -H "$H" -H 'Content-Type: application/json' -d '{"model":"gpt-3.5-turbo-instruct","prompt":"Reply with the single word ok","max_tokens":4}'
   ```

2. Observed output:

   ```
   {"text": "\n\nok"}
   http=200
   ```

#### POST /v1/files (purpose=batch, model=gpt-5.4-nano)

1. Command:

   ```bash
   curl -s "$U/v1/files" -H "$H" -F purpose=batch -F file=@batch_input.jsonl -F model=gpt-5.4-nano
   ```

2. Observed output:

   ```
   {"id":"file-bGl0ZWxs...","bytes":212,"created_at":1788599780,"filename":"batch_input.jsonl","object":"file","purpose":"batch","status":"processed","expires_at":1791191780,"status_details":null}
   http=200
   ```

#### POST /v1/batches (model=gpt-5.4-nano)

1. Command:

   ```bash
   curl -s "$U/v1/batches" -H "$H" -H 'Content-Type: application/json' -d '{"input_file_id":"<id from the files step>","endpoint":"/v1/chat/completions","completion_window":"24h","model":"gpt-5.4-nano"}'
   ```

2. Observed output:

   ```
   {"id":"batch_bGl0ZWxs...","completion_window":"24h","created_at":1788599783,"endpoint":"/v1/chat/completions","input_file_id":"file-bGl0ZWxs...","object":"batch","status":"validating","cancelled_at":null,"cancelling_at":null,"completed_at":null,"error_file_id":nu
   http=200
   ```

3. Retrieve it:

   ```bash
   curl -s "$U/v1/batches/<id from step 2>?model=gpt-5.4-nano" -H "$H"
   ```

4. Observed output:

   ```
   {"id": "batch_bGl0ZWxs...", "status": "in_progress", "input_file_id": "file-bGl0ZWxs...", "endpoint": "/v1/chat/completions"}
   http=200
   ```

#### GET /v1/fine_tuning/jobs?target_model_names=gpt-5.4-nano

1. Command:

   ```bash
   curl -s "$U/v1/fine_tuning/jobs?target_model_names=gpt-5.4-nano&limit=1" -H "$H"
   ```

2. Observed output:

   ```
   {"data":[{"id":"ftjob-XVEXgElPbgDI7PCwwCcAJ45r","object":"fine_tuning.job",...}],...}
   http=200
   ```

## Type

🆕 New Feature

## Caveats (if any)

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 4ff429652c passes /live-pr-risk
