### PR TITLE
test(proxy): fix Prisma timeout cleanup after subreaper tests

### DIFF
--- a/tests/test_litellm/proxy/db/conftest.py
+++ b/tests/test_litellm/proxy/db/conftest.py
@@ -6,7 +6,7 @@ import time
 from collections.abc import Generator
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Final, Optional
 
 import pytest
 
@@ -122,10 +122,18 @@ class FakePrismaCli:
         return [json.loads(line) for line in self.calls_file.read_text().splitlines()]
 
     def grandchild_is_gone(self, within_seconds: float) -> bool:
-        deadline = time.monotonic() + within_seconds
+        pid: Final = int(self.grandchild_pidfile.read_text())
+        deadline: Final = time.monotonic() + within_seconds
         while time.monotonic() < deadline:
+            if os.name != "nt":
+                try:
+                    reaped_pid, _ = os.waitpid(pid, os.WNOHANG)
+                    if reaped_pid == pid:
+                        return True
+                except ChildProcessError:
+                    pass
             try:
-                os.kill(int(self.grandchild_pidfile.read_text()), 0)
+                os.kill(pid, 0)
             except ProcessLookupError:
                 return True
             time.sleep(0.05)
@@ -154,3 +162,4 @@ def fake_prisma_cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Generato
             os.kill(int(cli.grandchild_pidfile.read_text()), signal.SIGKILL)
         except ProcessLookupError:
             pass
+        assert cli.grandchild_is_gone(within_seconds=5)

--- a/tests/test_litellm/proxy/db/test_query_engine_reaper.py
+++ b/tests/test_litellm/proxy/db/test_query_engine_reaper.py
@@ -3,6 +3,7 @@ import signal
 import subprocess
 import sys
 import time
+from typing import Final
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -15,7 +16,6 @@ from litellm.proxy.db.query_engine_reaper import (
     _try_reap,
     list_orphaned_engine_pids,
     reap_orphaned_engines,
-    set_child_subreaper,
     start_query_engine_reaper,
     terminate_and_reap,
     terminate_and_reap_all,
@@ -79,11 +79,19 @@ class TestListOrphanedEnginePids:
 
 class TestSetChildSubreaper:
     def test_matches_platform_capability(self):
-        result = set_child_subreaper()
-        if sys.platform.startswith("linux"):
-            assert result is True
-        else:
-            assert result is False
+        result: Final = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "import sys; "
+                "from litellm.proxy.db.query_engine_reaper import set_child_subreaper; "
+                "assert set_child_subreaper() is sys.platform.startswith('linux')",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0, result.stderr
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX signals and waitpid")

--- a/tests/test_litellm/proxy/test_proxy_cli.py
+++ b/tests/test_litellm/proxy/test_proxy_cli.py
@@ -1525,7 +1525,12 @@ class TestProxyInitializationHelpers:
         def capture_run(self):
             captured["options"] = dict(self.options)
 
-        with patch("gunicorn.app.base.BaseApplication.run", capture_run):
+        with (
+            patch("gunicorn.app.base.BaseApplication.run", capture_run),
+            patch(  # test-quality-ok: option tests must not start a thread or change the pytest worker's child ownership
+                "litellm.proxy.proxy_cli.start_query_engine_reaper"
+            ),
+        ):
             ProxyInitializationHelpers._run_gunicorn_server(
                 host="127.0.0.1",
                 port=4010,
@@ -1553,6 +1558,9 @@ class TestProxyInitializationHelpers:
         with (
             patch("gunicorn.app.base.BaseApplication.run", capture_run),
             patch("builtins.print") as mock_print,
+            patch(  # test-quality-ok: option tests must not start a thread or change the pytest worker's child ownership
+                "litellm.proxy.proxy_cli.start_query_engine_reaper"
+            ),
         ):
             ProxyInitializationHelpers._run_gunicorn_server(
                 host="127.0.0.1",


### PR DESCRIPTION
## TLDR

Problem this solves:

- Linux test ordering makes killed Prisma children fail cleanup assertions

How it solves it:

- Reap adopted children in the existing Prisma fixture
- Keep Gunicorn option tests from starting a real reaper
- Run the existing subreaper capability check in a subprocess

## User Flow

Before: a contributor reproduces a false process-cleanup failure on Linux

1. Run the existing Gunicorn option tests before the migration timeout test in one process
2. The timeout test fails because a terminated child remains an unreaped zombie

After: the same existing tests pass together

1. Run the existing Gunicorn option tests before the migration timeout test in one process
2. The timeout test passes and fixture cleanup collects adopted children

## Relevant issues

Fixes the test failure observed in [the proxy-infra job for #40307](https://github.com/BerriAI/litellm/actions/runs/34294337966/job/102287551972?pr=40307)

## Linear ticket

## Validation

### Before (754a2afe12891f0fc9e8b20fbf17f7504d71215a)

1. Run the existing Gunicorn jitter-warning test followed by the migration timeout test on Linux with Python 3.12
2. Result: 1 passed, 1 failed at `grandchild_is_gone(within_seconds=5)`

### After (5a7919f3f5ecab734946c1a2e0ea8e81b859c046)

1. Run both Gunicorn option tests, then the existing query-engine reaper, migration-check, and Prisma-client test files in one Linux process with Python 3.12
2. Result: 49 passed
3. Run `make check`: test-tree lint and test-quality budget passed

The current head, `c0bc3152d623ee7f20de2db930a5f58691968835`, has exactly the same Git tree as the validated test-fix commit above

Hosted CI: the dependency scan still flags unchanged `diskcache 5.6.3`; the remaining checks are running

## Pre-Submission checklist

- [x] Existing tests corrected; no additional test cases added
- [x] Focused tests pass locally
- [ ] Required CI checks pass
- [x] Scope is limited to test isolation and fixture cleanup
- [x] Greptile has independently posted 5/5 for the current head

## Screenshots / Proof of Fix

This changes test infrastructure only. There is no proxy runtime or API/UI behavior change to demonstrate

## Type

Test

## Caveats (if any)

## Final Attestation

- [x] Product code is unchanged, and no new regression tests were added
