### PR TITLE
fix: keep provider id and metadata on Responses API bridged chat completions

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -33,7 +33,7 @@ from litellm.responses.sse_output_recovery import (
     record_output_item_chunk,
     record_output_text_chunk,
 )
-from litellm.responses.utils import normalize_responses_api_stream_options
+from litellm.responses.utils import ResponsesAPIRequestUtils, normalize_responses_api_stream_options
 from litellm.types.llms.openai import (
     REASONING_EFFORT,
     ChatCompletionAnnotation,
@@ -54,7 +54,7 @@ if TYPE_CHECKING:
     )
     from pydantic import BaseModel
 
-    from litellm import LiteLLMLoggingObj, ModelResponse
+    from litellm import LiteLLMLoggingObj
     from litellm.llms.base_llm.base_model_iterator import BaseModelResponseIterator
     from litellm.types.llms.openai import (
         ALL_RESPONSES_API_TOOL_PARAMS,
@@ -67,6 +67,15 @@ if TYPE_CHECKING:
         OpenAIMessageContentListBlock,
     )
     from litellm.types.utils import Choices
+
+
+_CHAT_COMPLETION_FIELDS: Final = frozenset((*ModelResponse.model_fields, "usage"))
+
+
+def _upstream_response_id(response_id: str | None) -> str | None:
+    if response_id is None:
+        return None
+    return ResponsesAPIRequestUtils.decode_previous_response_id_to_original_previous_response_id(response_id)
 
 
 class _ReasoningSummaryText(TypedDict):
@@ -904,6 +913,12 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
             ResponseAPILoggingUtils._transform_response_api_usage_to_chat_usage(raw_response.usage),
         )
 
+        model_response.id = _upstream_response_id(raw_response.id) or raw_response.id
+        provider_extras: Final = raw_response.model_extra.items() if raw_response.model_extra else ()
+        for key, value in provider_extras:
+            if key not in _CHAT_COMPLETION_FIELDS and value is not None:
+                setattr(model_response, key, value)
+
         # Preserve hidden params from the ResponsesAPIResponse, especially the headers
         # which contain important provider information like x-request-id
         raw_response_hidden_params: Final = getattr(raw_response, "_hidden_params", {})
@@ -1359,14 +1374,16 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
         if event_type == "response.created":
             # Initial response creation event
             verbose_logger.debug("Chat provider: response.created -> %s", parsed_chunk)
+            created_response: Final = parsed_chunk.get("response")
             return ModelResponseStream(
+                id=_upstream_response_id(created_response.get("id")) if created_response else None,
                 choices=[
                     StreamingChoices(
                         index=0,
                         delta=Delta(content=""),
                         finish_reason=None,
                     )
-                ]
+                ],
             )
         elif event_type == "response.output_item.added":
             # New output item added

--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -5,8 +5,11 @@ Handler for transforming /chat/completions api requests to litellm.responses req
 import json
 import os
 from collections.abc import AsyncIterator, Callable, Iterable, Iterator, Mapping, Sequence
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Final, Literal, TypedDict, Union, cast, get_args
 
+from openai.types.chat import ChatCompletion
+from openai.types.responses import Response
 from openai.types.responses.custom_tool_param import CustomToolParam
 from openai.types.responses.response_input_param import (
     FunctionCallOutput,
@@ -43,6 +46,7 @@ from litellm.types.llms.openai import (
     ChatCompletionToolParamFunctionChunk,
     Reasoning,
     ResponsesAPIOptionalRequestParams,
+    ResponsesAPIResponse,
     ResponsesAPIStreamEvents,
 )
 from litellm.types.utils import GenericStreamingChunk, ModelResponseStream
@@ -70,6 +74,19 @@ if TYPE_CHECKING:
 
 
 _CHAT_COMPLETION_FIELDS: Final = frozenset((*ModelResponse.model_fields, "usage"))
+_RESPONSES_API_ONLY_FIELDS: Final = frozenset((*Response.model_fields, *ResponsesAPIResponse.model_fields)) - frozenset(
+    ChatCompletion.model_fields
+)
+
+
+def _provider_metadata(response_fields: Mapping[str, object] | None) -> Mapping[str, object]:
+    return MappingProxyType(
+        {
+            key: value
+            for key, value in (response_fields.items() if response_fields else ())
+            if value is not None and key not in _CHAT_COMPLETION_FIELDS and key not in _RESPONSES_API_ONLY_FIELDS
+        }
+    )
 
 
 def _upstream_response_id(response_id: str | None) -> str | None:
@@ -914,10 +931,8 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
         )
 
         model_response.id = _upstream_response_id(raw_response.id) or raw_response.id
-        provider_extras: Final = raw_response.model_extra.items() if raw_response.model_extra else ()
-        for key, value in provider_extras:
-            if key not in _CHAT_COMPLETION_FIELDS and value is not None:
-                setattr(model_response, key, value)
+        for key, value in _provider_metadata(raw_response.model_extra).items():
+            setattr(model_response, key, value)
 
         # Preserve hidden params from the ResponsesAPIResponse, especially the headers
         # which contain important provider information like x-request-id
