### PR TITLE
test: repair two CI tests broken by intentional changes

### DIFF
--- a/tests/e2e/ui/tests/tables/tableScrolling.spec.ts
+++ b/tests/e2e/ui/tests/tables/tableScrolling.spec.ts
@@ -184,6 +184,7 @@ test.describe("Admin tables scroll inside the page", () => {
     );
     try {
       await navigateToPage(page, Page.TagManagement);
+      await setRowsPerPage(page, "50");
       await expectRowsAtLeast(page, SEED_ROWS);
       expect(await rowsPaintingPastAnAncestor(page)).toEqual([]);
     } finally {
@@ -207,6 +208,7 @@ test.describe("Admin tables scroll inside the page", () => {
     );
     try {
       await navigateToPage(page, Page.ModelHubTable);
+      await setRowsPerPage(page, "50");
       await expectRowsAtLeast(page, SEED_ROWS);
       expect(await rowsPaintingPastAnAncestor(page)).toEqual([]);
     } finally {

--- a/tests/router_unit_tests/test_router_index_management.py
+++ b/tests/router_unit_tests/test_router_index_management.py
@@ -241,7 +241,7 @@ class TestRouterIndexManagement:
             "_get_deployment_by_litellm_model": "lookup by litellm_params.model, which is not indexed",
             "_finalize_adaptive_router_if_configured": 'init-time prefix scan for "auto_router/adaptive_router"; no index for prefix match',
             "config_deployments": "filters the whole list on model_info.db_model; admin path only (model add/upsert)",
-            "heuristic_v2_router_limit_violation": "counts heuristic_v2 routers across the whole list; admin path only (auto-router init/upsert)",
+            "auto_router_capability_violation": "counts gated auto-routers across the whole list; admin path only (auto-router init/upsert)",
         }
 
         # Get path to router.py


### PR DESCRIPTION
## TLDR

Problem this solves:

- `litellm_router_unit_testing` and `e2e_ui_testing` are red on staging since this afternoon
- #39674 renamed a router method the static-scan allowlist still named
- 9ba6cab889 (LIT-4738) paginated the Tags and Model Hub tables at 25 rows
- The scrolling spec seeds 40 rows and expected all of them on one page

How it solves it:

- Rename the allowlist entry to `auto_router_capability_violation`
- Select 50 rows per page before counting, as the Logs case already does

## User Flow

No user-facing change. Both edits are to tests only

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

### Before (98784360)

#### test_no_linear_scans_in_router

1. CircleCI `litellm_router_unit_testing` on the last staging-bound run: https://app.circleci.com/pipelines/gh/BerriAI/litellm/89202/workflows/2e9c2960-9fd4-4cba-bf73-5acb3101ca4f
2. Observed: `Found O(n) linear scan pattern in router.py: auto_router_capability_violation() at line 8815`. The allowlist still names the pre-rename `heuristic_v2_router_limit_violation`

#### Tags and Model Hub scrolling specs

1. CircleCI `e2e_ui_testing` on the same workflow
2. Observed: both `Tags: no row paints past the box it lives in` and `Model Hub: no row paints past the box it lives in` fail with `Expected: >= 40, Received: 25` after three attempts. The tables now page at 25

### After (da5af0cb27)

#### test_no_linear_scans_in_router

1. `python -m pytest tests/router_unit_tests/test_router_index_management.py -k test_no_linear_scans_in_router -q`
2. Observed: `1 passed, 8 deselected in 1.03s`
3. CircleCI `litellm_router_unit_testing` on this PR reports the same test as `success` (5.98s)

#### Tags and Model Hub scrolling specs

1. Brought the UI e2e stack up with `E2E_KEEP_ALIVE=1 ./run_e2e.sh` from `tests/e2e/ui` (seeded postgres, mock LLM on 8090, proxy on 4000 serving the UI built from this branch)
2. `E2E_UI_BASE_URL=http://localhost:4000 LITELLM_MASTER_KEY=sk-1234 PROXY_LOGOUT_URL=https://www.example.com MOCK_LLM_PORT=8090 npx playwright test --config playwright.config.ts tests/tables/tableScrolling.spec.ts -g "Tags|Model Hub"`
3. Observed: `2 passed (28.2s)`
4. CircleCI `e2e_ui_testing` on this PR: `139 passed (9.6m)`, and the whole `build_and_test` workflow succeeded: https://app.circleci.com/pipelines/github/BerriAI/litellm?branch=litellm_%2Fcircleci-pipeline-failure-afe848

## Type

✅ Test

## Caveats (if any)

## QA runbook

- tests/e2e/ui/tests/tables/tableScrolling.spec.ts › Tags: no row paints past the box it lives in - with 40 tags and the page size raised to 50, every row stays inside the table's own scroll box
  - [ ] Create 40 tags: `for i in $(seq 1 40); do curl -s -X POST http://localhost:4000/tag/new -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d "{\"name\": \"scroll-tag-$i\"}"; done`
  - [ ] Open http://localhost:4000/ui/?page=tag-management, set the rows-per-page selector in the table footer to 50
  - [ ] Expect at least 40 rows in the table, none of them painting below the bottom edge of the table body or of the page
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/ui/tests/tables/tableScrolling.spec.ts › Model Hub: no row paints past the box it lives in - same check on the Model Hub table with 40 models
  - [ ] Create 40 models: `for i in $(seq 1 40); do curl -s -X POST http://localhost:4000/model/new -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d "{\"model_name\": \"scroll-model-$i\", \"litellm_params\": {\"model\": \"openai/fake-gpt-4\", \"api_base\": \"http://127.0.0.1:8090/v1\", \"api_key\": \"fake-key\"}}"; done`
  - [ ] Open http://localhost:4000/ui/?page=model-hub-table, set the rows-per-page selector to 50
  - [ ] Expect at least 40 rows, none painting past the table body or the page
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


