### PR TITLE
fix(router): preserve encrypted reasoning affinity for bridged chat

### DIFF
--- a/litellm/router_utils/pre_call_checks/encrypted_content_affinity_check.py
+++ b/litellm/router_utils/pre_call_checks/encrypted_content_affinity_check.py
@@ -148,7 +148,7 @@ class EncryptedContentAffinityCheck(CustomLogger):
         return None
 
     @staticmethod
-    def _extract_model_id_from_messages(
+    def _extract_model_id_from_messages(  # noqa: LIT001  # callback contract supplies the router's message list
         messages: list[AllMessageValues] | None,  # noqa: LIT001  # callback contract supplies the router's message list
     ) -> str | None:
         if messages is None:

--- a/litellm/router_utils/pre_call_checks/encrypted_content_affinity_check.py
+++ b/litellm/router_utils/pre_call_checks/encrypted_content_affinity_check.py
@@ -148,8 +148,8 @@ class EncryptedContentAffinityCheck(CustomLogger):
         return None
 
     @staticmethod
-    def _extract_model_id_from_messages(  # noqa: LIT001  # callback contract supplies the router's message list
-        messages: list[AllMessageValues] | None,  # noqa: LIT001  # callback contract supplies the router's message list
+    def _extract_model_id_from_messages(  # mutable-ok: callback contract supplies the router's message list
+        messages: list[AllMessageValues] | None,  # mutable-ok: callback contract supplies the router's message list
     ) -> str | None:
         if messages is None:
             return None

--- a/litellm/router_utils/pre_call_checks/encrypted_content_affinity_check.py
+++ b/litellm/router_utils/pre_call_checks/encrypted_content_affinity_check.py
@@ -37,7 +37,6 @@ Safe to enable globally:
 """
 
 import time
-from collections.abc import Sequence
 from typing import TYPE_CHECKING, Final, Optional, Protocol, cast
 
 import httpx
@@ -149,8 +148,10 @@ class EncryptedContentAffinityCheck(CustomLogger):
         return None
 
     @staticmethod
-    def _extract_model_id_from_messages(messages: Sequence[AllMessageValues] | None) -> str | None:
-        for message in messages or ():
+    def _extract_model_id_from_messages(messages: list[AllMessageValues] | None) -> str | None:
+        if messages is None:
+            return None
+        for message in messages:
             if message.get("role") != "assistant":
                 continue
             model_id: Final = EncryptedContentAffinityCheck._extract_model_id_from_input(message.get("reasoning_items"))

--- a/litellm/router_utils/pre_call_checks/encrypted_content_affinity_check.py
+++ b/litellm/router_utils/pre_call_checks/encrypted_content_affinity_check.py
@@ -149,7 +149,7 @@ class EncryptedContentAffinityCheck(CustomLogger):
 
     @staticmethod
     def _extract_model_id_from_messages(
-        messages: list[AllMessageValues] | None,  # mutable-ok: callback contract supplies the router's message list
+        messages: list[AllMessageValues] | None,  # noqa: LIT001  # callback contract supplies the router's message list
     ) -> str | None:
         if messages is None:
             return None

--- a/litellm/router_utils/pre_call_checks/encrypted_content_affinity_check.py
+++ b/litellm/router_utils/pre_call_checks/encrypted_content_affinity_check.py
@@ -252,13 +252,17 @@ class EncryptedContentAffinityCheck(CustomLogger):
         # creating litellm_metadata here would hide chat routing tags.
         if "litellm_metadata" in routing_kwargs or messages is not None:
             metadata_key: Final = "litellm_metadata" if "litellm_metadata" in routing_kwargs else "metadata"
-            routing_kwargs[metadata_key] = {  # mutable-ok: routing callbacks share this context with response post-processing
+            routing_kwargs[
+                metadata_key
+            ] = {  # mutable-ok: routing callbacks share this context with response post-processing
                 **(routing_kwargs.get(metadata_key) or {}),
                 "encrypted_content_affinity_enabled": True,
             }
 
         request_input: Final = routing_kwargs.get("input")
-        model_id: Final = self._extract_model_id_from_input(request_input) or self._extract_model_id_from_messages(messages)
+        model_id: Final = self._extract_model_id_from_input(request_input) or self._extract_model_id_from_messages(
+            messages
+        )
         if not model_id:
             return typed_healthy_deployments
 

--- a/litellm/router_utils/pre_call_checks/encrypted_content_affinity_check.py
+++ b/litellm/router_utils/pre_call_checks/encrypted_content_affinity_check.py
@@ -156,7 +156,7 @@ class EncryptedContentAffinityCheck(CustomLogger):
         for message in messages:
             if message.get("role") != "assistant":
                 continue
-            model_id: Final = EncryptedContentAffinityCheck._extract_model_id_from_input(message.get("reasoning_items"))
+            model_id = EncryptedContentAffinityCheck._extract_model_id_from_input(message.get("reasoning_items"))
             if model_id:
                 return model_id
         return None

--- a/litellm/router_utils/pre_call_checks/encrypted_content_affinity_check.py
+++ b/litellm/router_utils/pre_call_checks/encrypted_content_affinity_check.py
@@ -148,7 +148,9 @@ class EncryptedContentAffinityCheck(CustomLogger):
         return None
 
     @staticmethod
-    def _extract_model_id_from_messages(messages: list[AllMessageValues] | None) -> str | None:
+    def _extract_model_id_from_messages(
+        messages: list[AllMessageValues] | None,  # mutable-ok: callback contract supplies the router's message list
+    ) -> str | None:
         if messages is None:
             return None
         for message in messages:

--- a/litellm/router_utils/pre_call_checks/encrypted_content_affinity_check.py
+++ b/litellm/router_utils/pre_call_checks/encrypted_content_affinity_check.py
@@ -37,6 +37,7 @@ Safe to enable globally:
 """
 
 import time
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Final, Optional, Protocol, cast
 
 import httpx
@@ -148,8 +149,8 @@ class EncryptedContentAffinityCheck(CustomLogger):
         return None
 
     @staticmethod
-    def _extract_model_id_from_messages(messages: list[AllMessageValues] | None) -> str | None:
-        for message in messages or []:
+    def _extract_model_id_from_messages(messages: Sequence[AllMessageValues] | None) -> str | None:
+        for message in messages or ():
             if message.get("role") != "assistant":
                 continue
             model_id: Final = EncryptedContentAffinityCheck._extract_model_id_from_input(message.get("reasoning_items"))
@@ -228,7 +229,7 @@ class EncryptedContentAffinityCheck(CustomLogger):
         self,
         model: str,
         healthy_deployments: list,
-        messages: list[AllMessageValues] | None,
+        messages: Sequence[AllMessageValues] | None,
         request_kwargs: dict | None = None,
         parent_otel_span: Span | None = None,
     ) -> list[dict]:
@@ -243,8 +244,12 @@ class EncryptedContentAffinityCheck(CustomLogger):
         remaining cooldown window) so OpenAI-compatible clients back off and
         retry after the deployment is eligible again.
         """
-        routing_kwargs: Final = request_kwargs if request_kwargs is not None else {}
-        typed_healthy_deployments: Final = cast(list[dict], healthy_deployments)
+        routing_kwargs: Final = (
+            request_kwargs if request_kwargs is not None else {}
+        )  # mutable-ok: preserve shared request context when kwargs are absent
+        typed_healthy_deployments: Final = cast(
+            list[dict], healthy_deployments
+        )  # cast-ok: router supplies deployment dictionaries
         if not self._is_enabled_for_model_group(model):
             return typed_healthy_deployments
 

--- a/litellm/router_utils/pre_call_checks/encrypted_content_affinity_check.py
+++ b/litellm/router_utils/pre_call_checks/encrypted_content_affinity_check.py
@@ -245,7 +245,9 @@ class EncryptedContentAffinityCheck(CustomLogger):
         retry after the deployment is eligible again.
         """
         routing_kwargs: Final = (
-            request_kwargs if request_kwargs is not None else {}
+            request_kwargs
+            if request_kwargs is not None
+            else {}  # mutable-ok: preserve shared request context when kwargs are absent
         )  # mutable-ok: preserve shared request context when kwargs are absent
         typed_healthy_deployments: Final = cast(
             list[dict], healthy_deployments
@@ -261,7 +263,7 @@ class EncryptedContentAffinityCheck(CustomLogger):
                 metadata_key
             ] = {  # mutable-ok: routing callbacks share this context with response post-processing
                 **(routing_kwargs.get(metadata_key) or {}),
-                "encrypted_content_affinity_enabled": True,
+                "encrypted_content_affinity_enabled": True,  # mutable-ok: merge shared routing metadata for response post-processing
             }
 
         request_input: Final = routing_kwargs.get("input")

