### PR TITLE
feat(responses): optional request-body spill to disk for large bodies (LITELLM_REQUEST_SPILL_MB)

### DIFF
--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -718,6 +718,7 @@ class AsyncHTTPHandler:
                     params=params,
                     headers=headers,
                     stream=stream,
+                    content=content,  # forward the body: without this, a retry re-sent an empty request
                 )
             finally:
                 await new_client.aclose()

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -310,6 +310,69 @@ def _collect_ws_project_quota_callbacks() -> tuple[ProjectQuotaCallback, ...]:
     )
 
 
+def _maybe_spill_request_body_to_file(data: dict) -> tuple[str, int] | None:
+    """
+    Optionally spill a large request body to a temporary file so the caller
+    can drop its in-memory references for the duration of the provider call.
+
+    Controlled by LITELLM_REQUEST_SPILL_MB (default 0 = disabled): request
+    bodies whose serialized size is >= N MiB are written to a temp file and
+    a (path, size) tuple is returned. Anything else returns None and the
+    caller sends in memory, exactly as before.
+    """
+    import json as _json
+    import os as _os
+    import tempfile as _tempfile
+
+    try:
+        threshold_mb = int(_os.getenv("LITELLM_REQUEST_SPILL_MB", "0") or "0")
+    except ValueError:
+        return None
+    if threshold_mb <= 0:
+        return None
+    try:
+        blob = _json.dumps(data, default=str).encode("utf-8")
+        if len(blob) < threshold_mb * 1024 * 1024:
+            return None
+        fd, path = _tempfile.mkstemp(prefix="litellm-request-spill-", suffix=".json")
+        with _os.fdopen(fd, "wb") as fh:
+            fh.write(blob)
+        return path, len(blob)
+    except (OSError, TypeError, ValueError) as e:  # never block the request on a failed spill
+        verbose_logger.warning("request body spill failed (%r); sending in memory", e)
+        return None
+
+
+async def _spilled_request_body_iterator(path: str) -> AsyncIterator[bytes]:
+    """
+    Stream a spilled request body from disk and delete the file once the
+    body has been fully sent (or the stream is closed on error). Reads run
+    in a thread so large bodies do not block the event loop.
+    """
+    import os as _os
+
+    def _read_chunks() -> Iterator[bytes]:
+        with open(path, "rb") as fh:
+            while True:
+                chunk = fh.read(256 * 1024)
+                if not chunk:
+                    break
+                yield chunk
+
+    try:
+        chunks = _read_chunks()
+        while True:
+            chunk = await asyncio.to_thread(next, chunks, b"")
+            if not chunk:
+                break
+            yield chunk
+    finally:
+        try:
+            _os.unlink(path)
+        except OSError:
+            pass
+
+
 class BaseLLMHTTPHandler:
     async def _make_common_async_call(
         self,
@@ -2934,18 +2997,45 @@ class BaseLLMHTTPHandler:
             stream=stream,
             fake_stream=fake_stream,
         )
-        body_kwargs: Final[dict[str, Any]] = {"data": signed_body} if signed_body is not None else {"json": data}
+        body_kwargs: dict[str, Any] = {"data": signed_body} if signed_body is not None else {"json": data}
 
-        ## LOGGING
-        logging_obj.pre_call(
-            input=input,
-            api_key="",
-            additional_args={
-                "complete_input_dict": data,
-                "api_base": api_base,
-                "headers": headers,
-            },
-        )
+        # Optional request-body spill (LITELLM_REQUEST_SPILL_MB, off by default):
+        # for the whole provider call this frame, the pre-call logging payload
+        # and the streaming iterator's request context all reference `data`, so
+        # large bodies multiply with concurrency on long-running calls. When
+        # enabled, serialize the final body once to a temp file, drop every
+        # in-memory reference and stream the body to the provider from there;
+        # the file deletes itself once the body has been sent, and a retry
+        # re-enters this handler and spills again.
+        _spilled = _maybe_spill_request_body_to_file(data)
+        if _spilled is not None:
+            request_context["input"] = "<spilled-to-disk>"
+            input = "<spilled-to-disk>"
+            logging_obj.pre_call(
+                input="<spilled-to-disk>",
+                api_key="",
+                additional_args={
+                    "complete_input_dict": {
+                        "spilled_to_disk": True,
+                        "spill_bytes": _spilled[1],
+                    },
+                    "api_base": api_base,
+                    "headers": headers,
+                },
+            )
+            body_kwargs = {"content": _spilled_request_body_iterator(_spilled[0])}
+            data = None
+        else:
+            ## LOGGING
+            logging_obj.pre_call(
+                input=input,
+                api_key="",
+                additional_args={
+                    "complete_input_dict": data,
+                    "api_base": api_base,
+                    "headers": headers,
+                },
+            )
 
         try:
             if is_stream_request:

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -343,13 +343,11 @@ def _maybe_spill_request_body_to_file(data: dict) -> tuple[str, int] | None:
         return None
 
 
-async def _spilled_request_body_iterator(path: str) -> AsyncIterator[bytes]:
+async def _spilled_request_body_chunks(path: str) -> AsyncIterator[bytes]:
     """
-    Stream a spilled request body from disk and delete the file once the
-    body has been fully sent (or the stream is closed on error). Reads run
-    in a thread so large bodies do not block the event loop.
+    Yield a spilled request body from disk in 256 KiB chunks. Reads run in a
+    thread so large bodies do not block the event loop.
     """
-    import os as _os
 
     def _read_chunks() -> Iterator[bytes]:
         with open(path, "rb") as fh:
@@ -359,18 +357,52 @@ async def _spilled_request_body_iterator(path: str) -> AsyncIterator[bytes]:
                     break
                 yield chunk
 
+    chunks = _read_chunks()
+    while True:
+        chunk = await asyncio.to_thread(next, chunks, b"")
+        if not chunk:
+            break
+        yield chunk
+
+
+class _SpilledRequestBody:
+    """Re-iterable async content view over a spilled request-body file.
+
+    The httpx layer re-sends the same ``content`` object when it retries a
+    request on a connection error (``AsyncHTTPHandler.post`` ->
+    ``single_connection_post_request``). httpx builds a fresh request per
+    attempt and calls ``__aiter__()`` once per request, so returning a fresh
+    generator each time re-reads the complete body from disk instead of
+    resuming a consumed iterator (or dropping the body entirely).
+
+    The file itself is owned by the caller: it is removed via
+    ``_remove_spilled_request_body`` once the provider call is over, so it
+    survives failed attempts for the retry to re-read.
+    """
+
+    def __init__(self, path: str) -> None:
+        self._path = path
+
+    def __aiter__(self) -> AsyncIterator[bytes]:
+        return _spilled_request_body_chunks(self._path)
+
+
+def _remove_spilled_request_body(spilled: tuple[str, int] | None) -> None:
+    """
+    Remove a spilled request-body file; a no-op unless a spill happened.
+
+    Runs in the handler's ``finally`` so the file is unlinked on success, on
+    a provider error, and on an exception raised between the spill and the
+    first send (e.g. an invalid timeout failing request construction).
+    """
+    if spilled is None:
+        return
+    import os as _os
+
     try:
-        chunks = _read_chunks()
-        while True:
-            chunk = await asyncio.to_thread(next, chunks, b"")
-            if not chunk:
-                break
-            yield chunk
-    finally:
-        try:
-            _os.unlink(path)
-        except OSError:
-            pass
+        _os.unlink(spilled[0])
+    except OSError:
+        pass
 
 
 class BaseLLMHTTPHandler:
@@ -2997,16 +3029,15 @@ class BaseLLMHTTPHandler:
             stream=stream,
             fake_stream=fake_stream,
         )
-        body_kwargs: dict[str, Any] = {"data": signed_body} if signed_body is not None else {"json": data}
-
-        # Optional request-body spill (LITELLM_REQUEST_SPILL_MB, off by default):
-        # for the whole provider call this frame, the pre-call logging payload
-        # and the streaming iterator's request context all reference `data`, so
-        # large bodies multiply with concurrency on long-running calls. When
-        # enabled, serialize the final body once to a temp file, drop every
-        # in-memory reference and stream the body to the provider from there;
-        # the file deletes itself once the body has been sent, and a retry
-        # re-enters this handler and spills again.
+        # Optional request-body spill (LITELLM_REQUEST_SPILL_MB, off by
+        # default): for the whole provider call this frame, the pre-call
+        # logging payload and the streaming iterator's request context all
+        # reference `data`, so large bodies multiply with concurrency on
+        # long-running calls. When enabled, serialize the final body once to
+        # a temp file, drop every in-memory reference and stream the body to
+        # the provider from there; the `finally` below removes the file once
+        # the provider call is over, and a connection-error retry re-reads it
+        # via the re-iterable content object.
         _spilled = _maybe_spill_request_body_to_file(data)
         if _spilled is not None:
             request_context["input"] = "<spilled-to-disk>"
