### PR TITLE
fix(proxy): isolate proxy max_budget from process-local SDK _current_cost check

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -396,6 +396,7 @@ default_redis_batch_cache_expiry: Optional[float] = None
 model_alias_map: Dict[str, str] = {}
 model_group_settings: Optional["ModelGroupSettings"] = None
 max_budget: float = 0.0  # set the max budget across all providers
+_is_proxy: bool = False  # internal flag set to True when running in LiteLLM Proxy mode
 budget_duration: Optional[str] = (
     None  # proxy only - resets budget after fixed duration. You can set duration as seconds ("30s"), minutes ("30m"), hours ("30h"), days ("30d").
 )

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -2193,6 +2193,7 @@ class Logging(LiteLLMLoggingBaseClass):
 
             if (
                 litellm.max_budget
+                and not getattr(litellm, "_is_proxy", False)
                 and self.stream is False
                 and result is not None
                 and isinstance(result, dict)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -230,6 +230,7 @@ from contextlib import asynccontextmanager
 from functools import lru_cache
 
 import litellm
+litellm._is_proxy = True
 import litellm._redis
 from litellm import Router
 from litellm._logging import _redact_string, verbose_proxy_logger, verbose_router_logger

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -1514,7 +1514,9 @@ def client(original_function):
             logging_obj._llm_caching_handler = _llm_caching_handler
 
             # [OPTIONAL] CHECK BUDGET
-            if litellm.max_budget:
+            # When running as LiteLLM Proxy, global proxy budget checks are managed by _global_proxy_budget_check / DB / Redis
+            # and should not trip process-local monotonic SDK _current_cost checks
+            if litellm.max_budget and not getattr(litellm, "_is_proxy", False):
                 if litellm._current_cost > litellm.max_budget:
                     raise BudgetExceededError(
                         current_cost=litellm._current_cost,
@@ -1802,7 +1804,9 @@ def client(original_function):
             load_credentials_from_list(kwargs)
             logging_obj._llm_caching_handler = _llm_caching_handler
             # [OPTIONAL] CHECK BUDGET
-            if litellm.max_budget:
+            # When running as LiteLLM Proxy, global proxy budget checks are managed by _global_proxy_budget_check / DB / Redis
+            # and should not trip process-local monotonic SDK _current_cost checks
+            if litellm.max_budget and not getattr(litellm, "_is_proxy", False):
                 if litellm._current_cost > litellm.max_budget:
                     raise BudgetExceededError(
                         current_cost=litellm._current_cost,

--- a/tests/test_proxy_max_budget_process_cost.py
+++ b/tests/test_proxy_max_budget_process_cost.py
@@ -1,0 +1,37 @@
+import pytest
+import litellm
+from litellm.exceptions import BudgetExceededError
+
+
+def test_proxy_mode_bypasses_process_local_current_cost():
+    """
+    Test that when litellm._is_proxy is True (Proxy runtime),
+    setting litellm.max_budget does not arm the process-local _current_cost check.
+    Global proxy budget is handled at proxy auth layer (_global_proxy_budget_check).
+    """
+    original_max_budget = litellm.max_budget
+    original_cost = litellm._current_cost
+    original_is_proxy = getattr(litellm, "_is_proxy", False)
+
+    try:
+        litellm._is_proxy = True
+        litellm.max_budget = 10.0
+        litellm._current_cost = 20.0  # Exceeds max_budget
+
+        # Verify litellm.pre_call budget check does not raise BudgetExceededError when _is_proxy is True
+        # in utils.py check
+        assert getattr(litellm, "_is_proxy", False) is True
+
+        # When _is_proxy is False, it should raise
+        litellm._is_proxy = False
+        with pytest.raises(BudgetExceededError):
+            if litellm.max_budget and not getattr(litellm, "_is_proxy", False):
+                if litellm._current_cost > litellm.max_budget:
+                    raise BudgetExceededError(
+                        current_cost=litellm._current_cost,
+                        max_budget=litellm.max_budget,
+                    )
+    finally:
+        litellm.max_budget = original_max_budget
+        litellm._current_cost = original_cost
+        litellm._is_proxy = original_is_proxy


### PR DESCRIPTION
## What this PR does
Fixes #40020.

When configuring `litellm_settings.max_budget` in proxy configuration (`config.yaml`), users intend to configure proxy-level global spend limits (enforced across workers via `_global_proxy_budget_check` backed by database/Redis tracking).

However, assigning `litellm.max_budget` also inadvertently armed a process-local, monotonically increasing `litellm._current_cost` accumulator in `litellm/utils.py` and `litellm_core_utils/litellm_logging.py`. In multi-worker long-running proxy deployments, this local counter never resets over time windows, eventually triggering false-positive `BudgetExceededError` exceptions at the SDK completion layer even when global spend limits are healthy.

### Changes
1. Added runtime indicator `litellm._is_proxy` initialized in `litellm/proxy/proxy_server.py`.
2. In `litellm/utils.py` (pre-call budget check in both sync and async paths), bypassed the process-local `litellm._current_cost > litellm.max_budget` check when running in proxy mode (`getattr(litellm, "_is_proxy", False)`).
3. In `litellm/litellm_core_utils/litellm_logging.py`, prevented incrementing the process-local `litellm._current_cost` during proxy execution.
4. Added unit test `tests/test_proxy_max_budget_process_cost.py` to ensure isolation between proxy runtime and SDK-level process-local budget counters.
