### PR TITLE
fix(anthropic): price recovered tokens when a /v1/messages client disconnects mid-stream

### DIFF
--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
@@ -216,10 +216,15 @@ class AnthropicPassthroughLoggingHandler:
             model=model,
             speed=AnthropicPassthroughLoggingHandler._cost_relevant_speed(request_body),
         )
-        if response is None:
-            return None
-        AnthropicPassthroughLoggingHandler._recover_interrupted_stream_output_tokens(
+        if not isinstance(response, ModelResponse):
+            return response
+        recovered_usage: Final = AnthropicPassthroughLoggingHandler._recover_interrupted_stream_output_tokens(
             response=response, all_chunks=all_chunks, model=model
+        )
+        if recovered_usage is None:
+            return response
+        AnthropicPassthroughLoggingHandler._reprice_recovered_stream(
+            response=response, usage=recovered_usage, model=model, logging_obj=litellm_logging_obj
         )
         return response
 
@@ -259,7 +264,9 @@ class AnthropicPassthroughLoggingHandler:
             )
         except Exception as e:  # noqa: BLE001  # an uncostable partial stream still bills its tokens, at zero cost
             verbose_proxy_logger.warning(
-                "Anthropic passthrough: could not cost the partial usage of a failed stream (model=%s): %s", model, e
+                "Anthropic passthrough: could not cost the partial usage of an interrupted stream (model=%s): %s",
+                model,
+                e,
             )
             return 0.0
 
@@ -359,7 +366,7 @@ class AnthropicPassthroughLoggingHandler:
         response: ModelResponse | TextCompletionResponse,
         all_chunks: Sequence[str | bytes],
         model: str,
-    ) -> None:
+    ) -> Usage | None:
         """
         An Anthropic stream interrupted before its terminal ``message_delta``
         (client disconnect) carries only the ``message_start`` ``output_tokens``
@@ -369,24 +376,24 @@ class AnthropicPassthroughLoggingHandler:
         untouched because their terminal ``message_delta`` short-circuits here.
         """
         if not isinstance(response, ModelResponse):
-            return
+            return None
         if not AnthropicPassthroughLoggingHandler._stream_was_interrupted(all_chunks):
-            return
+            return None
         usage: Final = getattr(response, "usage", None)
-        if usage is None:
-            return
+        if not isinstance(usage, Usage):
+            return None
         output_text: Final = get_content_from_model_response(response)
         if not output_text:
-            return
+            return None
         try:
             recovered_output_tokens = litellm.token_counter(model=model, text=output_text, count_response_tokens=True)
         except Exception:
             verbose_proxy_logger.warning(
                 "Could not re-tokenize interrupted stream output; keeping placeholder completion token count."
             )
-            return
+            return None
         if recovered_output_tokens <= (usage.completion_tokens or 0):
-            return
+            return None
         usage.completion_tokens = recovered_output_tokens
         usage.total_tokens = (usage.prompt_tokens or 0) + recovered_output_tokens
         # Anthropic costing reads completion_tokens_details.text_tokens, so the
@@ -395,6 +402,25 @@ class AnthropicPassthroughLoggingHandler:
         details: Final = getattr(usage, "completion_tokens_details", None)
         if details is not None and getattr(details, "text_tokens", None) is not None:
             details.text_tokens = recovered_output_tokens
+        return usage
+
+    @staticmethod
+    def _reprice_recovered_stream(
+        response: ModelResponse,
+        usage: Usage,
+        model: str,
+        logging_obj: LiteLLMLoggingObj,
+    ) -> None:
+        hidden_params: Final = response._hidden_params  # pyright: ignore[reportPrivateUsage]  # no public accessor
+        usage.cost = None
+        hidden_params.pop("response_cost", None)
+        recovered_cost: Final = AnthropicPassthroughLoggingHandler._cost_partial_stream_or_zero(
+            partial_response=response, model=model, logging_obj=logging_obj
+        )
+        if recovered_cost <= 0:
+            return
+        usage.cost = recovered_cost
+        hidden_params["response_cost"] = recovered_cost
 
     @staticmethod
     def _create_anthropic_response_logging_payload(

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
@@ -223,9 +223,7 @@ class AnthropicPassthroughLoggingHandler:
         )
         if recovered_usage is None:
             return response