@@ -1551,6 +1566,7 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
                 from litellm.responses.utils import ResponseAPILoggingUtils
 
                 usage = ResponseAPILoggingUtils._transform_response_api_usage_to_chat_usage(response_data.get("usage"))
+            provider_metadata: Final = _provider_metadata(response_data)
             return ModelResponseStream(
                 choices=[
                     StreamingChoices(
@@ -1563,6 +1579,7 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
                     )
                 ],
                 usage=usage,
+                provider_specific_fields=dict(provider_metadata) or None,  # mutable-ok: field is typed dict
             )
         else:
             pass

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -3918,11 +3918,12 @@ class Logging(LiteLLMLoggingBaseClass):
             LiteLLMResponsesTransformationHandler,
         )
 
+        served_id: Final = _provider_response_id(result)
         try:
-            return LiteLLMResponsesTransformationHandler().transform_response(
+            translated: Final = LiteLLMResponsesTransformationHandler().transform_response(
                 model=self.model,
                 raw_response=result,
-                model_response=litellm.ModelResponse(id=_provider_response_id(result)),
+                model_response=litellm.ModelResponse(id=served_id),
                 logging_obj=self,
                 request_data={},
                 messages=[],
@@ -3930,6 +3931,8 @@ class Logging(LiteLLMLoggingBaseClass):
                 litellm_params={},
                 encoding=litellm.encoding,
             )
+            translated.id = served_id or translated.id
+            return translated
         except Exception as e:
             verbose_logger.debug(
                 "Responses API -> ModelResponse translation failed for "
@@ -3937,7 +3940,7 @@ class Logging(LiteLLMLoggingBaseClass):
                 "usage-only ModelResponse to keep the spend_logs row.",
                 str(e),
             )
-            model_response: Final = litellm.ModelResponse(id=_provider_response_id(result))
+            model_response: Final = litellm.ModelResponse(id=served_id)
             model_response.model = self.model
             usage: Final = getattr(result, "usage", None)
             if usage is not None and ResponseAPILoggingUtils._is_response_api_usage(usage):

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -3955,8 +3955,6 @@ def test_convert_chat_completion_messages_to_responses_api_tool_result_with_tool
 
 
 def _litellm_encoded_response_id(upstream_id: str) -> str:
-    """The id a Responses API call hands back through LiteLLM: the provider's id wrapped with the
-    deployment it came from, the way ``/v1/responses`` clients see it."""
     import base64
 
     tagged = f"litellm:custom_llm_provider:azure;model_id:deployment-1;response_id:{upstream_id}"
@@ -3964,11 +3962,6 @@ def _litellm_encoded_response_id(upstream_id: str) -> str:
 
 
 def test_transform_response_keeps_upstream_id_and_provider_extras():
-    """A chat completion bridged through the Responses API must answer with the provider's own
-    response id, decoded out of the deployment-tagged id LiteLLM wraps around it, and every
-    top-level field the provider adds beyond the Responses schema (Azure's ``content_filters``,
-    ``service_tier``), the way the native chat path passes unknown top-level fields through,
-    instead of a locally minted ``chatcmpl-`` id and nothing else."""
     from unittest.mock import Mock
 
     from litellm.completion_extras.litellm_responses_transformation.transformation import (
@@ -4040,9 +4033,6 @@ def test_transform_response_keeps_upstream_id_and_provider_extras():
 
 
 def test_streaming_chunks_carry_the_upstream_response_id():
-    """Every streamed chunk of a bridged chat completion must carry the provider's response id
-    from ``response.created`` rather than a locally minted ``chatcmpl-`` id, so a client can
-    correlate the stream with the provider's request the same way the non-streaming path does."""
     from litellm.completion_extras.litellm_responses_transformation.transformation import (
         OpenAiResponsesToChatCompletionStreamIterator,
     )

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -3955,10 +3955,11 @@ def test_convert_chat_completion_messages_to_responses_api_tool_result_with_tool
 
 
 def _litellm_encoded_response_id(upstream_id: str) -> str:
-    import base64
+    from litellm.responses.utils import ResponsesAPIRequestUtils
 
-    tagged = f"litellm:custom_llm_provider:azure;model_id:deployment-1;response_id:{upstream_id}"
-    return "resp_" + base64.b64encode(tagged.encode()).decode()
+    return ResponsesAPIRequestUtils._build_responses_api_response_id(
+        custom_llm_provider="azure", model_id="deployment-1", response_id=upstream_id
+    )
 
 
 def test_transform_response_keeps_upstream_id_and_provider_extras():
@@ -3997,6 +3998,9 @@ def test_transform_response_keeps_upstream_id_and_provider_extras():
             "service_tier": "default",
             "content_filters": content_filters,
             "max_tool_calls": None,
+            "background": False,
+            "top_logprobs": 0,
+            "store": True,
         }
     )
     model_response = ModelResponse(
@@ -4029,7 +4033,61 @@ def test_transform_response_keeps_upstream_id_and_provider_extras():
     assert "output" not in dumped and "status" not in dumped, (
         "Responses schema fields must not leak into the chat response"
     )
+    assert not {"background", "top_logprobs", "store"} & dumped.keys(), (
+        "Responses API bookkeeping must not ride along as chat metadata"
+    )
     assert dumped["choices"][0]["message"]["tool_calls"][0]["function"]["name"] == "lookup_weather"
+
+
+def test_bridged_response_is_priced_by_the_reported_service_tier():
+    from unittest.mock import Mock
+
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        LiteLLMResponsesTransformationHandler,
+    )
+    from litellm.types.llms.openai import ResponsesAPIResponse
+    from litellm.types.utils import ModelResponse
+
+    raw_response = ResponsesAPIResponse.model_validate(
+        {
+            "id": "resp_flex",
+            "created_at": 1734366691,
+            "object": "response",
+            "model": "gpt-5.4",
+            "status": "completed",
+            "output": [
+                {
+                    "type": "message",
+                    "id": "msg_1",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": "hi", "annotations": []}],
+                }
+            ],
+            "usage": {"input_tokens": 1000, "output_tokens": 100, "total_tokens": 1100},
+            "service_tier": "flex",
+        }
+    )
+
+    result = LiteLLMResponsesTransformationHandler().transform_response(
+        model="gpt-5.4",
+        raw_response=raw_response,
+        model_response=ModelResponse(),
+        logging_obj=Mock(),
+        request_data={"model": "gpt-5.4"},
+        messages=[{"role": "user", "content": "hi"}],
+        optional_params={},
+        litellm_params={},
+        encoding=Mock(),
+    )
+    pricing = litellm.model_cost["gpt-5.4"]
+    flex_cost = 1000 * pricing["input_cost_per_token_flex"] + 100 * pricing["output_cost_per_token_flex"]
+    standard_cost = 1000 * pricing["input_cost_per_token"] + 100 * pricing["output_cost_per_token"]
+
+    cost = litellm.completion_cost(completion_response=result, custom_llm_provider="openai")
+
+    assert cost == pytest.approx(flex_cost)
+    assert cost < standard_cost
 
 
 def test_streaming_chunks_carry_the_upstream_response_id():
