### PR TITLE
fix(spend): compare auto-router targets by deployment identity

### DIFF
--- a/litellm/proxy/spend_tracking/savings.py
+++ b/litellm/proxy/spend_tracking/savings.py
@@ -299,6 +299,8 @@ def compute_autorouter_savings(
     selected_info: ModelInfo | None = None,
     baseline_info: ModelInfo | None = None,
     cost_breakdown: Mapping[str, object] | None = None,
+    baseline_deployment_id: str | None = None,
+    selected_deployment_id: str | None = None,
 ) -> float:
     """Net dollars the router saved, or cost, by serving this request on ``selected_model``.
 
@@ -334,11 +336,12 @@ def compute_autorouter_savings(
     selected: Final = _resolve_model(selected_model, selected_provider)
     if baseline is None or selected is None:
         return 0.0
-    # Same model is only the same cost when it is also the same deployment. Two
-    # deployments of one model can carry different negotiated rates, and routing from
-    # the dear one to the cheap one is a real saving that short-circuiting on the model
-    # name alone reports as zero.
-    if baseline == selected:
+    same_target: Final = (
+        baseline_deployment_id == selected_deployment_id
+        if baseline_deployment_id and selected_deployment_id
+        else baseline == selected
+    )
+    if same_target:
         return 0.0
     basis: Final = _pricing_basis(cost_breakdown)
     effective_baseline_info: Final = baseline_info if baseline_info is not None else _model_info(baseline)
@@ -517,6 +520,8 @@ def autorouter_savings_for_request(
         selected_info=_effective_model_info(router_instance, model_id, model or ""),
         baseline_info=_effective_model_info(router_instance, baseline_id, baseline_model or ""),
         cost_breakdown=cost_breakdown,
+        baseline_deployment_id=baseline_id,
+        selected_deployment_id=model_id,
     )
     classifier_cost: Final = classifier_cost_from_decision(decision)
     return gross if classifier_cost is None else gross - classifier_cost

--- a/tests/test_litellm/proxy/spend_tracking/test_savings.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_savings.py
@@ -1162,6 +1162,104 @@ def test_prompt_caching_prices_at_the_deployment_rate_not_the_public_one():
     assert result.prompt_caching > at_public_rates.prompt_caching
 
 
+@pytest.mark.parametrize(
+    "baseline_id, selected_id, selected_multiplier, billed_input, classifier_cost, expected",
+    [
+        ("baseline", "selected", 0.1, None, 0.0, 0.0135),
+        ("baseline", "selected", 2.0, None, 0.0, -0.015),
+        ("baseline", "selected", 1.0, None, 0.0, 0.0),
+        ("baseline", "selected", 0.1, 0.004, 0.001, 0.01),
+        ("baseline", "baseline", 0.1, 0.004, 0.001, -0.001),
+        (None, "selected", 0.1, None, 0.0, 0.0),
+        ("baseline", None, 0.1, None, 0.0, 0.0),
+        (None, None, 0.1, None, 0.0, 0.0),
+        ("", "selected", 0.1, None, 0.0, 0.0),
+        ("baseline", "", 0.1, None, 0.0, 0.0),
+    ],
+)
+def test_autorouter_savings_distinguishes_priced_deployments(
+    baseline_id: str | None,
+    selected_id: str | None,
+    selected_multiplier: float,
+    billed_input: float | None,
+    classifier_cost: float,
+    expected: float,
+) -> None:
+    router: Final = Router(
+        model_list=[
+            {
+                "model_name": name,
+                "litellm_params": {
+                    "model": "anthropic/claude-opus-5",
+                    "api_key": "test-key",
+                    "input_cost_per_token": 1e-5 * multiplier,
+                    "output_cost_per_token": 5e-5 * multiplier,
+                },
+                "model_info": {"id": name},
+            }
+            for name, multiplier in (("baseline", 1.0), ("selected", selected_multiplier))
+        ]
+    )
+    result: Final = compute_savings_spend(
+        model="claude-opus-5",
+        custom_llm_provider="anthropic",
+        compression_saved_tokens=0,
+        gateway_injected_cache=False,
+        model_id=selected_id,
+        llm_router=lambda: router,
+        routing_decision={
+            "savings_baseline_model": "anthropic/claude-opus-5",
+            "savings_baseline_deployment_id": baseline_id,
+            "conversation_continuing": False,
+            "classifier_cost": classifier_cost,
+        },
+        usage_object={"prompt_tokens": 1000, "completion_tokens": 100, "total_tokens": 1100},
+        cost_breakdown=None if billed_input is None else {"input_cost": billed_input, "output_cost": 0.0},
+    )
+    assert result.autorouter == pytest.approx(expected)
+
+
+@pytest.mark.parametrize("selected_model", ["azure/contract-deployment", "contract-deployment"])
+def test_autorouter_savings_recognizes_one_deployment_under_its_base_model(selected_model: str) -> None:
+    router: Final = Router(
+        model_list=[
+            {
+                "model_name": "contract",
+                "litellm_params": {
+                    "model": "azure/contract-deployment",
+                    "api_key": "test-key",
+                    "api_base": "https://example.openai.azure.com",
+                    "input_cost_per_token": 0.0001,
+                    "output_cost_per_token": 0.0002,
+                    "cache_read_input_token_cost": 0.00001,
+                },
+                "model_info": {"id": "contract", "base_model": "azure/gpt-5.5"},
+            }
+        ]
+    )
+    result: Final = compute_savings_spend(
+        model=selected_model,
+        custom_llm_provider="azure",
+        compression_saved_tokens=0,
+        gateway_injected_cache=False,
+        model_id="contract",
+        llm_router=lambda: router,
+        routing_decision={
+            "savings_baseline_model": "azure/gpt-5.5",
+            "savings_baseline_deployment_id": "contract",
+            "conversation_continuing": True,
+        },
+        usage_object={
+            "prompt_tokens": 21000,
+            "completion_tokens": 100,
+            "total_tokens": 21100,
+            "prompt_tokens_details": {"text_tokens": 1000, "cached_tokens": 0, "cache_creation_tokens": 20000},
+        },
+        cost_breakdown={"input_cost": 2.1, "output_cost": 0.02},
+    )
+    assert result.autorouter == 0.0
+
+
 def test_a_recorded_baseline_deployment_prices_at_its_configured_rate():
     """A hardest-tier deployment with a negotiated rate is what the traffic would
     really have cost; pricing its model publicly misstates the saving."""


### PR DESCRIPTION
## TLDR

Problem this solves:

- Auto-router savings compared provider/model names, not deployments
- Two differently priced deployments of one model reported $0.00
- One deployment seen under an alias and its base model could report a loss

How it solves it:

- Pass both deployment IDs into the savings calculation
- Compare IDs when both are present, keep canonical model fallback otherwise
- Pin negotiated-rate, unchanged-deployment, alias and missing-ID cases

## User Flow

Before: an operator routes between two differently priced deployments of the same model, but the dashboard reports no saving

1. The operator configures `cheap` and `expensive` deployments of `anthropic/claude-opus-5` with different negotiated rates, and an auto-router whose hardest tier is `expensive`
2. A developer sends POST http://localhost:4381/v1/chat/completions with `"model": "savings-router"` and gets `200 OK` with `x-litellm-model-id: cheap-opus`
3. The operator opens http://localhost:4381/ui/?page=logs and the request shows auto-router savings `0.0`, and http://localhost:4381/ui/?page=cost-optimization shows `$0.00` auto-router savings

After: the same request reports the negotiated-rate saving

1. The operator configures the same two deployments and auto-router
2. A developer sends the same POST http://localhost:4381/v1/chat/completions and gets `200 OK` with `x-litellm-model-id: cheap-opus`
3. The request now shows a positive auto-router saving equal to the expensive deployment's cost minus the cheap deployment's cost, and the cost-optimization total is the sum of those requests

## Relevant issues

- Savings identity now keys on deployment IDs when both sides carry one
- Pricing, classifier deduction and stored historical savings are unchanged
- Credit to @QuantumBreakz for proposing this approach in #38834

Fixes #38811

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup. The direct Anthropic key on this machine is out of credit, so both deployments call the sandbox gateway as an `anthropic/` upstream. The calls are real and billed. The proxy runs from the worktree source on port 4381 with a dedicated Postgres database. Both arms use the same config, database and commands

```yaml
model_list:
  - model_name: cheap
    litellm_params:
      model: anthropic/claude-opus-5
      api_key: os.environ/RIG_UPSTREAM_KEY
      api_base: https://gateway.litellm-sandbox.ai
      input_cost_per_token: 0.000001
      output_cost_per_token: 0.000005
    model_info:
      id: cheap-opus
  - model_name: expensive
    litellm_params:
      model: anthropic/claude-opus-5
      api_key: os.environ/RIG_UPSTREAM_KEY
      api_base: https://gateway.litellm-sandbox.ai
      input_cost_per_token: 0.000010
      output_cost_per_token: 0.000050
    model_info:
      id: expensive-opus
  - model_name: savings-router
    litellm_params:
      model: auto_router/complexity_router
      complexity_router_config:
        classifier_type: heuristic
        tiers:
          SIMPLE: cheap
          MEDIUM: cheap
          COMPLEX: expensive
          REASONING: expensive
router_settings:
  num_retries: 0
general_settings:
  master_key: os.environ/RIG_MASTER_KEY
```

Each case sends one request, then reads the stored row through the logs endpoint the dashboard uses. Expected saving per request is `prompt_tokens * 0.000009 + completion_tokens * 0.000045`, the configured rate difference between the two deployments

```bash
curl -sS -D - http://localhost:4381/v1/chat/completions -H "Authorization: Bearer $MASTER_KEY" -H "Content-Type: application/json" \
  -d '{"model":"savings-router","messages":[{"role":"user","content":"Reply with exactly OK. Probe <uuid>"}],"max_tokens":128}'
curl -sS "http://localhost:4381/spend/logs/ui?start_date=2026-09-08%2000:00:00&end_date=2026-09-08%2023:59:59&page_size=50" -H "Authorization: Bearer $MASTER_KEY"
```

### Before (9dbfb060bd)

#### /v1/chat/completions

1. Two requests, without and with caller `metadata`, both return `200 OK`, `x-litellm-model-id: cheap-opus`
2. Stored rows: 48 prompt / 30 completion tokens saved `0.0` (expected `0.001782`), 45 / 4 saved `0.0` (expected `0.000585`), baseline deployment `expensive-opus`

#### /v1/responses

1. Two requests, without and with caller `metadata`, both return `200 OK`, `x-litellm-model-id: cheap-opus`
2. Stored rows: 46 / 26 saved `0.0` (expected `0.001584`), 42 / 17 saved `0.0` (expected `0.001143`)

#### /v1/messages

1. Two requests, without and with caller `metadata`, both return `200 OK`, `x-litellm-model-id: cheap-opus`
2. Stored rows: 45 / 99 saved `0.0` (expected `0.00486`), 45 / 17 saved `0.0` (expected `0.00117`)

#### Dashboard total

1. `GET /user/daily/activity?start_date=2026-09-08&end_date=2026-09-08` returns `total_autorouter_savings_spend: 0.0`

### After (1a32663)

#### /v1/chat/completions

1. Two requests, without and with caller `metadata`, both return `200 OK`, `x-litellm-model-id: cheap-opus`
2. Stored rows: 44 / 21 saved `0.001341`, 45 / 4 saved `0.000585`, each equal to the expected rate difference

#### /v1/responses

1. Two requests, without and with caller `metadata`, both return `200 OK`, `x-litellm-model-id: cheap-opus`
2. Stored rows: 43 / 40 saved `0.002187`, 44 / 26 saved `0.001566`

#### /v1/messages

1. Two requests, without and with caller `metadata`, both return `200 OK`, `x-litellm-model-id: cheap-opus`
2. Stored rows: 49 / 26 saved `0.001611`, 46 / 17 saved `0.001179`

#### Dashboard total

1. `GET /user/daily/activity?start_date=2026-09-08&end_date=2026-09-08` returns `total_autorouter_savings_spend: 0.008469`, the sum of the six rows above

#### Unchanged deployment control

1. `POST /model/new` adds `unchanged-router` with every tier on `cheap`, then one `POST /v1/chat/completions` returns `200 OK`
2. Stored row: selected `cheap-opus`, baseline `cheap-opus`, saved `0.0`

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Rows already written with `0.0` keep that figure; there is no backfill
- The session cache-transition rollup still classifies turns by model name; that is a separate mechanism and out of scope here

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Spend-dashboard metric logic only; pricing and logging paths are unchanged aside from when savings are zero vs computed.
> 
> **Overview**
> Auto-router **savings** no longer treat two differently priced deployments of the same model as **$0** because they share a canonical model name.
> 
> `compute_autorouter_savings` accepts **baseline** and **selected deployment IDs** and treats a route as unchanged only when both IDs match (when present); otherwise it falls back to the previous canonical model comparison. `autorouter_savings_for_request` passes `savings_baseline_deployment_id` and the served `model_id` through that path.
> 
> New tests cover **negotiated-rate** gaps between deployments, **same deployment** (including alias vs base model), missing IDs, and classifier / billed-cost netting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a32663b717d6ce6d5120f84a0cbac48fd39d814. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->