### PR TITLE
test(e2e): prove the virtual key lifecycle on every gateway replica

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -2840,6 +2840,8 @@ async def update_key_fn(
     """
     Update an existing API key's parameters.
 
+    The body is a merge patch: a field left out keeps its stored value and an explicit null clears it, except `metadata`, which replaces the stored metadata wholesale.
+
     Parameters:
     - key: Optional[str] - The key to update. Either key or key_alias must be provided.
     - key_alias: Optional[str] - User-friendly key alias. If key is omitted, also identifies the key to update (must match exactly one key, same as /key/delete's key_aliases)

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -2840,7 +2840,10 @@ async def update_key_fn(
     """
     Update an existing API key's parameters.
 
-    The body is a merge patch: a field left out keeps its stored value and an explicit null clears it, except `metadata`, which replaces the stored metadata wholesale.
+    The body is a merge patch: a field left out keeps its stored value, and on the key's own columns
+    an explicit null clears it. The metadata-backed fields below are the exception, merging into the
+    stored metadata instead: passing one as null leaves it unchanged, while `metadata` itself
+    replaces the stored metadata wholesale.
 
     Parameters:
     - key: Optional[str] - The key to update. Either key or key_alias must be provided.

--- a/tests/e2e/coverage_registry/mgmt.yaml
+++ b/tests/e2e/coverage_registry/mgmt.yaml
@@ -5,6 +5,8 @@
 - {id: mgmt.key.update.persists, module: mgmt, tier: P0, surface: api, assertions: [persists], source: "key_management_endpoints.py:2462", rationale: "Budget/model changes persist"}
 - {id: mgmt.key.update.admin_only, module: mgmt, tier: P0, surface: api, assertions: [admin_only], source: "key_management_endpoints.py:2462", rationale: "Non-admin cannot escalate perms"}
 - {id: mgmt.key.update.happy_path, module: mgmt, tier: P1, surface: ui, assertions: [happy_path], source: "key_management_endpoints.py:2462", rationale: "Key edit through the dashboard"}
+- {id: mgmt.key.update.preserves_unrelated_fields, module: mgmt, tier: P0, surface: api, assertions: [preserves_unrelated_fields], source: "key_management_endpoints.py:2829", rationale: "A partial /key/update changes only the field it names; alias, models, limits, budget window, team and metadata read back unchanged on every gateway replica"}
+- {id: mgmt.key.update.clear_persists, module: mgmt, tier: P0, surface: api, assertions: [clear_persists], source: "key_management_endpoints.py:2829", rationale: "An explicit null on /key/update clears max_budget and budget_duration, and the derived budget_reset_at with it, on every gateway replica"}
 - {id: mgmt.key.delete.persists, module: mgmt, tier: P0, surface: api, assertions: [persists], source: "key_management_endpoints.py:3122", rationale: "Deletion revokes future calls"}
 - {id: mgmt.key.delete.admin_only, module: mgmt, tier: P0, surface: api, assertions: [admin_only], source: "key_management_endpoints.py:3122", rationale: "Non-owner cannot delete"}
 - {id: mgmt.key.info.persists, module: mgmt, tier: P0, surface: api, assertions: [persists], source: "key_management_endpoints.py:3380", rationale: "Info reflects all writes"}

--- a/tests/e2e/management/test_key_lifecycle_e2e.py
+++ b/tests/e2e/management/test_key_lifecycle_e2e.py
@@ -3,11 +3,15 @@ gateway replica.
 
 Create, read, partial update, clear, enforce, delete: one method per step, and every
 step creates its own team and key (both deleted on teardown) so a step reruns or skips
-on its own. Writes go through the control plane; read-backs poll /key/info on every
-URL in PROXY_REPLICA_URLS until each replica converges, because a write that is
-visible on the gateway that took it and stale on its neighbour is exactly the failure
-this file exists to catch. /key/update is a merge patch: a field left out of the body
-keeps its stored value and an explicit null clears it.
+on its own. Writes go through the control plane; read-backs poll every URL in
+PROXY_REPLICA_URLS until each replica converges, because a write that is visible on the
+gateway that took it and stale on its neighbour is exactly the failure this file exists
+to catch. Revocation is the slowest of those: a deleted key stays usable on the other
+replicas until their auth cache entry expires, so the delete step polls each of them
+rather than asserting once.
+
+/key/update is a merge patch: a field left out of the body keeps its stored value and an
+explicit null clears it.
 """
 
 from __future__ import annotations
@@ -21,11 +25,13 @@ from typing import Final
 import pytest
 
 from e2e_config import unique_marker
-from e2e_http import Result, Success, UnknownApiError, unwrap
+from e2e_http import Result, StreamingResponse, Success, UnknownApiError, unwrap
 from lifecycle import ResourceManager
 from management_client import MODEL_ACCESS_DENIED_MARKER, ManagementClient
 from models import (
     CLEAR,
+    ChatBody,
+    ChatMessage,
     KeyGenerateBody,
     KeyGenerateResponse,
     KeyInfo,
@@ -36,10 +42,12 @@ from models import (
     LiteLLMParamsBody,
     TeamNewBody,
 )
+from proxy_client import Converged, NotConverged, Poller, await_converged, await_converged_everywhere
+from transport import Transport
 
 pytestmark = pytest.mark.e2e
 
-MODEL: Final = "gpt-4o-mini"
+BACKING_MODEL: Final = "gpt-4o-mini"
 DENIED_MODEL: Final = "gpt-5.5"
 MAX_BUDGET: Final = 25.0
 TPM_LIMIT: Final = 313131
@@ -60,30 +68,52 @@ class CreatedKey:
 
 @pytest.fixture(scope="module")
 def mock_deployment(client: ManagementClient) -> Iterator[str]:
-    model_id: Final = client.proxy.create_model(MODEL, LiteLLMParamsBody(model=MODEL, mock_response="ok"))
+    """A deployment that answers from a canned response, so the enforcement step needs no
+    provider key. The alias carries a unique marker, like every other model this suite
+    registers, so concurrent runs never share one model group."""
+    model_name: Final = f"e2e-key-lifecycle-{unique_marker()}"
+    model_id: Final = client.proxy.create_model(model_name, LiteLLMParamsBody(model=BACKING_MODEL, mock_response="ok"))
     try:
-        yield MODEL
+        yield model_name
     finally:
         client.proxy.delete_model(model_id)
 
 
-def _poll[T](client: ManagementClient, attempt: Callable[[], T | None], failure: str) -> T:
-    deadline: Final = time.monotonic() + client.proxy.poll_timeout
-    while time.monotonic() < deadline:
-        found = attempt()
-        if found is not None:
-            return found
-        time.sleep(client.proxy.poll_interval)
-    pytest.fail(failure)
+def _await[T](client: ManagementClient, poller: Poller[T], converged: Callable[[T], bool], failure: str) -> T:
+    outcome: Final = await_converged(
+        poller,
+        converged=converged,
+        timeout=client.proxy.poll_timeout,
+        interval=client.proxy.poll_interval,
+        now=time.monotonic,
+        sleep=time.sleep,
+    )
+    match outcome:
+        case Converged(result=result):
+            return result
+        case NotConverged(last_result=last):
+            pytest.fail(f"{failure}; last outcome: {last}")
 
 
-def _create_key(client: ManagementClient, resources: ResourceManager) -> CreatedKey:
+def _chat_poller(transport: Transport, key: str, model: str) -> Poller[StreamingResponse]:
+    return lambda: transport.send(
+        "/chat/completions",
+        headers=transport.bearer(key),
+        json=ChatBody(
+            model=model,
+            messages=[ChatMessage(role="user", content=f"say hi {unique_marker()}")],
+            max_tokens=16,
+        ),
+    )
+
+
+def _create_key(client: ManagementClient, resources: ResourceManager, model: str) -> CreatedKey:
     marker: Final = unique_marker()
     team_id: Final = client.create_team(TeamNewBody(team_alias=f"e2e-key-lifecycle-team-{marker}"))
     resources.defer(lambda: client.delete_team(team_id))
     written: Final = KeyGenerateBody(
         key_alias=f"e2e-key-lifecycle-{marker}",
-        models=[MODEL],
+        models=[model],
         max_budget=MAX_BUDGET,
         tpm_limit=TPM_LIMIT,
         rpm_limit=RPM_LIMIT,
@@ -127,15 +157,48 @@ def _assert_reads_back(info: KeyInfo, expected: KeyGenerateBody, replica: str) -
 
 
 def _poll_chat_ok(client: ManagementClient, key: str, model: str) -> None:
-    def attempt() -> bool | None:
-        return True if client.chat_status(key, model, f"reply with one word {unique_marker()}").ok else None
+    _ = _await(
+        client,
+        _chat_poller(client.proxy.transport, key, model),
+        lambda outcome: outcome.ok,
+        f"chat on {model} never succeeded for the key before the deadline",
+    )
 
-    _ = _poll(client, attempt, f"chat on {model} never succeeded for the key before the deadline")
+
+def _warm_every_replica(client: ManagementClient, key: str, model: str) -> None:
+    """Serve one call from every replica, so each has the key in its auth cache. Without
+    this the revocation check below would only prove a replica rejects a key it never
+    knew, which is true of any random string."""
+    for replica, transport in client.proxy.replicas.items():
+        _ = _await(
+            client,
+            _chat_poller(transport, key, model),
+            lambda outcome: outcome.ok,
+            f"{replica}: chat on {model} never succeeded for the key before the deadline",
+        )
+
+
+def _assert_chat_rejected_everywhere(client: ManagementClient, key: str, model: str) -> None:
+    outcomes: Final = await_converged_everywhere(
+        {replica: _chat_poller(transport, key, model) for replica, transport in client.proxy.replicas.items()},
+        converged=lambda outcome: outcome.status_code == 401,
+        timeout=client.proxy.poll_timeout,
+        interval=client.proxy.poll_interval,
+        now=time.monotonic,
+        sleep=time.sleep,
+    )
+    for replica, outcome in outcomes.items():
+        assert isinstance(outcome, Converged), (
+            f"{replica}: the deleted key was still accepted on chat after "
+            f"{client.proxy.poll_timeout}s, last status {outcome.last_result.status_code}"
+        )
 
 
 class TestKeyLifecycle:
-    def test_create_echoes_every_field_written(self, client: ManagementClient, resources: ResourceManager) -> None:
-        created: Final = _create_key(client, resources)
+    def test_create_echoes_every_field_written(
+        self, client: ManagementClient, resources: ResourceManager, mock_deployment: str
+    ) -> None:
+        created: Final = _create_key(client, resources, mock_deployment)
 
         response: Final = created.response
         for field, observed, wanted in (
@@ -151,9 +214,9 @@ class TestKeyLifecycle:
             assert observed == wanted, f"/key/generate echoed {field}={observed!r}, sent {wanted!r}"
 
     def test_read_reflects_the_create_on_every_replica(
-        self, client: ManagementClient, resources: ResourceManager
+        self, client: ManagementClient, resources: ResourceManager, mock_deployment: str
     ) -> None:
-        created: Final = _create_key(client, resources)
+        created: Final = _create_key(client, resources, mock_deployment)
 
         infos: Final = _key_info_everywhere(
             client, created.key, lambda info: info.key_alias == created.written.key_alias
@@ -166,9 +229,9 @@ class TestKeyLifecycle:
 
     @pytest.mark.covers("mgmt.key.update.preserves_unrelated_fields")
     def test_partial_update_changes_only_the_named_field(
-        self, client: ManagementClient, resources: ResourceManager
+        self, client: ManagementClient, resources: ResourceManager, mock_deployment: str
     ) -> None:
-        created: Final = _create_key(client, resources)
+        created: Final = _create_key(client, resources, mock_deployment)
         before: Final = _key_info_everywhere(client, created.key, lambda info: info.rpm_limit == RPM_LIMIT)
 
         _ = unwrap(client.update_key(KeyUpdateBody(key=created.key, rpm_limit=UPDATED_RPM_LIMIT)))
@@ -183,15 +246,15 @@ class TestKeyLifecycle:
 
     @pytest.mark.covers("mgmt.key.update.clear_persists")
     def test_explicit_null_clears_the_budget_and_its_reset_time(
-        self, client: ManagementClient, resources: ResourceManager
+        self, client: ManagementClient, resources: ResourceManager, mock_deployment: str
     ) -> None:
-        created: Final = _create_key(client, resources)
+        created: Final = _create_key(client, resources, mock_deployment)
+        _ = _key_info_everywhere(client, created.key, lambda info: info.max_budget == MAX_BUDGET)
 
         _ = unwrap(client.update_key(KeyUpdateBody(key=created.key, max_budget=CLEAR, budget_duration=CLEAR)))
 
         cleared: Final = _key_info_everywhere(client, created.key, lambda info: info.max_budget is None)
         for replica, info in cleared.items():
-            assert info.max_budget is None, f"{replica}: max_budget={info.max_budget!r} survived an explicit null"
             assert info.budget_duration is None, (
                 f"{replica}: budget_duration={info.budget_duration!r} survived an explicit null"
             )
@@ -205,7 +268,7 @@ class TestKeyLifecycle:
     def test_key_serves_its_model_and_is_denied_others(
         self, client: ManagementClient, resources: ResourceManager, mock_deployment: str
     ) -> None:
-        created: Final = _create_key(client, resources)
+        created: Final = _create_key(client, resources, mock_deployment)
 
         _poll_chat_ok(client, created.key, mock_deployment)
 
@@ -221,12 +284,15 @@ class TestKeyLifecycle:
     def test_delete_revokes_info_and_chat_on_every_replica(
         self, client: ManagementClient, resources: ResourceManager, mock_deployment: str
     ) -> None:
-        """The teardown's deferred delete fires again on the already-deleted key by
+        """Every replica serves the key first, so each one caches it and the delete has
+        something to revoke everywhere rather than on the gateway that took the write.
+
+        The teardown's deferred delete fires again on the already-deleted key by
         design: the deferred cleanup must survive this test failing before the
         in-body delete, and a repeat /key/delete is a cheap no-op the warn-only
         teardown absorbs."""
-        created: Final = _create_key(client, resources)
-        _poll_chat_ok(client, created.key, mock_deployment)
+        created: Final = _create_key(client, resources, mock_deployment)
+        _warm_every_replica(client, created.key, mock_deployment)
 
         client.delete_key_strict(created.key)
 
@@ -236,9 +302,4 @@ class TestKeyLifecycle:
             response_type=KeyInfoResponse,
             converged=_is_key_not_found,
         )
