### PR TITLE
fix(transcription): preserve literal text in WebVTT cues

### DIFF
--- a/litellm/litellm_core_utils/audio_utils/subtitle_utils.py
+++ b/litellm/litellm_core_utils/audio_utils/subtitle_utils.py
@@ -3,6 +3,7 @@
 import unicodedata
 from collections.abc import Sequence
 from dataclasses import dataclass
+from html import escape
 from itertools import accumulate, groupby
 from typing import Final
 
@@ -210,7 +211,7 @@ def _render_vtt(cues: Sequence[SubtitleCue]) -> str:
         for cue in cues
         for line in (
             f"{_format_timestamp(cue.start_ms, '.')} --> {_format_timestamp(cue.end_ms, '.')}",
-            cue.text,
+            escape(cue.text, quote=False),
             "",
         )
     )

--- a/tests/test_litellm/litellm_core_utils/audio_utils/test_subtitle_utils.py
+++ b/tests/test_litellm/litellm_core_utils/audio_utils/test_subtitle_utils.py
@@ -1,3 +1,7 @@
+from typing import Final
+
+import pytest
+
 from litellm.litellm_core_utils.audio_utils.subtitle_utils import (
     SubtitleToken,
     _merge_tokens_into_words,
@@ -105,6 +109,19 @@ class TestRenderSubtitleTokensAsSrt:
 
 
 class TestRenderSubtitleTokensAsVtt:
+    @pytest.mark.parametrize(
+        ("text", "payload"),
+        (
+            ("Use <b>bold</b>.", "Use &lt;b&gt;bold&lt;/b&gt;."),
+            ("Write &amp; literally.", "Write &amp;amp; literally."),
+            ("A --> B", "A --&gt; B"),
+            ("\"नमस्ते\" & 'hello'", "\"नमस्ते\" &amp; 'hello'"),
+        ),
+    )
+    def test_transcript_text_is_escaped_for_cue_payload(self, text: str, payload: str) -> None:
+        tokens: Final = (SubtitleToken(text=text, start_ms=0, end_ms=1000),)
+        assert render_subtitle_tokens_as_vtt(tokens) == f"WEBVTT\n\n00:00:00.000 --> 00:00:01.000\n{payload}\n"
+
     def test_single_cue_full_document(self):
         tokens = (
             SubtitleToken(text="Hello ", start_ms=0, end_ms=500),
@@ -130,6 +147,20 @@ class TestRenderSubtitleTokensAsVtt:
 
 
 class TestSynthesizeSubtitleDocument:
+    @pytest.mark.parametrize(
+        ("response_format", "expected"),
+        (
+            ("vtt", "WEBVTT\n\n00:00:00.000 --> 00:00:01.000\n&lt;word&gt; &amp;amp;\n"),
+            ("srt", "1\n00:00:00,000 --> 00:00:01,000\n<word> &amp;\n"),
+        ),
+    )
+    def test_transcript_escaping_is_specific_to_vtt(self, response_format: str, expected: str) -> None:
+        words: Final = (
+            {"word": "<word>", "start": 0.0, "end": 0.5},
+            {"word": "&amp;", "start": 0.5, "end": 1.0},
+        )
+        assert synthesize_subtitle_document(words, response_format) == expected
+
     WORDS = [
         {"word": "Four", "start": 0.4, "end": 0.7, "speaker": "spk:0"},
         {"word": "score", "start": 0.7, "end": 1.1, "speaker": "spk:0"},


### PR DESCRIPTION
## TLDR

Problem this solves:

- Literal transcript characters disappear when synthesized WebVTT reaches browsers
- An arrow can erase the entire cue text

How it solves it:

- Escape cue payloads with Python's standard HTML escaping function
- Keep timestamps, cue grouping, and SRT output unchanged

## User Flow

Before: a developer exports a transcript as WebVTT and sees different text in the browser

1. They export timestamped transcript text such as `Use <b>bold</b>.`, `Write &amp; literally.`, or `A --> B` using LiteLLM's subtitle renderer
2. They load the generated file as an HTML subtitle track
3. The browser displays `Use bold.`, `Write & literally.`, or an empty cue, respectively

After: the same transcript remains literal when played as browser subtitles

1. They export the same timestamped transcript using LiteLLM's subtitle renderer
2. They load the generated file as an HTML subtitle track
3. The browser displays the original transcript exactly, with the same cue timing

## Relevant issues

Follow-up to the shared subtitle renderer introduced in #38561, also used by Soniox

The [WebVTT cue text specification](https://www.w3.org/TR/webvtt1/#webvtt-cue-text) defines character references for literal ampersands and angle brackets. This escapes raw transcript text at the WebVTT output boundary, so transcript content cannot become a formatting tag, entity, or cue separator

No matching open subtitle-escaping issue or PR was found during the September 7 search

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves one specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

The subtitle, Gemini transcription, and Soniox transcription test files pass together: **110 passed**. The new tests against the unchanged renderer produce **5 failures and 26 passes**, including an SRT control that stays green

All local `lint-checks` gates passed in the locked proxy-dev/e2e-dev environment, including whole-tree Ruff, formatting, strict-rule budgets, test-quality and type-discipline budgets, basedpyright budgets, E2E typing, circular imports, and import safety. The codebase type-budget gate passed without increasing existing diagnostics; the changed source file alone has zero type errors. Dependencies and Prisma were provisioned first, then the normal gated `lint-inner` target ran with the completed install step skipped

AI assistance was used for implementation and a separate agent reviewed the final diff. The browser proof below was run against the original and final code

## Screenshots / Proof of Fix

This is a deterministic encoder-to-browser reproduction. It uses actual Chrome text-track loading and `VTTCue.getCueAsHTML()`, with no mocked browser API. Model inference does not participate in this failure, so no provider call or private recording is needed

Generate a fixture from either checkout:

```bash
python - <<'PY'
from pathlib import Path
from litellm.litellm_core_utils.audio_utils.subtitle_utils import (
    SubtitleToken,
    render_subtitle_tokens_as_vtt,
)

for i, text in enumerate(("Use <b>bold</b>.", "Write &amp; literally.", "A --> B")):
    Path(f"cue-{i}.vtt").write_text(
        render_subtitle_tokens_as_vtt((SubtitleToken(text=text, start_ms=0, end_ms=1000),)),
        encoding="utf-8",
    )
PY
python -m http.server 8876 --bind 127.0.0.1
```

Open `http://127.0.0.1:8876/` in Chrome and run this in its console to load the files through the browser's real WebVTT parser:

```javascript
for (const i of [0, 1, 2]) {
  const video = document.createElement("video");
  const track = document.createElement("track");
  track.kind = "subtitles";
  track.src = `cue-${i}.vtt`;
  track.onload = () => console.log(i, Array.from(track.track.cues, cue => ({
    text: cue.getCueAsHTML().textContent,
    start: cue.startTime,
    end: cue.endTime,
  })));
  video.append(track);
  document.body.append(video);
  track.track.mode = "hidden";
}
```

### Before (168a0055a244acdcf97c330c52e085ab40b1424c)

1. Generate and load the three fixtures with the commands above
2. Chrome parses these cue texts, all with `start: 0` and `end: 1`:

   ```text
   0: "Use bold."
   1: "Write & literally."
   2: ""
   ```

### After (67c28cf9f4923ff383f39d67b7c7e4da0ada9504)

1. Generate and load the same three fixtures with the commands above
2. Chrome parses the original texts exactly, all with `start: 0` and `end: 1`:

   ```text
   0: "Use <b>bold</b>."
   1: "Write &amp; literally."
   2: "A --> B"
   ```

## Type

Bug Fix

## Caveats (if any)

### Low

- This covers synthesized WebVTT, not provider-native subtitle responses
- Transcript text is literal, including text resembling WebVTT markup

## Final Attestation

- [x] Regression tests cover literal markup, entities, arrows, Unicode, and unchanged SRT output
