### PR TITLE
refactor(ocr): route Mistral through the gateway facade

### DIFF
--- a/litellm-rust/crates/ai-gateway/src/ocr/hooks.rs
+++ b/litellm-rust/crates/ai-gateway/src/ocr/hooks.rs
@@ -399,3 +399,102 @@ fn core_error_kind(error: &Error) -> &'static str {
         Error::Unsupported(_) => "UnsupportedRequest",
     }
 }
+
+impl litellm_core::ocr::hooks::OcrHooks for OcrLifecycleHooks {
+    fn has_guardrails(&self) -> bool {
+        !self.guardrail_runner.is_empty()
+    }
+
+    fn pre_call(
+        &self,
+        request: litellm_core::ocr::hooks::OcrPreCallRequest,
+    ) -> litellm_core::ocr::hooks::OcrHookFuture<'_, litellm_core::ocr::hooks::OcrPreCallRequest>
+    {
+        Box::pin(async move {
+            let context = guardrail_context(&self.request_metadata);
+            let payload = GuardrailRequest::new(json!(&request));
+            let (changed, _) = self
+                .guardrail_runner
+                .run_pre_call(&context, payload)
+                .await
+                .map_err(guardrail_error_to_core_error)?;
+            Ok(litellm_core::ocr::wire::decode_pre_call_result(
+                request,
+                changed.data,
+            )?)
+        })
+    }
+
+    fn during_call(
+        &self,
+        request: litellm_core::ocr::hooks::OcrDuringCallRequest,
+    ) -> litellm_core::ocr::hooks::OcrHookFuture<'_, litellm_core::ocr::hooks::OcrDuringCallRequest>
+    {
+        Box::pin(async move {
+            let context = guardrail_context(&self.request_metadata);
+            let payload = GuardrailRequest::new(json!(&request));
+            let (changed, _) = self
+                .guardrail_runner
+                .run_during_call(&context, payload)
+                .await
+                .map_err(guardrail_error_to_core_error)?;
+            Ok(litellm_core::ocr::wire::decode_during_call_result(
+                request,
+                changed.data,
+            )?)
+        })
+    }
+
+    fn success<'a>(
+        &'a self,
+        context: &'a CallLifecycleContext,
+        response: &'a litellm_core::ocr::LiteLLMOcrResponse,
+        timing: &'a CallLifecycleTiming,
+    ) -> litellm_core::ocr::hooks::OcrLogFuture<'a> {
+        Box::pin(async move {
+            if self.logger_runner.is_empty() {
+                return;
+            }
+            self.logger_runner
+                .async_log_success_event(
+                    &ModelCallDetails::from_standard_logging_payload(
+                        self.standard_logging_payload(context, timing),
+                    ),
+                    &CallbackValue::new("ocr", json!(response)),
+                    CallbackTiming::new(timing.start_time, timing.end_time),
+                )
+                .await;
+        })
+    }
+
+    fn failure<'a>(
+        &'a self,
+        context: &'a CallLifecycleContext,
+        error: &'a Error,
+        timing: &'a CallLifecycleTiming,
+    ) -> litellm_core::ocr::hooks::OcrLogFuture<'a> {
+        Box::pin(async move {
+            if self.logger_runner.is_empty() {
+                return;
+            }
+            let logging_error = LoggingError {
+                message: error.to_string(),
+                kind: core_error_kind(error).to_string(),
+            };
+            let response = CallbackValue::new(
+                "error",
+                json!({"message":logging_error.message,"kind":logging_error.kind}),
+            );
+            self.logger_runner
+                .async_log_failure_event(
+                    &ModelCallDetails::from_standard_logging_payload(
+                        self.standard_logging_payload(context, timing),
+                    )
+                    .with_failure_error(logging_error),
+                    Some(&response),
+                    CallbackTiming::new(timing.start_time, timing.end_time),
+                )
+                .await;
+        })
+    }
+}

