### PR TITLE
fix(router): keep provider response headers on streaming chat completions

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -2158,13 +2158,13 @@ class ProxyBaseLLMRequestProcessing:
         return fallback_model_group
 
     @staticmethod
-    def _get_model_id_from_response(hidden_params: Mapping[str, object], data: dict) -> str:
+    def _get_model_id_from_response(hidden_params: Mapping[str, object], data: Mapping[str, object]) -> str:
         """Extract model_id from hidden_params with fallback to litellm_metadata."""
         model_id = hidden_params.get("model_id", None) or ""
         if not model_id:
-            litellm_metadata: Final = data.get("litellm_metadata", {}) or {}
-            model_info: Final = litellm_metadata.get("model_info", {}) or {}
-            model_id = model_info.get("id", "") or ""
+            litellm_metadata: Final = data.get("litellm_metadata")
+            model_info: Final = litellm_metadata.get("model_info") if isinstance(litellm_metadata, Mapping) else None
+            model_id = (model_info.get("id") or "") if isinstance(model_info, Mapping) else ""
         return str(model_id) if model_id else ""
 
     def _stream_response_headers(

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -896,7 +896,6 @@ def _sse_stream_headers(headers: Mapping[str, str]) -> Mapping[str, str]:
 async def _resolve_stream_headers(
     headers: Mapping[str, str], refresh_headers: Callable[[], Awaitable[Mapping[str, str]]] | None
 ) -> Mapping[str, str]:
-    """The response headers to publish once the first chunk has been buffered."""
     if refresh_headers is None:
         return headers
     try:
@@ -2168,11 +2167,10 @@ class ProxyBaseLLMRequestProcessing:
             model_id = model_info.get("id", "") or ""
         return str(model_id) if model_id else ""
 
-    @staticmethod
     def _stream_response_headers(
+        self,
         *,
         hidden_params: Mapping[str, object],
-        request_data: dict,
         user_api_key_dict: UserAPIKeyAuth,
         logging_obj: LiteLLMLoggingObj,
         version: str | None,
@@ -2184,14 +2182,14 @@ class ProxyBaseLLMRequestProcessing:
                 **ProxyBaseLLMRequestProcessing.get_custom_headers(
                     user_api_key_dict=user_api_key_dict,
                     call_id=logging_obj.litellm_call_id,
-                    model_id=ProxyBaseLLMRequestProcessing._get_model_id_from_response(hidden_params, request_data),
+                    model_id=self._get_model_id_from_response(hidden_params, self.data),
                     cache_key=hidden_params.get("cache_key") or "",
                     api_base=hidden_params.get("api_base") or "",
                     version=version,
                     response_cost=hidden_params.get("response_cost") or "",
                     model_region=getattr(user_api_key_dict, "allowed_model_region", ""),
                     fastest_response_batch_completion=hidden_params.get("fastest_response_batch_completion"),
-                    request_data=request_data,
+                    request_data=self.data,
                     hidden_params=hidden_params,
                     litellm_logging_obj=logging_obj,
                     **(hidden_params.get("additional_headers") or MappingProxyType({})),
@@ -2476,7 +2474,6 @@ class ProxyBaseLLMRequestProcessing:
                 )
                 custom_headers: Final = self._stream_response_headers(
                     hidden_params=hidden_params,
-                    request_data=self.data,
                     user_api_key_dict=user_api_key_dict,
                     logging_obj=logging_obj,
                     version=version,
@@ -2484,16 +2481,11 @@ class ProxyBaseLLMRequestProcessing:
                 )
 
                 async def refresh_stream_headers() -> Mapping[str, str]:
-                    """`custom_headers` rebuilt for whichever deployment served the stream.
-
-                    `create_response` buffers the first chunk before it commits headers, so a
-                    fallback that took over by then has already repointed `response`.
-                    """
+                    """`custom_headers` rebuilt for whichever deployment served the stream."""
                     if not getattr(response, "fallback_headers_adopted", False):
                         return custom_headers
                     return self._stream_response_headers(
                         hidden_params=get_hidden_params_dict(response),
-                        request_data=self.data,
                         user_api_key_dict=user_api_key_dict,
                         logging_obj=logging_obj,
                         version=version,

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -756,7 +756,7 @@ class _UpstreamClosingStreamingResponse(StreamingResponse):
         content: AsyncGenerator[str, None],
         *,
         media_type: str | None = None,
-        headers: dict | None = None,
+        headers: Mapping[str, str] | None = None,
         status_code: int = status.HTTP_200_OK,
         upstream_generator: AsyncGenerator[str, None] | None = None,
     ) -> None:
@@ -888,25 +888,40 @@ def _sse_error_frames(error_obj: Mapping[str, object]) -> tuple[str, str]:
     return f"data: {json.dumps({'error': error_obj})}\n\n", "data: [DONE]\n\n"
 
 
+def _sse_stream_headers(headers: Mapping[str, str]) -> Mapping[str, str]:
+    """`headers` plus the two that stop reverse proxies from buffering SSE (issue #28384)."""
+    return MappingProxyType({**headers, **_TTFT_KEEPALIVE_HEADERS})
+
+
+async def _resolve_stream_headers(
+    headers: Mapping[str, str], refresh_headers: Callable[[], Awaitable[Mapping[str, str]]] | None
+) -> Mapping[str, str]:
+    """The response headers to publish once the first chunk has been buffered."""
+    if refresh_headers is None:
+        return headers
+    try:
+        return await refresh_headers()
+    except Exception as e:  # noqa: BLE001  # a stream whose first chunk is already paid for must not fail over its headers
+        verbose_proxy_logger.exception("Error refreshing streaming response headers: %s", e)
+        return headers
+
+
 async def create_response(
     generator: AsyncGenerator[str, None],
     media_type: str,
-    headers: dict,
+    headers: Mapping[str, str],
     default_status_code: int = status.HTTP_200_OK,
     request: Request | None = None,
+    refresh_headers: Callable[[], Awaitable[Mapping[str, str]]] | None = None,
 ) -> StreamingResponse | JSONResponse:
     """
     Create streaming response, checking if the first chunk is an error.
     If the first chunk is an error, return a standard JSON error response.
     Otherwise, return StreamingResponse and stream all content.
+
+    ``refresh_headers`` is consulted once the first chunk has been buffered, for
+    callers whose headers can only be known then.
     """
-    # Tell buffering reverse proxies (nginx, ingress-nginx, Envoy) to flush SSE
-    # immediately instead of releasing the whole stream in one batch (issue #28384).
-    streaming_headers: Final = {
-        **headers,
-        "Cache-Control": "no-cache",
-        "X-Accel-Buffering": "no",
-    }
     first_chunk_value: str | None = None
     final_status_code = default_status_code
 
@@ -917,6 +932,7 @@ async def create_response(
 
         # Now get the first chunk from the actual generator
         first_chunk_value = await _buffer_first_chunk_honoring_disconnect(generator, request)
+        resolved_headers: Final = await _resolve_stream_headers(headers, refresh_headers)
 
         if first_chunk_value is not None:
             try:
@@ -943,7 +959,7 @@ async def create_response(
                     return JSONResponse(
                         status_code=final_status_code,
                         content={"error": error_dict},
-                        headers=headers,
+                        headers=resolved_headers,
                     )
             except Exception as e:
                 verbose_proxy_logger.debug("Error parsing first chunk value: %s", e)
@@ -972,7 +988,7 @@ async def create_response(
         return StreamingResponse(
             empty_gen(),
             media_type=media_type,
-            headers=streaming_headers,
+            headers=_sse_stream_headers(await _resolve_stream_headers(headers, refresh_headers)),
             status_code=default_status_code,
         )
     except Exception as e:
@@ -988,7 +1004,7 @@ async def create_response(
         return StreamingResponse(
             error_gen_message(),
             media_type=media_type,
-            headers=streaming_headers,
+            headers=_sse_stream_headers(await _resolve_stream_headers(headers, refresh_headers)),
             status_code=error_status,
         )
 
@@ -1010,7 +1026,7 @@ async def create_response(
     return _UpstreamClosingStreamingResponse(
         combined_generator(),
         media_type=media_type,
-        headers=streaming_headers,
+        headers=_sse_stream_headers(resolved_headers),
         status_code=final_status_code,
         upstream_generator=generator,
     )
@@ -1535,7 +1551,7 @@ class ProxyBaseLLMRequestProcessing:
     @staticmethod
     def _merge_passthrough_streaming_headers(
         response_headers: httpx.Headers | dict | None,
-        custom_headers: dict,
+        custom_headers: Mapping[str, str],
     ) -> dict:
         """
         Merge upstream passthrough headers with proxy/custom headers.
@@ -2143,14 +2159,46 @@ class ProxyBaseLLMRequestProcessing:
         return fallback_model_group
 
     @staticmethod
-    def _get_model_id_from_response(hidden_params: dict, data: dict) -> str:
+    def _get_model_id_from_response(hidden_params: Mapping[str, object], data: dict) -> str:
         """Extract model_id from hidden_params with fallback to litellm_metadata."""
         model_id = hidden_params.get("model_id", None) or ""
         if not model_id:
             litellm_metadata: Final = data.get("litellm_metadata", {}) or {}
             model_info: Final = litellm_metadata.get("model_info", {}) or {}
             model_id = model_info.get("id", "") or ""
-        return model_id
+        return str(model_id) if model_id else ""
+
+    @staticmethod
+    def _stream_response_headers(
+        *,
+        hidden_params: Mapping[str, object],
+        request_data: dict,
+        user_api_key_dict: UserAPIKeyAuth,
+        logging_obj: LiteLLMLoggingObj,
+        version: str | None,
+        callback_headers: Mapping[str, str],
+    ) -> Mapping[str, str]:
+        """The streaming response headers describing `hidden_params`' deployment."""
+        return MappingProxyType(
+            {
+                **ProxyBaseLLMRequestProcessing.get_custom_headers(
+                    user_api_key_dict=user_api_key_dict,
+                    call_id=logging_obj.litellm_call_id,
+                    model_id=ProxyBaseLLMRequestProcessing._get_model_id_from_response(hidden_params, request_data),
+                    cache_key=hidden_params.get("cache_key") or "",
+                    api_base=hidden_params.get("api_base") or "",
+                    version=version,
+                    response_cost=hidden_params.get("response_cost") or "",
+                    model_region=getattr(user_api_key_dict, "allowed_model_region", ""),
+                    fastest_response_batch_completion=hidden_params.get("fastest_response_batch_completion"),
+                    request_data=request_data,
+                    hidden_params=hidden_params,
+                    litellm_logging_obj=logging_obj,
+                    **(hidden_params.get("additional_headers") or MappingProxyType({})),
+                ),
+                **callback_headers,
+            }
+        )
 
     @staticmethod
     def _get_deployment_model_name(
@@ -2419,31 +2467,38 @@ class ProxyBaseLLMRequestProcessing:
             if self._is_streaming_request(
                 data=self.data, is_streaming_request=is_streaming_request
             ) or self._is_streaming_response(response):  # use generate_responses to stream responses
-                custom_headers: Final = ProxyBaseLLMRequestProcessing.get_custom_headers(
-                    user_api_key_dict=user_api_key_dict,
-                    call_id=logging_obj.litellm_call_id,
-                    model_id=model_id,
-                    cache_key=cache_key,
-                    api_base=api_base,
-                    version=version,
-                    response_cost=response_cost,
-                    model_region=getattr(user_api_key_dict, "allowed_model_region", ""),
-                    fastest_response_batch_completion=fastest_response_batch_completion,
-                    request_data=self.data,
-                    hidden_params=hidden_params,
-                    litellm_logging_obj=logging_obj,
-                    **additional_headers,
-                )
-
                 # Call response headers hook for streaming success
-                callback_headers = await proxy_logging_obj.post_call_response_headers_hook(
+                stream_callback_headers: Final = await proxy_logging_obj.post_call_response_headers_hook(
                     data=self.data,
                     user_api_key_dict=user_api_key_dict,
                     response=response,
                     request_headers=dict(request.headers),
                 )
-                if callback_headers:
-                    custom_headers.update(callback_headers)
+                custom_headers: Final = self._stream_response_headers(
+                    hidden_params=hidden_params,
+                    request_data=self.data,
+                    user_api_key_dict=user_api_key_dict,
+                    logging_obj=logging_obj,
+                    version=version,
+                    callback_headers=stream_callback_headers or MappingProxyType({}),
+                )
+
+                async def refresh_stream_headers() -> Mapping[str, str]:
+                    """`custom_headers` rebuilt for whichever deployment served the stream.
+
+                    `create_response` buffers the first chunk before it commits headers, so a
+                    fallback that took over by then has already repointed `response`.
+                    """
+                    if not getattr(response, "fallback_headers_adopted", False):
+                        return custom_headers
+                    return self._stream_response_headers(
+                        hidden_params=get_hidden_params_dict(response),
+                        request_data=self.data,
+                        user_api_key_dict=user_api_key_dict,
+                        logging_obj=logging_obj,
+                        version=version,
+                        callback_headers=stream_callback_headers or MappingProxyType({}),
+                    )
 
                 # Preserve the original client-requested model (pre-alias mapping) for downstream
                 # streaming generators. Pre-call processing can rewrite `self.data["model"]` for
@@ -2581,6 +2636,7 @@ class ProxyBaseLLMRequestProcessing:
                         media_type="text/event-stream",
                         headers=custom_headers,
                         request=request,
+                        refresh_headers=refresh_stream_headers,
                     )
 
             ### CALL HOOKS ### - modify outgoing data
@@ -3032,7 +3088,7 @@ class ProxyBaseLLMRequestProcessing:
         response: Any,
         proxy_logging_obj: "ProxyLogging",
         user_api_key_dict: "UserAPIKeyAuth",
-        custom_headers: dict,
+        custom_headers: Mapping[str, str],
         request_headers: dict[str, str],
     ) -> Response | None:
         if not self._has_post_call_guardrails_for_passthrough():

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -322,7 +322,7 @@ class HttpPassThroughEndpointHelpers(BasePassthroughUtils):
     def get_response_headers(
         headers: httpx.Headers,
         litellm_call_id: str | None = None,
-        custom_headers: dict | None = None,
+        custom_headers: Mapping[str, str] | None = None,
     ) -> dict:
         # Exclude headers that uvicorn writes itself (server, date) and
         # encoding/length headers that don't survive re-serialization.

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -2605,6 +2605,18 @@ class Router:
         return fallback_hidden_params, cast("dict[str, object]", fallback_headers)
 
     @staticmethod
+    def _adopt_fallback_response_headers(
+        wrapper_ref: "weakref.ref[FallbackAwareStreamWrapper]",
+        fallback_response: object,
+    ) -> tuple[dict[str, object], dict[str, object]]:
+        """Repoint the wrapper at `fallback_response`, returning its prepared hidden params."""
+        prepared: Final = Router._prepare_fallback_hidden_params(fallback_response)
+        adopting_wrapper: Final = wrapper_ref()
+        if adopting_wrapper is not None:
+            adopting_wrapper.adopt_fallback_response_headers(fallback_response, prepared)
+        return prepared
+
+    @staticmethod
     def _apply_fallback_hidden_params_to_item(
         fallback_item: object,
         prepared_fallback_hidden_params: tuple[dict[str, object], dict[str, object]],
@@ -2728,13 +2740,17 @@ class Router:
 
                     # If fallback returns a streaming response, iterate over it
                     if hasattr(fallback_response, "__aiter__"):
-                        prepared_fallback_hidden_params = Router._prepare_fallback_hidden_params(fallback_response)
-                        _adopting_wrapper = wrapper_ref()
-                        if _adopting_wrapper is not None:
-                            _adopting_wrapper.adopt_fallback_response_headers(
-                                fallback_response, prepared_fallback_hidden_params
-                            )
+                        prepared_fallback_hidden_params = Router._adopt_fallback_response_headers(
+                            wrapper_ref, fallback_response
+                        )
+                        fallback_headers_are_settled = False
                         async for fallback_item in fallback_response:
+                            if not fallback_headers_are_settled:
+                                # a fallback that failed over again only repoints itself once it yields
+                                fallback_headers_are_settled = True
+                                prepared_fallback_hidden_params = Router._adopt_fallback_response_headers(
+                                    wrapper_ref, fallback_response
+                                )
                             Router._apply_fallback_hidden_params_to_item(fallback_item, prepared_fallback_hidden_params)
                             if (
                                 fallback_item
@@ -3272,13 +3288,17 @@ class Router:
                     )
 
                     if hasattr(fallback_response, "__iter__"):
-                        prepared_fallback_hidden_params = Router._prepare_fallback_hidden_params(fallback_response)
-                        _adopting_wrapper = wrapper_ref()
-                        if _adopting_wrapper is not None:
-                            _adopting_wrapper.adopt_fallback_response_headers(
-                                fallback_response, prepared_fallback_hidden_params
-                            )
+                        prepared_fallback_hidden_params = Router._adopt_fallback_response_headers(
+                            wrapper_ref, fallback_response
+                        )
+                        fallback_headers_are_settled = False
                         for fallback_item in fallback_response:
+                            if not fallback_headers_are_settled:
+                                # a fallback that failed over again only repoints itself once it yields
+                                fallback_headers_are_settled = True
+                                prepared_fallback_hidden_params = Router._adopt_fallback_response_headers(
+                                    wrapper_ref, fallback_response
+                                )
                             Router._apply_fallback_hidden_params_to_item(fallback_item, prepared_fallback_hidden_params)
                             if (
                                 fallback_item

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -2746,10 +2746,10 @@ class Router:
                         fallback_headers_are_settled = False
                         async for fallback_item in fallback_response:
                             if not fallback_headers_are_settled:
+                                fallback_headers_are_settled = True  # rebind-ok: one-shot latch
                                 # a fallback that failed over again only repoints itself once it yields
-                                fallback_headers_are_settled = True
-                                prepared_fallback_hidden_params = Router._adopt_fallback_response_headers(
-                                    wrapper_ref, fallback_response
+                                prepared_fallback_hidden_params = (  # rebind-ok: re-read once the fallback yields
+                                    Router._adopt_fallback_response_headers(wrapper_ref, fallback_response)
                                 )
                             Router._apply_fallback_hidden_params_to_item(fallback_item, prepared_fallback_hidden_params)
                             if (
@@ -3294,10 +3294,10 @@ class Router:
                         fallback_headers_are_settled = False
                         for fallback_item in fallback_response:
                             if not fallback_headers_are_settled:
+                                fallback_headers_are_settled = True  # rebind-ok: one-shot latch
                                 # a fallback that failed over again only repoints itself once it yields
-                                fallback_headers_are_settled = True
-                                prepared_fallback_hidden_params = Router._adopt_fallback_response_headers(
-                                    wrapper_ref, fallback_response
+                                prepared_fallback_hidden_params = (  # rebind-ok: re-read once the fallback yields
+                                    Router._adopt_fallback_response_headers(wrapper_ref, fallback_response)
                                 )
                             Router._apply_fallback_hidden_params_to_item(fallback_item, prepared_fallback_hidden_params)
                             if (

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -612,6 +612,38 @@ RETRY_BREADCRUMB_EXCLUDED_KWARGS: Final = frozenset(
 RETRY_BREADCRUMB_LIMIT: Final = 4
 
 
+class FallbackAwareStreamWrapper(CustomStreamWrapper):
+    """Base for the Router's chat-completion stream wrappers, which are built around the
+    attempt the Router picked first and have to repoint themselves when a fallback takes over."""
+
+    fallback_headers_adopted: bool = False
+
+    def adopt_fallback_response_headers(
+        self,
+        fallback_response: object,
+        prepared_fallback_hidden_params: tuple[dict[str, object], dict[str, object]],
+    ) -> None:
+        """Repoint this wrapper at the deployment that served the stream.
+
+        Replaces rather than merges, so the failed attempt's `x-request-id`, rate limit
+        counters, `model_id` and `api_base` cannot reach the proxy's response headers or
+        its callbacks.
+        """
+        self._response_headers = getattr(fallback_response, "_response_headers", None)
+        fallback_hidden_params, fallback_headers = prepared_fallback_hidden_params
+        if fallback_hidden_params:
+            self._hidden_params = {  # mutable-ok: the rest of litellm writes into _hidden_params
+                **fallback_hidden_params,
+                # dict() because add_retry_fallback_headers mutates additional_headers in place
+                "additional_headers": dict(fallback_headers),  # mutable-ok: see above
+            }
+            self._base_hidden_params = {  # mutable-ok: CustomStreamWrapper keeps this snapshot as a dict
+                **self._hidden_params,
+                "response_cost": None,
+            }
+        self.fallback_headers_adopted = True
+
+
 class Router:
     model_names: set = set()
     cache_responses: bool | None = False
@@ -2611,7 +2643,7 @@ class Router:
 
         held_slot: Final = deployment_slot if deployment_slot is not None else contextlib.AsyncExitStack()
 
-        class FallbackStreamWrapper(CustomStreamWrapper):
+        class FallbackStreamWrapper(FallbackAwareStreamWrapper):
             def __init__(self, async_generator: AsyncGenerator):
                 # Copy attributes from the original model_response
                 super().__init__(
@@ -2619,6 +2651,7 @@ class Router:
                     model=model_response.model,
                     custom_llm_provider=model_response.custom_llm_provider,
                     logging_obj=model_response.logging_obj,
+                    _response_headers=getattr(model_response, "_response_headers", None),
                 )
                 self._async_generator = async_generator
                 inner_chunks: Final[object] = getattr(model_response, "chunks", None)
@@ -2696,6 +2729,11 @@ class Router:
                     # If fallback returns a streaming response, iterate over it
                     if hasattr(fallback_response, "__aiter__"):
                         prepared_fallback_hidden_params = Router._prepare_fallback_hidden_params(fallback_response)
+                        _adopting_wrapper = wrapper_ref()
+                        if _adopting_wrapper is not None:
+                            _adopting_wrapper.adopt_fallback_response_headers(
+                                fallback_response, prepared_fallback_hidden_params
+                            )
                         async for fallback_item in fallback_response:
                             Router._apply_fallback_hidden_params_to_item(fallback_item, prepared_fallback_hidden_params)
                             if (
@@ -2738,7 +2776,11 @@ class Router:
                                 e,
                             )
 
-        return FallbackStreamWrapper(stream_with_fallbacks())
+        wrapped_response: Final = FallbackStreamWrapper(stream_with_fallbacks())
+        # weak, so the generator closing over it does not keep the wrapper out of
+        # refcount teardown and delay the `finally` that releases the deployment slot
+        wrapper_ref: Final = weakref.ref(wrapped_response)
+        return wrapped_response
 
     @staticmethod
     def _extract_partial_responses_usage(
@@ -3167,13 +3209,14 @@ class Router:
         """
         from litellm.exceptions import MidStreamFallbackError
 
-        class SyncFallbackStreamWrapper(CustomStreamWrapper):
+        class SyncFallbackStreamWrapper(FallbackAwareStreamWrapper):
             def __init__(self, sync_generator: Generator):
                 super().__init__(
                     completion_stream=sync_generator,
                     model=model_response.model,
                     custom_llm_provider=model_response.custom_llm_provider,
                     logging_obj=model_response.logging_obj,
+                    _response_headers=getattr(model_response, "_response_headers", None),
                 )
                 self._sync_generator = sync_generator
                 if hasattr(model_response, "_hidden_params"):
@@ -3230,6 +3273,11 @@ class Router:
 
                     if hasattr(fallback_response, "__iter__"):
                         prepared_fallback_hidden_params = Router._prepare_fallback_hidden_params(fallback_response)
+                        _adopting_wrapper = wrapper_ref()
+                        if _adopting_wrapper is not None:
+                            _adopting_wrapper.adopt_fallback_response_headers(
+                                fallback_response, prepared_fallback_hidden_params
+                            )
                         for fallback_item in fallback_response:
                             Router._apply_fallback_hidden_params_to_item(fallback_item, prepared_fallback_hidden_params)
                             if (
@@ -3268,7 +3316,10 @@ class Router:
                             close_err,
                         )
 
-        return SyncFallbackStreamWrapper(stream_with_fallbacks())
+        wrapped_response: Final = SyncFallbackStreamWrapper(stream_with_fallbacks())
+        # weak, for the same reason as the async twin
+        wrapper_ref: Final = weakref.ref(wrapped_response)
+        return wrapped_response
 
     async def _silent_experiment_acompletion(self, silent_model: str, messages: Sequence[Mapping[str, str]], **kwargs):
         """

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -2,7 +2,7 @@ import asyncio
 import copy
 import datetime
 import json
-from types import SimpleNamespace
+from types import MappingProxyType, SimpleNamespace
 from typing import AsyncGenerator, Callable, Final, Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -1816,7 +1816,7 @@ class TestCommonRequestProcessingHelpers:
         headers are still uncommitted, so ``refresh_headers`` is consulted after
         the first chunk is buffered and its result wins.
         """
-        refreshed_at = []
+        refreshed_at: Final[list[str]] = []
 
         async def mock_generator():
             yield 'data: {"content": "data"}\n\n'
@@ -8245,3 +8245,18 @@ class TestStreamingResponseHeadersFollowFallback:
         assert result.headers["llm_provider-x-request-id"] == "req-SERVED"
         assert "llm_provider-stale-marker" not in result.headers
         assert result.headers["x-callback-header"] == "kept"
+
+
+class TestPassthroughHeadersAcceptImmutableMappings:
+    """LIT-6767: the streaming branch now hands the passthrough helpers an immutable mapping."""
+
+    def test_merge_passthrough_streaming_headers_accepts_a_read_only_mapping(self):
+        merged = ProxyBaseLLMRequestProcessing._merge_passthrough_streaming_headers(
+            response_headers=httpx.Headers({"content-type": "text/event-stream", "transfer-encoding": "chunked"}),
+            custom_headers=MappingProxyType({"x-litellm-model-id": "served-deployment"}),
+        )
+
+        assert merged["x-litellm-model-id"] == "served-deployment"
+        assert merged["content-type"] == "text/event-stream"
+        # the excluded hop-by-hop header is still dropped
+        assert "transfer-encoding" not in merged

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -1809,6 +1809,147 @@ class TestCommonRequestProcessingHelpers:
         response = await create_response(mock_generator(), "text/event-stream", custom_headers)
         assert response.headers["x-custom-header"] == "TestValue"
 
+    async def test_create_streaming_response_refresh_headers_after_first_chunk(self):
+        """LIT-6767: headers a caller can only resolve once the first chunk exists.
+
+        A pre-first-chunk fallback replaces the deployment while the response
+        headers are still uncommitted, so ``refresh_headers`` is consulted after
+        the first chunk is buffered and its result wins.
+        """
+        refreshed_at = []
+
+        async def mock_generator():
+            yield 'data: {"content": "data"}\n\n'
+            yield "data: [DONE]\n\n"
+
+        async def refresh_headers():
+            refreshed_at.append("called")
+            return {"x-litellm-model-id": "fallback-deployment", "llm_provider-x-request-id": "req-FALLBACK"}
+
+        response = await create_response(
+            mock_generator(),
+            "text/event-stream",
+            {"x-litellm-model-id": "failed-deployment", "llm_provider-x-request-id": "req-FAILED"},
+            refresh_headers=refresh_headers,
+        )
+        assert isinstance(response, StreamingResponse)
+        assert refreshed_at == ["called"]
+        assert response.headers["x-litellm-model-id"] == "fallback-deployment"
+        assert response.headers["llm_provider-x-request-id"] == "req-FALLBACK"
+        # the buffering headers are still applied on top of the refreshed set
+        assert response.headers["x-accel-buffering"] == "no"
+        assert response.headers["cache-control"] == "no-cache"
+
+    async def test_create_streaming_response_refreshes_only_after_the_first_chunk(self):
+        """LIT-6767: the refresh has to be consulted after the generator produced a chunk.
+
+        A pre-first-chunk fallback only repoints the response while that first chunk is
+        being produced, so a refresh consulted any earlier still describes the attempt
+        that failed and the headers go out wrong.
+        """
+        produced = {"first_chunk": False}
+
+        async def mock_generator():
+            produced["first_chunk"] = True
+            yield 'data: {"content": "data"}\n\n'
+            yield "data: [DONE]\n\n"
+
+        async def refresh_headers():
+            served = "fallback-deployment" if produced["first_chunk"] else "failed-deployment"
+            return {"x-litellm-model-id": served}
+
+        response = await create_response(
+            mock_generator(),
+            "text/event-stream",
+            {"x-litellm-model-id": "failed-deployment"},
+            refresh_headers=refresh_headers,
+        )
+        assert response.headers["x-litellm-model-id"] == "fallback-deployment"
+
+    async def test_create_streaming_response_empty_stream_uses_refreshed_headers(self):
+        """LIT-6767: a fallback that served nothing still gets to name itself.
+
+        The empty-generator branch returns its own StreamingResponse, so it needs the
+        refreshed headers too or the client is told the failed deployment answered.
+        """
+
+        async def mock_generator():
+            return
+            yield  # make it an async generator
+
+        async def refresh_headers():
+            return {"x-litellm-model-id": "fallback-deployment"}
+
+        response = await create_response(
+            mock_generator(),
+            "text/event-stream",
+            {"x-litellm-model-id": "failed-deployment"},
+            refresh_headers=refresh_headers,
+        )
+        assert isinstance(response, StreamingResponse)
+        assert response.headers["x-litellm-model-id"] == "fallback-deployment"
+        assert response.headers["x-accel-buffering"] == "no"
+
+    async def test_create_streaming_response_without_refresh_headers_is_unchanged(self):
+        """LIT-6767: the default keeps the caller-supplied headers verbatim."""
+
+        async def mock_generator():
+            yield 'data: {"content": "data"}\n\n'
+            yield "data: [DONE]\n\n"
+
+        response = await create_response(
+            mock_generator(),
+            "text/event-stream",
+            {"x-litellm-model-id": "failed-deployment"},
+        )
+        assert response.headers["x-litellm-model-id"] == "failed-deployment"
+
+    async def test_create_streaming_response_refresh_headers_failure_keeps_stream(self):
+        """LIT-6767: the first chunk is already paid for, so a failing refresh
+        falls back to the caller's headers instead of erroring the stream."""
+
+        async def mock_generator():
+            yield 'data: {"content": "data"}\n\n'
+            yield "data: [DONE]\n\n"
+
+        async def refresh_headers():
+            raise RuntimeError("boom")
+
+        response = await create_response(
+            mock_generator(),
+            "text/event-stream",
+            {"x-litellm-model-id": "failed-deployment"},
+            refresh_headers=refresh_headers,
+        )
+        assert isinstance(response, StreamingResponse)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.headers["x-litellm-model-id"] == "failed-deployment"
+        assert await self.consume_stream(response) == [
+            'data: {"content": "data"}\n\n',
+            "data: [DONE]\n\n",
+        ]
+
+    async def test_create_response_first_chunk_error_uses_refreshed_headers(self):
+        """LIT-6767: the JSON error response built from a bad first chunk carries
+        the refreshed headers too, so it cannot describe a deployment that no
+        longer served the request."""
+
+        async def mock_generator():
+            yield 'data: {"error": {"code": 403, "message": "forbidden"}}\n\n'
+            yield "data: [DONE]\n\n"
+
+        async def refresh_headers():
+            return {"x-litellm-model-id": "fallback-deployment"}
+
+        response = await create_response(
+            mock_generator(),
+            "text/event-stream",
+            {"x-litellm-model-id": "failed-deployment"},
+            refresh_headers=refresh_headers,
+        )
+        assert isinstance(response, JSONResponse)
+        assert response.headers["x-litellm-model-id"] == "fallback-deployment"
+
     async def test_create_streaming_response_disables_proxy_buffering(self):
         """Regression for #28384: every StreamingResponse create_response returns
         must carry the headers that stop nginx/ingress/Envoy from buffering the
@@ -8014,3 +8155,93 @@ class TestDetachedStreamFailureHook:
         await logging_obj._on_detached_stream_failure(failure)
 
         assert [call["original_exception"] for call in recorder.calls] == [failure]
+
+
+class TestStreamingResponseHeadersFollowFallback:
+    """LIT-6767: the streaming branch has to publish the deployment that served the stream."""
+
+    @staticmethod
+    def _fallback_adopting_stream():
+        class _Stream:
+            def __init__(self) -> None:
+                self._hidden_params = {
+                    "model_id": "failed-deployment",
+                    "api_base": "http://127.0.0.1:20769/v1",
+                    "additional_headers": {"llm_provider-stale-marker": "failed-deployment"},
+                }
+                self.fallback_headers_adopted = False
+
+            def adopt(self) -> None:
+                self._hidden_params = {
+                    "model_id": "served-deployment",
+                    "api_base": "https://api.openai.com",
+                    "additional_headers": {"llm_provider-x-request-id": "req-SERVED"},
+                }
+                self.fallback_headers_adopted = True
+
+        return _Stream()
+
+    @pytest.mark.asyncio
+    async def test_streaming_headers_name_the_deployment_that_served(self, monkeypatch):
+        """A pre-first-chunk fallback repoints the stream while the headers are still
+        uncommitted, so the published headers must describe the fallback, not the attempt
+        the Router picked first."""
+        stream = self._fallback_adopting_stream()
+
+        def select_data_generator(**kwargs):
+            async def generator():
+                stream.adopt()
+                yield 'data: {"choices": [{"delta": {"content": "OK"}}]}\n\n'
+                yield "data: [DONE]\n\n"
+
+            return generator()
+
+        logging_obj = MagicMock()
+        logging_obj.litellm_call_id = "lit-6767-call"
+        logging_obj._defer_async_logging = False
+        logging_obj._on_deferred_stream_complete = None
+        logging_obj.cost_breakdown = None
+
+        processor = ProxyBaseLLMRequestProcessing(
+            data={"model": "oa-midfail", "stream": True, "litellm_logging_obj": logging_obj}
+        )
+
+        proxy_logging_obj = MagicMock(spec=ProxyLogging)
+        proxy_logging_obj.during_call_hook = AsyncMock(return_value=None)
+        proxy_logging_obj.update_request_status = AsyncMock(return_value=None)
+        proxy_logging_obj.post_call_success_hook = AsyncMock(
+            side_effect=lambda data, user_api_key_dict, response: response
+        )
+        proxy_logging_obj.post_call_response_headers_hook = AsyncMock(
+            return_value={"x-callback-header": "kept"}
+        )
+
+        async def fake_route_request(**kwargs):
+            async def call():
+                return stream
+
+            return call()
+
+        monkeypatch.setattr(
+            litellm.proxy.common_request_processing, "route_request", fake_route_request
+        )
+
+        result = await processor.base_process_llm_request(
+            request=Request(scope={"type": "http", "headers": []}),
+            fastapi_response=Response(),
+            user_api_key_dict=ProxyUserAPIKeyAuth(api_key="sk-test"),
+            route_type="acompletion",
+            proxy_logging_obj=proxy_logging_obj,
+            general_settings={},
+            proxy_config=MagicMock(spec=ProxyConfig),
+            select_data_generator=select_data_generator,
+            is_streaming_request=True,
+            skip_pre_call_logic=True,
+        )
+
+        assert isinstance(result, StreamingResponse)
+        assert result.headers["x-litellm-model-id"] == "served-deployment"
+        assert result.headers["x-litellm-model-api-base"] == "https://api.openai.com"
+        assert result.headers["llm_provider-x-request-id"] == "req-SERVED"
+        assert "llm_provider-stale-marker" not in result.headers
+        assert result.headers["x-callback-header"] == "kept"

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -1816,15 +1816,14 @@ class TestCommonRequestProcessingHelpers:
         headers are still uncommitted, so ``refresh_headers`` is consulted after
         the first chunk is buffered and its result wins.
         """
-        refreshed_at: Final[list[str]] = []
 
         async def mock_generator():
             yield 'data: {"content": "data"}\n\n'
             yield "data: [DONE]\n\n"
 
-        async def refresh_headers():
-            refreshed_at.append("called")
-            return {"x-litellm-model-id": "fallback-deployment", "llm_provider-x-request-id": "req-FALLBACK"}
+        refresh_headers: Final = AsyncMock(
+            return_value={"x-litellm-model-id": "fallback-deployment", "llm_provider-x-request-id": "req-FALLBACK"}
+        )
 
         response = await create_response(
             mock_generator(),
@@ -1833,7 +1832,7 @@ class TestCommonRequestProcessingHelpers:
             refresh_headers=refresh_headers,
         )
         assert isinstance(response, StreamingResponse)
-        assert refreshed_at == ["called"]
+        assert refresh_headers.await_count == 1
         assert response.headers["x-litellm-model-id"] == "fallback-deployment"
         assert response.headers["llm_provider-x-request-id"] == "req-FALLBACK"
         # the buffering headers are still applied on top of the refreshed set
@@ -1847,15 +1846,15 @@ class TestCommonRequestProcessingHelpers:
         being produced, so a refresh consulted any earlier still describes the attempt
         that failed and the headers go out wrong.
         """
-        produced = {"first_chunk": False}
+        first_chunk_produced: Final = asyncio.Event()
 
         async def mock_generator():
-            produced["first_chunk"] = True
+            first_chunk_produced.set()
             yield 'data: {"content": "data"}\n\n'
             yield "data: [DONE]\n\n"
 
         async def refresh_headers():
-            served = "fallback-deployment" if produced["first_chunk"] else "failed-deployment"
+            served = "fallback-deployment" if first_chunk_produced.is_set() else "failed-deployment"
             return {"x-litellm-model-id": served}
 
         response = await create_response(

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -2682,6 +2682,184 @@ async def test_acompletion_streaming_iterator_adopts_fallback_response_headers()
     assert result._hidden_params is not fallback_stream._hidden_params
 
 
+@pytest.mark.asyncio
+async def test_acompletion_streaming_iterator_adopts_the_deployment_that_served_a_nested_fallback():
+    """LIT-6767: a fallback that itself fails over before its first chunk.
+
+    The selected fallback still describes its own failed attempt at selection time, so
+    the wrapper has to re-read it once a chunk exists or it publishes a deployment that
+    produced no output.
+    """
+    from unittest.mock import MagicMock, patch
+
+    from litellm.exceptions import MidStreamFallbackError
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "gpt-4",
+                "litellm_params": {"model": "gpt-4", "api_key": "fake-key"},
+            }
+        ],
+    )
+
+    failed_error: Final = MidStreamFallbackError(
+        message="upstream died before the first chunk",
+        model="gpt-4",
+        llm_provider="openai",
+        generated_content="",
+        is_pre_first_chunk=True,
+    )
+
+    class FailedStream:
+        def __init__(self):
+            self.model = "gpt-4"
+            self.custom_llm_provider = "openai"
+            self.logging_obj = MagicMock()
+            self.chunks = []
+            self._response_headers = {"x-request-id": "req-FAILED"}
+            self._hidden_params = {
+                "model_id": "failed-deployment",
+                "additional_headers": {"llm_provider-x-request-id": "req-FAILED"},
+            }
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise failed_error
+
+    class NestedFallbackStream:
+        """A fallback that repoints itself at a third deployment as it yields."""
+
+        def __init__(self):
+            self._response_headers = {"x-request-id": "req-MIDDLE"}
+            self._hidden_params = {
+                "model_id": "middle-deployment",
+                "additional_headers": {"llm_provider-x-request-id": "req-MIDDLE"},
+            }
+            self._chunks = iter([litellm.ModelResponseStream(choices=[{"index": 0, "delta": {"content": "OK"}}])])
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            try:
+                chunk = next(self._chunks)
+            except StopIteration:
+                raise StopAsyncIteration from None
+            self._response_headers = {"x-request-id": "req-SERVED"}
+            self._hidden_params = {
+                "model_id": "served-deployment",
+                "additional_headers": {"llm_provider-x-request-id": "req-SERVED"},
+            }
+            return chunk
+
+    with patch.object(
+        router,
+        "async_function_with_fallbacks_common_utils",
+        return_value=NestedFallbackStream(),
+    ):
+        result = await router._acompletion_streaming_iterator(
+            model_response=FailedStream(),
+            messages=[{"role": "user", "content": "hi"}],
+            initial_kwargs={"model": "gpt-4", "stream": True},
+        )
+        first_chunk: Final = await result.__anext__()
+        # the proxy commits response headers once this chunk is buffered
+        assert result._response_headers == {"x-request-id": "req-SERVED"}
+        assert result._hidden_params["model_id"] == "served-deployment"
+        assert result._hidden_params["additional_headers"] == {"llm_provider-x-request-id": "req-SERVED"}
+        # and the chunk itself carries the same deployment
+        assert first_chunk._hidden_params["model_id"] == "served-deployment"
+        async for _ in result:
+            pass
+
+    assert result._response_headers == {"x-request-id": "req-SERVED"}
+    assert result._hidden_params["model_id"] == "served-deployment"
+
+
+def test_completion_streaming_iterator_adopts_the_deployment_that_served_a_nested_fallback():
+    """LIT-6767, sync counterpart of the nested-fallback adoption test."""
+    from unittest.mock import MagicMock, patch
+
+    from litellm.exceptions import MidStreamFallbackError
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "gpt-4",
+                "litellm_params": {"model": "gpt-4", "api_key": "fake-key"},
+            }
+        ],
+    )
+
+    failed_error: Final = MidStreamFallbackError(
+        message="upstream died before the first chunk",
+        model="gpt-4",
+        llm_provider="openai",
+        generated_content="",
+        is_pre_first_chunk=True,
+    )
+
+    class FailedStream:
+        def __init__(self):
+            self.model = "gpt-4"
+            self.custom_llm_provider = "openai"
+            self.logging_obj = MagicMock()
+            self.chunks = []
+            self._response_headers = {"x-request-id": "req-FAILED"}
+            self._hidden_params = {
+                "model_id": "failed-deployment",
+                "additional_headers": {"llm_provider-x-request-id": "req-FAILED"},
+            }
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            raise failed_error
+
+    class NestedFallbackStream:
+        """A fallback that repoints itself at a third deployment as it yields."""
+
+        def __init__(self):
+            self._response_headers = {"x-request-id": "req-MIDDLE"}
+            self._hidden_params = {
+                "model_id": "middle-deployment",
+                "additional_headers": {"llm_provider-x-request-id": "req-MIDDLE"},
+            }
+            self._chunks = iter([litellm.ModelResponseStream(choices=[{"index": 0, "delta": {"content": "OK"}}])])
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            chunk = next(self._chunks)
+            self._response_headers = {"x-request-id": "req-SERVED"}
+            self._hidden_params = {
+                "model_id": "served-deployment",
+                "additional_headers": {"llm_provider-x-request-id": "req-SERVED"},
+            }
+            return chunk
+
+    with patch.object(router, "function_with_fallbacks", return_value=NestedFallbackStream()):
+        result = router._completion_streaming_iterator(
+            model_response=FailedStream(),
+            messages=[{"role": "user", "content": "hi"}],
+            initial_kwargs={"model": "gpt-4", "stream": True},
+        )
+        first_chunk: Final = next(result)
+        assert result._response_headers == {"x-request-id": "req-SERVED"}
+        assert result._hidden_params["model_id"] == "served-deployment"
+        assert first_chunk._hidden_params["model_id"] == "served-deployment"
+        for _ in result:
+            pass
+
+    assert result._response_headers == {"x-request-id": "req-SERVED"}
+    assert result._hidden_params["model_id"] == "served-deployment"
+
+
 def test_completion_streaming_iterator_adopts_fallback_response_headers():
     """LIT-6767, sync counterpart of the fallback-adoption test."""
     from unittest.mock import MagicMock, patch

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -2523,6 +2523,44 @@ def test_adopt_fallback_response_headers_replaces_rather_than_merges():
     assert wrapper._hidden_params["additional_headers"] == {"llm_provider-x-request-id": "req-FALLBACK"}
 
 
+def test_adopt_fallback_response_headers_survives_a_collected_wrapper():
+    """LIT-6767: the fallback generator holds only a weak reference to its wrapper.
+
+    A client that disconnects mid-stream can drop the wrapper while the generator is
+    still draining, and the adoption call has to keep working with nothing to adopt into
+    so the deployment slot is still released.
+    """
+    import weakref
+    from unittest.mock import MagicMock
+
+    from litellm.router import FallbackAwareStreamWrapper, Router
+
+    fallback: Final = MagicMock()
+    fallback._response_headers = {"x-request-id": "req-FALLBACK"}
+    fallback._hidden_params = {
+        "model_id": "fallback-deployment",
+        "additional_headers": {"llm_provider-x-request-id": "req-FALLBACK"},
+    }
+
+    wrapper = FallbackAwareStreamWrapper(
+        completion_stream=iter([]),
+        model="gpt-4",
+        custom_llm_provider="openai",
+        logging_obj=MagicMock(),
+    )
+    live_ref: Final = weakref.ref(wrapper)
+    prepared: Final = Router._adopt_fallback_response_headers(live_ref, fallback)
+    assert prepared == (fallback._hidden_params, fallback._hidden_params["additional_headers"])
+    assert wrapper.fallback_headers_adopted is True
+    assert wrapper._response_headers == {"x-request-id": "req-FALLBACK"}
+
+    dead_ref: Final = weakref.ref(wrapper)
+    del wrapper
+    assert dead_ref() is None
+    # no wrapper left to repoint, and the caller still needs the params for the chunks
+    assert Router._adopt_fallback_response_headers(dead_ref, fallback) == prepared
+
+
 def test_adopt_fallback_response_headers_drops_headers_the_fallback_cannot_replace():
     """LIT-6767: a fallback that carries no raw provider headers publishes none.
 

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -2386,6 +2386,370 @@ async def test_acompletion_streaming_iterator_preserves_hidden_params():
     assert result._hidden_params.get("_response_ms") == 500.0
 
 
+@pytest.mark.asyncio
+async def test_acompletion_streaming_iterator_preserves_response_headers():
+    """LIT-6767: the returned wrapper must carry the provider's raw response headers.
+
+    Proxy callbacks read ``_response_headers`` off the object the router hands
+    back. The wrapper used to be built without it, so every streaming chat
+    completion reported zero raw provider headers while the non-streaming path
+    reported the full set.
+    """
+    from unittest.mock import MagicMock
+
+    from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "gpt-4",
+                "litellm_params": {"model": "gpt-4", "api_key": "fake-key"},
+            }
+        ],
+    )
+
+    async def _empty():
+        return
+        yield  # make it an async generator
+
+    provider_headers = {
+        "x-request-id": "req-provider-123",
+        "x-ratelimit-remaining-requests": "42",
+        # a provider must never be able to spoof an internal header
+        "x-litellm-model-id": "spoofed",
+    }
+    source = CustomStreamWrapper(
+        completion_stream=_empty(),
+        model="gpt-4",
+        custom_llm_provider="openai",
+        logging_obj=MagicMock(),
+        _response_headers=provider_headers,
+    )
+
+    result = await router._acompletion_streaming_iterator(
+        model_response=source,
+        messages=[{"role": "user", "content": "hi"}],
+        initial_kwargs={"model": "gpt-4", "stream": True},
+    )
+
+    assert result._response_headers == provider_headers
+    additional_headers = result._hidden_params["additional_headers"]
+    assert additional_headers["llm_provider-x-request-id"] == "req-provider-123"
+    assert additional_headers["llm_provider-x-ratelimit-remaining-requests"] == "42"
+    # internal-header protection survives: the provider value is namespaced, never promoted
+    assert additional_headers["llm_provider-x-litellm-model-id"] == "spoofed"
+    assert "x-litellm-model-id" not in additional_headers
+
+
+def test_completion_streaming_iterator_preserves_response_headers():
+    """LIT-6767, sync counterpart of the async header-preservation test."""
+    from unittest.mock import MagicMock
+
+    from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "gpt-4",
+                "litellm_params": {"model": "gpt-4", "api_key": "fake-key"},
+            }
+        ],
+    )
+
+    provider_headers = {"x-request-id": "req-provider-sync", "openai-organization": "org-real"}
+    source = CustomStreamWrapper(
+        completion_stream=iter([]),
+        model="gpt-4",
+        custom_llm_provider="openai",
+        logging_obj=MagicMock(),
+        _response_headers=provider_headers,
+    )
+
+    result = router._completion_streaming_iterator(
+        model_response=source,
+        messages=[{"role": "user", "content": "hi"}],
+        initial_kwargs={"model": "gpt-4", "stream": True},
+    )
+
+    assert result._response_headers == provider_headers
+    assert result._hidden_params["additional_headers"]["llm_provider-x-request-id"] == "req-provider-sync"
+
+
+def test_adopt_fallback_response_headers_replaces_rather_than_merges():
+    """LIT-6767: direct unit for FallbackAwareStreamWrapper.adopt_fallback_response_headers.
+
+    Values from the failed attempt must not survive, so the wrapper replaces both
+    ``_response_headers`` and ``_hidden_params`` instead of merging them.
+    """
+    from unittest.mock import MagicMock
+
+    from litellm.router import FallbackAwareStreamWrapper, Router
+
+    wrapper = FallbackAwareStreamWrapper(
+        completion_stream=iter([]),
+        model="gpt-4",
+        custom_llm_provider="openai",
+        logging_obj=MagicMock(),
+        _response_headers={"x-request-id": "req-FAILED"},
+    )
+    wrapper._hidden_params = {
+        "model_id": "failed-deployment",
+        "only_on_failed_attempt": "stale",
+        "additional_headers": {"llm_provider-x-request-id": "req-FAILED"},
+    }
+
+    fallback = MagicMock()
+    fallback._response_headers = {"x-request-id": "req-FALLBACK"}
+    fallback._hidden_params = {
+        "model_id": "fallback-deployment",
+        "additional_headers": {"llm_provider-x-request-id": "req-FALLBACK"},
+    }
+
+    wrapper.adopt_fallback_response_headers(
+        fallback, Router._prepare_fallback_hidden_params(fallback)
+    )
+
+    assert wrapper._response_headers == {"x-request-id": "req-FALLBACK"}
+    assert wrapper._hidden_params["model_id"] == "fallback-deployment"
+    assert "only_on_failed_attempt" not in wrapper._hidden_params
+    assert wrapper._hidden_params is not fallback._hidden_params
+    # the snapshot CustomStreamWrapper caches at init has to follow, or a chunk built
+    # from it would still be stamped with the deployment that failed
+    assert wrapper._base_hidden_params["model_id"] == "fallback-deployment"
+    # the nested header dict is copied too, so a later mutation on the fallback
+    # response cannot reach headers the proxy has already published
+    assert wrapper._hidden_params["additional_headers"] is not fallback._hidden_params["additional_headers"]
+    fallback._hidden_params["additional_headers"]["llm_provider-x-request-id"] = "req-MUTATED"
+    assert wrapper._hidden_params["additional_headers"] == {"llm_provider-x-request-id": "req-FALLBACK"}
+
+
+def test_adopt_fallback_response_headers_drops_headers_the_fallback_cannot_replace():
+    """LIT-6767: a fallback that carries no raw provider headers publishes none.
+
+    Keeping the failed attempt's raw headers would hand the client and the callbacks a
+    provider ``x-request-id`` for a request that deployment never served, which is the
+    leak this fix exists to close.
+    """
+    from unittest.mock import MagicMock
+
+    from litellm.router import FallbackAwareStreamWrapper, Router
+
+    wrapper = FallbackAwareStreamWrapper(
+        completion_stream=iter([]),
+        model="gpt-4",
+        custom_llm_provider="openai",
+        logging_obj=MagicMock(),
+        _response_headers={"x-request-id": "req-FAILED"},
+    )
+    wrapper._hidden_params = {"model_id": "failed-deployment", "additional_headers": {}}
+
+    fallback = MagicMock()
+    fallback._response_headers = None
+    fallback._hidden_params = {"model_id": "fallback-deployment"}
+
+    wrapper.adopt_fallback_response_headers(
+        fallback, Router._prepare_fallback_hidden_params(fallback)
+    )
+
+    assert wrapper._response_headers is None
+    assert wrapper._hidden_params["model_id"] == "fallback-deployment"
+    assert wrapper.fallback_headers_adopted is True
+
+
+def test_adopt_fallback_response_headers_keeps_identity_when_fallback_has_none():
+    """A fallback response carrying no hidden params keeps the identity headers.
+
+    Publishing no ``x-litellm-*`` header at all for a request the fallback served is
+    worse than keeping what is there, so only the raw provider headers are dropped.
+    """
+    from unittest.mock import MagicMock
+
+    from litellm.router import FallbackAwareStreamWrapper, Router
+
+    wrapper = FallbackAwareStreamWrapper(
+        completion_stream=iter([]),
+        model="gpt-4",
+        custom_llm_provider="openai",
+        logging_obj=MagicMock(),
+        _response_headers={"x-request-id": "req-FAILED"},
+    )
+    hidden_params_before = wrapper._hidden_params
+
+    fallback = object()
+    wrapper.adopt_fallback_response_headers(
+        fallback, Router._prepare_fallback_hidden_params(fallback)
+    )
+
+    assert wrapper._response_headers is None
+    assert wrapper._hidden_params is hidden_params_before
+    assert wrapper.fallback_headers_adopted is True
+
+
+@pytest.mark.asyncio
+async def test_acompletion_streaming_iterator_adopts_fallback_response_headers():
+    """LIT-6767: after a successful pre-first-chunk fallback, the wrapper must
+    describe the deployment that served the stream, with no value left over
+    from the attempt that failed."""
+    from unittest.mock import MagicMock, patch
+
+    from litellm.exceptions import MidStreamFallbackError
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "gpt-4",
+                "litellm_params": {"model": "gpt-4", "api_key": "fake-key"},
+            }
+        ],
+    )
+
+    failed_error = MidStreamFallbackError(
+        message="upstream died before the first chunk",
+        model="gpt-4",
+        llm_provider="openai",
+        generated_content="",
+        is_pre_first_chunk=True,
+    )
+
+    class FailedStream:
+        def __init__(self):
+            self.model = "gpt-4"
+            self.custom_llm_provider = "openai"
+            self.logging_obj = MagicMock()
+            self.chunks = []
+            self._response_headers = {"x-request-id": "req-FAILED"}
+            self._hidden_params = {
+                "model_id": "failed-deployment",
+                "api_base": "https://failed.example",
+                "additional_headers": {"llm_provider-x-request-id": "req-FAILED"},
+                "only_on_failed_attempt": "stale",
+            }
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise failed_error
+
+    class FallbackStream:
+        def __init__(self):
+            self._response_headers = {"x-request-id": "req-FALLBACK"}
+            self._hidden_params = {
+                "model_id": "fallback-deployment",
+                "api_base": "https://fallback.example",
+                "additional_headers": {"llm_provider-x-request-id": "req-FALLBACK"},
+            }
+            self._chunks = iter([litellm.ModelResponseStream(choices=[{"index": 0, "delta": {"content": "OK"}}])])
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            try:
+                return next(self._chunks)
+            except StopIteration:
+                raise StopAsyncIteration from None
+
+    fallback_stream = FallbackStream()
+    with patch.object(
+        router,
+        "async_function_with_fallbacks_common_utils",
+        return_value=fallback_stream,
+    ):
+        result = await router._acompletion_streaming_iterator(
+            model_response=FailedStream(),
+            messages=[{"role": "user", "content": "hi"}],
+            initial_kwargs={"model": "gpt-4", "stream": True},
+        )
+        # the failed attempt is what the wrapper is built from
+        assert result._response_headers == {"x-request-id": "req-FAILED"}
+        # the very first chunk the fallback produces must already be published under
+        # the fallback's identity: the proxy commits response headers once that chunk
+        # is buffered, so adopting any later is adopting too late
+        await result.__anext__()
+        assert result._response_headers == {"x-request-id": "req-FALLBACK"}
+        assert result._hidden_params["model_id"] == "fallback-deployment"
+        async for _ in result:
+            pass
+
+    assert result._response_headers == {"x-request-id": "req-FALLBACK"}
+    assert result._hidden_params["model_id"] == "fallback-deployment"
+    assert result._hidden_params["api_base"] == "https://fallback.example"
+    assert result._hidden_params["additional_headers"] == {"llm_provider-x-request-id": "req-FALLBACK"}
+    # stale values are removed, not merged over
+    assert "only_on_failed_attempt" not in result._hidden_params
+    # and the wrapper holds its own copy, so later fallback mutations cannot leak in
+    assert result._hidden_params is not fallback_stream._hidden_params
+
+
+def test_completion_streaming_iterator_adopts_fallback_response_headers():
+    """LIT-6767, sync counterpart of the fallback-adoption test."""
+    from unittest.mock import MagicMock, patch
+
+    from litellm.exceptions import MidStreamFallbackError
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "gpt-4",
+                "litellm_params": {"model": "gpt-4", "api_key": "fake-key"},
+            }
+        ],
+    )
+
+    failed_error = MidStreamFallbackError(
+        message="upstream died before the first chunk",
+        model="gpt-4",
+        llm_provider="openai",
+        generated_content="",
+        is_pre_first_chunk=True,
+    )
+
+    class FailedStream:
+        def __init__(self):
+            self.model = "gpt-4"
+            self.custom_llm_provider = "openai"
+            self.logging_obj = MagicMock()
+            self.chunks = []
+            self._response_headers = {"x-request-id": "req-FAILED"}
+            self._hidden_params = {
+                "model_id": "failed-deployment",
+                "additional_headers": {"llm_provider-x-request-id": "req-FAILED"},
+                "only_on_failed_attempt": "stale",
+            }
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            raise failed_error
+
+    class FallbackStream:
+        def __init__(self):
+            self._response_headers = {"x-request-id": "req-FALLBACK"}
+            self._hidden_params = {
+                "model_id": "fallback-deployment",
+                "additional_headers": {"llm_provider-x-request-id": "req-FALLBACK"},
+            }
+
+        def __iter__(self):
+            return iter([])
+
+    with patch.object(router, "function_with_fallbacks", return_value=FallbackStream()):
+        result = router._completion_streaming_iterator(
+            model_response=FailedStream(),
+            messages=[{"role": "user", "content": "hi"}],
+            initial_kwargs={"model": "gpt-4", "stream": True},
+        )
+        assert result._response_headers == {"x-request-id": "req-FAILED"}
+        for _ in result:
+            pass
+
+    assert result._response_headers == {"x-request-id": "req-FALLBACK"}
+    assert result._hidden_params["model_id"] == "fallback-deployment"
+    assert "only_on_failed_attempt" not in result._hidden_params
+
+
 def test_completion_streaming_iterator_fallback_on_429():
     """Sync streaming: MidStreamFallbackError (429 pre-first-chunk) triggers fallback.
 

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -2524,12 +2524,7 @@ def test_adopt_fallback_response_headers_replaces_rather_than_merges():
 
 
 def test_adopt_fallback_response_headers_survives_a_collected_wrapper():
-    """LIT-6767: the fallback generator holds only a weak reference to its wrapper.
-
-    A client that disconnects mid-stream can drop the wrapper while the generator is
-    still draining, and the adoption call has to keep working with nothing to adopt into
-    so the deployment slot is still released.
-    """
+    """LIT-6767: adoption still returns the fallback's params once the wrapper is gone."""
     import weakref
     from unittest.mock import MagicMock
 
@@ -2557,7 +2552,6 @@ def test_adopt_fallback_response_headers_survives_a_collected_wrapper():
     dead_ref: Final = weakref.ref(wrapper)
     del wrapper
     assert dead_ref() is None
-    # no wrapper left to repoint, and the caller still needs the params for the chunks
     assert Router._adopt_fallback_response_headers(dead_ref, fallback) == prepared
 
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Streaming chat completions hand callbacks no provider headers
- A mid stream fallback publishes the failed deployment's headers
- Clients reading `llm_provider-*` on streams see stale or missing values

How it solves it:

- Forward `_response_headers` into both fallback stream wrappers
- Repoint the wrapper at the deployment that served the stream
- Rebuild the response headers once the first chunk is buffered

## User Flow

Before: a developer streaming chat completions cannot tell which deployment answered, and after a failover the headers name a deployment that never produced the reply

1. They send POST https://litellm-domain/v1/chat/completions with `"model": "oa-midfail"` and `"stream": true`, where `oa-midfail` falls back to `oa-good`
2. The upstream for `oa-midfail` opens a 200 SSE stream and dies before the first content chunk, so the reply is served by `oa-good` and streams back normally
3. The response headers still say `x-litellm-model-group: oa-midfail` and `x-litellm-model-api-base: http://127.0.0.1:20769/v1`, which is the deployment that failed
4. Only 6 `llm_provider-*` headers come back, and 3 of them carry the dead deployment's values, including its `llm_provider-x-request-id: req_STALE_FAILED_PROVIDER`
5. Opening a support ticket with that request id gets nowhere, because the provider never saw it

After: the same request reports the deployment that actually answered

1. They send the same POST https://litellm-domain/v1/chat/completions
2. The same failover happens and the reply streams back normally
3. The response headers now say `x-litellm-model-group: oa-good` and `x-litellm-model-api-base: https://api.openai.com`, which is the deployment that served the reply
4. 23 `llm_provider-*` headers come back and none of them carry the dead deployment's values
5. The request id in `llm_provider-x-request-id` is one the provider can look up

## Relevant issues

## Linear ticket

Resolves LIT-6767

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup, identical on both sides, against real OpenAI, real Anthropic and a real Postgres.

`stub.py`, an upstream that opens a real 200 SSE stream carrying its own provider headers and then dies before the first content chunk, which is what makes the proxy fail over mid stream:

```python
import socket

FRAME = (
    b"HTTP/1.1 200 OK\r\n"
    b"Content-Type: text/event-stream; charset=utf-8\r\n"
    b"Transfer-Encoding: chunked\r\n"
    b"x-request-id: req_STALE_FAILED_PROVIDER\r\n"
    b"openai-organization: org-FAILED-PROVIDER\r\n"
    b"stale-marker: failed-deployment\r\n"
    b"\r\n"
    b"200\r\n"
)
srv = socket.socket()
srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
srv.bind(("127.0.0.1", 20769))
srv.listen(16)
while True:
    conn, _ = srv.accept()
    conn.recv(65536)
    conn.sendall(FRAME)
    conn.shutdown(socket.SHUT_RDWR)
    conn.close()
```

`config.yaml`:

```yaml
model_list:
  - model_name: oa-good
    litellm_params:
      model: openai/gpt-4.1-mini
      api_key: os.environ/OPENAI_API_KEY
  - model_name: oa-midfail
    litellm_params:
      model: openai/gpt-4.1-mini
      api_key: os.environ/OPENAI_API_KEY
      api_base: http://127.0.0.1:20769/v1
  - model_name: oa-midfail-x
    litellm_params:
      model: openai/gpt-4.1-mini
      api_key: os.environ/OPENAI_API_KEY
      api_base: http://127.0.0.1:20769/v1
  - model_name: claude-good
    litellm_params:
      model: anthropic/claude-haiku-4-5-20251001
      api_key: os.environ/ANTHROPIC_API_KEY
router_settings:
  num_retries: 0
  fallbacks: [{"oa-midfail": ["oa-good"]}, {"oa-midfail-x": ["claude-good"]}]
litellm_settings:
  callbacks: [probe.probe]
general_settings:
  master_key: os.environ/LITELLM_MASTER_KEY
```

`probe.py`, a plain `CustomLogger` that prints what the streaming callback hooks are handed:

```python
import json
from litellm.integrations.custom_logger import CustomLogger


class HeaderProbe(CustomLogger):
    def record(self, hook, response):
        raw = getattr(response, "_response_headers", None) or {}
        hp = getattr(response, "_hidden_params", None) or {}
        print("PROBE " + json.dumps({
            "hook": hook,
            "raw_header_count": len(raw),
            "wrapper_class": type(response).__name__,
            "model_id": hp.get("model_id"),
            "api_base": hp.get("api_base"),
        }), flush=True)

    async def async_post_call_response_headers_hook(self, data, user_api_key_dict, response, **kwargs):
        self.record("response_headers", response)

    async def async_post_call_streaming_iterator_hook(self, user_api_key_dict, response, request_data):
        self.record("streaming_iterator", response)
        async for chunk in response:
            yield chunk
        self.record("streaming_iterator_end", response)


probe = HeaderProbe()
```

`sync_path.py`, which drives the Router's sync streaming path in process, because the proxy only ever reaches the async one:

```python
import json, os
from litellm import Router

router = Router(
    model_list=[
        {"model_name": "oa-good", "litellm_params": {"model": "openai/gpt-4.1-mini", "api_key": os.environ["OPENAI_API_KEY"]}},
    ],
    num_retries=0,
)
w = router.completion(model="oa-good", messages=[{"role": "user", "content": "Reply exactly OK"}], stream=True, max_tokens=16)
raw = getattr(w, "_response_headers", None) or {}
print(json.dumps({"class": type(w).__name__, "raw_header_count": len(raw)}))
for _ in w:
    pass
```

Both sides run the proxy the same way:

```bash
python stub.py &
python -m litellm.proxy.proxy_cli --config config.yaml --port 4000 --use_prisma_db_push
```

### Before (02522a5441a1aabc7791304a31a9cdcae6db4a37)

#### Case 1: /v1/chat/completions, plain stream, no failover

1. Run the request

   ```bash
   curl -sS -N http://127.0.0.1:4000/v1/chat/completions \
     -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
     -d '{"model":"oa-good","messages":[{"role":"user","content":"Reply exactly OK"}],"stream":true,"max_tokens":16}' \
     -o /dev/null
   ```

2. The proxy log shows the callbacks were handed a wrapper with no provider headers at all

   ```
   PROBE {"hook": "response_headers", "raw_header_count": 0, "wrapper_class": "FallbackStreamWrapper", ...}
   PROBE {"hook": "streaming_iterator", "raw_header_count": 0, "wrapper_class": "FallbackStreamWrapper", ...}
   ```

3. Across a 16 request run, 13 of the 14 streaming callback invocations reported `raw_header_count: 0`

#### Case 2: /v1/chat/completions, stream that fails over before the first chunk

1. Run the request

   ```bash
   curl -sS -N -D headers.txt http://127.0.0.1:4000/v1/chat/completions \
     -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
     -d '{"model":"oa-midfail","messages":[{"role":"user","content":"Reply exactly OK"}],"stream":true,"max_tokens":16}' \
     -o /dev/null
   ```

2. The reply streams back fine, HTTP 200, served by `oa-good`

3. The headers name the deployment that failed, and carry its values

   ```bash
   grep -ci '^llm_provider-' headers.txt
   6
   grep -iE '^x-litellm-model-group:|^x-litellm-model-api-base:' headers.txt
   x-litellm-model-group: oa-midfail
   x-litellm-model-api-base: http://127.0.0.1:20769/v1
   grep -ci 'stale-marker\|req_STALE_FAILED_PROVIDER\|org-FAILED-PROVIDER' headers.txt
   3
   ```

#### Case 3: /v1/chat/completions, cross provider failover

1. Run the request against `oa-midfail-x`, whose fallback is an Anthropic deployment

   ```bash
   curl -sS -N -D headers.txt http://127.0.0.1:4000/v1/chat/completions \
     -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
     -d '{"model":"oa-midfail-x","messages":[{"role":"user","content":"Reply exactly OK"}],"stream":true,"max_tokens":16}' \
     -o /dev/null
   ```

2. Anthropic serves the reply, but the headers describe the OpenAI deployment that failed

   ```bash
   grep -iE '^x-litellm-model-name:|^x-litellm-model-group:' headers.txt
   x-litellm-model-name: openai/gpt-4.1-mini
   x-litellm-model-group: oa-midfail-x
   grep -ci '^llm_provider-' headers.txt
   6
   grep -ci 'stale-marker\|req_STALE_FAILED_PROVIDER\|org-FAILED-PROVIDER' headers.txt
   3
   ```

#### Case 4: /v1/responses and /v1/messages streams

1. Run both

   ```bash
   curl -sS -N http://127.0.0.1:4000/v1/responses -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
     -d '{"model":"oa-good","input":"Reply exactly OK","stream":true,"max_output_tokens":16}' -o /dev/null
   curl -sS -N http://127.0.0.1:4000/v1/messages -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
     -d '{"model":"claude-good","messages":[{"role":"user","content":"Reply exactly OK"}],"stream":true,"max_tokens":16}' -o /dev/null
   ```

2. Both report `raw_header_count: 0` to the callbacks, on their own wrapper classes

   ```
   PROBE {"hook": "response_headers", "raw_header_count": 0, "wrapper_class": "FallbackResponsesStreamWrapper", ...}
   PROBE {"hook": "response_headers", "raw_header_count": 0, "wrapper_class": "FallbackAwareAnthropicMessagesStream", ...}
   ```

#### Case 5: the same failover seen from the proxy's own Swagger UI

1. Open http://127.0.0.1:4000/, click Authorize, enter `Bearer sk-1234`, expand POST /v1/chat/completions, click Try it out

2. Paste `{"model": "oa-midfail", "messages": [{"role": "user", "content": "Reply exactly OK"}], "stream": true, "max_tokens": 16}` and click Execute

3. The Response body streams from `oa-good`, while the Response headers panel names `oa-midfail` and carries `llm_provider-stale-marker: failed-deployment`

   ![before](https://raw.githubusercontent.com/BerriAI/litellm/assets-lit6767/lit6767/base-swagger-response.png)

#### Case 6: the Router's sync streaming path, driven in process

1. Run it

   ```bash
   python sync_path.py
   ```

2. The sync wrapper is handed no provider headers either

   ```
   {"class": "SyncFallbackStreamWrapper", "raw_header_count": 0}
   ```

#### Case 7: a fallback chain two hops deep

1. `oa-nested` falls back to `oa-midfail2`, which falls back to `oa-good`. The first two both point at the stub that dies before its first chunk

   ```bash
   curl -sS -N -D headers.txt http://127.0.0.1:4000/v1/chat/completions \
     -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
     -d '{"model":"oa-nested","messages":[{"role":"user","content":"Reply exactly OK"}],"stream":true,"max_tokens":16}' \
     -o /dev/null
   ```

2. The reply streams back fine, HTTP 200, served by `oa-good`, but the headers name the group that was asked for and never produced a token

   ```
   x-litellm-model-group: oa-nested
   x-litellm-model-api-base: http://127.0.0.1:20769/v1
   llm_provider-x-request-id: req_STALE_FAILED_PROVIDER
   ```

3. 6 `llm_provider-*` headers, all from the dead stub, and `x-litellm-attempted-fallbacks: 0`

4. The same request through the proxy's own Swagger UI

   ![base nested chain in Swagger](https://raw.githubusercontent.com/BerriAI/litellm/assets-lit6767/lit6767/base-nested-swagger.png)

### After (2252b4b790f17e407f666820c6526abbcac6520d)

#### Case 1: /v1/chat/completions, plain stream, no failover

1. Run the same request

   ```bash
   curl -sS -N http://127.0.0.1:4000/v1/chat/completions \
     -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
     -d '{"model":"oa-good","messages":[{"role":"user","content":"Reply exactly OK"}],"stream":true,"max_tokens":16}' \
     -o /dev/null
   ```

2. The callbacks now receive the provider's raw headers

   ```
   PROBE {"hook": "response_headers", "raw_header_count": 24, "wrapper_class": "FallbackStreamWrapper", ...}
   PROBE {"hook": "streaming_iterator", "raw_header_count": 24, "wrapper_class": "FallbackStreamWrapper", ...}
   ```

3. Across the same 16 request run, only 2 of the 14 streaming callback invocations still report `raw_header_count: 0`, and both are the `/v1/responses` and `/v1/messages` wrappers from case 4

#### Case 2: /v1/chat/completions, stream that fails over before the first chunk

1. Run the same request

   ```bash
   curl -sS -N -D headers.txt http://127.0.0.1:4000/v1/chat/completions \
     -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
     -d '{"model":"oa-midfail","messages":[{"role":"user","content":"Reply exactly OK"}],"stream":true,"max_tokens":16}' \
     -o /dev/null
   ```

2. The reply streams back fine, HTTP 200, served by `oa-good`

3. The headers now name the deployment that served, with none of the dead deployment's values

   ```bash
   grep -ci '^llm_provider-' headers.txt
   23
   grep -iE '^x-litellm-model-group:|^x-litellm-model-api-base:' headers.txt
   x-litellm-model-group: oa-good
   x-litellm-model-api-base: https://api.openai.com
   grep -ci 'stale-marker\|req_STALE_FAILED_PROVIDER\|org-FAILED-PROVIDER' headers.txt
   0
   ```

#### Case 3: /v1/chat/completions, cross provider failover

1. Run the same request against `oa-midfail-x`

   ```bash
   curl -sS -N -D headers.txt http://127.0.0.1:4000/v1/chat/completions \
     -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
     -d '{"model":"oa-midfail-x","messages":[{"role":"user","content":"Reply exactly OK"}],"stream":true,"max_tokens":16}' \
     -o /dev/null
   ```

2. The headers now describe the Anthropic deployment that served the reply

   ```bash
   grep -iE '^x-litellm-model-name:|^x-litellm-model-group:' headers.txt
   x-litellm-model-name: anthropic/claude-haiku-4-5-20251001
   x-litellm-model-group: claude-good
   grep -ci '^llm_provider-' headers.txt
   33
   grep -ci 'stale-marker\|req_STALE_FAILED_PROVIDER\|org-FAILED-PROVIDER' headers.txt
   0
   ```

#### Case 4: /v1/responses and /v1/messages streams

1. Run the same two requests

   ```bash
   curl -sS -N http://127.0.0.1:4000/v1/responses -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
     -d '{"model":"oa-good","input":"Reply exactly OK","stream":true,"max_output_tokens":16}' -o /dev/null
   curl -sS -N http://127.0.0.1:4000/v1/messages -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
     -d '{"model":"claude-good","messages":[{"role":"user","content":"Reply exactly OK"}],"stream":true,"max_tokens":16}' -o /dev/null
   ```

2. Both are unchanged, still `raw_header_count: 0`, because they use different wrapper classes that this PR does not touch. They are tracked separately

   ```
   PROBE {"hook": "response_headers", "raw_header_count": 0, "wrapper_class": "FallbackResponsesStreamWrapper", ...}
   PROBE {"hook": "response_headers", "raw_header_count": 0, "wrapper_class": "FallbackAwareAnthropicMessagesStream", ...}
   ```

#### Case 5: the same failover seen from the proxy's own Swagger UI

1. Open http://127.0.0.1:4000/, click Authorize, enter `Bearer sk-1234`, expand POST /v1/chat/completions, click Try it out

2. Paste the same body and click Execute

3. The Response body still streams from `oa-good`, and the Response headers panel now names `oa-good`, points at `https://api.openai.com`, and carries none of the dead deployment's markers

   ![after](https://raw.githubusercontent.com/BerriAI/litellm/assets-lit6767/lit6767/fix-swagger-response.png)

#### Case 6: the Router's sync streaming path, driven in process

1. Run the same script

   ```bash
   python sync_path.py
   ```

2. The sync wrapper now carries the provider's headers

   ```
   {"class": "SyncFallbackStreamWrapper", "raw_header_count": 24}
   ```

#### Case 7: a fallback chain two hops deep

1. Run the same request

   ```bash
   curl -sS -N -D headers.txt http://127.0.0.1:4000/v1/chat/completions \
     -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
     -d '{"model":"oa-nested","messages":[{"role":"user","content":"Reply exactly OK"}],"stream":true,"max_tokens":16}' \
     -o /dev/null
   ```

2. The headers now name the deployment at the end of the chain, the one that actually served

   ```
   x-litellm-model-group: oa-good
   x-litellm-model-api-base: https://api.openai.com
   llm_provider-x-request-id: req_cb2d3da839204d7b9f3a771a49821406
   ```

3. 24 `llm_provider-*` headers, 0 headers left over from either failed hop, and `x-litellm-attempted-fallbacks: 2`

4. The same request through the proxy's own Swagger UI. The chunk bodies now name `oa-good` too

   ![fixed nested chain in Swagger](https://raw.githubusercontent.com/BerriAI/litellm/assets-lit6767/lit6767/fix-nested-swagger.png)

Also run on both sides and identical: non streaming chat completions, a pre request 404 failover, Anthropic through `/v1/chat/completions`, 8 concurrent streams, and the OpenAI passthrough route `/openai/v1/chat/completions` streaming and non streaming, where both sides returned the same 25 and 27 header key sets and byte identical bodies. The failover and the two hop chain were also driven under `cost-based-routing`, `least-busy`, `latency-based-routing` and a local response cache, and 8 times each against a 4 worker proxy on both sides, with every leg matching the single worker result

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- After a mid stream failover `x-litellm-model-group` names the group that served, not the group requested. The pre request failover path already behaved this way, so this makes the two consistent
- With `sse_keepalive_ping_interval_seconds` set, the proxy commits headers before the failover happens, so neither side publishes any `x-litellm-*` or `llm_provider-*` header on that request. This is pre existing and unchanged by this PR, and the callback half of the fix still works there

### Low

- `async_post_call_response_headers_hook` still fires once before the first chunk, so on a failover it sees the attempt the router picked first. On base that hook is handed a wrapper with no provider headers at all, so this is an improvement rather than a new gap, and the same wrapper repoints itself before the stream drains. Re-invoking the hook after the failover would fire every user callback twice, so that is a follow up. The client headers and the streaming iterator hook are both correct
- The sync mid stream failover errors out the same way on both sides in this rig, so only its header adoption is covered by unit tests. The sync header forwarding is covered live in case 6
- `/v1/responses` and `/v1/messages` streams still hand callbacks no raw provider headers. They use separate wrapper classes and are out of scope here

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm/pull/40091" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

ran /live-pr-risk and found no regressions/backward incompatible risks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core streaming and router fallback paths where response headers are committed at first chunk; behavior change for mid-stream failover (headers now name the serving deployment) is intentional but affects observability and callbacks.
> 
> **Overview**
> Fixes **LIT-6767**: streaming chat completions could expose the **failed** deployment’s `x-litellm-*` and `llm_provider-*` headers (or none at all) when the router failed over before the first SSE chunk.
> 
> The **router** adds `FallbackAwareStreamWrapper`, which **replaces** (not merges) `_response_headers` and `_hidden_params` when a fallback stream takes over, copies provider headers into async/sync fallback wrappers, and re-adopts identity on the **first yielded chunk** so nested fallbacks stay correct. A **weakref** avoids keeping the wrapper alive past teardown.
> 
> The **proxy** adds optional **`refresh_headers`** to `create_response`, called **after** the first chunk is buffered so HTTP headers can match the serving deployment before they are committed. The streaming success path builds headers via `_stream_response_headers` and passes a `refresh_stream_headers` closure when `fallback_headers_adopted` is set. SSE anti-buffering headers are centralized in `_sse_stream_headers`; several APIs now take `Mapping[str, str]` instead of mutable dicts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2252b4b790f17e407f666820c6526abbcac6520d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->