### PR TITLE
fix(router): refresh repeated cooldown expiry

### DIFF
--- a/litellm/router_utils/cooldown_cache.py
+++ b/litellm/router_utils/cooldown_cache.py
@@ -93,6 +93,9 @@ class CooldownCache:
             )
 
             # Set the cache with a TTL equal to the cooldown time
+            self.cache.in_memory_cache.delete_cache(  # pyright: ignore[reportUnknownMemberType]  # InMemoryCache is untyped
+                cooldown_key
+            )
             self.cache.set_cache(
                 value=cooldown_data,
                 key=cooldown_key,

--- a/tests/router_unit_tests/test_router_cooldown_per_deployment.py
+++ b/tests/router_unit_tests/test_router_cooldown_per_deployment.py
@@ -231,6 +231,19 @@ class TestCooldownCacheTTLCorrection:
         dual_cache = DualCache(in_memory_cache=in_memory)
         return CooldownCache(cache=dual_cache, default_cooldown_time=60.0)
 
+    def test_repeated_cooldown_refreshes_in_memory_expiry(self):
+        cc = self._make_cooldown_cache()
+        model_id = "repeated-cooldown-deployment"
+
+        with patch("time.time", return_value=100.0):
+            cc.add_deployment_to_cooldown(model_id, Exception("429"), 429, cooldown_time=1.0)
+        with patch("time.time", return_value=100.2):
+            cc.add_deployment_to_cooldown(model_id, Exception("429"), 429, cooldown_time=60.0)
+        with patch("time.time", return_value=101.5):
+            active = cc.get_active_cooldowns(model_ids=[model_id], parent_otel_span=None)
+
+        assert [deployment_id for deployment_id, _ in active] == [model_id]
+
     def test_expired_entry_evicted_and_not_returned(self):
         """
         An entry with timestamp+cooldown_time in the past must be evicted from


### PR DESCRIPTION
## TLDR

Problem this solves:

- Repeated cooldowns kept the first in-memory expiry
- Deployments returned to rotation before the latest cooldown ended

How it solves it:

- Clears the stale local entry before writing the new cooldown
- Adds a regression test for shorter-to-longer cooldown renewal

## User Flow

Before: a rate-limited deployment returns to rotation after the first one-second cooldown, despite a later 60-second cooldown

1. The developer's app sends `POST https://litellm.example.com/v1/chat/completions` to a model backed by two deployments
2. One deployment returns 429 with `Retry-After: 1`
3. A slower request to that deployment returns 429 without `Retry-After`, so the configured 60-second cooldown applies
4. After one second, the app sends the same request and receives another 429 from the rate-limited deployment
5. The logs page shows traffic reaching that deployment during its expected 60-second cooldown

After: the same rate-limited deployment stays out of rotation for the latest 60-second cooldown

1. The developer's app sends `POST https://litellm.example.com/v1/chat/completions` to a model backed by two deployments
2. One deployment returns 429 with `Retry-After: 1`
3. A slower request to that deployment returns 429 without `Retry-After`, so the configured 60-second cooldown applies
4. After one second, the app sends the same request and receives a 200 from the healthy deployment
5. The logs page shows no traffic reaching the rate-limited deployment during the cooldown

## Relevant issues

Fixes #40130

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

The reproduction uses the issue's local provider stub. One deployment returns concurrent 429 responses, first with `Retry-After: 1` and then without it. The second deployment returns 200

### Before (1af7a403c6)

1. Run `uv run python /tmp/repro_cooldown_extension.py` on the merge base
2. The cached value records 60 seconds, but the actual expiry is only `0.64s`
3. At `t+2.07s`, the active cooldown list is empty instead of containing `dep-a`
4. Ten later requests send one request to `dep-a` and return one 429

```console
recorded cooldown_time : 60 (router default)
actual expiry in       : 0.64s
t+2.07s  cooling down  : []   EXPECTED ['dep-a']
429s returned to caller: 1   EXPECTED 0
requests sent to dep-a : 1   EXPECTED 0
```

### After (fa5c832523)

1. Run the same command on this branch
2. The cached value records 60 seconds and the actual expiry is `59.99s`
3. At `t+1.74s`, the active cooldown list still contains `dep-a`
4. Ten later requests all return 200 and send no traffic to `dep-a`

```console
recorded cooldown_time : 60 (router default)
actual expiry in       : 59.99s
t+1.74s  cooling down  : ['dep-a']   EXPECTED ['dep-a']
429s returned to caller: 0   EXPECTED 0
requests sent to dep-a : 0   EXPECTED 0
```

## Type

Bug Fix

## Caveats (if any)

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
