### PR TITLE
docs(proxy): drop docstring entries for parameters that don't exist

### DIFF
--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -2139,8 +2139,8 @@ async def get_users(
             - internal_user_viewer
         user_ids: Optional[str]
             Get list of users by user_ids. Comma separated list of user_ids.
-        sso_ids: Optional[str]
-            Get list of users by sso_ids. Comma separated list of sso_ids.
+        sso_user_ids: Optional[str]
+            Get list of users by sso_user_ids. Comma separated list of sso_user_ids.
         user_email: Optional[str]
             Filter users by partial email match
         search: Optional[str]

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -4371,7 +4371,6 @@ async def delete_verification_tokens(
 
     Args:
         tokens: List of tokens to delete
-        user_id: Optional user_id to filter by
 
     Returns:
         Tuple[Optional[Dict], List[LiteLLM_VerificationToken]]:

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -7861,7 +7861,6 @@ def validate_chat_completion_user_messages(messages: list[AllMessageValues]):
 
     Args:
         messages: List of message dictionaries
-        message_content_type: Type to validate content against
 
     Returns:
         List[dict]: The validated messages


### PR DESCRIPTION
Three docstring/parameter mismatches in the management endpoints:

- `internal_user_endpoints.py` `get_users`: the Args block documents `sso_ids`; the actual FastAPI query parameter is `sso_user_ids`
- `litellm/utils.py` `validate_chat_completion_user_messages`: documents `message_content_type`, which isn't a parameter (the body only uses `messages`)
- `key_management_endpoints.py` `delete_verification_tokens`: documents `user_id: Optional user_id to filter by`, which isn't a parameter

Docs-only; the stale entries are removed/renamed to match the signatures.