### PR TITLE
fix(ocr): isolate Azure Document Intelligence credential resolution

### DIFF
--- a/litellm/llms/azure_ai/ocr/document_intelligence/transformation.py
+++ b/litellm/llms/azure_ai/ocr/document_intelligence/transformation.py
@@ -92,6 +92,19 @@ class AzureDocumentIntelligenceOCRConfig(BaseOCRConfig):
     def get_api_key_env_var(self) -> str | None:
         return AZURE_DOCUMENT_INTELLIGENCE_API_KEY_ENV_VAR
 
+    def resolve_connection_params(
+        self,
+        *,
+        api_key: str | None,
+        api_base: str | None,
+        dynamic_api_key: str | None,
+        dynamic_api_base: str | None,
+    ) -> tuple[str | None, str | None]:
+        return (
+            (dynamic_api_key or api_key) if api_key is not None else None,
+            (dynamic_api_base or api_base) if api_base is not None else None,
+        )
+
     def get_supported_ocr_params(self, model: str) -> list:
         """
         Get supported OCR parameters for Azure Document Intelligence.

--- a/litellm/llms/azure_ai/ocr/document_intelligence/transformation.py
+++ b/litellm/llms/azure_ai/ocr/document_intelligence/transformation.py
@@ -100,10 +100,9 @@ class AzureDocumentIntelligenceOCRConfig(BaseOCRConfig):
         dynamic_api_key: str | None,
         dynamic_api_base: str | None,
     ) -> tuple[str | None, str | None]:
-        return (
-            (dynamic_api_key or api_key) if api_key is not None else None,
-            (dynamic_api_base or api_base) if api_base is not None else None,
-        )
+        explicit_api_key: Final = None if api_key is None else dynamic_api_key or api_key
+        explicit_api_base: Final = None if api_base is None else dynamic_api_base or api_base
+        return explicit_api_key, explicit_api_base
 
     def get_supported_ocr_params(self, model: str) -> list:
         """

