### PR TITLE
feat(guardrails): allow Entra ID auth for Azure Content Safety

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/azure/__init__.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/azure/__init__.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Final
 
 from litellm.types.guardrails import SupportedGuardrailIntegrations
@@ -9,11 +10,13 @@ if TYPE_CHECKING:
     from litellm.types.guardrails import Guardrail, LitellmParams
 
 
-def initialize_guardrail(litellm_params: "LitellmParams", guardrail: "Guardrail"):
+def initialize_guardrail(
+    litellm_params: "LitellmParams",
+    guardrail: "Guardrail",
+    entra_token_provider: Callable[[], str] | None = None,
+) -> AzureContentSafetyPromptShieldGuardrail | AzureContentSafetyTextModerationGuardrail:
     import litellm
 
-    if not litellm_params.api_key:
-        raise ValueError("Azure Content Safety: api_key is required")
     if not litellm_params.api_base:
         raise ValueError("Azure Content Safety: api_base is required")
 
@@ -32,6 +35,7 @@ def initialize_guardrail(litellm_params: "LitellmParams", guardrail: "Guardrail"
                 **litellm_params.model_dump(exclude_none=True),
                 "api_key": litellm_params.api_key,
                 "api_base": litellm_params.api_base,
+                "entra_token_provider": entra_token_provider,
                 "default_on": litellm_params.default_on,
                 "event_hook": litellm_params.mode,
             },
@@ -43,6 +47,7 @@ def initialize_guardrail(litellm_params: "LitellmParams", guardrail: "Guardrail"
                 **litellm_params.model_dump(exclude_none=True),
                 "api_key": litellm_params.api_key,
                 "api_base": litellm_params.api_base,
+                "entra_token_provider": entra_token_provider,
                 "default_on": litellm_params.default_on,
                 "event_hook": litellm_params.mode,
             },

