### PR TITLE
fix(router): treat a routing entry with no latency samples as zero latency

### DIFF
--- a/litellm/router_strategy/lowest_cost.py
+++ b/litellm/router_strategy/lowest_cost.py
@@ -1,6 +1,6 @@
 #### What this does ####
 #   picks based on response time (for streaming, this is time to first token)
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import Final
 
 import litellm
@@ -52,16 +52,12 @@ class LowestCostLoggingHandler(CustomLogger):
                 precise_minute: Final = f"{current_date}-{current_hour}-{current_minute}"
                 cost_key: Final = f"{model_group}_map"
 
-                response_ms: Final[timedelta] = end_time - start_time
-
                 total_tokens = 0
 
                 if isinstance(response_obj, ModelResponse):
                     _usage: Final = getattr(response_obj, "usage", None)
                     if _usage is not None and isinstance(_usage, litellm.Usage):
-                        completion_tokens: Final = _usage.completion_tokens
                         total_tokens = _usage.total_tokens
-                        float(response_ms.total_seconds() / completion_tokens)
 
                 # ------------
                 # Update usage
@@ -131,17 +127,12 @@ class LowestCostLoggingHandler(CustomLogger):
                 current_minute: Final = datetime.now().strftime("%M")
                 precise_minute: Final = f"{current_date}-{current_hour}-{current_minute}"
 
-                response_ms: Final[timedelta] = end_time - start_time
-
                 total_tokens = 0
 
                 if isinstance(response_obj, ModelResponse):
                     _usage: Final = getattr(response_obj, "usage", None)
                     if _usage is not None and isinstance(_usage, litellm.Usage):
-                        completion_tokens: Final = _usage.completion_tokens
                         total_tokens = _usage.total_tokens
-
-                        float(response_ms.total_seconds() / completion_tokens)
 
                 # ------------
                 # Update usage

--- a/litellm/router_strategy/lowest_latency.py
+++ b/litellm/router_strategy/lowest_latency.py
@@ -1,6 +1,7 @@
 #### What this does ####
 #   picks based on response time (for streaming, this is time to first token)
 import random
+from collections.abc import Sequence
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any, Final
 
@@ -23,6 +24,12 @@ class RoutingArgs(LiteLLMPydanticObjectBase):
     ttl: float = 1 * 60 * 60  # 1 hour
     lowest_latency_buffer: float = 0
     max_latency_list_size: int = 10
+
+
+def _average_latency(samples: Sequence[float | int]) -> float:
+    if not samples:
+        return 0.0
+    return sum(sample for sample in samples if isinstance(sample, float)) / len(samples)
 
 
 class LowestLatencyLoggingHandler(CustomLogger):
@@ -431,23 +438,13 @@ class LowestLatencyLoggingHandler(CustomLogger):
             item_tpm = item_map.get(precise_minute, {}).get("tpm", 0)
 
             # get average latency or average ttft (depending on streaming/non-streaming)
-            total: float = 0.0
             use_ttft = (
                 request_kwargs is not None
                 and request_kwargs.get("stream", None) is not None
                 and request_kwargs["stream"] is True
                 and len(item_ttft_latency) > 0
             )
-            if use_ttft:
-                for _call_latency in item_ttft_latency:
-                    if isinstance(_call_latency, float):
-                        total += _call_latency
-                item_latency = total / len(item_ttft_latency)
-            else:
-                for _call_latency in item_latency:
-                    if isinstance(_call_latency, float):
-                        total += _call_latency
-                item_latency = total / len(item_latency)
+            average_latency = _average_latency(item_ttft_latency if use_ttft else item_latency)
 
             # -------------- #
             # Debugging Logic
@@ -456,7 +453,7 @@ class LowestLatencyLoggingHandler(CustomLogger):
             # this helps a user to debug why the router picked a specfic deployment      #
             _deployment_api_base = _deployment.get("litellm_params", {}).get("api_base", "")
             if _deployment_api_base is not None:
-                _latency_per_deployment[_deployment_api_base] = item_latency
+                _latency_per_deployment[_deployment_api_base] = average_latency
             # -------------- #
             # End of Debugging Logic
             # -------------- #
@@ -466,7 +463,7 @@ class LowestLatencyLoggingHandler(CustomLogger):
             ):  # if user passed in tpm / rpm in the model_list
                 continue
             else:
-                potential_deployments.append((_deployment, item_latency))
+                potential_deployments.append((_deployment, average_latency))
 
         if len(potential_deployments) == 0:
             return None

--- a/litellm/router_strategy/lowest_latency.py
+++ b/litellm/router_strategy/lowest_latency.py
@@ -26,10 +26,10 @@ class RoutingArgs(LiteLLMPydanticObjectBase):
     max_latency_list_size: int = 10
 
 
-def _average_latency(samples: Sequence[float | int]) -> float:
+def _average_latency(samples: Sequence[float]) -> float:
     if not samples:
         return 0.0
-    return sum(sample for sample in samples if isinstance(sample, float)) / len(samples)
+    return sum(samples) / len(samples)
 
 
 class LowestLatencyLoggingHandler(CustomLogger):

