### PR TITLE
fix(azure): apply keyless auth headers to image generation requests

### DIFF
--- a/litellm/llms/azure/azure.py
+++ b/litellm/llms/azure/azure.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 import time
-from collections.abc import Callable, Coroutine
+from collections.abc import Callable, Coroutine, Mapping
 from typing import Final
 
 import httpx
@@ -47,6 +47,7 @@ from .common_utils import (
     BaseAzureLLM,
     get_azure_ad_token_from_oidc,
     process_azure_headers,
+    resolve_azure_image_auth_headers,
     select_azure_base_url_or_endpoint,
 )
 from .image_generation import (
@@ -1134,6 +1135,51 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
 
         return base_url_with_deployment
 
+    @staticmethod
+    def _extract_azure_ad_token_provider(
+        azure_client_params: Mapping[str, object],
+    ) -> Callable[[], object] | None:
+        candidate: Final = azure_client_params.get("azure_ad_token_provider")
+        return candidate if callable(candidate) else None
+
+    @staticmethod
+    def _extract_azure_ad_token(azure_client_params: Mapping[str, object]) -> str | None:
+        candidate: Final = azure_client_params.get("azure_ad_token")
+        return candidate if isinstance(candidate, str) else None
+
+    @staticmethod
+    def _resolve_image_auth_headers(
+        headers: Mapping[str, str],
+        api_key: str | None,
+        azure_client_params: Mapping[str, object],
+        azure_ad_token_provider: Callable[[], object] | None = None,
+        azure_ad_token: str | None = None,
+    ) -> dict[str, str]:  # mutable-ok: HTTP handlers require a concrete mutable header dictionary.
+        provider: Final = azure_ad_token_provider or AzureChatCompletion._extract_azure_ad_token_provider(
+            azure_client_params
+        )
+        token: Final = azure_ad_token or AzureChatCompletion._extract_azure_ad_token(azure_client_params)
+        return resolve_azure_image_auth_headers(
+            headers=headers,
+            api_key=api_key,
+            azure_ad_token_provider=provider,
+            azure_ad_token=token,
+        )
+
+    @staticmethod
+    async def _aresolve_image_auth_headers(
+        headers: Mapping[str, str], api_key: str | None, azure_client_params: Mapping[str, object]
+    ) -> dict[str, str]:  # mutable-ok: HTTP handlers require a concrete mutable header dictionary.
+        provider: Final = AzureChatCompletion._extract_azure_ad_token_provider(azure_client_params)
+        provider_token: Final = await asyncio.to_thread(provider) if not api_key and provider is not None else None
+        token: Final = AzureChatCompletion._extract_azure_ad_token(azure_client_params)
+        return resolve_azure_image_auth_headers(
+            headers=headers,
+            api_key=api_key,
+            azure_ad_token_provider=None,
+            azure_ad_token=provider_token if isinstance(provider_token, str) and provider_token else token,
+        )
+
     async def aimage_generation(
         self,
         data: dict,
@@ -1149,6 +1195,9 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
     ) -> ImageResponse:
         response: dict | None = None
         try:
+            resolved_headers: Final = await self._aresolve_image_auth_headers(
+                headers=headers, api_key=api_key, azure_client_params=azure_client_params
+            )
             # response = await azure_client.images.generate(**data, timeout=timeout)
             api_base: str = azure_client_params.get("api_base", "")  # "https://example-endpoint.openai.azure.com"
             if api_base.endswith("/"):
@@ -1177,7 +1226,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                 api_version=api_version,
                 api_key=api_key,
                 data=data,
-                headers=headers,
+                headers=resolved_headers,
                 deployment_name=model,
             )
 
@@ -1261,12 +1310,6 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
             if not isinstance(max_retries, int):
                 raise AzureOpenAIError(status_code=422, message="max retries must be an int")
 
-            if api_key is None and azure_ad_token_provider is not None:
-                azure_ad_token = azure_ad_token_provider()
-                if azure_ad_token:
-                    headers.pop("api-key", None)
-                    headers["Authorization"] = f"Bearer {azure_ad_token}"
-
             # init AzureOpenAI Client
             azure_client_params: Final[dict[str, object]] = self.initialize_azure_sdk_client(
                 litellm_params=litellm_params or {},
@@ -1289,6 +1332,14 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                     headers=headers,
                     model=model,
                 )
