### PR TITLE
fix(baseten): forward reasoning_effort to Baseten Model API

### DIFF
--- a/litellm/llms/baseten/chat.py
+++ b/litellm/llms/baseten/chat.py
@@ -54,6 +54,7 @@ class BasetenConfig(OpenAIGPTConfig):
         return [
             "max_tokens",
             "max_completion_tokens",
+            "reasoning_effort",
             "response_format",
             "seed",
             "stop",

--- a/tests/test_litellm/llms/baseten/chat/test_baseten_completions.py
+++ b/tests/test_litellm/llms/baseten/chat/test_baseten_completions.py
@@ -54,5 +54,50 @@ class TestBasetenModelAPI:
         assert api_key == "test-key"
 
 
+class TestBasetenReasoningEffort:
+    """Test reasoning_effort support for Baseten reasoning models.
+
+    Baseten's Model API accepts a top-level `reasoning_effort` parameter and
+    validates it server-side (invalid values return 400), so LiteLLM should
+    forward it verbatim instead of dropping it:
+    https://docs.baseten.co/inference/model-apis/reasoning
+    """
+
+    def test_reasoning_effort_is_supported(self):
+        """reasoning_effort is advertised as a supported param"""
+        config = BasetenConfig()
+
+        assert "reasoning_effort" in config.get_supported_openai_params(
+            model="moonshotai/Kimi-K3"
+        )
+
+    def test_reasoning_effort_passthrough_with_drop_params(self):
+        """reasoning_effort survives drop_params=True and is forwarded verbatim"""
+        config = BasetenConfig()
+
+        result = config.map_openai_params(
+            non_default_params={"reasoning_effort": "high", "max_tokens": 100},
+            optional_params={},
+            model="deepseek-ai/DeepSeek-V4-Flash-0731",
+            drop_params=True,
+        )
+
+        assert result["reasoning_effort"] == "high"
+        assert result["max_tokens"] == 100
+
+    def test_reasoning_effort_none_passthrough(self):
+        """reasoning_effort="none" (disable thinking) is forwarded verbatim"""
+        config = BasetenConfig()
+
+        result = config.map_openai_params(
+            non_default_params={"reasoning_effort": "none"},
+            optional_params={},
+            model="moonshotai/Kimi-K3",
+            drop_params=True,
+        )
+
+        assert result["reasoning_effort"] == "none"
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
## TLDR

Problem this solves:

- `reasoning_effort` sent to Baseten models never reaches Baseten: LiteLLM silently drops it when `drop_params=True`, and raises "baseten does not support parameters: ['reasoning_effort']" otherwise
- Baseten's Model API supports a top-level `reasoning_effort` and validates it server-side, so callers behind LiteLLM cannot control thinking effort for Kimi K3, DeepSeek V4, GLM 5.3, gpt-oss-120b, etc.

How it solves it:

- Add `reasoning_effort` to the Baseten provider's supported OpenAI params so it is forwarded verbatim
- Baseten returns a clear 400 for values outside a model's supported set, and ignores the param on non-reasoning models, so verbatim passthrough is safe for the whole catalog

## User Flow

Before: a developer routing Kimi K3 through a LiteLLM proxy cannot control thinking effort — the setting never reaches Baseten

1. They send POST https://litellm-domain/v1/chat/completions with `"model": "baseten/moonshotai/Kimi-K3"` and `"reasoning_effort": "high"`
2. The proxy is configured with `drop_params: true`, so the request goes to Baseten without `reasoning_effort`; the model always runs at its default effort (`max` for Kimi K3)
3. The response burns the default amount of reasoning tokens no matter what they asked for; setting `"reasoning_effort": "none"` has no effect either
4. If the proxy does not set `drop_params`, the same request instead fails with an error saying baseten does not support `reasoning_effort`

After: the same request carries `reasoning_effort` to Baseten, and the model thinks at the requested level

1. They send the same POST https://litellm-domain/v1/chat/completions with `"model": "baseten/moonshotai/Kimi-K3"` and `"reasoning_effort": "high"`
2. Baseten receives `reasoning_effort` and Kimi K3 runs at high effort; `"reasoning_effort": "none"` disables thinking and the response contains no `reasoning_content`
3. A value the model does not accept (e.g. `"medium"` on Kimi K3, which takes `none`/`low`/`high`/`max`) comes back as a 400 from Baseten naming the accepted values

## Relevant issues

None filed. Baseten documents the parameter at https://docs.baseten.co/inference/model-apis/reasoning — per-model value sets from that page:

| Model | Supported `reasoning_effort` values |
| --- | --- |
| DeepSeek V4 Pro | `none`, `minimal`, `low`, `medium` (default), `high`, `xhigh`, `max` |
| DeepSeek V4 Pro 0813 | `none`, `low`, `high`, `max` |
| DeepSeek V4 Flash 0731 | `none`, `minimal`, `low`, `medium`, `high` (default), `xhigh`, `max` |
| Kimi K3 | `none`, `low`, `high`, `max` (default) |
| GLM 5.3 / 5.3 Fast / 5.3 Flash | `none`, `low`, `high` (default), `max` |
| GLM 5.2 / 5.2 Fast | `none`, `high`, `max` |
| gpt-oss-120b, Inkling, Inkling Small | `none`, `minimal`, `low`, `medium` (default), `high`, `xhigh`, `max` |

Because the accepted set differs per model, LiteLLM deliberately does not validate the value client-side; Baseten's own 400 is the source of truth. This mirrors how the `hosted_vllm` and `deepseek` providers already expose `reasoning_effort`.

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

I don't hold a Baseten API key, so the proof is at the exact code path the proxy runs (`get_optional_params` with `drop_params=True`), executed against this branch and against its parent commit. Happy to add a live-call capture if a maintainer wants one.

`pytest tests/test_litellm/llms/baseten/chat/test_baseten_completions.py -v` on this branch:

```
tests/test_litellm/llms/baseten/chat/test_baseten_completions.py::TestBasetenRouting::test_routing_logic PASSED
tests/test_litellm/llms/baseten/chat/test_baseten_completions.py::TestBasetenModelAPI::test_model_api_inference PASSED
tests/test_litellm/llms/baseten/chat/test_baseten_completions.py::TestBasetenReasoningEffort::test_reasoning_effort_is_supported PASSED
tests/test_litellm/llms/baseten/chat/test_baseten_completions.py::TestBasetenReasoningEffort::test_reasoning_effort_passthrough_with_drop_params PASSED
tests/test_litellm/llms/baseten/chat/test_baseten_completions.py::TestBasetenReasoningEffort::test_reasoning_effort_none_passthrough PASSED
5 passed
```

Before / after, same interpreter, same call — the only difference is this branch:

```python
>>> import litellm
>>> litellm.get_optional_params(model="moonshotai/Kimi-K3", custom_llm_provider="baseten",
...                             reasoning_effort="high", max_tokens=100, drop_params=True)
# parent commit 6908318c (before):
{'stream': False, 'max_tokens': 100, 'extra_body': {}}
# this branch (after):
{'stream': False, 'max_tokens': 100, 'reasoning_effort': 'high', 'extra_body': {}}
```

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
