### PR TITLE
fix(vertex): sanitise empty-string enums under anyOf

### DIFF
--- a/litellm/llms/vertex_ai/common_utils.py
+++ b/litellm/llms/vertex_ai/common_utils.py
@@ -571,6 +571,9 @@ def _fix_enum_empty_strings(schema, depth=0):
     if depth > DEFAULT_MAX_RECURSE_DEPTH:
         raise ValueError(f"Max depth of {DEFAULT_MAX_RECURSE_DEPTH} exceeded while processing schema.")
 
+    if not isinstance(schema, dict):
+        return
+
     if "enum" in schema and isinstance(schema["enum"], list):
         schema["enum"] = [None if value == "" else value for value in schema["enum"]]
 
@@ -583,6 +586,14 @@ def _fix_enum_empty_strings(schema, depth=0):
     items: Final = schema.get("items", None)
     if items is not None:
         _fix_enum_empty_strings(items, depth=depth + 1)
+
+    # An Optional[Literal[...]] arrives here as an `anyOf` branch, because
+    # convert_anyof_null_to_nullable runs first. Without this arm the empty string
+    # survives on optional fields while the same enum is fixed on required ones.
+    anyof: Final = schema.get("anyOf", None)
+    if anyof is not None and isinstance(anyof, list):
+        for item in anyof:
+            _fix_enum_empty_strings(item, depth=depth + 1)
 
 
 def _fix_enum_types(schema, depth=0):

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
@@ -1779,3 +1779,69 @@ def test_get_vertex_ai_lyria_model_info_falls_back_to_bundled_map(monkeypatch):
     assert model_info is not None
     assert model_info["vertex_ai_audio_api"] == "lyria_interactions"
     assert model_info["supported_audio_formats"] == ("mp3", "wav")
+
+
+def test_fix_enum_empty_strings_nullable_enum():
+    """An Optional[Literal["", ...]] field must be sanitised like a required one.
+
+    convert_anyof_null_to_nullable runs before _fix_enum_empty_strings, so a nullable
+    enum has already become an `anyOf` branch by the time the sanitiser sees it. Without
+    recursion into `anyOf` the empty string survives on the optional field only.
+    """
+    from litellm.llms.vertex_ai.common_utils import _fix_enum_empty_strings
+
+    schema = {
+        "type": "object",
+        "properties": {
+            "mode": {"anyOf": [{"type": "string", "enum": ["", "fast", "slow"]}, {"type": "null"}]},
+            "plain_mode": {"type": "string", "enum": ["", "fast", "slow"]},
+        },
+    }
+
+    _fix_enum_empty_strings(schema)
+
+    assert schema["properties"]["mode"]["anyOf"][0]["enum"] == [None, "fast", "slow"]
+    assert schema["properties"]["plain_mode"]["enum"] == [None, "fast", "slow"]
+
+
+def test_fix_enum_empty_strings_anyof_without_a_null_branch():
+    """The gap is not limited to nullable fields - any enum under `anyOf` was missed."""
+    from litellm.llms.vertex_ai.common_utils import _fix_enum_empty_strings
+
+    schema = {
+        "type": "object",
+        "properties": {"m": {"anyOf": [{"type": "string", "enum": ["", "a"]}, {"type": "integer"}]}},
+    }
+
+    _fix_enum_empty_strings(schema)
+
+    assert schema["properties"]["m"]["anyOf"][0]["enum"] == [None, "a"]
+
+
+def test_fix_enum_empty_strings_tolerates_a_non_dict_anyof_branch():
+    """A malformed branch must not raise, matching _fix_enum_types' isinstance guard."""
+    from litellm.llms.vertex_ai.common_utils import _fix_enum_empty_strings
+
+    schema = {"anyOf": ["string", {"type": "string", "enum": ["", "a"]}]}
+
+    _fix_enum_empty_strings(schema)
+
+    assert schema["anyOf"][1]["enum"] == [None, "a"]
+
+
+def test_build_vertex_schema_sanitises_a_nullable_enum_end_to_end():
+    """The whole pipeline, as a tool schema reaches it from pydantic."""
+    from litellm.llms.vertex_ai.common_utils import _build_vertex_schema
+
+    parameters = {
+        "type": "object",
+        "properties": {
+            "mode": {"anyOf": [{"type": "string", "enum": ["", "fast", "slow"]}, {"type": "null"}]},
+            "plain_mode": {"type": "string", "enum": ["", "fast", "slow"]},
+        },
+    }
+
+    built = _build_vertex_schema(parameters)
+
+    assert "" not in built["properties"]["mode"]["anyOf"][0]["enum"]
+    assert "" not in built["properties"]["plain_mode"]["enum"]


