### PR TITLE
feat(cloudflare): support Workers AI reranking via /ai/run

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -1602,6 +1602,9 @@ if TYPE_CHECKING:
     from .llms.hosted_vllm.rerank.transformation import (
         HostedVLLMRerankConfig as HostedVLLMRerankConfig,
     )
+    from .llms.cloudflare.rerank.transformation import (
+        CloudflareRerankConfig as CloudflareRerankConfig,
+    )
     from .llms.nvidia_nim.rerank.transformation import (
         NvidiaNimRerankConfig as NvidiaNimRerankConfig,
     )

--- a/litellm/_lazy_imports_registry.py
+++ b/litellm/_lazy_imports_registry.py
@@ -153,6 +153,7 @@ LLM_CONFIG_NAMES: Final = (
     "JinaAIRerankConfig",
     "DeepinfraRerankConfig",
     "HostedVLLMRerankConfig",
+    "CloudflareRerankConfig",
     "NvidiaNimRerankConfig",
     "NvidiaNimRankingConfig",
     "VertexAIRerankConfig",
@@ -680,6 +681,10 @@ _LLM_CONFIGS_IMPORT_MAP: Final = {
     "HostedVLLMRerankConfig": (
         ".llms.hosted_vllm.rerank.transformation",
         "HostedVLLMRerankConfig",
+    ),
+    "CloudflareRerankConfig": (
+        ".llms.cloudflare.rerank.transformation",
+        "CloudflareRerankConfig",
     ),
     "NvidiaNimRerankConfig": (
         ".llms.nvidia_nim.rerank.transformation",

--- a/litellm/llms/cloudflare/chat/transformation.py
+++ b/litellm/llms/cloudflare/chat/transformation.py
@@ -11,19 +11,7 @@ from litellm.secret_managers.main import (
 )
 from litellm.types.llms.openai import AllMessageValues
 
-
-class CloudflareError(BaseLLMException):
-    def __init__(self, status_code, message):
-        self.status_code = status_code
-        self.message = message
-        self.request = httpx.Request(method="POST", url="https://api.cloudflare.com")
-        self.response = httpx.Response(status_code=status_code, request=self.request)
-        super().__init__(
-            status_code=status_code,
-            message=message,
-            request=self.request,
-            response=self.response,
-        )
+from ..common_utils import CloudflareError
 
 
 class CloudflareChatConfig(OpenAIGPTConfig):

--- a/litellm/llms/cloudflare/common_utils.py
+++ b/litellm/llms/cloudflare/common_utils.py
@@ -1,0 +1,17 @@
+import httpx
+
+from litellm.llms.base_llm.chat.transformation import BaseLLMException
+
+
+class CloudflareError(BaseLLMException):
+    def __init__(self, status_code: int, message: str) -> None:
+        self.status_code = status_code
+        self.message = message
+        self.request = httpx.Request(method="POST", url="https://api.cloudflare.com")
+        self.response = httpx.Response(status_code=status_code, request=self.request)
+        super().__init__(
+            status_code=status_code,
+            message=message,
+            request=self.request,
+            response=self.response,
+        )

--- a/litellm/llms/cloudflare/rerank/transformation.py
+++ b/litellm/llms/cloudflare/rerank/transformation.py
@@ -1,0 +1,286 @@
+"""
+Translate between Cohere's `/rerank` format and Cloudflare Workers AI's `/ai/run/<model>` format.
+
+Workers AI reranking is not served by the OpenAI-compatible `/ai/v1` surface, so this targets
+the native run path. Its request uses `contexts[].text` instead of `documents[]`, and its
+response returns `{id, score}` pairs where `score` is a raw logit rather than a 0-1 relevance.
+"""
+
+import math
+from collections.abc import Mapping, Sequence
+from typing import Final
+
+import httpx
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+from litellm._uuid import uuid
+from litellm.exceptions import UnsupportedParamsError
+from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+from litellm.llms.base_llm.chat.transformation import BaseLLMException
+from litellm.llms.base_llm.rerank.transformation import BaseRerankConfig
+from litellm.secret_managers.main import get_secret_str, normalize_nonempty_secret_str
+from litellm.types.rerank import (
+    OptionalRerankParams,
+    RerankBilledUnits,
+    RerankResponse,
+    RerankResponseDocument,
+    RerankResponseMeta,
+    RerankResponseResult,
+    RerankTokens,
+)
+
+from ..common_utils import CloudflareError
+
+RUN_PATH: Final = "/ai/run"
+OPENAI_COMPAT_PATH: Final = "/ai/v1"
+SUPPORTED_COHERE_PARAMS: Final = ("query", "documents", "top_n", "return_documents")
+
+
+class CloudflareRerankParams(BaseModel):
+    """The Cohere-format rerank params this provider needs, validated off the untyped param dict."""
+
+    model_config = ConfigDict(frozen=True)
+
+    query: str
+    documents: tuple[str | Mapping[str, object], ...]
+    top_n: int | None = None
+
+
+class CloudflareRerankContext(BaseModel):
+    """One entry of the `contexts` array Workers AI scores against."""
+
+    model_config = ConfigDict(frozen=True)
+
+    text: str
+
+
+class CloudflareRerankRequest(BaseModel):
+    """The body Workers AI reranking expects at `/ai/run/<model>`."""
+
+    model_config = ConfigDict(frozen=True)
+
+    query: str
+    contexts: tuple[CloudflareRerankContext, ...]
+    top_k: int | None = None
+
+
+class CloudflareRerankScore(BaseModel):
+    """One `{id, score}` pair, where `id` indexes into the request's `contexts`."""
+
+    model_config = ConfigDict(frozen=True)
+
+    id: int
+    score: float
+
+
+class CloudflareRerankResult(BaseModel):
+    """The `result` block of a Workers AI reranking response."""
+
+    model_config = ConfigDict(frozen=True)
+
+    response: tuple[CloudflareRerankScore, ...] | None = None
+
+
+class CloudflareRerankEnvelope(BaseModel):
+    """The Cloudflare v4 API envelope wrapping a Workers AI reranking result."""
+
+    model_config = ConfigDict(frozen=True)
+
+    result: CloudflareRerankResult | None = None
+    success: bool = True
+    errors: tuple[Mapping[str, object], ...] = ()
+
+
+def sigmoid(score: float) -> float:
+    """Map a raw reranker logit onto the 0-1 relevance range Cohere clients expect."""
+    if score >= 0:
+        return 1.0 / (1.0 + math.exp(-score))
+    exponentiated: Final = math.exp(score)
+    return exponentiated / (1.0 + exponentiated)
+
+
+def context_text(document: str | Mapping[str, object]) -> str:
+    """Read the scorable text out of one Cohere-format rerank document."""
+    if isinstance(document, str):
+        return document
+    text: Final = document.get("text")
+    if isinstance(text, str):
+        return text
+    raise ValueError(f"Cloudflare rerank documents must be strings or objects with a 'text' field, got {document!r}")
+
+
+def validated_rerank_params(optional_rerank_params: Mapping[str, object]) -> CloudflareRerankParams:
+    """Turn the untyped Cohere param mapping into the typed params this provider sends."""
+    try:
+        return CloudflareRerankParams.model_validate(optional_rerank_params)
+    except ValidationError as error:
+        raise ValueError(f"Invalid Cloudflare rerank request: {error}") from error
+
+
+def validated_rerank_envelope(raw_response: httpx.Response) -> CloudflareRerankEnvelope:
+    """Decode a Workers AI reranking response, or fail with the body that could not be read."""
+    try:
+        return CloudflareRerankEnvelope.model_validate_json(raw_response.text)
+    except ValidationError as error:
+        raise CloudflareError(
+            status_code=raw_response.status_code,
+            message=f"Error parsing Cloudflare rerank response: {raw_response.text}",
+        ) from error
+
+
+def context_texts(request_data: Mapping[str, object] | None) -> tuple[str, ...]:
+    """Recover the request's context texts so scored indices can be echoed back as documents."""
+    if request_data is None:
+        return ()
+    try:
+        request: Final = CloudflareRerankRequest.model_validate(request_data)
+    except ValidationError:
+        return ()
+    return tuple(context.text for context in request.contexts)
+
+
+class CloudflareRerankConfig(BaseRerankConfig):
+    def get_complete_url(
+        self,
+        api_base: str | None,
+        model: str,
+        optional_params: Mapping[str, object] | None = None,
+    ) -> str:
+        if api_base is None:
+            account_id: Final = normalize_nonempty_secret_str(get_secret_str("CLOUDFLARE_ACCOUNT_ID"))
+            if account_id is None:
+                raise ValueError(
+                    "Missing CLOUDFLARE_ACCOUNT_ID - set CLOUDFLARE_ACCOUNT_ID in the environment "
+                    "or pass api_base explicitly"
+                )
+            return f"https://api.cloudflare.com/client/v4/accounts/{account_id}{RUN_PATH}/{model}"
+
+        trimmed: Final = api_base.rstrip("/")
+        if trimmed.endswith(f"{RUN_PATH}/{model}"):
+            return trimmed
+        if trimmed.endswith(OPENAI_COMPAT_PATH):
+            return f"{trimmed[: -len(OPENAI_COMPAT_PATH)]}{RUN_PATH}/{model}"
+        if trimmed.endswith(RUN_PATH):
+            return f"{trimmed}/{model}"
+        return f"{trimmed}{RUN_PATH}/{model}"
+
+    def validate_environment(
+        self,
+        headers: Mapping[str, str],
+        model: str,
+        api_key: str | None = None,
+        optional_params: Mapping[str, object] | None = None,
+        litellm_params: Mapping[str, object] | None = None,
+    ) -> dict:
+        resolved_key: Final = api_key or get_secret_str("CLOUDFLARE_API_KEY")
+        if resolved_key is None:
+            raise ValueError(
+                "Missing Cloudflare API key - set CLOUDFLARE_API_KEY in the environment or pass api_key explicitly"
+            )
+        defaults: Final = (
+            ("Authorization", f"Bearer {resolved_key}"),
+            ("accept", "application/json"),
+            ("content-type", "application/json"),
+        )
+        return dict((*defaults, *headers.items()))  # mutable-ok: BaseRerankConfig fixes this return type as dict
+
+    def get_supported_cohere_rerank_params(self, model: str) -> list:
+        return sorted(SUPPORTED_COHERE_PARAMS)
+
+    def map_cohere_rerank_params(
+        self,
+        non_default_params: Mapping[str, object] | None,
+        model: str,
+        drop_params: bool,
+        query: str,
+        documents: list[str | dict[str, object]],
+        custom_llm_provider: str | None = None,
+        top_n: int | None = None,
+        rank_fields: Sequence[str] | None = None,
+        return_documents: bool | None = True,
+        max_chunks_per_doc: int | None = None,
+        max_tokens_per_doc: int | None = None,
+        instruction: str | None = None,
+    ) -> dict:
+        rejected: Final = tuple(
+            name
+            for name, value in (
+                ("rank_fields", rank_fields),
+                ("max_chunks_per_doc", max_chunks_per_doc),
+                ("max_tokens_per_doc", max_tokens_per_doc),
+                ("instruction", instruction),
+            )
+            if value is not None
+        )
+        if rejected and not drop_params:
+            raise UnsupportedParamsError(
+                status_code=400,
+                message=f"cloudflare rerank does not support {', '.join(rejected)}. Pass `drop_params=True` to ignore.",
+            )
+        return OptionalRerankParams(query=query, documents=documents, top_n=top_n)
+
+    def transform_rerank_request(
+        self,
+        model: str,
+        optional_rerank_params: Mapping[str, object],
+        headers: Mapping[str, str],
+        litellm_params: Mapping[str, object] | None = None,
+    ) -> dict:
+        params: Final = validated_rerank_params(optional_rerank_params)
+        return CloudflareRerankRequest(
+            query=params.query,
+            contexts=tuple(CloudflareRerankContext(text=context_text(document)) for document in params.documents),
+            top_k=params.top_n,
+        ).model_dump(exclude_none=True, mode="json")
+
+    def transform_rerank_response(
+        self,
+        model: str,
+        raw_response: httpx.Response,
+        model_response: RerankResponse,
+        logging_obj: LiteLLMLoggingObj,
+        api_key: str | None = None,
+        request_data: Mapping[str, object] | None = None,
+        optional_params: Mapping[str, object] | None = None,
+        litellm_params: Mapping[str, object] | None = None,
+    ) -> RerankResponse:
+        logging_obj.post_call(original_response=raw_response.text)
+
+        envelope: Final = validated_rerank_envelope(raw_response)
+        if not envelope.success:
+            raise CloudflareError(
+                status_code=raw_response.status_code,
+                message=f"Cloudflare rerank request failed: {envelope.errors}",
+            )
+        scores: Final = envelope.result.response if envelope.result is not None else None
+        if scores is None:
+            raise CloudflareError(
+                status_code=raw_response.status_code,
+                message=f"No rerank results found in the Cloudflare response={raw_response.text}",
+            )
+
+        contexts: Final = context_texts(request_data)
+        return RerankResponse(
+            id=str(uuid.uuid4()),
+            results=tuple(self._transform_score(score, contexts) for score in scores),
+            meta=RerankResponseMeta(billed_units=RerankBilledUnits(), tokens=RerankTokens()),
+        )
+
+    def get_error_class(
+        self,
+        error_message: str,
+        status_code: int,
+        headers: Mapping[str, str] | httpx.Headers,
+    ) -> BaseLLMException:
+        return CloudflareError(status_code=status_code, message=error_message)
+
+    @staticmethod
+    def _transform_score(score: CloudflareRerankScore, contexts: Sequence[str]) -> RerankResponseResult:
+        scored: Final = RerankResponseResult(index=score.id, relevance_score=sigmoid(score.score))
+        if not 0 <= score.id < len(contexts):
+            return scored
+        with_document: Final[RerankResponseResult] = {
+            **scored,
+            "document": RerankResponseDocument(text=contexts[score.id]),
+        }
+        return with_document

--- a/litellm/llms/cloudflare/rerank/transformation.py
+++ b/litellm/llms/cloudflare/rerank/transformation.py
@@ -20,7 +20,6 @@ from litellm.llms.base_llm.chat.transformation import BaseLLMException
 from litellm.llms.base_llm.rerank.transformation import BaseRerankConfig
 from litellm.secret_managers.main import get_secret_str, normalize_nonempty_secret_str
 from litellm.types.rerank import (
-    OptionalRerankParams,
     RerankBilledUnits,
     RerankResponse,
     RerankResponseDocument,
@@ -44,6 +43,7 @@ class CloudflareRerankParams(BaseModel):
     query: str
     documents: tuple[str | Mapping[str, object], ...]
     top_n: int | None = None
+    return_documents: bool | None = None
 
 
 class CloudflareRerankContext(BaseModel):
@@ -146,7 +146,8 @@ class CloudflareRerankConfig(BaseRerankConfig):
         model: str,
         optional_params: Mapping[str, object] | None = None,
     ) -> str:
-        if api_base is None:
+        resolved_base: Final = api_base or get_secret_str("CLOUDFLARE_API_BASE")
+        if resolved_base is None:
             account_id: Final = normalize_nonempty_secret_str(get_secret_str("CLOUDFLARE_ACCOUNT_ID"))
             if account_id is None:
                 raise ValueError(
@@ -155,7 +156,7 @@ class CloudflareRerankConfig(BaseRerankConfig):
                 )
             return f"https://api.cloudflare.com/client/v4/accounts/{account_id}{RUN_PATH}/{model}"
 
-        trimmed: Final = api_base.rstrip("/")
+        trimmed: Final = resolved_base.rstrip("/")
         if trimmed.endswith(f"{RUN_PATH}/{model}"):
             return trimmed
         if trimmed.endswith(OPENAI_COMPAT_PATH):
@@ -171,7 +172,7 @@ class CloudflareRerankConfig(BaseRerankConfig):
         api_key: str | None = None,
         optional_params: Mapping[str, object] | None = None,
         litellm_params: Mapping[str, object] | None = None,
-    ) -> dict:
+    ) -> dict[str, str]:
         resolved_key: Final = api_key or get_secret_str("CLOUDFLARE_API_KEY")
         if resolved_key is None:
             raise ValueError(
@@ -184,7 +185,7 @@ class CloudflareRerankConfig(BaseRerankConfig):
         )
         return dict((*defaults, *headers.items()))  # mutable-ok: BaseRerankConfig fixes this return type as dict
 
-    def get_supported_cohere_rerank_params(self, model: str) -> list:
+    def get_supported_cohere_rerank_params(self, model: str) -> list[str]:
         return sorted(SUPPORTED_COHERE_PARAMS)
 
     def map_cohere_rerank_params(
@@ -193,7 +194,7 @@ class CloudflareRerankConfig(BaseRerankConfig):
         model: str,
         drop_params: bool,
         query: str,
-        documents: list[str | dict[str, object]],
+        documents: Sequence[str | Mapping[str, object]],
         custom_llm_provider: str | None = None,
         top_n: int | None = None,
         rank_fields: Sequence[str] | None = None,
@@ -201,7 +202,7 @@ class CloudflareRerankConfig(BaseRerankConfig):
         max_chunks_per_doc: int | None = None,
         max_tokens_per_doc: int | None = None,
         instruction: str | None = None,
-    ) -> dict:
+    ) -> dict[str, object]:
         rejected: Final = tuple(
             name
             for name, value in (
@@ -217,7 +218,12 @@ class CloudflareRerankConfig(BaseRerankConfig):
                 status_code=400,
                 message=f"cloudflare rerank does not support {', '.join(rejected)}. Pass `drop_params=True` to ignore.",
             )
-        return OptionalRerankParams(query=query, documents=documents, top_n=top_n)
+        return CloudflareRerankParams(
+            query=query,
+            documents=tuple(documents),
+            top_n=top_n,
+            return_documents=return_documents,
+        ).model_dump(mode="json")
 
     def transform_rerank_request(
         self,
@@ -225,7 +231,7 @@ class CloudflareRerankConfig(BaseRerankConfig):
         optional_rerank_params: Mapping[str, object],
         headers: Mapping[str, str],
         litellm_params: Mapping[str, object] | None = None,
-    ) -> dict:
+    ) -> dict[str, object]:
         params: Final = validated_rerank_params(optional_rerank_params)
         return CloudflareRerankRequest(
             query=params.query,
@@ -259,7 +265,8 @@ class CloudflareRerankConfig(BaseRerankConfig):
                 message=f"No rerank results found in the Cloudflare response={raw_response.text}",
             )
 
