### PR TITLE
feat(auto-router): refresh family reasoning presets

### DIFF
--- a/litellm/proxy/public_endpoints/autorouter_presets.json
+++ b/litellm/proxy/public_endpoints/autorouter_presets.json
@@ -10,7 +10,12 @@
         "REASONING": ["claude-opus-5"]
       },
       "tier_model_configs": {
-        "REASONING": [{ "model_name": "claude-opus-5", "litellm_params": { "reasoning_effort": "high" } }]
+        "REASONING": [
+          {
+            "model_name": "claude-opus-5",
+            "litellm_params": { "reasoning_effort": "high" }
+          }
+        ]
       },
       "classifier_type": "heuristic_v2",
       "escalation_keywords": ["LITELLM ESCALATE"],
@@ -23,16 +28,21 @@
   },
   "anthropic_family": {
     "label": "Anthropic Family",
-    "description": "Routes across the Claude model family: Haiku for simple queries, Sonnet for medium, Opus for complex, Opus at high thinking for reasoning.",
+    "description": "Routes across the Claude model family: Haiku for simple queries, Sonnet for medium, Opus for complex, Fable 5.1 at high thinking for reasoning.",
     "complexity_router_config": {
       "tiers": {
         "SIMPLE": ["claude-haiku-4-5"],
         "MEDIUM": ["claude-sonnet-5"],
         "COMPLEX": ["claude-opus-5"],
-        "REASONING": ["claude-opus-5"]
+        "REASONING": ["claude-fable-5-1"]
       },
       "tier_model_configs": {
-        "REASONING": [{ "model_name": "claude-opus-5", "litellm_params": { "reasoning_effort": "high" } }]
+        "REASONING": [
+          {
+            "model_name": "claude-fable-5-1",
+            "litellm_params": { "reasoning_effort": "high" }
+          }
+        ]
       },
       "classifier_type": "heuristic",
       "escalation_keywords": ["LITELLM ESCALATE"],
@@ -73,8 +83,18 @@
         "REASONING": ["claude-opus-5"]
       },
       "tier_model_configs": {
-        "MEDIUM": [{ "model_name": "muse-spark-1.2", "litellm_params": { "reasoning_effort": "xhigh" } }],
-        "COMPLEX": [{ "model_name": "kimi-k3", "litellm_params": { "reasoning_effort": "max" } }]
+        "MEDIUM": [
+          {
+            "model_name": "muse-spark-1.2",
+            "litellm_params": { "reasoning_effort": "xhigh" }
+          }
+        ],
+        "COMPLEX": [
+          {
+            "model_name": "kimi-k3",
+            "litellm_params": { "reasoning_effort": "max" }
+          }
+        ]
       },
       "classifier_type": "llm",
       "classifier_llm_config": {
@@ -93,16 +113,21 @@
   },
   "openai_family": {
     "label": "OpenAI Family",
-    "description": "Routes across the GPT model family: Luna for simple queries, Terra for medium, Sol for complex, Sol at xhigh thinking for reasoning.",
+    "description": "Routes across the GPT model family: Luna for simple queries, Terra for medium, Sol for complex, Astra at xhigh thinking for reasoning.",
     "complexity_router_config": {
       "tiers": {
         "SIMPLE": ["gpt-5.6-luna"],
         "MEDIUM": ["gpt-5.6-terra"],
         "COMPLEX": ["gpt-5.6-sol"],
-        "REASONING": ["gpt-5.6-sol"]
+        "REASONING": ["gpt-6-astra"]
       },
       "tier_model_configs": {
-        "REASONING": [{ "model_name": "gpt-5.6-sol", "litellm_params": { "reasoning_effort": "xhigh" } }]
+        "REASONING": [
+          {
+            "model_name": "gpt-6-astra",
+            "litellm_params": { "reasoning_effort": "xhigh" }
+          }
+        ]
       },
       "classifier_type": "heuristic",
       "escalation_keywords": ["LITELLM ESCALATE"],

--- a/ui/litellm-dashboard/src/lib/autorouter_presets.test.ts
+++ b/ui/litellm-dashboard/src/lib/autorouter_presets.test.ts
@@ -149,13 +149,12 @@ describe("autorouter_presets", () => {
     );
   });
 
-  // Opus serves both tiers, so the effort is all that separates them and losing it fails silently.
-  it("pins the anthropic preset's reasoning tier to Opus at high thinking", () => {
+  it("pins the anthropic preset's reasoning tier to Fable 5.1 at high thinking", () => {
     const config = getPresetByKey("anthropic_family")!.complexity_router_config;
     expect(config.tiers.COMPLEX).toEqual(["claude-opus-5"]);
-    expect(config.tiers.REASONING).toEqual(["claude-opus-5"]);
+    expect(config.tiers.REASONING).toEqual(["claude-fable-5-1"]);
     expect(config.tier_model_configs).toEqual({
-      REASONING: [{ model_name: "claude-opus-5", litellm_params: { reasoning_effort: "high" } }],
+      REASONING: [{ model_name: "claude-fable-5-1", litellm_params: { reasoning_effort: "high" } }],
     });
   });
 
@@ -214,7 +213,7 @@ describe("autorouter_presets", () => {
     const preset = getPresetByKey("anthropic_family")!;
     const prefill = buildPresetPrefill(preset.complexity_router_config, groupsOnly(getRequiredModelsInPreset(preset)));
     expect(prefill.complexityRouterConfig.tier_model_params).toEqual({
-      REASONING: { "claude-opus-5": { reasoning_effort: "high" } },
+      REASONING: { "claude-fable-5-1": { reasoning_effort: "high" } },
     });
   });
 
@@ -227,21 +226,21 @@ describe("autorouter_presets", () => {
     });
   });
 
-  it("pins the OpenAI preset to the Luna, Terra, and Sol progression", () => {
+  it("pins the OpenAI preset to the Luna, Terra, Sol, and Astra progression", () => {
     const preset = getPresetByKey("openai_family")!;
     const expectedTiers = {
       SIMPLE: ["gpt-5.6-luna"],
       MEDIUM: ["gpt-5.6-terra"],
       COMPLEX: ["gpt-5.6-sol"],
-      REASONING: ["gpt-5.6-sol"],
+      REASONING: ["gpt-6-astra"],
     };
     expect(preset.complexity_router_config.tiers).toEqual(expectedTiers);
     expect(preset.complexity_router_config.tier_model_configs).toEqual({
-      REASONING: [{ model_name: "gpt-5.6-sol", litellm_params: { reasoning_effort: "xhigh" } }],
+      REASONING: [{ model_name: "gpt-6-astra", litellm_params: { reasoning_effort: "xhigh" } }],
     });
     const prefill = buildPresetPrefill(preset.complexity_router_config, groupsOnly(getRequiredModelsInPreset(preset)));
     expect(prefill.complexityRouterConfig.tier_model_params).toEqual({
-      REASONING: { "gpt-5.6-sol": { reasoning_effort: "xhigh" } },
+      REASONING: { "gpt-6-astra": { reasoning_effort: "xhigh" } },
     });
   });
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Family presets send reasoning traffic to older models

How it solves it:

- OpenAI reasoning uses GPT-6 Astra at xhigh effort
- Anthropic reasoning uses Claude Fable 5.1 at high effort

## User Flow

Before: an admin selects a family preset and gets an older reasoning model

1. They open Models + Endpoints and add an Auto Router
2. They select OpenAI Family or Anthropic Family
3. The Reasoning tier shows GPT-5.6 Sol or Claude Opus 5

After: the same presets fill the Reasoning tier with current models

1. They open Models + Endpoints and add an Auto Router
2. They select OpenAI Family or Anthropic Family
3. The Reasoning tier shows GPT-6 Astra or Claude Fable 5.1

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The focused Auto-Router preset test passes locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible
- [ ] I have received a Greptile Confidence Score of at least 4/5

## Screenshots / Proof of Fix

The catalog data determines what the dashboard fills into each tier.

### Before (fb36c3c5a5)

1. Read both family presets from the bundled catalog with `jq`
2. Anthropic Reasoning returned `claude-opus-5` at `high`
3. OpenAI Reasoning returned `gpt-5.6-sol` at `xhigh`

### After (02f819563)

1. Read both family presets from the bundled catalog with the same `jq` query
2. Anthropic Reasoning returned `claude-fable-5-1` at `high`
3. OpenAI Reasoning returned `gpt-6-astra` at `xhigh`

## Validation

- `npm test -- --run --project unit src/lib/autorouter_presets.test.ts`: 89 passed
- `npx prettier --check src/lib/autorouter_presets.test.ts ../../litellm/proxy/public_endpoints/autorouter_presets.json`: passed
- `jq empty litellm/proxy/public_endpoints/autorouter_presets.json`: passed

## Type

New Feature

## Caveats (if any)

### Low

- Existing routers keep their saved tier choices
- The preset changes new selections and reapplications
- OSV flags `diskcache` 5.6.3, which has no fixed release
- This branch does not edit `uv.lock`

## Final Attestation

- [x] Tests cover both reasoning model IDs and effort values
