### PR TITLE
fix(mcp): respect optional discovery capabilities and quiet unsupported methods

### DIFF
--- a/litellm/experimental_mcp_client/client.py
+++ b/litellm/experimental_mcp_client/client.py
@@ -54,18 +54,22 @@ def missing_streamable_http_client_error() -> ImportError:
     )
 
 
-from mcp.types import CallToolRequestParams as MCPCallToolRequestParams
-from mcp.types import CallToolResult as MCPCallToolResult
 from mcp.types import (
+    METHOD_NOT_FOUND,
     ClientResult,
     GetPromptRequestParams,
     GetPromptResult,
+    ListPromptsResult,
+    ListResourcesResult,
+    ListResourceTemplatesResult,
     Prompt,
     ResourceTemplate,
     ServerNotification,
     ServerRequest,
     TextContent,
 )
+from mcp.types import CallToolRequestParams as MCPCallToolRequestParams
+from mcp.types import CallToolResult as MCPCallToolResult
 from mcp.types import Tool as MCPTool
 from pydantic import AnyUrl
 
@@ -777,8 +781,19 @@ class MCPClient:
         """List available prompts from the server."""
         verbose_logger.debug("MCP client listing tools from %s", self.server_url or "stdio")
 
-        async def _list_prompts_operation(session: ClientSession):
-            return await session.list_prompts()
+        async def _list_prompts_operation(session: ClientSession) -> ListPromptsResult:
+            capabilities: Final = session.get_server_capabilities()
+            if capabilities is not None and capabilities.prompts is None:
+                return ListPromptsResult(prompts=[])
+            try:
+                return await session.list_prompts()
+            except McpError as error:
+                if error.error.code != METHOD_NOT_FOUND:
+                    raise
+                verbose_logger.debug(
+                    "MCP client list_prompts is unsupported by %s: %s", self.server_url or "stdio", error
+                )
+                return ListPromptsResult(prompts=[])
 
         try:
             result: Final = await self.run_with_session(_list_prompts_operation)
@@ -854,8 +869,19 @@ class MCPClient:
         """List available resources from the server."""
         verbose_logger.debug("MCP client listing resources from %s", self.server_url or "stdio")
 
-        async def _list_resources_operation(session: ClientSession):
-            return await session.list_resources()
+        async def _list_resources_operation(session: ClientSession) -> ListResourcesResult:
+            capabilities: Final = session.get_server_capabilities()
+            if capabilities is not None and capabilities.resources is None:
+                return ListResourcesResult(resources=[])
+            try:
+                return await session.list_resources()
+            except McpError as error:
+                if error.error.code != METHOD_NOT_FOUND:
+                    raise
+                verbose_logger.debug(
+                    "MCP client list_resources is unsupported by %s: %s", self.server_url or "stdio", error
+                )
+                return ListResourcesResult(resources=[])
 
         try:
             result: Final = await self.run_with_session(_list_resources_operation)
@@ -890,8 +916,19 @@ class MCPClient:
         """List available resource templates from the server."""
         verbose_logger.debug("MCP client listing resource templates from %s", self.server_url or "stdio")
 
-        async def _list_resource_templates_operation(session: ClientSession):
-            return await session.list_resource_templates()
+        async def _list_resource_templates_operation(session: ClientSession) -> ListResourceTemplatesResult:
+            capabilities: Final = session.get_server_capabilities()
+            if capabilities is not None and capabilities.resources is None:
+                return ListResourceTemplatesResult(resourceTemplates=[])
+            try:
+                return await session.list_resource_templates()
+            except McpError as error:
+                if error.error.code != METHOD_NOT_FOUND:
+                    raise
+                verbose_logger.debug(
+                    "MCP client list_resource_templates is unsupported by %s: %s", self.server_url or "stdio", error
+                )
+                return ListResourceTemplatesResult(resourceTemplates=[])
 
         try:
             result: Final = await self.run_with_session(_list_resource_templates_operation)

--- a/tests/test_litellm/experimental_mcp_client/test_mcp_client.py
+++ b/tests/test_litellm/experimental_mcp_client/test_mcp_client.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import anyio
 import httpx
 import pytest
+import respx
 from litellm.proxy._experimental.mcp_server.outbound_credentials.httpx_auth import StaticHeaderAuth
 from mcp import McpError
 from mcp.client.streamable_http import streamable_http_client
@@ -1686,3 +1687,211 @@ async def test_empty_http_event_stream_uses_the_existing_request_deadline() -> N
                 timeout=3,
             )
     assert isinstance(as_mcp_read_timeout(caught.value), TimeoutError)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method", ("prompts/list", "resources/list", "resources/templates/list"))
