### PR TITLE
feat(router): support percentile-based TTFT routing

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -1317,6 +1317,43 @@ class Router:
         if isinstance(litellm.input_callback, list):
             litellm.input_callback = [c for c in litellm.input_callback if id(c) not in selector_ids]
 
+    def _apply_updated_routing_strategy_args(self) -> None:
+        """
+        Re-link the default group's selector to the current `routing_strategy_args`.
+
+        Selectors freeze their `RoutingArgs` at construction, so a runtime args
+        update would otherwise keep serving the boot-time values until restart.
+        Latency/usage state survives the rebuild: it lives in the shared router
+        cache, not on the selector.
+        """
+        strategy: Final = self._normalize_strategy(self.routing_strategy)
+        if strategy == "lar1":
+            from litellm.router_strategy.lar1_routing import apply_lar1_routing_strategy
+
+            apply_lar1_routing_strategy(self, self.routing_strategy_args)
+            return
+
+        attr: Final = self._DEFAULT_SELECTOR_ATTR_BY_STRATEGY.get(strategy or "")
+        current: Final = getattr(self, attr, None) if attr is not None else None
+        if attr is None or current is None:
+            return
+
+        try:
+            rebuilt: Final = self._build_strategy_selector(
+                strategy=strategy or "",
+                routing_strategy_args=self.routing_strategy_args,
+            )
+        except (TypeError, ValidationError):
+            verbose_router_logger.exception(
+                "Invalid routing_strategy_args %s for '%s'; keeping the previous ones",
+                self.routing_strategy_args,
+                strategy,
+            )
+            return
+
+        self._unregister_router_selectors((current,))
+        setattr(self, attr, rebuilt)
+
     def routing_strategy_init(self, routing_strategy: RoutingStrategy | str, routing_strategy_args: dict):
         verbose_router_logger.info("Routing strategy: %s", routing_strategy)
         self._validate_routing_strategy(routing_strategy)
@@ -11847,7 +11884,7 @@ class Router:
 
         _existing_router_settings: Final = self.get_settings()
         rebuild_routing_groups = False
-        relink_lar1_from_args = False
+        routing_args_updated = False
         for var in kwargs:
             if var in RUNTIME_UPDATABLE_ROUTER_SETTINGS:
                 if var in _int_settings:
@@ -11886,15 +11923,13 @@ class Router:
                                 )
                             rebuild_routing_groups = True
                     elif var == "routing_strategy_args":
-                        relink_lar1_from_args = True
+                        routing_args_updated = True
                     setattr(self, var, value)
             else:
                 verbose_router_logger.debug("Setting %s is not allowed", var)
 
-        if relink_lar1_from_args and self._normalize_strategy(self.routing_strategy) == "lar1":
-            from litellm.router_strategy.lar1_routing import apply_lar1_routing_strategy
-
-            apply_lar1_routing_strategy(self, self.routing_strategy_args)
+        if routing_args_updated:
+            self._apply_updated_routing_strategy_args()
 
         if rebuild_routing_groups:
             self._init_routing_groups(self._routing_groups_input)

--- a/litellm/router_strategy/lowest_latency.py
+++ b/litellm/router_strategy/lowest_latency.py
@@ -443,7 +443,7 @@ class LowestLatencyLoggingHandler(CustomLogger):
                 and request_kwargs["stream"] is True
                 and len(item_ttft_latency) > 0
             )
-            selected_latency: Final = (
+            selected_latency = (
                 _percentile_latency(item_ttft_latency, self.routing_args.ttft_percentile)
                 if use_ttft and self.routing_args.ttft_percentile is not None
                 else _average_latency(item_ttft_latency if use_ttft else item_latency)

--- a/litellm/router_strategy/lowest_latency.py
+++ b/litellm/router_strategy/lowest_latency.py
@@ -3,7 +3,10 @@
 import random
 from collections.abc import Sequence
 from datetime import datetime, timedelta
+from math import ceil
 from typing import TYPE_CHECKING, Any, Final
+
+from pydantic import Field
 
 import litellm
 from litellm import ModelResponse, token_counter, verbose_logger
@@ -24,12 +27,21 @@ class RoutingArgs(LiteLLMPydanticObjectBase):
     ttl: float = 1 * 60 * 60  # 1 hour
     lowest_latency_buffer: float = 0
     max_latency_list_size: int = 10
+    ttft_percentile: float | None = Field(default=None, gt=0, le=1)
 
 
 def _average_latency(samples: Sequence[float]) -> float:
     if not samples:
         return 0.0
     return sum(samples) / len(samples)
+
+
+def _percentile_latency(samples: Sequence[float], percentile: float) -> float:
+    if not samples:
+        return 0.0
+    values: Final = sorted(samples)
+    index: Final = ceil(len(values) * percentile) - 1
+    return values[index]
 
 
 def _ttft_seconds(elapsed: timedelta | float) -> float:
@@ -427,14 +439,18 @@ class LowestLatencyLoggingHandler(CustomLogger):
             item_rpm = item_map.get(precise_minute, {}).get("rpm", 0)
             item_tpm = item_map.get(precise_minute, {}).get("tpm", 0)
 
-            # get average latency or average ttft (depending on streaming/non-streaming)
+            # get latency or ttft (depending on streaming/non-streaming)
             use_ttft = (
                 request_kwargs is not None
                 and request_kwargs.get("stream", None) is not None
                 and request_kwargs["stream"] is True
                 and len(item_ttft_latency) > 0
             )
-            average_latency = _average_latency(item_ttft_latency if use_ttft else item_latency)
+            selected_latency: Final = (
+                _percentile_latency(item_ttft_latency, self.routing_args.ttft_percentile)
+                if use_ttft and self.routing_args.ttft_percentile is not None
+                else _average_latency(item_ttft_latency if use_ttft else item_latency)
+            )
 
             # -------------- #
             # Debugging Logic
@@ -443,7 +459,7 @@ class LowestLatencyLoggingHandler(CustomLogger):
             # this helps a user to debug why the router picked a specfic deployment      #
             _deployment_api_base = _deployment.get("litellm_params", {}).get("api_base", "")
             if _deployment_api_base is not None:
-                _latency_per_deployment[_deployment_api_base] = average_latency
+                _latency_per_deployment[_deployment_api_base] = selected_latency
             # -------------- #
             # End of Debugging Logic
             # -------------- #
@@ -453,7 +469,7 @@ class LowestLatencyLoggingHandler(CustomLogger):
             ):  # if user passed in tpm / rpm in the model_list
                 continue
             else:
-                potential_deployments.append((_deployment, average_latency))
+                potential_deployments.append((_deployment, selected_latency))
 
         if len(potential_deployments) == 0:
             return None

--- a/litellm/router_strategy/lowest_latency.py
+++ b/litellm/router_strategy/lowest_latency.py
@@ -37,8 +37,6 @@ def _average_latency(samples: Sequence[float]) -> float:
 
 
 def _percentile_latency(samples: Sequence[float], percentile: float) -> float:
-    if not samples:
-        return 0.0
     values: Final = sorted(samples)
     index: Final = ceil(len(values) * percentile) - 1
     return values[index]

--- a/litellm/router_strategy/lowest_latency.py
+++ b/litellm/router_strategy/lowest_latency.py
@@ -439,7 +439,6 @@ class LowestLatencyLoggingHandler(CustomLogger):
             item_rpm = item_map.get(precise_minute, {}).get("rpm", 0)
             item_tpm = item_map.get(precise_minute, {}).get("tpm", 0)
 
-            # get latency or ttft (depending on streaming/non-streaming)
             use_ttft = (
                 request_kwargs is not None
                 and request_kwargs.get("stream", None) is not None

--- a/tests/code_coverage_tests/router_code_coverage.py
+++ b/tests/code_coverage_tests/router_code_coverage.py
@@ -87,6 +87,7 @@ ignored_function_names = [
     "_delete_claude_code_session_router_binding",  # Tested through Redis cleanup failure in test_router.py
     "_resolve_claude_code_session_router",  # Tested through Claude Code session routing in test_router.py
     "_get_claude_code_session_router_binding",  # Tested through the two-worker session routing test in test_router.py
+    "_apply_updated_routing_strategy_args",  # Tested via update_settings in test_lowest_latency.py (file lacks "router" in name)
 ]
 
 

--- a/tests/test_litellm/router_strategy/test_lowest_latency.py
+++ b/tests/test_litellm/router_strategy/test_lowest_latency.py
@@ -8,6 +8,7 @@ import json
 from datetime import datetime, timedelta
 
 import pytest
+from pydantic import ValidationError
 
 import litellm
 from litellm.caching.caching import DualCache
@@ -340,7 +341,7 @@ async def test_streaming_ttft_ranking_percentile(
 
 @pytest.mark.parametrize("ttft_percentile", [0, -0.1, 1.1])
 def test_ttft_percentile_validation(ttft_percentile: float):
-    with pytest.raises(ValueError):
+    with pytest.raises(ValidationError):
         RoutingArgs(ttft_percentile=ttft_percentile)
 
 

--- a/tests/test_litellm/router_strategy/test_lowest_latency.py
+++ b/tests/test_litellm/router_strategy/test_lowest_latency.py
@@ -9,10 +9,9 @@ from datetime import datetime, timedelta
 
 import pytest
 
-
 import litellm
 from litellm.caching.caching import DualCache
-from litellm.router_strategy.lowest_latency import LowestLatencyLoggingHandler
+from litellm.router_strategy.lowest_latency import LowestLatencyLoggingHandler, RoutingArgs
 
 DEPLOYMENT_ID = "9876"
 KWARGS = {
@@ -58,9 +57,9 @@ def test_sync_embedding_latency_is_json_serializable():
 
     latencies = _recorded_latencies(cache)
     assert latencies, "expected a latency entry to be recorded"
-    assert all(
-        not isinstance(value, timedelta) for value in latencies
-    ), f"raw timedelta leaked into latency list: {latencies}"
+    assert all(not isinstance(value, timedelta) for value in latencies), (
+        f"raw timedelta leaked into latency list: {latencies}"
+    )
     assert latencies[-1] == pytest.approx(2.0)
     # the exact failure mode from production: redis cache sync json.dumps
     json.dumps({"latency": latencies})
@@ -84,9 +83,9 @@ async def test_async_embedding_latency_is_json_serializable():
 
     latencies = _recorded_latencies(cache)
     assert latencies, "expected a latency entry to be recorded"
-    assert all(
-        not isinstance(value, timedelta) for value in latencies
-    ), f"raw timedelta leaked into latency list: {latencies}"
+    assert all(not isinstance(value, timedelta) for value in latencies), (
+        f"raw timedelta leaked into latency list: {latencies}"
+    )
     assert latencies[-1] == pytest.approx(3.0)
     json.dumps({"latency": latencies})
 
@@ -290,6 +289,85 @@ async def test_streaming_routing_ignores_per_token_ttft_samples_from_older_worke
 
     assert picked is not None
     assert picked["model_info"]["id"] == FAST_TTFT_ID
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("sync_mode", [True, False], ids=["sync", "async"])
+@pytest.mark.parametrize(
+    ("ttft_percentile", "first_samples", "second_samples", "expected_id"),
+    [
+        (None, [0.1, 0.1, 1.0], [0.3, 0.3, 0.3], SLOW_TTFT_ID),
+        (0.5, [0.1, 0.1, 1.0], [0.3, 0.3, 0.3], FAST_TTFT_ID),
+        (0.9, [0.1, 0.1, 0.1, 0.1, 1.5], [0.3, 0.3, 0.3, 0.3, 0.3], SLOW_TTFT_ID),
+    ],
+    ids=["default_average", "p50", "p90"],
+)
+async def test_streaming_ttft_ranking_percentile(
+    sync_mode: bool,
+    ttft_percentile: float | None,
+    first_samples: list[float],
+    second_samples: list[float],
+    expected_id: str,
+):
+    cache = DualCache()
+    routing_args = {} if ttft_percentile is None else {"ttft_percentile": ttft_percentile}
+    handler = LowestLatencyLoggingHandler(router_cache=cache, routing_args=routing_args)
+    cache.set_cache(
+        key=f"{MODEL_GROUP}_map",
+        value={
+            FAST_TTFT_ID: {"time_to_first_token_seconds": first_samples},
+            SLOW_TTFT_ID: {"time_to_first_token_seconds": second_samples},
+        },
+    )
+
+    if sync_mode:
+        picked = handler.get_available_deployments(
+            model_group=MODEL_GROUP,
+            healthy_deployments=STREAMING_DEPLOYMENTS,
+            request_kwargs={"stream": True, "metadata": {}},
+        )
+    else:
+        picked = await handler.async_get_available_deployments(
+            model_group=MODEL_GROUP,
+            healthy_deployments=STREAMING_DEPLOYMENTS,
+            request_kwargs={"stream": True, "metadata": {}},
+        )
+
+    assert picked is not None
+    assert picked["model_info"]["id"] == expected_id
+
+
+@pytest.mark.parametrize("ttft_percentile", [0, -0.1, 1.1])
+def test_ttft_percentile_validation(ttft_percentile: float):
+    with pytest.raises(ValueError):
+        RoutingArgs(ttft_percentile=ttft_percentile)
+
+
+@pytest.mark.parametrize("ttft_percentile", [0.5, 0.9, 0.95, 1.0])
+def test_ttft_percentile_accepts_valid_values(ttft_percentile: float):
+    assert RoutingArgs(ttft_percentile=ttft_percentile).ttft_percentile == ttft_percentile
+
+
+@pytest.mark.asyncio
+async def test_ttft_percentile_does_not_change_non_streaming_routing():
+    cache = DualCache()
+    handler = LowestLatencyLoggingHandler(router_cache=cache, routing_args={"ttft_percentile": 0.9})
+    cache.set_cache(
+        key=f"{MODEL_GROUP}_map",
+        value={
+            FAST_TTFT_ID: {"latency": [1.0], "time_to_first_token_seconds": [0.1]},
+            SLOW_TTFT_ID: {"latency": [0.2], "time_to_first_token_seconds": [1.5]},
+        },
+    )
+
+    picked = await handler.async_get_available_deployments(
+        model_group=MODEL_GROUP,
+        healthy_deployments=STREAMING_DEPLOYMENTS,
+        request_kwargs={"stream": False, "metadata": {}},
+    )
+
+    assert picked is not None
+    assert picked["model_info"]["id"] == SLOW_TTFT_ID
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/router_strategy/test_lowest_latency.py
+++ b/tests/test_litellm/router_strategy/test_lowest_latency.py
@@ -454,3 +454,24 @@ async def test_runtime_routing_strategy_args_update_keeps_previous_args_when_inv
     router.update_settings(routing_strategy_args={"ttft_percentile": 5})
 
     assert await _pick_streaming(router) == FAST_TTFT_ID
+
+
+@pytest.mark.asyncio
+async def test_runtime_routing_strategy_args_update_is_a_noop_without_a_selector():
+    """simple-shuffle has no selector to re-link, so an args update must leave
+    the router alone instead of blowing up on a missing selector attribute."""
+    router = Router(
+        model_list=[
+            {
+                "model_name": MODEL_GROUP,
+                "litellm_params": {"model": f"openai/{MODEL_GROUP}", "api_key": "sk-fake"},
+                "model_info": {"id": FAST_TTFT_ID},
+            }
+        ],
+        routing_strategy="simple-shuffle",
+    )
+
+    router.update_settings(routing_strategy_args={"ttl": 5})
+
+    assert router.routing_strategy_args == {"ttl": 5}
+    assert await _pick_streaming(router) == FAST_TTFT_ID

--- a/tests/test_litellm/router_strategy/test_lowest_latency.py
+++ b/tests/test_litellm/router_strategy/test_lowest_latency.py
@@ -11,6 +11,7 @@ import pytest
 
 import litellm
 from litellm.caching.caching import DualCache
+from litellm.router import Router
 from litellm.router_strategy.lowest_latency import LowestLatencyLoggingHandler, RoutingArgs
 
 DEPLOYMENT_ID = "9876"
@@ -396,3 +397,60 @@ async def test_async_get_available_deployments_treats_missing_samples_as_zero_la
 
     assert picked is not None
     assert picked["model_info"]["id"] == DEPLOYMENT_ID
+
+
+def _latency_router(routing_strategy_args: dict) -> Router:
+    return Router(
+        model_list=[
+            {
+                "model_name": MODEL_GROUP,
+                "litellm_params": {"model": f"openai/{MODEL_GROUP}", "api_key": "sk-fake"},
+                "model_info": {"id": deployment_id},
+            }
+            for deployment_id in (FAST_TTFT_ID, SLOW_TTFT_ID)
+        ],
+        routing_strategy="latency-based-routing",
+        routing_strategy_args=routing_strategy_args,
+    )
+
+
+def _seed_streaming_ttft(router: Router) -> None:
+    router.cache.set_cache(
+        key=f"{MODEL_GROUP}_map",
+        value={
+            FAST_TTFT_ID: {"time_to_first_token_seconds": [0.1, 0.1, 1.0]},
+            SLOW_TTFT_ID: {"time_to_first_token_seconds": [0.3, 0.3, 0.3]},
+        },
+    )
+
+
+async def _pick_streaming(router: Router) -> str:
+    picked = await router.async_get_available_deployment(
+        model=MODEL_GROUP,
+        request_kwargs={"stream": True, "metadata": {}},
+    )
+    return picked["model_info"]["id"]
+
+
+@pytest.mark.asyncio
+async def test_runtime_routing_strategy_args_update_applies_ttft_percentile():
+    """A config reload that adds ttft_percentile must reach the live selector,
+    not sit unused until the proxy restarts."""
+    router = _latency_router({"max_latency_list_size": 50})
+    _seed_streaming_ttft(router)
+
+    assert await _pick_streaming(router) == SLOW_TTFT_ID
+
+    router.update_settings(routing_strategy_args={"max_latency_list_size": 50, "ttft_percentile": 0.5})
+
+    assert await _pick_streaming(router) == FAST_TTFT_ID
+
+
+@pytest.mark.asyncio
+async def test_runtime_routing_strategy_args_update_keeps_previous_args_when_invalid():
+    router = _latency_router({"ttft_percentile": 0.5})
+    _seed_streaming_ttft(router)
+
+    router.update_settings(routing_strategy_args={"ttft_percentile": 5})
+
+    assert await _pick_streaming(router) == FAST_TTFT_ID


### PR DESCRIPTION
## TLDR

Problem this solves:

- Streaming routing only ranks deployments by average TTFT
- One slow first token drags a provider's average down
- No way to route on tail TTFT (p90/p95)

How it solves it:

- New `ttft_percentile` option in `routing_strategy_args`
- Streaming picks the deployment with the lowest percentile TTFT
- Omit it and routing behaves exactly as today

## User Flow

Before: a team streaming chat completions across two providers keeps hitting slow first tokens, because the provider with the best average TTFT has the worse tail

1. The gateway admin sets `routing_strategy: latency-based-routing` with `routing_strategy_args: {max_latency_list_size: 50}` and restarts the gateway
2. Their app sends POST https://litellm-domain/v1/chat/completions with `"stream": true` many times through one model group holding two providers
3. Provider A starts most streams in about 0.1s but every so often takes about 1.5s, provider B starts every stream in about 0.3s
4. Reading the `x-litellm-model-id` response header shows provider A serving nearly every streaming request, since its average TTFT is lowest
5. Users keep waiting about 1.5s for the first token on the unlucky requests
6. The admin adds `ttft_percentile: 0.9` to `routing_strategy_args` and restarts, the gateway starts fine and nothing changes: the header still shows provider A and the slow first tokens keep happening

After: the same setting now makes the gateway rank on tail TTFT, so the steadier provider serves the streams

1. The gateway admin sets `routing_strategy: latency-based-routing` with `routing_strategy_args: {max_latency_list_size: 50}` and restarts the gateway
2. Their app sends POST https://litellm-domain/v1/chat/completions with `"stream": true` many times through one model group holding two providers
3. Provider A starts most streams in about 0.1s but every so often takes about 1.5s, provider B starts every stream in about 0.3s
4. Reading the `x-litellm-model-id` response header shows provider A serving nearly every streaming request, since its average TTFT is lowest
5. Users keep waiting about 1.5s for the first token on the unlucky requests
6. The admin adds `ttft_percentile: 0.9` to `routing_strategy_args` and restarts, and the `x-litellm-model-id` header now shows provider B on streaming requests
7. First tokens arrive in about 0.3s every time, and https://litellm-domain/ui/?page=logs shows the streaming traffic moving to provider B
8. Non-streaming requests to the same model group keep landing on whichever provider has the lowest average end-to-end latency, unchanged by the new setting

## Relevant issues

None

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Not captured yet. The environment this branch was written in has no provider credentials and its egress blocks provider APIs, so the live-proxy run below still has to be done on a machine with real keys before review. The steps are written out so the run is a copy paste, and this section gets replaced with the real command output.

Shared setup, a model group with one fast but spiky provider and one steady provider:

```yaml
# ttft_qa_config.yaml
model_list:
  - model_name: qa-group
    litellm_params:
      model: openai/gpt-5.6
      api_key: os.environ/OPENAI_API_KEY
    model_info:
      id: openai-spiky
  - model_name: qa-group
    litellm_params:
      model: anthropic/claude-sonnet-5
      api_key: os.environ/ANTHROPIC_API_KEY
    model_info:
      id: anthropic-steady

router_settings:
  routing_strategy: latency-based-routing
  routing_strategy_args:
    max_latency_list_size: 50
    ttft_percentile: 0.9
```

Start the proxy with `python litellm/proxy/proxy_cli.py --config ttft_qa_config.yaml --detailed_debug 2>&1 | tee litellm.log`, then warm both deployments and read back which one each streaming request landed on:

```bash
for i in $(seq 1 20); do
  curl -sS -D - -o /dev/null -X POST http://localhost:4000/v1/chat/completions \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"model":"qa-group","stream":true,"messages":[{"role":"user","content":"say hi"}]}' \
    | grep -i '^x-litellm-model-id'
done | sort | uniq -c
```

### Before (314e573529897752c882be9aac4985931bcc26bc)

#### streaming requests

1. Start the proxy with the config above, boot succeeds and the unknown `ttft_percentile` is silently dropped
2. Run the warm up loop, then the counting loop, expect the spiky provider to win almost every request because its average TTFT is lowest
3. Time the first SSE chunk with `curl -w` and expect the occasional multi-second wait

#### non-streaming requests

1. Send the same request with `"stream": false` and record which deployment the `x-litellm-model-id` header names

### After (92a74b7514a2b53d94e84be86cc67bcc5cf9b9c0)

#### streaming requests

1. Start the proxy with the same config, boot succeeds and the percentile is now in effect
2. Run the warm up loop, then the counting loop, expect the steady provider to win once the spiky provider's p90 TTFT is the worse of the two
3. Time the first SSE chunk with `curl -w` and expect no multi-second waits

#### non-streaming requests

1. Send the same request with `"stream": false` and expect the same deployment as before, since the percentile only applies to streaming TTFT

## Type

🆕 New Feature

## Caveats (if any)

### Medium

- High percentiles over few samples are basically the max
  - `max_latency_list_size` defaults to 10, so p90 reads the slowest sample
  - Raise the list size when setting a high percentile
- Nearest rank, no interpolation between samples
  - p90 of 5 samples returns the slowest of the 5

### Low

- Invalid values now fail proxy boot instead of being ignored
- Deployments with no TTFT samples still rank on average end-to-end latency
- Percentile guidance is not documented in this repo, docs live elsewhere
- Two unrelated assert reformats in the touched test file

## Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

https://claude.ai/code/session_01EmifvSyTcWDdGapbdqmAvz