### PR TITLE
fix(proxy): price budget reservations at the above-272k and tiered rates

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -33,6 +33,7 @@ from litellm.litellm_core_utils.llm_cost_calc.utils import (
     generic_cost_per_token,
     get_billable_input_tokens,
     get_token_type_cost_breakdown,
+    normalize_service_tier,
     parse_prompt_tokens_details,
     select_cost_metric_for_model,
 )
@@ -109,7 +110,6 @@ from litellm.types.utils import (
     LlmProvidersSet,
     ModelInfo,
     PromptTokensDetailsWrapper,
-    ServiceTier,
     StandardBuiltInToolsParams,
     TranscriptionUsageDurationObject,
     TranscriptionUsageTokensObject,
@@ -893,20 +893,6 @@ def _map_traffic_type_to_service_tier(traffic_type: str | None) -> str | None:
     return service_tier
 
 
-def _normalize_service_tier(service_tier: object) -> str | None:
-    """
-    Reduce a service_tier value to a concrete billable tier string or None.
-
-    "auto" is a routing preference and any non-string value is not a billable
-    tier, so both defer to standard pricing (or to the tier the provider reports
-    on the response usage) instead of crashing the downstream cost-key lookup,
-    which calls service_tier.lower()
-    """
-    if not isinstance(service_tier, str) or service_tier.lower() == ServiceTier.AUTO.value:
-        return None
-    return service_tier
-
-
 def _extract_service_tier(source: object) -> str | None:
     """Read a raw ``service_tier`` off a response body or usage object, dict or pydantic model alike."""
     if isinstance(source, BaseModel):
@@ -1260,19 +1246,19 @@ def completion_cost(
         if service_tier is None and optional_params is not None:
             service_tier = optional_params.get("service_tier")
 
-        service_tier = _normalize_service_tier(service_tier)
+        service_tier = normalize_service_tier(service_tier)
 
         # Extract service_tier from completion_response if not provided
         if service_tier is None and completion_response is not None:
             service_tier = _extract_service_tier(completion_response)
 
-        service_tier = _normalize_service_tier(service_tier)
+        service_tier = normalize_service_tier(service_tier)
 
         # Extract service_tier from usage object if not provided
         if service_tier is None and cost_per_token_usage_object is not None:
             service_tier = _extract_service_tier(cost_per_token_usage_object)
 
-        service_tier = _normalize_service_tier(service_tier)
+        service_tier = normalize_service_tier(service_tier)
 
         selected_model: Final = _select_model_name_for_cost_calc(
             model=model,

--- a/litellm/integrations/anthropic_cache_control_hook.py
+++ b/litellm/integrations/anthropic_cache_control_hook.py
@@ -113,6 +113,11 @@ def _accepts_prompt_cache_breakpoint(block: object) -> bool:
 CARRY_UNMATCHED_MESSAGE_POINTS: Final = "_litellm_carry_unmatched_cache_control_points"
 
 
+def _sequence_field(request_body: Mapping[str, object], field: str) -> tuple[object, ...]:
+    value: Final = request_body.get(field)
+    return tuple(value) if isinstance(value, (list, tuple)) else ()
+
+
 class AnthropicCacheControlHook(CustomPromptManagement):
     def get_chat_completion_prompt(
         self,
@@ -603,6 +608,17 @@ class AnthropicCacheControlHook(CustomPromptManagement):
                 for tool in tools
             )
         return False
+
+    @staticmethod
+    def body_has_cache_control(request_body: Mapping[str, object]) -> bool:
+        """Whether a proxy request body marks a cache breakpoint of its own, on either surface a
+        breakpoint can arrive on: `messages` for chat completions and `input` for the Responses
+        API, alongside the `system` and `tools` blocks both surfaces share."""
+        return AnthropicCacheControlHook.request_has_cache_control(
+            messages=_sequence_field(request_body, "messages") + _sequence_field(request_body, "input"),
+            system=request_body.get("system"),
+            tools=_sequence_field(request_body, "tools"),
+        )
 
     @staticmethod
     def get_default_injection_points(

--- a/litellm/integrations/anthropic_cache_control_hook.py
+++ b/litellm/integrations/anthropic_cache_control_hook.py
@@ -573,13 +573,13 @@ class AnthropicCacheControlHook(CustomPromptManagement):
         """
         if all(point.get("_litellm_judged") for point in points):
             return False
-        return AnthropicCacheControlHook._request_has_cache_control(messages, system, tools)
+        return AnthropicCacheControlHook.request_has_cache_control(messages, system, tools)
 
     @staticmethod
-    def _request_has_cache_control(
-        messages: list[AllMessageValues],
-        system: str | list | None,
-        tools: list | None = None,
+    def request_has_cache_control(
+        messages: Iterable[object],
+        system: object = None,
+        tools: Iterable[object] | None = None,
     ) -> bool:
         """Return True if the request already carries any client-supplied cache_control.
 
@@ -649,7 +649,7 @@ class AnthropicCacheControlHook(CustomPromptManagement):
         if not supports_prompt_caching(model=model, custom_llm_provider=provider):
             return []
 
-        if AnthropicCacheControlHook._request_has_cache_control(messages, system, tools):
+        if AnthropicCacheControlHook.request_has_cache_control(messages, system, tools):
             return []
 
         control: Final = AnthropicCacheControlHook._default_control()

--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -1143,27 +1143,24 @@ def resolve_token_rates(
     *_above_Nk_tokens thresholds, service-tier rates, the regional-processing uplift of the host
     the request is sent to, and the provider's threshold inclusivity), so a caller that only knows
     the token counts ahead of the request, such as budget reservation, prices them the way the
-    finished request will be. Two of those can still move between the estimate and the bill: an
-    off-peak window open right now can close before the response lands, and a requested service
-    tier can come back billed at the standard rate. Each rate is therefore the highest of the
-    candidates rather than the one in force right now.
+    finished request will be. One of those can still move between the estimate and the bill: an
+    off-peak window open right now can close before the response lands, so each rate is the
+    highest of the off-peak and standard-hours candidates rather than the one in force right now.
     """
     standard_hours_info: Final[ModelInfo] = {**model_info, "off_peak_pricing": None}
     off_peak_variants: Final = (
         (model_info,) if model_info.get("off_peak_pricing") is None else (model_info, standard_hours_info)
     )
-    service_tiers: Final = (None,) if service_tier is None else (service_tier, None)
     return _highest_token_rates(
         tuple(
             _token_rates_at(
                 model_info=info,
                 usage=usage,
                 custom_llm_provider=custom_llm_provider,
-                service_tier=tier,
+                service_tier=service_tier,
                 current_time=current_time,
             )
             for info in off_peak_variants
-            for tier in service_tiers
         ),
         multiplier=_get_regional_uplift_multiplier(model_info, data_residency),
     )

--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -783,13 +783,18 @@ class PromptTokensDetailsResult(TypedDict):
 
 
 AUTO_CACHE_WRITING_PROVIDERS: Final = frozenset({"openai", "azure"})
+AUTO_CACHE_WRITING_MINIMUM_PROMPT_TOKENS: Final = 1024
 
 
-def provider_writes_prompt_to_cache_unasked(custom_llm_provider: object) -> bool:
+def provider_writes_prompt_to_cache_unasked(custom_llm_provider: object, prompt_tokens: int) -> bool:
     """OpenAI and Azure write a long prompt into their own cache without the request asking for it
-    and bill every written token at the cache-creation rate, which runs above the input rate.
-    Every other provider writes only the blocks a request marks with cache_control."""
-    return custom_llm_provider in AUTO_CACHE_WRITING_PROVIDERS
+    and bill every written token at the cache-creation rate, which runs above the input rate. Both
+    of them cache from 1024 tokens up and nothing below that, so a shorter prompt bills the plain
+    input rate. Every other provider writes only the blocks a request marks with cache_control."""
+    return (
+        custom_llm_provider in AUTO_CACHE_WRITING_PROVIDERS
+        and prompt_tokens >= AUTO_CACHE_WRITING_MINIMUM_PROMPT_TOKENS
+    )
 
 
 def normalize_service_tier(service_tier: object) -> str | None:

--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -1094,11 +1094,13 @@ def _token_rates_at(
     model_info: ModelInfo,
     usage: Usage,
     custom_llm_provider: str | None,
+    service_tier: str | None,
     current_time: datetime | None,
 ) -> TokenRates:
     (prompt_rate, completion_rate, cache_creation_rate, _, cache_read_rate) = _get_token_base_cost(
         model_info=model_info,
         usage=usage,
+        service_tier=service_tier,
         current_time=current_time,
         threshold_is_inclusive=_uses_inclusive_token_thresholds(custom_llm_provider),
     )
@@ -1110,10 +1112,20 @@ def _token_rates_at(
         reasoning_rate=_resolve_billed_reasoning_rate(
             model_info=model_info,
             usage=usage,
-            service_tier=None,
+            service_tier=service_tier,
             completion_base_cost=completion_rate,
             current_time=current_time,
         ),
+    )
+
+
+def _highest_token_rates(rates: Sequence[TokenRates], multiplier: float) -> TokenRates:
+    return TokenRates(
+        input_rate=max(rate.input_rate for rate in rates) * multiplier,
+        output_rate=max(rate.output_rate for rate in rates) * multiplier,
+        cache_read_rate=max(rate.cache_read_rate for rate in rates) * multiplier,
+        cache_creation_rate=max(rate.cache_creation_rate for rate in rates) * multiplier,
+        reasoning_rate=max(rate.billed_reasoning_rate for rate in rates) * multiplier,
     )
 
 
@@ -1121,37 +1133,39 @@ def resolve_token_rates(
     model_info: ModelInfo,
     usage: Usage,
     custom_llm_provider: str | None,
+    service_tier: str | None = None,
+    data_residency: str | None = None,
     current_time: datetime | None = None,
 ) -> TokenRates:
     """The highest per-token rates a request with this usage can be billed at.
 
     Applies the same rate selection generic_cost_per_token does (tiered_pricing tables,
-    *_above_Nk_tokens thresholds, the provider's threshold inclusivity), so a caller that only
-    knows the token counts ahead of the request, such as budget reservation, prices them the way
-    the finished request will be. An off-peak window open right now can close before the response
-    lands, which bills the whole request at the standard rate, so each rate is the higher of the
-    two. Service tiers are not applied: the rates are the model's standard ones.
+    *_above_Nk_tokens thresholds, service-tier rates, the regional-processing uplift of the host
+    the request is sent to, and the provider's threshold inclusivity), so a caller that only knows
+    the token counts ahead of the request, such as budget reservation, prices them the way the
+    finished request will be. Two of those can still move between the estimate and the bill: an
+    off-peak window open right now can close before the response lands, and a requested service
+    tier can come back billed at the standard rate. Each rate is therefore the highest of the
+    candidates rather than the one in force right now.
     """
-    rates_now: Final = _token_rates_at(
-        model_info=model_info,
-        usage=usage,
-        custom_llm_provider=custom_llm_provider,
-        current_time=current_time,
+    standard_hours_info: Final[ModelInfo] = {**model_info, "off_peak_pricing": None}
+    off_peak_variants: Final = (
+        (model_info,) if model_info.get("off_peak_pricing") is None else (model_info, standard_hours_info)
     )
-    if model_info.get("off_peak_pricing") is None:
-        return rates_now
-    standard_rates: Final = _token_rates_at(
-        model_info={**model_info, "off_peak_pricing": None},
-        usage=usage,
-        custom_llm_provider=custom_llm_provider,
-        current_time=current_time,
-    )
-    return TokenRates(
-        input_rate=max(rates_now.input_rate, standard_rates.input_rate),
-        output_rate=max(rates_now.output_rate, standard_rates.output_rate),
-        cache_read_rate=max(rates_now.cache_read_rate, standard_rates.cache_read_rate),
-        cache_creation_rate=max(rates_now.cache_creation_rate, standard_rates.cache_creation_rate),
-        reasoning_rate=max(rates_now.billed_reasoning_rate, standard_rates.billed_reasoning_rate),
+    service_tiers: Final = (None,) if service_tier is None else (service_tier, None)
+    return _highest_token_rates(
+        tuple(
+            _token_rates_at(
+                model_info=info,
+                usage=usage,
+                custom_llm_provider=custom_llm_provider,
+                service_tier=tier,
+                current_time=current_time,
+            )
+            for info in off_peak_variants
+            for tier in service_tiers
+        ),
+        multiplier=_get_regional_uplift_multiplier(model_info, data_residency),
     )
 
 

--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -782,6 +782,30 @@ class PromptTokensDetailsResult(TypedDict):
     audio_length_seconds: float
 
 
+AUTO_CACHE_WRITING_PROVIDERS: Final = frozenset({"openai", "azure"})
+
+
+def provider_writes_prompt_to_cache_unasked(custom_llm_provider: object) -> bool:
+    """OpenAI and Azure write a long prompt into their own cache without the request asking for it
+    and bill every written token at the cache-creation rate, which runs above the input rate.
+    Every other provider writes only the blocks a request marks with cache_control."""
+    return custom_llm_provider in AUTO_CACHE_WRITING_PROVIDERS
+
+
+def normalize_service_tier(service_tier: object) -> str | None:
+    """
+    Reduce a service_tier value to a concrete billable tier string or None.
+
+    "auto" is a routing preference and any non-string value is not a billable
+    tier, so both defer to standard pricing (or to the tier the provider reports
+    on the response usage) instead of crashing the downstream cost-key lookup,
+    which calls service_tier.lower()
+    """
+    if not isinstance(service_tier, str) or service_tier.lower() == ServiceTier.AUTO.value:
+        return None
+    return service_tier
+
+
 def parse_prompt_tokens_details(usage: Usage) -> PromptTokensDetailsResult:
     cache_hit_tokens: Final = cast(int | None, getattr(usage.prompt_tokens_details, "cached_tokens", 0)) or 0
     cache_creation_tokens: Final = (
@@ -1135,17 +1159,19 @@ def resolve_token_rates(
     custom_llm_provider: str | None,
     service_tier: str | None = None,
     data_residency: str | None = None,
+    vertex_location: str | None = None,
     current_time: datetime | None = None,
 ) -> TokenRates:
     """The highest per-token rates a request with this usage can be billed at.
 
     Applies the same rate selection generic_cost_per_token does (tiered_pricing tables,
-    *_above_Nk_tokens thresholds, service-tier rates, the regional-processing uplift of the host
-    the request is sent to, and the provider's threshold inclusivity), so a caller that only knows
-    the token counts ahead of the request, such as budget reservation, prices them the way the
-    finished request will be. One of those can still move between the estimate and the bill: an
-    off-peak window open right now can close before the response lands, so each rate is the
-    highest of the off-peak and standard-hours candidates rather than the one in force right now.
+    *_above_Nk_tokens thresholds, service-tier rates, the uplift of the regional OpenAI host or
+    non-global Vertex location the request is sent to, and the provider's threshold inclusivity),
+    so a caller that only knows the token counts ahead of the request, such as budget reservation,
+    prices them the way the finished request will be. One of those can still move between the
+    estimate and the bill: an off-peak window open right now can close before the response lands,
+    so each rate is the highest of the off-peak and standard-hours candidates rather than the one
+    in force right now.
     """
     standard_hours_info: Final[ModelInfo] = {**model_info, "off_peak_pricing": None}
     off_peak_variants: Final = (
@@ -1162,7 +1188,8 @@ def resolve_token_rates(
             )
             for info in off_peak_variants
         ),
-        multiplier=_get_regional_uplift_multiplier(model_info, data_residency),
+        multiplier=_get_regional_uplift_multiplier(model_info, data_residency)
+        * get_vertex_regional_endpoint_uplift(model_info, vertex_location),
     )
 
 

--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -1090,6 +1090,41 @@ def _resolve_billed_reasoning_rate(
     )
 
 
+def resolve_token_rates(
+    model_info: ModelInfo,
+    usage: Usage,
+    custom_llm_provider: str | None,
+    current_time: datetime | None = None,
+) -> TokenRates:
+    """Per-token rates a request with this usage is billed at.
+
+    Applies the same rate selection generic_cost_per_token does (tiered_pricing tables,
+    *_above_Nk_tokens thresholds, off-peak windows, the provider's threshold inclusivity),
+    so a caller that only knows the token counts ahead of the request, such as budget
+    reservation, prices them the way the finished request will be. Service tiers are not
+    applied: the rates are the model's standard ones.
+    """
+    (prompt_rate, completion_rate, cache_creation_rate, _, cache_read_rate) = _get_token_base_cost(
+        model_info=model_info,
+        usage=usage,
+        current_time=current_time,
+        threshold_is_inclusive=_uses_inclusive_token_thresholds(custom_llm_provider),
+    )
+    return TokenRates(
+        input_rate=prompt_rate,
+        output_rate=completion_rate,
+        cache_read_rate=cache_read_rate,
+        cache_creation_rate=cache_creation_rate,
+        reasoning_rate=_resolve_billed_reasoning_rate(
+            model_info=model_info,
+            usage=usage,
+            service_tier=None,
+            completion_base_cost=completion_rate,
+            current_time=current_time,
+        ),
+    )
+
+
 def generic_cost_per_token(
     model: str,
     usage: Usage,

--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -1090,20 +1090,12 @@ def _resolve_billed_reasoning_rate(
     )
 
 
-def resolve_token_rates(
+def _token_rates_at(
     model_info: ModelInfo,
     usage: Usage,
     custom_llm_provider: str | None,
-    current_time: datetime | None = None,
+    current_time: datetime | None,
 ) -> TokenRates:
-    """Per-token rates a request with this usage is billed at.
-
-    Applies the same rate selection generic_cost_per_token does (tiered_pricing tables,
-    *_above_Nk_tokens thresholds, off-peak windows, the provider's threshold inclusivity),
-    so a caller that only knows the token counts ahead of the request, such as budget
-    reservation, prices them the way the finished request will be. Service tiers are not
-    applied: the rates are the model's standard ones.
-    """
     (prompt_rate, completion_rate, cache_creation_rate, _, cache_read_rate) = _get_token_base_cost(
         model_info=model_info,
         usage=usage,
@@ -1122,6 +1114,44 @@ def resolve_token_rates(
             completion_base_cost=completion_rate,
             current_time=current_time,
         ),
+    )
+
+
+def resolve_token_rates(
+    model_info: ModelInfo,
+    usage: Usage,
+    custom_llm_provider: str | None,
+    current_time: datetime | None = None,
+) -> TokenRates:
+    """The highest per-token rates a request with this usage can be billed at.
+
+    Applies the same rate selection generic_cost_per_token does (tiered_pricing tables,
+    *_above_Nk_tokens thresholds, the provider's threshold inclusivity), so a caller that only
+    knows the token counts ahead of the request, such as budget reservation, prices them the way
+    the finished request will be. An off-peak window open right now can close before the response
+    lands, which bills the whole request at the standard rate, so each rate is the higher of the
+    two. Service tiers are not applied: the rates are the model's standard ones.
+    """
+    rates_now: Final = _token_rates_at(
+        model_info=model_info,
+        usage=usage,
+        custom_llm_provider=custom_llm_provider,
+        current_time=current_time,
+    )
+    if model_info.get("off_peak_pricing") is None:
+        return rates_now
+    standard_rates: Final = _token_rates_at(
+        model_info={**model_info, "off_peak_pricing": None},
+        usage=usage,
+        custom_llm_provider=custom_llm_provider,
+        current_time=current_time,
+    )
+    return TokenRates(
+        input_rate=max(rates_now.input_rate, standard_rates.input_rate),
+        output_rate=max(rates_now.output_rate, standard_rates.output_rate),
+        cache_read_rate=max(rates_now.cache_read_rate, standard_rates.cache_read_rate),
+        cache_creation_rate=max(rates_now.cache_creation_rate, standard_rates.cache_creation_rate),
+        reasoning_rate=max(rates_now.billed_reasoning_rate, standard_rates.billed_reasoning_rate),
     )
 
 

--- a/litellm/proxy/spend_tracking/budget_reservation.py
+++ b/litellm/proxy/spend_tracking/budget_reservation.py
@@ -1175,8 +1175,6 @@ def _max_cost_for_cost_info(
         request_body=request_body,
         model_info=model_info,
     )
-    if image_cost is not None:
-        return image_cost
 
     estimated_input_tokens: Final = _estimate_input_tokens(
         request_body=request_body,
@@ -1191,7 +1189,7 @@ def _max_cost_for_cost_info(
         model_info=model_info,
     )
     if estimated_input_tokens is None or output_tokens is None:
-        return None
+        return image_cost
 
     output_multiplier: Final = _get_output_multiplier(request_body=request_body)
     rates: Final = _token_rates_for_cost_info(
@@ -1203,7 +1201,9 @@ def _max_cost_for_cost_info(
     # output token at the higher of the standard and reasoning rates to avoid
     # under-reserving reasoning-heavy requests.
     output_rate: Final = max(rates.output_rate, rates.billed_reasoning_rate)
-    return (estimated_input_tokens * rates.input_rate) + (output_tokens * output_multiplier * output_rate)
+    token_cost: Final = (estimated_input_tokens * rates.input_rate) + (output_tokens * output_multiplier * output_rate)
+    # Image models are often priced per image and per token at once, so reserve the larger.
+    return token_cost if image_cost is None else max(image_cost, token_cost)
 
 
 def _estimate_image_generation_cost(

--- a/litellm/proxy/spend_tracking/budget_reservation.py
+++ b/litellm/proxy/spend_tracking/budget_reservation.py
@@ -14,7 +14,12 @@ import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.integrations.anthropic_cache_control_hook import AnthropicCacheControlHook
 from litellm.litellm_core_utils.duration_parser import duration_in_seconds
-from litellm.litellm_core_utils.llm_cost_calc.utils import TokenRates, resolve_token_rates
+from litellm.litellm_core_utils.llm_cost_calc.utils import (
+    TokenRates,
+    normalize_service_tier,
+    provider_writes_prompt_to_cache_unasked,
+    resolve_token_rates,
+)
 from litellm.llms.openai.data_residency import infer_openai_data_residency
 from litellm.proxy._types import (
     Litellm_EntityType,
@@ -1136,36 +1141,24 @@ def _input_cost_for_cost_info(
     )
 
 
-AUTO_PROMPT_CACHING_PROVIDERS: Final = frozenset({"openai", "azure"})
-
-
 def _billed_input_rate(
     rates: TokenRates,
     model_info: Mapping[str, object],
     request_body: Mapping[str, object],
 ) -> float:
-    """OpenAI writes a large prompt into its own cache without the request asking and bills every
-    written token at the cache-creation rate, so an input token there costs the higher of the two.
-    Every other provider writes only what the request marks with cache_control, and holding the
-    write rate for a request that marks nothing reserves above anything it can bill."""
+    """An input token costs the higher of the input and cache-creation rates wherever the prompt
+    lands in the provider's cache, since every written token bills at the write rate. Holding the
+    write rate for a request that marks nothing, on a provider that writes nothing unasked, would
+    reserve above anything the request can bill."""
     if _writes_the_prompt_to_cache(model_info=model_info, request_body=request_body):
         return max(rates.input_rate, rates.cache_creation_rate)
     return rates.input_rate
 
 
 def _writes_the_prompt_to_cache(model_info: Mapping[str, object], request_body: Mapping[str, object]) -> bool:
-    if model_info.get("litellm_provider") in AUTO_PROMPT_CACHING_PROVIDERS:
-        return True
-    return AnthropicCacheControlHook.request_has_cache_control(
-        messages=_blocks_in(request_body, "messages") + _blocks_in(request_body, "input"),
-        system=request_body.get("system"),
-        tools=_blocks_in(request_body, "tools"),
-    )
-
-
-def _blocks_in(request_body: Mapping[str, object], field: str) -> tuple[object, ...]:
-    value: Final = request_body.get(field)
-    return tuple(value) if isinstance(value, (list, tuple)) else ()
+    return provider_writes_prompt_to_cache_unasked(
+        model_info.get("litellm_provider")
+    ) or AnthropicCacheControlHook.body_has_cache_control(request_body)
 
 
 def _token_rates_for_cost_info(
@@ -1185,14 +1178,18 @@ def _token_rates_for_cost_info(
             total_tokens=input_tokens + output_tokens,
         ),
         custom_llm_provider=pricing.model_info.get("litellm_provider"),
-        service_tier=_requested_service_tier(request_body),
+        service_tier=_billed_service_tier(request_body=request_body, pricing=pricing),
         data_residency=pricing.data_residency,
+        vertex_location=pricing.vertex_location,
     )
 
 
-def _requested_service_tier(request_body: Mapping[str, object]) -> str | None:
-    service_tier: Final = request_body.get("service_tier")
-    return service_tier if isinstance(service_tier, str) else None
+def _billed_service_tier(request_body: Mapping[str, object], pricing: _DeploymentPricing) -> str | None:
+    """The tier the finished request bills on: its own `service_tier` when it names one, and
+    otherwise the tier the deployment pins, which the router applies to every request that does
+    not. "auto" leaves the choice to the provider, so it prices as the standard tier does."""
+    requested: Final = request_body.get("service_tier")
+    return normalize_service_tier(requested if isinstance(requested, str) else pricing.service_tier)
 
 
 def _estimate_request_max_cost_for_model(
@@ -1227,6 +1224,8 @@ def _max_cost_for_cost_info(
         request_body=request_body,
         model_info=pricing.model_info,
     )
+    if image_cost is not None:
+        return image_cost
 
     estimated_input_tokens: Final = _estimate_input_tokens(
         request_body=request_body,
@@ -1241,7 +1240,7 @@ def _max_cost_for_cost_info(
         model_info=pricing.model_info,
     )
     if estimated_input_tokens is None or output_tokens is None:
-        return image_cost
+        return None
 
     output_multiplier: Final = _get_output_multiplier(request_body=request_body)
     rates: Final = _token_rates_for_cost_info(
@@ -1250,17 +1249,30 @@ def _max_cost_for_cost_info(
         input_tokens=estimated_input_tokens,
         output_tokens=output_tokens,
     )
-    # The reasoning-token share is unknown before the request runs, so reserve every
-    # output token at the higher of the standard and reasoning rates to avoid
-    # under-reserving reasoning-heavy requests.
-    output_rate: Final = max(rates.output_rate, rates.billed_reasoning_rate)
     input_rate: Final = _billed_input_rate(
         rates=rates,
         model_info=pricing.model_info,
         request_body=request_body,
     )
-    token_cost: Final = (estimated_input_tokens * input_rate) + (output_tokens * output_multiplier * output_rate)
-    return token_cost if image_cost is None else max(image_cost, token_cost)
+    output_rate: Final = _billed_output_rate(rates=rates, model_info=pricing.model_info)
+    return (estimated_input_tokens * input_rate) + (output_tokens * output_multiplier * output_rate)
+
+
+def _billed_output_rate(rates: TokenRates, model_info: Mapping[str, object]) -> float:
+    """How much of the reasoning budget a response spends is unknown before it runs, so every
+    output token reserves at the higher of the standard and reasoning rates. An image model
+    priced only per image token is the exception: that rate belongs to the tokens of a generated
+    picture, which the per-image path reserves, and charging it for the text-completion cap an
+    image route never spends would hold tens of times the picture's price."""
+    if _prices_output_per_image_token(model_info):
+        return 0.0
+    return max(rates.output_rate, rates.billed_reasoning_rate)
+
+
+def _prices_output_per_image_token(model_info: Mapping[str, object]) -> bool:
+    return not _to_float(model_info.get("output_cost_per_token")) and bool(
+        _to_float(model_info.get("output_cost_per_image_token"))
+    )
 
 
 def _estimate_image_generation_cost(
@@ -1303,11 +1315,15 @@ def _estimate_image_generation_cost(
 
 @dataclass(frozen=True, slots=True)
 class _DeploymentPricing:
-    """A deployment's cost entry, with the pricing context that comes from the deployment
-    rather than the request: the regional host it is sent to sets a data-residency uplift."""
+    """A deployment's cost entry, with the pricing context that comes from the deployment rather
+    than the request: the regional host or Vertex location it is sent to carries a price uplift,
+    and a service tier pinned in its litellm_params bills every request that does not name its
+    own tier at that tier's rates."""
 
     model_info: ModelInfo
     data_residency: str | None = None
+    vertex_location: str | None = None
+    service_tier: str | None = None
 
 
 def _get_model_cost_info(model: str) -> ModelInfo:
@@ -1369,12 +1385,16 @@ def _deployment_cost_info(
     if model_info is None:
         return None
     api_base: Final = _get_value(litellm_params, "api_base")
+    vertex_location: Final = _get_value(litellm_params, "vertex_location") or litellm.vertex_location
+    service_tier: Final = _get_value(litellm_params, "service_tier")
     return _DeploymentPricing(
         model_info=model_info,
         data_residency=infer_openai_data_residency(
             custom_llm_provider=model_info.get("litellm_provider"),
             api_base=api_base if isinstance(api_base, str) else None,
         ),
+        vertex_location=vertex_location if isinstance(vertex_location, str) else None,
+        service_tier=service_tier if isinstance(service_tier, str) else None,
     )
 
 
@@ -1494,7 +1514,7 @@ def _estimate_output_tokens(
     route: str,
     model_info: Mapping[str, object],
 ) -> int | None:
-    if _bills_no_completion_tokens(route=route):
+    if _is_input_only_route(route=route):
         return 0
 
     requested: int | None = None
@@ -1546,17 +1566,13 @@ def _get_output_multiplier(request_body: dict) -> int:
     return output_multiplier
 
 
-def _bills_no_completion_tokens(route: str) -> bool:
-    """Image routes bill the picture, sized by the request's own `size` and `quality`, so the
-    completion-token fallback below would price a chat-shaped guess at the model's image-token
-    rate and reserve about sixty times what a 1024x1024 image costs."""
+def _is_input_only_route(route: str) -> bool:
     return any(
         route_part in route
         for route_part in (
             "embeddings",
             "rerank",
             "moderations",
-            "images/",
         )
     )
 

--- a/litellm/proxy/spend_tracking/budget_reservation.py
+++ b/litellm/proxy/spend_tracking/budget_reservation.py
@@ -1128,7 +1128,13 @@ def _input_cost_for_cost_info(
         input_tokens=estimated_input_tokens,
         output_tokens=0,
     )
-    return estimated_input_tokens * rates.input_rate
+    return estimated_input_tokens * _billed_input_rate(rates)
+
+
+def _billed_input_rate(rates: TokenRates) -> float:
+    """Providers write a large prompt into their own cache without the request asking and bill
+    every written token at the cache-creation rate, so an input token costs the higher of the two."""
+    return max(rates.input_rate, rates.cache_creation_rate)
 
 
 def _token_rates_for_cost_info(
@@ -1217,9 +1223,7 @@ def _max_cost_for_cost_info(
     # output token at the higher of the standard and reasoning rates to avoid
     # under-reserving reasoning-heavy requests.
     output_rate: Final = max(rates.output_rate, rates.billed_reasoning_rate)
-    # Providers write large prompts to their cache without being asked and bill the written
-    # tokens at the cache-creation rate, so reserve every input token at the higher of the two.
-    input_rate: Final = max(rates.input_rate, rates.cache_creation_rate)
+    input_rate: Final = _billed_input_rate(rates)
     token_cost: Final = (estimated_input_tokens * input_rate) + (output_tokens * output_multiplier * output_rate)
     return token_cost if image_cost is None else max(image_cost, token_cost)
 

--- a/litellm/proxy/spend_tracking/budget_reservation.py
+++ b/litellm/proxy/spend_tracking/budget_reservation.py
@@ -13,7 +13,7 @@ from fastapi import HTTPException, status
 import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.litellm_core_utils.duration_parser import duration_in_seconds
-from litellm.litellm_core_utils.llm_cost_calc.tiered_pricing import select_tier_for_input, tier_rate
+from litellm.litellm_core_utils.llm_cost_calc.utils import TokenRates, resolve_token_rates
 from litellm.proxy._types import (
     Litellm_EntityType,
     LiteLLM_TeamMembership,
@@ -36,6 +36,7 @@ from litellm.proxy.utils import PrismaClient, ProxyLogging
 from litellm.router import Router
 from litellm.types.proxy.model_access_group_budget import ModelAccessGroupBudget
 from litellm.types.router import DeploymentTypedDict
+from litellm.types.utils import ModelInfo, Usage
 
 
 @dataclass
@@ -1108,7 +1109,7 @@ def _input_cost_for_cost_info(
     request_body: dict,
     route: str,
     model: str,
-    model_info: Mapping[str, object],
+    model_info: ModelInfo,
     input_tokens: int | None = None,
 ) -> float | None:
     estimated_input_tokens: Final = _estimate_input_tokens(
@@ -1120,15 +1121,26 @@ def _input_cost_for_cost_info(
     )
     if estimated_input_tokens is None:
         return None
-    tiered_pricing: Final = model_info.get("tiered_pricing")
-    if isinstance(tiered_pricing, list) and tiered_pricing:
-        tier: Final = select_tier_for_input(tiered_pricing=tiered_pricing, input_tokens=estimated_input_tokens)
-        if tier is not None:
-            return estimated_input_tokens * tier_rate(tier, "input_cost_per_token")
-    input_cost_per_token: Final = _to_float(model_info.get("input_cost_per_token"))
-    if input_cost_per_token is None:
-        return None
-    return estimated_input_tokens * input_cost_per_token
+    rates: Final = _token_rates_for_cost_info(
+        model_info=model_info,
+        input_tokens=estimated_input_tokens,
+        output_tokens=0,
+    )
+    return estimated_input_tokens * rates.input_rate
+
+
+def _token_rates_for_cost_info(model_info: ModelInfo, input_tokens: int, output_tokens: int) -> TokenRates:
+    """The rates this request will be billed at, so a prompt past a *_above_Nk_tokens
+    threshold or inside a tiered_pricing tier is reserved at that price, not the base one."""
+    return resolve_token_rates(
+        model_info=model_info,
+        usage=Usage(
+            prompt_tokens=input_tokens,
+            completion_tokens=output_tokens,
+            total_tokens=input_tokens + output_tokens,
+        ),
+        custom_llm_provider=model_info.get("litellm_provider"),
+    )
 
 
 def _estimate_request_max_cost_for_model(
@@ -1156,7 +1168,7 @@ def _max_cost_for_cost_info(
     request_body: dict,
     route: str,
     model: str,
-    model_info: Mapping[str, object],
+    model_info: ModelInfo,
     input_tokens: int | None = None,
 ) -> float | None:
     image_cost: Final = _estimate_image_generation_cost(
@@ -1182,37 +1194,16 @@ def _max_cost_for_cost_info(
         return None
 
     output_multiplier: Final = _get_output_multiplier(request_body=request_body)
-    tiered_pricing: Final = model_info.get("tiered_pricing")
-    if isinstance(tiered_pricing, list) and tiered_pricing:
-        tier: Final = select_tier_for_input(tiered_pricing=tiered_pricing, input_tokens=estimated_input_tokens)
-        if tier is not None:
-            output_rate = max(
-                tier_rate(tier, "output_cost_per_token"),
-                tier_rate(tier, "output_cost_per_reasoning_token"),
-            )
-            return (estimated_input_tokens * tier_rate(tier, "input_cost_per_token")) + (
-                output_tokens * output_multiplier * output_rate
-            )
-
-    input_cost_per_token: Final = _to_float(model_info.get("input_cost_per_token"))
-    output_cost_per_token: Final = _to_float(model_info.get("output_cost_per_token"))
-    output_cost_per_reasoning_token: Final = _to_float(model_info.get("output_cost_per_reasoning_token"))
-    cost = 0.0
-    if input_cost_per_token is not None:
-        cost += estimated_input_tokens * input_cost_per_token
-    elif estimated_input_tokens > 0:
-        return None
-
+    rates: Final = _token_rates_for_cost_info(
+        model_info=model_info,
+        input_tokens=estimated_input_tokens,
+        output_tokens=output_tokens,
+    )
     # The reasoning-token share is unknown before the request runs, so reserve every
     # output token at the higher of the standard and reasoning rates to avoid
     # under-reserving reasoning-heavy requests.
-    output_rate = max(output_cost_per_token or 0.0, output_cost_per_reasoning_token or 0.0)
-    if output_cost_per_token is not None or output_cost_per_reasoning_token is not None:
-        cost += output_tokens * output_multiplier * output_rate
-    elif output_tokens > 0:
-        return None
-
-    return cost
+    output_rate: Final = max(rates.output_rate, rates.billed_reasoning_rate)
+    return (estimated_input_tokens * rates.input_rate) + (output_tokens * output_multiplier * output_rate)
 
 
 def _estimate_image_generation_cost(
@@ -1253,74 +1244,61 @@ def _estimate_image_generation_cost(
     return cost_per_image * max(n, 1)
 
 
-def _get_model_cost_info(
-    model: str,
-    llm_router: Router | None,
-) -> Mapping[str, object] | None:
-    if llm_router is not None:
-        model_group_info: Final = llm_router.get_model_group_info(model_group=model)
-        if model_group_info is not None:
-            return model_group_info.model_dump()
-    return dict(litellm.get_model_info(model=model))
+def _get_model_cost_info(model: str) -> ModelInfo:
+    return litellm.get_model_info(model=model)
 
 
 def _get_model_cost_infos(
     model: str,
     llm_router: Router | None,
-) -> Sequence[Mapping[str, object]]:
-    """Cost-info candidates to estimate a request against for one model group.
+) -> Sequence[ModelInfo]:
+    """Cost-info candidates to estimate a request against for one model name.
 
     Reservation runs before routing, so the deployment that will serve the request
-    is unknown. Rather than guess, we estimate the cost against every eligible
-    pricing shape in the group (the group's flat rates plus each deployment's
-    tiered table) and let the caller reserve the maximum, so a cheaper sibling
-    deployment can never leave the request under-reserved.
+    is unknown. Rather than guess, we estimate the cost against every deployment's
+    full pricing (its flat rates, *_above_Nk_tokens thresholds, and tiered table)
+    and let the caller reserve the maximum, so a cheaper sibling deployment can
+    never leave the request under-reserved. A name the router serves no deployment
+    for is priced from the public cost map entry of the name itself.
     """
     try:
-        base: Final = _get_model_cost_info(model=model, llm_router=llm_router)
-        if base is None:
-            return []
-        tiered_tables: Final = _get_deployment_tiered_pricing_tables(model=model, llm_router=llm_router)
+        deployment_infos: Final = _get_deployment_cost_infos(model=model, llm_router=llm_router)
+        if deployment_infos is not None:
+            return deployment_infos
+        return (_get_model_cost_info(model=model),)
     except Exception:
         verbose_proxy_logger.debug(
             "Unable to load model cost info for budget reservation",
             exc_info=True,
         )
-        return []
-    if not tiered_tables:
-        return [base]
-    return [base, *({**base, "tiered_pricing": table} for table in tiered_tables)]
+        return ()
 
 
-def _deployment_tiered_pricing_table(
+def _get_deployment_cost_infos(
+    model: str,
+    llm_router: Router | None,
+) -> Sequence[ModelInfo] | None:
+    if llm_router is None:
+        return None
+    deployments: Final = llm_router.get_model_list(model_name=model)
+    if not deployments:
+        return None
+    return tuple(
+        deployment_info
+        for deployment in deployments
+        if (deployment_info := _deployment_cost_info(deployment, llm_router)) is not None
+    )
+
+
+def _deployment_cost_info(
     deployment: DeploymentTypedDict,
     llm_router: Router,
-) -> Sequence[Mapping[str, object]] | None:
+) -> ModelInfo | None:
     model_id: Final = _get_value(_get_value(deployment, "model_info"), "id")
     backend_model: Final = _get_value(_get_value(deployment, "litellm_params"), "model")
     if not isinstance(model_id, str) or not isinstance(backend_model, str):
         return None
-    deployment_model_info: Final = llm_router.get_deployment_model_info(model_id=model_id, model_name=backend_model)
-    if deployment_model_info is None:
-        return None
-    tiered_pricing: Final = deployment_model_info.get("tiered_pricing")
-    if isinstance(tiered_pricing, list) and tiered_pricing:
-        return tiered_pricing
-    return None
-
-
-def _get_deployment_tiered_pricing_tables(
-    model: str,
-    llm_router: Router | None,
-) -> Sequence[Sequence[Mapping[str, object]]]:
-    if llm_router is None:
-        return []
-    deployments: Final = llm_router.get_model_list(model_name=model) or []
-    return [
-        table
-        for deployment in deployments
-        if (table := _deployment_tiered_pricing_table(deployment, llm_router)) is not None
-    ]
+    return llm_router.get_deployment_model_info(model_id=model_id, model_name=backend_model)
 
 
 def _get_request_models(

--- a/litellm/proxy/spend_tracking/budget_reservation.py
+++ b/litellm/proxy/spend_tracking/budget_reservation.py
@@ -1157,7 +1157,7 @@ def _writes_the_prompt_to_cache(model_info: Mapping[str, object], request_body: 
     if model_info.get("litellm_provider") in AUTO_PROMPT_CACHING_PROVIDERS:
         return True
     return AnthropicCacheControlHook.request_has_cache_control(
-        messages=_blocks_in(request_body, "messages"),
+        messages=_blocks_in(request_body, "messages") + _blocks_in(request_body, "input"),
         system=request_body.get("system"),
         tools=_blocks_in(request_body, "tools"),
     )

--- a/litellm/proxy/spend_tracking/budget_reservation.py
+++ b/litellm/proxy/spend_tracking/budget_reservation.py
@@ -14,6 +14,7 @@ import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.litellm_core_utils.duration_parser import duration_in_seconds
 from litellm.litellm_core_utils.llm_cost_calc.utils import TokenRates, resolve_token_rates
+from litellm.llms.openai.data_residency import infer_openai_data_residency
 from litellm.proxy._types import (
     Litellm_EntityType,
     LiteLLM_TeamMembership,
@@ -1096,10 +1097,10 @@ def _estimate_request_input_cost_for_model(
             request_body=request_body,
             route=route,
             model=model,
-            model_info=model_info,
+            pricing=pricing,
             input_tokens=input_tokens,
         )
-        for model_info in _get_model_cost_infos(model=model, llm_router=llm_router)
+        for pricing in _get_model_cost_infos(model=model, llm_router=llm_router)
     ]
     valid_estimates: Final = [estimate for estimate in estimates if estimate is not None]
     return max(valid_estimates) if valid_estimates else None
@@ -1109,38 +1110,52 @@ def _input_cost_for_cost_info(
     request_body: dict,
     route: str,
     model: str,
-    model_info: ModelInfo,
+    pricing: _DeploymentPricing,
     input_tokens: int | None = None,
 ) -> float | None:
     estimated_input_tokens: Final = _estimate_input_tokens(
         request_body=request_body,
         route=route,
         model=model,
-        model_info=model_info,
+        model_info=pricing.model_info,
         input_tokens=input_tokens,
     )
     if estimated_input_tokens is None:
         return None
     rates: Final = _token_rates_for_cost_info(
-        model_info=model_info,
+        request_body=request_body,
+        pricing=pricing,
         input_tokens=estimated_input_tokens,
         output_tokens=0,
     )
     return estimated_input_tokens * rates.input_rate
 
 
-def _token_rates_for_cost_info(model_info: ModelInfo, input_tokens: int, output_tokens: int) -> TokenRates:
+def _token_rates_for_cost_info(
+    request_body: Mapping[str, object],
+    pricing: _DeploymentPricing,
+    input_tokens: int,
+    output_tokens: int,
+) -> TokenRates:
     """The rates this request will be billed at, so a prompt past a *_above_Nk_tokens
-    threshold or inside a tiered_pricing tier is reserved at that price, not the base one."""
+    threshold, inside a tiered_pricing tier, sent on a service tier, or bound for a
+    regional host is reserved at that price rather than the model's base one."""
     return resolve_token_rates(
-        model_info=model_info,
+        model_info=pricing.model_info,
         usage=Usage(
             prompt_tokens=input_tokens,
             completion_tokens=output_tokens,
             total_tokens=input_tokens + output_tokens,
         ),
-        custom_llm_provider=model_info.get("litellm_provider"),
+        custom_llm_provider=pricing.model_info.get("litellm_provider"),
+        service_tier=_requested_service_tier(request_body),
+        data_residency=pricing.data_residency,
     )
+
+
+def _requested_service_tier(request_body: Mapping[str, object]) -> str | None:
+    service_tier: Final = request_body.get("service_tier")
+    return service_tier if isinstance(service_tier, str) else None
 
 
 def _estimate_request_max_cost_for_model(
@@ -1155,10 +1170,10 @@ def _estimate_request_max_cost_for_model(
             request_body=request_body,
             route=route,
             model=model,
-            model_info=model_info,
+            pricing=pricing,
             input_tokens=input_tokens,
         )
-        for model_info in _get_model_cost_infos(model=model, llm_router=llm_router)
+        for pricing in _get_model_cost_infos(model=model, llm_router=llm_router)
     ]
     valid_estimates: Final = [estimate for estimate in estimates if estimate is not None]
     return max(valid_estimates) if valid_estimates else None
@@ -1168,32 +1183,33 @@ def _max_cost_for_cost_info(
     request_body: dict,
     route: str,
     model: str,
-    model_info: ModelInfo,
+    pricing: _DeploymentPricing,
     input_tokens: int | None = None,
 ) -> float | None:
     image_cost: Final = _estimate_image_generation_cost(
         request_body=request_body,
-        model_info=model_info,
+        model_info=pricing.model_info,
     )
 
     estimated_input_tokens: Final = _estimate_input_tokens(
         request_body=request_body,
         route=route,
         model=model,
-        model_info=model_info,
+        model_info=pricing.model_info,
         input_tokens=input_tokens,
     )
     output_tokens: Final = _estimate_output_tokens(
         request_body=request_body,
         route=route,
-        model_info=model_info,
+        model_info=pricing.model_info,
     )
     if estimated_input_tokens is None or output_tokens is None:
         return image_cost
 
     output_multiplier: Final = _get_output_multiplier(request_body=request_body)
     rates: Final = _token_rates_for_cost_info(
-        model_info=model_info,
+        request_body=request_body,
+        pricing=pricing,
         input_tokens=estimated_input_tokens,
         output_tokens=output_tokens,
     )
@@ -1201,8 +1217,10 @@ def _max_cost_for_cost_info(
     # output token at the higher of the standard and reasoning rates to avoid
     # under-reserving reasoning-heavy requests.
     output_rate: Final = max(rates.output_rate, rates.billed_reasoning_rate)
-    token_cost: Final = (estimated_input_tokens * rates.input_rate) + (output_tokens * output_multiplier * output_rate)
-    # Image models are often priced per image and per token at once, so reserve the larger.
+    # Providers write large prompts to their cache without being asked and bill the written
+    # tokens at the cache-creation rate, so reserve every input token at the higher of the two.
+    input_rate: Final = max(rates.input_rate, rates.cache_creation_rate)
+    token_cost: Final = (estimated_input_tokens * input_rate) + (output_tokens * output_multiplier * output_rate)
     return token_cost if image_cost is None else max(image_cost, token_cost)
 
 
@@ -1244,6 +1262,15 @@ def _estimate_image_generation_cost(
     return cost_per_image * max(n, 1)
 
 
+@dataclass(frozen=True, slots=True)
+class _DeploymentPricing:
+    """A deployment's cost entry, with the pricing context that comes from the deployment
+    rather than the request: the regional host it is sent to sets a data-residency uplift."""
+
+    model_info: ModelInfo
+    data_residency: str | None = None
+
+
 def _get_model_cost_info(model: str) -> ModelInfo:
     return litellm.get_model_info(model=model)
 
@@ -1251,7 +1278,7 @@ def _get_model_cost_info(model: str) -> ModelInfo:
 def _get_model_cost_infos(
     model: str,
     llm_router: Router | None,
-) -> Sequence[ModelInfo]:
+) -> Sequence[_DeploymentPricing]:
     """Cost-info candidates to estimate a request against for one model name.
 
     Reservation runs before routing, so the deployment that will serve the request
@@ -1265,7 +1292,7 @@ def _get_model_cost_infos(
         deployment_infos: Final = _get_deployment_cost_infos(model=model, llm_router=llm_router)
         if deployment_infos is not None:
             return deployment_infos
-        return (_get_model_cost_info(model=model),)
+        return (_DeploymentPricing(model_info=_get_model_cost_info(model=model)),)
     except Exception:
         verbose_proxy_logger.debug(
             "Unable to load model cost info for budget reservation",
@@ -1277,28 +1304,39 @@ def _get_model_cost_infos(
 def _get_deployment_cost_infos(
     model: str,
     llm_router: Router | None,
-) -> Sequence[ModelInfo] | None:
+) -> Sequence[_DeploymentPricing] | None:
     if llm_router is None:
         return None
     deployments: Final = llm_router.get_model_list(model_name=model)
     if not deployments:
         return None
     return tuple(
-        deployment_info
+        deployment_pricing
         for deployment in deployments
-        if (deployment_info := _deployment_cost_info(deployment, llm_router)) is not None
+        if (deployment_pricing := _deployment_cost_info(deployment, llm_router)) is not None
     )
 
 
 def _deployment_cost_info(
     deployment: DeploymentTypedDict,
     llm_router: Router,
-) -> ModelInfo | None:
+) -> _DeploymentPricing | None:
+    litellm_params: Final = _get_value(deployment, "litellm_params")
     model_id: Final = _get_value(_get_value(deployment, "model_info"), "id")
-    backend_model: Final = _get_value(_get_value(deployment, "litellm_params"), "model")
+    backend_model: Final = _get_value(litellm_params, "model")
     if not isinstance(model_id, str) or not isinstance(backend_model, str):
         return None
-    return llm_router.get_deployment_model_info(model_id=model_id, model_name=backend_model)
+    model_info: Final = llm_router.get_deployment_model_info(model_id=model_id, model_name=backend_model)
+    if model_info is None:
+        return None
+    api_base: Final = _get_value(litellm_params, "api_base")
+    return _DeploymentPricing(
+        model_info=model_info,
+        data_residency=infer_openai_data_residency(
+            custom_llm_provider=model_info.get("litellm_provider"),
+            api_base=api_base if isinstance(api_base, str) else None,
+        ),
+    )
 
 
 def _get_request_models(

--- a/litellm/proxy/spend_tracking/budget_reservation.py
+++ b/litellm/proxy/spend_tracking/budget_reservation.py
@@ -1128,13 +1128,40 @@ def _input_cost_for_cost_info(
         input_tokens=estimated_input_tokens,
         output_tokens=0,
     )
-    return estimated_input_tokens * _billed_input_rate(rates)
+    return estimated_input_tokens * _billed_input_rate(
+        rates=rates,
+        model_info=pricing.model_info,
+        request_body=request_body,
+    )
 
 
-def _billed_input_rate(rates: TokenRates) -> float:
-    """Providers write a large prompt into their own cache without the request asking and bill
-    every written token at the cache-creation rate, so an input token costs the higher of the two."""
-    return max(rates.input_rate, rates.cache_creation_rate)
+AUTO_PROMPT_CACHING_PROVIDERS: Final = frozenset({"openai", "azure"})
+
+
+def _billed_input_rate(
+    rates: TokenRates,
+    model_info: Mapping[str, object],
+    request_body: Mapping[str, object],
+) -> float:
+    """OpenAI writes a large prompt into its own cache without the request asking and bills every
+    written token at the cache-creation rate, so an input token there costs the higher of the two.
+    Every other provider writes only what the request marks with cache_control, and holding the
+    write rate for a request that marks nothing reserves above anything it can bill."""
+    if _writes_the_prompt_to_cache(model_info=model_info, request_body=request_body):
+        return max(rates.input_rate, rates.cache_creation_rate)
+    return rates.input_rate
+
+
+def _writes_the_prompt_to_cache(model_info: Mapping[str, object], request_body: Mapping[str, object]) -> bool:
+    return model_info.get("litellm_provider") in AUTO_PROMPT_CACHING_PROVIDERS or _contains_cache_control(request_body)
+
+
+def _contains_cache_control(value: object) -> bool:
+    if isinstance(value, Mapping):
+        return "cache_control" in value or any(_contains_cache_control(item) for item in value.values())
+    if isinstance(value, (list, tuple)):
+        return any(_contains_cache_control(item) for item in value)
+    return False
 
 
 def _token_rates_for_cost_info(
@@ -1223,7 +1250,11 @@ def _max_cost_for_cost_info(
     # output token at the higher of the standard and reasoning rates to avoid
     # under-reserving reasoning-heavy requests.
     output_rate: Final = max(rates.output_rate, rates.billed_reasoning_rate)
-    input_rate: Final = _billed_input_rate(rates)
+    input_rate: Final = _billed_input_rate(
+        rates=rates,
+        model_info=pricing.model_info,
+        request_body=request_body,
+    )
     token_cost: Final = (estimated_input_tokens * input_rate) + (output_tokens * output_multiplier * output_rate)
     return token_cost if image_cost is None else max(image_cost, token_cost)
 
@@ -1459,7 +1490,7 @@ def _estimate_output_tokens(
     route: str,
     model_info: Mapping[str, object],
 ) -> int | None:
-    if _is_input_only_route(route=route):
+    if _bills_no_completion_tokens(route=route):
         return 0
 
     requested: int | None = None
@@ -1511,13 +1542,17 @@ def _get_output_multiplier(request_body: dict) -> int:
     return output_multiplier
 
 
-def _is_input_only_route(route: str) -> bool:
+def _bills_no_completion_tokens(route: str) -> bool:
+    """Image routes bill the picture, sized by the request's own `size` and `quality`, so the
+    completion-token fallback below would price a chat-shaped guess at the model's image-token
+    rate and reserve about sixty times what a 1024x1024 image costs."""
     return any(
         route_part in route
         for route_part in (
             "embeddings",
             "rerank",
             "moderations",
+            "images/",
         )
     )
 

--- a/litellm/proxy/spend_tracking/budget_reservation.py
+++ b/litellm/proxy/spend_tracking/budget_reservation.py
@@ -1138,6 +1138,7 @@ def _input_cost_for_cost_info(
         rates=rates,
         model_info=pricing.model_info,
         request_body=request_body,
+        input_tokens=estimated_input_tokens,
     )
 
 
@@ -1145,19 +1146,24 @@ def _billed_input_rate(
     rates: TokenRates,
     model_info: Mapping[str, object],
     request_body: Mapping[str, object],
+    input_tokens: int,
 ) -> float:
     """An input token costs the higher of the input and cache-creation rates wherever the prompt
     lands in the provider's cache, since every written token bills at the write rate. Holding the
     write rate for a request that marks nothing, on a provider that writes nothing unasked, would
     reserve above anything the request can bill."""
-    if _writes_the_prompt_to_cache(model_info=model_info, request_body=request_body):
+    if _writes_the_prompt_to_cache(model_info=model_info, request_body=request_body, input_tokens=input_tokens):
         return max(rates.input_rate, rates.cache_creation_rate)
     return rates.input_rate
 
 
-def _writes_the_prompt_to_cache(model_info: Mapping[str, object], request_body: Mapping[str, object]) -> bool:
+def _writes_the_prompt_to_cache(
+    model_info: Mapping[str, object],
+    request_body: Mapping[str, object],
+    input_tokens: int,
+) -> bool:
     return provider_writes_prompt_to_cache_unasked(
-        model_info.get("litellm_provider")
+        model_info.get("litellm_provider"), prompt_tokens=input_tokens
     ) or AnthropicCacheControlHook.body_has_cache_control(request_body)
 
 
@@ -1253,6 +1259,7 @@ def _max_cost_for_cost_info(
         rates=rates,
         model_info=pricing.model_info,
         request_body=request_body,
+        input_tokens=estimated_input_tokens,
     )
     output_rate: Final = _billed_output_rate(rates=rates, model_info=pricing.model_info)
     return (estimated_input_tokens * input_rate) + (output_tokens * output_multiplier * output_rate)

--- a/litellm/proxy/spend_tracking/budget_reservation.py
+++ b/litellm/proxy/spend_tracking/budget_reservation.py
@@ -12,6 +12,7 @@ from fastapi import HTTPException, status
 
 import litellm
 from litellm._logging import verbose_proxy_logger
+from litellm.integrations.anthropic_cache_control_hook import AnthropicCacheControlHook
 from litellm.litellm_core_utils.duration_parser import duration_in_seconds
 from litellm.litellm_core_utils.llm_cost_calc.utils import TokenRates, resolve_token_rates
 from litellm.llms.openai.data_residency import infer_openai_data_residency
@@ -1153,15 +1154,18 @@ def _billed_input_rate(
 
 
 def _writes_the_prompt_to_cache(model_info: Mapping[str, object], request_body: Mapping[str, object]) -> bool:
-    return model_info.get("litellm_provider") in AUTO_PROMPT_CACHING_PROVIDERS or _contains_cache_control(request_body)
+    if model_info.get("litellm_provider") in AUTO_PROMPT_CACHING_PROVIDERS:
+        return True
+    return AnthropicCacheControlHook.request_has_cache_control(
+        messages=_blocks_in(request_body, "messages"),
+        system=request_body.get("system"),
+        tools=_blocks_in(request_body, "tools"),
+    )
 
 
-def _contains_cache_control(value: object) -> bool:
-    if isinstance(value, Mapping):
-        return "cache_control" in value or any(_contains_cache_control(item) for item in value.values())
-    if isinstance(value, (list, tuple)):
-        return any(_contains_cache_control(item) for item in value)
-    return False
+def _blocks_in(request_body: Mapping[str, object], field: str) -> tuple[object, ...]:
+    value: Final = request_body.get(field)
+    return tuple(value) if isinstance(value, (list, tuple)) else ()
 
 
 def _token_rates_for_cost_info(

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
@@ -39,6 +39,7 @@ from litellm.litellm_core_utils.llm_cost_calc.utils import (
     calculate_cache_writing_cost,
     generic_cost_per_token,
     get_token_type_cost_breakdown,
+    resolve_token_rates,
 )
 from litellm.types.utils import CacheCreationTokenDetails, Usage
 
@@ -411,6 +412,38 @@ def test_get_token_base_cost_picks_highest_crossed_tier():
     prompt_base_cost = _get_token_base_cost(model_info, usage)[0]
 
     assert prompt_base_cost == 9e-6
+
+
+def test_resolve_token_rates_prices_prompt_past_threshold_at_the_above_rates():
+    """Rates resolved from the token counts alone must follow the same threshold rules the
+    billed cost does: base rates below the threshold, the *_above_Nk_tokens rates past it,
+    and the reasoning rate falling back to the billed output rate when none is declared."""
+    model_info = {
+        "input_cost_per_token": 5e-06,
+        "input_cost_per_token_above_272k_tokens": 1e-05,
+        "output_cost_per_token": 3e-05,
+        "output_cost_per_token_above_272k_tokens": 4.5e-05,
+    }
+
+    below = resolve_token_rates(
+        model_info=model_info,
+        usage=Usage(prompt_tokens=272_000, completion_tokens=10, total_tokens=272_010),
+        custom_llm_provider="openai",
+    )
+    above = resolve_token_rates(
+        model_info=model_info,
+        usage=Usage(prompt_tokens=272_001, completion_tokens=10, total_tokens=272_011),
+        custom_llm_provider="openai",
+    )
+    inclusive = resolve_token_rates(
+        model_info=model_info,
+        usage=Usage(prompt_tokens=272_000, completion_tokens=10, total_tokens=272_010),
+        custom_llm_provider="xai",
+    )
+
+    assert (below.input_rate, below.output_rate, below.billed_reasoning_rate) == (5e-06, 3e-05, 3e-05)
+    assert (above.input_rate, above.output_rate, above.billed_reasoning_rate) == (1e-05, 4.5e-05, 4.5e-05)
+    assert (inclusive.input_rate, inclusive.output_rate) == (1e-05, 4.5e-05)
 
 
 def test_is_within_off_peak_window_same_day():

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
@@ -446,6 +446,37 @@ def test_resolve_token_rates_prices_prompt_past_threshold_at_the_above_rates():
     assert (inclusive.input_rate, inclusive.output_rate) == (1e-05, 4.5e-05)
 
 
+def test_resolve_token_rates_covers_the_service_tier_and_the_regional_uplift():
+    """A tier the provider honors bills above the standard rates and one it declines bills at
+    them, so the resolved rates take the higher of the two. A regional host multiplies whatever
+    that leaves by the model's uplift, the same way the billed cost does."""
+    model_info = {
+        "input_cost_per_token": 5e-06,
+        "input_cost_per_token_priority": 1.25e-05,
+        "output_cost_per_token": 3e-05,
+        "output_cost_per_token_priority": 7.5e-05,
+        "input_cost_per_token_flex": 2.5e-06,
+        "output_cost_per_token_flex": 1.5e-05,
+        "regional_processing_uplift_multiplier_eu": 1.1,
+    }
+    usage = Usage(prompt_tokens=10_000, completion_tokens=100, total_tokens=10_100)
+
+    standard = resolve_token_rates(model_info=model_info, usage=usage, custom_llm_provider="openai")
+    priority = resolve_token_rates(
+        model_info=model_info, usage=usage, custom_llm_provider="openai", service_tier="priority"
+    )
+    flex = resolve_token_rates(model_info=model_info, usage=usage, custom_llm_provider="openai", service_tier="flex")
+    regional = resolve_token_rates(
+        model_info=model_info, usage=usage, custom_llm_provider="openai", data_residency="eu"
+    )
+
+    assert (standard.input_rate, standard.output_rate) == (5e-06, 3e-05)
+    assert (priority.input_rate, priority.output_rate) == (1.25e-05, 7.5e-05)
+    assert (flex.input_rate, flex.output_rate) == (5e-06, 3e-05)
+    assert regional.input_rate == pytest.approx(5e-06 * 1.1)
+    assert regional.output_rate == pytest.approx(3e-05 * 1.1)
+
+
 def test_is_within_off_peak_window_same_day():
     from datetime import datetime, timezone
 

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
@@ -447,9 +447,10 @@ def test_resolve_token_rates_prices_prompt_past_threshold_at_the_above_rates():
 
 
 def test_resolve_token_rates_covers_the_service_tier_and_the_regional_uplift():
-    """A tier the provider honors bills above the standard rates and one it declines bills at
-    them, so the resolved rates take the higher of the two. A regional host multiplies whatever
-    that leaves by the model's uplift, the same way the billed cost does."""
+    """The bill reads the service tier off the request, so a request that asks for one is priced
+    at that tier's own rates: priority above the standard ones and flex below them. Falling back
+    to the dearer standard rates for flex reserves above anything the request can bill. A regional
+    host multiplies whatever that leaves by the model's uplift, the same way the billed cost does."""
     model_info = {
         "input_cost_per_token": 5e-06,
         "input_cost_per_token_priority": 1.25e-05,
@@ -472,7 +473,7 @@ def test_resolve_token_rates_covers_the_service_tier_and_the_regional_uplift():
 
     assert (standard.input_rate, standard.output_rate) == (5e-06, 3e-05)
     assert (priority.input_rate, priority.output_rate) == (1.25e-05, 7.5e-05)
-    assert (flex.input_rate, flex.output_rate) == (5e-06, 3e-05)
+    assert (flex.input_rate, flex.output_rate) == (2.5e-06, 1.5e-05)
     assert regional.input_rate == pytest.approx(5e-06 * 1.1)
     assert regional.output_rate == pytest.approx(3e-05 * 1.1)
 

--- a/tests/test_litellm/proxy/test_budget_reservation.py
+++ b/tests/test_litellm/proxy/test_budget_reservation.py
@@ -39,6 +39,7 @@ from litellm.proxy.spend_tracking.budget_reservation import (
     TOKENIZE_OFF_EVENT_LOOP_MIN_CHARS,
     _approximate_input_size,
     _get_model_access_group_budget_counters,
+    estimate_request_input_cost,
     estimate_request_max_cost,
     get_budget_window_start,
     invalidate_budget_reservation_counters,
@@ -1185,12 +1186,11 @@ def test_reservation_uses_most_expensive_deployment_in_group():
 
     with (
         patch(
-            "litellm.proxy.spend_tracking.budget_reservation._get_model_cost_info",
-            return_value={"max_output_tokens": 200000},
-        ),
-        patch(
-            "litellm.proxy.spend_tracking.budget_reservation._get_deployment_tiered_pricing_tables",
-            return_value=[cheap, expensive],
+            "litellm.proxy.spend_tracking.budget_reservation._get_deployment_cost_infos",
+            return_value=[
+                {"tiered_pricing": cheap, "max_output_tokens": 200000},
+                {"tiered_pricing": expensive, "max_output_tokens": 200000},
+            ],
         ),
         patch(
             "litellm.proxy.spend_tracking.budget_reservation._estimate_input_tokens",
@@ -1211,6 +1211,109 @@ def test_reservation_uses_most_expensive_deployment_in_group():
     expected_cheap = (input_tokens * 1e-06) + (output_tokens * 2e-06)
     assert expected_expensive > expected_cheap
     assert estimated == pytest.approx(expected_expensive)
+
+
+def _long_prompt_request(model: str, max_tokens: int) -> dict[str, object]:
+    return {"model": model, "messages": [{"role": "user", "content": "hello"}], "max_tokens": max_tokens}
+
+
+def test_reservation_prices_prompt_above_272k_at_the_above_threshold_rate():
+    """A prompt past a model's *_above_272k_tokens threshold is billed at the above rate for
+    every token, so the reservation must price it there too. Reserving at the base rate
+    let a 300K-token request through a budget it then overshot by the full above-rate cost."""
+    model_info = litellm.get_model_info("gpt-5.5")
+    above_input_rate = model_info.get("input_cost_per_token_above_272k_tokens")
+    above_output_rate = model_info.get("output_cost_per_token_above_272k_tokens")
+    base_input_rate = model_info.get("input_cost_per_token")
+    base_output_rate = model_info.get("output_cost_per_token")
+    assert above_input_rate is not None and above_output_rate is not None
+    assert base_input_rate is not None and base_output_rate is not None
+    input_tokens = 300_000
+    output_tokens = 1_000
+    request_body = _long_prompt_request(model="gpt-5.5", max_tokens=output_tokens)
+
+    estimated = estimate_request_max_cost(
+        request_body=request_body,
+        route="/chat/completions",
+        llm_router=None,
+        input_token_counts={"gpt-5.5": input_tokens},
+    )
+    estimated_input = estimate_request_input_cost(
+        request_body=request_body,
+        route="/chat/completions",
+        llm_router=None,
+        input_token_counts={"gpt-5.5": input_tokens},
+    )
+
+    assert estimated is not None
+    assert estimated == pytest.approx((input_tokens * above_input_rate) + (output_tokens * above_output_rate))
+    assert estimated_input == pytest.approx(input_tokens * above_input_rate)
+    base_rate_under_reserve = (input_tokens * base_input_rate) + (output_tokens * base_output_rate)
+    assert estimated > base_rate_under_reserve
+
+
+def test_reservation_prices_above_272k_rate_through_router_deployment():
+    """On the proxy the model name resolves through the router, whose group summary only
+    carries flat rates. The reservation must read each deployment's full pricing so the
+    above-threshold keys from the cost map reach the estimate."""
+    router = Router(
+        model_list=[
+            {
+                "model_name": "gpt-5.5",
+                "litellm_params": {"model": "openai/gpt-5.5", "api_key": "sk-fake"},
+            }
+        ]
+    )
+    model_info = litellm.get_model_info("openai/gpt-5.5")
+    above_input_rate = model_info.get("input_cost_per_token_above_272k_tokens")
+    above_output_rate = model_info.get("output_cost_per_token_above_272k_tokens")
+    base_input_rate = model_info.get("input_cost_per_token")
+    assert above_input_rate is not None and above_output_rate is not None
+    assert base_input_rate is not None and above_input_rate > base_input_rate
+    input_tokens = 300_000
+    output_tokens = 1_000
+
+    estimated = estimate_request_max_cost(
+        request_body=_long_prompt_request(model="gpt-5.5", max_tokens=output_tokens),
+        route="/chat/completions",
+        llm_router=router,
+        input_token_counts={"gpt-5.5": input_tokens},
+    )
+
+    assert estimated == pytest.approx((input_tokens * above_input_rate) + (output_tokens * above_output_rate))
+
+
+def test_reservation_honors_inclusive_threshold_providers():
+    """xAI bills the higher tier once the prompt reaches the threshold while OpenAI bills it
+    only past the threshold, so a prompt of exactly the threshold length reserves at the
+    above rate for xAI and at the base rate for OpenAI."""
+    output_tokens = 10
+
+    def estimate(model: str, input_tokens: int) -> float:
+        estimated = estimate_request_max_cost(
+            request_body=_long_prompt_request(model=model, max_tokens=output_tokens),
+            route="/chat/completions",
+            llm_router=None,
+            input_token_counts={model: input_tokens},
+        )
+        assert estimated is not None
+        return estimated
+
+    xai_info = litellm.get_model_info("xai/grok-4.6")
+    xai_above_input_rate = xai_info.get("input_cost_per_token_above_200k_tokens")
+    xai_above_output_rate = xai_info.get("output_cost_per_token_above_200k_tokens")
+    assert xai_above_input_rate is not None and xai_above_output_rate is not None
+    openai_info = litellm.get_model_info("gpt-5.5")
+    openai_base_input_rate = openai_info.get("input_cost_per_token")
+    openai_base_output_rate = openai_info.get("output_cost_per_token")
+    assert openai_base_input_rate is not None and openai_base_output_rate is not None
+
+    assert estimate("xai/grok-4.6", 200_000) == pytest.approx(
+        (200_000 * xai_above_input_rate) + (output_tokens * xai_above_output_rate)
+    )
+    assert estimate("gpt-5.5", 272_000) == pytest.approx(
+        (272_000 * openai_base_input_rate) + (output_tokens * openai_base_output_rate)
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/test_budget_reservation.py
+++ b/tests/test_litellm/proxy/test_budget_reservation.py
@@ -1488,19 +1488,35 @@ def test_reservation_holds_the_cache_write_rate_only_when_the_request_asks_for_i
         ],
     }
 
+    cached_responses_request = {
+        "model": "claude-haiku-4-5",
+        "max_output_tokens": 100,
+        "input": [
+            {
+                "role": "user",
+                "content": [{"type": "input_text", "text": "hello", "cache_control": {"type": "ephemeral"}}],
+            }
+        ],
+    }
+
     estimates = [
         estimate_request_input_cost(
             request_body=body,
-            route="/chat/completions",
+            route=route,
             llm_router=None,
             input_token_counts={"claude-haiku-4-5": input_tokens},
         )
-        for body in (plain_request, cached_request)
+        for body, route in (
+            (plain_request, "/chat/completions"),
+            (cached_request, "/chat/completions"),
+            (cached_responses_request, "/v1/responses"),
+        )
     ]
 
-    plain, cached = estimates
+    plain, cached, cached_responses = estimates
     assert plain == pytest.approx(input_tokens * input_rate)
     assert cached == pytest.approx(input_tokens * cache_write_rate)
+    assert cached_responses == pytest.approx(input_tokens * cache_write_rate)
 
 
 def test_reservation_prices_above_272k_rate_through_router_deployment():

--- a/tests/test_litellm/proxy/test_budget_reservation.py
+++ b/tests/test_litellm/proxy/test_budget_reservation.py
@@ -1175,37 +1175,30 @@ def test_flat_reservation_uses_higher_reasoning_output_rate():
 
 
 def test_reservation_uses_most_expensive_deployment_in_group():
-    """When a model group mixes deployments with different tiered rates, reservation
-    must estimate against the most expensive one. Reserving the cheaper sibling would
-    let a caller repeatedly hit the alias and exceed the budget once routed to the
-    costlier deployment."""
+    """When a model group mixes deployments the config prices differently, reservation must
+    estimate against the most expensive one. Reserving the cheaper sibling would let a caller
+    repeatedly hit the alias and exceed the budget once routed to the costlier deployment."""
     cheap = [{"range": [0, 32000], "input_cost_per_token": 1e-06, "output_cost_per_token": 2e-06}]
     expensive = [{"range": [0, 32000], "input_cost_per_token": 5e-06, "output_cost_per_token": 1e-05}]
     input_tokens = 1000
     output_tokens = 10
+    router = Router(
+        model_list=[
+            {
+                "model_name": "mixed-rates",
+                "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "sk-fake"},
+                "model_info": {"id": deployment_id, "tiered_pricing": tiers, "max_output_tokens": 200_000},
+            }
+            for deployment_id, tiers in (("cheap-deployment", cheap), ("expensive-deployment", expensive))
+        ]
+    )
 
-    with (
-        patch(
-            "litellm.proxy.spend_tracking.budget_reservation._get_deployment_cost_infos",
-            return_value=[
-                {"tiered_pricing": cheap, "max_output_tokens": 200000},
-                {"tiered_pricing": expensive, "max_output_tokens": 200000},
-            ],
-        ),
-        patch(
-            "litellm.proxy.spend_tracking.budget_reservation._estimate_input_tokens",
-            return_value=input_tokens,
-        ),
-        patch(
-            "litellm.proxy.spend_tracking.budget_reservation._estimate_output_tokens",
-            return_value=output_tokens,
-        ),
-    ):
-        estimated = estimate_request_max_cost(
-            request_body=_request_body(),
-            route="/chat/completions",
-            llm_router=None,
-        )
+    estimated = estimate_request_max_cost(
+        request_body=_long_prompt_request(model="mixed-rates", max_tokens=output_tokens),
+        route="/chat/completions",
+        llm_router=router,
+        input_token_counts={"mixed-rates": input_tokens},
+    )
 
     expected_expensive = (input_tokens * 5e-06) + (output_tokens * 1e-05)
     expected_cheap = (input_tokens * 1e-06) + (output_tokens * 2e-06)
@@ -1300,6 +1293,100 @@ def test_image_reservation_keeps_the_token_cost_when_it_is_the_larger_one():
     )
 
     assert estimated == pytest.approx(input_tokens * 1e-05)
+
+
+def _openai_router(model_name: str, api_base: str | None = None) -> Router:
+    litellm_params: dict[str, object] = {"model": "openai/gpt-5.5", "api_key": "sk-fake"}
+    if api_base is not None:
+        litellm_params["api_base"] = api_base
+    return Router(model_list=[{"model_name": model_name, "litellm_params": litellm_params}])
+
+
+def test_reservation_prices_a_priority_tier_request_at_the_priority_rate():
+    """A request that asks for the priority service tier is billed at the model's priority rates,
+    which run 2.5x the standard ones on gpt-5.5. Reserving at the standard rate lets a priority
+    request through a budget its own bill then overshoots."""
+    model_info = litellm.get_model_info("gpt-5.5")
+    priority_input_rate = model_info.get("input_cost_per_token_priority")
+    priority_output_rate = model_info.get("output_cost_per_token_priority")
+    assert priority_input_rate is not None and priority_output_rate is not None
+    input_tokens = 10_000
+    output_tokens = 100
+    router = _openai_router("gpt-5.5")
+    standard_request = _long_prompt_request(model="gpt-5.5", max_tokens=output_tokens)
+
+    estimated = estimate_request_max_cost(
+        request_body={**standard_request, "service_tier": "priority"},
+        route="/chat/completions",
+        llm_router=router,
+        input_token_counts={"gpt-5.5": input_tokens},
+    )
+
+    assert estimated == pytest.approx((input_tokens * priority_input_rate) + (output_tokens * priority_output_rate))
+    standard_estimate = estimate_request_max_cost(
+        request_body=standard_request,
+        route="/chat/completions",
+        llm_router=router,
+        input_token_counts={"gpt-5.5": input_tokens},
+    )
+    assert standard_estimate is not None and estimated > standard_estimate
+
+
+def test_reservation_prices_a_regional_deployment_at_the_uplifted_rate():
+    """OpenAI charges a flat uplift on every token a regional host processes, so a deployment
+    pointed at eu.api.openai.com bills above the global rate. Reserving at the global rate
+    under-reserves every request that deployment serves."""
+    uplift = litellm.get_model_info("gpt-5.5").get("regional_processing_uplift_multiplier_eu")
+    assert uplift is not None and uplift > 1
+    input_tokens = 10_000
+    output_tokens = 100
+    request_body = _long_prompt_request(model="gpt-5.5", max_tokens=output_tokens)
+
+    estimates = [
+        estimate_request_max_cost(
+            request_body=request_body,
+            route="/chat/completions",
+            llm_router=_openai_router("gpt-5.5", api_base=api_base),
+            input_token_counts={"gpt-5.5": input_tokens},
+        )
+        for api_base in (None, "https://eu.api.openai.com/v1")
+    ]
+
+    global_estimate, regional_estimate = estimates
+    assert global_estimate is not None and regional_estimate is not None
+    assert regional_estimate == pytest.approx(global_estimate * uplift)
+
+
+def test_reservation_prices_a_prompt_at_the_cache_write_rate():
+    """OpenAI writes a long prompt into its own cache without the request asking and bills every
+    written token at the cache-creation rate: a 305,124-token gpt-5.6-luna request came back with
+    `cache_creation_tokens: 305124` and `x-litellm-response-cost-cache-creation: 0.152562` out of a
+    0.1525938 bill. Reserving at the input rate leaves that whole gap unreserved."""
+    model_info = litellm.get_model_info("gpt-5.6-luna")
+    input_rate = model_info.get("input_cost_per_token_above_272k_tokens")
+    cache_write_rate = model_info.get("cache_creation_input_token_cost_above_272k_tokens")
+    output_rate = model_info.get("output_cost_per_token_above_272k_tokens")
+    assert input_rate is not None and output_rate is not None
+    assert cache_write_rate is not None and cache_write_rate > input_rate
+    input_tokens = 305_124
+    output_tokens = 100
+    router = Router(
+        model_list=[
+            {
+                "model_name": "luna",
+                "litellm_params": {"model": "openai/gpt-5.6-luna", "api_key": "sk-fake"},
+            }
+        ]
+    )
+
+    estimated = estimate_request_max_cost(
+        request_body=_long_prompt_request(model="luna", max_tokens=output_tokens),
+        route="/chat/completions",
+        llm_router=router,
+        input_token_counts={"luna": input_tokens},
+    )
+
+    assert estimated == pytest.approx((input_tokens * cache_write_rate) + (output_tokens * output_rate))
 
 
 def test_reservation_prices_above_272k_rate_through_router_deployment():

--- a/tests/test_litellm/proxy/test_budget_reservation.py
+++ b/tests/test_litellm/proxy/test_budget_reservation.py
@@ -1316,6 +1316,35 @@ def test_reservation_honors_inclusive_threshold_providers():
     )
 
 
+def test_reservation_ignores_an_off_peak_discount_whose_window_can_close():
+    """A deployment's off-peak window can close between the reservation and the response, and the
+    finished request is then billed at the standard rate. Reserving the discounted rate would let
+    a request through a budget the standard rate goes on to overshoot."""
+    now = datetime.now(timezone.utc)
+    open_window = f"{(now - timedelta(hours=1)).strftime('%H:%M')}-{(now + timedelta(hours=1)).strftime('%H:%M')}"
+    router = Router(
+        model_list=[
+            {
+                "model_name": "gpt-5.5-off-peak",
+                "litellm_params": {"model": "openai/gpt-5.5", "api_key": "sk-fake"},
+                "model_info": {"off_peak_pricing": {"hours_utc": open_window, "input_cost_per_token": 1e-08}},
+            }
+        ]
+    )
+    above_input_rate = litellm.get_model_info("openai/gpt-5.5").get("input_cost_per_token_above_272k_tokens")
+    assert above_input_rate is not None
+    input_tokens = 300_000
+
+    estimated_input = estimate_request_input_cost(
+        request_body=_long_prompt_request(model="gpt-5.5-off-peak", max_tokens=16),
+        route="/chat/completions",
+        llm_router=router,
+        input_token_counts={"gpt-5.5-off-peak": input_tokens},
+    )
+
+    assert estimated_input == pytest.approx(input_tokens * above_input_rate)
+
+
 @pytest.mark.asyncio
 async def test_should_clamp_reservation_to_model_ceiling_when_caller_overrequests(
     spend_counter_state,

--- a/tests/test_litellm/proxy/test_budget_reservation.py
+++ b/tests/test_litellm/proxy/test_budget_reservation.py
@@ -1295,6 +1295,31 @@ def test_image_reservation_keeps_the_token_cost_when_it_is_the_larger_one():
     assert estimated == pytest.approx(input_tokens * 1e-05)
 
 
+def test_image_generation_reserves_the_picture_not_a_chat_token_fallback():
+    """An image request carries no token cap, so the chat fallback of 16K output tokens priced at
+    gpt-image-1's per-image-token rate reserves $0.65 against a 1024x1024 low-quality picture that
+    bills about a cent, and a key with headroom for the picture is refused."""
+    from litellm.proxy.spend_tracking.budget_reservation import (
+        DEFAULT_MAX_OUTPUT_TOKENS_FALLBACK,
+    )
+
+    model_info = litellm.get_model_info("gpt-image-1")
+    image_token_rate = model_info.get("output_cost_per_image_token")
+    input_rate = model_info.get("input_cost_per_token")
+    assert image_token_rate is not None and input_rate is not None
+    input_tokens = 8
+
+    estimated = estimate_request_max_cost(
+        request_body={"model": "gpt-image-1", "prompt": "a red bicycle", "size": "1024x1024", "quality": "low"},
+        route="/v1/images/generations",
+        llm_router=None,
+        input_token_counts={"gpt-image-1": input_tokens},
+    )
+
+    assert estimated == pytest.approx(input_tokens * input_rate)
+    assert estimated < DEFAULT_MAX_OUTPUT_TOKENS_FALLBACK * image_token_rate
+
+
 def _openai_router(model_name: str, api_base: str | None = None) -> Router:
     litellm_params: dict[str, object] = {"model": "openai/gpt-5.5", "api_key": "sk-fake"}
     if api_base is not None:
@@ -1330,6 +1355,36 @@ def test_reservation_prices_a_priority_tier_request_at_the_priority_rate():
         input_token_counts={"gpt-5.5": input_tokens},
     )
     assert standard_estimate is not None and estimated > standard_estimate
+
+
+def test_reservation_prices_a_flex_request_at_the_flex_rate():
+    """The bill prices a request by the service tier it asked for, and gpt-5.5's flex rates are
+    half the standard ones. Reserving at the standard rate holds twice what a flex request can
+    bill, so a key with room for the request is refused."""
+    model_info = litellm.get_model_info("gpt-5.5")
+    flex_input_rate = model_info.get("input_cost_per_token_flex")
+    flex_output_rate = model_info.get("output_cost_per_token_flex")
+    assert flex_input_rate is not None and flex_output_rate is not None
+    input_tokens = 10_000
+    output_tokens = 100
+    router = _openai_router("gpt-5.5")
+    standard_request = _long_prompt_request(model="gpt-5.5", max_tokens=output_tokens)
+
+    estimated = estimate_request_max_cost(
+        request_body={**standard_request, "service_tier": "flex"},
+        route="/chat/completions",
+        llm_router=router,
+        input_token_counts={"gpt-5.5": input_tokens},
+    )
+
+    assert estimated == pytest.approx((input_tokens * flex_input_rate) + (output_tokens * flex_output_rate))
+    standard_estimate = estimate_request_max_cost(
+        request_body=standard_request,
+        route="/chat/completions",
+        llm_router=router,
+        input_token_counts={"gpt-5.5": input_tokens},
+    )
+    assert standard_estimate is not None and estimated < standard_estimate
 
 
 def test_reservation_prices_a_regional_deployment_at_the_uplifted_rate():
@@ -1409,6 +1464,43 @@ def test_cancelled_request_keeps_the_cache_write_cost_it_already_incurred():
     )
 
     assert estimated_input == pytest.approx(input_tokens * cache_write_rate)
+
+
+def test_reservation_holds_the_cache_write_rate_only_when_the_request_asks_for_it():
+    """Anthropic writes a prompt into its cache only where cache_control marks a block, so a
+    request that marks nothing is billed the plain input rate. Holding the 25% dearer write rate
+    for every Anthropic request reserves above anything the request can bill, and one that does
+    mark a block still has to hold it."""
+    model_info = litellm.get_model_info("claude-haiku-4-5")
+    input_rate = model_info.get("input_cost_per_token")
+    cache_write_rate = model_info.get("cache_creation_input_token_cost")
+    assert input_rate is not None
+    assert cache_write_rate is not None and cache_write_rate > input_rate
+    input_tokens = 72_801
+    plain_request = _long_prompt_request(model="claude-haiku-4-5", max_tokens=100)
+    cached_request = {
+        **plain_request,
+        "messages": [
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "hello", "cache_control": {"type": "ephemeral"}}],
+            }
+        ],
+    }
+
+    estimates = [
+        estimate_request_input_cost(
+            request_body=body,
+            route="/chat/completions",
+            llm_router=None,
+            input_token_counts={"claude-haiku-4-5": input_tokens},
+        )
+        for body in (plain_request, cached_request)
+    ]
+
+    plain, cached = estimates
+    assert plain == pytest.approx(input_tokens * input_rate)
+    assert cached == pytest.approx(input_tokens * cache_write_rate)
 
 
 def test_reservation_prices_above_272k_rate_through_router_deployment():

--- a/tests/test_litellm/proxy/test_budget_reservation.py
+++ b/tests/test_litellm/proxy/test_budget_reservation.py
@@ -1513,6 +1513,31 @@ def test_cancelled_request_keeps_the_cache_write_cost_it_already_incurred():
     assert estimated_input == pytest.approx(input_tokens * cache_write_rate)
 
 
+def test_a_prompt_too_short_to_cache_reserves_the_plain_input_rate():
+    """OpenAI and Azure write a prompt into their own cache from 1024 tokens up and nothing below
+    that, so a shorter prompt bills the plain input rate. Reserving the 25% dearer write rate for
+    it holds budget the request cannot spend, and a cancelled request is reconciled to that
+    inflated number as real spend rather than as a hold that gets released."""
+    model_info = litellm.get_model_info("gpt-5.6-luna")
+    input_rate = model_info.get("input_cost_per_token")
+    cache_write_rate = model_info.get("cache_creation_input_token_cost")
+    assert input_rate is not None
+    assert cache_write_rate is not None and cache_write_rate > input_rate
+
+    below_threshold, at_threshold = [
+        estimate_request_input_cost(
+            request_body=_long_prompt_request(model="gpt-5.6-luna", max_tokens=100),
+            route="/chat/completions",
+            llm_router=None,
+            input_token_counts={"gpt-5.6-luna": input_tokens},
+        )
+        for input_tokens in (1_023, 1_024)
+    ]
+
+    assert below_threshold == pytest.approx(1_023 * input_rate)
+    assert at_threshold == pytest.approx(1_024 * cache_write_rate)
+
+
 def test_reservation_holds_the_cache_write_rate_only_when_the_request_asks_for_it():
     """Anthropic writes a prompt into its cache only where cache_control marks a block, so a
     request that marks nothing is billed the plain input rate. Holding the 25% dearer write rate

--- a/tests/test_litellm/proxy/test_budget_reservation.py
+++ b/tests/test_litellm/proxy/test_budget_reservation.py
@@ -1389,6 +1389,28 @@ def test_reservation_prices_a_prompt_at_the_cache_write_rate():
     assert estimated == pytest.approx((input_tokens * cache_write_rate) + (output_tokens * output_rate))
 
 
+def test_cancelled_request_keeps_the_cache_write_cost_it_already_incurred():
+    """A cancelled in-flight request is reconciled down to its input cost, and the provider has
+    already written the prompt into its cache and billed it at the cache-creation rate. Holding
+    only the plain input rate releases budget that is already spent, so the next request is
+    admitted against headroom the key does not have."""
+    model_info = litellm.get_model_info("gpt-5.6-luna")
+    input_rate = model_info.get("input_cost_per_token_above_272k_tokens")
+    cache_write_rate = model_info.get("cache_creation_input_token_cost_above_272k_tokens")
+    assert input_rate is not None
+    assert cache_write_rate is not None and cache_write_rate > input_rate
+    input_tokens = 305_124
+
+    estimated_input = estimate_request_input_cost(
+        request_body=_long_prompt_request(model="gpt-5.6-luna", max_tokens=100),
+        route="/chat/completions",
+        llm_router=None,
+        input_token_counts={"gpt-5.6-luna": input_tokens},
+    )
+
+    assert estimated_input == pytest.approx(input_tokens * cache_write_rate)
+
+
 def test_reservation_prices_above_272k_rate_through_router_deployment():
     """On the proxy the model name resolves through the router, whose group summary only
     carries flat rates. The reservation must read each deployment's full pricing so the

--- a/tests/test_litellm/proxy/test_budget_reservation.py
+++ b/tests/test_litellm/proxy/test_budget_reservation.py
@@ -1252,6 +1252,56 @@ def test_reservation_prices_prompt_above_272k_at_the_above_threshold_rate():
     assert estimated > base_rate_under_reserve
 
 
+def test_reservation_prices_every_image_of_a_router_served_image_model():
+    """A deployment's own cost entry carries the per-image price, so an image-generation
+    request through the router reserves `n x per-image cost` instead of nothing."""
+    router = Router(
+        model_list=[{"model_name": "pixels", "litellm_params": {"model": "openai/dall-e-3", "api_key": "sk-fake"}}]
+    )
+    per_image = litellm.get_model_info("dall-e-3").get("input_cost_per_image")
+    assert per_image is not None
+
+    estimated = estimate_request_max_cost(
+        request_body={"model": "pixels", "prompt": "a cat", "n": 3},
+        route="/v1/images/generations",
+        llm_router=router,
+        input_token_counts={"pixels": 5},
+    )
+
+    assert estimated == pytest.approx(3 * per_image)
+
+
+def test_image_reservation_keeps_the_token_cost_when_it_is_the_larger_one():
+    """Image models are commonly priced per image and per prompt token at once, so a long
+    prompt can cost more than the pictures. Reserving only the per-image price would let such
+    a request through a budget its token bill goes on to overshoot."""
+    router = Router(
+        model_list=[
+            {
+                "model_name": "pixels-with-a-long-prompt",
+                "litellm_params": {"model": "openai/dall-e-3", "api_key": "sk-fake"},
+                "model_info": {
+                    "mode": "image_generation",
+                    "output_cost_per_image": 0.01,
+                    "input_cost_per_token": 1e-05,
+                    "output_cost_per_token": 0.0,
+                    "max_output_tokens": 1000,
+                },
+            }
+        ]
+    )
+    input_tokens = 50_000
+
+    estimated = estimate_request_max_cost(
+        request_body={"model": "pixels-with-a-long-prompt", "prompt": "a cat", "n": 1},
+        route="/v1/images/generations",
+        llm_router=router,
+        input_token_counts={"pixels-with-a-long-prompt": input_tokens},
+    )
+
+    assert estimated == pytest.approx(input_tokens * 1e-05)
+
+
 def test_reservation_prices_above_272k_rate_through_router_deployment():
     """On the proxy the model name resolves through the router, whose group summary only
     carries flat rates. The reservation must read each deployment's full pricing so the

--- a/tests/test_litellm/proxy/test_budget_reservation.py
+++ b/tests/test_litellm/proxy/test_budget_reservation.py
@@ -1264,41 +1264,11 @@ def test_reservation_prices_every_image_of_a_router_served_image_model():
     assert estimated == pytest.approx(3 * per_image)
 
 
-def test_image_reservation_keeps_the_token_cost_when_it_is_the_larger_one():
-    """Image models are commonly priced per image and per prompt token at once, so a long
-    prompt can cost more than the pictures. Reserving only the per-image price would let such
-    a request through a budget its token bill goes on to overshoot."""
-    router = Router(
-        model_list=[
-            {
-                "model_name": "pixels-with-a-long-prompt",
-                "litellm_params": {"model": "openai/dall-e-3", "api_key": "sk-fake"},
-                "model_info": {
-                    "mode": "image_generation",
-                    "output_cost_per_image": 0.01,
-                    "input_cost_per_token": 1e-05,
-                    "output_cost_per_token": 0.0,
-                    "max_output_tokens": 1000,
-                },
-            }
-        ]
-    )
-    input_tokens = 50_000
-
-    estimated = estimate_request_max_cost(
-        request_body={"model": "pixels-with-a-long-prompt", "prompt": "a cat", "n": 1},
-        route="/v1/images/generations",
-        llm_router=router,
-        input_token_counts={"pixels-with-a-long-prompt": input_tokens},
-    )
-
-    assert estimated == pytest.approx(input_tokens * 1e-05)
-
-
 def test_image_generation_reserves_the_picture_not_a_chat_token_fallback():
-    """An image request carries no token cap, so the chat fallback of 16K output tokens priced at
-    gpt-image-1's per-image-token rate reserves $0.65 against a 1024x1024 low-quality picture that
-    bills about a cent, and a key with headroom for the picture is refused."""
+    """gpt-image-1 prices its output only per image token, so charging the chat fallback of 16K
+    output tokens at that rate would reserve $0.65 against a 1024x1024 low-quality picture that
+    bills about a cent, and refuse a key holding enough for the picture. The reservation prices
+    the prompt and leaves the picture to the per-image path."""
     from litellm.proxy.spend_tracking.budget_reservation import (
         DEFAULT_MAX_OUTPUT_TOKENS_FALLBACK,
     )
@@ -1405,6 +1375,83 @@ def test_reservation_prices_a_regional_deployment_at_the_uplifted_rate():
             input_token_counts={"gpt-5.5": input_tokens},
         )
         for api_base in (None, "https://eu.api.openai.com/v1")
+    ]
+
+    global_estimate, regional_estimate = estimates
+    assert global_estimate is not None and regional_estimate is not None
+    assert regional_estimate == pytest.approx(global_estimate * uplift)
+
+
+def test_reservation_prices_a_deployment_pinned_service_tier_at_that_tier_rate():
+    """The router hands every request that does not name its own service_tier the one pinned in
+    the deployment's litellm_params, and the bill follows it: gpt-5.5's priority rates run 2.5x
+    the standard ones. Reserving at the standard rate lets those requests through a budget their
+    own bill then overshoots. A request that names a tier still wins, so flex on the same
+    deployment reserves at the flex rate."""
+    model_info = litellm.get_model_info("gpt-5.5")
+    priority_input_rate = model_info.get("input_cost_per_token_priority")
+    priority_output_rate = model_info.get("output_cost_per_token_priority")
+    flex_input_rate = model_info.get("input_cost_per_token_flex")
+    flex_output_rate = model_info.get("output_cost_per_token_flex")
+    assert priority_input_rate is not None and priority_output_rate is not None
+    assert flex_input_rate is not None and flex_output_rate is not None
+    input_tokens = 10_000
+    output_tokens = 100
+    router = Router(
+        model_list=[
+            {
+                "model_name": "gpt-5.5-priority",
+                "litellm_params": {"model": "openai/gpt-5.5", "api_key": "sk-fake", "service_tier": "priority"},
+            }
+        ]
+    )
+    request_body = _long_prompt_request(model="gpt-5.5-priority", max_tokens=output_tokens)
+
+    estimated = estimate_request_max_cost(
+        request_body=request_body,
+        route="/chat/completions",
+        llm_router=router,
+        input_token_counts={"gpt-5.5-priority": input_tokens},
+    )
+
+    assert estimated == pytest.approx((input_tokens * priority_input_rate) + (output_tokens * priority_output_rate))
+    flex_estimate = estimate_request_max_cost(
+        request_body={**request_body, "service_tier": "flex"},
+        route="/chat/completions",
+        llm_router=router,
+        input_token_counts={"gpt-5.5-priority": input_tokens},
+    )
+    assert flex_estimate == pytest.approx((input_tokens * flex_input_rate) + (output_tokens * flex_output_rate))
+
+
+def test_reservation_prices_a_regional_vertex_deployment_at_the_uplifted_rate():
+    """Google bills every non-global Vertex endpoint at a flat premium over the global one, 1.1x
+    on gemini-3.5-flash, so a deployment pinned to us-east1 costs 10% more than the same model on
+    the global endpoint. Reserving at the global rate under-reserves every request it serves."""
+    uplift = litellm.get_model_info("vertex_ai/gemini-3.5-flash").get("regional_endpoint_uplift_multiplier")
+    assert uplift is not None and uplift > 1
+    input_tokens = 10_000
+    request_body = _long_prompt_request(model="vertex-flash", max_tokens=100)
+
+    estimates = [
+        estimate_request_max_cost(
+            request_body=request_body,
+            route="/chat/completions",
+            llm_router=Router(
+                model_list=[
+                    {
+                        "model_name": "vertex-flash",
+                        "litellm_params": {
+                            "model": "vertex_ai/gemini-3.5-flash",
+                            "vertex_project": "test-project",
+                            "vertex_location": vertex_location,
+                        },
+                    }
+                ]
+            ),
+            input_token_counts={"vertex-flash": input_tokens},
+        )
+        for vertex_location in ("global", "us-east1")
     ]
 
     global_estimate, regional_estimate = estimates


### PR DESCRIPTION
## TLDR

Problem this solves:

- Budget reservation priced every prompt at the base per-token rate
- The `*_above_272k_tokens` keys on gpt-5.x and gpt-6 entries were never read
- A 300K-token gpt-5.5 request reserved half its real cost
- Keys with a hard `max_budget` ended over budget on long-context requests

How it solves it:

- New `resolve_token_rates` helper picks rates the way the cost calculator bills
- Reservation now prices `*_above_Nk_tokens` thresholds, `tiered_pricing` tiers, and xAI's inclusive thresholds
- An open off-peak window never lowers a reservation, since it can close before the response lands
- A service tier the request names or its deployment pins, and the uplift of a regional OpenAI host or a non-global Vertex location, are each priced at the rate the bill uses
- Input tokens reserve at the cache-creation rate where the body marks a block with `cache_control`, and on OpenAI and Azure from the 1024 tokens up at which they write a prompt into their own cache unasked
- An image request reserves the picture's real price behind a router for the first time, since the model-group view a router hands back drops the per-image cost keys
- A model priced only per image token reserves what it did before, since that rate stays out of the chat output fallback
- Router deployments are priced from their own cost info, custom per-deployment pricing included
- Regression tests reserve a 300K-token gpt-5.5 request at the above-272K rate

## User Flow

Before: a developer whose key has a hard $0.45 budget fires five 300K-token gpt-5.6-luna chat completions at once, four of them go through, and the key lands 36% over its cap

1. The proxy admin runs the proxy with a `gpt-5.6-luna` deployment and stock settings, then creates a key with POST https://litellm-domain/key/generate and `{"max_budget": 0.45}`, getting back an `sk-...` key with `max_budget: 0.45`
2. The developer fires five POST https://litellm-domain/v1/chat/completions at once with that key, `"model": "gpt-5.6-luna"`, and a distinct prompt of about 300K tokens in each
3. Four come back 200, each with `x-litellm-response-cost: 0.1525...`, and only the fifth is refused with `Budget has been exceeded! ... Current cost: 0.6034843000000001, Max budget: 0.45`, which arrives after the money is already spent
4. GET https://litellm-domain/key/info with that key shows `spend: 0.6103328` next to `max_budget: 0.45`, so the key is $0.16 past a cap it was supposed to stop at

After: the same five requests reserve at the above-272K rate, so only what the budget covers reaches OpenAI and the key finishes a cent short of a dollar's overshoot

1. The proxy admin runs the proxy with a `gpt-5.6-luna` deployment and stock settings, then creates a key with POST https://litellm-domain/key/generate and `{"max_budget": 0.45}`, getting back an `sk-...` key with `max_budget: 0.45`
2. The developer fires five POST https://litellm-domain/v1/chat/completions at once with that key, `"model": "gpt-5.6-luna"`, and a distinct prompt of about 300K tokens in each
3. Three come back 200 with `x-litellm-response-cost: 0.1525...` and two are refused with `Budget has been exceeded! ... Max budget: 0.45` before anything reaches OpenAI
4. GET https://litellm-domain/key/info with that key shows `spend: 0.4577...` next to `max_budget: 0.45`, so the key ends under a cent over instead of $0.16 over, and an admin who turns on `general_settings.fail_closed_budget_enforcement` gets the last request refused too instead of resized down to the remaining budget

## Relevant issues

## Linear ticket

Resolves LIT-7002

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Real OpenAI and Anthropic deployments, real spend, no mocks anywhere. Every prompt carries its own uuid prefix so the provider's prompt cache cannot mask the cost, and every leg runs 2 uvicorn workers against one Postgres so the reservation counter is shared the way it is in a multi-pod deployment

The first pair is the one a stock deployment hits: a config with no `general_settings` block at all, a Redis so the two workers share the spend counter, and five 300K-token requests fired at once against a single $0.45 key. The second pair is one long prompt per surface (`/v1/chat/completions`, `/v1/responses`, `/v1/messages`) with `general_settings.fail_closed_budget_enforcement: true`, which is what an admin turns on to have a single oversized request refused outright. The third pair covers the requests that must keep passing: an image generation, an Anthropic prompt with no `cache_control`, and a flex-tier request. The fourth pair reads the reservation itself out of the refusal message on tiny keys, for a request that names `service_tier: priority`, a model group holding one standard and one priority-pinned `gpt-5.5` deployment, and a 48-token and a 2,655-token prompt on the same model

### Before (02cbff4918), stock settings, five concurrent long prompts

Four of the five are admitted, and the refusal only lands once $0.60 is already spent against a $0.45 cap

```console
===== leg before: one key with max_budget 0.45, 5 concurrent 300K-token gpt-5.6-luna chat completions =====
$ curl -s -X POST http://127.0.0.1:24551/key/generate -H 'Authorization: Bearer sk-lit7002-master' -H 'Content-Type: application/json' -d '{"max_budget": 0.45, "key_alias": "lit7002-burst-before-f017df71"}'
-> key sk-ie2eW9q... max_budget 0.45

$ for i in $(seq 1 5); do curl -s -D h$i.txt -o r$i.json -w '%{http_code}' -X POST http://127.0.0.1:24551/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' --data-binary @req$i.json & done; wait
req1 http 429  Budget has been exceeded! Key=41828bbaa2347f067d62ffdb804bef0bc60ee3b15788065ad827d6241417a277 Current cost: 0.6034843000000001, Max budget: 0.45
req2 http 200  x-litellm-response-cost: 0.1525933
req3 http 200  x-litellm-response-cost: 0.1525977
req4 http 200  x-litellm-response-cost: 0.1525709
req5 http 200  x-litellm-response-cost: 0.1525709

waiting 40s for the spend to flush to the DB
$ curl -s http://127.0.0.1:24551/key/info -H "Authorization: Bearer $KEY"
{"key_alias":"lit7002-burst-before-f017df71","spend":0.6103328,"max_budget":0.45}
===== leg before done =====
```

### After (272bdc4960), stock settings, five concurrent long prompts

Two of the five are refused before OpenAI is called, and the key lands under a cent over rather than $0.16 over. The residual overshoot is the default over-budget policy: with `fail_closed_budget_enforcement` off, the last request that does not fit is resized down to whatever budget remains and admitted, so it can still bill slightly past the cap

```console
===== leg after9: one key with max_budget 0.45, 5 concurrent 300K-token gpt-5.6-luna chat completions =====
$ curl -s -X POST http://127.0.0.1:23762/key/generate -H 'Authorization: Bearer sk-lit7002-master' -H 'Content-Type: application/json' -d '{"max_budget": 0.45, "key_alias": "lit7002-burst-after9-25208a79"}'
-> key sk-D4Av_hT... max_budget 0.45

$ for i in $(seq 1 5); do curl -s -D h$i.txt -o r$i.json -w '%{http_code}' -X POST http://127.0.0.1:23762/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' --data-binary @req$i.json & done; wait
req1 http 429  Budget has been exceeded! Key=lit7002-burst-after9-25208a79 (sk-...5P3g) Current cost: 0.45, Max budget: 0.45
req2 http 200  x-litellm-response-cost: 0.1525699
req3 http 200  x-litellm-response-cost: 0.1525963
req4 http 429  Budget has been exceeded! Key=lit7002-burst-after9-25208a79 (sk-...5P3g) Current cost: 0.45, Max budget: 0.45
req5 http 200  x-litellm-response-cost: 0.15257140000000002

waiting 40s for the spend to flush to the DB
$ curl -s http://127.0.0.1:23762/key/info -H "Authorization: Bearer $KEY"
{"key_alias":"lit7002-burst-after9-25208a79","spend":0.4577376000000001,"max_budget":0.45}
===== leg after9 done =====
```

### Before (02cbff4918), one long prompt per surface, fail-closed on

Every long request is admitted and each key lands over its cap. On `/v1/messages` the key's recorded spend also comes back at twice the response cost, which is a pre-existing behaviour at the merge base and not something this PR touches

```console
===== case gpt55-chat: /v1/chat/completions gpt-5.5 key max_budget 2.5 =====
prompt starts with: [run b031ce0e-bdd9-483b-8c83-e0dabb0deeaf] Reply with the si
$ curl -s -X POST http://127.0.0.1:23099/key/generate -H 'Authorization: Bearer sk-lit7002-master' -H 'Content-Type: application/json' -d '{"max_budget": 2.5, "key_alias": "lit7002-before-r2-gpt55-chat"}'
-> key sk-kh44h... max_budget 2.5
$ curl -s -D headers.txt -o response.json -w 'http %{http_code} in %{time_total}s' -X POST http://127.0.0.1:23099/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' --data-binary @gpt55-chat_request.json
http 200 in 6.967022s
x-litellm-response-cost: 3.0522150000000003
x-litellm-key-max-budget: 2.5
x-litellm-key-spend: 3.0522150000000003
response.json (usage or error):
{"usage":{"completion_tokens":21,"prompt_tokens":305127,"total_tokens":305148,"completion_tokens_details":{"accepted_prediction_tokens":0,"audio_tokens":0,"reasoning_tokens":11,"rejected_prediction_tokens":0},"prompt_tokens_details":{"audio_tokens":0,"cached_tokens":0}}}
$ curl -s http://127.0.0.1:23099/key/info -H "Authorization: Bearer $KEY"
{"key_alias":"lit7002-before-r2-gpt55-chat","spend":3.052215,"max_budget":2.5}

===== case luna-chat: /v1/chat/completions gpt-5.6-luna key max_budget 0.10 =====
prompt starts with: [run bf43b785-3d1b-49ff-8887-0ef662e4ad29] Reply with the si
$ curl -s -X POST http://127.0.0.1:23099/key/generate -H 'Authorization: Bearer sk-lit7002-master' -H 'Content-Type: application/json' -d '{"max_budget": 0.10, "key_alias": "lit7002-before-r2-luna-chat"}'
-> key sk-Xjyhc... max_budget 0.1
$ curl -s -D headers.txt -o response.json -w 'http %{http_code} in %{time_total}s' -X POST http://127.0.0.1:23099/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' --data-binary @luna-chat_request.json
http 200 in 3.218674s
x-litellm-response-cost: 0.1525925
x-litellm-key-max-budget: 0.1
x-litellm-key-spend: 0.1525925
response.json (usage or error):
{"usage":{"completion_tokens":16,"prompt_tokens":305128,"total_tokens":305144,"completion_tokens_details":{"accepted_prediction_tokens":0,"audio_tokens":0,"reasoning_tokens":6,"rejected_prediction_tokens":0},"prompt_tokens_details":{"audio_tokens":0,"cached_tokens":0,"cache_write_tokens":305125,"cache_creation_tokens":305125}}}
$ curl -s http://127.0.0.1:23099/key/info -H "Authorization: Bearer $KEY"
{"key_alias":"lit7002-before-r2-luna-chat","spend":0.1525925,"max_budget":0.1}

===== case luna-responses: /v1/responses gpt-5.6-luna key max_budget 0.10 =====
prompt starts with: [run b4e0c8d4-b2a3-4600-b441-89e24ef63ba7] Reply with the si
$ curl -s -X POST http://127.0.0.1:23099/key/generate -H 'Authorization: Bearer sk-lit7002-master' -H 'Content-Type: application/json' -d '{"max_budget": 0.10, "key_alias": "lit7002-before-r2-luna-responses"}'
-> key sk-8ExbK... max_budget 0.1
$ curl -s -D headers.txt -o response.json -w 'http %{http_code} in %{time_total}s' -X POST http://127.0.0.1:23099/v1/responses -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' --data-binary @luna-responses_request.json
http 200 in 3.026248s
x-litellm-response-cost: 0.1525737
x-litellm-key-max-budget: 0.1
x-litellm-key-spend: 0.1525737
response.json (usage or error):
{"usage":{"input_tokens":305130,"input_tokens_details":{"audio_tokens":null,"cached_tokens":0,"text_tokens":null,"cache_write_tokens":305127},"output_tokens":5,"output_tokens_details":{"audio_tokens":null,"reasoning_tokens":0,"text_tokens":null},"total_tokens":305135,"cost":null}}
$ curl -s http://127.0.0.1:23099/key/info -H "Authorization: Bearer $KEY"
{"key_alias":"lit7002-before-r2-luna-responses","spend":0.1525737,"max_budget":0.1}

===== case luna-messages: /v1/messages gpt-5.6-luna key max_budget 0.10 =====
prompt starts with: [run 7e55152e-4e98-452a-a915-3c45393bb816] Reply with the si
$ curl -s -X POST http://127.0.0.1:23099/key/generate -H 'Authorization: Bearer sk-lit7002-master' -H 'Content-Type: application/json' -d '{"max_budget": 0.10, "key_alias": "lit7002-before-r2-luna-messages"}'
-> key sk-lgjF4... max_budget 0.1
$ curl -s -D headers.txt -o response.json -w 'http %{http_code} in %{time_total}s' -X POST http://127.0.0.1:23099/v1/messages -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' --data-binary @luna-messages_request.json
http 200 in 3.096984s
x-litellm-response-cost: 0.1525956
x-litellm-key-max-budget: 0.1
x-litellm-key-spend: 0.1525956
response.json (usage or error):
{"usage":{"input_tokens":3,"output_tokens":18,"cache_creation_input_tokens":305124}}
$ curl -s http://127.0.0.1:23099/key/info -H "Authorization: Bearer $KEY"
{"key_alias":"lit7002-before-r2-luna-messages","spend":0.3051912,"max_budget":0.1}

===== case luna-chat-fits: /v1/chat/completions gpt-5.6-luna key max_budget 0.50 =====
prompt starts with: [run 8c48ba8a-60c2-4d15-a795-114f37c2d60a] Reply with the si
$ curl -s -X POST http://127.0.0.1:23099/key/generate -H 'Authorization: Bearer sk-lit7002-master' -H 'Content-Type: application/json' -d '{"max_budget": 0.50, "key_alias": "lit7002-before-r2-luna-chat-fits"}'
-> key sk-qxD4b... max_budget 0.5
$ curl -s -D headers.txt -o response.json -w 'http %{http_code} in %{time_total}s' -X POST http://127.0.0.1:23099/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' --data-binary @luna-chat-fits_request.json
http 200 in 2.681570s
x-litellm-response-cost: 0.1525958
x-litellm-key-max-budget: 0.5
x-litellm-key-spend: 0.1525958
response.json (usage or error):
{"usage":{"completion_tokens":17,"prompt_tokens":305131,"total_tokens":305148,"completion_tokens_details":{"accepted_prediction_tokens":0,"audio_tokens":0,"reasoning_tokens":7,"rejected_prediction_tokens":0},"prompt_tokens_details":{"audio_tokens":0,"cached_tokens":0,"cache_write_tokens":305128,"cache_creation_tokens":305128}}}
$ curl -s http://127.0.0.1:23099/key/info -H "Authorization: Bearer $KEY"
{"key_alias":"lit7002-before-r2-luna-chat-fits","spend":0.1525958,"max_budget":0.5}

===== leg before r2 done =====
```

### After (272bdc4960), one long prompt per surface, fail-closed on

The four over-budget requests are refused with 429 before the provider is called and their keys stay at `spend: 0.0`. The $0.50 key, whose request costs $0.15, still goes through, so nothing that fits is turned away

```console
===== case gpt55-chat: /v1/chat/completions gpt-5.5 key max_budget 2.5 =====
prompt starts with: [run d672a863-4221-452a-a071-f70be69bbb4e] Reply with the si
$ curl -s -X POST http://127.0.0.1:29872/key/generate -H 'Authorization: Bearer sk-lit7002-master' -H 'Content-Type: application/json' -d '{"max_budget": 2.5, "key_alias": "lit7002-after-r9-gpt55-chat"}'
-> key sk-1RU0F... max_budget 2.5
$ curl -s -D headers.txt -o response.json -w 'http %{http_code} in %{time_total}s' -X POST http://127.0.0.1:29872/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' --data-binary @gpt55-chat_request.json
http 429 in 0.329552s
response.json (usage or error):
{"error":{"message":"Budget has been exceeded! Key=e7fbc61f8b495ca3d88994cfa0fda7f12a8134d23f1346dccd7a2532dbd61a6d Current cost: 0.0, Estimated request cost: 3.6432300000000004, Max budget: 2.5","type":"budget_exceeded","param":null,"code":"429"}}
$ curl -s http://127.0.0.1:29872/key/info -H "Authorization: Bearer $KEY"
{"key_alias":"lit7002-after-r9-gpt55-chat","spend":0.0,"max_budget":2.5}

===== case luna-chat: /v1/chat/completions gpt-5.6-luna key max_budget 0.10 =====
prompt starts with: [run bb48cbe9-9f7e-450c-901a-edda8308af16] Reply with the si
$ curl -s -X POST http://127.0.0.1:29872/key/generate -H 'Authorization: Bearer sk-lit7002-master' -H 'Content-Type: application/json' -d '{"max_budget": 0.10, "key_alias": "lit7002-after-r9-luna-chat"}'
-> key sk-PMHr4... max_budget 0.1
$ curl -s -D headers.txt -o response.json -w 'http %{http_code} in %{time_total}s' -X POST http://127.0.0.1:29872/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' --data-binary @luna-chat_request.json
http 429 in 0.093648s
response.json (usage or error):
{"error":{"message":"Budget has been exceeded! Key=ded59db9de4554e113ab745c5872e344ba318b64bc8d76278664312e62aca0bc Current cost: 0.0, Estimated request cost: 0.1821486, Max budget: 0.1","type":"budget_exceeded","param":null,"code":"429"}}
$ curl -s http://127.0.0.1:29872/key/info -H "Authorization: Bearer $KEY"
{"key_alias":"lit7002-after-r9-luna-chat","spend":0.0,"max_budget":0.1}

===== case luna-responses: /v1/responses gpt-5.6-luna key max_budget 0.10 =====
prompt starts with: [run 9efec269-ea6d-4562-b7b3-20d512dff288] Reply with the si
$ curl -s -X POST http://127.0.0.1:29872/key/generate -H 'Authorization: Bearer sk-lit7002-master' -H 'Content-Type: application/json' -d '{"max_budget": 0.10, "key_alias": "lit7002-after-r9-luna-responses"}'
-> key sk-QxdxQ... max_budget 0.1
$ curl -s -D headers.txt -o response.json -w 'http %{http_code} in %{time_total}s' -X POST http://127.0.0.1:29872/v1/responses -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' --data-binary @luna-responses_request.json
http 429 in 0.224473s
response.json (usage or error):
{"error":{"message":"Budget has been exceeded! Key=474f9570a20b2593a395c83f01dca68e072cc7db4ddb044acb44b587866ad7d3 Current cost: 0.0, Estimated request cost: 0.18214509999999998, Max budget: 0.1","type":"budget_exceeded","param":null,"code":"429"}}
$ curl -s http://127.0.0.1:29872/key/info -H "Authorization: Bearer $KEY"
{"key_alias":"lit7002-after-r9-luna-responses","spend":0.0,"max_budget":0.1}

===== case luna-messages: /v1/messages gpt-5.6-luna key max_budget 0.10 =====
prompt starts with: [run d3e8a6cb-522d-46c2-af13-39cbdcb190a2] Reply with the si
$ curl -s -X POST http://127.0.0.1:29872/key/generate -H 'Authorization: Bearer sk-lit7002-master' -H 'Content-Type: application/json' -d '{"max_budget": 0.10, "key_alias": "lit7002-after-r9-luna-messages"}'
-> key sk-mOdSb... max_budget 0.1
$ curl -s -D headers.txt -o response.json -w 'http %{http_code} in %{time_total}s' -X POST http://127.0.0.1:29872/v1/messages -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' --data-binary @luna-messages_request.json
http 429 in 0.115736s
response.json (usage or error):
{"error":{"message":"Budget has been exceeded! Key=28f9aca940323f4be743bd206e0bf93d5714c5bf3a2d5b53b683fee718266cae Current cost: 0.0, Estimated request cost: 0.1821496, Max budget: 0.1","type":"budget_exceeded","param":null,"code":"429"}}
$ curl -s http://127.0.0.1:29872/key/info -H "Authorization: Bearer $KEY"
{"key_alias":"lit7002-after-r9-luna-messages","spend":0.0,"max_budget":0.1}

===== case luna-chat-fits: /v1/chat/completions gpt-5.6-luna key max_budget 0.50 =====
prompt starts with: [run 094ac798-e16b-4348-9e1f-c7f1e87969ca] Reply with the si
$ curl -s -X POST http://127.0.0.1:29872/key/generate -H 'Authorization: Bearer sk-lit7002-master' -H 'Content-Type: application/json' -d '{"max_budget": 0.50, "key_alias": "lit7002-after-r9-luna-chat-fits"}'
-> key sk-rxx-T... max_budget 0.5
$ curl -s -D headers.txt -o response.json -w 'http %{http_code} in %{time_total}s' -X POST http://127.0.0.1:29872/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' --data-binary @luna-chat-fits_request.json
http 200 in 2.968600s
x-litellm-response-cost: 0.1525943
x-litellm-key-max-budget: 0.5
x-litellm-key-spend: 0.1525943
response.json (usage or error):
{"usage":{"completion_tokens":17,"prompt_tokens":305128,"total_tokens":305145,"completion_tokens_details":{"accepted_prediction_tokens":0,"audio_tokens":0,"reasoning_tokens":7,"rejected_prediction_tokens":0},"prompt_tokens_details":{"audio_tokens":0,"cached_tokens":0,"cache_write_tokens":305125,"cache_creation_tokens":305125}}}
$ curl -s http://127.0.0.1:29872/key/info -H "Authorization: Bearer $KEY"
{"key_alias":"lit7002-after-r9-luna-chat-fits","spend":0.1525943,"max_budget":0.5}
```

### Before (02cbff4918), the requests that must keep passing, fail-closed on

Each key is sized so that a reservation above what the request can bill would refuse it: $0.10 against a picture that bills $0.011, and $0.085 against an Anthropic prompt that bills $0.059. The flex request is the one the merge base already gets wrong, reserving $0.90 at the standard rate for a request that bills $0.0003

```console
===== case image: /v1/images/generations gpt-image-1 key max_budget 0.10 =====
prompt starts with: [run b1af4c37-a47e-45ee-8526-51c9af4b9da8] a red bicycle lea
$ curl -s -X POST http://127.0.0.1:27321/key/generate -H 'Authorization: Bearer sk-lit7002-master' -H 'Content-Type: application/json' -d '{"max_budget": 0.10, "key_alias": "lit7002-before-r5-image"}'
-> key sk-0pa2B... max_budget 0.1
$ curl -s -D headers.txt -o response.json -w 'http %{http_code} in %{time_total}s' -X POST http://127.0.0.1:27321/v1/images/generations -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' --data-binary @image_request.json
http 200 in 13.769140s
x-litellm-response-cost: 0.011090000000000001
x-litellm-key-max-budget: 0.1
x-litellm-key-spend: 0.011090000000000001
response.json (usage or error):
{"usage":{"total_tokens":314,"input_tokens":42,"input_tokens_details":{"image_tokens":0,"text_tokens":42},"output_tokens":272,"output_tokens_details":{"image_tokens":272,"text_tokens":0}}}
$ curl -s http://127.0.0.1:27321/key/info -H "Authorization: Bearer $KEY"
{"key_alias":"lit7002-before-r5-image","spend":0.01109,"max_budget":0.1}

===== case anthropic: /v1/chat/completions claude-haiku-4-5 key max_budget 0.085 =====
prompt starts with: [run fb6ad03b-8408-4670-9d5e-16c1b7e99117] Reply with the si
$ curl -s -X POST http://127.0.0.1:27321/key/generate -H 'Authorization: Bearer sk-lit7002-master' -H 'Content-Type: application/json' -d '{"max_budget": 0.085, "key_alias": "lit7002-before-r5-anthropic"}'
-> key sk-212jb... max_budget 0.085
$ curl -s -D headers.txt -o response.json -w 'http %{http_code} in %{time_total}s' -X POST http://127.0.0.1:27321/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' --data-binary @anthropic_request.json
http 200 in 1.397470s
x-litellm-response-cost: 0.059363
x-litellm-key-max-budget: 0.085
x-litellm-key-spend: 0.059363
response.json (usage or error):
{"usage":{"completion_tokens":4,"prompt_tokens":59343,"total_tokens":59347,"completion_tokens_details":{"reasoning_tokens":0,"text_tokens":4},"prompt_tokens_details":{"cached_tokens":0,"text_tokens":59343,"cache_write_tokens":0,"cache_creation_tokens":0,"cache_creation_token_details":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0}},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"not_available","service_tier":"standard"}}
$ curl -s http://127.0.0.1:27321/key/info -H "Authorization: Bearer $KEY"
{"key_alias":"lit7002-before-r5-anthropic","spend":0.059363,"max_budget":0.085}

===== case flex: /v1/chat/completions gpt-5.5 key max_budget 0.60 =====
prompt starts with: [run f2e2ea08-2596-44e1-b54f-503397541ca9] Reply with the si
$ curl -s -X POST http://127.0.0.1:27321/key/generate -H 'Authorization: Bearer sk-lit7002-master' -H 'Content-Type: application/json' -d '{"max_budget": 0.60, "key_alias": "lit7002-before-r5-flex"}'
-> key sk-8reRK... max_budget 0.6
$ curl -s -D headers.txt -o response.json -w 'http %{http_code} in %{time_total}s' -X POST http://127.0.0.1:27321/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' --data-binary @flex_request.json
http 429 in 0.026881s
response.json (usage or error):
{"error":{"message":"Budget has been exceeded! Key=594102ea082d0ca6c64a97dba903ac92cba5f674f750e61a7bf7957387b4878f Current cost: 0.0, Estimated request cost: 0.900195, Max budget: 0.6","type":"budget_exceeded","param":null,"code":"429"}}
$ curl -s http://127.0.0.1:27321/key/info -H "Authorization: Bearer $KEY"
{"key_alias":"lit7002-before-r5-flex","spend":0.0,"max_budget":0.6}
```

### After (272bdc4960), the requests that must keep passing, fail-closed on

The picture and the Anthropic prompt still go through at the same cost, so neither the image-token rate nor the cache-creation rate is held against a request that cannot bill it. The flex request is now reserved at the flex rate the bill uses and goes through instead of being refused

```console
===== case image: /v1/images/generations gpt-image-1 key max_budget 0.10 =====
prompt starts with: [run 17a37fa4-646f-456c-93a3-785b8c633802] a red bicycle lea
$ curl -s -X POST http://127.0.0.1:20932/key/generate -H 'Authorization: Bearer sk-lit7002-master' -H 'Content-Type: application/json' -d '{"max_budget": 0.10, "key_alias": "lit7002-after-r9-image"}'
-> key sk-bET0H... max_budget 0.1
$ curl -s -D headers.txt -o response.json -w 'http %{http_code} in %{time_total}s' -X POST http://127.0.0.1:20932/v1/images/generations -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' --data-binary @image_request.json
http 200 in 11.394188s
x-litellm-response-cost: 0.011080000000000001
x-litellm-key-max-budget: 0.1
x-litellm-key-spend: 0.011080000000000001
response.json (usage or error):
{"usage":{"total_tokens":312,"input_tokens":40,"input_tokens_details":{"image_tokens":0,"text_tokens":40},"output_tokens":272,"output_tokens_details":{"image_tokens":272,"text_tokens":0}}}
$ curl -s http://127.0.0.1:20932/key/info -H "Authorization: Bearer $KEY"
{"key_alias":"lit7002-after-r9-image","spend":0.01108,"max_budget":0.1}

===== case anthropic: /v1/chat/completions claude-haiku-4-5 key max_budget 0.085 =====
prompt starts with: [run 95e595f9-1c03-4bfc-92b6-87eee48a5357] Reply with the si
$ curl -s -X POST http://127.0.0.1:20932/key/generate -H 'Authorization: Bearer sk-lit7002-master' -H 'Content-Type: application/json' -d '{"max_budget": 0.085, "key_alias": "lit7002-after-r9-anthropic"}'
-> key sk-FqM4q... max_budget 0.085
$ curl -s -D headers.txt -o response.json -w 'http %{http_code} in %{time_total}s' -X POST http://127.0.0.1:20932/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' --data-binary @anthropic_request.json
http 200 in 1.416170s
x-litellm-response-cost: 0.05936399999999999
x-litellm-key-max-budget: 0.085
x-litellm-key-spend: 0.05936399999999999
response.json (usage or error):
{"usage":{"completion_tokens":4,"prompt_tokens":59344,"total_tokens":59348,"completion_tokens_details":{"reasoning_tokens":0,"text_tokens":4},"prompt_tokens_details":{"cached_tokens":0,"text_tokens":59344,"cache_write_tokens":0,"cache_creation_tokens":0,"cache_creation_token_details":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0}},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"not_available","service_tier":"standard"}}
$ curl -s http://127.0.0.1:20932/key/info -H "Authorization: Bearer $KEY"
{"key_alias":"lit7002-after-r9-anthropic","spend":0.05936399999999999,"max_budget":0.085}

===== case flex: /v1/chat/completions gpt-5.5 key max_budget 0.60 =====
prompt starts with: [run 4b0ca81d-c5ec-4ddf-84b3-aef06c76f5e1] Reply with the si
$ curl -s -X POST http://127.0.0.1:20932/key/generate -H 'Authorization: Bearer sk-lit7002-master' -H 'Content-Type: application/json' -d '{"max_budget": 0.60, "key_alias": "lit7002-after-r9-flex"}'
-> key sk-rrqHj... max_budget 0.6
$ curl -s -D headers.txt -o response.json -w 'http %{http_code} in %{time_total}s' -X POST http://127.0.0.1:20932/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' --data-binary @flex_request.json
http 200 in 0.943697s
x-litellm-response-cost: 0.00036250000000000003
x-litellm-key-max-budget: 0.6
x-litellm-key-spend: 0.00036250000000000003
response.json (usage or error):
{"usage":{"completion_tokens":17,"prompt_tokens":43,"total_tokens":60,"completion_tokens_details":{"accepted_prediction_tokens":0,"audio_tokens":0,"reasoning_tokens":7,"rejected_prediction_tokens":0},"prompt_tokens_details":{"audio_tokens":0,"cached_tokens":0}}}
$ curl -s http://127.0.0.1:20932/key/info -H "Authorization: Bearer $KEY"
{"key_alias":"lit7002-after-r9-flex","spend":0.0003625,"max_budget":0.6}
```

### Before (02cbff4918), a priority request, a mixed-price group, and a short and a long prompt

The keys with a `max_budget` of 0.000001 exist to read the reservation out of the refusal message; nothing about them can pass. The merge base prices the `gpt-5.5-mixed` group off its cheaper deployment, prices the priority request at the standard rate, and holds the same input rate for a 48-token prompt as for a 2,655-token one

```console
===== case priority: /v1/chat/completions gpt-5.5 key max_budget 2.00 =====
prompt starts with: [run 6c30547e-a129-4b13-b782-35ca03cec517] Reply with the si
$ curl -s -X POST http://127.0.0.1:24033/key/generate -H 'Authorization: Bearer sk-lit7002-master' -H 'Content-Type: application/json' -d '{"max_budget": 2.00, "key_alias": "lit7002-base-r9c4-priority"}'
-> key sk-29krM... max_budget 2.0
$ curl -s -D headers.txt -o response.json -w 'http %{http_code} in %{time_total}s' -X POST http://127.0.0.1:24033/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' --data-binary @priority.json
http 200 in 1.268360s
x-litellm-response-cost: 0.001725
response.json (usage or error):
{"usage":{"completion_tokens":17,"prompt_tokens":36,"total_tokens":53,"completion_tokens_details":{"accepted_prediction_tokens":0,"audio_tokens":0,"reasoning_tokens":7,"rejected_prediction_tokens":0},"prompt_tokens_details":{"audio_tokens":0,"cached_tokens":0}}}
$ curl -s http://127.0.0.1:24033/key/info -H "Authorization: Bearer $KEY"
{"key_alias":"lit7002-base-r9c4-priority","spend":0.001725,"max_budget":2.0}

===== case mixed-group: /v1/chat/completions gpt-5.5-mixed key max_budget 0.000001 =====
prompt starts with: [run 3be56fe7-a409-4601-96a7-b6d8d0c69399] Reply with the si
$ curl -s -X POST http://127.0.0.1:24033/key/generate -H 'Authorization: Bearer sk-lit7002-master' -H 'Content-Type: application/json' -d '{"max_budget": 0.000001, "key_alias": "lit7002-base-r9c4-mixed-group"}'
-> key sk-pQoxq... max_budget 0.000001
$ curl -s -D headers.txt -o response.json -w 'http %{http_code} in %{time_total}s' -X POST http://127.0.0.1:24033/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' --data-binary @mixed-group.json
http 429 in 0.014656s
response.json (usage or error):
{"error":{"message":"Budget has been exceeded! Key=15160a1b1f6a734a4c0b6d320f716d3ec3f90331d724a4b4a8ef2ddd8422292d Current cost: 0.0, Estimated request cost: 0.900205, Max budget: 1e-06","type":"budget_exceeded","param":null,"code":"429"}}
$ curl -s http://127.0.0.1:24033/key/info -H "Authorization: Bearer $KEY"
{"key_alias":"lit7002-base-r9c4-mixed-group","spend":0.0,"max_budget":0.000001}

===== case short-pass: /v1/chat/completions gpt-5.6-luna key max_budget 0.01 =====
prompt starts with: [run 77892cc7-89f5-4921-85a0-868d8ad6dd0b] Reply with the si
$ curl -s -X POST http://127.0.0.1:24033/key/generate -H 'Authorization: Bearer sk-lit7002-master' -H 'Content-Type: application/json' -d '{"max_budget": 0.01, "key_alias": "lit7002-base-r9c4-short-pass"}'
-> key sk-VKgKT... max_budget 0.01
$ curl -s -D headers.txt -o response.json -w 'http %{http_code} in %{time_total}s' -X POST http://127.0.0.1:24033/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' --data-binary @short-pass.json
http 200 in 0.458876s
x-litellm-response-cost: 8.4e-06
response.json (usage or error):
{"usage":{"completion_tokens":0,"prompt_tokens":42,"total_tokens":42}}
$ curl -s http://127.0.0.1:24033/key/info -H "Authorization: Bearer $KEY"
{"key_alias":"lit7002-base-r9c4-short-pass","spend":0.0000084,"max_budget":0.01}

===== case short-estimate: /v1/chat/completions gpt-5.6-luna key max_budget 0.000001 =====
prompt starts with: [run 2edc2c18-b5a7-47f7-b482-4ba018c93c23] Reply with the si
$ curl -s -X POST http://127.0.0.1:24033/key/generate -H 'Authorization: Bearer sk-lit7002-master' -H 'Content-Type: application/json' -d '{"max_budget": 0.000001, "key_alias": "lit7002-base-r9c4-short-estimate"}'
-> key sk-zkhht... max_budget 0.000001
$ curl -s -D headers.txt -o response.json -w 'http %{http_code} in %{time_total}s' -X POST http://127.0.0.1:24033/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' --data-binary @short-estimate.json
http 429 in 0.041605s
response.json (usage or error):
{"error":{"message":"Budget has been exceeded! Key=7c58f33af902bf894fdf0438352d1843e3bd23446044107e43fe6ffc24631ca7 Current cost: 0.0, Estimated request cost: 9.6e-06, Max budget: 1e-06","type":"budget_exceeded","param":null,"code":"429"}}
$ curl -s http://127.0.0.1:24033/key/info -H "Authorization: Bearer $KEY"
{"key_alias":"lit7002-base-r9c4-short-estimate","spend":0.0,"max_budget":0.000001}

===== case long-estimate: /v1/chat/completions gpt-5.6-luna key max_budget 0.000001 =====
prompt starts with: [run 1933a5e0-79fd-4910-9291-ffb497e96db2] The quick brown f
$ curl -s -X POST http://127.0.0.1:24033/key/generate -H 'Authorization: Bearer sk-lit7002-master' -H 'Content-Type: application/json' -d '{"max_budget": 0.000001, "key_alias": "lit7002-base-r9c4-long-estimate"}'
-> key sk-jaQE8... max_budget 0.000001
$ curl -s -D headers.txt -o response.json -w 'http %{http_code} in %{time_total}s' -X POST http://127.0.0.1:24033/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' --data-binary @long-estimate.json
http 429 in 0.021431s
response.json (usage or error):
{"error":{"message":"Budget has been exceeded! Key=167bf52754b2df27d3d387df414b41f98d56e9395011afb84a9f06ec67eec7cd Current cost: 0.0, Estimated request cost: 0.000531, Max budget: 1e-06","type":"budget_exceeded","param":null,"code":"429"}}
$ curl -s http://127.0.0.1:24033/key/info -H "Authorization: Bearer $KEY"
{"key_alias":"lit7002-base-r9c4-long-estimate","spend":0.0,"max_budget":0.000001}
```

### After (272bdc4960), a priority request, a mixed-price group, and a short and a long prompt

The priority request still passes on a $2.00 key, since a budget that size covers the priority rate too. The mixed group is priced off its priority-pinned deployment, 2.2505125 against the merge base's 0.900205, because the router has not picked a deployment yet. The 48-token prompt reserves 9.6e-06 on both sides, the same plain input rate, while the 2,655-token one moves from 0.000531 to 0.00066345, the cache-creation rate OpenAI bills once a prompt is long enough for it to cache

```console
===== case priority: /v1/chat/completions gpt-5.5 key max_budget 2.00 =====
prompt starts with: [run 6c30547e-a129-4b13-b782-35ca03cec517] Reply with the si
$ curl -s -X POST http://127.0.0.1:30031/key/generate -H 'Authorization: Bearer sk-lit7002-master' -H 'Content-Type: application/json' -d '{"max_budget": 2.00, "key_alias": "lit7002-after-r9c4-priority"}'
-> key sk-KUx5H... max_budget 2.0
$ curl -s -D headers.txt -o response.json -w 'http %{http_code} in %{time_total}s' -X POST http://127.0.0.1:30031/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' --data-binary @priority.json
http 200 in 1.187577s
x-litellm-response-cost: 0.001725
response.json (usage or error):
{"usage":{"completion_tokens":17,"prompt_tokens":36,"total_tokens":53,"completion_tokens_details":{"accepted_prediction_tokens":0,"audio_tokens":0,"reasoning_tokens":7,"rejected_prediction_tokens":0},"prompt_tokens_details":{"audio_tokens":0,"cached_tokens":0}}}
$ curl -s http://127.0.0.1:30031/key/info -H "Authorization: Bearer $KEY"
{"key_alias":"lit7002-after-r9c4-priority","spend":0.001725,"max_budget":2.0}

===== case mixed-group: /v1/chat/completions gpt-5.5-mixed key max_budget 0.000001 =====
prompt starts with: [run 3be56fe7-a409-4601-96a7-b6d8d0c69399] Reply with the si
$ curl -s -X POST http://127.0.0.1:30031/key/generate -H 'Authorization: Bearer sk-lit7002-master' -H 'Content-Type: application/json' -d '{"max_budget": 0.000001, "key_alias": "lit7002-after-r9c4-mixed-group"}'
-> key sk-jP0T8... max_budget 0.000001
$ curl -s -D headers.txt -o response.json -w 'http %{http_code} in %{time_total}s' -X POST http://127.0.0.1:30031/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' --data-binary @mixed-group.json
http 429 in 0.122301s
response.json (usage or error):
{"error":{"message":"Budget has been exceeded! Key=daf9818989954876c1360764aa069e07c67660e8423d40b394cf5f39ab92407e Current cost: 0.0, Estimated request cost: 2.2505125, Max budget: 1e-06","type":"budget_exceeded","param":null,"code":"429"}}
$ curl -s http://127.0.0.1:30031/key/info -H "Authorization: Bearer $KEY"
{"key_alias":"lit7002-after-r9c4-mixed-group","spend":0.0,"max_budget":0.000001}

===== case short-pass: /v1/chat/completions gpt-5.6-luna key max_budget 0.01 =====
prompt starts with: [run 77892cc7-89f5-4921-85a0-868d8ad6dd0b] Reply with the si
$ curl -s -X POST http://127.0.0.1:30031/key/generate -H 'Authorization: Bearer sk-lit7002-master' -H 'Content-Type: application/json' -d '{"max_budget": 0.01, "key_alias": "lit7002-after-r9c4-short-pass"}'
-> key sk-Y1xu8... max_budget 0.01
$ curl -s -D headers.txt -o response.json -w 'http %{http_code} in %{time_total}s' -X POST http://127.0.0.1:30031/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' --data-binary @short-pass.json
http 200 in 0.507014s
x-litellm-response-cost: 8.4e-06
response.json (usage or error):
{"usage":{"completion_tokens":0,"prompt_tokens":42,"total_tokens":42}}
$ curl -s http://127.0.0.1:30031/key/info -H "Authorization: Bearer $KEY"
{"key_alias":"lit7002-after-r9c4-short-pass","spend":0.0000084,"max_budget":0.01}

===== case short-estimate: /v1/chat/completions gpt-5.6-luna key max_budget 0.000001 =====
prompt starts with: [run 2edc2c18-b5a7-47f7-b482-4ba018c93c23] Reply with the si
$ curl -s -X POST http://127.0.0.1:30031/key/generate -H 'Authorization: Bearer sk-lit7002-master' -H 'Content-Type: application/json' -d '{"max_budget": 0.000001, "key_alias": "lit7002-after-r9c4-short-estimate"}'
-> key sk-uottn... max_budget 0.000001
$ curl -s -D headers.txt -o response.json -w 'http %{http_code} in %{time_total}s' -X POST http://127.0.0.1:30031/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' --data-binary @short-estimate.json
http 429 in 0.017498s
response.json (usage or error):
{"error":{"message":"Budget has been exceeded! Key=648448a0b76df3fd1f0bdb6dd500e498aabd84faf7e29c4f4c0530810a550578 Current cost: 0.0, Estimated request cost: 9.6e-06, Max budget: 1e-06","type":"budget_exceeded","param":null,"code":"429"}}
$ curl -s http://127.0.0.1:30031/key/info -H "Authorization: Bearer $KEY"
{"key_alias":"lit7002-after-r9c4-short-estimate","spend":0.0,"max_budget":0.000001}

===== case long-estimate: /v1/chat/completions gpt-5.6-luna key max_budget 0.000001 =====
prompt starts with: [run 1933a5e0-79fd-4910-9291-ffb497e96db2] The quick brown f
$ curl -s -X POST http://127.0.0.1:30031/key/generate -H 'Authorization: Bearer sk-lit7002-master' -H 'Content-Type: application/json' -d '{"max_budget": 0.000001, "key_alias": "lit7002-after-r9c4-long-estimate"}'
-> key sk-XVao7... max_budget 0.000001
$ curl -s -D headers.txt -o response.json -w 'http %{http_code} in %{time_total}s' -X POST http://127.0.0.1:30031/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' --data-binary @long-estimate.json
http 429 in 0.013120s
response.json (usage or error):
{"error":{"message":"Budget has been exceeded! Key=3be70cd5a226aac7a7d30598d05411c8c921572b794829846f5ec0e73e13b66b Current cost: 0.0, Estimated request cost: 0.00066345, Max budget: 1e-06","type":"budget_exceeded","param":null,"code":"429"}}
$ curl -s http://127.0.0.1:30031/key/info -H "Authorization: Bearer $KEY"
{"key_alias":"lit7002-after-r9c4-long-estimate","spend":0.0,"max_budget":0.000001}
```

### Before (02cbff4918), the same priority request with fail-closed off

Fail-closed off is the stock setting, and it is what decides whether a bigger reservation refuses anything. The merge base admits the request and bills 0.001725

```console
===== case priority-nofc: /v1/chat/completions gpt-5.5 service_tier priority, key max_budget 1.00, fail-closed OFF =====
$ curl -s -X POST http://127.0.0.1:31442/key/generate -H 'Authorization: Bearer sk-lit7002-master' -H 'Content-Type: application/json' -d '{"max_budget": 1.00, "key_alias": "lit7002-base-r9c5b-priority-nofc"}'
-> key sk-gctLP... max_budget 1.0
$ curl -s -D headers.txt -o response.json -w 'http %{http_code} in %{time_total}s' -X POST http://127.0.0.1:31442/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' --data-binary @priority.json
http 200 in 1.295638s
x-litellm-response-cost: 0.001725
response.json (usage or error):
{"usage":{"completion_tokens":17,"prompt_tokens":36,"total_tokens":53,"completion_tokens_details":{"accepted_prediction_tokens":0,"audio_tokens":0,"reasoning_tokens":7,"rejected_prediction_tokens":0},"prompt_tokens_details":{"audio_tokens":0,"cached_tokens":0}}}
$ curl -s http://127.0.0.1:31442/key/info -H "Authorization: Bearer $KEY"
{"key_alias":"lit7002-base-r9c5b-priority-nofc","spend":0.001725,"max_budget":1.0}
```

### After (272bdc4960), the same priority request with fail-closed off

The reservation is now larger than the $1.00 the key has (1.2290625, from the fail-closed reading in the caveats below), so it is resized down to what is left and the request is admitted anyway, with the same 0.001725 billed. Nothing is refused until the budget is actually spent or held by requests running at the same time, which is why every refusal quoted in the caveats below is quoted with `fail_closed_budget_enforcement` on

```console
===== case priority-nofc: /v1/chat/completions gpt-5.5 service_tier priority, key max_budget 1.00, fail-closed OFF =====
$ curl -s -X POST http://127.0.0.1:21903/key/generate -H 'Authorization: Bearer sk-lit7002-master' -H 'Content-Type: application/json' -d '{"max_budget": 1.00, "key_alias": "lit7002-after-r9c5b-priority-nofc"}'
-> key sk-1V1ld... max_budget 1.0
$ curl -s -D headers.txt -o response.json -w 'http %{http_code} in %{time_total}s' -X POST http://127.0.0.1:21903/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' --data-binary @priority.json
http 200 in 1.687993s
x-litellm-response-cost: 0.001725
response.json (usage or error):
{"usage":{"completion_tokens":17,"prompt_tokens":36,"total_tokens":53,"completion_tokens_details":{"accepted_prediction_tokens":0,"audio_tokens":0,"reasoning_tokens":7,"rejected_prediction_tokens":0},"prompt_tokens_details":{"audio_tokens":0,"cached_tokens":0}}}
$ curl -s http://127.0.0.1:21903/key/info -H "Authorization: Bearer $KEY"
{"key_alias":"lit7002-after-r9c5b-priority-nofc","spend":0.001725,"max_budget":1.0}
```

## Type

🐛 Bug Fix

## Caveats (if any)

### Severe

- Reservation is on by default, so upgrading refuses long-context traffic that used to pass. Of the 3,817 entries in the cost map, 173 reserve more than they did at the merge base for a 300K-token standard-tier prompt (1.25x to 6.6x, most between 1.85x and 2.25x) and 24 do for a 5,000-token prompt (about 1.4%); none reserve less. Any key, team, user, or organization sitting just inside its cap on those models starts getting 429s, so raise the caps before upgrading. With stock settings a reservation the budget cannot cover is resized down to what is left and the request still goes through, so the refusals land once the budget is spent or held by requests running at the same time, while `general_settings.fail_closed_budget_enforcement` refuses the first oversized request outright. The only escape hatch is `general_settings.disable_budget_reservation`
- Image generation reserves the picture's price for the first time on a proxy. A router hands the reservation a model-group view that drops `input_cost_per_image` and `output_cost_per_image`, so at the merge base a router-served image request reserved $0 whatever the picture cost, and reading the deployment's own cost info is what surfaces the price. 238 named entries in the cost map are priced per image (median $0.04, up to $0.60), so a key sitting close to its cap now gets a 429 on an image route where it used to get the picture and go over. Live against a `dall-e-3` deployment on a $0.02 key with fail-closed on, `POST /v1/images/generations` reached OpenAI at 02cbff4918 and is refused at 272bdc4960 with `Estimated request cost: 0.04, Max budget: 0.02`. Image models priced per token are unaffected: gpt-image-1 reserves 5e-05 on both sides
- A request that names `service_tier: "priority"` reserves at the priority rates, which the cost map sets between 1.67x and 2.5x the standard rates on 113 of the 116 entries carrying them, so the tier a key was already paying for now costs it that much of its budget up front. Live on gpt-5.5 with a $1.00 key and fail-closed on, the request passed at 02cbff4918 and is refused at 272bdc4960 with `Estimated request cost: 1.2290625, Max budget: 1.0`. With fail-closed off the same request comes back 200 on both trees, since the reservation is resized down to the $1.00 that is left. `gpt-5-nano` and `gpt-5-nano-2025-08-07` sit at 50x, far outside what every other entry shows, which reads like a cost-map typo rather than a real price, and both the bill and the reservation read it
- A deployment priced above its siblings raises the reservation for the whole model group. The router picks the deployment after the reservation is taken, so the group has to be priced at its dearest deployment, and a `gpt-5.5` group holding one standard deployment and one pinned to `service_tier: priority` reserves 2.2505125 for a request the merge base reserved 0.900205 for, including the requests the router sends to the standard deployment. A sibling on a regional host raises the group the same way, by the 1.1x the cost map prices that region at. Pricing the group at its cheapest deployment is the under-reservation this PR exists to fix, so the way around it is to put priced-up deployments in a model group of their own
- A reservation is an optimistic ceiling, not the bill. Output is priced at `max_tokens` and every token class at the highest rate it can reach, so a request is refused whenever its ceiling exceeds the remaining budget even though the finished request would have billed less. A $3.20 key refuses a request that bills $3.05

### Medium

- A request that marks its own `cache_control` breakpoint reserves every input token at the cache-creation rate, while Anthropic bills that rate only up to the last breakpoint and the rest at the input rate. The reservation therefore holds an extra 25% of the input rate on every token after the breakpoint. Splitting the count there would mean tokenizing each block on its own, and the hold is released the moment the request finishes
- Cache breakpoints LiteLLM injects itself are invisible to the reservation. `body_has_cache_control` reads the request body, while `litellm.enable_anthropic_prompt_caching`, a key's `enable_prompt_caching`, and a deployment's `cache_control_injection_points` all add their breakpoint after the reservation is taken, so those requests reserve the input rate and bill the write rate: 0.00091100 reserved with the automatic caching on against 0.00101375 when the client marks the same block itself. This is the same under-reservation the merge base has on every path, and closing it means reaching key and deployment config from the reservation
- OpenAI models served through an aggregator carry that aggregator's `litellm_provider`, so the automatic cache-write rate is not held for them: 17 entries across `bedrock_mantle`, `bedrock_converse`, `databricks`, and `openrouter`, 16 of which bill cache writes at 1.25x their input rate. A provider-name set cannot tell them apart from the Anthropic models on those same providers without over-reserving every one of those. This gap is unchanged from the merge base
- Image models priced per token rather than per image (the gpt-image-1 family, `azure/gpt-image-*`, `chatgpt-image-latest`, `azure_ai/MAI-Image-*`) still reserve only their input tokens, well under the price of the picture. The real per-image price lives in the size and quality keyed cost-map entries that `default_image_cost_calculator` resolves at bill time, and duplicating that lookup here would fork the pricing logic. This under-reservation is pre-existing at the merge base

### Low

- A request that names `service_tier: "flex"` reserves half of what it did before, the only direction any reservation moved down. The bill reads the same flex keys the reservation now reads, so the smaller hold still covers the request in full
- The regional uplift is the one rate this run did not drive on a live host, since the rig has no EU or other regional deployment to call. It rests on the unit tests and on the `_eu` and `_us` keys in the cost map rather than on an observed request
- The off-peak safeguard, which never lowers a reservation on the strength of a discount window that can close before the response lands, cannot fire on any model in `model_prices_and_context_window.json`, since `off_peak_pricing` appears there zero times. It only reaches config-priced and DB-priced deployments

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
- [x] 272bdc4960 passes /live-pr-risk