-
-        def rejected() -> bool | None:
-            outcome = client.chat_status(created.key, mock_deployment, f"say hi {unique_marker()}")
-            return True if outcome.status_code == 401 else None
-
-        _ = _poll(client, rejected, "deleted key was still accepted on chat (never rejected 401) at the deadline")
+        _assert_chat_rejected_everywhere(client, created.key, mock_deployment)

--- a/tests/e2e/management/test_key_lifecycle_e2e.py
+++ b/tests/e2e/management/test_key_lifecycle_e2e.py
@@ -9,9 +9,6 @@ gateway that took it and stale on its neighbour is exactly the failure this file
 to catch. Revocation is the slowest of those: a deleted key stays usable on the other
 replicas until their auth cache entry expires, so the delete step polls each of them
 rather than asserting once.
-
-/key/update is a merge patch: a field left out of the body keeps its stored value and an
-explicit null clears it.
 """
 
 from __future__ import annotations
@@ -284,10 +281,7 @@ class TestKeyLifecycle:
     def test_delete_revokes_info_and_chat_on_every_replica(
         self, client: ManagementClient, resources: ResourceManager, mock_deployment: str
     ) -> None:
-        """Every replica serves the key first, so each one caches it and the delete has
-        something to revoke everywhere rather than on the gateway that took the write.
-
-        The teardown's deferred delete fires again on the already-deleted key by
+        """The teardown's deferred delete fires again on the already-deleted key by
         design: the deferred cleanup must survive this test failing before the
         in-body delete, and a repeat /key/delete is a cheap no-op the warn-only
         teardown absorbs."""

