### PR TITLE
fix(terraform): omit empty key team updates

### DIFF
--- a/terraform/provider/litellm/client.go
+++ b/terraform/provider/litellm/client.go
@@ -79,7 +79,6 @@ func (c *Client) UpdateKey(key *Key) (*Key, error) {
 	// Create a new map with only the fields that can be updated
 	updateData := map[string]interface{}{
 		"key":              key.Key,
-		"team_id":          key.TeamID,
 		"metadata":         key.Metadata,
 		"key_alias":        key.KeyAlias,
 		"aliases":          key.Aliases,
@@ -92,6 +91,9 @@ func (c *Client) UpdateKey(key *Key) (*Key, error) {
 
 	// The proxy rejects an empty-string budget_duration with a 400, so only
 	// send it when set.
+	if key.TeamID != "" {
+		updateData["team_id"] = key.TeamID
+	}
 	if key.BudgetDuration != "" {
 		updateData["budget_duration"] = key.BudgetDuration
 	}

--- a/terraform/provider/litellm/resource_key_test.go
+++ b/terraform/provider/litellm/resource_key_test.go
@@ -122,7 +122,7 @@ func TestUpdateKeyOmitsUnsetNewFields(t *testing.T) {
 	}
 
 	for _, k := range []string{
-		"budget_id", "enforced_params", "allowed_routes", "allowed_passthrough_routes",
+		"team_id", "budget_id", "enforced_params", "allowed_routes", "allowed_passthrough_routes",
 		"rpm_limit_type", "tpm_limit_type", "prompts", "organization_id",
 	} {
 		if _, present := captured[k]; present {


### PR DESCRIPTION
## TLDR

Problem this solves:

- Updating a teamless key fails with HTTP 500

How it solves it:

- Omit `team_id` when no team is assigned

## User Flow

Before: updating an unassigned key fails

1. Create `litellm_key.audit` without `team_id`
2. Change its `key_alias` and run `tofu apply`
3. Observe HTTP 500, `Team object not found for team change validation`

After: updating an unassigned key succeeds

1. Create `litellm_key.audit` without `team_id`
2. Change its `key_alias` and run `tofu apply`
3. Observe success and an empty subsequent plan

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Local LiteLLM v1.101.0-rc.1 with PostgreSQL 17, using image `ghcr.io/berriai/litellm@sha256:32c04b00bc1a720e6d5eeb56a7e72f4e1e7d1e538e779c59b990cbddfd5e27da`. Providers were built at the revisions below and selected using development overrides. The disposable key has `key_alias = "tf-audit-teamless"`, `models = []`, `max_budget = 5`, and no `team_id`. No inference requests are needed

### Before (168a0055a244acdcf97c330c52e085ab40b1424c)

1. Run `tofu apply -auto-approve`: exit 0
2. Change `key_alias` to `tf-audit-teamless-updated`, then run `tofu apply -auto-approve`: exit 1, `/key/update` returns HTTP 500 with `Team object not found for team change validation`
3. Run `tofu plan -detailed-exitcode` twice: both exit 2
4. Run `tofu destroy -auto-approve`: exit 0

### After (9ed1ca3399)

1. Run `tofu apply -auto-approve`: exit 0
2. Change `key_alias` to `tf-audit-teamless-updated`, then run `tofu apply -auto-approve`: exit 0
3. Run `tofu plan -detailed-exitcode` twice: both exit 0
4. Run `tofu destroy -auto-approve`: exit 0

## Type

Bug Fix

## Caveats (if any)

### Low

- This does not add support for detaching assigned teams

## Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
