### PR TITLE
fix(router): honor stream_timeout on bridged /v1/messages and /v1/responses streams and raise mid-stream errors

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1900,6 +1900,12 @@ class Logging(LiteLLMLoggingBaseClass):
         self.model_call_details["combined_usage_object"] = usage
         self.model_call_details["response_cost"] = response_cost
 
+    def record_priced_partial_usage_for_failure(self, usage: Usage) -> None:
+        partial_response: Final = ModelResponse(model=self.model, usage=usage)
+        self.record_partial_usage_for_failure(
+            usage=usage, response_cost=self._response_cost_calculator(result=partial_response) or 0.0
+        )
+
     async def dispatch_failure_handlers(
         self,
         exception: Exception,

--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/streaming_iterator.py
@@ -1,12 +1,10 @@
 # What is this?
 ## Translates OpenAI call to Anthropic `/v1/messages` format
 import json
-import traceback
 from collections import deque
 from collections.abc import AsyncIterator, Mapping
 from typing import TYPE_CHECKING, Any, Final
 
-from litellm import verbose_logger
 from litellm._uuid import uuid
 from litellm.types.llms.anthropic_messages.anthropic_response import AnthropicUsage
 
@@ -272,8 +270,6 @@ class AnthropicResponsesStreamWrapper:
                     return self._chunk_queue.popleft()
         except StopAsyncIteration:
             pass
-        except Exception as e:
-            verbose_logger.error("AnthropicResponsesStreamWrapper error: %s\n%s", e, traceback.format_exc())
 
         # Drain any remaining queued chunks
         if self._chunk_queue:

--- a/litellm/passthrough/timeout_utils.py
+++ b/litellm/passthrough/timeout_utils.py
@@ -1,4 +1,5 @@
 import sys
+from collections.abc import Mapping
 from typing import Final
 
 DEFAULT_PASS_THROUGH_REQUEST_TIMEOUT_SECONDS: Final = 600.0
@@ -31,8 +32,8 @@ def resolve_pass_through_request_timeout(
 
 
 def resolve_llm_passthrough_timeout(
-    kwargs: dict | None = None,
-    litellm_params: dict | None = None,
+    kwargs: Mapping[str, object] | None = None,
+    litellm_params: Mapping[str, object] | None = None,
     router_timeout: float | None = None,
 ) -> float:
     """
@@ -47,7 +48,7 @@ def resolve_llm_passthrough_timeout(
     for source in (kwargs, litellm_params):
         for key in ("timeout", "request_timeout"):
             val = source.get(key)
-            if val is not None:
+            if isinstance(val, (int, float, str)):
                 return float(val)
 
     if router_timeout is not None:

--- a/litellm/responses/streaming_iterator.py
+++ b/litellm/responses/streaming_iterator.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any, Final, Literal, Protocol, overload, runti
 
 import httpx
 from openai._streaming import SSEDecoder
+from pydantic import TypeAdapter
 from typing_extensions import TypeIs
 
 import litellm
@@ -35,11 +36,13 @@ from litellm.responses.utils import ResponseAPILoggingUtils, ResponsesAPIRequest
 from litellm.types.llms.openai import (
     PART_UNION_TYPES,
     ResponseAPIUsage,
+    ResponseInputParam,
+    ResponsesAPIOptionalRequestParams,
     ResponsesAPIResponse,
     ResponsesAPIStreamEvents,
     ResponsesAPIStreamingResponse,
 )
-from litellm.types.utils import CallTypes
+from litellm.types.utils import CallTypes, Usage
 from litellm.utils import async_post_call_success_deployment_hook
 
 if TYPE_CHECKING:
@@ -218,6 +221,11 @@ def _status_code_for_error_fields(error_type: str | None, error_code: str | None
         (_ERROR_CODE_HTTP_STATUS[field] for field in fields if field in _ERROR_CODE_HTTP_STATUS),
         500,
     )
+
+
+@lru_cache(maxsize=1)
+def _responses_input_adapter() -> TypeAdapter[ResponseInputParam]:
+    return TypeAdapter(ResponseInputParam)
 
 
 class BaseResponsesAPIStreamingIterator:
@@ -787,6 +795,35 @@ class BaseResponsesAPIStreamingIterator:
         except Exception:
             pass
 
+    def _record_partial_usage_for_failure(self) -> None:
+        if not self._generated_content or self.logging_obj.model_call_details.get("combined_usage_object") is not None:
+            return
+        from litellm.litellm_core_utils.streaming_handler import backfill_missing_cache_usage_fields
+        from litellm.responses.litellm_completion_transformation.transformation import (
+            LiteLLMCompletionResponsesConfig,
+        )
+
+        try:
+            prompt_tokens: Final = litellm.token_counter(
+                model=self.model,
+                messages=LiteLLMCompletionResponsesConfig.transform_responses_api_input_to_messages(
+                    input=_responses_input_adapter().validate_python(self.logging_obj.messages),
+                    responses_api_request=ResponsesAPIOptionalRequestParams(),
+                ),
+            )
+            completion_tokens: Final = litellm.token_counter(
+                model=self.model, text=self._generated_content, count_response_tokens=True
+            )
+            usage: Final = Usage(
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                total_tokens=prompt_tokens + completion_tokens,
+            )
+            backfill_missing_cache_usage_fields(usage)
+            self.logging_obj.record_priced_partial_usage_for_failure(usage)
+        except Exception as recover_error:
+            verbose_logger.debug("could not recover partial usage for interrupted responses stream: %s", recover_error)
+
     def _handle_failure(self, exception: Exception):
         """
         Trigger failure handlers before bubbling the exception.
@@ -796,6 +833,7 @@ class BaseResponsesAPIStreamingIterator:
         if self._failure_handled:
             return
         self._failure_handled = True
+        self._record_partial_usage_for_failure()
 
         traceback_exception: Final = traceback.format_exc()
         try:

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -3666,18 +3666,7 @@ class Router:
         kwargs["model_info"] = model_info
 
         if function_name == "_ageneric_api_call_with_fallbacks":
-            from litellm.passthrough.timeout_utils import (
-                resolve_llm_passthrough_timeout,
-            )
-
-            _router_timeout: Final = (
-                float(self._explicit_timeout) if isinstance(self._explicit_timeout, (int, float)) else None
-            )
-            kwargs["timeout"] = resolve_llm_passthrough_timeout(
-                kwargs=kwargs,
-                litellm_params=deployment["litellm_params"],
-                router_timeout=_router_timeout,
-            )
+            kwargs["timeout"] = self._get_generic_api_call_timeout(kwargs=kwargs, data=deployment["litellm_params"])
         else:
             kwargs["timeout"] = self._get_timeout(kwargs=kwargs, data=deployment["litellm_params"])
 
@@ -3716,6 +3705,22 @@ class Router:
             or self.request_timeout  # litellm_settings.request_timeout (per-attempt)
             or self.default_litellm_params.get("stream_timeout", None)
         )
+
+    def _get_generic_api_call_timeout(self, kwargs: Mapping[str, object], data: Mapping[str, object]) -> float | int:
+        from litellm.passthrough.timeout_utils import resolve_llm_passthrough_timeout
+
+        stream_timeout: Final = (
+            kwargs.get("stream_timeout")
+            or data.get("stream_timeout")
+            or self.stream_timeout
+            or self.default_litellm_params.get("stream_timeout")
+        )
+        if kwargs.get("stream", False) and isinstance(stream_timeout, (int, float)):
+            return stream_timeout
+        router_timeout: Final = (
+            float(self._explicit_timeout) if isinstance(self._explicit_timeout, (int, float)) else None
+        )
+        return resolve_llm_passthrough_timeout(kwargs=kwargs, litellm_params=data, router_timeout=router_timeout)
 
     def _get_non_stream_timeout(self, kwargs: dict, data: dict) -> float | int | None:
         """Helper to get non-stream timeout from kwargs or deployment params"""

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_streaming_iterator.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_streaming_iterator.py
@@ -8,6 +8,9 @@ import os
 import sys
 from types import SimpleNamespace
 
+import httpx
+import pytest
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../../..")))
 
 from litellm.llms.anthropic.experimental_pass_through.responses_adapters.streaming_iterator import (
@@ -308,3 +311,31 @@ class TestResponseCompletedUsage:
             "cache_creation_input_tokens": 10,
             "cache_read_input_tokens": 4004,
         }
+
+
+class TestUpstreamStreamErrorPropagates:
+    """A Responses stream that dies mid-way (read timeout, dropped connection) must reach the
+    caller as the exception, not as a clean end of the Anthropic stream, so the proxy can send
+    the client an error frame and record the failure."""
+
+    def test_upstream_exception_is_raised_after_the_chunks_before_it(self):
+        async def _gen():
+            yield {"type": "response.created"}
+            yield {"type": "response.output_text.delta", "item_id": "m1", "delta": "hi"}
+            raise httpx.ReadTimeout("Timeout on reading data from socket")
+
+        received: list[bytes] = []
+
+        async def _drain() -> None:
+            wrapper = AnthropicResponsesStreamWrapper(responses_stream=_gen(), model="m")
+            async for chunk in wrapper.async_anthropic_sse_wrapper():
+                received.append(chunk)
+
+        with pytest.raises(httpx.ReadTimeout, match="Timeout on reading data from socket"):
+            asyncio.run(_drain())
+        assert [chunk.split(b"\n", 1)[0] for chunk in received] == [
+            b"event: message_start",
+            b"event: content_block_start",
+            b"event: content_block_delta",
+        ]
+

--- a/tests/test_litellm/responses/test_responses_streaming_iterator.py
+++ b/tests/test_litellm/responses/test_responses_streaming_iterator.py
@@ -7,7 +7,9 @@ crashed with exit 139 whenever any CustomLogger was registered).
 """
 
 import asyncio
+import json
 import time
+from typing import cast
 
 import httpx
 import pytest
@@ -15,8 +17,9 @@ import pytest
 import litellm
 from litellm.integrations.custom_logger import CustomLogger
 from litellm.litellm_core_utils import thread_pool_executor as thread_pool_executor_module
-from litellm.responses import streaming_iterator as responses_streaming_iterator_module
 from litellm.litellm_core_utils.litellm_logging import Logging as LitellmLogging
+from litellm.llms.openai.responses.transformation import OpenAIResponsesAPIConfig
+from litellm.responses import streaming_iterator as responses_streaming_iterator_module
 from litellm.responses.streaming_iterator import ResponsesAPIStreamingIterator
 from litellm.types.llms.openai import ResponsesAPIResponse
 
@@ -156,3 +159,75 @@ async def test_sync_callbacks_run_only_after_async_handler_completes(recording_e
     submit_times = recording_executor.submit_times_for(logging_obj)
     assert len(submit_times) == 1
     assert submit_times[0] >= recorder.async_hook_finished
+
+
+class FailureRecorder(CustomLogger):
+    def __init__(self):
+        super().__init__()
+        self.failure_payloads: list = []
+        self.success_payloads: list = []
+
+    async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
+        self.failure_payloads.append(kwargs["standard_logging_object"])
+
+    async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
+        self.success_payloads.append(kwargs["standard_logging_object"])
+
+
+class _UpstreamThatTimesOutAfterThreeDeltas:
+    headers: dict = {}
+
+    async def aiter_bytes(self):
+        for sequence_number, delta in enumerate(("The sea ", "is wide ", "and deep.")):
+            event = {
+                "type": "response.output_text.delta",
+                "item_id": "msg_1",
+                "output_index": 0,
+                "content_index": 0,
+                "delta": delta,
+                "sequence_number": sequence_number,
+            }
+            yield f"data: {json.dumps(event)}\n\n".encode()
+        raise httpx.ReadTimeout("Timeout on reading data from socket")
+
+
+@pytest.mark.asyncio
+async def test_mid_stream_read_timeout_logs_failure_with_partial_usage_and_no_success(monkeypatch):
+    recorder = FailureRecorder()
+    monkeypatch.setattr(litellm, "failure_callback", [recorder])
+    monkeypatch.setattr(litellm, "_async_failure_callback", [recorder])
+    monkeypatch.setattr(litellm, "success_callback", [recorder])
+    monkeypatch.setattr(litellm, "_async_success_callback", [recorder])
+    logging_obj = _make_logging_obj()
+    logging_obj.update_environment_variables(
+        model="gpt-5.4-nano",
+        optional_params={"stream": True},
+        litellm_params={"custom_llm_provider": "openai", "aresponses": True},
+    )
+    iterator = ResponsesAPIStreamingIterator(
+        response=cast(httpx.Response, _UpstreamThatTimesOutAfterThreeDeltas()),
+        model="gpt-5.4-nano",
+        responses_api_provider_config=OpenAIResponsesAPIConfig(),
+        logging_obj=logging_obj,
+        custom_llm_provider="openai",
+    )
+    received: list = []
+
+    async def _drain():
+        async for chunk in iterator:
+            received.append(chunk)
+
+    with pytest.raises(httpx.ReadTimeout, match="Timeout on reading data from socket"):
+        await _drain()
+    assert [chunk.delta for chunk in received] == ["The sea ", "is wide ", "and deep."]
+
+    for _ in range(50):
+        if recorder.failure_payloads:
+            break
+        await asyncio.sleep(0.1)
+    (payload,) = recorder.failure_payloads
+    assert payload["status"] == "failure"
+    assert payload["prompt_tokens"] > 0
+    assert payload["completion_tokens"] > 0
+    assert payload["response_cost"] > 0
+    assert recorder.success_payloads == []

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -4569,6 +4569,50 @@ def test_update_kwargs_with_deployment_uses_pass_through_request_timeout():
     assert kwargs["timeout"] == 6.0
 
 
+def test_update_kwargs_with_deployment_generic_stream_honors_stream_timeout():
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "gpt-6-astra",
+                "litellm_params": {"model": "openai/gpt-6-astra", "stream_timeout": 5},
+            }
+        ],
+    )
+    deployment = router.model_list[0]
+    stream_kwargs: dict = {"stream": True, "timeout": 42}
+    non_stream_kwargs: dict = {"timeout": 42}
+
+    router._update_kwargs_with_deployment(
+        deployment=deployment,
+        kwargs=stream_kwargs,
+        function_name="_ageneric_api_call_with_fallbacks",
+    )
+    router._update_kwargs_with_deployment(
+        deployment=deployment,
+        kwargs=non_stream_kwargs,
+        function_name="_ageneric_api_call_with_fallbacks",
+    )
+
+    assert stream_kwargs["timeout"] == 5
+    assert non_stream_kwargs["timeout"] == 42.0
+
+
+def test_update_kwargs_with_deployment_generic_stream_honors_router_stream_timeout():
+    router = litellm.Router(
+        model_list=[{"model_name": "gpt-6-astra", "litellm_params": {"model": "openai/gpt-6-astra"}}],
+        stream_timeout=7,
+    )
+    kwargs: dict = {"stream": True, "timeout": 42}
+
+    router._update_kwargs_with_deployment(
+        deployment=router.model_list[0],
+        kwargs=kwargs,
+        function_name="_ageneric_api_call_with_fallbacks",
+    )
+
+    assert kwargs["timeout"] == 7
+
+
 @pytest.mark.asyncio
 async def test_router_acompletion_with_unknown_model_and_default_fallback():
     """


