### PR TITLE
fix(proxy): retain health-check deployment pricing

### DIFF
--- a/litellm/litellm_core_utils/health_check_helpers.py
+++ b/litellm/litellm_core_utils/health_check_helpers.py
@@ -82,7 +82,16 @@ class HealthCheckHelpers:
         from litellm.proxy.litellm_pre_call_utils import LiteLLMProxyRequestSetup
 
         _metadata_variable_name: Final = "litellm_metadata"
-        litellm_metadata: Final = HealthCheckHelpers._get_metadata_for_health_check_call()
+        existing_metadata: Final = model_params.get(_metadata_variable_name)
+        health_check_metadata: Final = HealthCheckHelpers._get_metadata_for_health_check_call()
+        existing_tags: Final = existing_metadata.get("tags", ()) if isinstance(existing_metadata, dict) else ()
+        health_check_tags: Final = health_check_metadata["tags"]
+        litellm_metadata: Final = health_check_metadata.copy()
+        if isinstance(existing_metadata, dict):
+            litellm_metadata.update(existing_metadata)
+        litellm_metadata.update(health_check_metadata)
+        health_check_tags[:] = dict.fromkeys((*existing_tags, *health_check_tags))
+        litellm_metadata["tags"] = health_check_tags
         model_params[_metadata_variable_name] = litellm_metadata
         model_params = LiteLLMProxyRequestSetup.add_user_api_key_auth_to_request_metadata(
             data=model_params,

--- a/litellm/proxy/health_check.py
+++ b/litellm/proxy/health_check.py
@@ -482,6 +482,14 @@ async def _run_model_health_check(model: dict):
         litellm_params,  # any-ok: untyped router config dict
     )
     litellm_params = _update_litellm_params_for_health_check(model_info, litellm_params)
+    existing_metadata: Final = litellm_params.get("litellm_metadata")
+    health_check_metadata: Final = (
+        existing_metadata.copy()
+        if isinstance(existing_metadata, dict)
+        else {}  # mutable-ok: health-check metadata is enriched in place
+    )
+    health_check_metadata["model_info"] = model_info
+    litellm_params["litellm_metadata"] = health_check_metadata
     timeout: Final = model_info.get("health_check_timeout") or HEALTH_CHECK_TIMEOUT_SECONDS
 
     return await run_with_timeout(

--- a/tests/test_litellm/proxy/test_health_check_max_tokens.py
+++ b/tests/test_litellm/proxy/test_health_check_max_tokens.py
@@ -481,6 +481,42 @@ async def test_run_model_health_check_threads_resolved_mode_to_ahealth_check():
     assert probed_params["model"] == "amazon.titan-embed-text-v2:0"
 
 
+@pytest.mark.asyncio
+async def test_run_model_health_check_preserves_deployment_identity_for_spend_tracking():
+    fake_ahealth_check = AsyncMock(return_value={})
+    model_info = {
+        "id": "bedrock-health-check-deployment",
+        "input_cost_per_token": 1e-06,
+        "output_cost_per_token": 5e-06,
+        "health_check_params": {"litellm_metadata": {"operator_probe_flag": True, "tags": ["operator-health-tag"]}},
+    }
+    model = {
+        "litellm_params": {"model": "bedrock/claude_platform/claude-haiku-4-5"},
+        "model_info": model_info,
+    }
+
+    with patch.object(  # test-quality-ok: observes probe payload before provider execution
+        hc_module.litellm, "ahealth_check", fake_ahealth_check
+    ):
+        await hc_module._run_model_health_check(model)
+
+    probed_params = fake_ahealth_check.call_args.args[0]
+    assert probed_params["model"] == "claude_platform/claude-haiku-4-5"
+    assert probed_params["litellm_metadata"]["operator_probe_flag"] is True
+    assert probed_params["litellm_metadata"]["model_info"] == model_info
+
+
+def test_health_check_tracking_preserves_deployment_identity():
+    model_info = {"id": "bedrock-health-check-deployment"}
+
+    updated = HealthCheckHelpers._update_model_params_with_health_check_tracking_information(
+        {"litellm_metadata": {"model_info": model_info, "tags": ["operator-health-tag"]}}
+    )
+
+    assert updated["litellm_metadata"]["model_info"] == model_info
+    assert "operator-health-tag" in updated["litellm_metadata"]["tags"]
+
+
 def test_autodetected_embedding_skips_reasoning_effort():
     """reasoning_effort must not leak into an embedding probe whose mode is auto-detected.
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Health checks lose sub-routed Bedrock deployment pricing
- Spend logs record those successful probes as free

How it solves it:

- Keep deployment pricing metadata through probe normalization
- Preserve configured health metadata and health-check tags

## User Flow

Before: a proxy admin runs health checks for a sub-routed Bedrock deployment and the spend ledger records zero cost

1. They configure `bedrock/claude_platform/claude-haiku-4-5` with deployment pricing
2. They call `GET https://litellm-domain/health`
3. The health probe succeeds, but its spend record resolves no deployment price

After: the same health check keeps the deployment identity used for pricing

1. They keep the same deployment configuration
2. They call `GET https://litellm-domain/health`
3. The successful probe carries its deployment pricing metadata to spend tracking

## Relevant issues

Fixes #40044

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Provider-backed proof was not run because this workspace has no Bedrock credentials. The focused provider-free regression module passed locally: `uv run pytest tests/test_litellm/proxy/test_health_check_max_tokens.py -q`, 81 passed. `make format-check` and `make lint-ruff` also passed

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Provider-backed spend-log verification remains for CI or a credentialed reviewer

## Final Attestation

- [x] The tests check deployment identity, metadata preservation, and configured tags
