### PR TITLE
fix(router): strip Codex harness envelopes before classification

### DIFF
--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -2,6 +2,7 @@
 ## Helper utilities
 import copy
 import logging
+import re
 from collections.abc import Iterable, Mapping
 from typing import TYPE_CHECKING, Any, Final, Literal
 
@@ -19,6 +20,13 @@ if TYPE_CHECKING:
     Span = _Span | Any
 else:
     Span = Any
+
+
+_CODEX_CLIENT_PREFIX_RE: Final = re.compile(r"^codex[-_ /]", re.IGNORECASE)
+
+
+def is_codex_user_agent(user_agent: str) -> bool:
+    return bool(_CODEX_CLIENT_PREFIX_RE.match(user_agent))
 
 
 def safe_divide_seconds(seconds: float, denominator: float, default: float | None = None) -> float | None:

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -31,6 +31,7 @@ from litellm.constants import (
     SESSION_ID_OMITTED_METADATA_KEY,
     X_LITELLM_DISABLE_CALLBACKS,
 )
+from litellm.litellm_core_utils.core_helpers import is_codex_user_agent
 from litellm.litellm_core_utils.credential_accessor import CredentialAccessor
 from litellm.litellm_core_utils.initialize_dynamic_callback_params import (
     TRUSTED_CALLBACK_VARS_FIELD,
@@ -83,10 +84,6 @@ _EXPLICIT_SESSION_HEADERS: Final = frozenset({"x-litellm-trace-id", "x-litellm-s
 # ``session-id``/``thread-id``; builds before the codex-api split sent
 # ``session_id``/``conversation_id``. Ordered session before thread.
 _CODEX_SESSION_ID_HEADERS: Final = ("session-id", "session_id", "thread-id", "conversation_id")
-# Matches every first-party Codex originator: codex-tui, codex_cli_rs, codex_exec,
-# codex_vscode, "Codex ...". A separator is required so an unrelated "codexfoo" client
-# does not read as Codex.
-_CODEX_CLIENT_PREFIX_RE: Final = re.compile(r"^codex[-_ /]", re.IGNORECASE)
 # Session-id values must be non-empty strings of alphanumerics, hyphens, or underscores
 # (covers UUIDs and most common session-id formats).
 _SESSION_ID_VALUE_RE: Final = re.compile(r"^[a-zA-Z0-9_\-]{8,}$")
@@ -808,16 +805,6 @@ def apply_missing_session_id_policy(
                 "Ignoring unknown general_settings.missing_session_id=%r; expected 'generate', 'reject' or 'omit'",
                 policy,
             )
-
-
-def is_codex_user_agent(user_agent: str) -> bool:
-    """Codex builds its user agent as ``<originator>/<version> ...`` and ships
-    several first-party originators: ``codex-tui``, ``codex_cli_rs``,
-    ``codex_exec`` (exec mode), ``codex_vscode`` (IDE extension) and ``Codex ...``
-    (see ``is_first_party_originator`` in codex-rs). They agree only on the
-    ``codex`` stem, and the TUI sends a bare ``codex-tui`` with no version at all,
-    so match the stem plus a separator rather than any one spelling."""
-    return bool(_CODEX_CLIENT_PREFIX_RE.match(user_agent))
 
 
 def should_auto_drop_params_for_agentic_cli(user_agent: str, data: dict, proxy_config: ProxyConfig) -> bool:

--- a/litellm/router_strategy/complexity_router/README.md
+++ b/litellm/router_strategy/complexity_router/README.md
@@ -446,7 +446,11 @@ Reasoning markers in the system prompt do **not** trigger the reasoning override
 
 Agent harnesses inject their own context into the conversation as ordinary message text. That text is plumbing, not something a human asked for, so the router strips complete reminder blocks before classifying and picking a tier. A turn that is nothing but a reminder block strips to empty and is skipped, and the router falls back to the last real ask instead
 
-By default a block is anything between `<system-reminder>` and `</system-reminder>`. `reminder_markers` replaces that with your harness's own delimiters. Many harnesses use a different envelope per agent type, so list every pair you emit:
+By default the router strips complete `<system-reminder>`, `<environment_context>`, `<recommended_plugins>`, `<user_instructions>`, and `<environments_instructions>` blocks. It also strips Codex repository instructions from the fixed heading prefix `# AGENTS.md instructions for ` through `</INSTRUCTIONS>`, regardless of the repository path
+
+The Codex `Message Type: NEW_TASK` wrapper and its delegated-task payload remain available for classification. Cleanup applies to the current ask and quoted prior turns; the routed request retains its original content
+
+`reminder_markers` replaces these defaults with your harness's own delimiters. Many harnesses use a different envelope per agent type, so list every pair you emit:
 
 ```yaml
 model_list:
@@ -461,7 +465,7 @@ model_list:
             close: "[[SUBAGENT_CONTEXT_END]]"
 ```
 
-Setting `reminder_markers` replaces the built-in `<system-reminder>` pair rather than adding to it, so list that pair too if your harness also emits it. Matching is case-insensitive. Blocks that nest or overlap across pairs are stripped whole. An unclosed delimiter is not a block and is left in place, which keeps prose that merely mentions a delimiter from being eaten
+Setting `reminder_markers` replaces all built-in pairs, including the Codex heading pair, so include every default your harness still needs. Matching is case-insensitive. Blocks that nest or overlap across pairs are stripped whole. An unclosed delimiter is not a block and is left in place, which keeps prose that merely mentions a delimiter from being eaten
 
 ### Code Detection
 

--- a/litellm/router_strategy/complexity_router/README.md
+++ b/litellm/router_strategy/complexity_router/README.md
@@ -446,7 +446,9 @@ Reasoning markers in the system prompt do **not** trigger the reasoning override
 
 Agent harnesses inject their own context into the conversation as ordinary message text. That text is plumbing, not something a human asked for, so the router strips complete reminder blocks before classifying and picking a tier. A turn that is nothing but a reminder block strips to empty and is skipped, and the router falls back to the last real ask instead
 
-By default the router strips complete `<system-reminder>`, `<environment_context>`, `<recommended_plugins>`, `<user_instructions>`, and `<environments_instructions>` blocks. It also strips Codex repository instructions from the fixed heading prefix `# AGENTS.md instructions for ` through `</INSTRUCTIONS>`, regardless of the repository path
+By default the router strips complete `<system-reminder>` blocks. For requests with a Codex user agent, it also strips complete `<environment_context>`, `<recommended_plugins>`, `<user_instructions>`, and `<environments_instructions>` blocks, plus repository instructions from the fixed heading prefix `# AGENTS.md instructions for ` through `</INSTRUCTIONS>`, regardless of the repository path. Other clients keep those tags and their contents
+
+The proxy records the incoming user agent in request metadata. SDK callers can supply `metadata.user_agent` (or `litellm_metadata.user_agent` on Responses requests), or configure `reminder_markers` explicitly when their client identity is unavailable
 
 The Codex `Message Type: NEW_TASK` wrapper and its delegated-task payload remain available for classification. Cleanup applies to the current ask and quoted prior turns; the routed request retains its original content
 

--- a/litellm/router_strategy/complexity_router/README.md
+++ b/litellm/router_strategy/complexity_router/README.md
@@ -452,6 +452,8 @@ The proxy records the incoming user agent in request metadata. SDK callers can s
 
 The Codex `Message Type: NEW_TASK` wrapper and its delegated-task payload remain available for classification. Cleanup applies to the current ask and quoted prior turns; the routed request retains its original content
 
+In `classification_mode: user_turn`, complete text-only reminder tails leave the preceding fresh ask eligible for classification. Assistant turns and tool results still mark continuations, including tool results carried alongside reminder text
+
 `reminder_markers` replaces these defaults with your harness's own delimiters. Many harnesses use a different envelope per agent type, so list every pair you emit:
 
 ```yaml

--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -386,7 +386,14 @@ def _effective_turn_off_message_logging(request_kwargs: Mapping[str, object] | N
 
 _REMINDER_OPEN: Final = "<system-reminder>"
 _REMINDER_CLOSE: Final = "</system-reminder>"
-_DEFAULT_REMINDER_MARKERS: Final = ((_REMINDER_OPEN, _REMINDER_CLOSE),)
+_DEFAULT_REMINDER_MARKERS: Final = (
+    (_REMINDER_OPEN, _REMINDER_CLOSE),
+    ("<environment_context>", "</environment_context>"),
+    ("<recommended_plugins>", "</recommended_plugins>"),
+    ("<user_instructions>", "</user_instructions>"),
+    ("<environments_instructions>", "</environments_instructions>"),
+    ("# agents.md instructions for ", "</instructions>"),
+)
 
 _TRUNCATION_MARKER: Final = "..."
 _TRUNCATION_HEAD_FRACTION: Final = 0.3

--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -39,6 +39,7 @@ from litellm.integrations.custom_logger import CustomLogger
 from litellm.litellm_core_utils.core_helpers import (
     _get_parent_otel_span_from_kwargs,
     get_metadata_variable_name_from_kwargs,
+    is_codex_user_agent,
 )
 from litellm.litellm_core_utils.internal_call_metadata import forwarded_internal_call_metadata
 from litellm.litellm_core_utils.prompt_templates.common_utils import (
@@ -386,8 +387,8 @@ def _effective_turn_off_message_logging(request_kwargs: Mapping[str, object] | N
 
 _REMINDER_OPEN: Final = "<system-reminder>"
 _REMINDER_CLOSE: Final = "</system-reminder>"
-_DEFAULT_REMINDER_MARKERS: Final = (
-    (_REMINDER_OPEN, _REMINDER_CLOSE),
+_DEFAULT_REMINDER_MARKERS: Final = ((_REMINDER_OPEN, _REMINDER_CLOSE),)
+_CODEX_REMINDER_MARKERS: Final = _DEFAULT_REMINDER_MARKERS + (
     ("<environment_context>", "</environment_context>"),
     ("<recommended_plugins>", "</recommended_plugins>"),
     ("<user_instructions>", "</user_instructions>"),
@@ -1951,6 +1952,7 @@ class ComplexityRouter(CustomLogger):
             raise ValueError("classifier_llm_config is not set")
 
         include_assistant: Final = self.config.classifier_context_include_assistant_turns
+        marker_pairs: Final = self._reminder_markers_for_request(request_kwargs or {})
         context_enabled: Final = bool(messages) and self.config.classifier_context_window_size > 0
         prior_turns: Final = (
             _extract_prior_turns(
@@ -1960,20 +1962,14 @@ class ComplexityRouter(CustomLogger):
                 budget_chars=self.config.classifier_context_budget_chars,
                 per_turn_chars=self.config.classifier_context_per_turn_chars,
                 include_assistant=include_assistant,
-                marker_pairs=self._reminder_markers,
+                marker_pairs=marker_pairs,
             )
             if context_enabled
             else ()
         )
         has_prior_conversation: Final = (
             context_enabled
-            and len(
-                tuple(
-                    islice(
-                        _iter_context_turns_newest_first(messages or (), include_assistant, self._reminder_markers), 2
-                    )
-                )
-            )
+            and len(tuple(islice(_iter_context_turns_newest_first(messages or (), include_assistant, marker_pairs), 2)))
             > 1
         )
 
@@ -2434,7 +2430,7 @@ class ComplexityRouter(CustomLogger):
             body if isinstance(body, Mapping) else None,
             resolved_messages,
             tuple(self.config.plan_mode_patterns or ()),
-            self._reminder_markers,
+            self._reminder_markers_for_request(request_kwargs),
         )
 
     def _matched_housekeeping_sentinel(self, newest_ask: str | None) -> str | None:
@@ -3255,6 +3251,18 @@ class ComplexityRouter(CustomLogger):
         """
         return _extract_current_ask_and_system_prompt(messages)
 
+    def _reminder_markers_for_request(self, request_kwargs: Mapping[str, object]) -> tuple[tuple[str, str], ...]:
+        if self.config.reminder_markers is not None:
+            return self._reminder_markers
+        if any(
+            is_codex_user_agent(user_agent)
+            for metadata_key in ("litellm_metadata", "metadata")
+            if isinstance(metadata := request_kwargs.get(metadata_key), Mapping)
+            if isinstance(user_agent := metadata.get("user_agent"), str)
+        ):
+            return _CODEX_REMINDER_MARKERS
+        return _DEFAULT_REMINDER_MARKERS
+
     @staticmethod
     def _iter_metadata_dicts(request_kwargs: dict) -> list[dict]:
         """Metadata may land on `metadata` or `litellm_metadata` depending on the
@@ -3356,6 +3364,7 @@ class ComplexityRouter(CustomLogger):
         # chat-completions messages, so it is real work on every non-chat surface, and
         # both the conversation shape and the classifier read the same list.
         resolved_messages: Final = self._resolve_messages(messages, request_kwargs)
+        marker_pairs: Final = self._reminder_markers_for_request(request_kwargs)
         conversation_continuing: Final = _conversation_is_continuing(resolved_messages)
 
         use_session_affinity: Final = self._uses_tier_pin
@@ -3365,7 +3374,7 @@ class ComplexityRouter(CustomLogger):
         # In 'user_turn' mode a held pin is replayed only on continuation turns; a new human
         # ask falls through and re-classifies. session_affinity restores pin-first for asks too.
         pin_replay_allowed: Final = bool(self.config.session_affinity) or not _newest_turn_is_human_ask(
-            resolved_messages, self._reminder_markers
+            resolved_messages, marker_pairs
         )
 
         if cache_key is not None and pin_replay_allowed:
@@ -3376,7 +3385,7 @@ class ComplexityRouter(CustomLogger):
                 pin_escalation_keyword: str | None = None
                 if self.escalation_keywords:
                     user_message: Final = (
-                        _newest_turn_ask(resolved_messages, self._reminder_markers) if resolved_messages else None
+                        _newest_turn_ask(resolved_messages, marker_pairs) if resolved_messages else None
                     )
                     if user_message is not None:
                         pin_escalation_keyword = self._matched_escalation_keyword(user_message)
@@ -3564,7 +3573,8 @@ class ComplexityRouter(CustomLogger):
         # Determine whether the original request used messages directly
         has_original_messages: Final = messages is not None and len(messages) > 0
 
-        user_message, system_prompt = _extract_current_ask_and_system_prompt(resolved_messages, self._reminder_markers)
+        marker_pairs: Final = self._reminder_markers_for_request(request_kwargs)
+        user_message, system_prompt = _extract_current_ask_and_system_prompt(resolved_messages, marker_pairs)
         classifier_images: Final = self._classifier_image_parts(resolved_messages)
 
         if user_message is None and not classifier_images:
@@ -3598,7 +3608,7 @@ class ComplexityRouter(CustomLogger):
             )
 
         ask: Final = user_message or ""
-        newest_ask: Final = _newest_turn_ask(resolved_messages, self._reminder_markers)
+        newest_ask: Final = _newest_turn_ask(resolved_messages, marker_pairs)
         escalation_keyword: Final = self._matched_escalation_keyword(newest_ask) if newest_ask is not None else None
         # Resolved here rather than beside the classifier because the keyword-override path below
         # returns before any classification runs, and a forced tier gets stuck for the same reason

--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -599,6 +599,18 @@ def _last_human_ask_index(
     )
 
 
+def _is_reminder_only_turn(message: Mapping[str, object], marker_pairs: tuple[tuple[str, str], ...]) -> bool:
+    if message.get("role") != "user":
+        return False
+    content: Final = message.get("content")
+    if not isinstance(content, str) and not (
+        isinstance(content, list) and all(isinstance(part, Mapping) and part.get("type") == "text" for part in content)
+    ):
+        return False
+    text: Final = _message_text(content)
+    return bool(text.strip()) and not _strip_reminder_blocks(text, marker_pairs)
+
+
 def _newest_turn_is_human_ask(
     messages: Sequence[Mapping[str, object]] | None,
     marker_pairs: tuple[tuple[str, str], ...] = _DEFAULT_REMINDER_MARKERS,
@@ -609,21 +621,23 @@ def _newest_turn_is_human_ask(
     Anchored on `_last_human_ask_index` so every surface's plumbing reads as a continuation:
     chat-completions tool turns are role=tool, Messages-surface tool_result turns flatten to empty
     human text, and a hybrid turn carrying an ask alongside a tool_result still counts as an ask.
-    Compared against the newest non-system message rather than the raw tail, because Claude Code
-    appends a system-role reminder after the human turn; that trailing plumbing is neither an ask
-    nor loop traffic and must not turn a fresh ask into a continuation. An unreadable request (no
-    messages) is treated as a continuation: there is no ask to classify, which is the same reading
-    `_extract_current_ask_and_system_prompt` gives it downstream.
+    Trailing system messages and complete text-only reminders do not turn a fresh ask into a
+    continuation. Assistant turns and non-text content, including tool results alongside reminders,
+    still form continuation boundaries. An unreadable request has no ask to classify.
     """
     if not messages:
         return False
-    newest_non_system: Final = next(
-        (index for index in range(len(messages) - 1, -1, -1) if messages[index].get("role") != "system"),
+    newest_activity: Final = next(
+        (
+            index
+            for index in range(len(messages) - 1, -1, -1)
+            if messages[index].get("role") != "system" and not _is_reminder_only_turn(messages[index], marker_pairs)
+        ),
         None,
     )
-    if newest_non_system is None:
+    if newest_activity is None:
         return False
-    return _last_human_ask_index(messages, marker_pairs) == newest_non_system
+    return _last_human_ask_index(messages, marker_pairs) == newest_activity
 
 
 def _iter_system_scope_texts(

--- a/litellm/router_strategy/complexity_router/config.py
+++ b/litellm/router_strategy/complexity_router/config.py
@@ -1292,8 +1292,9 @@ class ComplexityRouterConfig(BaseModel):
             "Override the delimiter pairs used to recognize and strip harness-injected reminder "
             "blocks before classification. A harness that wraps injected context differently per "
             "agent type (main, subagent, cron) lists every pair it emits. Replaces, rather than "
-            "adds to, the built-in system-reminder and Codex envelope pairs, so list every "
-            "built-in pair your harness also emits. Matching is case-insensitive."
+            "adds to, the built-in system-reminder pair and the Codex envelope pairs enabled "
+            "for Codex user agents, so list every built-in pair your harness also emits. "
+            "Matching is case-insensitive."
         ),
     )
 

--- a/litellm/router_strategy/complexity_router/config.py
+++ b/litellm/router_strategy/complexity_router/config.py
@@ -1292,8 +1292,8 @@ class ComplexityRouterConfig(BaseModel):
             "Override the delimiter pairs used to recognize and strip harness-injected reminder "
             "blocks before classification. A harness that wraps injected context differently per "
             "agent type (main, subagent, cron) lists every pair it emits. Replaces, rather than "
-            "adds to, the built-in default of ('<system-reminder>', '</system-reminder>'), so a "
-            "harness that also emits that pair lists it too. Matching is case-insensitive."
+            "adds to, the built-in system-reminder and Codex envelope pairs, so list every "
+            "built-in pair your harness also emits. Matching is case-insensitive."
         ),
     )
 

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -5,6 +5,7 @@ Tests the rule-based complexity scoring and tier assignment logic.
 """
 
 import asyncio
+from copy import deepcopy
 import logging
 import sys
 import time
@@ -194,7 +195,14 @@ class TestComplexityRouterInit:
             complexity_router_config=basic_config,
         )
 
-        assert router._reminder_markers == (("<system-reminder>", "</system-reminder>"),)
+        from litellm.router_strategy.complexity_router.complexity_router import _extract_current_ask_and_system_prompt
+
+        assert (
+            _extract_current_ask_and_system_prompt(
+                [{"role": "user", "content": "<system-reminder>noise</system-reminder>hello"}], router._reminder_markers
+            )[0]
+            == "hello"
+        )
 
     def test_init_without_config(self, mock_router_instance):
         """Test initialization without configuration uses defaults."""
@@ -7601,10 +7609,102 @@ _ASKED = {"role": "user", "content": _ASK}
 _ANSWERED = {"role": "assistant", "content": "Working on it."}
 _TOOL_RESULT = {"type": "tool_result", "tool_use_id": "x", "content": "out"}
 _REMINDER = "<system-reminder>Budget: 42 tokens remaining. Do not mention this.</system-reminder>"
+_CODEX_NEW_TASK: Final = (
+    "Message Type: NEW_TASK\nTask name: /root/cache_worker\nSender: /root\nPayload:\n"
+    "Implement and test a thread-safe bounded LRU cache."
+)
+_CODEX_ENVELOPES: Final = (
+    "<environment_context>LITELLM ESCALATE cwd=/repo</environment_context>",
+    "<recommended_plugins>LITELLM ESCALATE plugin list</recommended_plugins>",
+    "<user_instructions>LITELLM ESCALATE preferences</user_instructions>",
+    "<environments_instructions>LITELLM ESCALATE environment</environments_instructions>",
+    "# AGENTS.md instructions for /repo with spaces/中文\n<INSTRUCTIONS>LITELLM ESCALATE instructions</INSTRUCTIONS>",
+)
 
 
 class TestContextAwareClassifier:
     """Test the new classifier context window and trajectory signals."""
+
+    @pytest.mark.parametrize("envelope", _CODEX_ENVELOPES)
+    def test_codex_envelopes_preserve_delegated_task_and_prior_context(self, envelope: str) -> None:
+        from litellm.router_strategy.complexity_router.complexity_router import (
+            _extract_current_ask_and_system_prompt,
+            _extract_prior_turns,
+            _newest_turn_ask,
+            _newest_turn_is_human_ask,
+        )
+
+        messages: Final = [
+            {"role": "user", "content": f"{envelope}\nDesign cache invalidation"},
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": envelope}, {"type": "text", "text": _CODEX_NEW_TASK}],
+            },
+            {"role": "developer", "content": "<permissions instructions>developer scope</permissions instructions>"},
+            {"role": "user", "content": envelope},
+        ]
+
+        assert _extract_current_ask_and_system_prompt(messages)[0] == _CODEX_NEW_TASK
+        assert _extract_prior_turns(messages, _CODEX_NEW_TASK, 1, 100, None, False) == (
+            ("user", "Design cache invalidation"),
+        )
+        assert _newest_turn_ask(messages) is None
+        assert _newest_turn_is_human_ask(messages) is False
+        assert _extract_current_ask_and_system_prompt([messages[-1]])[0] is None
+
+    @pytest.mark.parametrize("envelope", _CODEX_ENVELOPES)
+    def test_codex_marker_override_and_incomplete_blocks_preserve_text(self, envelope: str) -> None:
+        from litellm.router_strategy.complexity_router.complexity_router import _strip_reminder_blocks
+
+        incomplete: Final = envelope.rsplit("</", 1)[0]
+        assert _strip_reminder_blocks(f"before {envelope.upper()} after") == "before after"
+        assert _strip_reminder_blocks(incomplete) == incomplete
+        assert _strip_reminder_blocks(f"<custom>noise</custom>{envelope}", (("<custom>", "</custom>"),)) == envelope
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("responses_api", (False, True))
+    async def test_codex_routing_preserves_original_request(self, responses_api: bool) -> None:
+        completion: Final = AsyncMock(return_value=_llm_response('{"tier":"COMPLEX"}'))
+        router: Final = ComplexityRouter(
+            model_name="codex-router",
+            litellm_router_instance=MagicMock(acompletion=completion),
+            complexity_router_config={
+                "tiers": {"COMPLEX": "task-model", "REASONING": "escalated-model"},
+                "classifier_type": "llm",
+                "classifier_llm_config": {"model": "classifier-model"},
+                "keyword_tier_rules": [{"keywords": ["LITELLM ESCALATE"], "tier": "REASONING"}],
+            },
+        )
+        messages: Final = [
+            {"role": "user", "content": _CODEX_NEW_TASK},
+            {"role": "user", "content": "\n".join(_CODEX_ENVELOPES)},
+        ]
+        original: Final = deepcopy(messages)
+        request_kwargs: Final = (
+            {"input": messages, "litellm_metadata": {"user_api_key_request_route": "/v1/responses"}}
+            if responses_api
+            else {}
+        )
+
+        response: Final = await router.async_pre_routing_hook(
+            model="codex-router",
+            request_kwargs=request_kwargs,
+            messages=None if responses_api else messages,
+            input=messages if responses_api else None,
+        )
+
+        assert response is not None
+        assert response.model == "task-model"
+        completion.assert_awaited_once()
+        assert completion.call_args.kwargs["messages"][1]["content"].strip() == (
+            f"Classify this message:\n{_CODEX_NEW_TASK}"
+        )
+        assert messages == original
+        if responses_api:
+            assert response.messages is None
+            assert request_kwargs["input"] == original
+        else:
+            assert response.messages == original
 
     @pytest.mark.parametrize(
         "messages,expected_ask",
@@ -13661,6 +13761,7 @@ class _OutputCeilingRecorder(CustomLogger):
 
     def log_pre_api_call(self, model, messages, kwargs):
         self.seen.append((model, kwargs.get("optional_params", {}).get("max_tokens")))
+
 
 NON_REASONING_TIERS: Final = {
     "NON_REASONING": "gpt-4o-mini",

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -7625,6 +7625,102 @@ _CODEX_ENVELOPES: Final = (
 class TestContextAwareClassifier:
     """Test the new classifier context window and trajectory signals."""
 
+    @pytest.mark.parametrize(
+        "tail,expected",
+        (
+            ([{"role": "user", "content": [{"type": "text", "text": _CODEX_ENVELOPES[0]}]}], True),
+            ([{"role": "assistant", "content": _CODEX_ENVELOPES[0]}], False),
+            ([{"role": "tool", "content": _CODEX_ENVELOPES[0]}], False),
+            ([{"role": "user", "content": " "}], False),
+            (
+                [{"role": "user", "content": [_TOOL_RESULT, {"type": "text", "text": _CODEX_ENVELOPES[0]}]}],
+                False,
+            ),
+            (
+                [{"role": "user", "content": [{"type": "image_url"}, {"type": "text", "text": _CODEX_ENVELOPES[0]}]}],
+                False,
+            ),
+        ),
+    )
+    def test_only_text_reminder_tails_are_ignored_for_new_asks(self, tail: list[dict[str, object]], expected: bool) -> None:
+        from litellm.router_strategy.complexity_router.complexity_router import (
+            _CODEX_REMINDER_MARKERS,
+            _newest_turn_is_human_ask,
+        )
+
+        assert _newest_turn_is_human_ask([_ASKED, *tail], _CODEX_REMINDER_MARKERS) is expected
+        assert _newest_turn_is_human_ask(tail, _CODEX_REMINDER_MARKERS) is False
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("new_ask", (_CODEX_NEW_TASK, "Now design cache invalidation"))
+    @pytest.mark.parametrize("responses_api", (False, True))
+    @pytest.mark.parametrize("session_affinity", (False, True))
+    async def test_codex_tail_preserves_new_ask_and_tool_continuation_boundaries(
+        self, new_ask: str, responses_api: bool, session_affinity: bool
+    ) -> None:
+        completion: Final = AsyncMock(
+            side_effect=[_llm_response('{"tier":"SIMPLE"}'), _llm_response('{"tier":"COMPLEX"}')]
+        )
+        router: Final = ComplexityRouter(
+            model_name="router",
+            litellm_router_instance=MagicMock(acompletion=completion, cache=DualCache()),
+            complexity_router_config={
+                "tiers": {"SIMPLE": "simple-model", "COMPLEX": "task-model"},
+                "classifier_type": "llm",
+                "classifier_llm_config": {"model": "classifier-model"},
+                "classification_mode": "user_turn",
+                "session_affinity": session_affinity,
+                "escalation_keywords": [],
+            },
+        )
+        metadata: Final = {"user_agent": "codex-tui", "session_id": "codex-tail-session"}
+        first_messages: Final = [{"role": "user", "content": "Hello"}]
+        tail: Final = [{"role": "user", "content": envelope} for envelope in _CODEX_ENVELOPES]
+        new_messages: Final = [
+            *first_messages,
+            {"role": "assistant", "content": "Hello"},
+            {"role": "user", "content": new_ask},
+            *tail,
+        ]
+        continuation: Final = [
+            *new_messages,
+            {"role": "assistant", "content": "Working on it"},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "read-cache", "content": "cache source"},
+                    {"type": "text", "text": _CODEX_ENVELOPES[0]},
+                ],
+            },
+            *tail,
+        ]
+        results: Final = [
+            await router.async_pre_routing_hook(
+                model="router",
+                request_kwargs=(
+                    {"input": messages, "litellm_metadata": {**metadata, "user_api_key_request_route": "/v1/responses"}}
+                    if responses_api
+                    else {"metadata": metadata}
+                ),
+                messages=None if responses_api else messages,
+                input=messages if responses_api else None,
+            )
+            for messages in (first_messages, new_messages, continuation)
+        ]
+
+        assert [result.model for result in results] == (
+            ["simple-model", "simple-model", "simple-model"]
+            if session_affinity
+            else ["simple-model", "task-model", "task-model"]
+        )
+        assert completion.await_count == (1 if session_affinity else 2)
+        assert results[-1].routing_decision["cause"] == (
+            "session_affinity_pin" if session_affinity else "user_turn_continuation"
+        )
+        if not session_affinity:
+            assert completion.call_args.kwargs["messages"][1]["content"].endswith(f"Classify this message:\n{new_ask}")
+        assert results[1].messages == (None if responses_api else new_messages)
+
     @pytest.mark.asyncio
     @pytest.mark.parametrize("envelope", _CODEX_ENVELOPES)
     @pytest.mark.parametrize("user_agent", (None, "curl/8.7.1", "codexify/1.0"))

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -7625,9 +7625,38 @@ _CODEX_ENVELOPES: Final = (
 class TestContextAwareClassifier:
     """Test the new classifier context window and trajectory signals."""
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("envelope", _CODEX_ENVELOPES)
+    @pytest.mark.parametrize("user_agent", (None, "curl/8.7.1", "codexify/1.0"))
+    async def test_non_codex_requests_preserve_tagged_asks(self, envelope: str, user_agent: str | None) -> None:
+        completion: Final = AsyncMock(return_value=_llm_response('{"tier":"COMPLEX"}'))
+        router: Final = ComplexityRouter(
+            model_name="router",
+            litellm_router_instance=MagicMock(acompletion=completion),
+            complexity_router_config={
+                "tiers": {"COMPLEX": "task-model"},
+                "default_model": "fallback-model",
+                "classifier_type": "llm",
+                "classifier_llm_config": {"model": "classifier-model"},
+                "escalation_keywords": [],
+            },
+        )
+
+        response: Final = await router.async_pre_routing_hook(
+            model="router",
+            request_kwargs={"metadata": {"user_agent": user_agent}} if user_agent is not None else {},
+            messages=[{"role": "user", "content": envelope}],
+        )
+
+        assert response is not None
+        assert response.model == "task-model"
+        completion.assert_awaited_once()
+        assert completion.call_args.kwargs["messages"][1]["content"].strip() == f"Classify this message:\n{envelope}"
+
     @pytest.mark.parametrize("envelope", _CODEX_ENVELOPES)
     def test_codex_envelopes_preserve_delegated_task_and_prior_context(self, envelope: str) -> None:
         from litellm.router_strategy.complexity_router.complexity_router import (
+            _CODEX_REMINDER_MARKERS,
             _extract_current_ask_and_system_prompt,
             _extract_prior_turns,
             _newest_turn_ask,
@@ -7644,21 +7673,25 @@ class TestContextAwareClassifier:
             {"role": "user", "content": envelope},
         ]
 
-        assert _extract_current_ask_and_system_prompt(messages)[0] == _CODEX_NEW_TASK
-        assert _extract_prior_turns(messages, _CODEX_NEW_TASK, 1, 100, None, False) == (
+        assert _extract_current_ask_and_system_prompt(messages, _CODEX_REMINDER_MARKERS)[0] == _CODEX_NEW_TASK
+        assert _extract_prior_turns(messages, _CODEX_NEW_TASK, 1, 100, None, False, _CODEX_REMINDER_MARKERS) == (
             ("user", "Design cache invalidation"),
         )
-        assert _newest_turn_ask(messages) is None
-        assert _newest_turn_is_human_ask(messages) is False
-        assert _extract_current_ask_and_system_prompt([messages[-1]])[0] is None
+        assert _newest_turn_ask(messages, _CODEX_REMINDER_MARKERS) is None
+        assert _newest_turn_is_human_ask(messages, _CODEX_REMINDER_MARKERS) is False
+        assert _extract_current_ask_and_system_prompt([messages[-1]], _CODEX_REMINDER_MARKERS)[0] is None
 
     @pytest.mark.parametrize("envelope", _CODEX_ENVELOPES)
     def test_codex_marker_override_and_incomplete_blocks_preserve_text(self, envelope: str) -> None:
-        from litellm.router_strategy.complexity_router.complexity_router import _strip_reminder_blocks
+        from litellm.router_strategy.complexity_router.complexity_router import (
+            _CODEX_REMINDER_MARKERS,
+            _strip_reminder_blocks,
+        )
 
         incomplete: Final = envelope.rsplit("</", 1)[0]
-        assert _strip_reminder_blocks(f"before {envelope.upper()} after") == "before after"
-        assert _strip_reminder_blocks(incomplete) == incomplete
+        assert _strip_reminder_blocks(f"before {envelope.upper()} after", _CODEX_REMINDER_MARKERS) == "before after"
+        assert _strip_reminder_blocks(incomplete, _CODEX_REMINDER_MARKERS) == incomplete
+        assert _strip_reminder_blocks(envelope) == envelope
         assert _strip_reminder_blocks(f"<custom>noise</custom>{envelope}", (("<custom>", "</custom>"),)) == envelope
 
     @pytest.mark.asyncio
@@ -7681,9 +7714,12 @@ class TestContextAwareClassifier:
         ]
         original: Final = deepcopy(messages)
         request_kwargs: Final = (
-            {"input": messages, "litellm_metadata": {"user_api_key_request_route": "/v1/responses"}}
+            {
+                "input": messages,
+                "litellm_metadata": {"user_api_key_request_route": "/v1/responses", "user_agent": "codex-tui"},
+            }
             if responses_api
-            else {}
+            else {"metadata": {"user_agent": "codex-tui"}}
         )
 
         response: Final = await router.async_pre_routing_hook(
@@ -7705,6 +7741,46 @@ class TestContextAwareClassifier:
             assert request_kwargs["input"] == original
         else:
             assert response.messages == original
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("custom_markers", (False, True))
+    async def test_codex_markers_are_request_scoped_and_respect_overrides(self, custom_markers: bool) -> None:
+        completion: Final = AsyncMock(return_value=_llm_response('{"tier":"COMPLEX"}'))
+        router: Final = ComplexityRouter(
+            model_name="router",
+            litellm_router_instance=MagicMock(acompletion=completion),
+            complexity_router_config={
+                "tiers": {"COMPLEX": "task-model"},
+                "classifier_type": "llm",
+                "classifier_llm_config": {"model": "classifier-model"},
+                "classifier_context_window_size": 2,
+                "escalation_keywords": [],
+                **({"reminder_markers": [{"open": "<custom>", "close": "</custom>"}]} if custom_markers else {}),
+            },
+        )
+        envelope: Final = "\n".join(_CODEX_ENVELOPES)
+        prior: Final = f"{envelope}\nDesign cache invalidation"
+        messages: Final = [
+            {"role": "user", "content": prior},
+            {"role": "user", "content": _CODEX_NEW_TASK},
+            {"role": "user", "content": envelope},
+        ]
+        for user_agent in ("codex-tui", "curl/8.7.1", "codex_cli_rs/0.62.0"):
+            response: Final = await router.async_pre_routing_hook(
+                model="router", request_kwargs={"metadata": {"user_agent": user_agent}}, messages=messages
+            )
+            assert response is not None
+            assert response.model == "task-model"
+            payload: Final = completion.call_args.kwargs["messages"][1]["content"]
+            if user_agent.startswith("codex") and not custom_markers:
+                assert payload.endswith(f"Classify this message:\n{_CODEX_NEW_TASK}")
+                assert "Design cache invalidation" in payload
+                assert "LITELLM ESCALATE" not in payload
+            else:
+                assert payload.endswith(f"Classify this message:\n{envelope}")
+                assert prior in payload
+            assert response.messages == messages
+        assert completion.await_count == 3
 
     @pytest.mark.parametrize(
         "messages,expected_ask",

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -35221,7 +35221,7 @@ export interface components {
             reasoning_override_min_score?: number | null;
             /**
              * Reminder Markers
-             * @description Override the delimiter pairs used to recognize and strip harness-injected reminder blocks before classification. A harness that wraps injected context differently per agent type (main, subagent, cron) lists every pair it emits. Replaces, rather than adds to, the built-in default of ('<system-reminder>', '</system-reminder>'), so a harness that also emits that pair lists it too. Matching is case-insensitive.
+             * @description Override the delimiter pairs used to recognize and strip harness-injected reminder blocks before classification. A harness that wraps injected context differently per agent type (main, subagent, cron) lists every pair it emits. Replaces, rather than adds to, the built-in system-reminder pair and the Codex envelope pairs enabled for Codex user agents, so list every built-in pair your harness also emits. Matching is case-insensitive.
              */
             reminder_markers?: components["schemas"]["ReminderMarkerPair"][] | null;
             /**


### PR DESCRIPTION
## TLDR

Problem this solves:

- Codex harness messages can displace the delegated classification task

How it solves it:

- Strip Codex envelopes only for recognized Codex user agents
- Keep other clients' tagged asks intact
- Preserve delegated tasks and original routed request content
- Reclassify fresh asks followed by text-only reminder tails

## User Flow

Before: Codex's trailing harness message displaces the delegated task used to choose a model

1. The developer sends POST http://127.0.0.1:17492/v1/responses with `model: auto/codex-user-turn`, `User-Agent: codex-tui`, `session-id: pin-responses-session-7492`, and the seed request below
2. They send the new `NEW_TASK` request on the same session, followed by Codex envelopes. The classification request contains the envelope as its current message
3. They append an assistant response and another envelope-only tail. The gateway classifies the harness message again

After: The new task gets classified and subsequent continuation traffic keeps its selected model

1. The developer sends POST http://127.0.0.1:17493/v1/responses with `model: auto/codex-user-turn`, `User-Agent: codex-tui`, `session-id: pin-responses-session-7492`, and the seed request below
2. They send the new `NEW_TASK` request on the same session, followed by Codex envelopes. The classification request contains the complete delegated task as its current message
3. They append an assistant response and another envelope-only tail. The gateway reuses the task's selected model without another classification call

## Relevant issues

## Linear ticket

Resolves LIT-7492

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves one specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

The full complexity-router test file passed: 953 passed, 14 existing skips. `make check` passed. Four new session-reclassification cases failed against the previous PR tip and pass with this fix, covering delegated tasks and later asks on Chat Completions and Responses. Additional cases verify explicit session affinity, text-only content parts, and assistant/tool continuation boundaries

## Screenshots / Proof of Fix

Fresh live verification is blocked by the sandbox returning HTTP 503. Both local proxies start successfully, but the upstream rejects the seed, task, and continuation requests on all three endpoints. No session seed succeeds, so this run cannot verify pin reuse or claim successful paid inference. The earlier successful captures have been replaced because they were from a previous PR tip

The sandbox itself also returned 503:

```sh
curl --silent --show-error --max-time 10 -o /dev/null -w 'HTTP %{http_code}\n' \
  https://gateway.litellm-sandbox.ai/health/liveliness
```

```text
HTTP 503
```

Run each checkout with the same config and a writable QA directory. Set `LIT7492_GATEWAY_URL` to the sandbox's OpenAI-compatible base URL, including `/v1`, and set `LIT7492_GATEWAY_KEY` from a private environment variable. The key is not included here. The classifier and every routed tier call the real `openai/gpt-5.6-luna` deployment; upstream response caching is disabled

<details>
<summary>Shared config, request bodies, and read-only capture setup</summary>

Save `config.yaml`:

```yaml
model_list:
  - model_name: auto/codex-subagent
    litellm_params:
      model: auto_router/complexity_router
      complexity_router_config: &classification
        classifier_type: llm
        classifier_llm_config:
          model: classifier
          timeout_ms: 60000
          reasoning_effort: low
        tiers:
          SIMPLE: simple-model
          MEDIUM: medium-model
          COMPLEX: complex-model
          REASONING: reasoning-model
  - model_name: auto/codex-user-turn
    litellm_params:
      model: auto_router/complexity_router
      complexity_router_config:
        <<: *classification
        classification_mode: user_turn
  - model_name: classifier
    litellm_params: &upstream
      model: openai/openai/gpt-5.6-luna
      api_base: os.environ/LIT7492_GATEWAY_URL
      api_key: os.environ/LIT7492_GATEWAY_KEY
      extra_body:
        cache:
          no-cache: true
          no-store: true
  - model_name: simple-model
    litellm_params: *upstream
  - model_name: medium-model
    litellm_params: *upstream
  - model_name: complex-model
    litellm_params: *upstream
  - model_name: reasoning-model
    litellm_params: *upstream
litellm_settings:
  callbacks: audit.audit
  drop_params: true
  telemetry: false
general_settings:
  master_key: sk-lit7492-local
router_settings:
  num_retries: 0
```

Save `audit.py`. This existing callback interface observes the provider-bound request and completed classifier call without changing either:

```python
import json
import os
from pathlib import Path
from litellm.integrations.custom_logger import CustomLogger

class Audit(CustomLogger):
    def write(self, payload):
        with Path(os.environ['LIT7492_AUDIT']).open('a') as output:
            output.write(json.dumps(payload, default=str) + '\n')

    def log_pre_api_call(self, model, messages, kwargs):
        additional = kwargs.get('additional_args') or {}
        body = additional.get('complete_input_dict') or {}
        self.write({
            'event': 'provider_request',
            'model': model,
            'messages': messages,
            'body': {key: body[key] for key in ('model', 'messages', 'input', 'instructions') if key in body},
        })

    async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
        standard = kwargs.get('standard_logging_object') or {}
        self.write({
            'event': 'success',
            'model': kwargs.get('model'),
            'model_group': standard.get('model_group'),
            'messages': kwargs.get('messages'),
            'input': kwargs.get('input'),
            'cost': kwargs.get('response_cost'),
            'response_id': getattr(response_obj, 'id', None),
            'routing_decision': (standard.get('metadata') or {}).get('routing_decision'),
        })

audit = Audit()
```

Save `summarize.jq`:

```jq
. as $rows
| ($source[0] | [.. | strings | select(startswith("Message Type: NEW_TASK"))][0]) as $task
| ($task | split("\n")[1]) as $task_name
| ($source[0] | [.. | strings | select(startswith("<recommended_plugins>"))][0]) as $envelopes
| ($rows | map(select(.event == "success" and .model_group == "classifier" and (.messages | tostring | contains($task_name)))) | last) as $classifier
| ($rows | map(select(.event == "provider_request" and (.body | tostring | contains($task_name)) and (.body | tostring | contains("Classify this message:") | not))) | last | .body | [.. | strings] | join("\n")) as $routed
| {
    classifier_current_message_first_line: ($classifier.messages[1].content | split("Classify this message:\n")[1] | split("\n")[0]),
    classifier_current_task_matches: (($classifier.messages[1].content | split("Classify this message:\n")[1]) == $task),
    routed_task_preserved: ($routed | contains($task)),
    routed_envelopes_preserved: ($routed | contains($envelopes)),
    classifier_cost_usd: $classifier.cost
  }
```

Save `summarize-plain.jq` for the ordinary-client cases:

```jq
. as $rows
| ($source[0] | [.. | strings | select(startswith("<environment_context>"))][0]) as $ask
| ($ask | capture("(?<id>TAGGED_ASK_[A-Z]+_7492)").id) as $case_id
| ($rows | map(select(.event == "success" and .model_group == "classifier" and (.messages | tostring | contains($case_id)))) | last) as $classifier
| ($rows | map(select(.event == "provider_request" and (.body | tostring | contains($case_id)) and (.body | tostring | contains("Classify this message:") | not))) | last | .body | [.. | strings] | join("\n")) as $routed
| {
    classifier_current_ask_matches: (($classifier.messages[1].content | split("Classify this message:\n")[1]) == $ask),
    routed_ask_preserved: ($routed | contains($ask)),
    classifier_cost_usd: $classifier.cost
  }
```

Save `task.txt`:

```text
Message Type: NEW_TASK
Task name: /root/cache_worker_CASE_7492
Sender: /root
Payload:
Implement and test a thread-safe bounded LRU cache.
```

Save `envelopes.txt`:

```text
<recommended_plugins>PLUGIN_CANARY: no optional plugins</recommended_plugins>
# AGENTS.md instructions for /worktree/cache
<INSTRUCTIONS>AGENTS_CANARY: follow repository conventions</INSTRUCTIONS>
<user_instructions>USER_CANARY: use concise output</user_instructions>
<environments_instructions>ENV_INSTRUCTIONS_CANARY: workspace is writable</environments_instructions>
<environment_context>ENV_CANARY: ORIGINAL_REQUEST; cwd=/worktree/cache; shell=zsh; date=2026-09-10</environment_context>
```

Save `system.txt`:

```text
For this verification, acknowledge the delegated task in one short sentence and quote the ENV_CANARY value. Do not write the implementation.
```

Build the three request bodies in the QA directory:

```sh
for case in chat responses messages; do
  jq -n --arg case "$case" \
    --rawfile task task.txt --rawfile envelopes envelopes.txt \
    '{model: "auto/codex-subagent", messages: [
      {role: "user", content: ($task | rtrimstr("\n") | sub("CASE"; $case))},
      {role: "user", content: ($envelopes | rtrimstr("\n"))}
    ]}' > "$case.source.json"
done
jq --rawfile system system.txt \
  '.messages = [{role: "system", content: ($system | rtrimstr("\n"))}] + .messages | .max_completion_tokens = 256' \
  chat.source.json > chat.json
jq --rawfile system system.txt \
  '{model, instructions: ($system | rtrimstr("\n")), max_output_tokens: 256, input: [.messages[] |
    {type: "message", role, content: [{type: "input_text", text: .content}]}]}' \
  responses.source.json > responses.json
