### PR TITLE
fix(anthropic): preserve reasoning encrypted_content across /v1/messages turns

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -1909,15 +1909,11 @@ def _responses_reasoning_item(
     summary_list: Final = list(summary)  # mutable-ok: Responses API summary is a json list
     match (item_id, encrypted_content):
         case (str() as rid, str() as blob):
-            return ChatCompletionReasoningItem(
-                type="reasoning", id=rid, encrypted_content=blob, summary=summary_list
-            )
+            return ChatCompletionReasoningItem(type="reasoning", id=rid, encrypted_content=blob, summary=summary_list)
         case (str() as rid, None):
             return ChatCompletionReasoningItem(type="reasoning", id=rid, summary=summary_list)
         case (None, str() as blob):
-            return ChatCompletionReasoningItem(
-                type="reasoning", encrypted_content=blob, summary=summary_list
-            )
+            return ChatCompletionReasoningItem(type="reasoning", encrypted_content=blob, summary=summary_list)
         case _:
             return ChatCompletionReasoningItem(type="reasoning", summary=summary_list)
 

--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -2,6 +2,7 @@
 Common utility functions used for translating messages across providers
 """
 
+import base64
 import io
 import json
 import mimetypes
@@ -1843,22 +1844,103 @@ def reasoning_content_from_thinking_blocks(
     return "\n".join(text for block in thinking_blocks if (text := _readable_thinking_text(block)))
 
 
+_RESPONSES_REASONING_SIGNATURE_PREFIX: Final = "lllm-rsenc-v1:"
+
+
+def pack_responses_reasoning_signature(item_id: str | None, encrypted_content: str | None) -> str | None:
+    """Pack a Responses reasoning `id` + `encrypted_content` into an Anthropic thinking signature.
+
+    The client must echo `signature` unmodified. A fabricated id 404s upstream, so id is only
+    written when the provider minted one. No signature is invented from summary text alone.
+    """
+    if not encrypted_content:
+        return None
+    payload: Final = {"id": item_id, "ec": encrypted_content} if item_id else {"ec": encrypted_content}
+    encoded: Final = base64.b64encode(json.dumps(payload, separators=(",", ":")).encode()).decode()
+    return f"{_RESPONSES_REASONING_SIGNATURE_PREFIX}{encoded}"
+
+
+def unpack_responses_reasoning_signature(signature: str) -> tuple[str | None, str | None]:
+    """Restore `(id, encrypted_content)` from a packed thinking signature, else `(None, None)`.
+
+    Native Anthropic signatures and fabricated stand-ins fail closed so they are never sent
+    upstream as `encrypted_content`.
+    """
+    if not signature.startswith(_RESPONSES_REASONING_SIGNATURE_PREFIX):
+        return None, None
+    raw: Final = signature[len(_RESPONSES_REASONING_SIGNATURE_PREFIX) :]
+    try:
+        payload: Final[object] = json.loads(base64.b64decode(raw, validate=True))
+    except (ValueError, json.JSONDecodeError):
+        return None, None
+    if not isinstance(payload, dict):
+        return None, None
+    item_id: Final = payload.get("id")
+    encrypted_content: Final = payload.get("ec")
+    return (
+        item_id if isinstance(item_id, str) and item_id else None,
+        encrypted_content if isinstance(encrypted_content, str) and encrypted_content else None,
+    )
+
+
+def is_responses_reasoning_thinking_signature(signature: str) -> bool:
+    """True when `signature` is a packed Responses replay blob, not an Anthropic signature."""
+    return signature.startswith(_RESPONSES_REASONING_SIGNATURE_PREFIX)
+
+
+def _reasoning_replay_fields_from_thinking_blocks(
+    thinking_blocks: Iterable[ChatCompletionThinkingBlock | ChatCompletionRedactedThinkingBlock],
+) -> tuple[str | None, str | None]:
+    for block in thinking_blocks:
+        signature: Final = block.get("signature") if isinstance(block, Mapping) else None
+        if not isinstance(signature, str) or not signature:
+            continue
+        item_id, encrypted_content = unpack_responses_reasoning_signature(signature)
+        if item_id is not None or encrypted_content is not None:
+            return item_id, encrypted_content
+    return None, None
+
+
+def _responses_reasoning_item(
+    summary: tuple[ChatCompletionReasoningSummaryTextBlock, ...],
+    item_id: str | None,
+    encrypted_content: str | None,
+) -> ChatCompletionReasoningItem:
+    summary_list: Final = list(summary)  # mutable-ok: Responses API summary is a json list
+    match (item_id, encrypted_content):
+        case (str() as rid, str() as blob):
+            return ChatCompletionReasoningItem(
+                type="reasoning", id=rid, encrypted_content=blob, summary=summary_list
+            )
+        case (str() as rid, None):
+            return ChatCompletionReasoningItem(type="reasoning", id=rid, summary=summary_list)
+        case (None, str() as blob):
+            return ChatCompletionReasoningItem(
+                type="reasoning", encrypted_content=blob, summary=summary_list
+            )
+        case _:
+            return ChatCompletionReasoningItem(type="reasoning", summary=summary_list)
+
+
 def responses_reasoning_item_from_thinking_blocks(
     thinking_blocks: Iterable[ChatCompletionThinkingBlock | ChatCompletionRedactedThinkingBlock],
 ) -> ChatCompletionReasoningItem | None:
     """Build a Responses API `reasoning` input item from Anthropic thinking blocks.
 
-    The item carries no `id`: the Responses API rejects an empty one and 404s on any id it
-    did not mint itself, while an item without an id is always accepted.
+    A packed thinking `signature` restores the original `id` and `encrypted_content` so the
+    item is byte-stable across turns. A fabricated id 404s, so an unpacked miss omits those
+    fields. Summary-only text is never used to invent a new reasoning item identity.
     """
-    summary: Final[list[ChatCompletionReasoningSummaryTextBlock]] = [  # mutable-ok: API message payload
+    blocks: Final = tuple(thinking_blocks)
+    summary: Final = tuple(
         ChatCompletionReasoningSummaryTextBlock(type="summary_text", text=text)
-        for block in thinking_blocks
+        for block in blocks
         if (text := _readable_thinking_text(block))
-    ]
-    if not summary:
+    )
+    item_id, encrypted_content = _reasoning_replay_fields_from_thinking_blocks(blocks)
+    if not summary and encrypted_content is None:
         return None
-    return ChatCompletionReasoningItem(type="reasoning", summary=summary)
+    return _responses_reasoning_item(summary, item_id, encrypted_content)
 
 
 def _parse_content_for_reasoning(

--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -1855,8 +1855,12 @@ def pack_responses_reasoning_signature(item_id: str | None, encrypted_content: s
     """
     if not encrypted_content:
         return None
-    payload: Final = {"id": item_id, "ec": encrypted_content} if item_id else {"ec": encrypted_content}
-    encoded: Final = base64.b64encode(json.dumps(payload, separators=(",", ":")).encode()).decode()
+    body: Final = (
+        f'{{"id":{json.dumps(item_id)},"ec":{json.dumps(encrypted_content)}}}'
+        if item_id
+        else f'{{"ec":{json.dumps(encrypted_content)}}}'
+    )
+    encoded: Final = base64.b64encode(body.encode()).decode()
     return f"{_RESPONSES_REASONING_SIGNATURE_PREFIX}{encoded}"
 
 

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -47,6 +47,7 @@ from .common_utils import (
     convert_content_list_to_str,
     infer_content_type_from_url_and_content,
     is_non_content_values_set,
+    is_responses_reasoning_thinking_signature,
     parse_tool_call_arguments,
 )
 from .image_handling import convert_url_to_base64
@@ -2309,7 +2310,9 @@ def _is_unsignable_thinking_block(block: object) -> bool:
     if not isinstance(block, dict) or block.get("type") != "thinking":
         return False
     signature: Final = block.get("signature")
-    return not (isinstance(signature, str) and len(signature) > 0)
+    if not (isinstance(signature, str) and len(signature) > 0):
+        return True
+    return is_responses_reasoning_thinking_signature(signature)
 
 
 def _drop_unsignable_thinking_blocks(

--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
@@ -609,7 +609,7 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
             )
             if reasoning:
                 responses_kwargs["reasoning"] = reasoning
-                responses_kwargs["include"] = ["reasoning.encrypted_content"]
+                responses_kwargs["include"] = ("reasoning.encrypted_content",)
 
         # output_format / output_config.format -> text format
         # output_format: {"type": "json_schema", "schema": {...}}

--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
@@ -13,6 +13,7 @@ from typing import Any, Final, cast
 from litellm.litellm_core_utils.prompt_templates.common_utils import (
     TOOL_RESULT_IMAGE_BOUNDARY,
     TOOL_RESULT_IMAGE_PLACEHOLDER,
+    pack_responses_reasoning_signature,
     responses_reasoning_item_from_thinking_blocks,
     with_prompt_cache_breakpoint,
 )
@@ -162,24 +163,60 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
             return str(mapping.get("text") or "")
         return str(getattr(part, "text", None) or "")
 
+    @staticmethod
+    def _optional_str_field(value: object) -> str | None:
+        return value if isinstance(value, str) and value else None
+
+    @classmethod
+    def _reasoning_replay_fields(cls, item: object) -> tuple[str | None, str | None]:
+        if isinstance(item, Mapping):
+            mapping: Final = cast(Mapping[str, object], item)  # cast-ok: untyped provider json
+            return (
+                cls._optional_str_field(mapping.get("id")),
+                cls._optional_str_field(mapping.get("encrypted_content")),
+            )
+        return (
+            cls._optional_str_field(getattr(item, "id", None)),
+            cls._optional_str_field(getattr(item, "encrypted_content", None)),
+        )
+
     @classmethod
     def _thinking_blocks_from_reasoning_item(
         cls,
-        summary: Iterable[object],
+        item: object,
     ) -> tuple[dict[str, Any], ...]:  # mutable-ok: API message payload
         """Anthropic thinking blocks for one Responses reasoning item.
 
-        The signature stays empty: only Anthropic can sign a thinking block, and a stand-in
-        value would be replayed as a real one and rejected by every backend that verifies it.
+        `encrypted_content` (and the provider-minted `id`) are packed into `signature` so
+        the client can echo them back. A stand-in is never invented from `id` or summary
+        text alone: that would be rejected by every backend that verifies signatures.
         """
+        raw_summary: Final = (
+            cast(Mapping[str, object], item).get("summary")  # cast-ok: untyped provider json
+            if isinstance(item, Mapping)
+            else getattr(item, "summary", None)
+        )
+        summary: Final = raw_summary or ()
+        item_id, encrypted_content = cls._reasoning_replay_fields(item)
+        signature: Final = pack_responses_reasoning_signature(item_id, encrypted_content)
+        texts: Final = tuple(text for part in summary if (text := cls._summary_part_text(part)))
+        if not texts:
+            if signature is None:
+                return ()
+            return (
+                AnthropicResponseContentBlockThinking(
+                    type="thinking",
+                    thinking="",
+                    signature=signature,
+                ).model_dump(),
+            )
         return tuple(
             AnthropicResponseContentBlockThinking(
                 type="thinking",
                 thinking=text,
-                signature=None,
+                signature=signature,
             ).model_dump()
-            for part in summary
-            if (text := cls._summary_part_text(part))
+            for text in texts
         )
 
     @staticmethod
@@ -572,6 +609,7 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
             )
             if reasoning:
                 responses_kwargs["reasoning"] = reasoning