--- a/litellm/llms/base_llm/ocr/transformation.py
+++ b/litellm/llms/base_llm/ocr/transformation.py
@@ -144,6 +144,16 @@ class BaseOCRConfig:
         """
         return None
 
+    def resolve_connection_params(
+        self,
+        *,
+        api_key: str | None,
+        api_base: str | None,
+        dynamic_api_key: str | None,
+        dynamic_api_base: str | None,
+    ) -> tuple[str | None, str | None]:
+        return dynamic_api_key or api_key, dynamic_api_base or api_base
+
     def supports_rust_bridge(self) -> bool:
         """Whether the Rust OCR bridge may serve this config when it is enabled for the provider."""
         return True

--- a/litellm/ocr/main.py
+++ b/litellm/ocr/main.py
@@ -94,9 +94,6 @@ def _prepare_ocr_request(
     if doc_type not in ["document_url", "image_url"]:
         raise ValueError(f"Invalid document type: {doc_type}. Must be 'document_url', 'image_url', or 'file'")
 
-    caller_supplied_api_key: Final = api_key is not None
-    caller_supplied_api_base: Final = api_base is not None
-
     (
         model,
         custom_llm_provider,
@@ -109,21 +106,6 @@ def _prepare_ocr_request(
         api_key=api_key,
     )
 
-    suppress_dynamic_api_base: Final = (
-        not caller_supplied_api_base
-        and custom_llm_provider == "azure_ai"
-        and is_azure_document_intelligence_model(model)
-    )
-    suppress_dynamic_api_key: Final = (
-        not caller_supplied_api_key
-        and custom_llm_provider == "azure_ai"
-        and is_azure_document_intelligence_model(model)
-    )
-    if dynamic_api_key and not suppress_dynamic_api_key:
-        api_key = dynamic_api_key
-    if dynamic_api_base and not suppress_dynamic_api_base:
-        api_base = dynamic_api_base
-
     ocr_provider_config: Final = ProviderConfigManager.get_provider_ocr_config(
         model=model,
         provider=litellm.LlmProviders(custom_llm_provider),
@@ -131,6 +113,13 @@ def _prepare_ocr_request(
 
     if ocr_provider_config is None:
         raise ValueError(f"OCR is not supported for provider: {custom_llm_provider}")
+
+    resolved_api_key, resolved_api_base = ocr_provider_config.resolve_connection_params(
+        api_key=api_key,
+        api_base=api_base,
+        dynamic_api_key=dynamic_api_key,
+        dynamic_api_base=dynamic_api_base,
+    )
 
     verbose_logger.debug("OCR call - model: %s, provider: %s", model, custom_llm_provider)
 
@@ -176,7 +165,7 @@ def _prepare_ocr_request(
         optional_params=optional_params,
         litellm_params={
             "litellm_call_id": litellm_call_id,
-            "api_base": api_base,
+            "api_base": resolved_api_base,
         },
         custom_llm_provider=custom_llm_provider,
     )
@@ -184,8 +173,8 @@ def _prepare_ocr_request(
     return _PreparedOCRRequest(
         model=model,
         document=document,
-        api_key=api_key,
-        api_base=api_base,
+        api_key=resolved_api_key,
+        api_base=resolved_api_base,
         custom_llm_provider=custom_llm_provider,
         extra_headers=extra_headers,
         provider_config=ocr_provider_config,

--- a/litellm/ocr/main.py
+++ b/litellm/ocr/main.py
@@ -94,6 +94,7 @@ def _prepare_ocr_request(
     if doc_type not in ["document_url", "image_url"]:
         raise ValueError(f"Invalid document type: {doc_type}. Must be 'document_url', 'image_url', or 'file'")
 
+    caller_supplied_api_key: Final = api_key is not None
     caller_supplied_api_base: Final = api_base is not None
 
     (
@@ -113,7 +114,12 @@ def _prepare_ocr_request(
         and custom_llm_provider == "azure_ai"
         and is_azure_document_intelligence_model(model)
     )
-    if dynamic_api_key:
+    suppress_dynamic_api_key: Final = (
+        not caller_supplied_api_key
+        and custom_llm_provider == "azure_ai"
+        and is_azure_document_intelligence_model(model)
+    )
+    if dynamic_api_key and not suppress_dynamic_api_key:
         api_key = dynamic_api_key
     if dynamic_api_base and not suppress_dynamic_api_base:
         api_base = dynamic_api_base

--- a/tests/test_litellm/ocr/test_ocr_azure_document_intelligence_api_base.py
+++ b/tests/test_litellm/ocr/test_ocr_azure_document_intelligence_api_base.py
@@ -1,16 +1,19 @@
 """
-Regression tests for Azure Document Intelligence api_base resolution in OCR.
+Regression tests for Azure Document Intelligence connection resolution in OCR.
 
 `azure_ai` exposes two OCR services on one provider; the `doc-intelligence`
 sub-route must resolve to `AZURE_DOCUMENT_INTELLIGENCE_ENDPOINT`, not to the
 generic `AZURE_AI_API_BASE` fallback that `get_llm_provider` injects. These tests
 pin that routing and guard the backwards-compatibility contract that an explicitly
