### PR TITLE
fix(guardrails): record an intentional block as guardrail_intervened, not a failure

### DIFF
--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -80,30 +80,10 @@ _guardrail_self_recorded: Final[contextvars.ContextVar[bool]] = contextvars.Cont
 def is_guardrail_intervention(e: Exception) -> bool:
     """
     Returns True if the exception represents an intentional guardrail block
-    (this was logged previously as an API failure - guardrail_failed_to_respond).
+    rather than a technical failure
 
-    Guardrails signal intentional blocks by raising:
-    - GuardrailRaisedException (generic guardrail API, tool permission)
-    - BlockedPiiEntityError (Presidio PII detection)
-    - SensitiveDataRouteException (sensitive-data reroute to on-premise model)
-    - HTTPException with a block-signalling status (400, 403, 422)
-    - ModifyResponseException (passthrough mode violation)
-    - an exception carrying OpenAI's ``content_policy_violation`` code (aim)
-
-    Only the statuses guardrails use in-tree to signal a deliberate rejection
-    count as an intervention: 400 (content policy), 403 (e.g. akto) and 422
-    (e.g. llm_as_a_judge). Other 4xx codes are commonly propagated from an
-    upstream guardrail provider response (401 bad key, 408 timeout, 429 rate
-    limit, or a raw upstream status), which are technical failures, not
-    blocks, so they stay guardrail_failed_to_respond.
-
-    ``openai_code`` is the OpenAI-standard error code and only ever set on
-    ``ProxyException``; a guardrail that sets it to ``content_policy_violation``
-    is stating that it judged the content, which is what this function asks.
-    Aim raises ``ProxyException`` for both a policy verdict and a fail-closed
-    refusal it could not apply (a malformed anonymize response), and only the
-    verdict carries that code, so keying on the code rather than on the class
-    keeps the refusals classified as failures.
+    Guardrails signal blocks with dedicated exceptions, block HTTP statuses,
+    or OpenAI's ``content_policy_violation`` code
     """
     if isinstance(e, ModifyResponseException):
         return True

--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -64,6 +64,8 @@ _PRE_CALL_EXECUTED_TOKEN: Final = secrets.token_hex(16)
 
 _GUARDRAIL_BLOCK_STATUS_CODES: Final = frozenset({400, 403, 422})
 
