### PR TITLE
fix(model-map): set supports_minimal_reasoning_effort false for gpt-5.1 and gpt-5.4

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -30295,7 +30295,7 @@
         "supports_none_reasoning_effort": true,
         "default_reasoning_effort": "none",
         "supports_xhigh_reasoning_effort": false,
-        "supports_minimal_reasoning_effort": true
+        "supports_minimal_reasoning_effort": false
     },
     "gpt-5.1-2025-11-13": {
         "cache_read_input_token_cost": 1.25e-07,
@@ -31474,7 +31474,7 @@
         "supports_none_reasoning_effort": true,
         "default_reasoning_effort": "none",
         "supports_xhigh_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": true,
+        "supports_minimal_reasoning_effort": false,
         "input_cost_per_token_above_272k_tokens_flex": 2.5e-06,
         "output_cost_per_token_above_272k_tokens_flex": 1.125e-05,
         "cache_read_input_token_cost_above_272k_tokens_flex": 2.5e-07

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -30295,7 +30295,7 @@
         "supports_none_reasoning_effort": true,
         "default_reasoning_effort": "none",
         "supports_xhigh_reasoning_effort": false,
-        "supports_minimal_reasoning_effort": true
+        "supports_minimal_reasoning_effort": false
     },
     "gpt-5.1-2025-11-13": {
         "cache_read_input_token_cost": 1.25e-07,
@@ -31474,7 +31474,7 @@
         "supports_none_reasoning_effort": true,
         "default_reasoning_effort": "none",
         "supports_xhigh_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": true,
+        "supports_minimal_reasoning_effort": false,
         "input_cost_per_token_above_272k_tokens_flex": 2.5e-06,
         "output_cost_per_token_above_272k_tokens_flex": 1.125e-05,
         "cache_read_input_token_cost_above_272k_tokens_flex": 2.5e-07

--- a/tests/test_litellm/llms/openai/test_gpt5_transformation.py
+++ b/tests/test_litellm/llms/openai/test_gpt5_transformation.py
@@ -276,6 +276,17 @@ def test_gpt5_drops_reasoning_effort_xhigh_when_requested(config: OpenAIConfig):
     assert "reasoning_effort" not in params
 
 
+def test_gpt5_1_and_gpt5_4_drop_minimal_reasoning_effort(config: OpenAIConfig):
+    for model in ("gpt-5.1", "gpt-5.4"):
+        params = config.map_openai_params(
+            non_default_params={"reasoning_effort": "minimal"},
+            optional_params={},
+            model=model,
+            drop_params=True,
+        )
+        assert "reasoning_effort" not in params
+
+
 # GPT-5.1 temperature handling tests
 def test_gpt5_1_model_detection(gpt5_config: OpenAIGPT5Config):
     """Test that models supporting reasoning_effort='none' are correctly detected via model map."""
@@ -388,15 +399,15 @@ def test_gpt5_4_mini_allows_reasoning_effort_none(config: OpenAIConfig):
     assert params["reasoning_effort"] == "none"
 
 
-def test_gpt5_4_allows_reasoning_effort_minimal(config: OpenAIConfig):
-    """gpt-5.4 supports reasoning_effort='minimal'."""
-    params = config.map_openai_params(
-        non_default_params={"reasoning_effort": "minimal"},
-        optional_params={},
-        model="gpt-5.4",
-        drop_params=False,
-    )
-    assert params["reasoning_effort"] == "minimal"
+def test_gpt5_4_rejects_reasoning_effort_minimal(config: OpenAIConfig):
+    """gpt-5.4 rejects reasoning_effort='minimal'."""
+    with pytest.raises(litellm.utils.UnsupportedParamsError):
+        config.map_openai_params(
+            non_default_params={"reasoning_effort": "minimal"},
+            optional_params={},
+            model="gpt-5.4",
+            drop_params=False,
+        )
 
 
 def test_gpt5_4_pro_allows_reasoning_effort_minimal(config: OpenAIConfig):
@@ -468,13 +479,13 @@ def test_gpt5_minimal_dict_triggers_validation(config: OpenAIConfig):
 
 
 def test_gpt5_minimal_dict_accepted_for_supported_model(config: OpenAIConfig):
-    """Dict with effort='minimal' passes through for gpt-5.4+."""
+    """Dict with effort='minimal' passes through for gpt-5.4-pro."""
     params = config.map_openai_params(
         non_default_params={
             "reasoning_effort": {"effort": "minimal", "summary": "detailed"}
         },
         optional_params={},
-        model="gpt-5.4",
+        model="gpt-5.4-pro",
         drop_params=False,
     )
     assert params["reasoning_effort"] == "minimal"
@@ -482,7 +493,7 @@ def test_gpt5_minimal_dict_accepted_for_supported_model(config: OpenAIConfig):
 
 def test_gpt5_supports_reasoning_effort_level_minimal(gpt5_config: OpenAIGPT5Config):
     """Test that _supports_reasoning_effort_level correctly identifies minimal support."""
-    assert gpt5_config._supports_reasoning_effort_level("gpt-5.4", "minimal")
+    assert not gpt5_config._supports_reasoning_effort_level("gpt-5.4", "minimal")
     assert gpt5_config._supports_reasoning_effort_level("gpt-5.4-pro", "minimal")
     assert not gpt5_config._supports_reasoning_effort_level("gpt-5.4-mini", "minimal")
     assert not gpt5_config._supports_reasoning_effort_level("gpt-5.4-nano", "minimal")
@@ -504,7 +515,7 @@ def test_gpt5_minimal_explicitly_disabled_check(gpt5_config: OpenAIGPT5Config):
     assert gpt5_config._is_reasoning_effort_level_explicitly_disabled(
         "openai/gpt-5.4-mini", "minimal"
     )
-    assert not gpt5_config._is_reasoning_effort_level_explicitly_disabled(
+    assert gpt5_config._is_reasoning_effort_level_explicitly_disabled(
         "gpt-5.4", "minimal"
     )
     assert not gpt5_config._is_reasoning_effort_level_explicitly_disabled(
@@ -523,7 +534,7 @@ def test_is_explicitly_disabled_factory_minimal():
     assert _is_explicitly_disabled_factory("gpt-5.4-mini", None, key)
     assert _is_explicitly_disabled_factory("gpt-5.4-nano", None, key)
     assert _is_explicitly_disabled_factory("openai/gpt-5.4-mini", None, key)
-    assert not _is_explicitly_disabled_factory("gpt-5.4", None, key)
+    assert _is_explicitly_disabled_factory("gpt-5.4", None, key)
     assert not _is_explicitly_disabled_factory("gpt-5.4-pro", None, key)
     assert not _is_explicitly_disabled_factory("gpt-5.4-turbo-preview", None, key)
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- gpt-5.1 and gpt-5.4 reject reasoning_effort minimal with a provider 400
- The model map flagged both as supporting minimal, so LiteLLM forwarded it

How it solves it:

- Sets supports_minimal_reasoning_effort to false for gpt-5.1 and gpt-5.4
- Syncs the bundled backup map and updates the affected test expectations

## User Flow

Before: a developer sending reasoning_effort minimal to gpt-5.1 gets a hard failure

1. They call the chat completions route with model gpt-5.1 and reasoning_effort minimal
2. LiteLLM forwards minimal because the map says it is supported
3. OpenAI answers 400 Unsupported value, supported values exclude minimal

After: the same call has minimal dropped, so no provider error

1. They send the same request with drop_params enabled
2. LiteLLM drops reasoning_effort before calling OpenAI
3. The request succeeds without the unsupported value

## Relevant issues

Fixes #40473

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Local param-mapping check with LITELLM_LOCAL_MODEL_COST_MAP=True, no live call

After (PR tip):

1. Run get_optional_params for gpt-5.1, gpt-5.4, gpt-5.4-mini with reasoning_effort minimal and drop_params True
2. All three return without reasoning_effort: {'stream': False, 'extra_body': {}}
3. Full test file passes: 124 passed (tests/test_litellm/llms/openai/test_gpt5_transformation.py)

The live provider 400 for both models is documented in the linked issue

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Dated snapshots and codex variants still carry true, left as is since only the two base models were verified live

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
