### PR TITLE
fix(gemini): raise UnsupportedParamsError (400) instead of bare ValueError for invalid reasoning_effort

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -842,7 +842,13 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                 "includeThoughts": False,
             }
         else:
-            raise ValueError(f"Invalid reasoning effort: {reasoning_effort}")
+            raise litellm.utils.UnsupportedParamsError(
+                message=(
+                    f"reasoning_effort={reasoning_effort!r} is not valid for this model. "
+                    "Accepted values: 'minimal', 'low', 'medium', 'high', 'none', 'disable'."
+                ),
+                status_code=400,
+            )
 
     @staticmethod
     def _map_reasoning_effort_to_thinking_level(
@@ -890,7 +896,13 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
             else:
                 return {"thinkingLevel": "low", "includeThoughts": False}
         else:
-            raise ValueError(f"Invalid reasoning effort: {reasoning_effort}")
+            raise litellm.utils.UnsupportedParamsError(
+                message=(
+                    f"reasoning_effort={reasoning_effort!r} is not valid for this model. "
+                    "Accepted values: 'minimal', 'low', 'medium', 'high', 'none', 'disable'."
+                ),
+                status_code=400,
+            )
 
     @staticmethod
     def _is_thinking_budget_zero(thinking_budget: int | None) -> bool:


### PR DESCRIPTION
## Summary

Both `_map_reasoning_effort_to_thinking_budget` and `_map_reasoning_effort_to_thinking_level` in `vertex_and_google_ai_studio_gemini.py` raised a bare `ValueError` when `reasoning_effort` held an unrecognised value. Nothing upstream caught it, so litellm wrapped it in `APIConnectionError` and the proxy returned **HTTP 500** — a server-fault response for an unambiguous client mistake.

The providers themselves return HTTP 400 for the equivalent bad input (invalid `thinkingLevel` / `thinkingBudget`), so the 500 was a litellm-introduced regression on top of a request the provider would have rejected cleanly.

### Problem

```python
from litellm.utils import get_optional_params

for prov in ["gemini", "vertex_ai"]:
    try:
        get_optional_params(model="gemini-3.5-flash", custom_llm_provider=prov,
                            reasoning_effort="banana", drop_params=True)
    except Exception as e:
        print(prov, type(e).__name__, e)

# gemini    ValueError  Invalid reasoning effort: banana   ← bare, uncaught
# vertex_ai ValueError  Invalid reasoning effort: banana   ← same
```

Through the proxy this surfaces as `litellm.APIConnectionError` + HTTP 500. Clients and routers treat 5xx as retryable, so they retry a request that can never succeed.

### Fix

Replace both `raise ValueError(...)` calls with `litellm.utils.UnsupportedParamsError(status_code=400)`. The message lists the accepted values (`minimal`, `low`, `medium`, `high`, `none`, `disable`) so callers know exactly what to fix.

`UnsupportedParamsError` is already used for the equivalent guard in `gpt_5_transformation.py` (lines 285, 299), so this aligns the error type across providers.

Fixes #40474.