-supplied api_base is always honoured.
+supplied connection parameters are always honoured.
 """
+
+import pytest
 
 from litellm.llms.azure_ai.ocr.common_utils import (
     is_azure_document_intelligence_model,
 )
+from litellm.llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
 from litellm.ocr.main import _prepare_ocr_request, _rust_bridge_api_base
 
 _DOC = {"type": "document_url", "document_url": "https://example.com/doc.pdf"}
@@ -22,6 +25,9 @@ _AZURE_AI_API_KEY = "generic-azure-ai-key"
 
 class _FakeLogging:
     def update_from_kwargs(self, **kwargs: object) -> None:
+        return None
+
+    def pre_call(self, **kwargs: object) -> None:
         return None
 
 
@@ -112,9 +118,70 @@ class TestDocIntelligenceApiKeyResolution:
 
         assert prepared.api_key == "explicit-key"
 
+    def test_explicit_secret_references_are_preserved(self, monkeypatch):
+        monkeypatch.setenv("AZURE_AI_API_KEY", _AZURE_AI_API_KEY)
+        monkeypatch.setenv("AZURE_AI_API_BASE", _AZURE_AI_API_BASE)
+
+        prepared = _prepare(
+            "azure_ai/doc-intelligence/prebuilt-layout",
+            "os.environ/AZURE_DOCUMENT_INTELLIGENCE_ENDPOINT",
+            api_key="os.environ/AZURE_DOCUMENT_INTELLIGENCE_API_KEY",
+        )
+
+        assert prepared.api_key == "os.environ/AZURE_DOCUMENT_INTELLIGENCE_API_KEY"
+        assert prepared.api_base == "os.environ/AZURE_DOCUMENT_INTELLIGENCE_ENDPOINT"
+
+    def test_generic_azure_credentials_are_not_forwarded_to_doc_intelligence(self, monkeypatch):
+        monkeypatch.setenv("AZURE_AI_API_KEY", _AZURE_AI_API_KEY)
+        monkeypatch.setenv("AZURE_AI_API_BASE", _AZURE_AI_API_BASE)
+        monkeypatch.delenv("AZURE_DOCUMENT_INTELLIGENCE_API_KEY", raising=False)
+        monkeypatch.delenv("AZURE_DOCUMENT_INTELLIGENCE_ENDPOINT", raising=False)
+
+        prepared = _prepare("azure_ai/doc-intelligence/prebuilt-layout", None, api_key=None)
+
+        assert prepared.api_key is None
+        assert prepared.api_base is None
+
     def test_generic_azure_ai_key_still_applies_to_mistral_ocr(self, monkeypatch):
         monkeypatch.setenv("AZURE_AI_API_KEY", _AZURE_AI_API_KEY)
 
         prepared = _prepare("azure_ai/mistral-document-ai-2505", None, api_key=None)
 
         assert prepared.api_key == _AZURE_AI_API_KEY
+
+
+@pytest.mark.asyncio
+async def test_sync_and_async_request_headers_use_document_intelligence_key(monkeypatch):
+    monkeypatch.setenv("AZURE_AI_API_KEY", _AZURE_AI_API_KEY)
+    monkeypatch.setenv("AZURE_AI_API_BASE", _AZURE_AI_API_BASE)
+    monkeypatch.setenv("AZURE_DOCUMENT_INTELLIGENCE_API_KEY", _DOC_INTELLIGENCE_API_KEY)
+    monkeypatch.setenv("AZURE_DOCUMENT_INTELLIGENCE_ENDPOINT", _DOC_INTELLIGENCE_ENDPOINT)
+    prepared = _prepare("azure_ai/doc-intelligence/prebuilt-layout", None, api_key=None)
+    logging = _FakeLogging()
+    handler = BaseLLMHTTPHandler()
+
+    sync_headers, _, _, _ = handler._prepare_ocr_request(
+        model=prepared.model,
+        document=prepared.document,
+        optional_params=prepared.optional_params,
+        logging_obj=logging,
+        api_key=prepared.api_key,
+        api_base=prepared.api_base,
+        headers=None,
+        provider_config=prepared.provider_config,
+        litellm_params=prepared.litellm_params,
+    )
+    async_headers, _, _, _ = await handler._async_prepare_ocr_request(
+        model=prepared.model,
+        document=prepared.document,
+        optional_params=prepared.optional_params,
+        logging_obj=logging,
+        api_key=prepared.api_key,
+        api_base=prepared.api_base,
+        headers=None,
+        provider_config=prepared.provider_config,
+        litellm_params=prepared.litellm_params,
+    )
+
+    assert sync_headers["Ocp-Apim-Subscription-Key"] == _DOC_INTELLIGENCE_API_KEY
+    assert async_headers["Ocp-Apim-Subscription-Key"] == _DOC_INTELLIGENCE_API_KEY

--- a/tests/test_litellm/ocr/test_ocr_azure_document_intelligence_api_base.py
+++ b/tests/test_litellm/ocr/test_ocr_azure_document_intelligence_api_base.py
@@ -16,6 +16,8 @@ from litellm.ocr.main import _prepare_ocr_request, _rust_bridge_api_base
 _DOC = {"type": "document_url", "document_url": "https://example.com/doc.pdf"}
 _DOC_INTELLIGENCE_ENDPOINT = "https://di.cognitiveservices.azure.com"
 _AZURE_AI_API_BASE = "https://generic-azure-ai.example.com"
+_DOC_INTELLIGENCE_API_KEY = "document-intelligence-key"
+_AZURE_AI_API_KEY = "generic-azure-ai-key"
 
 
 class _FakeLogging:
@@ -30,11 +32,11 @@ def _resolve_secret(name: str) -> str | None:
     }.get(name)
 
 
-def _prepare(model: str, api_base: str | None):
+def _prepare(model: str, api_base: str | None, api_key: str | None = "test-key"):
     return _prepare_ocr_request(
         model=model,
         document=dict(_DOC),
-        api_key="test-key",
+        api_key=api_key,
         api_base=api_base,
         timeout=None,
         custom_llm_provider=None,
@@ -83,3 +85,36 @@ class TestDocIntelligenceApiBaseResolution:
         prepared = _prepare("azure_ai/mistral-document-ai-2505", None)
 
         assert prepared.api_base == _AZURE_AI_API_BASE
+
+
+class TestDocIntelligenceApiKeyResolution:
+    def test_dedicated_key_wins_over_generic_azure_ai_fallback(self, monkeypatch):
+        monkeypatch.setenv("AZURE_AI_API_KEY", _AZURE_AI_API_KEY)
+        monkeypatch.setenv("AZURE_DOCUMENT_INTELLIGENCE_API_KEY", _DOC_INTELLIGENCE_API_KEY)
+        monkeypatch.setenv("AZURE_DOCUMENT_INTELLIGENCE_ENDPOINT", _DOC_INTELLIGENCE_ENDPOINT)
+
+        prepared = _prepare("azure_ai/doc-intelligence/prebuilt-layout", None, api_key=None)
+        headers = prepared.provider_config.validate_environment(
+            headers={},
+            model=prepared.model,
+            api_key=prepared.api_key,
+            api_base=prepared.api_base,
+            litellm_params=prepared.litellm_params,
+        )
+
+        assert headers["Ocp-Apim-Subscription-Key"] == _DOC_INTELLIGENCE_API_KEY
+
+    def test_explicit_key_is_honoured_for_doc_intelligence(self, monkeypatch):
+        monkeypatch.setenv("AZURE_AI_API_KEY", _AZURE_AI_API_KEY)
+        monkeypatch.setenv("AZURE_DOCUMENT_INTELLIGENCE_API_KEY", _DOC_INTELLIGENCE_API_KEY)
+
+        prepared = _prepare("azure_ai/doc-intelligence/prebuilt-layout", None, api_key="explicit-key")
+
+        assert prepared.api_key == "explicit-key"
+
+    def test_generic_azure_ai_key_still_applies_to_mistral_ocr(self, monkeypatch):
+        monkeypatch.setenv("AZURE_AI_API_KEY", _AZURE_AI_API_KEY)
+
+        prepared = _prepare("azure_ai/mistral-document-ai-2505", None, api_key=None)
+
+        assert prepared.api_key == _AZURE_AI_API_KEY

--- a/tests/test_litellm/ocr/test_ocr_azure_document_intelligence_api_base.py
+++ b/tests/test_litellm/ocr/test_ocr_azure_document_intelligence_api_base.py
@@ -1,12 +1,5 @@
-"""
-Regression tests for Azure Document Intelligence connection resolution in OCR.
-
-`azure_ai` exposes two OCR services on one provider; the `doc-intelligence`
-sub-route must resolve to `AZURE_DOCUMENT_INTELLIGENCE_ENDPOINT`, not to the
-generic `AZURE_AI_API_BASE` fallback that `get_llm_provider` injects. These tests
-pin that routing and guard the backwards-compatibility contract that an explicitly
-supplied connection parameters are always honoured.
-"""
+from inspect import isawaitable
+from typing import Final
 
 import pytest
 
@@ -14,7 +7,7 @@ from litellm.llms.azure_ai.ocr.common_utils import (
     is_azure_document_intelligence_model,
 )
 from litellm.llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
-from litellm.ocr.main import _prepare_ocr_request, _rust_bridge_api_base
+from litellm.ocr.main import _prepare_ocr_request, _PreparedOCRRequest, _rust_bridge_api_base
 
 _DOC = {"type": "document_url", "document_url": "https://example.com/doc.pdf"}
 _DOC_INTELLIGENCE_ENDPOINT = "https://di.cognitiveservices.azure.com"
@@ -38,7 +31,7 @@ def _resolve_secret(name: str) -> str | None:
     }.get(name)
 
 
-def _prepare(model: str, api_base: str | None, api_key: str | None = "test-key"):
+def _prepare(model: str, api_base: str | None = None, *, api_key: str | None = None) -> _PreparedOCRRequest:
     return _prepare_ocr_request(
         model=model,
         document=dict(_DOC),
@@ -64,8 +57,6 @@ class TestIsAzureDocumentIntelligenceModel:
 
 class TestDocIntelligenceApiBaseResolution:
     def test_generic_azure_ai_base_does_not_hijack_doc_intelligence(self, monkeypatch):
-        """Without an explicit api_base, the AZURE_AI_API_BASE fallback must not
-        overwrite the endpoint, so it resolves to the Document Intelligence one."""
         monkeypatch.setenv("AZURE_AI_API_BASE", _AZURE_AI_API_BASE)
         monkeypatch.delenv("AZURE_DOCUMENT_INTELLIGENCE_ENDPOINT", raising=False)
 
@@ -75,7 +66,6 @@ class TestDocIntelligenceApiBaseResolution:
         assert _rust_bridge_api_base(prepared, _resolve_secret) == _DOC_INTELLIGENCE_ENDPOINT
 
     def test_explicit_api_base_is_honoured_for_doc_intelligence(self, monkeypatch):
-        """A caller-supplied api_base must always win, even for doc-intelligence."""
         monkeypatch.setenv("AZURE_AI_API_BASE", _AZURE_AI_API_BASE)
 
         custom = "https://my-di.cognitiveservices.azure.com"
@@ -85,7 +75,6 @@ class TestDocIntelligenceApiBaseResolution:
         assert _rust_bridge_api_base(prepared, _resolve_secret) == custom
 
     def test_generic_azure_ai_base_still_applies_to_mistral_ocr(self, monkeypatch):
-        """Non doc-intelligence azure_ai models keep using AZURE_AI_API_BASE."""
         monkeypatch.setenv("AZURE_AI_API_BASE", _AZURE_AI_API_BASE)
 
         prepared = _prepare("azure_ai/mistral-document-ai-2505", None)
@@ -94,43 +83,6 @@ class TestDocIntelligenceApiBaseResolution:
 
 
 class TestDocIntelligenceApiKeyResolution:
-    def test_dedicated_key_wins_over_generic_azure_ai_fallback(self, monkeypatch):
-        monkeypatch.setenv("AZURE_AI_API_KEY", _AZURE_AI_API_KEY)
-        monkeypatch.setenv("AZURE_DOCUMENT_INTELLIGENCE_API_KEY", _DOC_INTELLIGENCE_API_KEY)
-        monkeypatch.setenv("AZURE_DOCUMENT_INTELLIGENCE_ENDPOINT", _DOC_INTELLIGENCE_ENDPOINT)
-
-        prepared = _prepare("azure_ai/doc-intelligence/prebuilt-layout", None, api_key=None)
-        headers = prepared.provider_config.validate_environment(
-            headers={},
-            model=prepared.model,
-            api_key=prepared.api_key,
-            api_base=prepared.api_base,
-            litellm_params=prepared.litellm_params,
-        )
-
-        assert headers["Ocp-Apim-Subscription-Key"] == _DOC_INTELLIGENCE_API_KEY
-
-    def test_explicit_key_is_honoured_for_doc_intelligence(self, monkeypatch):
-        monkeypatch.setenv("AZURE_AI_API_KEY", _AZURE_AI_API_KEY)
-        monkeypatch.setenv("AZURE_DOCUMENT_INTELLIGENCE_API_KEY", _DOC_INTELLIGENCE_API_KEY)
-
-        prepared = _prepare("azure_ai/doc-intelligence/prebuilt-layout", None, api_key="explicit-key")
-
-        assert prepared.api_key == "explicit-key"
-
-    def test_explicit_secret_references_are_preserved(self, monkeypatch):
-        monkeypatch.setenv("AZURE_AI_API_KEY", _AZURE_AI_API_KEY)
-        monkeypatch.setenv("AZURE_AI_API_BASE", _AZURE_AI_API_BASE)
-
-        prepared = _prepare(
-            "azure_ai/doc-intelligence/prebuilt-layout",
-            "os.environ/AZURE_DOCUMENT_INTELLIGENCE_ENDPOINT",
-            api_key="os.environ/AZURE_DOCUMENT_INTELLIGENCE_API_KEY",
-        )
-
-        assert prepared.api_key == "os.environ/AZURE_DOCUMENT_INTELLIGENCE_API_KEY"
-        assert prepared.api_base == "os.environ/AZURE_DOCUMENT_INTELLIGENCE_ENDPOINT"
-
     def test_generic_azure_credentials_are_not_forwarded_to_doc_intelligence(self, monkeypatch):
         monkeypatch.setenv("AZURE_AI_API_KEY", _AZURE_AI_API_KEY)
         monkeypatch.setenv("AZURE_AI_API_BASE", _AZURE_AI_API_BASE)
@@ -150,32 +102,41 @@ class TestDocIntelligenceApiKeyResolution:
         assert prepared.api_key == _AZURE_AI_API_KEY
 
 
+@pytest.mark.parametrize("use_async", (False, True), ids=("sync", "async"))
+@pytest.mark.parametrize(
+    "api_key, api_base, expected_key, expected_endpoint",
+    (
+        pytest.param(None, None, _DOC_INTELLIGENCE_API_KEY, _DOC_INTELLIGENCE_ENDPOINT, id="environment"),
+        pytest.param(
+            "explicit-key",
+            "https://explicit.example.com",
+            "explicit-key",
+            "https://explicit.example.com",
+            id="explicit",
+        ),
+    ),
+)
 @pytest.mark.asyncio
-async def test_sync_and_async_request_headers_use_document_intelligence_key(monkeypatch):
+async def test_document_intelligence_request_uses_its_own_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+    use_async: bool,
+    api_key: str | None,
+    api_base: str | None,
+    expected_key: str,
+    expected_endpoint: str,
+) -> None:
     monkeypatch.setenv("AZURE_AI_API_KEY", _AZURE_AI_API_KEY)
     monkeypatch.setenv("AZURE_AI_API_BASE", _AZURE_AI_API_BASE)
     monkeypatch.setenv("AZURE_DOCUMENT_INTELLIGENCE_API_KEY", _DOC_INTELLIGENCE_API_KEY)
     monkeypatch.setenv("AZURE_DOCUMENT_INTELLIGENCE_ENDPOINT", _DOC_INTELLIGENCE_ENDPOINT)
-    prepared = _prepare("azure_ai/doc-intelligence/prebuilt-layout", None, api_key=None)
-    logging = _FakeLogging()
-    handler = BaseLLMHTTPHandler()
-
-    sync_headers, _, _, _ = handler._prepare_ocr_request(
+    prepared: Final = _prepare("azure_ai/doc-intelligence/prebuilt-layout", api_base, api_key=api_key)
+    handler: Final = BaseLLMHTTPHandler()
+    prepare_request: Final = handler._async_prepare_ocr_request if use_async else handler._prepare_ocr_request
+    result: Final = prepare_request(
         model=prepared.model,
         document=prepared.document,
         optional_params=prepared.optional_params,
-        logging_obj=logging,
-        api_key=prepared.api_key,
-        api_base=prepared.api_base,
-        headers=None,
-        provider_config=prepared.provider_config,
-        litellm_params=prepared.litellm_params,
-    )
-    async_headers, _, _, _ = await handler._async_prepare_ocr_request(
-        model=prepared.model,
-        document=prepared.document,
-        optional_params=prepared.optional_params,
-        logging_obj=logging,
+        logging_obj=_FakeLogging(),
         api_key=prepared.api_key,
         api_base=prepared.api_base,
         headers=None,
@@ -183,5 +144,21 @@ async def test_sync_and_async_request_headers_use_document_intelligence_key(monk
         litellm_params=prepared.litellm_params,
     )
 
-    assert sync_headers["Ocp-Apim-Subscription-Key"] == _DOC_INTELLIGENCE_API_KEY
-    assert async_headers["Ocp-Apim-Subscription-Key"] == _DOC_INTELLIGENCE_API_KEY
+    headers, url, _, _ = await result if isawaitable(result) else result
+
+    assert headers["Ocp-Apim-Subscription-Key"] == expected_key
+    assert url.startswith(f"{expected_endpoint}/documentintelligence/documentModels/prebuilt-layout:analyze?")
+
+
+def test_explicit_secret_references_are_preserved(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AZURE_AI_API_KEY", _AZURE_AI_API_KEY)
+    monkeypatch.setenv("AZURE_AI_API_BASE", _AZURE_AI_API_BASE)
+
+    prepared: Final = _prepare(
+        "azure_ai/doc-intelligence/prebuilt-layout",
+        "os.environ/AZURE_DOCUMENT_INTELLIGENCE_ENDPOINT",
+        api_key="os.environ/AZURE_DOCUMENT_INTELLIGENCE_API_KEY",
+    )
+
+    assert prepared.api_key == "os.environ/AZURE_DOCUMENT_INTELLIGENCE_API_KEY"
+    assert prepared.api_base == "os.environ/AZURE_DOCUMENT_INTELLIGENCE_ENDPOINT"

--- a/tests/test_litellm/proxy/auth/test_auth_utils.py
+++ b/tests/test_litellm/proxy/auth/test_auth_utils.py
@@ -31,6 +31,20 @@ from litellm.proxy.auth.auth_utils import (
 )
 
 
+def test_document_intelligence_rejects_request_endpoint_without_credentials() -> None:
+    with pytest.raises(ValueError, match="api_base is not allowed in request body"):
+        is_request_body_safe(
+            request_body={
+                "model": "azure_ai/doc-intelligence/prebuilt-layout",
+                "api_base": "https://attacker.example.com",
+                "document": {"type": "document_url", "document_url": "https://example.com/document.pdf"},
+            },
+            general_settings={},
+            llm_router=None,
+            model="azure_ai/doc-intelligence/prebuilt-layout",
+        )
+
+
 class TestCustomAuthCommonChecksWarning:
     """custom_auth_common_checks_warning only warns when custom auth is configured
     and the common-checks opt-in is off, since that is the only state where


