### PR TITLE
fix(router): enforce deployment TPM against shared Redis usage

### DIFF
--- a/litellm/router_utils/pre_call_checks/model_rate_limit_check.py
+++ b/litellm/router_utils/pre_call_checks/model_rate_limit_check.py
@@ -155,14 +155,12 @@ class ModelRateLimitingCheck(CustomLogger):
         local_tpm: Final = cached if isinstance(cached, (int, float)) else None
         if self.dual_cache.redis_cache is None or (local_tpm is not None and local_tpm >= tpm_limit):
             return local_tpm
-        from redis.exceptions import RedisError
-
         try:
             shared_tpm: Final[object] = await self.dual_cache.redis_cache.async_get_cache(
                 key=key, parent_otel_span=parent_otel_span
             )
             return shared_tpm if isinstance(shared_tpm, (int, float)) else local_tpm
-        except (RedisError, OSError):
+        except Exception:  # noqa: BLE001  # The async Redis circuit breaker raises a plain Exception
             verbose_router_logger.exception("Redis TPM read failed, using local usage")
             return local_tpm
 

--- a/litellm/router_utils/pre_call_checks/model_rate_limit_check.py
+++ b/litellm/router_utils/pre_call_checks/model_rate_limit_check.py
@@ -136,6 +136,36 @@ class ModelRateLimitingCheck(CustomLogger):
 
         return tpm_key, rpm_key
 
+    def _get_current_tpm(self, key: str, tpm_limit: int) -> float | None:
+        cached: Final[object] = self.dual_cache.get_cache(key=key, local_only=True)
+        local_tpm: Final = cached if isinstance(cached, (int, float)) else None
+        if self.dual_cache.redis_cache is None or (local_tpm is not None and local_tpm >= tpm_limit):
+            return local_tpm
+        from redis.exceptions import RedisError
+
+        try:
+            shared_tpm: Final[object] = self.dual_cache.redis_cache.get_cache(key=key)
+            return shared_tpm if isinstance(shared_tpm, (int, float)) else local_tpm
+        except (RedisError, OSError):
+            verbose_router_logger.exception("Redis TPM read failed, using local usage")
+            return local_tpm
+
+    async def _async_get_current_tpm(self, key: str, tpm_limit: int, parent_otel_span: Span | None) -> float | None:
+        cached: Final[object] = await self.dual_cache.async_get_cache(key=key, local_only=True)
+        local_tpm: Final = cached if isinstance(cached, (int, float)) else None
+        if self.dual_cache.redis_cache is None or (local_tpm is not None and local_tpm >= tpm_limit):
+            return local_tpm
+        from redis.exceptions import RedisError
+
+        try:
+            shared_tpm: Final[object] = await self.dual_cache.redis_cache.async_get_cache(
+                key=key, parent_otel_span=parent_otel_span
+            )
+            return shared_tpm if isinstance(shared_tpm, (int, float)) else local_tpm
+        except (RedisError, OSError):
+            verbose_router_logger.exception("Redis TPM read failed, using local usage")
+            return local_tpm
+
     def pre_call_check(self, deployment: dict) -> dict | None:
         """
         Synchronous pre-call check for model rate limits.
@@ -168,11 +198,7 @@ class ModelRateLimitingCheck(CustomLogger):
 
             # Check TPM limit
             if tpm_limit is not None:
-                current_tpm: Final = (
-                    self.dual_cache.redis_cache.get_cache(key=tpm_key)
-                    if self.dual_cache.redis_cache is not None
-                    else self.dual_cache.get_cache(key=tpm_key, local_only=True)
-                )
+                current_tpm: Final = self._get_current_tpm(tpm_key, tpm_limit)
                 if current_tpm is not None and current_tpm >= tpm_limit:
                     raise litellm.RateLimitError(
                         message=f"Model rate limit exceeded. TPM limit={tpm_limit}, current usage={current_tpm}",
@@ -252,11 +278,7 @@ class ModelRateLimitingCheck(CustomLogger):
 
             # Check TPM limit
             if tpm_limit is not None:
-                current_tpm: Final = (
-                    await self.dual_cache.redis_cache.async_get_cache(key=tpm_key, parent_otel_span=parent_otel_span)
-                    if self.dual_cache.redis_cache is not None
-                    else await self.dual_cache.async_get_cache(key=tpm_key, local_only=True)
-                )
+                current_tpm: Final = await self._async_get_current_tpm(tpm_key, tpm_limit, parent_otel_span)
                 if current_tpm is not None and current_tpm >= tpm_limit:
                     raise litellm.RateLimitError(
                         message=f"Model rate limit exceeded. TPM limit={tpm_limit}, current usage={current_tpm}",

--- a/litellm/router_utils/pre_call_checks/model_rate_limit_check.py
+++ b/litellm/router_utils/pre_call_checks/model_rate_limit_check.py
@@ -168,8 +168,11 @@ class ModelRateLimitingCheck(CustomLogger):
 
             # Check TPM limit
             if tpm_limit is not None:
-                # First check local cache
-                current_tpm: Final = self.dual_cache.get_cache(key=tpm_key, local_only=True)
+                current_tpm: Final = (
+                    self.dual_cache.redis_cache.get_cache(key=tpm_key)
+                    if self.dual_cache.redis_cache is not None
+                    else self.dual_cache.get_cache(key=tpm_key, local_only=True)
+                )
                 if current_tpm is not None and current_tpm >= tpm_limit:
                     raise litellm.RateLimitError(
                         message=f"Model rate limit exceeded. TPM limit={tpm_limit}, current usage={current_tpm}",
@@ -249,8 +252,11 @@ class ModelRateLimitingCheck(CustomLogger):
 
             # Check TPM limit
             if tpm_limit is not None:
-                # First check local cache
-                current_tpm: Final = await self.dual_cache.async_get_cache(key=tpm_key, local_only=True)
+                current_tpm: Final = (
+                    await self.dual_cache.redis_cache.async_get_cache(key=tpm_key, parent_otel_span=parent_otel_span)
+                    if self.dual_cache.redis_cache is not None
+                    else await self.dual_cache.async_get_cache(key=tpm_key, local_only=True)
+                )
                 if current_tpm is not None and current_tpm >= tpm_limit:
                     raise litellm.RateLimitError(
                         message=f"Model rate limit exceeded. TPM limit={tpm_limit}, current usage={current_tpm}",

--- a/tests/test_litellm/test_router/test_enforce_model_rate_limits.py
+++ b/tests/test_litellm/test_router/test_enforce_model_rate_limits.py
@@ -6,16 +6,114 @@ regardless of the routing strategy being used.
 """
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock
+from datetime import datetime, timezone
+from typing import Final
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 import litellm
 from litellm import Router
 from litellm.caching.dual_cache import DualCache
