### PR TITLE
feat: add Jalapeno Cloud as an OpenAI-compatible provider

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -874,6 +874,7 @@ openai_compatible_endpoints: Final[list] = [
     "https://api.meta.ai/v1",
     "https://api.cognition.ai/v1",
     "https://api.scx.ai/v1",
+    "https://api.jalapeno-cloud.ai/v1",
     "https://gigachat.devices.sberbank.ru/api/v1",
 ]
 
@@ -946,6 +947,7 @@ openai_compatible_providers: Final[list] = [
     "meta",  # Meta Model API (Muse Spark) - JSON-configured provider
     "cognition",
     "scx-ai",
+    "jalapeno",  # Jalapeno Cloud - JSON-configured provider
 ]
 openai_text_completion_compatible_providers: Final[list] = [  # providers that support `/v1/completions`
     "together_ai",

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -947,7 +947,7 @@ openai_compatible_providers: Final[list] = [
     "meta",  # Meta Model API (Muse Spark) - JSON-configured provider
     "cognition",
     "scx-ai",
-    "jalapeno",  # Jalapeno Cloud - JSON-configured provider
+    "jalapeno",
 ]
 openai_text_completion_compatible_providers: Final[list] = [  # providers that support `/v1/completions`
     "together_ai",

--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -200,5 +200,18 @@
       "temperature_max": 1.99
     },
     "supported_endpoints": ["/v1/chat/completions"]
+  },
+  "jalapeno": {
+    "base_url": "https://api.jalapeno-cloud.ai/v1",
+    "api_key_env": "JALAPENO_API_KEY",
+    "api_base_env": "JALAPENO_API_BASE",
+    "param_mappings": {
+      "max_completion_tokens": "max_tokens"
+    },
+    "supported_endpoints": [
+      "/v1/chat/completions",
+      "/v1/responses",
+      "/v1/messages"
+    ]
   }
 }

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -63784,5 +63784,390 @@
         "supports_tool_choice": false,
         "supports_response_schema": true,
         "supports_vision": false
