### PR TITLE
fix(azure): send the resolved Entra ID token on image generation requests

### DIFF
--- a/litellm/llms/azure/azure.py
+++ b/litellm/llms/azure/azure.py
@@ -46,7 +46,9 @@ from .common_utils import (
     AzureOpenAIError,
     BaseAzureLLM,
     get_azure_ad_token_from_oidc,
+    get_azure_request_auth_headers,
     process_azure_headers,
+    redact_azure_auth_headers,
     select_azure_base_url_or_endpoint,
 )
 from .image_generation import (
@@ -1142,7 +1144,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
         api_key: str,
         input: list,
         logging_obj: LiteLLMLoggingObj,
-        headers: dict,
+        headers: dict[str, str],
         client=None,
         timeout=None,
         model: str | None = None,
@@ -1167,7 +1169,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                 additional_args={
                     "complete_input_dict": data,
                     "api_base": img_gen_api_base,
-                    "headers": headers,
+                    "headers": redact_azure_auth_headers(headers),
                 },
             )
             httpx_response: Final[httpx.Response] = await self.make_async_azure_httpx_request(
@@ -1226,7 +1228,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
         timeout: float,
         optional_params: dict,
         logging_obj: LiteLLMLoggingObj,
-        headers: dict,
+        headers: dict[str, str],
         model: str | None = None,
         api_key: str | None = None,
         api_base: str | None = None,
@@ -1261,20 +1263,21 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
             if not isinstance(max_retries, int):
                 raise AzureOpenAIError(status_code=422, message="max retries must be an int")
 
-            if api_key is None and azure_ad_token_provider is not None:
-                azure_ad_token = azure_ad_token_provider()
-                if azure_ad_token:
-                    headers.pop("api-key", None)
-                    headers["Authorization"] = f"Bearer {azure_ad_token}"
-
-            # init AzureOpenAI Client
+            auth_params: Final[dict[str, object]] = {**(litellm_params or {})}  # mutable-ok: SDK init takes a dict
+            if azure_ad_token is not None:
+                auth_params["azure_ad_token"] = azure_ad_token
+            if azure_ad_token_provider is not None:
+                auth_params["azure_ad_token_provider"] = azure_ad_token_provider
             azure_client_params: Final[dict[str, object]] = self.initialize_azure_sdk_client(
-                litellm_params=litellm_params or {},
+                litellm_params=auth_params,
                 api_key=api_key,
                 model_name=model or "",
                 api_version=api_version,
                 api_base=api_base,
                 is_async=False,
+            )
+            request_headers: Final = dict(  # mutable-ok: the httpx request helpers take a dict
+                get_azure_request_auth_headers(headers=headers, azure_client_params=azure_client_params)
             )
             if aimg_generation is True:
                 return self.aimage_generation(
@@ -1286,7 +1289,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                     client=client,
                     azure_client_params=azure_client_params,
                     timeout=timeout,
-                    headers=headers,
+                    headers=request_headers,
                     model=model,
                 )
 
@@ -1303,7 +1306,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                 additional_args={
                     "complete_input_dict": data,
                     "api_base": img_gen_api_base,
-                    "headers": headers,
+                    "headers": redact_azure_auth_headers(request_headers),
                 },
             )
             httpx_response: Final[httpx.Response] = self.make_sync_azure_httpx_request(
@@ -1313,7 +1316,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                 api_version=api_version or "",
                 api_key=api_key or "",
                 data=data,
-                headers=headers,
+                headers=request_headers,
                 deployment_name=model,
             )
             provider_config: Final = get_azure_image_generation_config(data.get("model", "dall-e-2"))

