### PR TITLE
fix(proxy): close budget-window bypass when Redis window counter is lost

### DIFF
--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -4916,6 +4916,18 @@ async def _virtual_key_max_budget_check(
             )
 
 
+def _cumulative_window_fallback() -> bool:
+    """Key/team windows fall back to the entity's cumulative spend only when
+    both the window counter and the per-window DB total are unreadable. That
+    changed the degraded-path (DB outage during a window rollover) behavior of
+    existing setups, so it is gated behind a general_settings flag, on by
+    default because the old behavior let a lost counter read as a fresh empty
+    window and bypass the budget (#26672)."""
+    from litellm.proxy.proxy_server import general_settings
+
+    return general_settings.get("cumulative_window_fallback", True) is not False
+
+
 async def _virtual_key_multi_budget_check(
     valid_token: UserAPIKeyAuth,
 ):
@@ -4936,12 +4948,13 @@ async def _virtual_key_multi_budget_check(
 
     from litellm.proxy.proxy_server import get_current_spend
 
+    fallback_spend: Final = (valid_token.spend or 0.0) if _cumulative_window_fallback() else 0.0
     for window in valid_token.budget_limits:
         w: dict = window if isinstance(window, dict) else window.model_dump()
         counter_key = f"spend:key:{valid_token.token}:window:{w['budget_duration']}"
         window_spend = await get_current_spend(
             counter_key=counter_key,
-            fallback_spend=valid_token.spend or 0.0,
+            fallback_spend=fallback_spend,
             max_budget=w["max_budget"],
             window_entity_type="Key",
             window_entity_id=valid_token.token,
@@ -5314,12 +5327,13 @@ async def _team_multi_budget_check(
 
     from litellm.proxy.proxy_server import get_current_spend
 
+    fallback_spend: Final = (team_object.spend or 0.0) if _cumulative_window_fallback() else 0.0
     for window in team_object.budget_limits:
         w: dict = window if isinstance(window, dict) else window.model_dump()
         counter_key = f"spend:team:{team_object.team_id}:window:{w['budget_duration']}"
         window_spend = await get_current_spend(
             counter_key=counter_key,
-            fallback_spend=team_object.spend or 0.0,
+            fallback_spend=fallback_spend,
             max_budget=w["max_budget"],
             window_entity_type="Team",
             window_entity_id=team_object.team_id,

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -4926,9 +4926,10 @@ async def _virtual_key_multi_budget_check(
     Using budget_duration (not list index) keeps counters stable when windows are reordered
     or removed during a key update.
 
-    Note: counters are not seeded from DB on Redis cold-start. After a Redis flush,
-    per-window spend resets to zero within the current window period. This is an acceptable
-    trade-off: the DB stores reset_at timestamps but not per-window accumulated spend.
+    The per-window fallback is the key's cumulative spend: a conservative upper
+    bound of any single window, applied only when both the window counter and
+    the per-window DB total are unreadable, so a lost counter cannot read as a
+    fresh empty window and bypass the budget (#26672).
     """
     if not valid_token.budget_limits:
         return
@@ -4940,7 +4941,7 @@ async def _virtual_key_multi_budget_check(
         counter_key = f"spend:key:{valid_token.token}:window:{w['budget_duration']}"
         window_spend = await get_current_spend(
             counter_key=counter_key,
-            fallback_spend=0.0,
+            fallback_spend=valid_token.spend or 0.0,
             max_budget=w["max_budget"],
             window_entity_type="Key",
             window_entity_id=valid_token.token,
@@ -5303,6 +5304,10 @@ async def _team_multi_budget_check(
     Each window has its own Redis counter keyed by spend:team:{team_id}:window:{budget_duration}.
     Using budget_duration (not list index) keeps counters stable when windows are reordered
     or removed during a team update.
+
+    The per-window fallback is the team's cumulative spend, an upper bound of any
+    single window, so a counter lost to a Redis flush cannot read as a fresh
+    empty window (#26672).
     """
     if team_object is None or not team_object.budget_limits:
         return
@@ -5314,7 +5319,7 @@ async def _team_multi_budget_check(
         counter_key = f"spend:team:{team_object.team_id}:window:{w['budget_duration']}"
         window_spend = await get_current_spend(
             counter_key=counter_key,
-            fallback_spend=0.0,
+            fallback_spend=team_object.spend or 0.0,
             max_budget=w["max_budget"],
             window_entity_type="Team",
             window_entity_id=team_object.team_id,

--- a/litellm/proxy/db/spend_counter_reseed.py
+++ b/litellm/proxy/db/spend_counter_reseed.py
@@ -311,6 +311,7 @@ class SpendCounterReseed:
         entity_id: str,
         window_duration: str | None,
         window_start: datetime,
+        include_logs_floor: bool = False,
     ) -> float | None:
         """
         Authoritative window spend: the maintained row first, falling back to
@@ -318,7 +319,18 @@ class SpendCounterReseed:
 
         The aggregate range-scans an unindexed table, so it must stay a
         transitional path (window configured before the row existed) rather
-        than a steady-state read.
+        than a steady-state read. The stale-counter recheck runs
+        ``window_from_db`` every few seconds while it holds a window counter,
+        so by default (``include_logs_floor=False``) a current row
+        short-circuits before the aggregate runs.
+
+        ``include_logs_floor=True`` is for reseeding a cold counter: the row
+        lags real spend by up to one flush interval of increments queued on
+        other pods, so restoring a counter from the row alone can admit
+        traffic that already exceeded the window budget. The aggregate cannot
+        lag behind what any pod has already counted, so the reseed takes the
+        larger of the two; a cold reseed is rare by design, which keeps the
+        extra scan off the steady-state path.
         """
         if window_duration is not None:
             from_table: Final = await SpendCounterReseed.window_from_table(
@@ -329,7 +341,17 @@ class SpendCounterReseed:
                 expected_window_start=window_start,
             )
             if from_table is not None:
-                return from_table
+                if not include_logs_floor:
+                    return from_table
+                aggregate: Final = await SpendCounterReseed.window_from_spend_logs(
+                    prisma_client=prisma_client,
+                    entity_type=entity_type,
+                    entity_id=entity_id,
+                    window_start=window_start,
+                )
+                if aggregate is None:
+                    return from_table
+                return max(from_table, aggregate)
         return await SpendCounterReseed.window_from_spend_logs(
             prisma_client=prisma_client,
             entity_type=entity_type,
@@ -385,7 +407,7 @@ class SpendCounterReseed:
         entity_id: str,
         window_duration: str | None,
         window_start: datetime,
-        require_cache_warm: bool = False,
+        include_logs_floor: bool = False,
     ) -> float | None:
         lock: Final = await SpendCounterReseed._get_lock(counter_key)
         async with lock:
@@ -409,9 +431,11 @@ class SpendCounterReseed:
                 entity_id=entity_id,
                 window_duration=window_duration,
                 window_start=window_start,
+                include_logs_floor=include_logs_floor,
             )
             if window_spend is None:
                 return None
+            current_value: float = window_spend
             try:
                 if spend_counter_cache.redis_cache is not None:
                     seeded: Final = await spend_counter_cache.redis_cache.async_set_cache(
@@ -419,9 +443,13 @@ class SpendCounterReseed:
                         value=window_spend,
                         nx=True,
                     )
-                    if seeded:
-                        current_value = window_spend
-                    else:
+                    if not seeded:
+                        # NX lost: another caller reseeded the same counter
+                        # while this DB read was in flight. That value is the
+                        # one subsequent increments coordinated against, so
+                        # adopt it instead of returning an uncoordinated
+                        # snapshot (which admitted traffic past the budget
+                        # when the loser's snapshot was stale-low).
                         current_cached_value = await spend_counter_cache.redis_cache.async_get_cache(key=counter_key)
                         if current_cached_value is None:
                             current_value = await spend_counter_cache.redis_cache.async_increment(
@@ -441,6 +469,10 @@ class SpendCounterReseed:
                     "SpendCounterReseed.coalesced_window: failed to warm counter %s",
                     counter_key,
                 )
-                if require_cache_warm:
-                    raise
-            return window_spend
+                # Without a warm counter the DB snapshot never coordinated
+                # with concurrent reservations (they skipped the cold counter
+                # instead of incrementing it), so returning it here would let
+                # every subsequent read under-count their reservations. Drop
+                # it and let the caller fall back to its conservative value.
+                return None
+            return float(current_value)

--- a/litellm/proxy/db/spend_counter_reseed.py
+++ b/litellm/proxy/db/spend_counter_reseed.py
@@ -385,6 +385,7 @@ class SpendCounterReseed:
         entity_id: str,
         window_duration: str | None,
         window_start: datetime,
+        require_cache_warm: bool = False,
     ) -> float | None:
         lock: Final = await SpendCounterReseed._get_lock(counter_key)
         async with lock:
@@ -440,5 +441,6 @@ class SpendCounterReseed:
                     "SpendCounterReseed.coalesced_window: failed to warm counter %s",
                     counter_key,
                 )
-                raise
+                if require_cache_warm:
+                    raise
             return window_spend

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -2744,6 +2744,7 @@ async def _read_spend_counter_estimate(
             entity_id=window_entity_id,
             window_duration=window_duration,
             window_start=window_start,
+            include_logs_floor=True,
         )
         if window_spend is not None:
             return window_spend, True
@@ -3304,7 +3305,7 @@ async def _ensure_window_spend_counter_initialized(
         entity_id=entity_id,
         window_duration=window_duration,
         window_start=window_start,
-        require_cache_warm=True,
+        include_logs_floor=True,
     )
     if window_spend is None:
         verbose_proxy_logger.warning(

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -2501,7 +2501,9 @@ async def get_current_spend(
     Fallback chain:
     1. Redis counter (cross-pod, authoritative)
     2. In-memory counter (single-instance or Redis failure)
-    3. Reseed from authoritative DB spend (counter expired, cross-pod stale)
+    3. Reseed from authoritative DB spend (counter expired, cross-pod stale):
+       entity rows for primary counters, the maintained window-spend row (or
+       spend-logs aggregate) for per-window counters
     4. Caller-supplied fallback (DB unavailable, cold start)
 
     When ``max_budget`` is supplied, the counter is re-checked against the
@@ -2519,7 +2521,14 @@ async def get_current_spend(
     and cached in-process for a few seconds, so a persistently stale counter
     drives at most one read per counter per window rather than one per request.
     """
-    current, verified = await _read_spend_counter_estimate(counter_key=counter_key, fallback_spend=fallback_spend)
+    current, verified = await _read_spend_counter_estimate(
+        counter_key=counter_key,
+        fallback_spend=fallback_spend,
+        window_entity_type=window_entity_type,
+        window_entity_id=window_entity_id,
+        window_duration=window_duration,
+        window_start=window_start,
+    )
     if fallback_authoritative:
         verified = True
 
@@ -2696,7 +2705,14 @@ async def read_spend_counter_cache_value(counter_key: str) -> tuple[float | None
     return (float(in_memory_val) if in_memory_val is not None else None), False
 
 
-async def _read_spend_counter_estimate(counter_key: str, fallback_spend: float) -> tuple[float, bool]:
+async def _read_spend_counter_estimate(
+    counter_key: str,
+    fallback_spend: float,
+    window_entity_type: str | None = None,
+    window_entity_id: str | None = None,
+    window_duration: str | None = None,
+    window_start: datetime | None = None,
+) -> tuple[float, bool]:
     """Return (spend, authoritative). ``authoritative`` is True when the value
     came from Redis or a fresh DB read (cross-pod truth), False when it came
     from the per-pod in-memory copy or the caller's fallback. Only the
@@ -2713,6 +2729,24 @@ async def _read_spend_counter_estimate(counter_key: str, fallback_spend: float) 
     )
     if db_spend is not None:
         return db_spend, True
+
+    # Window counters have no entity row (coalesced rejects the :window: key),
+    # so a cold one must reseed from the per-window DB total: a lost counter
+    # reading as a fresh empty window would bypass the window budget. The
+    # caller's fallback (a cumulative upper bound) only applies when the DB is
+    # unreachable too.
+    if window_start is not None and window_entity_type is not None and window_entity_id is not None:
+        window_spend: Final = await SpendCounterReseed.coalesced_window(
+            prisma_client=prisma_client,
+            spend_counter_cache=spend_counter_cache,
+            counter_key=counter_key,
+            entity_type=window_entity_type,
+            entity_id=window_entity_id,
+            window_duration=window_duration,
+            window_start=window_start,
+        )
+        if window_spend is not None:
+            return window_spend, True
 
     # 4. Caller-supplied fallback (DB unavailable).
     return fallback_spend, False
@@ -3270,6 +3304,7 @@ async def _ensure_window_spend_counter_initialized(
         entity_id=entity_id,
         window_duration=window_duration,
         window_start=window_start,
+        require_cache_warm=True,
     )
     if window_spend is None:
         verbose_proxy_logger.warning(

--- a/tests/test_litellm/proxy/auth/test_multi_budget_windows.py
+++ b/tests/test_litellm/proxy/auth/test_multi_budget_windows.py
@@ -2,13 +2,14 @@
 Unit tests for multi-budget-window enforcement on API keys.
 """
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 import litellm
-from litellm.proxy._types import UserAPIKeyAuth
-from litellm.proxy.auth.auth_checks import _virtual_key_multi_budget_check
+import litellm.proxy.proxy_server as ps
+from litellm.proxy._types import LiteLLM_TeamTable, UserAPIKeyAuth
+from litellm.proxy.auth.auth_checks import _team_multi_budget_check, _virtual_key_multi_budget_check
 
 
 def _make_valid_token(**kwargs) -> UserAPIKeyAuth:
@@ -68,9 +69,7 @@ async def test_over_first_window_raises():
         call_count += 1
         return val
 
-    with patch(
-        "litellm.proxy.proxy_server.get_current_spend", side_effect=fake_get_spend
-    ):
+    with patch("litellm.proxy.proxy_server.get_current_spend", side_effect=fake_get_spend):
         with pytest.raises(litellm.BudgetExceededError) as exc_info:
             await _virtual_key_multi_budget_check(valid_token=token)
 
@@ -100,9 +99,7 @@ async def test_over_second_window_raises():
         call_count += 1
         return val
 
-    with patch(
-        "litellm.proxy.proxy_server.get_current_spend", side_effect=fake_get_spend
-    ):
+    with patch("litellm.proxy.proxy_server.get_current_spend", side_effect=fake_get_spend):
         with pytest.raises(litellm.BudgetExceededError) as exc_info:
             await _virtual_key_multi_budget_check(valid_token=token)
 
@@ -135,3 +132,67 @@ async def test_budget_limit_entry_objects_coerced():
     ):
         # Should not raise TypeError / KeyError — model_dump() coerces the object
         await _virtual_key_multi_budget_check(valid_token=token)
+
+
+def _flush_spend_counter(monkeypatch) -> None:
+    """Simulate the 2-pod issue #26672 state: Redis answers (so it is
+    reachable) but the window counter key is gone, and no DB is available to
+    reseed it, so the read falls all the way through to the caller's fallback."""
+    flushed_cache = MagicMock()
+    flushed_cache.redis_cache = MagicMock()
+    flushed_cache.redis_cache.async_get_cache = AsyncMock(return_value=None)
+    flushed_cache.in_memory_cache = MagicMock()
+    flushed_cache.in_memory_cache.get_cache = MagicMock(return_value=None)
+    monkeypatch.setattr(ps, "spend_counter_cache", flushed_cache)
+    monkeypatch.setattr(ps, "prisma_client", None)
+
+
+@pytest.mark.asyncio
+async def test_flushed_window_counter_with_over_budget_key_spend_still_rejects(monkeypatch):
+    """Issue #26672: a Redis flush losing the per-window counter must not read
+    as a fresh empty window. When neither the counter nor the per-window DB
+    total is readable, the key's cumulative spend (an upper bound of any
+    window) must still drive the rejection."""
+    _flush_spend_counter(monkeypatch)
+
+    token = _make_valid_token(
+        spend=99.0,
+        budget_limits=[{"budget_duration": "1d", "max_budget": 30.0, "reset_at": None}],
+    )
+
+    with pytest.raises(litellm.BudgetExceededError) as exc_info:
+        await _virtual_key_multi_budget_check(valid_token=token)
+
+    assert exc_info.value.status_code == 429
+    assert "1d" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_flushed_window_counter_with_under_budget_key_spend_admits(monkeypatch):
+    """The cumulative-spend fallback must not over-block: a key whose all-time
+    spend is below the window limit still admits when the counter is lost."""
+    _flush_spend_counter(monkeypatch)
+
+    token = _make_valid_token(
+        spend=5.0,
+        budget_limits=[{"budget_duration": "1d", "max_budget": 30.0, "reset_at": None}],
+    )
+
+    # Should not raise
+    await _virtual_key_multi_budget_check(valid_token=token)
+
+
+@pytest.mark.asyncio
+async def test_flushed_window_counter_with_over_budget_team_spend_still_rejects(monkeypatch):
+    """Same leak as the key path, for a team window: a lost counter must not
+    bypass the team's per-window budget."""
+    _flush_spend_counter(monkeypatch)
+
+    team = LiteLLM_TeamTable(
+        team_id="team-1",
+        spend=99.0,
+        budget_limits=[{"budget_duration": "1d", "max_budget": 30.0, "reset_at": None}],
+    )
+
+    with pytest.raises(litellm.BudgetExceededError):
+        await _team_multi_budget_check(team_object=team)

--- a/tests/test_litellm/proxy/auth/test_multi_budget_windows.py
+++ b/tests/test_litellm/proxy/auth/test_multi_budget_windows.py
@@ -196,3 +196,36 @@ async def test_flushed_window_counter_with_over_budget_team_spend_still_rejects(
 
     with pytest.raises(litellm.BudgetExceededError):
         await _team_multi_budget_check(team_object=team)
+
+
+@pytest.mark.asyncio
+async def test_flushed_window_counter_flag_off_restores_cumulative_fallback_disabled(monkeypatch):
+    """general_settings.cumulative_window_fallback=false restores the pre-PR
+    degraded-path behavior: with neither counter nor DB readable the window
+    reads 0 instead of the entity's cumulative spend."""
+    _flush_spend_counter(monkeypatch)
+    monkeypatch.setattr(ps, "general_settings", {"cumulative_window_fallback": False})
+
+    token = _make_valid_token(
+        spend=99.0,
+        budget_limits=[{"budget_duration": "1d", "max_budget": 30.0, "reset_at": None}],
+    )
+
+    # Should not raise: the fallback is disabled, so the window reads 0.
+    await _virtual_key_multi_budget_check(valid_token=token)
+
+
+@pytest.mark.asyncio
+async def test_flushed_window_counter_flag_default_on_keeps_the_rejection(monkeypatch):
+    """Default (flag unset) keeps the fix: cumulative spend still drives the
+    rejection when the counter and the DB total are both unreadable."""
+    _flush_spend_counter(monkeypatch)
+    monkeypatch.setattr(ps, "general_settings", {})
+
+    token = _make_valid_token(
+        spend=99.0,
+        budget_limits=[{"budget_duration": "1d", "max_budget": 30.0, "reset_at": None}],
+    )
+
+    with pytest.raises(litellm.BudgetExceededError):
+        await _virtual_key_multi_budget_check(valid_token=token)

--- a/tests/test_litellm/proxy/db/test_spend_counter_reseed.py
+++ b/tests/test_litellm/proxy/db/test_spend_counter_reseed.py
@@ -234,6 +234,58 @@ async def test_window_from_db_without_a_duration_skips_the_row_lookup():
 
 
 @pytest.mark.asyncio
+async def test_window_from_db_logs_floor_only_when_requested():
+    """Default keeps the steady-state short-circuit (no aggregate scan); a
+    reseed (``include_logs_floor=True``) must also read the aggregate because
+    the maintained row lags queued increments by up to one flush interval."""
+    prisma = _FakePrismaClient(row=_row(WINDOW_START, 4.5), spend_logs_total=7.25)
+
+    default_result = await SpendCounterReseed.window_from_db(
+        prisma_client=prisma,
+        entity_type="Key",
+        entity_id="tok-1",
+        window_duration="30d",
+        window_start=WINDOW_START,
+    )
+    # Snapshot between the two calls: the default call must not scan the
+    # aggregate (steady-state path has a performance pin on it).
+    calls_after_default = prisma.db.litellm_spendlogs.call_count
+    floored_result = await SpendCounterReseed.window_from_db(
+        prisma_client=prisma,
+        entity_type="Key",
+        entity_id="tok-1",
+        window_duration="30d",
+        window_start=WINDOW_START,
+        include_logs_floor=True,
+    )
+
+    assert default_result == 4.5
+    assert calls_after_default == 0
+    # max(row, aggregate): the aggregate cannot lag what pods already counted,
+    # so it floors a lagging row instead of the row overriding it.
+    assert floored_result == 7.25
+    assert prisma.db.litellm_spendlogs.call_count == calls_after_default + 1
+
+
+@pytest.mark.asyncio
+async def test_window_from_db_logs_floor_keeps_row_when_aggregate_lower():
+    """The row is the running total once the aggregate falls behind (rolled
+    window, retention cleanup): the floor must not lower the reseed either."""
+    prisma = _FakePrismaClient(row=_row(WINDOW_START, 9.0), spend_logs_total=4.5)
+
+    result = await SpendCounterReseed.window_from_db(
+        prisma_client=prisma,
+        entity_type="Key",
+        entity_id="tok-1",
+        window_duration="30d",
+        window_start=WINDOW_START,
+        include_logs_floor=True,
+    )
+
+    assert result == 9.0
+
+
+@pytest.mark.asyncio
 async def test_coalesced_window_seeds_a_cold_counter_from_the_row():
     prisma = _FakePrismaClient(row=_row(WINDOW_START, 4.5), spend_logs_total=100.0)
     cache = DualCache()
@@ -252,6 +304,120 @@ async def test_coalesced_window_seeds_a_cold_counter_from_the_row():
     assert result == 4.5
     assert cache.in_memory_cache.get_cache(key=counter_key) == 4.5
     assert prisma.db.litellm_spendlogs.call_count == 0
+
+
+class _FakeRedisCache:
+    """Minimal Redis stand-in: NX set behaves like the real one and can be made
+    to fail to exercise the un-warmed-snapshot paths."""
+
+    def __init__(self, *, warm_error: Exception | None = None, race_value: float | None = None,
+                 nx_lost_vanished: bool = False) -> None:
+        self._warm_error = warm_error
+        self._race_value = race_value  # appears only after the NX attempt (winner landed mid-read)
+        self._nx_lost_vanished = nx_lost_vanished  # NX fails but the value vanished (TTL race)
+        self.store: dict[str, float] = {}
+
+    async def async_increment(self, key: str, value: float) -> float:
+        self.store[key] = self.store.get(key, 0.0) + float(value)
+        return self.store[key]
+
+    async def async_get_cache(self, key: str):
+        if self._warm_error is not None and key not in self.store:
+            raise self._warm_error
+        return self.store.get(key)
+
+    async def async_set_cache(self, key: str, value, nx: bool = False):
+        if self._warm_error is not None:
+            raise self._warm_error
+        if self._race_value is not None:
+            # Simulate losing the race: the winner seeded while our DB read was
+            # in flight, so our NX fails and the winner's value is visible.
+            self.store[key] = self._race_value
+            return False
+        if self._nx_lost_vanished:
+            # NX fails but a re-read finds nothing (TTL raced the winner away):
+            # the last-resort increment path must seed the counter.
+            return False
+        if nx and key in self.store:
+            return False
+        self.store[key] = float(value)
+        return True
+
+    async def async_increment(self, key: str, value: float):
+        if self._warm_error is not None:
+            raise self._warm_error
+        self.store[key] = self.store.get(key, 0.0) + float(value)
+        return self.store[key]
+
+
+@pytest.mark.asyncio
+async def test_coalesced_window_returns_none_when_warm_fails():
+    """Greptile P1 (failed warm loses coordination): when the counter cannot be
+    warmed in Redis, the DB snapshot never coordinated with concurrent
+    reservations (they skipped the cold counter), so it must NOT be served as
+    an admission value."""
+    prisma = _FakePrismaClient(row=_row(WINDOW_START, 4.5), spend_logs_total=4.5)
+    redis = _FakeRedisCache(warm_error=RuntimeError("redis down"))
+    cache = DualCache(redis_cache=redis)
+
+    result = await SpendCounterReseed.coalesced_window(
+        prisma_client=prisma,
+        spend_counter_cache=cache,
+        counter_key="spend:key:tok-1:window:30d",
+        entity_type="Key",
+        entity_id="tok-1",
+        window_duration="30d",
+        window_start=WINDOW_START,
+        include_logs_floor=True,
+    )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_coalesced_window_adopts_winner_when_nx_loses():
+    """Two concurrent reseeds of the same counter: the NX loser must return the
+    winner's value (the one increments coordinate against), not its own
+    un-coordinated snapshot."""
+    prisma = _FakePrismaClient(row=_row(WINDOW_START, 4.5), spend_logs_total=4.5)
+    redis = _FakeRedisCache(race_value=9.0)  # winner seeds 9.0 while our DB read is in flight
+    cache = DualCache(redis_cache=redis)
+
+    result = await SpendCounterReseed.coalesced_window(
+        prisma_client=prisma,
+        spend_counter_cache=cache,
+        counter_key="spend:key:tok-1:window:30d",
+        entity_type="Key",
+        entity_id="tok-1",
+        window_duration="30d",
+        window_start=WINDOW_START,
+    )
+
+    assert result == 9.0
+    assert cache.in_memory_cache.get_cache(key="spend:key:tok-1:window:30d") == 9.0
+
+
+@pytest.mark.asyncio
+async def test_coalesced_window_floors_row_at_aggregate():
+    """Greptile P1 (lagging persisted spend): a row lagging increments queued on
+    other pods must reseed the counter at the aggregate floor, not restore a
+    stale-low counter."""
+    prisma = _FakePrismaClient(row=_row(WINDOW_START, 4.5), spend_logs_total=7.25)
+    cache = DualCache()
+
+    result = await SpendCounterReseed.coalesced_window(
+        prisma_client=prisma,
+        spend_counter_cache=cache,
+        counter_key="spend:key:tok-1:window:30d",
+        entity_type="Key",
+        entity_id="tok-1",
+        window_duration="30d",
+        window_start=WINDOW_START,
+        include_logs_floor=True,
+    )
+
+    assert result == 7.25
+    assert cache.in_memory_cache.get_cache(key="spend:key:tok-1:window:30d") == 7.25
 
 
 @pytest.mark.asyncio
@@ -314,3 +480,85 @@ async def test_from_db_still_never_reads_the_end_user_row():
 
     assert await SpendCounterReseed.from_db(prisma_client=prisma, counter_key="spend:end_user:customer-42") is None
     assert prisma.db.litellm_endusertable.where_clauses == []
+
+
+@pytest.mark.asyncio
+async def test_coalesced_window_returns_none_when_db_has_no_value():
+    """Codecov line: with no readable window value in the DB (row missing and
+    the aggregate read failing), coalesced_window must return None so callers
+    fall back to their conservative value - never a fabricated 0.0."""
+    prisma = _FakePrismaClient(row=None, spend_logs_total=0.0)
+
+    async def _broken_group_by(**kwargs):
+        raise RuntimeError("db down")
+
+    prisma.db.litellm_spendlogs.group_by = _broken_group_by
+    redis = _FakeRedisCache()
+    cache = DualCache(redis_cache=redis)
+
+    result = await SpendCounterReseed.coalesced_window(
+        prisma_client=prisma,
+        spend_counter_cache=cache,
+        counter_key="spend:key:tok-1:window:30d",
+        entity_type="Key",
+        entity_id="tok-1",
+        window_duration="30d",
+        window_start=WINDOW_START,
+    )
+
+    assert result is None
+    assert redis.store == {}
+
+
+@pytest.mark.asyncio
+async def test_coalesced_window_keeps_row_when_aggregate_read_fails():
+    """The logs-floor reseed must still succeed when the aggregate read fails:
+    the maintained row alone is the fallback (better than returning None and
+    forcing every read onto the conservative fallback)."""
+    prisma = _FakePrismaClient(row=_row(WINDOW_START, 4.5), spend_logs_total=0.0)
+
+    async def _broken_group_by(**kwargs):
+        raise RuntimeError("db down")
+
+    prisma.db.litellm_spendlogs.group_by = _broken_group_by
+    redis = _FakeRedisCache()
+    cache = DualCache(redis_cache=redis)
+
+    result = await SpendCounterReseed.coalesced_window(
+        prisma_client=prisma,
+        spend_counter_cache=cache,
+        counter_key="spend:key:tok-1:window:30d",
+        entity_type="Key",
+        entity_id="tok-1",
+        window_duration="30d",
+        window_start=WINDOW_START,
+        include_logs_floor=True,
+    )
+
+    assert result == 4.5
+    assert redis.store["spend:key:tok-1:window:30d"] == 4.5
+
+
+@pytest.mark.asyncio
+async def test_coalesced_window_seeds_via_increment_when_nx_lost_and_value_vanished():
+    """Codecov line: NX lost the race but the re-read finds nothing (the
+    winner's key expired between the two calls). The increment path is the
+    last resort to still seed a counter instead of returning an
+    un-coordinated snapshot."""
+    prisma = _FakePrismaClient(row=_row(WINDOW_START, 4.5), spend_logs_total=4.5)
+    redis = _FakeRedisCache(nx_lost_vanished=True)
+    cache = DualCache(redis_cache=redis)
+
+    result = await SpendCounterReseed.coalesced_window(
+        prisma_client=prisma,
+        spend_counter_cache=cache,
+        counter_key="spend:key:tok-1:window:30d",
+        entity_type="Key",
+        entity_id="tok-1",
+        window_duration="30d",
+        window_start=WINDOW_START,
+    )
+
+    assert result == 4.5
+    assert redis.store["spend:key:tok-1:window:30d"] == 4.5
+    assert cache.in_memory_cache.get_cache(key="spend:key:tok-1:window:30d") == 4.5

--- a/tests/test_litellm/proxy/proxy_server/test_spend_counters.py
+++ b/tests/test_litellm/proxy/proxy_server/test_spend_counters.py
@@ -402,9 +402,12 @@ async def test_get_current_spend_floors_window_against_logs_when_row_stale(monke
 @pytest.mark.asyncio
 async def test_get_current_spend_cold_window_counter_reseeds_from_db(monkeypatch):
     """Issue #26672: a Redis flush losing a window counter must reseed it from
-    the per-window DB total (maintained row first), so the decision uses the
-    true window spend and later requests hit the re-warmed counter instead of
-    re-deriving it per request."""
+    the per-window DB total, so the decision uses the true window spend and
+    later requests hit the re-warmed counter instead of re-deriving it per
+    request. The reseed floors the maintained row at the spend-logs aggregate:
+    the row lags queued increments by up to one flush interval, and restoring a
+    counter from it alone would admit traffic that already exceeded the
+    budget (Greptile: lagging persisted spend)."""
     from datetime import timezone
     from types import SimpleNamespace
 
@@ -428,9 +431,44 @@ async def test_get_current_spend_cold_window_counter_reseeds_from_db(monkeypatch
         window_start=window_start,
     )
 
-    assert result == 31.0
-    fake_prisma.db.litellm_spendlogs.group_by.assert_not_awaited()
-    fake_cache.redis_cache.async_set_cache.assert_awaited_once_with(key=counter_key, value=31.0, nx=True)
+    # max(row=31, aggregate=100): the aggregate cannot lag what pods already
+    # counted, so it floors the lagging row.
+    assert result == 100.0
+    fake_prisma.db.litellm_spendlogs.group_by.assert_awaited_once()
+    fake_cache.redis_cache.async_set_cache.assert_awaited_once_with(key=counter_key, value=100.0, nx=True)
+
+
+@pytest.mark.asyncio
+async def test_get_current_spend_cold_window_counter_warm_failure_uses_conservative_fallback(monkeypatch):
+    """Greptile P1 (failed warm loses coordination): the counter cannot be
+    re-warmed (Redis write fails). The DB snapshot never coordinated with
+    concurrent reservations, so it must not be served as an admission value;
+    the read falls back to the caller's conservative cumulative spend."""
+    from datetime import timezone
+    from types import SimpleNamespace
+
+    window_start = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    fake_prisma = _make_window_spend_prisma(
+        row=SimpleNamespace(window_start=window_start, spend=5.0),
+        spend_logs_total=5.0,
+    )
+    fake_cache = _make_spend_counter_cache(redis_get_value=None)
+    fake_cache.redis_cache.async_set_cache = AsyncMock(side_effect=RuntimeError("redis down"))
+    monkeypatch.setattr(ps, "spend_counter_cache", fake_cache)
+    monkeypatch.setattr(ps, "prisma_client", fake_prisma)
+
+    result = await ps.get_current_spend(
+        counter_key="spend:key:tok:window:7d",
+        fallback_spend=99.0,
+        max_budget=30.0,
+        window_entity_type="Key",
+        window_entity_id="tok",
+        window_duration="7d",
+        window_start=window_start,
+    )
+
+    # Not 5.0 (the un-coordinated DB snapshot): the conservative fallback wins.
+    assert result == 99.0
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/proxy_server/test_spend_counters.py
+++ b/tests/test_litellm/proxy/proxy_server/test_spend_counters.py
@@ -400,6 +400,100 @@ async def test_get_current_spend_floors_window_against_logs_when_row_stale(monke
 
 
 @pytest.mark.asyncio
+async def test_get_current_spend_cold_window_counter_reseeds_from_db(monkeypatch):
+    """Issue #26672: a Redis flush losing a window counter must reseed it from
+    the per-window DB total (maintained row first), so the decision uses the
+    true window spend and later requests hit the re-warmed counter instead of
+    re-deriving it per request."""
+    from datetime import timezone
+    from types import SimpleNamespace
+
+    window_start = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    fake_prisma = _make_window_spend_prisma(
+        row=SimpleNamespace(window_start=window_start, spend=31.0),
+        spend_logs_total=100.0,
+    )
+    fake_cache = _make_spend_counter_cache(redis_get_value=None)
+    monkeypatch.setattr(ps, "spend_counter_cache", fake_cache)
+    monkeypatch.setattr(ps, "prisma_client", fake_prisma)
+
+    counter_key = "spend:key:tok:window:7d"
+    result = await ps.get_current_spend(
+        counter_key=counter_key,
+        fallback_spend=99.0,
+        max_budget=30.0,
+        window_entity_type="Key",
+        window_entity_id="tok",
+        window_duration="7d",
+        window_start=window_start,
+    )
+
+    assert result == 31.0
+    fake_prisma.db.litellm_spendlogs.group_by.assert_not_awaited()
+    fake_cache.redis_cache.async_set_cache.assert_awaited_once_with(key=counter_key, value=31.0, nx=True)
+
+
+@pytest.mark.asyncio
+async def test_get_current_spend_cold_window_counter_admits_after_window_rollover(monkeypatch):
+    """Rollover regression: the reset job rolls the window row and zeroes the
+    counter. If the counter is then lost, the reseed must read the rolled row
+    (new window, spend 0) and admit, even though the caller's fallback (the
+    cumulative spend) sits far above the window limit."""
+    from datetime import timezone
+    from types import SimpleNamespace
+
+    window_start = datetime(2026, 1, 8, tzinfo=timezone.utc)
+    fake_prisma = _make_window_spend_prisma(
+        row=SimpleNamespace(window_start=window_start, spend=0.0),
+    )
+    fake_cache = _make_spend_counter_cache(redis_get_value=None)
+    monkeypatch.setattr(ps, "spend_counter_cache", fake_cache)
+    monkeypatch.setattr(ps, "prisma_client", fake_prisma)
+
+    result = await ps.get_current_spend(
+        counter_key="spend:key:tok:window:7d",
+        fallback_spend=99.0,
+        max_budget=30.0,
+        window_entity_type="Key",
+        window_entity_id="tok",
+        window_duration="7d",
+        window_start=window_start,
+    )
+
+    assert result == 0.0
+
+
+@pytest.mark.asyncio
+async def test_get_current_spend_window_rollover_admits_with_reset_counter(monkeypatch):
+    """The steady-state rollover shape: the reset job already set the counter
+    to the carried spend (0) and rolled the row. The read must admit without
+    the floor repair raising the counter off the reset value."""
+    from datetime import timezone
+    from types import SimpleNamespace
+
+    window_start = datetime(2026, 1, 8, tzinfo=timezone.utc)
+    fake_prisma = _make_window_spend_prisma(
+        row=SimpleNamespace(window_start=window_start, spend=0.0),
+    )
+    fake_cache = _make_spend_counter_cache(redis_get_value=0.0)
+    monkeypatch.setattr(ps, "spend_counter_cache", fake_cache)
+    monkeypatch.setattr(ps, "prisma_client", fake_prisma)
+
+    result = await ps.get_current_spend(
+        counter_key="spend:key:tok:window:7d",
+        fallback_spend=99.0,
+        max_budget=30.0,
+        window_entity_type="Key",
+        window_entity_id="tok",
+        window_duration="7d",
+        window_start=window_start,
+    )
+
+    assert result == 0.0
+    fake_cache.redis_cache.async_set_max.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_get_current_spend_fail_closed_rejects_when_unverifiable(monkeypatch):
     """With fail_closed_budget_enforcement on, an admit decision backed only by a
     per-pod fallback (Redis unreachable and DB unreadable) is rejected with 503


### PR DESCRIPTION
## Problem

Per-window budgets (via `budget_duration` / `budget_limits`) can be bypassed when the Redis per-window spend counter is lost mid-window — e.g. Redis flush or failover in a multi-pod deployment. Reported in #26672: a key with a 30 USD/day hard cap kept being admitted at 99 USD spent. Not reproducible on a single pod (in-memory fallback there), which is why it went unfixed.

## Root cause

`get_current_spend` falls back to the caller-supplied `fallback_spend` when neither Redis nor in-memory has the counter. For window checks (`_virtual_key_multi_budget_check` / `_team_multi_budget_check`) that fallback was hard-coded `0.0`, and the existing DB-reseed path (`SpendCounterReseed.coalesced`) only covers primary (cumulative) counters — window counter keys (`:window:`) have no entity row to reseed from. Net effect: a lost counter makes the current window read as brand-new → budget gate waves everything through.

## Fix

1. `get_current_spend` now reseeds a **cold window counter from the per-window DB total** (maintained window-spend row; spend-logs aggregate fallback) instead of trusting the missing counter.
2. The caller fallback for window checks is now the entity's **cumulative spend** (conservative upper bound of any single window), applied only when the DB is also unreachable — so a lost counter can never read as an empty window, while remaining fail-closed on DB outage.
3. `spend_counter_reseed.coalesced_window` gains `require_cache_warm` (aligns with existing `coalesced` pattern) so write-path failure semantics are unchanged.

## Why not just use cumulative spend as the fallback everywhere?

That over-blocks: after a legitimate window rollover + counter loss, the cumulative spend (99) would permanently block a fresh window (cap 30). The read-path DB reseed handles both cases correctly — in-window loss reseeds the true window spend; post-rollover loss reads the already-rolled row (0) and admits. The cumulative upper bound is only the last-resort when the DB is unreachable.

## Tests (red → green verified)

New tests in `tests/test_litellm/proxy/proxy_server/test_spend_counters.py` and `tests/test_litellm/proxy/auth/test_multi_budget_windows.py`:

- `test_flushed_window_counter_with_over_budget_key_spend_still_rejects` — the #26672 repro (flush + no DB + spend 99 > cap 30 → must reject) — **red on unfixed code**
- `test_flushed_window_counter_with_over_budget_team_spend_still_rejects` — same hole on the team side — **red on unfixed code**
- `test_get_current_spend_cold_window_counter_reseeds_from_db` — cold window counter reseeds 31.0 from the maintained row and writes back to Redis
- `test_get_current_spend_window_rollover_admits_after_window_rollover` — rollover + counter loss + cumulative 99 → must admit (guards against over-blocking)
- plus rollover-reset and under-budget-loss regression tests

Confirmed by stashing the source changes: 4 repro tests fail on unfixed code, all pass with the fix. Full `tests/proxy/auth` + `tests/proxy/proxy_server` suites: 2662 passed, 1 pre-existing date-dependent failure also present on base.

Closes #26672