### PR TITLE
ci: prepare workflows for main default branch

### DIFF
--- a/.github/workflows/publish-basedpyright-base-counts.yml
+++ b/.github/workflows/publish-basedpyright-base-counts.yml
@@ -1,6 +1,6 @@
 name: Publish basedpyright base counts
 
-# Every commit on litellm_internal_staging is some branch's future merge-base.
+# Every commit on main or litellm_internal_staging can become a future merge-base.
 # Publishing its per-rule basedpyright counts as an artifact lets
 # scripts/type_check_gate.py download them in seconds instead of paying a
 # 60-110s second basedpyright pass on every fresh worktree or moved merge-base.
@@ -10,13 +10,13 @@ name: Publish basedpyright base counts
 on:
   push:
     branches:
+      - main
       - litellm_internal_staging
   workflow_dispatch:
     inputs:
       ref:
-        description: "Ref to compute and publish base counts for"
+        description: "Ref to compute and publish base counts for (defaults to the workflow run's commit)"
         required: false
-        default: litellm_internal_staging
 
 permissions:
   contents: read

--- a/.github/workflows/sync-together-ai-models.yml
+++ b/.github/workflows/sync-together-ai-models.yml
@@ -13,10 +13,12 @@ jobs:
   sync_together_ai_models:
     if: github.repository == 'BerriAI/litellm'
     runs-on: ubuntu-latest
+    env:
+      BASE_BRANCH: ${{ github.event.repository.default_branch }}
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
-          ref: litellm_internal_staging
+          ref: ${{ env.BASE_BRANCH }}
           persist-credentials: false
       - name: Set up uv
         uses: ./.github/actions/setup-uv-with-retries
@@ -63,6 +65,6 @@ jobs:
           gh pr create --title "feat(models): sync together_ai model registry" \
             --body-file "$RUNNER_TEMP/pr_body.md" \
             --head "$branch" \
-            --base litellm_internal_staging
+            --base "$BASE_BRANCH"
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}

--- a/.github/workflows/test-litellm-ui-unit.yml
+++ b/.github/workflows/test-litellm-ui-unit.yml
@@ -12,6 +12,7 @@ on:
       - "litellm_**"
   push:
     branches:
+      - main
       - litellm_internal_staging
 
 concurrency:


### PR DESCRIPTION
## TLDR

Problem this solves:

- Main pushes miss full UI tests and lint-count publication
- Model synchronization remains tied to internal staging

How it solves it:

- Enable both push workflows on main and staging
- Make synchronization follow the repository's default branch
- Let manual lint-count publication use the selected run commit

## User Flow

Before: maintainers changing the default branch would leave automation targeting staging

1. A maintainer merges changes into main
2. The Actions page has no full UI unit-test or lint-count publication run from that push
3. Scheduled model synchronization still opens its PR against staging

After: once this change reaches main, the workflows support either default branch

1. A maintainer merges changes into main
2. The Actions page includes full UI unit-test and lint-count publication runs
3. Scheduled model synchronization opens its PR against the repository's current default branch

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [ ] I have added meaningful tests
- [x] Changed workflows pass actionlint and Zizmor; repository workflow startup, naming, and directory checks pass
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of 5/5 for the current head

## Screenshots / Proof of Fix

These are source-validation results. Post-cutover main push behavior has not been exercised, and the repository default remains staging

### Before (6908318c168cf50d750b3535fc3a2e4def0abf8e)

1. The UI unit and lint-count publisher push filters contain only staging
2. The publisher's manual ref input defaults to staging
3. Together AI synchronization checks out staging and uses it as the PR base

### After (edeb93e727135b43bd5c50c25630279ea34a1502)

1. Both push filters include main and staging
2. Omitting the publisher's manual ref uses the workflow run's commit, while explicit overrides remain supported
3. Together AI synchronization uses the same repository-default value for checkout and PR creation
4. All 50 workflows were scanned: no staging-only PR or push filters remain, job identities are unchanged, and guard-main-branch.yml is byte-for-byte unchanged
5. Actionlint 1.7.7 and Zizmor 1.24.1 pass for all three changed workflows. Repository workflow startup, job-name collision, and directory hygiene checks also pass

No new test file was added for the YAML-only change. The local pre-commit command has no checks matching these files, so its no-op result is not counted as validation

## Type

Infrastructure

## Caveats (if any)

### Low

- Main's guard and repository settings remain unchanged
- Existing synchronization PRs still require separate retargeting
- External repository workflows belong to a later migration phase
- Main push execution remains pending promotion to main

## Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