--- a/litellm/router_utils/pre_call_checks/encrypted_content_affinity_check.py
+++ b/litellm/router_utils/pre_call_checks/encrypted_content_affinity_check.py
@@ -229,7 +229,7 @@ class EncryptedContentAffinityCheck(CustomLogger):
         self,
         model: str,
         healthy_deployments: list,
-        messages: Sequence[AllMessageValues] | None,
+        messages: list[AllMessageValues] | None,
         request_kwargs: dict | None = None,
         parent_otel_span: Span | None = None,
     ) -> list[dict]:

--- a/litellm/router_utils/pre_call_checks/encrypted_content_affinity_check.py
+++ b/litellm/router_utils/pre_call_checks/encrypted_content_affinity_check.py
@@ -30,8 +30,8 @@ This pre-call check is responsible only for the routing decision: it reads the e
 the matching deployment.
 
 Safe to enable globally:
-- Only activates when encoded markers appear in the request ``input``.
-- No effect on embedding models, chat completions, or first-time requests.
+- Only pins requests carrying encoded markers in ``input`` or assistant ``reasoning_items``.
+- No effect on embedding models or first-time deployment selection.
 - No quota reduction -- first requests are fully load balanced.
 - No cache required.
 """
@@ -67,8 +67,8 @@ class _SupportsActiveCooldowns(Protocol):
 
 class EncryptedContentAffinityCheck(CustomLogger):
     """
-    Routes follow-up Responses API requests to the deployment that produced
-    the encrypted output items they reference.
+    Routes follow-up Responses API and bridged chat requests to the deployment
+    that produced the encrypted output items they reference.
 
     The ``model_id`` is decoded directly from the litellm-encoded item IDs –
     no caching or TTL management needed.
@@ -148,6 +148,16 @@ class EncryptedContentAffinityCheck(CustomLogger):
         return None
 
     @staticmethod
+    def _extract_model_id_from_messages(messages: list[AllMessageValues] | None) -> str | None:
+        for message in messages or []:
+            if message.get("role") != "assistant":
+                continue
+            model_id: Final = EncryptedContentAffinityCheck._extract_model_id_from_input(message.get("reasoning_items"))
+            if model_id:
+                return model_id
+        return None
+
+    @staticmethod
     def _find_deployment_by_model_id(healthy_deployments: list[dict], model_id: str) -> dict | None:
         for deployment in healthy_deployments:
             model_info = deployment.get("model_info")
@@ -223,7 +233,7 @@ class EncryptedContentAffinityCheck(CustomLogger):
         parent_otel_span: Span | None = None,
     ) -> list[dict]:
         """
-        If the request ``input`` contains litellm-encoded item IDs, decode the
+        If ``input`` or assistant ``reasoning_items`` contain encoded item IDs, decode the
         embedded ``model_id`` and pin the request to that deployment. Raises
         ``RateLimitError`` / ``ServiceUnavailableError`` / ``BadRequestError``
         when the originating deployment is unavailable and no encryption-boundary
@@ -233,23 +243,22 @@ class EncryptedContentAffinityCheck(CustomLogger):
         remaining cooldown window) so OpenAI-compatible clients back off and
         retry after the deployment is eligible again.
         """
