### PR TITLE
fix(azure): apply keyless auth headers to image generation requests

### DIFF
--- a/litellm/llms/azure/azure.py
+++ b/litellm/llms/azure/azure.py
@@ -47,6 +47,7 @@ from .common_utils import (
     BaseAzureLLM,
     get_azure_ad_token_from_oidc,
     process_azure_headers,
+    resolve_azure_image_auth_headers,
     select_azure_base_url_or_endpoint,
 )
 from .image_generation import (
@@ -1134,12 +1135,48 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
 
         return base_url_with_deployment
 
+    @staticmethod
+    def _extract_azure_ad_token_provider(azure_client_params: dict) -> Callable[[], str] | None:
+        provider = azure_client_params.get("azure_ad_token_provider")
+        return provider if callable(provider) else None
+
+    @staticmethod
+    def _extract_azure_ad_token(azure_client_params: dict) -> str | None:
+        token = azure_client_params.get("azure_ad_token")
+        return token if isinstance(token, str) else None
+
+    @staticmethod
+    def _resolve_image_auth_headers(headers: dict, api_key: str | None, azure_client_params: dict) -> dict[str, str]:
+        return resolve_azure_image_auth_headers(
+            headers=headers,
+            api_key=api_key,
+            azure_ad_token_provider=AzureChatCompletion._extract_azure_ad_token_provider(azure_client_params),
+            azure_ad_token=AzureChatCompletion._extract_azure_ad_token(azure_client_params),
+        )
+
+    @staticmethod
+    async def _aresolve_image_auth_headers(
+        headers: dict, api_key: str | None, azure_client_params: dict
+    ) -> dict[str, str]:
+        azure_ad_token_provider: Final = AzureChatCompletion._extract_azure_ad_token_provider(azure_client_params)
+        provider_token: Final[str | None] = (
+            await asyncio.to_thread(azure_ad_token_provider)
+            if not api_key and azure_ad_token_provider is not None
+            else None
+        )
+        return resolve_azure_image_auth_headers(
+            headers=headers,
+            api_key=api_key,
+            azure_ad_token_provider=None,
+            azure_ad_token=provider_token or AzureChatCompletion._extract_azure_ad_token(azure_client_params),
+        )
+
     async def aimage_generation(
         self,
         data: dict,
         model_response: ImageResponse | None,
         azure_client_params: dict,
-        api_key: str,
+        api_key: str | None,
         input: list,
         logging_obj: LiteLLMLoggingObj,
         headers: dict,
@@ -1149,6 +1186,9 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
     ) -> ImageResponse:
         response: dict | None = None
         try:
+            resolved_headers: Final[dict[str, str]] = await self._aresolve_image_auth_headers(
+                headers=headers, api_key=api_key, azure_client_params=azure_client_params
+            )
             # response = await azure_client.images.generate(**data, timeout=timeout)
             api_base: str = azure_client_params.get("api_base", "")  # "https://example-endpoint.openai.azure.com"
             if api_base.endswith("/"):
@@ -1167,7 +1207,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                 additional_args={
                     "complete_input_dict": data,
                     "api_base": img_gen_api_base,
-                    "headers": headers,
+                    "headers": logging_obj._get_masked_headers(resolved_headers),
                 },
             )
             httpx_response: Final[httpx.Response] = await self.make_async_azure_httpx_request(
@@ -1175,9 +1215,9 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                 timeout=timeout,
                 api_base=img_gen_api_base,
                 api_version=api_version,
-                api_key=api_key,
+                api_key=api_key or "",
                 data=data,
-                headers=headers,
+                headers=resolved_headers,
                 deployment_name=model,
             )
 
@@ -1261,15 +1301,15 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
             if not isinstance(max_retries, int):
                 raise AzureOpenAIError(status_code=422, message="max retries must be an int")
 