--- a/tests/test_litellm/router_strategy/test_lowest_cost.py
+++ b/tests/test_litellm/router_strategy/test_lowest_cost.py
@@ -1,0 +1,59 @@
+from datetime import datetime
+
+import pytest
+
+import litellm
+from litellm.caching.caching import DualCache
+from litellm.router_strategy.lowest_cost import LowestCostLoggingHandler
+
+DEPLOYMENT_ID = "9876"
+KWARGS = {
+    "litellm_params": {
+        "metadata": {"model_group": "gpt-5.5-pool"},
+        "model_info": {"id": DEPLOYMENT_ID},
+    }
+}
+
+
+def _chat_response_with_no_completion_tokens() -> litellm.ModelResponse:
+    return litellm.ModelResponse(
+        model="gpt-5.5",
+        choices=[{"index": 0, "message": {"role": "assistant", "content": ""}, "finish_reason": "length"}],
+        usage=litellm.Usage(prompt_tokens=12, completion_tokens=0, total_tokens=12),
+    )
+
+
+def _recorded_minute_counters(cache: DualCache) -> dict[str, int]:
+    cached = cache.get_cache(key="gpt-5.5-pool_map") or {}
+    minute_buckets = cached.get(DEPLOYMENT_ID, {})
+    assert len(minute_buckets) == 1, f"expected one minute bucket, got {minute_buckets}"
+    return next(iter(minute_buckets.values()))
+
+
+def test_log_success_event_counts_a_response_with_no_completion_tokens():
+    cache = DualCache()
+    handler = LowestCostLoggingHandler(router_cache=cache)
+
+    handler.log_success_event(
+        kwargs=KWARGS,
+        response_obj=_chat_response_with_no_completion_tokens(),
+        start_time=datetime(2026, 1, 1, 12, 0, 0),
+        end_time=datetime(2026, 1, 1, 12, 0, 2),
+    )
+
+    assert _recorded_minute_counters(cache) == {"tpm": 12, "rpm": 1}
+
+
+@pytest.mark.asyncio
+async def test_async_log_success_event_counts_a_response_with_no_completion_tokens():
+    cache = DualCache()
+    handler = LowestCostLoggingHandler(router_cache=cache)
+
+    await handler.async_log_success_event(
+        kwargs=KWARGS,
+        response_obj=_chat_response_with_no_completion_tokens(),
+        start_time=datetime(2026, 1, 1, 12, 0, 0),
+        end_time=datetime(2026, 1, 1, 12, 0, 2),
+    )
+
+    assert _recorded_minute_counters(cache) == {"tpm": 12, "rpm": 1}

--- a/tests/test_litellm/router_strategy/test_lowest_latency.py
+++ b/tests/test_litellm/router_strategy/test_lowest_latency.py
@@ -163,3 +163,33 @@ def test_sync_chat_zero_completion_tokens_falls_back_to_seconds():
     assert latencies and latencies[-1] == pytest.approx(2.0)
     assert not isinstance(latencies[-1], timedelta)
     json.dumps({"latency": latencies})
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "cached_entry",
+    [{"latency": []}, {"2026-09-05-15-39": {"tpm": 28, "rpm": 1}}],
+    ids=["empty_latency_list", "minute_bucket_only_as_cost_based_routing_writes"],
+)
+async def test_async_get_available_deployments_treats_missing_samples_as_zero_latency(cached_entry):
+    """A cached entry with no latency samples (cost-based routing shares the group's map key and writes
+    minute buckets only) must count as 0 latency, like an unseen deployment, instead of dividing by zero."""
+    cache = DualCache()
+    handler = LowestLatencyLoggingHandler(router_cache=cache)
+    cache.set_cache(
+        key="gemini-embedding-001_map",
+        value={DEPLOYMENT_ID: cached_entry, "slower": {"latency": [0.5]}},
+    )
+    healthy_deployments = [
+        {"model_info": {"id": DEPLOYMENT_ID}, "litellm_params": {}},
+        {"model_info": {"id": "slower"}, "litellm_params": {}},
+    ]
+
+    picked = await handler.async_get_available_deployments(
+        model_group="gemini-embedding-001",
+        healthy_deployments=healthy_deployments,
+        request_kwargs={"stream": False, "metadata": {}},
+    )
+
+    assert picked is not None
+    assert picked["model_info"]["id"] == DEPLOYMENT_ID

--- a/tests/test_litellm/router_strategy/test_lowest_latency.py
+++ b/tests/test_litellm/router_strategy/test_lowest_latency.py
@@ -172,8 +172,6 @@ def test_sync_chat_zero_completion_tokens_falls_back_to_seconds():
     ids=["empty_latency_list", "minute_bucket_only_as_cost_based_routing_writes"],
 )
 async def test_async_get_available_deployments_treats_missing_samples_as_zero_latency(cached_entry):
