### PR TITLE
fix(e2e): match the sidebar's trailing slash and label UI PRs for CI

### DIFF
--- a/.github/workflows/label-ui-prs-for-ci.yml
+++ b/.github/workflows/label-ui-prs-for-ci.yml
@@ -2,6 +2,8 @@
 # request that never gets the label never runs e2e_ui_testing or e2e_ui_testing_server_root_path.
 # A push to an already-labelled pull request fires no label event and therefore builds nothing,
 # so every new head removes the label and adds it back rather than leaving the existing one alone.
+# Drafts are left alone, which is the way to work on a UI branch without paying for a pipeline
+# on every push; marking the pull request ready for review labels it.
 name: Label UI PRs for CircleCI
 
 on:
@@ -10,6 +12,7 @@ on:
       - opened
       - reopened
       - synchronize
+      - ready_for_review
     paths:
       - "ui/**"
       - "tests/e2e/ui/**"
@@ -24,7 +27,9 @@ jobs:
   add-run-ci-label:
     name: add run-ci label
     # Fork pull requests get a read-only token, so labelling them stays manual.
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository
+      && github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -36,5 +41,11 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
+          set -euo pipefail
           gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label run-ci || true
+          labels="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json labels --jq '.labels[].name')"
+          if printf '%s\n' "$labels" | grep -Fxq run-ci; then
+            echo "run-ci is still on the pull request, so adding it back fires no label event and CircleCI builds nothing"
+            exit 1
+          fi
           gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label run-ci

--- a/.github/workflows/label-ui-prs-for-ci.yml
+++ b/.github/workflows/label-ui-prs-for-ci.yml
@@ -1,5 +1,7 @@
 # CircleCI builds this repo's pull request branches off the run-ci label event, so a UI pull
 # request that never gets the label never runs e2e_ui_testing or e2e_ui_testing_server_root_path.
+# A push to an already-labelled pull request fires no label event and therefore builds nothing,
+# so every new head removes the label and adds it back rather than leaving the existing one alone.
 name: Label UI PRs for CircleCI
 
 on:
@@ -28,10 +30,11 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - name: Add run-ci
-        if: ${{ !contains(github.event.pull_request.labels.*.name, 'run-ci') }}
+      - name: Re-add run-ci
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
-        run: gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label run-ci
+        run: |
+          gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label run-ci || true
+          gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label run-ci

--- a/.github/workflows/label-ui-prs-for-ci.yml
+++ b/.github/workflows/label-ui-prs-for-ci.yml
@@ -1,0 +1,37 @@
+# CircleCI builds this repo's pull request branches off the run-ci label event, so a UI pull
+# request that never gets the label never runs e2e_ui_testing or e2e_ui_testing_server_root_path.
+name: Label UI PRs for CircleCI
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    paths:
+      - "ui/**"
+      - "tests/e2e/ui/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  add-run-ci-label:
+    name: add run-ci label
+    # Fork pull requests get a read-only token, so labelling them stays manual.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Add run-ci
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'run-ci') }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label run-ci

--- a/.github/workflows/label-ui-prs-for-ci.yml
+++ b/.github/workflows/label-ui-prs-for-ci.yml
@@ -49,3 +49,13 @@ jobs:
             exit 1
           fi
           gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label run-ci
+
+      # A job that dies between the removal and the re-add would leave the pull request with no
+      # label and so no CircleCI, which is the failure this workflow exists to prevent.
+      - name: Put run-ci back if this run did not finish
+        if: failure() || cancelled()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label run-ci

--- a/tests/e2e/ui/fixtures/migratedPages.ts
+++ b/tests/e2e/ui/fixtures/migratedPages.ts
@@ -8,7 +8,8 @@
  *       server-root-path mount:  SERVER_ROOT_PATH=/<root> npm run e2e:migration:root
  *   - navigation specs that assert per-page URLs (tests/navigation/sidebar.spec.ts)
  *
