### PR TITLE
fix(model-prices): add OpenRouter GPT-5.6 Sol

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -61423,6 +61423,45 @@
         "cache_read_input_token_cost": 2e-08,
         "supports_prompt_caching": true
     },
+    "openrouter/openai/gpt-5.6-sol": {
+        "input_cost_per_token": 2e-06,
+        "input_cost_per_token_above_272k_tokens": 4e-06,
+        "output_cost_per_token": 1e-05,
+        "output_cost_per_token_above_272k_tokens": 1.5e-05,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "source": "https://openrouter.ai/openai/gpt-5.6-sol",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "reasoning_effort_levels": [
+            "none",
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            "max"
+        ],
+        "default_reasoning_effort": "medium",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "cache_read_input_token_cost": 2e-07,
+        "cache_read_input_token_cost_above_272k_tokens": 4e-07,
+        "cache_creation_input_token_cost": 2.5e-06,
+        "cache_creation_input_token_cost_above_272k_tokens": 5e-06
+    },
     "openrouter/openai/gpt-5.6-terra": {
         "input_cost_per_token": 2e-06,
         "output_cost_per_token": 1.2e-05,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -61423,6 +61423,45 @@
         "cache_read_input_token_cost": 2e-08,
         "supports_prompt_caching": true
     },
