### PR TITLE
test: drop the __file__-relative sys.path.insert calls from the unit tests

### DIFF
--- a/test-quality-budget.json
+++ b/test-quality-budget.json
@@ -6,7 +6,7 @@
     "limit": 737
   },
   "TQ003": {
-    "limit": 62
+    "limit": 20
   },
   "TQ004": {
     "limit": 469

--- a/tests/test_litellm/litellm_core_utils/test_request_timeout_resolver.py
+++ b/tests/test_litellm/litellm_core_utils/test_request_timeout_resolver.py
@@ -6,12 +6,7 @@ at the package default. This is what lets request_timeout act as an independent
 per-attempt timeout instead of being indistinguishable from "nobody set it".
 """
 
-import os
-import sys
-
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
 
 import litellm
 from litellm.constants import DEFAULT_REQUEST_TIMEOUT_SECONDS

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_handler_output_config_passthrough.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_handler_output_config_passthrough.py
@@ -25,12 +25,6 @@ Tests cover (consolidating PRs #23706 and #22727):
    the fallback inference path from being exercised).
 """
 
-
-
-# Anchor sys.path to this file's location — not the working-directory-relative
-# pattern Greptile flagged on PR #23706. Resolves correctly regardless of
-# where pytest is invoked from.
-
 from litellm.llms.anthropic.experimental_pass_through.adapters.handler import (
     ANTHROPIC_ONLY_REQUEST_KEYS,
     LiteLLMMessagesToCompletionTransformationHandler,

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_handler_output_config_passthrough.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_handler_output_config_passthrough.py
@@ -25,18 +25,11 @@ Tests cover (consolidating PRs #23706 and #22727):
    the fallback inference path from being exercised).
 """
 
-import os
-import sys
-from unittest.mock import MagicMock, patch
 
-import pytest
 
 # Anchor sys.path to this file's location — not the working-directory-relative
 # pattern Greptile flagged on PR #23706. Resolves correctly regardless of
 # where pytest is invoked from.
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../../.."))
-)
 
 from litellm.llms.anthropic.experimental_pass_through.adapters.handler import (
     ANTHROPIC_ONLY_REQUEST_KEYS,

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_handler_prompt_cache_key.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_handler_prompt_cache_key.py
@@ -1,10 +1,6 @@
 import json
-import os
-import sys
 
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../../..")))
 
 from litellm.llms.anthropic.experimental_pass_through.adapters.handler import (
     LiteLLMMessagesToCompletionTransformationHandler,

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_handler.py
@@ -1,13 +1,9 @@
 import datetime
 import json
-import os
-import sys
 from unittest.mock import AsyncMock, patch
 
 import pytest
 import respx
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../../..")))
 
 import litellm
 from litellm.llms.anthropic.experimental_pass_through.responses_adapters.handler import (

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_streaming_iterator.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_streaming_iterator.py
@@ -4,11 +4,7 @@ Tests for AnthropicResponsesStreamWrapper
 """
 
 import asyncio
-import os
-import sys
 from types import SimpleNamespace
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../../..")))
 
 from litellm.litellm_core_utils.prompt_templates.common_utils import (
     encrypted_reasoning_signature,

--- a/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
+++ b/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
@@ -11,14 +11,10 @@ Verifies that:
 """
 
 import json
-import os
-import sys
 from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../..")))
 
 # Fake tokens for testing (not real secrets)
 FAKE_OAUTH_TOKEN = "sk-ant-oat01-fake-token-for-testing-123456789abcdef"

--- a/tests/test_litellm/llms/anthropic/test_count_tokens_oauth.py
+++ b/tests/test_litellm/llms/anthropic/test_count_tokens_oauth.py
@@ -7,12 +7,6 @@ Verifies that get_required_headers() correctly handles OAuth tokens
 Regression test for https://github.com/BerriAI/litellm/issues/22040
 """
 
-import os
-import sys
-
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../.."))
-)
 
 from litellm.llms.anthropic.count_tokens.transformation import (
     AnthropicCountTokensConfig,

--- a/tests/test_litellm/llms/anthropic/test_message_sanitization.py
+++ b/tests/test_litellm/llms/anthropic/test_message_sanitization.py
@@ -8,13 +8,6 @@ C. Empty text content
 """
 
 import pytest
-import sys
-import os
-
-# Add the parent directory to the path so we can import litellm
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../.."))
-)
 
 import litellm
 from litellm.litellm_core_utils.prompt_templates.factory import (

--- a/tests/test_litellm/llms/azure/chat/test_azure_chat_gpt_transformation.py
+++ b/tests/test_litellm/llms/azure/chat/test_azure_chat_gpt_transformation.py
@@ -1,13 +1,7 @@
-import os
-import sys
 from typing import Final
 
 import pytest
 from pydantic import TypeAdapter
-
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../.."))
-)
 
 import litellm
 from litellm.litellm_core_utils.prompt_templates.common_utils import TOOL_RESULT_IMAGE_BOUNDARY

--- a/tests/test_litellm/llms/azure/test_azure_embedding.py
+++ b/tests/test_litellm/llms/azure/test_azure_embedding.py
@@ -1,12 +1,6 @@
-import os
-import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
-
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../.."))
-)
 
 from litellm.llms.azure.azure import AzureChatCompletion
 from litellm.types.utils import EmbeddingResponse, Usage

--- a/tests/test_litellm/llms/azure/videos/test_azure_video_transformation.py
+++ b/tests/test_litellm/llms/azure/videos/test_azure_video_transformation.py
@@ -1,21 +1,9 @@
-import json
-import os
-import sys
-from typing import Any, Dict, Optional
-from unittest.mock import MagicMock, patch, Mock, mock_open
+from unittest.mock import MagicMock, patch, mock_open
 import pytest
-import httpx
 
-# Add the parent directory to the system path
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../../.."))
-)
-
-import litellm
 from litellm.llms.azure.videos.transformation import AzureVideoConfig
 from litellm.types.videos.main import (
     VideoObject,
-    VideoResponse,
     VideoCreateOptionalRequestParams,
 )
 from litellm.types.router import GenericLiteLLMParams

--- a/tests/test_litellm/llms/azure_ai/claude/test_azure_anthropic_handler.py
+++ b/tests/test_litellm/llms/azure_ai/claude/test_azure_anthropic_handler.py
@@ -1,14 +1,6 @@
-import os
-import sys
-
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../.."))
-)
 
 import json
 from unittest.mock import MagicMock, patch
-
-import pytest
 
 from litellm.llms.azure_ai.anthropic.handler import AzureAnthropicChatCompletion
 from litellm.types.utils import ModelResponse

--- a/tests/test_litellm/llms/azure_ai/claude/test_azure_anthropic_messages_transformation.py
+++ b/tests/test_litellm/llms/azure_ai/claude/test_azure_anthropic_messages_transformation.py
@@ -1,12 +1,6 @@
 import copy
 import json
 import os
-import sys
-
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../.."))
-)
-
 from unittest.mock import patch
 
 import pytest

--- a/tests/test_litellm/llms/azure_ai/claude/test_azure_anthropic_provider_routing.py
+++ b/tests/test_litellm/llms/azure_ai/claude/test_azure_anthropic_provider_routing.py
@@ -1,11 +1,4 @@
-import os
-import sys
 
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../.."))
-)
-
-import pytest
 
 from litellm.litellm_core_utils.get_llm_provider_logic import (
     _is_azure_claude_model,

--- a/tests/test_litellm/llms/azure_ai/claude/test_azure_anthropic_transformation.py
+++ b/tests/test_litellm/llms/azure_ai/claude/test_azure_anthropic_transformation.py
@@ -1,11 +1,5 @@
-import os
-import sys
 
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../.."))
-)
-
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 

--- a/tests/test_litellm/llms/azure_ai/claude/test_main_azure_anthropic_timeout.py
+++ b/tests/test_litellm/llms/azure_ai/claude/test_main_azure_anthropic_timeout.py
@@ -2,13 +2,7 @@
 Ensure litellm.completion() forwards timeout to Azure Anthropic handler (main.py dispatch).
 """
 
-import os
-import sys
 from unittest.mock import MagicMock, patch
-
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../.."))
-)
 
 from litellm import completion
 from litellm.types.utils import ModelResponse

--- a/tests/test_litellm/llms/custom_httpx/test_gemini_session_leak.py
+++ b/tests/test_litellm/llms/custom_httpx/test_gemini_session_leak.py
@@ -11,12 +11,8 @@ Validates that:
 import asyncio
 import gc
 import sys
-from pathlib import Path
 
 import pytest
-
-# Add litellm to path
-sys.path.insert(0, str(Path(__file__).parent))
 
 
 async def test_aiohttp_handler_cleanup():

--- a/tests/test_litellm/llms/databricks/test_databricks_e2e.py
+++ b/tests/test_litellm/llms/databricks/test_databricks_e2e.py
@@ -72,11 +72,6 @@ pytestmark = pytest.mark.skip(
     "python tests/test_litellm/llms/databricks/test_databricks_e2e.py"
 )
 
-# Add the litellm package to path
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../.."))
-)
-
 # Config file path - can be overridden with DATABRICKS_TEST_CONFIG env var
 DEFAULT_CONFIG_PATH = os.path.expanduser("~/.databricks_litellm_config.txt")
 CONFIG_FILE = os.environ.get("DATABRICKS_TEST_CONFIG", DEFAULT_CONFIG_PATH)

--- a/tests/test_litellm/llms/lm_studio/test_lm_studio_chat_transformation.py
+++ b/tests/test_litellm/llms/lm_studio/test_lm_studio_chat_transformation.py
@@ -1,12 +1,6 @@
-import os
-import sys
 from unittest.mock import patch
 
 from pydantic import BaseModel
-
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../.."))
-)
 
 from litellm.llms.lm_studio.chat.transformation import LMStudioChatConfig
 from litellm.utils import get_optional_params

