### PR TITLE
fix(vertex_ai): recurse into anyOf in _fix_enum_empty_strings for nullable enums

### DIFF
--- a/litellm/llms/vertex_ai/common_utils.py
+++ b/litellm/llms/vertex_ai/common_utils.py
@@ -511,6 +511,9 @@ def _fix_enum_empty_strings(schema, depth=0):
     if depth > DEFAULT_MAX_RECURSE_DEPTH:
         raise ValueError(f"Max depth of {DEFAULT_MAX_RECURSE_DEPTH} exceeded while processing schema.")
 
+    if not isinstance(schema, dict):
+        return
+
     if "enum" in schema and isinstance(schema["enum"], list):
         schema["enum"] = [None if value == "" else value for value in schema["enum"]]
 
@@ -523,6 +526,12 @@ def _fix_enum_empty_strings(schema, depth=0):
     items: Final = schema.get("items", None)
     if items is not None:
         _fix_enum_empty_strings(items, depth=depth + 1)
+
+    anyof = schema.get("anyOf", None)
+    if anyof is not None and isinstance(anyof, list):
+        for item in anyof:
+            if isinstance(item, dict):
+                _fix_enum_empty_strings(item, depth=depth + 1)
 
 
 def _fix_enum_types(schema, depth=0):

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
@@ -885,6 +885,46 @@ def test_fix_enum_empty_strings():
     assert "tablet" in enum_values
 
 
+def test_fix_enum_empty_strings_anyof():
+    """Test _fix_enum_empty_strings handles anyOf structures including nullable enums."""
+    from litellm.llms.vertex_ai.common_utils import _fix_enum_empty_strings
+
+    schema = {
+        "type": "object",
+        "properties": {
+            "mode": {
+                "anyOf": [
+                    {"enum": ["", "fast", "slow"], "type": "string"},
+                    {"type": "null"},
+                ]
+            },
+            "complex_choice": {
+                "anyOf": [
+                    {"enum": ["", "option1"], "type": "string"},
+                    {"type": "integer"},
+                ]
+            },
+        },
+    }
+
+    _fix_enum_empty_strings(schema)
+
+    mode_enum = schema["properties"]["mode"]["anyOf"][0]["enum"]
+    assert "" not in mode_enum
+    assert None in mode_enum
+    assert mode_enum == [None, "fast", "slow"]
+
+    choice_enum = schema["properties"]["complex_choice"]["anyOf"][0]["enum"]
+    assert "" not in choice_enum
+    assert None in choice_enum
+    assert choice_enum == [None, "option1"]
+
+    # Non-dict input should not raise AttributeError
+    _fix_enum_empty_strings("string_input")
+    _fix_enum_empty_strings(None)
+
+
+
 def test_get_vertex_model_id_from_url():
     """Test get_vertex_model_id_from_url with various URLs"""
     from litellm.llms.vertex_ai.common_utils import get_vertex_model_id_from_url

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
@@ -919,7 +919,6 @@ def test_fix_enum_empty_strings_anyof():
     assert None in choice_enum
     assert choice_enum == [None, "option1"]
 
-    # Non-dict input should not raise AttributeError
     _fix_enum_empty_strings("string_input")
     _fix_enum_empty_strings(None)
 


### PR DESCRIPTION
Closes #40003

### Problem
When schemas define nullable enums via `anyOf` (e.g. from Pydantic `Optional[Literal["", "fast", "slow"]]`), `_fix_enum_empty_strings` in `litellm/llms/vertex_ai/common_utils.py` traversed `properties` and `items` but did not recurse into `anyOf` sub-schemas. As a result, empty strings in nullable enums were not sanitized into `None`, leading to Gemini API rejections on tool calling. Additionally, calling `_fix_enum_empty_strings` with a non-dict schema could raise `AttributeError`.

### Solution
1. Added non-dict early return guard in `_fix_enum_empty_strings`.
2. Added recursion into `anyOf` list items, matching the recursion pattern in `_fix_enum_types`.
3. Added regression tests in `tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py` (`test_fix_enum_empty_strings_anyof`).