-            if api_key is None and azure_ad_token_provider is not None:
-                azure_ad_token = azure_ad_token_provider()
-                if azure_ad_token:
-                    headers.pop("api-key", None)
-                    headers["Authorization"] = f"Bearer {azure_ad_token}"
+            auth_litellm_params: Final[dict[str, object]] = {
+                **(litellm_params or {}),
+                **({"azure_ad_token_provider": azure_ad_token_provider} if azure_ad_token_provider is not None else {}),
+                **({"azure_ad_token": azure_ad_token} if azure_ad_token else {}),
+            }
 
             # init AzureOpenAI Client
             azure_client_params: Final[dict[str, object]] = self.initialize_azure_sdk_client(
-                litellm_params=litellm_params or {},
+                litellm_params=auth_litellm_params,
                 api_key=api_key,
                 model_name=model or "",
                 api_version=api_version,
@@ -1290,6 +1330,10 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                     model=model,
                 )
 
+            resolved_headers: Final[dict[str, str]] = self._resolve_image_auth_headers(
+                headers=headers, api_key=api_key, azure_client_params=azure_client_params
+            )
+
             img_gen_api_base: Final = self.create_azure_base_url(
                 azure_client_params=azure_client_params,
                 model=model,
@@ -1303,7 +1347,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                 additional_args={
                     "complete_input_dict": data,
                     "api_base": img_gen_api_base,
-                    "headers": headers,
+                    "headers": logging_obj._get_masked_headers(resolved_headers),
                 },
             )
             httpx_response: Final[httpx.Response] = self.make_sync_azure_httpx_request(
@@ -1313,7 +1357,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                 api_version=api_version or "",
                 api_key=api_key or "",
                 data=data,
-                headers=headers,
+                headers=resolved_headers,
                 deployment_name=model,
             )
             provider_config: Final = get_azure_image_generation_config(data.get("model", "dall-e-2"))

--- a/litellm/llms/azure/common_utils.py
+++ b/litellm/llms/azure/common_utils.py
@@ -77,6 +77,31 @@ def process_azure_headers(headers: httpx.Headers | dict) -> dict:
     return {**llm_response_headers, **openai_headers}
 
 
