### PR TITLE
test(e2e): cover Anthropic and OpenAI prompt caching, Cohere embeddings, and costed /openai chat passthrough

### DIFF
--- a/tests/e2e/llm_translation/test_cache_control.py
+++ b/tests/e2e/llm_translation/test_cache_control.py
@@ -10,6 +10,11 @@ Each case asserts the feature actually happened, not just a 200. Coverage matrix
   intentionally not covered here.
 - Vertex (gemini-2.5-flash): prompt caching via ``cache_control`` context
   caching; the second identical call must report cached prompt tokens > 0.
+- Anthropic (claude-haiku-4-5, direct): the same ``cache_control`` prefix over
+  the OpenAI-compatible route; the second call must report cache-read tokens > 0.
+- OpenAI (gpt-5.6): automatic prompt caching needs no request marker, so the
+  cacheable prefix goes out as a plain system string with a ``prompt_cache_key``
+  and the second call must report ``prompt_tokens_details.cached_tokens`` > 0.
 
 service_tier lives in test_provider_features_e2e.py.
 
@@ -21,6 +26,7 @@ built from the typed content blocks shared in ``endpoints_client.py``.
 from __future__ import annotations
 
 import time
+from collections.abc import Callable
 
 import pytest
 from pydantic import BaseModel
@@ -29,7 +35,7 @@ from e2e_config import unique_marker
 from e2e_http import Result, unwrap
 from endpoints_client import CacheControl, RichMessage, TextBlock
 from lifecycle import ResourceManager
-from models import ChatResponse, LiteLLMParamsBody, Usage
+from models import ChatBody, ChatMessage, ChatResponse, LiteLLMParamsBody, Usage
 from passthrough_client import PassthroughClient
 import os
 
@@ -37,6 +43,8 @@ pytestmark = pytest.mark.e2e
 
 BEDROCK_MODEL = "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0"
 VERTEX_MODEL = "vertex_ai/gemini-2.5-flash"
+ANTHROPIC_MODEL = "anthropic/claude-haiku-4-5-20251001"
+OPENAI_MODEL = "openai/gpt-5.6"
 
 
 class CacheChatBody(BaseModel):
@@ -89,17 +97,36 @@ def _cache_chat(
     )
 
 
+def _plain_cache_chat(
+    client: PassthroughClient, key: str, model: str, prefix: str, cache_key: str
+) -> Result[ChatResponse]:
+    """The same cacheable prefix as a plain system string, for providers that cache
+    automatically and take no per-block marker (OpenAI)."""
+    return client.proxy.chat(
+        key,
+        ChatBody(
+            model=model,
+            messages=[
+                ChatMessage(role="system", content=prefix),
+                ChatMessage(role="user", content="Reply with one word."),
+            ],
+            max_tokens=64,
+            prompt_cache_key=cache_key,
+        ),
+    )
+
+
 def _assert_cache_read_on_second_call(
-    client: PassthroughClient, key: str, model: str
+    model: str, send: Callable[[str], Result[ChatResponse]]
 ) -> None:
     prefix = _cacheable_prefix()
 
-    first = unwrap(_cache_chat(client, key, model, prefix))
+    first = unwrap(send(prefix))
     assert first.choices, f"{model}: first cache-priming call returned no choices: {first}"
 
     deadline = time.monotonic() + 30.0
     while True:
-        second = unwrap(_cache_chat(client, key, model, prefix))
+        second = unwrap(send(prefix))
         read_tokens = _cached_read_tokens(second.usage)
         if read_tokens > 0 or time.monotonic() >= deadline:
             break
@@ -125,7 +152,8 @@ class TestCacheControl:
             LiteLLMParamsBody(model=BEDROCK_MODEL, aws_region_name="us-east-1"),
         )
         resources.defer(lambda: client.proxy.delete_model(model_id))
-        _assert_cache_read_on_second_call(client, resources.key(), model)
+        key = resources.key()
+        _assert_cache_read_on_second_call(model, lambda prefix: _cache_chat(client, key, model, prefix))
 
     @pytest.mark.covers(
         "llm.chat_completions.vertex.prompt_cache_5m.nonstream.works",
@@ -145,4 +173,40 @@ class TestCacheControl:
             ),
         )
         resources.defer(lambda: client.proxy.delete_model(model_id))
-        _assert_cache_read_on_second_call(client, resources.key(), model)
+        key = resources.key()
+        _assert_cache_read_on_second_call(model, lambda prefix: _cache_chat(client, key, model, prefix))
+
+    @pytest.mark.covers(
+        "llm.chat_completions.anthropic.prompt_cache_5m.nonstream.works",
+        exercised_on=[],
+    )
+    def test_anthropic_prompt_caching_reads_cache(
+        self, client: PassthroughClient, resources: ResourceManager
+    ) -> None:
+        model = f"e2e-anthropic-cache-{unique_marker()}"
+        model_id = client.proxy.create_model(
+            model,
+            LiteLLMParamsBody(model=ANTHROPIC_MODEL, api_key="os.environ/ANTHROPIC_API_KEY"),
+        )
+        resources.defer(lambda: client.proxy.delete_model(model_id))
+        key = resources.key()
+        _assert_cache_read_on_second_call(model, lambda prefix: _cache_chat(client, key, model, prefix))
+
+    @pytest.mark.covers(
+        "llm.chat_completions.openai.prompt_cache_5m.nonstream.works",
+        exercised_on=[],
+    )
+    def test_openai_prompt_caching_reads_cache(
+        self, client: PassthroughClient, resources: ResourceManager
+    ) -> None:
+        model = f"e2e-openai-cache-{unique_marker()}"
+        model_id = client.proxy.create_model(
+            model,
+            LiteLLMParamsBody(model=OPENAI_MODEL, api_key="os.environ/OPENAI_API_KEY"),
+        )
+        resources.defer(lambda: client.proxy.delete_model(model_id))
+        key = resources.key()
+        cache_key = f"e2e-openai-cache-{unique_marker()}"
+        _assert_cache_read_on_second_call(
+            model, lambda prefix: _plain_cache_chat(client, key, model, prefix, cache_key)
+        )

--- a/tests/e2e/llm_translation/test_embeddings_endpoint_e2e.py
+++ b/tests/e2e/llm_translation/test_embeddings_endpoint_e2e.py
@@ -1,4 +1,4 @@
-"""Live e2e: POST /embeddings returns a real vector across OpenAI, Bedrock, Vertex.
+"""Live e2e: POST /embeddings returns a real vector across OpenAI, Bedrock, Vertex, Cohere.
 
 Each test registers the deployment it needs at runtime (deleted on teardown) and
 asserts a non-empty, non-zero vector came back. The LIT-3167 guard in
@@ -74,6 +74,26 @@ class TestEmbeddingsEndpoint:
                 aws_secret_access_key="os.environ/AWS_SECRET_ACCESS_KEY",
                 aws_region_name="os.environ/AWS_REGION",
             ),
+        )
+        resources.defer(lambda: endpoints_client.delete_model(model_id))
+        key = resources.key()
+
+        result = endpoints_client.embeddings(key, model, "Say this is a test!")
+        require_successful_call(result)
+        parsed = EmbeddingsResult.model_validate_json(result.body)
+        assert parsed.first_vector, f"/embeddings returned no vector: {result.body[:300]}"
+        assert any(component != 0.0 for component in parsed.first_vector), (
+            f"embedding vector is all zeros: {result.body[:300]}"
+        )
+
+    @pytest.mark.covers("llm.embeddings.cohere.basic.nonstream.works")
+    def test_cohere_embeddings_returns_vector(
+        self, endpoints_client: EndpointsClient, resources: ResourceManager
+    ) -> None:
+        model = f"e2e-embeddings-cohere-{unique_marker()}"
+        model_id = endpoints_client.create_model(
+            model,
+            LiteLLMParamsBody(model="cohere/embed-v4.0", api_key="os.environ/COHERE_API_KEY"),
         )
         resources.defer(lambda: endpoints_client.delete_model(model_id))
         key = resources.key()

--- a/tests/e2e/llm_translation/test_passthrough_e2e.py
+++ b/tests/e2e/llm_translation/test_passthrough_e2e.py
@@ -361,8 +361,14 @@ class TestOpenAIProviderPrefixChat:
 
         completion = ChatResponse.model_validate_json(result.body)
         assert completion.id, f"/openai/v1/chat/completions relayed no completion id: {result.body[:300]}"
-        content = completion.choices[0].message.content if completion.choices and completion.choices[0].message else None
-        assert content and content.strip(), f"/openai/v1/chat/completions relayed an empty completion: {result.body[:300]}"
+        content = (
+            completion.choices[0].message.content
+            if completion.choices and completion.choices[0].message
+            else None
+        )
+        assert content and content.strip(), (
+            f"/openai/v1/chat/completions relayed an empty completion: {result.body[:300]}"
+        )
         assert completion.usage is not None, f"the completion carried no usage to price from: {completion}"
 
         row = _fetch_cost_breakdown(client, completion.id)

--- a/tests/e2e/llm_translation/test_passthrough_e2e.py
+++ b/tests/e2e/llm_translation/test_passthrough_e2e.py
@@ -17,7 +17,7 @@ import pytest
 from e2e_config import CHEAP_OPENAI_MODEL, unique_marker
 from e2e_http import require_successful_call, unwrap
 from lifecycle import ResourceManager
