### PR TITLE
fix(responses): keep cache breakpoints on requests that reach the Responses API

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -1057,7 +1057,10 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
                             verbose_logger.debug("Chat provider:   passthrough -> %s", item)
                         else:
                             # Default to input_text for unknown types
-                            converted = self._convert_content_str_to_input_text(str(item.get("text", item)), role)
+                            converted = with_prompt_cache_breakpoint(
+                                self._convert_content_str_to_input_text(str(item.get("text", item)), role),
+                                item.get("prompt_cache_breakpoint"),
+                            )
                             result.append(converted)
                             verbose_logger.debug("Chat provider:   unknown(%s) -> %s", original_type, converted)
             verbose_logger.debug("Chat provider: Final converted content: %s", result)

--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -23,6 +23,7 @@ from litellm import ModelResponse
 from litellm._logging import verbose_logger
 from litellm.litellm_core_utils.prompt_templates.common_utils import (
     responses_reasoning_item_from_thinking_blocks,
+    with_prompt_cache_breakpoint,
 )
 from litellm.llms.base_llm.base_model_iterator import BaseModelResponseIterator
 from litellm.llms.base_llm.bridges.completion_transformation import (
@@ -1003,16 +1004,22 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
                     # Handle multimodal content
                     original_type = item.get("type")
                     if original_type == "text":
-                        converted = self._convert_content_str_to_input_text(item.get("text", ""), role)
+                        converted = with_prompt_cache_breakpoint(
+                            self._convert_content_str_to_input_text(item.get("text", ""), role),
+                            item.get("prompt_cache_breakpoint"),
+                        )
                         result.append(converted)
                         verbose_logger.debug("Chat provider:   text -> %s", converted)
                     elif original_type == "image_url":
                         # Map to responses API image format
-                        converted = cast(
-                            dict,
-                            self._convert_content_to_responses_format_image(
-                                cast(ChatCompletionImageObject, item), role
+                        converted = with_prompt_cache_breakpoint(
+                            cast(
+                                dict,
+                                self._convert_content_to_responses_format_image(
+                                    cast(ChatCompletionImageObject, item), role
+                                ),
                             ),
+                            item.get("prompt_cache_breakpoint"),
                         )
                         result.append(converted)
                         verbose_logger.debug("Chat provider:   image_url -> %s", converted)
@@ -1024,8 +1031,11 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
                             result.append(converted)
                             verbose_logger.debug("Chat provider:   image -> %s", converted)
                         elif item_type == "file":
-                            converted = _input_file_from_file_value(
-                                cast("ChatCompletionFileObject", item).get("file"),  # cast-ok: type tag checked
+                            converted = with_prompt_cache_breakpoint(
+                                _input_file_from_file_value(
+                                    cast("ChatCompletionFileObject", item).get("file"),  # cast-ok: type tag checked
+                                ),
+                                item.get("prompt_cache_breakpoint"),
                             )
                             result.append(converted)
                             verbose_logger.debug("Chat provider:   file -> %s", converted)

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -437,6 +437,15 @@ def _resolve_responses_api_provider_config(
     return OpenAILikeResponsesConfig()
 
 
+def _responses_config_lookup_model(model: str, custom_llm_provider: str) -> str:
+    """The model id the dispatch hands the config lookup, with the routing prefixes off.
+
+    A config keyed on the model, such as bedrock_mantle reading its cost-map entry, misses on
+    the prefixed id, so every one of those models reads as having no native Responses support.
+    """
+    return _strip_responses_routing_prefix(model.removeprefix(f"{custom_llm_provider}/"))
+
+
 def _will_bridge_to_chat_completions(
     model: str, custom_llm_provider: str | None, use_chat_completions_api: bool, model_info: object
 ) -> bool:
@@ -452,7 +461,11 @@ def _will_bridge_to_chat_completions(
     if custom_llm_provider is None:
         return True
     return _bridges_to_chat_completions(
-        _resolve_responses_api_provider_config(normalized_model[0], custom_llm_provider, model_info),
+        _resolve_responses_api_provider_config(
+            _responses_config_lookup_model(normalized_model[0], custom_llm_provider),
+            custom_llm_provider,
+            model_info,
+        ),
         use_chat_completions_api or normalized_model[1],
     )
 

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -4015,3 +4015,38 @@ def test_convert_chat_completion_messages_to_responses_api_omits_absent_prompt_c
     response, _ = handler.convert_chat_completion_messages_to_responses_api(messages)
 
     assert all("prompt_cache_breakpoint" not in block for block in response[0]["content"])
+
+
+def test_convert_chat_completion_messages_to_responses_api_keeps_prompt_cache_breakpoint_on_unknown_block():
+    """A block type the bridge cannot map still has to keep the marker.
+
+    The hook marks the last block of the message it targets, so a message ending in a block this
+    bridge does not know falls through to the stringify path. Losing the marker there is the same
+    failure as losing it on a text block: the request goes out in explicit mode with nothing marked.
+    """
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        LiteLLMResponsesTransformationHandler,
+    )
+
+    handler = LiteLLMResponsesTransformationHandler()
+    breakpoint_marker = {"mode": "explicit"}
+
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "describe this"},
+                {
+                    "type": "input_audio",
+                    "input_audio": {"data": "Zm9v", "format": "wav"},
+                    "prompt_cache_breakpoint": breakpoint_marker,
+                },
+            ],
+        },
+    ]
+
+    response, _ = handler.convert_chat_completion_messages_to_responses_api(messages)
+
+    content = response[0]["content"]
+    assert [block["type"] for block in content] == ["input_text", "input_text"]
+    assert content[1]["prompt_cache_breakpoint"] == breakpoint_marker

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -3952,3 +3952,66 @@ def test_convert_chat_completion_messages_to_responses_api_tool_result_with_tool
 
     function_call_output = next(item for item in response if item.get("type") == "function_call_output")
     assert function_call_output["output"] == [{"type": "input_text", "text": "1 tool found"}]
+
+
+def test_convert_chat_completion_messages_to_responses_api_keeps_prompt_cache_breakpoint():
+    """The OpenAI-dialect cache marker has to survive the rebuild into Responses input blocks.
+
+    The cache-control hook marks the block it wants cached before the bridge runs, so dropping
+    the marker here sends `prompt_cache_options: {"mode": "explicit"}` with nothing marked, which
+    turns off the implicit caching the request would otherwise have gotten.
+    """
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        LiteLLMResponsesTransformationHandler,
+    )
+
+    handler = LiteLLMResponsesTransformationHandler()
+    breakpoint_marker = {"mode": "explicit"}
+
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "cache up to here", "prompt_cache_breakpoint": breakpoint_marker},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "https://example.com/image.png"},
+                    "prompt_cache_breakpoint": breakpoint_marker,
+                },
+                {
+                    "type": "file",
+                    "file": {"file_id": "file-abc123", "filename": "manual.pdf"},
+                    "prompt_cache_breakpoint": breakpoint_marker,
+                },
+            ],
+        },
+    ]
+
+    response, _ = handler.convert_chat_completion_messages_to_responses_api(messages)
+
+    content = response[0]["content"]
+    assert [block["type"] for block in content] == ["input_text", "input_image", "input_file"]
+    assert [block.get("prompt_cache_breakpoint") for block in content] == [breakpoint_marker] * 3
+
+
+def test_convert_chat_completion_messages_to_responses_api_omits_absent_prompt_cache_breakpoint():
+    """Unmarked blocks must not grow the key, or every request would look explicitly cached."""
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        LiteLLMResponsesTransformationHandler,
+    )
+
+    handler = LiteLLMResponsesTransformationHandler()
+
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "no caching here"},
+                {"type": "image_url", "image_url": {"url": "https://example.com/image.png"}},
+            ],
+        },
+    ]
+
+    response, _ = handler.convert_chat_completion_messages_to_responses_api(messages)
+
+    assert all("prompt_cache_breakpoint" not in block for block in response[0]["content"])