+@pytest.mark.parametrize(
+    "outcome",
+    (
+        "absent",
+        "other_capability",
+        "supported",
+        "method_not_found",
+        "internal_error",
+        "unauthorized",
+        "timeout",
+        "initialize_not_found",
+    ),
+)
+async def test_optional_discovery_capabilities_and_errors(
+    method: str, outcome: str, caplog: pytest.LogCaptureFixture
+) -> None:
+    import logging
+    from unittest.mock import Mock
+
+    from mcp.types import JSONRPCRequest
+
+    capability: Final = "prompts" if method == "prompts/list" else "resources"
+    field: Final = {
+        "prompts/list": "prompts",
+        "resources/list": "resources",
+        "resources/templates/list": "resourceTemplates",
+    }[method]
+    advertised: Final = "resources" if capability == "prompts" else "prompts"
+    entry: Final = {
+        "prompts/list": {"name": "example"},
+        "resources/list": {"name": "example", "uri": "test://example"},
+        "resources/templates/list": {"name": "example", "uriTemplate": "test://{name}"},
+    }[method]
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        if request.method == "DELETE":
+            return httpx.Response(200)
+        payload: Final = JSONRPCMessage.model_validate_json(request.content).root
+        if not isinstance(payload, JSONRPCRequest):
+            return httpx.Response(202)
+        if outcome == "initialize_not_found":
+            return httpx.Response(
+                200,
+                json={
+                    "jsonrpc": "2.0",
+                    "id": payload.id,
+                    "error": {"code": -32601, "message": "Initialization rejected"},
+                },
+            )
+        if payload.method == "initialize":
+            return httpx.Response(
+                200,
+                json={
+                    "jsonrpc": "2.0",
+                    "id": payload.id,
+                    "result": {
+                        "protocolVersion": LATEST_PROTOCOL_VERSION,
+                        "capabilities": {}
+                        if outcome == "absent"
+                        else {advertised if outcome == "other_capability" else capability: {}},
+                        "serverInfo": {"name": "discovery", "version": "1"},
+                    },
+                },
+            )
+        if outcome == "timeout":
+            raise httpx.ReadTimeout("Optional list timed out", request=request)
+        if outcome == "unauthorized":
+            return httpx.Response(401)
+        if outcome in ("method_not_found", "internal_error", "absent", "other_capability"):
+            return httpx.Response(
+                200,
+                json={
+                    "jsonrpc": "2.0",
+                    "id": payload.id,
+                    "error": {
+                        "code": -32603 if outcome == "internal_error" else -32601,
+                        "message": "Optional list rejected",
+                    },
+                },
+            )
+        return httpx.Response(200, json={"jsonrpc": "2.0", "id": payload.id, "result": {field: [entry]}})
+
+    responder: Final = Mock(side_effect=respond)
+    caplog.set_level(logging.DEBUG, logger="LiteLLM")
+    with respx.mock(base_url="https://example.com") as router:
+        router.route().mock(side_effect=responder)
+        client: Final = MCPClient(server_url="https://example.com/mcp")
+        operation: Final = {
+            "prompts/list": client.list_prompts,
+            "resources/list": client.list_resources,
+            "resources/templates/list": client.list_resource_templates,
+        }[method]
+        result: Final = await operation()
+
+    requests: Final = tuple(
+        JSONRPCMessage.model_validate_json(call.args[0].content).root
+        for call in responder.call_args_list
+        if call.args[0].method == "POST"
+    )
+    assert sum(isinstance(request, JSONRPCRequest) and request.method == method for request in requests) == (
+        0 if outcome in ("absent", "other_capability", "initialize_not_found") else 1
+    )
+    assert [item.name for item in result] == (["example"] if outcome == "supported" else [])
+    failures: Final = tuple(
+        record for record in caplog.records if record.name == "LiteLLM" and record.levelno >= logging.WARNING
+    )
+    if outcome in ("internal_error", "unauthorized", "timeout", "initialize_not_found"):
+        assert any(record.levelno == logging.ERROR and "failed" in record.message for record in failures)
+    else:
+        assert failures == ()
+    if outcome == "method_not_found":
+        assert any(
+            record.levelno == logging.DEBUG and "Optional list rejected" in record.message for record in caplog.records
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("supports_first", (True, False))
+async def test_optional_discovery_uses_each_sessions_capabilities(supports_first: bool) -> None:
+    from unittest.mock import Mock
+    from mcp.types import JSONRPCRequest
+
+    capabilities: Final = iter(({"resources": {}}, {}) if supports_first else ({}, {"resources": {}}))
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        if request.method == "DELETE":
+            return httpx.Response(200)
+        payload: Final = JSONRPCMessage.model_validate_json(request.content).root
+        if not isinstance(payload, JSONRPCRequest):
+            return httpx.Response(202)
+        result: Final = (
+            {
+                "protocolVersion": LATEST_PROTOCOL_VERSION,
+                "capabilities": next(capabilities),
+                "serverInfo": {"name": "changing", "version": "1"},
+            }
+            if payload.method == "initialize"
+            else {"resources": [{"name": "example", "uri": "test://example"}]}
+        )
+        return httpx.Response(200, json={"jsonrpc": "2.0", "id": payload.id, "result": result})
+
+    responder: Final = Mock(side_effect=respond)
+    with respx.mock(base_url="https://example.com") as router:
+        router.route().mock(side_effect=responder)
+        client: Final = MCPClient(server_url="https://example.com/mcp")
+        first: Final = await client.list_resources()
+        second: Final = await client.list_resources()
+
+    assert [item.name for item in first] == (["example"] if supports_first else [])
+    assert [item.name for item in second] == ([] if supports_first else ["example"])
+    requests: Final = tuple(
+        JSONRPCMessage.model_validate_json(call.args[0].content).root
+        for call in responder.call_args_list
+        if call.args[0].method == "POST"
+    )
+    assert sum(isinstance(request, JSONRPCRequest) and request.method == "resources/list" for request in requests) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method", ("prompts/list", "resources/list", "resources/templates/list"))
+async def test_optional_discovery_preserves_cancellation(method: str) -> None:
+    from mcp.types import JSONRPCRequest
+
+    ready: Final = asyncio.Event()
+    pending: Final = asyncio.Event()
+
+    async def respond(request: httpx.Request) -> httpx.Response:
+        if request.method == "DELETE":
+            return httpx.Response(200)
+        payload: Final = JSONRPCMessage.model_validate_json(request.content).root
+        if not isinstance(payload, JSONRPCRequest):
+            return httpx.Response(202)
+        if payload.method == "initialize":
+            return httpx.Response(
+                200,
+                json={
+                    "jsonrpc": "2.0",
+                    "id": payload.id,
+                    "result": {
+                        "protocolVersion": LATEST_PROTOCOL_VERSION,
+                        "capabilities": {"resources": {}, "prompts": {}},
+                        "serverInfo": {"name": "pending", "version": "1"},
+                    },
+                },
+            )
+        ready.set()
+        await pending.wait()
+        return httpx.Response(202)
+
+    with respx.mock(base_url="https://example.com") as router:
+        router.route().mock(side_effect=respond)
+        client: Final = MCPClient(server_url="https://example.com/mcp")
+        operation: Final = {
+            "prompts/list": client.list_prompts,
+            "resources/list": client.list_resources,
+            "resources/templates/list": client.list_resource_templates,
+        }[method]
+        task: Final = asyncio.create_task(operation())
+        try:
+            await asyncio.wait_for(ready.wait(), timeout=3)
+        finally:
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await asyncio.wait_for(task, timeout=3)


### PR DESCRIPTION
## TLDR

Problem this solves:

- Optional MCP discovery calls unsupported methods and generates false errors

How it solves it:

- Check each session's advertised prompts/resources capabilities
- Handle optional `-32601` responses at DEBUG before outer logging
- Preserve genuine failures, successful discovery, and cancellation

## User Flow

Before: normal discovery against tools-only MCP servers produces error noise

1. Configure a tools-only MCP server and connect to `POST http://localhost:4000/mcp/`
2. Send `initialize`, `notifications/initialized`, then `resources/list`, `resources/templates/list`, and `prompts/list`
3. Receive empty lists for that server and see WARNING/ERROR lines for `Method not found`

After: normal discovery returns the same empty lists without false errors

1. Configure a tools-only MCP server and connect to `POST http://localhost:4000/mcp/`
2. Send `initialize`, `notifications/initialized`, then `resources/list`, `resources/templates/list`, and `prompts/list`
3. Receive empty lists for that server with no unsupported calls or WARNING/ERROR lines

## Relevant issues

[Pylon #8380](https://app.usepylon.com/issues?issueNumber=8380)

## Linear ticket

Resolves LIT-7423

Addresses the capability-checking portion of LIT-6585 and duplicate LIT-7446. LIT-6585 stays open for upstream session reuse and caching

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The affected test files pass locally: 160 tests
- [x] My PR passes all required CI/CD checks (33 passing)
- [x] My PR's scope is isolated to optional MCP discovery
- [x] Greptile Confidence Score is at least 4/5 (5/5 at the current tip)

Veria passed with no security issues and no annotations; Bugbot passed with no new issues and no annotations; Greptile scored 5/5. All three reviews cover current tip `935611d25d`, with no inline findings. The sole committer already signed the contributor agreement, confirmed by CLAassistant on [PR #40359](https://github.com/BerriAI/litellm/pull/40359)

The 29 new regression cases exercise the real client and SDK session against an HTTP boundary. Eleven fail against the merge-base source; all 29 pass at the tip. Coverage includes absent/unrelated capabilities, advertised empty capability objects, successful lists, unsupported methods, RPC/HTTP/timeouts, initialization errors, capability changes across sessions, and cancellation

Coverage verified on the current tip with the affected tests and `--cov-branch`: **35/35 changed executable lines (100%) and 12/12 changed branches (100%)**. Each of the three changed discovery operations is fully covered. The completed [Codecov patch report](https://app.codecov.io/gh/BerriAI/litellm/pull/40525) independently confirms 35 hits and zero misses. [Raw coverage data, the scoped summary, and the exact command](https://gist.github.com/joshua-berri/00ebf8ee3337f8e5fef32b01d3add74f) are included with the evidence

These figures describe the changed behavior. Repository-wide Codecov coverage is 80.22%; this focused local test set covers 77.37% of lines and 67.5% of branches across the entire existing client module

Local validation: Ruff lint/format, full test-tree lint, strict-rule, type-discipline, test-quality, e2e basedpyright, circular-import and import-safety checks passed. The full basedpyright budget gate also passed against the merge base in its canonical dependency environment. No budgets or suppressions changed

The non-required [OSV scan](https://github.com/BerriAI/litellm/actions/runs/34433502311) reports GHSA-7w5x-hrqm-74c2 in dashboard dev dependency `smol-toml` 1.6.1. The same version is present at the merge base; this PR does not change either lockfile

## Screenshots / Proof of Fix

[Reproduction setup and captured evidence](https://gist.github.com/joshua-berri/00ebf8ee3337f8e5fef32b01d3add74f) contains the Compose setup, SDK upstream, exact curl commands, and captured results. Both gateway images use clean source archives with revision labels and the same locked runtime dependencies. Verification uses PostgreSQL and real HTTP MCP connections on `http://127.0.0.1:47423/mcp/`; no LLM calls are needed

### Before (87e2026f0a440279c3a1b32d7351df91d13d2d29)

#### Optional discovery

1. Start `REVISION=before docker compose up -d --force-recreate gateway upstream` and wait for `curl -sS http://127.0.0.1:47423/health/liveliness` to return `"I'm alive!"`
2. Run `bash reproduce.sh before`, which initializes a session and sends the three optional list requests. Responses contain `supported-example`, `supported-example_template`, and `supported-example_prompt`
3. Inspect upstream request logs: the tools-only server receives all three unsupported requests. Gateway logs contain three WARNING/ERROR pairs for it and three more for advertised methods returning `-32601`
4. Inspect the genuine-error control: `Upstream internal failure` remains ERROR for all three methods

#### Tool happy path

1. The same `bash reproduce.sh before` run sends `tools/list` and lists four echo tools
2. It calls `tools-echo` with `text=optional-discovery-happy-path` and receives `isError: false` with the same text

### After (935611d25d092c5623b44e08d89d7c2e3d565933)

#### Optional discovery

1. Start `REVISION=after docker compose up -d --force-recreate gateway upstream` and wait for `curl -sS http://127.0.0.1:47423/health/liveliness` to return `"I'm alive!"`
2. Run `bash reproduce.sh after`, which initializes a session and sends the three optional list requests. Responses contain `supported-example`, `supported-example_template`, and `supported-example_prompt`
3. Inspect upstream request logs: the tools-only server receives zero optional requests. Advertised methods returning `-32601` produce three DEBUG lines and no WARNING/ERROR pairs
4. Inspect the genuine-error control: `Upstream internal failure` remains ERROR for all three methods

#### Tool happy path

1. The same `bash reproduce.sh after` run sends `tools/list` and lists four echo tools
2. It calls `tools-echo` with `text=optional-discovery-happy-path` and receives `isError: false` with the same text

## Type

Bug Fix

## Caveats (if any)

### Low

- Session creation and caching are unchanged; LIT-6585 remains open

## Final Attestation

- [x] Tests cover the reproduced failures and relevant discovery edge cases
