### PR TITLE
fix(router): resolve team-scoped auto-routers by public name

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -12242,6 +12242,57 @@ class Router:
         """
         return resolve_model_group_alias(self.model_group_alias, model)
 
+    def _team_strategy_marker_model_name(self, model: str, request_kwargs: Mapping[str, object]) -> str | None:
+        if model in self.model_names:
+            return None
+        metadata: Final = request_kwargs.get("metadata") or MappingProxyType({})
+        litellm_metadata: Final = request_kwargs.get("litellm_metadata") or MappingProxyType({})
+        team_id: Final = (metadata.get("user_api_key_team_id") if isinstance(metadata, Mapping) else None) or (
+            litellm_metadata.get("user_api_key_team_id") if isinstance(litellm_metadata, Mapping) else None
+        )
+        if not isinstance(team_id, str):
+            return None
+        indices: Final = self.team_model_to_deployment_indices.get((team_id, model), ())
+        marker_names: Final = tuple(
+            deployment["model_name"]
+            for idx in indices
+            if self._is_strategy_marker_deployment(deployment := self.model_list[idx])
+        )
+        if not marker_names:
+            return None
+        registries: Final = (
+            self.auto_routers,
+            self.complexity_routers,
+            self.adaptive_routers,
+            self.quality_routers,
+        )
+        candidates: Final = tuple(
+            (marker_name, tagged.tags)
+            for marker_name in marker_names
+            for registry in registries
+            for tagged in registry.get(marker_name, ())
+        )
+        if not candidates:
+            return None
+        request_tags: Final = _get_tags_from_request_kwargs(request_kwargs)
+        for marker_name, tags in candidates:
+            if tags and request_tags and is_valid_deployment_tag(tags, request_tags, self.tag_filtering_match_any):
+                return marker_name
+        for marker_name, tags in candidates:
+            if "default" in tags:
+                return marker_name
+        request_scoped_filtering: Final = request_kwargs.get("enable_tag_filtering") is True
+        has_plain_deployment: Final = any(
+            not self._is_strategy_marker_deployment(self.model_list[idx]) for idx in indices
+        )
+        if (
+            (self.enable_tag_filtering or request_scoped_filtering)
+            and all(tags for _, tags in candidates)
+            and has_plain_deployment
+        ):
+            return None
+        return candidates[0][0]
+
     def _get_deployment_by_litellm_model(self, model: str) -> list:
         """
         Get the deployment by litellm model.
@@ -13272,7 +13323,11 @@ class Router:
             bound_model: Final = await self._get_claude_code_session_router_binding(cache_key)
             if not isinstance(bound_model, str):
                 return registered_model_name
-            bound_registered_model: Final = self._get_model_from_alias(model=bound_model) or bound_model
+            bound_registered_model: Final = (
+                self._get_model_from_alias(model=bound_model)
+                or self._team_strategy_marker_model_name(model=bound_model, request_kwargs=request_kwargs)
+                or bound_model
+            )
             if self._select_pre_routing_strategy(bound_registered_model, request_kwargs) is None:
                 await self._delete_claude_code_session_router_binding(cache_key)
                 return registered_model_name
@@ -13310,11 +13365,15 @@ class Router:
 
         `model` is whatever the caller asked for, which may be a `model_group_alias` key, while the
         strategy registries and the marker deployment are keyed by the marker's own `model_name`, so
-        every lookup below resolves the alias first. Only the lookups: the caller-facing name stays
-        the alias, since spend metadata is stamped before routing and the response carries the tier
-        group the strategy picked.
+        every lookup below resolves the alias, then the team public name, first. Only the lookups: the
+        caller-facing name stays the alias, since spend metadata is stamped before routing and the
+        response carries the tier group the strategy picked.
         """
-        requested_registered_model_name: Final = self._get_model_from_alias(model=model) or model
+        requested_registered_model_name: Final = (
+            self._get_model_from_alias(model=model)
+            or self._team_strategy_marker_model_name(model=model, request_kwargs=request_kwargs)
+            or model
+        )
         registered_model_name: Final = await self._resolve_claude_code_session_router(
             model=model,
             registered_model_name=requested_registered_model_name,

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -9096,6 +9096,164 @@ class TestPreRoutingStrategyRegistryLifecycle:
             )
             assert actual is expected, params["model"]
 
+    @classmethod
+    def _team_scoped_router(cls) -> "litellm.Router":
+        def params(model: str) -> dict:
+            return {
+                **cls._complexity_router_params(model),
+                "complexity_router_config": {
+                    "tiers": {
+                        "SIMPLE": model,
+                        "MEDIUM": model,
+                        "COMPLEX": model,
+                    }
+                },
+            }
+
+        return litellm.Router(
+            model_list=[
+                {"model_name": "gpt-4o", "litellm_params": {"model": "gpt-4o"}},
+                {"model_name": "gpt-4o-mini", "litellm_params": {"model": "gpt-4o-mini"}},
+                {
+                    "model_name": "model_name_team-a_1",
+                    "litellm_params": params("gpt-4o-mini"),
+                    "model_info": {
+                        "team_id": "team-a",
+                        "team_public_model_name": "smart-router",
+                        "id": "router-a",
+                    },
+                },
+                {
+                    "model_name": "model_name_team-b_1",
+                    "litellm_params": params("gpt-4o"),
+                    "model_info": {
+                        "team_id": "team-b",
+                        "team_public_model_name": "smart-router",
+                        "id": "router-b",
+                    },
+                },
+                {
+                    "model_name": "smart-router-global",
+                    "litellm_params": params("gpt-4o"),
+                    "model_info": {"id": "router-global"},
+                },
+            ],
+            ignore_invalid_deployments=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_team_scoped_public_name_routes_to_the_team_strategy(self):
+        router = self._team_scoped_router()
+
+        assert (
+            router._team_strategy_marker_model_name(
+                model="smart-router",
+                request_kwargs={"metadata": {"user_api_key_team_id": "team-a"}},
+            )
+            == "model_name_team-a_1"
+        )
+        response = await router.async_pre_routing_hook(
+            model="smart-router",
+            request_kwargs={"metadata": {"user_api_key_team_id": "team-a"}},
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+        assert response is not None
+        assert response.model == "gpt-4o-mini"
+
+    @pytest.mark.asyncio
+    async def test_team_scoped_public_name_uses_request_tags(self):
+        router = litellm.Router(
+            model_list=[
+                {"model_name": "gpt-4o", "litellm_params": {"model": "gpt-4o"}},
+                {"model_name": "gpt-4o-mini", "litellm_params": {"model": "gpt-4o-mini"}},
+                {
+                    "model_name": "model_name_team-a_simple",
+                    "litellm_params": self._complexity_router_params("gpt-4o-mini", tags=["simple"]),
+                    "model_info": {"team_id": "team-a", "team_public_model_name": "smart-router", "id": "router-a-simple"},
+                },
+                {
+                    "model_name": "model_name_team-a_complex",
+                    "litellm_params": {
+                        **self._complexity_router_params("gpt-4o", tags=["complex"]),
+                        "complexity_router_config": {
+                            "tiers": {"SIMPLE": "gpt-4o", "MEDIUM": "gpt-4o", "COMPLEX": "gpt-4o"}
+                        },
+                    },
+                    "model_info": {"team_id": "team-a", "team_public_model_name": "smart-router", "id": "router-a-complex"},
+                },
+            ],
+            ignore_invalid_deployments=True,
+        )
+
+        response = await router.async_pre_routing_hook(
+            model="smart-router",
+            request_kwargs={"metadata": {"user_api_key_team_id": "team-a", "tags": ["complex"]}},
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+        assert response is not None
+        assert response.model == "gpt-4o"
+
+    @pytest.mark.asyncio
+    async def test_global_model_name_takes_precedence_over_team_public_name(self):
+        router = litellm.Router(
+            model_list=[
+                {"model_name": "smart-router", "litellm_params": {"model": "gpt-4o"}},
+                {
+                    "model_name": "model_name_team-a_1",
+                    "litellm_params": self._complexity_router_params("gpt-4o-mini"),
+                    "model_info": {"team_id": "team-a", "team_public_model_name": "smart-router", "id": "router-a"},
+                },
+            ],
+            ignore_invalid_deployments=True,
+        )
+
+        response = await router.async_pre_routing_hook(
+            model="smart-router",
+            request_kwargs={"metadata": {"user_api_key_team_id": "team-a"}},
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+        assert response is None
+
+    async def test_team_scoped_public_name_does_not_leak_between_teams(self):
+        router = self._team_scoped_router()
+
+        response = await router.async_pre_routing_hook(
+            model="smart-router",
+            request_kwargs={"metadata": {"user_api_key_team_id": "team-b"}},
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+        assert response is not None
+        assert response.model == "gpt-4o"
+
+    @pytest.mark.asyncio
+    async def test_team_scoped_public_name_requires_team_context(self):
+        router = self._team_scoped_router()
+
+        response = await router.async_pre_routing_hook(
+            model="smart-router",
+            request_kwargs={"metadata": {}},
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+        assert response is None
+
+    @pytest.mark.asyncio
+    async def test_global_complexity_router_still_resolves_without_team_context(self):
+        router = self._team_scoped_router()
+
+        response = await router.async_pre_routing_hook(
+            model="smart-router-global",
+            request_kwargs={"metadata": {}},
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+        assert response is not None
+        assert response.model == "gpt-4o"
+
 
 def test_model_info_is_active_for_environment_matrix(monkeypatch):
     """The model-write endpoints consult this predicate to tell a deliberately
@@ -9527,6 +9685,43 @@ class TestClaudeCodeSubagentSessionRouterBinding:
             "proxy_server_request": {"headers": headers},
             **({"fallback_depth": fallback_depth} if fallback_depth is not None else {}),
         }
