### PR TITLE
fix(azure): preserve Entra auth while polling OCR

### DIFF
--- a/litellm/llms/azure_ai/ocr/document_intelligence/transformation.py
+++ b/litellm/llms/azure_ai/ocr/document_intelligence/transformation.py
@@ -618,7 +618,11 @@ class AzureDocumentIntelligenceOCRConfig(BaseOCRConfig):
         except SSRFError as ssrf_err:
             raise ValueError(f"Azure Document Intelligence: rejected polling URL ({ssrf_err})")
 
-        poll_headers = {"Ocp-Apim-Subscription-Key": raw_response.request.headers.get("Ocp-Apim-Subscription-Key", "")}
+        poll_headers: Final = {
+            header: raw_response.request.headers[header]
+            for header in ("Ocp-Apim-Subscription-Key", "Authorization")
+            if header in raw_response.request.headers
+        }
         return operation_url, poll_headers
 
     @staticmethod

--- a/tests/test_litellm/llms/azure_ai/test_azure_document_intelligence_ocr_transformation.py
+++ b/tests/test_litellm/llms/azure_ai/test_azure_document_intelligence_ocr_transformation.py
@@ -371,3 +371,33 @@ def test_validate_environment_falls_back_to_entra_token(monkeypatch):
 
     assert headers["Authorization"] == "Bearer entra-token"
     assert "Ocp-Apim-Subscription-Key" not in headers
+
+
+@pytest.mark.parametrize(
+    ("request_headers", "expected_poll_headers"),
+    (
+        (
+            {"Ocp-Apim-Subscription-Key": "subscription-key"},
+            {"Ocp-Apim-Subscription-Key": "subscription-key"},
+        ),
+        (
+            {"Authorization": "Bearer entra-token"},
+            {"Authorization": "Bearer entra-token"},
+        ),
+    ),
+)
+def test_get_polling_target_preserves_request_authentication(request_headers, expected_poll_headers):
+    response = httpx.Response(
+        status_code=202,
+        headers={"Operation-Location": "https://example.cognitiveservices.azure.com/operations/123"},
+        request=httpx.Request(
+            "POST",
+            "https://example.cognitiveservices.azure.com/documentintelligence/documentModels/prebuilt-layout:analyze",
+            headers=request_headers,
+        ),
+    )
+
+    operation_url, poll_headers = AzureDocumentIntelligenceOCRConfig()._get_polling_target(response)
+
+    assert operation_url == "https://example.cognitiveservices.azure.com/operations/123"
+    assert poll_headers == expected_poll_headers

--- a/tests/test_litellm/llms/azure_ai/test_azure_document_intelligence_ocr_transformation.py
+++ b/tests/test_litellm/llms/azure_ai/test_azure_document_intelligence_ocr_transformation.py
@@ -386,7 +386,9 @@ def test_validate_environment_falls_back_to_entra_token(monkeypatch):
         ),
     ),
 )
-def test_get_polling_target_preserves_request_authentication(request_headers, expected_poll_headers):
+def test_get_polling_target_preserves_request_authentication(
+    request_headers: dict[str, str], expected_poll_headers: dict[str, str]
+):
     response = httpx.Response(
         status_code=202,
         headers={"Operation-Location": "https://example.cognitiveservices.azure.com/operations/123"},


### PR DESCRIPTION
## TLDR

Problem this solves:

- Regression from #32018 drops Entra polling authentication

How it solves it:

- Forward accepted request authentication to polling calls
- Cover subscription-key and Entra header forwarding

## User Flow

Before: a developer uses Entra authentication for document OCR and the accepted analysis fails while LiteLLM polls for its result

1. They call `litellm.ocr()` with `azure_ai/doc-intelligence/prebuilt-layout`, an Entra token, and a document URL
2. Azure accepts the analysis request with `202 Accepted`
3. LiteLLM polls without the bearer token and returns `Unknown operation status: None`

After: the same Entra-authenticated OCR call returns its completed document analysis

1. They call `litellm.ocr()` with `azure_ai/doc-intelligence/prebuilt-layout`, an Entra token, and a document URL
2. Azure accepts the analysis request with `202 Accepted`
3. LiteLLM forwards the bearer token while polling and returns the completed OCR response

## Relevant issues

Regression from #32018

## Linear ticket


## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

### Before (096984bfc2)

1. Call `litellm.ocr()` against Azure Document Intelligence with an Azure CLI Entra bearer token and a public PDF
2. The analysis request returns `202 Accepted`, but polling fails with `Unknown operation status: None`

### After (40a01e5d69)

1. Run `PYTHONPATH="$PWD" /Users/yujonglee/dev/litellm/.venv/bin/python -m pytest tests/test_litellm/llms/azure_ai/test_azure_document_intelligence_ocr_transformation.py -q`
2. Output: `34 passed in 0.24s`
3. Call `litellm.ocr()` against Azure Document Intelligence with the same Azure CLI Entra bearer token and public PDF
4. Output: `POST Azure Document Intelligence OCR via Entra: model=doc-intelligence/prebuilt-layout, pages=2`

## Type

🐛 Bug Fix

## Caveats (if any)


## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
