### PR TITLE
fix(router): classify encrypted delegated tasks with native Responses

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -1201,6 +1201,9 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
         # Cast to Any to match the expected union type for tools list items
         tools.append(cast(Any, web_search_tool))
 
+    def transform_response_format_to_text_format(self, response_format: object) -> "ResponseText | None":
+        return self._transform_response_format_to_text_format(response_format)
+
     def _transform_response_format_to_text_format(self, response_format: object) -> "ResponseText | None":
         """
         Transform Chat Completion response_format parameter to Responses API text.format parameter.

--- a/litellm/llms/base_llm/responses/transformation.py
+++ b/litellm/llms/base_llm/responses/transformation.py
@@ -62,6 +62,9 @@ class BaseResponsesAPIConfig(ABC):
         """
         return False
 
+    def supports_encrypted_agent_messages(self) -> bool:
+        return False
+
     def sign_request(
         self,
         headers: dict,

--- a/litellm/llms/openai/responses/transformation.py
+++ b/litellm/llms/openai/responses/transformation.py
@@ -110,6 +110,9 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
     def supports_native_file_search(self) -> bool:
         return True
 
+    def supports_encrypted_agent_messages(self) -> bool:
+        return self.custom_llm_provider in (LlmProviders.OPENAI, LlmProviders.AZURE)
+
     @staticmethod
     def _is_gpt_5_model(model: str) -> bool:
         """Return True only for actual OpenAI GPT-5 models.

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -4,10 +4,11 @@ from collections.abc import Coroutine, Generator, Iterable, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass
 from functools import partial
-from typing import TYPE_CHECKING, Any, Final, Literal, Optional, cast
+from typing import TYPE_CHECKING, Any, Final, Literal, NoReturn, Optional, TypeAlias, cast
 
 import httpx
 from pydantic import BaseModel
+from typing_extensions import assert_never
 
 import litellm
 from litellm._logging import verbose_logger
@@ -405,6 +406,37 @@ def _bridges_to_chat_completions(
 ) -> bool:
     """Whether the request reaches its provider as a chat completion, not a Responses call."""
     return responses_api_provider_config is None or use_chat_completions_api is True
+
+
+_ResponsesCompatibilityFailure: TypeAlias = Literal["encrypted_task_unsupported"]
+
+
+def _encrypted_task_support_failure(
+    responses_api_provider_config: BaseResponsesAPIConfig | None, use_chat_completions_api: bool
+) -> _ResponsesCompatibilityFailure | None:
+    if (
+        responses_api_provider_config is None
+        or _bridges_to_chat_completions(responses_api_provider_config, use_chat_completions_api)
+        or not responses_api_provider_config.supports_encrypted_agent_messages()
+    ):
+        return "encrypted_task_unsupported"
+    return None
+
+
+def _raise_responses_compatibility_failure(
+    failure: _ResponsesCompatibilityFailure, model: str, custom_llm_provider: str | None
+) -> NoReturn:
+    match failure:
+        case "encrypted_task_unsupported":
+            raise litellm.exception_type(
+                model=model,
+                custom_llm_provider=custom_llm_provider,
+                original_exception=ValueError(
+                    "Encrypted task classification requires a compatible native Responses deployment"
+                ),
+            )
+        case _:
+            assert_never(failure)
 
 
 def _deployment_passes_through_responses(model_info: object) -> bool:
@@ -1187,12 +1219,16 @@ def responses(
                 model, custom_llm_provider, deployment_model_info
             )
 
-        if require_encrypted_task_support and (
-            _bridges_to_chat_completions(responses_api_provider_config, use_chat_completions_api)
-            or responses_api_provider_config is None
-            or not responses_api_provider_config.supports_encrypted_agent_messages()
+        if (
+            require_encrypted_task_support
+            and (
+                compatibility_failure := _encrypted_task_support_failure(
+                    responses_api_provider_config, use_chat_completions_api
+                )
+            )
+            is not None
         ):
-            raise ValueError("Encrypted task classification requires a compatible native Responses deployment")
+            _raise_responses_compatibility_failure(compatibility_failure, model, custom_llm_provider)
 
         local_vars.update(kwargs)
         # Map reasoning_effort (from litellm_params/proxy config) to reasoning when not set

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -1078,6 +1078,7 @@ def responses(
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id", None)
         _is_async: Final = kwargs.pop("aresponses", False) is True
         skip_mcp_handler: Final = kwargs.pop("_skip_mcp_handler", False)
+        require_encrypted_task_support: Final = kwargs.pop("_require_encrypted_task_support", False) is True
         use_chat_completions_api = _pop_use_chat_completions_api_kw(kwargs)
 
         client_headers: Final = kwargs.get("headers")
@@ -1185,6 +1186,13 @@ def responses(
             responses_api_provider_config = _resolve_responses_api_provider_config(
                 model, custom_llm_provider, deployment_model_info
             )
+
+        if require_encrypted_task_support and (
+            _bridges_to_chat_completions(responses_api_provider_config, use_chat_completions_api)
+            or responses_api_provider_config is None
+            or not responses_api_provider_config.supports_encrypted_agent_messages()
+        ):
+            raise ValueError("Encrypted task classification requires a compatible native Responses deployment")
 
         local_vars.update(kwargs)
         # Map reasoning_effort (from litellm_params/proxy config) to reasoning when not set

--- a/litellm/router_strategy/complexity_router/README.md
+++ b/litellm/router_strategy/complexity_router/README.md
@@ -367,6 +367,9 @@ local scoring shortcut in `heuristic_first` and `hybrid` modes. The configured c
 a native OpenAI or Azure OpenAI Responses deployment with access to the encrypted content. The
 provider handles the encrypted task, and the classifier still chooses the tier dynamically
 
+Compatibility is checked after normal deployment selection. A paused incompatible member of the
+classifier group does not prevent an eligible compatible deployment from classifying the task
+
 Unsupported classifier deployments and provider decryption errors use the existing
 `classifier_fallback` policy. No fixed tier is introduced for encrypted tasks. Plaintext asks and
 requests carrying only historical encrypted reasoning retain the existing classifier path

--- a/litellm/router_strategy/complexity_router/README.md
+++ b/litellm/router_strategy/complexity_router/README.md
@@ -361,6 +361,16 @@ model_list:
 keep the classifier deployment or provider default, or set a supported value such as `none` or
 `low` to override that call.
 
+When the current ask is a Responses API `agent_message` containing `encrypted_content`, LLM
+classification preserves the encrypted task and uses native Responses. This also bypasses the
+local scoring shortcut in `heuristic_first` and `hybrid` modes. The configured classifier must use
+a native OpenAI or Azure OpenAI Responses deployment with access to the encrypted content. The
+provider handles the encrypted task, and the classifier still chooses the tier dynamically
+
+Unsupported classifier deployments and provider decryption errors use the existing
+`classifier_fallback` policy. No fixed tier is introduced for encrypted tasks. Plaintext asks and
+requests carrying only historical encrypted reasoning retain the existing classifier path
+
 Classifier calls have a one-attempt hard deadline. After a timeout, the router opens a process-local
 circuit for that classifier and sends every session through `classifier_fallback` for
 `classifier_llm_config.circuit_breaker_cooldown_seconds` (30 seconds by default). When the cooldown

--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -25,7 +25,7 @@ from threading import Lock
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Final, Literal, NamedTuple, cast
 
-from pydantic import BaseModel, TypeAdapter, create_model
+from pydantic import BaseModel, TypeAdapter, ValidationError, create_model
 
 from litellm._logging import verbose_router_logger
 from litellm.constants import (
@@ -504,7 +504,10 @@ def _encrypted_classifier_task(
     raw_input: Final = (request_kwargs or EMPTY_MAPPING).get("input")
     if not isinstance(raw_input, list) or (request_kwargs or EMPTY_MAPPING).get("messages"):
         return None
-    items: Final = TypeAdapter(tuple[dict[str, object], ...]).validate_python(raw_input)
+    try:
+        items: Final = TypeAdapter(tuple[dict[str, object], ...]).validate_python(raw_input)
+    except ValidationError:
+        return None
     current: Final = next(
         (
             item
@@ -516,7 +519,10 @@ def _encrypted_classifier_task(
     )
     if current is None or current.get("type") != "agent_message" or not isinstance(current.get("content"), list):
         return None
-    parts: Final = TypeAdapter(tuple[dict[str, object], ...]).validate_python(current["content"])
+    try:
+        parts: Final = TypeAdapter(tuple[dict[str, object], ...]).validate_python(current["content"])
+    except ValidationError:
+        return None
     if not any(part.get("type") == "encrypted_content" and part.get("encrypted_content") for part in parts):
         return None
     return {
@@ -2058,7 +2064,7 @@ class ComplexityRouter(CustomLogger):
             classifier_call_params = MappingProxyType({"reasoning_effort": llm_config.reasoning_effort})
 
         payload: Final = (
-            self._native_classifier_payload(llm_config.model, messages_for_call, response_format, encrypted_task)
+            self._native_classifier_payload(messages_for_call, response_format, encrypted_task)
             if encrypted_task is not None
             else {"messages": messages_for_call, "response_format": response_format, **classifier_call_params}
         )
@@ -2098,7 +2104,6 @@ class ComplexityRouter(CustomLogger):
 
     def _native_classifier_payload(
         self,
-        model: str,
         messages: list[AllMessageValues],  # mutable-ok: existing transformation accepts the SDK message list
         response_format: Mapping[str, object],
         encrypted_task: Mapping[str, object],
@@ -2106,26 +2111,7 @@ class ComplexityRouter(CustomLogger):
         from litellm.completion_extras.litellm_responses_transformation.transformation import (
             LiteLLMResponsesTransformationHandler,
         )
-        from litellm.litellm_core_utils.get_llm_provider_logic import declared_authenticating_provider, get_llm_provider
-        from litellm.types.router import LiteLLM_Params
 
-        deployments: Final = self._group_deployments(model)
-        if not deployments:
-            raise ValueError("Encrypted task classification requires a native OpenAI Responses classifier deployment")
-        for params in (LiteLLM_Params.model_validate(deployment.get("litellm_params")) for deployment in deployments):
-            if declared_authenticating_provider(params.model, params.custom_llm_provider):
-                raise ValueError(
-                    "Encrypted task classification requires a native OpenAI Responses classifier deployment"
-                )
-            _, provider, _, _ = get_llm_provider(model=params.model, litellm_params=params)
-            if (
-                provider not in ("openai", "azure")
-                or params.use_chat_completions_api
-                or params.model.startswith("openai/chat_completions/")
-            ):
-                raise ValueError(
-                    "Encrypted task classification requires a native OpenAI Responses classifier deployment"
-                )
         transformation: Final = LiteLLMResponsesTransformationHandler()
         input_items, instructions = transformation.convert_chat_completion_messages_to_responses_api(messages)
         llm_config: Final = self.config.classifier_llm_config
@@ -2139,6 +2125,7 @@ class ComplexityRouter(CustomLogger):
             "instructions": instructions,
             "text": transformation.transform_response_format_to_text_format(dict(response_format)),
             "store": False,
+            "_require_encrypted_task_support": True,
             **reasoning,
         }
 

--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -1690,7 +1690,7 @@ class ComplexityRouter(CustomLogger):
         if self.config.classifier_type == "custom":
             return await self._classify_with_plugin(prompt, system_prompt, request_kwargs, raw_messages)
         if self.config.classifier_type in ("heuristic_first", "hybrid") and _encrypted_classifier_task(
-            request_kwargs, self._reminder_markers
+            request_kwargs, self._reminder_markers_for_request(request_kwargs or EMPTY_MAPPING)
         ):
             return await self._llm_classifier_outcome(prompt, system_prompt, request_kwargs, messages)
         if self.config.classifier_type == "heuristic_first" and self.config.classifier_llm_config is not None:
@@ -2028,7 +2028,7 @@ class ComplexityRouter(CustomLogger):
             > 1
         )
 
-        encrypted_task: Final = _encrypted_classifier_task(request_kwargs, self._reminder_markers)
+        encrypted_task: Final = _encrypted_classifier_task(request_kwargs, marker_pairs)
         user_payload: Final = self._build_classifier_user_payload(
             prompt="The delegated task in the following agent_message." if encrypted_task is not None else prompt,
             system_prompt=system_prompt,

--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -25,7 +25,7 @@ from threading import Lock
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Final, Literal, NamedTuple, cast
 
-from pydantic import BaseModel, create_model
+from pydantic import BaseModel, TypeAdapter, create_model
 
 from litellm._logging import verbose_router_logger
 from litellm.constants import (
@@ -56,6 +56,7 @@ from litellm.types.llms.openai import (
     AllMessageValues,
     ChatCompletionImageObject,
     ChatCompletionTextObject,
+    ResponsesAPIResponse,
 )
 from litellm.types.utils import (
     AUTOROUTER_CLASSIFIER_CALL_ORIGIN,
@@ -364,7 +365,7 @@ def _parent_session_kwargs(request_kwargs: Mapping[str, Any] | None) -> Mapping[
     return {k: kwargs[k] for k in ("litellm_session_id", "litellm_trace_id") if kwargs.get(k) is not None}
 
 
-def _response_cost_or_none(response: ModelResponse) -> float | None:
+def _response_cost_or_none(response: ModelResponse | ResponsesAPIResponse) -> float | None:
     hidden_params: Final = response._hidden_params
     if not isinstance(hidden_params, dict):
         return None
@@ -484,6 +485,36 @@ def _human_text(content: object, marker_pairs: tuple[tuple[str, str], ...] = _DE
     model and therefore the spend. An unclosed tag is not a block and is left intact.
     """
     return _strip_reminder_blocks(_message_text(content), marker_pairs)
+
+
+def _encrypted_classifier_task(
+    request_kwargs: Mapping[str, object] | None,
+    marker_pairs: tuple[tuple[str, str], ...],
+) -> dict[str, object] | None:
+    from litellm.litellm_core_utils.prompt_templates.factory import resolve_structured_messages
+
+    raw_input: Final = (request_kwargs or EMPTY_MAPPING).get("input")
+    if not isinstance(raw_input, list) or (request_kwargs or EMPTY_MAPPING).get("messages"):
+        return None
+    items: Final = TypeAdapter(tuple[dict[str, object], ...]).validate_python(raw_input)
+    current: Final = next(
+        (
+            item
+            for item in reversed(items)
+            if (messages := resolve_structured_messages(messages=None, request_kwargs={"input": [item]}))
+            and any(_iter_human_asks_newest_first(messages, marker_pairs))
+        ),
+        None,
+    )
+    if current is None or current.get("type") != "agent_message" or not isinstance(current.get("content"), list):
+        return None
+    parts: Final = TypeAdapter(tuple[dict[str, object], ...]).validate_python(current["content"])
+    if not any(part.get("type") == "encrypted_content" and part.get("encrypted_content") for part in parts):
+        return None
+    return {
+        **current,
+        "content": [part for part in parts if part.get("type") in ("input_text", "encrypted_content")],
+    }
 
 
 def _iter_human_asks_newest_first(
@@ -1630,6 +1661,10 @@ class ComplexityRouter(CustomLogger):
             return self._classify_with_heuristic_v2(prompt)
         if self.config.classifier_type == "custom":
             return await self._classify_with_plugin(prompt, system_prompt, request_kwargs, raw_messages)
+        if self.config.classifier_type in ("heuristic_first", "hybrid") and _encrypted_classifier_task(
+            request_kwargs, self._reminder_markers
+        ):
+            return await self._llm_classifier_outcome(prompt, system_prompt, request_kwargs, messages)
         if self.config.classifier_type == "heuristic_first" and self.config.classifier_llm_config is not None:
             return await self._classify_heuristic_first(prompt, system_prompt, request_kwargs, messages)
         if self.config.classifier_type == "hybrid" and self.config.classifier_llm_config is not None:
@@ -1970,8 +2005,9 @@ class ComplexityRouter(CustomLogger):
             > 1
         )
 
+        encrypted_task: Final = _encrypted_classifier_task(request_kwargs, self._reminder_markers)
         user_payload: Final = self._build_classifier_user_payload(
-            prompt=prompt,
+            prompt="The delegated task in the following agent_message." if encrypted_task is not None else prompt,
             system_prompt=system_prompt,
             prior_turns=prior_turns,
             messages=messages,
@@ -2004,34 +2040,37 @@ class ComplexityRouter(CustomLogger):
         if llm_config.reasoning_effort is not None:
             classifier_call_params = MappingProxyType({"reasoning_effort": llm_config.reasoning_effort})
 
-        proxy_server_request: Final = {
-            "body": {
-                "model": llm_config.model,
-                "messages": messages_for_call,
-                "response_format": response_format,
-                **classifier_call_params,
-            }
-        }
+        payload: Final = (
+            self._native_classifier_payload(llm_config.model, messages_for_call, response_format, encrypted_task)
+            if encrypted_task is not None
+            else {"messages": messages_for_call, "response_format": response_format, **classifier_call_params}
+        )
+        proxy_server_request: Final = {"body": {"model": llm_config.model, **payload}}
+        classify: Final = (
+            self.litellm_router_instance.aresponses
+            if encrypted_task is not None
+            else self.litellm_router_instance.acompletion
+        )
 
         classifier_timeout_s: Final[float] = llm_config.timeout_ms / 1000
-        response: Final[ModelResponse] = await asyncio.wait_for(
-            self.litellm_router_instance.acompletion(
+        response: Final[ModelResponse | ResponsesAPIResponse] = await asyncio.wait_for(
+            classify(
                 model=llm_config.model,
-                messages=messages_for_call,
                 stream=False,
-                response_format=response_format,
                 timeout=classifier_timeout_s,
                 num_retries=0,
                 disable_fallbacks=True,
                 metadata=metadata,
                 proxy_server_request=proxy_server_request,
                 turn_off_message_logging=turn_off_message_logging,
-                **classifier_call_params,
+                **payload,
                 **_parent_session_kwargs(request_kwargs),
             ),
             timeout=classifier_timeout_s,
         )
-        content: Final = response.choices[0].message.content
+        content: Final = (
+            response.output_text if isinstance(response, ResponsesAPIResponse) else response.choices[0].message.content
+        )
         if not content:
             raise ValueError("LLM classifier returned empty content")
         raw_tier: Final = _LabeledTierClassification.model_validate_json(content).tier
@@ -2039,6 +2078,52 @@ class ComplexityRouter(CustomLogger):
         if tier is None:
             raise ValueError(f"LLM classifier returned an unrecognized tier: {raw_tier!r}")
         return tier, _response_cost_or_none(response)
+
+    def _native_classifier_payload(
+        self,
+        model: str,
+        messages: list[AllMessageValues],  # mutable-ok: existing transformation accepts the SDK message list
+        response_format: Mapping[str, object],
+        encrypted_task: Mapping[str, object],
+    ) -> Mapping[str, object]:
+        from litellm.completion_extras.litellm_responses_transformation.transformation import (
+            LiteLLMResponsesTransformationHandler,
+        )
+        from litellm.litellm_core_utils.get_llm_provider_logic import declared_authenticating_provider, get_llm_provider
+        from litellm.types.router import LiteLLM_Params
+
+        deployments: Final = self._group_deployments(model)
+        if not deployments:
+            raise ValueError("Encrypted task classification requires a native OpenAI Responses classifier deployment")
+        for params in (LiteLLM_Params.model_validate(deployment.get("litellm_params")) for deployment in deployments):
+            if declared_authenticating_provider(params.model, params.custom_llm_provider):
+                raise ValueError(
+                    "Encrypted task classification requires a native OpenAI Responses classifier deployment"
+                )
+            _, provider, _, _ = get_llm_provider(model=params.model, litellm_params=params)
+            if (
+                provider not in ("openai", "azure")
+                or params.use_chat_completions_api
+                or params.model.startswith("openai/chat_completions/")
+            ):
+                raise ValueError(
+                    "Encrypted task classification requires a native OpenAI Responses classifier deployment"
+                )
+        transformation: Final = LiteLLMResponsesTransformationHandler()
+        input_items, instructions = transformation.convert_chat_completion_messages_to_responses_api(messages)
+        llm_config: Final = self.config.classifier_llm_config
+        reasoning: Final = (
+            {"reasoning": {"effort": llm_config.reasoning_effort}}
+            if llm_config is not None and llm_config.reasoning_effort is not None
+            else {}
+        )
+        return {
+            "input": [*input_items, encrypted_task],
+            "instructions": instructions,
+            "text": transformation.transform_response_format_to_text_format(dict(response_format)),
+            "store": False,
+            **reasoning,
+        }
 
     @staticmethod
     def _build_classifier_user_payload(

--- a/tests/test_litellm/responses/test_responses_api_bridge_flag.py
+++ b/tests/test_litellm/responses/test_responses_api_bridge_flag.py
@@ -7,16 +7,40 @@ calls so routed requests do not hit a custom api_base /v1/responses endpoint.
 """
 
 from importlib import import_module
+from typing import Final
 from unittest.mock import MagicMock, patch
 
+import httpx
+import pytest
 
 import litellm
+from litellm.llms.custom_httpx.http_handler import HTTPHandler
 from litellm.types.llms.openai import ResponseAPIUsage, ResponsesAPIResponse
 from litellm.types.utils import Choices, Message, ModelResponse, Usage
 
 
 class TestUseResponsesApiBridgeFlag:
     """Test that bridge opt-in forces the chat completions path."""
+
+    @pytest.mark.parametrize("model", ["openai/chat_completions/gpt-6-astra", "xai/test-classifier"])
+    def test_encrypted_classifier_rejection_preserves_public_error(self, model: str) -> None:
+        respond: Final = MagicMock(side_effect=AssertionError("Incompatible classifier sent an upstream request"))
+        with httpx.Client(transport=httpx.MockTransport(respond)) as client:
+            with pytest.raises(
+                litellm.APIConnectionError,
+                match="Encrypted task classification requires a compatible native Responses deployment",
+            ) as error:
+                litellm.responses(
+                    model=model,
+                    input="Delegated task",
+                    api_key="test-key",
+                    api_base="https://classifier.test/v1",
+                    client=HTTPHandler(client=client),
+                    _require_encrypted_task_support=True,
+                    num_retries=0,
+                )
+        assert error.value.status_code == 500
+        respond.assert_not_called()
 
     @patch.object(
         import_module("litellm.responses.main").litellm_completion_transformation_handler, "response_api_handler"

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -2579,6 +2579,40 @@ async def native_classifier_http() -> AsyncIterator[tuple[AsyncHTTPHandler, Magi
 class TestEncryptedTaskClassifier:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("classifier_type", ["llm", "heuristic_first", "hybrid"])
+    @pytest.mark.parametrize("codex", [True, False])
+    @pytest.mark.parametrize(
+        "reminder",
+        [
+            "<environment_context>cwd=/repo</environment_context>",
+            "<user_instructions>Keep answers concise</user_instructions>",
+        ],
+    )
+    async def test_encrypted_task_detection_uses_request_reminder_markers(
+        self, classifier_type: str, codex: bool, reminder: str
+    ):
+        router, dependency = _native_classifier_router(classifier_type=classifier_type)
+        task: Final = _encrypted_agent_task()
+        request: Final = {
+            "input": [task, {"role": "user", "content": reminder}],
+            "metadata": {"user_agent": "codex-tui" if codex else "curl/8.7.1"},
+        }
+        original: Final = deepcopy(request)
+
+        result: Final = await router.async_pre_routing_hook(model="encrypted-router", request_kwargs=request)
+
+        assert request == original
+        assert result.model == ("deep-model" if codex else "cheap-model")
+        if codex:
+            assert result.routing_decision["cause"] == "llm_classifier"
+            assert result.routing_decision["tier"] == "REASONING"
+            dependency.aresponses.assert_awaited_once()
+            assert dependency.aresponses.call_args.kwargs["input"][-1] == task
+            dependency.acompletion.assert_not_called()
+        else:
+            dependency.aresponses.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("classifier_type", ["llm", "heuristic_first", "hybrid"])
     @pytest.mark.parametrize("tier,model", [("SIMPLE", "cheap-model"), ("REASONING", "deep-model")])
     async def test_encrypted_task_routes_by_native_verdict(self, classifier_type: str, tier: str, model: str):
         router, dependency = _native_classifier_router(json.dumps({"tier": tier}), classifier_type)

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -5,6 +5,8 @@ Tests the rule-based complexity scoring and tier assignment logic.
 """
 
 import asyncio
+import copy
+import json
 import logging
 import sys
 import time
@@ -66,6 +68,7 @@ from litellm.types.router import (
     LiteLLM_Params,
     TaggedPreRoutingStrategy,
 )
+from litellm.types.llms.openai import ResponsesAPIResponse
 
 
 requires_semantic_router = pytest.mark.skipif(
@@ -2480,6 +2483,181 @@ class TestTierLabels:
         )
         assert set(config.tiers) == {"SIMPLE", "REASONING"}
         assert set(config.tier_boundaries) == {"simple_medium", "medium_complex", "complex_reasoning"}
+
+
+def _encrypted_agent_task() -> dict[str, object]:
+    return {
+        "type": "agent_message",
+        "author": "/root",
+        "recipient": "/root/child",
+        "content": [
+            {"type": "input_text", "text": "Message Type: NEW_TASK\nTask name: /root/child\nPayload:\nHello"},
+            {"type": "encrypted_content", "encrypted_content": "opaque-provider-task"},
+        ],
+    }
+
+
+def _native_classifier_response(content: str) -> ResponsesAPIResponse:
+    response: Final = ResponsesAPIResponse(
+        id="resp_classifier",
+        created_at=0,
+        status="completed",
+        output=[{"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": content}]}],
+    )
+    response._hidden_params = {"response_cost": 0.0001}
+    return response
+
+
+def _native_classifier_router(
+    output: str = '{"tier":"REASONING"}',
+    classifier_type: str = "llm",
+    deployment_model: str = "openai/gpt-6-astra",
+    failure: Exception | None = None,
+) -> tuple[ComplexityRouter, MagicMock]:
+    dependency: Final = MagicMock(
+        aresponses=AsyncMock(return_value=_native_classifier_response(output), side_effect=failure),
+        acompletion=AsyncMock(return_value=_llm_response('{"tier":"SIMPLE"}')),
+        get_model_list=MagicMock(return_value=[{"litellm_params": {"model": deployment_model}}]),
+    )
+    return (
+        ComplexityRouter(
+            model_name="encrypted-router",
+            litellm_router_instance=dependency,
+            complexity_router_config={
+                "tiers": {"SIMPLE": "cheap-model", "REASONING": "deep-model"},
+                "classifier_type": classifier_type,
+                "classifier_llm_config": {"model": "classifier", "timeout_ms": 100, "reasoning_effort": "low"},
+                "heuristic_first_max_tier": "SIMPLE" if classifier_type == "heuristic_first" else None,
+                "hybrid_boundary_margin": 0.01 if classifier_type == "hybrid" else None,
+                "classifier_fallback": "default_model",
+                "default_model": "deep-model",
+                "session_affinity": False,
+                "deployment_affinity": False,
+            },
+        ),
+        dependency,
+    )
+
+
+class TestEncryptedTaskClassifier:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("classifier_type", ["llm", "heuristic_first", "hybrid"])
+    @pytest.mark.parametrize("tier,model", [("SIMPLE", "cheap-model"), ("REASONING", "deep-model")])
+    async def test_encrypted_task_routes_by_native_verdict(self, classifier_type: str, tier: str, model: str):
+        router, dependency = _native_classifier_router(json.dumps({"tier": tier}), classifier_type)
+        task: Final = _encrypted_agent_task()
+        request: Final = {
+            "input": [
+                {"role": "user", "content": "Prior task context"},
+                task,
+                {"type": "function_call_output", "call_id": "call_1", "output": "Tool output"},
+                {"role": "user", "content": "<system-reminder>Injected reminder</system-reminder>"},
+            ],
+            "instructions": "Caller constraints",
+            "tools": [{"type": "function", "name": "execute"}],
+            "previous_response_id": "resp_parent",
+            "litellm_session_id": "parent-session",
+            "litellm_trace_id": "parent-trace",
+            "turn_off_message_logging": True,
+            "litellm_metadata": {"user_api_key_hash": "caller-key-hash"},
+        }
+        original: Final = copy.deepcopy(request)
+
+        result: Final = await router.async_pre_routing_hook(model="encrypted-router", request_kwargs=request)
+
+        assert result.model == model
+        assert result.routing_decision["tier"] == tier
+        assert result.routing_decision["cause"] == "llm_classifier"
+        assert result.routing_decision["classifier_cost"] == 0.0001
+        assert result.messages is None
+        assert request == original
+        dependency.acompletion.assert_not_called()
+        call: Final = dependency.aresponses.call_args.kwargs
+        assert call["input"][-1] == task
+        assert "opaque-provider-task" not in json.dumps(call["input"][:-1])
+        assert "Prior task context" in json.dumps(call["input"][:-1])
+        assert "Caller constraints" in json.dumps(call["input"][:-1])
+        assert "Caller constraints" not in call["instructions"]
+        assert "SIMPLE" in call["instructions"] and "REASONING" in call["instructions"]
+        assert call["text"]["format"]["schema"]["properties"]["tier"]["enum"] == [
+            "SIMPLE", "MEDIUM", "COMPLEX", "REASONING"
+        ]
+        assert call["text"]["format"]["strict"] is True
+        assert call["reasoning"] == {"effort": "low"}
+        assert call["store"] is False
+        assert call["stream"] is False
+        assert "tools" not in call and "previous_response_id" not in call
+        assert "messages" not in call and "response_format" not in call
+        assert call["timeout"] == 0.1 and call["num_retries"] == 0 and call["disable_fallbacks"] is True
+        assert call["litellm_session_id"] == "parent-session"
+        assert call["litellm_trace_id"] == "parent-trace"
+        assert call["turn_off_message_logging"] is True
+        assert call["metadata"]["user_api_key_hash"] == "caller-key-hash"
+        assert call["proxy_server_request"]["body"]["input"] == call["input"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "items",
+        [
+            [{"type": "reasoning", "encrypted_content": "opaque-history", "summary": []}, {"role": "user", "content": "hi"}],
+            [_encrypted_agent_task(), {"role": "user", "content": "hi"}],
+            [{**_encrypted_agent_task(), "content": [{"type": "input_text", "text": "hi"}]}],
+            [{"role": "user", "content": "gAAAA is plain text"}],
+            [{"role": "user", "content": "hi"}, {"type": "function_call_output", "call_id": "call_1", "output": "opaque-provider-task"}],
+        ],
+        ids=["historical-reasoning", "older-encrypted-task", "plaintext-agent", "ciphertext-looking-text", "tool-output"],
+    )
+    async def test_other_asks_keep_chat_classifier(self, items: list[dict[str, object]]):
+        router, dependency = _native_classifier_router()
+
+        result: Final = await router.async_pre_routing_hook(model="encrypted-router", request_kwargs={"input": items})
+
+        assert result.model == "cheap-model"
+        assert result.routing_decision["cause"] == "llm_classifier"
+        dependency.aresponses.assert_not_called()
+        dependency.acompletion.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("output", ["", "not-json", '{"tier":"UNKNOWN"}'])
+    async def test_invalid_native_verdict_uses_existing_fallback(self, output: str):
+        router, dependency = _native_classifier_router(output=output)
+
+        result: Final = await router.async_pre_routing_hook(
+            model="encrypted-router", request_kwargs={"input": [_encrypted_agent_task()]}
+        )
+
+        assert result.model == "deep-model"
+        assert result.routing_decision["cause"] == "default_model_fallback"
+        dependency.aresponses.assert_awaited_once()
+        dependency.acompletion.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("deployment_model", ["anthropic/test-classifier", "openai/chat_completions/gpt-6-astra"])
+    async def test_incompatible_classifier_does_not_flatten_encryption(self, deployment_model: str):
+        router, dependency = _native_classifier_router(deployment_model=deployment_model)
+
+        result: Final = await router.async_pre_routing_hook(
+            model="encrypted-router", request_kwargs={"input": [_encrypted_agent_task()]}
+        )
+
+        assert result.model == "deep-model"
+        assert result.routing_decision["cause"] == "default_model_fallback"
+        dependency.aresponses.assert_not_called()
+        dependency.acompletion.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("failure", [ValueError("invalid_encrypted_content"), TimeoutError("classifier timed out")])
+    async def test_native_provider_failure_uses_existing_fallback(self, failure: Exception):
+        router, dependency = _native_classifier_router(failure=failure)
+
+        result: Final = await router.async_pre_routing_hook(
+            model="encrypted-router", request_kwargs={"input": [_encrypted_agent_task()]}
+        )
+
+        assert result.model == "deep-model"
+        assert result.routing_decision["cause"] == "default_model_fallback"
+        dependency.aresponses.assert_awaited_once()
+        dependency.acompletion.assert_not_called()
 
 
 class TestLLMClassifier:

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -5,8 +5,10 @@ Tests the rule-based complexity scoring and tier assignment logic.
 """
 
 import asyncio
+from collections.abc import AsyncIterator
 import json
 from copy import deepcopy
+from functools import partial
 import logging
 import sys
 import time
@@ -14,6 +16,7 @@ from typing import Dict, Final, List
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+import httpx
 from pydantic import ValidationError
 
 import litellm
@@ -69,6 +72,7 @@ from litellm.types.router import (
     TaggedPreRoutingStrategy,
 )
 from litellm.types.llms.openai import ResponsesAPIResponse
+from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
 
 
 requires_semantic_router = pytest.mark.skipif(
@@ -2520,11 +2524,21 @@ def _native_classifier_router(
     classifier_type: str = "llm",
     deployment_model: str = "openai/gpt-6-astra",
     failure: Exception | None = None,
+    native_router: Router | None = None,
+    http_handler: AsyncHTTPHandler | None = None,
 ) -> tuple[ComplexityRouter, MagicMock]:
     dependency: Final = MagicMock(
-        aresponses=AsyncMock(return_value=_native_classifier_response(output), side_effect=failure),
+        aresponses=(
+            native_router.factory_function(partial(litellm.aresponses, client=http_handler), call_type="aresponses")
+            if native_router is not None
+            else AsyncMock(return_value=_native_classifier_response(output), side_effect=failure)
+        ),
         acompletion=AsyncMock(return_value=_llm_response('{"tier":"SIMPLE"}')),
-        get_model_list=MagicMock(return_value=[{"litellm_params": {"model": deployment_model}}]),
+        get_model_list=(
+            native_router.get_model_list
+            if native_router is not None
+            else MagicMock(return_value=[{"litellm_params": {"model": deployment_model}}])
+        ),
     )
     return (
         ComplexityRouter(
@@ -2533,7 +2547,11 @@ def _native_classifier_router(
             complexity_router_config={
                 "tiers": {"SIMPLE": "cheap-model", "REASONING": "deep-model"},
                 "classifier_type": classifier_type,
-                "classifier_llm_config": {"model": "classifier", "timeout_ms": 100, "reasoning_effort": "low"},
+                "classifier_llm_config": {
+                    "model": "classifier",
+                    "timeout_ms": 5000 if native_router is not None else 100,
+                    "reasoning_effort": "low",
+                },
                 "heuristic_first_max_tier": "SIMPLE" if classifier_type == "heuristic_first" else None,
                 "hybrid_boundary_margin": 0.01 if classifier_type == "hybrid" else None,
                 "classifier_fallback": "default_model",
@@ -2544,6 +2562,18 @@ def _native_classifier_router(
         ),
         dependency,
     )
+
+
+@pytest.fixture
+async def native_classifier_http() -> AsyncIterator[tuple[AsyncHTTPHandler, MagicMock]]:
+    respond: Final = MagicMock(
+        return_value=httpx.Response(200, json=_native_classifier_response('{"tier":"REASONING"}').model_dump())
+    )
+    async with httpx.AsyncClient(transport=httpx.MockTransport(respond)) as client:
+        handler: Final = AsyncHTTPHandler()
+        await handler.client.aclose()
+        handler.client = client
+        yield handler, respond
 
 
 class TestEncryptedTaskClassifier:
@@ -2587,11 +2617,15 @@ class TestEncryptedTaskClassifier:
         assert "Caller constraints" not in call["instructions"]
         assert "SIMPLE" in call["instructions"] and "REASONING" in call["instructions"]
         assert call["text"]["format"]["schema"]["properties"]["tier"]["enum"] == [
-            "SIMPLE", "MEDIUM", "COMPLEX", "REASONING"
+            "SIMPLE",
+            "MEDIUM",
+            "COMPLEX",
+            "REASONING",
         ]
         assert call["text"]["format"]["strict"] is True
         assert call["reasoning"] == {"effort": "low"}
         assert call["store"] is False
+        assert call["_require_encrypted_task_support"] is True
         assert call["stream"] is False
         assert "tools" not in call and "previous_response_id" not in call
         assert "messages" not in call and "response_format" not in call
@@ -2606,13 +2640,25 @@ class TestEncryptedTaskClassifier:
     @pytest.mark.parametrize(
         "items",
         [
-            [{"type": "reasoning", "encrypted_content": "opaque-history", "summary": []}, {"role": "user", "content": "hi"}],
+            [
+                {"type": "reasoning", "encrypted_content": "opaque-history", "summary": []},
+                {"role": "user", "content": "hi"},
+            ],
             [_encrypted_agent_task(), {"role": "user", "content": "hi"}],
             [{**_encrypted_agent_task(), "content": [{"type": "input_text", "text": "hi"}]}],
             [{"role": "user", "content": "gAAAA is plain text"}],
-            [{"role": "user", "content": "hi"}, {"type": "function_call_output", "call_id": "call_1", "output": "opaque-provider-task"}],
+            [
+                {"role": "user", "content": "hi"},
+                {"type": "function_call_output", "call_id": "call_1", "output": "opaque-provider-task"},
+            ],
         ],
-        ids=["historical-reasoning", "older-encrypted-task", "plaintext-agent", "ciphertext-looking-text", "tool-output"],
+        ids=[
+            "historical-reasoning",
+            "older-encrypted-task",
+            "plaintext-agent",
+            "ciphertext-looking-text",
+            "tool-output",
+        ],
     )
     async def test_other_asks_keep_chat_classifier(self, items: list[dict[str, object]]):
         router, dependency = _native_classifier_router()
@@ -2639,9 +2685,28 @@ class TestEncryptedTaskClassifier:
         dependency.acompletion.assert_not_called()
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("deployment_model", ["anthropic/test-classifier", "openai/chat_completions/gpt-6-astra"])
-    async def test_incompatible_classifier_does_not_flatten_encryption(self, deployment_model: str):
-        router, dependency = _native_classifier_router(deployment_model=deployment_model)
+    @pytest.mark.parametrize(
+        "deployment_model",
+        ["anthropic/test-classifier", "openai/chat_completions/gpt-6-astra", "xai/test-classifier"],
+    )
+    async def test_incompatible_classifier_does_not_flatten_encryption(
+        self, deployment_model: str, native_classifier_http: tuple[AsyncHTTPHandler, MagicMock]
+    ):
+        handler, respond = native_classifier_http
+        native: Final = Router(
+            model_list=[
+                {
+                    "model_name": "classifier",
+                    "litellm_params": {
+                        "model": deployment_model,
+                        "api_key": "test-key",
+                        "api_base": "https://classifier.test/v1",
+                    },
+                }
+            ],
+            num_retries=0,
+        )
+        router, _ = _native_classifier_router(native_router=native, http_handler=handler)
 
         result: Final = await router.async_pre_routing_hook(
             model="encrypted-router", request_kwargs={"input": [_encrypted_agent_task()]}
@@ -2649,8 +2714,72 @@ class TestEncryptedTaskClassifier:
 
         assert result.model == "deep-model"
         assert result.routing_decision["cause"] == "default_model_fallback"
+        respond.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("blocked", [True, False])
+    async def test_native_classifier_validates_selected_deployment(
+        self, blocked: bool, native_classifier_http: tuple[AsyncHTTPHandler, MagicMock]
+    ):
+        handler, respond = native_classifier_http
+        native: Final = Router(
+            model_list=[
+                {
+                    "model_name": "classifier",
+                    "litellm_params": {"model": "anthropic/test-classifier", "api_key": "test-key", "order": 0},
+                    "model_info": {"id": "incompatible", "blocked": blocked},
+                },
+                {
+                    "model_name": "classifier",
+                    "litellm_params": {
+                        "model": "openai/gpt-6-astra",
+                        "api_key": "test-key",
+                        "order": 1,
+                        "api_base": "https://classifier.test/v1",
+                    },
+                    "model_info": {"id": "compatible"},
+                },
+            ],
+            num_retries=0,
+        )
+        router, _ = _native_classifier_router(native_router=native, http_handler=handler)
+        task: Final = _encrypted_agent_task()
+
+        result: Final = await router.async_pre_routing_hook(model="encrypted-router", request_kwargs={"input": [task]})
+
+        assert result.model == "deep-model"
+        assert result.routing_decision["cause"] == ("llm_classifier" if blocked else "default_model_fallback")
+        if blocked:
+            respond.assert_called_once()
+            request: Final = respond.call_args.args[0]
+            assert request.url.path == "/v1/responses"
+            body: Final = json.loads(request.content)
+            assert body["input"][-1] == task
+            assert "_require_encrypted_task_support" not in body
+        else:
+            respond.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("classifier_type", ["llm", "heuristic_first", "hybrid"])
+    @pytest.mark.parametrize(
+        "input_items",
+        [
+            ["unsupported-input-item"],
+            [{**_encrypted_agent_task(), "content": [{"type": "input_text", "text": "hi"}, None]}],
+        ],
+    )
+    async def test_encrypted_detection_does_not_reject_other_input_shapes(
+        self, classifier_type: str, input_items: list[object]
+    ):
+        router, dependency = _native_classifier_router(classifier_type=classifier_type)
+
+        result: Final = await router.aclassify("hi", request_kwargs={"input": input_items})
+
+        assert result.cause != "default_model_fallback"
+        assert result.tier == ComplexityTier.SIMPLE
         dependency.aresponses.assert_not_called()
-        dependency.acompletion.assert_not_called()
+        if classifier_type == "llm":
+            dependency.acompletion.assert_awaited_once()
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("failure", [ValueError("invalid_encrypted_content"), TimeoutError("classifier timed out")])


### PR DESCRIPTION
## TLDR

Problem this solves:

- Encrypted delegated tasks reach the classifier as meaningless text
- Difficult tasks receive a valid but incorrect SIMPLE classification

How it solves it:

- Preserve encrypted task blocks in native Responses classifier calls
- Reuse the existing rubric, tier selection, and failure policy
- Check provider compatibility after normal deployment selection
- Respect request-specific reminder markers when finding encrypted tasks
- Keep ordinary classification and routed execution input unchanged

## User Flow

Before: the difficult encrypted Codex task succeeds on the cheapest model

1. Send `POST http://127.0.0.1:4017/v1/responses` with the `lit7493-repro` test route and a Codex `agent_message` containing the encrypted delegated task
2. Receive HTTP 200 and a completed answer, with model `openai/openai/gpt-5.6-luna` and classification SIMPLE
3. Repeat with streaming enabled and observe the same model and tier
4. Append a user message containing `<environment_context>cwd=/repo</environment_context>` and send with `User-Agent: codex-tui`; observe the same model and tier

After: the difficult encrypted task reaches the reasoning tier, while an easy encrypted task stays cheap

1. Send the same body to `POST http://127.0.0.1:4018/v1/responses` with the `lit7493-repro` test route and the same encrypted delegated task
2. Receive HTTP 200 and a completed answer, with model `openai/openai/gpt-6-astra` and classification REASONING
3. Repeat with streaming enabled and observe the same model and tier
4. Append a user message containing `<environment_context>cwd=/repo</environment_context>` and send with `User-Agent: codex-tui`; observe the same model and tier

## Relevant issues

Related: LIT-7490 and LIT-7492

## Linear ticket

Resolves LIT-7493

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

Local validation: 1,166 tests passed across the complexity router, Responses conversion, bridge selection, and OpenAI Responses transformation test files, with no skips. `make check` passed, including Ruff, typing budgets, circular imports, and import safety

Coverage includes dynamic tier selection, heuristic shortcut bypass, ordinary and historical-encryption requests, preserved caller context and execution input, cost and logging attribution, blocked classifier deployments, selected incompatible providers, non-matching input shapes, request-specific Codex reminders, non-Codex tagged asks, public error mapping, malformed verdicts, provider errors, and timeouts

## Screenshots / Proof of Fix

Live provider calls on September 10, 2026. The test route reproduces the `auto/codex-subagent` protocol using an isolated local proxy configuration. The encrypted easy and difficult payloads were produced by OpenAI through the reserved `collaboration` namespace and reused unchanged across both checkouts. No local encryption/decryption or mocked provider responses were used

The extra `x-repro-tier` and `x-repro-cause` headers below come from a local QA callback, not a new public API. `x-litellm-model-name` is the standard proxy header. All four streaming requests per checkout ended with `response.completed`, and all eight requests per checkout completed without a classifier fallback. The blocked-deployment case uses the same difficult task, with a blocked incompatible member ahead of the compatible classifier in its model group

<details>
<summary>Shared setup: configuration, encrypted task generation, and proxy launch</summary>

Use an OpenAI gateway credential in `LIT7493_GATEWAY_KEY`. The same gateway access must generate the encrypted content and serve the classifier. Save this as `proxy.yaml`

```yaml
model_list:
- model_name: openai/gpt-6-astra
  litellm_params:
    model: openai/openai/gpt-6-astra
    api_base: https://gateway.litellm-sandbox.ai/v1
    api_key: os.environ/LIT7493_GATEWAY_KEY
- model_name: openai/gpt-5.6-luna
  litellm_params:
    model: openai/openai/gpt-5.6-luna
    api_base: https://gateway.litellm-sandbox.ai/v1
    api_key: os.environ/LIT7493_GATEWAY_KEY
- model_name: lit7493-repro
  litellm_params:
    model: auto_router/complexity_router
    complexity_router_config:
      tiers:
        SIMPLE: openai/gpt-5.6-luna
        MEDIUM: openai/gpt-6-astra
        COMPLEX: openai/gpt-6-astra
        REASONING: openai/gpt-6-astra
      classifier_type: llm
      classifier_llm_config:
        model: openai/gpt-6-astra
        timeout_ms: 60000
        reasoning_effort: low
        classification_rubric: agentic
      session_affinity: false
      deployment_affinity: false
      classifier_context_window_size: 0
      default_model: openai/gpt-6-astra
      classifier_fallback: default_model
      max_tokens_from_tier_model: false
- model_name: review-classifier
  litellm_params:
    model: anthropic/test-classifier
    api_key: unused
    api_base: https://blocked.invalid
    order: 0
  model_info:
    blocked: true
    id: blocked-incompatible-classifier
- model_name: review-classifier
  litellm_params:
    model: openai/openai/gpt-6-astra
    api_base: https://gateway.litellm-sandbox.ai/v1
    api_key: os.environ/LIT7493_GATEWAY_KEY
    order: 1
  model_info:
    id: compatible-classifier
- model_name: lit7493-blocked-repro
  litellm_params:
    model: auto_router/complexity_router
    complexity_router_config:
      tiers:
        SIMPLE: openai/gpt-5.6-luna
        MEDIUM: openai/gpt-6-astra
        COMPLEX: openai/gpt-6-astra
        REASONING: openai/gpt-6-astra
      classifier_type: llm
      classifier_llm_config:
        model: review-classifier
        timeout_ms: 60000
        reasoning_effort: low
        classification_rubric: agentic
      session_affinity: false
      deployment_affinity: false
      classifier_context_window_size: 0
      default_model: openai/gpt-6-astra
      classifier_fallback: default_model
      max_tokens_from_tier_model: false
litellm_settings:
  callbacks:
  - capture.callback
  telemetry: false
router_settings:
  num_retries: 0
```

Save this QA header callback as `capture.py` beside the configuration

```python
from litellm.integrations.custom_logger import CustomLogger

class Capture(CustomLogger):
    async def async_post_call_response_headers_hook(
        self, data, user_api_key_dict, response, request_headers=None, litellm_call_info=None
    ):
        metadata = data.get("litellm_metadata") or data.get("metadata") or {}
        decision = metadata.get("routing_decision") or {}
        return {
            "x-repro-tier": str(decision.get("tier", "")),
            "x-repro-cause": str(decision.get("cause", "")),
        }

callback = Capture()
```

Save the parent request as `parent.json`

```json
{
  "model": "openai/gpt-6-astra",
  "input": "Delegate the following task using collaboration.spawn_agent with task_name child. Put the full task verbatim in message. Do not solve it yourself. Task: Analyze a distributed payment processor for duplicate charges under concurrent retries, delayed webhooks, database failover, and partial network partitions. Propose an idempotency protocol, reason about its safety and liveness, and identify a counterexample to a naive check-then-insert implementation. Keep your answer under 120 words.",
  "tools": [
    {
      "type": "namespace",
      "name": "collaboration",
      "description": "Delegate work to another agent",
      "tools": [
        {
          "type": "function",
          "name": "spawn_agent",
          "description": "Start a child agent on a task",
          "parameters": {
            "type": "object",
            "properties": {
              "task_name": {
                "type": "string"
              },
              "message": {
                "type": "string",
                "encrypted": true
              }
            },
            "required": [
              "task_name",
              "message"
            ],
            "additionalProperties": false
          },
          "strict": true
        }
      ]
    }
  ],
  "tool_choice": "required",
  "include": [
    "reasoning.encrypted_content"
  ],
  "store": false,
  "max_output_tokens": 2000,
  "reasoning": {
    "effort": "low"
  }
}
```

Generate each encrypted task and its streaming/non-streaming child request

```bash
mkdir -p before after
for task_case in difficult easy; do
  if [ "$task_case" = easy ]; then
    jq '.input = "Delegate the following task using collaboration.spawn_agent with task_name child. Put the full task verbatim in message. Do not solve it yourself. Task: Reply with the single word hello."' parent.json > parent-current.json
  else
    cp parent.json parent-current.json
  fi
  curl --silent --show-error --max-time 120 \
    https://gateway.litellm-sandbox.ai/v1/responses \
    -H "Authorization: Bearer ${LIT7493_GATEWAY_KEY}" \
    -H 'Content-Type: application/json' \
    --data-binary @parent-current.json -o "parent-${task_case}.json"
  for task_stream in false true; do
    jq --argjson stream "$task_stream" '
      (.output[] | select(.type == "function_call" and .name == "spawn_agent") | .arguments | fromjson | .message) as $cipher |
      {model: "lit7493-repro", input: [{
        type: "agent_message", author: "/root", recipient: "/root/child",
        content: [
          {type: "input_text", text: "Message Type: NEW_TASK\nTask name: /root/child\nPayload:\n"},
          {type: "encrypted_content", encrypted_content: $cipher}
        ]
      }], store: false, max_output_tokens: 1500, reasoning: {effort: "low"}, stream: $stream}
    ' "parent-${task_case}.json" > "${task_case}-${task_stream}.json"
  done
done
```

Create the blocked-deployment variant from the same difficult task

```bash
for task_stream in false true; do
  jq '.model = "lit7493-blocked-repro"' "difficult-${task_stream}.json" > "blocked-${task_stream}.json"
done
```

Create the Codex environment-reminder variant from the same difficult task

```bash
for task_stream in false true; do
  jq '.input += [{role: "user", content: "<environment_context>cwd=/repo</environment_context>"}]' "difficult-${task_stream}.json" > "reminder-${task_stream}.json"
done
```

Start a proxy from each checkout, with this directory on `PYTHONPATH` for the QA callback. The recorded baseline used port 4017 and the PR tip used 4018

```bash
PYTHONPATH="$CHECKOUT:$QA_DIR" "$PYTHON" "$CHECKOUT/litellm/proxy/proxy_cli.py" \
  --config "$QA_DIR/proxy.yaml" --host 127.0.0.1 --port "$PORT"
```

</details>

### Before (692a311efb781dd512656434faaac6e7e7d56641)

#### Difficult encrypted task

1. Send the same encrypted task with streaming disabled and enabled

   ```bash
   for task_stream in false true; do
     curl --silent --show-error --max-time 120 http://127.0.0.1:4017/v1/responses \
       -H 'Content-Type: application/json' -H 'User-Agent: codex-tui' \
       --data-binary @"difficult-${task_stream}.json" \
       -D "before/difficult-${task_stream}.headers" \
       -o "before/difficult-${task_stream}.response" \
       -w "difficult stream=${task_stream} HTTP %{http_code}\n"
   done
   ```

2. Observe the HTTP status and saved response headers

   ```text
   stream=false HTTP 200
   x-litellm-model-name: openai/openai/gpt-5.6-luna
   x-repro-tier: SIMPLE
   x-repro-cause: llm_classifier
   x-litellm-call-id: 17ec753c-9ea2-4c8a-96fb-9f08f8b3b223
   response status: completed

   stream=true HTTP 200
   x-litellm-model-name: openai/openai/gpt-5.6-luna
   x-repro-tier: SIMPLE
   x-repro-cause: llm_classifier
   x-litellm-call-id: 8ce5fb52-0e53-4028-8c2d-e90996a00c77
   response status: completed
   ```

#### Easy encrypted task

1. Send the same encrypted task with streaming disabled and enabled

   ```bash
   for task_stream in false true; do
     curl --silent --show-error --max-time 120 http://127.0.0.1:4017/v1/responses \
       -H 'Content-Type: application/json' -H 'User-Agent: codex-tui' \
       --data-binary @"easy-${task_stream}.json" \
       -D "before/easy-${task_stream}.headers" \
       -o "before/easy-${task_stream}.response" \
       -w "easy stream=${task_stream} HTTP %{http_code}\n"
   done
   ```

2. Observe the HTTP status and saved response headers

   ```text
   stream=false HTTP 200
   x-litellm-model-name: openai/openai/gpt-5.6-luna
   x-repro-tier: SIMPLE
   x-repro-cause: llm_classifier
   x-litellm-call-id: c49e1987-b40e-4378-bd78-a8a4a980b62a
   response status: completed
   output: hello

   stream=true HTTP 200
   x-litellm-model-name: openai/openai/gpt-5.6-luna
   x-repro-tier: SIMPLE
   x-repro-cause: llm_classifier
   x-litellm-call-id: 2eee0b66-2339-428e-a136-64a170f27072
   response status: completed
   output: hello
   ```

#### Blocked incompatible classifier

1. Send the same encrypted task with streaming disabled and enabled

   ```bash
   for task_stream in false true; do
     curl --silent --show-error --max-time 120 http://127.0.0.1:4017/v1/responses \
       -H 'Content-Type: application/json' -H 'User-Agent: codex-tui' \
       --data-binary @"blocked-${task_stream}.json" \
       -D "before/blocked-${task_stream}.headers" \
       -o "before/blocked-${task_stream}.response" \
       -w "blocked stream=${task_stream} HTTP %{http_code}\n"
   done
   ```

2. Observe the HTTP status and saved response headers

   ```text
   stream=false HTTP 200
   x-litellm-model-name: openai/openai/gpt-5.6-luna
   x-repro-tier: SIMPLE
   x-repro-cause: llm_classifier
   x-litellm-call-id: 1644a89d-824b-4d8a-ac7c-23af53effc8f
   response status: completed

   stream=true HTTP 200
   x-litellm-model-name: openai/openai/gpt-5.6-luna
   x-repro-tier: SIMPLE
   x-repro-cause: llm_classifier
   x-litellm-call-id: 79a5969f-314c-4149-b67a-31b22aba888c
   response status: completed
   ```

#### Codex environment reminder after encrypted task

1. Send the same encrypted task with streaming disabled and enabled

   ```bash
   for task_stream in false true; do
     curl --silent --show-error --max-time 120 http://127.0.0.1:4017/v1/responses \
       -H 'Content-Type: application/json' -H 'User-Agent: codex-tui' \
       --data-binary @"reminder-${task_stream}.json" \
       -D "before/reminder-${task_stream}.headers" \
       -o "before/reminder-${task_stream}.response" \
       -w "reminder stream=${task_stream} HTTP %{http_code}\n"
   done
   ```

2. Observe the HTTP status and saved response headers

   ```text
   stream=false HTTP 200
   x-litellm-model-name: openai/openai/gpt-5.6-luna
   x-repro-tier: SIMPLE
   x-repro-cause: llm_classifier
   x-litellm-call-id: e5fc9ebb-ec32-4f84-b64e-525012134ea8
   response status: completed

   stream=true HTTP 200
   x-litellm-model-name: openai/openai/gpt-5.6-luna
   x-repro-tier: SIMPLE
   x-repro-cause: llm_classifier
   x-litellm-call-id: 3e09b18a-e607-408f-a784-bedb921b4d16
   response status: completed
   ```

### After (d266b76a8bcbb6cbec408eeeb8758a7af1a92644)

#### Difficult encrypted task

1. Send the same encrypted task with streaming disabled and enabled

   ```bash
   for task_stream in false true; do
     curl --silent --show-error --max-time 120 http://127.0.0.1:4018/v1/responses \
       -H 'Content-Type: application/json' -H 'User-Agent: codex-tui' \
       --data-binary @"difficult-${task_stream}.json" \
       -D "after/difficult-${task_stream}.headers" \
       -o "after/difficult-${task_stream}.response" \
       -w "difficult stream=${task_stream} HTTP %{http_code}\n"
   done
   ```

2. Observe the HTTP status and saved response headers

   ```text
   stream=false HTTP 200
   x-litellm-model-name: openai/openai/gpt-6-astra
   x-repro-tier: REASONING
   x-repro-cause: llm_classifier
   x-litellm-call-id: b29e5b07-a42f-4de9-a478-f1ad9a02f942
   response status: completed

   stream=true HTTP 200
   x-litellm-model-name: openai/openai/gpt-6-astra
   x-repro-tier: REASONING
   x-repro-cause: llm_classifier
   x-litellm-call-id: 7accdaa0-c765-4acd-957a-27afa635659d
   response status: completed
   ```

#### Easy encrypted task

1. Send the same encrypted task with streaming disabled and enabled

   ```bash
   for task_stream in false true; do
     curl --silent --show-error --max-time 120 http://127.0.0.1:4018/v1/responses \
       -H 'Content-Type: application/json' -H 'User-Agent: codex-tui' \
       --data-binary @"easy-${task_stream}.json" \
       -D "after/easy-${task_stream}.headers" \
       -o "after/easy-${task_stream}.response" \
       -w "easy stream=${task_stream} HTTP %{http_code}\n"
   done
   ```

2. Observe the HTTP status and saved response headers

   ```text
   stream=false HTTP 200
   x-litellm-model-name: openai/openai/gpt-5.6-luna
   x-repro-tier: SIMPLE
   x-repro-cause: llm_classifier
   x-litellm-call-id: 13b08419-e7dc-437c-bcd9-634d39344236
   response status: completed
   output: hello

   stream=true HTTP 200
   x-litellm-model-name: openai/openai/gpt-5.6-luna
   x-repro-tier: SIMPLE
   x-repro-cause: llm_classifier
   x-litellm-call-id: 935f9988-51e1-42bc-9b57-44398622cbb2
   response status: completed
   output: hello
   ```

#### Blocked incompatible classifier

1. Send the same encrypted task with streaming disabled and enabled

   ```bash
   for task_stream in false true; do
     curl --silent --show-error --max-time 120 http://127.0.0.1:4018/v1/responses \
       -H 'Content-Type: application/json' -H 'User-Agent: codex-tui' \
       --data-binary @"blocked-${task_stream}.json" \
       -D "after/blocked-${task_stream}.headers" \
       -o "after/blocked-${task_stream}.response" \
       -w "blocked stream=${task_stream} HTTP %{http_code}\n"
   done
   ```

2. Observe the HTTP status and saved response headers

   ```text
   stream=false HTTP 200
   x-litellm-model-name: openai/openai/gpt-6-astra
   x-repro-tier: REASONING
   x-repro-cause: llm_classifier
   x-litellm-call-id: c5885a35-1e5b-4a21-b7e9-5433a27f79e6
   response status: completed

   stream=true HTTP 200
   x-litellm-model-name: openai/openai/gpt-6-astra
   x-repro-tier: REASONING
   x-repro-cause: llm_classifier
   x-litellm-call-id: 683bc36a-eeea-4a27-8d8b-70e3fd224f80
   response status: completed
   ```

#### Codex environment reminder after encrypted task

1. Send the same encrypted task with streaming disabled and enabled

   ```bash
   for task_stream in false true; do
     curl --silent --show-error --max-time 120 http://127.0.0.1:4018/v1/responses \
       -H 'Content-Type: application/json' -H 'User-Agent: codex-tui' \
       --data-binary @"reminder-${task_stream}.json" \
       -D "after/reminder-${task_stream}.headers" \
       -o "after/reminder-${task_stream}.response" \
       -w "reminder stream=${task_stream} HTTP %{http_code}\n"
   done
   ```

2. Observe the HTTP status and saved response headers

   ```text
   stream=false HTTP 200
   x-litellm-model-name: openai/openai/gpt-6-astra
   x-repro-tier: REASONING
   x-repro-cause: llm_classifier
   x-litellm-call-id: 00861b61-550a-4318-9121-71c97fcb23e3
   response status: completed

   stream=true HTTP 200
   x-litellm-model-name: openai/openai/gpt-6-astra
   x-repro-tier: REASONING
   x-repro-cause: llm_classifier
   x-litellm-call-id: cee86325-86f9-4049-8468-10fc8327d180
   response status: completed
   ```

## Type

Bug Fix

## Caveats (if any)

### Medium

- Classifier credentials must be able to consume the encrypted content
- Other providers and decryption failures retain configured fallback behavior

### Low

- Live verification used OpenAI; Azure transport was not exercised
- Verification covered Codex request payloads through the Responses endpoint

## Final Attestation

- [x] The tests check the affected behavior and its relevant edge cases

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auto-router classification and Responses dispatch for encrypted agent tasks; misconfiguration or provider gaps fall back to default tier rather than wrong SIMPLE routing, but routing spend and tier outcomes shift for affected Codex-style requests.
> 
> **Overview**
> Fixes complexity-router misclassification when the **current** Responses `input` is an `agent_message` with `encrypted_content` (delegated Codex tasks), which previously went through chat completions and looked like trivial plaintext.
> 
> The router now detects that shape (newest human ask, request-specific reminder markers), **forces the LLM classifier** for `heuristic_first`/`hybrid` shortcuts, and calls **`aresponses`** with a native payload that appends the stripped `agent_message` and sets `_require_encrypted_task_support`. Tier JSON is read from `output_text`; existing `classifier_fallback` behavior is unchanged for incompatible deployments, bad verdicts, and provider errors.
> 
> **Responses API** gains an opt-in `_require_encrypted_task_support` gate: before dispatch, it rejects bridged or non-native providers via `supports_encrypted_agent_messages()` (enabled on OpenAI/Azure). A small public `transform_response_format_to_text_format` helper supports building classifier `text.format`. Docs and tests cover detection edge cases, deployment selection, and no-upstream-call rejection for incompatible classifiers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d266b76a8bcbb6cbec408eeeb8758a7af1a92644. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->