@@ -4048,3 +4106,44 @@ def test_streaming_chunks_carry_the_upstream_response_id():
     ids = [iterator.chunk_parser(event).id for event in events]
 
     assert ids == ["resp_azure_stream"] * len(events), f"streamed chunks did not carry the upstream id: {ids}"
+
+
+def test_streaming_final_chunk_carries_provider_metadata():
+    from unittest.mock import MagicMock
+
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        OpenAiResponsesToChatCompletionStreamIterator,
+    )
+    from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
+
+    iterator = OpenAiResponsesToChatCompletionStreamIterator(streaming_response=None, sync_stream=True)
+    content_filters = [{"blocked": False, "source_type": "completion", "content_filter_results": {}}]
+    events = [
+        {"type": "response.created", "response": {"id": "resp_azure_stream", "output": []}},
+        {"type": "response.output_text.delta", "delta": "Hello"},
+        {
+            "type": "response.completed",
+            "response": {
+                "id": "resp_azure_stream",
+                "output": [{"type": "message"}],
+                "usage": {"input_tokens": 3, "output_tokens": 1, "total_tokens": 4},
+                "service_tier": "default",
+                "content_filters": content_filters,
+                "background": False,
+            },
+        },
+    ]
+    stream = CustomStreamWrapper(
+        completion_stream=iter([iterator.chunk_parser(event) for event in events]),
+        model="gpt-5.6",
+        custom_llm_provider="azure",
+        logging_obj=MagicMock(),
+    )
+
+    chunks = [chunk.model_dump() for chunk in stream]
+
+    assert chunks[-1]["choices"][0]["finish_reason"] == "stop"
+    assert chunks[-1]["service_tier"] == "default"
+    assert chunks[-1]["content_filters"] == content_filters
+    assert "background" not in chunks[-1]
+    assert all("service_tier" not in chunk for chunk in chunks[:-1])

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -3952,3 +3952,109 @@ def test_convert_chat_completion_messages_to_responses_api_tool_result_with_tool
 
     function_call_output = next(item for item in response if item.get("type") == "function_call_output")
     assert function_call_output["output"] == [{"type": "input_text", "text": "1 tool found"}]
