### PR TITLE
fix(mcp): probe openapi-backed servers by their spec in health checks

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -6665,25 +6665,33 @@ class MCPServerManager:
 
         if not should_skip_health_check:
             try:
-                resolved_static_headers: Final = await self._resolve_static_headers_with_env_vars(
-                    server=server,
-                    user_api_key_auth=None,
-                    raise_on_missing=False,
-                )
-                extra_headers: Final = dict(resolved_static_headers) if resolved_static_headers else {}
-                client: Final = await self._create_mcp_client(
-                    server=server,
-                    mcp_auth_header=None,
-                    extra_headers=extra_headers,
-                    stdio_env=None,
-                )
+                if server.spec_path:
+                    # url is a REST base, not an MCP endpoint, so the spec is the only thing to probe
+                    from litellm.proxy._experimental.mcp_server.openapi_to_mcp_generator import (
+                        load_openapi_spec_async,
+                    )
 
-                async def _noop(session):
-                    return "ok"
+                    await asyncio.wait_for(load_openapi_spec_async(server.spec_path), timeout=MCP_HEALTH_CHECK_TIMEOUT)
+                else:
+                    resolved_static_headers: Final = await self._resolve_static_headers_with_env_vars(
+                        server=server,
+                        user_api_key_auth=None,
+                        raise_on_missing=False,
+                    )
+                    extra_headers: Final = dict(resolved_static_headers) if resolved_static_headers else {}
+                    client: Final = await self._create_mcp_client(
+                        server=server,
+                        mcp_auth_header=None,
+                        extra_headers=extra_headers,
+                        stdio_env=None,
+                    )
 
-                # Add timeout wrapper to prevent hanging
-                await asyncio.wait_for(client.run_with_session(_noop), timeout=MCP_HEALTH_CHECK_TIMEOUT)
-                self._remember_upstream_initialize_instructions(server, client)
+                    async def _noop(session):
+                        return "ok"
+
+                    # Add timeout wrapper to prevent hanging
+                    await asyncio.wait_for(client.run_with_session(_noop), timeout=MCP_HEALTH_CHECK_TIMEOUT)
+                    self._remember_upstream_initialize_instructions(server, client)
                 status = "healthy"
             except asyncio.TimeoutError:
                 health_check_error = f"Health check timed out after {MCP_HEALTH_CHECK_TIMEOUT} seconds"

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -4494,86 +4494,73 @@ class TestMCPServerManager:
         assert "OAuth discovery unavailable" in (result.health_check_error or "")
 
     @pytest.mark.asyncio
