### PR TITLE
fix(fireworks_ai): strip reasoning_details from messages

### DIFF
--- a/litellm/llms/fireworks_ai/chat/transformation.py
+++ b/litellm/llms/fireworks_ai/chat/transformation.py
@@ -512,6 +512,7 @@ class FireworksAIConfig(FireworksAIMixin, OpenAIGPTConfig):
                 m.pop("provider_specific_fields", None)
                 m.pop("thinking_blocks", None)
                 m.pop("reasoning_content", None)
+                m.pop("reasoning_details", None)
 
         return messages
 

--- a/tests/test_litellm/llms/fireworks_ai/chat/test_fireworks_ai_chat_transformation.py
+++ b/tests/test_litellm/llms/fireworks_ai/chat/test_fireworks_ai_chat_transformation.py
@@ -227,9 +227,7 @@ def test_validate_environment_raises_without_api_key(monkeypatch):
 
 def test_get_fireworks_session_id_prefers_litellm_session_id_over_trace_id():
     assert (
-        get_fireworks_session_id(
-            {"litellm_session_id": "session-123", "litellm_trace_id": "trace-123"}
-        )
+        get_fireworks_session_id({"litellm_session_id": "session-123", "litellm_trace_id": "trace-123"})
         == "session-123"
     )
 
@@ -281,16 +279,11 @@ def test_handle_message_content_with_tool_calls():
             },
         }
     ]
-    updated_message = config._handle_message_content_with_tool_calls(
-        message, tool_calls
-    )
+    updated_message = config._handle_message_content_with_tool_calls(message, tool_calls)
     assert updated_message.tool_calls is not None
     assert len(updated_message.tool_calls) == 1
     assert updated_message.tool_calls[0].function.name == "get_current_weather"
-    assert (
-        updated_message.tool_calls[0].function.arguments
-        == expected_tool_call.function.arguments
-    )
+    assert updated_message.tool_calls[0].function.arguments == expected_tool_call.function.arguments
 
 
 def test_supports_reasoning_effort():
@@ -317,23 +310,21 @@ def test_supports_reasoning_effort():
     ]
 
     for model in supported_models:
-        assert (
-            supports_reasoning(model=model, custom_llm_provider="fireworks_ai") is True
-        ), f"{model} should support reasoning_effort"
+        assert supports_reasoning(model=model, custom_llm_provider="fireworks_ai") is True, (
+            f"{model} should support reasoning_effort"
+        )
 
     for model in unsupported_models:
-        assert (
-            supports_reasoning(model=model, custom_llm_provider="fireworks_ai") is False
-        ), f"{model} should not support reasoning_effort"
+        assert supports_reasoning(model=model, custom_llm_provider="fireworks_ai") is False, (
+            f"{model} should not support reasoning_effort"
+        )
 
 
 def test_get_supported_openai_params_reasoning_effort():
     """Test that reasoning_effort is only included in supported params for models that support it."""
     config = FireworksAIConfig()
 
-    supported_params = config.get_supported_openai_params(
-        "fireworks_ai/accounts/fireworks/models/glm-5p1"
-    )
+    supported_params = config.get_supported_openai_params("fireworks_ai/accounts/fireworks/models/glm-5p1")
     assert "reasoning_effort" in supported_params
     assert "thinking" in supported_params
 
@@ -348,9 +339,7 @@ def test_get_supported_openai_params_parallel_tool_calls():
     """Test that parallel_tool_calls is included for models that support function calling."""
     config = FireworksAIConfig()
 
-    supported_params = config.get_supported_openai_params(
-        "fireworks_ai/accounts/fireworks/models/glm-5p1"
-    )
+    supported_params = config.get_supported_openai_params("fireworks_ai/accounts/fireworks/models/glm-5p1")
     assert "parallel_tool_calls" in supported_params
     assert "tools" in supported_params
     assert "tool_choice" in supported_params
@@ -364,9 +353,7 @@ def test_get_supported_openai_params_parallel_tool_calls():
 def test_get_supported_openai_params_short_model_name_resolves_account_prefixed_entry():
     config = FireworksAIConfig()
 
-    supported_params = config.get_supported_openai_params(
-        "fireworks_ai/deepseek-v4-pro-0813"
-    )
+    supported_params = config.get_supported_openai_params("fireworks_ai/deepseek-v4-pro-0813")
 
     assert "tool_choice" in supported_params
     assert "reasoning_effort" in supported_params
@@ -375,9 +362,7 @@ def test_get_supported_openai_params_short_model_name_resolves_account_prefixed_
 def test_get_supported_openai_params_preserves_generic_reasoning_fallback():
     config = FireworksAIConfig()
 
