### PR TITLE
feat(providers): add Standard Compute chat completions

### DIFF
--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -200,5 +200,12 @@
       "temperature_max": 1.99
     },
     "supported_endpoints": ["/v1/chat/completions"]
+  },
+  "standardcompute": {
+    "base_url": "https://api.stdcmpt.com/v1",
+    "api_key_env": "STANDARDCOMPUTE_API_KEY",
+    "param_mappings": {
+      "max_completion_tokens": "max_tokens"
+    }
   }
 }

--- a/litellm/provider_endpoints_support_backup.json
+++ b/litellm/provider_endpoints_support_backup.json
@@ -2099,6 +2099,23 @@
         "interactions": true
       }
     },
+    "standardcompute": {
+      "display_name": "Standard Compute (`standardcompute`)",
+      "url": "https://standardcompute.com/integrations",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": false,
+        "responses": false,
+        "embeddings": false,
+        "image_generations": false,
+        "audio_transcriptions": false,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "a2a": false
+      }
+    },
     "synthetic": {
       "display_name": "Synthetic (`synthetic`)",
       "endpoints": {

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -2349,6 +2349,23 @@
         "rerank": false
       }
     },
+    "standardcompute": {
+      "display_name": "Standard Compute (`standardcompute`)",
+      "url": "https://standardcompute.com/integrations",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": false,
+        "responses": false,
+        "embeddings": false,
+        "image_generations": false,
+        "audio_transcriptions": false,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "a2a": false
+      }
+    },
     "synthetic": {
       "display_name": "Synthetic (`synthetic`)",
       "endpoints": {

--- a/tests/test_litellm/llms/openai_like/test_standardcompute_provider.py
+++ b/tests/test_litellm/llms/openai_like/test_standardcompute_provider.py
@@ -1,0 +1,158 @@
+import json
+
+import httpx
+import pytest
+import respx
+
+import litellm
+
+
+@pytest.fixture(autouse=True)
+def httpx_transport(monkeypatch):
+    monkeypatch.setenv("DISABLE_AIOHTTP_TRANSPORT", "True")
+
+
+@pytest.mark.asyncio
+async def test_standardcompute_completion_preserves_tools_and_maps_token_limit():
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "read_file",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"path": {"type": "string"}},
+                    "required": ["path"],
+                },
+            },
+        }
+    ]
+    response = {
+        "id": "chatcmpl-test",
+        "object": "chat.completion",
+        "created": 1,
+        "model": "standardcompute",
+        "choices": [
+            {
+                "index": 0,
+                "finish_reason": "tool_calls",
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call-read",
+                            "type": "function",
+                            "function": {
+                                "name": "read_file",
+                                "arguments": '{"path":"README.md"}',
+                            },
+                        }
+                    ],
+                },
+            }
+        ],
+    }
+    with respx.mock as transport:
+        request = transport.post("https://api.stdcmpt.com/v1/chat/completions").mock(
+            return_value=httpx.Response(200, json=response)
+        )
+        result = await litellm.acompletion(
+            model="standardcompute/standardcompute",
+            api_key="test-key",
+            messages=[{"role": "user", "content": "Read README.md"}],
+            tools=tools,
+            max_completion_tokens=64,
+        )
+    sent = json.loads(request.calls.last.request.content)
+    assert sent["model"] == "standardcompute"
+    assert sent["tools"] == tools
+    assert sent["max_tokens"] == 64
+    assert "max_completion_tokens" not in sent
+    assert request.calls.last.request.headers["authorization"] == "Bearer test-key"
+    assert result.choices[0].message.tool_calls[0].function.name == "read_file"
+
+
+@pytest.mark.asyncio
+async def test_standardcompute_environment_key_and_api_base_override(monkeypatch):
+    monkeypatch.setenv("STANDARDCOMPUTE_API_KEY", "environment-test-key")
+    response = {
+        "id": "chatcmpl-test",
+        "object": "chat.completion",
+        "created": 1,
+        "model": "standardcompute",
+        "choices": [
+            {
+                "index": 0,
+                "finish_reason": "stop",
+                "message": {"role": "assistant", "content": "Connected"},
+            }
+        ],
+    }
+    with respx.mock as transport:
+        request = transport.post("https://example.test/v1/chat/completions").mock(
+            return_value=httpx.Response(200, json=response)
+        )
+        result = await litellm.acompletion(
+            model="standardcompute/standardcompute",
+            api_base="https://example.test/v1",
+            messages=[{"role": "user", "content": "Connection check"}],
+        )
+    assert (
+        request.calls.last.request.headers["authorization"]
+        == "Bearer environment-test-key"
+    )
+    assert result.choices[0].message.content == "Connected"
+
+
+@pytest.mark.asyncio
+async def test_standardcompute_stream_consumes_chat_completion_events():
+    chunks = [
+        {
+            "id": "chatcmpl-test",
+            "object": "chat.completion.chunk",
+            "created": 1,
+            "model": "standardcompute",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"role": "assistant", "content": "Connected"},
+                    "finish_reason": None,
+                }
+            ],
+        },
+        {
+            "id": "chatcmpl-test",
+            "object": "chat.completion.chunk",
+            "created": 1,
+            "model": "standardcompute",
+            "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+        },
+    ]
+    events = (
+        "".join("data: " + json.dumps(chunk) + "\n\n" for chunk in chunks)
+        + "data: [DONE]\n\n"
+    )
+    with respx.mock as transport:
+        request = transport.post("https://api.stdcmpt.com/v1/chat/completions").mock(
+            return_value=httpx.Response(
+                200, text=events, headers={"content-type": "text/event-stream"}
+            )
+        )
+        stream = await litellm.acompletion(
+            model="standardcompute/standardcompute",
+            api_key="test-key",
+            messages=[{"role": "user", "content": "Connection check"}],
+            stream=True,
+        )
+        received = [chunk async for chunk in stream]
+    assert json.loads(request.calls.last.request.content)["stream"] is True
+    assert (
+        "".join(
+            chunk.choices[0].delta.content or "" for chunk in received if chunk.choices
+        )
+        == "Connected"
+    )
+    assert any(
+        chunk.choices and chunk.choices[0].finish_reason == "stop" for chunk in received
+    )