-    async def test_health_check_server_openapi_spec_is_probed_instead_of_mcp_session(self):
+    async def test_health_check_server_openapi_spec_is_probed_instead_of_mcp_session(self, tmp_path):
         """An OpenAPI server is healthy when its spec loads, and is never asked to speak MCP.
 
         Regression for #40079: these servers store the REST base url in ``url`` and only look like
         http transport, so opening an MCP session against them always failed with "Session
-        terminated" even though every tool had loaded from the spec.
+        terminated" even though every tool had loaded from the spec. ``url`` is a closed port, so
+        an MCP handshake would report unhealthy.
+        """
+        spec = tmp_path / "openapi.json"
+        spec.write_text(json.dumps({"openapi": "3.0.0", "paths": {}}))
+        manager = MCPServerManager()
+        server = MCPServer(
+            server_id="openapi-server",
+            name="openapi-server",
+            transport=MCPTransport.http,
+            auth_type=MCPAuth.none,
+            url="http://127.0.0.1:1",
+            spec_path=str(spec),
+        )
+        manager.config_mcp_servers[server.server_id] = server
+
+        result = await manager.health_check_server("openapi-server")
+
+        assert result.status == "healthy"
+        assert result.health_check_error is None
+
+    @pytest.mark.asyncio
+    async def test_health_check_server_openapi_spec_failure_is_unhealthy(self, tmp_path):
+        """A spec that stopped loading is unhealthy, and the upstream error is what gets reported."""
+        missing = tmp_path / "openapi.json"
+        manager = MCPServerManager()
+        server = MCPServer(
+            server_id="openapi-server",
+            name="openapi-server",
+            transport=MCPTransport.http,
+            auth_type=MCPAuth.none,
+            url="http://127.0.0.1:1",
+            spec_path=str(missing),
+        )
+        manager.config_mcp_servers[server.server_id] = server
+
+        result = await manager.health_check_server("openapi-server")
+
+        assert result.status == "unhealthy"
+        assert result.health_check_error == f"OpenAPI spec not found at {missing}"
+
+    @pytest.mark.asyncio
+    async def test_health_check_server_openapi_spec_keeps_per_user_auth_skip(self, tmp_path):
+        """Per-user auth still wins: fetching the spec userless could 401 and report a false failure.
+
+        The spec file is absent, so probing it would have reported unhealthy rather than unknown.
         """
         manager = MCPServerManager()
         server = MCPServer(
             server_id="openapi-server",
             name="openapi-server",
             transport=MCPTransport.http,
-            auth_type=MCPAuth.none,
-            url="http://rest.example.com",
-            spec_path="http://rest.example.com/openapi.json",
-        )
-        manager.get_mcp_server_by_id = MagicMock(return_value=server)
-        manager._create_mcp_client = AsyncMock()
-
-        with patch(
-            "litellm.proxy._experimental.mcp_server.openapi_to_mcp_generator.load_openapi_spec_async",
-            new=AsyncMock(return_value={"openapi": "3.0.0", "paths": {}}),
-        ) as mock_load:
-            result = await manager.health_check_server("openapi-server")
-
-        assert result.status == "healthy"
-        assert result.health_check_error is None
-        mock_load.assert_awaited_once_with("http://rest.example.com/openapi.json")
-        manager._create_mcp_client.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_health_check_server_openapi_spec_failure_is_unhealthy(self):
-        """A spec that stopped loading is unhealthy, and the upstream error is what gets reported."""
-        manager = MCPServerManager()
-        server = MCPServer(
-            server_id="openapi-server",
-            name="openapi-server",
-            transport=MCPTransport.http,
-            auth_type=MCPAuth.none,
-            url="http://rest.example.com",
-            spec_path="http://rest.example.com/openapi.json",
-        )
-        manager.get_mcp_server_by_id = MagicMock(return_value=server)
-        manager._create_mcp_client = AsyncMock()
-
-        with patch(
-            "litellm.proxy._experimental.mcp_server.openapi_to_mcp_generator.load_openapi_spec_async",
-            new=AsyncMock(side_effect=httpx.ConnectError("Cannot connect to host rest.example.com")),
-        ):
-            result = await manager.health_check_server("openapi-server")
-
-        assert result.status == "unhealthy"
-        assert result.health_check_error == "Cannot connect to host rest.example.com"
-        manager._create_mcp_client.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_health_check_server_openapi_spec_keeps_per_user_auth_skip(self):
-        """Per-user auth still wins: fetching the spec userless could 401 and report a false failure."""
-        manager = MCPServerManager()
-        server = MCPServer(
-            server_id="openapi-server",
-            name="openapi-server",
-            transport=MCPTransport.http,
             auth_type=MCPAuth.bearer_token,
-            url="http://rest.example.com",
-            spec_path="http://rest.example.com/openapi.json",
+            url="http://127.0.0.1:1",
+            spec_path=str(tmp_path / "openapi.json"),
         )
-        manager.get_mcp_server_by_id = MagicMock(return_value=server)
-        manager._create_mcp_client = AsyncMock()
+        manager.config_mcp_servers[server.server_id] = server
 
-        with patch(
-            "litellm.proxy._experimental.mcp_server.openapi_to_mcp_generator.load_openapi_spec_async",
-            new=AsyncMock(return_value={"openapi": "3.0.0", "paths": {}}),
-        ) as mock_load:
-            result = await manager.health_check_server("openapi-server")
+        result = await manager.health_check_server("openapi-server")
 
         assert result.status == "unknown"
         assert result.health_check_error is None
-        mock_load.assert_not_called()
-        manager._create_mcp_client.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_health_check_server_not_found(self):

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -4494,6 +4494,88 @@ class TestMCPServerManager:
         assert "OAuth discovery unavailable" in (result.health_check_error or "")
 
     @pytest.mark.asyncio