-        AnthropicPassthroughLoggingHandler._reprice_recovered_stream(
-            response=response, usage=recovered_usage, model=model, logging_obj=litellm_logging_obj
-        )
+        AnthropicPassthroughLoggingHandler._clear_placeholder_cost(response=response, usage=recovered_usage)
         return response
 
     @staticmethod
@@ -405,22 +403,9 @@ class AnthropicPassthroughLoggingHandler:
         return usage
 
     @staticmethod
-    def _reprice_recovered_stream(
-        response: ModelResponse,
-        usage: Usage,
-        model: str,
-        logging_obj: LiteLLMLoggingObj,
-    ) -> None:
-        hidden_params: Final = response._hidden_params  # pyright: ignore[reportPrivateUsage]  # no public accessor
+    def _clear_placeholder_cost(response: ModelResponse, usage: Usage) -> None:
         usage.cost = None
-        hidden_params.pop("response_cost", None)
-        recovered_cost: Final = AnthropicPassthroughLoggingHandler._cost_partial_stream_or_zero(
-            partial_response=response, model=model, logging_obj=logging_obj
-        )
-        if recovered_cost <= 0:
-            return
-        usage.cost = recovered_cost
-        hidden_params["response_cost"] = recovered_cost
+        response._hidden_params.pop("response_cost", None)  # pyright: ignore[reportPrivateUsage]  # no public accessor
 
     @staticmethod
     def _create_anthropic_response_logging_payload(

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_streaming_iterator.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_streaming_iterator.py
@@ -834,6 +834,50 @@ class _SuccessRecorder(CustomLogger):
         self.success_kwargs.append(kwargs)
 
 
+def _make_priced_logging_obj(call_id: str, recorder: _SuccessRecorder, model: str) -> LiteLLMLoggingObj:
+    logging_obj = LiteLLMLoggingObj(
+        model=model,
+        messages=[{"role": "user", "content": "hi"}],
+        stream=True,
+        call_type="anthropic_messages",
+        start_time=datetime.now(),
+        litellm_call_id=call_id,
+        function_id=call_id,
+        dynamic_async_success_callbacks=[recorder],
+    )
+    logging_obj.update_environment_variables(
+        model=model,
+        user="",
+        optional_params={},
+        litellm_params={"custom_llm_provider": "anthropic"},
+        custom_llm_provider="anthropic",
+    )
+    return logging_obj
+
+
+class _UpstreamClosedOnDetach:
+    """Upstream that yields its events and then, like a socket read, waits until it is closed."""
+
+    def __init__(self, events: tuple[dict, ...]):
+        self._events = iter(events)
+        self._closed = asyncio.Event()
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self) -> dict:
+        if self._closed.is_set():
+            raise StopAsyncIteration
+        try:
+            return next(self._events)
+        except StopIteration:
+            await self._closed.wait()
+            raise StopAsyncIteration
+
+    async def aclose(self) -> None:
+        self._closed.set()
+
+
 @pytest.mark.asyncio
 async def test_client_disconnect_partial_billing_prices_recovered_tokens(monkeypatch):
     """
@@ -849,25 +893,9 @@ async def test_client_disconnect_partial_billing_prices_recovered_tokens(monkeyp
     monkeypatch.setattr(streaming_iterator_module, "ANTHROPIC_MESSAGES_STREAM_RELAY_QUEUE_MAXSIZE", 4)
     model = "claude-sonnet-5"
     recorder = _SuccessRecorder()
-    logging_obj = LiteLLMLoggingObj(
-        model=model,
-        messages=[{"role": "user", "content": "hi"}],
-        stream=True,
-        call_type="anthropic_messages",
-        start_time=datetime.now(),
-        litellm_call_id="disconnect_partial_cost",
-        function_id="disconnect_partial_cost",
-        dynamic_async_success_callbacks=[recorder],
-    )
-    logging_obj.update_environment_variables(
-        model=model,
-        user="",
-        optional_params={},
-        litellm_params={"custom_llm_provider": "anthropic"},
-        custom_llm_provider="anthropic",
-    )
     iterator = BaseAnthropicMessagesStreamingIterator(
-        litellm_logging_obj=logging_obj, request_body={"model": model, "stream": True}
+        litellm_logging_obj=_make_priced_logging_obj("disconnect_partial_cost", recorder, model),
+        request_body={"model": model, "stream": True},
     )
     sentence = "The history of computing spans centuries of mechanical and electronic invention. "
 
@@ -902,6 +930,63 @@ async def test_client_disconnect_partial_billing_prices_recovered_tokens(monkeyp
     assert len(recorder.success_kwargs) == 1
     logged = recorder.success_kwargs[0]["standard_logging_object"]
     assert 1 < logged["completion_tokens"] < 1500
+    prompt_cost, completion_cost = litellm.cost_per_token(
+        model=model, prompt_tokens=29, completion_tokens=logged["completion_tokens"]
+    )
+    assert logged["response_cost"] == pytest.approx(prompt_cost + completion_cost)
+
+
+@pytest.mark.asyncio
+async def test_proxy_disconnect_closing_upstream_prices_recovered_tokens():
+    """
+    Regression (LIT-6872), proxy path: after a client disconnect the proxy's
+    shielded cleanup closes the upstream stream while the pump is still reading
+    it, so the pump bills the chunks collected so far without ever seeing
+    message_delta. That row's response_cost must be priced from its recovered
+    completion_tokens, not from the message_start placeholder.
+    """
+    import litellm
+    from litellm.litellm_core_utils.logging_worker import GLOBAL_LOGGING_WORKER
+
+    model = "claude-sonnet-5"
+    recorder = _SuccessRecorder()
+    iterator = BaseAnthropicMessagesStreamingIterator(
+        litellm_logging_obj=_make_priced_logging_obj("disconnect_upstream_closed", recorder, model),
+        request_body={"model": model, "stream": True},
+    )
+    sentence = "The history of computing spans centuries of mechanical and electronic invention. "
+    upstream = _UpstreamClosedOnDetach(
+        (
+            {"type": "message_start", "message": {"id": "msg_1", "usage": {"input_tokens": 29, "output_tokens": 1}}},
+            {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}},
+            *({"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": sentence}} for _ in range(6)),
+        )
+    )
+    enqueued: list = []
+
+    def _capture(async_coroutine):
+        enqueued.append(async_coroutine)
+
+    with patch.object(  # test-quality-ok: GLOBAL_LOGGING_WORKER is a process-global singleton with no injection seam
+        GLOBAL_LOGGING_WORKER, "ensure_initialized_and_enqueue", side_effect=_capture
+    ):
+        gen = iterator.async_sse_wrapper(upstream)
+        for _ in range(4):
+            await gen.__anext__()
+        await gen.aclose()
+        assert not enqueued, "billing must wait for the upstream read to end, not the client detach"
+        await upstream.aclose()
+        for _ in range(500):
+            if enqueued:
+                break
+            await asyncio.sleep(0.01)
+
+    assert len(enqueued) == 1, "closing the upstream never reached partial billing"
+    await enqueued[0]
+
+    assert len(recorder.success_kwargs) == 1
+    logged = recorder.success_kwargs[0]["standard_logging_object"]
+    assert logged["completion_tokens"] > 1
     prompt_cost, completion_cost = litellm.cost_per_token(
         model=model, prompt_tokens=29, completion_tokens=logged["completion_tokens"]
     )

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_streaming_iterator.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_streaming_iterator.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 from datetime import datetime
+from unittest.mock import patch
 
 import pytest
 
@@ -822,6 +823,89 @@ async def test_async_sse_wrapper_bills_partial_when_detached_drains_disabled(mon
     assert not any(c.startswith(b"event: message_stop\n") for c in iterator.logged_chunks)
     assert tail_reached is False, "pump kept draining despite detached drains being disabled"
     assert len(streaming_iterator_module._DETACHED_STREAM_DRAINS) == 0
+
+
+class _SuccessRecorder(CustomLogger):
+    def __init__(self):
+        super().__init__()
+        self.success_kwargs: list = []
+
+    async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
+        self.success_kwargs.append(kwargs)
+
+
+@pytest.mark.asyncio
+async def test_client_disconnect_partial_billing_prices_recovered_tokens(monkeypatch):
+    """
+    Regression (LIT-6872): a client disconnect that lands on partial billing
+    re-tokenizes the buffered text into completion_tokens, but the logged cost
+    stayed priced at the message_start placeholder (1 output token). The success
+    row's response_cost must match its recovered completion_tokens.
+    """
+    import litellm
+    from litellm.litellm_core_utils.logging_worker import GLOBAL_LOGGING_WORKER
+
+    monkeypatch.setattr(streaming_iterator_module, "ANTHROPIC_MESSAGES_MAX_DETACHED_STREAM_DRAINS", 0)
+    monkeypatch.setattr(streaming_iterator_module, "ANTHROPIC_MESSAGES_STREAM_RELAY_QUEUE_MAXSIZE", 4)
+    model = "claude-sonnet-5"
+    recorder = _SuccessRecorder()
+    logging_obj = LiteLLMLoggingObj(
+        model=model,
+        messages=[{"role": "user", "content": "hi"}],
+        stream=True,
+        call_type="anthropic_messages",
+        start_time=datetime.now(),
+        litellm_call_id="disconnect_partial_cost",
+        function_id="disconnect_partial_cost",
+        dynamic_async_success_callbacks=[recorder],
+    )
+    logging_obj.update_environment_variables(
+        model=model,
+        user="",
+        optional_params={},
+        litellm_params={"custom_llm_provider": "anthropic"},
+        custom_llm_provider="anthropic",
+    )
+    iterator = BaseAnthropicMessagesStreamingIterator(
+        litellm_logging_obj=logging_obj, request_body={"model": model, "stream": True}
+    )
+    sentence = "The history of computing spans centuries of mechanical and electronic invention. "
+
+    async def _stream():
+        yield {"type": "message_start", "message": {"id": "msg_1", "usage": {"input_tokens": 29, "output_tokens": 1}}}
+        yield {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}}
+        for _ in range(100):
+            yield {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": sentence}}
+        yield {"type": "message_delta", "delta": {"stop_reason": "end_turn"}, "usage": {"output_tokens": 1500}}
+        yield {"type": "message_stop"}
+
+    enqueued: list = []
+
+    def _capture(async_coroutine):
+        enqueued.append(async_coroutine)
+
+    with patch.object(  # test-quality-ok: GLOBAL_LOGGING_WORKER is a process-global singleton with no injection seam
+        GLOBAL_LOGGING_WORKER, "ensure_initialized_and_enqueue", side_effect=_capture
+    ):
+        gen = iterator.async_sse_wrapper(_stream())
+        for _ in range(4):
+            await gen.__anext__()
+        await gen.aclose()
+        for _ in range(500):
+            if enqueued:
+                break
+            await asyncio.sleep(0.01)
+
+    assert len(enqueued) == 1, "client disconnect never reached partial billing"
+    await enqueued[0]
+
+    assert len(recorder.success_kwargs) == 1
+    logged = recorder.success_kwargs[0]["standard_logging_object"]
+    assert 1 < logged["completion_tokens"] < 1500
+    prompt_cost, completion_cost = litellm.cost_per_token(
+        model=model, prompt_tokens=29, completion_tokens=logged["completion_tokens"]
+    )
+    assert logged["response_cost"] == pytest.approx(prompt_cost + completion_cost)
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_anthropic_passthrough_logging_handler.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_anthropic_passthrough_logging_handler.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 
+from litellm.integrations.custom_logger import CustomLogger
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_passthrough_logging_handler import (
     AnthropicPassthroughLoggingHandler,
@@ -1551,6 +1552,7 @@ class TestInterruptedStreamOutputTokenRecovery:
         return f"event: {event}\ndata: {json.dumps(data)}\n\n".encode()
 
     _MODEL = "claude-3-5-haiku-20241022"
+    _PRICED_MODEL = "claude-sonnet-5"
     _OUTPUT_TEXT = (
         "The history of computing spans centuries, beginning with mechanical "
         "calculators and the abacus, advancing through Charles Babbage's "
@@ -1559,7 +1561,7 @@ class TestInterruptedStreamOutputTokenRecovery:
         "century that gave rise to the modern information age."
     )
 
-    def _interrupted_chunks(self, *, placeholder_output_tokens: int = 2):
+    def _interrupted_chunks(self, *, placeholder_output_tokens: int = 2, model: str | None = None):
         from litellm.proxy.pass_through_endpoints.streaming_handler import (
             PassThroughStreamingHandler,
         )
@@ -1574,7 +1576,7 @@ class TestInterruptedStreamOutputTokenRecovery:
                         "id": "msg_interrupted",
                         "type": "message",
                         "role": "assistant",
-                        "model": self._MODEL,
+                        "model": model or self._MODEL,
                         "content": [],
                         "stop_reason": None,
                         "stop_sequence": None,
@@ -1675,6 +1677,82 @@ class TestInterruptedStreamOutputTokenRecovery:
         # Terminal message_delta present: recovery must not fire; the authoritative
         # provider count is preserved verbatim.
         assert usage.completion_tokens == final
+
+    @pytest.mark.asyncio
+    async def test_interrupted_stream_logs_cost_of_recovered_tokens(self):
+        """
+        Regression (LIT-6872): stream_chunk_builder stamps usage.cost and
+        _hidden_params["response_cost"] from the message_start placeholder before
+        the interrupted stream is re-tokenized, and the success handler prefers
+        that hidden cost over the recomputed one. The logged cost must price the
+        recovered completion tokens, not the placeholder.
+        """
+        import litellm
+
+        class _SuccessRecorder(CustomLogger):
+            def __init__(self):
+                super().__init__()
+                self.success_kwargs: list = []
+
+            async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
+                self.success_kwargs.append(kwargs)
+
+        recorder = _SuccessRecorder()
+        logging_obj = LiteLLMLoggingObj(
+            model=self._PRICED_MODEL,
+            messages=[{"role": "user", "content": "hi"}],
+            stream=True,
+            call_type="pass_through_endpoint",
+            start_time=datetime.now(),
+            litellm_call_id="lit-6872",
+            function_id="lit-6872",
+            dynamic_async_success_callbacks=[recorder],
+        )
+        logging_obj.update_environment_variables(
+            model=self._PRICED_MODEL,
+            user="",
+            optional_params={},
+            litellm_params={"custom_llm_provider": "anthropic"},
+            custom_llm_provider="anthropic",
+        )
+        placeholder = 1
+        handled = AnthropicPassthroughLoggingHandler._handle_logging_anthropic_collected_chunks(
+            litellm_logging_obj=logging_obj,
+            passthrough_success_handler_obj=MagicMock(),
+            url_route="/anthropic/v1/messages",
+            request_body={"model": self._PRICED_MODEL, "stream": True},
+            endpoint_type="messages",
+            start_time=datetime.now(),
+            all_chunks=self._interrupted_chunks(placeholder_output_tokens=placeholder, model=self._PRICED_MODEL),
+            end_time=datetime.now(),
+        )
+        await logging_obj.dispatch_success_handlers(
+            result=handled["result"],
+            start_time=datetime.now(),
+            end_time=datetime.now(),
+            cache_hit=False,
+            prefer_async_handlers=True,
+            **handled["kwargs"],
+        )
+        for _ in range(300):
+            if recorder.success_kwargs:
+                break
+            await asyncio.sleep(0.01)
+
+        assert len(recorder.success_kwargs) == 1
+        logged = recorder.success_kwargs[0]["standard_logging_object"]
+        recovered_tokens = handled["result"].usage.completion_tokens
+        assert recovered_tokens > placeholder
+        assert logged["completion_tokens"] == recovered_tokens
+        prompt_cost, completion_cost = litellm.cost_per_token(
+            model=self._PRICED_MODEL, prompt_tokens=29, completion_tokens=recovered_tokens
+        )
+        _, placeholder_completion_cost = litellm.cost_per_token(
+            model=self._PRICED_MODEL, prompt_tokens=29, completion_tokens=placeholder
+        )
+        assert logged["response_cost"] == pytest.approx(prompt_cost + completion_cost)
+        assert logged["response_cost"] > prompt_cost + placeholder_completion_cost
+        assert handled["result"].usage.cost == pytest.approx(prompt_cost + completion_cost)
 
 
 class TestStreamFalseDeduplication:

--- a/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_anthropic_passthrough_logging_handler.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_anthropic_passthrough_logging_handler.py
@@ -1752,7 +1752,6 @@ class TestInterruptedStreamOutputTokenRecovery:
         )
         assert logged["response_cost"] == pytest.approx(prompt_cost + completion_cost)
         assert logged["response_cost"] > prompt_cost + placeholder_completion_cost
-        assert handled["result"].usage.cost == pytest.approx(prompt_cost + completion_cost)
 
 
 class TestStreamFalseDeduplication:


### PR DESCRIPTION
## TLDR

Problem this solves:

- A client drops a streamed `/v1/messages` reply partway through
- The logged row recovers the real `completion_tokens` from the delivered text
- But `response_cost` on that row still prices one placeholder output token

How it solves it:

- After token recovery, clear the cost stamped from the placeholder usage
- The existing success and failure logging then price the recovered usage once, as they already do for every other row
- Regression tests at the logging handler and at the streaming iterator, including the upstream-close path the proxy takes on a disconnect

## User Flow

Before: a developer whose app cancels a streamed `/v1/messages` reply partway sees the real token count on the logged row but a cost that only covers one output token

1. They send POST https://litellm-domain/v1/messages with `"model": "claude-sonnet-5"`, `"stream": true`, and a prompt that produces a long reply
2. SSE events start arriving: `message_start` with `"usage": {"input_tokens": 25, "output_tokens": 1}`, `content_block_start`, then `content_block_delta` text chunks
3. After a few text deltas the app closes the connection (the user hit stop, or the client timed out), so no `message_delta` or `message_stop` ever arrives
4. They take the `id` from the `message_start` event and call GET https://litellm-domain/spend/logs?request_id=msg_... with the admin key, which returns the row with `prompt_tokens: 25` and `completion_tokens: 63`, the output the model had produced by the time the connection dropped
5. The same row shows `spend: 0.00006`, which is 25 input tokens plus a single output token, so the other 62 output tokens count for $0 against the key and team budgets

After: the same canceled stream logs a cost that matches the delivered tokens

1. They send POST https://litellm-domain/v1/messages with `"model": "claude-sonnet-5"`, `"stream": true`, and a prompt that produces a long reply
2. SSE events start arriving: `message_start` with `"usage": {"input_tokens": 25, "output_tokens": 1}`, `content_block_start`, then `content_block_delta` text chunks
3. After a few text deltas the app closes the connection (the user hit stop, or the client timed out), so no `message_delta` or `message_stop` ever arrives
4. They take the `id` from the `message_start` event and call GET https://litellm-domain/spend/logs?request_id=msg_... with the admin key, which returns the row with `prompt_tokens: 25` and `completion_tokens: 63`, the output the model had produced by the time the connection dropped
5. The same row shows `spend: 0.00068` (25 input tokens at $2/M plus 63 output tokens at $10/M), so key and team spend match the tokens the row reports

## Relevant issues

## Linear ticket

Resolves LIT-6872

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Real Anthropic spend against a local proxy booted with `--num_workers 2` (one proxy process, two uvicorn workers) and a fresh Postgres reached through `DATABASE_URL`, whose migrations the proxy applied at boot. Each leg has its own worktree, `.venv`, and random port. `claude-sonnet-5` is priced at 2e-06 per input token and 1e-05 per output token, so a spend row should satisfy `spend = prompt_tokens * 2e-06 + completion_tokens * 1e-05`

`config.yaml`:

```yaml
model_list:
  - model_name: claude-sonnet-5
    litellm_params:
      model: anthropic/claude-sonnet-5
      api_key: os.environ/ANTHROPIC_API_KEY

general_settings:
  master_key: sk-lit6872
```

`body.json`:

```json
{"model": "claude-sonnet-5", "max_tokens": 600, "stream": true, "messages": [{"role": "user", "content": "Write a 400 word essay about the history of lighthouses."}]}
```

The client is `curl --max-time 2`, which reads the first text deltas and then drops the connection mid-stream. The spend row is then read back through `GET /spend/logs?request_id=<id from the message_start event>`

### Before (c52b53706e)

1. Boot the proxy at the merge base and send the streamed request, letting curl hang up after 2 seconds

```
$ litellm --config config.yaml --port 41608 --num_workers 2
$ curl -sS -N --max-time 2 -D before-headers.txt -o before-stream.txt -X POST http://127.0.0.1:41608/v1/messages \
    -H "Authorization: Bearer sk-lit6872" -H "Content-Type: application/json" -d @body.json
curl: (28) Operation timed out after 2003 milliseconds with 1346 bytes received
$ grep -o '"id":"msg_[^"]*"' before-stream.txt | head -1; grep -c '"type":"text_delta"' before-stream.txt; grep -c '"type":"message_delta"' before-stream.txt
"id":"msg_011Cek6fMQ3PYrurQBDXunXG"
3
0
```

2. Read the spend row for that message id

```
$ curl -s 'http://127.0.0.1:41608/spend/logs?request_id=msg_011Cek6fMQ3PYrurQBDXunXG' -H 'Authorization: Bearer sk-lit6872' | jq '.[0] | {request_id, model, prompt_tokens, completion_tokens, spend}'
{
  "request_id": "msg_011Cek6fMQ3PYrurQBDXunXG",
  "model": "anthropic/claude-sonnet-5",
  "prompt_tokens": 25,
  "completion_tokens": 63,
  "spend": 0.00005999999999999999
}
```

3. `spend` is 6e-05 = 25 * 2e-06 + 1 * 1e-05: the row recovered 63 completion tokens but priced the single placeholder token from `message_start`. 63 tokens should price at 6.8e-04. Two earlier requests in the same run (1 and 2 delivered deltas, 1 and 36 recovered tokens) landed on the same 6e-05

### After (2dabac186a)

1. Boot the proxy at the PR tip and send the same streamed request, letting curl hang up after 2 seconds

```
$ litellm --config config.yaml --port 22356 --num_workers 2
$ curl -sS -N --max-time 2 -D after-headers.txt -o after-stream.txt -X POST http://127.0.0.1:22356/v1/messages \
    -H "Authorization: Bearer sk-lit6872" -H "Content-Type: application/json" -d @body.json
curl: (28) Operation timed out after 2007 milliseconds with 1308 bytes received
$ grep -o '"id":"msg_[^"]*"' after-stream.txt | head -1; grep -c '"type":"text_delta"' after-stream.txt; grep -c '"type":"message_delta"' after-stream.txt
"id":"msg_011CekAnNmJjZip8cfyn5KtN"
3
0
```

2. Read the spend row for that message id

```
$ curl -s 'http://127.0.0.1:22356/spend/logs?request_id=msg_011CekAnNmJjZip8cfyn5KtN' -H 'Authorization: Bearer sk-lit6872' | jq '.[0] | {request_id, model, prompt_tokens, completion_tokens, spend}'
{
  "request_id": "msg_011CekAnNmJjZip8cfyn5KtN",
  "model": "anthropic/claude-sonnet-5",
  "prompt_tokens": 25,
  "completion_tokens": 62,
  "spend": 0.00067
}
```

3. `spend` is 6.7e-04 = 25 * 2e-06 + 62 * 1e-05: the row now prices every recovered completion token instead of the single placeholder token

QA observations (behavior next to the fix, none caused or changed by this PR):

- Spend row `request_id` is the upstream message id, not `x-litellm-call-id`
- Recovered `completion_tokens` exceed the deltas the client received
- Both hold identically at the merge base

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Bedrock and Vertex `/v1/messages` interrupted rows take the same placeholder clearing but were not live-run
  - Same iterator, same handler, no separate code path; only Anthropic-direct was driven against a real proxy (no AWS or Vertex creds in .env). A cost-map miss there degrades to a warning plus the fallback price, not a wrong row

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