+    },
+    "jalapeno/DeepSeek-V4-Flash": {
+        "input_cost_per_token": 1.4e-07,
+        "output_cost_per_token": 2.8e-07,
+        "litellm_provider": "jalapeno",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 393216,
+        "max_tokens": 393216,
+        "mode": "chat",
+        "source": "https://www.jalapeno-cloud.ai/models",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses",
+            "/v1/messages"
+        ],
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true
+    },
+    "jalapeno/DeepSeek-V4-Flash-0731": {
+        "input_cost_per_token": 4.4e-07,
+        "output_cost_per_token": 1.32e-06,
+        "litellm_provider": "jalapeno",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 393216,
+        "max_tokens": 393216,
+        "mode": "chat",
+        "source": "https://www.jalapeno-cloud.ai/models",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses",
+            "/v1/messages"
+        ],
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true,
+        "supports_vision": true
+    },
+    "jalapeno/DeepSeek-V4-Pro": {
+        "input_cost_per_token": 1.6e-06,
+        "output_cost_per_token": 3.38e-06,
+        "litellm_provider": "jalapeno",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 393216,
+        "max_tokens": 393216,
+        "mode": "chat",
+        "source": "https://www.jalapeno-cloud.ai/models",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses",
+            "/v1/messages"
+        ],
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true
+    },
+    "jalapeno/GLM-5.1": {
+        "input_cost_per_token": 1.38e-06,
+        "output_cost_per_token": 4.4e-06,
+        "litellm_provider": "jalapeno",
+        "max_input_tokens": 202752,
+        "max_output_tokens": 202752,
+        "max_tokens": 202752,
+        "mode": "chat",
+        "source": "https://www.jalapeno-cloud.ai/models",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses",
+            "/v1/messages"
+        ],
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true
+    },
+    "jalapeno/GLM-5.2": {
+        "input_cost_per_token": 1.4e-06,
+        "output_cost_per_token": 4.4e-06,
+        "litellm_provider": "jalapeno",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "source": "https://www.jalapeno-cloud.ai/models",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses",
+            "/v1/messages"
+        ],
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true
+    },
+    "jalapeno/GLM-5.3": {
+        "input_cost_per_token": 1.4e-06,
+        "output_cost_per_token": 4.4e-06,
+        "litellm_provider": "jalapeno",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "source": "https://www.jalapeno-cloud.ai/models",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses",
+            "/v1/messages"
+        ],
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true
+    },
+    "jalapeno/GLM-5.3-Flash": {
+        "input_cost_per_token": 1.5e-07,
+        "output_cost_per_token": 5e-07,
+        "litellm_provider": "jalapeno",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "source": "https://www.jalapeno-cloud.ai/models",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses",
+            "/v1/messages"
+        ],
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true
+    },
+    "jalapeno/Hy4": {
+        "input_cost_per_token": 8.34e-07,
+        "output_cost_per_token": 2.501e-06,
+        "litellm_provider": "jalapeno",
+        "max_input_tokens": 202752,
+        "max_output_tokens": 202752,
+        "max_tokens": 202752,
+        "mode": "chat",
+        "source": "https://www.jalapeno-cloud.ai/models",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses",
+            "/v1/messages"
+        ],
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true
+    },
+    "jalapeno/Kimi-K2.5": {
+        "input_cost_per_token": 6e-07,
+        "output_cost_per_token": 3e-06,
+        "litellm_provider": "jalapeno",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 180224,
+        "max_tokens": 180224,
+        "mode": "chat",
+        "source": "https://www.jalapeno-cloud.ai/models",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses",
+            "/v1/messages"
+        ],
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true,
+        "supports_vision": true
+    },
+    "jalapeno/Kimi-K2.7-Code": {
+        "input_cost_per_token": 9.5e-07,
+        "output_cost_per_token": 4e-06,
+        "litellm_provider": "jalapeno",
+        "max_input_tokens": 271360,
+        "max_output_tokens": 271360,
+        "max_tokens": 271360,
+        "mode": "chat",
+        "source": "https://www.jalapeno-cloud.ai/models",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses",
+            "/v1/messages"
+        ],
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true
+    },
+    "jalapeno/Kimi-K3": {
+        "input_cost_per_token": 3e-06,
+        "output_cost_per_token": 1.5e-05,
+        "litellm_provider": "jalapeno",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 1048576,
+        "max_tokens": 1048576,
+        "mode": "chat",
+        "source": "https://www.jalapeno-cloud.ai/models",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses",
+            "/v1/messages"
+        ],
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true
+    },
+    "jalapeno/MiniMax-M3": {
+        "input_cost_per_token": 3e-07,
+        "output_cost_per_token": 1.2e-06,
+        "litellm_provider": "jalapeno",
+        "max_input_tokens": 524288,
+        "max_output_tokens": 524288,
+        "max_tokens": 524288,
+        "mode": "chat",
+        "source": "https://www.jalapeno-cloud.ai/models",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses",
+            "/v1/messages"
+        ],
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true
+    },
+    "jalapeno/Qwen3.5-27B": {
+        "input_cost_per_token": 3e-07,
+        "output_cost_per_token": 2.4e-06,
+        "litellm_provider": "jalapeno",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "source": "https://www.jalapeno-cloud.ai/models",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses",
+            "/v1/messages"
+        ],
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true
+    },
+    "jalapeno/Qwen3.5-35B-A3B": {
+        "input_cost_per_token": 2.5e-07,
+        "output_cost_per_token": 2e-06,
+        "litellm_provider": "jalapeno",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "source": "https://www.jalapeno-cloud.ai/models",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses",
+            "/v1/messages"
+        ],
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true
+    },
+    "jalapeno/Qwen3.5-122B-A10B": {
+        "input_cost_per_token": 4e-07,
+        "output_cost_per_token": 3.2e-06,
+        "litellm_provider": "jalapeno",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "source": "https://www.jalapeno-cloud.ai/models",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses",
+            "/v1/messages"
+        ],
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true
+    },
+    "jalapeno/Qwen3.5-397B-A17B": {
+        "input_cost_per_token": 6e-07,
+        "output_cost_per_token": 3.6e-06,
+        "litellm_provider": "jalapeno",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "source": "https://www.jalapeno-cloud.ai/models",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses",
+            "/v1/messages"
+        ],
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true
+    },
+    "jalapeno/Qwen3-Next-80B-A3B-Instruct": {
+        "input_cost_per_token": 1.5e-07,
+        "output_cost_per_token": 1.5e-06,
+        "litellm_provider": "jalapeno",
+        "max_input_tokens": 129024,
+        "max_output_tokens": 129024,
+        "max_tokens": 129024,
+        "mode": "chat",
+        "source": "https://www.jalapeno-cloud.ai/models",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses",
+            "/v1/messages"
+        ],
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_response_schema": true
+    },
+    "jalapeno/Qwen3-Next-80B-A3B-Thinking": {
+        "input_cost_per_token": 1.5e-07,
+        "output_cost_per_token": 1.5e-06,
+        "litellm_provider": "jalapeno",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "source": "https://www.jalapeno-cloud.ai/models",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses",
+            "/v1/messages"
+        ],
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true
+    },
+    "jalapeno/Qwen3-VL-235B-A22B-Instruct": {
+        "input_cost_per_token": 3e-07,
+        "output_cost_per_token": 1.5e-06,
+        "litellm_provider": "jalapeno",
+        "max_input_tokens": 129024,
+        "max_output_tokens": 129024,
+        "max_tokens": 129024,
+        "mode": "chat",
+        "source": "https://www.jalapeno-cloud.ai/models",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses",
+            "/v1/messages"
+        ],
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "jalapeno/Qwen3-VL-235B-A22B-Thinking": {
+        "input_cost_per_token": 9.8e-07,
+        "output_cost_per_token": 3.95e-06,
+        "litellm_provider": "jalapeno",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "source": "https://www.jalapeno-cloud.ai/models",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses",
+            "/v1/messages"
+        ],
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true,
+        "supports_vision": true
     }
 }

