### PR TITLE
fix(proxy): increase spend counter cache capacity

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -240,6 +240,7 @@ import litellm._redis
 from litellm import Router
 from litellm._logging import _redact_string, verbose_proxy_logger, verbose_router_logger
 from litellm.caching.caching import DualCache, RedisCache
+from litellm.caching.in_memory_cache import InMemoryCache
 from litellm.caching.redis_cluster_cache import RedisClusterCache
 from litellm.constants import (
     _REALTIME_BODY_CACHE_SIZE,
@@ -2301,7 +2302,11 @@ shared_aiohttp_session: Optional["ClientSession"] = None  # Global shared sessio
 user_api_key_cache: UserApiKeyCache = UserApiKeyCache(
     default_in_memory_ttl=UserAPIKeyCacheTTLEnum.in_memory_cache_ttl.value
 )
-spend_counter_cache: Final = DualCache(default_in_memory_ttl=UserAPIKeyCacheTTLEnum.in_memory_cache_ttl.value)
+SPEND_COUNTER_CACHE_MAX_SIZE: Final = 10_000
+spend_counter_cache: Final = DualCache(
+    in_memory_cache=InMemoryCache(max_size_in_memory=SPEND_COUNTER_CACHE_MAX_SIZE),
+    default_in_memory_ttl=UserAPIKeyCacheTTLEnum.in_memory_cache_ttl.value,
+)
 cli_sso_session_cache: Final = DualCache(default_in_memory_ttl=CLI_SSO_SESSION_TTL_SECONDS)
 model_max_budget_limiter: Final = _PROXY_VirtualKeyModelMaxBudgetLimiter(dual_cache=spend_counter_cache)
 litellm.logging_callback_manager.add_litellm_callback(model_max_budget_limiter)

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -7542,6 +7542,24 @@ async def test_store_model_in_db_db_failure_graceful(monkeypatch):
 # =====================================================================
 
 
+def test_spend_counter_cache_keeps_active_counters_warm(monkeypatch):
+    from litellm.caching.in_memory_cache import InMemoryCache
+    from litellm.proxy.proxy_server import spend_counter_cache
+
+    cache = InMemoryCache(
+        max_size_in_memory=spend_counter_cache.in_memory_cache.max_size_in_memory,
+        default_ttl=60,
+    )
+    monkeypatch.setattr(spend_counter_cache, "in_memory_cache", cache)
+
+    sentinel = "spend:key:sentinel"
+    cache.set_cache(key=sentinel, value=1.0)
+    for index in range(300):
+        cache.set_cache(key=f"spend:end_user:scope-{index}", value=1.0)
+
+    assert cache.get_cache(key=sentinel) == 1.0
+
+
 @pytest.mark.asyncio
 async def test_get_current_spend_reads_redis_first():
     """get_current_spend should prefer Redis over in-memory."""


### PR DESCRIPTION
## TLDR

Problem this solves:

- Spend counters inherit a 200-entry in-memory limit
- Active counters are evicted before their TTL expires

How it solves it:

- Give the dedicated spend counter cache a bounded 10,000-entry limit
- Add a regression test covering 300 active budget scopes

## User Flow

Before: a proxy serving more than 200 active budget scopes repeatedly reloads warm spend counters

1. An operator runs the proxy with database-backed budgets and no Redis
2. Applications send POST https://litellm-domain/v1/chat/completions through more than 200 distinct budget scopes
3. Earlier active scopes are evicted before their 60-second TTL and later requests trigger avoidable durable-store reads

After: the same traffic keeps active spend counters available during the configured TTL

1. An operator runs the proxy with database-backed budgets and no Redis
2. Applications send the same POST https://litellm-domain/v1/chat/completions requests through more than 200 distinct budget scopes
3. Active scopes remain cached and budget checks avoid repeated reseeds

## Relevant issues

Fixes #40221

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] The targeted pytest command is blocked locally by missing MSVC `link.exe` while building LiteLLM's Rust/PyO3 editable package
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is isolated to the spend counter cache capacity
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting maintainer review

## Screenshots / Proof of Fix

### After (8cb42ca)

1. `py -3.13 -m py_compile litellm/proxy/proxy_server.py tests/test_litellm/proxy/test_proxy_server.py` completed successfully
2. `git diff --check` completed successfully
3. The targeted pytest, Black, and Ruff commands were attempted but blocked before test collection or linting by the missing MSVC `link.exe` required for the editable Rust/PyO3 build

## Type

Bug Fix

## Caveats

The cache remains bounded at 10,000 entries and keeps the existing TTL behavior

## Final Attestation

- [x] The regression test covers the reported active-counter eviction scenario