-    supported_params = config.get_supported_openai_params(
-        "fireworks_ai/accounts/fireworks/models/glm-5p3-flash"
-    )
+    supported_params = config.get_supported_openai_params("fireworks_ai/accounts/fireworks/models/glm-5p3-flash")
 
     assert "reasoning_effort" in supported_params
 
@@ -453,14 +438,10 @@ def test_get_models_url_no_double_v1(api_base, expected_url_prefix):
 
     mock_response = MagicMock()
     mock_response.status_code = 200
-    mock_response.json.return_value = {
-        "models": [{"name": "accounts/fireworks/models/llama-v3-70b"}]
-    }
+    mock_response.json.return_value = {"models": [{"name": "accounts/fireworks/models/llama-v3-70b"}]}
 
     with (
-        patch(
-            "litellm.module_level_client.get", return_value=mock_response
-        ) as mock_get,
+        patch("litellm.module_level_client.get", return_value=mock_response) as mock_get,
         patch(
             "litellm.llms.fireworks_ai.chat.transformation.get_secret_str",
             side_effect=lambda key: {
@@ -472,13 +453,9 @@ def test_get_models_url_no_double_v1(api_base, expected_url_prefix):
     ):
         result = config.get_models(api_key="test-key", api_base=api_base)
 
-        called_url = mock_get.call_args.kwargs.get("url") or mock_get.call_args[1].get(
-            "url", ""
-        )
+        called_url = mock_get.call_args.kwargs.get("url") or mock_get.call_args[1].get("url", "")
         assert "/v1/v1/" not in called_url, f"Double /v1/ detected in URL: {called_url}"
-        assert called_url.startswith(
-            expected_url_prefix
-        ), f"URL {called_url} does not start with {expected_url_prefix}"
+        assert called_url.startswith(expected_url_prefix), f"URL {called_url} does not start with {expected_url_prefix}"
         assert result == ["fireworks_ai/accounts/fireworks/models/llama-v3-70b"]
 
 
@@ -506,9 +483,7 @@ def test_transform_messages_helper_removes_provider_specific_fields():
         },
     ]
     # Call helper
-    out = config._transform_messages_helper(
-        messages, model="fireworks/test", litellm_params={}
-    )
+    out = config._transform_messages_helper(messages, model="fireworks/test", litellm_params={})
     for msg in out:
         assert "provider_specific_fields" not in msg
 
@@ -529,18 +504,49 @@ def test_transform_messages_helper_strips_thinking_blocks():
         {
             "role": "assistant",
             "content": "I can help.",
-            "thinking_blocks": [
-                {"type": "thinking", "thinking": "internal", "signature": ""}
-            ],
+            "thinking_blocks": [{"type": "thinking", "thinking": "internal", "signature": ""}],
             "reasoning_content": "internal",
         },
     ]
-    out = config._transform_messages_helper(
-        messages, model="accounts/fireworks/models/glm-5p1", litellm_params={}
-    )
+    out = config._transform_messages_helper(messages, model="accounts/fireworks/models/glm-5p1", litellm_params={})
     assert "thinking_blocks" not in out[1]
     assert "reasoning_content" not in out[1]
     assert out[1]["content"] == "I can help."
+
+
+def test_transform_request_strips_reasoning_details():
+    """reasoning_details, returned some other providers on assistant messages, is rejected by
+    Fireworks with "Extra inputs are not permitted" when both are in one model group."""
+    config = FireworksAIConfig()
+    reply = Message(
+        role="assistant",
+        content="4",
+        reasoning_details=[
+            {
+                "type": "reasoning.text",
+                "text": "The user asked for 2+2.",
+                "format": "unknown",
+                "index": 0,
+            }
+        ],
+    ).model_dump(exclude_none=True)
+    assert "reasoning_details" in reply
+
+    request = config.transform_request(
+        model="fireworks_ai/accounts/fireworks/models/glm-5p1",
+        messages=[
+            {"role": "user", "content": "What is 2+2?"},
+            reply,
+            {"role": "user", "content": "And 3+3?"},
+        ],
+        optional_params={},
+        litellm_params={},
+        headers={},
+    )
+
+    assistant_message = request["messages"][1]
+    assert "reasoning_details" not in assistant_message
+    assert assistant_message["content"] == "4"
 
 
 # -----------------------------------------------------------------------------
@@ -1026,9 +1032,7 @@ def test_transform_messages_helper_rejects_file_blocks():
         litellm.BadRequestError,
         match="Fireworks AI chat completions does not support file content blocks",
     ):
-        config._transform_messages_helper(
-            messages, model="accounts/fireworks/models/kimi-k2p6", litellm_params={}
-        )
+        config._transform_messages_helper(messages, model="accounts/fireworks/models/kimi-k2p6", litellm_params={})
 
 
 def test_transform_messages_helper_rejects_non_vision_image_inputs():