+
+
+def _litellm_encoded_response_id(upstream_id: str) -> str:
+    """The id a Responses API call hands back through LiteLLM: the provider's id wrapped with the
+    deployment it came from, the way ``/v1/responses`` clients see it."""
+    import base64
+
+    tagged = f"litellm:custom_llm_provider:azure;model_id:deployment-1;response_id:{upstream_id}"
+    return "resp_" + base64.b64encode(tagged.encode()).decode()
+
+
+def test_transform_response_keeps_upstream_id_and_provider_extras():
+    """A chat completion bridged through the Responses API must answer with the provider's own
+    response id, decoded out of the deployment-tagged id LiteLLM wraps around it, and every
+    top-level field the provider adds beyond the Responses schema (Azure's ``content_filters``,
+    ``service_tier``), the way the native chat path passes unknown top-level fields through,
+    instead of a locally minted ``chatcmpl-`` id and nothing else."""
+    from unittest.mock import Mock
+
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        LiteLLMResponsesTransformationHandler,
+    )
+    from litellm.types.llms.openai import ResponsesAPIResponse
+    from litellm.types.utils import ModelResponse, Usage
+
+    content_filters = [
+        {"blocked": False, "source_type": "prompt", "content_filter_results": {"hate": {"filtered": False}}}
+    ]
+    raw_response = ResponsesAPIResponse.model_validate(
+        {
+            "id": _litellm_encoded_response_id("resp_azure_123"),
+            "created_at": 1734366691,
+            "object": "response",
+            "model": "gpt-5.6",
+            "status": "completed",
+            "output": [
+                {
+                    "type": "function_call",
+                    "id": "fc_1",
+                    "call_id": "call_1",
+                    "name": "lookup_weather",
+                    "arguments": '{"city": "Seattle"}',
+                    "status": "completed",
+                }
+            ],
+            "parallel_tool_calls": True,
+            "tool_choice": "auto",
+            "tools": [],
+            "usage": {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+            "service_tier": "default",
+            "content_filters": content_filters,
+            "max_tool_calls": None,
+        }
+    )
+    model_response = ModelResponse(
+        id="chatcmpl-local",
+        created=1734366691,
+        model=None,
+        object="chat.completion",
+        choices=[],
+        usage=Usage(completion_tokens=0, prompt_tokens=0, total_tokens=0),
+    )
+
+    result = LiteLLMResponsesTransformationHandler().transform_response(
+        model="gpt-5.6",
+        raw_response=raw_response,
+        model_response=model_response,
+        logging_obj=Mock(),
+        request_data={"model": "gpt-5.6"},
+        messages=[{"role": "user", "content": "What is the weather in Seattle?"}],
+        optional_params={},
+        litellm_params={},
+        encoding=Mock(),
+    )
+    dumped = result.model_dump()
+
+    assert dumped["id"] == "resp_azure_123"
+    assert dumped["object"] == "chat.completion"
+    assert dumped["service_tier"] == "default"
+    assert dumped["content_filters"] == content_filters
+    assert "max_tool_calls" not in dumped, "a null provider field must not appear as a null top-level key"
+    assert "output" not in dumped and "status" not in dumped, (
+        "Responses schema fields must not leak into the chat response"
+    )
+    assert dumped["choices"][0]["message"]["tool_calls"][0]["function"]["name"] == "lookup_weather"
+
+
+def test_streaming_chunks_carry_the_upstream_response_id():
+    """Every streamed chunk of a bridged chat completion must carry the provider's response id
+    from ``response.created`` rather than a locally minted ``chatcmpl-`` id, so a client can
+    correlate the stream with the provider's request the same way the non-streaming path does."""
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        OpenAiResponsesToChatCompletionStreamIterator,
+    )
+
+    iterator = OpenAiResponsesToChatCompletionStreamIterator(streaming_response=None, sync_stream=True)
+    encoded_id = _litellm_encoded_response_id("resp_azure_stream")
+    events = [
+        {"type": "response.created", "response": {"id": encoded_id, "output": []}},
+        {"type": "response.output_text.delta", "delta": "Hel"},
+        {"type": "response.completed", "response": {"id": encoded_id, "output": [{"type": "message"}]}},
+    ]
+
+    ids = [iterator.chunk_parser(event).id for event in events]
+
+    assert ids == ["resp_azure_stream"] * len(events), f"streamed chunks did not carry the upstream id: {ids}"

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -4391,6 +4391,39 @@ def test_handle_anthropic_messages_response_logging_translates_bare_responses_ap
     assert result.usage.total_tokens == 18  # type: ignore[attr-defined]
 
 
+def test_handle_anthropic_messages_response_logging_keeps_the_served_response_id():
+    from openai.types.responses import ResponseOutputMessage, ResponseOutputText
+
+    from litellm.responses.utils import ResponsesAPIRequestUtils
+    from litellm.types.llms.openai import ResponseAPIUsage, ResponsesAPIResponse
+
+    served_id = ResponsesAPIRequestUtils._build_responses_api_response_id(
+        custom_llm_provider="openai", model_id="deployment-1", response_id="resp_upstream"
+    )
+    logging_obj = _anthropic_messages_logging_obj()
+    result = logging_obj._handle_anthropic_messages_response_logging(
+        result=ResponsesAPIResponse(
+            id=served_id,
+            created_at=1700000000,
+            output=[
+                ResponseOutputMessage(
+                    id="msg-1",
+                    type="message",
+                    role="assistant",
+                    status="completed",
+                    content=[ResponseOutputText(annotations=[], text="hi", type="output_text")],
+                )
+            ],
+            usage=ResponseAPIUsage(input_tokens=2, output_tokens=1, total_tokens=3),
+            service_tier="flex",
+        )
+    )
+
+    assert isinstance(result, ModelResponse)
+    assert result.id == served_id, "the spend log row must keep the id the caller was served"
+    assert result.service_tier == "flex"
+
+
 def test_handle_anthropic_messages_response_logging_passes_model_response_through():
     """Anthropic-native path already yields a ModelResponse; it must be returned unchanged."""
     logging_obj = _anthropic_messages_logging_obj()


### PR DESCRIPTION
## TLDR

Problem this solves:

- Chat completions bridged through the Responses API answer with a made-up `chatcmpl-<uuid>` id
- Azure's `service_tier` and `content_filters` never reach the chat completion, streamed or not
- Since v1.97.0 every Azure gpt-5.4+ chat request with function tools rides that bridge

