### PR TITLE
feat(dashscope): add separate explicit and implicit cache pricing

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -93,6 +93,7 @@ from litellm.llms.xai.cost_calculator import cost_per_token as xai_cost_per_toke
 from litellm.responses.utils import ResponseAPILoggingUtils
 from litellm.types.agents import LiteLLMSendMessageResponse
 from litellm.types.llms.openai import (
+    AllMessageValues,
     HttpxBinaryResponseContent,
     ImageGenerationRequestQuality,
     OpenAIModerationResponse,
@@ -128,6 +129,7 @@ from litellm.utils import (
     TextCompletionResponse,
     TranscriptionResponse,
     _cached_get_model_info_helper,
+    is_cached_message,
     token_counter,
 )
 
@@ -188,6 +190,28 @@ _SEARCH_CALL_TYPES: Final = frozenset(
 
 _AREALTIME_CALL_TYPE: Final = CallTypes.arealtime.value
 _MCP_CALL_TYPE: Final = CallTypes.call_mcp_tool.value
+_DASHSCOPE_PROVIDERS: Final = frozenset(("dashscope", "qwencloud", "qwen_ai_platform"))
+
+
+def _get_dashscope_cache_read_mode(
+    model: str,
+    custom_llm_provider: str | None,
+    usage: Usage,
+    cached_tokens: int,
+    cache_control_requested: bool,
+) -> Literal["explicit", "implicit"] | None:
+    if custom_llm_provider not in _DASHSCOPE_PROVIDERS and not any(
+        model.startswith(f"{provider}/") for provider in _DASHSCOPE_PROVIDERS
+    ):
+        return None
+
+    from litellm.llms.dashscope.cost_calculator import get_cache_read_mode
+
+    return get_cache_read_mode(
+        usage=usage,
+        cached_tokens=cached_tokens,
+        cache_control_requested=cache_control_requested,
+    )
 
 
 def _cost_per_token_custom_pricing_helper(
@@ -196,6 +220,7 @@ def _cost_per_token_custom_pricing_helper(
     response_time_ms: float | None = 0.0,
     cached_tokens: float = 0,
     cache_creation_tokens: float = 0,
+    cache_read_mode: Literal["explicit", "implicit"] | None = None,
     ### CUSTOM PRICING ###
     custom_cost_per_token: CostPerToken | None = None,
     custom_cost_per_second: float | None = None,
@@ -214,8 +239,8 @@ def _cost_per_token_custom_pricing_helper(
         output_cost_per_token: Final = custom_cost_per_token["output_cost_per_token"]
 
         cache_read_input_token_cost: Final = custom_cost_per_token.get(
-            "cache_read_input_token_cost",
-            input_cost_per_token,
+            "implicit_cache_read_input_token_cost" if cache_read_mode == "implicit" else "cache_read_input_token_cost",
+            custom_cost_per_token.get("cache_read_input_token_cost", input_cost_per_token),
         )
         cache_creation_input_token_cost: Final = custom_cost_per_token.get(
             "cache_creation_input_token_cost",
@@ -340,6 +365,7 @@ def cost_per_token(
     response: Any | None = None,
     ### REQUEST MODEL ###
     request_model: str | None = None,  # original request model for router detection
+    cache_control_requested: bool = False,
 ) -> tuple[float, float]:
     """
     Calculates the cost per token for a given model, prompt tokens, and completion tokens.
@@ -418,12 +444,21 @@ def cost_per_token(
     if _is_anthropic_style:
         _normalized_prompt_tokens += _cache_read_tokens + _cache_creation_tokens
 
+    _cache_read_mode: Final = _get_dashscope_cache_read_mode(
+        model=model,
+        custom_llm_provider=custom_llm_provider,
+        usage=usage_block,
+        cached_tokens=int(_cache_read_tokens),
+        cache_control_requested=cache_control_requested,
+    )
+
     response_cost: Final = _cost_per_token_custom_pricing_helper(
         prompt_tokens=_normalized_prompt_tokens,
         completion_tokens=completion_tokens,
         response_time_ms=response_time_ms,
         cached_tokens=_cache_read_tokens,
         cache_creation_tokens=_cache_creation_tokens,
+        cache_read_mode=_cache_read_mode,
         custom_cost_per_second=custom_cost_per_second,
         custom_cost_per_token=custom_cost_per_token,
     )
@@ -655,7 +690,12 @@ def cost_per_token(
             cost_per_token as dashscope_cost_per_token,
         )
 
-        return dashscope_cost_per_token(model=model, usage=usage_block, custom_llm_provider=custom_llm_provider)
+        return dashscope_cost_per_token(
+            model=model,
+            usage=usage_block,
+            custom_llm_provider=custom_llm_provider,
+            cache_control_requested=cache_control_requested,
+        )
     elif custom_llm_provider == "azure_ai":
         return azure_ai_cost_per_token(
             model=model,
@@ -1183,7 +1223,7 @@ def completion_cost(
     completion_response: object | None = None,
     model: str | None = None,
     prompt="",
-    messages: list = [],
+    messages: Sequence[AllMessageValues] = (),
     completion="",
     total_time: float | None = 0.0,  # used for replicate, sagemaker
     call_type: CallTypesLiteral | None = None,
@@ -1660,6 +1700,10 @@ def completion_cost(
                     vertex_location=vertex_location,
                     response=completion_response,
                     request_model=request_model_for_cost,
+                    cache_control_requested=(
+                        custom_llm_provider in _DASHSCOPE_PROVIDERS
+                        and any(is_cached_message(message) for message in messages)
+                    ),
                 )
 
                 # Get additional costs from provider (e.g., routing fees, infrastructure costs)

--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -93,7 +93,6 @@ from litellm.llms.xai.cost_calculator import cost_per_token as xai_cost_per_toke
 from litellm.responses.utils import ResponseAPILoggingUtils
 from litellm.types.agents import LiteLLMSendMessageResponse
 from litellm.types.llms.openai import (
-    AllMessageValues,
     HttpxBinaryResponseContent,
     ImageGenerationRequestQuality,
     OpenAIModerationResponse,
@@ -129,7 +128,6 @@ from litellm.utils import (
     TextCompletionResponse,
     TranscriptionResponse,
     _cached_get_model_info_helper,
-    is_cached_message,
     token_counter,
 )
 
@@ -190,28 +188,6 @@ _SEARCH_CALL_TYPES: Final = frozenset(
 
 _AREALTIME_CALL_TYPE: Final = CallTypes.arealtime.value
 _MCP_CALL_TYPE: Final = CallTypes.call_mcp_tool.value
-_DASHSCOPE_PROVIDERS: Final = frozenset(("dashscope", "qwencloud", "qwen_ai_platform"))
-
-
-def _get_dashscope_cache_read_mode(
-    model: str,
-    custom_llm_provider: str | None,
-    usage: Usage,
-    cached_tokens: int,
-    cache_control_requested: bool,
-) -> Literal["explicit", "implicit"] | None:
-    if custom_llm_provider not in _DASHSCOPE_PROVIDERS and not any(
-        model.startswith(f"{provider}/") for provider in _DASHSCOPE_PROVIDERS
-    ):
-        return None
-
-    from litellm.llms.dashscope.cost_calculator import get_cache_read_mode
-
-    return get_cache_read_mode(
-        usage=usage,
-        cached_tokens=cached_tokens,
-        cache_control_requested=cache_control_requested,
-    )
 
 
 def _cost_per_token_custom_pricing_helper(
@@ -220,7 +196,6 @@ def _cost_per_token_custom_pricing_helper(
     response_time_ms: float | None = 0.0,
     cached_tokens: float = 0,
     cache_creation_tokens: float = 0,
-    cache_read_mode: Literal["explicit", "implicit"] | None = None,
     ### CUSTOM PRICING ###
     custom_cost_per_token: CostPerToken | None = None,
     custom_cost_per_second: float | None = None,
@@ -239,8 +214,8 @@ def _cost_per_token_custom_pricing_helper(
         output_cost_per_token: Final = custom_cost_per_token["output_cost_per_token"]
 
         cache_read_input_token_cost: Final = custom_cost_per_token.get(
-            "implicit_cache_read_input_token_cost" if cache_read_mode == "implicit" else "cache_read_input_token_cost",
-            custom_cost_per_token.get("cache_read_input_token_cost", input_cost_per_token),
+            "cache_read_input_token_cost",
+            input_cost_per_token,
         )
         cache_creation_input_token_cost: Final = custom_cost_per_token.get(
             "cache_creation_input_token_cost",
@@ -365,7 +340,6 @@ def cost_per_token(
     response: Any | None = None,
     ### REQUEST MODEL ###
     request_model: str | None = None,  # original request model for router detection
-    cache_control_requested: bool = False,
 ) -> tuple[float, float]:
     """
     Calculates the cost per token for a given model, prompt tokens, and completion tokens.
@@ -444,21 +418,12 @@ def cost_per_token(
     if _is_anthropic_style:
         _normalized_prompt_tokens += _cache_read_tokens + _cache_creation_tokens
 
-    _cache_read_mode: Final = _get_dashscope_cache_read_mode(
-        model=model,
-        custom_llm_provider=custom_llm_provider,
-        usage=usage_block,
-        cached_tokens=int(_cache_read_tokens),
-        cache_control_requested=cache_control_requested,
-    )
-
     response_cost: Final = _cost_per_token_custom_pricing_helper(
         prompt_tokens=_normalized_prompt_tokens,
         completion_tokens=completion_tokens,
         response_time_ms=response_time_ms,
         cached_tokens=_cache_read_tokens,
         cache_creation_tokens=_cache_creation_tokens,
-        cache_read_mode=_cache_read_mode,
         custom_cost_per_second=custom_cost_per_second,
         custom_cost_per_token=custom_cost_per_token,
     )
@@ -690,12 +655,7 @@ def cost_per_token(
             cost_per_token as dashscope_cost_per_token,
         )
 
-        return dashscope_cost_per_token(
-            model=model,
-            usage=usage_block,
-            custom_llm_provider=custom_llm_provider,
-            cache_control_requested=cache_control_requested,
-        )
+        return dashscope_cost_per_token(model=model, usage=usage_block, custom_llm_provider=custom_llm_provider)
     elif custom_llm_provider == "azure_ai":
         return azure_ai_cost_per_token(
             model=model,
@@ -1223,7 +1183,7 @@ def completion_cost(
     completion_response: object | None = None,
     model: str | None = None,
     prompt="",
-    messages: Sequence[AllMessageValues] = (),
+    messages: list = [],
     completion="",
     total_time: float | None = 0.0,  # used for replicate, sagemaker
     call_type: CallTypesLiteral | None = None,
@@ -1700,10 +1660,6 @@ def completion_cost(
                     vertex_location=vertex_location,
                     response=completion_response,
                     request_model=request_model_for_cost,
-                    cache_control_requested=(
-                        custom_llm_provider in _DASHSCOPE_PROVIDERS
-                        and any(is_cached_message(message) for message in messages)
-                    ),
                 )
 
                 # Get additional costs from provider (e.g., routing fees, infrastructure costs)

--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -453,7 +453,12 @@ def _open_off_peak_block(model_info: ModelInfo, current_time: datetime | None) -
     return off_peak
 
 
-def apply_off_peak_pricing(model_info: ModelInfo, current_time: datetime | None, rates: TokenRates) -> TokenRates:
+def apply_off_peak_pricing(
+    model_info: ModelInfo,
+    current_time: datetime | None,
+    rates: TokenRates,
+    cache_read_cost_key: str = "cache_read_input_token_cost",
+) -> TokenRates:
     """Swap in off-peak per-token rates when the current UTC time is inside one of the model's
     off_peak_pricing rules, the every-day hours_utc windows or a day-of-week-qualified entry in
     windows. An off-peak rate replaces the rate that would otherwise apply rather than
@@ -467,10 +472,19 @@ def apply_off_peak_pricing(model_info: ModelInfo, current_time: datetime | None,
     if off_peak is None:
         return rates
     off_peak_reasoning_rate: Final = _parse_off_peak_rate(off_peak.get("output_cost_per_reasoning_token"))
+    mode_specific_cache_read_rate: Final = _parse_off_peak_rate(off_peak.get(cache_read_cost_key))
+    generic_cache_read_rate: Final = (
+        _parse_off_peak_rate(off_peak.get("cache_read_input_token_cost"))
+        if cache_read_cost_key != "cache_read_input_token_cost"
+        else None
+    )
+    cache_read_rate: Final = (
+        mode_specific_cache_read_rate if mode_specific_cache_read_rate is not None else generic_cache_read_rate
+    )
     return TokenRates(
         input_rate=_off_peak_rate(off_peak, "input_cost_per_token", rates.input_rate),
         output_rate=_off_peak_rate(off_peak, "output_cost_per_token", rates.output_rate),
-        cache_read_rate=_off_peak_rate(off_peak, "cache_read_input_token_cost", rates.cache_read_rate),
+        cache_read_rate=rates.cache_read_rate if cache_read_rate is None else cache_read_rate,
         cache_creation_rate=_off_peak_rate(off_peak, "cache_creation_input_token_cost", rates.cache_creation_rate),
         reasoning_rate=rates.reasoning_rate if off_peak_reasoning_rate is None else off_peak_reasoning_rate,
     )
@@ -1341,6 +1355,18 @@ def get_token_type_cost_breakdown(
         current_time=billing_time,
         threshold_is_inclusive=_uses_inclusive_token_thresholds(custom_llm_provider),
     )
+
+    if custom_llm_provider in ("dashscope", "qwencloud", "qwen_ai_platform"):
+        from litellm.llms.dashscope.cost_calculator import (
+            get_token_breakdown_and_rates,
+        )
+
+        _, dashscope_rates = get_token_breakdown_and_rates(
+            model_info=model_info,
+            usage=usage,
+            current_time=billing_time,
+        )
+        cache_read_cost_rate = dashscope_rates.cache_read_rate
 
     reasoning_tokens = (
         parse_completion_tokens_details(usage)["reasoning_tokens"] if usage.completion_tokens_details is not None else 0

--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -2,7 +2,7 @@
 ## Helper utilities for cost_per_token()
 
 import re
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone, tzinfo
 from types import MappingProxyType
@@ -426,6 +426,36 @@ class TokenRates:
     @property
     def billed_reasoning_rate(self) -> float:
         return self.output_rate if self.reasoning_rate is None else self.reasoning_rate
+
+
+CacheReadCostRateResolver = Callable[
+    [ModelInfo, Usage, datetime | None],  # mutable-ok: Callable parameter syntax
+    float,
+]
+_CACHE_READ_COST_RATE_RESOLVERS: dict[
+    str, CacheReadCostRateResolver
+] = {}  # mutable-ok: provider adapters register one process-wide resolver at import time
+
+
+def register_cache_read_cost_rate_resolver(
+    providers: Sequence[str],
+    resolver: CacheReadCostRateResolver,
+) -> None:
+    """Register a provider-owned cache-read rate resolver for cost breakdowns."""
+    for provider in providers:
+        _CACHE_READ_COST_RATE_RESOLVERS[provider] = resolver
+
+
+def _resolve_cache_read_cost_rate(
+    custom_llm_provider: str | None,
+    model_info: ModelInfo,
+    usage: Usage,
+    current_time: datetime | None,
+) -> float | None:
+    resolver: Final = _CACHE_READ_COST_RATE_RESOLVERS.get(custom_llm_provider or "")
+    if resolver is None:
+        return None
+    return resolver(model_info, usage, current_time)
 
 
 def _parse_off_peak_rate(value: object) -> float | None:
@@ -1356,17 +1386,14 @@ def get_token_type_cost_breakdown(
         threshold_is_inclusive=_uses_inclusive_token_thresholds(custom_llm_provider),
     )
 
-    if custom_llm_provider in ("dashscope", "qwencloud", "qwen_ai_platform"):
-        from litellm.llms.dashscope.cost_calculator import (
-            get_token_breakdown_and_rates,
-        )
-
-        _, dashscope_rates = get_token_breakdown_and_rates(
-            model_info=model_info,
-            usage=usage,
-            current_time=billing_time,
-        )
-        cache_read_cost_rate = dashscope_rates.cache_read_rate
+    provider_cache_read_cost_rate: Final = _resolve_cache_read_cost_rate(
+        custom_llm_provider=custom_llm_provider,
+        model_info=model_info,
+        usage=usage,
+        current_time=billing_time,
+    )
+    if provider_cache_read_cost_rate is not None:
+        cache_read_cost_rate = provider_cache_read_cost_rate
 
     reasoning_tokens = (
         parse_completion_tokens_details(usage)["reasoning_tokens"] if usage.completion_tokens_details is not None else 0

--- a/litellm/llms/dashscope/cost_calculator.py
+++ b/litellm/llms/dashscope/cost_calculator.py
@@ -9,7 +9,11 @@ See https://help.aliyun.com/zh/model-studio/billing-for-model-studio
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Final
+from typing import (
+    Final,
+    Literal,
+    cast,  # noqa: TID251  # legacy tier selector returns an untyped dict after runtime range validation
+)
 
 from litellm.litellm_core_utils.llm_cost_calc.tiered_pricing import select_tier_for_input, tier_rate
 from litellm.litellm_core_utils.llm_cost_calc.utils import (
@@ -21,6 +25,8 @@ from litellm.litellm_core_utils.llm_cost_calc.utils import (
 from litellm.types.utils import ModelInfo, Usage
 from litellm.utils import get_model_info
 
+QwenContextCacheMode = Literal["explicit", "implicit"]
+
 
 @dataclass(frozen=True, slots=True)
 class TokenBreakdown:
@@ -29,13 +35,38 @@ class TokenBreakdown:
     cache_creation_tokens: int
     completion_tokens: int
     reasoning_tokens: int
+    cache_read_mode: QwenContextCacheMode | None
 
     @property
     def total_input_tokens(self) -> int:
         return self.text_tokens + self.cached_tokens + self.cache_creation_tokens
 
 
-def _extract_token_breakdown(usage: Usage) -> TokenBreakdown:
+def get_cache_read_mode(
+    usage: Usage,
+    cached_tokens: int,
+    cache_control_requested: bool = False,
+) -> QwenContextCacheMode | None:
+    if cached_tokens <= 0:
+        return None
+
+    prompt_tokens_details: Final = usage.prompt_tokens_details
+    cache_type: Final = (
+        getattr(prompt_tokens_details, "cache_type", None) if prompt_tokens_details is not None else None
+    )
+    if cache_type == "ephemeral":
+        return "explicit"
+    if cache_type is not None:
+        return None
+    if cache_control_requested:
+        return "explicit"
+    return "implicit"
+
+
+def _extract_token_breakdown(
+    usage: Usage,
+    cache_control_requested: bool = False,
+) -> TokenBreakdown:
     prompt_details: Final = parse_prompt_tokens_details(usage)
     cached_tokens: Final = prompt_details["cache_hit_tokens"]
     cache_creation_tokens: Final = prompt_details["cache_creation_tokens"]
@@ -50,6 +81,11 @@ def _extract_token_breakdown(usage: Usage) -> TokenBreakdown:
         cache_creation_tokens=cache_creation_tokens,
         completion_tokens=completion_tokens,
         reasoning_tokens=reasoning_tokens,
+        cache_read_mode=get_cache_read_mode(
+            usage=usage,
+            cached_tokens=cached_tokens,
+            cache_control_requested=cache_control_requested,
+        ),
     )
 
 
@@ -60,27 +96,56 @@ def _flat_rate(model_info: ModelInfo, cost_key: str, fallback_cost_key: str) -> 
     return float(value)
 
 
-def _flat_rates(model_info: ModelInfo) -> TokenRates:
+def _cache_read_cost_key(cache_read_mode: QwenContextCacheMode | None) -> str:
+    if cache_read_mode == "implicit":
+        return "implicit_cache_read_input_token_cost"
+    return "cache_read_input_token_cost"
+
+
+def _flat_cache_read_rate(
+    model_info: ModelInfo,
+    cache_read_mode: QwenContextCacheMode | None,
+) -> float:
+    if cache_read_mode == "implicit":
+        implicit_rate: Final = model_info.get("implicit_cache_read_input_token_cost")
+        if implicit_rate is not None:
+            return implicit_rate
+    return _flat_rate(model_info, "cache_read_input_token_cost", "input_cost_per_token")
+
+
+def _flat_rates(
+    model_info: ModelInfo,
+    cache_read_mode: QwenContextCacheMode | None = None,
+) -> TokenRates:
     reasoning_rate: Final = model_info.get("output_cost_per_reasoning_token")
     return TokenRates(
         input_rate=float(model_info.get("input_cost_per_token") or 0.0),
-        cache_read_rate=_flat_rate(model_info, "cache_read_input_token_cost", "input_cost_per_token"),
+        cache_read_rate=_flat_cache_read_rate(model_info, cache_read_mode),
         cache_creation_rate=_flat_rate(model_info, "cache_creation_input_token_cost", "input_cost_per_token"),
         output_rate=float(model_info.get("output_cost_per_token") or 0.0),
         reasoning_rate=None if reasoning_rate is None else float(reasoning_rate),
     )
 
 
-def _tier_rates(model_info: ModelInfo, tier: dict) -> TokenRates:
+def _tier_rates(
+    model_info: ModelInfo,
+    tier: dict[str, object],
+    cache_read_mode: QwenContextCacheMode | None = None,
+) -> TokenRates:
     # A tier that declares output rates keeps the request on them, all-or-nothing. A tier table
     # spelling out only input rates would serve every completion for free, so there the model's
     # own output rates stand in
-    flat_rates: Final = _flat_rates(model_info)
+    flat_rates: Final = _flat_rates(model_info, cache_read_mode)
     tier_declares_output: Final = "output_cost_per_token" in tier
     tier_declares_reasoning: Final = "output_cost_per_reasoning_token" in tier
+    cache_read_rate: Final = (
+        tier_rate(tier, "implicit_cache_read_input_token_cost")
+        if cache_read_mode == "implicit" and "implicit_cache_read_input_token_cost" in tier
+        else tier_rate(tier, "cache_read_input_token_cost", "input_cost_per_token")
+    )
     return TokenRates(
         input_rate=tier_rate(tier, "input_cost_per_token"),
-        cache_read_rate=tier_rate(tier, "cache_read_input_token_cost", "input_cost_per_token"),
+        cache_read_rate=cache_read_rate,
         cache_creation_rate=tier_rate(tier, "cache_creation_input_token_cost", "input_cost_per_token"),
         output_rate=tier_rate(tier, "output_cost_per_token") if tier_declares_output else flat_rates.output_rate,
         reasoning_rate=(
@@ -105,11 +170,55 @@ def _bill(breakdown: TokenBreakdown, rates: TokenRates) -> tuple[float, float]:
     return prompt_cost, completion_cost
 
 
+def get_token_breakdown_and_rates(
+    model_info: ModelInfo,
+    usage: Usage,
+    current_time: datetime | None = None,
+    cache_control_requested: bool = False,
+) -> tuple[TokenBreakdown, TokenRates]:
+    breakdown: Final = _extract_token_breakdown(
+        usage,
+        cache_control_requested=cache_control_requested,
+    )
+    raw_tiers: Final = model_info.get("tiered_pricing")
+    tiered_pricing: Final = (
+        cast(  # cast-ok: ModelInfo's legacy tier type uses Any; the list check preserves the existing runtime boundary
+            list[dict[str, object]], raw_tiers
+        )
+        if isinstance(raw_tiers, list)
+        else None
+    )
+    tier: Final = (
+        cast(  # cast-ok: the shared selector returns one dict from the checked tier list but lacks generic annotations
+            dict[str, object] | None,
+            select_tier_for_input(
+                tiered_pricing=tiered_pricing,
+                input_tokens=breakdown.total_input_tokens,
+            ),
+        )
+        if tiered_pricing
+        else None
+    )
+    standard_rates: Final = (
+        _flat_rates(model_info, breakdown.cache_read_mode)
+        if tier is None
+        else _tier_rates(model_info, tier, breakdown.cache_read_mode)
+    )
+    rates: Final = apply_off_peak_pricing(
+        model_info,
+        current_time,
+        standard_rates,
+        cache_read_cost_key=_cache_read_cost_key(breakdown.cache_read_mode),
+    )
+    return breakdown, rates
+
+
 def cost_per_token(
     model: str,
     usage: Usage,
     custom_llm_provider: str = "dashscope",
     current_time: datetime | None = None,
+    cache_control_requested: bool = False,
 ) -> tuple[float, float]:
     """
     Calculate cost per token for Dashscope models.
@@ -127,15 +236,11 @@ def cost_per_token(
         Tuple[float, float] - (prompt_cost_in_usd, completion_cost_in_usd)
     """
     model_info: Final = get_model_info(model=model, custom_llm_provider=custom_llm_provider)
-    breakdown: Final = _extract_token_breakdown(usage)
-    raw_tiers: Final = model_info.get("tiered_pricing")
-    tiered_pricing: Final = raw_tiers if isinstance(raw_tiers, list) else None
-    tier: Final = (
-        select_tier_for_input(tiered_pricing=tiered_pricing, input_tokens=breakdown.total_input_tokens)
-        if tiered_pricing
-        else None
+    breakdown, rates = get_token_breakdown_and_rates(
+        model_info=model_info,
+        usage=usage,
+        current_time=current_time,
+        cache_control_requested=cache_control_requested,
     )
-    standard_rates: Final = _flat_rates(model_info) if tier is None else _tier_rates(model_info, tier)
-    rates: Final = apply_off_peak_pricing(model_info, current_time, standard_rates)
 
     return _bill(breakdown, rates)

--- a/litellm/llms/dashscope/cost_calculator.py
+++ b/litellm/llms/dashscope/cost_calculator.py
@@ -45,7 +45,6 @@ class TokenBreakdown:
 def get_cache_read_mode(
     usage: Usage,
     cached_tokens: int,
-    cache_control_requested: bool = False,
 ) -> QwenContextCacheMode | None:
     if cached_tokens <= 0:
         return None
@@ -58,14 +57,11 @@ def get_cache_read_mode(
         return "explicit"
     if cache_type is not None:
         return None
-    if cache_control_requested:
-        return "explicit"
     return "implicit"
 
 
 def _extract_token_breakdown(
     usage: Usage,
-    cache_control_requested: bool = False,
 ) -> TokenBreakdown:
     prompt_details: Final = parse_prompt_tokens_details(usage)
     cached_tokens: Final = prompt_details["cache_hit_tokens"]
@@ -84,7 +80,6 @@ def _extract_token_breakdown(
         cache_read_mode=get_cache_read_mode(
             usage=usage,
             cached_tokens=cached_tokens,
-            cache_control_requested=cache_control_requested,
         ),
     )
 
@@ -174,12 +169,8 @@ def get_token_breakdown_and_rates(
     model_info: ModelInfo,
     usage: Usage,
     current_time: datetime | None = None,
-    cache_control_requested: bool = False,
 ) -> tuple[TokenBreakdown, TokenRates]:
-    breakdown: Final = _extract_token_breakdown(
-        usage,
-        cache_control_requested=cache_control_requested,
-    )
+    breakdown: Final = _extract_token_breakdown(usage)
     raw_tiers: Final = model_info.get("tiered_pricing")
     tiered_pricing: Final = (
         cast(  # cast-ok: ModelInfo's legacy tier type uses Any; the list check preserves the existing runtime boundary
@@ -218,7 +209,6 @@ def cost_per_token(
     usage: Usage,
     custom_llm_provider: str = "dashscope",
     current_time: datetime | None = None,
-    cache_control_requested: bool = False,
 ) -> tuple[float, float]:
     """
     Calculate cost per token for Dashscope models.
@@ -240,7 +230,6 @@ def cost_per_token(
         model_info=model_info,
         usage=usage,
         current_time=current_time,
-        cache_control_requested=cache_control_requested,
     )
 
     return _bill(breakdown, rates)

--- a/litellm/llms/dashscope/cost_calculator.py
+++ b/litellm/llms/dashscope/cost_calculator.py
@@ -21,6 +21,7 @@ from litellm.litellm_core_utils.llm_cost_calc.utils import (
     apply_off_peak_pricing,
     parse_completion_tokens_details,
     parse_prompt_tokens_details,
+    register_cache_read_cost_rate_resolver,
 )
 from litellm.types.utils import ModelInfo, Usage
 from litellm.utils import get_model_info
@@ -202,6 +203,25 @@ def get_token_breakdown_and_rates(
         cache_read_cost_key=_cache_read_cost_key(breakdown.cache_read_mode),
     )
     return breakdown, rates
+
+
+def _resolve_cache_read_cost_rate(
+    model_info: ModelInfo,
+    usage: Usage,
+    current_time: datetime | None,
+) -> float:
+    _, rates = get_token_breakdown_and_rates(
+        model_info=model_info,
+        usage=usage,
+        current_time=current_time,
+    )
+    return rates.cache_read_rate
+
+
+register_cache_read_cost_rate_resolver(
+    providers=("dashscope", "qwencloud", "qwen_ai_platform"),
+    resolver=_resolve_cache_read_cost_rate,
+)
 
 
 def cost_per_token(

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -124,7 +124,6 @@ class CostPerToken(TypedDict, total=False):
     input_cost_per_token: Required[float]
     output_cost_per_token: Required[float]
     cache_read_input_token_cost: float
-    implicit_cache_read_input_token_cost: ReadOnly[float]
     cache_creation_input_token_cost: float
 
 

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -124,6 +124,7 @@ class CostPerToken(TypedDict, total=False):
     input_cost_per_token: Required[float]
     output_cost_per_token: Required[float]
     cache_read_input_token_cost: float
+    implicit_cache_read_input_token_cost: ReadOnly[float]
     cache_creation_input_token_cost: float
 
 
@@ -226,6 +227,7 @@ class OffPeakPricing(TypedDict, total=False):
     output_cost_per_token: ReadOnly[float]
     output_cost_per_reasoning_token: ReadOnly[float]
     cache_read_input_token_cost: ReadOnly[float]
+    implicit_cache_read_input_token_cost: ReadOnly[float]
     cache_creation_input_token_cost: ReadOnly[float]
 
 
@@ -249,6 +251,7 @@ class ModelInfoBase(ProviderSpecificModelInfo, total=False):
     cache_creation_input_token_cost_priority: float | None  # OpenAI priority service tier pricing
     cache_creation_input_token_cost_ultrafast: ReadOnly[float | None]  # OpenAI ultrafast service tier pricing
     cache_read_input_token_cost: float | None
+    implicit_cache_read_input_token_cost: ReadOnly[float | None]
     cache_read_input_token_cost_flex: float | None  # OpenAI flex service tier pricing
     cache_read_input_token_cost_priority: float | None  # OpenAI priority service tier pricing
     cache_read_input_token_cost_ultrafast: ReadOnly[float | None]  # OpenAI ultrafast service tier pricing
@@ -1683,6 +1686,9 @@ class PromptTokensDetailsWrapper(
     cache_creation_token_details: CacheCreationTokenDetails | None = None
     """Details of cache creation tokens sent to the model. Used for tracking 5m/1h cache creation tokens for Anthropic prompt caching."""
 
+    cache_type: str | None = None
+    """Provider-reported cache mode. DashScope returns ``ephemeral`` for explicit Qwen Context Cache requests."""
+
     def __setattr__(self, name: str, value: object) -> None:
         super().__setattr__(name, value)
         if name == "cache_write_tokens":
@@ -1727,6 +1733,8 @@ class PromptTokensDetailsWrapper(
             del self.cache_creation_tokens
         if self.cache_creation_token_details is None:
             del self.cache_creation_token_details
+        if self.cache_type is None:
+            del self.cache_type
 
 
 class ServerToolUse(BaseModel):
@@ -3486,6 +3494,7 @@ class MirroredPricingParams(BaseModel):
     input_cost_per_character: float | None = None
     output_cost_per_character: float | None = None
     cache_read_input_token_cost: float | None = None
+    implicit_cache_read_input_token_cost: float | None = None
     cache_creation_input_token_cost: float | None = None
     tiered_pricing: list[dict[str, Any]] | None = None
 

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -2922,6 +2922,7 @@ _CACHE_PRICING_FIELDS: Final = (
     "cache_creation_input_token_cost_above_200k_tokens",
     "cache_read_input_token_cost",
     "cache_read_input_token_cost_above_200k_tokens",
+    "implicit_cache_read_input_token_cost",
 )
 
 
@@ -3097,13 +3098,14 @@ def register_model(
                 elif (
                     value.get("cache_creation_input_token_cost") is None
                     and value.get("cache_read_input_token_cost") is None
+                    and value.get("implicit_cache_read_input_token_cost") is None  # pyright: ignore[reportUnknownMemberType]  # loaded model entries are dynamic mappings
                     and value.get("tiered_pricing") is None
                     and (
                         value.get("input_cost_per_token") is not None or value.get("output_cost_per_token") is not None
                     )
                 ):
                     verbose_logger.warning(
-                        "register_model: model=%s has custom pricing but not in built-in cost map and no prefix/region variant matched; cache_creation_input_token_cost and cache_read_input_token_cost will default to 0 for this model (input/output cost tracking is unaffected). To track cache cost, add them to model_info",
+                        "register_model: model=%s has custom pricing but not in built-in cost map and no prefix/region variant matched; cache_creation_input_token_cost, cache_read_input_token_cost, and implicit_cache_read_input_token_cost will default to 0 for this model (input/output cost tracking is unaffected). To track cache cost, add them to model_info",
                         warning_display_name or key,
                     )
         # ``get_model_info`` returns ``litellm_provider: None`` when the
@@ -5796,6 +5798,7 @@ def _get_model_info_helper(
                     "cache_creation_input_token_cost_ultrafast", None
                 ),
                 cache_read_input_token_cost=_model_info.get("cache_read_input_token_cost", None),
+                implicit_cache_read_input_token_cost=_model_info.get("implicit_cache_read_input_token_cost", None),
                 prompt_cache_min_tokens=_model_info.get("prompt_cache_min_tokens", None),
                 cache_read_input_token_cost_above_200k_tokens=_model_info.get(
                     "cache_read_input_token_cost_above_200k_tokens", None

--- a/tests/test_litellm/llms/dashscope/test_dashscope_cost_calculator.py
+++ b/tests/test_litellm/llms/dashscope/test_dashscope_cost_calculator.py
@@ -16,7 +16,6 @@ import pytest
 
 # Add the project root to Python path
 import litellm
-from litellm.cost_calculator import cost_per_token as litellm_cost_per_token
 from litellm.litellm_core_utils.llm_cost_calc.utils import get_token_type_cost_breakdown
 from litellm.llms.dashscope.cost_calculator import (
     cost_per_token as dashscope_cost_per_token,
@@ -112,8 +111,19 @@ class TestDashscopeCostCalculator:
 
         assert math.isclose(prompt_cost, (400 * 1e-06) + (600 * 1e-07), rel_tol=1e-10)
 
-    def test_dashscope_request_cache_control_is_explicit_mode_fallback(self):
-        litellm.model_cost["dashscope/qwen-cache-control-fallback-test"] = {
+    @pytest.mark.parametrize(
+        ("prompt_tokens_details", "expected_cache_rate"),
+        [
+            ({"cached_tokens": 600, "cache_type": "ephemeral"}, 1e-07),
+            ({"cached_tokens": 600}, 2e-07),
+        ],
+    )
+    def test_completion_cost_routes_dashscope_cache_mode_pricing(
+        self,
+        prompt_tokens_details: dict[str, int | str],
+        expected_cache_rate: float,
+    ):
+        litellm.model_cost["dashscope/qwen-completion-cache-mode-test"] = {
             "litellm_provider": "dashscope",
             "mode": "chat",
             "input_cost_per_token": 1e-06,
@@ -121,19 +131,27 @@ class TestDashscopeCostCalculator:
             "cache_read_input_token_cost": 1e-07,
             "implicit_cache_read_input_token_cost": 2e-07,
         }
-        usage = Usage(
-            prompt_tokens=1000,
-            completion_tokens=0,
-            prompt_tokens_details={"cached_tokens": 600},
+        response = litellm.ModelResponse(
+            model="qwen-completion-cache-mode-test",
+            usage=Usage(
+                prompt_tokens=1000,
+                completion_tokens=100,
+                total_tokens=1100,
+                prompt_tokens_details=prompt_tokens_details,
+            ),
         )
 
-        prompt_cost, _ = dashscope_cost_per_token(
-            model="qwen-cache-control-fallback-test",
-            usage=usage,
-            cache_control_requested=True,
+        cost = litellm.completion_cost(
+            completion_response=response,
+            model="qwen-completion-cache-mode-test",
+            custom_llm_provider="dashscope",
         )
 
-        assert math.isclose(prompt_cost, (400 * 1e-06) + (600 * 1e-07), rel_tol=1e-10)
+        assert math.isclose(
+            cost,
+            (400 * 1e-06) + (600 * expected_cache_rate) + (100 * 4e-06),
+            rel_tol=1e-10,
+        )
 
     def test_dashscope_tiered_pricing_uses_mode_specific_cache_read_rate(self):
         self._register_tiered_model(
@@ -158,7 +176,15 @@ class TestDashscopeCostCalculator:
 
         assert math.isclose(prompt_cost, (400 * 1e-06) + (600 * 1e-07), rel_tol=1e-10)
 
-    def test_dashscope_cost_breakdown_uses_mode_specific_cache_read_rate(self):
+    @pytest.mark.parametrize(
+        ("cache_type", "expected_cache_rate"),
+        [("ephemeral", 1e-07), (None, 2e-07)],
+    )
+    def test_dashscope_cost_breakdown_matches_mode_specific_total(
+        self,
+        cache_type: str | None,
+        expected_cache_rate: float,
+    ):
         litellm.model_cost["dashscope/qwen-cache-breakdown-mode-test"] = {
             "litellm_provider": "dashscope",
             "mode": "chat",
@@ -167,87 +193,24 @@ class TestDashscopeCostCalculator:
             "cache_read_input_token_cost": 1e-07,
             "implicit_cache_read_input_token_cost": 2e-07,
         }
+        prompt_tokens_details: dict[str, int | str] = {"cached_tokens": 600}
+        if cache_type is not None:
+            prompt_tokens_details["cache_type"] = cache_type
         usage = Usage(
             prompt_tokens=1000,
             completion_tokens=0,
-            prompt_tokens_details={"cached_tokens": 600, "cache_type": "ephemeral"},
+            prompt_tokens_details=prompt_tokens_details,
         )
 
+        prompt_cost, _ = dashscope_cost_per_token(model="qwen-cache-breakdown-mode-test", usage=usage)
         breakdown = get_token_type_cost_breakdown(
             model="qwen-cache-breakdown-mode-test",
             custom_llm_provider="dashscope",
             usage=usage,
         )
 
-        assert math.isclose(breakdown.cache_read_cost, 600 * 1e-07, rel_tol=1e-10)
-
-    def test_dashscope_custom_pricing_uses_mode_specific_cache_read_rate(self):
-        usage = Usage(
-            prompt_tokens=1000,
-            completion_tokens=0,
-            prompt_tokens_details={"cached_tokens": 600, "cache_type": "ephemeral"},
-        )
-
-        prompt_cost, _ = litellm_cost_per_token(
-            model="custom-qwen",
-            custom_llm_provider="dashscope",
-            usage_object=usage,
-            prompt_tokens=1000,
-            custom_cost_per_token={
-                "input_cost_per_token": 1e-06,
-                "output_cost_per_token": 4e-06,
-                "implicit_cache_read_input_token_cost": 2e-07,
-                "cache_read_input_token_cost": 1e-07,
-            },
-        )
-
-        assert math.isclose(prompt_cost, (400 * 1e-06) + (600 * 1e-07), rel_tol=1e-10)
-
-    def test_completion_cost_detects_cache_control_request_fallback(self):
-        usage = Usage(
-            prompt_tokens=1000,
-            completion_tokens=100,
-            total_tokens=1100,
-            prompt_tokens_details={"cached_tokens": 600},
-        )
-        response = litellm.ModelResponse(
-            id="test-id",
-            created=1234567890,
-            model="custom-qwen",
-            object="chat.completion",
-            choices=[],
-            usage=usage,
-        )
-
-        cost = litellm.completion_cost(
-            completion_response=response,
-            model="custom-qwen",
-            custom_llm_provider="dashscope",
-            messages=[
-                {
-                    "role": "user",
-                    "content": [
-                        {
-                            "type": "text",
-                            "text": "stable prefix",
-                            "cache_control": {"type": "ephemeral"},
-                        }
-                    ],
-                }
-            ],
-            custom_cost_per_token={
-                "input_cost_per_token": 1e-06,
-                "output_cost_per_token": 4e-06,
-                "cache_read_input_token_cost": 1e-07,
-                "implicit_cache_read_input_token_cost": 2e-07,
-            },
-        )
-
-        assert math.isclose(
-            cost,
-            (400 * 1e-06) + (600 * 1e-07) + (100 * 4e-06),
-            rel_tol=1e-10,
-        )
+        assert math.isclose(breakdown.cache_read_cost, 600 * expected_cache_rate, rel_tol=1e-10)
+        assert math.isclose(prompt_cost, (400 * 1e-06) + breakdown.cache_read_cost, rel_tol=1e-10)
 
     def test_dashscope_tiered_pricing_within_first_tier(self):
         """

--- a/tests/test_litellm/llms/dashscope/test_dashscope_cost_calculator.py
+++ b/tests/test_litellm/llms/dashscope/test_dashscope_cost_calculator.py
@@ -16,6 +16,8 @@ import pytest
 
 # Add the project root to Python path
 import litellm
+from litellm.cost_calculator import cost_per_token as litellm_cost_per_token
+from litellm.litellm_core_utils.llm_cost_calc.utils import get_token_type_cost_breakdown
 from litellm.llms.dashscope.cost_calculator import (
     cost_per_token as dashscope_cost_per_token,
 )
@@ -52,6 +54,200 @@ class TestDashscopeCostCalculator:
 
         assert math.isclose(prompt_cost, expected_prompt_cost, rel_tol=1e-10)
         assert math.isclose(completion_cost, expected_completion_cost, rel_tol=1e-10)
+
+    @pytest.mark.parametrize(
+        ("cache_type", "expected_cache_rate"),
+        [
+            ("ephemeral", 1e-07),
+            (None, 2e-07),
+            ("unknown-future-type", 1e-07),
+        ],
+    )
+    def test_dashscope_flat_pricing_distinguishes_explicit_and_implicit_cache_reads(
+        self, cache_type: str | None, expected_cache_rate: float
+    ):
+        litellm.model_cost["dashscope/qwen-context-cache-mode-test"] = {
+            "litellm_provider": "dashscope",
+            "mode": "chat",
+            "input_cost_per_token": 1e-06,
+            "output_cost_per_token": 4e-06,
+            "implicit_cache_read_input_token_cost": 2e-07,
+            "cache_read_input_token_cost": 1e-07,
+        }
+        prompt_tokens_details: dict[str, int | str] = {"cached_tokens": 600}
+        if cache_type is not None:
+            prompt_tokens_details["cache_type"] = cache_type
+        usage = Usage(
+            prompt_tokens=1000,
+            completion_tokens=0,
+            prompt_tokens_details=prompt_tokens_details,
+        )
+
+        prompt_cost, _ = dashscope_cost_per_token(model="qwen-context-cache-mode-test", usage=usage)
+
+        assert math.isclose(
+            prompt_cost,
+            (400 * 1e-06) + (600 * expected_cache_rate),
+            rel_tol=1e-10,
+        )
+
+    def test_dashscope_implicit_cache_read_falls_back_to_existing_cache_read_rate(self):
+        litellm.model_cost["dashscope/qwen-implicit-cache-fallback-test"] = {
+            "litellm_provider": "dashscope",
+            "mode": "chat",
+            "input_cost_per_token": 1e-06,
+            "output_cost_per_token": 4e-06,
+            "cache_read_input_token_cost": 1e-07,
+        }
+        usage = Usage(
+            prompt_tokens=1000,
+            completion_tokens=0,
+            prompt_tokens_details={"cached_tokens": 600},
+        )
+
+        prompt_cost, _ = dashscope_cost_per_token(
+            model="qwen-implicit-cache-fallback-test",
+            usage=usage,
+        )
+
+        assert math.isclose(prompt_cost, (400 * 1e-06) + (600 * 1e-07), rel_tol=1e-10)
+
+    def test_dashscope_request_cache_control_is_explicit_mode_fallback(self):
+        litellm.model_cost["dashscope/qwen-cache-control-fallback-test"] = {
+            "litellm_provider": "dashscope",
+            "mode": "chat",
+            "input_cost_per_token": 1e-06,
+            "output_cost_per_token": 4e-06,
+            "cache_read_input_token_cost": 1e-07,
+            "implicit_cache_read_input_token_cost": 2e-07,
+        }
+        usage = Usage(
+            prompt_tokens=1000,
+            completion_tokens=0,
+            prompt_tokens_details={"cached_tokens": 600},
+        )
+
+        prompt_cost, _ = dashscope_cost_per_token(
+            model="qwen-cache-control-fallback-test",
+            usage=usage,
+            cache_control_requested=True,
+        )
+
+        assert math.isclose(prompt_cost, (400 * 1e-06) + (600 * 1e-07), rel_tol=1e-10)
+
+    def test_dashscope_tiered_pricing_uses_mode_specific_cache_read_rate(self):
+        self._register_tiered_model(
+            "dashscope/qwen-tiered-cache-mode-test",
+            [
+                {
+                    "range": [0, 1000],
+                    "input_cost_per_token": 1e-06,
+                    "output_cost_per_token": 4e-06,
+                    "implicit_cache_read_input_token_cost": 2e-07,
+                    "cache_read_input_token_cost": 1e-07,
+                }
+            ],
+        )
+        usage = Usage(
+            prompt_tokens=1000,
+            completion_tokens=0,
+            prompt_tokens_details={"cached_tokens": 600, "cache_type": "ephemeral"},
+        )
+
+        prompt_cost, _ = dashscope_cost_per_token(model="qwen-tiered-cache-mode-test", usage=usage)
+
+        assert math.isclose(prompt_cost, (400 * 1e-06) + (600 * 1e-07), rel_tol=1e-10)
+
+    def test_dashscope_cost_breakdown_uses_mode_specific_cache_read_rate(self):
+        litellm.model_cost["dashscope/qwen-cache-breakdown-mode-test"] = {
+            "litellm_provider": "dashscope",
+            "mode": "chat",
+            "input_cost_per_token": 1e-06,
+            "output_cost_per_token": 4e-06,
+            "cache_read_input_token_cost": 1e-07,
+            "implicit_cache_read_input_token_cost": 2e-07,
+        }
+        usage = Usage(
+            prompt_tokens=1000,
+            completion_tokens=0,
+            prompt_tokens_details={"cached_tokens": 600, "cache_type": "ephemeral"},
+        )
+
+        breakdown = get_token_type_cost_breakdown(
+            model="qwen-cache-breakdown-mode-test",
+            custom_llm_provider="dashscope",
+            usage=usage,
+        )
+
+        assert math.isclose(breakdown.cache_read_cost, 600 * 1e-07, rel_tol=1e-10)
+
+    def test_dashscope_custom_pricing_uses_mode_specific_cache_read_rate(self):
+        usage = Usage(
+            prompt_tokens=1000,
+            completion_tokens=0,
+            prompt_tokens_details={"cached_tokens": 600, "cache_type": "ephemeral"},
+        )
+
+        prompt_cost, _ = litellm_cost_per_token(
+            model="custom-qwen",
+            custom_llm_provider="dashscope",
+            usage_object=usage,
+            prompt_tokens=1000,
+            custom_cost_per_token={
+                "input_cost_per_token": 1e-06,
+                "output_cost_per_token": 4e-06,
+                "implicit_cache_read_input_token_cost": 2e-07,
+                "cache_read_input_token_cost": 1e-07,
+            },
+        )
+
+        assert math.isclose(prompt_cost, (400 * 1e-06) + (600 * 1e-07), rel_tol=1e-10)
+
+    def test_completion_cost_detects_cache_control_request_fallback(self):
+        usage = Usage(
+            prompt_tokens=1000,
+            completion_tokens=100,
+            total_tokens=1100,
+            prompt_tokens_details={"cached_tokens": 600},
+        )
+        response = litellm.ModelResponse(
+            id="test-id",
+            created=1234567890,
+            model="custom-qwen",
+            object="chat.completion",
+            choices=[],
+            usage=usage,
+        )
+
+        cost = litellm.completion_cost(
+            completion_response=response,
+            model="custom-qwen",
+            custom_llm_provider="dashscope",
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "stable prefix",
+                            "cache_control": {"type": "ephemeral"},
+                        }
+                    ],
+                }
+            ],
+            custom_cost_per_token={
+                "input_cost_per_token": 1e-06,
+                "output_cost_per_token": 4e-06,
+                "cache_read_input_token_cost": 1e-07,
+                "implicit_cache_read_input_token_cost": 2e-07,
+            },
+        )
+
+        assert math.isclose(
+            cost,
+            (400 * 1e-06) + (600 * 1e-07) + (100 * 4e-06),
+            rel_tol=1e-10,
+        )
 
     def test_dashscope_tiered_pricing_within_first_tier(self):
         """
@@ -576,6 +772,45 @@ class TestDashscopeCostCalculator:
 
         assert math.isclose(peak_prompt_cost, (600 * 2.4e-06) + (300 * 2e-07) + (100 * 3e-06), rel_tol=1e-10)
         assert math.isclose(peak_completion_cost, 200 * 4.8e-06, rel_tol=1e-10)
+
+    @pytest.mark.parametrize(
+        ("cache_type", "expected_cache_rate"),
+        [("ephemeral", 5e-08), (None, 8e-08)],
+    )
+    def test_dashscope_off_peak_uses_mode_specific_cache_read_rate(
+        self, cache_type: str | None, expected_cache_rate: float
+    ):
+        model_key = "dashscope/qwen-cache-mode-off-peak-test"
+        litellm.model_cost[model_key] = {
+            "litellm_provider": "dashscope",
+            "mode": "chat",
+            "input_cost_per_token": 2e-06,
+            "output_cost_per_token": 4e-06,
+            "cache_read_input_token_cost": 1e-07,
+            "implicit_cache_read_input_token_cost": 2e-07,
+            "off_peak_pricing": {
+                "hours_utc": self.OFF_PEAK_WINDOW,
+                "input_cost_per_token": 1e-06,
+                "cache_read_input_token_cost": 5e-08,
+                "implicit_cache_read_input_token_cost": 8e-08,
+            },
+        }
+        prompt_tokens_details: dict[str, int | str] = {"cached_tokens": 600}
+        if cache_type is not None:
+            prompt_tokens_details["cache_type"] = cache_type
+        usage = Usage(
+            prompt_tokens=1000,
+            completion_tokens=0,
+            prompt_tokens_details=prompt_tokens_details,
+        )
+
+        prompt_cost, _ = dashscope_cost_per_token(
+            model="qwen-cache-mode-off-peak-test",
+            usage=usage,
+            current_time=self.INSIDE_WINDOW,
+        )
+
+        assert math.isclose(prompt_cost, (400 * 1e-06) + (600 * expected_cache_rate), rel_tol=1e-10)
 
     def test_dashscope_off_peak_window_overrides_the_selected_tier(self):
         """An open off-peak window bills the whole request at the flat off-peak rates, whichever tier

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
@@ -252,6 +252,7 @@ def test_get_logging_payload_maps_nested_cache_creation_input_tokens():
 
     assert additional_usage_values["cache_creation_input_tokens"] == 2048
     assert additional_usage_values["prompt_tokens_details"]["cache_write_tokens"] == 2048
+    assert additional_usage_values["prompt_tokens_details"]["cache_type"] == "ephemeral"
 
 
 def test_get_logging_payload_preserves_anthropic_cache_creation_input_tokens():

--- a/tests/test_litellm/types/test_types_utils.py
+++ b/tests/test_litellm/types/test_types_utils.py
@@ -96,6 +96,31 @@ def test_prompt_tokens_details_maps_nested_cache_creation_input_tokens():
     assert not hasattr(non_int, "cache_write_tokens")
 
 
+def test_prompt_tokens_details_preserves_qwen_cache_type():
+    from litellm.types.utils import PromptTokensDetailsWrapper
+
+    details = PromptTokensDetailsWrapper(
+        cached_tokens=1889,
+        cache_creation_input_tokens=0,
+        cache_type="ephemeral",
+    )
+
+    assert details.cache_type == "ephemeral"
+    assert details.model_dump()["cache_type"] == "ephemeral"
+
+
+def test_custom_pricing_accepts_qwen_implicit_cache_rate():
+    from litellm.types.utils import CustomPricingLiteLLMParams
+
+    pricing = CustomPricingLiteLLMParams(
+        cache_read_input_token_cost=1e-07,
+        implicit_cache_read_input_token_cost=2e-07,
+    )
+
+    assert pricing.cache_read_input_token_cost == 1e-07
+    assert pricing.implicit_cache_read_input_token_cost == 2e-07
+
+
 def test_usage_server_tool_use_dict_is_coerced_and_round_trips():
     from litellm.types.utils import ServerToolUse, Usage
 

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -29389,6 +29389,8 @@ export interface components {
             gcs_bucket_name?: string | null;
             /** Google Maps Grounding Cost Per Query */
             google_maps_grounding_cost_per_query?: number | null;
+            /** Implicit Cache Read Input Token Cost */
+            implicit_cache_read_input_token_cost?: number | null;
             /** Input Cost Per Audio Per Second */
             input_cost_per_audio_per_second?: number | null;
             /** Input Cost Per Audio Per Second Above 128K Tokens */
@@ -39385,6 +39387,8 @@ export interface components {
             enable_tag_filtering?: boolean | null;
             /** Id */
             id: string | null;
+            /** Implicit Cache Read Input Token Cost */
+            implicit_cache_read_input_token_cost?: number | null;
             /** Input Cost Per Character */
             input_cost_per_character?: number | null;
             /** Input Cost Per Token */
@@ -39556,6 +39560,8 @@ export interface components {
             gcs_bucket_name?: string | null;
             /** Google Maps Grounding Cost Per Query */
             google_maps_grounding_cost_per_query?: number | null;
+            /** Implicit Cache Read Input Token Cost */
+            implicit_cache_read_input_token_cost?: number | null;
             /** Input Cost Per Audio Per Second */
             input_cost_per_audio_per_second?: number | null;
             /** Input Cost Per Audio Per Second Above 128K Tokens */


### PR DESCRIPTION
## TLDR

Feature this adds:

- Add separate, configurable read prices for Qwen explicit and implicit Context Cache
- Extend existing DashScope cache support with optional mode-aware pricing
- Keep existing cache-read pricing when no implicit rate is configured

How it works:

- Preserve provider-reported `cache_type` in normalized usage
- Reuse `cache_read_input_token_cost` for explicit reads and `cache_creation_input_token_cost` for cache creation
- Add optional `implicit_cache_read_input_token_cost` for implicit reads
- Apply the selected rate consistently to request cost, cost breakdown, tiered pricing, and caching savings

Explicit (`cache_control`-based) and implicit (automatic prefix) caching are documented DashScope capabilities. This PR adds pricing support for distinguishing their cache reads in LiteLLM.

Provider documentation: https://www.alibabacloud.com/help/en/model-studio/context-cache

## User Flow

Before: Qwen cache reads share one configured rate

1. The proxy admin configures `cache_read_input_token_cost` at `$0.10/M` tokens; separate implicit-cache read pricing is not supported
2. A developer sends `POST http://localhost:4000/v1/chat/completions` twice with the same long Qwen prompt and no `cache_control`
3. The repeated response is `200 OK` with `cached_tokens` and no `cache_type`
4. The cache-read cost header uses the shared `$0.10/M` rate

After: the admin can opt into separate implicit-cache read pricing

1. The proxy admin keeps `cache_read_input_token_cost` at `$0.10/M` and sets the new `implicit_cache_read_input_token_cost` to `$0.20/M`
2. The developer repeats the same requests
3. An implicit hit uses `$0.20/M`; an explicit hit with `cache_type: "ephemeral"` continues to use `$0.10/M`
4. Omitting the new field preserves the existing shared-rate behavior

## Relevant issues

Closes https://github.com/BerriAI/litellm/issues/40090

Related transport and pricing work:

- https://github.com/BerriAI/litellm/issues/25330
- https://github.com/BerriAI/litellm/pull/25331
- https://github.com/BerriAI/litellm/issues/27191
- https://github.com/BerriAI/litellm/issues/34729

## Affected release

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The focused tests pass locally: the core cost, provider, and dispatcher suites report `608 passed`; spend tracking reports `225 passed`; savings reports `97 passed`; types reports `39 passed`
- [x] My PR passes all required CI/CD checks on current commit `2cafaa308f`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** on the current commit (`5/5` for `2cafaa308f`)

Local verification:

- Patch coverage is `100%` across 88 changed executable Python lines
- All `make check` gates passed on `2cafaa308f`, including circular-import, type-discipline, test-quality, frontend, and `schema.d.ts` sync checks
- GitHub reports every required check as passing. The separate non-required OSV scan reports `mlflow 3.15.0` / `PYSEC-2026-3865` from the unchanged `uv.lock`; OSV reports no fixed release
- Local CodSpeed wall-time A/B improved OpenAI from `20.17µs` to `14.47µs` and Anthropic from `21.50µs` to `18.14µs`
- A second `npm run gen:api` produced no generated diff

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Feature Verification

This no-mock proof used real `dashscope/qwen3.8-max` calls. A local relay forwarded request bodies unchanged to the development gateway and removed only upstream cost headers, forcing each checkout to calculate its own cost from the unmodified provider usage.

Both checkouts used the same model configuration below. The new `implicit_cache_read_input_token_cost` field enables separate implicit-cache pricing in the PR checkout; the baseline uses the existing shared cache-read rate. These values are illustrative custom rates, not a statement of the provider's current model prices:

```yaml
input_cost_per_token: 0.000001
output_cost_per_token: 0.000002
cache_creation_input_token_cost: 0.00000125
cache_read_input_token_cost: 0.0000001
implicit_cache_read_input_token_cost: 0.0000002
```

The implicit request contained a stable prompt longer than 1,024 tokens and no `cache_control`. The explicit request used the same text with `cache_control: {"type": "ephemeral"}`. Each `curl` loop sent the request twice and captured the second response.

### Before (30f33a949b)

#### Implicit automatic cache hit

1. Send the implicit request twice to the baseline `main` checkout (`30f33a949b`):

   ```bash
   for _ in 1 2; do
     curl --fail-with-body --silent --show-error \
       --dump-header before-implicit.headers \
       --output before-implicit.json \
       --header "Authorization: Bearer $LOCAL_PROXY_KEY" \
       --header "Content-Type: application/json" \
       --data-binary @implicit.json \
       http://127.0.0.1:4011/v1/chat/completions
   done
   ```

2. Observe 50,176 cached tokens with no `cache_type`, priced using the existing shared cache-read rate:

   ```text
   HTTP/1.1 200 OK
   x-litellm-response-cost-cache-read: 0.0050176
   usage.prompt_tokens: 50664
   usage.prompt_tokens_details.cached_tokens: 50176
   usage.prompt_tokens_details.cache_type: null
   ```

   `50176 * 0.0000001 = 0.0050176`

#### Explicit ephemeral cache hit

1. Send the explicit request twice to the same `main` checkout:

   ```bash
   for _ in 1 2; do
     curl --fail-with-body --silent --show-error \
       --dump-header before-explicit.headers \
       --output before-explicit.json \
       --header "Authorization: Bearer $LOCAL_PROXY_KEY" \
       --header "Content-Type: application/json" \
       --data-binary @explicit.json \
       http://127.0.0.1:4011/v1/chat/completions
   done
   ```

2. Observe 50,654 cached tokens with `cache_type: "ephemeral"`, priced using the existing explicit cache-read rate:

   ```text
   HTTP/1.1 200 OK
   x-litellm-response-cost-cache-read: 0.005065399999999999
   usage.prompt_tokens: 50668
   usage.prompt_tokens_details.cached_tokens: 50654
   usage.prompt_tokens_details.cache_creation_input_tokens: 0
   usage.prompt_tokens_details.cache_type: ephemeral
   ```

   `50654 * 0.0000001 = 0.0050654`

### After (2cafaa308f)

#### Implicit automatic cache hit

1. Send the identical implicit request twice to the current PR checkout:

   ```bash
   for _ in 1 2; do
     curl --fail-with-body --silent --show-error \
       --dump-header after-implicit.headers \
       --output after-implicit.json \
       --header "Authorization: Bearer $LOCAL_PROXY_KEY" \
       --header "Content-Type: application/json" \
       --data-binary @implicit.json \
       http://127.0.0.1:4012/v1/chat/completions
   done
   ```

2. Observe the same 50,176 cached tokens, now priced using the separately configured implicit-cache read rate:

   ```text
   HTTP/1.1 200 OK
   x-litellm-response-cost-cache-read: 0.0100352
   usage.prompt_tokens: 50664
   usage.prompt_tokens_details.cached_tokens: 50176
   usage.prompt_tokens_details.cache_type: null
   ```

   `50176 * 0.0000002 = 0.0100352`

#### Explicit ephemeral cache hit

1. Send the identical explicit request twice to the same PR checkout:

   ```bash
   for _ in 1 2; do
     curl --fail-with-body --silent --show-error \
       --dump-header after-explicit.headers \
       --output after-explicit.json \
       --header "Authorization: Bearer $LOCAL_PROXY_KEY" \
       --header "Content-Type: application/json" \
       --data-binary @explicit.json \
       http://127.0.0.1:4012/v1/chat/completions
   done
   ```

2. Observe the same 50,654 explicit cached tokens still using the existing explicit rate:

   ```text
   HTTP/1.1 200 OK
   x-litellm-response-cost-cache-read: 0.005065399999999999
   usage.prompt_tokens: 50668
   usage.prompt_tokens_details.cached_tokens: 50654
   usage.prompt_tokens_details.cache_creation_input_tokens: 0
   usage.prompt_tokens_details.cache_type: ephemeral
   ```

   `50654 * 0.0000001 = 0.0050654`

## Type

🆕 New Feature

## Caveats (if any)

### Low

- Separate implicit pricing is opt-in per model
- Missing implicit rates preserve existing cache-read pricing

## Final Attestation

- [x] The tests check the right things, including edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