- * Keep this in lockstep with MIGRATED_PAGES in src/utils/migratedPages.ts.
+ * Route segments must match LEGACY_PAGE_ROUTES in src/app/(dashboard)/legacyPageRoutes.ts,
+ * which is where the dashboard maps legacy page ids to their App Router routes.
  */
 export const MIGRATED_E2E_PAGES: Record<string, string> = {
   "api-keys": "api-keys",

--- a/tests/e2e/ui/tests/migration/migratedPages.spec.ts
+++ b/tests/e2e/ui/tests/migration/migratedPages.spec.ts
@@ -29,12 +29,13 @@ async function expectRendered(page: Page) {
 }
 
 /**
- * Click a migrated page's sidebar link. Migrated items render as <a href=".../ui/<segment>">;
- * nested ones live under collapsible groups whose children only render while the
- * group is open, so expand collapsed groups until the link is clickable.
+ * Click a migrated page's sidebar link. next.config.mjs sets trailingSlash, so Next renders these as
+ * <a href=".../ui/<segment>/">; match the unslashed form too, since it names the same route. Nested
+ * items live under collapsible groups whose children only render while the group is open, so expand
+ * collapsed groups until the link is clickable.
  */
 async function clickSidebar(page: Page, segment: string) {
-  const link = sidebar(page).locator(`a[href$="/ui/${segment}"]`).first();
+  const link = sidebar(page).locator(`a[href$="/ui/${segment}"], a[href$="/ui/${segment}/"]`).first();
   const collapsedGroups = sidebar(page).getByRole("button", { expanded: false });
   for (let i = 0; i < 8 && !(await link.isVisible().catch(() => false)); i++) {
     const stillCollapsed = await collapsedGroups.count();


### PR DESCRIPTION
## TLDR

Problem this solves:

- Every migrated-page e2e test fails since #39978 landed
- The left nav now renders links with a trailing slash
- UI pull requests keep merging with zero CircleCI runs

How it solves it:

- Match sidebar links with or without the trailing slash
- Add the `run-ci` label on every UI pull request push

## User Flow

### Before

A pull request that touches the dashboard's migrated pages either gets no CircleCI run at all, or gets one that goes red on 35 left-nav tests that have nothing to do with the change

1. Push a branch that edits a file under `ui/litellm-dashboard/`, then open a pull request against `litellm_internal_staging`
2. Open the pull request at https://github.com/BerriAI/litellm/pull/<number> and scroll to the checks list at the bottom
3. Only GitHub Actions checks are listed. Neither `ci/circleci: e2e_ui_testing` nor `ci/circleci: e2e_ui_testing_server_root_path` shows up, because CircleCI only builds the branch once somebody adds the `run-ci` label by hand, and nobody did
4. Ask a maintainer to add `run-ci` from the Labels menu on the right of the pull request page, and wait
5. Once the label lands, the two CircleCI checks appear and both turn red
6. Click Details on `ci/circleci: e2e_ui_testing` and read the summary at the end of the run: `35 failed, 104 passed`, every failure in the App Router migrated pages group
7. Open any one of them and see a 15 second timeout waiting to click a link in the left nav, in a part of the dashboard the change never went near
8. Push a commit to answer review feedback, then reload the checks list: it still shows the old run. The label is already on the pull request, so nothing new starts and the commit that will actually merge is never tested
9. Spend the afternoon proving the red is not yours, then merge past it anyway

### After

The same pull request gets its CircleCI run on its own, both e2e_ui jobs come back green, and every later commit gets its own run

1. Push a branch that edits a file under `ui/litellm-dashboard/`, then open a pull request against `litellm_internal_staging`
2. Open the pull request at https://github.com/BerriAI/litellm/pull/<number> and scroll to the checks list at the bottom
3. The `run-ci` label appears on the pull request within about a minute, and `ci/circleci: e2e_ui_testing` plus `ci/circleci: e2e_ui_testing_server_root_path` show up in the checks list without anyone asking
4. Both CircleCI checks turn green
5. Click Details on `ci/circleci: e2e_ui_testing` and read the summary at the end of the run: `139 passed`, including all 35 App Router migrated pages tests
6. Push a commit to answer review feedback and watch the label come off and go straight back on, so both checks start over on the new commit
7. Merge knowing the migrated dashboard pages were exercised on the exact commit that is merging

## Relevant issues

## Linear ticket

Resolves LIT-7109

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup for the local half. This is the same stack the two CircleCI jobs build: a live proxy with a database, the mock LLM, and the dashboard served from the proxy.

```
cd tests/e2e/ui
export E2E_KEEP_ALIVE=1 PROXY_PORT=4731 POSTGRES_PORT=5731 MOCK_LLM_PORT=8731
export PROXY_BASE_URL=http://127.0.0.1:4731
./run_e2e.sh
```

The trailing slash is the dashboard's own canonical URL, so the page is right and the spec was wrong:

```
$ for p in /ui/organizations/ /ui/organizations /ui/api-keys/ /ui/api-keys; do
    printf '%-22s ' "$p"
    curl -s -o /dev/null -w '%{http_code} %{redirect_url}\n' "http://127.0.0.1:4731$p"
  done
/ui/organizations/     200
/ui/organizations      307 http://127.0.0.1:4731/ui/organizations/
/ui/api-keys/          200
/ui/api-keys           307 http://127.0.0.1:4731/ui/api-keys/
```

### Before (4104868458; the CircleCI builds ran at 2427dc7373)

#### One migrated page, locally

1. Put the merge base's spec back and run the organizations journey on its own

   ```
   $ git show 4104868458:tests/e2e/ui/tests/migration/migratedPages.spec.ts > tests/e2e/ui/tests/migration/migratedPages.spec.ts
   $ npx playwright test tests/migration/migratedPages.spec.ts -g "organizations: sidebar nav"
   ```

2. It times out clicking the left-nav link

   ```
   TimeoutError: locator.click: Timeout 15000ms exceeded.
   Call log:
     - waiting for getByRole('complementary').locator('a[href$="/ui/organizations"]').first()

     43 |     await expect(collapsedGroups).toHaveCount(stillCollapsed - 1);
     44 |   }
   > 45 |   await link.click();
        |              ^
       at clickSidebar (tests/e2e/ui/tests/migration/migratedPages.spec.ts:45:14)

     1 failed
   ```

#### The full suite, in CircleCI

1. Open the last `e2e_ui_testing` run on a branch that got the `run-ci` label, https://circleci.com/gh/BerriAI/litellm/2162458. That build ran on `litellm_lit_6898_openai_wif_routes` at `2427dc7373`, an unrelated pull request that touches no UI code and carries the merge base's copy of the spec byte for byte

2. Read the end of the Playwright step

   ```
   Running 139 tests using 1 worker
     35 failed
     104 passed (42.1m)
   ```

3. Every one of the 35 is the same timeout, once per migrated page

   ```
     - waiting for getByRole('complementary').locator('a[href$="/ui/api-keys"]').first()
     - waiting for getByRole('complementary').locator('a[href$="/ui/organizations"]').first()
     - waiting for getByRole('complementary').locator('a[href$="/ui/teams"]').first()
     ... 32 more, one per migrated page
   ```

4. The page snapshot the run saves alongside the failure lists every one of those links with a trailing slash, so the links were on screen the whole time

   ```
   /ui/api-keys/  /ui/organizations/  /ui/teams/  /ui/logs/  /ui/usage/  ... 30 more
   ```

#### The migrated pages under a server root path, in CircleCI

1. Open the `e2e_ui_testing_server_root_path` job from that same `2427dc7373` run, https://circleci.com/gh/BerriAI/litellm/2162476, and read the end of its migration smoke step

   ```
   Running 35 tests using 1 worker
     35 failed
   ```

2. The list names the same 34 migrated pages plus the direct round trip

   ```
     [chromium] › tests/migration/migratedPages.spec.ts:52:9 › App Router migrated pages › organizations: sidebar nav, reload, and round-trip via the api-keys landing
     [chromium] › tests/migration/migratedPages.spec.ts:83:7 › App Router migrated pages › navigates directly between two migrated pages
     ... 33 more, one per migrated page
   ```

#### A second commit on the same pull request

1. Take a pull request that already carries `run-ci` and push another commit to it, for example `52f6347cda` on https://github.com/BerriAI/litellm/pull/39966, pushed at 04:20:21Z

2. Ask CircleCI what it built on that branch and get nothing back for that commit

   ```
   $ curl -s -H "Circle-Token: $CIRCLECI_PAT" \
       "https://circleci.com/api/v1.1/project/gh/BerriAI/litellm/tree/litellm_lit_6898_openai_wif_routes?limit=100&shallow=true" \
     | jq -r '.[].vcs_revision[0:10]' | sort | uniq -c
     14 9db819d039
     43 4aa9a2b27b
     43 2427dc7373
   ```

3. Every one of those three commits was built right after somebody took the label off and put it back by hand, and `52f6347cda` never got that, so it never got a build

   ```
   $ gh api repos/BerriAI/litellm/issues/39966/events \
       -q '.[] | select(.event | test("labeled")) | "\(.event) \(.label.name) \(.created_at)"'
   unlabeled run-ci 2026-09-06T03:33:23Z
   labeled   run-ci 2026-09-06T03:33:25Z
   unlabeled run-ci 2026-09-06T05:46:38Z
   labeled   run-ci 2026-09-06T05:46:40Z
   ```

### After (5989cb1b65)

#### One migrated page, locally (b656d35d70)

This leg ran at the spec fix itself. Everything pushed since (`c2820b814f`, `6aab498938`, `b0a0aa8d55`, `5989cb1b65`) only adds `.github/workflows/label-ui-prs-for-ci.yml` and rewrites one comment in `tests/e2e/ui/fixtures/migratedPages.ts`, so none of it can change what Playwright does here. `git diff b656d35d70..HEAD --stat` shows those two files and nothing else

1. Same command, on this branch's spec

   ```
   $ npx playwright test tests/migration/migratedPages.spec.ts -g "organizations: sidebar nav"
   ```

2. It passes

   ```
   Running 1 test using 1 worker
     1 passed (8.3s)
   ```

#### The full suite, in CircleCI

1. This pull request touches `tests/e2e/ui/`, so it picks up the `run-ci` label on its own and both jobs run on it. Open `ci/circleci: e2e_ui_testing` at https://circleci.com/gh/BerriAI/litellm/2164283 and read the end of the Playwright step

2. All 139 pass, so the 35 that were red are green and the 104 that were already green stayed green

   ```
   Running 139 tests using 1 worker
     139 passed (12.0m)
   ```

#### The migrated pages under a server root path, in CircleCI

1. Open the `e2e_ui_testing_server_root_path` job on this branch, https://circleci.com/gh/BerriAI/litellm/2164265, and read the end of its migration smoke step

2. All 35 pass

   ```
   Running 35 tests using 1 worker
     35 passed (1.6m)
   ```

#### Every later commit on the same pull request

1. Push `6aab498938`, then `b0a0aa8d55`, then `5989cb1b65` on top of `c2820b814f` on this pull request, with the label already on it each time. The last of those three touches only `.github/workflows/`, and it still qualifies, because a `pull_request` workflow's `paths:` filter is matched against the whole pull request diff rather than the individual push

2. The label comes off and goes back on by itself within three seconds, once per push, with no human in the loop

   ```
   $ gh api repos/BerriAI/litellm/issues/40033/events --paginate \
       -q '.[] | select(.event | test("labeled")) | "\(.event) \(.label.name) \(.created_at) \(.actor.login)"'
   labeled   run-ci 2026-09-06T08:32:24Z github-actions[bot]
   unlabeled run-ci 2026-09-06T08:42:26Z github-actions[bot]
   labeled   run-ci 2026-09-06T08:42:28Z github-actions[bot]
   unlabeled run-ci 2026-09-06T09:18:29Z github-actions[bot]
   labeled   run-ci 2026-09-06T09:18:32Z github-actions[bot]
   unlabeled run-ci 2026-09-06T10:03:30Z github-actions[bot]
   labeled   run-ci 2026-09-06T10:03:32Z github-actions[bot]
   ```

3. One workflow run per push, each built from this branch's own head, all green

   ```
   $ gh run list -R BerriAI/litellm --workflow=label-ui-prs-for-ci.yml --limit 5 \
       --json databaseId,headSha,conclusion,event \
       -q '.[] | "\(.databaseId) \(.headSha[0:10]) \(.event) \(.conclusion)"'
   34026348995 5989cb1b65 pull_request success
   34024275007 b0a0aa8d55 pull_request success
   34022521020 6aab498938 pull_request success
   34022070479 c2820b814f pull_request success
   ```

4. Inside the last run, the label came back before the guard checked, so the guard passed, and the recovery step added in `5989cb1b65` stayed out of the way

   ```
   $ gh api repos/BerriAI/litellm/actions/runs/34026348995/jobs \
       --jq '.jobs[] | "JOB \(.name) \(.conclusion)", (.steps[] | "   \(.number) \(.name) -> \(.conclusion)")'
   JOB add run-ci label success
      1 Set up job -> success
      2 Re-add run-ci -> success
      3 Put run-ci back if this run did not finish -> skipped
      4 Complete job -> success
   ```

5. CircleCI builds each new commit straight after, both e2e_ui jobs included

   ```
   $ curl -s -H "Circle-Token: $CIRCLECI_PAT" \
       "https://circleci.com/api/v1.1/project/gh/BerriAI/litellm/tree/litellm_lit_7109_ui_e2e_sidebar_href?limit=100&shallow=true" \
     | jq -r '.[] | select(.workflows.job_name | startswith("e2e_ui")) | "\(.vcs_revision[0:10]) \(.workflows.job_name) \(.build_num)"'
   5989cb1b65 e2e_ui_testing              2164283
   5989cb1b65 e2e_ui_testing_server_root_path 2164265
   b0a0aa8d55 e2e_ui_testing_server_root_path 2163810
   b0a0aa8d55 e2e_ui_testing              2163787
   6aab498938 e2e_ui_testing              2163642
   6aab498938 e2e_ui_testing_server_root_path 2163641
   c2820b814f e2e_ui_testing              2163567
   c2820b814f e2e_ui_testing_server_root_path 2163566
   ```

## Type

🐛 Bug Fix

✅ Test

🚄 Infrastructure

## Caveats (if any)

### Severe

- A mixed UI plus backend pull request now runs the paid half of the CircleCI pipeline on every push
  - `run-ci` is what creates a pipeline, and a pipeline runs whichever jobs `skip_if_unrelated_changes` does not halt. 41 of the 43 jobs in `build_and_test` carry that filter, 39 of them on the default `backend` category, so a UI-only pull request halts everything except the two `e2e_ui` ones and the two that always run, `base_sdk_install` and `using_litellm_on_windows`
  - The paid jobs (`llm_translation_testing`, `image_gen_testing`, `audio_testing`, `agent_testing`, `ocr_testing`, `search_testing`, `e2e_openai_endpoints`) all carry the `backend` filter, so they halt on a UI-only change and run on a mixed one
  - Of the last 53 merged pull requests that touched `ui/` or `tests/e2e/ui/` (merged between 2026-09-03 and 2026-09-06), 35 were mixed, and 26 of those merged carrying no `run-ci` label and so no CircleCI at all. This is new spend rather than a restored default
  - This pull request is itself an example. It touches `.github/**`, so `classify_changes.sh` calls it backend and all seven of those jobs ran on it: `gh pr checks 40033 --json name,bucket` returns `pass` for `agent_testing`, `audio_testing`, `e2e_openai_endpoints`, `image_gen_testing`, `llm_translation_testing`, `ocr_testing`, and `search_testing`
  - The label also stops being an opt-in. A maintainer who takes `run-ci` off to stop a pipeline gets it back on the next push, and the only way out is putting the pull request back in draft, which this workflow skips

### Medium

- Neither `e2e_ui` job gates a merge, so a red one still merges
  - The `guard-internal-staging` ruleset lists 33 required checks and every one is a GitHub Actions context: `gh api repos/BerriAI/litellm/rulesets/17360296` returns no `ci/circleci:` context at all
  - So this makes the run happen and makes it visible, which is what the ticket asked for, but a UI pull request with 35 red migration tests can still merge the way #39978 did. Requiring the context would deadlock every pull request that never gets a pipeline, so that is a separate call
- #40026 fixes the same spec a stronger way and would conflict with this one
  - It was opened at 07:40Z, is still a draft, and rewrites `MIGRATED_E2E_PAGES` into a struct that `sidebar.spec.ts` reads, replacing href matching with accessible link names plus a destination-content assertion
  - Both are mergeable against staging right now. Whichever lands second needs a rebase, and the part that gets dropped is the one-line selector widening here. The labelling workflow has no counterpart in #40026
- The migration suite covers 34 of the 35 migrated pages
  - `cost-optimization` has an App Router page, a left-nav entry, and a `LEGACY_PAGE_ROUTES` mapping, and no entry in `tests/e2e/ui/fixtures/migratedPages.ts`, so nothing exercises it
  - Adding it belongs with #40026's rewrite of that fixture rather than here, since both PRs would otherwise edit the same lines
- A green labelling run is not proof that CircleCI built anything
  - `build_and_test` filters on `main` and `/litellm_.*/`, so a same-repo UI branch named anything else gets the label, a passing workflow run, and no `e2e_ui` checks, with nothing saying so
  - Widening that filter touches `.circleci/**` and changes which branches every job in the pipeline runs on, so it is not a change to fold in here
- Fork pull requests still have to be labelled by hand
  - `GITHUB_TOKEN` is read-only on a fork, and auto-labelling one would run untrusted code against CircleCI's provider credentials, so the label stays a maintainer's call
- Nothing pins the shape of the sidebar's hrefs
  - `leftnav.test.tsx` asserts them under jsdom, where `trailingSlash` does not apply, so the same drift could land again. A revert to a raw anchor would cost a full page load and a redirect on every sidebar click and still pass
  - Asserting one exact shape is what made this spec brittle in the first place, so the fix widens the selector instead of tightening the unit test
- This one needs two approvals, not one
  - It touches `.github/**`, which the `Protect Sensitive Files` ruleset covers, so a one-line test fix for red CI carries the sensitive-files bar

### Low

- The label check reads back through a different API than the one that removed the label
  - An unlucky read-after-write would fail the job on a pull request whose removal actually landed. `5989cb1b65` adds a step that runs on failure or cancellation and puts `run-ci` back, so the window where a pull request sits unlabelled narrows to a runner that dies hard enough to skip that step, and what is left is a red job on a workflow that gates no merge
- The recovery step can trip the guard on a run that is racing it
  - `cancel-in-progress` is on, so two pushes close together cancel the first run. If that run's recovery step puts `run-ci` back while the second run sits between its own removal and its read-back, the second run sees the label present and exits 1
  - The label ends up on either way, and the `labeled` event fires against the branch's current head, so CircleCI still builds the newer commit. What it costs is a red run on `add run-ci label`, which is not one of the 33 checks `guard-internal-staging` requires
- The local before and after legs did not run on a live proxy pair built from each side's full tree
  - The before leg ran at the merge base `4104868458` and the after leg at `b656d35d70`, both against a real dashboard build, and the CircleCI legs cover the tip end to end. The CircleCI before leg borrowed a sibling branch at `2427dc7373` whose `tests/e2e/ui` tree and `ui/litellm-dashboard/` tree match the merge base apart from `schema.d.ts`, so its backend difference cannot move a sidebar href

## QA runbook

Prerequisites: a proxy on http://localhost:4000 with a database (`DATABASE_URL` set) and an admin login, since every one of these pages is admin-only. No provider credentials needed, the journeys never send a completion

- `tests/e2e/ui/tests/migration/migratedPages.spec.ts:53:9 › App Router migrated pages › organizations: sidebar nav, reload, and round-trip via the api-keys landing`, and the 33 sibling cases the same block generates, one per migrated page. Proves that clicking a migrated page in the left nav actually routes there, that the page survives a reload on its own URL, and that you can bounce to Virtual Keys and back
  - [ ] Open http://localhost:4000/ui/ and log in as admin, then dismiss the feedback popup if it shows
  - [ ] Click Organizations in the left nav, expanding the group it sits under if it is collapsed
  - [ ] Expect the address bar to read http://localhost:4000/ui/organizations/ with the organizations table on screen
  - [ ] Reload that URL and expect the same page again, not a 404 and not a bounce back to the keys page
  - [ ] Click Virtual Keys, expect http://localhost:4000/ui/api-keys/, then click Organizations again and expect http://localhost:4000/ui/organizations/ back
  - [ ] Repeat for any other page in the left nav, for example Teams at http://localhost:4000/ui/teams/ and Logs at http://localhost:4000/ui/logs/
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky
- `tests/e2e/ui/tests/migration/migratedPages.spec.ts:84:7 › App Router migrated pages › navigates directly between two migrated pages`. Proves that going from one migrated page straight to another keeps routing and rendering, without passing through the keys page in between
  - [ ] Open http://localhost:4000/ui/ and log in as admin
  - [ ] Click Virtual Keys, expect http://localhost:4000/ui/api-keys/
  - [ ] Click Models + Endpoints straight after, expect http://localhost:4000/ui/models-and-endpoints/ with the model list on screen
  - [ ] Click Virtual Keys again and expect http://localhost:4000/ui/api-keys/ back
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky
- The labelling half of this PR has no test of its own. Check it on this PR itself, which touches `tests/e2e/ui/`
  - [ ] Open this pull request and confirm the `run-ci` label is on it without anyone having added it by hand
  - [ ] Confirm `ci/circleci: e2e_ui_testing` and `ci/circleci: e2e_ui_testing_server_root_path` are in the checks list and green
  - [ ] Push an empty commit to this branch and confirm the label comes off and goes back on, and that both checks start again on the new commit
  - [ ] Open a pull request from a fork that touches `ui/` and confirm the label is not added, since a fork's token cannot write labels
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
