### PR TITLE
fix(adaptive_router): add the persisted delta to the cold-start prior on load

### DIFF
--- a/litellm/router_strategy/adaptive_router/adaptive_router.py
+++ b/litellm/router_strategy/adaptive_router/adaptive_router.py
@@ -123,7 +123,17 @@ class AdaptiveRouter:
                 self._cells[(rt, model)] = initial_cell(prefs, rt)
 
     async def load_state_from_db(self, prisma_client: Any) -> None:
-        """Override cold-start cells with persisted state. Called once at startup."""
+        """Add persisted deltas on top of the cold-start prior for every cell with a row.
+
+        A DB row holds accumulated deltas only (AdaptiveRouterUpdateQueue.flush_state_to_db
+        creates the row with the raw delta as its initial value, then increments it), never
+        the prior. Assigning `row.alpha`/`row.beta` straight into the cell would silently drop
+        the cold-start prior _init_cold_start_cells already put there, and the first flush after
+        a cell sees only one kind of signal persists a one-sided row (e.g. alpha=1, beta=0) - as
+        a bare Beta(alpha, beta) that zeroes out one shape parameter, which is invalid and 500s
+        on every later thompson_sample() draw for that cell. Adding the row on top of a freshly
+        computed prior keeps both parameters positive, since deltas are never negative.
+        """
         if prisma_client is None:
             return
         try:
@@ -139,7 +149,12 @@ class AdaptiveRouter:
                     continue
                 if row.model_name not in self.config.available_models:
                     continue
