### PR TITLE
fix(auto_router): build the semantic route layer off the event loop

### DIFF
--- a/litellm/router_strategy/auto_router/auto_router.py
+++ b/litellm/router_strategy/auto_router/auto_router.py
@@ -119,12 +119,7 @@ class AutoRouter(CustomLogger):
         return auto_router_routes
 
     def _build_routelayer(self) -> "SemanticRouter":
-        """Build (once) the SemanticRouter for this alias's static route config.
-
-        `auto_sync="local"` embeds every route's utterances against the encoder, so
-        this does a synchronous embedding call and must never run directly on the
-        event loop; see `_ensure_routelayer`.
-        """
+        """Synchronous (embeds every route's utterances); run only via `_ensure_routelayer`."""
         if self.routelayer is not None:
             return self.routelayer
 
@@ -139,27 +134,16 @@ class AutoRouter(CustomLogger):
         return routelayer
 
     def _clear_build_task_on_failure(self, build_task: "asyncio.Task[SemanticRouter]") -> None:
-        """Done-callback: drop a failed build so the next caller gets a fresh attempt.
-
-        Runs whether or not any caller is still awaiting `build_task` (that's the point:
-        a caller cancelled via `cancel_on_disconnect` mid-build must not leave a later
-        failure cached with nothing left to clear it), and `not build_task.cancelled()`
-        guards `.exception()`, which raises on a cancelled task instead of returning one.
-        """
+        """Runs even with no caller left awaiting, so a failure never stays cached forever."""
         if build_task is self._routelayer_build_task and not build_task.cancelled() and build_task.exception():
             self._routelayer_build_task = None
 
     async def _ensure_routelayer(self) -> "SemanticRouter":
-        """Return the cached route layer, building it once under a lock if needed.
+        """Build the route layer once, off the event loop, shared across concurrent callers.
 