jq --rawfile system system.txt \
  '.system = ($system | rtrimstr("\n")) | .max_tokens = 256' \
  messages.source.json > messages.json
```

For the merge-base checkout, run from the QA directory with `CHECKOUT` pointing to `6c69dd0f72`:

```sh
PYTHONPATH="$CHECKOUT:$PWD" LITELLM_MODE=PRODUCTION PYTHON_DOTENV_DISABLED=1 \
  LIT7492_AUDIT="$PWD/before.jsonl" \
  python -m litellm.proxy.proxy_cli --config "$PWD/config.yaml" --host 127.0.0.1 --port 17492
```

For the PR checkout, run from the same directory with `CHECKOUT` pointing to `181b3fd94a`:

```sh
PYTHONPATH="$CHECKOUT:$PWD" LITELLM_MODE=PRODUCTION PYTHON_DOTENV_DISABLED=1 \
  LIT7492_AUDIT="$PWD/after.jsonl" \
  python -m litellm.proxy.proxy_cli --config "$PWD/config.yaml" --host 127.0.0.1 --port 17493
```

Use a Python environment with LiteLLM's proxy dependencies installed and no database environment variables for these standalone QA processes


Build the session requests, using the `case.source.json` files generated above:

```sh
for case in chat responses messages; do
  jq -n --arg case "$case" --slurpfile source "$case.source.json" '
    {role: "user", content: ("Say hello. PIN_SEED_" + ($case | ascii_upcase) + "_7492")} as $seed
    | ($source[0].messages | .[0].content |= sub("cache_worker_" + $case + "_7492"; "cache_worker_" + $case + "_pin_7492")) as $task
    | ([$seed, {role: "assistant", content: "Hello"}] + $task) as $new
    | {seed: [$seed], task: $new, continuation: ($new + [{role: "assistant", content: "Delegated task accepted"}, $task[1]])}
  ' > "pin-$case.steps.json"
  for step in seed task continuation; do
    jq --arg case "$case" --arg step "$step" \
      --arg system 'For this verification, acknowledge the latest user task in one short sentence. Do not write the implementation.' '
      {model: "auto/codex-user-turn", messages: .[$step]}
      | if $case == "responses" then
          {model, instructions: $system, max_output_tokens: 256, input: [.messages[] | {type: "message", role, content}]}
        elif $case == "chat" then
          .messages = [{role: "system", content: $system}] + .messages | .max_completion_tokens = 256
        else .system = $system | .max_tokens = 256 end
    ' "pin-$case.steps.json" > "pin-$case-$step.json"
  done