### PR DESCRIPTION
## TLDR

Problem this solves:

- Generic Azure AI keys override Document Intelligence credentials
- Environment-only sync and async OCR calls return 401

How it solves it:

- Let each OCR adapter resolve connection defaults
- Document Intelligence rejects inferred generic Azure defaults
- Keep explicit keys and Azure Foundry behavior unchanged

## User Flow

The bug occurs when an application configures both Azure AI and Azure Document Intelligence credentials, then calls Document Intelligence OCR without an explicit `api_key`. LiteLLM sends the generic Azure AI key to the Document Intelligence endpoint, causing 401 even though the correct dedicated key is configured

Both services use `litellm.ocr()`; the `model` string selects the service. The keys and resource URLs below are placeholders to replace with your own values

```python
import os
import litellm

os.environ["AZURE_DOCUMENT_INTELLIGENCE_API_KEY"] = "di-key"
os.environ["AZURE_DOCUMENT_INTELLIGENCE_ENDPOINT"] = "https://my-di.cognitiveservices.azure.com"

os.environ["AZURE_AI_API_KEY"] = "foundry-key"
os.environ["AZURE_AI_API_BASE"] = "https://my-foundry-endpoint"

document = {
    "type": "document_url",
    "document_url": (
        "https://cdn.jsdelivr.net/gh/BerriAI/litellm"
        "@d769e81c90d453240c61fc572cdb27fae06a89d0"
        "/tests/llm_translation/fixtures/dummy.pdf"
    ),
}

response = litellm.ocr(
    model="azure_ai/doc-intelligence/prebuilt-layout",
    document=document,
)
print(len(response.pages))
```