--- a/litellm-rust/crates/ai-gateway/src/ocr/mod.rs
+++ b/litellm-rust/crates/ai-gateway/src/ocr/mod.rs
@@ -1,6 +1,12 @@
 use litellm_core::Error;
 use litellm_core::call_lifecycle::CallLifecycle;
+use litellm_core::ocr::{
+    OcrClient,
+    wire::{OcrWireRequest, decode_request},
+};
+use litellm_core::routing_utils::provider::{CustomLlmProvider, get_custom_llm_provider};
 use serde_json::Value;
+use std::sync::Arc;
 
 mod common_utils;
 mod handler;
@@ -15,6 +21,45 @@ use prepare::{PreparedOcrCall, prepare_ocr_call};
 
 #[tracing::instrument(target = "litellm::function_trace", level = "trace", skip_all)]
 pub async fn ocr(request: OcrRequest<'_>) -> Result<Value, Error> {
+    let provider = get_custom_llm_provider(request.model, request.custom_llm_provider).unwrap_or(
+        CustomLlmProvider {
+            model: request.model,
+            custom_llm_provider: "mistral",
+        },
+    );
+    if provider.custom_llm_provider == "mistral" {
+        return core_mistral_ocr(request).await;
+    }
+    legacy_ocr(request).await
+}
+
+async fn core_mistral_ocr(request: OcrRequest<'_>) -> Result<Value, Error> {
+    let client = OcrClient::new(crate::client::http_client().clone())?;
+    let core_request = decode_request(OcrWireRequest {
+        model: request.model.to_string(),
+        document: request.document,
+        api_key: request.api_key.map(str::to_string),
+        api_base: request.api_base.map(str::to_string),
+        custom_llm_provider: request.custom_llm_provider.map(str::to_string),
+        extra_headers: request.extra_headers,
+        optional_params: request.optional_params,
+        timeout_seconds: request.timeout.map(|timeout| timeout.as_secs_f64()),
+    })?
+    .with_host_hooks(
+        Arc::new(hooks::OcrLifecycleHooks::new(
+            crate::integrations::custom_logger::CustomLoggerRunner::new(request.callbacks),
+            crate::integrations::custom_guardrail::CustomGuardrailRunner::new(request.guardrails),
+            request.request_metadata,
+        )),
+        request.litellm_call_id.map(str::to_string),
+    );
+    client
+        .perform(core_request)
+        .await
+        .map(|response| response.into_json())
+}
+
+async fn legacy_ocr(request: OcrRequest<'_>) -> Result<Value, Error> {
     let PreparedOcrCall { request, hooks } = prepare_ocr_call(request);
     CallLifecycle::default()
         .run_request(request, &hooks, |request| {


### PR DESCRIPTION
## TLDR

Problem this solves:

- Gateway Mistral calls still used the legacy OCR executor

How it solves it:

- Translates gateway logging and guardrails into core hooks

## User Flow

Before: `POST https://litellm-domain/v1/ocr` uses legacy Mistral execution

1. A developer sends a Mistral document to the OCR endpoint
2. Gateway logging and guardrails run around the legacy route

After: the same request uses core without changing gateway behavior

1. A developer sends the same Mistral document to the OCR endpoint
2. Logging, guardrails, metadata, and the response remain intact

## Stack

- Layer 2 of 9
- Depends on #40530
- Next: #40532

## Validation

- Seven gateway lifecycle cases pass
- Native wheel smoke remains a regression check at this boundary

## Scope notes

- Behavior: preserves gateway logger and guardrail semantics
- Mechanical: routes only direct Mistral through the core facade
- Unmigrated providers retain their legacy gateway paths

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The focused test files pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible
- [ ] I have received a Greptile Confidence Score of at least 4/5

## Type

🧹 Refactoring
✅ Test

## Final Attestation

- [x] The tests count upstream and lifecycle effects through the gateway