-                self._cells[(rt, row.model_name)] = BanditCell(alpha=row.alpha, beta=row.beta)
+                prefs = self.model_to_prefs.get(row.model_name) or _default_prefs()
+                prior = initial_cell(prefs, rt)
+                self._cells[(rt, row.model_name)] = BanditCell(
+                    alpha=prior.alpha + row.alpha,
+                    beta=prior.beta + row.beta,
+                )
                 loaded += 1
             verbose_router_logger.info(
                 "AdaptiveRouter[%s]: loaded %d cells from DB",

--- a/litellm/router_strategy/adaptive_router/adaptive_router.py
+++ b/litellm/router_strategy/adaptive_router/adaptive_router.py
@@ -123,16 +123,11 @@ class AdaptiveRouter:
                 self._cells[(rt, model)] = initial_cell(prefs, rt)
 
     async def load_state_from_db(self, prisma_client: Any) -> None:
-        """Add persisted deltas on top of the cold-start prior for every cell with a row.
+        """Add each row's persisted delta to a freshly computed cold-start prior.
 
-        A DB row holds accumulated deltas only (AdaptiveRouterUpdateQueue.flush_state_to_db
-        creates the row with the raw delta as its initial value, then increments it), never
-        the prior. Assigning `row.alpha`/`row.beta` straight into the cell would silently drop
-        the cold-start prior _init_cold_start_cells already put there, and the first flush after
-        a cell sees only one kind of signal persists a one-sided row (e.g. alpha=1, beta=0) - as
-        a bare Beta(alpha, beta) that zeroes out one shape parameter, which is invalid and 500s
-        on every later thompson_sample() draw for that cell. Adding the row on top of a freshly
-        computed prior keeps both parameters positive, since deltas are never negative.
+        A row holds an accumulated delta, not a full posterior, and can be one-sided
+        (e.g. beta=0) - assigning it straight into the cell would zero out a Beta shape
+        parameter and crash thompson_sample() on every later draw for that cell.
         """
         if prisma_client is None:
             return

--- a/tests/test_litellm/router_strategy/adaptive_router/test_adaptive_router.py
+++ b/tests/test_litellm/router_strategy/adaptive_router/test_adaptive_router.py
@@ -269,7 +269,11 @@ async def test_record_turn_bounds_feedback_contexts_and_evicts_least_recent_sess
 
 
 @pytest.mark.asyncio
-async def test_load_state_from_db_overrides_cold_start():
+async def test_load_state_from_db_adds_the_persisted_delta_to_the_cold_start_prior():
+    """A DB row holds an accumulated delta, not a full posterior (AdaptiveRouterUpdateQueue
+    creates the row with the raw delta and increments it from there) - loading it must add
+    that delta on top of the same cold-start prior _init_cold_start_cells already computed,
+    not replace the cell outright."""
     r = _make_router()
     cold = r._cells[(RequestType.GENERAL, "fast")]
 
@@ -284,8 +288,34 @@ async def test_load_state_from_db_overrides_cold_start():
     await r.load_state_from_db(prisma)
 
     new_cell = r._cells[(RequestType.GENERAL, "fast")]
-    assert (new_cell.alpha, new_cell.beta) == (42.0, 13.0)
-    assert (new_cell.alpha, new_cell.beta) != (cold.alpha, cold.beta)
+    assert (new_cell.alpha, new_cell.beta) == (cold.alpha + 42.0, cold.beta + 13.0)
+
+
+@pytest.mark.asyncio
+async def test_load_state_from_db_keeps_a_one_sided_delta_row_sampleable():
+    """Regression: a cell whose only DB activity is one signal type persists a one-sided row
+    (e.g. delta_beta=0.0, per AdaptiveRouterUpdateQueue.flush_state_to_db's create branch).
+    Loading that row must not zero out a Beta shape parameter - thompson_sample() raises
+    `ValueError: gammavariate: alpha and beta must be > 0.0` on a zeroed side, bricking every
+    request for that cell until the process restarts."""
+    from litellm.router_strategy.adaptive_router.bandit import thompson_sample
+
+    r = _make_router()
+
+    one_sided_row = MagicMock()
+    one_sided_row.request_type = "general"
+    one_sided_row.model_name = "fast"
+    one_sided_row.alpha = 1.0
+    one_sided_row.beta = 0.0
+
+    prisma = MagicMock()
+    prisma.db.litellm_adaptiverouterstate.find_many = AsyncMock(return_value=[one_sided_row])
+    await r.load_state_from_db(prisma)
+
+    loaded_cell = r._cells[(RequestType.GENERAL, "fast")]
+    assert loaded_cell.alpha > 0.0
+    assert loaded_cell.beta > 0.0
+    thompson_sample(loaded_cell)  # must not raise
 
 
 @pytest.mark.asyncio
@@ -309,10 +339,11 @@ async def test_load_state_from_db_handles_unknown_request_type():
     prisma.db.litellm_adaptiverouterstate.find_many = AsyncMock(return_value=[bad_row, good_row])
     await r.load_state_from_db(prisma)
 
-    # Unknown skipped; good applied.
-    assert r._cells[(RequestType.GENERAL, "fast")].alpha == 7.0
+    # Unknown skipped; good added to the cold-start prior.
+    new_general = r._cells[(RequestType.GENERAL, "fast")]
+    assert new_general.alpha == cold.alpha + 7.0
     # Other request types kept their cold-start values.
-    assert r._cells[(RequestType.WRITING, "fast")] == cold or True
+    assert r._cells[(RequestType.WRITING, "fast")] == cold
 
 
 # ---- Session state eviction ---------------------------------------------

--- a/tests/test_litellm/router_strategy/adaptive_router/test_adaptive_router.py
+++ b/tests/test_litellm/router_strategy/adaptive_router/test_adaptive_router.py
@@ -270,10 +270,8 @@ async def test_record_turn_bounds_feedback_contexts_and_evicts_least_recent_sess
 
 @pytest.mark.asyncio
 async def test_load_state_from_db_adds_the_persisted_delta_to_the_cold_start_prior():
-    """A DB row holds an accumulated delta, not a full posterior (AdaptiveRouterUpdateQueue
-    creates the row with the raw delta and increments it from there) - loading it must add
-    that delta on top of the same cold-start prior _init_cold_start_cells already computed,
-    not replace the cell outright."""
+    """A row holds an accumulated delta, not a full posterior; loading must add it to the
+    cold-start prior, not replace the cell outright."""
     r = _make_router()
     cold = r._cells[(RequestType.GENERAL, "fast")]
 
@@ -293,11 +291,8 @@ async def test_load_state_from_db_adds_the_persisted_delta_to_the_cold_start_pri
 
 @pytest.mark.asyncio
 async def test_load_state_from_db_keeps_a_one_sided_delta_row_sampleable():
-    """Regression: a cell whose only DB activity is one signal type persists a one-sided row
-    (e.g. delta_beta=0.0, per AdaptiveRouterUpdateQueue.flush_state_to_db's create branch).
-    Loading that row must not zero out a Beta shape parameter - thompson_sample() raises
-    `ValueError: gammavariate: alpha and beta must be > 0.0` on a zeroed side, bricking every
-    request for that cell until the process restarts."""
+    """A cell whose only DB activity is one signal type persists a one-sided row (e.g.
+    beta=0.0); loading it must not zero out a Beta shape parameter and crash thompson_sample()."""
     from litellm.router_strategy.adaptive_router.bandit import thompson_sample
 
     r = _make_router()
@@ -321,7 +316,8 @@ async def test_load_state_from_db_keeps_a_one_sided_delta_row_sampleable():
 @pytest.mark.asyncio
 async def test_load_state_from_db_handles_unknown_request_type():
     r = _make_router()
-    cold = r._cells[(RequestType.GENERAL, "fast")]
+    cold_general = r._cells[(RequestType.GENERAL, "fast")]
+    cold_writing = r._cells[(RequestType.WRITING, "fast")]
 
     bad_row = MagicMock()
     bad_row.request_type = "nonexistent_type_v999"
@@ -341,9 +337,9 @@ async def test_load_state_from_db_handles_unknown_request_type():
 
     # Unknown skipped; good added to the cold-start prior.
     new_general = r._cells[(RequestType.GENERAL, "fast")]
-    assert new_general.alpha == cold.alpha + 7.0
-    # Other request types kept their cold-start values.
-    assert r._cells[(RequestType.WRITING, "fast")] == cold
+    assert new_general.alpha == cold_general.alpha + 7.0
+    # Other request types kept their own cold-start values.
+    assert r._cells[(RequestType.WRITING, "fast")] == cold_writing
 
 
 # ---- Session state eviction ---------------------------------------------

--- a/tests/test_litellm/router_strategy/adaptive_router/test_e2e_adaptive_router.py
+++ b/tests/test_litellm/router_strategy/adaptive_router/test_e2e_adaptive_router.py
@@ -186,8 +186,14 @@ async def test_failure_signal_increments_beta_after_flush():
 
 
 @pytest.mark.asyncio
-async def test_load_state_from_db_overrides_cold_start():
+async def test_load_state_from_db_adds_persisted_delta_to_cold_start():
+    """A DB row is an accumulated delta, not a full posterior, so loading it must add onto the
+    same cold-start prior _init_cold_start_cells already computed, not replace the cell outright
+    (see test_adaptive_router.py's version of this test, and the one-sided create row
+    test_failure_signal_increments_beta_after_flush above asserts, for why)."""
     router = _make_router()
+    cold = router._cells[(RequestType.GENERAL, "gpt-4o")]
+
     fake_row = MagicMock()
     fake_row.request_type = RequestType.GENERAL.value
     fake_row.model_name = "gpt-4o"
@@ -200,8 +206,8 @@ async def test_load_state_from_db_overrides_cold_start():
     await router.load_state_from_db(prisma)
 
     cell = router._cells[(RequestType.GENERAL, "gpt-4o")]
-    assert cell.alpha == 90.0
-    assert cell.beta == 10.0
+    assert cell.alpha == cold.alpha + 90.0
+    assert cell.beta == cold.beta + 10.0
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/router_strategy/adaptive_router/test_e2e_adaptive_router.py
+++ b/tests/test_litellm/router_strategy/adaptive_router/test_e2e_adaptive_router.py
@@ -187,10 +187,8 @@ async def test_failure_signal_increments_beta_after_flush():
 
 @pytest.mark.asyncio
 async def test_load_state_from_db_adds_persisted_delta_to_cold_start():
-    """A DB row is an accumulated delta, not a full posterior, so loading it must add onto the
-    same cold-start prior _init_cold_start_cells already computed, not replace the cell outright
-    (see test_adaptive_router.py's version of this test, and the one-sided create row
-    test_failure_signal_increments_beta_after_flush above asserts, for why)."""
+    """A row holds an accumulated delta, not a full posterior; loading must add it to the
+    cold-start prior, not replace the cell outright."""
     router = _make_router()
     cold = router._cells[(RequestType.GENERAL, "gpt-4o")]
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Loading persisted adaptive-router state overwrites the cell's prior entirely
- A cell whose first flush saw only one signal type persists a one-sided row
- Reloading that row hands `thompson_sample` a `Beta(x, 0)` or `Beta(0, x)`
- Every request for that (model, request type) then 500s, permanently, even across restarts

How it solves it:

- Add the persisted delta on top of a freshly computed cold-start prior, instead of replacing the cell with it
- Deltas are never negative, so both Beta parameters stay positive no matter how lopsided the feedback was

## User Flow

Before: an operator running an `auto_router/adaptive_router` deployment finds one request type permanently 500ing after enough one-sided feedback accumulates for a model

1. Traffic runs normally against the adaptive router for a while
2. One (model, request type) pairing happens to only ever receive positive (or only ever negative) feedback signals before its next periodic state flush
3. Every later request that would route through that pairing returns HTTP 500: `gammavariate: alpha and beta must be > 0.0`
4. Restarting the proxy does not help - the same bad state reloads from the database and the same request type breaks again immediately

After: the same lopsided feedback no longer corrupts the cell

1. Traffic runs the same way and hits the same one-sided feedback pattern
2. The flushed state is added on top of the cell's original prior instead of replacing it
3. Requests for that (model, request type) pairing keep returning normal completions
4. A proxy restart reloads the same state cleanly, with no 500s

## Relevant issues

Fixes #35590
Fixes #29397

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

This environment has no LLM provider credentials, so there is no live proxy to curl. The bug only needs the persisted-state reload path, which these tests exercise directly against the real `AdaptiveRouter`/`BanditCell` classes with a mocked Prisma client (no mocked business logic):

- `test_adaptive_router.py::test_load_state_from_db_keeps_a_one_sided_delta_row_sampleable` - loads a one-sided row (`alpha=1.0, beta=0.0`, exactly what a first flush persists per `test_failure_signal_increments_beta_after_flush`'s existing assertion), then calls the real `thompson_sample` on the loaded cell
- `test_adaptive_router.py::test_load_state_from_db_adds_the_persisted_delta_to_the_cold_start_prior` and `test_e2e_adaptive_router.py::test_load_state_from_db_adds_persisted_delta_to_cold_start` - assert the loaded cell equals prior + row, not just row

```
uv run pytest tests/test_litellm/router_strategy/adaptive_router/ -q
156 passed
```

Confirmed these fail against the pre-fix code with the exact production error:

```
$ git stash push -- litellm/router_strategy/adaptive_router/adaptive_router.py
$ uv run pytest tests/test_litellm/router_strategy/adaptive_router/test_adaptive_router.py -q -k keeps_a_one_sided
...
    assert loaded_cell.beta > 0.0
E   assert 0.0 > 0.0
E    +  where 0.0 = BanditCell(alpha=1.0, beta=0.0).beta
1 failed
$ git stash pop
```

and separately, calling `random.betavariate(1.0, 0.0)` directly (what `thompson_sample` does on that same loaded cell) raises:

```
ValueError: gammavariate: alpha and beta must be > 0.0
```

which is the exact error both linked issues report in production.

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Proof of fix is the regression tests above plus a direct interpreter repro of the crash, not a live-proxy curl demo, since this sandbox has no provider credentials to run one against
- A row already persisted before this fix ships still self-heals on the next load, since load always recomputes prior + row from scratch rather than trusting what is already in `_cells`

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how adaptive router bandit state is hydrated at startup, which directly affects model selection; the logic is narrow and covered by targeted regression tests.
> 
> **Overview**
> Fixes adaptive router startup reload so persisted Postgres rows are treated as **accumulated bandit deltas**, not full `BanditCell` posteriors.
> 
> **`load_state_from_db`** no longer assigns `BanditCell(alpha=row.alpha, beta=row.beta)` over cold-start cells. It recomputes the cold-start prior via `initial_cell`, then sets the cell to **prior + row**. That keeps both Beta shape parameters strictly positive when a flushed row is one-sided (e.g. `beta=0.0` after only failure signals), so **`thompson_sample`** no longer raises `gammavariate: alpha and beta must be > 0.0` and routing stops permanently 500ing for that `(request_type, model)` after restart.
> 
> Tests were renamed/updated to expect **prior + delta**, and a regression test loads a one-sided row and asserts **`thompson_sample`** succeeds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d86efde9c1cb67ec00cff257580f63db620d387. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->