### PR TITLE
test: give mocked chat completion clients a real payload so the no-choices guard does not trip

### DIFF
--- a/tests/llm_translation/conftest.py
+++ b/tests/llm_translation/conftest.py
@@ -9,6 +9,7 @@ import asyncio
 import importlib
 
 import pytest
+from openai.types.chat import ChatCompletion
 
 
 import litellm  # noqa: E402
@@ -27,6 +28,26 @@ from tests._vcr_conftest_common import (  # noqa: E402,F401
     vcr_config_dict,
 )
 from tests.fake_openai_endpoint import ensure_fake_openai_endpoint  # noqa: E402
+
+
+@pytest.fixture
+def chat_completion_response() -> ChatCompletion:
+    return ChatCompletion.model_validate(
+        {
+            "id": "chatcmpl-123",
+            "object": "chat.completion",
+            "created": 1677652288,
+            "model": "gpt-4o-mini",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "Hello there"},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 9, "completion_tokens": 12, "total_tokens": 21},
+        }
+    )
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/llm_translation/test_azure_o_series.py
+++ b/tests/llm_translation/test_azure_o_series.py
@@ -156,10 +156,13 @@ def test_azure_o_series_routing():
 
 
 @patch("litellm.main.azure_o1_chat_completions._get_openai_client")
-def test_openai_o_series_max_retries_0(mock_get_openai_client):
+def test_openai_o_series_max_retries_0(mock_get_openai_client, chat_completion_response):
     import litellm
 
     litellm.set_verbose = True
+    mock_get_openai_client.return_value.chat.completions.with_raw_response.create.return_value.parse.return_value = (
+        chat_completion_response
+    )
     response = litellm.completion(
         model="azure/o1-preview",
         messages=[{"role": "user", "content": "hi"}],

--- a/tests/llm_translation/test_azure_openai.py
+++ b/tests/llm_translation/test_azure_openai.py
@@ -290,7 +290,7 @@ def test_azure_openai_gpt_4o_naming(monkeypatch):
         # "2024-02-15-preview",
     ],
 )
-def test_azure_gpt_4o_with_tool_call_and_response_format(api_version):
+def test_azure_gpt_4o_with_tool_call_and_response_format(api_version, chat_completion_response):
     from litellm import completion
     from typing import Optional
     from pydantic import BaseModel
@@ -335,6 +335,7 @@ def test_azure_gpt_4o_with_tool_call_and_response_format(api_version):
     ]
 
     with patch.object(client.chat.completions.with_raw_response, "create") as mock_post:
