### PR TITLE
fix(responses): fix codex stream tool finish reason

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -1545,7 +1545,7 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
             response_data: Final = parsed_chunk.get("response", {})
             output_items: Final = response_data.get("output", []) if response_data else []
 
-            has_function_calls: Final = any(
+            has_function_calls: Final = bool(tool_call_index_map) or any(
                 item.get("type") in ("function_call", "custom_tool_call")
                 for item in output_items
                 if isinstance(item, dict)

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -1078,6 +1078,67 @@ def test_response_completed_with_function_calls_emits_tool_calls_finish_reason()
     ), "response.completed with function_call output should emit finish_reason='tool_calls'"
 
 
+@pytest.mark.parametrize("tool_type", ("function_call", "custom_tool_call"))
+@pytest.mark.parametrize(
+    ("terminal_event", "reason", "expected"),
+    (
+        ("response.completed", None, "tool_calls"),
+        ("response.incomplete", "max_output_tokens", "length"),
+        ("response.incomplete", "content_filter", "content_filter"),
+    ),
+)
+def test_streamed_tool_calls_with_empty_terminal_output(
+    tool_type: Literal["function_call", "custom_tool_call"],
+    terminal_event: Literal["response.completed", "response.incomplete"],
+    reason: str | None,
+    expected: str,
+) -> None:
+    """Retain streamed tool calls without overriding incomplete responses or leaking state."""
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        OpenAiResponsesToChatCompletionStreamIterator,
+    )
+
+    iterator: Final = OpenAiResponsesToChatCompletionStreamIterator(iter(()), sync_stream=True)
+    for index in (1, 2):
+        item: Final = {
+            "type": tool_type,
+            "id": f"fc_{index}",
+            "call_id": f"call_{index}",
+            "name": "read_file",
+            **({"arguments": "{}"} if tool_type == "function_call" else {"input": "file.txt"}),
+        }
+        added: Final = iterator.chunk_parser(
+            {"type": "response.output_item.added", "output_index": index, "item": item}
+        )
+        assert added.choices[0].delta.tool_calls[0].function.name == "read_file"
+        assert added.choices[0].delta.tool_calls[0].index == index - 1
+        assert added.choices[0].finish_reason is None
+        done: Final = iterator.chunk_parser(
+            {"type": "response.output_item.done", "output_index": index, "item": {**item, "status": "completed"}}
+        )
+        assert done.choices[0].finish_reason is None
+        assert not done.choices[0].delta.tool_calls
+
+    terminal: Final = {
+        "type": terminal_event,
+        "response": {
+            "status": "completed" if reason is None else "incomplete",
+            "output": [],
+            "incomplete_details": None if reason is None else {"reason": reason},
+        },
+    }
+    result: Final = iterator.chunk_parser(terminal)
+    assert result.choices[0].finish_reason == expected
+    assert not result.choices[0].delta.tool_calls
+
+    other_stream: Final = OpenAiResponsesToChatCompletionStreamIterator(iter(()), sync_stream=True)
+    assert other_stream.chunk_parser(terminal).choices[0].finish_reason == ("stop" if reason is None else expected)
+    stateless: Final = OpenAiResponsesToChatCompletionStreamIterator.translate_responses_chunk_to_openai_stream(
+        terminal
+    )
+    assert stateless.choices[0].finish_reason == ("stop" if reason is None else expected)
+
+
 def test_response_completed_with_message_only_emits_stop_finish_reason():
     """
     Test that response.completed with only message output (no function_call) emits finish_reason='stop'.
@@ -1281,13 +1342,9 @@ def test_text_plus_tool_calls_sequence():
         function_done_result.choices[0].finish_reason is None
     ), "output_item.done for function_call must not emit finish_reason"
 
-    # Check response.completed (index 6) has finish_reason='stop'
-    # (the mock chunk has no nested 'response' data, so has_function_calls is False → 'stop')
     completed_result = results[6]
     assert len(completed_result.choices) > 0, "response.completed should have choices"
-    assert (
-        completed_result.choices[0].finish_reason == "stop"
-    ), "response.completed should have finish_reason='stop'"
+    assert completed_result.choices[0].finish_reason == "tool_calls"
 
 
 # =============================================================================

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -1093,7 +1093,6 @@ def test_streamed_tool_calls_with_empty_terminal_output(
     reason: str | None,
     expected: str,
 ) -> None:
-    """Retain streamed tool calls without overriding incomplete responses or leaking state."""
     from litellm.completion_extras.litellm_responses_transformation.transformation import (
         OpenAiResponsesToChatCompletionStreamIterator,
     )


### PR DESCRIPTION
## TLDR

Problem this solves:


- LiteLLM is swallowing tool calls when mid-stream.

How it solves it:

- One line fix to also consider tool calls inside the stream when determining `has_tool_calls`.

## User Flow

Before: a user requests a tool call from GPT 5.6 Sol, but the stream ends with `finish_reason: "stop"` instead of the expected `"tool_calls"`

 1. Define a client-executed function named `WebSearch` with a required string argument `query`
 2. Send `POST http://litellm:4000/v1/chat/completions` with `"model": "chatgpt-gpt-5.6-sol"`, `"stream": true`, that function in tools, and `"tool_choice": {"type": "function",
    "function": {"name": "WebSearch"}}`.
 3. Receive HTTP 200 and SSE chunks containing a `WebSearch` function call, an ID beginning with `call_`, and streamed arguments containing a search query
 4. Final chunk contains `"finish_reason": "stop"`

After: the same request ends with `finish_reason: "tool_calls"`, correctly signaling that the client must execute the tool

## Relevant issues

- Fixes additional part of https://github.com/BerriAI/litellm/issues/27144
- Also related: https://github.com/BerriAI/litellm/issues/19744

## Linear ticket


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Proof of Fix

Real Codex calls, no mocks. Unpatched checkouts of the merge base and branch tip used identical dependencies, configuration, and authenticated ChatGPT credentials on ports `4011` and `4012`. Commands below are shortened equivalents of the captured run; output shows tool-call starts and termination, omitting argument deltas

Shared `config.json`:
```json
{"model_list":[{"model_name":"chatgpt-gpt-5.6-sol","model_info":{"mode":"responses"},"litellm_params":{"model":"chatgpt/gpt-5.6-sol"}}],"litellm_settings":{"drop_params":true}}
```

Shared `chat.json`:
```json
{
  "model":"chatgpt-gpt-5.6-sol","max_tokens":1024,"stream":true,
  "messages":[{"role":"user","content":"Use WebSearch to look up NixOS documentation."}],
  "tools":[{"type":"function","function":{"name":"WebSearch","description":"Search the web using the client.","parameters":{"type":"object","properties":{"query":{"type":"string"}},"required":["query"]}}}],
  "tool_choice":{"type":"function","function":{"name":"WebSearch"}}
}
```

Derive the equivalent Messages payload and define the SSE display filter:
```sh
jq '.tools = [.tools[0].function | {name, description, input_schema: .parameters}] | .tool_choice = {type: "tool", name: "WebSearch"}' chat.json > messages.json
FILTER='select(startswith("data: ")) | .[6:] | select(. != "[DONE]") | fromjson | (.choices[0] // .) | select(.delta.tool_calls[0].function.name or .finish_reason or .content_block.type == "tool_use" or .delta.stop_reason)'
```

### Before (`1af7a403c66e037bec2e0ae6ea455a1c10b17b1b`)

#### Chat Completions

1. Request:
   ```sh
   curl -sS --fail-with-body http://127.0.0.1:4011/v1/chat/completions -H 'Content-Type: application/json' --data-binary @chat.json -o before-chat.sse -w 'HTTP %{http_code}\n'
   jq -Rc "$FILTER" before-chat.sse
   ```
2. Tool call emitted, incorrect `stop`:
   ```text
   HTTP 200
   {"index":0,"delta":{"role":"assistant","tool_calls":[{"id":"call_HJTP3Crn1oZvNmYChX99POyE","function":{"arguments":"","name":"WebSearch"},"type":"function","index":0}]}}
   {"finish_reason":"stop","index":0,"delta":{}}
   ```

#### Anthropic Messages

1. Request:
   ```sh
   curl -sS --fail-with-body http://127.0.0.1:4011/v1/messages -H 'Content-Type: application/json' --data-binary @messages.json -o before-messages.sse -w 'HTTP %{http_code}\n'
   jq -Rc "$FILTER" before-messages.sse
   ```
2. Tool call emitted, incorrect `end_turn`:
   ```text
   HTTP 200
   {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"call_hXaBSEG6xUJz6lTY3otFxyqM","name":"WebSearch","input":{}}}
   {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":66,"output_tokens":23}}
   ```

### After (`e7aaece11aad2eb46e10a54f77aae5ad4e15a769`)

#### Chat Completions

1. Request:
   ```sh
   curl -sS --fail-with-body http://127.0.0.1:4012/v1/chat/completions -H 'Content-Type: application/json' --data-binary @chat.json -o after-chat.sse -w 'HTTP %{http_code}\n'
   jq -Rc "$FILTER" after-chat.sse
   ```
2. Tool call emitted, correct `tool_calls`:
   ```text
   HTTP 200
   {"index":0,"delta":{"role":"assistant","tool_calls":[{"id":"call_jO9oaMNJDNQVHtYYdBRoroa5","function":{"arguments":"","name":"WebSearch"},"type":"function","index":0}]}}
   {"finish_reason":"tool_calls","index":0,"delta":{}}
   ```

#### Anthropic Messages

1. Request:
   ```sh
   curl -sS --fail-with-body http://127.0.0.1:4012/v1/messages -H 'Content-Type: application/json' --data-binary @messages.json -o after-messages.sse -w 'HTTP %{http_code}\n'
   jq -Rc "$FILTER" after-messages.sse
   ```
2. Tool call emitted, correct `tool_use`:
   ```text
   HTTP 200
   {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"call_RuaxCKCx5N8W8VI13dbEXtrg","name":"WebSearch","input":{}}}
   {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"input_tokens":66,"output_tokens":27}}
   ```

## Type

🐛 Bug Fix

## Final Attestation

(who fills this out?)

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
