### PR TITLE
fix(databricks): route Unity model services through AI Gateway

### DIFF
--- a/litellm/llms/databricks/chat/transformation.py
+++ b/litellm/llms/databricks/chat/transformation.py
@@ -250,8 +250,10 @@ class DatabricksConfig(DatabricksBase, OpenAILikeChatConfig, AnthropicConfig):
         litellm_params: dict,
         stream: bool | None = None,
     ) -> str:
-        api_base = self._get_api_base(api_base)
-        complete_url: Final = f"{api_base}/chat/completions"
+        use_ai_gateway: Final = model.removeprefix("databricks/").count(".") >= 2
+        api_base = self._get_api_base(api_base, use_ai_gateway=use_ai_gateway)
+        url_base: Final = api_base.rstrip("/") if use_ai_gateway else api_base
+        complete_url: Final = f"{url_base}/chat/completions"
         return complete_url
 
     def get_supported_openai_params(self, model: str | None = None) -> list:

--- a/litellm/llms/databricks/common_utils.py
+++ b/litellm/llms/databricks/common_utils.py
@@ -177,19 +177,13 @@ class DatabricksBase:
         # Default: just litellm
         return f"litellm/{version}"
 
-    def _get_api_base(self, api_base: str | None) -> str:
-        """
-        Get the Databricks API base URL.
-
-        If not provided, attempts to get it from the Databricks SDK.
-        """
+    def _get_api_base(self, api_base: str | None, use_ai_gateway: bool = False) -> str:
         if api_base is None:
             try:
                 from databricks.sdk import WorkspaceClient
 
                 databricks_client: Final = WorkspaceClient()
                 api_base = f"{databricks_client.config.host}/serving-endpoints"
-                return api_base
             except ImportError:
                 raise DatabricksException(
                     status_code=400,
@@ -198,6 +192,18 @@ class DatabricksBase:
                         "or install the databricks-sdk Python library."
                     ),
                 )
