### PR TITLE
test(e2e): prove Vertex context caching on the first cold call and on the spend row

### DIFF
--- a/tests/e2e/llm_translation/test_cache_control.py
+++ b/tests/e2e/llm_translation/test_cache_control.py
@@ -150,7 +150,7 @@ def _assert_cache_read_on_second_call(
 
 def _cold_cache_calls(send: Callable[[str], Result[ChatResponse]]) -> Iterator[ChatResponse]:
     for _ in range(VERTEX_COLD_CALL_ATTEMPTS):
-        result = send(_cacheable_prefix())
+        result: Final = send(_cacheable_prefix())
         match result:
             case UnknownApiError(status_code=400, body=body) if VERTEX_CACHE_REJECTION_MARKER in body:
                 continue
@@ -241,7 +241,7 @@ class TestCacheControl:
         )
         resources.defer(lambda: client.proxy.delete_model(model_id))
         key = resources.key()
-        completion = _first_cold_call_reads_cache(
+        completion: Final = _first_cold_call_reads_cache(
             model, lambda prefix: _cache_chat(client, key, model, prefix, ttl=VERTEX_CACHE_TTL)
         )
         _assert_billed_below_uncached_prompt(client, model, completion)

--- a/tests/e2e/llm_translation/test_cache_control.py
+++ b/tests/e2e/llm_translation/test_cache_control.py
@@ -8,8 +8,12 @@ Each case asserts the feature actually happened, not just a 200. Coverage matrix
   cache-read usage tokens > 0. service_tier is out of scope for Bedrock; AWS
   Bedrock does not expose an OpenAI-style request service tier, so that cell is
   intentionally not covered here.
-- Vertex (gemini-2.5-flash): prompt caching via ``cache_control`` context
-  caching; the second identical call must report cached prompt tokens > 0.
+- Vertex (gemini-2.5-flash): explicit context caching via ``cache_control``
+  with a 5-minute ttl. litellm builds the Vertex cache before the generate
+  call, so a never-seen prefix must come back cached on its very first call
+  (Gemini's implicit caching cannot hit a cold prefix), the cached count must
+  cover the marked block, and the spend row must be billed below the uncached
+  price of the prompt.
 - Anthropic (claude-haiku-4-5, direct): the same ``cache_control`` prefix over
   the OpenAI-compatible route; the second call must report cache-read tokens > 0.
 - OpenAI (gpt-5.6): automatic prompt caching needs no request marker, so the
@@ -26,7 +30,8 @@ built from the typed content blocks shared in ``endpoints_client.py``.
 from __future__ import annotations
 
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from typing import Final
 
 import pytest
 from pydantic import BaseModel
@@ -45,6 +50,10 @@ BEDROCK_MODEL = "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0"
 VERTEX_MODEL = "vertex_ai/gemini-2.5-flash"
 ANTHROPIC_MODEL = "anthropic/claude-haiku-4-5-20251001"
 OPENAI_MODEL = "openai/gpt-5.6"
+VERTEX_CACHE_TTL: Final = "300s"
+VERTEX_COLD_CALL_ATTEMPTS: Final = 3
+VERTEX_MINIMUM_CACHED_TOKENS: Final = 1024
+CACHED_SHARE_OF_PROMPT: Final = 0.9
 
 
 class CacheChatBody(BaseModel):
@@ -77,14 +86,14 @@ def _cached_read_tokens(usage: Usage | None) -> int:
 
 
 def _cache_chat(
-    client: PassthroughClient, key: str, model: str, prefix: str
+    client: PassthroughClient, key: str, model: str, prefix: str, ttl: str | None = None
 ) -> Result[ChatResponse]:
     body = CacheChatBody(
         model=model,
         messages=[
             RichMessage(
                 role="system",
-                content=[TextBlock(text=prefix, cache_control=CacheControl())],
+                content=[TextBlock(text=prefix, cache_control=CacheControl(ttl=ttl))],
             ),
             RichMessage(role="user", content=[TextBlock(text="Reply with one word.")]),
         ],
@@ -138,6 +147,58 @@ def _assert_cache_read_on_second_call(
     )
 
 
+def _cold_cache_calls(send: Callable[[str], Result[ChatResponse]]) -> Iterator[ChatResponse]:
+    for _ in range(VERTEX_COLD_CALL_ATTEMPTS):
+        yield unwrap(send(_cacheable_prefix()))
+
+
+def _first_cold_call_reads_cache(model: str, send: Callable[[str], Result[ChatResponse]]) -> ChatResponse:
+    completion: Final = next(
+        (
+            candidate
+            for candidate in _cold_cache_calls(send)
+            if _cached_read_tokens(candidate.usage) >= VERTEX_MINIMUM_CACHED_TOKENS
+        ),
+        None,
+    )
+    assert completion is not None, (
+        f"{model}: {VERTEX_COLD_CALL_ATTEMPTS} never-seen prompts marked with cache_control all reported fewer "
+        f"than {VERTEX_MINIMUM_CACHED_TOKENS} cached tokens on their first call; explicit context caching did "
+        "not engage"
+    )
+    assert completion.choices, f"{model}: cached call returned no choices: {completion}"
+    usage: Final = completion.usage
+    cached: Final = _cached_read_tokens(usage)
+    assert usage and usage.prompt_tokens and cached >= CACHED_SHARE_OF_PROMPT * usage.prompt_tokens, (
+        f"{model}: only {cached} of {usage.prompt_tokens if usage else None} prompt tokens were served from the "
+        "cache; the cache_control block was not cached whole"
+    )
+    return completion
+
+
+def _input_rate(client: PassthroughClient, model: str) -> float:
+    entry: Final = next((row for row in client.proxy.model_info() if row.model_name == model), None)
+    assert entry and entry.model_info.input_cost_per_token, f"/model/info resolved no input rate for {model}"
+    return entry.model_info.input_cost_per_token
+
+
+def _assert_billed_below_uncached_prompt(client: PassthroughClient, model: str, completion: ChatResponse) -> None:
+    assert completion.id, f"{model}: cached completion carried no id to find its spend row by"
+    usage: Final = completion.usage
+    assert usage and usage.prompt_tokens, f"{model}: cached completion carried no prompt_tokens: {usage}"
+    rows: Final = client.proxy.poll_logs_for_request_id(completion.id, predicate=lambda rs: (rs[0].spend or 0) > 0)
+    assert rows, f"{model}: no costed /spend/logs row for request {completion.id}"
+    row: Final = rows[0]
+    assert row.prompt_tokens == usage.prompt_tokens, (
+        f"{model}: spend row prompt_tokens {row.prompt_tokens} != response prompt_tokens {usage.prompt_tokens}"
+    )
+    uncached_prompt_cost: Final = usage.prompt_tokens * _input_rate(client, model)
+    assert row.spend is not None and row.spend < uncached_prompt_cost, (
+        f"{model}: spend {row.spend} is not below the uncached price of the prompt alone ({uncached_prompt_cost} for "
+        f"{usage.prompt_tokens} tokens); cache-read pricing was not applied"
+    )
+
+
 class TestCacheControl:
     @pytest.mark.covers(
         "llm.chat_completions.bedrock_converse.prompt_cache_5m.nonstream.works",
@@ -174,7 +235,10 @@ class TestCacheControl:
         )
         resources.defer(lambda: client.proxy.delete_model(model_id))
         key = resources.key()
-        _assert_cache_read_on_second_call(model, lambda prefix: _cache_chat(client, key, model, prefix))
+        completion = _first_cold_call_reads_cache(
+            model, lambda prefix: _cache_chat(client, key, model, prefix, ttl=VERTEX_CACHE_TTL)
+        )
+        _assert_billed_below_uncached_prompt(client, model, completion)
 
     @pytest.mark.covers(
         "llm.chat_completions.anthropic.prompt_cache_5m.nonstream.works",

--- a/tests/e2e/llm_translation/test_cache_control.py
+++ b/tests/e2e/llm_translation/test_cache_control.py
@@ -37,7 +37,7 @@ import pytest
 from pydantic import BaseModel
 
 from e2e_config import unique_marker
-from e2e_http import Result, unwrap
+from e2e_http import Result, UnknownApiError, unwrap
 from endpoints_client import CacheControl, RichMessage, TextBlock
 from lifecycle import ResourceManager
 from models import ChatBody, ChatMessage, ChatResponse, LiteLLMParamsBody, Usage
@@ -54,6 +54,7 @@ VERTEX_CACHE_TTL: Final = "300s"
 VERTEX_COLD_CALL_ATTEMPTS: Final = 3
 VERTEX_MINIMUM_CACHED_TOKENS: Final = 1024
 CACHED_SHARE_OF_PROMPT: Final = 0.9
+VERTEX_CACHE_REJECTION_MARKER: Final = "minimum token count to start explicit caching"
 
 
 class CacheChatBody(BaseModel):
@@ -149,7 +150,12 @@ def _assert_cache_read_on_second_call(
 
 def _cold_cache_calls(send: Callable[[str], Result[ChatResponse]]) -> Iterator[ChatResponse]:
     for _ in range(VERTEX_COLD_CALL_ATTEMPTS):
-        yield unwrap(send(_cacheable_prefix()))
+        result = send(_cacheable_prefix())
+        match result:
+            case UnknownApiError(status_code=400, body=body) if VERTEX_CACHE_REJECTION_MARKER in body:
+                continue
+            case _:
+                yield unwrap(result)
 
 
 def _first_cold_call_reads_cache(model: str, send: Callable[[str], Result[ChatResponse]]) -> ChatResponse:
@@ -162,9 +168,9 @@ def _first_cold_call_reads_cache(model: str, send: Callable[[str], Result[ChatRe
         None,
     )
     assert completion is not None, (
-        f"{model}: {VERTEX_COLD_CALL_ATTEMPTS} never-seen prompts marked with cache_control all reported fewer "
-        f"than {VERTEX_MINIMUM_CACHED_TOKENS} cached tokens on their first call; explicit context caching did "
-        "not engage"
+        f"{model}: {VERTEX_COLD_CALL_ATTEMPTS} never-seen prompts marked with cache_control were each either "
+        f"rejected by Vertex's minimum-token check or served with fewer than {VERTEX_MINIMUM_CACHED_TOKENS} "
+        "cached tokens on their first call; explicit context caching did not engage"
     )
     assert completion.choices, f"{model}: cached call returned no choices: {completion}"
     usage: Final = completion.usage

--- a/tests/e2e/llm_translation/test_cache_control.py
+++ b/tests/e2e/llm_translation/test_cache_control.py
@@ -30,7 +30,7 @@ built from the typed content blocks shared in ``endpoints_client.py``.
 from __future__ import annotations
 
 import time
-from collections.abc import Callable, Iterator
+from collections.abc import Callable
 from typing import Final
 
 import pytest
@@ -148,22 +148,21 @@ def _assert_cache_read_on_second_call(
     )
 
 
-def _cold_cache_calls(send: Callable[[str], Result[ChatResponse]]) -> Iterator[ChatResponse]:
-    for _ in range(VERTEX_COLD_CALL_ATTEMPTS):
-        result: Final = send(_cacheable_prefix())
-        match result:
-            case UnknownApiError(status_code=400, body=body) if VERTEX_CACHE_REJECTION_MARKER in body:
-                continue
-            case _:
-                yield unwrap(result)
+def _cold_cache_call(send: Callable[[str], Result[ChatResponse]]) -> ChatResponse | None:
+    result: Final = send(_cacheable_prefix())
+    match result:
+        case UnknownApiError(status_code=400, body=body) if VERTEX_CACHE_REJECTION_MARKER in body:
+            return None
+        case _:
+            return unwrap(result)
 
 
 def _first_cold_call_reads_cache(model: str, send: Callable[[str], Result[ChatResponse]]) -> ChatResponse:
     completion: Final = next(
         (
             candidate
-            for candidate in _cold_cache_calls(send)
-            if _cached_read_tokens(candidate.usage) >= VERTEX_MINIMUM_CACHED_TOKENS
+            for candidate in (_cold_cache_call(send) for _ in range(VERTEX_COLD_CALL_ATTEMPTS))
+            if candidate is not None and _cached_read_tokens(candidate.usage) >= VERTEX_MINIMUM_CACHED_TOKENS
         ),
         None,
     )

--- a/tests/e2e/models.py
+++ b/tests/e2e/models.py
@@ -181,6 +181,7 @@ class ChatMessage(BaseModel):
 
 class CacheControl(BaseModel):
     type: str = "ephemeral"
+    ttl: str | None = None
 
 
 class TextBlock(BaseModel):


### PR DESCRIPTION
## TLDR

Problem this solves:

- The Vertex prompt-cache e2e test only checks a second call reports cached tokens
- Gemini's implicit caching can satisfy that without litellm's cache_control path doing anything
- The priming call is the flaky step: Vertex sometimes rejects a system-only cache with "1 tokens"
- The test never looked at the spend row, which is what customers actually see

How it solves it:

- Send a never-seen prefix and assert the very first response is already served from cache
- Assert the cached count covers at least 90% of the prompt, not just "> 0"
- Retry with a fresh prefix, never the same one, so implicit caching cannot fake a hit
- Treat Vertex's own minimum-token rejection of the cache create as one more reason to retry
- Give the cache a 300s ttl so the run does not leave hour-long caches on Vertex
- Assert the spend row is billed below the uncached price of the prompt

## User Flow

Before: an engineer opening a Buildkite run for an unrelated PR sees the Vertex cache test red, and a green run would not have proven the feature either

1. They send POST http://localhost:4000/v1/chat/completions to a `vertex_ai/gemini-2.5-flash` deployment with a long system block marked `cache_control` and a one-line user turn
2. Sometimes the response is 400 `The cached content is of 1 tokens. The minimum token count to start explicit caching is 1024.` and the run is red
3. When it succeeds, they send the identical request again and only then check `usage.prompt_tokens_details.cached_tokens > 0`, which Gemini's own implicit caching also produces on a repeated 9k-token prefix
4. They open http://localhost:4000/ui/?page=logs and the row's spend is never checked against the cache-read rate

After: the same engineer sees the first call for a brand-new prefix come back cached and billed at the cache-read rate, or a failure that names which of those did not happen

1. They send POST http://localhost:4000/v1/chat/completions with the same shape plus `"cache_control": {"type": "ephemeral", "ttl": "300s"}` on the system block, using a prefix no one has sent before
2. The first response already carries `usage.prompt_tokens_details.cached_tokens` covering at least 90% of `usage.prompt_tokens`; a cold prefix can only be cached by the explicit cache_control path
3. If Vertex rejects the cache with its `minimum token count` 400, or the response comes back uncached, they try again with another never-seen prefix rather than re-sending the same one, up to three times
4. GET http://localhost:4000/spend/logs?request_id=<response id> returns a row whose `prompt_tokens` matches the response and whose `spend` is below `prompt_tokens * input_cost_per_token` from GET http://localhost:4000/model/info, proving the cache-read rate was applied

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The Vertex call itself can only run where Vertex credentials exist, which is the Buildkite e2e stack, not this laptop. The Before is the failing Buildkite run on the merge base. The After shows the two harness lookups the new assertions depend on, captured live against a local proxy on port 4001, followed by the Buildkite run of the Vertex test at this PR's tip

### Before (17e13126cc)

1. Buildkite `litellm-e2e-pr` build 268 ran `llm_translation/test_cache_control.py::TestCacheControl::test_vertex_prompt_caching_reads_cache` on the merge base
2. Output:

```text
FAILED llm_translation/test_cache_control.py::TestCacheControl::test_vertex_prompt_caching_reads_cache
AssertionError: kind='unknown' status_code=400 body='{"error":{"message":"litellm.BadRequestError: Vertex_aiException BadRequestError - {
  "error": {
    "code": 400,
    "message": "The cached content is of 1 tokens. The minimum token count to start explicit caching is 1024.",
    "status": "INVALID_ARGUMENT"
  }
}
```

3. The same test passed in builds 248, 255, 257, 258, 265 and 266 the same day, so the priming call is the flaky step

### After (b56e4f80a4)

1. `curl -s http://localhost:4001/model/new -H "Authorization: Bearer $MK" -H "Content-Type: application/json" -d '{"model_name":"e2e-vertex-rate-probe","litellm_params":{"model":"vertex_ai/gemini-2.5-flash","vertex_project":"probe","vertex_location":"us-central1"}}'` then `curl -s http://localhost:4001/model/info -H "Authorization: Bearer $MK" | jq '.data[] | select(.model_name=="e2e-vertex-rate-probe") | {input: .model_info.input_cost_per_token, cache_read: .model_info.cache_read_input_token_cost}'`
2. Output, the rate the new spend assertion compares against:

```text
{"input":3E-7,"cache_read":3E-8}
```

3. `curl -s http://localhost:4001/chat/completions -H "Authorization: Bearer $MK" -d '{"model":"e2e-gemini-row-probe","messages":[{"role":"user","content":"Reply with one word."}],"max_tokens":32}' | jq -r .id` then `curl -s "http://localhost:4001/spend/logs?request_id=PHOcapf1O9LljMcPlfKY0AQ" -H "Authorization: Bearer $MK" | jq '.[0] | {request_id, spend, prompt_tokens}'`
4. Output, the spend row is keyed by the response id the new assertion polls with:

```text
{"request_id":"PHOcapf1O9LljMcPlfKY0AQ","spend":0.0000736,"prompt_tokens":12}
```

5. `LITELLM_PROXY_URL=http://localhost:4001 uv run pytest tests/e2e/llm_translation/test_cache_control.py::TestCacheControl::test_anthropic_prompt_caching_reads_cache -v` exercises the edited shared request builder end to end against the real Anthropic API: `1 passed in 21.22s`
6. `uv run basedpyright tests/e2e` reports 0 errors and `python -m coverage_registry.collector --strict` still reports 416/544
7. Buildkite `litellm-e2e-pr` build 276 (upstream `e2e-tests` build 9687, tip b56e4f80a4) ran the whole suite with real Vertex credentials:

```text
[gw0] [ 69%] PASSED llm_translation/test_cache_control.py::TestCacheControl::test_vertex_prompt_caching_reads_cache
1 failed, 777 passed, 55 skipped in 1290.21s (0:21:30)
```

   The one failure is `logging/test_otel_trace_e2e.py::TestOtelTraceCompleteness::test_responses_stream_exports_complete_trace` (no trace arrived at the destination in time), which this PR does not touch

## Type

✅ Test

## Caveats (if any)

### Low

- The retry absorbs Vertex's minimum-token rejection for this test only; litellm still fails the customer's completion on that rejection instead of falling back to an uncached call, which is a separate product fix
- First-call cached-token reporting on Vertex is verified from litellm's request flow and the Buildkite run, not a local run, because this machine has no Vertex credentials
- Bedrock, Anthropic and OpenAI cases keep their second-call assertion; only the Vertex case changes

## QA runbook

- tests/e2e/llm_translation/test_cache_control.py::TestCacheControl::test_vertex_prompt_caching_reads_cache - a never-seen prefix marked with cache_control comes back cached on its first call to a Gemini deployment, the cached count covers the prompt, and the spend row is billed at the cache-read rate
  - [ ] Needs VERTEXAI_PROJECT and VERTEXAI_CREDENTIALS in the proxy environment and a Postgres-backed proxy with store_model_in_db
  - [ ] POST /model/new with the master key: `{"model_name":"vertex-cache-qa","litellm_params":{"model":"vertex_ai/gemini-2.5-flash","vertex_project":"os.environ/VERTEXAI_PROJECT","vertex_location":"us-central1","vertex_credentials":"os.environ/VERTEXAI_CREDENTIALS"}}`
  - [ ] POST /v1/chat/completions with a system message whose single text block is ~600 sentences containing a fresh random word and `"cache_control": {"type": "ephemeral", "ttl": "300s"}`, plus a user message `Reply with one word.` and `"max_tokens": 64`
  - [ ] Expect 200 on that first call with `usage.prompt_tokens_details.cached_tokens` at least 1024 and at least 90% of `usage.prompt_tokens`
  - [ ] If it came back uncached, repeat with a new random word rather than the same body, at most three times
  - [ ] GET /model/info and note `input_cost_per_token` for `vertex-cache-qa` (3e-7 today)
  - [ ] GET /spend/logs?request_id=<the response id> until the row has non-zero spend; expect `prompt_tokens` equal to the response's and `spend` below `prompt_tokens * 3e-7`
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
