### PR TITLE
feat(proxy): serve registered skills as an Agent Skills well-known index

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -492,6 +492,7 @@ disable_copilot_system_to_assistant: bool = False  # If false (default), convert
 public_mcp_servers: Optional[List[str]] = None
 public_mcp_hub_strict_whitelist: bool = True
 public_model_groups: Optional[List[str]] = None
+public_skills_index: bool = False
 public_agent_groups: Optional[List[str]] = None
 agent_search_embedding_model: Optional[str] = None
 mcp_tool_search: Optional[Mapping[str, object]] = None

--- a/litellm/proxy/_lazy_openapi_snapshot.json
+++ b/litellm/proxy/_lazy_openapi_snapshot.json
@@ -5065,6 +5065,47 @@
             "anthropic_skills"
           ]
         }
+      },
+      "/v1/skills/{skill_id}/archive": {
+        "get": {
+          "description": "Stored skill upload, repacked so SKILL.md sits at the archive root.",
+          "operationId": "agent_skills_archive_v1_skills__skill_id__archive_get",
+          "parameters": [
+            {
+              "in": "path",
+              "name": "skill_id",
+              "required": true,
+              "schema": {
+                "title": "Skill Id",
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "content": {
+                "application/json": {
+                  "schema": {}
+                }
+              },
+              "description": "Successful Response"
+            },
+            "422": {
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HTTPValidationError"
+                  }
+                }
+              },
+              "description": "Validation Error"
+            }
+          },
+          "summary": "Agent Skills Archive",
+          "tags": [
+            "anthropic_skills"
+          ]
+        }
       }
     }
   },