-        contexts: Final = context_texts(request_data)
+        echo_documents: Final = optional_params is None or optional_params.get("return_documents") is not False
+        contexts: Final = context_texts(request_data) if echo_documents else ()
         return RerankResponse(
             id=str(uuid.uuid4()),
             results=tuple(self._transform_score(score, contexts) for score in scores),

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -1178,6 +1178,7 @@ class BaseLLMHTTPHandler:
                 api_key=api_key,
                 timeout=timeout,
                 client=client,
+                optional_rerank_params=optional_rerank_params,
             )
 
         if client is None or not isinstance(client, HTTPHandler):
@@ -1205,6 +1206,7 @@ class BaseLLMHTTPHandler:
             logging_obj=logging_obj,
             api_key=api_key,
             request_data=data,
+            optional_params=optional_rerank_params,
         )
 
     async def arerank(
@@ -1220,6 +1222,7 @@ class BaseLLMHTTPHandler:
         api_key: str | None = None,
         timeout: float | httpx.Timeout | None = None,
         client: HTTPHandler | AsyncHTTPHandler | None = None,
+        optional_rerank_params: dict | None = None,
     ) -> RerankResponse:
         if client is None or not isinstance(client, AsyncHTTPHandler):
             async_httpx_client = get_async_httpx_client(llm_provider=litellm.LlmProviders(custom_llm_provider))
