### PR TITLE
fix(proxy/auth): copy end_user_max_budget onto token in update_valid_token_with_end_user_params

### DIFF
--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -563,6 +563,8 @@ def update_valid_token_with_end_user_params(valid_token: UserAPIKeyAuth, end_use
         valid_token.end_user_rpm_limit = end_user_params["end_user_rpm_limit"]
     if end_user_params.get("allowed_model_region") is not None:
         valid_token.allowed_model_region = end_user_params["allowed_model_region"]
+    if end_user_params.get("end_user_max_budget") is not None:
+        valid_token.end_user_max_budget = end_user_params["end_user_max_budget"]
     if end_user_params.get("end_user_model_max_budget") is not None:
         valid_token.end_user_model_max_budget = end_user_params["end_user_model_max_budget"]
     return valid_token

--- a/tests/test_litellm/proxy/auth/test_custom_auth_end_user_budget.py
+++ b/tests/test_litellm/proxy/auth/test_custom_auth_end_user_budget.py
@@ -280,10 +280,6 @@ def test_update_valid_token_db_values_override_custom_auth_when_set():
 
 
 def test_update_valid_token_copies_end_user_max_budget():
-    # Regression: end_user_max_budget was the only limit field not copied by
-    # update_valid_token_with_end_user_params, so a budget from
-    # max_end_user_budget_id was silently dropped and budget reservation
-    # returned None, letting all concurrent first requests bypass the limit.
     valid_token = UserAPIKeyAuth(token="test_token", end_user_id="customer-1")
 
     end_user_params = {
@@ -297,8 +293,6 @@ def test_update_valid_token_copies_end_user_max_budget():
 
 
 def test_update_valid_token_preserves_custom_auth_max_budget_when_db_has_none():
-    # If custom auth sets end_user_max_budget and the DB budget table has no
-    # max_budget, the custom-auth-supplied value must survive the copy.
     valid_token = UserAPIKeyAuth(
         token="test_token",
         end_user_id="customer-1",
@@ -307,7 +301,6 @@ def test_update_valid_token_preserves_custom_auth_max_budget_when_db_has_none():
 
     end_user_params = {
         "end_user_id": "customer-1",
-        # no end_user_max_budget key: DB found no value
     }
 
     result = update_valid_token_with_end_user_params(valid_token, end_user_params)
@@ -317,9 +310,6 @@ def test_update_valid_token_preserves_custom_auth_max_budget_when_db_has_none():
 
 @pytest.mark.asyncio
 async def test_end_user_budget_counter_created_from_token_max_budget():
-    # Regression: _get_end_user_budget_counter reads valid_token.end_user_max_budget
-    # first. When that field was always None (due to the copy bug), no counter was
-    # returned and budget reservation skipped enforcement entirely for new end users.
     from litellm.proxy.spend_tracking.budget_reservation import (
         _get_end_user_budget_counter,
     )
@@ -343,8 +333,6 @@ async def test_end_user_budget_counter_created_from_token_max_budget():
 
 @pytest.mark.asyncio
 async def test_end_user_budget_counter_none_when_max_budget_missing():
-    # Without a budget on the token or the end_user_object, no counter should
-    # be returned: the user is unrestricted and reservation is skipped correctly.
     from litellm.proxy.spend_tracking.budget_reservation import (
         _get_end_user_budget_counter,
     )

--- a/tests/test_litellm/proxy/auth/test_custom_auth_end_user_budget.py
+++ b/tests/test_litellm/proxy/auth/test_custom_auth_end_user_budget.py
@@ -277,3 +277,87 @@ def test_update_valid_token_db_values_override_custom_auth_when_set():
     # DB values should win
     assert result.end_user_tpm_limit == 500
     assert result.end_user_model_max_budget == db_budget
+
+
+def test_update_valid_token_copies_end_user_max_budget():
+    # Regression: end_user_max_budget was the only limit field not copied by
+    # update_valid_token_with_end_user_params, so a budget from
+    # max_end_user_budget_id was silently dropped and budget reservation
+    # returned None, letting all concurrent first requests bypass the limit.
+    valid_token = UserAPIKeyAuth(token="test_token", end_user_id="customer-1")
+
+    end_user_params = {
+        "end_user_id": "customer-1",
+        "end_user_max_budget": 0.000000001,
+    }
+
+    result = update_valid_token_with_end_user_params(valid_token, end_user_params)
+
+    assert result.end_user_max_budget == 0.000000001
+
+
+def test_update_valid_token_preserves_custom_auth_max_budget_when_db_has_none():
+    # If custom auth sets end_user_max_budget and the DB budget table has no
+    # max_budget, the custom-auth-supplied value must survive the copy.
+    valid_token = UserAPIKeyAuth(
+        token="test_token",
+        end_user_id="customer-1",
+        end_user_max_budget=50.0,
+    )
+
+    end_user_params = {
+        "end_user_id": "customer-1",
+        # no end_user_max_budget key: DB found no value
+    }
+
+    result = update_valid_token_with_end_user_params(valid_token, end_user_params)
+
+    assert result.end_user_max_budget == 50.0
+
+
+@pytest.mark.asyncio
+async def test_end_user_budget_counter_created_from_token_max_budget():
+    # Regression: _get_end_user_budget_counter reads valid_token.end_user_max_budget
+    # first. When that field was always None (due to the copy bug), no counter was
+    # returned and budget reservation skipped enforcement entirely for new end users.
+    from litellm.proxy.spend_tracking.budget_reservation import (
+        _get_end_user_budget_counter,
+    )
+
+    token = UserAPIKeyAuth(
+        token="test_token",
+        end_user_id="customer-1",
+        end_user_max_budget=0.000000001,
+    )
+
+    counter = await _get_end_user_budget_counter(
+        valid_token=token,
+        end_user_id="customer-1",
+        end_user_object=None,
+    )
+
+    assert counter is not None
+    assert counter.max_budget == 0.000000001
+    assert counter.counter_key == "spend:end_user:customer-1"
+
+
+@pytest.mark.asyncio
+async def test_end_user_budget_counter_none_when_max_budget_missing():
+    # Without a budget on the token or the end_user_object, no counter should
+    # be returned: the user is unrestricted and reservation is skipped correctly.
+    from litellm.proxy.spend_tracking.budget_reservation import (
+        _get_end_user_budget_counter,
+    )
+
+    token = UserAPIKeyAuth(
+        token="test_token",
+        end_user_id="customer-1",
+    )
+
+    counter = await _get_end_user_budget_counter(
+        valid_token=token,
+        end_user_id="customer-1",
+        end_user_object=None,
+    )
+
+    assert counter is None


### PR DESCRIPTION
## TLDR

Problem this solves:

- When `max_end_user_budget_id` is configured, concurrent first requests for a new end user all bypass the budget limit and hit the provider
- A customer with a $0.000000001 budget could accumulate real spend before the first rejection fires

How it solves it:

- `update_valid_token_with_end_user_params` was copying `tpm_limit`, `rpm_limit`, `allowed_model_region`, and `model_max_budget` from `end_user_params` onto the token, but silently dropping `end_user_max_budget`
- The budget reservation path reads `valid_token.end_user_max_budget` first; when it was always `None`, no reservation counter was created and pre-call enforcement was skipped entirely for new end users
- Added the one missing copy line, consistent with the four fields already handled

## What tests were added

All four tests are in `tests/test_litellm/proxy/auth/test_custom_auth_end_user_budget.py`:

- `test_update_valid_token_copies_end_user_max_budget` — calls `update_valid_token_with_end_user_params` with `end_user_max_budget` in params and asserts it lands on the token. Fails before the fix, passes after.
- `test_update_valid_token_preserves_custom_auth_max_budget_when_db_has_none` — custom auth sets the budget on the token, DB has no value; the token value must not be wiped. Matches the existing guard behavior for the other four fields.
- `test_end_user_budget_counter_created_from_token_max_budget` — with `end_user_max_budget` on the token, `_get_end_user_budget_counter` must return a counter with the correct key and limit. Before the fix this returned `None` even with the token correctly populated, meaning budget reservation was skipped.
- `test_end_user_budget_counter_none_when_max_budget_missing` — negative case: no budget on token or end_user_object means no counter, so unrestricted users are not incorrectly throttled.

## Relevant issues

Fixes #40095

## Linear ticket

## Type

🐛 Bug Fix

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR