### PR TITLE
fix(responses): return an empty assistant turn for a completed response with no output

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -262,6 +262,19 @@ def _tool_call_dict_from_output_item(item: Mapping[str, Any], index: int) -> _Ch
     return tool_call_dict
 
 
+def _is_silent_output(output_items: Sequence[object]) -> bool:
+    """True when a completed response carries no message and no tool call.
+
+    Covers an empty ``output`` list and a reasoning-only list. Both are legal
+    ``status: completed`` responses that convert to zero chat choices.
+    """
+    for item in output_items:
+        item_type = item.get("type") if isinstance(item, Mapping) else getattr(item, "type", None)
+        if item_type != "reasoning":
+            return False
+    return True
+
+
 def _flat_responses_tool_choice(choice_type: str, name: str) -> ToolChoiceFunctionParam | ToolChoiceCustomParam:
     if choice_type == "custom":
         return ToolChoiceCustomParam(type="custom", name=name)
@@ -779,7 +792,7 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
     @staticmethod
     def _build_empty_incomplete_choice(
         output_items: Sequence[object],
-        finish_reason: Literal["length", "content_filter"],
+        finish_reason: Literal["length", "content_filter", "stop"],
     ) -> "Choices":
         from litellm.types.utils import Choices, Message
 
@@ -908,7 +921,15 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
         )
 
         if len(choices) == 0 and not response_is_incomplete:
-            raise ValueError(f"Unknown items in responses API response: {output_items}")
+            if raw_response.status == "completed" and _is_silent_output(output_items):
+                # A completed turn with nothing to say: no message and no tool
+                # call (empty output, or reasoning only). Chat Completions
+                # returns an empty assistant message with finish_reason "stop"
+                # for this case; mirror it instead of failing a successful
+                # request with a 500.
+                choices.append(self._build_empty_incomplete_choice(output_items, "stop"))
+            else:
+                raise ValueError(f"Unknown items in responses API response: {output_items}")
 
         if response_is_incomplete:
             incomplete_finish_reason: Final = _map_incomplete_reason_to_finish_reason(

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -3662,12 +3662,56 @@ def test_transform_response_incomplete_content_filter_maps_finish_reason():
     assert result.choices[0].message.content == ""
 
 
-def test_transform_response_zero_choices_not_incomplete_still_raises():
+def test_transform_response_zero_choices_not_completed_still_raises():
     handler = LiteLLMResponsesTransformationHandler()
     raw_response = _make_empty_responses_api_response()
+    raw_response.status = "in_progress"
 
     with pytest.raises(ValueError, match="Unknown items"):
         _call_transform_response(handler, raw_response)
+
+
+def test_transform_response_unknown_completed_item_still_raises():
+    handler = LiteLLMResponsesTransformationHandler()
+    raw_response = _make_empty_responses_api_response()
+    raw_response.output = [{"type": "mystery_item", "id": "x_1"}]
+
+    with pytest.raises(ValueError, match="Unknown items"):
+        _call_transform_response(handler, raw_response)
+
+
+def test_transform_response_empty_completed_output_returns_silent_stop_choice():
+    """A ``status: completed`` response with ``output: []`` is a legal silent turn
+    (seen live from gpt-5.6 on Bedrock Mantle right after a tool result). The
+    bridge mirrors Chat Completions: one empty assistant message with
+    finish_reason "stop", usage preserved, instead of a 500 (#37039)."""
+    handler = LiteLLMResponsesTransformationHandler()
+    raw_response = _make_empty_responses_api_response()
+
+    result = _call_transform_response(handler, raw_response)
+
+    assert len(result.choices) == 1
+    choice = result.choices[0]
+    assert choice.finish_reason == "stop"
+    assert choice.index == 0
+    assert choice.message.role == "assistant"
+    assert choice.message.content == ""
+    assert not choice.message.tool_calls
+    assert result.usage.total_tokens == 2
+
+
+def test_transform_response_reasoning_only_completed_output_returns_silent_stop_choice():
+    handler = LiteLLMResponsesTransformationHandler()
+    raw_response = _make_empty_responses_api_response()
+    raw_response.output = [_make_reasoning_only_output_item()]
+
+    result = _call_transform_response(handler, raw_response)
+
+    assert len(result.choices) == 1
+    choice = result.choices[0]
+    assert choice.finish_reason == "stop"
+    assert choice.message.content == ""
+    assert choice.message.reasoning_items[0]["encrypted_content"] == "enc_abc"
 
 
 def test_transform_response_completed_with_reasonless_incomplete_details_keeps_stop():


### PR DESCRIPTION
## TLDR

Problem this solves:

- `/v1/chat/completions` returns HTTP 500 when a Responses-mode model ends a turn with no output
- gpt-5.6 on Bedrock Mantle does this after a tool result; retries fail the same way

How it solves it:

- Return an empty assistant message with `finish_reason: stop`, as OpenAI's Chat Completions does
- Keep raising for a non-completed empty response and for unknown item types

## User Flow

Before: an agent that calls tools through the proxy has its run killed by a 500 that the model did not cause

1. They send POST https://litellm-domain/v1/chat/completions with `"model": "gpt-5.6-luna"` (a `bedrock_mantle/` deployment in Responses mode), the conversation so far, and `tools`
2. The model has nothing to add after the last tool result and ends the turn with no output
3. The proxy returns 500 with `Unknown items in responses API response: []`
4. Their agent retries three times, gets the same 500 each time, and marks the task as failed; https://litellm-domain/ui/?page=logs shows three failed requests

After: the same request returns a normal, empty assistant turn

1. They send the same POST https://litellm-domain/v1/chat/completions
2. The model ends the turn with no output, as before
3. The proxy returns 200 with `choices[0].message.content: ""`, `finish_reason: "stop"`, and the real `usage`
4. Their agent ends the turn cleanly; https://litellm-domain/ui/?page=logs shows one normal completion

## Relevant issues

Fixes #37039

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally: `pytest tests/test_litellm/completion_extras -q` → 124 passed
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)

## Changes

- `transform_response`: a `status: completed` response whose output has no `message` and no tool-call item (empty list, or reasoning only) becomes one assistant choice with `content: ""` and `finish_reason: "stop"`. Usage is preserved.
- `_is_silent_output()` makes that decision. `_build_empty_incomplete_choice()` now accepts `"stop"` so the completed case reuses the same reasoning-carrying builder as the incomplete case.
- A non-completed empty response and any unrecognized item type still raise `Unknown items in responses API response`, so a real parser gap stays loud.
- Tests: empty completed → stop choice; reasoning-only completed → stop choice with reasoning items; `in_progress` empty → still raises; unknown completed item → still raises. The existing `zero_choices_not_incomplete_still_raises` test asserted the buggy behaviour on exactly this input and now uses `status: in_progress`.
