### PR TITLE
fix(mcp): challenge and scope gateway-owned server authentication

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
+++ b/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
@@ -179,16 +179,7 @@ def _gateway_dcr_challenge_target(
     mcp_servers: list[str] | None,
     client_ip: str | None,
 ) -> str | None:
-    """The single path-named server this request targets, iff it resolves to a
-    gateway-managed oauth2 server — the one per-server shape the gateway's own keyless
-    DCR flow serves end to end, so the 401 challenge may advertise the per-server
-    protected-resource metadata (whose ``authorization_servers`` names the gateway).
-
-    Multi-server CSV paths, header/path mismatches, unknown names, and every
-    client-forwarded or delegated mode return ``None``: those cells keep their existing
-    challenge (or absence of one), and a challenge is never emitted for a name the
-    public discovery routes would 404, so this reveals exactly the server set the
-    per-server protected-resource metadata already reveals."""
+    """Resolve a single path target whose sign-in metadata advertises the gateway."""
     from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
         global_mcp_server_manager,
     )
@@ -217,7 +208,7 @@ def _is_gateway_dcr_challenge_scope(
     the caller is not a cold-start DCR client), on the scopes the gateway's keyless
     flow serves: the aggregate ``/mcp`` endpoint, an ``x-mcp-servers``-scoped request
     (the resource the client configured is still ``/mcp``), or a per-server path whose
-    single target is a gateway-managed oauth2 server. Every other named target keeps
+    single target advertises gateway-owned sign-in. Every other named target keeps
     its existing behavior, failing closed to the original admission error."""
     if not _is_litellm_auth_admission_error(exc):
         return False
@@ -236,7 +227,7 @@ def _gateway_dcr_challenge(
 ) -> HTTPException:
     """The RFC 9728 challenge pointing the client at the protected-resource metadata
     matching the scope it requested: the per-server document (same URL spelling the
-    request arrived on) when the single target is a gateway-managed oauth2 server,
+    request arrived on) when the single target advertises gateway-owned sign-in,
     else the gateway's aggregate document. Either way the client discovers the gateway
     as its authorization server and starts the same sign-in flow.
 

