### PR TITLE
feat: search date filtering

### DIFF
--- a/litellm/llms/brave/search/transformation.py
+++ b/litellm/llms/brave/search/transformation.py
@@ -175,6 +175,8 @@ class BraveSearchConfig(BaseSearchConfig):
         - max_results → count
         - search_domain_filter → q (append domain filters)
         - country → country
+        - start_date + end_date → freshness (combined as "YYYY-MM-DDtoYYYY-MM-DD";
+        only sent when both are provided — Brave's custom range requires both)
         - max_tokens_per_page → (not applicable, ignored)
 
         All other Brave Search API-specific parameters are passed through as-is.
@@ -190,36 +192,48 @@ class BraveSearchConfig(BaseSearchConfig):
             # Brave Search API only supports single string queries
             query = " ".join(query)
 
+        remaining = dict(optional_params)
+
         request_data: Final[BraveSearchRequest] = {
             "q": query,
         }
 
         # Only include "include_fetch_metadata" if it is not explicitly set to False
         # This parameter results (more often than not) in a timestamp which we can use for last_updated
-        if "include_fetch_metadata" in optional_params and optional_params["include_fetch_metadata"] is False:
+        if remaining.pop("include_fetch_metadata", None) is False:
             request_data["include_fetch_metadata"] = False
         else:
             request_data["include_fetch_metadata"] = True
 
         # Transform unified spec parameters to Brave Search API format
-        if "max_results" in optional_params:
+        if "max_results" in remaining:
             # Brave Search API supports 1-20 results per /web/search request
-            num_results: Final = min(optional_params["max_results"], 20)
+            num_results: Final = min(remaining.pop("max_results"), 20)
             request_data["count"] = num_results
 
         if "search_domain_filter" in optional_params:
             # Convert to multiple "site:domain" clauses, joined by OR
-            domains: Final = optional_params["search_domain_filter"]
+            domains: Final = remaining.pop("search_domain_filter")
             if isinstance(domains, list) and len(domains) > 0:
                 request_data["q"] = self._append_domain_filters(request_data["q"], domains)
+
+        start_date = remaining.pop("start_date", None)
+        end_date = remaining.pop("end_date", None)
+        if start_date and end_date:
+            request_data["freshness"] = f"{start_date}to{end_date}"
+
+        if "country" in remaining:
+            request_data["country"] = remaining.pop("country")
+
+        # Not applicable therefore popped and ignored
+        if "max_tokens_per_page" in remaining:
+            remaining.pop("max_tokens_per_page")
 
         # Convert to dict before dynamic key assignments
         result_data: Final = dict(request_data)
 
-        # Pass through all other parameters as-is
-        for param, value in optional_params.items():
-            if param not in self.get_supported_perplexity_optional_params() and param not in result_data:
-                result_data[param] = value
+        # Pass through anything the function did not explicitly consume
+        result_data.update(remaining)
 
         # Store params in special key for URL building (Brave Search API uses GET not POST)
         # Return a wrapper dict that stores params for get_complete_url to use

--- a/litellm/llms/linkup/search/transformation.py
+++ b/litellm/llms/linkup/search/transformation.py
@@ -143,6 +143,9 @@ class LinkupSearchConfig(BaseSearchConfig):
         if "end_date" in remaining:
             request_data["toDate"] = remaining.pop("end_date")
 
+        if "max_tokens_per_page" in remaining:
+            remaining.pop("max_tokens_per_page")
+
         # Convert to dict before dynamic key assignments
         result_data: Final = dict(request_data)
 
@@ -198,7 +201,7 @@ class LinkupSearchConfig(BaseSearchConfig):
             elif result_type == "image":
                 # For image results, use the URL as both title and snippet if name not provided
                 search_result = SearchResult(
-                    title=result.get("name", result.get("url", "")),
+                    title=result.get("name") or result.get("url", ""),
                     url=result.get("url", ""),
                     snippet=result.get("content", ""),
                     date=None,

--- a/litellm/llms/linkup/search/transformation.py
+++ b/litellm/llms/linkup/search/transformation.py
@@ -104,6 +104,8 @@ class LinkupSearchConfig(BaseSearchConfig):
         - max_results -> maxResults
         - search_domain_filter -> includeDomains
         - country -> (not directly supported)
+        - start_date -> fromDate
+        - end_date -> toDate
         - max_tokens_per_page -> (not applicable)
 
         All other Linkup-specific parameters are passed through as-is.
@@ -119,26 +121,33 @@ class LinkupSearchConfig(BaseSearchConfig):
             # Linkup only supports single string queries, join with spaces
             query = " ".join(query)
 
+        # Copy for passthrough data (Done this way to avoid having to change / add to Perplexity unified spec parameters)
+        remaining = dict(optional_params)
+
         request_data: Final[LinkupSearchRequest] = {
             "q": query,
-            "depth": optional_params.get("depth", "standard"),
-            "outputType": optional_params.get("outputType", "searchResults"),
+            "depth": remaining.pop("depth", "standard"),
+            "outputType": remaining.pop("outputType", "searchResults"),
         }
 
         # Transform Perplexity unified spec parameters to Linkup format
-        if "max_results" in optional_params:
-            request_data["maxResults"] = optional_params["max_results"]
+        if "max_results" in remaining:
+            request_data["maxResults"] = remaining.pop("max_results")
 
-        if "search_domain_filter" in optional_params:
-            request_data["includeDomains"] = optional_params["search_domain_filter"]
+        if "search_domain_filter" in remaining:
+            request_data["includeDomains"] = remaining.pop("search_domain_filter")
+
+        if "start_date" in remaining:
+            request_data["fromDate"] = remaining.pop("start_date")
+
+        if "end_date" in remaining:
+            request_data["toDate"] = remaining.pop("end_date")
 
         # Convert to dict before dynamic key assignments
         result_data: Final = dict(request_data)
 
-        # pass through all other parameters as-is
-        for param, value in optional_params.items():
-            if param not in self.get_supported_perplexity_optional_params() and param not in result_data:
-                result_data[param] = value
+        # Pass through any unhandled data
+        result_data.update(remaining)
 
         return result_data
 

--- a/litellm/search/main.py
+++ b/litellm/search/main.py
@@ -29,6 +29,8 @@ def _build_search_optional_params(
     search_domain_filter: list[str] | None = None,
     max_tokens_per_page: int | None = None,
     country: str | None = None,
+    start_date: str | None = None,
+    end_date: str | None = None,
 ) -> dict[str, Any]:
     """
     Helper function to build optional_params dict from Perplexity Search API parameters.
@@ -38,6 +40,8 @@ def _build_search_optional_params(
         search_domain_filter: List of domains to filter (max 20)
         max_tokens_per_page: Max tokens per page
         country: Country code filter
+        start_date: Start date for results (YYYY-MM-DD)
+        end_date: End date for results (YYYY-MM-DD)
 
     Returns:
         Dict with non-None optional parameters
@@ -52,6 +56,10 @@ def _build_search_optional_params(
         optional_params["max_tokens_per_page"] = max_tokens_per_page
     if country is not None:
         optional_params["country"] = country
+    if start_date is not None:
+        optional_params["start_date"] = start_date
+    if end_date is not None:
+        optional_params["end_date"] = end_date
 
     return optional_params
 
@@ -64,6 +72,8 @@ async def asearch(
     search_domain_filter: list[str] | None = None,
     max_tokens_per_page: int | None = None,
     country: str | None = None,
+    start_date: str | None = None,
+    end_date: str | None = None,
     api_key: str | None = None,
     api_base: str | None = None,
     timeout: float | httpx.Timeout | None = None,
@@ -80,6 +90,8 @@ async def asearch(
         search_domain_filter: Optional list of domains to filter (max 20)
         max_tokens_per_page: Optional max tokens per page, default 1024
         country: Optional country code filter (e.g., 'US', 'GB', 'DE')
+        start_date: Optional start date for results (YYYY-MM-DD)
+        end_date: Optional end date for results (YYYY-MM-DD)
         api_key: Optional API key
         api_base: Optional API base URL
         timeout: Optional timeout
@@ -128,6 +140,8 @@ async def asearch(
             search_domain_filter=search_domain_filter,
             max_tokens_per_page=max_tokens_per_page,
             country=country,
+            start_date=start_date,
+            end_date=end_date,
             api_key=api_key,
             api_base=api_base,
             timeout=timeout,
@@ -167,6 +181,8 @@ def search(
     search_domain_filter: list[str] | None = None,
     max_tokens_per_page: int | None = None,
     country: str | None = None,
+    start_date: str | None = None,
+    end_date: str | None = None,
     api_key: str | None = None,
     api_base: str | None = None,
     timeout: float | httpx.Timeout | None = None,
@@ -183,6 +199,8 @@ def search(
         search_domain_filter: Optional list of domains to filter (max 20)
         max_tokens_per_page: Optional max tokens per page, default 1024
         country: Optional country code filter (e.g., 'US', 'GB', 'DE')
+        start_date: Optional start date for results (YYYY-MM-DD)
+        end_date: Optional end date for results (YYYY-MM-DD)
         api_key: Optional API key
         api_base: Optional API base URL
         timeout: Optional timeout
@@ -255,6 +273,8 @@ def search(
             search_domain_filter=search_domain_filter,
             max_tokens_per_page=max_tokens_per_page,
             country=country,
+            start_date=start_date,
+            end_date=end_date,
         )
 
         # Filter out internal LiteLLM parameters from kwargs

--- a/tests/test_litellm/llms/brave/search/test_brave_search_transformation.py
+++ b/tests/test_litellm/llms/brave/search/test_brave_search_transformation.py
@@ -1,0 +1,279 @@
+from unittest.mock import Mock
+
+import pytest
+
+from litellm.llms.brave.search.transformation import BraveSearchConfig, to_yyyy_mm_dd
+
+
+def _config() -> BraveSearchConfig:
+    return BraveSearchConfig()
+
+
+def _resp(payload: dict, params: dict | None = None) -> Mock:
+    """Mock httpx.Response with the .json() and .request.url.params shape
+    Brave's transform_search_response actually reads."""
+    r = Mock()
+    r.json.return_value = payload
+    req = Mock()
+    req.url = Mock()
+    req.url.params = params or {}
+    r.request = req
+    return r
+
+
+def _result(**overrides):
+    base = {
+        "title": "Test Title",
+        "url": "https://example.com",
+        "description": "Test description",
+        "page_age": None,
+        "age": None,
+        "fetched_content_timestamp": None,
+    }
+    return {**base, **overrides}
+
+
+# --- ui_friendly_name / get_http_method ---
+
+
+def test_ui_friendly_name():
+    assert _config().ui_friendly_name() == "Brave Search"
+
+
+def test_get_http_method_is_get():
+    """Brave's /web/search endpoint takes query params, not a JSON body."""
+    assert _config().get_http_method() == "GET"
+
+
+# --- validate_environment ---
+
+
+def test_validate_environment_with_explicit_key():
+    headers = _config().validate_environment({}, api_key="explicit-key")
+    assert headers["X-Subscription-Token"] == "explicit-key"
+    assert headers["Accept"] == "application/json"
+    assert headers["Accept-Encoding"] == "gzip"
+    assert headers["Content-Type"] == "application/json"
+
+
+def test_validate_environment_reads_env_key(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("BRAVE_API_KEY", "env-key")
+    assert _config().validate_environment({})["X-Subscription-Token"] == "env-key"
+
+
+def test_validate_environment_missing_key_raises(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("BRAVE_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="BRAVE_API_KEY"):
+        _config().validate_environment({})
+
+
+# --- get_complete_url ---
+
+
+def test_get_complete_url_default_base(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("BRAVE_API_BASE", raising=False)
+    url = _config().get_complete_url(None, {}, data={"_brave_params": {"q": "test"}})
+    assert url.startswith("https://api.search.brave.com/res/v1/web/search?")
+    assert "q=test" in url
+
+
+def test_get_complete_url_reads_env_base(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("BRAVE_API_BASE", "https://env-base.local/search")
+    url = _config().get_complete_url(None, {}, data={"_brave_params": {"q": "test"}})
+    assert url.startswith("https://env-base.local/search?")
+
+
+def test_get_complete_url_without_brave_params_returns_bare_base(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("BRAVE_API_BASE", raising=False)
+    assert _config().get_complete_url(None, {}, data=None) == "https://api.search.brave.com/res/v1/web/search"
+
+
+# --- transform_search_request ---
+
+
+def test_transform_search_request_joins_list_query():
+    data = _config().transform_search_request(["foo", "bar"], {})
+    assert data["_brave_params"]["q"] == "foo bar"
+
+
+def test_transform_search_request_max_results_clamped_to_20():
+    """Unlike Nimble, Brave's /web/search hard-caps at 20 results per request."""
+    data = _config().transform_search_request("q", {"max_results": 500})
+    assert data["_brave_params"]["count"] == 20
+
+
+def test_transform_search_request_max_results_under_cap_passes_through():
+    data = _config().transform_search_request("q", {"max_results": 5})
+    assert data["_brave_params"]["count"] == 5
+
+
+def test_transform_search_request_appends_domain_filters_as_site_clauses():
+    data = _config().transform_search_request("q", {"search_domain_filter": ["arxiv.org", "nature.com"]})
+    assert data["_brave_params"]["q"] == "(q) AND (site:arxiv.org OR site:nature.com)"
+
+
+def test_transform_search_request_empty_domain_filter_leaves_query_unchanged():
+    data = _config().transform_search_request("q", {"search_domain_filter": []})
+    assert data["_brave_params"]["q"] == "q"
+
+
+def test_transform_search_request_drops_max_tokens_per_page():
+    """No Brave equivalent — must not leak through as an unrecognized param."""
+    assert "max_tokens_per_page" not in _config().transform_search_request("q", {"max_tokens_per_page": 1024})[
+        "_brave_params"
+    ]
+
+
+def test_transform_search_request_country_is_forwarded():
+    """Regression test: the docstring always claimed country -> country, but
+    there was previously no code path that actually implemented it — it
+    relied on shared-list passthrough, which excluded it."""
+    data = _config().transform_search_request("q", {"country": "US"})
+    assert data["_brave_params"]["country"] == "US"
+
+
+def test_transform_search_request_passes_through_unhandled_kwargs():
+    data = _config().transform_search_request("q", {"safesearch": "strict"})
+    assert data["_brave_params"]["safesearch"] == "strict"
+
+
+@pytest.mark.parametrize(
+    "optional_params",
+    [
+        {},  # absent entirely
+        {"include_fetch_metadata": True},  # explicitly True
+    ],
+)
+def test_transform_search_request_include_fetch_metadata_defaults_true(optional_params):
+    data = _config().transform_search_request("q", optional_params)
+    assert data["_brave_params"]["include_fetch_metadata"] is True
+
+
+def test_transform_search_request_include_fetch_metadata_explicit_false_is_respected():
+    data = _config().transform_search_request("q", {"include_fetch_metadata": False})
+    assert data["_brave_params"]["include_fetch_metadata"] is False
+
+
+# --- transform_search_request: date filtering ---
+
+
+def test_transform_search_request_date_range_maps_to_freshness():
+    data = _config().transform_search_request("q", {"start_date": "2022-04-01", "end_date": "2022-07-30"})
+    assert data["_brave_params"]["freshness"] == "2022-04-01to2022-07-30"
+
+
+def test_transform_search_request_only_start_date_is_dropped():
+    """Brave's custom range needs both bounds; there's no correct open-ended equivalent."""
+    data = _config().transform_search_request("q", {"start_date": "2022-04-01"})
+    params = data["_brave_params"]
+    assert "freshness" not in params
+    assert "start_date" not in params  # must not leak through raw either
+
+
+def test_transform_search_request_only_end_date_is_dropped():
+    data = _config().transform_search_request("q", {"end_date": "2022-07-30"})
+    params = data["_brave_params"]
+    assert "freshness" not in params
+    assert "end_date" not in params
+
+
+def test_transform_search_request_no_dates_omits_freshness():
+    data = _config().transform_search_request("q", {"max_results": 5})
+    assert "freshness" not in data["_brave_params"]
+
+
+def test_transform_search_request_explicit_freshness_not_clobbered_by_absent_dates():
+    """A caller-supplied native `freshness` preset (e.g. 'pw') should survive
+    when start_date/end_date aren't given at all."""
+    data = _config().transform_search_request("q", {"freshness": "pw"})
+    assert data["_brave_params"]["freshness"] == "pw"
+
+
+# --- transform_search_response ---
+
+
+def test_transform_search_response_extracts_basic_fields():
+    resp = _resp({"web": {"results": [_result()]}})
+    result = _config().transform_search_response(resp, logging_obj=Mock()).results[0]
+    assert result.title == "Test Title"
+    assert result.url == "https://example.com"
+    assert result.snippet == "Test description"
+
+
+def test_transform_search_response_date_from_page_age():
+    resp = _resp({"web": {"results": [_result(page_age="2024-01-15")]}})
+    result = _config().transform_search_response(resp, logging_obj=Mock()).results[0]
+    assert result.date == "2024-01-15"
+
+
+def test_transform_search_response_date_falls_back_to_age_when_page_age_absent():
+    resp = _resp({"web": {"results": [_result(page_age=None, age="2024-01-15")]}})
+    result = _config().transform_search_response(resp, logging_obj=Mock()).results[0]
+    assert result.date == "2024-01-15"
+
+
+def test_transform_search_response_last_updated_from_fetched_content_timestamp():
+    resp = _resp({"web": {"results": [_result(fetched_content_timestamp="1705334400")]}})
+    result = _config().transform_search_response(resp, logging_obj=Mock()).results[0]
+    assert result.last_updated == "2024-01-15"
+
+
+def test_transform_search_response_zero_hits():
+    resp = _resp({"web": {"results": []}})
+    assert _config().transform_search_response(resp, logging_obj=Mock()).results == []
+
+
+def test_transform_search_response_result_filter_limits_sections():
+    resp = _resp(
+        {
+            "web": {"results": [_result(title="web result")]},
+            "news": {"results": [_result(title="news result")]},
+        },
+        params={"result_filter": "news"},
+    )
+    titles = [r.title for r in _config().transform_search_response(resp, logging_obj=Mock()).results]
+    assert titles == ["news result"]
+
+
+def test_transform_search_response_no_result_filter_includes_all_sections():
+    resp = _resp(
+        {
+            "web": {"results": [_result(title="web result")]},
+            "news": {"results": [_result(title="news result")]},
+        },
+    )
+    titles = {r.title for r in _config().transform_search_response(resp, logging_obj=Mock()).results}
+    assert titles == {"web result", "news result"}
+
+
+def test_transform_search_response_max_results_limits_across_combined_sections():
+    """count doesn't limit Brave's own per-section results server-side, so
+    LiteLLM has to truncate across sections manually."""
+    resp = _resp(
+        {
+            "web": {"results": [_result(title=f"web-{i}") for i in range(5)]},
+            "news": {"results": [_result(title=f"news-{i}") for i in range(5)]},
+        },
+        params={"count": "3"},
+    )
+    results = _config().transform_search_response(resp, logging_obj=Mock()).results
+    assert len(results) == 3
+
+
+# --- to_yyyy_mm_dd helper ---
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (None, None),
+        ("", None),
+        ("not-a-date", None),
+        ("2024-01-15", "2024-01-15"),
+        ("2024/01/15", "2024-01-15"),
+        (1705334400, "2024-01-15"),  # unix seconds
+        (1705334400000, "2024-01-15"),  # unix milliseconds
+    ],
+)
+def test_to_yyyy_mm_dd(value, expected):
+    assert to_yyyy_mm_dd(value) == expected

--- a/tests/test_litellm/llms/linkup/search/test_linkup_search_transformation.py
+++ b/tests/test_litellm/llms/linkup/search/test_linkup_search_transformation.py
@@ -1,0 +1,52 @@
+import json
+from unittest.mock import Mock
+
+import pytest
+
+from litellm.llms.linkup.search.transformation import LinkupSearchConfig
+
+
+def _config() -> LinkupSearchConfig:
+    return LinkupSearchConfig()
+
+
+def test_transform_search_request_maps_start_date_to_from_date():
+    data = _config().transform_search_request("q", {"start_date": "1999-03-20"})
+    assert data["fromDate"] == "1999-03-20"
+    assert "start_date" not in data
+
+
+def test_transform_search_request_maps_end_date_to_to_date():
+    data = _config().transform_search_request("q", {"end_date": "1999-04-20"})
+    assert data["toDate"] == "1999-04-20"
+    assert "end_date" not in data
+
+
+def test_transform_search_request_date_range_together():
+    data = _config().transform_search_request(
+        "q", {"start_date": "1999-03-20", "end_date": "1999-04-20"}
+    )
+    assert data["fromDate"] == "1999-03-20"
+    assert data["toDate"] == "1999-04-20"
+
+
+def test_transform_search_request_without_dates_omits_both():
+    data = _config().transform_search_request("q", {"max_results": 5})
+    assert "fromDate" not in data
+    assert "toDate" not in data
+
+
+def test_transform_search_request_passes_through_unhandled_kwargs():
+    """A param this function doesn't explicitly handle should still reach Linkup unchanged."""
+    data = _config().transform_search_request("q", {"includeImages": True})
+    assert data["includeImages"] is True
+
+
+def test_transform_search_request_joins_list_query():
+    assert _config().transform_search_request(["foo", "bar"], {})["q"] == "foo bar"
+
+
+def test_transform_search_request_defaults_depth_and_output_type():
+    data = _config().transform_search_request("q", {})
+    assert data["depth"] == "standard"
+    assert data["outputType"] == "searchResults"

--- a/tests/test_litellm/llms/linkup/search/test_linkup_search_transformation.py
+++ b/tests/test_litellm/llms/linkup/search/test_linkup_search_transformation.py
@@ -1,4 +1,3 @@
-import json
 from unittest.mock import Mock
 
 import pytest
@@ -8,6 +7,124 @@ from litellm.llms.linkup.search.transformation import LinkupSearchConfig
 
 def _config() -> LinkupSearchConfig:
     return LinkupSearchConfig()
+
+
+def _resp(payload: dict) -> Mock:
+    r = Mock()
+    r.json.return_value = payload
+    return r
+
+
+def _result(**overrides):
+    base = {
+        "type": "text",
+        "name": "Test Title",
+        "url": "https://example.com",
+        "content": "Test content",
+    }
+    return {**base, **overrides}
+
+
+# --- ui_friendly_name ---
+
+
+def test_ui_friendly_name():
+    assert _config().ui_friendly_name() == "Linkup"
+
+
+# --- validate_environment ---
+
+
+def test_validate_environment_with_explicit_key():
+    headers = _config().validate_environment({}, api_key="explicit-key")
+    assert headers["Authorization"] == "Bearer explicit-key"
+    assert headers["Content-Type"] == "application/json"
+
+
+def test_validate_environment_reads_env_key(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("LINKUP_API_KEY", "env-key")
+    assert _config().validate_environment({})["Authorization"] == "Bearer env-key"
+
+
+def test_validate_environment_missing_key_raises(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("LINKUP_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="LINKUP_API_KEY"):
+        _config().validate_environment({})
+
+
+# --- get_complete_url ---
+
+
+def test_get_complete_url_default_base(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("LINKUP_API_BASE", raising=False)
+    assert _config().get_complete_url(None, {}) == "https://api.linkup.so/v1/search"
+
+
+def test_get_complete_url_reads_env_base(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("LINKUP_API_BASE", "https://env-base.local/v1")
+    assert _config().get_complete_url(None, {}) == "https://env-base.local/v1/search"
+
+
+def test_get_complete_url_does_not_duplicate_search_suffix():
+    assert _config().get_complete_url("https://self-hosted.local/v1/search", {}) == "https://self-hosted.local/v1/search"
+
+
+def test_get_complete_url_appends_search_when_missing():
+    assert _config().get_complete_url("https://self-hosted.local/v1", {}) == "https://self-hosted.local/v1/search"
+
+
+# --- transform_search_request: query / defaults ---
+
+
+def test_transform_search_request_joins_list_query():
+    assert _config().transform_search_request(["foo", "bar"], {})["q"] == "foo bar"
+
+
+def test_transform_search_request_string_query_unchanged():
+    assert _config().transform_search_request("foo bar", {})["q"] == "foo bar"
+
+
+def test_transform_search_request_defaults_depth_and_output_type():
+    data = _config().transform_search_request("q", {})
+    assert data["depth"] == "standard"
+    assert data["outputType"] == "searchResults"
+
+
+def test_transform_search_request_respects_explicit_depth_and_output_type():
+    data = _config().transform_search_request("q", {"depth": "deep", "outputType": "sourcedAnswer"})
+    assert data["depth"] == "deep"
+    assert data["outputType"] == "sourcedAnswer"
+
+
+# --- transform_search_request: unified param mapping ---
+
+
+def test_transform_search_request_max_results_maps_to_maxResults():
+    data = _config().transform_search_request("q", {"max_results": 10})
+    assert data["maxResults"] == 10
+    assert "max_results" not in data
+
+
+def test_transform_search_request_search_domain_filter_maps_to_includeDomains():
+    data = _config().transform_search_request("q", {"search_domain_filter": ["arxiv.org", "nature.com"]})
+    assert data["includeDomains"] == ["arxiv.org", "nature.com"]
+    assert "search_domain_filter" not in data
+
+
+def test_transform_search_request_drops_max_tokens_per_page():
+    """No Linkup equivalent — must not leak through as an unrecognized param."""
+    assert "max_tokens_per_page" not in _config().transform_search_request("q", {"max_tokens_per_page": 1024})
+
+
+def test_transform_search_request_country_has_no_native_equivalent():
+    """Linkup has no native country filter; per the docstring this is intentionally unmapped —
+    it should pass through raw rather than silently vanish, since Linkup's real API will just
+    ignore an unrecognized field."""
+    data = _config().transform_search_request("q", {"country": "US"})
+    assert data.get("country") == "US"
+
+
+# --- transform_search_request: date filtering ---
 
 
 def test_transform_search_request_maps_start_date_to_from_date():
@@ -36,17 +153,68 @@ def test_transform_search_request_without_dates_omits_both():
     assert "toDate" not in data
 
 
+# --- transform_search_request: passthrough ---
+
+
 def test_transform_search_request_passes_through_unhandled_kwargs():
     """A param this function doesn't explicitly handle should still reach Linkup unchanged."""
     data = _config().transform_search_request("q", {"includeImages": True})
     assert data["includeImages"] is True
 
 
-def test_transform_search_request_joins_list_query():
-    assert _config().transform_search_request(["foo", "bar"], {})["q"] == "foo bar"
+def test_transform_search_request_does_not_duplicate_consumed_params():
+    """Regression test: a translated param (start_date -> fromDate) must not
+    also leak through raw via the passthrough path."""
+    data = _config().transform_search_request(
+        "q", {"start_date": "1999-03-20", "max_results": 5, "includeImages": True}
+    )
+    assert "start_date" not in data
+    assert "max_results" not in data
+    assert data["fromDate"] == "1999-03-20"
+    assert data["maxResults"] == 5
+    assert data["includeImages"] is True
 
 
-def test_transform_search_request_defaults_depth_and_output_type():
-    data = _config().transform_search_request("q", {})
-    assert data["depth"] == "standard"
-    assert data["outputType"] == "searchResults"
+# --- transform_search_response ---
+
+
+def test_transform_search_response_text_result_fields():
+    resp = _resp({"results": [_result()]})
+    result = _config().transform_search_response(resp, logging_obj=Mock()).results[0]
+    assert result.title == "Test Title"
+    assert result.url == "https://example.com"
+    assert result.snippet == "Test content"
+    assert result.date is None
+    assert result.last_updated is None
+
+
+def test_transform_search_response_image_result_falls_back_to_url_for_title():
+    resp = _resp({"results": [_result(type="image", name="", url="https://example.com/img.png")]})
+    result = _config().transform_search_response(resp, logging_obj=Mock()).results[0]
+    assert result.title == "https://example.com/img.png"
+
+
+def test_transform_search_response_image_result_uses_name_when_present():
+    resp = _resp({"results": [_result(type="image", name="Alt text")]})
+    result = _config().transform_search_response(resp, logging_obj=Mock()).results[0]
+    assert result.title == "Alt text"
+
+
+def test_transform_search_response_preserves_order():
+    resp = _resp({"results": [_result(name=n) for n in ("first", "second", "third")]})
+    titles = [r.title for r in _config().transform_search_response(resp, logging_obj=Mock()).results]
+    assert titles == ["first", "second", "third"]
+
+
+def test_transform_search_response_zero_hits():
+    resp = _resp({"results": []})
+    assert _config().transform_search_response(resp, logging_obj=Mock()).results == []
+
+
+def test_transform_search_response_unknown_result_type_is_skipped():
+    """A result type that's neither "text" nor "image" (e.g. a future Linkup
+    addition) shouldn't crash the call; it's just silently omitted."""
+    resp = _resp({"results": [_result(type="video"), _result()]})
+    results = _config().transform_search_response(resp, logging_obj=Mock()).results
+    assert len(results) == 1
+    assert results[0].title == "Test Title"

--- a/tests/test_litellm/llms/nimble/search/test_nimble_search_transformation.py
+++ b/tests/test_litellm/llms/nimble/search/test_nimble_search_transformation.py
@@ -100,6 +100,14 @@ def test_transform_search_request_max_results_is_not_clamped():
 def test_transform_search_request_uppercases_country():
     assert _config().transform_search_request("q", {"country": "us"})["country"] == "US"
 
+def test_transform_search_request_date_range_passes_through_native_names():
+    """Nimble already uses the unified spec's own field names for date filtering."""
+    data = _config().transform_search_request(
+        "q", {"start_date": "1999-03-20", "end_date": "1999-04-20"}
+    )
+    assert data["start_date"] == "1999-03-20"
+    assert data["end_date"] == "1999-04-20"
+
 
 def test_transform_search_request_drops_max_tokens_per_page():
     assert "max_tokens_per_page" not in _config().transform_search_request("q", {"max_tokens_per_page": 1024})

--- a/tests/test_litellm/llms/tavily/search/test_tavily_search_transformation.py
+++ b/tests/test_litellm/llms/tavily/search/test_tavily_search_transformation.py
@@ -1,0 +1,180 @@
+from unittest.mock import Mock
+
+import pytest
+
+from litellm.llms.tavily.search.transformation import TavilySearchConfig
+
+
+def _config() -> TavilySearchConfig:
+    return TavilySearchConfig()
+
+
+def _resp(payload: dict) -> Mock:
+    r = Mock()
+    r.json.return_value = payload
+    return r
+
+
+def _result(**overrides):
+    base = {
+        "title": "Test Title",
+        "url": "https://example.com",
+        "content": "Test content",
+    }
+    return {**base, **overrides}
+
+
+# --- ui_friendly_name ---
+
+
+def test_ui_friendly_name():
+    assert _config().ui_friendly_name() == "Tavily"
+
+
+# --- validate_environment ---
+
+
+def test_validate_environment_with_explicit_key():
+    headers = _config().validate_environment({}, api_key="explicit-key")
+    assert headers["Authorization"] == "Bearer explicit-key"
+    assert headers["Content-Type"] == "application/json"
+
+
+def test_validate_environment_reads_env_key(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("TAVILY_API_KEY", "env-key")
+    assert _config().validate_environment({})["Authorization"] == "Bearer env-key"
+
+
+def test_validate_environment_missing_key_raises(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="TAVILY_API_KEY"):
+        _config().validate_environment({})
+
+
+# --- get_complete_url ---
+
+
+def test_get_complete_url_default_base(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("TAVILY_API_BASE", raising=False)
+    assert _config().get_complete_url(None, {}) == "https://api.tavily.com/search"
+
+
+def test_get_complete_url_reads_env_base(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("TAVILY_API_BASE", "https://env-base.local")
+    assert _config().get_complete_url(None, {}) == "https://env-base.local/search"
+
+
+def test_get_complete_url_does_not_duplicate_search_suffix():
+    assert _config().get_complete_url("https://self-hosted.local/search", {}) == "https://self-hosted.local/search"
+
+
+# --- transform_search_request: query ---
+
+
+def test_transform_search_request_joins_list_query():
+    assert _config().transform_search_request(["foo", "bar"], {})["query"] == "foo bar"
+
+
+def test_transform_search_request_string_query_unchanged():
+    assert _config().transform_search_request("foo bar", {})["query"] == "foo bar"
+
+
+# --- transform_search_request: unified param mapping ---
+
+
+def test_transform_search_request_max_results_passes_through():
+    data = _config().transform_search_request("q", {"max_results": 10})
+    assert data["max_results"] == 10
+
+
+def test_transform_search_request_search_domain_filter_maps_to_include_domains():
+    data = _config().transform_search_request("q", {"search_domain_filter": ["arxiv.org", "nature.com"]})
+    assert data["include_domains"] == ["arxiv.org", "nature.com"]
+    assert "search_domain_filter" not in data
+
+
+def test_transform_search_request_lowercases_country():
+    data = _config().transform_search_request("q", {"country": "US"})
+    assert data["country"] == "us"
+
+
+def test_transform_search_request_drops_max_tokens_per_page():
+    """No Tavily equivalent — must not leak through as an unrecognized param."""
+    assert "max_tokens_per_page" not in _config().transform_search_request("q", {"max_tokens_per_page": 1024})
+
+
+# --- transform_search_request: date filtering (native passthrough) ---
+
+
+def test_transform_search_request_date_range_passes_through_native_names():
+    """Tavily already uses the unified spec's own field names for date filtering."""
+    data = _config().transform_search_request(
+        "q", {"start_date": "1999-03-20", "end_date": "1999-04-20"}
+    )
+    assert data["start_date"] == "1999-03-20"
+    assert data["end_date"] == "1999-04-20"
+
+
+def test_transform_search_request_single_date_passes_through():
+    """Unlike Brave, Tavily has no combined-range requirement — a lone bound is valid."""
+    data = _config().transform_search_request("q", {"start_date": "1999-03-20"})
+    assert data["start_date"] == "1999-03-20"
+    assert "end_date" not in data
+
+
+def test_transform_search_request_without_dates_omits_both():
+    data = _config().transform_search_request("q", {"max_results": 5})
+    assert "start_date" not in data
+    assert "end_date" not in data
+
+
+# --- transform_search_request: passthrough ---
+
+
+def test_transform_search_request_passes_through_unhandled_kwargs():
+    """Native Tavily-specific params (topic, search_depth, time_range, etc.)
+    aren't explicitly mapped, but should still reach the request unchanged."""
+    data = _config().transform_search_request("q", {"topic": "news", "search_depth": "advanced"})
+    assert data["topic"] == "news"
+    assert data["search_depth"] == "advanced"
+
+
+def test_transform_search_request_does_not_duplicate_consumed_params():
+    """Regression test: a translated param (search_domain_filter -> include_domains)
+    must not also leak through raw via the passthrough path."""
+    data = _config().transform_search_request(
+        "q", {"search_domain_filter": ["arxiv.org"], "max_results": 5}
+    )
+    assert "search_domain_filter" not in data
+    assert data["include_domains"] == ["arxiv.org"]
+    assert data["max_results"] == 5
+
+
+# --- transform_search_response ---
+
+
+def test_transform_search_response_extracts_basic_fields():
+    resp = _resp({"results": [_result()]})
+    result = _config().transform_search_response(resp, logging_obj=Mock()).results[0]
+    assert result.title == "Test Title"
+    assert result.url == "https://example.com"
+    assert result.snippet == "Test content"
+
+
+def test_transform_search_response_date_and_last_updated_are_none():
+    """Tavily's response has no date/last_updated equivalent."""
+    resp = _resp({"results": [_result()]})
+    result = _config().transform_search_response(resp, logging_obj=Mock()).results[0]
+    assert result.date is None
+    assert result.last_updated is None
+
+
+def test_transform_search_response_zero_hits():
+    resp = _resp({"results": []})
+    assert _config().transform_search_response(resp, logging_obj=Mock()).results == []
+
+
+def test_transform_search_response_preserves_order():
+    resp = _resp({"results": [_result(title=t) for t in ("first", "second", "third")]})
+    titles = [r.title for r in _config().transform_search_response(resp, logging_obj=Mock()).results]
+    assert titles == ["first", "second", "third"]


### PR DESCRIPTION
<!-- The whole description's target audience is humans, not AI agents: write it in plain, simple,
     everyday engineering language, extremely parsable and readable at a glance. This goes double for
     the TLDR, User Flow, and Caveats sections -->

## TLDR


<!-- Fill in the bullets below and keep each one short and concrete: one line per bullet, roughly 10 words max -->

### Problem this solves:
- Unified `/v1/search` has no way to filter results by date range

### How it solves it:
- Adds `start_date`/`end_date` to `litellm.search()`/`asearch()`
- Translates them per-provider: renamed (Linkup), combined into one field (Brave), or passed through unchanged (Nimble, Tavily)

## User Flow

<!-- Two ordered lists, Before and After, walking the same end user through the same task, written strictly from that user's seat
     Read the linked issue, ticket, or customer thread first so the flow reflects the real application and the routes its users actually hit; don't invent a generic scenario
     Lead each list with one plain sentence saying where the flow fails (Before) or succeeds (After), then number the steps
     Every step is something the user does or observes: the HTTP method and full URL they hit, what they sent, and what visibly came back (status code, error text, the shape of an ID). UI steps name the page URL and what is on screen
     No LiteLLM internals: never name functions, files, DB tables, config classes, hooks, callbacks, or code paths. "The upload hands back an ID that looks like OpenAI's own `file-abc123` instead of the scrambled one the gateway returned" is right, "no managed-file row was registered" is wrong
     Keep the two lists step-for-step identical until they diverge, so the changed step is obvious
     If the bug had a security or authorization consequence, end each list with what another user could or could no longer do
     Regenerate this section whenever new commits change the PR's behavior, so it never describes an older revision

Example:

Before: a developer whose app streams chat completions gets no token counts back, so their cost dashboard reads zero

1. They send POST https://litellm-domain/v1/chat/completion with `"stream": true` and no `stream_options`
2. The last SSE chunk arrives with `"usage": null`, so their app records 0 prompt and 0 completion tokens
3. They open https://litellm-domain/ui/?page=logs and see the request logged at $0 spend

After: the same request comes back with real token counts, so the dashboard shows real spend

1. The proxy admin sets `always_include_stream_usage: true` and restarts the proxy
2. The developer sends the same POST https://litellm-domain/v1/chat/completions with `"stream": true` and no `stream_options`
3. The last SSE chunk now carries a `usage` object with real prompt and completion token counts
4. https://litellm-domain/ui/?page=logs shows that request at non-zero spend
-->
**Before**: a developer wants to restrict search results to a specific date range and has no way to do it through the unified API.

1. They call litellm.search(query="...", search_provider="linkup") with no way to express a date range
2. To filter by date at all, they'd have to bypass the unified interface and pass Linkup's native fromDate/toDate (or Brave's freshness, or another provider's own field) directly as kwargs
3. Switching search_provider to a different backend silently breaks their date filtering, since the provider-specific param name doesn't carry over

**After**: the same date-range intent works identically regardless of which provider is behind the call.

1. They call litellm.search(query="...", search_provider="linkup", start_date="2024-01-01", end_date="2024-12-31")
2. LiteLLM translates start_date/end_date into whatever that provider actually expects (fromDate/toDate for Linkup, freshness=2024-01-01to2024-12-31 for Brave, passed through unchanged for Nimble/Tavily)
3. Switching search_provider to any of the four supported here keeps the same start_date/end_date kwargs working, no code change required
4. Results come back filtered to the requested date range

## Relevant issues

<!-- e.g., "Fixes #000" -->
Closes #40096 (partially — Perplexity and Google-SERP-style providers deferred to a follow-up PR; see Caveats)
## Linear ticket

<!-- if you are an internal contributor, add "Resolves " followed by the Linear ticket e.g., "Resolves LIT-1234" to link the Linear ticket to the GitHub PR. If you don't have one, leave the section blank rather than guessing -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected
     The proof must be completely e2e with no mocks, using actual LLM calls costing real $$$ if applicable. `pytest` commands are not enough
     Show ONLY the latest run: capture Before at the merge base and After at the PR's current tip, and when new commits change behavior, replace this whole section with the fresh run instead of stacking it on top of older ones. The run must be up to date. As soon as a new commit is made and it makes this PR description's after sha stale (it's no longer tip of PR), you must re-run the QA
     Structure the section exactly as below: Before and After one heading level below this section, each naming the commit hash it was captured at, one lower-level heading per case inside each, the same case names in the same order on both sides, and numbered steps (command, observed output) under every case, never loose prose; shared setup (config, payloads) goes above Before, and with a single case, drop the case headings and number the steps directly

### Before (<hash>)

#### <case 1>

1. ...
2. ...

#### <case 2>

1. ...

### After (<hash>)

#### <case 1>

1. ...
2. ...

#### <case 2>

1. ...

     For bug fixes: Before shows the reproduction, After shows the same steps passing
     For new features: Before shows the capability missing, After shows it working end-to-end
     If the change applies to all three LLM endpoints (/v1/responses, /v1/chat/completions, /v1/messages), make each endpoint its own case, not just one
     For UI changes: before/after screenshots under the same headings -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature

## Caveats (if any)

<!-- Group caveats under severity subheadings (### Severe, ### High, ### Medium, ### Low), with
     short bullet points inside each, just like the TLDR: one line per bullet, roughly 10 words max
     Call out known limitations, follow-up work, or anything a reviewer should watch out for
     Include only the tiers that have caveats; drop the empty ones
     - Severe: inherent to what the PR deliberately ships, there even when the code works as intended:
       it can degrade or take down a running deployment (e.g. a slow or table-locking boot migration),
       rewrite data by design, break an existing workflow on purpose, or change auth behavior. An
       operator must plan around it before rollout
     - High: an unintended hole: a correctness, security, data-loss, or backward-compatibility bug,
       unsafe to ship as is
     - Medium: a real gap someone can hit, but with a workaround or a narrow blast radius
     - Low: anything else worth noting: naming, cleanup, an edge case nobody hits
     Nest bullets as deep as helps: hierarchy beats one long line when it makes things clearer to a
     human reader
     Leave this section empty if there are none -->
### Medium
- Perplexity, Exa AI, and Google-SERP-style providers (Serper, SearchAPI, SearXNG) are out of scope for this PR — confirmed with @moh3nhadavi in #40096, deferred to a follow-up PR since they require date reformatting (different date formats, combined-parameter syntax) rather than a simple rename or passthrough
- Exa AI's published-date vs. crawl-date mapping choice is an open design question, to be resolved when that follow-up PR is written — flagging now per discussion in the issue
Low
- Also fixed a pre-existing bug in Brave's transformation: country was documented as a supported mapping but had no code path actually forwarding it — this PR adds that
- Introduces a "consumed key" pattern in Linkup/Brave rather than expanding the shared _PERPLEXITY_UNIFIED_PARAMS set — requesting explicit sign-off on this pattern here since it'll be reused across the deferred providers in the follow-up PR if approved

<!-- Only needed when your PR edits tests/e2e; delete this section otherwise

For each e2e test you added or changed, list the manual steps a reviewer can follow to reproduce it by hand against a live proxy, mapping 1:1 to what the test asserts: one top-level bullet per test giving its pytest node id followed by what it proves in plain words, then a nested "- [ ]" checklist where each item is a concrete action (route, request body, expected response) and the final item is the sanity-check step shown in the examples. Note environment prerequisites (provider credentials, config flags) and any nuances a manual run will hit. See PRs #32914 and #32963 for full examples

Example checklists:

- tests/e2e/quota_management/ratelimit/test_rate_limit_e2e.py::TestKeyRateLimits::test_rpm_limit_blocks_over_limit - a key allowed 2 requests a minute serves exactly 2 and refuses the 3rd
  - [ ] Generate a limited key: curl -X POST http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -d '{"rpm_limit": 2}'
  - [ ] Send three /v1/chat/completions requests with that key inside one minute
  - [ ] Expect the first two to return 200 and the third to return 429 naming the rpm limit
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/management/test_management_e2e.py::TestModelRoutes::test_model_create_appears_in_ui - a deployment created through the API shows up on the Admin UI models page
  - [ ] POST /model/new with the master key, a bedrock model, and aws_region_name (needs STORE_MODEL_IN_DB=True and AWS credentials)
  - [ ] Open http://localhost:4000/ui/?page=models and expect a deployment row showing the returned model id
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky
-->

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
