### PR TITLE
fix(responses): ensure reasoning output items have summary=[] not null

### DIFF
--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -2410,6 +2410,7 @@ class LiteLLMCompletionResponsesConfig:
                                 for text in (reasoning_content,)
                                 if text
                             ],
+                            summary=[],
                             encrypted_content=encrypted_content,
                         )
                     ]

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -4034,22 +4034,8 @@ class TestBridgedOutputItemIdPrefixes:
         assert len(items) == 1
         # summary must be an empty list, never None/null
         summary = getattr(items[0], "summary", "MISSING")
-        assert summary is not "MISSING", "summary attribute should be present"
+        assert summary != "MISSING", "summary attribute should be present"
         assert summary is not None, "summary should not be None"
-        assert isinstance(summary, list), f"summary should be a list, got {type(summary)}"
-        assert summary == [], f"summary should be an empty list, got {summary}"
-
-    def test_reasoning_item_summary_is_empty_list_not_null(self):
-        """Regression: reasoning output items must have summary as a list, not null.
-
-        OpenAI Responses API spec requires reasoning items to have a 'summary'
-        field as an array. LiteLLM was emitting null instead of [], causing
-        strict SDK clients to crash when trying to iterate over the summary.
-        """
-        items = self._reasoning_items()
-        assert len(items) == 1
-        summary = getattr(items[0], "summary", None)
-        assert summary is not None, "summary should not be None (regression for #40519)"
         assert isinstance(summary, list), f"summary should be a list, got {type(summary)}"
         assert summary == [], f"summary should be an empty list, got {summary}"
 

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -335,6 +335,9 @@ class TestLiteLLMCompletionResponsesConfig:
         assert reasoning_item.content[0].type == "output_text"
         assert "step by step" in reasoning_item.content[0].text
         assert "42" in reasoning_item.content[0].text
+        # Regression for #40519: summary must be an empty array, not null
+        assert hasattr(reasoning_item, "summary"), "reasoning item should have summary attribute"
+        assert reasoning_item.summary == [], f"summary should be empty list, got {reasoning_item.summary}"
 
         message_items = [
             item for item in responses_api_response.output if item.type == "message"
@@ -4019,6 +4022,20 @@ class TestBridgedOutputItemIdPrefixes:
 
         assert not suffix.lstrip("-").isdigit()
         assert not suffix.startswith("-")
+
+    def test_reasoning_item_summary_is_empty_list_not_null(self):
+        """Regression: reasoning output items must have summary as a list, not null.
+
+        OpenAI Responses API spec requires reasoning items to have a 'summary'
+        field as an array. LiteLLM was emitting null instead of [], causing
+        strict SDK clients to crash when trying to iterate over the summary.
+        """
+        items = self._reasoning_items()
+        assert len(items) == 1
+        summary = getattr(items[0], "summary", None)
+        assert summary is not None, "summary should not be None (regression for #40519)"
+        assert isinstance(summary, list), f"summary should be a list, got {type(summary)}"
+        assert summary == [], f"summary should be an empty list, got {summary}"
 
 
 class TestStreamingSnapshotItemIds:

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -4024,6 +4024,22 @@ class TestBridgedOutputItemIdPrefixes:
         assert not suffix.startswith("-")
 
     def test_reasoning_item_summary_is_empty_list_not_null(self):
+        """Regression: reasoning output items must have summary as an empty array, not null.
+
+        OpenAI Responses API spec requires reasoning items to have a 'summary'
+        field as an array. A null summary causes strict SDK clients to crash.
+        See issue #40519.
+        """
+        items = self._reasoning_items()
+        assert len(items) == 1
+        # summary must be an empty list, never None/null
+        summary = getattr(items[0], "summary", "MISSING")
+        assert summary is not "MISSING", "summary attribute should be present"
+        assert summary is not None, "summary should not be None"
+        assert isinstance(summary, list), f"summary should be a list, got {type(summary)}"
+        assert summary == [], f"summary should be an empty list, got {summary}"
+
+    def test_reasoning_item_summary_is_empty_list_not_null(self):
         """Regression: reasoning output items must have summary as a list, not null.
 
         OpenAI Responses API spec requires reasoning items to have a 'summary'


### PR DESCRIPTION
Fix: Anthropic Responses bridge emits null reasoning item summary (Issue #40519)\n\nWhen Gemini returns a candidate with finishReason but no content, the LiteLLM /v1/responses bridge creates a reasoning output item with summary: null. The OpenAI Responses API spec requires summary to be an array (empty [] means no summary). Strict SDK clients crash when trying to iterate over a null summary.\n\nFix: explicitly set summary=[] when creating GenericResponseOutputItem with type=reasoning.\n\nFixes #40519