### PR TITLE
fix(docker): ship pymongo in the proxy images for the MongoDB vector store

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,7 @@ RUN uv sync --frozen --no-install-project --no-install-workspace --no-default-gr
     --extra semantic-router \
     --extra saml \
     --extra bedrock-realtime \
+    --extra mongodb \
     --python python3.13
 
 # Copy full source tree
@@ -89,6 +90,7 @@ RUN uv sync --frozen --no-default-groups --no-editable \
     --extra semantic-router \
     --extra saml \
     --extra bedrock-realtime \
+    --extra mongodb \
     --python python3.13
 
 RUN HOME=/opt/prisma XDG_CACHE_HOME=/opt/prisma/.cache PRISMA_BINARY_CACHE_DIR=/opt/prisma/binaries \

--- a/docker/Dockerfile.database
+++ b/docker/Dockerfile.database
@@ -65,6 +65,7 @@ RUN uv sync --frozen --no-install-project --no-install-workspace --no-default-gr
     --extra semantic-router \
     --extra saml \
     --extra bedrock-realtime \
+    --extra mongodb \
     --python python3.13
 
 # Copy full source tree
@@ -87,6 +88,7 @@ RUN uv sync --frozen --no-default-groups --no-editable \
     --extra semantic-router \
     --extra saml \
     --extra bedrock-realtime \
+    --extra mongodb \
     --python python3.13
 
 RUN HOME=/opt/prisma XDG_CACHE_HOME=/opt/prisma/.cache PRISMA_BINARY_CACHE_DIR=/opt/prisma/binaries \

--- a/docker/Dockerfile.non_root
+++ b/docker/Dockerfile.non_root
@@ -71,6 +71,7 @@ RUN --mount=type=cache,target=/app/.cache/uv,id=litellm-uv-cache \
     --extra semantic-router \
     --extra saml \
     --extra bedrock-realtime \
+    --extra mongodb \
     --python python3.13
 
 # Copy full source tree
@@ -99,6 +100,7 @@ RUN --mount=type=cache,target=/app/.cache/uv,id=litellm-uv-cache \
         --extra semantic-router \
         --extra saml \
         --extra bedrock-realtime \
+        --extra mongodb \
         --python python3.13 \
         --no-sources-package litellm-proxy-extras; \
     else \
@@ -109,6 +111,7 @@ RUN --mount=type=cache,target=/app/.cache/uv,id=litellm-uv-cache \
         --extra semantic-router \
         --extra saml \
         --extra bedrock-realtime \
+        --extra mongodb \
         --python python3.13; \
     fi
 

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -47,6 +47,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
         --extra extra_proxy \
         --extra semantic-router \
         --extra bedrock-realtime \
+        --extra mongodb \
         --python python3.13
 
 # Stage 2 — copy source and install the project + workspace members.
@@ -59,6 +60,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
         --extra extra_proxy \
         --extra semantic-router \
         --extra bedrock-realtime \
+        --extra mongodb \
         --python python3.13
 
 RUN HOME=/opt/prisma XDG_CACHE_HOME=/opt/prisma/.cache PRISMA_BINARY_CACHE_DIR=/opt/prisma/binaries \


### PR DESCRIPTION
## TLDR

Problem this solves:

- Every shipped image lacks pymongo, so MongoDB vector store searches 400
- Users of a prebuilt image cannot pip install their way out

How it solves it:

- Adds `--extra mongodb` to every proxy image's `uv sync`
- Root Dockerfile, Dockerfile.database, Dockerfile.non_root, and the gateway component
- Resolves from the existing uv.lock, no lock change

## User Flow

Before: an operator running the published Docker image points a vector store at MongoDB Atlas and every search fails with an install hint they cannot act on

1. They add a `vector_store_registry` entry with `custom_llm_provider: mongodb` to their config and start the image
2. They send POST https://litellm-domain/v1/vector_stores/litellm_plot_vector_idx/search with `{"query": "a submarine crew trapped underwater"}`
3. They get HTTP 400 and `The MongoDB vector store requires the 'pymongo' package. Run 'pip install litellm[mongodb]'`
4. The container is prebuilt, so there is nowhere to run that pip install without building their own image

After: the same request returns ranked results from their collection

1. They add the same `vector_store_registry` entry and start the image
2. They send the same POST https://litellm-domain/v1/vector_stores/litellm_plot_vector_idx/search
3. They get HTTP 200 with their documents back, each with a similarity score

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both runs use the non-root image built with the exact command from the bug report, started as a proxy against a real Atlas cluster loaded with the `sample_mflix` dataset, which has a 1536-dim cosine vector index named `litellm_plot_vector_idx` on `embedded_movies.plot_embedding`. Embeddings are real OpenAI calls

The run was captured on the hotfix branch at 16fd14f537, merged to main in #39994; this branch is a `git cherry-pick -x` of that commit on main (`37e8b99a9f`), so the Dockerfile diff is byte-identical, and the Before image is the pre-fix `docker/Dockerfile.non_root`, whose extras block is the same on main and staging

```yaml
model_list:
  - model_name: embed
    litellm_params:
      model: openai/text-embedding-ada-002
      api_key: os.environ/OPENAI_API_KEY

vector_store_registry:
  - vector_store_name: movies
    litellm_params:
      vector_store_id: litellm_plot_vector_idx
      custom_llm_provider: mongodb
      mongodb_connection_string: mongodb+srv://<user>:<password>@<cluster>.mongodb.net/
      mongodb_database: sample_mflix
      mongodb_collection: embedded_movies
      mongodb_text_field: plot
      mongodb_embedding_field: plot_embedding
      litellm_embedding_model: openai/text-embedding-ada-002

general_settings:
  master_key: sk-1234
```

```bash
docker build -f docker/Dockerfile.non_root --build-arg PROXY_EXTRAS_SOURCE=local -t litellm-non-root:<tag> .
docker run -d -p 4000:4000 --env-file proof.env -v $PWD/proof_config.yaml:/app/proof_config.yaml:ro litellm-non-root:<tag> --config /app/proof_config.yaml --port 4000
```

### Before (60440ee4d3)

1. Check the driver is in the image

```bash
docker run --rm --entrypoint python litellm-non-root:local -c "import pymongo"
```

```
ModuleNotFoundError: No module named 'pymongo'
```

2. Run the search

```bash
curl -s -w '\nHTTP %{http_code}\n' -X POST http://localhost:4000/v1/vector_stores/litellm_plot_vector_idx/search \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"query": "a submarine crew trapped underwater", "max_num_results": 2}'
```

```
{"error":{"message":"litellm.BadRequestError: The MongoDB vector store requires the 'pymongo' package. Run 'pip install litellm[mongodb]' (or 'pip install pymongo') to install it.","type":"invalid_request_error","param":null,"code":"400"}}
HTTP 400
```

### After (37e8b99a9f)

1. Check the driver is in the image

```bash
docker run --rm --entrypoint python litellm-non-root:mongodb -c "import pymongo, dns; print('pymongo', pymongo.version)"
```

```
pymongo 4.17.0
```

2. Run the same search

```bash
curl -s -w '\nHTTP %{http_code}\n' -X POST http://localhost:4000/v1/vector_stores/litellm_plot_vector_idx/search \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"query": "a submarine crew trapped underwater", "max_num_results": 2}'
```

```
{
  "object": "vector_store.search_results.page",
  "search_query": "a submarine crew trapped underwater",
  "data": [
    {
      "file_id": "573a13b0f29313caabd3298d",
      "score": 0.9515222311019897,
      "content": [{"type": "text", "text": "Every second is precious for a Russian submarine crew, as they are stranded 72 meters below the ocea..."}]
    },
    {
      "file_id": "573a139cf29313caabcf5e3e",
      "score": 0.9428974390029907,
      "content": [{"type": "text", "text": "A German submarine is boarded by disguised American submariners trying to capture their Enigma ciphe..."}]
    }
  ]
}
HTTP 200
```

## Type

🐛 Bug Fix
🚄 Infrastructure

## Caveats (if any)

### Low

- Images grow by pymongo 4.17.0 and dnspython 2.8.0, a few MB
- The backend component image is left as is; it does not serve /vector_stores
- No automated test: the change is Dockerfile-only, verified by building and running the image above

## Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

