### PR TITLE
fix(oci): report the real finish_reason and one id per streamed tool call

### DIFF
--- a/litellm/llms/oci/chat/cohere.py
+++ b/litellm/llms/oci/chat/cohere.py
@@ -235,7 +235,10 @@ def handle_cohere_response(
     model_response.created = int(datetime.datetime.now().timestamp())
 
     response_text: Final = cohere_response.chatResponse.text
-    finish_reason: Final = _normalize_oci_finish_reason(cohere_response.chatResponse.finishReason)
+    finish_reason: Final = _normalize_oci_finish_reason(
+        cohere_response.chatResponse.finishReason,
+        has_tool_calls=bool(cohere_response.chatResponse.toolCalls),
+    )
 
     tool_calls: list[dict[str, object]] | None = None
     if cohere_response.chatResponse.toolCalls:
@@ -361,7 +364,10 @@ def handle_cohere_stream_chunk(
             for i, tc in enumerate(cohere_tool_calls)
         ]
 
-    finish_reason: Final = _normalize_oci_finish_reason(typed_chunk.finishReason)
+    finish_reason: Final = _normalize_oci_finish_reason(
+        typed_chunk.finishReason,
+        has_tool_calls=bool(typed_chunk.toolCalls) or prior_tool_calls_emitted,
+    )
 
     return ModelResponseStream(
         choices=[

--- a/litellm/llms/oci/chat/generic.py
+++ b/litellm/llms/oci/chat/generic.py
@@ -8,6 +8,7 @@ parsing, and streaming chunk parsing for models served with
 
 import datetime
 import hashlib
+from types import MappingProxyType
 from typing import Any, Final
 
 import httpx
@@ -240,25 +241,33 @@ def adapt_tool_definition_to_oci_standard(tools: list[dict], vendor: OCIVendors)
     return new_tools
 
 
-def _normalize_oci_finish_reason(raw: str | None) -> str | None:
-    """Map an OCI-specific finish reason to its OpenAI-standard equivalent.
+_OCI_FINISH_REASONS: Final = MappingProxyType(
+    {
+        "COMPLETE": "stop",
+        "MAX_TOKENS": "length",
+        "TOOL_CALL": "tool_calls",
+        "TOOL_CALLS": "tool_calls",
+    }
+)
 
-    OCI emits ``COMPLETE`` / ``MAX_TOKENS`` / ``TOOL_CALL(S)`` plus a long tail
-    of error/cancel reasons (``ERROR``, ``ERROR_TOXIC``, ``ERROR_LIMIT``,
-    ``USER_CANCEL``, ``CONTENT_FILTERED``, ``CANCELLED``, ...). The OpenAI
-    spec only defines ``stop`` / ``length`` / ``tool_calls`` / ... — anything
-    else is collapsed to ``"stop"`` so downstream consumers switching on
-    ``finish_reason`` keep working. A ``None`` input passes through unchanged.
+_OPENAI_FINISH_REASONS: Final = frozenset({"stop", "length", "tool_calls", "content_filter", "function_call"})
+
+
+def _normalize_oci_finish_reason(raw: str | None, *, has_tool_calls: bool = False) -> str | None:
+    """Map an OCI finish reason to its OpenAI-standard equivalent.
+
+    OCI uses two vocabularies. Cohere sends ``COMPLETE`` / ``MAX_TOKENS`` /
+    ``TOOL_CALL(S)`` plus a long tail of error and cancel reasons, while GENERIC
+    already sends the OpenAI names and has to be passed through rather than
+    collapsed. Anything outside both sets becomes ``"stop"``, ``None`` stays
+    ``None`` so intermediate stream chunks stay open, and ``has_tool_calls``
+    upgrades ``stop`` to ``tool_calls`` for a Cohere tool turn, which OCI still
+    labels ``COMPLETE``.
     """
     if raw is None:
         return None
-    if raw == "COMPLETE":
-        return "stop"
-    if raw == "MAX_TOKENS":
-        return "length"
-    if raw in ("TOOL_CALL", "TOOL_CALLS"):
-        return "tool_calls"
-    return "stop"
+    normalized: Final = _OCI_FINISH_REASONS.get(raw, raw if raw in _OPENAI_FINISH_REASONS else "stop")
+    return "tool_calls" if has_tool_calls and normalized == "stop" else normalized
 
 
 def _synthesize_oci_tool_call_id(position: int, name: str, arguments: str) -> str:
@@ -341,7 +350,10 @@ def handle_generic_response(
         if response_message.toolCalls:
             message.tool_calls = adapt_tools_to_openai_standard(response_message.toolCalls)
 
-    model_response.choices[0].finish_reason = _normalize_oci_finish_reason(response_choice.finishReason)
+    model_response.choices[0].finish_reason = _normalize_oci_finish_reason(
+        response_choice.finishReason,
+        has_tool_calls=bool(message.tool_calls),
+    )
 
     oci_usage: Final = completion_response.chatResponse.usage
     reasoning_tokens: int | None = None
@@ -408,7 +420,7 @@ def handle_generic_stream_chunk(dict_chunk: dict) -> ModelResponseStream:
     if typed_chunk.message and typed_chunk.message.toolCalls:
         tool_calls = [
             {
-                "id": tc.id or _synthesize_oci_tool_call_id(i, tc.name, tc.arguments),
+                "id": tc.id or (_synthesize_oci_tool_call_id(i, tc.name, tc.arguments) if tc.name else None),
                 "type": "function",
                 "function": {
                     "name": tc.name,
@@ -418,7 +430,10 @@ def handle_generic_stream_chunk(dict_chunk: dict) -> ModelResponseStream:
             for i, tc in enumerate(typed_chunk.message.toolCalls)
         ]
 
-    finish_reason: Final[str | None] = _normalize_oci_finish_reason(typed_chunk.finishReason)
+    finish_reason: Final[str | None] = _normalize_oci_finish_reason(
+        typed_chunk.finishReason,
+        has_tool_calls=bool(tool_calls),
+    )
 
     return ModelResponseStream(
         choices=[

--- a/litellm/llms/oci/chat/generic.py
+++ b/litellm/llms/oci/chat/generic.py
@@ -252,22 +252,18 @@ _OCI_FINISH_REASONS: Final = MappingProxyType(
 
 _OPENAI_FINISH_REASONS: Final = frozenset({"stop", "length", "tool_calls", "content_filter", "function_call"})
 
+_OCI_RAN_TO_COMPLETION_REASONS: Final = frozenset({"COMPLETE", "stop"})
+
 
 def _normalize_oci_finish_reason(raw: str | None, *, has_tool_calls: bool = False) -> str | None:
-    """Map an OCI finish reason to its OpenAI-standard equivalent.
-
-    OCI uses two vocabularies. Cohere sends ``COMPLETE`` / ``MAX_TOKENS`` /
-    ``TOOL_CALL(S)`` plus a long tail of error and cancel reasons, while GENERIC
-    already sends the OpenAI names and has to be passed through rather than
-    collapsed. Anything outside both sets becomes ``"stop"``, ``None`` stays
-    ``None`` so intermediate stream chunks stay open, and ``has_tool_calls``
-    upgrades ``stop`` to ``tool_calls`` for a Cohere tool turn, which OCI still
-    labels ``COMPLETE``.
+    """Cohere speaks ``COMPLETE`` / ``MAX_TOKENS`` / ``TOOL_CALL(S)`` plus a tail of error and
+    cancel reasons while GENERIC already speaks OpenAI, and only a turn that ran to completion
+    may be upgraded to ``tool_calls``, so an aborted one never invites a client to run the call.
     """
     if raw is None:
         return None
     normalized: Final = _OCI_FINISH_REASONS.get(raw, raw if raw in _OPENAI_FINISH_REASONS else "stop")
-    return "tool_calls" if has_tool_calls and normalized == "stop" else normalized
+    return "tool_calls" if has_tool_calls and raw in _OCI_RAN_TO_COMPLETION_REASONS else normalized
 
 
 def _synthesize_oci_tool_call_id(position: int, name: str, arguments: str) -> str:

--- a/tests/test_litellm/llms/oci/chat/test_oci_chat_transformation.py
+++ b/tests/test_litellm/llms/oci/chat/test_oci_chat_transformation.py
@@ -721,7 +721,7 @@ class TestOCIChatConfig:
 
         choice = result.choices[0]
         assert isinstance(choice, litellm.Choices)
-        assert choice.finish_reason == "stop"
+        assert choice.finish_reason == "tool_calls"
 
         # Message and tool_calls assertions
         message = choice.message

--- a/tests/test_litellm/llms/oci/chat/test_oci_cohere_tool_calls.py
+++ b/tests/test_litellm/llms/oci/chat/test_oci_cohere_tool_calls.py
@@ -445,6 +445,91 @@ class TestOCICohereToolCalls:
         assert result.choices[0].index == 0
         assert result.choices[0].finish_reason == "stop"  # COMPLETE is mapped to stop
 
+    def test_cohere_tool_turn_reports_tool_calls_despite_complete(self):
+        """OCI Cohere labels a tool-calling turn ``COMPLETE`` rather than ``TOOL_CALL``.
+
+        Passing that through as ``stop`` leaves an agent loop with nothing telling
+        it to run the tool it was just handed.
+        """
+        wrapper = OCIStreamWrapper(
+            completion_stream=MagicMock(), model="cohere.command-a-03-2025", logging_obj=MagicMock()
+        )
+        preamble = {"apiFormat": "COHERE", "text": "I will use the get_weather tool."}
+        tool_calls_event = {
+            "apiFormat": "COHERE",
+            "text": "I will use the get_weather tool.",
+            "toolCalls": [{"name": "get_weather", "parameters": {"city": "Paris"}}],
+        }
+        terminal = {
+            "apiFormat": "COHERE",
+            "text": "I will use the get_weather tool.",
+            "chatHistory": [
+                {"role": "USER", "message": "What is the weather in Paris?"},
+                {
+                    "role": "CHATBOT",
+                    "message": "I will use the get_weather tool.",
+                    "toolCalls": [{"name": "get_weather", "parameters": {"city": "Paris"}}],
+                },
+            ],
+            "finishReason": "COMPLETE",
+            "toolCalls": [{"name": "get_weather", "parameters": {"city": "Paris"}}],
+        }
+
+        chunks = [
+            wrapper.chunk_creator(f"data: {json.dumps(event)}")
+            for event in (preamble, tool_calls_event, terminal)
+        ]
+
+        assert [chunk.choices[0].finish_reason for chunk in chunks if chunk.choices[0].finish_reason] == [
+            "tool_calls"
+        ]
+
+    def test_cohere_tool_turn_reports_tool_calls_when_the_last_chunk_is_bare(self):
+        """The finish reason can arrive on its own chunk, after the tool calls were streamed."""
+        wrapper = OCIStreamWrapper(
+            completion_stream=MagicMock(), model="cohere.command-a-03-2025", logging_obj=MagicMock()
+        )
+        tool_calls_event = {
+            "apiFormat": "COHERE",
+            "text": "I will use the get_weather tool.",
+            "toolCalls": [{"name": "get_weather", "parameters": {"city": "Paris"}}],
+        }
+
+        chunks = [
+            wrapper.chunk_creator(f"data: {json.dumps(event)}")
+            for event in (tool_calls_event, {"apiFormat": "COHERE", "finishReason": "COMPLETE"})
+        ]
+
+        assert chunks[-1].choices[0].finish_reason == "tool_calls"
+
+    def test_cohere_non_streaming_tool_call_reports_tool_calls(self):
+        """Same COMPLETE-on-a-tool-turn story on the non-streaming Cohere response."""
+        body = {
+            "modelId": "cohere.command-a-03-2025",
+            "modelVersion": "1.0",
+            "chatResponse": {
+                "apiFormat": "COHERE",
+                "text": "I will look up the weather in Paris.",
+                "finishReason": "COMPLETE",
+                "toolCalls": [{"name": "get_weather", "parameters": {"city": "Paris"}}],
+                "usage": {"completionTokens": 17, "promptTokens": 13, "totalTokens": 30},
+            },
+        }
+        result = OCIChatConfig().transform_response(
+            model="cohere.command-a-03-2025",
+            raw_response=httpx.Response(status_code=200, json=body),
+            model_response=ModelResponse(),
+            logging_obj={},  # type: ignore
+            request_data={},
+            messages=[],
+            optional_params={},
+            litellm_params={},
+            encoding={},
+        )
+
+        assert result.choices[0].finish_reason == "tool_calls"
+        assert len(result.choices[0].message.tool_calls) == 1
+
     def test_cohere_parameter_mapping_excludes_tool_choice(self):
         """Test that tool_choice is excluded from Cohere parameter mapping"""
         config = OCIChatConfig()

--- a/tests/test_litellm/llms/oci/chat/test_oci_cohere_tool_calls.py
+++ b/tests/test_litellm/llms/oci/chat/test_oci_cohere_tool_calls.py
@@ -502,6 +502,27 @@ class TestOCICohereToolCalls:
 
         assert chunks[-1].choices[0].finish_reason == "tool_calls"
 
+    @pytest.mark.parametrize(
+        "aborted_reason", ["ERROR", "ERROR_TOXIC", "ERROR_LIMIT", "USER_CANCEL", "CANCELLED"]
+    )
+    def test_cohere_aborted_tool_turn_still_reports_stop(self, aborted_reason: str):
+        """A turn OCI cut short is not a tool turn, however many tool deltas already went out."""
+        wrapper = OCIStreamWrapper(
+            completion_stream=MagicMock(), model="cohere.command-a-03-2025", logging_obj=MagicMock()
+        )
+        tool_calls_event = {
+            "apiFormat": "COHERE",
+            "text": "I will use the get_weather tool.",
+            "toolCalls": [{"name": "get_weather", "parameters": {"city": "Paris"}}],
+        }
+
+        chunks = [
+            wrapper.chunk_creator(f"data: {json.dumps(event)}")
+            for event in (tool_calls_event, {"apiFormat": "COHERE", "finishReason": aborted_reason})
+        ]
+
+        assert chunks[-1].choices[0].finish_reason == "stop"
+
     def test_cohere_non_streaming_tool_call_reports_tool_calls(self):
         """Same COMPLETE-on-a-tool-turn story on the non-streaming Cohere response."""
         body = {

--- a/tests/test_litellm/llms/oci/chat/test_oci_generic_chat.py
+++ b/tests/test_litellm/llms/oci/chat/test_oci_generic_chat.py
@@ -2,12 +2,14 @@
 Unit tests for litellm/llms/oci/chat/generic.py — error paths and stream handling.
 """
 
+import json
+
 import pytest
 from unittest.mock import MagicMock
 
 import httpx
 
-from litellm import ModelResponse
+from litellm import ModelResponse, stream_chunk_builder
 from litellm.llms.oci.chat.generic import (
     adapt_messages_to_generic_oci_standard,
     adapt_messages_to_generic_oci_standard_content_message,
@@ -462,3 +464,144 @@ class TestGpt5MaxCompletionTokens:
         dumped = payload.model_dump(exclude_none=True)
         assert dumped["maxCompletionTokens"] == 64
         assert "maxTokens" not in dumped
+
+
+# ---------------------------------------------------------------------------
+# finish_reason fidelity — replays what OCI GENERIC actually sends
+# ---------------------------------------------------------------------------
+
+
+class TestGenericFinishReasonFidelity:
+    """OCI GENERIC sends the OpenAI finish-reason names verbatim.
+
+    Captured against ``oci/meta.llama-3.3-70b-instruct`` in ``us-chicago-1``: a
+    tool-calling turn ends with ``"finishReason": "tool_calls"`` and a
+    max-token cut-off with ``"finishReason": "length"``, both lowercase.
+    Collapsing either to ``stop`` leaves an agent loop with no signal to run
+    the tool and hides truncation from the caller.
+    """
+
+    _TOOL_CALL_WIRE = [
+        {
+            "index": 0,
+            "message": {
+                "role": "ASSISTANT",
+                "toolCalls": [
+                    {"type": "FUNCTION", "id": "chatcmpl-tool-a8c3005a5731db5e", "name": "get_weather"}
+                ],
+            },
+            "pad": "aaaaaaaaa",
+        },
+        {
+            "index": 0,
+            "message": {"role": "ASSISTANT", "toolCalls": [{"type": "FUNCTION", "arguments": '{"city": "'}]},
+            "pad": "aaa",
+        },
+        {
+            "index": 0,
+            "message": {"role": "ASSISTANT", "toolCalls": [{"type": "FUNCTION", "arguments": 'Paris"}'}]},
+            "pad": "aaaa",
+        },
+        {
+            "message": {"role": "ASSISTANT", "toolCalls": [{"type": "FUNCTION", "arguments": ""}]},
+            "finishReason": "tool_calls",
+            "pad": "aaaa",
+        },
+    ]
+
+    @staticmethod
+    def _drain(events):
+        wrapper = OCIStreamWrapper(
+            completion_stream=MagicMock(), model="meta.llama-3.3-70b-instruct", logging_obj=MagicMock()
+        )
+        return [wrapper.chunk_creator(f"data: {json.dumps(event)}") for event in events]
+
+    def test_tool_calling_stream_ends_with_tool_calls(self):
+        chunks = self._drain(self._TOOL_CALL_WIRE)
+        assert [chunk.choices[0].finish_reason for chunk in chunks] == [None, None, None, "tool_calls"]
+
+    def test_truncated_stream_ends_with_length(self):
+        chunks = self._drain(
+            [
+                {
+                    "message": {"role": "ASSISTANT", "content": [{"type": "TEXT", "text": " conditions"}]},
+                    "finishReason": "length",
+                }
+            ]
+        )
+        assert chunks[0].choices[0].finish_reason == "length"
+
+    def test_argument_fragments_carry_no_id_of_their_own(self):
+        chunks = self._drain(self._TOOL_CALL_WIRE)
+        emitted_ids = [call["id"] for chunk in chunks for call in (chunk.choices[0].delta.tool_calls or [])]
+        assert emitted_ids == ["chatcmpl-tool-a8c3005a5731db5e", None, None, None]
+
+    def test_assembled_tool_call_keeps_the_id_oci_issued(self):
+        assembled = stream_chunk_builder(self._drain(self._TOOL_CALL_WIRE), messages=[])
+
+        choice = assembled.choices[0]
+        assert choice.finish_reason == "tool_calls"
+        assert len(choice.message.tool_calls) == 1
+        assert choice.message.tool_calls[0].id == "chatcmpl-tool-a8c3005a5731db5e"
+        assert choice.message.tool_calls[0].function.arguments == '{"city": "Paris"}'
+
+    def test_non_streaming_tool_call_response_ends_with_tool_calls(self):
+        body = {
+            "modelId": "meta.llama-3.3-70b-instruct",
+            "modelVersion": "1.0.0",
+            "chatResponse": {
+                "apiFormat": "GENERIC",
+                "timeCreated": "2026-09-06T09:00:39.841Z",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "ASSISTANT",
+                            "toolCalls": [
+                                {
+                                    "type": "FUNCTION",
+                                    "id": "chatcmpl-tool-a6e053a520f1cfe9",
+                                    "name": "get_weather",
+                                    "arguments": '{"city": "Paris"}',
+                                }
+                            ],
+                        },
+                        "finishReason": "tool_calls",
+                    }
+                ],
+                "usage": {"completionTokens": 23, "promptTokens": 238, "totalTokens": 261},
+            },
+        }
+        result = handle_generic_response(
+            body, "meta.llama-3.3-70b-instruct", ModelResponse(), httpx.Response(status_code=200, json=body)
+        )
+
+        assert result.choices[0].finish_reason == "tool_calls"
+        assert result.choices[0].message.tool_calls[0].id == "chatcmpl-tool-a6e053a520f1cfe9"
+
+    def test_non_streaming_truncated_response_ends_with_length(self):
+        body = {
+            "modelId": "meta.llama-3.3-70b-instruct",
+            "modelVersion": "1.0.0",
+            "chatResponse": {
+                "apiFormat": "GENERIC",
+                "timeCreated": "2026-09-06T09:00:40.889Z",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "ASSISTANT",
+                            "content": [{"type": "TEXT", "text": "I'm a large language model, I don't"}],
+                            "toolCalls": [],
+                        },
+                        "finishReason": "length",
+                    }
+                ],
+                "usage": {"completionTokens": 20, "promptTokens": 42, "totalTokens": 62},
+            },
+        }
+        result = handle_generic_response(
+            body, "meta.llama-3.3-70b-instruct", ModelResponse(), httpx.Response(status_code=200, json=body)
+        )
+
+        assert result.choices[0].finish_reason == "length"

--- a/tests/test_litellm/llms/oci/chat/test_oci_generic_chat.py
+++ b/tests/test_litellm/llms/oci/chat/test_oci_generic_chat.py
@@ -472,13 +472,9 @@ class TestGpt5MaxCompletionTokens:
 
 
 class TestGenericFinishReasonFidelity:
-    """OCI GENERIC sends the OpenAI finish-reason names verbatim.
-
-    Captured against ``oci/meta.llama-3.3-70b-instruct`` in ``us-chicago-1``: a
-    tool-calling turn ends with ``"finishReason": "tool_calls"`` and a
-    max-token cut-off with ``"finishReason": "length"``, both lowercase.
-    Collapsing either to ``stop`` leaves an agent loop with no signal to run
-    the tool and hides truncation from the caller.
+    """``_TOOL_CALL_WIRE`` was captured against ``oci/meta.llama-3.3-70b-instruct`` in
+    ``us-chicago-1``, where a GENERIC tool-calling turn ends with ``"finishReason": "tool_calls"``
+    and a max-token cut-off with ``"finishReason": "length"``, both already lowercase.
     """
 
     _TOOL_CALL_WIRE = [

--- a/tests/test_litellm/llms/oci/chat/test_oci_streaming_tool_calls.py
+++ b/tests/test_litellm/llms/oci/chat/test_oci_streaming_tool_calls.py
@@ -99,7 +99,12 @@ class TestOCIStreamingToolCalls:
         assert result.choices[0].delta.tool_calls[0]["function"]["name"] == ""
 
     def test_stream_chunk_with_all_missing_fields(self):
-        """All optional fields missing — all default gracefully."""
+        """All optional fields missing — all default gracefully.
+
+        A delta carrying neither an id nor a function name is an argument
+        fragment of a call that was already opened, so it carries no id of its
+        own and the consumer merges it onto the open call by index.
+        """
         chunk_data = {
             "index": 0,
             "finishReason": None,
@@ -119,7 +124,7 @@ class TestOCIStreamingToolCalls:
 
         assert isinstance(result, ModelResponseStream)
         assert result.choices[0].delta.tool_calls is not None
-        assert result.choices[0].delta.tool_calls[0]["id"].startswith("call_")
+        assert result.choices[0].delta.tool_calls[0]["id"] is None
         assert result.choices[0].delta.tool_calls[0]["function"]["name"] == ""
         assert result.choices[0].delta.tool_calls[0]["function"]["arguments"] == ""
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- OCI streaming tool turns end with `stop`, not `tool_calls`
- Truncated OCI replies end with `stop`, not `length`
- Every streamed argument fragment carries a brand new tool-call id

How it solves it:

- Pass through the OpenAI reason names OCI GENERIC already sends
- Report `tool_calls` when a turn that ran to completion carries tool calls, and leave an aborted one on `stop`
- Send the tool-call id only on the delta that opens the call

## User Flow

Before: a developer whose agent streams tool calls through an OCI model never sees the tool turn, and the ids on the wire don't line up

1. They POST https://litellm-domain/v1/chat/completions with `"model": "oci-llama"`, `"stream": true`, and a `get_weather` tool, asking for the weather in Paris
2. The first tool-call event arrives with `"id": "chatcmpl-tool-b83c26f82cdb1c48"` and `"name": "get_weather"`
3. The next two events carry the argument fragments `{"city": "` and `Paris"}`, and each one carries its own brand new id (`call_b49ea28955...`, then `call_ed8209ffd3...`), so a client that groups deltas by id sees three half-filled calls instead of one
4. The last event says `"finish_reason": "stop"`, so their agent loop reads the turn as a plain text answer, never runs `get_weather`, and hands the user an empty reply
5. They send the same request without `"stream": true` and get `"finish_reason": "stop"` back even though `tool_calls` is populated, so the non-streaming path breaks the same way
6. They cap a plain completion with `"max_tokens": 20`, the reply comes back cut off mid-sentence, and it also says `"finish_reason": "stop"`, so the branch that would ask the model to continue never fires

After: the same run reports the tool turn and the truncation correctly, and the streamed call keeps the one id the model issued

1. They POST https://litellm-domain/v1/chat/completions with `"model": "oci-llama"`, `"stream": true`, and a `get_weather` tool, asking for the weather in Paris
2. The first tool-call event arrives with `"id": "chatcmpl-tool-a30e41df8d81dbce"` and `"name": "get_weather"`
3. The next two events carry the argument fragments `{"city": "` and `Paris"}` with no id of their own, so the client merges them onto the open call and ends up with one `get_weather` call under the id the model issued
4. The last event says `"finish_reason": "tool_calls"`, so their agent loop runs `get_weather`, posts the result back, and the user gets a real answer
5. They send the same request without `"stream": true` and get `"finish_reason": "tool_calls"` back
6. They cap a plain completion with `"max_tokens": 20` and it comes back `"finish_reason": "length"`, so the continue branch fires

## Relevant issues

## Linear ticket

Resolves LIT-6826
Resolves LIT-6818

Supersedes #30947, which reported `tool_calls` on both handlers but left the GENERIC reason names collapsed to `stop` and the tool-call ids untouched

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy against real OCI Generative AI in `us-chicago-1`, one `oci/meta.llama-3.3-70b-instruct` deployment (GENERIC format) and one `oci/cohere.command-a-03-2025` deployment (Cohere format)

Both sides ran the same proxy topology, one process with two uvicorn workers, and the same six cases in the same order

Shared setup, same on both sides:

```yaml
model_list:
  - model_name: oci-llama
    litellm_params:
      model: oci/meta.llama-3.3-70b-instruct
  - model_name: oci-cohere
    litellm_params:
      model: oci/cohere.command-a-03-2025

general_settings:
  master_key: sk-lit6826
```

```sh
python litellm/proxy/proxy_cli.py --config config.yaml --port 37265 --num_workers 2

B=http://127.0.0.1:37265
H=(-H "Authorization: Bearer sk-lit6826" -H "Content-Type: application/json")
TOOLS='[{"type":"function","function":{"name":"get_weather","description":"Get weather","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}}]'
```

### Before (02522a5441)

#### 1. GENERIC streaming, tool call

1. Run:

   ```sh
   curl -sN $B/v1/chat/completions "${H[@]}" -d "{\"model\":\"oci-llama\",\"stream\":true,\"max_tokens\":80,\"messages\":[{\"role\":\"user\",\"content\":\"What is the weather in Paris?\"}],\"tools\":$TOOLS}" | grep '^data:'
   ```

2. Observed:

   ```
   data: {"id":"chatcmpl-6867760b-a087-4381-8334-88918b7e54ae","object":"chat.completion.chunk","created":1788687333,"model":"oci-llama","choices":[{"index":0,"delta":{"content":""}}]}
   data: {"id":"chatcmpl-bf685b0b-e62c-4c05-8099-0b1bd82edccf","created":1788687333,"model":"oci-llama","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"id":"chatcmpl-tool-a91e77be296474b3","function":{"arguments":"","name":"get_weather"},"type":"function","index":0}]}}]}
   data: {"id":"chatcmpl-fe5fcd9a-9744-437c-9dc7-7085a45517d6","created":1788687333,"model":"oci-llama","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"id":"call_b49ea289550d6ce098bc0017","function":{"arguments":"{\"city\": \"","name":""},"type":"function","index":0}]}}]}
   data: {"id":"chatcmpl-369c71c8-6303-4be1-ac17-eda6ee6051da","created":1788687334,"model":"oci-llama","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"id":"call_ed8209ffd3f30ae6f020ed82","function":{"arguments":"Paris\"}","name":""},"type":"function","index":0}]}}]}
   data: {"id":"chatcmpl-e1c1ff67-8a75-40f1-b59d-992f91f3e23c","created":1788687334,"model":"oci-llama","object":"chat.completion.chunk","choices":[{"finish_reason":"stop","index":0,"delta":{"tool_calls":[{"id":"call_72b4abaee3cdf325c4a4c800","function":{"arguments":"","name":""},"type":"function","index":0}]}}]}
   data: {"error": {"message": "litellm.InternalServerError: OciException - Chunk cannot be parsed as JSON: Expecting value: line 1 column 3 (char 2)", "type": null, "param": null, "code": "500"}}
   ```

#### 2. GENERIC non-streaming, tool call

1. Run:

   ```sh
   curl -s $B/v1/chat/completions "${H[@]}" -d "{\"model\":\"oci-llama\",\"max_tokens\":80,\"messages\":[{\"role\":\"user\",\"content\":\"What is the weather in Paris?\"}],\"tools\":$TOOLS}"
   ```

2. Observed:

   ```
   {"id":"chatcmpl-73e21ce4-f01c-4e72-920c-1c6d9d0c3fe7","created":1788687335,"model":"oci-llama","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"role":"assistant","tool_calls":[{"function":{"arguments":"{\"city\": \"Paris\"}","name":"get_weather"},"id":"chatcmpl-tool-a9e58b60cfe1dc1d","type":"function"}],"content":null}}],"usage":{"completion_tokens":23,"prompt_tokens":238,"total_tokens":261}}
   ```

#### 3. GENERIC non-streaming, max_tokens=20 truncation

1. Run:

   ```sh
   curl -s $B/v1/chat/completions "${H[@]}" -d '{"model":"oci-llama","max_tokens":20,"messages":[{"role":"user","content":"Write a long essay about Paris."}]}'
   ```

2. Observed:

   ```
   {"id":"chatcmpl-9aa52235-0522-422d-ad00-64bbb03ec287","created":1788687336,"model":"oci-llama","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"Paris, the capital city of France, is one of the most iconic and romantic destinations in the world","role":"assistant"}}],"usage":{"completion_tokens":20,"prompt_tokens":42,"total_tokens":62}}
   ```

#### 4. GENERIC streaming, max_tokens=20 truncation (last 2 events)

1. Run:

   ```sh
   curl -sN $B/v1/chat/completions "${H[@]}" -d '{"model":"oci-llama","stream":true,"max_tokens":20,"messages":[{"role":"user","content":"Write a long essay about Paris."}]}' | grep '^data:' | tail -2
   ```

2. Observed:

   ```
   data: {"id":"chatcmpl-ea645c9b-6dbb-41ec-97c7-ad42855b898a","object":"chat.completion.chunk","created":1788687337,"model":"oci-llama","choices":[{"index":0,"delta":{"content":" culture"},"finish_reason":"stop"}]}
   data: {"error": {"message": "litellm.InternalServerError: OciException - Chunk cannot be parsed as JSON: Expecting value: line 1 column 3 (char 2)", "type": null, "param": null, "code": "500"}}
   ```

#### 5. COHERE non-streaming, tool call

1. Run:

   ```sh
   curl -s $B/v1/chat/completions "${H[@]}" -d "{\"model\":\"oci-cohere\",\"max_tokens\":80,\"messages\":[{\"role\":\"user\",\"content\":\"What is the weather in Paris?\"}],\"tools\":$TOOLS}"
   ```

2. Observed:

   ```
   {"id":"chatcmpl-8460d644-fa66-41b3-94da-4e14f7890daf","created":1788687341,"model":"oci-cohere","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"I will use the 'get_weather' tool to find the weather in Paris.","role":"assistant","tool_calls":[{"function":{"arguments":"{\"city\": \"Paris\"}","name":"get_weather"},"id":"call_62d99ad643129b8feebf7923","type":"function"}]}}],"usage":{"completion_tokens":25,"prompt_tokens":13,"total_tokens":38}}
   ```

#### 6. COHERE streaming, tool call (events carrying tool calls or a finish reason)

1. Run:

   ```sh
   curl -sN $B/v1/chat/completions "${H[@]}" -d "{\"model\":\"oci-cohere\",\"stream\":true,\"max_tokens\":80,\"messages\":[{\"role\":\"user\",\"content\":\"What is the weather in Paris?\"}],\"tools\":$TOOLS}" | grep -E 'tool_calls|finish_reason'
   ```

2. Observed:

   ```
   data: {"id":"chatcmpl-7785279a-022e-4e30-a96f-cf0f6f3c2836","created":1788687343,"model":"oci-cohere","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"I will use the get_weather tool to find the weather in Paris.","tool_calls":[{"id":"call_62d99ad643129b8feebf7923","function":{"arguments":"{\"city\": \"Paris\"}","name":"get_weather"},"type":"function","index":0}]}}]}
   data: {"id":"chatcmpl-3ba5d2e7-d226-4cdd-ba85-519044f145af","object":"chat.completion.chunk","created":1788687343,"model":"oci-cohere","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}
   data: {"id":"chatcmpl-cdd21af7-ff67-4e21-84e7-5e0a3cd273cd","object":"chat.completion.chunk","created":1788687343,"model":"oci-cohere","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}
   ```

### After (07de96ca98)

#### 1. GENERIC streaming, tool call

1. Run:

   ```sh
   curl -sN $B/v1/chat/completions "${H[@]}" -d "{\"model\":\"oci-llama\",\"stream\":true,\"max_tokens\":80,\"messages\":[{\"role\":\"user\",\"content\":\"What is the weather in Paris?\"}],\"tools\":$TOOLS}" | grep '^data:'
   ```

2. Observed:

   ```
   data: {"id":"chatcmpl-3f9ee602-450b-43f2-8f92-09af52b88817","object":"chat.completion.chunk","created":1788688081,"model":"oci-llama","choices":[{"index":0,"delta":{"content":""}}]}
   data: {"id":"chatcmpl-8e55af51-0b8d-49f5-ab45-5f5769c0df59","created":1788688081,"model":"oci-llama","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"id":"chatcmpl-tool-a165800d4d7789c7","function":{"arguments":"","name":"get_weather"},"type":"function","index":0}]}}]}
   data: {"id":"chatcmpl-6fae3479-4a30-40fc-95d3-2197bc360123","created":1788688081,"model":"oci-llama","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"function":{"arguments":"{\"city\": \"","name":""},"type":"function","index":0}]}}]}
   data: {"id":"chatcmpl-959eceb7-b909-424e-bedb-cc41f5f3a4d7","created":1788688081,"model":"oci-llama","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"function":{"arguments":"Paris\"}","name":""},"type":"function","index":0}]}}]}
   data: {"id":"chatcmpl-b846bf85-beb1-48e7-bb62-be2d14e37be0","created":1788688081,"model":"oci-llama","object":"chat.completion.chunk","choices":[{"finish_reason":"tool_calls","index":0,"delta":{"tool_calls":[{"function":{"arguments":"","name":""},"type":"function","index":0}]}}]}
   data: {"error": {"message": "litellm.InternalServerError: OciException - Chunk cannot be parsed as JSON: Expecting value: line 1 column 3 (char 2)", "type": null, "param": null, "code": "500"}}
   ```

#### 2. GENERIC non-streaming, tool call

1. Run:

   ```sh
   curl -s $B/v1/chat/completions "${H[@]}" -d "{\"model\":\"oci-llama\",\"max_tokens\":80,\"messages\":[{\"role\":\"user\",\"content\":\"What is the weather in Paris?\"}],\"tools\":$TOOLS}"
   ```

2. Observed:

   ```
   {"id":"chatcmpl-ae0dfdcf-ea2d-4d5d-a73e-914609c1d9f2","created":1788688083,"model":"oci-llama","object":"chat.completion","choices":[{"finish_reason":"tool_calls","index":0,"message":{"role":"assistant","tool_calls":[{"function":{"arguments":"{\"city\": \"Paris\"}","name":"get_weather"},"id":"chatcmpl-tool-94843dfb921caaaa","type":"function"}],"content":null}}],"usage":{"completion_tokens":23,"prompt_tokens":238,"total_tokens":261}}
   ```

#### 3. GENERIC non-streaming, max_tokens=20 truncation

1. Run:

   ```sh
   curl -s $B/v1/chat/completions "${H[@]}" -d '{"model":"oci-llama","max_tokens":20,"messages":[{"role":"user","content":"Write a long essay about Paris."}]}'
   ```

2. Observed:

   ```
   {"id":"chatcmpl-c9594365-918f-4772-99b3-3cefde5ec764","created":1788688084,"model":"oci-llama","object":"chat.completion","choices":[{"finish_reason":"length","index":0,"message":{"content":"Paris, the City of Light, is one of the most iconic and romantic destinations in the world.","role":"assistant"}}],"usage":{"completion_tokens":20,"prompt_tokens":42,"total_tokens":62}}
   ```

#### 4. GENERIC streaming, max_tokens=20 truncation (last 2 events)

1. Run:

   ```sh
   curl -sN $B/v1/chat/completions "${H[@]}" -d '{"model":"oci-llama","stream":true,"max_tokens":20,"messages":[{"role":"user","content":"Write a long essay about Paris."}]}' | grep '^data:' | tail -2
   ```

2. Observed:

   ```
   data: {"id":"chatcmpl-07dddd34-d414-49d4-853e-74a1df440b2e","object":"chat.completion.chunk","created":1788688084,"model":"oci-llama","choices":[{"index":0,"delta":{"content":"."},"finish_reason":"length"}]}
   data: {"error": {"message": "litellm.InternalServerError: OciException - Chunk cannot be parsed as JSON: Expecting value: line 1 column 3 (char 2)", "type": null, "param": null, "code": "500"}}
   ```

#### 5. COHERE non-streaming, tool call

1. Run:

   ```sh
   curl -s $B/v1/chat/completions "${H[@]}" -d "{\"model\":\"oci-cohere\",\"max_tokens\":80,\"messages\":[{\"role\":\"user\",\"content\":\"What is the weather in Paris?\"}],\"tools\":$TOOLS}"
   ```

2. Observed:

   ```
   {"id":"chatcmpl-bc6cdc19-87d4-4607-b2d6-a32e4967b387","created":1788688087,"model":"oci-cohere","object":"chat.completion","choices":[{"finish_reason":"tool_calls","index":0,"message":{"content":"I will look up the weather in Paris.","role":"assistant","tool_calls":[{"function":{"arguments":"{\"city\": \"Paris\"}","name":"get_weather"},"id":"call_62d99ad643129b8feebf7923","type":"function"}]}}],"usage":{"completion_tokens":17,"prompt_tokens":13,"total_tokens":30}}
   ```

#### 6. COHERE streaming, tool call (events carrying tool calls or a finish reason)

1. Run:

   ```sh
   curl -sN $B/v1/chat/completions "${H[@]}" -d "{\"model\":\"oci-cohere\",\"stream\":true,\"max_tokens\":80,\"messages\":[{\"role\":\"user\",\"content\":\"What is the weather in Paris?\"}],\"tools\":$TOOLS}" | grep -E 'tool_calls|finish_reason'
   ```

2. Observed:

   ```
   data: {"id":"chatcmpl-94f838e4-e606-4873-8611-06eb66915a6a","created":1788688089,"model":"oci-cohere","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"I will look up the weather in Paris.","tool_calls":[{"id":"call_62d99ad643129b8feebf7923","function":{"arguments":"{\"city\": \"Paris\"}","name":"get_weather"},"type":"function","index":0}]}}]}
   data: {"id":"chatcmpl-12a73ce1-71e7-4efa-9da2-b8b34a7860c7","object":"chat.completion.chunk","created":1788688089,"model":"oci-cohere","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}
   data: {"id":"chatcmpl-6e414520-7606-4711-b78f-fe516fe199b0","object":"chat.completion.chunk","created":1788688089,"model":"oci-cohere","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}
   ```

Observations from the run:

- GENERIC already sends lowercase OpenAI reason names
- Cohere labels a tool turn `COMPLETE`, never `TOOL_CALL`
- OCI never returned an aborted reason live; unit tests cover those
- Ids on GENERIC argument fragments were minted per fragment

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- Cohere streaming still ends on an extra `stop` event
  - OCI's own last event now says `tool_calls`, and #39507 drops the extra one
- GENERIC streams still 500 on the `[DONE]` sentinel, also #39507

### Low

- #39965 asserts `["stop"]` on a Cohere tool turn
  - whichever of the two lands second updates that assertion to `["tool_calls"]`
- Reasons outside both vocabularies still collapse to `stop`, unchanged

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
