### PR TITLE
test(mcp): fix proxy fixture isolation after manager reload

### DIFF
--- a/tests/test_litellm/proxy/_experimental/mcp_server/conftest.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/conftest.py
@@ -2,15 +2,15 @@ import os
 
 import pytest
 
-from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
-    global_mcp_server_manager,
-)
-
 
 @pytest.fixture(autouse=True)
 def _hermetic_mcp_server_registry():
     """Restore the singleton ``global_mcp_server_manager``'s registry state around every
     test, so entries seeded by one test never leak into another on a shared shard."""
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        global_mcp_server_manager,
+    )
+
     saved_registry = dict(global_mcp_server_manager.registry)
     saved_config_servers = dict(global_mcp_server_manager.config_mcp_servers)
     saved_tool_mapping = dict(global_mcp_server_manager.tool_name_to_mcp_server_name_mapping)

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_proxy_mode.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_proxy_mode.py
@@ -7,7 +7,6 @@ from mcp.types import CallToolResult, TextContent, Tool
 
 from litellm.proxy._experimental.mcp_server import server
 from litellm.proxy._experimental.mcp_server.faults.list_outcomes import AggregateToolListing
-from litellm.proxy._experimental.mcp_server.mcp_server_manager import global_mcp_server_manager
 from litellm.proxy._experimental.mcp_server.tool_search import (
     MCP_PROXY_CALL_TOOL_NAME,
     MCP_PROXY_SCHEMA_TOOL_NAME,
@@ -271,6 +270,8 @@ class TestMcpProxyAuthorizationScope:
 
     @pytest.fixture
     def rig(self) -> Iterator[AsyncMock]:
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import global_mcp_server_manager
+
         upstream = {
             "srv-alpha": [_upstream_tool("alpha", "add"), _upstream_tool("alpha", "multiply")],
             "srv-beta": [_upstream_tool("beta", "add")],


### PR DESCRIPTION
## TLDR

Problem this solves:

- MCP proxy tests fail after another test reloads the manager

How it solves it:

- Resolve the current manager when each fixture starts
- Restore that same manager during fixture cleanup

The fixture added in #40298 captured the manager at collection time. Existing separator tests reload its module, leaving the fixture seeding and mocking an obsolete instance. Move the imports inside the proxy fixture and shared registry cleanup fixture

## User Flow

Before: a contributor sees four MCP failures depending on worker assignment

1. Run the proxy-infra CI job
2. Observe empty tool results and a 403 when tests share a worker

After: the same tests use the current manager after a reload

1. Run the proxy-infra CI job
2. Observe the expected tools and successful authorization assertions

## Relevant issues

[Failing job on #40334](https://github.com/BerriAI/litellm/actions/runs/34296957159/job/102295558622?pr=40334)

## Linear ticket

## Pre-Submission checklist

- [ ] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible
- [ ] Greptile has independently posted 5/5 for the current head

## Validation

Existing authorization assertions are unchanged

- Both affected test modules together on one worker: 588 passed
- Separator test forced before all proxy mode tests at fb21852f7b: 13 passed; the same sequence at the base had four failures
- Local lint and test-quality checks: passed
- Current-head CI and Greptile: pending

## Screenshots / Proof of Fix

This change only repairs test fixtures. There is no application behavior change requiring a live proxy demonstration

### Before (314e573529897752c882be9aac4985931bcc26bc)

1. Run the separator test before the proxy mode tests on one worker
2. Observe four failures, matching the linked CI job

### After (fb21852f7bc5ba2a1d79a89b5d46a1ec6fc1e56d)

1. Run the same sequence on one worker
2. Observe all 13 tests passing, including the four previously failing cases

## Type

Test

## Caveats (if any)

## Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
