### PR TITLE
fix(guardrails): keep client tools untouched when a guardrail does not rewrite them

### DIFF
--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -478,7 +478,11 @@ class AnthropicMessagesHandler(BaseTranslation):
 
             guardrailed_texts: Final = guardrailed_inputs.get("texts", [])
             guardrailed_tools: Final = guardrailed_inputs.get("tools")
-            if guardrailed_tools is not None:
+            # A guardrail signals "I rewrote the tools" by returning a new list (same contract as
+            # structured_messages below). Re-serializing an untouched list would stamp type:"custom" onto
+            # every tool, which strict Anthropic-compat upstreams (e.g. DeepSeek) reject with
+            # `tools[0]: unknown variant 'custom'`.
+            if guardrailed_tools is not None and guardrailed_tools is not tools_to_check:
                 # Convert tools back from OpenAI format to Anthropic format
                 anthropic_config: Final = AnthropicConfig()
                 anthropic_tools: Final[list[AllAnthropicToolsValues]] = []

--- a/tests/test_litellm/llms/anthropic/chat/guardrail_translation/test_anthropic_guardrail_handler.py
+++ b/tests/test_litellm/llms/anthropic/chat/guardrail_translation/test_anthropic_guardrail_handler.py
@@ -1207,12 +1207,13 @@ class TestAnthropicMessagesHandlerInputProcessing:
         tool_search_tool_regex_20251119 were being converted to OpenAI format and then
         not properly converted back, causing API errors.
 
