### PR TITLE
test: trace OCR parity through public SDK

### DIFF
--- a/litellm-rust/crates/python-bridge/src/function_trace.rs
+++ b/litellm-rust/crates/python-bridge/src/function_trace.rs
@@ -1,8 +1,22 @@
+use std::cell::Cell;
+use std::collections::HashMap;
 use std::future::Future;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, OnceLock};
 
 use litellm_core::observability::{FunctionTrace, FunctionTraceEvent};
+use litellm_python_interop::Pythonized;
+use pyo3::exceptions::PyRuntimeError;
+use pyo3::prelude::*;
 use serde::Serialize;
 use tracing::instrument::WithSubscriber;
+
+thread_local! {
+    static ACTIVE_CAPTURE: Cell<Option<u64>> = const { Cell::new(None) };
+}
+
+static NEXT_CAPTURE_ID: AtomicU64 = AtomicU64::new(1);
+static CAPTURES: OnceLock<Mutex<HashMap<u64, FunctionTrace>>> = OnceLock::new();
 
 #[derive(Serialize)]
 pub(crate) struct TracedResponse<T> {
@@ -19,4 +33,76 @@ pub(crate) async fn capture<T, E>(
         response,
         trace: trace.events(),
     })
+}
+
+pub(crate) fn capture_active<T, E>(
+    future: impl Future<Output = Result<T, E>>,
+) -> impl Future<Output = Result<T, E>> {
+    let trace = ACTIVE_CAPTURE.with(|active| {
+        active.get().and_then(|capture_id| {
+            captures()
+                .lock()
+                .unwrap_or_else(|error| error.into_inner())
+                .get(&capture_id)
+                .cloned()
+        })
+    });
+    async move {
+        match trace {
+            Some(trace) => future.with_subscriber(trace.dispatcher()).await,
+            None => future.await,
+        }
+    }
+}
+
+fn captures() -> &'static Mutex<HashMap<u64, FunctionTrace>> {
+    CAPTURES.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+#[pyfunction]
+fn start_capture() -> PyResult<u64> {
+    ACTIVE_CAPTURE.with(|active| {
+        if active.get().is_some() {
+            return Err(PyRuntimeError::new_err(
+                "a native trace capture is already active",
+            ));
+        }
+        let capture_id = NEXT_CAPTURE_ID.fetch_add(1, Ordering::Relaxed);
+        captures()
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .insert(capture_id, FunctionTrace::default());
+        active.set(Some(capture_id));
+        Ok(capture_id)
+    })
+}
+
+#[pyfunction]
+fn finish_capture(py: Python<'_>, capture_id: u64) -> PyResult<Py<PyAny>> {
+    ACTIVE_CAPTURE.with(|active| {
+        if active.get() != Some(capture_id) {
+            return Err(PyRuntimeError::new_err(
+                "native trace capture is not active on this thread",
+            ));
+        }
+        active.set(None);
+        let trace = captures()
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .remove(&capture_id)
+            .ok_or_else(|| PyRuntimeError::new_err("native trace capture does not exist"))?;
+        let events = trace.events();
+        if events.is_empty() {
+            return Err(PyRuntimeError::new_err(
+                "native trace capture did not observe a production bridge route",
+            ));
+        }
+        Pythonized(events).into_pyobject(py).map(Bound::unbind)
+    })
+}
+
+pub(crate) fn register(module: &Bound<'_, PyModule>) -> PyResult<()> {
+    module.add_function(wrap_pyfunction!(start_capture, module)?)?;
+    module.add_function(wrap_pyfunction!(finish_capture, module)?)?;
+    Ok(())
 }

--- a/litellm-rust/crates/python-bridge/src/lib.rs
+++ b/litellm-rust/crates/python-bridge/src/lib.rs
@@ -149,6 +149,8 @@ mod tests {
                         "chat_completions",
                         "achat_completions",
                         "gateway_messages",
+                        "start_capture",
+                        "finish_capture",
                     ]
                 );
             }

--- a/litellm-rust/crates/python-bridge/src/routes/definition.rs
+++ b/litellm-rust/crates/python-bridge/src/routes/definition.rs
@@ -31,6 +31,8 @@ macro_rules! bridge_route {
                 $($required_name,)*
                 $($optional_name),*
             })?;
+            #[cfg(feature = "trace-parity")]
+            let future = $crate::function_trace::capture_active(future);
             $crate::execution::run_sync(py, future, $map_error)
         }
 
@@ -46,6 +48,8 @@ macro_rules! bridge_route {
                 $($required_name,)*
                 $($optional_name),*
             })?;
+            #[cfg(feature = "trace-parity")]
+            let future = $crate::function_trace::capture_active(future);
             $crate::execution::run_async(py, future, $map_error)
         }
 