--- a/tests/e2e/management/test_key_lifecycle_e2e.py
+++ b/tests/e2e/management/test_key_lifecycle_e2e.py
@@ -1,0 +1,244 @@
+"""Live e2e: one virtual key walked through its whole lifecycle, read back on every
+gateway replica.
+
+Create, read, partial update, clear, enforce, delete: one method per step, and every
+step creates its own team and key (both deleted on teardown) so a step reruns or skips
+on its own. Writes go through the control plane; read-backs poll /key/info on every
+URL in PROXY_REPLICA_URLS until each replica converges, because a write that is
+visible on the gateway that took it and stale on its neighbour is exactly the failure
+this file exists to catch. /key/update is a merge patch: a field left out of the body
+keeps its stored value and an explicit null clears it.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable, Iterator, Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Final
+
+import pytest
+
+from e2e_config import unique_marker
+from e2e_http import Result, Success, UnknownApiError, unwrap
+from lifecycle import ResourceManager
+from management_client import MODEL_ACCESS_DENIED_MARKER, ManagementClient
+from models import (
+    CLEAR,
+    KeyGenerateBody,
+    KeyGenerateResponse,
+    KeyInfo,
+    KeyInfoParams,
+    KeyInfoResponse,
+    KeyMetadata,
+    KeyUpdateBody,
+    LiteLLMParamsBody,
+    TeamNewBody,
+)
+
+pytestmark = pytest.mark.e2e
+
+MODEL: Final = "gpt-4o-mini"
+DENIED_MODEL: Final = "gpt-5.5"
+MAX_BUDGET: Final = 25.0
+TPM_LIMIT: Final = 313131
+RPM_LIMIT: Final = 323232
+UPDATED_RPM_LIMIT: Final = 424242
+BUDGET_DURATION: Final = "30d"
+
+
+@dataclass(frozen=True, slots=True)
+class CreatedKey:
+    written: KeyGenerateBody
+    response: KeyGenerateResponse
+
+    @property
+    def key(self) -> str:
+        return self.response.key
+
+
+@pytest.fixture(scope="module")
+def mock_deployment(client: ManagementClient) -> Iterator[str]:
+    model_id: Final = client.proxy.create_model(MODEL, LiteLLMParamsBody(model=MODEL, mock_response="ok"))
+    try:
+        yield MODEL
+    finally:
+        client.proxy.delete_model(model_id)
+
+
+def _poll[T](client: ManagementClient, attempt: Callable[[], T | None], failure: str) -> T:
+    deadline: Final = time.monotonic() + client.proxy.poll_timeout
+    while time.monotonic() < deadline:
+        found = attempt()
+        if found is not None:
+            return found
+        time.sleep(client.proxy.poll_interval)
+    pytest.fail(failure)
+
+
+def _create_key(client: ManagementClient, resources: ResourceManager) -> CreatedKey:
+    marker: Final = unique_marker()
+    team_id: Final = client.create_team(TeamNewBody(team_alias=f"e2e-key-lifecycle-team-{marker}"))
+    resources.defer(lambda: client.delete_team(team_id))
+    written: Final = KeyGenerateBody(
+        key_alias=f"e2e-key-lifecycle-{marker}",
+        models=[MODEL],
+        max_budget=MAX_BUDGET,
+        tpm_limit=TPM_LIMIT,
+        rpm_limit=RPM_LIMIT,
+        budget_duration=BUDGET_DURATION,
+        metadata=KeyMetadata(tag=marker),
+        team_id=team_id,
+    )
+    response: Final = unwrap(client.generate_key(written))
+    resources.defer(lambda: client.proxy.delete_key(response.key))
+    return CreatedKey(written=written, response=response)
+
+
+def _key_info_everywhere(
+    client: ManagementClient, key: str, settled: Callable[[KeyInfo], bool]
+) -> Mapping[str, KeyInfo]:
+    def converged(result: Result[KeyInfoResponse]) -> bool:
+        return isinstance(result, Success) and settled(result.data.info)
+
+    reads: Final = client.proxy.read_back_everywhere(
+        "/key/info", params=KeyInfoParams(key=key), response_type=KeyInfoResponse, converged=converged
+    )
+    return MappingProxyType({replica: unwrap(read).info for replica, read in reads.items()})
+
+
+def _is_key_not_found(result: Result[KeyInfoResponse]) -> bool:
+    return isinstance(result, UnknownApiError) and result.status_code == 404
+
+
+def _assert_reads_back(info: KeyInfo, expected: KeyGenerateBody, replica: str) -> None:
+    for field, observed, wanted in (
+        ("key_alias", info.key_alias, expected.key_alias),
+        ("models", info.models, expected.models),
+        ("max_budget", info.max_budget, expected.max_budget),
+        ("tpm_limit", info.tpm_limit, expected.tpm_limit),
+        ("rpm_limit", info.rpm_limit, expected.rpm_limit),
+        ("budget_duration", info.budget_duration, expected.budget_duration),
+        ("team_id", info.team_id, expected.team_id),
+        ("metadata", info.metadata, expected.metadata),
+    ):
+        assert observed == wanted, f"{replica}: /key/info reports {field}={observed!r}, expected {wanted!r}"
+
+
+def _poll_chat_ok(client: ManagementClient, key: str, model: str) -> None:
+    def attempt() -> bool | None:
+        return True if client.chat_status(key, model, f"reply with one word {unique_marker()}").ok else None
+
+    _ = _poll(client, attempt, f"chat on {model} never succeeded for the key before the deadline")
+
+
+class TestKeyLifecycle:
+    def test_create_echoes_every_field_written(self, client: ManagementClient, resources: ResourceManager) -> None:
+        created: Final = _create_key(client, resources)
+
+        response: Final = created.response
+        for field, observed, wanted in (
+            ("key_alias", response.key_alias, created.written.key_alias),
+            ("models", response.models, created.written.models),
+            ("max_budget", response.max_budget, created.written.max_budget),
+            ("tpm_limit", response.tpm_limit, created.written.tpm_limit),
+            ("rpm_limit", response.rpm_limit, created.written.rpm_limit),
+            ("budget_duration", response.budget_duration, created.written.budget_duration),
+            ("team_id", response.team_id, created.written.team_id),
+            ("metadata", response.metadata, created.written.metadata),
+        ):
+            assert observed == wanted, f"/key/generate echoed {field}={observed!r}, sent {wanted!r}"
+
+    def test_read_reflects_the_create_on_every_replica(
+        self, client: ManagementClient, resources: ResourceManager
+    ) -> None:
+        created: Final = _create_key(client, resources)
+
+        infos: Final = _key_info_everywhere(
+            client, created.key, lambda info: info.key_alias == created.written.key_alias
+        )
+        for replica, info in infos.items():
+            _assert_reads_back(info, created.written, replica)
+            assert info.budget_reset_at is not None, (
+                f"{replica}: /key/info reports no budget_reset_at for budget_duration={BUDGET_DURATION!r}"
+            )
+
+    @pytest.mark.covers("mgmt.key.update.preserves_unrelated_fields")
+    def test_partial_update_changes_only_the_named_field(
+        self, client: ManagementClient, resources: ResourceManager
+    ) -> None:
+        created: Final = _create_key(client, resources)
+        before: Final = _key_info_everywhere(client, created.key, lambda info: info.rpm_limit == RPM_LIMIT)
+
+        _ = unwrap(client.update_key(KeyUpdateBody(key=created.key, rpm_limit=UPDATED_RPM_LIMIT)))
+
+        after: Final = _key_info_everywhere(client, created.key, lambda info: info.rpm_limit == UPDATED_RPM_LIMIT)
+        for replica, info in after.items():
+            _assert_reads_back(info, created.written.model_copy(update={"rpm_limit": UPDATED_RPM_LIMIT}), replica)
+            assert info.budget_reset_at == before[replica].budget_reset_at, (
+                f"{replica}: budget_reset_at moved from {before[replica].budget_reset_at!r} to "
+                f"{info.budget_reset_at!r} on a /key/update that did not name budget_duration"
+            )
+
+    @pytest.mark.covers("mgmt.key.update.clear_persists")
+    def test_explicit_null_clears_the_budget_and_its_reset_time(
+        self, client: ManagementClient, resources: ResourceManager
+    ) -> None:
+        created: Final = _create_key(client, resources)
+
+        _ = unwrap(client.update_key(KeyUpdateBody(key=created.key, max_budget=CLEAR, budget_duration=CLEAR)))
+
+        cleared: Final = _key_info_everywhere(client, created.key, lambda info: info.max_budget is None)
+        for replica, info in cleared.items():
+            assert info.max_budget is None, f"{replica}: max_budget={info.max_budget!r} survived an explicit null"
+            assert info.budget_duration is None, (
+                f"{replica}: budget_duration={info.budget_duration!r} survived an explicit null"
+            )
+            assert info.budget_reset_at is None, (
+                f"{replica}: clearing budget_duration left budget_reset_at={info.budget_reset_at!r}"
+            )
+            _assert_reads_back(
+                info, created.written.model_copy(update={"max_budget": None, "budget_duration": None}), replica
+            )
+
+    def test_key_serves_its_model_and_is_denied_others(
+        self, client: ManagementClient, resources: ResourceManager, mock_deployment: str
+    ) -> None:
+        created: Final = _create_key(client, resources)
+
+        _poll_chat_ok(client, created.key, mock_deployment)
+
+        denied: Final = client.chat_status(created.key, DENIED_MODEL, f"say hi {unique_marker()}")
+        assert denied.status_code == 403, (
+            f"chat on {DENIED_MODEL!r} outside the key's model list must be denied 403, got "
+            f"{denied.status_code}: {denied.body[:300]}"
+        )
+        assert MODEL_ACCESS_DENIED_MARKER in denied.body, (
+            f"403 body must be a model-access denial, got: {denied.body[:300]}"
+        )
+
+    def test_delete_revokes_info_and_chat_on_every_replica(
+        self, client: ManagementClient, resources: ResourceManager, mock_deployment: str
+    ) -> None:
+        """The teardown's deferred delete fires again on the already-deleted key by
+        design: the deferred cleanup must survive this test failing before the
+        in-body delete, and a repeat /key/delete is a cheap no-op the warn-only
+        teardown absorbs."""
+        created: Final = _create_key(client, resources)
+        _poll_chat_ok(client, created.key, mock_deployment)
+
+        client.delete_key_strict(created.key)
+
+        _ = client.proxy.read_back_everywhere(
+            "/key/info",
+            params=KeyInfoParams(key=created.key),
+            response_type=KeyInfoResponse,
+            converged=_is_key_not_found,
+        )
+
+        def rejected() -> bool | None:
+            outcome = client.chat_status(created.key, mock_deployment, f"say hi {unique_marker()}")
+            return True if outcome.status_code == 401 else None
+
+        _ = _poll(client, rejected, "deleted key was still accepted on chat (never rejected 401) at the deadline")

--- a/tests/e2e/models.py
+++ b/tests/e2e/models.py
@@ -8,9 +8,9 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from datetime import datetime
-from typing import Literal
+from typing import Final, Literal
 
-from pydantic import AliasChoices, BaseModel, ConfigDict, Field, RootModel, model_validator
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, RootModel, model_serializer, model_validator
 
 # ---------- keys ----------
 
@@ -49,6 +49,7 @@ class KeyMetadata(BaseModel):
     logging: list[KeyLoggingCallback] | None = None
     priority: str | None = None
     batch_enqueued_token_limit: int | None = None
+    tag: str | None = None
 
 
 class ObjectPermission(BaseModel):
@@ -81,6 +82,14 @@ class KeyGenerateBody(BaseModel):
 
 class KeyGenerateResponse(BaseModel):
     key: str
+    key_alias: str | None = None
+    models: list[str] = []
+    max_budget: float | None = None
+    tpm_limit: int | None = None
+    rpm_limit: int | None = None
+    budget_duration: str | None = None
+    team_id: str | None = None
+    metadata: KeyMetadata | None = None
 
 
 class KeyRegenerateBody(BaseModel):
@@ -122,6 +131,7 @@ class KeyInfo(BaseModel):
     blocked: bool | None = None
     spend: float | None = None
     max_budget: float | None = None
+    budget_duration: str | None = None
     budget_reset_at: str | None = None
     budget_id: str | None = None
     litellm_budget_table: LiteLLMBudgetTable | None = None
@@ -918,12 +928,34 @@ class CredentialCreateResponse(BaseModel):
 # ---------- key / team / user / organization management ----------
 
 
+class Cleared(BaseModel):
+    """An explicit JSON null in a merge-patch body. The transport drops `None` fields
+    before sending (`exclude_none`), so `None` means "leave the stored value alone"; a
+    field set to `CLEAR` reaches the wire as `null`, which tells the proxy to clear it."""
+
+    model_config = ConfigDict(frozen=True)
+
+    @model_serializer
+    def _as_null(self) -> None:
+        return None
+
+
+CLEAR: Final = Cleared()
+
+
 class KeyUpdateBody(BaseModel):
+    """POST /key/update is a merge patch: a field left `None` is dropped from the body and
+    keeps its stored value, `CLEAR` sends an explicit null that clears it (`budget_duration`
+    clears `budget_reset_at` with it), and `metadata` replaces the stored metadata wholesale."""
+
     key: str
     models: list[str] | None = None
     key_alias: str | None = None
     tpm_limit: int | None = None
     rpm_limit: int | None = None
+    max_budget: float | Cleared | None = None
+    budget_duration: str | Cleared | None = None
+    metadata: KeyMetadata | None = None
 
 
 class KeyBlockBody(BaseModel):

--- a/tests/e2e/proxy_client.py
+++ b/tests/e2e/proxy_client.py
@@ -497,7 +497,11 @@ class ProxyClient:
             )
         ).model_id
         written_at = time.monotonic()
-        self._await_model_servable(body.model_name, listed_for)
+        try:
+            self._await_model_servable(body.model_name, listed_for)
+        except BaseException:
+            self.delete_model(model_id)
+            raise
         settle_propagation(written_at)
         return model_id
 

--- a/tests/e2e/proxy_client.py
+++ b/tests/e2e/proxy_client.py
@@ -151,9 +151,7 @@ def await_servable(
     last_result: Result[ModelsListResponse] | None = None
     while True:
         t = now()
-        phase_deadline = (
-            started + timeout if first_seen_at is None else first_seen_at + db_sync_seconds
-        )
+        phase_deadline = started + timeout if first_seen_at is None else first_seen_at + db_sync_seconds
         remaining = phase_deadline - t
         if remaining <= 0:
             if (
@@ -166,9 +164,7 @@ def await_servable(
 
         poll_timeout = min(request_timeout, remaining)
         last_result = list_models(poll_timeout)
-        listed = isinstance(last_result, Success) and any(
-            entry.id == model_name for entry in last_result.data.data
-        )
+        listed = isinstance(last_result, Success) and any(entry.id == model_name for entry in last_result.data.data)
         t = now()
         if not listed:
             first_seen_at = None
@@ -181,9 +177,7 @@ def await_servable(
         elif t - first_seen_at >= db_sync_seconds:
             return Servable()
 
-        phase_deadline = (
-            started + timeout if first_seen_at is None else first_seen_at + db_sync_seconds
-        )
+        phase_deadline = started + timeout if first_seen_at is None else first_seen_at + db_sync_seconds
         wait = min(interval, phase_deadline - now())
         if wait > 0:
             sleep(wait)
@@ -241,39 +235,39 @@ def servable_timeout_message(
     )
 
 
-type BodyPoller[R: BaseModel] = Callable[[], Result[R]]
+type Poller[T] = Callable[[], T]
 
 
 @dataclass(frozen=True, slots=True)
-class Converged[R: BaseModel]:
-    """The replica's read satisfied the predicate; `result` is that read."""
-
-    result: Result[R]
+class Converged[T]:
+    result: T
 
 
 @dataclass(frozen=True, slots=True)
