### PR TITLE
feat(bedrock): add openai.gpt-6-astra profiles and route its reasoning_effort like gpt-5.x

### DIFF
--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -115,6 +115,12 @@ UNSUPPORTED_BEDROCK_CONVERSE_BETA_PATTERNS: Final = [
 ]
 
 
+def _is_openai_frontier_model(model: str) -> bool:
+    """OpenAI GPT-5.x / GPT-6 on Bedrock (``openai.gpt-5.6-sol``, ``openai.gpt-6-astra``): reasoning goes
+    through ``reasoning.effort``. ``openai.gpt-oss-*`` is excluded; it takes ``reasoning_effort`` as-is."""
+    return "openai.gpt-" in model and "gpt-oss" not in model
+
+
 class AmazonConverseConfig(BaseConfig):
     """
     Reference - https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html
@@ -430,7 +436,7 @@ class AmazonConverseConfig(BaseConfig):
         """
         if "gpt-oss" in model:
             optional_params["reasoning_effort"] = reasoning_effort
-        elif "openai.gpt-5" in model:
+        elif _is_openai_frontier_model(model):
             reasoning: Final[BedrockConverseGptReasoningEffortBlock] = {"effort": reasoning_effort}
             optional_params["reasoning"] = reasoning
         elif self._is_nova_2_model(model):
@@ -564,7 +570,7 @@ class AmazonConverseConfig(BaseConfig):
             # only anthropic and mistral support tool choice config. otherwise (E.g. cohere) will fail the call - https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolChoice.html
             supported_params.append("tool_choice")
 
-        if "gpt-oss" in model or "openai.gpt-5" in model or "openai.gpt-5" in base_model:
+        if "gpt-oss" in model or _is_openai_frontier_model(model) or _is_openai_frontier_model(base_model):
             supported_params.append("reasoning_effort")
         elif self._is_nova_2_model(model):
             # Nova 2 models support reasoning_effort (transformed to reasoningConfig)
@@ -920,7 +926,7 @@ class AmazonConverseConfig(BaseConfig):
                 optional_params["_parallel_tool_use_config"] = {
                     "tool_choice": {"type": "auto", "disable_parallel_tool_use": not value}
                 }
-            if param == "thinking" and "openai.gpt-5" not in model:
+            if param == "thinking" and not _is_openai_frontier_model(model):
                 if (
                     isinstance(value, dict)
                     and value.get("type") == "adaptive"

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -55196,6 +55196,60 @@
         "supports_reasoning": true,
         "supports_vision": true
     },
+    "us.openai.gpt-6-astra": {
+        "input_cost_per_token": 1.1e-05,
+        "input_cost_per_token_above_272k_tokens": 2.2e-05,
+        "cache_creation_input_token_cost": 1.375e-05,
+        "cache_creation_input_token_cost_above_272k_tokens": 2.75e-05,
+        "cache_read_input_token_cost": 1.1e-06,
+        "cache_read_input_token_cost_above_272k_tokens": 2.2e-06,
+        "output_cost_per_token": 5.5e-05,
+        "output_cost_per_token_above_272k_tokens": 8.25e-05,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true,
+        "supports_prompt_caching": true,
+        "supports_vision": true
+    },
+    "global.openai.gpt-6-astra": {
+        "input_cost_per_token": 1e-05,
+        "input_cost_per_token_above_272k_tokens": 2e-05,
+        "cache_creation_input_token_cost": 1.25e-05,
+        "cache_creation_input_token_cost_above_272k_tokens": 2.5e-05,
+        "cache_read_input_token_cost": 1e-06,
+        "cache_read_input_token_cost_above_272k_tokens": 2e-06,
+        "output_cost_per_token": 5e-05,
+        "output_cost_per_token_above_272k_tokens": 7.5e-05,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true,
+        "supports_prompt_caching": true,
+        "supports_vision": true
+    },
     "bedrock_mantle/openai.gpt-5.5": {
         "input_cost_per_token": 5.5e-06,
         "input_cost_per_token_above_272k_tokens": 1.1e-05,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -55196,6 +55196,60 @@
         "supports_reasoning": true,
         "supports_vision": true
     },
