### PR TITLE
feat: default capabilities for new chat catalog entries

### DIFF
--- a/scripts/sync_together_ai_models.py
+++ b/scripts/sync_together_ai_models.py
@@ -85,6 +85,16 @@ _TOOLS: Final = MappingProxyType(
     }
 )
 
+_CHAT_DEFAULTS: Final = MappingProxyType(
+    {
+        "max_output_tokens": 120000,
+        "supports_function_calling": True,
+        "supports_parallel_function_calling": True,
+        "supports_reasoning": True,
+        "supports_tool_choice": True,
+    }
+)
+
 CAPABILITY_RULES: Final = (
     _rule(
         "MiniMaxAI/MiniMax-M3",
@@ -308,6 +318,7 @@ def _new_entry(model: CatalogModel, mode: str) -> RegistryEntry:
         "litellm_provider": PROVIDER,
         "mode": mode,
         "source": SOURCE_URL,
+        **(_CHAT_DEFAULTS if model.type == "chat" else {}),
         **(dict(rule.fields) if rule else {}),
     }
     return dict(sorted(merged.items()))

--- a/tests/test_litellm/test_sync_together_ai_models.py
+++ b/tests/test_litellm/test_sync_together_ai_models.py
@@ -105,6 +105,7 @@ def test_added_chat_model_matches_reviewed_registry_shape() -> None:
         "input_cost_per_token": 3e-06,
         "litellm_provider": "together_ai",
         "max_input_tokens": 1048576,
+        "max_output_tokens": 120000,
         "max_tokens": 1048576,
         "mode": "chat",
         "output_cost_per_token": 1.5e-05,
@@ -117,6 +118,12 @@ def test_added_chat_model_matches_reviewed_registry_shape() -> None:
         "supports_tool_choice": True,
         "supports_vision": True,
     }
+
+
+def test_unreviewed_chat_model_gets_catalog_defaults() -> None:
+    outcome = sync.compute_sync({}, [_chat_model("acme/unreviewed")], _doc({"x": "2026-01-01"}))
+    entry = outcome.cost_map["together_ai/acme/unreviewed"]
+    assert {key: entry[key] for key in sync._CHAT_DEFAULTS} == dict(sync._CHAT_DEFAULTS)
 
 
 def test_added_embedding_model_has_no_output_token_cap() -> None:
@@ -144,7 +151,7 @@ def test_output_ceiling_comes_from_the_rule_never_from_context_length() -> None:
     glm = next(model for model in RECORDED_CATALOG if model.id == "zai-org/GLM-5.2")
     fresh = sync.compute_sync({}, [_chat_model("acme/unreviewed", ctx=1048576), glm], _doc({"x": "2026-01-01"}))
     unreviewed = fresh.cost_map["together_ai/acme/unreviewed"]
-    assert "max_output_tokens" not in unreviewed
+    assert unreviewed["max_output_tokens"] == 120000
     assert (unreviewed["max_input_tokens"], unreviewed["max_tokens"]) == (1048576, 1048576)
     reviewed = fresh.cost_map["together_ai/zai-org/GLM-5.2"]
     assert (reviewed["max_input_tokens"], reviewed["max_output_tokens"], reviewed["max_tokens"]) == (


### PR DESCRIPTION
## Linear ticket

## Problem
New chat entries created by the litellm-owned Together catalog sync lacked agreed defaults for output capacity and capabilities.

## Solution
The authoring sync now applies max_output_tokens 120000 and the agreed tool and reasoning defaults only to new chat entries. Reviewed per-model rules still override these defaults, and embeddings and moderation entries remain unchanged.

## Tests
- `env -u PYTHONPATH python -m pytest tests/test_litellm/test_sync_together_ai_models.py -q`
- `env -u PYTHONPATH python ci_cd/generate_model_prices_schema.py --check`
- Mutation check: removing the new default merge caused three regression tests to fail
- Live fixed proxy: `/health/liveliness` and `/v1/models` returned HTTP 200 on four workers

## Behavior changes
New chat entries receive the agreed authoring defaults; runtime fallback resolution is unchanged.

ran /live-pr-risk and found no regressions/backward incompatible risks
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm/pull/39950" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->