### PR TITLE
fix(model_prices): update jina-reranker-v2-base-multilingual to Jina's current rate

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -33709,13 +33709,14 @@
         "supports_tool_choice": true
     },
     "jina-reranker-v2-base-multilingual": {
-        "input_cost_per_token": 1.8e-08,
+        "input_cost_per_token": 5e-08,
         "litellm_provider": "jina_ai",
         "max_input_tokens": 1024,
         "max_output_tokens": 1024,
         "max_tokens": 1024,
         "mode": "rerank",
-        "output_cost_per_token": 1.8e-08
+        "output_cost_per_token": 0.0,
+        "source": "https://api.jina.ai/v1/models"
     },
     "jp.anthropic.claude-sonnet-4-5-20250929-v1:0": {
         "cache_creation_input_token_cost": 4.125e-06,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -33709,13 +33709,14 @@
         "supports_tool_choice": true
     },
     "jina-reranker-v2-base-multilingual": {
-        "input_cost_per_token": 1.8e-08,
+        "input_cost_per_token": 5e-08,
         "litellm_provider": "jina_ai",
         "max_input_tokens": 1024,
         "max_output_tokens": 1024,
         "max_tokens": 1024,
         "mode": "rerank",
-        "output_cost_per_token": 1.8e-08
+        "output_cost_per_token": 0.0,
+        "source": "https://api.jina.ai/v1/models"
     },
     "jp.anthropic.claude-sonnet-4-5-20250929-v1:0": {
         "cache_creation_input_token_cost": 4.125e-06,


### PR DESCRIPTION
## Relevant issues

n/a

## Pre-Submission checklist

- [x] I have Added testing in the `tests/litellm/` directory — n/a, pricing data only
- [x] I have added a screenshot of my new test passing locally — n/a, pricing data only
- [x] My PR passes all unit tests on `make test-unit` — n/a, pricing data only
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

`jina-reranker-v2-base-multilingual` still carries Jina's pre-May-2025 rate (`1.8e-08` per token, i.e. $0.018/1M) and mirrors it into `output_cost_per_token`.

Jina moved all Search Foundation APIs (reranker included) to $0.05 per 1M tokens in May 2025. The machine-readable catalog confirms it for this exact model id:

```
$ curl -s https://api.jina.ai/v1/models | jq '.data[] | select(.id=="jina-ai/jina-reranker-v2-base-multilingual") | .pricing'
{
  "prompt": "0.00000005",
  "completion": "0",
  ...
}
```

- `input_cost_per_token`: `1.8e-08` → `5e-08`
- `output_cost_per_token`: `1.8e-08` → `0.0` (a reranker returns scores; Jina bills input tokens only, `completion` is `0`)
- added `source` pointing at the catalog endpoint

No other entry touched.
