### PR TITLE
fix(router): serialize heuristic tuning quota filters for Prisma

### DIFF
--- a/litellm/repositories/model_repository.py
+++ b/litellm/repositories/model_repository.py
@@ -4,7 +4,6 @@ Model repository for database operations on LiteLLM_ProxyModelTable.
 
 import json
 from collections.abc import Mapping, Sequence
-from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Final, Protocol
 
 from litellm.models.model import LiteLLM_ProxyModelTable
@@ -109,7 +108,7 @@ class ModelRepository(BaseRepository[LiteLLM_ProxyModelTable]):
     async def find_all_except(self, model_id: str) -> Sequence[LiteLLM_ProxyModelTable]:
         """Find every model except the row currently being updated."""
         records: Final = await self.table.find_many(
-            where=MappingProxyType({"model_id": MappingProxyType({"not": model_id})})
+            where={"model_id": {"not": model_id}}  # mutable-ok: Prisma requires plain dicts for query serialization
         )
         return tuple(self._to_model_list(records))
 

--- a/tests/test_litellm/repositories/test_repositories.py
+++ b/tests/test_litellm/repositories/test_repositories.py
@@ -4,10 +4,13 @@ Tests for gateway repository layer.
 
 import json
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from types import SimpleNamespace
+from typing import Any, Dict, Final, List, Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from prisma import models as prisma_models
+from prisma.builder import QueryBuilder
 
 from litellm.models.base import DomainModel
 from litellm.models.budget import LiteLLM_BudgetTable
@@ -306,6 +309,23 @@ class TestModelRepository:
     def repo(self):
         client = MockPrismaClient()
         return ModelRepository(client)
+
+    @pytest.mark.asyncio
+    async def test_find_all_except_serializes_exclusion_for_prisma(self) -> None:
+        find_many: Final = AsyncMock(return_value=[])
+        client: Final = SimpleNamespace(
+            db=SimpleNamespace(litellm_proxymodeltable=SimpleNamespace(find_many=find_many))
+        )
+
+        await ModelRepository(client).find_all_except("current-model")
+
+        find_many.assert_awaited_once()
+        query: Final = QueryBuilder(
+            method="find_many",
+            model=prisma_models.LiteLLM_ProxyModelTable,
+            arguments=find_many.call_args.kwargs,
+        ).build_query()
+        assert 'where: { model_id: { not: "current-model" } }' in " ".join(query.split())
 
     def test_table_is_wrapped_for_config_sync(self, repo):
         from litellm.proxy.common_utils.config_sync_pubsub import (


### PR DESCRIPTION
## TLDR

Problem this solves:

- Custom heuristic-router registration fails with HTTP 500

How it solves it:

- Passes serializable dictionaries into Prisma's exclusion filter
- Tests the filter through Prisma's real query builder

## User Flow

Before: an admin cannot register a heuristic router with custom tier models

1. They send `POST http://localhost:4000/model/new` with `model: "auto_router/complexity_router"`, `classifier_type: "heuristic"`, and custom tier models
2. They receive HTTP 500 with `Failed to add model to db. Check your server logs for more details.`

After: the same registration succeeds when within the license allowance

1. They send `POST http://localhost:4000/model/new` with `model: "auto_router/complexity_router"`, `classifier_type: "heuristic"`, and custom tier models
2. They receive HTTP 200 with the new model's ID and name

## Relevant issues

Regression introduced by #39952, observed in [Buildkite build 322](https://buildkite.com/berriai-1/litellm-e2e-pr/builds/322/list?jid=01a0770a-6a77-4eb0-aa0d-37070bbff77e&tab=output)

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The focused test files pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR only solves one problem
- [ ] Greptile has posted 5/5 confidence for the current head

## Screenshots / Proof of Fix

Tested against a live proxy and PostgreSQL, with `STORE_MODEL_IN_DB=True`, the local master key `sk-1234`, and no `auto_router` license feature. The tier alias `prisma-filter-tier` was registered first with `model: "openai/gpt-5.6"` and `api_key: "os.environ/OPENAI_API_KEY"`. Registration requires no inference request

The same request body was saved as `router.json`:

```json
{
  "model_name": "prisma-filter-proof",
  "litellm_params": {
    "model": "auto_router/complexity_router",
    "complexity_router_config": {
      "classifier_type": "heuristic",
      "tiers": {
        "SIMPLE": "prisma-filter-tier",
        "MEDIUM": "prisma-filter-tier",
        "COMPLEX": "prisma-filter-tier",
        "REASONING": "prisma-filter-tier"
      }
    }
  }
}
```

### Before (a2b7868a5bdb45030d4b224189eb1b1010ad1c4f)

1. Send the registration request:

   ```bash
   curl -sS -w '\nHTTP %{http_code}\n' http://127.0.0.1:63418/model/new \
     -H 'Authorization: Bearer sk-1234' \
     -H 'Content-Type: application/json' \
     --data-binary @router.json
   ```

2. Observe HTTP 500:

   ```json
   {"error":{"message":"{'error': 'Failed to add model to db. Check your server logs for more details.'}","type":"auth_error","param":"None","code":"500"}}
   ```

   The server traceback ends in `TypeError: Type <class 'mappingproxy'> not serializable`

### After (f40c3842dc4cebbf1eb02379a492acb1d0c87605)

1. Send the same registration request:

   ```bash
   curl -sS -w '\nHTTP %{http_code}\n' http://127.0.0.1:63539/model/new \
     -H 'Authorization: Bearer sk-1234' \
     -H 'Content-Type: application/json' \
     --data-binary @router.json
   ```

2. Observe HTTP 200. Selected response fields:

   ```json
   {"model_id":"a1bfeca4-57a5-46c5-993b-81e388317960","model_name":"prisma-filter-proof"}
   ```

Additional live checks: `/model/info` returns the created model, updating that router's tuning returns 200, and registering a second custom router returns the intended 403 quota error

Validation: the new regression test fails before the fix with the same Prisma exception. After the fix, all 148 repository tests and 10 existing heuristic-tuning licensing tests pass. `make check` passed

## Type

Bug Fix
Test

## Caveats (if any)

### Medium

- Multi-router E2E fixtures still require appropriate licensing

## Final Attestation

- [x] Regression coverage checks Prisma serialization and the exclusion filter
- [x] Live verification covers registration, persistence, updates, and quota rejection
