### PR TITLE
feat(hooks): add per-hook, per-callback request filters

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -527,6 +527,7 @@ context_window_fallbacks: Optional[List] = None
 content_policy_fallbacks: Optional[List] = None
 allowed_fails: int = 3
 allow_dynamic_callback_disabling: bool = True
+enable_hook_filters: bool = False  # when True, a callback/guardrail's hook_filters config (models/key_aliases/model_tags/request_tags) is enforced; default-off so existing configs are unaffected
 num_retries_per_request: Optional[int] = None  # for the request overall (incl. fallbacks + model retries)
 ####### SECRET MANAGERS #####################
 secret_manager_client: Optional[Any] = (

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -527,7 +527,7 @@ context_window_fallbacks: Optional[List] = None
 content_policy_fallbacks: Optional[List] = None
 allowed_fails: int = 3
 allow_dynamic_callback_disabling: bool = True
-enable_hook_filters: bool = False  # when True, a callback/guardrail's hook_filters config (models/key_aliases/model_tags/request_tags) is enforced; default-off so existing configs are unaffected
+enable_hook_filters: bool = False
 num_retries_per_request: Optional[int] = None  # for the request overall (incl. fallbacks + model retries)
 ####### SECRET MANAGERS #####################
 secret_manager_client: Optional[Any] = (

--- a/litellm/integrations/custom_logger.py
+++ b/litellm/integrations/custom_logger.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel
 
 from litellm._logging import verbose_logger
 from litellm.constants import DEFAULT_MAX_RECURSE_DEPTH_SENSITIVE_DATA_MASKER
+from litellm.types.hook_filters import HookFilterConfig
 from litellm.types.integrations.argilla import ArgillaItem
 from litellm.types.integrations.custom_logger import AgenticLoopPlan
 from litellm.types.llms.openai import AllMessageValues, ChatCompletionRequest
@@ -81,6 +82,15 @@ class CustomLogger:  # https://docs.litellm.ai/docs/observability/custom_callbac
     routing, as the managed-files and managed-vector-store hooks do, stays False: a per-record
     rewrite would read as a redaction and ship embedded in the record. Only the leaf class is
     consulted, so a subclass that does not override ``async_pre_call_hook`` inherits nothing.
+    """
+
+    hook_filters: Mapping[str, HookFilterConfig] | None = None
+    """
+    Per-hook-method request filters (models/key_aliases/model_tags/request_tags), keyed by
+    hook method name (e.g. ``async_pre_call_hook``). Set by the callback's own config loader
+    (``guardrail_registry.py`` for guardrails, ``callback_utils.py`` for plain callbacks) and
+    consulted by ``call_custom_hook``. A hook with no entry here always runs, unfiltered, and
+    the whole attribute is inert unless ``litellm.enable_hook_filters`` is True.
     """
 
     def __init__(

--- a/litellm/litellm_core_utils/call_custom_hook.py
+++ b/litellm/litellm_core_utils/call_custom_hook.py
@@ -5,15 +5,23 @@ from litellm.integrations.custom_logger import CustomLogger
 from litellm.litellm_core_utils.hook_filter_utils import should_run_hook_for_filters
 
 
-def _should_run(
+def should_run_hook_for_callback(
     callback: CustomLogger,
     hook_name: str,
     *,
     model: str | None,
-    key_alias: str | None,
-    model_tags: tuple[str, ...],
-    request_tags: tuple[str, ...],
+    key_alias: str | None = None,
+    model_tags: tuple[str, ...] = (),
+    request_tags: tuple[str, ...] = (),
 ) -> bool:
+    """
+    Whether ``hook_name`` on ``callback`` should run for this request, per
+    ``callback``'s own ``hook_filters`` config. Exposed publicly (not just used
+    internally by ``call_custom_hook``) for hook shapes that don't fit that
+    dispatcher's await-a-coroutine signature -- e.g. an async-generator-returning
+    hook, where the caller must skip invoking the callback entirely rather than
+    await its result.
+    """
     if not litellm.enable_hook_filters:
         return True
     hook_filter: Final = None if callback.hook_filters is None else callback.hook_filters.get(hook_name)
@@ -44,7 +52,7 @@ async def call_custom_hook(
     differs from the one holding the config: ProxyLogging's unified-guardrail
     wrapper. It defaults to ``callback`` itself.
     """
-    if not _should_run(
+    if not should_run_hook_for_callback(
         callback, hook_name, model=model, key_alias=key_alias, model_tags=model_tags, request_tags=request_tags
     ):
         return None
@@ -66,7 +74,7 @@ def call_custom_hook_sync(
     **hook_kwargs: object,  # kwargs-ok: forwards arbitrary, hook-specific kwargs to the named hook method
 ) -> object:
     """Sync counterpart to call_custom_hook, for the sync hook methods (log_success_event, logging_hook)."""
-    if not _should_run(
+    if not should_run_hook_for_callback(
         callback, hook_name, model=model, key_alias=key_alias, model_tags=model_tags, request_tags=request_tags
     ):
         return None

--- a/litellm/litellm_core_utils/call_custom_hook.py
+++ b/litellm/litellm_core_utils/call_custom_hook.py
@@ -1,0 +1,76 @@
+from typing import Final
+
+import litellm
+from litellm.integrations.custom_logger import CustomLogger
+from litellm.litellm_core_utils.hook_filter_utils import should_run_hook_for_filters
+
+
+def _should_run(
+    callback: CustomLogger,
+    hook_name: str,
+    *,
+    model: str | None,
+    key_alias: str | None,
+    model_tags: tuple[str, ...],
+    request_tags: tuple[str, ...],
+) -> bool:
+    if not litellm.enable_hook_filters:
+        return True
+    hook_filter: Final = None if callback.hook_filters is None else callback.hook_filters.get(hook_name)
+    return should_run_hook_for_filters(
+        hook_filter, model=model, key_alias=key_alias, model_tags=model_tags, request_tags=request_tags
+    )
+
+
+async def call_custom_hook(
+    callback: CustomLogger,
+    hook_name: str,
+    *,
+    target: CustomLogger | None = None,
+    model: str | None = None,
+    key_alias: str | None = None,
+    model_tags: tuple[str, ...] = (),
+    request_tags: tuple[str, ...] = (),
+    **hook_kwargs: object,  # kwargs-ok: forwards arbitrary, hook-specific kwargs to the named hook method
+) -> object:
+    """
+    The one place any code path invokes a named async hook method on a
+    CustomLogger/CustomGuardrail instance. Consults ``callback``'s own
+    hook_filters (set by its config loader) before invoking, so every
+    dispatch site gets filtering for free by routing through here instead of
+    calling the hook method directly.
+
+    ``target`` covers the one real case where the object actually invoked
+    differs from the one holding the config: ProxyLogging's unified-guardrail
+    wrapper. It defaults to ``callback`` itself.
+    """
+    if not _should_run(
+        callback, hook_name, model=model, key_alias=key_alias, model_tags=model_tags, request_tags=request_tags
+    ):
+        return None
+    hook_fn: Final = getattr(  # pyright: ignore[reportAny]  # dynamic dispatch by name
+        target if target is not None else callback, hook_name
+    )
+    return await hook_fn(**hook_kwargs)  # pyright: ignore[reportAny]  # named hook's own return type
+
+
+def call_custom_hook_sync(
+    callback: CustomLogger,
+    hook_name: str,
+    *,
+    target: CustomLogger | None = None,
+    model: str | None = None,
+    key_alias: str | None = None,
+    model_tags: tuple[str, ...] = (),
+    request_tags: tuple[str, ...] = (),
+    **hook_kwargs: object,  # kwargs-ok: forwards arbitrary, hook-specific kwargs to the named hook method
+) -> object:
+    """Sync counterpart to call_custom_hook, for the sync hook methods (log_success_event, logging_hook)."""
+    if not _should_run(
+        callback, hook_name, model=model, key_alias=key_alias, model_tags=model_tags, request_tags=request_tags
+    ):
+        return None
+    hook_fn: Final = getattr(  # pyright: ignore[reportAny]  # dynamic dispatch by name
+        target if target is not None else callback, hook_name
+    )
+    return hook_fn(**hook_kwargs)  # pyright: ignore[reportAny]  # named hook's own return type

--- a/litellm/litellm_core_utils/hook_filter_utils.py
+++ b/litellm/litellm_core_utils/hook_filter_utils.py
@@ -1,0 +1,88 @@
+import fnmatch
+from collections.abc import Mapping
+from types import MappingProxyType
+from typing import Final
+
+from litellm.types.hook_filters import DEPLOYMENT_SCOPED_HOOK_NAMES, FILTERABLE_HOOK_NAMES, HookFilterConfig
+
+
+def _matches_single(value: str | None, patterns: tuple[str, ...] | None) -> bool:
+    if patterns is None:
+        return True
+    if value is None:
+        return False
+    return any(fnmatch.fnmatch(value, pattern) for pattern in patterns)
+
+
+def _matches_any_of(values: tuple[str, ...], patterns: tuple[str, ...] | None) -> bool:
+    if patterns is None:
+        return True
+    return any(fnmatch.fnmatch(value, pattern) for value in values for pattern in patterns)
+
+
+def should_run_hook_for_filters(
+    hook_filter: HookFilterConfig | None,
+    *,
+    model: str | None,
+    key_alias: str | None,
+    model_tags: tuple[str, ...],
+    request_tags: tuple[str, ...],
+) -> bool:
+    """
+    True if a hook with this filter should run for this request. A filter of
+    None (no hook_filters entry configured for this hook) always runs, so
+    behavior is unchanged for every hook nobody has opted into filtering.
+    """
+    if hook_filter is None:
+        return True
+    return (
+        _matches_single(model, hook_filter.models)
+        and _matches_single(key_alias, hook_filter.key_aliases)
+        and _matches_any_of(model_tags, hook_filter.model_tags)
+        and _matches_any_of(request_tags, hook_filter.request_tags)
+    )
+
+
+def validate_hook_filters(owner_name: str, hook_filters: Mapping[str, HookFilterConfig]) -> None:
+    """
+    Fail fast on a misconfigured hook_filters block: an unknown hook name, or
+    model_tags scoped to a hook that runs before a deployment is resolved (its
+    tags don't exist yet, so the filter would either always or never match).
+    """
+    for hook_name, hook_filter in hook_filters.items():
+        if hook_name not in FILTERABLE_HOOK_NAMES:
+            raise ValueError(
+                f"{owner_name}: hook_filters has unknown hook name '{hook_name}'; "
+                f"valid hook names are {sorted(FILTERABLE_HOOK_NAMES)}"
+            )
+        if hook_filter.model_tags is not None and hook_name not in DEPLOYMENT_SCOPED_HOOK_NAMES:
+            raise ValueError(
+                f"{owner_name}: hook '{hook_name}' cannot filter on model_tags; deployment tags are only "
+                f"resolved on {sorted(DEPLOYMENT_SCOPED_HOOK_NAMES)}"
+            )
+
+
+def parse_hook_filters(owner_name: str, raw_hook_filters: Mapping[str, object]) -> Mapping[str, HookFilterConfig]:
+    """Builds a validated HookFilterConfig per hook name from a raw config mapping."""
+    parsed: Final[Mapping[str, HookFilterConfig]] = MappingProxyType(
+        {hook_name: HookFilterConfig.model_validate(raw_filter) for hook_name, raw_filter in raw_hook_filters.items()}
+    )
+    validate_hook_filters(owner_name, parsed)
+    return parsed
+
+
+def get_request_tags_for_hook_filters(data: dict) -> tuple[str, ...]:  # mutable-ok: matches external dict param
+    """
+    Shared by every dispatch site that builds a proxy-request-shaped ``data``
+    dict (as opposed to litellm_logging.py's ``litellm_params`` shape, which
+    nests the raw request under a differently-keyed ``proxy_server_request``).
+    Lazily imports ``StandardLoggingPayloadSetup`` to avoid a circular import:
+    ``litellm_logging.py`` imports ``call_custom_hook``, which imports this module.
+    """
+    from litellm.litellm_core_utils.litellm_logging import StandardLoggingPayloadSetup
+
+    proxy_server_request: Final = data.get("metadata") or {}  # mutable-ok: read-only lookup
+    tags: Final = StandardLoggingPayloadSetup._get_request_tags(  # pyright: ignore[reportPrivateUsage]  # shared
+        data, proxy_server_request
+    )
+    return tuple(tags)

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -62,6 +62,7 @@ from litellm.integrations.custom_logger import CustomLogger
 from litellm.integrations.deepeval.deepeval import DeepEvalLogger
 from litellm.integrations.mlflow import MlflowLogger
 from litellm.integrations.sqs import SQSLogger
+from litellm.litellm_core_utils.call_custom_hook import call_custom_hook, call_custom_hook_sync
 from litellm.litellm_core_utils.core_helpers import is_expected_client_error, reconstruct_model_name
 from litellm.litellm_core_utils.get_litellm_params import get_litellm_params
 from litellm.litellm_core_utils.internal_call_metadata import (
@@ -1978,6 +1979,19 @@ class Logging(LiteLLMLoggingBaseClass):
 
         return True
 
+    def _hook_filter_context(
+        self,
+        litellm_params: dict,  # mutable-ok: matches _get_request_tags's own dict param
+    ) -> tuple[str | None, str | None, tuple[str, ...]]:
+        metadata: Final = litellm_params.get("metadata") or MappingProxyType({})
+        key_alias: Final = metadata.get("user_api_key_alias")
+        proxy_server_request: Final = litellm_params.get("proxy_server_request") or {}  # mutable-ok: read-only
+        tags: Final = StandardLoggingPayloadSetup._get_request_tags(  # pyright: ignore[reportPrivateUsage]  # shared
+            litellm_params, proxy_server_request
+        )
+        request_tags: Final = tuple(tags)
+        return self.model, key_alias, request_tags
+
     def _update_completion_start_time(self, completion_start_time: datetime.datetime):
         self.completion_start_time = completion_start_time
         self.model_call_details["completion_start_time"] = self.completion_start_time
@@ -2507,17 +2521,37 @@ class Logging(LiteLLMLoggingBaseClass):
                     ):
                         continue
 
-                    self.model_call_details, result = callback.logging_hook(
+                    hook_filter_model, hook_filter_key_alias, hook_filter_request_tags = self._hook_filter_context(
+                        litellm_params
+                    )
+                    logging_hook_result = call_custom_hook_sync(
+                        callback,
+                        "logging_hook",
+                        model=hook_filter_model,
+                        key_alias=hook_filter_key_alias,
+                        request_tags=hook_filter_request_tags,
                         kwargs=self.model_call_details,
                         result=result,
                         call_type=self.call_type,
                     )
+                    if logging_hook_result is not None:
+                        self.model_call_details, result = logging_hook_result  # pyright: ignore[reportGeneralTypeIssues]  # object-typed
                 elif isinstance(callback, CustomLogger):
-                    self.model_call_details, result = callback.logging_hook(
+                    hook_filter_model, hook_filter_key_alias, hook_filter_request_tags = self._hook_filter_context(
+                        litellm_params
+                    )
+                    logging_hook_result = call_custom_hook_sync(
+                        callback,
+                        "logging_hook",
+                        model=hook_filter_model,
+                        key_alias=hook_filter_key_alias,
+                        request_tags=hook_filter_request_tags,
                         kwargs=self.model_call_details,
                         result=result,
                         call_type=self.call_type,
                     )
+                    if logging_hook_result is not None:
+                        self.model_call_details, result = logging_hook_result  # pyright: ignore[reportGeneralTypeIssues]  # object-typed
 
             self.has_run_logging(event_type="sync_success")
             for callback in callbacks:
@@ -2812,7 +2846,15 @@ class Logging(LiteLLMLoggingBaseClass):
                                 )
                                 result = self.model_call_details["complete_response"]
 
-                            callback.log_success_event(
+                            hook_filter_model, hook_filter_key_alias, hook_filter_request_tags = (
+                                self._hook_filter_context(litellm_params)
+                            )
+                            call_custom_hook_sync(
+                                callback,
+                                "log_success_event",
+                                model=hook_filter_model,
+                                key_alias=hook_filter_key_alias,
+                                request_tags=hook_filter_request_tags,
                                 kwargs=self.model_call_details,
                                 response_obj=result,
                                 start_time=start_time,
@@ -3046,20 +3088,40 @@ class Logging(LiteLLMLoggingBaseClass):
                     ):
                         continue
 
-                    self.model_call_details, result = await callback.async_logging_hook(
+                    hook_filter_model, hook_filter_key_alias, hook_filter_request_tags = self._hook_filter_context(
+                        self.model_call_details.get("litellm_params", {})  # mutable-ok: read-only lookup
+                    )
+                    async_logging_hook_result = await call_custom_hook(
+                        callback,
+                        "async_logging_hook",
+                        model=hook_filter_model,
+                        key_alias=hook_filter_key_alias,
+                        request_tags=hook_filter_request_tags,
                         kwargs=self.model_call_details,
                         result=result,
                         call_type=self.call_type,
                     )
+                    if async_logging_hook_result is not None:
+                        self.model_call_details, result = async_logging_hook_result  # pyright: ignore[reportGeneralTypeIssues]  # object-typed
                 elif isinstance(callback, CustomLogger):
                     result = redact_message_input_output_from_custom_logger(
                         result=result, litellm_logging_obj=self, custom_logger=callback
                     )
-                    self.model_call_details, result = await callback.async_logging_hook(
+                    hook_filter_model, hook_filter_key_alias, hook_filter_request_tags = self._hook_filter_context(
+                        self.model_call_details.get("litellm_params", {})  # mutable-ok: read-only lookup
+                    )
+                    async_logging_hook_result = await call_custom_hook(
+                        callback,
+                        "async_logging_hook",
+                        model=hook_filter_model,
+                        key_alias=hook_filter_key_alias,
+                        request_tags=hook_filter_request_tags,
                         kwargs=self.model_call_details,
                         result=result,
                         call_type=self.call_type,
                     )
+                    if async_logging_hook_result is not None:
+                        self.model_call_details, result = async_logging_hook_result  # pyright: ignore[reportGeneralTypeIssues]  # object-typed
             except Exception:  # noqa: BLE001  # one failing hook must not skip later callbacks (slot release)
                 verbose_logger.error(
                     "LiteLLM.LoggingError: [Non-Blocking] Exception occurred in async_logging_hook %s",
@@ -3105,34 +3167,50 @@ class Logging(LiteLLMLoggingBaseClass):
                         )
 
                 if isinstance(callback, CustomLogger):  # custom logger class
-                    model_call_details: dict = self.model_call_details
+                    hook_filter_model, hook_filter_key_alias, hook_filter_request_tags = self._hook_filter_context(
+                        litellm_params
+                    )
+                    logged_details: dict = self.model_call_details
                     ##################################
                     # call redaction hook for custom logger
-                    model_call_details = callback.redact_standard_logging_payload_from_model_call_details(
-                        model_call_details=model_call_details
+                    logged_details = callback.redact_standard_logging_payload_from_model_call_details(
+                        model_call_details=logged_details  # pyright: ignore[reportGeneralTypeIssues]  # quirk
                     )
-                    model_call_details = redact_streaming_responses_for_custom_logger(
-                        model_call_details=model_call_details, custom_logger=callback
+                    logged_details = redact_streaming_responses_for_custom_logger(
+                        model_call_details=logged_details,  # pyright: ignore[reportGeneralTypeIssues]  # quirk
+                        custom_logger=callback,
                     )
                     ##################################
+                    stream_key = "async_complete_streaming_response"
+                    has_stream = stream_key in logged_details  # pyright: ignore[reportGeneralTypeIssues]  # quirk
                     if self.stream is True:
-                        if "async_complete_streaming_response" in model_call_details:
-                            await callback.async_log_success_event(
-                                kwargs=model_call_details,
-                                response_obj=model_call_details["async_complete_streaming_response"],
+                        if has_stream:
+                            await call_custom_hook(
+                                callback,
+                                "async_log_success_event",
+                                model=hook_filter_model,
+                                key_alias=hook_filter_key_alias,
+                                request_tags=hook_filter_request_tags,
+                                kwargs=logged_details,
+                                response_obj=logged_details["async_complete_streaming_response"],
                                 start_time=start_time,
                                 end_time=end_time,
                             )
                         else:
                             await callback.async_log_stream_event(  # [TODO]: move this to being an async log stream event function
-                                kwargs=model_call_details,
+                                kwargs=logged_details,
                                 response_obj=result,
                                 start_time=start_time,
                                 end_time=end_time,
                             )
                     else:
-                        await callback.async_log_success_event(
-                            kwargs=model_call_details,
+                        await call_custom_hook(
+                            callback,
+                            "async_log_success_event",
+                            model=hook_filter_model,
+                            key_alias=hook_filter_key_alias,
+                            request_tags=hook_filter_request_tags,
+                            kwargs=logged_details,
                             response_obj=result,
                             start_time=start_time,
                             end_time=end_time,
@@ -3414,7 +3492,15 @@ class Logging(LiteLLMLoggingBaseClass):
                         and is_sync_request
                         and self.call_type != CallTypes.pass_through.value
                     ):  # custom logger class
-                        callback.log_failure_event(
+                        hook_filter_model, hook_filter_key_alias, hook_filter_request_tags = self._hook_filter_context(
+                            self.model_call_details.get("litellm_params", {})  # mutable-ok: read-only lookup
+                        )
+                        call_custom_hook_sync(
+                            callback,
+                            "log_failure_event",
+                            model=hook_filter_model,
+                            key_alias=hook_filter_key_alias,
+                            request_tags=hook_filter_request_tags,
                             start_time=start_time,
                             end_time=end_time,
                             response_obj=result,
@@ -3548,7 +3634,15 @@ class Logging(LiteLLMLoggingBaseClass):
                 if not should_run:
                     continue
                 if isinstance(callback, CustomLogger):  # custom logger class
-                    await callback.async_log_failure_event(
+                    hook_filter_model, hook_filter_key_alias, hook_filter_request_tags = self._hook_filter_context(
+                        litellm_params
+                    )
+                    await call_custom_hook(
+                        callback,
+                        "async_log_failure_event",
+                        model=hook_filter_model,
+                        key_alias=hook_filter_key_alias,
+                        request_tags=hook_filter_request_tags,
                         kwargs=self.model_call_details,
                         response_obj=result,
                         start_time=start_time,

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -1724,8 +1724,22 @@ class CustomStreamWrapper:
             except ValueError:
                 typed_call_type = None
 
+            from litellm.litellm_core_utils.call_custom_hook import call_custom_hook
+
+            litellm_params: Final = request_data.get("litellm_params") or {}  # mutable-ok: read-only lookup
+            metadata: Final = litellm_params.get("metadata") or {}  # mutable-ok: read-only lookup
+            hook_filter_key_alias: Final = metadata.get("user_api_key_alias")
+            raw_tags: Final = metadata.get("tags")
+            hook_filter_request_tags: Final = tuple(raw_tags) if isinstance(raw_tags, list) else ()
+
             for callback in self._post_streaming_hooks:
-                result = await callback.async_post_call_streaming_deployment_hook(
+                result = await call_custom_hook(
+                    callback,
+                    "async_post_call_streaming_deployment_hook",
+                    model=self.model,
+                    key_alias=hook_filter_key_alias,
+                    model_tags=hook_filter_request_tags,
+                    request_tags=hook_filter_request_tags,
                     request_data=request_data,
                     response_chunk=chunk,
                     call_type=typed_call_type,

--- a/litellm/proxy/common_utils/callback_utils.py
+++ b/litellm/proxy/common_utils/callback_utils.py
@@ -19,6 +19,7 @@ from litellm.litellm_core_utils.core_helpers import (
     get_metadata_variable_name_from_kwargs,
     get_or_create_metadata_bucket,
 )
+from litellm.litellm_core_utils.hook_filter_utils import parse_hook_filters
 from litellm.litellm_core_utils.sensitive_data_masker import SensitiveDataMasker
 from litellm.proxy._types import CommonProxyErrors, LiteLLMPromptInjectionParams
 from litellm.proxy.common_utils.encrypt_decrypt_utils import (
@@ -113,6 +114,31 @@ def _loaded_callback_or_raise(entry: str, loaded: object) -> CustomLogger | Call
     if isinstance(resolved, _CallbackResolvedToClass | _CallbackNotDispatchable):
         _raise_callback_load_error(resolved)
     return resolved
+
+
+def _attach_hook_filters(
+    original_entries: Iterable[object],
+    instantiated_callbacks: Iterable[object],
+    callback_specific_params: Mapping[str, object],
+) -> None:
+    """
+    Generic, callback-agnostic counterpart to guardrail_registry.py's
+    ``_apply_hook_filters``: validates and attaches ``callback_settings.<name>.hook_filters``
+    onto the resolved CustomLogger instance for every ``litellm_settings.callbacks`` entry
+    that is a plain string (the config key) resolving to a CustomLogger (the filterable
+    target). ``original_entries``/``instantiated_callbacks`` are positionally aligned:
+    the caller's loop appends exactly one instantiated object per source entry.
+    """
+    for original_entry, instance in zip(original_entries, instantiated_callbacks, strict=True):
+        if not isinstance(original_entry, str) or not isinstance(instance, CustomLogger):
+            continue
+        entry_params = callback_specific_params.get(original_entry)
+        if not isinstance(entry_params, Mapping):
+            continue
+        raw_hook_filters = entry_params.get("hook_filters")
+        if not isinstance(raw_hook_filters, Mapping):
+            continue
+        instance.hook_filters = parse_hook_filters(original_entry, raw_hook_filters)
 
 
 def initialize_callbacks_on_proxy(
@@ -382,6 +408,8 @@ def initialize_callbacks_on_proxy(
             litellm.callbacks.extend(imported_list)
         else:
             litellm.callbacks = imported_list
+
+        _attach_hook_filters(value, imported_list, callback_specific_params)
 
         if "prometheus" in value:
             from litellm.integrations.prometheus import PrometheusLogger

--- a/litellm/proxy/guardrails/guardrail_registry.py
+++ b/litellm/proxy/guardrails/guardrail_registry.py
@@ -15,6 +15,7 @@ from litellm import Router
 from litellm._logging import verbose_proxy_logger
 from litellm._uuid import uuid
 from litellm.integrations.custom_guardrail import CustomGuardrail
+from litellm.litellm_core_utils.hook_filter_utils import validate_hook_filters
 from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 from litellm.llms.base_llm.guardrail_translation.utils import (
     effective_scan_only_tool_results_for_guardrail,
@@ -436,6 +437,15 @@ def _as_callback_tuple(
     return (initialized,)
 
 
+def _apply_hook_filters(
+    custom_guardrail_callback: CustomGuardrail, guardrail_name: str, litellm_params: LitellmParams
+) -> None:
+    if litellm_params.hook_filters is None:
+        return
+    validate_hook_filters(guardrail_name, litellm_params.hook_filters)
+    custom_guardrail_callback.hook_filters = litellm_params.hook_filters
+
+
 def _configure_callback_scoping(
     custom_guardrail_callback: CustomGuardrail, guardrail_name: str, litellm_params: LitellmParams
 ) -> None:
@@ -445,6 +455,7 @@ def _configure_callback_scoping(
         "scan_only_tool_results",
     ):
         setattr(custom_guardrail_callback, scoping_param, getattr(litellm_params, scoping_param, None))
+    _apply_hook_filters(custom_guardrail_callback, guardrail_name, litellm_params)
     scan_only_tool_results_enabled: Final = effective_scan_only_tool_results_for_guardrail(custom_guardrail_callback)
     if scan_only_tool_results_enabled and not custom_guardrail_callback.supports_scan_only_tool_results():
         raise ValueError(

--- a/litellm/proxy/policy_engine/pipeline_executor.py
+++ b/litellm/proxy/policy_engine/pipeline_executor.py
@@ -16,7 +16,9 @@ from litellm.integrations.custom_guardrail import (
     ModifyResponseException,
 )
 from litellm.integrations.custom_logger import CustomLogger
+from litellm.litellm_core_utils.call_custom_hook import call_custom_hook
 from litellm.litellm_core_utils.core_helpers import independent_snapshot
+from litellm.litellm_core_utils.hook_filter_utils import get_request_tags_for_hook_filters
 from litellm.proxy.guardrails.guardrail_hooks.unified_guardrail.unified_guardrail import (
     UnifiedLLMGuardrails,
 )
@@ -196,8 +198,17 @@ class PipelineExecutor:
                 hook_input["guardrail_to_apply"] = callback
                 target = UnifiedLLMGuardrails()
 
+            hook_filter_key_alias: Final = getattr(user_api_key_dict, "key_alias", None)
+            hook_filter_request_tags: Final = get_request_tags_for_hook_filters(hook_input)
+
             if mode == "pre_call":
-                response = await target.async_pre_call_hook(
+                response = await call_custom_hook(
+                    callback,
+                    "async_pre_call_hook",
+                    target=target,
+                    model=hook_input.get("model"),
+                    key_alias=hook_filter_key_alias,
+                    request_tags=hook_filter_request_tags,
                     user_api_key_dict=user_api_key_dict,
                     cache=None,
                     data=hook_input,
@@ -208,7 +219,13 @@ class PipelineExecutor:
                     if isinstance(response, dict):
                         callback.mark_pre_call_hook_ran(response)
             elif mode == "post_call":
-                response = await target.async_post_call_success_hook(
+                response = await call_custom_hook(
+                    callback,
+                    "async_post_call_success_hook",
+                    target=target,
+                    model=hook_input.get("model"),
+                    key_alias=hook_filter_key_alias,
+                    request_tags=hook_filter_request_tags,
                     user_api_key_dict=user_api_key_dict,
                     data=data,
                     response=data.get("response"),

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -91,10 +91,17 @@ from litellm.integrations.custom_logger import CustomLogger
 from litellm.integrations.prometheus import PrometheusLogger
 from litellm.integrations.SlackAlerting.slack_alerting import SlackAlerting
 from litellm.integrations.SlackAlerting.utils import _add_langfuse_trace_id_to_alert
+from litellm.litellm_core_utils.call_custom_hook import call_custom_hook
 from litellm.litellm_core_utils.core_helpers import (
     coerce_token_limit,
     independent_snapshot,
     is_expected_client_error,
+)
+from litellm.litellm_core_utils.hook_filter_utils import (
+    get_request_tags_for_hook_filters as _get_request_tags_for_hook_filters,
+)
+from litellm.litellm_core_utils.hook_filter_utils import (
+    parse_hook_filters,
 )
 from litellm.litellm_core_utils.litellm_logging import Logging
 from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
@@ -597,6 +604,25 @@ def _failure_fields_to_lift(request_data: Mapping[str, object]) -> Mapping[str, 
     return MappingProxyType({key: value for key, value in _entries if value is not None})
 
 
+def _attach_hook_filters_to_resolved_string_callback(callback_name: str, resolved: CustomLogger) -> None:
+    """
+    A callback configured by its known-integration name (e.g. ``"langfuse"`` in
+    ``litellm_settings.callbacks``) stays a bare string in ``litellm.callbacks`` until
+    ``_init_litellm_callbacks`` resolves it to a real instance here; a
+    ``callback_settings.<name>.hook_filters`` block has nothing to attach to until
+    then, so it must be applied at this resolution point rather than at config-load
+    time (the string-instance counterpart to ``callback_utils.py``'s
+    ``_attach_hook_filters``, which only ever sees already-instantiated callbacks).
+    """
+    entry_params: Final = litellm.callback_settings.get(callback_name)
+    if not isinstance(entry_params, Mapping):
+        return
+    raw_hook_filters: Final = entry_params.get("hook_filters")
+    if not isinstance(raw_hook_filters, Mapping):
+        return
+    resolved.hook_filters = parse_hook_filters(callback_name, raw_hook_filters)
+
+
 @dataclass(frozen=True)
 class _CallbackCapabilities:
     """Cached per-hook capability flags derived from ``litellm.callbacks``.
@@ -835,6 +861,7 @@ class ProxyLogging:
                 )
 
                 if initialized_callback is not None:
+                    _attach_hook_filters_to_resolved_string_callback(callback, initialized_callback)
                     string_callbacks_to_replace[idx] = initialized_callback
 
         # Replace string entries in litellm.callbacks with initialized instances
@@ -1229,22 +1256,43 @@ class ProxyLogging:
             data["guardrail_to_apply"] = callback
 
         target: Final = unified_guardrail if use_unified else callback
+        model: Final = data.get("model")
+        key_alias: Final = user_api_key_dict.key_alias if user_api_key_dict is not None else None
+        request_tags: Final = _get_request_tags_for_hook_filters(data)
 
         if hook_type == "pre_call":
-            return await target.async_pre_call_hook(
+            return await call_custom_hook(
+                callback,
+                "async_pre_call_hook",
+                target=target,
+                model=model,
+                key_alias=key_alias,
+                request_tags=request_tags,
                 user_api_key_dict=user_api_key_dict,
                 cache=self.call_details["user_api_key_cache"],
                 data=data,
                 call_type=call_type,
             )
         elif hook_type == "during_call":
-            return await target.async_moderation_hook(
+            return await call_custom_hook(
+                callback,
+                "async_moderation_hook",
+                target=target,
+                model=model,
+                key_alias=key_alias,
+                request_tags=request_tags,
                 data=data,
                 user_api_key_dict=user_api_key_dict,
                 call_type=call_type,
             )
         elif hook_type == "post_call":
-            return await target.async_post_call_success_hook(
+            return await call_custom_hook(
+                callback,
+                "async_post_call_success_hook",
+                target=target,
+                model=model,
+                key_alias=key_alias,
+                request_tags=request_tags,
                 user_api_key_dict=user_api_key_dict,
                 data=data,
                 response=response,
@@ -1853,7 +1901,12 @@ class ProxyLogging:
                         if call_type == "call_mcp_tool" and user_api_key_dict is None:
                             continue
 
-                        response: Exception | str | Mapping[str, object] | None = await _callback.async_pre_call_hook(
+                        response = await call_custom_hook(
+                            _callback,
+                            "async_pre_call_hook",
+                            model=data.get("model") if data is not None else None,
+                            key_alias=user_api_key_dict.key_alias,
+                            request_tags=_get_request_tags_for_hook_filters(data) if data is not None else (),
                             user_api_key_dict=user_api_key_dict,
                             cache=self.call_details["user_api_key_cache"],
                             data=data,
@@ -2287,6 +2340,8 @@ class ProxyLogging:
                 else:
                     user_api_key_auth_dict = user_api_key_dict
                 # Add task to list for parallel execution
+                hook_filter_key_alias = user_api_key_dict.key_alias if user_api_key_dict is not None else None
+                hook_filter_request_tags = _get_request_tags_for_hook_filters(data)
                 if (
                     "apply_guardrail" in type(callback).__dict__
                     and not callback.use_native_lifecycle_hooks
@@ -2296,7 +2351,13 @@ class ProxyLogging:
                     data["guardrail_to_apply"] = callback
                     guardrail_task = self._run_guardrail_with_metrics(
                         callback,
-                        unified_guardrail.async_moderation_hook(
+                        call_custom_hook(
+                            callback,
+                            "async_moderation_hook",
+                            target=unified_guardrail,
+                            model=data.get("model"),
+                            key_alias=hook_filter_key_alias,
+                            request_tags=hook_filter_request_tags,
                             user_api_key_dict=user_api_key_dict,
                             data=data,
                             call_type=call_type,
@@ -2306,7 +2367,12 @@ class ProxyLogging:
                 else:
                     guardrail_task = self._run_guardrail_with_metrics(
                         callback,
-                        callback.async_moderation_hook(
+                        call_custom_hook(
+                            callback,
+                            "async_moderation_hook",
+                            model=data.get("model"),
+                            key_alias=hook_filter_key_alias,
+                            request_tags=hook_filter_request_tags,
                             data=data,
                             user_api_key_dict=user_api_key_auth_dict,
                             call_type=call_type,
@@ -2570,6 +2636,9 @@ class ProxyLogging:
 
         # Track the first HTTPException returned or raised by any callback
         transformed_exception: HTTPException | None = None
+        hook_filter_model: Final = request_data.get("model")
+        hook_filter_key_alias: Final = user_api_key_dict.key_alias
+        hook_filter_request_tags: Final = _get_request_tags_for_hook_filters(request_data)
 
         for callback in litellm.callbacks:
             try:
@@ -2582,7 +2651,12 @@ class ProxyLogging:
                     _callback = callback
                 if _callback is not None and isinstance(_callback, CustomLogger):
                     try:
-                        hook_result = await _callback.async_post_call_failure_hook(
+                        hook_result = await call_custom_hook(
+                            _callback,
+                            "async_post_call_failure_hook",
+                            model=hook_filter_model,
+                            key_alias=hook_filter_key_alias,
+                            request_tags=hook_filter_request_tags,
                             request_data=request_data,
                             user_api_key_dict=user_api_key_dict,
                             original_exception=original_exception,
@@ -2800,6 +2874,9 @@ class ProxyLogging:
             parallel_guardrails: Final[tuple[CustomGuardrail, ...]] = tuple(
                 callback for callback in guardrail_callbacks if getattr(callback, "run_in_parallel", False)
             )
+            hook_filter_model: Final = data.get("model")
+            hook_filter_key_alias: Final = user_api_key_dict.key_alias
+            hook_filter_request_tags: Final = _get_request_tags_for_hook_filters(data)
 
             for callback in guardrail_callbacks:
                 # Main - V2 Guardrails implementation
@@ -2822,7 +2899,13 @@ class ProxyLogging:
                     data["guardrail_to_apply"] = callback
                     guardrail_response = await self._run_guardrail_with_metrics(
                         callback,
-                        unified_guardrail.async_post_call_success_hook(
+                        call_custom_hook(
+                            callback,
+                            "async_post_call_success_hook",
+                            target=unified_guardrail,
+                            model=hook_filter_model,
+                            key_alias=hook_filter_key_alias,
+                            request_tags=hook_filter_request_tags,
                             user_api_key_dict=user_api_key_dict,
                             data=data,
                             response=response,
@@ -2832,7 +2915,12 @@ class ProxyLogging:
                 else:
                     guardrail_response = await self._run_guardrail_with_metrics(
                         callback,
-                        callback.async_post_call_success_hook(
+                        call_custom_hook(
+                            callback,
+                            "async_post_call_success_hook",
+                            model=hook_filter_model,
+                            key_alias=hook_filter_key_alias,
+                            request_tags=hook_filter_request_tags,
                             user_api_key_dict=user_api_key_dict,
                             data=data,
                             response=response,
@@ -2856,11 +2944,18 @@ class ProxyLogging:
             #################################################################
 
             for callback in other_callbacks:
-                callback_response: LLMResponseTypes | None = await callback.async_post_call_success_hook(
-                    user_api_key_dict=user_api_key_dict, data=data, response=response
+                callback_response = await call_custom_hook(
+                    callback,
+                    "async_post_call_success_hook",
+                    model=hook_filter_model,
+                    key_alias=hook_filter_key_alias,
+                    request_tags=hook_filter_request_tags,
+                    user_api_key_dict=user_api_key_dict,
+                    data=data,
+                    response=response,
                 )
                 if callback_response is not None:
-                    response = callback_response
+                    response = callback_response  # pyright: ignore[reportAssignmentType]  # object-typed
         except Exception as e:
             raise e
         return response
@@ -2888,6 +2983,10 @@ class ProxyLogging:
         suspension point, so concurrent guardrails never race on that key.
         """
 
+        hook_filter_model: Final = data.get("model")
+        hook_filter_key_alias: Final = user_api_key_dict.key_alias
+        hook_filter_request_tags: Final = _get_request_tags_for_hook_filters(data)
+
         async def _run_one(callback: CustomGuardrail) -> None:
             if callback.should_run_guardrail(data=guardrail_data, event_type=GuardrailEventHooks.post_call) is not True:
                 return
@@ -2895,7 +2994,13 @@ class ProxyLogging:
                 data["guardrail_to_apply"] = callback
                 await self._run_guardrail_with_metrics(
                     callback,
-                    unified_guardrail.async_post_call_success_hook(
+                    call_custom_hook(
+                        callback,
+                        "async_post_call_success_hook",
+                        target=unified_guardrail,
+                        model=hook_filter_model,
+                        key_alias=hook_filter_key_alias,
+                        request_tags=hook_filter_request_tags,
                         user_api_key_dict=user_api_key_dict,
                         data=data,
                         response=response,
@@ -2905,7 +3010,12 @@ class ProxyLogging:
             else:
                 await self._run_guardrail_with_metrics(
                     callback,
-                    callback.async_post_call_success_hook(
+                    call_custom_hook(
+                        callback,
+                        "async_post_call_success_hook",
+                        model=hook_filter_model,
+                        key_alias=hook_filter_key_alias,
+                        request_tags=hook_filter_request_tags,
                         user_api_key_dict=user_api_key_dict,
                         data=data,
                         response=response,
@@ -3014,8 +3124,16 @@ class ProxyLogging:
                     _callback = callback
 
                 if _callback is not None and isinstance(_callback, CustomLogger):
+                    hook_filter_model = data.get("model")
+                    hook_filter_key_alias = user_api_key_dict.key_alias
+                    hook_filter_request_tags = _get_request_tags_for_hook_filters(data)
                     if _accepts_litellm_call_info(_callback):
-                        result = await _callback.async_post_call_response_headers_hook(
+                        result = await call_custom_hook(
+                            _callback,
+                            "async_post_call_response_headers_hook",
+                            model=hook_filter_model,
+                            key_alias=hook_filter_key_alias,
+                            request_tags=hook_filter_request_tags,
                             data=data,
                             user_api_key_dict=user_api_key_dict,
                             response=response,
@@ -3024,13 +3142,18 @@ class ProxyLogging:
                         )
                     else:
                         # Backwards compat: callback doesn't accept litellm_call_info
-                        result = await _callback.async_post_call_response_headers_hook(
+                        result = await call_custom_hook(
+                            _callback,
+                            "async_post_call_response_headers_hook",
+                            model=hook_filter_model,
+                            key_alias=hook_filter_key_alias,
+                            request_tags=hook_filter_request_tags,
                             data=data,
                             user_api_key_dict=user_api_key_dict,
                             response=response,
                             request_headers=request_headers,
                         )
-                    if result is not None:
+                    if isinstance(result, Mapping):
                         merged_headers.update(result)
         except Exception as e:
             verbose_proxy_logger.exception("Error in post_call_response_headers_hook: %s", str(e))
@@ -3100,6 +3223,9 @@ class ProxyLogging:
             # dict lookups + llm_router.get_deployment() per callback per chunk.
             _cached_guardrail_data: dict | None = None
             _guardrail_data_computed = False
+            hook_filter_model: Final = data.get("model")
+            hook_filter_key_alias: Final = user_api_key_dict.key_alias
+            hook_filter_request_tags: Final = _get_request_tags_for_hook_filters(data)
 
             for callback in litellm.callbacks:
                 try:
@@ -3134,15 +3260,17 @@ class ProxyLogging:
                             complete_response = str_so_far + response_str
                         else:
                             complete_response = response_str
-                        callback_response: (
-                            ModelResponse | EmbeddingResponse | ImageResponse | ModelResponseStream | None
-                        )
-                        callback_response = await _callback.async_post_call_streaming_hook(
+                        callback_response = await call_custom_hook(
+                            _callback,
+                            "async_post_call_streaming_hook",
+                            model=hook_filter_model,
+                            key_alias=hook_filter_key_alias,
+                            request_tags=hook_filter_request_tags,
                             user_api_key_dict=user_api_key_dict,
                             response=complete_response,
                         )
                         if callback_response is not None:
-                            response = callback_response
+                            response = callback_response  # pyright: ignore[reportAssignmentType]  # object-typed
                 except Exception as e:
                     raise e
         return response

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -91,7 +91,7 @@ from litellm.integrations.custom_logger import CustomLogger
 from litellm.integrations.prometheus import PrometheusLogger
 from litellm.integrations.SlackAlerting.slack_alerting import SlackAlerting
 from litellm.integrations.SlackAlerting.utils import _add_langfuse_trace_id_to_alert
-from litellm.litellm_core_utils.call_custom_hook import call_custom_hook
+from litellm.litellm_core_utils.call_custom_hook import call_custom_hook, should_run_hook_for_callback
 from litellm.litellm_core_utils.core_helpers import (
     coerce_token_limit,
     independent_snapshot,
@@ -3321,6 +3321,14 @@ class ProxyLogging:
                     is not True
                 ):
                     continue
+            if not should_run_hook_for_callback(
+                resolved_callback,
+                "async_post_call_streaming_iterator_hook",
+                model=request_data.get("model"),
+                key_alias=user_api_key_dict.key_alias,
+                request_tags=_get_request_tags_for_hook_filters(request_data),
+            ):
+                continue
             effective_kind = (
                 "apply_guardrail"
                 if (

--- a/litellm/types/guardrails.py
+++ b/litellm/types/guardrails.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 from typing_extensions import Required, TypedDict
 
 from litellm.constants import BEDROCK_APPLY_GUARDRAIL_CHUNK_BUDGET_CHARS
+from litellm.types.hook_filters import HookFilterConfig
 from litellm.types.proxy.guardrails.guardrail_hooks.akto import (
     AktoConfigModel,
 )
@@ -829,6 +830,15 @@ class BaseLitellmParams(ContentFilterConfigModel):  # works for new and patch up
             "agent feeds back into the model, and skip system, user, and assistant content. "
             "Intended for agent harnesses whose own prompt scaffolding is trusted but often "
             "trips prompt-attack detectors."
+        ),
+    )
+
+    hook_filters: Mapping[str, HookFilterConfig] | None = Field(
+        default=None,
+        description=(
+            "Per-hook-method request filters, keyed by CustomLogger/CustomGuardrail hook "
+            "name (e.g. async_pre_call_hook). Only enforced when litellm.enable_hook_filters "
+            "is True; a hook with no entry here always runs, unfiltered."
         ),
     )
 

--- a/litellm/types/hook_filters.py
+++ b/litellm/types/hook_filters.py
@@ -1,0 +1,67 @@
+from typing import Final
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class HookFilterConfig(BaseModel):
+    """
+    Scopes a single hook method on a callback/guardrail to a subset of requests.
+    Each field is OR-matched against its own dimension (any pattern matching is
+    enough); a filter with more than one dimension set requires all of them to
+    match (AND across dimensions). A dimension left unset (``None``) always
+    matches; an explicit empty list matches nothing, since it has no patterns
+    for any value to satisfy.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    models: tuple[str, ...] | None = Field(
+        default=None,
+        description="Glob patterns matched against the requested model group name.",
+    )
+    key_aliases: tuple[str, ...] | None = Field(
+        default=None,
+        description="Glob patterns matched against the calling virtual key's key_alias.",
+    )
+    model_tags: tuple[str, ...] | None = Field(
+        default=None,
+        description=(
+            "Glob patterns matched against the resolved deployment's litellm_params.tags. "
+            "Only valid on deployment-scoped hooks, since deployment tags aren't resolved "
+            "yet when a pre-routing hook runs."
+        ),
+    )
+    request_tags: tuple[str, ...] | None = Field(
+        default=None,
+        description="Glob patterns matched against the request's metadata.tags / x-litellm-tags.",
+    )
+
+
+DEPLOYMENT_SCOPED_HOOK_NAMES: Final[frozenset[str]] = frozenset(
+    (
+        "async_pre_call_deployment_hook",
+        "async_post_call_success_deployment_hook",
+        "async_post_call_failure_deployment_hook",
+        "async_post_call_streaming_deployment_hook",
+    )
+)
+
+_PROXY_SCOPED_HOOK_NAMES: Final[frozenset[str]] = frozenset(
+    (
+        "async_pre_call_hook",
+        "async_moderation_hook",
+        "async_post_call_success_hook",
+        "async_post_call_failure_hook",
+        "async_post_call_response_headers_hook",
+        "async_post_call_streaming_hook",
+        "async_post_call_streaming_iterator_hook",
+        "logging_hook",
+        "async_logging_hook",
+        "log_success_event",
+        "async_log_success_event",
+        "log_failure_event",
+        "async_log_failure_event",
+    )
+)
+
+FILTERABLE_HOOK_NAMES: Final[frozenset[str]] = DEPLOYMENT_SCOPED_HOOK_NAMES | _PROXY_SCOPED_HOOK_NAMES

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -105,6 +105,26 @@ def _get_cached_custom_logger():
     return _CustomLogger
 
 
+def _hook_filter_context_for_deployment_hook(
+    request_data: Mapping[str, object],
+) -> tuple[str | None, str | None, tuple[str, ...]]:
+    """
+    By the time a deployment-scoped hook fires, the router has already merged the
+    resolved deployment's own litellm_params.tags into metadata.tags alongside any
+    caller-supplied tags, so model_tags and request_tags share one merged list here.
+    """
+    model: Final = request_data.get("model")
+    metadata: Final = request_data.get("metadata")
+    key_alias: Final = metadata.get("user_api_key_alias") if isinstance(metadata, Mapping) else None
+    raw_tags: Final = metadata.get("tags") if isinstance(metadata, Mapping) else None
+    tags: Final = tuple(raw_tags) if isinstance(raw_tags, list) else ()
+    return (
+        model if isinstance(model, str) else None,
+        key_alias if isinstance(key_alias, str) else None,
+        tags,
+    )
+
+
 @lru_cache(maxsize=None)
 def _accepts_fallback_depth_kwarg_for_class(cls: type) -> bool:
     """
@@ -1272,11 +1292,25 @@ async def async_pre_call_deployment_hook(kwargs: dict[str, Any], call_type: str)
 
     modified_kwargs = kwargs.copy()
 
+    from litellm.litellm_core_utils.call_custom_hook import call_custom_hook
+
+    hook_filter_model, hook_filter_key_alias, hook_filter_request_tags = _hook_filter_context_for_deployment_hook(
+        modified_kwargs
+    )
     CustomLogger: Final = _get_cached_custom_logger()
     for callback in litellm.callbacks:
         if isinstance(callback, CustomLogger):
-            result = await callback.async_pre_call_deployment_hook(modified_kwargs, typed_call_type)
-            if result is not None:
+            result = await call_custom_hook(
+                callback,
+                "async_pre_call_deployment_hook",
+                model=hook_filter_model,
+                key_alias=hook_filter_key_alias,
+                model_tags=hook_filter_request_tags,
+                request_tags=hook_filter_request_tags,
+                kwargs=modified_kwargs,
+                call_type=typed_call_type,
+            )
+            if isinstance(result, dict):
                 modified_kwargs = result
 
     return modified_kwargs
@@ -1295,11 +1329,24 @@ async def async_post_call_success_deployment_hook(
 
     modified_response = response
 
+    from litellm.litellm_core_utils.call_custom_hook import call_custom_hook
+
+    hook_filter_model, hook_filter_key_alias, hook_filter_request_tags = _hook_filter_context_for_deployment_hook(
+        request_data
+    )
     CustomLogger: Final = _get_cached_custom_logger()
     for callback in litellm.callbacks:
         if isinstance(callback, CustomLogger):
-            result = await callback.async_post_call_success_deployment_hook(
-                request_data, cast(LLMResponseTypes, modified_response), typed_call_type
+            result = await call_custom_hook(
+                callback,
+                "async_post_call_success_deployment_hook",
+                model=hook_filter_model,
+                key_alias=hook_filter_key_alias,
+                model_tags=hook_filter_request_tags,
+                request_tags=hook_filter_request_tags,
+                request_data=request_data,
+                response=cast(LLMResponseTypes, modified_response),
+                call_type=typed_call_type,
             )
             if result is not None:
                 modified_response = result
@@ -1340,17 +1387,39 @@ async def async_post_call_failure_deployment_hook(
     safe_request_data: Final = MappingProxyType({k: v for k, v in request_data.items() if k != "attempted_targets"})
     safe_exception: Final = _snapshot_exception_for_hook(exception)
 
+    from litellm.litellm_core_utils.call_custom_hook import call_custom_hook
+
+    hook_filter_model, hook_filter_key_alias, hook_filter_request_tags = _hook_filter_context_for_deployment_hook(
+        safe_request_data
+    )
     CustomLogger: Final = _get_cached_custom_logger()
     for callback in litellm.callbacks:
         if isinstance(callback, CustomLogger):
             try:
                 if _accepts_fallback_depth_kwarg_for_class(type(callback)):
-                    await callback.async_post_call_failure_deployment_hook(
-                        safe_request_data, safe_exception, typed_call_type, fallback_depth=fallback_depth
+                    await call_custom_hook(
+                        callback,
+                        "async_post_call_failure_deployment_hook",
+                        model=hook_filter_model,
+                        key_alias=hook_filter_key_alias,
+                        model_tags=hook_filter_request_tags,
+                        request_tags=hook_filter_request_tags,
+                        request_data=safe_request_data,
+                        exception=safe_exception,
+                        call_type=typed_call_type,
+                        fallback_depth=fallback_depth,
                     )
                 else:
-                    await callback.async_post_call_failure_deployment_hook(
-                        safe_request_data, safe_exception, typed_call_type
+                    await call_custom_hook(
+                        callback,
+                        "async_post_call_failure_deployment_hook",
+                        model=hook_filter_model,
+                        key_alias=hook_filter_key_alias,
+                        model_tags=hook_filter_request_tags,
+                        request_tags=hook_filter_request_tags,
+                        request_data=safe_request_data,
+                        exception=safe_exception,
+                        call_type=typed_call_type,
                     )
             except Exception as callback_error:  # noqa: BLE001  # a broken callback must not mask the real failure
                 verbose_logger.debug(

--- a/tests/test_litellm/litellm_core_utils/test_call_custom_hook.py
+++ b/tests/test_litellm/litellm_core_utils/test_call_custom_hook.py
@@ -1,0 +1,284 @@
+import pytest
+
+from litellm.integrations.custom_logger import CustomLogger
+from litellm.litellm_core_utils.call_custom_hook import call_custom_hook, call_custom_hook_sync
+from litellm.litellm_core_utils.hook_filter_utils import parse_hook_filters
+
+
+class _RecordingLogger(CustomLogger):
+    def __init__(self):
+        super().__init__()
+        self.calls = []
+
+    async def async_pre_call_hook(self, user_api_key_dict, cache, data, call_type):
+        self.calls.append(("async_pre_call_hook", data, call_type))
+        return data
+
+    async def async_moderation_hook(self, data, user_api_key_dict, call_type):
+        self.calls.append(("async_moderation_hook", data, call_type))
+        return None
+
+    def log_success_event(self, kwargs, response_obj, start_time, end_time):
+        self.calls.append(("log_success_event", kwargs))
+        return "logged"
+
+
+@pytest.fixture
+def callback():
+    return _RecordingLogger()
+
+
+class TestCallCustomHookAsync:
+    @pytest.mark.asyncio
+    async def test_runs_when_no_hook_filters_attached_at_all(self, monkeypatch, callback):
+        monkeypatch.setattr("litellm.enable_hook_filters", True)
+        assert callback.hook_filters is None
+        result = await call_custom_hook(
+            callback,
+            "async_pre_call_hook",
+            model="gpt-4o",
+            key_alias=None,
+            model_tags=(),
+            request_tags=(),
+            user_api_key_dict=None,
+            cache=None,
+            data={"model": "gpt-4o"},
+            call_type="acompletion",
+        )
+        assert result == {"model": "gpt-4o"}
+        assert callback.calls == [("async_pre_call_hook", {"model": "gpt-4o"}, "acompletion")]
+
+    @pytest.mark.asyncio
+    async def test_runs_when_this_hook_has_no_filter_entry_but_sibling_hook_does(self, monkeypatch, callback):
+        """Per-hook-method granularity: a filter on async_moderation_hook must not
+        affect async_pre_call_hook on the same instance."""
+        monkeypatch.setattr("litellm.enable_hook_filters", True)
+        callback.hook_filters = parse_hook_filters(
+            "recording", {"async_moderation_hook": {"models": ["claude-*"]}}
+        )
+        result = await call_custom_hook(
+            callback,
+            "async_pre_call_hook",
+            model="gpt-4o",
+            key_alias=None,
+            model_tags=(),
+            request_tags=(),
+            user_api_key_dict=None,
+            cache=None,
+            data={"model": "gpt-4o"},
+            call_type="acompletion",
+        )
+        assert result == {"model": "gpt-4o"}
+        assert len(callback.calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_skips_when_enable_hook_filters_true_and_models_filter_excludes(self, monkeypatch, callback):
+        monkeypatch.setattr("litellm.enable_hook_filters", True)
+        callback.hook_filters = parse_hook_filters("recording", {"async_pre_call_hook": {"models": ["claude-*"]}})
+        result = await call_custom_hook(
+            callback,
+            "async_pre_call_hook",
+            model="gpt-4o",
+            key_alias=None,
+            model_tags=(),
+            request_tags=(),
+            user_api_key_dict=None,
+            cache=None,
+            data={"model": "gpt-4o"},
+            call_type="acompletion",
+        )
+        assert result is None
+        assert callback.calls == []
+
+    @pytest.mark.asyncio
+    async def test_runs_when_enable_hook_filters_true_and_models_filter_matches(self, monkeypatch, callback):
+        monkeypatch.setattr("litellm.enable_hook_filters", True)
+        callback.hook_filters = parse_hook_filters("recording", {"async_pre_call_hook": {"models": ["gpt-4o*"]}})
+        result = await call_custom_hook(
+            callback,
+            "async_pre_call_hook",
+            model="gpt-4o",
+            key_alias=None,
+            model_tags=(),
+            request_tags=(),
+            user_api_key_dict=None,
+            cache=None,
+            data={"model": "gpt-4o"},
+            call_type="acompletion",
+        )
+        assert result == {"model": "gpt-4o"}
+        assert len(callback.calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_skips_on_key_aliases_filter_mismatch(self, monkeypatch, callback):
+        monkeypatch.setattr("litellm.enable_hook_filters", True)
+        callback.hook_filters = parse_hook_filters(
+            "recording", {"async_pre_call_hook": {"key_aliases": ["prod-*"]}}
+        )
+        result = await call_custom_hook(
+            callback,
+            "async_pre_call_hook",
+            model=None,
+            key_alias="dev-key-1",
+            model_tags=(),
+            request_tags=(),
+            user_api_key_dict=None,
+            cache=None,
+            data={},
+            call_type="acompletion",
+        )
+        assert result is None
+        assert callback.calls == []
+
+    @pytest.mark.asyncio
+    async def test_runs_on_request_tags_filter_match(self, monkeypatch, callback):
+        monkeypatch.setattr("litellm.enable_hook_filters", True)
+        callback.hook_filters = parse_hook_filters(
+            "recording", {"async_pre_call_hook": {"request_tags": ["scan-me"]}}
+        )
+        result = await call_custom_hook(
+            callback,
+            "async_pre_call_hook",
+            model=None,
+            key_alias=None,
+            model_tags=(),
+            request_tags=("unrelated", "scan-me"),
+            user_api_key_dict=None,
+            cache=None,
+            data={},
+            call_type="acompletion",
+        )
+        assert result == {}
+        assert len(callback.calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_ignores_hook_filters_entirely_when_enable_hook_filters_false(self, monkeypatch, callback):
+        monkeypatch.setattr("litellm.enable_hook_filters", False)
+        callback.hook_filters = parse_hook_filters("recording", {"async_pre_call_hook": {"models": ["claude-*"]}})
+        result = await call_custom_hook(
+            callback,
+            "async_pre_call_hook",
+            model="gpt-4o",
+            key_alias=None,
+            model_tags=(),
+            request_tags=(),
+            user_api_key_dict=None,
+            cache=None,
+            data={"model": "gpt-4o"},
+            call_type="acompletion",
+        )
+        assert result == {"model": "gpt-4o"}
+        assert len(callback.calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_target_is_invoked_but_filters_are_checked_against_callback(self, monkeypatch, callback):
+        """Covers ProxyLogging's unified-guardrail wrapper: the config-owning
+        object (callback) and the object actually invoked (target) can differ."""
+        monkeypatch.setattr("litellm.enable_hook_filters", True)
+        callback.hook_filters = parse_hook_filters("recording", {"async_pre_call_hook": {"models": ["claude-*"]}})
+        wrapper = _RecordingLogger()
+
+        result = await call_custom_hook(
+            callback,
+            "async_pre_call_hook",
+            target=wrapper,
+            model="gpt-4o",
+            key_alias=None,
+            model_tags=(),
+            request_tags=(),
+            user_api_key_dict=None,
+            cache=None,
+            data={"model": "gpt-4o"},
+            call_type="acompletion",
+        )
+        assert result is None
+        assert callback.calls == []
+        assert wrapper.calls == []
+
+        callback.hook_filters = parse_hook_filters("recording", {"async_pre_call_hook": {"models": ["gpt-4o*"]}})
+        result = await call_custom_hook(
+            callback,
+            "async_pre_call_hook",
+            target=wrapper,
+            model="gpt-4o",
+            key_alias=None,
+            model_tags=(),
+            request_tags=(),
+            user_api_key_dict=None,
+            cache=None,
+            data={"model": "gpt-4o"},
+            call_type="acompletion",
+        )
+        assert result == {"model": "gpt-4o"}
+        assert callback.calls == []
+        assert len(wrapper.calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_forwards_hook_kwargs_verbatim_to_the_named_hook(self, monkeypatch, callback):
+        monkeypatch.setattr("litellm.enable_hook_filters", False)
+        sentinel_data = {"model": "gpt-4o", "messages": [{"role": "user", "content": "hi"}]}
+        await call_custom_hook(
+            callback,
+            "async_pre_call_hook",
+            user_api_key_dict="fake-key-dict",
+            cache="fake-cache",
+            data=sentinel_data,
+            call_type="acompletion",
+        )
+        assert callback.calls == [("async_pre_call_hook", sentinel_data, "acompletion")]
+
+
+class TestCallCustomHookSync:
+    def test_runs_when_filter_matches(self, monkeypatch, callback):
+        monkeypatch.setattr("litellm.enable_hook_filters", True)
+        callback.hook_filters = parse_hook_filters("recording", {"log_success_event": {"key_aliases": ["prod-*"]}})
+        result = call_custom_hook_sync(
+            callback,
+            "log_success_event",
+            model=None,
+            key_alias="prod-key-1",
+            model_tags=(),
+            request_tags=(),
+            kwargs={},
+            response_obj=None,
+            start_time=0,
+            end_time=1,
+        )
+        assert result == "logged"
+        assert len(callback.calls) == 1
+
+    def test_skips_when_filter_excludes(self, monkeypatch, callback):
+        monkeypatch.setattr("litellm.enable_hook_filters", True)
+        callback.hook_filters = parse_hook_filters("recording", {"log_success_event": {"key_aliases": ["prod-*"]}})
+        result = call_custom_hook_sync(
+            callback,
+            "log_success_event",
+            model=None,
+            key_alias="dev-key-1",
+            model_tags=(),
+            request_tags=(),
+            kwargs={},
+            response_obj=None,
+            start_time=0,
+            end_time=1,
+        )
+        assert result is None
+        assert callback.calls == []
+
+    def test_ignores_hook_filters_when_enable_hook_filters_false(self, monkeypatch, callback):
+        monkeypatch.setattr("litellm.enable_hook_filters", False)
+        callback.hook_filters = parse_hook_filters("recording", {"log_success_event": {"key_aliases": ["prod-*"]}})
+        result = call_custom_hook_sync(
+            callback,
+            "log_success_event",
+            model=None,
+            key_alias="dev-key-1",
+            model_tags=(),
+            request_tags=(),
+            kwargs={},
+            response_obj=None,
+            start_time=0,
+            end_time=1,
+        )
+        assert result == "logged"
+        assert len(callback.calls) == 1

--- a/tests/test_litellm/litellm_core_utils/test_hook_filter_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_hook_filter_utils.py
@@ -1,0 +1,160 @@
+import pytest
+
+from litellm.litellm_core_utils.hook_filter_utils import parse_hook_filters, should_run_hook_for_filters
+from litellm.types.hook_filters import HookFilterConfig
+
+
+class TestShouldRunHookForFilters:
+    def test_none_filter_always_runs(self):
+        assert (
+            should_run_hook_for_filters(
+                None, model="gpt-4o", key_alias="prod-key", model_tags=(), request_tags=()
+            )
+            is True
+        )
+
+    def test_empty_filter_always_runs(self):
+        assert (
+            should_run_hook_for_filters(
+                HookFilterConfig(), model="gpt-4o", key_alias="prod-key", model_tags=(), request_tags=()
+            )
+            is True
+        )
+
+    def test_models_dimension_matches_glob(self):
+        hook_filter = HookFilterConfig(models=["gpt-4o*"])
+        assert (
+            should_run_hook_for_filters(
+                hook_filter, model="gpt-4o-mini", key_alias=None, model_tags=(), request_tags=()
+            )
+            is True
+        )
+        assert (
+            should_run_hook_for_filters(
+                hook_filter, model="claude-3-opus", key_alias=None, model_tags=(), request_tags=()
+            )
+            is False
+        )
+
+    def test_models_dimension_no_model_never_matches(self):
+        hook_filter = HookFilterConfig(models=["gpt-4o*"])
+        assert (
+            should_run_hook_for_filters(hook_filter, model=None, key_alias=None, model_tags=(), request_tags=())
+            is False
+        )
+
+    def test_key_aliases_dimension_or_within(self):
+        hook_filter = HookFilterConfig(key_aliases=["prod-*", "staging-*"])
+        assert (
+            should_run_hook_for_filters(
+                hook_filter, model=None, key_alias="staging-key-1", model_tags=(), request_tags=()
+            )
+            is True
+        )
+        assert (
+            should_run_hook_for_filters(
+                hook_filter, model=None, key_alias="dev-key-1", model_tags=(), request_tags=()
+            )
+            is False
+        )
+
+    def test_request_tags_matches_if_any_request_tag_matches_any_pattern(self):
+        hook_filter = HookFilterConfig(request_tags=["scan-me"])
+        assert (
+            should_run_hook_for_filters(
+                hook_filter,
+                model=None,
+                key_alias=None,
+                model_tags=(),
+                request_tags=("unrelated", "scan-me"),
+            )
+            is True
+        )
+        assert (
+            should_run_hook_for_filters(
+                hook_filter, model=None, key_alias=None, model_tags=(), request_tags=("unrelated",)
+            )
+            is False
+        )
+
+    def test_explicit_empty_list_dimension_matches_nothing_unlike_unset(self):
+        """An explicit `[]` is not the same as leaving the field unset: it has
+        no patterns for any value to satisfy, so it matches nothing, while an
+        unset (None) dimension always matches."""
+        hook_filter = HookFilterConfig(models=[])
+        assert (
+            should_run_hook_for_filters(
+                hook_filter, model="gpt-4o", key_alias=None, model_tags=(), request_tags=()
+            )
+            is False
+        )
+
+    def test_model_tags_matches_if_any_deployment_tag_matches_any_pattern(self):
+        hook_filter = HookFilterConfig(model_tags=["needs-pii-scan"])
+        assert (
+            should_run_hook_for_filters(
+                hook_filter,
+                model=None,
+                key_alias=None,
+                model_tags=("needs-pii-scan", "other-tag"),
+                request_tags=(),
+            )
+            is True
+        )
+        assert (
+            should_run_hook_for_filters(
+                hook_filter, model=None, key_alias=None, model_tags=("other-tag",), request_tags=()
+            )
+            is False
+        )
+
+    def test_multiple_dimensions_are_and_ed_together(self):
+        hook_filter = HookFilterConfig(models=["gpt-4o*"], key_aliases=["prod-*"])
+        # model matches but key_alias doesn't -> overall False
+        assert (
+            should_run_hook_for_filters(
+                hook_filter, model="gpt-4o", key_alias="dev-key", model_tags=(), request_tags=()
+            )
+            is False
+        )
+        # both match -> True
+        assert (
+            should_run_hook_for_filters(
+                hook_filter, model="gpt-4o", key_alias="prod-key", model_tags=(), request_tags=()
+            )
+            is True
+        )
+        # neither match -> False
+        assert (
+            should_run_hook_for_filters(
+                hook_filter, model="claude-3", key_alias="dev-key", model_tags=(), request_tags=()
+            )
+            is False
+        )
+
+
+class TestParseHookFilters:
+    def test_valid_hook_names_parse_successfully(self):
+        parsed = parse_hook_filters(
+            "lakera_guard",
+            {"async_pre_call_hook": {"models": ["gpt-4o*"]}},
+        )
+        assert parsed["async_pre_call_hook"].models == ("gpt-4o*",)
+
+    def test_unknown_hook_name_raises(self):
+        with pytest.raises(ValueError, match="unknown hook name"):
+            parse_hook_filters("lakera_guard", {"not_a_real_hook": {"models": ["gpt-4o*"]}})
+
+    def test_model_tags_on_non_deployment_hook_raises(self):
+        with pytest.raises(ValueError, match="model_tags"):
+            parse_hook_filters(
+                "lakera_guard",
+                {"async_pre_call_hook": {"model_tags": ["needs-pii-scan"]}},
+            )
+
+    def test_model_tags_on_deployment_scoped_hook_is_allowed(self):
+        parsed = parse_hook_filters(
+            "lakera_guard",
+            {"async_pre_call_deployment_hook": {"model_tags": ["needs-pii-scan"]}},
+        )
+        assert parsed["async_pre_call_deployment_hook"].model_tags == ("needs-pii-scan",)

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -6277,3 +6277,179 @@ def test_passthrough_embeddings_result_swapped_for_callbacks():
 
     assert isinstance(swapped_result, EmbeddingResponse)
     assert swapped_result.data[0]["embedding"] == [0.1, 0.2, 0.3]
+
+
+# ---------------------------------------------------------------------------
+# hook_filters: success_handler (sync log_success_event)
+# ---------------------------------------------------------------------------
+
+
+def test_success_handler_skips_when_hook_filters_model_excludes(logging_obj, monkeypatch):
+    from litellm.integrations.custom_logger import CustomLogger
+    from litellm.litellm_core_utils.hook_filter_utils import parse_hook_filters
+
+    monkeypatch.setattr(litellm, "enable_hook_filters", True)
+    calls = []
+
+    class DummyLogger(CustomLogger):
+        def log_success_event(self, kwargs, response_obj, start_time, end_time):
+            calls.append(response_obj)
+
+    logging_obj.stream = False
+    logging_obj.call_type = "completion"
+    logging_obj.model_call_details["litellm_params"] = {}
+    logging_obj.litellm_params = {}
+
+    dummy_logger = DummyLogger()
+    dummy_logger.hook_filters = parse_hook_filters("dummy", {"log_success_event": {"models": ["claude-*"]}})
+
+    model_response = ModelResponse(
+        id="resp-123",
+        model="gpt-4o-mini",
+        choices=[{"message": {"role": "assistant", "content": "hello"}, "finish_reason": "stop", "index": 0}],
+        usage={"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    )
+
+    with patch.object(logging_obj, "get_combined_callback_list", return_value=[dummy_logger]):
+        logging_obj.success_handler(result=model_response)
+
+    assert calls == []
+
+
+def test_success_handler_runs_when_hook_filters_model_matches(logging_obj, monkeypatch):
+    from litellm.integrations.custom_logger import CustomLogger
+    from litellm.litellm_core_utils.hook_filter_utils import parse_hook_filters
+
+    monkeypatch.setattr(litellm, "enable_hook_filters", True)
+    calls = []
+
+    class DummyLogger(CustomLogger):
+        def log_success_event(self, kwargs, response_obj, start_time, end_time):
+            calls.append(response_obj)
+
+    logging_obj.stream = False
+    logging_obj.call_type = "completion"
+    logging_obj.model_call_details["litellm_params"] = {}
+    logging_obj.litellm_params = {}
+
+    dummy_logger = DummyLogger()
+    dummy_logger.hook_filters = parse_hook_filters("dummy", {"log_success_event": {"models": ["bedrock/*"]}})
+
+    model_response = ModelResponse(
+        id="resp-123",
+        model="gpt-4o-mini",
+        choices=[{"message": {"role": "assistant", "content": "hello"}, "finish_reason": "stop", "index": 0}],
+        usage={"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    )
+
+    with patch.object(logging_obj, "get_combined_callback_list", return_value=[dummy_logger]):
+        logging_obj.success_handler(result=model_response)
+
+    assert calls == [model_response]
+
+
+# ---------------------------------------------------------------------------
+# hook_filters: async_success_handler (async_log_success_event)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_success_handler_skips_when_hook_filters_model_excludes(logging_obj, monkeypatch):
+    from litellm.integrations.custom_logger import CustomLogger
+    from litellm.litellm_core_utils.hook_filter_utils import parse_hook_filters
+
+    monkeypatch.setattr(litellm, "enable_hook_filters", True)
+    calls = []
+
+    class DummyLogger(CustomLogger):
+        async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
+            calls.append(response_obj)
+
+    logging_obj.stream = False
+    logging_obj.model_call_details["litellm_params"] = {}
+
+    dummy_logger = DummyLogger()
+    dummy_logger.hook_filters = parse_hook_filters("dummy", {"async_log_success_event": {"models": ["claude-*"]}})
+
+    model_response = ModelResponse(
+        id="resp-123",
+        model="gpt-4o-mini",
+        choices=[{"message": {"role": "assistant", "content": "hello"}, "finish_reason": "stop", "index": 0}],
+        usage={"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    )
+
+    with patch.object(logging_obj, "get_combined_callback_list", return_value=[dummy_logger]):
+        await logging_obj.async_success_handler(result=model_response)
+
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_async_success_handler_runs_when_hook_filters_model_matches(logging_obj, monkeypatch):
+    from litellm.integrations.custom_logger import CustomLogger
+    from litellm.litellm_core_utils.hook_filter_utils import parse_hook_filters
+
+    monkeypatch.setattr(litellm, "enable_hook_filters", True)
+    calls = []
+
+    class DummyLogger(CustomLogger):
+        async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
+            calls.append(response_obj)
+
+    logging_obj.stream = False
+    logging_obj.model_call_details["litellm_params"] = {}
+
+    dummy_logger = DummyLogger()
+    dummy_logger.hook_filters = parse_hook_filters("dummy", {"async_log_success_event": {"models": ["bedrock/*"]}})
+
+    model_response = ModelResponse(
+        id="resp-123",
+        model="gpt-4o-mini",
+        choices=[{"message": {"role": "assistant", "content": "hello"}, "finish_reason": "stop", "index": 0}],
+        usage={"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    )
+
+    with patch.object(logging_obj, "get_combined_callback_list", return_value=[dummy_logger]):
+        await logging_obj.async_success_handler(result=model_response)
+
+    assert calls == [model_response]
+
+
+def test_success_handler_request_tags_include_user_agent_derived_tag(logging_obj, monkeypatch):
+    """_hook_filter_context must derive request_tags the same way the standard
+    logging payload does, including the User-Agent tag from proxy_server_request,
+    not just metadata.tags -- otherwise a hook_filters.request_tags pattern written
+    against that documented tag vocabulary silently never matches."""
+    from litellm.integrations.custom_logger import CustomLogger
+    from litellm.litellm_core_utils.hook_filter_utils import parse_hook_filters
+
+    monkeypatch.setattr(litellm, "enable_hook_filters", True)
+    calls = []
+
+    class DummyLogger(CustomLogger):
+        def log_success_event(self, kwargs, response_obj, start_time, end_time):
+            calls.append(response_obj)
+
+    logging_obj.stream = False
+    logging_obj.call_type = "completion"
+    logging_obj.model_call_details["litellm_params"] = {
+        "proxy_server_request": {"headers": {"user-agent": "my-custom-client/1.0"}},
+    }
+    logging_obj.litellm_params = {}
+
+    dummy_logger = DummyLogger()
+    dummy_logger.hook_filters = parse_hook_filters(
+        "dummy", {"log_success_event": {"request_tags": ["User-Agent: my-custom-client"]}}
+    )
+
+    model_response = ModelResponse(
+        id="resp-123",
+        model="gpt-4o-mini",
+        choices=[{"message": {"role": "assistant", "content": "hello"}, "finish_reason": "stop", "index": 0}],
+        usage={"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    )
+
+    with patch.object(logging_obj, "get_combined_callback_list", return_value=[dummy_logger]):
+        logging_obj.success_handler(result=model_response)
+
+    assert calls == [model_response]

--- a/tests/test_litellm/litellm_core_utils/test_streaming_overhead.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_overhead.py
@@ -506,3 +506,54 @@ def test_async_streaming_overhead_not_regressed():
         f"Async streaming of {n_chunks} chunks took {elapsed:.3f}s — "
         "per-chunk overhead regression detected"
     )
+
+
+# ---------------------------------------------------------------------------
+# hook_filters: _call_post_streaming_deployment_hook
+# ---------------------------------------------------------------------------
+
+
+def test_post_streaming_deployment_hook_skipped_when_hook_filters_model_excludes(monkeypatch):
+    from litellm.integrations.custom_logger import CustomLogger
+    from litellm.litellm_core_utils.hook_filter_utils import parse_hook_filters
+
+    monkeypatch.setattr(litellm, "enable_hook_filters", True)
+    calls = []
+
+    class _Cb(CustomLogger):
+        async def async_post_call_streaming_deployment_hook(self, request_data, response_chunk, call_type):
+            calls.append(response_chunk)
+            return None
+
+    cb = _Cb()
+    cb.hook_filters = parse_hook_filters(
+        "cb", {"async_post_call_streaming_deployment_hook": {"models": ["claude-3-opus"]}}
+    )
+    wrapper = _make_wrapper([], provider="anthropic")
+    monkeypatch.setattr(litellm, "callbacks", [cb])
+
+    asyncio.run(wrapper._call_post_streaming_deployment_hook(MagicMock(spec=ModelResponseStream)))
+    assert calls == []
+
+
+def test_post_streaming_deployment_hook_runs_when_hook_filters_model_matches(monkeypatch):
+    from litellm.integrations.custom_logger import CustomLogger
+    from litellm.litellm_core_utils.hook_filter_utils import parse_hook_filters
+
+    monkeypatch.setattr(litellm, "enable_hook_filters", True)
+    calls = []
+
+    class _Cb(CustomLogger):
+        async def async_post_call_streaming_deployment_hook(self, request_data, response_chunk, call_type):
+            calls.append(response_chunk)
+            return None
+
+    cb = _Cb()
+    cb.hook_filters = parse_hook_filters(
+        "cb", {"async_post_call_streaming_deployment_hook": {"models": ["claude-3-5-sonnet"]}}
+    )
+    wrapper = _make_wrapper([], provider="anthropic")
+    monkeypatch.setattr(litellm, "callbacks", [cb])
+
+    asyncio.run(wrapper._call_post_streaming_deployment_hook(MagicMock(spec=ModelResponseStream)))
+    assert len(calls) == 1

--- a/tests/test_litellm/proxy/common_utils/test_callback_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_callback_utils.py
@@ -670,3 +670,40 @@ def test_initialize_callbacks_on_proxy_accepts_instance_non_list_value(probe_con
 
     assert len(litellm.callbacks) == 1
     assert isinstance(litellm.callbacks[0], CustomLogger)
+
+
+def test_initialize_callbacks_on_proxy_attaches_hook_filters(probe_config_path):
+    """callback_settings.<name>.hook_filters must be validated and attached onto the
+    resolved callback instance, the same mechanism guardrails get via litellm_params."""
+    entry = f"{_PROBE_MODULE_NAME}.proxy_handler_instance"
+    initialize_callbacks_on_proxy(
+        value=[entry],
+        premium_user=False,
+        config_file_path=probe_config_path,
+        litellm_settings={},
+        callback_specific_params={entry: {"hook_filters": {"async_pre_call_hook": {"models": ["gpt-4o*"]}}}},
+    )
+
+    assert len(litellm.callbacks) == 1
+    callback = litellm.callbacks[0]
+    assert isinstance(callback, CustomLogger)
+    assert callback.hook_filters is not None
+    assert callback.hook_filters["async_pre_call_hook"].models == ("gpt-4o*",)
+
+
+def test_initialize_callbacks_on_proxy_rejects_unknown_hook_name_in_hook_filters(probe_config_path):
+    entry = f"{_PROBE_MODULE_NAME}.proxy_handler_instance"
+    with pytest.raises(ValueError, match="unknown hook name"):
+        initialize_callbacks_on_proxy(
+            value=[entry],
+            premium_user=False,
+            config_file_path=probe_config_path,
+            litellm_settings={},
+            callback_specific_params={entry: {"hook_filters": {"not_a_real_hook": {"models": ["gpt-4o*"]}}}},
+        )
+
+
+def test_initialize_callbacks_on_proxy_without_hook_filters_leaves_attribute_none(probe_config_path):
+    _load_callbacks([f"{_PROBE_MODULE_NAME}.proxy_handler_instance"], probe_config_path)
+
+    assert litellm.callbacks[0].hook_filters is None

--- a/tests/test_litellm/proxy/guardrails/test_guardrail_registry.py
+++ b/tests/test_litellm/proxy/guardrails/test_guardrail_registry.py
@@ -930,6 +930,88 @@ class TestScanOnlyToolResultsInitRefusal:
             )
 
 
+class TestHookFiltersConfigScoping:
+    """A guardrail's litellm_params.hook_filters is validated at init time (bad hook
+    names or model_tags on a non-deployment-scoped hook must fail fast) and, once
+    valid, attached to the constructed callback for call_custom_hook to consult."""
+
+    def _initialize(self, name: str, params: dict):
+        lists = _all_callback_lists()
+        snapshots = [list(cb_list) for cb_list in lists]
+        try:
+            return InMemoryGuardrailHandler().initialize_guardrail(
+                guardrail={"guardrail_name": name, "litellm_params": params},
+            )
+        finally:
+            for cb_list, snapshot in zip(lists, snapshots):
+                cb_list[:] = snapshot
+
+    def test_unknown_hook_name_is_rejected(self):
+        with pytest.raises(ValueError, match="unknown hook name"):
+            self._initialize(
+                "hook-filters-unknown-hook",
+                {
+                    "guardrail": "bedrock",
+                    "mode": "pre_call",
+                    "guardrailIdentifier": "gr-1",
+                    "guardrailVersion": "1",
+                    "hook_filters": {"not_a_real_hook": {"models": ["gpt-4o*"]}},
+                },
+            )
+
+    def test_model_tags_on_non_deployment_hook_is_rejected(self):
+        with pytest.raises(ValueError, match="model_tags"):
+            self._initialize(
+                "hook-filters-model-tags-pre-call",
+                {
+                    "guardrail": "bedrock",
+                    "mode": "pre_call",
+                    "guardrailIdentifier": "gr-1",
+                    "guardrailVersion": "1",
+                    "hook_filters": {"async_pre_call_hook": {"model_tags": ["needs-pii-scan"]}},
+                },
+            )
+
+    def test_valid_hook_filters_attached_to_callback(self):
+        handler = InMemoryGuardrailHandler()
+        lists = _all_callback_lists()
+        snapshots = [list(cb_list) for cb_list in lists]
+        try:
+            handler.initialize_guardrail(
+                guardrail={
+                    "guardrail_name": "hook-filters-valid",
+                    "litellm_params": {
+                        "guardrail": "bedrock",
+                        "mode": "pre_call",
+                        "guardrailIdentifier": "gr-1",
+                        "guardrailVersion": "1",
+                        "hook_filters": {"async_pre_call_hook": {"models": ["gpt-4o*"]}},
+                    },
+                },
+            )
+            callback = handler.guardrail_id_to_custom_guardrail[
+                next(iter(handler.guardrail_id_to_custom_guardrail))
+            ]
+            assert callback is not None
+            assert callback.hook_filters is not None
+            assert callback.hook_filters["async_pre_call_hook"].models == ("gpt-4o*",)
+        finally:
+            for cb_list, snapshot in zip(lists, snapshots):
+                cb_list[:] = snapshot
+
+    def test_no_hook_filters_leaves_attribute_none(self):
+        result = self._initialize(
+            "hook-filters-absent",
+            {
+                "guardrail": "bedrock",
+                "mode": "pre_call",
+                "guardrailIdentifier": "gr-1",
+                "guardrailVersion": "1",
+            },
+        )
+        assert result is not None
+
+
 @pytest.mark.asyncio
 async def test_update_guardrail_in_db_raises_when_row_missing():
     prisma_client = MagicMock()

--- a/tests/test_litellm/proxy/policy_engine/test_pipeline_executor.py
+++ b/tests/test_litellm/proxy/policy_engine/test_pipeline_executor.py
@@ -911,3 +911,129 @@ async def test_pipeline_step_keeps_native_hook_when_opted_out(monkeypatch):
     assert outcome == "pass"
     assert guardrail.native_pre_call_ran is True
     assert "guardrail_to_apply" not in data
+
+
+# ---------------------------------------------------------------------------
+# hook_filters
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pipeline_step_skipped_when_hook_filters_model_excludes(monkeypatch):
+    from litellm.litellm_core_utils.hook_filter_utils import parse_hook_filters
+
+    monkeypatch.setattr(litellm, "enable_hook_filters", True)
+    guard = AlwaysPassGuardrail(guardrail_name="passer")
+    guard.hook_filters = parse_hook_filters("passer", {"async_pre_call_hook": {"models": ["claude-*"]}})
+
+    pipeline = GuardrailPipeline(
+        mode="pre_call",
+        steps=[PipelineStep(guardrail="passer", on_pass="allow")],
+    )
+
+    monkeypatch.setattr(litellm, "callbacks", [guard])
+
+    await PipelineExecutor.execute_steps(
+        steps=pipeline.steps,
+        mode=pipeline.mode,
+        data={"model": "gpt-4o", "messages": [{"role": "user", "content": "test"}]},
+        user_api_key_dict=MagicMock(),
+        call_type="completion",
+        policy_name="test",
+    )
+
+    assert guard.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_pipeline_step_runs_when_hook_filters_model_matches(monkeypatch):
+    from litellm.litellm_core_utils.hook_filter_utils import parse_hook_filters
+
+    monkeypatch.setattr(litellm, "enable_hook_filters", True)
+    guard = AlwaysPassGuardrail(guardrail_name="passer")
+    guard.hook_filters = parse_hook_filters("passer", {"async_pre_call_hook": {"models": ["gpt-4o*"]}})
+
+    pipeline = GuardrailPipeline(
+        mode="pre_call",
+        steps=[PipelineStep(guardrail="passer", on_pass="allow")],
+    )
+
+    monkeypatch.setattr(litellm, "callbacks", [guard])
+
+    result = await PipelineExecutor.execute_steps(
+        steps=pipeline.steps,
+        mode=pipeline.mode,
+        data={"model": "gpt-4o", "messages": [{"role": "user", "content": "test"}]},
+        user_api_key_dict=MagicMock(),
+        call_type="completion",
+        policy_name="test",
+    )
+
+    assert result.terminal_action == "allow"
+    assert guard.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_pipeline_step_ignores_hook_filters_when_flag_is_false(monkeypatch):
+    from litellm.litellm_core_utils.hook_filter_utils import parse_hook_filters
+
+    monkeypatch.setattr(litellm, "enable_hook_filters", False)
+    guard = AlwaysPassGuardrail(guardrail_name="passer")
+    guard.hook_filters = parse_hook_filters("passer", {"async_pre_call_hook": {"models": ["claude-*"]}})
+
+    pipeline = GuardrailPipeline(
+        mode="pre_call",
+        steps=[PipelineStep(guardrail="passer", on_pass="allow")],
+    )
+
+    monkeypatch.setattr(litellm, "callbacks", [guard])
+
+    result = await PipelineExecutor.execute_steps(
+        steps=pipeline.steps,
+        mode=pipeline.mode,
+        data={"model": "gpt-4o", "messages": [{"role": "user", "content": "test"}]},
+        user_api_key_dict=MagicMock(),
+        call_type="completion",
+        policy_name="test",
+    )
+
+    assert result.terminal_action == "allow"
+    assert guard.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_pipeline_step_runs_on_user_agent_derived_request_tag(monkeypatch):
+    """A pipeline-managed guardrail's request_tags must see the same tag
+    vocabulary (including the User-Agent-derived tag) as the same guardrail
+    would see running outside a pipeline via ProxyLogging, so hook_filters
+    behaves identically regardless of which dispatch path invokes it."""
+    from litellm.litellm_core_utils.hook_filter_utils import parse_hook_filters
+
+    monkeypatch.setattr(litellm, "enable_hook_filters", True)
+    guard = AlwaysPassGuardrail(guardrail_name="passer")
+    guard.hook_filters = parse_hook_filters(
+        "passer", {"async_pre_call_hook": {"request_tags": ["User-Agent: my-custom-client"]}}
+    )
+
+    pipeline = GuardrailPipeline(
+        mode="pre_call",
+        steps=[PipelineStep(guardrail="passer", on_pass="allow")],
+    )
+
+    monkeypatch.setattr(litellm, "callbacks", [guard])
+
+    result = await PipelineExecutor.execute_steps(
+        steps=pipeline.steps,
+        mode=pipeline.mode,
+        data={
+            "model": "gpt-4o",
+            "messages": [{"role": "user", "content": "test"}],
+            "metadata": {"headers": {"user-agent": "my-custom-client/1.0"}},
+        },
+        user_api_key_dict=MagicMock(),
+        call_type="completion",
+        policy_name="test",
+    )
+
+    assert result.terminal_action == "allow"
+    assert guard.calls == 1

--- a/tests/test_litellm/proxy/test_init_litellm_callbacks.py
+++ b/tests/test_litellm/proxy/test_init_litellm_callbacks.py
@@ -173,3 +173,35 @@ class TestInitLitellmCallbacks:
 
         # Clean up
         litellm.callbacks = []  # type: ignore
+
+    def test_should_attach_hook_filters_from_callback_settings_to_resolved_string_callback(
+        self, monkeypatch
+    ):
+        """
+        litellm_settings.callbacks: ["some_integration"] plus
+        callback_settings.some_integration.hook_filters is the standard way most
+        built-in logging integrations (langfuse, datadog, etc.) are configured; a
+        hook_filters block under that name must land on the instance that replaces
+        the string, not be silently dropped because the string had no hook_filters
+        attribute of its own to attach to.
+        """
+        fake_logger = FakeCustomLogger()
+        monkeypatch.setattr(
+            "litellm.proxy.utils.ProxyLogging._add_proxy_hooks", lambda self, *a, **kw: None
+        )
+        monkeypatch.setattr(litellm, "callbacks", ["lago"])
+        monkeypatch.setattr(
+            litellm,
+            "callback_settings",
+            {"lago": {"hook_filters": {"async_pre_call_hook": {"models": ["gpt-4o*"]}}}},
+        )
+        monkeypatch.setattr(
+            "litellm.litellm_core_utils.litellm_logging._init_custom_logger_compatible_class",
+            lambda *a, **kw: fake_logger,
+        )
+
+        proxy_logging = self._make_proxy_logging()
+        proxy_logging._init_litellm_callbacks(llm_router=None)
+
+        assert fake_logger.hook_filters is not None
+        assert fake_logger.hook_filters["async_pre_call_hook"].models == ("gpt-4o*",)

--- a/tests/test_litellm/proxy/utils/proxy_logging/test_during_call_hook.py
+++ b/tests/test_litellm/proxy/utils/proxy_logging/test_during_call_hook.py
@@ -84,3 +84,64 @@ async def test_during_call_hook_guardrail_error_raises(proxy_logging, make_user_
             user_api_key_dict=make_user_api_key_auth(),
             call_type="completion",
         )
+
+
+# ---------------------------------------------------------------------------
+# hook_filters
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_during_call_hook_skipped_when_hook_filters_model_excludes(
+    proxy_logging, make_user_api_key_auth, monkeypatch
+):
+    from litellm.litellm_core_utils.hook_filter_utils import parse_hook_filters
+
+    monkeypatch.setattr(litellm, "enable_hook_filters", True)
+    g = _make_guardrail("g")
+    g.hook_filters = parse_hook_filters("g", {"async_moderation_hook": {"models": ["claude-*"]}})
+    monkeypatch.setattr(litellm, "callbacks", [g])
+
+    await proxy_logging.during_call_hook(
+        data={"model": "gpt-4o"},
+        user_api_key_dict=make_user_api_key_auth(),
+        call_type="completion",
+    )
+    g.async_moderation_hook.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_during_call_hook_runs_when_hook_filters_model_matches(
+    proxy_logging, make_user_api_key_auth, monkeypatch
+):
+    from litellm.litellm_core_utils.hook_filter_utils import parse_hook_filters
+
+    monkeypatch.setattr(litellm, "enable_hook_filters", True)
+    g = _make_guardrail("g")
+    g.hook_filters = parse_hook_filters("g", {"async_moderation_hook": {"models": ["gpt-4o*"]}})
+    monkeypatch.setattr(litellm, "callbacks", [g])
+
+    await proxy_logging.during_call_hook(
+        data={"model": "gpt-4o"},
+        user_api_key_dict=make_user_api_key_auth(),
+        call_type="completion",
+    )
+    g.async_moderation_hook.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_during_call_hook_ignores_hook_filters_when_flag_is_false(
+    proxy_logging, make_user_api_key_auth, monkeypatch
+):
+    from litellm.litellm_core_utils.hook_filter_utils import parse_hook_filters
+
+    g = _make_guardrail("g")
+    g.hook_filters = parse_hook_filters("g", {"async_moderation_hook": {"models": ["claude-*"]}})
+    monkeypatch.setattr(litellm, "callbacks", [g])
+
+    await proxy_logging.during_call_hook(
+        data={"model": "gpt-4o"},
+        user_api_key_dict=make_user_api_key_auth(),
+        call_type="completion",
+    )
+    g.async_moderation_hook.assert_called_once()

--- a/tests/test_litellm/proxy/utils/proxy_logging/test_post_call_failure_hook.py
+++ b/tests/test_litellm/proxy/utils/proxy_logging/test_post_call_failure_hook.py
@@ -267,3 +267,62 @@ async def test_handle_logging_proxy_only_path_propagates_async_failure_raises(
             route="/chat/completions",
             original_exception=Exception("x"),
         )
+
+
+# ---------------------------------------------------------------------------
+# hook_filters
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_post_call_failure_hook_skipped_when_hook_filters_model_excludes(
+    proxy_logging, make_user_api_key_auth, monkeypatch
+):
+    from litellm.litellm_core_utils.hook_filter_utils import parse_hook_filters
+
+    monkeypatch.setattr(litellm, "enable_hook_filters", True)
+    calls = []
+
+    class _Cb(CustomLogger):
+        async def async_post_call_failure_hook(self, **kwargs):  # type: ignore[override]
+            calls.append(kwargs)
+            return None
+
+    cb = _Cb()
+    cb.hook_filters = parse_hook_filters("cb", {"async_post_call_failure_hook": {"models": ["claude-*"]}})
+    monkeypatch.setattr(litellm, "callbacks", [cb])
+    proxy_logging.alert_types = []
+
+    await proxy_logging.post_call_failure_hook(
+        request_data={"litellm_call_id": "abc", "model": "gpt-4o"},
+        original_exception=ValueError("oops"),
+        user_api_key_dict=make_user_api_key_auth(),
+    )
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_post_call_failure_hook_runs_when_hook_filters_model_matches(
+    proxy_logging, make_user_api_key_auth, monkeypatch
+):
+    from litellm.litellm_core_utils.hook_filter_utils import parse_hook_filters
+
+    monkeypatch.setattr(litellm, "enable_hook_filters", True)
+    calls = []
+
+    class _Cb(CustomLogger):
+        async def async_post_call_failure_hook(self, **kwargs):  # type: ignore[override]
+            calls.append(kwargs)
+            return None
+
+    cb = _Cb()
+    cb.hook_filters = parse_hook_filters("cb", {"async_post_call_failure_hook": {"models": ["gpt-4o*"]}})
+    monkeypatch.setattr(litellm, "callbacks", [cb])
+    proxy_logging.alert_types = []
+
+    await proxy_logging.post_call_failure_hook(
+        request_data={"litellm_call_id": "abc", "model": "gpt-4o"},
+        original_exception=ValueError("oops"),
+        user_api_key_dict=make_user_api_key_auth(),
+    )
+    assert len(calls) == 1

--- a/tests/test_litellm/proxy/utils/proxy_logging/test_post_call_success_hook.py
+++ b/tests/test_litellm/proxy/utils/proxy_logging/test_post_call_success_hook.py
@@ -96,3 +96,90 @@ async def test_post_call_success_hook_guardrail_returns_modified_response(
         data={}, response={"orig": True}, user_api_key_dict=make_user_api_key_auth()
     )
     assert out == modified
+
+
+# ---------------------------------------------------------------------------
+# hook_filters
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_post_call_success_hook_guardrail_skipped_when_hook_filters_model_excludes(
+    proxy_logging, make_user_api_key_auth, monkeypatch
+):
+    from litellm.litellm_core_utils.hook_filter_utils import parse_hook_filters
+
+    monkeypatch.setattr(litellm, "enable_hook_filters", True)
+    g = _make_guardrail()
+    g.hook_filters = parse_hook_filters("g", {"async_post_call_success_hook": {"models": ["claude-*"]}})
+    monkeypatch.setattr(litellm, "callbacks", [g])
+
+    await proxy_logging.post_call_success_hook(
+        data={"model": "gpt-4o"}, response=MagicMock(), user_api_key_dict=make_user_api_key_auth()
+    )
+    g.async_post_call_success_hook.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_post_call_success_hook_guardrail_runs_when_hook_filters_model_matches(
+    proxy_logging, make_user_api_key_auth, monkeypatch
+):
+    from litellm.litellm_core_utils.hook_filter_utils import parse_hook_filters
+
+    monkeypatch.setattr(litellm, "enable_hook_filters", True)
+    g = _make_guardrail()
+    g.hook_filters = parse_hook_filters("g", {"async_post_call_success_hook": {"models": ["gpt-4o*"]}})
+    monkeypatch.setattr(litellm, "callbacks", [g])
+
+    await proxy_logging.post_call_success_hook(
+        data={"model": "gpt-4o"}, response=MagicMock(), user_api_key_dict=make_user_api_key_auth()
+    )
+    g.async_post_call_success_hook.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_post_call_success_hook_plain_callback_skipped_when_hook_filters_model_excludes(
+    proxy_logging, make_user_api_key_auth, monkeypatch
+):
+    from litellm.litellm_core_utils.hook_filter_utils import parse_hook_filters
+
+    monkeypatch.setattr(litellm, "enable_hook_filters", True)
+    calls = []
+
+    class _CL(CustomLogger):
+        async def async_post_call_success_hook(self, **kwargs):  # type: ignore[override]
+            calls.append(kwargs)
+            return None
+
+    cb = _CL()
+    cb.hook_filters = parse_hook_filters("cl", {"async_post_call_success_hook": {"models": ["claude-*"]}})
+    monkeypatch.setattr(litellm, "callbacks", [cb])
+
+    await proxy_logging.post_call_success_hook(
+        data={"model": "gpt-4o"}, response={"original": True}, user_api_key_dict=make_user_api_key_auth()
+    )
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_post_call_success_hook_plain_callback_runs_when_hook_filters_model_matches(
+    proxy_logging, make_user_api_key_auth, monkeypatch
+):
+    from litellm.litellm_core_utils.hook_filter_utils import parse_hook_filters
+
+    monkeypatch.setattr(litellm, "enable_hook_filters", True)
+    calls = []
+
+    class _CL(CustomLogger):
+        async def async_post_call_success_hook(self, **kwargs):  # type: ignore[override]
+            calls.append(kwargs)
+            return None
+
+    cb = _CL()
+    cb.hook_filters = parse_hook_filters("cl", {"async_post_call_success_hook": {"models": ["gpt-4o*"]}})
+    monkeypatch.setattr(litellm, "callbacks", [cb])
+
+    await proxy_logging.post_call_success_hook(
+        data={"model": "gpt-4o"}, response={"original": True}, user_api_key_dict=make_user_api_key_auth()
+    )
+    assert len(calls) == 1

--- a/tests/test_litellm/proxy/utils/proxy_logging/test_pre_call_hook.py
+++ b/tests/test_litellm/proxy/utils/proxy_logging/test_pre_call_hook.py
@@ -13,6 +13,7 @@ from litellm.caching.caching import DualCache
 from litellm.exceptions import RejectedRequestError
 from litellm.integrations.custom_guardrail import CustomGuardrail
 from litellm.integrations.custom_logger import CustomLogger
+from litellm.litellm_core_utils.hook_filter_utils import parse_hook_filters
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.utils import ProxyLogging
 from litellm.types.guardrails import GuardrailEventHooks
@@ -875,3 +876,206 @@ async def test_scan_raw_request_warns_on_in_place_mutation_returning_none(
     )
     mock_logger.warning.assert_called_once()
     assert "scan_raw_request" in str(mock_logger.warning.call_args)
+
+
+# ---------------------------------------------------------------------------
+# hook_filters: pre_call_hook's plain-CustomLogger branch and the guardrail
+# branch (_execute_guardrail_hook) both go through call_custom_hook, which
+# must consult a callback's own hook_filters when litellm.enable_hook_filters
+# is True and leave every unfiltered callback's behavior unchanged.
+# ---------------------------------------------------------------------------
+
+
+class _RecordingCustomLogger(CustomLogger):
+    def __init__(self):
+        super().__init__()
+        self.calls = 0
+
+    async def async_pre_call_hook(self, user_api_key_dict, cache, data, call_type):
+        self.calls += 1
+        return data
+
+
+class _RecordingPreCallGuardrail(CustomGuardrail):
+    def __init__(self, **kwargs):
+        kwargs.setdefault("default_on", True)
+        kwargs.setdefault("event_hook", GuardrailEventHooks.pre_call)
+        super().__init__(guardrail_name="recording-guardrail", **kwargs)
+        self.calls = 0
+
+    async def async_pre_call_hook(self, user_api_key_dict, cache, data, call_type):
+        self.calls += 1
+        return None
+
+
+@pytest.fixture
+def _reset_enable_hook_filters(monkeypatch):
+    monkeypatch.setattr(litellm, "enable_hook_filters", False)
+
+
+@pytest.mark.asyncio
+async def test_plain_callback_skipped_when_hook_filters_model_excludes(
+    proxy_logging, make_user_api_key_auth, monkeypatch, _reset_enable_hook_filters
+):
+    monkeypatch.setattr(litellm, "enable_hook_filters", True)
+    cb = _RecordingCustomLogger()
+    cb.hook_filters = parse_hook_filters("recording", {"async_pre_call_hook": {"models": ["claude-*"]}})
+    monkeypatch.setattr(litellm, "callbacks", [cb])
+
+    await proxy_logging.pre_call_hook(
+        user_api_key_dict=make_user_api_key_auth(),
+        data={"model": "gpt-4o", "messages": [{"role": "user", "content": "hi"}]},
+        call_type="acompletion",
+    )
+    assert cb.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_plain_callback_runs_when_hook_filters_model_matches(
+    proxy_logging, make_user_api_key_auth, monkeypatch, _reset_enable_hook_filters
+):
+    monkeypatch.setattr(litellm, "enable_hook_filters", True)
+    cb = _RecordingCustomLogger()
+    cb.hook_filters = parse_hook_filters("recording", {"async_pre_call_hook": {"models": ["gpt-4o*"]}})
+    monkeypatch.setattr(litellm, "callbacks", [cb])
+
+    await proxy_logging.pre_call_hook(
+        user_api_key_dict=make_user_api_key_auth(),
+        data={"model": "gpt-4o", "messages": [{"role": "user", "content": "hi"}]},
+        call_type="acompletion",
+    )
+    assert cb.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_plain_callback_ignores_hook_filters_when_flag_is_false(
+    proxy_logging, make_user_api_key_auth, monkeypatch, _reset_enable_hook_filters
+):
+    cb = _RecordingCustomLogger()
+    cb.hook_filters = parse_hook_filters("recording", {"async_pre_call_hook": {"models": ["claude-*"]}})
+    monkeypatch.setattr(litellm, "callbacks", [cb])
+
+    await proxy_logging.pre_call_hook(
+        user_api_key_dict=make_user_api_key_auth(),
+        data={"model": "gpt-4o", "messages": [{"role": "user", "content": "hi"}]},
+        call_type="acompletion",
+    )
+    assert cb.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_plain_callback_skipped_when_key_alias_excludes(
+    proxy_logging, make_user_api_key_auth, monkeypatch, _reset_enable_hook_filters
+):
+    monkeypatch.setattr(litellm, "enable_hook_filters", True)
+    cb = _RecordingCustomLogger()
+    cb.hook_filters = parse_hook_filters("recording", {"async_pre_call_hook": {"key_aliases": ["prod-*"]}})
+    monkeypatch.setattr(litellm, "callbacks", [cb])
+
+    await proxy_logging.pre_call_hook(
+        user_api_key_dict=make_user_api_key_auth(key_alias="dev-key-1"),
+        data={"model": "gpt-4o", "messages": [{"role": "user", "content": "hi"}]},
+        call_type="acompletion",
+    )
+    assert cb.calls == 0
+
+    await proxy_logging.pre_call_hook(
+        user_api_key_dict=make_user_api_key_auth(key_alias="prod-key-1"),
+        data={"model": "gpt-4o", "messages": [{"role": "user", "content": "hi"}]},
+        call_type="acompletion",
+    )
+    assert cb.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_guardrail_skipped_when_hook_filters_model_excludes(
+    proxy_logging, make_user_api_key_auth, monkeypatch, _reset_enable_hook_filters
+):
+    monkeypatch.setattr(litellm, "enable_hook_filters", True)
+    guardrail = _RecordingPreCallGuardrail()
+    guardrail.hook_filters = parse_hook_filters("recording-guardrail", {"async_pre_call_hook": {"models": ["claude-*"]}})
+    monkeypatch.setattr(litellm, "callbacks", [guardrail])
+
+    await proxy_logging.pre_call_hook(
+        user_api_key_dict=make_user_api_key_auth(),
+        data={"model": "gpt-4o", "messages": [{"role": "user", "content": "hi"}]},
+        call_type="acompletion",
+    )
+    assert guardrail.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_guardrail_runs_when_hook_filters_model_matches(
+    proxy_logging, make_user_api_key_auth, monkeypatch, _reset_enable_hook_filters
+):
+    monkeypatch.setattr(litellm, "enable_hook_filters", True)
+    guardrail = _RecordingPreCallGuardrail()
+    guardrail.hook_filters = parse_hook_filters("recording-guardrail", {"async_pre_call_hook": {"models": ["gpt-4o*"]}})
+    monkeypatch.setattr(litellm, "callbacks", [guardrail])
+
+    await proxy_logging.pre_call_hook(
+        user_api_key_dict=make_user_api_key_auth(),
+        data={"model": "gpt-4o", "messages": [{"role": "user", "content": "hi"}]},
+        call_type="acompletion",
+    )
+    assert guardrail.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_guardrail_skipped_on_request_tags_mismatch(
+    proxy_logging, make_user_api_key_auth, monkeypatch, _reset_enable_hook_filters
+):
+    monkeypatch.setattr(litellm, "enable_hook_filters", True)
+    guardrail = _RecordingPreCallGuardrail()
+    guardrail.hook_filters = parse_hook_filters(
+        "recording-guardrail", {"async_pre_call_hook": {"request_tags": ["scan-me"]}}
+    )
+    monkeypatch.setattr(litellm, "callbacks", [guardrail])
+
+    await proxy_logging.pre_call_hook(
+        user_api_key_dict=make_user_api_key_auth(),
+        data={
+            "model": "gpt-4o",
+            "messages": [{"role": "user", "content": "hi"}],
+            "metadata": {"tags": ["unrelated"]},
+        },
+        call_type="acompletion",
+    )
+    assert guardrail.calls == 0
+
+    await proxy_logging.pre_call_hook(
+        user_api_key_dict=make_user_api_key_auth(),
+        data={
+            "model": "gpt-4o",
+            "messages": [{"role": "user", "content": "hi"}],
+            "metadata": {"tags": ["scan-me"]},
+        },
+        call_type="acompletion",
+    )
+    assert guardrail.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_guardrail_runs_on_user_agent_derived_request_tag(
+    proxy_logging, make_user_api_key_auth, monkeypatch, _reset_enable_hook_filters
+):
+    """request_tags must include the same User-Agent-derived tag the standard
+    logging payload adds by default, not just metadata.tags, since a customer's
+    hook_filters.request_tags pattern is written against that documented vocabulary."""
+    monkeypatch.setattr(litellm, "enable_hook_filters", True)
+    guardrail = _RecordingPreCallGuardrail()
+    guardrail.hook_filters = parse_hook_filters(
+        "recording-guardrail", {"async_pre_call_hook": {"request_tags": ["User-Agent: my-custom-client"]}}
+    )
+    monkeypatch.setattr(litellm, "callbacks", [guardrail])
+
+    await proxy_logging.pre_call_hook(
+        user_api_key_dict=make_user_api_key_auth(),
+        data={
+            "model": "gpt-4o",
+            "messages": [{"role": "user", "content": "hi"}],
+            "metadata": {"headers": {"user-agent": "my-custom-client/1.0"}},
+        },
+        call_type="acompletion",
+    )
+    assert guardrail.calls == 1

--- a/tests/test_litellm/proxy/utils/proxy_logging/test_streaming_hooks.py
+++ b/tests/test_litellm/proxy/utils/proxy_logging/test_streaming_hooks.py
@@ -563,3 +563,138 @@ async def test_post_call_response_headers_hook_swallows_callback_error(proxy_log
         data={}, user_api_key_dict=make_user_api_key_auth(), response=response
     )
     assert out == {}
+
+
+# ---------------------------------------------------------------------------
+# hook_filters
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_post_call_streaming_hook_skipped_when_hook_filters_model_excludes(
+    proxy_logging, make_user_api_key_auth, monkeypatch
+):
+    from litellm.litellm_core_utils.hook_filter_utils import parse_hook_filters
+
+    monkeypatch.setattr(litellm, "enable_hook_filters", True)
+    calls = []
+
+    class _Per(CustomLogger):
+        async def async_post_call_streaming_hook(self, **kwargs):  # type: ignore[override]
+            calls.append(kwargs)
+            return None
+
+    cb = _Per()
+    cb.hook_filters = parse_hook_filters("cb", {"async_post_call_streaming_hook": {"models": ["claude-*"]}})
+    monkeypatch.setattr(litellm, "callbacks", [cb])
+
+    from litellm import ModelResponse
+
+    fake_resp = ModelResponse(
+        id="rid",
+        choices=[{"index": 0, "delta": {"role": "assistant", "content": "hi"}, "finish_reason": None}],
+        created=0,
+        model="gpt-4o-mini",
+        object="chat.completion.chunk",
+    )
+    await proxy_logging.async_post_call_streaming_hook(
+        data={"model": "gpt-4o"},
+        response=fake_resp,
+        user_api_key_dict=make_user_api_key_auth(),
+    )
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_async_post_call_streaming_hook_runs_when_hook_filters_model_matches(
+    proxy_logging, make_user_api_key_auth, monkeypatch
+):
+    from litellm.litellm_core_utils.hook_filter_utils import parse_hook_filters
+
+    monkeypatch.setattr(litellm, "enable_hook_filters", True)
+    calls = []
+
+    class _Per(CustomLogger):
+        async def async_post_call_streaming_hook(self, **kwargs):  # type: ignore[override]
+            calls.append(kwargs)
+            return None
+
+    cb = _Per()
+    cb.hook_filters = parse_hook_filters("cb", {"async_post_call_streaming_hook": {"models": ["gpt-4o*"]}})
+    monkeypatch.setattr(litellm, "callbacks", [cb])
+
+    from litellm import ModelResponse
+
+    fake_resp = ModelResponse(
+        id="rid",
+        choices=[{"index": 0, "delta": {"role": "assistant", "content": "hi"}, "finish_reason": None}],
+        created=0,
+        model="gpt-4o-mini",
+        object="chat.completion.chunk",
+    )
+    await proxy_logging.async_post_call_streaming_hook(
+        data={"model": "gpt-4o"},
+        response=fake_resp,
+        user_api_key_dict=make_user_api_key_auth(),
+    )
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_post_call_response_headers_hook_skipped_when_hook_filters_model_excludes(
+    proxy_logging, make_user_api_key_auth, monkeypatch
+):
+    from litellm.litellm_core_utils.hook_filter_utils import parse_hook_filters
+
+    monkeypatch.setattr(litellm, "enable_hook_filters", True)
+    calls = []
+
+    class _Cb(CustomLogger):
+        async def async_post_call_response_headers_hook(self, **kwargs):  # type: ignore[override]
+            calls.append(kwargs)
+            return {"x-test": "1"}
+
+    cb = _Cb()
+    cb.hook_filters = parse_hook_filters(
+        "cb", {"async_post_call_response_headers_hook": {"models": ["claude-*"]}}
+    )
+    monkeypatch.setattr(litellm, "callbacks", [cb])
+    ProxyLogging._callback_capabilities_cache.clear()
+
+    out = await proxy_logging.post_call_response_headers_hook(
+        data={"model": "gpt-4o"},
+        user_api_key_dict=make_user_api_key_auth(),
+        response=MagicMock(),
+    )
+    assert calls == []
+    assert out == {}
+
+
+@pytest.mark.asyncio
+async def test_post_call_response_headers_hook_runs_when_hook_filters_model_matches(
+    proxy_logging, make_user_api_key_auth, monkeypatch
+):
+    from litellm.litellm_core_utils.hook_filter_utils import parse_hook_filters
+
+    monkeypatch.setattr(litellm, "enable_hook_filters", True)
+    calls = []
+
+    class _Cb(CustomLogger):
+        async def async_post_call_response_headers_hook(self, **kwargs):  # type: ignore[override]
+            calls.append(kwargs)
+            return {"x-test": "1"}
+
+    cb = _Cb()
+    cb.hook_filters = parse_hook_filters(
+        "cb", {"async_post_call_response_headers_hook": {"models": ["gpt-4o*"]}}
+    )
+    monkeypatch.setattr(litellm, "callbacks", [cb])
+    ProxyLogging._callback_capabilities_cache.clear()
+
+    out = await proxy_logging.post_call_response_headers_hook(
+        data={"model": "gpt-4o"},
+        user_api_key_dict=make_user_api_key_auth(),
+        response=MagicMock(),
+    )
+    assert len(calls) == 1
+    assert out == {"x-test": "1"}

--- a/tests/test_litellm/proxy/utils/proxy_logging/test_streaming_hooks.py
+++ b/tests/test_litellm/proxy/utils/proxy_logging/test_streaming_hooks.py
@@ -698,3 +698,69 @@ async def test_post_call_response_headers_hook_runs_when_hook_filters_model_matc
     )
     assert len(calls) == 1
     assert out == {"x-test": "1"}
+
+
+@pytest.mark.asyncio
+async def test_async_post_call_streaming_iterator_hook_skipped_when_hook_filters_model_excludes(
+    proxy_logging, make_user_api_key_auth, monkeypatch
+):
+    from litellm.litellm_core_utils.hook_filter_utils import parse_hook_filters
+
+    monkeypatch.setattr(litellm, "enable_hook_filters", True)
+
+    class _IterOverride(CustomLogger):
+        async def async_post_call_streaming_iterator_hook(self, **kwargs):  # type: ignore[override]
+            async for ch in kwargs["response"]:
+                yield ch + "*"
+
+    cb = _IterOverride()
+    cb.hook_filters = parse_hook_filters(
+        "cb", {"async_post_call_streaming_iterator_hook": {"models": ["claude-*"]}}
+    )
+    monkeypatch.setattr(litellm, "callbacks", [cb])
+
+    async def gen():
+        for ch in ("a", "b"):
+            yield ch
+
+    out: List[str] = []
+    async for ch in proxy_logging.async_post_call_streaming_iterator_hook(
+        response=gen(),
+        user_api_key_dict=make_user_api_key_auth(),
+        request_data={"model": "gpt-4o"},
+    ):
+        out.append(ch)
+    assert out == ["a", "b"]
+
+
+@pytest.mark.asyncio
+async def test_async_post_call_streaming_iterator_hook_runs_when_hook_filters_model_matches(
+    proxy_logging, make_user_api_key_auth, monkeypatch
+):
+    from litellm.litellm_core_utils.hook_filter_utils import parse_hook_filters
+
+    monkeypatch.setattr(litellm, "enable_hook_filters", True)
+
+    class _IterOverride(CustomLogger):
+        async def async_post_call_streaming_iterator_hook(self, **kwargs):  # type: ignore[override]
+            async for ch in kwargs["response"]:
+                yield ch + "*"
+
+    cb = _IterOverride()
+    cb.hook_filters = parse_hook_filters(
+        "cb", {"async_post_call_streaming_iterator_hook": {"models": ["gpt-4o*"]}}
+    )
+    monkeypatch.setattr(litellm, "callbacks", [cb])
+
+    async def gen():
+        for ch in ("a", "b"):
+            yield ch
+
+    out: List[str] = []
+    async for ch in proxy_logging.async_post_call_streaming_iterator_hook(
+        response=gen(),
+        user_api_key_dict=make_user_api_key_auth(),
+        request_data={"model": "gpt-4o"},
+    ):
+        out.append(ch)
+    assert out == ["a*", "b*"]

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -42,6 +42,7 @@ from litellm.utils import (
     _snapshot_exception_for_hook,
     async_post_call_failure_deployment_hook,
     async_post_call_success_deployment_hook,
+    async_pre_call_deployment_hook,
     client,
     get_llm_provider,
     get_non_default_completion_params,
@@ -5340,6 +5341,181 @@ async def test_async_post_call_failure_deployment_hook_skips_non_custom_logger_c
     await async_post_call_failure_deployment_hook(request_data={}, exception=ValueError("x"), call_type="acompletion")
 
     assert called == []
+
+
+# ---------------------------------------------------------------------------
+# hook_filters: deployment-scoped hooks (async_pre_call_deployment_hook,
+# async_post_call_success_deployment_hook, async_post_call_failure_deployment_hook)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_pre_call_deployment_hook_skipped_when_hook_filters_model_excludes(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from litellm.litellm_core_utils.hook_filter_utils import parse_hook_filters
+
+    monkeypatch.setattr(litellm, "enable_hook_filters", True)
+    calls = []
+
+    class _Cb(CustomLogger):
+        async def async_pre_call_deployment_hook(self, kwargs, call_type):
+            calls.append(kwargs)
+            return None
+
+    cb = _Cb()
+    cb.hook_filters = parse_hook_filters("cb", {"async_pre_call_deployment_hook": {"models": ["claude-*"]}})
+    monkeypatch.setattr(litellm, "callbacks", [cb])
+
+    await async_pre_call_deployment_hook(kwargs={"model": "gpt-4o"}, call_type="acompletion")
+
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_async_pre_call_deployment_hook_runs_when_hook_filters_model_matches(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from litellm.litellm_core_utils.hook_filter_utils import parse_hook_filters
+
+    monkeypatch.setattr(litellm, "enable_hook_filters", True)
+    calls = []
+
+    class _Cb(CustomLogger):
+        async def async_pre_call_deployment_hook(self, kwargs, call_type):
+            calls.append(kwargs)
+            return None
+
+    cb = _Cb()
+    cb.hook_filters = parse_hook_filters("cb", {"async_pre_call_deployment_hook": {"models": ["gpt-4o*"]}})
+    monkeypatch.setattr(litellm, "callbacks", [cb])
+
+    await async_pre_call_deployment_hook(kwargs={"model": "gpt-4o"}, call_type="acompletion")
+
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_async_pre_call_deployment_hook_skipped_when_model_tags_exclude(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """model_tags is the whole point of the deployment-scoped hooks: the deployment's
+    own litellm_params.tags, merged by the router into metadata.tags by this point."""
+    from litellm.litellm_core_utils.hook_filter_utils import parse_hook_filters
+
+    monkeypatch.setattr(litellm, "enable_hook_filters", True)
+    calls = []
+
+    class _Cb(CustomLogger):
+        async def async_pre_call_deployment_hook(self, kwargs, call_type):
+            calls.append(kwargs)
+            return None
+
+    cb = _Cb()
+    cb.hook_filters = parse_hook_filters(
+        "cb", {"async_pre_call_deployment_hook": {"model_tags": ["needs-pii-scan"]}}
+    )
+    monkeypatch.setattr(litellm, "callbacks", [cb])
+
+    await async_pre_call_deployment_hook(
+        kwargs={"model": "gpt-4o", "metadata": {"tags": ["unrelated"]}}, call_type="acompletion"
+    )
+    assert calls == []
+
+    await async_pre_call_deployment_hook(
+        kwargs={"model": "gpt-4o", "metadata": {"tags": ["needs-pii-scan"]}}, call_type="acompletion"
+    )
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_async_post_call_success_deployment_hook_skipped_when_hook_filters_model_excludes(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from litellm.litellm_core_utils.hook_filter_utils import parse_hook_filters
+
+    monkeypatch.setattr(litellm, "enable_hook_filters", True)
+    calls = []
+
+    class _Cb(CustomLogger):
+        async def async_post_call_success_deployment_hook(self, request_data, response, call_type):
+            calls.append(response)
+            return None
+
+    cb = _Cb()
+    cb.hook_filters = parse_hook_filters(
+        "cb", {"async_post_call_success_deployment_hook": {"models": ["claude-*"]}}
+    )
+    monkeypatch.setattr(litellm, "callbacks", [cb])
+
+    await async_post_call_success_deployment_hook(
+        request_data={"model": "gpt-4o"}, response="resp", call_type="acompletion"
+    )
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_async_post_call_success_deployment_hook_runs_when_hook_filters_model_matches(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from litellm.litellm_core_utils.hook_filter_utils import parse_hook_filters
+
+    monkeypatch.setattr(litellm, "enable_hook_filters", True)
+    calls = []
+
+    class _Cb(CustomLogger):
+        async def async_post_call_success_deployment_hook(self, request_data, response, call_type):
+            calls.append(response)
+            return None
+
+    cb = _Cb()
+    cb.hook_filters = parse_hook_filters(
+        "cb", {"async_post_call_success_deployment_hook": {"models": ["gpt-4o*"]}}
+    )
+    monkeypatch.setattr(litellm, "callbacks", [cb])
+
+    await async_post_call_success_deployment_hook(
+        request_data={"model": "gpt-4o"}, response="resp", call_type="acompletion"
+    )
+    assert calls == ["resp"]
+
+
+@pytest.mark.asyncio
+async def test_async_post_call_failure_deployment_hook_skipped_when_hook_filters_model_excludes(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from litellm.litellm_core_utils.hook_filter_utils import parse_hook_filters
+
+    monkeypatch.setattr(litellm, "enable_hook_filters", True)
+    recorder = _RecordingDeploymentFailureLogger()
+    recorder.hook_filters = parse_hook_filters(
+        "recorder", {"async_post_call_failure_deployment_hook": {"models": ["claude-*"]}}
+    )
+    monkeypatch.setattr(litellm, "callbacks", [recorder])
+
+    await async_post_call_failure_deployment_hook(
+        request_data={"model": "gpt-4o"}, exception=ValueError("x"), call_type="acompletion"
+    )
+    assert recorder.calls == []
+
+
+@pytest.mark.asyncio
+async def test_async_post_call_failure_deployment_hook_runs_when_hook_filters_model_matches(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from litellm.litellm_core_utils.hook_filter_utils import parse_hook_filters
+
+    monkeypatch.setattr(litellm, "enable_hook_filters", True)
+    recorder = _RecordingDeploymentFailureLogger()
+    recorder.hook_filters = parse_hook_filters(
+        "recorder", {"async_post_call_failure_deployment_hook": {"models": ["gpt-4o*"]}}
+    )
+    monkeypatch.setattr(litellm, "callbacks", [recorder])
+
+    await async_post_call_failure_deployment_hook(
+        request_data={"model": "gpt-4o"}, exception=ValueError("x"), call_type="acompletion"
+    )
+    assert len(recorder.calls) == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## TLDR

Problem this solves:

- Guardrails and logging callbacks run for every request, no per-model/key/tag scoping
- Scoping one hook to a subset of traffic today needs a whole separate proxy deployment

How it solves it:

- New opt-in `litellm.enable_hook_filters` switch, default off, zero behavior change until set
- New `hook_filters` block per hook method on a callback's own config: models, key aliases, model tags, request tags
- `call_custom_hook`/`call_custom_hook_sync` become the one dispatcher every hook invocation now routes through, so the filter check lives in one place instead of ~15 call sites

## User Flow

Before: an admin wants a PII-scanning guardrail to run only for a specific group of models, and a separate audit-logging callback to run only for requests tagged "finance", but neither has a config field to scope that way

1. They add the guardrail under `guardrails:` in config.yaml and it becomes active for every model on the proxy
2. Every `POST https://litellm-domain/v1/chat/completions` request runs the guardrail, including calls to models it was never meant to cover
3. Their workaround is running a second, separately-configured proxy deployment just for the models that shouldn't see the guardrail

After: each hook can be scoped directly in its own config, on the same proxy deployment

1. They add a filter restricting the guardrail to a glob pattern over model names, and a separate filter restricting the logging callback to a request tag
2. `POST https://litellm-domain/v1/chat/completions` for a matching model runs the guardrail; the same request for any other model does not
3. A request tagged "finance" (via `metadata.tags` or the `x-litellm-tags` header) triggers the audit-logging callback; an untagged request to the same model does not
4. Both workloads run on the same proxy deployment, each scoped to only the traffic it's meant for

## Relevant issues

Fixes #40339

Related, narrower prior art (not closed by this PR): #34397 (single-dimension, guardrail-only version of the models filter, closed with its PR unmerged), #31881, #31870 (the same model-group scoping gap, limited to one guardrail integration)

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Config used for both cases (a throwaway custom callback logging an `x-hook-filters-probe: ran` response header, used only to make each filter's effect directly observable):

```yaml
model_list:
  - model_name: haiku
    litellm_params:
      model: anthropic/claude-haiku-4-5
      api_key: os.environ/ANTHROPIC_API_KEY
  - model_name: sonnet
    litellm_params:
      model: anthropic/claude-sonnet-4-5
      api_key: os.environ/ANTHROPIC_API_KEY

litellm_settings:
  callbacks: ["my_module.my_probe_instance"]
  # enable_hook_filters: true   <- present only in the "flag enabled" case below

callback_settings:
  my_module.my_probe_instance:
    hook_filters:
      async_post_call_response_headers_hook:
        models: ["haiku"]

general_settings:
  master_key: sk-1234
```

### Before (c52b53706ed4c7f50bc3afe05a6937c6b8783ce7)

#### hook_filters has no effect, with or without the flag

1. `curl -sD - -o /dev/null -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model":"haiku","messages":[{"role":"user","content":"say hi in 3 words"}]}' http://localhost:4000/v1/chat/completions` -> `HTTP/1.1 200 OK`, `x-hook-filters-probe: ran`
2. Same request with `"model":"sonnet"` (meant to be excluded by `models: ["haiku"]`) -> `HTTP/1.1 200 OK`, `x-hook-filters-probe: ran` anyway
3. Adding `enable_hook_filters: true` to `litellm_settings` and repeating both requests gives the identical result: the header runs on both models regardless, since the switch doesn't exist yet

### After (f3d8961b60c60d5ed06eb4203d3de8262e587a08)

#### hook_filters has no effect, with or without the flag

1. With `enable_hook_filters` absent from config (default `False`): the haiku request -> `HTTP/1.1 200 OK`, `x-hook-filters-probe: ran`
2. The sonnet request -> `HTTP/1.1 200 OK`, `x-hook-filters-probe: ran` -- identical to Before, proving the default is unaffected
3. Adding `enable_hook_filters: true` and repeating: haiku -> `HTTP/1.1 200 OK`, `x-hook-filters-probe: ran`; sonnet -> `HTTP/1.1 200 OK` with no `x-hook-filters-probe` header -- the filter is now enforced

## Type

🆕 New Feature
✅ Test

## Caveats (if any)

### Medium

- `model_tags`/`request_tags` share one merged tag list at deployment-scoped hooks, since the router already merges deployment tags into request tags before those hooks fire; true separation would need router changes out of scope here
- Coverage is scoped to direct `CustomLogger`/`CustomGuardrail` hook-method dispatch; the long-standing hardcoded `if callback == "promptlayer":`-style legacy integrations in the logging-event handlers are unchanged, matching how `callback_settings` already only applies to registered callback instances

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