### PR DESCRIPTION
## TLDR

Problem this solves:

- `/v1/messages` onto an OpenAI Responses model ignores `stream_timeout` mid-stream
- `/v1/responses` streams ignore `stream_timeout` the same way
- a bridged `/v1/messages` stream that dies upstream ends with HTTP 200 and no error

How it solves it:

- router resolves a configured `stream_timeout` for streaming generic (non chat) calls
- the Anthropic-to-Responses stream wrapper re-raises upstream errors instead of logging them

## User Flow

Before: a developer whose Claude SDK app streams through `/v1/messages` onto an OpenAI Responses deployment with `stream_timeout: 5` waits 40+ seconds on a stalled upstream and then gets a clean HTTP 200 with no error

1. The proxy admin sets `stream_timeout: 5` on the `gpt-6-astra` deployment (`openai/gpt-6-astra`) and restarts the proxy
2. The developer sends POST https://litellm-domain/v1/messages with `"model": "gpt-6-astra"`, `"stream": true` and a user message
3. The upstream stalls after its first few events. For 40+ seconds the developer only sees `event: ping` frames on the wire
4. When the upstream finally drops the connection the stream ends with a lone `message_start` and a clean end of body: HTTP 200, no `error` frame, so the app treats the request as a success with no content
5. https://litellm-domain/ui/?page=logs shows the request as failed, but no failure alert or failure callback fired for it
6. The same app streaming POST https://litellm-domain/v1/responses onto the same deployment also waits 40+ seconds before the error arrives

After: the same request fails after 5 seconds with an explicit error frame, and failure alerting fires

1. The proxy admin sets `stream_timeout: 5` on the `gpt-6-astra` deployment (`openai/gpt-6-astra`) and restarts the proxy
2. The developer sends POST https://litellm-domain/v1/messages with `"model": "gpt-6-astra"`, `"stream": true` and a user message
3. The upstream stalls after its first few events. About 5 seconds later the request fails with `Timeout on reading data from socket`: as an HTTP 500 error body when nothing has been streamed to the client yet, or as a `data: {"error": ...}` frame that closes the stream when content was already flowing
4. The Claude SDK raises on that error, so the app retries or falls back instead of showing an empty reply
5. https://litellm-domain/ui/?page=logs shows the request as failed, and failure alerts and failure callbacks fire for it
6. The same app streaming POST https://litellm-domain/v1/responses onto the same deployment now gets its error about 5 seconds after the stall

## Relevant issues

## Linear ticket

Resolves LIT-6871

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Setup shared by both runs: a proxy from the named commit on a random port with this config, sitting behind a small relay in front of the real OpenAI and Anthropic APIs that forwards the first 6 body chunks of every upstream response, stalls for 30 seconds, then drops the connection. The `gpt-6-astra-midstream` deployment points at a second copy of the relay that forwards 40 chunks (so text is already flowing when it stalls) and stalls for 60 seconds. Every leg costs real provider money