+        mock_post.return_value.parse.return_value = chat_completion_response
         response = litellm.completion(
             model="azure/gpt-4.1-mini",
             messages=[

--- a/tests/llm_translation/test_openai.py
+++ b/tests/llm_translation/test_openai.py
@@ -289,10 +289,13 @@ class TestOpenAIChatCompletion(BaseLLMChatTest):
 
 
 @patch("litellm.main.openai_chat_completions._get_openai_client")
-def test_openai_max_retries_0(mock_get_openai_client):
+def test_openai_max_retries_0(mock_get_openai_client, chat_completion_response):
     import litellm
 
     litellm.set_verbose = True
+    mock_get_openai_client.return_value.chat.completions.with_raw_response.create.return_value.parse.return_value = (
+        chat_completion_response
+    )
     response = litellm.completion(
         model="gpt-4o-mini",
         messages=[{"role": "user", "content": "hi"}],

--- a/tests/local_testing/test_completion.py
+++ b/tests/local_testing/test_completion.py
@@ -3999,7 +3999,7 @@ def test_completion_novita_ai():
     openai_client = OpenAI(api_key="fake-key")
 
     with patch.object(
-        openai_client.chat.completions, "create", new=MagicMock()
+        openai_client.chat.completions, "create", new=MagicMock(return_value=_openai_mock_response())
     ) as mock_call:
         try:
             completion(


### PR DESCRIPTION
## TLDR

Problem this solves:

- Four mocked completion tests fail on every staging pipeline since #40294
- Their bare `MagicMock` responses now trip the new no-choices `APIError`
- `local_testing_part1` and `llm_translation_testing` are red on every PR carrying that merge base

How it solves it:

- Each mock now returns a minimal real chat completion (one assistant message)
- The three `tests/llm_translation` tests share one `chat_completion_response` conftest fixture
- The novita test reuses `test_completion.py`'s existing `_openai_mock_response`
- Every test still asserts on the same `create` call kwargs it was written for
- Test-only change, no proxy or SDK behavior involved

## User Flow

Before: a contributor opens a PR against `litellm_internal_staging` and two CircleCI jobs come back red on tests their change never touched

1. They push a branch and open a PR on https://github.com/BerriAI/litellm against `litellm_internal_staging`
2. On the PR's Checks tab, `ci/circleci: local_testing_part1` and `ci/circleci: llm_translation_testing` show as failed
3. They open the job pages on https://app.circleci.com/pipelines/github/BerriAI/litellm and see `test_completion_novita_ai`, `test_openai_max_retries_0`, `test_azure_gpt_4o_with_tool_call_and_response_format[2024-10-21]`, and `test_openai_o_series_max_retries_0` failing with `litellm.APIError: LiteLLM: provider returned a response with no 'choices'. Raw keys: []`
4. They rerun the jobs and get the same four failures, so they cannot tell whether their own change broke anything in those two jobs

After: the same PR gets green `local_testing_part1` and `llm_translation_testing` jobs unless the contributor's own change breaks something

1. They push a branch and open a PR on https://github.com/BerriAI/litellm against `litellm_internal_staging`
2. On the PR's Checks tab, `ci/circleci: local_testing_part1` and `ci/circleci: llm_translation_testing` show as passed
3. The four tests above show as passed on their job pages, so a red job in either of them now points at the contributor's own change

## Relevant issues

Follow-up to #40294

## Linear ticket


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

This PR changes only test code, so there is no proxy or end-user behavior to drive: the observable behavior is the four tests themselves and the two CircleCI jobs that run them. Both legs run the same four node ids from a fresh worktree with `AZURE_API_KEY` and `AZURE_API_BASE` set the way CircleCI injects them (the o-series test builds an Azure client before it reaches the mock, and it needs those two variables to get that far)

Shared setup:

```
T=("tests/local_testing/test_completion.py::test_completion_novita_ai" "tests/llm_translation/test_openai.py::test_openai_max_retries_0" "tests/llm_translation/test_azure_openai.py::test_azure_gpt_4o_with_tool_call_and_response_format" "tests/llm_translation/test_azure_o_series.py::test_openai_o_series_max_retries_0")
AZURE_API_KEY=... AZURE_API_BASE=... .venv/bin/python -m pytest "${T[@]}" -p no:cacheprovider -q --no-header
```

### Before (26626348f8, the merge base on litellm_internal_staging)

1. Run the command above
2. Observed output:

```
FAILED tests/llm_translation/test_azure_openai.py::test_azure_gpt_4o_with_tool_call_and_response_format[2024-10-21]
FAILED tests/local_testing/test_completion.py::test_completion_novita_ai
FAILED tests/llm_translation/test_openai.py::test_openai_max_retries_0
FAILED tests/llm_translation/test_azure_o_series.py::test_openai_o_series_max_retries_0
4 failed in 0.52s
```

3. Every failure is the same error, wrapped per provider:

```
litellm.exceptions.APIError: litellm.APIError: AzureException APIError - litellm.APIError: LiteLLM: provider returned a response with no 'choices'. Raw keys: []
litellm.exceptions.APIError: litellm.APIError: LiteLLM: provider returned a response with no 'choices'. Raw keys: []
litellm.exceptions.InternalServerError: litellm.InternalServerError: InternalServerError: NovitaException - litellm.APIError: LiteLLM: provider returned a response with no 'choices'. Raw keys: []
litellm.exceptions.InternalServerError: litellm.InternalServerError: InternalServerError: OpenAIException - litellm.APIError: LiteLLM: provider returned a response with no 'choices'. Raw keys: []
litellm.llms.azure.common_utils.AzureOpenAIError: litellm.APIError: LiteLLM: provider returned a response with no 'choices'. Raw keys: []
litellm.llms.openai.common_utils.OpenAIError: litellm.APIError: LiteLLM: provider returned a response with no 'choices'. Raw keys: []
```

### After (74a9b426a6, PR tip)

1. Run the same command
2. Observed output:

```
4 passed in 0.60s
```

3. The two CircleCI jobs that run these tests are green at the same tip: [local_testing_part1](https://app.circleci.com/workflow/10fd1f48-8b0e-4c80-aacb-5ddb9319eab9/job/b9c75a0d-ce18-4837-b8a9-e8bb323429bd) and [llm_translation_testing](https://app.circleci.com/workflow/10fd1f48-8b0e-4c80-aacb-5ddb9319eab9/job/8476474d-6d3c-4e72-99df-0230b49b01f7)

## Type

✅ Test

## Caveats (if any)

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to mock return values; no runtime or production code paths are modified.
> 
> **Overview**
> **Fixes four CI failures** where mocked OpenAI/Azure completion tests started erroring with `provider returned a response with no 'choices'` after the stricter response validation from #40294.
> 
> Adds a shared **`chat_completion_response`** pytest fixture in `tests/llm_translation/conftest.py` (minimal `ChatCompletion` with one assistant choice). Three `llm_translation` tests wire it into mocked `with_raw_response.create` → `.parse` return values so completion parsing succeeds while assertions on `max_retries`, tool/response_format kwargs, etc. stay the same.
> 
> In **`test_completion_novita_ai`**, the bare `MagicMock` on `create` is replaced with `MagicMock(return_value=_openai_mock_response())`, reusing the file’s existing helper.
> 
> **Test-only** — no production/SDK behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74a9b426a642e4393a70217403d201a470adcde7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->