-    """A cached entry with no latency samples (cost-based routing shares the group's map key and writes
-    minute buckets only) must count as 0 latency, like an unseen deployment, instead of dividing by zero."""
     cache = DualCache()
     handler = LowestLatencyLoggingHandler(router_cache=cache)
     cache.set_cache(


### PR DESCRIPTION
## TLDR

Problem this solves:

- Latency-based routing answers 500 `float division by zero` for a whole model group
- Happens once a deployment's routing entry holds no latency samples
- Cost-based routing shares that entry and writes minute counters only
- The group stays broken on every instance sharing the routing cache for as long as that entry lives

How it solves it:

- A deployment with no latency samples counts as 0 latency
- Same as the router already assumes for a deployment it has never seen
- Regression test drives selection over an empty list and a minute-only entry
- Cost handler's dead per-token division goes; zero-token responses now count toward rpm/tpm
- The ticket's second ask is skipped: nothing reads an entry mid-update on the proxy

## User Flow

Before: an app that asks for latency-based routing on a model group gets 500s on every request for that group as soon as another app has used cost-based routing on the same group through the same proxy

1. App A sends POST https://litellm-domain/v1/chat/completions with `"model": "gpt-5.5-pool"` and `"router_settings_override": {"routing_strategy": "cost-based-routing"}` and gets a 200
2. App B sends POST https://litellm-domain/v1/chat/completions with `"model": "gpt-5.5-pool"` and `"router_settings_override": {"routing_strategy": "latency-based-routing"}` and gets a 500 with `{"error": {"message": "litellm.InternalServerError: float division by zero", ...}}`
3. Every further latency-routed request App B sends for `gpt-5.5-pool` is the same 500, on every proxy instance behind the load balancer, for as long as App A keeps using the group
4. App B moves to a fresh group `gpt-5.5-fast-pool` nobody has used yet: its POST https://litellm-domain/v1/chat/completions requests answer 200, or 408 from the deployment that times out, while `gpt-5.5-pool` stays broken
5. The same happens for POST https://litellm-domain/v1/responses and POST https://litellm-domain/v1/messages, since the routing decision is shared

After: the same requests answer 200, or the deployment's own timeout error, and never 500

1. App A sends POST https://litellm-domain/v1/chat/completions with `"model": "gpt-5.5-pool"` and `"router_settings_override": {"routing_strategy": "cost-based-routing"}` and gets a 200
2. App B sends POST https://litellm-domain/v1/chat/completions with `"model": "gpt-5.5-pool"` and `"router_settings_override": {"routing_strategy": "latency-based-routing"}` and gets a 200 with a normal chat completion body
3. Every further latency-routed request App B sends for `gpt-5.5-pool` answers 200, on every proxy instance behind the load balancer
4. App B moves to a fresh group `gpt-5.5-fast-pool` nobody has used yet: its POST https://litellm-domain/v1/chat/completions requests answer 200, or 408 from the deployment that times out, and never 500
5. The same holds for POST https://litellm-domain/v1/responses and POST https://litellm-domain/v1/messages

## Relevant issues

## Linear ticket

Resolves LIT-7053

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both legs ran the same rig: two proxy processes booted from the leg's commit, `--num_workers 2` each, on two random ports sharing one private Redis (the proxy's `router_settings.redis_host`), every request alternating between the two ports the way a load balancer would, real OpenAI `gpt-5.5` and `gpt-5-mini` traffic, no mocks. One case per unified endpoint, each on freshly booted instances and a flushed Redis, with its own model groups: `<prefix>-pool` is one `gpt-5.5` plus one `gpt-5-mini` deployment (both healthy), `<prefix>-fast-pool` is two `gpt-5.5` deployments, one with `timeout: 0.001` so it always answers 408. Each output line below is `status  :instance-port  strategy  model-group  response id or error message`

```yaml
model_list:
  - model_name: <prefix>-fast-pool
    litellm_params:
      model: openai/gpt-5.5
      api_key: os.environ/OPENAI_API_KEY
    model_info:
      id: <prefix>-fast
  - model_name: <prefix>-fast-pool
    litellm_params:
      model: openai/gpt-5.5
      api_key: os.environ/OPENAI_API_KEY
      timeout: 0.001
    model_info:
      id: <prefix>-slow
  - model_name: <prefix>-pool
    litellm_params:
      model: openai/gpt-5.5
      api_key: os.environ/OPENAI_API_KEY
    model_info:
      id: <prefix>-pool-a
  - model_name: <prefix>-pool
    litellm_params:
      model: openai/gpt-5-mini
      api_key: os.environ/OPENAI_API_KEY
    model_info:
      id: <prefix>-pool-b

router_settings:
  routing_strategy: simple-shuffle
  redis_host: 127.0.0.1
  redis_port: 40088

general_settings:
  master_key: os.environ/LITELLM_MASTER_KEY
```

Every request in the steps below goes through this helper. It alternates between the two instances, posts the route's body with the strategy override, and prints one line per call: status, port, strategy, group, then the response id or the error message. Everything it prints is also appended to `flow-output.txt` for the count in step 5. `PA` and `PB` are the two ports step 1 booted and `KEY` is the proxy master key

```zsh
body_for() {
  local group=$1 strategy=$2 prompt=$3
  local ov="\"router_settings_override\":{\"routing_strategy\":\"$strategy\",\"num_retries\":0}"
  case $ROUTE in
    /v1/chat/completions|/v1/messages) echo "{\"model\":\"$group\",\"messages\":[{\"role\":\"user\",\"content\":\"$prompt\"}],\"max_tokens\":16,$ov}" ;;
    /v1/responses) echo "{\"model\":\"$group\",\"input\":\"$prompt\",\"max_output_tokens\":16,$ov}" ;;
  esac
}
call() {
  local strategy=$1 group=$2
  n=$((n+1))
  local port=$PA; [[ $((n % 2)) -eq 0 ]] && port=$PB
  local out=$(mktemp)
  local code=$(curl -s -o "$out" -w "%{http_code}" "http://127.0.0.1:$port$ROUTE" \
    -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -d "$(body_for $group $strategy "say hi $n")")
  echo "$code  :$port  $strategy  $group  $(python3 - "$out" <<'PY'
import json, sys
d = json.load(open(sys.argv[1]))
err = d.get("error")
if err is None:
    print("id=" + str(d.get("id"))[:32])
else:
    msg = err.get("message") if isinstance(err, dict) else str(err)
    print(str(msg).split(". Error_str")[0][:80])
PY
)"
  rm -f "$out"
}
```

