### PR TITLE
fix(model management): only proxy admins may set auto router compression fields

### DIFF
--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -850,6 +850,12 @@ async def patch_model(
             existing_litellm_params=db_model.litellm_params,
         )
 
+        ModelManagementAuthChecks.can_user_set_auto_router_compression(
+            litellm_params=patch_data.litellm_params,
+            user_api_key_dict=user_api_key_dict,
+            existing_litellm_params=db_model.litellm_params,
+        )
+
         _raise_on_strategy_router_write_violation(
             incoming_params=patch_data.litellm_params,
             existing_params=db_model.litellm_params,
@@ -1603,6 +1609,17 @@ async def _update_existing_team_model_assignment(
     # No team_model_add/delete calls required; public name is already registered
 
 
+def _stored_auto_router_compression(
+    litellm_params: GenericLiteLLMParams | None,
+) -> tuple[str | None, str | None]:
+    """The stored auto router compression values, decrypting if necessary."""
+    if litellm_params is None:
+        return (None, None)
+    routing: Final = litellm_params.auto_router_routing_compression
+    model: Final = litellm_params.auto_router_model_compression
+    return (routing, model)
+
+
 class ModelManagementAuthChecks:
     """
     Common auth checks for model management endpoints
@@ -1655,6 +1672,34 @@ class ModelManagementAuthChecks:
             type=ProxyErrorTypes.auth_error.value,
             code=status.HTTP_403_FORBIDDEN,
             param="litellm_credential_name",
+        )
+
+    @staticmethod
+    def can_user_set_auto_router_compression(
+        litellm_params: GenericLiteLLMParams | None,
+        user_api_key_dict: UserAPIKeyAuth,
+        existing_litellm_params: GenericLiteLLMParams | None = None,
+    ) -> Literal[True]:
+        if litellm_params is None:
+            return True
+        incoming: Final = (
+            litellm_params.auto_router_routing_compression,
+            litellm_params.auto_router_model_compression,
+        )
+        if incoming == (None, None):
+            return True
+        if incoming == _stored_auto_router_compression(existing_litellm_params):
+            return True
+        if user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN:
+            return True
+        raise ProxyException(
+            message=(
+                "Only a proxy admin can set auto_router_routing_compression / auto_router_model_compression on a "
+                f"model. Your role={user_api_key_dict.user_role}."
+            ),
+            type=ProxyErrorTypes.auth_error.value,
+            code=status.HTTP_403_FORBIDDEN,
+            param="auto_router_model_compression",
         )
 
     @staticmethod
@@ -1990,6 +2035,11 @@ async def add_new_model(
             user_api_key_dict=user_api_key_dict,
         )
 
+        ModelManagementAuthChecks.can_user_set_auto_router_compression(
+            litellm_params=model_params.litellm_params,
+            user_api_key_dict=user_api_key_dict,
+        )
+
         _raise_on_strategy_router_write_violation(
             incoming_params=model_params.litellm_params,
             existing_params=None,
@@ -2169,6 +2219,12 @@ async def update_model(
         )
 
         ModelManagementAuthChecks.can_user_attach_credential(
+            litellm_params=model_params.litellm_params,
+            user_api_key_dict=user_api_key_dict,
+            existing_litellm_params=deployment.litellm_params,
+        )
+
+        ModelManagementAuthChecks.can_user_set_auto_router_compression(
             litellm_params=model_params.litellm_params,
             user_api_key_dict=user_api_key_dict,
             existing_litellm_params=deployment.litellm_params,

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -400,6 +400,130 @@ class TestModelManagementAuthChecks:
             )
         assert exc_info.value.code == "403"
 
+    def test_can_user_set_auto_router_compression_admin_success(self):
+        result = ModelManagementAuthChecks.can_user_set_auto_router_compression(
+            litellm_params=LiteLLM_Params(model="auto_router/test", auto_router_model_compression="none"),
+            user_api_key_dict=self.admin_user,
+        )
+        assert result is True
+
+    def test_can_user_set_auto_router_compression_without_fields_allows_any_role(self):
+        result = ModelManagementAuthChecks.can_user_set_auto_router_compression(
+            litellm_params=LiteLLM_Params(model="test_model"),
+            user_api_key_dict=self.team_admin_user,
+        )
+        assert result is True
+
+    def test_can_user_set_auto_router_compression_team_admin_fails(self):
+        with pytest.raises(Exception, match="Only a proxy admin can set auto_router") as exc_info:
+            ModelManagementAuthChecks.can_user_set_auto_router_compression(
+                litellm_params=LiteLLM_Params(model="auto_router/test", auto_router_model_compression="none"),
+                user_api_key_dict=self.team_admin_user,
+            )
+        assert exc_info.value.code == "403"
+
+    def test_can_user_set_auto_router_compression_routing_only_team_admin_fails(self):
+        with pytest.raises(Exception, match="Only a proxy admin can set auto_router") as exc_info:
+            ModelManagementAuthChecks.can_user_set_auto_router_compression(
+                litellm_params=LiteLLM_Params(model="auto_router/test", auto_router_routing_compression="headroom"),
+                user_api_key_dict=self.team_admin_user,
+            )
+        assert exc_info.value.code == "403"
+
+    def test_can_user_set_auto_router_compression_unchanged_existing_allows_any_role(self):
+        result = ModelManagementAuthChecks.can_user_set_auto_router_compression(
+            litellm_params=LiteLLM_Params(model="auto_router/test", auto_router_model_compression="none"),
+            user_api_key_dict=self.team_admin_user,
+            existing_litellm_params=LiteLLM_Params(model="auto_router/test", auto_router_model_compression="none"),
+        )
+        assert result is True
+
+    def test_can_user_set_auto_router_compression_changed_model_field_team_admin_fails(self):
+        with pytest.raises(Exception, match="Only a proxy admin can set auto_router") as exc_info:
+            ModelManagementAuthChecks.can_user_set_auto_router_compression(
+                litellm_params=LiteLLM_Params(model="auto_router/test", auto_router_model_compression="headroom"),
+                user_api_key_dict=self.team_admin_user,
+                existing_litellm_params=LiteLLM_Params(model="auto_router/test", auto_router_model_compression="none"),
+            )
+        assert exc_info.value.code == "403"
+
+    @pytest.mark.asyncio
+    async def test_add_new_model_rejects_auto_router_compression_for_non_admin(self):
+        from litellm.proxy._types import ProxyException
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            add_new_model,
+        )
+
+        mock_prisma = MagicMock()
+        with (
+            patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),  # test-quality-ok: endpoint reads proxy server globals with no injection seam
+            patch("litellm.proxy.proxy_server.store_model_in_db", True),  # test-quality-ok: endpoint reads proxy server globals with no injection seam
+            patch("litellm.proxy.proxy_server.premium_user", True),  # test-quality-ok: endpoint reads proxy server globals with no injection seam
+            patch(  # test-quality-ok: prior auth check needs a live DB; only the compression check is under test
+                "litellm.proxy.management_endpoints.model_management_endpoints.ModelManagementAuthChecks.can_user_make_model_call",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            with pytest.raises(ProxyException) as exc_info:
+                await add_new_model(
+                    model_params=Deployment(
+                        model_name="compression-model",
+                        litellm_params=LiteLLM_Params(
+                            model="auto_router/complexity_router",
+                            auto_router_model_compression="none",
+                        ),
+                        model_info={"id": "compression-create-test"},
+                    ),
+                    user_api_key_dict=self.team_admin_user,
+                )
+            assert exc_info.value.code == "403"
+            mock_prisma.db.litellm_proxymodeltable.create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_patch_model_rejects_auto_router_compression_for_non_admin(self):
+        from litellm.proxy._types import ProxyException
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            patch_model,
+        )
+        from litellm.types.router import updateLiteLLMParams
+
+        model_id = "compression-patch-test"
+        db_model = Deployment(
+            model_name="compression-model",
+            litellm_params=LiteLLM_Params(model="auto_router/complexity_router"),
+            model_info={"id": model_id},
+        )
+        with (
+            patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),  # test-quality-ok: endpoint reads proxy server globals with no injection seam
+            patch("litellm.proxy.proxy_server.llm_router", MagicMock()),  # test-quality-ok: endpoint reads proxy server globals with no injection seam
+            patch("litellm.proxy.proxy_server.store_model_in_db", True),  # test-quality-ok: endpoint reads proxy server globals with no injection seam
+            patch("litellm.proxy.proxy_server.premium_user", True),  # test-quality-ok: endpoint reads proxy server globals with no injection seam
+            patch(  # test-quality-ok: stubs the DB row fetch; only the compression check is under test
+                "litellm.proxy.management_endpoints.model_management_endpoints.get_db_model",
+                new=AsyncMock(return_value=db_model),
+            ),
+            patch(  # test-quality-ok: prior auth check needs a live DB; only the compression check is under test
+                "litellm.proxy.management_endpoints.model_management_endpoints.ModelManagementAuthChecks.can_user_make_model_call",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(  # test-quality-ok: asserts the DB write is never reached on rejection
+                "litellm.proxy.management_endpoints.model_management_endpoints._update_team_model_in_db",
+                new=AsyncMock(),
+            ) as mock_update,
+        ):
+            with pytest.raises(ProxyException) as exc_info:
+                await patch_model(
+                    model_id=model_id,
+                    patch_data=updateDeployment(
+                        litellm_params=updateLiteLLMParams(
+                            auto_router_model_compression="none",
+                        )
+                    ),
+                    user_api_key_dict=self.team_admin_user,
+                )
+            assert exc_info.value.code == "403"
+            mock_update.assert_not_awaited()
+
 
 class MockModelTable:
     def __init__(self, model_aliases: Dict[str, str], include: Optional[dict] = None):


### PR DESCRIPTION
## TLDR

Problem this solves:
- Team admins can set compression fields on models, suppressing default-on proxy admin guardrails

How it solves it:
- Gates the two compression fields to proxy admins only, matching how `litellm_credential_name` is already gated

## User Flow

Before: a team admin uses `/model/new` to create a model with `auto_router_model_compression: "none"`, switching off a proxy admin's default-on compression guardrail

1. Team admin with API key `sk-team-...` calls POST /model/new with model="auto_router/complexity_router" and auto_router_model_compression="none"
2. The request succeeds with 200, model created in DB
3. On routing, the proxy suppresses all compression guardrails for that model, even though the proxy admin configured them default-on

After: the same attempt is rejected before the DB write

1. Team admin with API key `sk-team-...` calls POST /model/new with model="auto_router/complexity_router" and auto_router_model_compression="none"
2. The request fails with 403 "Only a proxy admin can set auto_router_routing_compression / auto_router_model_compression on a model"
3. The model is never created; the proxy admin's guardrail settings remain in effect

Same restriction applies to PATCH /model/{model_id}/update and PUT /model/{model_id}.

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks (lint, type check, test quality)
- [x] My PR's scope is as isolated as possible
- [x] Awaiting Greptile confidence review (auto-triggered on PR open)

## Type

🐛 Bug Fix

## Caveats

### Medium

This gates compression fields to proxy admins only. A team admin who tries to set these on a team-scoped model (or on a global model via a team-scoped key) will hit a 403. They cannot work around this via the UI or API; only a proxy admin can set these fields, same as with `litellm_credential_name`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authorization on model management APIs for privileged litellm_params; mis-comparison against stored values could block legitimate team-admin edits, but scope is limited to two fields and aligns with existing credential gating.
> 
> **Overview**
> **Restricts who can change auto-router compression guardrails** on model create/update paths so team admins can no longer override proxy-wide default-on compression settings.
> 
> Adds `ModelManagementAuthChecks.can_user_set_auto_router_compression`, mirroring the existing `litellm_credential_name` gate: non-admins get **403** if they set or change `auto_router_routing_compression` or `auto_router_model_compression`, while requests that omit those fields or leave them identical to the stored deployment still pass. The check runs on **PATCH** `/model/{model_id}/update`, **POST** `/model/new`, and **POST** `/model/update` before DB writes.
> 
> Unit and endpoint tests cover admin success, unchanged-value passthrough, and rejection on add/patch for team admins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bcfdaf7cbb9bec3f7470be3ec93774a7b8b5c41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->