### PR TITLE
test(e2e): cover Anthropic /chat/completions streaming and tool calls

### DIFF
--- a/tests/e2e/llm_translation/test_chat_completions_regression_e2e.py
+++ b/tests/e2e/llm_translation/test_chat_completions_regression_e2e.py
@@ -11,7 +11,7 @@ fails that provider's row here.
 
 The per-provider classes below cover the OpenAI-compatible /chat/completions
 translation for providers customers reach by registering their own deployment
-via /model/new (Cohere, Gemini, hosted_vllm), each deleted on teardown.
+via /model/new (Cohere, Gemini, hosted_vllm, Anthropic), each deleted on teardown.
 """
 
 from __future__ import annotations
@@ -46,6 +46,7 @@ pytestmark = pytest.mark.e2e
 COHERE_BACKEND = "cohere/command-r-08-2024"
 GEMINI_BACKEND = "gemini/gemini-2.5-flash"
 OPENAI_BACKEND = "openai/gpt-5.6"
+ANTHROPIC_BACKEND = "anthropic/claude-haiku-4-5-20251001"
 BEDROCK_CONVERSE_BACKEND = "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0"
 
 
@@ -746,3 +747,98 @@ class TestBedrockConverseChatCompletions:
 
         response = unwrap(client.proxy.chat(key, ChatBody(model=model, messages=_vision_messages(), max_tokens=32)))
         _assert_describes_cat(response)
+
+
+class TestAnthropicChatCompletions:
+    """Anthropic via the OpenAI-compatible /chat/completions path, the translation
+    customers on the OpenAI SDK rely on when they route to Claude. The streamed call
+    must deliver real content deltas, and a tool-forced call must come back as a
+    well-formed tool_call on both the non-streamed and streamed paths.
+    """
+
+    def _register(self, client: PassthroughClient, resources: ResourceManager, prefix: str) -> str:
+        model = f"{prefix}-{unique_marker()}"
+        model_id = client.proxy.create_model(
+            model, LiteLLMParamsBody(model=ANTHROPIC_BACKEND, api_key="os.environ/ANTHROPIC_API_KEY")
+        )
+        resources.defer(lambda: client.proxy.delete_model(model_id))
+        return model
+
+    @pytest.mark.covers(
+        "llm.chat_completions.anthropic.basic.stream.works",
+        exercised_on=["chat_completions"],
+    )
+    def test_anthropic_chat_streams_real_content(
+        self, client: PassthroughClient, resources: ResourceManager
+    ) -> None:
+        model = self._register(client, resources, "e2e-anthropic-stream")
+        key = resources.key()
+
+        result = client.proxy.chat_stream(
+            key,
+            ChatBody(
+                model=model,
+                messages=[
+                    ChatMessage(role="user", content=f"Count from 1 to 5, one number per line. {unique_marker()}")
+                ],
+                max_tokens=64,
+                stream=True,
+            ),
+        )
+        _assert_streamed_completion(result)
+
+    @pytest.mark.covers(
+        "llm.chat_completions.anthropic.tool_use.nonstream.works",
+        exercised_on=["chat_completions"],
+    )
+    def test_anthropic_chat_returns_tool_call(
+        self, client: PassthroughClient, resources: ResourceManager
+    ) -> None:
+        model = self._register(client, resources, "e2e-anthropic-tool")
+        key = resources.key()
+
+        response = unwrap(
+            client.proxy.chat(
+                key,
+                ChatBody(
+                    model=model,
+                    messages=[
+                        ChatMessage(role="user", content="What is the weather in San Francisco? Use the get_weather tool.")
+                    ],
+                    tools=[_WEATHER_TOOL],
+                    tool_choice="required",
+                    max_tokens=128,
+                ),
+            )
+        )
+        _assert_weather_tool_call(response)
+
+    @pytest.mark.covers(
+        "llm.chat_completions.anthropic.tool_use.stream.works",
+        exercised_on=["chat_completions"],
+    )
+    def test_anthropic_chat_streams_tool_call(
+        self, client: PassthroughClient, resources: ResourceManager
+    ) -> None:
+        model = self._register(client, resources, "e2e-anthropic-tool-stream")
+        key = resources.key()
+
+        result = client.proxy.chat_stream(
+            key,
+            ChatBody(
+                model=model,
+                messages=[
+                    ChatMessage(role="user", content="What is the weather in San Francisco? Use the get_weather tool.")
+                ],
+                tools=[_WEATHER_TOOL],
+                tool_choice="required",
+                max_tokens=128,
+                stream=True,
+            ),
+        )
+        assert result.ok and result.is_streaming, f"tool stream was not established: {result}"
+        assert result.stream_error is None, f"tool stream carried an error event: {result.stream_error}"
+        name, arguments = _streamed_tool_call(result.stream_events)
+        assert name == "get_weather", f"streamed tool call named {name!r}: {result.stream_events[:5]}"
+        args = _WeatherArgs.model_validate_json(arguments)
+        assert args.location.strip(), f"streamed tool call arguments missing location: {arguments!r}"


### PR DESCRIPTION
## TLDR

Problem this solves:

- Anthropic over /chat/completions had no e2e test for streaming or tool calls
- Three P0 registry cells sat uncovered, so a translation regression ships silently

How it solves it:

- Adds TestAnthropicChatCompletions to the chat completions regression suite
- Streams a claude-haiku-4-5 completion and asserts real content deltas arrive
- Forces get_weather tool calls, non-streamed and streamed, and parses the arguments

## User Flow

Before: a release that breaks Claude tool calls over the OpenAI-compatible route reaches customers, because nothing in the e2e suite exercises that path

1. A developer on the OpenAI SDK sends POST https://litellm-domain/v1/chat/completions with `"model": "claude-haiku-4-5"`, a `get_weather` tool and `"tool_choice": "required"`
2. They get a 200 whose `tool_calls` is empty, or whose `arguments` string is not valid JSON
3. Nothing went red in CI before that release shipped

After: the same regression fails the e2e run before release

1. The suite registers `anthropic/claude-haiku-4-5-20251001` through POST /model/new and generates a virtual key
2. It sends POST /v1/chat/completions three ways: `"stream": true`, tool-forced, and tool-forced with `"stream": true`
3. A stream with no content deltas, a missing `get_weather` call, or unparseable arguments fails the run

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both runs are live against the real Anthropic API, no mocks. The proxy runs from the named commit on port 4001 with a config wiring `gpt-5.5`, `claude-haiku-4-5`, `gemini-2.5-flash` and `openai-text-embedding-3-small`, `store_model_in_db: true`, and the Postgres from `.env`

```bash
python litellm/proxy/proxy_cli.py --config e2e_config.yaml --port 4001
```

### Before (f0618394c1)

1. `cd tests/e2e && PYTHONPATH=. python -m coverage_registry.collector`
2. Headline coverage: 406/544 (74.6%), Core LLMs 130/162, with `llm.chat_completions.anthropic.basic.stream.works`, `llm.chat_completions.anthropic.tool_use.nonstream.works` and `llm.chat_completions.anthropic.tool_use.stream.works` in the uncovered set

### After (98784360e8)

1. `LITELLM_PROXY_URL=http://localhost:4001 uv run pytest tests/e2e/llm_translation/test_chat_completions_regression_e2e.py -k TestAnthropicChatCompletions -v`
2. Output:

```text
llm_translation/test_chat_completions_regression_e2e.py::TestAnthropicChatCompletions::test_anthropic_chat_streams_real_content PASSED [ 33%]
llm_translation/test_chat_completions_regression_e2e.py::TestAnthropicChatCompletions::test_anthropic_chat_returns_tool_call PASSED [ 66%]
llm_translation/test_chat_completions_regression_e2e.py::TestAnthropicChatCompletions::test_anthropic_chat_streams_tool_call PASSED [100%]

================= 3 passed, 18 deselected in 60.87s (0:01:00) ==================
```

3. `cd tests/e2e && PYTHONPATH=. python -m coverage_registry.collector --strict` now reports 409/544 (75.2%), Core LLMs 133/162
4. `uv run basedpyright tests/e2e` reports 0 errors

## Type

✅ Test

## Caveats (if any)

## QA runbook

All three steps need `ANTHROPIC_API_KEY` on the proxy and `store_model_in_db: true`. Register the deployment once and reuse it: POST /model/new with the master key and `{"model_name": "qa-anthropic-chat", "litellm_params": {"model": "anthropic/claude-haiku-4-5-20251001", "api_key": "os.environ/ANTHROPIC_API_KEY"}}`, then POST /key/generate with `{"models": []}` and use that key below

- tests/e2e/llm_translation/test_chat_completions_regression_e2e.py::TestAnthropicChatCompletions::test_anthropic_chat_streams_real_content - a streamed Claude call over /chat/completions delivers real content deltas, not a clean but empty stream
  - [ ] POST /v1/chat/completions with `{"model": "qa-anthropic-chat", "stream": true, "max_tokens": 64, "messages": [{"role": "user", "content": "Count from 1 to 5, one number per line."}]}`
  - [ ] Expect `content-type: text/event-stream`, more than one `data:` event, no error event, and non-empty `delta.content` text when the chunks are concatenated
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/llm_translation/test_chat_completions_regression_e2e.py::TestAnthropicChatCompletions::test_anthropic_chat_returns_tool_call - a tool-forced Claude call comes back as a well-formed get_weather tool_call
  - [ ] POST /v1/chat/completions with `{"model": "qa-anthropic-chat", "max_tokens": 128, "tool_choice": "required", "tools": [{"type": "function", "function": {"name": "get_weather", "description": "Get the current weather for a location", "parameters": {"type": "object", "properties": {"location": {"type": "string"}}, "required": ["location"]}}}], "messages": [{"role": "user", "content": "What is the weather in San Francisco? Use the get_weather tool."}]}`
  - [ ] Expect 200 with `choices[0].message.tool_calls` containing a `get_weather` call whose `arguments` parses as JSON with a non-empty `location`
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/llm_translation/test_chat_completions_regression_e2e.py::TestAnthropicChatCompletions::test_anthropic_chat_streams_tool_call - the same tool-forced call streamed reassembles into the same well-formed tool_call
  - [ ] Send the previous request body with `"stream": true` added
  - [ ] Expect an SSE stream with no error event whose `delta.tool_calls` fragments concatenate to the name `get_weather` and an `arguments` string that parses as JSON with a non-empty `location`
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