--- a/tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py
+++ b/tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py
@@ -1,14 +1,6 @@
-import inspect
-import os
-import sys
 from typing import cast
 
-import pytest
 from pydantic import BaseModel
-
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../.."))
-)
 
 from litellm.llms.ollama.chat.transformation import (
     OllamaChatConfig,

--- a/tests/test_litellm/llms/openai_like/responses/test_openai_like_responses.py
+++ b/tests/test_litellm/llms/openai_like/responses/test_openai_like_responses.py
@@ -2,15 +2,7 @@
 Tests for OpenAI-like Responses API support in the JSON provider system.
 """
 
-import os
-import sys
 from unittest.mock import patch
-
-import pytest
-
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../.."))
-)
 
 
 class TestSimpleProviderConfigSupportedEndpoints:

--- a/tests/test_litellm/llms/openai_like/test_abliteration_provider.py
+++ b/tests/test_litellm/llms/openai_like/test_abliteration_provider.py
@@ -2,12 +2,6 @@
 Unit tests for the Abliteration OpenAI-like provider.
 """
 
-import os
-import sys
-
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../.."))
-)
 
 from litellm.llms.openai_like.dynamic_config import create_config_class
 from litellm.llms.openai_like.json_loader import JSONProviderRegistry

--- a/tests/test_litellm/llms/openai_like/test_assemblyai_provider.py
+++ b/tests/test_litellm/llms/openai_like/test_assemblyai_provider.py
@@ -2,12 +2,6 @@
 Unit tests for the AssemblyAI LLM Gateway OpenAI-like provider.
 """
 
-import os
-import sys
-
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../.."))
-)
 
 from litellm.llms.openai_like.dynamic_config import create_config_class
 from litellm.llms.openai_like.json_loader import JSONProviderRegistry

--- a/tests/test_litellm/llms/openai_like/test_charity_engine.py
+++ b/tests/test_litellm/llms/openai_like/test_charity_engine.py
@@ -2,17 +2,11 @@
 Tests for Charity Engine provider configuration and integration.
 """
 