--- a/litellm/provider_endpoints_support_backup.json
+++ b/litellm/provider_endpoints_support_backup.json
@@ -1291,6 +1291,23 @@
         "rerank": false
       }
     },
+    "jalapeno": {
+      "display_name": "Jalapeno Cloud (`jalapeno`)",
+      "url": "https://docs.litellm.ai/docs/providers/jalapeno",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": true,
+        "responses": true,
+        "embeddings": false,
+        "image_generations": false,
+        "audio_transcriptions": false,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "a2a": false
+      }
+    },
     "jina_ai": {
       "display_name": "Jina AI (`jina_ai`)",
       "url": "https://docs.litellm.ai/docs/providers/jina_ai",

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3979,6 +3979,7 @@ class LlmProviders(str, Enum):
     SCX_AI = "scx-ai"
     DARKBLOOM = "darkbloom"
     META = "meta"
+    JALAPENO = "jalapeno"
     LITELLM_AGENT = "litellm_agent"
     CURSOR = "cursor"
     BEDROCK_MANTLE = "bedrock_mantle"

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -63784,5 +63784,390 @@
         "supports_tool_choice": false,
         "supports_response_schema": true,
         "supports_vision": false
+    },
+    "jalapeno/DeepSeek-V4-Flash": {
+        "input_cost_per_token": 1.4e-07,
+        "output_cost_per_token": 2.8e-07,
+        "litellm_provider": "jalapeno",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 393216,
+        "max_tokens": 393216,
+        "mode": "chat",
+        "source": "https://www.jalapeno-cloud.ai/models",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses",
+            "/v1/messages"
+        ],
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true
+    },
+    "jalapeno/DeepSeek-V4-Flash-0731": {
+        "input_cost_per_token": 4.4e-07,
+        "output_cost_per_token": 1.32e-06,
+        "litellm_provider": "jalapeno",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 393216,
+        "max_tokens": 393216,
+        "mode": "chat",
+        "source": "https://www.jalapeno-cloud.ai/models",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses",
+            "/v1/messages"
+        ],
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true,
+        "supports_vision": true
+    },
+    "jalapeno/DeepSeek-V4-Pro": {
+        "input_cost_per_token": 1.6e-06,
+        "output_cost_per_token": 3.38e-06,
+        "litellm_provider": "jalapeno",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 393216,
+        "max_tokens": 393216,
+        "mode": "chat",
+        "source": "https://www.jalapeno-cloud.ai/models",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses",
+            "/v1/messages"
+        ],
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true
+    },
+    "jalapeno/GLM-5.1": {
+        "input_cost_per_token": 1.38e-06,
+        "output_cost_per_token": 4.4e-06,
+        "litellm_provider": "jalapeno",
+        "max_input_tokens": 202752,
+        "max_output_tokens": 202752,
+        "max_tokens": 202752,
+        "mode": "chat",
+        "source": "https://www.jalapeno-cloud.ai/models",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses",
+            "/v1/messages"
+        ],
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true
+    },
+    "jalapeno/GLM-5.2": {
+        "input_cost_per_token": 1.4e-06,
+        "output_cost_per_token": 4.4e-06,
+        "litellm_provider": "jalapeno",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "source": "https://www.jalapeno-cloud.ai/models",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses",
+            "/v1/messages"
+        ],
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true
+    },
+    "jalapeno/GLM-5.3": {
+        "input_cost_per_token": 1.4e-06,
+        "output_cost_per_token": 4.4e-06,
+        "litellm_provider": "jalapeno",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "source": "https://www.jalapeno-cloud.ai/models",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses",
+            "/v1/messages"
+        ],
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true
+    },
+    "jalapeno/GLM-5.3-Flash": {
+        "input_cost_per_token": 1.5e-07,
+        "output_cost_per_token": 5e-07,
+        "litellm_provider": "jalapeno",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "source": "https://www.jalapeno-cloud.ai/models",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses",
+            "/v1/messages"
+        ],
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true
+    },
+    "jalapeno/Hy4": {
+        "input_cost_per_token": 8.34e-07,
+        "output_cost_per_token": 2.501e-06,
+        "litellm_provider": "jalapeno",
+        "max_input_tokens": 202752,
+        "max_output_tokens": 202752,
+        "max_tokens": 202752,
+        "mode": "chat",
+        "source": "https://www.jalapeno-cloud.ai/models",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses",
+            "/v1/messages"
+        ],
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true
+    },
+    "jalapeno/Kimi-K2.5": {
+        "input_cost_per_token": 6e-07,
+        "output_cost_per_token": 3e-06,
+        "litellm_provider": "jalapeno",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 180224,
+        "max_tokens": 180224,
+        "mode": "chat",
+        "source": "https://www.jalapeno-cloud.ai/models",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses",
+            "/v1/messages"
+        ],
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true,
+        "supports_vision": true
+    },
+    "jalapeno/Kimi-K2.7-Code": {
+        "input_cost_per_token": 9.5e-07,
+        "output_cost_per_token": 4e-06,
+        "litellm_provider": "jalapeno",
+        "max_input_tokens": 271360,
+        "max_output_tokens": 271360,
+        "max_tokens": 271360,
+        "mode": "chat",
+        "source": "https://www.jalapeno-cloud.ai/models",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses",
+            "/v1/messages"
+        ],
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true
+    },
+    "jalapeno/Kimi-K3": {
+        "input_cost_per_token": 3e-06,
+        "output_cost_per_token": 1.5e-05,
+        "litellm_provider": "jalapeno",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 1048576,
+        "max_tokens": 1048576,
+        "mode": "chat",
+        "source": "https://www.jalapeno-cloud.ai/models",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses",
+            "/v1/messages"
+        ],
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true
+    },
+    "jalapeno/MiniMax-M3": {
+        "input_cost_per_token": 3e-07,
+        "output_cost_per_token": 1.2e-06,
+        "litellm_provider": "jalapeno",
+        "max_input_tokens": 524288,
+        "max_output_tokens": 524288,
+        "max_tokens": 524288,
+        "mode": "chat",
+        "source": "https://www.jalapeno-cloud.ai/models",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses",
+            "/v1/messages"
+        ],
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true
+    },
+    "jalapeno/Qwen3.5-27B": {
+        "input_cost_per_token": 3e-07,
+        "output_cost_per_token": 2.4e-06,
+        "litellm_provider": "jalapeno",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "source": "https://www.jalapeno-cloud.ai/models",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses",
+            "/v1/messages"
+        ],
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true
+    },
+    "jalapeno/Qwen3.5-35B-A3B": {
+        "input_cost_per_token": 2.5e-07,
+        "output_cost_per_token": 2e-06,
+        "litellm_provider": "jalapeno",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "source": "https://www.jalapeno-cloud.ai/models",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses",
+            "/v1/messages"
+        ],
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true
+    },
+    "jalapeno/Qwen3.5-122B-A10B": {
+        "input_cost_per_token": 4e-07,
+        "output_cost_per_token": 3.2e-06,
+        "litellm_provider": "jalapeno",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "source": "https://www.jalapeno-cloud.ai/models",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses",
+            "/v1/messages"
+        ],
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true
+    },
+    "jalapeno/Qwen3.5-397B-A17B": {
+        "input_cost_per_token": 6e-07,
+        "output_cost_per_token": 3.6e-06,
+        "litellm_provider": "jalapeno",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "source": "https://www.jalapeno-cloud.ai/models",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses",
+            "/v1/messages"
+        ],
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true
+    },
+    "jalapeno/Qwen3-Next-80B-A3B-Instruct": {
+        "input_cost_per_token": 1.5e-07,
+        "output_cost_per_token": 1.5e-06,
+        "litellm_provider": "jalapeno",
+        "max_input_tokens": 129024,
+        "max_output_tokens": 129024,
+        "max_tokens": 129024,
+        "mode": "chat",
+        "source": "https://www.jalapeno-cloud.ai/models",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses",
+            "/v1/messages"
+        ],
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_response_schema": true
+    },
+    "jalapeno/Qwen3-Next-80B-A3B-Thinking": {
+        "input_cost_per_token": 1.5e-07,
+        "output_cost_per_token": 1.5e-06,
+        "litellm_provider": "jalapeno",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "source": "https://www.jalapeno-cloud.ai/models",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses",
+            "/v1/messages"
+        ],
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true
+    },
+    "jalapeno/Qwen3-VL-235B-A22B-Instruct": {
+        "input_cost_per_token": 3e-07,
+        "output_cost_per_token": 1.5e-06,
+        "litellm_provider": "jalapeno",
+        "max_input_tokens": 129024,
+        "max_output_tokens": 129024,
+        "max_tokens": 129024,
+        "mode": "chat",
+        "source": "https://www.jalapeno-cloud.ai/models",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses",
+            "/v1/messages"
+        ],
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "jalapeno/Qwen3-VL-235B-A22B-Thinking": {
+        "input_cost_per_token": 9.8e-07,
+        "output_cost_per_token": 3.95e-06,
+        "litellm_provider": "jalapeno",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "source": "https://www.jalapeno-cloud.ai/models",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses",
+            "/v1/messages"
+        ],
+        "supports_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true,
+        "supports_vision": true
     }
 }

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -3034,6 +3034,23 @@
         "rerank": false,
         "a2a": false
       }
