### PR TITLE
feat(bedrock): enable tool choice across Nova v1

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -364,6 +364,7 @@
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_response_schema": true,
+        "supports_tool_choice": true,
         "supports_vision": true
     },
     "amazon.nova-2-lite-v1:0": {
@@ -537,7 +538,8 @@
         "output_cost_per_token": 1.4e-07,
         "supports_function_calling": true,
         "supports_prompt_caching": true,
-        "supports_response_schema": true
+        "supports_response_schema": true,
+        "supports_tool_choice": true
     },
     "amazon.nova-pro-v1:0": {
         "input_cost_per_token": 8e-07,
@@ -551,6 +553,7 @@
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_response_schema": true,
+        "supports_tool_choice": true,
         "supports_vision": true
     },
     "amazon.nova-sonic-v1:0": {
@@ -2831,6 +2834,7 @@
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_response_schema": true,
+        "supports_tool_choice": true,
         "supports_vision": true
     },
     "apac.amazon.nova-micro-v1:0": {
@@ -2843,7 +2847,8 @@
         "output_cost_per_token": 1.48e-07,
         "supports_function_calling": true,
         "supports_prompt_caching": true,
-        "supports_response_schema": true
+        "supports_response_schema": true,
+        "supports_tool_choice": true
     },
     "apac.amazon.nova-pro-v1:0": {
         "input_cost_per_token": 8.4e-07,
@@ -2857,6 +2862,7 @@
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_response_schema": true,
+        "supports_tool_choice": true,
         "supports_vision": true
     },
     "apac.anthropic.claude-3-5-sonnet-20240620-v1:0": {
@@ -12136,6 +12142,7 @@
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_response_schema": true,
+        "supports_tool_choice": true,
         "supports_vision": true
     },
     "bedrock/us-gov-east-1/amazon.titan-embed-text-v1": {
@@ -12315,6 +12322,7 @@
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_response_schema": true,
+        "supports_tool_choice": true,
         "supports_vision": true
     },
     "bedrock/us-gov-west-1/amazon.nova-micro-v1:0": {
@@ -12327,7 +12335,8 @@
         "output_cost_per_token": 1.68e-07,
         "supports_function_calling": true,
         "supports_prompt_caching": true,
-        "supports_response_schema": true
+        "supports_response_schema": true,
+        "supports_tool_choice": true
     },
     "bedrock/us-gov-west-1/amazon.nova-pro-v1:0": {
         "input_cost_per_token": 9.6e-07,
@@ -12341,6 +12350,7 @@
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_response_schema": true,
+        "supports_tool_choice": true,
         "supports_vision": true
     },
     "bedrock/us-gov-west-1/amazon.titan-embed-text-v1": {
@@ -20778,6 +20788,7 @@
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_response_schema": true,
+        "supports_tool_choice": true,
         "supports_vision": true
     },
     "eu.amazon.nova-micro-v1:0": {
@@ -20790,7 +20801,8 @@
         "output_cost_per_token": 1.84e-07,
         "supports_function_calling": true,
         "supports_prompt_caching": true,
-        "supports_response_schema": true
+        "supports_response_schema": true,
+        "supports_tool_choice": true
     },
     "eu.amazon.nova-pro-v1:0": {
         "input_cost_per_token": 1.05e-06,
@@ -20805,6 +20817,7 @@
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_response_schema": true,
+        "supports_tool_choice": true,
         "supports_vision": true
     },
     "eu.anthropic.claude-3-5-haiku-20241022-v1:0": {
@@ -43490,6 +43503,7 @@
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_response_schema": true,
+        "supports_tool_choice": true,
         "supports_vision": true
     },
     "us.amazon.nova-micro-v1:0": {
@@ -43502,7 +43516,8 @@
         "output_cost_per_token": 1.4e-07,
         "supports_function_calling": true,
         "supports_prompt_caching": true,
-        "supports_response_schema": true
+        "supports_response_schema": true,
+        "supports_tool_choice": true
     },
     "us.amazon.nova-premier-v1:0": {
         "deprecation_date": "2026-09-14",
@@ -43531,6 +43546,7 @@
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_response_schema": true,
+        "supports_tool_choice": true,
         "supports_vision": true
     },
     "us.anthropic.claude-3-5-haiku-20241022-v1:0": {

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -364,6 +364,7 @@
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_response_schema": true,
+        "supports_tool_choice": true,
         "supports_vision": true
     },
     "amazon.nova-2-lite-v1:0": {
@@ -537,7 +538,8 @@
         "output_cost_per_token": 1.4e-07,
         "supports_function_calling": true,
         "supports_prompt_caching": true,
-        "supports_response_schema": true
+        "supports_response_schema": true,
+        "supports_tool_choice": true
     },
     "amazon.nova-pro-v1:0": {
         "input_cost_per_token": 8e-07,
@@ -551,6 +553,7 @@
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_response_schema": true,
+        "supports_tool_choice": true,
         "supports_vision": true
     },
     "amazon.nova-sonic-v1:0": {
@@ -2831,6 +2834,7 @@
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_response_schema": true,
+        "supports_tool_choice": true,
         "supports_vision": true
     },
     "apac.amazon.nova-micro-v1:0": {
@@ -2843,7 +2847,8 @@
         "output_cost_per_token": 1.48e-07,
         "supports_function_calling": true,
         "supports_prompt_caching": true,
-        "supports_response_schema": true
+        "supports_response_schema": true,
+        "supports_tool_choice": true
     },
     "apac.amazon.nova-pro-v1:0": {
         "input_cost_per_token": 8.4e-07,
@@ -2857,6 +2862,7 @@
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_response_schema": true,
+        "supports_tool_choice": true,
         "supports_vision": true
     },
     "apac.anthropic.claude-3-5-sonnet-20240620-v1:0": {
@@ -12136,6 +12142,7 @@
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_response_schema": true,
+        "supports_tool_choice": true,
         "supports_vision": true
     },
     "bedrock/us-gov-east-1/amazon.titan-embed-text-v1": {
@@ -12315,6 +12322,7 @@
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_response_schema": true,
+        "supports_tool_choice": true,
         "supports_vision": true
     },
     "bedrock/us-gov-west-1/amazon.nova-micro-v1:0": {
@@ -12327,7 +12335,8 @@
         "output_cost_per_token": 1.68e-07,
         "supports_function_calling": true,
         "supports_prompt_caching": true,
-        "supports_response_schema": true
+        "supports_response_schema": true,
+        "supports_tool_choice": true
     },
     "bedrock/us-gov-west-1/amazon.nova-pro-v1:0": {
         "input_cost_per_token": 9.6e-07,
@@ -12341,6 +12350,7 @@
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_response_schema": true,
+        "supports_tool_choice": true,
         "supports_vision": true
     },
     "bedrock/us-gov-west-1/amazon.titan-embed-text-v1": {
@@ -20778,6 +20788,7 @@
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_response_schema": true,
+        "supports_tool_choice": true,
         "supports_vision": true
     },
     "eu.amazon.nova-micro-v1:0": {
@@ -20790,7 +20801,8 @@
         "output_cost_per_token": 1.84e-07,
         "supports_function_calling": true,
         "supports_prompt_caching": true,
-        "supports_response_schema": true
+        "supports_response_schema": true,
+        "supports_tool_choice": true
     },
     "eu.amazon.nova-pro-v1:0": {
         "input_cost_per_token": 1.05e-06,
@@ -20805,6 +20817,7 @@
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_response_schema": true,
+        "supports_tool_choice": true,
         "supports_vision": true
     },
     "eu.anthropic.claude-3-5-haiku-20241022-v1:0": {
@@ -43490,6 +43503,7 @@
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_response_schema": true,
+        "supports_tool_choice": true,
         "supports_vision": true
     },
     "us.amazon.nova-micro-v1:0": {
@@ -43502,7 +43516,8 @@
         "output_cost_per_token": 1.4e-07,
         "supports_function_calling": true,
         "supports_prompt_caching": true,
-        "supports_response_schema": true
+        "supports_response_schema": true,
+        "supports_tool_choice": true
     },
     "us.amazon.nova-premier-v1:0": {
         "deprecation_date": "2026-09-14",
@@ -43531,6 +43546,7 @@
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
         "supports_response_schema": true,
+        "supports_tool_choice": true,
         "supports_vision": true
     },
     "us.anthropic.claude-3-5-haiku-20241022-v1:0": {

--- a/tests/test_litellm/proxy/management_endpoints/policy_endpoints/test_ai_policy_suggester.py
+++ b/tests/test_litellm/proxy/management_endpoints/policy_endpoints/test_ai_policy_suggester.py
@@ -265,7 +265,7 @@ class TestSuggesterRejectsModelsWithoutToolCalling:
 
     def test_a_model_without_forced_tool_choice_support_remains_eligible(self, local_model_cost_map):
         supported_params = litellm.get_supported_openai_params(
-            model="amazon.nova-pro-v1:0",
+            model="meta.llama4-scout-17b-instruct-v1:0",
             custom_llm_provider="bedrock",
         )
 

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -1403,21 +1403,33 @@ def test_supports_tool_choice_simple_tests():
         is True
     )
 
