### PR TITLE
fix(spend_logs): strip the partitioned PK rewrite in any DDL formatting

### DIFF
--- a/litellm-proxy-extras/litellm_proxy_extras/utils.py
+++ b/litellm-proxy-extras/litellm_proxy_extras/utils.py
@@ -7,8 +7,9 @@ import subprocess
 import tempfile
 import time
 from dataclasses import dataclass, replace
+from itertools import accumulate
 from pathlib import Path
-from typing import Optional
+from typing import Final, NamedTuple, Optional
 
 from litellm_proxy_extras import prisma_toolchain
 from litellm_proxy_extras._logging import logger
@@ -79,11 +80,6 @@ class _MigrateAttemptBudget:
         return replace(self, recoveries=self.recoveries | {recovery})
 
 
-# Prisma qualifies DDL with the datasource schema when it is not the default,
-# which LiteLLM supports through the `schema` URL parameter (see
-# _prisma_schema_param). Match the qualified and bare spellings alike, plus the
-# ONLY that dump-shaped scripts carry, so the guard below does not depend on
-# which one the drift script happens to use.
 _QUALIFIED_SPEND_LOGS = r'(?:ONLY\s+)?(?:(?:"[^"]+"|\w+)\s*\.\s*)?"LiteLLM_SpendLogs'
 _SPEND_LOGS_ALTER_RE = re.compile(
     r'^ALTER\s+TABLE\s+' + _QUALIFIED_SPEND_LOGS + r'"\s', re.IGNORECASE
@@ -116,33 +112,40 @@ def _without_sql_comments(statement: str) -> str:
     ).strip()
 
 
-def _split_alter_clauses(body: str) -> list[str]:
-    """Split an ALTER TABLE clause list on its top-level commas.
+class _ClauseScan(NamedTuple):
+    depth: int
+    in_identifier: bool
+    in_string: bool
+    ends_clause: bool
 
-    Commas inside parentheses (`PRIMARY KEY ("request_id", "startTime")`) and
-    inside quoted identifiers separate nothing, so only depth-zero commas
-    outside quotes end a clause. Splitting on the comma itself rather than on
-    `",\n"` keeps the guard working whichever way the drift script wraps
-    lines -- one clause per line, all on one line, or with trailing spaces.
-    """
-    clauses = []
-    depth = 0
-    quoted = False
-    start = 0
-    for i, ch in enumerate(body):
-        if ch == '"':
-            quoted = not quoted
-        elif quoted:
-            continue
-        elif ch == "(":
-            depth += 1
-        elif ch == ")":
-            depth -= 1
-        elif ch == "," and depth == 0:
-            clauses.append(body[start:i])
-            start = i + 1
-    clauses.append(body[start:])
-    return clauses
+
+_CLAUSE_SCAN_START: Final = _ClauseScan(0, False, False, False)
+
+
+def _scan_clause_char(state: _ClauseScan, char: str) -> _ClauseScan:
+    if state.in_string:
+        return _ClauseScan(state.depth, False, char != "'", False)
+    if state.in_identifier:
+        return _ClauseScan(state.depth, char != '"', False, False)
+    if char == "'":
+        return _ClauseScan(state.depth, False, True, False)
+    if char == '"':
+        return _ClauseScan(state.depth, True, False, False)
+    if char == "(":
+        return _ClauseScan(state.depth + 1, False, False, False)
+    if char == ")":
+        return _ClauseScan(state.depth - 1, False, False, False)
+    return _ClauseScan(state.depth, False, False, char == "," and state.depth == 0)
+
+
+def _split_alter_clauses(body: str) -> tuple[str, ...]:
+    """Split an ALTER TABLE clause list on its top-level commas, ignoring those
+    inside parentheses, quoted identifiers and string literals."""
+    scans: Final = tuple(accumulate(body, _scan_clause_char, initial=_CLAUSE_SCAN_START))
+    separators: Final = tuple(i for i, scan in enumerate(scans[1:]) if scan.ends_clause)
+    starts: Final = (0,) + tuple(i + 1 for i in separators)
+    ends: Final = separators + (len(body),)
+    return tuple(body[start:end] for start, end in zip(starts, ends))
 
 
 def _without_spend_logs_pk_clauses(statement: str) -> Optional[str]:

--- a/litellm-proxy-extras/litellm_proxy_extras/utils.py
+++ b/litellm-proxy-extras/litellm_proxy_extras/utils.py
@@ -79,9 +79,17 @@ class _MigrateAttemptBudget:
         return replace(self, recoveries=self.recoveries | {recovery})
 
 
