### PR TITLE
fix(teams): release a moved team model's public name from its former team

### DIFF
--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -835,7 +835,9 @@ async def patch_model(
         llm_router,
         premium_user,
         prisma_client,
+        proxy_logging_obj,
         store_model_in_db,
+        user_api_key_cache,
     )
 
     try:
@@ -953,6 +955,19 @@ async def patch_model(
         # Clear cache and reload models (uses config setting or defaults to preserving config models for DB updates)
         live_before_reload: Final = live_model_ids_snapshot()
         reload_outcome: Final = await clear_cache()
+        source_team_id: Final = db_model.model_info.team_id if db_model.model_info else None
+        if (
+            source_team_id is not None
+            and patch_data.model_info is not None
+            and patch_data.model_info.team_id not in (None, source_team_id)
+        ):
+            await _remove_unbacked_team_models(
+                model_params=db_model,
+                prisma_client=prisma_client,
+                user_api_key_cache=user_api_key_cache,
+                proxy_logging_obj=proxy_logging_obj,
+                llm_router=llm_router,
+            )
 
         ## CREATE AUDIT LOG ##
         asyncio.create_task(
@@ -1507,11 +1522,12 @@ async def _remove_unbacked_team_models(
     llm_router: Router | None = None,
 ) -> None:
     """
-    Strip a deleted team model's public name(s) from team.models and refresh the cache.
+    Strip a team model's public name(s) from team.models once the row no longer backs them, and refresh the cache.
 
-    Must be called after the deployment row is deleted: a public name is removed only
-    when no remaining team deployment still backs it, so a load-balanced replica isn't
-    revoked while siblings serve it, and concurrent deletes can't leave a ghost.
+    Runs after the row is deleted, or after a move to another team has been reloaded into the
+    router: a public name is removed only when no remaining team deployment still backs it, so
+    a load-balanced replica isn't revoked while siblings serve it, concurrent deletes can't
+    leave a ghost, and a moved row's former team does not keep a grant nothing of its own serves.
 
     Legacy team models (created before team_public_model_name existed) store a
     ``{public_name: "model_name_{team_id}_{uuid}"}`` entry in the team's model_aliases,
@@ -1523,7 +1539,9 @@ async def _remove_unbacked_team_models(
 
     A public name that still resolves to a live router deployment (e.g. a gateway-level
     model group shared with the team) is kept in team.models, so deleting a per-team
-    duplicate does not revoke the team's access to the shared deployment.
+    duplicate does not revoke the team's access to the shared deployment. Team rows are
+    indexed under their internal ``model_name_{team_id}_{uuid}`` key, so a row that was just
+    moved does not keep its public name alive for the team it left.
     """
     team_id: Final = model_params.model_info.team_id
     if team_id is None:

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -15,6 +15,7 @@ from litellm.proxy._types import (
     LiteLLM_ModelTable,
     LiteLLM_ProxyModelTable,
     LiteLLM_TeamTable,
+    LiteLLM_TeamTableCachedObj,
     LitellmUserRoles,
     Member,
     ReconcileOutcome,
@@ -1392,6 +1393,128 @@ class TestTeamModelUpdate:
             mock_team_model_add.assert_called_once()
             # update_team (model_aliases write) must NOT be called in the new implementation
             mock_update_team.assert_not_called()
+
+    # Moving a row between teams registers its public name on the destination; the source must
+    # give the name up too, unless a sibling row there still backs it, or it keeps a grant to a
+    # name nothing of its own serves. A legacy row lists its name through a team alias rather
+    # than team_public_model_name; the alias is scrubbed and its key released the same way.
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "moved_row, source_backing, released",
+        [
+            ("named", "nothing", True),
+            ("named", "sibling row with the same public name", False),
+            ("legacy alias", "nothing", True),
+        ],
+    )
+    async def test_team_move_releases_the_public_name_from_the_source_team(self, moved_row, source_backing, released):
+        from litellm.proxy.common_utils.user_api_key_cache import UserApiKeyCache
+        from litellm.proxy.management_endpoints.model_management_endpoints import patch_model
+
+        named = moved_row == "named"
+        moved = LiteLLM_ProxyModelTable(
+            model_id="m-moved",
+            model_name="model_name_team_a_uuid1",
+            litellm_params={"model": "azure/gpt-4o-mini"},
+            model_info={"id": "m-moved", "team_id": "team_a", **({"team_public_model_name": "shared-name"} if named else {})},
+            created_by="admin",
+            updated_by="admin",
+        )
+        sibling = MagicMock()
+        sibling.model_name = "model_name_team_a_uuid2"
+        sibling.model_info = {"team_id": "team_a", "team_public_model_name": "shared-name"}
+        alias_row = MagicMock()
+        alias_row.id = 1
+        alias_row.model_aliases = {"shared-name": "model_name_team_a_uuid1"}
+        alias_row.team.team_id = "team_a"
+
+        async def team_update(where, data, include=None):
+            return LiteLLM_TeamTable(team_id=where["team_id"], models=data.get("models", ["shared-name"]))
+
+        prisma = MagicMock()
+        prisma.db.litellm_proxymodeltable.find_unique = AsyncMock(return_value=moved)
+        prisma.db.litellm_proxymodeltable.update = AsyncMock(return_value=moved)
+        prisma.db.litellm_proxymodeltable.find_many = AsyncMock(
+            return_value=[sibling] if source_backing.startswith("sibling") else []
+        )
+        prisma.db.litellm_modeltable.find_many = AsyncMock(return_value=[] if named else [alias_row])
+        prisma.db.litellm_modeltable.update = AsyncMock()
+        prisma.db.litellm_teamtable.find_unique = AsyncMock(
+            return_value=LiteLLM_TeamTable(team_id="team_a", models=["shared-name"])
+        )
+        prisma.db.litellm_teamtable.update = AsyncMock(side_effect=team_update)
+        prisma.db.execute_raw = AsyncMock()
+        cache = UserApiKeyCache()
+        router = MagicMock(**{"get_model_ids.return_value": ["m-moved"], "model_name_to_deployment_indices": {}})
+
+        with (
+            patch("litellm.proxy.proxy_server.prisma_client", prisma),  # test-quality-ok: endpoint reads proxy server globals with no injection seam
+            patch("litellm.proxy.proxy_server.llm_router", router),  # test-quality-ok: same
+            patch("litellm.proxy.proxy_server.user_api_key_cache", cache),  # test-quality-ok: same
+            patch("litellm.proxy.proxy_server.proxy_logging_obj", None),  # test-quality-ok: same
+            patch("litellm.proxy.proxy_server.store_model_in_db", True),  # test-quality-ok: same
+            patch("litellm.proxy.proxy_server.premium_user", True),  # test-quality-ok: same
+            patch(  # test-quality-ok: the reload needs a live router; the team list write is what is under test
+                "litellm.proxy.management_endpoints.model_management_endpoints.clear_cache",
+                new=AsyncMock(return_value=ReconcileOutcome(still_desired=None, live_after=None)),
+            ),
+        ):
+            await patch_model(
+                model_id="m-moved",
+                patch_data=updateDeployment(model_info=ModelInfo(team_id="team_b")),
+                user_api_key_dict=UserAPIKeyAuth(user_id="admin", user_role=LitellmUserRoles.PROXY_ADMIN),
+            )
+
+        source_team = await cache.async_get_cache(key="team_id:team_a", model_type=LiteLLM_TeamTableCachedObj)
+        assert (source_team.models if source_team is not None else ["shared-name"]) == ([] if released else ["shared-name"])
+        assert prisma.db.litellm_modeltable.update.await_count == (0 if named else 1)
+
+    # The cleanup keeps a name only while a deployment of exactly that name is live; a wildcard
+    # or alias that would merely answer a call to it is not a grant the team should keep.
+    @pytest.mark.asyncio
+    async def test_cleanup_ignores_wildcards_that_would_match_the_released_name(self):
+        from litellm.proxy.common_utils.user_api_key_cache import UserApiKeyCache
+        from litellm.proxy.management_endpoints.model_management_endpoints import _remove_unbacked_team_models
+
+        released = Deployment(
+            model_name="model_name_team_a_uuid1",
+            litellm_params=LiteLLM_Params(model="anthropic/claude-haiku-4-5"),
+            model_info=ModelInfo(id="m-moved", team_id="team_a", team_public_model_name="anthropic/team-name"),
+        )
+        llm_router = Router(
+            model_list=[
+                {"model_name": "anthropic/*", "litellm_params": {"model": "anthropic/*", "api_key": "k"}},
+                {
+                    "model_name": "model_name_team_b_uuid1",
+                    "litellm_params": {"model": "anthropic/claude-haiku-4-5", "api_key": "k"},
+                    "model_info": {"id": "m-moved", "team_id": "team_b", "team_public_model_name": "anthropic/team-name"},
+                },
+            ],
+            model_group_alias={"anthropic/team-name": "anthropic/*"},
+        )
+
+        async def update(where, data, include=None):
+            return LiteLLM_TeamTable(team_id="team_a", models=data["models"])
+
+        prisma = MagicMock()
+        prisma.db.litellm_teamtable.find_unique = AsyncMock(
+            return_value=LiteLLM_TeamTable(team_id="team_a", models=["anthropic/team-name"])
+        )
+        prisma.db.litellm_teamtable.update = AsyncMock(side_effect=update)
+        prisma.db.litellm_proxymodeltable.find_many = AsyncMock(return_value=[])
+        prisma.db.litellm_modeltable.find_many = AsyncMock(return_value=[])
+        cache = UserApiKeyCache()
+
+        await _remove_unbacked_team_models(
+            model_params=released,
+            prisma_client=prisma,
+            user_api_key_cache=cache,
+            proxy_logging_obj=None,
+            llm_router=llm_router,
+        )
+
+        cached_team = await cache.async_get_cache(key="team_id:team_a", model_type=LiteLLM_TeamTableCachedObj)
+        assert cached_team is not None and cached_team.models == []
 
     @pytest.mark.asyncio
     async def test_rename_preserves_old_name_when_siblings_exist(self):


### PR DESCRIPTION
## TLDR

Problem this solves:

- Moving a team model to another team leaves its name in the source team's model list
- That stale grant is honoured: a later proxy-wide model of that name is callable by the source team

How it solves it:

- After the move is reloaded, run the same cleanup a delete runs on the source team
- The name is kept only while a sibling row or a live model group of that exact name still backs it

## User Flow

Before: a proxy admin moves a team's model to another team, and the source team keeps calling a name it no longer owns

1. Team A has `models: ["solo-model", "haiku-direct"]` backing a team-scoped deployment named `solo-model`
2. The admin sends PATCH https://litellm-domain/model/{id}/update with `{"model_info": {"team_id": "<team B>"}}` and gets 200
3. GET https://litellm-domain/team/info for team A still shows `"models": ["solo-model", "haiku-direct"]`
4. The admin later creates a proxy-wide model named `solo-model`; a team A key sends POST https://litellm-domain/v1/chat/completions with `"model": "solo-model"` and gets 200, though team A was never granted that model

After: the source team's list drops the moved name

1. Same team A, same PATCH -> 200
2. GET https://litellm-domain/team/info for team A shows `"models": ["haiku-direct"]`
3. The same later proxy-wide `solo-model` returns 403 to the team A key; `haiku-direct` still returns 200
4. If another team A row still serves the name, or the name is also a model group the whole proxy serves, the list keeps it and those calls keep working

## Relevant issues

- Split out of #40340, where a review bot found the move leaving the grant behind

## Linear ticket

Resolves LIT-7445

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Rig: fresh Postgres, proxy from this worktree, sandbox gateway upstream, `haiku-direct`, `sonnet-direct` and `anthropic/*` from config. Restricted teams with team keys. Every step is a curl with the master key unless it says team key. `team.models` and the alias row are read straight from the tables after each write. The same script ran at both legs.

### Before (fb603fdb6b)

#### moving a team's model with a second model still on the team

1. Source `team.models = {solo-model,haiku-direct}`; PATCH /model/{id}/update with `model_info.team_id` of the other team -> 200
2. Source `team.models = {solo-model,haiku-direct}`, destination `{all-proxy-models,solo-model}`
3. Master creates a proxy-wide model also named `solo-model`; source team key POST /chat/completions `solo-model` -> 200, `haiku-direct` -> 200

#### a sibling row still backs the name on the source team

1. Two team rows named `shared-name`; move one -> 200
2. Source `team.models = {shared-name}`; source team key on `shared-name` -> 200

#### a legacy row listed through a team alias (no `team_public_model_name`)

1. Source `team.models = {legacy-name,haiku-direct}`, alias row `{"legacy-name": "model_name_<team>_<uuid>"}`; the same PATCH -> 200
2. Source `team.models = {legacy-name,haiku-direct}`, alias row unchanged

#### a wildcard deployment that would answer the released name

1. Config serves `anthropic/*`; source `team.models = {anthropic/team-name,haiku-direct}`; the same PATCH -> 200
2. Source `team.models = {anthropic/team-name,haiku-direct}`; source team key on `anthropic/team-name` -> 400 from the wildcard route (the grant is still honoured)

#### a name also served as a gateway model group

1. Source `team.models = {haiku-direct,sonnet-direct}` with a team row named `haiku-direct`; the same PATCH -> 200
2. Source `team.models = {haiku-direct,sonnet-direct}`; source team key on `haiku-direct` -> 200

#### non-move PATCHes

1. Config-only PATCH -> 200, `team.models` unchanged; same-team `team_id` echo -> 200, unchanged

### After (97f88f5513)

#### moving a team's model with a second model still on the team

1. Source `team.models = {solo-model,haiku-direct}`; the same PATCH -> 200
2. Source `team.models = {haiku-direct}`, destination `{all-proxy-models,solo-model}`
3. Master creates a proxy-wide `solo-model`; source team key on `solo-model` -> 403, `haiku-direct` -> 200

#### a sibling row still backs the name on the source team

1. Move one of two `shared-name` rows -> 200
2. Source `team.models = {shared-name}`; source team key on `shared-name` -> 200

#### a legacy row listed through a team alias (no `team_public_model_name`)

1. Same PATCH -> 200
2. Source `team.models = {haiku-direct}`, alias row `{}`

#### a wildcard deployment that would answer the released name

1. Same PATCH -> 200
2. Source `team.models = {haiku-direct}`; source team key on `anthropic/team-name` -> 403

#### a name also served as a gateway model group

1. Same PATCH -> 200
2. Source `team.models = {haiku-direct,sonnet-direct}`; source team key on `haiku-direct` -> 200

#### non-move PATCHes

1. Config-only PATCH -> 200, unchanged; same-team echo -> 200, unchanged

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Moving a team's last model empties `team.models`, which the access check reads as unrestricted. That matches what deleting a team's last model does today (live: `{only-model}` -> delete -> `{}` -> the team key gets 200 on a model it was never granted) and is the intended meaning of an empty list, so this PR keeps it rather than changing the semantics
- The cleanup keeps a name only while a deployment of exactly that model group is live in the router; a wildcard or alias that would merely answer a call to the name is not a reason to keep the grant

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes team ACL bookkeeping on model PATCH when team_id changes; incorrect cleanup could revoke valid access or leave stale grants, though logic mirrors the existing delete path with new tests.
> 
> **Overview**
> Fixes a bug where **PATCH** `/model/{model_id}/update` with a new `model_info.team_id` left the model’s public name on the **source** team’s `models` list, so that team could still call that name (including unrelated proxy-wide models added later).
> 
> After `clear_cache()` reloads the router, **`patch_model`** now runs **`_remove_unbacked_team_models`** on the pre-move deployment when `team_id` actually changes. That reuses the same cleanup as model delete: drop names the source no longer backs, keep them if a sibling team row or an **exact** live router `model_name` still serves them (not wildcards/aliases alone), and scrub legacy **`model_aliases`**.
> 
> Tests cover team moves (named vs legacy alias, sibling retention) and wildcard cleanup behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97f88f5513e03b01435b9ebc6d5cfa8da050a2b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->