```yaml
model_list:
  - model_name: gpt-6-astra
    litellm_params:
      model: openai/gpt-6-astra
      api_key: os.environ/OPENAI_API_KEY
      api_base: http://127.0.0.1:49600/v1
      stream_timeout: 5
  - model_name: gpt-6-astra-midstream
    litellm_params:
      model: openai/gpt-6-astra
      api_key: os.environ/OPENAI_API_KEY
      api_base: http://127.0.0.1:41733/v1
      stream_timeout: 20
  - model_name: claude-sonnet-5
    litellm_params:
      model: anthropic/claude-sonnet-5
      api_key: os.environ/ANTHROPIC_API_KEY
      api_base: http://127.0.0.1:49600
      stream_timeout: 5
litellm_settings:
  callbacks: ["lit6871_callbacks.qa_logger"]
  num_retries: 0
```

`stamp.py` prefixes each output line with seconds since the request started and trims it to 170 characters. `qa_logger` is a `CustomLogger` that appends one line per `async_log_failure_event` and `async_post_call_failure_hook` call to a jsonl file

### Before (c52b53706e)

#### /v1/messages onto gpt-6-astra (Anthropic-to-Responses bridge)

1. Command

    ```
    curl -sN --max-time 90 http://127.0.0.1:55957/v1/messages -H 'x-api-key: sk-lit6871' -H 'anthropic-version: 2023-06-01' -H 'content-type: application/json' \
      -d '{"model":"gpt-6-astra","max_tokens":2000,"stream":true,"messages":[{"role":"user","content":"Write 300 words about the sea."}]}' \
      -w '\nHTTP %{http_code} total %{time_total}s\n' | python3 stamp.py
    ```

