### PR TITLE
feat(auto-router): emit trajectory signals for agentic tasks

### DIFF
--- a/litellm/router_strategy/complexity_router/README.md
+++ b/litellm/router_strategy/complexity_router/README.md
@@ -314,6 +314,13 @@ currently sits, each written into `routing_decision.signals` as `trajectory:<nam
 - `production_intensity`: fraction of write-intent calls (`write`, `edit`, `create`, `delete`,
   and similar)
 
+A turn that carried tool calls also records `trajectory:observed_calls=<count>`, which is the
+denominator the four fractions are over and decides how much they are worth: `spinning=0.500`
+across two calls is much weaker evidence than the same number across six. It is recorded even
+when all four fractions are zero, so a window that was read and scored nothing stays
+distinguishable from a plain chat turn that had no tool calls to read at all. The fractions
+themselves are recorded only when non-zero, to keep the record short.
+
 This is observational only: it never changes which tier or model a request routes to. It reuses
 the same tool-call parsing stall escalation uses, so a call counts the same way for both, and is
 read over `trajectory_signal_window` (default 6) rather than `stall_escalation_window`. A turn

--- a/litellm/router_strategy/complexity_router/README.md
+++ b/litellm/router_strategy/complexity_router/README.md
@@ -299,6 +299,47 @@ rejected together with `tier_definitions`, for the same reason `escalation_keywo
 rely on the built-in tier severity order, which a custom tier set does not define. Off by
 default.
 
+### Trajectory signals
+
+`trajectory_signals_enabled` (on by default) reads the assistant's own recent tool calls on
+every classified turn and records four independent fractions describing where an agentic task
+currently sits, each written into `routing_decision.signals` as `trajectory:<name>=<value>`:
+
+- `error_severity`: fraction of recent calls that errored (always 0.0 on chat-completions
+  surfaces, which carry no standard error flag)
+- `spinning`: 1.0 minus the fraction of unique call signatures, high when the assistant keeps
+  calling the same tool with the same arguments
+- `exploring`: fraction of read-intent calls (`read`, `get`, `list`, `search`, and similar verbs
+  matched against the tool name)
+- `production_intensity`: fraction of write-intent calls (`write`, `edit`, `create`, `delete`,
+  and similar)
+
+This is observational only: it never changes which tier or model a request routes to. It reuses
+the same tool-call parsing stall escalation uses, so a call counts the same way for both, and is
+read over `trajectory_signal_window` (default 6) rather than `stall_escalation_window`. A turn
+with no tool-call history emits nothing, and a tool name whose verb matches none of the built-in
+lists counts toward neither `exploring` nor `production_intensity`. Use `trajectory_tool_intents`
+to tell the router what a custom tool name means when it doesn't describe itself:
+
+```yaml
+model_list:
+  - model_name: smart-router
+    litellm_params:
+      model: auto_router/complexity_router
+      complexity_router_config:
+        trajectory_signal_window: 6
+        trajectory_tool_intents:
+          frobnicate: write
+        tiers:
+          SIMPLE: gpt-4o-mini
+          MEDIUM: gpt-4o
+          COMPLEX: claude-sonnet-4
+          REASONING: o1-preview
+```
+
+Set `trajectory_signals_enabled: false` to skip the extra tool-call scan on routers that don't
+want the signals.
+
 ### Heuristic-first chaining
 
 `classifier_type: heuristic_first` runs the local scorer on every request and only calls the LLM

--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -1479,10 +1479,11 @@ class ComplexityRouter(CustomLogger):
     def _trajectory_signal_strings(self, messages: Sequence[Mapping[str, object]] | None) -> tuple[str, ...]:
         """This turn's trajectory as `trajectory:<name>=<value>` entries, for the decision record.
 
-        Observational: nothing reads these back to choose a tier. Only non-zero values are
-        recorded, because a zero meaning "no tool calls to read" and a zero meaning "read them,
-        nothing fired" are different facts, and emitting both as 0.000 would conflate them on
-        every plain chat turn.
+        Observational: nothing reads these back to choose a tier. A turn carrying tool calls
+        always records `observed_calls`, so a window that was read and scored zero on every
+        fraction stays distinguishable from a plain chat turn with nothing to read, and it is
+        also the denominator the fractions are over, which decides how much they are worth. The
+        fractions themselves are recorded only when non-zero, to keep the record short.
         """
         if not self.config.trajectory_signals_enabled:
             return ()
@@ -1493,15 +1494,18 @@ class ComplexityRouter(CustomLogger):
         )
         if trajectory.observed_calls == 0:
             return ()
-        return tuple(
-            f"trajectory:{name}={value:.3f}"
-            for name, value in (
-                ("error_severity", trajectory.error_severity),
-                ("spinning", trajectory.spinning),
-                ("exploring", trajectory.exploring),
-                ("production_intensity", trajectory.production_intensity),
-            )
-            if value > 0.0
+        return (
+            f"trajectory:observed_calls={trajectory.observed_calls}",
+            *(
+                f"trajectory:{name}={value:.3f}"
+                for name, value in (
+                    ("error_severity", trajectory.error_severity),
+                    ("spinning", trajectory.spinning),
+                    ("exploring", trajectory.exploring),
+                    ("production_intensity", trajectory.production_intensity),
+                )
+                if value > 0.0
+            ),
         )
 
     def _build_routing_decision(
@@ -3559,6 +3563,7 @@ class ComplexityRouter(CustomLogger):
                     conversation_continuing=conversation_continuing,
                     cause="plan_mode",
                     tier=plan_floor,
+                    signals=trajectory_signals,
                     matched_keyword=plan_mode_sentinel,
                     escalation_keyword=escalation_keyword,
                     escalated=False,
@@ -3662,7 +3667,7 @@ class ComplexityRouter(CustomLogger):
                     routed_model=fallback_model,
                     conversation_continuing=conversation_continuing,
                     cause=outcome.cause,
-                    signals=outcome.signals,
+                    signals=(*outcome.signals, *trajectory_signals),
                     escalation_keyword=escalation_keyword,
                     escalated=False,
                 ),

--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -3398,6 +3398,11 @@ class ComplexityRouter(CustomLogger):
                                         routed_model=routed_model,
                                         cause=cause,
                                         tier=routed_pin_tier,
+                                        # Replaying a pin skips classification, but the turn still
+                                        # happened and its trajectory is still the calibration data
+                                        # this records. Leaving it off here would drop exactly the
+                                        # agentic continuations a pinned session is made of.
+                                        signals=self._trajectory_signal_strings(resolved_messages),
                                         matched_keyword=pin_plan_sentinel if plan_floored else None,
                                         escalation_keyword=pin_escalation_keyword,
                                         escalated=escalated,
@@ -3524,6 +3529,9 @@ class ComplexityRouter(CustomLogger):
                     routed_model=routed_model,
                     cause="default_fallback",
                     tier=fallback_tier,
+                    # An agentic turn answering a tool call carries no user text of its own, so it
+                    # lands here rather than at the classifier. Its trajectory is still readable.
+                    signals=self._trajectory_signal_strings(resolved_messages),
                     conversation_continuing=conversation_continuing,
                 ),
             )

--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -84,6 +84,7 @@ from .config import (
     TierDefinition,
 )
 from .stall_detector import detect_stalled_task
+from .trajectory_signals import compute_trajectory_signals
 
 if TYPE_CHECKING:
     from semantic_router.routers import SemanticRouter
@@ -1473,6 +1474,34 @@ class ComplexityRouter(CustomLogger):
             simple_medium=boundaries.get("simple_medium", 0.15),
             medium_complex=boundaries.get("medium_complex", 0.35),
             complex_reasoning=boundaries.get("complex_reasoning", 0.60),
