### PR TITLE
fix(proxy): chunk end-user budget resets

### DIFF
--- a/litellm/proxy/common_utils/reset_budget_job.py
+++ b/litellm/proxy/common_utils/reset_budget_job.py
@@ -70,6 +70,7 @@ _RowT = TypeVar("_RowT")
 
 _LINKED_KEYS_WHERE: Final[Mapping[str, object]] = MappingProxyType({"budget_duration": None, "spend": {"gt": 0}})
 _SPENT_ROWS_WHERE: Final[Mapping[str, object]] = MappingProxyType({"spend": {"gt": 0}})
+_ENDUSER_RESET_CHUNK_SIZE: Final = 30_000
 
 
 class _BudgetLinkedRow(Protocol):
@@ -223,15 +224,20 @@ def _queue_budget_linked_resets(
         writes.queue_spend_zero(where=_budget_link_where(plain_ids, extra))
 
 
+def _enduser_id_chunks(user_ids: Sequence[str]) -> Iterable[list[str]]:
+    for start in range(0, len(user_ids), _ENDUSER_RESET_CHUNK_SIZE):
+        yield list(user_ids[start : start + _ENDUSER_RESET_CHUNK_SIZE])
+
+
 def _queue_enduser_resets(writes: LinkedSpendResetWrites, cascade: "_BudgetCascade") -> None:
     """End users are matched by id rather than budget link: rows with no
     budget_id ride the default budget tier (litellm.max_end_user_budget_id).
     Zero-before-decrement ordering matters here too (see
     _queue_budget_linked_resets)."""
     if not cascade.rollover_caps:
-        if cascade.endusers:
+        for user_ids in _enduser_id_chunks(tuple(row.user_id for row in cascade.endusers)):
             writes.queue_spend_zero(
-                where={"user_id": {"in": [row.user_id for row in cascade.endusers]}}
+                where={"user_id": {"in": user_ids}}
             )  # mutable-ok: prisma where filter must be a dict
         return
     tiered: Final = tuple((row.budget_id or litellm.max_end_user_budget_id, row.user_id) for row in cascade.endusers)
@@ -240,17 +246,18 @@ def _queue_enduser_resets(writes: LinkedSpendResetWrites, cascade: "_BudgetCasca
             user_ids := [uid for bid, uid in tiered if bid == budget_id]
         ):  # mutable-ok: prisma "in" filter takes a list
             continue
-        writes.queue_spend_zero(
-            where={"user_id": {"in": user_ids}, "spend": {"lte": cap}}
-        )  # mutable-ok: prisma where filter must be a dict
-        writes.queue_spend_decrement(
-            where={"user_id": {"in": user_ids}, "spend": {"gt": cap}}, amount=cap
-        )  # mutable-ok: prisma where filter must be a dict
+        for chunk in _enduser_id_chunks(user_ids):
+            writes.queue_spend_zero(
+                where={"user_id": {"in": chunk}, "spend": {"lte": cap}}
+            )  # mutable-ok: prisma where filter must be a dict
+            writes.queue_spend_decrement(
+                where={"user_id": {"in": chunk}, "spend": {"gt": cap}}, amount=cap
+            )  # mutable-ok: prisma where filter must be a dict
     plain: Final = [
         uid for bid, uid in tiered if bid is None or bid not in cascade.rollover_caps
     ]  # mutable-ok: prisma "in" filter takes a list
-    if plain:
-        writes.queue_spend_zero(where={"user_id": {"in": plain}})  # mutable-ok: prisma where filter must be a dict
+    for user_ids in _enduser_id_chunks(plain):
+        writes.queue_spend_zero(where={"user_id": {"in": user_ids}})  # mutable-ok: prisma where filter must be a dict
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
+++ b/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
@@ -3054,6 +3054,67 @@ def test_budget_cascade_carries_enduser_overage_when_rollover_enabled(
     } in enduser_writes
 
 
+def test_budget_cascade_chunks_enduser_id_filters(reset_budget_job, mock_prisma_client, monkeypatch):
+    monkeypatch.setattr(reset_budget_job_module, "_ENDUSER_RESET_CHUNK_SIZE", 2)
+    budget = _budget_row(budget_id="budget-large", budget_duration="1d")
+    mock_prisma_client.data["budget"] = [budget]
+    mock_prisma_client.data["enduser"] = [
+        type(
+            "EndUser",
+            (),
+            {
+                "spend": 1.0,
+                "litellm_budget_table": budget,
+                "user_id": f"enduser-{index}",
+                "budget_id": "budget-large",
+            },
+        )
+        for index in range(5)
+    ]
+
+    asyncio.run(reset_budget_job.reset_budget_for_litellm_budget_table())
+
+    enduser_writes = _batch_writes(mock_prisma_client, "enduser")
+    chunks = [write["where"]["user_id"]["in"] for write in enduser_writes]
+    assert [len(chunk) for chunk in chunks] == [2, 2, 1]
+    assert [user_id for chunk in chunks for user_id in chunk] == [f"enduser-{index}" for index in range(5)]
+    assert len(mock_prisma_client.db.batchers) == 1
+
+
+def test_budget_cascade_chunks_plain_endusers_when_another_tier_rolls_over(
+    rollover_enabled, reset_budget_job, mock_prisma_client, monkeypatch
+):
+    monkeypatch.setattr(reset_budget_job_module, "_ENDUSER_RESET_CHUNK_SIZE", 2)
+    rollover_budget = _budget_row(budget_id="budget-roll", budget_duration="1d", max_budget=10.0)
+    plain_budget = _budget_row(budget_id="budget-plain", budget_duration="1d")
+    plain_budget.max_budget = None
+    mock_prisma_client.data["budget"] = [rollover_budget, plain_budget]
+    mock_prisma_client.data["enduser"] = [
+        type(
+            "EndUser",
+            (),
+            {
+                "spend": 15.0 if index == 0 else 1.0,
+                "litellm_budget_table": rollover_budget if index == 0 else plain_budget,
+                "user_id": f"enduser-{index}",
+                "budget_id": "budget-roll" if index == 0 else "budget-plain",
+            },
+        )
+        for index in range(6)
+    ]
+
+    asyncio.run(reset_budget_job.reset_budget_for_litellm_budget_table())
+
+    plain_writes = [
+        write
+        for write in _batch_writes(mock_prisma_client, "enduser")
+        if "spend" not in write["where"]
+    ]
+    chunks = [write["where"]["user_id"]["in"] for write in plain_writes]
+    assert [len(chunk) for chunk in chunks] == [2, 2, 1]
+    assert [user_id for chunk in chunks for user_id in chunk] == [f"enduser-{index}" for index in range(1, 6)]
+
+
 def test_budget_cascade_carries_default_tier_enduser_counter_when_rollover_enabled(
     rollover_enabled, reset_budget_job, mock_prisma_client, monkeypatch
 ):


### PR DESCRIPTION
## TLDR

Problem this solves:

- Large end-user resets exceed the PostgreSQL bind-variable limit
- The reset transaction fails before end-user spend is cleared

How it solves it:

- Split end-user ID filters into 30,000-ID chunks
- Keep every chunk inside the existing atomic transaction

## User Flow

Before: a proxy admin resets a budget with more than 32,767 end users, but the scheduled reset never completes

1. The admin configures a shared budget used by more than 32,767 end users
2. The scheduled budget reset runs after the budget window expires
3. PostgreSQL rejects the oversized statement, so end-user spend remains unchanged

After: the same scheduled reset completes without exceeding the PostgreSQL parameter limit

1. The admin configures the same shared budget used by more than 32,767 end users
2. The scheduled budget reset runs after the budget window expires
3. PostgreSQL receives bounded statements inside one transaction, so all end-user spend is reset atomically

## Relevant issues

Fixes #40564

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The test file covering my change passes locally
- [x] My PR passes the local make check gate
- [x] My PR scope is as isolated as possible
- [ ] I have received a Greptile Confidence Score of at least 4/5

## Screenshots / Proof of Fix

Live PostgreSQL proof is still pending. The regression tests lower the chunk size to two and verify bounded writes of sizes 2, 2, and 1 for both plain resets and mixed rollover/plain tiers inside one batch transaction

## Type

Bug Fix

## Caveats (if any)

### Low

- Live PostgreSQL verification with more than 32,767 users is pending

## Final Attestation

- [x] The tests cover the parameter-boundary behavior and atomic batch use
- [x] This patch only changes end-user reset query batching

