### PR TITLE
fix(vertex): report an unreadable credentials file as a read failure

### DIFF
--- a/litellm/llms/vertex_ai/credentials_source.py
+++ b/litellm/llms/vertex_ai/credentials_source.py
@@ -142,5 +142,5 @@ def raise_vertex_credentials_failure(failure: VertexCredentialsFailure) -> NoRet
                 f"The inline `vertex_credentials` value is not valid JSON: {detail}. "
                 "Check for unescaped newlines in private_key."
             )
-        case _:
+        case _:  # pragma: no cover - exhaustiveness guard, unreachable while the union holds
             assert_never(failure)

--- a/litellm/llms/vertex_ai/credentials_source.py
+++ b/litellm/llms/vertex_ai/credentials_source.py
@@ -15,6 +15,7 @@ from pydantic import TypeAdapter, ValidationError
 from typing_extensions import assert_never
 
 from litellm._logging import verbose_logger
+from litellm.litellm_core_utils.secret_redaction import redact_string
 
 
 @dataclass(frozen=True, slots=True)
@@ -120,17 +121,18 @@ def raise_vertex_credentials_failure(failure: VertexCredentialsFailure) -> NoRet
 
     The caller is told which of the three faults it was; the path goes to the proxy log
     instead, because the message reaches whoever sent the request and the operator who can
-    act on the path is reading the log anyway.
+    act on the path is reading the log anyway. The path is redacted on the way there too, so
+    a credential misconfigured into this field does not become a log entry.
     """
     match failure:
         case VertexCredentialsFileUnreadable(path=path, reason=reason):
-            verbose_logger.error("Vertex: cannot read the credentials file at %s: %s", path, reason)
+            verbose_logger.error("Vertex: cannot read the credentials file at %s: %s", redact_string(path), reason)
             raise ValueError(
                 f"Unable to read the vertex credentials file: {reason}. The proxy log names the path. "
                 "Set `vertex_credentials` to a readable file path, or to the credentials JSON itself."
             )
         case VertexCredentialsFileNotJson(path=path, detail=detail):
-            verbose_logger.error("Vertex: credentials file at %s is not valid JSON: %s", path, detail)
+            verbose_logger.error("Vertex: credentials file at %s is not valid JSON: %s", redact_string(path), detail)
             raise ValueError(
                 f"The vertex credentials file is not valid JSON: {detail}. The proxy log names the path. "
                 "Check for unescaped newlines in private_key."

--- a/litellm/llms/vertex_ai/credentials_source.py
+++ b/litellm/llms/vertex_ai/credentials_source.py
@@ -13,7 +13,7 @@ from typing import Final, NoReturn, TypeAlias
 from pydantic import TypeAdapter, ValidationError
 from typing_extensions import assert_never
 
-from litellm.litellm_core_utils.secret_redaction import redact_string
+from litellm._logging import verbose_logger
 
 
 @dataclass(frozen=True, slots=True)
@@ -47,6 +47,9 @@ VertexCredentialsFailure: TypeAlias = (
     VertexCredentialsFileUnreadable | VertexCredentialsFileNotJson | VertexCredentialsInlineNotJson
 )
 VertexCredentialsSource: TypeAlias = VertexCredentialsJson | VertexCredentialsFailure
+_VertexCredentialsFile: TypeAlias = (
+    VertexCredentialsJson | VertexCredentialsFileUnreadable | VertexCredentialsFileNotJson
+)
 
 
 _JSON_OBJECT_ADAPTER: Final = TypeAdapter(dict[str, object])
@@ -62,6 +65,21 @@ def _parse_json_object(raw: str) -> Mapping[str, object] | _NotAJsonObject:
         return _NotAJsonObject("; ".join(detail["msg"] for detail in e.errors()))
 
 
+def _read_json_file(path: str) -> _VertexCredentialsFile:
+    try:
+        with open(path, encoding="utf-8") as f:
+            contents: Final = f.read()
+    except OSError as e:
+        return VertexCredentialsFileUnreadable(path, f"{e.strerror or e} ({type(e).__name__})")
+    except UnicodeDecodeError:
+        return VertexCredentialsFileNotJson(path, "file is not UTF-8 text")
+
+    parsed: Final = _parse_json_object(contents)
+    if isinstance(parsed, _NotAJsonObject):
+        return VertexCredentialsFileNotJson(path, parsed.detail)
+    return VertexCredentialsJson(parsed)
+
+
 def is_inline_credentials_json(credentials: str) -> bool:
     """Whether *credentials* carries the JSON itself rather than a path to a file holding it."""
     return credentials.lstrip().startswith("{")
@@ -74,42 +92,39 @@ def load_vertex_credentials_source(credentials: str) -> VertexCredentialsSource:
     failure recognisable: `os.path.exists()` answers False for an unreadable path as well as
     an absent one, so both used to reach the inline branch and be reported as malformed JSON.
     """
-    if is_inline_credentials_json(credentials):
-        inline: Final = _parse_json_object(credentials)
-        if isinstance(inline, _NotAJsonObject):
-            return VertexCredentialsInlineNotJson(inline.detail)
+    if not is_inline_credentials_json(credentials):
+        return _read_json_file(credentials)
+
+    inline: Final = _parse_json_object(credentials)
+    if not isinstance(inline, _NotAJsonObject):
         return VertexCredentialsJson(inline)
 
-    try:
-        with open(credentials, encoding="utf-8") as f:
-            contents: Final = f.read()
-    except OSError as e:
-        return VertexCredentialsFileUnreadable(credentials, f"{e.strerror or e} ({type(e).__name__})")
-    except UnicodeDecodeError:
-        return VertexCredentialsFileNotJson(credentials, "file is not UTF-8 text")
-
-    from_file: Final = _parse_json_object(contents)
-    if isinstance(from_file, _NotAJsonObject):
-        return VertexCredentialsFileNotJson(credentials, from_file.detail)
-    return VertexCredentialsJson(from_file)
+    # A file can legitimately be named "{vertex}.json", so a brace-prefixed value that does
+    # not parse is still given the file read it used to get before dispatch moved to shape.
+    from_file: Final = _read_json_file(credentials)
+    if isinstance(from_file, VertexCredentialsJson):
+        return from_file
+    return VertexCredentialsInlineNotJson(inline.detail)
 
 
 def raise_vertex_credentials_failure(failure: VertexCredentialsFailure) -> NoReturn:
-    """Map a load failure onto the ValueError the auth flow already surfaces as a 500.
+    """Map a load failure onto the ValueError the auth flow already surfaces to the caller.
 
-    A path names itself in the message so the operator's log says which file failed. The
-    proxy scrubs filesystem paths out of what it hands back to the API caller, and the value
-    is redacted first so a non-path value misconfigured here cannot leak instead.
+    The caller is told which of the three faults it was; the path goes to the proxy log
+    instead, because the message reaches whoever sent the request and the operator who can
+    act on the path is reading the log anyway.
     """
     match failure:
         case VertexCredentialsFileUnreadable(path=path, reason=reason):
+            verbose_logger.error("Vertex: cannot read the credentials file at %s: %s", path, reason)
             raise ValueError(
-                f"Unable to read the vertex credentials file at {redact_string(path)}: {reason}. "
+                f"Unable to read the vertex credentials file: {reason}. The proxy log names the path. "
                 "Set `vertex_credentials` to a readable file path, or to the credentials JSON itself."
             )
         case VertexCredentialsFileNotJson(path=path, detail=detail):
+            verbose_logger.error("Vertex: credentials file at %s is not valid JSON: %s", path, detail)
             raise ValueError(
-                f"The vertex credentials file at {redact_string(path)} is not valid JSON: {detail}. "
+                f"The vertex credentials file is not valid JSON: {detail}. The proxy log names the path. "
                 "Check for unescaped newlines in private_key."
             )
         case VertexCredentialsInlineNotJson(detail=detail):

--- a/litellm/llms/vertex_ai/credentials_source.py
+++ b/litellm/llms/vertex_ai/credentials_source.py
@@ -6,6 +6,7 @@ it is decides what a failure means, so the two are told apart by the shape of th
 each failure is returned as its own case instead of collapsing into one parse error.
 """
 
+import os
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Final, NoReturn, TypeAlias
@@ -80,7 +81,7 @@ def _read_json_file(path: str) -> _VertexCredentialsFile:
     return VertexCredentialsJson(parsed)
 
 
-def is_inline_credentials_json(credentials: str) -> bool:
+def _is_inline_credentials_json(credentials: str) -> bool:
     """Whether *credentials* carries the JSON itself rather than a path to a file holding it."""
     return credentials.lstrip().startswith("{")
 
