### PR TITLE
chore(lint): clear the last violation of 11 strict ruff rules

### DIFF
--- a/litellm/integrations/weights_biases.py
+++ b/litellm/integrations/weights_biases.py
@@ -4,17 +4,9 @@ imported_openAIResponse = True
 try:
     import io
     import logging
-    import sys
-    from typing import Any, TypeVar
+    from typing import Any, Literal, Protocol, TypeVar
 
     from wandb.sdk.data_types import trace_tree
-
-    if sys.version_info >= (3, 8):
-        from typing import Literal, Protocol
-    else:
-        from typing import Literal
-
-        from typing_extensions import Protocol
 
     logger: Final = logging.getLogger(__name__)
 

--- a/litellm/litellm_core_utils/coroutine_checker.py
+++ b/litellm/litellm_core_utils/coroutine_checker.py
@@ -36,9 +36,8 @@ class CoroutineChecker:
         target = callback
         if not inspect.isfunction(target) and not inspect.ismethod(target):
             try:
-                call_attr: Final = getattr(target, "__call__", None)
-                if call_attr is not None:
-                    target = call_attr
+                if callable(target):
+                    target = target.__call__
             except Exception:
                 pass
 

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -1756,7 +1756,7 @@ def convert_to_anthropic_tool_invoke(
     anthropic_tool_invoke: Final[list[AnthropicMessagesToolUseParam | dict[str, object]]] = []
 
     for tool in tool_calls:
-        if not get_attribute_or_key(tool, "type") == "function":
+        if get_attribute_or_key(tool, "type") != "function":
             continue
 
         tool_id = cast(str, get_attribute_or_key(tool, "id"))

--- a/litellm/litellm_core_utils/token_counter.py
+++ b/litellm/litellm_core_utils/token_counter.py
@@ -414,7 +414,7 @@ def token_counter(
         params: Final = _MessageCountParams(model, custom_tokenizer)
         num_tokens = _count_messages(params, new_messages, use_default_image_token_count, default_token_count)
         if count_response_tokens is False:
-            includes_system_message: Final = any([message.get("role", None) == "system" for message in new_messages])
+            includes_system_message: Final = any(message.get("role", None) == "system" for message in new_messages)
             num_tokens += _count_extra(params.count_function, tools, tool_choice, includes_system_message)
 
     else:

--- a/litellm/llms/azure_ai/common_utils.py
+++ b/litellm/llms/azure_ai/common_utils.py
@@ -138,9 +138,8 @@ class AzureFoundryModelInfo(BaseLLMModelInfo):
         return api_key or litellm.api_key or get_secret_str("AZURE_AI_API_KEY")
 
     @property
-    def api_version(self, api_version: str | None = None) -> str | None:
-        api_version = api_version or litellm.api_version or get_secret_str("AZURE_API_VERSION")
-        return api_version
+    def api_version(self) -> str | None:
+        return litellm.api_version or get_secret_str("AZURE_API_VERSION")
 
     def get_token_counter(self) -> BaseTokenCounter | None:
         """

--- a/litellm/proxy/guardrails/guardrail_hooks/javelin/javelin.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/javelin/javelin.py
@@ -44,7 +44,7 @@ class JavelinGuardrail(CustomGuardrail):
         application: str | None = None,
         **kwargs,
     ):
-        f"""
+        """
         Initialize the JavelinGuardrail class.
 
         This calls: {api_base}/{api_version}/guardrail/{guardrail_name}/apply

--- a/litellm/proxy/guardrails/guardrail_hooks/mcp_end_user_permission/__init__.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/mcp_end_user_permission/__init__.py
@@ -15,7 +15,7 @@ def initialize_guardrail(litellm_params: "LitellmParams", guardrail: "Guardrail"
     # We check the raw guardrail dict because LitellmParams normalizes None → False,
     # making it impossible to distinguish "not set" from "explicitly false" via litellm_params.
     _raw_default_on: Final = cast(dict[str, Any], guardrail).get("litellm_params", {}).get("default_on")
-    _default_on: Final = False if _raw_default_on is False else True
+    _default_on: Final = _raw_default_on is not False
 
     _callback: Final = MCPEndUserPermissionGuardrail(
         guardrail_name=guardrail.get("guardrail_name", ""),

--- a/litellm/proxy/management_helpers/team_metadata_validation.py
+++ b/litellm/proxy/management_helpers/team_metadata_validation.py
@@ -116,7 +116,8 @@ async def run_team_metadata_validation(
             },
         )
     if not (
-        inspect.iscoroutinefunction(validator) or inspect.iscoroutinefunction(getattr(validator, "__call__", None))
+        inspect.iscoroutinefunction(validator)
+        or (callable(validator) and inspect.iscoroutinefunction(validator.__call__))
     ):
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/litellm/proxy/spend_tracking/spend_tracking_utils.py
+++ b/litellm/proxy/spend_tracking/spend_tracking_utils.py
@@ -152,7 +152,7 @@ def _get_spend_logs_metadata(
             requester_ip_address=None,
             additional_usage_values=None,
             applied_guardrails=None,
-            status=None or "success",
+            status="success",
             error_information=None,
             proxy_server_request=None,
             batch_models=None,

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -4,6 +4,7 @@ import copy
 import hashlib
 import inspect
 import json
+import math
 import os
 import smtplib
 import ssl
@@ -5887,7 +5888,7 @@ class PrismaClient:
             return None
         try:
             value: Final = float(response_time_ms)
-            return value if value == value and value not in (float("inf"), float("-inf")) else None
+            return value if math.isfinite(value) else None
         except (ValueError, TypeError):
             verbose_proxy_logger.warning("Invalid response_time_ms value: %s", response_time_ms)
             return None

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -4024,9 +4024,9 @@ class Router:
                 except KeyError:
                     pass
 
-        for model in models:
+        for model_name in models:
             task = asyncio.create_task(
-                _async_completion_no_exceptions(model=model, messages=messages, stream=stream, **kwargs)
+                _async_completion_no_exceptions(model=model_name, messages=messages, stream=stream, **kwargs)
             )
             pending_tasks.append(task)
 

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -6188,7 +6188,7 @@ def function_to_dict(input_function) -> dict:
             "enum": param_enum,
         }
 
-        parameters[param_name] = dict([(k, v) for k, v in param_dict.items() if isinstance(v, str)])
+        parameters[param_name] = {k: v for k, v in param_dict.items() if isinstance(v, str)}
 
         # Check if the parameter has no default value (i.e., it's required)
         if param.default == param.empty:

--- a/tests/test_litellm/litellm_core_utils/test_coroutine_checker.py
+++ b/tests/test_litellm/litellm_core_utils/test_coroutine_checker.py
@@ -84,6 +84,23 @@ class TestCoroutineChecker:
         assert self.checker.is_async_callable(obj.sync_method) is False
         assert self.checker.is_async_callable(SyncCallable()) is False
 
+    def test_instance_attribute_dunder_call_is_not_callable(self):
+        """An async __call__ set on the instance does not make the object callable."""
+
+        async def async_func():
+            return "async"
+
+        class NotCallable:
+            pass
+
+        obj = NotCallable()
+        obj.__call__ = async_func  # readable attribute, but never used for a call
+
+        with pytest.raises(TypeError):
+            obj()
+
+        assert self.checker.is_async_callable(obj) is False
+
     def test_is_async_callable_caching(self):
         """Test that is_async_callable caches callable objects."""
 


### PR DESCRIPTION
## User Flow

Only one change in this PR is observable from outside the code. The rest are equivalence preserving rewrites, covered under Caveats

Before: a developer setting up the Javelin guardrail gets no help text when they inspect it, so they have to go read the source to learn the arguments

1. They start a Python shell and import `JavelinGuardrail` from `litellm.proxy.guardrails.guardrail_hooks.javelin.javelin`
2. They run `help(JavelinGuardrail.__init__)` to see what it accepts
3. Nothing comes back, because the docstring is `None`
4. They open the file and read the argument list by hand

After: the same inspection prints the argument list the author already wrote

1. They start a Python shell and import `JavelinGuardrail` the same way
2. They run `help(JavelinGuardrail.__init__)`
3. The docstring prints, naming `api_key`, `api_base`, `default_on`, `api_version`, `guardrail_name`, `metadata`, `config` and `application`
4. They configure the guardrail without opening the source

## Relevant issues

None. This came out of reading `ruff-strict-budget.json` for rules close to zero

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Screenshots / Proof of Fix

Two commands, run from the repo root at each commit, using the ruff pinned in the dev group. Command A asks ruff for every violation of the eleven rules:

```
ruff check --config ruff-strict.toml \
  --select B004,B021,C404,C419,PLR0124,PLR0206,PLR1704,SIM201,SIM211,SIM222,UP036 \
  --no-fix --output-format concise litellm/
```

Command B reads the Javelin docstring back:

```
python -c "from litellm.proxy.guardrails.guardrail_hooks.javelin.javelin import JavelinGuardrail
print(JavelinGuardrail.__init__.__doc__)"
```

### Before (9dbfb060bd)

#### Each of the eleven rules still carries its last violation

1. Run command A
2. Output:

```
litellm\integrations\weights_biases.py:12:8: UP036 Version block is outdated for minimum Python version
litellm\litellm_core_utils\coroutine_checker.py:39:36: B004 Using `hasattr(x, "__call__")` to test if x is callable is unreliable. Use `callable(x)` for consistent results.
litellm\litellm_core_utils\prompt_templates\factory.py:1759:12: SIM201 Use `get_attribute_or_key(tool, "type") != "function"` instead of `not get_attribute_or_key(tool, "type") == "function"`
litellm\litellm_core_utils\token_counter.py:417:50: C419 Unnecessary list comprehension
litellm\llms\azure_ai\common_utils.py:141:9: PLR0206 Cannot have defined parameters for properties
litellm\proxy\guardrails\guardrail_hooks\javelin\javelin.py:47:9: B021 f-string used as docstring. Python will interpret this as a joined string, rather than a docstring.
litellm\proxy\guardrails\guardrail_hooks\mcp_end_user_permission\__init__.py:18:26: SIM211 Use `not ...` instead of `False if ... else True`
litellm\proxy\management_helpers\team_metadata_validation.py:119:79: B004 Using `hasattr(x, "__call__")` to test if x is callable is unreliable. Use `callable(x)` for consistent results.
litellm\proxy\spend_tracking\spend_tracking_utils.py:155:20: SIM222 Use `"success"` instead of `... or "success"`
litellm\proxy\utils.py:5890:29: PLR0124 Name compared with itself, consider replacing `value == value`
litellm\router.py:4027:13: PLR1704 Redefining argument with the local name `model`
litellm\utils.py:6191:34: C404 Unnecessary list comprehension (rewrite as a dict comprehension)
Found 12 errors.
```

#### The Javelin docstring is discarded

1. Run command B
2. Output:

```
None
```

### After (c3fc8aedb7)

#### All eleven rules are clear

1. Run command A
2. Output:

```
All checks passed!
```

#### The Javelin docstring survives

1. Run command B
2. Output:

```
        Initialize the JavelinGuardrail class.

        This calls: {api_base}/{api_version}/guardrail/{guardrail_name}/apply

        Args:
            api_key: str = None,
            api_base: str = None,
            ...
```

Paths read with backslashes because both runs were on Windows

Every rule in `ruff-strict-budget.json` was counted at both commits as well. This branch raises none of them, and the fourteen rules currently above their limit read identically at the merge base, so they are existing drift rather than anything added here

## Type

Refactoring

## Caveats (if any)

### Medium

- Eight of the eleven rewrites change no runtime behavior
  - A dict comprehension, a generator handed to `any()`, `!=` over `not ==`, a plain boolean over a conditional expression, a constant over `None or "success"`, `math.isfinite` over a NaN self comparison paired with an inf membership test, a renamed loop variable, and a dead `sys.version_info >= (3, 8)` branch under a `>=3.10` floor
  - There is no request path to curl for these, so the proof above is the rule count

### Low

- `B004` rewrites two `getattr(x, "__call__")` probes as `callable(x)`
  - Ruff's hint says to replace the expression with `callable()`, which would break both sites, since each needs the `__call__` object to hand to `inspect.iscoroutinefunction`
  - `callable()` resolves `__call__` on the type the way a real call does, so an object carrying `__call__` as an instance attribute is no longer reported as an async callable when calling it would raise `TypeError`
  - `tests/test_litellm/litellm_core_utils/test_coroutine_checker.py` covers that case, and it fails against the old implementation
- `PLR0206` drops an `api_version` parameter from a property getter on `AzureFoundryModelInfo`
  - Attribute access cannot pass arguments, so it was unreachable and read as `None` on every call
- `B019` and `N999` are left at one violation each, for separate PRs
  - `B019` needs the `lru_cache` moved off the method onto a per instance cache, and four test files assert on `cache_info`
  - `N999` renames `litellm/proxy/lambda.py`, which deployment config points at
- `ruff-strict-budget.json` is untouched, per CLAUDE.md
- `tests/test_litellm/litellm_core_utils/test_coroutine_checker.py` still has older 88 column formatting in parts I did not touch, left alone to keep the diff scoped
