### PR TITLE
fix(guardrails): preserve apply_guardrail provider verdicts

### DIFF
--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -1298,7 +1298,9 @@ class CustomGuardrail(CustomLogger):
                 and self._inputs_were_modified(original_inputs, response)
                 else "allow"
                 if original_inputs is not None and isinstance(response, dict)
-                else {} if response is None else response
+                else {}
+                if response is None
+                else response
             )
         )  # mutable-ok: the logging payload requires a mutable response mapping
 

--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -1287,7 +1287,6 @@ class CustomGuardrail(CustomLogger):
         """
         verdict: Final = _guardrail_verdict.get()
 
-        # Convert None to empty dict to satisfy type requirements
         guardrail_response: dict[str, object] | str = (
             dict(verdict)  # mutable-ok: a TypedDict is not assignable to dict[str, object]
             if verdict is not None
@@ -1298,7 +1297,7 @@ class CustomGuardrail(CustomLogger):
                 and self._inputs_were_modified(original_inputs, response)
                 else "allow"
                 if original_inputs is not None and isinstance(response, dict)
-                else {}
+                else {}  # mutable-ok: the logging payload requires a mutable response mapping
                 if response is None
                 else response
             )
@@ -1338,6 +1337,7 @@ class CustomGuardrail(CustomLogger):
 
         This gets logged on downsteam Langfuse, DataDog, etc.
         """
+        verdict: Final = _guardrail_verdict.get()
         guardrail_status: Final[GuardrailStatus] = (
             "guardrail_intervened" if self._is_guardrail_intervention(e) else "guardrail_failed_to_respond"
         )
@@ -1348,13 +1348,17 @@ class CustomGuardrail(CustomLogger):
             guardrail_response = "deny"
 
         self.add_standard_logging_guardrail_information_to_request_data(
-            guardrail_json_response=guardrail_response,
+            guardrail_json_response=dict(verdict)  # mutable-ok: logging requires a mutable dict
+            if verdict is not None
+            else guardrail_response,
             request_data=request_data,
             guardrail_status=guardrail_status,
             duration=duration,
             start_time=start_time,
             end_time=end_time,
             event_type=event_type,
+            guardrail_provider=self.guardrail_provider if verdict is not None else None,
+            tracing_detail=_verdict_tracing_detail(verdict),
         )
         raise e
 

--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -1288,18 +1288,19 @@ class CustomGuardrail(CustomLogger):
         verdict: Final = _guardrail_verdict.get()
 
         # Convert None to empty dict to satisfy type requirements
-        guardrail_response: dict[str, object] | str = {} if response is None else response
-
-        if verdict is not None:
-            guardrail_response = dict(verdict)  # mutable-ok: a TypedDict is not assignable to dict[str, object]
-        elif original_inputs is not None and isinstance(response, dict):
-            # For apply_guardrail functions in custom_code_guardrail scenario,
-            # simplify the logged response to "allow", "deny", or "mask"
-            # Check if inputs were modified by comparing them
-            if self._inputs_were_modified(original_inputs, response):
-                guardrail_response = "mask"
-            else:
-                guardrail_response = "allow"
+        guardrail_response: dict[str, object] | str = (
+            dict(verdict)  # mutable-ok: a TypedDict is not assignable to dict[str, object]
+            if verdict is not None
+            else (
+                "mask"
+                if original_inputs is not None
+                and isinstance(response, dict)
+                and self._inputs_were_modified(original_inputs, response)
+                else "allow"
+                if original_inputs is not None and isinstance(response, dict)
+                else {} if response is None else response
+            )
+        )  # mutable-ok: the logging payload requires a mutable response mapping
 
         verbose_logger.debug("Guardrail response: %s", response)
 

--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -1348,9 +1348,7 @@ class CustomGuardrail(CustomLogger):
             guardrail_response = "deny"
 
         self.add_standard_logging_guardrail_information_to_request_data(
-            guardrail_json_response=dict(verdict)  # mutable-ok: logging requires a mutable dict
-            if verdict is not None
-            else guardrail_response,
+            guardrail_json_response=guardrail_response,
             request_data=request_data,
             guardrail_status=guardrail_status,
             duration=duration,

--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -159,7 +159,6 @@ class CustomGuardrail(CustomLogger):
 
     records_own_guardrail_information: ClassVar[bool] = False
 
-    # Name of the service behind this guardrail, set by subclasses that have one.
     guardrail_provider: str | None = None
 
     def __init_subclass__(cls, **kwargs: object) -> None:  # kwargs-ok: forwarded to cooperative __init_subclass__ hooks

--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -27,6 +27,7 @@ from litellm.types.proxy.guardrails.guardrail_hooks.base import GuardrailConfigM
 from litellm.types.utils import (
     CallTypes,
     GenericGuardrailAPIInputs,
+    GuardrailProviderVerdict,
     GuardrailStatus,
     GuardrailTracingDetail,
     LLMResponseTypes,
@@ -72,6 +73,12 @@ DEFAULT_ADVISORY_MESSAGE: Final = (
 
 _guardrail_self_recorded: Final[contextvars.ContextVar[bool]] = contextvars.ContextVar(
     "litellm_guardrail_self_recorded", default=False
+)
+
+# Scoped with a ContextVar for the same reason as the flag above: asyncio copies the context
+# into each gathered task, so concurrent guardrails cannot read each other's verdict.
+_guardrail_verdict: Final[contextvars.ContextVar[GuardrailProviderVerdict | None]] = contextvars.ContextVar(
+    "litellm_guardrail_verdict", default=None
 )
 
 
@@ -151,6 +158,9 @@ class CustomGuardrail(CustomLogger):
     use_native_lifecycle_hooks: ClassVar[bool] = False
 
     records_own_guardrail_information: ClassVar[bool] = False
+
+    # Name of the service behind this guardrail, set by subclasses that have one.
+    guardrail_provider: str | None = None
 
     def __init_subclass__(cls, **kwargs: object) -> None:  # kwargs-ok: forwarded to cooperative __init_subclass__ hooks
         super().__init_subclass__(**kwargs)
@@ -1248,6 +1258,19 @@ class CustomGuardrail(CustomLogger):
         """
         return inputs
 
+    @staticmethod
+    def record_guardrail_verdict(verdict: GuardrailProviderVerdict) -> None:
+        """
+        Report the provider's decision so it is logged in place of the inferred "allow"/"mask".
+
+        Call this from ``apply_guardrail`` when the provider distinguishes outcomes that the
+        returned inputs do not, e.g. a violation it detects and allows through. Pass a
+        sanitized verdict rather than the raw vendor body: what the provider decided, and the
+        identifiers needed to look the call up on their side. The verdict applies to the
+        current guardrail call only.
+        """
+        _guardrail_verdict.set(verdict)
+
     def _process_response(
         self,
         response: dict | None,
@@ -1263,12 +1286,16 @@ class CustomGuardrail(CustomLogger):
 
         This gets logged on downsteam Langfuse, DataDog, etc.
         """
+        verdict: Final = _guardrail_verdict.get()
+
         # Convert None to empty dict to satisfy type requirements
         guardrail_response: dict[str, object] | str = {} if response is None else response
 
-        # For apply_guardrail functions in custom_code_guardrail scenario,
-        # simplify the logged response to "allow", "deny", or "mask"
-        if original_inputs is not None and isinstance(response, dict):
+        if verdict is not None:
+            guardrail_response = dict(verdict)  # mutable-ok: a TypedDict is not assignable to dict[str, object]
+        elif original_inputs is not None and isinstance(response, dict):
+            # For apply_guardrail functions in custom_code_guardrail scenario,
+            # simplify the logged response to "allow", "deny", or "mask"
             # Check if inputs were modified by comparing them
             if self._inputs_were_modified(original_inputs, response):
                 guardrail_response = "mask"
@@ -1280,11 +1307,13 @@ class CustomGuardrail(CustomLogger):
         self.add_standard_logging_guardrail_information_to_request_data(
             guardrail_json_response=guardrail_response,
             request_data=request_data,
-            guardrail_status="success",
+            guardrail_status=_verdict_status(verdict),
             duration=duration,
             start_time=start_time,
             end_time=end_time,
             event_type=event_type,
+            guardrail_provider=self.guardrail_provider if verdict is not None else None,
+            tracing_detail=_verdict_tracing_detail(verdict),
         )
         return response
 
@@ -1451,6 +1480,28 @@ def _sync_guardrail_info_to_logging_obj(request_data: dict, logging_obj: object)
     _append_slg_to_litellm_params(mcd.get("litellm_params"), entries)
 
 
+def _verdict_status(verdict: GuardrailProviderVerdict | None) -> GuardrailStatus:
+    """``guardrail_flagged`` when the provider recorded a violation it allowed through."""
+    if verdict is not None and verdict.get("flagged"):
+        return "guardrail_flagged"
+    return "success"
+
+
+def _verdict_tracing_detail(verdict: GuardrailProviderVerdict | None) -> GuardrailTracingDetail | None:
+    """Copy the verdict onto the audit fields of the guardrail record.
+
+    ``guardrail_response`` is prompt-carrying, so prompt redaction replaces it. These fields
+    are not, so the verdict survives on a redacted record.
+    """
+    if verdict is None:
+        return None
+    return GuardrailTracingDetail(
+        guardrail_action=verdict.get("action"),
+        guardrail_transaction_id=verdict.get("transaction_id"),
+        violation_categories=verdict.get("violation_categories"),
+    )
+
+
 def log_guardrail_information(func):
     """
     Decorator to add standard logging guardrail information to any function
@@ -1515,6 +1566,7 @@ def log_guardrail_information(func):
 
         logging_obj: Final = kwargs.get("logging_obj") or request_data.get("litellm_logging_obj")
         self_recorded_token: Final = _guardrail_self_recorded.set(False)
+        verdict_token: Final = _guardrail_verdict.set(None)
         try:
             response: Final = await func(*args, **kwargs)
             if self.records_own_guardrail_information or _guardrail_self_recorded.get():
@@ -1541,6 +1593,7 @@ def log_guardrail_information(func):
             )
         finally:
             _guardrail_self_recorded.reset(self_recorded_token)
+            _guardrail_verdict.reset(verdict_token)
             _sync_guardrail_info_to_logging_obj(request_data, logging_obj)
 
     @functools.wraps(func)
@@ -1557,6 +1610,7 @@ def log_guardrail_information(func):
 
         logging_obj: Final = kwargs.get("logging_obj") or request_data.get("litellm_logging_obj")
         self_recorded_token: Final = _guardrail_self_recorded.set(False)
+        verdict_token: Final = _guardrail_verdict.set(None)
         try:
             response: Final = func(*args, **kwargs)
             if self.records_own_guardrail_information or _guardrail_self_recorded.get():
@@ -1579,6 +1633,7 @@ def log_guardrail_information(func):
             )
         finally:
             _guardrail_self_recorded.reset(self_recorded_token)
+            _guardrail_verdict.reset(verdict_token)
             _sync_guardrail_info_to_logging_obj(request_data, logging_obj)
 
     @functools.wraps(func)

--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -2048,9 +2048,7 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
             guardrail_action = guardrail_information.get("guardrail_action")
             if guardrail_action:
                 guardrail_span.set_attribute("guardrail_action", guardrail_action)
-            guardrail_transaction_id = guardrail_information.get("guardrail_transaction_id")
-            if guardrail_transaction_id:
-                guardrail_span.set_attribute("guardrail_transaction_id", guardrail_transaction_id)
+            self._set_guardrail_transaction_id(guardrail_span, guardrail_information)
 
             # The provider hook (e.g. Bedrock) extracts violation_categories
             # from the raw response BEFORE redaction and stamps them onto
@@ -2086,6 +2084,12 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
             self._set_team_attributes_from_kwargs(guardrail_span, kwargs)
 
             guardrail_span.end(end_time=self._to_ns(end_time_datetime))
+
+    @staticmethod
+    def _set_guardrail_transaction_id(span: Span, information: dict) -> None:
+        transaction_id = information.get("guardrail_transaction_id")
+        if transaction_id:
+            span.set_attribute("guardrail_transaction_id", transaction_id)
 
     def _handle_failure(self, kwargs, response_obj, start_time, end_time):
         from opentelemetry.trace import Status, StatusCode

--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -2048,6 +2048,9 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
             guardrail_action = guardrail_information.get("guardrail_action")
             if guardrail_action:
                 guardrail_span.set_attribute("guardrail_action", guardrail_action)
+            guardrail_transaction_id = guardrail_information.get("guardrail_transaction_id")
+            if guardrail_transaction_id:
+                guardrail_span.set_attribute("guardrail_transaction_id", guardrail_transaction_id)
 
             # The provider hook (e.g. Bedrock) extracts violation_categories
             # from the raw response BEFORE redaction and stamps them onto

--- a/litellm/integrations/otel/mappers/genai.py
+++ b/litellm/integrations/otel/mappers/genai.py
@@ -137,6 +137,7 @@ class GenAIMapper:
         LiteLLM.GUARDRAIL_MASKED_ENTITY_COUNT: lambda d: d.masked_entity_count,
         LiteLLM.GUARDRAIL_DURATION: lambda d: d.duration,
         LiteLLM.GUARDRAIL_ID: lambda d: d.guardrail_id,
+        LiteLLM.GUARDRAIL_TRANSACTION_ID: lambda d: d.guardrail_transaction_id,
         LiteLLM.GUARDRAIL_POLICY_TEMPLATE: lambda d: d.policy_template,
         LiteLLM.GUARDRAIL_DETECTION_METHOD: lambda d: d.detection_method,
         LiteLLM.GUARDRAIL_USAGE: lambda d: d.usage_json,

--- a/litellm/integrations/otel/model/payloads.py
+++ b/litellm/integrations/otel/model/payloads.py
@@ -243,6 +243,7 @@ class GuardrailSpanData:
     # ``StandardLoggingGuardrailInformation``). Present for any guardrail that
     # populates them, not just one provider's shape.
     guardrail_id: str | None = None
+    guardrail_transaction_id: str | None = None
     policy_template: str | None = None
     detection_method: str | None = None
     # Provider-reported billable usage counters (JSON-serialized) and the USD cost
@@ -295,6 +296,7 @@ class GuardrailSpanData:
             start_time=as_float(get("start_time")),
             end_time=as_float(get("end_time")),
             guardrail_id=as_str(get("guardrail_id")),
+            guardrail_transaction_id=as_str(get("guardrail_transaction_id")),
             policy_template=as_str(get("policy_template")),
             detection_method=as_str(get("detection_method")),
             usage_json=_json_or_none(usage) if usage is not None else None,

--- a/litellm/integrations/otel/model/semconv.py
+++ b/litellm/integrations/otel/model/semconv.py
@@ -309,6 +309,8 @@ class LiteLLM:
     GUARDRAIL_MASKED_ENTITY_COUNT: Final = "litellm.guardrail.masked_entity_count"
     GUARDRAIL_DURATION: Final = "litellm.guardrail.duration"
     GUARDRAIL_ID: Final = "litellm.guardrail.id"
+    # The provider's identifier for one evaluation, distinct from the stable GUARDRAIL_ID.
+    GUARDRAIL_TRANSACTION_ID: Final = "litellm.guardrail.transaction_id"
     GUARDRAIL_POLICY_TEMPLATE: Final = "litellm.guardrail.policy_template"
     GUARDRAIL_DETECTION_METHOD: Final = "litellm.guardrail.detection_method"
     # Provider-reported billable usage counters, JSON-serialized into one value.

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -2028,16 +2028,16 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
     def _build_invoke_checks_tracing_detail(
         violations: list[BedrockChecksViolation],
     ) -> GuardrailTracingDetail:
-        tracing_detail: Final[GuardrailTracingDetail] = {}
-        categories: Final = [
+        categories: Final = tuple(
             label
             for label in (v.get("category") or v.get("type") for v in violations)
             if isinstance(label, str) and label
-        ]
-        if categories:
-            tracing_detail["violation_categories"] = categories
-        tracing_detail["guardrail_action"] = "GUARDRAIL_INTERVENED" if violations else "NONE"
-        return tracing_detail
+        )
+        categories_detail: Final[GuardrailTracingDetail] = {"violation_categories": categories}
+        return {
+            **(categories_detail if categories else _NO_TRACING_DETAIL),
+            "guardrail_action": "GUARDRAIL_INTERVENED" if violations else "NONE",
+        }
 
     def _get_block_exception_for_checks(
         self, violations: list[BedrockChecksViolation], request_data: dict | None = None

--- a/litellm/proxy/guardrails/guardrail_hooks/zscaler_ai_guard/zscaler_ai_guard.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/zscaler_ai_guard/zscaler_ai_guard.py
@@ -4,11 +4,13 @@
 #
 # +-------------------------------------------------------------+
 import os
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Final, Literal, Optional
 
 from fastapi import HTTPException
 
 from litellm._logging import verbose_proxy_logger
+from litellm.constants import EMPTY_MAPPING
 from litellm.integrations.custom_guardrail import (
     CustomGuardrail,
     log_guardrail_information,
@@ -18,7 +20,7 @@ from litellm.llms.custom_httpx.http_handler import (
     httpxSpecialProvider,
 )
 from litellm.types.guardrails import GuardrailEventHooks
-from litellm.types.utils import GenericGuardrailAPIInputs
+from litellm.types.utils import GenericGuardrailAPIInputs, GuardrailProviderVerdict
 
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
@@ -29,6 +31,8 @@ DEFAULT_GUARDRAIL_TIMEOUT: Final = 5.0
 
 
 class ZscalerAIGuard(CustomGuardrail):
+    guardrail_provider = "zscaler_ai_guard"
+
     @classmethod
     def get_supported_event_hooks(cls) -> list[GuardrailEventHooks]:
         return [
@@ -234,7 +238,39 @@ class ZscalerAIGuard(CustomGuardrail):
             raise e
 
         verbose_proxy_logger.debug("ZscalerAIGuard: Successfully applied guardrail.")
+        if isinstance(zscaler_ai_guard_result, Mapping):
+            self.record_guardrail_verdict(self._build_verdict(zscaler_ai_guard_result))
         return inputs
+
+    @staticmethod
+    def _build_verdict(result: Mapping[str, object]) -> GuardrailProviderVerdict:
+        """
+        Sanitized verdict for logging: the AI Guard action, its transaction id and the detectors
+        that triggered, without the vendor body.
+
+        The action comes from the AI Guard response rather than from ``result``, because
+        ``_handle_response`` reports DETECT as ALLOW. Neither blocks the request, but only DETECT
+        means the policy matched.
+        """
+        ai_guard_response: Final = result.get("zscaler_ai_guard_response")
+        response_fields: Final = ai_guard_response if isinstance(ai_guard_response, Mapping) else EMPTY_MAPPING
+        raw_action: Final = response_fields.get("action") or result.get("action")
+        action: Final = raw_action if isinstance(raw_action, str) else None
+        transaction_id: Final = response_fields.get("transactionId")
+        detector_responses: Final = response_fields.get("detectorResponses")
+        triggered: Final = tuple(
+            detector
+            for detector, details in (detector_responses.items() if isinstance(detector_responses, Mapping) else ())
+            if isinstance(detector, str)
+            and isinstance(details, Mapping)
+            and details.get("action") not in (None, "ALLOW")
+        )
+        return GuardrailProviderVerdict(
+            action=action,
+            transaction_id=transaction_id if isinstance(transaction_id, str) else None,
+            violation_categories=triggered or None,
+            flagged=action is not None and action != "ALLOW",
+        )
 
     def extract_blocking_info(self, response):
         """

--- a/litellm/proxy/guardrails/guardrail_hooks/zscaler_ai_guard/zscaler_ai_guard.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/zscaler_ai_guard/zscaler_ai_guard.py
@@ -228,6 +228,7 @@ class ZscalerAIGuard(CustomGuardrail):
                 )
                 verbose_proxy_logger.debug("response from zscaler ai guards: %s", zscaler_ai_guard_result)
             if zscaler_ai_guard_result and zscaler_ai_guard_result.get("action") == "BLOCK":
+                self.record_guardrail_verdict(self._build_verdict(zscaler_ai_guard_result))
                 blocking_info: Final = zscaler_ai_guard_result.get("zscaler_ai_guard_response")
                 error_message = f"Content blocked by Zscaler AI Guard: {self.extract_blocking_info(blocking_info)}"
                 raise HTTPException(status_code=400, detail={"error": error_message})

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3115,6 +3115,7 @@ AUDIT_GUARDRAIL_FIELDS: Final[frozenset[str]] = frozenset(
         "duration",
         "masked_entity_count",
         "guardrail_id",
+        "guardrail_transaction_id",
         "policy_template",
         "detection_method",
         "confidence_score",
@@ -3155,7 +3156,13 @@ class StandardLoggingGuardrailInformation(TypedDict, total=False):
     """
 
     guardrail_id: str | None
-    """Unique identifier for the guardrail configuration, e.g. 'gd-eu-pii-001'"""
+    """Unique identifier for the guardrail configuration, e.g. 'gd-eu-pii-001'.
+
+    Stable across requests: the usage rollup groups daily metrics by it, so a value that
+    varies per request belongs in ``guardrail_transaction_id`` instead."""
+
+    guardrail_transaction_id: ReadOnly[str | None]
+    """Provider identifier for this evaluation, such as a vendor transaction id."""
 
     policy_template: str | None
     """Name of the policy template this guardrail belongs to, e.g. 'EU AI Act Article 5'"""
@@ -3181,7 +3188,7 @@ class StandardLoggingGuardrailInformation(TypedDict, total=False):
     risk_score: float | None
     """Risk score 0-10 indicating how risky the request was (higher = riskier). Computed by the guardrail provider."""
 
-    violation_categories: list[str] | None
+    violation_categories: Sequence[str] | None
     """Names of the policy items that intervened on this request (e.g. Bedrock
     topic-policy topic names, content-policy filter types, PII entity types).
     Populated by the provider hook before redaction so downstream loggers
@@ -3250,6 +3257,7 @@ class GuardrailTracingDetail(TypedDict, total=False):
     """
 
     guardrail_id: str | None
+    guardrail_transaction_id: ReadOnly[str | None]
     policy_template: str | None
     detection_method: str | None
     confidence_score: float | None
@@ -3258,12 +3266,35 @@ class GuardrailTracingDetail(TypedDict, total=False):
     patterns_checked: int | None
     alert_recipients: list[str] | None
     risk_score: float | None
-    violation_categories: list[str] | None
+    violation_categories: Sequence[str] | None
     guardrail_action: str | None
     guardrail_usage: ReadOnly[Mapping[str, int] | None]
     guardrail_cost: ReadOnly[float | None]
     guardrail_cost_by_unit: ReadOnly[Mapping[str, float | None] | None]
     guardrail_cost_in_spend: ReadOnly[bool | None]
+
+
+class GuardrailProviderVerdict(TypedDict, total=False):
+    """
+    Sanitized decision an ``apply_guardrail`` implementation reports for logging.
+
+    ``apply_guardrail`` returns the (possibly masked) inputs, so the decorator wrapping it
+    can only tell "allow" from "mask" by diffing them. A provider that distinguishes more
+    outcomes than that - a detection it deliberately does not block, for instance - reports
+    them here, carrying its own verdict and identifiers without the raw vendor body.
+    """
+
+    action: ReadOnly[str | None]
+    """The verdict as the provider names it, e.g. 'ALLOW', 'DETECT', 'BLOCK'."""
+
+    transaction_id: ReadOnly[str | None]
+    """The provider's identifier for this one evaluation, e.g. a transaction id."""
+
+    violation_categories: ReadOnly[Sequence[str] | None]
+    """Names of the provider's detectors that triggered."""
+
+    flagged: ReadOnly[bool | None]
+    """True when the provider recorded a violation it allowed through."""
 
 
 StandardLoggingPayloadStatus = Literal["success", "failure"]

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3188,7 +3188,7 @@ class StandardLoggingGuardrailInformation(TypedDict, total=False):
     risk_score: float | None
     """Risk score 0-10 indicating how risky the request was (higher = riskier). Computed by the guardrail provider."""
 
-    violation_categories: Sequence[str] | None
+    violation_categories: ReadOnly[Sequence[str] | None]
     """Names of the policy items that intervened on this request (e.g. Bedrock
     topic-policy topic names, content-policy filter types, PII entity types).
     Populated by the provider hook before redaction so downstream loggers
@@ -3266,7 +3266,7 @@ class GuardrailTracingDetail(TypedDict, total=False):
     patterns_checked: int | None
     alert_recipients: list[str] | None
     risk_score: float | None
-    violation_categories: Sequence[str] | None
+    violation_categories: ReadOnly[Sequence[str] | None]
     guardrail_action: str | None
     guardrail_usage: ReadOnly[Mapping[str, int] | None]
     guardrail_cost: ReadOnly[float | None]

--- a/tests/guardrails_tests/test_zscaler_ai_guard.py
+++ b/tests/guardrails_tests/test_zscaler_ai_guard.py
@@ -359,13 +359,19 @@ async def test_apply_guardrail_block_raises_400(mock_api_call):
     }
     guardrail = ZscalerAIGuard(api_key="test_key", policy_id=1)
     inputs = {"texts": ["inject malicious content"]}
-    request_data = {}
+    request_data = {"metadata": {}}
 
     with pytest.raises(HTTPException) as exc_info:
-        await guardrail.apply_guardrail(inputs, request_data, "request")
+        await guardrail.apply_guardrail(inputs=inputs, request_data=request_data, input_type="request")
 
     assert exc_info.value.status_code == 400
     assert "blocked" in exc_info.value.detail["error"].lower()
+    entry = request_data["metadata"]["standard_logging_guardrail_information"][0]
+    assert entry["guardrail_status"] == "guardrail_intervened"
+    assert entry["guardrail_provider"] == "zscaler_ai_guard"
+    assert entry["guardrail_action"] == "BLOCK"
+    assert entry["guardrail_transaction_id"] == "tx-123"
+    assert entry["violation_categories"] == ("detector1",)
 
 
 @pytest.mark.asyncio

--- a/tests/guardrails_tests/test_zscaler_ai_guard.py
+++ b/tests/guardrails_tests/test_zscaler_ai_guard.py
@@ -10,8 +10,10 @@ Tests covering:
 - resolve-and-execute-policy endpoint (policyId omission)
 """
 
-import pytest
+from typing import Mapping
 from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
 from fastapi import HTTPException
 from litellm.proxy.guardrails.guardrail_hooks.zscaler_ai_guard import ZscalerAIGuard
 import asyncio
@@ -517,7 +519,7 @@ def test_update_in_memory_litellm_params_keeps_timeout_resolved():
     assert guardrail.timeout == 45.0
 
 
-def _ai_guard_response(action, transaction_id, detector_responses):
+def _ai_guard_response(action: str, transaction_id: str, detector_responses: Mapping[str, Mapping[str, object]]) -> Mock:
     response = Mock()
     response.status_code = 200
     response.json.return_value = {
@@ -529,7 +531,7 @@ def _ai_guard_response(action, transaction_id, detector_responses):
     return response
 
 
-async def _apply(guardrail, response):
+async def _apply(guardrail: ZscalerAIGuard, response: Mock) -> dict[str, object]:
     request_data = {"metadata": {}}
     with patch.object(guardrail, "_send_request", new_callable=AsyncMock) as send:
         send.return_value = response

--- a/tests/guardrails_tests/test_zscaler_ai_guard.py
+++ b/tests/guardrails_tests/test_zscaler_ai_guard.py
@@ -515,3 +515,89 @@ def test_update_in_memory_litellm_params_keeps_timeout_resolved():
         )
     )
     assert guardrail.timeout == 45.0
+
+
+def _ai_guard_response(action, transaction_id, detector_responses):
+    response = Mock()
+    response.status_code = 200
+    response.json.return_value = {
+        "statusCode": 200,
+        "action": action,
+        "transactionId": transaction_id,
+        "detectorResponses": detector_responses,
+    }
+    return response
+
+
+async def _apply(guardrail, response):
+    request_data = {"metadata": {}}
+    with patch.object(guardrail, "_send_request", new_callable=AsyncMock) as send:
+        send.return_value = response
+        await guardrail.apply_guardrail(
+            inputs={"texts": ["my ssn is 123-45-6789"]},
+            request_data=request_data,
+            input_type="request",
+        )
+    return request_data["metadata"]["standard_logging_guardrail_information"][0]
+
+
+@pytest.mark.asyncio
+async def test_detect_verdict_is_logged_with_transaction_id_and_detectors():
+    """
+    Regression (LIT-4877): AI Guard returns the texts untouched on DETECT just as it does on
+    ALLOW, so the logged record collapsed to "allow" and the detection, its transaction id
+    and the detector that fired were all lost.
+    """
+    guardrail = ZscalerAIGuard(api_key="test_key", api_base="http://example.com", policy_id=1)
+
+    entry = await _apply(
+        guardrail,
+        _ai_guard_response(
+            "DETECT",
+            "tx-detect-1",
+            {"pii": {"triggered": True, "action": "DETECT"}, "toxicity": {"triggered": False, "action": "ALLOW"}},
+        ),
+    )
+
+    assert entry["guardrail_status"] == "guardrail_flagged"
+    assert entry["guardrail_action"] == "DETECT"
+    assert entry["guardrail_transaction_id"] == "tx-detect-1"
+    assert entry.get("guardrail_id") is None
+    assert entry["violation_categories"] == ("pii",)
+    assert entry["guardrail_response"] != "allow"
+    assert entry["guardrail_provider"] == "zscaler_ai_guard"
+
+
+@pytest.mark.asyncio
+async def test_clean_allow_is_not_flagged():
+    guardrail = ZscalerAIGuard(api_key="test_key", api_base="http://example.com", policy_id=1)
+
+    entry = await _apply(guardrail, _ai_guard_response("ALLOW", "tx-allow-1", {"pii": {"action": "ALLOW"}}))
+
+    assert entry["guardrail_status"] == "success"
+    assert entry["guardrail_action"] == "ALLOW"
+    assert entry["guardrail_transaction_id"] == "tx-allow-1"
+    assert entry["violation_categories"] is None
+
+
+@pytest.mark.asyncio
+async def test_detect_and_allow_records_are_not_identical():
+    guardrail = ZscalerAIGuard(api_key="test_key", api_base="http://example.com", policy_id=1)
+
+    detected = await _apply(
+        guardrail, _ai_guard_response("DETECT", "tx-1", {"pii": {"action": "DETECT"}})
+    )
+    allowed = await _apply(guardrail, _ai_guard_response("ALLOW", "tx-2", {"pii": {"action": "ALLOW"}}))
+
+    assert detected["guardrail_response"] != allowed["guardrail_response"]
+    assert detected["guardrail_status"] != allowed["guardrail_status"]
+
+
+def test_build_verdict_ignores_a_malformed_detector_map():
+    verdict = ZscalerAIGuard._build_verdict(
+        {"action": "ALLOW", "zscaler_ai_guard_response": {"action": "DETECT", "detectorResponses": "not-a-map"}}
+    )
+
+    assert verdict["action"] == "DETECT"
+    assert verdict["flagged"] is True
+    assert verdict["violation_categories"] is None

--- a/tests/test_litellm/integrations/datadog/test_datadog_llm_obs.py
+++ b/tests/test_litellm/integrations/datadog/test_datadog_llm_obs.py
@@ -980,3 +980,36 @@ def test_reasoning_content_survives_the_mapping(logger: DataDogLLMObsLogger) -> 
     )
 
     assert payload["meta"]["output"]["messages"][0]["reasoning_content"] == "thinking"
+
+
+def test_redaction_keeps_the_provider_verdict_audit_fields(logger: DataDogLLMObsLogger) -> None:
+    """LIT-4877: the verdict itself rides in guardrail_response, which redaction replaces, so a
+    flagged record must still name the provider, the action and the transaction id."""
+    span = _span_json(
+        _redacting_logger(turn_off_message_logging=True),
+        _payload_with_guardrail_record(
+            [
+                {
+                    **_AUDIT_RECORD,
+                    "guardrail_provider": "zscaler_ai_guard",
+                    "guardrail_status": "guardrail_flagged",
+                    "guardrail_action": "DETECT",
+                    "guardrail_transaction_id": "tx-detect-1",
+                    "guardrail_response": {
+                        "action": "DETECT",
+                        "transaction_id": "tx-detect-1",
+                        "flagged": True,
+                        "matched_text": "alice@acme.com",
+                    },
+                }
+            ]
+        ),
+    )
+    record = span["meta"]["metadata"]["guardrail_information"][0]
+
+    assert record["guardrail_response"] == "REDACTED_BY_LITELM"
+    assert record["guardrail_provider"] == "zscaler_ai_guard"
+    assert record["guardrail_status"] == "guardrail_flagged"
+    assert record["guardrail_action"] == "DETECT"
+    assert record["guardrail_transaction_id"] == "tx-detect-1"
+    assert "alice@acme.com" not in safe_dumps(span["meta"]["metadata"])

--- a/tests/test_litellm/integrations/otel/test_otel_v2_config_baggage_parenting_guardrails.py
+++ b/tests/test_litellm/integrations/otel/test_otel_v2_config_baggage_parenting_guardrails.py
@@ -213,15 +213,18 @@ def test_guardrail_typed_metadata_fields_mapped_to_span():
             "guardrail_name": "eu-pii",
             "guardrail_status": "success",
             "guardrail_id": "gd-eu-pii-001",
+            "guardrail_transaction_id": "tx-123",
             "policy_template": "EU AI Act Article 5",
             "detection_method": "presidio",
         }
     )
     assert d.guardrail_id == "gd-eu-pii-001"
+    assert d.guardrail_transaction_id == "tx-123"
     assert d.policy_template == "EU AI Act Article 5"
     assert d.detection_method == "presidio"
     attrs = GenAIMapper().map(d)
     assert attrs[LiteLLM.GUARDRAIL_ID] == "gd-eu-pii-001"
+    assert attrs[LiteLLM.GUARDRAIL_TRANSACTION_ID] == "tx-123"
     assert attrs[LiteLLM.GUARDRAIL_POLICY_TEMPLATE] == "EU AI Act Article 5"
     assert attrs[LiteLLM.GUARDRAIL_DETECTION_METHOD] == "presidio"
 

--- a/tests/test_litellm/integrations/test_custom_guardrail.py
+++ b/tests/test_litellm/integrations/test_custom_guardrail.py
@@ -10,7 +10,11 @@ from litellm.integrations.custom_guardrail import (
     log_guardrail_information,
 )
 from litellm.proxy._types import CallTypes, UserAPIKeyAuth
-from litellm.types.utils import GenericGuardrailAPIInputs, GuardrailTracingDetail
+from litellm.types.utils import (
+    GenericGuardrailAPIInputs,
+    GuardrailProviderVerdict,
+    GuardrailTracingDetail,
+)
 
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
@@ -2610,3 +2614,158 @@ class TestCustomGuardrailPostCallSuccessDeploymentHook:
         )
 
         assert result is replacement