+                responses_kwargs["include"] = ["reasoning.encrypted_content"]
 
         # output_format / output_config.format -> text format
         # output_format: {"type": "json_schema", "schema": {...}}
@@ -634,7 +672,7 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
 
         for item in response.output:
             if isinstance(item, ResponseReasoningItem):
-                content.extend(self._thinking_blocks_from_reasoning_item(item.summary))
+                content.extend(self._thinking_blocks_from_reasoning_item(item))
 
             elif isinstance(item, ResponseOutputMessage):
                 for part in item.content:
@@ -684,11 +722,7 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
                                     ).model_dump()
                                 )
                 elif item_type == "reasoning":
-                    content.extend(
-                        self._thinking_blocks_from_reasoning_item(
-                            cast(Iterable[object], item.get("summary") or ()),  # cast-ok: untyped provider json
-                        )
-                    )
+                    content.extend(self._thinking_blocks_from_reasoning_item(item))
                 elif item_type == "function_call":
                     try:
                         input_data = json.loads(item.get("arguments", "{}"))

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_common_utils.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_common_utils.py
@@ -1554,3 +1554,106 @@ class TestRequestContainsImageContent:
         for _ in range(50):
             nested = {"type": "tool_result", "content": [nested]}
         assert request_contains_image_content([{"role": "user", "content": [nested]}]) is False