@@ -1243,6 +1246,7 @@ class BaseLLMHTTPHandler:
             logging_obj=logging_obj,
             api_key=api_key,
             request_data=request_data,
+            optional_params=optional_rerank_params,
         )
 
     def _prepare_audio_transcription_request(

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -60661,6 +60661,18 @@
         "mode": "embedding",
         "output_cost_per_token": 0.0
     },
+    "cloudflare/@cf/baai/bge-reranker-base": {
+        "input_cost_per_token": 3.1e-09,
+        "litellm_provider": "cloudflare",
+        "max_input_tokens": 512,
+        "max_tokens": 512,
+        "mode": "rerank",
+        "output_cost_per_token": 0.0,
+        "source": "https://developers.cloudflare.com/workers-ai/models/bge-reranker-base/",
+        "supported_endpoints": [
+            "/v1/rerank"
+        ]
+    },
     "cloudflare/@cf/openai/whisper": {
         "input_cost_per_second": 7.5e-06,
         "litellm_provider": "cloudflare",

--- a/litellm/rerank_api/main.py
+++ b/litellm/rerank_api/main.py
@@ -101,6 +101,7 @@ def rerank(
             "cohere",
             "together_ai",
             "azure_ai",
+            "cloudflare",
             "infinity",
             "litellm_proxy",
             "hosted_vllm",
@@ -386,6 +387,31 @@ def rerank(
                 extra_headers=merged_headers,
                 logging_obj=litellm_logging_obj,
                 client=client,
+            )
+        elif _custom_llm_provider == litellm.LlmProviders.CLOUDFLARE:
+            api_key = dynamic_api_key or optional_params.api_key or get_secret_str("CLOUDFLARE_API_KEY")
+
+            api_base = (
+                dynamic_api_base
+                or optional_params.api_base
+                or litellm.api_base
+                or get_secret_str("CLOUDFLARE_API_BASE")
+            )
+
+            response = base_llm_http_handler.rerank(
+                model=model,
+                custom_llm_provider=_custom_llm_provider,
+                provider_config=rerank_provider_config,
+                optional_rerank_params=optional_rerank_params,
+                logging_obj=litellm_logging_obj,
+                timeout=optional_params.timeout,
+                api_key=api_key,
+                api_base=api_base,
+                _is_async=_is_async,
+                headers=headers or litellm.headers,
+                client=client,
+                model_response=model_response,
+                litellm_params=rerank_litellm_params,
             )
         elif _custom_llm_provider == litellm.LlmProviders.HOSTED_VLLM:
             # Implement Hosted VLLM rerank logic

--- a/litellm/rerank_api/main.py
+++ b/litellm/rerank_api/main.py
@@ -389,14 +389,10 @@ def rerank(
                 client=client,
             )
         elif _custom_llm_provider == litellm.LlmProviders.CLOUDFLARE:
-            api_key = dynamic_api_key or optional_params.api_key or get_secret_str("CLOUDFLARE_API_KEY")
+            # CloudflareRerankConfig resolves the key, account id and base URL itself.
+            api_key = dynamic_api_key or optional_params.api_key
 
-            api_base = (
-                dynamic_api_base
-                or optional_params.api_base
-                or litellm.api_base
-                or get_secret_str("CLOUDFLARE_API_BASE")
-            )
+            api_base = dynamic_api_base or optional_params.api_base or litellm.api_base
 
             response = base_llm_http_handler.rerank(
                 model=model,

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -8390,35 +8390,14 @@ class ProviderConfigManager:
         if litellm.LlmProviders.COHERE == provider or litellm.LlmProviders.COHERE_CHAT == provider:
             if should_use_cohere_v1_client(api_base, present_version_params):
                 return litellm.CohereRerankConfig()
-            else:
-                return litellm.CohereRerankV2Config()
-        elif litellm.LlmProviders.AZURE_AI == provider:
-            return litellm.AzureAIRerankConfig()
-        elif litellm.LlmProviders.INFINITY == provider:
-            return litellm.InfinityRerankConfig()
-        elif litellm.LlmProviders.JINA_AI == provider:
-            return litellm.JinaAIRerankConfig()
-        elif litellm.LlmProviders.HOSTED_VLLM == provider:
-            return litellm.HostedVLLMRerankConfig()
-        elif litellm.LlmProviders.HUGGINGFACE == provider:
-            return litellm.HuggingFaceRerankConfig()
-        elif litellm.LlmProviders.DEEPINFRA == provider:
-            return litellm.DeepinfraRerankConfig()
-        elif litellm.LlmProviders.NVIDIA_NIM == provider:
+            return litellm.CohereRerankV2Config()
+        if litellm.LlmProviders.NVIDIA_NIM == provider:
             from litellm.llms.nvidia_nim.rerank.common_utils import (
                 get_nvidia_nim_rerank_config,
             )
 
             return get_nvidia_nim_rerank_config(model)
-        elif litellm.LlmProviders.VERTEX_AI == provider:
-            return litellm.VertexAIRerankConfig()
-        elif litellm.LlmProviders.FIREWORKS_AI == provider:
-            return litellm.FireworksAIRerankConfig()
-        elif litellm.LlmProviders.VOYAGE == provider:
-            return litellm.VoyageRerankConfig()
-        elif litellm.LlmProviders.WATSONX == provider:
-            return litellm.IBMWatsonXRerankConfig()
-        elif provider in (
+        if provider in (
             litellm.LlmProviders.DASHSCOPE,
             litellm.LlmProviders.QWENCLOUD,
             litellm.LlmProviders.QWEN_AI_PLATFORM,
@@ -8428,6 +8407,33 @@ class ProviderConfigManager:
             )
 
             return get_dashscope_family_rerank_config(provider.value)
+        return ProviderConfigManager._get_single_deployment_rerank_config(provider)
+
+    @staticmethod
+    def _get_single_deployment_rerank_config(provider: LlmProviders) -> BaseRerankConfig:
+        """The providers whose rerank config depends on nothing but the provider itself."""
+        if litellm.LlmProviders.AZURE_AI == provider:
+            return litellm.AzureAIRerankConfig()
+        if litellm.LlmProviders.INFINITY == provider:
+            return litellm.InfinityRerankConfig()
+        if litellm.LlmProviders.JINA_AI == provider:
+            return litellm.JinaAIRerankConfig()
+        if litellm.LlmProviders.CLOUDFLARE == provider:
+            return litellm.CloudflareRerankConfig()
+        if litellm.LlmProviders.HOSTED_VLLM == provider:
+            return litellm.HostedVLLMRerankConfig()
+        if litellm.LlmProviders.HUGGINGFACE == provider:
+            return litellm.HuggingFaceRerankConfig()
+        if litellm.LlmProviders.DEEPINFRA == provider:
+            return litellm.DeepinfraRerankConfig()
+        if litellm.LlmProviders.VERTEX_AI == provider:
+            return litellm.VertexAIRerankConfig()
+        if litellm.LlmProviders.FIREWORKS_AI == provider:
+            return litellm.FireworksAIRerankConfig()
+        if litellm.LlmProviders.VOYAGE == provider:
+            return litellm.VoyageRerankConfig()
+        if litellm.LlmProviders.WATSONX == provider:
+            return litellm.IBMWatsonXRerankConfig()
         return litellm.CohereRerankConfig()
 
     @staticmethod

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -60661,6 +60661,18 @@
         "mode": "embedding",
         "output_cost_per_token": 0.0
     },
+    "cloudflare/@cf/baai/bge-reranker-base": {
+        "input_cost_per_token": 3.1e-09,
+        "litellm_provider": "cloudflare",
+        "max_input_tokens": 512,
+        "max_tokens": 512,
+        "mode": "rerank",
+        "output_cost_per_token": 0.0,
+        "source": "https://developers.cloudflare.com/workers-ai/models/bge-reranker-base/",
+        "supported_endpoints": [
+            "/v1/rerank"
+        ]
+    },
     "cloudflare/@cf/openai/whisper": {
         "input_cost_per_second": 7.5e-06,
         "litellm_provider": "cloudflare",

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -540,7 +540,7 @@
         "audio_speech": false,
         "moderations": false,
         "batches": false,
-        "rerank": false,
+        "rerank": true,
         "a2a": true,
         "interactions": true
       }

--- a/tests/test_litellm/llms/cloudflare/test_cloudflare_rerank_transformation.py
+++ b/tests/test_litellm/llms/cloudflare/test_cloudflare_rerank_transformation.py
@@ -69,7 +69,6 @@ def test_url_without_account_id_raises(config, monkeypatch):
     ],
 )
 def test_url_normalizes_every_accepted_base_form(config, api_base):
-    """The OpenAI-compat base is the one users already have, but rerank only lives on /ai/run."""
     assert config.get_complete_url(api_base=api_base, model=MODEL) == RUN_URL
 
 
@@ -155,7 +154,7 @@ def test_request_rejects_documents_without_text(config):
         )
 
 
