### PR TITLE
fix(grayswan): honor failure policy for invalid monitor decisions

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/grayswan/grayswan.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/grayswan/grayswan.py
@@ -2,9 +2,11 @@
 
 import os
 import time
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Final, Literal, Optional, Protocol
 
 from fastapi import HTTPException
+from pydantic import TypeAdapter, ValidationError
 from typing_extensions import NotRequired, ReadOnly, TypedDict
 
 from litellm._logging import verbose_proxy_logger
@@ -26,6 +28,7 @@ if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 
 GRAYSWAN_BLOCK_ERROR_MSG: Final = "Blocked by Gray Swan Guardrail"
+_MONITOR_RESPONSE_ADAPTER: Final = TypeAdapter(Mapping[str, object])
 
 
 class _GraySwanMonitorResponse(TypedDict):
@@ -36,6 +39,7 @@ class _GraySwanMonitorResponse(TypedDict):
     violated_rule_descriptions: ReadOnly[NotRequired[list[object]]]
     mutation: ReadOnly[NotRequired[bool | None]]
     ipi: ReadOnly[NotRequired[bool | None]]
+    error: ReadOnly[NotRequired[bool]]
 
 
 class _GraySwanMonitorHTTPResponse(Protocol):
@@ -65,6 +69,20 @@ class GraySwanGuardrailAPIError(Exception):
     def __init__(self, message: str, status_code: int | None = None) -> None:
         super().__init__(message)
         self.status_code = status_code
+
+
+def _validated_violation_score(response_json: object) -> float:
+    """Do not interpret an unevaluated or malformed response as a clean decision."""
+    try:
+        response: Final = _MONITOR_RESPONSE_ADAPTER.validate_python(response_json, strict=True)
+    except ValidationError:
+        raise GraySwanGuardrailAPIError("Gray Swan returned an invalid monitor response") from None
+    if response.get("error"):
+        raise GraySwanGuardrailAPIError("Gray Swan moderation failed")
+    score: Final = response.get("violation")
+    if isinstance(score, bool) or not isinstance(score, (int, float)) or not 0 <= score <= 1:
+        raise GraySwanGuardrailAPIError("Gray Swan returned an invalid violation score")
+    return float(score)
 
 
 class GraySwanGuardrail(CustomGuardrail):
@@ -331,7 +349,7 @@ class GraySwanGuardrail(CustomGuardrail):
             data: Optional request data (for passthrough exceptions)
             hook_type: Optional GuardrailEventHooks for determining behavior
         """
-        violation_score: Final = float(response_json.get("violation", 0.0) or 0.0)
+        violation_score: Final = _validated_violation_score(response_json)
         violated_rules: Final = response_json.get("violated_rules", [])
         mutation_detected: Final = response_json.get("mutation")
         ipi_detected: Final = response_json.get("ipi")
@@ -456,7 +474,7 @@ class GraySwanGuardrail(CustomGuardrail):
         Raises:
             HTTPException: If content is blocked (block mode)
         """
-        violation_score: Final = float(response_json.get("violation", 0.0) or 0.0)
+        violation_score: Final = _validated_violation_score(response_json)
         violated_rules: Final = response_json.get("violated_rule_descriptions", [])
         mutation_detected: Final = response_json.get("mutation")
         ipi_detected: Final = response_json.get("ipi")

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_grayswan.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_grayswan.py
@@ -1,4 +1,7 @@
 from typing import Optional
+from unittest.mock import Mock
+
+import httpx
 
 import pytest
 from fastapi import HTTPException
