### PR TITLE
fix(router): make cooldown TTL refresh atomic

### DIFF
--- a/litellm/caching/dual_cache.py
+++ b/litellm/caching/dual_cache.py
@@ -117,14 +117,27 @@ class DualCache(BaseCache):
     def set_cache(self, key, value, local_only: bool = False, **kwargs):
         # Update both Redis and in-memory cache
         try:
+            force_in_memory_ttl_override: Final = kwargs.get("force_in_memory_ttl_override") is True
+            backend_kwargs: Final = {
+                kwarg_name: kwarg_value
+                for kwarg_name, kwarg_value in kwargs.items()
+                if kwarg_name != "force_in_memory_ttl_override"
+            }
+            cache_kwargs: Final = (
+                {**backend_kwargs, "ttl": self.default_in_memory_ttl}
+                if "ttl" not in backend_kwargs and self.default_in_memory_ttl is not None
+                else backend_kwargs
+            )
             if self.in_memory_cache is not None:
-                if "ttl" not in kwargs and self.default_in_memory_ttl is not None:
-                    kwargs["ttl"] = self.default_in_memory_ttl
-
-                self.in_memory_cache.set_cache(key, value, **kwargs)
+                self.in_memory_cache.set_cache(
+                    key,
+                    value,
+                    force_ttl=force_in_memory_ttl_override,
+                    **cache_kwargs,
+                )
 
             if self.redis_cache is not None and local_only is False:
-                self.redis_cache.set_cache(key, value, **kwargs)
+                self.redis_cache.set_cache(key, value, **cache_kwargs)
         except Exception as e:
             print_verbose(e)
 

--- a/litellm/caching/in_memory_cache.py
+++ b/litellm/caching/in_memory_cache.py
@@ -46,6 +46,7 @@ class InMemoryCache(BaseCache):
         self.cache_dict: dict = {}
         self.ttl_dict: dict = {}
         self.expiration_heap: list[tuple[float, str]] = []
+        self._cache_lock = threading.RLock()
         self._increment_lock = threading.Lock()
 
     def check_value_size(self, value: Any):
@@ -155,21 +156,23 @@ class InMemoryCache(BaseCache):
         if self.max_size_in_memory == 0:
             return  # Don't cache anything if max size is 0
 
-        # Always prune expired/outdated heap roots before inserting.
-        # This keeps expiration_heap bounded even when the live cache stays
-        # below max_size_in_memory and keys are reinserted after TTL expiry.
-        self.evict_cache()
         if not self.check_value_size(value):
             return
 
-        self.cache_dict[key] = value
-        if self.allow_ttl_override(key):  # if ttl is not set, set it to default ttl
-            if "ttl" in kwargs and kwargs["ttl"] is not None:
-                self.ttl_dict[key] = time.time() + float(kwargs["ttl"])
-                heapq.heappush(self.expiration_heap, (self.ttl_dict[key], key))
-            else:
-                self.ttl_dict[key] = time.time() + self.default_ttl
-                heapq.heappush(self.expiration_heap, (self.ttl_dict[key], key))
+        force_ttl: Final = kwargs.get("force_ttl") is True
+        with self._cache_lock:
+            # Always prune expired/outdated heap roots before inserting.
+            # This keeps expiration_heap bounded even when the live cache stays
+            # below max_size_in_memory and keys are reinserted after TTL expiry.
+            self.evict_cache()
+            self.cache_dict[key] = value
+            if force_ttl or self.allow_ttl_override(key):  # if ttl is not set, set it to default ttl
+                if "ttl" in kwargs and kwargs["ttl"] is not None:
+                    self.ttl_dict[key] = time.time() + float(kwargs["ttl"])
+                    heapq.heappush(self.expiration_heap, (self.ttl_dict[key], key))
+                else:
+                    self.ttl_dict[key] = time.time() + self.default_ttl
+                    heapq.heappush(self.expiration_heap, (self.ttl_dict[key], key))
 
     async def async_set_cache(self, key, value, **kwargs):
         self.set_cache(key=key, value=value, **kwargs)
@@ -204,16 +207,17 @@ class InMemoryCache(BaseCache):
         return False
 
     def get_cache(self, key, **kwargs):
-        if key in self.cache_dict:
-            if self.evict_element_if_expired(key):
-                return None
-            original_cached_response: Final = self.cache_dict[key]
-            try:
-                cached_response = json.loads(original_cached_response)
-            except Exception:
-                cached_response = original_cached_response
-            return cached_response
-        return None
+        with self._cache_lock:
+            if key in self.cache_dict:
+                if self.evict_element_if_expired(key):
+                    return None
+                original_cached_response: Final = self.cache_dict[key]
+                try:
+                    cached_response = json.loads(original_cached_response)
+                except Exception:
+                    cached_response = original_cached_response
+                return cached_response
+            return None
 
     def batch_get_cache(self, keys: list, **kwargs):
         return_val: Final = []
