### PR TITLE
fix(messages): translate GenericResponseOutputItem output instead of dropping it

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
@@ -632,7 +632,25 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
             cast(Iterable[object], response.output)  # cast-ok: output items re-validated per item
         )
 
-        for item in response.output:
+        # An upstream whose dialect fails ResponsesAPIResponse.model_validate
+        # reaches this function through the model_construct fallback, whose
+        # output items are GenericResponseOutputItem -- litellm's own wrapper,
+        # not an openai-SDK type and not a dict. Without normalisation none of
+        # the branches below matches and every item is silently skipped.
+        _sdk_item_types: Final = (ResponseReasoningItem, ResponseOutputMessage, ResponseFunctionToolCall)
+
+        def _normalised(item: object) -> object:
+            if isinstance(item, (dict, *_sdk_item_types)):
+                return item
+            _dump = getattr(item, "model_dump", None)
+            if callable(_dump):
+                _dumped = _dump()
+                return _dumped if isinstance(_dumped, dict) else item
+            return item
+
+        output_items: Final = tuple(_normalised(_raw_item) for _raw_item in response.output)
+
+        for item in output_items:
             if isinstance(item, ResponseReasoningItem):
                 content.extend(self._thinking_blocks_from_reasoning_item(item.summary))
 

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py
@@ -1508,6 +1508,124 @@ class TestTranslateResponse:
         assert result["stop_reason"] == "tool_use"
 
 