2. Observed: nothing but pings for 45 seconds, then a lone `message_start` and a clean close, HTTP 200, no error frame

    ```
    [ 17.76s] event: ping
    [ 17.76s] data: {"type": "ping"}
    [ 32.76s] event: ping
    [ 32.76s] data: {"type": "ping"}
    [ 45.90s] event: message_start
    [ 45.90s] data: {"type": "message_start", "message": {"id": "msg_0eea13d7-0dc6-4c0f-836b-7c92e53cc60f", "type": "message", "role": "assistant", "content": [], "model": "gpt-6-astra
    [ 45.94s] HTTP 200 total 45.938060s
    ```

3. Callback log for this request: the failure is logged but the proxy's post-call failure hook never runs

    ```
    02:45:27.415 async_log_failure_event       call_type=anthropic_messages model=gpt-6-astra      error='Response payload is not completed: <TransferEncodingError: 400, messag'
    ```

#### /v1/responses onto gpt-6-astra

1. Command

    ```
    curl -sN --max-time 90 http://127.0.0.1:55957/v1/responses -H 'Authorization: Bearer sk-lit6871' -H 'content-type: application/json' \
      -d '{"model":"gpt-6-astra","max_output_tokens":2000,"stream":true,"input":"Write 300 words about the sea."}' \
      -w '\nHTTP %{http_code} total %{time_total}s\n' | python3 stamp.py
    ```

2. Observed: the error only arrives once the relay drops the connection, 43 seconds after the last event, so `stream_timeout: 5` was ignored

    ```
    [  4.44s] data: {"type":"response.created","response":{"id":"resp__HTlyreqAP0OI2MjT_pr3ScdAP_rQaD1WFscBmPq1Qgy5UHGMz67N0mGTDaWEIaQQKdqQxK2mbAVZZzcFwLPt86T17iNwdszI7UHSs6y92AVYG-T2m
    [  4.44s] data: {"type":"response.in_progress","response":{"id":"resp__HTlyreqAP0OI2MjT_pr3ScdAP_rQaD1WFscBmPq1Qgy5UHGMz67N0mGTDaWEIaQQKdqQxK2mbAVZZzcFwLPt86T17iNwdszI7UHSs6y92AVYG
    [  4.46s] data: {"type":"response.output_item.added","output_index":0,"item":{"id":"rs_017e029ad243411e006a9be4bc3f9887d0ae37c9b785947c39","type":"reasoning","content":[],"encrypte
    [ 47.35s] data: {"error": {"message": "Response payload is not completed: <TransferEncodingError: 400, message='Not enough data to satisfy transfer length header.'>", "type": "None
    [ 47.36s] HTTP 200 total 47.313318s
    ```