-_SPEND_LOGS_ALTER_RE = re.compile(r'^ALTER\s+TABLE\s+"LiteLLM_SpendLogs"\s', re.IGNORECASE)
+# Prisma qualifies DDL with the datasource schema when it is not the default,
+# which LiteLLM supports through the `schema` URL parameter (see
+# _prisma_schema_param). Match the qualified and bare spellings alike, plus the
+# ONLY that dump-shaped scripts carry, so the guard below does not depend on
+# which one the drift script happens to use.
+_QUALIFIED_SPEND_LOGS = r'(?:ONLY\s+)?(?:(?:"[^"]+"|\w+)\s*\.\s*)?"LiteLLM_SpendLogs'
+_SPEND_LOGS_ALTER_RE = re.compile(
+    r'^ALTER\s+TABLE\s+' + _QUALIFIED_SPEND_LOGS + r'"\s', re.IGNORECASE
+)
 _SPEND_LOGS_ARTIFACT_DROP_RE = re.compile(
-    r'^DROP\s+TABLE\s+"LiteLLM_SpendLogs_[^"]*"', re.IGNORECASE
+    r'^DROP\s+TABLE\s+' + _QUALIFIED_SPEND_LOGS + r'_[^"]*"', re.IGNORECASE
 )
 _SPEND_LOGS_PK_CLAUSE_RE = re.compile(
     r'^(?:DROP\s+CONSTRAINT\s+"[^"]*_pkey"'
@@ -108,14 +116,44 @@ def _without_sql_comments(statement: str) -> str:
     ).strip()
 
 
+def _split_alter_clauses(body: str) -> list[str]:
+    """Split an ALTER TABLE clause list on its top-level commas.
+
+    Commas inside parentheses (`PRIMARY KEY ("request_id", "startTime")`) and
+    inside quoted identifiers separate nothing, so only depth-zero commas
+    outside quotes end a clause. Splitting on the comma itself rather than on
+    `",\n"` keeps the guard working whichever way the drift script wraps
+    lines -- one clause per line, all on one line, or with trailing spaces.
+    """
+    clauses = []
+    depth = 0
+    quoted = False
+    start = 0
+    for i, ch in enumerate(body):
+        if ch == '"':
+            quoted = not quoted
+        elif quoted:
+            continue
+        elif ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+        elif ch == "," and depth == 0:
+            clauses.append(body[start:i])
+            start = i + 1
+    clauses.append(body[start:])
+    return clauses
+
+
 def _without_spend_logs_pk_clauses(statement: str) -> Optional[str]:
     prefix_match = _SPEND_LOGS_ALTER_RE.match(statement)
     if not prefix_match:
         return statement
     kept = tuple(
-        clause.strip()
-        for clause in statement[prefix_match.end():].split(",\n")
-        if not _SPEND_LOGS_PK_CLAUSE_RE.match(clause.strip())
+        stripped
+        for clause in _split_alter_clauses(statement[prefix_match.end():])
+        for stripped in (clause.strip(),)
+        if stripped and not _SPEND_LOGS_PK_CLAUSE_RE.match(stripped)
     )
     if not kept:
         return None

--- a/tests/litellm-proxy-extras/test_litellm_proxy_extras_utils.py
+++ b/tests/litellm-proxy-extras/test_litellm_proxy_extras_utils.py
@@ -531,6 +531,83 @@ class TestPartitionedSpendLogsDriftFilter:
         assert 'PRIMARY KEY ("team_id")' in filtered
 
 
