### PR TITLE
fix(proxy): gate budget_duration behind the admin check on /key/update

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -2645,11 +2645,16 @@ async def _validate_update_key_data(
     # - Anyone else (non-PROXY_ADMIN, not the owner, not a team member
     #   on a team key): must pass _check_key_admin_access (PROXY_ADMIN
     #   / key-owner / team-admin / org-admin of the key).
-    # - max_budget / spend / budget_limits: always require the admin
+    # - max_budget / spend / budget_limits / budget_duration: always require the admin
     #   check, even for the key owner or a team member (matches the
-    #   existing admin-only budget semantics).  budget_limits uses
-    #   model_fields_set because an explicit null/[] clears the field
-    #   and must gate the same as setting or changing it.
+    #   existing admin-only budget semantics).  budget_limits and
+    #   budget_duration use model_fields_set because an explicit null
+    #   clears the field and must gate the same as setting or changing it.
+    #   budget_duration is budget-enforcement state, not a display field:
+    #   setting it arms budget_reset_at and the default-on ResetBudgetJob
+    #   re-zeroes spend every elapsed window, so a self-service
+    #   {"budget_duration": "1s"} would let a capped key's owner reset
+    #   their own spend forever and never hit max_budget.
     # - spend gates on presence alone (not a value diff): the DB spend
     #   lags the live cross-pod counter, so letting an "unchanged" spend
     #   through the non-admin path would let a key owner / team member
@@ -2659,6 +2664,7 @@ async def _validate_update_key_data(
         (data.max_budget is not None and data.max_budget != existing_key_row.max_budget)
         or data.spend is not None
         or "budget_limits" in data.model_fields_set
+        or "budget_duration" in data.model_fields_set
     )
 
     _existing_metadata: Final = getattr(existing_key_row, "metadata", None)
@@ -2707,7 +2713,7 @@ async def _validate_update_key_data(
             hashed_token=hashed_key,
             prisma_client=checked_prisma_client,
             user_api_key_cache=user_api_key_cache,
-            route=("/key/update (max_budget/spend)" if _is_budget_change else "/key/update"),
+            route=("/key/update (budget fields)" if _is_budget_change else "/key/update"),
         )
 
     # Check team limits if key has a team_id (from request or existing key)


### PR DESCRIPTION
## Summary

`_validate_update_key_data` treats some `/key/update` fields as budget-enforcement state that only admins may change, gating them behind `_check_key_admin_access` even for the key's owner. That `_is_budget_change` list covered `max_budget` / `spend` / `budget_limits` but missed **`budget_duration`**, so a non-admin key owner (or a team member with the `/key/update` member permission) could self-service `{"budget_duration": "1s"}` on their own capped key.

`budget_duration` is not a display field: setting it arms `budget_reset_at`, and the default-on `ResetBudgetJob` re-zeroes `spend` every elapsed window. A key owner could therefore re-arm a 1s budget window at will and never hit `max_budget` — the cap stops enforcing while spend tracking keeps recording (cost lands on whoever pays for the key's team/org).

## Fix

Add `"budget_duration" in data.model_fields_set` to `_is_budget_change`, using `model_fields_set` like `budget_limits` so an explicit `null` (which clears the field) gates the same as setting or changing it. Also updates the surrounding comment and the audit-log route label. No behavior change for admins or for non-budget self-service fields.

## PoC evidence

Driving the production functions (`_validate_update_key_data` -> `prepare_key_update_data` -> `ResetBudgetJob._reset_budget_for_key`) with a capped key (`max_budget=10`, `spend=9.5`):

- **Pre-fix (current `litellm_internal_staging`):** the non-admin owner's `{"budget_duration": "1s"}` passes validation, arms `budget_reset_at ~ now+1s`, and the job zeroes `spend 9.5 -> 0.0` — cap defeated.
- **Post-fix (this branch):** the same update is rejected at the admin gate before anything is persisted; the benign path (same owner updating `key_alias`) still succeeds.

## Test / lint

- `uvx ruff@0.15.3 check` + `format --check` on the changed file: clean (repo `ruff.toml`).
- Regression PoC flips vulnerable -> blocked on this branch (summary above); no repo test suite covers this gate today.

Happy to adjust wording/placement — the change is deliberately minimal to match the existing budget-field gating.
