### PR TITLE
Add OpenRouter pricing for z-ai/glm-5.3-flash

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -38599,6 +38599,22 @@
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
+    "openrouter/z-ai/glm-5.3-flash": {
+        "input_cost_per_token": 1.5e-07,
+        "output_cost_per_token": 5e-07,
+        "cache_read_input_token_cost": 3e-08,
+        "cache_creation_input_token_cost": 0.0,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 1310720,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "source": "https://openrouter.ai/z-ai/glm-5.3-flash",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
     "openrouter/minimax/minimax-m2.1": {
         "input_cost_per_token": 2.7e-07,
         "output_cost_per_token": 1.2e-06,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -38599,6 +38599,22 @@
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
+    "openrouter/z-ai/glm-5.3-flash": {
+        "input_cost_per_token": 1.5e-07,
+        "output_cost_per_token": 5e-07,
+        "cache_read_input_token_cost": 3e-08,
+        "cache_creation_input_token_cost": 0.0,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 1310720,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "source": "https://openrouter.ai/z-ai/glm-5.3-flash",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
     "openrouter/minimax/minimax-m2.1": {
         "input_cost_per_token": 2.7e-07,
         "output_cost_per_token": 1.2e-06,


### PR DESCRIPTION
## TLDR

Problem this solves:

- `openrouter/z-ai/glm-5.3-flash` has no pricing row, so spend logs $0 or a fallback estimate
- The direct `zai/glm-5.3-flash` row exists, but not the OpenRouter one

How it solves it:

- Adds `openrouter/z-ai/glm-5.3-flash` to `model_prices_and_context_window.json` and the backup copy
- Prices are Z.ai's list prices, matching the existing `zai/glm-5.3-flash` row (OpenRouter is running a temporary 50% promo through 2026-09-09; not encoded)
- Context and max output are from `https://openrouter.ai/api/v1/models`

## User Flow

Before: a developer routing GLM 5.3 Flash through OpenRouter sees no cost for those calls

1. They send POST https://litellm-domain/v1/chat/completions with `"model": "openrouter/z-ai/glm-5.3-flash"`
2. The response comes back fine, but the spend recorded for the request is $0 because the model has no pricing row
3. They open https://litellm-domain/ui/?page=logs and see the request at $0 spend

After: the same request records real spend

1. They send the same POST with `"model": "openrouter/z-ai/glm-5.3-flash"`
2. The response comes back the same, and spend is computed from $0.15/M input, $0.50/M output, $0.03/M cache read
3. They open https://litellm-domain/ui/?page=logs and see the request with a real dollar figure

## Caveats

- OpenRouter currently shows a limited-time 50% discount for this model (through September 9, 2026). This row uses the undiscounted list price, consistent with the `zai/glm-5.3-flash` row.

## Type

🆕 New Feature

## Changes

- `model_prices_and_context_window.json`: add `openrouter/z-ai/glm-5.3-flash`
- `litellm/model_prices_and_context_window_backup.json`: same row