--- a/litellm/proxy/_lazy_openapi_snapshot.json
+++ b/litellm/proxy/_lazy_openapi_snapshot.json
@@ -5084,8 +5084,10 @@
           "responses": {
             "200": {
               "content": {
-                "application/json": {
-                  "schema": {}
+                "application/zip": {
+                  "schema": {
+                    "type": "string"
+                  }
                 }
               },
               "description": "Successful Response"

--- a/litellm/proxy/discovery_endpoints/__init__.py
+++ b/litellm/proxy/discovery_endpoints/__init__.py
@@ -1,3 +1,4 @@
+from .agent_skills_endpoints import router as agent_skills_discovery_router
 from .ui_discovery_endpoints import router as ui_discovery_endpoints_router
 
-__all__ = ["ui_discovery_endpoints_router"]
+__all__ = ["agent_skills_discovery_router", "ui_discovery_endpoints_router"]

--- a/litellm/proxy/discovery_endpoints/agent_skills_archive.py
+++ b/litellm/proxy/discovery_endpoints/agent_skills_archive.py
@@ -1,0 +1,130 @@
+"""Repack a stored skill upload into the archive shape Agent Skills clients install from.
+
+Uploads follow the Anthropic Skills API layout, where every file sits under a single
+top-level folder. Discovery clients read ``SKILL.md`` from the archive root, so that
+folder is stripped and the zip is rebuilt with fixed entry timestamps, which keeps the
+SHA-256 digest published in the index reproducible for identical uploads.
+"""
+
+import hashlib
+import io
+import re
+import zipfile
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Final
+
+import yaml
+
+MAX_ARCHIVE_UNPACKED_BYTES: Final = 50 * 1024 * 1024
+MAX_ARCHIVE_ENTRIES: Final = 1000
+SKILL_MANIFEST_FILENAME: Final = "SKILL.md"
+
+_ZIP_ENTRY_TIMESTAMP: Final = (1980, 1, 1, 0, 0, 0)
+_ZIP_ENTRY_PERMISSIONS: Final = 0o644 << 16
+_FRONTMATTER_PATTERN: Final = re.compile(r"^---\s*\n(.*?)\n---\s*(?:\n|$)", re.DOTALL)
+_WINDOWS_DRIVE_PATTERN: Final = re.compile(r"^[A-Za-z]:")
+_EMPTY_FRONTMATTER: Final[Mapping[str, object]] = MappingProxyType({})
+
+
+@dataclass(frozen=True, slots=True)
+class SkillArchive:
+    content: bytes
+    digest: str
+    declared_name: str | None
+    declared_description: str | None
+
+
+def build_skill_archive(stored_content: bytes) -> SkillArchive | None:
+    """Return the installable archive for an upload, or None when it holds no root SKILL.md."""
+    try:
+        with zipfile.ZipFile(io.BytesIO(stored_content)) as uploaded:
+            members: Final = _flattened_members(uploaded)
+    except (zipfile.BadZipFile, OSError, RuntimeError):
+        return None
+
+    if members is None:
+        return None
+
+    frontmatter: Final = _manifest_frontmatter(next(data for name, data in members if name == SKILL_MANIFEST_FILENAME))
+    content: Final = _repack(members)
+    return SkillArchive(
+        content=content,
+        digest=f"sha256:{hashlib.sha256(content).hexdigest()}",
+        declared_name=_frontmatter_text(frontmatter, "name"),
+        declared_description=_frontmatter_text(frontmatter, "description"),
+    )
+
+
+def _flattened_members(uploaded: zipfile.ZipFile) -> tuple[tuple[str, bytes], ...] | None:
+    infos: Final = tuple(info for info in uploaded.infolist() if not info.is_dir())
+    if not infos or len(infos) > MAX_ARCHIVE_ENTRIES:
+        return None
+    if sum(info.file_size for info in infos) > MAX_ARCHIVE_UNPACKED_BYTES:
+        return None
+
+    normalized: Final = tuple((info, _normalized_path(info.filename)) for info in infos)
+    if any(path is None for _, path in normalized):
+        return None
+
+    prefix: Final = _common_root_prefix(tuple(path for _, path in normalized if path is not None))
+    flattened: Final = tuple((info, path[len(prefix) :]) for info, path in normalized if path is not None)
+    names: Final = frozenset(name for _, name in flattened)
+    if SKILL_MANIFEST_FILENAME not in names or len(names) != len(flattened):
+        return None
+
+    return tuple((name, uploaded.read(info)) for info, name in sorted(flattened, key=lambda member: member[1]))
+
+
+def _common_root_prefix(paths: tuple[str, ...]) -> str:
+    roots: Final = frozenset(path.split("/", 1)[0] for path in paths)
+    if len(roots) != 1 or not all("/" in path for path in paths):
+        return ""
+    return f"{next(iter(roots))}/"
+
+
+def _normalized_path(raw_path: str) -> str | None:
+    if not raw_path or "\0" in raw_path or "\\" in raw_path:
+        return None
+    if raw_path.startswith("/") or _WINDOWS_DRIVE_PATTERN.match(raw_path):
+        return None
+    parts: Final = tuple(part for part in raw_path.split("/") if part)
+    if not parts or any(part in (".", "..") for part in parts):
+        return None
+    return "/".join(parts)
+
+
+def _manifest_frontmatter(manifest: bytes) -> Mapping[str, object]:
+    match: Final = _FRONTMATTER_PATTERN.match(manifest.decode("utf-8", errors="replace"))
+    if match is None:
+        return _EMPTY_FRONTMATTER
+    try:
+        parsed: Final = yaml.safe_load(match.group(1))
+    except yaml.YAMLError:
+        return _EMPTY_FRONTMATTER
+    if not isinstance(parsed, dict):
+        return _EMPTY_FRONTMATTER
+    return parsed
+
+
+def _frontmatter_text(frontmatter: Mapping[str, object], key: str) -> str | None:
+    value: Final = frontmatter.get(key)
+    if not isinstance(value, str):
+        return None
+    return value.strip() or None
+
+
+def _zip_entry(name: str) -> zipfile.ZipInfo:
+    entry: Final = zipfile.ZipInfo(filename=name, date_time=_ZIP_ENTRY_TIMESTAMP)
+    entry.compress_type = zipfile.ZIP_DEFLATED
+    entry.external_attr = _ZIP_ENTRY_PERMISSIONS
+    return entry
+
+
+def _repack(members: tuple[tuple[str, bytes], ...]) -> bytes:
+    buffer: Final = io.BytesIO()
+    with zipfile.ZipFile(buffer, mode="w", compression=zipfile.ZIP_DEFLATED) as repacked:
+        for name, data in members:
+            repacked.writestr(_zip_entry(name), data)
+    return buffer.getvalue()

--- a/litellm/proxy/discovery_endpoints/agent_skills_endpoints.py
+++ b/litellm/proxy/discovery_endpoints/agent_skills_endpoints.py
@@ -1,0 +1,171 @@
+"""Serve skills stored on the proxy as an Agent Skills well-known discovery index.
+
+``npx skills add <proxy url> -a <agent>`` reads ``/.well-known/agent-skills/index.json``
+and downloads each entry's archive. Discovery clients send no credentials, so both
+routes are unauthenticated and stay off until ``litellm_settings.public_skills_index``
+is enabled, which publishes every stored skill to anyone who can reach the proxy.
+"""
+
+import re
+from collections.abc import Sequence
+from itertools import groupby
+from operator import itemgetter
+from types import MappingProxyType
+from typing import Final
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
+
+import litellm
+from litellm._logging import verbose_proxy_logger
+from litellm.models.skills import LiteLLM_SkillsTable
+from litellm.proxy.discovery_endpoints.agent_skills_archive import SkillArchive, build_skill_archive
+from litellm.types.proxy.discovery_endpoints.agent_skills_endpoints import (
+    MAX_SKILL_DESCRIPTION_LENGTH,
+    MAX_SKILL_NAME_LENGTH,
+    AgentSkillsIndex,
+    AgentSkillsIndexEntry,
+)
+
+MAX_INDEXED_SKILLS: Final = 1000
+
+_NON_SLUG_PATTERN: Final = re.compile(r"[^a-z0-9]+")
+_FALLBACK_SKILL_NAME: Final = "skill"
+
+router: Final = APIRouter(tags=["public", "skills"])  # mutable-ok: fastapi types tags as list[str | Enum]
+
+
+def ensure_index_enabled() -> None:
+    if litellm.public_skills_index is not True:
+        raise HTTPException(status_code=404, detail="Not Found")
+
+
+async def stored_skills() -> Sequence[LiteLLM_SkillsTable]:
+    from litellm.llms.litellm_proxy.skills.handler import LiteLLMSkillsHandler
+
+    return await LiteLLMSkillsHandler.list_skills(limit=MAX_INDEXED_SKILLS)
+
+
+async def stored_skill(skill_id: str) -> LiteLLM_SkillsTable | None:
+    from litellm.llms.litellm_proxy.skills.handler import LiteLLMSkillsHandler
+
+    try:
+        return await LiteLLMSkillsHandler.get_skill(skill_id)
+    except ValueError:
+        return None
+
+
+@router.get(
+    "/.well-known/agent-skills/index.json",
+    response_model=AgentSkillsIndex,
+    dependencies=(Depends(ensure_index_enabled),),
+)
+@router.get(
+    "/.well-known/skills/index.json",
+    response_model=AgentSkillsIndex,
+    dependencies=(Depends(ensure_index_enabled),),
+    include_in_schema=False,
+)
+async def agent_skills_index(
+    request: Request,
+    skills: Sequence[LiteLLM_SkillsTable] = Depends(stored_skills),
+) -> AgentSkillsIndex:
+    """Agent Skills v0.2.0 discovery index over every skill stored on this proxy."""
+    from litellm.proxy.utils import get_custom_url
+
+    installable: Final = tuple(
+        (skill, archive)
+        for skill, archive in ((skill, _archive_for(skill)) for skill in reversed(skills))
+        if archive is not None
+    )
+    names: Final = _deduplicated(tuple(_base_name(skill, archive) for skill, archive in installable))
+
+    return AgentSkillsIndex(
+        skills=tuple(
+            AgentSkillsIndexEntry(
+                name=name,
+                type="archive",
+                description=_description(skill, archive, name),
+                url=get_custom_url(
+                    request_base_url=str(request.base_url),
+                    route=f"v1/skills/{skill.skill_id}/archive",
+                ),
+                digest=archive.digest,
+            )
+            for (skill, archive), name in zip(installable, names, strict=True)
+        )
+    )
+
+
+@router.get(
+    "/v1/skills/{skill_id}/archive",
+    dependencies=(Depends(ensure_index_enabled),),
+)
+async def agent_skills_archive(
+    skill_id: str,
+    skill: LiteLLM_SkillsTable | None = Depends(stored_skill),
+) -> Response:
+    """Stored skill upload, repacked so SKILL.md sits at the archive root."""
+    archive: Final = _archive_for(skill) if skill is not None else None
+    if archive is None:
+        raise HTTPException(status_code=404, detail=f"No installable skill archive for: {skill_id}")
+
+    return Response(
+        content=archive.content,
+        media_type="application/zip",
+        headers=MappingProxyType({"Content-Disposition": f'attachment; filename="{skill_id}.zip"'}),
+    )
+
+
+def _archive_for(skill: LiteLLM_SkillsTable) -> SkillArchive | None:
+    if skill.file_content is None:
+        return None
+
+    archive: Final = build_skill_archive(skill.file_content)
+    if archive is None:
+        verbose_proxy_logger.warning(
+            "Agent Skills index: skipping skill %s, its upload is not a zip holding SKILL.md at the root of a "
+            "single top-level folder",
+            skill.skill_id,
+        )
+    return archive
+
+
+def _base_name(skill: LiteLLM_SkillsTable, archive: SkillArchive) -> str:
+    candidates: Final = (archive.declared_name, skill.display_title, skill.skill_id)
+    return next(
+        (slug for slug in (_slugify(candidate) for candidate in candidates) if slug is not None),
+        _FALLBACK_SKILL_NAME,
+    )
+
+
+def _slugify(raw: str | None) -> str | None:
+    if raw is None:
+        return None
+    return _NON_SLUG_PATTERN.sub("-", raw.lower()).strip("-")[:MAX_SKILL_NAME_LENGTH].rstrip("-") or None
+
+
+def _deduplicated(names: Sequence[str]) -> tuple[str, ...]:
+    ordinals: Final = MappingProxyType(
+        {
+            position: ordinal
+            for _, duplicates in groupby(sorted(enumerate(names), key=itemgetter(1)), key=itemgetter(1))
+            for ordinal, (position, _) in enumerate(duplicates)
+        }
+    )
+    return tuple(_with_ordinal(name, ordinals[position]) for position, name in enumerate(names))
+
+
+def _with_ordinal(name: str, ordinal: int) -> str:
+    if ordinal == 0:
+        return name
+    suffix: Final = f"-{ordinal + 1}"
+    return f"{name[: MAX_SKILL_NAME_LENGTH - len(suffix)].rstrip('-')}{suffix}"
+
+
+def _description(skill: LiteLLM_SkillsTable, archive: SkillArchive, name: str) -> str:
+    candidates: Final = (archive.declared_description, skill.description, skill.display_title)
+    chosen: Final = next(
+        (candidate.strip() for candidate in candidates if candidate is not None and candidate.strip()),
+        name,
+    )
+    return chosen[:MAX_SKILL_DESCRIPTION_LENGTH]

--- a/litellm/proxy/discovery_endpoints/agent_skills_endpoints.py
+++ b/litellm/proxy/discovery_endpoints/agent_skills_endpoints.py
@@ -6,6 +6,7 @@ routes are unauthenticated and stay off until ``litellm_settings.public_skills_i
 is enabled, which publishes every stored skill to anyone who can reach the proxy.
 """
 
+import asyncio
 import re
 from collections.abc import Sequence
 from itertools import groupby
@@ -17,6 +18,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, Response
 
 import litellm
 from litellm._logging import verbose_proxy_logger
+from litellm.caching.in_memory_cache import InMemoryCache
 from litellm.models.skills import LiteLLM_SkillsTable
 from litellm.proxy.discovery_endpoints.agent_skills_archive import SkillArchive, build_skill_archive
 from litellm.types.proxy.discovery_endpoints.agent_skills_endpoints import (
@@ -27,11 +29,26 @@ from litellm.types.proxy.discovery_endpoints.agent_skills_endpoints import (
 )
 
 MAX_INDEXED_SKILLS: Final = 1000
+MAX_CACHED_ARCHIVES: Final = 128
+MAX_CACHED_ARCHIVE_BYTES: Final = 512 * 1024
+ARCHIVE_CACHE_TTL_SECONDS: Final = 3600
+
+_ARCHIVE_CACHE: Final = InMemoryCache(
+    max_size_in_memory=MAX_CACHED_ARCHIVES,
+    default_ttl=ARCHIVE_CACHE_TTL_SECONDS,
+    max_size_per_item=MAX_CACHED_ARCHIVE_BYTES // 1024,
+)
 
 _NON_SLUG_PATTERN: Final = re.compile(r"[^a-z0-9]+")
 _FALLBACK_SKILL_NAME: Final = "skill"
 
 router: Final = APIRouter(tags=["public", "skills"])  # mutable-ok: fastapi types tags as list[str | Enum]
+
+
+class ZipArchiveResponse(Response):
+    """Response whose OpenAPI entry declares an application/zip download rather than JSON."""
+
+    media_type = "application/zip"
 
 
 def ensure_index_enabled() -> None:
@@ -72,11 +89,7 @@ async def agent_skills_index(
     """Agent Skills v0.2.0 discovery index over every skill stored on this proxy."""
     from litellm.proxy.utils import get_custom_url
 
-    installable: Final = tuple(
-        (skill, archive)
-        for skill, archive in ((skill, _archive_for(skill)) for skill in reversed(skills))
-        if archive is not None
-    )
+    installable: Final = await _installable(skills)
     names: Final = _deduplicated(tuple(_base_name(skill, archive) for skill, archive in installable))
 
     return AgentSkillsIndex(
@@ -99,34 +112,50 @@ async def agent_skills_index(
 @router.get(
     "/v1/skills/{skill_id}/archive",
     dependencies=(Depends(ensure_index_enabled),),
+    response_class=ZipArchiveResponse,
 )
 async def agent_skills_archive(
     skill_id: str,
     skill: LiteLLM_SkillsTable | None = Depends(stored_skill),
-) -> Response:
+) -> ZipArchiveResponse:
     """Stored skill upload, repacked so SKILL.md sits at the archive root."""
-    archive: Final = _archive_for(skill) if skill is not None else None
+    archive: Final = await _archive_for(skill) if skill is not None else None
     if archive is None:
         raise HTTPException(status_code=404, detail=f"No installable skill archive for: {skill_id}")
 
-    return Response(
+    return ZipArchiveResponse(
         content=archive.content,
-        media_type="application/zip",
         headers=MappingProxyType({"Content-Disposition": f'attachment; filename="{skill_id}.zip"'}),
     )
 
 
-def _archive_for(skill: LiteLLM_SkillsTable) -> SkillArchive | None:
+async def _installable(
+    skills: Sequence[LiteLLM_SkillsTable],
+) -> tuple[tuple[LiteLLM_SkillsTable, SkillArchive], ...]:
+    built: Final = tuple([(skill, await _archive_for(skill)) for skill in reversed(skills)])
+    return tuple((skill, archive) for skill, archive in built if archive is not None)
+
+
+async def _archive_for(skill: LiteLLM_SkillsTable) -> SkillArchive | None:
     if skill.file_content is None:
         return None
 
-    archive: Final = build_skill_archive(skill.file_content)
+    cache_key: Final = None if skill.updated_at is None else f"{skill.skill_id}:{skill.updated_at.isoformat()}"
+    cached: Final = None if cache_key is None else _ARCHIVE_CACHE.get_cache(cache_key)
+    if isinstance(cached, SkillArchive):
+        return cached
+
+    archive: Final = await asyncio.to_thread(build_skill_archive, skill.file_content)
     if archive is None:
         verbose_proxy_logger.warning(
             "Agent Skills index: skipping skill %s, its upload is not a zip holding SKILL.md at the root of a "
             "single top-level folder",
             skill.skill_id,
         )
+        return None
+
+    if cache_key is not None and len(archive.content) <= MAX_CACHED_ARCHIVE_BYTES:
+        _ARCHIVE_CACHE.set_cache(cache_key, archive)
     return archive
 
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -431,7 +431,10 @@ from litellm.proxy.db.proxy_worker_heartbeat import (
     ProxyWorkerHeartbeat,
 )
 from litellm.proxy.db.spend_counter_reseed import END_USER_COUNTER_PREFIX, SpendCounterReseed
-from litellm.proxy.discovery_endpoints import ui_discovery_endpoints_router
+from litellm.proxy.discovery_endpoints import (
+    agent_skills_discovery_router,
+    ui_discovery_endpoints_router,
+)
 from litellm.proxy.fine_tuning_endpoints.endpoints import router as fine_tuning_router
 from litellm.proxy.fine_tuning_endpoints.endpoints import set_fine_tuning_config
 from litellm.proxy.google_endpoints.endpoints import router as google_router
@@ -18370,6 +18373,7 @@ app.include_router(user_agent_analytics_router)
 app.include_router(gateway_request_router)
 app.include_router(enterprise_router)
 app.include_router(ui_discovery_endpoints_router)
+app.include_router(agent_skills_discovery_router)
 # Eager: /models/{name}:method overlaps with the OpenAI /models endpoint.
 app.include_router(google_router)
 

--- a/litellm/types/proxy/discovery_endpoints/agent_skills_endpoints.py
+++ b/litellm/types/proxy/discovery_endpoints/agent_skills_endpoints.py
@@ -1,0 +1,25 @@
+"""Agent Skills discovery index, version 0.2.0.
+
+Schema: https://schemas.agentskills.io/discovery/0.2.0/schema.json
+"""
+
+from typing import Final, Literal
+
+from pydantic import BaseModel, Field
+
+AGENT_SKILLS_DISCOVERY_SCHEMA_URL: Final = "https://schemas.agentskills.io/discovery/0.2.0/schema.json"
+MAX_SKILL_NAME_LENGTH: Final = 64
+MAX_SKILL_DESCRIPTION_LENGTH: Final = 1024
+
+
+class AgentSkillsIndexEntry(BaseModel):
+    name: str
+    type: Literal["archive"]
+    description: str
+    url: str
+    digest: str
+
+
+class AgentSkillsIndex(BaseModel):
+    discovery_schema: str = Field(default=AGENT_SKILLS_DISCOVERY_SCHEMA_URL, alias="$schema")
+    skills: tuple[AgentSkillsIndexEntry, ...]

--- a/tests/test_litellm/proxy/discovery_endpoints/test_agent_skills_archive.py
+++ b/tests/test_litellm/proxy/discovery_endpoints/test_agent_skills_archive.py
@@ -1,0 +1,106 @@
+import hashlib
+import io
+import zipfile
+
+from litellm.proxy.discovery_endpoints.agent_skills_archive import (
+    MAX_ARCHIVE_ENTRIES,
+    build_skill_archive,
+)
+
+MANIFEST = b"""---
+name: pdf-summarizer
+description: Summarize a PDF into an executive brief.
+---
+
+Read the PDF, then write the brief.
+"""
+
+
+def zip_bytes(files: dict[str, bytes]) -> bytes:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as archive:
+        for name, content in files.items():
+            archive.writestr(name, content)
+    return buffer.getvalue()
+
+
+def entries_of(content: bytes) -> dict[str, bytes]:
+    with zipfile.ZipFile(io.BytesIO(content)) as archive:
+        return {name: archive.read(name) for name in archive.namelist()}
+
+
+def test_single_top_level_folder_is_stripped_so_skill_md_sits_at_the_root():
+    archive = build_skill_archive(
+        zip_bytes(
+            {
+                "pdf-summarizer/SKILL.md": MANIFEST,
+                "pdf-summarizer/reference.md": b"page citations",
+                "pdf-summarizer/scripts/extract.py": b"print('hi')",
+            }
+        )
+    )
+
+    assert archive is not None
+    assert entries_of(archive.content) == {
+        "SKILL.md": MANIFEST,
+        "reference.md": b"page citations",
+        "scripts/extract.py": b"print('hi')",
+    }
+
+
+def test_digest_covers_the_repacked_bytes_and_is_stable_across_builds():
+    upload = zip_bytes({"pdf-summarizer/SKILL.md": MANIFEST, "pdf-summarizer/reference.md": b"page citations"})
+
+    first = build_skill_archive(upload)
+    second = build_skill_archive(upload)
+
+    assert first is not None and second is not None
+    assert first.digest == f"sha256:{hashlib.sha256(first.content).hexdigest()}"
+    assert first.content == second.content
+
+
+def test_an_upload_that_is_already_flat_keeps_every_file_where_it_is():
+    archive = build_skill_archive(zip_bytes({"SKILL.md": MANIFEST, "reference.md": b"page citations"}))
+
+    assert archive is not None
+    assert sorted(entries_of(archive.content)) == ["SKILL.md", "reference.md"]
+
+
+def test_manifest_frontmatter_supplies_the_declared_name_and_description():
+    archive = build_skill_archive(zip_bytes({"pdf-summarizer/SKILL.md": MANIFEST}))
+
+    assert archive is not None
+    assert archive.declared_name == "pdf-summarizer"
+    assert archive.declared_description == "Summarize a PDF into an executive brief."
+
+
+def test_a_manifest_without_frontmatter_declares_nothing():
+    archive = build_skill_archive(zip_bytes({"pdf-summarizer/SKILL.md": b"just prose, no frontmatter"}))
+
+    assert archive is not None
+    assert archive.declared_name is None
+    assert archive.declared_description is None
+
+
+def test_a_manifest_buried_below_the_stripped_folder_is_not_installable():
+    assert build_skill_archive(zip_bytes({"pdf-summarizer/nested/SKILL.md": MANIFEST})) is None
+
+
+def test_an_upload_with_no_manifest_is_not_installable():
+    assert build_skill_archive(zip_bytes({"pdf-summarizer/reference.md": b"page citations"})) is None
+
+
+def test_a_non_zip_upload_is_not_installable():
+    assert build_skill_archive(MANIFEST) is None
+
+
+def test_a_path_traversal_entry_is_not_installable():
+    assert build_skill_archive(zip_bytes({"SKILL.md": MANIFEST, "../escape.md": b"nope"})) is None
+
+
+def test_an_upload_over_the_entry_cap_is_not_installable():
+    files = {"pdf-summarizer/SKILL.md": MANIFEST} | {
+        f"pdf-summarizer/file-{index}.md": b"x" for index in range(MAX_ARCHIVE_ENTRIES)
+    }
+
+    assert build_skill_archive(zip_bytes(files)) is None

--- a/tests/test_litellm/proxy/discovery_endpoints/test_agent_skills_endpoints.py
+++ b/tests/test_litellm/proxy/discovery_endpoints/test_agent_skills_endpoints.py
@@ -1,6 +1,7 @@
 import hashlib
 import io
 import zipfile
+from datetime import datetime, timezone
 
 import pytest
 from fastapi import FastAPI
@@ -42,12 +43,14 @@ def skill(
     display_title: str | None = "PDF Summarizer",
     description: str | None = None,
     files: dict[str, bytes] | None = None,
+    updated_at: datetime | None = None,
 ) -> LiteLLM_SkillsTable:
     return LiteLLM_SkillsTable(
         skill_id=skill_id,
         display_title=display_title,
         description=description,
         file_content=zip_bytes(files if files is not None else {"pdf-summarizer/SKILL.md": MANIFEST}),
+        updated_at=updated_at,
     )
 
 
@@ -162,3 +165,47 @@ def test_archive_route_404s_for_a_skill_that_does_not_exist(index_enabled):
     client = client_for(skill("litellm_skill_1"))
 
     assert client.get("/v1/skills/litellm_skill_missing/archive").status_code == 404
+
+
+def test_a_stored_skill_is_repacked_once_per_version(index_enabled):
+    stamp = datetime(2026, 9, 6, 9, 0, tzinfo=timezone.utc)
+    first = client_for(skill("litellm_skill_cached", files={"s/SKILL.md": MANIFEST}, updated_at=stamp))
+    published = first.get(WELL_KNOWN_PATHS[0]).json()["skills"][0]["digest"]
+
+    unchanged_row = client_for(
+        skill("litellm_skill_cached", files={"s/SKILL.md": MANIFEST, "s/extra.md": b"rewritten"}, updated_at=stamp)
+    )
+
+    assert unchanged_row.get(WELL_KNOWN_PATHS[0]).json()["skills"][0]["digest"] == published
+    assert hashlib.sha256(unchanged_row.get("/v1/skills/litellm_skill_cached/archive").content).hexdigest() == (
+        published.removeprefix("sha256:")
+    )
+
+
+def test_a_skill_edited_since_the_last_read_is_republished(index_enabled):
+    stamp = datetime(2026, 9, 6, 9, 0, tzinfo=timezone.utc)
+    before = client_for(skill("litellm_skill_edited", files={"s/SKILL.md": MANIFEST}, updated_at=stamp))
+    published = before.get(WELL_KNOWN_PATHS[0]).json()["skills"][0]["digest"]
+
+    after = client_for(
+        skill(
+            "litellm_skill_edited",
+            files={"s/SKILL.md": MANIFEST, "s/extra.md": b"rewritten"},
+            updated_at=datetime(2026, 9, 6, 10, 0, tzinfo=timezone.utc),
+        )
+    )
+    republished = after.get(WELL_KNOWN_PATHS[0]).json()["skills"][0]["digest"]
+
+    assert republished != published
+    assert hashlib.sha256(after.get("/v1/skills/litellm_skill_edited/archive").content).hexdigest() == (
+        republished.removeprefix("sha256:")
+    )
+
+
+def test_openapi_declares_the_archive_route_as_a_zip_download(index_enabled):
+    schema = client_for(skill("litellm_skill_1")).get("/openapi.json").json()
+
+    content = schema["paths"]["/v1/skills/{skill_id}/archive"]["get"]["responses"]["200"]["content"]
+
+    assert "application/zip" in content
+    assert "application/json" not in content

--- a/tests/test_litellm/proxy/discovery_endpoints/test_agent_skills_endpoints.py
+++ b/tests/test_litellm/proxy/discovery_endpoints/test_agent_skills_endpoints.py
@@ -1,0 +1,164 @@
+import hashlib
+import io
+import zipfile
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import litellm
+from litellm.models.skills import LiteLLM_SkillsTable
+from litellm.proxy.discovery_endpoints.agent_skills_endpoints import (
+    router,
+    stored_skill,
+    stored_skills,
+)
+from litellm.types.proxy.discovery_endpoints.agent_skills_endpoints import (
+    AGENT_SKILLS_DISCOVERY_SCHEMA_URL,
+)
+
+WELL_KNOWN_PATHS = ("/.well-known/agent-skills/index.json", "/.well-known/skills/index.json")
+
+MANIFEST = b"""---
+name: pdf-summarizer
+description: Summarize a PDF into an executive brief.
+---
+
+Read the PDF, then write the brief.
+"""
+
+
+def zip_bytes(files: dict[str, bytes]) -> bytes:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as archive:
+        for name, content in files.items():
+            archive.writestr(name, content)
+    return buffer.getvalue()
+
+
+def skill(
+    skill_id: str,
+    *,
+    display_title: str | None = "PDF Summarizer",
+    description: str | None = None,
+    files: dict[str, bytes] | None = None,
+) -> LiteLLM_SkillsTable:
+    return LiteLLM_SkillsTable(
+        skill_id=skill_id,
+        display_title=display_title,
+        description=description,
+        file_content=zip_bytes(files if files is not None else {"pdf-summarizer/SKILL.md": MANIFEST}),
+    )
+
+
+def client_for(*skills: LiteLLM_SkillsTable) -> TestClient:
+    app = FastAPI()
+    app.include_router(router)
+
+    def _skills() -> tuple[LiteLLM_SkillsTable, ...]:
+        return skills
+
+    def _skill(skill_id: str) -> LiteLLM_SkillsTable | None:
+        return next((candidate for candidate in skills if candidate.skill_id == skill_id), None)
+
+    app.dependency_overrides[stored_skills] = _skills
+    app.dependency_overrides[stored_skill] = _skill
+    return TestClient(app)
+
+
+@pytest.fixture
+def index_enabled(monkeypatch):
+    monkeypatch.setattr(litellm, "public_skills_index", True)
+
+
+def test_discovery_is_absent_until_public_skills_index_is_enabled(monkeypatch):
+    monkeypatch.setattr(litellm, "public_skills_index", False)
+    client = client_for(skill("litellm_skill_1"))
+
+    for path in WELL_KNOWN_PATHS:
+        assert client.get(path).status_code == 404
+    assert client.get("/v1/skills/litellm_skill_1/archive").status_code == 404
+
+
+@pytest.mark.parametrize("path", WELL_KNOWN_PATHS)
+def test_index_publishes_each_stored_skill_in_the_v0_2_0_shape(index_enabled, path):
+    client = client_for(skill("litellm_skill_1"))
+
+    body = client.get(path).json()
+
+    assert body["$schema"] == AGENT_SKILLS_DISCOVERY_SCHEMA_URL
+    assert len(body["skills"]) == 1
+    entry = body["skills"][0]
+    assert entry["name"] == "pdf-summarizer"
+    assert entry["type"] == "archive"
+    assert entry["description"] == "Summarize a PDF into an executive brief."
+    assert entry["url"].endswith("/v1/skills/litellm_skill_1/archive")
+    assert entry["digest"].startswith("sha256:")
+
+
+def test_index_digest_matches_the_bytes_the_archive_route_serves(index_enabled):
+    client = client_for(skill("litellm_skill_1"))
+
+    entry = client.get(WELL_KNOWN_PATHS[0]).json()["skills"][0]
+    downloaded = client.get(entry["url"])
+
+    assert downloaded.status_code == 200
+    assert downloaded.headers["content-type"] == "application/zip"
+    assert entry["digest"] == f"sha256:{hashlib.sha256(downloaded.content).hexdigest()}"
+
+
+def test_install_name_falls_back_to_the_manifest_name_without_a_display_title(index_enabled):
+    client = client_for(skill("litellm_skill_1", display_title=None))
+
+    assert client.get(WELL_KNOWN_PATHS[0]).json()["skills"][0]["name"] == "pdf-summarizer"
+
+
+@pytest.mark.parametrize(
+    "manifest, stored_description, expected",
+    [
+        (MANIFEST, "registry copy", "Summarize a PDF into an executive brief."),
+        (b"no frontmatter here", "registry copy", "registry copy"),
+        (b"no frontmatter here", None, "PDF Summarizer"),
+    ],
+)
+def test_description_prefers_the_manifest_then_the_registry_then_the_title(
+    index_enabled, manifest, stored_description, expected
+):
+    client = client_for(
+        skill(
+            "litellm_skill_1",
+            description=stored_description,
+            files={"pdf-summarizer/SKILL.md": manifest},
+        )
+    )
+
+    assert client.get(WELL_KNOWN_PATHS[0]).json()["skills"][0]["description"] == expected
+
+
+def test_skills_sharing_a_title_get_distinct_install_names(index_enabled):
+    client = client_for(
+        skill("litellm_skill_2", files={"pdf-summarizer/SKILL.md": b"second"}),
+        skill("litellm_skill_1", files={"pdf-summarizer/SKILL.md": b"first"}),
+    )
+
+    names = [entry["name"] for entry in client.get(WELL_KNOWN_PATHS[0]).json()["skills"]]
+
+    assert names == ["pdf-summarizer", "pdf-summarizer-2"]
+
+
+def test_uploads_without_a_root_manifest_are_left_out_of_the_index(index_enabled):
+    client = client_for(
+        skill("litellm_skill_1"),
+        skill("litellm_skill_2", files={"pdf-summarizer/reference.md": b"no manifest"}),
+    )
+
+    body = client.get(WELL_KNOWN_PATHS[0]).json()
+
+    assert [entry["url"].split("/")[-2] for entry in body["skills"]] == ["litellm_skill_1"]
+    assert client.get("/v1/skills/litellm_skill_2/archive").status_code == 404
+
+
+def test_archive_route_404s_for_a_skill_that_does_not_exist(index_enabled):
+    client = client_for(skill("litellm_skill_1"))
+
+    assert client.get("/v1/skills/litellm_skill_missing/archive").status_code == 404

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -64820,7 +64820,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/zip": string;
                 };
             };
             /** @description Validation Error */

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -21,6 +21,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/.well-known/agent-skills/index.json": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Agent Skills Index
+         * @description Agent Skills v0.2.0 discovery index over every skill stored on this proxy.
+         */
+        get: operations["agent_skills_index__well_known_agent_skills_index_json_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/.well-known/jwks.json": {
         parameters: {
             query?: never;
@@ -311,6 +331,26 @@ export interface paths {
         };
         /** Openid Configuration */
         get: operations["openid_configuration__well_known_openid_configuration_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/.well-known/skills/index.json": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Agent Skills Index
+         * @description Agent Skills v0.2.0 discovery index over every skill stored on this proxy.
+         */
+        get: operations["agent_skills_index__well_known_skills_index_json_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -19962,6 +20002,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/skills/{skill_id}/archive": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Agent Skills Archive
+         * @description Stored skill upload, repacked so SKILL.md sits at the archive root.
+         */
+        get: operations["agent_skills_archive_v1_skills__skill_id__archive_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/threads": {
         parameters: {
             query?: never;
@@ -23161,6 +23221,32 @@ export interface components {
             }[] | null;
             /** Tags */
             tags?: string[];
+        };
+        /** AgentSkillsIndex */
+        AgentSkillsIndex: {
+            /**
+             * $Schema
+             * @default https://schemas.agentskills.io/discovery/0.2.0/schema.json
+             */
+            $schema: string;
+            /** Skills */
+            skills: components["schemas"]["AgentSkillsIndexEntry"][];
+        };
+        /** AgentSkillsIndexEntry */
+        AgentSkillsIndexEntry: {
+            /** Description */
+            description: string;
+            /** Digest */
+            digest: string;
+            /** Name */
+            name: string;
+            /**
+             * Type
+             * @constant
+             */
+            type: "archive";
+            /** Url */
+            url: string;
         };
         /**
          * AlertType
@@ -39831,6 +39917,26 @@ export interface operations {
             };
         };
     };
+    agent_skills_index__well_known_agent_skills_index_json_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentSkillsIndex"];
+                };
+            };
+        };
+    };
     jwks_json__well_known_jwks_json_get: {
         parameters: {
             query?: never;
@@ -40164,6 +40270,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+        };
+    };
+    agent_skills_index__well_known_skills_index_json_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentSkillsIndex"];
                 };
             };
         };
@@ -64664,6 +64790,37 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["DeleteSkillResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    agent_skills_archive_v1_skills__skill_id__archive_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                skill_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
## TLDR

Problem this solves:

- `npx skills add <proxy>` finds nothing on a LiteLLM proxy
- Gemini CLI, Cursor and most coding agents install through that CLI
- No route hands back an uploaded skill's files, only metadata

How it solves it:

- Serves an Agent Skills v0.2.0 index at `/.well-known/agent-skills/index.json`
- Adds `GET /v1/skills/{id}/archive` with `SKILL.md` at the root
- Both routes are public, and off until an admin opts in

## User Flow

Before: a platform admin uploads a skill to the proxy, tells the team to run `npx skills add`, and every agent finds nothing to install

1. The admin uploads the skill with `POST http://localhost:35021/v1/skills?beta=true&custom_llm_provider=litellm_proxy`, sending `display_title=pdf-summarizer` and the zip as `files[]`, and gets back `{"id": "litellm_skill_121f99d6-...", "display_title": "pdf-summarizer", ...}`
2. A developer runs `npx skills add http://localhost:35021 -a gemini-cli` from an empty directory
3. The CLI prints "No well-known skills found; trying direct download...", then "Downloaded URL is not a valid SKILL.md file or supported archive", then "Installation failed"
4. The developer checks the two paths the CLI probes: `GET http://localhost:35021/.well-known/agent-skills/index.json` returns `404 {"detail":"Not Found"}`, and `GET http://localhost:35021/.well-known/skills/index.json` returns the same
5. They try to read the upload's bytes back: `GET http://localhost:35021/v1/skills/litellm_skill_121f99d6-.../archive` returns `404 {"detail":"Not Found"}`
6. `GET http://localhost:35021/v1/skills/litellm_skill_121f99d6-...` returns the title, the id and the timestamps, with nothing that carries the skill's files
7. Nothing on the proxy can hand an agent the skill, so the team copies skill folders around by hand instead

After: the admin turns the index on, and the same `npx skills add` installs the uploaded skill into whichever agent the developer names

1. The admin adds `public_skills_index: true` under `litellm_settings` and restarts the proxy
2. The admin uploads the skill exactly as before and gets back the same kind of id
3. The developer runs `npx skills add http://localhost:35021 -a gemini-cli` from an empty directory
4. The CLI prints "Found 1 skill", shows "pdf-summarizer", its description, and "Files: SKILL.md, reference.md", then "Installed 1 skill" into `./.agents/skills/pdf-summarizer`
5. Running the same command with `-a cursor` installs the same skill for Cursor
6. Checking the paths the CLI probed, `GET http://localhost:35021/.well-known/agent-skills/index.json` now returns a `$schema` of `https://schemas.agentskills.io/discovery/0.2.0/schema.json` and one skill carrying a name, a description, an archive url, and a `sha256:` digest, and `/.well-known/skills/index.json` returns the same body
7. `GET http://localhost:35021/v1/skills/litellm_skill_121f99d6-.../archive` returns `200` with `content-type: application/zip`, and the zip's SHA-256 equals the digest the index published, with `SKILL.md` sitting at the archive root
8. An admin who never sets `public_skills_index` still gets `404` on all three paths, so no upload becomes public by accident

## Relevant issues

## Linear ticket

Resolves LIT-6996

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both legs run the same topology: one proxy booted with `--num_workers 2` on port 35021, one Postgres behind it, one skill uploaded through the Skills Gateway. Before runs a worktree at `02522a5441`, After runs the PR tip. The only config difference is the `litellm_settings` block, which exists on the After side only:

```yaml
model_list:
  - model_name: gpt-5-mini
    litellm_params:
      model: openai/gpt-5-mini
      api_key: os.environ/OPENAI_API_KEY

general_settings:
  store_model_in_db: true

litellm_settings:
  public_skills_index: true
```

```
$ cat pdf-summarizer/SKILL.md
---
name: pdf-summarizer
description: Summarize a PDF into an executive brief with page citations.
---

# PDF Summarizer
...

$ zip -qr pdf-summarizer.zip pdf-summarizer

$ curl -s -X POST "http://localhost:35021/v1/skills?beta=true&custom_llm_provider=litellm_proxy" \
    -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
    -F "display_title=pdf-summarizer" \
    -F "files[]=@pdf-summarizer.zip"
{"id":"litellm_skill_121f99d6-b455-40ed-845a-f5be0e2cb99a","created_at":"2026-09-06T09:11:58.844000+00:00","display_title":"pdf-summarizer","latest_version":null,"source":"custom","type":"skill","updated_at":"2026-09-06T09:11:58.844000+00:00"}
```

### Before (02522a5441)

#### npx skills add installs the uploaded skill

1. From an empty directory, run the command every agent's docs point at:

```
$ npx skills add http://localhost:35021 -a gemini-cli

●   claude-code_2-1-261_agent  Agent detected — installing non-interactively
◇  Source: http://localhost:35021
◇  No well-known skills found; trying direct download...

■  Downloaded URL is not a valid SKILL.md file or supported archive

│  Tip: use the --yes (-y) and --global (-g) flags to install without prompts.

└  Installation failed

■  Canceled
```

2. Nothing landed on disk:

```
$ find . -name SKILL.md
```

#### The well-known index the CLI probes

1. Neither path the CLI tries exists, even with the config block in place:

```
$ curl -s http://localhost:35021/.well-known/agent-skills/index.json
{"detail":"Not Found"}
HTTP 404

$ curl -s http://localhost:35021/.well-known/skills/index.json
{"detail":"Not Found"}
HTTP 404
```

#### The archive the index points at

1. No route hands back the upload's bytes:

```
$ curl -s http://localhost:35021/v1/skills/litellm_skill_121f99d6-b455-40ed-845a-f5be0e2cb99a/archive
{"detail":"Not Found"}
HTTP 404
```

2. The existing read route returns metadata only, with nothing carrying the files:

```
$ curl -s "http://localhost:35021/v1/skills/litellm_skill_121f99d6-b455-40ed-845a-f5be0e2cb99a?beta=true&custom_llm_provider=litellm_proxy" \
    -H "Authorization: Bearer $LITELLM_MASTER_KEY"
{"id":"litellm_skill_121f99d6-b455-40ed-845a-f5be0e2cb99a","created_at":"2026-09-06T09:11:58.844000+00:00","display_title":"pdf-summarizer","latest_version":null,"source":"custom","type":"skill","updated_at":"2026-09-06T09:11:58.844000+00:00"}
```

#### With public_skills_index left unset

1. The setting does not exist yet, so this is the same 404 shown above on all three paths

### After (9440dbac74)

#### npx skills add installs the uploaded skill

1. The same command from an empty directory:

```
$ npx skills add http://localhost:35021 -a gemini-cli

●   claude-code_2-1-261_agent  Agent detected — installing non-interactively
◇  Source: http://localhost:35021
◇  Found 1 skill

●  Skill: pdf-summarizer
│  Summarize a PDF into an executive brief with page citations.
│    Files: SKILL.md, reference.md

◇  Installation Summary ────────────╮
│  ./.agents/skills/pdf-summarizer  │
│    copy → Gemini CLI              │
│    files: 2                       │
├───────────────────────────────────╯

◇  Installation complete

◇  Installed 1 skill ───────────────────╮
│  ✓ pdf-summarizer (copied)            │
│    → ./.agents/skills/pdf-summarizer  │
├───────────────────────────────────────╯

└  Done!  Review skills before use; they run with full agent permissions.
```

2. The skill is on disk with its manifest intact:

```
$ find .agents -print
.agents
.agents/skills
.agents/skills/pdf-summarizer
.agents/skills/pdf-summarizer/reference.md
.agents/skills/pdf-summarizer/SKILL.md
```

3. The CLI's own lockfile records that it came from the well-known index, at the digest this PR published:

```
$ cat skills-lock.json
{
  "version": 1,
  "skills": {
    "pdf-summarizer": {
      "source": "localhost",
      "sourceUrl": "http://localhost:35021",
      "sourceType": "well-known",
      "computedHash": "848b9010b4b504e3d3b991d29377051ac825ca78dd482fb8ff9c09c26195952f",
      "wellKnownDigest": "sha256:c2b72b3c75c926a5720d077919331a94e071272e4fc9df35a6c9b296a901321c"
    }
  }
}
```

4. Naming a different agent installs the same skill for that one:

```
$ npx skills add http://localhost:35021 -a cursor

◇  Found 1 skill

●  Skill: pdf-summarizer
│  Summarize a PDF into an executive brief with page citations.
│    Files: SKILL.md, reference.md

◇  Installation Summary ────────────╮
│  ./.agents/skills/pdf-summarizer  │
│    copy → Cursor                  │
│    files: 2                       │
├───────────────────────────────────╯

◇  Installed 1 skill ───────────────────╮
│  ✓ pdf-summarizer (copied)            │
│    → ./.agents/skills/pdf-summarizer  │
├───────────────────────────────────────╯

└  Done!  Review skills before use; they run with full agent permissions.
```

#### The well-known index the CLI probes

1. Both paths now serve the v0.2.0 shape, with no credentials sent:

```
$ curl -s http://localhost:35021/.well-known/agent-skills/index.json
{
    "$schema": "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
    "skills": [
        {
            "name": "pdf-summarizer",
            "type": "archive",
            "description": "Summarize a PDF into an executive brief with page citations.",
            "url": "http://localhost:35021/v1/skills/litellm_skill_121f99d6-b455-40ed-845a-f5be0e2cb99a/archive",
            "digest": "sha256:c2b72b3c75c926a5720d077919331a94e071272e4fc9df35a6c9b296a901321c"
        }
    ]
}

$ curl -s http://localhost:35021/.well-known/skills/index.json
{
    "$schema": "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
    "skills": [
        {
            "name": "pdf-summarizer",
            "type": "archive",
            "description": "Summarize a PDF into an executive brief with page citations.",
            "url": "http://localhost:35021/v1/skills/litellm_skill_121f99d6-b455-40ed-845a-f5be0e2cb99a/archive",
            "digest": "sha256:c2b72b3c75c926a5720d077919331a94e071272e4fc9df35a6c9b296a901321c"
        }
    ]
}
```

#### The archive the index points at

1. Downloading the url the index published returns a zip whose SHA-256 is exactly the digest it advertised:

```
$ curl -sD - -o skill.zip http://localhost:35021/v1/skills/litellm_skill_121f99d6-b455-40ed-845a-f5be0e2cb99a/archive
HTTP/1.1 200 OK
content-disposition: attachment; filename="litellm_skill_121f99d6-b455-40ed-845a-f5be0e2cb99a.zip"
content-length: 541
content-type: application/zip
x-content-type-options: nosniff

$ shasum -a 256 skill.zip
c2b72b3c75c926a5720d077919331a94e071272e4fc9df35a6c9b296a901321c  skill.zip

index digest: sha256:c2b72b3c75c926a5720d077919331a94e071272e4fc9df35a6c9b296a901321c
```

2. `SKILL.md` sits at the archive root rather than under the uploaded folder, which is what discovery clients read:

```
$ unzip -l skill.zip
Archive:  skill.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
      364  01-01-1980 00:00   SKILL.md
       91  01-01-1980 00:00   reference.md
---------                     -------
      455                     2 files
```

3. Four downloads in a row, landing across both workers, all repack to the same digest:

```
$ for n in 1 2 3 4; do curl -s -o /tmp/s$n.zip http://localhost:35021/v1/skills/litellm_skill_121f99d6-b455-40ed-845a-f5be0e2cb99a/archive; shasum -a 256 /tmp/s$n.zip | awk '{print $1}'; done
c2b72b3c75c926a5720d077919331a94e071272e4fc9df35a6c9b296a901321c
c2b72b3c75c926a5720d077919331a94e071272e4fc9df35a6c9b296a901321c
c2b72b3c75c926a5720d077919331a94e071272e4fc9df35a6c9b296a901321c
c2b72b3c75c926a5720d077919331a94e071272e4fc9df35a6c9b296a901321c
```

#### With public_skills_index left unset

1. On this same commit, with the `litellm_settings` block removed and the proxy restarted, all three paths are gone again:

```
$ curl -s -o /dev/null -w '%{http_code}\n' http://localhost:35021/.well-known/agent-skills/index.json
404
$ curl -s -o /dev/null -w '%{http_code}\n' http://localhost:35021/.well-known/skills/index.json
404
$ curl -s -o /dev/null -w '%{http_code}\n' http://localhost:35021/v1/skills/litellm_skill_121f99d6-b455-40ed-845a-f5be0e2cb99a/archive
404
```

#### Repeated index requests on a proxy holding 21 skills

The index republishes a digest for every stored upload, and both routes take no credentials, so what a repeated call costs is worth showing. 20 of the 21 skills here are a 41 KB zip that unpacks to 40 MB. On this PR's first commit (`6d993b5093`), which repacked everything per request:

```
$ for i in 1 2 3 4 5 6; do curl -s -o /dev/null -w 'index %{time_total}s\n' http://localhost:35021/.well-known/agent-skills/index.json; done
index 1.646299s
index 1.646729s
index 2.399644s
index 3.700283s
index 3.416107s
index 1.894268s

$ for j in $(seq 1 8); do curl -s -o /dev/null http://localhost:35021/.well-known/agent-skills/index.json & done
$ for i in $(seq 1 10); do curl -s -o /dev/null -w 'liveliness %{time_total}s\n' http://localhost:35021/health/liveliness; done
liveliness 0.017883s
liveliness 0.002997s
liveliness 0.001845s
liveliness 0.001409s
liveliness 0.001851s
liveliness 0.001407s
liveliness 0.001366s
liveliness 0.001236s
liveliness 0.002906s
liveliness 1.902988s
```

On the tip, where each worker repacks a skill once per version and does it off the event loop, same 21 skills and the same two commands:

```
$ for i in 1 2 3 4 5 6; do curl -s -o /dev/null -w 'index %{time_total}s\n' http://localhost:35021/.well-known/agent-skills/index.json; done
index 0.026045s
index 0.014090s
index 1.609906s
index 0.023173s
index 0.009968s
index 0.010298s

$ for j in $(seq 1 8); do curl -s -o /dev/null http://localhost:35021/.well-known/agent-skills/index.json & done
$ for i in $(seq 1 10); do curl -s -o /dev/null -w 'liveliness %{time_total}s\n' http://localhost:35021/health/liveliness; done
liveliness 0.002343s
liveliness 0.001016s
liveliness 0.000942s
liveliness 0.001185s
liveliness 0.000979s
liveliness 0.002433s
liveliness 0.000913s
liveliness 0.000884s
liveliness 0.000793s
liveliness 0.000889s
```

The single 1.6 s row is the one cold build the second worker pays; every later request is served from that worker's cache, and the health check no longer stalls behind a repack

What the run turned up, none of it caused by this PR:

- Both legs ran two uvicorn workers, same topology
- The published digest was identical across both workers
- `npx skills` sends no credentials, so the routes take none
- Uploads with no root `SKILL.md` are skipped and logged
- Eager import of the new module costs 15 ms
- Each worker warms its own archive cache separately

## Type

🆕 New Feature

## Caveats (if any)

### Severe

- Turning the flag on publishes every stored skill unauthenticated
  - Discovery clients send no credentials, so the routes take none
  - Anyone who can reach the proxy can download every upload
  - Default is off; the flag is the only way in

### Medium

- The index lists every stored skill, with no per-key or per-team scoping
  - LIT-5560 should gate the listing once scoped visibility lands
- Uploads with no `SKILL.md` at the root are skipped, not failed
  - They are left out of the index and logged
- Caps: 1000 skills listed, 1000 files and 50 MiB per archive
- Each worker caches 128 repacked archives of up to 512 KB, for an hour
  - A bigger archive is rebuilt per request, off the event loop
  - The cache key is the skill's `updated_at`, so an edit republishes

### Low

- Names come from the manifest, then the title, then the id
  - Collisions get a `-2`, `-3` suffix so clients keep them apart
- LIT-6285 wants `GET /v1/skills/{id}/files` to read uploads back
  - This takes `/archive` and leaves `/files` free for that

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
