### PR TITLE
fix(router): don't key the TPM counter on an empty model_id

### DIFF
--- a/litellm/router_utils/pre_call_checks/model_rate_limit_check.py
+++ b/litellm/router_utils/pre_call_checks/model_rate_limit_check.py
@@ -11,6 +11,7 @@ is logged the first time such a deployment is seen.
 """
 
 import contextlib
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Final
 
 import httpx
@@ -304,6 +305,24 @@ class ModelRateLimitingCheck(CustomLogger):
             # Don't fail the request if rate limit check fails
             return deployment
 
+    @staticmethod
+    def _model_id_from_kwargs(kwargs: Mapping[str, Any]) -> str | None:
+        """Recover the deployment id when the logging payload is missing it.
+
+        On the streaming path the payload is built from a ``litellm_params``
+        snapshot taken at ``Logging`` init, before the router stamped
+        ``model_info`` in, so ``model_id`` comes back as "". The router does
+        stamp ``kwargs["model_info"]``, so prefer that before giving up.
+        """
+        litellm_params: Final = kwargs.get("litellm_params") or {}
+        for source in (kwargs.get("model_info"), litellm_params.get("model_info")):
+            if isinstance(source, Mapping):
+                candidate = source.get("id")
+                if candidate:
+                    return str(candidate)
+        fallback: Final = litellm_params.get("model_id")
+        return str(fallback) if fallback else None
+
     async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
         from litellm.litellm_core_utils.core_helpers import (
             _get_parent_otel_span_from_kwargs,
@@ -333,8 +352,13 @@ class ModelRateLimitingCheck(CustomLogger):
             if standard_logging_object is None:
                 return
 
-            model_id: Final = standard_logging_object.get("model_id")
-            if model_id is None:
+            model_id: Final = standard_logging_object.get("model_id") or self._model_id_from_kwargs(kwargs)
+            if not model_id:
+                # An empty string reaches here as readily as None: the standard
+                # logging payload defaults model_id to "" when metadata carries
+                # no model_info. Keying the counter on it buckets every such
+                # deployment under ":<model>:tpm:<minute>" while the real
+                # deployment's key stays at zero, so limits never trigger.
                 return
 
             total_tokens: Final = standard_logging_object.get("total_tokens", 0)
@@ -397,8 +421,13 @@ class ModelRateLimitingCheck(CustomLogger):
             if standard_logging_object is None:
                 return
 
-            model_id: Final = standard_logging_object.get("model_id")
-            if model_id is None:
+            model_id: Final = standard_logging_object.get("model_id") or self._model_id_from_kwargs(kwargs)
+            if not model_id:
+                # An empty string reaches here as readily as None: the standard
+                # logging payload defaults model_id to "" when metadata carries
+                # no model_info. Keying the counter on it buckets every such
+                # deployment under ":<model>:tpm:<minute>" while the real
+                # deployment's key stays at zero, so limits never trigger.
                 return
 
             total_tokens: Final = standard_logging_object.get("total_tokens", 0)

--- a/litellm/router_utils/pre_call_checks/model_rate_limit_check.py
+++ b/litellm/router_utils/pre_call_checks/model_rate_limit_check.py
@@ -12,6 +12,7 @@ is logged the first time such a deployment is seen.
 
 import contextlib
 from collections.abc import Mapping
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Final
 
 import httpx
@@ -45,6 +46,9 @@ else:
 
 class RoutingArgs:
     ttl: int = 60  # 1min (RPM/TPM expire key)
+
+
+_NO_LITELLM_PARAMS: Final[Mapping[str, Any]] = MappingProxyType({})
 
 
 class ModelRateLimitingCheck(CustomLogger):
@@ -314,7 +318,7 @@ class ModelRateLimitingCheck(CustomLogger):
         ``model_info`` in, so ``model_id`` comes back as "". The router does
         stamp ``kwargs["model_info"]``, so prefer that before giving up.
         """
-        litellm_params: Final = kwargs.get("litellm_params") or {}
+        litellm_params: Final = kwargs.get("litellm_params") or _NO_LITELLM_PARAMS
         for source in (kwargs.get("model_info"), litellm_params.get("model_info")):
             if isinstance(source, Mapping):
                 candidate = source.get("id")

--- a/tests/test_litellm/test_router/test_enforce_model_rate_limits.py
+++ b/tests/test_litellm/test_router/test_enforce_model_rate_limits.py
@@ -268,6 +268,78 @@ class TestModelRateLimitingCheckAsync:
         assert "test-id:gpt-4:tpm:" in kwarg_params["key"]
         assert kwarg_params["value"] == 50
 