### Before (bf51dea36b)

#### POST /v1/chat/completions

1. Flush the shared Redis and boot two fresh instances from `bf51dea36b`, two uvicorn workers each, on ports 32064 and 25380

   ```
   redis-cli -p 40088 FLUSHALL
   for port in 32064 25380; do python litellm/proxy/proxy_cli.py --config chat.yaml --port $port --num_workers 2 & done
   ```

   ```
   instance :32064 up after 13s (bf51dea36b)
   instance :25380 up after 1s (bf51dea36b)
   ```

2. Six `cost-based-routing` requests on `qabefore-chat-pool`, alternating between the two instances

   ```
   ROUTE=/v1/chat/completions PA=32064 PB=25380 n=0
   for i in 1 2 3 4 5 6; do call cost-based-routing qabefore-chat-pool; done
   ```

   ```
   200  :32064  cost-based-routing  qabefore-chat-pool  id=chatcmpl-EKtZAcIV9KVuC3KKga2fEJy
   200  :25380  cost-based-routing  qabefore-chat-pool  id=chatcmpl-EKtZCasM9BwD4NhORJYToTL
   200  :32064  cost-based-routing  qabefore-chat-pool  id=chatcmpl-e4879d98-570d-4e80-8831
   200  :25380  cost-based-routing  qabefore-chat-pool  id=chatcmpl-2b617116-4dca-4d79-a988
   200  :32064  cost-based-routing  qabefore-chat-pool  id=chatcmpl-22e5be83-2a59-441c-82d2
   200  :25380  cost-based-routing  qabefore-chat-pool  id=chatcmpl-EKtZGCLs5OtduBJeCyo1Rc3
   ```

3. Six `latency-based-routing` requests on the same `qabefore-chat-pool`, alternating between the two instances

   ```
   for i in 1 2 3 4 5 6; do call latency-based-routing qabefore-chat-pool; done
   ```

   ```
   500  :32064  latency-based-routing  qabefore-chat-pool  float division by zero
   500  :25380  latency-based-routing  qabefore-chat-pool  float division by zero
   500  :32064  latency-based-routing  qabefore-chat-pool  float division by zero
   500  :25380  latency-based-routing  qabefore-chat-pool  float division by zero
   500  :32064  latency-based-routing  qabefore-chat-pool  float division by zero
   500  :25380  latency-based-routing  qabefore-chat-pool  float division by zero
   ```

4. Six `latency-based-routing` requests on a fresh `qabefore-chat-fast-pool`, alternating between the two instances

   ```
   for i in 1 2 3 4 5 6; do call latency-based-routing qabefore-chat-fast-pool; done
   ```

   ```
   200  :32064  latency-based-routing  qabefore-chat-fast-pool  id=chatcmpl-EKtZMjG1rEXpr0iKBiaO4nj
   408  :25380  latency-based-routing  qabefore-chat-fast-pool  litellm.Timeout: APITimeoutError - Request timed out
   408  :32064  latency-based-routing  qabefore-chat-fast-pool  litellm.Timeout: APITimeoutError - Request timed out
   408  :25380  latency-based-routing  qabefore-chat-fast-pool  litellm.Timeout: APITimeoutError - Request timed out
   200  :32064  latency-based-routing  qabefore-chat-fast-pool  id=chatcmpl-EKtZQD01jSKTjXHrY1qtzO5
   200  :25380  latency-based-routing  qabefore-chat-fast-pool  id=chatcmpl-EKtZRJdptPjcgkpp6FQtq9o
   ```

5. Count the 500s above and the `ZeroDivisionError` tracebacks across both instances' logs

   ```
   grep -c '^500' flow-output.txt
   cat proxy-32064.log proxy-25380.log | grep -c ZeroDivisionError
   ```

   ```
   500s=6  ZeroDivisionError in logs=9
   ```

#### POST /v1/responses

1. Flush the shared Redis and boot two fresh instances from `bf51dea36b`, two uvicorn workers each, on ports 32064 and 25380

   ```
   redis-cli -p 40088 FLUSHALL
   for port in 32064 25380; do python litellm/proxy/proxy_cli.py --config responses.yaml --port $port --num_workers 2 & done
   ```

   ```
   instance :32064 up after 10s (bf51dea36b)
   instance :25380 up after 1s (bf51dea36b)
   ```

2. Six `cost-based-routing` requests on `qabefore-responses-pool`, alternating between the two instances

   ```
   ROUTE=/v1/responses PA=32064 PB=25380 n=0
   for i in 1 2 3 4 5 6; do call cost-based-routing qabefore-responses-pool; done
   ```

   ```
   200  :32064  cost-based-routing  qabefore-responses-pool  id=resp_LQlHZ07nkc_aVqUxC1q4vNC76PF
   200  :25380  cost-based-routing  qabefore-responses-pool  id=resp_U_0STxTdjG_xvrJTyZtYE4cqCeM
   200  :32064  cost-based-routing  qabefore-responses-pool  id=resp_Q91uT7NEvf7IplABLKsHGMFVzEK
   200  :25380  cost-based-routing  qabefore-responses-pool  id=resp_QcAM3WIWPZMjMnaQU6zQKemMors
   200  :32064  cost-based-routing  qabefore-responses-pool  id=resp_mgVFpdXvX2rIcOZj3o2fkkkSqPu
   200  :25380  cost-based-routing  qabefore-responses-pool  id=resp_sitPoFbeeCETRKmgN9qf8oDhDiZ
   ```

