### PR TITLE
test(e2e/ui): select 50 rows per page before asserting the Tags and Model Hub tables overflow

### DIFF
--- a/tests/e2e/ui/tests/tables/tableScrolling.spec.ts
+++ b/tests/e2e/ui/tests/tables/tableScrolling.spec.ts
@@ -184,6 +184,7 @@ test.describe("Admin tables scroll inside the page", () => {
     );
     try {
       await navigateToPage(page, Page.TagManagement);
+      await setRowsPerPage(page, "50");
       await expectRowsAtLeast(page, SEED_ROWS);
       expect(await rowsPaintingPastAnAncestor(page)).toEqual([]);
     } finally {
@@ -207,6 +208,7 @@ test.describe("Admin tables scroll inside the page", () => {
     );
     try {
       await navigateToPage(page, Page.ModelHubTable);
+      await setRowsPerPage(page, "50");
       await expectRowsAtLeast(page, SEED_ROWS);
       expect(await rowsPaintingPastAnAncestor(page)).toEqual([]);
     } finally {


### PR DESCRIPTION
## TLDR

Problem this solves:

- Two table-scroll specs fail on every `litellm-e2e-ui` run since #39680 merged
- They seed 40 rows and expect all 40 on one page
- Tags and Model Hub tables now paginate at 25 by default, as intended

How it solves it:

- Each spec selects 50 rows per page before counting rows
- Same pattern the Request Logs spec in the file already uses

## User Flow

Before: a release engineer checking the `litellm-e2e` candidate sees the UI suite red for a reason that is not a product bug

1. They open https://buildkite.com/berriai-1/litellm-e2e-ui/builds/208, the UI suite triggered by candidate build 129
2. `tests/tables/tableScrolling.spec.ts` fails twice: "Tags: no row paints past the box it lives in" and "Model Hub: no row paints past the box it lives in", each with `Expected: >= 40, Received: 25`
3. They open http://localhost:4000/ui/?page=tag-management on a proxy with 40 tags and see 25 rows plus a pager, which is the behavior #39680 shipped on purpose

After: the same suite is green and the two specs still prove rows scroll inside their box

1. The specs open the same pages, pick 50 in the rows-per-page control, and then see all 40 seeded rows
2. The overflow assertion runs against a table that genuinely overflows its box
3. The UI suite on the candidate build passes

## Relevant issues

Follows #39680

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Both runs are the Buildkite `litellm-e2e-ui` lane, which deploys the dashboard built from source at the litellm SHA

### Before (7672399c26)

1. https://buildkite.com/berriai-1/litellm-e2e-ui/builds/208, job `ui - playwright suite`
2. Observed output:

```
✘ tests/tables/tableScrolling.spec.ts:179:7 › Admin tables scroll inside the page › Tags: no row paints past the box it lives in
✘ tests/tables/tableScrolling.spec.ts:196:7 › Admin tables scroll inside the page › Model Hub: no row paints past the box it lives in
Error: expect(received).toBeGreaterThanOrEqual(expected)
Expected: >= 40
Received:    25
```

### After (5298deb491)

1. https://buildkite.com/berriai-1/litellm-e2e-ui/builds/210 runs this branch's specs (`suite_sha`) against the 7672399 gateway image: passed, both scroll specs green

## Type

✅ Test

## Caveats (if any)

## QA runbook

- tests/e2e/ui/tests/tables/tableScrolling.spec.ts › Admin tables scroll inside the page › Tags: no row paints past the box it lives in - with 40 tags and 50 rows per page selected, every row stays inside the table box
  - [ ] Create 40 tags: for i in $(seq 1 40); do curl -s -X POST http://localhost:4000/tag/new -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d "{\"name\": \"scroll-tag-$i\", \"description\": \"scroll\"}"; done
  - [ ] Open http://localhost:4000/ui/?page=tag-management and expect 25 rows and a pager
  - [ ] Pick 50 in the rows-per-page control at the bottom of the table and expect at least 40 rows
  - [ ] Scroll the table and expect the rows to scroll inside the table box, never painting past it
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/ui/tests/tables/tableScrolling.spec.ts › Admin tables scroll inside the page › Model Hub: no row paints past the box it lives in - same check on the Model Hub table
  - [ ] Create 40 deployments through POST http://localhost:4000/model/new with distinct model_name values pointing at any reachable api_base
  - [ ] Open http://localhost:4000/ui/?page=model-hub-table, pick 50 rows per page, and expect at least 40 rows
  - [ ] Scroll the table and expect the rows to stay inside the table box
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
