### PR TITLE
fix: capture provider request id in failure logging payloads

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -1901,6 +1901,17 @@ HTTP_FRAMING_HEADERS: Final[frozenset[str]] = frozenset(
     }
 )
 
+# Provider request-id response headers, most authoritative first.
+PROVIDER_REQUEST_ID_HEADERS: Final[tuple[str, ...]] = (
+    "x-amzn-requestid",
+    "x-request-id",
+    "request-id",
+    "x-ms-request-id",
+    "apim-request-id",
+    "x-goog-request-id",
+    "cf-ray",
+)
+
 # Browser-facing security headers that a malicious or misconfigured upstream
 # provider must not be able to set on the proxy's own response.
 BROWSER_SECURITY_HEADERS: Final[frozenset[str]] = frozenset(

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -1901,7 +1901,6 @@ HTTP_FRAMING_HEADERS: Final[frozenset[str]] = frozenset(
     }
 )
 
-# Provider request-id response headers, most authoritative first.
 PROVIDER_REQUEST_ID_HEADERS: Final[tuple[str, ...]] = (
     "x-amzn-requestid",
     "x-request-id",

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -254,6 +254,37 @@ else:
 _in_memory_loggers: Final[list[CustomLogger]] = []
 
 _STANDARD_LOGGING_METADATA_KEYS: Final[frozenset[str]] = frozenset(StandardLoggingMetadata.__annotations__.keys())
+_PROVIDER_REQUEST_ID_HEADERS: Final = (
+    "x-amzn-requestid",
+    "x-request-id",
+    "request-id",
+    "x-ms-request-id",
+    "cf-ray",
+)
+
+
+def _get_provider_request_id(original_exception: Exception) -> str | None:
+    try:
+        error_response: Final = getattr(original_exception, "response", None)
+        header_sources: Final = (
+            _get_response_headers(original_exception),
+            getattr(error_response, "headers", None),
+            getattr(original_exception, "litellm_response_headers", None),
+        )
+        return next(
+            (
+                str(value)
+                for expected_header_name in _PROVIDER_REQUEST_ID_HEADERS
+                for headers in header_sources
+                if isinstance(headers, Mapping)
+                for header_name, value in headers.items()
+                if isinstance(header_name, str) and header_name.lower() == expected_header_name and value
+            ),
+            None,
+        )
+    except Exception:
+        return None
+
 
 ### GLOBAL VARIABLES ###
 
@@ -5661,6 +5692,7 @@ class StandardLoggingPayloadSetup:
         rate_limit_category: Final = validate_rate_limit_category(getattr(original_exception, "category", None))
         rate_limit_type: Final = validate_rate_limit_type(getattr(original_exception, "rate_limit_type", None))
         budget_error: Final = original_exception if isinstance(original_exception, BudgetExceededError) else None
+        provider_request_id: Final = _get_provider_request_id(original_exception) if original_exception else None
 
         return StandardLoggingPayloadErrorInformation(
             error_code=error_status,
@@ -5668,6 +5700,7 @@ class StandardLoggingPayloadSetup:
             llm_provider=_llm_provider_in_exception,
             traceback=_redact_string(traceback_info),
             error_message=_redact_string(error_message),
+            error_provider_request_id=provider_request_id,
             error_rate_limit_category=rate_limit_category,
             error_rate_limit_type=rate_limit_type,
             error_budget_entity_type=budget_error.entity_type if budget_error else None,

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -42,6 +42,7 @@ from litellm.caching.caching_handler import LLMCachingHandler
 from litellm.constants import (
     DEFAULT_MOCK_RESPONSE_COMPLETION_TOKEN_COUNT,
     DEFAULT_MOCK_RESPONSE_PROMPT_TOKEN_COUNT,
+    PROVIDER_REQUEST_ID_HEADERS,
     SENTRY_DENYLIST,
     SENTRY_PII_DENYLIST,
 )
@@ -254,15 +255,6 @@ else:
 _in_memory_loggers: Final[list[CustomLogger]] = []
 
 _STANDARD_LOGGING_METADATA_KEYS: Final[frozenset[str]] = frozenset(StandardLoggingMetadata.__annotations__.keys())
-_PROVIDER_REQUEST_ID_HEADERS: Final = (
-    "x-amzn-requestid",
-    "x-request-id",
-    "request-id",
-    "x-ms-request-id",
-    "apim-request-id",
-    "x-goog-request-id",
-    "cf-ray",
-)
 
 
 def _get_provider_request_id(original_exception: Exception) -> str | None:
@@ -276,7 +268,7 @@ def _get_provider_request_id(original_exception: Exception) -> str | None:
         return next(
             (
                 str(value)
-                for expected_header_name in _PROVIDER_REQUEST_ID_HEADERS
+                for expected_header_name in PROVIDER_REQUEST_ID_HEADERS
                 for headers in header_sources
                 if isinstance(headers, Mapping)
                 for header_name, value in headers.items()

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -259,6 +259,8 @@ _PROVIDER_REQUEST_ID_HEADERS: Final = (
     "x-request-id",
     "request-id",
     "x-ms-request-id",
+    "apim-request-id",
+    "x-goog-request-id",
     "cf-ray",
 )
 

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3053,6 +3053,7 @@ class StandardLoggingPayloadErrorInformation(TypedDict, total=False):
     llm_provider: str | None
     traceback: str | None
     error_message: str | None
+    error_provider_request_id: ReadOnly[str | None]
     # error_rate_limit_category:
     #   For 429 / rate-limit errors, the source of the rate limit. One of the
     #   string values defined by `litellm.exceptions.RateLimitErrorCategory`

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -6415,6 +6415,8 @@ def test_get_standard_logging_object_payload_survives_logging_obj_without_timing
         ("x-request-id", "response"),
         ("request-id", "response"),
         ("x-ms-request-id", "response"),
+        ("apim-request-id", "response"),
+        ("x-goog-request-id", "response"),
         ("cf-ray", "response"),
         ("X-Request-Id", "litellm_response_headers"),
         ("X-MS-Request-ID", "headers"),

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -6406,6 +6406,102 @@ def test_get_standard_logging_object_payload_survives_logging_obj_without_timing
     assert payload["hidden_params"]["litellm_overhead_time_ms"] is None
 
 
+@pytest.mark.parametrize(
+    ("header_name", "header_source"),
+    (
+        ("x-amzn-RequestId", "response"),
+        ("x-request-id", "response"),
+        ("request-id", "response"),
+        ("x-ms-request-id", "response"),
+        ("cf-ray", "response"),
+        ("X-Request-Id", "litellm_response_headers"),
+        ("X-MS-Request-ID", "headers"),
+    ),
+)
+def test_failure_standard_logging_payload_captures_provider_request_id(logging_obj, header_name, header_source):
+    import datetime
+
+    from litellm.litellm_core_utils.litellm_logging import (
+        get_standard_logging_object_payload,
+    )
+
+    request_id = "provider-request-123"
+    request = httpx.Request("POST", "https://provider.example/v1/chat/completions")
+    response = httpx.Response(429, headers={header_name: request_id}, request=request)
+    provider_error = httpx.HTTPStatusError("provider error", request=request, response=response)
+    if header_source == "litellm_response_headers":
+        response.headers.clear()
+        provider_error.litellm_response_headers = {header_name: request_id}
+    elif header_source == "headers":
+        response.headers.clear()
+        provider_error.headers = {header_name: request_id}
+    now = datetime.datetime.now()
+
+    payload = get_standard_logging_object_payload(
+        kwargs={"litellm_call_id": "call-1", "model": "test-model", "messages": []},
+        init_response_obj={},
+        start_time=now,
+        end_time=now,
+        logging_obj=logging_obj,
+        status="failure",
+        original_exception=provider_error,
+    )
+
+    assert payload is not None
+    assert payload["error_information"] is not None
+    assert payload["error_information"]["error_provider_request_id"] == request_id
+
+
+def test_get_error_information_ignores_unsupported_headers():
+    import httpx
+
+    from litellm.litellm_core_utils.litellm_logging import StandardLoggingPayloadSetup
+
+    request = httpx.Request("POST", "https://provider.example/v1/chat/completions")
+    response = httpx.Response(429, headers={"retry-after": "3"}, request=request)
+    provider_error = httpx.HTTPStatusError("provider error", request=request, response=response)
+
+    error_information = StandardLoggingPayloadSetup.get_error_information(provider_error)
+
+    assert error_information["error_provider_request_id"] is None
+
+
+def test_get_error_information_uses_header_precedence_and_fallback():
+    import httpx
+
+    from litellm.exceptions import RateLimitError
+    from litellm.litellm_core_utils.litellm_logging import StandardLoggingPayloadSetup
+
+    request = httpx.Request("POST", "https://provider.example/v1/chat/completions")
+    response = httpx.Response(
+        429,
+        headers={"x-request-id": "response-id", "x-amzn-requestid": "amazon-id"},
+        request=request,
+    )
+    provider_error = RateLimitError(
+        message="provider error",
+        llm_provider="test-provider",
+        model="test-model",
+        response=response,
+        headers={"retry-after": "3"},
+    )
+
+    error_information = StandardLoggingPayloadSetup.get_error_information(provider_error)
+
+    assert error_information["error_provider_request_id"] == "amazon-id"
+
+
+def test_get_error_information_ignores_malformed_headers():
+    from litellm.litellm_core_utils.litellm_logging import StandardLoggingPayloadSetup
+
+    provider_error = Exception("provider error")
+    provider_error.headers = [("x-request-id", "provider-request-123")]
+
+    error_information = StandardLoggingPayloadSetup.get_error_information(provider_error)
+
+    assert error_information["error_provider_request_id"] is None
+
+
 def test_get_standard_logging_object_payload_failure_status_keeps_overhead_none(logging_obj):
     """A post_call guardrail can fail the request after the upstream call succeeded; the failure
     payload keeps litellm_overhead_time_ms None, matching responses that carry their own _hidden_params."""

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -3968,7 +3968,9 @@ def test_get_standard_logging_object_payload_carries_matched_access_groups(loggi
             "model": "gpt-4o",
             "messages": [],
             "litellm_params": {
-                "metadata": {"user_api_key_matched_model_access_groups": ["premium-pool", "shared-pool"]},
+                "metadata": {
+                    "user_api_key_matched_model_access_groups": ["premium-pool", "shared-pool"]
+                },
                 "proxy_server_request": {"body": {}},
             },
         },
@@ -4052,7 +4054,9 @@ def _model_router_response(selected_model: str, stamp: bool):
     from litellm.types.utils import ModelResponse
 
     response = ModelResponse(model=selected_model)
-    response._hidden_params = {AZURE_MODEL_ROUTER_SELECTED_MODEL_KEY: selected_model} if stamp else {}
+    response._hidden_params = (
+        {AZURE_MODEL_ROUTER_SELECTED_MODEL_KEY: selected_model} if stamp else {}
+    )
     return response
 
 
@@ -4076,7 +4080,9 @@ def test_standard_logging_payload_uses_stamped_model_router_model(logging_obj):
             "messages": [],
             "litellm_params": {"metadata": {}},
         },
-        init_response_obj=_model_router_response("azure_ai/grok-4-1-fast-reasoning", stamp=True),
+        init_response_obj=_model_router_response(
+            "azure_ai/grok-4-1-fast-reasoning", stamp=True
+        ),
         start_time=now,
         end_time=now,
         logging_obj=logging_obj,
@@ -4108,7 +4114,9 @@ def test_standard_logging_payload_keeps_requested_model_without_router_stamp(
             "messages": [],
             "litellm_params": {"metadata": {}},
         },
-        init_response_obj=_model_router_response("azure_ai/grok-4-1-fast-reasoning", stamp=False),
+        init_response_obj=_model_router_response(
+            "azure_ai/grok-4-1-fast-reasoning", stamp=False
+        ),
         start_time=now,
         end_time=now,
         logging_obj=logging_obj,
@@ -5487,7 +5495,9 @@ class TestNonInferenceCallTypesAreNotBilled:
             init_response_obj=self._retrieved_response(),
             start_time=now,
             end_time=now,
-            logging_obj=self._logging_obj("aget_responses", litellm_metadata=self.BACKGROUND_POLL_METADATA),
+            logging_obj=self._logging_obj(
+                "aget_responses", litellm_metadata=self.BACKGROUND_POLL_METADATA
+            ),
             status="success",
         )
 
@@ -5733,7 +5743,9 @@ async def test_streaming_success_callbacks_survive_cost_calculation_failure():
     releasing.async_log_success_event = AsyncMock()
 
     patcher, logging_obj = _streaming_logging_obj_with_callbacks([releasing])
-    with patcher, patch.object(logging_obj, "_response_cost_calculator", side_effect=ValueError("bad usage block")):
+    with patcher, patch.object(
+        logging_obj, "_response_cost_calculator", side_effect=ValueError("bad usage block")
+    ):
         await logging_obj.async_success_handler(result=_assembled_stream_result())
 
     assert logging_obj.model_call_details["response_cost"] is None
@@ -5746,9 +5758,8 @@ async def test_streaming_success_callbacks_survive_standard_logging_payload_fail
     releasing.async_log_success_event = AsyncMock()
 
     patcher, logging_obj = _streaming_logging_obj_with_callbacks([releasing])
-    with (
-        patcher,
-        patch.object(logging_obj, "_build_standard_logging_payload", side_effect=ValueError("incomplete stream")),
+    with patcher, patch.object(
+        logging_obj, "_build_standard_logging_payload", side_effect=ValueError("incomplete stream")
     ):
         await logging_obj.async_success_handler(result=_assembled_stream_result())
 
@@ -6021,8 +6032,6 @@ def test_prompt_hooks_skip_prompt_managers_when_no_prompt_id(logging_obj, tmp_pa
             )
         for hook in [cb for cb in litellm.callbacks if isinstance(cb, VectorStorePreCallHook)]:
             litellm.logging_callback_manager.remove_callback_from_list_by_object(litellm.callbacks, hook)
-
-
 def test_newrelic_dispatch_prefers_otel_v2_when_flag_on(monkeypatch):
     """With LITELLM_OTEL_V2 on, the "newrelic" callback builds the OTel v2
     logger (per-team credential routing); with the flag off (default) it keeps
@@ -6175,9 +6184,7 @@ def test_get_error_information_skips_traceback_for_budget_rejection_with_provide
     from litellm.litellm_core_utils.litellm_logging import StandardLoggingPayloadSetup
 
     assert litellm.log_client_error_tracebacks is False
-    over_budget = _raise_and_catch(
-        litellm.BudgetExceededError(current_cost=0.01, max_budget=0.0, llm_provider="anthropic")
-    )
+    over_budget = _raise_and_catch(litellm.BudgetExceededError(current_cost=0.01, max_budget=0.0, llm_provider="anthropic"))
     result = StandardLoggingPayloadSetup.get_error_information(over_budget)
     assert result["error_code"] == "429"
     assert result["llm_provider"] == "anthropic"
@@ -6406,8 +6413,6 @@ def test_get_standard_logging_object_payload_survives_logging_obj_without_timing
         ("x-request-id", "response"),
         ("request-id", "response"),
         ("x-ms-request-id", "response"),
-        ("apim-request-id", "response"),
-        ("x-goog-request-id", "response"),
         ("cf-ray", "response"),
         ("X-Request-Id", "litellm_response_headers"),
         ("X-MS-Request-ID", "headers"),
@@ -6601,7 +6606,9 @@ def test_passthrough_embeddings_result_swapped_for_callbacks():
             ],
             "model": "EmbeddingsGigaR",
         },
-        request=httpx.Request("POST", "https://gigachat.devices.sberbank.ru/api/v1/embeddings"),
+        request=httpx.Request(
+            "POST", "https://gigachat.devices.sberbank.ru/api/v1/embeddings"
+        ),
     )
 
     _, _, swapped_result = logging_obj._success_handler_helper_fn(
@@ -6620,14 +6627,12 @@ def test_get_status_fields_ranks_guardrail_flagged_between_success_and_intervene
     request-level guardrail_status but never mask an intervention."""
     flagged = {"guardrail_status": "guardrail_flagged"}
 
-    assert (
-        _get_status_fields("success", [{"guardrail_status": "success"}, flagged], None)["guardrail_status"]
-        == "guardrail_flagged"
-    )
-    assert (
-        _get_status_fields("success", [flagged, {"guardrail_status": "guardrail_intervened"}], None)["guardrail_status"]
-        == "guardrail_intervened"
-    )
+    assert _get_status_fields(
+        "success", [{"guardrail_status": "success"}, flagged], None
+    )["guardrail_status"] == "guardrail_flagged"
+    assert _get_status_fields(
+        "success", [flagged, {"guardrail_status": "guardrail_intervened"}], None
+    )["guardrail_status"] == "guardrail_intervened"
 
 
 def test_get_error_information_redacts_provider_key_from_upstream_url():

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -3968,9 +3968,7 @@ def test_get_standard_logging_object_payload_carries_matched_access_groups(loggi
             "model": "gpt-4o",
             "messages": [],
             "litellm_params": {
-                "metadata": {
-                    "user_api_key_matched_model_access_groups": ["premium-pool", "shared-pool"]
-                },
+                "metadata": {"user_api_key_matched_model_access_groups": ["premium-pool", "shared-pool"]},
                 "proxy_server_request": {"body": {}},
             },
         },
@@ -4054,9 +4052,7 @@ def _model_router_response(selected_model: str, stamp: bool):
     from litellm.types.utils import ModelResponse
 
     response = ModelResponse(model=selected_model)
-    response._hidden_params = (
-        {AZURE_MODEL_ROUTER_SELECTED_MODEL_KEY: selected_model} if stamp else {}
-    )
+    response._hidden_params = {AZURE_MODEL_ROUTER_SELECTED_MODEL_KEY: selected_model} if stamp else {}
     return response
 
 
@@ -4080,9 +4076,7 @@ def test_standard_logging_payload_uses_stamped_model_router_model(logging_obj):
             "messages": [],
             "litellm_params": {"metadata": {}},
         },
-        init_response_obj=_model_router_response(
-            "azure_ai/grok-4-1-fast-reasoning", stamp=True
-        ),
+        init_response_obj=_model_router_response("azure_ai/grok-4-1-fast-reasoning", stamp=True),
         start_time=now,
         end_time=now,
         logging_obj=logging_obj,
@@ -4114,9 +4108,7 @@ def test_standard_logging_payload_keeps_requested_model_without_router_stamp(
             "messages": [],
             "litellm_params": {"metadata": {}},
         },
-        init_response_obj=_model_router_response(
-            "azure_ai/grok-4-1-fast-reasoning", stamp=False
-        ),
+        init_response_obj=_model_router_response("azure_ai/grok-4-1-fast-reasoning", stamp=False),
         start_time=now,
         end_time=now,
         logging_obj=logging_obj,
@@ -5495,9 +5487,7 @@ class TestNonInferenceCallTypesAreNotBilled:
             init_response_obj=self._retrieved_response(),
             start_time=now,
             end_time=now,
-            logging_obj=self._logging_obj(
-                "aget_responses", litellm_metadata=self.BACKGROUND_POLL_METADATA
-            ),
+            logging_obj=self._logging_obj("aget_responses", litellm_metadata=self.BACKGROUND_POLL_METADATA),
             status="success",
         )
 
@@ -5743,9 +5733,7 @@ async def test_streaming_success_callbacks_survive_cost_calculation_failure():
     releasing.async_log_success_event = AsyncMock()
 
     patcher, logging_obj = _streaming_logging_obj_with_callbacks([releasing])
-    with patcher, patch.object(
-        logging_obj, "_response_cost_calculator", side_effect=ValueError("bad usage block")
-    ):
+    with patcher, patch.object(logging_obj, "_response_cost_calculator", side_effect=ValueError("bad usage block")):
         await logging_obj.async_success_handler(result=_assembled_stream_result())
 
     assert logging_obj.model_call_details["response_cost"] is None
@@ -5758,8 +5746,9 @@ async def test_streaming_success_callbacks_survive_standard_logging_payload_fail
     releasing.async_log_success_event = AsyncMock()
 
     patcher, logging_obj = _streaming_logging_obj_with_callbacks([releasing])
-    with patcher, patch.object(
-        logging_obj, "_build_standard_logging_payload", side_effect=ValueError("incomplete stream")
+    with (
+        patcher,
+        patch.object(logging_obj, "_build_standard_logging_payload", side_effect=ValueError("incomplete stream")),
     ):
         await logging_obj.async_success_handler(result=_assembled_stream_result())
 
@@ -6032,6 +6021,8 @@ def test_prompt_hooks_skip_prompt_managers_when_no_prompt_id(logging_obj, tmp_pa
             )
         for hook in [cb for cb in litellm.callbacks if isinstance(cb, VectorStorePreCallHook)]:
             litellm.logging_callback_manager.remove_callback_from_list_by_object(litellm.callbacks, hook)
+
+
 def test_newrelic_dispatch_prefers_otel_v2_when_flag_on(monkeypatch):
     """With LITELLM_OTEL_V2 on, the "newrelic" callback builds the OTel v2
     logger (per-team credential routing); with the flag off (default) it keeps
@@ -6184,7 +6175,9 @@ def test_get_error_information_skips_traceback_for_budget_rejection_with_provide
     from litellm.litellm_core_utils.litellm_logging import StandardLoggingPayloadSetup
 
     assert litellm.log_client_error_tracebacks is False
-    over_budget = _raise_and_catch(litellm.BudgetExceededError(current_cost=0.01, max_budget=0.0, llm_provider="anthropic"))
+    over_budget = _raise_and_catch(
+        litellm.BudgetExceededError(current_cost=0.01, max_budget=0.0, llm_provider="anthropic")
+    )
     result = StandardLoggingPayloadSetup.get_error_information(over_budget)
     assert result["error_code"] == "429"
     assert result["llm_provider"] == "anthropic"
@@ -6413,6 +6406,8 @@ def test_get_standard_logging_object_payload_survives_logging_obj_without_timing
         ("x-request-id", "response"),
         ("request-id", "response"),
         ("x-ms-request-id", "response"),
+        ("apim-request-id", "response"),
+        ("x-goog-request-id", "response"),
         ("cf-ray", "response"),
         ("X-Request-Id", "litellm_response_headers"),
         ("X-MS-Request-ID", "headers"),
@@ -6606,9 +6601,7 @@ def test_passthrough_embeddings_result_swapped_for_callbacks():
             ],
             "model": "EmbeddingsGigaR",
         },
-        request=httpx.Request(
-            "POST", "https://gigachat.devices.sberbank.ru/api/v1/embeddings"
-        ),
+        request=httpx.Request("POST", "https://gigachat.devices.sberbank.ru/api/v1/embeddings"),
     )
 
     _, _, swapped_result = logging_obj._success_handler_helper_fn(
@@ -6627,12 +6620,14 @@ def test_get_status_fields_ranks_guardrail_flagged_between_success_and_intervene
     request-level guardrail_status but never mask an intervention."""
     flagged = {"guardrail_status": "guardrail_flagged"}
 
-    assert _get_status_fields(
-        "success", [{"guardrail_status": "success"}, flagged], None
-    )["guardrail_status"] == "guardrail_flagged"
-    assert _get_status_fields(
-        "success", [flagged, {"guardrail_status": "guardrail_intervened"}], None
-    )["guardrail_status"] == "guardrail_intervened"
+    assert (
+        _get_status_fields("success", [{"guardrail_status": "success"}, flagged], None)["guardrail_status"]
+        == "guardrail_flagged"
+    )
+    assert (
+        _get_status_fields("success", [flagged, {"guardrail_status": "guardrail_intervened"}], None)["guardrail_status"]
+        == "guardrail_intervened"
+    )
 
 
 def test_get_error_information_redacts_provider_key_from_upstream_url():

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -1,7 +1,9 @@
+import asyncio
 import contextlib
+import datetime
 import os
 import sys
-import asyncio
+from typing import Literal
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -6418,9 +6420,11 @@ def test_get_standard_logging_object_payload_survives_logging_obj_without_timing
         ("X-MS-Request-ID", "headers"),
     ),
 )