+
+
+class _VerdictGuardrail(CustomGuardrail):
+    """apply_guardrail that returns the inputs untouched and reports the provider's verdict."""
+
+    guardrail_provider = "acme_scanner"
+
+    def __init__(self, verdict: GuardrailProviderVerdict, **kwargs):
+        super().__init__(**kwargs)
+        self.verdict = verdict
+
+    @log_guardrail_information
+    async def apply_guardrail(self, inputs, request_data, input_type, logging_obj=None):
+        self.record_guardrail_verdict(self.verdict)
+        return inputs
+
+
+class _DelegatingGuardrail(CustomGuardrail):
+    """apply_guardrail that runs another guardrail and reports no verdict of its own."""
+
+    def __init__(self, inner: CustomGuardrail, **kwargs):
+        super().__init__(**kwargs)
+        self.inner = inner
+
+    @log_guardrail_information
+    async def apply_guardrail(self, inputs, request_data, input_type, logging_obj=None):
+        await self.inner.apply_guardrail(inputs=inputs, request_data=request_data, input_type=input_type)
+        return inputs
+
+
+DETECT_VERDICT = GuardrailProviderVerdict(
+    action="DETECT",
+    transaction_id="tx-detect-1",
+    violation_categories=("pii_detector",),
+    flagged=True,
+)
+ALLOW_VERDICT = GuardrailProviderVerdict(action="ALLOW", transaction_id="tx-allow-1", flagged=False)
+
+
+async def _run(guardrail: CustomGuardrail, request_data: dict) -> None:
+    await guardrail.apply_guardrail(
+        inputs=GenericGuardrailAPIInputs(texts=["my ssn is 123-45-6789"]),
+        request_data=request_data,
+        input_type="request",
+    )
+
+
+class TestApplyGuardrailProviderVerdict:
+    """LIT-4877 regression: apply_guardrail returns the inputs unchanged whether the provider
+    allowed the content or merely detected a violation it did not block, so collapsing the
+    logged response to "allow" made a detection byte-identical to a clean pass."""
+
+    @pytest.mark.asyncio
+    async def test_detection_is_distinguishable_from_a_clean_pass(self):
+        detect_data: dict = {"model": "gpt-4o"}
+        allow_data: dict = {"model": "gpt-4o"}
+
+        await _run(_VerdictGuardrail(DETECT_VERDICT, guardrail_name="zg"), detect_data)
+        await _run(_VerdictGuardrail(ALLOW_VERDICT, guardrail_name="zg"), allow_data)
+
+        detected = _guardrail_entries(detect_data)[0]
+        allowed = _guardrail_entries(allow_data)[0]
+
+        assert detected["guardrail_response"] != allowed["guardrail_response"]
+        assert detected["guardrail_status"] != allowed["guardrail_status"]
+
+    @pytest.mark.asyncio
+    async def test_flagged_verdict_carries_action_id_and_categories(self):
+        request_data: dict = {"model": "gpt-4o"}
+
+        await _run(_VerdictGuardrail(DETECT_VERDICT, guardrail_name="zg"), request_data)
+
+        entry = _guardrail_entries(request_data)[0]
+        assert entry["guardrail_status"] == "guardrail_flagged"
+        assert entry["guardrail_action"] == "DETECT"
+        assert entry["guardrail_transaction_id"] == "tx-detect-1"
+        assert entry["violation_categories"] == ("pii_detector",)
+        assert entry["guardrail_response"] == dict(DETECT_VERDICT)
+        assert entry["guardrail_provider"] == "acme_scanner"
+
+    @pytest.mark.asyncio
+    async def test_unflagged_verdict_stays_success_and_still_records_the_action(self):
+        request_data: dict = {"model": "gpt-4o"}
+
+        await _run(_VerdictGuardrail(ALLOW_VERDICT, guardrail_name="zg"), request_data)
+
+        entry = _guardrail_entries(request_data)[0]
+        assert entry["guardrail_status"] == "success"
+        assert entry["guardrail_action"] == "ALLOW"
+        assert entry["guardrail_transaction_id"] == "tx-allow-1"
+        assert entry["violation_categories"] is None
+
+    @pytest.mark.asyncio
+    async def test_a_verdict_does_not_claim_the_usage_rollup_key(self):
+        """``guardrail_id`` keys the daily usage rollup and the spend-log index, so a
+        per-request identifier there would give every call its own row."""
+        request_data: dict = {"model": "gpt-4o"}
+
+        await _run(_VerdictGuardrail(DETECT_VERDICT, guardrail_name="zg"), request_data)
+
+        entry = _guardrail_entries(request_data)[0]
+        assert entry.get("guardrail_id") is None
+        assert entry["guardrail_name"] == "zg"
+
+    @pytest.mark.asyncio
+    async def test_guardrail_without_a_verdict_still_logs_allow(self):
+        request_data: dict = {"model": "gpt-4o"}
+
+        await _run(_NoopGuardrail(guardrail_name="plain"), request_data)
+
+        entry = _guardrail_entries(request_data)[0]
+        assert entry["guardrail_response"] == "allow"
+        assert entry["guardrail_status"] == "success"
+        assert entry.get("guardrail_action") is None
+        assert entry["guardrail_provider"] is None
+
+    @pytest.mark.asyncio
+    async def test_a_verdict_does_not_leak_into_the_next_guardrail(self):
+        request_data: dict = {"model": "gpt-4o"}
+
+        await _run(_VerdictGuardrail(DETECT_VERDICT, guardrail_name="zg"), request_data)
+        await _run(_NoopGuardrail(guardrail_name="plain"), request_data)
+
+        flagged, plain = _guardrail_entries(request_data)
+        assert flagged["guardrail_status"] == "guardrail_flagged"
+        assert plain["guardrail_status"] == "success"
+        assert plain["guardrail_response"] == "allow"
+        assert plain.get("guardrail_action") is None
+
+    @pytest.mark.asyncio
+    async def test_a_delegating_guardrail_does_not_claim_the_inner_verdict(self):
+        request_data: dict = {"model": "gpt-4o"}
+        inner = _VerdictGuardrail(DETECT_VERDICT, guardrail_name="inner")
+
+        await _run(_DelegatingGuardrail(inner, guardrail_name="outer"), request_data)
+
+        inner_entry, outer_entry = _guardrail_entries(request_data)
+        assert inner_entry["guardrail_status"] == "guardrail_flagged"
+        assert outer_entry["guardrail_status"] == "success"
+        assert outer_entry["guardrail_response"] == "allow"
+        assert outer_entry.get("guardrail_action") is None
+
+    @pytest.mark.asyncio
+    async def test_concurrent_guardrails_do_not_share_a_verdict(self):
+        flagged_data: dict = {"model": "gpt-4o"}
+        plain_data: dict = {"model": "gpt-4o"}
+
+        await asyncio.gather(
+            _run(_VerdictGuardrail(DETECT_VERDICT, guardrail_name="zg"), flagged_data),
+            _run(_NoopGuardrail(guardrail_name="plain"), plain_data),
+        )
+
+        assert _guardrail_entries(flagged_data)[0]["guardrail_status"] == "guardrail_flagged"
+        assert _guardrail_entries(plain_data)[0]["guardrail_status"] == "success"
+        assert _guardrail_entries(plain_data)[0]["guardrail_response"] == "allow"