+class TestTranslateResponseGenericOutputItems:
+    """GenericResponseOutputItem output must not be silently dropped.
+
+    litellm itself manufactures GenericResponseOutputItem objects for
+    ResponsesAPIResponse.output (the chat-completions bridge in
+    responses/litellm_completion_transformation/transformation.py and the
+    proxy MCP handler), and on the model_construct fallback path of the
+    openai responses transformation (observed on v1.100.0 with a gateway
+    whose reasoning items carry content[].output_text instead of summary,
+    which fails model_validate). GenericResponseOutputItem is not an
+    openai-SDK type and not a dict, so the isinstance dispatch in
+    translate_response matched none of its branches and dropped every
+    item: /v1/messages answered with an empty content array while usage
+    flowed through.
+    """
+
+    @staticmethod
+    def _make_generic_item(item_type: str, **overrides: Any) -> Any:
+        """Build a GenericResponseOutputItem the way the completion bridge does."""
+        from litellm.types.responses.main import GenericResponseOutputItem, OutputText
+
+        base: Dict[str, Any] = {
+            "type": item_type,
+            "id": "item_1",
+            "status": "completed",
+            "role": "assistant",
+            "content": [OutputText(type="output_text", text="hi", annotations=[])],
+        }
+        base.update(overrides)
+        return GenericResponseOutputItem(**base)
+
+    def test_generic_message_item_becomes_text_block(self):
+        response = _make_mock_response(
+            output=[
+                self._make_generic_item(
+                    "reasoning",
+                    id="rs_1",
+                    content=[
+                        {
+                            "type": "output_text",
+                            "text": "thinking about the command",
+                            "annotations": [],
+                        }
+                    ],
+                ),
+                self._make_generic_item(
+                    "message",
+                    id="msg_1",
+                    content=[
+                        {
+                            "type": "output_text",
+                            "text": "<verdict>safe</verdict>",
+                            "annotations": [],
+                        }
+                    ],
+                ),
+            ]
+        )
+        result: Any = _ADAPTER.translate_response(response)
+
+        text_blocks = [b for b in result["content"] if b.get("type") == "text"]
+        assert len(text_blocks) == 1
+        assert text_blocks[0]["text"] == "<verdict>safe</verdict>"
+        assert result["stop_reason"] == "end_turn"
+
+    def test_generic_function_call_item_becomes_tool_use(self):
+        fc = self._make_generic_item(
+            "function_call",
+            call_id="call_1",
+            name="get_weather",
+            arguments='{"city": "NYC"}',
+            content=[],
+        )
+        response = _make_mock_response(output=[fc])
+        result: Any = _ADAPTER.translate_response(response)
+
+        assert len(result["content"]) == 1
+        block = result["content"][0]
+        assert block["type"] == "tool_use"
+        assert block["id"] == "call_1"
+        assert block["name"] == "get_weather"
+        assert block["input"] == {"city": "NYC"}
+        assert result["stop_reason"] == "tool_use"
+
+    def test_model_construct_output_survives(self):
+        """End-to-end fallback shape: whatever pydantic's model_construct
+        yields for a raw provider payload (dict or GenericResponseOutputItem,
+        depending on the union's first arm), the content must arrive."""
+        from litellm.types.llms.openai import ResponsesAPIResponse
+
+        response = ResponsesAPIResponse.model_construct(
+            id="resp_generic_1",
+            created_at=1788788375,
+            model="glm-5.3-flash",
+            status="completed",
+            output=[
+                {
+                    "type": "message",
+                    "id": "msg_1",
+                    "status": "completed",
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "<verdict>safe</verdict>",
+                            "annotations": [],
+                        }
+                    ],
+                }
+            ],
+        )
+        result: Any = _ADAPTER.translate_response(response)
+
+        text_blocks = [b for b in result["content"] if b.get("type") == "text"]
+        assert len(text_blocks) == 1
+        assert text_blocks[0]["text"] == "<verdict>safe</verdict>"
+
+
 class TestToolResultImages:
     """Images inside tool_result blocks must survive translation: the
     function_call_output carries a text placeholder and the image is sent as an


### PR DESCRIPTION
## The bug

`/v1/messages` (the Anthropic-shaped route) is served by converting to a Responses request and back, and the response side dispatches every output item against exactly four shapes:

```python
for item in response.output:
    if isinstance(item, ResponseReasoningItem): ...
    elif isinstance(item, ResponseOutputMessage): ...
    elif isinstance(item, ResponseFunctionToolCall): ...
    elif isinstance(item, dict): ...
```

`GenericResponseOutputItem` — litellm's own wrapper — is none of them, so any such item is silently skipped and the answer comes back `content: []` with `stop_reason: "end_turn"` while usage flows through.

These instances occur in practice:

- the chat-completions → Responses bridge manufactures them (`_extract_reasoning_output_items` / `_extract_message_output_items` in `responses/litellm_completion_transformation/transformation.py`), so a `/v1/messages` request against a chat-mode deployment runs them through this dispatch
- the proxy MCP handler puts them in `output` (`responses/mcp/litellm_proxy_mcp_handler.py`)
- on v1.100.0, the `model_construct` fallback in `transform_response_api_response` (openai responses transformation) yields them for any provider dialect that fails `model_validate` — measured with a gateway that carries its reasoning text in `reasoning.content[].output_text` instead of `summary`

Production evidence for the last one (v1.100.0, a proxy in front of such a gateway): every non-streaming `/v1/messages` call answered

```json
{"content": [], "stop_reason": "end_turn", "usage": {"input_tokens": 245, "output_tokens": 1054}}
```

while the raw provider reply contained the full text (verified by calling the gateway directly with the same request). Streaming was unaffected — the SSE wrapper parses deltas itself — which is why it looked like a provider problem at first.

On current `main` the `output` annotation changed, so the `model_construct` fallback now yields plain dicts for that path (the dict branch handles those). The manufactured instances above still hit the dispatch, which is why the tests construct `GenericResponseOutputItem` directly instead of relying on the fallback's shape.

## The change

Normalise items that are neither dicts nor one of the three openai-SDK types via `model_dump()` before the dispatch, so they land in the existing dict branch. Deliberately narrow:

- SDK-typed items and plain dicts keep their existing branches, unchanged
- only objects that expose `model_dump()` and produce a dict are converted; anything exotic is passed through as before

A thinking block is still only built from `summary`, so a reasoning item whose dialect carries its text in `content` contributes no thinking block — the message text, which every consumer parses, is restored either way.

## Test

`TestTranslateResponseGenericOutputItems` in the existing transformation test module builds `GenericResponseOutputItem` instances the way the completion bridge does and asserts:

- message + reasoning items → a text block, `stop_reason: "end_turn"`
- a function_call item → a `tool_use` block with parsed arguments, `stop_reason: "tool_use"`

Verified to fail before the change (`2 failed` — empty content) and pass after; the full module passes with the change (`152 passed`). A third test drives the `model_construct` fallback end-to-end and asserts the content survives whichever shape pydantic yields for that union.
