### PR TITLE
feat: add APIMODELS as an OpenAI-compatible provider

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -875,6 +875,7 @@ openai_compatible_endpoints: Final[list] = [
     "https://api.cognition.ai/v1",
     "https://api.scx.ai/v1",
     "https://gigachat.devices.sberbank.ru/api/v1",
+    "https://api.apimodels.app/v1",
 ]
 
 
@@ -946,6 +947,7 @@ openai_compatible_providers: Final[list] = [
     "meta",  # Meta Model API (Muse Spark) - JSON-configured provider
     "cognition",
     "scx-ai",
+    "apimodels",  # APIMODELS - JSON-configured provider
 ]
 openai_text_completion_compatible_providers: Final[list] = [  # providers that support `/v1/completions`
     "together_ai",

--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -200,5 +200,11 @@
       "temperature_max": 1.99
     },
     "supported_endpoints": ["/v1/chat/completions"]
+  },
+  "apimodels": {
+    "base_url": "https://api.apimodels.app/v1",
+    "api_key_env": "APIMODELS_API_KEY",
+    "api_base_env": "APIMODELS_API_BASE",
+    "supported_endpoints": ["/v1/chat/completions", "/v1/responses"]
   }
 }

--- a/litellm/proxy/public_endpoints/provider_create_fields.json
+++ b/litellm/proxy/public_endpoints/provider_create_fields.json
@@ -2873,6 +2873,34 @@
     "default_model_placeholder": "scx-ai/GLM-5.2"
   },
   {
+    "provider": "APIMODELS",
+    "provider_display_name": "APIMODELS",
+    "litellm_provider": "apimodels",
+    "credential_fields": [
+      {
+        "key": "api_base",
+        "label": "API Base",
+        "placeholder": "https://api.apimodels.app/v1",
+        "tooltip": null,
+        "required": false,
+        "field_type": "text",
+        "options": null,
+        "default_value": null
+      },
+      {
+        "key": "api_key",
+        "label": "API Key",
+        "placeholder": null,
+        "tooltip": null,
+        "required": true,
+        "field_type": "password",
+        "options": null,
+        "default_value": null
+      }
+    ],
+    "default_model_placeholder": "apimodels/gpt-5.6-luna"
+  },
+  {
     "provider": "Snowflake",
     "provider_display_name": "Snowflake",
     "litellm_provider": "snowflake",

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3974,6 +3974,7 @@ class LlmProviders(str, Enum):
     PINSTRIPES = "pinstripes"
     COGNITION = "cognition"
     SCX_AI = "scx-ai"
+    APIMODELS = "apimodels"
     DARKBLOOM = "darkbloom"
     META = "meta"
     LITELLM_AGENT = "litellm_agent"

--- a/tests/test_litellm/llms/openai_like/test_apimodels_provider.py
+++ b/tests/test_litellm/llms/openai_like/test_apimodels_provider.py
@@ -1,0 +1,128 @@
+"""
+Tests for the APIMODELS provider configuration.
+
+APIMODELS (https://apimodels.app) is an OpenAI-compatible gateway, so it is
+registered through the JSON provider system rather than a bespoke Python module.
+These tests are pure configuration assertions and mocks — no network calls.
+"""
+
+import litellm
+
+
+class TestAPIModelsProviderConfig:
+    def test_apimodels_in_provider_list(self):
+        from litellm import LlmProviders
+
+        assert hasattr(LlmProviders, "APIMODELS")
+        assert LlmProviders.APIMODELS.value == "apimodels"
+        assert "apimodels" in litellm.provider_list
+
+    def test_apimodels_json_config_exists(self):
+        from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+
+        assert JSONProviderRegistry.exists("apimodels")
+
+        provider = JSONProviderRegistry.get("apimodels")
+        assert provider is not None
+        assert provider.base_url == "https://api.apimodels.app/v1"
+        assert provider.api_key_env == "APIMODELS_API_KEY"
+
+    def test_apimodels_in_openai_compatible_providers(self):
+        from litellm.constants import openai_compatible_providers
+
+        assert "apimodels" in openai_compatible_providers
+
+    def test_apimodels_supports_responses_api(self):
+        from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+
+        assert JSONProviderRegistry.supports_responses_api("apimodels")
+
+    def test_apimodels_provider_resolution(self):
+        from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+
+        model, provider, api_key, api_base = get_llm_provider(
+            model="apimodels/gpt-5.6-luna",
+            custom_llm_provider=None,
+            api_base=None,
+            api_key=None,
+        )
+
+        assert model == "gpt-5.6-luna"
+        assert provider == "apimodels"
+        assert api_base == "https://api.apimodels.app/v1"
+
+    def test_apimodels_api_base_override(self):
+        from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+
+        model, provider, api_key, api_base = get_llm_provider(
+            model="apimodels/gpt-5.6-luna",
+            custom_llm_provider=None,
+            api_base="https://custom.apimodels.app/v1",
+            api_key="sk-test",
+        )
+
+        assert provider == "apimodels"
+        assert api_base == "https://custom.apimodels.app/v1"
+        assert api_key == "sk-test"
+
+    def test_apimodels_url_autodetection(self):
+        from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+
+        model, provider, api_key, api_base = get_llm_provider(
+            model="gpt-5.6-luna",
+            custom_llm_provider=None,
+            api_base="https://api.apimodels.app/v1",
+            api_key=None,
+        )
+
+        assert provider == "apimodels"
+        assert api_base == "https://api.apimodels.app/v1"
+
+    def test_apimodels_router_config(self):
+        from litellm import Router
+
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "apimodels-chat",
+                    "litellm_params": {
+                        "model": "apimodels/gpt-5.6-luna",
+                        "api_key": "test-key",
+                    },
+                }
+            ]
+        )
+
+        assert len(router.model_list) == 1
+        assert router.model_list[0]["model_name"] == "apimodels-chat"
+
+
+class TestAPIModelsDashboardRegistration:
+    @staticmethod
+    def _provider_create_fields():
+        import json
+        from pathlib import Path
+
+        path = (
+            Path(litellm.__file__).parent
+            / "proxy"
+            / "public_endpoints"
+            / "provider_create_fields.json"
+        )
+        with open(path) as f:
+            return json.load(f)
+
+    def test_apimodels_is_selectable_in_the_add_model_form(self):
+        entries = [
+            e for e in self._provider_create_fields() if e["litellm_provider"] == "apimodels"
+        ]
+        assert len(entries) == 1, "apimodels must appear exactly once in provider_create_fields.json"
+
+        entry = entries[0]
+        assert entry["provider"] == "APIMODELS"
+        assert entry["default_model_placeholder"].startswith("apimodels/")
+
+        fields = {f["key"]: f for f in entry["credential_fields"]}
+        assert fields["api_key"]["required"] is True
+        assert fields["api_key"]["field_type"] == "password"
+        assert fields["api_base"]["required"] is False