@@ -594,3 +597,120 @@ def test_ensure_litellm_metadata_noop_when_already_present() -> None:
     _ensure_litellm_metadata(data, user_auth)
 
     assert data["litellm_metadata"] == {"existing": "value"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("input_type", ["request", "response"])
+@pytest.mark.parametrize("action", ["block", "monitor", "passthrough"])
+@pytest.mark.parametrize("fail_open", [False, True])
+@pytest.mark.parametrize("payload", [{}, {"violation": None}, {"error": True, "violation": 0.0}])
+async def test_application_errors_respect_failure_policy(monkeypatch, input_type, action, fail_open, payload):
+    guardrail = GraySwanGuardrail(
+        guardrail_name="response-contract",
+        api_key="test-key",
+        policy_id="test-policy",
+        fail_open=fail_open,
+        on_flagged_action=action,
+        event_hook=GuardrailEventHooks.pre_call,
+    )
+    log_failure = Mock()
+    monkeypatch.setattr(guardrail, "_log_guardrail_failure", log_failure)
+    requests = []
+
+    def respond(request):
+        requests.append(request)
+        return httpx.Response(200, json=payload)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(respond)) as client:
+        guardrail.async_handler = client
+        inputs = {"texts": ["synthetic input"]}
+        if fail_open:
+            assert await guardrail.apply_guardrail(inputs, {}, input_type) is inputs
+        else:
+            with pytest.raises(GraySwanGuardrailAPIError):
+                await guardrail.apply_guardrail(inputs, {}, input_type)
+    assert len(requests) == 1
+    assert requests[0].headers["authorization"] == "Bearer test-key"
+    log_failure.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        None,
+        [],
+        {"violation": "0"},
+        {"violation": True},
+        {"violation": -0.1},
+        {"violation": 1.1},
+        {"violation": float("nan")},
+        {"violation": float("inf")},
+        {"error": True, "violation": 1.0},
+    ],
+)
+@pytest.mark.parametrize("legacy", [False, True])
+def test_invalid_decisions_are_errors(payload, legacy):
+    guardrail = GraySwanGuardrail(guardrail_name="invalid-decision", api_key="test-key")
+    if legacy:
+        with pytest.raises(GraySwanGuardrailAPIError):
+            guardrail._process_grayswan_response(payload)
+    else:
+        with pytest.raises(GraySwanGuardrailAPIError):
+            guardrail._process_response_internal(payload, {}, {"texts": ["hello"]}, False)
+
+
+@pytest.mark.parametrize("score", [0, 0.49, 0.5, 1])
+def test_valid_decisions_keep_threshold_semantics(score):
+    from fastapi import HTTPException
+
+    guardrail = GraySwanGuardrail(
+        guardrail_name="valid-decision",
+        api_key="test-key",
+        violation_threshold=0.5,
+        on_flagged_action="block",
+    )
+    inputs = {"texts": ["hello"]}
+    payload = {
+        "violation": score,
+        "error": False,
+        "observe_violation": 1.0,
+        "block_message": "Informational only below threshold",
+    }
+    if score >= 0.5:
+        with pytest.raises(HTTPException) as error:
+            guardrail._process_response_internal(payload, {}, inputs, False)
+        assert error.value.status_code == 400
+    else:
+        assert guardrail._process_response_internal(payload, {}, inputs, False) is inputs
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", ["timeout", "malformed_json", "http_error"])
+@pytest.mark.parametrize("fail_open", [False, True])
+async def test_transport_errors_respect_failure_policy(monkeypatch, failure, fail_open):
+    guardrail = GraySwanGuardrail(
+        guardrail_name="transport-contract",
+        api_key="test-key",
+        policy_id="test-policy",
+        fail_open=fail_open,
+        on_flagged_action="block",
+    )
+    log_failure = Mock()
+    monkeypatch.setattr(guardrail, "_log_guardrail_failure", log_failure)
+
+    def respond(request):
+        if failure == "timeout":
+            raise httpx.ReadTimeout("controlled timeout", request=request)
+        if failure == "malformed_json":
+            return httpx.Response(200, content=b"not-json")
+        return httpx.Response(503, json={"error": "controlled failure"})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(respond)) as client:
+        guardrail.async_handler = client
+        inputs = {"texts": ["synthetic input"]}
+        if fail_open:
+            assert await guardrail.apply_guardrail(inputs, {}, "request") is inputs
+        else:
+            with pytest.raises(GraySwanGuardrailAPIError):
+                await guardrail.apply_guardrail(inputs, {}, "request")
+    log_failure.assert_called_once()

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_grayswan.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_grayswan.py
@@ -1,4 +1,5 @@
-from typing import Optional
+from collections.abc import AsyncIterator
+from typing import Final, Optional
 from unittest.mock import Mock
 
 import httpx
@@ -599,38 +600,42 @@ def test_ensure_litellm_metadata_noop_when_already_present() -> None:
     assert data["litellm_metadata"] == {"existing": "value"}
 
 