@@ -92,7 +93,11 @@ def load_vertex_credentials_source(credentials: str) -> VertexCredentialsSource:
     failure recognisable: `os.path.exists()` answers False for an unreadable path as well as
     an absent one, so both used to reach the inline branch and be reported as malformed JSON.
     """
-    if not is_inline_credentials_json(credentials):
+    inline_first: Final = _is_inline_credentials_json(credentials)
+    verbose_logger.debug(
+        "Vertex: Loading vertex credentials, is_file_path=%s, current dir %s", not inline_first, os.getcwd()
+    )
+    if not inline_first:
         return _read_json_file(credentials)
 
     inline: Final = _parse_json_object(credentials)

--- a/litellm/llms/vertex_ai/credentials_source.py
+++ b/litellm/llms/vertex_ai/credentials_source.py
@@ -143,4 +143,4 @@ def raise_vertex_credentials_failure(failure: VertexCredentialsFailure) -> NoRet
                 "Check for unescaped newlines in private_key."
             )
         case _:  # pragma: no cover - exhaustiveness guard, unreachable while the union holds
-            assert_never(failure)
+            assert_never(failure)  # pragma: no cover

--- a/litellm/llms/vertex_ai/credentials_source.py
+++ b/litellm/llms/vertex_ai/credentials_source.py
@@ -74,6 +74,9 @@ def _read_json_file(path: str) -> _VertexCredentialsFile:
         return VertexCredentialsFileUnreadable(path, f"{e.strerror or e} ({type(e).__name__})")
     except UnicodeDecodeError:
         return VertexCredentialsFileNotJson(path, "file is not UTF-8 text")
+    except ValueError as e:
+        # open() rejects a few paths before touching the filesystem, e.g. "embedded null byte".
+        return VertexCredentialsFileUnreadable(path, f"{e} ({type(e).__name__})")
 
     parsed: Final = _parse_json_object(contents)
     if isinstance(parsed, _NotAJsonObject):

--- a/litellm/llms/vertex_ai/credentials_source.py
+++ b/litellm/llms/vertex_ai/credentials_source.py
@@ -1,0 +1,121 @@
+"""
+Resolve the `vertex_credentials` config value into the JSON object google-auth needs.
+
+The value is either the credentials JSON itself or a path to a file holding it. Which one
+it is decides what a failure means, so the two are told apart by the shape of the value and
+each failure is returned as its own case instead of collapsing into one parse error.
+"""
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Final, NoReturn, TypeAlias
+
+from pydantic import TypeAdapter, ValidationError
+from typing_extensions import assert_never
+
+from litellm.litellm_core_utils.secret_redaction import redact_string
+
+
+@dataclass(frozen=True, slots=True)
+class VertexCredentialsJson:
+    value: Mapping[str, object]
+
+
+@dataclass(frozen=True, slots=True)
+class VertexCredentialsFileUnreadable:
+    path: str
+    reason: str
+
+
+@dataclass(frozen=True, slots=True)
+class VertexCredentialsFileNotJson:
+    path: str
+    detail: str
+
+
+@dataclass(frozen=True, slots=True)
+class VertexCredentialsInlineNotJson:
+    detail: str
+
+
+@dataclass(frozen=True, slots=True)
+class _NotAJsonObject:
+    detail: str
+
+
+VertexCredentialsFailure: TypeAlias = (
+    VertexCredentialsFileUnreadable | VertexCredentialsFileNotJson | VertexCredentialsInlineNotJson
+)
+VertexCredentialsSource: TypeAlias = VertexCredentialsJson | VertexCredentialsFailure
+
+
+_JSON_OBJECT_ADAPTER: Final = TypeAdapter(dict[str, object])
+
+
+def _parse_json_object(raw: str) -> Mapping[str, object] | _NotAJsonObject:
+    """Parse *raw*, describing any failure without echoing it: the input can be key material."""
+    try:
+        return _JSON_OBJECT_ADAPTER.validate_json(raw)
+    except ValidationError as e:
+        # Only "msg" is reported. Pydantic keeps the offending value under "input", and that
+        # value is the credential.
+        return _NotAJsonObject("; ".join(detail["msg"] for detail in e.errors()))
+
+
+def is_inline_credentials_json(credentials: str) -> bool:
+    """Whether *credentials* carries the JSON itself rather than a path to a file holding it."""
+    return credentials.lstrip().startswith("{")
+
+
+def load_vertex_credentials_source(credentials: str) -> VertexCredentialsSource:
+    """Read *credentials* as the credentials JSON when it is shaped like one, else as a path to it.
+
+    Telling the two apart by shape rather than by `os.path.exists()` is what keeps a read
+    failure recognisable: `os.path.exists()` answers False for an unreadable path as well as
+    an absent one, so both used to reach the inline branch and be reported as malformed JSON.
+    """
+    if is_inline_credentials_json(credentials):
+        inline: Final = _parse_json_object(credentials)
+        if isinstance(inline, _NotAJsonObject):
+            return VertexCredentialsInlineNotJson(inline.detail)
+        return VertexCredentialsJson(inline)
+
+    try:
+        with open(credentials, encoding="utf-8") as f:
+            contents: Final = f.read()
+    except OSError as e:
+        return VertexCredentialsFileUnreadable(credentials, f"{e.strerror or e} ({type(e).__name__})")
+    except UnicodeDecodeError:
+        return VertexCredentialsFileNotJson(credentials, "file is not UTF-8 text")
+
+    from_file: Final = _parse_json_object(contents)
+    if isinstance(from_file, _NotAJsonObject):
+        return VertexCredentialsFileNotJson(credentials, from_file.detail)
+    return VertexCredentialsJson(from_file)
+
+
+def raise_vertex_credentials_failure(failure: VertexCredentialsFailure) -> NoReturn:
+    """Map a load failure onto the ValueError the auth flow already surfaces as a 500.
+
+    A path names itself in the message so the operator's log says which file failed. The
+    proxy scrubs filesystem paths out of what it hands back to the API caller, and the value
+    is redacted first so a non-path value misconfigured here cannot leak instead.
+    """
+    match failure:
+        case VertexCredentialsFileUnreadable(path=path, reason=reason):
+            raise ValueError(
+                f"Unable to read the vertex credentials file at {redact_string(path)}: {reason}. "
+                "Set `vertex_credentials` to a readable file path, or to the credentials JSON itself."
+            )
+        case VertexCredentialsFileNotJson(path=path, detail=detail):
+            raise ValueError(
+                f"The vertex credentials file at {redact_string(path)} is not valid JSON: {detail}. "
+                "Check for unescaped newlines in private_key."
+            )
+        case VertexCredentialsInlineNotJson(detail=detail):
+            raise ValueError(
+                f"The inline `vertex_credentials` value is not valid JSON: {detail}. "
+                "Check for unescaped newlines in private_key."
+            )
+        case _:
+            assert_never(failure)

--- a/litellm/llms/vertex_ai/vertex_llm_base.py
+++ b/litellm/llms/vertex_ai/vertex_llm_base.py
@@ -26,6 +26,12 @@ from .common_utils import (
     get_vertex_base_model_name,
     get_vertex_base_url,
 )
+from .credentials_source import (
+    VertexCredentialsJson,
+    is_inline_credentials_json,
+    load_vertex_credentials_source,
+    raise_vertex_credentials_failure,
+)
 
 
 def _graft_default_vertex_path(api_base: str, default_url: str) -> str:
@@ -127,27 +133,15 @@ class VertexBase:
     ) -> tuple[_VertexCredentialsObject | None, str]:
         if credentials is not None:
             if isinstance(credentials, str):
-                _is_path: Final = os.path.exists(
-                    credentials
-                )  # credentials is from server config (litellm_params), not user input
+                source: Final = load_vertex_credentials_source(credentials)
                 verbose_logger.debug(
                     "Vertex: Loading vertex credentials, is_file_path=%s, current dir %s",
-                    _is_path,
+                    not is_inline_credentials_json(credentials),
                     os.getcwd(),
                 )
-
-                try:
-                    if _is_path:
-                        with open(credentials) as f:
-                            json_obj = json.load(f)
-                    else:
-                        json_obj = json.loads(credentials)
-                except Exception as e:
-                    raise Exception(
-                        "Unable to load vertex credentials from environment. "
-                        "Ensure the JSON is valid (check for unescaped newlines in private_key). "
-                        f"Parse error: {type(e).__name__}"
-                    )
+                if not isinstance(source, VertexCredentialsJson):
+                    raise_vertex_credentials_failure(source)
+                json_obj: Mapping[str, object] = source.value
             elif isinstance(credentials, dict):
                 json_obj = credentials
             else:

--- a/litellm/llms/vertex_ai/vertex_llm_base.py
+++ b/litellm/llms/vertex_ai/vertex_llm_base.py
@@ -6,7 +6,6 @@ Handles Authentication and generating request urls for Vertex AI and Google AI S
 
 import asyncio
 import json
-import os
 import threading
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Final, Literal, Protocol
@@ -28,7 +27,6 @@ from .common_utils import (
 )
 from .credentials_source import (
     VertexCredentialsJson,
-    is_inline_credentials_json,
     load_vertex_credentials_source,
     raise_vertex_credentials_failure,
 )
@@ -134,11 +132,6 @@ class VertexBase:
         if credentials is not None:
             if isinstance(credentials, str):
                 source: Final = load_vertex_credentials_source(credentials)
-                verbose_logger.debug(
-                    "Vertex: Loading vertex credentials, is_file_path=%s, current dir %s",
-                    not is_inline_credentials_json(credentials),
-                    os.getcwd(),
-                )
                 if not isinstance(source, VertexCredentialsJson):
                     raise_vertex_credentials_failure(source)
                 json_obj: Mapping[str, object] = source.value

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_llm_base.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_llm_base.py
@@ -2207,12 +2207,11 @@ class TestVertexCredentialsSource:
     def test_missing_credentials_file_names_the_path_not_the_json(self, tmp_path):
         missing = tmp_path / "vertexai.json"
 
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ValueError, match="No such file or directory") as exc_info:
             VertexBase().load_auth(credentials=str(missing), project_id="p")
 
         message = str(exc_info.value)
         assert str(missing) in message
-        assert "No such file or directory" in message
         assert "not valid JSON" not in message
 
     def test_unreadable_credentials_file_names_the_read_failure(self, tmp_path):
@@ -2221,24 +2220,22 @@ class TestVertexCredentialsSource:
         unreadable = tmp_path / "vertexai.json"
         unreadable.mkdir()
 
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ValueError, match="Unable to read the vertex credentials file") as exc_info:
             VertexBase().load_auth(credentials=str(unreadable), project_id="p")
 
         message = str(exc_info.value)
         assert str(unreadable) in message
-        assert "Unable to read the vertex credentials file" in message
         assert "not valid JSON" not in message
 
     def test_malformed_credentials_file_names_the_file_and_keeps_the_private_key_hint(self, tmp_path):
         malformed = tmp_path / "vertexai.json"
         malformed.write_text('{"type": "service_account", "private_key": "-----BEGIN\nPRIVATE KEY-----"}')
 
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ValueError, match="is not valid JSON") as exc_info:
             VertexBase().load_auth(credentials=str(malformed), project_id="p")
 
         message = str(exc_info.value)
         assert str(malformed) in message
-        assert "not valid JSON" in message
         assert "private_key" in message
 
     def test_malformed_inline_credentials_do_not_echo_the_credential(self):
@@ -2247,11 +2244,12 @@ class TestVertexCredentialsSource:
             '"-----BEGIN PRIVATE KEY-----\nMIIEvQIBADA\n-----END PRIVATE KEY-----"}'
         )
 
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(
+            ValueError, match="The inline `vertex_credentials` value is not valid JSON"
+        ) as exc_info:
             VertexBase().load_auth(credentials=inline, project_id="p")
 
         message = str(exc_info.value)
-        assert "not valid JSON" in message
         assert "MIIEvQIBADA" not in message
         assert "BEGIN PRIVATE KEY" not in message
 
@@ -2297,7 +2295,7 @@ class TestVertexCredentialsSource:
 
         missing = tmp_path / "vertexai.json"
 
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ValueError, match="Unable to read the vertex credentials file") as exc_info:
             VertexBase().load_auth(credentials=str(missing), project_id="p")
 
         logged = str(exc_info.value)
@@ -2309,7 +2307,7 @@ class TestVertexCredentialsSource:
         so it is scrubbed before it reaches the message."""
         pem = "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADA\n-----END PRIVATE KEY-----"
 
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ValueError, match="Unable to read the vertex credentials file") as exc_info:
             VertexBase().load_auth(credentials=pem, project_id="p")
 
         message = str(exc_info.value)

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_llm_base.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_llm_base.py
@@ -2304,6 +2304,13 @@ class TestVertexCredentialsSource:
         assert project_id == "from-inline"
         assert from_sa.call_args.args[0] == {"type": "service_account", "project_id": "from-inline"}
 
+    def test_a_path_open_rejects_outright_is_reported_not_raised_raw(self):
+        """open() rejects some paths with a bare ValueError before any filesystem call."""
+        with pytest.raises(ValueError, match="Unable to read the vertex credentials file") as exc_info:
+            VertexBase().load_auth(credentials="creds" + chr(0) + ".json", project_id="p")
+
+        assert "embedded null" in str(exc_info.value)
+
     def test_a_file_whose_name_starts_with_a_brace_is_still_read(self, tmp_path):
         """Shape dispatch must not strand a real file that happens to be named like JSON."""
         braced = tmp_path / "{vertex}.json"

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_llm_base.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_llm_base.py
@@ -2193,3 +2193,125 @@ class TestVertexBase:
 
             assert token == "cached-token"
             assert not mock_get_lock.called, "Fast path should not acquire lock"
+
+
+class TestVertexCredentialsSource:
+    """A `vertex_credentials` path that cannot be read must not be reported as malformed JSON.
+
+    Regression for https://github.com/BerriAI/litellm/issues/40166: dispatching on
+    os.path.exists() sent a missing or unreadable path down the inline-JSON branch,
+    where the path string itself was parsed and every failure came back as a
+    JSONDecodeError blaming the key material.
+    """
+
+    def test_missing_credentials_file_names_the_path_not_the_json(self, tmp_path):
+        missing = tmp_path / "vertexai.json"
+
+        with pytest.raises(ValueError) as exc_info:
+            VertexBase().load_auth(credentials=str(missing), project_id="p")
+
+        message = str(exc_info.value)
+        assert str(missing) in message
+        assert "No such file or directory" in message
+        assert "not valid JSON" not in message
+
+    def test_unreadable_credentials_file_names_the_read_failure(self, tmp_path):
+        # Present but not openable as a file, the same shape as a path on a mount
+        # that has stopped serving reads.
+        unreadable = tmp_path / "vertexai.json"
+        unreadable.mkdir()
+
+        with pytest.raises(ValueError) as exc_info:
+            VertexBase().load_auth(credentials=str(unreadable), project_id="p")
+
+        message = str(exc_info.value)
+        assert str(unreadable) in message
+        assert "Unable to read the vertex credentials file" in message
+        assert "not valid JSON" not in message
+
+    def test_malformed_credentials_file_names_the_file_and_keeps_the_private_key_hint(self, tmp_path):
+        malformed = tmp_path / "vertexai.json"
+        malformed.write_text('{"type": "service_account", "private_key": "-----BEGIN\nPRIVATE KEY-----"}')
+
+        with pytest.raises(ValueError) as exc_info:
+            VertexBase().load_auth(credentials=str(malformed), project_id="p")
+
+        message = str(exc_info.value)
+        assert str(malformed) in message
+        assert "not valid JSON" in message
+        assert "private_key" in message
+
+    def test_malformed_inline_credentials_do_not_echo_the_credential(self):
+        inline = (
+            '{"type": "service_account", "private_key": '
+            '"-----BEGIN PRIVATE KEY-----\nMIIEvQIBADA\n-----END PRIVATE KEY-----"}'
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            VertexBase().load_auth(credentials=inline, project_id="p")
+
+        message = str(exc_info.value)
+        assert "not valid JSON" in message
+        assert "MIIEvQIBADA" not in message
+        assert "BEGIN PRIVATE KEY" not in message
+
+    def test_readable_credentials_file_is_still_loaded(self, tmp_path):
+        creds_file = tmp_path / "vertexai.json"
+        creds_file.write_text(json.dumps({"type": "service_account", "project_id": "from-file"}))
+        vertex_base = VertexBase()
+        mock_creds = MagicMock()
+        mock_creds.project_id = "from-file"
+
+        with (
+            patch.object(vertex_base, "_credentials_from_service_account", return_value=mock_creds) as from_sa,
+            patch.object(vertex_base, "refresh_auth"),
+        ):
+            creds, project_id = vertex_base.load_auth(credentials=str(creds_file), project_id=None)
+
+        assert creds is mock_creds
+        assert project_id == "from-file"
+        assert from_sa.call_args.args[0] == {"type": "service_account", "project_id": "from-file"}
+
+    def test_inline_credentials_json_is_still_parsed(self):
+        vertex_base = VertexBase()
+        mock_creds = MagicMock()
+        mock_creds.project_id = "from-inline"
+
+        with (
+            patch.object(vertex_base, "_credentials_from_service_account", return_value=mock_creds) as from_sa,
+            patch.object(vertex_base, "refresh_auth"),
+        ):
+            creds, project_id = vertex_base.load_auth(
+                credentials=json.dumps({"type": "service_account", "project_id": "from-inline"}),
+                project_id=None,
+            )
+
+        assert creds is mock_creds
+        assert project_id == "from-inline"
+        assert from_sa.call_args.args[0] == {"type": "service_account", "project_id": "from-inline"}
+
+    def test_credentials_path_reaches_the_operator_log_but_not_the_api_caller(self, tmp_path):
+        """The path is the actionable detail, so it is in the message the proxy logs.
+        What the proxy hands back to the caller goes through redact_internal_details."""
+        from litellm.litellm_core_utils.secret_redaction import redact_internal_details
+
+        missing = tmp_path / "vertexai.json"
+
+        with pytest.raises(ValueError) as exc_info:
+            VertexBase().load_auth(credentials=str(missing), project_id="p")
+
+        logged = str(exc_info.value)
+        assert str(missing) in logged
+        assert str(missing) not in redact_internal_details(logged)
+
+    def test_a_credential_misconfigured_as_a_path_is_redacted_not_echoed(self):
+        """A value that is neither a path nor JSON still lands in the file branch,
+        so it is scrubbed before it reaches the message."""
+        pem = "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADA\n-----END PRIVATE KEY-----"
+
+        with pytest.raises(ValueError) as exc_info:
+            VertexBase().load_auth(credentials=pem, project_id="p")
+
+        message = str(exc_info.value)
+        assert "MIIEvQIBADA" not in message
+        assert "BEGIN PRIVATE KEY" not in message

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_llm_base.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_llm_base.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import logging
 from unittest.mock import MagicMock, call, patch
 
 import pytest
@@ -2204,39 +2205,45 @@ class TestVertexCredentialsSource:
     JSONDecodeError blaming the key material.
     """
 
-    def test_missing_credentials_file_names_the_path_not_the_json(self, tmp_path):
+    def test_missing_credentials_file_names_the_read_failure(self, tmp_path, caplog):
         missing = tmp_path / "vertexai.json"
 
-        with pytest.raises(ValueError, match="No such file or directory") as exc_info:
-            VertexBase().load_auth(credentials=str(missing), project_id="p")
+        with caplog.at_level(logging.ERROR, logger="LiteLLM"):
+            with pytest.raises(ValueError, match="No such file or directory") as exc_info:
+                VertexBase().load_auth(credentials=str(missing), project_id="p")
 
         message = str(exc_info.value)
-        assert str(missing) in message
         assert "not valid JSON" not in message
+        assert str(missing) not in message
+        assert str(missing) in caplog.text
 
-    def test_unreadable_credentials_file_names_the_read_failure(self, tmp_path):
+    def test_unreadable_credentials_file_names_the_read_failure(self, tmp_path, caplog):
         # Present but not openable as a file, the same shape as a path on a mount
         # that has stopped serving reads.
         unreadable = tmp_path / "vertexai.json"
         unreadable.mkdir()
 
-        with pytest.raises(ValueError, match="Unable to read the vertex credentials file") as exc_info:
-            VertexBase().load_auth(credentials=str(unreadable), project_id="p")
+        with caplog.at_level(logging.ERROR, logger="LiteLLM"):
+            with pytest.raises(ValueError, match="Unable to read the vertex credentials file") as exc_info:
+                VertexBase().load_auth(credentials=str(unreadable), project_id="p")
 
         message = str(exc_info.value)
-        assert str(unreadable) in message
         assert "not valid JSON" not in message
+        assert str(unreadable) not in message
+        assert str(unreadable) in caplog.text
 
-    def test_malformed_credentials_file_names_the_file_and_keeps_the_private_key_hint(self, tmp_path):
+    def test_malformed_credentials_file_keeps_the_private_key_hint(self, tmp_path, caplog):
         malformed = tmp_path / "vertexai.json"
         malformed.write_text('{"type": "service_account", "private_key": "-----BEGIN\nPRIVATE KEY-----"}')
 
-        with pytest.raises(ValueError, match="is not valid JSON") as exc_info:
-            VertexBase().load_auth(credentials=str(malformed), project_id="p")
+        with caplog.at_level(logging.ERROR, logger="LiteLLM"):
+            with pytest.raises(ValueError, match="is not valid JSON") as exc_info:
+                VertexBase().load_auth(credentials=str(malformed), project_id="p")
 
         message = str(exc_info.value)
-        assert str(malformed) in message
         assert "private_key" in message
+        assert str(malformed) not in message
+        assert str(malformed) in caplog.text
 
     def test_malformed_inline_credentials_do_not_echo_the_credential(self):
         inline = (
@@ -2248,6 +2255,15 @@ class TestVertexCredentialsSource:
             ValueError, match="The inline `vertex_credentials` value is not valid JSON"
         ) as exc_info:
             VertexBase().load_auth(credentials=inline, project_id="p")
+
+        assert "MIIEvQIBADA" not in str(exc_info.value)
+
+    def test_a_credential_misconfigured_as_a_path_is_not_echoed(self):
+        """A value that is neither a path nor JSON must not come back in the message."""
+        pem = "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADA\n-----END PRIVATE KEY-----"
+
+        with pytest.raises(ValueError, match="Unable to read the vertex credentials file") as exc_info:
+            VertexBase().load_auth(credentials=pem, project_id="p")
 
         message = str(exc_info.value)
         assert "MIIEvQIBADA" not in message
@@ -2288,28 +2304,20 @@ class TestVertexCredentialsSource:
         assert project_id == "from-inline"
         assert from_sa.call_args.args[0] == {"type": "service_account", "project_id": "from-inline"}
 
-    def test_credentials_path_reaches_the_operator_log_but_not_the_api_caller(self, tmp_path):
-        """The path is the actionable detail, so it is in the message the proxy logs.
-        What the proxy hands back to the caller goes through redact_internal_details."""
-        from litellm.litellm_core_utils.secret_redaction import redact_internal_details
+    def test_a_file_whose_name_starts_with_a_brace_is_still_read(self, tmp_path):
+        """Shape dispatch must not strand a real file that happens to be named like JSON."""
+        braced = tmp_path / "{vertex}.json"
+        braced.write_text(json.dumps({"type": "service_account", "project_id": "from-braced-file"}))
+        vertex_base = VertexBase()
+        mock_creds = MagicMock()
+        mock_creds.project_id = "from-braced-file"
 
-        missing = tmp_path / "vertexai.json"
+        with (
+            patch.object(vertex_base, "_credentials_from_service_account", return_value=mock_creds) as from_sa,
+            patch.object(vertex_base, "refresh_auth"),
+        ):
+            creds, project_id = vertex_base.load_auth(credentials=str(braced), project_id=None)
 
-        with pytest.raises(ValueError, match="Unable to read the vertex credentials file") as exc_info:
-            VertexBase().load_auth(credentials=str(missing), project_id="p")
-
-        logged = str(exc_info.value)
-        assert str(missing) in logged
-        assert str(missing) not in redact_internal_details(logged)
-
-    def test_a_credential_misconfigured_as_a_path_is_redacted_not_echoed(self):
-        """A value that is neither a path nor JSON still lands in the file branch,
-        so it is scrubbed before it reaches the message."""
-        pem = "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADA\n-----END PRIVATE KEY-----"
-
-        with pytest.raises(ValueError, match="Unable to read the vertex credentials file") as exc_info:
-            VertexBase().load_auth(credentials=pem, project_id="p")
-
-        message = str(exc_info.value)
-        assert "MIIEvQIBADA" not in message
-        assert "BEGIN PRIVATE KEY" not in message
+        assert creds is mock_creds
+        assert project_id == "from-braced-file"
+        assert from_sa.call_args.args[0] == {"type": "service_account", "project_id": "from-braced-file"}

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_llm_base.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_llm_base.py
@@ -2304,6 +2304,17 @@ class TestVertexCredentialsSource:
         assert project_id == "from-inline"
         assert from_sa.call_args.args[0] == {"type": "service_account", "project_id": "from-inline"}
 
+    def test_a_credential_misconfigured_as_a_path_is_not_logged_either(self, caplog):
+        """The path reaches the log, so a credential put in that field must be scrubbed first."""
+        pem = "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADA\n-----END PRIVATE KEY-----"
+
+        with caplog.at_level(logging.ERROR, logger="LiteLLM"):
+            with pytest.raises(ValueError, match="Unable to read the vertex credentials file"):
+                VertexBase().load_auth(credentials=pem, project_id="p")
+
+        assert "MIIEvQIBADA" not in caplog.text
+        assert "REDACTED" in caplog.text
+
     def test_a_path_open_rejects_outright_is_reported_not_raised_raw(self):
         """open() rejects some paths with a bare ValueError before any filesystem call."""
         with pytest.raises(ValueError, match="Unable to read the vertex credentials file") as exc_info:

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_llm_base.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_llm_base.py
@@ -2322,10 +2322,15 @@ class TestVertexCredentialsSource:
 
         assert "embedded null" in str(exc_info.value)
 
-    def test_a_file_whose_name_starts_with_a_brace_is_still_read(self, tmp_path):
-        """Shape dispatch must not strand a real file that happens to be named like JSON."""
+    def test_a_file_whose_name_starts_with_a_brace_is_still_read(self, tmp_path, monkeypatch):
+        """Shape dispatch must not strand a real file that happens to be named like JSON.
+
+        The value has to be relative for this to bite: an absolute path never starts with
+        a brace, so only "{vertex}.json" reaches the inline branch and needs the fallback.
+        """
         braced = tmp_path / "{vertex}.json"
         braced.write_text(json.dumps({"type": "service_account", "project_id": "from-braced-file"}))
+        monkeypatch.chdir(tmp_path)
         vertex_base = VertexBase()
         mock_creds = MagicMock()
         mock_creds.project_id = "from-braced-file"
@@ -2334,8 +2339,17 @@ class TestVertexCredentialsSource:
             patch.object(vertex_base, "_credentials_from_service_account", return_value=mock_creds) as from_sa,
             patch.object(vertex_base, "refresh_auth"),
         ):
-            creds, project_id = vertex_base.load_auth(credentials=str(braced), project_id=None)
+            creds, project_id = vertex_base.load_auth(credentials="{vertex}.json", project_id=None)
 
         assert creds is mock_creds
         assert project_id == "from-braced-file"
         assert from_sa.call_args.args[0] == {"type": "service_account", "project_id": "from-braced-file"}
+
+    def test_a_credentials_file_that_is_not_text_is_reported_as_such(self, tmp_path):
+        not_text = tmp_path / "vertexai.json"
+        not_text.write_bytes(bytes([0xFF, 0xFE, 0x00, 0x01]))
+
+        with pytest.raises(ValueError, match="is not valid JSON") as exc_info:
+            VertexBase().load_auth(credentials=str(not_text), project_id="p")
+
+        assert "UTF-8" in str(exc_info.value)

--- a/tests/test_litellm/test_secret_redaction.py
+++ b/tests/test_litellm/test_secret_redaction.py
@@ -469,7 +469,7 @@ def test_vertex_error_message_no_credential_leak():
     )
 
     for failure in failures:
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ValueError, match="vertex") as exc_info:
             raise_vertex_credentials_failure(failure)
         message = str(exc_info.value)
         assert _redact_string(message) == message  # nothing to redact

--- a/tests/test_litellm/test_secret_redaction.py
+++ b/tests/test_litellm/test_secret_redaction.py
@@ -462,9 +462,10 @@ def test_vertex_error_message_no_credential_leak():
         raise_vertex_credentials_failure,
     )
 
+    path = "/etc/litellm/vertexai.json"
     failures = (
-        VertexCredentialsFileUnreadable("/etc/litellm/vertexai.json", "No such file or directory (FileNotFoundError)"),
-        VertexCredentialsFileNotJson("/etc/litellm/vertexai.json", "Invalid control character at: line 1 column 55"),
+        VertexCredentialsFileUnreadable(path, "No such file or directory (FileNotFoundError)"),
+        VertexCredentialsFileNotJson(path, "Invalid control character at: line 1 column 55"),
         VertexCredentialsInlineNotJson("Expecting value: line 1 column 1 (char 0)"),
     )
 
@@ -472,6 +473,7 @@ def test_vertex_error_message_no_credential_leak():
         with pytest.raises(ValueError, match="vertex") as exc_info:
             raise_vertex_credentials_failure(failure)
         message = str(exc_info.value)
+        assert path not in message  # the path goes to the log, not to the API caller
         assert _redact_string(message) == message  # nothing to redact
 
 

--- a/tests/test_litellm/test_secret_redaction.py
+++ b/tests/test_litellm/test_secret_redaction.py
@@ -452,15 +452,27 @@ def test_service_account_blob_fully_redacted():
 
 
 def test_vertex_error_message_no_credential_leak():
-    """The old Vertex error format leaked the full credential JSON.
-    The new format must not contain any credential material."""
-    new_msg = (
-        "Unable to load vertex credentials from environment. "
-        "Ensure the JSON is valid (check for unescaped newlines in private_key). "
-        "Parse error: JSONDecodeError"
+    """The old Vertex error format leaked the full credential JSON. Every message the
+    credential loader raises today must survive redaction unchanged, which it only can
+    if it never carried credential material in the first place."""
+    from litellm.llms.vertex_ai.credentials_source import (
+        VertexCredentialsFileNotJson,
+        VertexCredentialsFileUnreadable,
+        VertexCredentialsInlineNotJson,
+        raise_vertex_credentials_failure,
     )
-    result = _redact_string(new_msg)
-    assert result == new_msg  # nothing to redact
+
+    failures = (
+        VertexCredentialsFileUnreadable("/etc/litellm/vertexai.json", "No such file or directory (FileNotFoundError)"),
+        VertexCredentialsFileNotJson("/etc/litellm/vertexai.json", "Invalid control character at: line 1 column 55"),
+        VertexCredentialsInlineNotJson("Expecting value: line 1 column 1 (char 0)"),
+    )
+
+    for failure in failures:
+        with pytest.raises(ValueError) as exc_info:
+            raise_vertex_credentials_failure(failure)
+        message = str(exc_info.value)
+        assert _redact_string(message) == message  # nothing to redact
 
 
 def test_vertex_traceback_redacts_pem():


### PR DESCRIPTION
## TLDR

Problem this solves:

- A missing `vertex_credentials` file reports itself as invalid JSON
- An unreadable one reports the same, and so does genuinely bad JSON
- The advice sends operators to re-issue a key that works fine

How it solves it:

- A file path and inline JSON are told apart by shape
- Read failure, bad file JSON and bad inline JSON each named
- The failing path goes to the proxy log, not to the caller

## User Flow

Before: an operator whose gateway reads its Vertex service-account key from a file is told the key is malformed, when the file is simply not there

1. They set `vertex_credentials` to a file path on a Vertex model, and the gateway serves that model normally
2. A deployment change moves the file, or the mount it lives on stops serving reads
3. They send POST https://litellm-domain/v1/chat/completions for that model and get back `litellm.APIConnectionError: Unable to load vertex credentials from environment. Ensure the JSON is valid (check for unescaped newlines in private_key). Parse error: JSONDecodeError`
4. Taking the message at its word, they download the service-account key, check it for embedded newlines and re-issue it. All of it is wasted: the key was always fine
5. The proxy's own log says the same thing, so nothing anywhere points at the path, and the mount is the last place they look
6. A model configured with genuinely malformed JSON in its file returns that same sentence, so the three faults are indistinguishable from outside

After: the same failure names itself, and the proxy log says which file

1. Same configuration, gateway serving that Vertex model normally
2. Same deployment change or read failure
3. They send the same POST and get back `litellm.APIConnectionError: Unable to read the vertex credentials file: No such file or directory (FileNotFoundError). The proxy log names the path. Set 'vertex_credentials' to a readable file path, or to the credentials JSON itself.`
4. They open the proxy's log, where one line names the exact file that failed to open
5. They fix the path or the mount, and never touch the key
6. A model whose file is readable but really is malformed returns "is not valid JSON" instead, so the `private_key` advice now only shows up where it applies

The path itself stays out of the response and goes only to the log, so a caller holding a working virtual key learns that the gateway's credentials file is broken but not where it lives.

## Relevant issues

Fixes #40166

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Three Vertex model groups on one proxy, each pointing `vertex_credentials` at a different broken file: one path that does not exist, one that exists but cannot be opened, and one that opens and holds JSON with a raw newline inside `private_key`. Credential loading fails before any request is built, so none of these reach Google and none of them cost anything.

Fixtures:

```
$ mkdir -p ~/vertex-proof/creds/unreadable.json
$ printf '{"type": "service_account", "project_id": "proof", "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADA\n-----END PRIVATE KEY-----", "client_email": "sa@proof.iam.gserviceaccount.com"}' > ~/vertex-proof/creds/malformed.json
```

`~/vertex-proof/config.yaml`:

```yaml
model_list:
  - model_name: vertex-missing-file
    litellm_params:
      model: vertex_ai/gemini-3.8-flash
      vertex_project: proof
      vertex_location: us-central1
      vertex_credentials: C:/Users/USER/vertex-proof/creds/missing.json

  - model_name: vertex-unreadable-file
    litellm_params:
      model: vertex_ai/gemini-3.8-flash
      vertex_project: proof
      vertex_location: us-central1
      vertex_credentials: C:/Users/USER/vertex-proof/creds/unreadable.json

  - model_name: vertex-malformed-file
    litellm_params:
      model: vertex_ai/gemini-3.8-flash
      vertex_project: proof
      vertex_location: us-central1
      vertex_credentials: C:/Users/USER/vertex-proof/creds/malformed.json

general_settings:
  master_key: sk-1234
```

Proxy for both runs:

```
$ python litellm/proxy/proxy_cli.py --config ~/vertex-proof/config.yaml --port 4000
INFO:     Application startup complete.
```

### Before (6908318c16)

#### Missing file

1. Send the request

```
$ curl -s -X POST http://localhost:4000/v1/chat/completions \
    -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
    -d '{"model": "vertex-missing-file", "messages": [{"role": "user", "content": "hi"}]}' | jq -r .error.message
litellm.APIConnectionError: Unable to load vertex credentials from environment. Ensure the JSON is valid (check for unescaped newlines in private_key). Parse error: JSONDecodeError
```

2. The file was never opened, yet the answer is about JSON and about `private_key`, and nothing names the path that was tried

#### Present but not readable

1. Send the request

```
$ curl -s -X POST http://localhost:4000/v1/chat/completions \
    -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
    -d '{"model": "vertex-unreadable-file", "messages": [{"role": "user", "content": "hi"}]}' | jq -r .error.message
litellm.APIConnectionError: Unable to load vertex credentials from environment. Ensure the JSON is valid (check for unescaped newlines in private_key). Parse error: PermissionError
```

2. A read failure is still reported as a content problem, with the same `private_key` advice

#### Readable, genuinely malformed JSON

1. Send the request

```
$ curl -s -X POST http://localhost:4000/v1/chat/completions \
    -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
    -d '{"model": "vertex-malformed-file", "messages": [{"role": "user", "content": "hi"}]}' | jq -r .error.message
litellm.APIConnectionError: Unable to load vertex credentials from environment. Ensure the JSON is valid (check for unescaped newlines in private_key). Parse error: JSONDecodeError
```

2. The one case the message is right about is worded identically to the two it is wrong about

### After (8a48c1d665)

#### Missing file

1. Send the request

```
$ curl -s -X POST http://localhost:4000/v1/chat/completions \
    -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
    -d '{"model": "vertex-missing-file", "messages": [{"role": "user", "content": "hi"}]}' | jq -r .error.message
litellm.APIConnectionError: Unable to read the vertex credentials file: No such file or directory (FileNotFoundError). The proxy log names the path. Set `vertex_credentials` to a readable file path, or to the credentials JSON itself.
```

2. Read the proxy's own log, which names the file the response deliberately leaves out

```
$ grep -o 'Vertex: cannot read the credentials file at .*missing.*FileNotFoundError)' ~/vertex-proof/after.log | head -1
Vertex: cannot read the credentials file at C:/Users/USER/vertex-proof/creds/missing.json: No such file or directory (FileNotFoundError)
```

#### Present but not readable

1. Send the request

```
$ curl -s -X POST http://localhost:4000/v1/chat/completions \
    -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
    -d '{"model": "vertex-unreadable-file", "messages": [{"role": "user", "content": "hi"}]}' | jq -r .error.message
litellm.APIConnectionError: Unable to read the vertex credentials file: Permission denied (PermissionError). The proxy log names the path. Set `vertex_credentials` to a readable file path, or to the credentials JSON itself.
```

2. Read the proxy's own log

```
$ grep -o 'Vertex: cannot read the credentials file at .*unreadable.*PermissionError)' ~/vertex-proof/after.log | head -1
Vertex: cannot read the credentials file at C:/Users/USER/vertex-proof/creds/unreadable.json: Permission denied (PermissionError)
```

#### Readable, genuinely malformed JSON

1. Send the request

```
$ curl -s -X POST http://localhost:4000/v1/chat/completions \
    -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
    -d '{"model": "vertex-malformed-file", "messages": [{"role": "user", "content": "hi"}]}' | jq -r .error.message
litellm.APIConnectionError: The vertex credentials file is not valid JSON: Invalid JSON: control character (\u0000-\u001F) found while parsing a string at line 2 column 0. The proxy log names the path. Check for unescaped newlines in private_key.
```

2. Read the proxy's own log, which names the file and the exact position

```
$ grep -o 'Vertex: credentials file at .*malformed.*column 0' ~/vertex-proof/after.log | head -1
Vertex: credentials file at C:/Users/USER/vertex-proof/creds/malformed.json is not valid JSON: Invalid JSON: control character (\u0000-\u001F) found while parsing a string at line 2 column 0
```

#### The path never reaches the caller

1. Ask all three models again and count how many responses carry the credentials path

```
$ for m in vertex-missing-file vertex-unreadable-file vertex-malformed-file; do
    curl -s -X POST http://localhost:4000/v1/chat/completions \
      -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
      -d "{\"model\": \"$m\", \"messages\": [{\"role\": \"user\", \"content\": \"hi\"}]}"; echo
  done | grep -c 'vertex-proof/creds'
0
```

Nothing in the fixtures reached Google, so both runs cost $0. The private key in the malformed fixture never appears in any message on either side, which the added tests also assert.

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- The message text changed, so alerting that greps the old sentence needs updating
- Nothing matching "Unable to load vertex credentials from environment" fires any more

### Low

- The raised type moved from bare `Exception` to `ValueError`
- Both still map to the same `APIConnectionError` the caller already saw
- The path reaches the operator only through the proxy log, at ERROR level
  - It is passed through `redact_string()` first, so a credential misconfigured into
    `vertex_credentials` is scrubbed rather than logged
  - An opaque value matching none of the known secret shapes would still be logged verbatim,
    the same exposure it already has sitting in the proxy config
- The proof was captured on Windows, hence the drive-letter paths in the logs
