### PR TITLE
test: isolate bedrock aws tests from ambient SSL env vars

### DIFF
--- a/tests/test_litellm/llms/bedrock/test_base_aws_llm.py
+++ b/tests/test_litellm/llms/bedrock/test_base_aws_llm.py
@@ -38,6 +38,14 @@ def flush_shared_bedrock_iam_cache():
     yield
 
 
+@pytest.fixture(autouse=True)
+def _clean_ssl_env(monkeypatch):
+    """get_ssl_verify reads these, so the sts client's verify= would otherwise depend on
+    the ambient environment. The published images set SSL_CERT_FILE."""
+    for env_var in ("SSL_CERT_FILE", "SSL_VERIFY"):
+        monkeypatch.delenv(env_var, raising=False)
+
+
 def test_base_aws_llm_instances_share_process_wide_iam_cache():
     """Regression LIT-2662: new instances must reuse iam_cache (Bedrock passthrough is per-request)."""
     first = BaseAWSLLM()


### PR DESCRIPTION
## TLDR

Problem this solves:

- Nine bedrock tests fail inside the published images
- They assert `verify=True` but read the ambient environment
- Green in CI, so the breakage is invisible there

How it solves it:

- Clear `SSL_CERT_FILE` and `SSL_VERIFY` for this module

## User Flow

Before: someone running the suite inside the published image gets nine failures that have nothing to do with their change

1. They start the published `litellm-database` image, which sets `SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt`
2. They run `pytest tests/test_litellm/llms/bedrock/test_base_aws_llm.py`
3. Nine cases fail with `{'verify': '/etc/ssl/certs/ca-certificates.crt'} != {'verify': True}`
4. The same file passes on their laptop and in CI, so they cannot tell whether their change is at fault

After: the same run is green wherever it happens

1. They start the same image with the same variable set
2. They run the same command
3. All 150 cases pass
4. The result is the same on their laptop and in CI

## Relevant issues

Fixes #40357

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

This one changes only the test suite, so there is no proxy route to curl. What an operator sees is the suite itself, run the way the image runs it. `SSL_CERT_FILE` is set to a real CA bundle to stand in for the image's `/etc/ssl/certs/ca-certificates.crt`:

```bash
export SSL_CERT_FILE=$(python -c "import certifi;print(certifi.where())")
```

### Before (e8140eb269)

#### ambient SSL_CERT_FILE, as the published image sets it

1. Run the file

```bash
SSL_CERT_FILE="$SSL_CERT_FILE" pytest tests/test_litellm/llms/bedrock/test_base_aws_llm.py -q
```

```text
FAILED tests/test_litellm/llms/bedrock/test_base_aws_llm.py::test_cross_account_role_assumption
FAILED tests/test_litellm/llms/bedrock/test_base_aws_llm.py::test_eks_irsa_ambient_credentials_used[configured_region_is_sts_fallback]
FAILED tests/test_litellm/llms/bedrock/test_base_aws_llm.py::test_eks_irsa_ambient_credentials_used[explicit_sts_endpoint]
FAILED tests/test_litellm/llms/bedrock/test_base_aws_llm.py::test_eks_irsa_ambient_credentials_used[no_region_or_endpoint]
FAILED tests/test_litellm/llms/bedrock/test_base_aws_llm.py::test_explicit_credentials_used_when_provided[configured_region_is_sts_fallback]
FAILED tests/test_litellm/llms/bedrock/test_base_aws_llm.py::test_explicit_credentials_used_when_provided[explicit_sts_endpoint]
FAILED tests/test_litellm/llms/bedrock/test_base_aws_llm.py::test_explicit_credentials_used_when_provided[no_region_or_endpoint]
FAILED tests/test_litellm/llms/bedrock/test_base_aws_llm.py::test_partial_credentials_still_use_ambient
FAILED tests/test_litellm/llms/bedrock/test_base_aws_llm.py::test_sts_endpoint_region_matches_bedrock_region_param
9 failed, 141 passed in 1.47s
```

#### ambient SSL_VERIFY, the other variable the same helper reads

1. Run the file

```bash
SSL_VERIFY="$SSL_CERT_FILE" pytest tests/test_litellm/llms/bedrock/test_base_aws_llm.py -q
```

```text
9 failed, 141 passed in 1.20s
```

#### clean environment, the way CI runs it

1. Run the file

```bash
pytest tests/test_litellm/llms/bedrock/test_base_aws_llm.py -q
```

```text
150 passed
```

### After (07192dc707)

#### ambient SSL_CERT_FILE, as the published image sets it

1. Run the file

```bash
SSL_CERT_FILE="$SSL_CERT_FILE" pytest tests/test_litellm/llms/bedrock/test_base_aws_llm.py -q
```

```text
150 passed in 0.91s
```

#### ambient SSL_VERIFY, the other variable the same helper reads

1. Run the file

```bash
SSL_VERIFY="$SSL_CERT_FILE" pytest tests/test_litellm/llms/bedrock/test_base_aws_llm.py -q
```

```text
150 passed in 0.99s
```

#### clean environment, the way CI runs it

1. Run the file

```bash
pytest tests/test_litellm/llms/bedrock/test_base_aws_llm.py -q
```

```text
150 passed in 0.89s
```

## Type

✅ Test

## Caveats (if any)

### Low

- Only this file; other suites may read the same variables
- `litellm.ssl_verify` set in-process would still leak in

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
