### PR TITLE
fix(anthropic): key the /v1/messages prompt cache on Claude Code's session_id only

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/utils.py
+++ b/litellm/llms/anthropic/experimental_pass_through/utils.py
@@ -3,6 +3,8 @@ from collections.abc import Mapping
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Final
 
+from pydantic import BaseModel, ConfigDict, ValidationError
+
 import litellm
 from litellm.types.utils import ModelInfo
 
@@ -21,10 +23,27 @@ _EFFORT_DEGRADATION_CHAIN: Final[Mapping[str, tuple[str, ...]]] = MappingProxyTy
 _THINKING_OFF: Final = "none"
 
 
+class _ClaudeCodeUserId(BaseModel):
+    """The JSON Claude Code packs into ``metadata.user_id``; only ``session_id`` is per conversation."""
+
+    model_config = ConfigDict(frozen=True)
+
+    session_id: str
+
+
 def prompt_cache_key_from_user_id(user_id: object) -> str | None:
-    if user_id is None:
+    """The per-session key Claude Code carries inside ``metadata.user_id``, or nothing.
+
+    Anthropic defines ``user_id`` as an opaque end-user id, so a plain string names a person, not
+    a conversation. Keying the provider cache on it pins every parallel session and subagent of that
+    person to one slot, which caches worse than the provider's own prompt-prefix hashing does.
+    """
+    if not isinstance(user_id, str):
         return None
-    return str(user_id)[:OPENAI_MAX_PROMPT_CACHE_KEY_LENGTH] or None
+    try:
+        return _ClaudeCodeUserId.model_validate_json(user_id).session_id[:OPENAI_MAX_PROMPT_CACHE_KEY_LENGTH] or None
+    except ValidationError:
+        return None
 
 
 def litellm_logging_obj_from_kwargs(kwargs: Mapping[str, object]) -> "LiteLLMLoggingObject | None":

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -1,4 +1,5 @@
 import base64
+import json
 from typing import Any, Final, cast
 
 import pytest
@@ -724,9 +725,14 @@ def test_translate_anthropic_to_openai_orders_top_level_and_midturn_system():
     ]
 
 