+
+    @pytest.mark.asyncio
+    async def test_team_public_name_session_binding_replays_for_subagent(self):
+        from litellm.types.router import TaggedPreRoutingStrategy
+
+        router = litellm.Router(
+            model_list=[
+                {"model_name": "cheap-model", "litellm_params": {"model": "openai/gpt-4o-mini"}},
+                {
+                    "model_name": "internal-team-router",
+                    "litellm_params": {
+                        "model": "auto_router/complexity_router",
+                        "complexity_router_default_model": "cheap-model",
+                    },
+                    "model_info": {"team_id": "team-a", "team_public_model_name": "team-router"},
+                },
+            ],
+            num_retries=0,
+            ignore_invalid_deployments=True,
+        )
+        router.complexity_routers = {
+            "internal-team-router": (TaggedPreRoutingStrategy(tags=(), strategy=self._RewriteStrategy()),)
+        }
+
+        main_kwargs = self._request_kwargs()
+        main_kwargs["metadata"]["user_api_key_team_id"] = "team-a"
+        main = await router.async_pre_routing_hook(model="team-router", request_kwargs=main_kwargs)
+        assert main is not None
+        assert main.model == "cheap-model"
+
+        subagent_kwargs = self._request_kwargs(agent_id="agent-1234")
+        subagent_kwargs["metadata"]["user_api_key_team_id"] = "team-a"
+        replay = await router.async_pre_routing_hook(model="expensive-model", request_kwargs=subagent_kwargs)
+
+        assert replay is not None
+        assert replay.model == "cheap-model"
+        assert subagent_kwargs["metadata"]["model_group"] == "team-router"
 
     @pytest.mark.asyncio
     async def test_subagent_concrete_model_uses_the_main_sessions_router(self):


### PR DESCRIPTION
## TLDR

Problem this solves:

- Team-scoped auto-routers fail when called by their public model name
- The request falls through to the pseudo-model and returns HTTP 400

How it solves it:

- Resolves the team public name to its internal strategy marker
- Keeps model-group aliases ahead of team marker resolution

## User Flow

Before: a team key calls its team auto-router and receives an unmapped-provider error

1. They create a team-scoped auto-router with `POST http://localhost:4581/model/new`, using `model_info.team_id` and `litellm_params.model` set to `auto_router/complexity_router`
2. They create a key for that team and allow the public router model
3. They send `POST http://localhost:4581/v1/chat/completions` with the public router model and a short message
4. The proxy returns HTTP 400 with `Unmapped LLM provider` for `auto_router/complexity_router`

After: the same team key call routes to the configured tier and returns HTTP 200

1. They create a team-scoped auto-router with `POST http://localhost:4581/model/new`, using `model_info.team_id` and `litellm_params.model` set to `auto_router/complexity_router`
2. They create a key for that team and allow the public router model
3. They send `POST http://localhost:4581/v1/chat/completions` with the public router model and a short message
4. The proxy routes the request to the configured tier and returns HTTP 200 with a chat completion

## Relevant issues

- Fixes team-scoped auto-router calls by public model name
- Preserves existing alias and global auto-router behavior

## Linear ticket

Resolves LIT-7363

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Shared setup: both runs used the same isolated Postgres database, proxy port, team creation, auto-router registration, team key generation, public model, and chat payload. The proxy used the sandbox gateway as the real upstream for the configured tier

### Before (1183b2abc6)

1. `POST /team/new` returned a team id
2. `POST /model/new` returned a model id for the team-scoped `auto_router/complexity_router`
3. `POST /key/generate` returned a team key
4. `POST /v1/chat/completions` with the public router model returned HTTP 400
5. Response: `litellm.BadRequestError: Unmapped LLM provider for this endpoint. You passed model=complexity_router, custom_llm_provider=auto_router`

### After (9c6a8e2a9a)

1. `POST /team/new` returned a team id
2. `POST /model/new` returned a model id for the team-scoped `auto_router/complexity_router`
3. `POST /key/generate` returned a team key
4. `POST /v1/chat/completions` with the same public router model returned HTTP 200
5. Response contained a chat completion served through the configured tier

## Type

🐛 Bug Fix

## Caveats

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pre-routing model resolution for team-scoped strategy markers; incorrect mapping could route requests to the wrong deployment or team, though behavior is gated on team metadata and covered by new tests.
> 
> **Overview**
> Fixes team-scoped auto-routers when callers use the **team public model name** instead of the internal strategy marker, which previously fell through and could surface as an unmapped `auto_router` provider error.
> 
> Adds **`_team_strategy_marker_model_name`**, which maps `(team_id, public name)` to the right strategy-marker deployment using existing team deployment indices and router registries, with tag matching, `default` tag fallback, and tag-filtering behavior when plain deployments exist. Resolution order is **alias → team public name → raw model**; registered global `model_name` entries still win over team public names.
> 
> The same resolution is applied in **Claude Code session replay** so subagent requests bound to a team public router name replay the correct strategy. Tests cover per-team isolation, tags, missing team context, global routers, and session binding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53462f62347c332b2be3b44b2eac8ab5c8926173. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->