### PR TITLE
fix(proxy): keep guardrail cost in spend on cache hits

### DIFF
--- a/litellm/proxy/hooks/proxy_track_cost_callback.py
+++ b/litellm/proxy/hooks/proxy_track_cost_callback.py
@@ -254,7 +254,7 @@ class _ProxyDBLogger(CustomLogger):
             key_alias: Final = cast(str | None, metadata.get("user_api_key_alias", None))
             end_user_max_budget: Final = metadata.get("user_api_end_user_max_budget", None)
             sl_object: Final[StandardLoggingPayload | None] = kwargs.get("standard_logging_object", None)
-            response_cost = (
+            response_cost: Final = (
                 sl_object.get("response_cost", None) if sl_object is not None else kwargs.get("response_cost", None)
             )
             tags: Final = _get_request_tags_for_cost_tracking(
@@ -269,10 +269,6 @@ class _ProxyDBLogger(CustomLogger):
 
             if response_cost is not None:
                 user_api_key: Final = metadata.get("user_api_key", None)
-                if kwargs.get("cache_hit", False) is True:
-                    response_cost = 0.0
-                    verbose_proxy_logger.debug("Cache Hit: response_cost %s, for user_id %s", response_cost, user_id)
-
                 verbose_proxy_logger.debug(
                     "user_api_key %s, user_id %s, team_id %s, end_user_id %s",
                     user_api_key,

--- a/tests/test_litellm/proxy/hooks/test_proxy_track_cost_callback.py
+++ b/tests/test_litellm/proxy/hooks/test_proxy_track_cost_callback.py
@@ -1783,6 +1783,53 @@ async def test_track_cost_callback_enriches_user_id_for_mcp_style_metadata():
         )
 
 
+@pytest.mark.asyncio
+async def test_track_cost_callback_keeps_guardrail_cost_on_cache_hit():
+    """A cache hit skips the LLM, not the guardrail that screened the prompt, so the
+    guardrail's provider charge must still reach spend logs and budgets. The payload
+    already prices the LLM share at 0 on a cache hit, so its response_cost is the
+    guardrail cost alone and the callback must pass it through untouched."""
+    logger = _ProxyDBLogger()
+    kwargs = {
+        "call_type": "acompletion",
+        "model": "gpt-4o",
+        "cache_hit": True,
+        "response_cost": 0.0,
+        "litellm_params": {
+            "metadata": {
+                "user_api_key": "hashed-key",
+                "user_api_key_user_id": "user-1",
+                "user_api_key_team_id": "team-1",
+            }
+        },
+        "standard_logging_object": {
+            "response_cost": 0.0003,
+            "request_tags": [],
+            "metadata": {},
+            "cost_breakdown": {"guardrail_cost": 0.0003, "total_cost": 0.0003},
+        },
+    }
+
+    with (
+        patch("litellm.proxy.proxy_server.increment_spend_counters", new_callable=AsyncMock) as mock_increment,
+        patch("litellm.proxy.proxy_server.update_cache", new_callable=AsyncMock),
+        patch("litellm.proxy.proxy_server.proxy_logging_obj") as mock_proxy_logging,
+    ):
+        mock_proxy_logging.db_spend_update_writer.update_database = AsyncMock()
+        mock_proxy_logging.slack_alerting_instance.customer_spend_alert = AsyncMock()
+
+        await logger._PROXY_track_cost_callback(
+            kwargs=kwargs,
+            completion_response={"id": "cached-call-1"},
+            start_time=datetime.now(),
+            end_time=datetime.now(),
+        )
+
+        update_kwargs = mock_proxy_logging.db_spend_update_writer.update_database.await_args.kwargs
+        assert update_kwargs["response_cost"] == pytest.approx(0.0003)
+        assert mock_increment.call_args.kwargs["response_cost"] == pytest.approx(0.0003)
+
+
 @pytest.mark.parametrize(
     "call_type, expected",
     [

--- a/tests/test_litellm/proxy/hooks/test_proxy_track_cost_callback.py
+++ b/tests/test_litellm/proxy/hooks/test_proxy_track_cost_callback.py
@@ -1811,9 +1811,9 @@ async def test_track_cost_callback_keeps_guardrail_cost_on_cache_hit():
     }
 
     with (
-        patch("litellm.proxy.proxy_server.increment_spend_counters", new_callable=AsyncMock) as mock_increment,
-        patch("litellm.proxy.proxy_server.update_cache", new_callable=AsyncMock),
-        patch("litellm.proxy.proxy_server.proxy_logging_obj") as mock_proxy_logging,
+        patch("litellm.proxy.proxy_server.increment_spend_counters", new_callable=AsyncMock) as mock_increment,  # test-quality-ok: the callback imports this from proxy_server inside its body, so there is no injection seam
+        patch("litellm.proxy.proxy_server.update_cache", new_callable=AsyncMock),  # test-quality-ok: same function-body import, no injection seam
+        patch("litellm.proxy.proxy_server.proxy_logging_obj") as mock_proxy_logging,  # test-quality-ok: same function-body import, no injection seam
     ):
         mock_proxy_logging.db_spend_update_writer.update_database = AsyncMock()
         mock_proxy_logging.slack_alerting_instance.customer_spend_alert = AsyncMock()


### PR DESCRIPTION
## TLDR

Problem this solves:

- A cache hit skips the LLM, but the guardrail still ran and billed
- Spend logs, daily tables and budgets recorded the cached request at $0
- The proxy overwrote the request cost with 0 whenever the response was cached

How it solves it:

- The proxy stops zeroing the cost on cache hits
- The request cost is already LLM $0 plus guardrail cost by the time the proxy sees it
- Cached requests now carry exactly the guardrail charge into spend and budgets

## User Flow

Before: an operator who fronts a model with a paid Bedrock guardrail and turns on response caching sees every cache hit logged at $0, even though AWS billed the guardrail

1. They send POST https://litellm-domain/v1/chat/completions with a prompt containing an SSN, through a key whose model has a Bedrock PII guardrail on by default
2. The response comes back with the SSN masked and the log shows spend $0.0001594, with `guardrail_cost: 0.0001` in its cost breakdown
3. They send the identical request again and get the identical response back from the cache
4. GET https://litellm-domain/spend/logs?api_key=<hash> shows the second row with `cache_hit: "True"` and `spend: 0.0`, while its own cost breakdown still says `guardrail_cost: 0.0001`

After: the same cache hit is logged at the guardrail's real charge

1. They send POST https://litellm-domain/v1/chat/completions with the same SSN prompt through the same key
2. The response comes back masked with spend $0.0001594 and `guardrail_cost: 0.0001`, unchanged
3. They send the identical request again and get the cached response
4. GET https://litellm-domain/spend/logs?api_key=<hash> shows the second row with `cache_hit: "True"` and `spend: 0.0001`, matching its `guardrail_cost`

## Relevant issues

## Linear ticket

Refs LIT-5652

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Setup shared by both runs: proxy on port 4327 with `cache: true` (`cache_params: {type: local}`) and a real Bedrock guardrail (`guardrailIdentifier: 164nbov72q77`, `mode: pre_call`, `default_on: true`, bills `sensitiveInformationPolicyUnits` at $0.0001 each) in front of `bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0`. Each run generates a fresh virtual key, sends the same SSN prompt twice, waits for the spend batch write, then reads that key's spend logs back

```
KEY=$(curl -s -X POST http://localhost:4327/key/generate -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"key_alias":"cache-hit-guardrail","models":["bedrock-invoke-haiku-4-5"]}' | jq -r .key)
for i in 1 2; do
  curl -s http://localhost:4327/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' \
    -d '{"model":"bedrock-invoke-haiku-4-5","messages":[{"role":"user","content":"My SSN is 123-45-6789, reply with just the word ok"}],"max_tokens":5}' \
    | jq -c '{id, content: .choices[0].message.content}'
done
sleep 6
curl -s "http://localhost:4327/spend/logs?api_key=$(printf %s "$KEY" | sha256sum | cut -d' ' -f1)" -H 'Authorization: Bearer sk-1234' \
  | jq -c 'sort_by(.startTime)[] | {request_id, cache_hit, spend, guardrail_cost: .metadata.cost_breakdown.guardrail_cost}'
```

### Before (bf51dea36b)

1. Both calls return the same masked completion, the second served from cache

```
chatcmpl-ab256768-3f56-4cab-8cb6-50b65a2578dd "I can't process or"
chatcmpl-ab256768-3f56-4cab-8cb6-50b65a2578dd "I can't process or"
```

2. The cache-hit row is logged at $0 while its own breakdown records the $0.0001 guardrail charge

```
{"request_id": "chatcmpl-ab256768-3f56-4cab-8cb6-50b65a2578dd", "cache_hit": "None", "spend": 0.0001594, "guardrail_cost": 0.0001}
{"request_id": "chatcmpl-ab256768-3f56-4cab-8cb6-50b65a2578dd_cache_hit1788647497.430154", "cache_hit": "True", "spend": 0.0, "guardrail_cost": 0.0001}
```

### After (63156a7bd6)

Captured at acddd21860; the one commit after it only adds reason comments to the test

1. Both calls return the same masked completion, the second served from cache

```
chatcmpl-d628835c-8ee9-49dc-87d3-f10d5b9f5cfe "I can't process or"
chatcmpl-d628835c-8ee9-49dc-87d3-f10d5b9f5cfe "I can't process or"
```

2. The cache-hit row is logged at exactly the guardrail charge, and the first row is unchanged

```
{"request_id": "chatcmpl-d628835c-8ee9-49dc-87d3-f10d5b9f5cfe", "cache_hit": "None", "spend": 0.0001594, "guardrail_cost": 0.0001}
{"request_id": "chatcmpl-d628835c-8ee9-49dc-87d3-f10d5b9f5cfe_cache_hit1788647461.5990222", "cache_hit": "True", "spend": 0.0001, "guardrail_cost": 0.0001}
```

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- Cache hits without a guardrail keep costing $0; only the guardrail share changes
- Docs that say cached responses are free now need a "except guardrail cost" note

### Low

- The dropped check dates from Jan 2024, before the logging layer priced cache hits at $0 itself, so nothing else depended on it

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
