### PR TITLE
feat(terraform): expose generated key output

### DIFF
--- a/terraform/provider/docs/resources/key.md
+++ b/terraform/provider/docs/resources/key.md
@@ -132,3 +132,7 @@ $ terraform import litellm_key.example 12345
 ```
 
 This allows you to import existing keys into your Terraform state, enabling management of keys that were created outside of Terraform.
+
+### Generated key output
+
+`generated_key` is a sensitive computed string containing the key returned at creation. It remains in Terraform state across refreshes so dependent resources can use it. Protect state as secret material. Importing an existing token hash cannot recover the original key; `generated_key` is null after import. The optional write-only `key` argument still supplies a custom key at creation

--- a/terraform/provider/litellm/resource_key.go
+++ b/terraform/provider/litellm/resource_key.go
@@ -25,6 +25,11 @@ func resourceKey() *schema.Resource {
 				WriteOnly: true,
 				Sensitive: true,
 			},
+			"generated_key": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
 			"token_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -192,7 +197,7 @@ func resourceKeyCreate(ctx context.Context, d *schema.ResourceData, m interface{
 	// A config-supplied key value becomes the key itself; when absent the
 	// proxy generates one. Write-only attributes are invisible to d.Get in
 	// real Terraform runs, so read the raw config first.
-	if raw, err := d.GetRawConfigAt(cty.GetAttrPath("key")); err == nil && !raw.IsNull() && raw.Type() == cty.String && raw.AsString() != "" {
+	if raw, err := d.GetRawConfigAt(cty.GetAttrPath("key")); err == nil && raw.IsKnown() && !raw.IsNull() && raw.Type() == cty.String && raw.AsString() != "" {
 		key.Key = raw.AsString()
 	} else if v := d.Get("key").(string); v != "" {
 		key.Key = v
@@ -204,9 +209,9 @@ func resourceKeyCreate(ctx context.Context, d *schema.ResourceData, m interface{
 	}
 
 	d.SetId(createdKey.TokenID)
-	// Set the write-only key value so it's available during this apply
-	// but will not be persisted to state.
-	d.Set("key", createdKey.Key)
+	if err := d.Set("generated_key", createdKey.Key); err != nil {
+		return diag.FromErr(fmt.Errorf("error storing generated key: %w", err))
+	}
 	return resourceKeyRead(ctx, d, m)
 }
 

--- a/terraform/provider/litellm/resource_key_test.go
+++ b/terraform/provider/litellm/resource_key_test.go
@@ -3,6 +3,8 @@ package litellm
 import (
 	"context"
 	"encoding/json"
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -252,5 +254,39 @@ func TestGetKeyUnwrapsInfoEnvelope(t *testing.T) {
 	}
 	if key.RPMLimit == nil || *key.RPMLimit != 100 {
 		t.Errorf("RPMLimit not parsed: %+v", key.RPMLimit)
+	}
+}
+
+func TestKeyCreateUsesWriteOnlyRawConfig(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/key/generate" {
+			var payload map[string]interface{}
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Error(err)
+			}
+			if payload["key"] != "sk-custom-test" {
+				t.Errorf("custom key dropped: %v", payload["key"])
+			}
+			w.Write([]byte(`{"key":"sk-custom-test","token_id":"hash-1"}`))
+			return
+		}
+		w.Write([]byte(`{"key":"hash-1","info":{"key_alias":"remote"}}`))
+	}))
+	defer srv.Close()
+	d, err := schema.InternalMap(resourceKey().Schema).Data(nil, &terraform.InstanceDiff{
+		RawConfig: cty.ObjectVal(map[string]cty.Value{"key": cty.StringVal("sk-custom-test")}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Get("key") != "" {
+		t.Fatal("test must exercise a write-only key absent from d.Get")
+	}
+	if diags := resourceKeyCreate(context.Background(), d, NewClient(srv.URL, "test-key", false)); diags.HasError() {
+		t.Fatal(diags)
+	}
+	if d.Id() != "hash-1" || d.Get("generated_key") != "sk-custom-test" || d.Get("key_alias") != "remote" {
+		t.Fatal("create did not preserve generated key and refresh remote state")
 	}
 }


### PR DESCRIPTION
## TLDR

Problem this solves:

- Terraform consumers cannot access proxy-generated key values

How it solves it:

- Add sensitive, computed `generated_key` output
- Preserve the creation response across refreshes

## User Flow

Before: dependent resources cannot reference a generated key

1. Declare `litellm_key.audit` and reference `litellm_key.audit.generated_key`
2. Run `tofu validate` and observe `Unsupported attribute`

After: dependent resources can reference the generated key

1. Declare `litellm_key.audit` and reference `litellm_key.audit.generated_key`
2. Run `tofu validate` and observe success, then apply to populate the sensitive value

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Local LiteLLM v1.101.0-rc.1 with PostgreSQL 17. The image is pinned to `ghcr.io/berriai/litellm@sha256:32c04b00bc1a720e6d5eeb56a7e72f4e1e7d1e538e779c59b990cbddfd5e27da`. Providers were built from the revisions below and selected through development overrides

The configuration creates a disposable team-backed key with `max_budget = 5`. A sensitive output evaluates `try(length(litellm_key.audit.generated_key) > 0, false)`. No secret values are printed. These management operations require no inference calls

### Before (168a0055a244acdcf97c330c52e085ab40b1424c)

1. Run `tofu validate`: exit 1, `Unsupported attribute`, because `generated_key` does not exist
2. Creation and dependent-resource use cannot proceed with this configuration

### After (44903b3bde)

1. Run `tofu validate`: exit 0
2. Run `tofu apply -auto-approve`: exit 0, output evaluates true, and the generated key's SHA-256 matches `token_id`
3. Change `key_alias`, run `tofu apply -auto-approve`, then `tofu apply -refresh-only -auto-approve`: both exit 0, generated key remains identical
4. Run `tofu plan -detailed-exitcode` twice: both exit 0
5. Remove only the disposable local key address using `tofu state rm litellm_key.audit`, then `tofu import litellm_key.audit <token_id>`: exit 0, `generated_key` is null because a hash cannot recover the original secret
6. Run `tofu destroy -auto-approve`: exit 0, then delete the disposable team

## Type

New Feature

## Caveats (if any)

### Medium

- The output stores the secret in Terraform state
- Hash-only imports cannot recover the generated secret

## Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
