### PR TITLE
fix(spend): attribute CLI session spend to the per-user cli-session alias instead of the hashed session token

### DIFF
--- a/litellm/proxy/hooks/proxy_track_cost_callback.py
+++ b/litellm/proxy/hooks/proxy_track_cost_callback.py
@@ -109,7 +109,7 @@ class _ProxyDBLogger(CustomLogger):
         _metadata = dict(
             LiteLLMProxyRequestSetup.get_sanitized_user_information_from_key(user_api_key_dict=user_api_key_dict)
         )
-        _metadata["user_api_key"] = user_api_key_dict.api_key
+        _metadata["user_api_key"] = LiteLLMProxyRequestSetup.get_logged_api_key(user_api_key_dict)
         _metadata["status"] = "failure"
         _error_information = StandardLoggingPayloadSetup.get_error_information(
             original_exception=original_exception,
@@ -204,7 +204,7 @@ class _ProxyDBLogger(CustomLogger):
         )
 
         await proxy_logging_obj.db_spend_update_writer.update_database(
-            token=user_api_key_dict.api_key,
+            token=LiteLLMProxyRequestSetup.get_logged_api_key(user_api_key_dict),
             response_cost=recovered_response_cost,
             user_id=user_api_key_dict.user_id,
             end_user_id=user_api_key_dict.end_user_id,

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -1572,13 +1572,26 @@ class LiteLLMProxyRequestSetup:
         return data
 
     @staticmethod
+    def get_logged_api_key(user_api_key_dict: UserAPIKeyAuth) -> str | None:
+        """
+        The value spend rows and logging callbacks attribute a request to.
+
+        A CLI session token is a per-login random secret, so the key is the
+        session's stable alias (cli-session-<user_id>) instead: every login of
+        one user rolls up to one key and the live token never lands in a row.
+        """
+        if user_api_key_dict.is_session_token and user_api_key_dict.key_alias:
+            return user_api_key_dict.key_alias
+        return user_api_key_dict.api_key
+
+    @staticmethod
     def get_sanitized_user_information_from_key(
         user_api_key_dict: UserAPIKeyAuth,
     ) -> StandardLoggingUserAPIKeyMetadata:
         stripped_metadata: Final = strip_callback_config(user_api_key_dict.metadata)
         auth_metadata: Final = cast("dict[str, str] | None", stripped_metadata)  # cast-ok: metadata is free-form JSON
         user_api_key_logged_metadata: Final = StandardLoggingUserAPIKeyMetadata(
-            user_api_key_hash=user_api_key_dict.api_key,  # just the hashed token
+            user_api_key_hash=LiteLLMProxyRequestSetup.get_logged_api_key(user_api_key_dict),
             user_api_key_alias=user_api_key_dict.key_alias,
             user_api_key_spend=user_api_key_dict.spend,
             user_api_key_max_budget=user_api_key_dict.max_budget,
@@ -1616,7 +1629,7 @@ class LiteLLMProxyRequestSetup:
             user_api_key_dict=user_api_key_dict
         )
         data[_metadata_variable_name].update(user_api_key_logged_metadata)
-        data[_metadata_variable_name]["user_api_key"] = user_api_key_dict.api_key  # this is just the hashed token
+        data[_metadata_variable_name]["user_api_key"] = LiteLLMProxyRequestSetup.get_logged_api_key(user_api_key_dict)
 
         # Key-owned agent_id for spend attribution; keep existing (e.g. from header) if key has none
         _key_agent_id: Final = getattr(user_api_key_dict, "agent_id", None)

--- a/litellm/proxy/management_endpoints/common_daily_activity.py
+++ b/litellm/proxy/management_endpoints/common_daily_activity.py
@@ -12,7 +12,7 @@ from litellm._logging import verbose_proxy_logger
 from litellm.constants import PTU_SENTINEL_API_KEY
 from litellm.proxy._types import CommonProxyErrors
 from litellm.proxy.spend_tracking.key_metadata_recovery import (
-    attach_user_emails,
+    attach_user_details,
     recover_cli_session_key_metadata,
     recover_double_hashed_key_metadata,
     recover_key_metadata_from_spend_logs,
@@ -515,7 +515,7 @@ async def get_api_key_metadata(
         else _EMPTY_KEY_METADATA
     )
     combined: Final = MappingProxyType({**after_token_recovery, **from_spend_logs})
-    return await attach_user_emails(prisma_client, combined)
+    return await attach_user_details(prisma_client, combined)
 
 
 def _adjust_dates_for_timezone(

--- a/litellm/proxy/management_endpoints/common_daily_activity.py
+++ b/litellm/proxy/management_endpoints/common_daily_activity.py
@@ -13,6 +13,7 @@ from litellm.constants import PTU_SENTINEL_API_KEY
 from litellm.proxy._types import CommonProxyErrors
 from litellm.proxy.spend_tracking.key_metadata_recovery import (
     attach_user_emails,
+    recover_cli_session_key_metadata,
     recover_double_hashed_key_metadata,
     recover_key_metadata_from_spend_logs,
 )
@@ -501,11 +502,12 @@ async def get_api_key_metadata(
                 e,
             )
 
-    still_missing: Final = api_keys - frozenset(result)
+    from_session_keys: Final = recover_cli_session_key_metadata(api_keys - frozenset(result))
+    still_missing: Final = api_keys - frozenset(result) - frozenset(from_session_keys)
     from_reverse_hash: Final = (
         await recover_double_hashed_key_metadata(prisma_client, still_missing) if still_missing else _EMPTY_KEY_METADATA
     )
-    after_token_recovery: Final = MappingProxyType({**result, **from_reverse_hash})
+    after_token_recovery: Final = MappingProxyType({**result, **from_session_keys, **from_reverse_hash})
     unresolved: Final = api_keys - frozenset(after_token_recovery)
     from_spend_logs: Final = (
         await recover_key_metadata_from_spend_logs(prisma_client, unresolved, spend_logs_window)

--- a/litellm/proxy/spend_tracking/key_metadata_recovery.py
+++ b/litellm/proxy/spend_tracking/key_metadata_recovery.py
@@ -153,7 +153,7 @@ async def _reverse_hash_key_metadata(
 @dataclass(frozen=True, slots=True)
 class _UserDetails:
     email: str | None
-    first_team: str | None
+    only_team: str | None
 
 
 _EMPTY_USER_DETAILS: Final[Mapping[str, _UserDetails]] = MappingProxyType({})
@@ -178,12 +178,19 @@ async def _details_for_user_ids(
         {
             user.user_id: _UserDetails(
                 email=getattr(user, "user_email", None) or None,
-                first_team=next(iter(getattr(user, "teams", None) or ()), None),
+                only_team=_only_team(getattr(user, "teams", None)),
             )
             for user in users
             if getattr(user, "user_id", None)
         }
     )
+
+
+def _only_team(teams: object) -> str | None:
+    if not isinstance(teams, list) or len(teams) != 1:
+        return None
+    team: Final = teams[0]
+    return team if isinstance(team, str) and team else None
 
 
 def _is_cli_session_key(api_key: str) -> bool:
@@ -198,7 +205,7 @@ def _meta_with_user_details(
         return meta
     user: Final = details[user_id]
     email: Final = meta.get("user_email") or user.email
-    team_id: Final = meta.get("team_id") or (user.first_team if _is_cli_session_key(api_key) else None)
+    team_id: Final = meta.get("team_id") or (user.only_team if _is_cli_session_key(api_key) else None)
     updated: Final[KeyMetadataDict] = {
         **meta,
         **({"user_email": email} if email else {}),
@@ -213,7 +220,8 @@ async def attach_user_details(
 ) -> Mapping[str, KeyMetadataDict]:
     """
     Fill user_email from the owner's user row, and for a cli-session key also
-    the team the CLI login attaches to that user (its first team).
+    the team the CLI login attaches on its own: the user's only team. A user in
+    several teams picks one per login, so the alias claims none for them.
     """
     needing_details: Final = frozenset(
         user_id

--- a/litellm/proxy/spend_tracking/key_metadata_recovery.py
+++ b/litellm/proxy/spend_tracking/key_metadata_recovery.py
@@ -1,6 +1,7 @@
 import asyncio
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from collections.abc import Set as AbstractSet
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from types import MappingProxyType
 from typing import Final, TypeVar
@@ -110,7 +111,6 @@ _SPEND_LOG_METADATA_CACHE: Final = InMemoryCache(
 )
 _SPEND_LOG_QUERY_LOCK: Final = asyncio.Lock()
 _EMPTY_KEY_METADATA: Final[Mapping[str, KeyMetadataDict]] = MappingProxyType({})
-_EMPTY_EMAILS: Final[Mapping[str, str]] = MappingProxyType({})
 
 
 async def _db_or_empty(
@@ -150,54 +150,85 @@ async def _reverse_hash_key_metadata(
     )
 
 
-async def _emails_for_user_ids(
+@dataclass(frozen=True, slots=True)
+class _UserDetails:
+    email: str | None
+    first_team: str | None
+
+
+_EMPTY_USER_DETAILS: Final[Mapping[str, _UserDetails]] = MappingProxyType({})
+
+
+async def _details_for_user_ids(
     prisma_client: PrismaClient,
     user_ids: AbstractSet[str],
-) -> Mapping[str, str]:
+) -> Mapping[str, _UserDetails]:
     if not user_ids:
-        return _EMPTY_EMAILS
+        return _EMPTY_USER_DETAILS
     users: Final = await _db_or_empty(
         lambda: UserRepository(prisma_client).table.find_many(
             where={"user_id": {"in": list(user_ids)}},  # mutable-ok: Prisma find_many where= is a dict
         ),
-        "Failed user_email recovery for %d user ids: %s",
+        "Failed user detail recovery for %d user ids: %s",
         len(user_ids),
     )
     if users is None:
-        return _EMPTY_EMAILS
+        return _EMPTY_USER_DETAILS
     return MappingProxyType(
         {
-            user.user_id: user.user_email
+            user.user_id: _UserDetails(
+                email=getattr(user, "user_email", None) or None,
+                first_team=next(iter(getattr(user, "teams", None) or ()), None),
+            )
             for user in users
-            if getattr(user, "user_id", None) and getattr(user, "user_email", None)
+            if getattr(user, "user_id", None)
         }
     )
 
 
-def _meta_with_email(meta: KeyMetadataDict, emails: Mapping[str, str]) -> KeyMetadataDict:
-    if meta.get("user_email"):
-        return meta
+def _is_cli_session_key(api_key: str) -> bool:
+    return api_key.startswith(_CLI_SESSION_KEY_PREFIX) and len(api_key) > len(_CLI_SESSION_KEY_PREFIX)
+
+
+def _meta_with_user_details(
+    api_key: str, meta: KeyMetadataDict, details: Mapping[str, _UserDetails]
+) -> KeyMetadataDict:
     user_id: Final = meta.get("user_id")
-    if not isinstance(user_id, str) or user_id not in emails:
+    if not isinstance(user_id, str) or user_id not in details:
         return meta
-    updated: Final[KeyMetadataDict] = {**meta, "user_email": emails[user_id]}
+    user: Final = details[user_id]
+    email: Final = meta.get("user_email") or user.email
+    team_id: Final = meta.get("team_id") or (user.first_team if _is_cli_session_key(api_key) else None)
+    updated: Final[KeyMetadataDict] = {
+        **meta,
+        **({"user_email": email} if email else {}),
+        **({"team_id": team_id} if team_id else {}),
+    }
     return updated
 
 
-async def attach_user_emails(
+async def attach_user_details(
     prisma_client: PrismaClient,
     recovered: Mapping[str, KeyMetadataDict],
 ) -> Mapping[str, KeyMetadataDict]:
-    needing_email: Final = frozenset(
+    """
+    Fill user_email from the owner's user row, and for a cli-session key also
+    the team the CLI login attaches to that user (its first team).
+    """
+    needing_details: Final = frozenset(
         user_id
-        for meta in recovered.values()
+        for api_key, meta in recovered.items()
         for user_id in (meta.get("user_id"),)
-        if isinstance(user_id, str) and user_id and not meta.get("user_email")
+        if isinstance(user_id, str)
+        and user_id
+        and (not meta.get("user_email") or (_is_cli_session_key(api_key) and not meta.get("team_id")))
     )
-    emails: Final = await _emails_for_user_ids(prisma_client, needing_email)
-    if not emails:
+    details: Final = await _details_for_user_ids(prisma_client, needing_details)
+    if not details:
         return recovered
-    return MappingProxyType({api_key: _meta_with_email(meta, emails) for api_key, meta in recovered.items()})
+    return MappingProxyType(
+        {api_key: _meta_with_user_details(api_key, meta, details) for api_key, meta in recovered.items()}
+    )
 
 
 def recover_cli_session_key_metadata(missing_keys: AbstractSet[str]) -> Mapping[str, KeyMetadataDict]:
@@ -205,7 +236,7 @@ def recover_cli_session_key_metadata(missing_keys: AbstractSet[str]) -> Mapping[
         {
             key: KeyMetadataDict(key_alias=key, user_id=key.removeprefix(_CLI_SESSION_KEY_PREFIX))
             for key in missing_keys
-            if key.startswith(_CLI_SESSION_KEY_PREFIX) and len(key) > len(_CLI_SESSION_KEY_PREFIX)
+            if _is_cli_session_key(key)
         }
     )
 
@@ -396,7 +427,7 @@ async def fill_missing_api_key_aliases(
         return tuple(rows)
 
     from_session_keys: Final = recover_cli_session_key_metadata(missing_keys)
-    recovered: Final = await attach_user_emails(
+    recovered: Final = await attach_user_details(
         prisma_client,
         MappingProxyType(
             {

--- a/litellm/proxy/spend_tracking/key_metadata_recovery.py
+++ b/litellm/proxy/spend_tracking/key_metadata_recovery.py
@@ -11,6 +11,7 @@ from typing_extensions import ReadOnly, TypedDict
 from litellm._logging import verbose_proxy_logger
 from litellm.caching.in_memory_cache import InMemoryCache
 from litellm.constants import (
+    CLI_SESSION_KEY_PREFIX,
     SPEND_LOG_KEY_METADATA_CACHE_MAX_ITEMS,
     SPEND_LOG_KEY_METADATA_CACHE_TTL,
     SPEND_LOG_KEY_METADATA_MISS_CACHE_TTL,
@@ -62,6 +63,7 @@ _SPEND_LOG_STATEMENT_TIMEOUT_SQL: Final = f"SET LOCAL statement_timeout = {SPEND
 _SPEND_LOG_TRANSACTION_TIMEOUT: Final = timedelta(milliseconds=2 * SPEND_LOG_KEY_METADATA_QUERY_TIMEOUT_MS)
 
 _HASHED_JWT_PREFIX: Final = "hashed-jwt-"
+_CLI_SESSION_KEY_PREFIX: Final = f"{CLI_SESSION_KEY_PREFIX}-"
 
 
 class KeyMetadataDict(TypedDict, total=False):
@@ -196,6 +198,16 @@ async def attach_user_emails(
     if not emails:
         return recovered
     return MappingProxyType({api_key: _meta_with_email(meta, emails) for api_key, meta in recovered.items()})
+
+
+def recover_cli_session_key_metadata(missing_keys: AbstractSet[str]) -> Mapping[str, KeyMetadataDict]:
+    return MappingProxyType(
+        {
+            key: KeyMetadataDict(key_alias=key, user_id=key.removeprefix(_CLI_SESSION_KEY_PREFIX))
+            for key in missing_keys
+            if key.startswith(_CLI_SESSION_KEY_PREFIX) and len(key) > len(_CLI_SESSION_KEY_PREFIX)
+        }
+    )
 
 
 async def recover_double_hashed_key_metadata(
@@ -383,9 +395,15 @@ async def fill_missing_api_key_aliases(
     if not missing_keys:
         return tuple(rows)
 
+    from_session_keys: Final = recover_cli_session_key_metadata(missing_keys)
     recovered: Final = await attach_user_emails(
         prisma_client,
-        await recover_double_hashed_key_metadata(prisma_client, missing_keys),
+        MappingProxyType(
+            {
+                **from_session_keys,
+                **await recover_double_hashed_key_metadata(prisma_client, missing_keys - frozenset(from_session_keys)),
+            }
+        ),
     )
     if not recovered:
         return tuple(rows)

--- a/litellm/proxy/spend_tracking/spend_tracking_utils.py
+++ b/litellm/proxy/spend_tracking/spend_tracking_utils.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel
 import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.constants import (
+    CLI_SESSION_KEY_PREFIX,
     LITELLM_PROXY_MASTER_KEY_ALIAS,
     LITELLM_TRUNCATED_PAYLOAD_FIELD,
     LITELLM_TRUNCATION_DB_SAFEGUARD_NOTE,
@@ -85,19 +86,28 @@ _NON_SECRET_KEY_ALIASES: Final = frozenset(
 )
 
 
-def _is_non_secret_key_value(value: str) -> bool:
+def _is_cli_session_alias(value: str, key_alias: object) -> bool:
+    return value.startswith(f"{CLI_SESSION_KEY_PREFIX}-") and value == key_alias
+
+
+def _is_non_secret_key_value(value: str, *, key_alias: object = None) -> bool:
     return (
-        value in _NON_SECRET_KEY_ALIASES or is_valid_sha256_hash(value) or _HASHED_JWT_RE.fullmatch(value) is not None
+        value in _NON_SECRET_KEY_ALIASES
+        or is_valid_sha256_hash(value)
+        or _HASHED_JWT_RE.fullmatch(value) is not None
+        or _is_cli_session_alias(value, key_alias)
     )
 
 
-def _redact_logged_api_key(value: str | None, *, already_redacted: bool = False) -> str | None:
+def _redact_logged_api_key(
+    value: str | None, *, already_redacted: bool = False, key_alias: object = None
+) -> str | None:
     if not isinstance(value, str) or not value:
         return None
     stripped: Final = re.sub(r"(?i)^bearer ", "", value)
     if not stripped:
         return None
-    if already_redacted and _is_non_secret_key_value(stripped):
+    if already_redacted and _is_non_secret_key_value(stripped, key_alias=key_alias):
         return stripped
     return hash_token(stripped)
 
@@ -189,10 +199,15 @@ def _get_spend_logs_metadata(
     )
     _raw_key: Final = clean_metadata.get("user_api_key")
     _trusted_hash: Final = metadata.get("user_api_key_hash")
+    _key_alias: Final = metadata.get("user_api_key_alias")
     _already_redacted: Final = (
-        isinstance(_trusted_hash, str) and _is_non_secret_key_value(_trusted_hash) and _trusted_hash == _raw_key
+        isinstance(_trusted_hash, str)
+        and _is_non_secret_key_value(_trusted_hash, key_alias=_key_alias)
+        and _trusted_hash == _raw_key
     )
-    clean_metadata["user_api_key"] = _redact_logged_api_key(_raw_key, already_redacted=_already_redacted)
+    clean_metadata["user_api_key"] = _redact_logged_api_key(
+        _raw_key, already_redacted=_already_redacted, key_alias=_key_alias
+    )
     clean_metadata["applied_guardrails"] = applied_guardrails
     clean_metadata["batch_models"] = batch_models
     clean_metadata["batch_successful_requests"] = batch_successful_requests
@@ -388,10 +403,13 @@ def get_logging_payload(kwargs, response_obj, start_time, end_time) -> SpendLogs
         standard_logging_completion_tokens = standard_logging_payload.get("completion_tokens", 0)
         standard_logging_total_tokens = standard_logging_payload.get("total_tokens", 0)
     _trusted_hash = metadata.get("user_api_key_hash")
+    _key_alias = metadata.get("user_api_key_alias")
     _key_already_redacted = (
-        isinstance(_trusted_hash, str) and _is_non_secret_key_value(_trusted_hash) and _trusted_hash == api_key
+        isinstance(_trusted_hash, str)
+        and _is_non_secret_key_value(_trusted_hash, key_alias=_key_alias)
+        and _trusted_hash == api_key
     )
-    api_key = _redact_logged_api_key(api_key, already_redacted=_key_already_redacted) or ""
+    api_key = _redact_logged_api_key(api_key, already_redacted=_key_already_redacted, key_alias=_key_alias) or ""
 
     if (
         standard_logging_payload is not None
@@ -399,7 +417,9 @@ def get_logging_payload(kwargs, response_obj, start_time, end_time) -> SpendLogs
         api_key = (
             api_key
             or _redact_logged_api_key(
-                standard_logging_payload["metadata"].get("user_api_key_hash"), already_redacted=True
+                standard_logging_payload["metadata"].get("user_api_key_hash"),
+                already_redacted=True,
+                key_alias=standard_logging_payload["metadata"].get("user_api_key_alias"),
             )
             or ""
         )

--- a/tests/test_litellm/proxy/management_endpoints/test_common_daily_activity.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_common_daily_activity.py
@@ -2246,7 +2246,7 @@ async def test_get_api_key_metadata_resolves_cli_session_keys_from_the_key_itsel
     mock_prisma.db.litellm_deletedverificationtoken.find_many = AsyncMock(return_value=[])
     mock_prisma.db.query_raw = AsyncMock(side_effect=AssertionError("no reverse-hash or spend-log scan expected"))
     mock_prisma.db.litellm_usertable.find_many = AsyncMock(
-        return_value=[SimpleNamespace(user_id="alice", user_email="alice@example.com", teams=["team-a", "team-b"])]
+        return_value=[SimpleNamespace(user_id="alice", user_email="alice@example.com", teams=["team-a"])]
     )
 
     result = await get_api_key_metadata(prisma_client=mock_prisma, api_keys={"cli-session-alice"})

--- a/tests/test_litellm/proxy/management_endpoints/test_common_daily_activity.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_common_daily_activity.py
@@ -2246,10 +2246,11 @@ async def test_get_api_key_metadata_resolves_cli_session_keys_from_the_key_itsel
     mock_prisma.db.litellm_deletedverificationtoken.find_many = AsyncMock(return_value=[])
     mock_prisma.db.query_raw = AsyncMock(side_effect=AssertionError("no reverse-hash or spend-log scan expected"))
     mock_prisma.db.litellm_usertable.find_many = AsyncMock(
-        return_value=[SimpleNamespace(user_id="alice", user_email="alice@example.com")]
+        return_value=[SimpleNamespace(user_id="alice", user_email="alice@example.com", teams=["team-a", "team-b"])]
     )
 
     result = await get_api_key_metadata(prisma_client=mock_prisma, api_keys={"cli-session-alice"})
 
     assert result["cli-session-alice"]["key_alias"] == "cli-session-alice"
     assert result["cli-session-alice"]["user_email"] == "alice@example.com"
+    assert result["cli-session-alice"]["team_id"] == "team-a"

--- a/tests/test_litellm/proxy/management_endpoints/test_common_daily_activity.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_common_daily_activity.py
@@ -2237,3 +2237,19 @@ def test_spend_logs_window_is_none_when_no_date_parses():
     from litellm.proxy.management_endpoints.common_daily_activity import _spend_logs_window
 
     assert _spend_logs_window({"garbage", ""}) is None
+
+
+@pytest.mark.asyncio
+async def test_get_api_key_metadata_resolves_cli_session_keys_from_the_key_itself():
+    mock_prisma = MagicMock()
+    mock_prisma.db.litellm_verificationtoken.find_many = AsyncMock(return_value=[])
+    mock_prisma.db.litellm_deletedverificationtoken.find_many = AsyncMock(return_value=[])
+    mock_prisma.db.query_raw = AsyncMock(side_effect=AssertionError("no reverse-hash or spend-log scan expected"))
+    mock_prisma.db.litellm_usertable.find_many = AsyncMock(
+        return_value=[SimpleNamespace(user_id="alice", user_email="alice@example.com")]
+    )
+
+    result = await get_api_key_metadata(prisma_client=mock_prisma, api_keys={"cli-session-alice"})
+
+    assert result["cli-session-alice"]["key_alias"] == "cli-session-alice"
+    assert result["cli-session-alice"]["user_email"] == "alice@example.com"

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -1318,6 +1318,7 @@ async def test_pass_through_request_contains_proxy_server_request_in_kwargs():
                         mock_user_api_key_dict = MagicMock()
                         mock_user_api_key_dict.api_key = "test-api-key"
                         mock_user_api_key_dict.key_alias = "test-alias"
+                        mock_user_api_key_dict.is_session_token = False
                         mock_user_api_key_dict.user_email = "test@example.com"
                         mock_user_api_key_dict.user_id = "test-user-id"
                         mock_user_api_key_dict.team_id = "test-team-id"

--- a/tests/test_litellm/proxy/spend_tracking/test_key_metadata_recovery.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_key_metadata_recovery.py
@@ -15,6 +15,7 @@ from litellm.constants import (
     SPEND_LOG_KEY_METADATA_QUERY_TIMEOUT_MS,
 )
 from litellm.proxy.spend_tracking.key_metadata_recovery import (
+    attach_user_details,
     fill_missing_api_key_aliases,
     recover_cli_session_key_metadata,
     recover_double_hashed_key_metadata,
@@ -602,7 +603,7 @@ async def test_fill_missing_api_key_aliases_resolves_cli_session_keys_without_a_
     mock_prisma = MagicMock()
     mock_prisma.db.query_raw = AsyncMock(side_effect=AssertionError("no reverse-hash lookup expected"))
     mock_prisma.db.litellm_usertable.find_many = AsyncMock(
-        return_value=[SimpleNamespace(user_id="alice", user_email="alice@example.com")]
+        return_value=[SimpleNamespace(user_id="alice", user_email="alice@example.com", teams=["team-a", "team-b"])]
     )
     rows = ({"api_key": "cli-session-alice", "api_key_alias": None, "team_id": None, "user_email": None, "spend": 2.0},)
 
@@ -610,5 +611,28 @@ async def test_fill_missing_api_key_aliases_resolves_cli_session_keys_without_a_
 
     assert filled[0]["api_key_alias"] == "cli-session-alice"
     assert filled[0]["user_email"] == "alice@example.com"
+    assert filled[0]["team_id"] == "team-a"
     assert filled[0]["spend"] == 2.0
     assert mock_prisma.db.litellm_usertable.find_many.call_args.kwargs["where"] == {"user_id": {"in": ["alice"]}}
+
+
+@pytest.mark.asyncio
+async def test_attach_user_details_gives_the_login_team_only_to_cli_session_keys():
+    mock_prisma = MagicMock()
+    mock_prisma.db.litellm_usertable.find_many = AsyncMock(
+        return_value=[SimpleNamespace(user_id="alice", user_email="alice@example.com", teams=["team-a"])]
+    )
+    personal_key = hash_token("sk-personal")
+
+    attached = await attach_user_details(
+        mock_prisma,
+        {
+            "cli-session-alice": {"key_alias": "cli-session-alice", "user_id": "alice"},
+            personal_key: {"key_alias": "personal", "user_id": "alice"},
+        },
+    )
+
+    assert attached["cli-session-alice"]["team_id"] == "team-a"
+    assert attached["cli-session-alice"]["user_email"] == "alice@example.com"
+    assert "team_id" not in attached[personal_key]
+    assert attached[personal_key]["user_email"] == "alice@example.com"

--- a/tests/test_litellm/proxy/spend_tracking/test_key_metadata_recovery.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_key_metadata_recovery.py
@@ -603,7 +603,7 @@ async def test_fill_missing_api_key_aliases_resolves_cli_session_keys_without_a_
     mock_prisma = MagicMock()
     mock_prisma.db.query_raw = AsyncMock(side_effect=AssertionError("no reverse-hash lookup expected"))
     mock_prisma.db.litellm_usertable.find_many = AsyncMock(
-        return_value=[SimpleNamespace(user_id="alice", user_email="alice@example.com", teams=["team-a", "team-b"])]
+        return_value=[SimpleNamespace(user_id="alice", user_email="alice@example.com", teams=["team-a"])]
     )
     rows = ({"api_key": "cli-session-alice", "api_key_alias": None, "team_id": None, "user_email": None, "spend": 2.0},)
 
@@ -636,3 +636,18 @@ async def test_attach_user_details_gives_the_login_team_only_to_cli_session_keys
     assert attached["cli-session-alice"]["user_email"] == "alice@example.com"
     assert "team_id" not in attached[personal_key]
     assert attached[personal_key]["user_email"] == "alice@example.com"
+
+
+@pytest.mark.asyncio
+async def test_attach_user_details_claims_no_team_for_a_multi_team_user_session_key():
+    mock_prisma = MagicMock()
+    mock_prisma.db.litellm_usertable.find_many = AsyncMock(
+        return_value=[SimpleNamespace(user_id="bob", user_email="bob@example.com", teams=["team-a", "team-b"])]
+    )
+
+    attached = await attach_user_details(
+        mock_prisma, {"cli-session-bob": {"key_alias": "cli-session-bob", "user_id": "bob"}}
+    )
+
+    assert "team_id" not in attached["cli-session-bob"]
+    assert attached["cli-session-bob"]["user_email"] == "bob@example.com"

--- a/tests/test_litellm/proxy/spend_tracking/test_key_metadata_recovery.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_key_metadata_recovery.py
@@ -16,6 +16,7 @@ from litellm.constants import (
 )
 from litellm.proxy.spend_tracking.key_metadata_recovery import (
     fill_missing_api_key_aliases,
+    recover_cli_session_key_metadata,
     recover_double_hashed_key_metadata,
     recover_key_metadata_from_spend_logs,
 )
@@ -588,3 +589,26 @@ async def test_recover_key_metadata_from_spend_logs_bounds_the_scan_with_a_state
     assert mock_prisma.db.tx.call_args.kwargs["timeout"] == timedelta(
         milliseconds=2 * SPEND_LOG_KEY_METADATA_QUERY_TIMEOUT_MS
     )
+
+
+def test_recover_cli_session_key_metadata_names_the_alias_and_owner_from_the_key():
+    result = recover_cli_session_key_metadata({"cli-session-alice", hash_token("sk-other"), "cli-session-", "sk-raw"})
+
+    assert dict(result) == {"cli-session-alice": {"key_alias": "cli-session-alice", "user_id": "alice"}}
+
+
+@pytest.mark.asyncio
+async def test_fill_missing_api_key_aliases_resolves_cli_session_keys_without_a_digest_lookup():
+    mock_prisma = MagicMock()
+    mock_prisma.db.query_raw = AsyncMock(side_effect=AssertionError("no reverse-hash lookup expected"))
+    mock_prisma.db.litellm_usertable.find_many = AsyncMock(
+        return_value=[SimpleNamespace(user_id="alice", user_email="alice@example.com")]
+    )
+    rows = ({"api_key": "cli-session-alice", "api_key_alias": None, "team_id": None, "user_email": None, "spend": 2.0},)
+
+    filled = await fill_missing_api_key_aliases(mock_prisma, rows)
+
+    assert filled[0]["api_key_alias"] == "cli-session-alice"
+    assert filled[0]["user_email"] == "alice@example.com"
+    assert filled[0]["spend"] == 2.0
+    assert mock_prisma.db.litellm_usertable.find_many.call_args.kwargs["where"] == {"user_id": {"in": ["alice"]}}

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
@@ -4432,3 +4432,61 @@ def test_spend_log_request_id_is_the_response_id_a_bridged_messages_caller_recei
         )
         == "resp_01Lit6806Bridged"
     )
+
+
+_CLI_SESSION_ALIAS: Final = "cli-session-alice"
+_CLI_SESSION_TOKEN: Final = "cli-session-Qm7xJ2kP9sLw4vT1nR8yAa"
+
+
+def _cli_session_request_metadata(logged_key: str) -> dict[str, str]:
+    return {
+        "user_api_key": logged_key,
+        "user_api_key_hash": logged_key,
+        "user_api_key_alias": _CLI_SESSION_ALIAS,
+        "user_api_key_user_id": "alice",
+    }
+
+
+@pytest.mark.parametrize("call_type", ["acompletion", "anthropic_messages", "aresponses"])
+def test_get_logging_payload_attributes_a_cli_session_to_its_alias(call_type: str):
+    payload = get_logging_payload(
+        kwargs={
+            "call_type": call_type,
+            "model": "gpt-5.4-nano",
+            "response_cost": 0.00001,
+            "litellm_params": {"metadata": _cli_session_request_metadata(_CLI_SESSION_ALIAS)},
+        },
+        response_obj=litellm.ModelResponse(id=f"{call_type}-1", choices=[], usage=litellm.Usage()),
+        start_time=datetime.datetime.now(timezone.utc),
+        end_time=datetime.datetime.now(timezone.utc),
+    )
+
+    assert payload["api_key"] == _CLI_SESSION_ALIAS
+    assert json.loads(payload["metadata"])["user_api_key"] == _CLI_SESSION_ALIAS
+    assert json.loads(payload["metadata"])["user_api_key_alias"] == _CLI_SESSION_ALIAS
+
+
+@pytest.mark.parametrize("call_type", ["acompletion", "anthropic_messages", "aresponses"])
+def test_get_logging_payload_never_lands_a_raw_cli_session_token(call_type: str):
+    payload = get_logging_payload(
+        kwargs={
+            "call_type": call_type,
+            "model": "gpt-5.4-nano",
+            "litellm_params": {"metadata": _cli_session_request_metadata(_CLI_SESSION_TOKEN)},
+        },
+        response_obj=litellm.ModelResponse(id=f"{call_type}-2", choices=[], usage=litellm.Usage()),
+        start_time=datetime.datetime.now(timezone.utc),
+        end_time=datetime.datetime.now(timezone.utc),
+    )
+
+    assert payload["api_key"] == hash_token(_CLI_SESSION_TOKEN)
+    assert json.loads(payload["metadata"])["user_api_key"] == hash_token(_CLI_SESSION_TOKEN)
+
+
+def test_redact_logged_api_key_cli_session_alias_needs_alias_provenance():
+    assert _redact_logged_api_key(_CLI_SESSION_ALIAS, already_redacted=True, key_alias=_CLI_SESSION_ALIAS) == (
+        _CLI_SESSION_ALIAS
+    )
+    assert _redact_logged_api_key(_CLI_SESSION_ALIAS, already_redacted=True) == hash_token(_CLI_SESSION_ALIAS)
+    assert _redact_logged_api_key(_CLI_SESSION_ALIAS, key_alias=_CLI_SESSION_ALIAS) == hash_token(_CLI_SESSION_ALIAS)
+    assert _redact_logged_api_key("alice", already_redacted=True, key_alias="alice") == hash_token("alice")

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -7943,3 +7943,37 @@ def test_default_team_settings_bool_turn_off_message_logging_redacts():
         )
         is True
     )
+
+
+def test_add_user_api_key_auth_to_request_metadata_attributes_a_cli_session_to_its_alias():
+    data = {"model": "gpt-5.4-nano", "messages": [{"role": "user", "content": "hi"}], "litellm_metadata": {}}
+    session = UserAPIKeyAuth(
+        api_key="cli-session-Qm7xJ2kP9sLw4vT1nR8yAa",
+        key_alias="cli-session-alice",
+        user_id="alice",
+        is_session_token=True,
+    )
+
+    metadata = LiteLLMProxyRequestSetup.add_user_api_key_auth_to_request_metadata(
+        data=data, user_api_key_dict=session, _metadata_variable_name="litellm_metadata"
+    )["litellm_metadata"]
+
+    assert metadata["user_api_key"] == "cli-session-alice"
+    assert metadata["user_api_key_hash"] == "cli-session-alice"
+    assert metadata["user_api_key_alias"] == "cli-session-alice"
+    assert "Qm7xJ2kP9sLw4vT1nR8yAa" not in (metadata["user_api_key"], metadata["user_api_key_hash"])
+
+
+def test_add_user_api_key_auth_to_request_metadata_keeps_the_hashed_token_for_virtual_keys():
+    from litellm.proxy._types import hash_token
+
+    data = {"model": "gpt-5.4-nano", "messages": [], "litellm_metadata": {}}
+    hashed = hash_token("sk-virtual-key")
+    virtual_key = UserAPIKeyAuth(api_key=hashed, key_alias="cli-session-alice", user_id="alice")
+
+    metadata = LiteLLMProxyRequestSetup.add_user_api_key_auth_to_request_metadata(
+        data=data, user_api_key_dict=virtual_key, _metadata_variable_name="litellm_metadata"
+    )["litellm_metadata"]
+
+    assert metadata["user_api_key"] == hashed
+    assert metadata["user_api_key_hash"] == hashed


### PR DESCRIPTION
## TLDR

Problem this solves:

- Since v1.99 every `litellm-proxy login` spends under a fresh sha256 hash
- Usage APIs and the Usage page show one key per login, no alias or email
- The customer's BI joins on `api_key` lost the user behind each CLI session

How it solves it:

- Session spend now logs under the stable per-user alias `cli-session-<user_id>`
- Every unified endpoint (chat completions, messages, responses) writes that same identity
- Usage metadata resolves alias, email, and team straight from the key
- Customer-run SQL backfill folds the old per-login rows into the alias

## User Flow

Before: a developer who signs in with `litellm-proxy login` shows up in usage as a new 64-hex key every time they log in, with no alias or email next to it

1. They run `litellm-proxy login`, finish the Google sign-in in the browser, and the CLI stores a session token in `$HOME/.litellm/token.json`
2. They send POST https://litellm-domain/v1/chat/completions, POST https://litellm-domain/v1/messages, and POST https://litellm-domain/v1/responses with that token and get normal 200s back
3. They log in again the next day (new token) and send the same three requests
4. The admin opens GET https://litellm-domain/user/daily/activity?start_date=...&end_date=... and sees two keys for that one person, `7cc85d06...` and `7b782cfc...`, three requests each; on the customer's version those rows carry no `key_alias`, `user_email`, or `team_id`
5. GET https://litellm-domain/spend/logs?start_date=...&end_date=... lists spend under the two hashes, and the BI export that joins `api_key` to a user finds nothing for either

After: the same developer's spend rolls up under one stable key named after them, with alias, email, and team filled in

1. They run `litellm-proxy login`, finish the Google sign-in in the browser, and the CLI stores a session token in `$HOME/.litellm/token.json`
2. They send POST https://litellm-domain/v1/chat/completions, POST https://litellm-domain/v1/messages, and POST https://litellm-domain/v1/responses with that token and get normal 200s back
3. They log in again the next day (new token) and send the same three requests
4. The admin opens GET https://litellm-domain/user/daily/activity?start_date=...&end_date=... and sees one key for that person, `cli-session-<user_id>`, six requests, with `key_alias`, `user_email`, and `team_id` filled in
5. GET https://litellm-domain/spend/logs?start_date=...&end_date=... lists the spend under `cli-session-<user_id>`, and the BI export joins it to the user by name
6. For the rows written before the upgrade, the admin runs the backfill SQL below once (dry run first), and the older per-login hashes fold into the same `cli-session-<user_id>` row

## What `api_key` means for a CLI session row

`LiteLLM_SpendLogs.api_key` is the identity spend is attributed to and grouped by, and for a virtual key that is the sha256 of the secret because the secret is the only stable handle a key has. A CLI session has a different stable handle: the session key is minted fresh per login, but the alias `cli-session-<user_id>` is the same for every login of that user, so that alias is what a session row should carry. Everything that is not a session key keeps the sha256 gate exactly as before, and `UserAPIKeyAuth.api_key` still holds the session token, so per-session rate limits, caching, and budget checks do not change

Alternatives I rejected:

- sha256 of the session token (what v1.99+ does today): one key per login, opaque, and on the customer's version nothing can map it back to a user because there is no virtual-key row to reverse it against
- the raw session token (what v1.98 did): also one key per login, and it puts a live bearer credential in a spend row
- sha256 of the alias: stable per user, but opaque again, it breaks the customer's `NOT LIKE 'litellm-%'` style prefix filters, and it hashes a value that was never a secret

Consumers of `api_key` on this path and what changed for each:

- `LiteLLM_Daily{User,Team,Tag}Spend` aggregation: keyed by the alias now, so a user gets one row per day, model, and endpoint instead of one per login
- `/user/daily/activity` `api_keys` metadata (Usage page): a `cli-session-` key resolves `key_alias` and `user_id` from the key itself, `user_email` from the user row, and `team_id` from the user's only team; this no longer depends on a spend-log row being inside the read window
  - Only team, not first team: the CLI login asks a user in several teams to pick one per login, so the first team in the user row can be wrong for them and the alias claims no team instead; spend rows and team views keep the team each login attached
- CloudZero and Focus exports (`fill_missing_api_key_aliases`): session keys resolve from the key before the reverse-hash lookup runs
- #40275's sha256-gated recovery: untouched, it still runs for hashed keys and skips the alias since it is not a digest
- Prometheus and logging callbacks that read `user_api_key_hash`: carry the alias for session requests, the hash for everything else
- key spend updates: still a no-op for session keys (there is no `LiteLLM_VerificationToken` row), same as today
- the customer's BI `NOT LIKE 'litellm-%'` filters: unaffected, the alias starts with `cli-session-`

The redaction gate accepts a `cli-session-` value only when it equals the trusted alias from auth, so a client cannot smuggle an arbitrary `cli-session-` string into a spend row

## Backfill (customer-run SQL, not a migration)

This is deliberately not a Prisma migration: migrations run at boot before the proxy serves traffic, and rewriting `LiteLLM_SpendLogs` there is downtime. Run it by hand with `psql`, off-peak, with `:since` set to a date before the first CLI login you care about. PART 1 is read only and prints what would move. PART 2 is one transaction that rewrites `LiteLLM_SpendLogs.api_key` in place and folds the per-login rows of the three daily tables into the alias row for the same day, model, provider, endpoint, and owner, then prints per-key totals before and after so you can compare them before typing `COMMIT`. Rows written on v1.98 (raw `cli-session-<random>` token as the key) are mapped too, through the alias stored in the row's metadata. Session keys whose spend logs are already past retention cannot be mapped and stay as they are

```
psql "$DATABASE_URL" -v since=2026-01-01 -f cli_session_backfill.sql
```

<details>
<summary>cli_session_backfill.sql</summary>

```sql
-- CLI session spend backfill (run by hand with psql, never as a proxy boot migration)
-- What it does: rows written by `litellm-proxy login` sessions carry a per-login api_key
-- (a 64-hex sha256 since v1.99, a raw cli-session-<random> token on v1.98). This rewrites
-- them to the per-user alias cli-session-<user_id> that fixed proxies write, so one user
-- rolls up to one key: LiteLLM_SpendLogs.api_key is rewritten in place, and the per-session
-- rows of LiteLLM_DailyUserSpend, LiteLLM_DailyTeamSpend, and LiteLLM_DailyTagSpend are
-- summed into the alias row for the same day, model, provider, endpoint, and owner.
-- How to run: set :since to a date before the first CLI login you care about, run PART 1
-- (read only) and read the counts, then run PART 2. PART 2 is one transaction; it prints
-- the same totals before and after so you can compare them before typing COMMIT.
-- Session keys whose SpendLogs rows are already past your retention cannot be mapped to a
-- user and are left as they are.

\set since '2026-01-01'

-- PART 1: dry run (read only) -------------------------------------------------------------
BEGIN;
CREATE TEMP TABLE cli_session_key_map AS
SELECT DISTINCT api_key AS session_key, metadata->>'user_api_key_alias' AS alias
FROM "LiteLLM_SpendLogs"
WHERE "startTime" >= :'since'::timestamp
  AND metadata->>'user_api_key_alias' LIKE 'cli-session-%'
  AND api_key <> metadata->>'user_api_key_alias'
  AND (api_key ~ '^[0-9a-f]{64}$' OR api_key LIKE 'cli-session-%')
UNION
SELECT DISTINCT api_key, 'cli-session-' || user_id
FROM "LiteLLM_DailyUserSpend"
WHERE api_key LIKE 'cli-session-%' AND user_id <> '' AND api_key <> 'cli-session-' || user_id;

SELECT alias, count(*) AS session_keys FROM cli_session_key_map GROUP BY alias ORDER BY alias;
SELECT count(*) AS spend_logs_to_rewrite FROM "LiteLLM_SpendLogs" s JOIN cli_session_key_map m ON s.api_key = m.session_key;
SELECT 'LiteLLM_DailyUserSpend' AS tbl, count(*) AS rows_to_fold, sum(spend) AS spend FROM "LiteLLM_DailyUserSpend" t JOIN cli_session_key_map m ON t.api_key = m.session_key
UNION ALL SELECT 'LiteLLM_DailyTeamSpend', count(*), sum(spend) FROM "LiteLLM_DailyTeamSpend" t JOIN cli_session_key_map m ON t.api_key = m.session_key
UNION ALL SELECT 'LiteLLM_DailyTagSpend', count(*), sum(spend) FROM "LiteLLM_DailyTagSpend" t JOIN cli_session_key_map m ON t.api_key = m.session_key;
ROLLBACK;

-- PART 2: apply ---------------------------------------------------------------------------
BEGIN;
CREATE TEMP TABLE cli_session_key_map AS
SELECT DISTINCT api_key AS session_key, metadata->>'user_api_key_alias' AS alias
FROM "LiteLLM_SpendLogs"
WHERE "startTime" >= :'since'::timestamp
  AND metadata->>'user_api_key_alias' LIKE 'cli-session-%'
  AND api_key <> metadata->>'user_api_key_alias'
  AND (api_key ~ '^[0-9a-f]{64}$' OR api_key LIKE 'cli-session-%')
UNION
SELECT DISTINCT api_key, 'cli-session-' || user_id
FROM "LiteLLM_DailyUserSpend"
WHERE api_key LIKE 'cli-session-%' AND user_id <> '' AND api_key <> 'cli-session-' || user_id;

CREATE TEMP TABLE totals_before AS
SELECT 'LiteLLM_DailyUserSpend' AS tbl, coalesce(m.alias, t.api_key) AS key, sum(t.spend) AS spend, sum(t.api_requests) AS api_requests FROM "LiteLLM_DailyUserSpend" t LEFT JOIN cli_session_key_map m ON t.api_key = m.session_key GROUP BY 1, 2
UNION ALL SELECT 'LiteLLM_DailyTeamSpend', coalesce(m.alias, t.api_key), sum(t.spend), sum(t.api_requests) FROM "LiteLLM_DailyTeamSpend" t LEFT JOIN cli_session_key_map m ON t.api_key = m.session_key GROUP BY 1, 2
UNION ALL SELECT 'LiteLLM_DailyTagSpend', coalesce(m.alias, t.api_key), sum(t.spend), sum(t.api_requests) FROM "LiteLLM_DailyTagSpend" t LEFT JOIN cli_session_key_map m ON t.api_key = m.session_key GROUP BY 1, 2;

UPDATE "LiteLLM_SpendLogs" s SET api_key = m.alias
FROM cli_session_key_map m
WHERE s."startTime" >= :'since'::timestamp AND s.api_key = m.session_key;

-- LiteLLM_DailyUserSpend: fold each per-session row into the row of the same day, model, and owner under the alias
WITH folded AS (
  SELECT t.user_id, t.date, m.alias AS api_key, t.model, t.custom_llm_provider, t.mcp_namespaced_tool_name, t.endpoint, MIN(t.model_group) AS model_group, SUM(t.prompt_tokens) AS prompt_tokens, SUM(t.completion_tokens) AS completion_tokens, SUM(t.cache_read_input_tokens) AS cache_read_input_tokens, SUM(t.cache_creation_input_tokens) AS cache_creation_input_tokens, SUM(t.compression_saved_tokens) AS compression_saved_tokens, SUM(t.compression_savings_spend) AS compression_savings_spend, SUM(t.prompt_caching_savings_spend) AS prompt_caching_savings_spend, SUM(t.gateway_injected_caching_savings_spend) AS gateway_injected_caching_savings_spend, SUM(t.autorouter_savings_spend) AS autorouter_savings_spend, SUM(t.spend) AS spend, SUM(t.api_requests) AS api_requests, SUM(t.successful_requests) AS successful_requests, SUM(t.failed_requests) AS failed_requests
  FROM "LiteLLM_DailyUserSpend" t JOIN cli_session_key_map m ON t.api_key = m.session_key
  GROUP BY t.user_id, t.date, t.model, t.custom_llm_provider, t.mcp_namespaced_tool_name, t.endpoint, m.alias
), updated AS (
  UPDATE "LiteLLM_DailyUserSpend" t SET prompt_tokens = t.prompt_tokens + f.prompt_tokens, completion_tokens = t.completion_tokens + f.completion_tokens, cache_read_input_tokens = t.cache_read_input_tokens + f.cache_read_input_tokens, cache_creation_input_tokens = t.cache_creation_input_tokens + f.cache_creation_input_tokens, compression_saved_tokens = t.compression_saved_tokens + f.compression_saved_tokens, compression_savings_spend = t.compression_savings_spend + f.compression_savings_spend, prompt_caching_savings_spend = t.prompt_caching_savings_spend + f.prompt_caching_savings_spend, gateway_injected_caching_savings_spend = t.gateway_injected_caching_savings_spend + f.gateway_injected_caching_savings_spend, autorouter_savings_spend = t.autorouter_savings_spend + f.autorouter_savings_spend, spend = t.spend + f.spend, api_requests = t.api_requests + f.api_requests, successful_requests = t.successful_requests + f.successful_requests, failed_requests = t.failed_requests + f.failed_requests, updated_at = now()
  FROM folded f
  WHERE t.user_id IS NOT DISTINCT FROM f.user_id AND t.date IS NOT DISTINCT FROM f.date AND t.api_key IS NOT DISTINCT FROM f.api_key AND t.model IS NOT DISTINCT FROM f.model AND t.custom_llm_provider IS NOT DISTINCT FROM f.custom_llm_provider AND t.mcp_namespaced_tool_name IS NOT DISTINCT FROM f.mcp_namespaced_tool_name AND t.endpoint IS NOT DISTINCT FROM f.endpoint
  RETURNING f.user_id, f.date, f.api_key, f.model, f.custom_llm_provider, f.mcp_namespaced_tool_name, f.endpoint
)
INSERT INTO "LiteLLM_DailyUserSpend" (id, user_id, date, api_key, model, custom_llm_provider, mcp_namespaced_tool_name, endpoint, model_group, prompt_tokens, completion_tokens, cache_read_input_tokens, cache_creation_input_tokens, compression_saved_tokens, compression_savings_spend, prompt_caching_savings_spend, gateway_injected_caching_savings_spend, autorouter_savings_spend, spend, api_requests, successful_requests, failed_requests, created_at, updated_at)
SELECT gen_random_uuid()::text, f.user_id, f.date, f.api_key, f.model, f.custom_llm_provider, f.mcp_namespaced_tool_name, f.endpoint, f.model_group, f.prompt_tokens, f.completion_tokens, f.cache_read_input_tokens, f.cache_creation_input_tokens, f.compression_saved_tokens, f.compression_savings_spend, f.prompt_caching_savings_spend, f.gateway_injected_caching_savings_spend, f.autorouter_savings_spend, f.spend, f.api_requests, f.successful_requests, f.failed_requests, now(), now()
FROM folded f
WHERE NOT EXISTS (SELECT 1 FROM updated u WHERE u.user_id IS NOT DISTINCT FROM f.user_id AND u.date IS NOT DISTINCT FROM f.date AND u.api_key IS NOT DISTINCT FROM f.api_key AND u.model IS NOT DISTINCT FROM f.model AND u.custom_llm_provider IS NOT DISTINCT FROM f.custom_llm_provider AND u.mcp_namespaced_tool_name IS NOT DISTINCT FROM f.mcp_namespaced_tool_name AND u.endpoint IS NOT DISTINCT FROM f.endpoint);

DELETE FROM "LiteLLM_DailyUserSpend" t USING cli_session_key_map m WHERE t.api_key = m.session_key;

-- LiteLLM_DailyTeamSpend: fold each per-session row into the row of the same day, model, and owner under the alias
WITH folded AS (
  SELECT t.team_id, t.date, m.alias AS api_key, t.model, t.custom_llm_provider, t.mcp_namespaced_tool_name, t.endpoint, MIN(t.model_group) AS model_group, SUM(t.prompt_tokens) AS prompt_tokens, SUM(t.completion_tokens) AS completion_tokens, SUM(t.cache_read_input_tokens) AS cache_read_input_tokens, SUM(t.cache_creation_input_tokens) AS cache_creation_input_tokens, SUM(t.compression_saved_tokens) AS compression_saved_tokens, SUM(t.compression_savings_spend) AS compression_savings_spend, SUM(t.prompt_caching_savings_spend) AS prompt_caching_savings_spend, SUM(t.gateway_injected_caching_savings_spend) AS gateway_injected_caching_savings_spend, SUM(t.autorouter_savings_spend) AS autorouter_savings_spend, SUM(t.spend) AS spend, SUM(t.api_requests) AS api_requests, SUM(t.successful_requests) AS successful_requests, SUM(t.failed_requests) AS failed_requests, SUM(t.ptu_flat_cost) AS ptu_flat_cost
  FROM "LiteLLM_DailyTeamSpend" t JOIN cli_session_key_map m ON t.api_key = m.session_key
  GROUP BY t.team_id, t.date, t.model, t.custom_llm_provider, t.mcp_namespaced_tool_name, t.endpoint, m.alias
), updated AS (
  UPDATE "LiteLLM_DailyTeamSpend" t SET prompt_tokens = t.prompt_tokens + f.prompt_tokens, completion_tokens = t.completion_tokens + f.completion_tokens, cache_read_input_tokens = t.cache_read_input_tokens + f.cache_read_input_tokens, cache_creation_input_tokens = t.cache_creation_input_tokens + f.cache_creation_input_tokens, compression_saved_tokens = t.compression_saved_tokens + f.compression_saved_tokens, compression_savings_spend = t.compression_savings_spend + f.compression_savings_spend, prompt_caching_savings_spend = t.prompt_caching_savings_spend + f.prompt_caching_savings_spend, gateway_injected_caching_savings_spend = t.gateway_injected_caching_savings_spend + f.gateway_injected_caching_savings_spend, autorouter_savings_spend = t.autorouter_savings_spend + f.autorouter_savings_spend, spend = t.spend + f.spend, api_requests = t.api_requests + f.api_requests, successful_requests = t.successful_requests + f.successful_requests, failed_requests = t.failed_requests + f.failed_requests, ptu_flat_cost = t.ptu_flat_cost + f.ptu_flat_cost, updated_at = now()
  FROM folded f
  WHERE t.team_id IS NOT DISTINCT FROM f.team_id AND t.date IS NOT DISTINCT FROM f.date AND t.api_key IS NOT DISTINCT FROM f.api_key AND t.model IS NOT DISTINCT FROM f.model AND t.custom_llm_provider IS NOT DISTINCT FROM f.custom_llm_provider AND t.mcp_namespaced_tool_name IS NOT DISTINCT FROM f.mcp_namespaced_tool_name AND t.endpoint IS NOT DISTINCT FROM f.endpoint
  RETURNING f.team_id, f.date, f.api_key, f.model, f.custom_llm_provider, f.mcp_namespaced_tool_name, f.endpoint
)
INSERT INTO "LiteLLM_DailyTeamSpend" (id, team_id, date, api_key, model, custom_llm_provider, mcp_namespaced_tool_name, endpoint, model_group, prompt_tokens, completion_tokens, cache_read_input_tokens, cache_creation_input_tokens, compression_saved_tokens, compression_savings_spend, prompt_caching_savings_spend, gateway_injected_caching_savings_spend, autorouter_savings_spend, spend, api_requests, successful_requests, failed_requests, ptu_flat_cost, created_at, updated_at)
SELECT gen_random_uuid()::text, f.team_id, f.date, f.api_key, f.model, f.custom_llm_provider, f.mcp_namespaced_tool_name, f.endpoint, f.model_group, f.prompt_tokens, f.completion_tokens, f.cache_read_input_tokens, f.cache_creation_input_tokens, f.compression_saved_tokens, f.compression_savings_spend, f.prompt_caching_savings_spend, f.gateway_injected_caching_savings_spend, f.autorouter_savings_spend, f.spend, f.api_requests, f.successful_requests, f.failed_requests, f.ptu_flat_cost, now(), now()
FROM folded f
WHERE NOT EXISTS (SELECT 1 FROM updated u WHERE u.team_id IS NOT DISTINCT FROM f.team_id AND u.date IS NOT DISTINCT FROM f.date AND u.api_key IS NOT DISTINCT FROM f.api_key AND u.model IS NOT DISTINCT FROM f.model AND u.custom_llm_provider IS NOT DISTINCT FROM f.custom_llm_provider AND u.mcp_namespaced_tool_name IS NOT DISTINCT FROM f.mcp_namespaced_tool_name AND u.endpoint IS NOT DISTINCT FROM f.endpoint);

DELETE FROM "LiteLLM_DailyTeamSpend" t USING cli_session_key_map m WHERE t.api_key = m.session_key;

-- LiteLLM_DailyTagSpend: fold each per-session row into the row of the same day, model, and owner under the alias
WITH folded AS (
  SELECT t.tag, t.date, m.alias AS api_key, t.model, t.custom_llm_provider, t.mcp_namespaced_tool_name, t.endpoint, MIN(t.model_group) AS model_group, MIN(t.request_id) AS request_id, SUM(t.prompt_tokens) AS prompt_tokens, SUM(t.completion_tokens) AS completion_tokens, SUM(t.cache_read_input_tokens) AS cache_read_input_tokens, SUM(t.cache_creation_input_tokens) AS cache_creation_input_tokens, SUM(t.compression_saved_tokens) AS compression_saved_tokens, SUM(t.compression_savings_spend) AS compression_savings_spend, SUM(t.prompt_caching_savings_spend) AS prompt_caching_savings_spend, SUM(t.gateway_injected_caching_savings_spend) AS gateway_injected_caching_savings_spend, SUM(t.autorouter_savings_spend) AS autorouter_savings_spend, SUM(t.spend) AS spend, SUM(t.api_requests) AS api_requests, SUM(t.successful_requests) AS successful_requests, SUM(t.failed_requests) AS failed_requests
  FROM "LiteLLM_DailyTagSpend" t JOIN cli_session_key_map m ON t.api_key = m.session_key
  GROUP BY t.tag, t.date, t.model, t.custom_llm_provider, t.mcp_namespaced_tool_name, t.endpoint, m.alias
), updated AS (
  UPDATE "LiteLLM_DailyTagSpend" t SET prompt_tokens = t.prompt_tokens + f.prompt_tokens, completion_tokens = t.completion_tokens + f.completion_tokens, cache_read_input_tokens = t.cache_read_input_tokens + f.cache_read_input_tokens, cache_creation_input_tokens = t.cache_creation_input_tokens + f.cache_creation_input_tokens, compression_saved_tokens = t.compression_saved_tokens + f.compression_saved_tokens, compression_savings_spend = t.compression_savings_spend + f.compression_savings_spend, prompt_caching_savings_spend = t.prompt_caching_savings_spend + f.prompt_caching_savings_spend, gateway_injected_caching_savings_spend = t.gateway_injected_caching_savings_spend + f.gateway_injected_caching_savings_spend, autorouter_savings_spend = t.autorouter_savings_spend + f.autorouter_savings_spend, spend = t.spend + f.spend, api_requests = t.api_requests + f.api_requests, successful_requests = t.successful_requests + f.successful_requests, failed_requests = t.failed_requests + f.failed_requests, updated_at = now()
  FROM folded f
  WHERE t.tag IS NOT DISTINCT FROM f.tag AND t.date IS NOT DISTINCT FROM f.date AND t.api_key IS NOT DISTINCT FROM f.api_key AND t.model IS NOT DISTINCT FROM f.model AND t.custom_llm_provider IS NOT DISTINCT FROM f.custom_llm_provider AND t.mcp_namespaced_tool_name IS NOT DISTINCT FROM f.mcp_namespaced_tool_name AND t.endpoint IS NOT DISTINCT FROM f.endpoint
  RETURNING f.tag, f.date, f.api_key, f.model, f.custom_llm_provider, f.mcp_namespaced_tool_name, f.endpoint
)
INSERT INTO "LiteLLM_DailyTagSpend" (id, tag, date, api_key, model, custom_llm_provider, mcp_namespaced_tool_name, endpoint, model_group, request_id, prompt_tokens, completion_tokens, cache_read_input_tokens, cache_creation_input_tokens, compression_saved_tokens, compression_savings_spend, prompt_caching_savings_spend, gateway_injected_caching_savings_spend, autorouter_savings_spend, spend, api_requests, successful_requests, failed_requests, created_at, updated_at)
SELECT gen_random_uuid()::text, f.tag, f.date, f.api_key, f.model, f.custom_llm_provider, f.mcp_namespaced_tool_name, f.endpoint, f.model_group, f.request_id, f.prompt_tokens, f.completion_tokens, f.cache_read_input_tokens, f.cache_creation_input_tokens, f.compression_saved_tokens, f.compression_savings_spend, f.prompt_caching_savings_spend, f.gateway_injected_caching_savings_spend, f.autorouter_savings_spend, f.spend, f.api_requests, f.successful_requests, f.failed_requests, now(), now()
FROM folded f
WHERE NOT EXISTS (SELECT 1 FROM updated u WHERE u.tag IS NOT DISTINCT FROM f.tag AND u.date IS NOT DISTINCT FROM f.date AND u.api_key IS NOT DISTINCT FROM f.api_key AND u.model IS NOT DISTINCT FROM f.model AND u.custom_llm_provider IS NOT DISTINCT FROM f.custom_llm_provider AND u.mcp_namespaced_tool_name IS NOT DISTINCT FROM f.mcp_namespaced_tool_name AND u.endpoint IS NOT DISTINCT FROM f.endpoint);

DELETE FROM "LiteLLM_DailyTagSpend" t USING cli_session_key_map m WHERE t.api_key = m.session_key;

-- Verification: every row should read the same before and after (spend and request totals per key)
SELECT b.tbl, b.key, b.spend AS spend_before, a.spend AS spend_after, b.api_requests AS requests_before, a.api_requests AS requests_after
FROM totals_before b
LEFT JOIN (
  SELECT 'LiteLLM_DailyUserSpend' AS tbl, api_key AS key, sum(spend) AS spend, sum(api_requests) AS api_requests FROM "LiteLLM_DailyUserSpend" GROUP BY 1, 2
  UNION ALL SELECT 'LiteLLM_DailyTeamSpend', api_key, sum(spend), sum(api_requests) FROM "LiteLLM_DailyTeamSpend" GROUP BY 1, 2
  UNION ALL SELECT 'LiteLLM_DailyTagSpend', api_key, sum(spend), sum(api_requests) FROM "LiteLLM_DailyTagSpend" GROUP BY 1, 2
) a ON a.tbl = b.tbl AND a.key = b.key
WHERE b.key LIKE 'cli-session-%'
ORDER BY 1, 2;
SELECT count(*) AS spend_logs_still_on_a_session_key FROM "LiteLLM_SpendLogs" s JOIN cli_session_key_map m ON s.api_key = m.session_key WHERE s."startTime" >= :'since'::timestamp;

-- Type COMMIT; when the totals match, ROLLBACK; otherwise
```

</details>

## Relevant issues

None on GitHub; this came in through a customer support thread

## Linear ticket

Resolves LIT-6852

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup for both legs. One proxy instance with two workers on a fresh Postgres database, Google SSO wired up for the CLI, and the config below. Two real `litellm-proxy login` sessions for the same SSO user (user `mateo-cli-qa`, single team `cli-qa-team`), so login 1 and login 2 hold two different session tokens. Nothing on this path is per-process (the logged key is computed per request from the auth result and the usage routes read the database), so both workers behave the same; the before leg ran at the merge base with the four spend tables empty, and the after leg ran at the tip on top of the before leg's rows

```
python litellm/proxy/proxy_cli.py --config config.yaml --port 45780 --host 127.0.0.1 --detailed_debug --use_v2_migration_resolver --num_workers 2
```

```yaml
model_list:
  - model_name: gpt-5.4-nano
    litellm_params:
      model: openai/gpt-5.4-nano
      api_key: os.environ/OPENAI_API_KEY
  - model_name: claude-haiku-4-5
    litellm_params:
      model: anthropic/claude-haiku-4-5
      api_key: os.environ/ANTHROPIC_API_KEY
general_settings:
  master_key: os.environ/LITELLM_MASTER_KEY
  store_model_in_db: false

litellm_settings:
  drop_params: true
  telemetry: false
```

`DATABASE_URL`, `LITELLM_MASTER_KEY`, and the Google SSO client come from the environment

### Before (db7ca65b69)

#### POST /chat/completions

1. With `KEY` set to the login 1 token and then the login 2 token (the `key` field of `$HOME/.litellm/token.json` after `litellm-proxy login`):

```
curl -s http://127.0.0.1:45780/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -d '{"model":"gpt-5.4-nano","messages":[{"role":"user","content":"Say BEFORE in one word"}],"max_tokens":16}'
```

2. Output (trimmed to id, model, content, usage):

```
login 1: {"id": "chatcmpl-EMQPObJzafhSYHxNHwD3PWgYid1Tq", "model": "gpt-5.4-nano", "content": "PREVIOUSLY", "usage": {"prompt_tokens": 11, "completion_tokens": 6}}
login 2: {"id": "chatcmpl-EMQPQm292OrGVGk8W5vekt6od9B4P", "model": "gpt-5.4-nano", "content": "**Before**", "usage": {"prompt_tokens": 11, "completion_tokens": 6}}
```

#### POST /v1/messages

1. With `KEY` set to the login 1 token and then the login 2 token (the `key` field of `$HOME/.litellm/token.json` after `litellm-proxy login`):

```
curl -s http://127.0.0.1:45780/v1/messages -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -H 'anthropic-version: 2023-06-01' -d '{"model":"claude-haiku-4-5","max_tokens":16,"messages":[{"role":"user","content":"Say BEFORE in one word"}]}'
```

2. Output (trimmed to id, model, content, usage):

```
login 1: {"id": "msg_011Ceu71Vgi6ie3HsGKEnGHJ", "model": "claude-haiku-4-5", "content": "Before.", "usage": {"input_tokens": 13, "output_tokens": 5}}
login 2: {"id": "msg_011Ceu71fWoPVDMPHoJ1MPg4", "model": "claude-haiku-4-5", "content": "Before.", "usage": {"input_tokens": 13, "output_tokens": 5}}
```

#### POST /v1/responses

1. With `KEY` set to the login 1 token and then the login 2 token (the `key` field of `$HOME/.litellm/token.json` after `litellm-proxy login`):

```
curl -s http://127.0.0.1:45780/v1/responses -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -d '{"model":"gpt-5.4-nano","input":"Say BEFORE in one word","max_output_tokens":32}'
```

2. Output (trimmed to id, model, content, usage):

```
login 1: {"id": "resp_5VtCoY_V7HcV_5J\u2026", "model": "gpt-5.4-nano", "output_text": ["\u201cBefore\u201d"], "usage": {"input_tokens": 11, "output_tokens": 7}}
login 2: {"id": "resp_hkzTULLnbtsrHQz\u2026", "model": "gpt-5.4-nano", "output_text": ["\u201cPrior\u201d"], "usage": {"input_tokens": 11, "output_tokens": 7}}
```

#### Usage routes

1. Waited for the daily aggregates to flush, then read the three usage routes with the admin key and once more with the login 1 token `(daily spend flushed after 3x3s)`:

```
curl -s "http://127.0.0.1:45780/spend/logs?start_date=2026-09-10&end_date=2026-09-11" -H "Authorization: Bearer $ADMIN"
curl -s "http://127.0.0.1:45780/spend/logs/ui?start_date=2026-09-10%2000:00:00&end_date=2026-09-11%2000:00:00&page_size=50" -H "Authorization: Bearer $ADMIN"
curl -s "http://127.0.0.1:45780/user/daily/activity?start_date=2026-09-10&end_date=2026-09-10" -H "Authorization: Bearer $ADMIN"
curl -s "http://127.0.0.1:45780/user/daily/activity?start_date=2026-09-10&end_date=2026-09-10" -H "Authorization: Bearer $KEY"
```

2. Output (rows trimmed to the columns that matter; `/user/daily/activity` printed as one line per key from `breakdown.api_keys`):

```
## GET /spend/logs?start_date=2026-09-10&end_date=2026-09-11 (spend per api_key, admin key)
{"7b782cfc52df8ee6748bd867c5abf18ba44a8b97ac0e7a90550e9dedb6017b44": 5.865e-05, "7cc85d06641a8b9d4cc93d5e43f3aa4320d01749f3bc07e91c4e15d8030885d4": 5.865e-05, "startTime": "2026-09-10", "spend": 0.0001173, "users": {"mateo-cli-qa": 0.0001173}}
{"startTime": "2026-09-11", "spend": 0, "users": {}}
## GET /spend/logs/ui (what the Logs page lists, admin key)
{"startTime": "04:10:37", "call_type": "acompletion", "model": "openai/gpt-5.4-nano", "api_key": "7cc85d06641a8b9d4cc93d5e43f3aa4320d01749f3bc07e91c4e15d8030885d4", "key_alias": "cli-session-mateo-cli-qa", "user": "mateo-cli-qa", "team_id": "cli-qa-team", "spend": 9.700000000000002e-06}
{"startTime": "04:10:38", "call_type": "anthropic_messages", "model": "anthropic/claude-haiku-4-5", "api_key": "7cc85d06641a8b9d4cc93d5e43f3aa4320d01749f3bc07e91c4e15d8030885d4", "key_alias": "cli-session-mateo-cli-qa", "user": "mateo-cli-qa", "team_id": "cli-qa-team", "spend": 3.8e-05}
{"startTime": "04:10:39", "call_type": "aresponses", "model": "openai/gpt-5.4-nano", "api_key": "7cc85d06641a8b9d4cc93d5e43f3aa4320d01749f3bc07e91c4e15d8030885d4", "key_alias": "cli-session-mateo-cli-qa", "user": "mateo-cli-qa", "team_id": "cli-qa-team", "spend": 1.095e-05}
{"startTime": "04:10:40", "call_type": "acompletion", "model": "openai/gpt-5.4-nano", "api_key": "7b782cfc52df8ee6748bd867c5abf18ba44a8b97ac0e7a90550e9dedb6017b44", "key_alias": "cli-session-mateo-cli-qa", "user": "mateo-cli-qa", "team_id": "cli-qa-team", "spend": 9.700000000000002e-06}
{"startTime": "04:10:41", "call_type": "anthropic_messages", "model": "anthropic/claude-haiku-4-5", "api_key": "7b782cfc52df8ee6748bd867c5abf18ba44a8b97ac0e7a90550e9dedb6017b44", "key_alias": "cli-session-mateo-cli-qa", "user": "mateo-cli-qa", "team_id": "cli-qa-team", "spend": 3.8e-05}
{"startTime": "04:10:41", "call_type": "aresponses", "model": "openai/gpt-5.4-nano", "api_key": "7b782cfc52df8ee6748bd867c5abf18ba44a8b97ac0e7a90550e9dedb6017b44", "key_alias": "cli-session-mateo-cli-qa", "user": "mateo-cli-qa", "team_id": "cli-qa-team", "spend": 1.095e-05}
## GET /user/daily/activity?start_date=2026-09-10&end_date=2026-09-10 (admin key)
date 2026-09-10 spend 0.0001173 requests 6
  api_key 7b782cfc52df8ee6748bd867… | key_alias cli-session-mateo-cli-qa | user_email mateo@berri.ai | team_id cli-qa-team | requests 3 | spend 5.865e-05
  api_key 7cc85d06641a8b9d4cc93d5e… | key_alias cli-session-mateo-cli-qa | user_email mateo@berri.ai | team_id cli-qa-team | requests 3 | spend 5.865000000000001e-05
## same route with login 1 token (what the CLI user sees)
date 2026-09-10 spend 0.0001173 requests 6
  api_key 7b782cfc52df8ee6748bd867… | key_alias cli-session-mateo-cli-qa | user_email mateo@berri.ai | team_id cli-qa-team | requests 3 | spend 5.865e-05
  api_key 7cc85d06641a8b9d4cc93d5e… | key_alias cli-session-mateo-cli-qa | user_email mateo@berri.ai | team_id cli-qa-team | requests 3 | spend 5.865000000000001e-05
```

#### Backfill

1. Not run here: the merge base keeps writing a new hash per login, so a backfill at this commit would be undone by the next `litellm-proxy login`

### After (660203a99b)

The only commit after 660203a99b is 1d0dc56b1b, a test-only change (a mocked auth object in the pass-through tests gains `is_session_token = False`), so it cannot change what this run observed

#### POST /chat/completions

1. With `KEY` set to the login 1 token and then the login 2 token (the `key` field of `$HOME/.litellm/token.json` after `litellm-proxy login`):

```
curl -s http://127.0.0.1:45780/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -d '{"model":"gpt-5.4-nano","messages":[{"role":"user","content":"Say AFTER in one word"}],"max_tokens":16}'
```

2. Output (trimmed to id, model, content, usage):

```
login 1: {"id": "chatcmpl-EMQPx8XWonCcWtsGTDIZry5Q7UYBq", "model": "gpt-5.4-nano", "content": "AFTER", "usage": {"prompt_tokens": 11, "completion_tokens": 5}}
login 2: {"id": "chatcmpl-EMQPzEn4JlYNxSUyrGr29ldrjVMx6", "model": "gpt-5.4-nano", "content": "\u201cAfter\u201d", "usage": {"prompt_tokens": 11, "completion_tokens": 6}}
```

#### POST /v1/messages

1. With `KEY` set to the login 1 token and then the login 2 token (the `key` field of `$HOME/.litellm/token.json` after `litellm-proxy login`):

```
curl -s http://127.0.0.1:45780/v1/messages -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -H 'anthropic-version: 2023-06-01' -d '{"model":"claude-haiku-4-5","max_tokens":16,"messages":[{"role":"user","content":"Say AFTER in one word"}]}'
```

2. Output (trimmed to id, model, content, usage):

```
login 1: {"id": "msg_011Ceu744wXACANEXmcGzyZv", "model": "claude-haiku-4-5", "content": "After.", "usage": {"input_tokens": 13, "output_tokens": 5}}
login 2: {"id": "msg_011Ceu74G1mTeDvA8coda9kE", "model": "claude-haiku-4-5", "content": "AFTER", "usage": {"input_tokens": 13, "output_tokens": 5}}
```

#### POST /v1/responses

1. With `KEY` set to the login 1 token and then the login 2 token (the `key` field of `$HOME/.litellm/token.json` after `litellm-proxy login`):

```
curl -s http://127.0.0.1:45780/v1/responses -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -d '{"model":"gpt-5.4-nano","input":"Say AFTER in one word","max_output_tokens":32}'
```

2. Output (trimmed to id, model, content, usage):

```
login 1: {"id": "resp_1Fl5JeU03bchJ2h\u2026", "model": "gpt-5.4-nano", "output_text": ["AFTER"], "usage": {"input_tokens": 11, "output_tokens": 6}}
login 2: {"id": "resp_ZopKAgUQ6oYsyHL\u2026", "model": "gpt-5.4-nano", "output_text": ["AFTER"], "usage": {"input_tokens": 11, "output_tokens": 6}}
```

#### Usage routes

1. Waited for the daily aggregates to flush, then read the three usage routes with the admin key and once more with the login 1 token `(daily spend flushed after 6x3s)`:

```
curl -s "http://127.0.0.1:45780/spend/logs?start_date=2026-09-10&end_date=2026-09-11" -H "Authorization: Bearer $ADMIN"
curl -s "http://127.0.0.1:45780/spend/logs/ui?start_date=2026-09-10%2000:00:00&end_date=2026-09-11%2000:00:00&page_size=50" -H "Authorization: Bearer $ADMIN"
curl -s "http://127.0.0.1:45780/user/daily/activity?start_date=2026-09-10&end_date=2026-09-10" -H "Authorization: Bearer $ADMIN"
curl -s "http://127.0.0.1:45780/user/daily/activity?start_date=2026-09-10&end_date=2026-09-10" -H "Authorization: Bearer $KEY"
```

2. Output (rows trimmed to the columns that matter; `/user/daily/activity` printed as one line per key from `breakdown.api_keys`):

```
## GET /spend/logs?start_date=2026-09-10&end_date=2026-09-11 (spend per api_key, admin key)
{"7cc85d06641a8b9d4cc93d5e43f3aa4320d01749f3bc07e91c4e15d8030885d4": 5.865e-05, "cli-session-mateo-cli-qa": 0.00011355000000000001, "7b782cfc52df8ee6748bd867c5abf18ba44a8b97ac0e7a90550e9dedb6017b44": 5.865e-05, "startTime": "2026-09-10", "spend": 0.00023085, "users": {"mateo-cli-qa": 0.00023085}}
{"startTime": "2026-09-11", "spend": 0, "users": {}}
## GET /spend/logs/ui (what the Logs page lists, admin key)
{"startTime": "04:10:37", "call_type": "acompletion", "model": "openai/gpt-5.4-nano", "api_key": "7cc85d06641a8b9d4cc93d5e43f3aa4320d01749f3bc07e91c4e15d8030885d4", "key_alias": "cli-session-mateo-cli-qa", "user": "mateo-cli-qa", "team_id": "cli-qa-team", "spend": 9.700000000000002e-06}
{"startTime": "04:10:38", "call_type": "anthropic_messages", "model": "anthropic/claude-haiku-4-5", "api_key": "7cc85d06641a8b9d4cc93d5e43f3aa4320d01749f3bc07e91c4e15d8030885d4", "key_alias": "cli-session-mateo-cli-qa", "user": "mateo-cli-qa", "team_id": "cli-qa-team", "spend": 3.8e-05}
{"startTime": "04:10:39", "call_type": "aresponses", "model": "openai/gpt-5.4-nano", "api_key": "7cc85d06641a8b9d4cc93d5e43f3aa4320d01749f3bc07e91c4e15d8030885d4", "key_alias": "cli-session-mateo-cli-qa", "user": "mateo-cli-qa", "team_id": "cli-qa-team", "spend": 1.095e-05}
{"startTime": "04:10:40", "call_type": "acompletion", "model": "openai/gpt-5.4-nano", "api_key": "7b782cfc52df8ee6748bd867c5abf18ba44a8b97ac0e7a90550e9dedb6017b44", "key_alias": "cli-session-mateo-cli-qa", "user": "mateo-cli-qa", "team_id": "cli-qa-team", "spend": 9.700000000000002e-06}
{"startTime": "04:10:41", "call_type": "anthropic_messages", "model": "anthropic/claude-haiku-4-5", "api_key": "7b782cfc52df8ee6748bd867c5abf18ba44a8b97ac0e7a90550e9dedb6017b44", "key_alias": "cli-session-mateo-cli-qa", "user": "mateo-cli-qa", "team_id": "cli-qa-team", "spend": 3.8e-05}
{"startTime": "04:10:41", "call_type": "aresponses", "model": "openai/gpt-5.4-nano", "api_key": "7b782cfc52df8ee6748bd867c5abf18ba44a8b97ac0e7a90550e9dedb6017b44", "key_alias": "cli-session-mateo-cli-qa", "user": "mateo-cli-qa", "team_id": "cli-qa-team", "spend": 1.095e-05}
{"startTime": "04:11:12", "call_type": "acompletion", "model": "openai/gpt-5.4-nano", "api_key": "cli-session-mateo-cli-qa", "key_alias": "cli-session-mateo-cli-qa", "user": "mateo-cli-qa", "team_id": "cli-qa-team", "spend": 8.45e-06}
{"startTime": "04:11:13", "call_type": "anthropic_messages", "model": "anthropic/claude-haiku-4-5", "api_key": "cli-session-mateo-cli-qa", "key_alias": "cli-session-mateo-cli-qa", "user": "mateo-cli-qa", "team_id": "cli-qa-team", "spend": 3.8e-05}
{"startTime": "04:11:14", "call_type": "aresponses", "model": "openai/gpt-5.4-nano", "api_key": "cli-session-mateo-cli-qa", "key_alias": "cli-session-mateo-cli-qa", "user": "mateo-cli-qa", "team_id": "cli-qa-team", "spend": 9.700000000000002e-06}
{"startTime": "04:11:15", "call_type": "acompletion", "model": "openai/gpt-5.4-nano", "api_key": "cli-session-mateo-cli-qa", "key_alias": "cli-session-mateo-cli-qa", "user": "mateo-cli-qa", "team_id": "cli-qa-team", "spend": 9.700000000000002e-06}
{"startTime": "04:11:16", "call_type": "anthropic_messages", "model": "anthropic/claude-haiku-4-5", "api_key": "cli-session-mateo-cli-qa", "key_alias": "cli-session-mateo-cli-qa", "user": "mateo-cli-qa", "team_id": "cli-qa-team", "spend": 3.8e-05}
{"startTime": "04:11:17", "call_type": "aresponses", "model": "openai/gpt-5.4-nano", "api_key": "cli-session-mateo-cli-qa", "key_alias": "cli-session-mateo-cli-qa", "user": "mateo-cli-qa", "team_id": "cli-qa-team", "spend": 9.700000000000002e-06}
## GET /user/daily/activity?start_date=2026-09-10&end_date=2026-09-10 (admin key)
date 2026-09-10 spend 0.00023085 requests 12
  api_key 7b782cfc52df8ee6748bd867… | key_alias cli-session-mateo-cli-qa | user_email mateo@berri.ai | team_id cli-qa-team | requests 3 | spend 5.865e-05
  api_key 7cc85d06641a8b9d4cc93d5e… | key_alias cli-session-mateo-cli-qa | user_email mateo@berri.ai | team_id cli-qa-team | requests 3 | spend 5.865000000000001e-05
  api_key cli-session-mateo-cli-qa | key_alias cli-session-mateo-cli-qa | user_email mateo@berri.ai | team_id cli-qa-team | requests 6 | spend 0.00011355000000000001
## same route with login 1 token (what the CLI user sees)
date 2026-09-10 spend 0.00023085 requests 12
  api_key 7b782cfc52df8ee6748bd867… | key_alias cli-session-mateo-cli-qa | user_email mateo@berri.ai | team_id cli-qa-team | requests 3 | spend 5.865e-05
  api_key 7cc85d06641a8b9d4cc93d5e… | key_alias cli-session-mateo-cli-qa | user_email mateo@berri.ai | team_id cli-qa-team | requests 3 | spend 5.865000000000001e-05
  api_key cli-session-mateo-cli-qa | key_alias cli-session-mateo-cli-qa | user_email mateo@berri.ai | team_id cli-qa-team | requests 6 | spend 0.00011355000000000001
```

#### Backfill

1. Dry run against the database left by the two legs above (six rows on two hashed session keys plus six on the alias):

```
$ psql "$DATABASE_URL" -v since=2026-01-01 -f backfill_part1.sql   # dry run, ends in ROLLBACK
BEGIN
SELECT 2
          alias           | session_keys 
--------------------------+--------------
 cli-session-mateo-cli-qa |            2
(1 row)

 spend_logs_to_rewrite 
-----------------------
                     6
(1 row)

          tbl           | rows_to_fold |   spend   
------------------------+--------------+-----------
 LiteLLM_DailyUserSpend |            6 | 0.0001173
 LiteLLM_DailyTeamSpend |            6 | 0.0001173
 LiteLLM_DailyTagSpend  |            0 |          
(3 rows)

ROLLBACK
```

2. Apply, compare the per-key totals, then `COMMIT`:

```
$ psql "$DATABASE_URL" -v since=2026-01-01 -f backfill_part2.sql   # apply, then COMMIT once the totals match
BEGIN
SELECT 2
SELECT 3
UPDATE 6
INSERT 0 0
DELETE 6
INSERT 0 0
DELETE 6
INSERT 0 0
DELETE 0
          tbl           |           key            |      spend_before      | spend_after | requests_before | requests_after 
------------------------+--------------------------+------------------------+-------------+-----------------+----------------
 LiteLLM_DailyTagSpend  | cli-session-mateo-cli-qa |                7.6e-05 |     7.6e-05 |               2 |              2
 LiteLLM_DailyTeamSpend | cli-session-mateo-cli-qa | 0.00023085000000000003 |  0.00023085 |              12 |             12
 LiteLLM_DailyUserSpend | cli-session-mateo-cli-qa | 0.00023085000000000003 |  0.00023085 |              12 |             12
(3 rows)

 spend_logs_still_on_a_session_key 
-----------------------------------
                                 0
(1 row)

COMMIT
```

3. The same usage routes now show one key for the user with all twelve requests:

```
## GET /spend/logs?start_date=2026-09-10&end_date=2026-09-11 (admin key)
{"cli-session-mateo-cli-qa": 0.00023085000000000003, "startTime": "2026-09-10", "spend": 0.00023085000000000003, "users": {"mateo-cli-qa": 0.00023085000000000003}}
{"startTime": "2026-09-11", "spend": 0, "users": {}}
## GET /user/daily/activity?start_date=2026-09-10&end_date=2026-09-10 (admin key)
date 2026-09-10 spend 0.00023085 requests 12
  api_key cli-session-mateo-cli-qa | key_alias cli-session-mateo-cli-qa | user_email mateo@berri.ai | team_id cli-qa-team | requests 12 | spend 0.00023085
## same route with login 1 token (what the CLI user sees)
date 2026-09-10 spend 0.00023085 requests 12
  api_key cli-session-mateo-cli-qa | key_alias cli-session-mateo-cli-qa | user_email mateo@berri.ai | team_id cli-qa-team | requests 12 | spend 0.00023085
```

Closing observations:

- Both legs: same single instance, two workers, same two logins
- Before: two 64-hex keys, one per login, each three requests
- Before: alias and email show only because staging's #40275 read-time recovery found them in the log window; the customer's v1.101.0-rc.1 has no such recovery
- After: every new row lands on `cli-session-mateo-cli-qa`
- After: alias, email, and team filled from the key and user row
- Backfill: totals match, zero spend logs left on a session key
- Daily aggregates flush a few seconds after the request

## Type

🐛 Bug Fix

## Caveats (if any)

### Severe

- Session spend keys change from a per-login hash to `cli-session-<user_id>`
  - History stays on the old hashes until the customer runs the backfill
  - BI queries that grouped by the hash now group by the alias
- The backfill rewrites `LiteLLM_SpendLogs.api_key` in place and folds daily rows
  - One transaction, locks the rows it touches; run it off-peak, dry run first

### Medium

- Proof reads usage through the API routes, not a Usage page screenshot
  - LLM calls went through curl with real `litellm-proxy login` tokens, not a coding tool
- `user_api_key_hash` in logging callbacks carries the alias for session requests
  - Deployment affinity, complexity-router session affinity, and adaptive-router identity key on it, so CLI logins of one user now share one affinity scope
  - The v3 rate limiter's post-call TPM counters for session requests move to the alias scope; session tokens carry no key limits, so nothing is enforced either way
- A user in several teams gets no `team_id` in usage metadata for the alias
  - Spend rows and team views still carry the team the CLI login attached

### Low

- Folding daily rows keeps `MIN(model_group)` and `MIN(request_id)`; both are informational
- Daily aggregates queued at proxy stop are lost (pre-existing shutdown flush gap, seen on the before leg's tag rows)
- The Usage page groups the alias under "Unassigned" for a multi-team user until a team is picked
- CircleCI `local_testing_part1` and `llm_translation_testing` are red on four mocked no-choices tests that fail the same way on staging pipeline 89447; #40517 fixes them

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 660203a99b passes /live-pr-risk (1d0dc56b1b on top is test-only)
