### PR TITLE
fix(streaming): fail on clean EOF without finish reason

### DIFF
--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -243,6 +243,7 @@ class CustomStreamWrapper:
         self.make_call = make_call
         self.custom_llm_provider = custom_llm_provider
         self.is_mock = is_mock
+        self.uses_openai_chat_stream = False
         self.logging_obj: LiteLLMLoggingObject = logging_obj
         self.completion_stream = completion_stream
         self.sent_first_chunk = False
@@ -1501,6 +1502,7 @@ class CustomStreamWrapper:
             if response_obj["is_finished"]:
                 self.received_finish_reason = response_obj["finish_reason"]
         else:  # openai / azure chat model
+            self.uses_openai_chat_stream = True
             if self.custom_llm_provider in [
                 LlmProviders.AZURE.value,
                 LlmProviders.AZURE_AI.value,
@@ -1880,7 +1882,7 @@ class CustomStreamWrapper:
     def _should_fail_on_clean_eof(self) -> bool:
         return (
             not self.is_mock
-            and self.custom_llm_provider in _OPENAI_AZURE_CHAT_PROVIDERS
+            and (self.custom_llm_provider in _OPENAI_AZURE_CHAT_PROVIDERS or self.uses_openai_chat_stream)
             and self.received_finish_reason is None
             and self.intermittent_finish_reason is None
         )

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -55,6 +55,7 @@ _SYNC_ITER_EXHAUSTED: Final = object()
 
 _GCHUNK_FIELDS: Final[frozenset] = frozenset(GChunk.__annotations__)
 _USAGE_COST_HEADER_PROVIDERS: Final[frozenset[str]] = frozenset({LlmProviders.OPENROUTER.value})
+_OPENAI_AZURE_CHAT_PROVIDERS: Final[frozenset[str]] = frozenset({LlmProviders.OPENAI.value, LlmProviders.AZURE.value})
 
 
 def _next_sync_or_exhausted(it: Any) -> object:
@@ -236,10 +237,12 @@ class CustomStreamWrapper:
         stream_options=None,
         make_call: Callable | None = None,
         _response_headers: dict | httpx.Headers | None = None,
+        is_mock: bool = False,
     ):
         self.model = model
         self.make_call = make_call
         self.custom_llm_provider = custom_llm_provider
+        self.is_mock = is_mock
         self.logging_obj: LiteLLMLoggingObject = logging_obj
         self.completion_stream = completion_stream
         self.sent_first_chunk = False
@@ -1874,6 +1877,18 @@ class CustomStreamWrapper:
             model_response.choices[0].finish_reason = "tool_calls"
         return model_response
 
