### PR TITLE
feat(mcp): start the named server's OAuth directly for a resource-scoped gateway flow

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/db.py
+++ b/litellm/proxy/_experimental/mcp_server/db.py
@@ -4,7 +4,7 @@ import hashlib
 import json
 from collections.abc import Awaitable, Callable, Iterable, Mapping, Sequence
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Any, Final, Protocol, TypedDict, cast
+from typing import TYPE_CHECKING, Any, Final, Literal, Protocol, TypedDict, cast
 
 from litellm._logging import verbose_proxy_logger
 from litellm._uuid import uuid
@@ -120,6 +120,9 @@ class OAuthCredentialPayload(_OAuthCredentialAccessToken, total=False):
     connected_at: str
     scopes: list[str]
     server_id: str
+
+
+OAuthGrantState = Literal["valid", "refreshable", "absent"]
 
 
 class _OAuthTokenRefreshResponse(TypedDict, total=False):
@@ -1453,6 +1456,15 @@ def is_oauth_credential_expired(cred: OAuthCredentialPayload, buffer_seconds: in
         return False
 
 
+def oauth_grant_state(cred: OAuthCredentialPayload | None) -> OAuthGrantState:
+    """Classify local grant readiness without attempting a refresh or checking upstream revocation."""
+    if not cred or not cred.get("access_token"):
+        return "absent"
+    if not is_oauth_credential_expired(cred, buffer_seconds=MCP_PER_USER_TOKEN_EXPIRY_BUFFER_SECONDS):
+        return "valid"
+    return "refreshable" if cred.get("refresh_token") else "absent"
+
+
 async def get_user_oauth_credential(
     prisma_client: PrismaClient,
     user_id: str,
@@ -1715,12 +1727,11 @@ async def resolve_valid_user_oauth_token(
     dict it already holds. ``prisma_client`` is fetched lazily and only when a refresh
     actually happens, so the valid-token path never requires a DB handle.
     """
-    if not cred or not cred.get("access_token"):
+    grant: Final = oauth_grant_state(cred)
+    if cred is None or grant == "absent":
         return None
-    if not is_oauth_credential_expired(cred, buffer_seconds=MCP_PER_USER_TOKEN_EXPIRY_BUFFER_SECONDS):
+    if grant == "valid":
         return cred
-    if not cred.get("refresh_token"):
-        return None
     if prisma_client is None:
         from litellm.proxy.utils import get_prisma_client_or_throw
 

--- a/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
@@ -43,9 +43,11 @@ from litellm.proxy._experimental.mcp_server.faults import (
     render_token_fault,
 )
 from litellm.proxy._experimental.mcp_server.gateway_dcr_flow import (
+    VendorCredentialState,
     aggregate_authorize,
     aggregate_token,
     complete_connect_flow,
+    describe_connect_flow,
     introspect_gateway_token,
     is_gateway_dcr_client_id,
     is_proxy_api_resource,
@@ -798,21 +800,7 @@ def _bridge_access_denied_redirect(redirect_uri: str, state: str, mcp_server: MC
     return RedirectResponse(_append_query_params(redirect_uri, params), status_code=302)
 
 
-async def _bridge_authorize_access_denial(
-    litellm_user_id: str,
-    mcp_server: MCPServer,
-    redirect_uri: str,
-    state: str,
-) -> RedirectResponse | None:
-    """The denial redirect for a signed-in user who cannot reach the target server, or None to proceed.
-
-    Admits the user exactly as MCP egress will (the same ``reload_admitted_user`` constructor and the
-    same ``get_allowed_mcp_servers`` resolver), so an envelope is minted only when the resulting
-    session can actually list and call the server's tools. Without this gate the flow completes, the
-    client shows connected, and every tool request fail-closes to an empty list with nothing telling
-    the operator why. An availability fault (5xx, e.g. a DB outage's 503) propagates; an unknown or
-    deactivated user denies like a missing grant, fail closed.
-    """
+async def _user_can_reach_mcp_server(user_id: str, server_id: str) -> bool:
     from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import (
         MCPRequestHandler,
     )
@@ -821,13 +809,22 @@ async def _bridge_authorize_access_denial(
     )
 
     try:
-        admitted: Final = await MCPRequestHandler.reload_admitted_user(litellm_user_id)
+        admitted: Final = await MCPRequestHandler.reload_admitted_user(user_id)
     except HTTPException as exc:
         if exc.status_code >= 500:
             raise
-        return _bridge_access_denied_redirect(redirect_uri, state, mcp_server)
-    allowed_server_ids: Final = await global_mcp_server_manager.get_allowed_mcp_servers(admitted)
-    if mcp_server.server_id in allowed_server_ids:
+        return False
+    return server_id in await global_mcp_server_manager.get_allowed_mcp_servers(admitted)
+
+
+async def _bridge_authorize_access_denial(
+    litellm_user_id: str,
+    mcp_server: MCPServer,
+    redirect_uri: str,
+    state: str,
+) -> RedirectResponse | None:
+    """The denial redirect for a signed-in user who cannot reach the target server, or None to proceed."""
+    if await _user_can_reach_mcp_server(litellm_user_id, mcp_server.server_id):
         return None
     return _bridge_access_denied_redirect(redirect_uri, state, mcp_server)
 
@@ -1902,6 +1899,38 @@ async def token_endpoint(
     )
 
 
+async def _vendor_credential_state(user_id: str, server_id: str) -> VendorCredentialState:
+    """Whether the gateway itself can see a live vendor credential for this user and server.
+
+    The one reading of "authorized" the connect page displays and the finish step enforces, so
+    the button a user sees and the grant they get cannot disagree. A read fault is neither, and
+    fails the scoped grant closed."""
+    from litellm.proxy._experimental.mcp_server.db import (  # noqa: PLC0415  # circular import at module load
+        get_user_oauth_credential,
+        oauth_grant_state,
+    )
+    from litellm.proxy.proxy_server import prisma_client  # noqa: PLC0415  # circular import at module load
+
+    if prisma_client is None:
+        return "unavailable"
+    try:
+        credential: Final = await get_user_oauth_credential(prisma_client, user_id, server_id)
+    except Exception:  # noqa: BLE001  # a credential-read fault must fail the scoped grant closed
+        return "unavailable"
+    return "absent" if oauth_grant_state(credential) == "absent" else "present"
+
+
+@router.get("/authorize/flow")
+async def authorize_flow(request: Request, flow: str) -> Response:
+    return await describe_connect_flow(
+        request=request,
+        flow_handle=flow,
+        session_user_id=_session_cookie_user_id(request),
+        lookup_vendor_credential=_vendor_credential_state,
+        lookup_server_reachability=_user_can_reach_mcp_server,
+    )
+
+
 @router.post("/authorize/complete")
 async def authorize_complete(
     request: Request,
@@ -1926,6 +1955,8 @@ async def authorize_complete(
         delivery=delivery,
         team_id=team_id,
         decision=decision,
+        lookup_vendor_credential=_vendor_credential_state,
+        lookup_server_reachability=_user_can_reach_mcp_server,
     )
 
 

--- a/litellm/proxy/_experimental/mcp_server/gateway_dcr_flow.py
+++ b/litellm/proxy/_experimental/mcp_server/gateway_dcr_flow.py
@@ -152,10 +152,8 @@ _AUTH_CODE_DEBUG_KEY: Final = "gateway_authorization_code"
 
 ReloadUserFailure = Literal["unresolvable", "unavailable", "faulted", "no_active_key"]
 ReloadUser = Callable[[str], Awaitable[ReloadUserFailure | None]]
-"""Injected live-user revalidation (the token endpoint's mirror of admission):
-``None`` means the user is active; ``unavailable`` is a retryable DB outage; ``faulted`` is
-a DB fault retrying will not clear (still 503, worded so nobody just waits); anything else
-fails the grant closed."""
+VendorCredentialState = Literal["present", "absent", "unavailable"]
+"""The per-user vendor credential read has three outcomes: present, absent, or unavailable."""
 
 _DB_UNAVAILABLE_DESCRIPTION: Final = "the gateway database is unavailable; retry"
 _DB_FAULTED_DESCRIPTION: Final = (
@@ -195,6 +193,16 @@ class ConsentTeam(BaseModel):
     team_alias: str | None = None
 
 
+class LookupVendorCredential(Protocol):
+    """Injected read of a user's vendor credential for one server."""
+
+    def __call__(self, user_id: str, server_id: str, /) -> Awaitable[VendorCredentialState]: ...
+
+
+class LookupServerReachability(Protocol):
+    def __call__(self, user_id: str, server_id: str, /) -> Awaitable[bool]: ...
+
+
 class LookupConsentTeams(Protocol):
     """Injected lookup of the teams a signed-in user may bind a proxy-API credential to."""
 
@@ -203,6 +211,14 @@ class LookupConsentTeams(Protocol):
 
 async def _refuse_proxy_credential(user_id: str, team_id: str | None) -> ProxyCredentialMintFailure:
     return "unresolvable"
+
+
+async def _unavailable_vendor_credential(user_id: str, server_id: str) -> VendorCredentialState:
+    return "unavailable"
+
+
+async def _unreachable_server(user_id: str, server_id: str) -> bool:
+    return False
 
 
 class GatewayDcrClient(BaseModel):
@@ -449,7 +465,10 @@ def aggregate_authorize(
 
     A per-server RFC 8707 ``resource`` naming a gateway-managed oauth2 server scopes the
     flow to that one server: the scope is sealed into the flow, carried into the code, and
-    bound into the session token, while the connect page interlude runs exactly as before.
+    bound into the session token. The connect URL carries only the flow handle; the page
+    learns the client origin, the scoped server, and whether its vendor OAuth is done from
+    :func:`describe_connect_flow`, which reads the sealed flow, so nothing a link can carry
+    steers which server the page authorizes or names on the confirmation.
 
     Validation failures respond directly with 400 and never redirect: per RFC 6749
     section 4.1.2.1 an unvalidated redirect URI must not receive an error redirect, and
@@ -474,10 +493,7 @@ def aggregate_authorize(
         resource_server_id=scoped_server.server_id if scoped_server is not None else None,
         audience=None,
     )
-    connect_url: Final = _append_query_params(
-        f"{base_url}/ui/connect",
-        (("connect_flow", handle), ("connect_client", _origin_only(redirect_uri))),
-    )
+    connect_url: Final = _append_query_params(f"{base_url}/ui/connect", (("connect_flow", handle),))
     response: Final = RedirectResponse(connect_url, status_code=303)
     _set_flow_cookie(response, request, handle, flow)
     return response
@@ -684,6 +700,99 @@ def _origin_only(url: str) -> str:
     return f"{parsed.scheme}://{parsed.netloc}" if parsed.netloc else ""
 
 
+def _open_flow_for(
+    request: Request, flow_handle: str, session_user_id: str | None, now: datetime
+) -> _ConnectFlow | Response:
+    sealed_flow: Final = request.cookies.get(_flow_cookie_name(flow_handle))
+    if sealed_flow is None:
+        return _oauth_error(400, "invalid_request", "unknown or expired connect flow")
+    flow: Final = _open_sealed(sealed_flow, _UNPREFIXED, _ConnectFlow, _CONNECT_FLOW_DEBUG_KEY)
+    if flow is None or now.timestamp() >= flow.exp:
+        return _oauth_error(400, "invalid_request", "unknown or expired connect flow")
+    if session_user_id is None:
+        return _oauth_error(401, "login_required", "sign in to LiteLLM to finish connecting")
+    if session_user_id != flow.user_id:
+        return _oauth_error(403, "access_denied", "the signed-in user does not match this connect flow")
+    return flow
+
+
+async def _flow_target(
+    flow: _ConnectFlow, lookup_server_reachability: LookupServerReachability
+) -> tuple[Literal["unscoped", "interactive", "m2m", "stale"], MCPServer | None]:
+    if flow.resource_server_id is None:
+        return "unscoped", None
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (  # noqa: PLC0415  # import cycle
+        MCPServerManager,
+        global_mcp_server_manager,
+    )
+
+    server: Final = global_mcp_server_manager.get_mcp_server_by_id(flow.resource_server_id)
+    if (
+        server is None
+        or not server.is_gateway_managed_oauth2
+        or not await lookup_server_reachability(flow.user_id, server.server_id)
+    ):
+        return "stale", None
+    state: Final = "m2m" if MCPServerManager.effective_oauth2_flow(server) == "client_credentials" else "interactive"
+    return state, server
+
+
+class ConnectFlowDescription(TypedDict):
+    """What the connect page is allowed to know about one in-flight flow."""
+
+    state: ReadOnly[Literal["unscoped", "interactive", "m2m", "stale"]]
+    client_origin: ReadOnly[str]
+    server_id: ReadOnly[str | None]
+    server_name: ReadOnly[str | None]
+    connected: ReadOnly[bool | None]
+
+
+async def _describe_opened_flow(
+    flow: _ConnectFlow,
+    lookup_vendor_credential: LookupVendorCredential,
+    lookup_server_reachability: LookupServerReachability,
+) -> ConnectFlowDescription | Response:
+    state, server = await _flow_target(flow, lookup_server_reachability)
+    if state == "interactive" and server is not None:
+        credential: Final = await lookup_vendor_credential(flow.user_id, server.server_id)
+        if credential == "unavailable":
+            return _oauth_error(503, "temporarily_unavailable", _DB_UNAVAILABLE_DESCRIPTION)
+        interactive_description: Final[ConnectFlowDescription] = {
+            "state": state,
+            "client_origin": _origin_only(flow.redirect_uri),
+            "server_id": server.server_id,
+            "server_name": server.server_name or server.alias or server.name,
+            "connected": credential == "present",
+        }
+        return interactive_description
+    described: Final[ConnectFlowDescription] = {
+        "state": state,
+        "client_origin": _origin_only(flow.redirect_uri),
+        "server_id": None if server is None else server.server_id,
+        "server_name": None if server is None else (server.server_name or server.alias or server.name),
+        "connected": state == "m2m" or None,
+    }
+    return described
+
+
+async def describe_connect_flow(
+    request: Request,
+    flow_handle: str,
+    session_user_id: str | None,
+    lookup_vendor_credential: LookupVendorCredential,
+    lookup_server_reachability: LookupServerReachability,
+) -> Response:
+    opened: Final = _open_flow_for(request, flow_handle, session_user_id, datetime.now(timezone.utc))
+    if isinstance(opened, Response):
+        return opened
+    described: Final = await _describe_opened_flow(opened, lookup_vendor_credential, lookup_server_reachability)
+    return (
+        described
+        if isinstance(described, Response)
+        else JSONResponse(content=described, headers=TOKEN_NO_CACHE_HEADERS)
+    )
+
+
 async def complete_connect_flow(
     request: Request,
     flow_handle: str,
@@ -692,56 +801,34 @@ async def complete_connect_flow(
     delivery: str | None = None,
     team_id: str | None = None,
     decision: str | None = None,
+    lookup_vendor_credential: LookupVendorCredential = _unavailable_vendor_credential,
+    lookup_server_reachability: LookupServerReachability = _unreachable_server,
 ) -> Response:
-    """The deliberate finish step of the connect flow: mint the gateway authorization
-    code and send the browser back to the client.
+    """Mint the code only after a deliberate POST by the sealed user.
 
-    Reached by POST so a cross-site GET cannot trigger it, and bound to the HttpOnly
-    per-flow cookie plus an exact match between the signed-in user and the user sealed
-    into the flow: a link crafted by another party dies here with ``access_denied``
-    instead of minting a code for the victim's identity. The flow is single-use (an atomic
-    claim on its ``jti``), so a double-submit cannot mint two codes from one sign-in.
-
-    ``delivery`` chooses how the code reaches the client. Default (absent or
-    ``"redirect"``) is the 303 to the client's registered redirect URI. ``"manual"``
-    renders the callback URL on a page instead, for a client whose redirect URI is a
-    loopback host but which runs on a DIFFERENT machine than the browser (EC2/SSH box,
-    container): the 303 would dereference the browser machine's loopback and the code
-    would never arrive, so the user carries it over by pasting the URL into the client or
-    fetching it from the client machine's terminal. Manual delivery is honored only for
-    loopback redirect URIs; a routable redirect URI works from any browser by
-    construction, so those flows always redirect. The user who sees the page is exactly
-    the user the 303 would have carried the code to, and the same user already sees the
-    code today in the dead redirect's address bar, so the page exposes the code to no new
-    party. Unknown ``delivery`` values are rejected rather than defaulted: a client that
-    asked for manual delivery and got a dead redirect instead would silently lose its
-    code.
-
-    ``decision`` and ``team_id`` come from the native-client consent page. ``"deny"``
-    burns the flow and sends the client ``error=access_denied`` so it stops waiting;
-    ``team_id`` is sealed into the code only for proxy-API flows, where it picks which of
-    the user's teams the minted credential is attributed to.
+    A scoped flow additionally requires its sealed server to have a live vendor credential
+    before a code can be minted. The check happens before the single-use claim, so a
+    premature submit can be retried after authorization; denial deliberately bypasses it.
     """
     if delivery not in (None, "redirect", "manual"):
         return _oauth_error(400, "invalid_request", "delivery must be 'redirect' or 'manual'")
     if decision not in (None, "approve", "deny"):
         return _oauth_error(400, "invalid_request", "decision must be 'approve' or 'deny'")
-    sealed_flow: Final = request.cookies.get(_flow_cookie_name(flow_handle))
-    if sealed_flow is None:
-        return _oauth_error(400, "invalid_request", "unknown or expired connect flow")
-    flow: Final = _open_sealed(sealed_flow, _UNPREFIXED, _ConnectFlow, _CONNECT_FLOW_DEBUG_KEY)
-    if flow is None:
-        return _oauth_error(400, "invalid_request", "unknown or expired connect flow")
     now: Final = datetime.now(timezone.utc)
-    if now.timestamp() >= flow.exp:
-        return _oauth_error(400, "invalid_request", "the connect flow has expired; restart the connection")
-    if session_user_id is None:
-        return _oauth_error(401, "login_required", "sign in to LiteLLM to finish connecting")
-    if session_user_id != flow.user_id:
-        return _oauth_error(403, "access_denied", "the signed-in user does not match this connect flow")
+    opened: Final = _open_flow_for(request, flow_handle, session_user_id, now)
+    if isinstance(opened, Response):
+        return opened
+    if decision != "deny":
+        described: Final = await _describe_opened_flow(opened, lookup_vendor_credential, lookup_server_reachability)
+        if isinstance(described, Response):
+            return described
+        if described["state"] == "stale":
+            return _oauth_error(400, "invalid_request", "the requested MCP server is no longer available")
+        if described["connected"] is False:
+            return _oauth_error(400, "invalid_request", "authorize the requested MCP server before finishing")
     flow_refusal: Final = _claim_refusal(
         await _SingleUseGuard(cache).claim(
-            f"{_USED_FLOW_CACHE_PREFIX}{flow.jti}", CONNECT_FLOW_TTL_SECONDS + _CLAIM_TTL_BUFFER_SECONDS
+            f"{_USED_FLOW_CACHE_PREFIX}{opened.jti}", CONNECT_FLOW_TTL_SECONDS + _CLAIM_TTL_BUFFER_SECONDS
         ),
         replayed=_oauth_error(
             400, "invalid_request", "this connect flow was already completed; restart the connection"
@@ -750,7 +837,7 @@ async def complete_connect_flow(
     if flow_refusal is not None:
         return flow_refusal
     response: Final = (
-        _denied_flow_response(flow) if decision == "deny" else _approved_flow_response(flow, delivery, team_id, now)
+        _denied_flow_response(opened) if decision == "deny" else _approved_flow_response(opened, delivery, team_id, now)
     )
     path, secure = _cookie_path_and_secure(request)
     response.delete_cookie(key=_flow_cookie_name(flow_handle), path=path, secure=secure, httponly=True, samesite="lax")

--- a/litellm/proxy/_lazy_openapi_snapshot.json
+++ b/litellm/proxy/_lazy_openapi_snapshot.json
@@ -19746,6 +19746,46 @@
           ]
         }
       },
+      "/authorize/flow": {
+        "get": {
+          "operationId": "authorize_flow_authorize_flow_get",
+          "parameters": [
+            {
+              "in": "query",
+              "name": "flow",
+              "required": true,
+              "schema": {
+                "title": "Flow",
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "content": {
+                "application/json": {
+                  "schema": {}
+                }
+              },
+              "description": "Successful Response"
+            },
+            "422": {
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              },
+              "description": "Validation Error"
+            }
+          },
+          "summary": "Authorize Flow",
+          "tags": [
+            "mcp_discoverable"
+          ]
+        }
+      },
       "/callback": {
         "get": {
           "description": "OAuth 2.0 authorization response handler for MCP loopback clients.\n\nAccepts either:\n\n- A successful authorization response (``code`` + ``state``), which is\n  forwarded back to the validated client ``redirect_uri`` with the\n  original (un-wrapped) ``state``.\n- An error response (``error``[+``error_description``/``error_uri``]), per\n  RFC 6749 \u00a74.1.2.1. When ``state`` is present and decodes to a trusted\n  ``redirect_uri``, the error params are propagated back to the client so\n  its OAuth library can surface them. Otherwise we render an HTML error\n  page so the user is not left on an opaque 422 / blank screen.",

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 import time
 from base64 import urlsafe_b64encode
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -16,6 +17,57 @@ if TYPE_CHECKING:
     import httpx
 
     from litellm.types.mcp_server.mcp_server_manager import MCPServer
+
+
+def _stored_grant(access_token="access-token", refresh_token=None, expires_in_seconds=None, expires_at=None):
+    credential = {"type": "oauth2", "access_token": access_token}
+    if refresh_token is not None:
+        credential["refresh_token"] = refresh_token
+    if expires_in_seconds is not None:
+        credential["expires_at"] = (datetime.now(timezone.utc) + timedelta(seconds=expires_in_seconds)).isoformat()
+    if expires_at is not None:
+        credential["expires_at"] = expires_at
+    return credential
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("fields", "egress_has_token"),
+    [
+        (None, False),
+        ({"access_token": "", "refresh_token": "refresh-token"}, False),
+        ({}, True),
+        ({"expires_at": "never"}, True),
+        ({"expires_in_seconds": 600}, True),
+        ({"expires_in_seconds": 30}, False),
+        ({"expires_in_seconds": -300}, False),
+        ({"expires_in_seconds": -300, "refresh_token": ""}, False),
+        ({"expires_in_seconds": 30, "refresh_token": "refresh-token"}, True),
+        ({"expires_in_seconds": -300, "refresh_token": "refresh-token"}, True),
+    ],
+)
+async def test_vendor_credential_state_agrees_with_egress_token_resolution(monkeypatch, fields, egress_has_token):
+    from litellm.proxy._experimental.mcp_server import db as mcp_db
+    from litellm.proxy._experimental.mcp_server import discoverable_endpoints
+
+    monkeypatch.setattr(mcp_db, "MCP_PER_USER_TOKEN_EXPIRY_BUFFER_SECONDS", 60)
+    credential = _stored_grant(**fields) if fields is not None else None
+    read = AsyncMock(return_value=credential)
+    refresh = AsyncMock(return_value=_stored_grant(access_token="fresh-token", expires_in_seconds=3600))
+    prisma = MagicMock()
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", prisma)
+    monkeypatch.setattr(mcp_db, "get_user_oauth_credential", read)
+    monkeypatch.setattr(mcp_db, "refresh_user_oauth_token", refresh)
+
+    connect = await discoverable_endpoints._vendor_credential_state("user-1", "server-1")
+    read.assert_awaited_once_with(prisma, "user-1", "server-1")
+    refresh.assert_not_awaited()
+    egress = await mcp_db.resolve_valid_user_oauth_token(
+        user_id="user-1", server=MagicMock(), cred=credential, prisma_client=prisma
+    )
+
+    assert (egress is not None) is egress_has_token
+    assert connect == ("present" if egress_has_token else "absent")
 
 
 # Fixture to mock IP address check for all MCP tests

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_gateway_dcr_flow.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_gateway_dcr_flow.py
@@ -26,6 +26,7 @@ from litellm.proxy._experimental.mcp_server.gateway_dcr_flow import (
     aggregate_authorize,
     aggregate_token,
     complete_connect_flow,
+    describe_connect_flow,
     introspect_gateway_token,
     is_gateway_dcr_client_id,
     is_proxy_api_resource,
@@ -230,7 +231,7 @@ async def test_authorize_with_session_hands_browser_to_connect_page_with_flow_co
     assert location.path == "/ui/connect"
     params = parse_qs(location.query)
     handle = params["connect_flow"][0]
-    assert params["connect_client"] == ["https://claude.ai"]
+    assert set(params) == {"connect_flow"}
     set_cookie = response.headers["set-cookie"]
     assert f"{CONNECT_FLOW_COOKIE_PREFIX}{handle}" in set_cookie
     assert "HttpOnly" in set_cookie
@@ -889,14 +890,60 @@ def _opened_principal(payload):
     return admitted.principal
 
 
-async def _finish_connect_page(response):
+class _VendorCredential:
+    def __init__(self, state="present"):
+        self.calls = []
+        self.state = state
+
+    async def __call__(self, user_id, server_id):
+        self.calls.append((user_id, server_id))
+        return self.state
+
+
+class _ServerReachability:
+    def __init__(self, reachable=True):
+        self.calls = []
+        self.reachable = reachable
+
+    async def __call__(self, user_id, server_id):
+        self.calls.append((user_id, server_id))
+        return self.reachable
+
+
+async def _complete_page(response, scoped_server=None, vendor=None, reachable=None, cache=None, **overrides):
+    from unittest.mock import patch
+
     handle, cookies = _flow_cookie_from(response)
-    completed = await complete_connect_flow(
-        request=_request("/authorize/complete", cookies=cookies, method="POST"),
-        flow_handle=handle,
-        session_user_id="u1",
-        cache=DualCache(),
-    )
+    with patch(_MANAGER_PATCH) as manager:
+        manager.get_mcp_server_by_id.return_value = scoped_server
+        return await complete_connect_flow(
+            request=_request("/authorize/complete", cookies=cookies, method="POST"),
+            flow_handle=handle,
+            session_user_id="u1",
+            cache=cache or DualCache(),
+            lookup_vendor_credential=vendor or _VendorCredential(),
+            lookup_server_reachability=reachable or _ServerReachability(),
+            **overrides,
+        )
+
+
+async def _describe_page(response, scoped_server=None, vendor=None, reachable=None, session_user_id="u1", cookies=None):
+    from unittest.mock import patch
+
+    handle, flow_cookies = _flow_cookie_from(response)
+    with patch(_MANAGER_PATCH) as manager:
+        manager.get_mcp_server_by_id.return_value = scoped_server
+        return await describe_connect_flow(
+            request=_request("/authorize/flow", cookies=flow_cookies if cookies is None else cookies),
+            flow_handle=handle,
+            session_user_id=session_user_id,
+            lookup_vendor_credential=vendor or _VendorCredential(),
+            lookup_server_reachability=reachable or _ServerReachability(),
+        )
+
+
+async def _finish_connect_page(response, scoped_server=None):
+    completed = await _complete_page(response, scoped_server=scoped_server)
     return parse_qs(urlparse(completed.headers["location"]).query)["code"][0]
 
 
@@ -910,23 +957,43 @@ def _sealed_wire_json(sealed, prefix, debug_key):
 
 @pytest.mark.asyncio
 async def test_scoped_authorize_runs_connect_page_with_sealed_scope():
-    """LIT-4917: a per-server RFC 8707 resource naming a gateway-managed oauth2 server
-    seals that server into the flow. The connect page interlude runs exactly as before
-    (the scope restricts, it never skips consent), and the code minted at the finish step
-    and the session pair it redeems for are both scoped."""
+    """LIT-4917 plus LIT-7075: a per-server RFC 8707 resource naming a gateway-managed oauth2
+    server seals that server into the flow. The connect URL carries only the handle; the page
+    learns the scoped server and its vendor state from describe_connect_flow, and the finish
+    step refuses to mint a scoped code until that vendor credential exists, without burning
+    the flow. The code minted afterwards and the session pair it redeems for are both scoped."""
     from unittest.mock import patch
 
     client_id = (await _register([REDIRECT_URI]))["client_id"]
+    github = _scoped_mcp_server()
     with patch(_MANAGER_PATCH) as manager:
-        manager.get_mcp_server_by_name.return_value = _scoped_mcp_server()
+        manager.get_mcp_server_by_name.return_value = github
         response = _scoped_authorize(client_id, SCOPED_RESOURCE)
     assert response.status_code == 303
-    assert "/ui/connect" in response.headers["location"]
+    location = urlparse(response.headers["location"])
+    assert location.path == "/ui/connect"
+    assert set(parse_qs(location.query)) == {"connect_flow"}
     _, cookies = _flow_cookie_from(response)
     assert (
         _sealed_wire_json(next(iter(cookies.values())), "", "gateway_connect_flow")["resource_server_id"] == "github-id"
     )
-    code = await _finish_connect_page(response)
+    described = await _describe_page(response, scoped_server=github, vendor=_VendorCredential("absent"))
+    assert json.loads(described.body) == {
+        "state": "interactive",
+        "client_origin": "https://claude.ai",
+        "server_id": "github-id",
+        "server_name": "github",
+        "connected": False,
+    }
+    cache = DualCache()
+    premature = await _complete_page(response, scoped_server=github, vendor=_VendorCredential("absent"), cache=cache)
+    assert premature.status_code == 400
+    assert "authorize the requested MCP server" in json.loads(premature.body)["error_description"]
+    present = _VendorCredential("present")
+    completed = await _complete_page(response, scoped_server=github, vendor=present, cache=cache)
+    assert completed.status_code == 303
+    assert present.calls == [("u1", "github-id")]
+    code = parse_qs(urlparse(completed.headers["location"]).query)["code"][0]
     assert (
         _sealed_wire_json(code, GATEWAY_AUTH_CODE_PREFIX, "gateway_authorization_code")["resource_server_id"]
         == "github-id"
@@ -952,9 +1019,11 @@ async def test_scoped_authorize_runs_connect_page_with_sealed_scope():
 )
 async def test_unscoped_resources_leave_flow_and_token_byte_identical(resource, resolves):
     """Every resource shape outside 'exactly one gateway-managed server' keeps today's flow:
-    connect page interlude, and NONE of the minted artifacts carry the scope key on the
-    wire, not the flow cookie, not the code, not the session JWT, so an unscoped flow
-    started on a new pod completes on a pod whose strict models predate the claim."""
+    the generic connect grid (describe names no server, the finish step never consults the
+    vendor credential), and NONE of the minted
+    artifacts carry the scope key on the wire, not the flow cookie, not the code, not the
+    session JWT, so an unscoped flow started on a new pod completes on a pod whose strict
+    models predate the claim."""
     import base64
     from unittest.mock import patch
 
@@ -963,10 +1032,18 @@ async def test_unscoped_resources_leave_flow_and_token_byte_identical(resource, 
         manager.get_mcp_server_by_name.return_value = None if resolves is None else _scoped_mcp_server()
         response = _scoped_authorize(client_id, resource)
     assert response.status_code == 303
-    assert "/ui/connect" in response.headers["location"]
+    location = urlparse(response.headers["location"])
+    assert location.path == "/ui/connect"
+    assert set(parse_qs(location.query)) == {"connect_flow"}
     _, cookies = _flow_cookie_from(response)
     assert "resource_server_id" not in _sealed_wire_json(next(iter(cookies.values())), "", "gateway_connect_flow")
-    code = await _finish_connect_page(response)
+    vendor = _VendorCredential("absent")
+    described = await _describe_page(response, vendor=vendor)
+    assert json.loads(described.body)["state"] == "unscoped"
+    assert json.loads(described.body)["server_id"] is None
+    completed = await _complete_page(response, vendor=vendor)
+    assert vendor.calls == []
+    code = parse_qs(urlparse(completed.headers["location"]).query)["code"][0]
     assert "resource_server_id" not in _sealed_wire_json(code, GATEWAY_AUTH_CODE_PREFIX, "gateway_authorization_code")
     token_response = await _redeem(code, client_id)
     payload = json.loads(token_response.body)
@@ -979,17 +1056,148 @@ async def test_unscoped_resources_leave_flow_and_token_byte_identical(resource, 
 @pytest.mark.asyncio
 async def test_scoped_authorize_delegate_server_stays_unscoped():
     """A delegate-auth oauth2 server is outside the gateway-managed set (its keyless flow is
-    upstream PKCE via the relay), so a resource naming it never scopes the gateway flow."""
+    upstream PKCE via the relay), so a resource naming it never scopes the gateway flow and
+    never narrows the connect page to it."""
     from unittest.mock import patch
 
     client_id = (await _register([REDIRECT_URI]))["client_id"]
     with patch(_MANAGER_PATCH) as manager:
         manager.get_mcp_server_by_name.return_value = _scoped_mcp_server(delegate_auth_to_upstream=True)
         response = _scoped_authorize(client_id, SCOPED_RESOURCE)
-    assert "/ui/connect" in response.headers["location"]
+    location = urlparse(response.headers["location"])
+    assert location.path == "/ui/connect"
+    assert set(parse_qs(location.query)) == {"connect_flow"}
+    assert json.loads((await _describe_page(response)).body)["server_id"] is None
     code = await _finish_connect_page(response)
     token_response = await _redeem(code, client_id)
     assert _opened_principal(json.loads(token_response.body)).resource_server_id is None
+
+
+@pytest.mark.asyncio
+async def test_m2m_scoped_flow_mints_without_a_user_credential():
+    """A client-credentials server is already authorized by its gateway service credential, so
+    a resource-scoped flow finishes without consulting the per-user vault."""
+    from unittest.mock import patch
+
+    client_id = (await _register([REDIRECT_URI]))["client_id"]
+    m2m = _scoped_mcp_server(oauth2_flow="client_credentials")
+    with patch(_MANAGER_PATCH) as manager:
+        manager.get_mcp_server_by_name.return_value = m2m
+        response = _scoped_authorize(client_id, SCOPED_RESOURCE)
+    vendor = _VendorCredential("unavailable")
+    described = await _describe_page(response, scoped_server=m2m, vendor=vendor)
+    assert json.loads(described.body)["state"] == "m2m"
+    assert json.loads(described.body)["connected"] is True
+    assert vendor.calls == []
+    completed = await _complete_page(response, scoped_server=m2m, vendor=vendor)
+    assert completed.status_code == 303
+    assert vendor.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("oauth2_flow", ["authorization_code", "client_credentials"])
+async def test_unreachable_scoped_flow_cannot_describe_or_finish(oauth2_flow):
+    from unittest.mock import patch
+
+    client_id = (await _register([REDIRECT_URI]))["client_id"]
+    server = _scoped_mcp_server(oauth2_flow=oauth2_flow)
+    with patch(_MANAGER_PATCH) as manager:
+        manager.get_mcp_server_by_name.return_value = server
+        response = _scoped_authorize(client_id, SCOPED_RESOURCE)
+    reachable = _ServerReachability(False)
+    vendor = _VendorCredential("present")
+    described = await _describe_page(response, scoped_server=server, reachable=reachable, vendor=vendor)
+    assert json.loads(described.body) == {
+        "state": "stale",
+        "client_origin": "https://claude.ai",
+        "server_id": None,
+        "server_name": None,
+        "connected": None,
+    }
+    cache = DualCache()
+    refused = await _complete_page(response, scoped_server=server, reachable=reachable, vendor=vendor, cache=cache)
+    assert refused.status_code == 400
+    assert vendor.calls == []
+    assert reachable.calls == [("u1", "github-id"), ("u1", "github-id")]
+    completed = await _complete_page(response, scoped_server=server, vendor=vendor, cache=cache)
+    assert completed.status_code == 303
+
+
+@pytest.mark.asyncio
+async def test_stale_scoped_flow_remains_distinct_from_unscoped():
+    """A server removed after authorize stays a stale scoped flow, so the page cannot offer a
+    broader unscoped grant or report a misleading Finish action."""
+    from unittest.mock import patch
+
+    client_id = (await _register([REDIRECT_URI]))["client_id"]
+    with patch(_MANAGER_PATCH) as manager:
+        manager.get_mcp_server_by_name.return_value = _scoped_mcp_server()
+        response = _scoped_authorize(client_id, SCOPED_RESOURCE)
+    described = await _describe_page(response, scoped_server=None)
+    assert json.loads(described.body)["state"] == "stale"
+    assert json.loads(described.body)["connected"] is None
+    stale = await _complete_page(response, scoped_server=None)
+    assert stale.status_code == 400
+    assert json.loads(stale.body)["error_description"] == "the requested MCP server is no longer available"
+
+
+@pytest.mark.asyncio
+async def test_scoped_flow_deny_and_stale_server_never_need_the_vendor_credential():
+    """Cancel is the escape hatch: a scoped user who cannot finish the vendor step still ends
+    the flow with access_denied and no credential lookup. A scoped server that is no longer
+    gateway-managed refuses to mint (nothing could serve that code) but also burns nothing."""
+    from unittest.mock import patch
+
+    client_id = (await _register([REDIRECT_URI]))["client_id"]
+    github = _scoped_mcp_server()
+    with patch(_MANAGER_PATCH) as manager:
+        manager.get_mcp_server_by_name.return_value = github
+        response = _scoped_authorize(client_id, SCOPED_RESOURCE)
+    cache = DualCache()
+    skipped_reachability = _ServerReachability(False)
+    stale = await _complete_page(response, scoped_server=None, reachable=skipped_reachability, cache=cache)
+    assert stale.status_code == 400
+    assert skipped_reachability.calls == []
+    assert json.loads(stale.body)["error_description"] == "the requested MCP server is no longer available"
+    described = await _describe_page(response, scoped_server=github, vendor=_VendorCredential("unavailable"))
+    assert described.status_code == 503
+    vendor = _VendorCredential("absent")
+    deny_reachability = _ServerReachability(False)
+    denied = await _complete_page(
+        response,
+        scoped_server=github,
+        vendor=vendor,
+        reachable=deny_reachability,
+        cache=cache,
+        decision="deny",
+    )
+    assert denied.status_code == 303
+    assert parse_qs(urlparse(denied.headers["location"]).query)["error"] == ["access_denied"]
+    assert vendor.calls == []
+    assert deny_reachability.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "session_user_id, cookies, expected_status, expected_error",
+    [
+        ("u1", {}, 400, "invalid_request"),
+        ("u1", {"mcp_connect_flow_wrong": "garbage"}, 400, "invalid_request"),
+        (None, None, 401, "login_required"),
+        ("u2", None, 403, "access_denied"),
+    ],
+)
+async def test_describe_connect_flow_refuses_exactly_like_the_finish_step(
+    session_user_id, cookies, expected_status, expected_error
+):
+    """The page's read of the flow is gated the same way minting is: the HttpOnly cookie for
+    that handle must open and the signed-in user must be the sealed one. A lure link with a
+    made-up handle therefore learns nothing and starts nothing."""
+    client_id = (await _register([REDIRECT_URI]))["client_id"]
+    response = _authorize(client_id, session_user_id="u1")
+    described = await _describe_page(response, session_user_id=session_user_id, cookies=cookies)
+    assert described.status_code == expected_status
+    assert json.loads(described.body)["error"] == expected_error
 
 
 @pytest.mark.asyncio
@@ -1005,7 +1213,7 @@ async def test_token_rejects_resource_conflicting_with_sealed_scope():
     with patch(_MANAGER_PATCH) as manager:
         manager.get_mcp_server_by_name.return_value = github
         response = _scoped_authorize(client_id, SCOPED_RESOURCE)
-    code = await _finish_connect_page(response)
+    code = await _finish_connect_page(response, scoped_server=github)
 
     with patch(_MANAGER_PATCH) as manager:
         manager.get_mcp_server_by_name.return_value = linear

--- a/ui/litellm-dashboard/src/app/chat/integrations/page.tsx
+++ b/ui/litellm-dashboard/src/app/chat/integrations/page.tsx
@@ -1,43 +1,19 @@
 "use client";
 
-import { Suspense, useEffect } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { Suspense } from "react";
 import { useChatShell } from "@/contexts/ChatShellContext";
-import MCPAppsPanel from "@/components/chat/MCPAppsPanel";
-import ConnectFlowBanner from "@/components/chat/ConnectFlowBanner";
+import ConnectFlowSurface from "@/components/chat/ConnectFlowSurface";
 
 // useSearchParams() requires a Suspense boundary for static export.
 function IntegrationsPageContent() {
   const { accessToken, selectedMCPServers, setSelectedMCPServers } = useChatShell();
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const oauthReturn = searchParams.get("mcpOauthReturn");
-  // Set by the gateway DCR authorize when a DCR client sends the user here to
-  // authorize servers before finishing sign-in (see gateway_dcr_flow.py). The
-  // handle keys the sealed per-flow cookie; connect_client is the client origin
-  // for display only. connect_flow is NOT cleaned from the URL: the finish form
-  // needs it, and the sealed cookie (not the URL) is the security boundary.
-  const connectFlow = searchParams.get("connect_flow");
-  const connectClient = searchParams.get("connect_client");
-
-  // Clean up the OAuth return param after it's been consumed — real routing means
-  // we no longer need it to pick a tab, but it should not linger in the address bar.
-  useEffect(() => {
-    if (oauthReturn) {
-      const url = new URL(window.location.href);
-      url.searchParams.delete("mcpOauthReturn");
-      router.replace(url.pathname + url.search);
-    }
-  }, [oauthReturn, router]);
 
   return (
     <div className="flex-1 min-h-0 overflow-auto w-full py-8 px-8">
-      {connectFlow && <ConnectFlowBanner flowHandle={connectFlow} clientOrigin={connectClient} />}
-      <MCPAppsPanel
+      <ConnectFlowSurface
         accessToken={accessToken}
         selectedServers={selectedMCPServers}
         onChange={setSelectedMCPServers}
-        connectMode={!!connectFlow}
       />
     </div>
   );

--- a/ui/litellm-dashboard/src/app/connect/page.test.tsx
+++ b/ui/litellm-dashboard/src/app/connect/page.test.tsx
@@ -2,101 +2,29 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import ConnectPage from "./page";
 
-interface PanelProps {
+interface SurfaceProps {
   accessToken: string;
   selectedServers: string[];
   onChange: (servers: string[]) => void;
-  connectMode?: boolean;
 }
 
-interface BannerProps {
-  flowHandle: string;
-  clientOrigin: string | null;
-}
-
-const { mockReplace, mockPanel, mockBanner, state } = vi.hoisted(() => {
-  const state = {
-    oauthReturn: null as string | null,
-    connectFlow: null as string | null,
-    connectClient: null as string | null,
-  };
-  return {
-    state,
-    mockReplace: vi.fn(),
-    mockPanel: vi.fn((_props: PanelProps) => <div data-testid="mcp-apps-panel" />),
-    mockBanner: vi.fn((_props: BannerProps) => <div data-testid="connect-flow-banner" />),
-  };
-});
-
-vi.mock("next/navigation", () => ({
-  useRouter: () => ({ replace: mockReplace }),
-  useSearchParams: () => ({
-    get: (key: string) => {
-      if (key === "mcpOauthReturn") return state.oauthReturn;
-      if (key === "connect_flow") return state.connectFlow;
-      if (key === "connect_client") return state.connectClient;
-      return null;
-    },
-  }),
+const { mockSurface } = vi.hoisted(() => ({
+  mockSurface: vi.fn((_props: SurfaceProps) => <div data-testid="connect-flow-surface" />),
 }));
+
 vi.mock("@/app/(dashboard)/hooks/useAuthorized", () => ({
   default: () => ({ accessToken: "token-123" }),
 }));
-vi.mock("@/components/chat/MCPAppsPanel", () => ({ default: mockPanel }));
-vi.mock("@/components/chat/ConnectFlowBanner", () => ({ default: mockBanner }));
+vi.mock("@/components/chat/ConnectFlowSurface", () => ({ default: mockSurface }));
 
 describe("ConnectPage", () => {
   afterEach(() => {
-    state.oauthReturn = null;
-    state.connectFlow = null;
-    state.connectClient = null;
-    mockReplace.mockClear();
-    mockPanel.mockClear();
-    mockBanner.mockClear();
+    mockSurface.mockClear();
   });
 
-  it("renders the MCP connect panel with the user's access token", () => {
+  it("renders the gateway connect surface with the user's access token and an empty selection", () => {
     render(<ConnectPage />);
-    expect(screen.getByTestId("mcp-apps-panel")).toBeInTheDocument();
-    expect(mockPanel.mock.calls[0][0]).toMatchObject({ accessToken: "token-123", selectedServers: [] });
-  });
-
-  it("strips the mcpOauthReturn param from the URL after an OAuth return", () => {
-    state.oauthReturn = "apps";
-    window.history.replaceState({}, "", "/connect?mcpOauthReturn=apps");
-    render(<ConnectPage />);
-    expect(mockReplace).toHaveBeenCalledWith("/connect");
-  });
-
-  it("does not rewrite the URL when there is no OAuth return param", () => {
-    render(<ConnectPage />);
-    expect(mockReplace).not.toHaveBeenCalled();
-  });
-
-  it("mounts the gateway connect banner and puts the panel in connect mode for a DCR flow", () => {
-    state.connectFlow = "flow-handle-123";
-    state.connectClient = "https://claude.ai";
-    render(<ConnectPage />);
-    expect(screen.getByTestId("connect-flow-banner")).toBeInTheDocument();
-    expect(mockBanner.mock.calls[0][0]).toMatchObject({
-      flowHandle: "flow-handle-123",
-      clientOrigin: "https://claude.ai",
-    });
-    expect(mockPanel.mock.calls[0][0].connectMode).toBe(true);
-  });
-
-  it("shows no connect banner and leaves connect mode off for a plain visit", () => {
-    render(<ConnectPage />);
-    expect(screen.queryByTestId("connect-flow-banner")).not.toBeInTheDocument();
-    expect(mockBanner).not.toHaveBeenCalled();
-    expect(mockPanel.mock.calls[0][0].connectMode).toBe(false);
-  });
-
-  it("keeps the connect flow handle in the URL while stripping the OAuth return param", () => {
-    state.oauthReturn = "apps";
-    state.connectFlow = "flow-handle-123";
-    window.history.replaceState({}, "", "/connect?connect_flow=flow-handle-123&mcpOauthReturn=apps");
-    render(<ConnectPage />);
-    expect(mockReplace).toHaveBeenCalledWith("/connect?connect_flow=flow-handle-123");
+    expect(screen.getByTestId("connect-flow-surface")).toBeInTheDocument();
+    expect(mockSurface.mock.calls[0][0]).toMatchObject({ accessToken: "token-123", selectedServers: [] });
   });
 });

--- a/ui/litellm-dashboard/src/app/connect/page.tsx
+++ b/ui/litellm-dashboard/src/app/connect/page.tsx
@@ -1,36 +1,19 @@
 "use client";
 
-import { Suspense, useEffect, useState } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { Suspense, useState } from "react";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
-import MCPAppsPanel from "@/components/chat/MCPAppsPanel";
-import ConnectFlowBanner from "@/components/chat/ConnectFlowBanner";
+import ConnectFlowSurface from "@/components/chat/ConnectFlowSurface";
 
 function ConnectPageContent() {
   const { accessToken } = useAuthorized();
   const [selectedServers, setSelectedServers] = useState<string[]>([]);
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const oauthReturn = searchParams.get("mcpOauthReturn");
-  const connectFlow = searchParams.get("connect_flow");
-  const connectClient = searchParams.get("connect_client");
-
-  useEffect(() => {
-    if (oauthReturn) {
-      const url = new URL(window.location.href);
-      url.searchParams.delete("mcpOauthReturn");
-      router.replace(url.pathname + url.search);
-    }
-  }, [oauthReturn, router]);
 
   return (
     <div className="mx-auto w-full max-w-5xl px-8 py-8">
-      {connectFlow && <ConnectFlowBanner flowHandle={connectFlow} clientOrigin={connectClient} />}
-      <MCPAppsPanel
+      <ConnectFlowSurface
         accessToken={accessToken ?? ""}
         selectedServers={selectedServers}
         onChange={setSelectedServers}
-        connectMode={!!connectFlow}
       />
     </div>
   );

--- a/ui/litellm-dashboard/src/components/chat/ConnectFlowBanner.test.tsx
+++ b/ui/litellm-dashboard/src/components/chat/ConnectFlowBanner.test.tsx
@@ -1,59 +1,61 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
+import type { ConnectFlowStatus } from "@/components/networking";
 import ConnectFlowBanner, { isLoopbackOrigin } from "./ConnectFlowBanner";
 
 vi.mock("@/components/networking", () => ({
   getProxyBaseUrl: () => "https://gateway.example.com",
 }));
 
+vi.mock("@/hooks/useUserMcpOAuthFlow", () => ({
+  useUserMcpOAuthFlow: () => ({ startOAuthFlow: vi.fn(), status: "idle" }),
+}));
+
 afterEach(() => {
   vi.restoreAllMocks();
-  sessionStorage.clear();
 });
 
+const unscoped = (client_origin: string): ConnectFlowStatus => ({
+  state: "unscoped",
+  client_origin,
+  server_id: null,
+  server_name: null,
+  connected: null,
+});
+
+const renderBanner = (clientOrigin: string) =>
+  render(
+    <ConnectFlowBanner
+      flowHandle="flow-handle-123"
+      flow={unscoped(clientOrigin)}
+      accessToken="tok"
+      onConnected={vi.fn()}
+      failed={false}
+    />,
+  );
+
 describe("ConnectFlowBanner", () => {
-  it("posts the flow handle to the proxy /authorize/complete as a full-page form", () => {
-    const { container } = render(<ConnectFlowBanner flowHandle="flow-handle-123" clientOrigin="https://claude.ai" />);
+  it("posts only the flow handle to the proxy /authorize/complete as a full-page form", () => {
+    const { container } = renderBanner("https://claude.ai");
 
     const form = container.querySelector("form")!;
     expect(form).toHaveAttribute("method", "POST");
     expect(form).toHaveAttribute("action", "https://gateway.example.com/authorize/complete");
-
-    const hidden = form.querySelector('input[name="flow"]') as HTMLInputElement;
-    expect(hidden.value).toBe("flow-handle-123");
-    // No token, code, or secret is ever placed in the form; the sealed cookie carries them.
+    expect(screen.getByDisplayValue("flow-handle-123")).toHaveAttribute("name", "flow");
     expect(form.innerHTML).not.toContain("token");
-  });
-
-  it("shows the client origin so the user knows what they are connecting to", () => {
-    render(<ConnectFlowBanner flowHandle="h" clientOrigin="https://claude.ai" />);
-    expect(screen.getAllByText(/claude\.ai/).length).toBeGreaterThan(0);
     expect(screen.getByRole("button", { name: /finish connecting/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Cancel" })).not.toBeInTheDocument();
   });
 
-  it("falls back to a generic label when the client origin is unknown", () => {
-    render(<ConnectFlowBanner flowHandle="h" clientOrigin={null} />);
-    expect(screen.getAllByText(/the application/).length).toBeGreaterThan(0);
-  });
-
-  it("offers manual delivery for a loopback client, posted only when checked", () => {
-    const { container } = render(
-      <ConnectFlowBanner flowHandle="flow-handle-123" clientOrigin="http://localhost:3118" />,
-    );
-
-    const checkbox = container.querySelector('input[type="checkbox"][name="delivery"]') as HTMLInputElement;
-    expect(checkbox).not.toBeNull();
+  it("offers manual delivery only for a loopback client, posted only when checked", () => {
+    const loopback = renderBanner("http://localhost:3118");
+    const checkbox = loopback.container.querySelector('input[type="checkbox"][name="delivery"]') as HTMLInputElement;
     expect(checkbox.value).toBe("manual");
     expect(checkbox.checked).toBe(false);
-    expect(screen.getByText(/remote or SSH machine/i)).toBeInTheDocument();
-  });
+    loopback.unmount();
 
-  it("does not offer manual delivery for a routable client origin or an unknown one", () => {
-    const routable = render(<ConnectFlowBanner flowHandle="h" clientOrigin="https://claude.ai" />);
+    const routable = renderBanner("https://claude.ai");
     expect(routable.container.querySelector('input[name="delivery"]')).toBeNull();
-
-    const unknown = render(<ConnectFlowBanner flowHandle="h" clientOrigin={null} />);
-    expect(unknown.container.querySelector('input[name="delivery"]')).toBeNull();
   });
 
   it("classifies loopback origins like the server does", () => {
@@ -70,12 +72,9 @@ describe("ConnectFlowBanner", () => {
   });
 
   it("does NOT complete the flow on pagehide (completion requires the explicit button)", () => {
-    // Security regression: an attacker could lure a signed-in victim to their own client's
-    // authorize URL; the victim merely closing the tab must NOT deliver a victim-bound code.
-    // Completion is a deliberate button press, never a side effect of leaving the page.
     const beaconMock = vi.fn(() => true);
     vi.stubGlobal("navigator", { ...navigator, sendBeacon: beaconMock });
-    render(<ConnectFlowBanner flowHandle="flow-xyz" clientOrigin="https://claude.ai" />);
+    renderBanner("https://claude.ai");
 
     window.dispatchEvent(new Event("pagehide"));
 

--- a/ui/litellm-dashboard/src/components/chat/ConnectFlowBanner.tsx
+++ b/ui/litellm-dashboard/src/components/chat/ConnectFlowBanner.tsx
@@ -2,30 +2,18 @@
 
 import React from "react";
 import { CheckCircle } from "lucide-react";
-import { getProxyBaseUrl } from "@/components/networking";
+import { getProxyBaseUrl, ConnectFlowStatus } from "@/components/networking";
+import { OAuth2ConnectButton } from "@/components/chat/MCPAppsPanel";
 
 interface Props {
   flowHandle: string;
-  clientOrigin: string | null;
+  flow?: ConnectFlowStatus;
+  accessToken: string;
+  onConnected: () => void;
+  failed: boolean;
 }
 
-/**
- * The interlude shown when a DCR client (Claude Desktop, MCP Inspector) sends the user
- * through the gateway sign-in and lands them on the apps grid to authorize servers. The
- * grid below authorizes individual servers into the per-user vault; this banner is the
- * finish step that returns the user to the client.
- *
- * Finishing requires the explicit "Finish connecting" button: a native form POST to the proxy's
- * /authorize/complete, which mints the gateway authorization code and 303-redirects to the DCR
- * client's own redirect URI (the full-page navigation carries the HttpOnly per-flow cookie and
- * follows the cross-origin redirect to the client's loopback).
- *
- * The button press IS the consent gate and must not be bypassed. An earlier version auto-finished
- * on tab close via navigator.sendBeacon; that let an attacker who lured a signed-in victim to their
- * own client's authorize URL harvest a victim-bound code the moment the victim closed the tab
- * (no click). Merely visiting the authorize URL is attacker-inducible, so completion has to be a
- * deliberate user action, not a side effect of leaving the page.
- */
+/** Finish remains an explicit POST because a cross-site navigation must never mint a code. */
 export function isLoopbackOrigin(origin: string | null): boolean {
   if (!origin) return false;
   try {
@@ -36,10 +24,44 @@ export function isLoopbackOrigin(origin: string | null): boolean {
   }
 }
 
-const ConnectFlowBanner: React.FC<Props> = ({ flowHandle, clientOrigin }) => {
+const copyFor = (flow: ConnectFlowStatus | undefined, failed: boolean): readonly [string, string] => {
+  const clientLabel = flow?.client_origin ?? "the application";
+  const serverLabel = flow?.server_name ?? "the requested MCP server";
+  if (failed || flow === undefined || flow.state === "stale") {
+    return [
+      "The connection cannot continue",
+      `The gateway could not validate this connection. Cancel to return to ${clientLabel}.`,
+    ];
+  }
+  if (flow.state === "unscoped") {
+    return [
+      `Connect your MCP servers to ${clientLabel}`,
+      `Authorize the servers you want to use below, then click Finish connecting to return to ${clientLabel}.`,
+    ];
+  }
+  if (flow.state === "interactive" && !flow.connected) {
+    return [
+      `Allow ${clientLabel} to use ${serverLabel}`,
+      `Authorize ${serverLabel} below to continue, or cancel to send ${clientLabel} away.`,
+    ];
+  }
+  return [
+    `Allow ${clientLabel} to use ${serverLabel}`,
+    `Click Finish connecting to give ${clientLabel} access to ${serverLabel} as you.`,
+  ];
+};
+
+const ConnectFlowBanner: React.FC<Props> = ({ flowHandle, flow, accessToken, onConnected, failed }) => {
   const action = `${getProxyBaseUrl()}/authorize/complete`;
-  const clientLabel = clientOrigin ?? "the application";
-  const loopbackClient = isLoopbackOrigin(clientOrigin);
+  const state = failed || flow === undefined ? "stale" : flow.state;
+  const canFinish = state === "unscoped" || (state !== "stale" && flow?.connected === true);
+  const canCancel = state !== "unscoped";
+  const loopbackClient = isLoopbackOrigin(flow?.client_origin ?? null);
+  const vendorServer =
+    state === "interactive" && flow?.connected === false && flow.server_id !== null
+      ? { server_id: flow.server_id, server_name: flow.server_name }
+      : null;
+  const copy = copyFor(flow, failed);
 
   return (
     <div className="mb-6 rounded-lg border border-primary/30 bg-primary/5 px-5 py-4">
@@ -47,27 +69,48 @@ const ConnectFlowBanner: React.FC<Props> = ({ flowHandle, clientOrigin }) => {
         <div className="flex items-start gap-3 min-w-0">
           <CheckCircle className="h-5 w-5 text-primary shrink-0 mt-0.5" />
           <div className="min-w-0">
-            <p className="text-sm font-semibold text-foreground">Connect your MCP servers to {clientLabel}</p>
-            <p className="text-[13px] text-muted-foreground mt-0.5">
-              Authorize the servers you want to use below, then click Finish connecting to return to {clientLabel}.
-            </p>
+            <p className="text-sm font-semibold text-foreground">{copy[0]}</p>
+            <p className="text-[13px] text-muted-foreground mt-0.5">{copy[1]}</p>
           </div>
         </div>
-        <form method="POST" action={action} className="shrink-0">
-          <input type="hidden" name="flow" value={flowHandle} />
-          <button
-            type="submit"
-            className="h-[38px] rounded-md bg-primary px-4 text-sm font-semibold text-primary-foreground hover:bg-primary/90"
-          >
-            Finish connecting
-          </button>
-          {loopbackClient && (
-            <label className="mt-2 flex items-center gap-2 text-[13px] text-muted-foreground">
-              <input type="checkbox" name="delivery" value="manual" />
-              My client is on a remote or SSH machine
-            </label>
+        <div className="flex shrink-0 gap-2">
+          {vendorServer !== null && (
+            <OAuth2ConnectButton
+              server={vendorServer}
+              accessToken={accessToken}
+              onConnect={onConnected}
+              variant="button"
+              autoStartKey={`litellm-mcp-autostart:${flowHandle}`}
+            />
           )}
-        </form>
+          <form method="POST" action={action}>
+            <input type="hidden" name="flow" value={flowHandle} />
+            {canFinish && (
+              <button
+                type="submit"
+                className="h-[38px] rounded-md bg-primary px-4 text-sm font-semibold text-primary-foreground hover:bg-primary/90"
+              >
+                Finish connecting
+              </button>
+            )}
+            {canCancel && (
+              <button
+                type="submit"
+                name="decision"
+                value="deny"
+                className="ml-2 h-[38px] rounded-md border px-4 text-sm font-semibold text-foreground hover:bg-accent/40"
+              >
+                Cancel
+              </button>
+            )}
+            {loopbackClient && (
+              <label className="mt-2 flex items-center gap-2 text-[13px] text-muted-foreground">
+                <input type="checkbox" name="delivery" value="manual" />
+                My client is on a remote or SSH machine
+              </label>
+            )}
+          </form>
+        </div>
       </div>
     </div>
   );

--- a/ui/litellm-dashboard/src/components/chat/ConnectFlowSurface.test.tsx
+++ b/ui/litellm-dashboard/src/components/chat/ConnectFlowSurface.test.tsx
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import ConnectFlowSurface from "./ConnectFlowSurface";
+import { fetchConnectFlow } from "@/components/networking";
+
+const { startOAuthFlow, state, onSuccess } = vi.hoisted(() => ({
+  startOAuthFlow: vi.fn(),
+  onSuccess: { current: undefined as (() => void) | undefined },
+  state: { oauthReturn: null as string | null, connectFlow: null as string | null },
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: vi.fn() }),
+  useSearchParams: () => ({
+    get: (key: string) => ({ mcpOauthReturn: state.oauthReturn, connect_flow: state.connectFlow })[key] ?? null,
+  }),
+}));
+vi.mock("@/components/networking", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/components/networking")>()),
+  fetchConnectFlow: vi.fn(),
+  getProxyBaseUrl: () => "https://gateway.example.com",
+}));
+vi.mock("@/components/chat/MCPAppsPanel", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/components/chat/MCPAppsPanel")>()),
+  default: () => <div data-testid="mcp-apps-panel" />,
+}));
+vi.mock("@/hooks/useUserMcpOAuthFlow", () => ({
+  useUserMcpOAuthFlow: ({ onSuccess: success }: { onSuccess: () => void }) => {
+    onSuccess.current = success;
+    return { startOAuthFlow, status: "idle" };
+  },
+}));
+
+const flow = (state: "unscoped" | "interactive" | "m2m" | "stale", connected: boolean | null = null) => ({
+  state,
+  client_origin: "https://claude.ai",
+  server_id: state === "interactive" || state === "m2m" ? "s-design" : null,
+  server_name: state === "interactive" || state === "m2m" ? "design_tool" : null,
+  connected,
+});
+
+const renderSurface = () =>
+  render(
+    <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+      <ConnectFlowSurface accessToken="token-123" selectedServers={[]} onChange={vi.fn()} />
+    </QueryClientProvider>,
+  );
+
+afterEach(() => {
+  state.oauthReturn = null;
+  state.connectFlow = null;
+  onSuccess.current = undefined;
+  sessionStorage.clear();
+  vi.clearAllMocks();
+});
+
+describe("ConnectFlowSurface", () => {
+  it.each([
+    { result: flow("unscoped"), grid: true, finish: true, cancel: false, oauthStarts: 0 },
+    { result: flow("interactive", false), grid: false, finish: false, cancel: true, oauthStarts: 1 },
+    { result: flow("interactive", true), grid: false, finish: true, cancel: true, oauthStarts: 0 },
+    { result: flow("m2m", true), grid: false, finish: true, cancel: true, oauthStarts: 0 },
+    { result: flow("stale"), grid: false, finish: false, cancel: true, oauthStarts: 0 },
+  ])(
+    "renders $result.state without widening its action surface",
+    async ({ result, grid, finish, cancel, oauthStarts }) => {
+      state.connectFlow = "flow-handle-123";
+      vi.mocked(fetchConnectFlow).mockResolvedValue(result);
+      renderSurface();
+
+      await screen.findByRole("button", { name: /finish connecting|cancel|connect/i });
+      await waitFor(() => expect(startOAuthFlow).toHaveBeenCalledTimes(oauthStarts));
+      expect(screen.queryByTestId("mcp-apps-panel") !== null).toBe(grid);
+      expect(screen.queryByRole("button", { name: /finish connecting/i }) !== null).toBe(finish);
+      expect(screen.queryByRole("button", { name: "Cancel" }) !== null).toBe(cancel);
+    },
+  );
+
+  it("keeps the grid and Finish hidden until the gateway accepts a handle", () => {
+    state.connectFlow = "flow-handle-123";
+    vi.mocked(fetchConnectFlow).mockReturnValue(new Promise(() => {}));
+    renderSurface();
+
+    expect(screen.queryByTestId("mcp-apps-panel")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /finish connecting/i })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toHaveAttribute("value", "deny");
+  });
+
+  it("keeps the grid and Finish hidden when flow validation fails", async () => {
+    state.connectFlow = "invalid-handle";
+    vi.mocked(fetchConnectFlow).mockRejectedValue(new Error("invalid flow"));
+    renderSurface();
+
+    await screen.findByRole("button", { name: "Cancel" });
+    expect(screen.queryByTestId("mcp-apps-panel")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /finish connecting/i })).not.toBeInTheDocument();
+  });
+
+  it("refetches the sealed flow after the vendor connection completes", async () => {
+    state.connectFlow = "flow-handle-123";
+    vi.mocked(fetchConnectFlow)
+      .mockResolvedValueOnce(flow("interactive", false))
+      .mockResolvedValueOnce(flow("interactive", true));
+    renderSurface();
+
+    await waitFor(() => expect(startOAuthFlow).toHaveBeenCalledOnce());
+    await act(async () => onSuccess.current?.());
+
+    await screen.findByRole("button", { name: /finish connecting/i });
+  });
+
+  it("renders the ordinary panel without a flow handle", () => {
+    renderSurface();
+    expect(fetchConnectFlow).not.toHaveBeenCalled();
+    expect(screen.getByTestId("mcp-apps-panel")).toBeInTheDocument();
+  });
+});

--- a/ui/litellm-dashboard/src/components/chat/ConnectFlowSurface.tsx
+++ b/ui/litellm-dashboard/src/components/chat/ConnectFlowSurface.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import React, { useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
+import MCPAppsPanel from "@/components/chat/MCPAppsPanel";
+import ConnectFlowBanner from "@/components/chat/ConnectFlowBanner";
+import { fetchConnectFlow } from "@/components/networking";
+
+interface Props {
+  accessToken: string;
+  selectedServers: string[];
+  onChange: (servers: string[]) => void;
+}
+
+/** Renders the sealed gateway connect flow without trusting URL context. */
+const ConnectFlowSurface: React.FC<Props> = ({ accessToken, selectedServers, onChange }) => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const oauthReturn = searchParams.get("mcpOauthReturn");
+  const connectFlow = searchParams.get("connect_flow");
+
+  useEffect(() => {
+    if (oauthReturn) {
+      const url = new URL(window.location.href);
+      url.searchParams.delete("mcpOauthReturn");
+      router.replace(url.pathname + url.search);
+    }
+  }, [oauthReturn, router]);
+
+  const flowQuery = {
+    queryKey: ["gateway-connect-flow", connectFlow],
+    queryFn: () => fetchConnectFlow(connectFlow!),
+    enabled: !!connectFlow,
+    retry: false,
+  };
+  const { data: flow, isError, refetch } = useQuery(flowQuery);
+
+  if (connectFlow === null) {
+    return <MCPAppsPanel accessToken={accessToken} selectedServers={selectedServers} onChange={onChange} />;
+  }
+
+  return (
+    <>
+      <ConnectFlowBanner
+        flowHandle={connectFlow}
+        flow={flow}
+        accessToken={accessToken}
+        onConnected={refetch}
+        failed={isError}
+      />
+      {flow?.state === "unscoped" && (
+        <MCPAppsPanel accessToken={accessToken} selectedServers={selectedServers} onChange={onChange} connectMode />
+      )}
+    </>
+  );
+};
+
+export default ConnectFlowSurface;

--- a/ui/litellm-dashboard/src/components/chat/MCPAppsPanel.test.tsx
+++ b/ui/litellm-dashboard/src/components/chat/MCPAppsPanel.test.tsx
@@ -89,6 +89,13 @@ describe("MCPAppsPanel logos", () => {
 
 const connectServers = [
   {
+    server_id: "s-m2m",
+    server_name: "service_tool",
+    auth_type: "oauth2",
+    oauth2_flow: "client_credentials",
+    connected_app_reachable: true,
+  },
+  {
     server_id: "s-reach",
     server_name: "reachable_srv",
     auth_type: "none",
@@ -124,6 +131,8 @@ describe("MCPAppsPanel connected-app reachability (LIT-4861)", () => {
     expect(vi.mocked(fetchMCPServers)).toHaveBeenCalledWith("tok", undefined, true);
     expect(screen.queryByText("unreachable_srv")).not.toBeInTheDocument();
     expect(screen.getByText("Connected (1)")).toBeInTheDocument();
+    expect(screen.getByText("service_tool")).toBeInTheDocument();
+    expect(screen.queryByText("Connect", { exact: true })).not.toBeInTheDocument();
     const toolCountFetchedIds = vi.mocked(listMCPTools).mock.calls.map((call) => call[1]);
     expect(toolCountFetchedIds).toContain("s-reach");
     expect(toolCountFetchedIds).not.toContain("s-unreach");

--- a/ui/litellm-dashboard/src/components/chat/MCPAppsPanel.tsx
+++ b/ui/litellm-dashboard/src/components/chat/MCPAppsPanel.tsx
@@ -13,23 +13,32 @@ import {
   getMCPOAuthUserCredentialStatus,
   listMCPTools,
 } from "../networking";
-import { AUTH_TYPE, MCPServer, MCPTool, handleTransport, isUnsupportedOnGatewayConnect } from "../mcp_tools/types";
+import {
+  getMcpOAuthMode,
+  MCPServer,
+  MCPTool,
+  handleTransport,
+  isUnsupportedOnGatewayConnect,
+} from "../mcp_tools/types";
 import { Logo } from "@/components/molecules/logo/Logo";
 import { toast } from "@/lib/toast";
 import { useUserMcpOAuthFlow } from "@/hooks/useUserMcpOAuthFlow";
+import { getSecureItem, setSecureItem } from "@/utils/secureStorage";
 
 interface OAuth2ConnectButtonProps {
-  server: MCPServer;
+  server: Pick<MCPServer, "server_id" | "server_name" | "alias">;
   accessToken: string;
   onConnect: (serverId: string) => void;
   variant?: "badge" | "button";
+  autoStartKey?: string | null;
 }
 
-const OAuth2ConnectButton: React.FC<OAuth2ConnectButtonProps> = ({
+export const OAuth2ConnectButton: React.FC<OAuth2ConnectButtonProps> = ({
   server,
   accessToken,
   onConnect,
   variant = "badge",
+  autoStartKey = null,
 }) => {
   const name = server.server_name ?? server.alias ?? server.server_id;
   const { startOAuthFlow, status } = useUserMcpOAuthFlow({
@@ -38,6 +47,12 @@ const OAuth2ConnectButton: React.FC<OAuth2ConnectButtonProps> = ({
     serverAlias: name,
     onSuccess: useCallback(() => onConnect(server.server_id), [onConnect, server.server_id]),
   });
+
+  useEffect(() => {
+    if (autoStartKey === null || status !== "idle" || getSecureItem(autoStartKey) !== null) return;
+    setSecureItem(autoStartKey, "1");
+    startOAuthFlow();
+  }, [autoStartKey, status, startOAuthFlow]);
 
   const loading = status === "authorizing" || status === "exchanging";
 
@@ -190,7 +205,7 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange,
         if (!isCurrentLoad()) return;
         const list: MCPServer[] = Array.isArray(serverData) ? serverData : serverData?.data ?? [];
         const reachable = connectMode ? list.filter((s) => s.connected_app_reachable !== false) : list;
-        const oauthServers = reachable.filter((s) => s.auth_type === AUTH_TYPE.OAUTH2);
+        const oauthServers = reachable.filter((s) => getMcpOAuthMode(s) === "authorization_code");
         commitServers(reachable);
         setOauthChecking(new Set(oauthServers.map((s) => s.server_id)));
         setLoading(false);
@@ -274,7 +289,10 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange,
         <span className="text-[11px] text-muted-foreground shrink-0 whitespace-nowrap">{unavailabilityLabel}</span>
       );
     }
-    if (server.auth_type === AUTH_TYPE.OAUTH2) {
+    if (getMcpOAuthMode(server) === "m2m") {
+      return <CheckCircle className="h-3.5 w-3.5 text-success shrink-0" />;
+    }
+    if (getMcpOAuthMode(server) === "authorization_code") {
       if (oauthConnected.has(server.server_id)) {
         return <CheckCircle className="h-3.5 w-3.5 text-success shrink-0" />;
       }
@@ -339,7 +357,10 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange,
       if (unavailabilityLabel !== null) {
         return <span className="text-[13px] text-muted-foreground py-2.5 shrink-0">{unavailabilityLabel}</span>;
       }
-      if (detailServer.auth_type !== AUTH_TYPE.OAUTH2) {
+      if (getMcpOAuthMode(detailServer) === "m2m") {
+        return <span className="text-[13px] text-muted-foreground">Authorized</span>;
+      }
+      if (getMcpOAuthMode(detailServer) !== "authorization_code") {
         return (
           <Button
             variant={isConnected ? "outline" : "default"}

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -4976,6 +4976,24 @@ export const fetchDiscoverableMCPServers = async (accessToken: string) => {
   }
 };
 
+export interface ConnectFlowStatus {
+  state: "unscoped" | "interactive" | "m2m" | "stale";
+  client_origin: string;
+  server_id: string | null;
+  server_name: string | null;
+  connected: boolean | null;
+}
+
+/**
+ * What the gateway says about one in-flight connect flow, read from the sealed HttpOnly
+ * flow cookie rather than from the address bar (LIT-7075): the client asking, the server
+ * the flow is scoped to, and whether that server's vendor OAuth is already done. Sent with
+ * no access token; the flow and session cookies are the credential, exactly as they are for
+ * the finish form this page posts.
+ */
+export const fetchConnectFlow = async (flowHandle: string): Promise<ConnectFlowStatus> =>
+  apiClient.get(`/authorize/flow`, { query: { flow: flowHandle }, credentials: "include" });
+
 export const fetchMCPServers = async (accessToken: string, teamId?: string | null, connectedAppView?: boolean) => {
   try {
     return await apiClient.get(`/v1/mcp/server`, {

--- a/ui/litellm-dashboard/src/lib/http/client.test.ts
+++ b/ui/litellm-dashboard/src/lib/http/client.test.ts
@@ -41,6 +41,15 @@ describe("createApiClient", () => {
     expect(init.body).toBeUndefined();
   });
 
+  it("forwards the browser credential policy", async () => {
+    const fetchImpl = vi.fn(async () => okResponse({}));
+    const client = createApiClient({ getBaseUrl: () => "https://proxy.example", fetchImpl });
+
+    await client.get("/authorize/flow", { credentials: "include" });
+
+    expect(fetchImpl.mock.calls[0][1].credentials).toBe("include");
+  });
+
   it("JSON-serializes the body for writes", async () => {
     const fetchImpl = vi.fn(async () => okResponse({}));
     const client = createApiClient({ getBaseUrl: () => "", fetchImpl });

--- a/ui/litellm-dashboard/src/lib/http/client.ts
+++ b/ui/litellm-dashboard/src/lib/http/client.ts
@@ -25,6 +25,8 @@ export interface RequestOptions {
   query?: QueryParams;
   headers?: Record<string, string>;
   signal?: AbortSignal;
+  /** Send browser cookies with the request; needed for cookie-authenticated proxy routes. */
+  credentials?: RequestCredentials;
 }
 
 export class ApiError extends Error {
@@ -136,7 +138,7 @@ export function createApiClient(config: ApiClientConfig): ApiClient {
   const doFetch: typeof fetch = (input, init) => (fetchImpl ?? fetch)(input, init);
 
   async function request<T = any>(method: HttpMethod, path: string, options: RequestOptions = {}): Promise<T> {
-    const { accessToken, body, rawBody, query, headers: extraHeaders, signal } = options;
+    const { accessToken, body, rawBody, query, headers: extraHeaders, signal, credentials } = options;
 
     const url = appendQuery(`${getBaseUrl()}${path}`, query);
 
@@ -152,7 +154,7 @@ export function createApiClient(config: ApiClientConfig): ApiClient {
       Object.assign(headers, extraHeaders);
     }
 
-    const init: RequestInit = { method, headers, signal };
+    const init: RequestInit = { method, headers, signal, credentials };
     if (rawBody !== undefined) {
       init.body = rawBody;
     } else if (body !== undefined) {

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -1169,6 +1169,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/authorize/flow": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Authorize Flow */
+        get: operations["authorize_flow_authorize_flow_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/auto_router/benchmarks": {
         parameters: {
             query?: never;
@@ -41321,6 +41338,37 @@ export interface operations {
                 "application/x-www-form-urlencoded": components["schemas"]["Body_authorize_complete_authorize_complete_post"];
             };
         };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    authorize_flow_authorize_flow_get: {
+        parameters: {
+            query: {
+                flow: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
         responses: {
             /** @description Successful Response */
             200: {


### PR DESCRIPTION
## TLDR

Problem this solves:

- A resource-scoped client still lands on a generic MCP server grid
- Stale resources and M2M servers take the wrong OAuth path
- The browser could read flow state the gateway had not validated

How it solves it:

- The gateway classifies each sealed flow as unscoped, interactive, M2M, or stale
- Interactive flows require the user's vendor credential before Finish
- M2M flows finish with the configured service credential; unreachable and stale flows fail closed

## User Flow

Before: a client asking for one MCP server can show the wrong consent target or get stuck in an impossible OAuth loop

1. The client sends the user to GET https://litellm-domain/authorize with `resource=https://litellm-domain/mcp/design_tool`
2. The user signs in and lands on https://litellm-domain/ui/connect
3. The page reads server and completion state from URL values, so the browser can show a different server than the sealed flow names
4. Finish is available before the vendor credential exists, and a stale or M2M server cannot complete the interactive path

After: the gateway owns the flow state and each flow gets the appropriate path

1. The client sends the user to GET https://litellm-domain/authorize with `resource=https://litellm-domain/mcp/design_tool`
2. The user signs in and lands on https://litellm-domain/ui/connect with only an opaque flow handle
3. GET https://litellm-domain/authorize/flow reads the HttpOnly flow cookie and reports the sealed server and state
4. An interactive server appears alone and starts its vendor OAuth once; Finish appears only after its credential is stored
5. An M2M server appears Authorized and needs no user OAuth; a stale server shows Cancel only; an unscoped request keeps the full grid
6. The explicit Finish POST mints the code only for the state the gateway validated, or Cancel returns `error=access_denied`

## Relevant issues

## Linear ticket

Resolves LIT-7075

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Shared setup: proxy on 127.0.0.1:4717 with an interactive gateway-managed OAuth2 server, an M2M gateway-managed OAuth2 server, and a delegate-auth server. Each case registers a DCR client, signs in, starts `/authorize`, reads `/authorize/flow`, and posts `/authorize/complete`

### Before (7672399c26)

#### Scoped interactive resource

1. `GET /authorize ... resource=http://127.0.0.1:4717/mcp/design_tool`

```
location: http://127.0.0.1:4717/ui/connect?connect_flow=Qy6Ea87KdSw0tUo8wzF-wg1jGmKN-Dj1&connect_client=...
POST /authorize/complete -> HTTP 303 ...?code=llm_gcode_Q0OZ8yuisPL6...
```

2. The URL named no server, and Finish minted before any vendor credential existed

#### Unscoped and fallback resources

1. No resource, multi-server, delegate-auth, and unknown resources all landed on the same generic grid

### After (2c757bdc59)

#### Scoped interactive resource, vendor step pending

1. The authorize redirect carries only the flow handle:

```
1. authorize Location: http://127.0.0.1:4717/ui/connect?connect_flow=YEUcZYkTJFHIPPUmALmAlJ-gvvW3fiP2
2. GET /authorize/flow -> {"state":"interactive","client_origin":"http://127.0.0.1:9999","server_id":"a5ed061981d8c5d4fdcff0c2dc33706e","server_name":"design_tool","connected":false}
3. POST /authorize/complete -> HTTP 400
   refusal: authorize the requested MCP server before finishing
4. The same flow is still readable after the refusal
```

#### Scoped interactive resource, vendor step complete

1. After the per-user credential is stored, the same flow reports `state=interactive, connected=true`
2. `POST /authorize/complete -> HTTP 303` with a gateway authorization code

#### Scoped M2M resource

1. `GET /authorize/flow -> state=m2m, connected=true`
2. `POST /authorize/complete -> HTTP 303`; no per-user credential lookup or vendor OAuth occurs

#### Stale or unreachable scoped resource

1. With the server removed or the signed-in user granted only another server, `GET /authorize/flow -> state=stale, connected=null`
2. The page shows no generic grid, hides Finish, and offers Cancel
3. Approval returns HTTP 400 `the requested MCP server is no longer available`; Cancel returns HTTP 303 with `error=access_denied`
4. The same no-grant check applies to interactive and M2M resources before any vendor credential lookup

#### Unscoped resource

1. `GET /authorize/flow -> state=unscoped, server_id=null, connected=null`
2. The full grid and existing Finish flow remain available

#### Crafted handle

```
GET /authorize/flow?flow=invented-handle -> HTTP 400
{"error":"invalid_request","error_description":"unknown or expired connect flow"}
```

## Type

New Feature

## Caveats (if any)

### Medium

- Real upstream refresh for an expired grant was not verified

### Low

- The scoped page makes one status request before rendering the target
- The vendor leg remains browser-driven
- A stale or ungranted flow must be restarted after access is restored