-        The build runs in a worker thread (it embeds the static route utterances via the
-        encoder's synchronous path, so it must never run directly on the event loop) as a
-        task stored on `self`, not a bare `asyncio.to_thread` awaited inline: a disconnected
-        caller cancelled via `cancel_on_disconnect` would otherwise release `_routelayer_lock`
-        while the thread keeps running, letting a second concurrent request see no lock held
-        and start (and bill) a duplicate build. Every caller awaits the same stored task
-        through `asyncio.shield`, so cancelling one caller's wait never cancels the build
-        itself or lets another caller start a second one.
+        A shared task (not a bare `asyncio.to_thread` awaited under the lock) survives one
+        caller's cancellation, so `cancel_on_disconnect` can't free a second caller into
+        starting a duplicate build.
         """
         if self.routelayer is not None:
             return self.routelayer

--- a/litellm/router_strategy/auto_router/auto_router.py
+++ b/litellm/router_strategy/auto_router/auto_router.py
@@ -77,6 +77,7 @@ class AutoRouter(CustomLogger):
         self.loaded_routes: list[Route] = self._load_semantic_routing_routes()
         self.routelayer: SemanticRouter | None = None
         self._routelayer_lock = asyncio.Lock()
+        self._routelayer_build_task: asyncio.Task[SemanticRouter] | None = None
         self.default_model = default_model
         self.embedding_model: str = embedding_model
         self.max_input_chars: int = max_input_chars
@@ -140,18 +141,35 @@ class AutoRouter(CustomLogger):
     async def _ensure_routelayer(self) -> "SemanticRouter":
         """Return the cached route layer, building it once under a lock if needed.
 
-        The build embeds the static route utterances via the encoder's synchronous
-        path, so it runs in a worker thread to avoid blocking the event loop. A
-        double-checked asyncio lock ensures concurrent cold-start requests build it
-        exactly once rather than each firing duplicate embedding calls.
+        The build runs in a worker thread (it embeds the static route utterances via the
+        encoder's synchronous path, so it must never run directly on the event loop) as a
+        task stored on `self`, not a bare `asyncio.to_thread` awaited inline: a disconnected
+        caller cancelled via `cancel_on_disconnect` would otherwise release `_routelayer_lock`
+        while the thread keeps running, letting a second concurrent request see no lock held
+        and start (and bill) a duplicate build. Every caller awaits the same stored task
+        through `asyncio.shield`, so cancelling one caller's wait never cancels the build
+        itself or lets another caller start a second one.
         """
         if self.routelayer is not None:
             return self.routelayer
         async with self._routelayer_lock:
-            routelayer = self.routelayer
-            if routelayer is None:
-                routelayer = await asyncio.to_thread(self._build_routelayer)
-            return routelayer
+            if self.routelayer is not None:
+                return self.routelayer
+            build_task = self._routelayer_build_task
+            if build_task is None:
+                build_task = asyncio.ensure_future(asyncio.to_thread(self._build_routelayer))
+                self._routelayer_build_task = build_task
+        try:
+            return await asyncio.shield(build_task)
+        except Exception:
+            # Only a real build failure (not this caller's own cancellation, which
+            # asyncio.shield turns into a CancelledError here while the task keeps
+            # running for everyone else) clears the slot, so the next call retries
+            # a fresh build instead of replaying the same failure forever.
+            async with self._routelayer_lock:
+                if self._routelayer_build_task is build_task:
+                    self._routelayer_build_task = None
+            raise
 
     @staticmethod
     def _extract_text_from_messages(messages: list[dict[str, Any]]) -> str:

--- a/litellm/router_strategy/auto_router/auto_router.py
+++ b/litellm/router_strategy/auto_router/auto_router.py
@@ -138,6 +138,17 @@ class AutoRouter(CustomLogger):
         self.routelayer = routelayer
         return routelayer
 
+    def _clear_build_task_on_failure(self, build_task: "asyncio.Task[SemanticRouter]") -> None:
+        """Done-callback: drop a failed build so the next caller gets a fresh attempt.
+
+        Runs whether or not any caller is still awaiting `build_task` (that's the point:
+        a caller cancelled via `cancel_on_disconnect` mid-build must not leave a later
+        failure cached with nothing left to clear it), and `not build_task.cancelled()`
+        guards `.exception()`, which raises on a cancelled task instead of returning one.
+        """
+        if build_task is self._routelayer_build_task and not build_task.cancelled() and build_task.exception():
+            self._routelayer_build_task = None
+
     async def _ensure_routelayer(self) -> "SemanticRouter":
         """Return the cached route layer, building it once under a lock if needed.
 
@@ -158,18 +169,9 @@ class AutoRouter(CustomLogger):
             build_task = self._routelayer_build_task
             if build_task is None:
                 build_task = asyncio.ensure_future(asyncio.to_thread(self._build_routelayer))
+                build_task.add_done_callback(self._clear_build_task_on_failure)
                 self._routelayer_build_task = build_task
-        try:
-            return await asyncio.shield(build_task)
-        except Exception:
-            # Only a real build failure (not this caller's own cancellation, which
-            # asyncio.shield turns into a CancelledError here while the task keeps
-            # running for everyone else) clears the slot, so the next call retries
-            # a fresh build instead of replaying the same failure forever.
-            async with self._routelayer_lock:
-                if self._routelayer_build_task is build_task:
-                    self._routelayer_build_task = None
-            raise
+        return await asyncio.shield(build_task)
 
     @staticmethod
     def _extract_text_from_messages(messages: list[dict[str, Any]]) -> str:

--- a/litellm/router_strategy/auto_router/auto_router.py
+++ b/litellm/router_strategy/auto_router/auto_router.py
@@ -2,6 +2,7 @@
 Auto-Routing Strategy that works with a Semantic Router Config
 """
 
+import asyncio
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Final, Optional
 
@@ -75,6 +76,7 @@ class AutoRouter(CustomLogger):
         self.auto_sync_value = self.DEFAULT_AUTO_SYNC_VALUE
         self.loaded_routes: list[Route] = self._load_semantic_routing_routes()
         self.routelayer: SemanticRouter | None = None
+        self._routelayer_lock = asyncio.Lock()
         self.default_model = default_model
         self.embedding_model: str = embedding_model
         self.max_input_chars: int = max_input_chars
@@ -115,6 +117,42 @@ class AutoRouter(CustomLogger):
             )
         return auto_router_routes
 
+    def _build_routelayer(self) -> "SemanticRouter":
+        """Build (once) the SemanticRouter for this alias's static route config.
+
+        `auto_sync="local"` embeds every route's utterances against the encoder, so
+        this does a synchronous embedding call and must never run directly on the
+        event loop; see `_ensure_routelayer`.
+        """
+        if self.routelayer is not None:
+            return self.routelayer
+
+        from semantic_router.routers import SemanticRouter
+
+        routelayer: Final = SemanticRouter(
+            routes=self.loaded_routes,
+            encoder=self.encoder,
+            auto_sync=self.auto_sync_value,
+        )
+        self.routelayer = routelayer
+        return routelayer
+
+    async def _ensure_routelayer(self) -> "SemanticRouter":
+        """Return the cached route layer, building it once under a lock if needed.
+
+        The build embeds the static route utterances via the encoder's synchronous
+        path, so it runs in a worker thread to avoid blocking the event loop. A
+        double-checked asyncio lock ensures concurrent cold-start requests build it
+        exactly once rather than each firing duplicate embedding calls.
+        """
+        if self.routelayer is not None:
+            return self.routelayer
+        async with self._routelayer_lock:
+            routelayer = self.routelayer
+            if routelayer is None:
+                routelayer = await asyncio.to_thread(self._build_routelayer)
+            return routelayer
+
     @staticmethod
     def _extract_text_from_messages(messages: list[dict[str, Any]]) -> str:
         """
@@ -151,8 +189,6 @@ class AutoRouter(CustomLogger):
 
         Used for the litellm auto-router to modify the request before the routing decision is made.
         """
-        from semantic_router.routers import SemanticRouter
-
         from litellm.litellm_core_utils.prompt_templates.factory import resolve_structured_messages
         from litellm.types.router import PreRoutingHookResponse
 
@@ -164,17 +200,7 @@ class AutoRouter(CustomLogger):
         if resolved_messages is None:
             return None
 
-        routelayer = self.routelayer
-        if routelayer is None:
-            #######################
-            # Create the route layer
-            #######################
-            routelayer = SemanticRouter(
-                routes=self.loaded_routes,
-                encoder=self.encoder,
-                auto_sync=self.auto_sync_value,
-            )
-            self.routelayer = routelayer
+        routelayer = await self._ensure_routelayer()
 
         message_content: Final = self._extract_text_from_messages(resolved_messages)
         route_name: Final = await self._matched_route_name(routelayer, message_content, request_kwargs)

--- a/tests/test_litellm/router_strategy/test_auto_router.py
+++ b/tests/test_litellm/router_strategy/test_auto_router.py
@@ -612,13 +612,7 @@ class TestAutoRouterAttributesItsEmbeddingSpend:
 
 
 class ThreadTrackingEmbeddingRouter(StubEmbeddingRouter):
-    """Records which OS thread called the sync `embedding()` path, and how many times.
-
-    `auto_sync="local"` route-layer construction embeds every route's utterances through
-    this exact method (the encoder's synchronous path), so instrumenting it - an already
-    dependency-injected collaborator - observes the real build without reaching into
-    AutoRouter's own internals.
-    """
+    """Records which OS thread and how many times `embedding()` was called during a build."""
 
     def __init__(self) -> None:
         super().__init__()
@@ -675,9 +669,7 @@ class TestAutoRouterColdStartDoesNotBlockTheEventLoop:
 
     @pytest.mark.asyncio
     async def test_should_not_duplicate_the_build_when_a_caller_is_cancelled_mid_build(self):
-        """Regression: cancel_on_disconnect cancels the awaiting request, not the worker thread
-        actually doing the build. A second caller arriving before that thread finishes must
-        reuse the same in-flight build rather than starting a duplicate one."""
+        """A caller arriving while the first is cancelled mid-build must reuse it, not duplicate it."""
         import threading
 
         class BlockingEmbeddingRouter(ThreadTrackingEmbeddingRouter):
@@ -724,9 +716,7 @@ class TestAutoRouterColdStartDoesNotBlockTheEventLoop:
 
     @pytest.mark.asyncio
     async def test_should_clear_a_failed_build_even_with_no_caller_left_to_observe_it(self):
-        """Regression: a build that fails after its only caller was already cancelled must
-        still clear the slot, so the next request gets a fresh attempt instead of replaying
-        the same stale failure forever."""
+        """A build failing after its only caller was cancelled must still clear, not stay cached."""
         import threading
 
         class FailsOnFirstAttemptEmbeddingRouter(ThreadTrackingEmbeddingRouter):

--- a/tests/test_litellm/router_strategy/test_auto_router.py
+++ b/tests/test_litellm/router_strategy/test_auto_router.py
@@ -721,3 +721,62 @@ class TestAutoRouterColdStartDoesNotBlockTheEventLoop:
 
         assert result is not None
         assert len(embedding_router.embedding_call_threads) == _EMBEDDING_CALLS_PER_ROUTELAYER_BUILD
+
+    @pytest.mark.asyncio
+    async def test_should_clear_a_failed_build_even_with_no_caller_left_to_observe_it(self):
+        """Regression: a build that fails after its only caller was already cancelled must
+        still clear the slot, so the next request gets a fresh attempt instead of replaying
+        the same stale failure forever."""
+        import threading
+
+        class FailsOnFirstAttemptEmbeddingRouter(ThreadTrackingEmbeddingRouter):
+            def __init__(self) -> None:
+                super().__init__()
+                self.started = threading.Event()
+                self.release = threading.Event()
+                self.attempts = 0
+
+            def embedding(self, input: list[str], model: str, **kwargs: Any) -> Any:
+                self.attempts += 1
+                attempt = self.attempts
+                self.started.set()
+                self.release.wait(timeout=5)
+                if attempt == 1:
+                    raise ValueError("boom")
+                return super().embedding(input, model, **kwargs)
+
+        embedding_router: Final = FailsOnFirstAttemptEmbeddingRouter()
+        auto_router: Final = _auto_router(None, litellm_router_instance=embedding_router)
+
+        first_call: Final = asyncio.ensure_future(
+            auto_router.async_pre_routing_hook(
+                model="my-auto-router",
+                request_kwargs={},
+                messages=[{"role": "user", "content": "fix this stack trace"}],
+            )
+        )
+        while not embedding_router.started.is_set():
+            await asyncio.sleep(0.01)
+        first_call.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await first_call
+
+        # Nobody awaits the build now. Let the first attempt fail on its own.
+        embedding_router.release.set()
+        build_task = auto_router._routelayer_build_task
+        assert build_task is not None
+        while not build_task.done():
+            await asyncio.sleep(0.01)
+        await asyncio.sleep(0.01)  # let the done-callback (scheduled via call_soon) run
+
+        assert auto_router._routelayer_build_task is None
+
+        embedding_router.started.clear()
+        embedding_router.release.clear()
+        result: Final = await auto_router.async_pre_routing_hook(
+            model="my-auto-router",
+            request_kwargs={},
+            messages=[{"role": "user", "content": "fix this stack trace"}],
+        )
+
+        assert result is not None

--- a/tests/test_litellm/router_strategy/test_auto_router.py
+++ b/tests/test_litellm/router_strategy/test_auto_router.py
@@ -604,3 +604,59 @@ class TestAutoRouterAttributesItsEmbeddingSpend:
         assert router.aembedding_kwargs["proxy_server_request"] == {
             "body": {"model": "text-embedding-3-small", "input": ["fix this stack trace"]}
         }
+
+
+class TestAutoRouterColdStartDoesNotBlockTheEventLoop:
+    """The first request through a fresh alias builds the route layer off the event loop thread,
+    and concurrent first requests build it exactly once."""
+
+    @pytest.mark.asyncio
+    async def test_should_build_the_routelayer_on_a_worker_thread_not_the_event_loop_thread(self):
+        import threading
+
+        auto_router: Final = _auto_router(None, litellm_router_instance=StubEmbeddingRouter())
+        event_loop_thread: Final = threading.get_ident()
+        build_thread: list[int] = []
+        original_build = auto_router._build_routelayer
+
+        def _tracking_build() -> Any:
+            build_thread.append(threading.get_ident())
+            return original_build()
+
+        auto_router._build_routelayer = _tracking_build  # type: ignore[method-assign]
+
+        result: Final = await auto_router.async_pre_routing_hook(
+            model="my-auto-router",
+            request_kwargs={},
+            messages=[{"role": "user", "content": "fix this stack trace"}],
+        )
+
+        assert result is not None
+        assert len(build_thread) == 1
+        assert build_thread[0] != event_loop_thread
+
+    @pytest.mark.asyncio
+    async def test_should_build_the_routelayer_exactly_once_under_concurrent_cold_start_requests(self):
+        auto_router: Final = _auto_router(None, litellm_router_instance=StubEmbeddingRouter())
+        build_calls: Final[list[int]] = []
+        original_build = auto_router._build_routelayer
+
+        def _counting_build() -> Any:
+            build_calls.append(1)
+            return original_build()
+
+        auto_router._build_routelayer = _counting_build  # type: ignore[method-assign]
+
+        results: Final = await asyncio.gather(
+            *(
+                auto_router.async_pre_routing_hook(
+                    model="my-auto-router",
+                    request_kwargs={},
+                    messages=[{"role": "user", "content": "fix this stack trace"}],
+                )
+                for _ in range(10)
+            )
+        )
+
+        assert all(result is not None for result in results)
+        assert len(build_calls) == 1

--- a/tests/test_litellm/router_strategy/test_auto_router.py
+++ b/tests/test_litellm/router_strategy/test_auto_router.py
@@ -316,6 +316,11 @@ class TestAutoRouter:
 
 semantic_router = pytest.importorskip("semantic_router", reason="auto-router needs the semantic-router extra")
 
+# SemanticRouter(auto_sync="local") calls the encoder's sync embedding path twice per build:
+# once to probe the encoder's output dimension, once to embed ROUTER_CONFIG's one route's
+# utterances.
+_EMBEDDING_CALLS_PER_ROUTELAYER_BUILD: Final = 2
+
 ROUTER_CONFIG: Final = json.dumps(
     {
         "routes": [
@@ -606,6 +611,26 @@ class TestAutoRouterAttributesItsEmbeddingSpend:
         }
 
 
+class ThreadTrackingEmbeddingRouter(StubEmbeddingRouter):
+    """Records which OS thread called the sync `embedding()` path, and how many times.
+
+    `auto_sync="local"` route-layer construction embeds every route's utterances through
+    this exact method (the encoder's synchronous path), so instrumenting it - an already
+    dependency-injected collaborator - observes the real build without reaching into
+    AutoRouter's own internals.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.embedding_call_threads: list[int] = []
+
+    def embedding(self, input: list[str], model: str, **kwargs: Any) -> Any:
+        import threading
+
+        self.embedding_call_threads.append(threading.get_ident())
+        return super().embedding(input, model, **kwargs)
+
+
 class TestAutoRouterColdStartDoesNotBlockTheEventLoop:
     """The first request through a fresh alias builds the route layer off the event loop thread,
     and concurrent first requests build it exactly once."""
@@ -614,16 +639,9 @@ class TestAutoRouterColdStartDoesNotBlockTheEventLoop:
     async def test_should_build_the_routelayer_on_a_worker_thread_not_the_event_loop_thread(self):
         import threading
 
-        auto_router: Final = _auto_router(None, litellm_router_instance=StubEmbeddingRouter())
+        embedding_router: Final = ThreadTrackingEmbeddingRouter()
+        auto_router: Final = _auto_router(None, litellm_router_instance=embedding_router)
         event_loop_thread: Final = threading.get_ident()
-        build_thread: list[int] = []
-        original_build = auto_router._build_routelayer
-
-        def _tracking_build() -> Any:
-            build_thread.append(threading.get_ident())
-            return original_build()
-
-        auto_router._build_routelayer = _tracking_build  # type: ignore[method-assign]
 
         result: Final = await auto_router.async_pre_routing_hook(
             model="my-auto-router",
@@ -632,20 +650,14 @@ class TestAutoRouterColdStartDoesNotBlockTheEventLoop:
         )
 
         assert result is not None
-        assert len(build_thread) == 1
-        assert build_thread[0] != event_loop_thread
+        assert len(embedding_router.embedding_call_threads) == _EMBEDDING_CALLS_PER_ROUTELAYER_BUILD
+        assert set(embedding_router.embedding_call_threads) == {embedding_router.embedding_call_threads[0]}
+        assert embedding_router.embedding_call_threads[0] != event_loop_thread
 
     @pytest.mark.asyncio
     async def test_should_build_the_routelayer_exactly_once_under_concurrent_cold_start_requests(self):
-        auto_router: Final = _auto_router(None, litellm_router_instance=StubEmbeddingRouter())
-        build_calls: Final[list[int]] = []
-        original_build = auto_router._build_routelayer
-
-        def _counting_build() -> Any:
-            build_calls.append(1)
-            return original_build()
-
-        auto_router._build_routelayer = _counting_build  # type: ignore[method-assign]
+        embedding_router: Final = ThreadTrackingEmbeddingRouter()
+        auto_router: Final = _auto_router(None, litellm_router_instance=embedding_router)
 
         results: Final = await asyncio.gather(
             *(
@@ -659,4 +671,53 @@ class TestAutoRouterColdStartDoesNotBlockTheEventLoop:
         )
 
         assert all(result is not None for result in results)
-        assert len(build_calls) == 1
+        assert len(embedding_router.embedding_call_threads) == _EMBEDDING_CALLS_PER_ROUTELAYER_BUILD
+
+    @pytest.mark.asyncio
+    async def test_should_not_duplicate_the_build_when_a_caller_is_cancelled_mid_build(self):
+        """Regression: cancel_on_disconnect cancels the awaiting request, not the worker thread
+        actually doing the build. A second caller arriving before that thread finishes must
+        reuse the same in-flight build rather than starting a duplicate one."""
+        import threading
+
+        class BlockingEmbeddingRouter(ThreadTrackingEmbeddingRouter):
+            def __init__(self) -> None:
+                super().__init__()
+                self.started = threading.Event()
+                self.release = threading.Event()
+
+            def embedding(self, input: list[str], model: str, **kwargs: Any) -> Any:
+                self.started.set()
+                self.release.wait(timeout=5)
+                return super().embedding(input, model, **kwargs)
+
+        embedding_router: Final = BlockingEmbeddingRouter()
+        auto_router: Final = _auto_router(None, litellm_router_instance=embedding_router)
+
+        first_call: Final = asyncio.ensure_future(
+            auto_router.async_pre_routing_hook(
+                model="my-auto-router",
+                request_kwargs={},
+                messages=[{"role": "user", "content": "fix this stack trace"}],
+            )
+        )
+        while not embedding_router.started.is_set():
+            await asyncio.sleep(0.01)
+
+        first_call.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await first_call
+
+        second_call: Final = asyncio.ensure_future(
+            auto_router.async_pre_routing_hook(
+                model="my-auto-router",
+                request_kwargs={},
+                messages=[{"role": "user", "content": "fix this stack trace"}],
+            )
+        )
+        await asyncio.sleep(0.01)  # let the second call observe the still-running build
+        embedding_router.release.set()
+        result: Final = await second_call
+
+        assert result is not None
+        assert len(embedding_router.embedding_call_threads) == _EMBEDDING_CALLS_PER_ROUTELAYER_BUILD


### PR DESCRIPTION
## TLDR

Problem this solves:

- AutoRouter's first-request route layer build runs a synchronous embedding call on the event loop
- That build has no lock, so concurrent cold-start requests each build a duplicate

How it solves it:

- Run the build in a worker thread, as a single shared task stored on the router
- Every caller awaits that same task through `asyncio.shield`, so a disconnected caller can't free another to start a second build
- A failed build clears itself via a done-callback, so the next request retries fresh

## User Flow

Before: an app sending several concurrent requests to a freshly started semantic auto-router watches all of them stall together, and the same one-time setup call can be billed more than once

1. A developer restarts the proxy, so no request has reached their auto-router alias yet
2. Their app immediately fires several concurrent POST https://litellm-domain/v1/chat/completions requests to that alias
3. Every one of those requests waits in lockstep behind the same one-time setup instead of running in parallel, so the worker stalls for as long as that setup takes, and more than one duplicate embedding call can be billed for it
4. With `cancel_on_disconnect` on, a client that hangs up mid-setup frees the next request to start yet another duplicate setup

After: the same concurrent burst resolves in parallel and only one setup call is billed

1. The developer restarts the proxy
2. Their app fires the same concurrent burst of requests to the alias
3. The worker keeps serving other traffic while the one-time setup runs in the background, and exactly one embedding call is billed for it
4. A client hanging up mid-setup no longer causes a second one; the next request waits on the same setup already in flight, and if that setup fails, the request after it gets a clean retry

## Relevant issues

Fixes #33204

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

This environment has no LLM provider credentials, so there is no live proxy to curl. The bug is a concurrency/timing defect (whether a request blocks the event loop, whether N concurrent cold starts build one route layer or N, and what a mid-build disconnect leaves behind), which a curl trace would not show either way. Proof here is four regression tests that observe the injected embedding router - a real collaborator, not a patched internal:

- `test_should_build_the_routelayer_on_a_worker_thread_not_the_event_loop_thread` - the build's embedding calls land on a different OS thread than the one driving the hook
- `test_should_build_the_routelayer_exactly_once_under_concurrent_cold_start_requests` - 10 concurrent cold starts produce one build's worth of embedding calls, not ten
- `test_should_not_duplicate_the_build_when_a_caller_is_cancelled_mid_build` - cancelling the first caller mid-build leaves the second reusing the same in-flight build
- `test_should_clear_a_failed_build_even_with_no_caller_left_to_observe_it` - a build that fails after its only caller was cancelled still clears, so the next request retries fresh

```
uv run pytest tests/test_litellm/router_strategy/test_auto_router.py -q
25 passed, 4 skipped
```

Each was checked against the code it guards by reverting that revision's production diff and rerunning:

- against the original inline build, the cancellation test reports `assert 4 == 2` - two full builds, on two different threads
- against the first fix's except-based cleanup, the failed-build test reports the failed task still cached: `assert <Task finished ... exception=ValueError(...)> is None`

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Proof of fix is the regression tests above, not a live-proxy curl demo, since this sandbox has no provider credentials to run one against
- `ComplexityRouter._ensure_semantic_routelayer` builds its own route layer with the same lock-plus-`to_thread` shape this PR replaces, so it still has the cancellation gap. Left alone to keep this PR to one problem; worth a follow-up

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes async concurrency and cold-start routing initialization on the proxy hot path; behavior is well covered by new tests but timing/cancellation edge cases in production remain worth watching.
> 
> **Overview**
> Fixes cold-start behavior for semantic **AutoRouter** when the route layer is built on first use.
> 
> **Before**, `async_pre_routing_hook` constructed `SemanticRouter` inline on the event loop (sync embedding work), with no coordination—concurrent first requests could each trigger a full build and stall the worker together; disconnecting mid-build could start duplicate builds.
> 
> **After**, initialization goes through `_ensure_routelayer`: a single shared `asyncio` task runs `_build_routelayer` in a worker thread (`asyncio.to_thread`), guarded by a lock and awaited with `asyncio.shield` so one in-flight build is reused across callers and survives cancellation of an individual request. Failed builds clear `_routelayer_build_task` via a done callback so the next request retries.
> 
> Adds regression tests that track embedding calls on a stub router: build runs off the event-loop thread, only one build under 10 concurrent cold starts, no duplicate build when the first caller is cancelled mid-build, and failed builds are not left cached when no caller remains.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 515d1c865038b305b107336dc470fcd7fa3106ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->