+
+        if not use_ai_gateway:
+            return api_base
+
+        normalized_api_base: Final = api_base.rstrip("/")
+        if normalized_api_base.endswith("/ai-gateway/mlflow/v1"):
+            return normalized_api_base
+        if normalized_api_base.endswith("/serving-endpoints"):
+            return f"{normalized_api_base.removesuffix('/serving-endpoints')}/ai-gateway/mlflow/v1"
+        api_base_parts: Final = urlsplit(normalized_api_base)
+        if api_base_parts.path in ("", "/"):
+            return f"{normalized_api_base}/ai-gateway/mlflow/v1"
         return api_base
 
     def _get_oauth_m2m_token(

--- a/tests/test_litellm/llms/databricks/chat/test_databricks_chat_transformation.py
+++ b/tests/test_litellm/llms/databricks/chat/test_databricks_chat_transformation.py
@@ -255,6 +255,19 @@ def test_transform_messages_sanitizes_empty_content():
     assert result[1]["content"] == "Hi"
 
 
+def test_transform_request_preserves_unity_model_service_name():
+    config = DatabricksConfig()
+    result = config.transform_request(
+        model="system.ai.kimi-k3",
+        messages=[{"role": "user", "content": "hello"}],
+        optional_params={},
+        litellm_params={},
+        headers={},
+    )
+
+    assert result["model"] == "system.ai.kimi-k3"
+
+
 def test_transform_request_strips_thinking_blocks_and_reasoning_content():
     """Regression for LIT-6762: replaying an assistant turn that litellm decorated with
     `thinking_blocks` / `reasoning_content` made Databricks 400 with

--- a/tests/test_litellm/llms/databricks/test_databricks_partner_integration.py
+++ b/tests/test_litellm/llms/databricks/test_databricks_partner_integration.py
@@ -657,6 +657,77 @@ class TestEndpointURLConstruction:
 
         assert api_base.endswith("/chat/completions")
 
+    def test_chat_gateway_endpoint_for_unity_model_on_legacy_base(self, monkeypatch):
+        from litellm.llms.databricks.chat.transformation import DatabricksConfig
+
+        monkeypatch.delenv("DATABRICKS_CLIENT_ID", raising=False)
+        monkeypatch.delenv("DATABRICKS_CLIENT_SECRET", raising=False)
+
+        url = DatabricksConfig().get_complete_url(
+            api_base="https://test.net/serving-endpoints",
+            api_key="test-key",
+            model="system.ai.kimi-k3",
+            optional_params={},
+            litellm_params={},
+        )
+
+        assert url == "https://test.net/ai-gateway/mlflow/v1/chat/completions"
+
+    def test_chat_gateway_endpoint_preserves_explicit_gateway_base(self, monkeypatch):
+        from litellm.llms.databricks.chat.transformation import DatabricksConfig
+
+        monkeypatch.delenv("DATABRICKS_CLIENT_ID", raising=False)
+        monkeypatch.delenv("DATABRICKS_CLIENT_SECRET", raising=False)
+
+        url = DatabricksConfig().get_complete_url(
+            api_base="https://test.net/ai-gateway/mlflow/v1/",
+            api_key="test-key",
+            model="system.ai.kimi-k3",
+            optional_params={},
+            litellm_params={},
+        )
+
+        assert url == "https://test.net/ai-gateway/mlflow/v1/chat/completions"
+
+    def test_chat_gateway_preserves_unity_model_service_name_with_explicit_base(self, monkeypatch):
+        from litellm.llms.databricks.chat.transformation import DatabricksConfig
+
+        monkeypatch.delenv("DATABRICKS_CLIENT_ID", raising=False)
+        monkeypatch.delenv("DATABRICKS_CLIENT_SECRET", raising=False)
+        config = DatabricksConfig()
+        request = config.transform_request(
+            model="catalog.schema.kimi-k3",
+            messages=[{"role": "user", "content": "hello"}],
+            optional_params={},
+            litellm_params={},
+            headers={},
+        )
+
+        assert config.get_complete_url(
+            api_base="https://test.net/ai-gateway/mlflow/v1",
+            api_key="test-key",
+            model="catalog.schema.kimi-k3",
+            optional_params={},
+            litellm_params={},
+        ) == "https://test.net/ai-gateway/mlflow/v1/chat/completions"
+        assert request["model"] == "catalog.schema.kimi-k3"
+
+    def test_chat_legacy_endpoint_remains_default(self, monkeypatch):
+        from litellm.llms.databricks.chat.transformation import DatabricksConfig
+
+        monkeypatch.delenv("DATABRICKS_CLIENT_ID", raising=False)
+        monkeypatch.delenv("DATABRICKS_CLIENT_SECRET", raising=False)
+
+        url = DatabricksConfig().get_complete_url(
+            api_base="https://test.net/serving-endpoints",
+            api_key="test-key",
+            model="databricks-kimi-k3",
+            optional_params={},
+            litellm_params={},
+        )
+
+        assert url == "https://test.net/serving-endpoints/chat/completions"
+
     def test_embeddings_endpoint(self, monkeypatch):
         """Embeddings endpoint is correctly appended."""
         monkeypatch.delenv("DATABRICKS_CLIENT_ID", raising=False)


### PR DESCRIPTION
## TLDR

Problem this solves:

- Enforced Databricks workspaces reject legacy `databricks-*` model names with HTTP 501
- LiteLLM currently sends fully qualified Unity model-service names to `/serving-endpoints`

How it solves it:

- Routes fully qualified Unity model names through `/ai-gateway/mlflow/v1`
- Preserves legacy model names and serving-endpoint URLs
- Preserves Unity model names and normalizes Gateway trailing slashes

## User Flow

Before: a Databricks Unity model-service request reaches the legacy surface and fails

1. They configure `model: databricks/system.ai.kimi-k3` with a Databricks workspace base
2. LiteLLM sends the request to `/serving-endpoints/chat/completions`
3. Databricks returns HTTP 501 with `Use Unity Catalog model services (v3)`

After: the same configured Unity model-service request reaches the Gateway surface

1. They configure `model: databricks/system.ai.kimi-k3` with the same workspace base
2. LiteLLM sends the request to `/ai-gateway/mlflow/v1/chat/completions`
3. Databricks receives `system.ai.kimi-k3` in the request body

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The Databricks provider test suite passes locally
- [x] The required lint and budget gates pass locally
- [x] The PR scope is isolated to Databricks chat routing
- [ ] I have received a Greptile confidence score of at least 4/5

## Screenshots / Proof of Fix

Shared setup: isolated Postgres on port 15432 and a local Databricks-like HTTP stub on port 15433. The stub returns the reported HTTP 501 for `databricks-kimi-k3` and returns an OpenAI-compatible 200 response for `system.ai.kimi-k3`. No Databricks credentials were available, so the stub proves LiteLLM's emitted wire request and proxy behavior.

### Before (legacy base, unfixed behavior)

1. POST `/v1/chat/completions` with model alias `databricks-kimi-k3`
2. LiteLLM sends `POST /serving-endpoints/chat/completions` with model `databricks-kimi-k3`
3. The upstream returns HTTP 501 with the reported `NOT_IMPLEMENTED` body

### After (Unity model service, fixed behavior)

1. POST `/v1/chat/completions` with model alias `databricks-kimi-k3`
2. LiteLLM sends `POST /ai-gateway/mlflow/v1/chat/completions` with model `system.ai.kimi-k3`
3. The upstream returns HTTP 200 and LiteLLM returns the assistant response
4. Tools and `max_tokens` remain unchanged on the upstream request

## Type

Bug Fix

## Caveats

### Medium

- The model-service identifier must be a registered Unity Catalog model service
- The provider uses a fully qualified model name with at least two dots as the Gateway discriminator
- Embeddings and Responses API routing remain unchanged
- Databricks OAuth M2M URL handling is already fixed separately in staging

## Final Attestation

- [x] The tests check legacy and Unity model-service request shapes
- [x] The same isolated proxy rig reproduced the failure and verified the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMu8TwfrrHsmQPU1gg7g2P

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only Databricks chat URL construction with a dot-count heuristic; misclassification could send some models to the wrong surface, but embeddings/responses paths are untouched.
> 
> **Overview**
> Fixes Databricks chat calls for **Unity Catalog model service** names (e.g. `system.ai.kimi-k3`, `catalog.schema.model`) that were hitting legacy `/serving-endpoints/chat/completions` and failing with HTTP 501 on enforced workspaces.
> 
> **Routing:** `DatabricksConfig.get_complete_url` treats a model as Unity when the name (after stripping `databricks/`) has **at least two dots**, then builds `/ai-gateway/mlflow/v1/chat/completions`. Legacy names like `databricks-kimi-k3` still use `/serving-endpoints/chat/completions`.
> 
> **Base URL normalization:** `_get_api_base(..., use_ai_gateway=True)` maps common bases—`/serving-endpoints`, bare workspace host, or an already-set gateway path—to `/ai-gateway/mlflow/v1` and strips trailing slashes on the gateway path before appending `/chat/completions`.
> 
> **Tests** cover gateway vs legacy URLs, explicit gateway bases, and that request bodies keep fully qualified Unity model strings unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 673c374e079b3669626ec0545571b8b74c65cd08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->