-    assert (
-        litellm.utils.supports_tool_choice(model="us.amazon.nova-micro-v1:0") is False
-    )
-    assert (
-        litellm.utils.supports_tool_choice(model="bedrock/us.amazon.nova-micro-v1:0")
-        is False
-    )
-    assert (
-        litellm.utils.supports_tool_choice(
-            model="us.amazon.nova-micro-v1:0", custom_llm_provider="bedrock_converse"
-        )
-        is False
-    )
-
     assert litellm.utils.supports_tool_choice(model="perplexity/sonar") is False
+
+
+@pytest.mark.usefixtures("local_model_cost_map")
+@pytest.mark.parametrize(
+    "model",
+    [
+        "amazon.nova-lite-v1:0",
+        "amazon.nova-micro-v1:0",
+        "amazon.nova-pro-v1:0",
+        "apac.amazon.nova-lite-v1:0",
+        "apac.amazon.nova-micro-v1:0",
+        "apac.amazon.nova-pro-v1:0",
+        "bedrock/us-gov-east-1/amazon.nova-pro-v1:0",
+        "bedrock/us-gov-west-1/amazon.nova-lite-v1:0",
+        "bedrock/us-gov-west-1/amazon.nova-micro-v1:0",
+        "bedrock/us-gov-west-1/amazon.nova-pro-v1:0",
+        "eu.amazon.nova-lite-v1:0",
+        "eu.amazon.nova-micro-v1:0",
+        "eu.amazon.nova-pro-v1:0",
+        "us.amazon.nova-lite-v1:0",
+        "us.amazon.nova-micro-v1:0",
+        "us.amazon.nova-pro-v1:0",
+    ],
+)
+def test_amazon_nova_v1_understanding_models_support_tool_choice(model: str) -> None:
+    assert litellm.utils.supports_tool_choice(model=model) is True
 
 
 def test_check_provider_match():


