### PR TITLE
fix(proxy): preserve omitted metadata during scalar updates

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -2074,6 +2074,13 @@ def prepare_metadata_fields(data: BaseModel, non_default_values: dict, existing_
     """
     Check LiteLLM_ManagementEndpoint_MetadataFields (proxy/_types.py) for fields that are allowed to be updated
     """
+    data_json: Final = _as_object_dict(data.model_dump(exclude_unset=True, exclude_none=True))
+    if "metadata" not in non_default_values and not any(
+        field in LiteLLM_ManagementEndpoint_MetadataFields or field in LiteLLM_ManagementEndpoint_MetadataFields_Premium
+        for field in data_json
+    ):
+        return non_default_values
+
     raise_on_invalid_key_logging_config(non_default_values.get("metadata"))
 
     if "metadata" not in non_default_values:  # allow user to set metadata to none
@@ -2095,8 +2102,6 @@ def prepare_metadata_fields(data: BaseModel, non_default_values: dict, existing_
                 detail=f"{reserved_field} is immutable once set and cannot be changed via update.",
             )
         casted_metadata[reserved_field] = existing_value
-
-    data_json: Final = _as_object_dict(data.model_dump(exclude_unset=True, exclude_none=True))
 
     try:
         for k, v in data_json.items():

--- a/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
@@ -1,6 +1,7 @@
 import json
 from datetime import datetime, timezone
 from types import SimpleNamespace
+from typing import Final
 
 import pytest
 from fastapi.testclient import TestClient
@@ -22,6 +23,9 @@ from litellm.proxy.management_endpoints.internal_user_endpoints import (
     get_users,
     new_user,
     ui_view_users,
+)
+from litellm.proxy.management_endpoints.key_management_endpoints import (
+    prepare_metadata_fields,
 )
 from litellm.proxy.proxy_server import app
 
@@ -686,6 +690,22 @@ def test_update_user_request_pydantic_object():
     data_json = data.model_dump(exclude_unset=True)
 
     assert data_json == {"user_email": "test@example.com"}
+
+
+def test_update_internal_user_budget_omits_unchanged_metadata():
+    """A scalar user update must not write metadata from an earlier read."""
+    request_data: Final = UpdateUserRequest(user_id="test-user", max_budget=100)
+    update_values: Final = _update_internal_user_params(
+        request_data.model_dump(exclude_unset=True), request_data
+    )
+    prepared_values: Final = prepare_metadata_fields(
+        data=request_data,
+        non_default_values=update_values,
+        existing_metadata={"owner_label": "earlier-value"},
+    )
+
+    assert "metadata" not in prepared_values
+    assert prepared_values["max_budget"] == 100
 
 
 def test_update_internal_user_params_email():

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -1,5 +1,6 @@
 import json
 from datetime import datetime, timedelta, timezone
+from typing import Final
 
 import litellm
 import pytest
@@ -1922,18 +1923,25 @@ async def test_update_rejects_whole_metadata_null_on_service_account_key():
 
 @pytest.mark.asyncio
 async def test_update_without_metadata_still_preserves_existing():
-    """Omitting metadata entirely must not drop existing metadata fields."""
-    data = UpdateKeyRequest(key="sk-1", max_budget=100)
-    existing_key = LiteLLM_VerificationToken(
+    """A budget-only update must preserve metadata written after the initial read."""
+    data: Final = UpdateKeyRequest(key="sk-1", max_budget=100)
+    existing_key: Final = LiteLLM_VerificationToken(
         token="hashed",
         team_id="IJ",
         metadata={"service_account_id": "sa-123", "other": "kept"},
     )
 
-    result = await prepare_key_update_data(data=data, existing_key_row=existing_key)
+    result: Final = await prepare_key_update_data(data=data, existing_key_row=existing_key)
 
-    assert result["metadata"]["service_account_id"] == "sa-123"
-    assert result["metadata"]["other"] == "kept"
+    current_row: Final = {
+        "max_budget": 50,
+        "metadata": {"service_account_id": "sa-123", "other": "concurrent-value"},
+    }
+    saved_row: Final = current_row | result
+
+    assert "metadata" not in result
+    assert saved_row["max_budget"] == 100
+    assert saved_row["metadata"] == current_row["metadata"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## TLDR

Problem this solves:

- Budget updates can overwrite newer metadata they never supplied
- Key and user updates share the affected behavior

How it solves it:

- Leave untouched metadata out of the update payload
- Preserve existing validation for explicitly changed metadata

## User Flow

Before: saving a budget can undo another administrator's metadata change

1. An administrator creates a key at `POST http://127.0.0.1:56915/key/generate` with budget `100` and `metadata.proof_owner="initial"`
2. One administrator posts `metadata.proof_owner="parallel"` to `/key/update` while another posts only `max_budget=80` for the same key
3. Both updates return HTTP 200
4. `GET /key/info` reports budget `80` but the metadata has reverted to `initial`

After: saving the budget preserves the other administrator's metadata change

1. An administrator creates a key at `POST http://127.0.0.1:57256/key/generate` with budget `100` and `metadata.proof_owner="initial"`
2. One administrator posts `metadata.proof_owner="parallel"` to `/key/update` while another posts only `max_budget=80` for the same key
3. Both updates return HTTP 200
4. `GET /key/info` reports budget `80` and metadata remains `parallel`

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible
- [x] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

At head `f97f40c53227032946cfe09895b243825030c962`, GitHub reports 82 successful checks and one skipped check. Greptile reviewed this exact commit with Confidence Score 5/5 and no actionable failures. Maintainer approval remains separate.

Both existing key and user management test files passed: 579 tests, 72 dependency warnings, 254.24 seconds. The two changed-behavior regressions failed against the original source. Internet socket connections were forbidden during these unit runs

Python lint, strict-rule and test-quality budgets, type-discipline budgets, basedpyright comparison and scoped formatting passed. The type comparison allows existing baseline errors; this is not a zero-error type-check claim. Initial combined pre-commit validation found missing dashboard dependencies. After installing the lockfile, API snapshot and dashboard type generation passed separately and produced no contract changes

## Screenshots / Proof of Fix

These are actual curl requests against one local Uvicorn worker and a fresh PostgreSQL 16 database for each revision. No HTTP or database mocks and no provider inference were involved. Each phase used a distinct temporary database, unique key alias, private curl authorization file and reserved loopback socket inherited by the server. Both servers, both database containers and temporary credentials were removed afterward

The interleaving was controlled deliberately: a separate PostgreSQL transaction held `SELECT 1 FROM "LiteLLM_VerificationToken" WHERE token = <created-key-hash> FOR UPDATE`. The metadata request was started first and its database session was observed waiting on that controller. The budget request was then started and observed waiting behind the metadata writer using `pg_blocking_pids`. Only then was the controller committed. The controller never changed metadata or budget values; those writes used `/key/update`

The request files contained these bodies, with the same fresh alias within each phase:

```json
{"key_alias":"<fresh-alias>","max_budget":100,"metadata":{"proof_owner":"initial"}}
{"key_alias":"<fresh-alias>","metadata":{"proof_owner":"parallel"}}
{"key_alias":"<fresh-alias>","max_budget":80}
```

`curl.conf` supplied the local administrator authorization and JSON content type without placing credentials in arguments. Creation used `create.request.json`, the metadata update used `metadata.request.json`, and the budget update used `budget.request.json`. `KEY_HASH` was calculated from the newly created key and used only for the controller and final information request. The outputs below are the observed status codes and selected final response fields

### Before (02522a5441a1aabc7791304a31a9cdcae6db4a37)

1. Create the key:
   ```sh
   curl --silent --show-error --max-time 60 --config "$PROOF_DIR/curl.conf" --request POST http://127.0.0.1:56915/key/generate --data-binary "@$PROOF_DIR/create.request.json" --output "$PROOF_DIR/create.response.json" --write-out '%{http_code}'
   ```
   Observed HTTP `200`
2. Hold the controller row lock, start the metadata request, observe its waiter, start the budget request and observe the second waiter:
   ```sh
   curl --silent --show-error --max-time 60 --config "$PROOF_DIR/curl.conf" --request POST http://127.0.0.1:56915/key/update --data-binary "@$PROOF_DIR/metadata.request.json" --output "$PROOF_DIR/metadata.response.json" --write-out '%{http_code}'
   curl --silent --show-error --max-time 60 --config "$PROOF_DIR/curl.conf" --request POST http://127.0.0.1:56915/key/update --data-binary "@$PROOF_DIR/budget.request.json" --output "$PROOF_DIR/budget.response.json" --write-out '%{http_code}'
   ```
   Separate running curl processes produced the observed blocking chain `controller -> metadata writer -> budget writer`; after releasing the controller, both returned HTTP `200`
3. Read the saved state:
   ```sh
   curl --silent --show-error --max-time 20 --config "$PROOF_DIR/curl.conf" --get http://127.0.0.1:56915/key/info --data-urlencode "key=$KEY_HASH" --output "$PROOF_DIR/final.response.json" --write-out '%{http_code}'
   ```
   Observed HTTP `200`, `max_budget: 80.0`, `metadata.proof_owner: "initial"`

### After (f97f40c53227032946cfe09895b243825030c962)

1. Create the key:
   ```sh
   curl --silent --show-error --max-time 60 --config "$PROOF_DIR/curl.conf" --request POST http://127.0.0.1:57256/key/generate --data-binary "@$PROOF_DIR/create.request.json" --output "$PROOF_DIR/create.response.json" --write-out '%{http_code}'
   ```
   Observed HTTP `200`
2. Hold the controller row lock, start the metadata request, observe its waiter, start the budget request and observe the second waiter:
   ```sh
   curl --silent --show-error --max-time 60 --config "$PROOF_DIR/curl.conf" --request POST http://127.0.0.1:57256/key/update --data-binary "@$PROOF_DIR/metadata.request.json" --output "$PROOF_DIR/metadata.response.json" --write-out '%{http_code}'
   curl --silent --show-error --max-time 60 --config "$PROOF_DIR/curl.conf" --request POST http://127.0.0.1:57256/key/update --data-binary "@$PROOF_DIR/budget.request.json" --output "$PROOF_DIR/budget.response.json" --write-out '%{http_code}'
   ```
   Separate running curl processes produced the observed blocking chain `controller -> metadata writer -> budget writer`; after releasing the controller, both returned HTTP `200`
3. Read the saved state:
   ```sh
   curl --silent --show-error --max-time 20 --config "$PROOF_DIR/curl.conf" --get http://127.0.0.1:57256/key/info --data-urlencode "key=$KEY_HASH" --output "$PROOF_DIR/final.response.json" --write-out '%{http_code}'
   ```
   Observed HTTP `200`, `max_budget: 80.0`, `metadata.proof_owner: "parallel"`

## Type

Bug Fix

## Caveats (if any)

### Medium

- Explicit metadata writers still require separate concurrency protection
- This adds no compare-and-swap or revision check
- User updates have unit coverage, not this HTTP experiment

## Final Attestation

- [x] Tests cover omission through both existing callers, reserved fields, premium flags and callback encryption
