### PR TITLE
fix(anthropic): keep provider_specific_fields off the native /v1/messages wire

### DIFF
--- a/litellm/llms/anthropic/common_utils.py
+++ b/litellm/llms/anthropic/common_utils.py
@@ -1411,6 +1411,25 @@ def flatten_unencrypted_web_search_results_in_anthropic_messages(  # mutable-ok:
     return [_flatten_web_search_results_in_message(m) for m in messages]  # mutable-ok: JSON wire format
 
 
+def _without_provider_specific_fields(block: object) -> object:
+    if not isinstance(block, dict) or "provider_specific_fields" not in block:
+        return block
+    return {k: v for k, v in block.items() if k != "provider_specific_fields"}  # mutable-ok: JSON wire format
+
+
+def _strip_provider_specific_fields_in_message(message: object) -> object:
+    if not isinstance(message, dict) or not isinstance(message.get("content"), list):
+        return message
+    content: Final = [_without_provider_specific_fields(b) for b in message["content"]]  # mutable-ok: JSON wire format
+    return {**message, "content": content}  # mutable-ok: JSON wire format
+
+
+def strip_provider_specific_fields_from_anthropic_messages(
+    messages: Sequence[object],
+) -> Sequence[object]:
+    return [_strip_provider_specific_fields_in_message(m) for m in messages]  # mutable-ok: JSON wire format
+
+
 def _normalized_cache_control(cache_control: object) -> dict[str, str] | None:  # mutable-ok: JSON wire format
     if not isinstance(cache_control, Mapping):
         return None

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -1346,7 +1346,7 @@ class LiteLLMAnthropicMessagesAdapter:
                     # Add provider_specific_fields if signature is present
                     if provider_specific_fields:
                         tool_use_block.provider_specific_fields = provider_specific_fields
-                    new_content.append(tool_use_block.model_dump())
+                    new_content.append(tool_use_block.model_dump(exclude_none=True))
 
         return new_content
 

--- a/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
@@ -18,6 +18,7 @@ from litellm.llms.anthropic.common_utils import (
     flatten_unencrypted_web_search_results_in_anthropic_messages,
     sanitize_tool_use_ids_in_anthropic_messages,
     strip_empty_content_blocks_from_anthropic_messages,
+    strip_provider_specific_fields_from_anthropic_messages,
 )
 from litellm.llms.base_llm.anthropic_messages.transformation import (
     BaseAnthropicMessagesConfig,
@@ -650,7 +651,7 @@ def anthropic_messages_handler(
 
     return base_llm_http_handler.anthropic_messages_handler(
         model=model,
-        messages=messages,
+        messages=strip_provider_specific_fields_from_anthropic_messages(messages),
         anthropic_messages_provider_config=anthropic_messages_provider_config,
         anthropic_messages_optional_request_params=dict(anthropic_messages_optional_request_params),
         _is_async=is_async,

--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
@@ -647,7 +647,7 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
                         id=item.call_id or item.id or "",
                         name=item.name,
                         input=input_data,
-                    ).model_dump()
+                    ).model_dump(exclude_none=True)
                 )
                 stop_reason = "tool_use"
 
@@ -676,7 +676,7 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
                             id=item.get("call_id") or item.get("id", ""),
                             name=item.get("name", ""),
                             input=input_data,
-                        ).model_dump()
+                        ).model_dump(exclude_none=True)
                     )
                     stop_reason = "tool_use"
 

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -798,6 +798,7 @@ def test_translate_openai_content_to_anthropic_empty_function_arguments():
     assert (
         result[0]["input"] == {}
     ), "Empty function arguments should result in empty dict"
+    assert "provider_specific_fields" not in result[0]
 
 
 def test_translate_openai_content_to_anthropic_text_and_tool_calls():
@@ -843,6 +844,11 @@ def test_translate_openai_content_to_anthropic_strips_gemini_thought_from_tool_c
     base = "call_3e9417b7925e49aca9a71dc1885e"
     sig = "CiIBDDnWx+/a=="
     combined = f"{base}{THOUGHT_SIGNATURE_SEPARATOR}{sig}"
