### PR TITLE
fix(azure_ai): reject unsupported n and size params on MAI image models

### DIFF
--- a/litellm/llms/azure_ai/image_edit/__init__.py
+++ b/litellm/llms/azure_ai/image_edit/__init__.py
@@ -23,7 +23,7 @@ def get_azure_ai_image_edit_config(model: str) -> BaseImageEditConfig:
     """
     Get the appropriate image edit config for an Azure AI model.
 
-    - MAI models use /mai/v1/images/edits with multipart form data and size
+    - MAI models use /mai/v1/images/edits with multipart form data
     - FLUX 2 models use JSON with base64 image
     - FLUX 1 models use multipart/form-data
     """

--- a/litellm/llms/azure_ai/image_edit/mai_transformation.py
+++ b/litellm/llms/azure_ai/image_edit/mai_transformation.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Final, cast
+from typing import TYPE_CHECKING, Any, Final
 
 import httpx
 from httpx._types import RequestFiles
@@ -13,7 +13,6 @@ from litellm.llms.azure_ai.image_generation.mai_transformation import (
 from litellm.llms.openai.common_utils import OpenAIError
 from litellm.llms.openai.image_edit.transformation import OpenAIImageEditConfig
 from litellm.secret_managers.main import get_secret_str
-from litellm.types.images.main import ImageEditOptionalRequestParams
 from litellm.types.llms.openai import FileTypes
 from litellm.types.router import GenericLiteLLMParams
 from litellm.types.utils import ImageResponse
@@ -26,65 +25,8 @@ if TYPE_CHECKING:
 class AzureFoundryMAIImageEditConfig(OpenAIImageEditConfig):
     """Azure AI Foundry MAI image editing (e.g. MAI-Image-2.5)."""
 
-    DEFAULT_SIZE = "1024x1024"
-
     def get_supported_openai_params(self, model: str) -> list:
-        return ["prompt", "image", "model", "n", "size"]
-
-    def map_openai_params(
-        self,
-        image_edit_optional_params: ImageEditOptionalRequestParams,
-        model: str,
-        drop_params: bool,
-    ) -> dict:
-        optional_params: Final[dict[str, Any]] = {}
-        supported_params: Final = self.get_supported_openai_params(model)
-
-        for key, value in dict(image_edit_optional_params).items():
-            if value is None or key in optional_params:
-                continue
-
-            if key in supported_params:
-                if key == "size" and value:
-                    size_param = cast(str, value)
-                    self._validate_size_param(size_param)
-                    optional_params[key] = size_param
-                else:
-                    optional_params[key] = value
-            elif not drop_params:
-                raise ValueError(
-                    f"Parameter {key} is not supported for model {model}. "
-                    f"Supported parameters are {supported_params}. "
-                    f"Set drop_params=True to drop unsupported parameters."
-                )
-
-        if "size" not in optional_params:
-            optional_params["size"] = self.DEFAULT_SIZE
-
-        return optional_params
-
-    def _validate_size_param(self, size: str) -> None:
-        known_sizes: Final = {
-            "1024x1024",
-            "1792x1024",
-            "1024x1792",
-            "512x512",
-            "256x256",
-        }
-
-        if size in known_sizes:
-            return
-
-        if "x" in size:
-            try:
-                tuple(map(int, size.lower().split("x", 1)))
-                return
-            except ValueError:
-                raise ValueError(f"Invalid size format: '{size}'. Expected format 'WIDTHxHEIGHT' (e.g., '1024x1024').")
-
-        raise ValueError(
-            f"Unsupported size value: '{size}'. Use a known size (e.g., '1024x1024') or a custom 'WIDTHxHEIGHT' string."
-        )
+        return ["prompt", "image", "model", "n"]
 
     def validate_environment(
         self,

--- a/litellm/llms/azure_ai/image_generation/mai_transformation.py
+++ b/litellm/llms/azure_ai/image_generation/mai_transformation.py
@@ -21,6 +21,19 @@ class AzureFoundryMAIImageGenerationConfig(BaseImageGenerationConfig):
     DEFAULT_WIDTH = 1024
     DEFAULT_HEIGHT = 1024
 
+    # The MAI endpoint produces exactly one image per request. Its documented
+    # body is model/prompt/width/height (plus `image` for edits) — there is no
+    # count field, and `n` (or the native `sampleCount`) is accepted and
+    # ignored, so a request for more silently comes back with one.
+    MAX_IMAGES_PER_REQUEST: Final = 1
+
+    # Provider-side bounds on the generated image. Both are enforced by the
+    # MAI endpoint, which 400s with "'width' must be at least 768 pixels."
+    # Only `size` is checked against them: `width`/`height` pass through
+    # unmapped, which keeps a future model with different bounds reachable.
+    MIN_DIMENSION_PX: Final = 768
+    MAX_TOTAL_PX: Final = 1024 * 1024
+
     @staticmethod
     def get_mai_image_generation_url(
         api_base: str | None,
@@ -146,6 +159,15 @@ class AzureFoundryMAIImageGenerationConfig(BaseImageGenerationConfig):
             if k in supported_params:
                 if k == "size" and v:
                     self._map_size_param(v, optional_params)
+                elif k == "n" and v is not None and v > self.MAX_IMAGES_PER_REQUEST:
+                    if not drop_params:
+                        raise ValueError(
+                            f"n={v} is not supported for model {model}. The Azure AI MAI image "
+                            f"endpoint returns exactly {self.MAX_IMAGES_PER_REQUEST} image per "
+                            "request and ignores any count, so a larger value would silently "
+                            "return fewer images than requested. Send one request per image, or "
+                            "set drop_params=True to drop n."
+                        )
                 else:
                     optional_params[k] = v
             elif k in ("width", "height"):
@@ -176,19 +198,38 @@ class AzureFoundryMAIImageGenerationConfig(BaseImageGenerationConfig):
 
         if size in size_mapping:
             width, height = size_mapping[size]
-            optional_params["width"] = width
-            optional_params["height"] = height
         elif "x" in size:
             try:
                 width, height = map(int, size.lower().split("x"))
-                optional_params["width"] = width
-                optional_params["height"] = height
             except ValueError:
                 raise ValueError(f"Invalid size format: '{size}'. Expected format 'WIDTHxHEIGHT' (e.g., '1024x1024').")
         else:
             raise ValueError(
                 f"Unsupported size value: '{size}'. "
                 f"Use a known size (e.g., '1024x1024') or a custom 'WIDTHxHEIGHT' string."
+            )
+
+        self._validate_dimensions(size=size, width=width, height=height)
+        optional_params["width"] = width
+        optional_params["height"] = height
+
+    def _validate_dimensions(self, size: str, width: int, height: int) -> None:
+        """Reject a `size` the MAI endpoint would 400 on.
+
+        Several OpenAI-standard sizes are outside MAI's bounds: 512x512 and
+        256x256 fall under the per-side minimum, and 1792x1024 / 1024x1792
+        exceed the total pixel budget. Checking here turns an opaque provider
+        400 into an error that names the constraint.
+        """
+        if width < self.MIN_DIMENSION_PX or height < self.MIN_DIMENSION_PX:
+            raise ValueError(
+                f"Unsupported size value: '{size}'. Azure AI MAI image models require width and "
+                f"height of at least {self.MIN_DIMENSION_PX} pixels."
+            )
+        if width * height > self.MAX_TOTAL_PX:
+            raise ValueError(
+                f"Unsupported size value: '{size}'. Azure AI MAI image models accept at most "
+                f"{self.MAX_TOTAL_PX} total pixels ({width}x{height} is {width * height})."
             )
 
     def transform_image_generation_response(

--- a/litellm/llms/azure_ai/image_generation/mai_transformation.py
+++ b/litellm/llms/azure_ai/image_generation/mai_transformation.py
@@ -24,7 +24,7 @@ class AzureFoundryMAIImageGenerationConfig(BaseImageGenerationConfig):
 
     MAX_IMAGES_PER_REQUEST: Final = 1
     MIN_DIMENSION_PX: Final = 768
-    MAX_TOTAL_PX: Final = 1024 * 1024
+    MAX_TOTAL_PX: Final = 1_056_768
 
     @staticmethod
     def get_mai_image_generation_url(

--- a/litellm/llms/azure_ai/image_generation/mai_transformation.py
+++ b/litellm/llms/azure_ai/image_generation/mai_transformation.py
@@ -151,7 +151,7 @@ class AzureFoundryMAIImageGenerationConfig(BaseImageGenerationConfig):
             if k in supported_params:
                 if k == "size" and v:
                     self._map_size_param(v, optional_params, model)
-                elif k == "n" and v is not None and int(v) > self.MAX_IMAGES_PER_REQUEST:
+                elif k == "n" and v is not None and self._image_count(v, model) != self.MAX_IMAGES_PER_REQUEST:
                     if not drop_params:
                         raise self._unsupported(
                             model,
@@ -184,6 +184,14 @@ class AzureFoundryMAIImageGenerationConfig(BaseImageGenerationConfig):
     @staticmethod
     def _unsupported(model: str, message: str) -> UnsupportedParamsError:
         return UnsupportedParamsError(message=message, llm_provider="azure_ai", model=model)
+
+    def _image_count(self, n: object, model: str) -> int:
+        if isinstance(n, int):
+            return n
+        try:
+            return int(str(n))
+        except ValueError:
+            raise self._unsupported(model, f"n={n!r} is not a whole number of images for model {model}.")
 
     def _map_size_param(self, size: str, optional_params: dict, model: str) -> None:
         size_mapping: Final = {

--- a/litellm/llms/azure_ai/image_generation/mai_transformation.py
+++ b/litellm/llms/azure_ai/image_generation/mai_transformation.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Any, Final
 
 import httpx
 
+from litellm.exceptions import UnsupportedParamsError
 from litellm.llms.base_llm.image_generation.transformation import (
     BaseImageGenerationConfig,
 )
@@ -21,16 +22,7 @@ class AzureFoundryMAIImageGenerationConfig(BaseImageGenerationConfig):
     DEFAULT_WIDTH = 1024
     DEFAULT_HEIGHT = 1024
 
-    # The MAI endpoint produces exactly one image per request. Its documented
-    # body is model/prompt/width/height (plus `image` for edits) — there is no
-    # count field, and `n` (or the native `sampleCount`) is accepted and
-    # ignored, so a request for more silently comes back with one.
     MAX_IMAGES_PER_REQUEST: Final = 1
-
-    # Provider-side bounds on the generated image. Both are enforced by the
-    # MAI endpoint, which 400s with "'width' must be at least 768 pixels."
-    # Only `size` is checked against them: `width`/`height` pass through
-    # unmapped, which keeps a future model with different bounds reachable.
     MIN_DIMENSION_PX: Final = 768
     MAX_TOTAL_PX: Final = 1024 * 1024
 
@@ -158,25 +150,27 @@ class AzureFoundryMAIImageGenerationConfig(BaseImageGenerationConfig):
 
             if k in supported_params:
                 if k == "size" and v:
-                    self._map_size_param(v, optional_params)
-                elif k == "n" and v is not None and v > self.MAX_IMAGES_PER_REQUEST:
+                    self._map_size_param(v, optional_params, model)
+                elif k == "n" and v is not None and int(v) > self.MAX_IMAGES_PER_REQUEST:
                     if not drop_params:
-                        raise ValueError(
+                        raise self._unsupported(
+                            model,
                             f"n={v} is not supported for model {model}. The Azure AI MAI image "
                             f"endpoint returns exactly {self.MAX_IMAGES_PER_REQUEST} image per "
                             "request and ignores any count, so a larger value would silently "
                             "return fewer images than requested. Send one request per image, or "
-                            "set drop_params=True to drop n."
+                            "set drop_params=True to drop n.",
                         )
                 else:
                     optional_params[k] = v
             elif k in ("width", "height"):
                 optional_params[k] = v
             elif not drop_params:
-                raise ValueError(
+                raise self._unsupported(
+                    model,
                     f"Parameter {k} is not supported for model {model}. "
                     f"Supported parameters are {supported_params} and width/height. "
-                    f"Set drop_params=True to drop unsupported parameters."
+                    f"Set drop_params=True to drop unsupported parameters.",
                 )
 
         if "width" not in optional_params:
@@ -187,7 +181,11 @@ class AzureFoundryMAIImageGenerationConfig(BaseImageGenerationConfig):
         optional_params.pop("size", None)
         return optional_params
 
-    def _map_size_param(self, size: str, optional_params: dict) -> None:
+    @staticmethod
+    def _unsupported(model: str, message: str) -> UnsupportedParamsError:
+        return UnsupportedParamsError(message=message, llm_provider="azure_ai", model=model)
+
+    def _map_size_param(self, size: str, optional_params: dict, model: str) -> None:
         size_mapping: Final = {
             "1024x1024": (1024, 1024),
             "1792x1024": (1792, 1024),
@@ -202,34 +200,32 @@ class AzureFoundryMAIImageGenerationConfig(BaseImageGenerationConfig):
             try:
                 width, height = map(int, size.lower().split("x"))
             except ValueError:
-                raise ValueError(f"Invalid size format: '{size}'. Expected format 'WIDTHxHEIGHT' (e.g., '1024x1024').")
+                raise self._unsupported(
+                    model, f"Invalid size format: '{size}'. Expected format 'WIDTHxHEIGHT' (e.g., '1024x1024')."
+                )
         else:
-            raise ValueError(
+            raise self._unsupported(
+                model,
                 f"Unsupported size value: '{size}'. "
-                f"Use a known size (e.g., '1024x1024') or a custom 'WIDTHxHEIGHT' string."
+                f"Use a known size (e.g., '1024x1024') or a custom 'WIDTHxHEIGHT' string.",
             )
 
-        self._validate_dimensions(size=size, width=width, height=height)
+        self._validate_dimensions(model=model, size=size, width=width, height=height)
         optional_params["width"] = width
         optional_params["height"] = height
 
-    def _validate_dimensions(self, size: str, width: int, height: int) -> None:
-        """Reject a `size` the MAI endpoint would 400 on.
-
-        Several OpenAI-standard sizes are outside MAI's bounds: 512x512 and
-        256x256 fall under the per-side minimum, and 1792x1024 / 1024x1792
-        exceed the total pixel budget. Checking here turns an opaque provider
-        400 into an error that names the constraint.
-        """
+    def _validate_dimensions(self, model: str, size: str, width: int, height: int) -> None:
         if width < self.MIN_DIMENSION_PX or height < self.MIN_DIMENSION_PX:
-            raise ValueError(
+            raise self._unsupported(
+                model,
                 f"Unsupported size value: '{size}'. Azure AI MAI image models require width and "
-                f"height of at least {self.MIN_DIMENSION_PX} pixels."
+                f"height of at least {self.MIN_DIMENSION_PX} pixels.",
             )
         if width * height > self.MAX_TOTAL_PX:
-            raise ValueError(
+            raise self._unsupported(
+                model,
                 f"Unsupported size value: '{size}'. Azure AI MAI image models accept at most "
-                f"{self.MAX_TOTAL_PX} total pixels ({width}x{height} is {width * height})."
+                f"{self.MAX_TOTAL_PX} total pixels ({width}x{height} is {width * height}).",
             )
 
     def transform_image_generation_response(

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -3396,7 +3396,7 @@ def get_optional_params_image_gen(
             non_default_params=non_default_params,
             optional_params=optional_params,
             model=model or "",
-            drop_params=drop_params if drop_params is not None else False,
+            drop_params=litellm.drop_params is True or drop_params is True,
         )
     elif (
         custom_llm_provider == "openai"

--- a/tests/test_litellm/llms/azure_ai/image_edit/test_mai_image_edit_transformation.py
+++ b/tests/test_litellm/llms/azure_ai/image_edit/test_mai_image_edit_transformation.py
@@ -6,6 +6,7 @@ import pytest
 
 
 import litellm
+from litellm.images.utils import ImageEditRequestUtils
 from litellm.llms.azure_ai.image_edit import (
     AzureFoundryMAIImageEditConfig,
     get_azure_ai_image_edit_config,
@@ -70,44 +71,48 @@ class TestAzureMAIImageEdit:
         assert "/mai/v1/images/edits" in url
         assert "api-version=preview" in url
 
-    def test_map_openai_params_keeps_size(self):
-        config = AzureFoundryMAIImageEditConfig()
-        optional_params = config.map_openai_params(
-            image_edit_optional_params={"size": "1792x1024", "n": 1},
+    def test_get_optional_params_image_edit_size_raises_400(self, monkeypatch):
+        monkeypatch.setattr(litellm, "drop_params", False)
+        with pytest.raises(litellm.UnsupportedParamsError, match="size") as exc_info:
+            ImageEditRequestUtils.get_optional_params_image_edit(
+                model="MAI-Image-2.5",
+                image_edit_provider_config=AzureFoundryMAIImageEditConfig(),
+                image_edit_optional_params={"size": "1024x1024", "n": 1},
+            )
+        assert exc_info.value.status_code == 400
+
+    def test_get_optional_params_image_edit_size_dropped_with_drop_params(self, monkeypatch):
+        monkeypatch.setattr(litellm, "drop_params", False)
+        optional_params = ImageEditRequestUtils.get_optional_params_image_edit(
             model="MAI-Image-2.5",
+            image_edit_provider_config=AzureFoundryMAIImageEditConfig(),
+            image_edit_optional_params={"size": "1024x1024", "n": 1},
             drop_params=True,
         )
-        assert optional_params["size"] == "1792x1024"
+        assert "size" not in optional_params
         assert optional_params["n"] == 1
-        assert "width" not in optional_params
-        assert "height" not in optional_params
 
-    def test_map_openai_params_defaults_size(self):
-        config = AzureFoundryMAIImageEditConfig()
-        optional_params = config.map_openai_params(
-            image_edit_optional_params={},
+    def test_get_optional_params_image_edit_without_size_forwards_nothing_extra(self, monkeypatch):
+        monkeypatch.setattr(litellm, "drop_params", False)
+        optional_params = ImageEditRequestUtils.get_optional_params_image_edit(
             model="MAI-Image-2.5",
-            drop_params=True,
+            image_edit_provider_config=AzureFoundryMAIImageEditConfig(),
+            image_edit_optional_params={},
         )
-        assert optional_params["size"] == "1024x1024"
+        assert optional_params == {}
 
-    def test_map_openai_params_unsupported_size_raises(self):
-        config = AzureFoundryMAIImageEditConfig()
-        with pytest.raises(ValueError, match="Unsupported size value: 'auto'"):
-            config.map_openai_params(
-                image_edit_optional_params={"size": "auto"},
-                model="MAI-Image-2.5",
-                drop_params=True,
+    def test_image_edit_size_surfaces_as_400(self, monkeypatch):
+        monkeypatch.setattr(litellm, "drop_params", False)
+        with pytest.raises(litellm.BadRequestError) as exc_info:
+            litellm.image_edit(
+                model="azure_ai/MAI-Image-2.5",
+                image=io.BytesIO(b"fake-image-bytes"),
+                prompt="Turn this into a studio product shot",
+                size="1024x1024",
+                api_key="test-key",
+                api_base="https://my-resource.services.ai.azure.com",
             )
-
-    def test_map_openai_params_invalid_size_format_raises(self):
-        config = AzureFoundryMAIImageEditConfig()
-        with pytest.raises(ValueError, match="Invalid size format: '1024xabc'"):
-            config.map_openai_params(
-                image_edit_optional_params={"size": "1024xabc"},
-                model="MAI-Image-2.5",
-                drop_params=True,
-            )
+        assert exc_info.value.status_code == 400
 
     def test_transform_image_edit_request_uses_image_field(self):
         config = AzureFoundryMAIImageEditConfig()
@@ -117,14 +122,14 @@ class TestAzureMAIImageEdit:
             model="MAI-Image-2.5",
             prompt="Turn this into a studio product shot",
             image=image_bytes,
-            image_edit_optional_request_params={"size": "1024x1024", "n": 1},
+            image_edit_optional_request_params={"n": 1},
             litellm_params={},
             headers={},
         )
 
         assert data["model"] == "MAI-Image-2.5"
         assert data["prompt"] == "Turn this into a studio product shot"
-        assert data["size"] == "1024x1024"
+        assert "size" not in data
         assert data["n"] == 1
         assert len(files) == 1
         assert files[0][0] == "image"

--- a/tests/test_litellm/llms/azure_ai/image_generation/test_mai_image_generation.py
+++ b/tests/test_litellm/llms/azure_ai/image_generation/test_mai_image_generation.py
@@ -1,9 +1,7 @@
-import os
 from unittest.mock import MagicMock
 
 import httpx
 import pytest
-
 
 import litellm
 from litellm.llms.azure.azure import AzureChatCompletion
@@ -30,9 +28,7 @@ from litellm.utils import get_optional_params_image_gen
 class TestAzureMAIImageGeneration:
     def test_is_mai_model(self):
         assert AzureFoundryMAIImageGenerationConfig.is_mai_model("MAI-Image-2.5")
-        assert AzureFoundryMAIImageGenerationConfig.is_mai_model(
-            "azure_ai/MAI-Image-2.5"
-        )
+        assert AzureFoundryMAIImageGenerationConfig.is_mai_model("azure_ai/MAI-Image-2.5")
         assert AzureFoundryMAIImageGenerationConfig.is_mai_model("MAI-Image-2.5-Flash")
         assert AzureFoundryMAIImageGenerationConfig.is_mai_model("MAI-Image-2e")
         assert not AzureFoundryMAIImageGenerationConfig.is_mai_model("flux.2-pro")
@@ -62,16 +58,10 @@ class TestAzureMAIImageGeneration:
             api_base="https://my-resource.services.ai.azure.com",
             api_version="preview",
         )
-        assert (
-            url
-            == "https://my-resource.services.ai.azure.com/mai/v1/images/generations?api-version=preview"
-        )
+        assert url == "https://my-resource.services.ai.azure.com/mai/v1/images/generations?api-version=preview"
 
     def test_get_mai_image_generation_url_preserves_full_path(self):
-        api = (
-            "https://my-resource.services.ai.azure.com/mai/v1/images/generations"
-            "?api-version=preview"
-        )
+        api = "https://my-resource.services.ai.azure.com/mai/v1/images/generations?api-version=preview"
         url = AzureFoundryMAIImageGenerationConfig.get_mai_image_generation_url(
             api_base=api,
             api_version="preview",
@@ -83,10 +73,7 @@ class TestAzureMAIImageGeneration:
             api_base="https://my-resource.services.ai.azure.com/mai/v1",
             api_version="preview",
         )
-        assert (
-            url
-            == "https://my-resource.services.ai.azure.com/mai/v1/images/generations?api-version=preview"
-        )
+        assert url == "https://my-resource.services.ai.azure.com/mai/v1/images/generations?api-version=preview"
 
     def test_get_azure_ai_image_generation_config_returns_mai(self):
         config = get_azure_ai_image_generation_config("MAI-Image-2.5")
@@ -124,13 +111,13 @@ class TestAzureMAIImageGeneration:
         config = AzureFoundryMAIImageGenerationConfig()
         optional_params = get_optional_params_image_gen(
             model="MAI-Image-2.5",
-            size="1792x1024",
+            size="1024x1024",
             n=1,
             custom_llm_provider="azure_ai",
             provider_config=config,
             drop_params=True,
         )
-        assert optional_params["width"] == 1792
+        assert optional_params["width"] == 1024
         assert optional_params["height"] == 1024
         assert "size" not in optional_params
 
@@ -147,10 +134,7 @@ class TestAzureMAIImageGeneration:
         assert "api-version=preview" in url
 
     def test_mai_json_body_keeps_model(self):
-        api = (
-            "https://my-resource.services.ai.azure.com/mai/v1/images/generations"
-            "?api-version=preview"
-        )
+        api = "https://my-resource.services.ai.azure.com/mai/v1/images/generations?api-version=preview"
         data = {
             "model": "MAI-Image-2.5",
             "prompt": "A photograph of a red fox",
@@ -213,6 +197,74 @@ class TestAzureMAIImageGeneration:
                 model="MAI-Image-2.5",
                 drop_params=True,
             )
+
+    @pytest.mark.parametrize("size", ["512x512", "256x256", "700x1400"])
+    def test_map_openai_params_size_below_minimum_dimension_raises(self, size):
+        """MAI requires >= 768px per side; the OpenAI size table offered smaller ones."""
+        config = AzureFoundryMAIImageGenerationConfig()
+        with pytest.raises(ValueError, match="at least 768 pixels"):
+            config.map_openai_params(
+                non_default_params={"size": size},
+                optional_params={},
+                model="MAI-Image-2.5",
+                drop_params=True,
+            )
+
+    @pytest.mark.parametrize("size", ["1792x1024", "1024x1792"])
+    def test_map_openai_params_size_over_total_pixel_budget_raises(self, size):
+        """MAI caps total pixels at 1024*1024, so both landscape/portrait sizes 400 upstream."""
+        config = AzureFoundryMAIImageGenerationConfig()
+        with pytest.raises(ValueError, match="at most 1048576 total pixels"):
+            config.map_openai_params(
+                non_default_params={"size": size},
+                optional_params={},
+                model="MAI-Image-2.5",
+                drop_params=True,
+            )
+
+    def test_map_openai_params_explicit_width_height_not_range_checked(self):
+        """width/height pass through unmapped, so a future model's bounds stay reachable."""
+        config = AzureFoundryMAIImageGenerationConfig()
+        optional_params = config.map_openai_params(
+            non_default_params={"width": 1792, "height": 1024},
+            optional_params={},
+            model="MAI-Image-2.5",
+            drop_params=True,
+        )
+        assert optional_params["width"] == 1792
+        assert optional_params["height"] == 1024
+
+    @pytest.mark.parametrize("n", [2, 4])
+    def test_map_openai_params_multi_image_n_raises(self, n):
+        """The MAI endpoint returns one image and ignores any count, so n>1 must not pass silently."""
+        config = AzureFoundryMAIImageGenerationConfig()
+        with pytest.raises(ValueError, match="returns exactly 1 image per request"):
+            config.map_openai_params(
+                non_default_params={"n": n},
+                optional_params={},
+                model="MAI-Image-2.5",
+                drop_params=False,
+            )
+
+    def test_map_openai_params_multi_image_n_dropped_with_drop_params(self):
+        config = AzureFoundryMAIImageGenerationConfig()
+        optional_params = config.map_openai_params(
+            non_default_params={"n": 4},
+            optional_params={},
+            model="MAI-Image-2.5",
+            drop_params=True,
+        )
+        assert "n" not in optional_params
+
+    def test_map_openai_params_single_image_n_still_passes_through(self):
+        config = AzureFoundryMAIImageGenerationConfig()
+        optional_params = config.map_openai_params(
+            non_default_params={"n": 1},
+            optional_params={},
+            model="MAI-Image-2.5",
+            drop_params=False,
+        )
+        assert optional_params["n"] == 1
 
     def test_map_openai_params_unsupported_param_raises(self):
         config = AzureFoundryMAIImageGenerationConfig()
@@ -363,16 +415,12 @@ class TestAzureMAIImageGeneration:
         litellm.model_cost = litellm.get_model_cost_map(url="")
         model = "azure_ai/MAI-Image-2.5"
         model_info = litellm.get_model_info(model=model, custom_llm_provider="azure_ai")
-        image_response = ImageResponse(
-            data=[ImageObject(b64_json="img1"), ImageObject(b64_json="img2")]
-        )
+        image_response = ImageResponse(data=[ImageObject(b64_json="img1"), ImageObject(b64_json="img2")])
 
         cost = azure_ai_image_cost_calculator(
             model=model,
             image_response=image_response,
         )
 
-        assert (
-            cost == len(image_response.data or []) * model_info["output_cost_per_image"]
-        )
+        assert cost == len(image_response.data or []) * model_info["output_cost_per_image"]
         assert cost > 0

--- a/tests/test_litellm/llms/azure_ai/image_generation/test_mai_image_generation.py
+++ b/tests/test_litellm/llms/azure_ai/image_generation/test_mai_image_generation.py
@@ -253,8 +253,8 @@ class TestAzureMAIImageGeneration:
         assert optional_params["width"] == 1792
         assert optional_params["height"] == 1024
 
-    @pytest.mark.parametrize("n", [2, 4, "2"])
-    def test_map_openai_params_multi_image_n_raises(self, n):
+    @pytest.mark.parametrize("n", [2, 4, "2", 0, -1])
+    def test_map_openai_params_n_other_than_one_raises(self, n):
         config = AzureFoundryMAIImageGenerationConfig()
         with pytest.raises(UnsupportedParamsError, match="returns exactly 1 image per request"):
             config.map_openai_params(
@@ -262,6 +262,38 @@ class TestAzureMAIImageGeneration:
                 optional_params={},
                 model="MAI-Image-2.5",
                 drop_params=False,
+            )
+
+    def test_map_openai_params_non_numeric_n_raises_400(self):
+        config = AzureFoundryMAIImageGenerationConfig()
+        with pytest.raises(UnsupportedParamsError, match="not a whole number of images") as exc_info:
+            config.map_openai_params(
+                non_default_params={"n": "abc"},
+                optional_params={},
+                model="MAI-Image-2.5",
+                drop_params=False,
+            )
+        assert exc_info.value.status_code == 400
+
+    def test_get_optional_params_image_gen_global_drop_params_drops_multi_image_n(self, monkeypatch):
+        monkeypatch.setattr(litellm, "drop_params", True)
+        optional_params = get_optional_params_image_gen(
+            model="MAI-Image-2.5",
+            n=4,
+            custom_llm_provider="azure_ai",
+            provider_config=AzureFoundryMAIImageGenerationConfig(),
+        )
+        assert "n" not in optional_params
+        assert optional_params["width"] == 1024
+
+    def test_get_optional_params_image_gen_without_any_drop_params_still_raises(self, monkeypatch):
+        monkeypatch.setattr(litellm, "drop_params", False)
+        with pytest.raises(UnsupportedParamsError, match="returns exactly 1 image per request"):
+            get_optional_params_image_gen(
+                model="MAI-Image-2.5",
+                n=4,
+                custom_llm_provider="azure_ai",
+                provider_config=AzureFoundryMAIImageGenerationConfig(),
             )
 
     def test_map_openai_params_multi_image_n_dropped_with_drop_params(self):
@@ -284,7 +316,7 @@ class TestAzureMAIImageGeneration:
         )
         assert optional_params["n"] == 1
 
-    @pytest.mark.parametrize("params", [{"n": 2}, {"size": "512x512"}, {"size": "1792x1024"}])
+    @pytest.mark.parametrize("params", [{"n": 2}, {"n": "abc"}, {"size": "512x512"}, {"size": "1792x1024"}])
     def test_image_generation_rejected_params_surface_as_400(self, params):
         with pytest.raises(litellm.BadRequestError) as exc_info:
             litellm.image_generation(

--- a/tests/test_litellm/llms/azure_ai/image_generation/test_mai_image_generation.py
+++ b/tests/test_litellm/llms/azure_ai/image_generation/test_mai_image_generation.py
@@ -4,6 +4,7 @@ import httpx
 import pytest
 
 import litellm
+from litellm.exceptions import UnsupportedParamsError
 from litellm.llms.azure.azure import AzureChatCompletion
 from litellm.llms.azure.image_generation import get_azure_image_generation_config
 from litellm.llms.azure.image_generation.http_utils import (
@@ -180,7 +181,7 @@ class TestAzureMAIImageGeneration:
 
     def test_map_openai_params_unsupported_size_raises(self):
         config = AzureFoundryMAIImageGenerationConfig()
-        with pytest.raises(ValueError, match="Unsupported size value: 'auto'"):
+        with pytest.raises(UnsupportedParamsError, match="Unsupported size value: 'auto'"):
             config.map_openai_params(
                 non_default_params={"size": "auto"},
                 optional_params={},
@@ -190,7 +191,7 @@ class TestAzureMAIImageGeneration:
 
     def test_map_openai_params_invalid_custom_size_raises(self):
         config = AzureFoundryMAIImageGenerationConfig()
-        with pytest.raises(ValueError, match="Invalid size format: '1024xabc'"):
+        with pytest.raises(UnsupportedParamsError, match="Invalid size format: '1024xabc'"):
             config.map_openai_params(
                 non_default_params={"size": "1024xabc"},
                 optional_params={},
@@ -200,9 +201,8 @@ class TestAzureMAIImageGeneration:
 
     @pytest.mark.parametrize("size", ["512x512", "256x256", "700x1400"])
     def test_map_openai_params_size_below_minimum_dimension_raises(self, size):
-        """MAI requires >= 768px per side; the OpenAI size table offered smaller ones."""
         config = AzureFoundryMAIImageGenerationConfig()
-        with pytest.raises(ValueError, match="at least 768 pixels"):
+        with pytest.raises(UnsupportedParamsError, match="at least 768 pixels"):
             config.map_openai_params(
                 non_default_params={"size": size},
                 optional_params={},
@@ -212,9 +212,8 @@ class TestAzureMAIImageGeneration:
 
     @pytest.mark.parametrize("size", ["1792x1024", "1024x1792"])
     def test_map_openai_params_size_over_total_pixel_budget_raises(self, size):
-        """MAI caps total pixels at 1024*1024, so both landscape/portrait sizes 400 upstream."""
         config = AzureFoundryMAIImageGenerationConfig()
-        with pytest.raises(ValueError, match="at most 1048576 total pixels"):
+        with pytest.raises(UnsupportedParamsError, match="at most 1048576 total pixels"):
             config.map_openai_params(
                 non_default_params={"size": size},
                 optional_params={},
@@ -223,7 +222,6 @@ class TestAzureMAIImageGeneration:
             )
 
     def test_map_openai_params_explicit_width_height_not_range_checked(self):
-        """width/height pass through unmapped, so a future model's bounds stay reachable."""
         config = AzureFoundryMAIImageGenerationConfig()
         optional_params = config.map_openai_params(
             non_default_params={"width": 1792, "height": 1024},
@@ -234,11 +232,10 @@ class TestAzureMAIImageGeneration:
         assert optional_params["width"] == 1792
         assert optional_params["height"] == 1024
 
-    @pytest.mark.parametrize("n", [2, 4])
+    @pytest.mark.parametrize("n", [2, 4, "2"])
     def test_map_openai_params_multi_image_n_raises(self, n):
-        """The MAI endpoint returns one image and ignores any count, so n>1 must not pass silently."""
         config = AzureFoundryMAIImageGenerationConfig()
-        with pytest.raises(ValueError, match="returns exactly 1 image per request"):
+        with pytest.raises(UnsupportedParamsError, match="returns exactly 1 image per request"):
             config.map_openai_params(
                 non_default_params={"n": n},
                 optional_params={},
@@ -266,9 +263,21 @@ class TestAzureMAIImageGeneration:
         )
         assert optional_params["n"] == 1
 
+    @pytest.mark.parametrize("params", [{"n": 2}, {"size": "512x512"}, {"size": "1792x1024"}])
+    def test_image_generation_rejected_params_surface_as_400(self, params):
+        with pytest.raises(litellm.BadRequestError) as exc_info:
+            litellm.image_generation(
+                model="azure_ai/MAI-Image-2.5",
+                prompt="A photograph of a red fox",
+                api_key="test-key",
+                api_base="https://my-resource.services.ai.azure.com",
+                **params,
+            )
+        assert exc_info.value.status_code == 400
+
     def test_map_openai_params_unsupported_param_raises(self):
         config = AzureFoundryMAIImageGenerationConfig()
-        with pytest.raises(ValueError, match="Parameter quality is not supported"):
+        with pytest.raises(UnsupportedParamsError, match="Parameter quality is not supported"):
             config.map_openai_params(
                 non_default_params={"quality": "hd"},
                 optional_params={},

--- a/tests/test_litellm/llms/azure_ai/image_generation/test_mai_image_generation.py
+++ b/tests/test_litellm/llms/azure_ai/image_generation/test_mai_image_generation.py
@@ -213,12 +213,33 @@ class TestAzureMAIImageGeneration:
     @pytest.mark.parametrize("size", ["1792x1024", "1024x1792"])
     def test_map_openai_params_size_over_total_pixel_budget_raises(self, size):
         config = AzureFoundryMAIImageGenerationConfig()
-        with pytest.raises(UnsupportedParamsError, match="at most 1048576 total pixels"):
+        with pytest.raises(UnsupportedParamsError, match="at most 1056768 total pixels"):
             config.map_openai_params(
                 non_default_params={"size": size},
                 optional_params={},
                 model="MAI-Image-2.5",
                 drop_params=True,
+            )
+
+    @pytest.mark.parametrize("size", ["1032x1024", "1376x768"])
+    def test_map_openai_params_size_at_live_pixel_cap_passes_through(self, size):
+        config = AzureFoundryMAIImageGenerationConfig()
+        optional_params = config.map_openai_params(
+            non_default_params={"size": size},
+            optional_params={},
+            model="MAI-Image-2.5",
+            drop_params=False,
+        )
+        assert optional_params["width"] * optional_params["height"] == 1_056_768
+
+    def test_map_openai_params_size_one_pixel_over_live_cap_raises(self):
+        config = AzureFoundryMAIImageGenerationConfig()
+        with pytest.raises(UnsupportedParamsError, match="at most 1056768 total pixels"):
+            config.map_openai_params(
+                non_default_params={"size": "1033x1024"},
+                optional_params={},
+                model="MAI-Image-2.5",
+                drop_params=False,
             )
 
     def test_map_openai_params_explicit_width_height_not_range_checked(self):


### PR DESCRIPTION
## TLDR

Problem this solves:

- MAI image models advertise `n`, but the generations endpoint always returns one image: `n: 2` / `n: 4` come back 200 with one image, silently
- The `size` table offers four sizes the MAI endpoint rejects with an opaque provider 400
- The MAI edits config advertised and forwarded `size`, which the edits endpoint ignores: a `768x768` edit comes back `1024x1024` with a 200
- Image generation provider configs never saw `litellm_settings: drop_params: true`; only the per-call `drop_params` reached `map_openai_params`

How it solves it:

- `n` other than 1 (including `0`, negatives, and non-numeric strings) now fails with HTTP 400 (`UnsupportedParamsError`) or is dropped under `drop_params=True`, per call or through `litellm_settings: drop_params: true`; `n=1` is unchanged
- `size` is validated against the bounds the live MAI endpoint enforces (each side at least 768 px, at most 1,056,768 total px) where it is mapped; `width` / `height` pass-through is untouched
- `/v1/images/edits` on MAI models stops advertising `size`, which the edits endpoint ignores, so it is a 400 or dropped instead of a silently different output size
- `get_optional_params_image_gen` now hands the global `litellm.drop_params` flag to every image generation provider config, the way `get_optional_params_image_edit` already does, so `litellm_settings: drop_params: true` drops params the provider config rejects

## User Flow

Before: a developer asking `azure_ai/MAI-Image-2.5` for several images gets one and no warning; asking for a standard OpenAI size gets a provider error

1. They send `POST https://litellm-domain/v1/images/generations` with `{"model": "MAI-Image-2.5", "prompt": "...", "n": 4}`
2. HTTP 200 comes back with `data` holding exactly one image, billed as one; nothing in the response says the request was reduced
3. They send the same POST with `{"size": "512x512"}` instead of `n`
4. HTTP 400 from the provider: `Model does not support request parameter value supplied: 'width' must be at least 768 pixels.`

After: the same requests fail up front with an error that names the constraint, and the working request is unchanged

1. They send `POST https://litellm-domain/v1/images/generations` with `{"model": "MAI-Image-2.5", "prompt": "...", "n": 4}`
2. HTTP 400 from the proxy: `n=4 is not supported for model MAI-Image-2.5. The Azure AI MAI image endpoint returns exactly 1 image per request ... Send one request per image, or set drop_params=True to drop n.`
3. They send the same POST with `{"size": "512x512"}` instead of `n`
4. HTTP 400 from the proxy: `Unsupported size value: '512x512'. Azure AI MAI image models require width and height of at least 768 pixels.`
5. `{"n": 1, "size": "1024x1024"}` still returns HTTP 200 with one image, exactly as before
6. On a proxy with `litellm_settings: drop_params: true`, `{"n": 4}` returns HTTP 200 with one image instead of the 400
7. `POST /v1/images/edits` with `size=768x768` returns HTTP 400 from the proxy naming `size` as unsupported; the same edit without `size` returns HTTP 200 with the `1024x1024` image the endpoint always produces

## Relevant issues

Not filed. Measured against the live endpoint 2026-08-17 on Azure AI Foundry deployments of `MAI-Image-2.5` and `MAI-Image-2.5-Flash`: `n: 2` / `n: 4` return 200 with one image (the raw `/mai/v1/images/generations` endpoint ignores `n` and the native `sampleCount` alike; its documented body is `model` / `prompt` / `width` / `height`), while sizes under 768 px per side (`512x512`, `256x256`) and over the pixel budget (`1792x1024`, `1024x1792`) are rejected by the provider even though `get_supported_openai_params` / `_map_size_param` advertise them. The bounds match the request parameter table in the [MAI image models doc on Microsoft Learn](https://learn.microsoft.com/en-us/azure/foundry/foundry-models/how-to/use-foundry-models-mai-image)

Changes:

- `MAX_IMAGES_PER_REQUEST = 1`, `MIN_DIMENSION_PX = 768`, `MAX_TOTAL_PX = 1_056_768` class constants. The Microsoft Learn table says 1,048,576, but the live endpoint serves `1032x1024` (1,056,768 px) and refuses `1033x1024` with `exceeds the maximum of 1056768`, so the gateway uses the cap the provider actually enforces instead of rejecting sizes it serves
- `map_openai_params` (`litellm/llms/azure_ai/image_generation/mai_transformation.py`): any `n` other than `MAX_IMAGES_PER_REQUEST` raises `UnsupportedParamsError` (a 400, where a bare `ValueError` surfaced as a 500 `APIConnectionError`) unless `drop_params` (the existing opt-in); `n=1` passes through, a string `n` from proxy JSON is coerced by `_image_count`, and a non-numeric `n` is a 400 instead of a 500
- `get_optional_params_image_gen` (`litellm/utils.py`): passes `drop_params=litellm.drop_params is True or drop_params is True` to `provider_config.map_openai_params`, mirroring `ImageEditRequestUtils.get_optional_params_image_edit`. Before, only the per-call flag reached provider configs, so `litellm_settings: drop_params: true` did nothing for params a config rejects inside `map_openai_params` (every image generation config reads that flag the same way, so the fix applies to all of them; the unsupported-key check ahead of it already honoured the global flag)
- `AzureFoundryMAIImageEditConfig` (`litellm/llms/azure_ai/image_edit/mai_transformation.py`): `size` removed from `get_supported_openai_params` and the `size` mapping, validation and `1024x1024` default deleted, so the base `map_openai_params` pass-through is used. `n` stays advertised because the live edits endpoint honours it (`n=2` returned two images)
- `_map_size_param`: resolves the size first, then calls the new `_validate_dimensions` before writing `width` / `height`
- `get_azure_ai_image_edit_config`'s docstring no longer says MAI edits take `size`
- `width` / `height` passed directly are deliberately not validated, so a future MAI model with different bounds stays reachable
- Tests (`tests/test_litellm/llms/azure_ai/image_generation/test_mai_image_generation.py`): n=1 ok, n of 2, 4, "2", 0 and -1 raises / drops, `"abc"` is a 400, each rejected size, the live cap boundary (`1032x1024` and `1376x768` pass, `1033x1024` fails), the global `litellm.drop_params` flag dropping `n` through `get_optional_params_image_gen` (fails without the `utils.py` change) and the no-flag path still raising, and an SDK-level check that every rejected param surfaces as a 400; one existing assertion moved from `1792x1024` to a size the provider accepts
- Tests (`tests/test_litellm/llms/azure_ai/image_edit/test_mai_image_edit_transformation.py`): `size` is a 400 through `get_optional_params_image_edit` and through `litellm.image_edit`, is dropped under `drop_params`, and is no longer injected into the form data

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally: `uv run pytest tests/test_litellm/llms/azure_ai/image_generation/test_mai_image_generation.py -v` gives 47 passed (24 on the merge base), `tests/test_litellm/llms/azure_ai/image_edit/test_mai_image_edit_transformation.py` gives 15 passed, and every `tests/test_litellm/llms/*/image_generation` module plus `tests/test_litellm/images` and `tests/test_litellm/test_utils.py` pass (341 and 406)
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem (MAI image params the endpoint cannot honour, plus the one-line `drop_params` plumbing fix that makes the advertised opt-out work)
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live run against a real `MAI-Image-2.5` deployment on Azure AI Foundry (eastus, `api_version: preview`), proxies booted with `--num_workers 2` from the same config, the merge base on port 21335 and the tip on port 50616. Each response body is shown with the base64 payload replaced by its length; every 200 here is a paid image generation. Requests are spaced 32 seconds apart because the deployment allows 2 requests per minute. The follow-up legs further down (merge base on 32779 / 22320, tip on 20391 / 51989) use the same config, plus a copy with `litellm_settings: drop_params: true` for the global flag legs

```yaml
model_list:
  - model_name: MAI-Image-2.5
    litellm_params:
      model: azure_ai/MAI-Image-2.5
      api_base: os.environ/AZURE_AI_API_BASE
      api_key: os.environ/AZURE_AI_API_KEY
      api_version: preview
general_settings:
  master_key: sk-qa-40074
```

### Before (168a0055a2)

`n` is forwarded and ignored by the provider, so two and four images come back as one with a 200. Sizes the provider refuses fail at Azure with its error text. Note the provider's own cap is 1,056,768 pixels: `1032x1024` is served and `1033x1024` is refused

1. `$ curl -s http://localhost:21335/v1/images/generations -H 'Authorization: Bearer sk-qa-40074' -H 'Content-Type: application/json' -d '{"model":"MAI-Image-2.5","prompt":"A photograph of a red fox","n":2}'`
   HTTP 200, `data` holds 1 image (<2242200 chars>), `usage.output_tokens` 1024
2. `$ curl -s http://localhost:21335/v1/images/generations -H 'Authorization: Bearer sk-qa-40074' -H 'Content-Type: application/json' -d '{"model":"MAI-Image-2.5","prompt":"A photograph of a red fox","n":4}'`
   HTTP 200, `data` holds 1 image (<2136224 chars>), `usage.output_tokens` 1024
3. `$ curl -s http://localhost:21335/v1/images/generations -H 'Authorization: Bearer sk-qa-40074' -H 'Content-Type: application/json' -d '{"model":"MAI-Image-2.5","prompt":"A photograph of a red fox","size":"512x512"}'`
   HTTP 400, `litellm.BadRequestError: Azure_aiException - {"error":{"code":"unsupported_request_value","message":"Model does not support request parameter value supplied: 'width' must be at least 768 pixels.","details":"Model does not support request parameter value supplied: 'width' must be at least 768 pixels."}}`
4. `$ curl -s http://localhost:21335/v1/images/generations -H 'Authorization: Bearer sk-qa-40074' -H 'Content-Type: application/json' -d '{"model":"MAI-Image-2.5","prompt":"A photograph of a red fox","size":"1792x1024"}'`
   HTTP 400, `litellm.BadRequestError: Azure_aiException - {"error":{"code":"unsupported_request_value","message":"Model does not support request parameter value supplied: Invalid dimensions 1792x1024: total pixel count (1835008) exceeds the maximum of 1056768.","details":"Model does not support request parameter value supplied: Invalid dimensions 1792x1024: total pixel count (1835008) exceeds the maximum of 1056768."}}`
5. `$ curl -s http://localhost:21335/v1/images/generations -H 'Authorization: Bearer sk-qa-40074' -H 'Content-Type: application/json' -d '{"model":"MAI-Image-2.5","prompt":"A photograph of a red fox","size":"1033x1024"}'`
   HTTP 400, `litellm.BadRequestError: Azure_aiException - {"error":{"code":"unsupported_request_value","message":"Model does not support request parameter value supplied: Invalid dimensions 1033x1024: total pixel count (1057792) exceeds the maximum of 1056768.","details":"Model does not support request parameter value supplied: Invalid dimensions 1033x1024: total pixel count (1057792) exceeds the maximum of 1056768."}}`
6. `$ curl -s http://localhost:21335/v1/images/generations -H 'Authorization: Bearer sk-qa-40074' -H 'Content-Type: application/json' -d '{"model":"MAI-Image-2.5","prompt":"A photograph of a red fox","n":1,"size":"1024x1024"}'`
   HTTP 200, `data` holds 1 image (<2476252 chars>), `usage.output_tokens` 1024
7. `$ curl -s http://localhost:21335/v1/images/generations -H 'Authorization: Bearer sk-qa-40074' -H 'Content-Type: application/json' -d '{"model":"MAI-Image-2.5","prompt":"A photograph of a red fox","size":"1032x1024"}'`
   HTTP 200, `data` holds 1 image (<2405444 chars>), `usage.output_tokens` 1024

### After (38a3de7641)

The same requests fail up front with HTTP 400 and a message naming the constraint; the working requests, including the `1032x1024` boundary the provider serves, are unchanged

1. `$ curl -s http://localhost:50616/v1/images/generations -H 'Authorization: Bearer sk-qa-40074' -H 'Content-Type: application/json' -d '{"model":"MAI-Image-2.5","prompt":"A photograph of a red fox","n":2}'`
   HTTP 400, `litellm.UnsupportedParamsError: n=2 is not supported for model MAI-Image-2.5. The Azure AI MAI image endpoint returns exactly 1 image per request and ignores any count, so a larger value would silently return fewer images than requested. Send one request per image, or set drop_params=True to drop n.`
2. `$ curl -s http://localhost:50616/v1/images/generations -H 'Authorization: Bearer sk-qa-40074' -H 'Content-Type: application/json' -d '{"model":"MAI-Image-2.5","prompt":"A photograph of a red fox","n":4}'`
   HTTP 400, `litellm.UnsupportedParamsError: n=4 is not supported for model MAI-Image-2.5. The Azure AI MAI image endpoint returns exactly 1 image per request and ignores any count, so a larger value would silently return fewer images than requested. Send one request per image, or set drop_params=True to drop n.`
3. `$ curl -s http://localhost:50616/v1/images/generations -H 'Authorization: Bearer sk-qa-40074' -H 'Content-Type: application/json' -d '{"model":"MAI-Image-2.5","prompt":"A photograph of a red fox","size":"512x512"}'`
   HTTP 400, `litellm.UnsupportedParamsError: Unsupported size value: '512x512'. Azure AI MAI image models require width and height of at least 768 pixels.`
4. `$ curl -s http://localhost:50616/v1/images/generations -H 'Authorization: Bearer sk-qa-40074' -H 'Content-Type: application/json' -d '{"model":"MAI-Image-2.5","prompt":"A photograph of a red fox","size":"1792x1024"}'`
   HTTP 400, `litellm.UnsupportedParamsError: Unsupported size value: '1792x1024'. Azure AI MAI image models accept at most 1056768 total pixels (1792x1024 is 1835008).`
5. `$ curl -s http://localhost:50616/v1/images/generations -H 'Authorization: Bearer sk-qa-40074' -H 'Content-Type: application/json' -d '{"model":"MAI-Image-2.5","prompt":"A photograph of a red fox","size":"1033x1024"}'`
   HTTP 400, `litellm.UnsupportedParamsError: Unsupported size value: '1033x1024'. Azure AI MAI image models accept at most 1056768 total pixels (1033x1024 is 1057792).`
6. `$ curl -s http://localhost:50616/v1/images/generations -H 'Authorization: Bearer sk-qa-40074' -H 'Content-Type: application/json' -d '{"model":"MAI-Image-2.5","prompt":"A photograph of a red fox","n":1,"size":"1024x1024"}'`
   HTTP 200, `data` holds 1 image (<2212324 chars>), `usage.output_tokens` 1024
7. `$ curl -s http://localhost:50616/v1/images/generations -H 'Authorization: Bearer sk-qa-40074' -H 'Content-Type: application/json' -d '{"model":"MAI-Image-2.5","prompt":"A photograph of a red fox","size":"1032x1024"}'`
   HTTP 200, `data` holds 1 image (<2384784 chars>), `usage.output_tokens` 1024

### Before, follow-up legs (168a0055a2, ports 32779 and 22320)

Non-numeric and zero `n` are forwarded and ignored, the edits endpoint ignores `size` (a `768x768` ask comes back `1024x1024`) but does honour `n` (two images for `n=2`), and `litellm_settings: drop_params: true` in the proxy config does nothing for `n` because only the per-call flag reached the config

1. `$ curl -s http://localhost:32779/v1/images/generations -H 'Authorization: Bearer sk-qa-40074' -H 'Content-Type: application/json' -d '{"model":"MAI-Image-2.5","prompt":"A photograph of a red fox","n":"abc"}'`
   HTTP 200, `data` holds 1 image (<2473132 chars, 1024x1024>), `usage.output_tokens` 1024
2. `$ curl -s http://localhost:32779/v1/images/generations -H 'Authorization: Bearer sk-qa-40074' -H 'Content-Type: application/json' -d '{"model":"MAI-Image-2.5","prompt":"A photograph of a red fox","n":0}'`
   HTTP 200, `data` holds 1 image (<2288168 chars, 1024x1024>), `usage.output_tokens` 1024
3. `$ curl -s http://localhost:32779/v1/images/edits -H 'Authorization: Bearer sk-qa-40074' -F model=MAI-Image-2.5 -F 'prompt=Turn the yellow circle into a red square' -F image=@src.png -F size=768x768`
   HTTP 200, `data` holds 1 image (<812216 chars, 1024x1024>), the requested `768x768` was ignored
4. `$ curl -s http://localhost:32779/v1/images/edits -H 'Authorization: Bearer sk-qa-40074' -F model=MAI-Image-2.5 -F 'prompt=Turn the yellow circle into a red square' -F image=@src.png -F n=2`
   HTTP 200, `data` holds 2 images (<813476 chars, 1024x1024> and <464912 chars, 1024x1024>)
5. With `litellm_settings: drop_params: true` on port 22320: `$ curl -s http://localhost:22320/v1/images/generations -H 'Authorization: Bearer sk-qa-40074' -H 'Content-Type: application/json' -d '{"model":"MAI-Image-2.5","prompt":"A photograph of a red fox","n":4}'`
   HTTP 200, `data` holds 1 image (<2471996 chars, 1024x1024>), three of the four requested images never existed and nothing said so

### After, follow-up legs (8e3052ff65, ports 20391 and 51989)

The head 9c6a385efe adds only one docstring line to `litellm/llms/azure_ai/image_edit/__init__.py` on top of 8e3052ff65, so these legs stand at the head. Every `n` other than 1 is a 400 up front with the constraint named, `size` on the edits endpoint is a 400 instead of a silent no-op while an edit without `size` and an edit with `n=2` still work, and the global `drop_params` switch now actually drops `n`

1. `$ curl -s http://localhost:20391/v1/images/generations -H 'Authorization: Bearer sk-qa-40074' -H 'Content-Type: application/json' -d '{"model":"MAI-Image-2.5","prompt":"A photograph of a red fox","n":2}'`
   HTTP 400, `litellm.UnsupportedParamsError: n=2 is not supported for model MAI-Image-2.5. The Azure AI MAI image endpoint returns exactly 1 image per request and ignores any count, so a larger value would silently return fewer images than requested. Send one request per image, or set drop_params=True to drop n.`
2. `$ curl -s http://localhost:20391/v1/images/generations -H 'Authorization: Bearer sk-qa-40074' -H 'Content-Type: application/json' -d '{"model":"MAI-Image-2.5","prompt":"A photograph of a red fox","n":4}'`
   HTTP 400, `litellm.UnsupportedParamsError: n=4 is not supported for model MAI-Image-2.5. ...`
3. `$ curl -s http://localhost:20391/v1/images/generations -H 'Authorization: Bearer sk-qa-40074' -H 'Content-Type: application/json' -d '{"model":"MAI-Image-2.5","prompt":"A photograph of a red fox","n":"abc"}'`
   HTTP 400, `litellm.UnsupportedParamsError: n='abc' is not a whole number of images for model MAI-Image-2.5.`
4. `$ curl -s http://localhost:20391/v1/images/generations -H 'Authorization: Bearer sk-qa-40074' -H 'Content-Type: application/json' -d '{"model":"MAI-Image-2.5","prompt":"A photograph of a red fox","n":0}'`
   HTTP 400, `litellm.UnsupportedParamsError: n=0 is not supported for model MAI-Image-2.5. ...`
5. `$ curl -s http://localhost:20391/v1/images/generations -H 'Authorization: Bearer sk-qa-40074' -H 'Content-Type: application/json' -d '{"model":"MAI-Image-2.5","prompt":"A photograph of a red fox","size":"512x512"}'`
   HTTP 400, `litellm.UnsupportedParamsError: Unsupported size value: '512x512'. Azure AI MAI image models require width and height of at least 768 pixels.`
6. `$ curl -s http://localhost:20391/v1/images/generations -H 'Authorization: Bearer sk-qa-40074' -H 'Content-Type: application/json' -d '{"model":"MAI-Image-2.5","prompt":"A photograph of a red fox","size":"1792x1024"}'`
   HTTP 400, `litellm.UnsupportedParamsError: Unsupported size value: '1792x1024'. Azure AI MAI image models accept at most 1056768 total pixels (1792x1024 is 1835008).`
7. `$ curl -s http://localhost:20391/v1/images/generations -H 'Authorization: Bearer sk-qa-40074' -H 'Content-Type: application/json' -d '{"model":"MAI-Image-2.5","prompt":"A photograph of a red fox","size":"1033x1024"}'`
   HTTP 400, `litellm.UnsupportedParamsError: Unsupported size value: '1033x1024'. Azure AI MAI image models accept at most 1056768 total pixels (1033x1024 is 1057792).`
8. `$ curl -s http://localhost:20391/v1/images/generations -H 'Authorization: Bearer sk-qa-40074' -H 'Content-Type: application/json' -d '{"model":"MAI-Image-2.5","prompt":"A photograph of a red fox","n":1,"size":"1024x1024"}'`
   HTTP 200, `data` holds 1 image (<2386164 chars, 1024x1024>), `usage.output_tokens` 1024
9. `$ curl -s http://localhost:20391/v1/images/generations -H 'Authorization: Bearer sk-qa-40074' -H 'Content-Type: application/json' -d '{"model":"MAI-Image-2.5","prompt":"A photograph of a red fox","size":"1032x1024"}'`
   HTTP 200, `data` holds 1 image (<2217144 chars, 1024x1024>), `usage.output_tokens` 1024
10. `$ curl -s http://localhost:20391/v1/images/edits -H 'Authorization: Bearer sk-qa-40074' -F model=MAI-Image-2.5 -F 'prompt=Turn the yellow circle into a red square' -F image=@src.png -F size=768x768`
    HTTP 400, `litellm.UnsupportedParamsError: The following parameters are not supported for model MAI-Image-2.5: size.`
11. `$ curl -s http://localhost:20391/v1/images/edits -H 'Authorization: Bearer sk-qa-40074' -F model=MAI-Image-2.5 -F 'prompt=Turn the yellow circle into a red square' -F image=@src.png`
    HTTP 200, `data` holds 1 image (<665640 chars, 1024x1024>)
12. `$ curl -s http://localhost:20391/v1/images/edits -H 'Authorization: Bearer sk-qa-40074' -F model=MAI-Image-2.5 -F 'prompt=Turn the yellow circle into a red square' -F image=@src.png -F n=2`
    HTTP 200, `data` holds 2 images (<806656 chars, 1024x1024> and <495752 chars, 1024x1024>)
13. With `litellm_settings: drop_params: true` on port 51989: `$ curl -s http://localhost:51989/v1/images/generations -H 'Authorization: Bearer sk-qa-40074' -H 'Content-Type: application/json' -d '{"model":"MAI-Image-2.5","prompt":"A photograph of a red fox","n":4}'`
    HTTP 200, `data` holds 1 image (<2025940 chars, 1024x1024>), `n` dropped as the switch promises instead of the 400 above
14. With `litellm_settings: drop_params: true` on port 51989: `$ curl -s http://localhost:51989/v1/images/edits -H 'Authorization: Bearer sk-qa-40074' -F model=MAI-Image-2.5 -F 'prompt=Turn the yellow circle into a red square' -F image=@src.png -F size=768x768`
    HTTP 200, `data` holds 1 image (<872016 chars, 1024x1024>), `size` dropped

## Type

🐛 Bug Fix

## Caveats (if any)

Callers who relied on `n` other than 1 (including `0`, negatives, and non-numeric strings) quietly returning a single 200 image now get a 400 unless they set `drop_params=True` per call or `litellm.drop_params` / `litellm_settings: drop_params: true` globally; that is the point of the change. Other unsupported generation params that used to surface as a 500 `APIConnectionError` now surface as a 400. `width` / `height` passed directly are still forwarded unchecked. On the edits endpoint `size` is no longer advertised, so a `size` argument is a 400 (or dropped under `drop_params`) instead of being silently ignored by the provider; `n` stays advertised on edits because the live endpoint honours it there. The pixel cap is the one the live endpoint enforces (1,056,768: `1032x1024` is served and `1033x1024` is refused) rather than the 1,048,576 the docs state, so a doc-following caller sees no difference and the code matches what the service actually does

## Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 8e3052ff650460d8ba226381446c6a9b95e87cd8 passes /live-pr-risk; 9c6a385efe1f61cbd9d276ed09427102aec820ff adds one docstring line on top of it and changes no behavior

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request validation and error types for Azure MAI image APIs; valid `n=1` and in-bounds sizes stay the same, but callers who relied on ignored `n` or `size` on edits will see 400 unless `drop_params` is enabled.
> 
> **Overview**
> **Azure AI MAI image** calls now fail fast with HTTP 400 (`UnsupportedParamsError`) when clients pass parameters the live endpoint cannot honor, instead of returning 200 with silently wrong results.
> 
> For **generations**, `n` other than `1` is rejected (or dropped when `drop_params` is set per call or via `litellm_settings: drop_params: true`). `size` is validated when mapped to width/height: minimum **768 px** per side and at most **1,056,768** total pixels (matching the provider’s enforced cap). Direct `width`/`height` pass-through is unchanged. **`get_optional_params_image_gen`** now forwards the global `litellm.drop_params` flag into provider `map_openai_params`, aligning with image edit behavior.
> 
> For **edits**, `size` is no longer advertised or forwarded—the MAI edits API ignores it—so `size` yields 400 or is dropped under `drop_params`; `n` remains supported.
> 
> Tests cover boundary sizes, multi-image `n`, global `drop_params`, and SDK-level 400 responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c6a385efe1f61cbd9d276ed09427102aec820ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->