-class NotConverged[R: BaseModel]:
+class NotConverged[T]:
     """The deadline passed without a read satisfying the predicate; `last_result` is
     the final read, so the caller can tell a stale body from a failed request."""
 
-    last_result: Result[R]
+    last_result: T
 
 
-type ConvergeOutcome[R: BaseModel] = Converged[R] | NotConverged[R]
+type ConvergeOutcome[T] = Converged[T] | NotConverged[T]
 
 
-def await_converged[R: BaseModel](
-    poll: BodyPoller[R],
+def await_converged[T](
+    poll: Poller[T],
     *,
-    converged: Callable[[Result[R]], bool],
+    converged: Callable[[T], bool],
     timeout: float,
     interval: float,
     now: Callable[[], float],
     sleep: Callable[[float], None],
-) -> ConvergeOutcome[R]:
-    """Poll until a read satisfies `converged` or `timeout` elapses. Sleeps only
-    min(interval, time left) between polls so the last poll lands on the deadline
-    instead of being skipped. Clock and sleep are injected."""
+) -> ConvergeOutcome[T]:
+    """Poll until a read satisfies `converged` or `timeout` elapses.
+
+    Polls before testing the deadline, so a zero or already-spent budget still gets one
+    attempt, and sleeps only min(interval, time left), so the attempt that lands exactly
+    on the deadline is taken rather than skipped. Clock and sleep are injected."""
     deadline: Final = now() + timeout
     while True:
         result = poll()