-def test_map_params_keeps_the_three_supported_params(config):
+def test_map_params_keeps_only_the_supported_params(config):
     mapped = config.map_cohere_rerank_params(
         non_default_params={},
         model=MODEL,
@@ -165,7 +164,7 @@ def test_map_params_keeps_the_three_supported_params(config):
         top_n=1,
     )
 
-    assert mapped == {"query": "q", "documents": ["a", "b"], "top_n": 1}
+    assert mapped == {"query": "q", "documents": ["a", "b"], "top_n": 1, "return_documents": True}
 
 
 @pytest.mark.parametrize(
@@ -200,7 +199,7 @@ def test_map_params_drops_unsupported_params_when_asked(config):
         instruction="rank these",
     )
 
-    assert mapped == {"query": "q", "documents": ["a"], "top_n": None}
+    assert mapped == {"query": "q", "documents": ["a"], "top_n": None, "return_documents": True}
 
 
 def test_response_sigmoids_logits_and_preserves_cloudflare_ordering(config, logging_obj):
@@ -220,6 +219,66 @@ def test_response_sigmoids_logits_and_preserves_cloudflare_ordering(config, logg
     assert all(0.0 <= r["relevance_score"] <= 1.0 for r in result.results)
     assert result.results[0]["document"] == {"text": "a gateway"}
     assert result.results[1]["document"] == {"text": "bananas"}
+
+
+@pytest.mark.parametrize(
+    "optional_params, expects_document",
+    [
+        ({"return_documents": False}, False),
+        ({"return_documents": True}, True),
+        ({}, True),
+        (None, True),
+    ],
+)
+def test_response_echoes_documents_only_when_the_caller_wants_them(
+    config, logging_obj, optional_params, expects_document
+):
+    result = config.transform_rerank_response(
+        model=MODEL,
+        raw_response=cloudflare_response([{"id": 0, "score": 1.0}]),
+        model_response=RerankResponse(),
+        logging_obj=logging_obj,
+        request_data={"query": "q", "contexts": [{"text": "bananas"}]},
+        optional_params=optional_params,
+    )
+
+    assert ("document" in result.results[0]) is expects_document
+
+
+def test_map_params_forwards_return_documents_to_the_response_transform(config):
+    """Cloudflare never echoes documents, so the flag has to survive the request mapping."""
+    mapped = config.map_cohere_rerank_params(
+        non_default_params={},
+        model=MODEL,
+        drop_params=False,
+        query="q",
+        documents=["a"],
+        return_documents=False,
+    )
+
+    assert mapped["return_documents"] is False
+
+
+def test_rerank_respects_return_documents_false_end_to_end(monkeypatch):
+    monkeypatch.setenv("CLOUDFLARE_ACCOUNT_ID", "acct")
+    monkeypatch.setenv("CLOUDFLARE_API_KEY", "cf-key")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert "return_documents" not in json.loads(request.content)
+        return cloudflare_response([{"id": 0, "score": 1.0}])
+
+    client = HTTPHandler()
+    client.client = httpx.Client(transport=httpx.MockTransport(handler))
+
+    response = litellm.rerank(
+        model="cloudflare/@cf/baai/bge-reranker-base",
+        query="q",
+        documents=["bananas"],
+        return_documents=False,
+        client=client,
+    )
+
+    assert "document" not in response.results[0]
 
 
 def test_response_omits_document_when_index_is_out_of_range(config, logging_obj):
@@ -296,7 +355,6 @@ def test_sigmoid_is_monotonic_so_ranking_survives_normalisation():
 
 
 def test_rerank_routes_cloudflare_models_to_the_workers_ai_run_endpoint(monkeypatch):
-    """Covers provider resolution, the rerank_api dispatch branch and the lazy config export."""
     monkeypatch.setenv("CLOUDFLARE_ACCOUNT_ID", "acct")
     monkeypatch.setenv("CLOUDFLARE_API_KEY", "cf-key")
     captured = {}

--- a/tests/test_litellm/llms/cloudflare/test_cloudflare_rerank_transformation.py
+++ b/tests/test_litellm/llms/cloudflare/test_cloudflare_rerank_transformation.py
@@ -1,0 +1,352 @@
+import json
+import math
+
+import httpx
+import pytest
+
+import litellm
+from litellm.exceptions import UnsupportedParamsError
+from litellm.litellm_core_utils.litellm_logging import Logging
+from litellm.llms.cloudflare.common_utils import CloudflareError
+from litellm.llms.cloudflare.rerank.transformation import CloudflareRerankConfig, sigmoid
+from litellm.llms.custom_httpx.http_handler import HTTPHandler
+from litellm.types.rerank import RerankResponse
+
+MODEL = "@cf/baai/bge-reranker-base"
+ACCOUNT_BASE = "https://api.cloudflare.com/client/v4/accounts/acct"
+RUN_URL = f"{ACCOUNT_BASE}/ai/run/{MODEL}"
+
+
+@pytest.fixture
+def config():
+    return CloudflareRerankConfig()
+
+
+@pytest.fixture
+def logging_obj():
+    return Logging(
+        model=MODEL,
+        messages=[],
+        stream=False,
+        call_type="rerank",
+        start_time=None,
+        litellm_call_id="test-call-id",
+        function_id="test-function-id",
+    )
+
+
+def cloudflare_response(scores, success=True, status_code=200):
+    return httpx.Response(
+        status_code,
+        json={"result": {"response": scores}, "success": success, "errors": [], "messages": []},
+        request=httpx.Request("POST", RUN_URL),
+    )
+
+
+def test_url_defaults_to_account_run_path(config, monkeypatch):
+    monkeypatch.setenv("CLOUDFLARE_ACCOUNT_ID", "acct")
+
+    assert config.get_complete_url(api_base=None, model=MODEL) == RUN_URL
+
+
+def test_url_without_account_id_raises(config, monkeypatch):
+    monkeypatch.delenv("CLOUDFLARE_ACCOUNT_ID", raising=False)
+
+    with pytest.raises(ValueError, match="CLOUDFLARE_ACCOUNT_ID"):
+        config.get_complete_url(api_base=None, model=MODEL)
+
+
+@pytest.mark.parametrize(
+    "api_base",
+    [
+        ACCOUNT_BASE,
+        f"{ACCOUNT_BASE}/",
+        f"{ACCOUNT_BASE}/ai/v1",
+        f"{ACCOUNT_BASE}/ai/v1/",
+        f"{ACCOUNT_BASE}/ai/run",
+        f"{ACCOUNT_BASE}/ai/run/",
+        RUN_URL,
+    ],
+)
+def test_url_normalizes_every_accepted_base_form(config, api_base):
+    """The OpenAI-compat base is the one users already have, but rerank only lives on /ai/run."""
+    assert config.get_complete_url(api_base=api_base, model=MODEL) == RUN_URL
+
+
+def test_validate_environment_sets_bearer_token(config, monkeypatch):
+    monkeypatch.delenv("CLOUDFLARE_API_KEY", raising=False)
+
+    headers = config.validate_environment(headers={}, model=MODEL, api_key="cf-key")
+
+    assert headers["Authorization"] == "Bearer cf-key"
+    assert headers["content-type"] == "application/json"
+
+
+def test_validate_environment_falls_back_to_env_key(config, monkeypatch):
+    monkeypatch.setenv("CLOUDFLARE_API_KEY", "env-key")
+
+    headers = config.validate_environment(headers={}, model=MODEL, api_key=None)
+
+    assert headers["Authorization"] == "Bearer env-key"
+
+
+def test_validate_environment_lets_caller_headers_win(config):
+    headers = config.validate_environment(headers={"Authorization": "Bearer caller-key"}, model=MODEL, api_key="cf-key")
+
+    assert headers["Authorization"] == "Bearer caller-key"
+
+
+def test_validate_environment_without_key_raises(config, monkeypatch):
+    monkeypatch.delenv("CLOUDFLARE_API_KEY", raising=False)
+
+    with pytest.raises(ValueError, match="Cloudflare API key"):
+        config.validate_environment(headers={}, model=MODEL, api_key=None)
+
+
+def test_request_maps_documents_to_contexts_and_top_n_to_top_k(config):
+    body = config.transform_rerank_request(
+        model=MODEL,
+        optional_rerank_params={
+            "query": "which is cooler",
+            "documents": ["a cyberpunk lizzard", {"text": "a cyberpunk cat"}],
+            "top_n": 2,
+        },
+        headers={},
+    )
+
+    assert body == {
+        "query": "which is cooler",
+        "contexts": [{"text": "a cyberpunk lizzard"}, {"text": "a cyberpunk cat"}],
+        "top_k": 2,
+    }
+
+
+def test_request_omits_top_k_when_top_n_is_unset(config):
+    body = config.transform_rerank_request(
+        model=MODEL,
+        optional_rerank_params={"query": "q", "documents": ["a"], "top_n": None},
+        headers={},
+    )
+
+    assert "top_k" not in body
+
+
+@pytest.mark.parametrize(
+    "params, missing_field",
+    [
+        ({"documents": ["a"]}, "query"),
+        ({"query": "q"}, "documents"),
+    ],
+)
+def test_request_requires_query_and_documents(config, params, missing_field):
+    with pytest.raises(ValueError, match="Invalid Cloudflare rerank request") as failure:
+        config.transform_rerank_request(model=MODEL, optional_rerank_params=params, headers={})
+
+    assert missing_field in str(failure.value)
+    assert "Field required" in str(failure.value)
+
+
+def test_request_rejects_documents_without_text(config):
+    with pytest.raises(ValueError, match="'text' field"):
+        config.transform_rerank_request(
+            model=MODEL,
+            optional_rerank_params={"query": "q", "documents": [{"body": "no text key"}]},
+            headers={},
+        )
+
+
+def test_map_params_keeps_the_three_supported_params(config):
+    mapped = config.map_cohere_rerank_params(
+        non_default_params={},
+        model=MODEL,
+        drop_params=False,
+        query="q",
+        documents=["a", "b"],
+        top_n=1,
+    )
+
+    assert mapped == {"query": "q", "documents": ["a", "b"], "top_n": 1}
+
+
+@pytest.mark.parametrize(
+    "unsupported",
+    [
+        {"rank_fields": ["title"]},
+        {"max_chunks_per_doc": 4},
+        {"max_tokens_per_doc": 128},
+        {"instruction": "rank these"},
+    ],
+)
+def test_map_params_rejects_params_cloudflare_cannot_honour(config, unsupported):
+    with pytest.raises(UnsupportedParamsError, match=next(iter(unsupported))):
+        config.map_cohere_rerank_params(
+            non_default_params={},
+            model=MODEL,
+            drop_params=False,
+            query="q",
+            documents=["a"],
+            **unsupported,
+        )
+
+
+def test_map_params_drops_unsupported_params_when_asked(config):
+    mapped = config.map_cohere_rerank_params(
+        non_default_params={},
+        model=MODEL,
+        drop_params=True,
+        query="q",
+        documents=["a"],
+        rank_fields=["title"],
+        instruction="rank these",
+    )
+
+    assert mapped == {"query": "q", "documents": ["a"], "top_n": None}
+
+
+def test_response_sigmoids_logits_and_preserves_cloudflare_ordering(config, logging_obj):
+    request_data = {"query": "q", "contexts": [{"text": "bananas"}, {"text": "cars"}, {"text": "a gateway"}]}
+
+    result = config.transform_rerank_response(
+        model=MODEL,
+        raw_response=cloudflare_response([{"id": 2, "score": 5.1}, {"id": 0, "score": -1.0}]),
+        model_response=RerankResponse(),
+        logging_obj=logging_obj,
+        request_data=request_data,
+    )
+
+    assert [r["index"] for r in result.results] == [2, 0]
+    assert result.results[0]["relevance_score"] == pytest.approx(1 / (1 + math.exp(-5.1)))
+    assert result.results[1]["relevance_score"] == pytest.approx(1 / (1 + math.exp(1.0)))
+    assert all(0.0 <= r["relevance_score"] <= 1.0 for r in result.results)
+    assert result.results[0]["document"] == {"text": "a gateway"}
+    assert result.results[1]["document"] == {"text": "bananas"}
+
+
+def test_response_omits_document_when_index_is_out_of_range(config, logging_obj):
+    result = config.transform_rerank_response(
+        model=MODEL,
+        raw_response=cloudflare_response([{"id": 7, "score": 1.0}]),
+        model_response=RerankResponse(),
+        logging_obj=logging_obj,
+        request_data={"contexts": [{"text": "only one"}]},
+    )
+
+    assert "document" not in result.results[0]
+
+
+def test_response_rejects_a_failed_envelope(config, logging_obj):
+    raw = httpx.Response(
+        200,
+        json={"result": None, "success": False, "errors": [{"code": 7002, "message": "no route"}]},
+        request=httpx.Request("POST", RUN_URL),
+    )
+
+    with pytest.raises(CloudflareError, match="Cloudflare rerank request failed") as failure:
+        config.transform_rerank_response(
+            model=MODEL, raw_response=raw, model_response=RerankResponse(), logging_obj=logging_obj
+        )
+
+    assert "no route" in failure.value.message
+
+
+def test_response_rejects_missing_results(config, logging_obj):
+    raw = httpx.Response(200, json={"result": {}, "success": True}, request=httpx.Request("POST", RUN_URL))
+
+    with pytest.raises(CloudflareError, match="No rerank results"):
+        config.transform_rerank_response(
+            model=MODEL, raw_response=raw, model_response=RerankResponse(), logging_obj=logging_obj
+        )
+
+
+def test_response_rejects_non_json_body(config, logging_obj):
+    raw = httpx.Response(502, text="<html>bad gateway</html>", request=httpx.Request("POST", RUN_URL))
+
+    with pytest.raises(CloudflareError, match="Error parsing"):
+        config.transform_rerank_response(
+            model=MODEL, raw_response=raw, model_response=RerankResponse(), logging_obj=logging_obj
+        )
+
+
+def test_response_rejects_a_score_entry_missing_fields(config, logging_obj):
+    """An entry without a score cannot be ranked, so it is a malformed body rather than a gap."""
+    with pytest.raises(CloudflareError, match="Error parsing"):
+        config.transform_rerank_response(
+            model=MODEL,
+            raw_response=cloudflare_response([{"id": 0}]),
+            model_response=RerankResponse(),
+            logging_obj=logging_obj,
+        )
+
+
+@pytest.mark.parametrize("logit", [-800.0, -40.0, 0.0, 40.0, 800.0])
+def test_sigmoid_stays_in_range_without_overflowing(logit):
+    """math.exp(-logit) overflows well before these magnitudes, so the branchless form would raise."""
+    score = sigmoid(logit)
+
+    assert 0.0 <= score <= 1.0
+
+
+def test_sigmoid_is_monotonic_so_ranking_survives_normalisation():
+    logits = [-9.0, -1.5, 0.0, 1.5, 9.0]
+
+    scores = [sigmoid(logit) for logit in logits]
+
+    assert scores == sorted(scores)
+    assert sigmoid(0.0) == pytest.approx(0.5)
+
+
+def test_rerank_routes_cloudflare_models_to_the_workers_ai_run_endpoint(monkeypatch):
+    """Covers provider resolution, the rerank_api dispatch branch and the lazy config export."""
+    monkeypatch.setenv("CLOUDFLARE_ACCOUNT_ID", "acct")
+    monkeypatch.setenv("CLOUDFLARE_API_KEY", "cf-key")
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["auth"] = request.headers.get("authorization")
+        captured["body"] = json.loads(request.content)
+        return cloudflare_response([{"id": 2, "score": 5.1}, {"id": 0, "score": -1.0}])
+
+    client = HTTPHandler()
+    client.client = httpx.Client(transport=httpx.MockTransport(handler))
+
+    response = litellm.rerank(
+        model="cloudflare/@cf/baai/bge-reranker-base",
+        query="what is litellm",
+        documents=["bananas", "cars", "an LLM gateway"],
+        top_n=2,
+        client=client,
+    )
+
+    assert captured["url"] == RUN_URL
+    assert captured["auth"] == "Bearer cf-key"
+    assert captured["body"] == {
+        "query": "what is litellm",
+        "contexts": [{"text": "bananas"}, {"text": "cars"}, {"text": "an LLM gateway"}],
+        "top_k": 2,
+    }
+    assert [r["index"] for r in response.results] == [2, 0]
+    assert response.results[0]["relevance_score"] == pytest.approx(1 / (1 + math.exp(-5.1)))
+
+
+def test_rerank_honours_an_openai_compatible_api_base(monkeypatch):
+    """Deployments share one Cloudflare base URL, and for chat/embeddings that is the /ai/v1 form."""
+    monkeypatch.setenv("CLOUDFLARE_API_KEY", "cf-key")
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        return cloudflare_response([{"id": 0, "score": 1.0}])
+
+    client = HTTPHandler()
+    client.client = httpx.Client(transport=httpx.MockTransport(handler))
+
+    litellm.rerank(
+        model="cloudflare/@cf/baai/bge-reranker-base",
+        query="q",
+        documents=["a"],
+        api_base=f"{ACCOUNT_BASE}/ai/v1",
+        client=client,
+    )
+
+    assert captured["url"] == RUN_URL


### PR DESCRIPTION
## TLDR

Problem this solves:

- Cloudflare is chat-only, so Workers AI rerankers are unreachable
- The `openai/` workaround fails: LiteLLM has no OpenAI rerank surface
- Reranking is absent from Cloudflare's OpenAI-compatible `/ai/v1` base

How it solves it:

- New Cloudflare rerank provider targeting the native `/ai/run` path
- Translates `contexts[].text` and `{id, score}` to the Cohere shape
- Sigmoid maps raw logits onto the 0-1 relevance clients expect
- Documents echoed from request contexts, honoring `return_documents`
- One Cloudflare base URL now backs chat, embeddings and rerank

## User Flow

Before: a developer who wants Cloudflare Workers AI to rerank their RAG results cannot get a single successful call, whichever prefix they try

1. The proxy admin adds a deployment for `cloudflare/@cf/baai/bge-reranker-base` and restarts the proxy
2. The developer sends POST https://litellm-domain/v1/rerank with a query and three documents
3. The call comes back 500 saying the model is not mapped, because Cloudflare only ever served chat
4. The admin retries with the `openai/@cf/baai/bge-reranker-base` prefix, the same trick that works for Workers AI embeddings, and restarts again
5. The same POST now comes back 500 saying `Unsupported provider: openai`, so there is no prefix left to try
6. The developer gives up on Cloudflare and points their reranker somewhere else

After: the same deployment answers, and the response looks like every other reranker on the gateway

1. The proxy admin adds a deployment for `cloudflare/@cf/baai/bge-reranker-base` and restarts the proxy
2. The developer sends POST https://litellm-domain/v1/rerank with a query and three documents
3. The call comes back 200 with a `results` array, each entry carrying the index of the document it scored and a `relevance_score` between 0 and 1, sorted best first
4. Each entry also carries the document text back, so the developer can feed the ranking straight into their prompt without re-joining on index
5. The developer points an existing Cohere-format rerank client at the gateway and it works unchanged
6. https://litellm-domain/ui/?page=logs shows the request logged as a rerank call

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup, used for both sides. Set `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_KEY` in the environment, put this in the config, then run the proxy with `python litellm/proxy/proxy_cli.py --config <config> --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log`

```yaml
model_list:
  - model_name: bge-reranker-base
    litellm_params:
      model: cloudflare/@cf/baai/bge-reranker-base
      api_key: os.environ/CLOUDFLARE_API_KEY
  - model_name: bge-reranker-base-openai-prefix
    litellm_params:
      model: openai/@cf/baai/bge-reranker-base
      api_key: os.environ/CLOUDFLARE_API_KEY
      api_base: https://api.cloudflare.com/client/v4/accounts/<account-id>/ai/v1
```

The single request used everywhere below

```bash
curl -s http://localhost:4000/v1/rerank -H 'Authorization: Bearer sk-1234' \
  -H 'Content-Type: application/json' \
  -d '{"model":"MODEL_NAME","query":"what is litellm","documents":["bananas are yellow","a proxy that routes to 100+ LLM APIs","cars have four wheels"],"top_n":3}' | jq
```

### Before (02522a5441)

#### cloudflare/ prefix

1. Run the curl with `"model":"bge-reranker-base"`
2. Observed output: pending, to be captured on the merge base

#### openai/ prefix, the workaround that works for Workers AI embeddings

1. Run the curl with `"model":"bge-reranker-base-openai-prefix"`
2. Observed output: pending, to be captured on the merge base

### After (7ce6f12a90)

#### cloudflare/ prefix

1. Run the curl with `"model":"bge-reranker-base"`
2. Observed output: pending, to be captured at the PR tip

#### openai/ prefix, the workaround that works for Workers AI embeddings

1. Run the curl with `"model":"bge-reranker-base-openai-prefix"`
2. Observed output: pending, to be captured at the PR tip

## Type

🆕 New Feature

## Caveats (if any)

### Medium

- Cloudflare returns no token usage, so rerank spend logs $0
- bge-reranker-base caps at 512 tokens and silently truncates past it

### Low

- `rank_fields`, `instruction`, `max_chunks_per_doc` and `max_tokens_per_doc` are rejected unless `drop_params` is set
- The shared rerank handler now forwards `optional_params` to response transformation
  - It was declared on the base class but never populated; no other rerank provider reads it
- AI Gateway base URLs are not handled, matching what the chat config already does
- `get_provider_rerank_config` grew a helper for its single-deployment branches, to stay under the complexity ceiling this provider would have crossed

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
