### PR TITLE
test(logging): undo the stdout patch inside the test so capsys never restores a closed stream

### DIFF
--- a/tests/test_litellm/test_logging.py
+++ b/tests/test_litellm/test_logging.py
@@ -929,7 +929,7 @@ def test_plain_log_format_survives_hostile_streams(stdout, stderr):
     assert _plain_log_format(stdout, stderr) == _PLAIN_LOG_FORMAT
 
 
-def test_level_routing_handler_falls_back_to_stderr_when_stdout_is_unusable(monkeypatch, capsys):
+def test_level_routing_handler_falls_back_to_stderr_when_stdout_is_unusable(capsys):
     logger = logging.getLogger("test_level_routing_fallback")
     logger.handlers.clear()
     logger.propagate = False
@@ -938,9 +938,13 @@ def test_level_routing_handler_falls_back_to_stderr_when_stdout_is_unusable(monk
     handler.setFormatter(logging.Formatter("%(levelname)s %(message)s"))
     logger.addHandler(handler)
 
+    # Undo the stdout patch before the test returns. The autouse conftest fixtures
+    # request `monkeypatch`, so it tears down after `capsys` and would restore
+    # sys.stdout to capsys's already-closed stream (see #39882).
     try:
-        monkeypatch.setattr(sys, "stdout", None)
-        logger.info("stdout is gone")
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(sys, "stdout", None)
+            logger.info("stdout is gone")
     finally:
         logger.handlers.clear()
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- `test_level_routing_handler_falls_back_to_stderr_when_stdout_is_unusable` ends with a teardown ERROR on every run
- It patches `sys.stdout` via the `monkeypatch` fixture, which tears down after `capsys`
- monkeypatch then restores `sys.stdout` to capsys's already-closed stream
- The module-scoped `setup_and_teardown` print in `conftest.py` hits that closed stream

How it solves it:

- Patch `sys.stdout` with a scoped `pytest.MonkeyPatch.context()` inside the test body
- The patch is undone while capsys is still live, so nothing points at a closed stream
- Drop the now-unused `monkeypatch` parameter

Reordering the signature does not work: the autouse conftest fixtures request `monkeypatch` first, so it is always set up before `capsys` and torn down after it (`--setup-show` output in #39882).

## Relevant issues

Fixes #39882

## Pre-Submission checklist

- [x] I have added meaningful tests (this PR fixes an existing test; no product code changes)
- [x] The handful of test files covering my change pass locally: `uv run pytest tests/test_litellm/test_logging.py -n 2` -> 102 passed
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5

## Screenshots / Proof of Fix

Environment: `litellm_internal_staging`, CI dependency set (`--group ci --group proxy-dev --extra google --extra proxy --extra semantic-router --extra saml --extra mongodb`), Python 3.13.

### Before (aea5358c48)

1. `uv run --no-sync pytest "tests/test_litellm/test_logging.py::test_level_routing_handler_falls_back_to_stderr_when_stdout_is_unusable" -q`
   Observed: `1 passed, 1 error`, with `ERROR at teardown ... tests/test_litellm/conftest.py:491: ValueError: I/O operation on closed file.`
2. `uv run --no-sync pytest tests/test_litellm/test_*.py -n 4 --reruns 2 --reruns-delay 1`
   Observed: `4127 passed, 3 skipped, 1 error`

### After (d8f81082b6)

1. Same single-test command
   Observed: `1 passed`
2. Same root-shard command
   Observed: `4125 passed, 3 skipped` (no errors)
3. `uv run --no-sync ruff check tests/test_litellm/test_logging.py` and `ruff format --check`: no new findings, file already formatted
4. `python scripts/check_test_quality.py tests/test_litellm/test_logging.py`: same 4 pre-existing TQ005 findings, none added

## Type

✅ Test