+    async def test_health_check_server_openapi_spec_is_probed_instead_of_mcp_session(self):
+        """An OpenAPI server is healthy when its spec loads, and is never asked to speak MCP.
+
+        Regression for #40079: these servers store the REST base url in ``url`` and only look like
+        http transport, so opening an MCP session against them always failed with "Session
+        terminated" even though every tool had loaded from the spec.
+        """
+        manager = MCPServerManager()
+        server = MCPServer(
+            server_id="openapi-server",
+            name="openapi-server",
+            transport=MCPTransport.http,
+            auth_type=MCPAuth.none,
+            url="http://rest.example.com",
+            spec_path="http://rest.example.com/openapi.json",
+        )
+        manager.get_mcp_server_by_id = MagicMock(return_value=server)
+        manager._create_mcp_client = AsyncMock()
+
+        with patch(
+            "litellm.proxy._experimental.mcp_server.openapi_to_mcp_generator.load_openapi_spec_async",
+            new=AsyncMock(return_value={"openapi": "3.0.0", "paths": {}}),
+        ) as mock_load:
+            result = await manager.health_check_server("openapi-server")
+
+        assert result.status == "healthy"
+        assert result.health_check_error is None
+        mock_load.assert_awaited_once_with("http://rest.example.com/openapi.json")
+        manager._create_mcp_client.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_health_check_server_openapi_spec_failure_is_unhealthy(self):
+        """A spec that stopped loading is unhealthy, and the upstream error is what gets reported."""
+        manager = MCPServerManager()
+        server = MCPServer(
+            server_id="openapi-server",
+            name="openapi-server",
+            transport=MCPTransport.http,
+            auth_type=MCPAuth.none,
+            url="http://rest.example.com",
+            spec_path="http://rest.example.com/openapi.json",
+        )
+        manager.get_mcp_server_by_id = MagicMock(return_value=server)
+        manager._create_mcp_client = AsyncMock()
+
+        with patch(
+            "litellm.proxy._experimental.mcp_server.openapi_to_mcp_generator.load_openapi_spec_async",
+            new=AsyncMock(side_effect=httpx.ConnectError("Cannot connect to host rest.example.com")),
+        ):
+            result = await manager.health_check_server("openapi-server")
+
+        assert result.status == "unhealthy"
+        assert result.health_check_error == "Cannot connect to host rest.example.com"
+        manager._create_mcp_client.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_health_check_server_openapi_spec_keeps_per_user_auth_skip(self):
+        """Per-user auth still wins: fetching the spec userless could 401 and report a false failure."""
+        manager = MCPServerManager()
+        server = MCPServer(
+            server_id="openapi-server",
+            name="openapi-server",
+            transport=MCPTransport.http,
+            auth_type=MCPAuth.bearer_token,
+            url="http://rest.example.com",
+            spec_path="http://rest.example.com/openapi.json",
+        )
+        manager.get_mcp_server_by_id = MagicMock(return_value=server)
+        manager._create_mcp_client = AsyncMock()
+
+        with patch(
+            "litellm.proxy._experimental.mcp_server.openapi_to_mcp_generator.load_openapi_spec_async",
+            new=AsyncMock(return_value={"openapi": "3.0.0", "paths": {}}),
+        ) as mock_load:
+            result = await manager.health_check_server("openapi-server")
+
+        assert result.status == "unknown"
+        assert result.health_check_error is None
+        mock_load.assert_not_called()
+        manager._create_mcp_client.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_health_check_server_not_found(self):
         """Test health check for a server that doesn't exist"""
         manager = MCPServerManager()


### PR DESCRIPTION
## TLDR

Problem this solves:

- OpenAPI backed MCP servers always report unhealthy
- Their tools load fine, so the status contradicts reality
- Admins cannot tell a working server from a broken one

How it solves it:

- Health check now loads the spec for these servers
- A spec that stops loading still reports unhealthy
- Servers needing per user auth keep their existing skip

## User Flow

Before: an admin who adds an MCP server from an OpenAPI spec gets a server that works but is permanently labelled unhealthy

1. They open http://localhost:4000/ui/?page=mcp-servers and click Add MCP Server
2. They choose OpenAPI Spec, fill in the REST base url and the spec url, leave auth as none, and save
3. The server saves and the four tools from the spec show up under it
4. The same page shows the server's status as unhealthy, with the error "Session terminated"
5. Calling any of those tools still succeeds, so there is no way to tell this server apart from one that is genuinely down

After: the same server reports healthy, and still turns unhealthy when its spec really stops loading

1. They open http://localhost:4000/ui/?page=mcp-servers and click Add MCP Server
2. They choose OpenAPI Spec, fill in the REST base url and the spec url, leave auth as none, and save
3. The server saves and the four tools from the spec show up under it
4. The same page now shows the server's status as healthy
5. If the spec url later stops responding, the status goes back to unhealthy and reports the real connection error

## Relevant issues

Fixes #40079

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup. The upstream is the OpenAPI demo service the issue author linked in the thread, forcemeter/litellm-goframe-openapi, serving its spec at /api.json on port 8200. It answers 404 to anything that is not one of its four REST routes, which is what makes it a plain REST service rather than an MCP endpoint

