### PR TITLE
feat(ui): add key-scoped auto-router usage tab

### DIFF
--- a/litellm/proxy/db/autorouter_session_rollup.py
+++ b/litellm/proxy/db/autorouter_session_rollup.py
@@ -37,7 +37,9 @@ CACHE_TTL_1H_SECONDS: Final = 3600
 AUTOROUTER_BENCHMARKS_SQL: Final = """
 WITH windowed AS (
     SELECT * FROM "LiteLLM_AutoRouterSession"
-    WHERE last_turn_at >= $1::timestamp AND first_turn_at < $2::timestamp
+    WHERE last_turn_at >= $1::timestamp
+      AND first_turn_at < $2::timestamp
+      AND ($3::text IS NULL OR api_key = $3::text)
 ),
 tier_maps AS (
     SELECT router_name, router_type, jsonb_object_agg(tier, tier_turns) AS tier_turns

--- a/litellm/proxy/management_endpoints/auto_router_endpoints.py
+++ b/litellm/proxy/management_endpoints/auto_router_endpoints.py
@@ -645,6 +645,7 @@ async def get_auto_router_benchmarks(
         str | None, Query(description="YYYY-MM-DD UTC, inclusive (defaults to 30 days before end_date)")
     ] = None,
     end_date: Annotated[str | None, Query(description="YYYY-MM-DD UTC, inclusive (defaults to today)")] = None,
+    api_key: Annotated[str | None, Query(description="Filter to one virtual key token hash")] = None,
 ) -> AutoRouterBenchmarksResponse:
     """
     Benchmarks for the auto-router dashboard: session shape, savings against the configured
@@ -681,6 +682,7 @@ async def get_auto_router_benchmarks(
         AUTOROUTER_BENCHMARKS_SQL,
         start_day.isoformat(),
         (end_day + timedelta(days=1)).isoformat(),
+        api_key,
     )
     rows: Final = _SESSION_AGG_ROWS.validate_python(raw_rows or ())
     groups: Final = (

--- a/tests/proxy_behavior/spend/test_autorouter_session_rollup.py
+++ b/tests/proxy_behavior/spend/test_autorouter_session_rollup.py
@@ -169,6 +169,7 @@ async def test_the_benchmarks_aggregate_reads_only_overlapping_sessions(db):
         AUTOROUTER_BENCHMARKS_SQL,
         (T0 - timedelta(days=1)).isoformat(),
         (T0 + timedelta(days=1)).isoformat(),
+        None,
     )
     matching = [row for row in rows if row["router_name"] == router]
     assert len(matching) == 1
@@ -181,6 +182,33 @@ async def test_the_benchmarks_aggregate_reads_only_overlapping_sessions(db):
     assert grouped["session_seconds"] == pytest.approx(60.0)
 
 
+async def test_the_benchmarks_aggregate_can_filter_to_one_key(db):
+    router = f"r-{uuid.uuid4()}"
+    first_key = f"k-{uuid.uuid4()}"
+    second_key = f"k-{uuid.uuid4()}"
+    await _turn(db, first_key, "A", T0, session_id=f"s-{uuid.uuid4()}", router=router, saved=0.5)
+    await _turn(db, second_key, "A", T0, session_id=f"s-{uuid.uuid4()}", router=router, saved=9.0)
+
+    rows = await db.query_raw(
+        AUTOROUTER_BENCHMARKS_SQL,
+        (T0 - timedelta(days=1)).isoformat(),
+        (T0 + timedelta(days=1)).isoformat(),
+        first_key,
+    )
+    matching = [row for row in rows if row["router_name"] == router]
+    assert len(matching) == 1
+    assert matching[0]["sessions"] == 1
+    assert matching[0]["saved_spend"] == pytest.approx(0.5)
+
+    unknown_key_rows = await db.query_raw(
+        AUTOROUTER_BENCHMARKS_SQL,
+        (T0 - timedelta(days=1)).isoformat(),
+        (T0 + timedelta(days=1)).isoformat(),
+        f"k-{uuid.uuid4()}",
+    )
+    assert [row for row in unknown_key_rows if row["router_name"] == router] == []
+
+
 async def test_a_reconfigured_alias_reports_each_router_type_as_its_own_group(db):
     key = f"k-{uuid.uuid4()}"
     router = f"r-{uuid.uuid4()}"
@@ -191,6 +219,7 @@ async def test_a_reconfigured_alias_reports_each_router_type_as_its_own_group(db
         AUTOROUTER_BENCHMARKS_SQL,
         (T0 - timedelta(days=1)).isoformat(),
         (T0 + timedelta(days=1)).isoformat(),
+        None,
     )
     matching = sorted(
         (row for row in rows if row["router_name"] == router),
@@ -253,6 +282,7 @@ async def test_the_benchmarks_aggregate_sums_tier_turns_across_sessions(db):
         AUTOROUTER_BENCHMARKS_SQL,
         (T0 - timedelta(days=1)).isoformat(),
         (T0 + timedelta(days=1)).isoformat(),
+        None,
     )
     grouped = next(row for row in rows if row["router_name"] == router)
     assert grouped["tier_turns"] == {"simple": 2, "complex": 1}
@@ -280,6 +310,7 @@ async def test_tier_maps_stay_separate_per_router_type_on_a_reconfigured_alias(d
         AUTOROUTER_BENCHMARKS_SQL,
         (T0 - timedelta(days=1)).isoformat(),
         (T0 + timedelta(days=1)).isoformat(),
+        None,
     )
     by_type = {row["router_type"]: row["tier_turns"] for row in rows if row["router_name"] == router}
     assert by_type == {"complexity": {"medium": 1}, "quality": {"2": 1}}
@@ -294,6 +325,7 @@ async def test_a_window_with_no_tiered_turns_aggregates_to_an_empty_map(db):
         AUTOROUTER_BENCHMARKS_SQL,
         (T0 - timedelta(days=1)).isoformat(),
         (T0 + timedelta(days=1)).isoformat(),
+        None,
     )
     grouped = next(row for row in rows if row["router_name"] == router)
     assert grouped["tier_turns"] == {}

--- a/tests/test_litellm/proxy/management_endpoints/test_auto_router_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_auto_router_endpoints.py
@@ -489,6 +489,7 @@ class TestAutoRouterBenchmarks:
         monkeypatch: pytest.MonkeyPatch,
         rows: Sequence[Mapping[str, object]],
         model_list: Sequence[object],
