### PR TITLE
fix(ui): preserve dotted MCP tool argument names

### DIFF
--- a/ui/litellm-dashboard/src/components/mcp_tools/MCPToolArgumentsForm.integration.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/MCPToolArgumentsForm.integration.test.tsx
@@ -41,7 +41,7 @@ describe("MCPToolArgumentsForm", () => {
     fireEvent.change(screen.getByRole("textbox", { name: "filter.category *" }), {
       target: { value: "invoices" },
     });
-    fireEvent.change(screen.getByRole("textbox", { name: "filter", exact: true }), {
+    fireEvent.change(screen.getByRole("textbox", { name: "filter" }), {
       target: { value: '{"category":"receipts","metadata":{"region":"eu"}}' },
     });
     fireEvent.change(screen.getByRole("spinbutton", { name: "page.limit" }), { target: { value: "7" } });

--- a/ui/litellm-dashboard/src/components/mcp_tools/MCPToolArgumentsForm.integration.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/MCPToolArgumentsForm.integration.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect } from "vitest";
 import MCPToolArgumentsForm, { MCPToolArgumentsFormRef } from "./MCPToolArgumentsForm";
@@ -26,6 +26,118 @@ const submitError = async (ref: React.RefObject<MCPToolArgumentsFormRef | null>)
 };
 
 describe("MCPToolArgumentsForm", () => {
+  it("keeps dotted arguments separate from a same-prefix object and converts their values", async () => {
+    const ref = renderForm({
+      type: "object",
+      properties: {
+        "filter.category": { type: "string" },
+        filter: { type: "object" },
+        "page.limit": { type: "integer" },
+        query: { type: "string" },
+      },
+      required: ["filter.category"],
+    });
+
+    fireEvent.change(screen.getByRole("textbox", { name: "filter.category *" }), {
+      target: { value: "invoices" },
+    });
+    fireEvent.change(screen.getByRole("textbox", { name: "filter", exact: true }), {
+      target: { value: '{"category":"receipts","metadata":{"region":"eu"}}' },
+    });
+    fireEvent.change(screen.getByRole("spinbutton", { name: "page.limit" }), { target: { value: "7" } });
+    fireEvent.change(screen.getByRole("textbox", { name: "query" }), { target: { value: "September" } });
+
+    const expected = {
+      "filter.category": "invoices",
+      filter: { category: "receipts", metadata: { region: "eu" } },
+      "page.limit": 7,
+      query: "September",
+    };
+    await expect(submit(ref)).resolves.toEqual(expected);
+  });
+
+  it("shows required validation on the literal dotted field and accepts a correction", async () => {
+    const ref = renderForm({
+      type: "object",
+      properties: { "filter.category": { type: "string" } },
+      required: ["filter.category"],
+    });
+
+    expect(await submitError(ref)).toEqual({
+      errorFields: [{ name: ["filter.category"], errors: ["Please enter filter.category"] }],
+    });
+    expect(await screen.findByText("Please enter filter.category")).toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: "filter.category *" })).toHaveAttribute("aria-invalid", "true");
+
+    fireEvent.change(screen.getByRole("textbox", { name: "filter.category *" }), {
+      target: { value: "invoices" },
+    });
+    await expect(submit(ref)).resolves.toEqual({ "filter.category": "invoices" });
+  });
+
+  it("validates JSON for dotted arguments inside params and preserves their literal names", async () => {
+    const ref = renderForm({
+      type: "object",
+      properties: {
+        params: {
+          type: "object",
+          properties: { "filter.options": { type: "object" } },
+          required: ["filter.options"],
+        },
+      },
+      required: [],
+    });
+    const field = screen.getByRole("textbox", { name: "filter.options *" });
+    fireEvent.change(field, { target: { value: "invalid" } });
+
+    expect(await submitError(ref)).toEqual({
+      errorFields: [{ name: ["filter.options"], errors: ["Invalid JSON"] }],
+    });
+    expect(await screen.findByText("Invalid JSON")).toBeInTheDocument();
+
+    fireEvent.change(field, { target: { value: '{"region":"eu"}' } });
+    await expect(submit(ref)).resolves.toEqual({ params: { "filter.options": { region: "eu" } } });
+  });
+
+  it("resets dotted defaults and positional values when the selected tool changes", async () => {
+    const ref = React.createRef<MCPToolArgumentsFormRef>();
+    const { rerender } = render(
+      <MCPToolArgumentsForm
+        ref={ref}
+        tool={toolWith({
+          type: "object",
+          properties: { "filter.category": { type: "string", default: "invoices" } },
+          required: [],
+        })}
+      />,
+    );
+    expect(screen.getByRole("textbox", { name: "filter.category" })).toHaveValue("invoices");
+    await expect(submit(ref)).resolves.toEqual({ "filter.category": "invoices" });
+    fireEvent.change(screen.getByRole("textbox", { name: "filter.category" }), {
+      target: { value: "edited" },
+    });
+    await expect(submit(ref)).resolves.toEqual({ "filter.category": "edited" });
+
+    rerender(
+      <MCPToolArgumentsForm
+        ref={ref}
+        tool={{
+          ...toolWith({
+            type: "object",
+            properties: {
+              query: { type: "string", default: "new tool" },
+              "filter.category": { type: "string", default: "receipts" },
+            },
+            required: [],
+          }),
+          name: "another_tool",
+        }}
+      />,
+    );
+    expect(screen.getByRole("textbox", { name: "filter.category" })).toHaveValue("receipts");
+    await expect(submit(ref)).resolves.toEqual({ query: "new tool", "filter.category": "receipts" });
+  });
+
   it("returns typed values for a string, integer, number and boolean field", async () => {
     const user = userEvent.setup();
     const ref = renderForm({

--- a/ui/litellm-dashboard/src/components/mcp_tools/MCPToolArgumentsForm.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/MCPToolArgumentsForm.tsx
@@ -9,7 +9,10 @@ import { Textarea } from "@/components/ui/textarea";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { MCPTool, InputSchema, InputSchemaProperty } from "./types";
 
-type ToolFormValues = Record<string, unknown>;
+type ToolFormValues = { args: unknown[] };
+
+const argumentValues = (schema: InputSchema, values: ToolFormValues): Record<string, unknown> =>
+  Object.fromEntries(Object.keys(schema.properties ?? {}).map((key, index) => [key, values.args[index]]));
 
 const STRING_SCHEMA_MESSAGES: Readonly<Record<string, string>> = { input: "Please enter input for this tool" };
 
@@ -38,7 +41,7 @@ type FieldError = { type: string; message: string };
 const collectErrors = (
   actualSchema: InputSchema,
   requiredMessages: Readonly<Record<string, string>>,
-  values: ToolFormValues,
+  values: Record<string, unknown>,
 ): Record<string, FieldError> => {
   const entries = Object.entries(actualSchema.properties ?? {}).flatMap<[string, FieldError]>(([key, prop]) => {
     const value = values[key];
@@ -57,8 +60,18 @@ const collectErrors = (
 const buildResolver =
   (actualSchema: InputSchema, requiredMessages: Readonly<Record<string, string>> = {}): Resolver<ToolFormValues> =>
   (values) => {
-    const errors = collectErrors(actualSchema, requiredMessages, values);
-    return Object.keys(errors).length > 0 ? { values: {}, errors } : { values, errors: {} };
+    const errors = collectErrors(actualSchema, requiredMessages, argumentValues(actualSchema, values));
+    if (Object.keys(errors).length === 0) return { values, errors: {} };
+    return {
+      values: {},
+      errors: {
+        args: Object.fromEntries(
+          Object.keys(actualSchema.properties ?? {}).flatMap((key, index) =>
+            Object.hasOwn(errors, key) ? [[index, errors[key]]] : [],
+          ),
+        ),
+      },
+    };
   };
 
 const labelFor = (key: string, prop: InputSchemaProperty, required: boolean): React.ReactNode => (
@@ -238,10 +251,7 @@ const MCPToolArgumentsForm = forwardRef<MCPToolArgumentsFormRef, MCPToolArgument
     }, [schema]);
 
     const defaultValues = useMemo<ToolFormValues>(
-      () =>
-        Object.fromEntries(
-          Object.entries(actualSchema.properties ?? {}).map(([key, prop]) => [key, getInitialValueForField(prop)]),
-        ),
+      () => ({ args: Object.values(actualSchema.properties ?? {}).map(getInitialValueForField) }),
       [actualSchema],
     );
 
@@ -255,7 +265,7 @@ const MCPToolArgumentsForm = forwardRef<MCPToolArgumentsFormRef, MCPToolArgument
 
     useImperativeHandle(ref, () => ({
       getSubmitValues: async () => {
-        const values = form.getValues();
+        const values = argumentValues(actualSchema, form.getValues());
         const errors = collectErrors(actualSchema, requiredMessages, values);
         if (Object.keys(errors).length > 0) {
           await form.trigger();
@@ -286,14 +296,16 @@ const MCPToolArgumentsForm = forwardRef<MCPToolArgumentsFormRef, MCPToolArgument
           <FieldGroup>
             <FormField
               control={form.control}
-              name="input"
+              name="args.0"
               label={
                 <span>
                   Input <span className="text-destructive">*</span>
                 </span>
               }
             >
-              {(field) => <Input {...field} value={field.value as string} placeholder="Enter input for this tool" />}
+              {(field) => (
+                <Input {...field} value={(field.value as string) ?? ""} placeholder="Enter input for this tool" />
+              )}
             </FormField>
           </FieldGroup>
         </form>
@@ -318,13 +330,13 @@ const MCPToolArgumentsForm = forwardRef<MCPToolArgumentsFormRef, MCPToolArgument
           className={className}
         >
           <FieldGroup>
-            {Object.entries(actualSchema.properties).map(([key, prop]) => {
+            {Object.entries(actualSchema.properties).map(([key, prop], index) => {
               const required = actualSchema.required?.includes(key) ?? false;
               return (
                 <FormField
                   key={`${tool.name}-${key}`}
                   control={form.control}
-                  name={key}
+                  name={`args.${index}`}
                   label={labelFor(key, prop, required)}
                 >
                   {(field) => {
@@ -375,7 +387,7 @@ const MCPToolArgumentsForm = forwardRef<MCPToolArgumentsFormRef, MCPToolArgument
                           {...field}
                           type="number"
                           step={prop.type === "integer" ? 1 : undefined}
-                          value={field.value as number | string}
+                          value={(field.value as number | string) ?? ""}
                           placeholder={prop.description || `Enter ${key}`}
                         />
                       );
@@ -385,7 +397,7 @@ const MCPToolArgumentsForm = forwardRef<MCPToolArgumentsFormRef, MCPToolArgument
                         <Textarea
                           {...field}
                           rows={prop.type === "object" ? 4 : 3}
-                          value={field.value as string}
+                          value={(field.value as string) ?? ""}
                           spellCheck={false}
                           className="font-mono"
                           placeholder={
@@ -398,7 +410,7 @@ const MCPToolArgumentsForm = forwardRef<MCPToolArgumentsFormRef, MCPToolArgument
                     return (
                       <Input
                         {...field}
-                        value={field.value as string}
+                        value={(field.value as string) ?? ""}
                         placeholder={prop.description || `Enter ${key}`}
                       />
                     );

--- a/ui/litellm-dashboard/src/components/mcp_tools/MCPToolArgumentsForm.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/MCPToolArgumentsForm.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef, useImperativeHandle, useMemo } from "react";
 import { CircleHelp } from "lucide-react";
-import { useForm, type Resolver } from "react-hook-form";
+import { useForm, type Resolver, type ResolverResult } from "react-hook-form";
 import { FieldGroup } from "@/components/ui/field";
 import { FormField } from "@/components/shared/form/FormField";
 import { Input } from "@/components/ui/input";
@@ -59,7 +59,7 @@ const collectErrors = (
 
 const buildResolver =
   (actualSchema: InputSchema, requiredMessages: Readonly<Record<string, string>> = {}): Resolver<ToolFormValues> =>
-  (values) => {
+  (values): ResolverResult<ToolFormValues> => {
     const errors = collectErrors(actualSchema, requiredMessages, argumentValues(actualSchema, values));
     if (Object.keys(errors).length === 0) return { values, errors: {} };
     return {


### PR DESCRIPTION
## TLDR

Problem this solves:

- Playground nests literal dotted MCP argument names
- Filled required fields can fail validation

How it solves it:

- Store form values by position
- Restore exact schema names for validation and submission

## User Flow

Before: a filled dotted parameter fails validation or changes shape

1. Open http://localhost:45777/ui/playground/, choose `/mcp-rest/tools/call`, and select the MCP server
2. Select a tool declaring `filter.category` and enter `invoices`
3. Send the request: a required field reports `Please enter filter.category`; an optional field sends `{"filter":{"category":"invoices"}}`

After: the same parameter reaches the tool with its exact name

1. Open http://localhost:45777/ui/playground/, choose `/mcp-rest/tools/call`, and select the MCP server
2. Select a tool declaring `filter.category` and enter `invoices`
3. Send the request: both required and optional fields send `{"filter.category":"invoices"}`

## Relevant issues

Regression identified in #37349

## Linear ticket

Resolves LIT-5777

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible
- [x] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review
- [x] Contributor agreement requirement passes

Extended the existing form tests and renamed the file to `.integration.test.tsx` because it renders real form controls. All 18 tests pass locally; the four new cases fail against the original form. Coverage includes literal keys, collisions with a same-prefix object, numeric conversion, required and JSON validation, the params wrapper, defaults, and changing tools

Local validation: dashboard Prettier, changed-file ESLint, whole-dashboard lint budgets, Knip, and the root Dockerfile production build pass. Backend gates are skipped by the current CI change classifier for this UI-only diff

All 33 required CI checks pass. Greptile reviewed `0b21b99ebd193872c520996cec79defad07ee108` with confidence 5/5 and no actionable findings. The sole commit author is `joshua-berri`, whose existing CLA signature is [confirmed by CLA assistant](https://github.com/BerriAI/litellm/pull/40359#issuecomment-5595808317)

## Screenshots / Proof of Fix

[Reproduction setup and complete evidence](https://github.com/BerriAI/litellm/tree/8b731fb0b81a57a0465419772f2fe09b77f85767)

Both images were built with the root Dockerfile, including the dashboard, and run with isolated PostgreSQL and a real MCP SDK echo server. No mocks or LLM calls. The same values are used throughout: `filter.category` = `invoices`, `query` = `September`, `options` = `{"region":"eu"}`. Scroll inside the argument form to reach the JSON field

Start `REVISION=before docker compose up -d` using the linked fixture, then switch with `REVISION=after docker compose up -d gateway`. Log in at http://localhost:45777/ui/login/ using your local credentials. Image IDs and full source revisions are recorded in [source-images.json](https://raw.githubusercontent.com/BerriAI/litellm/8b731fb0b81a57a0465419772f2fe09b77f85767/source-images.json)

### Before (b7dad8b44e30e87e6ae174ea6f58054e17cfc8a5)

#### Required dotted parameter

1. Open http://localhost:45777/ui/playground/ and choose `/mcp-rest/tools/call`, server `dotted_echo`, tool `echo_required`
2. Enter the three values above and click the send arrow
3. Observe `Please enter filter.category` below the filled field; no tool request is sent

   ![Required dotted parameter fails despite a filled input](https://raw.githubusercontent.com/BerriAI/litellm/8b731fb0b81a57a0465419772f2fe09b77f85767/before-required.png)

#### Optional dotted parameter

1. Clear Chat, select `echo_optional`, and enter the same three values
2. Click send: `POST http://localhost:45777/mcp-rest/tools/call` returns HTTP 200, but sends and echoes `{"query":"September","options":{"region":"eu"},"filter":{"category":"invoices"}}`. [Actual request and response](https://raw.githubusercontent.com/BerriAI/litellm/8b731fb0b81a57a0465419772f2fe09b77f85767/before-optional-network.json)

   ![Optional dotted parameter incorrectly becomes a nested object](https://raw.githubusercontent.com/BerriAI/litellm/8b731fb0b81a57a0465419772f2fe09b77f85767/before-optional.png)

### After (0b21b99ebd193872c520996cec79defad07ee108)

#### Required dotted parameter

1. Open http://localhost:45777/ui/playground/ and choose `/mcp-rest/tools/call`, server `dotted_echo`, tool `echo_required`
2. Enter the three values above and click the send arrow
3. Observe HTTP 200 with arguments and echo `{"filter.category":"invoices","query":"September","options":{"region":"eu"}}`. [Actual request and response](https://raw.githubusercontent.com/BerriAI/litellm/8b731fb0b81a57a0465419772f2fe09b77f85767/after-required-network.json)

   ![Required dotted parameter submits successfully with its literal name](https://raw.githubusercontent.com/BerriAI/litellm/8b731fb0b81a57a0465419772f2fe09b77f85767/after-required.png)

#### Optional dotted parameter

1. Clear Chat, select `echo_optional`, and enter the same three values
2. Click send: `POST http://localhost:45777/mcp-rest/tools/call` returns HTTP 200 with arguments and echo `{"filter.category":"invoices","query":"September","options":{"region":"eu"}}`. [Actual request and response](https://raw.githubusercontent.com/BerriAI/litellm/8b731fb0b81a57a0465419772f2fe09b77f85767/after-optional-network.json)

   ![Optional dotted parameter preserves its literal name](https://raw.githubusercontent.com/BerriAI/litellm/8b731fb0b81a57a0465419772f2fe09b77f85767/after-optional.png)

## Type

Bug Fix

## Caveats

### Low

- Existing non-required OSV dependency failure tracked in #40478

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change to MCP playground argument form internals; submit payload shape stays schema-keyed and is covered by new integration tests.
> 
> **Overview**
> Fixes MCP playground tool arguments where **literal dotted property names** (e.g. `filter.category`) were mishandled: required fields could fail validation despite input, and optional fields could be sent as nested objects instead of flat keys.
> 
> **`MCPToolArgumentsForm`** now keeps react-hook-form state in a positional **`args[]`** array (`args.0`, `args.1`, …) rather than object keys, then maps back to the schema’s exact property names for validation, error reporting, and **`getSubmitValues()`** output. The custom resolver translates field errors to the correct array indices; controlled inputs use `?? ""` for empty values.
> 
> Adds **integration tests** for dotted keys alongside same-prefix objects, required/JSON validation (including under `params`), defaults, and reset when switching tools.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b21b99ebd193872c520996cec79defad07ee108. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->