### PR TITLE
fix(ui): keep the search select popup below its field and size it to the room left

### DIFF
--- a/tests/e2e/ui/tests/modelsPage/addModel.spec.ts
+++ b/tests/e2e/ui/tests/modelsPage/addModel.spec.ts
@@ -50,6 +50,70 @@ async function selectProvider(page: PlaywrightPage, providerName: string) {
 test.describe("Add Model", () => {
   test.use({ storageState: ADMIN_STORAGE_PATH });
 
+  test("opens the provider dropdown below its field, sized to the room left on screen", async ({ page }) => {
+    const viewport = { width: 1000, height: 493 };
+    await page.setViewportSize(viewport);
+    await navigateToPage(page, Page.Models);
+    await page.getByRole("tab", { name: "Add Model" }).click();
+
+    const providerDropdown = page.getByRole("combobox", { name: "Provider", exact: true });
+    const popup = page.locator('[data-slot="combobox-content"]');
+    const list = page.locator('[data-slot="combobox-list"]');
+
+    // Base UI places the popup asynchronously and animates it open, so every geometry read polls
+    // both boxes until they settle; a popup that never lands correctly still fails on timeout.
+    // The dashboard scrolls inside <main>, not the window, so scrolling that container is what
+    // changes how much room is left below the field.
+    const openAt = async (scrollTop: number) => {
+      await page.locator("main").evaluate((el, top) => el.scrollTo(0, top), scrollTop);
+      await providerDropdown.click();
+      await expect(popup).toBeVisible();
+      await expect.poll(() => popup.getAttribute("data-side")).toBe("bottom");
+      await expect
+        .poll(async () => {
+          const triggerBox = await providerDropdown.boundingBox();
+          const popupBox = await popup.boundingBox();
+          if (!triggerBox || !popupBox) return null;
+          return popupBox.y >= triggerBox.y + triggerBox.height && popupBox.y + popupBox.height <= viewport.height;
+        })
+        .toBe(true);
+      // Heights come from computed style, not getBoundingClientRect: the popup's open animation
+      // scales the box, so a rect read mid-animation reports ~2% short of the real layout height.
+      // Row counting stays on rects, where that scale cancels out between the list and its rows.
+      return list.evaluate((listEl) => {
+        const bounds = listEl.getBoundingClientRect();
+        const popupEl = listEl.closest('[data-slot="combobox-content"]')!;
+        return {
+          listHeight: parseFloat(getComputedStyle(listEl).height),
+          availableHeight: parseFloat(getComputedStyle(popupEl).getPropertyValue("--available-height")),
+          rows: Array.from(listEl.querySelectorAll('[data-slot="combobox-item"]')).filter((item) => {
+            const row = item.getBoundingClientRect();
+            return row.top >= bounds.top - 0.5 && row.bottom <= bounds.bottom + 0.5;
+          }).length,
+        };
+      });
+    };
+
+    // ComboboxList caps itself at --spacing(72) and reserves --spacing(9) of the space below the
+    // field for the popup's own chrome, so its height is min(LIST_MAX, available - RESERVED).
+    const LIST_MAX_PX = 288 - 36;
+    const RESERVED_PX = 36;
+
+    const tight = await openAt(150);
+    expect(tight.rows, "shows the rows that fit below the field").toBeGreaterThan(0);
+    expect(tight.listHeight, "is limited by the room below the field, not by its own cap").toBeCloseTo(
+      tight.availableHeight - RESERVED_PX,
+      0,
+    );
+    expect(tight.listHeight, "stays under its own cap while space-limited").toBeLessThan(LIST_MAX_PX);
+    await page.keyboard.press("Escape");
+
+    const roomy = await openAt(400);
+    expect(roomy.rows, "shows more rows once there is more room below the field").toBeGreaterThan(tight.rows);
+    expect(roomy.availableHeight - RESERVED_PX, "has more room below than the cap").toBeGreaterThan(LIST_MAX_PX);
+    expect(roomy.listHeight, "grows to its cap once the room below exceeds it").toBeCloseTo(LIST_MAX_PX, 0);
+  });
+
   // Set by the UI-add test below. The deployed stack keeps its database, so a leak
   // pollutes every later Models table and readback.
   let uiAddedModelName = "";

--- a/tests/e2e/ui/tests/modelsPage/addModel.spec.ts
+++ b/tests/e2e/ui/tests/modelsPage/addModel.spec.ts
@@ -60,12 +60,10 @@ test.describe("Add Model", () => {
     const popup = page.locator('[data-slot="combobox-content"]');
     const list = page.locator('[data-slot="combobox-list"]');
 
-    // Base UI places the popup asynchronously and animates it open, so every geometry read polls
-    // both boxes until they settle; a popup that never lands correctly still fails on timeout.
-    // The dashboard scrolls inside <main>, not the window, so scrolling that container is what
-    // changes how much room is left below the field.
+    const scrollContainer = page.locator("main");
+
     const openAt = async (scrollTop: number) => {
-      await page.locator("main").evaluate((el, top) => el.scrollTo(0, top), scrollTop);
+      await scrollContainer.evaluate((el, top) => el.scrollTo(0, top), scrollTop);
       await providerDropdown.click();
       await expect(popup).toBeVisible();
       await expect.poll(() => popup.getAttribute("data-side")).toBe("bottom");
@@ -77,9 +75,6 @@ test.describe("Add Model", () => {
           return popupBox.y >= triggerBox.y + triggerBox.height && popupBox.y + popupBox.height <= viewport.height;
         })
         .toBe(true);
-      // Heights come from computed style, not getBoundingClientRect: the popup's open animation
-      // scales the box, so a rect read mid-animation reports ~2% short of the real layout height.
-      // Row counting stays on rects, where that scale cancels out between the list and its rows.
       return list.evaluate((listEl) => {
         const bounds = listEl.getBoundingClientRect();
         const popupEl = listEl.closest('[data-slot="combobox-content"]')!;
@@ -94,15 +89,14 @@ test.describe("Add Model", () => {
       });
     };
 
-    // ComboboxList caps itself at --spacing(72) and reserves --spacing(9) of the space below the
-    // field for the popup's own chrome, so its height is min(LIST_MAX, available - RESERVED).
-    const LIST_MAX_PX = 288 - 36;
-    const RESERVED_PX = 36;
+    const SPACING_72_PX = 288;
+    const POPUP_CHROME_PX = 36;
+    const LIST_MAX_PX = SPACING_72_PX - POPUP_CHROME_PX;
 
     const tight = await openAt(150);
     expect(tight.rows, "shows the rows that fit below the field").toBeGreaterThan(0);
     expect(tight.listHeight, "is limited by the room below the field, not by its own cap").toBeCloseTo(
-      tight.availableHeight - RESERVED_PX,
+      tight.availableHeight - POPUP_CHROME_PX,
       0,
     );
     expect(tight.listHeight, "stays under its own cap while space-limited").toBeLessThan(LIST_MAX_PX);
@@ -110,7 +104,7 @@ test.describe("Add Model", () => {
 
     const roomy = await openAt(400);
     expect(roomy.rows, "shows more rows once there is more room below the field").toBeGreaterThan(tight.rows);
-    expect(roomy.availableHeight - RESERVED_PX, "has more room below than the cap").toBeGreaterThan(LIST_MAX_PX);
+    expect(roomy.availableHeight - POPUP_CHROME_PX, "has more room below than the cap").toBeGreaterThan(LIST_MAX_PX);
     expect(roomy.listHeight, "grows to its cap once the room below exceeds it").toBeCloseTo(LIST_MAX_PX, 0);
   });
 

--- a/ui/litellm-dashboard/src/components/shared/SearchSelect.tsx
+++ b/ui/litellm-dashboard/src/components/shared/SearchSelect.tsx
@@ -74,7 +74,7 @@ export function SearchSelect({
         showClear={allowClear && value != null && value !== ""}
         className={`h-8 w-full text-sm ${className ?? ""}`}
       />
-      <ComboboxContent side="bottom" collisionAvoidance={{ side: "shift", align: "shift", fallbackAxisSide: "none" }}>
+      <ComboboxContent collisionAvoidance={{ side: "none" }}>
         <ComboboxEmpty>{emptyText}</ComboboxEmpty>
         <ComboboxList>
           {(item: SearchSelectOption) => (


### PR DESCRIPTION
## TLDR

Problem this solves:

- Add Model provider dropdown slid up over its own field
- Happened when the form sat low in a short viewport

How it solves it:

- Drop the search select's custom shift collision policy
- Keep the list below the field and size it to the room left

## User Flow

Before: an admin opening the Provider dropdown near the bottom of a short window cannot see the field they are typing into

1. They open https://litellm-domain/ui/models-and-endpoints and click the Add Model tab
2. They click the Provider field while the form sits low in a short browser window
3. The provider list opens, but it extends upward across the Provider field and the page content above it
4. They scroll the page down, reopen the field, and only then does the list sit below the field

After: the same admin always sees the list below the field, holding as many providers as the space allows

1. They open https://litellm-domain/ui/models-and-endpoints and click the Add Model tab
2. They click the Provider field while the form sits low in a short browser window
3. The provider list opens below the field, showing the 3 providers that fit, and scrolls to reach the rest
4. They scroll the page so the field sits higher, reopen the field, and the same list now shows 7 providers

## Relevant issues

## Linear ticket

Resolves LIT-7095

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup: the UI e2e stack (`tests/e2e/ui/run_e2e.sh`, proxy plus seeded postgres plus mock LLM) and a Chromium at 1000 x 493 CSS pixels, the size from the report. The dashboard scrolls inside `main`, so each reading scrolls that container to leave a different amount of room below the Provider field, then reads `getBoundingClientRect()` on the field, on `[data-slot="combobox-content"]`, and counts the `[data-slot="combobox-item"]` rows fully inside `[data-slot="combobox-list"]`

### Before (09e9fd5f60)

#### Room below the field vs what the list does

1. Open the Add Model tab, scroll `main` to 150, click the Provider field
2. Observed: `side=top popup=[42,294] trigger bottom=336 rows=7`, the list jumps above the field
3. Scroll `main` to 394, click the Provider field
4. Observed: `side=bottom popup=[98,350] trigger bottom=92 rows=7`
5. The row count never changes with the space available, and at 150 the list covers the field it belongs to

#### Regression test against the unfixed component

1. `./run_e2e.sh tests/modelsPage/addModel.spec.ts --grep 'opens the provider dropdown below'`
2. Observed: `1 failed`, `Expected: "bottom"`, `Received: "top"`

### After (999495d41e)

#### Room below the field vs what the list does

1. Open the Add Model tab, scroll `main` to 150, click the Provider field
2. Observed: `side=bottom popup=[342,452] trigger bottom=336 rows=3`, below the field, sized to the 146px available
3. Scroll `main` to 394, click the Provider field
4. Observed: `side=bottom popup=[98,350] trigger bottom=92 rows=7`, still below the field, now using the 390px available
5. The list stays below the field in both cases and grows from 3 rows to 7 as room appears

Little room below the field, 3 rows, below the field:

<img width="1000" alt="Provider dropdown open below its field showing three providers when space is tight" src="https://github.com/user-attachments/assets/d1df98ea-5e56-4c90-92c9-e61c1aeba946" />

More room below the field, 7 rows, still below the field:

<img width="1000" alt="Provider dropdown open below its field showing seven providers when there is more space" src="https://github.com/user-attachments/assets/e930d9f5-3046-4f41-9df6-bd0433096342" />

#### Regression test against the fixed component

1. `./run_e2e.sh tests/modelsPage/addModel.spec.ts --grep 'opens the provider dropdown below'`
2. Observed: `1 passed (5.1s)`
3. Restore the old flip policy on the component and re-run the same command
4. Observed: `1 failed`, `Expected: "bottom"`, `Received: "top"`
5. Instead raise the list cap in `ComboboxList` from `--spacing(72)` to `--spacing(96)` and re-run
6. Observed: `1 failed`, `Expected: 252`, `Received: 348`, so the test pins the clamp arithmetic and not just a relative row count

To check it by hand: open http://localhost:4000/ui?page=models, click Add Model, shrink the window so the Provider field sits low, click the field, and confirm the list opens below it with fewer rows. Scroll the page so the field sits higher, reopen it, and confirm more rows appear

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- With under ~10px below the field, the list renders too short to use
  - Base UI offers no "shrink to a minimum, then flip" threshold, so keeping it below is all or nothing
  - Scrolling the page a little restores a usable list

### Low

- Every `SearchSelect` now stays below its field instead of flipping
- The 7-row ceiling in `ComboboxList` is unchanged, so roomy viewports look the same as before

## QA runbook

- tests/e2e/ui/tests/modelsPage/addModel.spec.ts "opens the provider dropdown below its field, sized to the room left on screen" - the Provider list always opens below the field, inside the viewport, and shows more rows when more room is available
  - [ ] Set the browser to 1000 x 493 and open http://localhost:4000/ui?page=models, then click Add Model
  - [ ] Scroll the page so the Provider field sits low, click the field, and expect the list below the field with only the rows that fit
  - [ ] Press Escape, scroll the page so the field sits near the top, click the field again
  - [ ] Expect the list still below the field, still inside the window, with strictly more rows than before
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only combobox positioning for shared SearchSelect; no auth or API changes, with regression coverage on the Provider field.
> 
> **Overview**
> Fixes the **Add Model** Provider dropdown opening **above** its field and covering the input when the form sits low in a short viewport.
> 
> **`SearchSelect`** stops using collision avoidance that **shifted/flipped** the popup (`side: "shift"`, `fallbackAxisSide: "none"`) and instead sets **`collisionAvoidance: { side: "none" }`**, so the list stays **below** the trigger and can shrink to the vertical space left on screen (still subject to the existing list max height).
> 
> Adds a Playwright test on **Add Model** that scrolls `main`, asserts **`data-side="bottom`**, viewport containment, and that visible row count and list height grow when more room appears below the field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 931b24b45b0f3a54c8905c22112cb2e848991df1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->