--- a/tests/test_litellm/responses/test_responses_prompt_management.py
+++ b/tests/test_litellm/responses/test_responses_prompt_management.py
@@ -428,7 +428,6 @@ class TestResponsesAPIPromptManagement:
         sent_input = mock_handler.call_args.kwargs["input"]
         assert "cache_control" not in sent_input[0]
 
-
     def test_all_non_message_input_items_remain_unchanged(self):
         reasoning_item = {
             "type": "reasoning",

--- a/tests/test_litellm/responses/test_responses_prompt_management.py
+++ b/tests/test_litellm/responses/test_responses_prompt_management.py
@@ -364,11 +364,16 @@ class TestResponsesAPIPromptManagement:
         assert sent_input[1] == reasoning_item
         assert sent_input[2]["id"] == "msg_1"
 
-    def test_native_responses_provider_places_role_targeted_cache_point(self):
+    @pytest.mark.parametrize(
+        "model",
+        ["bedrock_mantle/openai.gpt-5.6-sol", "bedrock_mantle/responses/openai.gpt-5.6-sol"],
+    )
+    def test_native_responses_provider_places_role_targeted_cache_point(self, model: str):
         """A provider serving Responses natively gets no second pass, so the point lands on this one.
 
         Handing a role-targeted point forward here sends it to the chat-completions bridge, which
         never runs for this request, and the call goes upstream with nothing marked for caching.
+        The ``responses/`` routing prefix reaches the same deployment, so it has to read the same way.
         """
         system_message = cast(AllMessageValues, {"role": "system", "content": "Analyze the request"})
         user_message = cast(AllMessageValues, {"role": "user", "content": "Check for security issues"})
@@ -389,7 +394,7 @@ class TestResponsesAPIPromptManagement:
 
             litellm.responses(
                 input=cast(ResponseInputParam, [system_message, user_message]),
-                model="bedrock_mantle/openai.gpt-5.6-sol",
+                model=model,
                 litellm_logging_obj=_make_hook_backed_logging_obj(),
                 cache_control_injection_points=[{"location": "message", "role": "system"}],
                 aws_region_name="us-east-1",

--- a/tests/test_litellm/responses/test_responses_prompt_management.py
+++ b/tests/test_litellm/responses/test_responses_prompt_management.py
@@ -82,6 +82,24 @@ def _patch_responses_dispatch():
     ]
 
 
+def _make_hook_backed_logging_obj() -> MagicMock:
+    """A logging object that runs the real cache-control hook, the way a configured proxy's does."""
+    hook = AnthropicCacheControlHook()
+    logging_obj = MagicMock()
+    logging_obj.__class__ = LiteLLMLoggingObj
+    logging_obj.should_run_prompt_management_hooks.return_value = True
+    logging_obj.get_chat_completion_prompt.side_effect = lambda **call: hook.get_chat_completion_prompt(
+        model=call["model"],
+        messages=call["messages"],
+        non_default_params=call["non_default_params"],
+        prompt_id=call["prompt_id"],
+        prompt_variables=call["prompt_variables"],
+        dynamic_callback_params={},
+    )
+    logging_obj.model_call_details = {}
+    return logging_obj
+
+
 def _make_cache_control_case() -> tuple[
     ResponseInputParam,
     list[AllMessageValues],
@@ -345,6 +363,71 @@ class TestResponsesAPIPromptManagement:
         assert sent_input[0]["cache_control"] == {"type": "ephemeral"}
         assert sent_input[1] == reasoning_item
         assert sent_input[2]["id"] == "msg_1"
+
+    def test_native_responses_provider_places_role_targeted_cache_point(self):
+        """A provider serving Responses natively gets no second pass, so the point lands on this one.
+
+        Handing a role-targeted point forward here sends it to the chat-completions bridge, which
+        never runs for this request, and the call goes upstream with nothing marked for caching.
+        """
+        system_message = cast(AllMessageValues, {"role": "system", "content": "Analyze the request"})
+        user_message = cast(AllMessageValues, {"role": "user", "content": "Check for security issues"})
+
+        with (
+            patch.object(
+                import_module("litellm.responses.mcp.litellm_proxy_mcp_handler").LiteLLM_Proxy_MCP_Handler,
+                "_should_use_litellm_mcp_gateway",
+                return_value=False,
+            ),
+            patch.object(
+                import_module("litellm.responses.main").base_llm_http_handler,
+                "response_api_handler",
+                return_value=MagicMock(),
+            ) as mock_handler,
+        ):
+            import litellm
+
+            litellm.responses(
+                input=cast(ResponseInputParam, [system_message, user_message]),
+                model="bedrock_mantle/openai.gpt-5.6-sol",
+                litellm_logging_obj=_make_hook_backed_logging_obj(),
+                cache_control_injection_points=[{"location": "message", "role": "system"}],
+                aws_region_name="us-east-1",
+            )
+
+        sent_input = mock_handler.call_args.kwargs["input"]
+        assert sent_input[0]["cache_control"] == {"type": "ephemeral"}
+
+    def test_bridged_responses_request_still_defers_role_targeted_cache_point(self):
+        """The bridge builds its own system message, so its own pass is the one that marks it."""
+        system_message = cast(AllMessageValues, {"role": "system", "content": "Analyze the request"})
+        user_message = cast(AllMessageValues, {"role": "user", "content": "Check for security issues"})
+
+        with (
+            patch.object(
+                import_module("litellm.responses.mcp.litellm_proxy_mcp_handler").LiteLLM_Proxy_MCP_Handler,
+                "_should_use_litellm_mcp_gateway",
+                return_value=False,
+            ),
+            patch.object(
+                import_module("litellm.responses.main").litellm_completion_transformation_handler,
+                "response_api_handler",
+                return_value=MagicMock(),
+            ) as mock_handler,
+        ):
+            import litellm
+
+            litellm.responses(
+                input=cast(ResponseInputParam, [system_message, user_message]),
+                model="openai/chat_completions/gpt-5.6",
+                litellm_logging_obj=_make_hook_backed_logging_obj(),
+                cache_control_injection_points=[{"location": "message", "role": "system"}],
+                api_key="fake-key",
+            )
+
+        sent_input = mock_handler.call_args.kwargs["input"]
+        assert "cache_control" not in sent_input[0]
+
 
     def test_all_non_message_input_items_remain_unchanged(self):
         reasoning_item = {


### PR DESCRIPTION
## TLDR

Problem this solves:

- Prompt caching over the Responses API returned zero cached tokens
- Marking a message switched implicit caching off without putting anything back
- Requests going straight to the Responses API were classified as bridged

How it solves it:

- The bridge keeps each block's cache breakpoint when rebuilding input
- The bridging check looks the config up with the dispatch's model id
- Five tests, three of which fail without the fix

## User Flow

Before: a developer turns on prompt caching for an OpenAI deployment served over the Responses API and their cached token count goes to zero

1. The proxy admin adds a deployment on `openai/responses/gpt-5.6-sol` and puts `cache_control_injection_points` with `location: message` and `role: system` on it
2. The developer sends POST https://litellm-domain/v1/chat/completions twice with the same ~8000 token system prompt and a one word user message
3. Both responses come back with `"prompt_tokens_details": {"cached_tokens": 0}`
4. They resend the same pair with the system prompt split into content blocks, and both responses still come back with `"cached_tokens": 0`
5. They point the same two requests at a copy of the deployment that has no injection point, and the second response comes back with `"cached_tokens": 8114`
6. So the deployment they configured for caching is the one that caches nothing, and https://litellm-domain/ui/?page=logs bills every request at the full prompt price

After: the same deployment reads its cached prefix on the second request

1. Same deployment and same `cache_control_injection_points` config
2. The developer sends the same two POST https://litellm-domain/v1/chat/completions requests
3. The first response comes back with `"cached_tokens": 0` and the second with `"cached_tokens": 8104`
4. The block-split system prompt caches too, and its second response comes back with `"cached_tokens": 8140`
5. The copy without an injection point still reports `"cached_tokens": 8114` on its second request, so the two deployments now agree
6. https://litellm-domain/ui/?page=logs shows the cached prompt tokens on both

## Relevant issues

None filed on GitHub

Related, and independent of this one: #38729 teaches the cache-control hook to read the OpenAI dialect off a deployment's own cost-map entry. That PR decides which models are eligible for an OpenAI-dialect breakpoint, this one makes sure the breakpoint survives the trip to the wire. They touch different files and either can land first. The routing half here is a prerequisite rather than a user-visible win on its own: a `bedrock_mantle` deployment needs both PRs before it caches end to end, and until #38729 lands its injection point still goes out in the Anthropic dialect, which the Responses transform strips

## Linear ticket

Resolves LIT-7108

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup. Two proxies on the same box, one booted at the merge base and one at the PR tip, each from its own worktree and virtualenv, both with 2 uvicorn workers, both hitting the real provider APIs:

```bash
python litellm/proxy/proxy_cli.py --config qa_config.yaml --port <port> --num_workers 2
```

```yaml
model_list:
  - model_name: cache-bridge
    litellm_params:
      model: openai/responses/gpt-5.6-sol
      api_key: os.environ/OPENAI_API_KEY
      cache_control_injection_points:
        - location: message
          role: system
  - model_name: cache-bridge-nopoints
    litellm_params:
      model: openai/responses/gpt-5.6-sol
      api_key: os.environ/OPENAI_API_KEY
  - model_name: mantle-points
    litellm_params:
      model: bedrock_mantle/openai.gpt-5.6-sol
      aws_region_name: us-east-1
      cache_control_injection_points:
        - location: message
          role: system

litellm_settings:
  drop_params: true
```

Each case sends the same ~8000 token system prompt twice and reads the cached token count back. Every case picks its own nonce, so no case reads a prefix another case already cached:

```bash
#!/bin/zsh
# usage: proof_case.sh <port> <chat|messages|responses> <model_name>
PORT=$1
API=$2
MODEL=$3
NONCE=$(python3 -c 'import random; print(random.randint(10**9, 10**10))')
python3 - "$MODEL" "$NONCE" "$API" <<'PY'
import json, sys
model, nonce, api = sys.argv[1], sys.argv[2], sys.argv[3]
system = f'cache probe {nonce} line. ' * 900
user = 'reply with the single word ok'
body = ({'model': model, 'max_tokens': 16,
         'messages': [{'role': 'system', 'content': system}, {'role': 'user', 'content': user}]}
        if api == 'chat' else
        {'model': model, 'max_tokens': 16, 'system': system,
         'messages': [{'role': 'user', 'content': user}]}
        if api == 'messages' else
        {'model': model, 'max_output_tokens': 16,
         'input': [{'role': 'system', 'content': system}, {'role': 'user', 'content': user}]})
json.dump(body, open('/tmp/probe.json', 'w'))
PY
case $API in
  chat)      ROUTE=/v1/chat/completions; FILTER='{prompt_tokens: .usage.prompt_tokens, cached_tokens: .usage.prompt_tokens_details.cached_tokens}' ;;
  messages)  ROUTE=/v1/messages;         FILTER='{prompt_tokens: .usage.input_tokens, cached_tokens: .usage.cache_read_input_tokens}' ;;
  responses) ROUTE=/v1/responses;        FILTER='{prompt_tokens: .usage.input_tokens, cached_tokens: .usage.input_tokens_details.cached_tokens}' ;;
esac
for i in 1 2; do
  printf 'call %s -> ' $i
  curl -s http://127.0.0.1:$PORT$ROUTE \
    -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
    -d @/tmp/probe.json | jq -c "$FILTER"
  sleep 2
done
```

One more case sends that same system prompt as a list of content blocks, ending in a block type the bridge has no mapping for, which is where the injection point's marker lands:

```bash
#!/bin/zsh
# usage: proof_block_case.sh <port> <model_name>
PORT=$1
MODEL=$2
NONCE=$(python3 -c 'import random; print(random.randint(10**9, 10**10))')
python3 - "$MODEL" "$NONCE" <<'PY'
import json, sys
model, nonce = sys.argv[1], sys.argv[2]
system = [{'type': 'text', 'text': f'cache probe {nonce} line. ' * 900},
          {'type': 'input_audio', 'input_audio': {'data': 'Zm9v', 'format': 'wav'}}]
body = {'model': model, 'max_tokens': 16,
        'messages': [{'role': 'system', 'content': system},
                     {'role': 'user', 'content': 'reply with the single word ok'}]}
json.dump(body, open('/tmp/probe_block.json', 'w'))
PY
for i in 1 2; do
  printf 'call %s -> ' $i
  curl -s http://127.0.0.1:$PORT/v1/chat/completions \
    -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
    -d @/tmp/probe_block.json | jq -c '{prompt_tokens: .usage.prompt_tokens, cached_tokens: .usage.prompt_tokens_details.cached_tokens}'
  sleep 2
done
```

One more case sends that same system prompt on a streaming request, which is how most clients call this, and reads the usage chunk at the end of the stream:

```bash
#!/bin/zsh
# usage: proof_stream_case.sh <port> <model_name>
PORT=$1
MODEL=$2
NONCE=$(python3 -c 'import random; print(random.randint(10**9, 10**10))')
python3 - "$MODEL" "$NONCE" <<'PY'
import json, sys
model, nonce = sys.argv[1], sys.argv[2]
body = {'model': model, 'max_tokens': 16, 'stream': True,
        'stream_options': {'include_usage': True},
        'messages': [{'role': 'system', 'content': f'cache probe {nonce} line. ' * 900},
                     {'role': 'user', 'content': 'reply with the single word ok'}]}
json.dump(body, open('/tmp/probe_stream.json', 'w'))
PY
for i in 1 2; do
  printf 'call %s -> ' $i
  curl -s -N http://127.0.0.1:$PORT/v1/chat/completions \
    -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
    -d @/tmp/probe_stream.json \
  | grep '"usage"' | tail -1 | sed 's/^data: //' \
  | jq -c '{prompt_tokens: .usage.prompt_tokens, cached_tokens: .usage.prompt_tokens_details.cached_tokens}'
  sleep 2
done
```

### Before (b9f5cd6)

#### /v1/chat/completions on a deployment with a cache_control_injection_point

1. `zsh proof_case.sh 21314 chat cache-bridge`
2. Neither call caches, so the caching config bought nothing:

```
call 1 -> {"prompt_tokens":8117,"cached_tokens":0}
call 2 -> {"prompt_tokens":8117,"cached_tokens":0}
```

#### /v1/chat/completions with the system prompt as content blocks

1. `zsh proof_block_case.sh 21314 cache-bridge`
2. Neither call caches here either:

```
call 1 -> {"prompt_tokens":8153,"cached_tokens":0}
call 2 -> {"prompt_tokens":8153,"cached_tokens":0}
```

#### /v1/chat/completions streaming, same deployment

1. `zsh proof_stream_case.sh 21314 cache-bridge`
2. A streaming request caches nothing either:

```
call 1 -> {"prompt_tokens":8117,"cached_tokens":0}
call 2 -> {"prompt_tokens":8117,"cached_tokens":0}
```

#### /v1/chat/completions control, same model with no injection point

1. `zsh proof_case.sh 21314 chat cache-bridge-nopoints`
2. The second call caches, which is the behavior the configured deployment lost:

```
call 1 -> {"prompt_tokens":8117,"cached_tokens":0}
call 2 -> {"prompt_tokens":8117,"cached_tokens":8114}
```

#### /v1/messages on the same bridged deployment

1. `zsh proof_case.sh 21314 messages cache-bridge`
2. The second call caches:

```
call 1 -> {"prompt_tokens":13,"cached_tokens":null}
call 2 -> {"prompt_tokens":13,"cached_tokens":8104}
```

#### /v1/responses on a Bedrock deployment with a cache_control_injection_point

1. `zsh proof_case.sh 21314 responses mantle-points`
2. A control rather than a symptom: this deployment already caches implicitly, and it reads the same on both sides because its injection point goes out in the Anthropic dialect that the Responses transform strips, which is what #38729 changes:

```
call 1 -> {"prompt_tokens":8117,"cached_tokens":0}
call 2 -> {"prompt_tokens":8117,"cached_tokens":8115}
```

### After (07083bd)

#### /v1/chat/completions on a deployment with a cache_control_injection_point

1. `zsh proof_case.sh 35885 chat cache-bridge`
2. The second call now reads the cached prefix:

```
call 1 -> {"prompt_tokens":8117,"cached_tokens":0}
call 2 -> {"prompt_tokens":8117,"cached_tokens":8104}
```

#### /v1/chat/completions with the system prompt as content blocks

1. `zsh proof_block_case.sh 35885 cache-bridge`
2. The block the bridge cannot map keeps its marker, so this caches now too:

```
call 1 -> {"prompt_tokens":8153,"cached_tokens":0}
call 2 -> {"prompt_tokens":8153,"cached_tokens":8140}
```

#### /v1/chat/completions streaming, same deployment

1. `zsh proof_stream_case.sh 35885 cache-bridge`
2. The streaming request caches on its second call too:

```
call 1 -> {"prompt_tokens":8117,"cached_tokens":0}
call 2 -> {"prompt_tokens":8117,"cached_tokens":8104}
```

#### /v1/chat/completions control, same model with no injection point

1. `zsh proof_case.sh 35885 chat cache-bridge-nopoints`
2. Unchanged, so the fix did not move the deployment that was already fine:

```
call 1 -> {"prompt_tokens":8117,"cached_tokens":0}
call 2 -> {"prompt_tokens":8117,"cached_tokens":8114}
```

#### /v1/messages on the same bridged deployment

1. `zsh proof_case.sh 35885 messages cache-bridge`
2. Unchanged:

```
call 1 -> {"prompt_tokens":13,"cached_tokens":null}
call 2 -> {"prompt_tokens":13,"cached_tokens":8104}
```

#### /v1/responses on a Bedrock deployment with a cache_control_injection_point

1. `zsh proof_case.sh 35885 responses mantle-points`
2. Unchanged after the routing classification change, as expected while #38729 is still open:

```
call 1 -> {"prompt_tokens":8117,"cached_tokens":0}
call 2 -> {"prompt_tokens":8117,"cached_tokens":8115}
```

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- Explicit mode caches only up to the marked message, so marking a short system prompt still loses most of the prefix
  - the proof above sends a long system prompt and a one word user message, which is the shape where the marked prefix is nearly the whole request
  - flip the shape and the win goes away: with a 3 word system prompt and a ~8000 token user message, `cache-bridge` reads `{"prompt_tokens":8120,"cached_tokens":0}` on both calls while `cache-bridge-nopoints` reads 8117 cached on its second
  - the merge base reads exactly the same 0 and 0, so this PR neither causes it nor fixes it, which is why it sits here rather than in the proof section
  - the mechanism is that the hook sets `prompt_cache_options` to explicit as soon as it adds a breakpoint, and explicit mode drops OpenAI's own breakpoint at the end of the prompt, so nothing after the marked message is cacheable
  - the knob is the injection point: the same tip proxy with `role: user` instead of `role: system` reads `{"cached_tokens":8117}` on the second call of that same tail heavy pair, so an operator should mark the message that carries the bulk
- `input_audio` and `encrypted_content` are real Responses input types that the bridge has no mapping for
  - both fall to the stringify branch and go out as `input_text` holding the repr of the whole block, so an audio block's base64 is billed as prose and the model never hears it
  - that is the branch this PR teaches to keep the marker, so the cache point now survives, but the block itself is still mangled
  - adding them to the passthrough list is a separate change: the two APIs do not agree on the block's inner shape, so it needs its own conversion and its own proof

### Low

- The `image` branch emits a type the Responses API rejects
  - `{"type": "input_image", **item}` lets the spread put `"type": "image"` back, and OpenAI answers 400 `Invalid value: 'image'`
  - reordering the spread is not the fix either, since the Anthropic style `source` block still has no `image_url` to hand over, so this needs a real conversion rather than a one word edit
  - it is the one branch of this converter left without a marker, and it is left alone deliberately: marking a block the API refuses would not change any request
- The routing half has no live `github_copilot` leg
  - its only live case, `mantle-points` over `/v1/responses`, reads 0 then 8115 on both proxies, which is why the table calls it unchanged
  - running `_will_bridge_to_chat_completions` over the 132 cost-map entries with `mode: responses`, in both their plain and their `responses/` prefixed form, 22 of the 264 ids change classification: 20 `bedrock_mantle` and 2 `github_copilot`, every one of them from bridged to native
  - a flip only decides whether the cache-control hook defers a role targeted point to the bridge: both call sites feed nothing but `_prompt_management_sees_a_provisional_message_list`, which sets one kwarg for the length of the hook, so it cannot move headers, params, streaming, cost tracking or error shapes
  - a point placed at this layer instead of deferred cannot reach the wire either, since `GithubCopilotResponsesAPIConfig` and `BedrockMantleResponsesAPIConfig` both end in `OpenAIResponsesAPIConfig.transform_responses_api_request`, which strips `cache_control` off the input
  - what is left is that no `github_copilot` deployment was exercised live, and a user visible leg there is not reachable until #38729 lands
- The marker now reaches every provider that bridges to the Responses API, not just OpenAI
  - 132 cost-map entries across nine provider families carry `mode: responses`, and a hand written `prompt_cache_breakpoint` that used to be dropped now goes out to all of them
  - a bridged `/v1/chat/completions` call on `xai/grok-4.20-multi-agent` answered normally both with and without the injection point, and `perplexity/openai/gpt-5.2` answered with it, so nothing broke in the two checked, but only OpenAI was measured for cached tokens end to end
- The bridging check still reads different deployment metadata than the dispatch
  - both prediction call sites pass `kwargs.get("model_info")` while the dispatch passes `deployment_model_info`
  - this PR lines up the model id and leaves that argument mismatched, so a prompt manager that swaps the provider can still make the prediction disagree with what happens

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
- [x] Mutation tested: seven mutants over the two changed files, every one killed by the new tests

- [x] 833f4393ce31c0d5cc7d2e43d88db80272f00284 passes /live-pr-risk
- [x] bf16fba1ba57df445c123113c33d176307df1774 passes /live-pr-risk
- [x] 07083bd4f62c90bc6b87a9d1deca7ed049e35391 passes /live-pr-risk
