### PR TITLE
feat(ui): make automatic auto-router setup discoverable and show what it configured

### DIFF
--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
@@ -60,16 +60,24 @@ const optionByLabel = (label: string): HTMLElement | undefined =>
 
 const isOptionDisabled = (option: HTMLElement): boolean => option.getAttribute("aria-disabled") === "true";
 
-// A tier's models are the chips in its multi-select, reachable by the placeholder on that row's
-// input. Nothing accessible enumerates the chips as a set, so they are collected by the data-slot
-// the combobox primitive sets and read back off the label each chip carries.
-const tierModels = (tier: string): string[] => {
+// A tier's multi-select renders as a toolbar holding one labelled chip per selected model, and its
+// own input carries the row's placeholder as a label. That placeholder is what tells the tiers
+// apart, so the toolbar is found by which one contains it.
+const tierChips = (tier: string): HTMLElement => {
+  const placeholder = `Select model(s) for ${tier.toLowerCase()} queries`;
   const chips = screen
-    .getByLabelText(`Select model(s) for ${tier.toLowerCase()} queries`)
-    .closest('[data-slot="combobox-chips"]') as HTMLElement;
-  return [...chips.querySelectorAll('[data-slot="combobox-chip"]')].map(
-    (chip) => chip.getAttribute("aria-label") ?? "",
-  );
+    .getAllByRole("toolbar")
+    .find((candidate) => within(candidate).queryByLabelText(placeholder) !== null);
+  if (!chips) throw new Error(`No tier row found for "${tier}"`);
+  return chips;
+};
+
+const expectTierModel = (tier: string, model: string): void => {
+  expect(within(tierChips(tier)).getByLabelText(model)).toBeInTheDocument();
+};
+
+const expectTierMissingModel = (tier: string, model: string): void => {
+  expect(within(tierChips(tier)).queryByLabelText(model)).not.toBeInTheDocument();
 };
 
 const selectTemplate = async (label: string): Promise<void> => {
@@ -200,10 +208,12 @@ describe("AddAutoRouterTab", () => {
     const button = await screen.findByTestId("configure-automatically-button");
     await userEvent.click(button);
 
-    expect(tierModels("Simple")).toEqual(["gpt-5.6-luna"]);
-    expect(tierModels("Medium")).toEqual(["claude-sonnet-5"]);
-    expect(tierModels("Complex")).toEqual(["claude-opus-5"]);
-    expect(tierModels("Reasoning")).toEqual(["claude-opus-5"]);
+    expectTierModel("Simple", "gpt-5.6-luna");
+    expectTierModel("Medium", "claude-sonnet-5");
+    expectTierModel("Complex", "claude-opus-5");
+    expectTierModel("Reasoning", "claude-opus-5");
+    // The cheap model is what the mix is proving: it must not have leaked onto the top tiers.
+    expectTierMissingModel("Complex", "gpt-5.6-luna");
     expect(toast.success).not.toHaveBeenCalledWith(expect.stringContaining("Configured with"));
   });
 
@@ -220,16 +230,18 @@ describe("AddAutoRouterTab", () => {
     const button = await screen.findByTestId("configure-automatically-button");
     await userEvent.click(button);
 
-    expect(tierModels("Simple")).toEqual(["gpt-5.6-luna"]);
-    expect(tierModels("Medium")).toEqual(["claude-sonnet-5"]);
-    expect(tierModels("Complex")).toEqual(["gpt-5.6-sol"]);
-    expect(tierModels("Reasoning")).toEqual(["gpt-5.6-sol"]);
+    expectTierModel("Simple", "gpt-5.6-luna");
+    expectTierModel("Medium", "claude-sonnet-5");
+    expectTierModel("Complex", "gpt-5.6-sol");
+    expectTierModel("Reasoning", "gpt-5.6-sol");
+    expectTierMissingModel("Complex", "gpt-5.6-luna");
   });
 
   // The whole point of the button is that a caller can see what it filled in, so it opens Detailed
   // Configuration rather than leaving the tiers behind a collapsed summary.
   it("opens Detailed Configuration on the tiers automatic setup just filled in", async () => {
-    mockFetchAvailableModels.mockResolvedValue(ALL_FAMILY_MODELS);
+    const simpleModel = "gpt-5.6-luna";
+    mockFetchAvailableModels.mockResolvedValue([...ALL_FAMILY_MODELS, { model_group: simpleModel, mode: "chat" }]);
     renderWithProviders(<Harness />);
 
     expect(screen.queryByText("Complexity Tier Configuration")).not.toBeInTheDocument();
@@ -237,7 +249,7 @@ describe("AddAutoRouterTab", () => {
     await userEvent.click(await screen.findByTestId("configure-automatically-button"));
 
     expect(screen.getByText("Complexity Tier Configuration")).toBeInTheDocument();
-    expect(tierModels("Simple")).not.toHaveLength(0);
+    expectTierModel("Simple", simpleModel);
   });
 
   // Nothing is filled in, so there is nothing to submit. The button reports that itself instead of

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
@@ -60,9 +60,6 @@ const optionByLabel = (label: string): HTMLElement | undefined =>
 
 const isOptionDisabled = (option: HTMLElement): boolean => option.getAttribute("aria-disabled") === "true";
 
-// A tier's multi-select renders as a toolbar holding one labelled chip per selected model, and its
-// own input carries the row's placeholder as a label. That placeholder is what tells the tiers
-// apart, so the toolbar is found by which one contains it.
 const tierChips = (tier: string): HTMLElement => {
   const placeholder = `Select model(s) for ${tier.toLowerCase()} queries`;
   const chips = screen
@@ -212,7 +209,6 @@ describe("AddAutoRouterTab", () => {
     expectTierModel("Medium", "claude-sonnet-5");
     expectTierModel("Complex", "claude-opus-5");
     expectTierModel("Reasoning", "claude-opus-5");
-    // The cheap model is what the mix is proving: it must not have leaked onto the top tiers.
     expectTierMissingModel("Complex", "gpt-5.6-luna");
     expect(toast.success).not.toHaveBeenCalledWith(expect.stringContaining("Configured with"));
   });
@@ -237,8 +233,6 @@ describe("AddAutoRouterTab", () => {
     expectTierMissingModel("Complex", "gpt-5.6-luna");
   });
 
-  // The whole point of the button is that a caller can see what it filled in, so it opens Detailed
-  // Configuration rather than leaving the tiers behind a collapsed summary.
   it("opens Detailed Configuration on the tiers automatic setup just filled in", async () => {
     const simpleModel = "gpt-5.6-luna";
     mockFetchAvailableModels.mockResolvedValue([...ALL_FAMILY_MODELS, { model_group: simpleModel, mode: "chat" }]);

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
@@ -70,11 +70,8 @@ const tierChips = (tier: string): HTMLElement => {
 };
 
 const expectTierModel = (tier: string, model: string): void => {
-  expect(within(tierChips(tier)).getByLabelText(model)).toBeInTheDocument();
-};
-
-const expectTierMissingModel = (tier: string, model: string): void => {
-  expect(within(tierChips(tier)).queryByLabelText(model)).not.toBeInTheDocument();
+  const chips = within(tierChips(tier)).getAllByLabelText(/.+/, { selector: '[data-slot="combobox-chip"]' });
+  expect(chips.map((chip) => chip.getAttribute("aria-label"))).toEqual([model]);
 };
 
 const selectTemplate = async (label: string): Promise<void> => {
@@ -209,7 +206,6 @@ describe("AddAutoRouterTab", () => {
     expectTierModel("Medium", "claude-sonnet-5");
     expectTierModel("Complex", "claude-opus-5");
     expectTierModel("Reasoning", "claude-opus-5");
-    expectTierMissingModel("Complex", "gpt-5.6-luna");
     expect(toast.success).not.toHaveBeenCalledWith(expect.stringContaining("Configured with"));
   });
 
@@ -230,7 +226,6 @@ describe("AddAutoRouterTab", () => {
     expectTierModel("Medium", "claude-sonnet-5");
     expectTierModel("Complex", "gpt-5.6-sol");
     expectTierModel("Reasoning", "gpt-5.6-sol");
-    expectTierMissingModel("Complex", "gpt-5.6-luna");
   });
 
   it("opens Detailed Configuration on the tiers automatic setup just filled in", async () => {

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
@@ -60,6 +60,18 @@ const optionByLabel = (label: string): HTMLElement | undefined =>
 
 const isOptionDisabled = (option: HTMLElement): boolean => option.getAttribute("aria-disabled") === "true";
 
+// A tier's models are the chips in its multi-select, reachable by the placeholder on that row's
+// input. Nothing accessible enumerates the chips as a set, so they are collected by the data-slot
+// the combobox primitive sets and read back off the label each chip carries.
+const tierModels = (tier: string): string[] => {
+  const chips = screen
+    .getByLabelText(`Select model(s) for ${tier.toLowerCase()} queries`)
+    .closest('[data-slot="combobox-chips"]') as HTMLElement;
+  return [...chips.querySelectorAll('[data-slot="combobox-chip"]')].map(
+    (chip) => chip.getAttribute("aria-label") ?? "",
+  );
+};
+
 const selectTemplate = async (label: string): Promise<void> => {
   await userEvent.click(optionByLabel(label)!);
 };
@@ -188,11 +200,10 @@ describe("AddAutoRouterTab", () => {
     const button = await screen.findByTestId("configure-automatically-button");
     await userEvent.click(button);
 
-    expect(
-      screen.getByText(
-        /Simple: gpt-5.6-luna.*Medium: claude-sonnet-5.*Complex: claude-opus-5.*Reasoning: claude-opus-5/,
-      ),
-    ).toBeInTheDocument();
+    expect(tierModels("Simple")).toEqual(["gpt-5.6-luna"]);
+    expect(tierModels("Medium")).toEqual(["claude-sonnet-5"]);
+    expect(tierModels("Complex")).toEqual(["claude-opus-5"]);
+    expect(tierModels("Reasoning")).toEqual(["claude-opus-5"]);
     expect(toast.success).not.toHaveBeenCalledWith(expect.stringContaining("Configured with"));
   });
 
@@ -209,9 +220,24 @@ describe("AddAutoRouterTab", () => {
     const button = await screen.findByTestId("configure-automatically-button");
     await userEvent.click(button);
 
-    expect(
-      screen.getByText(/Simple: gpt-5.6-luna.*Medium: claude-sonnet-5.*Complex: gpt-5.6-sol.*Reasoning: gpt-5.6-sol/),
-    ).toBeInTheDocument();
+    expect(tierModels("Simple")).toEqual(["gpt-5.6-luna"]);
+    expect(tierModels("Medium")).toEqual(["claude-sonnet-5"]);
+    expect(tierModels("Complex")).toEqual(["gpt-5.6-sol"]);
+    expect(tierModels("Reasoning")).toEqual(["gpt-5.6-sol"]);
+  });
+
+  // The whole point of the button is that a caller can see what it filled in, so it opens Detailed
+  // Configuration rather than leaving the tiers behind a collapsed summary.
+  it("opens Detailed Configuration on the tiers automatic setup just filled in", async () => {
+    mockFetchAvailableModels.mockResolvedValue(ALL_FAMILY_MODELS);
+    renderWithProviders(<Harness />);
+
+    expect(screen.queryByText("Complexity Tier Configuration")).not.toBeInTheDocument();
+
+    await userEvent.click(await screen.findByTestId("configure-automatically-button"));
+
+    expect(screen.getByText("Complexity Tier Configuration")).toBeInTheDocument();
+    expect(tierModels("Simple")).not.toHaveLength(0);
   });
 
   // Nothing is filled in, so there is nothing to submit. The button reports that itself instead of

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
@@ -207,10 +207,10 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const [selectedPreset, setSelectedPreset] = useState<string | undefined>(undefined);
-  // Closed by default: a caller opens it deliberately, either by clicking it or by choosing Custom
-  // (which expands it automatically, since there's nothing else to show them their config from). A
-  // preset re-collapses it after prefilling, offering the same "here's what got filled in, expand to
-  // change it" affordance. A caller can always toggle it manually at any point.
+  // Closed by default, and opened by a deliberate act: clicking it, choosing Custom, or running
+  // automatic setup. The latter two expand it so the tiers they just filled in are visible. A
+  // preset re-collapses it after prefilling, since its own label already says what got applied.
+  // A caller can always toggle it manually at any point.
   const [detailsExpanded, setDetailsExpanded] = useState<boolean>(false);
 
   const [isRoutingTestVisible, setIsRoutingTestVisible] = useState<boolean>(false);
@@ -335,7 +335,7 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
     if (automaticRouterConfig === null) return;
     setSelectedPreset(undefined);
     applyPrefill({ ...buildEmptyPrefill(), complexityRouterConfig: automaticRouterConfig });
-    setDetailsExpanded(false);
+    setDetailsExpanded(true);
     toast.success("Automatic setup created", { description: tierConfigSummary(automaticRouterConfig) });
   };
 

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
@@ -207,10 +207,6 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const [selectedPreset, setSelectedPreset] = useState<string | undefined>(undefined);
-  // Closed by default, and opened by a deliberate act: clicking it, choosing Custom, or running
-  // automatic setup. The latter two expand it so the tiers they just filled in are visible. A
-  // preset re-collapses it after prefilling, since its own label already says what got applied.
-  // A caller can always toggle it manually at any point.
   const [detailsExpanded, setDetailsExpanded] = useState<boolean>(false);
 
   const [isRoutingTestVisible, setIsRoutingTestVisible] = useState<boolean>(false);

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
@@ -543,14 +543,15 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
                 </FormField>
 
                 {!automaticSetupLoading && automaticRouterConfig && (
-                  <button
-                    type="button"
-                    className="mt-3 rounded-sm text-sm font-medium text-blue-600 hover:text-blue-700 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
-                    data-testid="configure-automatically-button"
-                    onClick={handleAutomaticSetup}
-                  >
-                    Configure automatically
-                  </button>
+                  <div className="mt-5 flex flex-wrap items-center justify-between gap-3 rounded-lg border border-border bg-muted px-4 py-3">
+                    <div>
+                      <p className="text-sm font-medium text-foreground">Not sure where to start?</p>
+                      <p className="text-sm text-muted-foreground">Let us pick models for each complexity tier.</p>
+                    </div>
+                    <Button type="button" data-testid="configure-automatically-button" onClick={handleAutomaticSetup}>
+                      Configure automatically
+                    </Button>
+                  </div>
                 )}
 
                 <div className="mt-5">


### PR DESCRIPTION
## TLDR

Problem this solves:

- Configure automatically was a faint link, easy to miss
- It filled the tiers, then hid them again

How it solves it:

- The button now sits in a callout saying what it does
- Automatic setup opens Detailed Configuration on the filled tiers

## User Flow

Before: an admin adding an auto router overlooks the small link, and clicking it hides what it picked

1. They open https://litellm-domain/ui/models-and-endpoints/, pick the Auto-Routers tab, and click Add Auto Router
2. Under the name field they see "Configure automatically" as a small blue link, with nothing saying what it will do
3. If they click it, a toast names the four picks, and Detailed Configuration stays collapsed behind a one-line summary
4. To check or change a tier, they click Detailed Configuration to open it

After: the option explains itself, and the tiers stay on screen

1. They open https://litellm-domain/ui/models-and-endpoints/, pick the Auto-Routers tab, and click Add Auto Router
2. Under the name field they see a callout reading "Not sure where to start? Let us pick models for each complexity tier." next to a Configure automatically button
3. They click it, and Detailed Configuration opens showing Simple, Medium, Complex and Reasoning with the model chosen for each
4. They can read or edit any tier without a further click

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Setup for both runs: a proxy on `litellm/proxy/dev_config.yaml` with the dashboard built into it, then log in at http://localhost:4000/ui/, open Models + Endpoints, pick the Auto-Routers tab, and click Add Auto Router

### Before (5f2b4d27d7)

#### The dialog as it opens

1. Open the Add Auto Router dialog
2. Configure automatically is a small blue link under the name field, with no hint of what it does

![Before: plain link](https://raw.githubusercontent.com/BerriAI/litellm/0879db8ef1bbc723073c4e45efb0b28287db7c64/pr_autoconfig_expand/before_link.png)

#### After clicking Configure automatically

1. Click Configure automatically
2. The toast names the picks, but Detailed Configuration is still collapsed and only its summary line shows them

![Before: Detailed Configuration collapsed](https://raw.githubusercontent.com/BerriAI/litellm/0879db8ef1bbc723073c4e45efb0b28287db7c64/pr_autoconfig_expand/before_collapsed.png)

### After (fbca24d8eb)

#### The dialog as it opens

1. Open the Add Auto Router dialog
2. A callout reads "Not sure where to start? Let us pick models for each complexity tier." next to a Configure automatically button

![After: callout banner](https://raw.githubusercontent.com/BerriAI/litellm/1f1030aa25bb8c71c076858779c2b301ca35c3d0/pr_autoconfig_expand/p2-fbca24d8eb/after_banner.png)

#### After clicking Configure automatically

1. Click Configure automatically
2. Detailed Configuration opens on the filled tiers, with anthropic-haiku-4-5 on Simple and anthropic-sonnet-5 on Medium

![After: Simple and Medium tiers filled](https://raw.githubusercontent.com/BerriAI/litellm/1f1030aa25bb8c71c076858779c2b301ca35c3d0/pr_autoconfig_expand/p2-fbca24d8eb/after_tiers_top.png)

3. Scroll the dialog down
4. Complex and Reasoning both carry anthropic-sonnet-5, Reasoning at max effort, and Default Model reads "Derived from tiers: anthropic-sonnet-5". Each of the four tiers contains exactly one model. No router was submitted

![After: Complex and Reasoning tiers filled](https://raw.githubusercontent.com/BerriAI/litellm/1f1030aa25bb8c71c076858779c2b301ca35c3d0/pr_autoconfig_expand/p2-fbca24d8eb/after_tiers_bottom.png)

## Validation

68 auto-router tests pass. ESLint, formatting, and all UI lint budgets pass locally; no-node-access remains 707/707. Injecting an extra model independently into each of the four tiers fails both tier-selection tests. The previous presence-only assertions missed the Simple, Medium, and Reasoning mutations. This follow-up changes tests only

## Type

Bug Fix

## Caveats (if any)

### Low

- Presets still collapse it; only automatic setup changed
- Tier assertions compare exact chip lists, rejecting unexpected extra models

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard-only UX and local state for the add auto-router form; no API, auth, or routing logic changes.
> 
> **Overview**
> **Automatic setup** on Add Auto Router is easier to find and shows its results immediately. The faint “Configure automatically” link is replaced with a bordered callout (“Not sure where to start?”) and a primary **Configure automatically** button.
> 
> Clicking automatic setup now **expands Detailed Configuration** (`setDetailsExpanded(true)`) so Simple/Medium/Complex/Reasoning chips are visible right away; preset selection behavior is unchanged.
> 
> Tests add `tierChips` / `expectTierModel` helpers, assert per-tier combobox chips instead of a collapsed summary regex, and cover that automatic setup opens Detailed Configuration with the filled Simple tier.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbca24d8ebba8ff6dec3883282023bc2b10d70f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

