### PR TITLE
fix(anthropic): keep vLLM tool ids intact on /v1/messages

### DIFF
--- a/litellm/llms/anthropic/common_utils.py
+++ b/litellm/llms/anthropic/common_utils.py
@@ -8,6 +8,7 @@ from collections.abc import Mapping, MutableMapping, Sequence
 from datetime import datetime, timezone
 from types import MappingProxyType
 from typing import Any, Final, Literal
+from urllib.parse import urlparse
 
 import httpx
 from pydantic import BaseModel, ConfigDict, TypeAdapter, ValidationError
@@ -1240,37 +1241,42 @@ def _sanitize_tool_use_id_content_block(block: object) -> object:
     return block
 
 
-_ANTHROPIC_TOOL_ID_CHARSET_HOST_MARKERS: Final = frozenset(
-    (
-        "api.anthropic.com",
-        "amazonaws.com",
-        "googleapis.com",
-        "cloud.google.com",
-    )
-)
+_ANTHROPIC_TOOL_ID_CHARSET_HOSTNAME: Final = "api.anthropic.com"
 
 
-def _upstream_enforces_anthropic_tool_id_charset(api_base: str | None) -> bool:
+def _should_sanitize_anthropic_tool_use_ids(
+    *,
+    api_base: str | None,
+    custom_llm_provider: str | None,
+) -> bool:
+    if custom_llm_provider is not None and custom_llm_provider.casefold() != "anthropic":
+        return True
     if api_base is None or not api_base.strip():
         return True
-    host: Final = api_base.casefold()
-    return any(marker in host for marker in _ANTHROPIC_TOOL_ID_CHARSET_HOST_MARKERS)
+    hostname: Final = urlparse(api_base).hostname
+    if hostname is None:
+        return True
+    return hostname.casefold() == _ANTHROPIC_TOOL_ID_CHARSET_HOSTNAME
 
 
 def sanitize_tool_use_ids_in_anthropic_messages(
     messages: list[Any],
     *,
     api_base: str | None = None,
+    custom_llm_provider: str | None = None,
 ) -> list[Any]:
     """
     Rewrite ``tool_use`` / ``server_tool_use`` ``id`` and ``tool_result``
     ``tool_use_id`` values to Anthropic's ``^[a-zA-Z0-9_-]+$`` pattern.
 
-    No-op when ``api_base`` is a host that is not Anthropic, Bedrock, or Vertex.
-    Those upstreams (vLLM, Kimi, SGLang) echo the original ids; rewriting them
-    breaks the next tool_result turn. See #32214.
+    No-op when ``custom_llm_provider`` is ``anthropic`` and ``api_base`` is a
+    non-Anthropic host. vLLM/Kimi echo the original ids; rewriting them breaks
+    the next tool_result turn. See #32214.
     """
-    if not _upstream_enforces_anthropic_tool_id_charset(api_base):
+    if not _should_sanitize_anthropic_tool_use_ids(
+        api_base=api_base,
+        custom_llm_provider=custom_llm_provider,
+    ):
         return messages
     out: Final[list[Any]] = []
     for m in messages:

--- a/litellm/llms/anthropic/common_utils.py
+++ b/litellm/llms/anthropic/common_utils.py
@@ -1240,17 +1240,38 @@ def _sanitize_tool_use_id_content_block(block: object) -> object:
     return block
 
 