-import os
-import sys
 
 try:
     import pytest
 except ImportError:
     pytest = None
-
-# Add workspace to path
-workspace_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../.."))
-sys.path.insert(0, workspace_path)
 
 import litellm
 

--- a/tests/test_litellm/llms/openai_like/test_empiriolabs_provider.py
+++ b/tests/test_litellm/llms/openai_like/test_empiriolabs_provider.py
@@ -2,12 +2,6 @@
 Unit tests for the EmpirioLabs OpenAI-like provider.
 """
 
-import os
-import sys
-
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../.."))
-)
 
 from litellm.llms.openai_like.dynamic_config import create_config_class
 from litellm.llms.openai_like.json_loader import JSONProviderRegistry

--- a/tests/test_litellm/llms/openai_like/test_json_providers.py
+++ b/tests/test_litellm/llms/openai_like/test_json_providers.py
@@ -3,7 +3,6 @@ Tests for JSON-based provider configuration system.
 """
 
 import os
-import sys
 from unittest.mock import patch
 
 try:
@@ -12,9 +11,8 @@ except ImportError:
     # pytest not available, will run as standalone script
     pytest = None
 
-# Add workspace to path
+# Repo root, used to locate model_prices_and_context_window.json.
 workspace_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../.."))
-sys.path.insert(0, workspace_path)
 
 import litellm
 

