### PR TITLE
fix(a2a): forward caller identity headers on message/send and message/stream

### DIFF
--- a/litellm/proxy/agent_endpoints/a2a_endpoints.py
+++ b/litellm/proxy/agent_endpoints/a2a_endpoints.py
@@ -144,31 +144,32 @@ def _validate_push_notification_url(url: str) -> None:
         raise HTTPException(status_code=400, detail=str(e)) from e
 
 
-def _caller_identity_headers(user_api_key_dict: UserAPIKeyAuth) -> dict[str, str]:
-    headers: Final[dict[str, str]] = {}
-    if user_api_key_dict.user_id:
-        headers["X-LiteLLM-User-Id"] = user_api_key_dict.user_id
-    if user_api_key_dict.team_id:
-        headers["X-LiteLLM-Team-Id"] = user_api_key_dict.team_id
-    return headers
+def _caller_identity_headers(user_api_key_dict: UserAPIKeyAuth) -> Mapping[str, str]:
+    return MappingProxyType(
+        {
+            name: value
+            for name, value in (
+                ("X-LiteLLM-User-Id", user_api_key_dict.user_id),
+                ("X-LiteLLM-Team-Id", user_api_key_dict.team_id),
+            )
+            if value
+        }
+    )
 
 
 def _forwarding_headers(
-    user_api_key_dict: UserAPIKeyAuth,
+    caller_identity: Mapping[str, str],
     request_data: Mapping[str, object],
     agent_extra_headers: Mapping[str, str] | None,
 ) -> dict[str, str] | None:
-    sanitized: Final = (
-        {k: v for k, v in agent_extra_headers.items() if not k.lower().startswith("x-litellm-")}
-        if agent_extra_headers
-        else None
+    passthrough: Final = tuple(
+        (name, value)
+        for name, value in (agent_extra_headers.items() if agent_extra_headers else ())
+        if not name.lower().startswith("x-litellm-")
     )
-    merged: Final = merge_agent_headers(dynamic_headers=sanitized, static_headers=None) or {}
-    identity: Final = _caller_identity_headers(user_api_key_dict)
     trace_id: Final = request_data.get("litellm_trace_id")
-    if trace_id:
-        identity["X-LiteLLM-Trace-Id"] = str(trace_id)
-    merged.update(identity)
+    trace: Final = (("X-LiteLLM-Trace-Id", str(trace_id)),) if trace_id else ()
+    merged: Final = dict((*passthrough, *caller_identity.items(), *trace))
     return merged or None
 
 
@@ -755,6 +756,7 @@ async def invoke_agent_a2a(
             ProxyBaseLLMRequestProcessing,
         )
 
+        caller_identity: Final = _caller_identity_headers(user_api_key_dict)
         processor: Final = ProxyBaseLLMRequestProcessing(data=body)
         data, logging_obj = await processor.common_processing_pre_call_logic(
             request=request,
@@ -793,20 +795,13 @@ async def invoke_agent_a2a(
                     if header_name:
                         dynamic_headers[header_name] = val
 
-        agent_extra_headers = merge_agent_headers(
-            dynamic_headers=dynamic_headers or None,
-            static_headers=static_headers or None,
-        )
-
-        # Stamp the caller's identity (X-LiteLLM-User-Id/-Team-Id) onto every method,
-        # not just the tasks/* ones _forwarding_headers was originally written for.
-        # message/send and message/stream previously sent agent_extra_headers as-is,
-        # so a downstream agent never saw who was calling it on the primary
-        # conversational path -- only on secondary task-management calls.
         agent_extra_headers = _forwarding_headers(
-            user_api_key_dict=user_api_key_dict,
+            caller_identity=caller_identity,
             request_data=data,
-            agent_extra_headers=agent_extra_headers,
+            agent_extra_headers=merge_agent_headers(
+                dynamic_headers=dynamic_headers or None,
+                static_headers=static_headers or None,
+            ),
         )
 
         # Databricks App endpoints require a short-lived OAuth M2M token rather

--- a/litellm/proxy/agent_endpoints/a2a_endpoints.py
+++ b/litellm/proxy/agent_endpoints/a2a_endpoints.py
@@ -157,7 +157,7 @@ def _forwarding_headers(
     user_api_key_dict: UserAPIKeyAuth,
     request_data: Mapping[str, object],
     agent_extra_headers: Mapping[str, str] | None,
-) -> Mapping[str, str] | None:
+) -> dict[str, str] | None:
     sanitized: Final = (
         {k: v for k, v in agent_extra_headers.items() if not k.lower().startswith("x-litellm-")}
         if agent_extra_headers
@@ -798,6 +798,17 @@ async def invoke_agent_a2a(
             static_headers=static_headers or None,
         )
 
+        # Stamp the caller's identity (X-LiteLLM-User-Id/-Team-Id) onto every method,
+        # not just the tasks/* ones _forwarding_headers was originally written for.
+        # message/send and message/stream previously sent agent_extra_headers as-is,
+        # so a downstream agent never saw who was calling it on the primary
+        # conversational path -- only on secondary task-management calls.
+        agent_extra_headers = _forwarding_headers(
+            user_api_key_dict=user_api_key_dict,
+            request_data=data,
+            agent_extra_headers=agent_extra_headers,
+        )
+
         # Databricks App endpoints require a short-lived OAuth M2M token rather
         # than a static bearer. Only agents explicitly configured with a
         # ``databricks_oauth`` block get one; every other agent is left untouched.
@@ -942,12 +953,7 @@ async def invoke_agent_a2a(
                 "method": method,
                 "params": params,
             }
-            caller_headers: Final = _forwarding_headers(
-                user_api_key_dict=user_api_key_dict,
-                request_data=data,
-                agent_extra_headers=agent_extra_headers,
-            )
-            result = await _forward_jsonrpc(agent_url, forward_body, extra_headers=caller_headers)
+            result = await _forward_jsonrpc(agent_url, forward_body, extra_headers=agent_extra_headers)
             if method == "agent/getAuthenticatedExtendedCard":
                 card: Final = result.get("result")
                 if isinstance(card, dict):
@@ -988,16 +994,11 @@ async def invoke_agent_a2a(
                 "method": method,
                 "params": params,
             }
-            sse_caller_headers: Final = _forwarding_headers(
-                user_api_key_dict=user_api_key_dict,
-                request_data=data,
-                agent_extra_headers=agent_extra_headers,
-            )
             return await _forward_jsonrpc_sse(
                 agent_url,
                 forward_body,
                 request_id=request_id,
-                extra_headers=sse_caller_headers,
+                extra_headers=agent_extra_headers,
                 proxy_logging_obj=proxy_logging_obj,
                 user_api_key_dict=user_api_key_dict,
                 request_data=data,

--- a/tests/test_litellm/proxy/agent_endpoints/test_a2a_endpoints.py
+++ b/tests/test_litellm/proxy/agent_endpoints/test_a2a_endpoints.py
@@ -9,7 +9,8 @@ import socket
 import sys
 from collections.abc import Awaitable, Callable, Mapping
 from contextlib import AbstractContextManager, ExitStack
-from typing import TypedDict
+from dataclasses import dataclass
+from typing import Final
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -19,7 +20,8 @@ from litellm.proxy._types import UserAPIKeyAuth
 AddLiteLLMData = Callable[..., Awaitable[dict[str, object]]]
 
 
-class CapturedAgentCall(TypedDict):
+@dataclass(frozen=True, slots=True)
+class CapturedAgentCall:
     request_id: object
     agent_extra_headers: dict[str, str] | None
 
@@ -413,14 +415,11 @@ def _base_patches(
 
 
 async def _add_proxy_data(data: dict[str, object], **kwargs: object) -> dict[str, object]:
-    data["proxy_server_request"] = {
-        "url": "http://localhost:4000",
-        "method": "POST",
-        "headers": {},
-        "body": {},
+    return {
+        **data,
+        "proxy_server_request": {"url": "http://localhost:4000", "method": "POST", "headers": {}, "body": {}},
+        "metadata": data.get("metadata", {}),
     }
-    data.setdefault("metadata", {})
-    return data
 
 
 _HELLO_MESSAGE_PARAMS = {
@@ -448,14 +447,8 @@ async def _invoke_message_method(
         def __init__(self, **kwargs: object) -> None:
             self.__dict__.update(kwargs)
 
-    captured: CapturedAgentCall = {"request_id": None, "agent_extra_headers": None}
-
-    async def capture_asend_message(
-        request: SendMessageRequest, agent_extra_headers: dict[str, str] | None = None, **kwargs: object
-    ) -> MagicMock:
-        captured["request_id"] = request.__dict__["id"]
-        captured["agent_extra_headers"] = agent_extra_headers
-        response = MagicMock()
+    async def fake_asend_message(request: SendMessageRequest, **kwargs: object) -> MagicMock:
+        response: Final = MagicMock()
         response.model_dump.return_value = {
             "jsonrpc": "2.0",
             "id": request.__dict__["id"],
@@ -463,40 +456,25 @@ async def _invoke_message_method(
         }
         return response
 
-    async def capture_stream_message(
-        request_id: object, agent_extra_headers: dict[str, str] | None = None, **kwargs: object
-    ) -> JSONResponse:
-        captured["request_id"] = request_id
-        captured["agent_extra_headers"] = agent_extra_headers
+    async def fake_stream_message(request_id: object, **kwargs: object) -> JSONResponse:
         return JSONResponse({"jsonrpc": "2.0", "id": request_id})
 
-    mock_a2a_types = MagicMock()
+    mock_a2a_types: Final = MagicMock()
     mock_a2a_types.MessageSendParams = MessageSendParams
     mock_a2a_types.SendMessageRequest = SendMessageRequest
+    is_send: Final = method == "message/send"
+    downstream: Final = AsyncMock(side_effect=fake_asend_message if is_send else fake_stream_message)
 
     with ExitStack() as stack:
         for p in _base_patches(_make_agent_mock(), add_litellm_data):
             stack.enter_context(p)
         stack.enter_context(patch("litellm.a2a_protocol.main.A2A_SDK_AVAILABLE", True))
-        if method == "message/send":
-            stack.enter_context(
-                patch.dict(
-                    sys.modules,
-                    {"a2a": MagicMock(), "a2a.types": mock_a2a_types},
-                )
-            )
-            stack.enter_context(
-                patch(
-                    "litellm.a2a_protocol.asend_message",
-                    new=AsyncMock(side_effect=capture_asend_message),
-                )
-            )
+        if is_send:
+            stack.enter_context(patch.dict(sys.modules, {"a2a": MagicMock(), "a2a.types": mock_a2a_types}))
+            stack.enter_context(patch("litellm.a2a_protocol.asend_message", new=downstream))
         else:
             stack.enter_context(
-                patch(
-                    "litellm.proxy.agent_endpoints.a2a_endpoints._handle_stream_message",
-                    new=AsyncMock(side_effect=capture_stream_message),
-                )
+                patch("litellm.proxy.agent_endpoints.a2a_endpoints._handle_stream_message", new=downstream)
             )
 
         from litellm.proxy.agent_endpoints.a2a_endpoints import invoke_agent_a2a
@@ -508,7 +486,9 @@ async def _invoke_message_method(
             user_api_key_dict=user_api_key_dict,
         )
 
-    return captured
+    kwargs: Final = downstream.call_args.kwargs
+    request_id: Final = kwargs["request"].__dict__["id"] if is_send else kwargs["request_id"]
+    return CapturedAgentCall(request_id=request_id, agent_extra_headers=kwargs.get("agent_extra_headers"))
 
 
 @pytest.mark.asyncio
@@ -519,7 +499,7 @@ async def test_message_methods_preserve_numeric_zero_request_id(method: str):
 
     captured = await _invoke_message_method(method, mock_request, user_api_key_dict)
 
-    assert captured["request_id"] == 0
+    assert captured.request_id == 0
 
 
 @pytest.mark.asyncio
@@ -530,7 +510,7 @@ async def test_message_methods_forward_caller_identity_headers(method: str):
 
     captured = await _invoke_message_method(method, mock_request, user_api_key_dict)
 
-    forwarded_headers = captured["agent_extra_headers"] or {}
+    forwarded_headers = captured.agent_extra_headers or {}
     assert forwarded_headers.get("X-LiteLLM-User-Id") == "user-abc"
     assert forwarded_headers.get("X-LiteLLM-Team-Id") == "team-xyz"
 
@@ -547,7 +527,7 @@ async def test_message_methods_caller_identity_headers_cannot_be_spoofed(method:
 
     captured = await _invoke_message_method(method, mock_request, user_api_key_dict)
 
-    forwarded_headers = captured["agent_extra_headers"] or {}
+    forwarded_headers = captured.agent_extra_headers or {}
     assert (
         forwarded_headers.get("X-LiteLLM-User-Id") == "real-user"
     ), "authenticated user id must not be overridden by forwarded client headers"
@@ -559,19 +539,27 @@ async def test_message_methods_caller_identity_headers_cannot_be_spoofed(method:
 @pytest.mark.asyncio
 @pytest.mark.parametrize("method", ["message/send", "message/stream"])
 async def test_message_methods_forward_key_bound_identity_not_pre_call_rewrite(method: str):
-    mock_request = _make_request_mock(method, _HELLO_MESSAGE_PARAMS)
-    user_api_key_dict = UserAPIKeyAuth(api_key="sk-test", user_id="key-user", team_id="key-team")
+    from litellm.proxy.litellm_pre_call_utils import LiteLLMProxyRequestSetup
 
-    async def rewrite_user_id_like_header_mapping(data: dict[str, object], **kwargs: object) -> dict[str, object]:
-        user_api_key_dict.user_id = "header-mapped-user"
+    mock_request = _make_request_mock(method, _HELLO_MESSAGE_PARAMS)
+    mock_request.headers = {"X-OpenWebUI-User-Id": "header-mapped-user"}
+    user_api_key_dict = UserAPIKeyAuth(api_key="sk-test", user_id="key-user", team_id="key-team")
+    general_settings: Final = {
+        "user_header_mappings": [{"header_name": "X-OpenWebUI-User-Id", "litellm_user_role": "internal_user"}]
+    }
+
+    async def apply_user_header_mapping(data: dict[str, object], **kwargs: object) -> dict[str, object]:
+        LiteLLMProxyRequestSetup.add_internal_user_from_user_mapping(
+            general_settings, user_api_key_dict, dict(mock_request.headers)
+        )
         return await _add_proxy_data(data, **kwargs)
 
     captured = await _invoke_message_method(
-        method, mock_request, user_api_key_dict, add_litellm_data=rewrite_user_id_like_header_mapping
+        method, mock_request, user_api_key_dict, add_litellm_data=apply_user_header_mapping
     )
 
     assert user_api_key_dict.user_id == "header-mapped-user", "precondition: pre-call rewrite ran"
-    forwarded_headers = captured["agent_extra_headers"] or {}
+    forwarded_headers = captured.agent_extra_headers or {}
     assert forwarded_headers.get("X-LiteLLM-User-Id") == "key-user"
     assert forwarded_headers.get("X-LiteLLM-Team-Id") == "key-team"
 

--- a/tests/test_litellm/proxy/agent_endpoints/test_a2a_endpoints.py
+++ b/tests/test_litellm/proxy/agent_endpoints/test_a2a_endpoints.py
@@ -379,7 +379,7 @@ def _make_request_mock(
     return req
 
 
-def _base_patches(agent: MagicMock):
+def _base_patches(agent: MagicMock, add_litellm_data=None):
     return [
         patch(
             "litellm.proxy.agent_endpoints.a2a_endpoints._get_agent",
@@ -391,7 +391,7 @@ def _base_patches(agent: MagicMock):
         ),
         patch(
             "litellm.proxy.common_request_processing.add_litellm_data_to_request",
-            new=AsyncMock(side_effect=_add_proxy_data),
+            new=AsyncMock(side_effect=add_litellm_data or _add_proxy_data),
         ),
         patch("litellm.proxy.proxy_server.general_settings", {}),
         patch("litellm.proxy.proxy_server.proxy_config", MagicMock()),
@@ -410,11 +410,24 @@ async def _add_proxy_data(data, **kwargs):
     return data
 
 
-@pytest.mark.asyncio
-@pytest.mark.parametrize("method", ["message/send", "message/stream"])
-async def test_message_methods_preserve_numeric_zero_request_id(method: str):
+_HELLO_MESSAGE_PARAMS = {
+    "message": {
+        "role": "user",
+        "parts": [{"kind": "text", "text": "Hello"}],
+        "messageId": "msg-123",
+    }
+}
+
+
+async def _invoke_message_method(
+    method: str,
+    mock_request: MagicMock,
+    user_api_key_dict,
+    add_litellm_data=None,
+) -> dict:
+    """Run invoke_agent_a2a for message/send or message/stream against a mocked backend
+    and return the ``request_id`` and ``agent_extra_headers`` the backend call received."""
     from fastapi.responses import JSONResponse
-    from litellm.proxy._types import UserAPIKeyAuth
 
     class MessageSendParams:
         def __init__(self, **kwargs):
@@ -424,20 +437,11 @@ async def test_message_methods_preserve_numeric_zero_request_id(method: str):
         def __init__(self, **kwargs):
             self.__dict__.update(kwargs)
 
-    agent = _make_agent_mock()
-    params = {
-        "message": {
-            "role": "user",
-            "parts": [{"kind": "text", "text": "Hello"}],
-            "messageId": "msg-123",
-        }
-    }
-    mock_request = _make_request_mock(method, params, request_id=0)
-    user_api_key_dict = UserAPIKeyAuth(api_key="sk-test", user_id="u1", team_id="t1")
     captured = {}
 
     async def capture_asend_message(request, **kwargs):
         captured["request_id"] = request.id
+        captured["agent_extra_headers"] = kwargs["agent_extra_headers"]
         response = MagicMock()
         response.model_dump.return_value = {
             "jsonrpc": "2.0",
@@ -448,6 +452,7 @@ async def test_message_methods_preserve_numeric_zero_request_id(method: str):
 
     async def capture_stream_message(**kwargs):
         captured["request_id"] = kwargs["request_id"]
+        captured["agent_extra_headers"] = kwargs["agent_extra_headers"]
         return JSONResponse({"jsonrpc": "2.0", "id": kwargs["request_id"]})
 
     mock_a2a_types = MagicMock()
@@ -455,7 +460,7 @@ async def test_message_methods_preserve_numeric_zero_request_id(method: str):
     mock_a2a_types.SendMessageRequest = SendMessageRequest
 
     with ExitStack() as stack:
-        for p in _base_patches(agent):
+        for p in _base_patches(_make_agent_mock(), add_litellm_data):
             stack.enter_context(p)
         stack.enter_context(patch("litellm.a2a_protocol.main.A2A_SDK_AVAILABLE", True))
         if method == "message/send":
@@ -487,6 +492,19 @@ async def test_message_methods_preserve_numeric_zero_request_id(method: str):
             fastapi_response=MagicMock(),
             user_api_key_dict=user_api_key_dict,
         )
+
+    return captured
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method", ["message/send", "message/stream"])
+async def test_message_methods_preserve_numeric_zero_request_id(method: str):
+    from litellm.proxy._types import UserAPIKeyAuth
+
+    mock_request = _make_request_mock(method, _HELLO_MESSAGE_PARAMS, request_id=0)
+    user_api_key_dict = UserAPIKeyAuth(api_key="sk-test", user_id="u1", team_id="t1")
+
+    captured = await _invoke_message_method(method, mock_request, user_api_key_dict)
 
     assert captured["request_id"] == 0
 
@@ -498,80 +516,12 @@ async def test_message_methods_forward_caller_identity_headers(method: str):
     X-LiteLLM-Team-Id, same as the tasks/* methods, so a downstream agent can scope
     resources to the authenticated caller on the primary conversational path -- not
     only on secondary task-management calls."""
-    from fastapi.responses import JSONResponse
     from litellm.proxy._types import UserAPIKeyAuth
 
-    class MessageSendParams:
-        def __init__(self, **kwargs):
-            self.__dict__.update(kwargs)
-
-    class SendMessageRequest:
-        def __init__(self, **kwargs):
-            self.__dict__.update(kwargs)
-
-    agent = _make_agent_mock()
-    params = {
-        "message": {
-            "role": "user",
-            "parts": [{"kind": "text", "text": "Hello"}],
-            "messageId": "msg-123",
-        }
-    }
-    mock_request = _make_request_mock(method, params)
+    mock_request = _make_request_mock(method, _HELLO_MESSAGE_PARAMS)
     user_api_key_dict = UserAPIKeyAuth(api_key="sk-test", user_id="user-abc", team_id="team-xyz")
-    captured = {}
 
-    async def capture_asend_message(request, **kwargs):
-        captured["agent_extra_headers"] = kwargs["agent_extra_headers"]
-        response = MagicMock()
-        response.model_dump.return_value = {
-            "jsonrpc": "2.0",
-            "id": request.id,
-            "result": {"status": "success"},
-        }
-        return response
-
-    async def capture_stream_message(**kwargs):
-        captured["agent_extra_headers"] = kwargs["agent_extra_headers"]
-        return JSONResponse({"jsonrpc": "2.0", "id": kwargs["request_id"]})
-
-    mock_a2a_types = MagicMock()
-    mock_a2a_types.MessageSendParams = MessageSendParams
-    mock_a2a_types.SendMessageRequest = SendMessageRequest
-
-    with ExitStack() as stack:
-        for p in _base_patches(agent):
-            stack.enter_context(p)
-        stack.enter_context(patch("litellm.a2a_protocol.main.A2A_SDK_AVAILABLE", True))
-        if method == "message/send":
-            stack.enter_context(
-                patch.dict(
-                    sys.modules,
-                    {"a2a": MagicMock(), "a2a.types": mock_a2a_types},
-                )
-            )
-            stack.enter_context(
-                patch(
-                    "litellm.a2a_protocol.asend_message",
-                    new=AsyncMock(side_effect=capture_asend_message),
-                )
-            )
-        else:
-            stack.enter_context(
-                patch(
-                    "litellm.proxy.agent_endpoints.a2a_endpoints._handle_stream_message",
-                    new=AsyncMock(side_effect=capture_stream_message),
-                )
-            )
-
-        from litellm.proxy.agent_endpoints.a2a_endpoints import invoke_agent_a2a
-
-        await invoke_agent_a2a(
-            agent_id="test-agent",
-            request=mock_request,
-            fastapi_response=MagicMock(),
-            user_api_key_dict=user_api_key_dict,
-        )
+    captured = await _invoke_message_method(method, mock_request, user_api_key_dict)
 
     forwarded_headers = captured["agent_extra_headers"] or {}
     assert forwarded_headers.get("X-LiteLLM-User-Id") == "user-abc"
@@ -579,73 +529,22 @@ async def test_message_methods_forward_caller_identity_headers(method: str):
 
 
 @pytest.mark.asyncio
-async def test_message_send_caller_identity_headers_cannot_be_spoofed():
-    """A client must not be able to override X-LiteLLM-User-Id / X-LiteLLM-Team-Id on
-    message/send by including x-a2a-<agent>-x-litellm-user-id in their request
-    headers. The authenticated identity must always win, matching the existing
-    guarantee for tasks/* (see test_caller_identity_headers_cannot_be_spoofed_via_forwarded_headers)."""
+@pytest.mark.parametrize("method", ["message/send", "message/stream"])
+async def test_message_methods_caller_identity_headers_cannot_be_spoofed(method: str):
+    """A client must not be able to override X-LiteLLM-User-Id / X-LiteLLM-Team-Id by
+    including x-a2a-<agent>-x-litellm-user-id in their request headers. The authenticated
+    identity must always win, matching the existing guarantee for tasks/* (see
+    test_caller_identity_headers_cannot_be_spoofed_via_forwarded_headers)."""
     from litellm.proxy._types import UserAPIKeyAuth
 
-    class MessageSendParams:
-        def __init__(self, **kwargs):
-            self.__dict__.update(kwargs)
-
-    class SendMessageRequest:
-        def __init__(self, **kwargs):
-            self.__dict__.update(kwargs)
-
-    agent = _make_agent_mock()
-    params = {
-        "message": {
-            "role": "user",
-            "parts": [{"kind": "text", "text": "Hello"}],
-            "messageId": "msg-123",
-        }
-    }
-    mock_request = _make_request_mock("message/send", params)
+    mock_request = _make_request_mock(method, _HELLO_MESSAGE_PARAMS)
     mock_request.headers = {
         "x-a2a-test-agent-x-litellm-user-id": "attacker-user",
         "x-a2a-test-agent-x-litellm-team-id": "attacker-team",
     }
     user_api_key_dict = UserAPIKeyAuth(api_key="sk-test", user_id="real-user", team_id="real-team")
-    captured = {}
 
-    async def capture_asend_message(request, **kwargs):
-        captured["agent_extra_headers"] = kwargs["agent_extra_headers"]
-        response = MagicMock()
-        response.model_dump.return_value = {
-            "jsonrpc": "2.0",
-            "id": request.id,
-            "result": {"status": "success"},
-        }
-        return response
-
-    mock_a2a_types = MagicMock()
-    mock_a2a_types.MessageSendParams = MessageSendParams
-    mock_a2a_types.SendMessageRequest = SendMessageRequest
-
-    with ExitStack() as stack:
-        for p in _base_patches(agent):
-            stack.enter_context(p)
-        stack.enter_context(patch("litellm.a2a_protocol.main.A2A_SDK_AVAILABLE", True))
-        stack.enter_context(
-            patch.dict(sys.modules, {"a2a": MagicMock(), "a2a.types": mock_a2a_types})
-        )
-        stack.enter_context(
-            patch(
-                "litellm.a2a_protocol.asend_message",
-                new=AsyncMock(side_effect=capture_asend_message),
-            )
-        )
-
-        from litellm.proxy.agent_endpoints.a2a_endpoints import invoke_agent_a2a
-
-        await invoke_agent_a2a(
-            agent_id="test-agent",
-            request=mock_request,
-            fastapi_response=MagicMock(),
-            user_api_key_dict=user_api_key_dict,
-        )
+    captured = await _invoke_message_method(method, mock_request, user_api_key_dict)
 
     forwarded_headers = captured["agent_extra_headers"] or {}
     assert (
@@ -654,6 +553,31 @@ async def test_message_send_caller_identity_headers_cannot_be_spoofed():
     assert (
         forwarded_headers.get("X-LiteLLM-Team-Id") == "real-team"
     ), "authenticated team id must not be overridden by forwarded client headers"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method", ["message/send", "message/stream"])
+async def test_message_methods_forward_key_bound_identity_not_pre_call_rewrite(method: str):
+    """Pre-call processing (add_litellm_data_to_request -> user_header_mappings) rewrites
+    user_api_key_dict.user_id from a client-supplied header. The identity forwarded to the
+    agent must be the one bound to the API key at auth time, captured before that rewrite."""
+    from litellm.proxy._types import UserAPIKeyAuth
+
+    mock_request = _make_request_mock(method, _HELLO_MESSAGE_PARAMS)
+    user_api_key_dict = UserAPIKeyAuth(api_key="sk-test", user_id="key-user", team_id="key-team")
+
+    async def rewrite_user_id_like_header_mapping(data, **kwargs):
+        kwargs["user_api_key_dict"].user_id = "header-mapped-user"
+        return await _add_proxy_data(data, **kwargs)
+
+    captured = await _invoke_message_method(
+        method, mock_request, user_api_key_dict, add_litellm_data=rewrite_user_id_like_header_mapping
+    )
+
+    assert user_api_key_dict.user_id == "header-mapped-user", "precondition: pre-call rewrite ran"
+    forwarded_headers = captured["agent_extra_headers"] or {}
+    assert forwarded_headers.get("X-LiteLLM-User-Id") == "key-user"
+    assert forwarded_headers.get("X-LiteLLM-Team-Id") == "key-team"
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/agent_endpoints/test_a2a_endpoints.py
+++ b/tests/test_litellm/proxy/agent_endpoints/test_a2a_endpoints.py
@@ -7,10 +7,21 @@ Tests that invoke_agent_a2a properly integrates with add_litellm_data_to_request
 import json
 import socket
 import sys
-from contextlib import ExitStack
+from collections.abc import Awaitable, Callable, Mapping
+from contextlib import AbstractContextManager, ExitStack
+from typing import TypedDict
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
+from litellm.proxy._types import UserAPIKeyAuth
+
+AddLiteLLMData = Callable[..., Awaitable[dict[str, object]]]
+
+
+class CapturedAgentCall(TypedDict):
+    request_id: object
+    agent_extra_headers: dict[str, str] | None
 
 
 @pytest.mark.asyncio
@@ -364,7 +375,7 @@ def _make_agent_mock(url: str = "http://backend-agent:10001") -> MagicMock:
 
 
 def _make_request_mock(
-    method: str, params: dict, request_id: object = "req-1"
+    method: str, params: Mapping[str, object], request_id: object = "req-1"
 ) -> MagicMock:
     req = MagicMock()
     req.headers = {}
@@ -379,7 +390,9 @@ def _make_request_mock(
     return req
 
 
-def _base_patches(agent: MagicMock, add_litellm_data=None):
+def _base_patches(
+    agent: MagicMock, add_litellm_data: AddLiteLLMData | None = None
+) -> list[AbstractContextManager[object]]:
     return [
         patch(
             "litellm.proxy.agent_endpoints.a2a_endpoints._get_agent",
@@ -399,7 +412,7 @@ def _base_patches(agent: MagicMock, add_litellm_data=None):
     ]
 
 
-async def _add_proxy_data(data, **kwargs):
+async def _add_proxy_data(data: dict[str, object], **kwargs: object) -> dict[str, object]:
     data["proxy_server_request"] = {
         "url": "http://localhost:4000",
         "method": "POST",
@@ -422,36 +435,40 @@ _HELLO_MESSAGE_PARAMS = {
 async def _invoke_message_method(
     method: str,
     mock_request: MagicMock,
-    user_api_key_dict,
-    add_litellm_data=None,
-) -> dict:
+    user_api_key_dict: UserAPIKeyAuth,
+    add_litellm_data: AddLiteLLMData | None = None,
+) -> CapturedAgentCall:
     from fastapi.responses import JSONResponse
 
     class MessageSendParams:
-        def __init__(self, **kwargs):
+        def __init__(self, **kwargs: object) -> None:
             self.__dict__.update(kwargs)
 
     class SendMessageRequest:
-        def __init__(self, **kwargs):
+        def __init__(self, **kwargs: object) -> None:
             self.__dict__.update(kwargs)
 
-    captured = {}
+    captured: CapturedAgentCall = {"request_id": None, "agent_extra_headers": None}
 
-    async def capture_asend_message(request, **kwargs):
-        captured["request_id"] = request.id
-        captured["agent_extra_headers"] = kwargs["agent_extra_headers"]
+    async def capture_asend_message(
+        request: SendMessageRequest, agent_extra_headers: dict[str, str] | None = None, **kwargs: object
+    ) -> MagicMock:
+        captured["request_id"] = request.__dict__["id"]
+        captured["agent_extra_headers"] = agent_extra_headers
         response = MagicMock()
         response.model_dump.return_value = {
             "jsonrpc": "2.0",
-            "id": request.id,
+            "id": request.__dict__["id"],
             "result": {"status": "success"},
         }
         return response
 
-    async def capture_stream_message(**kwargs):
-        captured["request_id"] = kwargs["request_id"]
-        captured["agent_extra_headers"] = kwargs["agent_extra_headers"]
-        return JSONResponse({"jsonrpc": "2.0", "id": kwargs["request_id"]})
+    async def capture_stream_message(
+        request_id: object, agent_extra_headers: dict[str, str] | None = None, **kwargs: object
+    ) -> JSONResponse:
+        captured["request_id"] = request_id
+        captured["agent_extra_headers"] = agent_extra_headers
+        return JSONResponse({"jsonrpc": "2.0", "id": request_id})
 
     mock_a2a_types = MagicMock()
     mock_a2a_types.MessageSendParams = MessageSendParams
@@ -497,8 +514,6 @@ async def _invoke_message_method(
 @pytest.mark.asyncio
 @pytest.mark.parametrize("method", ["message/send", "message/stream"])
 async def test_message_methods_preserve_numeric_zero_request_id(method: str):
-    from litellm.proxy._types import UserAPIKeyAuth
-
     mock_request = _make_request_mock(method, _HELLO_MESSAGE_PARAMS, request_id=0)
     user_api_key_dict = UserAPIKeyAuth(api_key="sk-test", user_id="u1", team_id="t1")
 
@@ -510,8 +525,6 @@ async def test_message_methods_preserve_numeric_zero_request_id(method: str):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("method", ["message/send", "message/stream"])
 async def test_message_methods_forward_caller_identity_headers(method: str):
-    from litellm.proxy._types import UserAPIKeyAuth
-
     mock_request = _make_request_mock(method, _HELLO_MESSAGE_PARAMS)
     user_api_key_dict = UserAPIKeyAuth(api_key="sk-test", user_id="user-abc", team_id="team-xyz")
 
@@ -525,8 +538,6 @@ async def test_message_methods_forward_caller_identity_headers(method: str):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("method", ["message/send", "message/stream"])
 async def test_message_methods_caller_identity_headers_cannot_be_spoofed(method: str):
-    from litellm.proxy._types import UserAPIKeyAuth
-
     mock_request = _make_request_mock(method, _HELLO_MESSAGE_PARAMS)
     mock_request.headers = {
         "x-a2a-test-agent-x-litellm-user-id": "attacker-user",
@@ -548,13 +559,11 @@ async def test_message_methods_caller_identity_headers_cannot_be_spoofed(method:
 @pytest.mark.asyncio
 @pytest.mark.parametrize("method", ["message/send", "message/stream"])
 async def test_message_methods_forward_key_bound_identity_not_pre_call_rewrite(method: str):
-    from litellm.proxy._types import UserAPIKeyAuth
-
     mock_request = _make_request_mock(method, _HELLO_MESSAGE_PARAMS)
     user_api_key_dict = UserAPIKeyAuth(api_key="sk-test", user_id="key-user", team_id="key-team")
 
-    async def rewrite_user_id_like_header_mapping(data, **kwargs):
-        kwargs["user_api_key_dict"].user_id = "header-mapped-user"
+    async def rewrite_user_id_like_header_mapping(data: dict[str, object], **kwargs: object) -> dict[str, object]:
+        user_api_key_dict.user_id = "header-mapped-user"
         return await _add_proxy_data(data, **kwargs)
 
     captured = await _invoke_message_method(

--- a/tests/test_litellm/proxy/agent_endpoints/test_a2a_endpoints.py
+++ b/tests/test_litellm/proxy/agent_endpoints/test_a2a_endpoints.py
@@ -492,6 +492,171 @@ async def test_message_methods_preserve_numeric_zero_request_id(method: str):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("method", ["message/send", "message/stream"])
+async def test_message_methods_forward_caller_identity_headers(method: str):
+    """message/send and message/stream must forward X-LiteLLM-User-Id and
+    X-LiteLLM-Team-Id, same as the tasks/* methods, so a downstream agent can scope
+    resources to the authenticated caller on the primary conversational path -- not
+    only on secondary task-management calls."""
+    from fastapi.responses import JSONResponse
+    from litellm.proxy._types import UserAPIKeyAuth
+
+    class MessageSendParams:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    class SendMessageRequest:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    agent = _make_agent_mock()
+    params = {
+        "message": {
+            "role": "user",
+            "parts": [{"kind": "text", "text": "Hello"}],
+            "messageId": "msg-123",
+        }
+    }
+    mock_request = _make_request_mock(method, params)
+    user_api_key_dict = UserAPIKeyAuth(api_key="sk-test", user_id="user-abc", team_id="team-xyz")
+    captured = {}
+
+    async def capture_asend_message(request, **kwargs):
+        captured["agent_extra_headers"] = kwargs["agent_extra_headers"]
+        response = MagicMock()
+        response.model_dump.return_value = {
+            "jsonrpc": "2.0",
+            "id": request.id,
+            "result": {"status": "success"},
+        }
+        return response
+
+    async def capture_stream_message(**kwargs):
+        captured["agent_extra_headers"] = kwargs["agent_extra_headers"]
+        return JSONResponse({"jsonrpc": "2.0", "id": kwargs["request_id"]})
+
+    mock_a2a_types = MagicMock()
+    mock_a2a_types.MessageSendParams = MessageSendParams
+    mock_a2a_types.SendMessageRequest = SendMessageRequest
+
+    with ExitStack() as stack:
+        for p in _base_patches(agent):
+            stack.enter_context(p)
+        stack.enter_context(patch("litellm.a2a_protocol.main.A2A_SDK_AVAILABLE", True))
+        if method == "message/send":
+            stack.enter_context(
+                patch.dict(
+                    sys.modules,
+                    {"a2a": MagicMock(), "a2a.types": mock_a2a_types},
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "litellm.a2a_protocol.asend_message",
+                    new=AsyncMock(side_effect=capture_asend_message),
+                )
+            )
+        else:
+            stack.enter_context(
+                patch(
+                    "litellm.proxy.agent_endpoints.a2a_endpoints._handle_stream_message",
+                    new=AsyncMock(side_effect=capture_stream_message),
+                )
+            )
+
+        from litellm.proxy.agent_endpoints.a2a_endpoints import invoke_agent_a2a
+
+        await invoke_agent_a2a(
+            agent_id="test-agent",
+            request=mock_request,
+            fastapi_response=MagicMock(),
+            user_api_key_dict=user_api_key_dict,
+        )
+
+    forwarded_headers = captured["agent_extra_headers"] or {}
+    assert forwarded_headers.get("X-LiteLLM-User-Id") == "user-abc"
+    assert forwarded_headers.get("X-LiteLLM-Team-Id") == "team-xyz"
+
+
+@pytest.mark.asyncio
+async def test_message_send_caller_identity_headers_cannot_be_spoofed():
+    """A client must not be able to override X-LiteLLM-User-Id / X-LiteLLM-Team-Id on
+    message/send by including x-a2a-<agent>-x-litellm-user-id in their request
+    headers. The authenticated identity must always win, matching the existing
+    guarantee for tasks/* (see test_caller_identity_headers_cannot_be_spoofed_via_forwarded_headers)."""
+    from litellm.proxy._types import UserAPIKeyAuth
+
+    class MessageSendParams:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    class SendMessageRequest:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    agent = _make_agent_mock()
+    params = {
+        "message": {
+            "role": "user",
+            "parts": [{"kind": "text", "text": "Hello"}],
+            "messageId": "msg-123",
+        }
+    }
+    mock_request = _make_request_mock("message/send", params)
+    mock_request.headers = {
+        "x-a2a-test-agent-x-litellm-user-id": "attacker-user",
+        "x-a2a-test-agent-x-litellm-team-id": "attacker-team",
+    }
+    user_api_key_dict = UserAPIKeyAuth(api_key="sk-test", user_id="real-user", team_id="real-team")
+    captured = {}
+
+    async def capture_asend_message(request, **kwargs):
+        captured["agent_extra_headers"] = kwargs["agent_extra_headers"]
+        response = MagicMock()
+        response.model_dump.return_value = {
+            "jsonrpc": "2.0",
+            "id": request.id,
+            "result": {"status": "success"},
+        }
+        return response
+
+    mock_a2a_types = MagicMock()
+    mock_a2a_types.MessageSendParams = MessageSendParams
+    mock_a2a_types.SendMessageRequest = SendMessageRequest
+
+    with ExitStack() as stack:
+        for p in _base_patches(agent):
+            stack.enter_context(p)
+        stack.enter_context(patch("litellm.a2a_protocol.main.A2A_SDK_AVAILABLE", True))
+        stack.enter_context(
+            patch.dict(sys.modules, {"a2a": MagicMock(), "a2a.types": mock_a2a_types})
+        )
+        stack.enter_context(
+            patch(
+                "litellm.a2a_protocol.asend_message",
+                new=AsyncMock(side_effect=capture_asend_message),
+            )
+        )
+
+        from litellm.proxy.agent_endpoints.a2a_endpoints import invoke_agent_a2a
+
+        await invoke_agent_a2a(
+            agent_id="test-agent",
+            request=mock_request,
+            fastapi_response=MagicMock(),
+            user_api_key_dict=user_api_key_dict,
+        )
+
+    forwarded_headers = captured["agent_extra_headers"] or {}
+    assert (
+        forwarded_headers.get("X-LiteLLM-User-Id") == "real-user"
+    ), "authenticated user id must not be overridden by forwarded client headers"
+    assert (
+        forwarded_headers.get("X-LiteLLM-Team-Id") == "real-team"
+    ), "authenticated team id must not be overridden by forwarded client headers"
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "method,params",
     [

--- a/tests/test_litellm/proxy/agent_endpoints/test_a2a_endpoints.py
+++ b/tests/test_litellm/proxy/agent_endpoints/test_a2a_endpoints.py
@@ -425,8 +425,6 @@ async def _invoke_message_method(
     user_api_key_dict,
     add_litellm_data=None,
 ) -> dict:
-    """Run invoke_agent_a2a for message/send or message/stream against a mocked backend
-    and return the ``request_id`` and ``agent_extra_headers`` the backend call received."""
     from fastapi.responses import JSONResponse
 
     class MessageSendParams:
@@ -512,10 +510,6 @@ async def test_message_methods_preserve_numeric_zero_request_id(method: str):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("method", ["message/send", "message/stream"])
 async def test_message_methods_forward_caller_identity_headers(method: str):
-    """message/send and message/stream must forward X-LiteLLM-User-Id and
-    X-LiteLLM-Team-Id, same as the tasks/* methods, so a downstream agent can scope
-    resources to the authenticated caller on the primary conversational path -- not
-    only on secondary task-management calls."""
     from litellm.proxy._types import UserAPIKeyAuth
 
     mock_request = _make_request_mock(method, _HELLO_MESSAGE_PARAMS)
@@ -531,10 +525,6 @@ async def test_message_methods_forward_caller_identity_headers(method: str):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("method", ["message/send", "message/stream"])
 async def test_message_methods_caller_identity_headers_cannot_be_spoofed(method: str):
-    """A client must not be able to override X-LiteLLM-User-Id / X-LiteLLM-Team-Id by
-    including x-a2a-<agent>-x-litellm-user-id in their request headers. The authenticated
-    identity must always win, matching the existing guarantee for tasks/* (see
-    test_caller_identity_headers_cannot_be_spoofed_via_forwarded_headers)."""
     from litellm.proxy._types import UserAPIKeyAuth
 
     mock_request = _make_request_mock(method, _HELLO_MESSAGE_PARAMS)
@@ -558,9 +548,6 @@ async def test_message_methods_caller_identity_headers_cannot_be_spoofed(method:
 @pytest.mark.asyncio
 @pytest.mark.parametrize("method", ["message/send", "message/stream"])
 async def test_message_methods_forward_key_bound_identity_not_pre_call_rewrite(method: str):
-    """Pre-call processing (add_litellm_data_to_request -> user_header_mappings) rewrites
-    user_api_key_dict.user_id from a client-supplied header. The identity forwarded to the
-    agent must be the one bound to the API key at auth time, captured before that rewrite."""
     from litellm.proxy._types import UserAPIKeyAuth
 
     mock_request = _make_request_mock(method, _HELLO_MESSAGE_PARAMS)

--- a/tests/test_litellm/proxy/agent_endpoints/test_agent_headers.py
+++ b/tests/test_litellm/proxy/agent_endpoints/test_agent_headers.py
@@ -223,7 +223,7 @@ async def test_static_overrides_dynamic():
 
 @pytest.mark.asyncio
 async def test_no_headers():
-    """When no headers are configured, agent_extra_headers is None and behaviour is unchanged."""
+    """When no headers are configured, only the caller identity is forwarded."""
     mock_agent = _make_mock_agent()  # no static_headers or extra_headers
     mock_request = _make_mock_request()
 
@@ -231,7 +231,7 @@ async def test_no_headers():
 
     call_kwargs = mock_asend.call_args.kwargs
     headers = call_kwargs.get("agent_extra_headers")
-    assert headers is None
+    assert headers == {"X-LiteLLM-User-Id": "u1"}
 
 
 # ---------------------------------------------------------------------------
@@ -303,7 +303,7 @@ async def test_convention_unrelated_prefix_not_forwarded():
     mock_asend = await _invoke(mock_agent, mock_request, None)
 
     headers = mock_asend.call_args.kwargs.get("agent_extra_headers")
-    assert headers is None
+    assert headers == {"X-LiteLLM-User-Id": "u1"}
 
 
 # ---------------------------------------------------------------------------
@@ -393,7 +393,7 @@ async def test_non_databricks_agent_skips_oauth_resolution():
 
     mock_resolve.assert_not_called()
     headers = mock_asend.call_args.kwargs.get("agent_extra_headers")
-    assert headers == {"x-custom": "v"}
+    assert headers == {"x-custom": "v", "X-LiteLLM-User-Id": "u1"}
     assert "Authorization" not in headers
 
 
@@ -477,7 +477,7 @@ async def test_convention_header_blocked_by_case_variant_static():
 
     headers = mock_asend.call_args.kwargs.get("agent_extra_headers")
     assert headers is not None
-    assert headers == {"Authorization": "Bearer admin-token"}
+    assert headers == {"Authorization": "Bearer admin-token", "X-LiteLLM-User-Id": "u1"}
     assert "authorization" not in headers
 
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Agents invoked via `message/send`/`message/stream` never learn the calling user's identity
- Downstream per-user MCP scoping and per-user FinOps budgets silently never apply
- A caller could impersonate another user via header mappings once identity was forwarded

How it solves it:

- Forward `X-LiteLLM-User-Id`/`X-LiteLLM-Team-Id` on every A2A method, not only `tasks/*`
- Snapshot the key-bound identity before request preprocessing can rewrite it
- Add regression tests covering forwarding and both spoofing paths on `message/send`/`message/stream`

## User Flow

Before: a developer builds a shared finance agent behind LiteLLM's A2A gateway, expecting each end user's identity to reach the agent so it can scope MCP tool access and bill against that user's own budget

1. They generate personal keys under the same team, one per business unit user
2. Unit A sends `POST https://litellm-domain/a2a/{agent_id}` with `method: "message/send"` using their key
3. The agent backend reads the `X-LiteLLM-User-Id` header LiteLLM is supposed to attach and gets nothing; it logs `end_user_id=None`
4. The agent calls `https://litellm-domain/v1/chat/completions` and the finance MCP server without any end-user identity attached, so per-user MCP tool access and Unit A's own spend budget are never enforced
5. Unit B's calls through the same shared agent are indistinguishable from Unit A's in every downstream system

After: the same request now carries the caller's key-bound identity all the way to the agent, and no request header can change it

1. They generate personal keys under the same team, one per business unit user
2. Unit A sends the same `POST https://litellm-domain/a2a/{agent_id}` with `method: "message/send"`
3. The agent backend reads `X-LiteLLM-User-Id` and gets Unit A's real user ID, plus `X-LiteLLM-Team-Id` with their team
4. The agent's calls to `/v1/chat/completions` and the MCP server now carry that identity, so Unit A's own budget is checked and enforced
5. Unit A resends the request adding `X-LiteLLM-User-Id: cfo` (and the header the proxy's `user_header_mappings` reads); the agent still receives Unit A's own user ID, so nobody can read another user's scoped resources through the agent

## Relevant issues

## Linear ticket

Resolves LIT-7342

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Setup, identical for both legs: a Postgres-backed proxy on `localhost:4600` with `store_model_in_db: true` and `user_header_mappings: [{header_name: X-OpenWebUI-User-Id, litellm_user_role: internal_user}]`, an internal user `unit-a-user` in team `finance-team`, a key generated with `{"user_id":"unit-a-user","team_id":"finance-team"}`, and an agent `finance-agent` registered via `POST /v1/agents` pointing at a stub A2A backend on `localhost:4601`. The stub logs the `X-LiteLLM-User-Id`/`X-LiteLLM-Team-Id` headers it receives and answers each message by calling the proxy's `/v1/chat/completions` on `anthropic-haiku-4-5` (real Anthropic calls). The message payload is the same in every case:

```json
{"jsonrpc":"2.0","id":"1","method":"message/send","params":{"message":{"kind":"message","messageId":"m1","role":"user","parts":[{"kind":"text","text":"Reply with one short sentence: what is the Q3 travel budget policy?"}]}}}
```

### Before (35451ecc7b)

#### Unit A sends message/send with their own key

1. `curl -s localhost:4600/a2a/finance-agent -H "Authorization: Bearer $UNIT_A_KEY" -H "Content-Type: application/json" -d @send.json`
2. Proxy returns `200` with `{"kind": "message", "role": "agent", "text": "I don't have access to your company's Q3 travel budget policy..."}`
3. Agent backend log: `[agent_backend] message/send text='Reply with one short sentence: what is the Q3 travel budget policy?' end_user_id=None team_id=None`

#### Unit A adds spoofed identity headers to the same request

1. `curl -s localhost:4600/a2a/finance-agent -H "Authorization: Bearer $UNIT_A_KEY" -H "Content-Type: application/json" -H "X-LiteLLM-User-Id: cfo" -H "X-OpenWebUI-User-Id: cfo" -d @send.json`
2. Proxy returns `200` with a normal agent answer
3. Agent backend log: `[agent_backend] message/send text='...' end_user_id=None team_id=None` (nothing forwarded either way)

### After (ec187dd7cf)

#### Unit A sends message/send with their own key

1. `curl -s localhost:4600/a2a/finance-agent -H "Authorization: Bearer $UNIT_A_KEY" -H "Content-Type: application/json" -d @send.json`
2. Proxy returns `200` with `{"kind": "message", "role": "agent", "text": "I don't have access to information about your Q3 travel budget policy. You'll need to check your company's internal documentation or contact your finance/HR department."}`
3. Agent backend log: `[agent_backend] message/send text='Reply with one short sentence: what is the Q3 travel budget policy?' end_user_id='unit-a-user' team_id='finance-team'`

#### Unit A adds spoofed identity headers to the same request

1. `curl -s localhost:4600/a2a/finance-agent -H "Authorization: Bearer $UNIT_A_KEY" -H "Content-Type: application/json" -H "X-LiteLLM-User-Id: cfo" -H "X-OpenWebUI-User-Id: cfo" -d @send.json`
2. Proxy returns `200` with a normal agent answer
3. Agent backend log: `[agent_backend] message/send text='...' end_user_id='unit-a-user' team_id='finance-team'`, the key-bound identity, even though the proxy's own spend log for this request shows `user=cfo` (the header mapping did fire, it just no longer reaches the agent)

## Type

🐛 Bug Fix
✅ Test

## Caveats (if any)

### Low

- Agents with no configured custom headers now receive the two identity headers where they received none before
- Identity is the gateway's own authenticated caller; a second A2A hop made with a service key forwards that service key's identity, not the original end user's

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authenticated identity propagation on a security-sensitive gateway path; behavior shifts for agents that previously saw no identity headers on message methods.
> 
> **Overview**
> Fixes a gap where **`message/send`** and **`message/stream`** did not attach **`X-LiteLLM-User-Id`** / **`X-LiteLLM-Team-Id`** to upstream agents (unlike task JSON-RPC paths), so shared agents could not scope MCP or budgets per caller.
> 
> **Caller identity is snapshotted** via `_caller_identity_headers` **before** `common_processing_pre_call_logic`, so `user_header_mappings` and similar pre-call rewrites no longer change what the agent receives. `_forwarding_headers` merges agent passthrough headers (stripping client-supplied `x-litellm-*`), then applies the frozen identity and optional trace id so **`x-a2a-{agent}-x-litellm-*` cannot spoof** the authenticated user/team. Those merged headers are built once as `agent_extra_headers` for all methods, including message flows.
> 
> Tests cover forwarding, spoof resistance, and key-bound identity on **`message/send`** / **`message/stream`**; header tests now expect identity even when no custom agent headers are configured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71adc7542f9dc7a1b49995a40ef8a7917ab1b24b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


Link to Devin session: https://app.devin.ai/sessions/29fb1383b0a04e55b60fae2a4b6507d0
Open in Devin Desktop: https://app.devin.ai/desktop/session/29fb1383b0a04e55b60fae2a4b6507d0?variant=devin
Requested by: @yassin-berriai