### PR TITLE
fix(bridge): ignore empty tool call argument deltas

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -1462,7 +1462,7 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
                         )
                     ]
                 )
-            else:
+            elif content_part != "":
                 raise ValueError(f"Chat provider: Invalid function argument delta {parsed_chunk}")
         elif event_type == ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE:
             # New output item added

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -339,6 +339,43 @@ def test_chunk_parser_function_call_added_produces_tool_use():
     assert choice.finish_reason is None
 
 
+@pytest.mark.parametrize(
+    "event_type",
+    [
+        "response.function_call_arguments.delta",
+        "response.custom_tool_call_input.delta",
+    ],
+)
+def test_chunk_parser_empty_tool_call_delta_is_noop(event_type: str) -> None:
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        OpenAiResponsesToChatCompletionStreamIterator,
+    )
+
+    chunks: Final = (
+        {"type": event_type, "output_index": 0, "delta": ""},
+        {"type": event_type, "output_index": 0, "delta": '{"city":'},
+    )
+    iterator: Final = OpenAiResponsesToChatCompletionStreamIterator(
+        streaming_response=iter(f"data: {json.dumps(chunk)}" for chunk in chunks),
+        sync_stream=True,
+    )
+
+    empty_result: Final = next(iterator)
+    assert empty_result.choices[0].delta.content == ""
+    assert empty_result.choices[0].delta.tool_calls is None
+    assert empty_result.choices[0].finish_reason is None
+
+    content_result: Final = next(iterator)
+    tool_calls: Final = content_result.choices[0].delta.tool_calls
+    assert tool_calls is not None
+    tool_call: Final = tool_calls[0]
+    assert tool_call.function.arguments == '{"city":'
+    assert content_result.choices[0].finish_reason is None
+
+    with pytest.raises(ValueError, match="Invalid function argument delta"):
+        iterator.chunk_parser({"type": event_type, "output_index": 0})
+
+
 def test_transform_response_with_reasoning_and_output():
     """Test transform_response handles ResponsesAPIResponse with reasoning items and output messages."""
     from unittest.mock import Mock


### PR DESCRIPTION
## TLDR

Problem this solves:

- Empty streamed tool arguments crash chat completions
- Affected streams end with an in-stream 500 error

How it solves it:

- Treats empty argument deltas as no-op chunks
- Preserves errors for missing or invalid deltas

## User Flow

Before: a developer streaming a forced tool call receives an error instead of a completed call

1. They send `POST https://litellm-domain/v1/chat/completions` with `"stream": true` and a forced function tool
2. They receive the initial tool-call SSE chunk with empty arguments
3. The next SSE event is a 500 error containing `Invalid function argument delta`
4. Their client cannot assemble or execute the requested tool call

After: the same request completes with usable tool-call arguments

1. They send `POST https://litellm-domain/v1/chat/completions` with `"stream": true` and a forced function tool
2. They receive the initial tool-call SSE chunk with empty arguments
3. The stream continues with the remaining argument chunks and `finish_reason: "tool_calls"`
4. Their client assembles `{"city": "Paris, France"}` and can execute the tool call

## Relevant issues

Fixes #40069

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup:

- Actual provider: Alibaba Cloud Model Studio, Beijing Responses endpoint
- Actual model: `qwen3.7-flash`
- Proxy route: `POST /v1/chat/completions`
- Request: streaming forced `get_weather` function call for Paris
- No mocks; the provider response was passed through unchanged
- This checkout's model map predates `qwen3.7-flash`, so the process registered only its real native-streaming capability to prevent LiteLLM's synthetic fallback stream

Request command used on both commits:

```powershell
curl.exe --silent --show-error --no-buffer `
  --request POST http://127.0.0.1:4100/v1/chat/completions `
  --header "Authorization: Bearer proof-key-not-secret" `
  --header "Content-Type: application/json" `
  --data-binary "@.issue_40069_request.json"
```

### Before (`13df85cceb85c85f990ac2a25214f43f03fdfb4f`)

1. Start the proxy at this commit with the shared provider, model, config, and request payload
2. Run the shared curl command; it returns HTTP 200 and the first tool-call chunk
3. Observe the real empty argument delta at sequence 3 becomes an in-stream error:

```text
data: {"choices":[{"delta":{"role":"assistant","tool_calls":[{"function":{"arguments":"","name":"get_weather"}}]}}]}

data: {"error":{"message":"... Invalid function argument delta ... 'delta': '', 'sequence_number': 3 ...","code":"500"}}
```

### After (`3269b967665a76b8d57e088a33f919c8db1c628f`)

1. Start the proxy at this commit with the shared provider, model, config, and request payload
2. Run the shared curl command; it returns HTTP 200 and the first tool-call chunk
3. Observe the empty argument delta is harmless and the real stream completes:

```text
data: {"choices":[{"delta":{"role":"assistant","tool_calls":[{"function":{"arguments":"","name":"get_weather"}}]}}]}
data: {"choices":[{"delta":{"tool_calls":[{"function":{"arguments":"{\"city\": "}}]}}]}
data: {"choices":[{"delta":{"tool_calls":[{"function":{"arguments":"\"Paris, France"}}]}}]}
data: {"choices":[{"delta":{"tool_calls":[{"function":{"arguments":"\""}}]}}]}
data: {"choices":[{"delta":{"tool_calls":[{"function":{"arguments":"}"}}]}}]}
data: {"choices":[{"finish_reason":"tool_calls","delta":{}}]}
data: [DONE]
```

The direct provider response independently contained an empty `response.function_call_arguments.delta` at sequence 3 and completed normally (`resp_af37ce41-de38-93d7-8644-eb6e831cd3cc`).

## Type

🐛 Bug Fix

## Caveats (if any)

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
