### PR TITLE
fix(gemini): preserve thoughtSignature emitted on a separate thought part

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -1556,14 +1556,25 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
     ]:
         function: ChatCompletionToolCallFunctionChunk | None = None
         _tools: Final[list[ChatCompletionToolCallChunk]] = []
+        # Gemini 3+ may emit the thought signature on a preceding thought part
+        # instead of on the functionCall part itself. Carry it forward so it is
+        # not dropped; consume it on the first function call that follows, since
+        # in parallel calls only the first one carries a signature.
+        pending_thought_signature: str | None = None
         for part in parts:
+            if part.get("thought") and part.get("thoughtSignature"):
+                pending_thought_signature = part.get("thoughtSignature")
+                continue
             if "functionCall" in part:
                 _function_chunk: ChatCompletionToolCallFunctionChunk = {
                     "name": part["functionCall"]["name"],
                     "arguments": json.dumps(part["functionCall"]["args"], ensure_ascii=False),
                 }
                 # Extract thought signature if present
-                thought_signature = part.get("thoughtSignature")
+                # Extract thought signature if present. Fall back to the one
+                # carried by a preceding thought part (Gemini 3+ places it there).
+                thought_signature = part.get("thoughtSignature") or pending_thought_signature
+                pending_thought_signature = None
                 # Gemini 3.5+ returns a stable `id` per function call to enable
                 # strict response matching. Preserve it as the OpenAI
                 # tool_call_id so it can be echoed back unchanged.

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_thought_signature_in_tool_call_id.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_thought_signature_in_tool_call_id.py
@@ -285,3 +285,76 @@ def test_parallel_tool_calls_with_signatures(enable_preview_features):
     assert THOUGHT_SIGNATURE_SEPARATOR not in tools[1]["id"]
     sig2 = _get_thought_signature_from_tool({"id": tools[1]["id"], "type": "function"})
     assert sig2 is None
+
+
+def test_thought_signature_on_separate_thought_part_is_preserved():
+    """Gemini 3+ places the signature on a thought part, not on the functionCall part.
+
+    Regression for the case where `_transform_parts` only looked at the
+    functionCall part and silently dropped the signature, so it was never
+    echoed back on the next turn.
+    """
+    test_signature = "CvsBAdHtim9thoughtPartSignature"
+    parts = [
+        HttpxPartType(thought=True, thoughtSignature=test_signature),
+        HttpxPartType(functionCall={"name": "get_weather", "args": {"city": "Recife"}}),
+    ]
+
+    _, tools, _ = VertexGeminiConfig._transform_parts(
+        parts=parts,
+        cumulative_tool_call_idx=0,
+        is_function_call=False,
+    )
+
+    assert tools is not None and len(tools) == 1
+    assert (
+        tools[0].get("provider_specific_fields", {}).get("thought_signature")
+        == test_signature
+    )
+
+
+def test_thought_signature_on_function_call_part_still_wins():
+    """A signature on the functionCall part keeps precedence over a pending one."""
+    own_signature = "CvsBAdHtim9onTheCallPart"
+    parts = [
+        HttpxPartType(thought=True, thoughtSignature="CvsBAdHtim9onTheThoughtPart"),
+        HttpxPartType(
+            functionCall={"name": "get_weather", "args": {"city": "Recife"}},
+            thoughtSignature=own_signature,
+        ),
+    ]
+
+    _, tools, _ = VertexGeminiConfig._transform_parts(
+        parts=parts,
+        cumulative_tool_call_idx=0,
+        is_function_call=False,
+    )
+
+    assert tools is not None and len(tools) == 1
+    assert (
+        tools[0].get("provider_specific_fields", {}).get("thought_signature")
+        == own_signature
+    )
+
+
+def test_pending_thought_signature_is_consumed_once():
+    """In parallel calls only the first function call carries a signature."""
+    test_signature = "CvsBAdHtim9onlyForTheFirstCall"
+    parts = [
+        HttpxPartType(thought=True, thoughtSignature=test_signature),
+        HttpxPartType(functionCall={"name": "get_weather", "args": {"city": "Recife"}}),
+        HttpxPartType(functionCall={"name": "get_time", "args": {"city": "Recife"}}),
+    ]
+
+    _, tools, _ = VertexGeminiConfig._transform_parts(
+        parts=parts,
+        cumulative_tool_call_idx=0,
+        is_function_call=False,
+    )
+
+    assert tools is not None and len(tools) == 2
+    assert (
+        tools[0].get("provider_specific_fields", {}).get("thought_signature")
+        == test_signature
+    )
+    assert tools[1].get("provider_specific_fields") is None


### PR DESCRIPTION
## The bug

Gemini 3+ may emit the thought signature on a **thought part** that precedes the `functionCall` part, instead of on the `functionCall` part itself.

`VertexGeminiConfig._transform_parts` only reads `thoughtSignature` from parts that contain `functionCall`. In that shape the signature is silently dropped — never stored in `provider_specific_fields`, never embedded in the tool call id, never echoed back on the following turn.

Downstream, Gemini rejects the next turn outright:

```
400 INVALID_ARGUMENT
Function call is missing a thought_signature in functionCall parts.
This is required for tools to work correctly, and missing thought_signature
may lead to degraded model performance.
Additional data, function call `default_api:Read`, position 2.
```

This is reproducible with any Anthropic-format client routed through `/v1/messages` to a Gemini 3 model: the first tool call works, and the run dies as soon as the tool result comes back. Reported in #25322.

## The fix

Carry a pending signature forward from the thought part and consume it on the **first** function call that follows — per the Gemini docs, in parallel function calls only the first call carries a signature.

A signature present on the `functionCall` part keeps precedence, so existing behaviour is unchanged when the API returns the older shape.

```python
pending_thought_signature: str | None = None
for part in parts:
    if part.get("thought") and part.get("thoughtSignature"):
        pending_thought_signature = part.get("thoughtSignature")
        continue
    if "functionCall" in part:
        thought_signature = part.get("thoughtSignature") or pending_thought_signature
        pending_thought_signature = None
```

## Tests

Three cases added to `tests/test_litellm/llms/vertex_ai/gemini/test_thought_signature_in_tool_call_id.py`:

- signature on a separate thought part is preserved
- signature on the `functionCall` part still takes precedence
- the pending signature is consumed once, so a second parallel call does not inherit it

```
14 passed, 2 warnings in 0.31s
```

Reverting only the source change and re-running the same file:

```
FAILED ... ::test_pending_thought_signature_is_consumed_once
FAILED ... ::test_thought_signature_on_separate_thought_part_is_preserved
2 failed, 12 passed
```

The 12 pre-existing tests in that file pass in both directions, so the two new failures isolate the change rather than the environment.

## What I did not run

Only the target test file, in a clean `python:3.13-slim` container against the repo copy. I did not run the wider suite or make live Gemini calls.