### PR DESCRIPTION
## TLDR

Problem this solves:

- Optional enum fields keep the empty string Gemini rejects
- The same enum on a required field is sanitised correctly
- Every tool carrying one is rejected, whatever the prompt

How it solves it:

- Recurse into `anyOf`, which is where a nullable enum ends up
- Mirrors the sibling function that already does this

## User Flow

Before a (hypothetical) fix: a developer running the proxy in front of `gemini/gemini-2.5-flash` finds one of their agent's tools is rejected on every call, while the same agent works against other providers.

1. They start the proxy with a `gemini/gemini-2.5-flash` model and point their agent at it
2. Their tool `set_mode` has two fields sharing one enum: `mode: Optional[Literal["", "fast", "slow"]]` and `plain_mode: Literal["", "fast", "slow"]`, where `""` is how the tool's author spells "unset"
3. They send POST https://litellm-domain/v1/chat/completions with `{"model": "gemini-2.5-flash", "messages": [{"role": "user", "content": "go"}], "tools": [ ... set_mode ... ]}`
4. The call comes back as a 400 from the upstream model complaining about the tool definition, not about anything in their prompt
5. They drop `mode` and resend: it succeeds. They restore `mode` and drop `""` from the `Literal`: it succeeds. So it fails only when the enum containing `""` sits on the optional field
6. Nothing in the response tells them which of the two identical-looking fields is at fault

After a (hypothetical) fix: the same request returns a completion, and the tool behaves the same whether the enum field is optional or required.

1. They start the proxy with a `gemini/gemini-2.5-flash` model and point their agent at it
2. Their tool `set_mode` has the same two fields, unchanged
3. They send the same POST https://litellm-domain/v1/chat/completions
4. They get a 200 with a completion, and a tool call for `set_mode` when the model chooses it
5. Both fields accept the same values, with `""` surfacing as a null - the behaviour the required field already had

## Relevant issues

Fixes #40003

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.) — **99 checks green, 0 failures**
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review — scored **5/5** after opening

## Type

🐛 Bug Fix

## Changes

`_fix_enum_empty_strings()` replaced `""` with `None` in enum arrays, recursing into `properties` and `items` but not `anyOf`. `_build_vertex_schema()` runs `convert_anyof_null_to_nullable()` before it, so an `Optional[Literal["", ...]]` field - what pydantic, zod-to-json-schema and most MCP servers emit for a nullable enum - is already an `anyOf` branch by then. That branch was never visited, so the empty string reached the `functionDeclarations` payload. The gap is not limited to nullable fields: any enum under `anyOf` was missed.

The sibling `_fix_enum_types()`, defined immediately below and called immediately after, already recurses into `anyOf`. This adds the same arm, plus the `isinstance(schema, dict)` guard that function also has - without it a malformed non-dict branch raises `AttributeError` once the arm exists.

## Proof of fix

Four regression tests, all failing before the change and passing after:

| run | result |
|---|---|
| the four new tests, production change reverted | **4 failed** |
| the four new tests, change applied | 4 passed |
| `tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py` | **86 passed** |

They cover the nullable enum, an `anyOf` with no null branch, a non-dict branch reaching the new guard, and `_build_vertex_schema()` end to end.

Observed on the unpatched tree, taking a pydantic schema through `litellm.completion()` with the transport stubbed so the recorded body is what would have gone to `generateContent`:

```
OUTBOUND nullable enum -> {"anyOf": [{"enum": ["", "fast", "slow"], "type": "string", "nullable": true, "title": "Mode"}]}
OUTBOUND plain    enum -> {"default": "fast", "enum": [null, "fast", "slow"], "title": "Plain Mode", "type": "string"}
```

Verified on `litellm_internal_staging` at `2151dcbd`, v1.101.0. No provider call is made by any of the tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
