### PR TITLE
fix(anthropic): resolve every reasoning_effort tier against the deployment's declared levels

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/utils.py
+++ b/litellm/llms/anthropic/experimental_pass_through/utils.py
@@ -11,14 +11,30 @@ if TYPE_CHECKING:
 
 OPENAI_MAX_PROMPT_CACHE_KEY_LENGTH: Final = 64
 
-_EFFORT_DEGRADATION_CHAIN: Final[Mapping[str, tuple[str, ...]]] = MappingProxyType(
+# Weakest to strongest. ``none`` is deliberately absent: it is an off switch rather than a tier, so
+# leaving it out of the ladder is what keeps it from ever being chosen for a caller who asked to think.
+_EFFORT_STRENGTH_ORDER: Final[tuple[str, ...]] = ("minimal", "low", "medium", "high", "xhigh", "max")
+
+# Where a tier lands when the deployment's accepted set cannot be read at all. Only the tiers that
+# shipped with a floor keep one; every other tier keeps the level the caller asked for.
+_EFFORT_BLIND_FALLBACK: Final[Mapping[str, str]] = MappingProxyType(
     {
-        "max": ("max", "xhigh", "high"),
-        "xhigh": ("xhigh", "high"),
-        "minimal": ("minimal", "low"),
+        "max": "high",
+        "xhigh": "high",
+        "minimal": "low",
     }
 )
-_THINKING_OFF: Final = "none"
+
+
+def _degradation_chain(effort: str) -> tuple[str, ...]:
+    """Nearest-first search order for one ask: the level itself, then weaker tiers, then stronger.
+
+    Lowering is preferred to raising because a tier the deployment does not accept is a hard 400,
+    while a weaker one costs thinking budget rather than the request. The floor of the ladder has
+    nothing weaker to fall to, so ``minimal`` climbs, which is the order it shipped with.
+    """
+    index: Final = _EFFORT_STRENGTH_ORDER.index(effort)
+    return (*_EFFORT_STRENGTH_ORDER[index::-1], *_EFFORT_STRENGTH_ORDER[index + 1 :])
 
 
 def prompt_cache_key_from_user_id(user_id: object) -> str | None:
@@ -50,33 +66,35 @@ def normalize_reasoning_effort_value(
     model: str,
     custom_llm_provider: str | None = None,
 ) -> str:
-    """Lower a tier the deployment does not accept to the nearest one it does, leaving others alone.
+    """Resolve a tier against the levels the deployment accepts, to the nearest one it does.
 
     The accepted set is resolved by the same owner that answers ``/model_group/info``, so a level
     the proxy advertises is a level this path forwards.
 
-    A deployment that refuses every step of a chain falls back to an accepted level read off that
-    same set rather than to an assumed one, since an entry naming its levels outright can exclude
-    the tiers the per-level flags treat as unconditional. ``none`` is never that fallback and is
-    never degraded to, being an off switch rather than a tier; an always-on-thinking model is
-    handled where the thinking block is built. A deployment accepting no tier at all keeps the
-    chain's floor, which is what every deployment degraded to before there was anything to ask.
+    Every tier is resolved, not just the ones with an opt-in flag. An entry naming its levels
+    outright can omit ``high``, ``medium`` or ``low``, and a level an entry omits is a level it
+    rejects, so the tier the caller asked for cannot be what decides whether the declaration is
+    read. ``none`` is never degraded to and is never chosen, being an off switch rather than a
+    tier; an always-on-thinking model is handled where the thinking block is built.
+
+    A deployment the map cannot answer for keeps the historical floor on the three tiers that
+    shipped with one and the caller's own level on the rest, since there is nothing to resolve
+    against and lowering blind would weaken deployments that never asked for it.
     """
-    chain: Final = _EFFORT_DEGRADATION_CHAIN.get(effort)
-    if chain is None:
+    if effort not in _EFFORT_STRENGTH_ORDER:
         return effort
 
     from litellm.router_utils.reasoning_effort_capability import resolve_supported_reasoning_efforts
     from litellm.utils import get_model_info
 
+    blind_fallback: Final = _EFFORT_BLIND_FALLBACK.get(effort, effort)
     try:
         model_info: Final[ModelInfo] = get_model_info(model=model, custom_llm_provider=custom_llm_provider)
     except Exception:
-        return chain[-1]
+        return blind_fallback
 
     supported: Final = resolve_supported_reasoning_efforts(model_info, deployment_is_mapped=True)
     if not supported:
-        return chain[-1]
+        return blind_fallback
 
-    accepted_tiers: Final = tuple(level for level in supported if level != _THINKING_OFF)
-    return next((level for level in (*chain, *accepted_tiers) if level in supported), chain[-1])
+    return next((level for level in _degradation_chain(effort) if level in supported), blind_fallback)

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/test_reasoning_effort_fields.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/test_reasoning_effort_fields.py
@@ -331,3 +331,55 @@ class TestADeclarationDisjointFromTheChain:
         what every deployment got before the resolver was consulted. Dropping the parameter outright
         is the real answer and belongs with the callers that build the request."""
         assert normalize_reasoning_effort_value(effort, declared_effort_entry, "synthetic") == expected
+
+
+class TestEveryTierIsResolvedAgainstTheDeclaration:
+    """A declaration has to bind for the tier the caller actually asked for.
+
+    ``max``, ``xhigh`` and ``minimal`` were the only tiers ever resolved against a deployment's
+    accepted set; every other level returned before the entry was read, so an entry declaring
+    ``low``, ``medium`` and ``xhigh`` still received ``high`` and answered 400. Which tier the
+    caller asked for cannot be what decides whether the declaration is consulted, because the
+    levels an entry omits are exactly the levels it rejects.
+    """
+
+    DECLARED_LEVELS = ("low", "medium", "xhigh")
+
+    @pytest.mark.parametrize("declared_effort_entry", [DECLARED_LEVELS], indirect=True)
+    def test_a_declaration_omitting_high_is_not_sent_high(self, declared_effort_entry):
+        """The reported case: a vocabulary of low, medium and xhigh, asked for ``high``. ``medium``
+        is the nearest level it accepts, since lowering costs thinking budget where raising to
+        ``xhigh`` would spend more than the caller asked for."""
+        assert normalize_reasoning_effort_value("high", declared_effort_entry, "synthetic") == "medium"
+
+    @pytest.mark.parametrize("declared_effort_entry", [DECLARED_LEVELS], indirect=True)
+    @pytest.mark.parametrize(
+        "effort, expected",
+        [
+            ("max", "xhigh"),
+            ("xhigh", "xhigh"),
+            ("high", "medium"),
+            ("medium", "medium"),
+            ("low", "low"),
+            ("minimal", "low"),
+        ],
+    )
+    def test_every_tier_lands_on_a_declared_level(self, declared_effort_entry, effort, expected):
+        assert normalize_reasoning_effort_value(effort, declared_effort_entry, "synthetic") == expected
+
+    @pytest.mark.parametrize("declared_effort_entry", [DECLARED_LEVELS], indirect=True)
+    @pytest.mark.parametrize("effort", ["minimal", "low", "medium", "high", "xhigh", "max"])
+    def test_no_tier_can_leave_the_declaration(self, declared_effort_entry, effort):
+        """The table above as a property: nothing the caller can ask for resolves to a level the
+        entry did not declare."""
+        assert normalize_reasoning_effort_value(effort, declared_effort_entry, "synthetic") in self.DECLARED_LEVELS
+
+    @pytest.mark.parametrize("effort", ["minimal", "low", "medium", "high", "xhigh", "max"])
+    def test_a_model_the_map_does_not_describe_still_keeps_its_historical_answer(
+        self, local_model_cost_map, effort
+    ):
+        """Resolving a tier must not start degrading deployments the map cannot answer for. An
+        unmapped model keeps the floor on the three tiers that shipped with one and the caller's own
+        level on the rest, which is what it returned before."""
+        expected = {"max": "high", "xhigh": "high", "minimal": "low"}.get(effort, effort)
+        assert normalize_reasoning_effort_value(effort, "totally-made-up-model-xyz", "openai") == expected


### PR DESCRIPTION
## TLDR

Problem this solves:

- A deployment declaring its `reasoning_effort_levels` still gets sent `high`
- Only `max`, `xhigh` and `minimal` were ever checked against that declaration
- Every other tier returned before the model entry was read at all
- Backends whose vocabulary omits `high` answer 400 on every thinking request

How it solves it:

- Every tier is now resolved against the levels the deployment accepts
- One strength ladder replaces the three hand-written chains
- Nearest-first search prefers a weaker tier over a stronger one
- Deployments the model map cannot answer for behave exactly as before

## User Flow

Before: an operator registers a self-hosted reasoning model, tells the proxy which effort levels it takes, and every request with a thinking budget still fails

1. They add the deployment to `config.yaml` with `model_info` carrying `reasoning_effort_levels: ["low", "medium", "xhigh"]`, and restart the proxy
2. They open `https://litellm-domain/model_group/info` and see the group advertise exactly `low`, `medium` and `xhigh`
3. They send POST `https://litellm-domain/v1/messages` with a thinking budget that maps to `high`
4. The response is 400 from the backend, refusing `high` as an unknown effort level, even though the proxy just advertised the three levels it does take
5. Asking for `max` on the same deployment returns 200, because that tier is lowered to `xhigh` — so the operator sees the declaration honoured for some levels and silently ignored for others

After: the declaration binds for every level, so the same request succeeds

1. Same registration, same restart
2. `https://litellm-domain/model_group/info` advertises the same three levels
3. They send the same POST `https://litellm-domain/v1/messages` with the same thinking budget
4. The response is 200, with `medium` sent to the deployment: the nearest level it declared
5. Asking for `max` still returns 200 at `xhigh`, and now every tier lands inside the advertised set

## Relevant issues

- #37359 — an operator cannot get a self-hosted reasoning model to accept `reasoning_effort`; the deployment's vocabulary is `low`, `medium` and `xhigh`, which is exactly the shape that still receives `high`
- #38530 — the three routes give three different answers for one deployment; this moves `/v1/messages` onto the deployment's declared set for every tier rather than three of them
- #38481 added `reasoning_effort_levels` so an entry can state its exact levels. This PR is about that mechanism being consulted for `max`, `xhigh` and `minimal` and skipped for the rest

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Shared setup — one deployment declaring the levels it accepts, which is what an operator writes on a `config.yaml` `model_info` block:

```python
import litellm
from litellm.llms.anthropic.experimental_pass_through.utils import normalize_reasoning_effort_value

litellm.model_cost["openai/example-reasoning-model"] = {
    "litellm_provider": "openai",
    "mode": "chat",
    "supports_reasoning": True,
    "reasoning_effort_levels": ["low", "medium", "xhigh"],
}
litellm.get_model_info.cache_clear()

for eff in ("minimal", "low", "medium", "high", "xhigh", "max"):
    got = normalize_reasoning_effort_value(eff, "openai/example-reasoning-model", "openai")
    print(eff, "->", got, "accepted" if got in ("low", "medium", "xhigh") else "NOT ACCEPTED -> backend 400")
```

### Before (168a0055a244acdcf97c330c52e085ab40b1424c)

#### Which level reaches the deployment

1. `uv run python proof.py`
2. Observed:

```
declared reasoning_effort_levels: ['low', 'medium', 'xhigh']
requested  sent to deployment   accepted?
minimal    low                  yes
low        low                  yes
medium     medium               yes
high       high                 NO -> backend 400
xhigh      xhigh                yes
max        xhigh                yes
```

`max` is lowered to `xhigh` correctly, which shows the declaration is being read — and `high` is forwarded verbatim to a deployment that just said it does not take it.

#### Regression tests

1. `uv run pytest tests/test_litellm/llms/anthropic/experimental_pass_through/test_reasoning_effort_fields.py -q`
2. Observed:

```
FAILED tests/test_litellm/llms/anthropic/experimental_pass_through/test_reasoning_effort_fields.py::TestEveryTierIsResolvedAgainstTheDeclaration::test_a_declaration_omitting_high_is_not_sent_high[declared_effort_entry0]
FAILED tests/test_litellm/llms/anthropic/experimental_pass_through/test_reasoning_effort_fields.py::TestEveryTierIsResolvedAgainstTheDeclaration::test_every_tier_lands_on_a_declared_level[high-medium-declared_effort_entry0]
FAILED tests/test_litellm/llms/anthropic/experimental_pass_through/test_reasoning_effort_fields.py::TestEveryTierIsResolvedAgainstTheDeclaration::test_no_tier_can_leave_the_declaration[high-declared_effort_entry0]
3 failed, 69 passed in 0.76s
```

### After (e61eabfe14c5e47b6fa1f0fbad4434d3aa77035f)

#### Which level reaches the deployment

1. `uv run python proof.py`
2. Observed:

```
declared reasoning_effort_levels: ['low', 'medium', 'xhigh']
requested  sent to deployment   accepted?
minimal    low                  yes
low        low                  yes
medium     medium               yes
high       medium               yes
xhigh      xhigh                yes
max        xhigh                yes
```

#### Regression tests

1. `uv run pytest tests/test_litellm/llms/anthropic/experimental_pass_through/test_reasoning_effort_fields.py -q`
2. Observed:

```
72 passed in 0.81s
```

The 69 pre-existing cases in that file are unchanged and still pass, including the ones pinning the historical floors and the `none` invariant.

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- `high` on a deployment omitting it now resolves to `medium` instead of being forwarded
- That is the point of the change, but it is a visible behavior change for any entry declaring `reasoning_effort_levels` without `high`
- Only entries that carry a declaration or the per-level flags are affected; unmapped deployments are byte-identical

### Low

- Lowering was chosen over raising, so `high` goes to `medium` rather than `xhigh`
- This matches the function's existing contract and its name, but it is a judgement call worth a reviewer's eye
- `_THINKING_OFF` is removed: once the ladder covers every tier, `none` can no longer be reached, so the filter it fed was dead. The invariant is now structural — `none` is not in the ladder — and the existing test that pins it still passes
- Full local suite not run (needs the DB-backed test environment); the covering files and the whole `experimental_pass_through` and `router_utils` directories were run, with the same pre-existing failures before and after. Opened as draft pending CI; happy to mark ready as soon as it is green

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