+    # The clause list is not always one clause per line: whether a drift script
+    # wraps, pads, or schema-qualifies is formatting, and the primary-key
+    # rewrite is rejected by Postgres either way.
+    _PK_ADD = 'ADD CONSTRAINT "LiteLLM_SpendLogs_pkey" PRIMARY KEY ("request_id")'
+
+    @pytest.mark.parametrize(
+        "statement",
+        [
+            pytest.param(
+                'ALTER TABLE "LiteLLM_SpendLogs" DROP CONSTRAINT '
+                '"LiteLLM_SpendLogs_pkey", ' + _PK_ADD + ";\n",
+                id="clauses-on-one-line",
+            ),
+            pytest.param(
+                'ALTER TABLE "LiteLLM_SpendLogs" DROP CONSTRAINT '
+                '"LiteLLM_SpendLogs_pkey",  \n' + _PK_ADD + ";\n",
+                id="trailing-space-before-newline",
+            ),
+            pytest.param(
+                'ALTER TABLE "LiteLLM_SpendLogs" DROP CONSTRAINT '
+                '"LiteLLM_SpendLogs_pkey",\r\n' + _PK_ADD + ";\r\n",
+                id="crlf-line-endings",
+            ),
+            pytest.param(
+                'ALTER TABLE "public"."LiteLLM_SpendLogs" DROP CONSTRAINT '
+                '"LiteLLM_SpendLogs_pkey",\n' + _PK_ADD + ";\n",
+                id="quoted-schema-qualified",
+            ),
+            pytest.param(
+                'ALTER TABLE litellm."LiteLLM_SpendLogs" DROP CONSTRAINT '
+                '"LiteLLM_SpendLogs_pkey", ' + _PK_ADD + ";\n",
+                id="bare-schema-qualified",
+            ),
+            pytest.param(
+                'ALTER TABLE ONLY "LiteLLM_SpendLogs" DROP CONSTRAINT '
+                '"LiteLLM_SpendLogs_pkey", ' + _PK_ADD + ";\n",
+                id="only-prefix",
+            ),
+        ],
+    )
+    def test_the_pk_rewrite_is_removed_however_the_script_is_formatted(self, statement):
+        assert filter_partitioned_spend_logs_diff(statement).strip() == ""
+
+    def test_a_schema_qualified_runbook_artifact_drop_is_removed(self):
+        sql = 'DROP TABLE "public"."LiteLLM_SpendLogs_legacy";\n'
+        assert filter_partitioned_spend_logs_diff(sql).strip() == ""
+
+    def test_column_work_survives_when_it_shares_a_line_with_the_pk_rewrite(self):
+        sql = (
+            'ALTER TABLE "LiteLLM_SpendLogs" DROP CONSTRAINT "LiteLLM_SpendLogs_pkey", '
+            'ADD COLUMN "created_at" TIMESTAMP(3), ' + self._PK_ADD + ";\n"
+        )
+        filtered = filter_partitioned_spend_logs_diff(sql)
+        assert 'ADD COLUMN "created_at" TIMESTAMP(3)' in filtered
+        assert "PRIMARY KEY" not in filtered
+        assert "DROP CONSTRAINT" not in filtered
+
+    def test_a_composite_pk_is_one_clause_not_two(self):
+        """The comma inside PRIMARY KEY ("request_id", "startTime") is not a
+        clause separator; splitting there would leave a `"startTime")` fragment
+        that no longer matches the primary-key pattern and would survive."""
+        sql = (
+            'ALTER TABLE "LiteLLM_SpendLogs" ADD CONSTRAINT "LiteLLM_SpendLogs_pkey" '
+            'PRIMARY KEY ("request_id", "startTime");\n'
+        )
+        assert filter_partitioned_spend_logs_diff(sql).strip() == ""
+
+    def test_other_tables_are_untouched_when_schema_qualified(self):
+        sql = (
+            'ALTER TABLE "public"."LiteLLM_TeamTable" DROP CONSTRAINT '
+            '"LiteLLM_TeamTable_pkey", ADD CONSTRAINT "LiteLLM_TeamTable_pkey" '
+            'PRIMARY KEY ("team_id");\n'
+        )
+        filtered = filter_partitioned_spend_logs_diff(sql)
+        assert 'PRIMARY KEY ("team_id")' in filtered
+        assert 'DROP CONSTRAINT "LiteLLM_TeamTable_pkey"' in filtered
+
 class _FakeCompleted:
     stdout = ""
     stderr = ""

--- a/tests/litellm-proxy-extras/test_litellm_proxy_extras_utils.py
+++ b/tests/litellm-proxy-extras/test_litellm_proxy_extras_utils.py
@@ -598,6 +598,16 @@ class TestPartitionedSpendLogsDriftFilter:
         )
         assert filter_partitioned_spend_logs_diff(sql).strip() == ""
 
+    def test_a_comma_inside_a_string_default_is_not_a_clause_separator(self):
+        """Splitting inside a quoted default would rewrite the value Postgres stores."""
+        sql = (
+            'ALTER TABLE "LiteLLM_SpendLogs" ADD COLUMN "tags" TEXT DEFAULT \'a,b\', '
+            'DROP CONSTRAINT "LiteLLM_SpendLogs_pkey";\n'
+        )
+        filtered = filter_partitioned_spend_logs_diff(sql)
+        assert "DEFAULT 'a,b'" in filtered
+        assert "DROP CONSTRAINT" not in filtered
+
     def test_other_tables_are_untouched_when_schema_qualified(self):
         sql = (
             'ALTER TABLE "public"."LiteLLM_TeamTable" DROP CONSTRAINT '


### PR DESCRIPTION
## TLDR

Problem this solves:

- Spend-log partitioning guard misses most DDL spellings
- Schema-qualified tables slip past it entirely
- Proxy then fails to start after upgrade

How it solves it:

- Split ALTER clauses on top-level commas, not newlines
- Accept an optional schema qualifier and ONLY

## User Flow

Before: an operator who partitioned spend logs on a non-default database schema cannot restart the proxy after upgrading.

1. They follow the documented spend-log partitioning runbook, and their `DATABASE_URL` ends in `?schema=litellm`
2. They pull a newer proxy image and restart it
3. Startup schema reconciliation stops on `ERROR: unique constraint on partitioned table must include all partitioning columns`
4. The run stops there, so part of the upgrade landed and the rest did not
5. The proxy does not come up; requests to `https://litellm-domain/v1/chat/completions` fail until someone fixes the database by hand

After: the same restart completes and the proxy serves traffic.

1. They follow the documented spend-log partitioning runbook, and their `DATABASE_URL` ends in `?schema=litellm`
2. They pull a newer proxy image and restart it
3. Startup schema reconciliation leaves the partitioned primary key alone and applies the rest of the script
4. Columns added by the upgrade are present, and the partitioning survives
5. The proxy comes up; requests to `https://litellm-domain/v1/chat/completions` return 200

## Relevant issues

Related to #40119, which reports this failure on v1.98.0. The guard that prevents it shipped in v1.100.0, so that report is already addressed on `litellm_internal_staging`; this PR closes the formatting gaps that remain in that guard rather than fixing #40119 itself.

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile Confidence Score of at least 4/5

## Screenshots / Proof of Fix

Real PostgreSQL 16.2. A database built by applying every shipped migration in order, then partitioned with the documented runbook, leaving the composite key `PRIMARY KEY (request_id, "startTime")`.

Shared setup — the drift script used in both runs, in the schema-qualified, single-line spelling:

```sql
ALTER TABLE "LiteLLM_BudgetTable" ADD COLUMN "e2e_probe" TEXT;

ALTER TABLE "public"."LiteLLM_SpendLogs" DROP CONSTRAINT "LiteLLM_SpendLogs_pkey", ADD COLUMN "e2e_probe" TEXT, ADD CONSTRAINT "LiteLLM_SpendLogs_pkey" PRIMARY KEY ("request_id");

DROP TABLE "public"."LiteLLM_SpendLogs_legacy";
```

### Before (3244a03)

1. Filter the script through the guard. The rewrite and the artifact drop both survive:
   ```sql
   ALTER TABLE "LiteLLM_BudgetTable" ADD COLUMN "e2e_probe" TEXT;
   ALTER TABLE "public"."LiteLLM_SpendLogs" DROP CONSTRAINT "LiteLLM_SpendLogs_pkey", ADD COLUMN "e2e_probe" TEXT, ADD CONSTRAINT "LiteLLM_SpendLogs_pkey" PRIMARY KEY ("request_id");
   DROP TABLE "public"."LiteLLM_SpendLogs_legacy";
   ```
2. Apply it: `psql "$URL" -v ON_ERROR_STOP=1 -f drift.sql`
   ```
   ALTER TABLE
   psql:drift.sql:3: ERROR:  unique constraint on partitioned table must include all partitioning columns
   DETAIL:  PRIMARY KEY constraint on table "LiteLLM_SpendLogs" lacks column "startTime" which is part of the partition key.
   ```
3. The run stops midway, leaving the database half migrated: the statement before the failure committed, the spend-log work did not.
   ```
   SpendLogs e2e_probe: 0
   BudgetTable e2e_probe: 1
   legacy table present: 1
   ```

### After (dacdefc)

1. Filter the same script through the guard. Only the real work is left:
   ```sql
   ALTER TABLE "LiteLLM_BudgetTable" ADD COLUMN "e2e_probe" TEXT;
   ALTER TABLE "public"."LiteLLM_SpendLogs" ADD COLUMN "e2e_probe" TEXT;
   ```
2. Apply it: `psql "$URL" -v ON_ERROR_STOP=1 -f drift.sql`
   ```
   ALTER TABLE
   ALTER TABLE
   ```
3. The whole script lands and the partitioning survives:
   ```
   SpendLogs PK: PRIMARY KEY (request_id, "startTime")
   SpendLogs e2e_probe: 1
   BudgetTable e2e_probe: 1
   legacy table present: 1
   still partitioned: 1
   ```

Coverage of the spellings, each confirmed against the same live database:

| Statement form | Before | After |
| --- | --- | --- |
| clauses on one line | rewrite survives | stripped |
| trailing space before newline | rewrite survives | stripped |
| `"public"."LiteLLM_SpendLogs"` | rewrite survives | stripped |
| `litellm."LiteLLM_SpendLogs"` | rewrite survives | stripped |
| `ALTER TABLE ONLY` | rewrite survives | stripped |
| one clause per line | stripped | stripped |
| CRLF line endings | stripped | stripped |
| DROP and ADD as separate statements | stripped | stripped |

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- Before this fix the abort could leave a half-applied schema
- A schema-qualified artifact drop also slipped the old filter

### Low

- Filtering stays textual; it does not parse SQL
- Only the shipped runbook's table and artifacts are matched

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