How it solves it:

- The chat completion carries the provider's own `resp_...` id, decoded from the deployment-tagged one
- Provider fields the Responses API schema doesn't declare, like `service_tier` and Azure's `content_filters`, pass through top-level the way the native chat path does; Responses bookkeeping (`background`, `store`, `top_logprobs`, ...) stays out
- Streamed chunks carry that same id from the first `response.created` event, and the last chunk carries the same provider fields
- Spend rows for `/v1/messages` calls served through the Responses adapter keep the id the client was handed, and a bridged response reporting `flex` or `priority` is priced at that tier like native chat

## User Flow

Before: a developer sending an Azure gpt-5.x chat completion with function tools gets a locally minted id and none of Azure's response metadata, so content-filter auditing and correlating with Azure's logs are impossible

1. They send POST https://litellm-domain/v1/chat/completions with `"model": "azure-gpt-5.6-luna"`, a user message, and a `lookup_weather` function tool
2. The 200 response has `"id": "chatcmpl-35bf2104-..."`, an id Azure never issued, and only `choices`, `created`, `id`, `model`, `object`, `usage` at the top level
3. `service_tier` and `content_filters` are missing, so there is nothing to audit and no id to look up on the Azure side
4. The same request with `"stream": true` streams every chunk under another `chatcmpl-...` id, and the last chunk has no `service_tier` or `content_filters` either
5. POST https://litellm-domain/v1/messages with the same tool answers with a `chatcmpl-...` id too

After: the same request answers with Azure's own response id and Azure's metadata alongside the chat completion

1. They send the same POST https://litellm-domain/v1/chat/completions with the function tool
2. The 200 response has `"id": "resp_0483ecdd..."`, the id Azure issued, plus `"service_tier": "default"` and the `content_filters` array
3. They look up that `resp_...` id on the Azure side and audit `content_filters` per request
4. The same request with `"stream": true` streams every chunk under that same `resp_...` id, and the last chunk carries `service_tier` and `content_filters`
5. POST https://litellm-domain/v1/messages with the same tool answers with Azure's `resp_...` id too

## Relevant issues

## Linear ticket

Resolves LIT-7079

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both legs ran the same config against a real Azure Foundry `gpt-5.6-luna` deployment and OpenAI's `gpt-5.3-codex` (a `mode: responses` model, so its chat completions take the same bridge), each proxy booted with `--num_workers 2` from its own worktree with `DATABASE_URL` set so the spend-log lookups at the end run for real (Before at the merge base on port 48788, After at the tip on port 44325), no mocks

```yaml
model_list:
  - model_name: azure-gpt-5.6-luna
    litellm_params:
      model: azure/gpt-5.6-luna
      api_base: os.environ/AZURE_API_BASE
      api_key: os.environ/AZURE_API_KEY
      api_version: "2025-03-01-preview"
  - model_name: openai-gpt-5.3-codex
    litellm_params:
      model: openai/gpt-5.3-codex
      api_key: os.environ/OPENAI_API_KEY
general_settings:
  master_key: os.environ/LITELLM_MASTER_KEY
```

The same nine requests ran on each leg, then every id the client received was looked up in the spend logs once the batch write landed

```bash
python litellm/proxy/proxy_cli.py --config config.yaml --port "${PORT}" --num_workers 2
AUTH=(-H "Authorization: Bearer sk-lit7079" -H "Content-Type: application/json")
TOOL='{"type": "function", "function": {"name": "lookup_weather", "description": "Get weather for a city", "parameters": {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}}}'
ATOOL='{"name": "lookup_weather", "description": "Get weather for a city", "input_schema": {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}}'
Q='What is the weather in Seattle?'
for MODEL in azure-gpt-5.6-luna openai-gpt-5.3-codex; do
  curl -s "http://localhost:${PORT}/v1/chat/completions" "${AUTH[@]}" -d '{"model": "'"${MODEL}"'", "messages": [{"role": "user", "content": "'"${Q}"'"}], "tools": ['"${TOOL}"']}' \
    | jq '{id, object, service_tier, content_filters, tool: .choices[0].message.tool_calls[0].function.name, top_level_keys: (keys | sort)}'
  curl -sN "http://localhost:${PORT}/v1/chat/completions" "${AUTH[@]}" -d '{"model": "'"${MODEL}"'", "messages": [{"role": "user", "content": "'"${Q}"'"}], "tools": ['"${TOOL}"'], "stream": true}' \
    | grep '^data: {' | sed 's/^data: //' | jq -s '{chunk_count: length, distinct_ids: (map(.id) | unique), finish_reasons: (map(.choices[0].finish_reason) | map(select(. != null))), last_chunk: (last | {service_tier, content_filters, top_level_keys: (keys | sort)})}'
  curl -s "http://localhost:${PORT}/v1/messages" "${AUTH[@]}" -d '{"model": "'"${MODEL}"'", "max_tokens": 512, "messages": [{"role": "user", "content": "'"${Q}"'"}], "tools": ['"${ATOOL}"']}' \
    | jq '{id, type, stop_reason, tool: (.content | map(select(.type == "tool_use")) | .[0].name)}'
  curl -sN "http://localhost:${PORT}/v1/messages" "${AUTH[@]}" -d '{"model": "'"${MODEL}"'", "max_tokens": 512, "messages": [{"role": "user", "content": "'"${Q}"'"}], "tools": ['"${ATOOL}"'], "stream": true}' \
    | grep '^data: {' | sed 's/^data: //' | jq -s '{event_count: length, message_start_id: (map(select(.type == "message_start")) | .[0].message.id), stop_reason: (map(select(.type == "message_delta")) | last | .delta.stop_reason)}'
done
curl -s "http://localhost:${PORT}/v1/responses" "${AUTH[@]}" -d '{"model": "azure-gpt-5.6-luna", "input": "'"${Q}"'", "tools": [{"type": "function", "name": "lookup_weather", "description": "Get weather for a city", "parameters": {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}}]}' \
  | jq '{id, object, service_tier, content_filters_present: has("content_filters"), tool: (.output | map(select(.type == "function_call")) | .[0].name)}'
sleep 30
lookup() { curl -sG "http://localhost:${PORT}/spend/logs" --data-urlencode "request_id=$1" "${AUTH[@]}" | jq -c 'map({request_id, call_type, model})'; }
```

