### PR TITLE
refactor(proxy): add team model identity groundwork

### DIFF
--- a/litellm-proxy-extras/litellm_proxy_extras/migrations/20260906000000_add_model_team_identity/migration.sql
+++ b/litellm-proxy-extras/litellm_proxy_extras/migrations/20260906000000_add_model_team_identity/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "LiteLLM_ProxyModelTable" ADD COLUMN "team_id" TEXT;

--- a/litellm-proxy-extras/litellm_proxy_extras/migrations/20260906000001_index_model_team_identity/migration.sql
+++ b/litellm-proxy-extras/litellm_proxy_extras/migrations/20260906000001_index_model_team_identity/migration.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY "LiteLLM_ProxyModelTable_team_id_idx" ON "LiteLLM_ProxyModelTable"("team_id");

--- a/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
+++ b/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
@@ -51,6 +51,7 @@ model LiteLLM_CredentialsTable {
 model LiteLLM_ProxyModelTable {
   model_id String @id @default(uuid())
   model_name String
+  team_id String?
   litellm_params Json
   model_info Json?
   blocked Boolean @default(false)
@@ -58,6 +59,8 @@ model LiteLLM_ProxyModelTable {
   created_by String
   updated_at    DateTime               @default(now()) @updatedAt @map("updated_at")
   updated_by String
+
+  @@index([team_id])
 }
 
 

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -51,6 +51,7 @@ model LiteLLM_CredentialsTable {
 model LiteLLM_ProxyModelTable {
   model_id String @id @default(uuid())
   model_name String
+  team_id String?
   litellm_params Json
   model_info Json?
   blocked Boolean @default(false)
@@ -58,6 +59,8 @@ model LiteLLM_ProxyModelTable {
   created_by String
   updated_at    DateTime               @default(now()) @updatedAt @map("updated_at")
   updated_by String
+
+  @@index([team_id])
 }
 
 

--- a/litellm/repositories/model_repository.py
+++ b/litellm/repositories/model_repository.py
@@ -5,7 +5,15 @@ Model repository for database operations on LiteLLM_ProxyModelTable.
 import json
 from collections.abc import Mapping, Sequence
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Final, Protocol
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Final,
+    Protocol,
+    cast,  # noqa: TID251  # Prisma's delegated actions cannot be validated as data
+)
+
+from pydantic import TypeAdapter
 
 from litellm.models.model import LiteLLM_ProxyModelTable
 from litellm.proxy.common_utils.config_sync_pubsub import wrap_table_actions_for_config_sync
@@ -18,6 +26,70 @@ from litellm.repositories.prisma_protocols import TableActions
 
 if TYPE_CHECKING:
     from prisma import models as prisma_models
+
+
+_MODEL_INFO: Final[TypeAdapter[Mapping[str, object] | None]] = TypeAdapter(Mapping[str, object] | None)
+_TEAM_ID: Final[TypeAdapter[str | None]] = TypeAdapter(str | None)
+_WRITE_DATA: Final[TypeAdapter[Mapping[str, object]]] = TypeAdapter(Mapping[str, object])
+
+
+def _with_team_identity(data: Mapping[str, object]) -> Mapping[str, object]:
+    if "model_info" not in data:
+        return data
+    from prisma import Json
+
+    supplied_info: Final = data["model_info"]
+    raw_info: Final = supplied_info.data if isinstance(supplied_info, Json) else supplied_info
+    info: Final = (
+        _MODEL_INFO.validate_json(raw_info, strict=True)
+        if isinstance(raw_info, str)
+        else _MODEL_INFO.validate_python(raw_info, strict=True)
+    )
+    team_id: Final = _TEAM_ID.validate_python(info.get("team_id") if info else None, strict=True)
+    return {**data, "team_id": team_id}  # mutable-ok: Prisma serializes dict inputs and rejects MappingProxyType
+
+
+class _TeamIdentityActions:
+    def __init__(self, actions: TableActions["prisma_models.LiteLLM_ProxyModelTable"]) -> None:
+        self._actions = actions
+
+    def __getattr__(self, name: str) -> object:
+        return cast(object, getattr(self._actions, name))  # cast-ok: unchanged Prisma read and delete actions
+
+    async def create(
+        self, data: Mapping[str, object], include: Mapping[str, object] | None = None
+    ) -> "prisma_models.LiteLLM_ProxyModelTable":
+        if include is None:
+            return await self._actions.create(data=_with_team_identity(data))
+        return await self._actions.create(data=_with_team_identity(data), include=include)
+
+    async def create_many(self, data: Sequence[Mapping[str, object]], *, skip_duplicates: bool | None = None) -> int:
+        return await self._actions.create_many(
+            data=tuple(_with_team_identity(row) for row in data), skip_duplicates=skip_duplicates
+        )
+
+    async def update(
+        self, data: Mapping[str, object], where: Mapping[str, object], include: Mapping[str, object] | None = None
+    ) -> "prisma_models.LiteLLM_ProxyModelTable | None":
+        if include is None:
+            return await self._actions.update(data=_with_team_identity(data), where=where)
+        return await self._actions.update(data=_with_team_identity(data), where=where, include=include)
+
+    async def update_many(self, data: Mapping[str, object], where: Mapping[str, object]) -> int:
+        return await self._actions.update_many(data=_with_team_identity(data), where=where)
+
+    async def upsert(
+        self, where: Mapping[str, object], data: Mapping[str, object], include: Mapping[str, object] | None = None
+    ) -> "prisma_models.LiteLLM_ProxyModelTable":
+        prepared: Final = {  # mutable-ok: Prisma serializes dict inputs and rejects MappingProxyType
+            key: _with_team_identity(_WRITE_DATA.validate_python(value, strict=True))
+            if key in ("create", "update")
+            else value
+            for key, value in data.items()
+        }
+        if include is None:
+            return await self._actions.upsert(where=where, data=prepared)
+        return await self._actions.upsert(where=where, data=prepared, include=include)
 
 
 class _PrismaModelDb(Protocol):
@@ -40,8 +112,11 @@ class ModelRepository(BaseRepository[LiteLLM_ProxyModelTable]):
     @property
     def table(self) -> TableActions["prisma_models.LiteLLM_ProxyModelTable"]:
         client: Final[_PrismaClientView] = self.prisma_client
+        identity_actions: Final = _TeamIdentityActions(client.db.litellm_proxymodeltable)
         return wrap_table_actions_for_config_sync(
-            actions=client.db.litellm_proxymodeltable,
+            actions=cast(  # cast-ok: writes preserve row types; unchanged actions delegate to Prisma
+                'TableActions["prisma_models.LiteLLM_ProxyModelTable"]', identity_actions
+            ),
             table_name="litellm_proxymodeltable",
         )
 
@@ -114,12 +189,7 @@ class ModelRepository(BaseRepository[LiteLLM_ProxyModelTable]):
         return tuple(self._to_model_list(records))
 
     async def find_by_team_id(self, team_id: str) -> list[LiteLLM_ProxyModelTable]:
-        """Find models associated with a specific team.
-
-        Note: This filters in-memory since team_id is stored within litellm_params
-        JSON. For large deployments with many models, consider adding a dedicated
-        team_id column with a database index.
-        """
+        """Read legacy model_info ownership until the rollout and backfill are complete."""
         all_models: Final = await self.find_all()
         return [m for m in all_models if m.team_id == team_id]
 

--- a/schema.prisma
+++ b/schema.prisma
@@ -51,6 +51,7 @@ model LiteLLM_CredentialsTable {
 model LiteLLM_ProxyModelTable {
   model_id String @id @default(uuid())
   model_name String
+  team_id String?
   litellm_params Json
   model_info Json?
   blocked Boolean @default(false)
@@ -58,6 +59,8 @@ model LiteLLM_ProxyModelTable {
   created_by String
   updated_at    DateTime               @default(now()) @updatedAt @map("updated_at")
   updated_by String
+
+  @@index([team_id])
 }
 
 

--- a/scripts/backfill_team_model_identity.md
+++ b/scripts/backfill_team_model_identity.md
@@ -1,0 +1,69 @@
+# Backfill team model ownership
+
+This optional script copies `model_info.team_id` into the new `LiteLLM_ProxyModelTable.team_id` column. It does not rename models, change routing, rewrite metadata, decrypt credentials, or modify timestamps. The schema migrations add the nullable column and its index only; they never run this backfill
+
+Run it with Python 3.10–3.14 in the existing LiteLLM proxy environment, using its existing `psycopg` driver. No additional package dependencies or Prisma client generation are required by the script. Apply the schema migrations first
+
+## Preview and execute
+
+Set `DATABASE_URL` through your existing secret-management mechanism. The script does not accept connection credentials on the command line or print the connection string
+
+```bash
+python scripts/backfill_team_model_identity.py
+python scripts/backfill_team_model_identity.py --execute
+python scripts/backfill_team_model_identity.py
+```
+
+The default is a database-enforced read-only dry run. `--dry-run` makes that choice explicit. Every scanned model is reported as one JSON line, identifying its model ID, stored name, current column value, proposed value and action. For example:
+
+```json
+{"event":"model","model_id":"example-model-id","model_name":"example-model","status":"pending","from_team_id":null,"to_team_id":"example-team","action":"set_team_id"}
+```
+
+`--execute` re-reads the database rather than applying a saved preview. Only rows marked `pending` are eligible. Rows changed since they were read are skipped as `concurrent_change`. Committed rows are reported as `updated`; skipped rows have `action: none`
+
+Global models remain unassigned. Already matching values are unchanged. Conflicting values, malformed metadata, invalid team IDs and references to missing teams are reported and skipped, while valid rows continue. The script never derives ownership from names or chooses between conflicting owners. Legacy metadata stored as a JSON string containing an object is supported
+
+## Live operation and replicas
+
+Dry runs can use read replicas, but their results may lag the primary. `--execute` requires a writable primary; read-only transactions and replicas are rejected before updates. Run the final verification against the primary
+
+PR one retains the existing metadata-based routing behavior. Older proxy versions can still insert unfilled rows or change ownership metadata without updating the new column. Safe reruns fill newly eligible rows but never overwrite conflicts. Complete the proxy rollout, resolve reported discrepancies, then run a full dry run on the primary with `pending: 0` and `issues: 0` before treating the new column as ready for future routing changes. A dry run is an observation, not a guarantee against subsequent model changes
+
+## Batching and resuming
+
+```bash
+python scripts/backfill_team_model_identity.py --execute --batch-size 200 --max-batches 10
+python scripts/backfill_team_model_identity.py --execute --after-model-id '<cursor from the last committed progress event>'
+```
+
+Each bounded batch commits atomically. Lock waits and statements have finite timeouts. An interrupted or failed batch rolls back; earlier committed batches remain valid. Rerunning from the beginning is always supported and is usually simplest. No checkpoint file or extra database table is required
+
+A resumed scan only covers IDs after its cursor. New rows may sort before it, so always finish with a full scan without `--after-model-id`. Each invocation bounds its scan using the greatest ID observed at startup rather than chasing an indefinitely growing table
+
+| Option | Default | Purpose |
+| --- | --- | --- |
+| `--schema` | URL `schema` parameter, otherwise `current_schema()` | Select the schema explicitly; conflicting schema settings fail |
+| `--batch-size` | `500` | Rows per transaction, from 1 to 10,000 |
+| `--max-batches` | No limit | Stop after a bounded number of batches |
+| `--after-model-id` | Beginning | Resume after a committed cursor |
+| `--lock-timeout-ms` | `2000` | Bound lock waits |
+| `--statement-timeout-ms` | `30000` | Bound each SQL statement |
+
+PostgreSQL URI and libpq connection strings are accepted. Prisma URL options `schema`, `connection_limit`, `pool_timeout` and `pgbouncer` are handled separately; TLS and other driver options are retained. Ordinary LiteLLM tables with the expected column types and unique IDs are required. Views, partitioned tables, incompatible schema layouts and active row-level filtering are rejected instead of being silently treated as complete scans
+
+Preview requires schema access and SELECT on the model and team tables. Execution additionally requires UPDATE on the model's `team_id` column. No INSERT, DELETE or schema-changing privileges are used by the script
+
+## Results
+
+| Exit code | Meaning |
+| --- | --- |
+| `0` | Requested scan finished without detected issues; a dry run may still report pending work |
+| `1` | Connection, schema, permission or database failure; earlier batches may have committed |
+| `2` | Ambiguous or concurrently changed rows were skipped; inspect model events |
+| `3` | Stopped at `--max-batches`; resume or rerun |
+| `130` | Interrupted; resume or rerun |
+
+Database failures include their SQLSTATE when available. Server exception text and provider parameters are excluded from output. Preserve the last committed progress event if resuming after a failure. The script intentionally offers no overwrite or automatic repair mode
+
+The concurrent index migration is separate from the column migration. If an index build is interrupted, inspect its validity and follow the existing Prisma failed-migration recovery procedure before retrying that migration; do not assume an index with the expected name is valid

--- a/scripts/backfill_team_model_identity.py
+++ b/scripts/backfill_team_model_identity.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+"""Preview or execute the optional team_id backfill using the existing proxy runtime."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import asdict, dataclass, replace
+from typing import Final, Literal, cast
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+import psycopg
+from psycopg import Connection, sql
+from psycopg.rows import class_row
+
+Row = tuple[object, ...]
+Emit = Callable[[Mapping[str, object]], None]
+Status = Literal["pending", "global", "already_set", "invalid_metadata", "invalid_team_id", "conflict", "missing_team"]
+PRISMA_OPTIONS: Final = frozenset({"schema", "connection_limit", "pool_timeout", "pgbouncer"})
+
+
+@dataclass(frozen=True, slots=True)
+class Options:
+    execute: bool = False
+    schema: str | None = None
+    batch_size: int = 500
+    after_model_id: str | None = None
+    max_batches: int | None = None
+    lock_timeout_ms: int = 2000
+    statement_timeout_ms: int = 30000
+
+
+@dataclass(frozen=True, slots=True)
+class Snapshot:
+    model_id: str
+    model_name: str
+    raw_info: str | None
+    team_id: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class Decision:
+    row: Snapshot
+    status: Status
+    proposed_team_id: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class Progress:
+    scanned: int = 0
+    pending: int = 0
+    updated: int = 0
+    issues: int = 0
+    batches: int = 0
+    cursor: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class Column:
+    name: str
+    data_type: str
+
+
+@dataclass(frozen=True, slots=True)
+class Target:
+    schema: str
+    replica: bool
+    read_only: bool
+
+
+def classify(row: Snapshot) -> Decision:
+    try:
+        decoded: Final[object] = (
+            json.loads(row.raw_info, object_pairs_hook=unique_object) if row.raw_info is not None else None
+        )
+        info: Final[object] = (
+            json.loads(decoded, object_pairs_hook=unique_object) if isinstance(decoded, str) else decoded
+        )
+    except (ValueError, RecursionError):
+        return Decision(row, "invalid_metadata")
+    if info is not None and not isinstance(info, dict):
+        return Decision(row, "invalid_metadata")
+    metadata: Final = cast("dict[str, object] | None", info)  # cast-ok: decoded JSON object keys are strings
+    owner: Final = metadata.get("team_id") if metadata is not None else None
+    if owner is None and metadata is not None and "team_public_model_name" in metadata:
+        return Decision(row, "invalid_team_id")
+    if owner is not None and (
+        not isinstance(owner, str)
+        or not owner.strip()
+        or "\x00" in owner
+        or any(0xD800 <= ord(character) <= 0xDFFF for character in owner)
+    ):
+        return Decision(row, "invalid_team_id")
+    proposed: Final = owner if isinstance(owner, str) else None
+    if row.team_id is not None and row.team_id != proposed:
+        return Decision(row, "conflict", proposed)
+    if proposed is None:
+        return Decision(row, "global")
+    return Decision(row, "already_set" if row.team_id is not None else "pending", proposed)
+
+
+def unique_object(pairs: Sequence[tuple[str, object]]) -> dict[str, object]:
+    result: Final = dict(pairs)
+    if len(result) != len(pairs):
+        raise ValueError("Duplicate metadata keys")
+    return result
+
+
+def connection_parameters(dsn: str, schema: str | None) -> tuple[str, str | None]:
+    if not dsn.startswith(("postgres://", "postgresql://")):
+        return dsn, schema
+    parsed: Final = urlsplit(dsn)
+    pairs: Final = tuple(parse_qsl(parsed.query, keep_blank_values=True))
+    schemas: Final = tuple(value for key, value in pairs if key == "schema")
+    if len(schemas) > 1 or (schemas and (not schemas[0] or (schema is not None and schema != schemas[0]))):
+        raise ValueError("Conflicting or empty schema settings")
+    cleaned: Final = urlunsplit(parsed._replace(query=urlencode(tuple(p for p in pairs if p[0] not in PRISMA_OPTIONS))))
+    return cleaned, schema if schema is not None else (schemas[0] if schemas else None)
+
+
+def _one(conn: Connection[Row], query: sql.SQL | sql.Composed, params: Sequence[object] = ()) -> Row:
+    result: Final = conn.execute(query, params).fetchone()
+    if result is None:
+        raise ValueError("Expected database result")
+    return result
+
+
+def inspect_target(conn: Connection[Row], options: Options) -> Target:
+    observed: Final = _one(
+        conn, sql.SQL("SELECT current_schema(), pg_is_in_recovery(), current_setting('transaction_read_only')")
+    )
+    schema: Final = options.schema if options.schema is not None else observed[0]
+    if not isinstance(schema, str) or not schema or "\x00" in schema:
+        raise ValueError("No valid schema selected")
+    return Target(schema, observed[1] is True, observed[2] == "on")
+
+
+def check_schema(conn: Connection[Row], schema: str) -> None:
+    for table, expected in (
+        (
+            "LiteLLM_ProxyModelTable",
+            {"model_id": {"text"}, "model_name": {"text"}, "model_info": {"json", "jsonb"}, "team_id": {"text"}},
+        ),
+        ("LiteLLM_TeamTable", {"team_id": {"text"}}),
+    ):
+        check_table(conn, schema, table, expected)
+
+
+def check_table(conn: Connection[Row], schema: str, table: str, expected: Mapping[str, set[str]]) -> None:
+    relation: Final = sql.Identifier(schema, table).as_string(conn)
+    flags: Final = _one(
+        conn,
+        sql.SQL("SELECT c.relkind, row_security_active(c.oid) FROM pg_class c WHERE c.oid = to_regclass(%s)"),
+        (relation,),
+    )
+    if flags[0] != "r" or flags[1] is not False:
+        raise ValueError("Expected an ordinary table with unrestricted row visibility")
+    with conn.cursor(row_factory=class_row(Column)) as cursor:
+        cursor.execute(
+            "SELECT attname AS name, typname AS data_type FROM pg_attribute a JOIN pg_type t ON t.oid=a.atttypid "
+            "WHERE attrelid=to_regclass(%s) AND attnum>0 AND NOT attisdropped",
+            (relation,),
+        )
+        columns: Final = {column.name: column.data_type for column in cursor.fetchall()}
+    if any(columns.get(name) not in accepted for name, accepted in expected.items()):
+        raise ValueError("Required columns or types are missing; apply the schema migration first")
+    id_column: Final = "model_id" if table == "LiteLLM_ProxyModelTable" else "team_id"
+    unique: Final = _one(
+        conn,
+        sql.SQL(
+            "SELECT EXISTS (SELECT 1 FROM pg_index i JOIN pg_attribute a "
+            "ON a.attrelid=i.indrelid AND a.attnum=i.indkey[0] "
+            "WHERE i.indrelid=to_regclass(%s) AND i.indisunique AND i.indisvalid "
+            "AND i.indnkeyatts=1 AND i.indpred IS NULL AND a.attname=%s AND a.attnotnull)"
+        ),
+        (relation, id_column),
+    )
+    if unique[0] is not True:
+        raise ValueError("Expected a non-null unique identifier")
+
+
+def read_batch(
+    conn: Connection[Row], table: sql.Identifier, after: str | None, upper: str, batch_size: int
+) -> tuple[Snapshot, ...]:
+    query: Final = sql.SQL(
+        'SELECT "model_id", "model_name", "model_info"::text AS raw_info, "team_id" FROM {} '
+        'WHERE (%s::text IS NULL OR "model_id" > %s) AND "model_id" <= %s ORDER BY "model_id" LIMIT %s'
+    ).format(table)
+    with conn.cursor(row_factory=class_row(Snapshot)) as cursor:
+        cursor.execute(query, (after, after, upper, batch_size))
+        return tuple(cursor.fetchall())
+
+
+def check_teams(conn: Connection[Row], table: sql.Identifier, decisions: tuple[Decision, ...]) -> tuple[Decision, ...]:
+    owners: Final = tuple({d.proposed_team_id for d in decisions if d.status in {"pending", "already_set"}})
+    if not owners:
+        return decisions
+    existing: Final = frozenset(
+        row[0]
+        for row in conn.execute(
+            sql.SQL('SELECT "team_id" FROM {} WHERE "team_id" = ANY(%s)').format(table), (list(owners),)
+        )
+    )
+    return tuple(
+        replace(d, status="missing_team")
+        if d.status in {"pending", "already_set"} and d.proposed_team_id not in existing
+        else d
+        for d in decisions
+    )
+
+
+def execute_batch(
+    conn: Connection[Row], models: sql.Identifier, teams: sql.Identifier, decisions: tuple[Decision, ...]
+) -> frozenset[str]:
+    candidates: Final = tuple(d for d in decisions if d.status == "pending")
+    if not candidates:
+        return frozenset()
+    values: Final = sql.SQL(", ").join(sql.SQL("(%s::text, %s::text, %s::text)") for _ in candidates)
+    query: Final = sql.SQL(
+        'UPDATE {} AS m SET "team_id" = v.team_id FROM (VALUES {}) AS v(model_id, raw_info, team_id) '
+        'WHERE m."model_id" = v.model_id AND m."team_id" IS NULL '
+        'AND m."model_info"::text IS NOT DISTINCT FROM v.raw_info '
+        'AND EXISTS (SELECT 1 FROM {} t WHERE t."team_id" = v.team_id) RETURNING m."model_id"'
+    ).format(models, values, teams)
+    params: Final = tuple(value for d in candidates for value in (d.row.model_id, d.row.raw_info, d.proposed_team_id))
+    return frozenset(str(row[0]) for row in conn.execute(query, params))
+
+
+def report_batch(decisions: tuple[Decision, ...], updated: frozenset[str], execute: bool, emit: Emit) -> int:
+    for decision in decisions:
+        emit(model_event(decision, updated, execute))
+    return sum(d.status not in {"pending", "global", "already_set"} for d in decisions) + (
+        sum(d.status == "pending" for d in decisions) - len(updated) if execute else 0
+    )
+
+
+def model_event(decision: Decision, updated: frozenset[str], execute: bool) -> Mapping[str, object]:
+    status: Final = (
+        ("updated" if decision.row.model_id in updated else "concurrent_change")
+        if execute and decision.status == "pending"
+        else decision.status
+    )
+    return {
+        "event": "model",
+        "model_id": decision.row.model_id,
+        "model_name": decision.row.model_name,
+        "status": status,
+        "from_team_id": decision.row.team_id,
+        "to_team_id": decision.proposed_team_id,
+        "action": "set_team_id" if status in {"pending", "updated"} else "none",
+    }
+
+
+def process_batch(
+    conn: Connection[Row],
+    models: sql.Identifier,
+    teams: sql.Identifier,
+    state: Progress,
+    upper: str,
+    options: Options,
+    emit: Emit,
+) -> Progress | None:
+    with conn.transaction():
+        if not options.execute:
+            conn.execute("SET TRANSACTION READ ONLY")
+        conn.execute("SELECT set_config('lock_timeout', %s, true)", (f"{options.lock_timeout_ms}ms",))
+        conn.execute("SELECT set_config('statement_timeout', %s, true)", (f"{options.statement_timeout_ms}ms",))
+        rows: Final = read_batch(conn, models, state.cursor, upper, options.batch_size)
+        decisions: Final = check_teams(conn, teams, tuple(classify(row) for row in rows))
+        updated: Final = execute_batch(conn, models, teams, decisions) if options.execute else frozenset[str]()
+    if not rows:
+        return None
+    issues: Final = report_batch(decisions, updated, options.execute, emit)
+    return Progress(
+        scanned=state.scanned + len(rows),
+        pending=state.pending + sum(d.status == "pending" for d in decisions),
+        updated=state.updated + len(updated),
+        issues=state.issues + issues,
+        batches=state.batches + 1,
+        cursor=rows[-1].model_id,
+    )
+
+
+def run(conn: Connection[Row], options: Options, emit: Emit) -> int:
+    target: Final = inspect_target(conn, options)
+    emit({"event": "target", "mode": "execute" if options.execute else "dry_run", **asdict(target)})
+    if options.execute and (target.replica or target.read_only):
+        emit({"event": "error", "reason": "execute_requires_writable_primary"})
+        return 1
+    if not options.execute:
+        conn.execute("SET default_transaction_read_only = on")
+    conn.execute("SELECT set_config('lock_timeout', %s, false)", (f"{options.lock_timeout_ms}ms",))
+    conn.execute("SELECT set_config('statement_timeout', %s, false)", (f"{options.statement_timeout_ms}ms",))
+    check_schema(conn, target.schema)
+    models: Final = sql.Identifier(target.schema, "LiteLLM_ProxyModelTable")
+    teams: Final = sql.Identifier(target.schema, "LiteLLM_TeamTable")
+    upper_row: Final = conn.execute(
+        sql.SQL('SELECT "model_id" FROM {} ORDER BY "model_id" DESC LIMIT 1').format(models)
+    ).fetchone()
+    upper: Final = str(upper_row[0]) if upper_row else None
+    state = Progress(
+        cursor=options.after_model_id
+    )  # rebind-ok: bounded scan progress advances after each committed batch
+    while upper is not None:
+        if (next_state := process_batch(conn, models, teams, state, upper, options, emit)) is None:
+            break
+        state = next_state  # rebind-ok: only committed batches contribute to progress
+        emit({"event": "progress", **asdict(state)})
+        if options.max_batches is not None and state.batches >= options.max_batches and state.cursor != upper:
+            emit({"event": "summary", "scan_finished": False, **asdict(state)})
+            return 2 if state.issues else 3
+    emit({"event": "summary", "scan_finished": True, "resumed": options.after_model_id is not None, **asdict(state)})
+    return 2 if state.issues else 0
+
+
+def positive_int(value: str) -> int:
+    parsed: Final = int(value)
+    if not 1 <= parsed <= 2_147_483_647:
+        raise argparse.ArgumentTypeError("Must be between 1 and 2147483647")
+    return parsed
+
+
+def batch_size(value: str) -> int:
+    parsed: Final = positive_int(value)
+    if parsed > 10000:
+        raise argparse.ArgumentTypeError("Batch size must not exceed 10000")
+    return parsed
+
+
+def emit_json(event: Mapping[str, object]) -> None:
+    sys.stdout.write(json.dumps(dict(event), ensure_ascii=True) + "\n")
+    sys.stdout.flush()
+
+
+class Arguments(argparse.Namespace):
+    execute: bool
+    schema: str | None
+    batch_size: int
+    after_model_id: str | None
+    max_batches: int | None
+    lock_timeout_ms: int
+    statement_timeout_ms: int
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    driver_logger: Final = logging.getLogger("psycopg")
+    driver_logger.addHandler(logging.NullHandler())
+    driver_logger.propagate = False
+    parser: Final = argparse.ArgumentParser(description=__doc__)
+    mode: Final = parser.add_mutually_exclusive_group()
+    mode.add_argument("--execute", action="store_true", help="Apply changes; the default is a read-only dry run")
+    mode.add_argument("--dry-run", action="store_true", help="Explicitly request the default read-only preview")
+    parser.add_argument("--schema", help="Database schema; otherwise use DATABASE_URL's schema or current_schema()")
+    parser.add_argument("--batch-size", type=batch_size, default=500)
+    parser.add_argument(
+        "--after-model-id", help="Resume after a committed progress cursor; rerun a full dry run afterward"
+    )
+    parser.add_argument(
+        "--max-batches", type=positive_int, help="Stop after this many batches and print a resume cursor"
+    )
+    parser.add_argument("--lock-timeout-ms", type=positive_int, default=2000)
+    parser.add_argument("--statement-timeout-ms", type=positive_int, default=30000)
+    args: Final = parser.parse_args(argv, namespace=Arguments())
+    dsn: Final = os.environ.get("DATABASE_URL")
+    if not dsn:
+        emit_json({"event": "error", "reason": "DATABASE_URL_is_required"})
+        return 1
+    try:
+        connection_string, schema = connection_parameters(dsn, args.schema)
+        options: Final = Options(
+            execute=args.execute,
+            schema=schema,
+            batch_size=args.batch_size,
+            after_model_id=args.after_model_id,
+            max_batches=args.max_batches,
+            lock_timeout_ms=args.lock_timeout_ms,
+            statement_timeout_ms=args.statement_timeout_ms,
+        )
+        with psycopg.connect(connection_string, autocommit=True, connect_timeout=10) as conn:
+            return run(conn, options, emit_json)
+    except KeyboardInterrupt:
+        emit_json({"event": "error", "reason": "interrupted_rerun_safely"})
+        return 130
+    except (psycopg.Error, ValueError, OSError) as error:
+        emit_json(
+            {
+                "event": "error",
+                "reason": "database_or_configuration_error_rerun_safely",
+                "sqlstate": error.sqlstate if isinstance(error, psycopg.Error) else None,
+            }
+        )
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/proxy_migration_tests/test_backfill_team_model_identity.py
+++ b/tests/proxy_migration_tests/test_backfill_team_model_identity.py
@@ -1,0 +1,573 @@
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+
+import psycopg
+import pytest
+from psycopg import sql
+from psycopg.conninfo import make_conninfo
+
+from scripts import backfill_team_model_identity as backfill
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts/backfill_team_model_identity.py"
+MIGRATIONS = ROOT / "litellm-proxy-extras/litellm_proxy_extras/migrations"
+MIGRATION_NAMES = ("20260906000000_add_model_team_identity", "20260906000001_index_model_team_identity")
+pytestmark = pytest.mark.skipif(not os.environ.get("DATABASE_URL"), reason="requires isolated PostgreSQL")
+
+
+@dataclass
+class Database:
+    dsn: str
+    schema: str
+    conn: psycopg.Connection
+
+    @property
+    def models(self):
+        return sql.Identifier(self.schema, "LiteLLM_ProxyModelTable")
+
+    @property
+    def teams(self):
+        return sql.Identifier(self.schema, "LiteLLM_TeamTable")
+
+    def seed(self, model_id="001", raw='{"team_id":"team-a"}', team_id=None, name="public-model"):
+        self.conn.execute(
+            sql.SQL(
+                'INSERT INTO {} ("model_id", "model_name", "model_info", "team_id") VALUES (%s,%s,%s::jsonb,%s)'
+            ).format(self.models),
+            (model_id, name, raw, team_id),
+        )
+
+    def rows(self):
+        return self.conn.execute(
+            sql.SQL('SELECT "model_id", "team_id", to_jsonb(m) - \'team_id\' FROM {} m ORDER BY "model_id"').format(
+                self.models
+            )
+        ).fetchall()
+
+    def cli(self, *args, dsn=None):
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), "--schema", self.schema, *args],
+            env={**os.environ, "DATABASE_URL": dsn or self.dsn},
+            text=True,
+            capture_output=True,
+            timeout=20,
+        )
+        assert result.stderr == "", result.stderr
+        return result.returncode, tuple(json.loads(line) for line in result.stdout.splitlines())
+
+
+@pytest.fixture
+def db():
+    schema = "team_identity_" + uuid.uuid4().hex
+    dsn, _ = backfill.connection_parameters(os.environ["DATABASE_URL"], None)
+    with psycopg.connect(dsn, autocommit=True) as conn:
+        conn.execute(sql.SQL("CREATE SCHEMA {}").format(sql.Identifier(schema)))
+        conn.execute(sql.SQL("SET search_path TO {}").format(sql.Identifier(schema)))
+        conn.execute('CREATE TABLE "LiteLLM_TeamTable" ("team_id" TEXT PRIMARY KEY)')
+        conn.execute(
+            'CREATE TABLE "LiteLLM_ProxyModelTable" ("model_id" TEXT PRIMARY KEY, "model_name" TEXT NOT NULL, '
+            '"model_info" JSONB, "litellm_params" JSONB NOT NULL DEFAULT \'{"api_key":"opaque-credential-sentinel"}\', '
+            "\"updated_at\" TIMESTAMP NOT NULL DEFAULT '2020-01-01', \"created_at\" TIMESTAMP NOT NULL DEFAULT '2020-01-01', "
+            '"created_by" TEXT NOT NULL DEFAULT \'operator\', "blocked" BOOLEAN NOT NULL DEFAULT false)'
+        )
+        conn.execute('ALTER TABLE "LiteLLM_ProxyModelTable" ADD COLUMN "updated_by" TEXT NOT NULL DEFAULT \'operator\'')
+        for name in MIGRATION_NAMES:
+            conn.execute((MIGRATIONS / name / "migration.sql").read_text())
+        conn.execute("INSERT INTO \"LiteLLM_TeamTable\" VALUES ('team-a'), ('team-b')")
+        try:
+            yield Database(dsn, schema, conn)
+        finally:
+            conn.execute(sql.SQL("DROP SCHEMA {} CASCADE").format(sql.Identifier(schema)))
+
+
+def test_default_dry_run_shows_exact_model_changes_and_writes_nothing(db):
+    db.seed()
+    before = db.rows()
+    code, events = db.cli()
+    assert code == 0
+    assert db.rows() == before
+    row = next(event for event in events if event["event"] == "model")
+    assert row == {
+        "event": "model",
+        "model_id": "001",
+        "model_name": "public-model",
+        "status": "pending",
+        "from_team_id": None,
+        "to_team_id": "team-a",
+        "action": "set_team_id",
+    }
+    assert events[-1]["pending"] == 1
+    assert events[-1]["updated"] == 0
+    assert "opaque-credential-sentinel" not in json.dumps(events)
+
+
+def test_execute_is_idempotent_and_preserves_every_other_column(db):
+    db.seed()
+    db.seed("002", raw=None, name="global")
+    before = db.rows()
+    code, events = db.cli("--execute")
+    assert code == 0
+    assert [r[1] for r in db.rows()] == ["team-a", None]
+    assert [r[2] for r in db.rows()] == [r[2] for r in before]
+    assert events[-1]["updated"] == 1
+    first = db.rows()
+    code, events = db.cli("--execute")
+    assert code == 0
+    assert events[-1]["updated"] == 0
+    assert db.rows() == first
+    assert db.cli()[1][-1]["pending"] == 0
+
+
+@pytest.mark.parametrize("raw", [None, "null", "{}", '{"team_id":null}'])
+def test_global_models_never_acquire_a_team_from_their_names(db, raw):
+    db.seed(raw=raw, name="model_name_team-a_fake-uuid")
+    before = db.rows()
+    assert db.cli("--execute")[0] == 0
+    assert db.rows() == before
+
+
+@pytest.mark.parametrize(
+    "raw,existing,status",
+    [
+        ('{"team_id":"does-not-exist"}', None, "missing_team"),
+        ('{"team_id":"does-not-exist"}', "does-not-exist", "missing_team"),
+        ('{"team_id":123}', None, "invalid_team_id"),
+        ('{"team_id":""}', None, "invalid_team_id"),
+        ('{"team_public_model_name":"public"}', None, "invalid_team_id"),
+        ("[]", None, "invalid_metadata"),
+        ('"not-json"', None, "invalid_metadata"),
+        ('{"team_id":"team-a"}', "team-b", "conflict"),
+        ("{}", "team-a", "conflict"),
+        (None, "team-a", "conflict"),
+    ],
+)
+def test_ambiguous_rows_are_skipped_valid_rows_commit_and_exit_is_nonzero(db, raw, existing, status):
+    db.seed("001", raw, existing)
+    db.seed("002")
+    before = db.rows()[0]
+    code, events = db.cli("--execute")
+    assert code == 2
+    assert db.rows()[0] == before
+    assert db.rows()[1][1] == "team-a"
+    first = next(event for event in events if event.get("model_id") == "001")
+    assert first["status"] == status
+    assert first["action"] == "none"
+    assert events[-1]["issues"] == 1
+    assert db.cli()[0] == 2
+
+
+def test_legacy_double_encoded_metadata_and_json_column_are_supported(db):
+    db.conn.execute(
+        sql.SQL('ALTER TABLE {} ALTER COLUMN "model_info" TYPE JSON USING "model_info"::json').format(db.models)
+    )
+    db.seed(raw=json.dumps(json.dumps({"team_id": "team-a", "unrelated": "retained"})))
+    before = db.rows()[0][2]
+    assert db.cli("--execute")[0] == 0
+    assert db.rows()[0][1] == "team-a"
+    assert db.rows()[0][2] == before
+
+
+def test_unicode_quotes_whitespace_and_sql_like_identifiers_are_literal(db):
+    owner = " 团队'; DROP TABLE anything; -- "
+    db.conn.execute(sql.SQL("INSERT INTO {} VALUES (%s)").format(db.teams), (owner,))
+    db.seed(model_id="id'\n\"", name='model\n"name', raw=json.dumps({"team_id": owner}))
+    code, events = db.cli("--execute")
+    assert code == 0
+    assert db.rows()[0][1] == owner
+    assert any(event.get("to_team_id") == owner for event in events)
+
+
+@pytest.mark.parametrize("size", [1, 2, 3, 100])
+def test_batches_visit_each_row_once_and_preserve_duplicate_public_names(db, size):
+    for i in range(7):
+        db.seed(f"{i:03}", raw=json.dumps({"team_id": "team-a" if i % 2 else "team-b"}))
+    code, events = db.cli("--execute", "--batch-size", str(size))
+    assert code == 0
+    assert events[-1]["scanned"] == events[-1]["updated"] == 7
+    assert events[-1]["batches"] == (7 + size - 1) // size
+    assert len({event["model_id"] for event in events if event["event"] == "model"}) == 7
+
+
+def test_bounded_run_can_resume_and_full_rerun_finds_new_earlier_ids(db):
+    for i in range(4):
+        db.seed(f"{i:03}")
+    code, events = db.cli("--execute", "--batch-size", "2", "--max-batches", "1")
+    assert code == 3
+    assert events[-1]["scan_finished"] is False
+    assert events[-1]["cursor"] == "001"
+    db.seed("000-new")
+    code, events = db.cli("--execute", "--after-model-id", "001")
+    assert code == 0
+    assert events[-1]["resumed"] is True
+    assert events[-1]["updated"] == 2
+    assert db.cli()[1][-1]["pending"] == 1
+    assert db.cli("--execute")[1][-1]["updated"] == 1
+    assert db.cli()[1][-1]["pending"] == 0
+
+
+def test_empty_database_and_resume_past_end_are_noops(db):
+    assert db.cli("--execute")[1][-1]["scanned"] == 0
+    db.seed()
+    code, events = db.cli("--execute", "--after-model-id", "zzz")
+    assert code == 0
+    assert events[-1]["scanned"] == 0
+    assert db.rows()[0][1] is None
+
+
+@pytest.mark.parametrize("change", ["metadata", "column", "delete", "team_delete"])
+def test_concurrent_changes_are_not_overwritten(db, change):
+    db.seed()
+    with psycopg.connect(db.dsn, autocommit=True) as worker:
+        rows = backfill.read_batch(worker, db.models, None, "zzz", 10)
+        decisions = tuple(backfill.classify(row) for row in rows)
+        if change == "metadata":
+            db.conn.execute(
+                sql.SQL('UPDATE {} SET "model_info"=%s::jsonb').format(db.models), ('{"team_id":"team-b"}',)
+            )
+        elif change == "column":
+            db.conn.execute(sql.SQL("UPDATE {} SET \"team_id\"='team-b'").format(db.models))
+        elif change == "delete":
+            db.conn.execute(sql.SQL("DELETE FROM {}").format(db.models))
+        else:
+            db.conn.execute(sql.SQL("DELETE FROM {} WHERE \"team_id\"='team-a'").format(db.teams))
+        before = db.rows()
+        with worker.transaction():
+            updated = backfill.execute_batch(worker, db.models, db.teams, decisions)
+        assert updated == frozenset()
+        assert db.rows() == before
+
+
+def test_concurrent_rename_is_preserved(db):
+    db.seed()
+    rows = backfill.read_batch(db.conn, db.models, None, "zzz", 10)
+    db.conn.execute(sql.SQL("UPDATE {} SET \"model_name\"='renamed'").format(db.models))
+    assert backfill.execute_batch(
+        db.conn, db.models, db.teams, tuple(backfill.classify(row) for row in rows)
+    ) == frozenset({"001"})
+    assert db.rows()[0][2]["model_name"] == "renamed"
+
+
+def test_overlapping_workers_cannot_double_update(db):
+    db.seed()
+    with psycopg.connect(db.dsn, autocommit=True) as second:
+        rows = backfill.read_batch(second, db.models, None, "zzz", 10)
+        decisions = tuple(backfill.classify(row) for row in rows)
+        assert db.cli("--execute")[0] == 0
+        assert backfill.execute_batch(second, db.models, db.teams, decisions) == frozenset()
+    assert db.cli("--execute")[1][-1]["updated"] == 0
+
+
+def test_old_writer_ownership_change_is_reported_until_reconciled(db):
+    db.seed()
+    assert db.cli("--execute")[0] == 0
+    db.conn.execute(sql.SQL('UPDATE {} SET "model_info"=%s::jsonb').format(db.models), ('{"team_id":"team-b"}',))
+    assert db.cli("--execute")[0] == 2
+    assert db.rows()[0][1] == "team-a"
+
+
+def test_read_only_connections_can_preview_but_cannot_execute(db):
+    db.seed()
+    dsn = make_conninfo(db.dsn, options="-c default_transaction_read_only=on")
+    assert db.cli(dsn=dsn)[0] == 0
+    code, events = db.cli("--execute", dsn=dsn)
+    assert code == 1
+    assert events[-1]["reason"] == "execute_requires_writable_primary"
+    assert db.rows()[0][1] is None
+
+
+@pytest.mark.skipif(
+    not os.environ.get("BACKFILL_TEST_REPLICA_URL"), reason="requires a physical standby of DATABASE_URL"
+)
+def test_physical_replica_can_preview_and_rejects_execution(db):
+    db.seed()
+    lsn = db.conn.execute("SELECT pg_current_wal_insert_lsn()::text").fetchone()[0]
+    replica_dsn = os.environ["BACKFILL_TEST_REPLICA_URL"]
+    with psycopg.connect(replica_dsn, autocommit=True) as replica:
+        assert replica.execute("SELECT pg_is_in_recovery()").fetchone() == (True,)
+        deadline = time.monotonic() + 10
+        while not replica.execute("SELECT pg_last_wal_replay_lsn() >= %s::pg_lsn", (lsn,)).fetchone()[0]:
+            assert time.monotonic() < deadline, "replica failed to catch up"
+            time.sleep(0.02)
+    code, events = db.cli(dsn=replica_dsn)
+    assert code == 0
+    assert events[0]["replica"] is True
+    assert events[-1]["pending"] == 1
+    code, events = db.cli("--execute", dsn=replica_dsn)
+    assert code == 1
+    assert events[-1]["reason"] == "execute_requires_writable_primary"
+    assert db.rows()[0][1] is None
+
+
+def test_duplicate_keys_in_legacy_json_are_reported_not_guessed(db):
+    db.seed(raw=json.dumps('{"team_id":"team-a","team_id":"team-b"}'))
+    code, events = db.cli("--execute")
+    assert code == 2
+    assert events[1]["status"] == "invalid_metadata"
+    assert db.rows()[0][1] is None
+
+
+@pytest.mark.parametrize("raw", ['{"team_id":"bad\\ud800id"}', '{"team_id":"bad\\u0000id"}'])
+def test_unencodable_json_owner_is_skipped_while_valid_rows_commit(db, raw):
+    db.conn.execute(
+        sql.SQL('ALTER TABLE {} ALTER COLUMN "model_info" TYPE JSON USING "model_info"::json').format(db.models)
+    )
+    db.conn.execute(
+        sql.SQL('INSERT INTO {} ("model_id", "model_name", "model_info") VALUES (\'001\', \'bad\', %s::json)').format(
+            db.models
+        ),
+        (raw,),
+    )
+    db.seed("002")
+    code, events = db.cli("--execute")
+    assert code == 2
+    assert events[1]["status"] == "invalid_team_id"
+    assert db.conn.execute(sql.SQL('SELECT "team_id" FROM {} ORDER BY "model_id"').format(db.models)).fetchall() == [
+        (None,),
+        ("team-a",),
+    ]
+
+
+def test_large_scan_has_bounded_commits_and_no_missed_rows(db):
+    db.conn.execute(
+        sql.SQL(
+            'INSERT INTO {} ("model_id", "model_name", "model_info") '
+            "SELECT lpad(n::text, 6, '0'), 'shared-name', jsonb_build_object('team_id', 'team-a') "
+            "FROM generate_series(1, 10001) n"
+        ).format(db.models)
+    )
+    code, events = db.cli("--execute", "--batch-size", "10000")
+    assert code == 0
+    assert events[-1]["updated"] == events[-1]["scanned"] == 10001
+    assert events[-1]["batches"] == 2
+    assert all(row[1] == "team-a" for row in db.rows())
+
+
+def test_schema_name_is_quoted(db):
+    renamed = db.schema + ' "; SQL --'
+    db.conn.execute(sql.SQL("ALTER SCHEMA {} RENAME TO {}").format(sql.Identifier(db.schema), sql.Identifier(renamed)))
+    try:
+        alternate = Database(db.dsn, renamed, db.conn)
+        alternate.seed()
+        assert alternate.cli("--execute")[0] == 0
+        assert alternate.rows()[0][1] == "team-a"
+    finally:
+        db.conn.execute(
+            sql.SQL("ALTER SCHEMA {} RENAME TO {}").format(sql.Identifier(renamed), sql.Identifier(db.schema))
+        )
+
+
+@pytest.mark.parametrize(
+    "args", [("--execute", "--dry-run"), ("--batch-size", "0"), ("--max-batches", "0"), ("--lock-timeout-ms", "0")]
+)
+def test_invalid_cli_arguments_never_write(db, args):
+    db.seed()
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        env={**os.environ, "DATABASE_URL": db.dsn},
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 2
+    assert db.rows()[0][1] is None
+
+
+def test_actual_dry_run_transaction_is_read_only(db):
+    db.seed()
+    with psycopg.connect(db.dsn, autocommit=True) as worker:
+        assert backfill.run(worker, backfill.Options(schema=db.schema), lambda event: None) == 0
+        with pytest.raises(psycopg.errors.ReadOnlySqlTransaction):
+            worker.execute(sql.SQL("UPDATE {} SET \"team_id\"='team-a'").format(db.models))
+
+
+@pytest.mark.parametrize("change", ["missing_column", "wrong_type", "nonunique_id", "missing_team_table", "view"])
+def test_incompatible_schemas_fail_without_changing_model_data(db, change):
+    db.seed()
+    if change == "missing_column":
+        db.conn.execute(sql.SQL('ALTER TABLE {} DROP COLUMN "team_id"').format(db.models))
+    elif change == "wrong_type":
+        db.conn.execute(sql.SQL('ALTER TABLE {} ALTER COLUMN "team_id" TYPE INTEGER USING NULL').format(db.models))
+    elif change == "nonunique_id":
+        db.conn.execute(sql.SQL('ALTER TABLE {} DROP CONSTRAINT "LiteLLM_ProxyModelTable_pkey"').format(db.models))
+    elif change == "missing_team_table":
+        db.conn.execute(sql.SQL("DROP TABLE {}").format(db.teams))
+    else:
+        db.conn.execute(sql.SQL('ALTER TABLE {} RENAME TO "source_models"').format(db.models))
+        db.conn.execute(
+            sql.SQL("CREATE VIEW {} AS SELECT * FROM {}").format(db.models, sql.Identifier(db.schema, "source_models"))
+        )
+    before = db.conn.execute(sql.SQL("SELECT to_jsonb(m) FROM {} m").format(db.models)).fetchall()
+    assert db.cli("--execute")[0] == 1
+    assert db.conn.execute(sql.SQL("SELECT to_jsonb(m) FROM {} m").format(db.models)).fetchall() == before
+
+
+def test_lock_timeout_rolls_back_entire_batch_and_rerun_succeeds(db):
+    db.seed("001")
+    db.seed("002")
+    with psycopg.connect(db.dsn) as blocker:
+        blocker.execute(sql.SQL('UPDATE {} SET "model_name"="model_name" WHERE "model_id"=\'002\'').format(db.models))
+        code, events = db.cli("--execute", "--lock-timeout-ms", "25")
+        assert code == 1
+        assert events[-1]["sqlstate"] == "55P03"
+        assert all(row[1] is None for row in db.rows())
+        blocker.rollback()
+    assert db.cli("--execute")[1][-1]["updated"] == 2
+
+
+def test_interruption_keeps_committed_batches_and_rolls_back_current_batch(db):
+    db.seed("001")
+    db.seed("002")
+    with psycopg.connect(db.dsn) as blocker:
+        blocker.execute(sql.SQL('UPDATE {} SET "model_name"="model_name" WHERE "model_id"=\'002\'').format(db.models))
+        process = subprocess.Popen(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--schema",
+                db.schema,
+                "--execute",
+                "--batch-size",
+                "1",
+                "--lock-timeout-ms",
+                "10000",
+            ],
+            env={**os.environ, "DATABASE_URL": db.dsn},
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        try:
+            assert process.stdout is not None
+            for line in process.stdout:
+                if json.loads(line)["event"] == "progress":
+                    process.send_signal(signal.SIGINT)
+                    break
+            stdout, stderr = process.communicate(timeout=10)
+            assert process.returncode == 130
+            assert stderr == ""
+            assert "interrupted_rerun_safely" in stdout
+            assert [row[1] for row in db.rows()] == ["team-a", None]
+        finally:
+            if process.poll() is None:
+                process.kill()
+                process.communicate()
+            blocker.rollback()
+    assert db.cli("--execute")[1][-1]["updated"] == 1
+
+
+@pytest.mark.parametrize(
+    "body,timeout,sqlstate",
+    [
+        ("PERFORM pg_sleep(0.1); RETURN NEW;", "10", "57014"),
+        ("RAISE EXCEPTION 'SECRET-provider-credential';", "30000", "P0001"),
+    ],
+)
+def test_statement_failure_is_atomic_and_server_details_are_redacted(db, body, timeout, sqlstate):
+    db.seed()
+    db.conn.execute(
+        sql.SQL("CREATE FUNCTION {}() RETURNS trigger LANGUAGE plpgsql AS {}").format(
+            sql.Identifier(db.schema, "test_before_update"), sql.Literal("BEGIN " + body + " END")
+        )
+    )
+    db.conn.execute(
+        sql.SQL("CREATE TRIGGER failure BEFORE UPDATE ON {} FOR EACH ROW EXECUTE FUNCTION {}()").format(
+            db.models, sql.Identifier(db.schema, "test_before_update")
+        )
+    )
+    code, events = db.cli("--execute", "--statement-timeout-ms", timeout)
+    assert code == 1
+    assert events[-1]["sqlstate"] == sqlstate
+    assert "SECRET-provider-credential" not in json.dumps(events)
+    assert db.rows()[0][1] is None
+
+
+def test_schema_migrations_do_not_backfill_or_modify_existing_data(db):
+    db.seed()
+    before = db.rows()
+    db.conn.execute(sql.SQL('ALTER TABLE {} DROP COLUMN "team_id"').format(db.models))
+    for name in MIGRATION_NAMES:
+        db.conn.execute((MIGRATIONS / name / "migration.sql").read_text())
+    assert db.rows() == before
+    valid = db.conn.execute(
+        "SELECT indisvalid FROM pg_index WHERE indexrelid=to_regclass(%s)",
+        (sql.Identifier(db.schema, "LiteLLM_ProxyModelTable_team_id_idx").as_string(db.conn),),
+    ).fetchone()
+    assert valid == (True,)
+
+
+def test_no_update_permission_and_rls_cannot_silently_hide_rows(db):
+    db.seed()
+    role = "team_identity_role_" + uuid.uuid4().hex
+    db.conn.execute(sql.SQL("CREATE ROLE {}").format(sql.Identifier(role)))
+    try:
+        db.conn.execute(
+            sql.SQL("GRANT USAGE ON SCHEMA {} TO {}").format(sql.Identifier(db.schema), sql.Identifier(role))
+        )
+        db.conn.execute(
+            sql.SQL("GRANT SELECT ON ALL TABLES IN SCHEMA {} TO {}").format(
+                sql.Identifier(db.schema), sql.Identifier(role)
+            )
+        )
+        dsn = make_conninfo(db.dsn, options=f"-c role={role}")
+        assert db.cli(dsn=dsn)[0] == 0
+        assert db.cli("--execute", dsn=dsn)[0] == 1
+        assert db.rows()[0][1] is None
+        db.conn.execute(sql.SQL('GRANT UPDATE ("team_id") ON {} TO {}').format(db.models, sql.Identifier(role)))
+        assert db.cli("--execute", dsn=dsn)[0] == 0
+        assert db.rows()[0][1] == "team-a"
+        db.conn.execute(sql.SQL("ALTER TABLE {} ENABLE ROW LEVEL SECURITY").format(db.models))
+        assert db.cli(dsn=dsn)[0] == 1
+    finally:
+        db.conn.execute(sql.SQL("DROP OWNED BY {}").format(sql.Identifier(role)))
+        db.conn.execute(sql.SQL("DROP ROLE {}").format(sql.Identifier(role)))
+
+
+@pytest.mark.asyncio
+async def test_actual_prisma_writes_keep_both_owners_in_sync(db):
+    from prisma import Json, Prisma
+
+    from litellm.repositories.model_repository import _TeamIdentityActions
+
+    client = Prisma(datasource={"url": db.dsn + "?schema=" + db.schema})
+    await client.connect()
+    try:
+        table = _TeamIdentityActions(client.litellm_proxymodeltable)
+        data = {
+            "model_id": "001",
+            "model_name": "shared",
+            "model_info": '{"team_id":"team-a"}',
+            "litellm_params": "{}",
+            "created_by": "operator",
+            "updated_by": "operator",
+        }
+        row = await table.create(data)
+        assert row.team_id == "team-a"
+        assert row.model_info["team_id"] == "team-a"
+        await table.update({"model_info": '{"team_id":"team-b"}'}, {"model_id": "001"})
+        assert db.rows()[0][1] == "team-b"
+        await table.update({"blocked": True}, {"model_id": "001"})
+        assert db.rows()[0][1] == "team-b"
+        assert (
+            await table.create_many(({**data, "model_id": "002"}, {**data, "model_id": "003"}), skip_duplicates=True)
+            == 2
+        )
+        assert (
+            await table.update_many({"model_info": '{"team_id":"team-b"}'}, {"model_id": {"in": ["002", "003"]}}) == 2
+        )
+        assert all(row[1] == "team-b" for row in db.rows())
+        await table.upsert({"model_id": "001"}, {"create": data, "update": {"model_info": "{}"}})
+        assert db.rows()[0][1] is None
+        await table.upsert({"model_id": "004"}, {"create": {**data, "model_id": "004"}, "update": {"blocked": True}})
+        assert db.rows()[-1][1] == "team-a"
+        await table.update({"model_info": Json({"team_id": "team-b"})}, {"model_id": "004"})
+        assert db.rows()[-1][1] == "team-b"
+        assert db.cli()[1][-1]["pending"] == 0
+    finally:
+        await client.disconnect()

--- a/tests/test_litellm/repositories/test_repositories.py
+++ b/tests/test_litellm/repositories/test_repositories.py
@@ -307,14 +307,13 @@ class TestModelRepository:
         client = MockPrismaClient()
         return ModelRepository(client)
 
-    def test_table_is_wrapped_for_config_sync(self, repo):
-        from litellm.proxy.common_utils.config_sync_pubsub import (
-            _PublishOnWriteActions,
-        )
-
-        table = repo.table
-        assert isinstance(table, _PublishOnWriteActions)
-        assert table._actions is repo.prisma_client.db.litellm_proxymodeltable
+    @pytest.mark.asyncio
+    async def test_table_dual_writes_model_ownership_and_preserves_reads(self, repo):
+        metadata = json.dumps({"team_id": "team-a", "team_public_model_name": "public"})
+        await repo.table.create(data={"model_id": "identity-test", "model_info": metadata})
+        row = await repo.table.find_unique(where={"model_id": "identity-test"})
+        assert row.team_id == "team-a"
+        assert row.model_info == metadata
 
     @pytest.mark.asyncio
     @patch(
@@ -2387,3 +2386,107 @@ class TestCountBillableUsers:
         client.db.litellm_usertable = _RacyTable()
         repo = UserRepository(client)
         assert await repo.count_billable_users() == 0
+
+
+class RecordingModelWrites:
+    def __init__(self):
+        self.calls = []
+
+    async def create(self, data, include=None):
+        self.calls.append(("create", data, include))
+        return MockRecord(data)
+
+    async def update(self, data, where, include=None):
+        self.calls.append(("update", data, include))
+        return MockRecord(data)
+
+    async def create_many(self, data, skip_duplicates=None):
+        self.calls.append(("create_many", data, skip_duplicates))
+        return len(data)
+
+    async def update_many(self, data, where):
+        self.calls.append(("update_many", data, where))
+        return 2
+
+    async def upsert(self, where, data, include=None):
+        self.calls.append(("upsert", data, include))
+        return MockRecord(data["create"])
+
+
+class TestModelIdentityWrites:
+    @pytest.mark.parametrize("metadata", [{"team_id": "team-a"}, '{"team_id":"team-a"}'])
+    @pytest.mark.parametrize("action", ["create", "update", "update_many", "create_many", "upsert"])
+    @pytest.mark.asyncio
+    async def test_every_metadata_write_sets_the_column_in_the_same_operation(self, metadata, action):
+        from litellm.repositories.model_repository import _TeamIdentityActions
+
+        raw = RecordingModelWrites()
+        table = _TeamIdentityActions(raw)
+        original = {
+            "model_id": "id",
+            "model_info": metadata,
+            "team_id": "untrusted-stale-value",
+            "model_name": "unchanged",
+        }
+        if action == "create":
+            await table.create(original, include={"example": True})
+        elif action == "update":
+            await table.update(original, {"model_id": "id"}, include={"example": True})
+        elif action == "update_many":
+            await table.update_many(original, {"model_id": "id"})
+        elif action == "create_many":
+            assert await table.create_many((original, original), skip_duplicates=True) == 2
+        else:
+            await table.upsert({"model_id": "id"}, {"create": original, "update": original}, include={"example": True})
+        assert len(raw.calls) == 1
+        payload = raw.calls[0][1]
+        rows = (
+            payload
+            if action == "create_many"
+            else (payload["create"], payload["update"])
+            if action == "upsert"
+            else (payload,)
+        )
+        for row in rows:
+            assert row == {**original, "team_id": "team-a"}
+            assert row["model_info"] == metadata
+        assert original["team_id"] == "untrusted-stale-value"
+        if action in {"create", "update", "upsert"}:
+            assert raw.calls[0][2] == {"example": True}
+
+    @pytest.mark.parametrize("metadata", [None, "null", {}, "{}", {"team_id": None}])
+    def test_clearing_metadata_clears_ownership_without_changing_metadata(self, metadata):
+        from litellm.repositories.model_repository import _with_team_identity
+
+        data = {"model_info": metadata, "team_id": "old"}
+        assert _with_team_identity(data) == {"model_info": metadata, "team_id": None}
+        assert data["team_id"] == "old"
+
+    def test_unrelated_patch_does_not_clear_ownership(self):
+        from litellm.repositories.model_repository import _with_team_identity
+
+        assert _with_team_identity({"blocked": True}) == {"blocked": True}
+
+    @pytest.mark.parametrize("metadata", ["{", "[]", [], {"team_id": 123}, {"team_id": True}])
+    @pytest.mark.asyncio
+    async def test_invalid_ownership_does_not_reach_database(self, metadata):
+        from pydantic import ValidationError
+        from litellm.repositories.model_repository import _TeamIdentityActions
+
+        raw = RecordingModelWrites()
+        with pytest.raises(ValidationError):
+            await _TeamIdentityActions(raw).create({"model_info": metadata})
+        assert raw.calls == []
+
+    def test_reads_still_use_metadata_before_and_after_backfill(self):
+        from litellm.models.model import LiteLLM_ProxyModelTable
+
+        for stored_team in (None, "team-a", "stale-other-team"):
+            row = LiteLLM_ProxyModelTable(
+                model_id="id",
+                model_name="name",
+                litellm_params={},
+                model_info={"team_id": "team-a"},
+                team_id=stored_team,
+            )
+            assert row.team_id == "team-a"

--- a/tests/test_litellm/test_backfill_team_model_identity.py
+++ b/tests/test_litellm/test_backfill_team_model_identity.py
@@ -1,0 +1,171 @@
+import argparse
+import json
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from scripts.backfill_team_model_identity import (
+    Snapshot,
+    batch_size,
+    classify,
+    connection_parameters,
+    positive_int,
+    report_batch,
+)
+
+
+@pytest.mark.parametrize("raw", [None, "null", "{}", '{"team_id": null}', '"{}"', '"null"'])
+def test_global_models_are_unchanged(raw):
+    decision = classify(Snapshot("global-id", "model_name_not_an_owner", raw, None))
+    assert decision.status == "global"
+    assert decision.proposed_team_id is None
+
+
+@pytest.mark.parametrize("raw", ["{", "[]", "1", "true", '"not json"', '"[]"', '"123"', '"\\"{}\\""'])
+def test_malformed_metadata_is_reported_without_guessing(raw):
+    assert classify(Snapshot("id", "model_name_team-a_uuid", raw, None)).status == "invalid_metadata"
+
+
+@pytest.mark.parametrize(
+    "owner", ["", " ", "\t\n", 0, 1, True, False, [], {}, ["team"], "bad\x00id", "high\ud800id", "low\udfffid"]
+)
+def test_invalid_ownership_is_not_coerced(owner):
+    row = Snapshot("id", "public", json.dumps({"team_id": owner}), None)
+    assert classify(row).status == "invalid_team_id"
+
+
+@pytest.mark.parametrize("owner", ["a", "team with spaces", " 团队 ", "a'b\"c\\d", "a\n\tb", "x" * 10000])
+@pytest.mark.parametrize("encoded", [False, True])
+def test_ownership_is_preserved_exactly_including_legacy_json_strings(owner, encoded):
+    raw = json.dumps({"team_id": owner, "other": {"nested": "unchanged"}})
+    row = Snapshot("id", "name", json.dumps(raw) if encoded else raw, None)
+    assert classify(row).status == "pending"
+    assert classify(row).proposed_team_id == owner
+    assert classify(Snapshot("id", "name", row.raw_info, owner)).status == "already_set"
+
+
+@pytest.mark.parametrize("raw", [None, "null", "{}", '{"team_id":null}', '{"team_id":"different"}'])
+def test_existing_conflicting_column_is_never_overwritten(raw):
+    decision = classify(Snapshot("id", "model", raw, "existing"))
+    assert decision.status == "conflict"
+    events = []
+    assert report_batch((decision,), frozenset(), True, events.append) == 1
+    assert events[0]["action"] == "none"
+
+
+@pytest.mark.parametrize("public_name", [None, "public", ""])
+def test_team_marker_without_owner_is_ambiguous(public_name):
+    assert (
+        classify(Snapshot("id", "model", json.dumps({"team_public_model_name": public_name}), None)).status
+        == "invalid_team_id"
+    )
+
+
+@given(st.text(min_size=1).filter(lambda text: bool(text.strip()) and "\x00" not in text))
+@settings(max_examples=300)
+def test_classification_is_idempotent_and_does_not_normalize_owner(owner):
+    row = Snapshot("id", "name", json.dumps({"team_id": owner}), None)
+    pending = classify(row)
+    assert pending.status == "pending"
+    assert pending.proposed_team_id == owner
+    applied = classify(Snapshot(row.model_id, row.model_name, row.raw_info, pending.proposed_team_id))
+    assert applied.status == "already_set"
+    assert applied.row.raw_info == row.raw_info
+
+
+@given(
+    st.recursive(
+        st.none() | st.booleans() | st.integers() | st.text(),
+        lambda children: st.lists(children) | st.dictionaries(st.text(), children),
+        max_leaves=30,
+    )
+)
+@settings(max_examples=300)
+def test_arbitrary_json_never_creates_ownership_from_an_unrelated_field(payload):
+    decision = classify(Snapshot("id", "model_name_team-hidden_uuid", json.dumps({"unrelated": payload}), None))
+    assert decision.status == "global"
+
+
+def test_deeply_nested_unreadable_metadata_is_a_row_error():
+    decision = classify(Snapshot("id", "name", "[" * 10000 + "0" + "]" * 10000, None))
+    assert decision.status == "invalid_metadata"
+
+
+@pytest.mark.parametrize("encoded", [False, True])
+def test_duplicate_ownership_keys_are_ambiguous(encoded):
+    raw = '{"team_id":"team-a", "team_id":"team-b"}'
+    assert classify(Snapshot("id", "name", json.dumps(raw) if encoded else raw, None)).status == "invalid_metadata"
+
+
+def test_preview_contains_exact_transformation_without_provider_data():
+    row = Snapshot("id\n1", 'public"name', json.dumps({"team_id": "team-a", "api_key": "NEVER-PRINT"}), None)
+    events = []
+    assert report_batch((classify(row),), frozenset(), False, events.append) == 0
+    assert events == [
+        {
+            "event": "model",
+            "model_id": "id\n1",
+            "model_name": 'public"name',
+            "status": "pending",
+            "from_team_id": None,
+            "to_team_id": "team-a",
+            "action": "set_team_id",
+        }
+    ]
+    assert "NEVER-PRINT" not in json.dumps(events)
+
+
+def test_only_returned_updates_are_reported_as_committed():
+    rows = tuple(classify(Snapshot(str(n), "name", '{"team_id":"a"}', None)) for n in range(2))
+    events = []
+    assert report_batch(rows, frozenset({"0"}), True, events.append) == 1
+    assert [event["status"] for event in events] == ["updated", "concurrent_change"]
+    assert [event["action"] for event in events] == ["set_team_id", "none"]
+
+
+def test_prisma_url_parameters_are_removed_without_losing_tls_or_credentials():
+    dsn, schema = connection_parameters(
+        "postgresql://u:p%40ss@db:5432/app?schema=team%20models&sslmode=verify-full&sslrootcert=%2Fcerts%2Fca.pem&connection_limit=5&pool_timeout=10&pgbouncer=true",
+        None,
+    )
+    assert schema == "team models"
+    assert dsn == "postgresql://u:p%40ss@db:5432/app?sslmode=verify-full&sslrootcert=%2Fcerts%2Fca.pem"
+
+
+@pytest.mark.parametrize(
+    "dsn, schema",
+    [
+        ("postgresql://db/app?schema=a&schema=b", None),
+        ("postgresql://db/app?schema=", None),
+        ("postgresql://db/app?schema=a", "b"),
+    ],
+)
+def test_conflicting_schema_configuration_fails(dsn, schema):
+    with pytest.raises(ValueError, match="Conflicting or empty schema settings"):
+        connection_parameters(dsn, schema)
+
+
+@pytest.mark.parametrize(
+    "dsn", ["host=/tmp dbname=app", "postgresql://db/app", "postgresql://db1,db2/app?target_session_attrs=read-write"]
+)
+def test_non_prisma_connection_settings_are_preserved(dsn):
+    assert connection_parameters(dsn, "custom") == (dsn, "custom")
+
+
+@pytest.mark.parametrize("value", ["0", "-1", "2147483648"])
+def test_timeouts_cannot_be_disabled_or_overflow_postgres(value):
+    with pytest.raises(argparse.ArgumentTypeError):
+        positive_int(value)
+
+
+@pytest.mark.parametrize("value", ["0", "-1", "10001"])
+def test_batches_are_bounded(value):
+    with pytest.raises(argparse.ArgumentTypeError):
+        batch_size(value)
+
+
+def test_boundary_option_values_are_accepted():
+    assert batch_size("1") == 1
+    assert batch_size("10000") == 10000
+    assert positive_int("2147483647") == 2147483647


### PR DESCRIPTION
## TLDR

Problem this solves:

- Team ownership exists only inside model metadata
- Existing models need an operator-controlled backfill

How it solves it:

- Add nullable, indexed ownership with schema-only migrations
- Populate both ownership fields atomically on model writes
- Provide default previews and explicit, conflict-aware execution

## User Flow

Before: operators have no supported command to preview this backfill

1. Deploy the proxy release
2. Run `python scripts/backfill_team_model_identity.py`
3. The command is unavailable

After: operators can preview each model change before executing it

1. Deploy the proxy release
2. Run `python scripts/backfill_team_model_identity.py`
3. See each model's current ownership, proposed ownership, and action
4. Run the same command with `--execute` to apply eligible changes
5. Rerun to verify completion; inspect skipped rows before proceeding

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The focused test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is isolated to team identity groundwork
- [ ] Current-head Greptile confidence is 5/5 before requesting maintainer review

Validation: 542 focused tests passed, including repository, model-management, and config-sync regressions. The final PostgreSQL suite passed 55 tests. The standalone script passed 122 tests on each Python version from 3.10 through 3.14, including a real physical standby. All 18 targeted behavioral mutations were detected. The complete Prisma migration chain applied and matched the schema. `make check` passed

## Screenshots / Proof of Fix

Used PostgreSQL 15.17 with synthetic records in an isolated schema: one global model and one team model belonging to `example-team`. The schema migrations were applied separately from the backfill. `DATABASE_URL` pointed to the local database. No LLM inference is involved in this migration

### Before (41048684581a71a102e6cb3b296d01c0b5f2240a)

1. Run the operator command from the base revision

   ```bash
   python scripts/backfill_team_model_identity.py
   ```

2. It exits with code `2`: `can't open file .../scripts/backfill_team_model_identity.py: [Errno 2] No such file or directory`

### After (2b03555008d4d10b5286555a5c405b78c61a69dd)

1. Preview the same migration without writing

   ```bash
   python scripts/backfill_team_model_identity.py --schema team_identity_proof_a2b25308c29d
   ```

2. The command exits `0` and shows the exact proposed change

   ```json
   {"event": "model", "model_id": "example-team-model", "model_name": "example-team-model", "status": "pending", "from_team_id": null, "to_team_id": "example-team", "action": "set_team_id"}
   ```

3. Execute the previewed operation against the current database

   ```bash
   python scripts/backfill_team_model_identity.py --schema team_identity_proof_a2b25308c29d --execute
   ```

4. The command exits `0`, reports the team model as `updated`, and reports one committed update. The global model remains unassigned. Model names, metadata, provider parameters, and timestamps are unchanged

5. Repeat the execute command. It exits `0`, reports the team model as `already_set`, and reports `updated: 0`, `pending: 0`, and `issues: 0`

## Type

Refactoring

## Caveats (if any)

### Severe

- Adding the column briefly requires an exclusive table lock
- Startup waits for the concurrent index build

### Medium

- Mixed versions require a final full scan on the primary
- Ownership conflicts require operator reconciliation
- Replica previews may lag; execution requires a writable primary
- Local team-model HTTP validation was blocked by the license gate

### Low

- Routing continues to read JSON ownership during this rollout
- Fallbacks, budgets, and rate limits remain follow-up work

Operator instructions: [backfill guide](scripts/backfill_team_model_identity.md)

## Final Attestation

- [ ] The tests check the right things, including edge cases, and regressions are not possible after this PR
