### PR TITLE
fix(ollama): read optional custom prompt template values with a default

### DIFF
--- a/litellm/llms/ollama/completion/transformation.py
+++ b/litellm/llms/ollama/completion/transformation.py
@@ -360,8 +360,8 @@ class OllamaConfig(BaseConfig):
             model_prompt_details: Final = custom_prompt_dict[model]
             ollama_prompt = custom_prompt(
                 role_dict=model_prompt_details["roles"],
-                initial_prompt_value=model_prompt_details["initial_prompt_value"],
-                final_prompt_value=model_prompt_details["final_prompt_value"],
+                initial_prompt_value=model_prompt_details.get("initial_prompt_value", ""),
+                final_prompt_value=model_prompt_details.get("final_prompt_value", ""),
                 messages=messages,
             )
         elif text_completion_request:  # handle `/completions` requests

--- a/tests/test_litellm/llms/ollama/test_ollama_completion_transformation.py
+++ b/tests/test_litellm/llms/ollama/test_ollama_completion_transformation.py
@@ -410,6 +410,61 @@ class TestOllamaConfig:
         assert result.choices[0]["finish_reason"] == "stop"
 
 
+class TestOllamaConfigTransformRequest:
+    def test_transform_request_custom_prompt_missing_initial_and_final_value(self):
+        """A custom prompt template that only sets `roles` (initial/final prompt
+        values omitted, as the docs say is allowed) must not raise KeyError."""
+        config = OllamaConfig()
+
+        litellm_params = {
+            "custom_prompt_dict": {
+                "llama2": {
+                    "roles": {
+                        "system": {"pre_message": "<<SYS>>\n", "post_message": "\n<</SYS>>\n"},
+                        "user": {"pre_message": "[INST] ", "post_message": " [/INST]"},
+                    }
+                }
+            }
+        }
+
+        result = config.transform_request(
+            model="llama2",
+            messages=[{"role": "user", "content": "hello"}],
+            optional_params={},
+            litellm_params=litellm_params,
+            headers={},
+        )
+
+        assert "[INST] hello [/INST]" in result["prompt"]
+
+    def test_transform_request_custom_prompt_with_initial_and_final_value(self):
+        """Existing behavior: explicit initial/final prompt values still apply."""
+        config = OllamaConfig()
+
+        litellm_params = {
+            "custom_prompt_dict": {
+                "llama2": {
+                    "roles": {
+                        "user": {"pre_message": "[INST] ", "post_message": " [/INST]"},
+                    },
+                    "initial_prompt_value": "<start>",
+                    "final_prompt_value": "<end>",
+                }
+            }
+        }
+
+        result = config.transform_request(
+            model="llama2",
+            messages=[{"role": "user", "content": "hello"}],
+            optional_params={},
+            litellm_params=litellm_params,
+            headers={},
+        )
+
+        assert result["prompt"].startswith("<start>")
+        assert result["prompt"].endswith("<end>")
+
+
 class TestOllamaTextCompletionResponseIterator:
     def test_chunk_parser_with_thinking_field(self):
         """Test that chunks with 'thinking' field and empty 'response' are handled correctly."""


### PR DESCRIPTION
## TLDR

Problem this solves:

- Ollama crashes with a misleading `APIConnectionError` when a custom prompt template omits either optional value
- The error blames "connection" while no connection was ever attempted

How it solves it:

- Read both optional keys with `.get(key, "")`, matching what `custom_prompt()` already defaults to
- Matches how other providers (e.g. `sagemaker`) already read the same optional keys

## Relevant issues

Fixes #39759

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, `python -m pytest tests/test_litellm/llms/ollama/test_ollama_completion_transformation.py -v`
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

### Before (eeb7732fc)

1. `litellm.completion(model="ollama/llama2", messages=[...], roles={"system": {...}, "user": {...}})` — no `initial_prompt_value` or `final_prompt_value` passed
2. Raises `litellm.APIConnectionError: 'initial_prompt_value'` — no connection was ever attempted

### After (c0a7e1d50)

1. Same call as above
2. No longer raises on the missing keys; proceeds to the real network call and raises `OllamaException - [WinError 10061] No connection could be made because the target machine actively refused it` (there's no Ollama server running in this environment) — the correct, honestly-labeled error for what actually happened

## Type

🐛 Bug Fix
✅ Test

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
