### PR TITLE
fix(responses-bridge): carry prompt_cache_breakpoint through the chat -> responses conversion

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -26,6 +26,7 @@ from litellm import ModelResponse
 from litellm._logging import verbose_logger
 from litellm.litellm_core_utils.prompt_templates.common_utils import (
     responses_reasoning_item_from_thinking_blocks,
+    with_prompt_cache_breakpoint,
 )
 from litellm.llms.base_llm.base_model_iterator import BaseModelResponseIterator
 from litellm.llms.base_llm.bridges.completion_transformation import (
@@ -1033,16 +1034,22 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
                     # Handle multimodal content
                     original_type = item.get("type")
                     if original_type == "text":
-                        converted = self._convert_content_str_to_input_text(item.get("text", ""), role)
+                        converted = with_prompt_cache_breakpoint(
+                            self._convert_content_str_to_input_text(item.get("text", ""), role),
+                            item.get("prompt_cache_breakpoint"),
+                        )
                         result.append(converted)
                         verbose_logger.debug("Chat provider:   text -> %s", converted)
                     elif original_type == "image_url":
                         # Map to responses API image format
-                        converted = cast(
-                            dict,
-                            self._convert_content_to_responses_format_image(
-                                cast(ChatCompletionImageObject, item), role
+                        converted = with_prompt_cache_breakpoint(
+                            cast(
+                                dict,
+                                self._convert_content_to_responses_format_image(
+                                    cast(ChatCompletionImageObject, item), role
+                                ),
                             ),
+                            item.get("prompt_cache_breakpoint"),
                         )
                         result.append(converted)
                         verbose_logger.debug("Chat provider:   image_url -> %s", converted)
@@ -1054,8 +1061,11 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
                             result.append(converted)
                             verbose_logger.debug("Chat provider:   image -> %s", converted)
                         elif item_type == "file":
-                            converted = _input_file_from_file_value(
-                                cast("ChatCompletionFileObject", item).get("file"),  # cast-ok: type tag checked
+                            converted = with_prompt_cache_breakpoint(
+                                _input_file_from_file_value(
+                                    cast("ChatCompletionFileObject", item).get("file"),  # cast-ok: type tag checked
+                                ),
+                                item.get("prompt_cache_breakpoint"),
                             )
                             result.append(converted)
                             verbose_logger.debug("Chat provider:   file -> %s", converted)

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -4147,3 +4147,100 @@ def test_streaming_final_chunk_carries_provider_metadata():
     assert chunks[-1]["content_filters"] == content_filters
     assert "background" not in chunks[-1]
     assert all("service_tier" not in chunk for chunk in chunks[:-1])
+
+
+_EXPLICIT_BREAKPOINT: Final = {"mode": "explicit"}
+
+
+def _dispatched_parts(messages):
+    handler = LiteLLMResponsesTransformationHandler()
+    items, _ = handler.convert_chat_completion_messages_to_responses_api(messages)
+    return [part for item in items for part in (item.get("content") or []) if isinstance(part, dict)]
+
+
+def test_convert_chat_completion_messages_carries_prompt_cache_breakpoint_on_text():
+    """A caller's explicit cache breakpoint must survive the chat -> responses conversion.
+
+    The bridge rebuilds each text block as {"type", "text"}, so the marker was dropped and
+    the target never saw a breakpoint: it writes the prefix on every request and reads it on
+    none. Only the marked block carries the marker through.
+    """
+    parts = _dispatched_parts(
+        [
+            {
+                "role": "system",
+                "content": [
+                    {"type": "text", "text": "stable head", "prompt_cache_breakpoint": _EXPLICIT_BREAKPOINT},
+                    {"type": "text", "text": "per-request tail"},
+                ],
+            }
+        ]
+    )
+
+    assert parts == [
+        {"type": "input_text", "text": "stable head", "prompt_cache_breakpoint": _EXPLICIT_BREAKPOINT},
+        {"type": "input_text", "text": "per-request tail"},
+    ]
+
+
+def test_convert_chat_completion_messages_carries_prompt_cache_breakpoint_on_image():
+    parts = _dispatched_parts(
+        [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "https://example.com/a.png", "detail": "high"},
+                        "prompt_cache_breakpoint": _EXPLICIT_BREAKPOINT,
+                    }
+                ],
+            }
+        ]
+    )
+
+    assert parts == [
+        {
+            "type": "input_image",
+            "image_url": "https://example.com/a.png",
+            "detail": "high",
+            "prompt_cache_breakpoint": _EXPLICIT_BREAKPOINT,
+        }
+    ]
+
+
+def test_convert_chat_completion_messages_carries_prompt_cache_breakpoint_on_file():
+    parts = _dispatched_parts(
+        [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "file",
+                        "file": {"filename": "a.pdf", "file_data": "data:application/pdf;base64,QQ=="},
+                        "prompt_cache_breakpoint": _EXPLICIT_BREAKPOINT,
+                    }
+                ],
+            }
+        ]
+    )
+
+    assert parts[0]["type"] == "input_file"
+    assert parts[0]["prompt_cache_breakpoint"] == _EXPLICIT_BREAKPOINT
+    assert parts[0]["filename"] == "a.pdf"
+
+
+def test_convert_chat_completion_messages_leaves_unmarked_content_untouched():
+    """with_prompt_cache_breakpoint returns the block unchanged when there is no marker, so a
+    request that sets no breakpoint converts exactly as it did before."""
+    parts = _dispatched_parts(
+        [
+            {"role": "system", "content": [{"type": "text", "text": "sys"}]},
+            {"role": "user", "content": [{"type": "image_url", "image_url": {"url": "https://example.com/a.png"}}]},
+        ]
+    )
+
+    assert parts == [
+        {"type": "input_text", "text": "sys"},
+        {"type": "input_image", "image_url": "https://example.com/a.png", "detail": "auto"},
+    ]