+
+
+class TestResponsesReasoningItemFromThinkingBlocks:
+    def test_summary_only_blocks_do_not_invent_id_or_encrypted_content(self):
+        from litellm.litellm_core_utils.prompt_templates.common_utils import (
+            responses_reasoning_item_from_thinking_blocks,
+        )
+
+        item = responses_reasoning_item_from_thinking_blocks(
+            [{"type": "thinking", "thinking": "Computing 12*13 via distribution."}]
+        )
+        assert item == {
+            "type": "reasoning",
+            "summary": [{"type": "summary_text", "text": "Computing 12*13 via distribution."}],
+        }
+        assert "id" not in item
+        assert "encrypted_content" not in item
+
+    def test_foreign_signature_is_not_replayed_as_encrypted_content(self):
+        from litellm.litellm_core_utils.prompt_templates.common_utils import (
+            responses_reasoning_item_from_thinking_blocks,
+        )
+
+        item = responses_reasoning_item_from_thinking_blocks(
+            [
+                {
+                    "type": "thinking",
+                    "thinking": "Private reasoning.",
+                    "signature": "rs_abc123",
+                }
+            ]
+        )
+        assert item is not None
+        assert "id" not in item
+        assert "encrypted_content" not in item
+
+    def test_packed_signature_restores_encrypted_content_and_id(self):
+        from litellm.litellm_core_utils.prompt_templates.common_utils import (
+            pack_responses_reasoning_signature,
+            responses_reasoning_item_from_thinking_blocks,
+        )
+
+        signature = pack_responses_reasoning_signature(
+            "rs_07db33a5c961deeb016aa06e634e1087d2914097f0ed2016c7",
+            "gAAAAABp-encrypted-content-blob",
+        )
+        item = responses_reasoning_item_from_thinking_blocks(
+            [
+                {
+                    "type": "thinking",
+                    "thinking": "Computing 12*13 via distribution.",
+                    "signature": signature,
+                }
+            ]
+        )
+        assert item == {
+            "type": "reasoning",
+            "id": "rs_07db33a5c961deeb016aa06e634e1087d2914097f0ed2016c7",
+            "encrypted_content": "gAAAAABp-encrypted-content-blob",
+            "summary": [{"type": "summary_text", "text": "Computing 12*13 via distribution."}],
+        }
+
+    def test_restored_reasoning_item_is_cache_stable_across_calls(self):
+        from litellm.litellm_core_utils.prompt_templates.common_utils import (
+            pack_responses_reasoning_signature,
+            responses_reasoning_item_from_thinking_blocks,
+        )
+
+        blocks = (
+            {
+                "type": "thinking",
+                "thinking": "Computing 12*13 via distribution.",
+                "signature": pack_responses_reasoning_signature("rs_stable", "gAAAAABp-stable"),
+            },
+        )
+        first = responses_reasoning_item_from_thinking_blocks(blocks)
+        second = responses_reasoning_item_from_thinking_blocks(blocks)
+        assert first == second
+        assert first is not None
+        assert first["id"] == "rs_stable"
+        assert first["encrypted_content"] == "gAAAAABp-stable"
+
+    def test_signature_only_block_restores_encrypted_content_without_summary_text(self):
+        from litellm.litellm_core_utils.prompt_templates.common_utils import (
+            pack_responses_reasoning_signature,
+            responses_reasoning_item_from_thinking_blocks,
+        )
+
+        item = responses_reasoning_item_from_thinking_blocks(
+            [
+                {
+                    "type": "thinking",
+                    "thinking": "",
+                    "signature": pack_responses_reasoning_signature("rs_empty", "gAAAAABp-empty"),
+                }
+            ]
+        )
+        assert item == {
+            "type": "reasoning",
+            "id": "rs_empty",
+            "encrypted_content": "gAAAAABp-empty",
+            "summary": [],
+        }

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -258,6 +258,40 @@ def test_anthropic_messages_pt_keeps_signed_thinking_block():
     assert thinking_blocks[0]["thinking"] == "genuine anthropic reasoning"
 
 
