### PR TITLE
fix(router): stop queueing Redis increments when no Redis is attached

### DIFF
--- a/litellm/router_strategy/base_routing_strategy.py
+++ b/litellm/router_strategy/base_routing_strategy.py
@@ -74,6 +74,8 @@ class BaseRoutingStrategy(ABC):
             value=value,
             ttl=ttl,
         )
+        if self.dual_cache.redis_cache is None:
+            return result
         increment_op: Final = RedisPipelineIncrementOperation(
             key=key,
             increment_value=value,

--- a/litellm/router_strategy/budget_limiter.py
+++ b/litellm/router_strategy/budget_limiter.py
@@ -389,6 +389,8 @@ class RouterBudgetLimiting(CustomLogger):
             value=response_cost,
             ttl=ttl,
         )
+        if self.dual_cache.redis_cache is None:
+            return
         increment_op: Final = RedisPipelineIncrementOperation(
             key=spend_key,
             increment_value=response_cost,

--- a/tests/proxy_unit_tests/test_unit_test_max_model_budget_limiter.py
+++ b/tests/proxy_unit_tests/test_unit_test_max_model_budget_limiter.py
@@ -1417,3 +1417,50 @@ async def test_spend_logged_on_one_replica_is_enforced_and_reported_on_another()
     replica_c = _PROXY_VirtualKeyModelMaxBudgetLimiter(dual_cache=DualCache(redis_cache=shared_redis))
     with pytest.raises(litellm.BudgetExceededError):
         await replica_c.is_key_within_model_budget(user_api_key, "gpt-4")
+
+
+def _redis_that_holds_nothing():
+    redis_cache = AsyncMock(spec=RedisCache)
+    redis_cache.async_get_cache.return_value = None
+    return redis_cache
+
+
+@pytest.mark.asyncio
+async def test_no_redis_means_no_queued_redis_ops():
+    """Nothing drains the queue without Redis, so a request must not grow it while the counter still moves."""
+    dual_cache = DualCache()
+    limiter = _PROXY_VirtualKeyModelMaxBudgetLimiter(dual_cache=dual_cache)
+    budget = {"gpt-4": {"budget_limit": 10.0, "time_period": "1d"}}
+
+    for _ in range(3):
+        await limiter.async_log_success_event(
+            _success_kwargs(model_group="gpt-4", response_cost=0.5, key_hash="vk-hash", key_model_max_budget=budget),
+            response_obj=None,
+            start_time=None,
+            end_time=None,
+        )
+
+    assert limiter.redis_increment_operation_queue == []
+    usage = await build_model_max_budget_usage(Litellm_EntityType.KEY, "vk-hash", budget, dual_cache)
+    assert usage["gpt-4"]["current_spend"] == 1.5
+
+
+@pytest.mark.asyncio
+async def test_redis_attached_queues_every_increment():
+    dual_cache = DualCache()
+    dual_cache.redis_cache = _redis_that_holds_nothing()
+    limiter = _PROXY_VirtualKeyModelMaxBudgetLimiter(dual_cache=dual_cache)
+    budget = {"gpt-4": {"budget_limit": 10.0, "time_period": "1d"}}
+
+    with patch.object(limiter, "_push_in_memory_increments_to_redis", new_callable=AsyncMock):
+        for _ in range(3):
+            await limiter.async_log_success_event(
+                _success_kwargs(
+                    model_group="gpt-4", response_cost=0.5, key_hash="vk-hash", key_model_max_budget=budget
+                ),
+                response_obj=None,
+                start_time=None,
+                end_time=None,
+            )
+
+    assert [op["increment_value"] for op in limiter.redis_increment_operation_queue] == [0.5, 0.5, 0.5]

--- a/tests/test_litellm/router_strategy/test_base_routing_strategy.py
+++ b/tests/test_litellm/router_strategy/test_base_routing_strategy.py
@@ -146,3 +146,20 @@ async def test_cache_keys_management(base_strategy):
     # Test resetting cache keys
     base_strategy.reset_in_memory_keys_to_update()
     assert len(base_strategy.get_in_memory_keys_to_update()) == 0
+
+
+@pytest.mark.asyncio
+async def test_increment_without_redis_queues_nothing(mock_dual_cache):
+    mock_dual_cache.redis_cache = None
+    strategy = BaseRoutingStrategy(
+        dual_cache=mock_dual_cache,
+        should_batch_redis_writes=False,
+        default_sync_interval=1,
+    )
+
+    for _ in range(3):
+        await strategy._increment_value_in_current_window("test_key", 1.0, 60)
+
+    assert mock_dual_cache.in_memory_cache.async_increment.call_count == 3
+    assert strategy.redis_increment_operation_queue == []
+    assert strategy.get_in_memory_keys_to_update() == set()


### PR DESCRIPTION
## TLDR

Problem this solves:

- Without Redis, every request appends a Redis op nobody drains
- Per-model budget limiter and usage-based-routing-v2 both grow the list forever
- Pod memory climbs one dict per request until restart

How it solves it:

- Skip the queue append when `dual_cache.redis_cache` is None
- In-memory counter still increments, single-pod enforcement unchanged
- Regression tests cover both leak sites plus the Redis-attached path

## User Flow

Before: an operator running a single proxy pod with no Redis sees its memory climb steadily under traffic on keys that carry a per-model budget, and only a restart brings it back down

1. The admin sends POST http://localhost:4000/key/generate with `{"model_max_budget": {"gpt-5.4-mini": {"budget_limit": 1.0, "time_period": "30d"}}}` and gets back a `sk-...` key
2. Their app sends POST http://localhost:4000/v1/chat/completions with that key, thousands of times a day, and every call returns 200 with a normal completion
3. GET http://localhost:4000/key/info with that key shows `current_spend` for `gpt-5.4-mini` climbing as expected
4. Their pod dashboard shows resident memory rising in step with request count and never coming back down, even when traffic stops
5. The pod eventually gets OOM-killed or restarted on a schedule, and the per-model spend counter resets to 0 with it

After: the same pod holds flat memory under the same traffic

1. The admin sends POST http://localhost:4000/key/generate with `{"model_max_budget": {"gpt-5.4-mini": {"budget_limit": 1.0, "time_period": "30d"}}}` and gets back a `sk-...` key
2. Their app sends POST http://localhost:4000/v1/chat/completions with that key, thousands of times a day, and every call returns 200 with a normal completion
3. GET http://localhost:4000/key/info with that key shows `current_spend` for `gpt-5.4-mini` climbing as expected
4. Their pod dashboard shows resident memory flat under load, with nothing accumulating per request

## Relevant issues

Context in #33325 (the cross-replica half of that report was fixed by #39375; this PR closes the memory leak half)

## Linear ticket

Refs LIT-5859

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup. Two proxies, one per commit, each on its own port with no Redis configured, plus a third on the fix with a `coordination_redis` block pointing at a local Redis on port 6399. To observe the queue length from outside the process, each proxy loads a small QA-only callback module (not committed) that registers `GET /debug/budget-queue` and returns `len(model_max_budget_limiter.redis_increment_operation_queue)` and whether Redis is attached

```yaml
model_list:
  - model_name: gpt-5.4-mini
    litellm_params:
      model: openai/gpt-5.4-mini
      api_key: os.environ/OPENAI_API_KEY

general_settings:
  master_key: sk-1234

litellm_settings:
  callbacks:
    - budget_queue_probe.probe
```

The per-arm script, run once per port

```bash
PORT=$1; BASE=http://127.0.0.1:$PORT
KEY=$(curl -s -X POST $BASE/key/generate -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model_max_budget": {"gpt-5.4-mini": {"budget_limit": 1.0, "time_period": "30d"}}}' | jq -r .key)
curl -s -H "Authorization: Bearer sk-1234" $BASE/debug/budget-queue
for i in 1 2 3 4 5; do
  curl -s -X POST $BASE/v1/chat/completions -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
    -d '{"model": "gpt-5.4-mini", "messages": [{"role": "user", "content": "Reply with the single word: ok"}], "max_tokens": 5}' \
    | jq -r '.id + " " + .choices[0].message.content'
done
sleep 4
curl -s -H "Authorization: Bearer sk-1234" $BASE/debug/budget-queue
curl -s -H "Authorization: Bearer $KEY" $BASE/key/info | jq -c .info.model_max_budget_usage
```

### Before (7c1745cc71)

#### No Redis: queue grows by one op per request

1. `litellm --config config_no_redis.yaml --port 4161`
2. `POST /key/generate` returns `{"key": "sk---fZ4J0jn...", "model_max_budget": {"gpt-5.4-mini": {"budget_limit": 1.0, "time_period": "30d"}}}`
3. `GET /debug/budget-queue` before any request: `{"queued_redis_ops": 0, "redis_attached": false}`
4. Five `POST /v1/chat/completions`, all 200 with content `ok`: `chatcmpl-ELbas2AAocjTM6jbB8604HqI8jDiM`, `chatcmpl-ELbatuvm0rVU7ZTfkFf6mruZ4wfDB`, `chatcmpl-ELbatIiBG50qgM2pd2IF1FYJVdX0Y`, `chatcmpl-ELbauRcBQbEViWyirFe8UaBlux0Pa`, `chatcmpl-ELbaurAkA5ISD8JV4bCPip73C3Zs9`
5. `GET /debug/budget-queue` after: `{"queued_redis_ops": 5, "redis_attached": false}`
6. `GET /key/info`: `{"gpt-5.4-mini": {"current_spend": 0.0001, "budget_limit": 1.0, "time_period": "30d"}}`
7. Second batch of five real requests (`chatcmpl-ELbbXerefuRzxQrrlbHF7uitAtRDx` and four more, all `ok`), then `GET /debug/budget-queue`: `{"queued_redis_ops": 10, "redis_attached": false}`. Nothing ever drains it

### After (cc064e0d7b)

#### No Redis: queue stays empty, counter still moves

1. `litellm --config config_no_redis.yaml --port 4162`
2. `POST /key/generate` returns `{"key": "sk-5Tl4LyGc5...", "model_max_budget": {"gpt-5.4-mini": {"budget_limit": 1.0, "time_period": "30d"}}}`
3. `GET /debug/budget-queue` before any request: `{"queued_redis_ops": 0, "redis_attached": false}`
4. Five `POST /v1/chat/completions`, all 200 with content `ok`: `chatcmpl-ELbazZwOp7Vc5UEe3VSAp6Ifwxasg`, `chatcmpl-ELbazVoxGQbCVHOZf1P5oIuH6ZGec`, `chatcmpl-ELbb0elC8Hsy1Y4LNTR8qQfdsYd3B`, `chatcmpl-ELbb0Y1lCgCGm0O1o7nhjbCy0qv20`, `chatcmpl-ELbb1auCrCljA1aoMu19axFpC2zAu`
5. `GET /debug/budget-queue` after: `{"queued_redis_ops": 0, "redis_attached": false}`
6. `GET /key/info`: `{"gpt-5.4-mini": {"current_spend": 0.0001, "budget_limit": 1.0, "time_period": "30d"}}`, same as Before, so enforcement input is unchanged
7. Second batch of five real requests (`chatcmpl-ELbbeX6nP59zgL2xqLzUYwBhABYqz` and four more, all `ok`), then `GET /debug/budget-queue`: `{"queued_redis_ops": 0, "redis_attached": false}`

#### Redis attached: increments still reach Redis

1. `docker run -d --name queue-leak-redis -p 6399:6379 redis:7-alpine`, then `litellm --config config_redis.yaml --port 4163` where the config adds `general_settings.coordination_redis: {host: 127.0.0.1, port: 6399}`
2. `GET /debug/budget-queue` before any request: `{"queued_redis_ops": 0, "redis_attached": true}`
3. Five `POST /v1/chat/completions`, all 200 with content `ok`: `chatcmpl-ELbb6e3ZZP8dWAtmFnHQ9rbpXThO7`, `chatcmpl-ELbb6fnwYhv5kZuxHqBokHAjwBSL6`, `chatcmpl-ELbb7Sx1igiLWIG4tgiD04FAtVDmr`, `chatcmpl-ELbb7bmyfvzaVmu9YQcBGWfJlQ4TC`, `chatcmpl-ELbb8pMftRfDyk1UamwSlBpB0ut0K`
4. `GET /debug/budget-queue` after: `{"queued_redis_ops": 0, "redis_attached": true}` (the hook flushes the queue to Redis right after each request, so it is empty between requests)
5. `docker exec queue-leak-redis redis-cli --scan --pattern 'virtual_key*'` and `get` on each key:

```
virtual_key_spend:9b91d5a8...:gpt-5.4-mini:30d = 0.00013875
virtual_key_budget_start_time:9b91d5a8...:gpt-5.4-mini:30d = 1788818120.585361
```

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Requests served in the window before Redis attaches at startup no longer buffer their ops for a later flush
  - The in-memory counter still records them, so single-pod enforcement is unaffected
  - Only cross-pod visibility of those few early requests is lost, same as any pre-Redis request today

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