+    },
+    "jalapeno": {
+      "display_name": "Jalapeno Cloud (`jalapeno`)",
+      "url": "https://docs.litellm.ai/docs/providers/jalapeno",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": true,
+        "responses": true,
+        "embeddings": false,
+        "image_generations": false,
+        "audio_transcriptions": false,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "a2a": false
+      }
     }
   },
   "endpoints": {

--- a/tests/test_litellm/llms/openai_like/test_jalapeno_provider.py
+++ b/tests/test_litellm/llms/openai_like/test_jalapeno_provider.py
@@ -1,0 +1,183 @@
+import litellm
+
+
+JALAPENO_BASE_URL = "https://api.jalapeno-cloud.ai/v1"
+
+
+class TestJalapenoProviderConfig:
+    def test_jalapeno_in_provider_list(self):
+        from litellm import LlmProviders
+
+        assert hasattr(LlmProviders, "JALAPENO")
+        assert LlmProviders.JALAPENO.value == "jalapeno"
+        assert "jalapeno" in litellm.provider_list
+
+    def test_jalapeno_json_config_exists(self):
+        from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+
+        assert JSONProviderRegistry.exists("jalapeno")
+        provider = JSONProviderRegistry.get("jalapeno")
+        assert provider is not None
+        assert provider.base_url == JALAPENO_BASE_URL
+        assert provider.api_key_env == "JALAPENO_API_KEY"
+        assert provider.api_base_env == "JALAPENO_API_BASE"
+        assert provider.param_mappings.get("max_completion_tokens") == "max_tokens"
+        assert provider.supported_endpoints == [
+            "/v1/chat/completions",
+            "/v1/responses",
+            "/v1/messages",
+        ]
+
+    def test_jalapeno_in_openai_compatible_lists(self):
+        from litellm.constants import (
+            openai_compatible_endpoints,
+            openai_compatible_providers,
+        )
+
+        assert "jalapeno" in openai_compatible_providers
+        assert JALAPENO_BASE_URL in openai_compatible_endpoints
+
+    def test_jalapeno_provider_resolution(self):
+        from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+
+        model, provider, api_key, api_base = get_llm_provider(
+            model="jalapeno/DeepSeek-V4-Flash",
+            custom_llm_provider=None,
+            api_base=None,
+            api_key=None,
+        )
+        assert model == "DeepSeek-V4-Flash"
+        assert provider == "jalapeno"
+        assert api_base == JALAPENO_BASE_URL
+
+    def test_jalapeno_api_base_inference(self):
+        from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+
+        model, provider, api_key, api_base = get_llm_provider(
+            model="DeepSeek-V4-Flash",
+            custom_llm_provider=None,
+            api_base=JALAPENO_BASE_URL,
+            api_key="sk-test",
+        )
+        assert model == "DeepSeek-V4-Flash"
+        assert provider == "jalapeno"
+        assert api_base == JALAPENO_BASE_URL
+        assert api_key == "sk-test"
+
+    def test_jalapeno_maps_max_completion_tokens(self):
+        from litellm.llms.openai_like.dynamic_config import create_config_class
+        from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+
+        provider = JSONProviderRegistry.get("jalapeno")
+        assert provider is not None
+        config = create_config_class(provider)()
+        params = config.map_openai_params(
+            non_default_params={"max_completion_tokens": 256},
+            optional_params={},
+            model="jalapeno/DeepSeek-V4-Flash",
+            drop_params=False,
+        )
+        assert params.get("max_tokens") == 256
+        assert "max_completion_tokens" not in params
+
+    def test_jalapeno_chat_complete_url(self):
+        from litellm.llms.openai_like.dynamic_config import create_config_class
+        from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+
+        provider = JSONProviderRegistry.get("jalapeno")
+        assert provider is not None
+        config = create_config_class(provider)()
+        url = config.get_complete_url(
+            api_base=JALAPENO_BASE_URL,
+            api_key="sk-test",
+            model="jalapeno/DeepSeek-V4-Flash",
+            optional_params={},
+            litellm_params={},
+            stream=False,
+        )
+        assert url == f"{JALAPENO_BASE_URL}/chat/completions"
+
+    def test_jalapeno_model_cost_map(self):
+        info = litellm.model_cost["jalapeno/DeepSeek-V4-Flash"]
+        assert info["litellm_provider"] == "jalapeno"
+        assert info["mode"] == "chat"
+        assert info["input_cost_per_token"] == 1.4e-07
+        assert info["output_cost_per_token"] == 2.8e-07
+        assert info["max_input_tokens"] == 1048576
+        assert info["supports_function_calling"] is True
+        assert info["supports_reasoning"] is True
+        assert "/v1/chat/completions" in info["supported_endpoints"]
+        assert "/v1/responses" in info["supported_endpoints"]
+        assert "/v1/messages" in info["supported_endpoints"]
+
+    def test_jalapeno_supported_endpoints_matrix(self):
+        import json
+        from pathlib import Path
+
+        backup_path = (
+            Path(litellm.__file__).parent / "provider_endpoints_support_backup.json"
+        )
+        matrix = json.loads(backup_path.read_text())
+        assert "jalapeno" in matrix["providers"]
+        endpoints = matrix["providers"]["jalapeno"]["endpoints"]
+        assert endpoints["chat_completions"] is True
+        assert endpoints["messages"] is True
+        assert endpoints["responses"] is True
+
+
+class TestJalapenoResponsesAndMessages:
+    def test_jalapeno_responses_config_url_and_auth(self, monkeypatch):
+        from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+        from litellm.utils import ProviderConfigManager
+
+        assert JSONProviderRegistry.supports_responses_api("jalapeno") is True
+        config = ProviderConfigManager.get_provider_responses_api_config(
+            provider="jalapeno",
+            model="jalapeno/DeepSeek-V4-Flash",
+        )
+        assert config is not None
+        assert config.custom_llm_provider == "jalapeno"
+        assert (
+            config.get_complete_url(api_base=None, litellm_params={})
+            == f"{JALAPENO_BASE_URL}/responses"
+        )
+
+        monkeypatch.setenv("JALAPENO_API_KEY", "sk-env-key")
+        headers = config.validate_environment(
+            headers={}, model="DeepSeek-V4-Flash", litellm_params=None
+        )
+        assert headers["Authorization"] == "Bearer sk-env-key"
+
+    def test_jalapeno_messages_config_url_and_auth(self, monkeypatch):
+        from litellm.llms.openai_like.messages.transformation import (
+            JSONProviderAnthropicMessagesConfig,
+        )
+
+        cfg = litellm.ProviderConfigManager.get_provider_anthropic_messages_config(
+            model="DeepSeek-V4-Flash",
+            provider=litellm.LlmProviders.JALAPENO,
+        )
+        assert isinstance(cfg, JSONProviderAnthropicMessagesConfig)
+        assert (
+            cfg.get_complete_url(
+                api_base=None,
+                api_key="sk-test",
+                model="DeepSeek-V4-Flash",
+                optional_params={},
+                litellm_params={},
+            )
+            == f"{JALAPENO_BASE_URL}/messages"
+        )
+
+        monkeypatch.setenv("JALAPENO_API_KEY", "sk-env-key")
+        headers, _ = cfg.validate_anthropic_messages_environment(
+            headers={},
+            model="DeepSeek-V4-Flash",
+            messages=[{"role": "user", "content": "hi"}],
+            optional_params={},
+            litellm_params={},
+            api_key=None,
+            api_base=None,
+        )
+        assert headers["authorization"] == "Bearer sk-env-key"
+        assert headers["anthropic-version"] == "2023-06-01"


### PR DESCRIPTION
Register jalapeno with chat/completions, responses, and messages support, including model pricing from the public marketplace catalog.

## TLDR

Problem this solves:

- Jalapeno Cloud is not a built-in LiteLLM provider
- Apps must manually set `api_base` for every call
- Cost tracking has no Jalapeno model prices

How it solves it:

- Adds `jalapeno/` as an OpenAI-compatible provider
- Supports chat completions, responses, and messages
- Ships marketplace pricing for 20 Jalapeno models

## User Flow

Before: a developer calling Jalapeno through LiteLLM has no built-in provider, so they must wire a custom OpenAI-compatible base URL by hand

1. They set a custom OpenAI-compatible route to `https://api.jalapeno-cloud.ai/v1` with their Jalapeno API key
2. They send `POST https://litellm-domain/v1/chat/completions` with a model like `openai/DeepSeek-V4-Flash` (or another custom prefix) and messages
3. The call may work only if they configured `api_base` correctly; `jalapeno/...` is not recognized as a first-class provider
4. Spend / model info for Jalapeno models is missing or wrong in logs and cost views

After: the same developer uses the built-in `jalapeno/` provider with catalog pricing

1. They set `JALAPENO_API_KEY` (optional: `JALAPENO_API_BASE`)
2. They send `POST https://litellm-domain/v1/chat/completions` with `"model": "jalapeno/DeepSeek-V4-Flash"` and messages
3. LiteLLM routes to Jalapeno and returns a normal chat completion
4. The same model works on `POST /v1/responses` and `POST /v1/messages`
5. Logs / spend use the catalog prices from https://www.jalapeno-cloud.ai/models

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup:

- Env: `export JALAPENO_API_KEY=...`
- Model: `jalapeno/DeepSeek-V4-Flash`
- Tip commit for After: `34d94ff49d1f5893d5c9c5322374feeb9bf99237`

### Before (`litellm_internal_staging` / merge base)

#### `/v1/chat/completions`

1. Call LiteLLM / SDK with `model="jalapeno/DeepSeek-V4-Flash"` and a simple user message
2. Observe: provider is not registered / request fails as an unknown or unsupported provider

#### `/v1/responses`

1. Call with `model="jalapeno/DeepSeek-V4-Flash"` and a simple input
2. Observe: Jalapeno responses route is unavailable

#### `/v1/messages`

1. Call Anthropic-style messages with `model="jalapeno/DeepSeek-V4-Flash"`
2. Observe: Jalapeno messages route is unavailable

### After (`34d94ff49d1f5893d5c9c5322374feeb9bf99237`)

#### `/v1/chat/completions`

1. `curl -sS https://api.jalapeno-cloud.ai/v1/chat/completions -H "Authorization: Bearer $JALAPENO_API_KEY" -H "Content-Type: application/json" -d '{"model":"DeepSeek-V4-Flash","messages":[{"role":"user","content":"ping"}],"max_tokens":16}'`
2. 200 response

#### `/v1/responses`

1. `curl -sS https://api.jalapeno-cloud.ai/v1/responses -H "Authorization: Bearer $JALAPENO_API_KEY" -H "Content-Type: application/json" -d '{"model":"DeepSeek-V4-Flash","input":"ping","max_output_tokens":16}'`
2. 200 response

#### `/v1/messages`

1. `curl -sS https://api.jalapeno-cloud.ai/v1/messages -H "Authorization: Bearer $JALAPENO_API_KEY" -H "Content-Type: application/json" -H "anthropic-version: 2023-06-01" -d '{"model":"DeepSeek-V4-Flash","max_tokens":16,"messages":[{"role":"user","content":"ping"}]}'`
2. 200 response

Local unit proof (not a substitute for the live section above):

```bash
uv run pytest tests/test_litellm/llms/openai_like/test_jalapeno_provider.py -v
# 11 passed