### PR TITLE
fix(responses): stream one lifecycle across MCP auto-execute rounds

### DIFF
--- a/litellm/responses/mcp/mcp_streaming_iterator.py
+++ b/litellm/responses/mcp/mcp_streaming_iterator.py
@@ -602,7 +602,7 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
         self._composed_output.extend(_output_items(response))
         self._composed_output.extend(self._pending_mcp_call_items)
         self._output_index_offset += width + len(self._pending_mcp_call_items)
-        self._pending_mcp_call_items = []
+        self._pending_mcp_call_items.clear()
         self._round_max_output_index = -1
 
     async def _compose_round_chunk(self, chunk: ResponsesAPIStreamingResponse) -> ResponsesAPIStreamingResponse | None:
@@ -648,7 +648,10 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
                 *self._composed_output,
                 *_output_items(response_obj),
             ]
-            _set_event_field(chunk, "response", response_obj.model_copy(update={"output": merged_output}))
+            merged_response: Final = response_obj.model_copy(
+                update={"output": merged_output}  # mutable-ok: pydantic's update argument must be a dict
+            )
+            _set_event_field(chunk, "response", merged_response)
         return chunk
 
     async def _process_base_iterator_chunk(self) -> ResponsesAPIStreamingResponse:
@@ -769,11 +772,11 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
                     call_items[tool_call_id] = (item_id, output_index)
                     self.tool_execution_events.append(
                         OutputItemAddedEvent.model_validate(
-                            {
+                            {  # mutable-ok: consumed once by model_validate
                                 "type": ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED,
                                 "sequence_number": len(self.tool_execution_events) + 1,
                                 "output_index": output_index,
-                                "item": {
+                                "item": {  # mutable-ok: consumed once by model_validate
                                     "id": item_id,
                                     "type": "mcp_call",
                                     "status": "in_progress",
@@ -850,7 +853,7 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
                 from litellm.types.llms.openai import OutputItemDoneEvent
 
                 mcp_call_item = BaseLiteLLMOpenAIResponseObject(
-                    **{
+                    **{  # mutable-ok: consumed once by the model constructor
                         "id": item_id,
                         "type": "mcp_call",
                         "approval_request_id": f"mcpr_{uuid.uuid4().hex[:8]}",

--- a/litellm/responses/mcp/mcp_streaming_iterator.py
+++ b/litellm/responses/mcp/mcp_streaming_iterator.py
@@ -34,6 +34,16 @@ else:
 MAX_MCP_TOOL_CALL_ROUNDS: Final = 5
 
 
+def _output_items(response: ResponsesAPIResponse) -> Sequence[object]:
+    """Read a response's output items as plain objects; the field is a wide union of item models."""
+    return tuple(cast("Sequence[object]", response.output))  # cast-ok: items are only carried, never inspected
+
+
+def _set_event_field(event: ResponsesAPIStreamingResponse, name: str, value: object) -> None:
+    """Events are pydantic models with extra fields allowed, so any event type can carry the field."""
+    setattr(event, name, value)
+
+
 async def create_mcp_list_tools_events(
     mcp_tools_with_litellm_proxy: Sequence[Mapping[str, object]],
     user_api_key_auth: "UserAPIKeyAuth | None",
@@ -170,6 +180,7 @@ def create_mcp_call_events(
     result: str | None = None,
     base_item_id: str | None = None,
     sequence_start: int = 1,
+    output_index: int = 0,
 ) -> list[ResponsesAPIStreamingResponse]:
     """Create MCP call events following OpenAI's specification"""
     events: Final[list[ResponsesAPIStreamingResponse]] = []
@@ -179,7 +190,7 @@ def create_mcp_call_events(
     in_progress_event: Final = MCPCallInProgressEvent(
         type=ResponsesAPIStreamEvents.MCP_CALL_IN_PROGRESS,
         sequence_number=sequence_start,
-        output_index=0,
+        output_index=output_index,
         item_id=item_id,
     )
     events.append(in_progress_event)
@@ -187,7 +198,7 @@ def create_mcp_call_events(
     # MCP call arguments delta event (streaming the arguments)
     arguments_delta_event: Final = MCPCallArgumentsDeltaEvent(
         type=ResponsesAPIStreamEvents.MCP_CALL_ARGUMENTS_DELTA,
-        output_index=0,
+        output_index=output_index,
         item_id=item_id,
         delta=arguments,  # JSON string with arguments
         sequence_number=sequence_start + 1,
@@ -197,7 +208,7 @@ def create_mcp_call_events(
     # MCP call arguments done event
     arguments_done_event: Final = MCPCallArgumentsDoneEvent(
         type=ResponsesAPIStreamEvents.MCP_CALL_ARGUMENTS_DONE,
-        output_index=0,
+        output_index=output_index,
         item_id=item_id,
         arguments=arguments,  # Complete JSON string with finalized arguments
         sequence_number=sequence_start + 2,
@@ -210,7 +221,7 @@ def create_mcp_call_events(
             type=ResponsesAPIStreamEvents.MCP_CALL_COMPLETED,
             sequence_number=sequence_start + 3,
             item_id=item_id,
-            output_index=0,
+            output_index=output_index,
         )
         events.append(completed_event)
 
@@ -219,7 +230,7 @@ def create_mcp_call_events(
 
         output_item_done_event: Final = OutputItemDoneEvent(
             type=ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE,
-            output_index=0,
+            output_index=output_index,
             item=BaseLiteLLMOpenAIResponseObject(
                 **{
                     "id": item_id,
@@ -239,7 +250,7 @@ def create_mcp_call_events(
             type=ResponsesAPIStreamEvents.MCP_CALL_FAILED,
             sequence_number=sequence_start + 3,
             item_id=item_id,
-            output_index=0,
+            output_index=output_index,
         )
         events.append(failed_event)
 
@@ -330,6 +341,17 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
         self._error_event_emitted = False
         self._last_sequence_number = 0
 
+        # Every auto-execute round is a distinct upstream response, but the
+        # client is reading one stream. Fold the rounds into one public
+        # lifecycle: one response.created, one response.completed whose
+        # output holds every round's items, and output indexes that are
+        # never reused for a different item.
+        self._round_index = 0
+        self._output_index_offset = 0
+        self._round_max_output_index = -1
+        self._composed_output: list[object] = []  # mutable-ok: grows as each round finishes
+        self._pending_mcp_call_items: list[dict[str, object]] = []  # mutable-ok: grows per executed tool
+
     def _extract_mcp_headers_from_params(self) -> None:
         """Extract MCP headers from original request params to pass to tool calls"""
 
@@ -415,8 +437,14 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
     async def __anext__(self) -> ResponsesAPIStreamingResponse:
         chunk: Final = await self._anext_impl()
         sequence_number: Final = getattr(chunk, "sequence_number", None)
-        if isinstance(sequence_number, int) and sequence_number > self._last_sequence_number:
-            self._last_sequence_number = sequence_number
+        if isinstance(sequence_number, int):
+            # Follow-up rounds and gateway events restart their numbering.
+            # Keep the public stream strictly increasing.
+            if sequence_number <= self._last_sequence_number and self._last_sequence_number > 0:
+                self._last_sequence_number += 1
+                _set_event_field(chunk, "sequence_number", self._last_sequence_number)
+            else:
+                self._last_sequence_number = max(self._last_sequence_number, sequence_number)
         return chunk
 
     async def _anext_impl(self) -> ResponsesAPIStreamingResponse:
@@ -472,7 +500,7 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
             await self._create_follow_up_iterator()
             if self.base_iterator is not None:
                 self.phase = "continue_initial_response"
-                return await self.__anext__()
+                return await self._anext_impl()
             self.phase = "finished"
             if self._stream_error is not None and not self._error_event_emitted:
                 self._error_event_emitted = True
@@ -530,17 +558,11 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
                         if chunk_type == ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED:
                             self.initial_events_emitted = True
                             self.phase = "mcp_discovery"
-                            return chunk
+                            return await self._compose_round_chunk(chunk)
 
-                    # If auto-execution is enabled, check for completed responses
-                    if self.should_auto_execute and self._is_response_completed(chunk):
-                        response_obj = getattr(chunk, "response", None)
-                        if isinstance(response_obj, ResponsesAPIResponse):
-                            self.collected_response = response_obj
-                        self.phase = "tool_execution"
-                        await self._generate_tool_execution_events()
-
-                    return chunk
+                    # None means the chunk was folded into the single public
+                    # lifecycle; fall through so phase 4 runs the follow-up.
+                    return await self._compose_round_chunk(chunk)
                 except StopAsyncIteration:
                     if self.should_auto_execute and self.collected_response:
                         self.phase = "tool_execution"
@@ -565,6 +587,69 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
 
         chunk_type: Final[object] = getattr(chunk, "type", None)
         return chunk_type == ResponsesAPIStreamEvents.RESPONSE_COMPLETED
+
+    def _follow_up_pending(self) -> bool:
+        """True when the current round's tool calls were executed and a follow-up round will run."""
+        return self.collected_response is not None and self.collected_response is self._tool_results_for_response
+
+    def _round_output_width(self, response: ResponsesAPIResponse) -> int:
+        """How many output indexes this round used, counting items it streamed but never listed."""
+        return max(len(_output_items(response)), self._round_max_output_index + 1)
+
+    def _absorb_round(self, response: ResponsesAPIResponse) -> None:
+        """Bank a finished round's items so the final response.completed can list them."""
+        width: Final = self._round_output_width(response)
+        self._composed_output.extend(_output_items(response))
+        self._composed_output.extend(self._pending_mcp_call_items)
+        self._output_index_offset += width + len(self._pending_mcp_call_items)
+        self._pending_mcp_call_items = []
+        self._round_max_output_index = -1
+
+    async def _compose_round_chunk(self, chunk: ResponsesAPIStreamingResponse) -> ResponsesAPIStreamingResponse | None:
+        """
+        Fold one round's event into the single public lifecycle.
+
+        Returns None when the event must not reach the client: the lifecycle
+        openers of a follow-up round, and the response.completed of a round
+        whose tool calls the gateway executes itself. Shifts output_index on
+        follow-up rounds past the items already emitted, and lists every
+        round's items on the final response.completed.
+        """
+        chunk_type: Final[object] = getattr(chunk, "type", None)
+        if self._round_index > 0 and chunk_type in (
+            ResponsesAPIStreamEvents.RESPONSE_CREATED,
+            ResponsesAPIStreamEvents.RESPONSE_IN_PROGRESS,
+        ):
+            return None
+
+        output_index: Final[object] = getattr(chunk, "output_index", None)
+        if isinstance(output_index, int):
+            self._round_max_output_index = max(self._round_max_output_index, output_index)
+            if self._output_index_offset:
+                _set_event_field(chunk, "output_index", output_index + self._output_index_offset)
+
+        if not (self.should_auto_execute and self._is_response_completed(chunk)):
+            return chunk
+
+        response_obj: Final[object] = getattr(chunk, "response", None)
+        if isinstance(response_obj, ResponsesAPIResponse):
+            self.collected_response = response_obj
+        # Move to tool execution phase after this chunk
+        self.phase = "tool_execution"
+        await self._generate_tool_execution_events()
+
+        if not isinstance(response_obj, ResponsesAPIResponse):
+            return chunk
+        if self._follow_up_pending():
+            self._absorb_round(response_obj)
+            return None
+        if self._composed_output:
+            merged_output: Final[list[object]] = [  # mutable-ok: the response model declares output as a list
+                *self._composed_output,
+                *_output_items(response_obj),
+            ]
+            _set_event_field(chunk, "response", response_obj.model_copy(update={"output": merged_output}))
+        return chunk
 
     async def _process_base_iterator_chunk(self) -> ResponsesAPIStreamingResponse:
         """
@@ -593,17 +678,11 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
                     )
                     response_obj.id = self._cached_response_id
 
-        # If auto-execution is enabled, check for completed responses
-        if self.should_auto_execute and self._is_response_completed(chunk):
-            # Collect the response for tool execution
-            response_obj = getattr(chunk, "response", None)
-            if isinstance(response_obj, ResponsesAPIResponse):
-                self.collected_response = response_obj
-            # Move to tool execution phase after emitting this chunk
-            self.phase = "tool_execution"
-            await self._generate_tool_execution_events()
-
-        return chunk
+        composed: Final = await self._compose_round_chunk(chunk)
+        if composed is None:
+            # The chunk stays internal; hand the next public event back instead.
+            return await self._anext_impl()
+        return composed
 
     async def _create_initial_response_iterator(self) -> None:
         """Create the initial response iterator by making the first LLM call"""
@@ -667,6 +746,16 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
                 return
             self.tool_call_round += 1
 
+            # Each executed tool is one mcp_call output item of the single
+            # public response. Announce it at an output_index past the items
+            # this round already streamed, and keep that item id for the
+            # completion events below.
+            from litellm.types.llms.openai import OutputItemAddedEvent
+
+            next_output_index = self._output_index_offset + self._round_output_width(  # rebind-ok: advances per item
+                self.collected_response
+            )
+            call_items: Final[dict[str, tuple[str, int]]] = {}  # mutable-ok: filled per tool call as events queue
             for tool_call in tool_calls:
                 (
                     tool_name,
@@ -674,14 +763,36 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
                     tool_call_id,
                 ) = LiteLLM_Proxy_MCP_Handler._extract_tool_call_details(tool_call)
                 if tool_name and tool_call_id:
+                    item_id = f"mcp_{uuid.uuid4().hex[:8]}"
+                    output_index = next_output_index
+                    next_output_index += 1
+                    call_items[tool_call_id] = (item_id, output_index)
+                    self.tool_execution_events.append(
+                        OutputItemAddedEvent.model_validate(
+                            {
+                                "type": ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED,
+                                "sequence_number": len(self.tool_execution_events) + 1,
+                                "output_index": output_index,
+                                "item": {
+                                    "id": item_id,
+                                    "type": "mcp_call",
+                                    "status": "in_progress",
+                                    "arguments": tool_arguments or "{}",
+                                    "name": tool_name,
+                                    "server_label": "litellm",
+                                },
+                            }
+                        )
+                    )
                     # Create MCP call events for this tool execution
                     call_events = create_mcp_call_events(
                         tool_name=tool_name,
                         tool_call_id=tool_call_id,
                         arguments=tool_arguments or "{}",  # JSON string with arguments
                         result=None,  # Will be set after execution
-                        base_item_id=f"mcp_{uuid.uuid4().hex[:8]}",
+                        base_item_id=item_id,
                         sequence_start=len(self.tool_execution_events) + 1,
+                        output_index=output_index,
                     )
                     # Add the in_progress and arguments events (not the completed event yet)
                     self.tool_execution_events.extend(call_events[:-1])
@@ -719,37 +830,45 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
                         tool_arguments = args or "{}"
                         break
 
-                item_id = f"mcp_{uuid.uuid4().hex[:8]}"
+                if tool_call_id in call_items:
+                    item_id, output_index = call_items[tool_call_id]
+                else:
+                    item_id = f"mcp_{uuid.uuid4().hex[:8]}"
+                    output_index = next_output_index
+                    next_output_index += 1
 
                 # Create the completion event
                 completed_event = MCPCallCompletedEvent(
                     type=ResponsesAPIStreamEvents.MCP_CALL_COMPLETED,
                     sequence_number=len(self.tool_execution_events) + 1,
                     item_id=item_id,
-                    output_index=0,
+                    output_index=output_index,
                 )
                 self.tool_execution_events.append(completed_event)
 
                 # Create output_item.done event with the tool call result
                 from litellm.types.llms.openai import OutputItemDoneEvent
 
+                mcp_call_item = BaseLiteLLMOpenAIResponseObject(
+                    **{
+                        "id": item_id,
+                        "type": "mcp_call",
+                        "approval_request_id": f"mcpr_{uuid.uuid4().hex[:8]}",
+                        "arguments": tool_arguments,
+                        "error": None,
+                        "name": tool_name,
+                        "output": result_text,
+                        "server_label": "litellm",  # or extract from tool config
+                    }
+                )
                 output_item_done_event = OutputItemDoneEvent(
                     type=ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE,
-                    output_index=0,
-                    item=BaseLiteLLMOpenAIResponseObject(
-                        **{
-                            "id": item_id,
-                            "type": "mcp_call",
-                            "approval_request_id": f"mcpr_{uuid.uuid4().hex[:8]}",
-                            "arguments": tool_arguments,
-                            "error": None,
-                            "name": tool_name,
-                            "output": result_text,
-                            "server_label": "litellm",  # or extract from tool config
-                        }
-                    ),
+                    output_index=output_index,
+                    item=mcp_call_item,
                 )
                 self.tool_execution_events.append(output_item_done_event)
+                # The response model accepts output items as dicts, not as the generic event object.
+                self._pending_mcp_call_items.append(mcp_call_item.model_dump())
 
             # Store tool results for follow-up call
             self.tool_results = tool_results
@@ -824,6 +943,7 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
                 self.base_iterator = follow_up_response
                 self.collected_response = None
                 self._cached_response_id = None
+                self._round_index += 1
 
         except Exception as e:
             verbose_logger.error("Error creating follow-up iterator: %s", e)

--- a/tests/test_litellm/responses/mcp/test_mcp_streaming_iterator.py
+++ b/tests/test_litellm/responses/mcp/test_mcp_streaming_iterator.py
@@ -57,6 +57,10 @@ def _text_message(text: str):
     return {"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": text}]}
 
 
+def _item_type(item) -> str:
+    return item["type"] if isinstance(item, dict) else item.type
+
+
 def _tool_call_stream(call_id: str, tool_name: str, response_id: str = "resp-1") -> _FakeAsyncStream:
     return _FakeAsyncStream([_completed_chunk([_function_call(call_id, tool_name)], response_id=response_id)])
 
@@ -134,11 +138,19 @@ async def test_second_round_tool_call_is_executed_and_reaches_final_text(monkeyp
     assert iterator.tool_call_round == 2
 
     # The stream reached round 3 and produced the final text response instead
-    # of stopping after round 1 or round 2.
+    # of stopping after round 1 or round 2. The client sees one lifecycle whose
+    # final output lists every round's items in order.
     completed_chunks = [c for c in chunks if getattr(c, "type", None) == ResponsesAPIStreamEvents.RESPONSE_COMPLETED]
-    assert len(completed_chunks) == 3
+    assert len(completed_chunks) == 1
     final_output = completed_chunks[-1].response.output
-    assert final_output[0]["content"][0]["text"] == "Here's what I found after retrying."
+    assert [_item_type(item) for item in final_output] == [
+        "function_call",
+        "mcp_call",
+        "function_call",
+        "mcp_call",
+        "message",
+    ]
+    assert final_output[-1]["content"][0]["text"] == "Here's what I found after retrying."
 
 
 @pytest.mark.asyncio
@@ -207,7 +219,7 @@ async def test_continuation_id_is_final_round_not_interim_tool_call(monkeypatch)
     chunks = [chunk async for chunk in iterator]
     completed = [c for c in chunks if getattr(c, "type", None) == ResponsesAPIStreamEvents.RESPONSE_COMPLETED]
 
-    assert completed[-1].response.output[0]["content"][0]["text"] == "The first item is Alpha."
+    assert completed[-1].response.output[-1]["content"][0]["text"] == "The first item is Alpha."
     assert completed[-1].response.id == "resp-final"
     assert completed[-1].response.id != "resp-interim"
 
@@ -280,7 +292,9 @@ async def test_streaming_follow_up_replays_reasoning_when_store_is_false(monkeyp
         base_iterator=_FakeAsyncStream(
             [
                 _output_item_added_chunk(),
-                _completed_chunk([_reasoning_item("gAAAAA-opaque-blob"), _function_call("call_1", "read_wiki_contents")]),
+                _completed_chunk(
+                    [_reasoning_item("gAAAAA-opaque-blob"), _function_call("call_1", "read_wiki_contents")]
+                ),
             ]
         ),
         mcp_events=[],
@@ -316,7 +330,9 @@ async def test_streaming_follow_up_keeps_previous_response_id_when_stored(monkey
         base_iterator=_FakeAsyncStream(
             [
                 _output_item_added_chunk(),
-                _completed_chunk([_reasoning_item("gAAAAA-opaque-blob"), _function_call("call_1", "read_wiki_contents")]),
+                _completed_chunk(
+                    [_reasoning_item("gAAAAA-opaque-blob"), _function_call("call_1", "read_wiki_contents")]
+                ),
             ]
         ),
         mcp_events=[],
@@ -336,3 +352,103 @@ async def test_streaming_follow_up_keeps_previous_response_id_when_stored(monkey
     follow_up_kwargs = aresponses_mock.call_args_list[0].kwargs
     assert follow_up_kwargs["previous_response_id"] == "resp_prev"
     assert not [item for item in follow_up_kwargs["input"] if item.get("type") == "reasoning"]
+
+
+def _event(event_type, **fields):
+    return SimpleNamespace(type=event_type, **fields)
+
+
+def _lifecycle_round(response_id: str, item: dict, sequence_start: int = 0):
+    """One upstream Responses round as a provider streams it: its own id, indexes from 0, numbering from 0."""
+    return [
+        _event(
+            ResponsesAPIStreamEvents.RESPONSE_CREATED,
+            response=ResponsesAPIResponse(id=response_id, created_at=0, output=[]),
+            sequence_number=sequence_start,
+        ),
+        _event(
+            ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED, output_index=0, item=item, sequence_number=sequence_start + 1
+        ),
+        _event(
+            ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE, output_index=0, item=item, sequence_number=sequence_start + 2
+        ),
+        _completed_chunk([item], response_id=response_id),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_auto_execute_rounds_share_one_public_lifecycle(monkeypatch):
+    """
+    Every auto-execute round is a distinct upstream response, but the client
+    reads one stream. It must see one response.created, one response.completed,
+    and no output_index reused for a different item, otherwise accumulating
+    clients such as the OpenAI SDK's responses.stream() abort mid-stream.
+    """
+    _mock_mcp_environment(monkeypatch)
+
+    follow_up = _FakeAsyncStream(_lifecycle_round("resp-final", _text_message("Alpha.")))
+    monkeypatch.setattr(responses_main_module, "aresponses", AsyncMock(side_effect=[follow_up]))
+
+    iterator = _make_iterator(_lifecycle_round("resp-interim", _function_call("call_1", "read_wiki_contents")))
+    chunks = [chunk async for chunk in iterator]
+    types = [chunk.type for chunk in chunks]
+
+    assert types.count(ResponsesAPIStreamEvents.RESPONSE_CREATED) == 1
+    assert types.count(ResponsesAPIStreamEvents.RESPONSE_COMPLETED) == 1
+    assert types[-1] == ResponsesAPIStreamEvents.RESPONSE_COMPLETED
+
+    # The function call, the gateway's mcp_call, and the final message each own an index.
+    added = [c for c in chunks if c.type == ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED]
+    assert [(c.output_index, _item_type(c.item)) for c in added] == [
+        (0, "function_call"),
+        (1, "mcp_call"),
+        (2, "message"),
+    ]
+    mcp_item_ids = {c.item_id for c in chunks if c.type == ResponsesAPIStreamEvents.MCP_CALL_IN_PROGRESS}
+    mcp_done = [
+        c for c in chunks if c.type == ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE and _item_type(c.item) == "mcp_call"
+    ]
+    assert [c.output_index for c in mcp_done] == [1]
+    assert {c.item.id for c in mcp_done} == mcp_item_ids
+    round_two = [
+        c for c in chunks if getattr(c, "item_id", None) is None and getattr(c, "output_index", None) is not None
+    ]
+    assert max(c.output_index for c in round_two) == 2
+
+    # The single completed event lists every round's items and keeps the final round's id for continuation.
+    completed = chunks[-1]
+    assert completed.response.id == "resp-final"
+    assert [_item_type(item) for item in completed.response.output] == ["function_call", "mcp_call", "message"]
+    assert completed.response.output[-1]["content"][0]["text"] == "Alpha."
+    # The proxy serializes every chunk; the merged output must still be a valid response.
+    assert '"type":"mcp_call"' in completed.response.model_dump_json(exclude_none=True, exclude_unset=True)
+
+    # Numbering stays strictly increasing across rounds and gateway events.
+    sequence_numbers = [c.sequence_number for c in chunks if getattr(c, "sequence_number", None) is not None]
+    assert sequence_numbers == sorted(sequence_numbers)
+    assert len(set(sequence_numbers)) == len(sequence_numbers)
+
+
+@pytest.mark.asyncio
+async def test_stream_without_auto_execute_is_forwarded_unchanged(monkeypatch):
+    """With approval required there is one round, and it passes through untouched."""
+    _mock_mcp_environment(monkeypatch)
+    aresponses_mock = AsyncMock()
+    monkeypatch.setattr(responses_main_module, "aresponses", aresponses_mock)
+
+    upstream = _lifecycle_round("resp-1", _function_call("call_1", "read_wiki_contents"))
+    iterator = MCPEnhancedStreamingIterator(
+        base_iterator=_FakeAsyncStream(list(upstream)),
+        mcp_events=[],
+        tool_server_map={"read_wiki_contents": "deepwiki"},
+        mcp_tools_with_litellm_proxy=[{"require_approval": "always"}],
+        user_api_key_auth=None,
+        original_request_params={"model": "gpt-4", "input": "hi", "tools": [{"type": "mcp"}]},
+    )
+
+    chunks = [chunk async for chunk in iterator]
+
+    assert chunks == upstream
+    assert [c.output_index for c in chunks if hasattr(c, "output_index")] == [0, 0]
+    assert [c.sequence_number for c in chunks if hasattr(c, "sequence_number")] == [0, 1, 2]
+    aresponses_mock.assert_not_called()


### PR DESCRIPTION
## TLDR

Problem this solves:

- Streaming `/v1/responses` with an auto-executed MCP tool emits two lifecycles in one stream
- `output_index` restarts at 0 for the follow-up round, so indexes collide
- OpenAI SDK `responses.stream()` raises `AssertionError` before the final answer
- `mcp_call` events use two different item ids and no `output_item.added`

How it solves it:

- Drops `response.created` and `response.in_progress` of follow-up rounds
- Holds back the interim `response.completed` when the gateway runs the tool calls
- Shifts later `output_index` values past items already emitted
- Lists every round's items on the single final `response.completed`
- Lists each executed call there as the gateway's completed `mcp_call`, not the model's `function_call`, so an agent framework never tries to run a tool the caller did not declare
- Announces each `mcp_call` with `output_item.added`, one item id, its own index
- Keeps `sequence_number` strictly increasing across rounds and gateway events
- Keeps the final round's id on `response.completed` for `previous_response_id`

## User Flow

Before: a developer streams a Responses request with an auto-executed proxy MCP tool through the OpenAI Python SDK and the SDK crashes before the final answer arrives

1. The proxy admin runs `litellm --config config.yaml --port 4000` with one deployment and one server under `mcp_servers`
2. The developer calls `client.responses.stream(model="mock", input="Use the echo tool with PING, then answer.", tools=[{"type": "mcp", "server_url": "litellm_proxy/mcp/demo", "server_label": "demo", "require_approval": "never"}], tool_choice="required")` against `http://127.0.0.1:4000/v1`
3. `POST http://127.0.0.1:4000/v1/responses` returns `200` and an SSE body with `response.created` (id `resp_A...`), a `function_call` at `output_index: 0`, the MCP list-tools and call events, and `response.completed` (id `resp_A...`)
4. The same body continues with a second `response.created` (id `resp_B...`), a `message` at `output_index: 0`, and `response.output_text.delta`
5. The SDK raises `AssertionError` on that delta and `stream.get_final_response()` is never reached, although the tool ran and the model answered

After: the same request comes back as one response the SDK can accumulate

1. The proxy admin runs the same `litellm --config config.yaml --port 4000`
2. The developer calls the same `client.responses.stream(...)`
3. `POST http://127.0.0.1:4000/v1/responses` returns `200` and an SSE body with exactly one `response.created` and one `response.completed`
4. The `function_call`, `mcp_call`, and `message` items sit at `output_index` 0, 1, and 2, each announced by its own `output_item.added`, with `sequence_number` running 0 to 20 without repeats
5. The SDK yields every event, `stream.get_final_response().output_text` is `FINAL_FROM_ROUND_2`, and `stream.get_final_response().output` lists the completed `mcp_call` and the `message`, with no `function_call` for the tool the gateway already ran

## Relevant issues

Fixes #40118

## Affected release

## Linear ticket

Resolves LIT-8179

## Pre-Submission checklist

- [x] I have added meaningful tests
  - Two expectations changed in e7557ada57 with the final-output change: `test_second_round_tool_call_is_executed_and_reaches_final_text` expected `[function_call, mcp_call, function_call, mcp_call, message]` and now expects `[mcp_call, mcp_call, message]`, and `test_auto_execute_rounds_share_one_public_lifecycle` expected `[function_call, mcp_call, message]` and now expects `[mcp_call, message]`. Reason: the OpenAI Agents SDK 0.22.3 raises `ModelBehaviorError` on a final `function_call` naming a tool the agent never declared, so the final list carries each executed call as the gateway's `mcp_call` only. `test_final_output_lists_executed_call_as_completed_mcp_call` pins the new shape and the `status: completed` on it
- [x] The handful of test files covering my change pass locally, `uv run pytest tests/test_litellm/responses/mcp/ -q` (54 passed) and `uv run pytest tests/test_litellm/responses/ -q` (588 passed)
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves one problem: the public shape of an auto-execute MCP stream on `/v1/responses`
- [x] I have received a Greptile Confidence Score of at least 4/5

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both legs ran the same three clients in the same order against a proxy booted with 2 uvicorn workers and no database, from a fresh worktree at that leg's commit, on a random free port. The model is a real `gpt-5.6` deployment on OpenAI (real spend) and the MCP server is a real stdio FastMCP process with one `echo` tool that logs every call it receives. Only the commit differs between the legs. The master key `sk-qa-1234` is a throwaway for the local proxy. Response ids are shortened to their first 16 characters for display; everything else is verbatim.

`config.yaml`

```yaml
model_list:
  - model_name: gpt-5.6
    litellm_params:
      model: openai/gpt-5.6
      api_key: os.environ/OPENAI_API_KEY

mcp_servers:
  demo:
    transport: stdio
    command: /path/to/worktree/.venv/bin/python
    args:
      - /path/to/mcp_echo_server.py
      - /path/to/mcp-calls.jsonl
    description: local echo tool

general_settings:
  master_key: sk-qa-1234

litellm_settings:
  telemetry: false
```

`mcp_echo_server.py`

```python
import json
import sys
from pathlib import Path

try:
    from mcp.server.mcpserver import MCPServer as _Server
except ImportError:
    from mcp.server.fastmcp import FastMCP as _Server

CALL_LOG = Path(sys.argv[1])
server = _Server("demo")


@server.tool()
def echo(value: str) -> str:
    """Return the supplied value."""
    with CALL_LOG.open("a", encoding="utf-8") as stream:
        stream.write(json.dumps({"tool": "echo", "value": value}) + "\n")
    return f"tool-result:{value}"


if __name__ == "__main__":
    server.run(transport="stdio")
```

`client_stream.py` (run as `python client_stream.py http://127.0.0.1:<port>/v1 <master_key>`, once from a venv with `openai==2.54.0`, the reporter's version, and once with `openai==3.16.2`, the latest)

```python
import sys
import traceback

import openai

client = openai.OpenAI(base_url=sys.argv[1], api_key=sys.argv[2])
print(f"openai sdk {openai.__version__}")
try:
    with client.responses.stream(
        model="gpt-5.6",
        input="Call the echo tool with the value PING, then reply with exactly the tool result and nothing else.",
        tools=[
            {
                "type": "mcp",
                "server_label": "demo",
                "server_url": "litellm_proxy/mcp/demo",
                "require_approval": "never",
            }
        ],
        tool_choice="required",
    ) as stream:
        for event in stream:
            response_id = getattr(getattr(event, "response", None), "id", None)
            output_index = getattr(event, "output_index", None)
            item_type = getattr(getattr(event, "item", None), "type", None)
            fields = " ".join(
                f"{name}={value}"
                for name, value in (("id", response_id), ("output_index", output_index), ("item", item_type))
                if value is not None
            )
            print(f"{event.type} {fields}".rstrip())
        final = stream.get_final_response()
    print(f"FINAL id={final.id} output_text={final.output_text!r}")
except Exception as exc:
    frame = traceback.extract_tb(exc.__traceback__)[-1]
    location = frame.filename.split("site-packages/")[-1]
    print(f"CLIENT ERROR: {type(exc).__name__}: {exc}")
    print(f"  raised at {location}:{frame.lineno}")
    sys.exit(1)
```

### Before (168a0055a2)

Booted with `python litellm/proxy/proxy_cli.py --config config.yaml --port 48827 --num_workers 2` from a worktree at `168a0055a2`

#### 1. Raw SSE, curl

```console
$ curl -sN http://127.0.0.1:48827/v1/responses -H 'content-type: application/json' -H 'authorization: Bearer sk-qa-1234' -d '{"model":"gpt-5.6","stream":true,"input":"Call the echo tool with the value PING, then reply with exactly the tool result and nothing else.","tool_choice":"required","tools":[{"type":"mcp","server_url":"litellm_proxy/mcp/demo","server_label":"demo","require_approval":"never"}]}' | sed -n 's/^data: //p' | grep -v '^\[DONE\]' | jq -c '{type, id: .response.id, output_index, item: .item.type} | with_entries(select(.value != null))'
```

```text
{"type":"response.created","id":"resp_oxr0SSWGlVni…"}
{"type":"response.in_progress","id":"resp_oxr0SSWGlVni…"}
{"type":"response.output_item.added","output_index":0,"item":"function_call"}
{"type":"response.mcp_list_tools.in_progress","output_index":0}
{"type":"response.mcp_list_tools.completed","output_index":0}
{"type":"response.output_item.done","output_index":0,"item":"mcp_list_tools"}
{"type":"response.function_call_arguments.delta","output_index":0}
{"type":"response.function_call_arguments.delta","output_index":0}
{"type":"response.function_call_arguments.delta","output_index":0}
{"type":"response.function_call_arguments.delta","output_index":0}
{"type":"response.function_call_arguments.delta","output_index":0}
{"type":"response.function_call_arguments.done","output_index":0}
{"type":"response.output_item.done","output_index":0,"item":"function_call"}
{"type":"response.completed","id":"resp_oxr0SSWGlVni…"}
{"type":"response.mcp_call.in_progress","output_index":0}
{"type":"response.mcp_call_arguments.delta","output_index":0}
{"type":"response.mcp_call_arguments.done","output_index":0}
{"type":"response.mcp_call.completed","output_index":0}
{"type":"response.output_item.done","output_index":0,"item":"mcp_call"}
{"type":"response.created","id":"resp_08JteiPTi8Yo…"}
{"type":"response.in_progress","id":"resp_08JteiPTi8Yo…"}
{"type":"response.output_item.added","output_index":0,"item":"message"}
{"type":"response.content_part.added","output_index":0}
{"type":"response.output_text.delta","output_index":0}
{"type":"response.output_text.delta","output_index":0}
{"type":"response.output_text.delta","output_index":0}
{"type":"response.output_text.delta","output_index":0}
{"type":"response.output_text.done","output_index":0}
{"type":"response.content_part.done","output_index":0}
{"type":"response.output_item.done","output_index":0,"item":"message"}
{"type":"response.completed","id":"resp_08JteiPTi8Yo…"}
```

#### 2. OpenAI Python SDK 2.54.0, `responses.stream()`

```console
$ clientvenv254/bin/python client_stream.py http://127.0.0.1:48827/v1 sk-qa-1234
```

```text
openai sdk 2.54.0
response.created id=resp_jwiPQfqC8M7H…
response.in_progress id=resp_jwiPQfqC8M7H…
response.output_item.added output_index=0 item=function_call
response.mcp_list_tools.in_progress output_index=0
response.mcp_list_tools.completed output_index=0
response.output_item.done output_index=0 item=mcp_list_tools
response.function_call_arguments.delta output_index=0
response.function_call_arguments.delta output_index=0
response.function_call_arguments.delta output_index=0
response.function_call_arguments.delta output_index=0
response.function_call_arguments.delta output_index=0
response.function_call_arguments.done output_index=0
response.output_item.done output_index=0 item=function_call
response.completed id=resp_jwiPQfqC8M7H…
response.mcp_call.in_progress output_index=0
response.mcp_call_arguments.delta output_index=0
response.mcp_call_arguments.done output_index=0
response.mcp_call.completed output_index=0
response.output_item.done output_index=0 item=mcp_call
response.created id=resp_ik4-g9GcP10K…
response.in_progress id=resp_ik4-g9GcP10K…
response.output_item.added output_index=0 item=message
response.content_part.added output_index=0
CLIENT ERROR: AssertionError: 
  raised at openai/lib/streaming/responses/_responses.py:254
exit code 1
```

#### 3. OpenAI Python SDK 3.16.2, `responses.stream()`

```console
$ clientvenv/bin/python client_stream.py http://127.0.0.1:48827/v1 sk-qa-1234
```

```text
openai sdk 3.16.2
response.created id=resp_2cv9lTmw5osI…
response.in_progress id=resp_2cv9lTmw5osI…
response.output_item.added output_index=0 item=function_call
response.mcp_list_tools.in_progress output_index=0
response.mcp_list_tools.completed output_index=0
response.output_item.done output_index=0 item=mcp_list_tools
response.function_call_arguments.delta output_index=0
response.function_call_arguments.delta output_index=0
response.function_call_arguments.delta output_index=0
response.function_call_arguments.delta output_index=0
response.function_call_arguments.delta output_index=0
response.function_call_arguments.done output_index=0
response.output_item.done output_index=0 item=function_call
response.completed id=resp_2cv9lTmw5osI…
response.mcp_call.in_progress output_index=0
response.mcp_call_arguments.delta output_index=0
response.mcp_call_arguments.done output_index=0
response.mcp_call.completed output_index=0
response.output_item.done output_index=0 item=mcp_call
response.created id=resp_OiR6iE8IlqZ8…
response.in_progress id=resp_OiR6iE8IlqZ8…
response.output_item.added output_index=0 item=message
response.content_part.added output_index=0
response.output_text.delta output_index=0
response.output_text.delta output_index=0
response.output_text.delta output_index=0
response.output_text.delta output_index=0
response.output_text.done output_index=0
response.content_part.done output_index=0
response.output_item.done output_index=0 item=message
response.completed id=resp_OiR6iE8IlqZ8…
FINAL id=resp_OiR6iE8IlqZ8… output_text='tool-result:PING'
exit code 0
```

`mcp-calls.jsonl` after the three calls (one real tool execution per case):

```text
{"tool": "echo", "value": "PING"}
{"tool": "echo", "value": "PING"}
{"tool": "echo", "value": "PING"}
```

### After (e7557ada57)

Booted with `python litellm/proxy/proxy_cli.py --config config.yaml --port 34221 --num_workers 2` from a worktree at `e7557ada57`

#### 1. Raw SSE, curl

```console
$ curl -sN http://127.0.0.1:34221/v1/responses -H 'content-type: application/json' -H 'authorization: Bearer sk-qa-1234' -d '{"model":"gpt-5.6","stream":true,"input":"Call the echo tool with the value PING, then reply with exactly the tool result and nothing else.","tool_choice":"required","tools":[{"type":"mcp","server_url":"litellm_proxy/mcp/demo","server_label":"demo","require_approval":"never"}]}' | sed -n 's/^data: //p' | grep -v '^\[DONE\]' | jq -c '{type, id: .response.id, output_index, item: .item.type} | with_entries(select(.value != null))'
```

```text
{"type":"response.created","id":"resp_WriuAleX-ezQ…"}
{"type":"response.in_progress","id":"resp_WriuAleX-ezQ…"}
{"type":"response.output_item.added","output_index":0,"item":"function_call"}
{"type":"response.mcp_list_tools.in_progress","output_index":0}
{"type":"response.mcp_list_tools.completed","output_index":0}
{"type":"response.output_item.done","output_index":0,"item":"mcp_list_tools"}
{"type":"response.function_call_arguments.delta","output_index":0}
{"type":"response.function_call_arguments.delta","output_index":0}
{"type":"response.function_call_arguments.delta","output_index":0}
{"type":"response.function_call_arguments.delta","output_index":0}
{"type":"response.function_call_arguments.delta","output_index":0}
{"type":"response.function_call_arguments.done","output_index":0}
{"type":"response.output_item.done","output_index":0,"item":"function_call"}
{"type":"response.output_item.added","output_index":1,"item":"mcp_call"}
{"type":"response.mcp_call.in_progress","output_index":1}
{"type":"response.mcp_call_arguments.delta","output_index":1}
{"type":"response.mcp_call_arguments.done","output_index":1}
{"type":"response.mcp_call.completed","output_index":1}
{"type":"response.output_item.done","output_index":1,"item":"mcp_call"}
{"type":"response.output_item.added","output_index":2,"item":"message"}
{"type":"response.content_part.added","output_index":2}
{"type":"response.output_text.delta","output_index":2}
{"type":"response.output_text.delta","output_index":2}
{"type":"response.output_text.delta","output_index":2}
{"type":"response.output_text.delta","output_index":2}
{"type":"response.output_text.done","output_index":2}
{"type":"response.content_part.done","output_index":2}
{"type":"response.output_item.done","output_index":2,"item":"message"}
{"type":"response.completed","id":"resp_h9JUCvOu71Gu…"}
```

#### 2. OpenAI Python SDK 2.54.0, `responses.stream()`

```console
$ clientvenv254/bin/python client_stream.py http://127.0.0.1:34221/v1 sk-qa-1234
```

```text
openai sdk 2.54.0
response.created id=resp_3R88GRRuZ4iR…
response.in_progress id=resp_3R88GRRuZ4iR…
response.output_item.added output_index=0 item=function_call
response.mcp_list_tools.in_progress output_index=0
response.mcp_list_tools.completed output_index=0
response.output_item.done output_index=0 item=mcp_list_tools
response.function_call_arguments.delta output_index=0
response.function_call_arguments.delta output_index=0
response.function_call_arguments.delta output_index=0
response.function_call_arguments.delta output_index=0
response.function_call_arguments.delta output_index=0
response.function_call_arguments.done output_index=0
response.output_item.done output_index=0 item=function_call
response.output_item.added output_index=1 item=mcp_call
response.mcp_call.in_progress output_index=1
response.mcp_call_arguments.delta output_index=1
response.mcp_call_arguments.done output_index=1
response.mcp_call.completed output_index=1
response.output_item.done output_index=1 item=mcp_call
response.output_item.added output_index=2 item=message
response.content_part.added output_index=2
response.output_text.delta output_index=2
response.output_text.delta output_index=2
response.output_text.delta output_index=2
response.output_text.delta output_index=2
response.output_text.done output_index=2
response.content_part.done output_index=2
response.output_item.done output_index=2 item=message
response.completed id=resp_irgZ3_95CFyL…
FINAL id=resp_irgZ3_95CFyL… output_text='tool-result:PING'
exit code 0
```

#### 3. OpenAI Python SDK 3.16.2, `responses.stream()`

```console
$ clientvenv/bin/python client_stream.py http://127.0.0.1:34221/v1 sk-qa-1234
```

```text
openai sdk 3.16.2
response.created id=resp_iG5LSUDS3yzc…
response.in_progress id=resp_iG5LSUDS3yzc…
response.output_item.added output_index=0 item=function_call
response.mcp_list_tools.in_progress output_index=0
response.mcp_list_tools.completed output_index=0
response.output_item.done output_index=0 item=mcp_list_tools
response.function_call_arguments.delta output_index=0
response.function_call_arguments.delta output_index=0
response.function_call_arguments.delta output_index=0
response.function_call_arguments.delta output_index=0
response.function_call_arguments.delta output_index=0
response.function_call_arguments.done output_index=0
response.output_item.done output_index=0 item=function_call
response.output_item.added output_index=1 item=mcp_call
response.mcp_call.in_progress output_index=1
response.mcp_call_arguments.delta output_index=1
response.mcp_call_arguments.done output_index=1
response.mcp_call.completed output_index=1
response.output_item.done output_index=1 item=mcp_call
response.output_item.added output_index=2 item=message
response.content_part.added output_index=2
response.output_text.delta output_index=2
response.output_text.delta output_index=2
response.output_text.delta output_index=2
response.output_text.delta output_index=2
response.output_text.done output_index=2
response.content_part.done output_index=2
response.output_item.done output_index=2 item=message
response.completed id=resp_F5ZAgv17GMSH…
FINAL id=resp_F5ZAgv17GMSH… output_text='tool-result:PING'
exit code 0
```

`mcp-calls.jsonl` after the three calls (one real tool execution per case):

```text
{"tool": "echo", "value": "PING"}
{"tool": "echo", "value": "PING"}
{"tool": "echo", "value": "PING"}
```

Observations from the run (bullets, what a reviewer cannot see in the diff):

- Created id differs from completed id; pre-existing, PR leaves alone
- mcp_list_tools done at index 0 without added; pre-existing, unchanged
- output_index 0 done twice (function_call, mcp_list_tools); pre-existing, unchanged
- SDK 3.16.2 on before silently returned round two's id; fixed
- Both SDKs tolerate the created/completed id mismatch after the fix
- Final output lists the executed call as mcp_call, not function_call; fixed

## Type

🐛 Bug Fix
✅ Test

## Caveats (if any)

### Low

- `response.created` carries the first round's id, `response.completed` the final round's
  - The final id is what `previous_response_id` continuation needs (kept from the earlier continuation fix)
  - The OpenAI SDK replaces its snapshot on `response.completed`, so this does not affect it (both 2.54.0 and 3.16.2 observed above)
  - Tiered Low rather than Medium by the review run: continuing from the first round's id already answered 400 at the merge base (the rig's continue-from-created-id scenario, identical on both trees), so no client that worked before loses anything, and the only new observable is the id mismatch inside one lifecycle
  - Mapping both to one public id would need the stored-response layer and is left for a follow-up
- `mcp_list_tools` events still use `output_index: 0` and are emitted mid round 1, as before
  - They are queued before the first round streams, so re-indexing them needs a different change
- `usage` on the final `response.completed` is the final round's, unchanged from before
- `sequence_number` values above the provider's own are renumbered only when a round or gateway event would repeat or go backwards
- The round-1 `function_call` still streams as events (`output_item.added`, `function_call_arguments.delta` and `.done`, `output_item.done` at index 0) while the final `response.completed` list shows the gateway's `mcp_call` in its place
  - Holding those events back until the gateway has run the call would buffer a whole model round before the client sees anything, which costs more than the wart, so it stays
  - The OpenAI SDK snapshot and the Agents SDK both take the final list, so neither runs the tool

### Live PR risk report (e7557ada57)

Verdict: passes at e7557ada57. The one Breaking finding below surfaced at 239bff3315 and is fixed by e7557ada57; every other observable change is listed with its decision. Rig: a merge-base tree (168a0055a2), a head tree (e7557ada57) and a merged tree (origin/main 17b56cc4ca plus the head, 20750c36cd), each booted as a 2-worker proxy on its own random port with no database, a forwarding recorder in front of api.openai.com so the outbound requests could be diffed, a local echo MCP server registered under `mcp_servers`, a custom logger and a custom guardrail (`streaming_iterator` and post-call hooks) loaded through the documented extension points. Ten scenarios ran in the same order on every tree: stream with one auto-executed call, stream with `require_approval: always`, non-stream auto-execute, stream with two calls, continuation via `previous_response_id` from the completed id and from the created id, stream with no tool call, OpenAI SDK 3.16.2 `responses.stream()`, Agents SDK 0.22.3 `Runner.run_streamed` and `Runner.run`

Breaking

- OpenAI Agents SDK 0.22.3, `Runner.run_streamed` with `HostedMCPTool(server_url="litellm_proxy/mcp/demo", require_approval="never")`. At 168a0055a2 the run exited 0 only because the SDK's last-wins accumulation ended on round 2. At 239bff3315, and on its merge with main, the final `response.completed` listed the model's `function_call`, so the SDK raised `ModelBehaviorError: Tool demo-echo not found in agent echo-agent` and exited 1. Fixed in e7557ada57: exit 0, `completed events seen: [['mcp_call', 'message']]`, `new_items: ['tool_call_item', 'message_output_item']`, `FINAL: 'tool-result:PING'`, identical on the merged tree. Non-stream `Runner.run` was unaffected on every tree (its final text is the `tool_execution_results` JSON)

Backward incompatible (each observed on the wire, base vs head, and identical on the merged tree)

- One lifecycle whose `response.created` id is round 1's and whose `response.completed` id is the final round's, where the base emitted two lifecycles with matching ids each (the first Low above). Both OpenAI SDKs tolerate it and continuation from the completed id works (the created id answers 400 on base and head alike). Decision: ships as is with the follow-up named above, approved by the approving review on this PR
- The final `response.completed` output list now reads `[mcp_call, message]` for one call and `[mcp_call, mcp_call, reasoning, message]` for two, each `mcp_call` carrying `status: completed`, where 239bff3315 listed the interim rounds' `function_call` items. Introduced by e7557ada57 to fix the Breaking finding; the OpenAI SDK snapshots and the Agents SDK read this list
- Follow-up rounds no longer emit `response.created`, `response.in_progress` or an interim `response.completed`, and later `output_index` and `sequence_number` values are shifted past the items already emitted. This is the fix itself; the base's shape crashed OpenAI SDK 2.54.0 (proof above)
- The round-1 `function_call` events still stream at index 0 while the final list shows the `mcp_call` (the last Low above). Decision: left as is, approved by the approving review on this PR

Regression risk

- The Admin UI playground reads `response.output_item.done` `mcp_call` events and text deltas (`MCPEventsDisplay.tsx`, `responses_api.tsx`) and never the final `response.output` list, so the final-list change cannot reach it; traced, not clicked, because machine headroom stayed tight during the run
- Background responses (`background: true`) poll a stored response and need Redis; the iterator is not on that path; traced only

Dependency graph

- `MCPEnhancedStreamingIterator` (`litellm/responses/mcp/mcp_streaming_iterator.py`): the only constructor is `LiteLLM_Proxy_MCP_Handler._create_mcp_streaming_response`, reached from `litellm/responses/main.py` for both `responses()` and `aresponses()`; verified live on all three trees
- `create_mcp_call_events` gained `output_index`: callers are the iterator and the handler only; unit tests plus verified live
- `_function_call_id`, the helper added in e7557ada57, got its own walk: no reader outside the iterator
- `mcp_call` item readers: the custom guardrail `streaming_iterator` hook (driven live, per-scenario event counts and post-call rows identical between 239bff3315 and e7557ada57 apart from the two intended item changes), the dashboard event readers (traced)
- Per-round logging and spend: every inner round is its own `litellm.aresponses` call with its own logger rows (round 1 `output_types: ["function_call"]`, round 2 `["message"]`, unchanged base vs head), so the composed final list reaches the client and the streaming hooks only; verified live
- Outbound wire: the recorded requests to api.openai.com match base vs head in key set, values and count for every scenario; the container-ownership warning (`no completed_response`) appears 6 times on both trees' full logs, pre-existing
- OpenAI Python SDK 2.54.0 and 3.16.2 `responses.stream()`, Agents SDK 0.22.3 `run_streamed` and `run`: verified live (proof above and the Breaking entry)
- `tests/test_litellm/responses/mcp/test_mcp_streaming_iterator.py`: 10 tests at the tip; the shared MagicMock `proxy_logging_obj` fixture cannot assert the executed call's `output` text, so that field is observed live only

Not verified

- Admin UI playground, live click (traced only, see Regression risk)
- `background: true` polling (needs Redis, traced only)
- Non-stream MCP logging drift on main: on the merged tree the custom logger's non-stream auto-execute row reads `output_types: ["function_call"]` where the merge base reads `["message", "mcp_tools_fetched", "tool_execution_results"]`, with an identical client body on both. The non-stream path is not touched by this PR and the main commit responsible was not bisected (candidate: #41058)
- A vendor MCP server other than the local echo server

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the public SSE contract for auto-execute MCP streaming (indexes, lifecycle events, merged `response.completed` output); high client impact but scoped to that path with regression tests.
> 
> **Overview**
> Fixes streaming `/v1/responses` when the LiteLLM proxy **auto-executes** MCP tools: multiple upstream LLM rounds were spliced into one SSE body with a **second** `response.created`/`response.completed`, **`output_index` resetting at 0**, and inconsistent **`mcp_call`** item ids—breaking accumulators such as the OpenAI SDK `responses.stream()`.
> 
> **`MCPEnhancedStreamingIterator`** now folds auto-execute rounds into **one public lifecycle**: suppress follow-up `response.created`/`response.in_progress` and interim `response.completed` when tools will run; **shift** `output_index` via `_output_index_offset`; **merge** all rounds’ output (including gateway **`mcp_call`** items) on the final `response.completed` (final round’s response id preserved); keep **`sequence_number`** strictly increasing; emit **`output_item.added`** per executed tool with a stable item id and dedicated index. **`create_mcp_call_events`** accepts `output_index` instead of hardcoding 0.
> 
> Non-auto-execute streams (`require_approval: always`) pass through unchanged. Tests assert single lifecycle, index ordering, merged output, and unchanged passthrough.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 146e5c492b1bee31a57c77a8fafff74122a13df9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

- [x] e7557ada57ad649fc0b0063aa2d89e1f7186f979 passes /live-pr-risk
