### PR TITLE
docs(proxy): fix ui_view_teams' copy-pasted docstring

### DIFF
--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -5420,14 +5420,14 @@ async def ui_view_teams(
     [PROXY-ADMIN ONLY] Filter teams based on partial match of team_id or team_alias with pagination.
 
     Args:
-        user_id (Optional[str]): Partial user ID to search for
-        user_email (Optional[str]): Partial email to search for
+        team_id (Optional[str]): Partial team ID to search for
+        team_alias (Optional[str]): Partial team alias to search for
         page (int): Page number for pagination (starts at 1)
         page_size (int): Number of items per page (max 100)
         user_api_key_dict (UserAPIKeyAuth): User authentication information
 
     Returns:
-        List[LiteLLM_SpendLogs]: Paginated list of matching user records
+        Dict with the paginated list of matching teams
     """
     from litellm.proxy.proxy_server import prisma_client
 


### PR DESCRIPTION
`ui_view_teams`'s docstring documents `user_id` / `user_email` parameters and a `List[LiteLLM_SpendLogs]` return — copied from a user/spend endpoint. The endpoint takes `team_id` / `team_alias` (its where-clause filters on exactly those) and returns the teams UI-view payload. The Args and Returns now match the code.