### PR TITLE
chore(ci): extend diskcache scan exception to October 1

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,6 +1,6 @@
 [[IgnoredVulns]]
 id = "GHSA-w8v5-vhqr-4h9v"
-ignoreUntil = 2026-09-09
+ignoreUntil = 2026-10-01
 reason = "diskcache has no fixed release published; remove this entry once one exists"
 
 [[IgnoredVulns]]


### PR DESCRIPTION
## TLDR

Problem this solves:

- The diskcache scan exception expired without a fixed release

How it solves it:

- Extend the diskcache exception to October 1, 2026

## User Flow

Before: a contributor sees the OSV scan fail

1. Open a pull request and inspect its OSV Scan check
2. The check reports diskcache because its exception expired

After: the existing exception remains active until October 1, 2026

1. Open a pull request and inspect its OSV Scan check
2. The check ignores the existing diskcache finding until that date

## Relevant issues

[Failing OSV scan on #40333](https://github.com/BerriAI/litellm/actions/runs/34295811465/job/102292085018?pr=40333)

## Linear ticket

## Pre-Submission checklist

- [x] TOML parses successfully; only the diskcache expiry changed
- [x] No new tests needed for a date-only configuration change
- [ ] Required CI checks pass
- [x] Scope is one configuration value
- [ ] Greptile has independently posted 5/5 for the current head

## Screenshots / Proof of Fix

### Before (5a7919f3f5ecab734946c1a2e0ea8e81b859c046)

1. Inspect the [original OSV scan](https://github.com/BerriAI/litellm/actions/runs/34295811465/job/102292085018)
2. It exits with code 1 and reports diskcache 5.6.3 with no fixed version

### After (810d48f28fcdd0e2b29a64b5a238aa9697fae8e7)

1. Parse the configuration and compare it with the base branch
2. The only change is diskcache's expiry from 2026-09-09 to 2026-10-01
3. This PR's CI scan is pending. The same date change already [passed OSV Scan on #40333](https://github.com/BerriAI/litellm/actions/runs/34295997817) before being moved into this separate PR

## Type

Infrastructure

## Caveats (if any)

### Low

- The diskcache finding becomes reportable again on October 1

## Final Attestation

- [x] Only the diskcache exception expiry changes
