### PR TITLE
fix(ui): limit shadow eval models to configured deployments

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/ShadowEvalSection.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/ShadowEvalSection.test.tsx
@@ -75,6 +75,7 @@ vi.mock("@/app/(dashboard)/hooks/models/useModels", () => ({
       { model_name: "gpt-auto", litellm_params: { model: "auto_router/gpt-auto" } },
     ],
   })),
+  usePlainChatModelGroups: vi.fn(() => new Set(["prod-claude", "anthropic/claude-sonnet-5"])),
   usePlainModelGroups: vi.fn(() => new Set(["prod-claude", "anthropic/claude-sonnet-5"])),
 }));
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/ShadowEvalSection.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/ShadowEvalSection.test.tsx
@@ -75,18 +75,7 @@ vi.mock("@/app/(dashboard)/hooks/models/useModels", () => ({
       { model_name: "gpt-auto", litellm_params: { model: "auto_router/gpt-auto" } },
     ],
   })),
-  usePlainModelGroups: vi.fn(() => new Set(["prod-claude"])),
-}));
-
-vi.mock("@/app/(dashboard)/hooks/models/useModelCostMap", () => ({
-  useModelCostMap: vi.fn(() => ({
-    data: {
-      "claude-sonnet-5": { litellm_provider: "anthropic", mode: "chat" },
-      "gpt-4o": { litellm_provider: "openai", mode: "chat" },
-      "gemini/gemini-2.5-pro": { litellm_provider: "gemini", mode: "chat" },
-      "text-embedding-3-large": { litellm_provider: "openai", mode: "embedding" },
-    },
-  })),
+  usePlainModelGroups: vi.fn(() => new Set(["prod-claude", "anthropic/claude-sonnet-5"])),
 }));
 
 import ShadowEvalSection, { shadowedTargetLabel } from "./ShadowEvalSection";