3. Six `latency-based-routing` requests on the same `qabefore-responses-pool`, alternating between the two instances

   ```
   for i in 1 2 3 4 5 6; do call latency-based-routing qabefore-responses-pool; done
   ```

   ```
   500  :32064  latency-based-routing  qabefore-responses-pool  float division by zero
   500  :25380  latency-based-routing  qabefore-responses-pool  float division by zero
   500  :32064  latency-based-routing  qabefore-responses-pool  float division by zero
   500  :25380  latency-based-routing  qabefore-responses-pool  float division by zero
   500  :32064  latency-based-routing  qabefore-responses-pool  float division by zero
   500  :25380  latency-based-routing  qabefore-responses-pool  float division by zero
   ```

4. Six `latency-based-routing` requests on a fresh `qabefore-responses-fast-pool`, alternating between the two instances

   ```
   for i in 1 2 3 4 5 6; do call latency-based-routing qabefore-responses-fast-pool; done
   ```

   ```
   200  :32064  latency-based-routing  qabefore-responses-fast-pool  id=resp_jLh4aV_nsLY0mfZdakrCvupVgE3
   408  :25380  latency-based-routing  qabefore-responses-fast-pool  litellm.Timeout: Timeout Error: OpenAIException - litellm.Timeout: Connection ti
   408  :32064  latency-based-routing  qabefore-responses-fast-pool  litellm.Timeout: Timeout Error: OpenAIException - litellm.Timeout: Connection ti
   200  :25380  latency-based-routing  qabefore-responses-fast-pool  id=resp_B4g1iVPg6iqRIakGZ-RLeQ876cd
   200  :32064  latency-based-routing  qabefore-responses-fast-pool  id=resp_B7heP1K-gWxYn8oQE3XmQkjrxzG
   200  :25380  latency-based-routing  qabefore-responses-fast-pool  id=resp_dcJER1LOcRbmsZg1vPTmHliuQip
   ```

5. Count the 500s above and the `ZeroDivisionError` tracebacks across both instances' logs

   ```
   grep -c '^500' flow-output.txt
   cat proxy-32064.log proxy-25380.log | grep -c ZeroDivisionError
   ```

   ```
   500s=6  ZeroDivisionError in logs=6
   ```

#### POST /v1/messages

1. Flush the shared Redis and boot two fresh instances from `bf51dea36b`, two uvicorn workers each, on ports 32064 and 25380

   ```
   redis-cli -p 40088 FLUSHALL
   for port in 32064 25380; do python litellm/proxy/proxy_cli.py --config messages.yaml --port $port --num_workers 2 & done
   ```

   ```
   instance :32064 up after 8s (bf51dea36b)
   instance :25380 up after 1s (bf51dea36b)
   ```

2. Six `cost-based-routing` requests on `qabefore-messages-pool`, alternating between the two instances

   ```
   ROUTE=/v1/messages PA=32064 PB=25380 n=0
   for i in 1 2 3 4 5 6; do call cost-based-routing qabefore-messages-pool; done
   ```

   ```
   200  :32064  cost-based-routing  qabefore-messages-pool  id=resp_bGl0ZWxsbTpjdXN0b21fbGxtX3B
   200  :25380  cost-based-routing  qabefore-messages-pool  id=resp_bGl0ZWxsbTpjdXN0b21fbGxtX3B
   200  :32064  cost-based-routing  qabefore-messages-pool  id=resp_bGl0ZWxsbTpjdXN0b21fbGxtX3B
   200  :25380  cost-based-routing  qabefore-messages-pool  id=resp_bGl0ZWxsbTpjdXN0b21fbGxtX3B
   200  :32064  cost-based-routing  qabefore-messages-pool  id=resp_bGl0ZWxsbTpjdXN0b21fbGxtX3B
   200  :25380  cost-based-routing  qabefore-messages-pool  id=resp_bGl0ZWxsbTpjdXN0b21fbGxtX3B
   ```

3. Six `latency-based-routing` requests on the same `qabefore-messages-pool`, alternating between the two instances

   ```
   for i in 1 2 3 4 5 6; do call latency-based-routing qabefore-messages-pool; done
   ```

   ```
   500  :32064  latency-based-routing  qabefore-messages-pool  float division by zero
   500  :25380  latency-based-routing  qabefore-messages-pool  float division by zero
   500  :32064  latency-based-routing  qabefore-messages-pool  float division by zero
   500  :25380  latency-based-routing  qabefore-messages-pool  float division by zero
   500  :32064  latency-based-routing  qabefore-messages-pool  float division by zero
   500  :25380  latency-based-routing  qabefore-messages-pool  float division by zero
   ```

4. Six `latency-based-routing` requests on a fresh `qabefore-messages-fast-pool`, alternating between the two instances

   ```
   for i in 1 2 3 4 5 6; do call latency-based-routing qabefore-messages-fast-pool; done
   ```

   ```
   408  :32064  latency-based-routing  qabefore-messages-fast-pool  litellm.Timeout: Timeout Error: OpenAIException - litellm.Timeout: Connection ti
   200  :25380  latency-based-routing  qabefore-messages-fast-pool  id=resp_bGl0ZWxsbTpjdXN0b21fbGxtX3B
   200  :32064  latency-based-routing  qabefore-messages-fast-pool  id=resp_bGl0ZWxsbTpjdXN0b21fbGxtX3B
   200  :25380  latency-based-routing  qabefore-messages-fast-pool  id=resp_bGl0ZWxsbTpjdXN0b21fbGxtX3B
   200  :32064  latency-based-routing  qabefore-messages-fast-pool  id=resp_bGl0ZWxsbTpjdXN0b21fbGxtX3B
   200  :25380  latency-based-routing  qabefore-messages-fast-pool  id=resp_bGl0ZWxsbTpjdXN0b21fbGxtX3B
   ```