-        The guardrail converts tools to OpenAI format for processing, then they need to be
-        converted back to Anthropic format. Native Anthropic tools should be preserved as-is,
-        while regular tools should be converted to type="custom".
+        The guardrail converts tools to OpenAI format for processing, then a guardrail that
+        rewrites them (returns a new list) needs them converted back to Anthropic format.
+        Native Anthropic tools should be preserved as-is, while regular tools should be
+        converted to type="custom".
         """
         handler = AnthropicMessagesHandler()
-        guardrail = MockPassThroughGuardrail(guardrail_name="test")
+        guardrail = ToolRewritingGuardrail(guardrail_name="test")
 
         data = {
             "model": "claude-opus-4-6",
@@ -1260,6 +1261,97 @@ class TestAnthropicMessagesHandlerInputProcessing:
         assert tools[1]["name"] == "get_weather"
         assert tools[1]["description"] == "Get the weather at a specific location"
         assert "input_schema" in tools[1]
+
+
+class ToolRewritingGuardrail(CustomGuardrail):
+    """Returns a new `tools` list, which is how a guardrail signals that it rewrote tool schemas."""
+
+    async def apply_guardrail(
+        self,
+        inputs: GenericGuardrailAPIInputs,
+        request_data: dict,
+        input_type: Literal["request", "response"],
+        logging_obj: Optional[Any] = None,
+    ) -> GenericGuardrailAPIInputs:
+        rewritten = inputs.copy()
+        rewritten["tools"] = list(inputs.get("tools") or [])
+        return rewritten
+
+
+class ToolDescriptionMaskingGuardrail(CustomGuardrail):
+    """Masks a secret out of every tool description, returning a new `tools` list."""
+
+    async def apply_guardrail(
+        self,
+        inputs: GenericGuardrailAPIInputs,
+        request_data: dict,
+        input_type: Literal["request", "response"],
+        logging_obj: Optional[Any] = None,
+    ) -> GenericGuardrailAPIInputs:
+        masked = inputs.copy()
+        masked["tools"] = [
+            {
+                **tool,
+                "function": {
+                    **tool["function"],
+                    "description": str(tool["function"].get("description", "")).replace("sk-live-123", "[MASKED]"),
+                },
+            }
+            for tool in inputs.get("tools") or []
+        ]
+        return masked
+
+
+class TestAnthropicMessagesHandlerUnmodifiedTools:
+    """Claude Code CLI sends Anthropic-native tools with no `type` key. A guardrail that hands
+    `tools` back untouched must not trigger the OpenAI-to-Anthropic re-serialization, because that
+    stamps type:"custom" and strict Anthropic-compat upstreams (DeepSeek) reject that variant with
+    `tools[0]: unknown variant 'custom'`."""
+
+    @staticmethod
+    def _client_tools() -> list:
+        return [
+            {
+                "name": "Bash",
+                "description": "Run a shell command, token sk-live-123",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"command": {"type": "string"}},
+                    "required": ["command"],
+                },
+            }
+        ]
+
+    def _data(self) -> dict:
+        return {
+            "model": "deepseek-v4-flash",
+            "max_tokens": 128,
+            "messages": [{"role": "user", "content": [{"type": "text", "text": "list /tmp"}]}],
+            "tools": self._client_tools(),
+        }
+
+    @pytest.mark.asyncio
+    async def test_tools_reach_upstream_verbatim_when_guardrail_leaves_them_alone(self):
+        data = self._data()
+
+        result = await AnthropicMessagesHandler().process_input_messages(
+            data=data, guardrail_to_apply=MockPassThroughGuardrail(guardrail_name="test")
+        )
+
+        assert result["tools"] == self._client_tools()
+        assert "type" not in result["tools"][0]
+
+    @pytest.mark.asyncio
+    async def test_tools_are_rewritten_when_guardrail_returns_a_new_list(self):
+        data = self._data()
+
+        result = await AnthropicMessagesHandler().process_input_messages(
+            data=data, guardrail_to_apply=ToolDescriptionMaskingGuardrail(guardrail_name="test")
+        )
+
+        assert [tool["name"] for tool in result["tools"]] == ["Bash"]
+        assert result["tools"][0]["description"] == "Run a shell command, token [MASKED]"
+        assert "sk-live-123" not in json.dumps(result["tools"])
 
 
 class ToolAppendingGuardrail(CustomGuardrail):


### PR DESCRIPTION
## TLDR

Problem this solves:

- Guarded `/v1/messages` requests get their tools rewritten
- Rewrite adds `type:"custom"`, strict Anthropic-compatible upstreams 400
- Happens even when the guardrail masked nothing

How it solves it:

- Rewrite tools only when the guardrail returns a different list
- Same contract the function already uses for `structured_messages`
- Genuine tool rewrites and tool injections keep working

## User Flow

Before: a developer using an Anthropic-compatible model behind a guardrailed key cannot use tools at all, and the error text points at a tool type they never sent

1. Their key has a content-scanning guardrail on in `pre_call` mode
2. They send POST https://litellm-domain/v1/messages with a model served by an Anthropic-compatible provider, and one tool shaped `{"name": "Bash", "description": "Run a shell command", "input_schema": {...}}`
3. They get back HTTP 400 reading `Failed to deserialize the JSON body into the target type: tools[0]: unknown variant 'custom', expected 'web_search_20250305' or 'web_search_20260209'`, naming a `custom` variant that was never in their request
4. Every retry fails the same way, and any configured fallback that lands on the same provider fails identically
5. They send the exact same request with no `tools` at all and it returns 200, so the tools array is the only difference
6. They turn the guardrail off for that key and the original tool-bearing request returns 200

After: the same request works with the guardrail left on

1. Their key has a content-scanning guardrail on in `pre_call` mode
2. They send the same POST https://litellm-domain/v1/messages with the same tool
3. They get back HTTP 200 with a normal message, and a `tool_use` block when the model decides to call `Bash`
4. The guardrail still scans and still masks: a secret placed in the prompt or in a tool description comes back redacted

## Relevant issues

Related to #24913, which is the mirror-image leak in the other direction (`translate_anthropic_tools_to_openai` copying the tool-level `type` into `function.parameters`). That one is fixed, this is the write-back side of the same round-trip and is not covered by it

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup, both runs use the same config and the same payload

`config.yaml`, pointed at an Anthropic-compatible upstream that rejects the explicit tool discriminator, with a content-scanning guardrail on for every request:

```yaml
model_list:
  - model_name: compat-model
    litellm_params:
      model: anthropic/deepseek-chat
      api_base: https://api.deepseek.com/anthropic
      api_key: os.environ/DEEPSEEK_API_KEY

guardrails:
  - guardrail_name: content-scan
    litellm_params:
      guardrail: litellm_content_filter
      mode: pre_call
      default_on: true
```

Proxy started with `python litellm/proxy/proxy_cli.py --config config.yaml --detailed_debug`

Payload, a client tool in the shape Anthropic clients actually send, with no `type` key:

```bash
curl -sS -o /dev/stderr -w '\nHTTP %{http_code}\n' http://localhost:4000/v1/messages \
  -H 'Authorization: Bearer sk-1234' \
  -H 'anthropic-version: 2023-06-01' \
  -H 'content-type: application/json' \
  -d '{"model":"compat-model","max_tokens":128,
       "messages":[{"role":"user","content":[{"type":"text","text":"Use your Bash tool to list /tmp, then stop."}]}],
       "tools":[{"name":"Bash","description":"Run a shell command","input_schema":{"type":"object","properties":{"command":{"type":"string"}},"required":["command"]}}]}'
```

### Before (168a0055a244acdcf97c330c52e085ab40b1424c)

1. Run the curl above. The upstream rejects a tool type the client never sent

```
HTTP 400
{"type":"error","error":{"type":"invalid_request_error","message":"litellm.BadRequestError: AnthropicException - {\"error\":{\"message\":\"Failed to deserialize the JSON body into the target type: tools[0]: unknown variant `custom`, expected `web_search_20250305` or `web_search_20260209` at line 1 column 372\",\"type\":\"invalid_request_error\",\"param\":null,\"code\":\"invalid_request_error\"}}. Received Model Group=compat-model"}}
```

2. The outbound body in the debug log carries a `type` the request did not have

```
'tools': [{'name': 'Bash', 'input_schema': {'type': 'object', 'properties': {'command': {'type': 'string'}}, 'required': ['command']}, 'type': 'custom', 'description': 'Run a shell command'}]
```

### After (27470d7726)

1. Run the same curl. The schema rejection is gone: the request now gets past deserialization and reaches billing, where this particular test account happens to be out of credit

```
HTTP 402
{"type":"error","error":{"type":"api_error","message":"litellm.BadRequestError: AnthropicException - {\"error\":{\"message\":\"Insufficient Balance\",\"type\":\"unknown_error\",\"param\":null,\"code\":\"invalid_request_error\"}}. Received Model Group=compat-model"}}
```

2. The outbound body now matches what the client sent, with no injected `type`

```
'tools': [{'name': 'Bash', 'description': 'Run a shell command', 'input_schema': {'type': 'object', 'properties': {'command': {'type': 'string'}}, 'required': ['command']}}]
```

Staying in draft until the same run lands a funded 200 with a `tool_use` block. The guardrail is on for both runs, so the difference is the write-back and nothing else

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Guardrails must return a new list to signal a tool rewrite
- In-place mutation of the received list is no longer picked up
- That is already the contract for `structured_messages` in the same function