--- a/tests/test_litellm/integrations/test_custom_guardrail.py
+++ b/tests/test_litellm/integrations/test_custom_guardrail.py
@@ -8,6 +8,7 @@ from litellm.exceptions import GuardrailRaisedException
 from litellm.integrations.custom_guardrail import (
     DEFAULT_ADVISORY_MESSAGE,
     CustomGuardrail,
+    _guardrail_verdict,
     log_guardrail_information,
 )
 from litellm.proxy._types import CallTypes, UserAPIKeyAuth
@@ -2838,3 +2839,111 @@ class TestApplyGuardrailProviderVerdict:
         assert entry["violation_categories"] == ("prompt_injection",)
         assert entry["guardrail_provider"] == "acme_scanner"
         assert "Content blocked" in str(entry["guardrail_response"])
+
+
+class _SyncVerdictGuardrail(CustomGuardrail):
+    """A guardrail whose apply_guardrail never went async, wrapped by ``__init_subclass__``."""
+
+    guardrail_provider = "acme_scanner"
+
+    def __init__(
+        self,
+        verdict: GuardrailProviderVerdict,
+        guardrail_name: str,
+        error: Exception | None = None,
+    ) -> None:
+        super().__init__(guardrail_name=guardrail_name)
+        self.verdict = verdict
+        self.error = error
+
+    def apply_guardrail(
+        self,
+        inputs: GenericGuardrailAPIInputs,
+        request_data: dict,
+        input_type: Literal["request", "response"],
+        logging_obj: Optional["LiteLLMLoggingObj"] = None,
+    ) -> GenericGuardrailAPIInputs:
+        self.record_guardrail_verdict(self.verdict)
+        if self.error is not None:
+            raise self.error
+        return inputs
+
+
+class _SyncNoopGuardrail(CustomGuardrail):
+    """A sync apply_guardrail that returns the inputs untouched and records nothing."""
+
+    def apply_guardrail(
+        self,
+        inputs: GenericGuardrailAPIInputs,
+        request_data: dict,
+        input_type: Literal["request", "response"],
+        logging_obj: Optional["LiteLLMLoggingObj"] = None,
+    ) -> GenericGuardrailAPIInputs:
+        return inputs
+
+
+def _run_sync(guardrail: CustomGuardrail, request_data: dict) -> None:
+    guardrail.apply_guardrail(
+        inputs=GenericGuardrailAPIInputs(texts=["my ssn is 123-45-6789"]),
+        request_data=request_data,
+        input_type="request",
+    )
+
+
+class TestSyncApplyGuardrailProviderVerdict:
+    """The decorator has a sync branch for guardrails that define a plain ``def apply_guardrail``,
+    and it reads the same request-local verdict the async branch does."""
+
+    def test_a_sync_guardrail_logs_the_flagged_verdict(self):
+        request_data: dict = {"model": "gpt-4o"}
+
+        _run_sync(_SyncVerdictGuardrail(DETECT_VERDICT, guardrail_name="zg"), request_data)
+
+        entry = _guardrail_entries(request_data)[0]
+        assert entry["guardrail_status"] == "guardrail_flagged"
+        assert entry["guardrail_action"] == "DETECT"
+        assert entry["guardrail_transaction_id"] == "tx-detect-1"
+        assert entry["violation_categories"] == ("pii_detector",)
+        assert entry["guardrail_provider"] == "acme_scanner"
+
+    def test_a_sync_failure_keeps_the_error_and_the_verdict(self):
+        request_data: dict = {"model": "gpt-4o"}
+        guardrail = _SyncVerdictGuardrail(ALLOW_VERDICT, guardrail_name="zg", error=RuntimeError("vendor exploded"))
+
+        with pytest.raises(RuntimeError, match="vendor exploded"):
+            _run_sync(guardrail, request_data)
+
+        entry = _guardrail_entries(request_data)[0]
+        assert entry["guardrail_status"] == "guardrail_failed_to_respond"
+        assert "vendor exploded" in str(entry["guardrail_response"])
+        assert entry["guardrail_transaction_id"] == "tx-allow-1"
+        assert entry["guardrail_provider"] == "acme_scanner"
+
+    def test_a_sync_guardrail_logs_two_calls_apart(self):
+        request_data: dict = {"model": "gpt-4o"}
+
+        _run_sync(_SyncVerdictGuardrail(DETECT_VERDICT, guardrail_name="zg"), request_data)
+        _run_sync(_SyncNoopGuardrail(guardrail_name="plain"), request_data)
+
+        flagged, plain = _guardrail_entries(request_data)
+        assert flagged["guardrail_status"] == "guardrail_flagged"
+        assert plain["guardrail_status"] == "success"
+        assert plain["guardrail_response"] == "allow"
+        assert plain["guardrail_provider"] is None
+        assert plain.get("guardrail_transaction_id") is None
+
+    def test_a_verdict_recorded_outside_the_decorator_is_not_claimed(self):
+        """The wrapper starts each call with no verdict, so a verdict left in the context by a
+        caller that reached a guardrail directly cannot be attributed to the next one."""
+        request_data: dict = {"model": "gpt-4o"}
+        token = _guardrail_verdict.set(None)
+        try:
+            CustomGuardrail.record_guardrail_verdict(DETECT_VERDICT)
+            _run_sync(_SyncNoopGuardrail(guardrail_name="plain"), request_data)
+        finally:
+            _guardrail_verdict.reset(token)
+
+        entry = _guardrail_entries(request_data)[0]
+        assert entry["guardrail_status"] == "success"
+        assert entry["guardrail_response"] == "allow"
+        assert entry["guardrail_provider"] is None

