### PR TITLE
fix(vertex): distinguish missing/unreadable credential file from invalid JSON

### DIFF
--- a/litellm/llms/vertex_ai/vertex_llm_base.py
+++ b/litellm/llms/vertex_ai/vertex_llm_base.py
@@ -150,8 +150,7 @@ class VertexBase:
                             json_obj = json.load(f)
                     except FileNotFoundError as e:
                         raise Exception(
-                            "Unable to load vertex credentials from file path: "
-                            f"{credentials}. File not found. ({e})"
+                            f"Unable to load vertex credentials from file path: {credentials}. File not found. ({e})"
                         ) from e
                     except PermissionError as e:
                         raise Exception(
@@ -163,7 +162,7 @@ class VertexBase:
                             "Unable to load vertex credentials from file path: "
                             f"{credentials}. Unable to read file. ({e})"
                         ) from e
-                    except json.JSONDecodeError as e:
+                    except (json.JSONDecodeError, UnicodeDecodeError) as e:
                         raise Exception(
                             "Unable to load vertex credentials from file path: "
                             f"{credentials}. Ensure the JSON is valid "

--- a/litellm/llms/vertex_ai/vertex_llm_base.py
+++ b/litellm/llms/vertex_ai/vertex_llm_base.py
@@ -127,27 +127,49 @@ class VertexBase:
     ) -> tuple[_VertexCredentialsObject | None, str]:
         if credentials is not None:
             if isinstance(credentials, str):
-                _is_path: Final = os.path.exists(
-                    credentials
-                )  # credentials is from server config (litellm_params), not user input
                 verbose_logger.debug(
-                    "Vertex: Loading vertex credentials, is_file_path=%s, current dir %s",
-                    _is_path,
+                    "Vertex: Loading vertex credentials, current dir %s",
                     os.getcwd(),
                 )
 
-                try:
-                    if _is_path:
+                # Decide by value shape, not os.path.exists(): exists()
+                # swallows every OSError (missing, unreadable, transient),
+                # which previously misreported all of them as invalid JSON.
+                if credentials.lstrip().startswith("{"):
+                    try:
+                        json_obj = json.loads(credentials)
+                    except json.JSONDecodeError as e:
+                        raise Exception(
+                            "Unable to load vertex credentials from environment. "
+                            "Ensure the JSON is valid (check for unescaped newlines in private_key). "
+                            f"Parse error: {type(e).__name__}: {e}"
+                        ) from e
+                else:
+                    try:
                         with open(credentials) as f:
                             json_obj = json.load(f)
-                    else:
-                        json_obj = json.loads(credentials)
-                except Exception as e:
-                    raise Exception(
-                        "Unable to load vertex credentials from environment. "
-                        "Ensure the JSON is valid (check for unescaped newlines in private_key). "
-                        f"Parse error: {type(e).__name__}"
-                    )
+                    except FileNotFoundError as e:
+                        raise Exception(
+                            "Unable to load vertex credentials from file path: "
+                            f"{credentials}. File not found. ({e})"
+                        ) from e
+                    except PermissionError as e:
+                        raise Exception(
+                            "Unable to load vertex credentials from file path: "
+                            f"{credentials}. File not readable (permission denied). ({e})"
+                        ) from e
+                    except OSError as e:
+                        raise Exception(
+                            "Unable to load vertex credentials from file path: "
+                            f"{credentials}. Unable to read file. ({e})"
+                        ) from e
+                    except json.JSONDecodeError as e:
+                        raise Exception(
+                            "Unable to load vertex credentials from file path: "
+                            f"{credentials}. Ensure the JSON is valid "
+                            "(check for unescaped newlines in private_key). "
+                            f"Parse error: {type(e).__name__}: {e}"
+                        ) from e
             elif isinstance(credentials, dict):
                 json_obj = credentials
             else:

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_llm_base.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_llm_base.py
@@ -2193,3 +2193,36 @@ class TestVertexBase:
 
             assert token == "cached-token"
             assert not mock_get_lock.called, "Fast path should not acquire lock"
+
+
+class TestLoadAuthCredentialFileErrors:
+    def test_missing_credential_file_names_path(self):
+        vertex_base = VertexBase()
+        with pytest.raises(Exception, match="File not found"):
+            vertex_base.load_auth(
+                credentials="/nonexistent/vertexai.json", project_id="p"
+            )
+
+    def test_unreadable_credential_file_names_path(self):
+        vertex_base = VertexBase()
+        with patch(
+            "builtins.open", side_effect=PermissionError(13, "Permission denied")
+        ):
+            with pytest.raises(Exception, match="not readable"):
+                vertex_base.load_auth(
+                    credentials="/some/vertexai.json", project_id="p"
+                )
+
+    def test_malformed_credential_file_keeps_json_advice(self, tmp_path):
+        bad_file = tmp_path / "vertexai.json"
+        bad_file.write_text("{not json")
+        vertex_base = VertexBase()
+        with pytest.raises(Exception, match="Ensure the JSON is valid"):
+            vertex_base.load_auth(
+                credentials=str(bad_file), project_id="p"
+            )
+
+    def test_malformed_inline_json_keeps_environment_message(self):
+        vertex_base = VertexBase()
+        with pytest.raises(Exception, match="from environment"):
+            vertex_base.load_auth(credentials="{not json", project_id="p")


### PR DESCRIPTION
## TLDR

Problem this solves:

- Missing vertex credentials file reports as invalid JSON
- Unreadable file also reports as invalid JSON
- Operators chase broken keys instead of storage

How it solves it:

- Branch on value shape, not os.path.exists
- Name missing, unreadable, malformed separately
- Chain original errno via raise from

## User Flow

Before: operator with a broken credentials path gets a key-content error, fixes the wrong thing

1. They set `vertex_credentials` to `/mnt/persistent/config/vertexai.json` and serve Vertex traffic normally
2. The file becomes unreadable (missing, permissions, network FS error)
3. They send POST https://litellm-domain/v1/chat/completions for a Vertex model and get `500`
4. Logs say invalid JSON with `private_key` newline advice, so they re-issue a key that was never broken

After: same outage names the file problem, so storage gets fixed

1. Same config serving Vertex traffic normally
2. The file becomes unreadable for the same reasons
3. Same POST returns `500` while unreadable, as before
4. Logs name the path with File not found / not readable plus errno, or invalid JSON only when contents are truly malformed

## Relevant issues

Fixes #40166

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

Note: full `uv run pytest` / `make lint` not run locally (deps not installed in this Windows env); relying on CI per the guide. `py_compile` passes on both files. Isolated logic check passes (missing file -> File not found, bad inline JSON -> environment message preserved, valid inline parses).

## Screenshots / Proof of Fix

Shared setup: no GCP project needed, failure happens at credential load before any provider call.

### Before (upstream main, issue repro)

1. Run `python -c "from litellm.llms.vertex_ai.vertex_llm_base import VertexBase; VertexBase().load_auth(credentials='/nonexistent/vertexai.json', project_id='p')"`
2. Observe `Unable to load vertex credentials from environment. Ensure the JSON is valid (check for unescaped newlines in private_key). Parse error: JSONDecodeError`

### After (6c999c5)

1. Same command with missing path
2. Observe `Unable to load vertex credentials from file path: /nonexistent/vertexai.json. File not found. ([Errno 2] ...)`
3. Same command with malformed inline JSON `{not json`
4. Observe original environment message preserved

## Type
- Bug Fix

## Caveats (if any)

### Low

- Inline JSON detection keys on leading `{` after whitespace
- A path starting with `{` would parse as JSON,acceptable tradeoff

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