@@ -486,15 +490,63 @@ asyncio.run(exercise())
             let code = CString::new(
                 r#"
 result = routes.echo("traced")
-assert result == {
-    "response": "traced",
-    "trace": [{"function": "execute_echo", "depth": 0}],
-}
+assert result["response"] == "traced"
+assert [event["function"] for event in result["trace"]] == ["execute_echo"]
+assert result["trace"][0]["id"] == 0
+assert result["trace"][0]["parent_id"] is None
 "#,
             )
             .expect("Python source should not contain null bytes");
             py.run(&code, Some(&locals), Some(&locals))
                 .expect("diagnostic route should return its response and trace");
+        });
+    }
+
+    #[cfg(feature = "trace-parity")]
+    #[test]
+    fn production_routes_capture_sync_and_async_execution() {
+        Python::initialize();
+        Python::attach(|py| {
+            let routes = PyModule::new(py, "synthetic").expect("module should be created");
+            synthetic::register(&routes).expect("routes should register");
+            let trace = PyModule::new(py, "trace").expect("trace module should be created");
+            crate::function_trace::register(&trace).expect("trace controls should register");
+            let locals = PyDict::new(py);
+            locals
+                .set_item("routes", &routes)
+                .expect("routes should enter Python locals");
+            locals
+                .set_item("trace", &trace)
+                .expect("trace should enter Python locals");
+            let code = CString::new(
+                r#"
+import asyncio
+
+empty_capture = trace.start_capture()
+try:
+    trace.finish_capture(empty_capture)
+except RuntimeError as error:
+    assert "did not observe a production bridge route" in str(error)
+else:
+    raise AssertionError("empty capture succeeded")
+
+sync_capture = trace.start_capture()
+assert routes.echo("sync") == "sync"
+sync_trace = trace.finish_capture(sync_capture)
+assert [event["function"] for event in sync_trace] == ["execute_echo"]
+
+async def exercise():
+    async_capture = trace.start_capture()
+    assert await routes.aecho("async") == "async"
+    async_trace = trace.finish_capture(async_capture)
+    assert [event["function"] for event in async_trace] == ["execute_echo"]
+
+asyncio.run(exercise())
+"#,
+            )
+            .expect("Python source should not contain null bytes");
+            py.run(&code, Some(&locals), Some(&locals))
+                .expect("production routes should join active capture sessions");
         });
     }
 

--- a/litellm-rust/crates/python-bridge/src/routes/mod.rs
+++ b/litellm-rust/crates/python-bridge/src/routes/mod.rs
@@ -24,6 +24,7 @@ pub(crate) fn register(module: &Bound<'_, PyModule>) -> PyResult<()> {
         messages::register_trace(&trace)?;
         chat_completions::register_trace(&trace)?;
         gateway_messages::register_trace(&trace)?;
+        crate::function_trace::register(&trace)?;
         module.add_submodule(&trace)?;
     }
     Ok(())

--- a/tests/rust-python-harness/shared/native_build.py
+++ b/tests/rust-python-harness/shared/native_build.py
@@ -6,7 +6,7 @@ import subprocess
 import sys
 from collections.abc import Iterator
 from pathlib import Path
-from typing import Final
+from typing import Final, cast
 
 from litellm.rust_bridge import get_native_bridge, reset_native_bridge_cache
 
@@ -16,6 +16,17 @@ _RUST_ROOT: Final = "litellm-rust"
 _LOCKFILE: Final = "Cargo.lock"
 _SOURCE_SUFFIXES: Final = frozenset({".rs", ".toml"})
 _FAILURE_OUTPUT_LINES: Final = 15
+_CAPABILITY_PROBE: Final = """
+from litellm.rust_bridge import get_native_bridge
+bridge = get_native_bridge()
+trace = getattr(bridge, "_trace", None)
+if bridge is None:
+    raise SystemExit(10)
+if trace is None:
+    raise SystemExit(11)
+if not all(callable(getattr(trace, name, None)) for name in ("start_capture", "finish_capture")):
+    raise SystemExit(12)
+"""
 
 
 def needs_rebuild(native_mtime: float | None, newest_source_mtime: float | None) -> bool:
@@ -28,11 +39,18 @@ def needs_rebuild(native_mtime: float | None, newest_source_mtime: float | None)
 
 def _source_files(rust_root: Path) -> Iterator[Path]:
     for path in rust_root.rglob("*"):
-        relative: Final = path.relative_to(rust_root)
-        if "target" in relative.parts or not path.is_file():
+        if not _is_source_file(rust_root, path):
             continue
-        if path.name == _LOCKFILE or path.suffix in _SOURCE_SUFFIXES:
-            yield path
+        yield path
+
+
+def _is_source_file(rust_root: Path, path: Path) -> bool:
+    relative: Final = path.relative_to(rust_root)
+    return (
+        "target" not in relative.parts
+        and path.is_file()
+        and (path.name == _LOCKFILE or path.suffix in _SOURCE_SUFFIXES)
+    )
 
 
 def _newest_source_mtime(repo_root: Path) -> float | None:
@@ -47,8 +65,8 @@ def _native_module_path() -> Path | None:
         spec: Final = importlib.util.find_spec("litellm.rust_bridge._native")
     except (ImportError, ValueError):
         return None
