### PR TITLE
fix(vertex_ai): stop grafting batch storage and job urls onto the deployment api_base

### DIFF
--- a/litellm/llms/vertex_ai/batches/handler.py
+++ b/litellm/llms/vertex_ai/batches/handler.py
@@ -72,6 +72,19 @@ class _VertexEndpointPayloadView(TypedDict):
     payload: ReadOnly[_VertexEndpointResponse]
 
 
+def _gateway_api_base_or_none(api_base: str | None) -> str | None:
+    """
+    A deployment `api_base` whose path names a concrete Vertex resource (contains `/projects/`,
+    e.g. the `.../endpoints/<id>:rawPredict` url configured for online inference) is not a Vertex
+    API gateway; grafting `batchPredictionJobs` or resource-GET paths onto it can only produce
+    urls Google answers with an HTML 404 (LIT-7386). Batch operations ignore it and use the real
+    Vertex host; only a host-level or `/v1`-style gateway mount passes through.
+    """
+    if api_base and "/projects/" in urlparse(api_base).path:
+        return None
+    return api_base
+
+
 def _vertex_batch_payload(response: _VertexBatchJsonSource) -> VertexBatchPredictionResponse:
     return response.json()
 
@@ -126,11 +139,12 @@ class VertexAIBatchPrediction(VertexLLM):
                 vertex_location=vertex_location or "us-central1",
             )
         )
+        gateway_api_base: Final = _gateway_api_base_or_none(api_base)
         vertex_batch_request: Final = self._resolve_fine_tuned_endpoint_model(
             vertex_batch_request=transformed_batch_request,
             headers=headers,
             sync_handler=sync_handler,
-            api_base=api_base,
+            api_base=gateway_api_base,
             vertex_location=vertex_location or "us-central1",
         )
 