@@ -253,15 +257,17 @@ class InMemoryCache(BaseCache):
         return results
 
     def flush_cache(self):
-        self.cache_dict.clear()
-        self.ttl_dict.clear()
-        self.expiration_heap.clear()
+        with self._cache_lock:
+            self.cache_dict.clear()
+            self.ttl_dict.clear()
+            self.expiration_heap.clear()
 
     async def disconnect(self):
         pass
 
     def delete_cache(self, key):
-        self._remove_key(key)
+        with self._cache_lock:
+            self._remove_key(key)
 
     async def async_get_ttl(self, key: str) -> int | None:
         """

--- a/litellm/router_utils/cooldown_cache.py
+++ b/litellm/router_utils/cooldown_cache.py
@@ -93,13 +93,11 @@ class CooldownCache:
             )
 
             # Set the cache with a TTL equal to the cooldown time
-            self.cache.in_memory_cache.delete_cache(  # pyright: ignore[reportUnknownMemberType]  # InMemoryCache is untyped
-                cooldown_key
-            )
             self.cache.set_cache(
                 value=cooldown_data,
                 key=cooldown_key,
                 ttl=_cooldown_time,
+                force_in_memory_ttl_override=True,
             )
         except Exception as e:
             verbose_logger.error("CooldownCache::add_deployment_to_cooldown - Exception occurred - %s", e)

--- a/litellm/router_utils/cooldown_cache.py
+++ b/litellm/router_utils/cooldown_cache.py
@@ -93,6 +93,9 @@ class CooldownCache:
             )
 
             # Set the cache with a TTL equal to the cooldown time
+            self.cache.in_memory_cache.delete_cache(  # pyright: ignore[reportUnknownMemberType]  # InMemoryCache is untyped
+                cooldown_key
+            )
             self.cache.set_cache(
                 value=cooldown_data,
                 key=cooldown_key,

--- a/tests/router_unit_tests/test_router_cooldown_per_deployment.py
+++ b/tests/router_unit_tests/test_router_cooldown_per_deployment.py
@@ -231,6 +231,19 @@ class TestCooldownCacheTTLCorrection:
         dual_cache = DualCache(in_memory_cache=in_memory)
         return CooldownCache(cache=dual_cache, default_cooldown_time=60.0)
 
+    def test_repeated_cooldown_refreshes_in_memory_expiry(self):
+        cc = self._make_cooldown_cache()
+        model_id = "repeated-cooldown-deployment"
+
+        with patch("time.time", return_value=100.0):
+            cc.add_deployment_to_cooldown(model_id, Exception("429"), 429, cooldown_time=1.0)
+        with patch("time.time", return_value=100.2):
+            cc.add_deployment_to_cooldown(model_id, Exception("429"), 429, cooldown_time=60.0)
+        with patch("time.time", return_value=101.5):
+            active = cc.get_active_cooldowns(model_ids=[model_id], parent_otel_span=None)
+
+        assert [deployment_id for deployment_id, _ in active] == [model_id]
+
     def test_expired_entry_evicted_and_not_returned(self):
         """
         An entry with timestamp+cooldown_time in the past must be evicted from

--- a/tests/test_litellm/caching/test_dual_cache.py
+++ b/tests/test_litellm/caching/test_dual_cache.py
@@ -154,6 +154,25 @@ def test_dual_cache_batch_get_cache_returns_memory_only_when_redis_read_is_throt
     mock_redis.batch_get_cache.assert_not_called()
 
 
+def test_dual_cache_force_ttl_only_applies_to_in_memory_cache():
+    in_memory_cache = InMemoryCache()
+    mock_redis = MagicMock(spec=RedisCache)
+    dual_cache = DualCache(in_memory_cache=in_memory_cache, redis_cache=mock_redis)
+
+    with patch("time.time", return_value=100.0):
+        dual_cache.set_cache(key="cooldown", value="first", ttl=60)
+    with patch("time.time", return_value=110.0):
+        dual_cache.set_cache(
+            key="cooldown",
+            value="second",
+            ttl=60,
+            force_in_memory_ttl_override=True,
+        )
+
+    assert in_memory_cache.ttl_dict["cooldown"] == 170.0
+    mock_redis.set_cache.assert_called_with("cooldown", "second", ttl=60)
+
+
 def test_dual_cache_sync_batch_redis_backfill_injects_default_in_memory_ttl():
     """Sync batch_get_cache's Redis-to-memory backfill must honor
     default_in_memory_ttl, same as the async path."""

