### PR TITLE
fix(rerank): exclude proxy request from parameter dumps

### DIFF
--- a/litellm/rerank_api/main.py
+++ b/litellm/rerank_api/main.py
@@ -190,7 +190,7 @@ def rerank(
             "model_info": model_info,
             "preset_cache_key": None,
             "stream_response": {},
-            **optional_params.model_dump(exclude_unset=True),
+            **optional_params.model_dump(exclude_unset=True, exclude={"proxy_server_request"}),
         }
 
         litellm_logging_obj.update_from_kwargs(
@@ -380,7 +380,7 @@ def rerank(
                 return_documents=return_documents,
                 max_chunks_per_doc=max_chunks_per_doc,
                 _is_async=_is_async,
-                optional_params=optional_params.model_dump(exclude_unset=True),
+                optional_params=optional_params.model_dump(exclude_unset=True, exclude={"proxy_server_request"}),
                 timeout=optional_params.timeout,
                 api_base=api_base,
                 extra_headers=merged_headers,

--- a/litellm/rerank_api/main.py
+++ b/litellm/rerank_api/main.py
@@ -127,9 +127,9 @@ def rerank(
     # adding real safety; it stays typed downstream via get_optional_rerank_params.
     instruction: Final[str | None] = kwargs.get("instruction", None)
     headers: Final[dict | None] = kwargs.get("headers")
-    litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
+    litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.pop("litellm_logging_obj")
     litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id", None)
-    proxy_server_request: Final = kwargs.get("proxy_server_request", None)
+    proxy_server_request: Final = kwargs.pop("proxy_server_request", None)
     model_info: Final = kwargs.get("model_info", None)
     user: Final = kwargs.get("user", None)
     client: Final = kwargs.get("client", None)

--- a/tests/test_litellm/rerank_api/test_main.py
+++ b/tests/test_litellm/rerank_api/test_main.py
@@ -3,7 +3,9 @@ from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
+from pydantic import BaseModel, field_serializer
 import respx
+from litellm.llms.custom_httpx.http_handler import HTTPHandler
 
 
 import litellm
@@ -63,60 +65,65 @@ def test_rerank_does_not_log_request_content_at_info(caplog):
 
     optional_params_logs = [r for r in litellm_records if "optional_rerank_params" in r.getMessage()]
     assert optional_params_logs, "expected the optional_rerank_params line to be logged"
-    assert all(
-        r.levelno == logging.DEBUG for r in optional_params_logs
-    ), "optional_rerank_params must be logged at DEBUG, not INFO"
+    assert all(r.levelno == logging.DEBUG for r in optional_params_logs), (
+        "optional_rerank_params must be logged at DEBUG, not INFO"
+    )
 
 
-def test_rerank_preserves_proxy_request_without_serializing_it():
-    """Large proxy request bodies must bypass GenericLiteLLMParams serialization."""
-    documents = [f"document-{index}-" + ("x" * 4096) for index in range(350)]
-    proxy_server_request = {"body": {"query": "query", "documents": documents}}
-    logging_obj = MagicMock()
+class SerializationProbe(BaseModel):
+    value: str
 
-    with patch(
-        "litellm.rerank_api.main.base_llm_http_handler.rerank",
-        return_value=MagicMock(),
-    ) as rerank_call:
-        litellm.rerank(
+    @field_serializer("value")
+    def reject_serialization(self, value: str) -> str:
+        raise RuntimeError("proxy request was serialized")
+
+
+def test_rerank_does_not_serialize_proxy_request():
+    proxy_server_request = {"body": {"probe": SerializationProbe(value="payload")}}
+    transport = httpx.MockTransport(
+        lambda request: httpx.Response(
+            200,
+            json={"data": [{"index": 0, "relevance_score": 0.95}], "usage": {}},
+            request=request,
+        )
+    )
+
+    with httpx.Client(transport=transport) as raw_client:
+        response = litellm.rerank(
             model="fireworks_ai/accounts/fireworks/models/qwen3-reranker-8b",
             query="query",
-            documents=documents,
+            documents=["document"],
             api_key="fake-fireworks-key",
-            litellm_logging_obj=logging_obj,
+            client=HTTPHandler(client=raw_client),
             proxy_server_request=proxy_server_request,
         )
 
-    provider_params = rerank_call.call_args.kwargs["litellm_params"]
-    assert provider_params["proxy_server_request"] is proxy_server_request
-
-    logging_params = logging_obj.update_from_kwargs.call_args.kwargs["litellm_params"]
-    assert logging_params["proxy_server_request"] is proxy_server_request
+    assert response.results[0]["relevance_score"] == 0.95
 
 
-def test_bedrock_rerank_excludes_proxy_request_from_optional_params():
-    """Bedrock's second parameter dump must also bypass the proxy request body."""
-    proxy_server_request = {"body": {"documents": ["document"] * 350}}
-    logging_obj = MagicMock()
+def test_bedrock_rerank_does_not_serialize_proxy_request():
+    proxy_server_request = {"body": {"probe": SerializationProbe(value="payload")}}
+    transport = httpx.MockTransport(
+        lambda request: httpx.Response(
+            200,
+            json={"results": [{"index": 0, "relevanceScore": 0.95}]},
+            request=request,
+        )
+    )
 
-    with patch(
-        "litellm.rerank_api.main.bedrock_rerank.rerank",
-        return_value=MagicMock(),
-    ) as rerank_call:
-        litellm.rerank(
+    with httpx.Client(transport=transport) as raw_client:
+        response = litellm.rerank(
             model="bedrock/arn:aws:bedrock:us-east-1::foundation-model/cohere.rerank-v3-5:0",
             query="query",
             documents=["document"],
             aws_region_name="us-east-1",
-            litellm_logging_obj=logging_obj,
+            aws_access_key_id="fake-access-key",
+            aws_secret_access_key="fake-secret-key",
+            client=HTTPHandler(client=raw_client),
             proxy_server_request=proxy_server_request,
         )
 
-    optional_params = rerank_call.call_args.kwargs["optional_params"]
-    assert "proxy_server_request" not in optional_params
-
-    logging_params = logging_obj.update_from_kwargs.call_args.kwargs["litellm_params"]
-    assert logging_params["proxy_server_request"] is proxy_server_request
+    assert response.results[0]["relevance_score"] == 0.95
 
 
 TOGETHER_RERANK_BODY = {

--- a/tests/test_litellm/rerank_api/test_main.py
+++ b/tests/test_litellm/rerank_api/test_main.py
@@ -75,11 +75,48 @@ class SerializationProbe(BaseModel):
 
     @field_serializer("value")
     def reject_serialization(self, value: str) -> str:
-        raise RuntimeError("proxy request was serialized")
+        raise RuntimeError("runtime request state was serialized")
 
 
-def test_rerank_does_not_serialize_proxy_request():
+class LoggingSerializationProbe:
+    def __init__(self, proxy_server_request):
+        self.proxy_server_request = proxy_server_request
+        self.model_call_details = {}
+
+    def update_from_kwargs(self, **kwargs):
+        pass
+
+    def pre_call(self, **kwargs):
+        pass
+
+    def post_call(self, **kwargs):
+        pass
+
+    def get_router_model_id(self):
+        return None
+
+    def success_handler(self, *args, **kwargs):
+        pass
+
+    def failure_handler(self, *args, **kwargs):
+        pass
+
+    def _response_cost_calculator(self, **kwargs):
+        return None
+
+    @property
+    def caching_details(self):
+        return None
+
+
+def _runtime_request_state():
     proxy_server_request = {"body": {"probe": SerializationProbe(value="payload")}}
+    return proxy_server_request, LoggingSerializationProbe(proxy_server_request)
+
+
+
+def test_rerank_does_not_serialize_runtime_request_state():
+    proxy_server_request, logging_obj = _runtime_request_state()
     transport = httpx.MockTransport(
         lambda request: httpx.Response(
             200,
@@ -96,13 +133,14 @@ def test_rerank_does_not_serialize_proxy_request():
             api_key="fake-fireworks-key",
             client=HTTPHandler(client=raw_client),
             proxy_server_request=proxy_server_request,
+            litellm_logging_obj=logging_obj,
         )
 
     assert response.results[0]["relevance_score"] == 0.95
 
 
-def test_bedrock_rerank_does_not_serialize_proxy_request():
-    proxy_server_request = {"body": {"probe": SerializationProbe(value="payload")}}
+def test_bedrock_rerank_does_not_serialize_runtime_request_state():
+    proxy_server_request, logging_obj = _runtime_request_state()
     transport = httpx.MockTransport(
         lambda request: httpx.Response(
             200,
@@ -121,6 +159,7 @@ def test_bedrock_rerank_does_not_serialize_proxy_request():
             aws_secret_access_key="fake-secret-key",
             client=HTTPHandler(client=raw_client),
             proxy_server_request=proxy_server_request,
+            litellm_logging_obj=logging_obj,
         )
 
     assert response.results[0]["relevance_score"] == 0.95

--- a/tests/test_litellm/rerank_api/test_main.py
+++ b/tests/test_litellm/rerank_api/test_main.py
@@ -68,6 +68,57 @@ def test_rerank_does_not_log_request_content_at_info(caplog):
     ), "optional_rerank_params must be logged at DEBUG, not INFO"
 
 
+def test_rerank_preserves_proxy_request_without_serializing_it():
+    """Large proxy request bodies must bypass GenericLiteLLMParams serialization."""
+    documents = [f"document-{index}-" + ("x" * 4096) for index in range(350)]
+    proxy_server_request = {"body": {"query": "query", "documents": documents}}
+    logging_obj = MagicMock()
+
+    with patch(
+        "litellm.rerank_api.main.base_llm_http_handler.rerank",
+        return_value=MagicMock(),
+    ) as rerank_call:
+        litellm.rerank(
+            model="fireworks_ai/accounts/fireworks/models/qwen3-reranker-8b",
+            query="query",
+            documents=documents,
+            api_key="fake-fireworks-key",
+            litellm_logging_obj=logging_obj,
+            proxy_server_request=proxy_server_request,
+        )
+
+    provider_params = rerank_call.call_args.kwargs["litellm_params"]
+    assert provider_params["proxy_server_request"] is proxy_server_request
+
+    logging_params = logging_obj.update_from_kwargs.call_args.kwargs["litellm_params"]
+    assert logging_params["proxy_server_request"] is proxy_server_request
+
+
+def test_bedrock_rerank_excludes_proxy_request_from_optional_params():
+    """Bedrock's second parameter dump must also bypass the proxy request body."""
+    proxy_server_request = {"body": {"documents": ["document"] * 350}}
+    logging_obj = MagicMock()
+
+    with patch(
+        "litellm.rerank_api.main.bedrock_rerank.rerank",
+        return_value=MagicMock(),
+    ) as rerank_call:
+        litellm.rerank(
+            model="bedrock/arn:aws:bedrock:us-east-1::foundation-model/cohere.rerank-v3-5:0",
+            query="query",
+            documents=["document"],
+            aws_region_name="us-east-1",
+            litellm_logging_obj=logging_obj,
+            proxy_server_request=proxy_server_request,
+        )
+
+    optional_params = rerank_call.call_args.kwargs["optional_params"]
+    assert "proxy_server_request" not in optional_params
+
+    logging_params = logging_obj.update_from_kwargs.call_args.kwargs["litellm_params"]
+    assert logging_params["proxy_server_request"] is proxy_server_request
+
+
 TOGETHER_RERANK_BODY = {
     "id": "rerank-mock-id",
     "results": [{"index": 0, "relevance_score": 0.95}],


### PR DESCRIPTION
## TLDR

Problem this solves:

- Large rerank requests can exhaust proxy memory
- Runtime-only request and logging objects were passed into `GenericLiteLLMParams`
- The logging object retains request state, including the document payload
- Pydantic therefore traversed that retained state during validation and serialization

How it solves it:

- Removes `proxy_server_request` and `litellm_logging_obj` from provider kwargs before Pydantic validation
- Preserves explicit references to both objects for logging and callback behavior
- Continues excluding `proxy_server_request` from the standard and Bedrock parameter dumps as defense in depth
- Adds behavior-level regression coverage for the standard and Bedrock rerank paths

## User Flow

Before: sustained large rerank requests can make the proxy unavailable

1. A developer sends repeated `POST https://<proxy-host>/rerank` requests containing hundreds of large documents
2. The LiteLLM logging object retains the proxy request and enters `GenericLiteLLMParams`
3. Pydantic traverses the retained request state during model validation and serialization
4. CPU usage, resident memory, swap usage, and memory pressure increase
5. Rerank and health requests eventually stop responding until the service is restarted

After: runtime-only request state does not enter provider parameter validation or serialization

1. The developer sends the same type of rerank request
2. LiteLLM removes `proxy_server_request` and `litellm_logging_obj` from provider kwargs before constructing `GenericLiteLLMParams`
3. Provider calls receive only the parameters they require
4. Logging and callbacks retain access to their explicit request context
5. The rerank request completes and the proxy remains responsive without the Pydantic serialization hotspot

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The focused tests covering my change pass locally
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves one specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** for the latest commit before requesting a maintainer review (Greptile reviews automatically once the PR is opened; comment `@greptileai` to request
another review after pushing changes)

## Screenshots / Proof of Fix

The production investigation used LiteLLM 1.100.0 under sustained rerank traffic.

The first revision of this PR excluded `proxy_server_request` only when calling `model_dump()`. Production profiling showed that this was insufficient: `litellm_logging_obj` was still present when constructing `GenericLiteLLMParams`, and the logging object retained the proxy request state.

The current revision removes both runtime-only objects before Pydantic validation while preserving explicit references for logging and callbacks.

### Before the complete fix

During approximately 69 minutes of sustained traffic:

1. LiteLLM processed 25,499 rerank requests
2. Python RSS increased from approximately 1.5 GiB to 4.3 GiB
3. The service used 511 MiB of swap
4. Memory PSI `full avg10` reached 88.71%
5. The service remained active according to systemd but stopped responding normally
6. Restarting the service took approximately 94 seconds
7. Pyroscope attributed 71.03% of sampled CPU to Pydantic `model_dump` from `litellm/rerank_api/main.py`

The Prisma process did not exhibit the same memory growth; the increase was isolated to the Python process handling rerank traffic.

### After the complete fix

After deploying the current implementation:

1. Live rerank requests returned HTTP 200
2. `GET /health/liveliness` returned `I'm alive!`
3. The service remained active and responsive
4. Resident memory settled near 878 MiB
5. Peak memory was approximately 1.436 GiB
6. Swap usage remained at zero
7. A post-fix Pyroscope sample did not contain `model_dump` among its top 80 nodes

### Unit verification

Focused verification:

```text
tests/test_litellm/rerank_api/test_main.py
2 passed, 7 deselected
```

The regression coverage:

- Exercises real Fireworks and Bedrock rerank transformations
- Uses httpx.MockTransport instead of mocking provider call arguments
- Supplies a logging object that retains the proxy request, matching the production ownership relationship
- Uses a Pydantic serialization probe that raises if runtime request state is traversed
- Confirms both rerank paths still return observable provider results

Both focused tests pass with the current fix.

Type

🐛 Bug Fix

Caveats

The production measurements come from a home-lab deployment under sustained rerank traffic. They establish the observed failure path and the effect of removing runtime-only state before validation, but they do not quantify the impact across larger LiteLLM deployments.

Final Attestation

- The tests cover the observed serialization regression in both the standard and Bedrock rerank paths
- The tests assert consumer-visible rerank behavior rather than provider call wiring
- Logging and callback request context remains available through explicit references