### PR TITLE
fix(headroom): protect cache_control-marked rows anywhere in history

### DIFF
--- a/litellm/compression/compress.py
+++ b/litellm/compression/compress.py
@@ -206,13 +206,6 @@ def _extract_anthropic_tool_exchange_spans(
 
 
 def _message_has_cache_control(message: Mapping[str, object]) -> bool:
-    """True if ``message`` carries an Anthropic ``cache_control`` breakpoint.
-
-    A breakpoint can sit directly on the message dict, or on any part of a
-    list-of-parts ``content`` (the shape Anthropic's own messages use). Either
-    placement pins the provider's KV-cache prefix to this row's exact bytes, so
-    either placement must protect the row the same way.
-    """
     if message.get("cache_control") is not None:
         return True
     content: Final = message.get("content")
@@ -231,28 +224,16 @@ def get_protected_indices(messages: Sequence[Mapping[str, object]]) -> tuple[int
 
     The last user message is what the model is being asked to act on right now,
     so compressing it replaces the live instruction with a marker. Compression
-    guardrails share this policy; see the Headroom guardrail.
-
-    A cache_control breakpoint pins the provider's prompt-cache prefix to that
-    row's exact bytes. Rewriting the row (even leaving the marker in place)
-    changes those bytes, so the next request misses the cache it thinks it is
-    reusing and silently pays a cache write instead of a cache read. This is
-    not limited to the last user/assistant row: a marker several turns back
-    (e.g. on a large cached tool result) needs the same protection.
+    guardrails share this policy; see the Headroom guardrail. A cache_control
+    breakpoint pins the provider's prompt-cache prefix to that row's exact
+    bytes, so rewriting a marked row anywhere in history turns the next
+    request's cache read into a cache write.
     """
     system_indices: Final = tuple(index for index, msg in enumerate(messages) if msg.get("role", "") == "system")
     last_user: Final = tuple(index for index, msg in enumerate(messages) if msg.get("role", "") == "user")[-1:]
-    last_assistant = tuple(index for index, msg in enumerate(messages) if msg.get("role", "") == "assistant")[-1:]
-    cache_control_indices: Final = tuple(
-        index for index, msg in enumerate(messages) if _message_has_cache_control(msg)
-    )
-    seen: Final[set[int]] = set()
-    ordered: Final[list[int]] = []
-    for index in system_indices + last_user + last_assistant + cache_control_indices:
-        if index not in seen:
-            seen.add(index)
-            ordered.append(index)
-    return tuple(ordered)
+    assistant_indices: Final = tuple(index for index, msg in enumerate(messages) if msg.get("role", "") == "assistant")
+    cache_control_indices: Final = tuple(index for index, msg in enumerate(messages) if _message_has_cache_control(msg))
+    return tuple(dict.fromkeys(system_indices + last_user + assistant_indices[-1:] + cache_control_indices))
 
 
 def _combine_scores(

--- a/litellm/compression/compress.py
+++ b/litellm/compression/compress.py
@@ -205,21 +205,54 @@ def _extract_anthropic_tool_exchange_spans(
     return spans, None
 
 
+def _message_has_cache_control(message: Mapping[str, object]) -> bool:
+    """True if ``message`` carries an Anthropic ``cache_control`` breakpoint.
+
+    A breakpoint can sit directly on the message dict, or on any part of a
+    list-of-parts ``content`` (the shape Anthropic's own messages use). Either
+    placement pins the provider's KV-cache prefix to this row's exact bytes, so
+    either placement must protect the row the same way.
+    """
+    if message.get("cache_control") is not None:
+        return True
+    content: Final = message.get("content")
+    if isinstance(content, list):
+        return any(isinstance(part, Mapping) and part.get("cache_control") is not None for part in content)
+    return False
+
+
 def get_protected_indices(messages: Sequence[Mapping[str, object]]) -> tuple[int, ...]:
     """
     Return indices of messages that must never be compressed:
     - All system messages
     - The last user message
     - The last assistant message
+    - Any message carrying an Anthropic cache_control breakpoint
 
     The last user message is what the model is being asked to act on right now,
     so compressing it replaces the live instruction with a marker. Compression
     guardrails share this policy; see the Headroom guardrail.
+
+    A cache_control breakpoint pins the provider's prompt-cache prefix to that
+    row's exact bytes. Rewriting the row (even leaving the marker in place)
+    changes those bytes, so the next request misses the cache it thinks it is
+    reusing and silently pays a cache write instead of a cache read. This is
+    not limited to the last user/assistant row: a marker several turns back
+    (e.g. on a large cached tool result) needs the same protection.
     """
     system_indices: Final = tuple(index for index, msg in enumerate(messages) if msg.get("role", "") == "system")
     last_user: Final = tuple(index for index, msg in enumerate(messages) if msg.get("role", "") == "user")[-1:]
     last_assistant = tuple(index for index, msg in enumerate(messages) if msg.get("role", "") == "assistant")[-1:]
-    return system_indices + last_user + last_assistant
+    cache_control_indices: Final = tuple(
+        index for index, msg in enumerate(messages) if _message_has_cache_control(msg)
+    )
+    seen: Final[set[int]] = set()
+    ordered: Final[list[int]] = []
+    for index in system_indices + last_user + last_assistant + cache_control_indices:
+        if index not in seen:
+            seen.add(index)
+            ordered.append(index)
+    return tuple(ordered)
 
 
 def _combine_scores(

--- a/tests/test_litellm/compression/test_compress.py
+++ b/tests/test_litellm/compression/test_compress.py
@@ -53,3 +53,63 @@ def test_every_system_row_is_protected():
 def test_no_user_or_assistant_rows():
     assert sorted(get_protected_indices([{"role": "system", "content": "sys"}])) == [0]
     assert get_protected_indices([]) == ()
+
+
+def test_mid_history_cache_control_part_is_protected():
+    # A large cached tool result from a few turns back, not the last user or
+    # last assistant row -- exactly the row a provider prompt-cache pins to
+    # exact bytes. Rewriting it (even leaving the marker on) changes those
+    # bytes and turns the next request's cache read into a cache write.
+    messages = [
+        {"role": "user", "content": "old question"},
+        {"role": "assistant", "content": "old answer"},
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "a large cached tool result"},
+            ],
+        },
+        {"role": "assistant", "content": "ack"},
+        {"role": "user", "content": "live instruction"},
+    ]
+    messages[2]["content"][0]["cache_control"] = {"type": "ephemeral"}
+
+    # index 3 = last assistant, index 4 = last user (both protected by role
+    # regardless), index 2 = the cache_control-marked row itself.
+    assert sorted(get_protected_indices(messages)) == [2, 3, 4]
+
+
+def test_cache_control_directly_on_message_is_protected():
+    messages = [
+        {"role": "user", "content": "old question", "cache_control": {"type": "ephemeral"}},
+        {"role": "assistant", "content": "old answer"},
+        {"role": "user", "content": "live instruction"},
+    ]
+
+    assert sorted(get_protected_indices(messages)) == [0, 1, 2]
+
+
+def test_cache_control_protection_does_not_duplicate_already_protected_rows():
+    # The last user row is already protected by role; marking it too must not
+    # produce a duplicate index.
+    messages = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "live", "cache_control": {"type": "ephemeral"}},
+    ]
+
+    protected = get_protected_indices(messages)
+
+    assert sorted(protected) == [0, 1]
+    assert len(protected) == len(set(protected))
+
+
+def test_content_that_is_not_a_list_of_mappings_is_not_treated_as_cache_control():
+    # Defensive: a plain string content, or a list of non-dict items, must not
+    # raise or be misread as carrying a breakpoint.
+    messages = [
+        {"role": "assistant", "content": "plain string content"},
+        {"role": "user", "content": ["not", "a", "dict", "list"]},
+        {"role": "user", "content": "live instruction"},
+    ]
+
+    assert sorted(get_protected_indices(messages)) == [0, 2]

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_headroom.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_headroom.py
@@ -1795,14 +1795,6 @@ PARTS_MESSAGES = [
         ],
     },
     {
-        # No cache_control here on purpose: this row exercises the general
-        # multi-part flatten/merge mechanics (shared with compresr). A row
-        # carrying its own cache_control is a different, dedicated case --
-        # see test_mid_history_cache_control_row_is_never_sent_for_compression
-        # (#39519): get_protected_indices withholds it from /v1/compress
-        # entirely rather than letting it be rewritten and re-merged, because
-        # rewriting the bytes under a live breakpoint busts the cache the
-        # marker is supposed to preserve.
         "role": "user",
         "content": [
             {"type": "text", "text": "Earlier turn."},
@@ -1895,14 +1887,6 @@ async def test_apply_guardrail_restores_rewritten_all_text_row(
 
     messages = result["structured_messages"]
     history_content = messages[1]["content"]
-    # Rewritten all-text row collapses to one part carrying the rewritten text.
-    # This fixture row carries no cache_control (see PARTS_MESSAGES): the
-    # last-declared-breakpoint-survives-the-merge behavior is a property of
-    # merge_rewritten_text_parts and is covered directly by compresr's
-    # test_all_text_row_merges_and_keeps_last_cache_control, since a
-    # cache_control-marked row never reaches this merge path through Headroom
-    # at all -- get_protected_indices withholds it before compression runs
-    # (see test_mid_history_cache_control_row_is_never_sent_for_compression).
     assert isinstance(history_content, list)
     assert len(history_content) == 1
     assert history_content[0]["text"] == "compressed history. Retrieve more: hash=b573993006976af767214fac"
@@ -2530,15 +2514,6 @@ async def test_history_is_still_compressed(guardrail: HeadroomGuardrail):
     assert messages[3] == compressed_history[1]
 
 
-# ---------------------------------------------------------------------------
-# #39519: a mid-history row carrying its own Anthropic cache_control marker
-# (e.g. a large tool result the client already cached several turns back) was
-# still sent to /v1/compress and rewritten. It came back byte-different but
-# kept its marker, so the next request's cache read silently became a cache
-# write. get_protected_indices() now protects any cache_control-marked row,
-# not just system/last-user/last-assistant, so it must never reach the wire.
-# ---------------------------------------------------------------------------
-
 CACHE_MARKED_HISTORY_MESSAGES = [
     {"role": "system", "content": "You are Claude Code. " + "S" * 5000},
     {"role": "user", "content": "old question " + "Q" * 5000},
@@ -2565,7 +2540,6 @@ async def test_mid_history_cache_control_row_is_never_sent_for_compression(guard
     cached_row = CACHE_MARKED_HISTORY_MESSAGES[3]
     assert cached_row not in wire
     assert not any(row.get("tool_call_id") == "old_1" for row in wire)
-    # Byte-identical, marker intact -- the next request's cache read survives.
     assert result["structured_messages"][3] == cached_row
 
 

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_headroom.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_headroom.py
@@ -1795,14 +1795,18 @@ PARTS_MESSAGES = [
         ],
     },
     {
+        # No cache_control here on purpose: this row exercises the general
+        # multi-part flatten/merge mechanics (shared with compresr). A row
+        # carrying its own cache_control is a different, dedicated case --
+        # see test_mid_history_cache_control_row_is_never_sent_for_compression
+        # (#39519): get_protected_indices withholds it from /v1/compress
+        # entirely rather than letting it be rewritten and re-merged, because
+        # rewriting the bytes under a live breakpoint busts the cache the
+        # marker is supposed to preserve.
         "role": "user",
         "content": [
-            {"type": "text", "text": "Earlier turn.", "cache_control": {"type": "ephemeral"}},
-            {
-                "type": "text",
-                "text": "Second block. " + "B" * 5000,
-                "cache_control": {"type": "ephemeral", "ttl": "1h"},
-            },
+            {"type": "text", "text": "Earlier turn."},
+            {"type": "text", "text": "Second block. " + "B" * 5000},
         ],
     },
     {
@@ -1891,14 +1895,17 @@ async def test_apply_guardrail_restores_rewritten_all_text_row(
 
     messages = result["structured_messages"]
     history_content = messages[1]["content"]
-    # Rewritten all-text row collapses to one part carrying the LAST declared
-    # breakpoint: an Anthropic breakpoint caches the prefix ending at its
-    # part, so after the merge the last one (and its TTL) still describes the
-    # row.
+    # Rewritten all-text row collapses to one part carrying the rewritten text.
+    # This fixture row carries no cache_control (see PARTS_MESSAGES): the
+    # last-declared-breakpoint-survives-the-merge behavior is a property of
+    # merge_rewritten_text_parts and is covered directly by compresr's
+    # test_all_text_row_merges_and_keeps_last_cache_control, since a
+    # cache_control-marked row never reaches this merge path through Headroom
+    # at all -- get_protected_indices withholds it before compression runs
+    # (see test_mid_history_cache_control_row_is_never_sent_for_compression).
     assert isinstance(history_content, list)
     assert len(history_content) == 1
     assert history_content[0]["text"] == "compressed history. Retrieve more: hash=b573993006976af767214fac"
-    assert history_content[0]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
     # Mixed row passes through byte-identical.
     assert messages[2]["content"] == PARTS_MESSAGES[2]["content"]
     # The service-declared hash still drives retrieve-tool injection on a restored row.
@@ -2521,6 +2528,45 @@ async def test_history_is_still_compressed(guardrail: HeadroomGuardrail):
     assert messages[1] == compressed_history[0]
     assert messages[2] == AGENTIC_MESSAGES[2]
     assert messages[3] == compressed_history[1]
+
+
+# ---------------------------------------------------------------------------
+# #39519: a mid-history row carrying its own Anthropic cache_control marker
+# (e.g. a large tool result the client already cached several turns back) was
+# still sent to /v1/compress and rewritten. It came back byte-different but
+# kept its marker, so the next request's cache read silently became a cache
+# write. get_protected_indices() now protects any cache_control-marked row,
+# not just system/last-user/last-assistant, so it must never reach the wire.
+# ---------------------------------------------------------------------------
+
+CACHE_MARKED_HISTORY_MESSAGES = [
+    {"role": "system", "content": "You are Claude Code. " + "S" * 5000},
+    {"role": "user", "content": "old question " + "Q" * 5000},
+    {
+        "role": "assistant",
+        "content": "Reading the file now.",
+        "tool_calls": [{"id": "old_1", "type": "function", "function": {"name": "Read", "arguments": "{}"}}],
+    },
+    {
+        "role": "tool",
+        "tool_call_id": "old_1",
+        "content": [{"type": "text", "text": "large cached file body " + "F" * 5000}],
+        "cache_control": {"type": "ephemeral"},
+    },
+    {"role": "assistant", "content": "Summarized the file for you."},
+    {"role": "user", "content": "live instruction"},
+]
+
+
+@pytest.mark.asyncio
+async def test_mid_history_cache_control_row_is_never_sent_for_compression(guardrail: HeadroomGuardrail):
+    wire, result = await _wire_and_result(guardrail, CACHE_MARKED_HISTORY_MESSAGES)
+
+    cached_row = CACHE_MARKED_HISTORY_MESSAGES[3]
+    assert cached_row not in wire
+    assert not any(row.get("tool_call_id") == "old_1" for row in wire)
+    # Byte-identical, marker intact -- the next request's cache read survives.
+    assert result["structured_messages"][3] == cached_row
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## TLDR

Problem this solves:
- `get_protected_indices()` only protected system rows, the last user row, and the last assistant row
- A mid-history message carrying its own Anthropic `cache_control` breakpoint (e.g. a large cached tool result from a few turns back) was not protected
- The Headroom guardrail sent that row to `/v1/compress` and rewrote it; it came back byte-different but kept its `cache_control` marker
- The next request's provider prompt cache treats that prefix as changed: a cache **read** silently becomes a cache **write**

How it solves it:
- `get_protected_indices()` now also protects any message whose content, directly on the message dict, or on any part of a list-of-parts content, carries a `cache_control` marker, regardless of position in history
- Both `compress()` and the Headroom guardrail already share this function as their compression-eligibility policy, so both get the fix from one change
- De-duplicates the returned indices (a row can now match more than one protection rule)
- `compress()` reads that policy off the original rows instead of the text-only copies it scores, since those copies drop part-level markers

## User Flow

Before: an app that pins a large tool result with `cache_control` behind the Headroom guardrail pays a fresh cache write on every follow-up turn instead of a cache read

1. The proxy admin turns on the Headroom guardrail (`mode: pre_call`, `default_on: true`) and restarts the proxy
2. The app sends POST https://litellm-domain/v1/chat/completions with `[system, user, assistant(tool_call), tool]`, the tool row carrying a 55 KB JSON result and `"cache_control": {"type": "ephemeral"}`
3. The reply comes back with `usage.cache_creation_input_tokens: 25542` and `usage.cache_read_input_tokens: 0`, the expected first write
4. The app appends the assistant reply and a new user question and sends the same POST again
5. The reply comes back with `usage.prompt_tokens: 18693`, `usage.cache_creation_input_tokens: 18652`, and `usage.cache_read_input_tokens: 0`: the pinned tool row was rewritten on the way out and came back about 6.9k tokens shorter, so the cache missed and the app paid another write

After: the same second turn reads the cache the first turn wrote

1. The proxy admin turns on the Headroom guardrail (`mode: pre_call`, `default_on: true`) and restarts the proxy
2. The app sends POST https://litellm-domain/v1/chat/completions with `[system, user, assistant(tool_call), tool]`, the tool row carrying a 55 KB JSON result and `"cache_control": {"type": "ephemeral"}`
3. The reply comes back with `usage.cache_creation_input_tokens: 25542` and `usage.cache_read_input_tokens: 0`, the expected first write
4. The app appends the assistant reply and a new user question and sends the same POST again
5. The reply comes back with `usage.cache_read_input_tokens: 25542` and `usage.cache_creation_input_tokens: 0`: the pinned tool row went out untouched, so the app paid a cache read instead of a second write

## Relevant issues

Relates to #39519. Reproduces the reported production symptom exactly: cache hit rate collapsing (~65-70% down to ~40-50%) once the guardrail runs against multi-turn Anthropic traffic with mid-history cache markers

#39519 also proposes a second, larger fix: having the Headroom guardrail use `/v1/compress`'s own `frozen_message_count`, `session_id`, and `/v1/usage` prefix-stability API so the whole cached prefix stays stable, not just individually cache_control-marked rows. That is a bigger change (new fields on the guardrail's request/response cycle, server-side session tracking) and this PR does not attempt it. This is the narrower, immediately actionable fix: it closes the gap for any row a client already marked, using the protection policy the codebase already has, without expanding the guardrail's contract with the compression service. It is worth landing on its own regardless of whether the broader session-based approach happens later

## Affected release

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
  - `tests/test_litellm/compression/test_compress.py`, `tests/test_litellm/test_compression.py`, and `tests/test_litellm/proxy/guardrails/guardrail_hooks/test_headroom.py`: 145 passed at 931bdb8c0b
  - The same three files with `compress.py` swapped back to the merge base: the 4 new regression tests fail (`test_mid_history_cache_control_part_is_protected`, `test_cache_control_directly_on_message_is_protected`, `test_compress_keeps_part_level_cache_control_row_verbatim`, `test_mid_history_cache_control_row_is_never_sent_for_compression`), the other 141 pass
  - The merge-base copies of those test files against the tip: the 3 `PARTS_MESSAGES` tests fail, since their fixture relied on a marked row being sent and merged back, which is exactly the path this PR closes; their fixture lost the marker and the marker-plus-merge interaction stays covered by the compresr guardrail's own `test_all_text_row_merges_and_keeps_last_cache_control`, which does not use `get_protected_indices`
  - Reproduced the gap against the real Headroom `/v1/compress` endpoint (0.37.0) directly: a mid-history `cache_control`-marked row that is not system, last user, or last assistant gets rewritten by the compression service when sent, so the marker alone gives no protection at that layer
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** (5/5 at 931bdb8c0b) before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both legs ran against a live LiteLLM proxy booted with `--num_workers 2` and no database (port 27703), the Headroom guardrail on, and a real `headroom-ai[proxy]` 0.37.0 sidecar (`uvx --from headroom-ai[proxy] headroom proxy --port 55407 --no-http2`) behind it, calling the real Anthropic API with `claude-sonnet-5`. Before is the merge base 8481bc27f9, After is the tip 931bdb8c0b. The same two-turn conversation went through `/v1/chat/completions` and `/v1/messages`. A third pair of legs booted a second proxy the same way (port 22469, no Headroom) with the `compression_interception` callback, which calls `compress()` directly on `/v1/messages`, since that is the other path the shared protection policy serves

Headroom proxy config:

```yaml
model_list:
  - model_name: claude-sonnet-5
    litellm_params:
      model: anthropic/claude-sonnet-5
      api_key: os.environ/ANTHROPIC_API_KEY

guardrails:
  - guardrail_name: headroom
    litellm_params:
      guardrail: headroom
      mode: pre_call
      default_on: true
      api_base: http://127.0.0.1:55407
```

Compression interception proxy config (same `model_list`):

```yaml
litellm_settings:
  callbacks: ["compression_interception"]
  compression_interception_params:
    compression_trigger: 1000
    compression_target: 700
```

Payloads: `*_chat_req1.json` is `[system, user, assistant(tool_call get_inventory), tool]`, the tool row a 55 KB JSON inventory snapshot (200 items) carrying `"cache_control": {"type": "ephemeral"}` on the message; `*_chat_req2.json` is the same four rows plus the assistant reply and a new user question. `*_msgs_req{1,2}.json` are the same conversation in the Anthropic shape: a `system` string, `[user, assistant(tool_use), user(tool_result)]` with the `cache_control` marker on the `tool_result` block itself, then the assistant text and the new question on the second turn. Every request has `max_tokens: 300` and `thinking: {"type": "disabled"}`, and every leg carries its own session tag in the system prompt so no leg can read another leg's cache

### Before (8481bc27f9)

`/v1/chat/completions`

1. `curl -s http://127.0.0.1:27703/v1/chat/completions -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" -d @before_chat_req1.json | jq '{usage: (.usage | {prompt_tokens, cache_creation_input_tokens, cache_read_input_tokens}), finish_reason: .choices[0].finish_reason, content: (.choices[0].message.content // "" | .[:80]), tool_calls: [(.choices[0].message.tool_calls // [])[].function.name]}'`

   ```json
   {
     "usage": {
       "prompt_tokens": 25544,
       "cache_creation_input_tokens": 25542,
       "cache_read_input_tokens": 0
     },
     "finish_reason": "length",
     "content": "Let me total the quantities by warehouse:\n\n- **gru**: 826+325+630+602+25+436+764",
     "tool_calls": []
   }
   ```

2. Same command with `-d @before_chat_req2.json`

   ```json
   {
     "usage": {
       "prompt_tokens": 18693,
       "cache_creation_input_tokens": 18652,
       "cache_read_input_tokens": 0
     },
     "finish_reason": "tool_calls",
     "content": "Let me count the items where the `tags` array includes `\"core\"`.",
     "tool_calls": [
       "get_inventory"
     ]
   }
   ```

   The second turn sent 18693 prompt tokens instead of 25583, paid an 18652-token cache write, and read nothing back: the pinned tool row went out rewritten and about 6.9k tokens shorter

`/v1/messages`

3. `curl -s http://127.0.0.1:27703/v1/messages -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" -d @before_msgs_req1.json | jq '{usage: (.usage | {input_tokens, cache_creation_input_tokens, cache_read_input_tokens}), stop_reason, content: [.content[] | if .type=="text" then {type, text: .text[:80]} else {type, name} end]}'`

   ```json
   {
     "usage": {
       "input_tokens": 2,
       "cache_creation_input_tokens": 25544,
       "cache_read_input_tokens": 0
     },
     "stop_reason": "tool_use",
     "content": [
       {
         "type": "text",
         "text": "Let me total quantities by warehouse."
       },
       {
         "type": "tool_use",
         "name": "get_inventory"
       }
     ]
   }
   ```

4. Same command with `-d @before_msgs_req2.json`

   ```json
   {
     "usage": {
       "input_tokens": 41,
       "cache_creation_input_tokens": 18654,
       "cache_read_input_tokens": 0
     },
     "stop_reason": "tool_use",
     "content": [
       {
         "type": "text",
         "text": "Let me tally the counts by going through the tags column of the snapshot."
       },
       {
         "type": "tool_use",
         "name": "get_inventory"
       }
     ]
   }
   ```

   Same miss on the Anthropic shape: an 18654-token write, no read

`/v1/messages` through the compression interception proxy

5. `curl -s http://127.0.0.1:22469/v1/messages -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" -d @before_icpt_req1.json | jq '{usage: (.usage | {input_tokens, cache_creation_input_tokens, cache_read_input_tokens}), stop_reason, content: [.content[] | if .type=="text" then {type, text: .text[:80]} else {type, name} end]}'`

   ```json
   {
     "usage": {
       "input_tokens": 2,
       "cache_creation_input_tokens": 25708,
       "cache_read_input_tokens": 0
     },
     "stop_reason": "end_turn",
     "content": [
       {
         "type": "text",
         "text": "I now have the current inventory snapshot (200 SKUs, snapshot_id `inv-2026-09-14"
       }
     ]
   }
   ```

6. Same command with `-d @before_icpt_req2.json`

   ```json
   {
     "usage": {
       "input_tokens": 41,
       "cache_creation_input_tokens": 25543,
       "cache_read_input_tokens": 0
     },
     "stop_reason": "tool_use",
     "content": [
       {
         "type": "tool_use",
         "name": "get_inventory"
       }
     ]
   }
   ```

   The second turn no longer matched the prefix the first turn wrote: a 25543-token write, no read, and the model asked for the inventory again

### After (931bdb8c0b)

`/v1/chat/completions`

1. `curl -s http://127.0.0.1:27703/v1/chat/completions -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" -d @after_chat_req1.json | jq '{usage: (.usage | {prompt_tokens, cache_creation_input_tokens, cache_read_input_tokens}), finish_reason: .choices[0].finish_reason, content: (.choices[0].message.content // "" | .[:80]), tool_calls: [(.choices[0].message.tool_calls // [])[].function.name]}'`

   ```json
   {
     "usage": {
       "prompt_tokens": 25544,
       "cache_creation_input_tokens": 25542,
       "cache_read_input_tokens": 0
     },
     "finish_reason": "stop",
     "content": "I aggregated quantities by warehouse from the current snapshot (inv-2026-09-14):",
     "tool_calls": []
   }
   ```

2. Same command with `-d @after_chat_req2.json`

   ```json
   {
     "usage": {
       "prompt_tokens": 25583,
       "cache_creation_input_tokens": 0,
       "cache_read_input_tokens": 25542
     },
     "finish_reason": "tool_calls",
     "content": "Let me count items where \"core\" appears in the tags list from the snapshot above",
     "tool_calls": [
       "get_inventory"
     ]
   }
   ```

   The second turn read the full 25542-token prefix the first turn wrote and paid no write

`/v1/messages`

3. `curl -s http://127.0.0.1:27703/v1/messages -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" -d @after_msgs_req1.json | jq '{usage: (.usage | {input_tokens, cache_creation_input_tokens, cache_read_input_tokens}), stop_reason, content: [.content[] | if .type=="text" then {type, text: .text[:80]} else {type, name} end]}'`

   ```json
   {
     "usage": {
       "input_tokens": 2,
       "cache_creation_input_tokens": 25543,
       "cache_read_input_tokens": 0
     },
     "stop_reason": "max_tokens",
     "content": [
       {
         "type": "text",
         "text": "Let me total the quantities by warehouse:\n\n- **SFO**: 239+92+171+421+584+791+431"
       }
     ]
   }
   ```

4. Same command with `-d @after_msgs_req2.json`

   ```json
   {
     "usage": {
       "input_tokens": 41,
       "cache_creation_input_tokens": 0,
       "cache_read_input_tokens": 25543
     },
     "stop_reason": "max_tokens",
     "content": [
       {
         "type": "text",
         "text": "Let me count the items tagged \"core\" from the snapshot.\n\nGoing through the items"
       }
     ]
   }
   ```

   A 25543-token read, no write, and the model counts from the snapshot it already has

`/v1/messages` through the compression interception proxy

5. `curl -s http://127.0.0.1:22469/v1/messages -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" -d @after_icpt_req1.json | jq '{usage: (.usage | {input_tokens, cache_creation_input_tokens, cache_read_input_tokens}), stop_reason, content: [.content[] | if .type=="text" then {type, text: .text[:80]} else {type, name} end]}'`

   ```json
   {
     "usage": {
       "input_tokens": 2,
       "cache_creation_input_tokens": 25708,
       "cache_read_input_tokens": 0
     },
     "stop_reason": "end_turn",
     "content": [
       {
         "type": "text",
         "text": "I now have the full inventory snapshot (200 SKUs across 6 warehouses: sfo, gru, "
       }
     ]
   }
   ```

6. Same command with `-d @after_icpt_req2.json`

   ```json
   {
     "usage": {
       "input_tokens": 121,
       "cache_creation_input_tokens": 0,
       "cache_read_input_tokens": 25708
     },
     "stop_reason": "end_turn",
     "content": [
       {
         "type": "text",
         "text": "Counting items with \"core\" in their tags list from the inventory snapshot:\n\nSKU-"
       }
     ]
   }
   ```

   A 25708-token read, no write, and the model answers from the pinned tool result instead of calling the tool again

A fourth pair of legs, from the /live-pr-risk pass at the same two commits, sent the conversation through `/v1/responses`: the inventory export as a `cache_control`-marked `input_text` part on the first user item, an assistant item, and a question, then a second turn appending the answer and a new question (`instructions` set, `max_output_tokens: 300`). Each side booted its own proxy the same way (`--num_workers 2`, Headroom on, the same sidecar; port 58030 before, 58113 after). Usage as each response reported it:

```
Before (8481bc27f9)
turn 1: input_tokens=18183  input_tokens_details.cached_tokens=0      input_tokens_details.cache_write_tokens=0
turn 2: input_tokens=18309  input_tokens_details.cached_tokens=0      input_tokens_details.cache_write_tokens=0

After (931bdb8c0b)
turn 1: input_tokens=25073  input_tokens_details.cached_tokens=0      input_tokens_details.cache_write_tokens=25049
turn 2: input_tokens=25167  input_tokens_details.cached_tokens=25049  input_tokens_details.cache_write_tokens=0
```

Before, the marked item went out compressed to about 18k tokens and the cache never wrote or read; after, it went out verbatim, was written on turn 1 and read back on turn 2

The logic change is `litellm/compression/compress.py` alone; `tests/test_litellm/compression/test_compress.py` and `tests/test_litellm/proxy/guardrails/guardrail_hooks/test_headroom.py` carry the four regression tests, which fail with `compress.py` at the merge base and pass at the tip

Observations from the run:

- Turn 1 answers hit `max_tokens: 300`; payload design, leaves alone
- Chat turn 2 re-calls `get_inventory` even when cached; leaves alone
- Interception prefix runs 165 tokens larger than Headroom's; leaves alone

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Rows ahead of a marked row stay compressible, so a prefix that ends at a mid-history marker can still change when an earlier row's compression changes between turns. #39519's session API ask (`frozen_message_count`, `session_id`, `/v1/usage`) is the full prefix-stability fix and stays open; protecting the whole prefix through a mid-history marker is the other option, and both are left with that follow-up
- A marked row is now never compressed, so a large cached tool result keeps its full size for the whole session
- The earlier tests that merged a rewritten marked row and kept its last breakpoint no longer describe a reachable path, so their fixture lost the marker

## Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 931bdb8c0b50e825d249949b726bafd9f2825443 passes /live-pr-risk
