### PR TITLE
fix(adaptive_router): fall back to model_info for cost-weighted scoring

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -9075,10 +9075,7 @@ class Router:
             if prefs_raw is not None:
                 model_to_prefs[name] = AdaptiveRouterPreferences(**prefs_raw)
 
-            # `input_cost_per_token` is a LiteLLM_Params field per types/router.py, but custom
-            # pricing is conventionally declared under model_info everywhere else in LiteLLM
-            # (cost_calculator.py, add_deployment's litellm.model_cost registration), so fall
-            # back to it here too rather than silently reading a zero cost for such deployments.
+            # model_info is the conventional pricing location elsewhere in LiteLLM; litellm_params wins if set.
             lp = d.get("litellm_params") if isinstance(d, dict) else d.litellm_params
             lp_dict: dict[str, Any] = lp if isinstance(lp, dict) else (lp.model_dump() if lp else {})
             cost = lp_dict.get("input_cost_per_token")

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -9075,10 +9075,15 @@ class Router:
             if prefs_raw is not None:
                 model_to_prefs[name] = AdaptiveRouterPreferences(**prefs_raw)
 
-            # `input_cost_per_token` is a LiteLLM_Params field per types/router.py.
+            # `input_cost_per_token` is a LiteLLM_Params field per types/router.py, but custom
+            # pricing is conventionally declared under model_info everywhere else in LiteLLM
+            # (cost_calculator.py, add_deployment's litellm.model_cost registration), so fall
+            # back to it here too rather than silently reading a zero cost for such deployments.
             lp = d.get("litellm_params") if isinstance(d, dict) else d.litellm_params
             lp_dict: dict[str, Any] = lp if isinstance(lp, dict) else (lp.model_dump() if lp else {})
             cost = lp_dict.get("input_cost_per_token")
+            if cost is None:
+                cost = mi_dict.get("input_cost_per_token")
             if cost is not None:
                 model_to_cost[name] = float(cost)
 

--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -2174,10 +2174,7 @@ class ComplexityRouter(CustomLogger):
             else:
                 model_to_prefs[name] = AdaptiveRouterPreferences(quality_tier=2, strengths=[])
 
-            # `input_cost_per_token` is a LiteLLM_Params field per types/router.py, but custom
-            # pricing is conventionally declared under model_info everywhere else in LiteLLM
-            # (cost_calculator.py, add_deployment's litellm.model_cost registration), so fall
-            # back to it here too rather than silently costing such a deployment at 0.0.
+            # model_info is the conventional pricing location elsewhere in LiteLLM; litellm_params wins if set.
             lp = deployment.get("litellm_params") if isinstance(deployment, dict) else deployment.litellm_params
             lp_dict: dict[str, Any] = lp if isinstance(lp, dict) else (lp.model_dump() if lp else {})
             cost = lp_dict.get("input_cost_per_token")

--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -2174,9 +2174,15 @@ class ComplexityRouter(CustomLogger):
             else:
                 model_to_prefs[name] = AdaptiveRouterPreferences(quality_tier=2, strengths=[])
 
+            # `input_cost_per_token` is a LiteLLM_Params field per types/router.py, but custom
+            # pricing is conventionally declared under model_info everywhere else in LiteLLM
+            # (cost_calculator.py, add_deployment's litellm.model_cost registration), so fall
+            # back to it here too rather than silently costing such a deployment at 0.0.
             lp = deployment.get("litellm_params") if isinstance(deployment, dict) else deployment.litellm_params
             lp_dict: dict[str, Any] = lp if isinstance(lp, dict) else (lp.model_dump() if lp else {})
             cost = lp_dict.get("input_cost_per_token")
+            if cost is None:
+                cost = mi_dict.get("input_cost_per_token")
             model_to_cost[name] = float(cost) if cost is not None else 0.0
 
         self.adaptive_router = AdaptiveRouter(

--- a/tests/test_litellm/router_strategy/adaptive_router/test_router_dispatch.py
+++ b/tests/test_litellm/router_strategy/adaptive_router/test_router_dispatch.py
@@ -166,6 +166,44 @@ def test_init_adaptive_router_falls_back_to_model_info_cost():
     }
 
 
