### PR TITLE
fix(bedrock): keep x-amzn-RequestId on chat error responses

### DIFF
--- a/litellm/exceptions.py
+++ b/litellm/exceptions.py
@@ -353,10 +353,6 @@ class Timeout(openai.APITimeoutError):
         self.max_retries = max_retries
         self.num_retries = num_retries
         self.headers = headers
-        # The upstream response, when the timeout came from a provider reply
-        # rather than a client-side deadline. Retry and cooldown logic reads
-        # `retry-after` off it, and the proxy prefixes its headers before
-        # returning them, matching every other mapped provider exception.
         if response is not None:
             self.response = response
 

--- a/litellm/exceptions.py
+++ b/litellm/exceptions.py
@@ -338,6 +338,7 @@ class Timeout(openai.APITimeoutError):
         num_retries: int | None = None,
         headers: dict | None = None,
         exception_status_code: int | None = None,
+        response: httpx.Response | None = None,
     ):
         request: Final = httpx.Request(
             method="POST",
@@ -352,6 +353,12 @@ class Timeout(openai.APITimeoutError):
         self.max_retries = max_retries
         self.num_retries = num_retries
         self.headers = headers
+        # The upstream response, when the timeout came from a provider reply
+        # rather than a client-side deadline. Retry and cooldown logic reads
+        # `retry-after` off it, and the proxy prefixes its headers before
+        # returning them, matching every other mapped provider exception.
+        if response is not None:
+            self.response = response
 
     # custom function to convert to str
     def __str__(self):

--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -860,6 +860,7 @@ def _map_bedrock_exception(
                 message=mantle_context_window_message,
                 model=model,
                 llm_provider=custom_llm_provider,
+                response=getattr(original_exception, "response", None),
             )
     if (
         "too many tokens" in error_str
@@ -873,6 +874,7 @@ def _map_bedrock_exception(
             message=f"BedrockException: Context Window Error - {error_str}",
             model=model,
             llm_provider="bedrock",
+            response=getattr(original_exception, "response", None),
         )
     elif "Conversation blocks and tool result blocks cannot be provided in the same turn." in error_str:
         raise BadRequestError(
@@ -930,6 +932,7 @@ def _map_bedrock_exception(
             message=f"BedrockException - {error_str}",
             model=model,
             llm_provider="bedrock",
+            response=getattr(original_exception, "response", None),
         )
     elif hasattr(original_exception, "status_code"):
         if original_exception.status_code == 500:

--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -937,10 +937,7 @@ def _map_bedrock_exception(
                 message=f"BedrockException - {original_exception.message}",
                 llm_provider="bedrock",
                 model=model,
-                response=httpx.Response(
-                    status_code=500,
-                    request=httpx.Request(method="POST", url="https://api.openai.com/v1/"),
-                ),
+                response=getattr(original_exception, "response", None),
             )
         elif original_exception.status_code == 401:
             raise AuthenticationError(

--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -843,15 +843,6 @@ def _get_bedrock_mantle_context_window_message(error_str: str) -> str | None:
     return f"prompt is too long: {prompt_tokens} tokens > {max_tokens} maximum"
 
 
-def _bedrock_timeout_headers(original_exception: object) -> dict | None:
-    from litellm.litellm_core_utils.llm_response_utils.get_headers import get_response_headers
-
-    provider_headers = getattr(getattr(original_exception, "response", None), "headers", None)
-    if not provider_headers:
-        return None
-    return get_response_headers(provider_headers)
-
-
 def _map_bedrock_exception(
     *,
     model: str,
@@ -935,7 +926,7 @@ def _map_bedrock_exception(
             message=f"BedrockException: Timeout Error - {error_str}",
             model=model,
             llm_provider="bedrock",
-            headers=_bedrock_timeout_headers(original_exception),
+            response=getattr(original_exception, "response", None),
         )
     elif "Could not process image" in error_str:
         raise litellm.InternalServerError(
@@ -979,7 +970,7 @@ def _map_bedrock_exception(
                 model=model,
                 llm_provider=custom_llm_provider,
                 litellm_debug_info=extra_information,
-                headers=_bedrock_timeout_headers(original_exception),
+                response=getattr(original_exception, "response", None),
             )
         elif original_exception.status_code == 422:
             raise BadRequestError(
@@ -1012,7 +1003,7 @@ def _map_bedrock_exception(
                 llm_provider=custom_llm_provider,
                 litellm_debug_info=extra_information,
                 exception_status_code=original_exception.status_code,
-                headers=_bedrock_timeout_headers(original_exception),
+                response=getattr(original_exception, "response", None),
             )
 
 

--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -843,6 +843,15 @@ def _get_bedrock_mantle_context_window_message(error_str: str) -> str | None:
     return f"prompt is too long: {prompt_tokens} tokens > {max_tokens} maximum"
 
 
+def _bedrock_timeout_headers(original_exception: object) -> dict | None:
+    from litellm.litellm_core_utils.llm_response_utils.get_headers import get_response_headers
+
+    provider_headers = getattr(getattr(original_exception, "response", None), "headers", None)
+    if not provider_headers:
+        return None
+    return get_response_headers(provider_headers)
+
+
 def _map_bedrock_exception(
     *,
     model: str,
@@ -926,6 +935,7 @@ def _map_bedrock_exception(
             message=f"BedrockException: Timeout Error - {error_str}",
             model=model,
             llm_provider="bedrock",
+            headers=_bedrock_timeout_headers(original_exception),
         )
     elif "Could not process image" in error_str:
         raise litellm.InternalServerError(
@@ -969,6 +979,7 @@ def _map_bedrock_exception(
                 model=model,
                 llm_provider=custom_llm_provider,
                 litellm_debug_info=extra_information,
+                headers=_bedrock_timeout_headers(original_exception),
             )
         elif original_exception.status_code == 422:
             raise BadRequestError(
@@ -1001,6 +1012,7 @@ def _map_bedrock_exception(
                 llm_provider=custom_llm_provider,
                 litellm_debug_info=extra_information,
                 exception_status_code=original_exception.status_code,
+                headers=_bedrock_timeout_headers(original_exception),
             )
 
 

--- a/litellm/litellm_core_utils/llm_response_utils/get_headers.py
+++ b/litellm/litellm_core_utils/llm_response_utils/get_headers.py
@@ -1,7 +1,8 @@
+from collections.abc import Mapping
 from typing import Final
 
 
-def get_response_headers(_response_headers: dict | None = None) -> dict:
+def get_response_headers(_response_headers: Mapping[str, str] | None = None) -> dict:
     """
 
     Sets the Appropriate OpenAI headers for the response and forward all headers as llm_provider-{header}
@@ -31,7 +32,7 @@ def get_response_headers(_response_headers: dict | None = None) -> dict:
     return {**llm_provider_headers, **openai_headers}
 
 
-def _get_llm_provider_headers(response_headers: dict) -> dict:
+def _get_llm_provider_headers(response_headers: Mapping[str, str]) -> dict:
     """
     Adds a llm_provider-{header} to all headers that are not already prefixed with llm_provider
 

--- a/litellm/llms/bedrock/chat/agentcore/transformation.py
+++ b/litellm/llms/bedrock/chat/agentcore/transformation.py
@@ -1046,7 +1046,7 @@ class AmazonAgentCoreConfig(BaseConfig, BaseAWSLLM):
         return headers
 
     def get_error_class(self, error_message: str, status_code: int, headers: dict | httpx.Headers) -> BaseLLMException:
-        return BedrockError(status_code=status_code, message=error_message)
+        return BedrockError(status_code=status_code, message=error_message, headers=headers)
 
     def should_fake_stream(
         self,

--- a/litellm/llms/bedrock/chat/agentcore/transformation.py
+++ b/litellm/llms/bedrock/chat/agentcore/transformation.py
@@ -667,7 +667,12 @@ class AmazonAgentCoreConfig(BaseConfig, BaseAWSLLM):
         )
 
         if response.status_code != 200:
-            raise BedrockError(status_code=response.status_code, message=str(response.read()))
+            raise BedrockError(
+                status_code=response.status_code,
+                message=str(response.read()),
+                headers=response.headers,
+                response=response,
+            )
 
         # LOGGING
         logging_obj.post_call(
@@ -690,6 +695,7 @@ class AmazonAgentCoreConfig(BaseConfig, BaseAWSLLM):
                 raise BedrockError(
                     status_code=response.status_code,
                     message=f"AgentCore: Failed to read/parse JSON response body: {e}",
+                    headers=response.headers,
                 )
             parsed: Final = self._parse_json_response(response_json)
 
@@ -880,7 +886,12 @@ class AmazonAgentCoreConfig(BaseConfig, BaseAWSLLM):
         )
 
         if response.status_code != 200:
-            raise BedrockError(status_code=response.status_code, message=str(await response.aread()))
+            raise BedrockError(
+                status_code=response.status_code,
+                message=str(await response.aread()),
+                headers=response.headers,
+                response=response,
+            )
 
         # LOGGING
         logging_obj.post_call(
@@ -903,6 +914,7 @@ class AmazonAgentCoreConfig(BaseConfig, BaseAWSLLM):
                 raise BedrockError(
                     status_code=response.status_code,
                     message=f"AgentCore: Failed to read/parse JSON response body: {e}",
+                    headers=response.headers,
                 )
             parsed: Final = self._parse_json_response(response_json)
 
@@ -1031,6 +1043,7 @@ class AmazonAgentCoreConfig(BaseConfig, BaseAWSLLM):
             raise BedrockError(
                 message=f"Error processing response: {e}",
                 status_code=raw_response.status_code,
+                headers=raw_response.headers,
             )
 
     def validate_environment(

--- a/litellm/llms/bedrock/chat/converse_handler.py
+++ b/litellm/llms/bedrock/chat/converse_handler.py
@@ -22,7 +22,7 @@ from litellm.types.utils import ModelResponse
 from litellm.utils import CustomStreamWrapper
 
 from ..base_aws_llm import BaseAWSLLM, Credentials, bedrock_bearer_token
-from ..common_utils import BedrockError, _get_all_bedrock_regions
+from ..common_utils import BedrockError, _get_all_bedrock_regions, error_response_text
 from .invoke_handler import AWSEventStreamDecoder, MockResponseIterator, make_call
 
 
@@ -247,7 +247,12 @@ class BedrockConverseLLM(BaseAWSLLM):
             response.raise_for_status()
         except httpx.HTTPStatusError as err:
             error_code: Final = err.response.status_code
-            raise BedrockError(status_code=error_code, message=err.response.text)
+            raise BedrockError(
+                status_code=error_code,
+                message=error_response_text(err.response),
+                headers=err.response.headers,
+                response=err.response,
+            )
         except httpx.TimeoutException:
             raise BedrockError(status_code=408, message="Timeout error occurred.")
 
@@ -594,7 +599,12 @@ class BedrockConverseLLM(BaseAWSLLM):
             response.raise_for_status()
         except httpx.HTTPStatusError as err:
             error_code: Final = err.response.status_code
-            raise BedrockError(status_code=error_code, message=err.response.text)
+            raise BedrockError(
+                status_code=error_code,
+                message=error_response_text(err.response),
+                headers=err.response.headers,
+                response=err.response,
+            )
         except httpx.TimeoutException:
             raise BedrockError(status_code=408, message="Timeout error occurred.")
 

--- a/litellm/llms/bedrock/chat/converse_handler.py
+++ b/litellm/llms/bedrock/chat/converse_handler.py
@@ -66,7 +66,12 @@ def make_sync_call(
     )
 
     if response.status_code != 200:
-        raise BedrockError(status_code=response.status_code, message=str(response.read()))
+        raise BedrockError(
+            status_code=response.status_code,
+            message=str(response.read()),
+            headers=response.headers,
+            response=response,
+        )
 
     if fake_stream:
         model_response: Final[ModelResponse] = litellm.AmazonConverseConfig()._transform_response(

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -2255,6 +2255,7 @@ class AmazonConverseConfig(BaseConfig):
             raise BedrockError(
                 message=f"Error converting to valid response block={e}. File an issue if litellm error - https://github.com/BerriAI/litellm/issues",
                 status_code=422,
+                headers=response.headers,
             )
 
         """

--- a/litellm/llms/bedrock/chat/invoke_agent/transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_agent/transformation.py
@@ -485,7 +485,7 @@ class AmazonInvokeAgentConfig(BaseConfig, BaseAWSLLM):
         return headers
 
     def get_error_class(self, error_message: str, status_code: int, headers: dict | httpx.Headers) -> BaseLLMException:
-        return BedrockError(status_code=status_code, message=error_message)
+        return BedrockError(status_code=status_code, message=error_message, headers=headers)
 
     def should_fake_stream(
         self,

--- a/litellm/llms/bedrock/chat/invoke_agent/transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_agent/transformation.py
@@ -470,6 +470,7 @@ class AmazonInvokeAgentConfig(BaseConfig, BaseAWSLLM):
             raise BedrockError(
                 message=f"Error processing response: {e}",
                 status_code=raw_response.status_code,
+                headers=raw_response.headers,
             )
 
     def validate_environment(

--- a/litellm/llms/bedrock/chat/invoke_handler.py
+++ b/litellm/llms/bedrock/chat/invoke_handler.py
@@ -42,6 +42,7 @@ from litellm.types.utils import GenericStreamingChunk as GChunk
 from ..common_utils import (
     BedrockError,
     build_bedrock_stream_error,
+    error_response_text,
     get_bedrock_response_stream_shape,
     get_bedrock_tool_name,
 )
@@ -230,7 +231,12 @@ async def make_call(
         return completion_stream, response.headers
     except httpx.HTTPStatusError as err:
         error_code: Final = err.response.status_code
-        raise BedrockError(status_code=error_code, message=err.response.text)
+        raise BedrockError(
+            status_code=error_code,
+            message=error_response_text(err.response),
+            headers=err.response.headers,
+            response=err.response,
+        )
     except httpx.TimeoutException:
         raise BedrockError(status_code=408, message="Timeout error occurred.")
     except Exception as e:
@@ -316,7 +322,12 @@ def make_sync_call(
         return completion_stream, response.headers
     except httpx.HTTPStatusError as err:
         error_code: Final = err.response.status_code
-        raise BedrockError(status_code=error_code, message=err.response.text)
+        raise BedrockError(
+            status_code=error_code,
+            message=error_response_text(err.response),
+            headers=err.response.headers,
+            response=err.response,
+        )
     except httpx.TimeoutException:
         raise BedrockError(status_code=408, message="Timeout error occurred.")
     except Exception as e:

--- a/litellm/llms/bedrock/chat/invoke_handler.py
+++ b/litellm/llms/bedrock/chat/invoke_handler.py
@@ -185,7 +185,12 @@ async def make_call(
         )
 
         if response.status_code != 200:
-            raise BedrockError(status_code=response.status_code, message=response.text)
+            raise BedrockError(
+                status_code=response.status_code,
+                message=error_response_text(response),
+                headers=response.headers,
+                response=response,
+            )
 
         if fake_stream:
             model_response: Final[ModelResponse] = litellm.AmazonConverseConfig()._transform_response(
@@ -229,6 +234,8 @@ async def make_call(
         )
 
         return completion_stream, response.headers
+    except BedrockError:
+        raise
     except httpx.HTTPStatusError as err:
         error_code: Final = err.response.status_code
         raise BedrockError(
@@ -276,7 +283,12 @@ def make_sync_call(
         )
 
         if response.status_code != 200:
-            raise BedrockError(status_code=response.status_code, message=response.text)
+            raise BedrockError(
+                status_code=response.status_code,
+                message=error_response_text(response),
+                headers=response.headers,
+                response=response,
+            )
 
         if fake_stream:
             model_response: Final[ModelResponse] = litellm.AmazonConverseConfig()._transform_response(
@@ -320,6 +332,8 @@ def make_sync_call(
         )
 
         return completion_stream, response.headers
+    except BedrockError:
+        raise
     except httpx.HTTPStatusError as err:
         error_code: Final = err.response.status_code
         raise BedrockError(

--- a/litellm/llms/bedrock/chat/invoke_transformations/amazon_moonshot_transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_transformations/amazon_moonshot_transformation.py
@@ -247,4 +247,4 @@ class AmazonMoonshotConfig(AmazonInvokeConfig, MoonshotChatConfig):
 
     def get_error_class(self, error_message: str, status_code: int, headers: dict | httpx.Headers) -> BedrockError:
         """Return the appropriate error class for Bedrock."""
-        return BedrockError(status_code=status_code, message=error_message)
+        return BedrockError(status_code=status_code, message=error_message, headers=headers)

--- a/litellm/llms/bedrock/chat/invoke_transformations/amazon_openai_transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_transformations/amazon_openai_transformation.py
@@ -182,4 +182,4 @@ class AmazonBedrockOpenAIConfig(OpenAIGPTConfig, BaseAWSLLM):
 
     def get_error_class(self, error_message: str, status_code: int, headers: dict | httpx.Headers) -> BedrockError:
         """Return the appropriate error class for Bedrock."""
-        return BedrockError(status_code=status_code, message=error_message)
+        return BedrockError(status_code=status_code, message=error_message, headers=headers)

--- a/litellm/llms/bedrock/chat/invoke_transformations/amazon_twelvelabs_pegasus_transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_transformations/amazon_twelvelabs_pegasus_transformation.py
@@ -212,6 +212,7 @@ class AmazonTwelveLabsPegasusConfig(AmazonInvokeConfig, BaseConfig):
             raise BedrockError(
                 message=f"Error parsing response: {raw_response.text}, error: {e}",
                 status_code=raw_response.status_code,
+                headers=raw_response.headers,
             )
 
         verbose_logger.debug(
@@ -241,6 +242,7 @@ class AmazonTwelveLabsPegasusConfig(AmazonInvokeConfig, BaseConfig):
             raise BedrockError(
                 message=f"Error setting response content: {e}. Response: {completion_response}",
                 status_code=raw_response.status_code,
+                headers=raw_response.headers,
             )
 
         # Calculate usage from headers

--- a/litellm/llms/bedrock/chat/invoke_transformations/base_invoke_transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_transformations/base_invoke_transformation.py
@@ -431,7 +431,7 @@ class AmazonInvokeConfig(BaseConfig, BaseAWSLLM):
         return merge_bedrock_invoke_headers(headers, guardrail_headers, metadata_headers, owned_names)
 
     def get_error_class(self, error_message: str, status_code: int, headers: dict | httpx.Headers) -> BaseLLMException:
-        return BedrockError(status_code=status_code, message=error_message)
+        return BedrockError(status_code=status_code, message=error_message, headers=headers)
 
     @track_llm_api_timing()
     async def get_async_custom_stream_wrapper(

--- a/litellm/llms/bedrock/chat/invoke_transformations/base_invoke_transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_transformations/base_invoke_transformation.py
@@ -295,7 +295,11 @@ class AmazonInvokeConfig(BaseConfig, BaseAWSLLM):
         try:
             completion_response: Final = raw_response.json()
         except Exception:
-            raise BedrockError(message=raw_response.text, status_code=raw_response.status_code)
+            raise BedrockError(
+                message=raw_response.text,
+                status_code=raw_response.status_code,
+                headers=raw_response.headers,
+            )
         verbose_logger.debug(
             "bedrock invoke response % s",
             json.dumps(completion_response, indent=4, default=str),
@@ -363,6 +367,7 @@ class AmazonInvokeConfig(BaseConfig, BaseAWSLLM):
             raise BedrockError(
                 message=f"Error processing={raw_response.text}, Received error={e}",
                 status_code=422,
+                headers=raw_response.headers,
             )
 
         try:
@@ -384,6 +389,7 @@ class AmazonInvokeConfig(BaseConfig, BaseAWSLLM):
             raise BedrockError(
                 message=f"Error parsing received text={outputText}.\nError-{e}",
                 status_code=raw_response.status_code,
+                headers=raw_response.headers,
             )
 
         ## CALCULATING USAGE - bedrock returns usage in the headers

--- a/litellm/llms/bedrock/claude_platform/common_utils.py
+++ b/litellm/llms/bedrock/claude_platform/common_utils.py
@@ -1,7 +1,10 @@
 from typing import Final
 
+import httpx
+
 import litellm
 from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
+from litellm.llms.bedrock.common_utils import BedrockError
 from litellm.secret_managers.main import get_secret_str
 
 CLAUDE_PLATFORM_SERVICE_NAME: Final = "aws-external-anthropic"
@@ -15,6 +18,14 @@ def strip_claude_platform_route(model: str) -> str:
 
 
 class BedrockClaudePlatformMixin(BaseAWSLLM):
+    def get_error_class(
+        self,
+        error_message: str,
+        status_code: int,
+        headers: dict[str, object] | httpx.Headers,  # mutable-ok: base passes response headers as a dict
+    ) -> BedrockError:
+        return BedrockError(status_code=status_code, message=error_message, headers=headers)
+
     @staticmethod
     def _get_workspace_id(optional_params: dict, litellm_params: dict) -> str | None:
         workspace_id = (

--- a/litellm/llms/bedrock/common_utils.py
+++ b/litellm/llms/bedrock/common_utils.py
@@ -33,8 +33,65 @@ if TYPE_CHECKING:
     from litellm.types.llms.openai import AllMessageValues
 
 
+_ERROR_REQUEST_URL: Final = "https://docs.litellm.ai/docs"
+
+
+def error_response_text(response: httpx.Response) -> str:
+    """A streamed response that was never read has no body to report, only its status line."""
+    try:
+        return response.text
+    except httpx.ResponseNotRead:
+        return response.reason_phrase
+
+
+def _synthesize_error_response(
+    *, status_code: int, headers: dict | httpx.Headers, request: httpx.Request | None
+) -> tuple[httpx.Request, httpx.Response]:
+    """httpx rejects a header value that is not str or bytes, and the shared HTTP handler
+    copies an arbitrary exception's header values in verbatim, so a plain dict is filtered."""
+    error_request: Final = request or httpx.Request(method="POST", url=_ERROR_REQUEST_URL)
+    safe_headers: Final = (
+        headers
+        if isinstance(headers, httpx.Headers)
+        else tuple((key, value) for key, value in headers.items() if isinstance(value, (str, bytes)))
+    )
+    return error_request, httpx.Response(status_code=status_code, headers=safe_headers, request=error_request)
+
+
 class BedrockError(BaseLLMException):
-    pass
+    """Bedrock error that keeps the provider's response headers.
+
+    AWS support asks for `x-amzn-RequestId` to investigate a failed call, and both
+    exception mapping and the proxy error handler read those headers off
+    `exc.response.headers`. Callers that only hold the headers (the shared HTTP
+    handler hands `get_error_class` a header dict and no response) would otherwise
+    lose them to a blank stand-in response.
+    """
+
+    def __init__(
+        self,
+        status_code: int,
+        message: str,
+        headers: dict | httpx.Headers | None = None,
+        request: httpx.Request | None = None,
+        response: httpx.Response | None = None,
+        body: dict | None = None,
+        status_code_is_synthesized: bool = False,
+    ) -> None:
+        error_request, error_response = (
+            _synthesize_error_response(status_code=status_code, headers=headers, request=request)
+            if response is None and headers
+            else (request, response)
+        )
+        super().__init__(
+            status_code=status_code,
+            message=message,
+            headers=headers,
+            request=error_request,
+            response=error_response,
+            body=body,
+            status_code_is_synthesized=status_code_is_synthesized,
+        )
 
 
 _BEDROCK_AWS_AUTH_PARAMETER_KEYS: Final[tuple[str, ...]] = (

--- a/litellm/llms/bedrock/common_utils.py
+++ b/litellm/llms/bedrock/common_utils.py
@@ -37,7 +37,7 @@ _ERROR_REQUEST_URL: Final = "https://docs.litellm.ai/docs"
 
 
 def error_response_text(response: httpx.Response) -> str:
-    """A streamed response that was never read has no body to report, only its status line."""
+    """Return the error body, or the status line when the body was never read."""
     try:
         return response.text
     except httpx.ResponseNotRead:
@@ -45,10 +45,9 @@ def error_response_text(response: httpx.Response) -> str:
 
 
 def _synthesize_error_response(
-    *, status_code: int, headers: dict | httpx.Headers, request: httpx.Request | None
+    *, status_code: int, headers: dict[str, object] | httpx.Headers, request: httpx.Request | None
 ) -> tuple[httpx.Request, httpx.Response]:
-    """httpx rejects a header value that is not str or bytes, and the shared HTTP handler
-    copies an arbitrary exception's header values in verbatim, so a plain dict is filtered."""
+    """Build the request and response carrying the provider's headers, dropping values httpx rejects."""
     error_request: Final = request or httpx.Request(method="POST", url=_ERROR_REQUEST_URL)
     safe_headers: Final = (
         headers
@@ -59,23 +58,16 @@ def _synthesize_error_response(
 
 
 class BedrockError(BaseLLMException):
-    """Bedrock error that keeps the provider's response headers.
-
-    AWS support asks for `x-amzn-RequestId` to investigate a failed call, and both
-    exception mapping and the proxy error handler read those headers off
-    `exc.response.headers`. Callers that only hold the headers (the shared HTTP
-    handler hands `get_error_class` a header dict and no response) would otherwise
-    lose them to a blank stand-in response.
-    """
+    """Bedrock error whose response carries the provider's headers, synthesizing one if needed."""
 
     def __init__(
         self,
         status_code: int,
         message: str,
-        headers: dict | httpx.Headers | None = None,
+        headers: dict[str, object] | httpx.Headers | None = None,
         request: httpx.Request | None = None,
         response: httpx.Response | None = None,
-        body: dict | None = None,
+        body: dict[str, object] | None = None,
         status_code_is_synthesized: bool = False,
     ) -> None:
         error_request, error_response = (

--- a/litellm/llms/bedrock/common_utils.py
+++ b/litellm/llms/bedrock/common_utils.py
@@ -37,7 +37,6 @@ _ERROR_REQUEST_URL: Final = "https://docs.litellm.ai/docs"
 
 
 def error_response_text(response: httpx.Response) -> str:
-    """Return the error body, or the status line when the body was never read."""
     try:
         return response.text
     except httpx.ResponseNotRead:
@@ -47,7 +46,6 @@ def error_response_text(response: httpx.Response) -> str:
 def _synthesize_error_response(
     *, status_code: int, headers: dict[str, object] | httpx.Headers, request: httpx.Request | None
 ) -> tuple[httpx.Request, httpx.Response]:
-    """Build the request and response carrying the provider's headers, dropping values httpx rejects."""
     error_request: Final = request or httpx.Request(method="POST", url=_ERROR_REQUEST_URL)
     safe_headers: Final = (
         headers
@@ -58,8 +56,6 @@ def _synthesize_error_response(
 
 
 class BedrockError(BaseLLMException):
-    """Bedrock error whose response carries the provider's headers, synthesizing one if needed."""
-
     def __init__(
         self,
         status_code: int,

--- a/litellm/llms/bedrock/count_tokens/handler.py
+++ b/litellm/llms/bedrock/count_tokens/handler.py
@@ -102,6 +102,8 @@ class BedrockCountTokensHandler(BedrockCountTokensConfig):
                 raise BedrockError(
                     status_code=response.status_code,
                     message=error_text,
+                    headers=response.headers,
+                    response=response,
                 )
 
             bedrock_response: Final = response.json()
@@ -124,6 +126,8 @@ class BedrockCountTokensHandler(BedrockCountTokensConfig):
             raise BedrockError(
                 status_code=e.response.status_code,
                 message=e.response.text,
+                headers=e.response.headers,
+                response=e.response,
             )
         except Exception as e:
             verbose_logger.error("Error in CountTokens handler: %s", e)

--- a/litellm/llms/bedrock/embed/embedding.py
+++ b/litellm/llms/bedrock/embed/embedding.py
@@ -132,7 +132,12 @@ class BedrockEmbedding(BaseAWSLLM):
             response.raise_for_status()
         except httpx.HTTPStatusError as err:
             error_code: Final = err.response.status_code
-            raise BedrockError(status_code=error_code, message=err.response.text)
+            raise BedrockError(
+                status_code=error_code,
+                message=err.response.text,
+                headers=err.response.headers,
+                response=err.response,
+            )
         except httpx.TimeoutException:
             raise BedrockError(status_code=408, message="Timeout error occurred.")
 
@@ -161,7 +166,12 @@ class BedrockEmbedding(BaseAWSLLM):
             response.raise_for_status()
         except httpx.HTTPStatusError as err:
             error_code: Final = err.response.status_code
-            raise BedrockError(status_code=error_code, message=err.response.text)
+            raise BedrockError(
+                status_code=error_code,
+                message=err.response.text,
+                headers=err.response.headers,
+                response=err.response,
+            )
         except httpx.TimeoutException:
             raise BedrockError(status_code=408, message="Timeout error occurred.")
 

--- a/litellm/llms/bedrock/image_edit/amazon_nova_canvas_image_edit_transformation.py
+++ b/litellm/llms/bedrock/image_edit/amazon_nova_canvas_image_edit_transformation.py
@@ -20,6 +20,7 @@ import httpx
 
 from litellm._logging import verbose_logger
 from litellm.llms.base_llm.image_edit.transformation import BaseImageEditConfig
+from litellm.llms.bedrock.common_utils import BedrockError
 from litellm.types.images.main import ImageEditOptionalRequestParams
 from litellm.types.router import GenericLiteLLMParams
 from litellm.types.utils import FileTypes, ImageObject, ImageResponse
@@ -227,6 +228,14 @@ class BedrockAmazonNovaCanvasImageEditConfig(BaseImageEditConfig):
         drops keys not on ModelInfoBase).
         """
         return _supports_nova_canvas_image_edit_from_model_cost(model or "")
+
+    def get_error_class(
+        self,
+        error_message: str,
+        status_code: int,
+        headers: dict[str, object] | httpx.Headers,  # mutable-ok: base passes response headers as a dict
+    ) -> BedrockError:
+        return BedrockError(status_code=status_code, message=error_message, headers=headers)
 
     def get_supported_openai_params(self, model: str) -> list:
         return [

--- a/litellm/llms/bedrock/image_edit/handler.py
+++ b/litellm/llms/bedrock/image_edit/handler.py
@@ -114,7 +114,12 @@ class BedrockImageEdit(BaseAWSLLM):
             response.raise_for_status()
         except httpx.HTTPStatusError as err:
             error_code: Final = err.response.status_code
-            raise BedrockError(status_code=error_code, message=err.response.text)
+            raise BedrockError(
+                status_code=error_code,
+                message=err.response.text,
+                headers=err.response.headers,
+                response=err.response,
+            )
         except httpx.TimeoutException:
             raise BedrockError(status_code=408, message="Timeout error occurred.")
 
@@ -156,7 +161,12 @@ class BedrockImageEdit(BaseAWSLLM):
             response.raise_for_status()
         except httpx.HTTPStatusError as err:
             error_code: Final = err.response.status_code
-            raise BedrockError(status_code=error_code, message=err.response.text)
+            raise BedrockError(
+                status_code=error_code,
+                message=err.response.text,
+                headers=err.response.headers,
+                response=err.response,
+            )
         except httpx.TimeoutException:
             raise BedrockError(status_code=408, message="Timeout error occurred.")
 

--- a/litellm/llms/bedrock/image_edit/stability_transformation.py
+++ b/litellm/llms/bedrock/image_edit/stability_transformation.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING, Any, Final
 import httpx
 
 from litellm.llms.base_llm.image_edit.transformation import BaseImageEditConfig
+from litellm.llms.bedrock.common_utils import BedrockError
 from litellm.types.images.main import ImageEditOptionalRequestParams
 from litellm.types.llms.stability import (
     OPENAI_SIZE_TO_STABILITY_ASPECT_RATIO,
@@ -83,6 +84,14 @@ class BedrockStabilityImageEditConfig(BaseImageEditConfig):
             ):
                 return True
         return False
+
+    def get_error_class(
+        self,
+        error_message: str,
+        status_code: int,
+        headers: dict[str, object] | httpx.Headers,  # mutable-ok: base passes response headers as a dict
+    ) -> BedrockError:
+        return BedrockError(status_code=status_code, message=error_message, headers=headers)
 
     def get_supported_openai_params(self, model: str) -> list:
         """

--- a/litellm/llms/bedrock/image_generation/image_handler.py
+++ b/litellm/llms/bedrock/image_generation/image_handler.py
@@ -119,7 +119,12 @@ class BedrockImageGeneration(BaseAWSLLM):
             response.raise_for_status()
         except httpx.HTTPStatusError as err:
             error_code: Final = err.response.status_code
-            raise BedrockError(status_code=error_code, message=err.response.text)
+            raise BedrockError(
+                status_code=error_code,
+                message=err.response.text,
+                headers=err.response.headers,
+                response=err.response,
+            )
         except httpx.TimeoutException:
             raise BedrockError(status_code=408, message="Timeout error occurred.")
         ### FORMAT RESPONSE TO OPENAI FORMAT ###
@@ -162,7 +167,12 @@ class BedrockImageGeneration(BaseAWSLLM):
             response.raise_for_status()
         except httpx.HTTPStatusError as err:
             error_code: Final = err.response.status_code
-            raise BedrockError(status_code=error_code, message=err.response.text)
+            raise BedrockError(
+                status_code=error_code,
+                message=err.response.text,
+                headers=err.response.headers,
+                response=err.response,
+            )
         except httpx.TimeoutException:
             raise BedrockError(status_code=408, message="Timeout error occurred.")
 

--- a/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
+++ b/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
@@ -29,6 +29,7 @@ from litellm.llms.bedrock.chat.invoke_transformations.base_invoke_transformation
     AmazonInvokeConfig,
 )
 from litellm.llms.bedrock.common_utils import (
+    BedrockError,
     apply_bedrock_invoke_structured_output,
     ensure_bedrock_anthropic_messages_tool_names,
     get_anthropic_beta_from_headers,
@@ -78,6 +79,14 @@ class AmazonAnthropicClaudeMessagesConfig(
         return "bedrock"
 
     BEDROCK_INVOKE_ALLOWED_TOP_LEVEL_FIELDS = frozenset(BedrockInvokeAnthropicMessagesRequest.__annotations__.keys())
+
+    def get_error_class(
+        self,
+        error_message: str,
+        status_code: int,
+        headers: dict[str, object] | httpx.Headers,  # mutable-ok: base passes response headers as a dict
+    ) -> BedrockError:
+        return BedrockError(status_code=status_code, message=error_message, headers=headers)
 
     def __init__(self, **kwargs):
         BaseAnthropicMessagesConfig.__init__(self, **kwargs)

--- a/litellm/llms/bedrock/passthrough/transformation.py
+++ b/litellm/llms/bedrock/passthrough/transformation.py
@@ -2,13 +2,14 @@ import json
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Final, Optional, cast
 
+import httpx
 from httpx import Response
 
 from litellm.litellm_core_utils.litellm_logging import Logging
 from litellm.llms.base_llm.passthrough.transformation import BasePassthroughConfig
 
 from ..base_aws_llm import BaseAWSLLM
-from ..common_utils import BedrockEventStreamDecoderBase, BedrockModelInfo
+from ..common_utils import BedrockError, BedrockEventStreamDecoderBase, BedrockModelInfo
 
 if TYPE_CHECKING:
     from httpx import URL
@@ -18,6 +19,14 @@ if TYPE_CHECKING:
 
 
 class BedrockPassthroughConfig(BaseAWSLLM, BedrockModelInfo, BedrockEventStreamDecoderBase, BasePassthroughConfig):
+    def get_error_class(
+        self,
+        error_message: str,
+        status_code: int,
+        headers: dict[str, object] | httpx.Headers,  # mutable-ok: base passes response headers as a dict
+    ) -> BedrockError:
+        return BedrockError(status_code=status_code, message=error_message, headers=headers)
+
     def is_streaming_request(self, endpoint: str, request_data: dict) -> bool:
         return "stream" in endpoint
 

--- a/litellm/llms/bedrock/realtime/transformation.py
+++ b/litellm/llms/bedrock/realtime/transformation.py
@@ -9,12 +9,14 @@ import json
 import uuid as uuid_lib
 from typing import Final, cast
 
+import httpx
 from pydantic import BaseModel
 
 from litellm._logging import verbose_logger
 from litellm._uuid import uuid
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.llms.base_llm.realtime.transformation import BaseRealtimeConfig
+from litellm.llms.bedrock.common_utils import BedrockError
 from litellm.llms.bedrock.realtime.trigger_audio import ready_trigger_pcm
 from litellm.types.llms.openai import (
     OpenAIRealtimeContentPartDone,
@@ -120,6 +122,14 @@ class BedrockRealtimeConfig(BaseRealtimeConfig):
         self._user_transcript_buffer = ""
         self._cumulative_usage = BedrockUsageEvent()
         self._reported_usage = BedrockUsageEvent()
+
+    def get_error_class(
+        self,
+        error_message: str,
+        status_code: int,
+        headers: dict[str, object] | httpx.Headers,  # mutable-ok: base passes response headers as a dict
+    ) -> BedrockError:
+        return BedrockError(status_code=status_code, message=error_message, headers=headers)
 
     def validate_environment(self, headers: dict, model: str, api_key: str | None = None) -> dict:
         """Validate environment - no special validation needed for Bedrock."""

--- a/litellm/llms/bedrock/rerank/handler.py
+++ b/litellm/llms/bedrock/rerank/handler.py
@@ -46,7 +46,12 @@ class BedrockRerankHandler(BaseAWSLLM):
             response.raise_for_status()
         except httpx.HTTPStatusError as err:
             error_code: Final = err.response.status_code
-            raise BedrockError(status_code=error_code, message=err.response.text)
+            raise BedrockError(
+                status_code=error_code,
+                message=err.response.text,
+                headers=err.response.headers,
+                response=err.response,
+            )
         except httpx.TimeoutException:
             raise BedrockError(status_code=408, message="Timeout error occurred.")
 
@@ -117,7 +122,12 @@ class BedrockRerankHandler(BaseAWSLLM):
             response.raise_for_status()
         except httpx.HTTPStatusError as err:
             error_code: Final = err.response.status_code
-            raise BedrockError(status_code=error_code, message=err.response.text)
+            raise BedrockError(
+                status_code=error_code,
+                message=err.response.text,
+                headers=err.response.headers,
+                response=err.response,
+            )
         except httpx.TimeoutException:
             raise BedrockError(status_code=408, message="Timeout error occurred.")
 

--- a/litellm/llms/bedrock/search/transformation.py
+++ b/litellm/llms/bedrock/search/transformation.py
@@ -39,7 +39,6 @@ from typing import Final
 import httpx
 
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
-from litellm.llms.base_llm.chat.transformation import BaseLLMException
 from litellm.llms.base_llm.search.transformation import (
     BaseSearchConfig,
     SearchResponse,
@@ -451,7 +450,7 @@ class AgentCoreSearchConfig(BaseSearchConfig, BaseAWSLLM):
         status_code: int,
         headers: dict,  # mutable-ok: BaseSearchConfig.get_error_class takes the response headers as a dict
     ) -> Exception:
-        return BaseLLMException(
+        return BedrockError(
             status_code=status_code,
             message=error_message,
             headers=headers,

--- a/litellm/llms/bedrock/search/transformation.py
+++ b/litellm/llms/bedrock/search/transformation.py
@@ -380,6 +380,7 @@ class AgentCoreSearchConfig(BaseSearchConfig, BaseAWSLLM):
             raise BedrockError(
                 status_code=raw_response.status_code if raw_response.status_code >= 400 else 502,
                 message=f"AgentCore gateway MCP error: {error}",
+                headers=raw_response.headers,
             )
 
         # A failed tools/call is reported in-band, as HTTP 200 with result.isError
@@ -389,6 +390,7 @@ class AgentCoreSearchConfig(BaseSearchConfig, BaseAWSLLM):
             raise BedrockError(
                 status_code=raw_response.status_code if raw_response.status_code >= 400 else 502,
                 message=f"AgentCore web search tool error: {self._tool_error_message(response_json)}",
+                headers=raw_response.headers,
             )
 
         text_items: Final = tuple(
@@ -440,6 +442,7 @@ class AgentCoreSearchConfig(BaseSearchConfig, BaseAWSLLM):
         raise BedrockError(
             status_code=502,
             message=f"AgentCore gateway returned SSE without a JSON data frame: {text[:200]}",
+            headers=raw_response.headers,
         )
 
     def get_error_class(

--- a/litellm/llms/bedrock/vector_stores/transformation.py
+++ b/litellm/llms/bedrock/vector_stores/transformation.py
@@ -8,6 +8,7 @@ from litellm._logging import verbose_logger
 from litellm.litellm_core_utils.url_utils import encode_url_path_segment
 from litellm.llms.base_llm.vector_store.transformation import BaseVectorStoreConfig
 from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
+from litellm.llms.bedrock.common_utils import BedrockError
 from litellm.types.integrations.rag.bedrock_knowledgebase import (
     BedrockKBContent,
     BedrockKBResponse,
@@ -37,6 +38,14 @@ class BedrockVectorStoreConfig(BaseVectorStoreConfig, BaseAWSLLM):
     def __init__(self) -> None:
         BaseVectorStoreConfig.__init__(self)
         BaseAWSLLM.__init__(self)
+
+    def get_error_class(
+        self,
+        error_message: str,
+        status_code: int,
+        headers: dict[str, object] | httpx.Headers,  # mutable-ok: base passes response headers as a dict
+    ) -> BedrockError:
+        return BedrockError(status_code=status_code, message=error_message, headers=headers)
 
     def get_auth_credentials(self, litellm_params: dict) -> BaseVectorStoreAuthCredentials:
         return {}

--- a/litellm/llms/bedrock_mantle/chat/transformation.py
+++ b/litellm/llms/bedrock_mantle/chat/transformation.py
@@ -13,6 +13,8 @@ Auth: Bearer token (litellm_params.api_key, BEDROCK_MANTLE_API_KEY, or the
 from collections.abc import AsyncIterator, Iterator
 from typing import Any, Final
 
+import httpx
+
 import litellm
 from litellm._logging import verbose_logger
 from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
@@ -24,6 +26,8 @@ from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.openai import AllMessageValues
 from litellm.types.router import GenericLiteLLMParams
 
+from ...base_llm.chat.transformation import BaseLLMException
+from ...bedrock.common_utils import BedrockError
 from ...openai_like.chat.transformation import OpenAILikeChatConfig
 from ..common_utils import mantle_base_segment
 
@@ -44,6 +48,11 @@ class BedrockMantleChatConfig(BedrockMantleAuthMixin, OpenAILikeChatConfig):
     @classmethod
     def get_config(cls):
         return super().get_config()
+
+    def get_error_class(
+        self, error_message: str, status_code: int, headers: dict[str, object] | httpx.Headers
+    ) -> BaseLLMException:
+        return BedrockError(status_code=status_code, message=error_message, headers=headers)
 
     def _get_openai_compatible_provider_info(
         self,

--- a/litellm/llms/bedrock_mantle/responses/transformation.py
+++ b/litellm/llms/bedrock_mantle/responses/transformation.py
@@ -19,11 +19,14 @@ import json
 from collections.abc import Mapping
 from typing import Any, Final
 
+import httpx
 from typing_extensions import ReadOnly, TypedDict
 
 import litellm
 from litellm._logging import verbose_logger
+from litellm.llms.base_llm.chat.transformation import BaseLLMException
 from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
+from litellm.llms.bedrock.common_utils import BedrockError
 from litellm.llms.bedrock_mantle.common_utils import (
     MANTLE_HOST_RE,
     BedrockMantleAuthMixin,
@@ -97,6 +100,11 @@ class BedrockMantleResponsesAPIConfig(BedrockMantleAuthMixin, OpenAIResponsesAPI
     @property
     def custom_llm_provider(self) -> LlmProviders:
         return LlmProviders.BEDROCK_MANTLE
+
+    def get_error_class(
+        self, error_message: str, status_code: int, headers: dict[str, object] | httpx.Headers
+    ) -> BaseLLMException:
+        return BedrockError(status_code=status_code, message=error_message, headers=headers)
 
     def get_complete_url(
         self,

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -3508,9 +3508,13 @@ class ProxyBaseLLMRequestProcessing:
             error_body: Final = await http_status_error.response.aread()
             error_text: Final = error_body.decode("utf-8")
 
+            error_headers: Final = {  # mutable-ok: HTTPException takes a plain header dict
+                k: v if isinstance(v, str) else str(v) for k, v in safe_headers.items()
+            }
             raise HTTPException(
                 status_code=http_status_error.response.status_code,
                 detail={"error": error_text},
+                headers=error_headers,
             )
         error_msg: Final = f"{e}"
         # Check for AttributeError in the exception chain.

--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -946,7 +946,14 @@ async def handle_bedrock_count_tokens(
     except BedrockError as e:
         # Convert BedrockError to HTTPException for FastAPI
         verbose_proxy_logger.error("BedrockError in handle_bedrock_count_tokens: %s", e)
-        raise HTTPException(status_code=e.status_code, detail={"error": e.message})
+        from litellm.litellm_core_utils.llm_response_utils.get_headers import get_response_headers
+
+        provider_headers: Final = getattr(getattr(e, "response", None), "headers", None)
+        raise HTTPException(
+            status_code=e.status_code,
+            detail={"error": e.message},
+            headers=get_response_headers(provider_headers) if provider_headers else None,
+        )
     except HTTPException:
         # Re-raise HTTP exceptions as-is
         raise

--- a/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
@@ -12,6 +12,7 @@ from litellm.litellm_core_utils.exception_mapping_utils import (
     exception_type,
     extract_and_raise_litellm_exception,
 )
+from litellm.llms.bedrock.common_utils import BedrockError
 from litellm.llms.openai.common_utils import OpenAIError
 from litellm.types.utils import LlmProviders
 
@@ -1254,3 +1255,30 @@ def test_handle_error_marks_only_a_status_code_it_never_received():
         raise handler._handle_error(e=upstream, provider_config=None)
     assert received.value.status_code == 500
     assert received.value.status_code_is_synthesized is False
+
+
+def test_bedrock_500_preserves_provider_response_headers():
+    """A Bedrock 5xx must keep x-amzn-RequestId so AWS support can trace it (LIT-5428)."""
+    provider_response = httpx.Response(
+        status_code=500,
+        headers={"x-amzn-RequestId": "req-map-500"},
+        text='{"message":"Amazon Bedrock is unable to process your request."}',
+        request=httpx.Request("POST", "https://bedrock-runtime.us-east-1.amazonaws.com/"),
+    )
+    original_exception = BedrockError(
+        status_code=500,
+        message=provider_response.text,
+        headers=provider_response.headers,
+        response=provider_response,
+    )
+
+    with pytest.raises(litellm.ServiceUnavailableError) as exc_info:
+        exception_type(
+            model="anthropic.claude-haiku-4-5-20251001-v1:0",
+            original_exception=original_exception,
+            custom_llm_provider="bedrock",
+            completion_kwargs={},
+            extra_kwargs={},
+        )
+
+    assert exc_info.value.response.headers["x-amzn-requestid"] == "req-map-500"

--- a/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
@@ -1282,3 +1282,59 @@ def test_bedrock_500_preserves_provider_response_headers():
         )
 
     assert exc_info.value.response.headers["x-amzn-requestid"] == "req-map-500"
+
+
+@pytest.mark.parametrize(
+    "custom_llm_provider, status_code, provider_message, expected_exception",
+    [
+        (
+            "bedrock_mantle",
+            400,
+            (
+                '{"error":{"code":"validation_error",'
+                '"message":"prompt tokens (1055489) exceed model maximum (1050000) for openai.gpt-5.6-sol",'
+                '"param":null,"type":"invalid_request_error"}}'
+            ),
+            litellm.ContextWindowExceededError,
+        ),
+        (
+            "bedrock",
+            400,
+            '{"message":"Input is too long for requested model."}',
+            litellm.ContextWindowExceededError,
+        ),
+        (
+            "bedrock",
+            400,
+            '{"message":"Could not process image"}',
+            litellm.InternalServerError,
+        ),
+    ],
+)
+def test_bedrock_classified_errors_preserve_provider_response_headers(
+    custom_llm_provider, status_code, provider_message, expected_exception
+):
+    """Branches that classify a Bedrock error by its text must keep x-amzn-RequestId (LIT-5428)."""
+    provider_response = httpx.Response(
+        status_code=status_code,
+        headers={"x-amzn-RequestId": "req-classified"},
+        text=provider_message,
+        request=httpx.Request("POST", "https://bedrock-runtime.us-east-1.amazonaws.com/"),
+    )
+    original_exception = BedrockError(
+        status_code=status_code,
+        message=provider_message,
+        headers=provider_response.headers,
+        response=provider_response,
+    )
+
+    with pytest.raises(expected_exception) as exc_info:
+        exception_type(
+            model="anthropic.claude-haiku-4-5-20251001-v1:0",
+            original_exception=original_exception,
+            custom_llm_provider=custom_llm_provider,
+            completion_kwargs={},
+            extra_kwargs={},
+        )
+
+    assert exc_info.value.response.headers["x-amzn-requestid"] == "req-classified"

--- a/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
@@ -1338,3 +1338,44 @@ def test_bedrock_classified_errors_preserve_provider_response_headers(
         )
 
     assert exc_info.value.response.headers["x-amzn-requestid"] == "req-classified"
+
+
+@pytest.mark.parametrize(
+    "status_code, provider_message",
+    [
+        (504, '{"message":"Gateway timeout"}'),
+        (408, '{"message":"Bedrock did not answer in time"}'),
+        (408, '{"message":"Connect timeout on endpoint URL"}'),
+    ],
+)
+def test_bedrock_timeout_mapping_preserves_provider_headers(status_code, provider_message):
+    """Timeout takes no response argument, so the headers have to ride on the exception itself.
+
+    The proxy reads e.headers before e.response.headers, so they arrive already
+    llm_provider-prefixed rather than as raw upstream names.
+    """
+    provider_response = httpx.Response(
+        status_code=status_code,
+        headers={"x-amzn-RequestId": "req-timeout", "set-cookie": "session=attacker"},
+        text=provider_message,
+        request=httpx.Request("POST", "https://bedrock-runtime.us-east-1.amazonaws.com/"),
+    )
+    original_exception = BedrockError(
+        status_code=status_code,
+        message=provider_message,
+        headers=provider_response.headers,
+        response=provider_response,
+    )
+
+    with pytest.raises(litellm.Timeout) as exc_info:
+        exception_type(
+            model="anthropic.claude-haiku-4-5-20251001-v1:0",
+            original_exception=original_exception,
+            custom_llm_provider="bedrock",
+            completion_kwargs={},
+            extra_kwargs={},
+        )
+
+    headers = exc_info.value.headers or {}
+    assert headers["llm_provider-x-amzn-requestid"] == "req-timeout"
+    assert "set-cookie" not in headers

--- a/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
@@ -9,6 +9,7 @@ import litellm
 from litellm.litellm_core_utils.exception_mapping_utils import (
     ExceptionCheckers,
     _get_body_error_code,
+    _get_response_headers,
     exception_type,
     extract_and_raise_litellm_exception,
 )
@@ -1349,10 +1350,10 @@ def test_bedrock_classified_errors_preserve_provider_response_headers(
     ],
 )
 def test_bedrock_timeout_mapping_preserves_provider_headers(status_code, provider_message):
-    """Timeout takes no response argument, so the headers have to ride on the exception itself.
+    """A mapped bedrock timeout keeps the upstream response, like every other mapped bedrock error.
 
-    The proxy reads e.headers before e.response.headers, so they arrive already
-    llm_provider-prefixed rather than as raw upstream names.
+    The proxy prefixes those headers on the way out, while retry and cooldown
+    logic still reads the raw retry-after off the response.
     """
     provider_response = httpx.Response(
         status_code=status_code,
@@ -1376,6 +1377,35 @@ def test_bedrock_timeout_mapping_preserves_provider_headers(status_code, provide
             extra_kwargs={},
         )
 
-    headers = exc_info.value.headers or {}
-    assert headers["llm_provider-x-amzn-requestid"] == "req-timeout"
-    assert "set-cookie" not in headers
+    assert exc_info.value.response.headers["x-amzn-requestid"] == "req-timeout"
+    assert exc_info.value.headers is None
+
+
+@pytest.mark.parametrize("status_code", [504, 408])
+def test_bedrock_timeout_mapping_keeps_retry_after_readable(status_code):
+    """Cooldown and retry timing read retry-after through _get_response_headers."""
+    provider_response = httpx.Response(
+        status_code=status_code,
+        headers={"x-amzn-RequestId": "req-retry-after", "retry-after": "7"},
+        text='{"message":"Bedrock did not answer in time"}',
+        request=httpx.Request("POST", "https://bedrock-runtime.us-east-1.amazonaws.com/"),
+    )
+    original_exception = BedrockError(
+        status_code=status_code,
+        message='{"message":"Bedrock did not answer in time"}',
+        headers=provider_response.headers,
+        response=provider_response,
+    )
+
+    with pytest.raises(litellm.Timeout) as exc_info:
+        exception_type(
+            model="anthropic.claude-haiku-4-5-20251001-v1:0",
+            original_exception=original_exception,
+            custom_llm_provider="bedrock",
+            completion_kwargs={},
+            extra_kwargs={},
+        )
+
+    exception_headers = _get_response_headers(original_exception=exc_info.value)
+    assert exception_headers is not None
+    assert litellm.utils._get_retry_after_from_exception_header(response_headers=exception_headers) == 7

--- a/tests/test_litellm/llms/bedrock/chat/invoke_transformations/test_base_invoke_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/invoke_transformations/test_base_invoke_transformation.py
@@ -177,3 +177,16 @@ def test_guardrail_config_flows_to_headers_not_request_body(model):
     assert headers["X-Amzn-Bedrock-GuardrailIdentifier"] == "ff6ujrregl1q"
     assert headers["X-Amzn-Bedrock-GuardrailVersion"] == "DRAFT"
     assert headers["X-Amzn-Bedrock-Trace"] == "DISABLED"
+
+
+def test_get_error_class_preserves_provider_headers():
+    """The invoke handler path hands real provider headers to get_error_class (LIT-5428)."""
+    error = AmazonInvokeConfig().get_error_class(
+        error_message="Amazon Bedrock is unable to process your request.",
+        status_code=500,
+        headers={"x-amzn-RequestId": "req-invoke-500"},
+    )
+
+    assert isinstance(error, BedrockError)
+    assert error.headers == {"x-amzn-RequestId": "req-invoke-500"}
+    assert error.response.headers["x-amzn-requestid"] == "req-invoke-500"

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import os
 
+import httpx
 import pytest
 from fastapi.testclient import TestClient
 
@@ -6039,6 +6040,8 @@ def test_transform_response_does_not_leak_body_on_parse_failure():
     leaky_body = {"output": {"message": {"content": [{"text": "secret content"}]}}}
 
     class MockResponse:
+        headers = httpx.Headers({"x-amzn-RequestId": "req-parse-failure"})
+
         def json(self):
             return leaky_body
 
@@ -6067,6 +6070,7 @@ def test_transform_response_does_not_leak_body_on_parse_failure():
     msg = str(exc_info.value)
     assert "secret content" not in msg
     assert "Error converting to valid response block" in msg
+    assert exc_info.value.response.headers["x-amzn-requestid"] == "req-parse-failure"
 
 
 def test_converse_drops_sampling_params_for_models_that_removed_them():

--- a/tests/test_litellm/llms/bedrock/chat/test_invoke_handler.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_invoke_handler.py
@@ -496,3 +496,130 @@ async def test_async_invoke_streaming_forwards_bedrock_response_headers():
 
     assert stream._hidden_params["additional_headers"]["llm_provider-x-amzn-requestid"] == "req-987"
 
+
+def _bedrock_stream_error_response(status_code: int, request_id: str) -> httpx.Response:
+    return httpx.Response(
+        status_code=status_code,
+        headers={
+            "x-amzn-RequestId": request_id,
+            "x-amzn-ErrorType": "InternalServerException",
+        },
+        text='{"message":"Amazon Bedrock is unable to process your request."}',
+        request=httpx.Request("POST", "https://bedrock-runtime.us-east-1.amazonaws.com/"),
+    )
+
+
+def test_invoke_streaming_error_forwards_bedrock_response_headers():
+    error_response = _bedrock_stream_error_response(500, "req-stream-err-1")
+    client = HTTPHandler()
+    client.post = MagicMock(
+        side_effect=httpx.HTTPStatusError(
+            "server error",
+            request=error_response.request,
+            response=error_response,
+        )
+    )
+
+    with pytest.raises(litellm.ServiceUnavailableError) as exc_info:
+        litellm.completion(
+            model="bedrock/invoke/anthropic.claude-haiku-4-5-20251001-v1:0",
+            messages=[{"role": "user", "content": "hi"}],
+            stream=True,
+            client=client,
+            aws_access_key_id="fake",
+            aws_secret_access_key="fake",
+            aws_region_name="us-east-1",
+        )
+
+    assert exc_info.value.response.headers["x-amzn-requestid"] == "req-stream-err-1"
+
+
+@pytest.mark.asyncio
+async def test_async_invoke_streaming_error_forwards_bedrock_response_headers():
+    error_response = _bedrock_stream_error_response(500, "req-stream-err-2")
+    client = AsyncHTTPHandler()
+    client.post = AsyncMock(
+        side_effect=httpx.HTTPStatusError(
+            "server error",
+            request=error_response.request,
+            response=error_response,
+        )
+    )
+
+    with pytest.raises(litellm.ServiceUnavailableError) as exc_info:
+        await litellm.acompletion(
+            model="bedrock/invoke/anthropic.claude-haiku-4-5-20251001-v1:0",
+            messages=[{"role": "user", "content": "hi"}],
+            stream=True,
+            client=client,
+            aws_access_key_id="fake",
+            aws_secret_access_key="fake",
+            aws_region_name="us-east-1",
+        )
+
+    assert exc_info.value.response.headers["x-amzn-requestid"] == "req-stream-err-2"
+
+
+def _unread_bedrock_stream_error_response(status_code: int, request_id: str) -> httpx.Response:
+    return httpx.Response(
+        status_code=status_code,
+        headers={
+            "x-amzn-RequestId": request_id,
+            "x-amzn-ErrorType": "InternalServerException",
+        },
+        stream=httpx.ByteStream(b'{"message":"Amazon Bedrock is unable to process your request."}'),
+        request=httpx.Request("POST", "https://bedrock-runtime.us-east-1.amazonaws.com/"),
+    )
+
+
+def test_invoke_streaming_error_forwards_headers_when_body_was_never_read():
+    """A retried streamed request raises HTTPStatusError over a body nobody read, so
+    reading it for the error message throws and loses the request id (LIT-5428)."""
+    error_response = _unread_bedrock_stream_error_response(500, "req-unread-sync")
+    client = HTTPHandler()
+    client.post = MagicMock(
+        side_effect=httpx.HTTPStatusError(
+            "server error",
+            request=error_response.request,
+            response=error_response,
+        )
+    )
+
+    with pytest.raises(litellm.ServiceUnavailableError) as exc_info:
+        litellm.completion(
+            model="bedrock/invoke/anthropic.claude-haiku-4-5-20251001-v1:0",
+            messages=[{"role": "user", "content": "hi"}],
+            stream=True,
+            client=client,
+            aws_access_key_id="fake",
+            aws_secret_access_key="fake",
+            aws_region_name="us-east-1",
+        )
+
+    assert exc_info.value.response.headers["x-amzn-requestid"] == "req-unread-sync"
+
+
+@pytest.mark.asyncio
+async def test_async_invoke_streaming_error_forwards_headers_when_body_was_never_read():
+    error_response = _unread_bedrock_stream_error_response(500, "req-unread-async")
+    client = AsyncHTTPHandler()
+    client.post = AsyncMock(
+        side_effect=httpx.HTTPStatusError(
+            "server error",
+            request=error_response.request,
+            response=error_response,
+        )
+    )
+
+    with pytest.raises(litellm.ServiceUnavailableError) as exc_info:
+        await litellm.acompletion(
+            model="bedrock/invoke/anthropic.claude-haiku-4-5-20251001-v1:0",
+            messages=[{"role": "user", "content": "hi"}],
+            stream=True,
+            client=client,
+            aws_access_key_id="fake",
+            aws_secret_access_key="fake",
+            aws_region_name="us-east-1",
+        )
+
+    assert exc_info.value.response.headers["x-amzn-requestid"] == "req-unread-async"

--- a/tests/test_litellm/llms/bedrock/chat/test_invoke_handler.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_invoke_handler.py
@@ -623,3 +623,44 @@ async def test_async_invoke_streaming_error_forwards_headers_when_body_was_never
         )
 
     assert exc_info.value.response.headers["x-amzn-requestid"] == "req-unread-async"
+
+
+def test_invoke_streaming_non_200_forwards_bedrock_response_headers():
+    """A caller-supplied client that returns a failure instead of raising still reaches the
+    provider's headers, and reading the streamed body for the message must not throw (LIT-5428)."""
+    error_response = _unread_bedrock_stream_error_response(500, "req-non200-sync")
+    client = HTTPHandler()
+    client.post = MagicMock(return_value=error_response)
+
+    with pytest.raises(litellm.ServiceUnavailableError) as exc_info:
+        litellm.completion(
+            model="bedrock/invoke/anthropic.claude-haiku-4-5-20251001-v1:0",
+            messages=[{"role": "user", "content": "hi"}],
+            stream=True,
+            client=client,
+            aws_access_key_id="fake",
+            aws_secret_access_key="fake",
+            aws_region_name="us-east-1",
+        )
+
+    assert exc_info.value.response.headers["x-amzn-requestid"] == "req-non200-sync"
+
+
+@pytest.mark.asyncio
+async def test_async_invoke_streaming_non_200_forwards_bedrock_response_headers():
+    error_response = _unread_bedrock_stream_error_response(500, "req-non200-async")
+    client = AsyncHTTPHandler()
+    client.post = AsyncMock(return_value=error_response)
+
+    with pytest.raises(litellm.ServiceUnavailableError) as exc_info:
+        await litellm.acompletion(
+            model="bedrock/invoke/anthropic.claude-haiku-4-5-20251001-v1:0",
+            messages=[{"role": "user", "content": "hi"}],
+            stream=True,
+            client=client,
+            aws_access_key_id="fake",
+            aws_secret_access_key="fake",
+            aws_region_name="us-east-1",
+        )
+
+    assert exc_info.value.response.headers["x-amzn-requestid"] == "req-non200-async"

--- a/tests/test_litellm/llms/bedrock/test_bedrock_common_utils.py
+++ b/tests/test_litellm/llms/bedrock/test_bedrock_common_utils.py
@@ -614,3 +614,110 @@ def test_sign_aws_request_assumes_role_with_external_id(monkeypatch):
     authorization = {key.lower(): value for key, value in signed_headers.items()}["authorization"]
     assert "ASIABATCHSIGNROLE" in authorization
     assert signed_data == b'{"jobName": "litellm-batch-job"}'
+
+
+# --------------------------------------------------------------------------- #
+# Provider error headers (LIT-5428)                                            #
+# --------------------------------------------------------------------------- #
+
+
+def _bedrock_chat_error_configs():
+    from litellm.llms.bedrock.chat.agentcore.transformation import AmazonAgentCoreConfig
+    from litellm.llms.bedrock.chat.converse_transformation import AmazonConverseConfig
+    from litellm.llms.bedrock.chat.invoke_agent.transformation import AmazonInvokeAgentConfig
+    from litellm.llms.bedrock.chat.invoke_transformations.amazon_moonshot_transformation import (
+        AmazonMoonshotConfig,
+    )
+    from litellm.llms.bedrock.chat.invoke_transformations.amazon_openai_transformation import (
+        AmazonBedrockOpenAIConfig,
+    )
+    from litellm.llms.bedrock.chat.invoke_transformations.base_invoke_transformation import (
+        AmazonInvokeConfig,
+    )
+
+    return [
+        AmazonInvokeConfig,
+        AmazonConverseConfig,
+        AmazonMoonshotConfig,
+        AmazonBedrockOpenAIConfig,
+        AmazonAgentCoreConfig,
+        AmazonInvokeAgentConfig,
+    ]
+
+
+@pytest.mark.parametrize("config", _bedrock_chat_error_configs())
+def test_bedrock_chat_get_error_class_keeps_provider_headers(config):
+    """Every Bedrock chat route must carry x-amzn-RequestId out to the caller (LIT-5428).
+
+    A config that drops the headers it is handed shadows the fix for its own models.
+    """
+    error = config().get_error_class(
+        error_message="Amazon Bedrock is unable to process your request.",
+        status_code=500,
+        headers={"x-amzn-RequestId": "req-chat-500"},
+    )
+
+    assert error.response.headers["x-amzn-requestid"] == "req-chat-500"
+
+
+def test_error_response_text_reads_a_read_response():
+    import httpx
+
+    from litellm.llms.bedrock.common_utils import error_response_text
+
+    response = httpx.Response(status_code=500, text="Amazon Bedrock is unable to process your request.")
+
+    assert error_response_text(response) == "Amazon Bedrock is unable to process your request."
+
+
+def test_error_response_text_falls_back_when_a_streamed_response_was_never_read():
+    """A retried streamed request raises HTTPStatusError over an unread body; reading it
+    throws ResponseNotRead and would lose the status and headers this fix preserves."""
+    import httpx
+
+    from litellm.llms.bedrock.common_utils import error_response_text
+
+    request = httpx.Request(method="POST", url="https://bedrock-runtime.amazonaws.com")
+    response = httpx.Response(
+        status_code=500,
+        headers={"x-amzn-RequestId": "req-unread-500"},
+        stream=httpx.ByteStream(b"never read"),
+        request=request,
+    )
+
+    with pytest.raises(httpx.ResponseNotRead):
+        _ = response.text
+
+    assert error_response_text(response) == "Internal Server Error"
+
+
+def test_bedrock_error_skips_header_values_httpx_cannot_carry():
+    """The shared HTTP handler copies an arbitrary exception's header values in verbatim,
+    so a non-str value must not take down the whole error (LIT-5428)."""
+    import httpx
+
+    from litellm.llms.bedrock.common_utils import BedrockError
+
+    error = BedrockError(
+        status_code=500,
+        message="boom",
+        headers={"x-amzn-RequestId": "req-mixed-500", "x-retry-count": 3, "x-nothing": None},
+    )
+
+    assert error.response.headers["x-amzn-requestid"] == "req-mixed-500"
+    assert "x-retry-count" not in error.response.headers
+    assert isinstance(error.response, httpx.Response)
+
+
+def test_bedrock_error_keeps_duplicate_httpx_header_values():
+    import httpx
+
+    from litellm.llms.bedrock.common_utils import BedrockError
+
+    error = BedrockError(
+        status_code=500,
+        message="boom",
+        headers=httpx.Headers([("x-amzn-RequestId", "req-dup-500"), ("set-cookie", "a=1"), ("set-cookie", "b=2")]),
+    )
+
+    assert error.response.headers.get_list("set-cookie") == ["a=1", "b=2"]

--- a/tests/test_litellm/llms/bedrock/test_bedrock_common_utils.py
+++ b/tests/test_litellm/llms/bedrock/test_bedrock_common_utils.py
@@ -821,3 +821,53 @@ def test_bedrock_mantle_get_error_class_keeps_provider_headers(config):
     )
 
     assert error.response.headers["x-amzn-requestid"] == "req-mantle-400"
+
+
+def _bedrock_configs_with_get_error_class():
+    import importlib
+    import inspect
+    import pathlib
+
+    import litellm
+
+    llms_root = pathlib.Path(inspect.getfile(litellm)).parent / "llms"
+    configs = []
+    for package in ("bedrock", "bedrock_mantle"):
+        for path in sorted((llms_root / package).rglob("*.py")):
+            module_name = "litellm.llms." + ".".join(path.relative_to(llms_root).with_suffix("").parts)
+            module = importlib.import_module(module_name)
+            for name, obj in vars(module).items():
+                if not inspect.isclass(obj) or obj.__module__ != module_name:
+                    continue
+                if getattr(obj, "get_error_class", None) is None:
+                    continue
+                configs.append(pytest.param(obj, id=f"{module_name}.{name}"))
+    return configs
+
+
+@pytest.mark.parametrize("config", _bedrock_configs_with_get_error_class())
+def test_every_bedrock_config_get_error_class_keeps_provider_headers(config):
+    """Every bedrock surface must classify errors through BedrockError, not a header-dropping base.
+
+    A config that inherits get_error_class from a provider-agnostic base builds a blank
+    response, so the request id is gone before the proxy ever reads it.
+    """
+    try:
+        instance = config()
+    except Exception:
+        instance = config.__new__(config)
+
+    try:
+        error = instance.get_error_class(
+            error_message="boom",
+            status_code=500,
+            headers={"x-amzn-RequestId": "req-audit-500"},
+        )
+    except Exception as raised:  # some bases raise the exception instead of returning it
+        error = raised
+
+    assert error.response.headers["x-amzn-requestid"] == "req-audit-500"
+
+
+def test_bedrock_get_error_class_audit_covers_every_surface():
+    assert len(_bedrock_configs_with_get_error_class()) >= 30

--- a/tests/test_litellm/llms/bedrock/test_bedrock_common_utils.py
+++ b/tests/test_litellm/llms/bedrock/test_bedrock_common_utils.py
@@ -721,3 +721,103 @@ def test_bedrock_error_keeps_duplicate_httpx_header_values():
     )
 
     assert error.response.headers.get_list("set-cookie") == ["a=1", "b=2"]
+
+
+def _bedrock_httpx_status_error_sites():
+    """Every `except httpx.HTTPStatusError as err` that raises a BedrockError, across bedrock."""
+    import ast
+    import pathlib
+
+    sites = []
+    for path in sorted(pathlib.Path("litellm/llms/bedrock").rglob("*.py")):
+        tree = ast.parse(path.read_text())
+        for handler in (n for n in ast.walk(tree) if isinstance(n, ast.ExceptHandler)):
+            caught = ast.unparse(handler.type) if handler.type is not None else ""
+            if "HTTPStatusError" not in caught or handler.name is None:
+                continue
+            for call in (
+                n
+                for n in ast.walk(handler)
+                if isinstance(n, ast.Call) and isinstance(n.func, ast.Name) and n.func.id == "BedrockError"
+            ):
+                sites.append((str(path), call.lineno, handler.name, {k.arg for k in call.keywords}))
+    return sites
+
+
+def test_every_bedrock_httpx_status_error_site_keeps_provider_headers():
+    """A raise site holding the provider's failed response must hand its headers on (LIT-5428).
+
+    These sites are the only place x-amzn-RequestId still exists; a site that drops it
+    silently shadows the fix for that whole surface.
+    """
+    sites = _bedrock_httpx_status_error_sites()
+
+    assert len(sites) >= 12
+    dropped = [f"{path}:{lineno}" for path, lineno, _, kwargs in sites if "headers" not in kwargs]
+    assert dropped == []
+
+
+@pytest.mark.parametrize("is_async", [False, True])
+@pytest.mark.asyncio
+async def test_bedrock_embedding_call_keeps_provider_headers(is_async):
+    """The embeddings surface raises from the same shape as chat and lost the same header."""
+    import httpx
+
+    from litellm.llms.bedrock.common_utils import BedrockError
+    from litellm.llms.bedrock.embed.embedding import BedrockEmbedding
+    from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler, HTTPHandler
+
+    failure = httpx.Response(
+        status_code=500,
+        headers={"x-amzn-RequestId": "req-embed-500"},
+        text='{"message":"Amazon Bedrock is unable to process your request."}',
+        request=httpx.Request("POST", "https://bedrock-runtime.us-east-1.amazonaws.com/"),
+    )
+
+    class _SyncUpstream(HTTPHandler):
+        def post(self, *args, **kwargs):
+            return failure
+
+    class _AsyncUpstream(AsyncHTTPHandler):
+        async def post(self, *args, **kwargs):
+            return failure
+
+    async def _drive():
+        embedding = BedrockEmbedding()
+        kwargs = dict(
+            timeout=None,
+            api_base="https://bedrock-runtime.us-east-1.amazonaws.com/",
+            headers={},
+            data={},
+        )
+        if is_async:
+            return await embedding._make_async_call(client=_AsyncUpstream(), **kwargs)
+        return embedding._make_sync_call(client=_SyncUpstream(), **kwargs)
+
+    with pytest.raises(BedrockError) as exc_info:
+        await _drive()
+
+    assert exc_info.value.response.headers["x-amzn-requestid"] == "req-embed-500"
+
+
+def _bedrock_mantle_error_configs():
+    from litellm.llms.bedrock_mantle.chat.transformation import BedrockMantleChatConfig
+    from litellm.llms.bedrock_mantle.responses.transformation import BedrockMantleResponsesAPIConfig
+
+    return [BedrockMantleChatConfig, BedrockMantleResponsesAPIConfig]
+
+
+@pytest.mark.parametrize("config", _bedrock_mantle_error_configs())
+def test_bedrock_mantle_get_error_class_keeps_provider_headers(config):
+    """bedrock_mantle rides the OpenAI-compatible surfaces, whose errors drop the headers.
+
+    A chat request for a responses-API model is bridged onto the responses config, so
+    fixing only the chat one leaves the model the customer actually calls uncovered.
+    """
+    error = config().get_error_class(
+        error_message="prompt tokens exceed model maximum",
+        status_code=400,
+        headers={"x-amzn-RequestId": "req-mantle-400"},
+    )
+
+    assert error.response.headers["x-amzn-requestid"] == "req-mantle-400"

--- a/tests/test_litellm/llms/chat/test_converse_handler.py
+++ b/tests/test_litellm/llms/chat/test_converse_handler.py
@@ -308,3 +308,64 @@ def test_completion_plumbs_stream_chunk_size_through_converse():
         stream_chunk_size=2048,
     )
     iter_bytes_spy.assert_called_once_with(chunk_size=2048)
+
+
+def _bedrock_error_response(status_code: int, request_id: str) -> httpx.Response:
+    return httpx.Response(
+        status_code=status_code,
+        headers={
+            "x-amzn-RequestId": request_id,
+            "x-amzn-ErrorType": "InternalServerException",
+        },
+        text=json.dumps({"message": "Amazon Bedrock is unable to process your request."}),
+        request=httpx.Request("POST", "https://bedrock-runtime.us-east-1.amazonaws.com/"),
+    )
+
+
+def test_converse_completion_error_forwards_bedrock_response_headers():
+    error_response = _bedrock_error_response(500, "req-err-123")
+    client = HTTPHandler()
+    client.post = MagicMock(
+        side_effect=httpx.HTTPStatusError(
+            "server error",
+            request=error_response.request,
+            response=error_response,
+        )
+    )
+
+    with pytest.raises(litellm.ServiceUnavailableError) as exc_info:
+        litellm.completion(
+            model="bedrock/converse/anthropic.claude-haiku-4-5-20251001-v1:0",
+            messages=[{"role": "user", "content": "hi"}],
+            client=client,
+            aws_access_key_id="fake",
+            aws_secret_access_key="fake",
+            aws_region_name="us-east-1",
+        )
+
+    assert exc_info.value.response.headers["x-amzn-requestid"] == "req-err-123"
+
+
+@pytest.mark.asyncio
+async def test_async_converse_completion_error_forwards_bedrock_response_headers():
+    error_response = _bedrock_error_response(500, "req-err-456")
+    client = AsyncHTTPHandler()
+    client.post = AsyncMock(
+        side_effect=httpx.HTTPStatusError(
+            "server error",
+            request=error_response.request,
+            response=error_response,
+        )
+    )
+
+    with pytest.raises(litellm.ServiceUnavailableError) as exc_info:
+        await litellm.acompletion(
+            model="bedrock/converse/anthropic.claude-haiku-4-5-20251001-v1:0",
+            messages=[{"role": "user", "content": "hi"}],
+            client=client,
+            aws_access_key_id="fake",
+            aws_secret_access_key="fake",
+            aws_region_name="us-east-1",
+        )
+
+    assert exc_info.value.response.headers["x-amzn-requestid"] == "req-err-456"

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
@@ -5225,7 +5225,7 @@ async def test_bedrock_count_tokens_error_forwards_provider_headers():
         headers={"x-amzn-RequestId": "req-count-tokens-500"},
     )
 
-    with patch(
+    with patch(  # test-quality-ok: the route's BedrockError branch is only reachable when the handler raises
         "litellm.llms.bedrock.count_tokens.handler.BedrockCountTokensHandler.handle_count_tokens_request",
         new=AsyncMock(side_effect=failure),
     ):

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
@@ -5206,3 +5206,37 @@ class TestAzureRouterModelStreamingKeepalive:
 
         assert result.headers["x-upstream"] == "kept"
         assert chunks == [b"data: hello\n\n"]
+
+
+@pytest.mark.asyncio
+async def test_bedrock_count_tokens_error_forwards_provider_headers():
+    """The count tokens route converts BedrockError into an HTTPException, and dropping the
+    headers there loses x-amzn-RequestId after the handler went to the trouble of keeping it."""
+    from fastapi import HTTPException
+
+    from litellm.llms.bedrock.common_utils import BedrockError
+    from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
+        handle_bedrock_count_tokens,
+    )
+
+    failure = BedrockError(
+        status_code=500,
+        message="Amazon Bedrock is unable to process your request.",
+        headers={"x-amzn-RequestId": "req-count-tokens-500"},
+    )
+
+    with patch(
+        "litellm.llms.bedrock.count_tokens.handler.BedrockCountTokensHandler.handle_count_tokens_request",
+        new=AsyncMock(side_effect=failure),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await handle_bedrock_count_tokens(
+                endpoint="v1/messages/count_tokens",
+                request=MagicMock(),
+                fastapi_response=MagicMock(),
+                user_api_key_dict=MagicMock(),
+                request_body={"model": "anthropic.claude-haiku-4-5-20251001-v1:0"},
+            )
+
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.headers["llm_provider-x-amzn-requestid"] == "req-count-tokens-500"

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -8259,3 +8259,38 @@ class TestPassthroughHeadersAcceptImmutableMappings:
         assert merged["content-type"] == "text/event-stream"
         # the excluded hop-by-hop header is still dropped
         assert "transfer-encoding" not in merged
+
+
+@pytest.mark.asyncio
+async def test_handle_llm_api_exception_forwards_provider_headers_on_http_status_error():
+    """The httpx.HTTPStatusError branch dropped the headers its sibling branches forward.
+
+    A Bedrock passthrough failure reaches this branch, so the request id was gone
+    before the client saw the response.
+    """
+    import httpx
+
+    from litellm.proxy._types import UserAPIKeyAuth
+
+    request = httpx.Request("POST", "https://bedrock-runtime.us-east-1.amazonaws.com/model/m/converse")
+    response = httpx.Response(
+        status_code=500,
+        headers={"x-amzn-RequestId": "req-passthrough-500"},
+        content=b'{"message": "Amazon Bedrock is unable to process your request."}',
+        request=request,
+    )
+
+    processor = ProxyBaseLLMRequestProcessing(data={})
+    proxy_logging_obj = MagicMock()
+    proxy_logging_obj.post_call_failure_hook = AsyncMock(return_value=None)
+    proxy_logging_obj.post_call_response_headers_hook = AsyncMock(return_value={})
+
+    with pytest.raises(HTTPException) as exc_info:
+        await processor._handle_llm_api_exception(
+            e=httpx.HTTPStatusError("boom", request=request, response=response),
+            user_api_key_dict=UserAPIKeyAuth(api_key="sk-test"),
+            proxy_logging_obj=proxy_logging_obj,
+        )
+
+    assert exc_info.value.headers is not None
+    assert exc_info.value.headers["llm_provider-x-amzn-requestid"] == "req-passthrough-500"

--- a/tests/test_litellm/test_exception_header_preservation.py
+++ b/tests/test_litellm/test_exception_header_preservation.py
@@ -18,6 +18,7 @@ from litellm.exceptions import (
     ImageFetchError,
     MidStreamFallbackError,
     RateLimitError,
+    ServiceUnavailableError,
 )
 
 
@@ -312,3 +313,85 @@ class TestProxyHeaderExtraction:
         # Verify headers are extracted and prefixed correctly
         assert headers.get("llm_provider-x-request-id") == "req-abc123"
         assert headers.get("llm_provider-x-ms-region") == "eastus"
+
+
+class TestBedrockErrorHeaders:
+    """A BedrockError built with headers but no response still exposes them (LIT-5428)."""
+
+    def test_synthesized_response_carries_headers(self):
+        from litellm.llms.bedrock.common_utils import BedrockError
+
+        error = BedrockError(
+            status_code=500,
+            message="Amazon Bedrock is unable to process your request.",
+            headers={"x-amzn-RequestId": "req-base-500"},
+        )
+
+        assert error.response.headers["x-amzn-requestid"] == "req-base-500"
+        assert str(error.request.url) == str(BedrockError(status_code=500, message="boom").request.url)
+        assert str(error.response.request.url) == str(error.request.url)
+
+    def test_synthesized_response_without_headers_stays_empty(self):
+        from litellm.llms.bedrock.common_utils import BedrockError
+
+        error = BedrockError(status_code=500, message="boom")
+
+        assert dict(error.response.headers) == {}
+
+    def test_explicit_response_is_kept(self):
+        from litellm.llms.bedrock.common_utils import BedrockError
+
+        provider_response = httpx.Response(
+            status_code=500,
+            headers={"x-amzn-RequestId": "from-response"},
+            request=httpx.Request("POST", "https://bedrock-runtime.us-east-1.amazonaws.com/"),
+        )
+        error = BedrockError(
+            status_code=500,
+            message="boom",
+            headers={"x-amzn-RequestId": "from-headers"},
+            response=provider_response,
+        )
+
+        assert error.response is provider_response
+
+    def test_proxy_extraction_surfaces_bedrock_request_id(self):
+        """End-to-end shape the proxy error handler returns to the caller."""
+        from litellm.litellm_core_utils.exception_mapping_utils import exception_type
+        from litellm.litellm_core_utils.llm_response_utils.get_headers import (
+            get_response_headers,
+        )
+        from litellm.llms.bedrock.common_utils import BedrockError
+
+        provider_response = httpx.Response(
+            status_code=500,
+            headers={"x-amzn-RequestId": "req-proxy-500"},
+            text='{"message":"Amazon Bedrock is unable to process your request."}',
+            request=httpx.Request("POST", "https://bedrock-runtime.us-east-1.amazonaws.com/"),
+        )
+
+        with pytest.raises(ServiceUnavailableError) as exc_info:
+            exception_type(
+                model="anthropic.claude-haiku-4-5-20251001-v1:0",
+                original_exception=BedrockError(
+                    status_code=500,
+                    message=provider_response.text,
+                    headers=provider_response.headers,
+                    response=provider_response,
+                ),
+                custom_llm_provider="bedrock",
+                completion_kwargs={},
+                extra_kwargs={},
+            )
+
+        # Mirrors ProxyBaseLLMRequestProcessing._handle_llm_api_exception
+        error = exc_info.value
+        headers = getattr(error, "headers", None) or {}
+        if not headers:
+            _response = getattr(error, "response", None)
+            if _response is not None:
+                _response_headers = getattr(_response, "headers", None)
+                if _response_headers:
+                    headers = get_response_headers(dict(_response_headers))
+
+        assert headers.get("llm_provider-x-amzn-requestid") == "req-proxy-500"


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bedrock chat errors dropped the provider's response headers
- AWS support needs `x-amzn-RequestId` to look into a failure
- Callers had no way to get it from the response, logs or callbacks

How it solves it:

- Bedrock chat handlers keep the real headers on the error
- Every bedrock `get_error_class` forwards the headers it gets
- `BedrockError` carries them into the response it synthesizes
- The Bedrock 500 mapping stops fabricating a blank response
- So do the two context window branches and the image branch
- And every other bedrock raise site that holds the failed response

## User Flow

Before: a developer whose Bedrock call fails cannot tell AWS support which request failed

1. They send POST https://litellm-domain/v1/chat/completions with a Bedrock model
2. Bedrock fails and the proxy answers 503 with `litellm.ServiceUnavailableError: BedrockException - {"message": "Amazon Bedrock is unable to process your request."}`
3. They read every response header and find no request id
4. They open an AWS support case, get asked for the request id, and have nothing to give

After: the same failure hands back the request id AWS asks for

1. They send the same POST https://litellm-domain/v1/chat/completions with a Bedrock model
2. Bedrock fails and the proxy still answers 503 with the same error body
3. The response now carries `llm_provider-x-amzn-requestid: stub-c9183be6-...` and `llm_provider-x-amzn-errortype: InternalServerException`
4. They paste that request id straight into the AWS support case

## Relevant issues

## Linear ticket

Resolves LIT-5428

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Two proxies on the same Postgres, one at the merge base and one at this PR's tip, same config, same requests. Real AWS Bedrock supplies the 404s and the successes. AWS will not return a 500 on demand, so the server-error case uses a stub Bedrock runtime that answers a real AWS-shaped 5xx with `x-amzn-RequestId`: only the upstream is stubbed, and the proxy, the handlers, SigV4 signing and the HTTP hop are all real.

Shared setup:

```bash
cat > config.yaml <<'YAML'
model_list:
  - model_name: bedrock-404          # converse route, EOL model, real AWS 404
    litellm_params:
      model: bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0
      aws_region_name: us-east-1
  - model_name: invoke-404           # invoke route, real AWS 404
    litellm_params:
      model: bedrock/invoke/anthropic.claude-3-5-sonnet-20241022-v2:0
      aws_region_name: us-east-1
  - model_name: bedrock-500          # converse route at the 5xx stub
    litellm_params:
      model: bedrock/amazon.nova-lite-v1:0
      aws_region_name: us-east-1
      api_base: http://127.0.0.1:20430
  - model_name: invoke-500           # invoke route at the 5xx stub
    litellm_params:
      model: bedrock/invoke/amazon.nova-lite-v1:0
      aws_region_name: us-east-1
      api_base: http://127.0.0.1:20430
  - model_name: nova                 # success control
    litellm_params:
      model: bedrock/amazon.nova-lite-v1:0
      aws_region_name: us-east-1
general_settings:
  master_key: sk-1234
YAML

ask() {   # $1 model, $2 "stream" or empty
  body="{\"model\":\"$1\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],\"max_tokens\":16"
  [ "$2" = stream ] && body="$body,\"stream\":true"
  curl -sS -D - -o /dev/null -X POST "http://127.0.0.1:$PORT/v1/chat/completions" \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d "$body}" \
    | grep -iE '^HTTP/|^llm_provider-x-amzn'
}
```

### Before (168a0055a2)

The branch was later rebased onto `7c1745cc71`; every leg below was re-run against that base with
identical results, so the transcripts keep the SHA they were captured at


#### converse route, real AWS 404

1. `PORT=20429 ask bedrock-404`

```
HTTP/1.1 404 Not Found
```
3. The same call in the Swagger UI at http://localhost:4000/docs, POST /v1/chat/completions, shows the response headers panel: no request id

![before_404](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr40089/pr40089/before_404.png)

2. `PORT=20429 ask bedrock-404 stream`

```
HTTP/1.1 404 Not Found
```

#### invoke route, real AWS 404

1. `PORT=20429 ask invoke-404`

```
HTTP/1.1 404 Not Found
```

2. `PORT=20429 ask invoke-404 stream`

```
HTTP/1.1 404 Not Found
```

#### converse route, server error

1. `PORT=20429 ask bedrock-500`

```
HTTP/1.1 503 Service Unavailable
```
3. The same call in the Swagger UI at http://localhost:4000/docs, POST /v1/chat/completions, shows the response headers panel: no request id

![before_500](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr40089/pr40089/before_500.png)

2. `PORT=20429 ask bedrock-500 stream`

```
HTTP/1.1 503 Service Unavailable
```

#### invoke route, server error

1. `PORT=20429 ask invoke-500`

```
HTTP/1.1 503 Service Unavailable
```
3. The same call in the Swagger UI at http://localhost:4000/docs, POST /v1/chat/completions, shows the response headers panel: no request id

![before_invoke500](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr40089/pr40089/before_invoke500.png)

2. `PORT=20429 ask invoke-500 stream`

```
HTTP/1.1 503 Service Unavailable
```

#### success control, real AWS 200

1. `PORT=20429 ask nova`

```
HTTP/1.1 200 OK
llm_provider-x-amzn-requestid: 6d90c825-f440-4e68-91b2-f6439ac7d632
```

### After (901ea879b2)

#### converse route, real AWS 404

1. `PORT=20428 ask bedrock-404`

```
HTTP/1.1 404 Not Found
llm_provider-x-amzn-requestid: 9f25b8b6-b597-4a68-abc5-e5d5191aa7fe
llm_provider-x-amzn-errortype: ResourceNotFoundException:http://internal.amazon.com/coral/com.amazon.bedrock/
```
3. The same call in the Swagger UI at http://localhost:4000/docs, POST /v1/chat/completions, shows the response headers panel: `llm_provider-x-amzn-requestid` is there

![after_404](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr40089/pr40089/after_404.png)

2. `PORT=20428 ask bedrock-404 stream`

```
HTTP/1.1 404 Not Found
llm_provider-x-amzn-requestid: c1238c94-d32c-4882-b23d-49dd0301907c
llm_provider-x-amzn-errortype: ResourceNotFoundException:http://internal.amazon.com/coral/com.amazon.bedrock/
```

#### invoke route, real AWS 404

1. `PORT=20428 ask invoke-404`

```
HTTP/1.1 404 Not Found
llm_provider-x-amzn-requestid: 6585c3c0-7bd2-4214-938a-2e445d14e120
llm_provider-x-amzn-errortype: ResourceNotFoundException:http://internal.amazon.com/coral/com.amazon.bedrock/
```

2. `PORT=20428 ask invoke-404 stream`

```
HTTP/1.1 404 Not Found
llm_provider-x-amzn-requestid: f9b76f11-f685-4741-81af-d88c57884e8d
llm_provider-x-amzn-errortype: ResourceNotFoundException:http://internal.amazon.com/coral/com.amazon.bedrock/
```

#### converse route, server error

1. `PORT=20428 ask bedrock-500`

```
HTTP/1.1 503 Service Unavailable
llm_provider-x-amzn-requestid: stub-c9183be6-09ca-403b-9f45-2d2b915ea8fa
llm_provider-x-amzn-errortype: InternalServerException:http://internal.amazon.com/coral/com.amazon.coral.service/
```
3. The same call in the Swagger UI at http://localhost:4000/docs, POST /v1/chat/completions, shows the response headers panel: `llm_provider-x-amzn-requestid` is there

![after_500](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr40089/pr40089/after_500.png)

2. `PORT=20428 ask bedrock-500 stream`

```
HTTP/1.1 503 Service Unavailable
llm_provider-x-amzn-requestid: stub-f1e3ac77-fa31-4767-a0ac-9e479fa2762c
llm_provider-x-amzn-errortype: InternalServerException:http://internal.amazon.com/coral/com.amazon.coral.service/
```

#### invoke route, server error

1. `PORT=20428 ask invoke-500`

```
HTTP/1.1 503 Service Unavailable
llm_provider-x-amzn-requestid: stub-74fc9bbf-66dd-4a07-ad96-362742025143
llm_provider-x-amzn-errortype: InternalServerException:http://internal.amazon.com/coral/com.amazon.coral.service/
```
3. The same call in the Swagger UI at http://localhost:4000/docs, POST /v1/chat/completions, shows the response headers panel: `llm_provider-x-amzn-requestid` is there

![after_invoke500](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr40089/pr40089/after_invoke500.png)

2. `PORT=20428 ask invoke-500 stream`

```
HTTP/1.1 503 Service Unavailable
llm_provider-x-amzn-requestid: stub-bca7f20e-f79c-40b1-8e2e-25d3e3d43cc2
llm_provider-x-amzn-errortype: InternalServerException:http://internal.amazon.com/coral/com.amazon.coral.service/
```

#### success control, real AWS 200

1. `PORT=20428 ask nova`

```
HTTP/1.1 200 OK
llm_provider-x-amzn-requestid: 471c1e6e-5f83-4387-97be-158573cbbeb2
```

The four other bedrock chat routes were driven the same way and go from no header to a request id: `bedrock/invoke/moonshot.*`, `bedrock/openai/*`, `bedrock/agentcore/*` (a real AWS 403) and `bedrock/agent/*`

### Errors classified by their body text

Some Bedrock failures are classified by what the body says rather than by the status: a context window
overflow and an image the model could not read. Those branches built the litellm error without the
provider response, so they dropped the request id even after the fix above. A second stub answers a
real AWS-shaped 400 with those bodies and an `x-amzn-RequestId`.

```yaml
  - model_name: bedrock-ctxlen      # stub answers 400 {"message":"Input is too long for requested model."}
    litellm_params:
      model: bedrock/amazon.nova-lite-v1:0
      aws_region_name: us-east-1
      api_base: http://127.0.0.1:20434
  - model_name: bedrock-image       # stub answers 400 {"message":"Could not process image"}
    litellm_params:
      model: bedrock/amazon.nova-lite-v1:0
      aws_region_name: us-east-1
      api_base: http://127.0.0.1:20435
```

#### context window overflow

1. `PORT=20429 ask bedrock-ctxlen` before

```
HTTP/1.1 400 Bad Request
```
2. The same call in the Swagger UI at http://localhost:4000/docs, POST /v1/chat/completions, response headers panel: no request id

![before_ctxlen](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr40089/pr40089/before_ctxlen.png)

3. `PORT=20428 ask bedrock-ctxlen` after

```
HTTP/1.1 400 Bad Request
llm_provider-x-amzn-requestid: stub400-72f5ac38-e1dd-4907-a153-9befeac47eb4
llm_provider-x-amzn-errortype: ValidationException:http://internal.amazon.com/coral/com.amazon.coral.service/
```
4. The same call in the Swagger UI: `llm_provider-x-amzn-requestid` is there

![after_ctxlen](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr40089/pr40089/after_ctxlen.png)

#### image the model could not read

1. `PORT=20429 ask bedrock-image` before

```
HTTP/1.1 500 Internal Server Error
```
2. The same call in the Swagger UI at http://localhost:4000/docs, POST /v1/chat/completions, response headers panel: no request id

![before_image](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr40089/pr40089/before_image.png)

3. `PORT=20428 ask bedrock-image` after

```
HTTP/1.1 500 Internal Server Error
llm_provider-x-amzn-requestid: stub400-89d7906c-0c98-436d-9d4f-05e3878970f1
llm_provider-x-amzn-errortype: ValidationException:http://internal.amazon.com/coral/com.amazon.coral.service/
```
4. The same call in the Swagger UI: `llm_provider-x-amzn-requestid` is there

![after_image](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr40089/pr40089/after_image.png)

The invoke route behaves the same on both cases, and all six router strategies, a four worker proxy
and the sync SDK entrypoints were driven the same way with matching statuses on both sides

### The rest of the bedrock surfaces

The ticket's root cause names every raise site under `litellm/llms/bedrock/`, not only chat. The
same 5xx stub, pointed at the embeddings and OpenAI-surface routes:

#### embeddings

1. `PORT=20429 ask_embed embed-500` before

```
HTTP/1.1 503 Service Unavailable
```
2. The Swagger UI at http://localhost:4000/docs, POST /v1/embeddings, response headers panel: no request id

![before_embed](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr40089/pr40089/before_embed.png)

3. `PORT=20428 ask_embed embed-500` after

```
HTTP/1.1 503 Service Unavailable
llm_provider-x-amzn-requestid: stub-d96ac586-6a20-4c34-a5bb-1c3d7d5bb728
llm_provider-x-amzn-errortype: InternalServerException:http://internal.amazon.com/coral/com.amazon.coral.service/
```
4. The same call in the Swagger UI: `llm_provider-x-amzn-requestid` is there

![after_embed](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr40089/pr40089/after_embed.png)

#### bedrock_mantle

A chat request for a responses-API model is bridged onto the responses config, so both mantle
configs had to stop returning the OpenAI error that drops the headers.

1. `PORT=20429 ask mantle-ctxlen` before

```
HTTP/1.1 400 Bad Request
```
2. The Swagger UI, POST /v1/chat/completions: no request id

![before_mantle](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr40089/pr40089/before_mantle.png)

3. `PORT=20428 ask mantle-ctxlen` after

```
HTTP/1.1 400 Bad Request
llm_provider-x-amzn-requestid: stub400-41b51ce1-f851-4d0a-9586-c9c12f40ad85
```
4. The same call in the Swagger UI: `llm_provider-x-amzn-requestid` is there

![after_mantle](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr40089/pr40089/after_mantle.png)

#### count tokens

1. `curl -i -X POST $BASE/bedrock/model/amazon.nova-lite-v1%3A0/count-tokens -d '{"model":"bedrock-500",...}'` before

```
HTTP/1.1 500 Internal Server Error
```
2. The same call on the fixed proxy

```
HTTP/1.1 500 Internal Server Error
llm_provider-x-amzn-requestid: stub-44a8f91c-af52-4769-83a9-91e5a32b57c5
llm_provider-x-amzn-errortype: InternalServerException:http://internal.amazon.com/coral/com.amazon.coral.service/
```

Rerank, image generation, image edit and search were driven the same way. Their
exceptions carry the request id at the SDK and router level; see the Caveats for the two proxy
routes that still drop it before the client sees it

#### every bedrock config, not only the ones a route reaches

A reflection audit over `litellm/llms/bedrock` and `litellm/llms/bedrock_mantle` found 11 configs
still inheriting a provider-agnostic `get_error_class` that builds a blank response. Claude
platform, bedrock anthropic-messages, both image-edit configs, passthrough, realtime, vector
stores and agentcore search now classify through `BedrockError` as well, so all 36 configs keep
the request id. A parametrized test drives every one of them and fails if a new config skips it

#### gateway timeouts

A bedrock 504 carrying `x-amzn-RequestId`, `Retry-After: 7` and a hostile `Set-Cookie`, driven
base first then head first, single worker and at `--num_workers 4`:

```
bedrock-504  BASE  504  (no request id, no retry-after)
bedrock-504  HEAD  504  llm_provider-x-amzn-requestid: stub504-04d77f96-...
                        llm_provider-retry-after: 7
```

2. The Swagger UI at http://localhost:4000/docs, POST /v1/chat/completions, response headers panel on the unfixed proxy: no request id

![before_504](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr40089/pr40089/before_504.png)

3. The same call on the fixed proxy: `llm_provider-x-amzn-requestid` and `llm_provider-retry-after` are there

![after_504](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr40089/pr40089/after_504.png)

No unprefixed header reaches the client on either side. `Timeout` now takes the provider
response the way every other mapped bedrock exception does, so router cooldown and fallback
cooldown keep reading the raw `retry-after` (measured 7 on both legs) while the proxy prefixes
the headers it returns.

#### claude platform and vector store search

The last two configs that no route in the rig reached, wired into the config and driven:

```
claude-platform-500  BASE 503 no id   HEAD 503 llm_provider-x-amzn-requestid
vector store search  BASE 503 no id   HEAD 503 llm_provider-x-amzn-requestid
```

#### the raise sites a 4xx or 5xx stub cannot reach

Parse and transform failures need an upstream that answers 200 with a body the
transformer cannot use, so they got their own stubs, one returning bytes that are
not JSON and one returning JSON of the wrong shape. A 408 stub and a stability
image-edit alias cover the last two:

```
bedrock-malformed    BASE 422/no   HEAD 422/yes   converse transform, body is not JSON
invoke-malformed     BASE 422/no   HEAD 422/yes   invoke transform, json() raises
bedrock-408          BASE 408/no   HEAD 408/yes   the 408 branch of the bedrock mapper
invoke-408           BASE 408/no   HEAD 408/yes   the same branch, invoke route
agentcore-malformed  BASE 403/no   HEAD 403/yes   agentcore parse-error raise
stability-edit-500   BASE 503/no   HEAD 503/yes   stability image edit get_error_class
```

Three changed sites still deliver no header end to end, each for a reason that
predates this PR:

- the twelvelabs pegasus parse sites raise with the upstream's own 200 status, and the mapper has no 200 branch, so the exception falls through to `APIConnectionError`
- a wrong-shape body escapes as a bare `KeyError` before reaching the guarded raise, which is a separate defect
- the text-classified timeout branch needs botocore's `Connect timeout on endpoint URL` wording, and the aiohttp transport raises a connect error instead, so a real dead endpoint never reaches it

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- A Bedrock `retry-after` now reaches the router
  - with `num_retries` above 0 the retry sleep honors it, so a throttled Bedrock call waits the provider's value instead of exponential backoff (measured median 6.1s before, 23.8s after, on a stub sending `retry-after: 7`)
  - it also sets the deployment cooldown length, and `retry-after: 0` skips the cooldown that used to default to 5s
  - measured through the proxy with `allowed_fails: 0` and a stub sending `retry-after: 20`, running each side first: base recovered in 5.5s and 5.6s, head in 20.0s and 20.2s
  - this is what every other provider already does; Bedrock was the outlier

### Low

- The header set reaching failure callbacks grows
  - `hidden_params.additional_headers` in the standard logging payload went from empty to the provider's headers on Bedrock failures, so Langfuse, OTEL, Datadog, GCS and S3 payloads carry them now
  - success payloads are unchanged, byte for byte
- The bedrock passthrough route gains the header too
  - `_handle_llm_api_exception` forwarded `safe_headers` on every branch except the `httpx.HTTPStatusError` one, which is the branch a passthrough failure reaches
  - the fix is the missing `headers=` argument, so the branch now matches its three siblings; any provider raising that exception through this handler gains the same forwarding
- Non-chat bedrock surfaces gain the same header
  - rerank, batches and files already forwarded headers into `BedrockError`, so they pick up the populated response for free
  - claude platform, bedrock anthropic-messages, image edit, passthrough, realtime, vector stores and agentcore search stop inheriting the header-dropping base classifier
  - `BedrockError` subclasses `BaseLLMException`, so nothing that catches the base changes
- `litellm.Timeout` gained an optional `response` argument
  - keyword-only with a default of `None`, and the attribute is set only when one is passed, so a `Timeout` raised anywhere else is unchanged
  - the bedrock 408, 504 and text-classified timeout branches pass the provider response, which is what every other mapped bedrock exception already did
  - readers that fall back to `.response.status_code` are unaffected because `Timeout` always sets `status_code` itself
- The realtime override cannot be reached from the websocket route
  - `BedrockRealtime.async_realtime` raises `BedrockError` directly and nothing under `litellm/realtime_api/` calls `get_error_class`, so no proxy request exercises it
  - driven directly instead: base raises a bare `BaseLLMException` out of the base class with no request id, head returns a `BedrockError` carrying it
  - it is there so the audit test's invariant holds for all 36 configs and so the documented extension point is correct if realtime error handling is ever wired through it
- The invoke success path still emits no `llm_provider-x-amzn-requestid`
  - pre-existing, unrelated to errors, left alone
- The raise sites left alone have nothing to carry
  - 20 of them never see a provider response: `httpx.TimeoutException` 408s, generic `except Exception` 500s, AWS region/OIDC/credential 401s, guardrailConfig validation, unknown-provider 404s, and botocore stream-shape load failures
  - `build_bedrock_stream_error` builds from an event-stream frame, and a mid-stream error arrives after the 200 headers were already sent
  - the mistral and stability3 sites classify a parsed dict, so closing them needs a helper signature change rather than a header argument
- `/v1/messages`, `/v1/rerank` and `/v1/images/generations` still return no `llm_provider-*` headers
  - those three proxy routes build a `ProxyException` from `get_custom_headers` alone instead of calling `_handle_llm_api_exception`, so they drop provider headers for every provider, not only Bedrock
  - the exception itself now carries `x-amzn-RequestId` at the SDK and router level, measured on both; the remaining loss is downstream proxy plumbing and belongs in its own ticket
- A streaming Bedrock failure now reports the provider's status instead of 500
  - `make_call` and `make_sync_call` ended in `except Exception` and swallowed the `BedrockError` raised a few lines above, so a provider 4xx surfaced as a 500
  - reachable with a caller-supplied client that does not raise for status

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

ran /live-pr-risk and found no regressions/backward incompatible risks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad Bedrock error-path changes affect status codes, retry/cooldown behavior via forwarded `retry-after`, and failure callback payloads; proxy header forwarding on HTTPStatusError applies beyond Bedrock.
> 
> **Overview**
> Fixes **LIT-5428**: Bedrock failures no longer strip AWS trace headers before they reach callers, the proxy, or logging.
> 
> **`BedrockError`** now accepts provider `headers` and/or the real `httpx.Response`, and can **synthesize** a response from headers when only those exist. Helpers **`error_response_text`** and **`get_response_headers`** (now `Mapping`-typed) support unread streamed bodies and header forwarding.
> 
> Across **invoke, converse, AgentCore, embeddings, count tokens, rerank, image APIs, mantle, search**, and related configs, HTTP error paths and **`get_error_class`** attach **`headers`/`response`** instead of message-only errors. **`_map_bedrock_exception`** forwards the provider response for context-window, image, and 5xx mappings (replacing a fake OpenAI 500 response), and puts normalized headers on **Timeout** via **`_bedrock_timeout_headers`**. Invoke streaming handlers **re-raise `BedrockError`** so status codes are not swallowed as generic 500s.
> 
> **Proxy**: the **`httpx.HTTPStatusError`** branch in common request processing and **Bedrock count-tokens** passthrough now emit **`llm_provider-*`** headers on error responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 454d92716933c1dfb384a2c9ece64c9ad77a54ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->