+def test_anthropic_messages_pt_drops_packed_responses_reasoning_signature():
+    """OpenAI encrypted_content packed into signature is not an Anthropic signature."""
+    from litellm.litellm_core_utils.prompt_templates.common_utils import (
+        pack_responses_reasoning_signature,
+    )
+
+    packed_block = {
+        "type": "thinking",
+        "thinking": "openai reasoning",
+        "signature": pack_responses_reasoning_signature("rs_abc", "gAAAAABp-blob"),
+    }
+    messages = [
+        {"role": "user", "content": "What is 2+2?"},
+        {
+            "role": "assistant",
+            "content": "2+2 equals 4.",
+            "thinking_blocks": [packed_block],
+        },
+        {"role": "user", "content": "Now what is 3+3?"},
+    ]
+
+    result = anthropic_messages_pt(
+        messages=messages, model="claude-sonnet-4-6", llm_provider="anthropic"
+    )
+
+    assistant = next(m for m in result if m["role"] == "assistant")
+    content = assistant["content"]
+    assert all(block.get("type") != "thinking" for block in content)
+    assert any(
+        block.get("type") == "text" and block.get("text") == "2+2 equals 4."
+        for block in content
+    )
+
+
 def test_convert_to_azure_openai_messages():
     """Test coverting image_url to azure_openai spec"""
 

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py
@@ -1096,11 +1096,13 @@ class TestTranslateRequestBroaderCoverage:
         # reasoning_auto_summary is False by default, so no summary key
         assert kwargs["reasoning"] == {"effort": "high"}
         assert "summary" not in kwargs["reasoning"]
+        assert kwargs["include"] == ["reasoning.encrypted_content"]
 
     def test_disabled_thinking_not_included_in_kwargs(self):
         req = _make_request(thinking={"type": "disabled"})
         kwargs = _ADAPTER.translate_request(req)
         assert "reasoning" not in kwargs
+        assert "include" not in kwargs
 
     def test_metadata_user_id_mapped_to_user(self):
         req = _make_request(metadata={"user_id": "user-42"})
@@ -1246,7 +1248,11 @@ def _make_function_call_item(call_id: str, name: str, arguments: str) -> MagicMo
     return item
 
 
-def _make_reasoning_item(summaries: List[str], item_id: str = "rs_test_1") -> MagicMock:
+def _make_reasoning_item(
+    summaries: List[str],
+    item_id: str = "rs_test_1",
+    encrypted_content: str | None = None,
+) -> MagicMock:
     """Build a mock ResponseReasoningItem."""
     from openai.types.responses import ResponseReasoningItem  # type: ignore[import]
 
@@ -1259,6 +1265,7 @@ def _make_reasoning_item(summaries: List[str], item_id: str = "rs_test_1") -> Ma
     item = MagicMock(spec=ResponseReasoningItem)
     item.id = item_id
     item.summary = summary_mocks
+    item.encrypted_content = encrypted_content
     return item
 
 
@@ -1382,11 +1389,94 @@ class TestTranslateResponse:
         assert result["content"] == []
 
     def test_reasoning_item_id_never_becomes_a_thinking_signature(self):
-        """Only Anthropic can sign a thinking block, so a stand-in signature is never invented."""
+        """An id alone is not a signature. Only encrypted_content is packed into one."""
         reasoning = _make_reasoning_item(["Part one.", "Part two."], item_id="rs_abc123")
         response = _make_mock_response(output=[reasoning])
         result: Any = _ADAPTER.translate_response(response)
         assert [block["signature"] for block in result["content"]] == [None, None]
+
+    def test_encrypted_content_is_packed_into_thinking_signature(self):
+        reasoning = _make_reasoning_item(
+            ["Computing 12*13 via distribution."],
+            item_id="rs_07db33a5c961deeb016aa06e634e1087d2914097f0ed2016c7",
+            encrypted_content="gAAAAABp-encrypted-content-blob",
+        )
+        response = _make_mock_response(output=[reasoning])
+        result: Any = _ADAPTER.translate_response(response)
+        from litellm.litellm_core_utils.prompt_templates.common_utils import (
+            unpack_responses_reasoning_signature,
+        )
+
+        assert len(result["content"]) == 1
+        item_id, encrypted_content = unpack_responses_reasoning_signature(result["content"][0]["signature"])
+        assert item_id == "rs_07db33a5c961deeb016aa06e634e1087d2914097f0ed2016c7"
+        assert encrypted_content == "gAAAAABp-encrypted-content-blob"
+
+    def test_dict_reasoning_item_packs_encrypted_content_into_signature(self):
+        response = _make_mock_response(
+            output=[
+                {
+                    "type": "reasoning",
+                    "id": "rs_dict_enc_1",
+                    "encrypted_content": "gAAAAABp-dict-blob",
+                    "summary": [{"type": "summary_text", "text": "Weighing the options."}],
+                }
+            ]
+        )
+        result: Any = _ADAPTER.translate_response(response)
+        from litellm.litellm_core_utils.prompt_templates.common_utils import (
+            unpack_responses_reasoning_signature,
+        )
+
+        item_id, encrypted_content = unpack_responses_reasoning_signature(result["content"][0]["signature"])
+        assert item_id == "rs_dict_enc_1"
+        assert encrypted_content == "gAAAAABp-dict-blob"
+
+    def test_reasoning_item_round_trip_is_cache_stable(self):
+        """Turn-2 replay must send the same reasoning item bytes OpenAI minted on turn 1."""
+        reasoning = _make_reasoning_item(
+            ["Computing 12*13 via distribution."],
+            item_id="rs_07db33a5c961deeb016aa06e634e1087d2914097f0ed2016c7",
+            encrypted_content="gAAAAABp-encrypted-content-blob",
+        )
+        anthropic = _ADAPTER.translate_response(_make_mock_response(output=[reasoning]))
+        replay = [
+            {
+                "role": "assistant",
+                "content": anthropic["content"],
+            }
+        ]
+        first = _ADAPTER.translate_messages_to_responses_input(replay)
+        second = _ADAPTER.translate_messages_to_responses_input(replay)
+        assert first == second
+        assert first == [
+            {
+                "type": "reasoning",
+                "id": "rs_07db33a5c961deeb016aa06e634e1087d2914097f0ed2016c7",
+                "encrypted_content": "gAAAAABp-encrypted-content-blob",
+                "summary": [{"type": "summary_text", "text": "Computing 12*13 via distribution."}],
+            }
+        ]
+
+    def test_encrypted_content_without_summary_still_round_trips(self):
+        reasoning = _make_reasoning_item(
+            [""],
+            item_id="rs_empty_summary",
+            encrypted_content="gAAAAABp-no-summary",
+        )
+        anthropic = _ADAPTER.translate_response(_make_mock_response(output=[reasoning]))
+        assert anthropic["content"][0]["thinking"] == ""
+        replayed = _ADAPTER.translate_messages_to_responses_input(
+            [{"role": "assistant", "content": anthropic["content"]}]
+        )
+        assert replayed == [
+            {
+                "type": "reasoning",
+                "id": "rs_empty_summary",
+                "encrypted_content": "gAAAAABp-no-summary",
+                "summary": [],
+            }
+        ]
 
     def test_dict_reasoning_item_becomes_thinking_block(self):
         """A reasoning item arriving as a plain dict is kept, not dropped."""
@@ -1410,6 +1500,24 @@ class TestTranslateResponse:
 
         response = _make_mock_response(output=[_make_reasoning_item(["Part one."], item_id="rs_abc123")])
         result: Any = _ADAPTER.translate_response(response)
+        assert _drop_unsignable_thinking_blocks(result["content"]) == []
+
+    def test_packed_reasoning_signature_is_dropped_when_replayed_to_anthropic(self):
+        from litellm.litellm_core_utils.prompt_templates.factory import (
+            _drop_unsignable_thinking_blocks,
+        )
+
+        response = _make_mock_response(
+            output=[
+                _make_reasoning_item(
+                    ["Part one."],
+                    item_id="rs_abc123",
+                    encrypted_content="gAAAAABp-encrypted-content-blob",
+                )
+            ]
+        )
+        result: Any = _ADAPTER.translate_response(response)
+        assert result["content"][0]["signature"]
         assert _drop_unsignable_thinking_blocks(result["content"]) == []
 
     def test_usage_mapped_correctly(self):

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py
@@ -1096,7 +1096,7 @@ class TestTranslateRequestBroaderCoverage:
         # reasoning_auto_summary is False by default, so no summary key
         assert kwargs["reasoning"] == {"effort": "high"}
         assert "summary" not in kwargs["reasoning"]
-        assert kwargs["include"] == ["reasoning.encrypted_content"]
+        assert kwargs["include"] == ("reasoning.encrypted_content",)
 
     def test_disabled_thinking_not_included_in_kwargs(self):
         req = _make_request(thinking={"type": "disabled"})


### PR DESCRIPTION
Fixes #40288

## Problem

Behind `/v1/messages`, OpenAI reasoning items were rebuilt from lossy thinking summary text on later turns, so prompt-cache prefixes were not byte-stable.

## Fix

Aligned with the #40198-style “cross-turn byte stability” approach for reasoning/thinking:

1. `translate_response`: pack OpenAI `encrypted_content` + minted `id` into Anthropic `thinking.signature` (`lllm-rsenc-v1:`…).
2. `responses_reasoning_item_from_thinking_blocks`: restore `encrypted_content` / `id` from that signature instead of summary-only rebuild.
3. When thinking is enabled, request `include: ["reasoning.encrypted_content"]`. Packed signatures are stripped before sending to Anthropic to avoid fake-signature 400s.

## Tests

Focused unit coverage for outbound pack, inbound restore, and two-call byte identity (agent run: related suites green).

Does not touch #39515 / #40194.
