### PR TITLE
fix(ui): repair pass-through delete confirm dialog and disable delete for config endpoints

### DIFF
--- a/ui/litellm-dashboard/src/components/PassThroughSettings/PassThroughEndpointsTable.test.tsx
+++ b/ui/litellm-dashboard/src/components/PassThroughSettings/PassThroughEndpointsTable.test.tsx
@@ -115,12 +115,24 @@ describe("PassThroughEndpointsTable", () => {
 
     expect(editItem).toHaveAttribute("data-disabled");
     expect(deleteItem).toHaveAttribute("data-disabled");
+    expect(screen.getByTestId("endpoint-config-hint")).toHaveTextContent(
+      "This endpoint is defined in the config file and cannot be edited or deleted on the dashboard.",
+    );
 
     await user.click(editItem);
     await user.click(deleteItem);
 
     expect(onEndpointClick).not.toHaveBeenCalled();
     expect(onDeleteClick).not.toHaveBeenCalled();
+  });
+
+  it("should not show the config hint for DB endpoints", async () => {
+    const user = userEvent.setup();
+    render(<PassThroughEndpointsTable {...defaultProps} />);
+
+    await user.click(screen.getByTestId("endpoint-actions-ep-1"));
+    await screen.findByTestId("endpoint-action-delete");
+    expect(screen.queryByTestId("endpoint-config-hint")).not.toBeInTheDocument();
   });
 
   it("should label endpoint source as Config or DB", () => {

--- a/ui/litellm-dashboard/src/components/PassThroughSettings/PassThroughEndpointsTable.test.tsx
+++ b/ui/litellm-dashboard/src/components/PassThroughSettings/PassThroughEndpointsTable.test.tsx
@@ -89,6 +89,53 @@ describe("PassThroughEndpointsTable", () => {
     expect(onDeleteClick).toHaveBeenCalledWith("ep-1");
   });
 
+  it("should disable edit and delete for config-defined endpoints", async () => {
+    const user = userEvent.setup();
+    const onEndpointClick = vi.fn();
+    const onDeleteClick = vi.fn();
+    const configEndpoint: passThroughItem = {
+      id: "ep-config",
+      path: "/from-config",
+      target: "https://config.example.com",
+      headers: {},
+      is_from_config: true,
+    };
+    render(
+      <PassThroughEndpointsTable
+        {...defaultProps}
+        endpoints={[configEndpoint]}
+        onEndpointClick={onEndpointClick}
+        onDeleteClick={onDeleteClick}
+      />,
+    );
+
+    await user.click(screen.getByTestId("endpoint-actions-ep-config"));
+    const editItem = await screen.findByTestId("endpoint-action-edit");
+    const deleteItem = await screen.findByTestId("endpoint-action-delete");
+
+    expect(editItem).toHaveAttribute("data-disabled");
+    expect(deleteItem).toHaveAttribute("data-disabled");
+
+    await user.click(editItem);
+    await user.click(deleteItem);
+
+    expect(onEndpointClick).not.toHaveBeenCalled();
+    expect(onDeleteClick).not.toHaveBeenCalled();
+  });
+
+  it("should label endpoint source as Config or DB", () => {
+    const configEndpoint: passThroughItem = {
+      id: "ep-config",
+      path: "/from-config",
+      target: "https://config.example.com",
+      headers: {},
+      is_from_config: true,
+    };
+    render(<PassThroughEndpointsTable {...defaultProps} endpoints={[...endpoints, configEndpoint]} />);
+    expect(screen.getByText("Config")).toBeInTheDocument();
+    expect(screen.getAllByText("DB")).toHaveLength(2);
+  });
+
   it("should disable edit and delete for endpoints without an id", async () => {
     const user = userEvent.setup();
     const onEndpointClick = vi.fn();

--- a/ui/litellm-dashboard/src/components/PassThroughSettings/PassThroughEndpointsTableColumns.tsx
+++ b/ui/litellm-dashboard/src/components/PassThroughSettings/PassThroughEndpointsTableColumns.tsx
@@ -18,6 +18,10 @@ import { cn } from "@/lib/cva.config";
 
 import type { passThroughItem } from "./PassThroughSettings";
 
+const CONFIG_EDIT_HINT = "Config pass-through endpoints cannot be edited on the dashboard. Please edit the config file.";
+const CONFIG_DELETE_HINT =
+  "Config pass-through endpoints cannot be deleted on the dashboard. Please edit the config file.";
+
 function HeaderWithTooltip({ title, tooltip }: { title: string; tooltip: string }) {
   return (
     <div className="flex items-center gap-1">
@@ -73,6 +77,7 @@ interface EndpointRowActionsProps {
 
 function EndpointRowActions({ endpoint, onEndpointClick, onDeleteClick }: EndpointRowActionsProps) {
   const endpointId = endpoint.id;
+  const isFromConfig = endpoint.is_from_config ?? false;
   return (
     <DropdownMenu>
       <DropdownMenuTrigger
@@ -85,8 +90,9 @@ function EndpointRowActions({ endpoint, onEndpointClick, onDeleteClick }: Endpoi
       <DropdownMenuContent align="end" className="w-52">
         <DropdownMenuItem
           data-testid="endpoint-action-edit"
-          disabled={!endpointId}
-          onClick={() => endpointId && onEndpointClick(endpointId)}
+          disabled={isFromConfig || !endpointId}
+          title={isFromConfig ? CONFIG_EDIT_HINT : undefined}
+          onClick={() => !isFromConfig && endpointId && onEndpointClick(endpointId)}
         >
           <Pencil />
           Edit
@@ -95,8 +101,9 @@ function EndpointRowActions({ endpoint, onEndpointClick, onDeleteClick }: Endpoi
         <DropdownMenuItem
           variant="destructive"
           data-testid="endpoint-action-delete"
-          disabled={!endpointId}
-          onClick={() => endpointId && onDeleteClick(endpointId)}
+          disabled={isFromConfig || !endpointId}
+          title={isFromConfig ? CONFIG_DELETE_HINT : undefined}
+          onClick={() => !isFromConfig && endpointId && onDeleteClick(endpointId)}
         >
           <Trash2 />
           Delete
@@ -124,7 +131,9 @@ export const getPassThroughEndpointsTableColumns = ({
     enableSorting: false,
     cell: ({ row }) => {
       const endpointId = row.original.id;
-      if (!endpointId) return <span className="font-mono text-xs text-muted-foreground">—</span>;
+      if (!endpointId || row.original.is_from_config) {
+        return <span className="font-mono text-xs text-muted-foreground">—</span>;
+      }
       return (
         <IdentityCell
           title={endpointId}
@@ -132,6 +141,17 @@ export const getPassThroughEndpointsTableColumns = ({
           onClick={() => onEndpointClick(endpointId)}
         />
       );
+    },
+  },
+  {
+    id: "source",
+    meta: { title: "Source", skeleton: "badge" },
+    header: "Source",
+    size: 100,
+    enableSorting: false,
+    cell: ({ row }) => {
+      const isFromConfig = row.original.is_from_config ?? false;
+      return <StatusBadge tone={isFromConfig ? "neutral" : "info"} label={isFromConfig ? "Config" : "DB"} />;
     },
   },
   {

--- a/ui/litellm-dashboard/src/components/PassThroughSettings/PassThroughEndpointsTableColumns.tsx
+++ b/ui/litellm-dashboard/src/components/PassThroughSettings/PassThroughEndpointsTableColumns.tsx
@@ -18,9 +18,8 @@ import { cn } from "@/lib/cva.config";
 
 import type { passThroughItem } from "./PassThroughSettings";
 
-const CONFIG_EDIT_HINT = "Config pass-through endpoints cannot be edited on the dashboard. Please edit the config file.";
-const CONFIG_DELETE_HINT =
-  "Config pass-through endpoints cannot be deleted on the dashboard. Please edit the config file.";
+const CONFIG_ENDPOINT_HINT =
+  "This endpoint is defined in the config file and cannot be edited or deleted on the dashboard.";
 
 function HeaderWithTooltip({ title, tooltip }: { title: string; tooltip: string }) {
   return (
@@ -91,7 +90,6 @@ function EndpointRowActions({ endpoint, onEndpointClick, onDeleteClick }: Endpoi
         <DropdownMenuItem
           data-testid="endpoint-action-edit"
           disabled={isFromConfig || !endpointId}
-          title={isFromConfig ? CONFIG_EDIT_HINT : undefined}
           onClick={() => !isFromConfig && endpointId && onEndpointClick(endpointId)}
         >
           <Pencil />
@@ -102,12 +100,16 @@ function EndpointRowActions({ endpoint, onEndpointClick, onDeleteClick }: Endpoi
           variant="destructive"
           data-testid="endpoint-action-delete"
           disabled={isFromConfig || !endpointId}
-          title={isFromConfig ? CONFIG_DELETE_HINT : undefined}
           onClick={() => !isFromConfig && endpointId && onDeleteClick(endpointId)}
         >
           <Trash2 />
           Delete
         </DropdownMenuItem>
+        {isFromConfig && (
+          <div data-testid="endpoint-config-hint" className="px-2 py-1.5 text-xs text-muted-foreground">
+            {CONFIG_ENDPOINT_HINT}
+          </div>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/ui/litellm-dashboard/src/components/PassThroughSettings/PassThroughSettings.tsx
+++ b/ui/litellm-dashboard/src/components/PassThroughSettings/PassThroughSettings.tsx
@@ -1,4 +1,13 @@
 import React, { useState, useEffect } from "react";
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { deletePassThroughEndpointsCall, getPassThroughEndpointsCall } from "../networking";
 import AddPassThroughEndpoint from "../add_pass_through";
@@ -25,6 +34,7 @@ export interface passThroughItem {
   methods?: string[];
   guardrails?: Record<string, { request_fields?: string[]; response_fields?: string[] } | null>;
   default_query_params?: Record<string, string>;
+  is_from_config?: boolean;
 }
 
 const PassThroughSettings: React.FC<PassThroughSettingsProps> = ({ accessToken, userRole, userID, premiumUser }) => {
@@ -133,42 +143,22 @@ const PassThroughSettings: React.FC<PassThroughSettingsProps> = ({ accessToken, 
         onDeleteClick={handleDelete}
       />
 
-      {isDeleteModalOpen && (
-        <div className="fixed z-overlay inset-0 overflow-y-auto">
-          <div className="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
-            <div className="fixed inset-0 transition-opacity" aria-hidden="true">
-              <div className="absolute inset-0 bg-gray-500 opacity-75"></div>
-            </div>
-
-            <span className="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">
-              &#8203;
-            </span>
-
-            <div className="inline-block align-bottom bg-card rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
-              <div className="bg-card px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
-                <div className="sm:flex sm:items-start">
-                  <div className="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
-                    <h3 className="text-lg leading-6 font-medium text-foreground">Delete Pass-Through Endpoint</h3>
-                    <div className="mt-2">
-                      <p className="text-sm text-muted-foreground">
-                        Are you sure you want to delete this pass-through endpoint? This action cannot be undone.
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div className="bg-muted px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
-                <Button variant="destructive" onClick={confirmDelete} className="ml-2">
-                  Delete
-                </Button>
-                <Button variant="outline" onClick={cancelDelete}>
-                  Cancel
-                </Button>
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
+      <AlertDialog open={isDeleteModalOpen} onOpenChange={(open) => !open && cancelDelete()}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete Pass-Through Endpoint</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to delete this pass-through endpoint? This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <Button variant="destructive" onClick={confirmDelete}>
+              Delete
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 };


### PR DESCRIPTION
## TLDR

Problem this solves:

- Delete confirm dialog rendered as an opaque grey box, hiding its buttons
- Config-defined endpoints showed active Delete/Edit actions that silently failed

How it solves it:

- Replaced the hand-rolled modal with the shared AlertDialog component
- Config rows now grey out Edit/Delete with a hint, plus a Config/DB Source badge

## User Flow

Before: an admin cannot delete a pass-through endpoint from the UI because the confirm dialog is unusable

1. They open the Admin UI pass-through endpoints page and click Delete in an endpoint's row actions menu
2. The screen is covered by an opaque grey overlay; the "Delete Pass-Through Endpoint" dialog and its buttons are hidden behind it
3. They can only escape by clicking the overlay; the endpoint is never deleted
4. For an endpoint defined in config.yaml, the Delete action looks enabled, but confirming returns "Endpoint with ID '...' was not found" and nothing happens

After: the same admin deletes a DB endpoint normally, and config endpoints are visibly not deletable

1. They open the same page and click Delete in a DB endpoint's row actions menu
2. A normal confirm dialog appears on top of a translucent backdrop with visible Cancel and Delete buttons
3. Clicking Delete removes the endpoint and shows "Endpoint deleted successfully."
4. For an endpoint defined in config.yaml, Edit and Delete are greyed out with the hint "Config pass-through endpoints cannot be deleted on the dashboard. Please edit the config file.", and a Source column labels each row Config or DB

## Relevant issues

## Linear ticket

Resolves LIT-7216

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Setup: local proxy on :4000 started with `litellm --config litellm-config.yml --debug`, where the config defines one pass-through endpoint:

```yaml
general_settings:
  master_key: sk-1234
  database_url: os.environ/DATABASE_URL
  pass_through_endpoints:
    - path: /from-config
      target: https://httpbin.org/anything
```

A DB endpoint was created via the create route:

```
curl -s -X POST http://localhost:4000/config/pass_through_endpoint \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"path": "/db-endpoint", "target": "https://httpbin.org/anything", "headers": {}}'
```

Dashboard dev server on :3000 (`npm run dev` in ui/litellm-dashboard)

### Before (6a425a5cc5)

<img width="1209" height="431" alt="Screenshot 2026-09-08 at 5 39 22 PM" src="https://github.com/user-attachments/assets/51cf61b9-d7d9-4f4f-b9f3-273772fb2a69" />


### After (d72eb4491a)
<img width="1209" height="431" alt="Screenshot 2026-09-08 at 5 38 11 PM" src="https://github.com/user-attachments/assets/4c5d2b28-91a5-4549-be98-8c4cd6d279e8" />

<img width="1209" height="431" alt="Screenshot 2026-09-08 at 5 38 17 PM" src="https://github.com/user-attachments/assets/0e7afe1c-0c5c-40fb-80bc-3fccc82b4b2f" />


## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- The backend still 400s "not found" if a config endpoint's generated id is DELETEd directly via API; a clearer message is a follow-up

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard-only UX around pass-through listing and delete confirmation; no auth or API behavior changes beyond preventing invalid delete/edit clicks for config rows.
> 
> **Overview**
> Fixes pass-through endpoint management in the admin UI by swapping the broken custom delete overlay for the shared **`AlertDialog`**, so Cancel/Delete are visible and DB deletes can complete.
> 
> Config-sourced endpoints (`is_from_config`) are now treated as read-only in the table: a **Source** badge shows **Config** vs **DB**, the ID column no longer opens edit for config rows, and **Edit**/**Delete** are disabled with tooltips directing admins to the config file. Tests cover disabled actions and source labeling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d72eb4491ab2da2a56944c720a3200280cdd040d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->