### PR TITLE
test(e2e): stream a longer /v1/messages reply so the delta-count pin has margin

### DIFF
--- a/tests/e2e/llm_translation/test_messages_e2e.py
+++ b/tests/e2e/llm_translation/test_messages_e2e.py
@@ -169,9 +169,9 @@ class TestAnthropicMessages:
             key,
             AnthropicMessagesBody(
                 model=model,
-                max_tokens=64,
+                max_tokens=400,
                 stream=True,
-                messages=[ChatMessage(role="user", content="Count from 1 to 20, one number per line.")],
+                messages=[ChatMessage(role="user", content="Count from 1 to 100, one number per line.")],
             ),
         )
         require_successful_call(result)


### PR DESCRIPTION
## TLDR

Problem this solves:

- `test_messages_streams_completion` fails on the current `litellm-e2e` candidate at staging head
- It streams a 64-token "count to 20" reply and expects at least 2 content deltas
- Anthropic now returns that short reply in 1 to 3 deltas, so the assertion is a coin flip
- The proxy relays exactly what Anthropic sends, so this is not a proxy regression

How it solves it:

- Ask for a "count to 100" reply at `max_tokens=400`
- That reply arrived in 5 to 50 deltas across every measured run, so the assertion has margin

## User Flow

Before: a release engineer checking the `litellm-e2e` candidate sees one red pytest that is not a product bug

1. They open https://buildkite.com/berriai-1/litellm-e2e/builds/130, the candidate at staging head 49a1145
2. `tests/e2e/llm_translation/test_messages_e2e.py::TestAnthropicMessages::test_messages_streams_completion` fails with `stream carried 1 content deltas, so it was not incremental`
3. They send the same POST https://litellm-domain/v1/messages with `"stream": true`, `"max_tokens": 64` and "Count from 1 to 20" and see the whole reply land in one `content_block_delta`

After: the same test proves the stream is incremental against a reply long enough to arrive in pieces

1. The test sends POST https://litellm-domain/v1/messages with `"stream": true`, `"max_tokens": 400` and "Count from 1 to 100, one number per line"
2. The SSE stream carries several `content_block_delta` events before `message_stop`
3. The candidate's pytest suite passes

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Both runs are the Buildkite `litellm-e2e-pr` lane running this one file against the 49a1145 gateway image, the same image the `litellm-e2e` candidate build 130 used

### Before (5df0e12e0f)

1. https://buildkite.com/berriai-1/litellm-e2e-pr/builds/278, `e2e-run` job
2. Observed output:

```
FAILED tests/e2e/llm_translation/test_messages_e2e.py::TestAnthropicMessages::test_messages_streams_completion
AssertionError: stream carried 1 content deltas, so it was not incremental: ['message_start', 'content_block_start', 'ping', 'content_block_delta', 'content_block_stop', 'message_delta', 'message_stop']
```

### After (d6bc8fe289)

1. https://buildkite.com/berriai-1/litellm-e2e-pr/builds/279 runs this branch's test file against the same 49a1145 gateway image, `e2e-run` job
2. Observed output:

```
PASSED llm_translation/test_messages_e2e.py::TestAnthropicMessages::test_messages_streams_completion
5 passed, 2 skipped in 96.54s
```

3. Repeat runs of the same file on the same image, https://buildkite.com/berriai-1/litellm-e2e-pr/builds/281 and https://buildkite.com/berriai-1/litellm-e2e-pr/builds/282, both passed

## Type

✅ Test

## Caveats (if any)

### Low

- The delta count still depends on Anthropic's chunking, so the prompt is sized for margin, not a guarantee

## QA runbook

- tests/e2e/llm_translation/test_messages_e2e.py::TestAnthropicMessages::test_messages_streams_completion - a streamed /v1/messages reply arrives as several content deltas, not one blob
  - [ ] Register an Anthropic deployment: curl -X POST http://localhost:4000/model/new -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model_name": "e2e-messages", "litellm_params": {"model": "anthropic/claude-haiku-4-5", "api_key": "os.environ/ANTHROPIC_API_KEY"}}' (needs ANTHROPIC_API_KEY)
  - [ ] Stream a long reply: curl -N -X POST http://localhost:4000/v1/messages -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model": "e2e-messages", "max_tokens": 400, "stream": true, "messages": [{"role": "user", "content": "Count from 1 to 100, one number per line."}]}'
  - [ ] Expect a 200 whose SSE body carries `message_start`, then at least 2 `content_block_delta` events, then `message_stop`
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
