### PR TITLE
fix(ui): offer No Default Models when picking a virtual key's models

### DIFF
--- a/ui/litellm-dashboard/src/components/key_team_helpers/fetch_available_models_team_key.test.tsx
+++ b/ui/litellm-dashboard/src/components/key_team_helpers/fetch_available_models_team_key.test.tsx
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { getModelDisplayName } from "./fetch_available_models_team_key";
+import {
+  collapseModelSentinelSelection,
+  getModelDisplayName,
+  hasModelSentinel,
+} from "./fetch_available_models_team_key";
 
 describe("getModelDisplayName", () => {
   it("should return display label for all proxy models", () => {
@@ -9,5 +13,33 @@ describe("getModelDisplayName", () => {
 
   it("should return provider-wide label for wildcard models", () => {
     expect(getModelDisplayName("openai/*")).toBe("All openai models");
+  });
+});
+
+describe("hasModelSentinel", () => {
+  it.each(["all-proxy-models", "all-team-models", "no-default-models"])(
+    "treats %s as exclusive, so the concrete models alongside it are unpickable",
+    (sentinel) => {
+      expect(hasModelSentinel([sentinel])).toBe(true);
+    },
+  );
+
+  it("leaves a plain selection pickable", () => {
+    expect(hasModelSentinel(["gpt-4o", "claude-sonnet-4-5"])).toBe(false);
+    expect(hasModelSentinel([])).toBe(false);
+  });
+});
+
+describe("collapseModelSentinelSelection", () => {
+  it.each(["all-team-models", "all-proxy-models", "no-default-models"])(
+    "drops the concrete models already picked when %s is chosen",
+    (sentinel) => {
+      expect(collapseModelSentinelSelection(["gpt-4o", sentinel])).toEqual([sentinel]);
+    },
+  );
+
+  it("leaves a selection of real models alone", () => {
+    expect(collapseModelSentinelSelection(["gpt-4o", "claude-sonnet-4-5"])).toEqual(["gpt-4o", "claude-sonnet-4-5"]);
+    expect(collapseModelSentinelSelection([])).toEqual([]);
   });
 });

--- a/ui/litellm-dashboard/src/components/key_team_helpers/fetch_available_models_team_key.tsx
+++ b/ui/litellm-dashboard/src/components/key_team_helpers/fetch_available_models_team_key.tsx
@@ -38,8 +38,15 @@ export const fetchAvailableModelsForTeamOrKey = async (
 export const excludeProxyWideSentinel = (models: string[]): string[] =>
   models.filter((model) => model !== "all-proxy-models");
 
-export const hasAllModelsSentinel = (models: string[]): boolean =>
-  models.includes("all-proxy-models") || models.includes("all-team-models");
+const MODEL_SENTINELS = ["all-team-models", "all-proxy-models", "no-default-models"] as const;
+
+export const hasModelSentinel = (models: string[]): boolean =>
+  MODEL_SENTINELS.some((sentinel) => models.includes(sentinel));
+
+export const collapseModelSentinelSelection = (models: string[]): string[] => {
+  const sentinel = MODEL_SENTINELS.find((candidate) => models.includes(candidate));
+  return sentinel === undefined ? models : [sentinel];
+};
 
 export const getModelDisplayName = (model: string) => {
   if (model === "all-proxy-models") {

--- a/ui/litellm-dashboard/src/components/organisms/create_key_button.integration.test.tsx
+++ b/ui/litellm-dashboard/src/components/organisms/create_key_button.integration.test.tsx
@@ -776,6 +776,44 @@ describe("CreateKey", () => {
       expect(await screen.findByRole("option", { name: "All Team Models" })).toBeInTheDocument();
       expect(screen.queryByRole("option", { name: "All Proxy Models" })).not.toBeInTheDocument();
     });
+
+    it("offers No Default Models whether or not a team is selected", async () => {
+      await openModal();
+      await userEvent.click(await screen.findByLabelText("Models"));
+
+      expect(await screen.findByRole("option", { name: "No Default Models" })).toBeInTheDocument();
+    });
+
+    it("sends the no-default-models sentinel rather than an empty list", async () => {
+      await openModal();
+      await nameTheKey();
+
+      await userEvent.click(await screen.findByLabelText("Models"));
+      await userEvent.click(await screen.findByRole("option", { name: "No Default Models" }));
+      await userEvent.keyboard("{Escape}");
+
+      await submit();
+
+      expect((await createdPayload()).models).toStrictEqual(["no-default-models"]);
+    });
+
+    it("drops a model already picked when No Default Models is chosen after it", async () => {
+      state.teams = [{ team_id: "team-1", team_alias: "Team One", models: ["team-model-1"] }];
+      await openModal({ teams: state.teams as unknown as Team[] });
+      await nameTheKey();
+
+      await userEvent.click(await screen.findByLabelText("Team"));
+      await userEvent.click(await screen.findByRole("option", { name: /Team One/ }));
+
+      await userEvent.click(await screen.findByLabelText("Models"));
+      await userEvent.click(await screen.findByRole("option", { name: "team-model-1" }));
+      await userEvent.click(await screen.findByRole("option", { name: "No Default Models" }));
+      await userEvent.keyboard("{Escape}");
+
+      await submit();
+
+      expect((await createdPayload()).models).toStrictEqual(["no-default-models"]);
+    });
   });
 
   describe("organization dropdown", () => {

--- a/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
+++ b/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
@@ -58,7 +58,8 @@ import { TagRateLimitEditor, TagRateLimitEntry } from "../key_team_helpers/TagRa
 import {
   excludeProxyWideSentinel,
   getModelDisplayName,
-  hasAllModelsSentinel,
+  collapseModelSentinelSelection,
+  hasModelSentinel,
 } from "../key_team_helpers/fetch_available_models_team_key";
 import { Team } from "../key_team_helpers/key_list";
 import MCPServerSelector from "../mcp_server_management/MCPServerSelector";
@@ -626,18 +627,25 @@ const CreateKey: React.FC<CreateKeyProps> = ({ team, teams, data, addKey, autoOp
     setSelectedProjectId(projectId);
   };
 
+  const sentinelOptions: MultiSelectOption[] =
+    selectedProjectId === null
+      ? [
+          selectedCreateKeyTeam
+            ? { value: "all-team-models", label: "All Team Models" }
+            : { value: "all-proxy-models", label: "All Proxy Models" },
+          { value: "no-default-models", label: "No Default Models" },
+        ]
+      : [];
+  const sentinelValues = new Set(sentinelOptions.map((option) => option.value));
   const modelOptions: MultiSelectOption[] = [
-    ...(selectedProjectId === null && selectedCreateKeyTeam
-      ? [{ value: "all-team-models", label: "All Team Models" }]
-      : []),
-    ...(selectedProjectId === null && !selectedCreateKeyTeam
-      ? [{ value: "all-proxy-models", label: "All Proxy Models" }]
-      : []),
-    ...modelsToPick.map((model) => ({
-      value: model,
-      label: getModelDisplayName(model),
-      disabled: hasAllModelsSentinel(selectedModels),
-    })),
+    ...sentinelOptions,
+    ...modelsToPick
+      .filter((model) => !sentinelValues.has(model))
+      .map((model) => ({
+        value: model,
+        label: getModelDisplayName(model),
+        disabled: hasModelSentinel(selectedModels),
+      })),
   ];
 
   const changeKeyType = (write: FieldWrite) => (value: string) => {
@@ -908,14 +916,7 @@ const CreateKey: React.FC<CreateKeyProps> = ({ team, teams, data, addKey, autoOp
                         value={(control.value as string[] | undefined) ?? []}
                         placeholder="Select models"
                         disabled={keyType === "management" || keyType === "read_only"}
-                        onValueChange={(values) => {
-                          control.onChange(values);
-                          if (values.includes("all-team-models")) {
-                            form.setValue("models", ["all-team-models"]);
-                          } else if (values.includes("all-proxy-models")) {
-                            form.setValue("models", ["all-proxy-models"]);
-                          }
-                        }}
+                        onValueChange={(values) => control.onChange(collapseModelSentinelSelection(values))}
                       />
                     )}
                   </MountedFormField>

--- a/ui/litellm-dashboard/src/components/templates/keyEditFieldNormalizers.test.ts
+++ b/ui/litellm-dashboard/src/components/templates/keyEditFieldNormalizers.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { modelSentinelOptions } from "./keyEditFieldNormalizers";
+
+describe("modelSentinelOptions", () => {
+  it("offers No Default Models on a key with no team, so an access-group-only key is selectable", () => {
+    expect(modelSentinelOptions(null, false)).toEqual([
+      { value: "all-proxy-models", label: "All Proxy Models" },
+      { value: "no-default-models", label: "No Default Models" },
+    ]);
+  });
+
+  it("offers No Default Models on a team key once the team has loaded", () => {
+    expect(modelSentinelOptions("team-1", true)).toEqual([
+      { value: "all-team-models", label: "All Team Models" },
+      { value: "no-default-models", label: "No Default Models" },
+    ]);
+  });
+
+  it("offers nothing while a team key is still loading its team", () => {
+    expect(modelSentinelOptions("team-1", false)).toEqual([]);
+  });
+});

--- a/ui/litellm-dashboard/src/components/templates/keyEditFieldNormalizers.ts
+++ b/ui/litellm-dashboard/src/components/templates/keyEditFieldNormalizers.ts
@@ -30,8 +30,9 @@ export const modelSentinelOptions = (
   keyTeamId: string | null | undefined,
   teamLoaded: boolean,
 ): { value: string; label: string }[] => {
-  if (keyTeamId == null) return [{ value: "all-proxy-models", label: "All Proxy Models" }];
-  return teamLoaded ? [{ value: "all-team-models", label: "All Team Models" }] : [];
+  const noDefaultModels = { value: "no-default-models", label: "No Default Models" };
+  if (keyTeamId == null) return [{ value: "all-proxy-models", label: "All Proxy Models" }, noDefaultModels];
+  return teamLoaded ? [{ value: "all-team-models", label: "All Team Models" }, noDefaultModels] : [];
 };
 
 export const currentValuePlaceholder = (

--- a/ui/litellm-dashboard/src/components/templates/key_edit_view.integration.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_edit_view.integration.test.tsx
@@ -326,6 +326,30 @@ describe("KeyEditView", () => {
     });
   });
 
+  it("lists No Default Models once when the available models already carry the sentinel", async () => {
+    vi.mocked(modelAvailableCall).mockResolvedValue({
+      data: [{ id: "gpt-4" }, { id: "no-default-models" }],
+    });
+
+    renderWithProviders(
+      <KeyEditView
+        keyData={MOCK_KEY_DATA}
+        onCancel={() => {}}
+        onSubmit={async () => {}}
+        accessToken={"test-token"}
+        userID={"user-1"}
+        userRole={"Admin"}
+        premiumUser={false}
+      />,
+    );
+
+    await userEvent.click(await screen.findByLabelText("Models"));
+
+    expect(await screen.findByRole("option", { name: "gpt-4" })).toBeInTheDocument();
+    expect(screen.getAllByRole("option", { name: "No Default Models" })).toHaveLength(1);
+    expect(screen.queryByRole("option", { name: "no-default-models" })).not.toBeInTheDocument();
+  });
+
   it("should render tags", async () => {
     renderWithProviders(
       <KeyEditView

--- a/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
@@ -49,7 +49,11 @@ import {
   tagLimitsToRows,
   tagRowsToLimits,
 } from "../key_team_helpers/TagRateLimitEditor";
-import { excludeProxyWideSentinel, hasAllModelsSentinel } from "../key_team_helpers/fetch_available_models_team_key";
+import {
+  collapseModelSentinelSelection,
+  excludeProxyWideSentinel,
+  hasModelSentinel,
+} from "../key_team_helpers/fetch_available_models_team_key";
 import { KeyResponse } from "../key_team_helpers/key_list";
 import MCPServerSelector from "../mcp_server_management/MCPServerSelector";
 import MCPToolPermissions from "../mcp_server_management/MCPToolPermissions";
@@ -325,13 +329,17 @@ export function KeyEditView({
     form.setValue("disabled_callbacks", internalValues);
   };
 
+  const sentinelOptions = modelSentinelOptions(keyData.team_id, team != null);
+  const sentinelValues = new Set(sentinelOptions.map((option) => option.value));
   const modelOptions = [
-    ...modelSentinelOptions(keyData.team_id, team != null),
-    ...availableModels.map((model) => ({
-      value: model,
-      label: model,
-      disabled: hasAllModelsSentinel(selectedModels),
-    })),
+    ...sentinelOptions,
+    ...availableModels
+      .filter((model) => !sentinelValues.has(model))
+      .map((model) => ({
+        value: model,
+        label: model,
+        disabled: hasModelSentinel(selectedModels),
+      })),
   ];
 
   const visibleTeams = selectedOrganizationId
@@ -361,15 +369,7 @@ export function KeyEditView({
                 id={id}
                 options={modelOptions}
                 value={isModelsDisabled ? [] : (value as string[] | undefined) ?? []}
-                onValueChange={(next) => {
-                  if (next.includes("all-team-models")) {
-                    onChange(["all-team-models"]);
-                  } else if (next.includes("all-proxy-models")) {
-                    onChange(["all-proxy-models"]);
-                  } else {
-                    onChange(next);
-                  }
-                }}
+                onValueChange={(next) => onChange(collapseModelSentinelSelection(next))}
                 disabled={isModelsDisabled}
                 placeholder="Select models"
               />


### PR DESCRIPTION
## TLDR

Problem this solves:

- The key Models dropdown never offers `no-default-models`
- Admins leave Models empty instead, which grants everything
- An access-group-only key cannot be built in the UI

How it solves it:

- Offer No Default Models on key create and edit
- Picking a sentinel clears the models already selected

## User Flow

Before: an administrator cannot restrict a key to the models its access groups grant, and the key they save can reach every model on the proxy

1. They open https://litellm-domain/ui/?page=api-keys and click + Create New Key
2. They open Models and see All Proxy Models, allowed-model and unrelated-model, with nothing that turns direct access off
3. They leave Models empty, name the key and save; it is created with an empty model list
4. `GET https://litellm-domain/v1/models` with that key answers `allowed-model` and `unrelated-model`
5. The key holder can list and call every model on the proxy, whatever their access groups say

After: the same administrator can save a key that grants no direct models

1. They open the same page and click + Create New Key
2. They open Models and now also see No Default Models
3. They pick it; any models they had already picked are dropped and the rest grey out, so the choice cannot be mixed with them
4. They name the key and save; it is created with `models: ["no-default-models"]`
5. `GET https://litellm-domain/v1/models` with that key answers an empty list, so the key reaches only what its access groups grant

## Relevant issues

Fixes #40212

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Shared setup. A proxy on port 4000 with a database and two models, the dashboard built from the tree under test and served at `/ui`:

```yaml
model_list:
  - model_name: allowed-model
    litellm_params:
      model: openai/gpt-4o-mini
  - model_name: unrelated-model
    litellm_params:
      model: openai/gpt-4o-mini
general_settings:
  database_url: os.environ/DATABASE_URL
```

Every case starts the same way: open http://127.0.0.1:4000/ui/?page=api-keys, click + Create New Key, open the Models field. The option list and the selected chips are read off the rendered dropdown with

```js
Array.from(document.querySelectorAll('[role="option"]')).map((e) => e.textContent.trim())
Array.from(document.querySelectorAll('[data-slot="combobox-chip"]')).map((e) => e.textContent.trim())
```

Rebased onto 9071ca503e on 12 Sep to clear a merge conflict. The rebase moved the
base only, the diff is byte for byte what it was, so the run below still describes this
code. It was captured at the pre-rebase shas named in each heading, not at the current
tip f0a0341e6f. Say the word if you want a fresh capture against the new base

### Before (e5da59336d)

#### the option is not offered

1. Open the Models field and read the options

```text
["All Proxy Models", "allowed-model", "unrelated-model"]
```

2. With no way to turn direct access off, leave Models empty, name the key `qa-before-empty` and click Create Key

3. Read the saved key

```bash
curl -s "http://127.0.0.1:4000/key/list?return_full_object=true" -H "Authorization: Bearer sk-1234"
```

```text
qa-before-empty -> models=[]
```

4. Ask what an empty list grants

```bash
curl -s http://127.0.0.1:4000/v1/models -H "Authorization: Bearer $KEY"
```

```text
['allowed-model', 'unrelated-model']
```

### After (58052eb279)

#### the option is offered

1. Open the Models field and read the options

```text
["All Proxy Models", "No Default Models", "allowed-model", "unrelated-model"]
```

#### picking it clears a model chosen first

1. Click `allowed-model`, then read the chips

```text
["allowed-model"]
```

2. Click `No Default Models`, then read the chips again

```text
["No Default Models"]
```

`allowed-model` and `unrelated-model` are greyed out at this point, so the two cannot be combined

3. Name the key `qa-after-collapse`, click Create Key, and read it back

```bash
curl -s "http://127.0.0.1:4000/key/list?return_full_object=true" -H "Authorization: Bearer sk-1234"
```

```text
qa-after-collapse -> models=["no-default-models"]
```

4. Ask what the sentinel grants

```bash
curl -s http://127.0.0.1:4000/v1/models -H "Authorization: Bearer $KEY"
```

```text
[]
```

Why the collapse matters rather than only greying out: a key saved as `["allowed-model", "no-default-models"]` still lists and calls `allowed-model`, so a retained chip would have quietly kept the access the admin meant to remove.

```text
models ["allowed-model","no-default-models"] -> /v1/models: ['allowed-model']   calling allowed-model: authorized
models ["no-default-models"]                 -> /v1/models: []                  calling allowed-model: HTTP 403
```

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Labelled No Default Models, matching the users and teams screens, where the issue said No direct models
- The collapse now also applies to `all-proxy-models` and `all-team-models`, which previously kept an earlier selection too. Harmless there, since both are supersets

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR



