### PR TITLE
fix(proxy): re-check key/team model allowlists on server-side fallbacks

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -1528,6 +1528,55 @@ def _timing_values(
     return getattr(logging_obj, "response_timing_metrics", None) or {}  # mutable-ok: empty fallback
 
 
+async def _filter_fallback_models_by_key_access(
+    fallback_models: Sequence[object],
+    user_api_key_dict: UserAPIKeyAuth,
+    llm_router: Router,
+) -> Sequence[object]:
+    """
+    Drop fallback targets the key/team is not allowed to call.
+
+    The rate-limit pre-call fallback swaps the request model after auth already
+    ran for the original model. Without this filter, a key restricted to one
+    model group would be rerouted to any model group the config (or the key's
+    router_settings) lists as a fallback. Mirrors the client-side fallback
+    checks in _enforce_key_and_fallback_model_access.
+    """
+    from litellm.proxy._types import ProxyException
+    from litellm.proxy.auth.auth_checks import (  # pyright: ignore[reportPrivateUsage]  # auth_checks exposes no public pair; budget blocks adding one
+        _can_object_call_model,
+        can_key_call_model,
+    )
+
+    allowed: list[object] = []  # mutable-ok: builds the filtered fallback list this function returns
+    for fallback_model in fallback_models:
+        if not isinstance(fallback_model, str):
+            # dict-form fallback entries ({model, messages}) re-run auth below
+            # via common_processing_pre_call_logic's model extraction; keep them.
+            allowed.append(fallback_model)
+            continue
+        try:
+            await can_key_call_model(
+                model=fallback_model,
+                llm_model_list=None,
+                valid_token=user_api_key_dict,
+                llm_router=llm_router,
+            )
+            if user_api_key_dict.team_models:
+                _can_object_call_model(
+                    model=fallback_model,
+                    llm_router=llm_router,
+                    models=user_api_key_dict.team_models,
+                    team_model_aliases=user_api_key_dict.team_model_aliases,
+                    team_id=user_api_key_dict.team_id,
+                    object_type="team",
+                )
+        except ProxyException:
+            continue
+        allowed.append(fallback_model)
+    return allowed
+
+
 class ProxyBaseLLMRequestProcessing:
     def __init__(self, data: dict):
         self.data = data
@@ -2083,8 +2132,20 @@ class ProxyBaseLLMRequestProcessing:
                 fallback_models,
             )
 
+            # Re-run the key/team model allowlist for each fallback target.
+            # Auth already ran for the original model; swapping the model here
+            # must not widen access to model groups the key is denied. Mirrors
+            # the client-side fallback checks in _enforce_key_and_fallback_model_access.
+            allowed_fallback_models: Final = await _filter_fallback_models_by_key_access(
+                fallback_models=fallback_models,
+                user_api_key_dict=user_api_key_dict,
+                llm_router=llm_router,
+            )
+            if not allowed_fallback_models:
+                raise
+
             try:
-                for fallback_model in fallback_models:
+                for fallback_model in allowed_fallback_models:
                     if fallback_model == original_model:
                         continue
                     self.data["model"] = fallback_model

--- a/litellm/router_utils/fallback_event_handlers.py
+++ b/litellm/router_utils/fallback_event_handlers.py
@@ -446,6 +446,68 @@ def creates_provider_scoped_resource(kwargs: Mapping[str, object]) -> bool:
     return getattr(kwargs.get("original_function"), "__name__", None) in PROVIDER_SCOPED_CREATION_FUNCTION_NAMES
 
 