--- a/tests/test_litellm/integrations/test_custom_guardrail.py
+++ b/tests/test_litellm/integrations/test_custom_guardrail.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from litellm.exceptions import GuardrailRaisedException
 from litellm.integrations.custom_guardrail import (
     DEFAULT_ADVISORY_MESSAGE,
     CustomGuardrail,
@@ -2621,12 +2622,18 @@ class _VerdictGuardrail(CustomGuardrail):
 
     guardrail_provider = "acme_scanner"
 
-    def __init__(self, verdict: GuardrailProviderVerdict, **kwargs: object) -> None:
-        super().__init__(**kwargs)
+    def __init__(self, verdict: GuardrailProviderVerdict, guardrail_name: str) -> None:
+        super().__init__(guardrail_name=guardrail_name)
         self.verdict = verdict
 
     @log_guardrail_information
-    async def apply_guardrail(self, inputs, request_data, input_type, logging_obj=None):
+    async def apply_guardrail(
+        self,
+        inputs: GenericGuardrailAPIInputs,
+        request_data: dict,
+        input_type: Literal["request", "response"],
+        logging_obj: Optional["LiteLLMLoggingObj"] = None,
+    ) -> GenericGuardrailAPIInputs:
         self.record_guardrail_verdict(self.verdict)
         return inputs
 
@@ -2634,14 +2641,42 @@ class _VerdictGuardrail(CustomGuardrail):
 class _DelegatingGuardrail(CustomGuardrail):
     """apply_guardrail that runs another guardrail and reports no verdict of its own."""
 
-    def __init__(self, inner: CustomGuardrail, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, inner: CustomGuardrail, guardrail_name: str) -> None:
+        super().__init__(guardrail_name=guardrail_name)
         self.inner = inner
 
     @log_guardrail_information
-    async def apply_guardrail(self, inputs, request_data, input_type, logging_obj=None):
+    async def apply_guardrail(
+        self,
+        inputs: GenericGuardrailAPIInputs,
+        request_data: dict,
+        input_type: Literal["request", "response"],
+        logging_obj: Optional["LiteLLMLoggingObj"] = None,
+    ) -> GenericGuardrailAPIInputs:
         await self.inner.apply_guardrail(inputs=inputs, request_data=request_data, input_type=input_type)
         return inputs
+
+
+class _RaisingVerdictGuardrail(CustomGuardrail):
+    """apply_guardrail that reports the provider's verdict and then raises."""
+
+    guardrail_provider = "acme_scanner"
+
+    def __init__(self, verdict: GuardrailProviderVerdict, error: Exception, guardrail_name: str) -> None:
+        super().__init__(guardrail_name=guardrail_name)
+        self.verdict = verdict
+        self.error = error
+
+    @log_guardrail_information
+    async def apply_guardrail(
+        self,
+        inputs: GenericGuardrailAPIInputs,
+        request_data: dict,
+        input_type: Literal["request", "response"],
+        logging_obj: Optional["LiteLLMLoggingObj"] = None,
+    ) -> GenericGuardrailAPIInputs:
+        self.record_guardrail_verdict(self.verdict)
+        raise self.error
 
 
 DETECT_VERDICT = GuardrailProviderVerdict(
@@ -2769,3 +2804,37 @@ class TestApplyGuardrailProviderVerdict:
         assert _guardrail_entries(flagged_data)[0]["guardrail_status"] == "guardrail_flagged"
         assert _guardrail_entries(plain_data)[0]["guardrail_status"] == "success"
         assert _guardrail_entries(plain_data)[0]["guardrail_response"] == "allow"
+
+    @pytest.mark.asyncio
+    async def test_a_failure_after_a_verdict_keeps_the_error_in_the_response(self):
+        """A recorded verdict must not replace the diagnostics of an exception raised afterwards."""
+        request_data: dict = {"model": "gpt-4o"}
+        guardrail = _RaisingVerdictGuardrail(ALLOW_VERDICT, RuntimeError("vendor exploded"), guardrail_name="zg")
+
+        with pytest.raises(RuntimeError, match="vendor exploded"):
+            await _run(guardrail, request_data)
+
+        entry = _guardrail_entries(request_data)[0]
+        assert entry["guardrail_status"] == "guardrail_failed_to_respond"
+        assert "vendor exploded" in str(entry["guardrail_response"])
+        assert entry["guardrail_provider"] == "acme_scanner"
+        assert entry["guardrail_transaction_id"] == "tx-allow-1"
+
+    @pytest.mark.asyncio
+    async def test_a_block_verdict_survives_the_intervention_exception(self):
+        request_data: dict = {"model": "gpt-4o"}
+        block_verdict = GuardrailProviderVerdict(
+            action="BLOCK", transaction_id="tx-block-1", violation_categories=("prompt_injection",), flagged=True
+        )
+        error = GuardrailRaisedException(guardrail_name="zg", message="Content blocked")
+
+        with pytest.raises(GuardrailRaisedException):
+            await _run(_RaisingVerdictGuardrail(block_verdict, error, guardrail_name="zg"), request_data)
+
+        entry = _guardrail_entries(request_data)[0]
+        assert entry["guardrail_status"] == "guardrail_intervened"
+        assert entry["guardrail_action"] == "BLOCK"
+        assert entry["guardrail_transaction_id"] == "tx-block-1"
+        assert entry["violation_categories"] == ("prompt_injection",)
+        assert entry["guardrail_provider"] == "acme_scanner"
+        assert "Content blocked" in str(entry["guardrail_response"])

--- a/tests/test_litellm/integrations/test_custom_guardrail.py
+++ b/tests/test_litellm/integrations/test_custom_guardrail.py
@@ -2621,7 +2621,7 @@ class _VerdictGuardrail(CustomGuardrail):
 
     guardrail_provider = "acme_scanner"
 
-    def __init__(self, verdict: GuardrailProviderVerdict, **kwargs):
+    def __init__(self, verdict: GuardrailProviderVerdict, **kwargs: object) -> None:
         super().__init__(**kwargs)
         self.verdict = verdict
 

--- a/tests/test_litellm/integrations/test_langfuse.py
+++ b/tests/test_litellm/integrations/test_langfuse.py
@@ -1554,3 +1554,43 @@ def test_langfuse_deployment_environment_fallback_never_raises(monkeypatch, env_
         langfuse_host="https://test.langfuse.com",
     )
     assert logger.langfuse_environment == expected
+
+
+def test_guardrail_span_output_carries_the_provider_verdict(monkeypatch):
+    """LIT-4877: the guardrail span reports ``guardrail_response`` as its output, and a provider
+    verdict is a mapping, so the span has to carry the verdict's fields rather than a bare
+    "allow" that reads the same for a detection and a clean pass."""
+    monkeypatch.setenv("LANGFUSE_MOCK", "true")
+    monkeypatch.setattr(litellm, "initialized_langfuse_clients", 0)
+    logger: Final = LangFuseLogger(
+        langfuse_public_key="pk-env",
+        langfuse_secret="sk-env",
+        langfuse_host="https://test.langfuse.com",
+    )
+    trace: Final = MagicMock()
+    verdict: Final = {
+        "action": "DETECT",
+        "transaction_id": "tx-detect-1",
+        "violation_categories": ["pii"],
+        "flagged": True,
+    }
+
+    logger._log_guardrail_information_as_span(
+        trace,
+        {
+            "guardrail_information": [
+                {
+                    "guardrail_name": "zg",
+                    "guardrail_mode": "pre_call",
+                    "guardrail_status": "guardrail_flagged",
+                    "guardrail_response": verdict,
+                    "start_time": 1_700_000_000.0,
+                    "end_time": 1_700_000_000.5,
+                }
+            ]
+        },
+    )
+
+    assert trace.span.call_args.kwargs["output"] == verdict
+    assert trace.span.call_args.kwargs["metadata"]["guardrail_name"] == "zg"
+    trace.span.return_value.end.assert_called_once()

--- a/tests/test_litellm/integrations/test_otel_guardrail_violation_spans.py
+++ b/tests/test_litellm/integrations/test_otel_guardrail_violation_spans.py
@@ -97,6 +97,7 @@ def _slg_entry(
     end=2.0,
     violation_categories=None,
     guardrail_action=None,
+    guardrail_transaction_id=None,
 ):
     """Build a StandardLoggingGuardrailInformation entry the way
     ``add_standard_logging_guardrail_information_to_request_data`` does."""
@@ -114,6 +115,8 @@ def _slg_entry(
         entry["violation_categories"] = violation_categories
     if guardrail_action is not None:
         entry["guardrail_action"] = guardrail_action
+    if guardrail_transaction_id is not None:
+        entry["guardrail_transaction_id"] = guardrail_transaction_id
     return entry
 
 
@@ -513,6 +516,21 @@ class TestGuardrailSpanAttributesOnViolation(unittest.TestCase):
         entry = _slg_entry("success", {"action": "NONE", "assessments": []})
         span = self._emit_and_get_guardrail_span(entry)
         self.assertIsNone(_attr(span, "guardrail_action"))
+
+    def test_guardrail_transaction_id_surfaced_when_provider_populates_it(self):
+        entry = _slg_entry(
+            "guardrail_flagged",
+            {"action": "DETECT", "flagged": True},
+            guardrail_action="DETECT",
+            guardrail_transaction_id="zg-detect-8f21",
+        )
+        span = self._emit_and_get_guardrail_span(entry)
+        self.assertEqual(_attr(span, "guardrail_transaction_id"), "zg-detect-8f21")
+
+    def test_no_guardrail_transaction_id_when_field_absent(self):
+        entry = _slg_entry("success", {"action": "NONE", "assessments": []})
+        span = self._emit_and_get_guardrail_span(entry)
+        self.assertIsNone(_attr(span, "guardrail_transaction_id"))
 
 
 class TestMultipleGuardrailsOneBlocks(unittest.TestCase):

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_invoke_guardrail_checks.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_invoke_guardrail_checks.py
@@ -13,6 +13,7 @@ from fastapi import HTTPException
 
 
 from litellm.exceptions import ModifyResponseException
+from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 from litellm.proxy.guardrails.guardrail_hooks.bedrock_guardrails import (
     _BEDROCK_INVOKE_GUARDRAIL_CHECKS_PATH,
     BedrockGuardrail,
@@ -861,3 +862,21 @@ async def test_checks_bearer_token_never_runs_the_sigv4_credential_chain(monkeyp
         {"check": "contentFilter", "category": "VIOLENCE", "severityScore": 0.8}
     ]
     assert post.call_args.kwargs["headers"]["Authorization"] == "Bearer env-bearer-token-12345"
+
+
+def test_invoke_checks_tracing_detail_serializes_categories_as_a_json_array():
+    """The categories are built immutably, and every sink for this record goes through
+    ``safe_dumps``, so the wire shape must stay a JSON array rather than a stringified tuple."""
+    detail = BedrockGuardrail._build_invoke_checks_tracing_detail(
+        [{"category": "PII"}, {"type": "PROMPT_ATTACK"}, {"category": None, "type": None}]
+    )
+
+    assert detail["guardrail_action"] == "GUARDRAIL_INTERVENED"
+    assert tuple(detail["violation_categories"]) == ("PII", "PROMPT_ATTACK")
+    assert json.loads(safe_dumps(detail))["violation_categories"] == ["PII", "PROMPT_ATTACK"]
+
+
+def test_invoke_checks_tracing_detail_without_violations_carries_no_categories():
+    """A clean check reports the action alone: an empty categories list would read as a
+    violation with no name on every span and spend row."""
+    assert BedrockGuardrail._build_invoke_checks_tracing_detail([]) == {"guardrail_action": "NONE"}

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/zscaler_ai_guard/test_zscaler_ai_guard.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/zscaler_ai_guard/test_zscaler_ai_guard.py
@@ -609,3 +609,51 @@ def test_build_verdict_ignores_a_malformed_detector_map():
     assert verdict["action"] == "DETECT"
     assert verdict["flagged"] is True
     assert verdict["violation_categories"] is None
+
+
+@pytest.mark.asyncio
+async def test_a_detection_on_the_model_response_is_logged():
+    """The answer is scanned in the OUT direction, and a detection there is as invisible in the
+    request payload as one on the way in, so it needs the same verdict record."""
+    guardrail = ZscalerAIGuard(api_key="test_key", api_base="http://example.com", policy_id=1)
+    request_data = {"metadata": {}}
+
+    with patch.object(guardrail, "_send_request", new_callable=AsyncMock) as send:
+        send.return_value = _ai_guard_response("DETECT", "tx-out-1", {"pii": {"action": "DETECT"}})
+        await guardrail.apply_guardrail(
+            inputs={"texts": ["my ssn is 123-45-6789"]},
+            request_data=request_data,
+            input_type="response",
+        )
+
+    entry = request_data["metadata"]["standard_logging_guardrail_information"][0]
+    assert send.await_args.args[2]["direction"] == "OUT"
+    assert entry["guardrail_status"] == "guardrail_flagged"
+    assert entry["guardrail_action"] == "DETECT"
+    assert entry["guardrail_transaction_id"] == "tx-out-1"
+    assert entry["violation_categories"] == ("pii",)
+
+
+@pytest.mark.asyncio
+async def test_a_vendor_failure_records_no_verdict_fields():
+    """AI Guard never answered, so there is no verdict to report: the record keeps the error and
+    stays free of the provider, action and transaction id that only a real verdict may claim."""
+    guardrail = ZscalerAIGuard(api_key="test_key", api_base="http://example.com", policy_id=1)
+    request_data = {"metadata": {}}
+
+    with patch.object(guardrail, "_send_request", new_callable=AsyncMock) as send:
+        send.side_effect = RuntimeError("ai guard unreachable")
+        with pytest.raises(HTTPException) as exc_info:
+            await guardrail.apply_guardrail(
+                inputs={"texts": ["my ssn is 123-45-6789"]},
+                request_data=request_data,
+                input_type="request",
+            )
+
+    assert exc_info.value.status_code == 500
+    entry = request_data["metadata"]["standard_logging_guardrail_information"][0]
+    assert entry["guardrail_status"] == "guardrail_failed_to_respond"
+    assert "ai guard unreachable" in str(entry["guardrail_response"])
+    assert entry["guardrail_provider"] is None
+    assert entry.get("guardrail_transaction_id") is None
+    assert entry.get("guardrail_action") is None

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/zscaler_ai_guard/test_zscaler_ai_guard.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/zscaler_ai_guard/test_zscaler_ai_guard.py
@@ -16,7 +16,14 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 from fastapi import HTTPException
 
+from litellm.caching import DualCache
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.guardrails.guardrail_hooks.unified_guardrail.unified_guardrail import (
+    UnifiedLLMGuardrails,
+)
 from litellm.proxy.guardrails.guardrail_hooks.zscaler_ai_guard import ZscalerAIGuard
+from litellm.types.guardrails import GuardrailEventHooks
+from litellm.types.utils import CallTypes
 
 
 @pytest.mark.asyncio
@@ -657,3 +664,47 @@ async def test_a_vendor_failure_records_no_verdict_fields():
     assert entry["guardrail_provider"] is None
     assert entry.get("guardrail_transaction_id") is None
     assert entry.get("guardrail_action") is None
+
+
+def _recorded_guardrail_entries(data: dict) -> list:
+    return [
+        entry
+        for key in ("metadata", "litellm_metadata")
+        for entry in ((data.get(key) or {}).get("standard_logging_guardrail_information") or [])
+    ]
+
+
+@pytest.mark.asyncio
+async def test_a_detection_survives_the_request_path_into_the_logged_record():
+    """A chat request reaches the guardrail through the unified hook and the chat translation
+    handler, and that is the path whose record the spend log and the guardrail spans read."""
+    guardrail = ZscalerAIGuard(
+        api_key="test_key",
+        api_base="http://example.com",
+        policy_id=1,
+        guardrail_name="zg",
+        event_hook=GuardrailEventHooks.pre_call,
+        default_on=True,
+    )
+    data = {
+        "guardrail_to_apply": guardrail,
+        "model": "gpt-4o",
+        "messages": [{"role": "user", "content": "my ssn is 123-45-6789"}],
+        "metadata": {},
+    }
+
+    with patch.object(guardrail, "_send_request", new_callable=AsyncMock) as send:
+        send.return_value = _ai_guard_response("DETECT", "tx-unified-1", {"pii": {"action": "DETECT"}})
+        await UnifiedLLMGuardrails().async_pre_call_hook(
+            user_api_key_dict=UserAPIKeyAuth(api_key="test-key"),
+            cache=DualCache(),
+            data=data,
+            call_type=CallTypes.acompletion.value,
+        )
+
+    entry = _recorded_guardrail_entries(data)[0]
+    assert entry["guardrail_status"] == "guardrail_flagged"
+    assert entry["guardrail_action"] == "DETECT"
+    assert entry["guardrail_transaction_id"] == "tx-unified-1"
+    assert entry["violation_categories"] == ("pii",)
+    assert entry["guardrail_provider"] == "zscaler_ai_guard"

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/zscaler_ai_guard/test_zscaler_ai_guard.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/zscaler_ai_guard/test_zscaler_ai_guard.py
@@ -10,13 +10,13 @@ Tests covering:
 - resolve-and-execute-policy endpoint (policyId omission)
 """
 
-from typing import Mapping
+from collections.abc import Mapping
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from fastapi import HTTPException
+
 from litellm.proxy.guardrails.guardrail_hooks.zscaler_ai_guard import ZscalerAIGuard
-import asyncio
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
@@ -4370,3 +4370,40 @@ def test_spend_log_request_id_is_the_response_id_a_bridged_messages_caller_recei
         )
         == "resp_01Lit6806Bridged"
     )
+
+
+@patch("litellm.proxy.spend_tracking.spend_tracking_utils._should_store_prompts_and_responses_in_spend_logs")
+def test_sanitize_guardrail_information_keeps_the_provider_verdict_audit_fields(
+    mock_should_store,
+):
+    """LIT-4877: a provider verdict rides in guardrail_response, which redaction replaces
+    wholesale, so the provider, action, transaction id and categories an operator searches by
+    have to survive on their own fields."""
+    mock_should_store.return_value = False
+    guardrail_info = [
+        {
+            "guardrail_name": "zg",
+            "guardrail_provider": "zscaler_ai_guard",
+            "guardrail_status": "guardrail_flagged",
+            "guardrail_action": "DETECT",
+            "guardrail_transaction_id": "tx-detect-1",
+            "violation_categories": ["pii"],
+            "guardrail_response": {
+                "action": "DETECT",
+                "transaction_id": "tx-detect-1",
+                "violation_categories": ["pii"],
+                "flagged": True,
+            },
+        }
+    ]
+
+    result = _sanitize_guardrail_information_for_spend_logs(guardrail_info)
+
+    assert result is not None
+    entry = result[0]
+    assert entry["guardrail_response"] == REDACTED_BY_LITELM_STRING
+    assert entry["guardrail_provider"] == "zscaler_ai_guard"
+    assert entry["guardrail_status"] == "guardrail_flagged"
+    assert entry["guardrail_action"] == "DETECT"
+    assert entry["guardrail_transaction_id"] == "tx-detect-1"
+    assert entry["violation_categories"] == ["pii"]


### PR DESCRIPTION
## TLDR

Problem this solves:

- A non-blocking guardrail detection logs exactly like a clean pass
- `guardrail_response` records the literal `"allow"`, not the verdict
- The provider's transaction id and detector names are dropped
- Detect mode reports success with no detail

How it solves it:

- A guardrail can now report a sanitized structured verdict
- The verdict replaces the inferred `"allow"` in the record
- A detection is logged as `guardrail_flagged`, not `success`
- `zscaler_ai_guard` reports action, transaction id and detectors
- OpenTelemetry exports the provider transaction id on guardrail spans

## User Flow

Before: an operator running an AI Guard policy in DETECT mode cannot tell a detection from a clean request

1. They configure the `zscaler_ai_guard` guardrail with `mode: pre_call` and set the policy action to DETECT
2. They send POST http://localhost:4000/v1/chat/completions with a matching prompt and get a normal 200 with the model's answer
3. They send the same request with a non-matching prompt and get the same 200
4. They open http://localhost:4000/ui/?page=logs and click either request, and the Guardrail panel shows PASSED for both
5. Both rows record `guardrail_status: "success"` and `guardrail_response: "allow"`, with no provider transaction id or detector name

After: the intended flow distinguishes detection from a clean pass; real-provider UI verification is still pending

1. They configure the `zscaler_ai_guard` guardrail with `mode: pre_call` and set the policy action to DETECT
2. They send POST http://localhost:4000/v1/chat/completions with a matching prompt and get a normal 200 with the model's answer
3. They send the same request with a non-matching prompt and get the same 200
4. They open http://localhost:4000/ui/?page=logs and click the matching request, and the Guardrail panel shows FLAGGED
5. That row records `guardrail_status: "guardrail_flagged"`, `guardrail_action: "DETECT"`, `guardrail_transaction_id` with the provider transaction id, and `violation_categories` with the detectors that fired
6. The non-matching request still shows PASSED with `guardrail_action: "ALLOW"`, so the two are no longer identical
7. A request the policy blocks is refused with 400 exactly as before

## Relevant issues

## Linear ticket

Resolves LIT-4877

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The focused guardrail and OTel tests pass locally
- [x] The PR passes required CI checks
- [x] The PR scope is isolated to provider verdict logging
- [x] Greptile scored the current head 5/5 with no open findings
- [x] The sync `apply_guardrail` branch, the response direction, a vendor failure and the spend log, DataDog and Langfuse records are covered

## Screenshots / Proof of Fix

No qualifying end-to-end proof is available for the pushed PR head

Previous base/head checks used real OpenAI calls, Postgres, four proxy workers and Jaeger, but the AI Guard endpoint was a local stand-in. Those checks do not clear the required zero-stubs live gate or prove the real provider flow

Real `ZSCALER_AI_GUARD_URL` and `ZSCALER_AI_GUARD_API_KEY` are missing. ALLOW, DETECT and BLOCK must be re-driven against a real AI Guard tenant, followed by screenshots from the bundled dashboard

## Type

Bug Fix

## Caveats (if any)

### High

- Exception paths retain their diagnostics while attaching recorded verdict audit fields
  - Covered by the focused regression tests and the pushed follow-up

### Medium

- Real AI Guard validation is blocked by missing credentials
- The final live regression gate and UI evidence remain incomplete
- DETECT now records `guardrail_flagged`, changing success-only log filters
- A clean ALLOW records the verdict object where it recorded the string `"allow"`, so a consumer matching that string now reads a mapping

### Low

- Only `zscaler_ai_guard` reports structured verdicts
- Per-request identifiers use `guardrail_transaction_id`, preserving `guardrail_id`

## Final Attestation

- [ ] The tests and live verification cover the required scenarios