@@ -1040,18 +1044,14 @@ def test_transform_messages_helper_rejects_non_vision_image_inputs():
                 {"type": "text", "text": "Describe this"},
                 {
                     "type": "image_url",
-                    "image_url": {
-                        "url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAE="
-                    },
+                    "image_url": {"url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAE="},
                 },
             ],
         }
     ]
 
     with pytest.raises(litellm.BadRequestError, match="does not support image inputs"):
-        config._transform_messages_helper(
-            messages, model="accounts/fireworks/models/glm-5p2", litellm_params={}
-        )
+        config._transform_messages_helper(messages, model="accounts/fireworks/models/glm-5p2", litellm_params={})
 
 
 def test_transform_messages_helper_allows_vision_image_inputs():
@@ -1063,17 +1063,13 @@ def test_transform_messages_helper_allows_vision_image_inputs():
                 {"type": "text", "text": "Describe this"},
                 {
                     "type": "image_url",
-                    "image_url": {
-                        "url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAE="
-                    },
+                    "image_url": {"url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAE="},
                 },
             ],
         }
     ]
 
-    out = config._transform_messages_helper(
-        messages, model="accounts/fireworks/models/minimax-m3", litellm_params={}
-    )
+    out = config._transform_messages_helper(messages, model="accounts/fireworks/models/minimax-m3", litellm_params={})
     assert out == messages
 
 
@@ -1089,9 +1085,7 @@ def test_image_inputs_not_rejected_for_fuzzy_non_vision_match():
     custom_model = "accounts/myorg/models/custom-glm-5p2"
 
     assert config._get_model_cost_capability(custom_model, "supports_vision") is False
-    assert (
-        config._get_model_cost_capability_exact(custom_model, "supports_vision") is None
-    )
+    assert config._get_model_cost_capability_exact(custom_model, "supports_vision") is None
 
     messages = [
         {
@@ -1099,16 +1093,12 @@ def test_image_inputs_not_rejected_for_fuzzy_non_vision_match():
             "content": [
                 {
                     "type": "image_url",
-                    "image_url": {
-                        "url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAE="
-                    },
+                    "image_url": {"url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAE="},
                 },
             ],
         }
     ]
-    out = config._transform_messages_helper(
-        messages, model=custom_model, litellm_params={}
-    )
+    out = config._transform_messages_helper(messages, model=custom_model, litellm_params={})
     assert out == messages
 
 
@@ -1121,9 +1111,7 @@ def test_transform_messages_helper_skips_non_dict_content():
         }
     ]
 
-    out = config._transform_messages_helper(
-        messages, model="accounts/fireworks/models/glm-5p2", litellm_params={}
-    )
+    out = config._transform_messages_helper(messages, model="accounts/fireworks/models/glm-5p2", litellm_params={})
     assert out == messages
 
 
@@ -1136,9 +1124,7 @@ def test_transform_messages_helper_no_transform_inline():
             "content": [{"type": "image_url", "image_url": url}],
         }
     ]
-    out = config._transform_messages_helper(
-        messages, model="accounts/fireworks/models/minimax-m3", litellm_params={}
-    )
+    out = config._transform_messages_helper(messages, model="accounts/fireworks/models/minimax-m3", litellm_params={})
     block = out[0]["content"][0]
     assert block["image_url"] == url
     assert "#transform=inline" not in block["image_url"]
@@ -1341,9 +1327,7 @@ def test_streaming_surfaces_fireworks_response_fields():
         surfaced: dict = {}
         for chunk in stream:
             fields = getattr(chunk, "provider_specific_fields", None) or {}
-            surfaced.update(
-                {k: v for k, v in fields.items() if k.startswith("fireworks_")}
-            )
+            surfaced.update({k: v for k, v in fields.items() if k.startswith("fireworks_")})
 
     assert surfaced["fireworks_token_ids"] == [[123]]
     assert surfaced["fireworks_raw_outputs"] == [raw_output]
@@ -1396,9 +1380,7 @@ def test_transform_request_direct_route_passthrough():
 
 def test_map_extra_body_params_translates_truncate_prompt_tokens():
     config = FireworksAIConfig()
-    result = config.map_extra_body_params(
-        {"extra_body": {"truncate_prompt_tokens": 4096}}, _REASONING_MODEL
-    )
+    result = config.map_extra_body_params({"extra_body": {"truncate_prompt_tokens": 4096}}, _REASONING_MODEL)
     assert result == {"prompt_truncate_len": 4096}
 
 
@@ -1557,9 +1539,7 @@ def test_map_extra_body_params_non_dict_chat_template_kwargs_dropped():
 def test_map_extra_body_params_guided_json():
     config = FireworksAIConfig()
     schema = {"type": "object", "properties": {"x": {"type": "string"}}}
