### PR TITLE
test(e2e): include the first websocket frame in the passthrough realtime assertion

### DIFF
--- a/tests/e2e/llm_translation/passthrough_client.py
+++ b/tests/e2e/llm_translation/passthrough_client.py
@@ -226,6 +226,7 @@ class WebsocketHandshake(BaseModel):
 
     rejected_status: int | None = None
     first_event_type: str | None = None
+    first_frame: str | None = None
 
 
 class PassthroughBatchList(BaseModel):
@@ -422,7 +423,8 @@ class PassthroughClient:
                 return WebsocketHandshake()
             text = frame.decode("utf-8") if isinstance(frame, bytes) else frame
             return WebsocketHandshake(
-                first_event_type=WebsocketEnvelope.model_validate_json(text).type
+                first_event_type=WebsocketEnvelope.model_validate_json(text).type,
+                first_frame=text[:600],
             )
 
 

--- a/tests/e2e/llm_translation/test_passthrough_e2e.py
+++ b/tests/e2e/llm_translation/test_passthrough_e2e.py
@@ -372,7 +372,7 @@ class TestOpenAIPassthroughWebsocket:
         assert handshake.first_event_type == "session.created", (
             "the accepted socket never carried OpenAI's opening session event, so the "
             f"upgrade was not relayed upstream; the first frame was "
-            f"{handshake.first_event_type}"
+            f"{handshake.first_event_type}: {handshake.first_frame}"
         )
 
     @pytest.mark.covers("llm.responses.openai.passthrough_websocket.stream.works")


### PR DESCRIPTION
## TLDR

Problem this solves:

- The realtime passthrough e2e assertion only printed the frame type, `error`
- Triaging the failure took three CI runs to learn which refusal fired

How it solves it:

- The websocket handshake helper keeps the first frame's text
- The assertion message prints that text next to the type

## User Flow

Before: an engineer triaging a red `litellm-e2e` run cannot tell from the log why the realtime upgrade was refused

1. They open the failed `e2e - full suite` job for `tests/e2e/llm_translation/test_passthrough_e2e.py::TestOpenAIPassthroughWebsocket::test_realtime_upgrade_reaches_openai_through_the_passthrough_prefix`
2. The assertion reads `the first frame was error` and `assert 'error' == 'session.created'`, nothing else
3. They have to rerun the suite with extra instrumentation to see whether the gateway refused the upgrade or OpenAI did

After: the same log line names the refusal

1. They open the same failed job
2. The assertion reads `the first frame was error: {"type": "error", "error": {"type": "invalid_request_error", "message": "OpenAI websocket passthrough is disabled on this gateway. A proxy admin can turn it on by setting general_settings.enable_openai_websocket_passthrough to true."}}`
3. They fix the stack config without another run

## Relevant issues

The failure this surfaced is the one #39841 introduced for the e2e stack, fixed on the stack side in project-releaser

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Both runs are the `litellm-e2e-pr` pipeline with `E2E_PATHS` set to the passthrough file, against an ephemeral stack whose values do not opt into the websocket passthrough, so the test fails on both sides and the only difference is the assertion text

### Before (7672399c26)

1. https://buildkite.com/berriai-1/litellm-e2e-pr/builds/251, job `e2e - selected tests`
2. Observed output:

```
FAILED llm_translation/test_passthrough_e2e.py::TestOpenAIPassthroughWebsocket::test_realtime_upgrade_reaches_openai_through_the_passthrough_prefix - AssertionError: the accepted socket never carried OpenAI's opening session event, so the upgrade was not relayed upstream; the first frame was error
assert 'error' == 'session.created'
```

### After (0b0ed97c4c)

1. https://buildkite.com/berriai-1/litellm-e2e-pr/builds/261, job `e2e - selected tests`
2. Observed output:

```
FAILED llm_translation/test_passthrough_e2e.py::TestOpenAIPassthroughWebsocket::test_realtime_upgrade_reaches_openai_through_the_passthrough_prefix - AssertionError: the accepted socket never carried OpenAI's opening session event, so the upgrade was not relayed upstream; the first frame was error: {"type": "error", "error": {"type": "invalid_request_error", "message": "OpenAI websocket passthrough is disabled on this gateway. A proxy admin can turn it on by setting general_settings.enable_openai_websocket_passthrough to true."}}
```

3. The same test at the same commit passes once the stack opts in: https://buildkite.com/berriai-1/litellm-e2e-pr/builds/263

## Type

✅ Test

## Caveats (if any)

### Low

- The frame text is capped at 600 characters so a large session frame cannot flood the log

## QA runbook

- tests/e2e/llm_translation/test_passthrough_e2e.py::TestOpenAIPassthroughWebsocket::test_realtime_upgrade_reaches_openai_through_the_passthrough_prefix - the assertion now shows the refusing frame, so a reviewer can see which side refused without a rerun
  - [ ] Start a proxy with an `openai/gpt-realtime-2` deployment and `general_settings.enable_openai_websocket_passthrough` unset (needs OPENAI_API_KEY)
  - [ ] Connect a websocket client to ws://localhost:4000/openai_passthrough/v1/realtime?model=gpt-realtime-2 with `Authorization: Bearer <virtual key>` and read the first frame
  - [ ] Expect a frame of type `error` whose message says the passthrough is disabled on this gateway
  - [ ] Run the test against that proxy and expect its assertion message to quote that same frame
  - [ ] Set `general_settings.enable_openai_websocket_passthrough: true`, restart, reconnect, and expect the first frame to be `session.created`
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