+
+            resolved_headers: Final = self._resolve_image_auth_headers(
+                headers=headers,
+                api_key=api_key,
+                azure_client_params=azure_client_params,
+                azure_ad_token_provider=azure_ad_token_provider,
+                azure_ad_token=azure_ad_token,
+            )
 
             img_gen_api_base: Final = self.create_azure_base_url(
                 azure_client_params=azure_client_params,
@@ -1313,7 +1364,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                 api_version=api_version or "",
                 api_key=api_key or "",
                 data=data,
-                headers=headers,
+                headers=resolved_headers,
                 deployment_name=model,
             )
             provider_config: Final = get_azure_image_generation_config(data.get("model", "dall-e-2"))

--- a/litellm/llms/azure/common_utils.py
+++ b/litellm/llms/azure/common_utils.py
@@ -77,6 +77,34 @@ def process_azure_headers(headers: httpx.Headers | dict) -> dict:
     return {**llm_response_headers, **openai_headers}
 
 
+def _resolve_azure_bearer_token(
+    azure_ad_token_provider: Callable[[], object] | None,
+    azure_ad_token: str | None,
+) -> str | None:
+    """Return the keyless credential, preferring a live provider over an already-resolved token."""
+    if azure_ad_token_provider is not None:
+        provided: Final = azure_ad_token_provider()
+        if isinstance(provided, str) and provided:
+            return provided
+
+    return azure_ad_token or None
+
+
+def resolve_azure_image_auth_headers(
+    headers: Mapping[str, str],
+    api_key: str | None,
+    azure_ad_token_provider: Callable[[], object] | None,
+    azure_ad_token: str | None,
+) -> dict[str, str]:  # mutable-ok: httpx post() takes a concrete dict.
+    """Return the image-request headers, swapping a stale api-key for the resolved bearer token."""
+    token: Final = None if api_key else _resolve_azure_bearer_token(azure_ad_token_provider, azure_ad_token)
+    if token is None:
+        return dict(headers)  # mutable-ok: httpx post() takes a concrete dict.
+
+    keyless: Final = {k: v for k, v in headers.items() if k != "api-key"}  # mutable-ok: httpx post() takes a dict.
+    return {**keyless, "Authorization": f"Bearer {token}"}  # mutable-ok: httpx post() takes a concrete dict.
+
+
 @lru_cache(maxsize=128)
 def _cached_entra_id_token_provider(
     tenant_id: str,

--- a/tests/test_litellm/llms/azure/image_generation/test_azure_image_generation_init.py
+++ b/tests/test_litellm/llms/azure/image_generation/test_azure_image_generation_init.py
@@ -10,14 +10,15 @@ import respx
 import litellm
 from litellm.caching.llm_caching_handler import LLMClientCache
 from litellm.llms.azure.azure import AzureChatCompletion
-from litellm.llms.azure.image_generation.http_utils import (
-    azure_deployment_image_generation_json_body,
-)
-from litellm.llms.custom_httpx.http_handler import HTTPHandler
+from litellm.llms.azure.common_utils import resolve_azure_image_auth_headers
 from litellm.llms.azure.image_generation import (
     AzureDallE3ImageGenerationConfig,
     get_azure_image_generation_config,
 )
+from litellm.llms.azure.image_generation.http_utils import (
+    azure_deployment_image_generation_json_body,
+)
+from litellm.llms.custom_httpx.http_handler import HTTPHandler
 from litellm.utils import get_optional_params_image_gen
 
 
@@ -436,6 +437,125 @@ async def test_azure_aimage_generation_base_model_vs_deployment_name():
         wire_json = post_kwargs.get("json") or {}
         assert "model" not in wire_json
         assert data.get("model") == base_model
+
+
+def test_resolve_azure_image_auth_headers_uses_keyless_provider_without_mutating_input():
+    headers = {"api-key": "stale", "Content-Type": "application/json"}
+
+    resolved_headers = resolve_azure_image_auth_headers(
+        headers=headers,
+        api_key=None,
+        azure_ad_token_provider=lambda: "ad-token",
+        azure_ad_token=None,
+    )
+
+    assert dict(resolved_headers) == {
+        "Authorization": "Bearer ad-token",
+        "Content-Type": "application/json",
+    }
+    assert headers == {"api-key": "stale", "Content-Type": "application/json"}
+
+
+def test_resolve_azure_image_auth_headers_prefers_api_key():
+    resolved_headers = resolve_azure_image_auth_headers(
+        headers={"api-key": "sk-123"},
+        api_key="sk-123",
+        azure_ad_token_provider=lambda: "ad-token",
+        azure_ad_token=None,
+    )
+
+    assert dict(resolved_headers) == {"api-key": "sk-123"}
+
+
+def test_resolve_azure_image_auth_headers_falls_back_to_static_token():
+    """A caller with no provider still authenticates off a pre-resolved ``azure_ad_token``."""
+    resolved_headers = resolve_azure_image_auth_headers(
+        headers={"api-key": "stale"},
+        api_key=None,
+        azure_ad_token_provider=None,
+        azure_ad_token="static-token",
+    )
+
+    assert dict(resolved_headers) == {"Authorization": "Bearer static-token"}
+
+
+def test_resolve_azure_image_auth_headers_without_any_credential_is_unchanged():
+    """No credential at all must not invent an Authorization header."""
+    resolved_headers = resolve_azure_image_auth_headers(
+        headers={"Content-Type": "application/json"},
+        api_key=None,
+        azure_ad_token_provider=None,
+        azure_ad_token=None,
+    )
+
+    assert dict(resolved_headers) == {"Content-Type": "application/json"}
+
+
+@pytest.mark.asyncio
+async def test_azure_aimage_generation_sends_keyless_bearer_header(
+    respx_mock: respx.MockRouter, monkeypatch: pytest.MonkeyPatch
+):
+    """Async image generation must authenticate off the Entra ID provider, not a stale api-key."""
+    monkeypatch.setattr(litellm, "disable_aiohttp_transport", True)
+    monkeypatch.setattr(litellm, "in_memory_llm_clients_cache", LLMClientCache())
+    api_base = "https://my-resource.openai.azure.com"
+    route = respx_mock.post(f"{api_base}/openai/v1/images/generations").mock(
+        return_value=httpx.Response(200, json={"created": 1234567890, "data": [{"b64_json": "aaaa"}]})
+    )
+
+    await AzureChatCompletion().aimage_generation(
+        data={"model": "gpt-image-2", "prompt": "a cat", "n": 1},
+        model_response=None,
+        azure_client_params={
+            "azure_endpoint": api_base,
+            "api_version": "preview",
+            "azure_ad_token_provider": lambda: "wif-token",
+        },
+        api_key=None,
+        input=[],
+        logging_obj=MagicMock(),
+        headers={"api-key": "stale"},
+        model="gpt-image-2",
+        timeout=60.0,
+    )
+
+    sent_headers = route.calls.last.request.headers
+    assert sent_headers["Authorization"] == "Bearer wif-token"
+    assert "api-key" not in sent_headers
+
+
+def test_azure_image_generation_sends_keyless_bearer_header(respx_mock: respx.MockRouter):
+    """The sync path must use a credential resolved inside ``initialize_azure_sdk_client``.
+
+    The caller passes no ``azure_ad_token_provider`` argument, so the credential is only
+    reachable through ``litellm_params`` -- the Workload Identity/Entra ID shape that used
+    to go out with no Authorization header at all.
+    """
+    api_base = "https://my-resource.openai.azure.com"
+    route = respx_mock.post(f"{api_base}/openai/v1/images/generations").mock(
+        return_value=httpx.Response(200, json={"created": 1234567890, "data": [{"b64_json": "aaaa"}]})
+    )
+
+    AzureChatCompletion().image_generation(
+        prompt="a cat",
+        timeout=60.0,
+        optional_params={"n": 1},
+        logging_obj=MagicMock(),
+        headers={"api-key": "stale"},
+        model="gpt-image-2",
+        api_key=None,
+        api_base=api_base,
+        api_version="v1",
+        litellm_params={
+            "api_base": api_base,
+            "api_version": "v1",
+            "azure_ad_token_provider": lambda: "wif-token",
+        },
+    )
+
+    sent_headers = route.calls.last.request.headers
+    assert sent_headers["Authorization"] == "Bearer wif-token"
+    assert "api-key" not in sent_headers
 
 
 @pytest.mark.parametrize("api_version", ["v1", "preview", "latest"])


### PR DESCRIPTION
## TLDR

Problem this solves:

- Azure image generation ignores keyless Entra ID credentials
- Image requests go out with no Authorization header
- Azure rejects them with 401, even with valid credentials

How it solves it:

- Resolve the credential into the image request headers
- Cover both the sync and the async image paths
- Drop a stale api-key when a bearer token applies

## User Flow

Before: a developer running the proxy for Azure image generation with Workload Identity, and no API key configured anywhere, has every request rejected

1. They set only their Entra ID environment credentials, then send POST http://localhost:4000/v1/images/generations with `"model": "gpt-image-2"` and a prompt
2. The response is 401 saying "Access denied due to invalid subscription key or wrong API endpoint", even though the credential is valid and works elsewhere
3. Every image request fails this way, so the only way forward is to go back to a static API key

After: the same request returns an image, with no API key anywhere

1. They send the same POST http://localhost:4000/v1/images/generations request, unchanged
2. The response is 200 carrying a `data[0].b64_json` payload that decodes to a 1024x1024 PNG
3. Image generation now works the same way chat completions already did with Workload Identity

## Relevant issues

Superseded by PR 40147 (see issue 16422)

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both runs use the same real Azure OpenAI `gpt-image-2` deployment and the same config, with `AZURE_TENANT_ID`, `AZURE_CLIENT_ID` and `AZURE_CLIENT_SECRET` set only as process environment variables. No `api_key`, and no `tenant_id` / `client_id` / `client_secret` in `litellm_params`, so the credential is reachable only the way a real Workload Identity credential would be. The resource host is redacted below.

```yaml
model_list:
  - model_name: gpt-image-2
    litellm_params:
      model: azure/gpt-image-2
      api_base: https://<resource>.cognitiveservices.azure.com
      api_version: preview

general_settings:
  master_key: sk-1234
```

Proxy started with `python litellm/proxy/proxy_cli.py --config config.yaml --port 4000`

### Before (728d0953af94c29959232032c0646bf13f87cfaf)

1. Send the image request:

```bash
curl -sS -X POST http://localhost:4000/v1/images/generations \
  -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{"model": "gpt-image-2", "prompt": "a small red bicycle on a white background", "n": 1, "size": "1024x1024"}' \
  -w "\nHTTP_STATUS:%{http_code}\n"
```

2. Azure rejects it, because no Authorization header was ever attached:

```
{"error":{"message":"litellm.AuthenticationError: AzureException AuthenticationError - {\"error\":{\"code\":\"401\",\"message\":\"Access denied due to invalid subscription key or wrong API endpoint. Make sure to provide a valid key for an active subscription and use a correct regional API endpoint for your resource.\"}}. Received Model Group=gpt-image-2
Available Model Group Fallbacks=None","type":null,"param":null,"code":"401"}}
HTTP_STATUS:401
```

### After (04d600e7f13894200a6d236a74c0574990e13c81)

1. Send the same request against the same deployment:

```bash
curl -sS -X POST http://localhost:4000/v1/images/generations \
  -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{"model": "gpt-image-2", "prompt": "a small red bicycle on a white background", "n": 1, "size": "1024x1024"}' \
  -o after_response.json -w "HTTP_STATUS:%{http_code}\n"
```

```
HTTP_STATUS:200
```

2. Decode the returned image and confirm it is a real PNG:

```bash
python -c "import json,base64; d=json.load(open('after_response.json')); open('after_image.png','wb').write(base64.b64decode(d['data'][0]['b64_json']))"
file after_image.png
```

```
after_image.png: PNG image data, 1024 x 1024, 8-bit/color RGB, non-interlaced
```

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- A sibling credential path, with `tenant_id` / `client_id` / `client_secret` passed through `litellm_params`, was already fixed earlier in `images/main.py`. This closes the remaining gap for credentials resolved deeper in, covering env-var Entra ID and Workload Identity Federation on both image paths
- Six `# mutable-ok` suppressions remain, all at the point where headers hand off to httpx. Removing them would mean widening the shared `HTTPHandler.post` signature, which is a wider change than this fix should carry

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