### PR DESCRIPTION
## TLDR

Problem this solves:

- Nova v1 models incorrectly report `tool_choice` as unsupported

How it solves it:

- Enable tool choice for Nova Pro, Lite, and Micro
- Cover all 16 model identifiers with regression tests

## User Flow

### Response Formatting

Before: a developer using `response_format` with Amazon Nova v1 models gets reasoning output that signals about tool selection

1. They send `POST https://litellm-domain/v1/chat/completions`: 
```
{
  "model": "amazon.nova-pro-v1:0",
  "messages": [
    {
      "role": "user",
      "content": "The Eiffel Tower is located in Paris, France, and it was completed in 1889. Extract the city, the country and the year."
    }
  ],
  "response_format": {
    "type": "json_schema",
    "json_schema": {
      "name": "landmark_location",
      "strict": true,
      "schema": {
        "type": "object",
        "properties": {
          "city": {
            "type": "string"
          },
          "country": {
            "type": "string"
          },
          "year": {
            "type": "integer"
          }
        },
        "required": ["city", "country", "year"],
        "additionalProperties": false
      }
    }
  }
}
```
2. They get: 

```
{
  "id": "chatcmpl-6d1adf65-3368-42cb-8e15-0ce66ecc9e6a",
  "choices": [
    {
      "finish_reason": "stop",
      "index": 0,
      "message": {
        "content": "{\"country\": \"France\", \"city\": \"Paris\", \"year\": 1889}",
        "role": "assistant",
        "function_call": null,
        "tool_calls": null,
        "reasoning_content": " The user has provided the location and completion year of the Eiffel Tower. I need to extract the city, country, and year from this information. ",
        "thinking_blocks": [
          {
            "type": "thinking",
            "thinking": " The user has provided the location and completion year of the Eiffel Tower. I need to extract the city, country, and year from this information. "
          }
        ],
        "provider_specific_fields": {
          "reasoningContentBlocks": [
            {
              "reasoningText": {
                "text": " The user has provided the location and completion year of the Eiffel Tower. I need to extract the city, country, and year from this information. "
              }
            }
          ]
        }
      }
    }
  ],
  "created": 1788879881,
  "model": "amazon.nova-pro-v1:0",
  "object": "chat.completion",
  "system_fingerprint": null
}
```

After: the same request reaches Bedrock but the response does not contain any thinking blocks (`usage` is omitted): 

```
{
  "id": "chatcmpl-f351d4d9-6f1c-4710-8543-1d4d264c3f98",
  "choices": [
    {
      "finish_reason": "stop",
      "index": 0,
      "message": {
        "content": "{\"country\": \"France\", \"city\": \"Paris\", \"year\": 1889}",
        "role": "assistant",
        "function_call": null,
        "tool_calls": null
      }
    }
  ],
  "created": 1787244350,
  "model": "amazon.nova-pro-v1:0",
  "object": "chat.completion",
  "system_fingerprint": null
}
```

Reasoning tokens 32 -> 0 in this case

## Linear ticket

(external contributor)

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

## Type

🆕 New Feature

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR