### PR TITLE
chore: bump litellm-enterprise 0.1.65 -> 0.1.66

### DIFF
--- a/enterprise/pyproject.toml
+++ b/enterprise/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "litellm-enterprise"
-version = "0.1.65"
+version = "0.1.66"
 description = "Package for LiteLLM Enterprise features"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -26,7 +26,7 @@ required-version = ">=0.10.9"
 module-root = ""
 
 [tool.commitizen]
-version = "0.1.65"
+version = "0.1.66"
 version_files = [
     "pyproject.toml:^version",
     "../pyproject.toml:litellm-enterprise==",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ proxy = [
     "azure-storage-blob>=12.28.0,<13.0",
     "mcp>=1.28.1,<2.0",
     "litellm-proxy-extras==0.4.95",
-    "litellm-enterprise==0.1.65",
+    "litellm-enterprise==0.1.66",
     "RestrictedPython>=8.5,<9.0",
     "rich>=13.9.4,<14.0",
     "InquirerPy>=0.3.4,<1.0",

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-09-05T20:24:07.535116Z"
+exclude-newer = "2026-09-06T00:40:30.433549Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -4767,7 +4767,7 @@ proxy-dev = [
 
 [[package]]
 name = "litellm-enterprise"
-version = "0.1.65"
+version = "0.1.66"
 source = { editable = "enterprise" }
 
 [[package]]


### PR DESCRIPTION
## TLDR

Problem this solves:

- enterprise changed since main but version is unchanged
- nothing else is due this round

How it solves it:

- PATCH bump litellm-enterprise 0.1.65 -> 0.1.66
- refresh uv.lock against the new version

## User Flow

Not applicable, this is a version-bump-only PR with no runtime behavior change

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [ ] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

There is no meaningful proof of fix for a version bump: nothing changes at runtime, only the version strings in enterprise, the root pin, and the matching entry in uv.lock

## Type

🚄 Infrastructure

## Caveats (if any)

### Low

- uv.lock's `exclude-newer` moves forward, that is the rolling P3D window
- no third-party dependency versions moved in the lock

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
