### PR TITLE
fix(router): stop least-busy collapsing onto one deployment after its counter expires

### DIFF
--- a/litellm/router_strategy/least_busy.py
+++ b/litellm/router_strategy/least_busy.py
@@ -62,11 +62,13 @@ class LeastBusyLoggingHandler(CustomLogger):
 
                 request_count_api_key: Final = f"{model_group}_request_count"
                 # decrement count in cache
-                request_count_dict: Final = self.router_cache.get_cache(key=request_count_api_key) or {}
+                request_count_dict: Final = self.router_cache.get_cache(key=request_count_api_key)
+                if request_count_dict is None:
+                    return
                 request_count_value: Final[int | None] = request_count_dict.get(id, 0)
                 if request_count_value is None:
                     return
-                request_count_dict[id] = request_count_value - 1
+                request_count_dict[id] = max(0, request_count_value - 1)
                 self.router_cache.set_cache(key=request_count_api_key, value=request_count_dict)
 
                 ### TESTING ###
@@ -89,11 +91,13 @@ class LeastBusyLoggingHandler(CustomLogger):
 
                 request_count_api_key: Final = f"{model_group}_request_count"
                 # decrement count in cache
-                request_count_dict: Final = self.router_cache.get_cache(key=request_count_api_key) or {}
+                request_count_dict: Final = self.router_cache.get_cache(key=request_count_api_key)
+                if request_count_dict is None:
+                    return
                 request_count_value: Final[int | None] = request_count_dict.get(id, 0)
                 if request_count_value is None:
                     return
-                request_count_dict[id] = request_count_value - 1
+                request_count_dict[id] = max(0, request_count_value - 1)
                 self.router_cache.set_cache(key=request_count_api_key, value=request_count_dict)
 
                 ### TESTING ###
@@ -117,11 +121,13 @@ class LeastBusyLoggingHandler(CustomLogger):
 
                 request_count_api_key: Final = f"{model_group}_request_count"
                 # decrement count in cache
-                request_count_dict: Final = await self.router_cache.async_get_cache(key=request_count_api_key) or {}
+                request_count_dict: Final = await self.router_cache.async_get_cache(key=request_count_api_key)
+                if request_count_dict is None:
+                    return
                 request_count_value: Final[int | None] = request_count_dict.get(id, 0)
                 if request_count_value is None:
                     return
-                request_count_dict[id] = request_count_value - 1
+                request_count_dict[id] = max(0, request_count_value - 1)
                 await self.router_cache.async_set_cache(key=request_count_api_key, value=request_count_dict)
 
                 ### TESTING ###
@@ -144,11 +150,13 @@ class LeastBusyLoggingHandler(CustomLogger):
 
                 request_count_api_key: Final = f"{model_group}_request_count"
                 # decrement count in cache
-                request_count_dict: Final = await self.router_cache.async_get_cache(key=request_count_api_key) or {}
+                request_count_dict: Final = await self.router_cache.async_get_cache(key=request_count_api_key)
+                if request_count_dict is None:
+                    return
                 request_count_value: Final[int | None] = request_count_dict.get(id, 0)
                 if request_count_value is None:
                     return
-                request_count_dict[id] = request_count_value - 1
+                request_count_dict[id] = max(0, request_count_value - 1)
                 await self.router_cache.async_set_cache(key=request_count_api_key, value=request_count_dict)
 
                 ### TESTING ###
@@ -169,23 +177,13 @@ class LeastBusyLoggingHandler(CustomLogger):
             ## if healthy deployment not yet used
             if d["model_info"]["id"] not in all_deployments:
                 all_deployments[d["model_info"]["id"]] = 0