+@pytest.mark.asyncio
+async def test_pick_model_favors_the_cheaper_model_info_priced_deployment():
+    """Same fix, exercised through pick_model's actual scoring rather than the model_to_cost
+    dict alone: with cost as the only weight and equal quality priors, the cheaper deployment
+    must win every draw. `smart` (expensive) is listed first deliberately: before the fix both
+    models silently cost 0.0, tying every score, and pick_best's insertion-order tie-break would
+    hand every request to the first-listed (expensive) model instead."""
+    r = Router(
+        model_list=[
+            {
+                "model_name": "smart-cheap-router",
+                "litellm_params": {
+                    "model": "auto_router/adaptive_router",
+                    "adaptive_router_config": {
+                        "available_models": ["smart", "fast"],
+                        "weights": {"quality": 0.0, "cost": 1.0},
+                    },
+                },
+            },
+            {
+                "model_name": "smart",
+                "litellm_params": {"model": "openai/gpt-4o"},
+                "model_info": {"input_cost_per_token": 0.0000050},
+            },
+            {
+                "model_name": "fast",
+                "litellm_params": {"model": "openai/gpt-4o-mini"},
+                "model_info": {"input_cost_per_token": 0.00000015},
+            },
+        ]
+    )
+    adaptive = _adaptive(r, "smart-cheap-router")
+
+    picks = [await adaptive.pick_model(RequestType.GENERAL) for _ in range(10)]
+
+    assert picks == ["fast"] * 10
+
+
 def test_init_adaptive_router_prefers_litellm_params_cost_over_model_info():
     r = Router(
         model_list=[

--- a/tests/test_litellm/router_strategy/adaptive_router/test_router_dispatch.py
+++ b/tests/test_litellm/router_strategy/adaptive_router/test_router_dispatch.py
@@ -133,6 +133,64 @@ def test_init_adaptive_router_reads_cost_from_litellm_params():
     }
 
 
+def test_init_adaptive_router_falls_back_to_model_info_cost():
+    """Custom pricing declared under model_info (the conventional location everywhere else in
+    LiteLLM: cost_calculator.py, add_deployment's litellm.model_cost registration) must still
+    feed cost-weighted routing, not silently zero it out."""
+    r = Router(
+        model_list=[
+            {
+                "model_name": "smart-cheap-router",
+                "litellm_params": {
+                    "model": "auto_router/adaptive_router",
+                    "adaptive_router_config": {
+                        "available_models": ["fast", "smart"],
+                    },
+                },
+            },
+            {
+                "model_name": "fast",
+                "litellm_params": {"model": "openai/gpt-4o-mini"},
+                "model_info": {"input_cost_per_token": 0.00000015},
+            },
+            {
+                "model_name": "smart",
+                "litellm_params": {"model": "openai/gpt-4o"},
+                "model_info": {"input_cost_per_token": 0.0000050},
+            },
+        ]
+    )
+    assert _adaptive(r, "smart-cheap-router").model_to_cost == {
+        "fast": 0.00000015,
+        "smart": 0.0000050,
+    }
+
+
+def test_init_adaptive_router_prefers_litellm_params_cost_over_model_info():
+    r = Router(
+        model_list=[
+            {
+                "model_name": "smart-cheap-router",
+                "litellm_params": {
+                    "model": "auto_router/adaptive_router",
+                    "adaptive_router_config": {
+                        "available_models": ["fast"],
+                    },
+                },
+            },
+            {
+                "model_name": "fast",
+                "litellm_params": {
+                    "model": "openai/gpt-4o-mini",
+                    "input_cost_per_token": 0.00000015,
+                },
+                "model_info": {"input_cost_per_token": 0.0000050},
+            },
+        ]
+    )
+    assert _adaptive(r, "smart-cheap-router").model_to_cost == {"fast": 0.00000015}
+
+
 # ---- Fix 4: pre-routing dispatch ---------------------------------------
 
 

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -1548,6 +1548,46 @@ class TestRouterComplexityDeploymentMethods:
             "premium": pytest.approx(0.000005),
         }
 
+    @pytest.mark.asyncio
+    async def test_hybrid_adaptive_router_pick_model_favors_the_cheaper_model_info_priced_deployment(self):
+        """Same fix, exercised through pick_model's actual scoring rather than the model_to_cost
+        dict alone. `premium` is listed first (SIMPLE tier) deliberately: before the fix both
+        models silently cost 0.0, tying every score, and pick_best's insertion-order tie-break
+        would hand every request to the first-listed (expensive) model instead."""
+        from litellm.types.router import RequestType
+
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "hybrid",
+                    "litellm_params": {
+                        "model": "auto_router/complexity_router",
+                        "complexity_router_default_model": "cheap",
+                        "complexity_router_config": {
+                            "adaptive": True,
+                            "adaptive_weights": {"quality": 0.0, "cost": 1.0},
+                            "tiers": {"SIMPLE": ["premium"], "MEDIUM": ["premium", "cheap"]},
+                        },
+                    },
+                },
+                {
+                    "model_name": "premium",
+                    "litellm_params": {"model": "openai/gpt-4o"},
+                    "model_info": {"input_cost_per_token": 0.000005},
+                },
+                {
+                    "model_name": "cheap",
+                    "litellm_params": {"model": "openai/gpt-4o-mini"},
+                    "model_info": {"input_cost_per_token": 0.00000015},
+                },
+            ]
+        )
+        adaptive = router.adaptive_routers["hybrid"][0].strategy
+
+        picks = [await adaptive.pick_model(RequestType.GENERAL) for _ in range(10)]
+
+        assert picks == ["cheap"] * 10
+
     def test_hybrid_adaptive_router_prefers_litellm_params_cost_over_model_info(self):
         router = Router(
             model_list=[

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -1512,6 +1512,70 @@ class TestRouterComplexityDeploymentMethods:
         assert adaptive.model_to_prefs["cheap"].quality_tier == 1
         assert adaptive.model_to_prefs["premium"].quality_tier == 3
 
+    def test_hybrid_adaptive_router_falls_back_to_model_info_cost(self):
+        """Custom pricing declared under model_info (the conventional location everywhere else
+        in LiteLLM) must still feed the hybrid adaptive router's cost-weighted scoring, not
+        silently cost the deployment at 0.0."""
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "hybrid",
+                    "litellm_params": {
+                        "model": "auto_router/complexity_router",
+                        "complexity_router_default_model": "cheap",
+                        "complexity_router_config": {
+                            "adaptive": True,
+                            "tiers": {"SIMPLE": ["cheap"], "MEDIUM": ["cheap", "premium"]},
+                        },
+                    },
+                },
+                {
+                    "model_name": "cheap",
+                    "litellm_params": {"model": "openai/gpt-4o-mini"},
+                    "model_info": {"input_cost_per_token": 0.00000015},
+                },
+                {
+                    "model_name": "premium",
+                    "litellm_params": {"model": "openai/gpt-4o"},
+                    "model_info": {"input_cost_per_token": 0.000005},
+                },
+            ]
+        )
+
+        adaptive = router.adaptive_routers["hybrid"][0].strategy
+        assert adaptive.model_to_cost == {
+            "cheap": pytest.approx(0.00000015),
+            "premium": pytest.approx(0.000005),
+        }
+
+    def test_hybrid_adaptive_router_prefers_litellm_params_cost_over_model_info(self):
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "hybrid",
+                    "litellm_params": {
+                        "model": "auto_router/complexity_router",
+                        "complexity_router_default_model": "cheap",
+                        "complexity_router_config": {
+                            "adaptive": True,
+                            "tiers": {"SIMPLE": ["cheap"]},
+                        },
+                    },
+                },
+                {
+                    "model_name": "cheap",
+                    "litellm_params": {
+                        "model": "openai/gpt-4o-mini",
+                        "input_cost_per_token": 0.00000015,
+                    },
+                    "model_info": {"input_cost_per_token": 0.000005},
+                },
+            ]
+        )
+
+        adaptive = router.adaptive_routers["hybrid"][0].strategy
+        assert adaptive.model_to_cost == {"cheap": pytest.approx(0.00000015)}
+
 
 class TestComplexityRouterTagBasedRouting:
     """Regression tests for https://github.com/BerriAI/litellm/issues/33655.


### PR DESCRIPTION
## TLDR

Problem this solves:

- Adaptive-router cost-weighted scoring only reads `input_cost_per_token` from `litellm_params`
- Custom pricing declared under `model_info` (the convention everywhere else in LiteLLM) reads as $0.00
- Every candidate then ties on cost, so routing runs on quality alone with no warning

How it solves it:

- Fall back to `model_info.input_cost_per_token` when `litellm_params` does not declare one
- Applied at both places that build `model_to_cost`: the plain `auto_router/adaptive_router` path and the hybrid adaptive-inside-`complexity_router` path
- `litellm_params` still wins when both are set

## User Flow

Before: an operator who prices a deployment under `model_info`, the same way they would for spend tracking or budget alerts, finds cost never influences their adaptive router

1. The operator registers a deployment with `model_info.input_cost_per_token` set (no `litellm_params.input_cost_per_token`)
2. They configure `auto_router/adaptive_router` (or a hybrid `complexity_router` with `adaptive: true`) with `weights: {quality: X, cost: Y}` including that deployment
3. Every request routes as if `cost weight` were 0: an expensive and a cheap deployment are chosen with equal likelihood
4. Nothing in the response or logs indicates the cost weight is being ignored

After: the same pricing is picked up

1. The operator registers the same deployment the same way
2. They configure the same adaptive/hybrid router
3. Requests now favor the cheaper deployment in proportion to the configured cost weight, same as a deployment priced under `litellm_params` already would

## Relevant issues

Fixes #31481

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

This environment has no LLM provider credentials, so there is no live proxy to curl. The fix is exercised end to end through the real `Router` class (no mocked routing logic), asserting the resulting `model_to_cost` dict the bandit actually scores against:

- `test_router_dispatch.py::test_init_adaptive_router_falls_back_to_model_info_cost` - plain `auto_router/adaptive_router`, cost only under `model_info`
- `test_router_dispatch.py::test_init_adaptive_router_prefers_litellm_params_cost_over_model_info` - both set, `litellm_params` wins
- `test_complexity_router.py::test_hybrid_adaptive_router_falls_back_to_model_info_cost` - same, through the hybrid `complexity_router(adaptive=True)` path
- `test_router_dispatch.py::test_pick_model_favors_the_cheaper_model_info_priced_deployment` - same fix through `pick_model`'s actual Thompson-sampling output, not just the cache dict; ordered so the pre-fix code always picks the expensive model on pick_best's tie-break
- `test_complexity_router.py::test_hybrid_adaptive_router_pick_model_favors_the_cheaper_model_info_priced_deployment` - same, hybrid path
- `test_complexity_router.py::test_hybrid_adaptive_router_prefers_litellm_params_cost_over_model_info` - same precedence check, hybrid path

```
uv run pytest tests/test_litellm/router_strategy/test_complexity_router.py tests/test_litellm/router_strategy/adaptive_router/ -q
958 passed
```

Both `_falls_back_to_model_info_cost` tests fail against the pre-fix code with `model_to_cost == {"cheap": 0.0, "premium": 0.0}` (confirmed by stashing the production diff and re-running), showing the exact silent-zero behavior the issue reports; both `_prefers_litellm_params` precedence tests already pass unmodified, confirming no change to the existing behavior when `litellm_params` sets the cost.

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Proof of fix is the tests above, not a live-proxy curl demo, since this sandbox has no provider credentials to run one against

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized routing init change with clear precedence rules and regression tests; no auth or data-path changes.
> 
> **Overview**
> **Adaptive and hybrid routers now honor `model_info.input_cost_per_token` when building cost scores**, fixing silent $0 pricing that made cost weights ineffective.
> 
> When initializing `model_to_cost`, both the standalone `auto_router/adaptive_router` path in `router.py` and the hybrid adaptive path inside `complexity_router` still read `litellm_params.input_cost_per_token` first; if missing, they **fall back to `model_info.input_cost_per_token`**, matching how pricing is set elsewhere in LiteLLM. If both are set, **`litellm_params` wins**.
> 
> New tests cover the fallback dict, cost-only `pick_model` preferring the cheaper deployment, hybrid complexity-router parity, and precedence when both fields differ.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afc604d1da842ef600e14589a3eccd908427639a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