done
```

The requests seed a session, submit a new delegated task followed by Codex envelopes, then append an assistant turn and another envelope-only tail. Once the sandbox is available, the expected after behavior is two classifier calls, a fresh decision for the delegated task, and `user_turn_continuation` for the third request

</details>

### Before (6c69dd0f72)

#### Chat Completions

1. Send the session's seed, new task, and continuation in order:

   ```sh
   for step in seed task continuation; do
     curl --silent --show-error --max-time 90 http://127.0.0.1:17492/v1/chat/completions \
       -H 'Authorization: Bearer sk-lit7492-local' -H 'Content-Type: application/json' \
       -H 'User-Agent: codex-tui' -H 'session-id: pin-chat-session-7492' \
       -H 'anthropic-version: 2023-06-01' --data-binary "@pin-chat-$step.json" \
       -o "before-pin-chat-$step.json" -w "$step HTTP %{http_code}\n"
   done
   ```

   ```text
   seed HTTP 503
   task HTTP 503
   continuation HTTP 503
   ```

2. Read the task response's error type:

   ```sh
   jq -r '.error.type' before-pin-chat-task.json
   ```

   ```text
   internal_server_error
   ```

#### Responses

1. Send the session's seed, new task, and continuation in order:

   ```sh
   for step in seed task continuation; do
     curl --silent --show-error --max-time 90 http://127.0.0.1:17492/v1/responses \
       -H 'Authorization: Bearer sk-lit7492-local' -H 'Content-Type: application/json' \
       -H 'User-Agent: codex-tui' -H 'session-id: pin-responses-session-7492' \
       -H 'anthropic-version: 2023-06-01' --data-binary "@pin-responses-$step.json" \
       -o "before-pin-responses-$step.json" -w "$step HTTP %{http_code}\n"
   done
   ```

   ```text
   seed HTTP 503
   task HTTP 503
   continuation HTTP 503
   ```

2. Read the task response's error type:

   ```sh
   jq -r '.error.type' before-pin-responses-task.json
   ```

   ```text
   internal_server_error
   ```

#### Messages

1. Send the session's seed, new task, and continuation in order:

   ```sh
   for step in seed task continuation; do
     curl --silent --show-error --max-time 90 http://127.0.0.1:17492/v1/messages \
       -H 'Authorization: Bearer sk-lit7492-local' -H 'Content-Type: application/json' \
       -H 'User-Agent: codex-tui' -H 'session-id: pin-messages-session-7492' \
       -H 'anthropic-version: 2023-06-01' --data-binary "@pin-messages-$step.json" \
       -o "before-pin-messages-$step.json" -w "$step HTTP %{http_code}\n"
   done
   ```

   ```text
   seed HTTP 503
   task HTTP 503
   continuation HTTP 503
   ```

2. Read the task response's error type:

   ```sh
   jq -r '.error.type' before-pin-messages-task.json
   ```

   ```text
   api_error
   ```

### After (181b3fd94a)

#### Chat Completions

1. Send the session's seed, new task, and continuation in order:

   ```sh
   for step in seed task continuation; do
     curl --silent --show-error --max-time 90 http://127.0.0.1:17493/v1/chat/completions \
       -H 'Authorization: Bearer sk-lit7492-local' -H 'Content-Type: application/json' \
       -H 'User-Agent: codex-tui' -H 'session-id: pin-chat-session-7492' \
       -H 'anthropic-version: 2023-06-01' --data-binary "@pin-chat-$step.json" \
       -o "after-pin-chat-$step.json" -w "$step HTTP %{http_code}\n"
   done
   ```

   ```text
   seed HTTP 503
   task HTTP 503
   continuation HTTP 503
   ```

2. Read the task response's error type:

   ```sh
   jq -r '.error.type' after-pin-chat-task.json
   ```

   ```text
   internal_server_error
   ```

#### Responses

1. Send the session's seed, new task, and continuation in order:

   ```sh
   for step in seed task continuation; do
     curl --silent --show-error --max-time 90 http://127.0.0.1:17493/v1/responses \
       -H 'Authorization: Bearer sk-lit7492-local' -H 'Content-Type: application/json' \
       -H 'User-Agent: codex-tui' -H 'session-id: pin-responses-session-7492' \
       -H 'anthropic-version: 2023-06-01' --data-binary "@pin-responses-$step.json" \
       -o "after-pin-responses-$step.json" -w "$step HTTP %{http_code}\n"
   done
   ```

   ```text
   seed HTTP 503
   task HTTP 503
   continuation HTTP 503
   ```

2. Read the task response's error type:

   ```sh
   jq -r '.error.type' after-pin-responses-task.json
   ```

   ```text
   internal_server_error
   ```

#### Messages

1. Send the session's seed, new task, and continuation in order:

   ```sh
   for step in seed task continuation; do
     curl --silent --show-error --max-time 90 http://127.0.0.1:17493/v1/messages \
       -H 'Authorization: Bearer sk-lit7492-local' -H 'Content-Type: application/json' \
       -H 'User-Agent: codex-tui' -H 'session-id: pin-messages-session-7492' \
       -H 'anthropic-version: 2023-06-01' --data-binary "@pin-messages-$step.json" \
       -o "after-pin-messages-$step.json" -w "$step HTTP %{http_code}\n"
   done
   ```

   ```text
   seed HTTP 503
   task HTTP 503
   continuation HTTP 503
   ```

2. Read the task response's error type:

   ```sh
   jq -r '.error.type' after-pin-messages-task.json
   ```

   ```text
   api_error
   ```

## Type

Bug Fix

## Caveats (if any)

### Medium

- The existing scanner's Unicode case-expansion offset issue remains

### Low

- Live session verification is blocked by sandbox HTTP 503

- Codex defaults require its user agent in request metadata
- Explicit `reminder_markers` lists still replace all built-in defaults
- Unclosed envelopes retain the existing leave-intact behavior

## Final Attestation

- [x] The tests check the reported task-selection regression, surrounding text, prior context, ordinary tagged asks, request isolation, new-ask session reclassification, continuation boundaries, explicit overrides, incomplete blocks, and routed-content preservation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes complexity-router tier selection and session pin replay for Codex-identified traffic; misclassified user agents or missing metadata could leave envelopes affecting routing or strip the wrong blocks when `reminder_markers` is customized.
> 
> **Overview**
> **Codex harness envelopes no longer drive complexity-router classification** when the request is identified as a Codex client (`metadata.user_agent` / `litellm_metadata.user_agent`, or proxy-populated `User-Agent`).
> 
> `is_codex_user_agent` moves to `core_helpers` and is reused by the proxy and complexity router. For Codex user agents (and only when `reminder_markers` is unset), the router strips extra delimiter pairs—`<environment_context>`, plugin/instruction tags, and `# AGENTS.md instructions for …` through `</INSTRUCTIONS>`—in addition to `<system-reminder>`. Stripping is for classification and turn detection only; outbound messages stay unchanged.
> 
> **Turn semantics** update so trailing **text-only reminder tails** do not count as a new human ask in `user_turn` mode (via `_is_reminder_only_turn` and `_reminder_markers_for_request` wired through pin replay, classifier context, and ask extraction). Delegated `Message Type: NEW_TASK` content and tool/assistant continuations keep prior behavior. Non-Codex clients still classify tagged envelope text as the ask.
> 
> Docs, OpenAPI schema text for `reminder_markers`, and broad router tests cover Codex vs non-Codex, Responses API, session affinity, and custom marker overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 181b3fd94a17e54f0acbf42776bef36b5da4f2ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->