-def sanitize_tool_use_ids_in_anthropic_messages(messages: list[Any]) -> list[Any]:
-    """
-    Return a new message list with ``tool_use`` / ``server_tool_use`` ``id`` and
-    ``tool_result`` ``tool_use_id`` values rewritten to satisfy Anthropic's
-    ``^[a-zA-Z0-9_-]+$`` requirement.
+_ANTHROPIC_TOOL_ID_CHARSET_HOST_MARKERS: Final = frozenset(
+    (
+        "api.anthropic.com",
+        "amazonaws.com",
+        "googleapis.com",
+        "cloud.google.com",
+    )
+)
 
-    Cross-provider clients (e.g. Claude Code routed through kimi) may replay
-    conversation history containing ids like ``functions.Bash:0`` with ``.``
-    and ``:`` — valid on the upstream provider but rejected by Anthropic when
-    the session is switched to a native Anthropic deployment.
+
+def _upstream_enforces_anthropic_tool_id_charset(api_base: str | None) -> bool:
+    if api_base is None or not api_base.strip():
+        return True
+    host: Final = api_base.casefold()
+    return any(marker in host for marker in _ANTHROPIC_TOOL_ID_CHARSET_HOST_MARKERS)
+
+
+def sanitize_tool_use_ids_in_anthropic_messages(
+    messages: list[Any],
+    *,
+    api_base: str | None = None,
+) -> list[Any]:
     """
+    Rewrite ``tool_use`` / ``server_tool_use`` ``id`` and ``tool_result``
+    ``tool_use_id`` values to Anthropic's ``^[a-zA-Z0-9_-]+$`` pattern.
+
+    No-op when ``api_base`` is a host that is not Anthropic, Bedrock, or Vertex.
+    Those upstreams (vLLM, Kimi, SGLang) echo the original ids; rewriting them
+    breaks the next tool_result turn. See #32214.
+    """
+    if not _upstream_enforces_anthropic_tool_id_charset(api_base):
+        return messages
     out: Final[list[Any]] = []
     for m in messages:
         if not isinstance(m, dict) or not isinstance(m.get("content"), list):

--- a/litellm/llms/anthropic/common_utils.py
+++ b/litellm/llms/anthropic/common_utils.py
@@ -1244,12 +1244,30 @@ def _sanitize_tool_use_id_content_block(block: object) -> object:
 _ANTHROPIC_TOOL_ID_CHARSET_HOSTNAME: Final = "api.anthropic.com"
 
 
+def _llm_provider_for_tool_id_sanitize(
+    *,
+    custom_llm_provider: str | None,
+    model: str | None,
+) -> str | None:
+    if custom_llm_provider is not None and custom_llm_provider.strip():
+        return custom_llm_provider.casefold()
+    if model is None or "/" not in model:
+        return None
+    prefix: Final = model.split("/", 1)[0].casefold()
+    return prefix or None
+
+
 def _should_sanitize_anthropic_tool_use_ids(
     *,
     api_base: str | None,
     custom_llm_provider: str | None,
+    model: str | None,
 ) -> bool:
-    if custom_llm_provider is not None and custom_llm_provider.casefold() != "anthropic":
+    provider: Final = _llm_provider_for_tool_id_sanitize(
+        custom_llm_provider=custom_llm_provider,
+        model=model,
+    )
+    if provider is not None and provider != "anthropic":
         return True
     if api_base is None or not api_base.strip():
         return True
@@ -1264,18 +1282,20 @@ def sanitize_tool_use_ids_in_anthropic_messages(
     *,
     api_base: str | None = None,
     custom_llm_provider: str | None = None,
+    model: str | None = None,
 ) -> list[Any]:
     """
     Rewrite ``tool_use`` / ``server_tool_use`` ``id`` and ``tool_result``
     ``tool_use_id`` values to Anthropic's ``^[a-zA-Z0-9_-]+$`` pattern.
 