-@pytest.mark.asyncio
-@pytest.mark.parametrize("input_type", ["request", "response"])
-@pytest.mark.parametrize("action", ["block", "monitor", "passthrough"])
-@pytest.mark.parametrize("fail_open", [False, True])
-@pytest.mark.parametrize("payload", [{}, {"violation": None}, {"error": True, "violation": 0.0}])
-async def test_application_errors_respect_failure_policy(monkeypatch, input_type, action, fail_open, payload):
-    guardrail = GraySwanGuardrail(
-        guardrail_name="response-contract",
+@pytest.fixture
+async def failure_policy_guardrail(
+    monkeypatch: pytest.MonkeyPatch, fail_open: bool, action: str
+) -> AsyncIterator[tuple[GraySwanGuardrail, Mock, Mock]]:
+    guardrail: Final = GraySwanGuardrail(
+        guardrail_name="failure-contract",
         api_key="test-key",
         policy_id="test-policy",
         fail_open=fail_open,
         on_flagged_action=action,
         event_hook=GuardrailEventHooks.pre_call,
     )
-    log_failure = Mock()
+    log_failure: Final = Mock()
     monkeypatch.setattr(guardrail, "_log_guardrail_failure", log_failure)
-    requests = []
-
-    def respond(request):
-        requests.append(request)
-        return httpx.Response(200, json=payload)
-
+    respond: Final = Mock()
     async with httpx.AsyncClient(transport=httpx.MockTransport(respond)) as client:
         guardrail.async_handler = client
-        inputs = {"texts": ["synthetic input"]}
-        if fail_open:
-            assert await guardrail.apply_guardrail(inputs, {}, input_type) is inputs
-        else:
-            with pytest.raises(GraySwanGuardrailAPIError):
-                await guardrail.apply_guardrail(inputs, {}, input_type)
-    assert len(requests) == 1
-    assert requests[0].headers["authorization"] == "Bearer test-key"
+        yield guardrail, respond, log_failure
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("input_type", ["request", "response"])
+@pytest.mark.parametrize("action", ["block", "monitor", "passthrough"])
+@pytest.mark.parametrize("fail_open", [False, True])
+@pytest.mark.parametrize("payload", [{}, {"violation": None}, {"error": True, "violation": 0.0}])
+async def test_application_errors_respect_failure_policy(failure_policy_guardrail, input_type, action, fail_open, payload):
+    guardrail, respond, log_failure = failure_policy_guardrail
+    respond.return_value = httpx.Response(200, json=payload)
+    inputs: Final = {"texts": ["synthetic input"]}
+    if fail_open:
+        assert await guardrail.apply_guardrail(inputs, {}, input_type) is inputs
+    else:
+        with pytest.raises(GraySwanGuardrailAPIError):
+            await guardrail.apply_guardrail(inputs, {}, input_type)
+    respond.assert_called_once()
+    assert respond.call_args.args[0].headers["authorization"] == "Bearer test-key"
     log_failure.assert_called_once()
 
 
@@ -661,8 +666,6 @@ def test_invalid_decisions_are_errors(payload, legacy):
 
 @pytest.mark.parametrize("score", [0, 0.49, 0.5, 1])
 def test_valid_decisions_keep_threshold_semantics(score):
-    from fastapi import HTTPException
-
     guardrail = GraySwanGuardrail(
         guardrail_name="valid-decision",
         api_key="test-key",
@@ -685,32 +688,24 @@ def test_valid_decisions_keep_threshold_semantics(score):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("action", ["block"])
 @pytest.mark.parametrize("failure", ["timeout", "malformed_json", "http_error"])
 @pytest.mark.parametrize("fail_open", [False, True])
-async def test_transport_errors_respect_failure_policy(monkeypatch, failure, fail_open):
-    guardrail = GraySwanGuardrail(
-        guardrail_name="transport-contract",
-        api_key="test-key",
-        policy_id="test-policy",
-        fail_open=fail_open,
-        on_flagged_action="block",
-    )
-    log_failure = Mock()
-    monkeypatch.setattr(guardrail, "_log_guardrail_failure", log_failure)
+async def test_transport_errors_respect_failure_policy(failure_policy_guardrail, failure, fail_open):
+    guardrail, respond, log_failure = failure_policy_guardrail
 
-    def respond(request):
+    def transport_response(request: httpx.Request) -> httpx.Response:
         if failure == "timeout":
             raise httpx.ReadTimeout("controlled timeout", request=request)
         if failure == "malformed_json":
             return httpx.Response(200, content=b"not-json")
         return httpx.Response(503, json={"error": "controlled failure"})
 
-    async with httpx.AsyncClient(transport=httpx.MockTransport(respond)) as client:
-        guardrail.async_handler = client
-        inputs = {"texts": ["synthetic input"]}
-        if fail_open:
-            assert await guardrail.apply_guardrail(inputs, {}, "request") is inputs
-        else:
-            with pytest.raises(GraySwanGuardrailAPIError):
-                await guardrail.apply_guardrail(inputs, {}, "request")
+    respond.side_effect = transport_response
+    inputs: Final = {"texts": ["synthetic input"]}
+    if fail_open:
+        assert await guardrail.apply_guardrail(inputs, {}, "request") is inputs
+    else:
+        with pytest.raises(GraySwanGuardrailAPIError):
+            await guardrail.apply_guardrail(inputs, {}, "request")
     log_failure.assert_called_once()


### PR DESCRIPTION
## TLDR

Problem this solves:

- Moderation failures could allow content despite `fail_open=False`
- Missing or invalid violation scores could become clean decisions

How it solves it:

- Validate the response object before reading its decision
- Route invalid decisions through the existing failure-policy handler

Both response-processing paths reject error envelopes and missing, nonnumeric, nonfinite, or out-of-range violation scores with `GraySwanGuardrailAPIError`. The existing handler propagates the failure when `fail_open=False`, or logs it and allows content when `fail_open=True`. Valid scores and threshold equality preserve their existing behavior

## User Flow

Before: a moderation failure could allow content despite the operator's policy

1. The operator enables the Gray Swan guardrail with `fail_open=False`
2. A developer submits input or output text for moderation
3. The monitor responds with HTTP 200 and `error: true`
4. The guardrail allows the text even though moderation failed

After: the same moderation failure follows the configured policy

1. The operator enables the Gray Swan guardrail with `fail_open=False`
2. A developer submits input or output text for moderation
3. The monitor responds with HTTP 200 and `error: true`
4. The guardrail raises an error; allowing text requires `fail_open=True`

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] Added meaningful regression tests in the existing mapped test file
- [x] Targeted test file passes locally
- [ ] All required CI checks pass
- [x] Scope is limited to the adapter fix and its tests
- [ ] Greptile confidence score received before maintainer review

## Validation

Base: `47b15ffb677902fc4550a4471b82e09f77ec77d7`

Head: `7b19c4d32f92767f2620b0a2c5c21e84f0ba9fd4`

The expanded test file produced **54 failures and 34 passes** against the base implementation. With the fix, **all 88 tests pass**. The 64 new cases cover input/output, all three intervention modes, both failure policies, invalid scores, HTTP errors, malformed JSON, timeouts, and the legacy response handler

```sh
LITELLM_LOCAL_MODEL_COST_MAP=True AWS_EC2_METADATA_DISABLED=true python -m pytest \
  tests/test_litellm/proxy/guardrails/guardrail_hooks/test_grayswan.py \
  --confcutdir=tests/test_litellm/proxy/guardrails/guardrail_hooks -q
```

The HTTP cases share a pytest fixture for the guardrail, HTTPX mock transport, and failure-log spy. All 88 cases remain enabled, including request-count and authorization-header assertions. The targeted suite and test-tree Ruff checks pass, and the repository test-quality gate passes against `origin/litellm_internal_staging`

Upstream CI completed with 82 successful checks and one skipped check. Its only failure is the [OSV scan](https://github.com/BerriAI/litellm/actions/runs/34399297307/job/102626874711) on the existing dashboard development dependency `smol-toml` 1.6.1 (GHSA-7w5x-hrqm-74c2; fixed in 1.7.1). The same version is present at the PR base, and this PR changes neither dependency lockfile

## Screenshots / Proof of Fix

Live proxy/provider verification has not been run. This remains a draft for that validation and upstream CI

## Type

Bug fix

## Caveats

### Low

- Local validation covers the adapter, not the complete gateway
- Full-suite validation is left to CI

## Final Attestation

- [ ] All pre-review validation is complete
