### PR TITLE
fix(integrations): pass original request object to post-call guardrail hooks

### DIFF
--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -850,20 +850,24 @@ class CustomGuardrail(CustomLogger):
         if self.should_run_guardrail(data=request_data, event_type=GuardrailEventHooks.post_call) is not True:
             return None
 
-        # CHECK IF GUARDRAIL REJECTS THE REQUEST
         target: Final = self._deployment_hook_target()
-        hook_request_data: Final = {**request_data, "guardrail_to_apply": self} if target is not self else request_data
-        result: Final = await target.async_post_call_success_hook(
-            user_api_key_dict=UserAPIKeyAuth(
-                user_id=request_data.get("user_api_key_user_id"),
-                team_id=request_data.get("user_api_key_team_id"),
-                end_user_id=request_data.get("user_api_key_end_user_id"),
-                api_key=request_data.get("user_api_key_hash"),
-                request_route=request_data.get("user_api_key_request_route"),
-            ),
-            data=hook_request_data,
-            response=response,
-        )
+        try:
+            if target is not self:
+                request_data["guardrail_to_apply"] = self  # rebind-ok: dispatch consumes this key
+            result: Final = await target.async_post_call_success_hook(
+                user_api_key_dict=UserAPIKeyAuth(
+                    user_id=request_data.get("user_api_key_user_id"),
+                    team_id=request_data.get("user_api_key_team_id"),
+                    end_user_id=request_data.get("user_api_key_end_user_id"),
+                    api_key=request_data.get("user_api_key_hash"),
+                    request_route=request_data.get("user_api_key_request_route"),
+                ),
+                data=request_data,
+                response=response,
+            )
+        finally:
+            if target is not self:
+                request_data.pop("guardrail_to_apply", None)
 
         if not self._is_valid_response_type(result):
             return None

--- a/tests/test_litellm/integrations/test_custom_guardrail.py
+++ b/tests/test_litellm/integrations/test_custom_guardrail.py
@@ -1842,12 +1842,14 @@ class _ApplyStyleGuardrail(CustomGuardrail):
         self.block = block
         self.apply_called = False
         self.seen_texts = None
+        self.seen_request_data = None
 
     async def apply_guardrail(self, inputs, request_data, input_type, logging_obj=None):
         from fastapi import HTTPException
 
         self.apply_called = True
         self.seen_texts = inputs.get("texts")
+        self.seen_request_data = request_data
         if self.block:
             raise HTTPException(status_code=400, detail={"error": "Violated moderation policy"})
         return inputs
@@ -2647,6 +2649,91 @@ class TestCustomGuardrailPostCallSuccessDeploymentHook:
     VectorStorePreCallHook that attaches provider_specific_fields["search_results"])."""
 
     @pytest.mark.asyncio
+    async def test_apply_guardrail_retains_request_identity(self) -> None:
+        from litellm.types.guardrails import GuardrailEventHooks
+        from litellm.types.utils import Choices, Message, ModelResponse
+
+        guardrail: Final = _ApplyStyleGuardrail(block=False)
+        guardrail.event_hook = GuardrailEventHooks.post_call
+        request_data: Final = {"guardrails": ["apply-style-guardrail"]}
+        response: Final = ModelResponse(choices=[Choices(message=Message(content="review me"))])
+
+        await guardrail.async_post_call_success_deployment_hook(
+            request_data=request_data, response=response, call_type=CallTypes.acompletion
+        )
+
+        assert guardrail.seen_request_data is request_data
+        assert guardrail.seen_texts == ["review me"]
+        assert "guardrail_to_apply" not in request_data
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("call_type", (None, CallTypes.acompletion))
+    async def test_apply_guardrail_masks_response_and_records_metadata(self, call_type: CallTypes | None) -> None:
+        from litellm.proxy.guardrails.guardrail_hooks.litellm_content_filter.content_filter import (
+            ContentFilterGuardrail,
+        )
+        from litellm.types.guardrails import BlockedWord, ContentFilterAction, GuardrailEventHooks
+        from litellm.types.utils import Choices, Message, ModelResponse
+
+        guardrail: Final = ContentFilterGuardrail(
+            guardrail_name="response-filter",
+            event_hook=GuardrailEventHooks.post_call,
+            blocked_words=[BlockedWord(keyword="secret", action=ContentFilterAction.MASK)],
+        )
+        request_data: Final = {"guardrails": ["response-filter"]}
+        response: Final = ModelResponse(choices=[Choices(message=Message(content="a secret"))])
+
+        result: Final = await guardrail.async_post_call_success_deployment_hook(
+            request_data=request_data, response=response, call_type=call_type
+        )
+
+        assert isinstance(result, ModelResponse)
+        assert result.choices[0].message.content == f"a {guardrail.keyword_redaction_tag}"
+        entries: Final = _guardrail_entries(request_data)
+        assert len(entries) == 1
+        assert entries[0]["guardrail_name"] == "response-filter"
+        assert entries[0]["guardrail_mode"] == "post_call"
+        assert "guardrail_to_apply" not in request_data
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("error_type", (None, RuntimeError, asyncio.CancelledError))
+    async def test_dispatch_cleans_up_request_on_every_exit(self, error_type: type[BaseException] | None) -> None:
+        from contextlib import nullcontext
+
+        from litellm.integrations.custom_logger import CustomLogger
+        from litellm.types.utils import LLMResponseTypes, ModelResponse
+
+        error: Final = error_type("dispatch interrupted") if error_type is not None else None
+
+        class Dispatch(CustomLogger):
+            request_data: dict[str, object] | None = None
+
+            async def async_post_call_success_hook(
+                self, data: dict[str, object], user_api_key_dict: UserAPIKeyAuth, response: LLMResponseTypes
+            ) -> LLMResponseTypes:
+                self.request_data = data
+                if error is not None:
+                    raise error
+                return response
+
+        dispatch: Final = Dispatch()
+
+        class Guardrail(_ApplyStyleGuardrail):
+            def _deployment_hook_target(self) -> CustomLogger:
+                return dispatch
+
+        guardrail: Final = Guardrail(block=False)
+        guardrail.event_hook = GuardrailEventHooks.post_call
+        request_data: Final = {"guardrails": ["apply-style-guardrail"]}
+        with pytest.raises(error_type) if error_type is not None else nullcontext():
+            await guardrail.async_post_call_success_deployment_hook(
+                request_data=request_data, response=ModelResponse(), call_type=CallTypes.acompletion
+            )
+
+        assert dispatch.request_data is request_data
+        assert "guardrail_to_apply" not in request_data
+
+    @pytest.mark.asyncio
     async def test_returns_none_when_request_has_no_guardrails(self):
         from litellm.types.utils import ModelResponse
 
@@ -2740,4 +2827,5 @@ class TestCustomGuardrailPostCallSuccessDeploymentHook:
 
         assert result is response
         assert response.choices[0].message.content == "filtered response"
-        assert request_data == {"guardrails": ["test-guardrail"]}
+        assert "guardrail_to_apply" not in request_data
+        assert len(_guardrail_entries(request_data)) == 1


### PR DESCRIPTION
## TLDR

Problem this solves:

- Post-call guardrails receive a copy of the request
- Newly attached metadata disappears from the caller's request

How it solves it:

- Pass the original request through unified guardrail dispatch
- Clean up the temporary dispatch key on every exit

This fixes an existing Python-only bug exposed by the Rust work. A response filter can change `a secret` to `a [KEYWORD_REDACTED]`, while a later callback sees no record of which guardrail ran

The simplified examples below show why. The request starts without metadata, and the guardrail creates it while processing the response

Before, the guardrail writes to a shallow copy:

```python
request_data = {"guardrails": ["response-filter"]}
hook_data = {**request_data}

hook_data["metadata"] = {"applied_guardrails": ["response-filter"]}

assert "metadata" not in request_data
```

The response can still be masked because it is passed separately. The new metadata exists only on `hook_data`, so later callbacks receiving `request_data` miss it

After, the guardrail receives the same request object:

```python
request_data = {"guardrails": ["response-filter"]}
hook_data = request_data

hook_data["metadata"] = {"applied_guardrails": ["response-filter"]}

assert request_data["metadata"]["applied_guardrails"] == ["response-filter"]
```

The actual fix passes `data=request_data` to the shared adapter. It temporarily adds `guardrail_to_apply` to select the guardrail, then removes that key in `finally`, including on errors and cancellation. The audit metadata remains

Existing nested dictionaries can already be shared by a shallow copy, so the old behavior depends on whether metadata exists before dispatch

The current Python `@client` wrapper already supplies the request to this dispatcher. No Rust implementation is needed to reproduce or fix the bug. The provider-handler versus `@client` context design raised in [the original review](https://github.com/BerriAI/litellm/pull/40070#discussion_r3960409870) remains a separate decision. This extraction also leaves the request-route fallback in #40070

## User Flow

Before: a developer's app receives masked output, but its request audit reports no guardrail execution

1. Use the Python SDK with Rust disabled, configure `response-filter` to mask `secret`, and configure the app to report executed guardrail names from the request audit data
2. Request a completion containing `a secret`, without supplying a `metadata` argument
3. Receive `a [KEYWORD_REDACTED]`
4. Observe `[]` in the app's request audit output, even though the response was filtered

After: the same masked response includes the guardrail execution in the app's request audit data

1. Use the Python SDK with Rust disabled, configure `response-filter` to mask `secret`, and configure the app to report executed guardrail names from the request audit data
2. Request a completion containing `a secret`, without supplying a `metadata` argument
3. Receive `a [KEYWORD_REDACTED]`
4. Observe `["response-filter"]` in the app's request audit output

This was reproduced through the public Python SDK with `mock_response` supplying the provider response. The confirmed failure is missing metadata for subsequent request-based audit processing; masking still works. Applications that export this observation can record an incomplete audit trail. Applications that require an execution record could incorrectly reject the request, although no production incident has been established

This does not establish missing records in all standard spend logs or logging integrations: a separate logging-object synchronization path can preserve them. A metadata dictionary already present before dispatch can also avoid this specific failure because the shallow copy shares that dictionary

## Relevant issues

Extracted from #40070. Independent of #40410

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The focused test file passes locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible
- [ ] I have received a Greptile Confidence Score of at least 4/5

Validation: the updated test file reports 7 failed and 162 passed against staging `47b15ffb67`, then 169 passed with this fix. Regressions cover request identity, production content-filter masking and metadata, and temporary-key cleanup after success, failure, and cancellation

`make check` passes, including scoped formatting, Ruff, type-discipline, test-quality, and basedpyright budget checks

## Screenshots / Proof of Fix

Live-provider proof is pending. The configured provider accounts rejected the requests before guardrail execution; unit tests are not presented as end-to-end proof. This PR remains a draft until that proof is available

Shared reproduction: set `MISTRAL_API_KEY` to a working provider key and run the following from each checkout. It sends one real completion and prints the response-filter audit data

<details>
<summary>SDK reproduction</summary>

```bash
python - <<'PYTHON'
import asyncio
import json
import litellm
from litellm.integrations.custom_logger import CustomLogger
from litellm.proxy.guardrails.guardrail_hooks.litellm_content_filter.content_filter import ContentFilterGuardrail
from litellm.types.guardrails import BlockedWord, ContentFilterAction, GuardrailEventHooks


class Audit(CustomLogger):
    def __init__(self):
        self.guardrail_names = []
        self.dispatch_key_leaked = None

    async def async_post_call_success_deployment_hook(self, request_data, response, call_type):
        metadata = request_data.get("metadata", {})
        entries = metadata.get("standard_logging_guardrail_information", [])
        self.guardrail_names = [entry["guardrail_name"] for entry in entries]
        self.dispatch_key_leaked = "guardrail_to_apply" in request_data


async def main():
    audit = Audit()
    guardrail = ContentFilterGuardrail(
        guardrail_name="response-filter",
        event_hook=GuardrailEventHooks.post_call,
        blocked_words=[BlockedWord(keyword="secret", action=ContentFilterAction.MASK)],
    )
    litellm.callbacks = [guardrail, audit]
    litellm.rust(False)
    response = await litellm.acompletion(
        model="mistral/mistral-small-latest",
        messages=[{"role": "user", "content": "Reply with exactly these two words: a secret"}],
        guardrails=["response-filter"],
        temperature=0,
        max_tokens=32,
    )
    print(json.dumps({
        "model": response.model,
        "content": response.choices[0].message.content,
        "guardrail_names": audit.guardrail_names,
        "dispatch_key_leaked": audit.dispatch_key_leaked,
        "total_tokens": response.usage.total_tokens,
    }, sort_keys=True))


asyncio.run(main())
PYTHON
```

</details>

### Before (47b15ffb67)

1. Request `mistral/mistral-small-latest` through the Python SDK with the response filter enabled and Rust disabled
2. Observe HTTP 429, `Rate limit exceeded`, before the response can be moderated

### After (94d1b418d5)

1. Request `mistral/mistral-small-latest` through the Python SDK with the response filter enabled and Rust disabled
2. Observe HTTP 429, `Rate limit exceeded`, before the response can be moderated

## Type

Bug Fix
Test

## Caveats (if any)

### Low

- Guardrail top-level mutations now reach the original request
- Live-provider verification remains pending

## Final Attestation

- [x] Tests cover metadata retention and dispatch cleanup edge cases