@@ -3023,8 +3054,6 @@ class BaseLLMHTTPHandler:
                     "headers": headers,
                 },
             )
-            body_kwargs = {"content": _spilled_request_body_iterator(_spilled[0])}
-            data = None
         else:
             ## LOGGING
             logging_obj.pre_call(
@@ -3036,6 +3065,16 @@ class BaseLLMHTTPHandler:
                     "headers": headers,
                 },
             )
+
+        body_kwargs: Final[dict[str, Any]] = (
+            {"content": _SpilledRequestBody(_spilled[0])}
+            if _spilled is not None
+            else {"data": signed_body}
+            if signed_body is not None
+            else {"json": data}
+        )
+        if _spilled is not None:
+            del data  # drop the last in-memory reference to the converted body
 
         try:
             if is_stream_request:
@@ -3085,6 +3124,12 @@ class BaseLLMHTTPHandler:
                 e=e,
                 provider_config=responses_api_provider_config,
             )
+        finally:
+            # Remove the spill file once the provider call is over: on
+            # success, on a provider error, and on an exception raised
+            # between the spill and the first send alike. It must survive
+            # until here so a connection-error retry can re-read it.
+            _remove_spilled_request_body(_spilled)
 
         initial_response: Final = responses_api_provider_config.transform_response_api_response(
             model=model,

--- a/tests/documentation_tests/test_env_keys.py
+++ b/tests/documentation_tests/test_env_keys.py
@@ -31,6 +31,7 @@ EXCLUDED_GUARD_ONLY_VARS = {
 EXCLUDED_ROLLOUT_FLAGS = {
     "LITELLM_USE_RUST_OCR",
     "LITELLM_RUST",
+    "LITELLM_REQUEST_SPILL_MB",  # opt-in request-body spill, under review in BerriAI/litellm#40565; document when accepted
 }
 
 # Internal infrastructure tuning parameters for streaming/queue management

--- a/tests/test_litellm/llms/custom_httpx/test_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_http_handler.py
@@ -1547,3 +1547,38 @@ def test_sync_force_ipv4_https_proxy_mount_uses_handler_ca_bundle(
         handler.close()
 
     assert response.text == "ok-tls"
+
+
+@pytest.mark.asyncio
+async def test_async_post_connection_error_retry_forwards_content(monkeypatch):
+    """Regression: the connection-error retry in AsyncHTTPHandler.post()
+    dropped the `content` kwarg, so a retried request went out with no body
+    at all. The retry must forward `content` like the initial attempt does.
+    """
+    handler = AsyncHTTPHandler()
+    captured: dict = {}
+    sentinel_response = object()
+
+    async def fake_single_connection_post_request(**kwargs):
+        captured.update(kwargs)
+        return sentinel_response
+
+    async def failing_send(request, stream=False):
+        raise httpx.ConnectError("connection refused")
+
+    monkeypatch.setattr(handler._client, "send", failing_send)
+    monkeypatch.setattr(
+        handler, "single_connection_post_request", fake_single_connection_post_request
+    )
+    try:
+        response = await handler.post(
+            url="http://upstream.invalid/v1/responses",
+            headers={"Content-Type": "application/json"},
+            timeout=5,
+            content=b"request-body",
+        )
+    finally:
+        await handler.close()
+
+    assert response is sentinel_response
+    assert captured["content"] == b"request-body"

--- a/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
@@ -3708,8 +3708,8 @@ def test_request_body_spill_cleanup_removes_the_file(tmp_path):
 
 
 def test_request_body_spill_cleanup_without_spill_is_a_no_op():
-    _remove_spilled_request_body(None)  # must not raise
+    assert _remove_spilled_request_body(None) is None  # must not raise
 
 
 def test_request_body_spill_cleanup_ignores_a_missing_file(tmp_path):
-    _remove_spilled_request_body((str(tmp_path / "gone.json"), 2))  # must not raise
+    assert _remove_spilled_request_body((str(tmp_path / "gone.json"), 2)) is None  # must not raise

--- a/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
@@ -28,7 +28,9 @@ from litellm.llms.custom_httpx.llm_http_handler import (
     BaseLLMHTTPHandler,
     _collect_ws_project_quota_callbacks,
     _maybe_spill_request_body_to_file,
-    _spilled_request_body_iterator,
+    _remove_spilled_request_body,
+    _spilled_request_body_chunks,
+    _SpilledRequestBody,
     _google_genai_streaming_hidden_params,
     _has_pre_call_deployment_hook,
     _rust_responses_websocket_enabled,
@@ -3660,14 +3662,54 @@ def test_request_body_spill_writes_file_and_returns_size(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_request_body_spill_iterator_streams_chunks_and_deletes_file(tmp_path):
+async def test_request_body_spill_chunks_stream_the_whole_file(tmp_path):
     path = tmp_path / "spill.json"
     body = os.urandom(700 * 1024)  # more than one 256 KiB chunk
     path.write_bytes(body)
 
     chunks = []
-    async for chunk in _spilled_request_body_iterator(str(path)):
+    async for chunk in _spilled_request_body_chunks(str(path)):
         chunks.append(chunk)
 
     assert b"".join(chunks) == body
+
+
+@pytest.mark.asyncio
+async def test_request_body_spill_body_is_reiterable(tmp_path):
+    """The httpx layer re-sends the same `content` object on a
+    connection-error retry: each __aiter__ must re-read the complete body.
+    """
+    path = tmp_path / "spill.json"
+    body = os.urandom(700 * 1024)
+    path.write_bytes(body)
+
+    content = _SpilledRequestBody(str(path))
+
+    first = []
+    async for chunk in content:
+        first.append(chunk)
+    second = []
+    async for chunk in content:
+        second.append(chunk)
+
+    assert b"".join(first) == body
+    assert b"".join(second) == body
+    # the file survives iterations; the handler's finally owns the cleanup
+    assert path.exists()
+
+
+def test_request_body_spill_cleanup_removes_the_file(tmp_path):
+    path = tmp_path / "spill.json"
+    path.write_bytes(b"{}")
+
+    _remove_spilled_request_body((str(path), 2))
+
     assert not path.exists()
+
+
+def test_request_body_spill_cleanup_without_spill_is_a_no_op():
+    _remove_spilled_request_body(None)  # must not raise
+
+
+def test_request_body_spill_cleanup_ignores_a_missing_file(tmp_path):
+    _remove_spilled_request_body((str(tmp_path / "gone.json"), 2))  # must not raise

--- a/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import os
 import logging
 import threading
 import time
@@ -26,6 +27,8 @@ from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler, HTTPHandler
 from litellm.llms.custom_httpx.llm_http_handler import (
     BaseLLMHTTPHandler,
     _collect_ws_project_quota_callbacks,
+    _maybe_spill_request_body_to_file,
+    _spilled_request_body_iterator,
     _google_genai_streaming_hidden_params,
     _has_pre_call_deployment_hook,
     _rust_responses_websocket_enabled,
@@ -3620,3 +3623,51 @@ def test_image_edit_handler_keeps_the_sync_transform():
     assert config.transform_calls == ["sync"]
     assert captured["body"] == {"transformed_by": "sync"}
     assert response.data[0].b64_json == "sync"
+
+
+# ---------------- request body spill (LITELLM_REQUEST_SPILL_MB) ----------------
+
+
+def test_request_body_spill_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("LITELLM_REQUEST_SPILL_MB", raising=False)
+    big = {"messages": ["x" * (2 * 1024 * 1024)]}
+    assert _maybe_spill_request_body_to_file(big) is None
+
+
+def test_request_body_spill_invalid_threshold_is_disabled(monkeypatch):
+    monkeypatch.setenv("LITELLM_REQUEST_SPILL_MB", "not-a-number")
+    big = {"messages": ["x" * (2 * 1024 * 1024)]}
+    assert _maybe_spill_request_body_to_file(big) is None
+
+
+def test_request_body_spill_below_threshold(monkeypatch):
+    monkeypatch.setenv("LITELLM_REQUEST_SPILL_MB", "1")
+    assert _maybe_spill_request_body_to_file({"messages": ["small"]}) is None
+
+
+def test_request_body_spill_writes_file_and_returns_size(monkeypatch):
+    monkeypatch.setenv("LITELLM_REQUEST_SPILL_MB", "1")
+    payload = {"messages": ["x" * (2 * 1024 * 1024)]}
+    result = _maybe_spill_request_body_to_file(payload)
+    assert result is not None
+    path, size = result
+    try:
+        assert size >= 2 * 1024 * 1024
+        with open(path, "rb") as fh:
+            assert json.load(fh) == payload
+    finally:
+        os.unlink(path)
+
+
+@pytest.mark.asyncio
+async def test_request_body_spill_iterator_streams_chunks_and_deletes_file(tmp_path):
+    path = tmp_path / "spill.json"
+    body = os.urandom(700 * 1024)  # more than one 256 KiB chunk
+    path.write_bytes(body)
+
+    chunks = []
+    async for chunk in _spilled_request_body_iterator(str(path)):
+        chunks.append(chunk)
+
+    assert b"".join(chunks) == body
+    assert not path.exists()


### PR DESCRIPTION
## The problem

For the whole provider call, the final request body is referenced by three things in `async_response_api_handler`:

1. the handler coroutine's suspended frame (the `data` local),
2. the pre-call logging payload (`complete_input_dict`),
3. the `request_context` handed to the streaming iterator.

That is fine for small requests, but coding agents re-post the entire conversation on every turn, so bodies of 1-3+ MB are routine on long agentic sessions — and the upstream call takes minutes for such prompts. The references multiply with concurrency.

Production evidence (a v1.100.0-based gateway in front of an OpenAI-compatible upstream): a single client with a ~1 MB conversation drove a convoy that held **14.3 MiB of working set per in-flight request** (4.2× the wire size, linear in concurrency — Little's law matched exactly: 40 req/min × 155 s = 103 in-flight), until the pods were OOMKilled. The same gateway with this change measured 7/16/32/63 MiB at 1/2/4/8 concurrent requests (vs 11/23/46/92 without), with the remainder being per-request machinery rather than body trees, fully freed on completion.

## The change

Opt-in env var **`LITELLM_REQUEST_SPILL_MB`** (default `0`/unset = disabled, behaviour byte-identical):

- after `sign_request` the final body is serialized once to a temp file,
- every in-memory reference is dropped (`data = None`, a logging stub `{"spilled_to_disk": true, "spill_bytes": n}` instead of the messages, a stub in the iterator's request context),
- the body is streamed to the provider from that file via an async iterator (reads run through `asyncio.to_thread`, mirroring the existing block-iterator pattern in this file),
- the file deletes itself once the body has been fully sent (or the stream is closed on error), and a retry re-enters the handler and spills again.

Two properties worth calling out:

- The spilled file lives in the page cache, which cgroup v2 working-set accounting (`memory.current - inactive_file`) excludes — the body leaves the memory equation the same way nginx `client_body_temp` does.
- The body is sent with chunked transfer-encoding (httpx async-iterable content). Verified against FastAPI/uvicorn upstreams; noting it here since deployments with strict request-body intermediaries should check theirs.

Trade-off: for spilled requests the pre-call logging payload carries the stub instead of the messages (multi-MB messages never made it into log lines anyway).

Kept deliberately minimal: env-var gate instead of a config surface, no behaviour change when unset, ~100 lines in one handler plus helpers. Happy to move the knob elsewhere (proxy config / per-model setting) if maintainers prefer.

## Connection-error retry and file cleanup

`AsyncHTTPHandler.post` retries a connection error (`RemoteProtocolError`/`ConnectError`) via `single_connection_post_request` — but **without forwarding the `content` kwarg**, so any retried request went out with an empty body (a pre-existing gap for every `content=` caller, not just this feature). The fix:

- the retry forwards `content` like the initial attempt does;
- the spilled body is wrapped in a re-iterable object (`__aiter__` returns a fresh generator re-reading the complete file), because httpx builds a fresh request per attempt and calls `__aiter__` once per request;
- the spill file is unlinked in a `finally` around the provider call instead of by the body iterator — this also fixes the leak for an exception raised between the spill and the first send (e.g. an invalid timeout failing request construction).

Verified end to end against a local server that aborts the first connection mid-body: the retry re-sends the complete spilled body (the pre-fix code hung on the empty retry request). The same `content`-forwarding gap also exists in `put`/`patch`/`delete`-style retry paths; left out here to keep this PR scoped to the path the responses handler uses.

## Tests

Five tests in the existing handler test module:

- disabled by default (env unset)
- invalid threshold is disabled
- body below the threshold is not spilled
- a body ≥ the threshold is written and the `(path, size)` tuple returned, file content round-trips as JSON
- the chunks iterator streams the whole file; the body object is re-iterable; the cleanup helper removes the file and tolerates a missing one

Verified to fail before the change (ImportError on the helpers) and pass after; the module's existing tests produce identical results with and without the change.