+    "us.openai.gpt-6-astra": {
+        "input_cost_per_token": 1.1e-05,
+        "input_cost_per_token_above_272k_tokens": 2.2e-05,
+        "cache_creation_input_token_cost": 1.375e-05,
+        "cache_creation_input_token_cost_above_272k_tokens": 2.75e-05,
+        "cache_read_input_token_cost": 1.1e-06,
+        "cache_read_input_token_cost_above_272k_tokens": 2.2e-06,
+        "output_cost_per_token": 5.5e-05,
+        "output_cost_per_token_above_272k_tokens": 8.25e-05,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true,
+        "supports_prompt_caching": true,
+        "supports_vision": true
+    },
+    "global.openai.gpt-6-astra": {
+        "input_cost_per_token": 1e-05,
+        "input_cost_per_token_above_272k_tokens": 2e-05,
+        "cache_creation_input_token_cost": 1.25e-05,
+        "cache_creation_input_token_cost_above_272k_tokens": 2.5e-05,
+        "cache_read_input_token_cost": 1e-06,
+        "cache_read_input_token_cost_above_272k_tokens": 2e-06,
+        "output_cost_per_token": 5e-05,
+        "output_cost_per_token_above_272k_tokens": 7.5e-05,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true,
+        "supports_prompt_caching": true,
+        "supports_vision": true
+    },
     "bedrock_mantle/openai.gpt-5.5": {
         "input_cost_per_token": 5.5e-06,
         "input_cost_per_token_above_272k_tokens": 1.1e-05,

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -382,6 +382,8 @@ def test_reasoning_with_forced_tool_choice_switches_to_auto():
         "us.openai.gpt-5.6-sol",
         "global.openai.gpt-5.6-terra",
         "bedrock/converse/us.openai.gpt-5.6-luna",
+        "global.openai.gpt-6-astra",
+        "bedrock/converse/us.openai.gpt-6-astra",
     ],
 )
 def test_reasoning_effort_maps_to_reasoning_effort_for_openai_gpt5_converse(model, local_model_cost_map):
@@ -412,6 +414,7 @@ def test_reasoning_effort_maps_to_reasoning_effort_for_openai_gpt5_converse(mode
     [
         "us.openai.gpt-5.6-sol",
         "bedrock/converse/global.openai.gpt-5.6-luna",
+        "us.openai.gpt-6-astra",
     ],
 )
 def test_openai_gpt5_converse_never_forwards_thinking(model, local_model_cost_map):

--- a/tests/test_litellm/llms/bedrock/test_cross_region_inference_profile_mapping.py
+++ b/tests/test_litellm/llms/bedrock/test_cross_region_inference_profile_mapping.py
@@ -98,6 +98,24 @@ GPT_5_6_PROFILES = [
     ),
 ]
 
+# From the GPT-6 Astra model card: Geo CRIS (us.) and Global CRIS (global.), 272K tiers, cache rates.
+GPT_6_PROFILES = [
+    GptProfile(
+        model_id="us.openai.gpt-6-astra",
+        input_cost=1.1e-05, input_cost_above_272k=2.2e-05,
+        cache_write=1.375e-05, cache_write_above_272k=2.75e-05,
+        cache_read=1.1e-06, cache_read_above_272k=2.2e-06,
+        output_cost=5.5e-05, output_cost_above_272k=8.25e-05,
+    ),
+    GptProfile(
+        model_id="global.openai.gpt-6-astra",
+        input_cost=1e-05, input_cost_above_272k=2e-05,
+        cache_write=1.25e-05, cache_write_above_272k=2.5e-05,
+        cache_read=1e-06, cache_read_above_272k=2e-06,
+        output_cost=5e-05, output_cost_above_272k=7.5e-05,
+    ),
+]
+
 
 def _bedrock_response(model, usage):
     return ModelResponse(
@@ -222,6 +240,57 @@ def test_bedrock_gpt_5_6_offers_tools_and_reasoning_effort_but_not_thinking(prof
     supported = AmazonConverseConfig().get_supported_openai_params(
         model=f"bedrock/{profile.model_id}"
     )
+
+    assert "tools" in supported
+    assert "tool_choice" in supported
+    assert "reasoning_effort" in supported
+    assert "thinking" not in supported
+    assert "output_config" not in supported
+
+
+@pytest.mark.parametrize("profile", GPT_6_PROFILES, ids=lambda p: p.model_id)
+def test_bedrock_gpt_6_profiles_route_to_converse(profile, local_model_cost_map):
+    """GPT-6 Astra has no in-Region id and no Invoke support on bedrock-runtime; the
+    us./global. profiles must resolve to Converse, not fall through to Invoke."""
+    assert BedrockModelInfo.get_bedrock_route(f"bedrock/{profile.model_id}") == "converse"
+
+
+@pytest.mark.parametrize("profile", GPT_6_PROFILES, ids=lambda p: p.model_id)
+def test_bedrock_gpt_6_price_map_matches_model_card(profile, local_model_cost_map):
+    info = _get_model_info_helper(model=profile.model_id, custom_llm_provider="bedrock")
+
+    assert info["mode"] == "chat"
+    assert info["max_input_tokens"] == 1050000
+    assert info["max_output_tokens"] == 128000
+    assert info["input_cost_per_token"] == pytest.approx(profile.input_cost)
+    assert info["input_cost_per_token_above_272k_tokens"] == pytest.approx(profile.input_cost_above_272k)
+    assert info["cache_creation_input_token_cost"] == pytest.approx(profile.cache_write)
+    assert info["cache_creation_input_token_cost_above_272k_tokens"] == pytest.approx(profile.cache_write_above_272k)
+    assert info["cache_read_input_token_cost"] == pytest.approx(profile.cache_read)
+    assert info["cache_read_input_token_cost_above_272k_tokens"] == pytest.approx(profile.cache_read_above_272k)
+    assert info["output_cost_per_token"] == pytest.approx(profile.output_cost)
+    assert info["output_cost_per_token_above_272k_tokens"] == pytest.approx(profile.output_cost_above_272k)
+
+
+def test_bedrock_gpt_6_above_272k_tier_applies_to_cost(local_model_cost_map):
+    response = _bedrock_response(
+        "bedrock/global.openai.gpt-6-astra",
+        Usage(prompt_tokens=300000, completion_tokens=1000, total_tokens=301000),
+    )
+
+    cost = completion_cost(
+        completion_response=response,
+        model="bedrock/global.openai.gpt-6-astra",
+        custom_llm_provider="bedrock",
+    )
+
+    assert cost == pytest.approx((300000 * 2e-05) + (1000 * 7.5e-05), rel=1e-9)
+
+
+@pytest.mark.parametrize("profile", GPT_6_PROFILES, ids=lambda p: p.model_id)
+def test_bedrock_gpt_6_offers_tools_and_reasoning_effort_but_not_thinking(profile, local_model_cost_map):
+    """Same Converse surface as GPT-5.6: tools and reasoning_effort in, Anthropic thinking out."""
+    supported = AmazonConverseConfig().get_supported_openai_params(model=f"bedrock/{profile.model_id}")
 
     assert "tools" in supported
     assert "tool_choice" in supported


### PR DESCRIPTION
## TLDR

Problem this solves:

- `bedrock/global.openai.gpt-6-astra` (and `us.`) cannot call tools through LiteLLM
- The model has no price-map entry, so it falls to the invoke route and `tools` is rejected or dropped
- `reasoning_effort` is mapped to Anthropic `thinking` because the Converse code only recognises `openai.gpt-5`

How it solves it:

- Add `us.` / `global.openai.gpt-6-astra` to the price map, same shape as the GPT-5.6 entries
- Treat every `openai.gpt-*` (except `gpt-oss`) as an OpenAI frontier model in the Converse transformation

## User Flow

Before: a developer pointing their agent at GPT-6 Astra on Bedrock through the gateway cannot get a single tool call back

1. They send POST https://litellm-domain/v1/chat/completions with `"model": "bedrock/global.openai.gpt-6-astra"`, a user message and a `tools` array
2. With default settings they get 400 `bedrock does not support parameters: ['tools'], for model=global.openai.gpt-6-astra`
3. If the proxy admin turns on `drop_params`, the tools are silently removed, the request goes to `.../model/global.openai.gpt-6-astra/invoke`, and AWS rejects it because this model does not support Invoke
4. Either way the agent never receives a `tool_calls` message

After: the same request comes back with a real tool call

1. They send the same POST https://litellm-domain/v1/chat/completions with `"model": "bedrock/global.openai.gpt-6-astra"` and the same `tools` array
2. The gateway forwards it to `https://bedrock-runtime.us-east-2.amazonaws.com/model/global.openai.gpt-6-astra/converse` with a `toolConfig`
3. The response is a normal chat completion with `finish_reason: "tool_calls"` and `tool_calls[0].function.name == "get_weather"`; `stream: true` returns the same as SSE deltas
4. Adding `"reasoning_effort": "low"` now reaches Bedrock as `reasoning.effort` instead of failing with `Unknown parameter: 'thinking'`
5. https://litellm-domain/ui/?page=logs shows the request with non-zero spend priced from the Bedrock rate card

## Relevant issues

Related (not closed by this PR): #40246, #40080

## Live verification

Run against a real account in `us-east-2` with an IAM role, using the bundled price map (`LITELLM_LOCAL_MODEL_COST_MAP=True`):

| Scenario | Result |
|---|---|
| `completion()` + tools + `reasoning_effort=low`, non-stream | `finish_reason=tool_calls`, `get_weather {"city": "Beijing"}`, cost 0.00142 |
| tool-result round trip | final text answer |
| `completion()` + tools + `reasoning_effort=low`, `stream=True` (`us.` profile) | 8 chunks, `finish_reason=tool_calls` |
| `Router` with a `model_list` entry | tool call returned |

Without the Converse change the `reasoning_effort` case fails with `BedrockException {"code":"unknown_parameter","message":"Unknown parameter: 'thinking'."}`

## Notes

- Earlier revisions of this PR added a bedrock-runtime `/openai/v1/responses` backend. That turned out to be unnecessary for tool calling: GPT-6 supports tools on Converse exactly like GPT-5.6, so this revision is the price-map entry plus the one-line model check, the same shape as the GPT-5.6 onboarding. A native Responses path can be a separate PR if a Responses-only feature is needed
- The `us.` entry uses the Geo CRIS rate and `global.` the Global CRIS rate from the model card; both carry the 272K tiers and cache write/read rates like the GPT-5.6 entries
- GPT-5.6 entries are untouched

## Pre-Submission checklist

- [x] I have added meaningful tests (`tests/test_litellm/llms/bedrock/test_cross_region_inference_profile_mapping.py`, `tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py`)
- [x] The handful of test files covering my change pass locally: those two files plus `tests/test_litellm/llms/bedrock/chat`, `tests/test_litellm/llms/bedrock/test_bedrock_common_utils.py`, `tests/test_litellm/llms/bedrock_mantle`, `tests/test_litellm/completion_extras`, `tests/test_litellm/test_model_prices_schema.py`. `scripts/ruff_strict_gate.py`, `scripts/type_discipline_gate.py` and `scripts/type_check_gate.py` pass against the merge-base
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
