### PR TITLE
fix(actions): handle missing gateway pricing fields

### DIFF
--- a/.github/scripts/auto_update_price_and_context_window_file.py
+++ b/.github/scripts/auto_update_price_and_context_window_file.py
@@ -85,21 +85,29 @@ def transform_openrouter_data(data):
 def transform_vercel_ai_gateway_data(data):
     transformed = {}
     for row in data:
-        obj = {
-            "max_tokens": row["context_window"],
-            "input_cost_per_token": float(row["pricing"]["input"]),
-            "output_cost_per_token": float(row["pricing"]["output"]),
-            'max_output_tokens': row['max_tokens'],
-            'max_input_tokens': row["context_window"],
-        }
+        obj = {}
+
+        context_window = row.get("context_window")
+        if context_window is not None:
+            obj["max_tokens"] = context_window
+            obj["max_input_tokens"] = context_window
+
+        max_output_tokens = row.get("max_tokens")
+        if max_output_tokens is not None:
+            obj["max_output_tokens"] = max_output_tokens
+
+        pricing = row.get("pricing") or {}
+        if pricing.get("input") is not None:
+            obj["input_cost_per_token"] = float(pricing["input"])
+        if pricing.get("output") is not None:
+            obj["output_cost_per_token"] = float(pricing["output"])
 
         # Handle cache pricing if available
-        if "pricing" in row:
-            if "input_cache_read" in row["pricing"] and row["pricing"]["input_cache_read"] is not None:
-                obj['cache_read_input_token_cost'] = float(f"{float(row['pricing']['input_cache_read']):e}")
-            
-            if "input_cache_write" in row["pricing"] and row["pricing"]["input_cache_write"] is not None:
-                obj['cache_creation_input_token_cost'] = float(f"{float(row['pricing']['input_cache_write']):e}")
+        if pricing.get("input_cache_read") is not None:
+            obj['cache_read_input_token_cost'] = float(f"{float(pricing['input_cache_read']):e}")
+
+        if pricing.get("input_cache_write") is not None:
+            obj['cache_creation_input_token_cost'] = float(f"{float(pricing['input_cache_write']):e}")
 
         mode = "embedding" if "embedding" in row["id"].lower() else "chat"
         

--- a/tests/test_litellm/test_auto_update_price_and_context_window.py
+++ b/tests/test_litellm/test_auto_update_price_and_context_window.py
@@ -1,0 +1,83 @@
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / ".github" / "scripts" / "auto_update_price_and_context_window_file.py"
+
+_spec = importlib.util.spec_from_file_location("auto_update_price_and_context_window", SCRIPT)
+assert _spec is not None and _spec.loader is not None
+updater: ModuleType = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(updater)
+
+
+def test_vercel_transform_omits_missing_and_null_optional_fields() -> None:
+    transformed = updater.transform_vercel_ai_gateway_data(
+        [
+            {
+                "id": "alibaba/qwen3-embedding-0.6b",
+                "context_window": 32768,
+                "max_tokens": None,
+                "pricing": {"input": "0.00000002"},
+            },
+            {"id": "provider/video-model"},
+            {
+                "id": "provider/chat-model",
+                "context_window": None,
+                "max_tokens": None,
+                "pricing": None,
+            },
+        ]
+    )
+
+    assert transformed == {
+        "vercel_ai_gateway/alibaba/qwen3-embedding-0.6b": {
+            "input_cost_per_token": 2e-08,
+            "litellm_provider": "vercel_ai_gateway",
+            "max_input_tokens": 32768,
+            "max_tokens": 32768,
+            "mode": "embedding",
+        },
+        "vercel_ai_gateway/provider/video-model": {
+            "litellm_provider": "vercel_ai_gateway",
+            "mode": "chat",
+        },
+        "vercel_ai_gateway/provider/chat-model": {
+            "litellm_provider": "vercel_ai_gateway",
+            "mode": "chat",
+        },
+    }
+
+
+def test_sync_preserves_existing_values_omitted_by_vercel() -> None:
+    local_data = {
+        "vercel_ai_gateway/alibaba/qwen3-embedding-0.6b": {
+            "input_cost_per_token": 1e-08,
+            "litellm_provider": "vercel_ai_gateway",
+            "max_input_tokens": 32768,
+            "mode": "embedding",
+            "output_cost_per_token": 9e-08,
+            "supports_pdf_input": True,
+        }
+    }
+    remote_data = updater.transform_vercel_ai_gateway_data(
+        [
+            {
+                "id": "alibaba/qwen3-embedding-0.6b",
+                "context_window": 65536,
+                "pricing": {"input": "0.00000002"},
+            }
+        ]
+    )
+
+    updater.sync_local_data_with_remote(local_data, remote_data)
+
+    assert local_data["vercel_ai_gateway/alibaba/qwen3-embedding-0.6b"] == {
+        "input_cost_per_token": 2e-08,
+        "litellm_provider": "vercel_ai_gateway",
+        "max_input_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "embedding",
+        "output_cost_per_token": 9e-08,
+        "supports_pdf_input": True,
+    }


### PR DESCRIPTION
## TLDR

Problem this solves:

- Importer crashes on Vercel models with no output price
- 117 of 373 live gateway models hit this today
- The weekly price-refresh job has been failing

How it solves it:

- Treat pricing and token limits as optional fields
- Omit them when the gateway sends null/nothing
- Existing local values survive, they are not overwritten

## User Flow

Before: nobody can refresh Vercel AI Gateway prices, so the shipped price list stays stale

1. A maintainer runs the price refresh against https://ai-gateway.vercel.sh/v1/models
2. The run dies with `KeyError: 'output'` on the first embedding model
3. No prices are written, so users pricing Vercel models keep the old numbers

After: the refresh completes and writes prices for every model the gateway lists

1. A maintainer runs the same refresh against the same URL
2. All 373 models are processed, including embedding and video models with partial pricing
3. Models with no published output price simply carry no output price, instead of blocking the run

## Relevant issues

No issue filed. The evidence is in this repo's own Actions history: the scheduled
`auto_update_price_and_context_window` workflow is failing on this line.

- Today's scheduled run: https://github.com/BerriAI/litellm/actions/runs/34000996531
- Of the 59 scheduled runs GitHub still retains (back to 2025-07-27), none succeeded
- Every run I opened (2026-06-21, 2026-08-02, 2026-09-06) fails identically

```
File ".github/scripts/auto_update_price_and_context_window_file.py", line 91, in transform_vercel_ai_gateway_data
    "output_cost_per_token": float(row["pricing"]["output"]),
KeyError: 'output'
```

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile Confidence Score of at least 4/5 (5/5 on `a4727400`)

## Screenshots / Proof of Fix

Shared setup:

```
curl -sS https://ai-gateway.vercel.sh/v1/models -o /tmp/vercel_models.json   # HTTP 200, 373 models
```

Both runs call `transform_vercel_ai_gateway_data` on that live payload.

### Before (02522a5441a1aabc7791304a31a9cdcae6db4a37)

1. Run the importer transform over the live payload
2. Observed: `CRASH: KeyError: 'output'` — 117 of 373 live models are missing a field the code required

### After (a47274000e03a32e6511583f508795f93ee76081)

1. Run the same transform over the same live payload
2. Observed: `OK: transformed 373 models`
3. Regression tests: `uv run --frozen pytest tests/test_litellm/test_auto_update_price_and_context_window.py tests/test_litellm/test_model_prices_schema.py -q` -> `23 passed`

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Models reporting `context_window: 0` keep `max_tokens: 0`
- Schema allows it; 15 committed entries already do this
