### PR TITLE
feat: add us.openai.gpt-6-astra and global.openai.gpt-6-astra (Bedrock Converse)

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -55060,6 +55060,58 @@
         "supports_reasoning": true,
         "supports_vision": true
     },
+    "us.openai.gpt-6-astra": {
+        "input_cost_per_token": 1.1e-05,
+        "input_cost_per_token_above_272k_tokens": 2.2e-05,
+        "cache_creation_input_token_cost": 1.375e-05,
+        "cache_creation_input_token_cost_above_272k_tokens": 2.75e-05,
+        "cache_read_input_token_cost": 1.1e-06,
+        "cache_read_input_token_cost_above_272k_tokens": 2.2e-06,
+        "output_cost_per_token": 5.5e-05,
+        "output_cost_per_token_above_272k_tokens": 8.25e-05,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true,
+        "supports_vision": true
+    },
+    "global.openai.gpt-6-astra": {
+        "input_cost_per_token": 1e-05,
+        "input_cost_per_token_above_272k_tokens": 2e-05,
+        "cache_creation_input_token_cost": 1.25e-05,
+        "cache_creation_input_token_cost_above_272k_tokens": 2.5e-05,
+        "cache_read_input_token_cost": 1e-06,
+        "cache_read_input_token_cost_above_272k_tokens": 2e-06,
+        "output_cost_per_token": 5e-05,
+        "output_cost_per_token_above_272k_tokens": 7.5e-05,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_reasoning": true,
+        "supports_vision": true
+    },
     "bedrock_mantle/openai.gpt-5.5": {
         "input_cost_per_token": 5.5e-06,
         "input_cost_per_token_above_272k_tokens": 1.1e-05,


### PR DESCRIPTION
## Problem

`gpt-6-astra` is available on Amazon Bedrock (launched 2026-09-08), but the cost map has no Bedrock route for it. Current keys are `gpt-6-astra`, `azure/gpt-6-astra`, `azure/us/gpt-6-astra`, `azure_ai/gpt-6-astra` and `openrouter/openai/gpt-6-astra` — nothing for `us.openai.*` or `global.openai.*`.

The visible effect is that **tool calling silently stops working** on Bedrock. In `AmazonConverseConfig.get_supported_openai_params()`, `"tools"` is appended only when the base model starts with `anthropic`/`mistral`/`cohere`/`meta.llama3-1`/`meta.llama3-2`/`meta.llama3-3`/`meta.llama4`/`amazon.nova`, **or** when `supports_function_calling()` returns true. `openai.*` is not in that prefix list, so Astra depends entirely on a cost-map entry. Without one, `tools` is dropped (silently, under `drop_params: true`) and the model answers as though no tools were sent.

`us.openai.gpt-5.6-{sol,terra,luna}` already have entries, which is why those models work. This just brings Astra to parity.

Verified that the model itself supports tool calling on this route, independent of LiteLLM:

```
aws bedrock-runtime converse --model-id us.openai.gpt-6-astra \
  --tool-config '{"tools":[{"toolSpec":{"name":"get_weather",...}}]}'
-> stopReason: tool_use, toolUse: get_weather
```

Note the model is inference-profile only — `openai.gpt-6-astra` returns `ValidationException: Invocation of model ID openai.gpt-6-astra with on-demand throughput isn't supported` — so the `us.`/`global.` prefixed keys are the ones that matter. Adding a bare `openai.gpt-6-astra` key would not help, because `tools` is gated on the full model string while only `tool_choice` falls back to `base_model`.

## Values

Both entries are taken from the [AWS model card](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-6-astra.html), Standard tier, per 1M tokens. The model is tiered above 272K tokens (one model with a 1,050,000-token context window, not two model ids), so the `*_above_272k_tokens` fields are used, matching how `us.openai.gpt-5.6-sol` is already structured.

| | `us.` (Geo CRIS) | `global.` (Global CRIS) |
|---|---|---|
| input | $11.00 → $22.00 | $10.00 → $20.00 |
| output | $55.00 → $82.50 | $50.00 → $75.00 |
| cache read | $1.10 → $2.20 | $1.00 → $2.00 |
| cache write (30m) | $13.75 → $27.50 | $12.50 → $25.00 |

Context window 1,050,000 and max output 128,000 also from the card. `supports_vision` is set because the card lists Image as a supported input modality.

## Diff

+52/−0, two entries inserted next to the existing `us.openai.gpt-5.6-*` block. No other keys touched and no reformatting.