### PR TITLE
fix(ui): support Access Group-only virtual keys

### DIFF
--- a/ui/litellm-dashboard/src/components/key_team_helpers/fetch_available_models_team_key.tsx
+++ b/ui/litellm-dashboard/src/components/key_team_helpers/fetch_available_models_team_key.tsx
@@ -41,6 +41,20 @@ export const excludeProxyWideSentinel = (models: string[]): string[] =>
 export const hasAllModelsSentinel = (models: string[]): boolean =>
   models.includes("all-proxy-models") || models.includes("all-team-models");
 
+const MODEL_ACCESS_SENTINELS = ["all-proxy-models", "all-team-models", "no-default-models"] as const;
+
+export const isModelAccessSentinel = (model: string): boolean =>
+  MODEL_ACCESS_SENTINELS.some((sentinel) => sentinel === model);
+
+export const hasModelAccessSentinel = (models: string[]): boolean => models.some(isModelAccessSentinel);
+
+export const normalizeModelAccessSelection = (models: string[], previousModels: string[]): string[] => {
+  const newlySelectedSentinel = models.find((model) => isModelAccessSentinel(model) && !previousModels.includes(model));
+  if (newlySelectedSentinel) return [newlySelectedSentinel];
+  const selectedSentinel = models.find(isModelAccessSentinel);
+  return selectedSentinel ? [selectedSentinel] : models;
+};
+
 export const getModelDisplayName = (model: string) => {
   if (model === "all-proxy-models") {
     return "All Proxy Models";

--- a/ui/litellm-dashboard/src/components/organisms/create_key_button.integration.test.tsx
+++ b/ui/litellm-dashboard/src/components/organisms/create_key_button.integration.test.tsx
@@ -737,6 +737,7 @@ describe("CreateKey", () => {
       await userEvent.click(await screen.findByLabelText("Models"));
 
       expect(await screen.findByRole("option", { name: "All Proxy Models" })).toBeInTheDocument();
+      expect(screen.getByRole("option", { name: "No Direct Models" })).toBeInTheDocument();
       expect(screen.queryByRole("option", { name: "All Team Models" })).not.toBeInTheDocument();
     });
 
@@ -750,7 +751,30 @@ describe("CreateKey", () => {
       await userEvent.click(await screen.findByLabelText("Models"));
 
       expect(await screen.findByRole("option", { name: "All Team Models" })).toBeInTheDocument();
+      expect(screen.getByRole("option", { name: "No Direct Models" })).toBeInTheDocument();
       expect(screen.queryByRole("option", { name: "All Proxy Models" })).not.toBeInTheDocument();
+    });
+
+    it("creates an Access Group-only key with no direct model grants", async () => {
+      state.accessGroups = [{ access_group_id: "ag-1", access_group_name: "Group One" }];
+      await openModal();
+      await nameTheKey();
+
+      await userEvent.click(await screen.findByLabelText("Models"));
+      await userEvent.click(await screen.findByRole("option", { name: "gpt-4" }));
+      await userEvent.click(screen.getByRole("option", { name: "No Direct Models" }));
+
+      expect(screen.getByRole("option", { name: "gpt-4" })).toHaveAttribute("aria-disabled", "true");
+      await userEvent.keyboard("{Escape}");
+      await openSection(/Optional Settings/i);
+      await userEvent.click(await screen.findByLabelText("Select access groups (optional)"));
+      await userEvent.click(await screen.findByRole("option", { name: /Group One/ }));
+      await userEvent.keyboard("{Escape}");
+      await submit();
+
+      const payload = await createdPayload();
+      expect(payload.models).toEqual(["no-default-models"]);
+      expect(payload.access_group_ids).toEqual(["ag-1"]);
     });
   });
 

--- a/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
+++ b/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
@@ -57,7 +57,9 @@ import { TagRateLimitEditor, TagRateLimitEntry } from "../key_team_helpers/TagRa
 import {
   excludeProxyWideSentinel,
   getModelDisplayName,
-  hasAllModelsSentinel,
+  hasModelAccessSentinel,
+  isModelAccessSentinel,
+  normalizeModelAccessSelection,
 } from "../key_team_helpers/fetch_available_models_team_key";
 import { Team } from "../key_team_helpers/key_list";
 import MCPServerSelector from "../mcp_server_management/MCPServerSelector";