--- a/tests/test_litellm/llms/openai_like/test_xiaomi_mimo.py
+++ b/tests/test_litellm/llms/openai_like/test_xiaomi_mimo.py
@@ -4,17 +4,11 @@ Related to issue #18794
 """
 
 import os
-import sys
-from unittest.mock import MagicMock, patch
 
 try:
     import pytest
 except ImportError:
     pytest = None
-
-# Add workspace to path
-workspace_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../.."))
-sys.path.insert(0, workspace_path)
 
 import litellm
 

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_ai_psc_endpoint_support.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_ai_psc_endpoint_support.py
@@ -5,13 +5,7 @@ Tests that LiteLLM properly constructs URLs when using custom api_base
 for PSC endpoints.
 """
 
-import os
-import sys
 
-import pytest
-
-# Add the litellm package to the path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
 
 from litellm.llms.vertex_ai.vertex_llm_base import VertexBase
 

--- a/tests/test_litellm/proxy/auth/test_banned_params_extra_body.py
+++ b/tests/test_litellm/proxy/auth/test_banned_params_extra_body.py
@@ -5,14 +5,8 @@ descending into it, the banned-param boundary check is bypassed by
 nesting the same fields under ``extra_body``.
 """
 
-import os
-import sys
 
 import pytest
-
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../.."))
-)
 
 from litellm.proxy.auth.auth_utils import is_request_body_safe  # noqa: E402
 

--- a/tests/test_litellm/proxy/proxy_server/conftest.py
+++ b/tests/test_litellm/proxy/proxy_server/conftest.py
@@ -9,8 +9,6 @@ from __future__ import annotations
 
 import contextlib
 import os
-import sys
-from pathlib import Path
 from typing import Any, AsyncIterator, Callable, Dict, Iterator, List, Optional
 from unittest.mock import AsyncMock, MagicMock
 
@@ -20,7 +18,6 @@ import pytest
 # matter where pytest is invoked from. With the project installed via
 # uv this is defensive — `litellm` already resolves through site-packages
 # — but it lets the harness work in editable-source layouts too.
-sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_litellm/proxy/proxy_server/conftest.py
+++ b/tests/test_litellm/proxy/proxy_server/conftest.py
@@ -14,12 +14,6 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-# Repo root, anchored to this file (not CWD) so the path is correct no
-# matter where pytest is invoked from. With the project installed via
-# uv this is defensive — `litellm` already resolves through site-packages
-# — but it lets the harness work in editable-source layouts too.
-
-
 # ---------------------------------------------------------------------------
 # normalize() — used by every dict-equality assertion to scrub volatile fields
 # ---------------------------------------------------------------------------

--- a/tests/test_litellm/proxy/test_component_allowlists.py
+++ b/tests/test_litellm/proxy/test_component_allowlists.py
@@ -24,7 +24,6 @@ RDS IAM token when ``IAM_TOKEN_DB_AUTH`` is set).
 """
 
 import os
-import sys
 
 # Importing ``litellm.proxy.proxy_server`` runs its module-level setup, which
 # reads ``DATABASE_URL`` (Prisma) and ``LITELLM_MASTER_KEY``. Tier-zero CI
@@ -45,10 +44,6 @@ from fastapi.routing import Mount
 from prometheus_client import make_asgi_app
 
 # gateway/ and backend/ live at the repo root, not inside litellm/.
