### PR TITLE
fix(guardrails): allow framework-supported logging-only mode

### DIFF
--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -601,6 +601,12 @@ class CustomGuardrail(CustomLogger):
         event_hook: GuardrailEventHooks | list[GuardrailEventHooks] | Mode | None,
         supported_event_hooks: list[GuardrailEventHooks],
     ) -> None:
+        allowed_hooks: Final = frozenset(supported_event_hooks) | (
+            frozenset((GuardrailEventHooks.logging_only,))
+            if self.uses_apply_guardrail_interface() and not self.use_native_lifecycle_hooks
+            else frozenset()
+        )
+
         def _validate_event_hook_list_is_in_supported_event_hooks(
             event_hook: list[GuardrailEventHooks] | list[str],
             supported_event_hooks: list[GuardrailEventHooks],
@@ -608,7 +614,7 @@ class CustomGuardrail(CustomLogger):
             for hook in event_hook:
                 if isinstance(hook, str):
                     hook = GuardrailEventHooks(hook)
-                if hook not in supported_event_hooks:
+                if hook not in allowed_hooks:
                     raise ValueError(f"Event hook {hook} is not in the supported event hooks {supported_event_hooks}")
 
         if event_hook is None:
@@ -629,7 +635,7 @@ class CustomGuardrail(CustomLogger):
                 default_list = event_hook.default if isinstance(event_hook.default, list) else [event_hook.default]
                 _validate_event_hook_list_is_in_supported_event_hooks(default_list, supported_event_hooks)
         elif isinstance(event_hook, GuardrailEventHooks):
-            if event_hook not in supported_event_hooks:
+            if event_hook not in allowed_hooks:
                 raise ValueError(f"Event hook {event_hook} is not in the supported event hooks {supported_event_hooks}")
 
     @staticmethod

--- a/tests/test_litellm/integrations/test_custom_guardrail.py
+++ b/tests/test_litellm/integrations/test_custom_guardrail.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import TYPE_CHECKING, Literal, Optional
+from typing import TYPE_CHECKING, ClassVar, Final, Literal, Optional
 from unittest.mock import AsyncMock
 
 import pytest
@@ -10,6 +10,7 @@ from litellm.integrations.custom_guardrail import (
     log_guardrail_information,
 )
 from litellm.proxy._types import CallTypes, UserAPIKeyAuth
+from litellm.types.guardrails import GuardrailEventHooks, Mode
 from litellm.types.utils import GenericGuardrailAPIInputs, GuardrailTracingDetail
 
 if TYPE_CHECKING:
@@ -2378,10 +2379,107 @@ def _logged_call(messages: list | str) -> tuple[dict, object]:
     return kwargs, response
 
 
+class _NativeApplyGuardrail(_InheritedApplyGuardrail):
+    use_native_lifecycle_hooks: ClassVar[bool] = True
+
+
+@pytest.mark.parametrize("guardrail_type", (CustomGuardrail, _NativeApplyGuardrail, _InheritedApplyGuardrail))
+@pytest.mark.parametrize(
+    "event_hook",
+    (
+        GuardrailEventHooks.logging_only,
+        "logging_only",
+        [GuardrailEventHooks.pre_call, GuardrailEventHooks.logging_only],
+        ["pre_call", "logging_only"],
+        Mode(tags={"audit": "logging_only"}, default="pre_call"),
+        Mode(tags={"audit": ["pre_call", "logging_only"]}),
+        Mode(tags={"enforce": "pre_call"}, default="logging_only"),
+        Mode(tags={}, default=["pre_call", "logging_only"]),
+    ),
+)
+def test_logging_only_requires_framework_support_or_explicit_declaration(
+    guardrail_type: type[CustomGuardrail],
+    event_hook: GuardrailEventHooks | str | list[GuardrailEventHooks] | list[str] | Mode,
+) -> None:
+    supported: Final = [GuardrailEventHooks.pre_call]
+    if guardrail_type is _InheritedApplyGuardrail:
+        guardrail: Final = guardrail_type(event_hook=event_hook, supported_event_hooks=supported)
+        assert guardrail.event_hook == event_hook
+        assert supported == [GuardrailEventHooks.pre_call]
+    else:
+        with pytest.raises(ValueError, match=r"logging_only.*not in the supported event hooks"):
+            guardrail_type(event_hook=event_hook, supported_event_hooks=supported)
+
+    explicitly_supported: Final = guardrail_type(
+        event_hook=event_hook,
+        supported_event_hooks=[GuardrailEventHooks.pre_call, GuardrailEventHooks.logging_only],
+    )
+    assert explicitly_supported.event_hook == event_hook
+
+
+@pytest.mark.parametrize(
+    "event_hook",
+    (
+        GuardrailEventHooks.post_call,
+        "post_call",
+        [GuardrailEventHooks.logging_only, GuardrailEventHooks.post_call],
+        ["logging_only", "post_call"],
+        Mode(tags={"enforce": "post_call"}, default="logging_only"),
+        Mode(tags={"enforce": ["logging_only", "post_call"]}),
+        Mode(tags={"audit": "logging_only"}, default="post_call"),
+        Mode(tags={}, default=["logging_only", "post_call"]),
+    ),
+)
+def test_framework_logging_only_does_not_allow_other_unsupported_modes(
+    event_hook: GuardrailEventHooks | str | list[GuardrailEventHooks] | list[str] | Mode,
+) -> None:
+    with pytest.raises(ValueError, match=r"post_call.*not in the supported event hooks"):
+        _InheritedApplyGuardrail(event_hook=event_hook, supported_event_hooks=[GuardrailEventHooks.pre_call])
+
+
 class TestLoggingOnlyApplyGuardrail:
     """LIT-4876 regression: a guardrail in mode logging_only that implements only
     apply_guardrail must still run against the logged request and response and
     record guardrail_information, instead of inheriting the CustomLogger no-op."""
+
+    @pytest.mark.parametrize(
+        "event_hook",
+        (
+            GuardrailEventHooks.logging_only,
+            "logging_only",
+            [GuardrailEventHooks.pre_call, GuardrailEventHooks.logging_only],
+            ["pre_call", "logging_only"],
+            Mode(tags={"audit": "logging_only"}, default="pre_call"),
+            Mode(tags={"audit": ["pre_call", "logging_only"]}),
+            Mode(tags={"enforce": "pre_call"}, default="logging_only"),
+            Mode(tags={}, default=["pre_call", "logging_only"]),
+        ),
+    )
+    @pytest.mark.asyncio
+    async def test_content_filter_accepts_logging_only_and_records_detection(
+        self, event_hook: GuardrailEventHooks | str | list[GuardrailEventHooks] | list[str] | Mode
+    ) -> None:
+        from litellm.proxy.guardrails.guardrail_hooks.litellm_content_filter.content_filter import (
+            ContentFilterGuardrail,
+        )
+        from litellm.types.guardrails import BlockedWord, ContentFilterAction, GuardrailEventHooks
+
+        guardrail: Final = ContentFilterGuardrail(
+            guardrail_name="content-review",
+            event_hook=event_hook,
+            default_on=True,
+            blocked_words=[BlockedWord(keyword="hello", action=ContentFilterAction.BLOCK)],
+        )
+        kwargs, response = _logged_call([{"role": "user", "content": "hello there"}])
+
+        out_kwargs, out_response = await guardrail.async_logging_hook(kwargs, response, CallTypes.acompletion.value)
+
+        assert out_response is response
+        assert out_kwargs["messages"] == kwargs["messages"]
+        assert (
+            out_kwargs["standard_logging_object"]["guardrail_information"][0]["guardrail_status"]
+            == "guardrail_intervened"
+        )
 
     @pytest.mark.asyncio
     async def test_runs_apply_guardrail_observe_only_and_records_verdict(self):


### PR DESCRIPTION
## TLDR

Problem this solves:

- Logging-only guardrails fail validation despite existing execution support

How it solves it:

- Accept framework-supported logging-only mode during validation
- Preserve native-lifecycle restrictions and other unsupported-mode errors

## User Flow

Before: a developer cannot start their Python app with logging-only content filtering

1. Configure content filtering to detect `hello` in `logging_only` mode
2. Start the app with Rust disabled
3. Initialization raises `ValueError: Event hook GuardrailEventHooks.logging_only is not in the supported event hooks`

After: the same app starts and records detections without blocking responses

1. Configure content filtering to detect `hello` in `logging_only` mode
2. Start the app with Rust disabled
3. Send `hello, reply with OK` to the provider and receive its response
4. Read `guardrail_intervened` in the audit result

## Relevant issues

Follow-up to #39297, which added async `logging_only` execution for `apply_guardrail` providers. That support is already merged; this PR fixes validation rejecting the same configuration

Extracted from #40070 so the validation fix can merge independently

## Linear ticket

Resolves LIT-4876

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

Local validation: `UV_PYTHON=3.12 make check` passes. With `LITELLM_RUST=0`, the mapped guardrail and recursion tests pass, 163 tests total. All eight production regression configurations fail at initialization without the fix and pass with it. Coverage includes enum/string scalars, lists, tag values, scalar/list defaults, inherited apply implementations, explicit support, native lifecycle restrictions, and rejection of other unsupported modes

## Delays in PR merge?

Contact the LiteLLM team through the repository's normal review process

## Screenshots / Proof of Fix

Run from the repository root with proxy dependencies installed and `MISTRAL_API_KEY` in `.env`. The script uses the public Python SDK with Rust disabled and a real paid provider request, with no mocks. Save the following as `/tmp/guardrail-validation-proof.py`

```python
import asyncio
from dotenv import load_dotenv
load_dotenv('.env')
import litellm
from litellm.integrations.custom_logger import CustomLogger
from litellm.proxy.guardrails.guardrail_hooks.litellm_content_filter.content_filter import ContentFilterGuardrail
from litellm.types.guardrails import BlockedWord, ContentFilterAction

async def main():
    litellm.rust(False)
    guardrail = ContentFilterGuardrail(
        guardrail_name='content-review', event_hook='logging_only', default_on=True,
        blocked_words=[BlockedWord(keyword='hello', action=ContentFilterAction.BLOCK)],
    )
    print('guardrail_initialized: True', flush=True)
    finished = asyncio.Event()
    class PrintVerdict(CustomLogger):
        async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
            entries = kwargs['standard_logging_object']['guardrail_information']
            print('guardrail_verdicts:', [(v['guardrail_name'], v['guardrail_status']) for v in entries], flush=True)
            finished.set()
    response = await litellm.acompletion(
        model='mistral/ministral-3b-latest', messages=[{'role': 'user', 'content': 'hello, reply with OK'}],
        callbacks=[guardrail, PrintVerdict()], max_tokens=32,
    )
    print('provider_response:', response.choices[0].message.content, flush=True)
    print('billed_tokens:', response.usage.total_tokens, flush=True)
    await asyncio.wait_for(finished.wait(), timeout=30)

try:
    asyncio.run(main())
except ValueError as exc:
    print(type(exc).__name__ + ': ' + str(exc), flush=True)
```

### Before (82e6b84f5a4b360ce569f6924cacdb9d788f2bac)

1. Run `LITELLM_LOCAL_MODEL_COST_MAP=True LITELLM_RUST=0 uv run --no-sync python - < /tmp/guardrail-validation-proof.py`
2. Initialization fails before any provider request

   ```text
   ValueError: Event hook GuardrailEventHooks.logging_only is not in the supported event hooks [<GuardrailEventHooks.pre_call: 'pre_call'>, <GuardrailEventHooks.post_call: 'post_call'>, <GuardrailEventHooks.during_call: 'during_call'>, <GuardrailEventHooks.realtime_input_transcription: 'realtime_input_transcription'>, <GuardrailEventHooks.pre_mcp_call: 'pre_mcp_call'>, <GuardrailEventHooks.post_mcp_call: 'post_mcp_call'>]
   ```

### After (6fa267990d)

1. Run `LITELLM_LOCAL_MODEL_COST_MAP=True LITELLM_RUST=0 uv run --no-sync python - < /tmp/guardrail-validation-proof.py`
2. Initialization succeeds, the provider returns a response, and the audit records the detection. Selected output from the latest run:

   ```text
   guardrail_initialized: True
   billed_tokens: 21
   guardrail_verdicts: [('content-review', 'guardrail_intervened')]
   ```

## Type

Bug Fix

## Caveats (if any)

## Final Attestation

- [x] The tests check the validation failure and relevant configuration edge cases