+async def _proxy_key_allows_fallback_model(
+    litellm_router: LitellmRouter,
+    kwargs: Mapping[str, object],
+    fallback_entry: str | Mapping[str, object],
+) -> bool:
+    """
+    Re-run the proxy's key/team model allowlist for a server-side fallback target.
+
+    Proxy requests carry the authenticated ``UserAPIKeyAuth`` on their metadata
+    (``user_api_key_auth``, set in ``add_user_api_key_auth_to_request_metadata``).
+    The allowlist is enforced at auth time for the request's primary model and
+    for client-supplied fallbacks in the request body, but a router-configured
+    fallback swaps the model after auth already ran -- without this check a key
+    restricted to one model group would be served by any shared deployment the
+    config lists as a fallback for it. Mirrors the budget_fallbacks re-check in
+    ``_check_key_model_budget_with_fallback``. Non-proxy (SDK) callers carry no
+    auth object and are unaffected.
+    """
+    metadata: Final = kwargs.get("metadata")
+    if not isinstance(metadata, Mapping):
+        return True
+    auth: Final = metadata.get("user_api_key_auth")
+    if auth is None:
+        return True
+    model: Final = _get_fallback_target_model_group(fallback_entry)
+    if model is None:
+        return True
+
+    # Inline import: the proxy layer is only reachable when the proxy populated
+    # the metadata above, and a module-level import would be circular.
+    from litellm.proxy._types import ProxyException
+    from litellm.proxy.auth.auth_checks import (  # pyright: ignore[reportPrivateUsage]  # auth_checks exposes no public pair; budget blocks adding one
+        _can_object_call_model,
+        can_key_call_model,
+    )
+
+    try:
+        await can_key_call_model(
+            model=model,
+            llm_model_list=None,
+            valid_token=auth,
+            llm_router=litellm_router,
+        )
+        team_models: Final = getattr(auth, "team_models", None)
+        if team_models:
+            _can_object_call_model(
+                model=model,
+                llm_router=litellm_router,
+                models=team_models,
+                team_model_aliases=getattr(auth, "team_model_aliases", None),
+                team_id=getattr(auth, "team_id", None),
+                object_type="team",
+            )
+    except ProxyException:
+        verbose_router_logger.info(
+            "Skipping fallback to model_group = %s: not allowed for this key/team.",
+            mask_sensitive_structure(model),
+        )
+        return False
+    return True
+
+
 async def run_async_fallback(
     *args: object,
     litellm_router: LitellmRouter,
@@ -529,6 +591,12 @@ async def run_async_fallback(
                 continue
             attempted.record(attempt_key)
         try:
+            if not await _proxy_key_allows_fallback_model(
+                litellm_router=litellm_router,
+                kwargs=kwargs,
+                fallback_entry=mg,
+            ):
+                continue
             # LOGGING
             kwargs = litellm_router.log_retry(kwargs=kwargs, e=original_exception)
             verbose_router_logger.info("Falling back to model_group = %s", mask_sensitive_structure(mg))


### PR DESCRIPTION
## Summary

`user_api_key_auth` enforces the key/team model allowlist for the PRIMARY model of a request and even for CLIENT-side fallbacks passed in the request body (`_enforce_key_and_fallback_model_access`); `budget_fallbacks` are re-checked too — the docs for that path already state fallbacks "cannot bypass model authorization". But SERVER-side router fallbacks (`router_settings.fallbacks`, `context_window_fallbacks`, `content_policy_fallbacks`, per-key `router_settings`) were never re-checked: when the primary deployment fails, `run_async_fallback` swaps `kwargs["model"]` to the fallback model group and re-dispatches with no allowlist re-check.

So a virtual key restricted to `model-a` could reach `model-b` by deterministically failing the primary (e.g. oversized prompt -> `ContextWindowExceededError` -> `context_window_fallbacks`), served with model-b's deployment credentials — and since deployments without `model_info.team_id` are usable by any team, shared fallback targets are reachable cross-allowlist.

## Fix

- `fallback_event_handlers.py`: before re-dispatch, re-run the key allowlist (`can_key_call_model`) and, for team keys, the team allowlist (`_can_object_call_model`) for each fallback target (`_proxy_key_allows_fallback_model`), mirroring auth-time semantics; dict-form fallback entries re-run auth through the normal pre-call path.
- `common_request_processing.py`: filter the pre-call rate-limit fallback list the same way (`_filter_fallback_models_by_key_access`), since that path also swaps the model after auth already ran.

Unrestricted keys (`models: []`) are unaffected — there is no allowlist to enforce.

## PoC evidence

Local proxy with two mock backends, `fallbacks: {model-a: [model-b]}`, key restricted to `model-a`:

- **Pre-fix (current `litellm_internal_staging`):** direct `model-b` -> 403 and body-fallback -> 403 (boundary enforced), but `model-a` -> trigger failure -> server-side fallback served **model-b with 200** using `sk-backend-B-credential` (bypass).
- **Post-fix (this branch):** both controls still 403; the attack now fails closed — the fallback re-dispatch is denied and the caller receives the fallback error instead of a completion from `model-b`.

## Test / lint

- `uvx ruff@0.15.3 check` + `format --check` on both changed files: clean (repo `ruff.toml`).
- Regression PoC flips bypass -> blocked on this branch (summary above).

Scoped deliberately to the router-side gap; client-side body fallbacks and `budget_fallbacks` were already gated.