-        # map deployment to id
-        # pick least busy deployment
-        min_traffic = float("inf")
-        min_deployment = None
-        for k, v in all_deployments.items():
-            if v < min_traffic:
-                min_traffic = v
-                min_deployment = k
-        if min_deployment is not None:
-            ## check if min deployment is a string, if so, cast it to int
-            for m in healthy_deployments:
-                if m["model_info"]["id"] == min_deployment:
-                    return m
-            min_deployment = random.choice(healthy_deployments)
-        else:
-            min_deployment = random.choice(healthy_deployments)
-        return min_deployment
+        healthy_by_id: Final = {d["model_info"]["id"]: d for d in healthy_deployments}
+        candidates: Final = {k: v for k, v in all_deployments.items() if k in healthy_by_id}
+        if not candidates:
+            return random.choice(healthy_deployments)
+        min_traffic: Final = min(candidates.values())
+        least_busy_ids: Final = tuple(k for k, v in candidates.items() if v == min_traffic)
+        return healthy_by_id[random.choice(least_busy_ids)]
 
     def get_available_deployments(
         self,

--- a/tests/test_litellm/router_strategy/test_least_busy.py
+++ b/tests/test_litellm/router_strategy/test_least_busy.py
@@ -1,0 +1,91 @@
+#### What this tests ####
+#    The request-count entry is written without a ttl, so InMemoryCache expires it
+#    on default_ttl (600s). A completion landing after that expiry used to re-create
+#    the counter as {id: -1} while its peers were absent, and since absent
+#    deployments are seeded to 0, that deployment then won every selection and the
+#    model group collapsed onto it. Issue #39322.
+
+import pytest
+
+from litellm.caching.caching import DualCache
+from litellm.router_strategy.least_busy import LeastBusyLoggingHandler
+
+MODEL_GROUP = "gpt-3.5-turbo"
+REQUEST_COUNT_KEY = f"{MODEL_GROUP}_request_count"
+DEPLOYMENT_IDS = ("1", "2", "3", "4")
+HEALTHY_DEPLOYMENTS = tuple(
+    {"model_info": {"id": deployment_id}, "litellm_params": {"model": "openai/gpt-4.1-mini"}}
+    for deployment_id in DEPLOYMENT_IDS
+)
+
+
+def _kwargs(deployment_id: str) -> dict:
+    return {
+        "litellm_params": {
+            "metadata": {"model_group": MODEL_GROUP, "deployment": "azure/gpt-4.1-mini"},
+            "model_info": {"id": deployment_id},
+        }
+    }
+
+
+@pytest.mark.parametrize("is_async", [True, False])
+@pytest.mark.asyncio
+async def test_completion_on_expired_counter_does_not_go_negative(is_async):
+    cache = DualCache()
+    handler = LeastBusyLoggingHandler(router_cache=cache)
+    assert cache.get_cache(key=REQUEST_COUNT_KEY) is None
+
+    if is_async:
+        await handler.async_log_success_event(kwargs=_kwargs("1"), response_obj=None, start_time=0, end_time=0)
+    else:
+        handler.log_success_event(kwargs=_kwargs("1"), response_obj=None, start_time=0, end_time=0)
+
+    counts = cache.get_cache(key=REQUEST_COUNT_KEY) or {}
+    assert counts.get("1", 0) >= 0
+
+
+@pytest.mark.parametrize("is_async", [True, False])
+@pytest.mark.asyncio
+async def test_failure_on_expired_counter_does_not_go_negative(is_async):
+    cache = DualCache()
+    handler = LeastBusyLoggingHandler(router_cache=cache)
+
+    if is_async:
+        await handler.async_log_failure_event(kwargs=_kwargs("1"), response_obj=None, start_time=0, end_time=0)
+    else:
+        handler.log_failure_event(kwargs=_kwargs("1"), response_obj=None, start_time=0, end_time=0)
+
+    counts = cache.get_cache(key=REQUEST_COUNT_KEY) or {}
+    assert counts.get("1", 0) >= 0
+
+
+@pytest.mark.asyncio
+async def test_expired_counter_does_not_pin_the_model_group():
+    cache = DualCache()
+    handler = LeastBusyLoggingHandler(router_cache=cache)
+    await handler.async_log_success_event(kwargs=_kwargs("1"), response_obj=None, start_time=0, end_time=0)
+
+    selected = {
+        handler._get_available_deployments(
+            healthy_deployments=list(HEALTHY_DEPLOYMENTS),
+            all_deployments=dict(cache.get_cache(key=REQUEST_COUNT_KEY) or {}),
+        )["model_info"]["id"]
+        for _ in range(200)
+    }
+    assert selected == set(DEPLOYMENT_IDS)
+
+
+def test_busiest_deployment_is_never_selected():
+    cache = DualCache()
+    handler = LeastBusyLoggingHandler(router_cache=cache)
+    for deployment_id in ("1", "1", "1", "2", "2", "3"):
+        handler.log_pre_api_call(model="test", messages=[], kwargs=_kwargs(deployment_id))
+
+    selected = {
+        handler._get_available_deployments(
+            healthy_deployments=list(HEALTHY_DEPLOYMENTS),
+            all_deployments=dict(cache.get_cache(key=REQUEST_COUNT_KEY) or {}),
+        )["model_info"]["id"]
+        for _ in range(200)
+    }
+    assert selected == {"4"}


### PR DESCRIPTION
## TLDR

Problem this solves:

- `least-busy` collapses a model group onto one deployment
- Its counter cache entry expires every 10 minutes
- A completion after that expiry seeds a negative count
- That negative count then wins every later selection
- Measured: one backend took 93.7% over 40 minutes
- With session affinity on, 26 consecutive sessions pinned to one backend

How it solves it:

- Skip the decrement when no counter exists
- Clamp the counter at zero
- Break ties at random instead of by dict order

## User Flow

Before: a developer running four identical upstreams behind one model name watches almost all traffic land on a single upstream while three sit idle, and every new conversation gets stuck on the busy one

1. They set `routing_strategy: least-busy` and start the proxy with four deployments under the model name `qwen`
2. They send POST http://localhost:4000/v1/chat/completions with `"model": "qwen"` continuously for 40 minutes
3. Reading each upstream's own request counter, they find one upstream served 252 of 269 requests, or 93.7%
4. The other three report zero requests for nine minutes at a stretch, even though all four are healthy and accepting traffic
5. Every ten minutes the spread recovers for a single batch, then collapses back onto the same upstream
6. They also turn on `optional_pre_call_checks: ["session_affinity"]` and start 35 conversations, one a minute, each sending `x-litellm-session-id`
7. Of those 35 conversations, 27 get pinned to the same upstream and one upstream receives none at all, with 26 of them landing back to back
8. Because a pin lasts `deployment_affinity_ttl_seconds`, which defaults to an hour, a ten minute window of bad routing keeps those conversations on the wrong upstream long after it passes

After: the same traffic spreads across all four upstreams, and new conversations land on all of them

1. They set the same `routing_strategy: least-busy` and start the proxy with the same four deployments
2. They send the same POST http://localhost:4000/v1/chat/completions traffic for 40 minutes
3. Each upstream's counter reports between 21.5% and 29.9% of the requests, against an even share of 25%
4. No upstream goes quiet for more than two consecutive minutes, and at seven requests a minute that gap is sampling noise, not starvation
5. The ten minute collapse pattern is gone
6. With session affinity on, the same 35 conversations spread 10, 12, 4 and 9 across the four upstreams, and the longest run landing on one upstream is 3
7. Every conversation still stays on the upstream it started on, so prompt caching keeps working

## Relevant issues

Fixes #39322

Related: #25323, #25325, #25393, #34444, #38746

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Two cases. Case 1 is request distribution against four real vLLM servers, no mocks, one GPU each, all serving the same model. Each server exposes its own request counter, so the router's choice can be checked against what the upstreams actually received. Case 2 is where conversations get pinned once `session_affinity` is on, which is the part that hurts in production: a pin outlives the bad routing window by up to an hour.

Load generator, shared by both cases. It sends four generations at once and waits for all of them before sending the next four, which is what agent traffic looks like: a turn runs for a while, and the next turn only starts once it returns. Start events are confined to the batch boundary, so for most of the wall clock there are requests in flight but nothing starting.

```bash
while :; do
  for i in 1 2 3 4; do
    curl -s -o /dev/null -X POST http://localhost:4000/v1/chat/completions \
      -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' \
      -d '{"model":"qwen","messages":[{"role":"user","content":"Write a long, detailed history of the late Joseon economy."}],"max_tokens":1500}' &
  done
  wait
done
```

Per-upstream counts, sampled once a minute:

```bash
for p in 8011 8012 8013 8014; do
  curl -s http://127.0.0.1:$p/metrics | awk '/^vllm:request_success_total/{s+=$NF} END{printf "%d ", s}'
done; echo
```

### Before (168a0055a)

Captured at 2e734004f, which carries a byte-identical copy of `litellm/router_strategy/least_busy.py` (sha256 prefix `36995e665844aa2d` at both commits), so this run reflects the merge base

#### case 1: request distribution, four real vLLM upstreams, 40 minutes

1. Start the proxy with four `hosted_vllm` deployments under one model name and `routing_strategy: least-busy`, then run the load generator for 40 minutes
2. Per-minute counts (b0 to b3), abridged:

```
min  b0   b1   b2   b3
  1   0    0    0    4
  2   0    0    0    8
  7   1    1    1    5     <- brief recovery
  8   0    0    0    8
 17   1    1    1    9     <- brief recovery
 18   0    0    0    8
 27   1    3    2    6     <- brief recovery
 28   0    0    0    7
 37   1    1    1    5     <- brief recovery
 38   0    0    0    8
 40   0    0    0    8
```

3. Totals over the 40 minutes:

```
b0:   5 requests ( 1.9%)
b1:   7 requests ( 2.6%)
b2:   5 requests ( 1.9%)
b3: 252 requests (93.7%)
total 269
```

4. Longest run of consecutive minutes at zero requests: b0 9 minutes, b1 9 minutes, b2 9 minutes, b3 0 minutes
5. The four brief recoveries land at minutes 7, 17, 27 and 37, a clean 10 minute period. `InMemoryCache.default_ttl` is 600 seconds and the counter is written without a ttl, so this is the cache entry expiring and being rebuilt from empty each time

#### case 2: where conversations get pinned, session affinity on, 35 minutes

1. Add `optional_pre_call_checks: ["session_affinity"]` with the default `deployment_affinity_ttl_seconds` of 3600, keep the load generator running in the background, and start one new conversation a minute for 35 minutes
2. Each conversation sends three turns carrying the same `x-litellm-session-id`, and the upstream that served it is read back from the response:

```bash
sid="sess-$(date +%s%N)"
for turn in 1 2 3; do
  curl -s -X POST http://localhost:4000/v1/chat/completions \
    -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' \
    -H "x-litellm-session-id: $sid" \
    -d '{"model":"mock","messages":[{"role":"user","content":"hi"}],"max_tokens":4}' \
    | python3 -c 'import sys,json; print(json.load(sys.stdin)["id"])'
  sleep 3
done
```

3. Where the 35 conversations ended up:

```
b0: 27 conversations (77.1%)
b1:  7 conversations (20.0%)
b2:  1 conversation  ( 2.9%)
b3:  0 conversations ( 0.0%)
```

4. Longest run of consecutive conversations landing on one upstream: 26, from conversation 10 through 35
5. All 35 conversations kept every turn on the upstream they started on, so affinity itself behaves correctly. The upstream it picks is the problem
6. At an hour per pin, the conversations started during one 10 minute window stay on that upstream for the rest of the hour, and their later turns never reach the router again

### After (57570bb84)

Captured at 1d3178c2e, which carries a byte-identical copy of the patched file (sha256 prefix `5ba9c44fc7714feb` at both commits)

#### case 1: request distribution, four real vLLM upstreams, 40 minutes

1. Same config, same load generator, same 40 minutes
2. Per-minute counts, abridged:

```
min  b0   b1   b2   b3
  1   0    2    1    1
  7   2    2    2    2
 17   5    1    0    2
 27   3    1    1    3
 37   1    2    3    2
 40   0    0    2    2
```

3. Totals over the 40 minutes:

```
b0:  65 requests (23.7%)
b1:  59 requests (21.5%)
b2:  82 requests (29.9%)
b3:  68 requests (24.8%)
total 274
```

4. Longest run of consecutive minutes at zero requests: b0 1 minute, b1 1 minute, b2 2 minutes, b3 1 minute. At about seven requests a minute across four upstreams, a one or two minute gap is sampling noise
5. The 10 minute collapse pattern is gone
6. Throughput is unchanged, 274 requests against 269

#### case 2: where conversations get pinned, session affinity on, 35 minutes

1. Same config with `session_affinity` on, same background load, same 35 conversations
2. Where they ended up:

```
b0: 10 conversations (28.6%)
b1: 12 conversations (34.3%)
b2:  4 conversations (11.4%)
b3:  9 conversations (25.7%)
```

3. Longest run of consecutive conversations landing on one upstream: 3, against 26 before
4. Every upstream now receives conversations, where b3 previously received none in 35 minutes
5. All 35 conversations still kept every turn on the upstream they started on, so the fix does not weaken affinity

### Production soak

Running the same fix on our own proxy for 39 hours of real agent traffic, four vLLM upstreams, `least-busy` with `session_affinity` on:

```
108,379 requests over 2,345 minutes

b0: 26,659 requests (24.60%)
b1: 26,972 requests (24.89%)
b2: 27,535 requests (25.41%)
b3: 27,213 requests (25.11%)
```

Within 0.41 percentage points of an even 25% split. Prefix cache hit rate held at 82% on all four upstreams over the same window, which is what session affinity is there to buy and what the collapse was destroying: piling every conversation onto one upstream makes their long contexts evict each other out of a single KV pool while three sit empty.

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- Tie-breaking overlaps #38746, happy to rebase onto it
- The counter fix alone is not enough, ties still pin

### Low

- The same decrement block is repeated in four methods
- Left as is to keep the diff small
- Production soak ran the same two fixes backported onto 1.95.0
