### PR TITLE
fix(masker): mask plural secret/password/certificate key names

### DIFF
--- a/litellm/litellm_core_utils/sensitive_data_masker.py
+++ b/litellm/litellm_core_utils/sensitive_data_masker.py
@@ -16,14 +16,9 @@ _DEFAULT_SENSITIVE_PATTERNS: Final = frozenset(
         "auth",
         "authorization",
         "credential",
-        # Segment-exact matching misses regular plurals: "credential" !=
-        # "credentials", so Vertex's ``vertex_credentials`` slipped through
-        # until this was added. "secrets" and "passwords" carry the same
-        # fix. "keys" and "tokens" are deliberately NOT added here: unlike
-        # the plurals above, they collide with real non-sensitive fields
-        # ("allow_all_keys", "missing_keys", "max_tokens", "total_tokens"),
-        # so pluralizing them would mask booleans and usage counts instead
-        # of secrets.
+        # Segment-exact matching misses plurals ("secret" != "secrets"), same gap
+        # already fixed once for "credential"/"credentials". "keys"/"tokens" are
+        # NOT pluralized: they'd mask real fields like "allow_all_keys"/"max_tokens".
         "credentials",
         "secrets",
         "passwords",

--- a/litellm/litellm_core_utils/sensitive_data_masker.py
+++ b/litellm/litellm_core_utils/sensitive_data_masker.py
@@ -16,12 +16,21 @@ _DEFAULT_SENSITIVE_PATTERNS: Final = frozenset(
         "auth",
         "authorization",
         "credential",
-        # Plural form: Vertex uses ``vertex_credentials``; segment-exact
-        # matching otherwise misses it because "credential" != "credentials".
+        # Segment-exact matching misses regular plurals: "credential" !=
+        # "credentials", so Vertex's ``vertex_credentials`` slipped through
+        # until this was added. "secrets" and "passwords" carry the same
+        # fix. "keys" and "tokens" are deliberately NOT added here: unlike
+        # the plurals above, they collide with real non-sensitive fields
+        # ("allow_all_keys", "missing_keys", "max_tokens", "total_tokens"),
+        # so pluralizing them would mask booleans and usage counts instead
+        # of secrets.
         "credentials",
+        "secrets",
+        "passwords",
         "access",
         "private",
         "certificate",
+        "certificates",
         "fingerprint",
         "tenancy",
     )

--- a/tests/test_litellm/litellm_core_utils/test_sensitive_data_masker.py
+++ b/tests/test_litellm/litellm_core_utils/test_sensitive_data_masker.py
@@ -344,6 +344,31 @@ def test_the_second_positional_argument_is_still_the_override_set():
     assert masker.is_sensitive_key("session_token") is False
     assert masker.is_sensitive_key("auth_token") is True
 
+
+def test_plural_secret_and_password_keys_are_masked():
+    """Segment-exact matching missed regular plurals ("secret" != "secrets"), the same class of
+    bug already fixed once for "credential"/"credentials". These plurals are safe to add: unlike
+    "keys"/"tokens", nothing in the codebase uses them for a non-sensitive field."""
+    masker = SensitiveDataMasker()
+
+    assert masker.is_sensitive_key("client_secrets") is True
+    assert masker.is_sensitive_key("secrets") is True
+    assert masker.is_sensitive_key("db_passwords") is True
+    assert masker.is_sensitive_key("passwords") is True
+    assert masker.is_sensitive_key("ssl_certificates") is True
+
+
+def test_keys_and_tokens_plurals_stay_unmasked_to_avoid_false_positives():
+    """"keys" and "tokens" are deliberately NOT added as sensitive patterns: real non-sensitive
+    fields use those plurals ("allow_all_keys" is a bool, "max_tokens"/"total_tokens" are usage
+    counts), so masking them would corrupt those fields instead of protecting a secret."""
+    masker = SensitiveDataMasker()
+
+    assert masker.is_sensitive_key("allow_all_keys") is False
+    assert masker.is_sensitive_key("missing_keys") is False
+    assert masker.is_sensitive_key("max_tokens") is False
+    assert masker.is_sensitive_key("total_tokens") is False
+
 def test_redact_credentials_in_payload_leaves_no_fragment_of_the_secret():
     """A payload rendered straight to stdout cannot afford the partial reveal
     mask_credentials_in_payload leaves, so every credential-named value is replaced


### PR DESCRIPTION
## TLDR

Problem this solves:

- `client_secrets`, `db_passwords`, `ssl_certificates` fields are never masked
- Segment-exact matching missed regular plurals, same gap as the earlier `credentials` fix (#26513)

How it solves it:

- Add `secrets`, `passwords`, `certificates` to the masker's sensitive-pattern set
- Verified `keys`/`tokens` plurals are unsafe to add (they collide with `allow_all_keys`, `max_tokens`) and left them out

## User Flow

Before: an admin who configures a model with a field named `client_secrets` or `ssl_certificates` gets that value logged and returned in plaintext everywhere the masker runs

1. They configure a model in `config.yaml` with `litellm_params.client_secrets` set to a real credential
2. They send GET https://litellm-domain/model/info with their proxy key
3. The response body's `litellm_params.client_secrets` shows the credential unmasked, character for character

After: the same field is masked like every other credential field

1. The admin configures the same model with the same `client_secrets` field
2. They send the same GET https://litellm-domain/model/info
3. The response shows `client_secrets` partially masked (e.g. `sk-s****************1234`), matching how `api_key` is already shown

## Relevant issues

Fixes #40104

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

### Before (02522a5)

1. Config:
   ```yaml
   model_list:
     - model_name: test-model
       litellm_params:
         model: openai/gpt-4o-mini
         api_key: sk-fake-key-not-real
         client_secrets: "sk-should-be-masked-1234"
         ssl_certificates: "cert-should-be-masked-5678"
   general_settings:
     master_key: sk-test-1234
   ```
2. Start: `PYTHONIOENCODING=utf-8 python litellm/proxy/proxy_cli.py --config config.yaml --port 4011`
3. `curl -s -H "Authorization: Bearer sk-test-1234" http://localhost:4011/model/info | python -m json.tool`
4. Output:
   ```json
   "litellm_params": {
     "model": "openai/gpt-4o-mini",
     "client_secrets": "sk-should-be-masked-1234",
     "ssl_certificates": "cert-should-be-masked-5678"
   }
   ```
   Both fields come back completely unmasked.

### After (a878706)

1. Same config as above, same proxy restarted on port 4010
2. `curl -s -H "Authorization: Bearer sk-test-1234" http://localhost:4010/model/info | python -m json.tool`
3. Output:
   ```json
   "litellm_params": {
     "model": "openai/gpt-4o-mini",
     "client_secrets": "sk-s****************1234",
     "ssl_certificates": "cert******************5678"
   }
   ```
   Both fields are now partially masked, matching `api_key`'s existing behavior. `max_tokens` and other usage-count fields elsewhere in the response are unaffected.

## Type

🐛 Bug Fix
✅ Test

## Caveats (if any)

### Low

- `keys` and `tokens` plurals are intentionally still unmasked (`api_keys`, `refresh_tokens`, etc). Fixing those needs an allowlist or a smarter check, not just adding the plural, since real fields (`allow_all_keys`, `max_tokens`) already use those exact words non-sensitively.

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