+        )
+
+    def _trajectory_signal_strings(self, messages: Sequence[Mapping[str, object]] | None) -> tuple[str, ...]:
+        """This turn's trajectory as `trajectory:<name>=<value>` entries, for the decision record.
+
+        Observational: nothing reads these back to choose a tier. Only non-zero values are
+        recorded, because a zero meaning "no tool calls to read" and a zero meaning "read them,
+        nothing fired" are different facts, and emitting both as 0.000 would conflate them on
+        every plain chat turn.
+        """
+        if not self.config.trajectory_signals_enabled:
+            return ()
+        trajectory: Final = compute_trajectory_signals(
+            messages,
+            window=self.config.trajectory_signal_window,
+            tool_intents=self.config.trajectory_tool_intents,
+        )
+        if trajectory.observed_calls == 0:
+            return ()
+        return tuple(
+            f"trajectory:{name}={value:.3f}"
+            for name, value in (
+                ("error_severity", trajectory.error_severity),
+                ("spinning", trajectory.spinning),
+                ("exploring", trajectory.exploring),
+                ("production_intensity", trajectory.production_intensity),
+            )
+            if value > 0.0
         )
 
     def _build_routing_decision(
@@ -3506,6 +3535,9 @@ class ComplexityRouter(CustomLogger):
             window=self.config.stall_escalation_window,
             repeat_threshold=self.config.stall_escalation_repeat_threshold,
         )
+        # Read here for the same reason `stalled` is: the keyword-override path below returns
+        # before any classification runs, and its decision record carries these too.
+        trajectory_signals: Final = self._trajectory_signal_strings(resolved_messages)
 
         plan_mode_sentinel: Final = self._matched_plan_mode_signal(request_kwargs, resolved_messages)
         plan_floor: Final = self._resolve_plan_mode_floor() if plan_mode_sentinel is not None else None
@@ -3567,7 +3599,7 @@ class ComplexityRouter(CustomLogger):
                     conversation_continuing=conversation_continuing,
                     cause=keyword_cause,
                     tier=routed_tier,
-                    signals=("stall_escalation",) if stalled else None,
+                    signals=(*trajectory_signals, "stall_escalation") if stalled else trajectory_signals,
                     matched_keyword=plan_mode_sentinel if keyword_plan_floored else override.matched_keyword,
                     escalation_keyword=escalation_keyword,
                     escalated=keyword_escalated,
@@ -3705,9 +3737,9 @@ class ComplexityRouter(CustomLogger):
             None if outcome.cause == "default_model_fallback" and plan_mode_sentinel is None else tier
         )
         decision_signals: Final = (
-            (*signals, f"plugin-filtered-pool:{_tier_name(tier)}")
+            (*signals, f"plugin-filtered-pool:{_tier_name(tier)}", *trajectory_signals)
             if outcome.cause == "default_model_fallback" and self.config.plugins
-            else signals
+            else (*signals, *trajectory_signals)
         )
         decision_cause: Final[RoutingDecisionCause] = "plan_mode" if plan_floored else outcome.cause
         decision_keyword: Final = (

--- a/litellm/router_strategy/complexity_router/config.py
+++ b/litellm/router_strategy/complexity_router/config.py
@@ -924,6 +924,31 @@ class ComplexityRouterConfig(BaseModel):
         ),
     )
 