```bash
git clone https://github.com/forcemeter/litellm-goframe-openapi && cd litellm-goframe-openapi
go run main.go   # serves :8200
```

```bash
curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:8200/api.json   # 200
curl -s -o /dev/null -w '%{http_code}\n' -X POST http://127.0.0.1:8200/   # 404
```

config.yaml used for every run below:

```yaml
model_list: []

mcp_servers:
  goframe_openapi_demo:
    url: http://127.0.0.1:8200
    spec_path: http://127.0.0.1:8200/api.json
    transport: http
    auth_type: none
    description: OpenAPI-backed REST service, no MCP endpoint

general_settings:
  master_key: sk-1234
  user_url_allowed_hosts: ["127.0.0.1", "127.0.0.1:8200"]
```

### Before (168a0055a2)

#### OpenAPI server whose spec loads

1. Start the proxy against that config

```bash
python litellm/proxy/proxy_cli.py --config config.yaml --port 4000
```

2. Confirm the tools came from the spec

```bash
curl -s http://127.0.0.1:4000/mcp-rest/tools/list -H 'Authorization: Bearer sk-1234' \
  | jq '[.tools[].name]'
```

```json
[
  "checkpassword",
  "generatepassword",
  "checkusername",
  "generateusername"
]
```

3. Health check the same server

```bash
curl -s http://127.0.0.1:4000/v1/mcp/server/health -H 'Authorization: Bearer sk-1234' | jq
```

```json
[
  {
    "server_id": "1edfd85b2372218770c2b9601505226e",
    "status": "unhealthy"
  }
]
```

4. The proxy log says what it actually tried to do

```
LiteLLM:WARNING: client.py:514 - MCP client run_with_session failed for http://127.0.0.1:8200
```

#### OpenAPI server whose spec stops loading

1. Leave that proxy running and stop the upstream

```bash
pkill -f 'go run main.go'
```

2. Health check again

```bash
curl -s http://127.0.0.1:4000/v1/mcp/server/health -H 'Authorization: Bearer sk-1234' | jq
```

```json
[
  {
    "server_id": "1edfd85b2372218770c2b9601505226e",
    "status": "unhealthy"
  }
]
```

### After (229f1fb6d9)

#### OpenAPI server whose spec loads

1. Start the proxy against the same config

```bash
python litellm/proxy/proxy_cli.py --config config.yaml --port 4000
```

2. Confirm the tools came from the spec

```bash
curl -s http://127.0.0.1:4000/mcp-rest/tools/list -H 'Authorization: Bearer sk-1234' \
  | jq '[.tools[].name]'
```

```json
[
  "checkpassword",
  "generatepassword",
  "checkusername",
  "generateusername"
]
```

3. Health check the same server

```bash
curl -s http://127.0.0.1:4000/v1/mcp/server/health -H 'Authorization: Bearer sk-1234' | jq
```

```json
[
  {
    "server_id": "1edfd85b2372218770c2b9601505226e",
    "status": "healthy"
  }
]
```

#### OpenAPI server whose spec stops loading

1. Leave that proxy running and stop the upstream

```bash
pkill -f 'go run main.go'
```

2. Health check again

```bash
curl -s http://127.0.0.1:4000/v1/mcp/server/health -H 'Authorization: Bearer sk-1234' | jq
```

```json
[
  {
    "server_id": "1edfd85b2372218770c2b9601505226e",
    "status": "unhealthy"
  }
]
```

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Health status endpoint returns status only, no error text
- A spec unreachable at boot still stops proxy startup, unchanged here

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrows health-check behavior for OpenAPI-backed MCP servers only; tool execution and auth paths are untouched.
> 
> **Overview**
> Fixes **false unhealthy** status for MCP servers configured from an OpenAPI spec, where `url` is the REST base and tools work but an MCP session handshake on that URL failed (e.g. "Session terminated").
> 
> **`health_check_server`** now branches on **`spec_path`**: OpenAPI-backed servers are validated by **`load_openapi_spec_async`** under the existing **`MCP_HEALTH_CHECK_TIMEOUT`**, instead of creating an MCP client and running a noop session. Classic MCP servers keep the previous session-based probe and still record upstream initialize instructions on success.
> 
> Per-user auth and other **skip health check** rules are unchanged—those servers still report **`unknown`** without probing the spec.
> 
> New tests cover spec load → healthy, missing spec → unhealthy with the loader error, and bearer/per-user auth → skipped check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 229f1fb6d981ed1854bce9e0fb044698b15af9a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->