### PR DESCRIPTION
## What

Adds [APIMODELS](https://apimodels.app) as an OpenAI-compatible provider through the JSON provider system.

## Files changed

| File | Why |
|---|---|
| `litellm/llms/openai_like/providers.json` | `base_url`, `api_key_env`, `api_base_env`, `supported_endpoints` (`/v1/chat/completions`, `/v1/responses`) |
| `litellm/types/utils.py` | `LlmProviders.APIMODELS` |
| `litellm/constants.py` | `openai_compatible_providers` **and** `openai_compatible_endpoints` |
| `litellm/proxy/public_endpoints/provider_create_fields.json` | selectable in the proxy "Add Model" form |
| `tests/test_litellm/llms/openai_like/test_apimodels_provider.py` | new tests |

165 insertions, no deletions, no reformatting of existing entries.

## One thing worth flagging for the docs

[The contributing guide](https://docs.litellm.ai/docs/contributing/adding_openai_compatible_providers) says editing `providers.json` is enough. While writing the tests I hit a case where that is not quite true:

`api_base` auto-detection in `get_llm_provider_logic.py` iterates `litellm.openai_compatible_endpoints`, **not** the JSON registry — the `JSONProviderRegistry.get_by_base_url()` fallback at the end of that chain is only reached if the endpoint already matched an entry in that list. So a JSON-only provider is resolvable via the `provider/model` prefix but silently *un*resolvable when a user passes just `api_base`:

```python
# works with providers.json alone
get_llm_provider(model="apimodels/gpt-5.6-luna")

# raises "LLM Provider NOT provided" without the openai_compatible_endpoints entry
get_llm_provider(model="gpt-5.6-luna", api_base="https://api.apimodels.app/v1")
```

This PR adds the entry so both paths work. Happy to send a separate docs PR mentioning it if that would be useful — existing JSON providers appear to hit the same thing.

## Testing

`tests/test_litellm/llms/openai_like/test_apimodels_provider.py` — 9 tests, configuration and mock assertions only, no network calls:

- provider enum / `provider_list` / `openai_compatible_providers` registration
- JSON config values (`base_url`, `api_key_env`)
- Responses API support flag
- `provider/model` prefix resolution
- `api_base` + `api_key` override
- `api_base` auto-detection
- Router config
- proxy "Add Model" form registration

```
tests/test_litellm/llms/openai_like/test_apimodels_provider.py  9 passed
tests/test_litellm/llms/openai_like/                          190 passed, 5 skipped
```

Two failures in `test_cognition_provider.py::TestCognitionRouting` reproduce on an unmodified checkout of `main`, so they are pre-existing and unrelated to this change.