5. Count the 500s above and the `ZeroDivisionError` tracebacks across both instances' logs

   ```
   grep -c '^500' flow-output.txt
   cat proxy-32064.log proxy-25380.log | grep -c ZeroDivisionError
   ```

   ```
   500s=6  ZeroDivisionError in logs=6
   ```

### After (be9a2ea7c9)

#### POST /v1/chat/completions

1. Flush the shared Redis and boot two fresh instances from `be9a2ea7c9`, two uvicorn workers each, on ports 45864 and 25445

   ```
   redis-cli -p 40088 FLUSHALL
   for port in 45864 25445; do python litellm/proxy/proxy_cli.py --config chat.yaml --port $port --num_workers 2 & done
   ```

   ```
   instance :45864 up after 10s (be9a2ea7c9)
   instance :25445 up after 1s (be9a2ea7c9)
   ```

2. Six `cost-based-routing` requests on `qaafter-chat-pool`, alternating between the two instances

   ```
   ROUTE=/v1/chat/completions PA=45864 PB=25445 n=0
   for i in 1 2 3 4 5 6; do call cost-based-routing qaafter-chat-pool; done
   ```

   ```
   200  :45864  cost-based-routing  qaafter-chat-pool  id=chatcmpl-EKtzbiRutS6SqNyw7w3VBpr
   200  :25445  cost-based-routing  qaafter-chat-pool  id=chatcmpl-EKtzci0A1XILn27DyugSRsl
   200  :45864  cost-based-routing  qaafter-chat-pool  id=chatcmpl-EKtzdGC3h7Z6oysP7YPCUVJ
   200  :25445  cost-based-routing  qaafter-chat-pool  id=chatcmpl-5d9a51a7-45d2-49c9-bdde
   200  :45864  cost-based-routing  qaafter-chat-pool  id=chatcmpl-24a9c424-e869-4c78-8afd
   200  :25445  cost-based-routing  qaafter-chat-pool  id=chatcmpl-EKtzfbEOc4gTMmHtHhvnz2a
   ```

3. Six `latency-based-routing` requests on the same `qaafter-chat-pool`, alternating between the two instances

   ```
   for i in 1 2 3 4 5 6; do call latency-based-routing qaafter-chat-pool; done
   ```

   ```
   200  :45864  latency-based-routing  qaafter-chat-pool  id=chatcmpl-EKtzgtuGPLo8QGoN3Fr9QBu
   200  :25445  latency-based-routing  qaafter-chat-pool  id=chatcmpl-EKtzhESn3E1NdXzFC86cwDz
   200  :45864  latency-based-routing  qaafter-chat-pool  id=chatcmpl-EKtziQVuljBPXLmsBRkPeIE
   200  :25445  latency-based-routing  qaafter-chat-pool  id=chatcmpl-EKtziIhySsfStAvMfchNfMQ
   200  :45864  latency-based-routing  qaafter-chat-pool  id=chatcmpl-EKtzjBajWZud7zZgTIcALNq
   200  :25445  latency-based-routing  qaafter-chat-pool  id=chatcmpl-EKtzkJh0jvxiN0VcW2SlGAu
   ```

4. Six `latency-based-routing` requests on a fresh `qaafter-chat-fast-pool`, alternating between the two instances

   ```
   for i in 1 2 3 4 5 6; do call latency-based-routing qaafter-chat-fast-pool; done
   ```

   ```
   408  :45864  latency-based-routing  qaafter-chat-fast-pool  litellm.Timeout: APITimeoutError - Request timed out
   200  :25445  latency-based-routing  qaafter-chat-fast-pool  id=chatcmpl-EKtzlSEqUzLP06HrXEJCnuy
   200  :45864  latency-based-routing  qaafter-chat-fast-pool  id=chatcmpl-EKtzmgBZQn3tk7tScLLzzdi
   200  :25445  latency-based-routing  qaafter-chat-fast-pool  id=chatcmpl-EKtznQj9CWtBZhxqRmMmhsp
   200  :45864  latency-based-routing  qaafter-chat-fast-pool  id=chatcmpl-EKtzoM3Neho4PwLNakQQ8JG
   200  :25445  latency-based-routing  qaafter-chat-fast-pool  id=chatcmpl-EKtzqpL6iOG3HcX4Qm6qjUV
   ```

5. Count the 500s above and the `ZeroDivisionError` tracebacks across both instances' logs

   ```
   grep -c '^500' flow-output.txt
   cat proxy-45864.log proxy-25445.log | grep -c ZeroDivisionError
   ```

   ```
   500s=0  ZeroDivisionError in logs=0
   ```

#### POST /v1/responses

1. Flush the shared Redis and boot two fresh instances from `be9a2ea7c9`, two uvicorn workers each, on ports 45864 and 25445

   ```
   redis-cli -p 40088 FLUSHALL
   for port in 45864 25445; do python litellm/proxy/proxy_cli.py --config responses.yaml --port $port --num_workers 2 & done
   ```

   ```
   instance :45864 up after 8s (be9a2ea7c9)
   instance :25445 up after 1s (be9a2ea7c9)
   ```

