### PR TITLE
test(e2e): cover key spend reset, regenerate grace period, and the llm_api_routes grant

### DIFF
--- a/tests/e2e/access_control/test_access_control_e2e.py
+++ b/tests/e2e/access_control/test_access_control_e2e.py
@@ -24,7 +24,7 @@ from access_control_client import (
 from e2e_config import unique_marker
 from e2e_http import Success, UnauthorizedError, UnknownApiError, unwrap
 from lifecycle import ResourceManager
-from models import ChatBody, ChatMessage, ChatResponse, LiteLLMParamsBody
+from models import ChatBody, ChatMessage, ChatResponse, EmbedBody, LiteLLMParamsBody
 from proxy_client import ProxyClient
 
 pytestmark = pytest.mark.e2e
@@ -32,6 +32,7 @@ pytestmark = pytest.mark.e2e
 ALLOWED_MODEL = "gemini-2.5-flash"
 DISALLOWED_MODEL = "gpt-5.5"
 VIRTUAL_KEY_BACKEND = "anthropic/claude-haiku-4-5-20251001"
+EMBEDDING_MODEL = "openai-text-embedding-3-small"
 
 
 class TestAccessControl:
@@ -69,6 +70,31 @@ class TestAccessControl:
         )
         assert MODEL_ACCESS_DENIED_MARKER in result.body, (
             f"403 body must be a model-access denial, got: {result.body[:300]}"
+        )
+
+    @pytest.mark.covers("other.auth.virtual_key.route_group_allowed")
+    def test_llm_api_routes_group_grants_every_llm_endpoint(
+        self, client: AccessControlClient, resources: ResourceManager
+    ) -> None:
+        """allowed_routes=["llm_api_routes"] names a route group, not a path: one
+        entry must open every LLM endpoint while the management routes stay shut."""
+        key = client.llm_only_key()
+        resources.defer(lambda: client.delete_key(key))
+
+        chat = client.chat_status(key, ALLOWED_MODEL, f"capital of France? {unique_marker()}")
+        assert chat.status_code == 200, (
+            f"llm_api_routes key must reach /chat/completions, got {chat.status_code}: {chat.body[:300]}"
+        )
+        assert ChatResponse.model_validate_json(chat.body).choices, (
+            f"200 must carry a real completion, not an error envelope: {chat.body[:300]}"
+        )
+
+        embedding = unwrap(client.proxy.embed(key, EmbedBody(model=EMBEDDING_MODEL, input=f"route group {unique_marker()}")))
+        assert embedding.model, f"llm_api_routes key reached /embeddings but got no model back: {embedding}"
+
+        denied = client.create_model_status(key, f"e2e-route-group-{unique_marker()}")
+        assert denied.status_code == 403 and ROUTE_NOT_ALLOWED_MARKER in denied.body, (
+            f"the same key must still be shut out of /model/new, got {denied.status_code}: {denied.body[:300]}"
         )
 
     def test_llm_only_key_forbidden_from_management_route_403(

--- a/tests/e2e/access_control/test_access_control_e2e.py
+++ b/tests/e2e/access_control/test_access_control_e2e.py
@@ -76,8 +76,6 @@ class TestAccessControl:
     def test_llm_api_routes_group_grants_every_llm_endpoint(
         self, client: AccessControlClient, resources: ResourceManager
     ) -> None:
-        """allowed_routes=["llm_api_routes"] names a route group, not a path: one
-        entry must open every LLM endpoint while the management routes stay shut."""
         key = client.llm_only_key()
         resources.defer(lambda: client.delete_key(key))
 
@@ -89,7 +87,9 @@ class TestAccessControl:
             f"200 must carry a real completion, not an error envelope: {chat.body[:300]}"
         )
 
-        embedding = unwrap(client.proxy.embed(key, EmbedBody(model=EMBEDDING_MODEL, input=f"route group {unique_marker()}")))
+        embedding = unwrap(
+            client.proxy.embed(key, EmbedBody(model=EMBEDDING_MODEL, input=f"route group {unique_marker()}"))
+        )
         assert embedding.model, f"llm_api_routes key reached /embeddings but got no model back: {embedding}"
 
         denied = client.create_model_status(key, f"e2e-route-group-{unique_marker()}")