@@ -285,15 +279,15 @@ def await_converged[R: BaseModel](
         sleep(min(interval, remaining))
 
 
-def await_converged_everywhere[R: BaseModel](
-    pollers: Mapping[str, BodyPoller[R]],
+def await_converged_everywhere[T](
+    pollers: Mapping[str, Poller[T]],
     *,
-    converged: Callable[[Result[R]], bool],
+    converged: Callable[[T], bool],
     timeout: float,
     interval: float,
     now: Callable[[], float],
     sleep: Callable[[float], None],
-) -> Mapping[str, ConvergeOutcome[R]]:
+) -> Mapping[str, ConvergeOutcome[T]]:
     """`await_converged` against every replica in turn, each with the full budget, so a
     replica that lags behind the one a write landed on is polled until it catches up
     rather than failing on its first stale read."""
@@ -307,18 +301,18 @@ def await_converged_everywhere[R: BaseModel](
     )
 
 
-def first_lagging_replica[R: BaseModel](
-    outcomes: Mapping[str, ConvergeOutcome[R]],
-) -> tuple[str, NotConverged[R]] | None:
+def first_lagging_replica[T](
+    outcomes: Mapping[str, ConvergeOutcome[T]],
+) -> tuple[str, NotConverged[T]] | None:
     return next(
         ((replica, outcome) for replica, outcome in outcomes.items() if isinstance(outcome, NotConverged)),
         None,
     )
 
 
-def read_back_timeout_message[R: BaseModel](*, path: str, replica: str, timeout: float, last_result: Result[R]) -> str:
+def converge_timeout_message(*, what: str, replica: str, timeout: float, last_result: object) -> str:
     return (
-        f"GET {path} on {replica} never converged within {timeout}s of the write "
+        f"{what} on {replica} never converged within {timeout}s of the write "
         f"(control/data-plane propagation issue); last read: {last_result}"
     )
 
@@ -403,8 +397,11 @@ class ProxyClient:
         if lagging is not None:
             replica, outcome = lagging
             raise AssertionError(
-                read_back_timeout_message(
-                    path=path, replica=replica, timeout=self.poll_timeout, last_result=outcome.last_result
+                converge_timeout_message(
+                    what=f"GET {path}",
+                    replica=replica,
+                    timeout=self.poll_timeout,
+                    last_result=outcome.last_result,
                 )
             )
         return MappingProxyType(
@@ -414,7 +411,7 @@ class ProxyClient:
     @staticmethod
     def _body_poller[R: BaseModel](
         transport: Transport, path: str, params: BaseModel, response_type: type[R]
-    ) -> BodyPoller[R]:
+    ) -> Poller[Result[R]]:
         return lambda: transport.get(path, headers=transport.master, params=params, response_type=response_type)
 
     def model_info(self) -> list[ModelInfoEntry]:
@@ -447,9 +444,7 @@ class ProxyClient:
             response_type=FileListResponse,
         )
 
-    def list_fine_tuning_jobs(
-        self, key: str, params: FineTuningJobsParams
-    ) -> Result[FineTuningJobsResponse]:
+    def list_fine_tuning_jobs(self, key: str, params: FineTuningJobsParams) -> Result[FineTuningJobsResponse]:
         return self.transport.get(
             "/v1/fine_tuning/jobs",
             headers=self.transport.bearer(key),

--- a/tests/e2e/proxy_client.py
+++ b/tests/e2e/proxy_client.py
@@ -16,6 +16,8 @@ from datetime import datetime
 from types import MappingProxyType
 from typing import Final
 
+from pydantic import BaseModel
+
 from e2e_http import (
     AnthropicHeaders,
     AuthHeaders,
@@ -239,6 +241,88 @@ def servable_timeout_message(
     )
 
 
+type BodyPoller[R: BaseModel] = Callable[[], Result[R]]
+
+
+@dataclass(frozen=True, slots=True)
+class Converged[R: BaseModel]:
+    """The replica's read satisfied the predicate; `result` is that read."""
+
+    result: Result[R]
+
+
+@dataclass(frozen=True, slots=True)
+class NotConverged[R: BaseModel]:
+    """The deadline passed without a read satisfying the predicate; `last_result` is
+    the final read, so the caller can tell a stale body from a failed request."""
+
+    last_result: Result[R]
+
+
+type ConvergeOutcome[R: BaseModel] = Converged[R] | NotConverged[R]
+
+
+def await_converged[R: BaseModel](
+    poll: BodyPoller[R],
+    *,
+    converged: Callable[[Result[R]], bool],
+    timeout: float,
+    interval: float,
+    now: Callable[[], float],
+    sleep: Callable[[float], None],
+) -> ConvergeOutcome[R]:
+    """Poll until a read satisfies `converged` or `timeout` elapses. Sleeps only
+    min(interval, time left) between polls so the last poll lands on the deadline
+    instead of being skipped. Clock and sleep are injected."""
+    deadline: Final = now() + timeout
+    while True:
+        result = poll()
+        if converged(result):
+            return Converged(result=result)
+        remaining = deadline - now()
+        if remaining <= 0:
+            return NotConverged(last_result=result)
+        sleep(min(interval, remaining))
+
+
+def await_converged_everywhere[R: BaseModel](
+    pollers: Mapping[str, BodyPoller[R]],
+    *,
+    converged: Callable[[Result[R]], bool],
+    timeout: float,
+    interval: float,
+    now: Callable[[], float],
+    sleep: Callable[[float], None],
+) -> Mapping[str, ConvergeOutcome[R]]:
+    """`await_converged` against every replica in turn, each with the full budget, so a
+    replica that lags behind the one a write landed on is polled until it catches up
+    rather than failing on its first stale read."""
+    return MappingProxyType(
+        {
+            replica: await_converged(
+                poll, converged=converged, timeout=timeout, interval=interval, now=now, sleep=sleep
+            )
+            for replica, poll in pollers.items()
+        }
+    )
+
+
+def first_lagging_replica[R: BaseModel](
+    outcomes: Mapping[str, ConvergeOutcome[R]],
+) -> tuple[str, NotConverged[R]] | None:
+    return next(
+        ((replica, outcome) for replica, outcome in outcomes.items() if isinstance(outcome, NotConverged)),
+        None,
+    )
+
+
+def read_back_timeout_message[R: BaseModel](*, path: str, replica: str, timeout: float, last_result: Result[R]) -> str:
+    return (
+        f"GET {path} on {replica} never converged within {timeout}s of the write "
+        f"(control/data-plane propagation issue); last read: {last_result}"
+    )
+
+
 @dataclass(frozen=True, slots=True)
 class ProxyClient:
     transport: Transport
@@ -289,6 +373,49 @@ class ProxyClient:
                 response_type=KeyInfoResponse,
             )
         ).info
+
+    def read_back_everywhere[R: BaseModel](
+        self,
+        path: str,
+        *,
+        params: BaseModel,
+        response_type: type[R],
+        converged: Callable[[Result[R]], bool],
+    ) -> Mapping[str, Result[R]]:
+        """GET `path` under the master key on every replica in PROXY_REPLICA_URLS (the
+        data-plane URL alone when the stack exports no per-gateway addresses), polling
+        each to poll_timeout until its read satisfies `converged`. Returns that read per
+        replica, or fails naming the first replica that never converged and its last
+        read. Behind a load balancer the single address proves one replica converged,
+        not all of them; only per-gateway addresses make this a fleet-wide proof."""
+        outcomes: Final = await_converged_everywhere(
+            {
+                url: self._body_poller(transport, path, params, response_type)
+                for url, transport in self.replicas.items()
+            },
+            converged=converged,
+            timeout=self.poll_timeout,
+            interval=self.poll_interval,
+            now=time.monotonic,
+            sleep=time.sleep,
+        )
+        lagging: Final = first_lagging_replica(outcomes)
+        if lagging is not None:
+            replica, outcome = lagging
+            raise AssertionError(
+                read_back_timeout_message(
+                    path=path, replica=replica, timeout=self.poll_timeout, last_result=outcome.last_result
+                )
+            )
+        return MappingProxyType(
+            {replica: outcome.result for replica, outcome in outcomes.items() if isinstance(outcome, Converged)}
+        )
+
+    @staticmethod
+    def _body_poller[R: BaseModel](
+        transport: Transport, path: str, params: BaseModel, response_type: type[R]
+    ) -> BodyPoller[R]:
+        return lambda: transport.get(path, headers=transport.master, params=params, response_type=response_type)
 
     def model_info(self) -> list[ModelInfoEntry]:
         """Every configured deployment with the price the proxy resolved for it

--- a/tests/e2e/test_proxy_client.py
+++ b/tests/e2e/test_proxy_client.py
@@ -1,9 +1,11 @@
-"""Harness coverage for the model barrier that gates on every replica.
+"""Harness coverage for the barriers that gate on every replica.
 
 No proxy needed and no ``e2e`` marker: this pins that a model registered through
 the control plane only counts as servable once every configured replica lists it
-on /v1/models, which is what keeps a two-gateway stack from handing a test a
-model that one gateway has not reloaded yet. The fakes are plain pollers and an
+on /v1/models, and that a management write only counts as read back once every
+replica's read satisfies the caller's predicate, which is what keeps a two-gateway
+stack from handing a test a model or a key that one gateway has not caught up on
+yet. The fakes are plain pollers standing in for each replica's transport plus an
 injected clock, so nothing here monkeypatches anything.
 """
 
@@ -12,18 +14,33 @@ from __future__ import annotations
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from itertools import chain, repeat
+from types import MappingProxyType
 from typing import Final
 
 import pytest
 
 from e2e_config import parse_replica_urls
-from e2e_http import Success
-from models import ModelListEntry, ModelsListResponse
-from proxy_client import ModelsPoller, NotServableOn, Servable, await_servable_everywhere
+from e2e_http import Result, Success
+from models import KeyInfo, KeyInfoResponse, ModelListEntry, ModelsListResponse
+from proxy_client import (
+    BodyPoller,
+    ConvergeOutcome,
+    Converged,
+    ModelsPoller,
+    NotConverged,
+    NotServableOn,
+    Servable,
+    await_converged_everywhere,
+    await_servable_everywhere,
+    first_lagging_replica,
+    read_back_timeout_message,
+)
 
 MODEL: Final = "gpt-under-test"
 TIMEOUT: Final = 10.0
 INTERVAL: Final = 2.0
+RPM_BEFORE_UPDATE: Final = 100
+RPM_AFTER_UPDATE: Final = 200
 
 
 @dataclass
@@ -76,6 +93,74 @@ class TestAwaitServableEverywhere:
             "gateway-2": _poller(chain(repeat(_listing(), 2), repeat(_listing(MODEL)))),
         }
         assert _await(pollers) == Servable()