3. Callback log for this request

    ```
    02:46:12.644 async_log_failure_event       call_type=aresponses         model=gpt-6-astra      error='Response payload is not completed: <TransferEncodingError: 400, messag'
    02:46:12.879 async_post_call_failure_hook  call_type=None               model=gpt-6-astra      error=''
    ```

#### Control: /v1/chat/completions onto gpt-6-astra

1. Command

    ```
    curl -sN --max-time 90 http://127.0.0.1:55957/v1/chat/completions -H 'Authorization: Bearer sk-lit6871' -H 'content-type: application/json' \
      -d '{"model":"gpt-6-astra","max_completion_tokens":2000,"stream":true,"messages":[{"role":"user","content":"Write 300 words about the sea."}]}' \
      -w '\nHTTP %{http_code} total %{time_total}s\n' | python3 stamp.py
    ```

2. Observed: the chat completions path honors `stream_timeout: 5` already

    ```
    [  7.61s] {"error":{"message":"litellm.Timeout: APITimeoutError - Request timed out. Error_str: Request timed out.\n\nDeployment Info: request_timeout: None\ntimeout: None. Receive
    [  7.61s] HTTP 408 total 7.603299s
    ```

#### Control: /v1/messages onto claude-sonnet-5 (native Anthropic path)

1. Command

    ```
    curl -sN --max-time 90 http://127.0.0.1:55957/v1/messages -H 'x-api-key: sk-lit6871' -H 'anthropic-version: 2023-06-01' -H 'content-type: application/json' \
      -d '{"model":"claude-sonnet-5","max_tokens":2000,"stream":true,"messages":[{"role":"user","content":"Write 300 words about the sea."}]}' \
      -w '\nHTTP %{http_code} total %{time_total}s\n' | python3 stamp.py
    ```

2. Observed: the native path honors `stream_timeout: 5` and sends an error frame

    ```
    [  1.08s] event: message_start
    [  2.13s] event: content_block_delta
    [  2.13s] data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" planet's surface, the ocean is a vast, interco
    [  7.87s] data: {"error": {"message": "Timeout on reading data from socket", "type": "internal_server_error", "param": null, "code": "500"}}
    [  7.87s] HTTP 200 total 7.905091s
    ```

3. Callback log for this request

    ```
    02:46:30.415 async_post_call_failure_hook  call_type=None               model=claude-sonnet-5  error=''
    02:46:30.506 async_log_failure_event       call_type=anthropic_messages model=claude-sonnet-5  error='Timeout on reading data from socket'
    ```

#### Spend logs after the four requests

```
$ psql $DB -c 'select call_type, model, status, prompt_tokens, completion_tokens, spend, round(extract(epoch from ("endTime"-"startTime"))::numeric,1) as secs from "LiteLLM_SpendLogs" order by "startTime"'
 call_type |       model        | status  | prompt_tokens | completion_tokens |  spend   | secs
-----------+--------------------+---------+---------------+-------------------+----------+------
           | openai/gpt-6-astra | failure |            15 |                 0 |        0 |  0.0
           | openai/gpt-6-astra | failure |            15 |                 0 |        0 |  0.0
           | claude-sonnet-5    | failure |            17 |                72 | 0.000754 |  0.0
(3 rows)
```

#### /v1/messages onto gpt-6-astra-midstream (bridge, upstream stalls while text is flowing)

1. Command

    ```
    curl -sN --max-time 90 http://127.0.0.1:55957/v1/messages -H 'x-api-key: sk-lit6871' -H 'anthropic-version: 2023-06-01' -H 'content-type: application/json' \
      -d '{"model":"gpt-6-astra-midstream","max_tokens":2000,"stream":true,"messages":[{"role":"user","content":"Write 300 words about the sea."}]}' \
      -w '\nHTTP %{http_code} total %{time_total}s\n' | python3 stamp.py
    ```

2. Observed: 17 text deltas stream out (the model reasons for about 17 seconds first), the upstream stalls, and the client sees nothing but pings for a minute until the relay drops the connection: a clean HTTP 200 close with no error frame, 60 seconds after `stream_timeout: 20` should have fired (`content_block_delta` lines other than the first and last are trimmed)

    ```
    [ 16.22s] event: ping
    [ 20.71s] event: message_start
    [ 20.71s] data: {"type":"message_start","message":{"id":"msg_bd19d39e-6d0b-407b-ad55-7a20a4024ee4","type":"message","role":"assistant","content":[],"model":"gpt-6-astra-midstream",
    [ 20.71s] event: content_block_start
    [ 20.71s] data: {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}}
    [ 20.71s] data: {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "The"}}
    [ 20.82s] data: {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": " blue"}}
    [ 35.83s] event: ping
    [ 50.83s] event: ping
    [ 65.84s] event: ping
    [ 80.84s] event: ping
    [ 81.24s] HTTP 200 total 81.255804s
    ```

