### PR TITLE
fix(ui): remove unreachable AI Hub dialog that put the session key in a URL

### DIFF
--- a/ui/litellm-dashboard/src/components/AIHub/ModelHubTable.tsx
+++ b/ui/litellm-dashboard/src/components/AIHub/ModelHubTable.tsx
@@ -32,7 +32,6 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/u
 import { InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput } from "@/components/ui/input-group";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Copy, Inbox, Search as SearchIcon, X } from "lucide-react";
-import { useRouter } from "next/navigation";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { prism } from "react-syntax-highlighter/dist/esm/styles/prism";
@@ -72,7 +71,6 @@ const ModelHubTable: React.FC<ModelHubTableProps> = ({ accessToken, publicPage, 
   const [modelHubData, setModelHubData] = useState<ModelHubData[] | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
   const [isModalVisible, setIsModalVisible] = useState(false);
-  const [isPublicPageModalVisible, setIsPublicPageModalVisible] = useState(false);
   const [selectedModel, setSelectedModel] = useState<null | ModelHubData>(null);
   const [filteredData, setFilteredData] = useState<ModelHubData[]>([]);
   const [isMakePublicModalVisible, setIsMakePublicModalVisible] = useState(false);
@@ -93,7 +91,6 @@ const ModelHubTable: React.FC<ModelHubTableProps> = ({ accessToken, publicPage, 
   const [skillHubData, setSkillHubData] = useState<Plugin[]>([]);
   const [skillLoading, setSkillLoading] = useState<boolean>(false);
   const [isMakeSkillPublicModalVisible, setIsMakeSkillPublicModalVisible] = useState(false);
-  const router = useRouter();
   const { data: uiSettings, isLoading: isUISettingsLoading } = useUISettings();
 
   // Check authentication requirement for public AI Hub
@@ -256,10 +253,6 @@ const ModelHubTable: React.FC<ModelHubTableProps> = ({ accessToken, publicPage, 
     setIsMcpModalVisible(true);
   }, []);
 
-  const goToPublicModelPage = () => {
-    router.replace(`/model_hub_table?key=${accessToken}`);
-  };
-
   const handleMakePublicPage = () => {
     if (!accessToken) {
       return;
@@ -289,7 +282,6 @@ const ModelHubTable: React.FC<ModelHubTableProps> = ({ accessToken, publicPage, 
 
   const handleOk = () => {
     setIsModalVisible(false);
-    setIsPublicPageModalVisible(false);
     setSelectedModel(null);
     setIsAgentModalVisible(false);
     setSelectedAgent(null);
@@ -299,7 +291,6 @@ const ModelHubTable: React.FC<ModelHubTableProps> = ({ accessToken, publicPage, 
 
   const handleCancel = () => {
     setIsModalVisible(false);
-    setIsPublicPageModalVisible(false);
     setSelectedModel(null);
     setIsAgentModalVisible(false);
     setSelectedAgent(null);
@@ -638,26 +629,6 @@ const ModelHubTable: React.FC<ModelHubTableProps> = ({ accessToken, publicPage, 
           </p>
         </Card>
       )}
-
-      {/* Public Page Modal */}
-      <Dialog open={isPublicPageModalVisible} onOpenChange={(open) => !open && handleCancel()}>
-        <DialogContent className="max-h-[calc(100dvh-2rem)] overflow-y-auto sm:max-w-[600px]">
-          <DialogHeader>
-            <DialogTitle>{"Public Model Hub"}</DialogTitle>
-          </DialogHeader>
-          <div className="pt-5 pb-5">
-            <div className="flex justify-between mb-4">
-              <p className="text-base mr-2">Shareable Link:</p>
-              <p className="max-w-sm ml-2 bg-border pr-2 pl-2 pt-1 pb-1 text-center rounded-sm">
-                {`${getProxyBaseUrl()}/ui/model_hub_table`}
-              </p>
-            </div>
-            <div className="flex justify-end">
-              <Button onClick={goToPublicModelPage}>See Page</Button>
-            </div>
-          </div>
-        </DialogContent>
-      </Dialog>
 
       {/* Model Details Modal */}
       <Dialog open={isModalVisible} onOpenChange={(open) => !open && handleCancel()}>


### PR DESCRIPTION
## TLDR

Problem this solves:

- The AI Hub had a hidden "See Page" dialog that was never opened
- Its button navigated to `/model_hub_table?key=<session key>`
- That would put the admin's Bearer key in history, Referer headers, and access logs

How it solves it:

- Deletes the dialog, its state, the handler, and the now unused router import
- Nothing visible changes; the code was unreachable

## User Flow

Before: an admin uses the AI Hub normally and cannot reach the dialog, but the code path exists

1. They open https://litellm-domain/ui/model-hub-table
2. They click "Select Models to Make Public" and copy the shareable link
3. No control on the page can open the "Public Model Hub" dialog with the "See Page" button
4. If a later change wired that dialog up, clicking "See Page" would load `/model_hub_table?key=<their session key>`

After: the same steps, and the dialog no longer exists to be wired up

1. They open https://litellm-domain/ui/model-hub-table
2. They click "Select Models to Make Public" and copy the shareable link
3. The page behaves exactly as before
4. There is no code path that can place the session key in a page URL

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Pure dead-code removal, so the UI is identical before and after. Sanity check that the AI Hub still works:

### After (tip of PR)

1. Run the proxy and `npm run dev` in `ui/litellm-dashboard`, then open http://localhost:3000/model-hub-table
2. Confirm the Models, Agents, MCP Servers and Skills tabs render and "Select Models to Make Public" still opens its dialog
3. Open a model row and confirm the Model Details dialog opens and closes

## Type

🧹 Refactoring

## Caveats (if any)

### Low

- No new test: there is no reachable behavior left to assert, and the existing 12 ModelHubTable tests still pass
- The public pages still read an optional `?key=` query param; nothing in the dashboard writes one any more

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