`reasoning_effort` is left unset in every request, so the Azure gpt-5.x plus function tools combination takes the Responses API bridge. The same request sent straight to Azure's Responses API returns `service_tier` and `content_filters` but no `prompt_filter_results`, `routing`, or `system_fingerprint`, so none of those three shows up on the bridged path here. `prompt_filter_results` and `routing` would pass through if a provider did send them, and `system_fingerprint` would not, since the passthrough skips every field `ModelResponse` already declares

### Before (b1e2f5bc)

#### chat completions on azure-gpt-5.6-luna, non-streaming: a locally minted `chatcmpl-` id, no `service_tier`, no `content_filters`

```json
{
  "id": "chatcmpl-35bf2104-7d1d-490a-8bed-590e56923b09",
  "object": "chat.completion",
  "service_tier": null,
  "content_filters": null,
  "tool": "lookup_weather",
  "top_level_keys": ["choices", "created", "id", "model", "object", "usage"]
}
```

#### chat completions on azure-gpt-5.6-luna, streaming: every chunk under a `chatcmpl-` id, nothing from Azure on the last chunk

```json
{
  "chunk_count": 7,
  "distinct_ids": ["chatcmpl-380ebf0b-cfc8-4266-a422-d915fe17b939"],
  "finish_reasons": ["tool_calls"],
  "last_chunk": {
    "service_tier": null,
    "content_filters": null,
    "top_level_keys": ["choices", "created", "id", "model", "object"]
  }
}
```

#### messages on azure-gpt-5.6-luna: a `chatcmpl-` id non-streaming, a `msg_` id streaming

```json
{"id": "chatcmpl-d4123ce6-225b-4ec9-9fae-f3142f377071", "type": "message", "stop_reason": "tool_use", "tool": "lookup_weather"}
{"event_count": 10, "message_start_id": "msg_3d905d5a-a439-4d58-aa74-949458d6c71a", "stop_reason": "tool_use"}
```

#### chat completions on openai-gpt-5.3-codex, non-streaming: same minted id, no `service_tier`

```json
{
  "id": "chatcmpl-d731d160-4cbb-4e3f-b0d2-ac7adcee68dc",
  "object": "chat.completion",
  "service_tier": null,
  "content_filters": null,
  "tool": "lookup_weather",
  "top_level_keys": ["choices", "created", "id", "model", "object", "usage"]
}
```

#### chat completions on openai-gpt-5.3-codex, streaming

```json
{
  "chunk_count": 7,
  "distinct_ids": ["chatcmpl-2390706c-6985-4d1d-ba7c-670b11d30124"],
  "finish_reasons": ["tool_calls"],
  "last_chunk": {
    "service_tier": null,
    "content_filters": null,
    "top_level_keys": ["choices", "created", "id", "model", "object"]
  }
}
```

#### messages on openai-gpt-5.3-codex (Responses adapter, not the chat bridge): LiteLLM's encoded id non-streaming, a `msg_` id streaming

```json
{"id": "resp_bGl0ZWxsbTpjdXN0b21fbGxtX3Byb3ZpZGVyOm9wZW5haTttb2RlbF9pZDozZTg0...", "type": "message", "stop_reason": "tool_use", "tool": "lookup_weather"}
{"event_count": 10, "message_start_id": "msg_16449330-9cd5-4d1c-be60-d5f9df6b7304", "stop_reason": "tool_use"}
```

#### responses on azure-gpt-5.6-luna (not bridged): already fine

```json
{"id": "resp_5niWBH9PXmCuHhZZ_JGMak04o5bgWUVKomCxOz0kyBv_ah4W...", "object": "response", "service_tier": "default", "content_filters_present": true, "tool": "lookup_weather"}
```

#### spend logs, looked up by the id each client received: no bridged call is findable, only the Responses-adapter `/v1/messages` rows and `/v1/responses` match

