### PR TITLE
fix(responses): default serialize_tool_call_arguments to "{}" instead of empty string

### DIFF
--- a/litellm/responses/litellm_completion_transformation/custom_tools.py
+++ b/litellm/responses/litellm_completion_transformation/custom_tools.py
@@ -55,7 +55,7 @@ def is_custom_tool_call(tool_name: str, custom_tool_names: set[str]) -> bool:
     return tool_name in custom_tool_names
 
 
-def serialize_tool_call_arguments(raw_arguments: object, default: str = "") -> str:
+def serialize_tool_call_arguments(raw_arguments: object, default: str = "{}") -> str:
     """Render tool call arguments as the JSON string tool-call schemas require.
 
     Arguments normally arrive already JSON-encoded, but clients and providers

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -1592,7 +1592,7 @@ class LiteLLMCompletionResponsesConfig:
             raw_arguments = REDACTED_TOOL_CALL_ARGUMENTS_PLACEHOLDER
         if not raw_arguments and function_call.get("type") == "custom_tool_call":
             raw_input: Final = function_call.get("input") or ""
-            raw_arguments = json.dumps({"content": raw_input}) if raw_input else ""
+            raw_arguments = json.dumps({"content": raw_input}) if raw_input else json.dumps({"content": ""})
         raw_name: Final = function_call.get("name") or ""
         namespace: Final = function_call.get("namespace") or ""
         qualify: Final = bool(namespace) and function_call.get("type") != "custom_tool_call"


### PR DESCRIPTION
## Summary

`serialize_tool_call_arguments` (`custom_tools.py:58`) defaulted to `""` — an empty string that is **not valid JSON**. OpenAI itself silently tolerates `""` for tool-call arguments, so the bug was invisible in direct OpenAI testing; any strict OpenAI-compatible gateway rejects it with:

```
BadRequestError: Assistant tool call ***.arguments must be valid JSON.
```

### Root cause

The codebase already disagreed with itself: line 1025 in `transformation.py` passed `"{}"` explicitly, showing `"{}"` is the intended sentinel. The other three unguarded call sites (lines 1554, 1604, 2582) simply inherited the wrong function default.

### Changes

| File | Change |
|------|--------|
| `custom_tools.py:58` | `default: str = ""` → `default: str = "{}"` |
| `transformation.py:1595` | empty custom-tool input: `""` → `json.dumps({"content": ""})` |

The `transformation.py` fix ensures an omitted custom-tool input produces `'{"content": ""}''` instead of `""`, matching the generated schema (`"required": ["content"]`) and round-tripping cleanly through `unwrap_custom_tool_arguments`.

### Sites intentionally left unchanged

`streaming_iterator.py` and the upstream responses transformation feed `fn_args` into `fn_args or accumulated` accumulators — a truthy `"{}"` default there would shadow real accumulated arguments and corrupt every streamed tool call. Only the terminal serialization points are changed.

Fixes #40369.