-    No-op when ``custom_llm_provider`` is ``anthropic`` and ``api_base`` is a
+    No-op when the resolved provider is ``anthropic`` and ``api_base`` is a
     non-Anthropic host. vLLM/Kimi echo the original ids; rewriting them breaks
     the next tool_result turn. See #32214.
     """
     if not _should_sanitize_anthropic_tool_use_ids(
         api_base=api_base,
         custom_llm_provider=custom_llm_provider,
+        model=model,
     ):
         return messages
     out: Final[list[Any]] = []

--- a/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
@@ -264,7 +264,10 @@ async def anthropic_messages(
     # Replay of cross-provider tool history (e.g. kimi -> Anthropic) may carry
     # ids like ``functions.Bash:0`` that violate Anthropic's id pattern.
     messages = sanitize_tool_use_ids_in_anthropic_messages(
-        messages, api_base=api_base, custom_llm_provider=custom_llm_provider
+        messages,
+        api_base=api_base,
+        custom_llm_provider=custom_llm_provider,
+        model=model,
     )
     messages = flatten_unencrypted_web_search_results_in_anthropic_messages(messages)
 
@@ -463,7 +466,10 @@ def anthropic_messages_handler(
     if not kwargs.pop("_litellm_messages_presanitized", False):
         messages = strip_empty_content_blocks_from_anthropic_messages(messages)
         messages = sanitize_tool_use_ids_in_anthropic_messages(
-            messages, api_base=api_base, custom_llm_provider=custom_llm_provider
+            messages,
+            api_base=api_base,
+            custom_llm_provider=custom_llm_provider,
+            model=model,
         )
         messages = flatten_unencrypted_web_search_results_in_anthropic_messages(messages)
 

--- a/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
@@ -263,7 +263,9 @@ async def anthropic_messages(
     messages = strip_empty_content_blocks_from_anthropic_messages(messages)
     # Replay of cross-provider tool history (e.g. kimi -> Anthropic) may carry
     # ids like ``functions.Bash:0`` that violate Anthropic's id pattern.
-    messages = sanitize_tool_use_ids_in_anthropic_messages(messages, api_base=api_base)
+    messages = sanitize_tool_use_ids_in_anthropic_messages(
+        messages, api_base=api_base, custom_llm_provider=custom_llm_provider
+    )
     messages = flatten_unencrypted_web_search_results_in_anthropic_messages(messages)
 
     from litellm.integrations.anthropic_cache_control_hook import (
@@ -460,7 +462,9 @@ def anthropic_messages_handler(
     # full-messages scan. Pop it so it never leaks into provider params.
     if not kwargs.pop("_litellm_messages_presanitized", False):
         messages = strip_empty_content_blocks_from_anthropic_messages(messages)
-        messages = sanitize_tool_use_ids_in_anthropic_messages(messages, api_base=api_base)
+        messages = sanitize_tool_use_ids_in_anthropic_messages(
+            messages, api_base=api_base, custom_llm_provider=custom_llm_provider
+        )
         messages = flatten_unencrypted_web_search_results_in_anthropic_messages(messages)
 
     from litellm.integrations.anthropic_cache_control_hook import (

--- a/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
@@ -263,7 +263,7 @@ async def anthropic_messages(
     messages = strip_empty_content_blocks_from_anthropic_messages(messages)
     # Replay of cross-provider tool history (e.g. kimi -> Anthropic) may carry
     # ids like ``functions.Bash:0`` that violate Anthropic's id pattern.
-    messages = sanitize_tool_use_ids_in_anthropic_messages(messages)
+    messages = sanitize_tool_use_ids_in_anthropic_messages(messages, api_base=api_base)
     messages = flatten_unencrypted_web_search_results_in_anthropic_messages(messages)
 
     from litellm.integrations.anthropic_cache_control_hook import (
@@ -460,7 +460,7 @@ def anthropic_messages_handler(
     # full-messages scan. Pop it so it never leaks into provider params.
     if not kwargs.pop("_litellm_messages_presanitized", False):
         messages = strip_empty_content_blocks_from_anthropic_messages(messages)
-        messages = sanitize_tool_use_ids_in_anthropic_messages(messages)
+        messages = sanitize_tool_use_ids_in_anthropic_messages(messages, api_base=api_base)
         messages = flatten_unencrypted_web_search_results_in_anthropic_messages(messages)
 
     from litellm.integrations.anthropic_cache_control_hook import (

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
@@ -220,11 +220,19 @@ async def test_anthropic_messages_sanitizes_tool_use_ids_before_dispatch():
     assert msgs[0]["content"][0]["id"] == "functions.Bash:0"
 
 
-@pytest.mark.asyncio
-async def test_anthropic_messages_keeps_tool_use_ids_for_non_anthropic_api_base():
-    from litellm.llms.anthropic.experimental_pass_through.messages import handler
+_ANTHROPIC_MESSAGES_OK = {
+    "id": "msg_test",
+    "type": "message",
+    "role": "assistant",
+    "model": "claude-sonnet-4-5-20250929",
+    "content": [{"type": "text", "text": "ok"}],
+    "stop_reason": "end_turn",
+    "usage": {"input_tokens": 1, "output_tokens": 1},
+}
 
-    msgs = [
+
+def _tool_use_replay_messages():
+    return [
         {
             "role": "assistant",
             "content": [
@@ -237,29 +245,38 @@ async def test_anthropic_messages_keeps_tool_use_ids_for_non_anthropic_api_base(
             ],
         }
     ]
+
+
+def _capturing_anthropic_client():
     captured = {}
 
-    def fake_handler(*args, **kwargs):
-        captured["messages"] = kwargs.get("messages")
-        return "stub"
+    def capture_upstream(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(200, json=_ANTHROPIC_MESSAGES_OK, request=request)
 
-    fake_loop = MagicMock()
-    fake_loop.run_in_executor = lambda _e, func: _async_return(func())
+    upstream = AsyncHTTPHandler()
+    upstream.client = httpx.AsyncClient(transport=httpx.MockTransport(capture_upstream))
+    return captured, upstream
 
-    with (
-        patch.object(handler, "anthropic_messages_handler", side_effect=fake_handler),
-        patch("asyncio.get_event_loop", return_value=fake_loop),
-    ):
-        await handler.anthropic_messages(
-            max_tokens=100,
-            messages=msgs,
-            model="anthropic/claude-sonnet-4-5-20250929",
-            custom_llm_provider="anthropic",
-            api_key="k",
-            api_base="http://127.0.0.1:8000/v1",
-        )
 
-    assert captured["messages"][0]["content"][0]["id"] == "functions.Bash:0"
+@pytest.mark.asyncio
+async def test_anthropic_messages_keeps_tool_use_ids_for_non_anthropic_api_base():
+    from litellm.llms.anthropic.experimental_pass_through.messages import handler
+
+    msgs = _tool_use_replay_messages()
+    captured, upstream = _capturing_anthropic_client()
+
+    await handler.anthropic_messages(
+        max_tokens=100,
+        messages=msgs,
+        model="anthropic/claude-sonnet-4-5-20250929",
+        custom_llm_provider="anthropic",
+        api_key="k",
+        api_base="http://127.0.0.1:8000/v1",
+        client=upstream,
+    )
+
+    assert captured["body"]["messages"][0]["content"][0]["id"] == "functions.Bash:0"
     assert msgs[0]["content"][0]["id"] == "functions.Bash:0"
 
 
@@ -267,41 +284,19 @@ async def test_anthropic_messages_keeps_tool_use_ids_for_non_anthropic_api_base(
 async def test_anthropic_messages_sanitizes_azure_ai_model_prefix_without_provider():
     from litellm.llms.anthropic.experimental_pass_through.messages import handler
 
-    msgs = [
-        {
-            "role": "assistant",
-            "content": [
-                {
-                    "type": "tool_use",
-                    "id": "functions.Bash:0",
-                    "name": "Bash",
-                    "input": {},
-                }
-            ],
-        }
-    ]
-    captured = {}
+    msgs = _tool_use_replay_messages()
+    captured, upstream = _capturing_anthropic_client()
 
-    def fake_handler(*args, **kwargs):
-        captured["messages"] = kwargs.get("messages")
-        return "stub"
+    await handler.anthropic_messages(
+        max_tokens=100,
+        messages=msgs,
+        model="azure_ai/claude-sonnet-4-5",
+        api_key="k",
+        api_base="https://myres.services.ai.azure.com/anthropic",
+        client=upstream,
+    )
 
-    fake_loop = MagicMock()
-    fake_loop.run_in_executor = lambda _e, func: _async_return(func())
-
-    with (
-        patch.object(handler, "anthropic_messages_handler", side_effect=fake_handler),
-        patch("asyncio.get_event_loop", return_value=fake_loop),
-    ):
-        await handler.anthropic_messages(
-            max_tokens=100,
-            messages=msgs,
-            model="azure_ai/claude-sonnet-4-5",
-            api_key="k",
-            api_base="https://myres.services.ai.azure.com/anthropic",
-        )
-
-    assert captured["messages"][0]["content"][0]["id"] == "functions_Bash_0"
+    assert captured["body"]["messages"][0]["content"][0]["id"] == "functions_Bash_0"
     assert msgs[0]["content"][0]["id"] == "functions.Bash:0"
 
 

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
@@ -702,6 +702,27 @@ def test_handler_strips_when_no_presanitized_flag():
     assert result is not None
 
 
+def test_handler_forwards_api_base_to_tool_id_sanitize():
+    from litellm.llms.anthropic.experimental_pass_through.messages import handler
+
+    with patch.object(
+        handler,
+        "sanitize_tool_use_ids_in_anthropic_messages",
+        wraps=handler.sanitize_tool_use_ids_in_anthropic_messages,
+    ) as spy:
+        result = handler.anthropic_messages_handler(
+            max_tokens=10,
+            messages=[{"role": "user", "content": "Hello"}],
+            model="anthropic/claude-3-5-sonnet-20241022",
+            custom_llm_provider="anthropic",
+            api_base="http://127.0.0.1:8000/v1",
+            mock_response="hi there",
+        )
+    assert result is not None
+    assert spy.call_count == 1
+    assert spy.call_args.kwargs["api_base"] == "http://127.0.0.1:8000/v1"
+
+
 def test_handler_skips_strip_when_presanitized():
     """Async wrapper already sanitized -> handler must NOT rescan."""
     from litellm.llms.anthropic.experimental_pass_through.messages import handler

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
@@ -220,6 +220,49 @@ async def test_anthropic_messages_sanitizes_tool_use_ids_before_dispatch():
     assert msgs[0]["content"][0]["id"] == "functions.Bash:0"
 
 
+@pytest.mark.asyncio
+async def test_anthropic_messages_keeps_tool_use_ids_for_non_anthropic_api_base():
+    from litellm.llms.anthropic.experimental_pass_through.messages import handler
+
+    msgs = [
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "functions.Bash:0",
+                    "name": "Bash",
+                    "input": {},
+                }
+            ],
+        }
+    ]
+    captured = {}
+
+    def fake_handler(*args, **kwargs):
+        captured["messages"] = kwargs.get("messages")
+        return "stub"
+
+    fake_loop = MagicMock()
+    fake_loop.run_in_executor = lambda _e, func: _async_return(func())
+
+    with (
+        patch.object(handler, "anthropic_messages_handler", side_effect=fake_handler),
+        patch("asyncio.get_event_loop", return_value=fake_loop),
+    ):
+        await handler.anthropic_messages(
+            max_tokens=100,
+            messages=msgs,
+            model="anthropic/claude-sonnet-4-5-20250929",
+            custom_llm_provider="anthropic",
+            api_key="k",
+            api_base="http://127.0.0.1:8000/v1",
+        )
+
+    assert captured["messages"][0]["content"][0]["id"] == "functions.Bash:0"
+    assert msgs[0]["content"][0]["id"] == "functions.Bash:0"
+
+
 async def _async_return(value):
     return value
 
@@ -700,27 +743,6 @@ def test_handler_strips_when_no_presanitized_flag():
         )
     assert spy.call_count == 1  # sanitized exactly once here
     assert result is not None
-
-
-def test_handler_forwards_api_base_to_tool_id_sanitize():
-    from litellm.llms.anthropic.experimental_pass_through.messages import handler
-
-    with patch.object(
-        handler,
-        "sanitize_tool_use_ids_in_anthropic_messages",
-        wraps=handler.sanitize_tool_use_ids_in_anthropic_messages,
-    ) as spy:
-        result = handler.anthropic_messages_handler(
-            max_tokens=10,
-            messages=[{"role": "user", "content": "Hello"}],
-            model="anthropic/claude-3-5-sonnet-20241022",
-            custom_llm_provider="anthropic",
-            api_base="http://127.0.0.1:8000/v1",
-            mock_response="hi there",
-        )
-    assert result is not None
-    assert spy.call_count == 1
-    assert spy.call_args.kwargs["api_base"] == "http://127.0.0.1:8000/v1"
 
 
 def test_handler_skips_strip_when_presanitized():

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
@@ -263,6 +263,48 @@ async def test_anthropic_messages_keeps_tool_use_ids_for_non_anthropic_api_base(
     assert msgs[0]["content"][0]["id"] == "functions.Bash:0"
 
 
+@pytest.mark.asyncio
+async def test_anthropic_messages_sanitizes_azure_ai_model_prefix_without_provider():
+    from litellm.llms.anthropic.experimental_pass_through.messages import handler
+
+    msgs = [
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "functions.Bash:0",
+                    "name": "Bash",
+                    "input": {},
+                }
+            ],
+        }
+    ]
+    captured = {}
+
+    def fake_handler(*args, **kwargs):
+        captured["messages"] = kwargs.get("messages")
+        return "stub"
+
+    fake_loop = MagicMock()
+    fake_loop.run_in_executor = lambda _e, func: _async_return(func())
+
+    with (
+        patch.object(handler, "anthropic_messages_handler", side_effect=fake_handler),
+        patch("asyncio.get_event_loop", return_value=fake_loop),
+    ):
+        await handler.anthropic_messages(
+            max_tokens=100,
+            messages=msgs,
+            model="azure_ai/claude-sonnet-4-5",
+            api_key="k",
+            api_base="https://myres.services.ai.azure.com/anthropic",
+        )
+
+    assert captured["messages"][0]["content"][0]["id"] == "functions_Bash_0"
+    assert msgs[0]["content"][0]["id"] == "functions.Bash:0"
+
+
 async def _async_return(value):
     return value
 

--- a/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
+++ b/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
@@ -1794,6 +1794,72 @@ class TestAnthropicThinkingSignatureSelfHeal:
         assert out[1]["content"][0]["tool_use_id"] == "functions_Bash_0"
         assert msgs[0]["content"][0]["id"] == "functions.Bash:0"
 
+    def test_sanitize_tool_use_ids_skips_non_anthropic_api_base(self):
+        from litellm.llms.anthropic.common_utils import (
+            sanitize_tool_use_ids_in_anthropic_messages,
+        )
+
+        msgs = [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "functions.Bash:0",
+                        "name": "Bash",
+                        "input": {},
+                    }
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "functions.Bash:0",
+                        "content": "ok",
+                    }
+                ],
+            },
+        ]
+        out = sanitize_tool_use_ids_in_anthropic_messages(
+            msgs, api_base="http://127.0.0.1:8000/v1"
+        )
+        assert out is msgs
+        assert out[0]["content"][0]["id"] == "functions.Bash:0"
+        assert out[1]["content"][0]["tool_use_id"] == "functions.Bash:0"
+
+    def test_sanitize_tool_use_ids_still_runs_for_anthropic_hosts(self):
+        from litellm.llms.anthropic.common_utils import (
+            sanitize_tool_use_ids_in_anthropic_messages,
+        )
+
+        msgs = [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "functions.Bash:0",
+                        "name": "Bash",
+                        "input": {},
+                    }
+                ],
+            }
+        ]
+        anthropic_hosts = (
+            "",
+            "https://api.anthropic.com",
+            "https://bedrock-runtime.us-east-1.amazonaws.com",
+            "https://us-east5-aiplatform.googleapis.com",
+            "https://aiplatform.googleapis.com",
+            "https://cloud.google.com/vertex-ai",
+        )
+        for api_base in anthropic_hosts:
+            out = sanitize_tool_use_ids_in_anthropic_messages(msgs, api_base=api_base)
+            assert out[0]["content"][0]["id"] == "functions_Bash_0", api_base
+            assert msgs[0]["content"][0]["id"] == "functions.Bash:0"
+
     def test_normalize_anthropic_tool_use_id_strips_thought_signature(self):
         from litellm.litellm_core_utils.prompt_templates.factory import (
             THOUGHT_SIGNATURE_SEPARATOR,

--- a/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
+++ b/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
@@ -1823,11 +1823,37 @@ class TestAnthropicThinkingSignatureSelfHeal:
             },
         ]
         out = sanitize_tool_use_ids_in_anthropic_messages(
-            msgs, api_base="http://127.0.0.1:8000/v1"
+            msgs, api_base="http://127.0.0.1:8000/v1", custom_llm_provider="anthropic"
         )
         assert out is msgs
         assert out[0]["content"][0]["id"] == "functions.Bash:0"
         assert out[1]["content"][0]["tool_use_id"] == "functions.Bash:0"
+
+    def test_sanitize_tool_use_ids_uses_url_hostname_not_query_string(self):
+        from litellm.llms.anthropic.common_utils import (
+            sanitize_tool_use_ids_in_anthropic_messages,
+        )
+
+        msgs = [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "functions.Bash:0",
+                        "name": "Bash",
+                        "input": {},
+                    }
+                ],
+            }
+        ]
+        out = sanitize_tool_use_ids_in_anthropic_messages(
+            msgs,
+            api_base="http://vllm:8000/v1?x=api.anthropic.com",
+            custom_llm_provider="anthropic",
+        )
+        assert out is msgs
+        assert out[0]["content"][0]["id"] == "functions.Bash:0"
 
     def test_sanitize_tool_use_ids_still_runs_for_anthropic_hosts(self):
         from litellm.llms.anthropic.common_utils import (
@@ -1847,17 +1873,19 @@ class TestAnthropicThinkingSignatureSelfHeal:
                 ],
             }
         ]
-        anthropic_hosts = (
-            "",
-            "https://api.anthropic.com",
-            "https://bedrock-runtime.us-east-1.amazonaws.com",
-            "https://us-east5-aiplatform.googleapis.com",
-            "https://aiplatform.googleapis.com",
-            "https://cloud.google.com/vertex-ai",
+        still_sanitize = (
+            ("anthropic", ""),
+            ("anthropic", "https://api.anthropic.com"),
+            ("azure_ai", "https://myres.services.ai.azure.com/anthropic"),
+            ("github_copilot", "https://api.githubcopilot.com"),
+            ("bedrock", "https://bedrock-runtime.us-east-1.amazonaws.com"),
+            ("vertex_ai", "https://us-east5-aiplatform.googleapis.com"),
         )
-        for api_base in anthropic_hosts:
-            out = sanitize_tool_use_ids_in_anthropic_messages(msgs, api_base=api_base)
-            assert out[0]["content"][0]["id"] == "functions_Bash_0", api_base
+        for custom_llm_provider, api_base in still_sanitize:
+            out = sanitize_tool_use_ids_in_anthropic_messages(
+                msgs, api_base=api_base, custom_llm_provider=custom_llm_provider
+            )
+            assert out[0]["content"][0]["id"] == "functions_Bash_0", (custom_llm_provider, api_base)
             assert msgs[0]["content"][0]["id"] == "functions.Bash:0"
 
     def test_normalize_anthropic_tool_use_id_strips_thought_signature(self):

--- a/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
+++ b/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
@@ -1874,18 +1874,23 @@ class TestAnthropicThinkingSignatureSelfHeal:
             }
         ]
         still_sanitize = (
-            ("anthropic", ""),
-            ("anthropic", "https://api.anthropic.com"),
-            ("azure_ai", "https://myres.services.ai.azure.com/anthropic"),
-            ("github_copilot", "https://api.githubcopilot.com"),
-            ("bedrock", "https://bedrock-runtime.us-east-1.amazonaws.com"),
-            ("vertex_ai", "https://us-east5-aiplatform.googleapis.com"),
+            ("anthropic", "", None),
+            ("anthropic", "https://api.anthropic.com", None),
+            ("azure_ai", "https://myres.services.ai.azure.com/anthropic", None),
+            ("github_copilot", "https://api.githubcopilot.com", None),
+            ("bedrock", "https://bedrock-runtime.us-east-1.amazonaws.com", None),
+            ("vertex_ai", "https://us-east5-aiplatform.googleapis.com", None),
+            (None, "https://myres.services.ai.azure.com/anthropic", "azure_ai/claude-sonnet-4-5"),
+            (None, "https://api.githubcopilot.com", "github_copilot/claude-sonnet-4-5"),
         )
-        for custom_llm_provider, api_base in still_sanitize:
+        for custom_llm_provider, api_base, model in still_sanitize:
             out = sanitize_tool_use_ids_in_anthropic_messages(
-                msgs, api_base=api_base, custom_llm_provider=custom_llm_provider
+                msgs,
+                api_base=api_base,
+                custom_llm_provider=custom_llm_provider,
+                model=model,
             )
-            assert out[0]["content"][0]["id"] == "functions_Bash_0", (custom_llm_provider, api_base)
+            assert out[0]["content"][0]["id"] == "functions_Bash_0", (custom_llm_provider, api_base, model)
             assert msgs[0]["content"][0]["id"] == "functions.Bash:0"
 
     def test_normalize_anthropic_tool_use_id_strips_thought_signature(self):


### PR DESCRIPTION
## TLDR

Problem this solves:

- v1.91.0 rewrites vLLM/Kimi tool ids (#32214)
- The next tool_result turn then breaks

How it solves it:

- Skip rewrite for anthropic + non-api.anthropic.com api_base
- Still rewrite azure_ai, github_copilot, bedrock, vertex_ai

## User Flow

Before, as reported in #32214: Claude Code against a vLLM api_base stops after a few Bash turns because the forwarded tool ids no longer match

1. POST http://localhost:4000/v1/messages with tool_use id functions.Bash:0 and matching tool_result, on a model whose yaml has custom_llm_provider anthropic and api_base a local sink
2. Proxy returns HTTP 200
3. The sink records id functions_Bash_0 and tool_use_id functions_Bash_0

After: the same POST now forwards the original ids, so the next tool_result turn matches

1. POST http://localhost:4000/v1/messages with tool_use id functions.Bash:0 and matching tool_result, on a model whose yaml has custom_llm_provider anthropic and api_base a local sink
2. Proxy returns HTTP 200
3. The sink records id functions.Bash:0 and tool_use_id functions.Bash:0

## Relevant issues

Fixes #32214

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup: a local HTTP sink on 127.0.0.1:18080 that records POST /v1/messages. Proxy yaml model_name claude-sonnet-4-6, custom_llm_provider anthropic, api_base http://127.0.0.1:18080, master_key sk-1234. I did not run vLLM or Claude Code

### Before (168a0055a2)

1. `curl -sS -X POST http://127.0.0.1:4000/v1/messages -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"claude-sonnet-4-6","max_tokens":32,"messages":[{"role":"user","content":"run ls"},{"role":"assistant","content":[{"type":"tool_use","id":"functions.Bash:0","name":"Bash","input":{"command":"ls"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"functions.Bash:0","content":"ok"}]}]}'`
2. Proxy returned HTTP 200. The sink body had `"id": "functions_Bash_0"` and `"tool_use_id": "functions_Bash_0"`

### After (7a10559ea8)

1. Same curl as Before
2. Proxy returned HTTP 200. The sink body had `"id": "functions.Bash:0"` and `"tool_use_id": "functions.Bash:0"`

## Type

Bug Fix

## Caveats (if any)

### Medium

- model=claude-sonnet-4-5 with no provider prefix and a non-Anthropic api_base skips the rewrite. I did not test Azure Foundry that way

### Low

- A reverse proxy in front of real Anthropic whose hostname is not api.anthropic.com will not rewrite ids. I did not test that setup
- The sync messages.create path has no test. Only the async path is covered
- thinking_blocks replay (#31279) is unchanged

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