```text
chat azure-gpt-5.6-luna              chatcmpl-35bf2104-...   []
chat stream azure-gpt-5.6-luna       chatcmpl-380ebf0b-...   []
messages azure-gpt-5.6-luna          chatcmpl-d4123ce6-...   []
messages stream azure-gpt-5.6-luna   msg_3d905d5a-...        []
chat openai-gpt-5.3-codex            chatcmpl-d731d160-...   []
chat stream openai-gpt-5.3-codex     chatcmpl-2390706c-...   []
messages openai-gpt-5.3-codex        resp_bGl0ZWxsbTpj...    [{"request_id":"resp_bGl0ZWxsbTpj...","call_type":"anthropic_messages","model":"openai/gpt-5.3-codex"}]
messages stream openai-gpt-5.3-codex msg_16449330-...        [{"request_id":"msg_16449330-...","call_type":"anthropic_messages","model":"openai/gpt-5.3-codex"}]
responses azure-gpt-5.6-luna         resp_5niWBH9PXmCu...    [{"request_id":"resp_5niWBH9PXmCu...","call_type":"aresponses","model":"azure/gpt-5.6-luna"}]
```

### After (64cbe6d0)

#### chat completions on azure-gpt-5.6-luna, non-streaming: Azure's own `resp_` id, `service_tier`, `content_filters`, no Responses bookkeeping

```json
{
  "id": "resp_0483ecddc4893ecc006a9ccc2360f8819785dbeec693d62645",
  "object": "chat.completion",
  "service_tier": "default",
  "content_filters": [
    {
      "blocked": false,
      "source_type": "prompt",
      "content_filter_raw": [],
      "content_filter_results": {},
      "content_filter_offsets": {"start_offset": 0, "end_offset": 64, "check_offset": 0}
    }
  ],
  "tool": "lookup_weather",
  "top_level_keys": [
    "choices", "content_filters", "created", "frequency_penalty", "id", "model", "object",
    "presence_penalty", "service_tier", "tool_usage", "usage"
  ]
}
```

#### chat completions on azure-gpt-5.6-luna, streaming: every chunk under Azure's `resp_` id, the last chunk carries `service_tier` and `content_filters`

```json
{
  "chunk_count": 7,
  "distinct_ids": ["resp_026e61e79b3495ae006a9ccc25131c81938c86d6bbc014963f"],
  "finish_reasons": ["tool_calls"],
  "last_chunk": {
    "service_tier": "default",
    "content_filters": [
      {
        "blocked": false,
        "source_type": "prompt",
        "content_filter_raw": [],
        "content_filter_results": {},
        "content_filter_offsets": {"start_offset": 0, "end_offset": 64, "check_offset": 0}
      }
    ],
    "top_level_keys": [
      "choices", "content_filters", "created", "frequency_penalty", "id", "model", "object",
      "presence_penalty", "provider_specific_fields", "service_tier", "tool_usage"
    ]
  }
}
```

#### messages on azure-gpt-5.6-luna: Azure's `resp_` id non-streaming, streaming unchanged

```json
{"id": "resp_0da5f404441a6e0d006a9ccc264ae08195a9225c4af83cc4c3", "type": "message", "stop_reason": "tool_use", "tool": "lookup_weather"}
{"event_count": 10, "message_start_id": "msg_e5e8ef44-1409-4450-b309-7352c794ec3d", "stop_reason": "tool_use"}
```

#### chat completions on openai-gpt-5.3-codex, non-streaming: OpenAI's own `resp_` id and `service_tier`, no `content_filters` because OpenAI sends none

```json
{
  "id": "resp_0dceac5d7b5a2443006a9ccc2919a487d0b3e72cb33d074582",
  "object": "chat.completion",
  "service_tier": "default",
  "content_filters": null,
  "tool": "lookup_weather",
  "top_level_keys": [
    "billing", "choices", "created", "frequency_penalty", "id", "model", "object",
    "presence_penalty", "service_tier", "tool_usage", "usage"
  ]
}
```

#### chat completions on openai-gpt-5.3-codex, streaming

```json
{
  "chunk_count": 7,
  "distinct_ids": ["resp_02bcddc70bd838b8006a9ccc2a12c887d0aabbba64e232f8ff"],
  "finish_reasons": ["tool_calls"],
  "last_chunk": {
    "service_tier": "default",
    "content_filters": null,
    "top_level_keys": [
      "choices", "created", "frequency_penalty", "id", "model", "object",
      "presence_penalty", "provider_specific_fields", "service_tier", "tool_usage"
    ]
  }
}
```

#### messages on openai-gpt-5.3-codex (Responses adapter): unchanged, the client still gets the encoded id

```json
{"id": "resp_bGl0ZWxsbTpjdXN0b21fbGxtX3Byb3ZpZGVyOm9wZW5haTttb2RlbF9pZDozZTg0...", "type": "message", "stop_reason": "tool_use", "tool": "lookup_weather"}
{"event_count": 10, "message_start_id": "msg_8b3f798b-4f62-4ced-8bc9-75815b8665bc", "stop_reason": "tool_use"}
```

#### responses on azure-gpt-5.6-luna (not bridged): unchanged

```json
{"id": "resp_UgpAE0XMm87cdvqPySP3qSZC6kItUH72-8IbM5MOMYDqt8qf...", "object": "response", "service_tier": "default", "content_filters_present": true, "tool": "lookup_weather"}
```