--- a/tests/test_litellm/caching/test_in_memory_cache.py
+++ b/tests/test_litellm/caching/test_in_memory_cache.py
@@ -21,6 +21,20 @@ class _SlowInt(int):
         return _SlowInt(int(self) + value)
 
 
+class _BlockingCacheDict(dict[str, object]):
+    def __init__(self, values: dict[str, object]):
+        super().__init__(values)
+        self.value_written = threading.Event()
+        self.allow_ttl_write = threading.Event()
+        self.block_writes = False
+
+    def __setitem__(self, key: str, value: object) -> None:
+        super().__setitem__(key, value)
+        if self.block_writes:
+            self.value_written.set()
+            self.allow_ttl_write.wait(timeout=1)
+
+
 def test_increment_cache_is_atomic_under_thread_concurrency():
     cache = InMemoryCache()
     seed = 1000
@@ -115,6 +129,60 @@ def test_in_memory_cache_ttl_allow_override():
     new_ttl_time = in_memory_cache.ttl_dict["new-fake-key"]
     assert new_ttl_time is not None
     assert new_ttl_time != initial_ttl_time
+
+
+def test_in_memory_cache_ttl_force_override():
+    in_memory_cache = InMemoryCache()
+
+    with patch("time.time", return_value=100.0):
+        in_memory_cache.set_cache(key="my-fake-key", value="first", ttl=60)
+    with patch("time.time", return_value=110.0):
+        in_memory_cache.set_cache(
+            key="my-fake-key", value="second", ttl=60, force_ttl=True
+        )
+        cached_value = in_memory_cache.get_cache("my-fake-key")
+
+    assert in_memory_cache.ttl_dict["my-fake-key"] == 170.0
+    assert cached_value == "second"
+
+
+def test_in_memory_cache_ttl_force_override_is_atomic():
+    in_memory_cache = InMemoryCache()
+    with patch("time.time", return_value=100.0):
+        in_memory_cache.set_cache(key="my-fake-key", value="first", ttl=2)
+
+    blocking_cache_dict = _BlockingCacheDict(in_memory_cache.cache_dict)
+    blocking_cache_dict.block_writes = True
+    in_memory_cache.cache_dict = blocking_cache_dict
+    read_results: list[object] = []
+
+    def clock() -> float:
+        if threading.current_thread().name == "cache-reader":
+            return 102.1
+        return 101.9
+
+    with patch("time.time", side_effect=clock):
+        writer = threading.Thread(
+            target=lambda: in_memory_cache.set_cache(
+                key="my-fake-key", value="second", ttl=60, force_ttl=True
+            )
+        )
+        writer.start()
+        assert blocking_cache_dict.value_written.wait(timeout=1)
+
+        reader = threading.Thread(
+            target=lambda: read_results.append(in_memory_cache.get_cache("my-fake-key")),
+            name="cache-reader",
+        )
+        reader.start()
+        time.sleep(0.05)
+        reader_blocked_during_write = reader.is_alive()
+        blocking_cache_dict.allow_ttl_write.set()
+        writer.join(timeout=1)
+        reader.join(timeout=1)
+
+    assert reader_blocked_during_write
+    assert read_results == ["second"]
 
 
 def test_in_memory_cache_max_size_with_ttl():


### PR DESCRIPTION
Fixes #40130: Repeated cooldowns now refresh the in-memory TTL instead of keeping the original expiry window.

## The Problem
When LiteLLM enters cooldown and then encounters the same error again, the second cooldown write would keep the original TTL expiry, not extend it. If you hit a 429 for 1 second, then immediately hit it again for 60 seconds, the cache would expire after the original 1 second window, not 60.

## The Fix
- Added `threading.RLock` to InMemoryCache to make value and TTL updates atomic
- Introduced `force_ttl` parameter: when true, the new TTL replaces the old one instead of being ignored
- DualCache strips the tier-specific `force_in_memory_ttl_override` before sending to Redis, so only the in-memory backend refreshes
- CooldownCache now passes `force_in_memory_ttl_override=True` when adding a deployment to cooldown

## Testing
- Sequential cooldown extension test: proves second cooldown extends expiry past first window
- Direct forced TTL test: verifies the flag refreshes TTL on repeated writes
- Deterministic concurrency test: writer and reader race at the old TTL boundary; reader is blocked until value and TTL are both updated together
- DualCache test: confirms `force_in_memory_ttl_override` does not reach Redis

All 74 targeted tests pass. Full `make lint` passes.
