### PR TITLE
feat(ui): route credential-only WIF variants on Add Model through an LLM Credential

### DIFF
--- a/litellm/types/proxy/public_endpoints/public_endpoints.py
+++ b/litellm/types/proxy/public_endpoints/public_endpoints.py
@@ -1,8 +1,10 @@
 from collections.abc import Mapping, Sequence
 from typing import Any, Final, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, computed_field, model_validator
 from typing_extensions import Self
+
+from litellm.types.router import server_owned_wif_fields_named
 
 
 class PublicModelHubInfo(BaseModel):
@@ -34,13 +36,21 @@ class ProviderCredentialVariant(BaseModel):
     ``anthropic_identity_source: keycloak``) and are submitted without a form field for them.
     ``optional_field_keys`` relaxes a globally-required field for this variant alone, for a value
     only obtainable after the credential exists (the federation rule id an operator can only read
-    off the Anthropic Console once the generated JWKS is registered)."""
+    off the Anthropic Console once the generated JWKS is registered).
+    ``credential_only`` is derived, never declared: a variant that submits a server-owned workload
+    identity federation parameter, as a field or a fixed value, can only be saved as a named LLM
+    Credential, since ``/model/new`` rejects those parameters inline."""
 
     id: str
     label: str
     field_keys: tuple[str, ...]
     optional_field_keys: tuple[str, ...] = ()
     fixed_values: Mapping[str, str] = Field(default_factory=dict)
+
+    @computed_field
+    @property
+    def credential_only(self) -> bool:
+        return bool(server_owned_wif_fields_named((*self.field_keys, *self.fixed_values)))
 
 
 def _validate_variant(variant: "ProviderCredentialVariant", defined_keys: frozenset[str]) -> None:

--- a/tests/test_litellm/proxy/public_endpoints/test_public_endpoints.py
+++ b/tests/test_litellm/proxy/public_endpoints/test_public_endpoints.py
@@ -983,8 +983,8 @@ def test_public_mcp_hub_returns_only_whitelisted_servers():
     litellm.public_mcp_servers, mirroring /public/model_hub and
     /public/agent_hub. Servers with available_on_public_internet=True that
     are not on the whitelist must not leak."""
-    from litellm.types.mcp_server.mcp_server_manager import MCPServer
     from litellm.proxy._types import MCPTransport
+    from litellm.types.mcp_server.mcp_server_manager import MCPServer
 
     app = FastAPI()
     app.include_router(router)
@@ -1045,8 +1045,8 @@ def test_public_mcp_hub_returns_empty_when_whitelist_unset():
 def test_public_mcp_hub_does_not_expose_upstream_url():
     """Regression: /public/mcp_hub is unauthenticated, so the gateway-internal
     upstream url must never appear in its response even when the server has one."""
-    from litellm.types.mcp_server.mcp_server_manager import MCPServer
     from litellm.proxy._types import MCPTransport
+    from litellm.types.mcp_server.mcp_server_manager import MCPServer
 
     app = FastAPI()
     app.include_router(router)
@@ -1559,3 +1559,46 @@ async def test_fetch_remote_autorouter_presets_parses_and_rejects_empty(monkeypa
     response.json = MagicMock(return_value={})
     with pytest.raises(ValueError, match="empty"):
         await _fetch_remote_autorouter_presets("https://example.test/presets.json")
+
+
+def test_credential_only_marks_variants_carrying_server_owned_wif_params():
+    """A variant is credential-only exactly when a field or a fixed value it submits is a
+    server-owned workload identity federation parameter, which /model/new refuses inline."""
+    variants = ProviderCredentialVariants(
+        selector_label="Authentication method",
+        default_variant="api_key",
+        field_definitions=(
+            ProviderCredentialField(key="api_base", label="API Base"),
+            ProviderCredentialField(key="api_key", label="API Key"),
+            ProviderCredentialField(key="openai_identity_provider_id", label="Identity Provider ID"),
+        ),
+        variants=(
+            ProviderCredentialVariant(id="api_key", label="API Key", field_keys=("api_base", "api_key")),
+            ProviderCredentialVariant(
+                id="wif_token_file", label="Federation", field_keys=("openai_identity_provider_id",)
+            ),
+            ProviderCredentialVariant(
+                id="wif_keycloak",
+                label="Federation (Keycloak)",
+                field_keys=("api_base",),
+                fixed_values={"anthropic_identity_source": "keycloak"},
+            ),
+        ),
+    )
+    expected = {"api_key": False, "wif_token_file": True, "wif_keycloak": True}
+    assert {variant.id: variant.credential_only for variant in variants.variants} == expected
+    assert {v["id"]: v["credential_only"] for v in variants.model_dump()["variants"]} == expected
+
+
+def test_provider_fields_flag_every_federation_variant_credential_only():
+    """The dashboard reads credential_only off /public/providers/fields to swap a federation
+    variant's inline fields for the create-credential step, so every federation variant must
+    carry the flag and the API-key variant must not."""
+    app_instance = FastAPI()
+    app_instance.include_router(router)
+    providers = TestClient(app_instance).get("/public/providers/fields").json()
+    for provider_name in ("OpenAI", "Anthropic"):
+        provider = next(p for p in providers if p["provider"] == provider_name)
+        flags = {v["id"]: v["credential_only"] for v in provider["credential_variants"]["variants"]}
+        assert flags.pop("api_key") is False, provider_name
+        assert flags and all(flags.values()), (provider_name, flags)

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/credentials/useCredentials.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/credentials/useCredentials.ts
@@ -3,7 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { createQueryKeys } from "../common/queryKeysFactory";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 
-const credentialsKeys = createQueryKeys("credentials");
+export const credentialsKeys = createQueryKeys("credentials");
 
 export const useCredentials = () => {
   const { accessToken } = useAuthorized();

--- a/ui/litellm-dashboard/src/components/add_model/AddModelForm.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/AddModelForm.test.tsx
@@ -1,8 +1,8 @@
-import { renderHook, screen, waitFor, renderWithProviders } from "../../../tests/test-utils";
+import { renderHook, screen, waitFor, within, renderWithProviders } from "../../../tests/test-utils";
 import userEvent, { PointerEventsCheckLevel } from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import type { Team } from "../key_team_helpers/key_list";
-import type { CredentialItem } from "../networking";
+import { credentialCreateCall, type CredentialItem } from "../networking";
 import { Providers } from "../provider_info_helpers";
 import { projectMountedValues, useMountRegistry, type MountedFormValues } from "../common_components/MountedFormField";
 import { useForm } from "react-hook-form";
@@ -34,6 +34,9 @@ vi.mock("../networking", async () => {
       ],
     }),
     testConnectionRequest: vi.fn().mockResolvedValue({ status: "success" }),
+    credentialCreateCall: vi.fn().mockResolvedValue({ success: true }),
+    discoverProviderModelsCall: vi.fn().mockResolvedValue({ models: [] }),
+    getCredentialJwksCall: vi.fn().mockResolvedValue({ keys: [] }),
     getProviderCreateMetadata: vi.fn().mockResolvedValue([
       {
         provider: "OpenAI",
@@ -55,6 +58,31 @@ vi.mock("@/app/(dashboard)/hooks/providers/useProviderFields", () => ({
         litellm_provider: "openai",
         default_model_placeholder: "gpt-3.5-turbo",
         credential_fields: [],
+        credential_variants: {
+          selector_label: "Authentication method",
+          default_variant: "api_key",
+          field_definitions: [
+            { key: "api_key", label: "OpenAI API Key", field_type: "password" },
+            { key: "openai_identity_provider_id", label: "Identity Provider ID", field_type: "text", required: true },
+            { key: "openai_service_account_id", label: "Service Account ID", field_type: "text", required: true },
+            {
+              key: "openai_identity_token_file",
+              label: "Identity Token File Path",
+              field_type: "text",
+              required: true,
+            },
+          ],
+          variants: [
+            { id: "api_key", label: "API Key", field_keys: ["api_key"], fixed_values: {}, credential_only: false },
+            {
+              id: "wif_token_file",
+              label: "Workload Identity Federation (token file)",
+              field_keys: ["openai_identity_provider_id", "openai_service_account_id", "openai_identity_token_file"],
+              fixed_values: {},
+              credential_only: true,
+            },
+          ],
+        },
       },
     ],
     isLoading: false,
@@ -65,6 +93,8 @@ vi.mock("@/app/(dashboard)/hooks/providers/useProviderFields", () => ({
 vi.mock("@/app/(dashboard)/hooks/useAuthorized", () => ({
   default: vi.fn(),
 }));
+
+vi.mock("@/lib/toast", () => ({ toast: { success: vi.fn(), error: vi.fn(), info: vi.fn(), warning: vi.fn() } }));
 
 vi.mock("@/app/(dashboard)/hooks/teams/useTeams", () => ({
   useInfiniteTeams: () => ({
@@ -429,6 +459,68 @@ describe("AddModelForm", () => {
       const values = await mountedValues();
       expect(values.cache_control).toBe(false);
       expect(values).not.toHaveProperty("cache_control_injection_points");
+    });
+  });
+
+  describe("credential-only auth variants", () => {
+    const WIF_KEYS = ["openai_identity_provider_id", "openai_service_account_id", "openai_identity_token_file"];
+
+    const pickWifVariant = async () => {
+      const mockUseAuthorized = vi.mocked(await import("@/app/(dashboard)/hooks/useAuthorized"));
+      mockUseAuthorized.default.mockReturnValue(mockAuthorizedUser("proxy_admin", "user-1", true));
+      const props = createTestProps();
+      renderWithProviders(<AddModelForm {...props} />);
+      const user = userEvent.setup({ pointerEventsCheck: PointerEventsCheckLevel.Never });
+      await screen.findByText("Provider");
+      await user.click(await screen.findByRole("combobox", { name: "Authentication method" }));
+      await user.click(await screen.findByRole("option", { name: "Workload Identity Federation (token file)" }));
+      return { user, props };
+    };
+
+    it("never mounts a credential-only variant's fields on the deployment", async () => {
+      const { props } = await pickWifVariant();
+
+      expect(await screen.findByRole("button", { name: "Create credential" })).toBeInTheDocument();
+      expect(screen.queryByLabelText("Identity Provider ID")).not.toBeInTheDocument();
+      expect(screen.queryByLabelText("OpenAI API Key")).not.toBeInTheDocument();
+      const values = props.mountedValues();
+      for (const key of [...WIF_KEYS, "api_key"]) {
+        expect(values).not.toHaveProperty(key);
+      }
+    });
+
+    it("saves the federation settings as a credential and attaches it to the model", async () => {
+      const { user, props } = await pickWifVariant();
+
+      await user.click(await screen.findByRole("button", { name: "Create credential" }));
+      const dialog = await screen.findByRole("dialog");
+      expect(within(dialog).getByText("Add New Credential")).toBeInTheDocument();
+      await user.type(within(dialog).getByLabelText("Credential Name:"), "openai-wif");
+      await user.type(await within(dialog).findByLabelText("Identity Provider ID"), "idp_123");
+      await user.type(within(dialog).getByLabelText("Service Account ID"), "user-456");
+      await user.type(within(dialog).getByLabelText("Identity Token File Path"), "/var/run/token");
+      await user.click(within(dialog).getByRole("button", { name: "Add Credential" }));
+
+      await waitFor(() =>
+        expect(vi.mocked(credentialCreateCall)).toHaveBeenCalledWith("test-access-token", {
+          credential_name: "openai-wif",
+          credential_values: {
+            openai_identity_provider_id: "idp_123",
+            openai_service_account_id: "user-456",
+            openai_identity_token_file: "/var/run/token",
+          },
+          credential_info: { custom_llm_provider: "OpenAI" },
+        }),
+      );
+      await waitFor(() => expect(props.form.getValues("litellm_credential_name")).toBe("openai-wif"));
+      await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+
+      const values = props.mountedValues();
+      expect(values.litellm_credential_name).toBe("openai-wif");
+      for (const key of WIF_KEYS) {
+        expect(values).not.toHaveProperty(key);
+      }
+      expect(screen.queryByRole("combobox", { name: "Authentication method" })).not.toBeInTheDocument();
     });
   });
 });

--- a/ui/litellm-dashboard/src/components/add_model/AddModelForm.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/AddModelForm.tsx
@@ -24,7 +24,16 @@ import {
   type MountedFormValues,
 } from "../common_components/MountedFormField";
 import type { Team } from "../key_team_helpers/key_list";
-import { type CredentialItem, type ProviderCreateInfo, modelAvailableCall } from "../networking";
+import {
+  type CredentialItem,
+  type ProviderCreateInfo,
+  credentialCreateCall,
+  discoverProviderModelsCall,
+  getCredentialJwksCall,
+  modelAvailableCall,
+} from "../networking";
+import CredentialModal from "../model_add/CredentialModal";
+import { buildCredential, withoutRestrictedFields } from "../model_add/credential_form_helpers";
 import { Providers } from "../provider_info_helpers";
 import { ProviderLogo } from "../molecules/models/ProviderLogo";
 import AccessGroupTagsCombobox from "./AccessGroupTagsCombobox";
@@ -35,6 +44,10 @@ import ConnectionErrorDisplay from "./model_connection_test";
 import ProviderSpecificFields from "./provider_specific_fields";
 import { TEST_MODES } from "./add_model_modes";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+import { credentialsKeys } from "@/app/(dashboard)/hooks/credentials/useCredentials";
+import { toast } from "@/lib/toast";
+import { extractProxyErrorMessage } from "@/lib/http/client";
+import { useQueryClient } from "@tanstack/react-query";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 
 interface AddModelFormProps {
@@ -92,6 +105,23 @@ const AddModelForm: React.FC<AddModelFormProps> = ({
   const guardrailsList = guardrailsData?.guardrails.map((g) => g.guardrail_name);
   const { data: tagsList } = useTags();
   const selectedCredentialName = useWatch({ control: form.control, name: "litellm_credential_name" });
+  const queryClient = useQueryClient();
+  const [credentialDraftVariantId, setCredentialDraftVariantId] = useState<string | null>(null);
+
+  const handleCreateCredential = async (values: Record<string, unknown>): Promise<boolean> => {
+    const credential = buildCredential(values, withoutRestrictedFields(values));
+    try {
+      await credentialCreateCall(accessToken, credential);
+    } catch (error) {
+      toast.error(extractProxyErrorMessage(error));
+      return false;
+    }
+    toast.success("Credential added successfully");
+    setCredentialDraftVariantId(null);
+    await queryClient.invalidateQueries({ queryKey: credentialsKeys.all });
+    form.setValue("litellm_credential_name", credential.credential_name, { shouldDirty: true });
+    return true;
+  };
 
   const handleTestConnection = async () => {
     setIsTestingConnection(true);
@@ -317,7 +347,10 @@ const AddModelForm: React.FC<AddModelFormProps> = ({
                             <span className="px-4 text-muted-foreground text-sm">OR</span>
                             <div className="grow border-t border-border"></div>
                           </div>
-                          <ProviderSpecificFields selectedProvider={selectedProvider} />
+                          <ProviderSpecificFields
+                            selectedProvider={selectedProvider}
+                            onCreateCredential={isAdmin ? setCredentialDraftVariantId : undefined}
+                          />
                         </>
                       )}
                       <div className="flex items-center my-4">
@@ -448,6 +481,18 @@ const AddModelForm: React.FC<AddModelFormProps> = ({
         </CardContent>
       </Card>
 
+      {credentialDraftVariantId !== null && (
+        <CredentialModal
+          open
+          mode="add"
+          initialProvider={selectedProvider}
+          initialVariantId={credentialDraftVariantId}
+          onCancel={() => setCredentialDraftVariantId(null)}
+          onSubmit={handleCreateCredential}
+          testConnection={(request) => discoverProviderModelsCall(accessToken, request)}
+          loadJwks={(credentialName) => getCredentialJwksCall(accessToken, credentialName)}
+        />
+      )}
       {/* Test Connection Results Modal */}
       <Dialog
         open={isResultModalVisible}

--- a/ui/litellm-dashboard/src/components/add_model/provider_credential_variants.test.ts
+++ b/ui/litellm-dashboard/src/components/add_model/provider_credential_variants.test.ts
@@ -26,18 +26,20 @@ const anthropicVariants: ProviderCredentialVariants = {
     field("anthropic_keycloak_client_secret_ref", true),
   ],
   variants: [
-    { id: "api_key", label: "API Key", field_keys: ["api_base", "api_key"], fixed_values: {} },
+    { id: "api_key", label: "API Key", field_keys: ["api_base", "api_key"], fixed_values: {}, credential_only: false },
     {
       id: "wif_token",
       label: "WIF (token)",
       field_keys: ["anthropic_federation_rule_id", "anthropic_organization_id", "anthropic_identity_token"],
       fixed_values: {},
+      credential_only: true,
     },
     {
       id: "wif_token_file",
       label: "WIF (token file)",
       field_keys: ["anthropic_federation_rule_id", "anthropic_organization_id", "anthropic_identity_token_file"],
       fixed_values: {},
+      credential_only: true,
     },
     {
       id: "wif_internal_issuer",
@@ -50,6 +52,7 @@ const anthropicVariants: ProviderCredentialVariants = {
       ],
       optional_field_keys: ["anthropic_federation_rule_id"],
       fixed_values: { anthropic_identity_source: "internal_issuer" },
+      credential_only: true,
     },
     {
       id: "wif_keycloak",
@@ -62,6 +65,7 @@ const anthropicVariants: ProviderCredentialVariants = {
         "anthropic_keycloak_client_secret_ref",
       ],
       fixed_values: { anthropic_identity_source: "keycloak" },
+      credential_only: true,
     },
   ],
 };
@@ -93,7 +97,15 @@ describe("resolveVariantFieldDefs", () => {
   it("drops a field_key that has no matching field_definitions entry, rather than crashing", () => {
     const variants: ProviderCredentialVariants = {
       ...anthropicVariants,
-      variants: [{ id: "broken", label: "Broken", field_keys: ["api_key", "missing_field"], fixed_values: {} }],
+      variants: [
+        {
+          id: "broken",
+          label: "Broken",
+          field_keys: ["api_key", "missing_field"],
+          fixed_values: {},
+          credential_only: false,
+        },
+      ],
     };
     expect(resolveVariantFieldDefs(variants, "broken").map((f) => f.key)).toEqual(["api_key"]);
   });

--- a/ui/litellm-dashboard/src/components/add_model/provider_specific_fields.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/provider_specific_fields.test.tsx
@@ -148,12 +148,19 @@ vi.mock("../networking", async () => {
             },
           ],
           variants: [
-            { id: "api_key", label: "API Key", field_keys: ["api_base", "api_key"], fixed_values: {} },
+            {
+              id: "api_key",
+              label: "API Key",
+              field_keys: ["api_base", "api_key"],
+              fixed_values: {},
+              credential_only: false,
+            },
             {
               id: "wif_token",
               label: "Workload Identity Federation (external token)",
               field_keys: ["anthropic_federation_rule_id", "anthropic_organization_id", "anthropic_identity_token"],
               fixed_values: {},
+              credential_only: true,
             },
             {
               id: "wif_internal_issuer",
@@ -165,6 +172,7 @@ vi.mock("../networking", async () => {
                 "anthropic_issuer_signing_key_ref",
               ],
               fixed_values: { anthropic_identity_source: "internal_issuer" },
+              credential_only: true,
             },
           ],
         },
@@ -585,6 +593,58 @@ describe("ProviderSpecificFields", () => {
 
       expect(await screen.findByLabelText("Identity Token Reference")).toBeInTheDocument();
       expect(screen.queryByLabelText("API Key")).not.toBeInTheDocument();
+    });
+
+    it("opens on the variant the caller hands in", async () => {
+      render(
+        <QueryClientProvider client={createQueryClient()}>
+          <MountedFormHost>
+            <ProviderSpecificFields selectedProvider={Providers.Anthropic} initialVariantId="wif_token" />
+          </MountedFormHost>
+        </QueryClientProvider>,
+      );
+
+      expect(await screen.findByLabelText("Federation Rule ID")).toBeInTheDocument();
+      expect(screen.queryByLabelText("API Key")).not.toBeInTheDocument();
+    });
+
+    it("swaps a credential-only variant's fields for the create-credential step on a deployment form", async () => {
+      const onCreateCredential = vi.fn();
+      render(
+        <QueryClientProvider client={createQueryClient()}>
+          <MountedFormHost>
+            <ProviderSpecificFields selectedProvider={Providers.Anthropic} onCreateCredential={onCreateCredential} />
+            <IdentitySourceProbe />
+          </MountedFormHost>
+        </QueryClientProvider>,
+      );
+
+      const user = userEvent.setup();
+      await screen.findByLabelText("API Key");
+      await user.click(await screen.findByRole("combobox", { name: "Authentication method" }));
+      await user.click(await screen.findByRole("option", { name: "Workload Identity Federation (LiteLLM-signed)" }));
+
+      const createButton = await screen.findByRole("button", { name: "Create credential" });
+      expect(screen.queryByLabelText("Issuer URL")).not.toBeInTheDocument();
+      expect(screen.queryByLabelText("Federation Rule ID")).not.toBeInTheDocument();
+      expect(screen.queryByLabelText("API Key")).not.toBeInTheDocument();
+      expect(screen.getByTestId("identity-source")).toBeEmptyDOMElement();
+
+      await user.click(createButton);
+      expect(onCreateCredential).toHaveBeenCalledWith("wif_internal_issuer");
+    });
+
+    it("keeps the api_key variant inline on a deployment form", async () => {
+      render(
+        <QueryClientProvider client={createQueryClient()}>
+          <MountedFormHost>
+            <ProviderSpecificFields selectedProvider={Providers.Anthropic} onCreateCredential={vi.fn()} />
+          </MountedFormHost>
+        </QueryClientProvider>,
+      );
+
+      expect(await screen.findByLabelText("API Key")).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "Create credential" })).not.toBeInTheDocument();
     });
   });
 });

--- a/ui/litellm-dashboard/src/components/add_model/provider_specific_fields.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/provider_specific_fields.tsx
@@ -14,15 +14,40 @@ import {
   type MountedFieldControlProps,
   type MountedFormValues,
 } from "../common_components/MountedFormField";
-import { CredentialItem, ProviderCredentialFieldMetadata, ProviderCredentialVariants } from "../networking";
+import {
+  CredentialItem,
+  ProviderCredentialFieldMetadata,
+  ProviderCredentialVariant,
+  ProviderCredentialVariants,
+} from "../networking";
 import { provider_map, Providers } from "../provider_info_helpers";
 import { labelWithHint } from "@/components/shared/form/LabelWithHint";
 import { Field, FieldLabel } from "@/components/ui/field";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import { getVariant, inferActiveVariant, resolveVariantFieldDefs } from "./provider_credential_variants";
 
 interface ProviderSpecificFieldsProps {
   selectedProvider: Providers;
+  initialVariantId?: string;
+  onCreateCredential?: (variantId: string) => void;
 }
+
+const CredentialOnlyNotice: React.FC<{
+  variant: ProviderCredentialVariant;
+  onCreateCredential: (variantId: string) => void;
+}> = ({ variant, onCreateCredential }) => (
+  <Alert className="mb-4">
+    <AlertDescription className="flex flex-col items-start gap-3">
+      <span>
+        {variant.label} uses server-owned identity settings, which are stored as an LLM Credential rather than entered
+        on the model. Create the credential and this model will use it.
+      </span>
+      <Button type="button" variant="outline" onClick={() => onCreateCredential(variant.id)}>
+        Create credential
+      </Button>
+    </AlertDescription>
+  </Alert>
+);
 
 const readTextFile = (file: File, onLoaded: (contents: string) => void) => {
   const reader = new FileReader();
@@ -141,7 +166,11 @@ const FixedValueField: React.FC<{ name: string; value: string }> = ({ name, valu
   return null;
 };
 
-const ProviderSpecificFields: React.FC<ProviderSpecificFieldsProps> = ({ selectedProvider }) => {
+const ProviderSpecificFields: React.FC<ProviderSpecificFieldsProps> = ({
+  selectedProvider,
+  initialVariantId,
+  onCreateCredential,
+}) => {
   const selectedProviderEnum = Providers[selectedProvider as keyof typeof Providers] as Providers;
   const form = useFormContext<MountedFormValues>();
   const credentialsFileRef = React.useRef<HTMLInputElement>(null);
@@ -235,7 +264,7 @@ const ProviderSpecificFields: React.FC<ProviderSpecificFieldsProps> = ({ selecte
   // still-loading `variants` or a provider switch resolve correctly with no effect needed to
   // "catch up" afterward). A choice left over from a different provider's variant list is
   // treated as unset rather than resolving to a variant id that provider doesn't have.
-  const [userChosenVariantId, setUserChosenVariantId] = React.useState<string | undefined>(undefined);
+  const [userChosenVariantId, setUserChosenVariantId] = React.useState<string | undefined>(initialVariantId);
   const validUserChoice = variants?.variants.some((variant) => variant.id === userChosenVariantId)
     ? userChosenVariantId
     : undefined;
@@ -400,6 +429,7 @@ const ProviderSpecificFields: React.FC<ProviderSpecificFieldsProps> = ({ selecte
   );
 
   const activeVariant = variants ? getVariant(variants, activeVariantId) : undefined;
+  const credentialOnlyVariant = onCreateCredential && activeVariant?.credential_only ? activeVariant : undefined;
 
   return (
     <>
@@ -433,13 +463,17 @@ const ProviderSpecificFields: React.FC<ProviderSpecificFieldsProps> = ({ selecte
       {/* Keyed by the active variant so switching variants fully unmounts the previous
           variant's fields (deregistering them from submission) and re-applies fixed_values
           fresh, rather than leaving a stale value behind under a reused field name. */}
-      <React.Fragment key={variants ? activeVariantId : "static"}>
-        {currentFields.map(renderFieldEntry)}
-        {activeVariant &&
-          Object.entries(activeVariant.fixed_values).map(([key, value]) => (
-            <FixedValueField key={key} name={key} value={value} />
-          ))}
-      </React.Fragment>
+      {credentialOnlyVariant && onCreateCredential ? (
+        <CredentialOnlyNotice variant={credentialOnlyVariant} onCreateCredential={onCreateCredential} />
+      ) : (
+        <React.Fragment key={variants ? activeVariantId : "static"}>
+          {currentFields.map(renderFieldEntry)}
+          {activeVariant &&
+            Object.entries(activeVariant.fixed_values).map(([key, value]) => (
+              <FixedValueField key={key} name={key} value={value} />
+            ))}
+        </React.Fragment>
+      )}
     </>
   );
 };

--- a/ui/litellm-dashboard/src/components/model_add/CredentialModal.test.tsx
+++ b/ui/litellm-dashboard/src/components/model_add/CredentialModal.test.tsx
@@ -63,12 +63,13 @@ vi.mock("../networking", async () => {
             },
           ],
           variants: [
-            { id: "api_key", label: "API Key", field_keys: ["api_key"], fixed_values: {} },
+            { id: "api_key", label: "API Key", field_keys: ["api_key"], fixed_values: {}, credential_only: false },
             {
               id: "wif_token",
               label: "Workload Identity Federation",
               field_keys: ["anthropic_federation_rule_id", "anthropic_organization_id", "anthropic_identity_token"],
               fixed_values: {},
+              credential_only: true,
             },
             {
               id: "wif_internal_issuer",
@@ -81,6 +82,7 @@ vi.mock("../networking", async () => {
                 "anthropic_federation_rule_id",
               ],
               fixed_values: { anthropic_identity_source: "internal_issuer" },
+              credential_only: true,
             },
           ],
         },
@@ -343,6 +345,70 @@ describe("CredentialModal", () => {
       await waitFor(() => expect(onSubmit).toHaveBeenCalled());
       const [, deletedKeys] = onSubmit.mock.calls[0];
       expect(deletedKeys).toEqual([]);
+    });
+  });
+
+  const presetWifProps = { mode: "add" as const, initialProvider: Providers.Anthropic, initialVariantId: "wif_token" };
+
+  describe("after submit", () => {
+    it("keeps the typed values when saving fails", async () => {
+      const onSubmit = vi.fn().mockResolvedValue(false);
+      renderModal({ ...presetWifProps, onSubmit });
+      const user = userEvent.setup();
+
+      await user.type(screen.getByLabelText("Credential Name:"), "anthropic-wif");
+      await user.type(await screen.findByLabelText("Federation Rule ID"), "rule-1");
+      await user.type(screen.getByLabelText("Organization ID"), "org-1");
+      await user.type(screen.getByLabelText("Identity Token Reference"), "oidc/env/TOKEN");
+      await user.click(screen.getByRole("button", { name: "Add Credential" }));
+
+      await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+      expect(screen.getByLabelText("Credential Name:")).toHaveValue("anthropic-wif");
+      expect(screen.getByLabelText("Federation Rule ID")).toHaveValue("rule-1");
+      expect(screen.getByLabelText("Identity Token Reference")).toHaveValue("oidc/env/TOKEN");
+    });
+
+    it("clears the form once saving succeeds", async () => {
+      const onSubmit = vi.fn().mockResolvedValue(true);
+      renderModal({ ...presetWifProps, onSubmit });
+      const user = userEvent.setup();
+
+      await user.type(screen.getByLabelText("Credential Name:"), "anthropic-wif");
+      await user.type(await screen.findByLabelText("Federation Rule ID"), "rule-1");
+      await user.type(screen.getByLabelText("Organization ID"), "org-1");
+      await user.type(screen.getByLabelText("Identity Token Reference"), "oidc/env/TOKEN");
+      await user.click(screen.getByRole("button", { name: "Add Credential" }));
+
+      await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+      await waitFor(() => expect(screen.getByLabelText("Credential Name:")).toHaveValue(""));
+    });
+  });
+
+  describe("preset from the Add Model form", () => {
+    it("opens on the handed-over provider and variant and submits that provider", async () => {
+      const onSubmit = vi.fn();
+      renderModal({ ...presetWifProps, onSubmit });
+      const user = userEvent.setup();
+
+      expect(await screen.findByLabelText("Federation Rule ID")).toBeInTheDocument();
+      expect(screen.queryByLabelText("Anthropic API Key")).not.toBeInTheDocument();
+      expect(screen.queryByLabelText("OpenAI API Key")).not.toBeInTheDocument();
+
+      await user.type(screen.getByLabelText("Credential Name:"), "anthropic-wif");
+      await user.type(screen.getByLabelText("Federation Rule ID"), "rule-1");
+      await user.type(screen.getByLabelText("Organization ID"), "org-1");
+      await user.type(screen.getByLabelText("Identity Token Reference"), "oidc/env/TOKEN");
+      await user.click(screen.getByRole("button", { name: "Add Credential" }));
+
+      await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+      const expectedCredential = {
+        credential_name: "anthropic-wif",
+        custom_llm_provider: "Anthropic",
+        anthropic_federation_rule_id: "rule-1",
+        anthropic_organization_id: "org-1",
+        anthropic_identity_token: "oidc/env/TOKEN",
+      };
+      expect(onSubmit.mock.calls[0][0]).toEqual(expectedCredential);
     });
   });
 });

--- a/ui/litellm-dashboard/src/components/model_add/CredentialModal.tsx
+++ b/ui/litellm-dashboard/src/components/model_add/CredentialModal.tsx
@@ -32,6 +32,7 @@ import { Providers } from "../provider_info_helpers";
 import {
   computeCredentialValuesToDelete,
   planCredentialTest,
+  providerEnumKey,
   resetCredentialFormOnProviderChange,
   summarizeDiscoveredModels,
 } from "./credential_form_helpers";
@@ -51,9 +52,11 @@ type ConnectionTest =
 interface CredentialModalProps {
   open: boolean;
   onCancel: () => void;
-  onSubmit: (values: any, credentialValuesToDelete: string[]) => void;
+  onSubmit: (values: any, credentialValuesToDelete: string[]) => Promise<boolean>;
   mode: "add" | "edit";
   existingCredential?: CredentialItem | null;
+  initialProvider?: Providers;
+  initialVariantId?: string;
   testConnection: (request: ProviderModelDiscoveryRequest) => Promise<ProviderModelDiscoveryResponse>;
   loadJwks: (credentialName: string) => Promise<AnthropicJwks>;
 }
@@ -93,15 +96,18 @@ export default function CredentialModal({
   onSubmit,
   mode,
   existingCredential = null,
+  initialProvider,
+  initialVariantId,
   testConnection,
   loadJwks,
 }: CredentialModalProps) {
   const isEdit = mode === "edit";
   const [selectedProvider, setSelectedProvider] = useState<Providers>(
-    (existingCredential?.credential_info.custom_llm_provider as Providers) ?? Providers.OpenAI,
+    (existingCredential?.credential_info.custom_llm_provider as Providers) ?? initialProvider ?? Providers.OpenAI,
   );
   const [connectionTest, setConnectionTest] = useState<ConnectionTest>({ kind: "idle" });
 
+  const presetValues = initialProvider ? { custom_llm_provider: providerEnumKey(initialProvider) } : undefined;
   const initialValues = existingCredential
     ? {
         credential_name: existingCredential.credential_name,
@@ -110,7 +116,7 @@ export default function CredentialModal({
           Object.entries(existingCredential.credential_values || {}).map(([key, value]) => [key, value ?? null]),
         ),
       }
-    : undefined;
+    : presetValues;
 
   const form = useForm<MountedFormValues>({ mode: "onChange", defaultValues: initialValues });
   const registry = useMountRegistry();
@@ -149,8 +155,10 @@ export default function CredentialModal({
     const credentialValuesToDelete = isEdit
       ? computeCredentialValuesToDelete(existingCredential?.credential_values ?? {}, values)
       : [];
-    onSubmit(filteredValues, credentialValuesToDelete);
-    form.reset();
+    const saved = await onSubmit(filteredValues, credentialValuesToDelete);
+    if (saved) {
+      form.reset();
+    }
   };
 
   const handleTestConnection = async () => {
@@ -225,7 +233,7 @@ export default function CredentialModal({
                 )}
               </MountedFormField>
 
-              <ProviderSpecificFields selectedProvider={selectedProvider} />
+              <ProviderSpecificFields selectedProvider={selectedProvider} initialVariantId={initialVariantId} />
 
               {jwksCredentialName && <JwksExport credentialName={jwksCredentialName} loadJwks={loadJwks} />}
 

--- a/ui/litellm-dashboard/src/components/model_add/CredentialsPanel.tsx
+++ b/ui/litellm-dashboard/src/components/model_add/CredentialsPanel.tsx
@@ -22,19 +22,7 @@ import DeleteResourceModal from "../common_components/DeleteResourceModal";
 import { toast } from "@/lib/toast";
 import CredentialModal from "./CredentialModal";
 import CredentialsTable from "./CredentialsTable";
-
-const restrictedFields = ["credential_name", "custom_llm_provider"];
-
-const buildCredential = (values: Record<string, unknown>, credentialValues: Record<string, unknown>) => ({
-  credential_name: values.credential_name as string,
-  credential_values: credentialValues,
-  credential_info: {
-    custom_llm_provider: values.custom_llm_provider as string,
-  },
-});
-
-const withoutRestrictedFields = (values: Record<string, unknown>): Record<string, unknown> =>
-  Object.fromEntries(Object.entries(values).filter(([key]) => !restrictedFields.includes(key)));
+import { buildCredential, withoutRestrictedFields } from "./credential_form_helpers";
 
 export default function CredentialsPanel() {
   const { accessToken, userRole } = useAuthorized();
@@ -54,9 +42,12 @@ export default function CredentialsPanel() {
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [isCredentialDeleting, setIsCredentialDeleting] = useState(false);
 
-  const handleUpdateCredential = async (values: Record<string, unknown>, credentialValuesToDelete: string[] = []) => {
+  const handleUpdateCredential = async (
+    values: Record<string, unknown>,
+    credentialValuesToDelete: string[] = [],
+  ): Promise<boolean> => {
     if (!accessToken) {
-      return;
+      return false;
     }
     try {
       const newCredential = {
@@ -67,14 +58,16 @@ export default function CredentialsPanel() {
       toast.success("Credential updated successfully");
       setIsUpdateModalOpen(false);
       await refetchCredentials();
+      return true;
     } catch (error) {
       toast.error("Failed to update credential");
+      return false;
     }
   };
 
-  const handleAddCredential = async (values: Record<string, unknown>) => {
+  const handleAddCredential = async (values: Record<string, unknown>): Promise<boolean> => {
     if (!accessToken) {
-      return;
+      return false;
     }
     try {
       const newCredential = buildCredential(values, withoutRestrictedFields(values));
@@ -82,8 +75,10 @@ export default function CredentialsPanel() {
       toast.success("Credential added successfully");
       setIsAddModalOpen(false);
       await refetchCredentials();
+      return true;
     } catch (error) {
       toast.error("Failed to add credential");
+      return false;
     }
   };
 

--- a/ui/litellm-dashboard/src/components/model_add/credential_form_helpers.ts
+++ b/ui/litellm-dashboard/src/components/model_add/credential_form_helpers.ts
@@ -126,3 +126,24 @@ export function summarizeDiscoveredModels(models: readonly string[]): string {
   const rest = models.length > 3 ? ` and ${models.length - 3} more` : "";
   return `Connection succeeded. ${models.length} model${models.length === 1 ? "" : "s"} available: ${shown}${rest}.`;
 }
+
+export type CredentialPayload = {
+  readonly credential_name: string;
+  readonly credential_values: Record<string, unknown>;
+  readonly credential_info: { readonly custom_llm_provider: string };
+};
+
+export const buildCredential = (
+  values: Record<string, unknown>,
+  credentialValues: Record<string, unknown>,
+): CredentialPayload => ({
+  credential_name: values.credential_name as string,
+  credential_values: credentialValues,
+  credential_info: { custom_llm_provider: values.custom_llm_provider as string },
+});
+
+export const withoutRestrictedFields = (values: Record<string, unknown>): Record<string, unknown> =>
+  Object.fromEntries(Object.entries(values).filter(([key]) => !FORM_META_KEYS.has(key)));
+
+export const providerEnumKey = (provider: Providers): string =>
+  Object.entries(Providers).find(([, displayName]) => displayName === provider)?.[0] ?? provider;

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -318,6 +318,7 @@ export interface ProviderCredentialVariant {
   field_keys: string[];
   optional_field_keys?: string[];
   fixed_values: Record<string, string>;
+  credential_only: boolean;
 }
 
 export interface ProviderCredentialVariants {

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -34301,8 +34301,13 @@ export interface components {
          *     ``optional_field_keys`` relaxes a globally-required field for this variant alone, for a value
          *     only obtainable after the credential exists (the federation rule id an operator can only read
          *     off the Anthropic Console once the generated JWKS is registered).
+         *     ``credential_only`` is derived, never declared: a variant that submits a server-owned workload
+         *     identity federation parameter, as a field or a fixed value, can only be saved as a named LLM
+         *     Credential, since ``/model/new`` rejects those parameters inline.
          */
         ProviderCredentialVariant: {
+            /** Credential Only */
+            readonly credential_only: boolean;
             /** Field Keys */
             field_keys: string[];
             /** Fixed Values */


### PR DESCRIPTION
## TLDR

Problem this solves:

- Add Model offers OpenAI and Anthropic federation auth methods whose fields the server rejects inline
- Test Connect and Add Model both return 401 naming the server-owned field
- Nothing on the page points at LLM Credentials, the only route that works

How it solves it:

- Every federation variant is flagged `credential_only` in the provider fields payload
- Add Model swaps those fields for a "Create credential" step preset to that provider and variant
- The saved credential is attached to the model, so Test Connect and Add Model go through

## User Flow

Before: a proxy admin adding an OpenAI deployment that authenticates with workload identity federation gets a 401 from the Add Model form and has no way forward

1. They open https://litellm-domain/ui/models-and-endpoints/, the Add Model tab, pick Provider "OpenAI" and Authentication method "Workload Identity Federation (token file)"
2. The form shows Identity Provider ID, Service Account ID, and Identity Token File Path; they fill them in and enter model `gpt-5.6`
3. They click Test Connect: POST https://litellm-domain/health/test_connection with the three values inline returns HTTP 401 "openai_identity_provider_id is a server-owned workload identity federation parameter and cannot be set in a request body; configure it on the deployment instead."
4. They click Add Model anyway: POST https://litellm-domain/model/new with the same three values in `litellm_params` returns the same HTTP 401 and the toast reads "Failed to add model: ... server-owned workload identity federation parameter ..."
5. The page never says the settings belong in an LLM Credential, so the deployment is never created

After: the same admin saves the federation settings as a named LLM Credential from inside the Add Model form and the deployment is created against it

1. They open https://litellm-domain/ui/models-and-endpoints/, the Add Model tab, pick Provider "OpenAI" and Authentication method "Workload Identity Federation (token file)"
2. The form shows a notice that this method's settings are stored as an LLM Credential, with a "Create credential" button instead of the three fields
3. They click Create credential: a dialog opens already set to OpenAI and Workload Identity Federation (token file); they name it `openai-wif`, fill Identity Provider ID, Service Account ID, and Identity Token File Path, and click Add Credential: POST https://litellm-domain/credentials returns HTTP 200 and the toast reads "Credential added successfully"
4. The dialog closes and the Add Model form now shows Existing Credentials = `openai-wif`; they enter model `gpt-5.6`
5. They click Test Connect: POST https://litellm-domain/health/test_connection with `litellm_credential_name: "openai-wif"` and no identity fields returns HTTP 200 and the dialog reads "Connection to gpt-5.6 successful!"
6. They click Add Model: POST https://litellm-domain/model/new with `litellm_credential_name: "openai-wif"` returns HTTP 200 with a `model_id` UUID and the row appears under All Models
7. A developer sends POST https://litellm-domain/v1/chat/completions with `"model": "gpt-5.6"` and gets HTTP 200 with a real completion, the proxy having exchanged its identity token with OpenAI

## Relevant issues

## Linear ticket

Resolves LIT-6897

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Rig for both legs: one proxy per leg on http://localhost:24369 booted with `--num_workers 2` (two uvicorn workers) from the commit named in each heading, with `store_model_in_db: true`, an empty model and credential table, and `OPENAI_API_KEY` unset so the identity token exchange is the only way the proxy can reach OpenAI. The Admin UI dev server on http://localhost:29579 was built from the same commit. The flow was driven in Chromium as a proxy admin who signed in through the UI login page (http://localhost:24369/ui/login/, since the dev server's own /login POST is blocked by CORS), and every dashboard call returned 200 until the step under test. The WIF trio is the OpenAI test identity provider `idp_740e435c63dee769ce9fe8e0`, service account `user-05a654475b435b10454b0ee6`, and a subject-token file minted for it. Both legs ran the same flow with the same values, only the commit differs

### Before (82afbbdba1)

Proxy booted from the merge base 82afbbdba1 (2 uvicorn workers, empty model and credential tables, `OPENAI_API_KEY` unset), dev server on the same commit, proxy admin signed in through the UI login page

1. Opened http://localhost:29579/models-and-endpoints/ and clicked the "Add Model" tab: GET /public/providers/fields, GET /v2/guardrails/list, GET /tag/list, GET /models?include_model_access_groups=True&only_model_access_groups=True, GET /credentials, GET /team/list, all HTTP 200. Observed: the "Add Model" form
2. Picked Provider "OpenAI" and Authentication method "Workload Identity Federation (token file)": no proxy request. Observed: the form shows API Base (https://api.openai.com/v1), OpenAI Organization ID, Identity Provider ID, Service Account ID, and Identity Token File Path inline, with no notice and no "Create credential" button
3. Filled Identity Provider ID `idp_740e435c63dee769ce9fe8e0`, Service Account ID `user-05a654475b435b10454b0ee6`, Identity Token File Path `/Users/mateo/.claude/qa-fixtures/lit6108-openai-wif/subject_token.jwt`, typed `gpt-5.6` into "LiteLLM Model Name(s)" and picked the first option: no proxy request. Observed: chip "gpt-5.6", a Model Mappings row "gpt-5.6 -> gpt-5.6", all three WIF values held, no validation message

![pr39886-64a2eb98ab-lit6897_qa_before_form_filled.png](https://github.com/mateo-berri/qa-screenshots/releases/download/assets/pr39886-64a2eb98ab-lit6897_qa_before_form_filled.png)

4. Clicked "Test Connect": POST /health/test_connection -> HTTP 401, request body `{"litellm_params":{"model":"gpt-5.6","custom_llm_provider":"openai","openai_identity_provider_id":"idp_740e435c63dee769ce9fe8e0","openai_service_account_id":"user-05a654475b435b10454b0ee6","openai_identity_token_file":"/Users/mateo/.claude/qa-fixtures/lit6108-openai-wif/subject_token.jwt"},"model_info":{}}`, response body identical to the curl control below. Observed: dialog "Connection Test Results" with the headline "Connection to  failed" (the model name is blank because closing the model dropdown with Escape had cleared the chip right before the click, while the request still carried "model":"gpt-5.6"), then "Error: Authentication Error, Rejected Request: openai_identity_provider_id is a server-owned workload identity federation parameter and cannot be set in a request body; configure it on the deployment instead.". "Show Details" reveals "Troubleshooting Details" with the same text and an "API Request" box reading "No request data available"

![pr39886-64a2eb98ab-lit6897_qa_before_test_connect_401.png](https://github.com/mateo-berri/qa-screenshots/releases/download/assets/pr39886-64a2eb98ab-lit6897_qa_before_test_connect_401.png)

5. Re-selected gpt-5.6 and clicked "Add Model": POST /model/new -> HTTP 401, request body `{"model_name":"gpt-5.6","litellm_params":{"model":"gpt-5.6","custom_llm_provider":"openai","openai_identity_provider_id":"idp_740e435c63dee769ce9fe8e0","openai_service_account_id":"user-05a654475b435b10454b0ee6","openai_identity_token_file":"/Users/mateo/.claude/qa-fixtures/lit6108-openai-wif/subject_token.jwt"},"model_info":{}}`, same response body. Observed: toast "Error" reading "Failed to add model: ApiError: Authentication Error, Rejected Request: openai_identity_provider_id is a server-owned workload identity federation parameter and cannot be set in a request body; configure it on the deployment instead.". The form stays filled and no model appears

![pr39886-64a2eb98ab-lit6897_qa_before_add_model_401.png](https://github.com/mateo-berri/qa-screenshots/releases/download/assets/pr39886-64a2eb98ab-lit6897_qa_before_add_model_401.png)

6. Proxy network log for steps 4 and 5: exactly two requests, POST /health/test_connection -> 401 and POST /model/new -> 401
7. Curl control with the same inline trio against /model/new (master key), exact command and output:

```
curl -sS -o /dev/stdout -w '\nHTTP %{http_code}\n' -X POST http://localhost:24369/model/new \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H 'Content-Type: application/json' \
  -d '{"model_name":"gpt-5.6","litellm_params":{"model":"openai/gpt-5.6","custom_llm_provider":"openai","openai_identity_provider_id":"idp_740e435c63dee769ce9fe8e0","openai_service_account_id":"user-05a654475b435b10454b0ee6","openai_identity_token_file":"/Users/mateo/.claude/qa-fixtures/lit6108-openai-wif/subject_token.jwt"},"model_info":{}}'
```

```
{"error":{"message":"Authentication Error, Rejected Request: openai_identity_provider_id is a server-owned workload identity federation parameter and cannot be set in a request body; configure it on the deployment instead.","type":"auth_error","param":"None","code":"401"}}
HTTP 401
```

8. Listed models with the master key, `curl -s http://localhost:24369/v1/models -H "Authorization: Bearer $LITELLM_MASTER_KEY"`: HTTP 200 with `{"data":[],"object":"list"}`, so neither the UI nor the curl attempt created anything
9. Console check for the observation noted under After: on the same merge base, filling the WIF inputs on the Add Model form logged React's "A component is changing an uncontrolled input to be controlled" warning, and the LLM Credentials tab's "Add Credential" dialog with the same variant selected logged nothing

### After (64a2eb98ab)

Same rig booted from 64a2eb98ab (proxy with 2 uvicorn workers, empty model and credential tables, `OPENAI_API_KEY` unset, dev server on the same commit, proxy admin signed in through the UI login page)

1. Opened http://localhost:29579/models-and-endpoints/, clicked the "Add Model" tab, picked Provider "OpenAI" and Authentication method "Workload Identity Federation (token file)": the tab load fired GET /credentials -> HTTP 200 and nothing else. Observed: instead of the inline Identity Provider ID, Service Account ID, and Identity Token File Path inputs, the form shows the notice "Workload Identity Federation (token file) uses server-owned identity settings, which are stored as an LLM Credential rather than entered on the model. Create the credential and this model will use it." with a "Create credential" button (API Base, OpenAI Organization ID, and OpenAI API Key are not shown for this variant either)

![pr39886-64a2eb98ab-lit6897_qa_after_notice.png](https://github.com/mateo-berri/qa-screenshots/releases/download/assets/pr39886-64a2eb98ab-lit6897_qa_after_notice.png)

2. Clicked "Create credential": no proxy request. Observed: the "Add New Credential" dialog opened with Provider "OpenAI" and Authentication method "Workload Identity Federation (token file)" preselected, showing Credential Name, API Base (prefilled https://api.openai.com/v1), OpenAI Organization ID, Identity Provider ID, Service Account ID, and Identity Token File Path. "Test Connection" is disabled with the helper text "Add the credential first, then test it from Edit. Only an API key and API base can be tested before saving."
3. Filled Credential Name `openai-wif`, Identity Provider ID `idp_740e435c63dee769ce9fe8e0`, Service Account ID `user-05a654475b435b10454b0ee6`, Identity Token File Path `/Users/mateo/.claude/qa-fixtures/lit6108-openai-wif/subject_token.jwt` and clicked "Add Credential": POST /credentials -> HTTP 200 with body `{"success":true,"message":"Credential created successfully"}`, then GET /credentials -> HTTP 200. The request body was `{"credential_name":"openai-wif","credential_values":{"openai_identity_provider_id":"idp_740e435c63dee769ce9fe8e0","openai_service_account_id":"user-05a654475b435b10454b0ee6","openai_identity_token_file":"/Users/mateo/.claude/qa-fixtures/lit6108-openai-wif/subject_token.jwt"},"credential_info":{"custom_llm_provider":"OpenAI"}}`. Observed: the dialog closed and the success toast ("Credential added successfully") had already auto-dismissed by the time the page was snapshotted

![pr39886-64a2eb98ab-lit6897_qa_after_credential_dialog.png](https://github.com/mateo-berri/qa-screenshots/releases/download/assets/pr39886-64a2eb98ab-lit6897_qa_after_credential_dialog.png)

4. Looked at the Add Model form again: no proxy request. Observed: "Existing Credentials" now reads "openai-wif" and the Authentication method block is gone, so the model will be saved against the credential. Typed `gpt-5.6` into "LiteLLM Model Name(s)" and picked the first option: chip "gpt-5.6" and a Model Mappings row "gpt-5.6 -> gpt-5.6"

![pr39886-64a2eb98ab-lit6897_qa_after_credential_saved.png](https://github.com/mateo-berri/qa-screenshots/releases/download/assets/pr39886-64a2eb98ab-lit6897_qa_after_credential_saved.png)

5. Clicked "Test Connect": POST /health/test_connection -> HTTP 200 after 7.8 s with request body `{"litellm_params":{"model":"gpt-5.6","custom_llm_provider":"openai","litellm_credential_name":"openai-wif"},"model_info":{}}` and response `{"status":"success","result":{"model":"gpt-5.6","custom_llm_provider":"openai","litellm_credential_name":"openai-wif","max_tokens":16,"cache":{"no-cache":true},"x-ratelimit-remaining-requests":"14999","x-ratelimit-remaining-tokens":"39999994"}}`. Observed: dialog "Connection Test Results" reading "Connection to gpt-5.6 successful!"

![pr39886-64a2eb98ab-lit6897_qa_after_test_connect_200.png](https://github.com/mateo-berri/qa-screenshots/releases/download/assets/pr39886-64a2eb98ab-lit6897_qa_after_test_connect_200.png)

6. Closed the dialog and clicked "Add Model": POST /model/new -> HTTP 200 with request body `{"model_name":"gpt-5.6","litellm_params":{"model":"gpt-5.6","custom_llm_provider":"openai","litellm_credential_name":"openai-wif"},"model_info":{}}` and a response echoing the deployment with `"model_id":"8f5df9e5-787d-4d29-80ad-7bc11a9d3e88"`. Neither request in steps 5 and 6 carries an inline `openai_identity_*` field. Observed: toast "Model gpt-5.6 created successfully" and the form reset

![pr39886-64a2eb98ab-lit6897_qa_after_add_model_200.png](https://github.com/mateo-berri/qa-screenshots/releases/download/assets/pr39886-64a2eb98ab-lit6897_qa_after_add_model_200.png)

7. Opened the "All Models" tab: GET /v2/model/info?include_team_models=true&page=1&size=50 -> HTTP 200. Observed: one row, Model ID 8f5df9e5-78..., "gpt-5.6 / gpt-5.6", Credentials "openai-wif", Created By default_user_id

![pr39886-64a2eb98ab-lit6897_qa_after_all_models.png](https://github.com/mateo-berri/qa-screenshots/releases/download/assets/pr39886-64a2eb98ab-lit6897_qa_after_all_models.png)

8. From a shell, read the new `credential_only` flag the form keys off, listed the models, and sent a chat completion through the deployment (no API key anywhere on the proxy, so the identity token was exchanged with OpenAI):

```
curl -s "http://localhost:24369/public/providers/fields" | python3 -c 'import json,sys; [print(json.dumps({"provider": p["provider"], "variants": [{k: v[k] for k in ("id","label","credential_only")} for v in p["credential_variants"]["variants"]]})) for p in json.load(sys.stdin) if p["provider"].lower() == "openai"]'
curl -s "http://localhost:24369/v1/models" -H "Authorization: Bearer $LITELLM_MASTER_KEY"
curl -s -X POST "http://localhost:24369/v1/chat/completions" -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H 'Content-Type: application/json' \
  -d '{"model":"gpt-5.6","messages":[{"role":"user","content":"Reply with the single word pong"}],"max_tokens":16}' \
  -w '\nHTTP %{http_code}\n'
```

```
{"provider": "OpenAI", "variants": [{"id": "api_key", "label": "API Key", "credential_only": false}, {"id": "wif_token_file", "label": "Workload Identity Federation (token file)", "credential_only": true}]}
{"data":[{"id":"gpt-5.6","object":"model","created":1677610602,"owned_by":"openai","mode":"chat","max_input_tokens":922000,"max_output_tokens":128000}],"object":"list"}
{"id":"chatcmpl-EKhe0vvlV9ioy4wy4c9I4jWA8S1kl","created":1788603036,"model":"gpt-5.6","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"pong","role":"assistant","provider_specific_fields":{"refusal":null},"annotations":[]},"provider_specific_fields":{}}],"usage":{"completion_tokens":4,"prompt_tokens":12,"total_tokens":16,"completion_tokens_details":{"accepted_prediction_tokens":0,"audio_tokens":0,"reasoning_tokens":0,"rejected_prediction_tokens":0},"prompt_tokens_details":{"audio_tokens":0,"cached_tokens":0,"cache_write_tokens":0,"cache_creation_tokens":0}},"service_tier":"default"}
HTTP 200
```

PASS: the merge base rejects the inline trio with HTTP 401 on both Test Connect and Add Model, and the tip routes the same values through an LLM Credential so Test Connect and Add Model return 200 and a real chat completion runs on the identity token exchange

Observations outside the fix, none caused or worsened by this PR:

- Test Connect "API Request" box reads "No request data available": pre-existing
- Test Connect with the chip cleared says "Connection to  failed": pre-existing
- Escape in the model dropdown clears the chosen model: pre-existing
- Error text overflows the Connection Test dialog: pre-existing
- Credential dialog shows API Base and Organization ID for WIF: pre-existing
- Credential POST sends provider display-cased "OpenAI", server lowercases it: pre-existing
- React uncontrolled-input warning follows the WIF inputs: pre-existing
- UI session key expires about ten minutes after login: pre-existing
- Test Connect took 7.8 s over a real token exchange: not a regression
- Credential success toast auto-dismisses within seconds: unchanged

## Type

🆕 New Feature

## Caveats (if any)

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