-from models import KeyGenerateBody, SpendLogRow
+from models import ChatResponse, KeyGenerateBody, SpendLogRow
 from passthrough_client import (
     AnthropicTool,
     GeminiFunctionDeclaration,
@@ -341,6 +341,38 @@ class TestOpenAIPassthroughSpend:
         assert (row.prompt_tokens or 0) > 0, (
             f"the embeddings row logged no prompt tokens, so whatever cost it carries "
             f"was not computed from the real usage: {row}"
+        )
+
+
+class TestOpenAIProviderPrefixChat:
+    """OpenAI-format chat through the raw `/openai/{endpoint}` passthrough (LIT-4752).
+
+    The body goes to OpenAI untranslated with the proxy's own OPENAI_API_KEY swapped
+    in, so the customer gets OpenAI's real completion back, and the gateway must
+    still write a costed pass_through_endpoint row for it.
+    """
+
+    @pytest.mark.covers("llm.chat_completions.openai.passthrough.nonstream.cost_logged")
+    def test_openai_prefix_chat_returns_completion_and_logs_its_cost(
+        self, client: PassthroughClient, scoped_key: str
+    ) -> None:
+        result = client.openai_chat(scoped_key, CHEAP_OPENAI_MODEL, f"Say hi in one word. {unique_marker()}")
+        require_successful_call(result)
+
+        completion = ChatResponse.model_validate_json(result.body)
+        assert completion.id, f"/openai/v1/chat/completions relayed no completion id: {result.body[:300]}"
+        content = completion.choices[0].message.content if completion.choices and completion.choices[0].message else None
+        assert content and content.strip(), f"/openai/v1/chat/completions relayed an empty completion: {result.body[:300]}"
+        assert completion.usage is not None, f"the completion carried no usage to price from: {completion}"
+
+        row = _fetch_cost_breakdown(client, completion.id)
+        assert row.prompt_tokens == completion.usage.prompt_tokens, (
+            f"logged {row.prompt_tokens} prompt tokens, the completion the customer read "
+            f"reported {completion.usage.prompt_tokens}"
+        )
+        assert row.completion_tokens == completion.usage.completion_tokens, (
+            f"logged {row.completion_tokens} completion tokens, the completion the customer read "
+            f"reported {completion.usage.completion_tokens}"
         )
 
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Anthropic and OpenAI prompt caching over /chat/completions had no e2e test
- Cohere embeddings and the raw /openai chat passthrough were also uncovered
- Four registry cells, two of them P0, could regress with no signal

How it solves it:

- Adds a direct Anthropic case and an OpenAI case to the cache_control suite
- Both send a large prefix twice and require cache-read tokens on the second call
- Adds a cohere/embed-v4.0 deployment that must return a non-zero vector
- Adds an /openai/v1/chat/completions call that must relay a completion and log its cost

## User Flow

Before: a customer relying on prompt caching, Cohere embeddings, or the raw OpenAI passthrough finds out about a regression from their own bill or a 500

1. They send POST https://litellm-domain/v1/chat/completions twice with the same cache-marked prefix on a Claude deployment
2. The second response reports `cache_read_input_tokens: 0` and they pay full price, with nothing in CI having gone red
3. The same holds for a repeated 1024+ token prefix on an OpenAI deployment, for POST /embeddings on a Cohere deployment, and for POST /openai/v1/chat/completions logging no spend

After: each of those four flows runs on every e2e run

1. The suite registers `anthropic/claude-haiku-4-5-20251001` and `openai/gpt-5.6` through POST /model/new and sends the same long prefix twice to each
2. It expects `usage.cache_read_input_tokens` above 0 from Claude and `usage.prompt_tokens_details.cached_tokens` above 0 from OpenAI on the second call
3. It registers `cohere/embed-v4.0`, sends POST /embeddings, and expects a non-empty vector with a non-zero component
4. It sends POST /openai/v1/chat/completions with `"model": "gpt-5.5"` and expects OpenAI's completion back plus a costed spend row whose token counts match that completion's usage

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both runs are live against the real Anthropic, OpenAI and Cohere APIs, no mocks. The proxy runs from the named commit on port 4001 with a config wiring `gpt-5.5`, `claude-haiku-4-5`, `gemini-2.5-flash` and `openai-text-embedding-3-small`, `store_model_in_db: true`, `proxy_batch_write_at: 5`, and the Postgres from `.env`

```bash
python litellm/proxy/proxy_cli.py --config e2e_config.yaml --port 4001
```

### Before (f0618394c1)

1. `cd tests/e2e && PYTHONPATH=. python -m coverage_registry.collector`
2. Headline coverage: 406/544 (74.6%), Core LLMs 130/162, Non-Core LLMs 71/91, with `llm.chat_completions.anthropic.prompt_cache_5m.nonstream.works`, `llm.chat_completions.openai.prompt_cache_5m.nonstream.works`, `llm.chat_completions.openai.passthrough.nonstream.cost_logged` and `llm.embeddings.cohere.basic.nonstream.works` in the uncovered set

### After (9ac893df15)

1. `LITELLM_PROXY_URL=http://localhost:4001 uv run pytest tests/e2e/llm_translation/test_cache_control.py::TestCacheControl::test_anthropic_prompt_caching_reads_cache tests/e2e/llm_translation/test_cache_control.py::TestCacheControl::test_openai_prompt_caching_reads_cache tests/e2e/llm_translation/test_embeddings_endpoint_e2e.py::TestEmbeddingsEndpoint::test_cohere_embeddings_returns_vector tests/e2e/llm_translation/test_passthrough_e2e.py::TestOpenAIProviderPrefixChat::test_openai_prefix_chat_returns_completion_and_logs_its_cost -v`
2. Output:

```text
llm_translation/test_cache_control.py::TestCacheControl::test_anthropic_prompt_caching_reads_cache PASSED [ 25%]
llm_translation/test_cache_control.py::TestCacheControl::test_openai_prompt_caching_reads_cache PASSED [ 50%]
llm_translation/test_embeddings_endpoint_e2e.py::TestEmbeddingsEndpoint::test_cohere_embeddings_returns_vector PASSED [ 75%]
llm_translation/test_passthrough_e2e.py::TestOpenAIProviderPrefixChat::test_openai_prefix_chat_returns_completion_and_logs_its_cost PASSED [100%]
========================= 4 passed in 76.55s (0:01:16) =========================
```

3. `cd tests/e2e && PYTHONPATH=. python -m coverage_registry.collector --strict` now reports 410/544 (75.4%), Core LLMs 133/162, Non-Core LLMs 72/91
4. `uv run basedpyright tests/e2e` reports 0 errors

## Type

✅ Test

## Caveats (if any)

### Low

- Provider caches are best effort, so both cache tests retry the second call for up to 30s before failing, the same loop the Bedrock and Vertex rows already use

## QA runbook

Management calls use the master key. The proxy needs `ANTHROPIC_API_KEY`, `OPENAI_API_KEY` and `COHERE_API_KEY`, plus `store_model_in_db: true`. Prompt caches expire after a few minutes, so run each pair of calls back to back. The cacheable prefix in the tests is about 600 short sentences, roughly 5000 tokens, which clears every provider's minimum

- tests/e2e/llm_translation/test_cache_control.py::TestCacheControl::test_anthropic_prompt_caching_reads_cache - a cache-marked prefix sent twice to Claude over /chat/completions is read from cache the second time
  - [ ] POST /model/new with `{"model_name": "qa-anthropic-cache", "litellm_params": {"model": "anthropic/claude-haiku-4-5-20251001", "api_key": "os.environ/ANTHROPIC_API_KEY"}}` and POST /key/generate with `{"models": []}`
  - [ ] POST /v1/chat/completions with `{"model": "qa-anthropic-cache", "max_tokens": 64, "messages": [{"role": "system", "content": [{"type": "text", "text": "<a prefix of 4000+ tokens>", "cache_control": {"type": "ephemeral"}}]}, {"role": "user", "content": [{"type": "text", "text": "Reply with one word."}]}]}`
  - [ ] Send the identical request again within a minute and expect `usage.cache_read_input_tokens` above 0
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/llm_translation/test_cache_control.py::TestCacheControl::test_openai_prompt_caching_reads_cache - a long plain prefix sent twice to OpenAI over /chat/completions is served from OpenAI's automatic prompt cache the second time
  - [ ] POST /model/new with `{"model_name": "qa-openai-cache", "litellm_params": {"model": "openai/gpt-5.6", "api_key": "os.environ/OPENAI_API_KEY"}}` and POST /key/generate with `{"models": []}`
  - [ ] POST /v1/chat/completions with `{"model": "qa-openai-cache", "max_tokens": 64, "prompt_cache_key": "qa-openai-cache-1", "messages": [{"role": "system", "content": "<a prefix of 1024+ tokens>"}, {"role": "user", "content": "Reply with one word."}]}`
  - [ ] Send the identical request again within a minute and expect `usage.prompt_tokens_details.cached_tokens` above 0
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/llm_translation/test_embeddings_endpoint_e2e.py::TestEmbeddingsEndpoint::test_cohere_embeddings_returns_vector - a Cohere deployment returns a real embedding vector through /embeddings
  - [ ] POST /model/new with `{"model_name": "qa-cohere-embed", "litellm_params": {"model": "cohere/embed-v4.0", "api_key": "os.environ/COHERE_API_KEY"}}` and POST /key/generate with `{"models": []}`
  - [ ] POST /embeddings with `{"model": "qa-cohere-embed", "input": "Say this is a test!"}`
  - [ ] Expect 200 with `data[0].embedding` non-empty and at least one component not equal to 0
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/llm_translation/test_passthrough_e2e.py::TestOpenAIProviderPrefixChat::test_openai_prefix_chat_returns_completion_and_logs_its_cost - OpenAI-format chat through the raw /openai prefix returns OpenAI's completion and is costed
  - [ ] POST /key/generate with `{"models": []}`
  - [ ] POST /openai/v1/chat/completions with `{"model": "gpt-5.5", "max_completion_tokens": 64, "messages": [{"role": "user", "content": "Say hi in one word."}]}`
  - [ ] Expect 200 with a `chatcmpl-...` id, non-empty `choices[0].message.content`, and a `usage` object
  - [ ] GET /spend/logs?request_id=<that id> until a row appears with `call_type` `pass_through_endpoint`, `spend` above 0, and `prompt_tokens` / `completion_tokens` equal to the usage in the response
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

