### PR TITLE
fix(proxy): resolve config include directives for bucket-hosted configs

### DIFF
--- a/litellm/integrations/gcs_bucket/gcs_bucket.py
+++ b/litellm/integrations/gcs_bucket/gcs_bucket.py
@@ -29,8 +29,6 @@ class GCSBucketLogger(GCSBucketBase, AdditionalLoggingUtils):
     def __init__(self, bucket_name: str | None = None) -> None:
         from litellm.proxy.proxy_server import premium_user
 
-        super().__init__(bucket_name=bucket_name)
-
         self.batch_size = int(os.getenv("GCS_BATCH_SIZE", GCS_DEFAULT_BATCH_SIZE))
         self.flush_interval = int(os.getenv("GCS_FLUSH_INTERVAL", GCS_DEFAULT_FLUSH_INTERVAL_SECONDS))
         self.use_batched_logging = (
@@ -38,6 +36,7 @@ class GCSBucketLogger(GCSBucketBase, AdditionalLoggingUtils):
         )
         self.flush_lock = asyncio.Lock()
         super().__init__(
+            bucket_name=bucket_name,
             flush_lock=self.flush_lock,
             batch_size=self.batch_size,
             flush_interval=self.flush_interval,

--- a/litellm/proxy/common_utils/config_includes.py
+++ b/litellm/proxy/common_utils/config_includes.py
@@ -13,28 +13,41 @@ def resolve_include_file_path(include_file: str, declared_in: str, root_config_p
     Resolve one `include` entry to the file it names, next to the config that declares it.
 
     A config written before nested entries resolved this way can name a file sitting next to the root
-    config instead, so that file is still read, with a warning naming where it was found.
+    config instead, so that file is still read, with a warning naming where it was found. When both
+    files exist the one next to the declaring config wins and the other is named in a warning.
     """
     declared_relative: Final = os.path.abspath(os.path.join(os.path.dirname(declared_in), include_file))
-    if os.path.exists(declared_relative):
-        return declared_relative
-
     root_relative: Final = os.path.abspath(os.path.join(os.path.dirname(root_config_path), include_file))
     if root_relative == declared_relative or not os.path.exists(root_relative):
         return declared_relative
 
+    if not os.path.exists(declared_relative):
+        verbose_proxy_logger.warning(
+            "Config include '%s' declared in %s was not found next to it, so %s was read instead. "
+            "Move the included file next to the config that declares it.",
+            include_file,
+            declared_in,
+            root_relative,
+        )
+        return root_relative
+
     verbose_proxy_logger.warning(
-        "Config include '%s' declared in %s was not found next to it, so %s was read instead. "
-        "Move the included file next to the config that declares it.",
+        "Config include '%s' declared in %s matches two files. %s sits next to that config and was read, "
+        "so %s was skipped. Rename one of the two to say which one you meant.",
         include_file,
         declared_in,
+        declared_relative,
         root_relative,
     )
-    return root_relative
+    return declared_relative
 
 
-class ConfigLoader(Protocol):
-    def __call__(self, include_entry: str, declared_in: str, /) -> Awaitable[tuple[str, Mapping[str, object]]]: ...
+class IncludeResolver(Protocol):
+    def __call__(self, include_entry: str, declared_in: str, /) -> str: ...
+
+
+class ConfigReader(Protocol):
+    def __call__(self, location: str, /) -> Awaitable[Mapping[str, object]]: ...
 
 
 def _merged_value(base_value: object, included_value: object) -> object:
@@ -80,32 +93,40 @@ async def _resolve(
     config: Mapping[str, object],
     pending: tuple[tuple[str, str], ...],
     loaded: frozenset[str],
-    load: ConfigLoader,
+    resolve: IncludeResolver,
+    read: ConfigReader,
 ) -> Mapping[str, object]:
     if not pending:
         return _without_include(config)
 
     entry, declared_in = pending[0]
-    location, included = await load(entry, declared_in)
+    location: Final = resolve(entry, declared_in)
     if location in loaded:
-        return await _resolve(config, pending[1:], loaded, load)
+        return await _resolve(config, pending[1:], loaded, resolve, read)
 
+    included: Final = await read(location)
     return await _resolve(
         _merged(config, _without_include(included)),
         (*pending[1:], *_pending_from(included, location)),
         loaded | frozenset((location,)),
-        load,
+        resolve,
+        read,
     )
 
 
-async def resolve_includes(config: Mapping[str, object], location: str, load: ConfigLoader) -> dict[str, object]:
+async def resolve_includes(
+    config: Mapping[str, object],
+    location: str,
+    resolve: IncludeResolver,
+    read: ConfigReader,
+) -> dict[str, object]:
     """
     Merge every config named by the `include` directive into the config that declares it.
 
-    List values are extended and every other value is overridden, each entry is resolved relative to
-    the config that declares it, a config already pulled in is not merged a second time, and `load`
-    decides where an entry is read from, so the same merge applies to configs on disk and to configs
-    hosted in a bucket.
+    List values are extended and every other value is overridden, `resolve` turns each entry into the
+    location it names relative to the config that declares it, a config already pulled in is neither
+    read nor merged a second time, and `read` decides where a location is read from, so the same merge
+    applies to configs on disk and to configs hosted in a bucket.
     """
-    merged: Final = await _resolve(config, _pending_from(config, location), frozenset((location,)), load)
+    merged: Final = await _resolve(config, _pending_from(config, location), frozenset((location,)), resolve, read)
     return dict(merged)  # mutable-ok: the proxy mutates the config it loads

--- a/litellm/proxy/common_utils/config_includes.py
+++ b/litellm/proxy/common_utils/config_includes.py
@@ -6,7 +6,7 @@ INCLUDE_KEY: Final = "include"
 
 
 class ConfigLoader(Protocol):
-    def __call__(self, include_entry: str, /) -> Awaitable[Mapping[str, object]]: ...
+    def __call__(self, include_entry: str, declared_in: str, /) -> Awaitable[tuple[str, Mapping[str, object]]]: ...
 
 
 def _merged_value(base_value: object, included_value: object) -> object:
@@ -44,25 +44,40 @@ def include_entries(config: Mapping[str, object]) -> tuple[str, ...]:
     return paths
 
 
-async def _resolve(config: Mapping[str, object], pending: tuple[str, ...], load: ConfigLoader) -> Mapping[str, object]:
+def _pending_from(config: Mapping[str, object], location: str) -> tuple[tuple[str, str], ...]:
+    return tuple((entry, location) for entry in include_entries(config))
+
+
+async def _resolve(
+    config: Mapping[str, object],
+    pending: tuple[tuple[str, str], ...],
+    loaded: frozenset[str],
+    load: ConfigLoader,
+) -> Mapping[str, object]:
     if not pending:
         return _without_include(config)
 
-    included: Final = await load(pending[0])
+    entry, declared_in = pending[0]
+    location, included = await load(entry, declared_in)
+    if location in loaded:
+        return await _resolve(config, pending[1:], loaded, load)
+
     return await _resolve(
         _merged(config, _without_include(included)),
-        (*pending[1:], *include_entries(included)),
+        (*pending[1:], *_pending_from(included, location)),
+        loaded | frozenset((location,)),
         load,
     )
 
 
-async def resolve_includes(config: Mapping[str, object], load: ConfigLoader) -> dict[str, object]:
+async def resolve_includes(config: Mapping[str, object], location: str, load: ConfigLoader) -> dict[str, object]:
     """
     Merge every config named by the `include` directive into the config that declares it.
 
-    List values are extended and every other value is overridden, an included config may declare
-    further includes, and `load` decides where an entry is read from, so the same merge applies to
-    configs on disk and to configs hosted in a bucket.
+    List values are extended and every other value is overridden, each entry is resolved relative to
+    the config that declares it, a config already pulled in is not merged a second time, and `load`
+    decides where an entry is read from, so the same merge applies to configs on disk and to configs
+    hosted in a bucket.
     """
-    merged: Final = await _resolve(config, include_entries(config), load)
+    merged: Final = await _resolve(config, _pending_from(config, location), frozenset((location,)), load)
     return dict(merged)  # mutable-ok: the proxy mutates the config it loads

--- a/litellm/proxy/common_utils/config_includes.py
+++ b/litellm/proxy/common_utils/config_includes.py
@@ -1,0 +1,68 @@
+from collections.abc import Awaitable, Mapping
+from types import MappingProxyType
+from typing import Final, Protocol
+
+INCLUDE_KEY: Final = "include"
+
+
+class ConfigLoader(Protocol):
+    def __call__(self, include_entry: str, /) -> Awaitable[Mapping[str, object]]: ...
+
+
+def _merged_value(base_value: object, included_value: object) -> object:
+    if isinstance(included_value, list) and isinstance(base_value, list):
+        return [*base_value, *included_value]  # mutable-ok: a merged config value stays the plain list the proxy loads
+    return included_value
+
+
+def _merged_entry(base: Mapping[str, object], included: Mapping[str, object], key: str) -> object:
+    if key not in included:
+        return base[key]
+    return _merged_value(base.get(key), included[key])
+
+
+def _merged(base: Mapping[str, object], included: Mapping[str, object]) -> Mapping[str, object]:
+    return MappingProxyType({key: _merged_entry(base, included, key) for key in (*base, *included)})
+
+
+def _without_include(config: Mapping[str, object]) -> Mapping[str, object]:
+    return MappingProxyType({key: value for key, value in config.items() if key != INCLUDE_KEY})
+
+
+def include_entries(config: Mapping[str, object]) -> tuple[str, ...]:
+    if INCLUDE_KEY not in config:
+        return ()
+
+    entries: Final = config[INCLUDE_KEY]
+    if not isinstance(entries, list):
+        raise ValueError("'include' must be a list of file paths")
+
+    paths: Final = tuple(entry for entry in entries if isinstance(entry, str))
+    if len(paths) != len(entries):
+        raise ValueError("'include' must be a list of file paths")
+
+    return paths
+
+
+async def _resolve(config: Mapping[str, object], pending: tuple[str, ...], load: ConfigLoader) -> Mapping[str, object]:
+    if not pending:
+        return _without_include(config)
+
+    included: Final = await load(pending[0])
+    return await _resolve(
+        _merged(config, _without_include(included)),
+        (*pending[1:], *include_entries(included)),
+        load,
+    )
+
+
+async def resolve_includes(config: Mapping[str, object], load: ConfigLoader) -> dict[str, object]:
+    """
+    Merge every config named by the `include` directive into the config that declares it.
+
+    List values are extended and every other value is overridden, an included config may declare
+    further includes, and `load` decides where an entry is read from, so the same merge applies to
+    configs on disk and to configs hosted in a bucket.
+    """
+    merged: Final = await _resolve(config, include_entries(config), load)
+    return dict(merged)  # mutable-ok: the proxy mutates the config it loads

--- a/litellm/proxy/common_utils/config_includes.py
+++ b/litellm/proxy/common_utils/config_includes.py
@@ -1,8 +1,36 @@
+import os
 from collections.abc import Awaitable, Mapping
 from types import MappingProxyType
 from typing import Final, Protocol
 
+from litellm._logging import verbose_proxy_logger
+
 INCLUDE_KEY: Final = "include"
+
+
+def resolve_include_file_path(include_file: str, declared_in: str, root_config_path: str) -> str:
+    """
+    Resolve one `include` entry to the file it names, next to the config that declares it.
+
+    A config written before nested entries resolved this way can name a file sitting next to the root
+    config instead, so that file is still read, with a warning naming where it was found.
+    """
+    declared_relative: Final = os.path.abspath(os.path.join(os.path.dirname(declared_in), include_file))
+    if os.path.exists(declared_relative):
+        return declared_relative
+
+    root_relative: Final = os.path.abspath(os.path.join(os.path.dirname(root_config_path), include_file))
+    if root_relative == declared_relative or not os.path.exists(root_relative):
+        return declared_relative
+
+    verbose_proxy_logger.warning(
+        "Config include '%s' declared in %s was not found next to it, so %s was read instead. "
+        "Move the included file next to the config that declares it.",
+        include_file,
+        declared_in,
+        root_relative,
+    )
+    return root_relative
 
 
 class ConfigLoader(Protocol):

--- a/litellm/proxy/common_utils/load_config_utils.py
+++ b/litellm/proxy/common_utils/load_config_utils.py
@@ -1,9 +1,19 @@
 import os
-from typing import Final
+import posixpath
+from collections.abc import Awaitable, Mapping
+from typing import Final, Protocol
 
 import yaml
+from pydantic import TypeAdapter, ValidationError
 
 from litellm._logging import verbose_proxy_logger
+from litellm.proxy.common_utils.config_includes import resolve_includes
+
+_BUCKET_CONFIG_ADAPTER: Final = TypeAdapter(dict[str, object])
+
+
+class BucketObjectFetcher(Protocol):
+    def __call__(self, object_key: str, /) -> Awaitable[Mapping[str, object] | None]: ...
 
 
 def get_file_contents_from_s3(bucket_name, object_key):
@@ -60,6 +70,60 @@ async def get_config_file_contents_from_gcs(bucket_name, object_key):
     except Exception as e:
         verbose_proxy_logger.error("Error retrieving file contents: %s", e)
         return None
+
+
+def resolve_include_object_key(config_object_key: str, include_entry: str) -> str:
+    """
+    Resolve one `include` entry to the object key it names, relative to the config object's prefix.
+
+    A leading "/" means the bucket root, mirroring how an absolute path on disk ignores the
+    directory the including config sits in.
+    """
+    if include_entry.startswith("/"):
+        return posixpath.normpath(include_entry).lstrip("/")
+    return posixpath.normpath(posixpath.join(posixpath.dirname(config_object_key), include_entry))
+
+
+async def resolve_bucket_includes(
+    *,
+    config: Mapping[str, object],
+    object_key: str,
+    fetch: BucketObjectFetcher,
+) -> dict[str, object]:
+    async def load(include_entry: str) -> Mapping[str, object]:
+        include_key: Final = resolve_include_object_key(object_key, include_entry)
+        included: Final = await fetch(include_key)
+        if included is None:
+            raise FileNotFoundError(f"Included config could not be read from bucket: {include_key}")
+        return included
+
+    return await resolve_includes(config=config, load=load)
+
+
+async def get_config_from_bucket(
+    *,
+    bucket_type: str | None,
+    bucket_name: str,
+    object_key: str,
+) -> dict[str, object] | None:
+    async def fetch(key: str) -> Mapping[str, object] | None:
+        raw: Final = (
+            await get_config_file_contents_from_gcs(bucket_name=bucket_name, object_key=key)
+            if bucket_type == "gcs"
+            else get_file_contents_from_s3(bucket_name=bucket_name, object_key=key)
+        )
+        if raw is None:
+            return None
+        try:
+            return _BUCKET_CONFIG_ADAPTER.validate_python(raw)
+        except ValidationError as e:
+            raise ValueError(f"Config object in bucket is not a YAML mapping: {key}") from e
+
+    config: Final = await fetch(object_key)
+    if config is None:
+        return None
+
+    return await resolve_bucket_includes(config=config, object_key=object_key, fetch=fetch)
 
 
 def download_python_file_from_s3(

--- a/litellm/proxy/common_utils/load_config_utils.py
+++ b/litellm/proxy/common_utils/load_config_utils.py
@@ -29,8 +29,12 @@ class SyncBucketObjectReader(Protocol):
     def __call__(self, object_key: str, /) -> object | None: ...
 
 
-def _parsed_config(file_contents: str) -> object:
-    parsed: Final = yaml.safe_load(file_contents)
+def _parsed_config(object_key: str, file_contents: str) -> object | None:
+    try:
+        parsed: Final = yaml.safe_load(file_contents)
+    except yaml.YAMLError as e:
+        verbose_proxy_logger.error("Config object %s is not valid YAML: %s", object_key, e)
+        return None
     return MappingProxyType({}) if parsed is None else parsed
 
 
@@ -64,10 +68,12 @@ def s3_object_reader(bucket_name: str) -> SyncBucketObjectReader:
         try:
             verbose_proxy_logger.debug("Retrieving %s from S3 bucket: %s", object_key, bucket_name)
             response: Final = s3_client.get_object(Bucket=bucket_name, Key=object_key)
-            return _parsed_config(response["Body"].read().decode("utf-8"))
+            file_contents: Final = response["Body"].read().decode("utf-8")
         except Exception as e:  # noqa: BLE001  # any boto3 error must read as a missing object
             verbose_proxy_logger.error("Error retrieving %s from S3 bucket %s: %s", object_key, bucket_name, e)
             return None
+
+        return _parsed_config(object_key, file_contents)
 
     return read
 
@@ -77,10 +83,16 @@ def get_file_contents_from_s3(bucket_name: str, object_key: str) -> object | Non
 
 
 def gcs_config_bucket(bucket_name: str) -> "GCSBucketBase | None":
-    try:
-        from litellm.integrations.gcs_bucket.gcs_bucket import GCSBucketLogger
+    """
+    Build a plain GCS client for reading config objects.
 
-        return GCSBucketLogger(bucket_name=bucket_name)
+    Reading a config out of a bucket is not GCS logging, so it neither needs the enterprise license
+    that gate covers nor the batching task the logger starts and never stops.
+    """
+    try:
+        from litellm.integrations.gcs_bucket.gcs_bucket_base import GCSBucketBase
+
+        return GCSBucketBase(bucket_name=bucket_name)
     except Exception as e:  # noqa: BLE001  # an unbuildable client must read as an unreadable bucket
         verbose_proxy_logger.error("Error creating the GCS client for bucket %s: %s", bucket_name, e)
         return None
@@ -98,11 +110,13 @@ async def get_config_file_contents_from_gcs(
         file_contents: Final = await bucket.download_gcs_object(object_key)
         if file_contents is None:
             raise Exception(f"File contents are None for {object_key}")
-        return _parsed_config(file_contents.decode("utf-8"))
+        decoded: Final = file_contents.decode("utf-8")
 
     except Exception as e:
         verbose_proxy_logger.error("Error retrieving %s from GCS bucket %s: %s", object_key, bucket_name, e)
         return None
+
+    return _parsed_config(object_key, decoded)
 
 
 def resolve_include_object_key(config_object_key: str, include_entry: str) -> str:
@@ -123,17 +137,19 @@ async def resolve_bucket_includes(
     object_key: str,
     fetch: BucketObjectFetcher,
 ) -> dict[str, object]:
-    async def load(include_entry: str, declared_in: str) -> tuple[str, Mapping[str, object]]:
-        include_key: Final = resolve_include_object_key(declared_in, include_entry)
+    async def read(include_key: str) -> Mapping[str, object]:
         included: Final = await fetch(include_key)
         if included is None:
             raise FileNotFoundError(
                 f"Included config could not be read from bucket: {include_key}. "
                 "The underlying bucket error is logged above."
             )
-        return include_key, included
+        return included
 
-    return await resolve_includes(config=config, location=object_key, load=load)
+    def resolve(include_entry: str, declared_in: str) -> str:
+        return resolve_include_object_key(declared_in, include_entry)
+
+    return await resolve_includes(config=config, location=object_key, resolve=resolve, read=read)
 
 
 async def bucket_object_reader(bucket_type: str | None, bucket_name: str) -> BucketObjectReader:
@@ -176,7 +192,7 @@ async def get_config_from_bucket(
             raise ValueError(f"Config object in bucket is not a YAML mapping: {key}") from e
 
     config: Final = await fetch(object_key)
-    if config is None:
+    if not config:
         return None
 
     return await resolve_bucket_includes(config=config, object_key=object_key, fetch=fetch)
@@ -256,11 +272,9 @@ async def download_python_file_from_gcs(
         bool: True if successful, False otherwise
     """
     try:
-        from litellm.integrations.gcs_bucket.gcs_bucket import GCSBucketLogger
+        from litellm.integrations.gcs_bucket.gcs_bucket_base import GCSBucketBase
 
-        gcs_bucket: Final = GCSBucketLogger(
-            bucket_name=bucket_name,
-        )
+        gcs_bucket: Final = GCSBucketBase(bucket_name=bucket_name)
         file_contents = await gcs_bucket.download_gcs_object(object_key)
         if file_contents is None:
             raise Exception(f"File contents are None for {object_key}")

--- a/litellm/proxy/common_utils/load_config_utils.py
+++ b/litellm/proxy/common_utils/load_config_utils.py
@@ -2,6 +2,7 @@ import asyncio
 import os
 import posixpath
 from collections.abc import Awaitable, Mapping
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Final, Protocol
 
 import yaml
@@ -24,7 +25,19 @@ class BucketObjectReader(Protocol):
     def __call__(self, object_key: str, /) -> Awaitable[object | None]: ...
 
 
-def get_file_contents_from_s3(bucket_name, object_key):
+class SyncBucketObjectReader(Protocol):
+    def __call__(self, object_key: str, /) -> object | None: ...
+
+
+def _parsed_config(file_contents: str) -> object:
+    parsed: Final = yaml.safe_load(file_contents)
+    return MappingProxyType({}) if parsed is None else parsed
+
+
+def s3_object_reader(bucket_name: str) -> SyncBucketObjectReader:
+    """
+    Build one reader for a whole config, so an `include` tree costs one S3 client rather than one per object.
+    """
     try:
         # v0 rely on boto3 for authentication - allowing boto3 to handle IAM credentials etc
         import boto3
@@ -39,24 +52,28 @@ def get_file_contents_from_s3(bucket_name, object_key):
             aws_secret_access_key=credentials.secret_key,
             aws_session_token=credentials.token,  # Optional, if using temporary credentials
         )
-        verbose_proxy_logger.debug("Retrieving %s from S3 bucket: %s", object_key, bucket_name)
-        response: Final = s3_client.get_object(Bucket=bucket_name, Key=object_key)
-        verbose_proxy_logger.debug("Response: %s", response)
-
-        # Read the file contents and directly parse YAML
-        file_contents: Final = response["Body"].read().decode("utf-8")
-        verbose_proxy_logger.debug("File contents retrieved from S3")
-
-        # Parse YAML directly from string
-        config: Final = yaml.safe_load(file_contents)
-        return config
-
     except ImportError as e:
         # this is most likely if a user is not using the litellm docker container
         verbose_proxy_logger.error("ImportError: %s", e)
+        return lambda object_key: None
     except Exception as e:
-        verbose_proxy_logger.error("Error retrieving file contents: %s", e)
-        return None
+        verbose_proxy_logger.error("Error creating the S3 client for bucket %s: %s", bucket_name, e)
+        return lambda object_key: None
+
+    def read(object_key: str) -> object | None:
+        try:
+            verbose_proxy_logger.debug("Retrieving %s from S3 bucket: %s", object_key, bucket_name)
+            response: Final = s3_client.get_object(Bucket=bucket_name, Key=object_key)
+            return _parsed_config(response["Body"].read().decode("utf-8"))
+        except Exception as e:  # noqa: BLE001  # any boto3 error must read as a missing object
+            verbose_proxy_logger.error("Error retrieving %s from S3 bucket %s: %s", object_key, bucket_name, e)
+            return None
+
+    return read
+
+
+def get_file_contents_from_s3(bucket_name: str, object_key: str) -> object | None:
+    return s3_object_reader(bucket_name)(object_key)
 
 
 def gcs_config_bucket(bucket_name: str) -> "GCSBucketBase | None":
@@ -64,27 +81,27 @@ def gcs_config_bucket(bucket_name: str) -> "GCSBucketBase | None":
         from litellm.integrations.gcs_bucket.gcs_bucket import GCSBucketLogger
 
         return GCSBucketLogger(bucket_name=bucket_name)
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001  # an unbuildable client must read as an unreadable bucket
         verbose_proxy_logger.error("Error creating the GCS client for bucket %s: %s", bucket_name, e)
         return None
 
 
-async def get_config_file_contents_from_gcs(bucket_name, object_key, gcs_bucket=None):
+async def get_config_file_contents_from_gcs(
+    bucket_name: str,
+    object_key: str,
+    gcs_bucket: "GCSBucketBase | None" = None,
+) -> object | None:
     try:
         bucket: Final = gcs_config_bucket(bucket_name) if gcs_bucket is None else gcs_bucket
         if bucket is None:
             return None
-        file_contents = await bucket.download_gcs_object(object_key)
+        file_contents: Final = await bucket.download_gcs_object(object_key)
         if file_contents is None:
             raise Exception(f"File contents are None for {object_key}")
-        # file_contentis is a bytes object, so we need to convert it to yaml
-        file_contents = file_contents.decode("utf-8")
-        # convert to yaml
-        config: Final = yaml.safe_load(file_contents)
-        return config
+        return _parsed_config(file_contents.decode("utf-8"))
 
     except Exception as e:
-        verbose_proxy_logger.error("Error retrieving file contents: %s", e)
+        verbose_proxy_logger.error("Error retrieving %s from GCS bucket %s: %s", object_key, bucket_name, e)
         return None
 
 
@@ -110,20 +127,24 @@ async def resolve_bucket_includes(
         include_key: Final = resolve_include_object_key(declared_in, include_entry)
         included: Final = await fetch(include_key)
         if included is None:
-            raise FileNotFoundError(f"Included config could not be read from bucket: {include_key}")
+            raise FileNotFoundError(
+                f"Included config could not be read from bucket: {include_key}. "
+                "The underlying bucket error is logged above."
+            )
         return include_key, included
 
     return await resolve_includes(config=config, location=object_key, load=load)
 
 
-def bucket_object_reader(bucket_type: str | None, bucket_name: str) -> BucketObjectReader:
+async def bucket_object_reader(bucket_type: str | None, bucket_name: str) -> BucketObjectReader:
     """
     Build one reader for a whole config, so an `include` tree costs one bucket client rather than one per object.
     """
     if bucket_type != "gcs":
+        read_object: Final = await asyncio.to_thread(s3_object_reader, bucket_name)
 
         async def read_from_s3(object_key: str) -> object | None:
-            return await asyncio.to_thread(get_file_contents_from_s3, bucket_name, object_key)
+            return await asyncio.to_thread(read_object, object_key)
 
         return read_from_s3
 
@@ -143,7 +164,7 @@ async def get_config_from_bucket(
     bucket_name: str,
     object_key: str,
 ) -> dict[str, object] | None:
-    read: Final = bucket_object_reader(bucket_type, bucket_name)
+    read: Final = await bucket_object_reader(bucket_type, bucket_name)
 
     async def fetch(key: str) -> Mapping[str, object] | None:
         raw: Final = await read(key)

--- a/litellm/proxy/common_utils/load_config_utils.py
+++ b/litellm/proxy/common_utils/load_config_utils.py
@@ -1,7 +1,8 @@
+import asyncio
 import os
 import posixpath
 from collections.abc import Awaitable, Mapping
-from typing import Final, Protocol
+from typing import TYPE_CHECKING, Final, Protocol
 
 import yaml
 from pydantic import TypeAdapter, ValidationError
@@ -9,11 +10,18 @@ from pydantic import TypeAdapter, ValidationError
 from litellm._logging import verbose_proxy_logger
 from litellm.proxy.common_utils.config_includes import resolve_includes
 
+if TYPE_CHECKING:
+    from litellm.integrations.gcs_bucket.gcs_bucket_base import GCSBucketBase
+
 _BUCKET_CONFIG_ADAPTER: Final = TypeAdapter(dict[str, object])
 
 
 class BucketObjectFetcher(Protocol):
     def __call__(self, object_key: str, /) -> Awaitable[Mapping[str, object] | None]: ...
+
+
+class BucketObjectReader(Protocol):
+    def __call__(self, object_key: str, /) -> Awaitable[object | None]: ...
 
 
 def get_file_contents_from_s3(bucket_name, object_key):
@@ -51,14 +59,22 @@ def get_file_contents_from_s3(bucket_name, object_key):
         return None
 
 
-async def get_config_file_contents_from_gcs(bucket_name, object_key):
+def gcs_config_bucket(bucket_name: str) -> "GCSBucketBase | None":
     try:
         from litellm.integrations.gcs_bucket.gcs_bucket import GCSBucketLogger
 
-        gcs_bucket: Final = GCSBucketLogger(
-            bucket_name=bucket_name,
-        )
-        file_contents = await gcs_bucket.download_gcs_object(object_key)
+        return GCSBucketLogger(bucket_name=bucket_name)
+    except Exception as e:
+        verbose_proxy_logger.error("Error creating the GCS client for bucket %s: %s", bucket_name, e)
+        return None
+
+
+async def get_config_file_contents_from_gcs(bucket_name, object_key, gcs_bucket=None):
+    try:
+        bucket: Final = gcs_config_bucket(bucket_name) if gcs_bucket is None else gcs_bucket
+        if bucket is None:
+            return None
+        file_contents = await bucket.download_gcs_object(object_key)
         if file_contents is None:
             raise Exception(f"File contents are None for {object_key}")
         # file_contentis is a bytes object, so we need to convert it to yaml
@@ -90,14 +106,35 @@ async def resolve_bucket_includes(
     object_key: str,
     fetch: BucketObjectFetcher,
 ) -> dict[str, object]:
-    async def load(include_entry: str) -> Mapping[str, object]:
-        include_key: Final = resolve_include_object_key(object_key, include_entry)
+    async def load(include_entry: str, declared_in: str) -> tuple[str, Mapping[str, object]]:
+        include_key: Final = resolve_include_object_key(declared_in, include_entry)
         included: Final = await fetch(include_key)
         if included is None:
             raise FileNotFoundError(f"Included config could not be read from bucket: {include_key}")
-        return included
+        return include_key, included
 
-    return await resolve_includes(config=config, load=load)
+    return await resolve_includes(config=config, location=object_key, load=load)
+
+
+def bucket_object_reader(bucket_type: str | None, bucket_name: str) -> BucketObjectReader:
+    """
+    Build one reader for a whole config, so an `include` tree costs one bucket client rather than one per object.
+    """
+    if bucket_type != "gcs":
+
+        async def read_from_s3(object_key: str) -> object | None:
+            return await asyncio.to_thread(get_file_contents_from_s3, bucket_name, object_key)
+
+        return read_from_s3
+
+    gcs_bucket: Final = gcs_config_bucket(bucket_name)
+
+    async def read_from_gcs(object_key: str) -> object | None:
+        if gcs_bucket is None:
+            return None
+        return await get_config_file_contents_from_gcs(bucket_name, object_key, gcs_bucket)
+
+    return read_from_gcs
 
 
 async def get_config_from_bucket(
@@ -106,12 +143,10 @@ async def get_config_from_bucket(
     bucket_name: str,
     object_key: str,
 ) -> dict[str, object] | None:
+    read: Final = bucket_object_reader(bucket_type, bucket_name)
+
     async def fetch(key: str) -> Mapping[str, object] | None:
-        raw: Final = (
-            await get_config_file_contents_from_gcs(bucket_name=bucket_name, object_key=key)
-            if bucket_type == "gcs"
-            else get_file_contents_from_s3(bucket_name=bucket_name, object_key=key)
-        )
+        raw: Final = await read(key)
         if raw is None:
             return None
         try:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -341,7 +341,7 @@ from litellm.proxy.common_utils.auth_cache_invalidation_pubsub import (
     AuthCacheInvalidationSubscriber,
 )
 from litellm.proxy.common_utils.callback_utils import initialize_callbacks_on_proxy
-from litellm.proxy.common_utils.config_includes import resolve_includes
+from litellm.proxy.common_utils.config_includes import resolve_include_file_path, resolve_includes
 from litellm.proxy.common_utils.config_sync_pubsub import ConfigSyncSubscriber
 from litellm.proxy.common_utils.debug_utils import init_verbose_loggers
 from litellm.proxy.common_utils.debug_utils import router as debugging_endpoints_router
@@ -4560,7 +4560,7 @@ class ProxyConfig:
         included_config_adapter: Final = TypeAdapter(dict[str, object])
 
         async def load_included(include_file: str, declared_in: str) -> tuple[str, Mapping[str, object]]:
-            file_path: Final = os.path.abspath(os.path.join(os.path.dirname(declared_in), include_file))
+            file_path: Final = resolve_include_file_path(include_file, declared_in, config_file_path)
             if not os.path.exists(file_path):
                 raise FileNotFoundError(f"Included file not found: {file_path}")
             try:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -341,6 +341,7 @@ from litellm.proxy.common_utils.auth_cache_invalidation_pubsub import (
     AuthCacheInvalidationSubscriber,
 )
 from litellm.proxy.common_utils.callback_utils import initialize_callbacks_on_proxy
+from litellm.proxy.common_utils.config_includes import resolve_includes
 from litellm.proxy.common_utils.config_sync_pubsub import ConfigSyncSubscriber
 from litellm.proxy.common_utils.debug_utils import init_verbose_loggers
 from litellm.proxy.common_utils.debug_utils import router as debugging_endpoints_router
@@ -359,10 +360,7 @@ from litellm.proxy.common_utils.http_parsing_utils import (
     check_file_size_under_limit,
     get_form_data,
 )
-from litellm.proxy.common_utils.load_config_utils import (
-    get_config_file_contents_from_gcs,
-    get_file_contents_from_s3,
-)
+from litellm.proxy.common_utils.load_config_utils import get_config_from_bucket
 from litellm.proxy.common_utils.model_deprecation import collect_model_deprecations
 from litellm.proxy.common_utils.model_listing_utils import (
     TeamModelNameTranslator,
@@ -4538,12 +4536,12 @@ class ProxyConfig:
         if config is None:
             raise Exception("Config cannot be None or Empty.")
         # Process includes
-        config = self._process_includes(config=config, base_dir=os.path.dirname(os.path.abspath(file_path or "")))
+        config = await self._process_includes(config=config, base_dir=os.path.dirname(os.path.abspath(file_path or "")))
 
         # verbose_proxy_logger.debug(f"loaded config={json.dumps(config, indent=4)}")
         return config
 
-    def _process_includes(self, config: dict, base_dir: str) -> dict:
+    async def _process_includes(self, config: dict, base_dir: str) -> dict:
         """
         Process includes by appending their contents to the main config
 
@@ -4558,29 +4556,14 @@ class ProxyConfig:
             callbacks: ["prometheus"]
         ```
         """
-        if "include" not in config:
-            return config
 
-        if not isinstance(config["include"], list):
-            raise ValueError("'include' must be a list of file paths")
-
-        # Load and append all included files
-        for include_file in config["include"]:
-            file_path = os.path.join(base_dir, include_file)
+        async def load_included(include_file: str) -> Mapping[str, object]:
+            file_path: Final = os.path.join(base_dir, include_file)
             if not os.path.exists(file_path):
                 raise FileNotFoundError(f"Included file not found: {file_path}")
+            return self._load_yaml_file(file_path)
 
-            included_config = self._load_yaml_file(file_path)
-            # Simply update/extend the main config with included config
-            for key, value in included_config.items():
-                if isinstance(value, list) and key in config:
-                    config[key].extend(value)
-                else:
-                    config[key] = value
-
-        # Remove the include directive
-        del config["include"]
-        return config
+        return await resolve_includes(config=config, load=load_included)
 
     async def save_config(self, new_config: dict, include_env_vars: bool = False):
         global prisma_client, general_settings, user_config_file_path, store_model_in_db
@@ -4936,15 +4919,19 @@ class ProxyConfig:
         global prisma_client, store_model_in_db
         # Load existing config
 
-        if os.environ.get("LITELLM_CONFIG_BUCKET_NAME") is not None:
-            bucket_name: Final = os.environ.get("LITELLM_CONFIG_BUCKET_NAME")
+        bucket_name: Final = os.environ.get("LITELLM_CONFIG_BUCKET_NAME")
+        if bucket_name is not None:
             object_key: Final = os.environ.get("LITELLM_CONFIG_BUCKET_OBJECT_KEY")
             bucket_type: Final = os.environ.get("LITELLM_CONFIG_BUCKET_TYPE")
             verbose_proxy_logger.debug("bucket_name: %s, object_key: %s", bucket_name, object_key)
-            if bucket_type == "gcs":
-                config = await get_config_file_contents_from_gcs(bucket_name=bucket_name, object_key=object_key)
-            else:
-                config = get_file_contents_from_s3(bucket_name=bucket_name, object_key=object_key)
+            if object_key is None:
+                raise Exception("LITELLM_CONFIG_BUCKET_OBJECT_KEY must be set to load the config from a bucket.")
+
+            config = await get_config_from_bucket(
+                bucket_type=bucket_type,
+                bucket_name=bucket_name,
+                object_key=object_key,
+            )
 
             if config is None:
                 raise Exception("Unable to load config from given source.")

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -4559,17 +4559,18 @@ class ProxyConfig:
 
         included_config_adapter: Final = TypeAdapter(dict[str, object])
 
-        async def load_included(include_file: str, declared_in: str) -> tuple[str, Mapping[str, object]]:
-            file_path: Final = resolve_include_file_path(include_file, declared_in, config_file_path)
+        def resolve(include_file: str, declared_in: str) -> str:
+            return resolve_include_file_path(include_file, declared_in, config_file_path)
+
+        async def read_included(file_path: str) -> Mapping[str, object]:
             if not os.path.exists(file_path):
                 raise FileNotFoundError(f"Included file not found: {file_path}")
             try:
-                included: Final = included_config_adapter.validate_python(self._load_yaml_file(file_path))
+                return included_config_adapter.validate_python(self._load_yaml_file(file_path))
             except ValidationError as e:
                 raise ValueError(f"Included config file is not a YAML mapping: {file_path}") from e
-            return file_path, included
 
-        return await resolve_includes(config=config, location=config_file_path, load=load_included)
+        return await resolve_includes(config=config, location=config_file_path, resolve=resolve, read=read_included)
 
     async def save_config(self, new_config: dict, include_env_vars: bool = False):
         global prisma_client, general_settings, user_config_file_path, store_model_in_db

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -4536,12 +4536,12 @@ class ProxyConfig:
         if config is None:
             raise Exception("Config cannot be None or Empty.")
         # Process includes
-        config = await self._process_includes(config=config, base_dir=os.path.dirname(os.path.abspath(file_path or "")))
+        config = await self._process_includes(config=config, config_file_path=os.path.abspath(file_path or ""))
 
         # verbose_proxy_logger.debug(f"loaded config={json.dumps(config, indent=4)}")
         return config
 
-    async def _process_includes(self, config: dict, base_dir: str) -> dict:
+    async def _process_includes(self, config: dict, config_file_path: str) -> dict:
         """
         Process includes by appending their contents to the main config
 
@@ -4557,13 +4557,19 @@ class ProxyConfig:
         ```
         """
 
-        async def load_included(include_file: str) -> Mapping[str, object]:
-            file_path: Final = os.path.join(base_dir, include_file)
+        included_config_adapter: Final = TypeAdapter(dict[str, object])
+
+        async def load_included(include_file: str, declared_in: str) -> tuple[str, Mapping[str, object]]:
+            file_path: Final = os.path.abspath(os.path.join(os.path.dirname(declared_in), include_file))
             if not os.path.exists(file_path):
                 raise FileNotFoundError(f"Included file not found: {file_path}")
-            return self._load_yaml_file(file_path)
+            try:
+                included: Final = included_config_adapter.validate_python(self._load_yaml_file(file_path))
+            except ValidationError as e:
+                raise ValueError(f"Included config file is not a YAML mapping: {file_path}") from e
+            return file_path, included
 
-        return await resolve_includes(config=config, load=load_included)
+        return await resolve_includes(config=config, location=config_file_path, load=load_included)
 
     async def save_config(self, new_config: dict, include_env_vars: bool = False):
         global prisma_client, general_settings, user_config_file_path, store_model_in_db

--- a/tests/test_litellm/integrations/gcs_bucket/test_gcs_bucket_base.py
+++ b/tests/test_litellm/integrations/gcs_bucket/test_gcs_bucket_base.py
@@ -128,3 +128,20 @@ class TestGCSBucketBase:
         assert object_name.endswith("-target_uploadType_media")
         assert ".." not in object_name
         assert "?" not in object_name
+
+
+class TestGCSBucketLoggerBucketName:
+    @pytest.mark.asyncio
+    async def test_the_bucket_name_it_is_constructed_with_survives(self, monkeypatch):
+        """Reading config.yaml out of a GCS bucket asks for that bucket, not the logging one (LIT-6982)."""
+        monkeypatch.setenv("GCS_BUCKET_NAME", "logging-bucket")
+        monkeypatch.setattr("litellm.proxy.proxy_server.premium_user", True)
+
+        assert GCSBucketLogger(bucket_name="config-bucket").BUCKET_NAME == "config-bucket"
+
+    @pytest.mark.asyncio
+    async def test_no_bucket_name_still_falls_back_to_the_environment(self, monkeypatch):
+        monkeypatch.setenv("GCS_BUCKET_NAME", "logging-bucket")
+        monkeypatch.setattr("litellm.proxy.proxy_server.premium_user", True)
+
+        assert GCSBucketLogger().BUCKET_NAME == "logging-bucket"

--- a/tests/test_litellm/proxy/common_utils/test_load_config_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_load_config_utils.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import re
 import threading
 from unittest.mock import MagicMock, mock_open, patch
@@ -7,6 +8,7 @@ import pytest
 import yaml
 
 from litellm.proxy.common_utils.load_config_utils import (
+    gcs_config_bucket,
     get_config_from_bucket,
     get_file_contents_from_s3,
     resolve_bucket_includes,
@@ -391,3 +393,84 @@ class TestBucketConfigIncludes:
             )
             is None
         )
+
+    @pytest.mark.asyncio
+    async def test_an_object_pulled_in_twice_is_read_once(self):
+        objects = {
+            "configs/a.yaml": {"include": ["shared.yaml"]},
+            "configs/b.yaml": {"include": ["./shared.yaml"]},
+            "configs/shared.yaml": {"model_list": [{"model_name": "shared"}]},
+        }
+        requested = []
+
+        async def fetch(object_key):
+            requested.append(object_key)
+            return objects.get(object_key)
+
+        await resolve_bucket_includes(
+            config={"include": ["a.yaml", "b.yaml"]},
+            object_key="configs/config.yaml",
+            fetch=fetch,
+        )
+
+        assert requested == ["configs/a.yaml", "configs/b.yaml", "configs/shared.yaml"]
+
+    @pytest.mark.asyncio
+    async def test_an_empty_root_object_does_not_boot_an_empty_proxy(self, monkeypatch):
+        class FakeGCSBucket:
+            async def download_gcs_object(self, object_key):
+                return b""
+
+        monkeypatch.setattr(
+            "litellm.proxy.common_utils.load_config_utils.gcs_config_bucket",
+            lambda bucket_name: FakeGCSBucket(),
+        )
+
+        config = await get_config_from_bucket(
+            bucket_type="gcs", bucket_name="litellm-configs", object_key="lit6982/config.yaml"
+        )
+
+        assert config is None
+
+    @pytest.mark.asyncio
+    async def test_an_object_that_is_not_valid_yaml_is_reported_as_a_yaml_error(self, monkeypatch, caplog):
+        class FakeGCSBucket:
+            async def download_gcs_object(self, object_key):
+                return b"model_list: [\n"
+
+        monkeypatch.setattr(
+            "litellm.proxy.common_utils.load_config_utils.gcs_config_bucket",
+            lambda bucket_name: FakeGCSBucket(),
+        )
+
+        with caplog.at_level(logging.ERROR, logger="LiteLLM Proxy"):
+            config = await get_config_from_bucket(
+                bucket_type="gcs", bucket_name="litellm-configs", object_key="lit6982/config.yaml"
+            )
+
+        assert config is None
+        assert [
+            record
+            for record in caplog.records
+            if "not valid YAML" in record.getMessage() and "lit6982/config.yaml" in record.getMessage()
+        ]
+
+
+class TestGCSConfigBucketClient:
+    @pytest.mark.asyncio
+    async def test_reading_a_config_from_gcs_does_not_need_an_enterprise_license(self, monkeypatch):
+        monkeypatch.setattr("litellm.proxy.proxy_server.premium_user", False)
+
+        bucket = gcs_config_bucket("litellm-configs")
+
+        assert bucket is not None
+        assert bucket.BUCKET_NAME == "litellm-configs"
+
+    @pytest.mark.asyncio
+    async def test_reading_a_config_from_gcs_starts_no_background_task(self, monkeypatch):
+        monkeypatch.setattr("litellm.proxy.proxy_server.premium_user", True)
+        running_before = asyncio.all_tasks()
+
+        gcs_config_bucket("litellm-configs")
+
+        assert asyncio.all_tasks() - running_before == set()

--- a/tests/test_litellm/proxy/common_utils/test_load_config_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_load_config_utils.py
@@ -1,4 +1,6 @@
+import asyncio
 import re
+import threading
 from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
@@ -158,6 +160,60 @@ class TestBucketConfigIncludes:
         assert merged == {"model_list": [{"model_name": "first"}, {"model_name": "second"}]}
 
     @pytest.mark.asyncio
+    async def test_a_nested_include_resolves_against_the_object_that_declares_it(self):
+        """A nested `include` names a neighbour of the object declaring it, not of the root config."""
+        merged = await resolve_bucket_includes(
+            config={"include": ["shared/models.yaml"]},
+            object_key="configs/config.yaml",
+            fetch=self._bucket(
+                {
+                    "configs/shared/models.yaml": {
+                        "include": ["more_models.yaml"],
+                        "model_list": [{"model_name": "first"}],
+                    },
+                    "configs/shared/more_models.yaml": {"model_list": [{"model_name": "second"}]},
+                    "configs/more_models.yaml": {"model_list": [{"model_name": "wrong-prefix"}]},
+                }
+            ),
+        )
+
+        assert merged == {"model_list": [{"model_name": "first"}, {"model_name": "second"}]}
+
+    @pytest.mark.asyncio
+    async def test_an_object_pulled_in_twice_is_merged_once(self):
+        merged = await resolve_bucket_includes(
+            config={"include": ["a.yaml", "b.yaml"]},
+            object_key="configs/config.yaml",
+            fetch=self._bucket(
+                {
+                    "configs/a.yaml": {"include": ["shared.yaml"]},
+                    "configs/b.yaml": {"include": ["./shared.yaml"]},
+                    "configs/shared.yaml": {"model_list": [{"model_name": "shared"}]},
+                }
+            ),
+        )
+
+        assert merged == {"model_list": [{"model_name": "shared"}]}
+
+    @pytest.mark.asyncio
+    async def test_a_cycle_between_included_objects_terminates(self):
+        merged = await asyncio.wait_for(
+            resolve_bucket_includes(
+                config={"include": ["a.yaml"]},
+                object_key="configs/config.yaml",
+                fetch=self._bucket(
+                    {
+                        "configs/a.yaml": {"include": ["b.yaml"], "model_list": [{"model_name": "from-a"}]},
+                        "configs/b.yaml": {"include": ["a.yaml"], "model_list": [{"model_name": "from-b"}]},
+                    }
+                ),
+            ),
+            timeout=10,
+        )
+
+        assert merged == {"model_list": [{"model_name": "from-a"}, {"model_name": "from-b"}]}
+
+    @pytest.mark.asyncio
     async def test_list_values_are_extended_and_other_values_are_overridden(self):
         merged = await resolve_bucket_includes(
             config={
@@ -223,6 +279,23 @@ class TestBucketConfigIncludes:
         }
 
     @pytest.mark.asyncio
+    async def test_the_blocking_s3_read_runs_off_the_event_loop_thread(self, monkeypatch):
+        loop_thread = threading.current_thread()
+        read_threads = []
+
+        def record_thread(bucket_name, object_key):
+            read_threads.append(threading.current_thread())
+            return {"model_list": [{"model_name": "a-model"}]}
+
+        monkeypatch.setattr(
+            "litellm.proxy.common_utils.load_config_utils.get_file_contents_from_s3", record_thread
+        )
+
+        await get_config_from_bucket(bucket_type="s3", bucket_name="litellm-configs", object_key="config.yaml")
+
+        assert read_threads and loop_thread not in read_threads
+
+    @pytest.mark.asyncio
     async def test_get_config_from_bucket_merges_includes_over_gcs(self, monkeypatch):
         objects = {
             "lit6982/config.yaml": {
@@ -232,11 +305,20 @@ class TestBucketConfigIncludes:
             "lit6982/model_config.yaml": {"model_list": [{"model_name": "included-model"}]},
         }
 
-        async def fake_gcs(bucket_name, object_key):
-            return objects.get(object_key)
+        buckets = []
+
+        class FakeGCSBucket:
+            def __init__(self):
+                self.requested = []
+                buckets.append(self)
+
+            async def download_gcs_object(self, object_key):
+                self.requested.append(object_key)
+                return yaml.dump(objects[object_key]).encode("utf-8")
 
         monkeypatch.setattr(
-            "litellm.proxy.common_utils.load_config_utils.get_config_file_contents_from_gcs", fake_gcs
+            "litellm.proxy.common_utils.load_config_utils.gcs_config_bucket",
+            lambda bucket_name: FakeGCSBucket(),
         )
 
         config = await get_config_from_bucket(
@@ -247,6 +329,9 @@ class TestBucketConfigIncludes:
             "general_settings": {"master_key": "sk-1234"},
             "model_list": [{"model_name": "included-model"}],
         }
+        assert [bucket.requested for bucket in buckets] == [
+            ["lit6982/config.yaml", "lit6982/model_config.yaml"]
+        ]
 
     @pytest.mark.asyncio
     async def test_get_config_from_bucket_returns_none_when_the_root_object_is_missing(self, monkeypatch):

--- a/tests/test_litellm/proxy/common_utils/test_load_config_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_load_config_utils.py
@@ -1,9 +1,14 @@
+import re
 from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
 import yaml
 
-from litellm.proxy.common_utils.load_config_utils import get_file_contents_from_s3
+from litellm.proxy.common_utils.load_config_utils import (
+    get_config_from_bucket,
+    get_file_contents_from_s3,
+    resolve_bucket_includes,
+)
 
 
 class TestGetFileContentsFromS3:
@@ -83,3 +88,176 @@ class TestGetFileContentsFromS3:
 
         # Verify yaml.safe_load was called with the decoded content
         mock_yaml_load.assert_called_once_with(yaml_content)
+
+
+class TestBucketConfigIncludes:
+    """`include:` directives in a bucket-hosted config.yaml (LIT-6982).
+
+    They used to be dropped silently: the proxy booted with the root config applied and everything
+    the included objects declared missing, with nothing logged.
+    """
+
+    @staticmethod
+    def _bucket(objects):
+        async def fetch(object_key):
+            return objects.get(object_key)
+
+        return fetch
+
+    @pytest.mark.asyncio
+    async def test_include_resolves_against_the_config_objects_prefix(self):
+        merged = await resolve_bucket_includes(
+            config={"include": ["model_config.yaml"], "general_settings": {"master_key": "sk-1234"}},
+            object_key="configs/prod/config.yaml",
+            fetch=self._bucket(
+                {"configs/prod/model_config.yaml": {"model_list": [{"model_name": "gpt-4o-mini"}]}}
+            ),
+        )
+
+        assert merged == {
+            "general_settings": {"master_key": "sk-1234"},
+            "model_list": [{"model_name": "gpt-4o-mini"}],
+        }
+
+    @pytest.mark.asyncio
+    async def test_include_with_a_leading_slash_reads_from_the_bucket_root(self):
+        merged = await resolve_bucket_includes(
+            config={"include": ["/shared/models.yaml"]},
+            object_key="configs/prod/config.yaml",
+            fetch=self._bucket({"shared/models.yaml": {"model_list": [{"model_name": "shared"}]}}),
+        )
+
+        assert merged == {"model_list": [{"model_name": "shared"}]}
+
+    @pytest.mark.asyncio
+    async def test_include_walks_out_of_the_prefix_with_dot_dot(self):
+        merged = await resolve_bucket_includes(
+            config={"include": ["../shared/models.yaml"]},
+            object_key="configs/prod/config.yaml",
+            fetch=self._bucket({"configs/shared/models.yaml": {"model_list": [{"model_name": "shared"}]}}),
+        )
+
+        assert merged == {"model_list": [{"model_name": "shared"}]}
+
+    @pytest.mark.asyncio
+    async def test_included_configs_may_declare_further_includes(self):
+        merged = await resolve_bucket_includes(
+            config={"include": ["models.yaml"]},
+            object_key="configs/config.yaml",
+            fetch=self._bucket(
+                {
+                    "configs/models.yaml": {
+                        "include": ["extra/more_models.yaml"],
+                        "model_list": [{"model_name": "first"}],
+                    },
+                    "configs/extra/more_models.yaml": {"model_list": [{"model_name": "second"}]},
+                }
+            ),
+        )
+
+        assert merged == {"model_list": [{"model_name": "first"}, {"model_name": "second"}]}
+
+    @pytest.mark.asyncio
+    async def test_list_values_are_extended_and_other_values_are_overridden(self):
+        merged = await resolve_bucket_includes(
+            config={
+                "include": ["models.yaml"],
+                "model_list": [{"model_name": "from-root"}],
+                "litellm_settings": {"drop_params": True},
+            },
+            object_key="config.yaml",
+            fetch=self._bucket(
+                {
+                    "models.yaml": {
+                        "model_list": [{"model_name": "from-include"}],
+                        "litellm_settings": {"num_retries": 3},
+                    }
+                }
+            ),
+        )
+
+        assert merged == {
+            "model_list": [{"model_name": "from-root"}, {"model_name": "from-include"}],
+            "litellm_settings": {"num_retries": 3},
+        }
+
+    @pytest.mark.asyncio
+    async def test_a_missing_included_object_fails_loudly_with_its_key(self):
+        with pytest.raises(FileNotFoundError, match=re.escape("configs/prod/model_config.yaml")):
+            await resolve_bucket_includes(
+                config={"include": ["model_config.yaml"]},
+                object_key="configs/prod/config.yaml",
+                fetch=self._bucket({}),
+            )
+
+    @pytest.mark.asyncio
+    async def test_a_non_list_include_fails_loudly(self):
+        with pytest.raises(ValueError, match="'include' must be a list of file paths"):
+            await resolve_bucket_includes(
+                config={"include": "model_config.yaml"},
+                object_key="config.yaml",
+                fetch=self._bucket({}),
+            )
+
+    @pytest.mark.asyncio
+    async def test_get_config_from_bucket_merges_includes_over_s3(self, monkeypatch):
+        objects = {
+            "lit6982/config.yaml": {
+                "include": ["model_config.yaml"],
+                "general_settings": {"master_key": "sk-1234"},
+            },
+            "lit6982/model_config.yaml": {"model_list": [{"model_name": "included-model"}]},
+        }
+        monkeypatch.setattr(
+            "litellm.proxy.common_utils.load_config_utils.get_file_contents_from_s3",
+            lambda bucket_name, object_key: objects.get(object_key),
+        )
+
+        config = await get_config_from_bucket(
+            bucket_type="s3", bucket_name="litellm-configs", object_key="lit6982/config.yaml"
+        )
+
+        assert config == {
+            "general_settings": {"master_key": "sk-1234"},
+            "model_list": [{"model_name": "included-model"}],
+        }
+
+    @pytest.mark.asyncio
+    async def test_get_config_from_bucket_merges_includes_over_gcs(self, monkeypatch):
+        objects = {
+            "lit6982/config.yaml": {
+                "include": ["model_config.yaml"],
+                "general_settings": {"master_key": "sk-1234"},
+            },
+            "lit6982/model_config.yaml": {"model_list": [{"model_name": "included-model"}]},
+        }
+
+        async def fake_gcs(bucket_name, object_key):
+            return objects.get(object_key)
+
+        monkeypatch.setattr(
+            "litellm.proxy.common_utils.load_config_utils.get_config_file_contents_from_gcs", fake_gcs
+        )
+
+        config = await get_config_from_bucket(
+            bucket_type="gcs", bucket_name="litellm-configs", object_key="lit6982/config.yaml"
+        )
+
+        assert config == {
+            "general_settings": {"master_key": "sk-1234"},
+            "model_list": [{"model_name": "included-model"}],
+        }
+
+    @pytest.mark.asyncio
+    async def test_get_config_from_bucket_returns_none_when_the_root_object_is_missing(self, monkeypatch):
+        monkeypatch.setattr(
+            "litellm.proxy.common_utils.load_config_utils.get_file_contents_from_s3",
+            lambda bucket_name, object_key: None,
+        )
+
+        assert (
+            await get_config_from_bucket(
+                bucket_type="s3", bucket_name="litellm-configs", object_key="missing.yaml"
+            )
+            is None
+        )

--- a/tests/test_litellm/proxy/common_utils/test_load_config_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_load_config_utils.py
@@ -93,11 +93,6 @@ class TestGetFileContentsFromS3:
 
 
 class TestBucketConfigIncludes:
-    """`include:` directives in a bucket-hosted config.yaml (LIT-6982).
-
-    They used to be dropped silently: the proxy booted with the root config applied and everything
-    the included objects declared missing, with nothing logged.
-    """
 
     @staticmethod
     def _bucket(objects):
@@ -161,7 +156,6 @@ class TestBucketConfigIncludes:
 
     @pytest.mark.asyncio
     async def test_a_nested_include_resolves_against_the_object_that_declares_it(self):
-        """A nested `include` names a neighbour of the object declaring it, not of the root config."""
         merged = await resolve_bucket_includes(
             config={"include": ["shared/models.yaml"]},
             object_key="configs/config.yaml",
@@ -265,8 +259,8 @@ class TestBucketConfigIncludes:
             "lit6982/model_config.yaml": {"model_list": [{"model_name": "included-model"}]},
         }
         monkeypatch.setattr(
-            "litellm.proxy.common_utils.load_config_utils.get_file_contents_from_s3",
-            lambda bucket_name, object_key: objects.get(object_key),
+            "litellm.proxy.common_utils.load_config_utils.s3_object_reader",
+            lambda bucket_name: objects.get,
         )
 
         config = await get_config_from_bucket(
@@ -279,21 +273,72 @@ class TestBucketConfigIncludes:
         }
 
     @pytest.mark.asyncio
-    async def test_the_blocking_s3_read_runs_off_the_event_loop_thread(self, monkeypatch):
+    async def test_the_blocking_s3_work_runs_off_the_event_loop_thread(self, monkeypatch):
         loop_thread = threading.current_thread()
-        read_threads = []
+        threads = []
 
-        def record_thread(bucket_name, object_key):
-            read_threads.append(threading.current_thread())
-            return {"model_list": [{"model_name": "a-model"}]}
+        def build_reader(bucket_name):
+            threads.append(threading.current_thread())
 
-        monkeypatch.setattr(
-            "litellm.proxy.common_utils.load_config_utils.get_file_contents_from_s3", record_thread
-        )
+            def read(object_key):
+                threads.append(threading.current_thread())
+                return {"model_list": [{"model_name": "a-model"}]}
+
+            return read
+
+        monkeypatch.setattr("litellm.proxy.common_utils.load_config_utils.s3_object_reader", build_reader)
 
         await get_config_from_bucket(bucket_type="s3", bucket_name="litellm-configs", object_key="config.yaml")
 
-        assert read_threads and loop_thread not in read_threads
+        assert len(threads) == 2 and loop_thread not in threads
+
+    @pytest.mark.asyncio
+    async def test_one_s3_client_serves_the_whole_include_tree(self, monkeypatch):
+        objects = {
+            "lit6982/config.yaml": {"include": ["model_config.yaml"]},
+            "lit6982/model_config.yaml": {"model_list": [{"model_name": "included-model"}]},
+        }
+        readers = []
+
+        def build_reader(bucket_name):
+            requested = []
+            readers.append(requested)
+
+            def read(object_key):
+                requested.append(object_key)
+                return objects.get(object_key)
+
+            return read
+
+        monkeypatch.setattr("litellm.proxy.common_utils.load_config_utils.s3_object_reader", build_reader)
+
+        await get_config_from_bucket(
+            bucket_type="s3", bucket_name="litellm-configs", object_key="lit6982/config.yaml"
+        )
+
+        assert readers == [["lit6982/config.yaml", "lit6982/model_config.yaml"]]
+
+    @pytest.mark.asyncio
+    async def test_an_empty_included_object_merges_as_an_empty_config(self, monkeypatch):
+        objects = {
+            "lit6982/config.yaml": "include:\n  - empty.yaml\nmodel_list:\n  - model_name: only-model\n",
+            "lit6982/empty.yaml": "",
+        }
+
+        class FakeGCSBucket:
+            async def download_gcs_object(self, object_key):
+                return objects[object_key].encode("utf-8")
+
+        monkeypatch.setattr(
+            "litellm.proxy.common_utils.load_config_utils.gcs_config_bucket",
+            lambda bucket_name: FakeGCSBucket(),
+        )
+
+        config = await get_config_from_bucket(
+            bucket_type="gcs", bucket_name="litellm-configs", object_key="lit6982/config.yaml"
+        )
+
+        assert config == {"model_list": [{"model_name": "only-model"}]}
 
     @pytest.mark.asyncio
     async def test_get_config_from_bucket_merges_includes_over_gcs(self, monkeypatch):
@@ -336,8 +381,8 @@ class TestBucketConfigIncludes:
     @pytest.mark.asyncio
     async def test_get_config_from_bucket_returns_none_when_the_root_object_is_missing(self, monkeypatch):
         monkeypatch.setattr(
-            "litellm.proxy.common_utils.load_config_utils.get_file_contents_from_s3",
-            lambda bucket_name, object_key: None,
+            "litellm.proxy.common_utils.load_config_utils.s3_object_reader",
+            lambda bucket_name: (lambda object_key: None),
         )
 
         assert (

--- a/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
+++ b/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
@@ -8,6 +8,7 @@ Pins covered:
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import re
@@ -716,7 +717,7 @@ async def test_ProxyConfig__process_includes_merges_files(tmp_path):
     inc.write_text("model_list:\n  - model_name: gpt-4\n")
     pc = ProxyConfig()
     cfg = {"include": ["models.yaml"], "model_list": [], "litellm_settings": {}}
-    result = await pc._process_includes(cfg, base_dir=str(tmp_path))
+    result = await pc._process_includes(cfg, config_file_path=str(tmp_path / "config.yaml"))
     assert result == {
         "model_list": [{"model_name": "gpt-4"}],
         "litellm_settings": {},
@@ -727,15 +728,70 @@ async def test_ProxyConfig__process_includes_merges_files(tmp_path):
 async def test_ProxyConfig__process_includes_missing_file_raises(tmp_path):
     pc = ProxyConfig()
     with pytest.raises(FileNotFoundError):
-        await pc._process_includes({"include": ["nope.yaml"]}, base_dir=str(tmp_path))
+        await pc._process_includes({"include": ["nope.yaml"]}, config_file_path=str(tmp_path / "config.yaml"))
 
 
 @pytest.mark.asyncio
 async def test_ProxyConfig__process_includes_follows_nested_includes(tmp_path):
     (tmp_path / "models.yaml").write_text("include:\n  - more_models.yaml\nmodel_list:\n  - model_name: first\n")
     (tmp_path / "more_models.yaml").write_text("model_list:\n  - model_name: second\n")
-    result = await ProxyConfig()._process_includes({"include": ["models.yaml"]}, base_dir=str(tmp_path))
+    result = await ProxyConfig()._process_includes(
+        {"include": ["models.yaml"]}, config_file_path=str(tmp_path / "config.yaml")
+    )
     assert result == {"model_list": [{"model_name": "first"}, {"model_name": "second"}]}
+
+
+@pytest.mark.asyncio
+async def test_ProxyConfig__process_includes_resolves_a_nested_include_next_to_its_own_file(tmp_path):
+    """A nested `include` names a sibling of the file that declares it, not of the root config."""
+    (tmp_path / "shared").mkdir()
+    (tmp_path / "shared" / "models.yaml").write_text(
+        "include:\n  - more_models.yaml\nmodel_list:\n  - model_name: first\n"
+    )
+    (tmp_path / "shared" / "more_models.yaml").write_text("model_list:\n  - model_name: second\n")
+    (tmp_path / "more_models.yaml").write_text("model_list:\n  - model_name: wrong-directory\n")
+
+    result = await ProxyConfig()._process_includes(
+        {"include": ["shared/models.yaml"]}, config_file_path=str(tmp_path / "config.yaml")
+    )
+
+    assert result == {"model_list": [{"model_name": "first"}, {"model_name": "second"}]}
+
+
+@pytest.mark.asyncio
+async def test_ProxyConfig__process_includes_merges_a_shared_file_once(tmp_path):
+    (tmp_path / "shared.yaml").write_text("model_list:\n  - model_name: shared\n")
+    (tmp_path / "a.yaml").write_text("include:\n  - shared.yaml\n")
+    (tmp_path / "b.yaml").write_text("include:\n  - ./shared.yaml\n")
+
+    result = await ProxyConfig()._process_includes(
+        {"include": ["a.yaml", "b.yaml"]}, config_file_path=str(tmp_path / "config.yaml")
+    )
+
+    assert result == {"model_list": [{"model_name": "shared"}]}
+
+
+@pytest.mark.asyncio
+async def test_ProxyConfig__process_includes_names_the_file_when_it_is_not_a_mapping(tmp_path):
+    (tmp_path / "models.yaml").write_text("- model_name: gpt-4\n")
+
+    with pytest.raises(ValueError, match=re.escape(str(tmp_path / "models.yaml"))):
+        await ProxyConfig()._process_includes(
+            {"include": ["models.yaml"]}, config_file_path=str(tmp_path / "config.yaml")
+        )
+
+
+@pytest.mark.asyncio
+async def test_ProxyConfig__process_includes_terminates_on_a_cycle(tmp_path):
+    (tmp_path / "a.yaml").write_text("include:\n  - b.yaml\nmodel_list:\n  - model_name: from-a\n")
+    (tmp_path / "b.yaml").write_text("include:\n  - a.yaml\nmodel_list:\n  - model_name: from-b\n")
+
+    result = await asyncio.wait_for(
+        ProxyConfig()._process_includes({"include": ["a.yaml"]}, config_file_path=str(tmp_path / "config.yaml")),
+        timeout=10,
+    )
+
+    assert result == {"model_list": [{"model_name": "from-a"}, {"model_name": "from-b"}]}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
+++ b/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import os
 import re
 from types import SimpleNamespace
@@ -770,6 +771,29 @@ async def test_ProxyConfig__process_includes_still_reads_a_nested_include_left_b
     )
 
     assert result == {"model_list": [{"model_name": "first"}, {"model_name": "second"}]}
+
+
+@pytest.mark.asyncio
+async def test_ProxyConfig__process_includes_names_both_files_when_a_nested_include_matches_two(tmp_path, caplog):
+    (tmp_path / "shared").mkdir()
+    (tmp_path / "shared" / "models.yaml").write_text(
+        "include:\n  - more_models.yaml\nmodel_list:\n  - model_name: first\n"
+    )
+    (tmp_path / "shared" / "more_models.yaml").write_text("model_list:\n  - model_name: next-to-the-declaring-file\n")
+    (tmp_path / "more_models.yaml").write_text("model_list:\n  - model_name: next-to-the-root-config\n")
+
+    with caplog.at_level(logging.WARNING, logger="LiteLLM Proxy"):
+        result = await ProxyConfig()._process_includes(
+            {"include": ["shared/models.yaml"]}, config_file_path=str(tmp_path / "config.yaml")
+        )
+
+    assert result == {"model_list": [{"model_name": "first"}, {"model_name": "next-to-the-declaring-file"}]}
+    assert [
+        record
+        for record in caplog.records
+        if str(tmp_path / "shared" / "more_models.yaml") in record.getMessage()
+        and str(tmp_path / "more_models.yaml") in record.getMessage()
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
+++ b/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
@@ -710,22 +710,32 @@ async def test_ProxyConfig__get_config_from_file_missing_path_raises():
 # ---------------------------------------------------------------------------
 
 
-def test_ProxyConfig__process_includes_merges_files(tmp_path):
+@pytest.mark.asyncio
+async def test_ProxyConfig__process_includes_merges_files(tmp_path):
     inc = tmp_path / "models.yaml"
     inc.write_text("model_list:\n  - model_name: gpt-4\n")
     pc = ProxyConfig()
     cfg = {"include": ["models.yaml"], "model_list": [], "litellm_settings": {}}
-    result = pc._process_includes(cfg, base_dir=str(tmp_path))
+    result = await pc._process_includes(cfg, base_dir=str(tmp_path))
     assert result == {
         "model_list": [{"model_name": "gpt-4"}],
         "litellm_settings": {},
     }
 
 
-def test_ProxyConfig__process_includes_missing_file_raises(tmp_path):
+@pytest.mark.asyncio
+async def test_ProxyConfig__process_includes_missing_file_raises(tmp_path):
     pc = ProxyConfig()
     with pytest.raises(FileNotFoundError):
-        pc._process_includes({"include": ["nope.yaml"]}, base_dir=str(tmp_path))
+        await pc._process_includes({"include": ["nope.yaml"]}, base_dir=str(tmp_path))
+
+
+@pytest.mark.asyncio
+async def test_ProxyConfig__process_includes_follows_nested_includes(tmp_path):
+    (tmp_path / "models.yaml").write_text("include:\n  - more_models.yaml\nmodel_list:\n  - model_name: first\n")
+    (tmp_path / "more_models.yaml").write_text("model_list:\n  - model_name: second\n")
+    result = await ProxyConfig()._process_includes({"include": ["models.yaml"]}, base_dir=str(tmp_path))
+    assert result == {"model_list": [{"model_name": "first"}, {"model_name": "second"}]}
 
 
 # ---------------------------------------------------------------------------
@@ -1040,6 +1050,32 @@ async def test_ProxyConfig_get_config_loads_from_file(tmp_path, monkeypatch):
         "general_settings": {},
         "litellm_settings": {},
     }
+
+
+@pytest.mark.asyncio
+async def test_ProxyConfig_get_config_from_a_bucket_merges_includes(monkeypatch):
+    """A bucket-hosted config.yaml used to drop its `include:` entries silently (LIT-6982)."""
+    objects = {
+        "lit6982/config.yaml": {
+            "include": ["model_config.yaml"],
+            "general_settings": {"master_key": "sk-1234"},
+        },
+        "lit6982/model_config.yaml": {"model_list": [{"model_name": "included-model"}]},
+    }
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", None)
+    monkeypatch.setattr("litellm.proxy.proxy_server.store_model_in_db", False)
+    monkeypatch.setattr(
+        "litellm.proxy.common_utils.load_config_utils.get_file_contents_from_s3",
+        lambda bucket_name, object_key: objects.get(object_key),
+    )
+    monkeypatch.setenv("LITELLM_CONFIG_BUCKET_NAME", "litellm-configs")
+    monkeypatch.setenv("LITELLM_CONFIG_BUCKET_OBJECT_KEY", "lit6982/config.yaml")
+    monkeypatch.setenv("LITELLM_CONFIG_BUCKET_TYPE", "s3")
+
+    cfg = await ProxyConfig().get_config()
+
+    assert cfg["model_list"] == [{"model_name": "included-model"}]
+    assert "include" not in cfg
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
+++ b/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
@@ -743,13 +743,27 @@ async def test_ProxyConfig__process_includes_follows_nested_includes(tmp_path):
 
 @pytest.mark.asyncio
 async def test_ProxyConfig__process_includes_resolves_a_nested_include_next_to_its_own_file(tmp_path):
-    """A nested `include` names a sibling of the file that declares it, not of the root config."""
     (tmp_path / "shared").mkdir()
     (tmp_path / "shared" / "models.yaml").write_text(
         "include:\n  - more_models.yaml\nmodel_list:\n  - model_name: first\n"
     )
     (tmp_path / "shared" / "more_models.yaml").write_text("model_list:\n  - model_name: second\n")
     (tmp_path / "more_models.yaml").write_text("model_list:\n  - model_name: wrong-directory\n")
+
+    result = await ProxyConfig()._process_includes(
+        {"include": ["shared/models.yaml"]}, config_file_path=str(tmp_path / "config.yaml")
+    )
+
+    assert result == {"model_list": [{"model_name": "first"}, {"model_name": "second"}]}
+
+
+@pytest.mark.asyncio
+async def test_ProxyConfig__process_includes_still_reads_a_nested_include_left_beside_the_root_config(tmp_path):
+    (tmp_path / "shared").mkdir()
+    (tmp_path / "shared" / "models.yaml").write_text(
+        "include:\n  - more_models.yaml\nmodel_list:\n  - model_name: first\n"
+    )
+    (tmp_path / "more_models.yaml").write_text("model_list:\n  - model_name: second\n")
 
     result = await ProxyConfig()._process_includes(
         {"include": ["shared/models.yaml"]}, config_file_path=str(tmp_path / "config.yaml")
@@ -1110,7 +1124,6 @@ async def test_ProxyConfig_get_config_loads_from_file(tmp_path, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_ProxyConfig_get_config_from_a_bucket_merges_includes(monkeypatch):
-    """A bucket-hosted config.yaml used to drop its `include:` entries silently (LIT-6982)."""
     objects = {
         "lit6982/config.yaml": {
             "include": ["model_config.yaml"],
@@ -1121,8 +1134,8 @@ async def test_ProxyConfig_get_config_from_a_bucket_merges_includes(monkeypatch)
     monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", None)
     monkeypatch.setattr("litellm.proxy.proxy_server.store_model_in_db", False)
     monkeypatch.setattr(
-        "litellm.proxy.common_utils.load_config_utils.get_file_contents_from_s3",
-        lambda bucket_name, object_key: objects.get(object_key),
+        "litellm.proxy.common_utils.load_config_utils.s3_object_reader",
+        lambda bucket_name: objects.get,
     )
     monkeypatch.setenv("LITELLM_CONFIG_BUCKET_NAME", "litellm-configs")
     monkeypatch.setenv("LITELLM_CONFIG_BUCKET_OBJECT_KEY", "lit6982/config.yaml")


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bucket-hosted configs ignored every `include:` entry
- Models behind an include never loaded, with no error
- A missing included file was skipped silently too

How it solves it:

- Bucket configs now run the same include merge as disk
- Include entries resolve relative to the config's prefix
- An include that cannot be read now fails boot loudly

## User Flow

Before: an operator whose proxy config lives in a GCS or S3 bucket and pulls its model list in with `include:` gets a proxy that serves no models at all

1. They put `config.yaml` and `model_config.yaml` in the bucket, where `config.yaml` opens with an `include:` block naming `model_config.yaml`
2. They start the proxy with `LITELLM_CONFIG_BUCKET_NAME`, `LITELLM_CONFIG_BUCKET_OBJECT_KEY` and `LITELLM_CONFIG_BUCKET_TYPE` pointed at that object, and it comes up clean
3. The rest of that file clearly took effect: `GET https://litellm-domain/v1/models` with no key returns `401`, so the master key set in the same config is live
4. The same `GET https://litellm-domain/v1/models` with the master key returns `{"data":[],"object":"list"}`
5. `POST https://litellm-domain/v1/chat/completions` with a model defined in the included file returns `400` and "Invalid model name passed in model=..."
6. Nothing in the startup log names the included file or any of its models, so there is no hint the include was dropped
7. Pointing that include at an object that isn't in the bucket changes nothing: the proxy still starts clean and still serves nothing

After: the same operator gets every model from every included file, and an include the proxy can't read stops the boot instead of quietly shrinking the list

1. They put the same two files in the bucket the same way
2. They start the proxy with the same three environment variables, and it comes up clean
3. `GET https://litellm-domain/v1/models` with no key still returns `401`
4. The same `GET https://litellm-domain/v1/models` with the master key now lists every model, including ones reached through an include inside an included file and ones named with a leading `/` for an object at the bucket root
5. `POST https://litellm-domain/v1/chat/completions` against any of those models returns a real completion
6. Pointing an include at an object that isn't in the bucket now stops the boot with an error naming the exact object key it looked for, so nothing serves traffic on a half-loaded config

## Relevant issues

## Linear ticket

Resolves LIT-6982

Resolves LIT-6998

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup. A real S3 bucket holds a config split across four objects, one reached through an include inside an included file and one through an absolute key at the bucket root, plus a second config whose include points at nothing:

```
$ aws s3 ls s3://litellm-lit6982-config-qa --recursive
2026-09-06 00:30:28        155 lit6982-full/config.yaml
2026-09-06 01:04:26        185 lit6982-full/model_config.yaml
2026-09-06 01:04:29        143 lit6982-full/nested/nested_models.yaml
2026-09-06 00:30:31         80 lit6982-missing/config.yaml
2026-09-06 01:04:28        144 shared/lit6982_extra_models.yaml

$ for k in lit6982-full/config.yaml lit6982-full/model_config.yaml lit6982-full/nested/nested_models.yaml \
           shared/lit6982_extra_models.yaml lit6982-missing/config.yaml; do
    echo "===== $k ====="
    aws s3 cp s3://litellm-lit6982-config-qa/$k -
  done
===== lit6982-full/config.yaml =====
include:
  - model_config.yaml
  - /shared/lit6982_extra_models.yaml

general_settings:
  master_key: sk-lit6982-qa

litellm_settings:
  drop_params: true
===== lit6982-full/model_config.yaml =====
include:
  - nested/nested_models.yaml

model_list:
  - model_name: lit6982-included-model
    litellm_params:
      model: openai/gpt-5.4-mini
      api_key: os.environ/OPENAI_API_KEY
===== lit6982-full/nested/nested_models.yaml =====
model_list:
  - model_name: lit6982-nested-model
    litellm_params:
      model: openai/gpt-5.4-mini
      api_key: os.environ/OPENAI_API_KEY
===== shared/lit6982_extra_models.yaml =====
model_list:
  - model_name: lit6982-rootkey-model
    litellm_params:
      model: openai/gpt-5.4-mini
      api_key: os.environ/OPENAI_API_KEY
===== lit6982-missing/config.yaml =====
include:
  - does_not_exist.yaml

general_settings:
  master_key: sk-lit6982-qa
```

Every proxy below is booted the same way, with two uvicorn workers so each one loads the config from the bucket on its own the way separate pods do:

```
export LITELLM_CONFIG_BUCKET_NAME=litellm-lit6982-config-qa
export LITELLM_CONFIG_BUCKET_TYPE=s3
export LITELLM_CONFIG_BUCKET_OBJECT_KEY=<the config object>
python litellm/proxy/proxy_cli.py --port <port> --num_workers 2 --detailed_debug
```

### Before (41048684581a71a102e6cb3b296d01c0b5f2240a)

#### Config with includes

1. The checkout this leg runs from is the merge base, not the branch

   ```
   $ PYTHONPATH=<merge-base checkout> python -c "import litellm; print(litellm.__file__)"
   /private/tmp/.../wt-base/litellm/__init__.py

   $ git -C <merge-base checkout> rev-parse HEAD
   41048684581a71a102e6cb3b296d01c0b5f2240a
   ```

2. Boot with `LITELLM_CONFIG_BUCKET_OBJECT_KEY=lit6982-full/config.yaml` on port 53949. Both workers start, no error

   ```
   INFO:     Started parent process [49244]
   INFO:     Started server process [49662]
   INFO:     Started server process [49661]
   ```

3. The master key from that same config is live, so the file did load

   ```
   $ curl -s -w '\nHTTP %{http_code}\n' http://127.0.0.1:53949/v1/models
   {"error":{"message":"Authentication Error, No api key passed in.","type":"auth_error","param":"None","code":"401"}}
   HTTP 401
   ```

4. The included models are nowhere

   ```
   $ curl -s http://127.0.0.1:53949/v1/models -H 'Authorization: Bearer sk-lit6982-qa'
   {"data":[],"object":"list"}
   ```

5. Calling any of them is rejected

   ```
   $ for m in lit6982-included-model lit6982-nested-model lit6982-rootkey-model; do
       curl -s http://127.0.0.1:53949/v1/chat/completions \
         -H 'Authorization: Bearer sk-lit6982-qa' -H 'Content-Type: application/json' \
         -d "{\"model\":\"$m\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with the single word: ok\"}]}" \
       | jq -c '{error: .error.message}'
     done
   {"error":"/chat/completions: Invalid model name passed in model=lit6982-included-model. Call `/v1/models` to view available models for your key."}
   {"error":"/chat/completions: Invalid model name passed in model=lit6982-nested-model. Call `/v1/models` to view available models for your key."}
   {"error":"/chat/completions: Invalid model name passed in model=lit6982-rootkey-model. Call `/v1/models` to view available models for your key."}
   ```

#### Config whose include is missing

1. Boot with `LITELLM_CONFIG_BUCKET_OBJECT_KEY=lit6982-missing/config.yaml` on port 58497. Both workers start, no error, and nothing in the log names the include

   ```
   INFO:     Started parent process [61759]
   INFO:     Started server process [62231]
   INFO:     Started server process [62232]
   ```

2. The proxy serves normally and looks identical to the case above, so a broken include is indistinguishable from a config with no models

   ```
   $ curl -s -w '\nHTTP %{http_code}\n' http://127.0.0.1:58497/v1/models
   {"error":{"message":"Authentication Error, No api key passed in.","type":"auth_error","param":"None","code":"401"}}
   HTTP 401

   $ curl -s -w '\nHTTP %{http_code}\n' http://127.0.0.1:58497/v1/models -H 'Authorization: Bearer sk-lit6982-qa'
   {"data":[],"object":"list"}
   HTTP 200
   ```

### After (eca59aa90b9ea6b696040857bbc3b495e717ca84)

#### Config with includes

1. The checkout this leg runs from is the PR branch at its current tip

   ```
   $ PYTHONPATH=<branch checkout> python -c "import litellm; print(litellm.__file__)"
   /Users/mateo/Development/litellm-worktrees/lit6982/litellm/__init__.py

   $ git -C <branch checkout> rev-parse HEAD
   eca59aa90b9ea6b696040857bbc3b495e717ca84
   ```

2. Boot with `LITELLM_CONFIG_BUCKET_OBJECT_KEY=lit6982-full/config.yaml` on port 34298. Both workers start, no error

   ```
   INFO:     Started parent process [55571]
   INFO:     Started server process [55937]
   INFO:     Started server process [55949]
   ```

3. Same 401 without a key

   ```
   $ curl -s -w '\nHTTP %{http_code}\n' http://127.0.0.1:34298/v1/models
   {"error":{"message":"Authentication Error, No api key passed in.","type":"auth_error","param":"None","code":"401"}}
   HTTP 401
   ```

4. Every included model is there: the direct include, the include inside it, and the one named with a leading `/`

   ```
   $ curl -s http://127.0.0.1:34298/v1/models -H 'Authorization: Bearer sk-lit6982-qa'
   {"data":[{"id":"lit6982-included-model","object":"model","created":1677610602,"owned_by":"openai"},{"id":"lit6982-rootkey-model","object":"model","created":1677610602,"owned_by":"openai"},{"id":"lit6982-nested-model","object":"model","created":1677610602,"owned_by":"openai"}],"object":"list"}
   ```

5. All three answer a real request against OpenAI

   ```
   $ for m in lit6982-included-model lit6982-nested-model lit6982-rootkey-model; do
       curl -s http://127.0.0.1:34298/v1/chat/completions \
         -H 'Authorization: Bearer sk-lit6982-qa' -H 'Content-Type: application/json' \
         -d "{\"model\":\"$m\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with the single word: ok\"}]}" \
       | jq -c '{id, model, content: .choices[0].message.content, total_tokens: .usage.total_tokens}'
     done
   {"id":"chatcmpl-EL4WCilXtk7EbC42Kpg1vnwqa5jMa","model":"lit6982-included-model","content":"ok","total_tokens":17}
   {"id":"chatcmpl-EL4WCh2E64WeXKV7Vy97bCbL1rQai","model":"lit6982-nested-model","content":"ok","total_tokens":17}
   {"id":"chatcmpl-EL4WDrWfo0H3IQUfypxRNRHcTSkwd","model":"lit6982-rootkey-model","content":"ok","total_tokens":17}
   ```

#### Config whose include is missing

1. Boot with `LITELLM_CONFIG_BUCKET_OBJECT_KEY=lit6982-missing/config.yaml` on port 56034. Both workers refuse to start and the error names the object key they looked for

   ```
       raise FileNotFoundError(
   FileNotFoundError: Included config could not be read from bucket: lit6982-missing/does_not_exist.yaml. The underlying bucket error is logged above.

   ERROR:    Application startup failed. Exiting.
   ERROR:    Application startup failed. Exiting.
   ```

2. Nothing serves on that port, so no traffic reaches a half-loaded config

   ```
   $ curl -s -m 10 -w 'HTTP %{http_code}\n' http://127.0.0.1:56034/v1/models -H 'Authorization: Bearer sk-lit6982-qa'
   HTTP 000
   ```

### Disk configs with a nested include, before and after

The bucket path and the plain `--config` path now share one resolver, so the same before/after pair runs on disk. Two fixtures, identical except that the second also has `sub/more.yaml`:

```
$ for d in incab_compat incab_sibling; do
    echo "########## $d"; (cd $d && find . -name '*.yaml' | sort | while read f; do echo "===== $f ====="; cat "$f"; done)
  done
########## incab_compat
===== ./config.yaml =====
include:
  - sub/models.yaml

general_settings:
  master_key: sk-lit6982-inc
===== ./more.yaml =====
model_list:
  - model_name: from-root-level-more
    litellm_params:
      model: openai/gpt-5.4-mini
      api_key: os.environ/OPENAI_API_KEY
===== ./sub/models.yaml =====
include:
  - more.yaml

model_list:
  - model_name: from-sub
    litellm_params:
      model: openai/gpt-5.4-mini
      api_key: os.environ/OPENAI_API_KEY
########## incab_sibling
(same three files, plus)
===== ./sub/more.yaml =====
model_list:
  - model_name: from-sub-level-more
    litellm_params:
      model: openai/gpt-5.4-mini
      api_key: os.environ/OPENAI_API_KEY
```

Each leg boots `python litellm/proxy/proxy_cli.py --config <fixture>/config.yaml --port <port> --num_workers 2 --detailed_debug` and asks the proxy what it loaded. Before runs at `41048684581a71a102e6cb3b296d01c0b5f2240a`, after at `eca59aa90b9ea6b696040857bbc3b495e717ca84`.

Only the file next to the root config exists (the back-compat case). Before, port 50788:

```
$ curl -s http://127.0.0.1:50788/v1/models -H 'Authorization: Bearer sk-lit6982-inc' | jq -c '[.data[].id]'
["from-sub","from-root-level-more"]
```

After, port 37757 at the tip. Same models, plus a warning naming the file it fell back to:

```
$ curl -s http://127.0.0.1:37757/v1/models -H 'Authorization: Bearer sk-lit6982-inc' | jq -c '[.data[].id]'
["from-sub","from-root-level-more"]

LiteLLM Proxy:WARNING: config_includes.py:25 - Config include 'more.yaml' declared in .../incab_compat/sub/models.yaml was not found next to it, so .../incab_compat/more.yaml was read instead. Move the included file next to the config that declares it.
```

Both files exist under that name (the case that changes). Before, port 35478, the entry resolves against the root config:

```
$ curl -s http://127.0.0.1:35478/v1/models -H 'Authorization: Bearer sk-lit6982-inc' | jq -c '[.data[].id]'
["from-sub","from-root-level-more"]
```

After, port 43431 at the tip, it resolves next to `sub/models.yaml`, which is the file that declares it, and names the file it skipped so the switch is not silent:

```
$ curl -s http://127.0.0.1:43431/v1/models -H 'Authorization: Bearer sk-lit6982-inc' | jq -c '[.data[].id]'
["from-sub","from-sub-level-more"]

LiteLLM Proxy:WARNING: config_includes.py:34 - Config include 'more.yaml' declared in .../incab_sibling/sub/models.yaml matches two files. .../incab_sibling/sub/more.yaml sits next to that config and was read, so .../incab_sibling/more.yaml was skipped. Rename one of the two to say which one you meant.
```

What the run noticed:

- Before the fix, a broken include looked exactly like an empty config
- Each worker reads the bucket itself, so all of them now fail together
- GCS shares the merge but has its own client, which no live leg covered
- A nested disk include next to the root config still loads, with a warning
- Where two files match one include, the proxy names the one it skipped

## Type

🐛 Bug Fix

## Caveats (if any)

### Severe

- An include the proxy cannot read now stops the boot instead of being skipped. That is the point of the fix, but a typo, a deleted object, or a transient bucket error (throttling, a 5xx, expired credentials) turns a proxy that used to come up short into one that does not come up at all. There is no retry, every worker reads the bucket itself so they all fail together, and a restart during a bucket blip leaves nothing serving. The error names the object key it looked for and points at the bucket error logged with it
- An included file's `general_settings` replaces the root config's wholesale, so an include that sets any key there drops the root's `master_key`. This is the same rule `include:` has always had on disk, mirrored onto buckets on purpose; keep `general_settings` in one file

### High

- The live proof covers S3 and the plain on-disk config path, not GCS. Both bucket types run the same include merge, but the GCS client is GCS-only code that never ran against a real bucket. Closing this needs a GCS project the run can create a bucket in
- Every config load refetches the whole include tree, so a config split across N files costs 1+N bucket GETs where it used to cost 1. `get_config()` has 36 call sites, the config reconcile job calls it every 30 seconds per worker, and one caller, `GET /get/ui_theme_settings`, is deliberately unauthenticated, so anyone who can reach the proxy multiplies their request by the include count. Caching config reads is a separate change with its own staleness rules and is not in this PR

### Medium

- On disk, a nested `include:` entry now resolves next to the file that declares it rather than next to the root config. A file left next to the root config is still read, with a warning naming where it was found, and a config carrying both files under the same name reads the one next to the declaring file and warns naming both, so neither case is silent. A config written against the old rule keeps booting
- The same file included twice now merges once, so two team files both including a shared one contribute its `model_list` entries once instead of twice. That same guard is what stops two configs including each other from looping, so it cannot just be dropped
- Reading a config out of a GCS bucket no longer builds the GCS logging client, so it no longer needs an enterprise license and no longer starts a flush loop nobody cancels. Before this PR a proxy without a license got `None` back and died with the vague error this PR set out to replace, and each read leaked a task. GCS logging itself keeps its license gate
- Custom callbacks loaded from `gcs://<bucket>/...` now read from the bucket the URL names. They used to read from `GCS_BUCKET_NAME` whatever the URL said, which is the bug LIT-6998 reports, so a setup relying on the old behavior needs the two to agree
- Loud failure only holds at boot. The config reload path already catches everything `get_config()` raises, warns, and carries on with an empty config, so after boot a broken include is one warning line and the DB overlay wins. That path is untouched here, and a bigger include tree gives it more ways to trip
- The resolution rule is documented nowhere. An entry resolves against the file or object that declares it, and in a bucket a leading `/` means the bucket root, which matches disk but not what issue #10632 assumed. A docs follow-up is proposed

### Low

- Include fan-out is capped by Python's recursion limit. 800 entries resolve, 2000 raises `RecursionError` rather than a readable message
- Every bucket read failure surfaces as `FileNotFoundError`, so a 403 or a throttled GET reads as a missing object. The underlying cause is still logged, and a YAML syntax error now logs its own line naming the object
- The resolver raises rather than returning a failure value, matching how a bad config on disk already fails at boot

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