-        request_kwargs = request_kwargs or {}
+        routing_kwargs: Final = request_kwargs if request_kwargs is not None else {}
         typed_healthy_deployments: Final = cast(list[dict], healthy_deployments)
         if not self._is_enabled_for_model_group(model):
             return typed_healthy_deployments
 
-        # Signal to the response post-processor that encrypted item IDs should be
-        # encoded in the output of this request.  Only set the flag when
-        # litellm_metadata already exists (Responses API path).  Using
-        # setdefault would create an empty litellm_metadata dict for chat
-        # completions / embeddings, which breaks tag-based routing because
-        # _get_metadata_variable_name_from_kwargs would pick "litellm_metadata"
-        # over "metadata" where tags are actually stored.
-        if "litellm_metadata" in request_kwargs:
-            request_kwargs["litellm_metadata"]["encrypted_content_affinity_enabled"] = True
+        # The chat bridge merges metadata into litellm_metadata after routing;
+        # creating litellm_metadata here would hide chat routing tags.
+        if "litellm_metadata" in routing_kwargs or messages is not None:
+            metadata_key: Final = "litellm_metadata" if "litellm_metadata" in routing_kwargs else "metadata"
+            routing_kwargs[metadata_key] = {
+                **(routing_kwargs.get(metadata_key) or {}),
+                "encrypted_content_affinity_enabled": True,
+            }
 
-        request_input: Final = request_kwargs.get("input")
-        model_id: Final = self._extract_model_id_from_input(request_input)
+        request_input: Final = routing_kwargs.get("input")
+        model_id: Final = self._extract_model_id_from_input(request_input) or self._extract_model_id_from_messages(messages)
         if not model_id:
             return typed_healthy_deployments
 
@@ -267,7 +276,7 @@ class EncryptedContentAffinityCheck(CustomLogger):
                 "EncryptedContentAffinityCheck: pinning -> deployment=%s",
                 model_id,
             )
-            request_kwargs["_encrypted_content_affinity_pinned"] = True
+            routing_kwargs["_encrypted_content_affinity_pinned"] = True
             return [deployment]
 
         # Follow-up switched model_name (LIT-2531): pin by Azure resource instead.
@@ -282,7 +291,7 @@ class EncryptedContentAffinityCheck(CustomLogger):
                 model_id,
                 len(boundary_matches),
             )
-            request_kwargs["_encrypted_content_affinity_pinned"] = True
+            routing_kwargs["_encrypted_content_affinity_pinned"] = True
             return boundary_matches
 
         # Dispatching to a non-peer would guarantee an upstream

--- a/litellm/router_utils/pre_call_checks/encrypted_content_affinity_check.py
+++ b/litellm/router_utils/pre_call_checks/encrypted_content_affinity_check.py
@@ -252,7 +252,7 @@ class EncryptedContentAffinityCheck(CustomLogger):
         # creating litellm_metadata here would hide chat routing tags.
         if "litellm_metadata" in routing_kwargs or messages is not None:
             metadata_key: Final = "litellm_metadata" if "litellm_metadata" in routing_kwargs else "metadata"