--- a/tests/test_litellm/llms/openai_like/test_standardcompute_provider.py
+++ b/tests/test_litellm/llms/openai_like/test_standardcompute_provider.py
@@ -98,10 +98,7 @@ async def test_standardcompute_environment_key_and_api_base_override(monkeypatch
             api_base="https://example.test/v1",
             messages=[{"role": "user", "content": "Connection check"}],
         )
-    assert (
-        request.calls.last.request.headers["authorization"]
-        == "Bearer environment-test-key"
-    )
+    assert request.calls.last.request.headers["authorization"] == "Bearer environment-test-key"
     assert result.choices[0].message.content == "Connected"
 
 
@@ -129,15 +126,10 @@ async def test_standardcompute_stream_consumes_chat_completion_events():
             "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
         },
     ]
-    events = (
-        "".join("data: " + json.dumps(chunk) + "\n\n" for chunk in chunks)
-        + "data: [DONE]\n\n"
-    )
+    events = "".join("data: " + json.dumps(chunk) + "\n\n" for chunk in chunks) + "data: [DONE]\n\n"
     with respx.mock as transport:
         request = transport.post("https://api.stdcmpt.com/v1/chat/completions").mock(
-            return_value=httpx.Response(
-                200, text=events, headers={"content-type": "text/event-stream"}
-            )
+            return_value=httpx.Response(200, text=events, headers={"content-type": "text/event-stream"})
         )
         stream = await litellm.acompletion(
             model="standardcompute/standardcompute",
@@ -147,12 +139,5 @@ async def test_standardcompute_stream_consumes_chat_completion_events():
         )
         received = [chunk async for chunk in stream]
     assert json.loads(request.calls.last.request.content)["stream"] is True
-    assert (
-        "".join(
-            chunk.choices[0].delta.content or "" for chunk in received if chunk.choices
-        )
-        == "Connected"
-    )
-    assert any(
-        chunk.choices and chunk.choices[0].finish_reason == "stop" for chunk in received
-    )
+    assert "".join(chunk.choices[0].delta.content or "" for chunk in received if chunk.choices) == "Connected"
+    assert any(chunk.choices and chunk.choices[0].finish_reason == "stop" for chunk in received)


### PR DESCRIPTION
## TLDR

Problem this solves:

- The native Standard Compute provider prefix is unrecognized.

How it solves it:

- Registers the endpoint, key environment variable and token-limit mapping.
- Tests completion requests, streaming and native tool-call preservation.
- Documents Chat Completions support in both endpoint catalogs.