-def _translate_with_metadata(
-    model: str, metadata: dict[str, str], custom_llm_provider: str | None
-) -> dict[str, Any]:
+def _claude_code_user_id(session_id: str) -> str:
+    return json.dumps({"device_id": "d" * 64, "account_uuid": "", "session_id": session_id})
+
+
+CLAUDE_CODE_USER_ID: Final = _claude_code_user_id("session-abc")
+
+
+def _translate_with_metadata(model: str, metadata: dict[str, str], custom_llm_provider: str | None) -> dict[str, Any]:
     openai_request, _ = LiteLLMAnthropicMessagesAdapter().translate_anthropic_to_openai(
         anthropic_message_request={
             "model": model,
@@ -739,23 +745,51 @@ def _translate_with_metadata(
     return cast(dict[str, Any], openai_request)
 
 
-def test_translate_anthropic_to_openai_maps_user_id_to_prompt_cache_key_for_openai():
-    openai_request = _translate_with_metadata("openai/gpt-5.6-luna", {"user_id": "session-abc"}, "openai")
-    assert openai_request["user"] == "session-abc"
+def test_translate_anthropic_to_openai_maps_claude_code_session_id_to_prompt_cache_key_for_openai():
+    openai_request = _translate_with_metadata("openai/gpt-5.6-luna", {"user_id": CLAUDE_CODE_USER_ID}, "openai")
+    assert openai_request["user"] == CLAUDE_CODE_USER_ID
     assert openai_request["prompt_cache_key"] == "session-abc"
 
 
-def test_translate_anthropic_to_openai_truncates_prompt_cache_key_but_keeps_full_user():
-    long_id = "".join(str(i % 10) for i in range(100))
-    openai_request = _translate_with_metadata("openai/gpt-5.6-luna", {"user_id": long_id}, "openai")
-    assert openai_request["user"] == long_id
-    assert openai_request["prompt_cache_key"] == long_id[:64]
-    assert len(openai_request["prompt_cache_key"]) == 64
+def test_translate_anthropic_to_openai_gives_each_claude_code_session_its_own_prompt_cache_key():
+    """BerriAI/litellm#39145: the first 64 chars of Claude Code's user_id are the per-install device_id."""
+    keys = tuple(
+        _translate_with_metadata("openai/gpt-5.6-luna", {"user_id": _claude_code_user_id(session_id)}, "openai")[
+            "prompt_cache_key"
+        ]
+        for session_id in ("11111111-1111-1111-1111-111111111111", "22222222-2222-2222-2222-222222222222")
+    )
+    assert keys == ("11111111-1111-1111-1111-111111111111", "22222222-2222-2222-2222-222222222222")
+
+
+def test_translate_anthropic_to_openai_truncates_long_session_id_to_openai_limit():
+    long_session_id = "".join(str(i % 10) for i in range(100))
+    openai_request = _translate_with_metadata(
+        "openai/gpt-5.6-luna", {"user_id": _claude_code_user_id(long_session_id)}, "openai"
+    )
+    assert openai_request["prompt_cache_key"] == long_session_id[:64]
+
+
+@pytest.mark.parametrize(
+    "user_id",
+    [
+        "alice",
+        "".join(str(i % 10) for i in range(100)),
+        json.dumps({"device_id": "d" * 64, "account_uuid": ""}),
+        json.dumps({"session_id": ""}),
+        json.dumps({"session_id": 123}),
+        "{not json",
+    ],
+)
+def test_translate_anthropic_to_openai_keeps_plain_user_id_off_prompt_cache_key(user_id: str):
+    openai_request = _translate_with_metadata("openai/gpt-5.6-luna", {"user_id": user_id}, "openai")
+    assert openai_request["user"] == user_id
+    assert "prompt_cache_key" not in openai_request
 
 
 @pytest.mark.parametrize("model", ["azure/my-gpt-5-deployment", "my-gpt-5-deployment"])
 def test_translate_anthropic_to_openai_sets_prompt_cache_key_for_azure(model: str):
-    openai_request = _translate_with_metadata(model, {"user_id": "session-abc"}, "azure")
+    openai_request = _translate_with_metadata(model, {"user_id": CLAUDE_CODE_USER_ID}, "azure")
     assert openai_request["prompt_cache_key"] == "session-abc"
 
 
@@ -772,8 +806,8 @@ def test_translate_anthropic_to_openai_sets_prompt_cache_key_for_azure(model: st
 def test_translate_anthropic_to_openai_skips_prompt_cache_key_when_provider_lacks_it(
     model: str, custom_llm_provider: str
 ):
-    openai_request = _translate_with_metadata(model, {"user_id": "session-abc"}, custom_llm_provider)
-    assert openai_request["user"] == "session-abc"
+    openai_request = _translate_with_metadata(model, {"user_id": CLAUDE_CODE_USER_ID}, custom_llm_provider)
+    assert openai_request["user"] == CLAUDE_CODE_USER_ID
     assert "prompt_cache_key" not in openai_request
 
 
@@ -781,14 +815,14 @@ def test_translate_anthropic_to_openai_skips_prompt_cache_key_for_chained_litell
     assert "prompt_cache_key" in litellm.get_supported_openai_params(
         model="xai", custom_llm_provider="litellm_proxy"
     )
-    openai_request = _translate_with_metadata("litellm_proxy/xai", {"user_id": "session-abc"}, "litellm_proxy")
-    assert openai_request["user"] == "session-abc"
+    openai_request = _translate_with_metadata("litellm_proxy/xai", {"user_id": CLAUDE_CODE_USER_ID}, "litellm_proxy")
+    assert openai_request["user"] == CLAUDE_CODE_USER_ID
     assert "prompt_cache_key" not in openai_request
 
 
 def test_translate_anthropic_to_openai_skips_prompt_cache_key_without_provider():
-    openai_request = _translate_with_metadata("openai/gpt-5.6-luna", {"user_id": "session-abc"}, None)
-    assert openai_request["user"] == "session-abc"
+    openai_request = _translate_with_metadata("openai/gpt-5.6-luna", {"user_id": CLAUDE_CODE_USER_ID}, None)
+    assert openai_request["user"] == CLAUDE_CODE_USER_ID
     assert "prompt_cache_key" not in openai_request
 
 

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_handler_prompt_cache_key.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_handler_prompt_cache_key.py
@@ -1,3 +1,4 @@
+import json
 import os
 import sys
 
@@ -10,6 +11,7 @@ from litellm.llms.anthropic.experimental_pass_through.adapters.handler import (
 )
 
 MESSAGES = [{"role": "user", "content": "hello"}]
+CLAUDE_CODE_USER_ID = json.dumps({"device_id": "d" * 64, "account_uuid": "", "session_id": "session-abc"})
 
 
 def _prepare(model: str, extra_kwargs: dict[str, object], thinking: dict[str, object] | None = None):
@@ -17,7 +19,7 @@ def _prepare(model: str, extra_kwargs: dict[str, object], thinking: dict[str, ob
         max_tokens=1024,
         messages=MESSAGES,
         model=model,
-        metadata={"user_id": "session-abc"},
+        metadata={"user_id": CLAUDE_CODE_USER_ID},
         thinking=thinking,
         extra_kwargs=extra_kwargs,
     )
@@ -26,7 +28,7 @@ def _prepare(model: str, extra_kwargs: dict[str, object], thinking: dict[str, ob
 
 def test_prepare_completion_kwargs_derives_prompt_cache_key_for_openai_provider():
     completion_kwargs = _prepare("openai/gpt-5.6-luna", {"custom_llm_provider": "openai"})
-    assert completion_kwargs["user"] == "session-abc"
+    assert completion_kwargs["user"] == CLAUDE_CODE_USER_ID
     assert completion_kwargs["prompt_cache_key"] == "session-abc"
 
 
@@ -35,7 +37,7 @@ def test_prepare_completion_kwargs_prefers_explicit_prompt_cache_key_over_derive
         "openai/gpt-5.6-luna",
         {"custom_llm_provider": "openai", "prompt_cache_key": "explicit-key"},
     )
-    assert completion_kwargs["user"] == "session-abc"
+    assert completion_kwargs["user"] == CLAUDE_CODE_USER_ID
     assert completion_kwargs["prompt_cache_key"] == "explicit-key"
 
 
@@ -50,13 +52,13 @@ def test_prepare_completion_kwargs_skips_prompt_cache_key_without_provider_suppo
     model: str, extra_kwargs: dict[str, object]
 ):
     completion_kwargs = _prepare(model, extra_kwargs)
-    assert completion_kwargs["user"] == "session-abc"
+    assert completion_kwargs["user"] == CLAUDE_CODE_USER_ID
     assert "prompt_cache_key" not in completion_kwargs
 
 
 def test_prepare_completion_kwargs_skips_prompt_cache_key_for_chained_litellm_proxy():
     completion_kwargs = _prepare("litellm_proxy/xai", {"custom_llm_provider": "litellm_proxy"})
-    assert completion_kwargs["user"] == "session-abc"
+    assert completion_kwargs["user"] == CLAUDE_CODE_USER_ID
     assert "prompt_cache_key" not in completion_kwargs
 
 

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_handler.py
@@ -16,6 +16,7 @@ from litellm.llms.anthropic.experimental_pass_through.responses_adapters.handler
 )
 
 MESSAGES = [{"role": "user", "content": "hello"}]
+CLAUDE_CODE_USER_ID = json.dumps({"device_id": "d" * 64, "account_uuid": "", "session_id": "session-abc"})
 
 RESPONSES_SSE_BODY = (
     b"event: response.created\n"
@@ -30,7 +31,19 @@ RESPONSES_SSE_BODY = (
 )
 
 
-def test_build_responses_kwargs_derives_prompt_cache_key_from_user_id():
+def test_build_responses_kwargs_derives_prompt_cache_key_from_claude_code_session_id():
+    responses_kwargs = _build_responses_kwargs(
+        max_tokens=1024,
+        messages=MESSAGES,
+        model="openai/gpt-5.6-luna",
+        metadata={"user_id": CLAUDE_CODE_USER_ID},
+        extra_kwargs={"custom_llm_provider": "openai"},
+    )
+    assert responses_kwargs["user"] == CLAUDE_CODE_USER_ID[:64]
+    assert responses_kwargs["prompt_cache_key"] == "session-abc"
+
+
+def test_build_responses_kwargs_sets_no_prompt_cache_key_for_plain_user_id():
     responses_kwargs = _build_responses_kwargs(
         max_tokens=1024,
         messages=MESSAGES,
@@ -39,7 +52,7 @@ def test_build_responses_kwargs_derives_prompt_cache_key_from_user_id():
         extra_kwargs={"custom_llm_provider": "openai"},
     )
     assert responses_kwargs["user"] == "session-abc"
-    assert responses_kwargs["prompt_cache_key"] == "session-abc"
+    assert "prompt_cache_key" not in responses_kwargs
 
 
 def test_build_responses_kwargs_prefers_explicit_prompt_cache_key_over_derived():
@@ -47,10 +60,10 @@ def test_build_responses_kwargs_prefers_explicit_prompt_cache_key_over_derived()
         max_tokens=1024,
         messages=MESSAGES,
         model="openai/gpt-5.6-luna",
-        metadata={"user_id": "session-abc"},
+        metadata={"user_id": CLAUDE_CODE_USER_ID},
         extra_kwargs={"custom_llm_provider": "openai", "prompt_cache_key": "explicit-key"},
     )
-    assert responses_kwargs["user"] == "session-abc"
+    assert responses_kwargs["user"] == CLAUDE_CODE_USER_ID[:64]
     assert responses_kwargs["prompt_cache_key"] == "explicit-key"
 
 

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py
@@ -1113,17 +1113,34 @@ class TestTranslateRequestBroaderCoverage:
         kwargs = _ADAPTER.translate_request(req)
         assert len(kwargs["user"]) == 64
 
-    def test_metadata_user_id_mapped_to_prompt_cache_key(self):
-        req = _make_request(metadata={"user_id": "user-42"})
+    def test_metadata_claude_code_session_id_mapped_to_prompt_cache_key(self):
+        user_id = json.dumps({"device_id": "d" * 64, "account_uuid": "", "session_id": "session-42"})
+        req = _make_request(metadata={"user_id": user_id})
         kwargs = _ADAPTER.translate_request(req)
-        assert kwargs["prompt_cache_key"] == "user-42"
+        assert kwargs["user"] == user_id[:64]
+        assert kwargs["prompt_cache_key"] == "session-42"
 
-    def test_metadata_user_id_prompt_cache_key_truncated_to_first_64_chars(self):
-        long_id = "".join(str(i % 10) for i in range(100))
-        req = _make_request(metadata={"user_id": long_id})
+    def test_metadata_claude_code_sessions_get_distinct_prompt_cache_keys(self):
+        """BerriAI/litellm#39145: the first 64 chars of Claude Code's user_id are the per-install device_id."""
+        keys = tuple(
+            _ADAPTER.translate_request(
+                _make_request(
+                    metadata={"user_id": json.dumps({"device_id": "d" * 64, "account_uuid": "", "session_id": sid})}
+                )
+            )["prompt_cache_key"]
+            for sid in ("11111111-1111-1111-1111-111111111111", "22222222-2222-2222-2222-222222222222")
+        )
+        assert keys == ("11111111-1111-1111-1111-111111111111", "22222222-2222-2222-2222-222222222222")
+
+    @pytest.mark.parametrize(
+        "user_id",
+        ["user-42", "".join(str(i % 10) for i in range(100)), json.dumps({"device_id": "d" * 64}), "{not json"],
+    )
+    def test_metadata_plain_user_id_sets_no_prompt_cache_key(self, user_id: str):
+        req = _make_request(metadata={"user_id": user_id})
         kwargs = _ADAPTER.translate_request(req)
-        assert kwargs["prompt_cache_key"] == long_id[:64]
-        assert len(kwargs["prompt_cache_key"]) == 64
+        assert kwargs["user"] == user_id[:64]
+        assert "prompt_cache_key" not in kwargs
 
     def test_metadata_empty_user_id_sets_no_prompt_cache_key(self):
         req = _make_request(metadata={"user_id": ""})


### PR DESCRIPTION
## TLDR

Problem this solves:

- `/v1/messages` derived `prompt_cache_key` from the first 64 chars of `metadata.user_id`
- Claude Code packs JSON there, and its prefix is the per-install `device_id`
- So every session and subagent on one machine shared one cache key
- A plain end-user id pinned all of that user's conversations to one key too

How it solves it:

- Parse Claude Code's JSON and use its `session_id` as the key
- Send no `prompt_cache_key` when `user_id` is not that JSON
- The provider then falls back to its own prompt-prefix hashing
- An explicit `prompt_cache_key` from the client still wins, unchanged

## User Flow

Before: a developer running two Claude Code sessions through the proxy sees both land on the same OpenAI cache key, so they compete for one slot

1. Session A sends POST https://litellm-domain/v1/messages with `metadata.user_id` set to `{"device_id":"aaaa...","account_uuid":"","session_id":"1111..."}`
2. Session B sends the same POST with `session_id` `2222...` and the same `device_id`
3. Both reach OpenAI with `prompt_cache_key` equal to `{"device_id":"aaaa...` (the first 64 chars), and the session ids never make it into the key
4. A separate app sends the same POST with `metadata.user_id` set to `alice`, and OpenAI receives `prompt_cache_key: alice`, pinning every one of that user's conversations to one key

After: each session gets its own key, and non-Claude-Code clients get no key at all

1. Session A sends POST https://litellm-domain/v1/messages with the same Claude Code `metadata.user_id`
2. Session B sends the same POST with `session_id` `2222...`
3. OpenAI receives `prompt_cache_key: 1111...` for A and `prompt_cache_key: 2222...` for B; `user` still carries the full string
4. The `alice` request reaches OpenAI with `user: alice` and no `prompt_cache_key`, so OpenAI routes by hashing the prompt prefix as it did before v1.99.0

## Relevant issues

Fixes #39145

Supersedes #39165, which kept the plain-string fallback the issue author objected to

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup. One `openai/gpt-5.6` deployment behind `/v1/messages`, proxy started with `--detailed_debug` so the upstream request body lands in the log. The chat-completions bridge run adds `litellm_settings: use_chat_completions_url_for_anthropic_messages: true`; the Responses bridge run is the default routing for OpenAI

```bash
CC_UID() { printf '{"device_id":"%s","account_uuid":"","session_id":"%s"}' "$(printf 'a%.0s' $(seq 1 64))" "$1"; }
send() { curl -s http://localhost:4000/v1/messages -H 'x-api-key: sk-1234' -H 'anthropic-version: 2023-06-01' -H 'content-type: application/json' \
  --data "$(jq -nc --arg uid "$1" '{model:"gpt-5.6",max_tokens:16,messages:[{role:"user",content:"Say hi"}],metadata:{user_id:$uid}}')" \
  | jq -c '{model, text: .content[0].text, err: .error.message}'; }
for SID in 11111111-1111-1111-1111-111111111111 22222222-2222-2222-2222-222222222222; do send "$(CC_UID $SID)"; done
send alice
grep -oE "prompt_cache_key['\"]: *['\"][^'\"]{0,60}" proxy.log | grep -v REDACTED | sort | uniq -c
grep -cE "user['\"]: *['\"]alice" proxy.log
```

### Before (754a2afe12)

#### Responses bridge (default OpenAI routing)

1. Ran the three `send` calls above. All three returned 200 with `"text":"Hi!"`
2. Upstream keys in the log:
   ```
      2 prompt_cache_key": "{\
      1 prompt_cache_key": "alice
   ```
   Both Claude Code sessions collapsed onto the `{"device_id":"aaaa...` prefix, and `alice` became a cache key

#### Chat-completions bridge (`use_chat_completions_url_for_anthropic_messages: true`)

1. Ran the same three `send` calls. All three returned 200 with `"text":"Hi!"`
2. Upstream keys in the log:
   ```
      6 prompt_cache_key': '{
      3 prompt_cache_key': 'alice
   ```
   Same collapse. The debug log prints each body three times, hence the multiples

### After (634852a183)

#### Responses bridge (default OpenAI routing)

1. Ran the three `send` calls. All three returned 200 with `"text":"Hi!"`
2. Upstream keys in the log:
   ```
      2 prompt_cache_key': '11111111-1111-1111-1111-111111111111
      2 prompt_cache_key': '22222222-2222-2222-2222-222222222222
      1 prompt_cache_key": "11111111-1111-1111-1111-111111111111
      1 prompt_cache_key": "22222222-2222-2222-2222-222222222222
   ```
3. `grep -cE "user['\"]: *['\"]alice"` printed `3`, and no `prompt_cache_key: alice` line exists, so the plain id reached OpenAI as `user` only

#### Chat-completions bridge (`use_chat_completions_url_for_anthropic_messages: true`)

1. Ran the same three `send` calls. All three returned 200 with `"text":"Hi!"`
2. Upstream keys in the log:
   ```
      3 prompt_cache_key': '11111111-1111-1111-1111-111111111111
      3 prompt_cache_key': '22222222-2222-2222-2222-222222222222
   ```
3. `grep -cE "user['\"]: *['\"]alice"` printed `5`, and no `prompt_cache_key: alice` line exists

## Type

🐛 Bug Fix

## Caveats (if any)

### Severe

- Behavior change from v1.99.0 (#37623): a plain-string `metadata.user_id` no longer becomes `prompt_cache_key`
  - Clients that relied on that get OpenAI's default prompt-prefix hashing instead, which is the pre-1.99.0 behavior
  - A client that wants a key can still send `prompt_cache_key` explicitly; both bridges honor it unchanged

### Low

- Only Claude Code's `session_id` shape is recognized; any other JSON in `user_id` yields no key
- `session_id` longer than 64 chars is still truncated to OpenAI's limit

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior change for plain-string `metadata.user_id` (no auto `prompt_cache_key` since v1.99.0); affects OpenAI/Azure routing for non–Claude Code clients but is intentional and documented.
> 
> **Overview**
> Fixes **incorrect `prompt_cache_key` derivation** for Anthropic `/v1/messages` when bridging to OpenAI/Azure: upstream caching no longer keys on the first 64 characters of `metadata.user_id` or on plain end-user strings.
> 
> **`prompt_cache_key_from_user_id`** now parses Claude Code’s JSON `user_id` (via a small Pydantic model) and uses **`session_id`** (truncated to 64 chars). Invalid JSON, missing `session_id`, or non-string `user_id` yields **no** derived key so providers can fall back to prompt-prefix hashing. The full `user_id` still flows as `user` unchanged; an explicit client **`prompt_cache_key`** still wins.
> 
> Tests across the chat-completions and Responses bridges were updated for per-session keys, truncation, and the regression where parallel Claude Code sessions shared one cache slot (#39145).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 634852a18309a97f8cb24f18fabd48bb0b80c6a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->