### PR TITLE
fix(proxy): drop stale passthrough content length

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -1545,6 +1545,7 @@ class ProxyBaseLLMRequestProcessing:
         excluded_headers: Final = {  # mutable-ok: set of header names to exclude from forwarding
             "transfer-encoding",
             "content-encoding",
+            "content-length",
             "set-cookie",
             "connection",
             "keep-alive",

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -8014,3 +8014,22 @@ class TestDetachedStreamFailureHook:
         await logging_obj._on_detached_stream_failure(failure)
 
         assert [call["original_exception"] for call in recorder.calls] == [failure]
+
+
+def test_passthrough_streaming_headers_drop_upstream_content_length():
+    """The proxy must recalculate framing headers for streamed passthrough bodies."""
+    merged = ProxyBaseLLMRequestProcessing._merge_passthrough_streaming_headers(
+        response_headers=httpx.Headers(
+            {
+                "content-type": "application/json",
+                "content-length": "0",
+                "transfer-encoding": "chunked",
+            }
+        ),
+        custom_headers={"x-litellm-model-id": "bedrock/claude"},
+    )
+
+    assert merged["content-type"] == "application/json"
+    assert merged["x-litellm-model-id"] == "bedrock/claude"
+    assert "content-length" not in merged
+    assert "transfer-encoding" not in merged


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bedrock Converse passthrough can return a non-empty body with Content-Length: 0.
- Clients receive an empty response or an ASGI framing error.

How it solves it:

- Stop forwarding upstream Content-Length on passthrough streaming responses.
- Add a regression test covering stale zero-length framing.

## User Flow

Before: a Bedrock SDK call through the LiteLLM proxy fails to parse the response.

1. The developer sends POST /bedrock/model/bedrock%2Fclaude-haiku-4-5/converse with a valid Converse request.
2. The model returns a valid Converse JSON body, but the proxy response advertises Content-Length: 0.
3. The SDK receives no usable body or raises a response parsing error.

After: the same Bedrock SDK call receives the complete Converse response.

1. The developer sends POST /bedrock/model/bedrock%2Fclaude-haiku-4-5/converse with the same request.
2. The proxy omits the stale upstream Content-Length header and lets the response layer compute framing.
3. The SDK receives and parses the complete Converse JSON body successfully.

## Relevant issues

Fixes #40131

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The target test file passes locally: 324 passed
- [x] Ruff checks and Python compilation pass for the changed files
- [x] The change is isolated to one proxy response-header bug

## Validation

- pytest tests/test_litellm/proxy/test_common_request_processing.py -q --basetemp .pytest-tmp
- ruff check --select E9,F401,F821,ASYNC on the changed files
- python -m compileall on the changed files
- git diff --check