### PR TITLE
fix(s3): replace colons in generated log filenames

### DIFF
--- a/litellm/integrations/s3.py
+++ b/litellm/integrations/s3.py
@@ -250,7 +250,7 @@ def get_s3_object_key(
     start_time: datetime,
     s3_file_name: str,
 ) -> str:
-    sanitized_s3_file_name: Final = s3_file_name.replace("/", "_")
+    sanitized_s3_file_name: Final = s3_file_name.replace("/", "_").replace(":", "_")
     configured_prefix: Final = (s3_path.rstrip("/") + "/" if s3_path else "") + prefix
     date_segment: Final = start_time.strftime("%Y-%m-%d") + "/"
     # we need the s3 key to include the time, so we log cache hits too

--- a/tests/test_litellm/integrations/test_s3_v2.py
+++ b/tests/test_litellm/integrations/test_s3_v2.py
@@ -1129,9 +1129,11 @@ async def test_combined_prefix_reflects_in_s3_object_key():
     assert "myteam/apikey/" in key, f"Expected both prefixes in key: {key}"
 
 
-def test_s3_object_key_sanitizes_slashes_in_file_name():
+def test_s3_object_key_sanitizes_slashes_and_colons_in_file_name():
     """Response ids containing slashes (e.g. bedrock batch job ARNs) must not
-    create nested S3 folders; only path/prefix/date slashes are separators."""
+    create nested S3 folders, and colons must not survive into the filename:
+    Hadoop-style consumers reject a colon in the first segment of a relative
+    URI path (https://github.com/BerriAI/litellm/issues/40234)."""
     from litellm.integrations.s3 import get_s3_object_key
 
     start_time = datetime(2026, 2, 11, 0, 35, 18, 391582)
@@ -1146,8 +1148,32 @@ def test_s3_object_key_sanitizes_slashes_in_file_name():
 
     assert key == (
         "LiteLLMAPPLogs/myteam/2026-02-11/"
-        "time-00-35-18-391582_arn:aws:bedrock:us-east-1:123456789012:model-invocation-job_gl18r6skk9yy.json"
+        "time-00-35-18-391582_arn_aws_bedrock_us-east-1_123456789012_model-invocation-job_gl18r6skk9yy.json"
     )
+
+
+@pytest.mark.parametrize(
+    "response_id",
+    [
+        "s3://example-batch-bucket/litellm-bedrock-files/input.jsonl",
+        "gs://example-batch-bucket/litellm-vertex-files/input.jsonl",
+    ],
+)
+def test_s3_object_key_has_no_colon_for_cloud_uri_file_ids(response_id: str):
+    """Bedrock and Vertex batch file uploads use s3:// and gs:// URIs as
+    response ids; the generated log filename must be colon-free."""
+    from litellm.integrations.s3 import get_s3_object_key
+
+    key = get_s3_object_key(
+        s3_path="",
+        prefix="",
+        start_time=datetime(2026, 9, 7, 4, 51, 6, 685889),
+        s3_file_name=f"time-04-51-06-685889_{response_id}",
+    )
+
+    filename = key.rsplit("/", 1)[-1]
+    assert ":" not in filename
+    assert filename.endswith("_input.jsonl.json")
 
 
 def test_create_s3_batch_logging_element_flat_key_for_arn_response_id():

--- a/tests/test_litellm/integrations/test_s3_v2.py
+++ b/tests/test_litellm/integrations/test_s3_v2.py
@@ -1130,10 +1130,6 @@ async def test_combined_prefix_reflects_in_s3_object_key():
 
 
 def test_s3_object_key_sanitizes_slashes_and_colons_in_file_name():
-    """Response ids containing slashes (e.g. bedrock batch job ARNs) must not
-    create nested S3 folders, and colons must not survive into the filename:
-    Hadoop-style consumers reject a colon in the first segment of a relative
-    URI path (https://github.com/BerriAI/litellm/issues/40234)."""
     from litellm.integrations.s3 import get_s3_object_key
 
     start_time = datetime(2026, 2, 11, 0, 35, 18, 391582)
@@ -1160,8 +1156,6 @@ def test_s3_object_key_sanitizes_slashes_and_colons_in_file_name():
     ],
 )
 def test_s3_object_key_has_no_colon_for_cloud_uri_file_ids(response_id: str):
-    """Bedrock and Vertex batch file uploads use s3:// and gs:// URIs as
-    response ids; the generated log filename must be colon-free."""
     from litellm.integrations.s3 import get_s3_object_key
 
     key = get_s3_object_key(


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bedrock/Vertex batch file ids are s3:// and gs:// URIs
- S3 request-log filenames kept the scheme colon
- Hadoop-style readers reject those keys as absolute URIs

How it solves it:

- The shared filename sanitizer now replaces ":" with "_"
- Provider ids and payloads are untouched, only the log key changes

## User Flow

Before: a platform team ingesting LiteLLM S3 request logs into Databricks sees the ingest job crash on batch upload logs

1. They send POST http://localhost:4000/v1/files with `purpose=batch` and `custom_llm_provider=bedrock`, and get back an id like `s3://their-bucket/litellm-bedrock-files-....jsonl`
2. The request log lands in their logging bucket as `request-logs/2026-09-09/time-..._s3:__their-bucket_litellm-bedrock-files-....jsonl.json`
3. Their Databricks job reads that directory and dies with `java.net.URISyntaxException: Relative path in absolute URI`

After: the same upload logs a colon-free filename and the ingest job reads it fine

1. They send the same POST http://localhost:4000/v1/files with `purpose=batch` and `custom_llm_provider=bedrock`, and get back the same `s3://...` id
2. The request log lands as `request-logs/2026-09-09/time-..._s3___their-bucket_litellm-bedrock-files-....jsonl.json`
3. Their Databricks job reads the directory without errors

## Relevant issues

Fixes #40234

## Linear ticket

Resolves LIT-7415

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Setup: proxy run from source on port 4010 with `files_settings` pointing bedrock uploads at a real S3 bucket (`litellm-issue-40234-proof`, us-east-1) and the `s3_v2` callback logging into the same bucket under `request-logs`. Upload payload:

```
printf '{"custom_id": "req-1", "method": "POST", "url": "/v1/chat/completions", "body": {"model": "anthropic.claude-3-5-sonnet-20240620-v1:0", "messages": [{"role": "user", "content": "hi"}], "max_tokens": 10}}\n' > /tmp/batch_input.jsonl
```

### Before (f529d6d6bd)

1. `curl -s http://localhost:4010/v1/files -H "Authorization: Bearer sk-1234" -F purpose=batch -F custom_llm_provider=bedrock -F file=@/tmp/batch_input.jsonl`
2. Response: `{"id":"s3://litellm-issue-40234-proof/litellm-bedrock-files-anthropic.claude-3-5-sonnet-20240620-v1-0-193e30dc-....jsonl", "purpose":"batch", "status":"uploaded", ...}`
3. `aws s3 ls s3://litellm-issue-40234-proof/request-logs/ --recursive`
4. Output shows the colon retained in the logged key:

```
2026-09-09 16:32:44  3786 request-logs/2026-09-09/time-16-32-41-360976_s3:__litellm-issue-40234-proof_litellm-bedrock-files-anthropic.claude-3-5-sonnet-20240620-v1-0-193e30dc-b00d-4980-9587-f9d078fb601b.jsonl.json
```

### After (d3374c8a86)

1. Same curl: `curl -s http://localhost:4010/v1/files -H "Authorization: Bearer sk-1234" -F purpose=batch -F custom_llm_provider=bedrock -F file=@/tmp/batch_input.jsonl`
2. Response id is still the untouched provider URI: `{"id":"s3://litellm-issue-40234-proof/litellm-bedrock-files-anthropic.claude-3-5-sonnet-20240620-v1-0-2d2b290a-....jsonl", "purpose":"batch", "status":"uploaded", ...}`
3. `aws s3 ls s3://litellm-issue-40234-proof/request-logs/ --recursive`
4. Output shows the new upload's key is colon-free:

```
2026-09-09 16:44:18  3786 request-logs/2026-09-09/time-16-44-09-206378_s3___litellm-issue-40234-proof_litellm-bedrock-files-anthropic.claude-3-5-sonnet-20240620-v1-0-2d2b290a-dac5-4690-8f49-d8c202f4ae50.jsonl.json
```

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Historical log objects keep their colon-bearing keys; reads by stored key still work

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
