### PR TITLE
test(e2e/ui): cover member role and budget edits, member permission delegation, and team guardrail removal

### DIFF
--- a/tests/e2e/ui/tests/proxy-admin/teamGuardrailRemoval.spec.ts
+++ b/tests/e2e/ui/tests/proxy-admin/teamGuardrailRemoval.spec.ts
@@ -1,0 +1,145 @@
+import { test, expect, type APIRequestContext, type Page as PlaywrightPage } from "@playwright/test";
+import { ADMIN_STORAGE_PATH } from "../../constants";
+import { Page } from "../../fixtures/pages";
+import { navigateToPage, dismissFeedbackPopup, clickTeamId } from "../../helpers/navigation";
+import { proxyIsPremium } from "../../helpers/premium";
+import { readBack } from "../../helpers/roundTrip";
+import { CHAT_MODEL_A, MOCK_RESPONSE_TEXT, masterKey } from "../../helpers/traffic";
+
+const auth = () => ({ Authorization: `Bearer ${masterKey()}` });
+
+async function guardrailId(request: APIRequestContext, name: string): Promise<string | undefined> {
+  const res = await request.get("/v2/guardrails/list", { headers: auth() });
+  expect(res.ok(), `GET /v2/guardrails/list (${res.status()})`).toBe(true);
+  const rows = (await res.json()).guardrails as { guardrail_id: string; guardrail_name: string | null }[];
+  return rows.find((row) => row.guardrail_name === name)?.guardrail_id;
+}
+
+async function teamGuardrails(page: PlaywrightPage, teamId: string): Promise<string[]> {
+  const body = await readBack<{ team_info: { metadata: { guardrails?: string[] } | null } }>(
+    page,
+    `/team/info?team_id=${encodeURIComponent(teamId)}`,
+  );
+  return body.team_info.metadata?.guardrails ?? [];
+}
+
+async function keywordPromptStatus(request: APIRequestContext, apiKey: string, keyword: string): Promise<number> {
+  const res = await request.post("/v1/chat/completions", {
+    headers: { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" },
+    data: { model: CHAT_MODEL_A, messages: [{ role: "user", content: `please tell me about ${keyword}` }] },
+  });
+  return res.status();
+}
+
+test.describe("Proxy Admin - Team guardrail removal", () => {
+  test.use({ storageState: ADMIN_STORAGE_PATH });
+
+  test("Clearing a team's only guardrail on the Settings tab lets blocked traffic through again", async ({
+    page,
+    request,
+  }) => {
+    test.skip(!proxyIsPremium(), "proxy under test is unlicensed, so team guardrails are premium-gated");
+
+    const stamp = Date.now();
+    const guardrailName = `e2e-team-guardrail-${stamp}`;
+    const bannedKeyword = `e2eteamban${stamp}`;
+    const teamAlias = `e2e-guardrail-team-${stamp}`;
+
+    let teamId = "";
+    let teamKey = "";
+    try {
+      const guardrailRes = await request.post("/guardrails", {
+        headers: auth(),
+        data: {
+          guardrail: {
+            guardrail_name: guardrailName,
+            litellm_params: {
+              guardrail: "litellm_content_filter",
+              mode: "pre_call",
+              default_on: false,
+              blocked_words: [{ keyword: bannedKeyword, action: "BLOCK" }],
+            },
+          },
+        },
+      });
+      expect(
+        guardrailRes.ok(),
+        `POST /guardrails failed (${guardrailRes.status()}): ${await guardrailRes.text()}`,
+      ).toBe(true);
+
+      const teamRes = await request.post("/team/new", {
+        headers: auth(),
+        data: { team_alias: teamAlias, models: [CHAT_MODEL_A], metadata: { guardrails: [guardrailName] } },
+      });
+      expect(teamRes.ok(), `POST /team/new failed (${teamRes.status()}): ${await teamRes.text()}`).toBe(true);
+      teamId = (await teamRes.json()).team_id as string;
+
+      const keyRes = await request.post("/key/generate", { headers: auth(), data: { team_id: teamId } });
+      expect(keyRes.ok(), `POST /key/generate failed (${keyRes.status()}): ${await keyRes.text()}`).toBe(true);
+      teamKey = (await keyRes.json()).key as string;
+
+      await expect
+        .poll(async () => keywordPromptStatus(request, teamKey, bannedKeyword), {
+          message: "the team's guardrail never started refusing the banned keyword",
+          timeout: 60_000,
+        })
+        .toBe(400);
+
+      await navigateToPage(page, Page.Teams);
+      await dismissFeedbackPopup(page);
+      await clickTeamId(page, teamId);
+      await page.getByRole("tab", { name: "Settings" }).click();
+      await page.getByRole("button", { name: "Edit Settings" }).click();
+
+      const chip = page.locator('[data-slot="combobox-chip"]').filter({ hasText: guardrailName });
+      await expect(chip).toBeVisible({ timeout: 10_000 });
+      await chip.locator('[data-slot="combobox-chip-remove"]').click();
+      await expect(chip).toHaveCount(0, { timeout: 10_000 });
+
+      await page.getByRole("button", { name: "Save Changes" }).click();
+
+      await expect
+        .poll(async () => teamGuardrails(page, teamId), {
+          message: "the team still carries a guardrail in /team/info after the save",
+          timeout: 20_000,
+        })
+        .toEqual([]);
+
+      await page.reload();
+      await page.getByRole("tab", { name: "Settings" }).click();
+      await page.getByRole("button", { name: "Edit Settings" }).click();
+      await expect(page.getByRole("combobox", { name: "Select guardrails" })).toBeVisible({ timeout: 15_000 });
+      await expect(
+        page.locator('[data-slot="combobox-chip"]').filter({ hasText: guardrailName }),
+        "the removed guardrail is gone from the Settings tab after a reload",
+      ).toHaveCount(0);
+
+      await expect
+        .poll(async () => keywordPromptStatus(request, teamKey, bannedKeyword), {
+          message: "the team key is still refused for a keyword whose guardrail was removed",
+          timeout: 60_000,
+        })
+        .toBe(200);
+
+      const served = await request.post("/v1/chat/completions", {
+        headers: { Authorization: `Bearer ${teamKey}`, "Content-Type": "application/json" },
+        data: {
+          model: CHAT_MODEL_A,
+          messages: [{ role: "user", content: `please tell me about ${bannedKeyword}` }],
+        },
+      });
+      expect((await served.json()).choices?.[0]?.message?.content).toContain(MOCK_RESPONSE_TEXT);
+    } finally {
+      if (teamKey) {
+        await request.post("/key/delete", { headers: auth(), data: { keys: [teamKey] } });
+      }
+      if (teamId) {
+        await request.post("/team/delete", { headers: auth(), data: { team_ids: [teamId] } });
+      }
+      const id = await guardrailId(request, guardrailName);
+      if (id) {
+        await request.delete(`/guardrails/${id}`, { headers: auth() });
+      }
+    }
+  });
+});

--- a/tests/e2e/ui/tests/proxy-admin/teamGuardrailRemoval.spec.ts
+++ b/tests/e2e/ui/tests/proxy-admin/teamGuardrailRemoval.spec.ts
@@ -40,7 +40,7 @@ test.describe("Proxy Admin - Team guardrail removal", () => {
   }) => {
     test.skip(!proxyIsPremium(), "proxy under test is unlicensed, so team guardrails are premium-gated");
 
-    const stamp = Date.now();
+    const stamp = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
     const guardrailName = `e2e-team-guardrail-${stamp}`;
     const bannedKeyword = `e2eteamban${stamp}`;
     const teamAlias = `e2e-guardrail-team-${stamp}`;

--- a/tests/e2e/ui/tests/proxy-admin/teamMemberEdit.spec.ts
+++ b/tests/e2e/ui/tests/proxy-admin/teamMemberEdit.spec.ts
@@ -53,7 +53,7 @@ test.describe("Proxy Admin - Team member edit", () => {
   });
 
   test("Editing a member's role and per-member budget persists and survives a reload", async ({ page, request }) => {
-    const stamp = Date.now();
+    const stamp = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
     const memberId = `e2e-member-edit-${stamp}`;
     const teamAlias = `e2e-member-edit-team-${stamp}`;
 
@@ -64,7 +64,6 @@ test.describe("Proxy Admin - Team member edit", () => {
     });
     expect(created.ok(), `POST /user/new failed (${created.status()}): ${await created.text()}`).toBe(true);
 
-    // /team/member_update refuses role="admin" without an enterprise license, so the UI edit demotes.
     const teamRes = await request.post("/team/new", {
       headers: auth(),
       data: {

--- a/tests/e2e/ui/tests/proxy-admin/teamMemberEdit.spec.ts
+++ b/tests/e2e/ui/tests/proxy-admin/teamMemberEdit.spec.ts
@@ -1,0 +1,130 @@
+import { test, expect, type Page as PlaywrightPage } from "@playwright/test";
+import { ADMIN_STORAGE_PATH } from "../../constants";
+import { Page } from "../../fixtures/pages";
+import { navigateToPage, dismissFeedbackPopup, clickTeamId } from "../../helpers/navigation";
+import { readBack } from "../../helpers/roundTrip";
+import { CHAT_MODEL_A, masterKey } from "../../helpers/traffic";
+
+interface TeamInfoResponse {
+  team_info: {
+    models: string[];
+    members_with_roles: { user_id?: string; role?: string }[];
+  };
+  team_memberships: {
+    user_id: string;
+    litellm_budget_table: { max_budget: number | null } | null;
+  }[];
+}
+
+const auth = () => ({ Authorization: `Bearer ${masterKey()}` });
+
+async function teamInfo(page: PlaywrightPage, teamId: string): Promise<TeamInfoResponse> {
+  return readBack<TeamInfoResponse>(page, `/team/info?team_id=${encodeURIComponent(teamId)}`);
+}
+
+function roleOf(info: TeamInfoResponse, userId: string): string | undefined {
+  return info.team_info.members_with_roles.find((member) => member.user_id === userId)?.role;
+}
+
+function budgetOf(info: TeamInfoResponse, userId: string): number | null | undefined {
+  return info.team_memberships.find((membership) => membership.user_id === userId)?.litellm_budget_table?.max_budget;
+}
+
+function otherMembers(info: TeamInfoResponse, userId: string): string[] {
+  return info.team_info.members_with_roles
+    .filter((member) => member.user_id !== userId)
+    .map((member) => `${member.user_id}:${member.role}`)
+    .sort();
+}
+
+test.describe("Proxy Admin - Team member edit", () => {
+  test.use({ storageState: ADMIN_STORAGE_PATH });
+
+  const createdTeams: string[] = [];
+  const createdUsers: string[] = [];
+
+  test.afterEach(async ({ request }) => {
+    for (const teamId of createdTeams.splice(0)) {
+      await request.post("/team/delete", { headers: auth(), data: { team_ids: [teamId] } });
+    }
+    for (const userId of createdUsers.splice(0)) {
+      await request.post("/user/delete", { headers: auth(), data: { user_ids: [userId] } });
+    }
+  });
+
+  test("Editing a member's role and per-member budget persists and survives a reload", async ({ page, request }) => {
+    const stamp = Date.now();
+    const memberId = `e2e-member-edit-${stamp}`;
+    const teamAlias = `e2e-member-edit-team-${stamp}`;
+
+    createdUsers.push(memberId);
+    const created = await request.post("/user/new", {
+      headers: auth(),
+      data: { user_id: memberId, user_role: "internal_user", auto_create_key: false },
+    });
+    expect(created.ok(), `POST /user/new failed (${created.status()}): ${await created.text()}`).toBe(true);
+
+    // /team/member_update refuses role="admin" without an enterprise license, so the UI edit demotes.
+    const teamRes = await request.post("/team/new", {
+      headers: auth(),
+      data: {
+        team_alias: teamAlias,
+        models: [CHAT_MODEL_A],
+        members_with_roles: [{ user_id: memberId, role: "admin" }],
+      },
+    });
+    expect(teamRes.ok(), `POST /team/new failed (${teamRes.status()}): ${await teamRes.text()}`).toBe(true);
+    const teamId = (await teamRes.json()).team_id as string;
+    createdTeams.push(teamId);
+
+    const before = await teamInfo(page, teamId);
+    expect(roleOf(before, memberId), "the member starts out as a team admin").toBe("admin");
+    expect(budgetOf(before, memberId) ?? null, "the member starts out with no per-member budget").toBeNull();
+    expect(
+      otherMembers(before, memberId).length,
+      "the team has another member for the edit to leave alone",
+    ).toBeGreaterThan(0);
+
+    await navigateToPage(page, Page.Teams);
+    await dismissFeedbackPopup(page);
+    await clickTeamId(page, teamId);
+    await page.getByRole("tab", { name: "Members" }).click();
+
+    const memberRow = page.locator("tr", { hasText: memberId }).first();
+    await expect(memberRow).toBeVisible({ timeout: 10_000 });
+    await memberRow.getByTestId("edit-member").click();
+
+    const modal = page.getByRole("dialog", { name: "Edit Member" });
+    await expect(modal).toBeVisible({ timeout: 10_000 });
+
+    await modal.getByLabel(/^Role/).click();
+    await page.getByRole("option", { name: "User", exact: true }).click();
+    await modal.getByLabel(/Team Member Budget \(USD\)/).fill("5");
+    await modal.getByRole("button", { name: "Save Changes" }).click();
+
+    await expect(page.getByText("Team member updated successfully").first()).toBeVisible({ timeout: 10_000 });
+
+    await expect
+      .poll(
+        async () => {
+          const info = await teamInfo(page, teamId);
+          return [roleOf(info, memberId), budgetOf(info, memberId)];
+        },
+        { message: "the member's role and budget never landed in /team/info", timeout: 20_000 },
+      )
+      .toEqual(["user", 5]);
+
+    await page.reload();
+    await page.getByRole("tab", { name: "Members" }).click();
+    const reloadedRow = page.locator("tr", { hasText: memberId }).first();
+    await expect(reloadedRow).toBeVisible({ timeout: 15_000 });
+    await expect(reloadedRow.getByText("user", { exact: true }), "role shown after a reload").toBeVisible();
+    await expect(reloadedRow.getByText("$5.00"), "per-member budget shown after a reload").toBeVisible();
+
+    const after = await teamInfo(page, teamId);
+    expect(after.team_info.models, "model access untouched by a member edit").toEqual(before.team_info.models);
+    expect(otherMembers(after, memberId), "the rest of the roster untouched by a member edit").toEqual(
+      otherMembers(before, memberId),
+    );
+  });
+});

--- a/tests/e2e/ui/tests/team-admin/memberPermissions.spec.ts
+++ b/tests/e2e/ui/tests/team-admin/memberPermissions.spec.ts
@@ -1,0 +1,167 @@
+import { test, expect, type Browser, type Page as PlaywrightPage } from "@playwright/test";
+import { Page } from "../../fixtures/pages";
+import { navigateToPage, dismissFeedbackPopup, clickTeamId } from "../../helpers/navigation";
+import { CHAT_MODEL_A, MOCK_RESPONSE_TEXT, masterKey } from "../../helpers/traffic";
+
+const PASSWORD = "E2e-Member-Perms-Pass-1!";
+
+const auth = () => ({ Authorization: `Bearer ${masterKey()}` });
+
+async function sessionKey(page: PlaywrightPage): Promise<string> {
+  const cookie = (await page.context().cookies()).find((candidate) => candidate.name === "token");
+  expect(cookie?.value, "logged-in session carries a token cookie").toBeTruthy();
+  const payload = JSON.parse(Buffer.from(cookie!.value.split(".")[1], "base64url").toString("utf-8")) as {
+    key?: string;
+  };
+  expect(payload.key, "session JWT carries the virtual key the dashboard calls with").toMatch(/^sk-/);
+  return payload.key!;
+}
+
+async function signIn(browser: Browser, email: string): Promise<PlaywrightPage> {
+  const context = await browser.newContext({ storageState: { cookies: [], origins: [] } });
+  const page = await context.newPage();
+  await page.goto("/ui/login");
+  await page.getByPlaceholder("Enter your username").fill(email);
+  await page.getByPlaceholder("Enter your password").fill(PASSWORD);
+  await page.getByRole("button", { name: "Login", exact: true }).click();
+  await expect(page.locator("a", { hasText: "Virtual Keys" })).toBeVisible({ timeout: 30_000 });
+  await dismissFeedbackPopup(page);
+  return page;
+}
+
+test.describe("Team Admin - Member permissions", () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test("Granting /key/generate lets a plain member create a team key that serves traffic", async ({
+    browser,
+    request,
+  }) => {
+    const stamp = Date.now();
+    const adminId = `e2e-perm-admin-${stamp}`;
+    const memberId = `e2e-perm-member-${stamp}`;
+    const adminEmail = `${adminId}@test.local`;
+    const memberEmail = `${memberId}@test.local`;
+    const teamAlias = `e2e-perm-team-${stamp}`;
+
+    const createUser = async (userId: string, email: string): Promise<void> => {
+      const created = await request.post("/user/new", {
+        headers: auth(),
+        data: { user_id: userId, user_email: email, user_role: "internal_user", auto_create_key: false },
+      });
+      expect(created.ok(), `POST /user/new for ${userId} (${created.status()}): ${await created.text()}`).toBe(true);
+      const password = await request.post("/user/update", {
+        headers: auth(),
+        data: { user_id: userId, password: PASSWORD },
+      });
+      expect(password.ok(), `POST /user/update for ${userId} (${password.status()})`).toBe(true);
+    };
+
+    await createUser(adminId, adminEmail);
+    await createUser(memberId, memberEmail);
+
+    // /team/member_add refuses role="admin" without an enterprise license, so /team/new seeds both roles.
+    const teamRes = await request.post("/team/new", {
+      headers: auth(),
+      data: {
+        team_alias: teamAlias,
+        models: [CHAT_MODEL_A],
+        members_with_roles: [
+          { user_id: adminId, role: "admin" },
+          { user_id: memberId, role: "user" },
+        ],
+      },
+    });
+    expect(teamRes.ok(), `POST /team/new failed (${teamRes.status()}): ${await teamRes.text()}`).toBe(true);
+    const teamId = (await teamRes.json()).team_id as string;
+
+    const createdKeys: string[] = [];
+    try {
+      const memberPage = await signIn(browser, memberEmail);
+      const memberSessionKey = await sessionKey(memberPage);
+
+      const refused = await memberPage.request.post("/key/generate", {
+        headers: { Authorization: `Bearer ${memberSessionKey}`, "Content-Type": "application/json" },
+        data: { team_id: teamId, key_alias: `e2e-perm-denied-${stamp}` },
+      });
+      expect(refused.status(), "a plain member cannot mint a team key before the grant").toBe(401);
+      expect(await refused.text()).toContain("/key/generate");
+
+      const adminPage = await signIn(browser, adminEmail);
+      await navigateToPage(adminPage, Page.Teams);
+      await clickTeamId(adminPage, teamId);
+      await adminPage.getByRole("tab", { name: "Member Permissions" }).click();
+
+      for (const route of ["/key/generate", "/key/update"]) {
+        await adminPage.getByRole("row").filter({ hasText: route }).getByRole("checkbox").check();
+      }
+      await adminPage.getByRole("button", { name: "Save Changes" }).click();
+      await expect(adminPage.getByText("Permissions updated successfully").first()).toBeVisible({ timeout: 10_000 });
+
+      await expect
+        .poll(
+          async () => {
+            const res = await request.get(`/team/permissions_list?team_id=${encodeURIComponent(teamId)}`, {
+              headers: auth(),
+            });
+            if (!res.ok()) return [];
+            return ((await res.json()).team_member_permissions ?? []) as string[];
+          },
+          { message: "the granted permissions never landed in /team/permissions_list", timeout: 20_000 },
+        )
+        .toEqual(expect.arrayContaining(["/key/generate", "/key/update"]));
+
+      const keyAlias = `e2e-perm-key-${stamp}`;
+      await navigateToPage(memberPage, Page.ApiKeys);
+      await memberPage.getByRole("button", { name: /Create New Key/i }).click();
+      await expect(memberPage.getByText("Key Ownership")).toBeVisible({ timeout: 10_000 });
+      await memberPage.getByLabel(/Key Name/).fill(keyAlias);
+
+      const teamSelect = memberPage.getByTestId("team-dropdown").getByRole("combobox");
+      await teamSelect.click();
+      await memberPage.keyboard.type(teamAlias);
+      await memberPage.getByRole("option", { name: teamAlias }).first().click();
+
+      await memberPage.getByRole("combobox", { name: "Select models" }).click();
+      await memberPage.getByRole("option", { name: "All Team Models", exact: true }).click();
+      await memberPage.keyboard.press("Escape");
+
+      await memberPage.getByRole("button", { name: "Create Key", exact: true }).click();
+      const saveDialog = memberPage.getByRole("dialog", { name: "Save your Key" });
+      await expect(saveDialog).toBeVisible({ timeout: 15_000 });
+      const apiKey = (await saveDialog.locator("pre").innerText()).trim();
+      expect(apiKey).toMatch(/^sk-/);
+      createdKeys.push(apiKey);
+      await memberPage.keyboard.press("Escape");
+
+      await expect
+        .poll(
+          async () => {
+            const res = await request.get(
+              `/key/list?team_id=${encodeURIComponent(teamId)}&return_full_object=true&size=100`,
+              { headers: auth() },
+            );
+            if (!res.ok()) return null;
+            const row = ((await res.json()).keys as Record<string, unknown>[]).find(
+              (candidate) => candidate.key_alias === keyAlias,
+            );
+            return row ? [row.user_id, row.team_id] : null;
+          },
+          { message: `key ${keyAlias} never appeared on the team with the member as its owner`, timeout: 20_000 },
+        )
+        .toEqual([memberId, teamId]);
+
+      const served = await request.post("/v1/chat/completions", {
+        headers: { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" },
+        data: { model: CHAT_MODEL_A, messages: [{ role: "user", content: `member key ping ${stamp}` }] },
+      });
+      expect(served.status(), "the delegated key is a real key the gateway serves").toBe(200);
+      expect((await served.json()).choices?.[0]?.message?.content).toContain(MOCK_RESPONSE_TEXT);
+    } finally {
+      for (const key of createdKeys) {
+        await request.post("/key/delete", { headers: auth(), data: { keys: [key] } });
+      }
+      await request.post("/team/delete", { headers: auth(), data: { team_ids: [teamId] } });
+      await request.post("/user/delete", { headers: auth(), data: { user_ids: [adminId, memberId] } });
+    }
+  });
+});

--- a/tests/e2e/ui/tests/team-admin/memberPermissions.spec.ts
+++ b/tests/e2e/ui/tests/team-admin/memberPermissions.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Browser, type Page as PlaywrightPage } from "@playwright/test";
+import { test, expect, type Browser, type BrowserContext, type Page as PlaywrightPage } from "@playwright/test";
 import { Page } from "../../fixtures/pages";
 import { navigateToPage, dismissFeedbackPopup, clickTeamId } from "../../helpers/navigation";
 import { CHAT_MODEL_A, MOCK_RESPONSE_TEXT, masterKey } from "../../helpers/traffic";
@@ -17,7 +17,7 @@ async function sessionKey(page: PlaywrightPage): Promise<string> {
   return payload.key!;
 }
 
-async function signIn(browser: Browser, email: string): Promise<PlaywrightPage> {
+async function signIn(browser: Browser, email: string): Promise<BrowserContext> {
   const context = await browser.newContext({ storageState: { cookies: [], origins: [] } });
   const page = await context.newPage();
   await page.goto("/ui/login");
@@ -26,7 +26,7 @@ async function signIn(browser: Browser, email: string): Promise<PlaywrightPage> 
   await page.getByRole("button", { name: "Login", exact: true }).click();
   await expect(page.locator("a", { hasText: "Virtual Keys" })).toBeVisible({ timeout: 30_000 });
   await dismissFeedbackPopup(page);
-  return page;
+  return context;
 }
 
 test.describe("Team Admin - Member permissions", () => {
@@ -36,7 +36,7 @@ test.describe("Team Admin - Member permissions", () => {
     browser,
     request,
   }) => {
-    const stamp = Date.now();
+    const stamp = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
     const adminId = `e2e-perm-admin-${stamp}`;
     const memberId = `e2e-perm-member-${stamp}`;
     const adminEmail = `${adminId}@test.local`;
@@ -56,27 +56,30 @@ test.describe("Team Admin - Member permissions", () => {
       expect(password.ok(), `POST /user/update for ${userId} (${password.status()})`).toBe(true);
     };
 
-    await createUser(adminId, adminEmail);
-    await createUser(memberId, memberEmail);
-
-    // /team/member_add refuses role="admin" without an enterprise license, so /team/new seeds both roles.
-    const teamRes = await request.post("/team/new", {
-      headers: auth(),
-      data: {
-        team_alias: teamAlias,
-        models: [CHAT_MODEL_A],
-        members_with_roles: [
-          { user_id: adminId, role: "admin" },
-          { user_id: memberId, role: "user" },
-        ],
-      },
-    });
-    expect(teamRes.ok(), `POST /team/new failed (${teamRes.status()}): ${await teamRes.text()}`).toBe(true);
-    const teamId = (await teamRes.json()).team_id as string;
-
+    let teamId = "";
     const createdKeys: string[] = [];
+    const contexts: BrowserContext[] = [];
     try {
-      const memberPage = await signIn(browser, memberEmail);
+      await createUser(adminId, adminEmail);
+      await createUser(memberId, memberEmail);
+
+      const teamRes = await request.post("/team/new", {
+        headers: auth(),
+        data: {
+          team_alias: teamAlias,
+          models: [CHAT_MODEL_A],
+          members_with_roles: [
+            { user_id: adminId, role: "admin" },
+            { user_id: memberId, role: "user" },
+          ],
+        },
+      });
+      expect(teamRes.ok(), `POST /team/new failed (${teamRes.status()}): ${await teamRes.text()}`).toBe(true);
+      teamId = (await teamRes.json()).team_id as string;
+
+      const memberContext = await signIn(browser, memberEmail);
+      contexts.push(memberContext);
+      const memberPage = memberContext.pages()[0];
       const memberSessionKey = await sessionKey(memberPage);
 
       const refused = await memberPage.request.post("/key/generate", {
@@ -86,7 +89,9 @@ test.describe("Team Admin - Member permissions", () => {
       expect(refused.status(), "a plain member cannot mint a team key before the grant").toBe(401);
       expect(await refused.text()).toContain("/key/generate");
 
-      const adminPage = await signIn(browser, adminEmail);
+      const adminContext = await signIn(browser, adminEmail);
+      contexts.push(adminContext);
+      const adminPage = adminContext.pages()[0];
       await navigateToPage(adminPage, Page.Teams);
       await clickTeamId(adminPage, teamId);
       await adminPage.getByRole("tab", { name: "Member Permissions" }).click();
@@ -157,10 +162,15 @@ test.describe("Team Admin - Member permissions", () => {
       expect(served.status(), "the delegated key is a real key the gateway serves").toBe(200);
       expect((await served.json()).choices?.[0]?.message?.content).toContain(MOCK_RESPONSE_TEXT);
     } finally {
+      for (const context of contexts) {
+        await context.close();
+      }
       for (const key of createdKeys) {
         await request.post("/key/delete", { headers: auth(), data: { keys: [key] } });
       }
-      await request.post("/team/delete", { headers: auth(), data: { team_ids: [teamId] } });
+      if (teamId) {
+        await request.post("/team/delete", { headers: auth(), data: { team_ids: [teamId] } });
+      }
       await request.post("/user/delete", { headers: auth(), data: { user_ids: [adminId, memberId] } });
     }
   });


### PR DESCRIPTION
## TLDR

Problem this solves:

- Teams member role and budget edits have no e2e coverage
- Nothing exercises delegating key creation to a member
- Removing a team's last guardrail is untested end to end

How it solves it:

- Three Playwright specs on the Admin UI Teams flows
- Each proves its write by reading the API back
- Each owns its team, users, guardrail and keys
- Regression cover for LIT-2315, LIT-3712, LIT-2651, LIT-2725

## User Flow

This PR adds tests only, so nothing a user does changes. The lists below are the flow a proxy admin walks today, which now has a spec standing behind it

Before: a proxy admin can edit a team member and clear a team guardrail, but a release that broke either one would ship green

1. They open http://localhost:4000/ui/?page=teams and click a team id
2. On the Members tab they edit a member, set the role to User and a $5 budget, and the row updates
3. They reload the page and the Members table still shows the new role and budget
4. On the Settings tab they remove the team's only guardrail and save, and prompts the guardrail refused start returning answers
5. Nothing in the Admin UI suite walks any of these steps, so a regression in them reaches customers first

After: the same flow, now driven on every run of the Admin UI e2e suite

1. They open http://localhost:4000/ui/?page=teams and click a team id
2. On the Members tab they edit a member, set the role to User and a $5 budget, and the row updates
3. They reload the page and the Members table still shows the new role and budget
4. On the Settings tab they remove the team's only guardrail and save, and prompts the guardrail refused start returning answers
5. Each of those steps is now asserted by a spec that reads the team back from the API, so a regression fails CI instead of reaching customers

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Setup for both sides: run the proxy with `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver`, run `npm run dev` in `ui/litellm-dashboard`, and open the dashboard on http://localhost:3000 pointed at that proxy. Steps 1 and 3 below need a licensed proxy: assigning a team admin and attaching a team guardrail are premium

The change is test-only, so the product behavior is identical on both sides. What differs is whether anything catches a regression in it, so Before walks the flows by hand with no spec behind them and After walks the same flows against the specs that now assert them

### Before (02522a5441)

#### Member role and budget edit

1. Create a member and a team holding them: `curl -X POST http://localhost:4000/user/new -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"user_id":"qa-member","user_role":"internal_user","auto_create_key":false}'` then `curl -X POST http://localhost:4000/team/new -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"team_alias":"qa-member-edit","models":["gpt-4o"],"members_with_roles":[{"user_id":"qa-member","role":"admin"}]}'`
2. Open http://localhost:3000/ui/?page=teams, click the `qa-member-edit` team id, and open the Members tab
3. Click the pencil on the `qa-member` row, set Role to User, type 5 into Team Member Budget (USD), click Save Changes
4. Observe the toast and the row switching to the user role and $5.00
5. Reload the browser, reopen the Members tab, and observe the row still showing user and $5.00
6. `curl "http://localhost:4000/team/info?team_id=<team id>" -H "Authorization: Bearer sk-1234"` and observe `members_with_roles` carrying role `user` and `team_memberships[].litellm_budget_table.max_budget` of 5
7. Nothing in `tests/e2e/ui` performs any of steps 2 through 6

#### Member permission delegation

1. Create two internal users with passwords, and one team seeding the first as admin and the second as user, the same way as above
2. Sign in on http://localhost:3000/ui/login as the plain member and try to create a key for that team on the Virtual Keys page: the Create Key call is refused with 401 naming `/key/generate`
3. Sign in as the team admin, open the team, open the Member Permissions tab, tick `/key/generate` and `/key/update`, click Save Changes
4. `curl "http://localhost:4000/team/permissions_list?team_id=<team id>" -H "Authorization: Bearer sk-1234"` and observe both routes listed
5. As the plain member, create a key on Virtual Keys with that team and All Team Models, and observe the Save your Key dialog handing back an `sk-` value
6. Send one completion with that key and observe a 200
7. Nothing in `tests/e2e/ui` performs any of steps 2 through 6

#### Team guardrail removal

1. Create a content filter guardrail with a banned keyword: `curl -X POST http://localhost:4000/guardrails -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"guardrail":{"guardrail_name":"qa-banned","litellm_params":{"guardrail":"litellm_content_filter","mode":"pre_call","default_on":false,"blocked_words":[{"keyword":"qabanword","action":"BLOCK"}]}}}'`
2. Create a team carrying it and a key on that team, then send a completion whose prompt contains `qabanword` and observe a 400 refusal
3. Open http://localhost:3000/ui/?page=teams, click the team id, open the Settings tab, click Edit Settings
4. Remove the guardrail chip from Select guardrails, click Save Changes
5. Reload the browser, reopen Settings and Edit Settings, and observe Select guardrails holding no chips
6. Send the same `qabanword` completion again and observe a 200 with the model's answer
7. Nothing in `tests/e2e/ui` performs any of steps 2 through 6

### After (6c8af8a3b6)

#### Member role and budget edit

1. Walk steps 1 through 6 above and observe the same results
2. `tests/e2e/ui/tests/proxy-admin/teamMemberEdit.spec.ts` now drives exactly those steps and polls `/team/info` until the role reads `user` and the per-member budget reads 5, then reloads and asserts the Members row
3. It also asserts the team's model list and the rest of the roster are untouched by the edit

#### Member permission delegation

1. Walk steps 1 through 6 above and observe the same results
2. `tests/e2e/ui/tests/team-admin/memberPermissions.spec.ts` now signs both users in for real, asserts the pre-grant 401 carries `/key/generate`, polls `/team/permissions_list` after the grant, then creates the key as the member
3. It finishes by polling `/key/list` until the key is owned by the member on that team and sending one completion with it

#### Team guardrail removal

1. Walk steps 1 through 6 above and observe the same results
2. `tests/e2e/ui/tests/proxy-admin/teamGuardrailRemoval.spec.ts` now polls the banned prompt until it is refused, removes the chip on Settings, polls `/team/info` until the team carries no guardrail, reloads and asserts the chip is gone
3. It finishes by polling the same prompt until it serves a 200 with the model's answer

### Runtime facts checked

Checked against a live proxy before writing the specs, since each one decides a locator or a payload

1. The Edit Member dialog labels its fields Role and Team Member Budget (USD), and the members table renders the budget through a money cell as $5.00
2. `/team/info` returns per-member budgets on the top level `team_memberships[].litellm_budget_table.max_budget`, not inside `team_info`
3. The Member Permissions tab lists the routes by their literal path, so `/key/generate` and `/key/update` are the row labels
4. `/team/new` takes team guardrails on `metadata.guardrails`; the top level `guardrails` field is premium gated, and `/v2/guardrails/list` plus `DELETE /guardrails/{id}` round trip cleanly for teardown
5. The members table prints the role through a CSS capitalize class, so the DOM text stays lowercase and the spec asserts `user`
6. The dashboard authenticates its own calls with the `key` claim inside the session JWT, so acting as a signed-in user means sending that virtual key rather than the cookie

### Qualification runs

Executed against a local stack booted by `E2E_KEEP_ALIVE=1 PROXY_PORT=4100 POSTGRES_PORT=5731 MOCK_LLM_PORT=8190 ./run_e2e.sh` from `tests/e2e/ui`

1. The three new specs, `--repeat-each=3`, four consecutive parallel runs: `3 skipped, 6 passed` each time. The 3 skips are the guardrail spec, which needs a licensed proxy
2. Neighbouring specs (teams, teamSettings, teamAdmin, internal-user, guardrails): `1 failed, 23 passed (13.1s)`. The failure is `teamAdmin.spec.ts:175`, which reproduces on the merge base too: it calls `/model/new`, which this proxy refuses as enterprise
3. Full suite, `--workers=1`: `95 passed, 6 skipped, 39 failed`, none of them in the three new files. A baseline run with the three files moved aside reproduces the same failures, dominated by `migratedPages` plus one `deleteTeamModel`, so they are pre-existing. I did not reconcile the two runs failure for failure
4. Mutation check: dropping the budget fill, the role change, the save click, or the permission grant each turns the matching spec red
5. Before the parallel-safety fix, roughly one parallel `--repeat-each=3` run in three failed: two repeats starting in the same millisecond minted the same user id, so one got a 409 and the loser's teardown deleted the user the other was signed in as

CI runs the guardrail spec for real, since the CircleCI proxy is licensed. On the tip commit the `e2e_ui_testing` job reports `35 failed, 107 passed` with no skips, so all three new specs ran and passed there. The 35 failures are all `tests/migration/migratedPages.spec.ts`, which this PR does not touch: the same job, and `e2e_ui_testing_server_root_path` beside it, were already failing on the scheduled staging run at this PR's merge base (`02522a5441`), and the same failures reproduce locally with the three new files moved aside

## Type

✅ Test

## Caveats (if any)

### Medium

- The guardrail spec needs a licensed proxy, and skips otherwise
- It has therefore only run in CI, never locally
- Both e2e UI jobs are already red on staging, for `migratedPages`

### Low

- Both role seeds go through `/team/new`, since `member_add` gates admin
- The member edit demotes admin to user, because promotion is premium
- The permission spec asserts a 401 whose body names the route
- Specs pin UI copy: tab names, field labels, toast text
- Fixture ids carry a random suffix, since timestamps collide under parallel repeats

## QA runbook

- `tests/e2e/ui/tests/proxy-admin/teamMemberEdit.spec.ts` › Editing a member's role and per-member budget persists and survives a reload - an admin changes a member's team role and gives them a $5 budget, and both stick
  - [ ] Create an internal user with `POST /user/new` (`auto_create_key: false`), then `POST /team/new` with `models: ["gpt-4o"]` and that user in `members_with_roles` as `admin`
  - [ ] Open the dashboard teams page, click the new team id, open the Members tab, click the pencil on the member's row
  - [ ] In the Edit Member dialog set Role to User, enter 5 in Team Member Budget (USD), click Save Changes
  - [ ] `GET /team/info?team_id=<id>` and expect `members_with_roles` to carry role `user` and `team_memberships[].litellm_budget_table.max_budget` to be 5
  - [ ] Reload the browser, reopen the Members tab, expect the row to read user and $5.00
  - [ ] Expect the team's model list and its other member to be unchanged by the edit
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky
- `tests/e2e/ui/tests/team-admin/memberPermissions.spec.ts` › Granting /key/generate lets a plain member create a team key that serves traffic - a team admin delegates key creation and the member can then mint a working key
  - [ ] Create two internal users, give each a password with `POST /user/update`, and `POST /team/new` seeding the first as `admin` and the second as `user`, with no `team_member_permissions`
  - [ ] Sign in as the plain member and `POST /key/generate` for that team with their session's virtual key, expecting 401 whose body names `/key/generate`
  - [ ] Sign in as the team admin, open the team, open the Member Permissions tab, tick `/key/generate` and `/key/update`, click Save Changes
  - [ ] `GET /team/permissions_list?team_id=<id>` and expect both routes listed
  - [ ] As the member, open Virtual Keys, click Create New Key, pick the team, pick All Team Models, click Create Key, and expect the Save your Key dialog
  - [ ] `GET /key/list?team_id=<id>&return_full_object=true` and expect the new key owned by the member on that team
  - [ ] Send one `/v1/chat/completions` with the new key and expect a 200 carrying the model's reply
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky
- `tests/e2e/ui/tests/proxy-admin/teamGuardrailRemoval.spec.ts` › Clearing a team's only guardrail on the Settings tab lets blocked traffic through again - removing a team's last guardrail really clears it and unblocks the traffic it refused
  - [ ] Needs a licensed proxy: team guardrails are premium, and the spec skips without one
  - [ ] `POST /guardrails` with a `litellm_content_filter` and a unique banned keyword, then `POST /team/new` with `metadata: {"guardrails": ["<name>"]}`, then `POST /key/generate` for the team
  - [ ] Send a completion whose prompt contains the keyword and expect a 400 refusal
  - [ ] Open the team, open the Settings tab, click Edit Settings, remove the guardrail chip from Select guardrails, click Save Changes
  - [ ] `GET /team/info?team_id=<id>` and expect no guardrails on the team
  - [ ] Reload the browser, reopen Settings and Edit Settings, expect Select guardrails to hold no chips
  - [ ] Send the same keyword prompt again and expect a 200 carrying the model's reply
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