3. Callback log for this request: the failure is logged, the post-call failure hook never runs, and no spend log row landed within 20 seconds

    ```
    03:48:54.305 async_log_failure_event       call_type=anthropic_messages model=gpt-6-astra            error='Response payload is not completed: <TransferEncodingError: 400, message='No'
    ```

### After (cc5061bd98)

#### /v1/messages onto gpt-6-astra (Anthropic-to-Responses bridge)

1. Command

    ```
    curl -sN --max-time 90 http://127.0.0.1:33579/v1/messages -H 'x-api-key: sk-lit6871' -H 'anthropic-version: 2023-06-01' -H 'content-type: application/json' \
      -d '{"model":"gpt-6-astra","max_tokens":2000,"stream":true,"messages":[{"role":"user","content":"Write 300 words about the sea."}]}' \
      -w '\nHTTP %{http_code} total %{time_total}s\n' | python3 stamp.py
    ```

2. Observed: `stream_timeout: 5` fires about 5 seconds after the upstream stalls. The stall hit while the model was still in its reasoning preamble, before the bridge had emitted any Anthropic event, so the failure surfaces as an HTTP 500 error body instead of a clean 200

    ```
    [  7.07s] {"error":{"message":"Timeout on reading data from socket","type":"internal_server_error","param":null,"code":"500"}}
    [  7.07s] HTTP 500 total 7.099990s
    ```

3. Callback log for this request: the failure is logged and the proxy's post-call failure hook now runs

    ```
    03:37:25.081 async_log_failure_event       call_type=anthropic_messages model=gpt-6-astra      error='Timeout on reading data from socket'
    03:37:25.106 async_post_call_failure_hook  call_type=None               model=gpt-6-astra      error=''
    ```

#### /v1/responses onto gpt-6-astra

1. Command

    ```
    curl -sN --max-time 90 http://127.0.0.1:33579/v1/responses -H 'Authorization: Bearer sk-lit6871' -H 'content-type: application/json' \
      -d '{"model":"gpt-6-astra","max_output_tokens":2000,"stream":true,"input":"Write 300 words about the sea."}' \
      -w '\nHTTP %{http_code} total %{time_total}s\n' | python3 stamp.py
    ```

2. Observed: the error frame arrives about 5 seconds after the last event instead of 43

    ```
    [  0.58s] data: {"type":"response.created","response":{"id":"resp_QqvTW2ULw289WtJbI4g5pm5U97Si6Di-YOJ4GJ3uibW-VoO0mcTzA69qlwlRjjcXAa_EgUC1M5dgSDFy1CrQVDDhM47sPRi1mDDYzU-AT5HbXLkoRT
    [  0.58s] data: {"type":"response.in_progress","response":{"id":"resp_QqvTW2ULw289WtJbI4g5pm5U97Si6Di-YOJ4GJ3uibW-VoO0mcTzA69qlwlRjjcXAa_EgUC1M5dgSDFy1CrQVDDhM47sPRi1mDDYzU-AT5HbXL
    [  1.33s] data: {"type":"response.output_item.added","output_index":0,"item":{"id":"rs_0e0e016a2056e845006a9bf0e71ee487d0b4c92681230ee32f","type":"reasoning","content":[],"encrypte
    [  6.68s] data: {"error": {"message": "Timeout on reading data from socket", "type": "None", "param": "None", "code": "500"}}
    [  6.68s] HTTP 200 total 6.701338s
    ```

3. Callback log for this request

    ```
    03:37:32.148 async_log_failure_event       call_type=aresponses         model=gpt-6-astra      error='Timeout on reading data from socket'
    03:37:32.171 async_post_call_failure_hook  call_type=None               model=gpt-6-astra      error=''
    ```

#### Control: /v1/chat/completions onto gpt-6-astra

1. Command

    ```
    curl -sN --max-time 90 http://127.0.0.1:33579/v1/chat/completions -H 'Authorization: Bearer sk-lit6871' -H 'content-type: application/json' \
      -d '{"model":"gpt-6-astra","max_completion_tokens":2000,"stream":true,"messages":[{"role":"user","content":"Write 300 words about the sea."}]}' \
      -w '\nHTTP %{http_code} total %{time_total}s\n' | python3 stamp.py
    ```

2. Observed: unchanged, the chat completions path still honors `stream_timeout: 5`

    ```
    [  7.94s] {"error":{"message":"litellm.Timeout: APITimeoutError - Request timed out. Error_str: Request timed out.\n\nDeployment Info: request_timeout: None\ntimeout: None. Receive
    [  7.94s] HTTP 408 total 7.955969s
    ```