@@ -632,11 +634,14 @@ const CreateKey: React.FC<CreateKeyProps> = ({ team, teams, data, addKey, autoOp
     ...(selectedProjectId === null && !selectedCreateKeyTeam
       ? [{ value: "all-proxy-models", label: "All Proxy Models" }]
       : []),
-    ...modelsToPick.map((model) => ({
-      value: model,
-      label: getModelDisplayName(model),
-      disabled: hasAllModelsSentinel(selectedModels),
-    })),
+    { value: "no-default-models", label: "No Direct Models" },
+    ...modelsToPick
+      .filter((model) => !isModelAccessSentinel(model))
+      .map((model) => ({
+        value: model,
+        label: getModelDisplayName(model),
+        disabled: hasModelAccessSentinel(selectedModels),
+      })),
   ];
 
   const changeKeyType = (write: FieldWrite) => (value: string) => {
@@ -887,7 +892,7 @@ const CreateKey: React.FC<CreateKeyProps> = ({ team, teams, data, addKey, autoOp
                     label={
                       <span>
                         Models{" "}
-                        <SimpleTooltip content="Select which models this key can access. Choose 'All Team Models' to grant access to all models available to the team. Leave empty to allow access to all models.">
+                        <SimpleTooltip content="Select which models this key can access. Choose 'No Direct Models' for Access Group-only access. Leaving this empty allows access to all models.">
                           <Info className="ml-1 inline size-3.5 align-text-bottom" />
                         </SimpleTooltip>
                       </span>
@@ -896,7 +901,7 @@ const CreateKey: React.FC<CreateKeyProps> = ({ team, teams, data, addKey, autoOp
                     help={
                       keyType === "management" || keyType === "read_only"
                         ? "Models field is disabled for this key type"
-                        : "optional - leave empty to allow access to all models"
+                        : "Select No Direct Models for Access Group-only access. Leaving this empty allows all models"
                     }
                     className="mt-4"
                   >
@@ -907,14 +912,9 @@ const CreateKey: React.FC<CreateKeyProps> = ({ team, teams, data, addKey, autoOp
                         value={(control.value as string[] | undefined) ?? []}
                         placeholder="Select models"
                         disabled={keyType === "management" || keyType === "read_only"}
-                        onValueChange={(values) => {
-                          control.onChange(values);
-                          if (values.includes("all-team-models")) {
-                            form.setValue("models", ["all-team-models"]);
-                          } else if (values.includes("all-proxy-models")) {
-                            form.setValue("models", ["all-proxy-models"]);
-                          }
-                        }}
+                        onValueChange={(values) =>
+                          control.onChange(normalizeModelAccessSelection(values, selectedModels))
+                        }
                       />
                     )}
                   </MountedFormField>

--- a/ui/litellm-dashboard/src/components/templates/keyEditFieldNormalizers.ts
+++ b/ui/litellm-dashboard/src/components/templates/keyEditFieldNormalizers.ts
@@ -30,8 +30,10 @@ export const modelSentinelOptions = (
   keyTeamId: string | null | undefined,
   teamLoaded: boolean,
 ): { value: string; label: string }[] => {
-  if (keyTeamId == null) return [{ value: "all-proxy-models", label: "All Proxy Models" }];
-  return teamLoaded ? [{ value: "all-team-models", label: "All Team Models" }] : [];
+  const noDirectModelsOption = { value: "no-default-models", label: "No Direct Models" };
+  if (keyTeamId == null) return [{ value: "all-proxy-models", label: "All Proxy Models" }, noDirectModelsOption];
+  if (teamLoaded) return [{ value: "all-team-models", label: "All Team Models" }, noDirectModelsOption];
+  return [noDirectModelsOption];
 };
 
 export const currentValuePlaceholder = (

--- a/ui/litellm-dashboard/src/components/templates/key_edit_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_edit_view.test.tsx
@@ -1530,6 +1530,7 @@ describe("KeyEditView", () => {
       });
 
       expect(screen.getAllByText("All Proxy Models").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("No Direct Models").length).toBeGreaterThan(0);
       expect(screen.queryAllByText("All Team Models")).toHaveLength(0);
     });
 
@@ -1561,8 +1562,40 @@ describe("KeyEditView", () => {
       });
 
       expect(screen.getAllByText("All Team Models").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("No Direct Models").length).toBeGreaterThan(0);
       expect(screen.queryAllByText("All Proxy Models")).toHaveLength(0);
       expect(screen.queryAllByText("all-proxy-models")).toHaveLength(0);
+    });
+
+    it("should save an Access Group-only key with no direct model grants", async () => {
+      const onSubmitMock = vi.fn().mockResolvedValue(undefined);
+
+      renderWithProviders(
+        <KeyEditView
+          keyData={MOCK_KEY_DATA}
+          onCancel={() => {}}
+          onSubmit={onSubmitMock}
+          accessToken="test-token"
+          userID="user-123"
+          userRole="Admin"
+          premiumUser={false}
+        />,
+      );
+
+      await openModelsDropdown();
+      fireEvent.click(await screen.findByRole("option", { name: "gpt-4" }));
+      fireEvent.click(screen.getByRole("option", { name: "No Direct Models" }));
+
+      expect(screen.getByRole("option", { name: "gpt-4" })).toHaveAttribute("aria-disabled", "true");
+      await userEvent.keyboard("{Escape}");
+      fireEvent.change(screen.getByTestId("access-group-selector"), { target: { value: "ag-1" } });
+      await userEvent.click(screen.getByRole("button", { name: /save changes/i }));
+
+      await waitFor(() => {
+        expect(onSubmitMock).toHaveBeenCalled();
+      });
+      expect(onSubmitMock.mock.calls[0][0].models).toEqual(["no-default-models"]);
+      expect(onSubmitMock.mock.calls[0][0].access_group_ids).toEqual(["ag-1"]);
     });
 
     it("should not offer all-team-models for a team key whose team has not loaded yet", async () => {

--- a/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
@@ -51,7 +51,12 @@ import {
   tagLimitsToRows,
   tagRowsToLimits,
 } from "../key_team_helpers/TagRateLimitEditor";
-import { excludeProxyWideSentinel, hasAllModelsSentinel } from "../key_team_helpers/fetch_available_models_team_key";
+import {
+  excludeProxyWideSentinel,
+  hasModelAccessSentinel,
+  isModelAccessSentinel,
+  normalizeModelAccessSelection,
+} from "../key_team_helpers/fetch_available_models_team_key";
 import { KeyResponse } from "../key_team_helpers/key_list";
 import MCPServerSelector from "../mcp_server_management/MCPServerSelector";
 import MCPToolPermissions from "../mcp_server_management/MCPToolPermissions";
@@ -329,11 +334,13 @@ export function KeyEditView({
 
   const modelOptions = [
     ...modelSentinelOptions(keyData.team_id, team != null),
-    ...availableModels.map((model) => ({
-      value: model,
-      label: model,
-      disabled: hasAllModelsSentinel(selectedModels),
-    })),
+    ...availableModels
+      .filter((model) => !isModelAccessSentinel(model))
+      .map((model) => ({
+        value: model,
+        label: model,
+        disabled: hasModelAccessSentinel(selectedModels),
+      })),
   ];
 
   const visibleTeams = selectedOrganizationId
@@ -363,15 +370,7 @@ export function KeyEditView({
                 id={id}
                 options={modelOptions}
                 value={isModelsDisabled ? [] : (value as string[] | undefined) ?? []}
-                onValueChange={(next) => {
-                  if (next.includes("all-team-models")) {
-                    onChange(["all-team-models"]);
-                  } else if (next.includes("all-proxy-models")) {
-                    onChange(["all-proxy-models"]);
-                  } else {
-                    onChange(next);
-                  }
-                }}
+                onValueChange={(next) => onChange(normalizeModelAccessSelection(next, selectedModels))}
                 disabled={isModelsDisabled}
                 placeholder="Select models"
               />


### PR DESCRIPTION
## TLDR

Problem this solves:

- Access Group-only keys cannot be configured in the dashboard
- Empty Models grants every proxy model

How it solves it:

- Add a No Direct Models choice to create and edit
- Keep model access sentinels mutually exclusive
- Preserve Access Groups in submitted key payloads

## User Flow

Before: an administrator cannot create an Access Group-only key in the dashboard

1. They open the Virtual Keys page and create or edit a key
2. They select an Access Group but cannot disable direct model access
3. Leaving Models empty saves `models: []`, which grants every model

After: the same administrator can limit the key to its Access Groups

1. They open the Virtual Keys page and create or edit a key
2. They select an Access Group and choose No Direct Models
3. Saving sends `models: ["no-default-models"]` with the Access Group IDs

## Relevant issues

Fixes #40212

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

### Before (c7163a80dd)

1. Open Create New Key and expand Models
2. The list has no option that disables direct model access

### After (9a720b55c8)

1. Open Create New Key and expand Models
2. No Direct Models appears with Access Group-only guidance
3. Selecting it disables callable models and submits only `no-default-models`

## Type

🐛 Bug Fix

## Caveats (if any)

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