+    trajectory_signals_enabled: bool = Field(
+        default=True,
+        description=(
+            "Read the assistant's recent tool calls on every classified turn and record how "
+            "erroring, repetitive, exploratory, or productive the task currently looks, as "
+            "trajectory:<name>=<value> entries in routing_decision.signals. Observational only: "
+            "this never changes which tier or model a request routes to. On by default because "
+            "the values are the calibration data a later routing feature would be tuned against; "
+            "turn off to skip the extra tool-call scan on routers that do not want the signals."
+        ),
+    )
+    trajectory_signal_window: int = Field(
+        default=6,
+        gt=0,
+        description="How many of the assistant's most recent tool calls trajectory signals are read over.",
+    )
+    trajectory_tool_intents: Mapping[str, Literal["read", "write", "execute", "unknown"]] | None = Field(
+        default=None,
+        description=(
+            "Tool name to intent overrides, matched case-insensitively and read before the "
+            "built-in verb matching. Use this when a tool's name does not describe what it does, "
+            "e.g. a custom tool named after a product rather than a verb."
+        ),
+    )
+
     plan_mode_min_tier: str | None = Field(
         default=None,
         description=(

--- a/litellm/router_strategy/complexity_router/stall_detector.py
+++ b/litellm/router_strategy/complexity_router/stall_detector.py
@@ -11,82 +11,17 @@ Tool calls arrive in two shapes and are read in place rather than translated:
   `tool_result` block carrying `is_error`
 - Chat completions: assistant `tool_calls` entries, answered by a `role: "tool"` message,
   which has no standard error flag, so those calls are judged on repetition alone
+
+Parsing is shared with `trajectory_signals`, so the two agree on what counts as the same call.
 """
 
 from __future__ import annotations
 
-import json
-from collections.abc import Iterator, Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from itertools import islice
-from typing import Final, NamedTuple
+from typing import Final
 
-_ARGUMENTS_PARSE_FAILED: Final = object()
-
-
-class _ToolCallEvent(NamedTuple):
-    signature: tuple[str, str]
-    is_error: bool | None
-    """None where the surface reports no error status, and never counted as an error."""
-
-
-def _json_arguments(raw: str) -> object:
-    try:
-        return json.loads(raw)
-    except (TypeError, ValueError):
-        return _ARGUMENTS_PARSE_FAILED
-
-
-def _tool_call_signature(name: str, raw_arguments: object) -> tuple[str, str]:
-    """Canonicalized so the same call compares equal across both surfaces, which carry
-    arguments as a dict and as a JSON string respectively."""
-    parsed: Final = _json_arguments(raw_arguments) if isinstance(raw_arguments, str) else raw_arguments
-    arguments: Final = raw_arguments if parsed is _ARGUMENTS_PARSE_FAILED else parsed
-    try:
-        return name, json.dumps(arguments, sort_keys=True, default=str)
-    except (TypeError, ValueError):
-        return name, str(arguments)
-
-
-def _iter_tool_result_error_pairs(messages: Sequence[Mapping[str, object]]) -> Iterator[tuple[str, bool]]:
-    for msg in messages:
-        content = msg.get("content")
-        if msg.get("role") != "user" or not isinstance(content, list):
-            continue
-        for part in content:
-            if isinstance(part, Mapping) and part.get("type") == "tool_result":
-                call_id = part.get("tool_use_id")
-                if isinstance(call_id, str):
-                    yield call_id, bool(part.get("is_error", False))
-
-
-def _iter_tool_call_events_newest_first(messages: Sequence[Mapping[str, object]]) -> Iterator[_ToolCallEvent]:
-    error_by_call_id: Final = dict(_iter_tool_result_error_pairs(messages))
-    for msg in reversed(messages):
-        if msg.get("role") != "assistant":
-            continue
-        content = msg.get("content")
-        if isinstance(content, list):
-            for part in reversed(content):
-                if not (isinstance(part, Mapping) and part.get("type") == "tool_use"):
-                    continue
-                name = part.get("name")
-                if isinstance(name, str):
-                    call_id = part.get("id")
-                    yield _ToolCallEvent(
-                        signature=_tool_call_signature(name, part.get("input")),
-                        is_error=error_by_call_id.get(call_id) if isinstance(call_id, str) else None,
-                    )
-        tool_calls = msg.get("tool_calls")
-        if not isinstance(tool_calls, list):
-            continue
-        for call in reversed(tool_calls):
-            function = call.get("function") if isinstance(call, Mapping) else None
-            name = function.get("name") if isinstance(function, Mapping) else None
-            if isinstance(name, str):
-                yield _ToolCallEvent(
-                    signature=_tool_call_signature(name, function.get("arguments") if function else None),
-                    is_error=None,
-                )
+from litellm.router_strategy.complexity_router.trajectory_signals import iter_tool_call_events_newest_first
 
 
 def detect_stalled_task(
@@ -106,7 +41,7 @@ def detect_stalled_task(
     """
     if not messages or repeat_threshold <= 0:
         return False
-    recent: Final = tuple(islice(_iter_tool_call_events_newest_first(messages), window))
+    recent: Final = tuple(islice(iter_tool_call_events_newest_first(messages), window))
     if len(recent) < repeat_threshold:
         return False
     newest: Final = recent[0]

--- a/litellm/router_strategy/complexity_router/trajectory_signals.py
+++ b/litellm/router_strategy/complexity_router/trajectory_signals.py
@@ -147,11 +147,17 @@ def _iter_tool_result_error_pairs(messages: Sequence[Mapping[str, object]]) -> I
 
 
 def iter_tool_call_events_newest_first(messages: Sequence[Mapping[str, object]]) -> Iterator[ToolCallEvent]:
-    error_by_call_id: Final = dict(  # mutable-ok: frozen immediately afterward via iteration; never escaped or reused
-        _iter_tool_result_error_pairs(messages)
-    )
+    """Newest tool call first, each carrying the error status of the result that answered it.
+
+    A result always sits after the call it answers, so walking backward reaches it first and the
+    error map fills in as the walk goes. Callers bound this with the window they want, and a long
+    conversation then costs only the messages that window actually reaches, rather than a full
+    scan for results the walk will never ask about.
+    """
+    error_by_call_id: Final[dict[str, bool]] = {}  # mutable-ok: fills in as the walk reaches results; never escapes
     for msg in reversed(messages):
         if msg.get("role") != "assistant":
+            error_by_call_id.update(_iter_tool_result_error_pairs((msg,)))
             continue
         content = msg.get("content")
         if isinstance(content, list):

--- a/litellm/router_strategy/complexity_router/trajectory_signals.py
+++ b/litellm/router_strategy/complexity_router/trajectory_signals.py
@@ -1,0 +1,229 @@
+"""
+Tool-trajectory signals for the Complexity Router.
+
+Reads the assistant's own recent tool calls, which every agentic client resends on each turn,
+and reports where the task currently sits: erroring, repeating itself, reading around, or
+producing. No LLM call and no stored state, so the same window is rescanned per classified turn
+and the reading follows the conversation rather than latching.
+
+Tool calls arrive in two shapes and are read in place rather than translated:
+- Anthropic Messages: assistant `tool_use` content blocks, answered by a user-turn
+  `tool_result` block carrying `is_error`
+- Chat completions: assistant `tool_calls` entries, answered by a `role: "tool"` message,
+  which has no standard error flag, so `error_severity` is always 0.0 on that surface and a
+  reading taken there rests on the other three signals
+
+This module also owns the tool-call parsing both this and `stall_detector` read from, so the
+two agree on what counts as the same call across surfaces.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Iterator, Mapping, Sequence
+from dataclasses import dataclass
+from itertools import islice
+from typing import Final, Literal, NamedTuple
+
+ToolIntent = Literal["read", "write", "execute", "unknown"]
+
+_ARGUMENTS_PARSE_FAILED: Final = object()
+
+_TOKEN_PATTERN: Final = re.compile(r"[A-Z]+(?![a-z])|[A-Za-z][a-z0-9]*")
+
+# Matched against name tokens rather than the raw name so "thread_get" reads as a get and not
+# as a read. Ordered: a tool that both edits and runs is producing, and one that both reads and
+# writes has already stopped exploring. Deliberately generic verbs, since a vendor's tool names
+# are theirs to change; anything unrecognized stays "unknown" and counts toward no signal.
+_INTENT_VERBS: Final[tuple[tuple[ToolIntent, frozenset[str]], ...]] = (
+    (
+        "write",
+        frozenset(
+            {
+                "write",
+                "edit",
+                "create",
+                "update",
+                "patch",
+                "apply",
+                "insert",
+                "replace",
+                "save",
+                "delete",
+                "remove",
+                "rename",
+                "move",
+                "mkdir",
+                "commit",
+            }
+        ),
+    ),
+    ("execute", frozenset({"bash", "shell", "run", "exec", "execute", "command", "terminal"})),
+    (
+        "read",
+        frozenset(
+            {
+                "read",
+                "get",
+                "list",
+                "ls",
+                "search",
+                "grep",
+                "glob",
+                "find",
+                "view",
+                "cat",
+                "fetch",
+                "query",
+                "lookup",
+                "describe",
+                "inspect",
+            }
+        ),
+    ),
+)
+
+
+class ToolCallEvent(NamedTuple):
+    signature: tuple[str, str]
+    is_error: bool | None
+    """None where the surface reports no error status, and never counted as an error."""
+
+
+@dataclass(frozen=True, slots=True)
+class TrajectorySignals:
+    """Where the task sits, as four independent fractions over the same window of tool calls.
+
+    Every field is in [0, 1] and none of them quotes the prompt. `observed_calls` is the
+    denominator they share, and is 0 exactly when the turn carries no tool-call history, which
+    is the "no evidence" case a caller must not read as "nothing happening".
+    """
+
+    error_severity: float
+    spinning: float
+    exploring: float
+    production_intensity: float
+    observed_calls: int
+
+
+NO_TRAJECTORY: Final = TrajectorySignals(
+    error_severity=0.0,
+    spinning=0.0,
+    exploring=0.0,
+    production_intensity=0.0,
+    observed_calls=0,
+)
+
+
+def _json_arguments(raw: str) -> object:
+    try:
+        return json.loads(raw)
+    except (TypeError, ValueError):
+        return _ARGUMENTS_PARSE_FAILED
+
+
+def tool_call_signature(name: str, raw_arguments: object) -> tuple[str, str]:
+    """Canonicalized so the same call compares equal across both surfaces, which carry
+    arguments as a dict and as a JSON string respectively."""
+    parsed: Final = _json_arguments(raw_arguments) if isinstance(raw_arguments, str) else raw_arguments
+    arguments: Final = raw_arguments if parsed is _ARGUMENTS_PARSE_FAILED else parsed
+    try:
+        return name, json.dumps(arguments, sort_keys=True, default=str)
+    except (TypeError, ValueError):
+        return name, str(arguments)
+
+
+def _iter_tool_result_error_pairs(messages: Sequence[Mapping[str, object]]) -> Iterator[tuple[str, bool]]:
+    for msg in messages:
+        content = msg.get("content")
+        if msg.get("role") != "user" or not isinstance(content, list):
+            continue
+        for part in content:
+            if isinstance(part, Mapping) and part.get("type") == "tool_result":
+                call_id = part.get("tool_use_id")
+                if isinstance(call_id, str):
+                    yield call_id, bool(part.get("is_error", False))
+
+
+def iter_tool_call_events_newest_first(messages: Sequence[Mapping[str, object]]) -> Iterator[ToolCallEvent]:
+    error_by_call_id: Final = dict(  # mutable-ok: frozen immediately afterward via iteration; never escaped or reused
+        _iter_tool_result_error_pairs(messages)
+    )
+    for msg in reversed(messages):
+        if msg.get("role") != "assistant":
+            continue
+        content = msg.get("content")
+        if isinstance(content, list):
+            for part in reversed(content):
+                if not (isinstance(part, Mapping) and part.get("type") == "tool_use"):
+                    continue
+                name = part.get("name")
+                if isinstance(name, str):
+                    call_id = part.get("id")
+                    yield ToolCallEvent(
+                        signature=tool_call_signature(name, part.get("input")),
+                        is_error=error_by_call_id.get(call_id) if isinstance(call_id, str) else None,
+                    )
+        tool_calls = msg.get("tool_calls")
+        if not isinstance(tool_calls, list):
+            continue
+        for call in reversed(tool_calls):
+            function = call.get("function") if isinstance(call, Mapping) else None
+            name = function.get("name") if isinstance(function, Mapping) else None
+            if isinstance(name, str):
+                yield ToolCallEvent(
+                    signature=tool_call_signature(name, function.get("arguments") if function else None),
+                    is_error=None,
+                )
+
+
+def resolve_tool_intent(name: str, overrides: Mapping[str, ToolIntent] | None = None) -> ToolIntent:
+    """What a tool call does, by name. An operator's override wins over the verbs.
+
+    Overrides are matched case-insensitively, so an operator writing them the way their tool
+    prints them does not have to know how the client capitalizes it on the wire.
+    """
+    lowered: Final = name.lower()
+    override: Final = (
+        next((intent for key, intent in overrides.items() if key.lower() == lowered), None) if overrides else None
+    )
+    if override is not None:
+        return override
+    tokens: Final[frozenset[str]] = (
+        frozenset(  # mutable-ok: wrapped in frozenset immediately; no mutable state escapes this function
+            str(token).lower() for token in _TOKEN_PATTERN.findall(name)
+        )
+    )
+    for intent, verbs in _INTENT_VERBS:
+        if tokens & verbs:
+            return intent
+    return "unknown"
+
+
+def compute_trajectory_signals(
+    messages: Sequence[Mapping[str, object]] | None,
+    *,
+    window: int,
+    tool_intents: Mapping[str, ToolIntent] | None = None,
+) -> TrajectorySignals:
+    """Read the last `window` tool calls and report the four signals over them.
+
+    Fractions are unweighted: `window` is the only recency control, so the reading stays a
+    plain count a reader can reproduce from the same messages rather than a curve with a
+    constant in it that nothing has yet calibrated.
+    """
+    if not messages or window <= 0:
+        return NO_TRAJECTORY
+    recent: Final = tuple(islice(iter_tool_call_events_newest_first(messages), window))
+    if not recent:
+        return NO_TRAJECTORY
+    total: Final = len(recent)
+    intents: Final = tuple(resolve_tool_intent(event.signature[0], tool_intents) for event in recent)
+    return TrajectorySignals(
+        error_severity=sum(1 for event in recent if event.is_error) / total,
+        spinning=1.0 - len({event.signature for event in recent}) / total,
+        exploring=intents.count("read") / total,
+        production_intensity=intents.count("write") / total,
+        observed_calls=total,
+    )

--- a/litellm/router_strategy/complexity_router/trajectory_signals.py
+++ b/litellm/router_strategy/complexity_router/trajectory_signals.py
@@ -23,12 +23,18 @@ import json
 import re
 from collections.abc import Iterator, Mapping, Sequence
 from dataclasses import dataclass
+from hashlib import sha256
 from itertools import islice
 from typing import Final, Literal, NamedTuple
 
 ToolIntent = Literal["read", "write", "execute", "unknown"]
 
 _ARGUMENTS_PARSE_FAILED: Final = object()
+
+# Real tool arguments are a path, a command, a query: kilobytes at the outside. Past this a
+# signature is carried as a digest instead, so the window holds a bounded amount per call
+# whatever the caller sends.
+_MAX_SIGNATURE_CHARS: Final = 8192
 
 _TOKEN_PATTERN: Final = re.compile(r"[A-Z]+(?![a-z])|[A-Za-z][a-z0-9]*")
 
@@ -123,15 +129,29 @@ def _json_arguments(raw: str) -> object:
         return _ARGUMENTS_PARSE_FAILED
 
 
+def _normalized_arguments(arguments: object) -> str:
+    try:
+        return json.dumps(arguments, sort_keys=True, default=str)
+    except (TypeError, ValueError):
+        return str(arguments)
+
+
 def tool_call_signature(name: str, raw_arguments: object) -> tuple[str, str]:
     """Canonicalized so the same call compares equal across both surfaces, which carry
-    arguments as a dict and as a JSON string respectively."""
+    arguments as a dict and as a JSON string respectively.
+
+    A signature is only ever compared against another one, never read back or recorded, so
+    anything longer than `_MAX_SIGNATURE_CHARS` is kept as a digest of the same canonical form.
+    Equality is unchanged at every size, including across the two surfaces, while a caller
+    sending multi-megabyte tool arguments no longer makes the router hold a second copy of them
+    for every call in the window.
+    """
     parsed: Final = _json_arguments(raw_arguments) if isinstance(raw_arguments, str) else raw_arguments
     arguments: Final = raw_arguments if parsed is _ARGUMENTS_PARSE_FAILED else parsed
-    try:
-        return name, json.dumps(arguments, sort_keys=True, default=str)
-    except (TypeError, ValueError):
-        return name, str(arguments)
+    normalized: Final = _normalized_arguments(arguments)
+    if len(normalized) <= _MAX_SIGNATURE_CHARS:
+        return name, normalized
+    return name, f"sha256:{sha256(normalized.encode('utf-8', errors='replace')).hexdigest()}"
 
 
 def _iter_tool_result_error_pairs(messages: Sequence[Mapping[str, object]]) -> Iterator[tuple[str, bool]]:

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -12993,7 +12993,31 @@ class TestTrajectorySignalsAreObservationalOnly:
 
         assert response is not None
         trajectory = [s for s in response.routing_decision["signals"] if s.startswith("trajectory:")]
-        assert trajectory == ["trajectory:exploring=1.000"]
+        assert trajectory == ["trajectory:observed_calls=2", "trajectory:exploring=1.000"]
+
+    @pytest.mark.asyncio
+    async def test_an_observed_all_zero_window_is_still_recorded(self, complexity_router):
+        """Distinct successful shell calls score zero on all four fractions. The turn must still
+        be distinguishable from a plain chat turn that had no tool calls to read, or the
+        calibration data silently loses every execute-only agentic turn."""
+        messages = [
+            *_agentic_tool_call("t1", "bash", {"cmd": "pytest"}),
+            *_agentic_tool_call("t2", "bash", {"cmd": "ruff"}),
+            {"role": "user", "content": "carry on"},
+        ]
+
+        agentic = await complexity_router.async_pre_routing_hook(
+            model="test-complexity-router", request_kwargs={}, messages=messages
+        )
+        plain = await complexity_router.async_pre_routing_hook(
+            model="test-complexity-router", request_kwargs={}, messages=[{"role": "user", "content": "carry on"}]
+        )
+
+        assert agentic is not None and plain is not None
+        agentic_trajectory = [s for s in agentic.routing_decision["signals"] if s.startswith("trajectory:")]
+        plain_trajectory = [s for s in plain.routing_decision.get("signals", []) if s.startswith("trajectory:")]
+        assert agentic_trajectory == ["trajectory:observed_calls=2"]
+        assert plain_trajectory == []
 
     @pytest.mark.asyncio
     async def test_the_toggle_suppresses_the_signals(self, mock_router_instance, basic_config):
@@ -13035,7 +13059,7 @@ class TestTrajectorySignalsAreObservationalOnly:
 
         assert response is not None
         trajectory = [s for s in response.routing_decision["signals"] if s.startswith("trajectory:")]
-        assert trajectory == ["trajectory:exploring=1.000"]
+        assert trajectory == ["trajectory:observed_calls=2", "trajectory:exploring=1.000"]
 
     @pytest.mark.asyncio
     async def test_operator_tool_intents_reach_the_router(self, mock_router_instance, basic_config):
@@ -13087,3 +13111,67 @@ class TestTrajectorySignalsAreObservationalOnly:
         signals = response.routing_decision["signals"]
         assert "stall_escalation" in signals
         assert "trajectory:error_severity=1.000" in signals
+
+    @pytest.mark.asyncio
+    async def test_a_top_tier_plan_mode_turn_still_records_its_trajectory(
+        self, mock_router_instance, basic_config
+    ):
+        """Plan mode at the top tier returns before classification. Coding agents are exactly
+        where tool trajectories exist, so that path has to carry them too."""
+        router = ComplexityRouter(
+            model_name="plan-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config={**basic_config, "plan_mode_min_tier": "REASONING"},
+        )
+        messages = [
+            *_agentic_tool_call("t1", "read_file", {"path": "a"}),
+            *_agentic_tool_call("t2", "read_file", {"path": "b"}),
+            {"role": "user", "content": "add a hello endpoint"},
+        ]
+
+        response = await router.async_pre_routing_hook(
+            model="plan-router",
+            request_kwargs={
+                "proxy_server_request": {
+                    "body": {
+                        "messages": [
+                            {"role": "system", "content": [{"type": "text", "text": "Plan mode is active."}]}
+                        ]
+                    }
+                }
+            },
+            messages=messages,
+        )
+
+        assert response is not None
+        assert response.routing_decision["cause"] == "plan_mode"
+        trajectory = [s for s in response.routing_decision["signals"] if s.startswith("trajectory:")]
+        assert trajectory == ["trajectory:observed_calls=2", "trajectory:exploring=1.000"]
+
+    @pytest.mark.asyncio
+    async def test_a_classifier_failure_falling_back_still_records_its_trajectory(
+        self, mock_router_instance, llm_classifier_config
+    ):
+        """The classifier failing is no reason to lose the turn's trajectory: that record is
+        the one telling us what the request looked like when routing gave up on it."""
+        router = ComplexityRouter(
+            model_name="fallback-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config={
+                **llm_classifier_config,
+                "classifier_fallback": "default_model",
+                "default_model": "gpt-4o",
+            },
+        )
+        mock_router_instance.acompletion = AsyncMock(side_effect=TimeoutError("classifier timed out"))
+        messages = [
+            *_agentic_tool_call("t1", "write_file", {"path": "a"}),
+            {"role": "user", "content": "prove the Riemann hypothesis step by step"},
+        ]
+
+        response = await router.async_pre_routing_hook(model="fallback-router", request_kwargs={}, messages=messages)
+
+        assert response is not None
+        assert response.routing_decision["cause"] == "default_model_fallback"
+        trajectory = [s for s in response.routing_decision["signals"] if s.startswith("trajectory:")]
+        assert trajectory == ["trajectory:observed_calls=1", "trajectory:production_intensity=1.000"]

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -13175,3 +13175,56 @@ class TestTrajectorySignalsAreObservationalOnly:
         assert response.routing_decision["cause"] == "default_model_fallback"
         trajectory = [s for s in response.routing_decision["signals"] if s.startswith("trajectory:")]
         assert trajectory == ["trajectory:observed_calls=1", "trajectory:production_intensity=1.000"]
+
+    @pytest.mark.asyncio
+    async def test_a_session_pin_replay_still_records_its_trajectory(self, mock_router_instance, basic_config):
+        """Replaying a session pin skips classification entirely, but it is exactly the agentic
+        continuation -- a tool result answering the assistant's last call -- that trajectory
+        signals exist to describe. Losing it here loses it for most of a pinned session."""
+        mock_router_instance.cache = DualCache()
+        router = ComplexityRouter(
+            model_name="test-complexity-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config={**basic_config, "session_affinity": True},
+        )
+        request_kwargs = {"metadata": {"session_id": "session-trajectory"}}
+        cache_key = router._get_session_affinity_cache_key("session-trajectory", request_kwargs)
+        await mock_router_instance.cache.async_set_cache(key=cache_key, value="gpt-4o")
+        messages = [
+            *_agentic_tool_call("t1", "write_file", {"path": "a"}),
+            {"role": "user", "content": "carry on"},
+        ]
+
+        response = await router.async_pre_routing_hook(
+            model="test-complexity-router", request_kwargs=request_kwargs, messages=messages
+        )
+
+        assert response is not None
+        assert response.routing_decision["cause"] == "session_affinity_pin"
+        trajectory = [s for s in response.routing_decision["signals"] if s.startswith("trajectory:")]
+        assert trajectory == ["trajectory:observed_calls=1", "trajectory:production_intensity=1.000"]
+
+    @pytest.mark.asyncio
+    async def test_a_default_fallback_with_no_classifiable_ask_still_records_its_trajectory(
+        self, mock_router_instance, basic_config
+    ):
+        """A tool result with no accompanying user text routes here rather than to the
+        classifier. Its trajectory is still readable from the assistant's own tool calls."""
+        router = ComplexityRouter(
+            model_name="test-complexity-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config={**basic_config, "default_model": "gpt-4o"},
+        )
+        messages = [
+            *_agentic_tool_call("t1", "write_file", {"path": "a"}),
+            {"role": "system", "content": "be nice"},
+        ]
+
+        response = await router.async_pre_routing_hook(
+            model="test-complexity-router", request_kwargs={}, messages=messages
+        )
+
+        assert response is not None
+        assert response.routing_decision["cause"] == "default_fallback"
+        trajectory = [s for s in response.routing_decision["signals"] if s.startswith("trajectory:")]
+        assert trajectory == ["trajectory:observed_calls=1", "trajectory:production_intensity=1.000"]

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -12907,3 +12907,183 @@ class TestClassifierVision:
     def test_max_images_must_be_positive(self):
         with pytest.raises(ValidationError):
             ClassifierLLMConfig(model="clf", vision={"enabled": True, "max_images": 0})
+
+
+def _agentic_tool_call(call_id: str, name: str, arguments: dict, *, is_error: bool = False) -> List[Dict]:
+    return [
+        {"role": "assistant", "content": [{"type": "tool_use", "id": call_id, "name": name, "input": arguments}]},
+        {
+            "role": "user",
+            "content": [{"type": "tool_result", "tool_use_id": call_id, "is_error": is_error, "content": "result"}],
+        },
+    ]
+
+
+class TestTrajectorySignalsAreObservationalOnly:
+    """Trajectory signals ride along on the decision record without changing the decision.
+
+    The guarantee this class exists to hold is the tier equality test below: the same ask routes
+    to the same tier whether or not the turn carries tool-call history.
+    """
+
+    @pytest.mark.asyncio
+    async def test_an_agentic_turn_records_its_trajectory(self, complexity_router):
+        messages = [
+            *_agentic_tool_call("t1", "bash", {"cmd": "pytest"}, is_error=True),
+            *_agentic_tool_call("t2", "bash", {"cmd": "pytest"}, is_error=True),
+            {"role": "user", "content": "try again"},
+        ]
+
+        response = await complexity_router.async_pre_routing_hook(
+            model="test-complexity-router", request_kwargs={}, messages=messages
+        )
+
+        assert response is not None
+        signals = response.routing_decision["signals"]
+        assert "trajectory:error_severity=1.000" in signals
+        assert "trajectory:spinning=0.500" in signals
+
+    @pytest.mark.asyncio
+    async def test_trajectory_history_does_not_change_the_routed_tier(self, complexity_router):
+        """The observe-only guarantee. If a later change lets these signals pick a tier, the two
+        decisions stop matching and this fails."""
+        ask = {"role": "user", "content": "try again"}
+        stuck = [
+            *_agentic_tool_call("t1", "bash", {"cmd": "pytest"}, is_error=True),
+            *_agentic_tool_call("t2", "bash", {"cmd": "pytest"}, is_error=True),
+            *_agentic_tool_call("t3", "bash", {"cmd": "pytest"}, is_error=True),
+            ask,
+        ]
+
+        with_history = await complexity_router.async_pre_routing_hook(
+            model="test-complexity-router", request_kwargs={}, messages=stuck
+        )
+        without_history = await complexity_router.async_pre_routing_hook(
+            model="test-complexity-router", request_kwargs={}, messages=[ask]
+        )
+
+        assert with_history is not None and without_history is not None
+        assert with_history.routing_decision["tier"] == without_history.routing_decision["tier"]
+        assert with_history.model == without_history.model
+        assert with_history.routing_decision["cause"] == without_history.routing_decision["cause"]
+
+    @pytest.mark.asyncio
+    async def test_a_plain_chat_turn_records_no_trajectory(self, complexity_router):
+        response = await complexity_router.async_pre_routing_hook(
+            model="test-complexity-router",
+            request_kwargs={},
+            messages=[{"role": "user", "content": "what is the capital of France?"}],
+        )
+
+        assert response is not None
+        assert not [s for s in response.routing_decision.get("signals", []) if s.startswith("trajectory:")]
+
+    @pytest.mark.asyncio
+    async def test_zero_valued_signals_are_left_out(self, complexity_router):
+        """Two distinct successful reads: exploring fires, the other three do not."""
+        messages = [
+            *_agentic_tool_call("t1", "read_file", {"path": "a"}),
+            *_agentic_tool_call("t2", "read_file", {"path": "b"}),
+            {"role": "user", "content": "carry on"},
+        ]
+
+        response = await complexity_router.async_pre_routing_hook(
+            model="test-complexity-router", request_kwargs={}, messages=messages
+        )
+
+        assert response is not None
+        trajectory = [s for s in response.routing_decision["signals"] if s.startswith("trajectory:")]
+        assert trajectory == ["trajectory:exploring=1.000"]
+
+    @pytest.mark.asyncio
+    async def test_the_toggle_suppresses_the_signals(self, mock_router_instance, basic_config):
+        router = ComplexityRouter(
+            model_name="quiet-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config={**basic_config, "trajectory_signals_enabled": False},
+        )
+        messages = [
+            *_agentic_tool_call("t1", "bash", {"cmd": "pytest"}, is_error=True),
+            {"role": "user", "content": "try again"},
+        ]
+
+        response = await router.async_pre_routing_hook(
+            model="quiet-router", request_kwargs={}, messages=messages
+        )
+
+        assert response is not None
+        assert not [s for s in response.routing_decision.get("signals", []) if s.startswith("trajectory:")]
+
+    @pytest.mark.asyncio
+    async def test_the_window_bounds_what_is_read(self, mock_router_instance, basic_config):
+        router = ComplexityRouter(
+            model_name="narrow-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config={**basic_config, "trajectory_signal_window": 2},
+        )
+        messages = [
+            *_agentic_tool_call("t1", "bash", {"cmd": "pytest"}, is_error=True),
+            *_agentic_tool_call("t2", "bash", {"cmd": "pytest"}, is_error=True),
+            *_agentic_tool_call("t3", "read_file", {"path": "a"}),
+            *_agentic_tool_call("t4", "read_file", {"path": "b"}),
+            {"role": "user", "content": "carry on"},
+        ]
+
+        response = await router.async_pre_routing_hook(
+            model="narrow-router", request_kwargs={}, messages=messages
+        )
+
+        assert response is not None
+        trajectory = [s for s in response.routing_decision["signals"] if s.startswith("trajectory:")]
+        assert trajectory == ["trajectory:exploring=1.000"]
+
+    @pytest.mark.asyncio
+    async def test_operator_tool_intents_reach_the_router(self, mock_router_instance, basic_config):
+        router = ComplexityRouter(
+            model_name="mapped-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config={
+                **basic_config,
+                "trajectory_tool_intents": {"Frobnicate": "write"},
+            },
+        )
+        messages = [
+            *_agentic_tool_call("t1", "frobnicate", {"x": 1}),
+            {"role": "user", "content": "carry on"},
+        ]
+
+        response = await router.async_pre_routing_hook(
+            model="mapped-router", request_kwargs={}, messages=messages
+        )
+
+        assert response is not None
+        assert "trajectory:production_intensity=1.000" in response.routing_decision["signals"]
+
+    @pytest.mark.asyncio
+    async def test_trajectory_rides_alongside_a_stall_escalation(self, mock_router_instance, basic_config):
+        """Both markers land on the same record, and the tier still moves for the stall alone."""
+        router = ComplexityRouter(
+            model_name="stall-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config={
+                **basic_config,
+                "stall_escalation_enabled": True,
+                "stall_escalation_window": 6,
+                "stall_escalation_repeat_threshold": 3,
+            },
+        )
+        messages = [
+            *_agentic_tool_call("t1", "bash", {"cmd": "pytest"}, is_error=True),
+            *_agentic_tool_call("t2", "bash", {"cmd": "pytest"}, is_error=True),
+            *_agentic_tool_call("t3", "bash", {"cmd": "pytest"}, is_error=True),
+            {"role": "user", "content": "try again"},
+        ]
+
+        response = await router.async_pre_routing_hook(
+            model="stall-router", request_kwargs={}, messages=messages
+        )
+
+        assert response is not None
+        signals = response.routing_decision["signals"]
+        assert "stall_escalation" in signals
+        assert "trajectory:error_severity=1.000" in signals

