### PR TITLE
feat: add support for traffic inspection in http proxies

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -515,6 +515,9 @@ disable_aiohttp_transport: bool = False  # Set this to true to use httpx instead
 disable_aiohttp_trust_env: bool = False  # When False, aiohttp will respect HTTP(S)_PROXY env vars
 force_ipv4: bool = False  # when True, litellm will force ipv4 for all LLM requests. Some users have seen httpx ConnectionError when using ipv6.
 network_mock: bool = False  # When True, use mock transport — no real network calls
+outbound_http_proxy: Optional[str] = (
+    None  # When set to an URL, use it to proxy all outgoing requests without CONNECT tunnelling.
+)
 
 ####### STOP SEQUENCE LIMIT #######
 disable_stop_sequence_limit: bool = False  # when True, stop sequence limit is disabled

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -40,6 +40,7 @@ from litellm.litellm_core_utils.logging_utils import track_llm_api_timing
 from litellm.litellm_core_utils.request_timeout_resolver import (
     get_configured_request_timeout,
 )
+from litellm.llms.custom_httpx.proxy_transport import AsyncProxyTransport, ProxyTransport
 from litellm.types.llms.custom_http import *
 
 if TYPE_CHECKING:
@@ -483,6 +484,17 @@ def _raise_masked_sync_error(e: httpx.HTTPStatusError, stream: bool) -> NoReturn
                 pass
     _text: Final = mask_sensitive_info(_safe_get_response_text(e.response))
     raise MaskedHTTPStatusError(e, message=_text, text=_text) from None
+
+
+def _get_outbound_http_proxy() -> str | None:
+    proxy = litellm.outbound_http_proxy
+    if proxy is None:
+        proxy = os.getenv("OUTBOUND_HTTP_PROXY")
+
+    if proxy is not None:
+        verbose_logger.debug("Sending requests through %s", proxy)
+
+    return proxy
 
 
 async def _raise_masked_async_error(e: httpx.HTTPStatusError, stream: bool) -> NoReturn:
@@ -1052,6 +1064,11 @@ class AsyncHTTPHandler:
         - Why force ipv4?
             - Some users have seen httpx ConnectionError when using ipv6 - forcing ipv4 resolves the issue for them
         """
+
+        outbound_proxy = _get_outbound_http_proxy()
+        if outbound_proxy is not None:
+            return AsyncHTTPHandler._create_proxy_transport(outbound_proxy)
+
         #########################################################
         # AIOHTTP TRANSPORT is off by default
         #########################################################
@@ -1213,6 +1230,10 @@ class AsyncHTTPHandler:
             return AsyncHTTPTransport(local_address=_IPV4_LOCAL_ADDRESS)
         else:
             return None
+
+    @staticmethod
+    def _create_proxy_transport(proxy: str) -> AsyncHTTPTransport:
+        return AsyncProxyTransport(proxy_url=proxy)
 
     @staticmethod
     def _create_httpx_proxy_mounts(
@@ -1538,6 +1559,11 @@ class HTTPHandler:
 
         Some users have seen httpx ConnectionError when using ipv6 - forcing ipv4 resolves the issue for them
         """
+
+        outbound_proxy = _get_outbound_http_proxy()
+        if outbound_proxy is not None:
+            return ProxyTransport(proxy_url=outbound_proxy)
+
         if litellm.force_ipv4:
             return HTTPTransport(local_address=_IPV4_LOCAL_ADDRESS)
         else:

--- a/litellm/llms/custom_httpx/proxy_transport.py
+++ b/litellm/llms/custom_httpx/proxy_transport.py
@@ -1,0 +1,48 @@
+import os
+import ssl
+from typing import Final
+
+import httpx
+
+
+def _get_http_proxy(proxy_url: str) -> httpx.Proxy:
+    from litellm.secret_managers.main import str_to_bool
+
+    if str_to_bool(os.getenv("DISABLE_OUTBOUND_PROXY_TLS_VERIFICATION", "False")):
+        # For the case when proxy uses self-signed certificate.
+        proxy_ssl_context: Final = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        proxy_ssl_context.check_hostname = False
+        proxy_ssl_context.verify_mode = ssl.CERT_NONE
+        return httpx.Proxy(url=proxy_url, ssl_context=proxy_ssl_context)
+
+    return httpx.Proxy(url=proxy_url, ssl_context=None)
+
+
+def _rewrite_request(request: httpx.Request) -> httpx.Request:
+    headers: Final = request.headers.copy()
+    headers["X-Forwarded-Proto"] = request.url.scheme
+    url: Final = request.url.copy_with(scheme="http")
+
+    return httpx.Request(
+        method=request.method,
+        url=url,
+        headers=headers,
+        stream=request.stream,
+        extensions=request.extensions,
+    )
+
+
+class AsyncProxyTransport(httpx.AsyncHTTPTransport):
+    def __init__(self, proxy_url: str) -> None:
+        super().__init__(proxy=_get_http_proxy(proxy_url))
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        return await super().handle_async_request(_rewrite_request(request))
+
+
+class ProxyTransport(httpx.HTTPTransport):
+    def __init__(self, proxy_url: str) -> None:
+        super().__init__(proxy=_get_http_proxy(proxy_url))
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        return super().handle_request(_rewrite_request(request))

--- a/tests/test_litellm/llms/custom_httpx/test_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_http_handler.py
@@ -5,6 +5,7 @@ import os
 import pathlib
 import ssl
 import threading
+from typing import Final
 import weakref
 from unittest.mock import MagicMock, patch
 
@@ -23,6 +24,7 @@ from litellm.llms.custom_httpx.http_handler import (
     _get_httpx_client,
     get_ssl_configuration,
 )
+from litellm.llms.custom_httpx.proxy_transport import AsyncProxyTransport, ProxyTransport
 
 
 @pytest.mark.asyncio
@@ -1547,3 +1549,44 @@ def test_sync_force_ipv4_https_proxy_mount_uses_handler_ca_bundle(
         handler.close()
 
     assert response.text == "ok-tls"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("config_source", ["attribute", "env_var"])
+async def test_proxy_transports_used_instead_of_default_when_configured(
+    monkeypatch: pytest.MonkeyPatch, config_source: str
+) -> None:
+    proxy_url: Final = "http://proxy.example.com:8080"
+    monkeypatch.setattr(litellm, "outbound_http_proxy", None)
+    monkeypatch.delenv("OUTBOUND_HTTP_PROXY", raising=False)
+
+    default_sync_handler: Final = HTTPHandler()
+    try:
+        assert not isinstance(default_sync_handler.client._transport, ProxyTransport)
+    finally:
+        default_sync_handler.close()
+
+    default_async_handler: Final = AsyncHTTPHandler()
+    try:
+        assert isinstance(default_async_handler.client._transport, LiteLLMAiohttpTransport)
+        assert not isinstance(default_async_handler.client._transport, AsyncProxyTransport)
+    finally:
+        await default_async_handler.close()
+
+    if config_source == "attribute":
+        monkeypatch.setattr(litellm, "outbound_http_proxy", proxy_url)
+    else:
+        monkeypatch.setenv("OUTBOUND_HTTP_PROXY", proxy_url)
+
+    configured_sync_handler: Final = HTTPHandler()
+    try:
+        assert isinstance(configured_sync_handler.client._transport, ProxyTransport)
+    finally:
+        configured_sync_handler.close()
+
+    configured_async_handler: Final = AsyncHTTPHandler()
+    try:
+        assert isinstance(configured_async_handler.client._transport, AsyncProxyTransport)
+        assert not isinstance(configured_async_handler.client._transport, LiteLLMAiohttpTransport)
+    finally:
+        await configured_async_handler.close()

--- a/tests/test_litellm/llms/custom_httpx/test_proxy_transport.py
+++ b/tests/test_litellm/llms/custom_httpx/test_proxy_transport.py
@@ -1,0 +1,150 @@
+from collections.abc import Generator
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import ssl
+from socketserver import ThreadingMixIn
+import threading
+from typing import Final
+
+import httpx
+import pytest
+
+from litellm.llms.custom_httpx.proxy_transport import (
+    AsyncProxyTransport,
+    ProxyTransport,
+    _get_http_proxy,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class RecordedRequest:
+    method: str
+    path: str
+    forwarded_proto: str | None
+
+
+class ThreadedServer(ThreadingMixIn, HTTPServer):
+    daemon_threads = True
+
+
+@pytest.fixture
+def recording_proxy_server() -> Generator[tuple[str, list[RecordedRequest]], None, None]:
+    recorded_requests: Final[list[RecordedRequest]] = []
+
+    class RecordingProxyHandler(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def do_GET(self) -> None:
+            self._record_and_respond()
+
+        def do_POST(self) -> None:
+            self._record_and_respond()
+
+        def _record_and_respond(self) -> None:
+            recorded_requests.append(
+                RecordedRequest(
+                    method=self.command,
+                    path=self.path,
+                    forwarded_proto=self.headers.get("X-Forwarded-Proto"),
+                )
+            )
+            self.send_response(200)
+            self.send_header("Content-Length", "2")
+            self.end_headers()
+            self.wfile.write(b"ok")
+
+        def log_message(self, format: str, *args: object) -> None:
+            pass
+
+    server: Final = ThreadedServer(("127.0.0.1", 0), RecordingProxyHandler)
+    thread: Final = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}", recorded_requests
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def test_proxy_transport_uses_configured_proxy_and_downgrades_https(
+    recording_proxy_server: tuple[str, list[RecordedRequest]],
+) -> None:
+    proxy_url, recorded_requests = recording_proxy_server
+    transport: Final = ProxyTransport(proxy_url=proxy_url)
+    client: Final = httpx.Client(transport=transport)
+    try:
+        response: Final = client.post(
+            "https://upstream.invalid/v1/chat/completions",
+            json={"model": "test"},
+        )
+    finally:
+        client.close()
+
+    assert response.status_code == 200
+    assert len(recorded_requests) == 1
+    assert recorded_requests[0].method == "POST"
+    assert recorded_requests[0].path == "http://upstream.invalid/v1/chat/completions"
+    assert recorded_requests[0].forwarded_proto == "https"
+
+
+@pytest.mark.asyncio
+async def test_async_proxy_transport_uses_configured_proxy_and_downgrades_https(
+    recording_proxy_server: tuple[str, list[RecordedRequest]],
+) -> None:
+    proxy_url, recorded_requests = recording_proxy_server
+    transport: Final = AsyncProxyTransport(proxy_url=proxy_url)
+    client: Final = httpx.AsyncClient(transport=transport)
+    try:
+        response: Final = await client.post(
+            "https://upstream.invalid/v1/chat/completions",
+            json={"model": "test"},
+        )
+    finally:
+        await client.aclose()
+
+    assert response.status_code == 200
+    assert len(recorded_requests) == 1
+    assert recorded_requests[0].method == "POST"
+    assert recorded_requests[0].path == "http://upstream.invalid/v1/chat/completions"
+    assert recorded_requests[0].forwarded_proto == "https"
+
+
+def test_proxy_transport_preserves_plain_http_scheme(
+    recording_proxy_server: tuple[str, list[RecordedRequest]],
+) -> None:
+    proxy_url, recorded_requests = recording_proxy_server
+    transport: Final = ProxyTransport(proxy_url=proxy_url)
+    client: Final = httpx.Client(transport=transport)
+    try:
+        response: Final = client.get("http://upstream.invalid/v1/models")
+    finally:
+        client.close()
+
+    assert response.status_code == 200
+    assert len(recorded_requests) == 1
+    assert recorded_requests[0].method == "GET"
+    assert recorded_requests[0].path == "http://upstream.invalid/v1/models"
+    assert recorded_requests[0].forwarded_proto == "http"
+
+
+@pytest.mark.parametrize(
+    ("disable_verify", "expect_ssl_context"),
+    [
+        ("False", False),
+        ("True", True),
+    ],
+)
+def test_get_http_proxy_tls_verification(
+    monkeypatch: pytest.MonkeyPatch, disable_verify: str, expect_ssl_context: bool
+) -> None:
+    monkeypatch.setenv("DISABLE_OUTBOUND_PROXY_TLS_VERIFICATION", disable_verify)
+    proxy: Final = _get_http_proxy("http://proxy.test:8080")
+
+    if expect_ssl_context:
+        assert isinstance(proxy.ssl_context, ssl.SSLContext)
+        assert proxy.ssl_context.check_hostname is False
+        assert proxy.ssl_context.verify_mode == ssl.CERT_NONE
+    else:
+        assert proxy.ssl_context is None
+


### PR DESCRIPTION
## TLDR

Problem this solves:

- Google Agent Gateway wants to integrate LiteLLM as an AI proxy.
- Gateway is intercepting all AI requests from user's tools and sends them to LiteLLM
- Processed requests need to be sent through Gateway for additional inspection.

How it solves it:

- Adds a configuration variable allowing to set Agent Gateway as outbound HTTP proxy in LiteLLM.
- Connection to proxy can be HTTP or HTTPS.
- To prevent HTTP clients from using CONNECT method, requests are sent as plain HTTP.
- Original scheme is restored from X-Forwarded-Proto header by Agent Gateway.
- Design doc for the Envoy's ext_proc proxy that uses this feature: https://gist.github.com/rblaze/118625501cb687bdddc398daef95c132

## User Flow

No changes in user flows. All changes are internal to LiteLLM request processing.

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

LiteLLM is configured with Gemini and Anthropic models: 
<img width="1030" height="370" alt="image" src="https://github.com/user-attachments/assets/fa3dc287-8278-4163-8393-41fe0b1353a3" />

Request is sent using following command:
```
curl http://127.0.0.1:4000/v1/chat/completions   -H "Content-Type: application/json"   -H "Authorization: Bearer sk-MY-KEY"   -d '{
    "model": "gemini/gemini-flash-lite-latest",
    "messages": [
      {
        "role": "user",
        "content": "Hello!"
      }
    ]
  }'
```

### Before (1af7a403c66e037bec2e0ae6ea455a1c10b17b1b)

#### Request sent directly to LLM provider

1. Response `{"id":"v2OgapuYBfXsz7IP-u2iqQ0","created":1788896191,"model":"gemini/gemini-flash-lite-latest","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"Hello! How can I help you today?","role":"assistant","images":[],"thinking_blocks":[],"provider_specific_fields":{"thought_signatures":["El4KXAERTTIPLy5Vyj9VRYaREarDyQayDYGOxN7VqHlWciLB++VsqC21KYFdvquOMxOPlza/T394rkQ8ZszdLAX9a1IxHd63kHCzwxthlmP/wnUOik6+yrsCidwLBfFk"]}}}],"usage":{"completion_tokens":9,"prompt_tokens":3,"total_tokens":12,"completion_tokens_details":{"text_tokens":9},"prompt_tokens_details":{"text_tokens":3}},"vertex_ai_grounding_metadata":[],"vertex_ai_url_context_metadata":[],"vertex_ai_safety_results":[],"vertex_ai_citation_metadata":[],"service_tier":"default"}`
2. tcpdump shows traffic to `generativelanguage.googleapis.com` (172.217.112.4)
```
19:45:43.591108 IP blazered-litellm-dev.us-east1-d.c.staging-quic-dev.internal.44986 > 172.217.112.4.https: Flags [S], seq 176520780, win 65320, options [mss 1420,sackOK,TS val 2201728622 ecr 0,nop,wscale 10], length 0                                                       
19:45:43.591765 IP 172.217.112.4.https > blazered-litellm-dev.us-east1-d.c.staging-quic-dev.internal.44986: Flags [S.], seq 629853241, ack 176520781, win 65535, options [mss 1420,sackOK,TS val 837899139 ecr 2201728622,nop,wscale 8], length 0                                
19:45:43.591800 IP blazered-litellm-dev.us-east1-d.c.staging-quic-dev.internal.44986 > 172.217.112.4.https: Flags [.], ack 1, win 64, options [nop,nop,TS val 2201728623 ecr 837899139], length 0                                                                                
19:45:43.592998 IP blazered-litellm-dev.us-east1-d.c.staging-quic-dev.internal.44986 > 172.217.112.4.https: Flags [P.], seq 1:1533, ack 1, win 64, options [nop,nop,TS val 2201728624 ecr 837899139], length 1532
```

### After (228c5923831adb28094f3bb2969e32f738f0ace5)

#### Request sent through proxy when .env includes `OUTBOUND_HTTP_PROXY = "https://127.0.0.1:11111"`

1. Response `{"id":"vGigasWtDuqIz7IPy82L2QI","created":1788897468,"model":"gemini/gemini-flash-lite-latest","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"Hello! How can I help you today?","role":"assistant","images":[],"thinking_blocks":[],"provider_specific_fields":{"thought_signatures":["El4KXAERTTIPxv++8Wia67Rp5WsT3cQB7otEpe5ehnmBZIpM4+OMoPMIBTcZ789+a293B+cShiqp+PyjDjVJ35nTpSJGJZ2IH3Urhwa4WI2RbPSk+jKP/JmDbX6C2P1U"]}}}],"usage":{"completion_tokens":9,"prompt_tokens":3,"total_tokens":12,"completion_tokens_details":{"text_tokens":9},"prompt_tokens_details":{"text_tokens":3}},"vertex_ai_grounding_metadata":[],"vertex_ai_url_context_metadata":[],"vertex_ai_safety_results":[],"vertex_ai_citation_metadata":[],"service_tier":"default"}`
2. tcpdump shows request going via proxy:
```
19:57:48.171214 IP localhost.52392 > localhost.11111: Flags [S], seq 3460096412, win 65495, options [mss 65495,sackOK,TS val 692506210 ecr 0,nop,wscale 10], length 0
19:57:48.171230 IP localhost.11111 > localhost.52392: Flags [S.], seq 1392578979, ack 3460096413, win 65483, options [mss 65495,sackOK,TS val 3707685308 ecr 692506210,nop,wscale 10], length 0
19:57:48.171241 IP localhost.52392 > localhost.11111: Flags [.], ack 1, win 64, options [nop,nop,TS val 692506210 ecr 3707685308], length 0
19:57:48.172231 IP localhost.52392 > localhost.11111: Flags [P.], seq 1:1514, ack 1, win 64, options [nop,nop,TS val 692506211 ecr 3707685308], length 1513
```

## Type

🆕 New Feature

## Caveats (if any)

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
