### PR TITLE
fix(volcengine): allow response_format in supported params for JSON mode

### DIFF
--- a/litellm/llms/volcengine/chat/transformation.py
+++ b/litellm/llms/volcengine/chat/transformation.py
@@ -63,6 +63,7 @@ class VolcEngineChatConfig(OpenAILikeChatConfig):
             "tool_choice",
             "function_call",
             "functions",
+            "response_format",
             "max_retries",
             "extra_headers",
             "thinking",

--- a/tests/test_litellm/llms/volcengine/test_volcengine.py
+++ b/tests/test_litellm/llms/volcengine/test_volcengine.py
@@ -42,6 +42,34 @@ class TestVolcEngineConfig:
             "type": "enabled",
         }
 
+    def test_response_format_supported(self):
+        """response_format must be a supported param so JSON mode is not rejected.
+
+        Regression for UnsupportedParamsError on volcengine/doubao when passing
+        response_format: the field was declared on the config but missing from
+        get_supported_openai_params, so litellm rejected it before dispatch.
+        """
+        config = VolcEngineConfig()
+        model = "doubao-seed-2-0-pro-260215"
+
+        assert "response_format" in config.get_supported_openai_params(model=model)
+
+        mapped = config.map_openai_params(
+            non_default_params={"response_format": {"type": "json_object"}},
+            optional_params={},
+            model=model,
+            drop_params=False,
+        )
+        assert mapped["response_format"] == {"type": "json_object"}
+
+        e2e = get_optional_params(
+            model=model,
+            custom_llm_provider="volcengine",
+            response_format={"type": "json_object"},
+            drop_params=False,
+        )
+        assert e2e["response_format"] == {"type": "json_object"}
+
     def test_thinking_parameter_handling(self):
         """Test comprehensive thinking parameter handling scenarios"""
         config = VolcEngineConfig()


### PR DESCRIPTION
## TLDR

Problem this solves:

- volcengine/doubao rejects `response_format`, so JSON mode is unusable
- `UnsupportedParamsError` is raised before the request is ever sent

How it solves it:

- add `response_format` to volcengine's supported OpenAI params
- the OpenAI-compatible base then forwards it to the model unchanged

## User Flow

Before: a developer asking a doubao model for JSON gets a hard error before any call goes out

1. They send POST https://litellm-domain/v1/chat/completions with `"model": "volcengine/doubao-seed-2-0-pro-260215"` and `"response_format": {"type": "json_object"}`
2. The proxy returns 400 with `litellm.UnsupportedParamsError: volcengine does not support parameters: ['response_format']`
3. No request reaches volcengine, so they cannot get structured JSON back at all

After: the same request goes through and the model returns JSON

1. They send the same POST with `"response_format": {"type": "json_object"}`
2. The proxy forwards `response_format` to volcengine and returns 200
3. The response body carries valid JSON content, so their app can parse it directly

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Reproduced against a live proxy hitting the real volcengine API (fill in commit hashes and paste output).

Before (commit `8841cbc10`), the request is rejected:

```
curl -sS http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "volcengine/doubao-seed-2-0-pro-260215",
    "messages": [{"role":"user","content":"Return a JSON object with keys city and country for Paris. Respond in JSON."}],
    "response_format": {"type":"json_object"}
  }'
```

After (commit `6a5e700c8`), the same curl returns 200 with JSON content.

## Type

🐛 Bug Fix

## Caveats (if any)

- structured `json_schema` support depends on the specific doubao model version
