### PR TITLE
refactor(native): establish send-once authorization boundary

### DIFF
--- a/litellm-rust/crates/core/src/auth/mod.rs
+++ b/litellm-rust/crates/core/src/auth/mod.rs
@@ -1,0 +1,437 @@
+use std::collections::HashSet;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
+
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
+use reqwest::{Client, Method, StatusCode, Url};
+use serde_json::Value;
+use tokio::sync::Notify;
+
+use crate::Error;
+
+pub type OperationFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T, Error>> + Send + 'a>>;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OutboundOperationKind {
+    Request,
+    Upload,
+    Submission,
+    Poll,
+}
+
+#[derive(Clone, Default)]
+pub struct OperationCancellation {
+    state: Arc<CancellationState>,
+}
+
+#[derive(Default)]
+struct CancellationState {
+    cancelled: AtomicBool,
+    notify: Notify,
+}
+
+impl OperationCancellation {
+    pub fn cancel(&self) {
+        self.state.cancelled.store(true, Ordering::Release);
+        self.state.notify.notify_waiters();
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        self.state.cancelled.load(Ordering::Acquire)
+    }
+
+    async fn cancelled(&self) {
+        let notified = self.state.notify.notified();
+        if self.is_cancelled() {
+            return;
+        }
+        notified.await;
+    }
+}
+
+#[derive(Clone)]
+pub struct OperationControl {
+    pub deadline: Instant,
+    pub cancellation: OperationCancellation,
+}
+
+impl OperationControl {
+    pub fn with_timeout(timeout: Duration) -> Self {
+        Self {
+            deadline: Instant::now() + timeout,
+            cancellation: OperationCancellation::default(),
+        }
+    }
+
+    async fn run<T>(&self, work: impl Future<Output = Result<T, Error>>) -> Result<T, Error> {
+        if self.cancellation.is_cancelled() {
+            return Err(cancelled_error());
+        }
+        if self.deadline <= Instant::now() {
+            return Err(deadline_error());
+        }
+        tokio::select! {
+            biased;
+            _ = self.cancellation.cancelled() => Err(cancelled_error()),
+            result = tokio::time::timeout_at(self.deadline.into(), work) => {
+                result.map_err(|_| deadline_error())?
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum OutboundBody {
+    Bodyless,
+    JsonObject(serde_json::Map<String, Value>),
+}
+
+#[derive(Clone, Debug)]
+pub enum BodyDecision {
+    Unchanged,
+    Replace(Value),
+    Reject(String),
+}
+
+pub struct OutboundOperation {
+    pub method: Method,
+    pub url: Url,
+    pub headers: HeaderMap,
+    pub body: OutboundBody,
+    pub operation: OutboundOperationKind,
+}
+
+#[derive(Clone, Debug)]
+pub struct OutboundRequestView {
+    pub method: Method,
+    pub url: Url,
+    pub headers: HeaderMap,
+    pub body: OutboundBody,
+}
+
+#[derive(Debug)]
+pub struct OutboundResponse {
+    pub status: StatusCode,
+    pub headers: HeaderMap,
+    pub body: Vec<u8>,
+}
+
+pub struct AuthorizationInput<'a> {
+    pub method: &'a Method,
+    pub url: &'a Url,
+    pub headers: &'a HeaderMap,
+    pub body: Option<&'a [u8]>,
+}
+
+#[derive(Default)]
+pub struct AuthorizationMutation {
+    pub set_headers: Vec<(HeaderName, HeaderValue)>,
+    pub remove_headers: Vec<HeaderName>,
+}
+
+pub trait RequestAuthorizer: Send + Sync {
+    fn declared_headers(&self) -> &[HeaderName];
+    fn authorize<'a>(
+        &'a self,
+        input: AuthorizationInput<'a>,
+    ) -> OperationFuture<'a, AuthorizationMutation>;
+}
+
+pub trait AuthorizationProvider: Send + Sync {
+    fn prepare(&self) -> OperationFuture<'_, AuthorizationPreparation>;
+}
+
+pub struct AuthorizationPreparation {
+    pub authorizer: Arc<dyn RequestAuthorizer>,
+    pub visible_headers: HeaderMap,
+    pub remove_headers: Vec<HeaderName>,
+}
+
+pub struct FixedAuthorization {
+    authorizer: Arc<dyn RequestAuthorizer>,
+    visible_headers: HeaderMap,
+    remove_headers: Vec<HeaderName>,
+}
+
+impl FixedAuthorization {
+    pub fn new(authorizer: Arc<dyn RequestAuthorizer>) -> Self {
+        Self {
+            authorizer,
+            visible_headers: HeaderMap::new(),
+            remove_headers: Vec::new(),
+        }
+    }
+
+    pub fn with_prepared_headers(
+        authorizer: Arc<dyn RequestAuthorizer>,
+        visible_headers: HeaderMap,
+        remove_headers: Vec<HeaderName>,
+    ) -> Self {
+        Self {
+            authorizer,
+            visible_headers,
+            remove_headers,
+        }
+    }
+}
+
+impl AuthorizationProvider for FixedAuthorization {
+    fn prepare(&self) -> OperationFuture<'_, AuthorizationPreparation> {
+        Box::pin(async move {
+            Ok(AuthorizationPreparation {
+                authorizer: self.authorizer.clone(),
+                visible_headers: self.visible_headers.clone(),
+                remove_headers: self.remove_headers.clone(),
+            })
+        })
+    }
+}
+
+pub struct NoAuthorization;
+
+impl AuthorizationProvider for NoAuthorization {
+    fn prepare(&self) -> OperationFuture<'_, AuthorizationPreparation> {
+        Box::pin(async {
+            Ok(AuthorizationPreparation {
+                authorizer: Arc::new(NoAuthorization),
+                visible_headers: HeaderMap::new(),
+                remove_headers: Vec::new(),
+            })
+        })
+    }
+}
+
+impl RequestAuthorizer for NoAuthorization {
+    fn declared_headers(&self) -> &[HeaderName] {
+        &[]
+    }
+
+    fn authorize<'a>(
+        &'a self,
+        _: AuthorizationInput<'a>,
+    ) -> OperationFuture<'a, AuthorizationMutation> {
+        Box::pin(async { Ok(AuthorizationMutation::default()) })
+    }
+}
+
+struct ValidatedRequest {
+    method: Method,
+    url: Url,
+    headers: HeaderMap,
+    body: Option<Vec<u8>>,
+}
+
+struct AuthorizedRequest(reqwest::Request);
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct Origin {
+    scheme: String,
+    host: String,
+    port: u16,
+}
+
+impl Origin {
+    fn parse(url: &Url) -> Result<Self, Error> {
+        if !matches!(url.scheme(), "http" | "https")
+            || !url.username().is_empty()
+            || url.password().is_some()
+        {
+            return Err(destination_error());
+        }
+        Ok(Self {
+            scheme: url.scheme().to_owned(),
+            host: url.host_str().ok_or_else(destination_error)?.to_owned(),
+            port: url.port_or_known_default().ok_or_else(destination_error)?,
+        })
+    }
+}
+
+pub async fn send_once<Callback, CallbackFuture>(
+    client: &Client,
+    origin: &Url,
+    request: OutboundOperation,
+    callback: Callback,
+    authorization: &dyn AuthorizationProvider,
+    control: &OperationControl,
+) -> Result<OutboundResponse, Error>
+where
+    Callback: FnOnce(OutboundRequestView) -> CallbackFuture,
+    CallbackFuture: Future<Output = Result<BodyDecision, Error>>,
+{
+    validate_destination(origin, &request)?;
+    let decision = control
+        .run(callback(OutboundRequestView {
+            method: request.method.clone(),
+            url: request.url.clone(),
+            headers: request.headers.clone(),
+            body: request.body.clone(),
+        }))
+        .await?;
+    let body = resolve_body(request.body, decision)?;
+    let body = match body {
+        OutboundBody::Bodyless => None,
+        OutboundBody::JsonObject(value) => Some(serde_json::to_vec(&value).map_err(|error| {
+            Error::InvalidRequest(format!("failed to encode request: {error}"))
+        })?),
+    };
+    let preparation = control.run(authorization.prepare()).await?;
+    let mut headers = request.headers;
+    apply_preparation(&mut headers, &preparation)?;
+
+    let validated = ValidatedRequest {
+        method: request.method,
+        url: request.url,
+        headers,
+        body,
+    };
+    let authorized = authorize(validated, preparation.authorizer.as_ref(), control).await?;
+    let response = control
+        .run(async { client.execute(authorized.0).await.map_err(transport_error) })
+        .await?;
+    let status = response.status();
+    let headers = response.headers().clone();
+    let body = control
+        .run(async {
+            response
+                .bytes()
+                .await
+                .map(Vec::from)
+                .map_err(transport_error)
+        })
+        .await?;
+    Ok(OutboundResponse {
+        status,
+        headers,
+        body,
+    })
+}
+
+fn apply_preparation(
+    headers: &mut HeaderMap,
+    preparation: &AuthorizationPreparation,
+) -> Result<(), Error> {
+    let declared: HashSet<_> = preparation
+        .authorizer
+        .declared_headers()
+        .iter()
+        .cloned()
+        .collect();
+    if preparation
+        .visible_headers
+        .keys()
+        .any(|name| !declared.contains(name))
+        || preparation
+            .remove_headers
+            .iter()
+            .any(|name| !declared.contains(name))
+    {
+        return Err(Error::Auth(
+            "credential preparation attempted an undeclared header mutation".into(),
+        ));
+    }
+    for name in &preparation.remove_headers {
+        headers.remove(name);
+    }
+    for (name, value) in &preparation.visible_headers {
+        headers.insert(name, value.clone());
+    }
+    Ok(())
+}
+
+fn validate_destination(origin: &Url, request: &OutboundOperation) -> Result<(), Error> {
+    if Origin::parse(origin)? != Origin::parse(&request.url)? {
+        return Err(destination_error());
+    }
+    Ok(())
+}
+
+fn resolve_body(body: OutboundBody, decision: BodyDecision) -> Result<OutboundBody, Error> {
+    match decision {
+        BodyDecision::Unchanged => Ok(body),
+        BodyDecision::Reject(message) => Err(Error::InvalidRequest(message)),
+        BodyDecision::Replace(value) => match body {
+            OutboundBody::Bodyless => Err(Error::InvalidRequest(
+                "callback cannot add a body to a bodyless operation".into(),
+            )),
+            OutboundBody::JsonObject(_) => value
+                .as_object()
+                .cloned()
+                .map(OutboundBody::JsonObject)
+                .ok_or_else(|| {
+                    Error::InvalidRequest("callback replacement must be a JSON object".into())
+                }),
+        },
+    }
+}
+
+async fn authorize(
+    request: ValidatedRequest,
+    authorizer: &dyn RequestAuthorizer,
+    control: &OperationControl,
+) -> Result<AuthorizedRequest, Error> {
+    let mutation = control
+        .run(authorizer.authorize(AuthorizationInput {
+            method: &request.method,
+            url: &request.url,
+            headers: &request.headers,
+            body: request.body.as_deref(),
+        }))
+        .await?;
+    let declared: HashSet<_> = authorizer.declared_headers().iter().cloned().collect();
+    if mutation
+        .set_headers
+        .iter()
+        .any(|(name, _)| !declared.contains(name))
+        || mutation
+            .remove_headers
+            .iter()
+            .any(|name| !declared.contains(name))
+    {
+        return Err(Error::Auth(
+            "authorizer attempted an undeclared header mutation".into(),
+        ));
+    }
+
+    let mut headers = request.headers;
+    for name in mutation.remove_headers {
+        headers.remove(name);
+    }
+    for (name, value) in mutation.set_headers {
+        headers.insert(name, value);
+    }
+    let mut wire = reqwest::Request::new(request.method, request.url);
+    *wire.headers_mut() = headers;
+    *wire.body_mut() = request.body.map(reqwest::Body::from);
+    let remaining = control
+        .deadline
+        .checked_duration_since(Instant::now())
+        .ok_or_else(deadline_error)?;
+    *wire.timeout_mut() = Some(remaining);
+    Ok(AuthorizedRequest(wire))
+}
+
+fn destination_error() -> Error {
+    Error::Auth("refusing to authorize a request for this destination".into())
+}
+
+fn deadline_error() -> Error {
+    Error::Network("Request timed out".into())
+}
+
+fn cancelled_error() -> Error {
+    Error::Network("Request cancelled".into())
+}
+
+fn transport_error(error: reqwest::Error) -> Error {
+    Error::Network(if error.is_timeout() {
+        "Request timed out".into()
+    } else {
+        error.to_string()
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/litellm-rust/crates/core/src/auth/tests.rs
+++ b/litellm-rust/crates/core/src/auth/tests.rs
@@ -1,0 +1,372 @@
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use reqwest::header::{AUTHORIZATION, CONTENT_TYPE};
+use sha2::{Digest, Sha256};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+use super::*;
+
+async fn server() -> (Url, tokio::task::JoinHandle<Vec<u8>>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let url = Url::parse(&format!(
+        "http://{}/request?version=one",
+        listener.local_addr().unwrap()
+    ))
+    .unwrap();
+    let task = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        let mut wire = Vec::new();
+        let mut buffer = [0; 4096];
+        loop {
+            let count = socket.read(&mut buffer).await.unwrap();
+            assert_ne!(count, 0);
+            wire.extend_from_slice(&buffer[..count]);
+            let text = String::from_utf8_lossy(&wire);
+            if let Some((headers, body)) = text.split_once("\r\n\r\n") {
+                let length = headers
+                    .lines()
+                    .find_map(|line| {
+                        line.to_ascii_lowercase()
+                            .strip_prefix("content-length: ")
+                            .and_then(|value| value.parse::<usize>().ok())
+                    })
+                    .unwrap_or(0);
+                if body.len() >= length {
+                    break;
+                }
+            }
+        }
+        socket
+            .write_all(b"HTTP/1.1 200 OK\r\ncontent-length: 2\r\nconnection: close\r\n\r\n{}")
+            .await
+            .unwrap();
+        wire
+    });
+    (url, task)
+}
+
+fn client() -> Client {
+    Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap()
+}
+
+fn request(url: Url, body: OutboundBody) -> OutboundOperation {
+    OutboundOperation {
+        method: Method::POST,
+        url,
+        headers: HeaderMap::from_iter([(
+            CONTENT_TYPE,
+            HeaderValue::from_static("application/json"),
+        )]),
+        body,
+        operation: OutboundOperationKind::Request,
+    }
+}
+
+struct RecordingHeaderAuthorizer {
+    calls: AtomicUsize,
+    bodies: Mutex<Vec<Option<Vec<u8>>>>,
+}
+
+impl RequestAuthorizer for RecordingHeaderAuthorizer {
+    fn declared_headers(&self) -> &[HeaderName] {
+        std::slice::from_ref(&AUTHORIZATION)
+    }
+
+    fn authorize<'a>(
+        &'a self,
+        input: AuthorizationInput<'a>,
+    ) -> OperationFuture<'a, AuthorizationMutation> {
+        Box::pin(async move {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            self.bodies.lock().unwrap().push(input.body.map(Vec::from));
+            Ok(AuthorizationMutation {
+                set_headers: vec![(AUTHORIZATION, HeaderValue::from_static("Bearer recorded"))],
+                remove_headers: Vec::new(),
+            })
+        })
+    }
+}
+
+struct BodySigner;
+
+impl RequestAuthorizer for BodySigner {
+    fn declared_headers(&self) -> &[HeaderName] {
+        static SIGNATURE: HeaderName = HeaderName::from_static("x-body-signature");
+        std::slice::from_ref(&SIGNATURE)
+    }
+
+    fn authorize<'a>(
+        &'a self,
+        input: AuthorizationInput<'a>,
+    ) -> OperationFuture<'a, AuthorizationMutation> {
+        Box::pin(async move {
+            let signature = format!("{:x}", Sha256::digest(input.body.unwrap_or_default()));
+            Ok(AuthorizationMutation {
+                set_headers: vec![(
+                    HeaderName::from_static("x-body-signature"),
+                    signature.parse().unwrap(),
+                )],
+                remove_headers: Vec::new(),
+            })
+        })
+    }
+}
+
+#[tokio::test]
+async fn header_authorizer_observes_final_replacement_and_send_occurs_once() {
+    let (url, server) = server().await;
+    let authorizer = Arc::new(RecordingHeaderAuthorizer {
+        calls: AtomicUsize::new(0),
+        bodies: Mutex::new(Vec::new()),
+    });
+    let control = OperationControl::with_timeout(Duration::from_secs(2));
+    let response = send_once(
+        &client(),
+        &url,
+        request(
+            url.clone(),
+            OutboundBody::JsonObject(serde_json::Map::new()),
+        ),
+        |view| async move {
+            assert!(view.headers.get(AUTHORIZATION).is_none());
+            Ok(BodyDecision::Replace(serde_json::json!({"masked": true})))
+        },
+        &FixedAuthorization::with_prepared_headers(
+            authorizer.clone(),
+            HeaderMap::from_iter([(AUTHORIZATION, HeaderValue::from_static("Bearer recorded"))]),
+            Vec::new(),
+        ),
+        &control,
+    )
+    .await
+    .unwrap();
+    let wire = server.await.unwrap();
+    assert_eq!(response.body, b"{}");
+    assert_eq!(authorizer.calls.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        authorizer.bodies.lock().unwrap().as_slice(),
+        [Some(br#"{"masked":true}"#.to_vec())]
+    );
+    assert!(String::from_utf8_lossy(&wire).contains("authorization: Bearer recorded\r\n"));
+}
+
+#[tokio::test]
+async fn body_sensitive_signer_signs_the_exact_wire_bytes() {
+    let (url, server) = server().await;
+    let final_body = br#"{"a":1,"z":"last"}"#;
+    send_once(
+        &client(),
+        &url,
+        request(
+            url.clone(),
+            OutboundBody::JsonObject(
+                serde_json::json!({"private": true})
+                    .as_object()
+                    .unwrap()
+                    .clone(),
+            ),
+        ),
+        |_| async {
+            Ok(BodyDecision::Replace(
+                serde_json::json!({"a": 1, "z": "last"}),
+            ))
+        },
+        &FixedAuthorization::new(Arc::new(BodySigner)),
+        &OperationControl::with_timeout(Duration::from_secs(2)),
+    )
+    .await
+    .unwrap();
+    let wire = server.await.unwrap();
+    let header_end = wire
+        .windows(4)
+        .position(|value| value == b"\r\n\r\n")
+        .unwrap()
+        + 4;
+    assert_eq!(&wire[header_end..], final_body);
+    let expected = format!("{:x}", Sha256::digest(final_body));
+    assert!(
+        String::from_utf8_lossy(&wire[..header_end])
+            .contains(&format!("x-body-signature: {expected}\r\n"))
+    );
+}
+
+#[tokio::test]
+async fn bodyless_rejection_and_invalid_replacement_never_authorize() {
+    let authorizer = Arc::new(RecordingHeaderAuthorizer {
+        calls: AtomicUsize::new(0),
+        bodies: Mutex::new(Vec::new()),
+    });
+    let url = Url::parse("http://127.0.0.1:9/").unwrap();
+    for (body, decision, expected) in [
+        (
+            OutboundBody::Bodyless,
+            BodyDecision::Replace(serde_json::json!({})),
+            "bodyless",
+        ),
+        (
+            OutboundBody::JsonObject(serde_json::Map::new()),
+            BodyDecision::Reject("blocked".into()),
+            "blocked",
+        ),
+        (
+            OutboundBody::JsonObject(serde_json::Map::new()),
+            BodyDecision::Replace(serde_json::json!([1, 2])),
+            "JSON object",
+        ),
+    ] {
+        let error = send_once(
+            &client(),
+            &url,
+            request(url.clone(), body),
+            |_| async { Ok(decision) },
+            &FixedAuthorization::new(authorizer.clone()),
+            &OperationControl::with_timeout(Duration::from_secs(1)),
+        )
+        .await
+        .unwrap_err();
+        assert!(error.to_string().contains(expected));
+    }
+    assert_eq!(authorizer.calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn bodyless_request_is_authorized_and_sent_without_a_body() {
+    let (url, server) = server().await;
+    let authorizer = Arc::new(RecordingHeaderAuthorizer {
+        calls: AtomicUsize::new(0),
+        bodies: Mutex::new(Vec::new()),
+    });
+    let mut operation = request(url.clone(), OutboundBody::Bodyless);
+    operation.method = Method::GET;
+    operation.headers.clear();
+    send_once(
+        &client(),
+        &url,
+        operation,
+        |_| async { Ok(BodyDecision::Unchanged) },
+        &FixedAuthorization::new(authorizer.clone()),
+        &OperationControl::with_timeout(Duration::from_secs(2)),
+    )
+    .await
+    .unwrap();
+    let wire = server.await.unwrap();
+    let header_end = wire
+        .windows(4)
+        .position(|value| value == b"\r\n\r\n")
+        .unwrap()
+        + 4;
+    assert!(wire[header_end..].is_empty());
+    assert_eq!(authorizer.bodies.lock().unwrap().as_slice(), [None]);
+}
+
+struct UndeclaredAuthorizer;
+
+impl RequestAuthorizer for UndeclaredAuthorizer {
+    fn declared_headers(&self) -> &[HeaderName] {
+        &[]
+    }
+
+    fn authorize<'a>(
+        &'a self,
+        _: AuthorizationInput<'a>,
+    ) -> OperationFuture<'a, AuthorizationMutation> {
+        Box::pin(async {
+            Ok(AuthorizationMutation {
+                set_headers: vec![(AUTHORIZATION, HeaderValue::from_static("forbidden"))],
+                remove_headers: Vec::new(),
+            })
+        })
+    }
+}
+
+#[tokio::test]
+async fn undeclared_auth_mutation_and_disallowed_destination_are_rejected() {
+    let url = Url::parse("http://127.0.0.1:9/").unwrap();
+    let error = send_once(
+        &client(),
+        &url,
+        request(url.clone(), OutboundBody::Bodyless),
+        |_| async { Ok(BodyDecision::Unchanged) },
+        &FixedAuthorization::new(Arc::new(UndeclaredAuthorizer)),
+        &OperationControl::with_timeout(Duration::from_secs(1)),
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(error, Error::Auth(_)));
+
+    let foreign = Url::parse("http://example.com/").unwrap();
+    let authorizer = Arc::new(RecordingHeaderAuthorizer {
+        calls: AtomicUsize::new(0),
+        bodies: Mutex::new(Vec::new()),
+    });
+    let error = send_once(
+        &client(),
+        &url,
+        request(foreign, OutboundBody::Bodyless),
+        |_| async { Ok(BodyDecision::Unchanged) },
+        &FixedAuthorization::new(authorizer.clone()),
+        &OperationControl::with_timeout(Duration::from_secs(1)),
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(error, Error::Auth(_)));
+    assert_eq!(authorizer.calls.load(Ordering::SeqCst), 0);
+}
+
+struct PendingAuthorization;
+
+impl AuthorizationProvider for PendingAuthorization {
+    fn prepare(&self) -> OperationFuture<'_, AuthorizationPreparation> {
+        Box::pin(async {
+            std::future::pending::<()>().await;
+            unreachable!()
+        })
+    }
+}
+
+#[tokio::test]
+async fn deadline_and_cancellation_cover_post_callback_credential_preparation() {
+    let url = Url::parse("http://127.0.0.1:9/").unwrap();
+    let callback_calls = Arc::new(AtomicUsize::new(0));
+    let callback_counter = callback_calls.clone();
+    let error = send_once(
+        &client(),
+        &url,
+        request(url.clone(), OutboundBody::Bodyless),
+        move |_| async move {
+            callback_counter.fetch_add(1, Ordering::SeqCst);
+            Ok(BodyDecision::Unchanged)
+        },
+        &PendingAuthorization,
+        &OperationControl::with_timeout(Duration::from_millis(10)),
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(
+        error.to_string(),
+        "upstream network error: Request timed out"
+    );
+    assert_eq!(callback_calls.load(Ordering::SeqCst), 1);
+
+    let control = OperationControl::with_timeout(Duration::from_secs(1));
+    control.cancellation.cancel();
+    let error = send_once(
+        &client(),
+        &url,
+        request(url.clone(), OutboundBody::Bodyless),
+        |_| async { Ok(BodyDecision::Unchanged) },
+        &PendingAuthorization,
+        &control,
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(
+        error.to_string(),
+        "upstream network error: Request cancelled"
+    );
+}

--- a/litellm-rust/crates/core/src/lib.rs
+++ b/litellm-rust/crates/core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod audio_transcription;
+pub mod auth;
 pub mod caching;
 pub mod call_lifecycle;
 pub mod chat_completions;

--- a/litellm-rust/crates/core/src/ocr/client.rs
+++ b/litellm-rust/crates/core/src/ocr/client.rs
@@ -7,6 +7,7 @@ pub(super) fn http_client() -> &'static reqwest::Client {
     static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
     CLIENT.get_or_init(|| {
         reqwest::Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
             .timeout(Duration::from_secs(OCR_TIMEOUT_SECS))
             .build()
             .unwrap_or_else(|_| reqwest::Client::new())

--- a/litellm-rust/crates/core/src/ocr/common_utils.rs
+++ b/litellm-rust/crates/core/src/ocr/common_utils.rs
@@ -241,7 +241,7 @@ fn same_origin(left: &str, right: &str) -> bool {
         && left.port_or_known_default() == right.port_or_known_default()
 }
 
-fn retry_after_secs(response: &reqwest::Response) -> u64 {
+fn poll_interval_secs(response: &reqwest::Response) -> u64 {
     response
         .headers()
         .get(reqwest::header::RETRY_AFTER)
@@ -308,7 +308,7 @@ pub(super) async fn poll_document_intelligence(
             .send()
             .await
             .map_err(|err| Error::Network(err.to_string()))?;
-        let retry_after = retry_after_secs(&response);
+        let poll_interval = poll_interval_secs(&response);
         let status = response.status();
         let text = response
             .text()
@@ -326,7 +326,7 @@ pub(super) async fn poll_document_intelligence(
         if operation_status(&response_json)? == "succeeded" {
             return Ok(response_json);
         }
-        tokio::time::sleep(Duration::from_secs(retry_after)).await;
+        tokio::time::sleep(Duration::from_secs(poll_interval)).await;
     }
 }
 

--- a/litellm-rust/crates/core/src/ocr/handler.rs
+++ b/litellm-rust/crates/core/src/ocr/handler.rs
@@ -1,4 +1,9 @@
-use reqwest::{RequestBuilder, StatusCode, header::HeaderMap};
+use std::time::Duration;
+
+use reqwest::{
+    Method, StatusCode, Url,
+    header::{HeaderMap, HeaderName, HeaderValue},
+};
 use serde_json::Value;
 
 use super::client::http_client;
@@ -7,7 +12,12 @@ use super::observers::{OcrObserver, OcrPostCall, OcrPreCall};
 use super::transformation::OcrResponseHandling;
 use super::types::{OcrRequestData, ProviderOcrRequest};
 use crate::Error;
-use crate::http_utils::{http_request, truncate_error_body};
+use crate::auth::{
+    BodyDecision, NoAuthorization, OperationControl, OutboundBody, OutboundOperation,
+    OutboundOperationKind, send_once,
+};
+use crate::constants::OCR_TIMEOUT_SECS;
+use crate::http_utils::truncate_error_body;
 
 pub struct OcrHttpResponse {
     pub status: StatusCode,
@@ -17,17 +27,29 @@ pub struct OcrHttpResponse {
 
 #[tracing::instrument(target = "litellm::function_trace", level = "trace", skip_all)]
 pub async fn send_ocr_request(
-    request: RequestBuilder,
+    origin: &Url,
+    request: OutboundOperation,
     event: &OcrPreCall,
     observer: &mut impl OcrObserver,
+    control: &OperationControl,
 ) -> Result<OcrHttpResponse, Error> {
-    if observer.pre_call(event).await.is_err() {
-        tracing::warn!("OCR pre-call observer failed");
-    }
-    let response = http_request(request).await.map_err(transport_error)?;
-    let status = response.status();
-    let headers = response.headers().clone();
-    let body = response.text().await.map_err(transport_error)?;
+    let response = send_once(
+        http_client(),
+        origin,
+        request,
+        |_| async {
+            if observer.pre_call(event).await.is_err() {
+                tracing::warn!("OCR pre-call observer failed");
+            }
+            Ok(BodyDecision::Unchanged)
+        },
+        &NoAuthorization,
+        control,
+    )
+    .await?;
+    let status = response.status;
+    let headers = response.headers;
+    let body = String::from_utf8_lossy(&response.body).into_owned();
     if !status.is_success() {
         return Err(Error::Http {
             status: status.as_u16(),
@@ -47,25 +69,22 @@ pub async fn send_ocr_request(
     })
 }
 
-fn transport_error(error: reqwest::Error) -> Error {
-    Error::Network(if error.is_timeout() {
-        "Request timed out".into()
-    } else {
-        error.to_string()
-    })
-}
-
 #[tracing::instrument(target = "litellm::function_trace", level = "trace", skip_all)]
 pub async fn execute_ocr_provider_call(
     request: ProviderOcrRequest,
     observer: &mut impl OcrObserver,
 ) -> Result<Value, Error> {
-    let mut request_builder = http_client().post(request.url()).json(request.body());
+    let url = Url::parse(request.url())
+        .map_err(|error| Error::InvalidRequest(format!("invalid OCR provider URL: {error}")))?;
+    let mut headers = HeaderMap::new();
     for (key, value) in &request.upstream_headers {
-        request_builder = request_builder.header(key, value);
-    }
-    if let Some(duration) = request.timeout {
-        request_builder = request_builder.timeout(duration);
+        let name = key.parse::<HeaderName>().map_err(|error| {
+            Error::InvalidRequest(format!("invalid OCR provider header name: {error}"))
+        })?;
+        let value = value.parse::<HeaderValue>().map_err(|error| {
+            Error::InvalidRequest(format!("invalid OCR provider header value: {error}"))
+        })?;
+        headers.append(name, value);
     }
 
     let event = OcrPreCall {
@@ -77,7 +96,28 @@ pub async fn execute_ocr_provider_call(
         api_base: request.url().to_string(),
         headers: request.upstream_headers.iter().cloned().collect(),
     };
-    let response = send_ocr_request(request_builder, &event, observer).await?;
+    let body =
+        request.body().as_object().cloned().ok_or_else(|| {
+            Error::InvalidRequest("OCR provider body must be a JSON object".into())
+        })?;
+    let timeout = request
+        .timeout
+        .unwrap_or(Duration::from_secs(OCR_TIMEOUT_SECS));
+    let operation = OutboundOperation {
+        method: Method::POST,
+        url: url.clone(),
+        headers,
+        body: OutboundBody::JsonObject(body),
+        operation: OutboundOperationKind::Submission,
+    };
+    let response = send_ocr_request(
+        &url,
+        operation,
+        &event,
+        observer,
+        &OperationControl::with_timeout(timeout),
+    )
+    .await?;
 
     let status = response.status;
     if request.config.response_handling() == OcrResponseHandling::AzureDocumentIntelligencePoll


### PR DESCRIPTION
## TLDR

Problem this solves:

- Attempt policy obscured the actual wire operation

How it solves it:

- Authorize exact encoded bytes and send once

## User Flow

Before: the SDK request can violate this layer contract.

1. They send a native provider request.
2. Retry-oriented attempts surround encoding and authorization.

After: the same request follows one predictable contract.

1. They send the same request.
2. It is replaced, validated, encoded, authorized, and sent once.

## Relevant issues

- Stack root: #39928

## Linear ticket


## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] Focused tests covering this change pass locally
- [ ] All required CI/CD checks pass
- [x] This PR is isolated to one stack responsibility
- [ ] Greptile Confidence Score is at least 4/5

## Stack

`39928 -> 39913 -> 39923 -> 39941 -> 39939 -> 39484 -> 39986 -> 39646 -> 39987 -> 39782 -> 39765`

Layer 9 of 11.

## Screenshots / Proof of Fix

### After (`7103456b9c31939a3cce2aa814b8c917e6bee5de`)

1. Rust loopback exact-byte and send-once tests: passed
2. `UV_PYTHON=3.12 make check`: passed
3. Final stack Rust workspace and strict Clippy: passed

No paid-provider calls were used for deterministic validation.

## Type

Refactoring

## Caveats (if any)

### Medium

- Automatic native transport retries are intentionally removed.

## Final Attestation

- [x] Tests cover this layer intended contracts and edge cases