Before: the Document Intelligence call fails despite valid dedicated credentials

1. Set both credential pairs as shown above, using distinct valid keys for the two services
2. Run the Document Intelligence SDK call above without passing `api_key` or `api_base`
3. Observe `AuthenticationError` with status 401: the call uses `foundry-key` against the Document Intelligence endpoint instead of `di-key`

After: the same Document Intelligence call uses its dedicated credentials and succeeds

1. Set both credential pairs as shown above, using distinct valid keys for the two services
2. Run the Document Intelligence SDK call above without passing `api_key` or `api_base`
3. Observe `1` parsed page: the call uses `di-key` and `https://my-di.cognitiveservices.azure.com`

The same fix applies to the async SDK call, inside an async function:

```python
response = await litellm.aocr(
    model="azure_ai/doc-intelligence/prebuilt-layout",
    document=document,
)
```

Other Azure OCR services retain their existing behavior. For example, this call uses `AZURE_AI_API_KEY` and `AZURE_AI_API_BASE` before and after the fix, with the model available on the configured endpoint:

```python
response = litellm.ocr(
    model="azure_ai/mistral-document-ai-2505",
    document=document,
)
```

Explicit Document Intelligence credentials also continue to take precedence:

```python
response = litellm.ocr(
    model="azure_ai/doc-intelligence/prebuilt-layout",
    document=document,
    api_key="explicit-di-key",
    api_base="https://another-di.cognitiveservices.azure.com",
)
```