2. Six `cost-based-routing` requests on `qaafter-responses-pool`, alternating between the two instances

   ```
   ROUTE=/v1/responses PA=45864 PB=25445 n=0
   for i in 1 2 3 4 5 6; do call cost-based-routing qaafter-responses-pool; done
   ```

   ```
   200  :45864  cost-based-routing  qaafter-responses-pool  id=resp_l0uvNp7FSlcAdxkBdJdXcr50zCM
   200  :25445  cost-based-routing  qaafter-responses-pool  id=resp_p6S21CdrfKI0XKqHh9IqoOREDep
   200  :45864  cost-based-routing  qaafter-responses-pool  id=resp_LJ0SStT-BqpyusuA82wBJHWvVtH
   200  :25445  cost-based-routing  qaafter-responses-pool  id=resp_rseXYKbo0_brqOi4TDuG5Re1Fnq
   200  :45864  cost-based-routing  qaafter-responses-pool  id=resp_d3yxdZiQgMIiE-LQp2k51H3kffI
   200  :25445  cost-based-routing  qaafter-responses-pool  id=resp_9jga35NyYJ-3Z7nLW7SxVZ-2SjN
   ```

3. Six `latency-based-routing` requests on the same `qaafter-responses-pool`, alternating between the two instances

   ```
   for i in 1 2 3 4 5 6; do call latency-based-routing qaafter-responses-pool; done
   ```

   ```
   200  :45864  latency-based-routing  qaafter-responses-pool  id=resp_rVpgrc-rZtTMNURNrUBvHpriRar
   200  :25445  latency-based-routing  qaafter-responses-pool  id=resp_SMggNZrjBjj8V1GN0q4x1G_khG6
   200  :45864  latency-based-routing  qaafter-responses-pool  id=resp_3LvAdHJXCvQ6su-tm4pVzRUcQoy
   200  :25445  latency-based-routing  qaafter-responses-pool  id=resp_mkotY1qa_KkiG4TFMgMILEoTrK3
   200  :45864  latency-based-routing  qaafter-responses-pool  id=resp_DV_Ix3iYTqiVlsP3MYF7iXOFHg4
   200  :25445  latency-based-routing  qaafter-responses-pool  id=resp_KT1590x5XE33xI6_AQJMzg3dzZm
   ```

4. Six `latency-based-routing` requests on a fresh `qaafter-responses-fast-pool`, alternating between the two instances

   ```
   for i in 1 2 3 4 5 6; do call latency-based-routing qaafter-responses-fast-pool; done
   ```

   ```
   200  :45864  latency-based-routing  qaafter-responses-fast-pool  id=resp__264pIRtbMveIEnC7tKg9LnWlb7
   408  :25445  latency-based-routing  qaafter-responses-fast-pool  litellm.Timeout: Timeout Error: OpenAIException - litellm.Timeout: Connection ti
   200  :45864  latency-based-routing  qaafter-responses-fast-pool  id=resp_pttJMZ_h5HUDjdd1Nxz337WBv-x
   200  :25445  latency-based-routing  qaafter-responses-fast-pool  id=resp_hJjJWPW9S15O8ylgD3wggDU5yy7
   408  :45864  latency-based-routing  qaafter-responses-fast-pool  litellm.Timeout: Timeout Error: OpenAIException - litellm.Timeout: Connection ti
   200  :25445  latency-based-routing  qaafter-responses-fast-pool  id=resp_lUHxuziZThunbcKBwHdtibOMB_k
   ```

5. Count the 500s above and the `ZeroDivisionError` tracebacks across both instances' logs

   ```
   grep -c '^500' flow-output.txt
   cat proxy-45864.log proxy-25445.log | grep -c ZeroDivisionError
   ```

   ```
   500s=0  ZeroDivisionError in logs=0
   ```

#### POST /v1/messages

1. Flush the shared Redis and boot two fresh instances from `be9a2ea7c9`, two uvicorn workers each, on ports 45864 and 25445

   ```
   redis-cli -p 40088 FLUSHALL
   for port in 45864 25445; do python litellm/proxy/proxy_cli.py --config messages.yaml --port $port --num_workers 2 & done
   ```

   ```
   instance :45864 up after 6s (be9a2ea7c9)
   instance :25445 up after 1s (be9a2ea7c9)
   ```

2. Six `cost-based-routing` requests on `qaafter-messages-pool`, alternating between the two instances

   ```
   ROUTE=/v1/messages PA=45864 PB=25445 n=0
   for i in 1 2 3 4 5 6; do call cost-based-routing qaafter-messages-pool; done
   ```

   ```
   200  :45864  cost-based-routing  qaafter-messages-pool  id=resp_bGl0ZWxsbTpjdXN0b21fbGxtX3B
   200  :25445  cost-based-routing  qaafter-messages-pool  id=resp_bGl0ZWxsbTpjdXN0b21fbGxtX3B
   200  :45864  cost-based-routing  qaafter-messages-pool  id=resp_bGl0ZWxsbTpjdXN0b21fbGxtX3B
   200  :25445  cost-based-routing  qaafter-messages-pool  id=resp_bGl0ZWxsbTpjdXN0b21fbGxtX3B
   200  :45864  cost-based-routing  qaafter-messages-pool  id=resp_bGl0ZWxsbTpjdXN0b21fbGxtX3B
   200  :25445  cost-based-routing  qaafter-messages-pool  id=resp_bGl0ZWxsbTpjdXN0b21fbGxtX3B
   ```

