### PR TITLE
fix(proxy): reject attaching strategy router config to non-router models (#39838)

### DIFF
--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -254,14 +254,27 @@ def _strategy_router_write_violation(
         for source in (incoming_params, existing_params)
         if source is not None and getattr(source, field, None) is not None
     )
-    # Scope reads the incoming model because the stored one is encrypted at rest.
-    if carries_complexity_router_settings(incoming_params.model, present_fields):
+    incoming_strategy_fields: Final = frozenset(
+        field for field in STRATEGY_ROUTER_PARAM_FIELDS if getattr(incoming_params, field, None) is not None
+    )
+    effective_model: Final = incoming_params.model or (
+        existing_params.model if existing_params is not None else None
+    )
+    if carries_complexity_router_settings(effective_model, present_fields):
         placement_violation: Final = validate_complexity_router_config_placement(incoming_params.model_extra)
         if placement_violation is not None:
             return placement_violation
-    if incoming_params.model is None:
+    if incoming_params.model is None and not incoming_strategy_fields:
         return None
-    return validate_strategy_router_model_write(model=incoming_params.model, present_fields=present_fields)
+    if effective_model is None:
+        if incoming_strategy_fields:
+            return (
+                "Cannot attach strategy router settings without a deployment model. "
+                f"Settings written: {', '.join(sorted(incoming_strategy_fields))}. "
+                "Set litellm_params.model to an 'auto_router/*' model."
+            )
+        return None
+    return validate_strategy_router_model_write(model=effective_model, present_fields=present_fields)
 
 
 def _raise_on_strategy_router_write_violation(

--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -257,9 +257,15 @@ def _strategy_router_write_violation(
     incoming_strategy_fields: Final = frozenset(
         field for field in STRATEGY_ROUTER_PARAM_FIELDS if getattr(incoming_params, field, None) is not None
     )
-    effective_model: Final = incoming_params.model or (
-        existing_params.model if existing_params is not None else None
+    raw_existing_model: Final[str | None] = (
+        existing_params.model if existing_params is not None and isinstance(existing_params.model, str) else None
     )
+    existing_model: Final[str | None] = (
+        decrypt_value_helper(value=raw_existing_model, key="model", return_original_value=True)
+        if raw_existing_model is not None
+        else None
+    )
+    effective_model: Final = incoming_params.model or existing_model
     if carries_complexity_router_settings(effective_model, present_fields):
         placement_violation: Final = validate_complexity_router_config_placement(incoming_params.model_extra)
         if placement_violation is not None:

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -4048,6 +4048,41 @@ class TestStrategyRouterWriteValidation:
         )
         assert _strategy_router_write_violation(incoming_params=None, existing_params=None) is None
 
+    def test_patch_attaching_complexity_router_config_to_non_router_rejected(self):
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _strategy_router_write_violation,
+        )
+        from litellm.types.router import LiteLLM_Params, updateLiteLLMParams
+
+        violation = _strategy_router_write_violation(
+            incoming_params=updateLiteLLMParams(
+                complexity_router_config={
+                    "tiers": {"SIMPLE": ["gpt-4o-mini"]},
+                    "keyword_tier_rules": [{"keywords": ["invoice"], "tier": "COMPLEX"}],
+                }
+            ),
+            existing_params=LiteLLM_Params(model="gpt-4o"),
+        )
+        assert violation is not None
+        assert "does not start with 'auto_router/'" in violation
+
+    def test_patch_attaching_strategy_router_config_without_model_rejected(self):
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _strategy_router_write_violation,
+        )
+        from litellm.types.router import updateLiteLLMParams
+
+        violation = _strategy_router_write_violation(
+            incoming_params=updateLiteLLMParams(
+                complexity_router_config={
+                    "tiers": {"SIMPLE": ["gpt-4o-mini"]},
+                }
+            ),
+            existing_params=None,
+        )
+        assert violation is not None
+        assert "Cannot attach strategy router settings without a deployment model" in violation
+
     def test_restore_of_corrupted_row_is_allowed(self):
         from litellm.proxy.management_endpoints.model_management_endpoints import (
             _strategy_router_write_violation,

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -4110,7 +4110,7 @@ class TestStrategyRouterWriteValidation:
         )
         from litellm.types.router import LiteLLM_Params, updateLiteLLMParams
 
-        with patch(
+        with patch(  # test-quality-ok: decrypt_value_helper is called directly in module; no injection seam
             "litellm.proxy.management_endpoints.model_management_endpoints.decrypt_value_helper",
             return_value="auto_router/complexity_router",
         ):

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -4049,12 +4049,13 @@ class TestStrategyRouterWriteValidation:
         assert _strategy_router_write_violation(incoming_params=None, existing_params=None) is None
 
     def test_patch_attaching_complexity_router_config_to_non_router_rejected(self):
+        from typing import Final
         from litellm.proxy.management_endpoints.model_management_endpoints import (
             _strategy_router_write_violation,
         )
         from litellm.types.router import LiteLLM_Params, updateLiteLLMParams
 
-        violation = _strategy_router_write_violation(
+        violation: Final = _strategy_router_write_violation(
             incoming_params=updateLiteLLMParams(
                 complexity_router_config={
                     "tiers": {"SIMPLE": ["gpt-4o-mini"]},
@@ -4067,12 +4068,13 @@ class TestStrategyRouterWriteValidation:
         assert "does not start with 'auto_router/'" in violation
 
     def test_patch_attaching_strategy_router_config_without_model_rejected(self):
+        from typing import Final
         from litellm.proxy.management_endpoints.model_management_endpoints import (
             _strategy_router_write_violation,
         )
         from litellm.types.router import updateLiteLLMParams
 
-        violation = _strategy_router_write_violation(
+        violation: Final = _strategy_router_write_violation(
             incoming_params=updateLiteLLMParams(
                 complexity_router_config={
                     "tiers": {"SIMPLE": ["gpt-4o-mini"]},
@@ -4082,6 +4084,48 @@ class TestStrategyRouterWriteValidation:
         )
         assert violation is not None
         assert "Cannot attach strategy router settings without a deployment model" in violation
+
+    def test_patch_updating_config_on_existing_auto_router_allowed(self):
+        from typing import Final
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _strategy_router_write_violation,
+        )
+        from litellm.types.router import updateLiteLLMParams
+
+        violation: Final = _strategy_router_write_violation(
+            incoming_params=updateLiteLLMParams(
+                complexity_router_config={
+                    "tiers": {"SIMPLE": ["gpt-4o-mini"]},
+                }
+            ),
+            existing_params=self._stored_complexity_params(),
+        )
+        assert violation is None
+
+    def test_patch_updating_config_on_encrypted_existing_auto_router_allowed(self):
+        from typing import Final
+        from unittest.mock import patch
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _strategy_router_write_violation,
+        )
+        from litellm.types.router import LiteLLM_Params, updateLiteLLMParams
+
+        with patch(
+            "litellm.proxy.management_endpoints.model_management_endpoints.decrypt_value_helper",
+            return_value="auto_router/complexity_router",
+        ):
+            violation: Final = _strategy_router_write_violation(
+                incoming_params=updateLiteLLMParams(
+                    complexity_router_config={
+                        "tiers": {"SIMPLE": ["gpt-4o-mini"]},
+                    }
+                ),
+                existing_params=LiteLLM_Params(
+                    model="enc:ciphertext_blob_123",
+                    complexity_router_config={"tiers": {"SIMPLE": "gpt-4o-mini"}},
+                ),
+            )
+            assert violation is None
 
     def test_restore_of_corrupted_row_is_allowed(self):
         from litellm.proxy.management_endpoints.model_management_endpoints import (


### PR DESCRIPTION
## TLDR

Problem this solves:

- Model-less PATCH requests could attach complexity router config to non-router deployments
- Corrupted deployment rows and exhausted capability router slots

How it solves it:

- Resolves effective model using incoming model falling back to existing params model
- Validates strategy router parameters against the effective model and rejects non-router attachments
- Requires model to be set when attaching strategy router settings

## User Flow

Before: an operator sending a partial PATCH update to an existing deployment could attach router configuration to a non-router model

1. Operator has an existing deployment with model "gpt-4o"
2. Operator sends PATCH /model/update or /model/patch with litellm_params containing complexity_router_config and no model field
3. Proxy accepts the update and attaches router configuration to a standard deployment, corrupting the router state

After: the proxy rejects attaching strategy router settings to non-router models during partial updates

1. Operator sends the same partial PATCH with complexity_router_config to the existing "gpt-4o" deployment
2. Proxy validates against the existing model and returns HTTP 400 error indicating complexity_router_config cannot be attached to a non-router deployment

## Relevant issues

Fixes #39838

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Type

Bug Fix

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
