### PR TITLE
fix: stop forwarding litellm_params into the provider request body

### DIFF
--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3683,6 +3683,7 @@ all_litellm_params = (
     + [
         "metadata",
         "litellm_metadata",
+        "litellm_params",
         "keepalive_seconds",
         "allow_client_keepalive_override",
         "litellm_trace_id",

--- a/tests/test_litellm/types/test_types_utils.py
+++ b/tests/test_litellm/types/test_types_utils.py
@@ -1,13 +1,50 @@
 from typing import Final
+from unittest.mock import MagicMock
 
 import pytest
 
-
+import litellm
 from litellm.types.utils import HiddenParams, all_litellm_params, text_tokens_without_nested_reasoning
 
 
 def test_rust_is_a_known_litellm_param():
     assert "rust" in all_litellm_params
+
+
+def test_litellm_params_is_not_sent_to_the_provider():
+    """https://github.com/BerriAI/litellm/issues/40072"""
+    parsed: Final = MagicMock()
+    parsed.model_dump.return_value = {
+        "id": "chatcmpl-1",
+        "object": "chat.completion",
+        "created": 1234567890,
+        "model": "gpt-4o-mini",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "hi"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    }
+    raw_response: Final = MagicMock()
+    raw_response.headers = {}
+    raw_response.parse.return_value = parsed
+    client: Final = MagicMock()
+    client.chat.completions.with_raw_response.create.return_value = raw_response
+
+    litellm.completion(
+        model="openai/gpt-4o-mini",
+        messages=[{"role": "user", "content": "hi"}],
+        litellm_params={"api_key": "sk-deployment-credential"},
+        api_key="sk-test",
+        client=client,
+    )
+
+    create_kwargs: Final = client.chat.completions.with_raw_response.create.call_args.kwargs
+    assert "litellm_params" not in create_kwargs
+    assert "litellm_params" not in (create_kwargs.get("extra_body") or {})
 
 
 def test_hidden_params_response_ms():


### PR DESCRIPTION
## TLDR

Problem this solves:

- `litellm_params` reaches the provider in the request body
- Bedrock Converse rejects it with `unknown_parameter: litellm_params`
- Other providers receive the credentials it carries

How it solves it:

- List `litellm_params` in `all_litellm_params`, like the fields it holds

## User Flow

Before: a developer whose gateway sits in front of Bedrock gets a hard rejection, and on other providers the deployment's own api key is sent upstream

1. They send POST https://litellm-domain/v1/chat/completions with a normal body that also carries a top-level `litellm_params` object
2. On a Bedrock deployment the call fails with a 400 naming `unknown_parameter: litellm_params`, and on a streamed request the stream stays open until their client times out
3. On an OpenAI-compatible deployment the call returns 200, but the object they sent, api key and all, went out in the request body to that provider
4. Another user on the same gateway can put an api key in that field and have it forwarded to whichever provider the deployment points at

After: the same request is accepted, and nothing internal goes upstream

1. They send the same POST https://litellm-domain/v1/chat/completions with the same body
2. The Bedrock deployment answers normally, and a streamed request ends when the answer does
3. The OpenAI-compatible deployment answers normally, and the provider receives only the model and messages
4. Another user can no longer get anything placed in that field forwarded to the provider

## Relevant issues

Fixes #40072

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Shared setup. A stand-in upstream on port 14999 writes out the exact body it is handed, so the bytes the provider would receive are visible without a paid call:

```python
import json
from http.server import BaseHTTPRequestHandler, HTTPServer

class H(BaseHTTPRequestHandler):
    def do_POST(self):
        body = self.rfile.read(int(self.headers.get("Content-Length", 0)))
        open("/tmp/lp/received.json", "w").write(body.decode())
        out = json.dumps({"id": "chatcmpl-echo", "object": "chat.completion", "created": 1,
            "model": "gpt-4o-mini",
            "choices": [{"index": 0, "message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}],
            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}}).encode()
        self.send_response(200); self.send_header("Content-Type", "application/json")
        self.send_header("Content-Length", str(len(out))); self.end_headers(); self.wfile.write(out)
    def log_message(self, *a): pass

HTTPServer(("127.0.0.1", 14999), H).serve_forever()
```

`cfg.yaml`:

```yaml
model_list:
  - model_name: echo-model
    litellm_params:
      model: openai/gpt-4o-mini
      api_base: http://127.0.0.1:14999
      api_key: sk-fake-not-a-real-key
      use_chat_completions_api: true
```

```bash
python litellm/proxy/proxy_cli.py --config cfg.yaml --host 127.0.0.1 --port 14000
```

### Before (e8140eb269)

#### /v1/chat/completions

1. Send the request

```bash
curl --noproxy '*' -sS -o /dev/null -w 'HTTP %{http_code}\n' \
  http://127.0.0.1:14000/v1/chat/completions \
  -H 'Content-Type: application/json' -H 'Authorization: Bearer sk-anything' \
  -d '{"model":"echo-model","messages":[{"role":"user","content":"hi"}],"litellm_params":{"api_key":"sk-injected"}}'
```

```text
HTTP 200
```

2. Read what the upstream was handed

```bash
cat /tmp/lp/received.json
```

```text
{"messages":[{"role":"user","content":"hi"}],"model":"gpt-4o-mini","litellm_params":{"api_key":"sk-injected"}}
```

#### /v1/responses

1. Send the request

```bash
curl --noproxy '*' -sS -o /dev/null -w 'HTTP %{http_code}\n' \
  http://127.0.0.1:14000/v1/responses \
  -H 'Content-Type: application/json' -H 'Authorization: Bearer sk-anything' \
  -d '{"model":"echo-model","input":"hi","litellm_params":{"api_key":"sk-injected"}}'
```

```text
HTTP 200
```

2. Read what the upstream was handed

```bash
cat /tmp/lp/received.json
```

```text
{"messages":[{"role":"user","content":"hi"}],"model":"gpt-4o-mini","litellm_params":{"api_key":"sk-injected"}}
```

### After (8eaeea1641)

#### /v1/chat/completions

1. Send the same request

```bash
curl --noproxy '*' -sS -o /dev/null -w 'HTTP %{http_code}\n' \
  http://127.0.0.1:14000/v1/chat/completions \
  -H 'Content-Type: application/json' -H 'Authorization: Bearer sk-anything' \
  -d '{"model":"echo-model","messages":[{"role":"user","content":"hi"}],"litellm_params":{"api_key":"sk-injected"}}'
```

```text
HTTP 200
```

2. Read what the upstream was handed

```bash
cat /tmp/lp/received.json
```

```text
{"messages":[{"role":"user","content":"hi"}],"model":"gpt-4o-mini"}
```

#### /v1/responses

1. Send the same request

```bash
curl --noproxy '*' -sS -o /dev/null -w 'HTTP %{http_code}\n' \
  http://127.0.0.1:14000/v1/responses \
  -H 'Content-Type: application/json' -H 'Authorization: Bearer sk-anything' \
  -d '{"model":"echo-model","input":"hi","litellm_params":{"api_key":"sk-injected"}}'
```

```text
HTTP 200
```

2. Read what the upstream was handed

```bash
cat /tmp/lp/received.json
```

```text
{"messages":[{"role":"user","content":"hi"}],"model":"gpt-4o-mini"}
```

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- Not reproduced against live Bedrock; no credentials on hand
- /v1/messages not covered: it has no OpenAI param builder

### Low

- Anyone relying on this reaching the provider loses it

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