3. Six `latency-based-routing` requests on the same `qaafter-messages-pool`, alternating between the two instances

   ```
   for i in 1 2 3 4 5 6; do call latency-based-routing qaafter-messages-pool; done
   ```

   ```
   200  :45864  latency-based-routing  qaafter-messages-pool  id=resp_bGl0ZWxsbTpjdXN0b21fbGxtX3B
   200  :25445  latency-based-routing  qaafter-messages-pool  id=resp_bGl0ZWxsbTpjdXN0b21fbGxtX3B
   200  :45864  latency-based-routing  qaafter-messages-pool  id=resp_bGl0ZWxsbTpjdXN0b21fbGxtX3B
   200  :25445  latency-based-routing  qaafter-messages-pool  id=resp_bGl0ZWxsbTpjdXN0b21fbGxtX3B
   200  :45864  latency-based-routing  qaafter-messages-pool  id=resp_bGl0ZWxsbTpjdXN0b21fbGxtX3B
   200  :25445  latency-based-routing  qaafter-messages-pool  id=resp_bGl0ZWxsbTpjdXN0b21fbGxtX3B
   ```

4. Six `latency-based-routing` requests on a fresh `qaafter-messages-fast-pool`, alternating between the two instances

   ```
   for i in 1 2 3 4 5 6; do call latency-based-routing qaafter-messages-fast-pool; done
   ```

   ```
   200  :45864  latency-based-routing  qaafter-messages-fast-pool  id=resp_bGl0ZWxsbTpjdXN0b21fbGxtX3B
   200  :25445  latency-based-routing  qaafter-messages-fast-pool  id=resp_bGl0ZWxsbTpjdXN0b21fbGxtX3B
   408  :45864  latency-based-routing  qaafter-messages-fast-pool  litellm.Timeout: Timeout Error: OpenAIException - litellm.Timeout: Connection ti
   408  :25445  latency-based-routing  qaafter-messages-fast-pool  litellm.Timeout: Timeout Error: OpenAIException - litellm.Timeout: Connection ti
   408  :45864  latency-based-routing  qaafter-messages-fast-pool  litellm.Timeout: Timeout Error: OpenAIException - litellm.Timeout: Connection ti
   200  :25445  latency-based-routing  qaafter-messages-fast-pool  id=resp_bGl0ZWxsbTpjdXN0b21fbGxtX3B
   ```

5. Count the 500s above and the `ZeroDivisionError` tracebacks across both instances' logs

   ```
   grep -c '^500' flow-output.txt
   cat proxy-45864.log proxy-25445.log | grep -c ZeroDivisionError
   ```

   ```
   500s=0  ZeroDivisionError in logs=0
   ```

Observations from the runs:

- Fresh group after a poisoned one routes fine, both legs
- Every 408 is the fast-pool deployment with `timeout: 0.001`
- Before logs also show the cost handler's swallowed ZeroDivisionError
- /v1/messages on OpenAI models returns resp_ ids, not msg_ ones (not this PR)
- The ticket's torn-read theory did not reproduce: on the proxy's async path nothing yields between resetting and filling an entry (`lowest_latency.py:320-324`), so the cost-then-latency trigger above is the deterministic one, and both end at the same guarded division
- Cost and latency handlers share one cache key and overwrite each other's entry, tracked as LIT-7090

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- The ticket's torn-read mechanism was not observed; the proof shows the cost-then-latency trigger instead
  - A proxy success callback never yields between resetting and filling an entry (`litellm/router_strategy/lowest_latency.py:320-324`)
  - The threaded sync path only runs `CustomLogger` success handlers for sync SDK calls (`litellm/litellm_core_utils/litellm_logging.py:2802-2803`)
  - Both paths hit the same division, which the guard now covers
- A deployment seeded by another strategy averages to 0 latency until this worker records a sample for it
  - Same rule as a never-seen deployment (`lowest_latency.py:395`)
  - With the default `lowest_latency_buffer: 0` it wins the group for that request
  - The shared `{model_group}_map` key behind this is LIT-7090

### Low

- Five CircleCI jobs and the non-required `misc / Run tests (Python 3.x)` rows are red at be9a2ea7c9 from a break outside this PR
  - Jobs: `auth_ui_unit_tests`, `batches_testing`, `litellm_utils_testing`, `proxy_logging_guardrails_model_info_tests`, `google_generate_content_endpoint_testing`; misc fails `tests/test_litellm/test_lazy_imports.py::test_star_import_exports_public_api`
  - Cause: #39121 (c091dd4608, inside this branch's merge base), reverted by #39969 (b1e2f5bc0b)
  - Staging pipeline 89211 fails the same tests; 89223, after the revert, passes them
  - The circular imports reproduce locally at bf51dea36b and are gone on this branch merged with current staging (a0be8912ad), where the unit tests and the live rig pass
  - Every required check is green: `gh pr checks 39970 --required` shows 33 of 33
- Cost-based routing now counts responses that come back with no completion tokens toward rpm and tpm
  - The dead division this PR removes aborted the whole success handler for those responses, so they were never counted
  - A deployment carrying `rpm` or `tpm` in the model list is skipped sooner by that strategy's limit check (`litellm/router_strategy/lowest_cost.py:284`)
  - The before rig logged three of these swallowed errors on live traffic, so the shape is not rare

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


- [x] be9a2ea7c9 passes /live-pr-risk