--- a/litellm/llms/azure/common_utils.py
+++ b/litellm/llms/azure/common_utils.py
@@ -95,6 +95,11 @@ def _cached_entra_id_token_provider(
     return get_bearer_token_provider(ClientSecretCredential(tenant_id, client_id, client_secret), scope)
 
 
+@lru_cache(maxsize=128)
+def _cached_azure_ad_token_refresh_provider(scope: str) -> Callable[[], str]:
+    return get_azure_ad_token_provider(azure_scope=scope)
+
+
 def get_azure_ad_token_from_entra_id(
     tenant_id: str,
     client_id: str,
@@ -649,9 +654,7 @@ class BaseAzureLLM(BaseOpenAILLM):
                 "Using Azure AD token provider based on Service Principal with Secret workflow for Azure Auth"
             )
             try:
-                azure_ad_token_provider = get_azure_ad_token_provider(
-                    azure_scope=scope,
-                )
+                azure_ad_token_provider = _cached_azure_ad_token_refresh_provider(scope)
             except ValueError:
                 verbose_logger.debug("Azure AD Token Provider could not be used.")
         if api_version is None:

--- a/litellm/llms/azure/common_utils.py
+++ b/litellm/llms/azure/common_utils.py
@@ -405,6 +405,41 @@ def get_azure_ad_token(
     return azure_ad_token
 
 
+_AZURE_AUTH_HEADER_NAMES: Final = frozenset(("api-key", "authorization"))
+_REDACTED_AZURE_HEADER_VALUE: Final = "***REDACTED***"
+
+
+def _resolve_azure_ad_token(azure_client_params: Mapping[str, object]) -> str | None:
+    azure_ad_token: Final = azure_client_params.get("azure_ad_token")
+    if isinstance(azure_ad_token, str) and azure_ad_token:
+        return azure_ad_token
+    token_provider: Final = azure_client_params.get("azure_ad_token_provider")
+    provided_token: Final = token_provider() if callable(token_provider) else None
+    return provided_token if isinstance(provided_token, str) and provided_token else None
+
+
+def get_azure_request_auth_headers(
+    headers: Mapping[str, str],
+    azure_client_params: Mapping[str, object],
+) -> Mapping[str, str]:
+    if any(name.lower() in _AZURE_AUTH_HEADER_NAMES for name in headers):
+        return headers
+    azure_ad_token: Final = _resolve_azure_ad_token(azure_client_params)
+    if azure_ad_token is not None:
+        return MappingProxyType({**headers, "Authorization": f"Bearer {azure_ad_token}"})
+    api_key: Final = azure_client_params.get("api_key")
+    if isinstance(api_key, str) and api_key:
+        return MappingProxyType({**headers, "api-key": api_key})
+    return headers
+
+
+def redact_azure_auth_headers(headers: Mapping[str, str]) -> Mapping[str, str]:
+    return {  # mutable-ok: logging callbacks JSON-serialize this copy
+        name: (_REDACTED_AZURE_HEADER_VALUE if name.lower() in _AZURE_AUTH_HEADER_NAMES else value)
+        for name, value in headers.items()
+    }
+
+
 class BaseAzureLLM(BaseOpenAILLM):
     @staticmethod
     def _try_get_default_azure_credential_provider(

--- a/tests/test_litellm/llms/azure/image_generation/test_azure_image_generation_init.py
+++ b/tests/test_litellm/llms/azure/image_generation/test_azure_image_generation_init.py
@@ -11,6 +11,7 @@ import litellm
 from litellm.caching.llm_caching_handler import LLMClientCache
 from litellm.llms.azure.azure import AzureChatCompletion
 from litellm.llms.azure.common_utils import (
+    _cached_azure_ad_token_refresh_provider,
     _cached_entra_id_token_provider,
     get_azure_request_auth_headers,
     redact_azure_auth_headers,
@@ -773,6 +774,52 @@ def test_azure_image_generation_with_api_key_keeps_api_key_header(
     assert fake_entra_id == []
     assert response.data[0].b64_json == "aaaa"
     assert logging_obj.pre_call.call_args.kwargs["additional_args"]["headers"]["api-key"] == "***REDACTED***"
+
+
+@pytest.fixture
+def fake_default_azure_credential(monkeypatch: pytest.MonkeyPatch):
+    built_credentials = []
+
+    class FakeDefaultAzureCredential:
+        def __init__(self) -> None:
+            built_credentials.append(self)
+
+    for name in ("AZURE_TENANT_ID", "AZURE_CLIENT_ID", "AZURE_CLIENT_SECRET", "AZURE_CREDENTIAL", "AZURE_AD_TOKEN"):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setattr("azure.identity.DefaultAzureCredential", FakeDefaultAzureCredential)
+    monkeypatch.setattr(
+        "azure.identity.get_bearer_token_provider", lambda credential, scope: lambda: "default-credential-token"
+    )
+    monkeypatch.setattr(litellm, "enable_azure_ad_token_refresh", True)
+    _cached_azure_ad_token_refresh_provider.cache_clear()
+    yield built_credentials
+    _cached_azure_ad_token_refresh_provider.cache_clear()
+
+
+def test_azure_image_generation_token_refresh_reuses_credential_across_requests(
+    respx_mock: respx.MockRouter, fake_default_azure_credential: list
+):
+    api_base = "https://my-resource.openai.azure.com"
+    api_version = "2025-04-01-preview"
+    route = _mock_image_generation_route(respx_mock, api_base, "gpt-image-1")
+
+    for _ in range(3):
+        AzureChatCompletion().image_generation(
+            prompt="a cat",
+            timeout=60.0,
+            optional_params={"n": 1, "size": "1024x1024"},
+            logging_obj=MagicMock(),
+            headers={"Content-Type": "application/json"},
+            model="gpt-image-1",
+            api_key=None,
+            api_base=api_base,
+            api_version=api_version,
+            litellm_params={"api_base": api_base, "api_version": api_version},
+        )
+
+    assert route.call_count == 3
+    assert all(call.request.headers["Authorization"] == "Bearer default-credential-token" for call in route.calls)
+    assert len(fake_default_azure_credential) == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/test_litellm/llms/azure/image_generation/test_azure_image_generation_init.py
+++ b/tests/test_litellm/llms/azure/image_generation/test_azure_image_generation_init.py
@@ -10,6 +10,11 @@ import respx
 import litellm
 from litellm.caching.llm_caching_handler import LLMClientCache
 from litellm.llms.azure.azure import AzureChatCompletion
+from litellm.llms.azure.common_utils import (
+    _cached_entra_id_token_provider,
+    get_azure_request_auth_headers,
+    redact_azure_auth_headers,
+)
 from litellm.llms.azure.image_generation.http_utils import (
     azure_deployment_image_generation_json_body,
 )
@@ -587,3 +592,247 @@ def test_azure_image_generation_v1_route_base_model_vs_deployment_name(respx_moc
     sent_body = json.loads(request.content)
     assert sent_body["model"] == model
     assert sent_body["prompt"] == prompt
+
+
+@pytest.fixture
+def fake_entra_id(monkeypatch: pytest.MonkeyPatch):
+    built_credentials = []
+
+    class FakeClientSecretCredential:
+        def __init__(self, tenant_id: str, client_id: str, client_secret: str) -> None:
+            built_credentials.append((tenant_id, client_id, client_secret))
+
+    monkeypatch.setattr("azure.identity.ClientSecretCredential", FakeClientSecretCredential)
+    monkeypatch.setattr("azure.identity.get_bearer_token_provider", lambda credential, scope: lambda: "entra-id-token")
+    _cached_entra_id_token_provider.cache_clear()
+    yield built_credentials
+    _cached_entra_id_token_provider.cache_clear()
+
+
+def _mock_image_generation_route(respx_mock: respx.MockRouter, api_base: str, model: str) -> respx.Route:
+    return respx_mock.post(f"{api_base}/openai/deployments/{model}/images/generations").mock(
+        return_value=httpx.Response(200, json={"created": 1234567890, "data": [{"b64_json": "aaaa"}]})
+    )
+
+
+@pytest.mark.parametrize("credentials_in_litellm_params", [False, True])
+def test_azure_image_generation_keyless_entra_id_sends_bearer_token(
+    respx_mock: respx.MockRouter,
+    monkeypatch: pytest.MonkeyPatch,
+    fake_entra_id: list,
+    credentials_in_litellm_params: bool,
+):
+    for name in ("AZURE_TENANT_ID", "AZURE_CLIENT_ID", "AZURE_CLIENT_SECRET"):
+        monkeypatch.delenv(name, raising=False)
+    api_base = "https://my-resource.openai.azure.com"
+    api_version = "2025-04-01-preview"
+    litellm_params = {"api_base": api_base, "api_version": api_version}
+    if credentials_in_litellm_params:
+        litellm_params.update(
+            tenant_id="tenant-from-params", client_id="client-from-params", client_secret="secret-from-params"
+        )
+        expected_credential = ("tenant-from-params", "client-from-params", "secret-from-params")
+    else:
+        monkeypatch.setenv("AZURE_TENANT_ID", "tenant-from-env")
+        monkeypatch.setenv("AZURE_CLIENT_ID", "client-from-env")
+        monkeypatch.setenv("AZURE_CLIENT_SECRET", "secret-from-env")
+        expected_credential = ("tenant-from-env", "client-from-env", "secret-from-env")
+    route = _mock_image_generation_route(respx_mock, api_base, "gpt-image-1")
+    logging_obj = MagicMock()
+
+    response = AzureChatCompletion().image_generation(
+        prompt="a cat",
+        timeout=60.0,
+        optional_params={"n": 1, "size": "1024x1024"},
+        logging_obj=logging_obj,
+        headers={"Content-Type": "application/json"},
+        model="gpt-image-1",
+        api_key=None,
+        api_base=api_base,
+        api_version=api_version,
+        litellm_params=litellm_params,
+    )
+
+    request = route.calls.last.request
+    assert request.headers["Authorization"] == "Bearer entra-id-token"
+    assert "api-key" not in request.headers
+    assert fake_entra_id == [expected_credential]
+    assert response.data[0].b64_json == "aaaa"
+    logged_headers = logging_obj.pre_call.call_args.kwargs["additional_args"]["headers"]
+    assert logged_headers == {"Content-Type": "application/json", "Authorization": "***REDACTED***"}
+    assert "entra-id-token" not in str(logging_obj.pre_call.call_args)
+
+
+@pytest.mark.asyncio
+async def test_azure_aimage_generation_keyless_entra_id_sends_bearer_token(
+    respx_mock: respx.MockRouter, monkeypatch: pytest.MonkeyPatch, fake_entra_id: list
+):
+    monkeypatch.setattr(litellm, "disable_aiohttp_transport", True)
+    monkeypatch.setattr(litellm, "in_memory_llm_clients_cache", LLMClientCache())
+    api_base = "https://my-resource.openai.azure.com"
+    api_version = "2025-04-01-preview"
+    route = _mock_image_generation_route(respx_mock, api_base, "gpt-image-1")
+    logging_obj = MagicMock()
+
+    response = await AzureChatCompletion().image_generation(
+        prompt="a cat",
+        timeout=60.0,
+        optional_params={"n": 1, "size": "1024x1024"},
+        logging_obj=logging_obj,
+        headers={"Content-Type": "application/json"},
+        model="gpt-image-1",
+        api_key=None,
+        api_base=api_base,
+        api_version=api_version,
+        aimg_generation=True,
+        litellm_params={
+            "api_base": api_base,
+            "api_version": api_version,
+            "tenant_id": "tenant-from-params",
+            "client_id": "client-from-params",
+            "client_secret": "secret-from-params",
+        },
+    )
+
+    request = route.calls.last.request
+    assert request.headers["Authorization"] == "Bearer entra-id-token"
+    assert "api-key" not in request.headers
+    assert fake_entra_id == [("tenant-from-params", "client-from-params", "secret-from-params")]
+    assert response.data[0].b64_json == "aaaa"
+    logged_headers = logging_obj.pre_call.call_args.kwargs["additional_args"]["headers"]
+    assert logged_headers == {"Content-Type": "application/json", "Authorization": "***REDACTED***"}
+    assert "entra-id-token" not in str(logging_obj.pre_call.call_args)
+
+
+@pytest.mark.parametrize(
+    "credential_kwargs, expected_authorization",
+    [
+        ({"azure_ad_token": "static-ad-token"}, "Bearer static-ad-token"),
+        ({"azure_ad_token_provider": lambda: "provider-token"}, "Bearer provider-token"),
+    ],
+)
+def test_azure_image_generation_explicit_azure_ad_credential_sends_bearer_token(
+    respx_mock: respx.MockRouter,
+    monkeypatch: pytest.MonkeyPatch,
+    credential_kwargs: dict,
+    expected_authorization: str,
+):
+    for name in ("AZURE_TENANT_ID", "AZURE_CLIENT_ID", "AZURE_CLIENT_SECRET"):
+        monkeypatch.delenv(name, raising=False)
+    api_base = "https://my-resource.openai.azure.com"
+    api_version = "2025-04-01-preview"
+    route = _mock_image_generation_route(respx_mock, api_base, "gpt-image-1")
+
+    response = AzureChatCompletion().image_generation(
+        prompt="a cat",
+        timeout=60.0,
+        optional_params={"n": 1, "size": "1024x1024"},
+        logging_obj=MagicMock(),
+        headers={"Content-Type": "application/json"},
+        model="gpt-image-1",
+        api_key=None,
+        api_base=api_base,
+        api_version=api_version,
+        litellm_params={"api_base": api_base, "api_version": api_version},
+        **credential_kwargs,
+    )
+
+    request = route.calls.last.request
+    assert request.headers["Authorization"] == expected_authorization
+    assert "api-key" not in request.headers
+    assert response.data[0].b64_json == "aaaa"
+
+
+def test_azure_image_generation_with_api_key_keeps_api_key_header(
+    respx_mock: respx.MockRouter, monkeypatch: pytest.MonkeyPatch, fake_entra_id: list
+):
+    monkeypatch.setenv("AZURE_TENANT_ID", "tenant-from-env")
+    monkeypatch.setenv("AZURE_CLIENT_ID", "client-from-env")
+    monkeypatch.setenv("AZURE_CLIENT_SECRET", "secret-from-env")
+    api_base = "https://my-resource.openai.azure.com"
+    api_version = "2025-04-01-preview"
+    route = _mock_image_generation_route(respx_mock, api_base, "gpt-image-1")
+    logging_obj = MagicMock()
+
+    response = AzureChatCompletion().image_generation(
+        prompt="a cat",
+        timeout=60.0,
+        optional_params={"n": 1, "size": "1024x1024"},
+        logging_obj=logging_obj,
+        headers={"Content-Type": "application/json", "api-key": "sk-test"},
+        model="gpt-image-1",
+        api_key="sk-test",
+        api_base=api_base,
+        api_version=api_version,
+        litellm_params={"api_base": api_base, "api_version": api_version},
+    )
+
+    request = route.calls.last.request
+    assert request.headers["api-key"] == "sk-test"
+    assert "Authorization" not in request.headers
+    assert fake_entra_id == []
+    assert response.data[0].b64_json == "aaaa"
+    assert logging_obj.pre_call.call_args.kwargs["additional_args"]["headers"]["api-key"] == "***REDACTED***"
+
+
+@pytest.mark.parametrize(
+    "caller_auth_header",
+    [{"api-key": "caller-key"}, {"Authorization": "Bearer caller-token"}, {"authorization": "Bearer caller-token"}],
+)
+def test_get_azure_request_auth_headers_keeps_caller_auth_header(caller_auth_header: dict):
+    headers = {"Content-Type": "application/json", **caller_auth_header}
+    azure_client_params = {
+        "api_key": "sk-resolved",
+        "azure_ad_token": "resolved-token",
+        "azure_ad_token_provider": lambda: "provider-token",
+    }
+    assert get_azure_request_auth_headers(headers=headers, azure_client_params=azure_client_params) is headers
+
+
+def test_get_azure_request_auth_headers_prefers_azure_ad_token_over_provider_and_api_key():
+    headers = {"Content-Type": "application/json"}
+    azure_client_params = {
+        "api_key": "sk-resolved",
+        "azure_ad_token": "static-token",
+        "azure_ad_token_provider": lambda: "provider-token",
+    }
+    out = get_azure_request_auth_headers(headers=headers, azure_client_params=azure_client_params)
+    assert dict(out) == {"Content-Type": "application/json", "Authorization": "Bearer static-token"}
+    assert headers == {"Content-Type": "application/json"}
+
+
+def test_get_azure_request_auth_headers_uses_token_provider_over_api_key():
+    azure_client_params = {"api_key": "sk-resolved", "azure_ad_token": None, "azure_ad_token_provider": lambda: "pt"}
+    out = get_azure_request_auth_headers(headers={}, azure_client_params=azure_client_params)
+    assert dict(out) == {"Authorization": "Bearer pt"}
+
+
+def test_get_azure_request_auth_headers_falls_back_to_api_key():
+    azure_client_params = {"api_key": "sk-resolved", "azure_ad_token": None, "azure_ad_token_provider": None}
+    out = get_azure_request_auth_headers(headers={"Content-Type": "application/json"}, azure_client_params=azure_client_params)
+    assert dict(out) == {"Content-Type": "application/json", "api-key": "sk-resolved"}
+
+
+@pytest.mark.parametrize(
+    "azure_client_params",
+    [
+        {},
+        {"api_key": "", "azure_ad_token": "", "azure_ad_token_provider": None},
+        {"azure_ad_token_provider": lambda: None},
+        {"azure_ad_token_provider": lambda: ""},
+    ],
+)
+def test_get_azure_request_auth_headers_without_credential_leaves_headers_unchanged(azure_client_params: dict):
+    headers = {"Content-Type": "application/json"}
+    assert get_azure_request_auth_headers(headers=headers, azure_client_params=azure_client_params) is headers
+
+
+def test_redact_azure_auth_headers_masks_only_credential_values():
+    headers = {"Content-Type": "application/json", "api-key": "sk-secret", "authorization": "Bearer secret"}
+    assert redact_azure_auth_headers(headers) == {
+        "Content-Type": "application/json",
+        "api-key": "***REDACTED***",
+        "authorization": "***REDACTED***",
+    }
+    assert headers["api-key"] == "sk-secret"
+    assert headers["authorization"] == "Bearer secret"

--- a/tests/test_litellm/llms/azure/test_azure_common_utils.py
+++ b/tests/test_litellm/llms/azure/test_azure_common_utils.py
@@ -9,6 +9,7 @@ import pytest
 import litellm
 from litellm.llms.azure.common_utils import (
     BaseAzureLLM,
+    _cached_azure_ad_token_refresh_provider,
     _cached_entra_id_token_provider,
     get_azure_ad_token,
     get_azure_ad_token_from_entra_id,
@@ -34,6 +35,7 @@ def setup_mocks(monkeypatch):
     monkeypatch.delenv("AZURE_TENANT_ID", raising=False)
     monkeypatch.delenv("AZURE_SCOPE", raising=False)
     monkeypatch.delenv("AZURE_AD_TOKEN", raising=False)
+    _cached_azure_ad_token_refresh_provider.cache_clear()
 
     with (
         patch(
@@ -78,6 +80,7 @@ def setup_mocks(monkeypatch):
             "logger": mock_logger,
             "select_url": mock_select_url,
         }
+    _cached_azure_ad_token_refresh_provider.cache_clear()
 
 
 def test_initialize_with_api_key(setup_mocks):


### PR DESCRIPTION
## TLDR

Problem this solves:

- Azure image generation sent no credential when the deployment has no `api_key`
- Entra ID / managed identity worked for chat, but `/v1/images/generations` returned 401

How it solves it:

- Resolve the credential the way the chat path does, then put it on the httpx request
- New helper turns that credential into an `Authorization: Bearer` (or `api-key`) header
- Logging metadata gets a redacted copy of the headers, never the token
- With `enable_azure_ad_token_refresh`, the resolved token provider is cached per scope, so the credential and its token are reused across image requests instead of being rebuilt on every call (the chat path already gets this from its cached SDK client)

## User Flow

Before: an operator whose Azure deployments authenticate with Entra ID (no `api_key`) gets a 401 on image generation while chat works

1. They deploy `azure/gpt-image-2` with only `api_base`, and `AZURE_TENANT_ID` / `AZURE_CLIENT_ID` / `AZURE_CLIENT_SECRET` in the proxy's environment
2. They send POST https://litellm-domain/v1/chat/completions with an Azure chat model on the same credentials and get a 200
3. They send POST https://litellm-domain/v1/images/generations with `{"model": "gpt-image-2", "prompt": "a cat"}`
4. They get a 401 whose body says `AzureException AuthenticationError - Access denied due to invalid subscription key or wrong API endpoint`

After: the same image request returns the image

1. They deploy `azure/gpt-image-2` with only `api_base`, and `AZURE_TENANT_ID` / `AZURE_CLIENT_ID` / `AZURE_CLIENT_SECRET` in the proxy's environment
2. They send POST https://litellm-domain/v1/chat/completions with an Azure chat model on the same credentials and get a 200
3. They send POST https://litellm-domain/v1/images/generations with `{"model": "gpt-image-2", "prompt": "a cat"}`
4. They get a 200 whose `data[0].b64_json` holds the generated image

## Relevant issues

Fixes #16422
Fixes #37727 (the `azure/` image-generation half; the `azure_ai` half landed in #35415)

## Affected release

## Linear ticket

Resolves LIT-7168

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live runs against a real Azure OpenAI resource with a `gpt-image-1-mini` deployment (image generation) and a `gpt-5.4-nano` deployment (chat control, so each proxy proves its Entra ID credentials are good on a path that already worked). Each leg boots two proxies with `--num_workers 2` from the same commit: proxy A has `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, and `AZURE_API_BASE` in its environment, proxy B has only `AZURE_API_BASE` plus an `az login` user session and sets `enable_azure_ad_token_refresh: true`, so it covers the `DefaultAzureCredential` path. No `api_key` anywhere. Before leg at the merge base 4b3355bdc6, after leg at the tip 66ebc722d6, same configs, same requests, same order

```yaml
# proxy A
model_list:
  - model_name: gpt-image-1-mini-env-creds      # credentials only in the environment, nothing on the deployment
    litellm_params:
      model: azure/gpt-image-1-mini
      api_base: os.environ/AZURE_API_BASE
      api_version: "2025-04-01-preview"
  - model_name: gpt-image-1-mini-params-creds   # the shape from the issue report
    litellm_params:
      model: azure/gpt-image-1-mini
      api_base: os.environ/AZURE_API_BASE
      api_version: "2025-04-01-preview"
      tenant_id: os.environ/AZURE_TENANT_ID
      client_id: os.environ/AZURE_CLIENT_ID
      client_secret: os.environ/AZURE_CLIENT_SECRET
  - model_name: gpt-5.4-nano
    litellm_params:
      model: azure/gpt-5.4-nano
      api_base: os.environ/AZURE_API_BASE
      api_version: "2025-04-01-preview"
general_settings:
  master_key: sk-qa
```

```yaml
# proxy B
model_list:
  - model_name: gpt-image-1-mini-token-refresh
    litellm_params:
      model: azure/gpt-image-1-mini
      api_base: os.environ/AZURE_API_BASE
      api_version: "2025-04-01-preview"
  - model_name: gpt-5.4-nano
    litellm_params:
      model: azure/gpt-5.4-nano
      api_base: os.environ/AZURE_API_BASE
      api_version: "2025-04-01-preview"
litellm_settings:
  enable_azure_ad_token_refresh: true
general_settings:
  master_key: sk-qa
```

Requests used for every case (only `model` and the port change):

```bash
curl -s -o resp.json -w '%{http_code}\n' http://localhost:$PORT/v1/images/generations \
  -H "Authorization: Bearer sk-qa" -H "Content-Type: application/json" \
  -d '{"model":"<model_name>","prompt":"a small red cube on a white background","size":"1024x1024","n":1,"quality":"low"}'
curl -s -o resp.json -w '%{http_code}\n' http://localhost:$PORT/v1/chat/completions \
  -H "Authorization: Bearer sk-qa" -H "Content-Type: application/json" \
  -d '{"model":"gpt-5.4-nano","messages":[{"role":"user","content":"say hi in three words"}]}'
```

### Before (4b3355bdc6)

Proxy A (service principal in the environment, port 35953) and proxy B (`enable_azure_ad_token_refresh`, port 57042), both `--num_workers 2`

```
## chat_env (/v1/chat/completions model=gpt-5.4-nano) -> 200
   content= 'Hello there friend'
## image_env_creds (/v1/images/generations model=gpt-image-1-mini-env-creds) -> 401
    {"error": {"message": "litellm.AuthenticationError: AzureException AuthenticationError - {\"error\":{\"code\":\"401\",\"message\":\"Access denied due to invalid subscription key or wrong API endpoint. Make sure to provide a valid key for an active subscription and use a correct regional API endpoint for your resource.\"}}. Received Model Group=gpt-image-1-mini-env-creds\nAvailable Model Group Fallbacks=None", "type": "None", "param": "None", "code": "401"}}
## image_params_creds (/v1/images/generations model=gpt-image-1-mini-params-creds) -> 200
   created=1788918013 data_len=1 b64_json_chars=1480148
## chat_token_refresh (/v1/chat/completions model=gpt-5.4-nano) -> 200
   content= 'Hi there today!'
## image_token_refresh (/v1/images/generations model=gpt-image-1-mini-token-refresh) -> 401
    {"error": {"message": "litellm.AuthenticationError: AzureException AuthenticationError - {\"error\":{\"code\":\"401\",\"message\":\"Access denied due to invalid subscription key or wrong API endpoint. Make sure to provide a valid key for an active subscription and use a correct regional API endpoint for your resource.\"}}. Received Model Group=gpt-image-1-mini-token-refresh\nAvailable Model Group Fallbacks=None", "type": "None", "param": "None", "code": "401"}}
```

### After (66ebc722d6)

Proxy A (service principal in the environment, port 31241) and proxy B (`enable_azure_ad_token_refresh`, port 20786), both `--num_workers 2`

```
## chat_env (/v1/chat/completions model=gpt-5.4-nano) -> 200
   content= 'Hello there friend.'
## image_env_creds (/v1/images/generations model=gpt-image-1-mini-env-creds) -> 200
   created=1788921229 data_len=1 b64_json_chars=1539328
## image_params_creds (/v1/images/generations model=gpt-image-1-mini-params-creds) -> 200
   created=1788921241 data_len=1 b64_json_chars=1546868
## chat_token_refresh (/v1/chat/completions model=gpt-5.4-nano) -> 200
   content= 'Hello there friend'
## image_token_refresh (/v1/images/generations model=gpt-image-1-mini-token-refresh) -> 200
   created=1788921261 data_len=1 b64_json_chars=1562984
```

Observations from the run:

- `params-creds` already worked at the merge base; env-only and token-refresh did not
- No `api-key` or `Authorization` value appears in either proxy's logs
- `tests/image_gen_tests` Azure cases, `tests/llm_translation` Azure image cases, and the PR's tests pass at the tip locally
- An earlier after leg at 91761d984d gave the same five 200s; it was re-run after the token provider cache commit
- OpenAI SDK: image 401 on main 1f6e5b60b5, 200 once merged

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Workload identity federation and managed identity were not exercised live (the QA account uses a client secret and an `az login` session); they flow through the same `get_azure_ad_token_provider` resolution the chat path already uses in production, and the change only touches what happens after that credential exists
- `get_azure_request_auth_headers` prefers a token provider over `api_key` when both are present, the same precedence the Azure OpenAI SDK applies in `_prepare_options`. `litellm.image_generation` stamps `api-key` into the headers whenever a key exists, so through the public API the key still wins; only direct callers of `AzureChatCompletion.image_generation` that pass both and no auth header see the token instead
- A caller-supplied `api-key` / `Authorization` header is now left as is; before, an explicit `azure_ad_token_provider` replaced a caller's `api-key`
- The cached `enable_azure_ad_token_refresh` provider is keyed by scope only, so the credential type inferred from `AZURE_CREDENTIAL` / `AZURE_CLIENT_ID` at first use stays for the life of the process, the same as the existing Entra ID provider cache and the hour-long SDK client cache on the chat path
- The credential is resolved once in `image_generation` (its only caller); on the async path that runs in the executor thread, so the token fetch never blocks the event loop. Calling `AzureChatCompletion.aimage_generation` directly still expects ready-to-send headers, as before
- `headers` on `AzureChatCompletion.image_generation` is now typed `dict[str, str]`

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Azure authentication header assembly for image generation only; api-key behavior is preserved when present, but credential precedence and caller-header handling shifted slightly.
> 
> **Overview**
> Fixes **401s on Azure image generation** when deployments authenticate with Entra ID (no `api_key`) while chat on the same credentials already worked. The httpx image path never got the credential that `initialize_azure_sdk_client` already resolves.
> 
> **`get_azure_request_auth_headers`** (in `common_utils`) builds outbound headers: respect caller `api-key` / `Authorization` if present, else `Authorization: Bearer` from static token, token provider, or `api-key` from resolved params. **`redact_azure_auth_headers`** masks those values in `pre_call` logging.
> 
> **`image_generation`** folds explicit `azure_ad_token` / `azure_ad_token_provider` into SDK init params, builds **`request_headers` once** for sync/async httpx calls, and drops the old provider-only header hack. Header typing is tightened to `dict[str, str]`.
> 
> Tests cover keyless Entra ID (env vs `litellm_params`), async path, explicit AD credentials, api-key regression, header precedence, and redaction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91761d984d55b2e4729e38c36ef7c7510c9ffc76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

- [x] 91761d984d passes /live-pr-risk
- [x] 66ebc722d6 passes /live-pr-risk

