### PR TITLE
fix(mcp): canonicalize per-server oauth issuer

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
@@ -59,6 +59,9 @@ from litellm.proxy._experimental.mcp_server.oauth_utils import (
     TOKEN_NO_CACHE_HEADERS,
     build_upstream_oauth2_token_request,
     get_request_base_url,
+    legacy_per_server_authorization_server_url,
+    per_server_authorization_server_metadata_url,
+    per_server_authorization_server_url,
     resolve_upstream_resource,
     validate_trusted_redirect_uri,
     well_known_root_suffix,
@@ -2322,9 +2325,17 @@ async def _build_oauth_protected_resource_response(
     else:
         resource_url = f"{request_base_url}/mcp"
 
+    authorization_server_url: Final = (
+        per_server_authorization_server_url(request_base_url, mcp_server_name)
+        if explicitly_named and mcp_server_name
+        else legacy_per_server_authorization_server_url(request_base_url, mcp_server_name)
+        if mcp_server_name
+        else request_base_url
+    )
+
     if mcp_server is not None and mcp_server_name and mcp_server.is_dcr_bridge:
         return {
-            "authorization_servers": [f"{request_base_url}/{mcp_server_name}"],
+            "authorization_servers": [authorization_server_url],
             "resource": resource_url,
             "scopes_supported": (mcp_server.scopes if mcp_server.scopes else []),
         }
@@ -2383,9 +2394,7 @@ async def _build_oauth_protected_resource_response(
         }
 
     return {
-        "authorization_servers": [
-            (f"{request_base_url}/{mcp_server_name}" if mcp_server_name else f"{request_base_url}")
-        ],
+        "authorization_servers": [authorization_server_url],
         "resource": resource_url,
         "scopes_supported": (mcp_server.scopes if mcp_server and mcp_server.scopes else []),
     }
@@ -2560,6 +2569,7 @@ async def oauth_protected_resource_mcp(request: Request, mcp_server_name: str | 
 def _build_oauth_authorization_server_response(
     request: Request,
     mcp_server_name: str | None,
+    use_legacy_named_issuer: bool = False,
 ) -> dict:
     """Build OAuth authorization server metadata response (gateway-as-AS shape).
 
@@ -2588,7 +2598,13 @@ def _build_oauth_authorization_server_response(
 
     _raise_unless_oauth2_discovery_server(mcp_server, mcp_server_name, "not an OAuth authorization server")
 
-    issuer: Final = f"{request_base_url}/{mcp_server_name}" if explicitly_named else request_base_url
+    issuer: Final = (
+        legacy_per_server_authorization_server_url(request_base_url, mcp_server_name)
+        if explicitly_named and use_legacy_named_issuer
+        else per_server_authorization_server_url(request_base_url, mcp_server_name)
+        if explicitly_named
+        else request_base_url
+    )
 
     return {
         "issuer": issuer,
@@ -2633,6 +2649,7 @@ async def oauth_authorization_server_mcp(request: Request, mcp_server_name: str 
     return _build_oauth_authorization_server_response(
         request=request,
         mcp_server_name=mcp_server_name,
+        use_legacy_named_issuer=mcp_server_name is not None,
     )
 
 
@@ -2696,14 +2713,19 @@ async def jwks_json(request: Request):
 
 
 # Additional legacy pattern support
-@router.get("/.well-known/oauth-authorization-server/{mcp_server_name}/mcp")
+@router.get(f"/.well-known/oauth-authorization-server{well_known_root_suffix()}/{{mcp_server_name}}/mcp")
 async def oauth_authorization_server_legacy(request: Request, mcp_server_name: str):
     """
     OAuth authorization server discovery for legacy /{server_name}/mcp pattern.
     """
-    return _build_oauth_authorization_server_response(
+    _build_oauth_authorization_server_response(
         request=request,
         mcp_server_name=mcp_server_name,
+    )
+    request_base_url: Final = get_request_base_url(request)
+    return RedirectResponse(
+        per_server_authorization_server_metadata_url(request_base_url, mcp_server_name),
+        status_code=308,
     )
 
 

--- a/litellm/proxy/_experimental/mcp_server/oauth_utils.py
+++ b/litellm/proxy/_experimental/mcp_server/oauth_utils.py
@@ -180,6 +180,24 @@ def well_known_root_suffix() -> str:
     return "" if root == "/" else root
 
 
+def per_server_authorization_server_url(request_base_url: str, server_name: str) -> str:
+    return f"{request_base_url}/mcp/{server_name}"
+
+
+def legacy_per_server_authorization_server_url(request_base_url: str, server_name: str) -> str:
+    return f"{request_base_url}/{server_name}"
+
+
+def per_server_authorization_server_metadata_url(request_base_url: str, server_name: str) -> str:
+    return f"{request_base_url}/.well-known/oauth-authorization-server{well_known_root_suffix()}/mcp/{server_name}"
+
+
+def per_server_authorization_server_challenge(request: Request, server_name: str) -> str:
+    request_base_url: Final = get_request_base_url(request)
+    metadata_url: Final = per_server_authorization_server_metadata_url(request_base_url, server_name)
+    return f'Bearer authorization_uri="{metadata_url}"'
+
+
 def get_route_relative_request_path(scope: Scope) -> str:
     """The request path the MCP route shapes are written against: the raw ASGI path with the
     deployment's ``root_path`` removed.

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -51,8 +51,7 @@ from litellm.proxy._experimental.mcp_server.mcp_debug import MCPDebug
 from litellm.proxy._experimental.mcp_server.oauth_utils import (
     _redact_mcp_resource_url,
     get_passthrough_www_authenticate,
-    get_route_relative_request_path,
-    well_known_root_suffix,
+    per_server_authorization_server_challenge,
 )
 from litellm.proxy._experimental.mcp_server.utils import (
     LITELLM_MCP_SERVER_DESCRIPTION,
@@ -3802,23 +3801,14 @@ if MCP_AVAILABLE:
                             },
                         )
 
-                    request = StarletteRequest(scope)
-                    base_url = get_request_base_url(request)
-                    _path = get_route_relative_request_path(scope)
-
-                    # Pick the well-known AS-metadata form that matches the inbound route
-                    # so strict RFC 9728 §3.2 clients can resolve it correctly.
-                    as_metadata_root = f"{base_url}/.well-known/oauth-authorization-server{well_known_root_suffix()}"
-                    if _path.startswith(f"/mcp/{server_name}"):
-                        _as_url = f"{as_metadata_root}/mcp/{server_name}"
-                    else:
-                        _as_url = f"{as_metadata_root}/{server_name}"
-                    authorization_uri = f'Bearer authorization_uri="{_as_url}"'
-
                     raise HTTPException(
                         status_code=401,
                         detail="Unauthorized",
-                        headers={"www-authenticate": authorization_uri},
+                        headers={
+                            "www-authenticate": per_server_authorization_server_challenge(
+                                StarletteRequest(scope), server_name
+                            )
+                        },
                     )
 
                 if not oauth2_headers:

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
@@ -2472,6 +2472,7 @@ async def test_oauth_authorization_server_respects_x_forwarded_proto():
 
         from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
             oauth_authorization_server_mcp,
+            oauth_authorization_server_mcp_standard,
         )
         from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
             global_mcp_server_manager,
@@ -2505,13 +2506,19 @@ async def test_oauth_authorization_server_respects_x_forwarded_proto():
     mock_request.base_url = "http://litellm.example.com/"  # HTTP
     mock_request.headers = {"X-Forwarded-Proto": "https"}  # Behind HTTPS proxy
 
-    # Call the endpoint
-    response = await oauth_authorization_server_mcp(
+    legacy_response = await oauth_authorization_server_mcp(
+        request=mock_request,
+        mcp_server_name="test_oauth",
+    )
+    assert legacy_response["issuer"] == "https://litellm.example.com/test_oauth"
+
+    response = await oauth_authorization_server_mcp_standard(
         request=mock_request,
         mcp_server_name="test_oauth",
     )
 
     # Verify response uses HTTPS URLs
+    assert response["issuer"] == "https://litellm.example.com/mcp/test_oauth"
     assert response["authorization_endpoint"].startswith("https://litellm.example.com/")
     assert response["token_endpoint"].startswith("https://litellm.example.com/")
     assert response["registration_endpoint"].startswith("https://litellm.example.com/")
@@ -3367,16 +3374,16 @@ async def test_oauth_protected_resource_gateway_managed_oauth2_advertises_gatewa
         relay_response = await _build_oauth_protected_resource_response(
             request=mock_request, mcp_server_name="relay_mcp", use_standard_pattern=True
         )
-        assert relay_response["authorization_servers"] == ["https://litellm.example.com/relay_mcp"]
+        assert relay_response["authorization_servers"] == ["https://litellm.example.com/mcp/relay_mcp"]
         relay_legacy_response = await _build_oauth_protected_resource_response(
             request=mock_request, mcp_server_name="relay_mcp", use_standard_pattern=False
         )
-        assert relay_legacy_response["authorization_servers"] == ["https://litellm.example.com/relay_mcp"]
+        assert relay_legacy_response["authorization_servers"] == ["https://litellm.example.com/mcp/relay_mcp"]
 
         delegated_response = await _build_oauth_protected_resource_response(
             request=mock_request, mcp_server_name="delegated_mcp", use_standard_pattern=True
         )
-        assert delegated_response["authorization_servers"] == ["https://litellm.example.com/delegated_mcp"]
+        assert delegated_response["authorization_servers"] == ["https://litellm.example.com/mcp/delegated_mcp"]
     finally:
         global_mcp_server_manager.registry.clear()
 
@@ -3495,6 +3502,7 @@ def _create_oauth2_server(
     client_secret="test_client_secret",
     available_on_public_internet=True,
     delegate_auth_to_upstream: bool = False,
+    per_server_oauth_discovery: bool = False,
 ):
     """Helper to create a mock OAuth2 MCPServer."""
     from litellm.proxy._types import MCPTransport
@@ -3515,6 +3523,7 @@ def _create_oauth2_server(
         scopes=["read", "write"],
         available_on_public_internet=available_on_public_internet,
         delegate_auth_to_upstream=delegate_auth_to_upstream,
+        per_server_oauth_discovery=per_server_oauth_discovery,
     )
 
 
@@ -3676,7 +3685,7 @@ def test_authorization_server_metadata_resolves_server_by_id_when_name_lookup_fa
         )
 
     assert result["scopes_supported"] == server.scopes
-    assert result["issuer"] == f"https://llm.example.com/{server.server_id}"
+    assert result["issuer"] == f"https://llm.example.com/mcp/{server.server_id}"
     by_name.assert_called_once_with(server.server_id, client_ip=None)
     by_id.assert_called_once_with(server.server_id, client_ip=None)
 
@@ -8872,9 +8881,9 @@ def test_as_aggregate_route_reserves_mcp_for_the_aggregate():
         assert prm.status_code == 200
         assert prm.json()["authorization_servers"] == [asm.json()["issuer"]]
 
-        # the mcp-named server keeps its own document on the standard two-segment route
         per_server = client.get("/.well-known/oauth-authorization-server/mcp/mcp")
         assert per_server.status_code == 200
+        assert per_server.json()["issuer"] == "http://testserver/mcp/mcp"
         assert "/mcp/authorize" in per_server.json()["authorization_endpoint"]
     finally:
         global_mcp_server_manager.registry.clear()
@@ -8904,11 +8913,13 @@ async def test_bare_origin_discovery_resolves_single_server_not_aggregate():
     oauth2 server configured, the no-suffix /.well-known/oauth-{authorization-server,
     protected-resource} still resolves THAT server, so an existing single-server deployment's
     discovery is unchanged. The aggregate document lives only at the /mcp-suffixed routes."""
-    from fastapi import Request
+    from fastapi import FastAPI, Request
+    from fastapi.testclient import TestClient
 
     from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
         _build_oauth_authorization_server_response,
         _build_oauth_protected_resource_response,
+        router,
     )
     from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
         global_mcp_server_manager,
@@ -8919,7 +8930,7 @@ async def test_bare_origin_discovery_resolves_single_server_not_aggregate():
     global_mcp_server_manager.registry[oauth2_server.server_id] = oauth2_server
 
     mock_request = MagicMock(spec=Request)
-    mock_request.base_url = "https://llm.example.com/"
+    mock_request.base_url = "http://testserver/"
     mock_request.headers = {}
 
     try:
@@ -8929,43 +8940,63 @@ async def test_bare_origin_discovery_resolves_single_server_not_aggregate():
         )
         # per-server, not aggregate: the single server's name is in the endpoints
         assert "/test_oauth/authorize" in authorization_response["authorization_endpoint"]
-        assert authorization_response["issuer"] == "https://llm.example.com"
-        assert resource_response["authorization_servers"] == ["https://llm.example.com/test_oauth"]
+        assert authorization_response["issuer"] == "http://testserver"
+        assert resource_response["authorization_servers"] == ["http://testserver/test_oauth"]
+
+        app = FastAPI()
+        app.include_router(router)
+        client = TestClient(app)
+        named_authorization_response = client.get("/.well-known/oauth-authorization-server/test_oauth")
+        assert named_authorization_response.status_code == 200
+        assert named_authorization_response.json()["issuer"] == resource_response["authorization_servers"][0]
     finally:
         global_mcp_server_manager.registry.clear()
 
 
 @pytest.mark.asyncio
-async def test_named_discovery_issuer_matches_protected_resource_authorization_servers():
-    """RFC 8414 requires the issuer to equal the authorization server identifier the client
-    resolved the metadata from, which is the protected-resource authorization_servers entry."""
-    from fastapi import Request
+@pytest.mark.parametrize(
+    "resource_metadata_path",
+    (
+        "/.well-known/oauth-protected-resource/mcp/test_oauth",
+        "/.well-known/oauth-protected-resource/test_oauth/mcp",
+    ),
+)
+async def test_named_discovery_issuer_matches_protected_resource_authorization_servers(resource_metadata_path):
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
 
-    from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
-        _build_oauth_authorization_server_response,
-        _build_oauth_protected_resource_response,
-    )
-    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
-        global_mcp_server_manager,
-    )
+    from litellm.proxy._experimental.mcp_server.discoverable_endpoints import router
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import global_mcp_server_manager
 
     global_mcp_server_manager.registry.clear()
-    server = _create_oauth2_server(delegate_auth_to_upstream=True)
+    server = _create_oauth2_server(per_server_oauth_discovery=True)
     global_mcp_server_manager.registry[server.server_id] = server
-
-    mock_request = MagicMock(spec=Request)
-    mock_request.base_url = "https://llm.example.com/"
-    mock_request.headers = {}
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
 
     try:
-        resource_response = await _build_oauth_protected_resource_response(
-            request=mock_request, mcp_server_name="test_oauth", use_standard_pattern=True
+        resource_response = client.get(resource_metadata_path)
+        assert resource_response.status_code == 200
+        issuer = resource_response.json()["authorization_servers"][0]
+        assert issuer == "http://testserver/mcp/test_oauth"
+
+        authorization_response = client.get("/.well-known/oauth-authorization-server/mcp/test_oauth")
+        assert authorization_response.status_code == 200
+        assert authorization_response.json()["issuer"] == issuer
+
+        legacy_response = client.get("/.well-known/oauth-authorization-server/test_oauth")
+        assert legacy_response.status_code == 200
+        assert legacy_response.json()["issuer"] == "http://testserver/test_oauth"
+
+        legacy_alias_response = client.get(
+            "/.well-known/oauth-authorization-server/test_oauth/mcp",
+            follow_redirects=False,
         )
-        authorization_response = _build_oauth_authorization_server_response(
-            request=mock_request, mcp_server_name="test_oauth"
+        assert legacy_alias_response.status_code == 308
+        assert legacy_alias_response.headers["location"] == (
+            "http://testserver/.well-known/oauth-authorization-server/mcp/test_oauth"
         )
-        assert resource_response["authorization_servers"] == ["https://llm.example.com/test_oauth"]
-        assert authorization_response["issuer"] == resource_response["authorization_servers"][0]
     finally:
         global_mcp_server_manager.registry.clear()
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_oauth_passthrough.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_oauth_passthrough.py
@@ -617,7 +617,7 @@ async def test_oauth_protected_resource_dcr_bridge_returns_gateway_facade(auth_t
         else "https://gateway.example.com/sample_docs/mcp"
     )
     assert result == {
-        "authorization_servers": ["https://gateway.example.com/sample_docs"],
+        "authorization_servers": ["https://gateway.example.com/mcp/sample_docs"],
         "resource": expected_resource,
         "scopes_supported": ["read"],
     }

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -8137,13 +8137,13 @@ class TestPreemptive401ModeAware:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "original_path, expected_as_path",
+        "original_path",
         (
-            ("/litellm/mcp/interactive", "/litellm/.well-known/oauth-authorization-server/litellm/mcp/interactive"),
-            ("/litellm/interactive/mcp", "/litellm/.well-known/oauth-authorization-server/litellm/interactive"),
+            "/litellm/mcp/interactive",
+            "/litellm/interactive/mcp",
         ),
     )
-    async def test_gateway_as_metadata_challenge_under_server_root_path(self, original_path, expected_as_path):
+    async def test_gateway_as_metadata_challenge_under_server_root_path(self, original_path):
         """Under SERVER_ROOT_PATH the challenge must keep the spelling the client called and point at
         a route the proxy registered, so it has to compare a route-relative path and carry the root suffix."""
         from litellm.proxy._experimental.mcp_server import server as server_module
@@ -8181,7 +8181,9 @@ class TestPreemptive401ModeAware:
 
         assert exc.value.status_code == 401
         headers = {k.lower(): v for k, v in (exc.value.headers or {}).items()}
-        assert headers["www-authenticate"] == f'Bearer authorization_uri="http://testserver{expected_as_path}"'
+        assert headers["www-authenticate"] == (
+            'Bearer authorization_uri="http://testserver/litellm/.well-known/oauth-authorization-server/litellm/mcp/interactive"'
+        )
 
     @pytest.mark.asyncio
     async def test_gateway_managed_interactive_no_token_challenges_with_authorization_bearer(self):


### PR DESCRIPTION
## TLDR

Problem this solves:

- Per-server OAuth metadata can return the wrong issuer
- Strict clients reject discovery before authorization starts

How it solves it:

- Uses one canonical per-server authorization server identifier
- Redirects legacy discovery URLs to the canonical document

## User Flow

Before: a developer connecting Claude Code to an opted-in OAuth MCP server cannot finish strict issuer validation

1. They configure `http://localhost:4078/mcp/figma_relay` in Claude Code
2. Claude Code requests `GET http://localhost:4078/.well-known/oauth-protected-resource/mcp/figma_relay`
3. The response advertises `http://localhost:4078/figma_relay` as the authorization server
4. `GET http://localhost:4078/.well-known/oauth-authorization-server/mcp/figma_relay` returns issuer `http://localhost:4078/figma_relay`
5. A strict validator rejects the document because the URL identifies `http://localhost:4078/mcp/figma_relay`

After: the same developer reaches the OAuth registration step through consistent discovery

1. They configure `http://localhost:4078/mcp/figma_relay` in Claude Code
2. Claude Code requests `GET http://localhost:4078/.well-known/oauth-protected-resource/mcp/figma_relay`
3. The response advertises `http://localhost:4078/mcp/figma_relay` as the authorization server
4. `GET http://localhost:4078/.well-known/oauth-authorization-server/mcp/figma_relay` returns issuer `http://localhost:4078/mcp/figma_relay`
5. Claude Code accepts discovery and continues to `POST http://localhost:4078/figma_relay/register`

## Relevant issues

Fixes #39665

## Linear ticket

Resolves LIT-7078

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible
- [ ] I have received a Greptile Confidence Score of at least 4/5

## Screenshots / Proof of Fix

Config: one `auth_type: oauth2`, `oauth2_flow: authorization_code` server with `per_server_oauth_discovery: true`

### Before (60440ee4d3)

1. `curl -sS http://localhost:4078/.well-known/oauth-protected-resource/mcp/figma_relay | jq -c '{resource,authorization_servers}'`
2. Output: `{"resource":"http://localhost:4078/mcp/figma_relay","authorization_servers":["http://localhost:4078/figma_relay"]}`
3. `curl -sS http://localhost:4078/.well-known/oauth-authorization-server/mcp/figma_relay | jq -c '{issuer}'`
4. Output: `{"issuer":"http://localhost:4078/figma_relay"}`

### After (050121d775)

1. `curl -sS http://localhost:4078/.well-known/oauth-protected-resource/mcp/figma_relay | jq -c '{resource,authorization_servers}'`
2. Output: `{"resource":"http://localhost:4078/mcp/figma_relay","authorization_servers":["http://localhost:4078/mcp/figma_relay"]}`
3. `curl -sS http://localhost:4078/.well-known/oauth-authorization-server/mcp/figma_relay | jq -c '{issuer}'`
4. Output: `{"issuer":"http://localhost:4078/mcp/figma_relay"}`
5. Real Claude Code requests the protected-resource document, then the canonical authorization-server document, and continues to `POST /figma_relay/register`

## Type

🐛 Bug Fix

## Final Attestation

- [x] The tests check standard, legacy, aggregate, root, and reserved-name cases

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OAuth discovery URLs and redirects on authenticated MCP connect paths; mis-issuance would break strict clients or legacy integrations, though legacy routes preserve the old issuer and redirect old aliases.
> 
> **Overview**
> **Aligns per-server OAuth discovery** so protected-resource metadata, authorization-server `issuer`, and 401 `authorization_uri` challenges all point at the same canonical authorization server id `{base}/mcp/{server}` for explicitly named (standard MCP) discovery.
> 
> Protected-resource responses and default authorization-server metadata now build `authorization_servers` / `issuer` through shared helpers in `oauth_utils` instead of ad hoc `{base}/{server_name}` strings. The legacy well-known route `/.well-known/oauth-authorization-server/{server}` still returns issuer `{base}/{server}` via `use_legacy_named_issuer`, while `/.well-known/oauth-authorization-server/mcp/{server}` uses the canonical issuer. The legacy alias `/.well-known/oauth-authorization-server/{server}/mcp` **308-redirects** to the canonical authorization-server metadata URL rather than serving a mismatched document.
> 
> Gateway-managed interactive OAuth **401** challenges now always advertise the canonical metadata URL through `per_server_authorization_server_challenge`, replacing path-shape-specific logic in `server.py`. Root-resolved (unnamed) single-server discovery keeps advertising `{base}/{server}` where that behavior was intentional.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b54f40d8099d8b34a12e1084a7d6879e18d1935. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->