--- a/litellm/proxy/guardrails/guardrail_hooks/azure/__init__.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/azure/__init__.py
@@ -32,7 +32,7 @@ def initialize_guardrail(
         ) = AzureContentSafetyPromptShieldGuardrail(
             guardrail_name=guardrail_name,
             **{
-                **litellm_params.model_dump(exclude_none=True),
+                **litellm_params.model_dump(exclude_unset=True),
                 "api_key": litellm_params.api_key,
                 "api_base": litellm_params.api_base,
                 "entra_token_provider": entra_token_provider,
@@ -44,7 +44,7 @@ def initialize_guardrail(
         azure_content_safety_guardrail = AzureContentSafetyTextModerationGuardrail(
             guardrail_name=guardrail_name,
             **{
-                **litellm_params.model_dump(exclude_none=True),
+                **litellm_params.model_dump(exclude_unset=True),
                 "api_key": litellm_params.api_key,
                 "api_base": litellm_params.api_base,
                 "entra_token_provider": entra_token_provider,

--- a/litellm/proxy/guardrails/guardrail_hooks/azure/base.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/azure/base.py
@@ -3,6 +3,7 @@ import re
 from collections.abc import Callable
 from functools import cache
 from typing import TYPE_CHECKING, Any, Final
+from urllib.parse import urlparse
 
 from litellm._logging import verbose_proxy_logger
 from litellm.litellm_core_utils.prompt_templates.common_utils import (
@@ -27,6 +28,28 @@ AZURE_CONTENT_SAFETY_MAX_TEXT_LENGTH: Final = 10000
 AZURE_CONTENT_SAFETY_TEXT_RECORD_LENGTH: Final = 1000
 
 AZURE_CONTENT_SAFETY_ENTRA_SCOPE: Final = "https://cognitiveservices.azure.com/.default"
+
+AZURE_CONTENT_SAFETY_ENTRA_HOST_SUFFIXES: Final = (
+    ".cognitiveservices.azure.com",
+    ".cognitiveservices.azure.us",
+    ".cognitiveservices.azure.cn",
+    ".services.ai.azure.com",
+)
+
+
+def _assert_entra_destination_is_azure(api_base: str) -> None:
+    """An Entra token is scoped to every Cognitive Services resource the identity can reach,
+    not to one resource, so it is only ever sent to an Azure endpoint over TLS. Entra also
+    requires the resource's custom subdomain, so any other host is not a valid destination."""
+    parsed: Final = urlparse(api_base)
+    host: Final = (parsed.hostname or "").lower()
+    if parsed.scheme == "https" and host.endswith(AZURE_CONTENT_SAFETY_ENTRA_HOST_SUFFIXES):
+        return
+    raise ValueError(
+        f"Azure Content Safety: refusing to send a Microsoft Entra token to api_base {api_base!r}. "
+        "Entra authentication needs the resource's HTTPS custom subdomain endpoint, for example "
+        "https://your-resource.cognitiveservices.azure.com. Set api_key to reach any other host"
+    )
 
 
 @cache
@@ -66,6 +89,8 @@ class AzureGuardrailBase:
         self.api_key = api_key
         self.api_base = api_base
         self.api_version: str = kwargs.get("api_version") or "2024-09-01"
+        if not api_key:
+            _assert_entra_destination_is_azure(api_base)
         self._entra_token_provider: Final = entra_token_provider or (
             None if api_key else _default_entra_token_provider()
         )
@@ -79,6 +104,7 @@ class AzureGuardrailBase:
         if self.api_key:
             return ("Ocp-Apim-Subscription-Key", self.api_key)
 
+        _assert_entra_destination_is_azure(self.api_base)
         minter: Final = self._entra_token_provider or _default_entra_token_provider()
         try:
             token: Final = await asyncio.to_thread(minter)

--- a/litellm/proxy/guardrails/guardrail_hooks/azure/base.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/azure/base.py
@@ -1,4 +1,7 @@
+import asyncio
 import re
+from collections.abc import Callable
+from functools import cache
 from typing import TYPE_CHECKING, Any, Final
 
 from litellm._logging import verbose_proxy_logger
@@ -8,6 +11,9 @@ from litellm.litellm_core_utils.prompt_templates.common_utils import (
 from litellm.llms.custom_httpx.http_handler import (
     get_async_httpx_client,
     httpxSpecialProvider,
+)
+from litellm.secret_managers.get_azure_ad_token_provider import (
+    get_azure_ad_token_provider,
 )
 
 if TYPE_CHECKING:
@@ -19,6 +25,20 @@ AZURE_CONTENT_SAFETY_MAX_TEXT_LENGTH: Final = 10000
 # Azure Content Safety bills text in 1,000-character "text records"; a submitted
 # chunk of N characters consumes ceil(N / 1000) text records.
 AZURE_CONTENT_SAFETY_TEXT_RECORD_LENGTH: Final = 1000
+
+AZURE_CONTENT_SAFETY_ENTRA_SCOPE: Final = "https://cognitiveservices.azure.com/.default"
+
+
+@cache
+def _default_entra_token_provider() -> Callable[[], str]:
+    """Entra token provider for the Content Safety data plane, one credential per process."""
+    try:
+        return get_azure_ad_token_provider(azure_scope=AZURE_CONTENT_SAFETY_ENTRA_SCOPE)
+    except ImportError as e:
+        raise ValueError(
+            "Azure Content Safety: api_key is not set and azure-identity is not installed. "
+            "Set api_key, or install azure-identity to authenticate with Microsoft Entra ID"
+        ) from e
 
 
 class AzureGuardrailBase:
@@ -32,8 +52,10 @@ class AzureGuardrailBase:
 
     def __init__(
         self,
-        api_key: str,
+        *,
         api_base: str,
+        api_key: str | None = None,
+        entra_token_provider: Callable[[], str] | None = None,
         **kwargs: Any,
     ):
         # Forward remaining kwargs to the next class in the MRO
@@ -44,6 +66,30 @@ class AzureGuardrailBase:
         self.api_key = api_key
         self.api_base = api_base
         self.api_version: str = kwargs.get("api_version") or "2024-09-01"
+        self._entra_token_provider: Final = entra_token_provider or (
+            None if api_key else _default_entra_token_provider()
+        )
+
+    async def _auth_header(self) -> tuple[str, str]:
+        """Credential header name and value for a single request.
+
+        Azure Content Safety accepts an API key or a Microsoft Entra token and rejects each
+        on the other's header, so exactly one is sent.
+        """
+        if self.api_key:
+            return ("Ocp-Apim-Subscription-Key", self.api_key)
+
+        minter: Final = self._entra_token_provider or _default_entra_token_provider()
+        try:
+            token: Final = await asyncio.to_thread(minter)
+        except Exception as e:
+            verbose_proxy_logger.exception("Azure Content Safety: Entra token request failed")
+            raise ValueError(
+                "Azure Content Safety: no credential available. Set api_key, or configure an Entra "
+                "identity (AZURE_CLIENT_ID / AZURE_CLIENT_SECRET / AZURE_TENANT_ID, workload identity, "
+                "managed identity, or az login) holding the Cognitive Services User role on the resource"
+            ) from e
+        return ("Authorization", f"Bearer {token}")
 
     async def _post_to_content_safety(self, endpoint_path: str, request_body: dict[str, object]) -> dict[str, Any]:
         """POST to an Azure Content Safety endpoint with standard auth headers.
@@ -57,8 +103,9 @@ class AzureGuardrailBase:
             Parsed JSON response dict.
         """
         url: Final = f"{self.api_base}/contentsafety/{endpoint_path}?api-version={self.api_version}"
-        headers: Final = {
-            "Ocp-Apim-Subscription-Key": self.api_key,
+        auth_name, auth_value = await self._auth_header()
+        headers: Final = {  # mutable-ok: AsyncHTTPHandler.post types headers as `dict | None`
+            auth_name: auth_value,
             "Content-Type": "application/json",
         }
 

--- a/litellm/proxy/guardrails/guardrail_hooks/azure/prompt_shield.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/azure/prompt_shield.py
@@ -120,8 +120,8 @@ class AzureContentSafetyPromptShieldGuardrail(AzureGuardrailBase, CustomGuardrai
 
     Configuration:
         guardrail_name: Name of the guardrail instance
-        api_key: Azure Prompt Shield API key
-        api_base: Azure Prompt Shield API endpoint
+        api_base: Azure Content Safety endpoint
+        api_key: Azure Content Safety API key. Omit it to authenticate with Microsoft Entra ID
         default_on: Whether to enable by default
     """
 
@@ -129,17 +129,18 @@ class AzureContentSafetyPromptShieldGuardrail(AzureGuardrailBase, CustomGuardrai
 
     def __init__(
         self,
+        *,
         guardrail_name: str,
-        api_key: str,
         api_base: str,
+        api_key: str | None = None,
         **kwargs,
     ):
         """Initialize Azure Prompt Shield guardrail handler."""
         # AzureGuardrailBase.__init__ stores api_key, api_base, api_version,
         # async_handler and forwards the rest to CustomGuardrail.
         super().__init__(
-            api_key=api_key,
             api_base=api_base,
+            api_key=api_key,
             guardrail_name=guardrail_name,
             supported_event_hooks=list(self.get_supported_event_hooks()),
             **kwargs,

--- a/litellm/proxy/guardrails/guardrail_hooks/azure/text_moderation.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/azure/text_moderation.py
@@ -37,8 +37,8 @@ class AzureContentSafetyTextModerationGuardrail(AzureGuardrailBase, CustomGuardr
 
     Configuration:
         guardrail_name: Name of the guardrail instance
-        api_key: Azure Text Moderation API key
-        api_base: Azure Text Moderation API endpoint
+        api_base: Azure Content Safety endpoint
+        api_key: Azure Content Safety API key. Omit it to authenticate with Microsoft Entra ID
         default_on: Whether to enable by default
     """
 
@@ -55,9 +55,10 @@ class AzureContentSafetyTextModerationGuardrail(AzureGuardrailBase, CustomGuardr
 
     def __init__(
         self,
+        *,
         guardrail_name: str,
-        api_key: str,
         api_base: str,
+        api_key: str | None = None,
         severity_threshold: int | None = None,
         severity_threshold_by_category: dict[str, int] | None = None,
         **kwargs,
@@ -71,8 +72,8 @@ class AzureContentSafetyTextModerationGuardrail(AzureGuardrailBase, CustomGuardr
         # AzureGuardrailBase.__init__ stores api_key, api_base, api_version,
         # async_handler and forwards the rest to CustomGuardrail.
         super().__init__(
-            api_key=api_key,
             api_base=api_base,
+            api_key=api_key,
             guardrail_name=guardrail_name,
             **kwargs,
         )

--- a/litellm/types/proxy/guardrails/guardrail_hooks/azure/base.py
+++ b/litellm/types/proxy/guardrails/guardrail_hooks/azure/base.py
@@ -6,7 +6,11 @@ class AzureContentSafetyConfigModel(BaseModel):
 
     api_key: str | None = Field(
         default=None,
-        description="API key for the Azure Content Safety Prompt Shield guardrail",
+        description=(
+            "API key for the Azure Content Safety resource. Optional: omit it to authenticate with "
+            "Microsoft Entra ID, which needs the Cognitive Services User role on the resource and a "
+            "custom subdomain api_base"
+        ),
     )
 
     api_base: str | None = Field(

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/azure/conftest.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/azure/conftest.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from typing import Final
 
 import httpx
@@ -31,9 +32,9 @@ def api_base() -> str:
 
 
 @pytest.fixture
-def capturing_handler() -> tuple[AsyncHTTPHandler, list[httpx.Request]]:
+def capturing_handler() -> tuple[AsyncHTTPHandler, Sequence[httpx.Request]]:
     """An HTTP handler answering every Content Safety call, paired with the requests it saw."""
-    sent: Final[list[httpx.Request]] = []
+    sent: Final[list[httpx.Request]] = []  # mutable-ok: callee-filled request log, handed back read-only
 
     def _record(request: httpx.Request) -> httpx.Response:
         sent.append(request)

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/azure/conftest.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/azure/conftest.py
@@ -1,0 +1,44 @@
+from typing import Final
+
+import httpx
+import pytest
+
+from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
+from litellm.proxy.guardrails.guardrail_hooks.azure.base import (
+    _default_entra_token_provider,
+)
+
+CLEAN_RESPONSE_FOR_BOTH_GUARDRAILS: Final = {
+    "userPromptAnalysis": {"attackDetected": False},
+    "documentsAnalysis": [],
+    "categoriesAnalysis": [],
+    "blocklistsMatch": [],
+}
+
+
+@pytest.fixture(autouse=True)
+def clear_default_entra_provider_cache():
+    """A credential resolved elsewhere in the session would otherwise be reused here, masking
+    the dependency and failure paths these tests assert."""
+    _default_entra_token_provider.cache_clear()
+    yield
+    _default_entra_token_provider.cache_clear()
+
+
+@pytest.fixture
+def api_base() -> str:
+    return "https://contoso.cognitiveservices.azure.com"
+
+
+@pytest.fixture
+def capturing_handler() -> tuple[AsyncHTTPHandler, list[httpx.Request]]:
+    """An HTTP handler answering every Content Safety call, paired with the requests it saw."""
+    sent: Final[list[httpx.Request]] = []
+
+    def _record(request: httpx.Request) -> httpx.Response:
+        sent.append(request)
+        return httpx.Response(200, json=CLEAN_RESPONSE_FOR_BOTH_GUARDRAILS)
+
+    handler: Final = AsyncHTTPHandler()
+    handler.client = httpx.AsyncClient(transport=httpx.MockTransport(_record))
+    return handler, sent

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/azure/test_azure_base.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/azure/test_azure_base.py
@@ -186,3 +186,77 @@ async def test_api_key_guardrail_never_reaches_azure_identity(api_base, capturin
     await guardrail.apply_guardrail(inputs={"texts": ["hello"]}, request_data={}, input_type="request")
 
     assert sent[0].headers["Ocp-Apim-Subscription-Key"] == "secret-key"
+
+
+@pytest.mark.parametrize(
+    "bad_api_base",
+    [
+        "http://contoso.cognitiveservices.azure.com",
+        "https://contoso.cognitiveservices.azure.com.attacker.example",
+        "https://attacker.example",
+        "https://australiaeast.api.cognitive.microsoft.com",
+    ],
+)
+def test_keyless_guardrail_refuses_a_non_azure_destination(bad_api_base):
+    """The Entra token covers every Cognitive Services resource the identity can reach, so a
+    typo or a hijacked host would receive far more than one resource's key would give away."""
+    with pytest.raises(ValueError, match="refusing to send a Microsoft Entra token") as exc_info:
+        AzureContentSafetyPromptShieldGuardrail(guardrail_name="azure-guard", api_base=bad_api_base)
+
+    assert "api_key" in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "good_api_base",
+    [
+        "https://contoso.cognitiveservices.azure.com",
+        "https://contoso.privatelink.cognitiveservices.azure.com",
+        "https://contoso.services.ai.azure.com",
+        "https://contoso.cognitiveservices.azure.us",
+    ],
+)
+def test_keyless_guardrail_accepts_azure_content_safety_endpoints(good_api_base):
+    guardrail: Final = AzureContentSafetyPromptShieldGuardrail(
+        guardrail_name="azure-guard",
+        api_base=good_api_base,
+        entra_token_provider=lambda: "entra-token",
+    )
+
+    assert guardrail.api_base == good_api_base
+
+
+@pytest.mark.asyncio
+async def test_api_key_guardrail_may_use_any_destination(capturing_handler):
+    """A key is scoped to one resource, so gateways and test doubles stay reachable with one."""
+    handler, sent = capturing_handler
+
+    guardrail: Final = AzureContentSafetyPromptShieldGuardrail(
+        guardrail_name="azure-guard",
+        api_base="https://gateway.internal.example",
+        api_key="secret-key",
+    )
+    guardrail.async_handler = handler
+
+    await guardrail.apply_guardrail(inputs={"texts": ["hello"]}, request_data={}, input_type="request")
+
+    assert sent[0].headers["Ocp-Apim-Subscription-Key"] == "secret-key"
+
+
+@pytest.mark.asyncio
+async def test_clearing_api_key_cannot_send_a_token_to_a_non_azure_destination(capturing_handler):
+    """A guardrail admitted on its api_key must not start minting tokens for that same host."""
+    handler, sent = capturing_handler
+
+    guardrail: Final = AzureContentSafetyPromptShieldGuardrail(
+        guardrail_name="azure-guard",
+        api_base="https://gateway.internal.example",
+        api_key="secret-key",
+        entra_token_provider=lambda: "entra-token",
+    )
+    guardrail.async_handler = handler
+    guardrail.update_in_memory_litellm_params({"api_key": None})
+
+    with pytest.raises(ValueError, match="refusing to send a Microsoft Entra token"):
+        await guardrail.apply_guardrail(inputs={"texts": ["hello"]}, request_data={}, input_type="request")
+
+    assert sent == []

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/azure/test_azure_base.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/azure/test_azure_base.py
@@ -1,0 +1,188 @@
+import sys
+import threading
+from typing import Final
+
+import pytest
+
+from litellm.proxy.guardrails.guardrail_hooks.azure import base
+from litellm.proxy.guardrails.guardrail_hooks.azure.prompt_shield import (
+    AzureContentSafetyPromptShieldGuardrail,
+)
+from litellm.proxy.guardrails.guardrail_hooks.azure.text_moderation import (
+    AzureContentSafetyTextModerationGuardrail,
+)
+
+GUARDRAIL_CLASSES: Final = (
+    AzureContentSafetyPromptShieldGuardrail,
+    AzureContentSafetyTextModerationGuardrail,
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("guardrail_class", GUARDRAIL_CLASSES)
+async def test_api_key_rides_the_subscription_key_header_and_mints_no_token(
+    guardrail_class, api_base, capturing_handler
+):
+    handler, sent = capturing_handler
+
+    def _must_not_mint() -> str:
+        raise AssertionError("Entra token minted despite api_key being set")
+
+    guardrail: Final = guardrail_class(
+        guardrail_name="azure-guard",
+        api_base=api_base,
+        api_key="secret-key",
+        entra_token_provider=_must_not_mint,
+    )
+    guardrail.async_handler = handler
+
+    await guardrail.apply_guardrail(inputs={"texts": ["hello"]}, request_data={}, input_type="request")
+
+    assert len(sent) == 1
+    assert sent[0].headers["Ocp-Apim-Subscription-Key"] == "secret-key"
+    assert "authorization" not in sent[0].headers
+    assert sent[0].headers["Content-Type"] == "application/json"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("guardrail_class", GUARDRAIL_CLASSES)
+async def test_omitted_api_key_rides_an_entra_bearer_token(guardrail_class, api_base, capturing_handler):
+    handler, sent = capturing_handler
+
+    guardrail: Final = guardrail_class(
+        guardrail_name="azure-guard",
+        api_base=api_base,
+        entra_token_provider=lambda: "entra-token",
+    )
+    guardrail.async_handler = handler
+
+    await guardrail.apply_guardrail(inputs={"texts": ["hello"]}, request_data={}, input_type="request")
+
+    assert len(sent) == 1
+    assert sent[0].headers["Authorization"] == "Bearer entra-token"
+    assert "ocp-apim-subscription-key" not in sent[0].headers
+    assert sent[0].headers["Content-Type"] == "application/json"
+
+
+@pytest.mark.asyncio
+async def test_blank_api_key_is_treated_as_absent(api_base, capturing_handler):
+    """An `os.environ/` api_key resolving to an empty string must reach Entra, not send a blank key."""
+    handler, sent = capturing_handler
+
+    guardrail: Final = AzureContentSafetyPromptShieldGuardrail(
+        guardrail_name="azure-guard",
+        api_base=api_base,
+        api_key="",
+        entra_token_provider=lambda: "entra-token",
+    )
+    guardrail.async_handler = handler
+
+    await guardrail.apply_guardrail(inputs={"texts": ["hello"]}, request_data={}, input_type="request")
+
+    assert sent[0].headers["Authorization"] == "Bearer entra-token"
+    assert "ocp-apim-subscription-key" not in sent[0].headers
+
+
+@pytest.mark.asyncio
+async def test_token_minting_failure_reports_the_options_and_sends_nothing(api_base, capturing_handler):
+    handler, sent = capturing_handler
+
+    def _fails() -> str:
+        raise RuntimeError("no managed identity endpoint found")
+
+    guardrail: Final = AzureContentSafetyPromptShieldGuardrail(
+        guardrail_name="azure-guard",
+        api_base=api_base,
+        entra_token_provider=_fails,
+    )
+    guardrail.async_handler = handler
+
+    with pytest.raises(ValueError, match="no credential available") as exc_info:
+        await guardrail.apply_guardrail(inputs={"texts": ["hello"]}, request_data={}, input_type="request")
+
+    assert sent == []
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+
+
+@pytest.mark.asyncio
+async def test_token_minting_failure_keeps_credential_detail_out_of_the_error(api_base, capturing_handler):
+    """azure-identity errors carry tenant and client ids, and this message reaches the API caller."""
+    handler, _ = capturing_handler
+
+    def _fails() -> str:
+        raise RuntimeError("tenant 11111111-2222-3333-4444-555555555555 rejected the request")
+
+    guardrail: Final = AzureContentSafetyPromptShieldGuardrail(
+        guardrail_name="azure-guard",
+        api_base=api_base,
+        entra_token_provider=_fails,
+    )
+    guardrail.async_handler = handler
+
+    with pytest.raises(ValueError, match="no credential available") as exc_info:
+        await guardrail.apply_guardrail(inputs={"texts": ["hello"]}, request_data={}, input_type="request")
+
+    assert "11111111-2222-3333-4444-555555555555" not in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_token_is_minted_off_the_event_loop_thread(api_base, capturing_handler):
+    """Credential sources block: IMDS probes time out and the az CLI credential spawns a subprocess."""
+    handler, _ = capturing_handler
+    minting_threads: Final[list[int]] = []
+
+    def _record_thread() -> str:
+        minting_threads.append(threading.get_ident())
+        return "entra-token"
+
+    guardrail: Final = AzureContentSafetyPromptShieldGuardrail(
+        guardrail_name="azure-guard",
+        api_base=api_base,
+        entra_token_provider=_record_thread,
+    )
+    guardrail.async_handler = handler
+
+    await guardrail.apply_guardrail(inputs={"texts": ["hello"]}, request_data={}, input_type="request")
+
+    assert len(minting_threads) == 1
+    assert minting_threads[0] != threading.get_ident()
+
+
+def test_default_credential_is_built_once_per_process(monkeypatch):
+    """Rebuilding it per request costs a fresh credential and token round trip on every scan."""
+    builds: Final[list[str]] = []
+
+    def _build(azure_scope: str):
+        builds.append(azure_scope)
+        return lambda: "entra-token"
+
+    monkeypatch.setattr(base, "get_azure_ad_token_provider", _build)
+
+    assert base._default_entra_token_provider() is base._default_entra_token_provider()
+    assert builds == [base.AZURE_CONTENT_SAFETY_ENTRA_SCOPE]
+
+
+@pytest.mark.parametrize("guardrail_class", GUARDRAIL_CLASSES)
+def test_keyless_guardrail_names_the_missing_dependency_at_startup(guardrail_class, api_base, monkeypatch):
+    monkeypatch.setitem(sys.modules, "azure", None)
+
+    with pytest.raises(ValueError, match="azure-identity"):
+        guardrail_class(guardrail_name="azure-guard", api_base=api_base)
+
+
+@pytest.mark.asyncio
+async def test_api_key_guardrail_never_reaches_azure_identity(api_base, capturing_handler, monkeypatch):
+    """azure-identity ships in the proxy extra, so a key-based deployment must not depend on it."""
+    handler, sent = capturing_handler
+    monkeypatch.setitem(sys.modules, "azure", None)
+
+    guardrail: Final = AzureContentSafetyPromptShieldGuardrail(
+        guardrail_name="azure-guard",
+        api_base=api_base,
+        api_key="secret-key",
+    )
+    guardrail.async_handler = handler
+
+    await guardrail.apply_guardrail(inputs={"texts": ["hello"]}, request_data={}, input_type="request")
+
+    assert sent[0].headers["Ocp-Apim-Subscription-Key"] == "secret-key"

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/azure/test_azure_base.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/azure/test_azure_base.py
@@ -129,7 +129,7 @@ async def test_token_minting_failure_keeps_credential_detail_out_of_the_error(ap
 async def test_token_is_minted_off_the_event_loop_thread(api_base, capturing_handler):
     """Credential sources block: IMDS probes time out and the az CLI credential spawns a subprocess."""
     handler, _ = capturing_handler
-    minting_threads: Final[list[int]] = []
+    minting_threads: Final[list[int]] = []  # mutable-ok: callee-filled thread log
 
     def _record_thread() -> str:
         minting_threads.append(threading.get_ident())
@@ -150,7 +150,7 @@ async def test_token_is_minted_off_the_event_loop_thread(api_base, capturing_han
 
 def test_default_credential_is_built_once_per_process(monkeypatch):
     """Rebuilding it per request costs a fresh credential and token round trip on every scan."""
-    builds: Final[list[str]] = []
+    builds: Final[list[str]] = []  # mutable-ok: callee-filled scope log
 
     def _build(azure_scope: str):
         builds.append(azure_scope)

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/azure/test_azure_prompt_shield.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/azure/test_azure_prompt_shield.py
@@ -4,6 +4,7 @@ import pytest
 from fastapi import HTTPException
 
 from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.guardrails.guardrail_hooks.azure import initialize_guardrail
 from litellm.proxy.guardrails.guardrail_hooks.azure.prompt_shield import (
     AzureContentSafetyPromptShieldGuardrail,
 )
@@ -635,3 +636,57 @@ def test_update_in_memory_litellm_params_dead_env_credential_rejected_untouched(
 
     assert guardrail.api_key == "azure_prompt_shield_api_key"
     assert guardrail.price_per_1000_text_records == 0.38
+
+
+@pytest.mark.asyncio
+async def test_initialize_guardrail_without_api_key_authenticates_with_entra(api_base, capturing_handler):
+    """A keyless config entry yields a guardrail that authenticates with Entra."""
+    handler, sent = capturing_handler
+
+    guardrail = initialize_guardrail(
+        LitellmParams(guardrail="azure/prompt_shield", mode="pre_call", api_base=api_base),
+        {"guardrail_name": "azure-prompt-shield"},
+        entra_token_provider=lambda: "entra-token",
+    )
+
+    assert isinstance(guardrail, AzureContentSafetyPromptShieldGuardrail)
+    assert guardrail.api_key is None
+    assert guardrail.api_base == api_base
+
+    guardrail.async_handler = handler
+    await guardrail.apply_guardrail(inputs={"texts": ["hello"]}, request_data={}, input_type="request")
+
+    assert sent[0].headers["Authorization"] == "Bearer entra-token"
+
+
+def test_initialize_guardrail_without_api_base_still_raises():
+    """api_base carries the resource's custom subdomain, which Entra auth cannot work without."""
+    with pytest.raises(ValueError, match="api_base is required"):
+        initialize_guardrail(
+            LitellmParams(guardrail="azure/prompt_shield", mode="pre_call"),
+            {"guardrail_name": "azure-prompt-shield"},
+            entra_token_provider=lambda: "entra-token",
+        )
+
+
+@pytest.mark.asyncio
+async def test_clearing_api_key_at_runtime_switches_to_entra(api_base, capturing_handler):
+    """A dashboard edit that removes the key must re-authenticate, not keep sending a stale header."""
+    handler, sent = capturing_handler
+
+    guardrail = AzureContentSafetyPromptShieldGuardrail(
+        guardrail_name="azure_prompt_shield",
+        api_base=api_base,
+        api_key="secret-key",
+        entra_token_provider=lambda: "entra-token",
+    )
+    guardrail.async_handler = handler
+
+    await guardrail.apply_guardrail(inputs={"texts": ["hello"]}, request_data={}, input_type="request")
+    guardrail.update_in_memory_litellm_params({"api_key": None})
+    await guardrail.apply_guardrail(inputs={"texts": ["hello again"]}, request_data={}, input_type="request")
+
+    assert sent[0].headers["Ocp-Apim-Subscription-Key"] == "secret-key"
+    assert "authorization" not in sent[0].headers
+    assert sent[1].headers["Authorization"] == "Bearer entra-token"
+    assert "ocp-apim-subscription-key" not in sent[1].headers

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/azure/test_azure_prompt_shield.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/azure/test_azure_prompt_shield.py
@@ -690,3 +690,62 @@ async def test_clearing_api_key_at_runtime_switches_to_entra(api_base, capturing
     assert "authorization" not in sent[0].headers
     assert sent[1].headers["Authorization"] == "Bearer entra-token"
     assert "ocp-apim-subscription-key" not in sent[1].headers
+
+
+@pytest.mark.asyncio
+async def test_config_without_api_version_uses_the_content_safety_default(api_base, capturing_handler):
+    """A config that omits api_version gets the Content Safety default, not another guardrail's."""
+    handler, sent = capturing_handler
+
+    guardrail = initialize_guardrail(
+        LitellmParams(guardrail="azure/prompt_shield", mode="pre_call", api_base=api_base),
+        {"guardrail_name": "azure-prompt-shield"},
+        entra_token_provider=lambda: "entra-token",
+    )
+    guardrail.async_handler = handler
+
+    await guardrail.apply_guardrail(inputs={"texts": ["hello"]}, request_data={}, input_type="request")
+
+    assert sent[0].url.params["api-version"] == "2024-09-01"
+
+
+@pytest.mark.asyncio
+async def test_config_api_version_is_honoured(api_base, capturing_handler):
+    """Pinning an older Content Safety version stays possible."""
+    handler, sent = capturing_handler
+
+    guardrail = initialize_guardrail(
+        LitellmParams(guardrail="azure/prompt_shield", mode="pre_call", api_base=api_base, api_version="2023-10-01"),
+        {"guardrail_name": "azure-prompt-shield"},
+        entra_token_provider=lambda: "entra-token",
+    )
+    guardrail.async_handler = handler
+
+    await guardrail.apply_guardrail(inputs={"texts": ["hello"]}, request_data={}, input_type="request")
+
+    assert sent[0].url.params["api-version"] == "2023-10-01"
+
+
+@pytest.mark.asyncio
+async def test_config_pricing_extras_survive_the_forwarded_params(api_base, capturing_handler):
+    """cost_tier and price_per_1000_text_records arrive as pydantic extras rather than declared
+    fields, so forwarding only the params the config set must still carry them through."""
+    handler, _ = capturing_handler
+
+    guardrail = initialize_guardrail(
+        LitellmParams(
+            guardrail="azure/prompt_shield",
+            mode="pre_call",
+            api_base=api_base,
+            cost_tier="paid",
+            price_per_1000_text_records=0.38,
+        ),
+        {"guardrail_name": "azure-prompt-shield"},
+        entra_token_provider=lambda: "entra-token",
+    )
+    guardrail.async_handler = handler
+    request_data = {"metadata": {}}
+
+    await guardrail.apply_guardrail(inputs={"texts": ["hello"]}, request_data=request_data, input_type="request")
+
+    assert _recorded_guardrail_info(request_data)["guardrail_cost"] == pytest.approx(0.38 / 1000)

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/azure/test_azure_text_moderation.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/azure/test_azure_text_moderation.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import Mock, patch
 
 import pytest
@@ -486,3 +487,45 @@ async def test_initialize_guardrail_without_api_key_authenticates_with_entra(api
     await guardrail.apply_guardrail(inputs={"texts": ["hello"]}, request_data={}, input_type="request")
 
     assert sent[0].headers["Authorization"] == "Bearer entra-token"
+
+
+@pytest.mark.asyncio
+async def test_config_without_api_version_uses_the_content_safety_default(api_base, capturing_handler):
+    """A config that omits api_version gets the Content Safety default, not another guardrail's."""
+    handler, sent = capturing_handler
+
+    guardrail = initialize_guardrail(
+        LitellmParams(guardrail="azure/text_moderations", mode="pre_call", api_base=api_base),
+        {"guardrail_name": "azure-text-moderation"},
+        entra_token_provider=lambda: "entra-token",
+    )
+    guardrail.async_handler = handler
+
+    await guardrail.apply_guardrail(inputs={"texts": ["hello"]}, request_data={}, input_type="request")
+
+    assert sent[0].url.params["api-version"] == "2024-09-01"
+
+
+@pytest.mark.asyncio
+async def test_config_moderation_options_still_reach_the_request(api_base, capturing_handler):
+    """Forwarding only params the config set must not drop the guardrail's own options."""
+    handler, sent = capturing_handler
+
+    guardrail = initialize_guardrail(
+        LitellmParams(
+            guardrail="azure/text_moderations",
+            mode="pre_call",
+            api_base=api_base,
+            outputType="EightSeverityLevels",
+            blocklistNames=["my-blocklist"],
+        ),
+        {"guardrail_name": "azure-text-moderation"},
+        entra_token_provider=lambda: "entra-token",
+    )
+    guardrail.async_handler = handler
+
+    await guardrail.apply_guardrail(inputs={"texts": ["hello"]}, request_data={}, input_type="request")
+
+    body = json.loads(sent[0].content)
+    assert body["outputType"] == "EightSeverityLevels"
+    assert body["blocklistNames"] == ["my-blocklist"]

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/azure/test_azure_text_moderation.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/azure/test_azure_text_moderation.py
@@ -4,9 +4,11 @@ import pytest
 from fastapi import HTTPException
 
 from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.guardrails.guardrail_hooks.azure import initialize_guardrail
 from litellm.proxy.guardrails.guardrail_hooks.azure.text_moderation import (
     AzureContentSafetyTextModerationGuardrail,
 )
+from litellm.types.guardrails import LitellmParams
 from litellm.types.utils import Choices, Message, ModelResponse
 
 
@@ -463,3 +465,24 @@ async def test_apply_guardrail_handles_missing_texts_key():
 
     mock_post.assert_not_called()
     assert result == {"images": ["x"]}
+
+
+@pytest.mark.asyncio
+async def test_initialize_guardrail_without_api_key_authenticates_with_entra(api_base, capturing_handler):
+    """A keyless config entry yields a guardrail that authenticates with Entra."""
+    handler, sent = capturing_handler
+
+    guardrail = initialize_guardrail(
+        LitellmParams(guardrail="azure/text_moderations", mode="pre_call", api_base=api_base),
+        {"guardrail_name": "azure-text-moderation"},
+        entra_token_provider=lambda: "entra-token",
+    )
+
+    assert isinstance(guardrail, AzureContentSafetyTextModerationGuardrail)
+    assert guardrail.api_key is None
+    assert guardrail.api_base == api_base
+
+    guardrail.async_handler = handler
+    await guardrail.apply_guardrail(inputs={"texts": ["hello"]}, request_data={}, input_type="request")
+
+    assert sent[0].headers["Authorization"] == "Bearer entra-token"

--- a/tests/test_litellm/proxy/guardrails/test_guardrail_endpoints.py
+++ b/tests/test_litellm/proxy/guardrails/test_guardrail_endpoints.py
@@ -632,7 +632,11 @@ def test_get_provider_specific_params():
     # Check the structure of a simple field
     assert (
         fields["api_key"]["description"]
-        == "API key for the Azure Content Safety Prompt Shield guardrail"
+        == (
+            "API key for the Azure Content Safety resource. Optional: omit it to authenticate with "
+            "Microsoft Entra ID, which needs the Cognitive Services User role on the resource and a "
+            "custom subdomain api_base"
+        )
     )
     assert fields["api_key"]["required"] == False
     assert fields["api_key"]["type"] == "string"  # Should be string, not None


### PR DESCRIPTION
## TLDR

Problem this solves:

- Azure Content Safety guardrails always demand an API key
- Orgs that ban key based auth cannot use them at all
- Those proxies start unguarded and silently scan nothing
- The documented config.yaml example also fails with 404

How it solves it:

- `api_key` becomes optional on both Azure guardrails
- Omitting it authenticates with Microsoft Entra ID
- Only params the config sets reach the guardrail
- That restores the Content Safety `api_version` default
- Tokens only ever go to an HTTPS Azure Content Safety host

## User Flow

Before: an admin whose Azure resource has key access disabled cannot run the Azure Content Safety guardrails, and is not clearly told

1. They add an `azure/text_moderations` guardrail with only the resource endpoint, because the resource issues no keys to paste
2. They start the proxy. It comes up healthy, and one line in the startup log says the guardrail was skipped for invalid configuration
3. They POST https://litellm-domain/guardrails/apply_guardrail with that guardrail name and clean text, and get `404` saying the guardrail is not configured
4. They repeat step 3 with hateful text and get the same `404`
5. They POST https://litellm-domain/v1/chat/completions with `"guardrails": ["azure-text-moderation"]` and the same hateful text, and the model answers it
6. Every prompt reaches the model unscreened, so naming a guardrail on a request buys nothing

After: the same config starts a working guardrail, and the same text is refused

1. They add the same guardrail entry with only the resource endpoint
2. They start the proxy, and the startup log shows both Azure Content Safety guardrails initialised
3. They POST https://litellm-domain/guardrails/apply_guardrail with that guardrail name and clean text, and get `200` with the text handed back
4. They repeat step 3 with hateful text and get `400` naming the category and severity that was crossed
5. They POST https://litellm-domain/v1/chat/completions with `"guardrails": ["azure-text-moderation"]` and the same hateful text, and get the same `400`
6. Prompts are screened before they reach the model, on a resource where no API key exists

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Captured at `b5dfba190c`. The tip is `579e0d37f3`, whose diff against it touches only test files, so `git diff b5dfba190c..579e0d37f3 -- litellm/` is empty and this run still stands.

Two real Azure AI Content Safety resources, both with a custom subdomain.

Resource A has key based access turned off, so an API key cannot work at all. Cases 1 to 4 run against it:

```shell
$ az cognitiveservices account show -n <resource-a> -g <rg> --query properties.disableLocalAuth -o tsv
true

# a key captured before local auth was turned off, sent straight to the resource
$ curl -s -o /dev/null -w "%{http_code}\n" -X POST \
    "https://<resource-a>.cognitiveservices.azure.com/contentsafety/text:analyze?api-version=2024-09-01" \
    -H "Ocp-Apim-Subscription-Key: $KEY" -H "Content-Type: application/json" -d '{"text":"hello"}'
401
```

Resource B still accepts keys. Case 5 runs against it, because on Resource A the Before side cannot start the guardrail at all.

The shell is signed in through `az login` as a user holding the Cognitive Services User role on both resources. Each case starts the proxy with `python litellm/proxy/proxy_cli.py --config <config>.yaml --detailed_debug`.

Config for cases 1 to 4, with an endpoint and no key on both guardrails, and a model reached with the same identity:

```yaml
model_list:
  - model_name: gpt-5.4-mini
    litellm_params:
      model: azure/gpt-5-4-mini-litellm
      api_base: https://<foundry-resource>.openai.azure.com
      api_version: "2025-02-01-preview"

guardrails:
  - guardrail_name: azure-prompt-shield
    litellm_params:
      guardrail: azure/prompt_shield
      mode: pre_call
      api_base: https://<resource-a>.cognitiveservices.azure.com
  - guardrail_name: azure-text-moderation
    litellm_params:
      guardrail: azure/text_moderations
      mode: [pre_call, post_call]
      api_base: https://<resource-a>.cognitiveservices.azure.com

litellm_settings:
  enable_azure_ad_token_refresh: true

general_settings:
  master_key: sk-1234
```

Config for case 5, matching the documented example, with a key and no `api_version`:

```yaml
guardrails:
  - guardrail_name: azure-text-moderation
    litellm_params:
      guardrail: azure/text_moderations
      mode: pre_call
      api_key: os.environ/AZURE_CS_KEY
      api_base: https://<resource-b>.cognitiveservices.azure.com
```

Config for case 6, keyless and pointed somewhere that is not Azure:

```yaml
guardrails:
  - guardrail_name: azure-text-moderation
    litellm_params:
      guardrail: azure/text_moderations
      mode: pre_call
      api_base: https://guardrails.internal.example
```

### Before (47b15ffb67)

#### Guardrails load from a keyless config

1. Start the proxy on the cases 1 to 4 config and read the startup log

```
LiteLLM Proxy:ERROR: init_guardrails.py:37 - Skipping guardrail 'azure-prompt-shield': invalid configuration, proxy is starting WITHOUT this guardrail: Azure Content Safety: api_key is required
LiteLLM Proxy:ERROR: init_guardrails.py:37 - Skipping guardrail 'azure-text-moderation': invalid configuration, proxy is starting WITHOUT this guardrail: Azure Content Safety: api_key is required
```

#### Scan clean text

1. Ask the proxy to run the guardrail directly

```shell
$ curl -s -w "\nHTTP %{http_code}\n" -X POST http://localhost:4001/guardrails/apply_guardrail \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"guardrail_name":"azure-text-moderation","text":"What is the capital of France?"}'
{"error":{"message":"Guardrail 'azure-text-moderation' not found. Please ensure the guardrail is configured in your LiteLLM proxy.","type":"internal_server_error","param":null,"code":"404"}}
HTTP 404
```

#### Scan violating text

1. Same route, hateful text

```shell
$ curl -s -w "\nHTTP %{http_code}\n" -X POST http://localhost:4001/guardrails/apply_guardrail \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"guardrail_name":"azure-text-moderation","text":"You are a complete idiot and I despise everything about people like you."}'
{"error":{"message":"Guardrail 'azure-text-moderation' not found. Please ensure the guardrail is configured in your LiteLLM proxy.","type":"internal_server_error","param":null,"code":"404"}}
HTTP 404
```

#### Chat completion with a hateful prompt

1. Send the request naming the guardrail

```shell
$ curl -s -X POST http://localhost:4001/v1/chat/completions \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"model":"gpt-5.4-mini","messages":[{"role":"user","content":"You are a complete idiot and I despise everything about people like you."}],"guardrails":["azure-text-moderation"],"max_completion_tokens":600}'
```

2. The model answers, so nothing screened the prompt

```
answered: 'I am here to help, but I cannot engage with insults or hostility. If you want, I can still assist you with whatever you need, just tell me the task, question, or problem, and I will get to work.'
```

#### Config that omits api_version

1. Start the proxy on the case 5 config and scan clean text

```shell
$ curl -s -w "\nHTTP %{http_code}\n" -X POST http://localhost:4001/guardrails/apply_guardrail \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"guardrail_name":"azure-text-moderation","text":"What is the capital of France?"}'
{"error":{"message":"Client error '404 Not Found' for url 'https://<resource-b>.cognitiveservices.azure.com/contentsafety/text:analyze?api-version=v1'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404","type":"internal_server_error","param":null,"code":"404"}}
HTTP 404
```

2. The guardrail loaded and reached Azure, but sent `api-version=v1`, which belongs to a different provider

#### Keyless guardrail on a non-Azure host

1. Start the proxy on the case 6 config and read the startup log

```
LiteLLM Proxy:ERROR: init_guardrails.py:37 - Skipping guardrail 'azure-text-moderation': invalid configuration, proxy is starting WITHOUT this guardrail: Azure Content Safety: api_key is required
```

2. The destination is never examined, because a keyless guardrail is rejected before it gets that far

### After (b5dfba190c)

#### Guardrails load from a keyless config

1. Start the proxy on the cases 1 to 4 config and read the startup log

```
LiteLLM Proxy:DEBUG: prompt_shield.py:156 - Initialized Azure Prompt Shield Guardrail: azure-prompt-shield
LiteLLM Proxy:INFO: text_moderation.py:97 - Initialized Azure Text Moderation Guardrail: azure-text-moderation
```

#### Scan clean text

1. Ask the proxy to run the guardrail directly

```shell
$ curl -s -w "\nHTTP %{http_code}\n" -X POST http://localhost:4000/guardrails/apply_guardrail \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"guardrail_name":"azure-text-moderation","text":"What is the capital of France?"}'
{"response_text":"What is the capital of France?"}
HTTP 200
```

#### Scan violating text

1. Same route, hateful text

```shell
$ curl -s -w "\nHTTP %{http_code}\n" -X POST http://localhost:4000/guardrails/apply_guardrail \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"guardrail_name":"azure-text-moderation","text":"You are a complete idiot and I despise everything about people like you."}'
{"error":{"message":"{'error': 'Azure Content Safety Guardrail: Hate crossed severity 2, Got severity: 2'}","type":"internal_server_error","param":null,"code":"400"}}
HTTP 400
```

#### Chat completion with a hateful prompt

1. Send the request naming the guardrail

```shell
$ curl -s -X POST http://localhost:4000/v1/chat/completions \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"model":"gpt-5.4-mini","messages":[{"role":"user","content":"You are a complete idiot and I despise everything about people like you."}],"guardrails":["azure-text-moderation"],"max_completion_tokens":600}'
{"error":{"message":"Azure Content Safety Guardrail: Hate crossed severity 2, Got severity: 2","type":"invalid_request_error","param":null,"code":"400", ...}}
```

2. A benign prompt still runs both guardrails and reaches the model

```shell
$ curl -s -X POST http://localhost:4000/v1/chat/completions \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"model":"gpt-5.4-mini","messages":[{"role":"user","content":"What is the capital of France? Answer in one word."}],"guardrails":["azure-prompt-shield","azure-text-moderation"],"max_completion_tokens":600}'
answered: 'Paris'
```

#### Config that omits api_version

1. Start the proxy on the case 5 config and scan clean text

```shell
$ curl -s -w "\nHTTP %{http_code}\n" -X POST http://localhost:4000/guardrails/apply_guardrail \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"guardrail_name":"azure-text-moderation","text":"What is the capital of France?"}'
{"response_text":"What is the capital of France?"}
HTTP 200
```

2. The guardrail now sends the Content Safety default of `2024-09-01`

#### Keyless guardrail on a non-Azure host

1. Start the proxy on the case 6 config and read the startup log

```
LiteLLM Proxy:ERROR: init_guardrails.py:37 - Skipping guardrail 'azure-text-moderation': invalid configuration, proxy is starting WITHOUT this guardrail: Azure Content Safety: refusing to send a Microsoft Entra token to api_base 'https://guardrails.internal.example'. Entra authentication needs the resource's HTTPS custom subdomain endpoint, for example https://your-resource.cognitiveservices.azure.com. Set api_key to reach any other host
```

2. The identity token is never minted for that host, and the error names `api_key` as the way to reach it

## Type

🆕 New Feature
🐛 Bug Fix

## Caveats (if any)

### Medium

- Two commits, one problem each, deliberately kept together
  - the feature is unusable from `config.yaml` without the `api_version` fix
  - a reviewer following the docs would hit 404 on the first request
- Azure guardrails now receive only params the config set
  - they previously also received 37 unrelated guardrails' defaults
  - only `api_version` changed observable behaviour, checked one by one

### Low

- Entra ID needs a custom subdomain endpoint, and it is now enforced
  - a keyless guardrail on any other host is refused at startup
  - fronting Content Safety with your own gateway needs `api_key`
  - a resource key is scoped to one resource, so that path is unrestricted
- Guardrails already stored in the database keep their persisted `api_version`
- The credential is built once per process and reused
- The token is minted on a worker thread, the credential is sync
- Docs for this live in `BerriAI/litellm-docs` and are a separate PR

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