-def test_failure_standard_logging_payload_captures_provider_request_id(logging_obj, header_name, header_source):
-    import datetime
-
+def test_failure_standard_logging_payload_captures_provider_request_id(
+    logging_obj: LitellmLogging,
+    header_name: str,
+    header_source: Literal["response", "litellm_response_headers", "headers"],
+):
     from litellm.litellm_core_utils.litellm_logging import (
         get_standard_logging_object_payload,
     )
@@ -6452,9 +6456,7 @@ def test_failure_standard_logging_payload_captures_provider_request_id(logging_o
     assert payload["error_information"]["error_provider_request_id"] == request_id
 
 
-def test_get_error_information_ignores_unsupported_headers():
-    import httpx
-
+def test_get_error_information_ignores_unsupported_headers() -> None:
     from litellm.litellm_core_utils.litellm_logging import StandardLoggingPayloadSetup
 
     request = httpx.Request("POST", "https://provider.example/v1/chat/completions")
@@ -6466,9 +6468,7 @@ def test_get_error_information_ignores_unsupported_headers():
     assert error_information["error_provider_request_id"] is None
 
 
-def test_get_error_information_uses_header_precedence_and_fallback():
-    import httpx
-
+def test_get_error_information_uses_header_precedence_and_fallback() -> None:
     from litellm.exceptions import RateLimitError
     from litellm.litellm_core_utils.litellm_logging import StandardLoggingPayloadSetup
 
@@ -6491,7 +6491,7 @@ def test_get_error_information_uses_header_precedence_and_fallback():
     assert error_information["error_provider_request_id"] == "amazon-id"
 
 
-def test_get_error_information_ignores_malformed_headers():
+def test_get_error_information_ignores_malformed_headers() -> None:
     from litellm.litellm_core_utils.litellm_logging import StandardLoggingPayloadSetup
 
     provider_error = Exception("provider error")

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -6504,6 +6504,17 @@ def test_get_error_information_ignores_malformed_headers() -> None:
     assert error_information["error_provider_request_id"] is None
 
 
+def test_get_provider_request_id_ignores_header_lookup_errors() -> None:
+    from litellm.litellm_core_utils.litellm_logging import _get_provider_request_id
+
+    class HeaderLookupError(Exception):
+        @property
+        def response(self) -> object:
+            raise RuntimeError("headers unavailable")
+
+    assert _get_provider_request_id(HeaderLookupError("provider error")) is None
+
+
 def test_get_standard_logging_object_payload_failure_status_keeps_overhead_none(logging_obj):
     """A post_call guardrail can fail the request after the upstream call succeeded; the failure
     payload keeps litellm_overhead_time_ms None, matching responses that carry their own _hidden_params."""


### PR DESCRIPTION
## TLDR

Problem this solves:

- Failure logs omit provider request IDs
- Operators cannot match failures to provider requests

How it solves it:

- Reads seven supported request ID headers case-insensitively
- Adds the ID to standard error metadata and spend logs

## User Flow

Before: a developer receives a provider failure but cannot match it to the provider request

1. They send `POST http://localhost:20433/v1/chat/completions` with a model that returns an upstream error
2. The proxy returns HTTP 404 for the upstream failure
3. They open `http://localhost:20433/ui/?page=logs` and inspect the failed request
4. The Metadata pane has error details but no provider request ID

After: the developer can match the same failure to the provider request

1. They send `POST http://localhost:20433/v1/chat/completions` with the same model
2. The proxy returns HTTP 404 for the same upstream failure
3. They open `http://localhost:20433/ui/?page=logs` and inspect the failed request
4. The Metadata pane shows `error_provider_request_id` with the provider request ID

## Relevant issues

## Linear ticket

Resolves LIT-5429

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

The 2026-09-07 run used the exact base and head below, real OpenAI calls, four workers per proxy, and separate Postgres databases. Both sides set `router_settings.disable_cooldowns: true` and `num_retries: 0` so upstream failures could not be hidden by router cooldown. Worker PID captures confirmed failures reached all four workers on each side

The first eight failure pairs alternated which side ran first, followed by concurrent requests until every worker was observed. The default DB traceback limit was also tested; the final comparison used `MAX_STRING_LENGTH_PROMPT_IN_DB=20000` on both sides to prevent different worktree path lengths from changing traceback truncation

Reproduce a streaming startup failure using the rig's missing-model alias, changing the port to `20435` for base

```bash
curl -sS -N -D - http://localhost:20433/v1/chat/completions \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
  -H 'Content-Type: application/json' \
  -d '{"model":"lit5429-real-error","messages":[{"role":"user","content":"Say exactly OK"}],"stream":true,"stream_options":{"include_usage":true},"max_tokens":16}'
```

The failure alias targets `openai/gpt-5-mini-does-not-exist-lit5429`; the control alias targets `openai/gpt-5-mini`. Both use the same real provider credential

### Before (02522a5441)

#### Streaming startup failure

1. Send the streaming request above to `http://localhost:20435/v1/chat/completions`
2. All 56 attempts returned HTTP 404 with the provider's missing-model error, never a router cooldown 429
3. All 56 failure callbacks had a request ID on the upstream exception but omitted `error_provider_request_id` from their standard payload
4. All 56 corresponding persisted failure rows omitted the field

#### Streaming control

1. Send the same request with `"model":"lit5429-control"` to `http://localhost:20435/v1/chat/completions`
2. All eight attempts returned HTTP 200 and an SSE stream ending with `[DONE]`
3. The model, chunks, finish reason, token counts, and usage cost matched head

#### Logs metadata

1. Read the failed request through `GET http://localhost:20435/spend/logs/ui` with its `request_id`, `start_date=2026-09-07 00:00:00`, and `end_date=2026-09-08 00:00:00`
2. The HTTP 200 response omitted `metadata.error_information.error_provider_request_id`

### After (8cfcc1e3cc)

#### Streaming startup failure

1. Send the same streaming request to `http://localhost:20433/v1/chat/completions`
2. All 56 attempts returned HTTP 404 with identical error bodies to base, never a router cooldown 429
3. All 56 standard failure payloads contained `error_provider_request_id` matching the upstream exception's request ID
4. All 56 corresponding persisted failure rows contained that same ID
5. Full error metadata differed only by the added field after worktree-path normalization; no existing keys or values changed

#### Streaming control

1. Send the same request with `"model":"lit5429-control"` to `http://localhost:20433/v1/chat/completions`
2. All eight attempts returned HTTP 200 and an SSE stream ending with `[DONE]`
3. Full SSE payloads matched base after replacing only response IDs and creation timestamps
4. Full successful spend rows differed only in independent IDs, timestamps, and request duration

#### Logs metadata

1. Read the failed request through `GET http://localhost:20433/spend/logs/ui` with its `request_id`, `start_date=2026-09-07 00:00:00`, and `end_date=2026-09-08 00:00:00`
2. The HTTP 200 response contained `metadata.error_information.error_provider_request_id` with the same ID as the callback and stored row

The existing real dashboard capture shows the same field in the Logs Metadata pane at `http://localhost:20433/ui/?page=logs`

![Logs UI showing provider request ID](https://raw.githubusercontent.com/BerriAI/litellm/assets-lit5429/docs/assets/lit5429-provider-request-id.png)

## Behavior changes

### Added

- Failure metadata can contain `error_provider_request_id`

### Removed or renamed

- None

### Migration for existing users

- None required

### Regression tests

- Mapped logging tests cover every supported header and fallback path
- Unsupported and malformed headers remain ignored

## Type

Bug Fix

## Caveats (if any)

These existing limitations are outside extracting IDs from exception headers

### Medium

- OTel v1 and v2 spans do not map the new field
- Datadog failure hooks and LLM Obs do not map it
- `lite debug` does not map the field
- Passthrough failures can lose upstream headers before logging
- Headerless mid-stream transport failures cannot supply a request ID

### Low

- Mistral and Kong request ID headers remain unsupported

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

ran /live-pr-risk and found no regressions/backward incompatible risks