#### Control: /v1/messages onto claude-sonnet-5 (native Anthropic path)

1. Command

    ```
    curl -sN --max-time 90 http://127.0.0.1:33579/v1/messages -H 'x-api-key: sk-lit6871' -H 'anthropic-version: 2023-06-01' -H 'content-type: application/json' \
      -d '{"model":"claude-sonnet-5","max_tokens":2000,"stream":true,"messages":[{"role":"user","content":"Write 300 words about the sea."}]}' \
      -w '\nHTTP %{http_code} total %{time_total}s\n' | python3 stamp.py
    ```

2. Observed: unchanged, the native path still honors `stream_timeout: 5` and sends an error frame

    ```
    [  1.45s] event: message_start
    [  3.61s] event: content_block_delta
    [  3.61s] data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"undtrack that has soothed countless generations. Yet the same waters can transform into
    [  8.98s] data: {"error": {"message": "Timeout on reading data from socket", "type": "internal_server_error", "param": null, "code": "500"}}
    [  8.98s] HTTP 200 total 9.047053s
    ```

3. Callback log for this request

    ```
    03:37:49.439 async_post_call_failure_hook  call_type=None               model=claude-sonnet-5  error=''
    03:37:49.457 async_log_failure_event       call_type=anthropic_messages model=claude-sonnet-5  error='Timeout on reading data from socket'
    ```

#### Spend logs after the four requests

```
$ psql $DB -c 'select call_type, model, status, prompt_tokens, completion_tokens, spend, round(extract(epoch from ("endTime"-"startTime"))::numeric,1) as secs from "LiteLLM_SpendLogs" order by "startTime"'
 call_type |       model        | status  | prompt_tokens | completion_tokens |  spend   | secs
-----------+--------------------+---------+---------------+-------------------+----------+------
           | openai/gpt-6-astra | failure |            15 |                 0 |        0 |  0.0
           | openai/gpt-6-astra | failure |            15 |                 0 |        0 |  0.0
           | openai/gpt-6-astra | failure |            15 |                 0 |        0 |  0.0
           | claude-sonnet-5    | failure |            17 |               124 | 0.001274 |  0.0
(4 rows)
```

#### /v1/messages onto gpt-6-astra-midstream (bridge, upstream stalls while text is flowing)

1. Command

    ```
    curl -sN --max-time 90 http://127.0.0.1:33579/v1/messages -H 'x-api-key: sk-lit6871' -H 'anthropic-version: 2023-06-01' -H 'content-type: application/json' \
      -d '{"model":"gpt-6-astra-midstream","max_tokens":2000,"stream":true,"messages":[{"role":"user","content":"Write 300 words about the sea."}]}' \
      -w '\nHTTP %{http_code} total %{time_total}s\n' | python3 stamp.py
    ```

2. Observed: 20 text deltas stream out, the upstream stalls, and about 20 seconds later the stream carries an error frame and closes, so a Claude SDK client raises instead of treating the truncated reply as complete (`content_block_delta` lines other than the first and last are trimmed)

    ```
    [ 16.68s] event: ping
    [ 16.97s] event: message_start
    [ 16.98s] data: {"type":"message_start","message":{"id":"msg_8f28a2cf-c67f-49a2-a673-d599238755c7","type":"message","role":"assistant","content":[],"model":"gpt-6-astra-midstream",
    [ 16.98s] event: content_block_start
    [ 16.98s] data: {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}}
    [ 16.98s] data: {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "The"}}
    [ 17.02s] data: {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": " and"}}
    [ 32.05s] event: ping
    [ 39.76s] data: {"error": {"message": "Timeout on reading data from socket", "type": "internal_server_error", "param": null, "code": "500"}}
    [ 39.76s] HTTP 200 total 39.782845s
    ```

3. Callback log for this request: both the failure log and the post-call failure hook fire

    ```
    03:50:53.191 async_log_failure_event       call_type=anthropic_messages model=gpt-6-astra            error='Timeout on reading data from socket'
    03:50:53.234 async_post_call_failure_hook  call_type=None               model=gpt-6-astra-midstream  error=''
    ```

4. Spend log row for this request

    ```
     call_type |       model        | status  | prompt_tokens | completion_tokens | spend
    -----------+--------------------+---------+---------------+-------------------+-------
               | openai/gpt-6-astra | failure |            15 |                 0 |     0
    (1 row)
    ```

## Type

🐛 Bug Fix

## Caveats (if any)

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