+    @pytest.mark.asyncio
+    async def test_async_log_success_event_recovers_model_id_from_kwargs(self):
+        """An empty model_id in the payload falls back to the router's model_info.
+
+        On the streaming path the standard logging payload is built from a
+        litellm_params snapshot taken before the router stamped model_info in,
+        so model_id arrives as "". The deployment id is still on kwargs.
+        """
+        mock_cache = MagicMock()
+        mock_cache.async_increment_cache = AsyncMock()
+        check = ModelRateLimitingCheck(dual_cache=mock_cache)
+
+        kwargs = {
+            "standard_logging_object": {
+                "model_id": "",
+                "total_tokens": 50,
+                "hidden_params": {"litellm_model_name": "gpt-4"},
+            },
+            "model_info": {"id": "deployment-1"},
+        }
+
+        await check.async_log_success_event(kwargs, None, None, None)
+
+        mock_cache.async_increment_cache.assert_called_once()
+        _, kwarg_params = mock_cache.async_increment_cache.call_args
+        assert "deployment-1:gpt-4:tpm:" in kwarg_params["key"]
+        assert kwarg_params["value"] == 50
+
+    @pytest.mark.asyncio
+    async def test_async_log_success_event_falls_back_to_litellm_params(self):
+        """model_info nested under litellm_params is also accepted."""
+        mock_cache = MagicMock()
+        mock_cache.async_increment_cache = AsyncMock()
+        check = ModelRateLimitingCheck(dual_cache=mock_cache)
+
+        kwargs = {
+            "standard_logging_object": {
+                "model_id": "",
+                "total_tokens": 10,
+                "hidden_params": {"litellm_model_name": "gpt-4"},
+            },
+            "litellm_params": {"model_info": {"id": "deployment-2"}},
+        }
+
+        await check.async_log_success_event(kwargs, None, None, None)
+
+        _, kwarg_params = mock_cache.async_increment_cache.call_args
+        assert "deployment-2:gpt-4:tpm:" in kwarg_params["key"]
+
+    @pytest.mark.asyncio
+    async def test_async_log_success_event_skips_when_no_model_id_anywhere(self):
+        """With no deployment id at all, nothing is counted.
+
+        Incrementing on an empty model_id would bucket unrelated deployments
+        under a shared ":<model>:tpm:<minute>" key.
+        """
+        mock_cache = MagicMock()
+        mock_cache.async_increment_cache = AsyncMock()
+        check = ModelRateLimitingCheck(dual_cache=mock_cache)
+
+        kwargs = {
+            "standard_logging_object": {
+                "model_id": "",
+                "total_tokens": 50,
+                "hidden_params": {"litellm_model_name": "gpt-4"},
+            }
+        }
+
+        await check.async_log_success_event(kwargs, None, None, None)
+
+        mock_cache.async_increment_cache.assert_not_called()
+
 
 class TestRouterWithEnforceModelRateLimits:
     """Test Router integration with enforce_model_rate_limits."""


### PR DESCRIPTION
Fixes #40292

## The defect on `main`

Both `async_log_success_event` and `async_log_failure_event` guard the TPM counter like this:

```python
model_id: Final = standard_logging_object.get("model_id")
if model_id is None:
    return
...
tpm_key: Final = f"{model_id}:{model}:tpm:{current_minute}"
await self.dual_cache.async_increment_cache(key=tpm_key, ...)
```

The guard only rejects `None`. But the standard logging payload defaults the field to an empty string:

```python
# litellm_logging.py
_model_id: Final = metadata.get("model_info", {}).get("id", "")
```

So `""` passes the guard and the counter is incremented under a key with an empty deployment id. Reproduced against `main` (47b15ff):

```
INCREMENTED a counter with an empty model_id
   key   = ':gpt-4:tpm:15-33'
   value = 50
```

Two consequences: every deployment whose payload lacks `model_info` collides on that single `":<model>:tpm:<minute>"` key, and each one's real key stays at zero — so the pre-call check never sees usage and limits never trigger. #40292 reports this from the streaming path, where the payload is built from a `litellm_params` snapshot taken at `Logging` init, before the router stamps `model_info` in.

## The change

Take option 2 from the issue — recover the id from kwargs rather than only skipping:

- `kwargs["model_info"]["id"]` (what `router.py` stamps)
- `kwargs["litellm_params"]["model_info"]["id"]`
- `kwargs["litellm_params"]["model_id"]`

and treat a still-empty id as a skip (`if not model_id`) rather than a usable key. That both restores tracking where the id is recoverable and stops the bogus shared counter where it isn't.

Applied to the failure handler as well, which carries the identical guard.

I did not touch the payload builder itself (option 1 in the issue). That path is shared by every callback and the streaming/non-streaming split is a larger change; this keeps the blast radius to the rate-limit callback. Happy to look at the root fix separately if you'd prefer it there.

## Relationship to #40331

#40331 touches the same two files but different functions — `_get_cache_keys`, `pre_call_check`, `async_pre_call_check` (lines 136–276). This PR is in `async_log_success_event` / `async_log_failure_event` (307+). No overlapping hunks in the source file; the test file will need a trivial conflict resolution depending on merge order.

The two are complementary: #40331 fixes how the check *reads* usage, this fixes the key it is *written* under.

## Tests

Three tests added next to the existing `test_async_log_success_event_increments_cache`:

- empty `model_id` + `kwargs["model_info"]` → counts under `deployment-1`
- empty `model_id` + `litellm_params["model_info"]` → counts under `deployment-2`
- empty `model_id` and nothing recoverable → `async_increment_cache` not called

`tests/test_litellm/test_router/test_enforce_model_rate_limits.py`: **20 passed**, up from 17. Reverting only the source change fails exactly the three new tests.

`ruff check` and `ruff format --check` clean on both files.