+def resolve_azure_image_auth_headers(
+    headers: dict[str, str],
+    api_key: str | None,
+    azure_ad_token_provider: Callable[[], str] | None,
+    azure_ad_token: str | None,
+) -> dict[str, str]:
+    if api_key:
+        return headers
+
+    if azure_ad_token_provider is not None:
+        token: Final = azure_ad_token_provider()
+        if token:
+            return _with_bearer_header(headers, token)
+
+    if azure_ad_token:
+        return _with_bearer_header(headers, azure_ad_token)
+
+    return headers
+
+
+def _with_bearer_header(headers: dict[str, str], token: str) -> dict[str, str]:
+    without_api_key: Final = {k: v for k, v in headers.items() if k != "api-key"}
+    return {**without_api_key, "Authorization": f"Bearer {token}"}
+
+
 @lru_cache(maxsize=128)
 def _cached_entra_id_token_provider(
     tenant_id: str,

--- a/tests/test_litellm/llms/azure/image_generation/test_azure_image_generation_init.py
+++ b/tests/test_litellm/llms/azure/image_generation/test_azure_image_generation_init.py
@@ -14,6 +14,7 @@ from litellm.llms.azure.image_generation.http_utils import (
     azure_deployment_image_generation_json_body,
 )
 from litellm.llms.custom_httpx.http_handler import HTTPHandler
+from litellm.llms.azure.common_utils import resolve_azure_image_auth_headers
 from litellm.llms.azure.image_generation import (
     AzureDallE3ImageGenerationConfig,
     get_azure_image_generation_config,
@@ -436,6 +437,268 @@ async def test_azure_aimage_generation_base_model_vs_deployment_name():
         wire_json = post_kwargs.get("json") or {}
         assert "model" not in wire_json
         assert data.get("model") == base_model
+
+
+def test_resolve_azure_image_auth_headers_api_key_takes_precedence():
+    out = resolve_azure_image_auth_headers(
+        headers={"Content-Type": "application/json", "api-key": "sk-123"},
+        api_key="sk-123",
+        azure_ad_token_provider=lambda: "ad-token",
+        azure_ad_token=None,
+    )
+    assert out["api-key"] == "sk-123"
+    assert "Authorization" not in out
+
+
+def test_resolve_azure_image_auth_headers_uses_token_provider_when_keyless():
+    out = resolve_azure_image_auth_headers(
+        headers={"Content-Type": "application/json"},
+        api_key=None,
+        azure_ad_token_provider=lambda: "ad-token",
+        azure_ad_token=None,
+    )
+    assert out["Authorization"] == "Bearer ad-token"
+    assert "api-key" not in out
+
+
+def test_resolve_azure_image_auth_headers_drops_stale_api_key_for_token():
+    out = resolve_azure_image_auth_headers(
+        headers={"api-key": "stale"},
+        api_key=None,
+        azure_ad_token_provider=lambda: "ad-token",
+        azure_ad_token=None,
+    )
+    assert "api-key" not in out
+    assert out["Authorization"] == "Bearer ad-token"
+
+
+def test_resolve_azure_image_auth_headers_falls_back_to_static_ad_token():
+    out = resolve_azure_image_auth_headers(
+        headers={"Content-Type": "application/json"},
+        api_key=None,
+        azure_ad_token_provider=None,
+        azure_ad_token="static-token",
+    )
+    assert out["Authorization"] == "Bearer static-token"
+
+
+def test_resolve_azure_image_auth_headers_unchanged_when_no_credentials():
+    headers = {"Content-Type": "application/json"}
+    out = resolve_azure_image_auth_headers(
+        headers=headers,
+        api_key=None,
+        azure_ad_token_provider=None,
+        azure_ad_token=None,
+    )
+    assert out == headers
+
+
+def test_resolve_azure_image_auth_headers_does_not_mutate_input():
+    headers = {"api-key": "stale"}
+    resolve_azure_image_auth_headers(
+        headers=headers,
+        api_key=None,
+        azure_ad_token_provider=lambda: "ad-token",
+        azure_ad_token=None,
+    )
+    assert headers == {"api-key": "stale"}
+
+
+def test_azure_image_generation_keyless_workload_identity_sets_bearer_header():
+    """https://github.com/BerriAI/litellm/issues/16422"""
+    azure_chat = AzureChatCompletion()
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {
+        "created": 1,
+        "data": [{"url": "https://example.com/cat.png"}],
+    }
+
+    with (
+        patch.object(HTTPHandler, "post", return_value=mock_resp) as mock_post,
+        patch(
+            "litellm.llms.azure.common_utils.get_azure_ad_token_from_entra_id",
+            return_value=lambda: "wif-token",
+        ),
+    ):
+        azure_chat.image_generation(
+            prompt="a cat",
+            timeout=60.0,
+            optional_params={"n": 1, "size": "1024x1024"},
+            logging_obj=MagicMock(),
+            headers={},
+            model="gpt-image-1-mini",
+            api_key=None,
+            api_base="https://res.openai.azure.com/",
+            api_version="2025-04-01-preview",
+            litellm_params={
+                "api_base": "https://res.openai.azure.com/",
+                "api_version": "2025-04-01-preview",
+                "tenant_id": "test-tenant-id",
+                "client_id": "test-client-id",
+                "client_secret": "test-client-secret",
+            },
+        )
+
+    sent_headers = mock_post.call_args.kwargs["headers"]
+    assert sent_headers.get("Authorization") == "Bearer wif-token"
+    assert "api-key" not in sent_headers
+
+
+def test_azure_image_generation_with_api_key_sets_api_key_header():
+    azure_chat = AzureChatCompletion()
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {
+        "created": 1,
+        "data": [{"url": "https://example.com/cat.png"}],
+    }
+
+    with patch.object(HTTPHandler, "post", return_value=mock_resp) as mock_post:
+        azure_chat.image_generation(
+            prompt="a cat",
+            timeout=60.0,
+            optional_params={"n": 1, "size": "1024x1024"},
+            logging_obj=MagicMock(),
+            headers={"api-key": "sk-test"},
+            model="gpt-image-1-mini",
+            api_key="sk-test",
+            api_base="https://res.openai.azure.com/",
+            api_version="2025-04-01-preview",
+            litellm_params={
+                "api_base": "https://res.openai.azure.com/",
+                "api_version": "2025-04-01-preview",
+            },
+        )
+
+    sent_headers = mock_post.call_args.kwargs["headers"]
+    assert sent_headers.get("api-key") == "sk-test"
+    assert "Authorization" not in sent_headers
+
+
+@pytest.mark.asyncio
+async def test_azure_aimage_generation_keyless_sets_bearer_header():
+    azure_chat = AzureChatCompletion()
+
+    data = {"model": "gpt-image-1-mini", "prompt": "a cat", "n": 1, "size": "1024x1024"}
+    azure_client_params = {
+        "api_base": "https://res.openai.azure.com/",
+        "api_version": "2025-04-01-preview",
+        "azure_ad_token_provider": (lambda: "wif-token"),
+    }
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {
+        "created": 1,
+        "data": [{"url": "https://example.com/cat.png"}],
+    }
+    mock_client = MagicMock()
+    mock_client.post = AsyncMock(return_value=mock_resp)
+
+    with patch("litellm.llms.azure.azure.get_async_httpx_client", return_value=mock_client):
+        await azure_chat.aimage_generation(
+            data=data,
+            model_response=None,
+            azure_client_params=azure_client_params,
+            api_key=None,
+            input=[],
+            logging_obj=MagicMock(),
+            headers={},
+            model="gpt-image-1-mini",
+            timeout=60.0,
+        )
+
+    sent_headers = mock_client.post.call_args.kwargs["headers"]
+    assert sent_headers.get("Authorization") == "Bearer wif-token"
+    assert "api-key" not in sent_headers
+
+
+@pytest.mark.asyncio
+async def test_azure_aimage_generation_empty_string_api_key_still_uses_token_provider():
+    azure_chat = AzureChatCompletion()
+
+    data = {"model": "gpt-image-1-mini", "prompt": "a cat", "n": 1, "size": "1024x1024"}
+    azure_client_params = {
+        "api_base": "https://res.openai.azure.com/",
+        "api_version": "2025-04-01-preview",
+        "azure_ad_token_provider": (lambda: "wif-token"),
+    }
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {
+        "created": 1,
+        "data": [{"url": "https://example.com/cat.png"}],
+    }
+    mock_client = MagicMock()
+    mock_client.post = AsyncMock(return_value=mock_resp)
+
+    with patch("litellm.llms.azure.azure.get_async_httpx_client", return_value=mock_client):
+        await azure_chat.aimage_generation(
+            data=data,
+            model_response=None,
+            azure_client_params=azure_client_params,
+            api_key="",
+            input=[],
+            logging_obj=MagicMock(),
+            headers={},
+            model="gpt-image-1-mini",
+            timeout=60.0,
+        )
+
+    sent_headers = mock_client.post.call_args.kwargs["headers"]
+    assert sent_headers.get("Authorization") == "Bearer wif-token"
+
+
+@pytest.mark.asyncio
+async def test_azure_image_generation_aimg_generation_flag_resolves_headers_once():
+    azure_chat = AzureChatCompletion()
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {
+        "created": 1,
+        "data": [{"url": "https://example.com/cat.png"}],
+    }
+    mock_client = MagicMock()
+    mock_client.post = AsyncMock(return_value=mock_resp)
+
+    token_provider = MagicMock(return_value="wif-token")
+
+    with (
+        patch("litellm.llms.azure.azure.get_async_httpx_client", return_value=mock_client),
+        patch(
+            "litellm.llms.azure.common_utils.get_azure_ad_token_from_entra_id",
+            return_value=token_provider,
+        ),
+    ):
+        await azure_chat.image_generation(
+            prompt="a cat",
+            timeout=60.0,
+            optional_params={"n": 1, "size": "1024x1024"},
+            logging_obj=MagicMock(),
+            headers={},
+            model="gpt-image-1-mini",
+            api_key=None,
+            api_base="https://res.openai.azure.com/",
+            api_version="2025-04-01-preview",
+            aimg_generation=True,
+            litellm_params={
+                "api_base": "https://res.openai.azure.com/",
+                "api_version": "2025-04-01-preview",
+                "tenant_id": "test-tenant-id",
+                "client_id": "test-client-id",
+                "client_secret": "test-client-secret",
+            },
+        )
+
+    assert token_provider.call_count == 1
+    sent_headers = mock_client.post.call_args.kwargs["headers"]
+    assert sent_headers.get("Authorization") == "Bearer wif-token"
+    assert "api-key" not in sent_headers
 
 
 @pytest.mark.parametrize("api_version", ["v1", "preview", "latest"])


### PR DESCRIPTION
## TLDR

Problem this solves:

- Azure image generation ignores keyless (Workload Identity/Entra ID) credentials
- Requests go out with no Authorization header, Azure rejects them with 401

How it solves it:

- Apply the resolved credential to the raw httpx headers, like chat completions already does
- Cover both the sync and async image generation request paths

## User Flow

Before: a developer running LiteLLM Proxy for Azure image generation with Workload Identity (no API key configured) gets every request rejected

1. They send POST https://proxy-domain/v1/images/generations with a `gpt-image` model, no `api_key`, relying on an Entra ID/Workload Identity credential
2. Azure returns 401 with "Access denied due to invalid subscription key or wrong API endpoint," even though the credential itself is valid, because no Authorization header was ever attached to the request
3. Every image generation call fails the same way, with no way to authenticate short of falling back to a static API key

After: the same setup generates images successfully using only the Workload Identity credential

1. They send the same POST https://proxy-domain/v1/images/generations request, unchanged
2. Azure returns 200 with a generated image, the same way chat completions already worked with Workload Identity
3. Images generate successfully without ever configuring a static API key

## Relevant issues

Superseded by PR 40147 (see issue 16422)

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Setup shared by both runs: a proxy config pointing `gpt-image-2` at a real Azure OpenAI resource, with `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, and `AZURE_CLIENT_SECRET` set only as process environment variables (no `api_key`, and no `tenant_id`/`client_id`/`client_secret` in `litellm_params`), so the credential is resolved only inside `initialize_azure_sdk_client`, the same way a real Workload Identity credential would be.

### Before (168a0055a244acdcf97c330c52e085ab40b1424c)

1. `curl -X POST http://localhost:4010/v1/images/generations -H "Authorization: Bearer sk-proof-1234" -H "Content-Type: application/json" -d '{"model": "gpt-image-2", "prompt": "a small red bicycle on a white background", "n": 1, "size": "1024x1024"}'`
2. Azure returns HTTP 401: `"Access denied due to invalid subscription key or wrong API endpoint. Make sure to provide a valid key for an active subscription and use a correct regional API endpoint for your resource."`, even though a valid Entra ID credential was resolved and available on the server, because it never reached the request headers

### After (2e6a20c11b37178185d11ea521e26229c60510aa)

1. Same command, same environment, patched code: `curl -X POST http://localhost:4011/v1/images/generations -H "Authorization: Bearer sk-proof-1234" -H "Content-Type: application/json" -d '{"model": "gpt-image-2", "prompt": "a small red bicycle on a white background", "n": 1, "size": "1024x1024"}'`
2. Azure returns HTTP 200 with a generated image; decoding the returned `data[0].b64_json` produces a valid 1024x1024 PNG

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- A related credential path (tenant_id/client_id/client_secret passed through `litellm_params`) was already fixed earlier in `images/main.py`; this PR closes the remaining gap for credentials resolved deeper inside `initialize_azure_sdk_client` (env-var-driven Entra ID and Workload Identity Federation), for both the sync and async image generation paths

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