+_CONTENT_POLICY_VIOLATION_CODE: Final = "content_policy_violation"
+
 DEFAULT_ADVISORY_MESSAGE: Final = (
     "The user's latest message was flagged for {reason} by a content safety "
     "guardrail. This may be a false positive. Use your judgment: respond "
@@ -86,6 +88,7 @@ def is_guardrail_intervention(e: Exception) -> bool:
     - SensitiveDataRouteException (sensitive-data reroute to on-premise model)
     - HTTPException with a block-signalling status (400, 403, 422)
     - ModifyResponseException (passthrough mode violation)
+    - an exception carrying OpenAI's ``content_policy_violation`` code (aim)
 
     Only the statuses guardrails use in-tree to signal a deliberate rejection
     count as an intervention: 400 (content policy), 403 (e.g. akto) and 422
@@ -93,6 +96,14 @@ def is_guardrail_intervention(e: Exception) -> bool:
     upstream guardrail provider response (401 bad key, 408 timeout, 429 rate
     limit, or a raw upstream status), which are technical failures, not
     blocks, so they stay guardrail_failed_to_respond.
+
+    ``openai_code`` is the OpenAI-standard error code and only ever set on
+    ``ProxyException``; a guardrail that sets it to ``content_policy_violation``
+    is stating that it judged the content, which is what this function asks.
+    Aim raises ``ProxyException`` for both a policy verdict and a fail-closed
+    refusal it could not apply (a malformed anonymize response), and only the
+    verdict carries that code, so keying on the code rather than on the class
+    keeps the refusals classified as failures.
     """
     if isinstance(e, ModifyResponseException):
         return True
@@ -106,6 +117,8 @@ def is_guardrail_intervention(e: Exception) -> bool:
     ):
         return True
     if HTTPException is not None and isinstance(e, HTTPException) and e.status_code in _GUARDRAIL_BLOCK_STATUS_CODES:
+        return True
+    if getattr(e, "openai_code", None) == _CONTENT_POLICY_VIOLATION_CODE:
         return True
     return False
 

--- a/litellm/proxy/example_config_yaml/custom_guardrail.py
+++ b/litellm/proxy/example_config_yaml/custom_guardrail.py
@@ -4,7 +4,10 @@ import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.caching.caching import DualCache
 from litellm.exceptions import GuardrailRaisedException
-from litellm.integrations.custom_guardrail import CustomGuardrail
+from litellm.integrations.custom_guardrail import (
+    CustomGuardrail,
+    log_guardrail_information,
+)
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.types.utils import CallTypesLiteral
 
@@ -79,6 +82,7 @@ class myCustomGuardrail(CustomGuardrail):
 
         return data
 
+    @log_guardrail_information
     async def async_moderation_hook(
         self,
         data: dict,
@@ -107,6 +111,7 @@ class myCustomGuardrail(CustomGuardrail):
                             blocked_content=True,
                         )
 
+    @log_guardrail_information
     async def async_post_call_success_hook(
         self,
         data: dict,

--- a/litellm/proxy/example_config_yaml/custom_guardrail.py
+++ b/litellm/proxy/example_config_yaml/custom_guardrail.py
@@ -3,6 +3,7 @@ from typing import Dict, Final, Optional, Union
 import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.caching.caching import DualCache
+from litellm.exceptions import GuardrailRaisedException
 from litellm.integrations.custom_guardrail import CustomGuardrail
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.types.utils import CallTypesLiteral
@@ -99,7 +100,12 @@ class myCustomGuardrail(CustomGuardrail):
                 _content = message.get("content")
                 if isinstance(_content, str):
                     if "litellm" in _content.lower():
-                        raise ValueError("Guardrail failed words - `litellm` detected")
+                        raise GuardrailRaisedException(
+                            guardrail_name=self.guardrail_name,
+                            message="Guardrail failed words - `litellm` detected",
+                            should_wrap_with_default_message=False,
+                            blocked_content=True,
+                        )
 
     async def async_post_call_success_hook(
         self,
@@ -124,4 +130,9 @@ class myCustomGuardrail(CustomGuardrail):
                         and isinstance(choice.message.content, str)
                         and "coffee" in choice.message.content
                     ):
-                        raise ValueError("Guardrail failed Coffee Detected")
+                        raise GuardrailRaisedException(
+                            guardrail_name=self.guardrail_name,
+                            message="Guardrail failed Coffee Detected",
+                            should_wrap_with_default_message=False,
+                            blocked_content=True,
+                        )

--- a/litellm/proxy/guardrails/guardrail_hooks/custom_guardrail.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/custom_guardrail.py
@@ -3,6 +3,7 @@ from typing import Final, Literal
 import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.caching.caching import DualCache
+from litellm.exceptions import GuardrailRaisedException
 from litellm.integrations.custom_guardrail import (
     CustomGuardrail,
     log_guardrail_information,
@@ -90,7 +91,12 @@ class myCustomGuardrail(CustomGuardrail):
                 _content = message.get("content")
                 if isinstance(_content, str):
                     if "litellm" in _content.lower():
-                        raise ValueError("Guardrail failed words - `litellm` detected")
+                        raise GuardrailRaisedException(
+                            guardrail_name=self.guardrail_name,
+                            message="Guardrail failed words - `litellm` detected",
+                            should_wrap_with_default_message=False,
+                            blocked_content=True,
+                        )
 
     @log_guardrail_information
     async def async_post_call_success_hook(
@@ -116,4 +122,9 @@ class myCustomGuardrail(CustomGuardrail):
                         and isinstance(choice.message.content, str)
                         and "coffee" in choice.message.content
                     ):
-                        raise ValueError("Guardrail failed Coffee Detected")
+                        raise GuardrailRaisedException(
+                            guardrail_name=self.guardrail_name,
+                            message="Guardrail failed Coffee Detected",
+                            should_wrap_with_default_message=False,
+                            blocked_content=True,
+                        )

--- a/tests/test_litellm/integrations/test_custom_guardrail.py
+++ b/tests/test_litellm/integrations/test_custom_guardrail.py
@@ -4,13 +4,23 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from litellm.exceptions import GuardrailRaisedException
 from litellm.integrations.custom_guardrail import (
     DEFAULT_ADVISORY_MESSAGE,
     CustomGuardrail,
     log_guardrail_information,
 )
 from litellm.proxy._types import CallTypes, UserAPIKeyAuth
-from litellm.types.utils import GenericGuardrailAPIInputs, GuardrailTracingDetail
+from litellm.proxy.example_config_yaml.custom_guardrail import myCustomGuardrail as ExampleConfigGuardrail
+from litellm.proxy.guardrails.guardrail_hooks.aim.aim import AimGuardrail
+from litellm.proxy.guardrails.guardrail_hooks.custom_guardrail import myCustomGuardrail
+from litellm.types.utils import (
+    Choices,
+    GenericGuardrailAPIInputs,
+    GuardrailTracingDetail,
+    Message,
+    ModelResponse,
+)
 
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
@@ -1828,25 +1838,17 @@ class TestGuardrailInterventionClassification:
 
     def test_content_policy_violation_proxy_exception_is_intervention(self):
         """Aim signals a policy verdict with a ProxyException carrying OpenAI's content-policy code."""
-        from litellm.proxy.guardrails.guardrail_hooks.aim.aim import AimGuardrail
-
         exc = AimGuardrail._rejection("blocked by policy", openai_code="content_policy_violation")
         assert CustomGuardrail._is_guardrail_intervention(exc) is True
 
     def test_proxy_exception_without_content_policy_code_is_not_intervention(self):
         """Aim reuses the same factory to refuse a response it could not anonymize, which is a failure."""
-        from litellm.proxy.guardrails.guardrail_hooks.aim.aim import AimGuardrail
-
         exc = AimGuardrail._rejection("anonymize action returned malformed redacted messages")
         assert CustomGuardrail._is_guardrail_intervention(exc) is False
 
     @pytest.mark.asyncio
     async def test_example_guardrail_block_logged_as_intervened(self):
         """The in-tree example guardrail is the pattern custom guardrails are copied from."""
-        from litellm.exceptions import GuardrailRaisedException
-        from litellm.proxy.guardrails.guardrail_hooks.custom_guardrail import myCustomGuardrail
-        from litellm.proxy._types import UserAPIKeyAuth
-
         guardrail = myCustomGuardrail(guardrail_name="example-custom")
         request_data: dict = {
             "metadata": {},
@@ -1867,23 +1869,42 @@ class TestGuardrailInterventionClassification:
 
     @pytest.mark.asyncio
     async def test_example_guardrail_output_block_is_intervened(self):
-        from litellm.exceptions import GuardrailRaisedException
-        from litellm.proxy.guardrails.guardrail_hooks.custom_guardrail import myCustomGuardrail
-        from litellm.proxy._types import UserAPIKeyAuth
-        from litellm.types.utils import Choices, Message, ModelResponse
-
         guardrail = myCustomGuardrail(guardrail_name="example-custom-post")
         response = ModelResponse(choices=[Choices(message=Message(role="assistant", content="coffee"))])
+        request_data: dict = {"metadata": {}}
 
         with pytest.raises(GuardrailRaisedException) as exc_info:
             await guardrail.async_post_call_success_hook(
-                data={"metadata": {}},
+                data=request_data,
                 user_api_key_dict=UserAPIKeyAuth(),
                 response=response,
             )
 
         assert exc_info.value.blocked_content is True
         assert str(exc_info.value) == "Guardrail failed Coffee Detected"
+        slg = request_data["metadata"]["standard_logging_guardrail_information"][0]
+        assert slg["guardrail_status"] == "guardrail_intervened"
+
+    @pytest.mark.asyncio
+    async def test_example_config_guardrail_blocks_with_blocked_content(self):
+        """The example_config_yaml copy is what otel_test_config.yaml loads; it must block the same way."""
+        guardrail = ExampleConfigGuardrail(guardrail_name="example-config")
+
+        with pytest.raises(GuardrailRaisedException) as input_block:
+            await guardrail.async_moderation_hook(
+                data={"messages": [{"role": "user", "content": "tell me about litellm"}]},
+                user_api_key_dict=UserAPIKeyAuth(),
+                call_type="completion",
+            )
+        assert input_block.value.blocked_content is True
+
+        with pytest.raises(GuardrailRaisedException) as output_block:
+            await guardrail.async_post_call_success_hook(
+                data={},
+                user_api_key_dict=UserAPIKeyAuth(),
+                response=ModelResponse(choices=[Choices(message=Message(role="assistant", content="coffee"))]),
+            )
+        assert output_block.value.blocked_content is True
 
 
 class _ApplyStyleGuardrail(CustomGuardrail):

--- a/tests/test_litellm/integrations/test_custom_guardrail.py
+++ b/tests/test_litellm/integrations/test_custom_guardrail.py
@@ -1889,22 +1889,28 @@ class TestGuardrailInterventionClassification:
     async def test_example_config_guardrail_blocks_with_blocked_content(self):
         """The example_config_yaml copy is what otel_test_config.yaml loads; it must block the same way."""
         guardrail = ExampleConfigGuardrail(guardrail_name="example-config")
+        input_request: dict = {"metadata": {}, "messages": [{"role": "user", "content": "tell me about litellm"}]}
+        output_request: dict = {"metadata": {}}
 
         with pytest.raises(GuardrailRaisedException) as input_block:
             await guardrail.async_moderation_hook(
-                data={"messages": [{"role": "user", "content": "tell me about litellm"}]},
+                data=input_request,
                 user_api_key_dict=UserAPIKeyAuth(),
                 call_type="completion",
             )
         assert input_block.value.blocked_content is True
+        input_slg = input_request["metadata"]["standard_logging_guardrail_information"][0]
+        assert input_slg["guardrail_status"] == "guardrail_intervened"
 
         with pytest.raises(GuardrailRaisedException) as output_block:
             await guardrail.async_post_call_success_hook(
-                data={},
+                data=output_request,
                 user_api_key_dict=UserAPIKeyAuth(),
                 response=ModelResponse(choices=[Choices(message=Message(role="assistant", content="coffee"))]),
             )
         assert output_block.value.blocked_content is True
+        output_slg = output_request["metadata"]["standard_logging_guardrail_information"][0]
+        assert output_slg["guardrail_status"] == "guardrail_intervened"
 
 
 class _ApplyStyleGuardrail(CustomGuardrail):

--- a/tests/test_litellm/integrations/test_custom_guardrail.py
+++ b/tests/test_litellm/integrations/test_custom_guardrail.py
@@ -1826,6 +1826,45 @@ class TestGuardrailInterventionClassification:
         slg = request_data["metadata"]["standard_logging_guardrail_information"][0]
         assert slg["guardrail_status"] == "guardrail_intervened"
 
+    def test_content_policy_violation_proxy_exception_is_intervention(self):
+        """Aim signals a policy verdict with a ProxyException carrying OpenAI's content-policy code."""
+        from litellm.proxy.guardrails.guardrail_hooks.aim.aim import AimGuardrail
+
+        exc = AimGuardrail._rejection("blocked by policy", openai_code="content_policy_violation")
+        assert CustomGuardrail._is_guardrail_intervention(exc) is True
+
+    def test_proxy_exception_without_content_policy_code_is_not_intervention(self):
+        """Aim reuses the same factory to refuse a response it could not anonymize, which is a failure."""
+        from litellm.proxy.guardrails.guardrail_hooks.aim.aim import AimGuardrail
+
+        exc = AimGuardrail._rejection("anonymize action returned malformed redacted messages")
+        assert CustomGuardrail._is_guardrail_intervention(exc) is False
+
+    @pytest.mark.asyncio
+    async def test_example_guardrail_block_logged_as_intervened(self):
+        """The in-tree example guardrail is the pattern custom guardrails are copied from."""
+        from litellm.exceptions import GuardrailRaisedException
+        from litellm.proxy.guardrails.guardrail_hooks.custom_guardrail import myCustomGuardrail
+        from litellm.proxy._types import UserAPIKeyAuth
+
+        guardrail = myCustomGuardrail(guardrail_name="example-custom")
+        request_data: dict = {
+            "metadata": {},
+            "messages": [{"role": "user", "content": "tell me about litellm"}],
+        }
+
+        with pytest.raises(GuardrailRaisedException) as exc_info:
+            await guardrail.async_moderation_hook(
+                data=request_data,
+                user_api_key_dict=UserAPIKeyAuth(),
+                call_type="completion",
+            )
+
+        assert exc_info.value.blocked_content is True
+        assert str(exc_info.value) == "Guardrail failed words - `litellm` detected"
+        slg = request_data["metadata"]["standard_logging_guardrail_information"][0]
+        assert slg["guardrail_status"] == "guardrail_intervened"
+
 
 class _ApplyStyleGuardrail(CustomGuardrail):
     """Overrides only apply_guardrail, like openai_moderation; async_pre_call_hook stays the CustomLogger no-op."""

--- a/tests/test_litellm/integrations/test_custom_guardrail.py
+++ b/tests/test_litellm/integrations/test_custom_guardrail.py
@@ -1865,6 +1865,26 @@ class TestGuardrailInterventionClassification:
         slg = request_data["metadata"]["standard_logging_guardrail_information"][0]
         assert slg["guardrail_status"] == "guardrail_intervened"
 
+    @pytest.mark.asyncio
+    async def test_example_guardrail_output_block_is_intervened(self):
+        from litellm.exceptions import GuardrailRaisedException
+        from litellm.proxy.guardrails.guardrail_hooks.custom_guardrail import myCustomGuardrail
+        from litellm.proxy._types import UserAPIKeyAuth
+        from litellm.types.utils import Choices, Message, ModelResponse
+
+        guardrail = myCustomGuardrail(guardrail_name="example-custom-post")
+        response = ModelResponse(choices=[Choices(message=Message(role="assistant", content="coffee"))])
+
+        with pytest.raises(GuardrailRaisedException) as exc_info:
+            await guardrail.async_post_call_success_hook(
+                data={"metadata": {}},
+                user_api_key_dict=UserAPIKeyAuth(),
+                response=response,
+            )
+
+        assert exc_info.value.blocked_content is True
+        assert str(exc_info.value) == "Guardrail failed Coffee Detected"
+
 
 class _ApplyStyleGuardrail(CustomGuardrail):
     """Overrides only apply_guardrail, like openai_moderation; async_pre_call_hook stays the CustomLogger no-op."""

--- a/tests/test_litellm/proxy/openai_files_endpoint/test_batch_guardrails.py
+++ b/tests/test_litellm/proxy/openai_files_endpoint/test_batch_guardrails.py
@@ -7,7 +7,8 @@ from fastapi import HTTPException
 from litellm.exceptions import BlockedPiiEntityError, GuardrailRaisedException
 
 from litellm.caching import DualCache
-from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy._types import ProxyException, UserAPIKeyAuth
+from litellm.proxy.guardrails.guardrail_hooks.aim.aim import AimGuardrail
 from litellm.proxy.utils import ProxyLogging
 from litellm.proxy.openai_files_endpoints.batch_guardrails import (
     BatchScanResult,
@@ -787,6 +788,25 @@ async def test_raising_a_native_block_exception_drops_whatever_status_it_carries
     result = await _scan_full(_jsonl(_record("b", content="tripwire")), FakeProxyLogging(_hook))
 
     assert result.changes == (RecordDropped(line_number=1, custom_id="b", guardrail="g"),)
+
+
+@pytest.mark.asyncio
+async def test_aim_policy_verdict_drops_only_the_blocked_record():
+    rejection = AimGuardrail._rejection("blocked", openai_code="content_policy_violation")
+    source = _jsonl(_record("a"), _record("b", content="tripwire"))
+    result = await _scan_full(source, FakeProxyLogging(_raise_on("tripwire", rejection)))
+
+    assert result.changes == (RecordDropped(line_number=2, custom_id="b", guardrail=None),)
+    assert result.submitted_records == 1
+
+
+@pytest.mark.asyncio
+async def test_aim_technical_refusal_aborts_instead_of_dropping_the_record():
+    rejection = AimGuardrail._rejection("anonymize action returned malformed redacted messages")
+    source = _jsonl(_record("a"), _record("b", content="tripwire"))
+    with pytest.raises(ProxyException) as exc_info:
+        await _scan_full(source, FakeProxyLogging(_raise_on("tripwire", rejection)))
+    assert exc_info.value is rejection
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/policy_engine/test_pipeline_executor.py
+++ b/tests/test_litellm/proxy/policy_engine/test_pipeline_executor.py
@@ -10,6 +10,7 @@ import pytest
 
 import litellm
 from litellm.integrations.custom_guardrail import CustomGuardrail
+from litellm.proxy.guardrails.guardrail_hooks.aim.aim import AimGuardrail
 from litellm.proxy.guardrails.guardrail_hooks.custom_code.custom_code_guardrail import (
     CustomCodeGuardrail,
 )
@@ -654,6 +655,35 @@ async def test_on_fail_next_on_content_on_error_block_stops_api_fallback(monkeyp
     assert fallback.calls == 0
     assert result.step_results[0].outcome == "error"
     assert result.step_results[0].action_taken == "block"
+
+
+@pytest.mark.parametrize(
+    "openai_code,expected_action,expected_outcome",
+    [("content_policy_violation", "block", "fail"), (None, "allow", "error")],
+)
+@pytest.mark.asyncio
+async def test_aim_policy_verdict_uses_on_fail_and_technical_refusal_uses_on_error(
+    monkeypatch, openai_code, expected_action, expected_outcome
+):
+    rejection = AimGuardrail._rejection("refused", openai_code=openai_code)
+
+    class RejectingGuardrail(CustomGuardrail):
+        async def async_pre_call_hook(self, user_api_key_dict, cache, data, call_type):
+            raise rejection
+
+    monkeypatch.setattr(litellm, "callbacks", [RejectingGuardrail(guardrail_name="aim")])
+    result = await PipelineExecutor.execute_steps(
+        steps=[PipelineStep(guardrail="aim", on_fail="block", on_error="allow")],
+        mode="pre_call",
+        data={"messages": [{"role": "user", "content": "test"}]},
+        user_api_key_dict=MagicMock(),
+        call_type="completion",
+        policy_name="aim-failopen",
+    )
+
+    assert result.terminal_action == expected_action
+    assert result.step_results[0].outcome == expected_outcome
+    assert result.step_results[0].action_taken == expected_action
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## TLDR

Scope correction: this PR does not resolve the original provider report in LIT-4878. The evidence below covers custom examples and an AIM simulator, not the reported provider

Problem this solves:

- Intentional custom guardrail blocks were treated as technical failures
- The Guardrails Monitor undercounted blocked requests
- The shared classifier did not recognize AIM policy verdicts
- The example config guardrail copy never reached the Monitor at all

How it solves it:

- Uses GuardrailRaisedException for copied custom-guardrail examples
- Recognizes the explicit content_policy_violation error code
- Leaves uncoded AIM technical refusals classified as failures
- Records example config guardrail input and output checks in the Monitor

## User Flow

Before: a custom guardrail blocks the request, but the dashboard shows no blocked requests

1. They send `POST https://litellm-domain/v1/chat/completions` with `"guardrails": ["example-custom"]` and the prompt `tell me about litellm`
2. They receive HTTP 500 with `Guardrail failed words - \`litellm\` detected`
3. They open `https://litellm-domain/ui/?page=guardrails-monitor` and see zero Blocked Requests, and a guardrail loaded from the example config file is missing from the table

After: the same custom guardrail block returns a client error and counts as blocked

1. They send `POST https://litellm-domain/v1/chat/completions` with `"guardrails": ["example-custom"]` and the prompt `tell me about litellm`
2. They receive HTTP 400 with `Guardrail failed words - \`litellm\` detected`
3. They open `https://litellm-domain/ui/?page=guardrails-monitor` and see the block counted under Blocked Requests, and the example config guardrail listed with its blocks

## Relevant issues

## Linear ticket

Refs LIT-4878

The original provider flow remains unverified. PR #31948, merged on 2026-08-05 as `bb58f019a0`, replaced its bare block exception with HTTP 400 after the ticket's `3bba3633c7` snapshot. Current staging contains that change, but no real vendor request, persisted record, or Monitor screenshot has verified the reported flow. Credentials and a BLOCK policy are unavailable locally

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks
- [ ] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile Confidence Score of at least 4/5 before requesting maintainer review

## Screenshots / Proof of Fix

Shared setup: base `168a0055a2` ran on port 20881 and head `b36738aa56` on port 20882, with separate real Postgres databases and the same proxy configuration. `example-custom` and `example-custom-post` load the guardrail from the guardrail hooks folder, `config-example` and `config-example-post` load the copy from the example config folder. The custom guardrail scenarios made real OpenAI model calls. Moderation-service failure was injected using a closed local port. Both databases' rig-only metrics and spend logs were cleared before this run on 2026-09-07

The following command was run twice per port for each request body, changing only the port and output filename

```bash
curl -sS -w '\nHTTP %{http_code}\n' \
  http://127.0.0.1:$PORT/v1/chat/completions \
  -H 'Authorization: Bearer sk-1234' \
  -H 'Content-Type: application/json' \
  -d "$BODY"
```

```json
{"model":"m-example","messages":[{"role":"user","content":"tell me about litellm"}],"guardrails":["example-custom"]}
{"model":"m-example","messages":[{"role":"user","content":"Reply with exactly this one word: coffee"}],"guardrails":["example-custom-post"]}
{"model":"m-example","messages":[{"role":"user","content":"tell me about litellm"}],"guardrails":["config-example"]}
{"model":"m-example","messages":[{"role":"user","content":"Reply with exactly this one word: coffee"}],"guardrails":["config-example-post"]}
{"model":"m-example","messages":[{"role":"user","content":"hello there"}],"guardrails":["mod-dead"]}
{"model":"m-example","messages":[{"role":"user","content":"say hello in one word"}]}
```

### Before (168a0055a2)

#### Custom guardrail blocks

1. Send the `example-custom` request and observe HTTP 500, `internal_server_error`, code `500`, message `Guardrail failed words - \`litellm\` detected`
2. Send the `example-custom-post` request and observe HTTP 500, `internal_server_error`, code `500`, message `Guardrail failed Coffee Detected`

#### Example config guardrail blocks

1. Send the `config-example` request and observe HTTP 500, `internal_server_error`, code `500`, message `Guardrail failed words - \`litellm\` detected`
2. Send the `config-example-post` request and observe HTTP 500, `internal_server_error`, code `500`, message `Guardrail failed Coffee Detected`

#### Technical failure and success controls

1. Send the request with `mod-dead` and observe HTTP 500 with `Cannot connect to host REDACTED:20899`
2. Send the request without a guardrail and observe HTTP 200 with a model response

#### Guardrails Monitor

1. Open `http://127.0.0.1:20881/ui/?page=guardrails-monitor` and observe Total Evaluations 6, Blocked Requests 0, Pass Rate 100%
2. Observe `example-custom`, `example-custom-post` and `mod-dead` listed as Healthy with 2 requests and 0% fail rate each, and no `config-example` or `config-example-post` rows
3. Screenshot: https://raw.githubusercontent.com/BerriAI/litellm/assets-pr4878/proof/guardrails-before.png

### After (b36738aa56)

#### Custom guardrail blocks

1. Send the `example-custom` request and observe HTTP 400, `invalid_request_error`, code `400`, message `Guardrail failed words - \`litellm\` detected`
2. Send the `example-custom-post` request and observe HTTP 400, `invalid_request_error`, code `400`, message `Guardrail failed Coffee Detected`

#### Example config guardrail blocks

1. Send the `config-example` request and observe HTTP 400, `invalid_request_error`, code `400`, message `Guardrail failed words - \`litellm\` detected`
2. Send the `config-example-post` request and observe HTTP 400, `invalid_request_error`, code `400`, message `Guardrail failed Coffee Detected`

#### Technical failure and success controls

1. Send the request with `mod-dead` and observe HTTP 500 with `Cannot connect to host REDACTED:20899`
2. Send the request without a guardrail and observe HTTP 200 with a model response

#### Guardrails Monitor

1. Open `http://127.0.0.1:20882/ui/?page=guardrails-monitor` and observe Total Evaluations 10, Blocked Requests 8, Pass Rate 20%
2. Observe `example-custom`, `example-custom-post`, `config-example` and `config-example-post` listed as Critical with 2 requests and 100% fail rate each, and `mod-dead` still Healthy at 0%
3. Screenshot: https://raw.githubusercontent.com/BerriAI/litellm/assets-pr4878/proof/guardrails-after.png

## Blast radius

The changed classifier is shared, so this is not an AIM-only change

- All callers of the shared classifier are in scope for regression checks
- The bundled custom guardrail examples changed which exception they raise
- The batch upload path, the policy pipeline, and passthrough logging all read the same classifier
- Only exceptions carrying OpenAI's `content_policy_violation` code are newly treated as blocks, and AIM is the only in-tree producer of that code today
- Azure Prompt Shield, OpenAI moderations, and secret detection call the same helper, but their verdicts were already classified correctly

## Live regression gate

`/live-pr-risk` ran against head `b36738aa56`, with base `168a0055a2` and the merged staging tree `249a5569da`

- Base and head ran side by side on separate real Postgres databases at four workers each
- The matrix drove 160 alternating requests over `POST /v1/chat/completions` and `POST /v1/files` with zero unexpected statuses
- No unintended regression was found on the driven paths. The intended contract changes are the ones listed under Caveats
- Failure legs covered a dead moderation endpoint, twenty-way concurrency, and a paused database
- Real AIM vendor calls, `/v1/responses`, `/v1/messages`, and passthrough routes were not driven. They were traced from source and are recorded on the ticket
- Because the real AIM leg is deferred, this PR does not carry the full no-regression attestation

## Type

Bug Fix

## Caveats

### Severe

- AIM batch blocks now drop records instead of aborting uploads
- AIM policy verdicts now follow `on_fail` instead of `on_error`

### Medium

- The original ticket's provider flow remains unverified
  - No real vendor request or Monitor proof was captured
  - Existing screenshots cover custom examples, not the reported provider
  - Real vendor access is required to complete verification
- AIM testing uses a user-approved simulator and dummy key
  - Vendor authentication and payload compatibility remain unverified
  - Pipeline and batch vendor behavior remain unverified
- Pre-existing AIM gaps remain tracked on LIT-4878
  - Standalone verdicts emit no Guardrails Monitor rows
  - AIM streaming blocks return identical SSE 500 failures on both sides
  - Batch drops report no guardrail name
- Streamed custom guardrail output blocks still reach the client
  - Observed on base, head, and the merged staging tree
  - The client sees HTTP 200 and the blocked text
  - Only the Monitor row records the block afterwards
- The example config guardrail's input masking hook stays unrecorded on purpose

### Low

- Documentation fix: https://github.com/BerriAI/litellm-docs/pull/1252
- The earlier provider fix was checked from source only
- This PR fixes remaining custom examples and AIM classification

## Final Attestation

- [ ] The tests check the right things, including edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