### PR DESCRIPTION
## Title

fix(responses-bridge): carry `prompt_cache_breakpoint` through the chat → responses conversion

## Relevant issues

Related to #37509 and #32669 — both established `prompt_cache_breakpoint` as a supported request field for GPT-5.6+ targets. This fixes a path where a caller-supplied one is silently dropped.

## Problem

`LiteLLMResponsesTransformationHandler._convert_content_to_responses_format` rebuilds each content block from a fixed field list — a text block becomes `{"type", "text"}` and nothing else — so a caller's `prompt_cache_breakpoint` marker is discarded on the way to the target. The image and file branches rebuild the same way.

This is reached by `litellm.acompletion(model="openai/responses/<gpt-5.6+ model>", messages=[...])`, i.e. any chat-shaped call routed at a Responses-API target.

There is no error. The target simply never sees a breakpoint, so it writes the prefix on every request and reads it on none. Measured against OpenAI on a ~1.3k-token stable system head, two calls 3s apart with the same `prompt_cache_key` and a changed per-request tail:

| | breakpoint in dispatched payload | 1st call `cached_tokens` | 2nd call `cached_tokens` |
|---|---|---|---|
| before | no | 0 | 0 |
| after | yes | 0 | **1323** |

1323 is what the same payload caches when sent to `/v1/responses` directly, so the gap closes completely.

The marker is preserved on other paths already — `litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py` and `.../responses_adapters/transformation.py` both call `with_prompt_cache_breakpoint` for exactly this reason — so this bridge is the outlier rather than a new capability.

## Changes

`litellm/completion_extras/litellm_responses_transformation/transformation.py` — apply the existing `with_prompt_cache_breakpoint` helper (`litellm_core_utils/prompt_templates/common_utils.py`) to the three branches that rebuild a block: `text`, `image_url` and `file`. The helper returns the block unchanged when the marker is absent, so a request that sets no breakpoint converts byte-identically to before.

The `input_text` / `input_image` / … passthrough branch already forwards the block untouched and needs nothing.

## Testing

Added to `tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py`:

- the marker survives on a text block, and only on the block that carried it;
- the marker survives on an `image_url` block and on a `file` block;
- content with no marker converts exactly as before.

```
pytest tests/test_litellm/completion_extras/ -q
125 passed
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
