### PR TITLE
fix(headroom): drop stream options after CCR conversion

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
@@ -890,7 +890,7 @@ class HeadroomGuardrail(CustomGuardrail):
         if not has_headroom_retrieve_tool(effective.get("tools")):
             return base_result
         return {  # mutable-ok: the hook contract is a plain dict the router merges into the request kwargs
-            **effective,
+            **{key: value for key, value in effective.items() if key != "stream_options"},  # mutable-ok: removes stream-only options
             "stream": False,
             HEADROOM_CONVERTED_STREAM_KEY: True,
         }

--- a/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
@@ -890,9 +890,9 @@ class HeadroomGuardrail(CustomGuardrail):
         if not has_headroom_retrieve_tool(effective.get("tools")):
             return base_result
         return {  # mutable-ok: the hook contract is a plain dict the router merges into the request kwargs
-            **{
+            **{  # mutable-ok: removes stream-only options
                 key: value for key, value in effective.items() if key != "stream_options"
-            },  # mutable-ok: removes stream-only options
+            },
             "stream": False,
             HEADROOM_CONVERTED_STREAM_KEY: True,
         }

--- a/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
@@ -890,7 +890,9 @@ class HeadroomGuardrail(CustomGuardrail):
         if not has_headroom_retrieve_tool(effective.get("tools")):
             return base_result
         return {  # mutable-ok: the hook contract is a plain dict the router merges into the request kwargs
-            **{key: value for key, value in effective.items() if key != "stream_options"},  # mutable-ok: removes stream-only options
+            **{
+                key: value for key, value in effective.items() if key != "stream_options"
+            },  # mutable-ok: removes stream-only options
             "stream": False,
             HEADROOM_CONVERTED_STREAM_KEY: True,
         }

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_headroom.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_headroom.py
@@ -2165,7 +2165,7 @@ async def test_pre_call_deployment_hook_converts_stream_only_for_ccr_chat_comple
     tools: Optional[list],
     expect_conversion: bool,
 ):
-    kwargs = {"model": "gpt-4o", "stream": stream, "tools": tools}
+    kwargs = {"model": "gpt-4o", "stream": stream, "stream_options": {"include_usage": True}, "tools": tools}
 
     result = await guardrail.async_pre_call_deployment_hook(kwargs=kwargs, call_type=call_type)
 
@@ -2173,12 +2173,15 @@ async def test_pre_call_deployment_hook_converts_stream_only_for_ccr_chat_comple
         assert result is kwargs
         assert HEADROOM_CONVERTED_STREAM_KEY not in kwargs
         assert kwargs["stream"] is stream
+        assert kwargs["stream_options"] == {"include_usage": True}
         return
 
     assert result is not None
     assert result["stream"] is False
+    assert "stream_options" not in result
     assert result[HEADROOM_CONVERTED_STREAM_KEY] is True
     assert kwargs["stream"] is True
+    assert kwargs["stream_options"] == {"include_usage": True}
 
 
 @pytest.mark.asyncio
@@ -2233,6 +2236,7 @@ async def test_pre_call_deployment_hook_converts_stream_after_deployment_level_c
         "model": "gpt-4o",
         "messages": [dict(m) for m in ORIGINAL_MESSAGES],
         "stream": True,
+        "stream_options": {"include_usage": True},
         "guardrails": ["headroom"],
         "metadata": {},
     }
@@ -2248,6 +2252,7 @@ async def test_pre_call_deployment_hook_converts_stream_after_deployment_level_c
     assert result is not None
     assert has_headroom_retrieve_tool(result["tools"])
     assert result["stream"] is False
+    assert "stream_options" not in result
     assert result[HEADROOM_CONVERTED_STREAM_KEY] is True
 
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- CCR changes streaming calls to non-streaming upstream requests
- DeepSeek rejects `stream_options` when `stream` is false

How it solves it:

- Remove `stream_options` only during the CCR stream conversion
- Preserve stream options when the request remains streaming

## User Flow

Before: a developer streams a chat completion through the proxy and receives a 400 response when CCR retrieval runs

1. They send POST https://litellm-domain/v1/chat/completions with `"stream": true` and `"stream_options": {"include_usage": true}`
2. CCR retrieval runs for the long request history
3. The upstream provider returns 400 stating `stream_options should be set along with stream = true`

After: the same developer receives the streamed completion when CCR retrieval runs

1. They send POST https://litellm-domain/v1/chat/completions with `"stream": true` and `"stream_options": {"include_usage": true}`
2. CCR retrieval runs for the long request history
3. The upstream request is valid and the proxy returns the completion stream

## Relevant issues

Fixes #40068

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The focused Headroom guardrail tests pass locally
- [x] `make lint` passes locally
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Live provider proof was not run because this environment has no Headroom or DeepSeek credentials. The draft includes provider-free regression coverage for both the conversion and unchanged streaming paths

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Live provider confirmation remains for a credentialed environment

## Final Attestation

- [x] The regression tests cover conversion and unchanged streaming controls