-    origin: Final = getattr(spec, "origin", None)
-    return Path(origin) if origin else None
+    origin: Final = cast(str | None, getattr(spec, "origin", None))
+    return Path(origin) if origin is not None else None
 
 
 def _drop_imported_bridge() -> None:
@@ -74,23 +92,42 @@ def _rebuild(repo_root: Path) -> tuple[bool, str]:
 
 
 def trace_bridge_error() -> str | None:
-    bridge: Final = get_native_bridge()
+    bridge: Final = cast(object | None, get_native_bridge())
     if bridge is None:
         return "native Rust bridge is not importable"
-    if getattr(bridge, "_trace", None) is None:
+    trace: Final = cast(object | None, getattr(bridge, "_trace", None))
+    if trace is None:
         return f"native Rust bridge does not expose _trace; it must be built with the {BRIDGE_FEATURE} feature"
+    if not all(callable(getattr(trace, name, None)) for name in ("start_capture", "finish_capture")):
+        return "native Rust trace bridge does not expose public route capture controls"
     return None
+
+
+def _probe_trace_bridge_error() -> str | None:
+    completed: Final = subprocess.run(
+        (sys.executable, "-c", _CAPABILITY_PROBE),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return {
+        0: None,
+        10: "native Rust bridge is not importable",
+        11: f"native Rust bridge does not expose _trace; it must be built with the {BRIDGE_FEATURE} feature",
+        12: "native Rust trace bridge does not expose public route capture controls",
+    }.get(completed.returncode, f"native Rust bridge capability probe failed with exit code {completed.returncode}")
 
 
 def ensure_trace_bridge(repo_root: Path) -> str | None:
     native_path: Final = _native_module_path()
     native_mtime: Final = native_path.stat().st_mtime if native_path is not None and native_path.exists() else None
-    if needs_rebuild(native_mtime, _newest_source_mtime(repo_root)):
-        print(f"Rebuilding native Rust bridge ({BRIDGE_FEATURE} feature)...", flush=True)
-        succeeded: Final
-        output: Final
-        succeeded, output = _rebuild(repo_root)
-        if not succeeded:
-            return f"native Rust bridge rebuild failed:\n{output}"
+    capability_error: Final = _probe_trace_bridge_error()
+    if needs_rebuild(native_mtime, _newest_source_mtime(repo_root)) or capability_error is not None:
+        print(  # noqa: T201  # CLI users need progress during the native rebuild
+            f"Rebuilding native Rust bridge ({BRIDGE_FEATURE} feature)...", flush=True
+        )
+        rebuilt: Final = _rebuild(repo_root)
+        if not rebuilt[0]:
+            return f"native Rust bridge rebuild failed:\n{rebuilt[1]}"
         _drop_imported_bridge()
     return trace_bridge_error()

--- a/tests/rust-python-harness/shared/test_native_build.py
+++ b/tests/rust-python-harness/shared/test_native_build.py
@@ -65,9 +65,11 @@ def test_ensure_trace_bridge_rebuilds_when_stale(
         return True, ""
 
     monkeypatch.setattr(native_build, "_native_module_path", lambda: native)
+    monkeypatch.setattr(native_build, "_probe_trace_bridge_error", lambda: None)
     monkeypatch.setattr(native_build, "_rebuild", fake_rebuild)
     monkeypatch.setattr(native_build, "_drop_imported_bridge", lambda: None)
-    monkeypatch.setattr(native_build, "get_native_bridge", lambda: SimpleNamespace(_trace=object()))
+    trace: Final = SimpleNamespace(start_capture=lambda: 1, finish_capture=lambda capture_id: ())
+    monkeypatch.setattr(native_build, "get_native_bridge", lambda: SimpleNamespace(_trace=trace))
 
     assert native_build.ensure_trace_bridge(tmp_path) is None
     assert state.rebuilt is True
@@ -80,6 +82,7 @@ def test_ensure_trace_bridge_reports_failed_rebuild(tmp_path: Final, monkeypatch
     source.write_text("fn main() {}\n")
 
     monkeypatch.setattr(native_build, "_native_module_path", lambda: None)
+    monkeypatch.setattr(native_build, "_probe_trace_bridge_error", lambda: "bridge missing")
     monkeypatch.setattr(native_build, "_rebuild", lambda repo_root: (False, "boom"))
 
     message: Final = native_build.ensure_trace_bridge(tmp_path)
@@ -89,7 +92,7 @@ def test_ensure_trace_bridge_reports_failed_rebuild(tmp_path: Final, monkeypatch
     assert "boom" in message
 
 
-def test_ensure_trace_bridge_flags_missing_trace_feature_without_rebuild(
+def test_ensure_trace_bridge_rebuilds_for_missing_trace_feature(
     tmp_path: Final, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     native: Final = tmp_path / "_native.abi3.so"
@@ -106,11 +109,22 @@ def test_ensure_trace_bridge_flags_missing_trace_feature_without_rebuild(
         return True, ""
 
     monkeypatch.setattr(native_build, "_native_module_path", lambda: native)
+    monkeypatch.setattr(native_build, "_probe_trace_bridge_error", lambda: "missing trace feature")
     monkeypatch.setattr(native_build, "_rebuild", fake_rebuild)
-    monkeypatch.setattr(native_build, "get_native_bridge", lambda: SimpleNamespace(_trace=None))
+    trace: Final = SimpleNamespace(start_capture=lambda: 1, finish_capture=lambda capture_id: ())
+    monkeypatch.setattr(
+        native_build,
+        "get_native_bridge",
+        lambda: SimpleNamespace(_trace=trace if state.rebuilt else None),
+    )
 
     message: Final = native_build.ensure_trace_bridge(tmp_path)
 
-    assert message is not None
-    assert "_trace" in message
-    assert state.rebuilt is False
+    assert message is None
+    assert state.rebuilt is True
+
+
+def test_trace_bridge_flags_missing_public_capture_controls(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(native_build, "get_native_bridge", lambda: SimpleNamespace(_trace=object()))
+
+    assert native_build.trace_bridge_error() == "native Rust trace bridge does not expose public route capture controls"

--- a/tests/rust-python-harness/strategies/trace_parity/AGENTS.md
+++ b/tests/rust-python-harness/strategies/trace_parity/AGENTS.md
@@ -1,1 +1,1 @@
-Maps Python profiler frames onto feature-gated Rust span names via an explicit per-case mapping (Rust span name is the identity) and compares steps, order, and nesting of both live traces against a replayed provider response.
+Compares explicit Python-frame and feature-gated Rust-span mappings, order, and nesting at both direct pipeline and public SDK boundaries against replayed provider responses.

--- a/tests/rust-python-harness/strategies/trace_parity/models.py
+++ b/tests/rust-python-harness/strategies/trace_parity/models.py
@@ -9,6 +9,7 @@ from ...shared.reporting.models import SdkFunction
 from ...shared.tracing.steps import Engine, TraceContract, TraceMapping
 
 TraceMode = Literal["sync", "async"]
+TraceBoundary = Literal["pipeline", "public_sdk"]
 TraceFailureSource = Literal["python", "rust", "harness"]
 
 
@@ -43,6 +44,8 @@ class TraceScenario:
     contract: TraceContract = TraceContract()
     sync_mappings: tuple[TraceMapping, ...] | None = None
     async_mappings: tuple[TraceMapping, ...] | None = None
+    boundary: TraceBoundary = "pipeline"
+    rust_wrapper_mappings: tuple[TraceMapping, ...] = ()
 
     def mappings_for(self, mode: TraceMode) -> tuple[TraceMapping, ...]:
         selected: Final = self.async_mappings if mode == "async" else self.sync_mappings

--- a/tests/rust-python-harness/strategies/trace_parity/runner.py
+++ b/tests/rust-python-harness/strategies/trace_parity/runner.py
@@ -41,6 +41,13 @@ def validate_trace_suite(suite: TraceSuite, harness_case: HarnessCase) -> str | 
     )
     if invalid_modes:
         return f"scenarios must use non-empty, unique sync/async modes: {', '.join(invalid_modes)}"
+    invalid_public: Final = tuple(
+        scenario.name
+        for scenario in suite.scenarios
+        if scenario.boundary == "public_sdk" and not scenario.rust_wrapper_mappings
+    )
+    if invalid_public:
+        return f"public SDK scenarios require Rust wrapper mappings: {', '.join(invalid_public)}"
     surface: Final = harness_case.surface
     if surface == "sdk" and not isinstance(suite.route, RouteSpec):
         return "must use RouteSpec for the sdk surface"

--- a/tests/rust-python-harness/strategies/trace_parity/sdk/execution.py
+++ b/tests/rust-python-harness/strategies/trace_parity/sdk/execution.py
@@ -1,21 +1,65 @@
 from __future__ import annotations
 
 import asyncio
+import os
+import subprocess
+import sys
 from collections.abc import Awaitable
 from pathlib import Path
-from typing import Final, Protocol, cast
+from typing import Final, Literal, Protocol, cast
+
+from pydantic import BaseModel, ConfigDict, JsonValue, ValidationError
 
 from ....shared.parity.replay import replay_server
 from ....shared.reporting.models import Surface
 from ....shared.tracing.native import native_trace_events
 from ....shared.tracing.profiler import FunctionTraceEvent, profile_python
-from ....shared.tracing.steps import Engine, pipeline_projection
+from ....shared.tracing.steps import Engine, PipelineProjection, PipelineStep, pipeline_projection
 from ..models import RouteSpec, TraceExecutionFailure, TraceMode, TraceScenario
 from ..reporting import TraceComparisonArtifact
 
 
 class SdkCall(Protocol):
     def __call__(self, **kwargs: object) -> object: ...
+
+
+class _WorkerCommand(BaseModel):
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    asynchronous: bool
+    kwargs: dict[str, JsonValue]
+
+
+class _WorkerTraceEvent(BaseModel):
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    id: int
+    parent_id: int | None
+    function: str
+    module_path: str | None = None
+    file: str | None = None
+    line: int | None = None
+
+    def event(self) -> FunctionTraceEvent:
+        return FunctionTraceEvent(self.id, self.parent_id, self.function, self.module_path, self.file, self.line)
+
+
+class _WorkerSuccess(BaseModel):
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    python: tuple[_WorkerTraceEvent, ...]
+    native: tuple[_WorkerTraceEvent, ...]
+
+
+class _WorkerFailure(BaseModel):
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    status: Literal["error"] = "error"
+    message: str
+
+
+_WORKER_PREFIX: Final = "LITELLM_TRACE_RESULT "
 
 
 def _invoke(function: SdkCall, kwargs: dict[str, object], *, asynchronous: bool) -> object:
@@ -86,7 +130,175 @@ def collect_trace(
     return events
 
 
-def _failure_message(result: tuple[FunctionTraceEvent, ...] | TraceExecutionFailure) -> str | None:
+def _worker_event(event: FunctionTraceEvent) -> _WorkerTraceEvent:
+    return _WorkerTraceEvent(
+        id=event.id,
+        parent_id=event.parent_id,
+        function=event.function,
+        module_path=event.module_path,
+        file=event.file,
+        line=event.line,
+    )
+
+
+def _public_worker(command: _WorkerCommand) -> _WorkerSuccess | _WorkerFailure:
+    try:
+        import litellm
+        from litellm.rust_bridge import get_native_bridge
+
+        native_events: tuple[FunctionTraceEvent, ...] = ()
+        trace_bridge: object | None = None
+        capture_id: int | None = None
+        if os.environ.get("LITELLM_RUST") == "1":
+            bridge: Final = cast(object | None, get_native_bridge())
+            trace_bridge = getattr(bridge, "_trace", None)
+            if trace_bridge is None:
+                return _WorkerFailure(message="native Rust bridge must include the trace-parity feature")
+            capture_id = cast(int, getattr(trace_bridge, "start_capture")())
+        entrypoint: Final = cast(SdkCall, getattr(litellm, "aocr" if command.asynchronous else "ocr"))
+        with profile_python(Path(litellm.__file__).parent, threads=True) as profiler:
+            _invoke(entrypoint, cast(dict[str, object], command.kwargs), asynchronous=command.asynchronous)
+        if trace_bridge is not None and capture_id is not None:
+            native_events = native_trace_events(
+                {"response": None, "trace": getattr(trace_bridge, "finish_capture")(capture_id)}
+            )
+        return _WorkerSuccess(
+            python=tuple(_worker_event(event) for event in profiler.events),
+            native=tuple(_worker_event(event) for event in native_events),
+        )
+    except Exception as error:
+        return _WorkerFailure(message=f"{type(error).__name__}: {error}")
+
+
+def _run_public_worker(
+    engine: Engine, kwargs: dict[str, object], *, asynchronous: bool
+) -> tuple[tuple[FunctionTraceEvent, ...], tuple[FunctionTraceEvent, ...]] | TraceExecutionFailure:
+    command: Final = _WorkerCommand.model_validate({"asynchronous": asynchronous, "kwargs": kwargs})
+    environment: Final = {**os.environ, "LITELLM_RUST": "1" if engine == "rust" else "0"}
+    completed: Final = subprocess.run(
+        (sys.executable, "-m", __name__, "--public-worker"),
+        input=command.model_dump_json(),
+        capture_output=True,
+        text=True,
+        env=environment,
+        check=False,
+        timeout=60,
+    )
+    result_line: Final = next(
+        (
+            line.removeprefix(_WORKER_PREFIX)
+            for line in completed.stdout.splitlines()
+            if line.startswith(_WORKER_PREFIX)
+        ),
+        None,
+    )
+    if result_line is None:
+        output: Final = "\n".join((*completed.stdout.splitlines()[-10:], *completed.stderr.splitlines()[-10:]))
+        return TraceExecutionFailure(
+            engine, f"public SDK trace worker failed with exit code {completed.returncode}: {output}"
+        )
+    try:
+        payload: Final = _WorkerSuccess.model_validate_json(result_line)
+    except ValidationError:
+        failure: Final = _WorkerFailure.model_validate_json(result_line)
+        return TraceExecutionFailure(engine, failure.message)
+    return tuple(event.event() for event in payload.python), tuple(event.event() for event in payload.native)
+
+
+def _collect_public_trace(
+    scenario: TraceScenario, engine: Engine, *, asynchronous: bool
+) -> tuple[tuple[FunctionTraceEvent, ...], tuple[FunctionTraceEvent, ...]] | TraceExecutionFailure:
+    try:
+        with replay_server() as provider:
+            fixture: Final = scenario.fixture("python", provider.url)
+            for response in fixture.provider_responses:
+                provider.enqueue_response(response)
+            kwargs: Final = {**fixture.kwargs, "api_key": "test-key", "api_base": provider.url, "timeout": 5}
+            traces: Final = _run_public_worker(engine, kwargs, asynchronous=asynchronous)
+            if isinstance(traces, TraceExecutionFailure):
+                return traces
+            provider.take_requests(len(fixture.provider_responses))
+            return traces
+    except Exception as error:
+        return TraceExecutionFailure(engine, f"{type(error).__name__}: {error}")
+
+
+def _combined_rust_projection(
+    python_events: tuple[FunctionTraceEvent, ...],
+    native_events: tuple[FunctionTraceEvent, ...],
+    scenario: TraceScenario,
+    mode: TraceMode,
+) -> PipelineProjection:
+    wrapper: Final = pipeline_projection("python", python_events, scenario.rust_wrapper_mappings)
+    native: Final = pipeline_projection("rust", native_events, scenario.mappings_for(mode))
+    wrapper_steps: Final = tuple(
+        PipelineStep(index, None if step.parent_id is None else index - 1, step.span, step.raw)
+        for index, step in enumerate(wrapper.steps)
+    )
+    native_offset: Final = len(wrapper_steps)
+    native_parent: Final = wrapper_steps[-1].id if wrapper_steps else None
+    native_steps: Final = tuple(
+        PipelineStep(
+            step.id + native_offset,
+            native_parent if step.parent_id is None else step.parent_id + native_offset,
+            step.span,
+            step.raw,
+        )
+        for step in native.steps
+    )
+    return PipelineProjection((*wrapper_steps, *native_steps), wrapper.unmatched)
+
+
+def _execute_public_trace(
+    route: RouteSpec, scenario: TraceScenario, mode: TraceMode, surface: Surface
+) -> TraceComparisonArtifact:
+    asynchronous: Final = mode == "async"
+    python_trace: Final = _collect_public_trace(scenario, "python", asynchronous=asynchronous)
+    rust_trace: Final = _collect_public_trace(scenario, "rust", asynchronous=asynchronous)
+    python_error: Final = _failure_message(python_trace)
+    rust_error: Final = _failure_message(rust_trace)
+    mappings: Final = scenario.mappings_for(mode)
+    try:
+        python: Final = (
+            PipelineProjection()
+            if isinstance(python_trace, TraceExecutionFailure)
+            else pipeline_projection("python", python_trace[0], mappings)
+        )
+        rust: Final = (
+            PipelineProjection()
+            if isinstance(rust_trace, TraceExecutionFailure)
+            else _combined_rust_projection(rust_trace[0], rust_trace[1], scenario, mode)
+        )
+    except ValueError as error:
+        return TraceComparisonArtifact.from_traces(
+            surface=surface,
+            sdk_function=route.route,
+            scenario=scenario.name,
+            mode=mode,
+            mappings=mappings,
+            contract=scenario.contract,
+            python=(),
+            rust=(),
+            python_unmatched=0,
+            python_error=f"harness: {error}",
+            rust_error=rust_error,
+        )
+    return TraceComparisonArtifact.from_traces(
+        surface=surface,
+        sdk_function=route.route,
+        scenario=scenario.name,
+        mode=mode,
+        mappings=mappings,
+        contract=scenario.contract,
+        python=python.steps,
+        rust=rust.steps,
+        python_unmatched=python.unmatched,
+        python_error=python_error,
+        rust_error=rust_error,
+    )
+
+
+def _failure_message(result: tuple[object, ...] | TraceExecutionFailure) -> str | None:
     if isinstance(result, tuple):
         return None
     return f"{result.engine}: {result.message}"
@@ -95,6 +307,8 @@ def _failure_message(result: tuple[FunctionTraceEvent, ...] | TraceExecutionFail
 def execute_trace(
     route: RouteSpec, scenario: TraceScenario, mode: TraceMode, surface: Surface
 ) -> TraceComparisonArtifact:
+    if scenario.boundary == "public_sdk":
+        return _execute_public_trace(route, scenario, mode, surface)
     asynchronous: Final = mode == "async"
     mappings: Final = scenario.mappings_for(mode)
     scenario_route: Final = RouteSpec(
@@ -138,3 +352,23 @@ def execute_trace(
         python_error=python_error,
         rust_error=rust_error,
     )
+
+
+def _worker_main() -> int:
+    result: Final = _worker_result()
+    print(f"{_WORKER_PREFIX}{result.model_dump_json()}", flush=True)
+    return int(isinstance(result, _WorkerFailure))
+
+
+def _worker_result() -> _WorkerSuccess | _WorkerFailure:
+    try:
+        command: Final = _WorkerCommand.model_validate_json(sys.stdin.read())
+        return _public_worker(command)
+    except Exception as error:
+        return _WorkerFailure(message=f"{type(error).__name__}: {error}")
+
+
+if __name__ == "__main__":
+    if sys.argv[1:] != ["--public-worker"]:
+        raise SystemExit("usage: execution.py --public-worker")
+    raise SystemExit(_worker_main())

--- a/tests/rust-python-harness/strategies/trace_parity/sdk/ocr/case.py
+++ b/tests/rust-python-harness/strategies/trace_parity/sdk/ocr/case.py
@@ -39,6 +39,23 @@ ASYNC_MAPPINGS: Final = (
     ),
 )
 
+PUBLIC_RUST_WRAPPER_MAPPINGS: Final = (
+    mapping(span="public_sdk_entrypoint", python_frame=r"ocr/main\.py:\d+ a?ocr$"),
+    mapping(span="rust_bridge_dispatch", python_frame=r"ocr/main\.py:\d+ _run_rust_a?ocr$"),
+)
+
+PUBLIC_SYNC_MAPPINGS: Final = (
+    *SYNC_MAPPINGS,
+    mapping(rust_span="public_sdk_entrypoint"),
+    mapping(rust_span="rust_bridge_dispatch"),
+)
+
+PUBLIC_ASYNC_MAPPINGS: Final = (
+    *ASYNC_MAPPINGS,
+    mapping(rust_span="public_sdk_entrypoint"),
+    mapping(rust_span="rust_bridge_dispatch"),
+)
+
 AZURE_COMMON_MAPPINGS: Final = (
     *COMMON_MAPPINGS[:7],
     mapping(
@@ -301,39 +318,48 @@ TRACE_SUITE: Final = TraceSuite(
     route=SPEC,
     scenarios=(
         TraceScenario(
-            name="mistral",
+            name="pipeline-mistral",
             fixture=_mistral_fixture,
             mappings=COMMON_MAPPINGS,
             sync_mappings=SYNC_MAPPINGS,
             async_mappings=ASYNC_MAPPINGS,
         ),
         TraceScenario(
-            name="azure-ai",
+            name="pipeline-azure-ai",
             fixture=_azure_fixture,
             mappings=AZURE_COMMON_MAPPINGS,
             sync_mappings=AZURE_SYNC_MAPPINGS,
             async_mappings=AZURE_ASYNC_MAPPINGS,
         ),
         TraceScenario(
-            name="azure-document-intelligence",
+            name="pipeline-azure-document-intelligence",
             fixture=_azure_document_intelligence_fixture,
             mappings=DOCUMENT_INTELLIGENCE_COMMON_MAPPINGS,
             sync_mappings=DOCUMENT_INTELLIGENCE_SYNC_MAPPINGS,
             async_mappings=DOCUMENT_INTELLIGENCE_ASYNC_MAPPINGS,
         ),
         TraceScenario(
-            name="vertex-ai",
+            name="pipeline-vertex-ai",
             fixture=_vertex_fixture,
             mappings=VERTEX_COMMON_MAPPINGS,
             sync_mappings=VERTEX_SYNC_MAPPINGS,
             async_mappings=VERTEX_ASYNC_MAPPINGS,
         ),
         TraceScenario(
-            name="vertex-deepseek",
+            name="pipeline-vertex-deepseek",
             fixture=_vertex_deepseek_fixture,
             mappings=DEEPSEEK_COMMON_MAPPINGS,
             sync_mappings=DEEPSEEK_SYNC_MAPPINGS,
             async_mappings=DEEPSEEK_ASYNC_MAPPINGS,
+        ),
+        TraceScenario(
+            name="public-sdk-mistral",
+            fixture=_mistral_fixture,
+            mappings=COMMON_MAPPINGS,
+            sync_mappings=PUBLIC_SYNC_MAPPINGS,
+            async_mappings=PUBLIC_ASYNC_MAPPINGS,
+            boundary="public_sdk",
+            rust_wrapper_mappings=PUBLIC_RUST_WRAPPER_MAPPINGS,
         ),
     ),
 )

--- a/tests/rust-python-harness/strategies/trace_parity/test_runner.py
+++ b/tests/rust-python-harness/strategies/trace_parity/test_runner.py
@@ -4,9 +4,11 @@ from typing import Final
 
 from ...shared.reporting.models import Coverage, HarnessCase, HarnessRun, RunStatus, SdkFunction, Surface
 from ...shared.reporting.strategy import ModuleCaseSpec
-from ...shared.tracing.steps import Engine
+from ...shared.tracing.profiler import FunctionTraceEvent
+from ...shared.tracing.steps import Engine, PipelineStep, mapping, trace_diff
 from .models import GatewayRouteSpec, RouteFixture, RouteSpec, TraceScenario, TraceSuite
 from .runner import run_trace_mode, scenario_nodeids, validate_trace_suite
+from .sdk.execution import _combined_rust_projection
 
 
 def _fixture(_engine: Engine, _base_url: str) -> RouteFixture:
@@ -69,6 +71,64 @@ def test_scenario_validation_rejects_invalid_modes_and_route_registration() -> N
     assert "unique sync/async modes" in (validate_trace_suite(invalid_modes, case) or "")
     assert "does not match case function" in (validate_trace_suite(wrong_function, case) or "")
     assert "must use RouteSpec" in (validate_trace_suite(wrong_surface, case) or "")
+
+
+def test_public_scenario_requires_wrapper_mappings() -> None:
+    suite: Final = TraceSuite(
+        route=RouteSpec("ocr", ("ocr", "aocr"), ("ocr", "aocr"), _fixture),
+        scenarios=(TraceScenario("public", _fixture, (), boundary="public_sdk"),),
+    )
+
+    assert "require Rust wrapper mappings" in (validate_trace_suite(suite, _case()) or "")
+
+
+def test_public_projection_attaches_native_trace_to_rust_dispatch() -> None:
+    mappings: Final = (
+        mapping(rust_span="ocr", python_frame=r" main_ocr$"),
+        mapping(rust_span="prepare", python_frame=r"prepare$"),
+        mapping(rust_span="public_sdk_entrypoint"),
+        mapping(rust_span="rust_bridge_dispatch"),
+    )
+    scenario: Final = TraceScenario(
+        "public",
+        _fixture,
+        mappings,
+        boundary="public_sdk",
+        rust_wrapper_mappings=(
+            mapping(span="public_sdk_entrypoint", python_frame=r" main_ocr$"),
+            mapping(span="rust_bridge_dispatch", python_frame=r"_run_rust_ocr$"),
+        ),
+    )
+    projection: Final = _combined_rust_projection(
+        (
+            FunctionTraceEvent(0, None, "ocr/main.py:1 main_ocr"),
+            FunctionTraceEvent(1, 0, "ocr/main.py:2 ignored"),
+            FunctionTraceEvent(2, 1, "ocr/main.py:3 _run_rust_ocr"),
+        ),
+        (
+            FunctionTraceEvent(0, None, "ocr"),
+            FunctionTraceEvent(1, 0, "prepare"),
+        ),
+        scenario,
+        "sync",
+    )
+
+    assert tuple((step.span, step.parent_id) for step in projection.steps) == (
+        ("public_sdk_entrypoint", None),
+        ("rust_bridge_dispatch", 0),
+        ("ocr", 1),
+        ("prepare", 2),
+    )
+    python: Final = (PipelineStep(0, None, "ocr", "ocr"), PipelineStep(1, 0, "prepare", "prepare"))
+    assert trace_diff(python, projection.steps, mappings).matches
+    native_only: Final = (
+        PipelineStep(0, None, "ocr", "ocr"),
+        PipelineStep(1, 0, "prepare", "prepare"),
+    )
+    assert trace_diff(python, native_only, mappings).missing_mappings == (
+        "public_sdk_entrypoint",
+        "rust_bridge_dispatch",
+    )
 
 
 def test_invalid_route_dispatch_records_harness_error() -> None:

--- a/tests/test_rust_python_harness.py
+++ b/tests/test_rust_python_harness.py
@@ -141,7 +141,8 @@ def test_should_report_a_bridge_built_without_the_trace_feature() -> None:
 
 def test_should_accept_a_bridge_built_with_the_trace_feature() -> None:
     with pytest.MonkeyPatch.context() as patch:
-        patch.setattr(native_build, "get_native_bridge", lambda: SimpleNamespace(_trace=object()))
+        trace: Final = SimpleNamespace(start_capture=lambda: 1, finish_capture=lambda capture_id: ())
+        patch.setattr(native_build, "get_native_bridge", lambda: SimpleNamespace(_trace=trace))
 
         assert native_build.trace_bridge_error() is None
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- OCR traces bypass the public SDK wrapper
- Missing Rust dispatch could appear as parity

How it solves it:

- Runs Python and Rust in isolated startup-configured workers
- Captures wrapper frames and native spans together

## User Flow

Before: a developer cannot verify that OCR trace parity exercises public SDK dispatch

1. They run `uv run python -m tests.rust-python-harness run trace_parity --surface sdk --function ocr`
2. The report shows 10 direct pipeline checks and no public SDK checks

After: the same command proves public sync and async dispatch reaches Rust

1. They run `uv run python -m tests.rust-python-harness run trace_parity --surface sdk --function ocr`
2. The report shows 12 checks, including passing public sync and async scenarios

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

### Before (02522a5441)

1. Run `uv run --no-sync python -m tests.rust-python-harness run trace_parity --surface sdk --function ocr`
2. Observe 10 checks: 8 pass, 2 existing document-intelligence mismatches fail, and no public SDK scenario appears

### After (f64f340e7d)

1. Run `uv run python -m tests.rust-python-harness run trace_parity --surface sdk --function ocr`
2. Observe an automatic `trace-parity` native rebuild from a non-feature bridge
3. Observe 12 checks: both new public SDK scenarios pass, while the same 2 existing mismatches remain visible

## Type

Test

## Caveats (if any)

### Low

- Public boundary coverage starts with deterministic Mistral OCR success
- Provider traffic uses the harness replay server
- Existing document-intelligence response-transform mismatches still fail

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