@@ -444,6 +433,7 @@ describe("ShadowEvalSection", () => {
     expect(screen.getByText("Start shadow eval")).toBeDisabled();
 
     await user.click(screen.getByPlaceholderText("Select a judge model"));
+    expect(screen.queryByRole("option", { name: /openai\/gpt-4o/ })).not.toBeInTheDocument();
     await user.click(await screen.findByRole("option", { name: /anthropic\/claude-sonnet-5/ }));
     await user.click(screen.getByText("Start shadow eval"));
 
@@ -537,7 +527,7 @@ describe("ShadowEvalSection", () => {
     expect(screen.getByText("Start shadow eval")).toBeDisabled();
 
     await user.click(screen.getByPlaceholderText("Select a baseline model"));
-    expect(await screen.findByRole("option", { name: /openai\/gpt-4o/ })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: /openai\/gpt-4o/ })).not.toBeInTheDocument();
     await user.click(screen.getByRole("option", { name: /prod-claude/ }));
     await user.click(screen.getByText("Start shadow eval"));
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/ShadowEvalStartForm.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/ShadowEvalStartForm.tsx
@@ -5,7 +5,6 @@ import React, { useMemo, useState } from "react";
 import { useInfiniteKeys } from "@/app/(dashboard)/hooks/keys/useKeys";
 import { useInfiniteUsers } from "@/app/(dashboard)/hooks/users/useUsers";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
-import { useModelCostMap } from "@/app/(dashboard)/hooks/models/useModelCostMap";
 import { useAutoRouters, usePlainModelGroups } from "@/app/(dashboard)/hooks/models/useModels";
 import { MultiSelect } from "@/components/shared/MultiSelect";
 import { PaginatedMultiSelect } from "@/components/shared/PaginatedMultiSelect";
@@ -25,50 +24,15 @@ type ShadowEvalDirection = ShadowEvalJob["direction"];
 const MAX_ROUTERS = 4;
 const MAX_MODELS = 100;
 
-const RECOMMENDED_JUDGE_MODELS = ["anthropic/claude-sonnet-5", "openai/gpt-4o", "gemini/gemini-2.5-pro"] as const;
-
-interface CostMapEntry {
-  litellm_provider?: string;
-  mode?: string;
-}
-
-const useChatModelNames = (): string[] => {
-  const { data: costMap } = useModelCostMap();
-  return useMemo(() => {
-    if (!costMap) return [];
-    const chatModels = Object.entries(costMap as Record<string, CostMapEntry>)
-      .filter(([, value]) => value?.mode === "chat" && value?.litellm_provider)
-      .map(([key, value]) => (key.startsWith(`${value.litellm_provider}/`) ? key : `${value.litellm_provider}/${key}`));
-    return [...new Set(chatModels)].toSorted((a, b) => a.localeCompare(b));
-  }, [costMap]);
-};
-
-const useJudgeModelOptions = (): SearchSelectOption[] => {
-  const chatModels = useChatModelNames();
-  return useMemo(() => {
-    const pinned: SearchSelectOption[] = RECOMMENDED_JUDGE_MODELS.map((model) => ({
-      label: model,
-      value: model,
-      sublabel: "Recommended",
-    }));
-    const pinnedNames = new Set<string>(RECOMMENDED_JUDGE_MODELS);
-    const rest = chatModels.filter((model) => !pinnedNames.has(model)).map((model) => ({ label: model, value: model }));
-    return [...pinned, ...rest];
-  }, [chatModels]);
-};
-
-const useBaselineModelOptions = (): SearchSelectOption[] => {
+const useConfiguredModelOptions = (): SearchSelectOption[] => {
   const configuredGroups = usePlainModelGroups();
-  const chatModels = useChatModelNames();
-  return useMemo(() => {
-    const configured = [...configuredGroups]
-      .toSorted((a, b) => a.localeCompare(b))
-      .map((model) => ({ label: model, value: model, sublabel: "Configured on this gateway" }));
-    const rest = chatModels
-      .filter((model) => !configuredGroups.has(model))
-      .map((model) => ({ label: model, value: model }));
-    return [...configured, ...rest];
-  }, [configuredGroups, chatModels]);
+  return useMemo(
+    () =>
+      [...configuredGroups]
+        .toSorted((a, b) => a.localeCompare(b))
+        .map((model) => ({ label: model, value: model, sublabel: "Configured on this gateway" })),
+    [configuredGroups],
+  );
 };
 
 const DIRECTION_OPTIONS: readonly { value: ShadowEvalDirection; label: string }[] = [
@@ -276,13 +240,7 @@ export const StartForm: React.FC = () => {
   const [judgeModel, setJudgeModel] = useState("");
   const [maxBudget, setMaxBudget] = useState("10");
   const { data: autoRouters } = useAutoRouters();
-  const judgeModelOptions = useJudgeModelOptions();
-  const baselineModelOptions = useBaselineModelOptions();
-  const configuredGroups = usePlainModelGroups();
-  const modelOptions = useMemo<SearchSelectOption[]>(
-    () => [...configuredGroups].toSorted((a, b) => a.localeCompare(b)).map((name) => ({ label: name, value: name })),
-    [configuredGroups],
-  );
+  const configuredModelOptions = useConfiguredModelOptions();
   const start = useStartShadowEval();
 
   const routerOptions = useMemo<SearchSelectOption[]>(() => {
@@ -360,7 +318,7 @@ export const StartForm: React.FC = () => {
           {direction === "forward" && (
             <Field label="Only on models">
               <MultiSelect
-                options={modelOptions}
+                options={configuredModelOptions}
                 value={models}
                 onValueChange={setModels}
                 placeholder="Every model the targets use"
@@ -434,7 +392,7 @@ export const StartForm: React.FC = () => {
           {direction === "reverse" && (
             <Field label="Baseline model">
               <SearchSelect
-                options={baselineModelOptions}
+                options={configuredModelOptions}
                 value={baselineModel}
                 onValueChange={setBaselineModel}
                 placeholder="Select a baseline model"
@@ -444,7 +402,7 @@ export const StartForm: React.FC = () => {
           )}
           <Field label="Judge model" className="sm:col-span-2">
             <SearchSelect
-              options={judgeModelOptions}
+              options={configuredModelOptions}
               value={judgeModel}
               onValueChange={setJudgeModel}
               placeholder="Select a judge model"

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/ShadowEvalStartForm.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/ShadowEvalStartForm.tsx
@@ -5,7 +5,7 @@ import React, { useMemo, useState } from "react";
 import { useInfiniteKeys } from "@/app/(dashboard)/hooks/keys/useKeys";
 import { useInfiniteUsers } from "@/app/(dashboard)/hooks/users/useUsers";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
-import { useAutoRouters, usePlainModelGroups } from "@/app/(dashboard)/hooks/models/useModels";
+import { useAutoRouters, usePlainChatModelGroups } from "@/app/(dashboard)/hooks/models/useModels";
 import { MultiSelect } from "@/components/shared/MultiSelect";
 import { PaginatedMultiSelect } from "@/components/shared/PaginatedMultiSelect";
 import TeamMultiSelect from "@/components/common_components/team_multi_select";
@@ -25,7 +25,7 @@ const MAX_ROUTERS = 4;
 const MAX_MODELS = 100;
 
 const useConfiguredModelOptions = (): SearchSelectOption[] => {
-  const configuredGroups = usePlainModelGroups();
+  const configuredGroups = usePlainChatModelGroups();
   return useMemo(
     () =>
       [...configuredGroups]

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/models/useModels.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/models/useModels.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   isAutoRouterDeployment,
   selectAutoRouterModelGroups,
+  selectPlainChatModelGroups,
   selectPlainModelGroups,
   useAllProxyModels,
   useAutoRouterModelGroups,
@@ -1007,6 +1008,25 @@ describe("selectPlainModelGroups", () => {
 
   it("drops deployments that have no public model_name", () => {
     expect(selectPlainModelGroups([{ model_name: "", litellm_params: { model: "openai/gpt-4o" } }])).toEqual(new Set());
+  });
+
+  it("keeps only configured chat model groups for Shadow Eval choices", () => {
+    const deployments: AutoRouterCandidateDeployment[] = [
+      { model_name: "chat-model", litellm_params: { model: "openai/gpt-4o" }, model_info: { mode: "chat" } },
+      {
+        model_name: "embedding-model",
+        litellm_params: { model: "openai/text-embedding-3-large" },
+        model_info: { mode: "embedding" },
+      },
+      { model_name: "unknown-mode", litellm_params: { model: "openai/gpt-4o" }, model_info: { mode: null } },
+      {
+        model_name: "router",
+        litellm_params: { model: "auto_router/complexity_router" },
+        model_info: { mode: "chat" },
+      },
+    ];
+
+    expect(selectPlainChatModelGroups(deployments)).toEqual(new Set(["chat-model"]));
   });
 });
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/models/useModels.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/models/useModels.ts
@@ -212,27 +212,23 @@ export const useAutoRouterModelGroups = (): ReadonlySet<string> => {
   return data ?? NO_AUTO_ROUTERS;
 };
 
-export const usePlainModelGroups = (): ReadonlySet<string> => {
+const useSelectedPlainModelGroups = (
+  select: (deployments: AutoRouterCandidateDeployment[]) => ReadonlySet<string>,
+): ReadonlySet<string> => {
   const { accessToken, userId, userRole } = useAuthorized();
   const { data } = useQuery<AutoRouterDeployment[], Error, ReadonlySet<string>>({
     queryKey: autoRouterListKey(userId, userRole),
     queryFn: async () => await fetchAllModelDeployments(accessToken!, userId!, userRole!),
     enabled: Boolean(accessToken && userId && userRole),
-    select: selectPlainModelGroups,
+    select,
   });
   return data ?? NO_AUTO_ROUTERS;
 };
 
-export const usePlainChatModelGroups = (): ReadonlySet<string> => {
-  const { accessToken, userId, userRole } = useAuthorized();
-  const { data } = useQuery<AutoRouterDeployment[], Error, ReadonlySet<string>>({
-    queryKey: autoRouterListKey(userId, userRole),
-    queryFn: async () => await fetchAllModelDeployments(accessToken!, userId!, userRole!),
-    enabled: Boolean(accessToken && userId && userRole),
-    select: selectPlainChatModelGroups,
-  });
-  return data ?? NO_AUTO_ROUTERS;
-};
+export const usePlainModelGroups = (): ReadonlySet<string> => useSelectedPlainModelGroups(selectPlainModelGroups);
+
+export const usePlainChatModelGroups = (): ReadonlySet<string> =>
+  useSelectedPlainModelGroups(selectPlainChatModelGroups);
 
 export const useAutoRouters = (): UseQueryResult<AutoRouterDeployment[], Error> => {
   const { accessToken, userId, userRole } = useAuthorized();

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/models/useModels.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/models/useModels.ts
@@ -91,7 +91,16 @@ const NO_AUTO_ROUTERS: ReadonlySet<string> = new Set<string>();
 export interface AutoRouterCandidateDeployment {
   model_name?: string | null;
   litellm_params?: { model?: string | null } | null;
-  model_info?: { mode?: string | null } | null;
+  model_info?: {
+    mode?: string | null;
+    id?: string | null;
+    db_model?: boolean | null;
+    base_model?: string | null;
+    created_at?: string | null;
+    updated_at?: string | null;
+    team_id?: string | null;
+    created_by?: string | null;
+  } | null;
 }
 
 export interface AutoRouterDeployment extends AutoRouterCandidateDeployment {

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/models/useModels.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/models/useModels.ts
@@ -91,6 +91,7 @@ const NO_AUTO_ROUTERS: ReadonlySet<string> = new Set<string>();
 export interface AutoRouterCandidateDeployment {
   model_name?: string | null;
   litellm_params?: { model?: string | null } | null;
+  model_info?: { mode?: string | null } | null;
 }
 
 export interface AutoRouterDeployment extends AutoRouterCandidateDeployment {
@@ -136,6 +137,17 @@ export const selectPlainModelGroups = (deployments: AutoRouterCandidateDeploymen
   const autoRouterGroups = selectAutoRouterModelGroups(deployments);
   return new Set(
     deployments
+      .map((deployment) => deployment.model_name)
+      .filter((modelName): modelName is string => Boolean(modelName))
+      .filter((modelName) => !autoRouterGroups.has(modelName)),
+  );
+};
+
+export const selectPlainChatModelGroups = (deployments: AutoRouterCandidateDeployment[]): ReadonlySet<string> => {
+  const autoRouterGroups = selectAutoRouterModelGroups(deployments);
+  return new Set(
+    deployments
+      .filter((deployment) => deployment.model_info?.mode === "chat")
       .map((deployment) => deployment.model_name)
       .filter((modelName): modelName is string => Boolean(modelName))
       .filter((modelName) => !autoRouterGroups.has(modelName)),
@@ -198,6 +210,17 @@ export const usePlainModelGroups = (): ReadonlySet<string> => {
     queryFn: async () => await fetchAllModelDeployments(accessToken!, userId!, userRole!),
     enabled: Boolean(accessToken && userId && userRole),
     select: selectPlainModelGroups,
+  });
+  return data ?? NO_AUTO_ROUTERS;
+};
+
+export const usePlainChatModelGroups = (): ReadonlySet<string> => {
+  const { accessToken, userId, userRole } = useAuthorized();
+  const { data } = useQuery<AutoRouterDeployment[], Error, ReadonlySet<string>>({
+    queryKey: autoRouterListKey(userId, userRole),
+    queryFn: async () => await fetchAllModelDeployments(accessToken!, userId!, userRole!),
+    enabled: Boolean(accessToken && userId && userRole),
+    select: selectPlainChatModelGroups,
   });
   return data ?? NO_AUTO_ROUTERS;
 };


### PR DESCRIPTION
## TLDR

Problem this solves:

- Shadow Eval listed models from the global catalog
- Non-chat deployments could also enter judge choices

How it solves it:

- Judge and baseline pickers now use configured chat model groups
- Hard-coded and catalog-only choices are removed

## User Flow

Before: an admin can choose a catalog or non-chat model the gateway cannot use for judging

1. They open the Cost Optimization page and choose Shadow Evals
2. They open the Judge model or Baseline model picker
3. The picker includes global catalog models or configured non-chat deployments
4. They submit the evaluation and receive a model or provider error

After: an admin sees configured chat model groups in these pickers

1. They open the Cost Optimization page and choose Shadow Evals
2. They open the Judge model or Baseline model picker
3. The picker lists configured chat model groups only
4. They select a chat group and start the evaluation without choosing an unsupported option

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The focused dashboard tests pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible
- [x] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Shared setup: the same live proxy at `http://127.0.0.1:4581`, with the same configured deployments and admin credentials

### Before (c7163a80dd)

#### Model sources

1. `GET /public/litellm_model_cost_map` returned 2,943 chat catalog entries and included `openai/gpt-4o`
2. `GET /v2/model/info?page=1&size=1000` returned five configured deployment rows
3. The old form used the public catalog for Judge and Baseline options, so catalog-only models were selectable

### After (8e51f812ab)

#### Model sources

1. `GET /v2/model/info?page=1&size=1000` returned the same five configured deployment rows
2. The fixed form derives Judge, Baseline, and forward model-scope options from configured chat deployment groups
3. The resulting chat options exclude embedding and null-mode deployments; catalog-only recommendations are not offered

Focused regressions passed with 101 tests:

`vitest run --project component src/app/(dashboard)/hooks/models/useModels.test.ts src/app/(dashboard)/cost-optimization/_components/ShadowEvalSection.test.tsx --no-file-parallelism`

The dashboard production build passed before this review-round change. It emitted existing warnings for the unsupported `useTypeScriptCli` config key and AVIF optimization

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- Explicit SDK model names remain supported by the backend
- The UI now requires a configured chat model group for these selectors

## Final Attestation

- [x] The tests check the configured-only and non-chat edge cases
- [x] The change removes the catalog source instead of adding another filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)