## User Flow

Before: a developer cannot call their Standard Compute account by provider name.

1. Set `STANDARDCOMPUTE_API_KEY` to their own Standard Compute key.
2. Call `litellm.completion(model="standardcompute/standardcompute", messages=[{"role":"user","content":"Reply with the single word connected."}], max_tokens=64)`.
3. Receive `BadRequestError: LLM Provider NOT provided`.

After: the same provider name reaches the account's inference endpoint.

1. Set `STANDARDCOMPUTE_API_KEY` to their own Standard Compute key.
2. Call `litellm.completion(model="standardcompute/standardcompute", messages=[{"role":"user","content":"Reply with the single word connected."}], max_tokens=64)`.
3. Receive a completion containing `connected`.

## Relevant issues

No existing Standard Compute provider-registration request was found in the issue/PR search.

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves one specific problem
- [x] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

Local checks: provider registry plus new transport tests: **21 passed, 4 skipped**. The four skips are pre-existing optional provider integration tests. Ruff formatting, the repository's `ruff-tests.toml` checks, and provider documentation validation pass. All 182 reported GitHub checks passed at commit b810e92c2a14780cdd68c35116c98b470984837e. Greptile reviewed that commit with confidence 5/5 and no actionable findings. The contributor's personal CLA signature is pending; this remains a draft.

## Delays in PR merge?

Awaiting the contributor's personal CLA signature. Automated checks and review are complete.

## Screenshots / Proof of Fix

Actual requests to `https://api.stdcmpt.com/v1/chat/completions`, using a dedicated internal Standard Compute account with a $0.25 maximum compute allowance. No mocks in the runs below. Captured September 5, 2026; the model response identifies a router and is not independent proof of underlying model identity.

Shared setup: set `STANDARDCOMPUTE_API_KEY` locally, then in Python:

```python
import litellm
shared = dict(
    model="standardcompute/standardcompute",
    messages=[{"role": "user", "content": "Reply with the single word connected."}],
    max_tokens=64, max_retries=0, num_retries=0, timeout=30,
)
tool_args = dict(
    messages=[{"role": "user", "content": "Call report_status with status connected."}],
    tools=[{"type": "function", "function": {
        "name": "report_status", "description": "Report a connection test status",
        "parameters": {"type": "object", "properties": {
            "status": {"type": "string", "enum": ["connected"]}
        }, "required": ["status"]}
    }}],
    tool_choice={"type": "function", "function": {"name": "report_status"}},
)
```

### Before (c52b53706ed4c7f50bc3afe05a6937c6b8783ce7)

#### Chat completion

1. Run `litellm.completion(**shared)`.
2. Observed `BadRequestError: LLM Provider NOT provided`, before an inference request.

#### Streaming

1. Run `list(litellm.completion(**(shared | {"stream": True})))`.
2. Observed `BadRequestError: LLM Provider NOT provided`, before an inference request.

#### Tool call

1. Run `litellm.completion(**(shared | tool_args))`.
2. Observed `BadRequestError: LLM Provider NOT provided`, before an inference request.

### After (b810e92c2a14780cdd68c35116c98b470984837e)

#### Chat completion

1. Run `litellm.completion(**shared)`.
2. Observed content `connected`; response ID `sc-1788616447-FPwuFPZpka6JZZo7c4Wj`.

#### Streaming

1. Run `list(litellm.completion(**(shared | {"stream": True})))`.
2. Observed 13 chunks, assembled text `connected`, and finish reason `stop`.

#### Tool call

1. Run `litellm.completion(**(shared | tool_args))`.
2. Observed tool `report_status`, arguments `{"status":"connected"}`; response ID `sc-1788616454-6RuR77PFgviGNbgvz2v8`.

## Type

🆕 New Feature
✅ Test

## Caveats (if any)

### Medium

- Native Responses and Anthropic Messages are outside this registration.
- No token-price entries or underlying model-identity verification.

### Low

- Router uses the customer's selected [model pool](https://standardcompute.com/models).
- Provider-specific docs link to existing [setup guides](https://standardcompute.com/integrations).
- [Plan budgets](https://standardcompute.com/pricing) determine available usage.

Disclosure: I run Standard Compute. The account in the live checks was an internal test account; no customer acquisition result is implied.

## Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

The relevant tests and live cases pass; I cannot assert that all regressions are impossible. All reported CI checks pass and Greptile reports confidence 5/5.