--- a/tests/e2e/management/management_client.py
+++ b/tests/e2e/management/management_client.py
@@ -40,6 +40,8 @@ from models import (
     KeyListParams,
     KeyListResponse,
     KeyRegenerateBody,
+    KeyResetSpendBody,
+    KeyResetSpendResponse,
     KeyUpdateBody,
     ModelDeleteBody,
     OrgDeleteBody,
@@ -191,15 +193,25 @@ class ManagementClient:
                 response_type=NoBody,
             )
         )
-    def regenerate_key(self, key: str) -> str:
+    def regenerate_key(self, key: str, *, grace_period: str | None = None) -> str:
         return unwrap(
             self.proxy.transport.post(
                 "/key/regenerate",
                 headers=self.proxy.transport.master,
-                json=KeyRegenerateBody(key=key),
+                json=KeyRegenerateBody(key=key, grace_period=grace_period),
                 response_type=KeyGenerateResponse,
             )
         ).key
+
+    def reset_key_spend(self, key: str, reset_to: float) -> KeyResetSpendResponse:
+        return unwrap(
+            self.proxy.transport.post(
+                f"/key/{key}/reset_spend",
+                headers=self.proxy.transport.master,
+                json=KeyResetSpendBody(reset_to=reset_to),
+                response_type=KeyResetSpendResponse,
+            )
+        )
 
     def key_list(self, key_alias: str, *, caller_key: str | None = None) -> Result[KeyListResponse]:
         """GET /key/list, the Virtual Keys page's own inventory call. `caller_key` is

--- a/tests/e2e/management/test_key_management_e2e.py
+++ b/tests/e2e/management/test_key_management_e2e.py
@@ -90,8 +90,6 @@ def _is_budget_block(outcome: StreamingResponse) -> bool:
 
 
 def _spend_until_budget_blocks(client: ManagementClient, key: str) -> None:
-    """Drive paid calls until the key's max_budget refuses one. The first call spends,
-    the reservation counter trips the cap, and the next call is the 429."""
     for _ in range(40):
         outcome = client.chat_status(key, SPEND_MODEL, f"spend {unique_marker()}")
         if _is_budget_block(outcome):
@@ -105,8 +103,6 @@ def _spend_until_budget_blocks(client: ManagementClient, key: str) -> None:
 
 
 def _settled_spend(client: ManagementClient, key: str) -> float | None:
-    """The key's recorded spend once it is positive and unchanged across two reads a
-    poll interval apart, so no batched spend write is still in flight when we reset."""
     first = client.proxy.key_info(key).spend or 0.0
     time.sleep(client.proxy.poll_interval)
     second = client.proxy.key_info(key).spend or 0.0

--- a/tests/e2e/management/test_key_management_e2e.py
+++ b/tests/e2e/management/test_key_management_e2e.py
@@ -18,13 +18,16 @@ from typing import Literal
 import pytest
 
 from e2e_config import unique_marker
-from e2e_http import NoBody, unwrap
+from e2e_http import NoBody, StreamingResponse, unwrap
 from lifecycle import ResourceManager
 from management_client import ManagementClient
 from models import KeyDeleteBody, KeyGenerateBody, KeyUpdateBody
 from pydantic import BaseModel
 
 pytestmark = pytest.mark.e2e
+
+TINY_BUDGET = 3e-6
+SPEND_MODEL = "claude-haiku-4-5"
 
 
 class KeyToggleBlockBody(BaseModel):
@@ -80,6 +83,34 @@ def _generate_key(client: ManagementClient, resources: ResourceManager, body: Ke
     key = client.proxy.generate_key(body)
     resources.defer(lambda: client.proxy.delete_key(key))
     return key
+
+
+def _is_budget_block(outcome: StreamingResponse) -> bool:
+    return not outcome.ok and "budget_exceeded" in outcome.body
+
+
+def _spend_until_budget_blocks(client: ManagementClient, key: str) -> None:
+    """Drive paid calls until the key's max_budget refuses one. The first call spends,
+    the reservation counter trips the cap, and the next call is the 429."""
+    for _ in range(40):
+        outcome = client.chat_status(key, SPEND_MODEL, f"spend {unique_marker()}")
+        if _is_budget_block(outcome):
+            assert outcome.status_code == 429, (
+                f"budget refusal must be 429, got {outcome.status_code}: {outcome.body[:200]}"
+            )
+            return
+        assert outcome.ok, f"paid call failed before the budget tripped ({outcome.status_code}): {outcome.body[:300]}"
+        time.sleep(2)
+    pytest.fail(f"max_budget={TINY_BUDGET} never blocked a call on the key")
+
+
+def _settled_spend(client: ManagementClient, key: str) -> float | None:
+    """The key's recorded spend once it is positive and unchanged across two reads a
+    poll interval apart, so no batched spend write is still in flight when we reset."""
+    first = client.proxy.key_info(key).spend or 0.0
+    time.sleep(client.proxy.poll_interval)
+    second = client.proxy.key_info(key).spend or 0.0
+    return second if first > 0 and first == second else None
 
 
 def _block(client: ManagementClient, key: str) -> None:
@@ -196,6 +227,32 @@ class TestKeyManagementRoutes:
             lambda: True if client.proxy.key_info(key).max_budget == 42.0 else None,
             "/key/info never reported max_budget 42.0 after /key/bulk_update before the deadline",
         )
+
+    @pytest.mark.covers("other.key_mgmt.spend_reset.resets_to_value")
+    def test_reset_spend_zeroes_recorded_spend_and_lifts_the_budget_block(
+        self, client: ManagementClient, resources: ResourceManager
+    ) -> None:
+        key = _generate_key(client, resources, KeyGenerateBody(models=[SPEND_MODEL], max_budget=TINY_BUDGET))
+        _spend_until_budget_blocks(client, key)
+        recorded = _poll(
+            client, lambda: _settled_spend(client, key), "key spend never landed in /key/info before the deadline"
+        )
+
+        reset = client.reset_key_spend(key, reset_to=0.0)
+        assert reset.previous_spend == recorded, (
+            f"reset_spend reported previous_spend {reset.previous_spend}, /key/info had recorded {recorded}"
+        )
+        assert reset.spend == 0.0, f"reset_spend to 0 reported spend {reset.spend}"
+        assert client.proxy.key_info(key).spend == 0.0, "/key/info still reports spend after the reset to 0"
+
+        def call_allowed_again() -> bool | None:
+            outcome = client.chat_status(key, SPEND_MODEL, f"after reset {unique_marker()}")
+            if _is_budget_block(outcome):
+                return None
+            assert outcome.ok, f"post-reset call failed ({outcome.status_code}): {outcome.body[:300]}"
+            return True
+
+        _ = _poll(client, call_allowed_again, "the key stayed budget-blocked after its spend was reset to 0")
 
     @pytest.mark.covers("mgmt.key.generate.admin_only")
     def test_generate_forbidden_for_non_admin_key(

--- a/tests/e2e/management/test_management_e2e.py
+++ b/tests/e2e/management/test_management_e2e.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import math
 import time
 from collections.abc import Callable
+from typing import Final
 
 import pytest
 
@@ -377,12 +378,12 @@ class TestKeyRegeneration:
 
         new_key = client.regenerate_key(old_key, grace_period=REGENERATE_GRACE_PERIOD)
         resources.defer(lambda: client.proxy.delete_key(new_key))
-        revoke_at = time.monotonic() + REGENERATE_GRACE_SECONDS
+        revoke_at: Final = time.monotonic() + REGENERATE_GRACE_SECONDS
         assert new_key != old_key, "regenerate returned the same key string, so no rotation happened"
 
         def old_accepted() -> bool | None:
             outcome = client.chat_status(old_key, "gpt-5.5", f"say hi {unique_marker()}")
-            return True if outcome.status_code != 401 else None
+            return True if outcome.ok else None
 
         _ = _poll(client, old_accepted, "old key was rejected 401 inside its grace period at the deadline")
         assert time.monotonic() < revoke_at, (

--- a/tests/e2e/management/test_management_e2e.py
+++ b/tests/e2e/management/test_management_e2e.py
@@ -42,6 +42,10 @@ from models import (
 
 pytestmark = pytest.mark.e2e
 
+REGENERATE_GRACE_PERIOD = "15s"
+REGENERATE_GRACE_SECONDS = 15.0
+
+
 def _poll[T](client: ManagementClient, attempt: Callable[[], T | None], failure: str) -> T:
     deadline = time.monotonic() + client.proxy.poll_timeout
     while time.monotonic() < deadline:
@@ -363,6 +367,36 @@ class TestKeyRegeneration:
 
         _ = _poll(
             client, old_rejected, "old key was still accepted after regeneration (never rejected 401) at the deadline"
+        )
+
+    @pytest.mark.covers("other.key_mgmt.regenerate.grace_period_honored")
+    def test_regenerate_with_grace_period_keeps_old_key_until_revoked(
+        self, client: ManagementClient, resources: ResourceManager
+    ) -> None:
+        old_key = _generate_key(client, resources, KeyGenerateBody(models=["gpt-5.5"]))
+
+        new_key = client.regenerate_key(old_key, grace_period=REGENERATE_GRACE_PERIOD)
+        resources.defer(lambda: client.proxy.delete_key(new_key))
+        revoke_at = time.monotonic() + REGENERATE_GRACE_SECONDS
+        assert new_key != old_key, "regenerate returned the same key string, so no rotation happened"
+
+        def old_accepted() -> bool | None:
+            outcome = client.chat_status(old_key, "gpt-5.5", f"say hi {unique_marker()}")
+            return True if outcome.status_code != 401 else None
+
+        _ = _poll(client, old_accepted, "old key was rejected 401 inside its grace period at the deadline")
+        assert time.monotonic() < revoke_at, (
+            f"old key was only accepted after its {REGENERATE_GRACE_PERIOD} grace period had elapsed"
+        )
+
+        def old_rejected() -> bool | None:
+            outcome = client.chat_status(old_key, "gpt-5.5", f"say hi {unique_marker()}")
+            return True if outcome.status_code == 401 else None
+
+        _ = _poll(
+            client,
+            old_rejected,
+            f"old key was still accepted past its {REGENERATE_GRACE_PERIOD} grace period (never 401) at the deadline",
         )
 
 

--- a/tests/e2e/models.py
+++ b/tests/e2e/models.py
@@ -83,6 +83,16 @@ class KeyGenerateResponse(BaseModel):
 
 class KeyRegenerateBody(BaseModel):
     key: str
+    grace_period: str | None = None
+
+
+class KeyResetSpendBody(BaseModel):
+    reset_to: float
+
+
+class KeyResetSpendResponse(BaseModel):
+    spend: float
+    previous_spend: float
 
 
 class KeyDeleteBody(BaseModel):


### PR DESCRIPTION
## TLDR

Problem this solves:

- Key spend reset, regenerate grace period, and the llm_api_routes grant had no e2e test
- All three are deterministic proxy behaviors an admin relies on daily

How it solves it:

- Drives a key over its budget, resets spend to 0, asserts /key/info and traffic both recover
- Regenerates a key with a 15s grace period, asserts the old key works then 401s
- Grants allowed_routes llm_api_routes, asserts chat and embeddings pass while /model/new stays 403

## User Flow

Before: an admin who resets spend, rotates a key with a grace period, or grants a route group gets no e2e signal when any of those breaks

1. The admin sends POST https://litellm-domain/key/{key}/reset_spend with `{"reset_to": 0}` on a key that is returning 429 budget_exceeded
2. They get a 200, but nothing in CI checks that GET /key/info now reads 0 or that the key serves traffic again
3. The same is true for POST /key/regenerate with `"grace_period": "15s"` and for a key generated with `"allowed_routes": ["llm_api_routes"]`

After: the same three admin flows are exercised on every e2e run

1. The suite generates a key with `max_budget` 0.000003, drives POST /v1/chat/completions until the 429 budget_exceeded, resets spend to 0, and expects GET /key/info at 0 and the next chat at 200
2. It regenerates a key with `"grace_period": "15s"` and expects the old key to keep returning non-401 inside the window and 401 after it
3. It generates a key with `"allowed_routes": ["llm_api_routes"]` and expects 200 from POST /v1/chat/completions and POST /embeddings but 403 from POST /model/new

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both runs are live, no mocks: the spend and route-group tests make real Anthropic, Gemini and OpenAI calls. The proxy runs from the named commit on port 4001 with a config wiring `gpt-5.5`, `claude-haiku-4-5`, `gemini-2.5-flash` and `openai-text-embedding-3-small`, `store_model_in_db: true`, `proxy_batch_write_at: 5`, a valid `LITELLM_LICENSE` (key regeneration is Enterprise-gated) and the Postgres from `.env`

```bash
python litellm/proxy/proxy_cli.py --config e2e_config.yaml --port 4001
```

### Before (f0618394c1)

1. `cd tests/e2e && PYTHONPATH=. python -m coverage_registry.collector`
2. Headline coverage: 406/544 (74.6%), Other 28/48, with `other.auth.virtual_key.route_group_allowed`, `other.key_mgmt.spend_reset.resets_to_value` and `other.key_mgmt.regenerate.grace_period_honored` in the uncovered set

### After (45cc2ed082)

1. `LITELLM_PROXY_URL=http://localhost:4001 uv run pytest tests/e2e/access_control/test_access_control_e2e.py::TestAccessControl::test_llm_api_routes_group_grants_every_llm_endpoint tests/e2e/management/test_key_management_e2e.py::TestKeyManagementRoutes::test_reset_spend_zeroes_recorded_spend_and_lifts_the_budget_block tests/e2e/management/test_management_e2e.py::TestKeyRegeneration::test_regenerate_with_grace_period_keeps_old_key_until_revoked -v`
2. Output:

```text
access_control/test_access_control_e2e.py::TestAccessControl::test_llm_api_routes_group_grants_every_llm_endpoint PASSED [ 33%]
management/test_key_management_e2e.py::TestKeyManagementRoutes::test_reset_spend_zeroes_recorded_spend_and_lifts_the_budget_block PASSED [ 66%]
management/test_management_e2e.py::TestKeyRegeneration::test_regenerate_with_grace_period_keeps_old_key_until_revoked PASSED [100%]
========================= 3 passed in 82.25s (0:01:22) =========================
```

3. `cd tests/e2e && PYTHONPATH=. python -m coverage_registry.collector --strict` now reports 409/544 (75.2%), Other 31/48
4. `uv run basedpyright tests/e2e` reports 0 errors

## Type

✅ Test

## Caveats (if any)

### Low

- The grace test runs about a minute: the old key's 60s auth-cache entry outlives the 15s grace, and the poll deadline is 120s
- With an expired or missing `LITELLM_LICENSE` the grace test fails on the regenerate call, the same way the existing regenerate test does

## QA runbook

Management calls use the master key. The regenerate steps need a valid `LITELLM_LICENSE` on the proxy; the spend steps need `ANTHROPIC_API_KEY`, and the route-group steps need `GEMINI_API_KEY` and `OPENAI_API_KEY`

- tests/e2e/management/test_key_management_e2e.py::TestKeyManagementRoutes::test_reset_spend_zeroes_recorded_spend_and_lifts_the_budget_block - resetting a budget-blocked key's spend to 0 zeroes /key/info and lets the key serve again
  - [ ] POST /key/generate with `{"models": ["claude-haiku-4-5"], "max_budget": 0.000003}`
  - [ ] POST /v1/chat/completions with that key and `{"model": "claude-haiku-4-5", "max_tokens": 16, "messages": [{"role": "user", "content": "spend"}]}` until one returns 429 with `budget_exceeded` in the body (the second call)
  - [ ] GET /key/info?key=<key> until `info.spend` is above 0 and unchanged across two reads a few seconds apart
  - [ ] POST /key/<key>/reset_spend with `{"reset_to": 0}` and expect 200 with `previous_spend` equal to that /key/info spend and `spend` 0
  - [ ] GET /key/info?key=<key> and expect `info.spend` 0
  - [ ] Repeat the POST /v1/chat/completions and expect 200 instead of the 429
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/management/test_management_e2e.py::TestKeyRegeneration::test_regenerate_with_grace_period_keeps_old_key_until_revoked - a rotated key stays valid for its grace period and is rejected once it elapses
  - [ ] POST /key/generate with `{"models": ["gpt-5.5"]}` and keep the key as OLD
  - [ ] POST /key/regenerate with `{"key": "<OLD>", "grace_period": "15s"}` and expect 200 with a different `key`
  - [ ] Immediately POST /v1/chat/completions with OLD and `{"model": "gpt-5.5", "max_tokens": 16, "messages": [{"role": "user", "content": "say hi"}]}` and expect anything but 401
  - [ ] Repeat that call after 15 seconds, allowing up to a minute more for the auth cache, and expect 401
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/access_control/test_access_control_e2e.py::TestAccessControl::test_llm_api_routes_group_grants_every_llm_endpoint - the llm_api_routes group opens every LLM endpoint while management routes stay shut
  - [ ] POST /key/generate with `{"models": [], "allowed_routes": ["llm_api_routes"]}`
  - [ ] POST /v1/chat/completions with that key and `{"model": "gemini-2.5-flash", "messages": [{"role": "user", "content": "capital of France?"}]}` and expect 200 with a non-empty `choices`
  - [ ] POST /embeddings with that key and `{"model": "openai-text-embedding-3-small", "input": "route group"}` and expect 200 with a `model` in the body
  - [ ] POST /model/new with that key and any body and expect 403 with a route-not-allowed error
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