--- a/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
@@ -2310,8 +2310,7 @@ async def _build_oauth_protected_resource_response(
     it. Only the legacy ``is_oauth_passthrough`` opt-in rewrites ``resource`` to
     the gateway's own URL so clients present the bearer token back to the gateway.
 
-    An explicitly named gateway-managed oauth2 server (interactive with
-    gateway-vaulted per-user tokens, or M2M) advertises the gateway's own
+    An explicitly named server with gateway-owned sign-in advertises the gateway's own
     authorization server (``{base}/mcp``): a keyless DCR client that configured the
     per-server URL completes the same sign-in flow the aggregate ``/mcp`` endpoint
     supports and is admitted with a gateway session bearer. The per-server relay
@@ -2401,17 +2400,15 @@ async def _build_oauth_protected_resource_response(
     if obo_response is not None:
         return obo_response
 
-    # An OBO server with no configured issuer falls through to the gateway default so discovery still
-    # returns metadata; every other non-oauth2 named server 404s to avoid enumeration.
-    if mcp_server is None or mcp_server.auth_type != MCPAuth.oauth2_token_exchange:
-        _raise_unless_oauth2_discovery_server(mcp_server, mcp_server_name, "not an OAuth-protected resource")
-
     if explicitly_named and mcp_server is not None and mcp_server.advertises_gateway_authorization_server:
         return {
             "authorization_servers": [f"{request_base_url}/mcp"],
             "resource": resource_url,
             "scopes_supported": (mcp_server.scopes if mcp_server.scopes else []),
         }
+
+    if mcp_server is None or mcp_server.auth_type != MCPAuth.oauth2_token_exchange:
+        _raise_unless_oauth2_discovery_server(mcp_server, mcp_server_name, "not an OAuth-protected resource")
 
     return {
         "authorization_servers": [

--- a/litellm/proxy/_experimental/mcp_server/gateway_dcr_flow.py
+++ b/litellm/proxy/_experimental/mcp_server/gateway_dcr_flow.py
@@ -411,7 +411,7 @@ def relative_request_url(request: Request) -> str:
 
 
 def resolve_scoped_resource_server(request: Request, resource: str | None) -> MCPServer | None:
-    """Resolve an RFC 8707 ``resource`` value to the single gateway-managed oauth2 server it
+    """Resolve an RFC 8707 ``resource`` value to the single gateway-owned server it
     names, or ``None`` for every other shape: absent, the aggregate resource, a foreign
     host, an unparseable value, a multi-server path, an unknown name, or any server mode the
     keyless gateway flow does not serve (whose protected-resource metadata never directs a
@@ -443,7 +443,7 @@ def resolve_scoped_resource_server(request: Request, resource: str | None) -> MC
     if len(names) != 1:
         return None
     server: Final = global_mcp_server_manager.get_mcp_server_by_name(names[0])
-    if server is None or not server.is_gateway_managed_oauth2:
+    if server is None or not (server.is_gateway_managed_oauth2 or server.advertises_gateway_authorization_server):
         return None
     return server
 
@@ -729,11 +729,15 @@ async def _flow_target(
     server: Final = global_mcp_server_manager.get_mcp_server_by_id(flow.resource_server_id)
     if (
         server is None
-        or not server.is_gateway_managed_oauth2
+        or not (server.is_gateway_managed_oauth2 or server.advertises_gateway_authorization_server)
         or not await lookup_server_reachability(flow.user_id, server.server_id)
     ):
         return "stale", None
-    state: Final = "m2m" if MCPServerManager.effective_oauth2_flow(server) == "client_credentials" else "interactive"
+    state: Final = (
+        "interactive"
+        if server.is_gateway_managed_oauth2 and MCPServerManager.effective_oauth2_flow(server) != "client_credentials"
+        else "m2m"
+    )
     return state, server
 
 

--- a/litellm/types/mcp_server/mcp_server_manager.py
+++ b/litellm/types/mcp_server/mcp_server_manager.py
@@ -250,7 +250,23 @@ class MCPServer(BaseModel):
     @property
     def advertises_gateway_authorization_server(self) -> bool:
         """Whether named discovery should advertise the aggregate gateway authorization server."""
-        return self.is_gateway_managed_oauth2 and not self.uses_per_server_oauth_relay
+        if self.auth_type == MCPAuth.oauth2:
+            return self.is_gateway_managed_oauth2 and not self.uses_per_server_oauth_relay
+        if self.auth_type not in (
+            None,
+            MCPAuth.none,
+            MCPAuth.api_key,
+            MCPAuth.bearer_token,
+            MCPAuth.basic,
+            MCPAuth.authorization,
+            MCPAuth.token,
+            MCPAuth.aws_sigv4,
+        ):
+            return False
+        return not any(
+            header.lower() in ("authorization", "x-api-key", "api-key", "apikey")
+            for header in (self.extra_headers or ())
+        )
 
     @property
     def is_true_passthrough(self) -> bool:

--- a/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
@@ -7193,14 +7193,13 @@ class TestAggregateGatewayDcrChallenge:
         www_authenticate = (exc_info.value.headers or {})["WWW-Authenticate"]
         assert www_authenticate == f"Bearer {self._EXPECTED_RESOURCE_METADATA}"
 
-    async def test_per_server_challenge_for_gateway_managed_oauth2(self):
-        """Anonymous request to a per-server path whose single target is a gateway-managed
-        oauth2 server: 401 plus the RFC 9728 challenge advertising the PER-SERVER
-        protected-resource metadata in the same URL spelling the request used, so a keyless
-        DCR client configured with either per-server spelling discovers the gateway as the
-        authorization server (LIT-4864). Covers interactive and M2M, which the gateway can
-        both serve end to end."""
-        from litellm.types.mcp import MCPAuth
+    @pytest.mark.parametrize(
+        "auth_type",
+        (None, "none", "api_key", "bearer_token", "basic", "aws_sigv4", "authorization", "token", "oauth2"),
+    )
+    @pytest.mark.parametrize("bearer_presented", (False, True))
+    async def test_per_server_challenge_for_gateway_owned_auth(self, auth_type, bearer_presented):
+        """Gateway admission challenges are independent of upstream authentication."""
         from litellm.types.mcp_server.mcp_server_manager import MCPServer
 
         server = MCPServer(
@@ -7209,7 +7208,7 @@ class TestAggregateGatewayDcrChallenge:
             server_name="github",
             url="https://upstream.example/mcp",
             transport="http",
-            auth_type=MCPAuth.oauth2,
+            auth_type=auth_type,
         )
         for path, expected_metadata_path in (
             ("/mcp/github", "/.well-known/oauth-protected-resource/mcp/github"),
@@ -7223,10 +7222,16 @@ class TestAggregateGatewayDcrChallenge:
             ):
                 mock_mgr.get_mcp_server_by_name.return_value = server
                 with pytest.raises(HTTPException) as exc_info:
-                    await MCPRequestHandler.process_mcp_request(self._scope(path=path))
+                    await MCPRequestHandler.process_mcp_request(
+                        self._scope(
+                            path=path,
+                            extra_headers=((b"authorization", b"Bearer invalid-key"),) if bearer_presented else (),
+                        )
+                    )
             assert exc_info.value.status_code == 401
             www_authenticate = (exc_info.value.headers or {})["WWW-Authenticate"]
-            assert www_authenticate == f'Bearer resource_metadata="http://testserver{expected_metadata_path}"'
+            error = 'error="invalid_token", ' if bearer_presented else ""
+            assert www_authenticate == f'Bearer {error}resource_metadata="http://testserver{expected_metadata_path}"'
 
     async def test_per_server_challenge_keeps_spelling_under_server_root_path(self):
         """On a sub-path deployment the challenge must still advertise the spelling the client
@@ -7303,10 +7308,7 @@ class TestAggregateGatewayDcrChallenge:
                     )
 
     def test_challenge_target_excludes_every_non_gateway_managed_mode(self):
-        """Unit pin of the challenge-target owner: only a resolved gateway-managed oauth2
-        target (interactive or M2M) yields a per-server challenge; delegate-auth oauth2
-        (whose keyless flow is upstream PKCE via the relay), every client-forwarded auth
-        type, OBO, api_key, unknown names, and CSV paths yield None (LIT-4864)."""
+        """Gateway challenges exclude unresolved, delegated, and client-forwarded targets."""
         from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import (
             _gateway_dcr_challenge_target,
         )
@@ -7333,7 +7335,11 @@ class TestAggregateGatewayDcrChallenge:
             (_server(MCPAuth.true_passthrough), None),
             (_server(MCPAuth.oauth_delegate), None),
             (_server(MCPAuth.oauth_delegate, dcr_bridge=True), None),
-            (_server(MCPAuth.api_key), None),
+            (_server(MCPAuth.api_key), "srv"),
+            (_server(MCPAuth.none, extra_headers=["Authorization"]), None),
+            (_server(None, extra_headers=["X-API-Key"]), None),
+            (_server(MCPAuth.none, extra_headers=["Authorization"], oauth_passthrough=True), None),
+            (_server(MCPAuth.oauth2_id_jag), None),
             (None, None),
         ]
         for resolved, expected in cases:

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
@@ -7651,12 +7651,6 @@ async def test_token_endpoint_client_secret_basic_without_secret_returns_400():
     assert exc_info.value.status_code == 400
 
 
-# -------------------------------------------------------------------
-# Non-oauth2 (auth_type=none, access-group gated) servers must not be
-# driven through the gateway OAuth authorize/token/register/discovery
-# flow, and must not be advertised as OAuth-protected in discovery docs.
-# -------------------------------------------------------------------
-
 
 def _access_group_none_server(server_name="access_group_server"):
     """A non-oauth2, access-group gated MCP server: no client_id, no OAuth."""
@@ -7794,35 +7788,38 @@ async def test_register_client_rejects_non_oauth2_server():
 
 
 @pytest.mark.asyncio
-async def test_oauth_protected_resource_404_for_non_oauth2_server():
-    """Discovery must not advertise a none-auth server as an OAuth-protected resource."""
-    try:
-        from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
-            _build_oauth_protected_resource_response,
-        )
-        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
-            global_mcp_server_manager,
-        )
-    except ImportError:
-        pytest.skip("MCP discoverable endpoints not available")
+@pytest.mark.parametrize(
+    "auth_type", (None, "none", "api_key", "bearer_token", "basic", "aws_sigv4", "authorization", "token")
+)
+@pytest.mark.parametrize("use_standard_pattern", (False, True))
+async def test_oauth_protected_resource_for_gateway_owned_auth(auth_type, use_standard_pattern):
+    from starlette.requests import Request
 
+    from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+        _build_oauth_protected_resource_response,
+    )
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        global_mcp_server_manager,
+    )
+
+    server = _access_group_none_server().model_copy(update={"auth_type": auth_type})
+    request = Request(
+        {"type": "http", "scheme": "https", "path": "/", "headers": [(b"host", b"litellm.example.com")]}
+    )
     global_mcp_server_manager.registry.clear()
-    server = _access_group_none_server()
     global_mcp_server_manager.registry[server.server_id] = server
-
-    mock_request = MagicMock()
-    mock_request.base_url = "https://litellm.example.com/"
-    mock_request.headers = {}
-
     try:
-        with pytest.raises(HTTPException) as exc_info:
-            await _build_oauth_protected_resource_response(
-                request=mock_request,
-                mcp_server_name="access_group_server",
-                use_standard_pattern=False,
-            )
-        assert exc_info.value.status_code == 404
-        assert "not an OAuth-protected resource" in str(exc_info.value.detail)
+        response = await _build_oauth_protected_resource_response(
+            request=request,
+            mcp_server_name="access_group_server",
+            use_standard_pattern=use_standard_pattern,
+        )
+        resource_path = "/mcp/access_group_server" if use_standard_pattern else "/access_group_server/mcp"
+        assert response == {
+            "resource": f"https://litellm.example.com{resource_path}",
+            "authorization_servers": ["https://litellm.example.com/mcp"],
+            "scopes_supported": [],
+        }
     finally:
         global_mcp_server_manager.registry.clear()
 
@@ -7914,9 +7911,7 @@ async def test_oauth_protected_resource_passthrough_none_auth_not_404():
 
 @pytest.mark.asyncio
 async def test_oauth_protected_resource_404_for_unknown_server_name():
-    """A discovery request for an unknown server name returns the same 404 as a non-oauth2
-    server (not a 200 metadata doc with broken URLs), so the well-known paths cannot be used
-    to enumerate non-OAuth server names."""
+    """Unknown server names must not produce metadata advertising nonexistent resources."""
     try:
         from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
             _build_oauth_protected_resource_response,

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_gateway_dcr_flow.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_gateway_dcr_flow.py
@@ -833,7 +833,7 @@ async def test_manual_delivery_page_renders_the_url_as_data_never_as_a_shell_com
     assert 'value="' in body
 
 
-def _scoped_mcp_server(name="github", **kw):
+def _scoped_mcp_server(name="github", auth_type="oauth2", **kw):
     from litellm.types.mcp import MCPAuth
     from litellm.types.mcp_server.mcp_server_manager import MCPServer
 
@@ -844,7 +844,7 @@ def _scoped_mcp_server(name="github", **kw):
         alias=name,
         url="https://upstream.example/mcp",
         transport="http",
-        auth_type=MCPAuth.oauth2,
+        auth_type=MCPAuth(auth_type) if auth_type is not None else None,
         **kw,
     )
 
@@ -2044,3 +2044,45 @@ async def test_introspect_fails_closed_on_dead_user_and_503s_on_outage():
 
     status, body = await _introspect(minted.token.get_secret_value(), master_key=None)
     assert (status, body["error"]) == (500, "server_error")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "auth_type", [None, "none", "api_key", "bearer_token", "basic", "authorization", "token", "aws_sigv4"]
+)
+@pytest.mark.parametrize("resource", ["https://llm.example.com/mcp/github", "https://llm.example.com/github/mcp"])
+async def test_gateway_owned_resource_stays_scoped_through_consent_and_refresh(auth_type, resource):
+    from unittest.mock import patch
+
+    client_id = (await _register([REDIRECT_URI]))["client_id"]
+    server = _scoped_mcp_server(auth_type=auth_type)
+    vendor = _VendorCredential("absent")
+    with patch(_MANAGER_PATCH) as manager:
+        manager.get_mcp_server_by_name.return_value = server
+        response = _scoped_authorize(client_id, resource)
+    described = await _describe_page(response, scoped_server=server, vendor=vendor)
+    assert json.loads(described.body) == {
+        "state": "m2m",
+        "client_origin": "https://claude.ai",
+        "server_id": "github-id",
+        "server_name": "github",
+        "connected": True,
+    }
+    unreachable = await _complete_page(response, scoped_server=server, reachable=_ServerReachability(False))
+    assert unreachable.status_code == 400
+    cache = DualCache()
+    completed = await _complete_page(response, scoped_server=server, vendor=vendor, cache=cache)
+    assert completed.status_code == 303
+    assert vendor.calls == []
+    code = parse_qs(urlparse(completed.headers["location"]).query)["code"][0]
+    with patch(_MANAGER_PATCH) as manager:
+        manager.get_mcp_server_by_name.return_value = server
+        redeemed = await _redeem(code, client_id, cache=cache, resource=resource)
+    assert redeemed.status_code == 200
+    payload = json.loads(redeemed.body)
+    assert _opened_principal(payload).resource_server_id == "github-id"
+    renewed = await _redeem(
+        None, client_id, cache=cache, grant_type="refresh_token", refresh_token=payload["refresh_token"]
+    )
+    assert renewed.status_code == 200
+    assert _opened_principal(json.loads(renewed.body)).resource_server_id == "github-id"


### PR DESCRIPTION
## TLDR

Problem this solves:

- Gateway-owned MCP endpoints omit authentication challenges and discovery metadata
- Newly advertised modes lose the requested server's authorization scope

How it solves it:

- Share eligibility for gateway challenges and protected-resource metadata
- Preserve named-server scope through consent, tokens, and refresh
- Keep delegated and client-forwarded authentication behavior unchanged

## User Flow

Before: a client cannot discover gateway sign-in for a named no-auth MCP server

1. POST an unauthenticated initialization to `/aws_knowledge_mcp/mcp` or `/mcp/aws_knowledge_mcp`
2. Receive `401` without `WWW-Authenticate`
3. GET the matching protected-resource metadata and receive `404`; sign-in stops

After: the client discovers sign-in and grants access to only the requested server

1. POST the same unauthenticated initialization to either URL format
2. Receive `401` with `WWW-Authenticate` pointing to matching protected-resource metadata
3. GET that metadata and receive `200`, identifying the resource and gateway authorization server
4. Complete registration, sign-in, consent for that server, and S256 PKCE token exchange
5. List tools and make a real tool call on that server
6. Attempt to list or call another server using the access token or a refreshed token; receive an MCP authorization error even when the user can access both servers

## Relevant issues

LIT-6634 tracks the separate root-metadata fallback defect

## Linear ticket

Resolves LIT-6635

https://linear.app/litellm-ai/issue/LIT-6635

## Pre-Submission checklist

- [x] Meaningful mapped regression tests added
- [x] Affected backend tests and applicable local lint/budget gates pass
- [ ] Required CI passes on the new commit
- [x] Scope remains limited to gateway-owned MCP authentication
- [ ] Greptile confidence at least 4/5 on the new commit
- [ ] Bugbot has no outstanding findings on the new commit
- [ ] Veria confirms zero unresolved concerns on the new commit
- [x] Contributor previously confirmed signing the CLA

Local affected-suite result: `897 passed, 10 warnings in 75.58s (0:01:15)`

The 16 new scope cases fail against the preceding PR tip and pass with this fix. They exercise both URL formats across None/none, API key, bearer, basic, authorization, token, and SigV4 modes. They verify scoped consent, rejection when the server becomes inaccessible, no unnecessary per-user vendor authorization, and scope preservation through token redemption and refresh

<details>
<summary>Test command and local gate results</summary>

```bash
python -m pytest tests/test_litellm/proxy/_experimental/mcp_server/test_gateway_dcr_flow.py tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py -q --tb=short
```

```text
897 passed, 10 warnings in 75.58s (0:01:15)
2 files already formatted
All checks passed!
All checks passed!
OK: every strict rule is within its codebase ceiling (base f529d6d6bd8f9bdc3177caf319446bf5a07b304a)
OK: every LIT rule is within its codebase ceiling (base f529d6d6bd8f9bdc3177caf319446bf5a07b304a)
OK: every TQ rule is within its test-suite ceiling (base f529d6d6bd8f9bdc3177caf319446bf5a07b304a)

OK: every rule is within its basedpyright limit or no higher than base (137951 errors total)
```

The first combined test run was killed with exit 137 during the Docker build. The complete successful run above was repeated after the build finished. No budgets or suppressions were changed

</details>

## Screenshots / Proof of Fix

Isolated Docker Compose gateway at `http://127.0.0.1:46635`, private PostgreSQL, the real public AWS Knowledge MCP, and a running MCP SDK server enforcing a gateway-held bearer. Both runtime images were built from clean commit archives with the repository Dockerfile. All four changed installed production files match the current commit by SHA-256. No LLM calls are needed for these MCP tools

Save these reproducible scripts/configs together. All shown credentials are disposable local-only values; session tokens are withheld from published traces. Build the images from the named commits, then run `LIT6635_IMAGE=<image-tag> docker compose up -d --no-build`. Tags used: `litellm-6635:f529d6d6bd` and `litellm-6635:scope-fixed`

<details>
<summary>config.yaml</summary>

```yaml
model_list: []
mcp_servers:
  aws_knowledge_mcp:
    url: https://knowledge-mcp.global.api.aws
    transport: http
    auth_type: none
  credential_mcp:
    url: http://upstream:8000/mcp
    transport: http
    auth_type: bearer_token
    authentication_token: upstream-only-lit6635
general_settings:
  master_key: os.environ/LITELLM_MASTER_KEY

```

</details>

<details>
<summary>compose.yaml</summary>

```yaml
name: litellm-6635-acceptance
services:
  gateway:
    image: ${LIT6635_IMAGE:-litellm-6635:f529d6d6bd}
    entrypoint: ["/app/docker/prod_entrypoint.sh"]
    ports:
      - "127.0.0.1:46635:4000"
    volumes:
      - ./config.yaml:/app/config.yaml:ro
    command: ["--config", "/app/config.yaml", "--port", "4000"]
    environment:
      DATABASE_URL: postgresql://lit6635:local6635@db:5432/lit6635
      LITELLM_MASTER_KEY: sk-local-lit6635-verification
      LITELLM_SALT_KEY: local-lit6635-verification-salt
      STORE_MODEL_IN_DB: "True"
      PRISMA_BINARY_CACHE_DIR: /opt/prisma/binaries
      PRISMA_CLI_PATH: /opt/prisma/binaries/node_modules/.bin/prisma
      PRISMA_CLI_QUERY_ENGINE_TYPE: binary
      PRISMA_OFFLINE_MODE: "true"
    depends_on:
      db:
        condition: service_healthy
  upstream:
    image: litellm-6635:1bcb587d33
    entrypoint: ["python", "/verification/upstream.py"]
    volumes:
      - ./:/verification
  db:
    image: postgres:16
    environment:
      POSTGRES_DB: lit6635
      POSTGRES_USER: lit6635
      POSTGRES_PASSWORD: local6635
    volumes:
      - db_data:/var/lib/postgresql/data
    healthcheck:
      test: ["CMD-SHELL", "pg_isready -d lit6635 -U lit6635"]
      interval: 2s
      timeout: 5s
      retries: 20
volumes:
  db_data:

```

</details>

<details>
<summary>upstream.py</summary>

```python
import json
import hashlib
from pathlib import Path
from mcp.server.fastmcp import FastMCP
from mcp.server.transport_security import TransportSecuritySettings
import uvicorn
mcp = FastMCP("credential-check", stateless_http=True, json_response=True, transport_security=TransportSecuritySettings(enable_dns_rebinding_protection=False))
@mcp.tool()
def verify_credentials() -> str:
    return "upstream credential accepted"
inner = mcp.streamable_http_app()
async def app(scope, receive, send):
    if scope["type"] == "http":
        headers = dict(scope["headers"])
        accepted = headers.get(b"authorization") == b"Bearer upstream-only-lit6635"
        known = Path("/verification/ingress-hashes").read_text().splitlines() if Path("/verification/ingress-hashes").exists() else []
        leaked = any(hashlib.sha256(v).hexdigest() in known for v in headers.values()) or any(b"sk-local-lit6635" in v or b"litellm-session" in v for v in headers.values())
        with Path("/verification/upstream-audit.jsonl").open("a") as out:
            out.write(json.dumps({"path":scope["path"], "accepted":accepted, "ingress_marker_leaked":leaked})+"\n")
        if not accepted or leaked:
            await send({"type":"http.response.start", "status":401, "headers":[(b"www-authenticate",b"Bearer")]})
            await send({"type":"http.response.body", "body":b"upstream credential rejected"})
            return
    await inner(scope, receive, send)
uvicorn.run(app, host="0.0.0.0", port=8000)

```

</details>

<details>
<summary>matrix.py</summary>

```python
import json, subprocess, sys
from pathlib import Path
revision=sys.argv[1]
out=Path(revision);out.mkdir(exist_ok=True)
base='http://127.0.0.1:46635'
for server in ['aws_knowledge_mcp','credential_mcp']:
 for path in [f'/{server}/mcp',f'/mcp/{server}']:
  for mode in ['missing','invalid','valid','metadata']:
   name=path.strip('/').replace('/','_')+'-'+mode
   url=base+('/.well-known/oauth-protected-resource' if mode=='metadata' else '')+path
   cmd=['curl','--max-time','45','-sS','-D',str(out/(name+'.headers')),'-o',str(out/(name+'.body')),url]
   if mode!='metadata':
    cmd+=['-H','Content-Type: application/json','-H','Accept: application/json, text/event-stream','-d',json.dumps({'jsonrpc':'2.0','id':1,'method':'tools/list' if mode=='valid' else 'initialize','params':{} if mode=='valid' else {'protocolVersion':'2025-06-18','capabilities':{},'clientInfo':{'name':'acceptance','version':'1'}}})]
   if mode in ['invalid','valid']:cmd+=['-H','Authorization: Bearer '+('invalid-local-token' if mode=='invalid' else 'sk-local-lit6635-verification')]
   subprocess.run(cmd,check=True)
   h=(out/(name+'.headers')).read_text();b=(out/(name+'.body')).read_text();status=int(h.splitlines()[0].split()[1]);challenge=next((l for l in h.splitlines() if l.lower().startswith('www-authenticate:')), '')
   expected=200 if mode=='valid' or (mode=='metadata' and revision=='after') else 404 if mode=='metadata' else 401
   assert status==expected,(name,status,b)
   if mode in ['missing','invalid']:
    assert bool(challenge)==(revision=='after'),(name,challenge)
    if revision=='after':
     assert base+'/.well-known/oauth-protected-resource'+path in challenge
     assert ('invalid_token' in challenge)==(mode=='invalid')
   if mode=='metadata' and revision=='after':
    m=json.loads(b);assert m['resource']==base+path and m['authorization_servers']==[base+'/mcp']
   if mode=='valid':
    m=json.loads(next((l[6:] for l in b.splitlines() if l.startswith('data: ')),b));assert len(m['result']['tools'])==(5 if server=='aws_knowledge_mcp' else 1)
   print(f'PASS {path} {mode}: {status} {challenge}',flush=True)

```

</details>

<details>
<summary>scope_probe.py</summary>

```python
import base64
import hashlib
import json
import re
import secrets
import subprocess
import sys
import tempfile
from pathlib import Path
from urllib.parse import parse_qs, urlencode, urlparse

base = 'http://127.0.0.1:46635'
resource = base + sys.argv[1]
work = Path(tempfile.mkdtemp(prefix='lit6635-dcr-'))
jar = work / 'cookies'

def call(url, payload=None, form=None, bearer=None):
    cmd = ['curl', '--max-time', '90', '-sS', '-D', str(work/'headers'), '-o', str(work/'body'), '-b', str(jar), '-c', str(jar), url]
    if payload is not None:
        cmd += ['-H', 'Content-Type: application/json', '-H', 'Accept: application/json, text/event-stream', '-d', json.dumps(payload)]
    if form is not None:
        cmd += ['-H', 'Content-Type: application/x-www-form-urlencoded', '-d', urlencode(form)]
    if bearer is not None:
        cmd += ['-H', 'Authorization: Bearer '+bearer]
    subprocess.run(cmd, check=True)
    lines = (work/'headers').read_text().splitlines()
    status = int(lines[0].split()[1])
    headers = dict(line.split(': ', 1) for line in lines[1:] if ': ' in line)
    return status, {k.lower(): v for k,v in headers.items()}, (work/'body').read_text()

def result(body):
    return json.loads(next((line[6:] for line in body.splitlines() if line.startswith('data: ')), body))

status, headers, body = call(resource, {'jsonrpc':'2.0','id':1,'method':'initialize','params':{'protocolVersion':'2025-06-18','capabilities':{},'clientInfo':{'name':'lit6635-dcr','version':'1'}}})
assert status == 401, (status, body)
challenge = headers.get('www-authenticate', '')
print('Unauthenticated initialize:', status, challenge or '(no WWW-Authenticate)', flush=True)
match = re.search('resource_metadata="([^"]+)"', challenge)
if not match:
    print('FAIL: client cannot discover sign-in from the 401 challenge', flush=True)
    sys.exit(1)
status, _, body = call(match[1])
metadata = json.loads(body)
assert status == 200 and metadata['resource'] == resource, (status, body)
issuer = metadata['authorization_servers'][0]
as_url = base + '/.well-known/oauth-authorization-server' + urlparse(issuer).path
status, _, body = call(as_url)
as_meta = json.loads(body)
assert status == 200 and as_meta['issuer'] == issuer, (status, body)
print('Resource and authorization-server metadata: matching resource and issuer', flush=True)
redirect = 'http://127.0.0.1:46636/callback'
status, _, body = call(as_meta['registration_endpoint'], {'client_name':'lit6635-verification','redirect_uris':[redirect],'grant_types':['authorization_code','refresh_token'],'response_types':['code'],'token_endpoint_auth_method':'none'})
assert status == 201, (status, body)
client_id = json.loads(body)['client_id']
status, _, body = call(base+'/login', form={'username':'admin','password':'sk-local-lit6635-verification'})
assert status == 303, (status, body)
verifier = secrets.token_urlsafe(48)
challenge = base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest()).decode().rstrip('=')
url = as_meta['authorization_endpoint']+'?'+urlencode({'client_id':client_id,'redirect_uri':redirect,'response_type':'code','state':'lit6635','code_challenge':challenge,'code_challenge_method':'S256','resource':resource})
status, headers, body = call(url)
assert status == 303, (status, body)
flow = parse_qs(urlparse(headers['location']).query)['connect_flow'][0]
status, _, body = call(base+'/authorize/flow?'+urlencode({'flow':flow}))
assert status == 200, (status, body)
description=json.loads(body)
if '--expect-denied' in sys.argv:
    expected_name='aws_knowledge_mcp' if 'aws_knowledge_mcp' in resource else 'credential_mcp'
    assert description['state']=='m2m' and description['server_name']==expected_name and description['connected'] is True,description
print('Consent scope: '+json.dumps(description),flush=True)
print('DCR registration, local user sign-in, and consent flow: successful', flush=True)
status, headers, body = call(base+'/authorize/complete', form={'flow':flow,'decision':'approve'})
assert status == 303, (status, body)
code = parse_qs(urlparse(headers['location']).query)['code'][0]
status, _, body = call(as_meta['token_endpoint'], form={'grant_type':'authorization_code','client_id':client_id,'code':code,'redirect_uri':redirect,'code_verifier':verifier,'resource':resource})
assert status == 200, (status, body)
bearer = json.loads(body)['access_token']
refresh_token = json.loads(body)['refresh_token']
with (Path(__file__).parent/'ingress-hashes').open('a') as out:
    out.write(hashlib.sha256(('Bearer '+bearer).encode()).hexdigest()+'\n')
print('Authorization-code exchange with S256 PKCE: successful (token withheld)', flush=True)
for method, params in [('initialize', {'protocolVersion':'2025-06-18','capabilities':{},'clientInfo':{'name':'acceptance','version':'1'}}), ('tools/list', {}), ('tools/call', {'name':('credential_mcp-verify_credentials' if 'credential_mcp' in resource else 'aws_knowledge_mcp-aws___list_regions'),'arguments':{}})]:
    status, _, body = call(resource, {'jsonrpc':'2.0','id':2,'method':method,'params':params}, bearer=bearer)
    obj = result(body)
    evidence = Path(__file__).parent/'after'
    evidence.mkdir(exist_ok=True)
    (evidence/(urlparse(resource).path.strip('/').replace('/','_')+'-'+method.replace('/','_')+'.json')).write_text(json.dumps(obj, indent=2))
    assert status == 200 and 'result' in obj and not obj['result'].get('isError', False), (status, body)
    if method == 'tools/list':
        assert len(obj['result']['tools']) == (1 if 'credential_mcp' in resource else 5), obj
    print('Gateway-session '+method+': 200, '+(str(len(obj['result']['tools']))+' tools' if method=='tools/list' else ('protocol negotiated' if method=='initialize' else 'tool result, isError=false')), flush=True)
other_name = 'credential_mcp' if 'aws_knowledge_mcp' in resource else 'aws_knowledge_mcp'
for token_kind in ['access','refresh']:
    if token_kind == 'refresh':
        status,_,body=call(as_meta['token_endpoint'],form={'grant_type':'refresh_token','client_id':client_id,'refresh_token':refresh_token})
        assert status==200,(status,body)
        bearer=json.loads(body)['access_token']
    status,_,own_body=call(resource,{'jsonrpc':'2.0','id':8,'method':'tools/list','params':{}},bearer=bearer)
    assert status==200 and len(result(own_body)['result']['tools'])==(5 if 'aws_knowledge_mcp' in resource else 1),(status,own_body)
    print('OWN-SERVER '+token_kind+' tools/list: 200, expected tools present',flush=True)
    for other in ['/'+other_name+'/mcp','/mcp/'+other_name]:
        for method,params in [('tools/list',{}),('tools/call',{'name':other_name+('-verify_credentials' if other_name=='credential_mcp' else '-aws___list_regions'),'arguments':{}})]:
            status,_,body=call(base+other,{'jsonrpc':'2.0','id':9,'method':method,'params':params},bearer=bearer)
            print('CROSS-SERVER '+token_kind+' '+other+' '+method+': HTTP '+str(status)+' '+body,flush=True)
            obj=result(body)
            if '--expect-denied' in sys.argv:
                assert status in (401,403,404) or 'error' in obj or obj.get('result',{}).get('isError') is True or (method=='tools/list' and obj.get('result',{}).get('tools')==[]),(status,body)
print('PASS scoped token and refresh cannot access the other server' if '--expect-denied' in sys.argv else 'Completed scope probe',flush=True)

```

</details>

### Before (f529d6d6bd8f9bdc3177caf319446bf5a07b304a)

#### Authentication and discovery matrix

1. Run `python3 matrix.py before`. This runs actual curl requests for missing, invalid, and valid gateway credentials, plus metadata, on both URL formats for both upstreams
2. Captured output:

```text
PASS /aws_knowledge_mcp/mcp missing: 401 
PASS /aws_knowledge_mcp/mcp invalid: 401 
PASS /aws_knowledge_mcp/mcp valid: 200 
PASS /aws_knowledge_mcp/mcp metadata: 404 
PASS /mcp/aws_knowledge_mcp missing: 401 
PASS /mcp/aws_knowledge_mcp invalid: 401 
PASS /mcp/aws_knowledge_mcp valid: 200 
PASS /mcp/aws_knowledge_mcp metadata: 404 
PASS /credential_mcp/mcp missing: 401 
PASS /credential_mcp/mcp invalid: 401 
PASS /credential_mcp/mcp valid: 200 
PASS /credential_mcp/mcp metadata: 404 
PASS /mcp/credential_mcp missing: 401 
PASS /mcp/credential_mcp invalid: 401 
PASS /mcp/credential_mcp valid: 200 
PASS /mcp/credential_mcp metadata: 404 
```

#### OAuth consent and cross-server authorization

1. Run the same challenge-driven flow for each server and URL format:

```bash
python3 scope_probe.py /aws_knowledge_mcp/mcp
python3 scope_probe.py /mcp/aws_knowledge_mcp
python3 scope_probe.py /credential_mcp/mcp
python3 scope_probe.py /mcp/credential_mcp
```

2. Captured results:

```text
Unauthenticated initialize: 401 (no WWW-Authenticate)
FAIL: client cannot discover sign-in from the 401 challenge
```

```text
Unauthenticated initialize: 401 (no WWW-Authenticate)
FAIL: client cannot discover sign-in from the 401 challenge
```

```text
Unauthenticated initialize: 401 (no WWW-Authenticate)
FAIL: client cannot discover sign-in from the 401 challenge
```

```text
Unauthenticated initialize: 401 (no WWW-Authenticate)
FAIL: client cannot discover sign-in from the 401 challenge
```

### After (a0bb021f028efa4b29ac6dca3bdbff67c6f890f0)

#### Authentication and discovery matrix

1. Run `python3 matrix.py after`. This runs actual curl requests for missing, invalid, and valid gateway credentials, plus metadata, on both URL formats for both upstreams
2. Captured output:

```text
PASS /aws_knowledge_mcp/mcp missing: 401 www-authenticate: Bearer resource_metadata="http://127.0.0.1:46635/.well-known/oauth-protected-resource/aws_knowledge_mcp/mcp"
PASS /aws_knowledge_mcp/mcp invalid: 401 www-authenticate: Bearer error="invalid_token", resource_metadata="http://127.0.0.1:46635/.well-known/oauth-protected-resource/aws_knowledge_mcp/mcp"
PASS /aws_knowledge_mcp/mcp valid: 200 
PASS /aws_knowledge_mcp/mcp metadata: 200 
PASS /mcp/aws_knowledge_mcp missing: 401 www-authenticate: Bearer resource_metadata="http://127.0.0.1:46635/.well-known/oauth-protected-resource/mcp/aws_knowledge_mcp"
PASS /mcp/aws_knowledge_mcp invalid: 401 www-authenticate: Bearer error="invalid_token", resource_metadata="http://127.0.0.1:46635/.well-known/oauth-protected-resource/mcp/aws_knowledge_mcp"
PASS /mcp/aws_knowledge_mcp valid: 200 
PASS /mcp/aws_knowledge_mcp metadata: 200 
PASS /credential_mcp/mcp missing: 401 www-authenticate: Bearer resource_metadata="http://127.0.0.1:46635/.well-known/oauth-protected-resource/credential_mcp/mcp"
PASS /credential_mcp/mcp invalid: 401 www-authenticate: Bearer error="invalid_token", resource_metadata="http://127.0.0.1:46635/.well-known/oauth-protected-resource/credential_mcp/mcp"
PASS /credential_mcp/mcp valid: 200 
PASS /credential_mcp/mcp metadata: 200 
PASS /mcp/credential_mcp missing: 401 www-authenticate: Bearer resource_metadata="http://127.0.0.1:46635/.well-known/oauth-protected-resource/mcp/credential_mcp"
PASS /mcp/credential_mcp invalid: 401 www-authenticate: Bearer error="invalid_token", resource_metadata="http://127.0.0.1:46635/.well-known/oauth-protected-resource/mcp/credential_mcp"
PASS /mcp/credential_mcp valid: 200 
PASS /mcp/credential_mcp metadata: 200 
```

#### OAuth consent and cross-server authorization

1. Run the same challenge-driven flow for each server and URL format:

```bash
python3 scope_probe.py /aws_knowledge_mcp/mcp --expect-denied
python3 scope_probe.py /mcp/aws_knowledge_mcp --expect-denied
python3 scope_probe.py /credential_mcp/mcp --expect-denied
python3 scope_probe.py /mcp/credential_mcp --expect-denied
```

2. Captured results:

<details>
<summary>aws-legacy full live trace</summary>

```text
Unauthenticated initialize: 401 Bearer resource_metadata="http://127.0.0.1:46635/.well-known/oauth-protected-resource/aws_knowledge_mcp/mcp"
Resource and authorization-server metadata: matching resource and issuer
Consent scope: {"state": "m2m", "client_origin": "http://127.0.0.1:46636", "server_id": "d4940e113c44b70e4708564777381b1c", "server_name": "aws_knowledge_mcp", "connected": true}
DCR registration, local user sign-in, and consent flow: successful
Authorization-code exchange with S256 PKCE: successful (token withheld)
Gateway-session initialize: 200, protocol negotiated
Gateway-session tools/list: 200, 5 tools
Gateway-session tools/call: 200, tool result, isError=false
OWN-SERVER access tools/list: 200, expected tools present
CROSS-SERVER access /credential_mcp/mcp tools/list: HTTP 200 event: message
data: {"jsonrpc":"2.0","id":9,"error":{"code":-32600,"message":"The key is not allowed to access the requested MCP servers: credential_mcp"}}


CROSS-SERVER access /credential_mcp/mcp tools/call: HTTP 200 event: message
data: {"jsonrpc":"2.0","id":9,"result":{"content":[{"type":"text","text":"The key is not allowed to access the requested MCP servers: credential_mcp"}],"isError":true}}


CROSS-SERVER access /mcp/credential_mcp tools/list: HTTP 200 event: message
data: {"jsonrpc":"2.0","id":9,"error":{"code":-32600,"message":"The key is not allowed to access the requested MCP servers: credential_mcp"}}


CROSS-SERVER access /mcp/credential_mcp tools/call: HTTP 200 event: message
data: {"jsonrpc":"2.0","id":9,"result":{"content":[{"type":"text","text":"The key is not allowed to access the requested MCP servers: credential_mcp"}],"isError":true}}


OWN-SERVER refresh tools/list: 200, expected tools present
CROSS-SERVER refresh /credential_mcp/mcp tools/list: HTTP 200 event: message
data: {"jsonrpc":"2.0","id":9,"error":{"code":-32600,"message":"The key is not allowed to access the requested MCP servers: credential_mcp"}}


CROSS-SERVER refresh /credential_mcp/mcp tools/call: HTTP 200 event: message
data: {"jsonrpc":"2.0","id":9,"result":{"content":[{"type":"text","text":"The key is not allowed to access the requested MCP servers: credential_mcp"}],"isError":true}}


CROSS-SERVER refresh /mcp/credential_mcp tools/list: HTTP 200 event: message
data: {"jsonrpc":"2.0","id":9,"error":{"code":-32600,"message":"The key is not allowed to access the requested MCP servers: credential_mcp"}}


CROSS-SERVER refresh /mcp/credential_mcp tools/call: HTTP 200 event: message
data: {"jsonrpc":"2.0","id":9,"result":{"content":[{"type":"text","text":"The key is not allowed to access the requested MCP servers: credential_mcp"}],"isError":true}}


PASS scoped token and refresh cannot access the other server
```

</details>

<details>
<summary>aws-standard full live trace</summary>

```text
Unauthenticated initialize: 401 Bearer resource_metadata="http://127.0.0.1:46635/.well-known/oauth-protected-resource/mcp/aws_knowledge_mcp"
Resource and authorization-server metadata: matching resource and issuer
Consent scope: {"state": "m2m", "client_origin": "http://127.0.0.1:46636", "server_id": "d4940e113c44b70e4708564777381b1c", "server_name": "aws_knowledge_mcp", "connected": true}
DCR registration, local user sign-in, and consent flow: successful
Authorization-code exchange with S256 PKCE: successful (token withheld)
Gateway-session initialize: 200, protocol negotiated
Gateway-session tools/list: 200, 5 tools
Gateway-session tools/call: 200, tool result, isError=false
OWN-SERVER access tools/list: 200, expected tools present
CROSS-SERVER access /credential_mcp/mcp tools/list: HTTP 200 event: message
data: {"jsonrpc":"2.0","id":9,"error":{"code":-32600,"message":"The key is not allowed to access the requested MCP servers: credential_mcp"}}


CROSS-SERVER access /credential_mcp/mcp tools/call: HTTP 200 event: message
data: {"jsonrpc":"2.0","id":9,"result":{"content":[{"type":"text","text":"The key is not allowed to access the requested MCP servers: credential_mcp"}],"isError":true}}


CROSS-SERVER access /mcp/credential_mcp tools/list: HTTP 200 event: message
data: {"jsonrpc":"2.0","id":9,"error":{"code":-32600,"message":"The key is not allowed to access the requested MCP servers: credential_mcp"}}


CROSS-SERVER access /mcp/credential_mcp tools/call: HTTP 200 event: message
data: {"jsonrpc":"2.0","id":9,"result":{"content":[{"type":"text","text":"The key is not allowed to access the requested MCP servers: credential_mcp"}],"isError":true}}


OWN-SERVER refresh tools/list: 200, expected tools present
CROSS-SERVER refresh /credential_mcp/mcp tools/list: HTTP 200 event: message
data: {"jsonrpc":"2.0","id":9,"error":{"code":-32600,"message":"The key is not allowed to access the requested MCP servers: credential_mcp"}}


CROSS-SERVER refresh /credential_mcp/mcp tools/call: HTTP 200 event: message
data: {"jsonrpc":"2.0","id":9,"result":{"content":[{"type":"text","text":"The key is not allowed to access the requested MCP servers: credential_mcp"}],"isError":true}}


CROSS-SERVER refresh /mcp/credential_mcp tools/list: HTTP 200 event: message
data: {"jsonrpc":"2.0","id":9,"error":{"code":-32600,"message":"The key is not allowed to access the requested MCP servers: credential_mcp"}}


CROSS-SERVER refresh /mcp/credential_mcp tools/call: HTTP 200 event: message
data: {"jsonrpc":"2.0","id":9,"result":{"content":[{"type":"text","text":"The key is not allowed to access the requested MCP servers: credential_mcp"}],"isError":true}}


PASS scoped token and refresh cannot access the other server
```

</details>

<details>
<summary>credential-legacy full live trace</summary>

```text
Unauthenticated initialize: 401 Bearer resource_metadata="http://127.0.0.1:46635/.well-known/oauth-protected-resource/credential_mcp/mcp"
Resource and authorization-server metadata: matching resource and issuer
Consent scope: {"state": "m2m", "client_origin": "http://127.0.0.1:46636", "server_id": "089ad23966ec2b8cbba9e3cd44b09db1", "server_name": "credential_mcp", "connected": true}
DCR registration, local user sign-in, and consent flow: successful
Authorization-code exchange with S256 PKCE: successful (token withheld)
Gateway-session initialize: 200, protocol negotiated
Gateway-session tools/list: 200, 1 tools
Gateway-session tools/call: 200, tool result, isError=false
OWN-SERVER access tools/list: 200, expected tools present
CROSS-SERVER access /aws_knowledge_mcp/mcp tools/list: HTTP 200 event: message
data: {"jsonrpc":"2.0","id":9,"error":{"code":-32600,"message":"The key is not allowed to access the requested MCP servers: aws_knowledge_mcp"}}


CROSS-SERVER access /aws_knowledge_mcp/mcp tools/call: HTTP 200 event: message
data: {"jsonrpc":"2.0","id":9,"result":{"content":[{"type":"text","text":"Error: The key is not allowed to access the requested MCP servers: aws_knowledge_mcp"}],"isError":true}}


CROSS-SERVER access /mcp/aws_knowledge_mcp tools/list: HTTP 200 event: message
data: {"jsonrpc":"2.0","id":9,"error":{"code":-32600,"message":"The key is not allowed to access the requested MCP servers: aws_knowledge_mcp"}}


CROSS-SERVER access /mcp/aws_knowledge_mcp tools/call: HTTP 200 event: message
data: {"jsonrpc":"2.0","id":9,"result":{"content":[{"type":"text","text":"Error: The key is not allowed to access the requested MCP servers: aws_knowledge_mcp"}],"isError":true}}


OWN-SERVER refresh tools/list: 200, expected tools present
CROSS-SERVER refresh /aws_knowledge_mcp/mcp tools/list: HTTP 200 event: message
data: {"jsonrpc":"2.0","id":9,"error":{"code":-32600,"message":"The key is not allowed to access the requested MCP servers: aws_knowledge_mcp"}}


CROSS-SERVER refresh /aws_knowledge_mcp/mcp tools/call: HTTP 200 event: message
data: {"jsonrpc":"2.0","id":9,"result":{"content":[{"type":"text","text":"Error: The key is not allowed to access the requested MCP servers: aws_knowledge_mcp"}],"isError":true}}


CROSS-SERVER refresh /mcp/aws_knowledge_mcp tools/list: HTTP 200 event: message
data: {"jsonrpc":"2.0","id":9,"error":{"code":-32600,"message":"The key is not allowed to access the requested MCP servers: aws_knowledge_mcp"}}


CROSS-SERVER refresh /mcp/aws_knowledge_mcp tools/call: HTTP 200 event: message
data: {"jsonrpc":"2.0","id":9,"result":{"content":[{"type":"text","text":"Error: The key is not allowed to access the requested MCP servers: aws_knowledge_mcp"}],"isError":true}}


PASS scoped token and refresh cannot access the other server
```

</details>

<details>
<summary>credential-standard full live trace</summary>

```text
Unauthenticated initialize: 401 Bearer resource_metadata="http://127.0.0.1:46635/.well-known/oauth-protected-resource/mcp/credential_mcp"
Resource and authorization-server metadata: matching resource and issuer
Consent scope: {"state": "m2m", "client_origin": "http://127.0.0.1:46636", "server_id": "089ad23966ec2b8cbba9e3cd44b09db1", "server_name": "credential_mcp", "connected": true}
DCR registration, local user sign-in, and consent flow: successful
Authorization-code exchange with S256 PKCE: successful (token withheld)
Gateway-session initialize: 200, protocol negotiated
Gateway-session tools/list: 200, 1 tools
Gateway-session tools/call: 200, tool result, isError=false
OWN-SERVER access tools/list: 200, expected tools present
CROSS-SERVER access /aws_knowledge_mcp/mcp tools/list: HTTP 200 event: message
data: {"jsonrpc":"2.0","id":9,"error":{"code":-32600,"message":"The key is not allowed to access the requested MCP servers: aws_knowledge_mcp"}}


CROSS-SERVER access /aws_knowledge_mcp/mcp tools/call: HTTP 200 event: message
data: {"jsonrpc":"2.0","id":9,"result":{"content":[{"type":"text","text":"Error: The key is not allowed to access the requested MCP servers: aws_knowledge_mcp"}],"isError":true}}


CROSS-SERVER access /mcp/aws_knowledge_mcp tools/list: HTTP 200 event: message
data: {"jsonrpc":"2.0","id":9,"error":{"code":-32600,"message":"The key is not allowed to access the requested MCP servers: aws_knowledge_mcp"}}


CROSS-SERVER access /mcp/aws_knowledge_mcp tools/call: HTTP 200 event: message
data: {"jsonrpc":"2.0","id":9,"result":{"content":[{"type":"text","text":"Error: The key is not allowed to access the requested MCP servers: aws_knowledge_mcp"}],"isError":true}}


OWN-SERVER refresh tools/list: 200, expected tools present
CROSS-SERVER refresh /aws_knowledge_mcp/mcp tools/list: HTTP 200 event: message
data: {"jsonrpc":"2.0","id":9,"error":{"code":-32600,"message":"The key is not allowed to access the requested MCP servers: aws_knowledge_mcp"}}


CROSS-SERVER refresh /aws_knowledge_mcp/mcp tools/call: HTTP 200 event: message
data: {"jsonrpc":"2.0","id":9,"result":{"content":[{"type":"text","text":"Error: The key is not allowed to access the requested MCP servers: aws_knowledge_mcp"}],"isError":true}}


CROSS-SERVER refresh /mcp/aws_knowledge_mcp tools/list: HTTP 200 event: message
data: {"jsonrpc":"2.0","id":9,"error":{"code":-32600,"message":"The key is not allowed to access the requested MCP servers: aws_knowledge_mcp"}}


CROSS-SERVER refresh /mcp/aws_knowledge_mcp tools/call: HTTP 200 event: message
data: {"jsonrpc":"2.0","id":9,"result":{"content":[{"type":"text","text":"Error: The key is not allowed to access the requested MCP servers: aws_knowledge_mcp"}],"isError":true}}


PASS scoped token and refresh cannot access the other server
```

</details>

3. All 32 cross-server attempts were denied: two source servers × two source URL formats × access/refreshed tokens × two destination formats × list/call. The approved server remained usable. Denials are MCP errors carried inside HTTP 200; the assertions inspect the MCP result, not just HTTP status

## Veria finding verification

Veria identified a scope gap in the preceding PR tip, `1bcb587d336c8a141809ca0fe165d1b305f1122f`: after approving AWS MCP, both the access and refreshed token could list and call the credential-protected server. This was reproduced locally using the same scope probe before changing the code. Representative captured response:

```json
{"jsonrpc":"2.0","id":9,"result":{"content":[{"type":"text","text":"upstream credential accepted"}],"structuredContent":{"result":"upstream credential accepted"},"isError":false}}
```

The current-tip traces above demonstrate the same cross-server requests denied. Consent also now names only the requested server. Gateway-owned modes enter the existing ready-to-connect state, while interactive OAuth still requires its vendor credential and existing gateway-managed OAuth scopes remain supported

## Type

Bug Fix

## Caveats (if any)

### Low

- Historical bootstrap retry did not reproduce on two fresh databases
- Pre-existing smol-toml OSV alert is not a required check
- Fresh automated reviews and CI are pending
- Terraform state regression from #40512 fails CI; rerun accepted

## Final Attestation

- [ ] Current-tip CI and automated reviews have completed successfully