-    result = config.map_extra_body_params(
-        {"extra_body": {"guided_json": schema}}, _REASONING_MODEL
-    )
+    result = config.map_extra_body_params({"extra_body": {"guided_json": schema}}, _REASONING_MODEL)
     assert result == {
         "response_format": {
             "type": "json_schema",
@@ -1570,16 +1550,10 @@ def test_map_extra_body_params_guided_json():
 
 def test_map_extra_body_params_guided_grammar_and_choice():
     config = FireworksAIConfig()
-    grammar = config.map_extra_body_params(
-        {"extra_body": {"guided_grammar": "root ::= 'hello'"}}, _REASONING_MODEL
-    )
-    assert grammar == {
-        "response_format": {"type": "grammar", "grammar": "root ::= 'hello'"}
-    }
+    grammar = config.map_extra_body_params({"extra_body": {"guided_grammar": "root ::= 'hello'"}}, _REASONING_MODEL)
+    assert grammar == {"response_format": {"type": "grammar", "grammar": "root ::= 'hello'"}}
 
-    choice = config.map_extra_body_params(
-        {"extra_body": {"guided_choice": ["yes", "no"]}}, _REASONING_MODEL
-    )
+    choice = config.map_extra_body_params({"extra_body": {"guided_choice": ["yes", "no"]}}, _REASONING_MODEL)
     assert choice == {
         "response_format": {
             "type": "json_schema",
@@ -1665,9 +1639,7 @@ def test_map_extra_body_params_strips_unsupported_nim_vllm_params(param, value, 
 
     config = FireworksAIConfig()
     with caplog.at_level(logging.DEBUG):
-        result = config.map_extra_body_params(
-            {"extra_body": {param: value}}, _REASONING_MODEL
-        )
+        result = config.map_extra_body_params({"extra_body": {param: value}}, _REASONING_MODEL)
     assert result == {}
     assert param in caplog.text
 
@@ -1759,10 +1731,7 @@ def test_in_schema_unsupported_params_still_raise():
 def test_streaming_preserves_selected_model_for_private_accounting():
     from litellm.llms.custom_httpx.http_handler import HTTPHandler
 
-    requested_route = (
-        "accounts/fireworks/routers/firerouter/"
-        "kimi-k3/deepseek-v4-pro-0813/deepseek-v4-flash-0731"
-    )
+    requested_route = "accounts/fireworks/routers/firerouter/kimi-k3/deepseek-v4-pro-0813/deepseek-v4-flash-0731"
     selected_model = "deepseek-v4-flash-0731"
     sse_lines = [
         "data: "
@@ -1816,19 +1785,14 @@ def test_streaming_preserves_selected_model_for_private_accounting():
 
     assert chunks
     assert {chunk.model for chunk in chunks} == {requested_route}
-    assert {
-        chunk._hidden_params.get("provider_response_model") for chunk in chunks
-    } == {selected_model}
+    assert {chunk._hidden_params.get("provider_response_model") for chunk in chunks} == {selected_model}
 
     assembled = litellm.stream_chunk_builder(chunks=chunks)
     assert assembled is not None
     assert assembled.model == requested_route
     assert assembled._hidden_params["provider_response_model"] == selected_model
     selected_model_info = litellm.model_cost[f"fireworks_ai/{selected_model}"]
-    expected_cost = (
-        5 * selected_model_info["input_cost_per_token"]
-        + selected_model_info["output_cost_per_token"]
-    )
+    expected_cost = 5 * selected_model_info["input_cost_per_token"] + selected_model_info["output_cost_per_token"]
     assert litellm.completion_cost(
         completion_response=assembled,
         custom_llm_provider="fireworks_ai",

--- a/tests/test_litellm/llms/fireworks_ai/chat/test_fireworks_ai_chat_transformation.py
+++ b/tests/test_litellm/llms/fireworks_ai/chat/test_fireworks_ai_chat_transformation.py
@@ -227,7 +227,9 @@ def test_validate_environment_raises_without_api_key(monkeypatch):
 
 def test_get_fireworks_session_id_prefers_litellm_session_id_over_trace_id():
     assert (
-        get_fireworks_session_id({"litellm_session_id": "session-123", "litellm_trace_id": "trace-123"})
+        get_fireworks_session_id(
+            {"litellm_session_id": "session-123", "litellm_trace_id": "trace-123"}
+        )
         == "session-123"
     )
 
@@ -279,11 +281,16 @@ def test_handle_message_content_with_tool_calls():
             },
         }
     ]
-    updated_message = config._handle_message_content_with_tool_calls(message, tool_calls)
+    updated_message = config._handle_message_content_with_tool_calls(
+        message, tool_calls
+    )
     assert updated_message.tool_calls is not None
     assert len(updated_message.tool_calls) == 1
     assert updated_message.tool_calls[0].function.name == "get_current_weather"
-    assert updated_message.tool_calls[0].function.arguments == expected_tool_call.function.arguments
+    assert (
+        updated_message.tool_calls[0].function.arguments
+        == expected_tool_call.function.arguments
+    )
 
 
 def test_supports_reasoning_effort():
@@ -310,21 +317,23 @@ def test_supports_reasoning_effort():
     ]
 
     for model in supported_models:
-        assert supports_reasoning(model=model, custom_llm_provider="fireworks_ai") is True, (
-            f"{model} should support reasoning_effort"
-        )
+        assert (
+            supports_reasoning(model=model, custom_llm_provider="fireworks_ai") is True
+        ), f"{model} should support reasoning_effort"
 
     for model in unsupported_models:
-        assert supports_reasoning(model=model, custom_llm_provider="fireworks_ai") is False, (
-            f"{model} should not support reasoning_effort"
-        )
+        assert (
+            supports_reasoning(model=model, custom_llm_provider="fireworks_ai") is False
+        ), f"{model} should not support reasoning_effort"
 
 
 def test_get_supported_openai_params_reasoning_effort():
     """Test that reasoning_effort is only included in supported params for models that support it."""
     config = FireworksAIConfig()
 
-    supported_params = config.get_supported_openai_params("fireworks_ai/accounts/fireworks/models/glm-5p1")
+    supported_params = config.get_supported_openai_params(
+        "fireworks_ai/accounts/fireworks/models/glm-5p1"
+    )
     assert "reasoning_effort" in supported_params
     assert "thinking" in supported_params
 
@@ -339,7 +348,9 @@ def test_get_supported_openai_params_parallel_tool_calls():
     """Test that parallel_tool_calls is included for models that support function calling."""
     config = FireworksAIConfig()
 
-    supported_params = config.get_supported_openai_params("fireworks_ai/accounts/fireworks/models/glm-5p1")
+    supported_params = config.get_supported_openai_params(
+        "fireworks_ai/accounts/fireworks/models/glm-5p1"
+    )
     assert "parallel_tool_calls" in supported_params
     assert "tools" in supported_params
     assert "tool_choice" in supported_params
@@ -353,7 +364,9 @@ def test_get_supported_openai_params_parallel_tool_calls():
 def test_get_supported_openai_params_short_model_name_resolves_account_prefixed_entry():
     config = FireworksAIConfig()
 
-    supported_params = config.get_supported_openai_params("fireworks_ai/deepseek-v4-pro-0813")
+    supported_params = config.get_supported_openai_params(
+        "fireworks_ai/deepseek-v4-pro-0813"
+    )
 
     assert "tool_choice" in supported_params
     assert "reasoning_effort" in supported_params
@@ -362,7 +375,9 @@ def test_get_supported_openai_params_short_model_name_resolves_account_prefixed_
 def test_get_supported_openai_params_preserves_generic_reasoning_fallback():
     config = FireworksAIConfig()
 
-    supported_params = config.get_supported_openai_params("fireworks_ai/accounts/fireworks/models/glm-5p3-flash")
+    supported_params = config.get_supported_openai_params(
+        "fireworks_ai/accounts/fireworks/models/glm-5p3-flash"
+    )
 
     assert "reasoning_effort" in supported_params
 
@@ -438,10 +453,14 @@ def test_get_models_url_no_double_v1(api_base, expected_url_prefix):
 
     mock_response = MagicMock()
     mock_response.status_code = 200
-    mock_response.json.return_value = {"models": [{"name": "accounts/fireworks/models/llama-v3-70b"}]}
+    mock_response.json.return_value = {
+        "models": [{"name": "accounts/fireworks/models/llama-v3-70b"}]
+    }
 
     with (
-        patch("litellm.module_level_client.get", return_value=mock_response) as mock_get,
+        patch(
+            "litellm.module_level_client.get", return_value=mock_response
+        ) as mock_get,
         patch(
             "litellm.llms.fireworks_ai.chat.transformation.get_secret_str",
             side_effect=lambda key: {
@@ -453,9 +472,13 @@ def test_get_models_url_no_double_v1(api_base, expected_url_prefix):
     ):
         result = config.get_models(api_key="test-key", api_base=api_base)
 
-        called_url = mock_get.call_args.kwargs.get("url") or mock_get.call_args[1].get("url", "")
+        called_url = mock_get.call_args.kwargs.get("url") or mock_get.call_args[1].get(
+            "url", ""
+        )
         assert "/v1/v1/" not in called_url, f"Double /v1/ detected in URL: {called_url}"
-        assert called_url.startswith(expected_url_prefix), f"URL {called_url} does not start with {expected_url_prefix}"
+        assert called_url.startswith(
+            expected_url_prefix
+        ), f"URL {called_url} does not start with {expected_url_prefix}"
         assert result == ["fireworks_ai/accounts/fireworks/models/llama-v3-70b"]
 
 
@@ -483,7 +506,9 @@ def test_transform_messages_helper_removes_provider_specific_fields():
         },
     ]
     # Call helper
-    out = config._transform_messages_helper(messages, model="fireworks/test", litellm_params={})
+    out = config._transform_messages_helper(
+        messages, model="fireworks/test", litellm_params={}
+    )
     for msg in out:
         assert "provider_specific_fields" not in msg
 
@@ -504,15 +529,18 @@ def test_transform_messages_helper_strips_thinking_blocks():
         {
             "role": "assistant",
             "content": "I can help.",
-            "thinking_blocks": [{"type": "thinking", "thinking": "internal", "signature": ""}],
+            "thinking_blocks": [
+                {"type": "thinking", "thinking": "internal", "signature": ""}
+            ],
             "reasoning_content": "internal",
         },
     ]
-    out = config._transform_messages_helper(messages, model="accounts/fireworks/models/glm-5p1", litellm_params={})
+    out = config._transform_messages_helper(
+        messages, model="accounts/fireworks/models/glm-5p1", litellm_params={}
+    )
     assert "thinking_blocks" not in out[1]
     assert "reasoning_content" not in out[1]
     assert out[1]["content"] == "I can help."
-
 
 def test_transform_request_strips_reasoning_details():
     """reasoning_details, returned some other providers on assistant messages, is rejected by
@@ -1032,7 +1060,9 @@ def test_transform_messages_helper_rejects_file_blocks():
         litellm.BadRequestError,
         match="Fireworks AI chat completions does not support file content blocks",
     ):
-        config._transform_messages_helper(messages, model="accounts/fireworks/models/kimi-k2p6", litellm_params={})
+        config._transform_messages_helper(
+            messages, model="accounts/fireworks/models/kimi-k2p6", litellm_params={}
+        )
 
 
 def test_transform_messages_helper_rejects_non_vision_image_inputs():
@@ -1044,14 +1074,18 @@ def test_transform_messages_helper_rejects_non_vision_image_inputs():
                 {"type": "text", "text": "Describe this"},
                 {
                     "type": "image_url",
-                    "image_url": {"url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAE="},
+                    "image_url": {
+                        "url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAE="
+                    },
                 },
             ],
         }
     ]
 
     with pytest.raises(litellm.BadRequestError, match="does not support image inputs"):
-        config._transform_messages_helper(messages, model="accounts/fireworks/models/glm-5p2", litellm_params={})
+        config._transform_messages_helper(
+            messages, model="accounts/fireworks/models/glm-5p2", litellm_params={}
+        )
 
 
 def test_transform_messages_helper_allows_vision_image_inputs():
@@ -1063,13 +1097,17 @@ def test_transform_messages_helper_allows_vision_image_inputs():
                 {"type": "text", "text": "Describe this"},
                 {
                     "type": "image_url",
-                    "image_url": {"url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAE="},
+                    "image_url": {
+                        "url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAE="
+                    },
                 },
             ],
         }
     ]
 
-    out = config._transform_messages_helper(messages, model="accounts/fireworks/models/minimax-m3", litellm_params={})
+    out = config._transform_messages_helper(
+        messages, model="accounts/fireworks/models/minimax-m3", litellm_params={}
+    )
     assert out == messages
 
 
@@ -1085,7 +1123,9 @@ def test_image_inputs_not_rejected_for_fuzzy_non_vision_match():
     custom_model = "accounts/myorg/models/custom-glm-5p2"
 
     assert config._get_model_cost_capability(custom_model, "supports_vision") is False
-    assert config._get_model_cost_capability_exact(custom_model, "supports_vision") is None
+    assert (
+        config._get_model_cost_capability_exact(custom_model, "supports_vision") is None
+    )
 
     messages = [
         {
@@ -1093,12 +1133,16 @@ def test_image_inputs_not_rejected_for_fuzzy_non_vision_match():
             "content": [
                 {
                     "type": "image_url",
-                    "image_url": {"url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAE="},
+                    "image_url": {
+                        "url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAE="
+                    },
                 },
             ],
         }
     ]
-    out = config._transform_messages_helper(messages, model=custom_model, litellm_params={})
+    out = config._transform_messages_helper(
+        messages, model=custom_model, litellm_params={}
+    )
     assert out == messages
 
 
@@ -1111,7 +1155,9 @@ def test_transform_messages_helper_skips_non_dict_content():
         }
     ]
 
-    out = config._transform_messages_helper(messages, model="accounts/fireworks/models/glm-5p2", litellm_params={})
+    out = config._transform_messages_helper(
+        messages, model="accounts/fireworks/models/glm-5p2", litellm_params={}
+    )
     assert out == messages
 
 
@@ -1124,7 +1170,9 @@ def test_transform_messages_helper_no_transform_inline():
             "content": [{"type": "image_url", "image_url": url}],
         }
     ]
-    out = config._transform_messages_helper(messages, model="accounts/fireworks/models/minimax-m3", litellm_params={})
+    out = config._transform_messages_helper(
+        messages, model="accounts/fireworks/models/minimax-m3", litellm_params={}
+    )
     block = out[0]["content"][0]
     assert block["image_url"] == url
     assert "#transform=inline" not in block["image_url"]
@@ -1327,7 +1375,9 @@ def test_streaming_surfaces_fireworks_response_fields():
         surfaced: dict = {}
         for chunk in stream:
             fields = getattr(chunk, "provider_specific_fields", None) or {}
-            surfaced.update({k: v for k, v in fields.items() if k.startswith("fireworks_")})
+            surfaced.update(
+                {k: v for k, v in fields.items() if k.startswith("fireworks_")}
+            )
 
     assert surfaced["fireworks_token_ids"] == [[123]]
     assert surfaced["fireworks_raw_outputs"] == [raw_output]
@@ -1380,7 +1430,9 @@ def test_transform_request_direct_route_passthrough():
 
 def test_map_extra_body_params_translates_truncate_prompt_tokens():
     config = FireworksAIConfig()
-    result = config.map_extra_body_params({"extra_body": {"truncate_prompt_tokens": 4096}}, _REASONING_MODEL)
+    result = config.map_extra_body_params(
+        {"extra_body": {"truncate_prompt_tokens": 4096}}, _REASONING_MODEL
+    )
     assert result == {"prompt_truncate_len": 4096}
 
 
@@ -1539,7 +1591,9 @@ def test_map_extra_body_params_non_dict_chat_template_kwargs_dropped():
 def test_map_extra_body_params_guided_json():
     config = FireworksAIConfig()
     schema = {"type": "object", "properties": {"x": {"type": "string"}}}
-    result = config.map_extra_body_params({"extra_body": {"guided_json": schema}}, _REASONING_MODEL)
+    result = config.map_extra_body_params(
+        {"extra_body": {"guided_json": schema}}, _REASONING_MODEL
+    )
     assert result == {
         "response_format": {
             "type": "json_schema",
@@ -1550,10 +1604,16 @@ def test_map_extra_body_params_guided_json():
 
 def test_map_extra_body_params_guided_grammar_and_choice():
     config = FireworksAIConfig()
-    grammar = config.map_extra_body_params({"extra_body": {"guided_grammar": "root ::= 'hello'"}}, _REASONING_MODEL)
-    assert grammar == {"response_format": {"type": "grammar", "grammar": "root ::= 'hello'"}}
+    grammar = config.map_extra_body_params(
+        {"extra_body": {"guided_grammar": "root ::= 'hello'"}}, _REASONING_MODEL
+    )
+    assert grammar == {
+        "response_format": {"type": "grammar", "grammar": "root ::= 'hello'"}
+    }
 
-    choice = config.map_extra_body_params({"extra_body": {"guided_choice": ["yes", "no"]}}, _REASONING_MODEL)
+    choice = config.map_extra_body_params(
+        {"extra_body": {"guided_choice": ["yes", "no"]}}, _REASONING_MODEL
+    )
     assert choice == {
         "response_format": {
             "type": "json_schema",
@@ -1639,7 +1699,9 @@ def test_map_extra_body_params_strips_unsupported_nim_vllm_params(param, value, 
 
     config = FireworksAIConfig()
     with caplog.at_level(logging.DEBUG):
-        result = config.map_extra_body_params({"extra_body": {param: value}}, _REASONING_MODEL)
+        result = config.map_extra_body_params(
+            {"extra_body": {param: value}}, _REASONING_MODEL
+        )
     assert result == {}
     assert param in caplog.text
 
@@ -1731,7 +1793,10 @@ def test_in_schema_unsupported_params_still_raise():
 def test_streaming_preserves_selected_model_for_private_accounting():
     from litellm.llms.custom_httpx.http_handler import HTTPHandler
 
-    requested_route = "accounts/fireworks/routers/firerouter/kimi-k3/deepseek-v4-pro-0813/deepseek-v4-flash-0731"
+    requested_route = (
+        "accounts/fireworks/routers/firerouter/"
+        "kimi-k3/deepseek-v4-pro-0813/deepseek-v4-flash-0731"
+    )
     selected_model = "deepseek-v4-flash-0731"
     sse_lines = [
         "data: "
@@ -1785,14 +1850,19 @@ def test_streaming_preserves_selected_model_for_private_accounting():
 
     assert chunks
     assert {chunk.model for chunk in chunks} == {requested_route}
-    assert {chunk._hidden_params.get("provider_response_model") for chunk in chunks} == {selected_model}
+    assert {
+        chunk._hidden_params.get("provider_response_model") for chunk in chunks
+    } == {selected_model}
 
     assembled = litellm.stream_chunk_builder(chunks=chunks)
     assert assembled is not None
     assert assembled.model == requested_route
     assert assembled._hidden_params["provider_response_model"] == selected_model
     selected_model_info = litellm.model_cost[f"fireworks_ai/{selected_model}"]
-    expected_cost = 5 * selected_model_info["input_cost_per_token"] + selected_model_info["output_cost_per_token"]
+    expected_cost = (
+        5 * selected_model_info["input_cost_per_token"]
+        + selected_model_info["output_cost_per_token"]
+    )
     assert litellm.completion_cost(
         completion_response=assembled,
         custom_llm_provider="fireworks_ai",


### PR DESCRIPTION
<!-- The whole description's target audience is humans, not AI agents: write it in plain, simple,
     everyday engineering language, extremely parsable and readable at a glance. This goes double for
     the TLDR, User Flow, and Caveats sections -->

## TLDR

Problem this solves:


- Some providers return `reasoning_details` field on assistant messages.
- That gets sent to Fireworks if they share the same model group.
- Fireworks AI gives you an `Extra inputs are not permitted` error because `additionalProperties: false`

How it solves it:

- Drops `reasoning_details` field

## User Flow

Before: someone chatting against a model group across an OpenRouter and a Fireworks provider hits a failure partway through the conversation

1. They open their chat client, pick the model group served by the proxy, and send a first message
2. Hits OpenRouter, reply arrives normally but `reasoning_details` is set.
3. They send another message, this one hits Fireworks, and it comes back as `litellm.BadRequestError: Fireworks_aiException - {"error": {"object":"error","type":"invalid_request_error","code":"invalid_request_error","message":"Extra inputs are not permitted, field: 'messages[1].reasoning_details', value: [{'type': 'reasoning.text', ...}]"}}. Received Model Group=deepseek/deepseek-v4-flash-0731`
5. Every retry fails, because the earlier reply with that field is still in the history

After: the same conversation keeps working whichever provider each turn lands on

1. They open their chat client, pick the same model group served by the proxy, and send a first message
2. Hits OpenRouter, the reply arrives normally with `reasoning_details`
3. They send a follow-up in the same conversation, lands on Fireworks, but `reasoning_details` has been stripped, and the reply arrives normally, reasoning section and all

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected
     The proof must be completely e2e with no mocks, using actual LLM calls costing real $$$ if applicable. `pytest` commands are not enough
     Show ONLY the latest run: capture Before at the merge base and After at the PR's current tip, and when new commits change behavior, replace this whole section with the fresh run instead of stacking it on top of older ones. The run must be up to date. As soon as a new commit is made and it makes this PR description's after sha stale (it's no longer tip of PR), you must re-run the QA
     Structure the section exactly as below: Before and After one heading level below this section, each naming the commit hash it was captured at, one lower-level heading per case inside each, the same case names in the same order on both sides, and numbered steps (command, observed output) under every case, never loose prose; shared setup (config, payloads) goes above Before, and with a single case, drop the case headings and number the steps directly

### Before (0cb759772caccee55fae6ca37dfdd05cf47c1da8)

<img width="1049" height="956" alt="image" src="https://github.com/user-attachments/assets/e81531f1-f6df-4cc4-8685-773e85f4471e" />

#### <case 1>

1. ...
2. ...

#### <case 2>

1. ...

### After (<hash>)

#### <case 1>

1. ...
2. ...

#### <case 2>

1. ...

     For bug fixes: Before shows the reproduction, After shows the same steps passing
     For new features: Before shows the capability missing, After shows it working end-to-end
     If the change applies to all three LLM endpoints (/v1/responses, /v1/chat/completions, /v1/messages), make each endpoint its own case, not just one
     For UI changes: before/after screenshots under the same headings -->
### Before (0cb759772caccee55fae6ca37dfdd05cf47c1da8)

<img width="1049" height="956" alt="image" src="https://github.com/user-attachments/assets/e81531f1-f6df-4cc4-8685-773e85f4471e" />

### After (842da53627b735a735a4316338f1d24c96cbfa6e)

<img width="1101" height="1146" alt="image" src="https://github.com/user-attachments/assets/c735a99c-2a1d-468d-a065-d1d6ddc19587" />
<img width="1026" height="1063" alt="image" src="https://github.com/user-attachments/assets/6c1a819e-54c4-4901-b45b-afb1bacfc3e5" />
<img width="1004" height="889" alt="image" src="https://github.com/user-attachments/assets/34089d90-bc17-498f-a984-66d8b8c02b5d" />



## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->
🐛 Bug Fix

## Caveats (if any)

### Low

- Strip list is hardcoded, so future provider fields break identically
- An allowlist of fields Fireworks accepts is the durable fix
- Reasoning from the other provider is not carried into Fireworks, matching `reasoning_content` today

## Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