## Relevant issues

The proxy already rejects request-supplied `api_base` unless the administrator enables client-side overrides. A regression test covers the reported Document Intelligence payload without a key. SDK callers can still combine an explicit endpoint with environment credentials

Validation: 125 OCR and provider tests, 317 auth tests, and both live SDK calls pass. The request tests check the final endpoint and subscription-key header for environment and explicit credentials in sync and async modes

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

The live check uses separate Azure AI and Document Intelligence keys, the documented environment-only SDK setup, and a public one-page PDF. [LiteLLM documents these provider-specific variables](https://docs.litellm.ai/docs/providers/azure_document_intelligence), while [Microsoft documents that Document Intelligence calls require the resource key and endpoint](https://learn.microsoft.com/en-us/azure/ai-services/document-intelligence/quickstarts/get-started-sdks-rest-api?view=doc-intel-4.0.0)

### Before (a8bb2f93b9)

1. Run `python /tmp/ocr_auth_matrix.py --case azure-di-env-key --modes both --jobs 1 --delay 1`
2. Observe both real SDK calls reject the environment-selected credential:

```text
BACKEND {"mode": "python"}
RUN     azure-di-env-key  sync  deadline=180s
FAIL    azure-di-env-key  sync  AuthenticationError: Azure_aiException - {"error":{"code":"401","message":"Access denied due to invalid subscription key or wrong API endpoint."}}
RUN     azure-di-env-key  async deadline=180s
FAIL    azure-di-env-key  async AuthenticationError: Azure_aiException - {"error":{"code":"401","message":"Access denied due to invalid subscription key or wrong API endpoint."}}
SUMMARY pass=0 fail=2 timeout=0 skip=0
```

### After (2c10639fcc)

1. Run `python /tmp/ocr_auth_matrix.py --case azure-di-env-key --modes both --jobs 1 --delay 5`
2. Observe both real SDK calls authenticate and parse the one-page PDF:

```text
BACKEND {"mode": "python"}
RUN     azure-di-env-key  sync  deadline=180s
PASS    azure-di-env-key  sync  model=doc-intelligence/prebuilt-layout pages=1 elapsed=6.21s
RUN     azure-di-env-key  async deadline=180s
PASS    azure-di-env-key  async model=doc-intelligence/prebuilt-layout pages=1 elapsed=6.01s
SUMMARY pass=2 fail=0 timeout=0 skip=0 elapsed=12.22s
```

## Type

🐛 Bug Fix

## Caveats (if any)

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
