### PR TITLE
ci: run unit tests on Python 3.12

### DIFF
--- a/.github/workflows/_test-unit-base.yml
+++ b/.github/workflows/_test-unit-base.yml
@@ -55,17 +55,14 @@ on:
 permissions:
   contents: read
 
+env:
+  UV_PYTHON: "3.12"
+
 jobs:
   run:
-    name: ${{ matrix.python-version == '3.12' && 'Run tests' || format('Run tests (Python {0})', matrix.python-version) }}
+    name: Run tests
     runs-on: ubuntu-latest
     timeout-minutes: ${{ inputs.job-timeout-minutes }}
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-    env:
-      UV_PYTHON: ${{ matrix.python-version }}
     permissions:
       contents: read
       pull-requests: read
@@ -88,7 +85,7 @@ jobs:
         timeout-minutes: 3
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ env.UV_PYTHON }}
 
       - name: Set up uv
         if: steps.changes.outputs.decision != 'skip'
@@ -103,9 +100,9 @@ jobs:
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ env.UV_CACHE_DIR }}
-          key: ${{ runner.os }}-uv-downloads-py${{ matrix.python-version }}-${{ hashFiles('uv.lock') }}
+          key: ${{ runner.os }}-uv-downloads-py${{ env.UV_PYTHON }}-${{ hashFiles('uv.lock') }}
           restore-keys: |
-            ${{ runner.os }}-uv-downloads-py${{ matrix.python-version }}-
+            ${{ runner.os }}-uv-downloads-py${{ env.UV_PYTHON }}-
 
       - name: Cache the Rust build
         if: steps.changes.outputs.decision != 'skip'
@@ -139,7 +136,7 @@ jobs:
           WORKERS: ${{ inputs.workers }}
           RERUNS: ${{ inputs.reruns }}
           DIST: ${{ inputs.dist }}
-          COVERAGE_CORE: ${{ contains(fromJSON('["3.10", "3.11"]'), matrix.python-version) && 'ctrace' || 'sysmon' }}
+          COVERAGE_CORE: sysmon
         run: |
           if [ "${WORKERS}" = "0" ]; then
             uv run --no-sync pytest ${TEST_PATH:?} \
@@ -166,7 +163,7 @@ jobs:
           fi
 
       - name: Save coverage report
-        if: always() && matrix.python-version == '3.12' && steps.changes.outputs.decision != 'skip'
+        if: always() && steps.changes.outputs.decision != 'skip'
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: coverage-${{ inputs.artifact-name }}-${{ github.run_id }}-${{ github.run_attempt }}


### PR DESCRIPTION
## TLDR

Problem this solves:

- Five GitHub unit runs execute for every shard

How it solves it:

- Runs each reusable unit shard on Python 3.12
- Removes matrix-only cache, coverage, and job-name logic

## User Flow

Before: a contributor updates backend code and each unit shard runs on five Python versions

1. They open a pull request with backend changes
2. GitHub starts each affected unit shard five times

After: the same pull request runs each affected unit shard once on Python 3.12

1. They open a pull request with backend changes
2. GitHub starts each affected unit shard on Python 3.12

## Relevant issues

Follow-up to #39399

## Linear ticket

## Pre-Submission checklist

- [ ] I have added meaningful tests
- [ ] The handful of test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5

## Screenshots / Proof of Fix

### Before (6f6822a975)

1. Inspect `.github/workflows/_test-unit-base.yml`
2. Observe a Python 3.10 through 3.14 matrix for every reusable unit shard

### After (c3d7b48ea3)

1. Inspect `.github/workflows/_test-unit-base.yml`
2. Observe one Python 3.12 unit job with matching cache and coverage settings
3. Run `git diff --check`
4. Output: no whitespace errors

## Type

Infrastructure

## Caveats (if any)

### Low

- Python compatibility coverage is no longer part of GitHub unit jobs

## Final Attestation

- [x] This change is limited to the reusable GitHub unit workflow