@@ -145,7 +159,7 @@ class VertexAIBatchPrediction(VertexLLM):
             endpoint = ""
 
         _, api_base = self._check_custom_proxy(
-            api_base=api_base,
+            api_base=gateway_api_base,
             custom_llm_provider="vertex_ai",
             gemini_api_key=None,
             endpoint=endpoint,
@@ -325,7 +339,7 @@ class VertexAIBatchPrediction(VertexLLM):
             endpoint = ""
 
         _, api_base = self._check_custom_proxy(
-            api_base=api_base,
+            api_base=_gateway_api_base_or_none(api_base),
             custom_llm_provider="vertex_ai",
             gemini_api_key=None,
             endpoint=endpoint,
@@ -481,7 +495,7 @@ class VertexAIBatchPrediction(VertexLLM):
             endpoint = ""
 
         _, api_base = self._check_custom_proxy(
-            api_base=api_base,
+            api_base=_gateway_api_base_or_none(api_base),
             custom_llm_provider="vertex_ai",
             gemini_api_key=None,
             endpoint=endpoint,
@@ -579,7 +593,7 @@ class VertexAIBatchPrediction(VertexLLM):
         cancel_api_base_default: Final = f"{retrieve_api_base_default}:cancel"
 
         _, api_base = self._check_custom_proxy(
-            api_base=api_base,
+            api_base=_gateway_api_base_or_none(api_base),
             custom_llm_provider="vertex_ai",
             gemini_api_key=None,
             endpoint="cancel",

--- a/litellm/llms/vertex_ai/files/transformation.py
+++ b/litellm/llms/vertex_ai/files/transformation.py
@@ -809,11 +809,7 @@ class VertexAIFilesConfig(VertexBase, BaseFilesConfig):
             object_name = f"{object_prefix}/{object_name}"
         encoded_object_name: Final = encode_gcs_object_name_for_url(object_name)
         endpoint: Final = f"upload/storage/v1/b/{bucket_name}/o?uploadType=media&name={encoded_object_name}"
-        api_base = api_base or "https://storage.googleapis.com"
-        if not api_base:
-            raise ValueError("api_base is required")
-
-        return f"{api_base}/{endpoint}"
+        return f"https://storage.googleapis.com/{endpoint}"
 
     def get_supported_openai_params(self, model: str) -> list[OpenAICreateFileRequestOptionalParams]:
         return []

--- a/tests/test_litellm/llms/vertex_ai/batches/test_handler.py
+++ b/tests/test_litellm/llms/vertex_ai/batches/test_handler.py
@@ -257,6 +257,45 @@ def test_create_batch_sync_resolves_fine_tuned_endpoint_to_tuned_model():
     assert sent["model"] == TUNED_MODEL_RESOURCE
 
 
+def test_create_batch_sync_ignores_resource_shaped_api_base():
+    """A deployment api_base like `.../endpoints/<id>:rawPredict` targets online inference, not
+    the Vertex API root; grafting batch urls onto it yields guaranteed 404s, so batch operations
+    must fall back to the default Vertex host (LIT-7386)."""
+    h = _make_handler()
+    client = MagicMock()
+    client.post.return_value = _http_response()
+    raw_predict_api_base = (
+        f"https://{LOCATION}-aiplatform.googleapis.com/v1/projects/{PROJECT}"
+        f"/locations/{LOCATION}/endpoints/{ENDPOINT_ID}:rawPredict"
+    )
+
+    with (
+        patch(f"{HMOD}._get_httpx_client", return_value=client),
+        patch(f"{HMOD}.safe_get", return_value=_endpoint_get_response()) as safe_get,
+    ):
+        out = h.create_batch(
+            _is_async=False,
+            create_batch_data=ENDPOINT_CREATE_DATA,
+            api_base=raw_predict_api_base,
+            vertex_credentials=None,
+            vertex_project=PROJECT,
+            vertex_location=LOCATION,
+            timeout=600.0,
+            max_retries=None,
+        )
+
+    assert isinstance(out, LiteLLMBatch)
+    resolution_url = safe_get.call_args.args[1]
+    assert ":rawPredict" not in resolution_url
+    assert resolution_url == (
+        f"https://{LOCATION}-aiplatform.googleapis.com/v1/projects/{PROJECT}"
+        f"/locations/{LOCATION}/endpoints/{ENDPOINT_ID}"
+    )
+    assert h._check_custom_proxy.call_args.kwargs["api_base"] is None
+    sent = json.loads(client.post.call_args.kwargs["data"])
+    assert sent["model"] == TUNED_MODEL_RESOURCE
+
+
 @pytest.mark.parametrize(
     "api_base, expected",
     [

--- a/tests/test_litellm/llms/vertex_ai/files/test_vertex_ai_files_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/files/test_vertex_ai_files_transformation.py
@@ -158,6 +158,32 @@ class TestCreateFileUrl:
         assert ".." not in object_name
         assert "?" not in object_name
 
+    def test_should_upload_to_gcs_host_even_when_deployment_sets_api_base(self, config):
+        """The deployment api_base points at the inference endpoint (often a full
+        `.../endpoints/<id>:rawPredict` URL); grafting the GCS upload onto it produces a
+        guaranteed 404 from Google, so the storage host must stay storage.googleapis.com
+        (LIT-7386)."""
+        url = config.get_complete_file_url(
+            api_base=(
+                "https://us-central1-aiplatform.googleapis.com/v1/projects/my-project"
+                "/locations/us-central1/endpoints/6335039103326748672:rawPredict"
+            ),
+            api_key=None,
+            model="",
+            optional_params={},
+            litellm_params={
+                "gcs_bucket_name": "my-bucket",
+                "model": "vertex_ai/gemini/6335039103326748672",
+            },
+            data={
+                "file": ("batch.jsonl", b'{"body": {"model": "gemini-2.5-flash"}}', "application/jsonl"),
+                "purpose": "batch",
+            },
+        )
+        assert url.startswith("https://storage.googleapis.com/upload/storage/v1/b/my-bucket/o?")
+        assert "aiplatform" not in url
+        assert "rawPredict" not in url
+
 
 class TestBatchObjectNaming:
     def test_should_store_publisher_model_under_publishers_path(self, config):


### PR DESCRIPTION
## TLDR

Problem this solves:

- A deployment api_base (e.g. `.../endpoints/{id}:rawPredict`) hijacked the batch GCS upload host
- Batch create/retrieve/list/cancel grafted job paths onto that same api_base
- Both produced Google's HTML "404. That's an error." page

How it solves it:

- Batch file uploads always target storage.googleapis.com
- Batch operations ignore a resource-shaped api_base (path contains `/projects/`)
- Host-level and `/v1` gateway mounts still pass through

## User Flow

Before: a team whose fine-tuned Gemini deployment carries the endpoint's rawPredict url as api_base (the shape their online chat calls use) cannot run batches at all

1. The admin configures a deployment with model `vertex_ai/gemini/{endpoint_id}` and `api_base: https://{location}-aiplatform.googleapis.com/v1/projects/{project}/locations/{location}/endpoints/{endpoint_id}:rawPredict`
2. Online chat on that deployment works fine
3. A developer sends POST https://litellm-domain/v1/files with `purpose=batch` targeting it and gets back Google's raw HTML "404. That's an error." page
4. No file id, no batch; the only workaround is removing api_base from the deployment

After: the same deployment, api_base untouched, runs batches end to end

1. The admin configures the same deployment with the same rawPredict api_base
2. Online chat still works through the api_base, unchanged
3. The developer sends the same POST https://litellm-domain/v1/files and gets a file id back
4. POST https://litellm-domain/v1/batches with that file id returns a batch id, and the Vertex console shows the job targeting their tuned model resource
5. GET https://litellm-domain/v1/batches/{batch_id} reports the job status instead of an HTML 404

## Relevant issues

## Linear ticket

Resolves LIT-7386

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Live run against a real Vertex project with a fine-tuned Gemini 2.5 Flash endpoint, real batch spend. Same config on both sides, fresh from-source proxy per side, same 2-line JSONL. The deployment under test:

```yaml
  - model_name: gemini-tuned-rawpredict
    litellm_params:
      model: vertex_ai/gemini/{endpoint_id}
      api_base: https://{location}-aiplatform.googleapis.com/v1/projects/{project}/locations/{location}/endpoints/{endpoint_id}:rawPredict
      vertex_project: {project}
      vertex_location: {location}
      gcs_bucket_name: {bucket}
    model_info:
      input_cost_per_token_batches: 0.00000015
      output_cost_per_token_batches: 0.0000012
```

### Before (1183b2abc6, the merge base)

#### Batch upload on the rawPredict-api_base deployment

1. `curl -X POST http://localhost:4012/v1/files -H "Authorization: Bearer $KEY" -F purpose=batch -F target_model_names=gemini-tuned-rawpredict -F file=@batch_input.jsonl`
2. Google's HTML error page comes back with code 404, quoting the grafted url: `/v1/projects/{project}/locations/{location}/endpoints/{endpoint_id}:rawPredict/upload/storage/v1/b/{bucket}/o?uploadType=media&...`

#### Batch retrieve on the same deployment

1. `curl http://localhost:4012/v1/batches/{batch_id} -H "Authorization: Bearer $KEY"` (batch created by the After side)
2. `{"error": {"message": "Error: 404 <!DOCTYPE html>...", "code": "404"}}`: the job GET was grafted the same way

### After (697da95bf4)

#### Batch upload on the rawPredict-api_base deployment

1. Same curl as Before against the fixed proxy
2. `{"status": "uploaded", "filename": "litellm-vertex-files/endpoints/{endpoint_id}/..."}`

#### Batch create and retrieve on the same deployment

1. `curl -X POST http://localhost:4011/v1/batches -H "Authorization: Bearer $KEY" -d '{"input_file_id": "{file_id}", "endpoint": "/v1/chat/completions", "completion_window": "24h", "model": "gemini-tuned-rawpredict"}'`
2. `{"status": "validating", ...}`; the Vertex job shows `"model": "projects/{project_number}/locations/{location}/models/{tuned_model_id}"` and runs
3. `curl http://localhost:4011/v1/batches/{batch_id}` returns `{"status": "in_progress"}`

#### Publisher control (no api_base)

1. Same upload against a plain `vertex_ai/gemini-2.5-flash` deployment
2. `{"status": "uploaded", "filename": "litellm-vertex-files/publishers/google/models/gemini-2.5-flash/..."}`: unchanged

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- A host-only or `/v1`-path api_base (a true gateway mount) still passes through to batch urls, preserving the cloudflare-ai-gateway use case; only an api_base whose path contains `/projects/` is ignored
- Online inference through the api_base is untouched; the filter applies only to file uploads and batch operations

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