+from litellm.caching.in_memory_cache import InMemoryCache
+from litellm.caching.redis_cache import RedisCache
 from litellm.router_utils.pre_call_checks.model_rate_limit_check import (
     ModelRateLimitingCheck,
 )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("use_async", [False, True])
+@pytest.mark.parametrize("local_tpm", [None, 100])
+@pytest.mark.parametrize("shared_tpm", [1000, 1100])
+async def test_deployment_tpm_reads_shared_usage(use_async: bool, local_tpm: int | None, shared_tpm: int) -> None:
+    shared_store: Final = InMemoryCache()
+    redis: Final = MagicMock(spec=RedisCache)
+    redis.get_cache.side_effect = shared_store.get_cache
+    redis.async_get_cache = AsyncMock(side_effect=shared_store.async_get_cache)
+    redis.increment_cache.side_effect = shared_store.increment_cache
+    redis.async_increment = AsyncMock(side_effect=shared_store.async_increment)
+    first_cache: Final = DualCache(redis_cache=redis)
+    second_cache: Final = DualCache(redis_cache=redis)
+    first_worker: Final = ModelRateLimitingCheck(first_cache)
+    second_worker: Final = ModelRateLimitingCheck(second_cache)
+    deployment: Final = {
+        "model_name": "test-model",
+        "tpm": 1000,
+        "litellm_params": {"model": "gpt-4"},
+        "model_info": {"id": "test-id"},
+    }
+    fixed_time: Final = datetime(2026, 9, 8, 12, 0, tzinfo=timezone.utc)
+    tpm_key: Final = "test-id:gpt-4:tpm:12-00"
+    if local_tpm is not None:
+        second_cache.in_memory_cache.set_cache(tpm_key, local_tpm)
+    success_kwargs: Final = {
+        "standard_logging_object": {
+            "model_id": "test-id",
+            "total_tokens": shared_tpm,
+            "hidden_params": {"litellm_model_name": "gpt-4"},
+        }
+    }
+    with patch(  # test-quality-ok: Freeze only the clock to keep callbacks and checks in the same minute
+        "litellm.router_utils.pre_call_checks.model_rate_limit_check.get_utc_datetime",
+        return_value=fixed_time,
+    ):
+        if use_async:
+            assert await second_worker.async_pre_call_check(deployment) == deployment
+            await first_worker.async_log_success_event(success_kwargs, None, None, None)
+            with pytest.raises(litellm.RateLimitError, match="TPM limit=1000"):
+                await second_worker.async_pre_call_check(deployment)
+        else:
+            assert second_worker.pre_call_check(deployment) == deployment
+            first_worker.log_success_event(success_kwargs, None, None, None)
+            with pytest.raises(litellm.RateLimitError, match="TPM limit=1000"):
+                second_worker.pre_call_check(deployment)
+    assert shared_store.get_cache(tpm_key) == shared_tpm
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("use_async", [False, True])
+@pytest.mark.parametrize("shared_tpm", [None, 999])
+async def test_deployment_tpm_ignores_stale_local_limit(use_async: bool, shared_tpm: int | None) -> None:
+    redis: Final = MagicMock(spec=RedisCache)
+    redis.get_cache.return_value = shared_tpm
+    redis.async_get_cache = AsyncMock(return_value=shared_tpm)
+    cache: Final = DualCache(redis_cache=redis)
+    cache.in_memory_cache.set_cache("test-id:gpt-4:tpm:12-00", 1000)
+    check: Final = ModelRateLimitingCheck(cache)
+    deployment: Final = {
+        "model_name": "test-model",
+        "tpm": 1000,
+        "litellm_params": {"model": "gpt-4"},
+        "model_info": {"id": "test-id"},
+    }
+    with patch(  # test-quality-ok: Freeze only the clock to read the seeded minute's counter deterministically
+        "litellm.router_utils.pre_call_checks.model_rate_limit_check.get_utc_datetime",
+        return_value=datetime(2026, 9, 8, 12, 0, tzinfo=timezone.utc),
+    ):
+        if use_async:
+            assert await check.async_pre_call_check(deployment) == deployment
+        else:
+            assert check.pre_call_check(deployment) == deployment
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("use_async", [False, True])
+async def test_deployment_tpm_redis_error_fails_open(use_async: bool) -> None:
+    redis: Final = MagicMock(spec=RedisCache)
+    redis.get_cache.side_effect = ConnectionError("Redis unavailable")
+    redis.async_get_cache = AsyncMock(side_effect=ConnectionError("Redis unavailable"))
+    check: Final = ModelRateLimitingCheck(DualCache(redis_cache=redis))
+    deployment: Final = {
+        "model_name": "test-model",
+        "tpm": 1000,
+        "litellm_params": {"model": "gpt-4"},
+        "model_info": {"id": "test-id"},
+    }
+    if use_async:
+        assert await check.async_pre_call_check(deployment) == deployment
+    else:
+        assert check.pre_call_check(deployment) == deployment
 
 
 class TestModelRateLimitingCheck:
@@ -128,6 +226,7 @@ class TestModelRateLimitingCheck:
         """Test that RateLimitError is raised when TPM limit is exceeded."""
         mock_cache = MagicMock()
         mock_cache.get_cache.return_value = 1000  # Already at limit
+        mock_cache.redis_cache = None
 
         check = ModelRateLimitingCheck(dual_cache=mock_cache)
 
@@ -230,6 +329,7 @@ class TestModelRateLimitingCheckAsync:
         """Test that RateLimitError is raised when TPM limit is exceeded (async)."""
         mock_cache = MagicMock()
         mock_cache.async_get_cache = AsyncMock(return_value=1000)  # Already at limit
+        mock_cache.redis_cache = None
 
         check = ModelRateLimitingCheck(dual_cache=mock_cache)
 

--- a/tests/test_litellm/test_router/test_enforce_model_rate_limits.py
+++ b/tests/test_litellm/test_router/test_enforce_model_rate_limits.py
@@ -11,6 +11,8 @@ from typing import Final
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from redis.exceptions import ConnectionError as RedisConnectionError
+from redis.exceptions import TimeoutError as RedisTimeoutError
 
 import litellm
 from litellm import Router
@@ -74,7 +76,7 @@ async def test_deployment_tpm_reads_shared_usage(use_async: bool, local_tpm: int
 @pytest.mark.asyncio
 @pytest.mark.parametrize("use_async", [False, True])
 @pytest.mark.parametrize("shared_tpm", [None, 999])
-async def test_deployment_tpm_ignores_stale_local_limit(use_async: bool, shared_tpm: int | None) -> None:
+async def test_deployment_tpm_rejects_local_limit_without_redis_read(use_async: bool, shared_tpm: int | None) -> None:
     redis: Final = MagicMock(spec=RedisCache)
     redis.get_cache.return_value = shared_tpm
     redis.async_get_cache = AsyncMock(return_value=shared_tpm)
@@ -92,28 +94,52 @@ async def test_deployment_tpm_ignores_stale_local_limit(use_async: bool, shared_
         return_value=datetime(2026, 9, 8, 12, 0, tzinfo=timezone.utc),
     ):
         if use_async:
-            assert await check.async_pre_call_check(deployment) == deployment
+            with pytest.raises(litellm.RateLimitError, match="TPM limit=1000"):
+                await check.async_pre_call_check(deployment)
         else:
-            assert check.pre_call_check(deployment) == deployment
+            with pytest.raises(litellm.RateLimitError, match="TPM limit=1000"):
+                check.pre_call_check(deployment)
+    redis.get_cache.assert_not_called()
+    redis.async_get_cache.assert_not_called()
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("use_async", [False, True])
-async def test_deployment_tpm_redis_error_fails_open(use_async: bool) -> None:
+@pytest.mark.parametrize("local_tpm", [None, 100, 1000])
+@pytest.mark.parametrize("read_error", [None, ConnectionError, RedisConnectionError, RedisTimeoutError])
+async def test_deployment_tpm_redis_failure_keeps_local_enforcement(
+    use_async: bool, local_tpm: int | None, read_error: type[Exception] | None
+) -> None:
     redis: Final = MagicMock(spec=RedisCache)
-    redis.get_cache.side_effect = ConnectionError("Redis unavailable")
-    redis.async_get_cache = AsyncMock(side_effect=ConnectionError("Redis unavailable"))
-    check: Final = ModelRateLimitingCheck(DualCache(redis_cache=redis))
+    redis.get_cache.return_value = None
+    redis.async_get_cache = AsyncMock(return_value=None)
+    if read_error is not None:
+        redis.get_cache.side_effect = read_error("Redis unavailable")
+        redis.async_get_cache.side_effect = read_error("Redis unavailable")
+    cache: Final = DualCache(redis_cache=redis)
+    if local_tpm is not None:
+        cache.in_memory_cache.set_cache("test-id:gpt-4:tpm:12-00", local_tpm)
+    check: Final = ModelRateLimitingCheck(cache)
     deployment: Final = {
         "model_name": "test-model",
         "tpm": 1000,
         "litellm_params": {"model": "gpt-4"},
         "model_info": {"id": "test-id"},
     }
-    if use_async:
-        assert await check.async_pre_call_check(deployment) == deployment
-    else:
-        assert check.pre_call_check(deployment) == deployment
+    with patch(  # test-quality-ok: Freeze only the clock to read the seeded minute's counter deterministically
+        "litellm.router_utils.pre_call_checks.model_rate_limit_check.get_utc_datetime",
+        return_value=datetime(2026, 9, 8, 12, 0, tzinfo=timezone.utc),
+    ):
+        if use_async and local_tpm == 1000:
+            with pytest.raises(litellm.RateLimitError, match="TPM limit=1000"):
+                await check.async_pre_call_check(deployment)
+        elif local_tpm == 1000:
+            with pytest.raises(litellm.RateLimitError, match="TPM limit=1000"):
+                check.pre_call_check(deployment)
+        elif use_async:
+            assert await check.async_pre_call_check(deployment) == deployment
+        else:
+            assert check.pre_call_check(deployment) == deployment
 
 
 class TestModelRateLimitingCheck:

--- a/tests/test_litellm/test_router/test_enforce_model_rate_limits.py
+++ b/tests/test_litellm/test_router/test_enforce_model_rate_limits.py
@@ -7,6 +7,7 @@ regardless of the routing strategy being used.
 
 import asyncio
 from datetime import datetime, timezone
+from functools import partial
 from typing import Final
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -18,7 +19,7 @@ import litellm
 from litellm import Router
 from litellm.caching.dual_cache import DualCache
 from litellm.caching.in_memory_cache import InMemoryCache
-from litellm.caching.redis_cache import RedisCache
+from litellm.caching.redis_cache import RedisCache, RedisCircuitBreaker
 from litellm.router_utils.pre_call_checks.model_rate_limit_check import (
     ModelRateLimitingCheck,
 )
@@ -140,6 +141,38 @@ async def test_deployment_tpm_redis_failure_keeps_local_enforcement(
             assert await check.async_pre_call_check(deployment) == deployment
         else:
             assert check.pre_call_check(deployment) == deployment
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("local_tpm", [None, 100])
+async def test_open_redis_circuit_preserves_async_rpm_enforcement(local_tpm: int | None) -> None:
+    breaker: Final = RedisCircuitBreaker(failure_threshold=1, recovery_timeout=60, enabled=True)
+    breaker.record_failure()
+    redis: Final = MagicMock(spec=RedisCache)
+    redis._circuit_breaker = breaker
+    redis.async_get_cache = partial(RedisCache.async_get_cache, redis)
+    redis.async_increment = partial(RedisCache.async_increment, redis)
+    cache: Final = DualCache(redis_cache=redis)
+    if local_tpm is not None:
+        cache.in_memory_cache.set_cache("test-id:gpt-4:tpm:12-00", local_tpm)
+    check: Final = ModelRateLimitingCheck(cache)
+    deployment: Final = {
+        "model_name": "test-model",
+        "tpm": 1000,
+        "rpm": 1,
+        "litellm_params": {"model": "gpt-4"},
+        "model_info": {"id": "test-id"},
+    }
+    with patch(  # test-quality-ok: Freeze only the clock to keep both requests in the same rate-limit window
+        "litellm.router_utils.pre_call_checks.model_rate_limit_check.get_utc_datetime",
+        return_value=datetime(2026, 9, 8, 12, 0, tzinfo=timezone.utc),
+    ):
+        with pytest.raises(Exception, match="Redis circuit breaker is open"):
+            await redis.async_get_cache(key="test-id:gpt-4:tpm:12-00")
+        assert await check.async_pre_call_check(deployment) == deployment
+        with pytest.raises(litellm.RateLimitError, match="RPM limit=1"):
+            await check.async_pre_call_check(deployment)
+    assert cache.in_memory_cache.get_cache("test-id:gpt-4:rpm:12-00") == 2
 
 
 class TestModelRateLimitingCheck:


### PR DESCRIPTION
## Summary

Fixes #40291

Deployment TPM checks read only local counters, so replicas can keep admitting requests after their combined usage reaches the limit

Reject locally exhausted deployments without querying Redis. Otherwise, read shared usage directly, in both sync and async checks. Missing or failed Redis reads fall back to local counters. Without Redis, local checks remain unchanged

## Validation

91 targeted tests pass, along with `make lint`. Regression tests cover cross-replica usage, stale counters, limit boundaries, Redis failures, and continued RPM enforcement with the actual circuit breaker open

Real-Redis diagnostics confirm shared-limit enforcement and local rejection with Redis stopped, for sync and async checks. Full proxy/provider E2E proof is still pending

## Tradeoffs

Adds a Redis read when local usage is below the limit. During Redis outages, enforcement is local only. In-flight requests can still overshoot because tokens are accounted for after completion

## Checklist

- [x] Focused fix with regression tests
- [x] Targeted tests and local lint pass
- [x] Required CI checks pass