+        api_key: str | None = None,
     ) -> AutoRouterBenchmarksResponse:
         from litellm.proxy import proxy_server
         from litellm.proxy.management_endpoints.auto_router_endpoints import get_auto_router_benchmarks
@@ -503,6 +504,7 @@ class TestAutoRouterBenchmarks:
             user_api_key_dict=ADMIN,
             start_date="2026-07-01",
             end_date="2026-08-01",
+            api_key=api_key,
         )
 
     ROW = _SessionAggRow(
@@ -652,8 +654,9 @@ class TestAutoRouterBenchmarks:
             user_api_key_dict=ADMIN,
             start_date="2026-07-01",
             end_date="2026-08-01",
+            api_key="key-hash",
         )
-        assert captured["params"] == ("2026-07-01T00:00:00", "2026-08-02T00:00:00")
+        assert captured["params"] == ("2026-07-01T00:00:00", "2026-08-02T00:00:00", "key-hash")
         assert response.routers_in_scope == 1
         assert response.groups[0].router_name == "live-auto"
         assert response.groups[0].saved_pct == response.totals.saved_pct == 75.0

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/AutoRouterBenchmarksTab.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/AutoRouterBenchmarksTab.test.tsx
@@ -22,7 +22,7 @@ vi.mock("@/components/shared/advanced_date_picker", () => ({
 
 import { useAutoRouters } from "@/app/(dashboard)/hooks/models/useModels";
 
-import AutoRouterBenchmarksTab from "./AutoRouterBenchmarksTab";
+import AutoRouterBenchmarksTab, { AutoRouterUsageView } from "./AutoRouterBenchmarksTab";
 import type {
   AutoRouterBenchmarkGroup,
   AutoRouterBenchmarksResponse,
@@ -359,11 +359,35 @@ describe("AutoRouterBenchmarksTab", () => {
     mockHook({ data: response([group()]) });
     const { dateValue, onDateChange } = renderTab();
 
-    expect(vi.mocked(useAutoRouterBenchmarks)).toHaveBeenCalledWith("sk-test", dateValue);
+    expect(vi.mocked(useAutoRouterBenchmarks)).toHaveBeenCalledWith("sk-test", dateValue, undefined);
     expect(screen.getByText("Jul 6 – Aug 5 (UTC)")).toBeInTheDocument();
 
     fireEvent.click(screen.getByTestId("date-picker"));
     expect(onDateChange).toHaveBeenCalledWith({ from: new Date(2026, 7, 1), to: new Date(2026, 7, 5) });
+  });
+
+  it("scopes the query to one key when the usage view is mounted for a key", () => {
+    mockHook({ data: response([group()]) });
+    const dateValue = { from: new Date(2026, 6, 6), to: new Date(2026, 7, 5) };
+    const activity = {
+      dateValue,
+      onDateChange: vi.fn(),
+      results: [],
+      loading: false,
+      isFetchingMore: false,
+      progress: { currentPage: 1, totalPages: 1 },
+      cancelled: false,
+      cancel: vi.fn(),
+    };
+    render(
+      <QueryClientProvider client={new QueryClient()}>
+        <AutoRouterUsageView accessToken="sk-test" activity={activity} apiKey="key-hash-1" />
+      </QueryClientProvider>,
+    );
+
+    expect(vi.mocked(useAutoRouterBenchmarks)).toHaveBeenCalledWith("sk-test", dateValue, "key-hash-1");
+    expect(screen.getByText("Total estimated savings")).toBeInTheDocument();
+    expect(screen.queryByRole("tab", { name: "Shadow Evals" })).not.toBeInTheDocument();
   });
 
   it("shows usage by default and mounts shadow evals only when its sub-tab is selected", () => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/AutoRouterBenchmarksTab.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/AutoRouterBenchmarksTab.tsx
@@ -273,12 +273,13 @@ const BenchmarksBody: React.FC<BenchmarksBodyProps> = ({ isPending, error, data,
 
 interface AutoRouterBenchmarksTabProps {
   accessToken: string | null;
-  activity: DailyActivityRange;
+  activity: Pick<DailyActivityRange, "dateValue" | "onDateChange">;
+  apiKey?: string;
 }
 
-const UsageView: React.FC<AutoRouterBenchmarksTabProps> = ({ accessToken, activity }) => {
+export const AutoRouterUsageView: React.FC<AutoRouterBenchmarksTabProps> = ({ accessToken, activity, apiKey }) => {
   const { dateValue, onDateChange } = activity;
-  const { data, isPending, error } = useAutoRouterBenchmarks(accessToken, dateValue);
+  const { data, isPending, error } = useAutoRouterBenchmarks(accessToken, dateValue, apiKey);
   const [selectedKey, setSelectedKey] = useState<string>(ALL_ROUTERS);
   const { data: autoRouters } = useAutoRouters();
 
@@ -347,7 +348,7 @@ const AutoRouterBenchmarksTab: React.FC<AutoRouterBenchmarksTabProps> = ({ acces
       </TabsList>
 
       <TabsContent value="usage" keepMounted={visitedTabs.includes("usage")}>
-        <UsageView accessToken={accessToken} activity={activity} />
+        <AutoRouterUsageView accessToken={accessToken} activity={activity} />
       </TabsContent>
       <TabsContent value="shadow-evals" keepMounted={visitedTabs.includes("shadow-evals")}>
         <ShadowEvalSection />

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/useAutoRouterBenchmarks.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/useAutoRouterBenchmarks.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it, vi } from "vitest";
 vi.mock("@/components/networking", () => ({ formatDate: vi.fn() }));
 vi.mock("@/lib/http/api", () => ({ $api: { useQuery: vi.fn() } }));
 
-import { benchmarksWindow } from "./useAutoRouterBenchmarks";
+import { $api } from "@/lib/http/api";
+
+import { benchmarksWindow, useAutoRouterBenchmarks } from "./useAutoRouterBenchmarks";
 
 const localDay =
   (offsetHours: number) =>
@@ -42,5 +44,32 @@ describe("benchmarksWindow", () => {
     const now = new Date("2026-08-21T19:00:00Z");
     expect(benchmarksWindow({ from: now }, now, pacific)).toEqual({});
     expect(benchmarksWindow({ to: now }, now, pacific)).toEqual({});
+  });
+});
+
+describe("useAutoRouterBenchmarks", () => {
+  const range = { from: new Date("2026-07-06T19:00:00Z"), to: new Date("2026-08-05T19:00:00Z") };
+
+  it("forwards the key hash as the endpoint's api_key filter", () => {
+    useAutoRouterBenchmarks("sk-test", range, "key-hash-1");
+
+    const [, path, init] = vi.mocked($api.useQuery).mock.calls.at(-1) as unknown as [
+      string,
+      string,
+      { params: { query: Record<string, string | undefined> } },
+    ];
+    expect(path).toBe("/auto_router/benchmarks");
+    expect(init.params.query.api_key).toBe("key-hash-1");
+  });
+
+  it("leaves the read deployment-wide when no key is given", () => {
+    useAutoRouterBenchmarks("sk-test", range);
+
+    const [, , init] = vi.mocked($api.useQuery).mock.calls.at(-1) as unknown as [
+      string,
+      string,
+      { params: { query: Record<string, string | undefined> } },
+    ];
+    expect(init.params.query.api_key).toBeUndefined();
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/useAutoRouterBenchmarks.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/useAutoRouterBenchmarks.ts
@@ -23,10 +23,10 @@ export const benchmarksWindow = (
   };
 };
 
-export const useAutoRouterBenchmarks = (accessToken: string | null, range: DateRange) =>
+export const useAutoRouterBenchmarks = (accessToken: string | null, range: DateRange, apiKey?: string) =>
   $api.useQuery(
     "get",
     "/auto_router/benchmarks",
-    { params: { query: benchmarksWindow(range, new Date()) } },
+    { params: { query: { ...benchmarksWindow(range, new Date()), api_key: apiKey } } },
     { enabled: Boolean(accessToken && range.from && range.to), retry: false },
   );

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/useDailyActivityRange.integration.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/useDailyActivityRange.integration.test.tsx
@@ -24,12 +24,18 @@ describe("useScopedDailyActivityRange wiring", () => {
     );
     global.fetch = mockFetch;
 
-    renderHook(() => useScopedDailyActivityRange("sk-token", { userId: "u1", apiKey: "hash-abc" }));
+    const activity = {
+      dateValue: { from: new Date(2026, 7, 1), to: new Date(2026, 7, 10) },
+      onDateChange: vi.fn(),
+    };
+    renderHook(() => useScopedDailyActivityRange("sk-token", { userId: "u1", apiKey: "hash-abc" }, activity));
 
     await waitFor(() => expect(mockFetch).toHaveBeenCalled());
 
     const url = String(mockFetch.mock.calls[0][0]);
     expect(url).toContain("user_id=u1");
     expect(url).toContain("api_key=hash-abc");
+    expect(url).toContain("start_date=2026-08-01");
+    expect(url).toContain("end_date=2026-08-10");
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/useDailyActivityRange.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/useDailyActivityRange.test.tsx
@@ -25,11 +25,19 @@ vi.mock("@/components/networking", () => ({
 }));
 
 import { userDailyActivityAggregatedCall } from "@/components/networking";
-import { useDailyActivityRange } from "./useDailyActivityRange";
+import { useActivityDateRange, useDailyActivityRange } from "./useDailyActivityRange";
 
 const argsOfLastCall = () => mockUsePaginatedDailyActivity.mock.calls.at(-1)?.[0].args as unknown[];
 
 describe("useDailyActivityRange", () => {
+  it("offers date-range state without starting a daily-activity query", () => {
+    const { result } = renderHook(() => useActivityDateRange());
+
+    expect(result.current.dateValue.from).toBeInstanceOf(Date);
+    expect(result.current.dateValue.to).toBeInstanceOf(Date);
+    expect(mockUsePaginatedDailyActivity).not.toHaveBeenCalled();
+  });
+
   it("queries every user's activity for an admin", () => {
     renderHook(() => useDailyActivityRange("test-token", "u1", "proxy_admin"));
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/useDailyActivityRange.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/useDailyActivityRange.ts
@@ -37,13 +37,18 @@ export interface DailyActivityScope {
   apiKey?: string | null;
 }
 
+export const useActivityDateRange = (): Pick<DailyActivityRange, "dateValue" | "onDateChange"> => {
+  const initialFrom = useMemo(() => new Date(new Date().getTime() - THIRTY_DAYS_MS), []);
+  const initialTo = useMemo(() => new Date(), []);
+  const [dateValue, setDateValue] = useState<DateRange>({ from: initialFrom, to: initialTo });
+  return { dateValue, onDateChange: setDateValue };
+};
+
 export const useScopedDailyActivityRange = (
   accessToken: string | null,
   scope: DailyActivityScope,
 ): DailyActivityRange => {
-  const initialFrom = useMemo(() => new Date(new Date().getTime() - THIRTY_DAYS_MS), []);
-  const initialTo = useMemo(() => new Date(), []);
-  const [dateValue, setDateValue] = useState<DateRange>({ from: initialFrom, to: initialTo });
+  const { dateValue, onDateChange } = useActivityDateRange();
 
   const startTime = dateValue.from ?? null;
   const endTime = dateValue.to ?? null;
@@ -63,7 +68,7 @@ export const useScopedDailyActivityRange = (
 
   return {
     dateValue,
-    onDateChange: setDateValue,
+    onDateChange,
     results: data.results as DailyData[],
     loading,
     isFetchingMore,

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/useDailyActivityRange.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/useDailyActivityRange.ts
@@ -37,7 +37,9 @@ export interface DailyActivityScope {
   apiKey?: string | null;
 }
 
-export const useActivityDateRange = (): Pick<DailyActivityRange, "dateValue" | "onDateChange"> => {
+export type ActivityDateRange = Pick<DailyActivityRange, "dateValue" | "onDateChange">;
+
+export const useActivityDateRange = (): ActivityDateRange => {
   const initialFrom = useMemo(() => new Date(new Date().getTime() - THIRTY_DAYS_MS), []);
   const initialTo = useMemo(() => new Date(), []);
   const [dateValue, setDateValue] = useState<DateRange>({ from: initialFrom, to: initialTo });
@@ -47,9 +49,8 @@ export const useActivityDateRange = (): Pick<DailyActivityRange, "dateValue" | "
 export const useScopedDailyActivityRange = (
   accessToken: string | null,
   scope: DailyActivityScope,
+  { dateValue, onDateChange }: ActivityDateRange,
 ): DailyActivityRange => {
-  const { dateValue, onDateChange } = useActivityDateRange();
-
   const startTime = dateValue.from ?? null;
   const endTime = dateValue.to ?? null;
   const { userId, apiKey = null } = scope;
@@ -82,7 +83,7 @@ export const useDailyActivityRange = (
   accessToken: string | null,
   userId: string | null,
   userRole: string,
-): DailyActivityRange =>
-  useScopedDailyActivityRange(accessToken, {
-    userId: spendScopeUserId(userRole, userId),
-  });
+): DailyActivityRange => {
+  const dateRange = useActivityDateRange();
+  return useScopedDailyActivityRange(accessToken, { userId: spendScopeUserId(userRole, userId) }, dateRange);
+};

--- a/ui/litellm-dashboard/src/components/templates/KeyAutoRouterUsageTab.integration.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/KeyAutoRouterUsageTab.integration.test.tsx
@@ -1,0 +1,92 @@
+import { screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { renderWithProviders, testQueryClient } from "../../../tests/test-utils";
+import KeyAutoRouterUsageTab from "./KeyAutoRouterUsageTab";
+
+vi.mock("@/app/(dashboard)/hooks/useAuthorized", () => ({
+  default: () => ({ accessToken: "test-token", userId: "admin-123", userRole: "Admin" }),
+}));
+
+const jsonResponse = (body: unknown) =>
+  new Response(JSON.stringify(body), { status: 200, headers: { "content-type": "application/json" } });
+
+const cache = {
+  coverage_pct: 100,
+  hit_rate_pct: 50,
+  same_model: { turns: 2, hits: 1, hit_rate_pct: 50 },
+  first_visit: { turns: 1, hits: 0, hit_rate_pct: 0 },
+  return_to_tier: { turns: 1, hits: 1, hit_rate_pct: 100 },
+  unordered_turns: 0,
+  return_misses_expired: 0,
+  return_misses_within_ttl: 0,
+  return_misses_unknown: 0,
+  ttl_5m_turns: 0,
+  ttl_1h_turns: 0,
+};
+
+const stats = {
+  sessions: 2,
+  turns: 4,
+  avg_turns_per_session: 2,
+  avg_session_seconds: 30,
+  avg_tokens_per_session: 100,
+  spend: 1.25,
+  saved_spend: 8.75,
+  baseline_spend: 10,
+  saved_pct: 87.5,
+  saved_per_session: 4.375,
+  cache,
+};
+
+const benchmarks = {
+  start_date: "2025-01-01",
+  end_date: "2025-01-31",
+  routers_in_scope: 2,
+  totals: stats,
+  groups: [
+    { router_name: "router-one", router_type: "complexity", tier_turns: { SIMPLE: 4 }, ...stats },
+    {
+      router_name: "router-two",
+      router_type: "complexity",
+      tier_turns: { SIMPLE: 1 },
+      ...stats,
+      spend: 0.25,
+      saved_spend: 0.75,
+      baseline_spend: 1,
+    },
+  ],
+};
+
+const noDeployments = { data: [], total_count: 0, current_page: 1, total_pages: 1, size: 1000 };
+const fetchMock = vi.fn(async (request: Request | string) => {
+  const url = typeof request === "string" ? request : request.url;
+  if (url.includes("/auto_router/benchmarks")) return jsonResponse(benchmarks);
+  return jsonResponse(noDeployments);
+});
+const requestedUrls = () =>
+  fetchMock.mock.calls.map(([request]) => (typeof request === "string" ? request : request.url));
+
+describe("KeyAutoRouterUsageTab", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    testQueryClient.clear();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  it("renders this key's spend, baseline, savings and per-router filter", async () => {
+    renderWithProviders(<KeyAutoRouterUsageTab accessToken="test-token" keyToken="key-hash-1" />);
+
+    expect(await screen.findByText("$8.75")).toBeInTheDocument();
+    expect(screen.getByText("Actual auto-router spend")).toBeInTheDocument();
+    expect(screen.getByText("$1.25")).toBeInTheDocument();
+    expect(screen.getByText("Estimated spend at highest-tier model")).toBeInTheDocument();
+    expect(screen.getByText("$10.00")).toBeInTheDocument();
+    expect(screen.getByText("Auto-router prompt caching")).toBeInTheDocument();
+    expect(screen.getAllByText("50.0%").length).toBeGreaterThan(0);
+    expect(screen.getByText("All auto-routers")).toBeInTheDocument();
+
+    const benchmarkUrl = new URL(requestedUrls().find((url) => url.includes("/auto_router/benchmarks")) ?? "");
+    expect(benchmarkUrl.searchParams.get("api_key")).toBe("key-hash-1");
+  });
+});

--- a/ui/litellm-dashboard/src/components/templates/KeyAutoRouterUsageTab.integration.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/KeyAutoRouterUsageTab.integration.test.tsx
@@ -75,7 +75,11 @@ describe("KeyAutoRouterUsageTab", () => {
   });
 
   it("renders this key's spend, baseline, savings and per-router filter", async () => {
-    renderWithProviders(<KeyAutoRouterUsageTab accessToken="test-token" keyToken="key-hash-1" />);
+    const activity = {
+      dateValue: { from: new Date(2025, 0, 1), to: new Date(2025, 0, 31) },
+      onDateChange: vi.fn(),
+    };
+    renderWithProviders(<KeyAutoRouterUsageTab accessToken="test-token" keyToken="key-hash-1" activity={activity} />);
 
     expect(await screen.findByText("$8.75")).toBeInTheDocument();
     expect(screen.getByText("Actual auto-router spend")).toBeInTheDocument();
@@ -88,5 +92,7 @@ describe("KeyAutoRouterUsageTab", () => {
 
     const benchmarkUrl = new URL(requestedUrls().find((url) => url.includes("/auto_router/benchmarks")) ?? "");
     expect(benchmarkUrl.searchParams.get("api_key")).toBe("key-hash-1");
+    expect(benchmarkUrl.searchParams.get("start_date")).toBe("2025-01-01");
+    expect(benchmarkUrl.searchParams.get("end_date")).toBe("2025-01-31");
   });
 });

--- a/ui/litellm-dashboard/src/components/templates/KeyAutoRouterUsageTab.tsx
+++ b/ui/litellm-dashboard/src/components/templates/KeyAutoRouterUsageTab.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import React from "react";
+
+import { AutoRouterUsageView } from "@/app/(dashboard)/cost-optimization/_components/AutoRouterBenchmarksTab";
+import { useActivityDateRange } from "@/app/(dashboard)/cost-optimization/_components/useDailyActivityRange";
+
+interface KeyAutoRouterUsageTabProps {
+  accessToken: string | null;
+  keyToken: string;
+}
+
+const KeyAutoRouterUsageTab: React.FC<KeyAutoRouterUsageTabProps> = ({ accessToken, keyToken }) => (
+  <AutoRouterUsageView accessToken={accessToken} activity={useActivityDateRange()} apiKey={keyToken} />
+);
+
+export default KeyAutoRouterUsageTab;

--- a/ui/litellm-dashboard/src/components/templates/KeyAutoRouterUsageTab.tsx
+++ b/ui/litellm-dashboard/src/components/templates/KeyAutoRouterUsageTab.tsx
@@ -3,15 +3,16 @@
 import React from "react";
 
 import { AutoRouterUsageView } from "@/app/(dashboard)/cost-optimization/_components/AutoRouterBenchmarksTab";
-import { useActivityDateRange } from "@/app/(dashboard)/cost-optimization/_components/useDailyActivityRange";
+import type { ActivityDateRange } from "@/app/(dashboard)/cost-optimization/_components/useDailyActivityRange";
 
 interface KeyAutoRouterUsageTabProps {
   accessToken: string | null;
   keyToken: string;
+  activity: ActivityDateRange;
 }
 
-const KeyAutoRouterUsageTab: React.FC<KeyAutoRouterUsageTabProps> = ({ accessToken, keyToken }) => (
-  <AutoRouterUsageView accessToken={accessToken} activity={useActivityDateRange()} apiKey={keyToken} />
+const KeyAutoRouterUsageTab: React.FC<KeyAutoRouterUsageTabProps> = ({ accessToken, keyToken, activity }) => (
+  <AutoRouterUsageView accessToken={accessToken} activity={activity} apiKey={keyToken} />
 );
 
 export default KeyAutoRouterUsageTab;

--- a/ui/litellm-dashboard/src/components/templates/KeySavingsTab.integration.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/KeySavingsTab.integration.test.tsx
@@ -46,6 +46,11 @@ const mockActivity = (
 
 const scopedRange = () => vi.spyOn(useScopedDailyActivityRangeModule, "useScopedDailyActivityRange");
 
+const activity = {
+  dateValue: { from: new Date(2025, 0, 1), to: new Date(2025, 0, 31) },
+  onDateChange: vi.fn(),
+};
+
 const renderTab = (props: Partial<React.ComponentProps<typeof KeySavingsTab>> = {}) =>
   render(
     <KeySavingsTab
@@ -53,6 +58,7 @@ const renderTab = (props: Partial<React.ComponentProps<typeof KeySavingsTab>> = 
       keyToken="key-abc123"
       userId="user-123"
       userRole="Internal User"
+      activity={activity}
       {...props}
     />,
   );
@@ -114,7 +120,7 @@ describe("KeySavingsTab", () => {
 
     renderTab({ userId: "user-456", userRole: "Internal User" });
 
-    expect(hook).toHaveBeenCalledWith("test-token", { userId: "user-456", apiKey: "key-abc123" });
+    expect(hook).toHaveBeenCalledWith("test-token", { userId: "user-456", apiKey: "key-abc123" }, activity);
     expect(screen.getByTestId("key-savings-scope-note")).toHaveTextContent("Showing your own requests");
   });
 
@@ -123,7 +129,7 @@ describe("KeySavingsTab", () => {
 
     renderTab({ userId: "admin-123", userRole: "Admin" });
 
-    expect(hook).toHaveBeenCalledWith("test-token", { userId: null, apiKey: "key-abc123" });
+    expect(hook).toHaveBeenCalledWith("test-token", { userId: null, apiKey: "key-abc123" }, activity);
     expect(screen.queryByTestId("key-savings-scope-note")).not.toBeInTheDocument();
   });
 
@@ -132,7 +138,7 @@ describe("KeySavingsTab", () => {
 
     renderTab({ userId: "org-admin-1", userRole: "Org Admin" });
 
-    expect(hook).toHaveBeenCalledWith("test-token", { userId: "org-admin-1", apiKey: "key-abc123" });
+    expect(hook).toHaveBeenCalledWith("test-token", { userId: "org-admin-1", apiKey: "key-abc123" }, activity);
     expect(screen.getByTestId("key-savings-scope-note")).toHaveTextContent("Showing your own requests");
   });
 });

--- a/ui/litellm-dashboard/src/components/templates/KeySavingsTab.tsx
+++ b/ui/litellm-dashboard/src/components/templates/KeySavingsTab.tsx
@@ -22,7 +22,10 @@ import {
   usd,
   withStartAnchor,
 } from "@/app/(dashboard)/cost-optimization/_components/costOptimizationUtils";
-import { useScopedDailyActivityRange } from "@/app/(dashboard)/cost-optimization/_components/useDailyActivityRange";
+import {
+  useScopedDailyActivityRange,
+  type ActivityDateRange,
+} from "@/app/(dashboard)/cost-optimization/_components/useDailyActivityRange";
 
 interface KeySavingsTabProps {
   accessToken: string | null;
@@ -30,19 +33,19 @@ interface KeySavingsTabProps {
   keyToken: string;
   userId: string | null;
   userRole: string;
+  activity: ActivityDateRange;
 }
 
-const KeySavingsTab: React.FC<KeySavingsTabProps> = ({ accessToken, keyToken, userId, userRole }) => {
+const KeySavingsTab: React.FC<KeySavingsTabProps> = ({ accessToken, keyToken, userId, userRole, activity }) => {
   // Proxy admins read the whole key. For anyone else the endpoint applies the caller's own user_id
   // alongside the key filter, so the figures cover only that viewer's requests on this key -- said
   // plainly in the scope note below rather than left to be misread as the key's total.
   const readsWholeKey = hasProxyWideSpendView(userRole);
-  const activity = useScopedDailyActivityRange(accessToken, {
-    userId: spendScopeUserId(userRole, userId),
-    apiKey: keyToken,
-  });
-
-  const { dateValue, onDateChange, results, loading, isFetchingMore } = activity;
+  const { dateValue, onDateChange, results, loading, isFetchingMore } = useScopedDailyActivityRange(
+    accessToken,
+    { userId: spendScopeUserId(userRole, userId), apiKey: keyToken },
+    activity,
+  );
   const startTime = dateValue.from ?? null;
   const endTime = dateValue.to ?? null;
 

--- a/ui/litellm-dashboard/src/components/templates/key_info_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.test.tsx
@@ -26,6 +26,10 @@ vi.mock("./key_edit_view", () => ({
   },
 }));
 
+vi.mock("./KeyAutoRouterUsageTab", () => ({
+  default: ({ keyToken }: { keyToken: string }) => <div data-testid="key-auto-router-usage">{keyToken}</div>,
+}));
+
 vi.mock("@/app/(dashboard)/hooks/useTeams", () => ({
   default: vi.fn(),
 }));
@@ -175,6 +179,22 @@ describe("KeyInfoView", () => {
   const openMoreKeyActions = async () => {
     await userEvent.click(await screen.findByRole("button", { name: /more key actions/i }));
   };
+
+  it("shows key-scoped auto-router usage as its own admin tab", async () => {
+    vi.mocked(useAuthorized).mockReturnValue({ ...baseUseAuthorizedMock, userRole: "Admin" });
+    renderWithProviders(<KeyInfoView keyData={MOCK_KEY_DATA} onClose={() => {}} keyId="test-key-id" teams={[]} />);
+
+    await userEvent.click(screen.getByRole("tab", { name: "Auto-router usage" }));
+
+    expect(screen.getByTestId("key-auto-router-usage")).toHaveTextContent("test-token-123");
+  });
+
+  it("does not offer the admin-only auto-router usage tab to an internal user", () => {
+    vi.mocked(useAuthorized).mockReturnValue({ ...baseUseAuthorizedMock, userRole: "Internal User" });
+    renderWithProviders(<KeyInfoView keyData={MOCK_KEY_DATA} onClose={() => {}} keyId="test-key-id" teams={[]} />);
+
+    expect(screen.queryByRole("tab", { name: "Auto-router usage" })).not.toBeInTheDocument();
+  });
 
   describe("last updated", () => {
     const renderWithTimestamps = (overrides: Partial<KeyResponse>) => {

--- a/ui/litellm-dashboard/src/components/templates/key_info_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.test.tsx
@@ -26,8 +26,28 @@ vi.mock("./key_edit_view", () => ({
   },
 }));
 
+import type { ActivityDateRange } from "@/app/(dashboard)/cost-optimization/_components/useDailyActivityRange";
+
+const AnalyticsDateControl = ({ activity, keyToken }: { activity: ActivityDateRange; keyToken: string }) => (
+  <div>
+    <span data-testid="key-auto-router-usage">{keyToken}</span>
+    <output aria-label="Selected dates">{activity.dateValue.from?.toISOString()}</output>
+    {[1, 10].map((day) => (
+      <button
+        key={day}
+        onClick={() => activity.onDateChange({ from: new Date(Date.UTC(2026, 7, day)), to: new Date(2026, 7, 20) })}
+      >
+        Select August {day}
+      </button>
+    ))}
+  </div>
+);
+
 vi.mock("./KeyAutoRouterUsageTab", () => ({
-  default: ({ keyToken }: { keyToken: string }) => <div data-testid="key-auto-router-usage">{keyToken}</div>,
+  default: (props: React.ComponentProps<typeof AnalyticsDateControl>) => <AnalyticsDateControl {...props} />,
+}));
+vi.mock("./KeySavingsTab", () => ({
+  default: (props: React.ComponentProps<typeof AnalyticsDateControl>) => <AnalyticsDateControl {...props} />,
 }));
 
 vi.mock("@/app/(dashboard)/hooks/useTeams", () => ({
@@ -187,6 +207,22 @@ describe("KeyInfoView", () => {
     await userEvent.click(screen.getByRole("tab", { name: "Auto-router usage" }));
 
     expect(screen.getByTestId("key-auto-router-usage")).toHaveTextContent("test-token-123");
+  });
+
+  it("preserves dates in both directions across unmounted analytics panels", async () => {
+    vi.mocked(useAuthorized).mockReturnValue({ ...baseUseAuthorizedMock, userRole: "Admin" });
+    renderWithProviders(<KeyInfoView keyData={MOCK_KEY_DATA} onClose={() => {}} keyId="test-key-id" teams={[]} />);
+
+    expect(screen.queryByLabelText("Selected dates")).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole("tab", { name: "Savings" }));
+    await userEvent.click(screen.getByRole("button", { name: "Select August 1" }));
+    await userEvent.click(screen.getByRole("tab", { name: "Auto-router usage" }));
+    expect(screen.getByLabelText("Selected dates")).toHaveTextContent("2026-08-01T00:00:00.000Z");
+    await userEvent.click(screen.getByRole("button", { name: "Select August 10" }));
+    await userEvent.click(screen.getByRole("tab", { name: "Settings" }));
+    expect(screen.queryByLabelText("Selected dates")).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole("tab", { name: "Savings" }));
+    expect(screen.getByLabelText("Selected dates")).toHaveTextContent("2026-08-10T00:00:00.000Z");
   });
 
   it("does not offer the admin-only auto-router usage tab to an internal user", () => {

--- a/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
@@ -16,8 +16,14 @@ import { modelGroupHref, teamDetailHref } from "@/utils/entityLinks";
 import { BadgeLink } from "@/components/shared/BadgeLink";
 import { KeyInfoHeader } from "./KeyInfoHeader";
 import KeySavingsTab from "./KeySavingsTab";
+import KeyAutoRouterUsageTab from "./KeyAutoRouterUsageTab";
 import { useEffect, useState } from "react";
-import { isProxyAdminRole, isUserTeamAdminForSingleTeam, rolesWithWriteAccess } from "../../utils/roles";
+import {
+  hasProxyWideSpendView,
+  isProxyAdminRole,
+  isUserTeamAdminForSingleTeam,
+  rolesWithWriteAccess,
+} from "../../utils/roles";
 import { mapDisplayToInternalNames, mapInternalToDisplayNames } from "../callback_info_helpers";
 import AutoRotationView from "../common_components/AutoRotationView";
 import DeleteResourceModal from "../common_components/DeleteResourceModal";
@@ -618,6 +624,11 @@ export default function KeyInfoView({
           <TabsTrigger value="savings" className="flex-none rounded-none px-4 py-2">
             Savings
           </TabsTrigger>
+          {hasProxyWideSpendView(userRole) && (
+            <TabsTrigger value="auto-router-usage" className="flex-none rounded-none px-4 py-2">
+              Auto-router usage
+            </TabsTrigger>
+          )}
           <TabsTrigger value="settings" className="flex-none rounded-none px-4 py-2">
             Settings
           </TabsTrigger>
@@ -763,6 +774,12 @@ export default function KeyInfoView({
               userRole={userRole}
             />
           </TabsContent>
+
+          {hasProxyWideSpendView(userRole) && (
+            <TabsContent value="auto-router-usage">
+              <KeyAutoRouterUsageTab accessToken={accessToken} keyToken={currentKeyData.token} />
+            </TabsContent>
+          )}
 
           {/* Settings Panel */}
           <TabsContent value="settings" keepMounted>

--- a/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
@@ -17,6 +17,7 @@ import { BadgeLink } from "@/components/shared/BadgeLink";
 import { KeyInfoHeader } from "./KeyInfoHeader";
 import KeySavingsTab from "./KeySavingsTab";
 import KeyAutoRouterUsageTab from "./KeyAutoRouterUsageTab";
+import { useActivityDateRange } from "@/app/(dashboard)/cost-optimization/_components/useDailyActivityRange";
 import { useEffect, useState } from "react";
 import {
   hasProxyWideSpendView,
@@ -87,6 +88,7 @@ export default function KeyInfoView({
   backButtonText = "Back to Keys",
 }: KeyInfoViewProps) {
   const { accessToken, userId: userID, userRole, premiumUser } = useAuthorized();
+  const activityDateRange = useActivityDateRange();
   const queryClient = useQueryClient();
   const canEditGuardrails = premiumUser || (userRole != null && rolesWithWriteAccess.includes(userRole));
   const { teams: teamsData } = useTeams();
@@ -772,12 +774,17 @@ export default function KeyInfoView({
               keyToken={currentKeyData.token}
               userId={userID}
               userRole={userRole}
+              activity={activityDateRange}
             />
           </TabsContent>
 
           {hasProxyWideSpendView(userRole) && (
             <TabsContent value="auto-router-usage">
-              <KeyAutoRouterUsageTab accessToken={accessToken} keyToken={currentKeyData.token} />
+              <KeyAutoRouterUsageTab
+                accessToken={accessToken}
+                keyToken={currentKeyData.token}
+                activity={activityDateRange}
+              />
             </TabsContent>
           )}
 

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -41392,6 +41392,8 @@ export interface operations {
                 start_date?: string | null;
                 /** @description YYYY-MM-DD UTC, inclusive (defaults to today) */
                 end_date?: string | null;
+                /** @description Filter to one virtual key token hash */
+                api_key?: string | null;
             };
             header?: never;
             path?: never;


### PR DESCRIPTION
## TLDR

Problem this solves:

- Auto-router usage can only be read deployment-wide
- A key's detail page shows its auto-router savings total but not the usage behind it
- `?api_key=` on `/auto_router/benchmarks` is silently ignored

How it solves it:

- `GET /auto_router/benchmarks` gains an optional `api_key` filter
- The filter lands on the rollup's primary-key column, index served
- Key detail pages get a separate Auto-router usage tab for proxy admins
- Auto-router reuses the Cost Optimization usage view, scoped to that key

Current head `b1d0c6ea26`: [Greptile 5/5, no blocking findings](https://github.com/BerriAI/litellm/pull/39999#issuecomment-5574471362), 84 successful checks, 1 skipped, Bugbot clean. Both review threads are resolved. The latest verdict supersedes the older 4/5 summary on `9c17332a6a`; the key detail view now owns one date controller shared by both analytics tabs across unmounts

## User Flow

Before: a proxy admin wanting one key's auto-router usage only gets the whole deployment's numbers

1. They open https://litellm-domain/ui/?page=api-keys&token=<hash> and click Savings
2. They see the four savings tiles and the chart, with an Auto-router savings dollar figure and nothing else about routing
3. They open https://litellm-domain/ui/?page=cost-optimization, Auto-Router tab, and see every key's sessions folded together
4. They try GET https://litellm-domain/auto_router/benchmarks?api_key=<hash> and get back the same deployment-wide totals as with no filter

After: the same admin reads that key's own sessions, tiers and savings from its page

1. They open https://litellm-domain/ui/?page=api-keys&token=<hash> and click Savings
2. The existing Savings tab is unchanged, and a separate Auto-router usage tab appears beside it
3. They click the separate Auto-router usage tab and see total estimated savings, spend vs highest-tier spend, routing by tier and the caching buckets for this key alone, on the same date range, with an All auto-routers selector
4. GET https://litellm-domain/auto_router/benchmarks?api_key=<hash> returns only that key's sessions, and an unknown hash returns zeros
5. A non-admin still sees the key page exactly as before, with no Auto-router usage tab

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Rig: proxy from this worktree on `127.0.0.1:4095`, its own Postgres, two heuristic complexity auto-routers (`arks-router`, `arks-router-2`) whose tiers are `openai/gpt-4o-mini` and `openai/gpt-4o` behind the sandbox gateway, so every turn is a real priced provider call. Two virtual keys, `alpha` and `beta`. Traffic sent once, before the fix, and the same rollup rows are read in both arms

```
for each of 5 turns: curl -s http://127.0.0.1:4095/v1/chat/completions -H "Authorization: Bearer $KEY" -H "x-litellm-session-id: $SESSION" -d '{"model":"<router>","messages":[{"role":"user","content":"..."}],"max_tokens":8}'
```

alpha: 2 turns in session a1 and 1 in a2 on `arks-router`, 1 turn in a3 on `arks-router-2`. beta: 1 turn in b1 on `arks-router`

```
$ docker exec arks-pg psql -U postgres -d litellm_arks -Atc 'SELECT left(api_key,12), router_name, session_id, turns FROM "LiteLLM_AutoRouterSession" ORDER BY 1,2,3'
517ea5a3113d|arks-router|arks-sess-a1|2
517ea5a3113d|arks-router|arks-sess-a2|1
517ea5a3113d|arks-router-2|arks-sess-a3|1
b99b8c48aca9|arks-router|arks-sess-b1|1
```

Each case runs `curl -s "http://127.0.0.1:4095/auto_router/benchmarks<query>" -H "Authorization: Bearer sk-arks-master" | jq -c '{routers_in_scope, totals: {sessions: .totals.sessions, turns: .totals.turns, spend: .totals.spend, saved: .totals.saved_spend}, groups: [.groups[] | {router_name, sessions, turns}]}'`

### Before (09e9fd5f60)

#### no filter

1. query: none
2. `{"routers_in_scope":2,"totals":{"sessions":4,"turns":5,"spend":0.0000357,"saved":0.0005593},"groups":[{"router_name":"arks-router","sessions":3,"turns":4},{"router_name":"arks-router-2","sessions":1,"turns":1}]}`

#### api_key=alpha

1. query: `?api_key=517ea5a3113d...`
2. `{"routers_in_scope":2,"totals":{"sessions":4,"turns":5,"spend":0.0000357,"saved":0.0005593},"groups":[{"router_name":"arks-router","sessions":3,"turns":4},{"router_name":"arks-router-2","sessions":1,"turns":1}]}` (identical to no filter)

#### api_key=beta

1. query: `?api_key=b99b8c48aca9...`
2. same deployment-wide payload as above

#### api_key=unknown

1. query: `?api_key=no-such-key`
2. `{"routers_in_scope":2,"totals":{"sessions":4,"turns":5}}`

#### key page

1. Open http://127.0.0.1:4095/ui/api-keys/?key=517ea5a3113d... as the proxy admin, click Savings
2. The tab strip reads Overview, Savings, Settings, so there is nowhere to read this key's routing, sessions or tier mix

<img width="1440" alt="Key page before: tabs are Overview, Savings, Settings" src="https://raw.githubusercontent.com/BerriAI/litellm/9b91b9f6f50b5d786d86bcac5fd1fb46f532d15b/autorouter-key-usage-before.png" />

### After (9c17332a6a)

#### no filter

1. query: none
2. `{"routers_in_scope":2,"totals":{"sessions":4,"turns":5,"spend":0.0000357,"saved":0.0005593},"groups":[{"router_name":"arks-router","sessions":3,"turns":4},{"router_name":"arks-router-2","sessions":1,"turns":1}]}` (unchanged)

#### api_key=alpha

1. query: `?api_key=517ea5a3113d...`
2. `{"routers_in_scope":2,"totals":{"sessions":3,"turns":4,"spend":0.00002955,"saved":0.00046295},"groups":[{"router_name":"arks-router","sessions":2,"turns":3},{"router_name":"arks-router-2","sessions":1,"turns":1}]}`

#### api_key=beta

1. query: `?api_key=b99b8c48aca9...`
2. `{"routers_in_scope":2,"totals":{"sessions":1,"turns":1,"spend":0.00000615,"saved":0.00009635},"groups":[{"router_name":"arks-router","sessions":1,"turns":1},{"router_name":"arks-router-2","sessions":0,"turns":0}]}`

#### api_key=unknown

1. query: `?api_key=no-such-key`
2. `{"routers_in_scope":2,"totals":{"sessions":0,"turns":0}}`

#### key page

1. Open http://127.0.0.1:4095/ui/api-keys/?key=517ea5a3113d... as the proxy admin
2. The tab strip now reads Overview, Savings, Auto-router usage, Settings, and Savings is unchanged
3. Click Auto-router usage: total estimated savings $0.0005 at -94%, actual auto-router spend $0.0000, estimated spend at highest-tier model $0.0005, over this key's 3 sessions, matching the `api_key=alpha` curl above

<img width="1440" alt="Auto-router usage tab for one key, all auto-routers" src="https://raw.githubusercontent.com/BerriAI/litellm/9b91b9f6f50b5d786d86bcac5fd1fb46f532d15b/autorouter-key-usage-after.png" />

4. Pick `arks-router-2` in the selector: savings narrow to $0.0001 for that router alone, and Routing by tier shows its 1 turn served by Simple at 100 percent on `cheap-tier`
5. Set Aug 1–10 in Savings, switch to Auto-router usage, and the same Aug 1–10 range remains selected. Change it to Sep 1–6 there, visit Settings, then return to Savings: Sep 1–6 remains selected

<img width="1440" alt="Auto-router usage tab filtered to one auto-router" src="https://raw.githubusercontent.com/BerriAI/litellm/9b91b9f6f50b5d786d86bcac5fd1fb46f532d15b/autorouter-key-usage-router-filter.png" />

The figures read in fractions of a cent because the rig's five turns are real `gpt-4o-mini` and `gpt-4o` calls capped at 8 output tokens

Query plan on 200,000 seeded sessions (Postgres 16): scoped `Bitmap Index Scan on LiteLLM_AutoRouterSession_pkey, Index Cond: (api_key = ...)`, 1.2 ms; unscoped keeps today's parallel seq scan, 10.8 ms

Mutation checks: reverting the SQL predicate to `($3::text IS NULL OR TRUE)` fails only `test_the_benchmarks_aggregate_can_filter_to_one_key` against real Postgres; dropping `api_key` from the hook's query fails `forwards the key hash as the endpoint's api_key filter`; dropping the key hash from `KeyAutoRouterUsageTab` fails the real-child integration test

## Type

🆕 New Feature

## Caveats (if any)

### Medium

- The Auto-router usage tab is proxy admin roles only, same gate as the Cost Optimization Auto-Router tab
  - The endpoint stays admin-only because its router list comes from the registry and the tier chart loads all deployments
  - Non-admins keep the Savings body as it was, including the Auto-router savings tile
- User detail pages get nothing here: the rollup has no user column
  - A join through key ownership would count by current owner, the daily rollup counts by requester
  - Adding the column needs a migration and leaves older sessions unattributed, so it is a separate decision

### Low

- The router picker lists every configured router, at zero when this key never used it, matching the global tab
- Sessions count whole when they overlap the range, so the Auto-router numbers can differ from the day-bucketed Overall tiles, as the note on the tab says

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are additive (optional query param, admin-only UI tab) on read-only analytics paths; unscoped benchmarks behavior is unchanged when `api_key` is omitted.
> 
> **Overview**
> Adds optional **`api_key`** filtering to **`GET /auto_router/benchmarks`**, wiring it through the **`LiteLLM_AutoRouterSession`** rollup SQL so scoped reads hit the primary key index; omitting the param keeps deployment-wide behavior.
> 
> On the dashboard, **`useAutoRouterBenchmarks`** sends that filter when a key hash is provided. **`AutoRouterUsageView`** is exported and reused from a new proxy-admin **Auto-router usage** tab on the virtual key page (**`KeyAutoRouterUsageTab`**), without the Cost Optimization Shadow Evals sub-tab.
> 
> **`useActivityDateRange`** lifts date-picker state to **`KeyInfoView`** so **Savings** and **Auto-router usage** share the same range when switching tabs; **`useScopedDailyActivityRange`** now takes that range as an argument instead of owning it internally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1d0c6ea26056e02de575e9956432bcb3ad7ea8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