+
+
+def _key_info(rpm_limit: int) -> Success[KeyInfoResponse]:
+    return Success(status_code=200, data=KeyInfoResponse(info=KeyInfo(rpm_limit=rpm_limit)))
+
+
+def _reads(results: Iterable[Result[KeyInfoResponse]]) -> BodyPoller[KeyInfoResponse]:
+    it: Final = iter(results)
+    return lambda: next(it)
+
+
+def _updated(result: Result[KeyInfoResponse]) -> bool:
+    return isinstance(result, Success) and result.data.info.rpm_limit == RPM_AFTER_UPDATE
+
+
+def _converge(
+    pollers: Mapping[str, BodyPoller[KeyInfoResponse]], clock: FakeClock
+) -> Mapping[str, ConvergeOutcome[KeyInfoResponse]]:
+    return await_converged_everywhere(
+        pollers,
+        converged=_updated,
+        timeout=TIMEOUT,
+        interval=INTERVAL,
+        now=clock.now,
+        sleep=clock.sleep,
+    )
+
+
+class TestAwaitConvergedEverywhere:
+    def test_waits_for_the_replica_that_lags_behind_the_write(self) -> None:
+        clock: Final = FakeClock()
+        pollers: Final = MappingProxyType(
+            {
+                "gateway-1": _reads(repeat(_key_info(RPM_AFTER_UPDATE))),
+                "gateway-2": _reads(
+                    chain(repeat(_key_info(RPM_BEFORE_UPDATE), 2), repeat(_key_info(RPM_AFTER_UPDATE)))
+                ),
+            }
+        )
+        outcomes: Final = _converge(pollers, clock)
+        assert outcomes == {
+            "gateway-1": Converged(result=_key_info(RPM_AFTER_UPDATE)),
+            "gateway-2": Converged(result=_key_info(RPM_AFTER_UPDATE)),
+        }
+        assert first_lagging_replica(outcomes) is None
+        assert clock.elapsed == 2 * INTERVAL
+
+    def test_names_the_replica_that_never_converges_with_its_last_read(self) -> None:
+        clock: Final = FakeClock()
+        pollers: Final = MappingProxyType(
+            {
+                "gateway-1": _reads(repeat(_key_info(RPM_AFTER_UPDATE))),
+                "gateway-2": _reads(repeat(_key_info(RPM_BEFORE_UPDATE))),
+            }
+        )
+        outcomes: Final = _converge(pollers, clock)
+        assert first_lagging_replica(outcomes) == (
+            "gateway-2",
+            NotConverged(last_result=_key_info(RPM_BEFORE_UPDATE)),
+        )
+        assert clock.elapsed == TIMEOUT
+        message: Final = read_back_timeout_message(
+            path="/key/info",
+            replica="gateway-2",
+            timeout=TIMEOUT,
+            last_result=_key_info(RPM_BEFORE_UPDATE),
+        )
+        assert "gateway-2" in message and "/key/info" in message and str(RPM_BEFORE_UPDATE) in message
 
 
 class TestParseReplicaUrls:

--- a/tests/e2e/test_proxy_client.py
+++ b/tests/e2e/test_proxy_client.py
@@ -23,7 +23,7 @@ from e2e_config import parse_replica_urls
 from e2e_http import Result, Success
 from models import KeyInfo, KeyInfoResponse, ModelListEntry, ModelsListResponse
 from proxy_client import (
-    BodyPoller,
+    Poller,
     ConvergeOutcome,
     Converged,
     ModelsPoller,
@@ -33,7 +33,7 @@ from proxy_client import (
     await_converged_everywhere,
     await_servable_everywhere,
     first_lagging_replica,
-    read_back_timeout_message,
+    converge_timeout_message,
 )
 
 MODEL: Final = "gpt-under-test"
@@ -99,7 +99,7 @@ def _key_info(rpm_limit: int) -> Success[KeyInfoResponse]:
     return Success(status_code=200, data=KeyInfoResponse(info=KeyInfo(rpm_limit=rpm_limit)))
 
 
-def _reads(results: Iterable[Result[KeyInfoResponse]]) -> BodyPoller[KeyInfoResponse]:
+def _reads(results: Iterable[Result[KeyInfoResponse]]) -> Poller[Result[KeyInfoResponse]]:
     it: Final = iter(results)
     return lambda: next(it)
 
@@ -109,8 +109,8 @@ def _updated(result: Result[KeyInfoResponse]) -> bool:
 
 
 def _converge(
-    pollers: Mapping[str, BodyPoller[KeyInfoResponse]], clock: FakeClock
-) -> Mapping[str, ConvergeOutcome[KeyInfoResponse]]:
+    pollers: Mapping[str, Poller[Result[KeyInfoResponse]]], clock: FakeClock
+) -> Mapping[str, ConvergeOutcome[Result[KeyInfoResponse]]]:
     return await_converged_everywhere(
         pollers,
         converged=_updated,
@@ -154,13 +154,30 @@ class TestAwaitConvergedEverywhere:
             NotConverged(last_result=_key_info(RPM_BEFORE_UPDATE)),
         )
         assert clock.elapsed == TIMEOUT
