### PR TITLE
fix(proxy): reject nested POST body on guardrail PATCH

### DIFF
--- a/litellm/types/guardrails.py
+++ b/litellm/types/guardrails.py
@@ -1215,6 +1215,8 @@ class ApplyGuardrailResponse(BaseModel):
 
 
 class PatchGuardrailRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     guardrail_name: str | None = None
     litellm_params: BaseLitellmParams | None = None
     guardrail_info: dict[str, Any] | None = None

--- a/tests/test_litellm/proxy/guardrails/test_guardrail_endpoints.py
+++ b/tests/test_litellm/proxy/guardrails/test_guardrail_endpoints.py
@@ -80,6 +80,21 @@ MOCK_PATCH_REQUEST = PatchGuardrailRequest(
 )
 
 
+def test_patch_guardrail_request_rejects_create_body_shape():
+    """Do not silently accept the nested POST /guardrails request body."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError, match="extra_forbidden"):
+        PatchGuardrailRequest.model_validate(
+            {
+                "guardrail": {
+                    "guardrail_name": "nested-name",
+                    "litellm_params": {},
+                }
+            }
+        )
+
+
 @pytest.fixture
 def mock_prisma_client(mocker):
     """Mock Prisma client for testing"""


### PR DESCRIPTION
## TLDR

Problem this solves:

- PATCH /guardrails/{id} accepted the nested POST body and returned 200 without applying changes.

How it solves it:

- Reject unknown top-level PATCH fields with a validation error instead of silently ignoring them.

## User Flow

Before: a proxy administrator can send the POST body shape to PATCH, receive 200, and believe the guardrail changed.

1. The administrator sends PATCH /guardrails/{id} with a top-level `guardrail` object.
2. The endpoint returns 200.
3. The next request still uses the old guardrail configuration.

After: the same malformed shape is rejected before any update is attempted.

1. The administrator sends PATCH /guardrails/{id} with a top-level `guardrail` object.
2. The endpoint returns 422 identifying the extra field.
3. The administrator can resend the documented flat PATCH body.

## Relevant issues

Fixes #40219

## Testing

- Added a regression test for the nested POST body shape.
- Verified Pydantic reports `extra_forbidden`.
- `git diff --check` passed.
- Python `compileall` passed for both changed files.
- Full pytest is blocked locally because the MSVC linker (`link.exe`) is unavailable for LiteLLM's Rust/PyO3 editable build.

## Type

🐛 Bug Fix

## Caveats

### Medium

- Undocumented extra top-level PATCH fields now return 422 instead of being ignored.