--- a/tests/test_litellm/router_strategy/test_trajectory_signals.py
+++ b/tests/test_litellm/router_strategy/test_trajectory_signals.py
@@ -3,11 +3,15 @@ Tests for tool-trajectory signals: the four fractions the Complexity Router read
 assistant's own recent tool calls, across both Anthropic Messages and chat-completions shapes.
 """
 
+import json
+
 import pytest
 
 from litellm.router_strategy.complexity_router.trajectory_signals import (
+    _MAX_SIGNATURE_CHARS,
     compute_trajectory_signals,
     resolve_tool_intent,
+    tool_call_signature,
 )
 
 
@@ -31,6 +35,44 @@ def _chat_completions_call(call_id: str, name: str, arguments_json: str) -> list
         },
         {"role": "tool", "tool_call_id": call_id, "content": "result"},
     ]
+
+
+class TestToolCallSignatureIsBounded:
+    """A caller controls tool arguments, and the window holds one signature per call, so an
+    oversized argument must not become an oversized signature held several times over."""
+
+    @staticmethod
+    def _big_arguments(marker: str) -> dict:
+        return {"path": marker, "blob": "x" * (_MAX_SIGNATURE_CHARS * 4)}
+
+    def test_a_huge_argument_yields_a_bounded_signature(self):
+        _, signature = tool_call_signature("write_file", self._big_arguments("a"))
+        assert len(signature) <= _MAX_SIGNATURE_CHARS
+        assert signature.startswith("sha256:")
+
+    def test_a_normal_argument_keeps_its_readable_form(self):
+        _, signature = tool_call_signature("write_file", {"path": "a.txt"})
+        assert signature == '{"path": "a.txt"}'
+
+    def test_two_different_huge_arguments_stay_distinguishable(self):
+        """Bounding must not collapse distinct calls into one, or a busy agent would read as
+        spinning purely because its arguments were large."""
+        _, first = tool_call_signature("write_file", self._big_arguments("a"))
+        _, second = tool_call_signature("write_file", self._big_arguments("b"))
+        assert first != second
+
+    def test_the_same_huge_argument_still_compares_equal(self):
+        _, first = tool_call_signature("write_file", self._big_arguments("a"))
+        _, second = tool_call_signature("write_file", self._big_arguments("a"))
+        assert first == second
+
+    def test_a_huge_argument_still_matches_across_surfaces(self):
+        """The cross-surface guarantee has to survive the bound: the same call sent as a dict
+        and as a JSON string is still one repeated call."""
+        arguments = self._big_arguments("a")
+        assert tool_call_signature("write_file", arguments) == tool_call_signature(
+            "write_file", json.dumps(arguments)
+        )
 
 
 class TestResolveToolIntent:

--- a/tests/test_litellm/router_strategy/test_trajectory_signals.py
+++ b/tests/test_litellm/router_strategy/test_trajectory_signals.py
@@ -1,0 +1,197 @@
+"""
+Tests for tool-trajectory signals: the four fractions the Complexity Router reads off the
+assistant's own recent tool calls, across both Anthropic Messages and chat-completions shapes.
+"""
+
+import pytest
+
+from litellm.router_strategy.complexity_router.trajectory_signals import (
+    compute_trajectory_signals,
+    resolve_tool_intent,
+)
+
+
+def _anthropic_call(call_id: str, name: str, arguments: dict, *, is_error: bool) -> list[dict]:
+    return [
+        {"role": "assistant", "content": [{"type": "tool_use", "id": call_id, "name": name, "input": arguments}]},
+        {
+            "role": "user",
+            "content": [{"type": "tool_result", "tool_use_id": call_id, "is_error": is_error, "content": "result"}],
+        },
+    ]
+
+
+def _chat_completions_call(call_id: str, name: str, arguments_json: str) -> list[dict]:
+    return [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {"id": call_id, "type": "function", "function": {"name": name, "arguments": arguments_json}}
+            ],
+        },
+        {"role": "tool", "tool_call_id": call_id, "content": "result"},
+    ]
+
+
+class TestResolveToolIntent:
+    @pytest.mark.parametrize(
+        "name, expected",
+        [
+            ("read_file", "read"),
+            ("Read", "read"),
+            ("Glob", "read"),
+            ("WebFetch", "read"),
+            ("get_issue", "read"),
+            ("write_file", "write"),
+            ("Edit", "write"),
+            ("NotebookEdit", "write"),
+            ("str_replace_editor", "write"),
+            ("bash", "execute"),
+            ("run_tests", "execute"),
+            ("Terminal", "execute"),
+        ],
+    )
+    def test_common_tool_names_resolve_by_verb(self, name: str, expected: str):
+        assert resolve_tool_intent(name) == expected
+
+    def test_verbs_match_name_tokens_not_substrings(self):
+        """'spreadsheet' contains 'read' and 'thread' contains 'read', but neither is a read."""
+        assert resolve_tool_intent("spreadsheet") == "unknown"
+        assert resolve_tool_intent("thread_summary") == "unknown"
+
+    def test_a_writing_tool_that_also_runs_counts_as_writing(self):
+        assert resolve_tool_intent("apply_patch_and_run") == "write"
+
+    def test_unrecognized_names_are_unknown(self):
+        assert resolve_tool_intent("frobnicate") == "unknown"
+        assert resolve_tool_intent("") == "unknown"
+
+    def test_operator_override_wins_over_the_verbs(self):
+        assert resolve_tool_intent("Glob", {"glob": "write"}) == "write"
+
+    def test_override_lets_an_operator_name_their_own_tool(self):
+        assert resolve_tool_intent("frobnicate", {"frobnicate": "write"}) == "write"
+
+
+class TestComputeTrajectorySignals:
+    def test_no_messages_reports_no_evidence(self):
+        for messages in (None, []):
+            signals = compute_trajectory_signals(messages, window=6)
+            assert signals.observed_calls == 0
+            assert signals.error_severity == 0.0
+            assert signals.spinning == 0.0
+
+    def test_a_turn_with_no_tool_calls_reports_no_evidence(self):
+        """Zero signals with observed_calls 0 is 'nothing to read', not 'nothing happening'."""
+        messages = [{"role": "user", "content": "hello"}, {"role": "assistant", "content": "hi"}]
+        assert compute_trajectory_signals(messages, window=6).observed_calls == 0
+
+    def test_error_severity_is_the_fraction_of_failing_calls(self):
+        messages = [
+            *_anthropic_call("t1", "bash", {"cmd": "a"}, is_error=True),
+            *_anthropic_call("t2", "bash", {"cmd": "b"}, is_error=True),
+            *_anthropic_call("t3", "bash", {"cmd": "c"}, is_error=True),
+            *_anthropic_call("t4", "bash", {"cmd": "d"}, is_error=False),
+        ]
+        assert compute_trajectory_signals(messages, window=4).error_severity == 0.75
+
+    def test_error_severity_is_zero_on_chat_completions(self):
+        """A chat-completions tool message carries no standard error flag, so a reading taken
+        on that surface rests on the other three signals."""
+        messages = [
+            *_chat_completions_call("c1", "bash", '{"cmd": "a"}'),
+            *_chat_completions_call("c2", "bash", '{"cmd": "b"}'),
+        ]
+        signals = compute_trajectory_signals(messages, window=6)
+        assert signals.error_severity == 0.0
+        assert signals.observed_calls == 2
+
+    def test_spinning_is_high_when_the_same_call_repeats(self):
+        messages = [
+            *_anthropic_call("t1", "bash", {"cmd": "pytest"}, is_error=False),
+            *_anthropic_call("t2", "bash", {"cmd": "pytest"}, is_error=False),
+            *_anthropic_call("t3", "bash", {"cmd": "pytest"}, is_error=False),
+            *_anthropic_call("t4", "bash", {"cmd": "pytest"}, is_error=False),
+        ]
+        assert compute_trajectory_signals(messages, window=4).spinning == 0.75
+
+    def test_spinning_is_zero_when_every_call_differs(self):
+        messages = [
+            *_anthropic_call("t1", "read_file", {"path": "a"}, is_error=False),
+            *_anthropic_call("t2", "read_file", {"path": "b"}, is_error=False),
+            *_anthropic_call("t3", "read_file", {"path": "c"}, is_error=False),
+        ]
+        assert compute_trajectory_signals(messages, window=6).spinning == 0.0
+
+    def test_the_same_call_counts_as_a_repeat_across_surfaces(self):
+        """Arguments arrive as a dict on one surface and a JSON string on the other."""
+        messages = [
+            *_anthropic_call("t1", "bash", {"cmd": "pytest"}, is_error=False),
+            *_chat_completions_call("c2", "bash", '{"cmd": "pytest"}'),
+        ]
+        assert compute_trajectory_signals(messages, window=6).spinning == 0.5
+
+    def test_exploring_counts_reads_and_production_counts_writes(self):
+        messages = [
+            *_anthropic_call("t1", "read_file", {"path": "a"}, is_error=False),
+            *_anthropic_call("t2", "read_file", {"path": "b"}, is_error=False),
+            *_anthropic_call("t3", "read_file", {"path": "c"}, is_error=False),
+            *_anthropic_call("t4", "write_file", {"path": "d"}, is_error=False),
+        ]
+        signals = compute_trajectory_signals(messages, window=4)
+        assert signals.exploring == 0.75
+        assert signals.production_intensity == 0.25
+
+    def test_executing_counts_toward_neither_exploring_nor_production(self):
+        """Running something is ambiguous between verifying work and churning on it, so it
+        contributes to no signal rather than being guessed into one."""
+        messages = [
+            *_anthropic_call("t1", "bash", {"cmd": "pytest"}, is_error=False),
+            *_anthropic_call("t2", "bash", {"cmd": "ruff"}, is_error=False),
+        ]
+        signals = compute_trajectory_signals(messages, window=6)
+        assert signals.exploring == 0.0
+        assert signals.production_intensity == 0.0
+        assert signals.observed_calls == 2
+
+    def test_unknown_tools_contribute_to_neither_signal(self):
+        messages = [
+            *_anthropic_call("t1", "frobnicate", {"x": 1}, is_error=False),
+            *_anthropic_call("t2", "write_file", {"path": "a"}, is_error=False),
+        ]
+        signals = compute_trajectory_signals(messages, window=6)
+        assert signals.exploring == 0.0
+        assert signals.production_intensity == 0.5
+
+    def test_operator_intents_reclassify_their_own_tools(self):
+        messages = [
+            *_anthropic_call("t1", "frobnicate", {"x": 1}, is_error=False),
+            *_anthropic_call("t2", "frobnicate", {"x": 2}, is_error=False),
+        ]
+        signals = compute_trajectory_signals(messages, window=6, tool_intents={"frobnicate": "write"})
+        assert signals.production_intensity == 1.0
+
+    def test_only_the_newest_window_of_calls_is_read(self):
+        messages = [
+            *_anthropic_call("t1", "bash", {"cmd": "pytest"}, is_error=True),
+            *_anthropic_call("t2", "bash", {"cmd": "pytest"}, is_error=True),
+            *_anthropic_call("t3", "read_file", {"path": "a"}, is_error=False),
+            *_anthropic_call("t4", "read_file", {"path": "b"}, is_error=False),
+        ]
+        signals = compute_trajectory_signals(messages, window=2)
+        assert signals.observed_calls == 2
+        assert signals.error_severity == 0.0
+        assert signals.exploring == 1.0
+
+    def test_a_zero_window_reports_no_evidence(self):
+        messages = [*_anthropic_call("t1", "bash", {"cmd": "pytest"}, is_error=True)]
+        assert compute_trajectory_signals(messages, window=0).observed_calls == 0
+
+    def test_evidence_survives_a_new_human_ask(self):
+        """A plain follow-up must not erase the tool calls before it, matching how stall
+        detection reads the whole visible conversation."""
+        messages = [
+            *_anthropic_call("t1", "write_file", {"path": "a"}, is_error=False),
+            {"role": "user", "content": [{"type": "text", "text": "try again"}]},
+        ]
+        assert compute_trajectory_signals(messages, window=6).production_intensity == 1.0

--- a/tests/test_litellm/router_strategy/test_trajectory_signals.py
+++ b/tests/test_litellm/router_strategy/test_trajectory_signals.py
@@ -187,6 +187,20 @@ class TestComputeTrajectorySignals:
         messages = [*_anthropic_call("t1", "bash", {"cmd": "pytest"}, is_error=True)]
         assert compute_trajectory_signals(messages, window=0).observed_calls == 0
 
+    def test_an_error_is_read_off_a_result_that_arrives_several_messages_later(self):
+        """The result answering a call need not be the very next message. The backward walk
+        collects results as it goes, so anything newer than the call is still matched to it."""
+        messages = [
+            {"role": "assistant", "content": [{"type": "tool_use", "id": "t1", "name": "bash", "input": {"c": "a"}}]},
+            {"role": "assistant", "content": "let me check that"},
+            {"role": "user", "content": "ok"},
+            {
+                "role": "user",
+                "content": [{"type": "tool_result", "tool_use_id": "t1", "is_error": True, "content": "boom"}],
+            },
+        ]
+        assert compute_trajectory_signals(messages, window=6).error_severity == 1.0
+
     def test_evidence_survives_a_new_human_ask(self):
         """A plain follow-up must not erase the tool calls before it, matching how stall
         detection reads the whole visible conversation."""


### PR DESCRIPTION
## TLDR

Problem this solves:

- The Complexity Router's mid-task stall escalation only sees whether tool calls repeat or error
- There's no calibration data yet on how agentic tasks actually behave in production traffic
- A future routing feature that reads task trajectory would be tuned on guesses, not real data

How it solves it:

- Reads the assistant's recent tool calls on every classified turn
- Records four fractions (error_severity, spinning, exploring, production_intensity) into `routing_decision.signals`
- Changes no routing at all: this is calibration data, not a routing feature

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Setup: a local proxy on the complexity router's `smart-router` model, with `SIMPLE: gpt-4o-mini` and `MEDIUM: gpt-4o` tiers and `trajectory_signal_window: 4`, both tiers dispatching to a real OpenAI-backed endpoint. Three requests per side: the same factual question alone, the same question behind a two-call agentic history that repeats one `search_web` call, and the same question behind two distinct successful `bash` calls (which score zero on all four fractions). All hit a live provider and returned real completions.

### Before (6a4fb2bbe8)

#### Plain prompt, no tool history

1. `curl -X POST http://localhost:4001/v1/chat/completions -d '{"model": "smart-router", "messages": [{"role": "user", "content": "What year did the Berlin Wall fall?"}]}'`
2. Returns `"The Berlin Wall fell on November 9, 1989."`
3. Decision record: `tier=SIMPLE model=gpt-4o-mini signals=['short (8 tokens)']`

#### Repeated-tool-call history

1. Same question, plus two `search_web` calls with identical arguments and a "confirm the year" follow-up
2. Returns `"The Berlin Wall fell in 1989."`
3. Decision record: `tier=SIMPLE model=gpt-4o-mini signals=['short (4 tokens)']`. The repeated calls leave no trace

#### Distinct successful shell calls

1. Same question, plus two different `bash` calls that both succeeded
2. Returns `"The Berlin Wall fell in 1989."`
3. Decision record: `tier=SIMPLE model=gpt-4o-mini signals=['short (4 tokens)']`, byte-identical to the case above and indistinguishable from a plain chat turn

### After (11a19fabc1)

#### Plain prompt, no tool history

1. Same request as Before
2. Returns `"The Berlin Wall fell on November 9, 1989."`
3. Decision record: `tier=SIMPLE model=gpt-4o-mini signals=['short (8 tokens)']`, unchanged

#### Repeated-tool-call history

1. Same request as Before
2. Returns `"The Berlin Wall fell on November 9, 1989."`
3. Decision record: `tier=SIMPLE model=gpt-4o-mini signals=['short (4 tokens)', 'trajectory:observed_calls=2', 'trajectory:spinning=0.500', 'trajectory:exploring=1.000']`. `spinning=0.5` because 1 of 2 calls is a duplicate, `exploring=1.0` because `search_web` reads as a read-intent verb

#### Distinct successful shell calls

1. Same request as Before
2. Returns `"The Berlin Wall fell in 1989."`
3. Decision record: `tier=SIMPLE model=gpt-4o-mini signals=['short (4 tokens)', 'trajectory:observed_calls=2']`. All four fractions really are zero here, and the turn is still separable from the plain chat turn above, which carries no `trajectory:` entry at all

#### Session-pin replay with a tool-call answer

1. First request establishes a session pin: `curl ... -d '{"model":"smart-router","metadata":{"session_id":"demo-session-1"},"messages":[{"role":"user","content":"What year did the Berlin Wall fall?"}]}'`
2. Second request, same session_id, now answering a `write_file` tool call: `curl ... -d '{"model":"smart-router","metadata":{"session_id":"demo-session-1"},"messages":[..., {"role":"assistant","tool_calls":[{"function":{"name":"write_file", ...}}]}, {"role":"tool", ...}, {"role":"user","content":"confirm the year"}]}'`
3. Decision record: `cause=session_affinity_pin tier=SIMPLE model=gpt-4o-mini signals=['trajectory:observed_calls=1', 'trajectory:production_intensity=1.000']`

Tier and routed model are `SIMPLE`/`gpt-4o-mini` on every case on both sides: the signals ride along on the decision without moving it.

## Type

🆕 New Feature
✅ Test
📖 Documentation

## Caveats (if any)

### Low

- `signals` is dropped from the logged decision entirely when message logging is off, same as the existing `stall_escalation` and `tier-probability:*` entries it sits alongside; there's no separate typed field yet for a deployment that wants trajectory data without full message logging
- `error_severity` is always 0.0 on the chat-completions surface, which carries no standard per-result error flag, so a reading taken there rests on the other three fractions

### Review history

This PR went through 3 rounds of automated review (Greptile, Cursor Bugbot, Veria AI) before this description was last updated. Findings addressed: an all-zero trajectory being indistinguishable from no tool-call history, trajectory signals missing from the plan-mode short-circuit, the non-plugin classifier-fallback path, session-pin replay, and the no-ask default-fallback path, plus an unbounded tool-result scan ahead of the configured window, and unbounded retention of caller-supplied tool arguments in the comparison signatures.
- The four fractions are unweighted counts over the configured window rather than recency-weighted; a future routing feature built on this data may want to weight them, but nothing here should bake in a weighting scheme before we have traffic to calibrate one against

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds per-request message scanning and enriches logging signals only; routing logic is explicitly not driven by trajectory values, with broad test coverage for that guarantee.
> 
> **Overview**
> Adds **observational trajectory signals** to the Complexity Router: on each classified turn it scans the assistant’s recent tool calls and appends `trajectory:<name>=<value>` entries to `routing_decision.signals` (e.g. `error_severity`, `spinning`, `exploring`, `production_intensity`, plus `observed_calls`). **Routing is unchanged**—tiers and models are not chosen from these values; they exist for logging and future calibration.
> 
> New config knobs default to on: `trajectory_signals_enabled`, `trajectory_signal_window` (default 6), and optional `trajectory_tool_intents` for custom tool names. Tool-call parsing moves into **`trajectory_signals.py`** and is shared with **`stall_detector`**, including bounded argument signatures (SHA-256 digest for huge args) and support for Anthropic Messages vs chat-completions shapes.
> 
> Trajectory strings are merged into decision records on **all** routing paths (classifier, plan mode, keyword override, stall escalation, session-pin replay, classifier fallback, and no-user-text default fallback), with non-zero fractions only emitted to keep signals short. README documents the feature; unit and integration tests assert observe-only behavior and edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11a19fabc13b6c7b9c73d72675ed3cf7e3d40b93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->