#### spend logs, looked up by the id each client received: the Responses-adapter `/v1/messages` rows still match the served id, so nothing drifted; bridged calls are still not findable by the client id (see Caveats)

```text
chat azure-gpt-5.6-luna              resp_0483ecddc489...    []
chat stream azure-gpt-5.6-luna       resp_026e61e79b34...    []
messages azure-gpt-5.6-luna          resp_0da5f404441a...    []
messages stream azure-gpt-5.6-luna   msg_e5e8ef44-...        []
chat openai-gpt-5.3-codex            resp_0dceac5d7b5a...    []
chat stream openai-gpt-5.3-codex     resp_02bcddc70bd8...    []
messages openai-gpt-5.3-codex        resp_bGl0ZWxsbTpj...    [{"request_id":"resp_bGl0ZWxsbTpj...","call_type":"anthropic_messages","model":"openai/gpt-5.3-codex"}]
messages stream openai-gpt-5.3-codex msg_8b3f798b-...        [{"request_id":"msg_8b3f798b-...","call_type":"anthropic_messages","model":"openai/gpt-5.3-codex"}]
responses azure-gpt-5.6-luna         resp_UgpAE0XMm87c...    [{"request_id":"resp_UgpAE0XMm87c...","call_type":"aresponses","model":"azure/gpt-5.6-luna"}]
```

The bridged rows do exist. Reading them straight from `LiteLLM_SpendLogs` and base64-decoding their `request_id` shows each one is LiteLLM's encoded wrapper (`litellm:custom_llm_provider:...;response_id:<raw id>`) around the very id the client received on the After leg, while on the Before leg the wrapped ids matched nothing the client ever saw

```text
02:22:18  responses  azure/gpt-5.6-luna    resp_bGl0ZWxsbTpj...  embeds=resp_04a7687477503d98006a9cce5ab76081978b594f73f241534f   (Before, client got chatcmpl-35bf2104-...)
02:22:19  responses  azure/gpt-5.6-luna    resp_bGl0ZWxsbTpj...  embeds=resp_0b0a59b01f8dffba006a9cce5c2f2c8190b3eed2e6e1f97031   (Before, client got chatcmpl-380ebf0b-...)
02:12:50  responses  azure/gpt-5.6-luna    resp_bGl0ZWxsbTpj...  embeds=resp_0483ecddc4893ecc006a9ccc2360f8819785dbeec693d62645   (After, client got that id)
02:12:52  responses  azure/gpt-5.6-luna    resp_bGl0ZWxsbTpj...  embeds=resp_026e61e79b3495ae006a9ccc25131c81938c86d6bbc014963f   (After, client got that id)
02:12:56  responses  openai/gpt-5.3-codex  resp_bGl0ZWxsbTpj...  embeds=resp_0dceac5d7b5a2443006a9ccc2919a487d0b3e72cb33d074582   (After, client got that id)
```

## Type

🐛 Bug Fix

## Caveats (if any)

### Low
- Raw ids lose the deployment tag when reused as `previous_response_id`
  - A `/v1/responses` follow-up pins its deployment by decoding `model_id` from the id. A chat client that feeds the raw `resp_` id back gets whichever deployment routing picks, which can 404 on a multi-deployment Azure model with `store` on. The ticket asked for the raw id, and chat clients got `chatcmpl-` ids before, so nothing regresses
- Spend rows for bridged chat calls are still keyed by LiteLLM's encoded wrapper of the id, with `call_type: responses`
  - Pre-existing: the inner Responses call writes the row, so `/spend/logs?request_id=<client id>` returns `[]` on both legs above. At the merge base the wrapper embedded an id the client never saw; at the tip it embeds the exact id the client received. Keying those rows by the served id is a follow-up
- Four fields the pinned openai SDK (2.33.0) does not declare on `Response` still pass through: `billing`, `tool_usage`, `frequency_penalty`, `presence_penalty`
  - The passthrough drops whatever the SDK's `Response` schema declares, so they disappear on their own once the SDK catches up. Declaring them on LiteLLM's `ResponsesAPIResponse` instead would make `/v1/responses` dump them as `null` when absent
- `system_fingerprint` cannot come through the passthrough even from a provider that does send it
  - The filter skips every `ModelResponse` field so the transformer's own values survive, and `system_fingerprint` is one of those fields. No provider in `litellm/llms/` puts it on a Responses payload today, so nothing is lost right now. Letting the unset ones through means narrowing the exclusion list to the fields the bridge actually fills
- Streaming bridged calls are still priced at the base tier
  - `stream_chunk_builder` reads provider fields only from each chunk's `_hidden_params`, so the `provider_specific_fields` on the final chunk never reaches the rebuilt response. A flex-tier `gpt-5` call comes out at 0.00112500 non-streaming and 0.00225000 streaming. That gap is pre-existing and repo-wide, so streaming prices exactly as it did before this PR
- A provider key named after a `BaseModel` method would shadow that method on the response object
  - `setattr` on the response object is how `convert_dict_to_response` already carries unknown provider keys on the direct chat path, so the bridge follows the same convention. A payload with a top-level `json` or `copy` key breaks serialization on both paths, and no provider sends one

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 64cbe6d0 passes /live-pr-risk