+    "openrouter/openai/gpt-5.6-sol": {
+        "input_cost_per_token": 2e-06,
+        "input_cost_per_token_above_272k_tokens": 4e-06,
+        "output_cost_per_token": 1e-05,
+        "output_cost_per_token_above_272k_tokens": 1.5e-05,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "source": "https://openrouter.ai/openai/gpt-5.6-sol",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "reasoning_effort_levels": [
+            "none",
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            "max"
+        ],
+        "default_reasoning_effort": "medium",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "cache_read_input_token_cost": 2e-07,
+        "cache_read_input_token_cost_above_272k_tokens": 4e-07,
+        "cache_creation_input_token_cost": 2.5e-06,
+        "cache_creation_input_token_cost_above_272k_tokens": 5e-06
+    },
     "openrouter/openai/gpt-5.6-terra": {
         "input_cost_per_token": 2e-06,
         "output_cost_per_token": 1.2e-05,

--- a/tests/test_litellm/test_model_prices_schema.py
+++ b/tests/test_litellm/test_model_prices_schema.py
@@ -58,6 +58,76 @@ def test_prices_file_validates_against_committed_schema(prices: dict, committed_
     assert errors == []
 
 
+def test_openrouter_gpt56_sol_catalog_entry_matches_official_metadata(prices: dict):
+    entry = prices["openrouter/openai/gpt-5.6-sol"]
+
+    assert {
+        key: entry[key]
+        for key in (
+            "litellm_provider",
+            "mode",
+            "source",
+            "input_cost_per_token",
+            "input_cost_per_token_above_272k_tokens",
+            "output_cost_per_token",
+            "output_cost_per_token_above_272k_tokens",
+            "cache_read_input_token_cost",
+            "cache_read_input_token_cost_above_272k_tokens",
+            "cache_creation_input_token_cost",
+            "cache_creation_input_token_cost_above_272k_tokens",
+            "max_input_tokens",
+            "max_output_tokens",
+            "max_tokens",
+            "supported_modalities",
+            "supported_output_modalities",
+            "reasoning_effort_levels",
+            "default_reasoning_effort",
+        )
+    } == {
+        "litellm_provider": "openrouter",
+        "mode": "chat",
+        "source": "https://openrouter.ai/openai/gpt-5.6-sol",
+        "input_cost_per_token": 2e-6,
+        "input_cost_per_token_above_272k_tokens": 4e-6,
+        "output_cost_per_token": 1e-5,
+        "output_cost_per_token_above_272k_tokens": 1.5e-5,
+        "cache_read_input_token_cost": 2e-7,
+        "cache_read_input_token_cost_above_272k_tokens": 4e-7,
+        "cache_creation_input_token_cost": 2.5e-6,
+        "cache_creation_input_token_cost_above_272k_tokens": 5e-6,
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "supported_modalities": ["text", "image"],
+        "supported_output_modalities": ["text"],
+        "reasoning_effort_levels": ["none", "low", "medium", "high", "xhigh", "max"],
+        "default_reasoning_effort": "medium",
+    }
+    assert {
+        key: entry[key]
+        for key in (
+            "supports_function_calling",
+            "supports_tool_choice",
+            "supports_reasoning",
+            "supports_response_schema",
+            "supports_vision",
+            "supports_pdf_input",
+            "supports_prompt_caching",
+        )
+    } == {
+        key: True
+        for key in (
+            "supports_function_calling",
+            "supports_tool_choice",
+            "supports_reasoning",
+            "supports_response_schema",
+            "supports_vision",
+            "supports_pdf_input",
+            "supports_prompt_caching",
+        )
+    }
+
+
 @pytest.mark.parametrize(
     "entry",
     [


### PR DESCRIPTION
## TLDR

问题：OpenRouter 的 GPT-5.6 Sol 无法从模型目录中选择

- LiteLLM 模型目录缺少 `openrouter/openai/gpt-5.6-sol`
- 用户无法将该模型加入 AI Gateway 模型管理

解决方式：加入官方资料支持的目录条目

- 记录 OpenRouter 当前上下文、价格、缓存和输出限制
- 记录已核验的图片、文件、工具和推理能力
- 同步根目录和打包 backup cost map

## User Flow

Before: 使用 OpenRouter GPT-5.6 Sol 的管理员找不到该模型

1. 管理员打开 AI Gateway 的模型管理页面
2. 管理员在 LiteLLM Model Name(s) 中搜索 `openrouter/openai/gpt-5.6-sol`
3. 模型目录没有该 ID，因此管理员无法选择并添加它

After: 管理员可以从模型目录中选择该模型

1. 管理员打开 AI Gateway 的模型管理页面
2. 管理员在 LiteLLM Model Name(s) 中搜索 `openrouter/openai/gpt-5.6-sol`
3. 模型目录返回该 ID，管理员可以选择并添加它

## Relevant issues

Fixes #40102

## Linear ticket

## Pre-Submission checklist

- [x] 已添加有意义的回归测试
- [x] 相关测试文件已在本地通过
- [x] 已通过目录 schema、生成同步、格式、静态检查、cost-map guard 和 diff 校验
- [x] PR 只修改一个模型目录问题
- [ ] Greptile Confidence Score 至少为 4/5，等待 PR 自动检查

## Screenshots / Proof of Fix

验证范围是静态模型目录，因此使用相同的目录读取步骤展示修复前后的结果

### Before (1009976c497592207804593ea7ffbd639b1f68d6)

1. 读取 `model_prices_and_context_window.json` 中的 `openrouter/openai/gpt-5.6-sol`
2. 结果为缺少该模型 ID

### After (a56c2ba678)

1. 读取 `model_prices_and_context_window.json` 中的 `openrouter/openai/gpt-5.6-sol`
2. 结果包含 `litellm_provider=openrouter`、`mode=chat`、`max_input_tokens=1050000` 和 `max_output_tokens=128000`
3. 结果包含输入 `$0.000002`、输出 `$0.000010`、缓存读 `$0.0000002` 和缓存写 `$0.0000025` 每 token
4. 根目录 cost map 与打包 backup 完全一致

本地验证命令：

```text
uv run pytest tests/test_litellm/test_model_prices_schema.py -q
24 passed
uv run python ci_cd/generate_model_prices_schema.py --check
model_prices_and_context_window.schema.json is in sync and model_prices_and_context_window.json validates against it
uv run python ci_cd/cost_map_guard.py --base 1009976c497592207804593ea7ffbd639b1f68d6 --head HEAD --head-ref litellm_openrouter_gpt56_sol_catalog
cost map guard passed (human PR, file checks only)
uv run ruff format --check tests/test_litellm/test_model_prices_schema.py
1 file already formatted
uv run ruff check tests/test_litellm/test_model_prices_schema.py
All checks passed!
```

官方来源：

- https://openrouter.ai/openai/gpt-5.6-sol
- https://openrouter.ai/docs/api/api-reference/models/get-model

## Type

Bug Fix

## Caveats (if any)

## Final Attestation

- [x] 测试覆盖了模型 ID、上游映射、价格、上下文、输出限制和已核验能力
