### PR TITLE
test: skip symlink and POSIX file-mode tests on Windows

### DIFF
--- a/tests/test_litellm/proxy/client/cli/test_claude_settings.py
+++ b/tests/test_litellm/proxy/client/cli/test_claude_settings.py
@@ -1,6 +1,7 @@
 import json
 import shlex
 import stat
+import sys
 import time
 from unittest.mock import patch
 
@@ -94,6 +95,7 @@ class TestWriteClaudeSettings:
 
         assert "ANTHROPIC_API_KEY" not in json.loads(settings_path.read_text())["env"]
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX mode bits (0o600) are not enforced on Windows")
     def test_written_file_is_owner_only(self, paths, lite_on_path):
         settings_path, backup_path = paths
         write_claude_settings("https://proxy.example.com", settings_path, _owners(backup_path))
@@ -240,6 +242,7 @@ class TestConflictingOwnersOfTheSettingsFile:
 
 
 class TestDoesNotDestroyUserOwnedStructure:
+    @pytest.mark.skipif(sys.platform == "win32", reason="symlink_to needs elevation or Developer Mode on Windows")
     def test_writes_through_a_symlinked_settings_file(self, tmp_path, lite_on_path):
         """os.replace() swaps the symlink for a regular file, detaching a dotfiles repo.
 

--- a/tests/test_litellm/proxy/common_utils/test_static_asset_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_static_asset_utils.py
@@ -7,6 +7,7 @@ arbitrary local image paths working while refusing non-image files like
 """
 
 import os
+import sys
 
 import pytest
 
@@ -52,6 +53,7 @@ class TestResolveValidatedLocalImagePath:
         result = resolve_validated_local_image_path("/proc/self/environ")
         assert result is None
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="os.symlink needs elevation or Developer Mode on Windows")
     def test_rejects_symlink_pointing_to_non_image(self, tmp_path):
         secret = tmp_path / "secret.txt"
         secret.write_text("password=hunter2")
@@ -62,6 +64,7 @@ class TestResolveValidatedLocalImagePath:
 
         assert result is None
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="os.symlink needs elevation or Developer Mode on Windows")
     def test_accepts_symlink_pointing_to_image(self, tmp_path):
         logo = tmp_path / "real_logo.png"
         logo.write_bytes(b"\x89PNG\r\n\x1a\nfake png body")


### PR DESCRIPTION
## Summary

Fixes #40046.

Four tests fail deterministically on Windows when run as a non-elevated user:

| Test | File | Failure |
|---|---|---|
| `test_rejects_symlink_pointing_to_non_image` | `test_static_asset_utils.py` | `OSError: [WinError 1314]` — symlink needs elevation |
| `test_accepts_symlink_pointing_to_image` | `test_static_asset_utils.py` | `OSError: [WinError 1314]` — symlink needs elevation |
| `test_writes_through_a_symlinked_settings_file` | `test_claude_settings.py` | `OSError: [WinError 1314]` — symlink needs elevation |
| `test_written_file_is_owner_only` | `test_claude_settings.py` | `AssertionError: assert 438 == 384` (0o666 vs 0o600) |

The first three call `os.symlink` / `Path.symlink_to`. Windows allows symlink creation only for elevated processes or when Developer Mode is enabled — neither is the default. The fourth asserts `stat.S_IMODE(...) == 0o600`; POSIX mode bits are not enforced on Windows and `chmod` is a no-op, so the file comes back as `0o666`.

The fix adds `@pytest.mark.skipif(sys.platform == "win32", reason="...")` to all four tests, matching the pattern already used in `tests/test_litellm/proxy/db/test_query_engine_reaper.py`. No CI job currently runs the suite on Windows, so these tests only surface on contributors' local machines.

## Test plan

- [ ] `pytest tests/test_litellm/proxy/common_utils/test_static_asset_utils.py tests/test_litellm/proxy/client/cli/test_claude_settings.py -v` passes on macOS/Linux
- [ ] Same command on Windows: 4 tests skipped instead of erroring