+    def _should_fail_on_clean_eof(self) -> bool:
+        return (
+            not self.is_mock
+            and self.custom_llm_provider in _OPENAI_AZURE_CHAT_PROVIDERS
+            and self.received_finish_reason is None
+            and self.intermittent_finish_reason is None
+        )
+
+    @staticmethod
+    def _stream_eof_error() -> httpx.RemoteProtocolError:
+        return httpx.RemoteProtocolError("Stream ended before a finish_reason was received")
+
     def _record_usage_only_chunk(self, model_response: "ModelResponseStream") -> None:
         """
         Keep provider usage-only chunks (e.g. OpenRouter's post-finish chunk, which carries a
@@ -1993,6 +2008,12 @@ class CustomStreamWrapper:
                     return response
 
         except StopIteration:
+            if self._should_fail_on_clean_eof():
+                error: Final = self._stream_eof_error()
+                eof_traceback: Final = traceback.format_exc()
+                self._record_partial_usage_for_failure()
+                threading.Thread(target=self.logging_obj.failure_handler, args=(error, eof_traceback)).start()
+                self._handle_stream_fallback_error(error)
             if self.sent_last_chunk is True:
                 try:
                     complete_streaming_response = litellm.stream_chunk_builder(
@@ -2224,6 +2245,8 @@ class CustomStreamWrapper:
                         self.chunks.append(processed_chunk)
                         return processed_chunk
         except (StopAsyncIteration, StopIteration):
+            if self._should_fail_on_clean_eof():
+                self._log_stream_failure_and_raise(self._stream_eof_error())
             return await self._finalize_completed_stream(cache_hit=cache_hit)
         except httpx.TimeoutException as e:  # if httpx read timeout error occues
             traceback_exception = traceback.format_exc()

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -920,6 +920,7 @@ def mock_completion(
                     model=model,
                     custom_llm_provider="openai",
                     logging_obj=logging,
+                    is_mock=True,
                 )
             return CustomStreamWrapper(
                 completion_stream=mock_completion_streaming_obj(
@@ -928,6 +929,7 @@ def mock_completion(
                 model=model,
                 custom_llm_provider="openai",
                 logging_obj=logging,
+                is_mock=True,
             )
         if isinstance(mock_response, litellm.MockException):
             raise mock_response

--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -1097,6 +1097,81 @@ async def test_async_streaming_read_timeout_triggers_midstream_fallback(
     assert isinstance(excinfo.value.original_exception, Exception)
 
 
+def _incomplete_openai_chat_chunk() -> ModelResponseStream:
+    return ModelResponseStream(
+        id="chatcmpl-incomplete-eof",
+        created=int(time.time()),
+        model="gpt-5.6",
+        object="chat.completion.chunk",
+        choices=[
+            StreamingChoices(
+                index=0,
+                delta=Delta(content='{"findings":[{"title":"unfinished', role="assistant"),
+                finish_reason=None,
+            )
+        ],
+    )
+
+
+@pytest.mark.parametrize("custom_llm_provider", ["openai", "azure"])
+@pytest.mark.asyncio
+async def test_async_openai_chat_clean_eof_without_finish_reason_raises_midstream_fallback(
+    logging_obj: Logging, custom_llm_provider: str
+):
+    """An OpenAI-compatible stream without a provider finish reason must fail at clean EOF."""
+    from litellm.exceptions import MidStreamFallbackError
+
+    async def source():
+        yield _incomplete_openai_chat_chunk()
+
+    logging_obj.model_call_details["custom_llm_provider"] = custom_llm_provider
+    response = CustomStreamWrapper(
+        completion_stream=source(),
+        model="gpt-5.6",
+        logging_obj=logging_obj,
+        custom_llm_provider=custom_llm_provider,
+        stream_options={"include_usage": True},
+    )
+
+    first_chunk = await response.__anext__()
+    with pytest.raises(MidStreamFallbackError) as excinfo:
+        await response.__anext__()
+
+    assert first_chunk.choices[0].delta.content == '{"findings":[{"title":"unfinished'
+    assert excinfo.value.generated_content == '{"findings":[{"title":"unfinished'
+    assert excinfo.value.is_pre_first_chunk is False
+    assert response.received_finish_reason is None
+
+
+@pytest.mark.parametrize("custom_llm_provider", ["openai", "azure"])
+def test_sync_openai_chat_clean_eof_without_finish_reason_raises_midstream_fallback(
+    logging_obj: Logging, custom_llm_provider: str
+):
+    """The synchronous OpenAI-compatible stream must fail at clean EOF too."""
+    from litellm.exceptions import MidStreamFallbackError
+
+    def source():
+        yield _incomplete_openai_chat_chunk()
+
+    logging_obj.model_call_details["custom_llm_provider"] = custom_llm_provider
+    response = CustomStreamWrapper(
+        completion_stream=source(),
+        model="gpt-5.6",
+        logging_obj=logging_obj,
+        custom_llm_provider=custom_llm_provider,
+        stream_options={"include_usage": True},
+    )
+
+    first_chunk = next(response)
+    with pytest.raises(MidStreamFallbackError) as excinfo:
+        next(response)
+
+    assert first_chunk.choices[0].delta.content == '{"findings":[{"title":"unfinished'
+    assert excinfo.value.generated_content == '{"findings":[{"title":"unfinished'
+    assert excinfo.value.is_pre_first_chunk is False
+    assert response.received_finish_reason is None
+
+
 def test_streaming_handler_with_created_time_propagation(
     initialized_custom_stream_wrapper: CustomStreamWrapper, logging_obj: Logging
 ):

--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -1113,9 +1113,9 @@ def _incomplete_openai_chat_chunk() -> ModelResponseStream:
     )
 
 
-@pytest.mark.parametrize("custom_llm_provider", ["openai", "azure"])
+@pytest.mark.parametrize("custom_llm_provider", ["openai", "azure", "hosted_vllm"])
 @pytest.mark.asyncio
-async def test_async_openai_chat_clean_eof_without_finish_reason_raises_midstream_fallback(
+async def test_async_openai_compatible_chat_clean_eof_without_finish_reason_raises_midstream_fallback(
     logging_obj: Logging, custom_llm_provider: str
 ):
     """An OpenAI-compatible stream without a provider finish reason must fail at clean EOF."""
@@ -1143,8 +1143,8 @@ async def test_async_openai_chat_clean_eof_without_finish_reason_raises_midstrea
     assert response.received_finish_reason is None
 
 
-@pytest.mark.parametrize("custom_llm_provider", ["openai", "azure"])
-def test_sync_openai_chat_clean_eof_without_finish_reason_raises_midstream_fallback(
+@pytest.mark.parametrize("custom_llm_provider", ["openai", "azure", "hosted_vllm"])
+def test_sync_openai_compatible_chat_clean_eof_without_finish_reason_raises_midstream_fallback(
     logging_obj: Logging, custom_llm_provider: str
 ):
     """The synchronous OpenAI-compatible stream must fail at clean EOF too."""

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -14268,6 +14268,9 @@ _SSE_CHUNKS: Final[tuple[bytes, ...]] = tuple(
     b'data: {"id":"c","object":"chat.completion.chunk","created":1,"model":"gpt-5.6",'
     b'"choices":[{"index":0,"delta":{"content":"x"},"finish_reason":null}]}\n\n'
     for _ in range(5)
+) + (
+    b'data: {"id":"c","object":"chat.completion.chunk","created":1,"model":"gpt-5.6",'
+    b'"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n',
 )
 
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Incomplete OpenAI-compatible streams look like successful completions
- Clients cannot trigger retry or error handling for partial output

How it solves it:

- Treat missing provider finish reasons as stream failures
- Preserve partial output for fallback and diagnostic accounting
- Keep LiteLLM mock streams' existing synthetic completion behavior

## User Flow

Before: an application receives incomplete JSON labeled as a successful completion

1. The developer sends `POST http://127.0.0.1:14000/v1/chat/completions` with `stream: true`, `stream_options: {"include_usage": true}`, and JSON-object response format
2. The upstream response ends after partial JSON without a terminal completion event
3. The client receives HTTP 200, partial text, `finish_reason: "stop"`, estimated usage, and `[DONE]`

After: the same interruption reaches the application's error handling

1. The developer sends `POST http://127.0.0.1:14000/v1/chat/completions` with `stream: true`, `stream_options: {"include_usage": true}`, and JSON-object response format
2. The upstream response ends after partial JSON without a terminal completion event
3. The client receives a stream error after the partial text instead of a generated successful completion

## Relevant issues

Fixes #40260

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, including `uv run pytest tests/test_litellm/litellm_core_utils/test_streaming_handler.py -v`
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Shared setup: use the deterministic `repro.py` shown in #40260. It yields one partial Azure-compatible chat chunk and closes without a provider finish reason or usage event

Command:

`LITELLM_LOCAL_MODEL_COST_MAP=True uv run --frozen --extra proxy python repro.py`

### Before (82e6b84f5a4b360ce569f6924cacdb9d788f2bac)

#### clean EOF

1. Run the command above against the merge-base checkout
2. The process exits 0 and outputs the partial content chunk, then a generated `finish_reason: "stop"` chunk and estimated usage

### After (4678a0f4bfa8724c3ea330e4dce9050dd09ab0b3)

#### clean EOF

1. Run the same command against this commit
2. The process exits 1 with `MidStreamFallbackError` after the partial content chunk, without a generated terminal chunk or usage event

## Type

Bug Fix

## Caveats (if any)

### Low

- The Before and After runs use the issue's deterministic stream, not a live provider request
- LiteLLM's built-in mock streams retain their existing synthetic completion behavior

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR