### PR TITLE
fix(mcp): reject URL credentials for none auth

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/exceptions.py
+++ b/litellm/proxy/_experimental/mcp_server/exceptions.py
@@ -5,6 +5,20 @@ from typing import Final
 from fastapi import HTTPException
 
 
+class MCPServerURLCredentialsError(HTTPException):
+    """A fixed, sanitized URL-credential migration error safe for operator previews."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            status_code=500,
+            detail=(
+                "misconfigured: auth_type none cannot be used with credentials embedded in the upstream URL; "
+                "remove them from the URL and configure Basic Auth with auth_type: basic and "
+                "auth_value: username:password"
+            ),
+        )
+
+
 class MCPUpstreamAuthError(Exception):
     """Raised when an upstream MCP server returns an authentication failure
     (typically HTTP 401) and the gateway should surface it transparently to

--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/adapter.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/adapter.py
@@ -19,6 +19,7 @@ from pydantic import SecretStr
 from typing_extensions import assert_never
 
 from litellm.experimental_mcp_client.client import strip_auth_scheme, to_basic_credentials
+from litellm.proxy._experimental.mcp_server.exceptions import MCPServerURLCredentialsError
 from litellm.proxy._experimental.mcp_server.oauth_utils import resolve_upstream_resource
 from litellm.proxy._experimental.mcp_server.outbound_credentials.types import (
     DEFAULT_CREDENTIAL_HEADER,
@@ -293,6 +294,8 @@ def raise_public(error: CredError) -> NoReturn:
             )
         case "misconfigured":
             raise HTTPException(status_code=500, detail=error.summary)
+        case "url_credentials_not_allowed":
+            raise MCPServerURLCredentialsError()
         case "upstream_unavailable":
             raise HTTPException(status_code=503, detail=error.summary)
         case "unsupported_mode":

--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/resolver.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/resolver.py
@@ -134,7 +134,7 @@ class UpstreamCredentialProvider:
     async def resolve_credentials(self, subject: Subject, server: ServerSpec) -> Result[httpx.Auth, CredError]:
         match server.config:
             case NoneConfig():
-                return Ok(NoOpAuth())
+                return self._none(server)
             case ApiKeyConfig() as config:
                 return self._api_key(config)
             case PassthroughConfig():
@@ -150,6 +150,15 @@ class UpstreamCredentialProvider:
             case AwsSigV4Config():
                 return _not_implemented(AuthSpecKind.aws_sigv4)
         assert_never(server.config)
+
+    def _none(self, server: ServerSpec) -> Result[httpx.Auth, CredError]:
+        try:
+            resource: Final = httpx.URL(server.resource)
+        except httpx.InvalidURL:
+            return Ok(NoOpAuth())
+        if resource.userinfo:
+            return Error(CredError.of_url_credentials_not_allowed())
+        return Ok(NoOpAuth())
 
     async def has_user_token(self, subject: Subject, server: ServerSpec) -> bool:
         """Whether a usable per-user token exists for this server (the preemptive 401's check).

--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/types.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/types.py
@@ -95,6 +95,7 @@ class CredError:
     tag: Literal[
         "unauthorized",
         "misconfigured",
+        "url_credentials_not_allowed",
         "upstream_unavailable",
         "unsupported_mode",
         "precondition_required",
@@ -103,6 +104,7 @@ class CredError:
 
     unauthorized: Unauthorized = case()  # no usable credential for this (subject, server) -> 401 challenge
     misconfigured: str = case()  # the declared mode is missing required config -> 5xx (operator)
+    url_credentials_not_allowed: None = case()
     upstream_unavailable: str = case()  # the IdP / token endpoint could not be reached -> 503
     unsupported_mode: str = case()  # a raw mode string did not parse into AuthSpecKind (boundary)
     precondition_required: str = case()  # a required per-user value (e.g. an env var) has not been provided -> 412
@@ -130,6 +132,10 @@ class CredError:
         return CredError(misconfigured=detail)
 
     @staticmethod
+    def of_url_credentials_not_allowed() -> CredError:
+        return CredError(url_credentials_not_allowed=None)
+
+    @staticmethod
     def of_upstream_unavailable(detail: str) -> CredError:
         return CredError(upstream_unavailable=detail)
 
@@ -154,6 +160,12 @@ class CredError:
                 return f"unauthorized: {self.unauthorized.detail}"
             case "misconfigured":
                 return f"misconfigured: {self.misconfigured}"
+            case "url_credentials_not_allowed":
+                return (
+                    "misconfigured: auth_type none cannot be used with credentials embedded in the upstream URL; "
+                    "remove them from the URL and configure Basic Auth with auth_type: basic and "
+                    "auth_value: username:password"
+                )
             case "upstream_unavailable":
                 return f"upstream unavailable: {self.upstream_unavailable}"
             case "unsupported_mode":

--- a/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
@@ -18,6 +18,7 @@ from litellm.exceptions import (
 )
 from litellm.proxy._experimental.mcp_server.exceptions import (
     MCPServerListError,
+    MCPServerURLCredentialsError,
     MCPUpstreamAuthError,
 )
 from litellm.proxy._experimental.mcp_server.faults.list_outcomes import (
@@ -75,6 +76,8 @@ _MCP_GUARDRAIL_REJECTIONS: Final = (
 
 
 def _connection_error_message(exc: BaseException, url: str | None, timeout_seconds: float) -> str:
+    if isinstance(exc, MCPServerURLCredentialsError):
+        return str(exc.detail)
     if isinstance(exc, TimeoutError):
         return (
             f"Failed to connect to MCP server: no response from {url or 'the server'} "

--- a/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_adapter.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_adapter.py
@@ -13,6 +13,7 @@ from fastapi import HTTPException
 from pydantic import ValidationError
 
 from litellm.experimental_mcp_client.client import MCPClient
+from litellm.proxy._experimental.mcp_server.exceptions import MCPServerURLCredentialsError
 from litellm.proxy._experimental.mcp_server.outbound_credentials.adapter import (
     oauth_protected_resource_path,
     raise_public,
@@ -440,6 +441,17 @@ def test_raise_public_maps_each_error_to_its_status(error, status):
     with pytest.raises(HTTPException) as exc_info:
         raise_public(error)
     assert exc_info.value.status_code == status
+
+
+def test_raise_public_marks_only_url_credentials_error_as_safe_for_preview():
+    with pytest.raises(HTTPException) as generic_exc_info:
+        raise_public(CredError.of_misconfigured("private operator detail"))
+    assert not isinstance(generic_exc_info.value, MCPServerURLCredentialsError)
+
+    error = CredError.of_url_credentials_not_allowed()
+    with pytest.raises(MCPServerURLCredentialsError) as url_exc_info:
+        raise_public(error)
+    assert url_exc_info.value.detail == error.summary
 
 
 def test_raise_public_emits_unauthorized_challenge():

--- a/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_resolver.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_resolver.py
@@ -117,6 +117,35 @@ async def test_none_mode_yields_a_no_op_auth():
 
 
 @pytest.mark.asyncio
+async def test_none_mode_rejects_url_userinfo():
+    spec = ServerSpec(
+        server_id="s",
+        resource="https://lit-user:s3cr3t@upstream.example.com/mcp",
+        config=NoneConfig(),
+    )
+
+    result = await UpstreamCredentialProvider().resolve_credentials(_SUBJECT, spec)
+
+    assert isinstance(result, Error)
+    assert result.error.tag == "url_credentials_not_allowed"
+    assert "Basic Auth" in result.error.summary
+    assert "auth_type: basic" in result.error.summary
+    assert "auth_value: username:password" in result.error.summary
+    assert "lit-user" not in result.error.summary
+    assert "s3cr3t" not in result.error.summary
+
+
+@pytest.mark.asyncio
+async def test_none_mode_does_not_validate_non_credential_resource():
+    spec = ServerSpec(server_id="s", resource="https://[::1", config=NoneConfig())
+
+    result = await UpstreamCredentialProvider().resolve_credentials(_SUBJECT, spec)
+
+    assert isinstance(result, Ok)
+    assert isinstance(result.ok, NoOpAuth)
+
+
+@pytest.mark.asyncio
 async def test_api_key_shared_emits_the_configured_header():
     config = ApiKeyConfig(
         header_name="X-API-Key",

--- a/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_types.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_types.py
@@ -75,6 +75,15 @@ def test_crederror_factory_sets_the_matching_tag(factory, expected_tag):
     assert "detail text" in err.summary
 
 
+def test_url_credentials_error_has_a_fixed_actionable_summary():
+    err = CredError.of_url_credentials_not_allowed()
+
+    assert err.tag == "url_credentials_not_allowed"
+    assert "Basic Auth" in err.summary
+    assert "auth_type: basic" in err.summary
+    assert "auth_value: username:password" in err.summary
+
+
 def test_apikeyconfig_requires_a_key_source():
     with pytest.raises(ValidationError):
         ApiKeyConfig()  # type: ignore[call-arg]

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -8966,6 +8966,24 @@ class TestCreateMcpClientV2Graft:
         assert isinstance(client._resolved_auth, NoOpAuth)
         assert client._mcp_auth_value is None
 
+    @pytest.mark.parametrize("auth_type", [None, MCPAuth.none])
+    async def test_none_mode_rejects_url_userinfo(self, auth_type):
+        with pytest.raises(HTTPException) as exc_info:
+            await MCPServerManager()._create_mcp_client(
+                self._http_server(
+                    auth_type=auth_type,
+                    url="https://lit-user:s3cr3t@upstream.example.com/mcp",
+                )
+            )
+
+        detail = str(exc_info.value.detail)
+        assert exc_info.value.status_code == 500
+        assert "Basic Auth" in detail
+        assert "auth_type: basic" in detail
+        assert "auth_value: username:password" in detail
+        assert "lit-user" not in detail
+        assert "s3cr3t" not in detail
+
     @pytest.mark.parametrize(
         "auth_type, token, expected_name, expected_value",
         [
@@ -11368,6 +11386,30 @@ class TestResolveOpenapiToolAuth:
         )
 
         assert "Authorization" not in (forwarded or {})
+
+    @pytest.mark.asyncio
+    async def test_none_mode_without_url_keeps_spec_path_server_unauthenticated(self):
+        server = MCPServer(
+            server_id="openapi-only",
+            name="report_api",
+            server_name="report_api",
+            url=None,
+            transport=MCPTransport.http,
+            auth_type=MCPAuth.none,
+            spec_path="https://api.example.com/openapi.json",
+        )
+
+        resolved, forwarded = await MCPServerManager().resolve_openapi_upstream_auth(
+            mcp_server=server,
+            oauth2_headers=None,
+            raw_headers=None,
+            mcp_auth_header=None,
+            user_api_key_auth=None,
+            forwarded_headers={"X-Trace": "trace-id"},
+        )
+
+        assert resolved is None
+        assert forwarded == {"X-Trace": "trace-id"}
 
 
 class TestOpenApiHandlerRelaysUpstreamAuth:

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
@@ -177,6 +177,36 @@ class TestExecuteWithMcpClient:
         assert "https://api.example.com/mcp/" in message
         assert "30s" in message
 
+    def test_connection_error_message_hides_arbitrary_http_exception_detail(self):
+        message = rest_endpoints._connection_error_message(
+            HTTPException(status_code=500, detail="secret upstream detail"),
+            "https://api.example.com/mcp/",
+            30.0,
+        )
+
+        assert "secret upstream detail" not in message
+
+    @pytest.mark.asyncio
+    async def test_none_mode_url_credentials_returns_actionable_redacted_error(self):
+        async def unreached_operation(client):
+            raise AssertionError("operation must not run for an invalid server configuration")
+
+        payload = NewMCPServerRequest(
+            server_name="example",
+            url="https://lit-user:s3cr3t@upstream.example.com/mcp",
+            auth_type=MCPAuth.none,
+        )
+
+        result = await rest_endpoints._execute_with_mcp_client(payload, unreached_operation)
+
+        message = str(result["message"])
+        assert result["error"] is True
+        assert "Basic Auth" in message
+        assert "auth_type: basic" in message
+        assert "auth_value: username:password" in message
+        assert "lit-user" not in message
+        assert "s3cr3t" not in message
+
     @pytest.mark.asyncio
     async def test_forwards_static_headers(self, monkeypatch):
         """Ensure static_headers are forwarded to the MCP client during test calls.


### PR DESCRIPTION
## TLDR

Problem this solves:

- Invalid `None` + URL-credential configurations fail as a generic upstream 401 after unauthenticated egress
- Admin previews return a generic upstream 401

How it solves it:

- Reject URL credentials before creating an upstream client
- Guide admins to explicit Basic Auth without leaking secrets

## User Flow

Before: an admin tests a credential-bearing MCP URL with `Auth Type: None` and gets an unexplained upstream 401

1. They send `POST https://litellm-domain/mcp-rest/test/tools/list` with `auth_type: none` and a URL containing `username:password@host`
2. The response says `Failed to connect to MCP server: it returned HTTP 401`
3. The upstream receives a request without an `Authorization` header

After: the same test explains how to configure the server and never sends the URL credential upstream

1. They send the same `POST https://litellm-domain/mcp-rest/test/tools/list` request
2. The response says URL credentials cannot be used with `None` and points to `auth_type: basic`
3. They move the credential to `auth_value`, use a clean URL, and the preview lists the upstream tools

## Relevant issues

- Defines `None` as contributing no upstream credential
- Keeps clean `None` and explicit Basic behavior unchanged
- Preserves URL-less OpenAPI MCP server behavior
- LIT-6981 is related customer context; this PR deliberately does not restore implicit URL Basic Auth