-_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
-if _REPO_ROOT not in sys.path:
-    sys.path.insert(0, _REPO_ROOT)
-
 from backend.routes.allowlist import (
     BACKEND_EXACT_PATHS,
     BACKEND_MOUNT_PATHS,

--- a/tests/test_litellm/proxy/test_model_level_guardrails.py
+++ b/tests/test_litellm/proxy/test_model_level_guardrails.py
@@ -6,17 +6,11 @@ deployment are merged into request metadata and trigger execution for both
 streaming and non-streaming post_call hooks.
 """
 
-import os
-import sys
-
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
-
 from litellm.proxy.utils import (
     _check_and_merge_model_level_guardrails,
-    _merge_guardrails_with_existing,
 )
 
 # ---------------------------------------------------------------------------

--- a/tests/test_litellm/proxy/types_utils/test_db_overlay_remote_module_scrub.py
+++ b/tests/test_litellm/proxy/types_utils/test_db_overlay_remote_module_scrub.py
@@ -13,14 +13,8 @@ pass and ``_load_instance_from_remote_storage`` would exec the
 remote module.
 """
 
-import os
-import sys
 
 import pytest
-
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../.."))
-)
 
 from litellm.proxy.proxy_server import (  # noqa: E402
     _scrub_db_overlay_remote_module_loads,

--- a/tests/test_litellm/proxy/types_utils/test_get_instance_fn_runtime_gate.py
+++ b/tests/test_litellm/proxy/types_utils/test_get_instance_fn_runtime_gate.py
@@ -7,15 +7,9 @@ unaffected — the documented ``litellm_settings.callbacks:
 ["s3://bucket/module.instance"]`` operator flow continues to work.
 """
 
-import os
-import sys
 from unittest.mock import patch
 
 import pytest
-
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../.."))
-)
 
 from litellm.proxy.types_utils.utils import get_instance_fn  # noqa: E402
 

--- a/tests/test_litellm/proxy/utils/prisma_and_spend/conftest.py
+++ b/tests/test_litellm/proxy/utils/prisma_and_spend/conftest.py
@@ -13,18 +13,13 @@ needing a generated Prisma client or a real database.
 from __future__ import annotations
 
 import asyncio
-import sys
 import threading
 from dataclasses import dataclass, field
 from email.message import EmailMessage
-from pathlib import Path
 from typing import Any, Callable, Dict, Iterator, List, Optional
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[5]))
-
 
 VOLATILE_KEYS = frozenset(
     {
@@ -188,6 +183,7 @@ def patched_prisma_import(monkeypatch: pytest.MonkeyPatch) -> Iterator[MagicMock
     directly and restore in teardown.
     """
     import prisma as _prisma_pkg
+
     import litellm.proxy.utils as _utils_mod
 
     fake_prisma = MagicMock(name="FakePrisma")

--- a/tests/test_litellm/proxy/utils/proxy_logging/conftest.py
+++ b/tests/test_litellm/proxy/utils/proxy_logging/conftest.py
@@ -6,15 +6,10 @@ live here. Tests should not declare fixtures inline.
 
 from __future__ import annotations
 
-import sys
-from pathlib import Path
 from typing import Any, Dict, Optional
 from unittest.mock import MagicMock
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[5]))
-
 
 VOLATILE_KEYS = frozenset(
     {

--- a/tests/test_litellm/test_chat_ui_responses_session.py
+++ b/tests/test_litellm/test_chat_ui_responses_session.py
@@ -9,12 +9,7 @@ Verifies that:
 
 import inspect
 import json
-import os
-import sys
 import unittest.mock as mock
-
-# Use __file__ so the import path is correct regardless of the pytest working directory.
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
 import httpx
 import pytest

--- a/tests/test_litellm/test_check_licenses.py
+++ b/tests/test_litellm/test_check_licenses.py
@@ -17,7 +17,7 @@ import requests
 _CODE_COVERAGE_DIR = os.path.join(
     os.path.dirname(os.path.abspath(__file__)), "..", "code_coverage_tests"
 )
-sys.path.insert(0, _CODE_COVERAGE_DIR)
+sys.path.insert(0, _CODE_COVERAGE_DIR)  # test-quality-ok: required to import checker from its source directory
 
 import check_licenses  # noqa: E402
 

--- a/tests/test_litellm/test_completion_timeout_resolution.py
+++ b/tests/test_litellm/test_completion_timeout_resolution.py
@@ -1,11 +1,6 @@
 """Unit tests for litellm.litellm_core_utils.completion_timeout.CompletionTimeout."""
 
-import os
-import sys
-
 import httpx
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
 
 from litellm.litellm_core_utils.completion_timeout import CompletionTimeout
 from litellm.utils import supports_httpx_timeout

--- a/tests/test_litellm/test_nested_drop_params.py
+++ b/tests/test_litellm/test_nested_drop_params.py
@@ -4,12 +4,7 @@ Test nested path support in additional_drop_params.
 This tests the new JSONPath-like syntax for removing nested fields.
 """
 
-import os
-import sys
 
-
-# Add parent directory to path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
 from litellm.litellm_core_utils.dot_notation_indexing import (
     delete_nested_value,

--- a/tests/test_litellm/test_ssl_verify_unit.py
+++ b/tests/test_litellm/test_ssl_verify_unit.py
@@ -5,14 +5,9 @@ These tests verify that ssl_verify parameters are correctly propagated
 through the call stack without requiring live API credentials.
 """
 
-import sys
-from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
-
-# Add litellm to path
-sys.path.insert(0, str(Path(__file__).parent))
 
 import litellm.proxy.guardrails.guardrail_hooks.aim.aim as _aim_module
 import litellm.proxy.guardrails.guardrail_hooks.cato_networks.cato_networks as _cato_networks_module

--- a/tests/test_litellm/test_vcr_safe_body_matcher.py
+++ b/tests/test_litellm/test_vcr_safe_body_matcher.py
@@ -1,14 +1,8 @@
 from __future__ import annotations
 
-import os
-import sys
 from types import SimpleNamespace
 
 import pytest
-
-_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
-if _REPO_ROOT not in sys.path:
-    sys.path.insert(0, _REPO_ROOT)
 
 from tests._vcr_conftest_common import (  # noqa: E402
     KEY_FINGERPRINT_HEADER,


### PR DESCRIPTION
## TLDR

Problem this solves:

- 42 unit tests still call `sys.path.insert` to add the repo root (rule TQ003)
- pytest already puts the repo root on `sys.path` for `tests/test_litellm` (`tests/` is a package)
- `litellm` is installed in the environment, so the inserts never change what is importable
- #37802 removed the cwd-relative form and left these `__file__`-relative ones for later

How it solves it:

- Remove the 41 dead call sites plus the `os`, `sys`, `Path` imports nothing else used
- Keep the one in `test_check_licenses.py`, marked `test-quality-ok`: it imports a checker from `tests/code_coverage_tests`, which is not a package, exactly as `test_check_py310_typing_imports.py` already does
- Ratchet the TQ003 budget from 62 to 20 (`scripts/test_quality_gate.py --update`)

## Relevant issues

Follow-up to #37802. Test-quality rule TQ003.

## Pre-Submission checklist

- [x] I have added meaningful tests (test-only change; no product code touched)
- [x] The test files covering my change pass locally: all 42 changed files plus the directories of the 3 changed conftests, `-n 4`: 1874 passed, 18 skipped, 1 failure that also fails on the untouched base (`test_prisma_client_reconnect.py::test_iam_refresh_racing_reconnect_recreates_engine_only_once`, needs a generated Prisma client)
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5

## Screenshots / Proof of Fix

### Before (c52b53706e)

1. `python scripts/check_test_quality.py tests/ | grep -c TQ003` -> `62`, of which 42 under `tests/test_litellm`
2. Probe test placed in `tests/test_litellm` printing whether the repo root is already on `sys.path` and importing `tests._vcr_conftest_common` and `backend` with no insert -> `REPO_ROOT_ON_PATH= True`, `IMPORTS_OK`, `1 passed`

### After (2e9c496482)

1. Same count -> `20`, none under `tests/test_litellm` except the suppressed licence-checker import
2. `python scripts/test_quality_gate.py --base litellm_internal_staging` -> `OK: every TQ rule is within its test-suite ceiling`
3. `ruff check` per rule code on the 42 files, base vs branch: F401 22 -> 0, I001 11 -> 7, no F821, every other code unchanged
4. `ruff format --check` on the 42 files: no file newly unformatted (35 were already unformatted on base and are left alone)
5. pytest on the 42 files and 3 conftest directories, `-n 4`: 1874 passed, 18 skipped, 1 pre-existing failure noted above

## Type

✅ Test