+    function = Function(
+        name="get_weather",
+        arguments='{"location": "Boston"}',
+    )
+    function.provider_specific_fields = {"thought_signature": sig}
     openai_choices = [
         Choices(
             message=Message(
@@ -852,10 +858,7 @@ def test_translate_openai_content_to_anthropic_strips_gemini_thought_from_tool_c
                     ChatCompletionAssistantToolCall(
                         id=combined,
                         type="function",
-                        function=Function(
-                            name="get_weather",
-                            arguments='{"location": "Boston"}',
-                        ),
+                        function=function,
                     )
                 ],
             )
@@ -871,6 +874,7 @@ def test_translate_openai_content_to_anthropic_strips_gemini_thought_from_tool_c
     assert THOUGHT_SIGNATURE_SEPARATOR not in result[0]["id"]
     assert result[0]["name"] == "get_weather"
     assert result[0]["input"] == {"location": "Boston"}
+    assert result[0]["provider_specific_fields"] == {"signature": sig}
 
 
 def test_translate_openai_content_to_anthropic_sanitizes_colon_dot_tool_call_ids():

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
@@ -1073,6 +1073,54 @@ async def test_messages_strips_provider_prefix_exactly_once(requested_model, exp
 
 
 @pytest.mark.asyncio
+async def test_native_messages_strips_replayed_provider_specific_fields_from_wire():
+    captured = {}
+
+    async def fake_send(self, request, **kwargs):
+        captured["body"] = json.loads(request.content)
+        raise httpx.ConnectError("cut at the wire", request=request)
+
+    messages = [
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "toolu_01",
+                    "name": "get_weather",
+                    "input": {"city": "Paris"},
+                    "provider_specific_fields": {"signature": "sig_abc"},
+                }
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_01",
+                    "content": "Sunny",
+                }
+            ],
+        },
+    ]
+
+    with (
+        patch.object(httpx.AsyncClient, "send", fake_send),
+        pytest.raises(litellm.exceptions.InternalServerError),
+    ):
+        await litellm.anthropic.messages.acreate(
+            max_tokens=100,
+            messages=messages,
+            model="anthropic/claude-haiku-4-5-20251001",
+            api_key="test-api-key",
+        )
+
+    assert "provider_specific_fields" in messages[0]["content"][0]
+    assert "provider_specific_fields" not in captured["body"]["messages"][0]["content"][0]
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "requested_model, expected_reported_model",
     [

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py
@@ -1265,6 +1265,7 @@ class TestTranslateResponse:
         assert block["id"] == "call_99"
         assert block["name"] == "get_weather"
         assert block["input"] == {"city": "NYC"}
+        assert "provider_specific_fields" not in block
 
     def test_function_call_sets_stop_reason_tool_use(self):
         """Presence of a function_call sets stop_reason to 'tool_use'."""
@@ -1447,6 +1448,7 @@ class TestTranslateResponse:
         assert result["content"][0]["type"] == "tool_use"
         assert result["content"][0]["name"] == "search"
         assert result["content"][0]["input"] == {"query": "cats"}
+        assert "provider_specific_fields" not in result["content"][0]
         assert result["stop_reason"] == "tool_use"
 
     def test_mixed_reasoning_text_and_tool_use(self):


### PR DESCRIPTION
## TLDR

Problem this solves:

- Cross-provider tool history could break later Anthropic turns
- Native Anthropic rejected LiteLLM-only tool block fields

How it solves it:

- Omits empty internal fields from bridged tool responses
- Cleans replayed history before native Anthropic dispatch

## User Flow

Before: a developer's multi-turn `/v1/messages` session fails when the router switches from an OpenAI tier to an Anthropic tier

1. They send POST http://localhost:4631/v1/messages and the SIMPLE tier calls a tool through OpenAI
2. The 200 response includes a `tool_use` block with `"provider_specific_fields": null`
3. They echo that block in their next POST http://localhost:4631/v1/messages
4. The REASONING tier selects Anthropic and returns 400: `tool_use.provider_specific_fields: Extra inputs are not permitted`

After: the same multi-turn session crosses providers without breaking

1. They send POST http://localhost:4631/v1/messages and the SIMPLE tier calls a tool through OpenAI
2. The 200 response includes a valid `tool_use` block without internal fields
3. They echo that block in their next POST http://localhost:4631/v1/messages
4. The REASONING tier selects Anthropic and returns 200

## Relevant issues

- Fixes cross-provider `/v1/messages` tool history replay
- Keeps populated Gemini signatures available to translated tiers
- Closes #19739

## Linear ticket


## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

Shared setup: isolated Postgres, real paid OpenAI and Anthropic calls, one complexity router with keyword-pinned SIMPLE and REASONING tiers

### Before (bf51dea36b)

1. POST http://localhost:4631/v1/messages to the SIMPLE tier returned 200 from `openai/gpt-4o-mini`; the tool block included `"provider_specific_fields": null`
2. The same request with `"stream": true` returned a valid tool block without the field, isolating the bug to non-streaming response serialization
3. POST http://localhost:4631/v1/messages with the first response echoed verbatim selected `anthropic/claude-haiku-4-5-20251001` and returned 400: `messages.1.content.0.tool_use.provider_specific_fields: Extra inputs are not permitted`

### After (3918364e9f)

1. The same SIMPLE-tier POST returned 200 from `openai/gpt-4o-mini`; the tool block omitted `provider_specific_fields`
2. The same poisoned before-fix history still selected `anthropic/claude-haiku-4-5-20251001` and returned 200: `Sunny, 20°C in Paris`
3. A real two-turn Claude Code session called Bash through the SIMPLE OpenAI tier, replayed its tool history, then answered through the REASONING Anthropic tier with zero 4xx responses

## Type

Bug Fix

## Caveats (if any)


## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world use cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted serialization and pre-dispatch sanitization on the Anthropic messages path; behavior change is omitting/stripping a non-API field that previously caused validation errors.
> 
> **Overview**
> Fixes **cross-provider `/v1/messages` sessions** where tool history echoed from a bridged tier (e.g. OpenAI) caused **400s on native Anthropic** because `tool_use.provider_specific_fields` is not allowed on the real API.
> 
> **Outbound responses:** OpenAI→Anthropic and Responses→Anthropic adapters now serialize `tool_use` blocks with `model_dump(exclude_none=True)`, so empty internal fields (e.g. `"provider_specific_fields": null`) are not returned to clients. Populated Gemini-style signatures can still appear on the block when present.
> 
> **Inbound native dispatch:** Before calling the native Anthropic messages handler, messages are passed through `strip_provider_specific_fields_from_anthropic_messages`, which removes `provider_specific_fields` from list-shaped message content on the wire only—client-held history is unchanged.
> 
> Tests cover wire stripping, omitted fields on translated tool blocks, and signature retention when signatures exist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3918364e9f180aa713ffe3af7a221028adda2856. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->