## Linear ticket

Resolves LIT-7077

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

The upstream is a local streamable HTTP MCP server that requires Basic Auth and exposes its request count and last `Authorization` header at `/stats`

### Before (7672399c26)

1. Test `Auth Type: None` with credentials embedded in the URL

   ```bash
   curl -sS -X POST http://127.0.0.1:46981/mcp-rest/test/tools/list \
     -H 'Authorization: Bearer sk-lit6981-local' \
     -H 'Content-Type: application/json' \
     --data '{"server_name":"implicit-basic-preview","url":"http://alice:s3cret@127.0.0.1:46982/mcp","transport":"http","auth_type":"none"}'
   ```

   ```json
   {"status":"error","error":true,"message":"Failed to connect to MCP server: it returned HTTP 401."}
   ```

2. The upstream request count increases from 4 to 5 and records no auth header

   ```bash
   curl -sS http://127.0.0.1:46982/stats
   ```

   ```json
   {"requests":5,"last_auth":null}
   ```

### After (e674097642)

1. Send the same test request

   ```bash
   curl -sS -X POST http://127.0.0.1:46981/mcp-rest/test/tools/list \
     -H 'Authorization: Bearer sk-lit6981-local' \
     -H 'Content-Type: application/json' \
     --data '{"server_name":"implicit-basic-preview","url":"http://alice:s3cret@127.0.0.1:46982/mcp","transport":"http","auth_type":"none"}'
   ```

   ```json
   {"status":"error","error":true,"message":"misconfigured: auth_type none cannot be used with credentials embedded in the upstream URL; remove them from the URL and configure Basic Auth with auth_type: basic and auth_value: username:password"}
   ```

2. The upstream request count stays at 8 and its last auth header is unchanged

   ```bash
   curl -sS http://127.0.0.1:46982/stats
   ```

   ```json
   {"requests":8,"last_auth":"Basic YWxpY2U6czNjcmV0"}
   ```

3. Explicit Basic Auth with a clean URL still lists the `echo` tool

   ```bash
   curl -sS -X POST http://127.0.0.1:46981/mcp-rest/test/tools/list \
     -H 'Authorization: Bearer sk-lit6981-local' \
     -H 'Content-Type: application/json' \
     --data '{"server_name":"explicit-basic-preview","url":"http://127.0.0.1:46982/mcp","transport":"http","auth_type":"basic","credentials":{"auth_value":"alice:s3cret"}}'
   ```

   ```json
   {"tools":[{"name":"echo","title":null,"description":"","inputSchema":{"properties":{"text":{"title":"Text","type":"string"}},"required":["text"],"title":"echoArguments","type":"object"},"outputSchema":{"properties":{"result":{"title":"Result","type":"string"}},"required":["result"],"title":"echoOutput","type":"object"},"icons":null,"annotations":null,"meta":null,"execution":null}],"error":null,"message":"Successfully retrieved tools"}
   ```

## Type

Bug Fix

## Caveats (if any)

### Low

- Create and update APIs can store the URL before runtime rejects it

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-time validation on MCP outbound auth with no change to runtime credential handling for valid setups; reduces misconfiguration and accidental credential exposure in error text.
> 
> **Overview**
> **MCP servers with `auth_type: none` can no longer use `user:pass@host` in the upstream URL.** The v2 credential resolver fails closed before any client connects when the resource URL contains userinfo, instead of sending unauthenticated requests that surface as misleading upstream 401s.
> 
> A dedicated `url_credentials_not_allowed` `CredError` maps to **`MCPServerURLCredentialsError`**, a fixed HTTP 500 message that tells operators to use `auth_type: basic` and `auth_value`—without echoing embedded secrets. Admin **test/tools/list** and **`_connection_error_message`** treat only this exception as safe to show verbatim; other `HTTPException` details stay hidden from preview responses.
> 
> **Unchanged:** plain URLs with `none`, explicit Basic auth, and OpenAPI servers with no URL (`spec_path` only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e674097642dabcd00bb1521c75246a3ac154941e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