-        message: Final = read_back_timeout_message(
-            path="/key/info",
+        message: Final = converge_timeout_message(
+            what="GET /key/info",
             replica="gateway-2",
             timeout=TIMEOUT,
             last_result=_key_info(RPM_BEFORE_UPDATE),
         )
         assert "gateway-2" in message and "/key/info" in message and str(RPM_BEFORE_UPDATE) in message
+
+    def test_each_replica_gets_its_own_full_budget(self) -> None:
+        """A replica that converges late must not eat into the next replica's budget: both
+        need most of the timeout here, so one shared deadline would starve the second."""
+        clock: Final = FakeClock()
+        slow: Final = chain(repeat(_key_info(RPM_BEFORE_UPDATE), 3), repeat(_key_info(RPM_AFTER_UPDATE)))
+        pollers: Final = MappingProxyType(
+            {
+                "gateway-1": _reads(slow),
+                "gateway-2": _reads(
+                    chain(repeat(_key_info(RPM_BEFORE_UPDATE), 3), repeat(_key_info(RPM_AFTER_UPDATE)))
+                ),
+            }
+        )
+        outcomes: Final = _converge(pollers, clock)
+        assert first_lagging_replica(outcomes) is None
+        assert clock.elapsed == 2 * 3 * INTERVAL
 
 
 class TestParseReplicaUrls:

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -8017,6 +8017,11 @@ export interface paths {
          * Update Key Fn
          * @description Update an existing API key's parameters.
          *
+         *     The body is a merge patch: a field left out keeps its stored value, and on the key's own columns
+         *     an explicit null clears it. The metadata-backed fields below are the exception, merging into the
+         *     stored metadata instead: passing one as null leaves it unchanged, while `metadata` itself
+         *     replaces the stored metadata wholesale.
+         *
          *     Parameters:
          *     - key: Optional[str] - The key to update. Either key or key_alias must be provided.
          *     - key_alias: Optional[str] - User-friendly key alias. If key is omitted, also identifies the key to update (must match exactly one key, same as /key/delete's key_aliases)


### PR DESCRIPTION
## TLDR

Problem this solves:

- Nothing proved a partial key update leaves other fields alone
- Nothing proved an explicit null clears a field
- Nothing proved a key write reaches every gateway

How it solves it:

- One e2e file walks a key through its whole lifecycle
- Every read-back polls every gateway, not just one
- Documents what /key/update's merge patch actually does

## User Flow

Before: an admin who edits one setting on a virtual key has no guarantee the rest survived, and the gateways can disagree about that key

1. They POST /key/generate with an alias, a model list, a budget, tpm and rpm limits, a budget window, a team and a metadata tag
2. They POST /key/update naming only rpm_limit, to raise that one limit
3. They GET /key/info and see the new rpm_limit, but nothing would have caught it if the budget, the model list, the team or the tag had been dropped on the way
4. Their next request lands on a different gateway, and nothing would have caught that gateway still serving the old settings, or still honouring a key they deleted

After: the same edits are covered end to end on every gateway, so a regression in any of them turns the suite red

1. They POST /key/generate with the same fields, and GET /key/info on every gateway returns what they sent, with a budget reset time set
2. They POST /key/update naming only rpm_limit
3. GET /key/info on every gateway shows the new rpm_limit, with the alias, models, budget, tpm limit, budget window, team and tag all unchanged and the reset time where it was
4. They POST /key/update with max_budget and budget_duration set to null, and every gateway reports both cleared along with the reset time
5. They chat on the key's allowed model and get a 200, chat on a model outside its list and get a 403
6. They POST /key/delete, and every gateway stops resolving the key and refuses it with a 401, including gateways that had been serving it

## Relevant issues

## Linear ticket

## Type

✅ Test

## Screenshots / Proof of Fix

Shared setup, a proxy on two ports against one Postgres, so the read-backs have more than one gateway to check:

```bash
docker compose up -d db   # or any postgres on 5432
export LITELLM_MASTER_KEY=sk-1234 DATABASE_URL=postgresql://llmproxy:dbpassword9090@127.0.0.1:5432/litellm STORE_MODEL_IN_DB=True
python litellm/proxy/proxy_cli.py --config proof_config.yaml --port 4010 &
python litellm/proxy/proxy_cli.py --config proof_config.yaml --port 4011 &
```

The config needs no provider key: the enforcement step registers its own mock_response deployment through /model/new, and gpt-5.5 is only ever used as a model the key may not call.

### Before (410486845 plus a one-line regression)

This PR changes no proxy behaviour, so a plain before/after of the same commands would read identically. To show what the suite is actually worth, this side runs the merge base with one line of `prepare_metadata_fields` changed so a key update stops preserving stored metadata.

#### An edit to one limit silently drops the key's metadata

1. Create a key carrying a metadata tag, then read it back on the other gateway:

```
curl -s "http://127.0.0.1:4011/key/info?key=$KEY" -H "Authorization: Bearer sk-1234"
{"key_alias": "proof-regressed", "models": ["gpt-5.5"], "max_budget": 25.0, "tpm_limit": 313131,
 "rpm_limit": 323232, "budget_duration": "30d", "metadata": {"tag": "team-checkout"}}
```

2. Raise only rpm_limit:

```
curl -X POST http://127.0.0.1:4010/key/update -H "Authorization: Bearer sk-1234" \
  -d '{"key":"'$KEY'","rpm_limit":424242}'
HTTP 200
```

3. Read it back on the other gateway. The tag is gone, with no error anywhere:

```
{"key_alias": "proof-regressed", "models": ["gpt-5.5"], "max_budget": 25.0, "tpm_limit": 313131,
 "rpm_limit": 424242, "budget_duration": "30d", "metadata": {}}
```

4. The new suite catches it, naming the lost tag and the gateway:

```
E  AssertionError: http://127.0.0.1:4010: /key/info reports metadata=KeyMetadata(..., tag=None),
   expected KeyMetadata(..., tag='1a7bd6f9c051')
FAILED tests/e2e/management/test_key_lifecycle_e2e.py::TestKeyLifecycle::test_partial_update_changes_only_the_named_field
FAILED tests/e2e/management/test_key_lifecycle_e2e.py::TestKeyLifecycle::test_explicit_null_clears_the_budget_and_its_reset_time
2 failed, 4 passed in 77.06s
```

### After (ac9d7f036)

#### An edit to one limit leaves everything else alone

1. Create the same key and read it back on the other gateway:

```
{"key_alias": "proof-fixed", "models": ["gpt-5.5"], "max_budget": 25.0, "tpm_limit": 313131,
 "rpm_limit": 323232, "budget_duration": "30d", "budget_reset_at": "2026-10-01T00:00:00+00:00",
 "metadata": {"tag": "team-checkout"}}
```

2. Raise only rpm_limit, then read back on the other gateway. Only that limit moved:

```
POST /key/update {"rpm_limit":424242} -> HTTP 200

{"key_alias": "proof-fixed", "models": ["gpt-5.5"], "max_budget": 25.0, "tpm_limit": 313131,
 "rpm_limit": 424242, "budget_duration": "30d", "budget_reset_at": "2026-10-01T00:00:00+00:00",
 "metadata": {"tag": "team-checkout"}}
```

3. Clear the budget with explicit nulls, then read back. Both fields and the derived reset time are gone, the rest untouched:

```
POST /key/update {"max_budget":null,"budget_duration":null} -> HTTP 200

{"key_alias": "proof-fixed", "models": ["gpt-5.5"], "max_budget": null, "tpm_limit": 313131,
 "rpm_limit": 424242, "budget_duration": null, "budget_reset_at": null,
 "metadata": {"tag": "team-checkout"}}
```

4. The suite passes against both gateways:

```
uv run pytest tests/e2e/management/test_key_lifecycle_e2e.py -v
6 passed in 76.83s (0:01:16)
```

## QA runbook

- tests/e2e/management/test_key_lifecycle_e2e.py::TestKeyLifecycle::test_create_echoes_every_field_written - /key/generate hands back every field it was given
  - [ ] POST /key/generate with key_alias, models, max_budget, tpm_limit, rpm_limit, budget_duration, metadata and a team_id from a team you just created
  - [ ] Expect the response body to echo each of those values unchanged
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey or potentially flaky

- tests/e2e/management/test_key_lifecycle_e2e.py::TestKeyLifecycle::test_read_reflects_the_create_on_every_replica - the create is visible on every gateway, not just the one that took it
  - [ ] GET /key/info?key=... against each address in LITELLM_PROXY_REPLICA_URLS
  - [ ] Expect every gateway to return the fields you sent, plus a non-null budget_reset_at
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey or potentially flaky

- tests/e2e/management/test_key_lifecycle_e2e.py::TestKeyLifecycle::test_partial_update_changes_only_the_named_field - a partial update touches only the field it names
  - [ ] POST /key/update with just {"key": ..., "rpm_limit": 424242}
  - [ ] GET /key/info on every gateway and expect the new rpm_limit
  - [ ] Expect key_alias, models, max_budget, tpm_limit, budget_duration, team_id and metadata to match the create exactly, and budget_reset_at not to have moved
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey or potentially flaky

- tests/e2e/management/test_key_lifecycle_e2e.py::TestKeyLifecycle::test_explicit_null_clears_the_budget_and_its_reset_time - an explicit null clears a column, and takes the derived reset time with it
  - [ ] POST /key/update with {"key": ..., "max_budget": null, "budget_duration": null}
  - [ ] GET /key/info on every gateway and expect max_budget, budget_duration and budget_reset_at all null
  - [ ] Expect every other field to still match the create
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey or potentially flaky

- tests/e2e/management/test_key_lifecycle_e2e.py::TestKeyLifecycle::test_key_serves_its_model_and_is_denied_others - the key's model list is enforced both ways
  - [ ] POST /chat/completions with the key against the model it was created for and expect 200 (needs STORE_MODEL_IN_DB=True; the test registers its own mock_response deployment, so no provider key)
  - [ ] POST /chat/completions with the same key against gpt-5.5 and expect 403 carrying key_model_access_denied
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey or potentially flaky

- tests/e2e/management/test_key_lifecycle_e2e.py::TestKeyLifecycle::test_delete_revokes_info_and_chat_on_every_replica - deleting a key revokes it on every gateway, including ones already serving it
  - [ ] Send one successful chat through every gateway address first, so each has the key cached
  - [ ] POST /key/delete with that key
  - [ ] Expect GET /key/info to answer 404 on every gateway
  - [ ] Expect POST /chat/completions to answer 401 on every gateway; without a shared Redis this takes up to a minute on the gateways that did not process the delete, which is why the test polls
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey or potentially flaky

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Caveats (if any)

### Medium

- `e2e-changed-tests` cannot pass until a maintainer approves the `e2e-changed` environment; every push cancels the run awaiting approval

### Low

- Delete test waits out cross-gateway revocation, around 60s without Redis
- Key is scoped to a uniquely named mock deployment, not a literal gpt-4o-mini

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