-            routing_kwargs[metadata_key] = {
+            routing_kwargs[metadata_key] = {  # mutable-ok: routing callbacks share this context with response post-processing
                 **(routing_kwargs.get(metadata_key) or {}),
                 "encrypted_content_affinity_enabled": True,
             }

--- a/tests/test_litellm/router_utils/pre_call_checks/test_encrypted_content_affinity_check.py
+++ b/tests/test_litellm/router_utils/pre_call_checks/test_encrypted_content_affinity_check.py
@@ -16,15 +16,19 @@ The mechanism works without any cache and supports two encoding strategies:
 """
 
 import time
-from typing import List, Optional
+from typing import Final, List, Optional
 from unittest.mock import AsyncMock, patch
 
 import pytest
-
+from typing_extensions import ReadOnly, TypedDict
 
 import litellm
 from litellm.responses.utils import ResponsesAPIRequestUtils
-from litellm.types.llms.openai import ResponsesAPIResponse
+from litellm.types.llms.openai import (
+    ChatCompletionAssistantMessage,
+    ChatCompletionReasoningItem,
+    ResponsesAPIResponse,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -711,6 +715,108 @@ def test_encrypted_content_wrapping_with_multiple_semicolons():
 from litellm.router_utils.pre_call_checks.encrypted_content_affinity_check import (
     EncryptedContentAffinityCheck,
 )
+
+
+class _ChatAffinityModelInfo(TypedDict):
+    id: ReadOnly[str]
+
+
+class _ChatAffinityDeployment(TypedDict):
+    model_info: ReadOnly[_ChatAffinityModelInfo]
+
+
+class _ChatAffinityMetadata(TypedDict, total=False):
+    tags: ReadOnly[list[str]]
+    model_info: ReadOnly[_ChatAffinityModelInfo]
+    encrypted_content_affinity_enabled: ReadOnly[bool]
+
+
+class _ChatAffinityRequest(TypedDict, total=False):
+    metadata: ReadOnly[_ChatAffinityMetadata]
+    litellm_metadata: ReadOnly[_ChatAffinityMetadata]
+    _encrypted_content_affinity_pinned: ReadOnly[bool]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("enabled", [True, False])
+@pytest.mark.parametrize("keep_item_id", [True, False])
+@pytest.mark.parametrize("stream", [True, False])
+async def test_chat_bridge_encrypted_content_affinity_roundtrip(
+    enabled: bool, keep_item_id: bool, stream: bool
+) -> None:
+    from openai.types.responses import ResponseFunctionToolCall, ResponseReasoningItem
+
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        LiteLLMResponsesTransformationHandler,
+        OpenAiResponsesToChatCompletionStreamIterator,
+    )
+    from litellm.types.llms.openai import ResponseCompletedEvent
+
+    check: Final = EncryptedContentAffinityCheck(enable_global_affinity=enabled)
+    bridge: Final = LiteLLMResponsesTransformationHandler()
+    deployments: Final = [
+        _ChatAffinityDeployment(model_info={"id": "origin"}),
+        _ChatAffinityDeployment(model_info={"id": "other"}),
+    ]
+    request: Final = _ChatAffinityRequest(metadata={"tags": ["prod"], "model_info": {"id": "origin"}})
+    first: Final = await check.async_filter_deployments("group", deployments, [], request)
+    assert first == deployments
+    assert "litellm_metadata" not in request
+    assert request["metadata"]["tags"] == ["prod"]
+    assert request["metadata"].get("encrypted_content_affinity_enabled", False) is enabled
+
+    sanitized: Final = bridge._build_sanitized_litellm_params(request)
+    response: Final = ResponsesAPIResponse(
+        id="resp_example",
+        created_at=1,
+        model="example",
+        output=[
+            ResponseReasoningItem(type="reasoning", id="rs_example", summary=[], encrypted_content="opaque"),
+            ResponseFunctionToolCall(type="function_call", call_id="call_example", name="get_weather", arguments="{}"),
+        ],
+    )
+    ResponsesAPIRequestUtils._update_responses_api_response_id_with_model_id(
+        response, "openai", sanitized["litellm_metadata"]
+    )
+    stored_items: Final = (
+        OpenAiResponsesToChatCompletionStreamIterator.translate_responses_chunk_to_openai_stream(
+            ResponseCompletedEvent(type="response.completed", response=response)
+        ).choices[0].delta.reasoning_items
+        if stream
+        else bridge._convert_response_output_to_choices(response.output)[0].message.reasoning_items
+    )
+    assert stored_items
+    stored: Final = stored_items[0]
+    assert stored["id"].startswith("encitem_") is enabled
+    replay: Final = ChatCompletionReasoningItem(
+        type="reasoning", summary=[], encrypted_content=stored["encrypted_content"],
+        **({"id": stored["id"]} if keep_item_id else {}),
+    )
+    messages: Final = [ChatCompletionAssistantMessage(role="assistant", content=None, reasoning_items=[replay])]
+    followup: Final = _ChatAffinityRequest(metadata={"tags": ["prod"]})
+    second: Final = await check.async_filter_deployments("group", deployments, messages, followup)
+    assert second == (deployments[:1] if enabled else deployments)
+    assert followup.get("_encrypted_content_affinity_pinned", False) is enabled
+    assert "litellm_metadata" not in followup
+    assert followup["metadata"]["tags"] == ["prod"]
+
+    response_input, _ = bridge.convert_chat_completion_messages_to_responses_api(messages)
+    restored: Final = ResponsesAPIRequestUtils._restore_encrypted_content_item_ids_in_input(response_input)
+    assert restored[0]["encrypted_content"] == "opaque"
+    if keep_item_id:
+        assert restored[0]["id"] == "rs_example"
+    assert messages[0]["reasoning_items"][0] == replay
+
+
+@pytest.mark.asyncio
+async def test_chat_affinity_marks_empty_kwargs_without_affecting_embeddings() -> None:
+    check: Final = EncryptedContentAffinityCheck()
+    chat_kwargs: Final = _ChatAffinityRequest()
+    embedding_kwargs: Final = _ChatAffinityRequest()
+    await check.async_filter_deployments("group", [], [], chat_kwargs)
+    await check.async_filter_deployments("group", [], None, embedding_kwargs)
+    assert chat_kwargs == {"metadata": {"encrypted_content_affinity_enabled": True}}
+    assert embedding_kwargs == {}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bridged chat follow-ups ignore encrypted reasoning deployment markers
- First-turn chat requests do not enable response marker encoding

How it solves it:

- Preserve encoding flags in chat metadata without hiding routing tags
- Read assistant reasoning items through the existing marker decoder
- Reuse existing Responses encoding, restoration, and unavailable-deployment handling

## User Flow

Before: a developer reports intermittent invalid_encrypted_content errors during multi-turn tool use across Azure deployments

1. Send POST https://litellm-domain/v1/chat/completions with tools and reasoning enabled to a model group with encrypted_content_affinity enabled
2. Keep the returned assistant message and append the tool result
3. Send the follow-up to the same endpoint
4. A different deployment can receive the encrypted reasoning and reject it

After: the follow-up carries deployment markers and the router selects their originating deployment

1. Send POST https://litellm-domain/v1/chat/completions with tools and reasoning enabled to a model group with encrypted_content_affinity enabled
2. Keep the returned assistant message and append the tool result
3. Send the follow-up to the same endpoint
4. The router selects the originating deployment or uses its existing unavailable-origin handling

## Relevant issues

Fixes #40364

## Linear ticket

## Validation

The regression exercises the actual affinity filter, chat bridge metadata conversion, Responses marker encoder, streaming and non-streaming chat conversion, and input restoration, without patching those functions

Coverage includes affinity enabled/disabled, retained/omitted item IDs, routing tags, and empty chat kwargs versus embedding kwargs

With the new tests and unmodified affinity code from base 36bd7f113837caadd3f3d400dd246cd4649b7b33: 5 failed, 4 passed, 37 deselected

At commit 212999a00b1aabd5e64fb7d7c9a065ba6ff4dc68: all 46 tests in
     test_encrypted_content_affinity_check.py pass. Source Ruff, test
     Ruff, and source formatting checks pass

     GitHub checks for this commit: 80 passed, 1 skipped, no failures.
     The [lint job](https://github.com/BerriAI/litellm/actions/
     runs/34347445111/job/102452306279) passes, including the
     basedpyright, type-discipline, and test-quality budgets

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The test file covering my change passes locally
- [x] My PR passes all required CI/CD checks
- [x] My PR only solves one specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

 The PR is open for maintainer review. Real multi-deployment Azure QA remains pending. 

## Type

Bug Fix

## Caveats (if any)

### Low

- Live Azure multi-deployment validation remains pending
- Local checkout originated from ZIP; changed files match the base

## Final Attestation

- [ ] End-to-end customer workflow verification is complete
