### PR TITLE
fix(cache): enforce item size limits for containers

### DIFF
--- a/litellm/caching/in_memory_cache.py
+++ b/litellm/caching/in_memory_cache.py
@@ -73,7 +73,10 @@ class InMemoryCache(BaseCache):
 
             # Only convert to JSON if absolutely necessary
             if not isinstance(value, (str, bytes)):
-                value = json.dumps(value, default=str)
+                try:
+                    value = json.dumps(value, default=str)
+                except (TypeError, ValueError):
+                    value = repr(value)
 
             return sys.getsizeof(value) / 1024 <= self.max_size_per_item
 

--- a/litellm/caching/in_memory_cache.py
+++ b/litellm/caching/in_memory_cache.py
@@ -65,11 +65,6 @@ class InMemoryCache(BaseCache):
             if isinstance(value, bytes):
                 return sys.getsizeof(value) / 1024 <= self.max_size_per_item
 
-            # Handle special types without full conversion when possible
-            if hasattr(value, "__sizeof__"):  # Use __sizeof__ if available
-                size: Final = value.__sizeof__() / 1024
-                return size <= self.max_size_per_item
-
             # Fallback for complex types
             if isinstance(value, BaseModel) and hasattr(value, "model_dump"):  # Pydantic v2
                 value = value.model_dump()

--- a/tests/test_litellm/caching/test_in_memory_cache.py
+++ b/tests/test_litellm/caching/test_in_memory_cache.py
@@ -72,6 +72,18 @@ def test_in_memory_cache_max_size_per_item():
     assert result is False
 
 
+def test_in_memory_cache_max_size_per_item_measures_container_contents():
+    in_memory_cache = InMemoryCache(max_size_per_item=1)
+    oversized_value = {"timestamp": 0.0, "response": "a" * 5000}
+    small_value = {"timestamp": 0.0, "response": "ok"}
+
+    in_memory_cache.set_cache(key="oversized", value=oversized_value)
+    in_memory_cache.set_cache(key="small", value=small_value)
+
+    assert in_memory_cache.get_cache(key="oversized") is None
+    assert in_memory_cache.get_cache(key="small") == small_value
+
+
 def test_in_memory_cache_ttl():
     """
     Check that

--- a/tests/test_litellm/caching/test_in_memory_cache.py
+++ b/tests/test_litellm/caching/test_in_memory_cache.py
@@ -84,6 +84,15 @@ def test_in_memory_cache_max_size_per_item_measures_container_contents():
     assert in_memory_cache.get_cache(key="small") == small_value
 
 
+def test_in_memory_cache_accepts_small_container_with_non_json_keys():
+    in_memory_cache = InMemoryCache(max_size_per_item=1)
+    value = {("key", "key-hash"): ("job-1",)}
+
+    in_memory_cache.set_cache(key="active-jobs", value=value)
+
+    assert in_memory_cache.get_cache(key="active-jobs") == value
+
+
 def test_in_memory_cache_ttl():
     """
     Check that


### PR DESCRIPTION
## Summary

Fixes #40129.

`InMemoryCache.check_value_size()` used `__sizeof__()` for every non-primitive object before reaching its existing JSON fallback. For containers, that only measures the shallow object header, so a cache entry containing a multi-megabyte response could pass a 1 KB item limit and be stored.

This change removes that universal shallow-size early return. Complex values now use full JSON sizing where possible, with a full `repr()` fallback for values JSON cannot represent, while the existing primitive and `bytes` fast paths remain unchanged.

## Reproduction on current main

```text
max_size_per_item: 1 KB
value: {"timestamp": 0.0, "response": "x" * 5000}
check_value_size: True
stored: True
shallow __sizeof__: 0.164 KB
```

## Regression coverage

The tests exercise the public `set_cache()`/`get_cache()` boundary and verify:

- an oversized response container is rejected and absent;
- a small response container is still stored unchanged;
- a small mapping with tuple keys remains cacheable.

With the size-limit implementation reverted, the oversized-container regression fails. With the JSON-only implementation from the previous head, the tuple-key regression and shadow-eval active-job cache fail.

## Validation

- `python -m pytest tests/test_litellm/caching/test_in_memory_cache.py -q` - 13 passed
- selected shadow-eval regressions on base `e5da59336d` - 4 passed
- selected shadow-eval regressions on previous head `5daa555bb0` - failed on the tuple-key cache path
- selected shadow-eval regressions on current head - 4 passed
- `ruff format --check --config ruff.toml litellm/caching/in_memory_cache.py` - passed
- `ruff check --config ruff-tests.toml tests/test_litellm/caching/test_in_memory_cache.py` - passed
- `git diff --check` - passed

A direct runtime-code Ruff invocation reports the same three pre-existing findings on both `upstream/main` and this branch; this patch introduces no new Ruff findings.

## Scope

This intentionally does not change the separate primitive-threshold multiplier noted in the issue. Keeping it out avoids mixing two independent sizing contracts in one PR.
