### PR TITLE
fix(guardrails): fail closed with a named error when a Responses input rewrite cannot be applied

### DIFF
--- a/litellm/llms/openai/responses/guardrail_translation/handler.py
+++ b/litellm/llms/openai/responses/guardrail_translation/handler.py
@@ -497,9 +497,14 @@ class OpenAIResponsesHandler(BaseTranslation):
             guardrailed_texts: Final = guardrailed_inputs.get("texts") or ()
             data["input"] = guardrailed_texts[0] if guardrailed_texts else input_data  # rebind-ok: data is an out-param
         else:
+            rewritten_texts: Final = guardrailed_inputs.get("texts") or ()
+            if len(rewritten_texts) != len(extracted.task_mappings):
+                from litellm.proxy.policy_engine.pipeline_executor import UnappliableRequestRewrite
+
+                raise UnappliableRequestRewrite(guardrail_to_apply.guardrail_name or "unknown")
             await self._apply_guardrail_responses_to_input(
                 messages=input_data,
-                responses=guardrailed_inputs.get("texts") or (),
+                responses=rewritten_texts,
                 task_mappings=extracted.task_mappings,
             )
         verbose_proxy_logger.debug("OpenAI Responses API: Processed input messages: %s", data.get("input"))
@@ -635,10 +640,12 @@ class OpenAIResponsesHandler(BaseTranslation):
         """
         Apply guardrail responses back to input messages.
 
+        ``responses`` pairs positionally with ``task_mappings``; the caller rejects
+        the request when the two disagree, so this never has to guess an alignment.
+
         Override this method to customize how responses are applied.
         """
-        for task_idx, guardrail_response in enumerate(responses):
-            mapping = task_mappings[task_idx]
+        for guardrail_response, mapping in zip(responses, task_mappings):
             msg_idx = cast(int, mapping[0])
             content_idx_optional = cast(int | None, mapping[1])
 

--- a/litellm/proxy/guardrails/guardrail_hooks/crowdstrike_aidr/crowdstrike_aidr.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/crowdstrike_aidr/crowdstrike_aidr.py
@@ -18,6 +18,7 @@ from litellm.llms.base_llm.guardrail_translation.utils import (
     effective_skip_tool_message_for_guardrail,
 )
 from litellm.llms.custom_httpx.http_handler import (
+    AsyncHTTPHandler,
     get_async_httpx_client,
     httpxSpecialProvider,
 )
@@ -261,6 +262,7 @@ class CrowdStrikeAIDRHandler(CustomGuardrail):
         fail_on_error: bool | None = True,
         streaming_end_of_stream_only: bool | None = None,
         streaming_sampling_rate: int | None = None,
+        async_handler: AsyncHTTPHandler | None = None,
         **kwargs,
     ) -> None:
         """
@@ -273,9 +275,13 @@ class CrowdStrikeAIDRHandler(CustomGuardrail):
             streaming_end_of_stream_only (bool | None): Scan streamed output once at end of stream instead of
                 every streaming_sampling_rate chunks. Defaults to False.
             streaming_sampling_rate (int | None): Scan the accumulated streamed output every Nth chunk. Defaults to 5.
+            async_handler (AsyncHTTPHandler | None): HTTP client to call AI Guard with. Defaults to the shared
+                guardrail-callback client.
             **kwargs: Additional arguments passed to the CustomGuardrail base class.
         """
-        self.async_handler = get_async_httpx_client(llm_provider=httpxSpecialProvider.GuardrailCallback)
+        self.async_handler = async_handler or get_async_httpx_client(
+            llm_provider=httpxSpecialProvider.GuardrailCallback
+        )
         self.fail_on_error = True if fail_on_error is None else fail_on_error
         self._set_streaming_params(
             CrowdStrikeAIDRGuardrailConfigModelOptionalParams(

--- a/litellm/proxy/policy_engine/pipeline_executor.py
+++ b/litellm/proxy/policy_engine/pipeline_executor.py
@@ -58,6 +58,15 @@ class UndeliverableStreamRewrite(Exception):
         self.guardrail_name: Final = guardrail_name
 
 
+class UnappliableRequestRewrite(Exception):
+    def __init__(self, guardrail_name: str) -> None:
+        super().__init__(
+            f"Guardrail '{guardrail_name}' rewrote the request in a way this endpoint cannot apply, "
+            "so the request was rejected rather than sent unrewritten"
+        )
+        self.guardrail_name: Final = guardrail_name
+
+
 def _tool_call_shape(tool_call: object) -> tuple[object, object]:
     plain: Final = tool_call.model_dump() if isinstance(tool_call, BaseModel) else tool_call
     function: Final = plain.get("function") if isinstance(plain, Mapping) else None

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_crowdstrike_aidr.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_crowdstrike_aidr.py
@@ -1,3 +1,6 @@
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Final, cast
 from unittest.mock import patch
 
 import httpx
@@ -7,6 +10,9 @@ from pydantic import ValidationError
 
 import litellm
 from litellm.exceptions import Timeout
+from litellm.integrations.custom_guardrail import CustomGuardrail
+from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
+from litellm.llms.openai.responses.guardrail_translation.handler import OpenAIResponsesHandler
 from litellm.litellm_core_utils.core_helpers import get_or_create_metadata_bucket
 from litellm.proxy.guardrails.guardrail_hooks.crowdstrike_aidr import initialize_guardrail
 from litellm.proxy.guardrails.guardrail_hooks.crowdstrike_aidr.crowdstrike_aidr import (
@@ -1719,3 +1725,114 @@ async def test_streaming_params_from_config_control_output_scan_cadence(
     handler = _initialize_from_config(mode="post_call", **configured)
 
     assert await _guard_calls_for_stream(handler, list("ABCDEFGHIJ")) == expected_calls
+
+
+@asynccontextmanager
+async def _guardrail_transforming_into(messages: list[dict[str, object]]) -> AsyncIterator[CrowdStrikeAIDRHandler]:
+    """A guardrail whose AI Guard returns ``messages`` as its rewrite."""
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            status_code=200,
+            json={
+                "result": {
+                    "blocked": False,
+                    "transformed": True,
+                    "guard_output": {"messages": messages},
+                },
+            },
+            request=request,
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(respond)) as client:
+        handler: Final = AsyncHTTPHandler()
+        handler.client = client
+        yield CrowdStrikeAIDRHandler(
+            mode="pre_call",
+            guardrail_name="crowdstrike-aidr-guard",
+            api_key="pts_crowdstrike_tokenid",
+            api_base="https://api.crowdstrike.com/aidr/aiguard",
+            async_handler=handler,
+        )
+
+
+class _MessageShapedGuardrail(CustomGuardrail):
+    """Returns one text per chat message and no ``structured_messages`` rewrite.
+
+    Prompt Security and friends scan messages rather than Responses text parts,
+    which is the shape that outnumbers the endpoint's own bookkeeping.
+    """
+
+    def __init__(self, redacted: str) -> None:
+        super().__init__(guardrail_name="message-shaped")
+        self.redacted: Final = redacted
+
+    async def apply_guardrail(
+        self,
+        inputs: GenericGuardrailAPIInputs,
+        request_data: dict,
+        input_type: str,
+        logging_obj: object = None,
+    ) -> GenericGuardrailAPIInputs:
+        messages: Final = inputs.get("structured_messages") or ()
+        return {"texts": [self.redacted for _ in messages]}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("case", "instructions", "responses_input"),
+    [
+        (
+            "instructions add a system message",
+            "be terse",
+            [{"role": "user", "content": [{"type": "input_text", "text": "my ssn is 078-05-1120"}]}],
+        ),
+        (
+            "tool items add messages that carry no text",
+            None,
+            [
+                {"role": "user", "content": [{"type": "input_text", "text": "my ssn is 078-05-1120"}]},
+                {"type": "function_call", "call_id": "c1", "name": "get_x", "arguments": "{}"},
+                {"type": "function_call_output", "call_id": "c1", "output": "42"},
+            ],
+        ),
+    ],
+)
+async def test_unalignable_rewrite_is_rejected_never_sent_unredacted(
+    case: str,
+    instructions: str | None,
+    responses_input: list[dict[str, object]],
+) -> None:
+    """An unalignable rewrite must fail the request, not forward the raw prompt.
+
+    Skipping the write-back would hand the model the unredacted text, so a
+    guardrail could be bypassed by adding ``instructions`` or a tool call.
+    """
+    from litellm.proxy.policy_engine.pipeline_executor import UnappliableRequestRewrite
+
+    data: dict[str, object] = {"model": "gpt-4o", "input": responses_input}
+    if instructions is not None:
+        data["instructions"] = instructions
+
+    with pytest.raises(UnappliableRequestRewrite):
+        await OpenAIResponsesHandler().process_input_messages(
+            data=data,
+            guardrail_to_apply=_MessageShapedGuardrail("my ssn is <US_SSN>"),
+        )
+
+    assert "078-05-1120" in str(responses_input), case
+
+
+@pytest.mark.asyncio
+async def test_aligned_rewrite_is_written_back() -> None:
+    """Matching counts must still redact the input in place."""
+    responses_input: list[dict[str, object]] = [
+        {"role": "user", "content": [{"type": "input_text", "text": "my ssn is 078-05-1120"}]}
+    ]
+
+    await OpenAIResponsesHandler().process_input_messages(
+        data={"model": "gpt-4o", "input": responses_input},
+        guardrail_to_apply=_MessageShapedGuardrail("my ssn is <US_SSN>"),
+    )
+
+    assert cast(list, responses_input[0]["content"])[0]["text"] == "my ssn is <US_SSN>"

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_crowdstrike_aidr.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_crowdstrike_aidr.py
@@ -1,6 +1,7 @@
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Final, cast
+import json
 from unittest.mock import patch
 
 import httpx
@@ -1728,17 +1729,28 @@ async def test_streaming_params_from_config_control_output_scan_cadence(
 
 
 @asynccontextmanager
-async def _guardrail_transforming_into(messages: list[dict[str, object]]) -> AsyncIterator[CrowdStrikeAIDRHandler]:
-    """A guardrail whose AI Guard returns ``messages`` as its rewrite."""
+async def _guardrail_redacting(secret: str, replacement: str) -> AsyncIterator[CrowdStrikeAIDRHandler]:
+    def redacted(content: object) -> object:
+        if isinstance(content, str):
+            return content.replace(secret, replacement)
+        if isinstance(content, list):
+            return [
+                {**part, "text": redacted(part["text"])} if isinstance(part, dict) and "text" in part else part
+                for part in content
+            ]
+        return content
 
     def respond(request: httpx.Request) -> httpx.Response:
+        sent: Final = json.loads(request.content)["guard_input"]["messages"]
         return httpx.Response(
             status_code=200,
             json={
                 "result": {
                     "blocked": False,
                     "transformed": True,
-                    "guard_output": {"messages": messages},
+                    "guard_output": {
+                        "messages": [{**message, "content": redacted(message.get("content"))} for message in sent]
+                    },
                 },
             },
             request=request,
@@ -1836,3 +1848,43 @@ async def test_aligned_rewrite_is_written_back() -> None:
     )
 
     assert cast(list, responses_input[0]["content"])[0]["text"] == "my ssn is <US_SSN>"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("case", "responses_input", "redacted_input"),
+    [
+        (
+            "instructions add a system message",
+            [{"role": "user", "content": [{"type": "input_text", "text": "my ssn is 078-05-1120"}]}],
+            [{"role": "user", "content": [{"type": "input_text", "text": "my ssn is <US_SSN>"}]}],
+        ),
+        (
+            "tool items sit between two user turns",
+            [
+                {"role": "user", "content": [{"type": "input_text", "text": "hello"}]},
+                {"type": "function_call", "call_id": "c1", "name": "get_x", "arguments": "{}"},
+                {"type": "function_call_output", "call_id": "c1", "output": "42"},
+                {"role": "user", "content": [{"type": "input_text", "text": "my ssn is 078-05-1120"}]},
+            ],
+            [
+                {"role": "user", "content": [{"type": "input_text", "text": "hello"}]},
+                {"type": "function_call", "call_id": "c1", "name": "get_x", "arguments": "{}"},
+                {"type": "function_call_output", "call_id": "c1", "output": "42"},
+                {"role": "user", "content": [{"type": "input_text", "text": "my ssn is <US_SSN>"}]},
+            ],
+        ),
+    ],
+)
+async def test_structured_rewrite_lands_on_shapes_the_flat_path_cannot_align(
+    case: str,
+    responses_input: list[dict[str, object]],
+    redacted_input: list[dict[str, object]],
+) -> None:
+    data: dict[str, object] = {"model": "gpt-5.6", "instructions": "be terse", "input": responses_input}
+
+    async with _guardrail_redacting("078-05-1120", "<US_SSN>") as guardrail:
+        await OpenAIResponsesHandler().process_input_messages(data=data, guardrail_to_apply=guardrail)
+
+    assert data["input"] == redacted_input, case
+    assert data["instructions"] == "be terse", case


### PR DESCRIPTION
## TLDR

Problem this solves:

- Some guardrails 500 `POST /v1/responses` with `tuple index out of range`
- Only turns with `instructions` or tool items break, so it looks flaky
- The error names no guardrail, so admins turn protection off to unblock

How it solves it:

- Reject the request when rewritten texts and input parts disagree in count
- The error names the guardrail; the raw prompt is never forwarded
- Whole-message rewrites (CrowdStrike AIDR) still land, now under test
- CrowdStrike takes an injectable HTTP client so that test patches nothing

## User Flow

Before: a developer whose app sends `instructions` on `POST /v1/responses` gets a bare `tuple index out of range` 500 once the admin turns on a guardrail that rewrites messages

1. The proxy admin turns on a guardrail that rewrites each message it scans (a Prompt Security `modify` policy, or a generic guardrail endpoint returning one text per message) with `mode: pre_call` and `default_on: true`
2. The developer sends POST https://litellm-domain/v1/responses with a plain user message holding an SSN and gets HTTP 200 with the SSN redacted in the answer
3. They send the same request plus `"instructions": "Repeat the user message back verbatim."` and get HTTP 500 `{"error": {"message": "tuple index out of range", "type": "internal_server_error"}}`, with nothing naming the guardrail
4. They replay a tool call (a `function_call` item plus its `function_call_output`) ahead of the next user message and get the same 500, while single-message turns keep returning 200, so the failure reads as random
5. They turn the guardrail off to unblock the app, and from then on the SSN reaches the model unredacted

After: the same two requests still fail, but the error names the guardrail and why, and no turn is forwarded with the redaction skipped

1. The proxy admin turns on a guardrail that rewrites each message it scans (a Prompt Security `modify` policy, or a generic guardrail endpoint returning one text per message) with `mode: pre_call` and `default_on: true`
2. The developer sends POST https://litellm-domain/v1/responses with a plain user message holding an SSN and gets HTTP 200 with the SSN redacted in the answer
3. They send the same request plus `"instructions": "Repeat the user message back verbatim."` and get HTTP 500 `Guardrail 'message-shaped-guard' rewrote the request in a way this endpoint cannot apply, so the request was rejected rather than sent unrewritten`
4. They replay a tool call ahead of the next user message and get the same named error, so the admin knows exactly which guardrail needs reconfiguring
5. The admin fixes that one guardrail and leaves protection on meanwhile, since the message tells them the request was refused rather than sent through unredacted

## Relevant issues

## Linear ticket

Resolves LIT-7604

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup: each leg boots its own fresh proxy with 2 uvicorn workers (`--num_workers 2`) and no database, making real `gpt-5.6` calls through OpenAI. Before ran the merge base `9a715df212` on `localhost:33740` and After ran this branch at `e4030597d8` on `localhost:39080`

The guardrail is a stand-in for Prompt Security's `modify` mode: a local endpoint on `127.0.0.1:41659`, wired in as `generic_guardrail_api`, that returns one rewritten text per message it is handed with the SSN replaced by `<US_SSN>`. Called directly with the `instructions` request's messages, it hands back two texts for the one text part the endpoint sent, which is the mismatch both legs run into

1. `curl -s http://127.0.0.1:41659/beta/litellm_basic_guardrail_api -H 'Content-Type: application/json' -d '{"input_type":"request","texts":["my ssn is 078-05-1120"],"structured_messages":[{"role":"system","content":"Repeat the user message back verbatim."},{"role":"user","content":[{"type":"text","text":"my ssn is 078-05-1120"}]}]}'`
2. Output:

   ```
   {"action": "GUARDRAIL_INTERVENED", "texts": ["Repeat the user message back verbatim.", "my ssn is <US_SSN>"]}
   ```

Proxy config:

```yaml
model_list:
  - model_name: gpt-5.6
    litellm_params:
      model: openai/gpt-5.6
      api_key: os.environ/OPENAI_API_KEY

guardrails:
  - guardrail_name: message-shaped-guard
    litellm_params:
      guardrail: generic_guardrail_api
      mode: pre_call
      default_on: true
      api_base: http://127.0.0.1:41659

general_settings:
  master_key: sk-lit7604-qa
```

What the guardrail endpoint logged for the five requests, identical on both legs (texts the endpoint sent in, messages the guardrail saw, texts it sent back):

```
guard: input_type=request texts_in=1 structured_messages=2 roles=['system', 'user'] texts_out=2
guard: input_type=request texts_in=2 structured_messages=4 roles=['user', 'assistant', 'tool', 'user'] texts_out=4
guard: input_type=request texts_in=1 structured_messages=1 roles=['user'] texts_out=1
guard: input_type=request texts_in=2 structured_messages=1 roles=['user'] texts_out=1
guard: input_type=request texts_in=2 structured_messages=2 roles=['system', 'user'] texts_out=2
```

### Before (9a715df212)

#### instructions plus a user message

1. `curl -s -o out.json -w 'HTTP %{http_code}\n' http://localhost:33740/v1/responses -H 'Authorization: Bearer sk-lit7604-qa' -H 'Content-Type: application/json' -d '{"model":"gpt-5.6","instructions":"Repeat the user message back verbatim.","input":[{"role":"user","content":[{"type":"input_text","text":"my ssn is 078-05-1120"}]}]}' && jq -c '{status: (.error.message // .status), output: .output[-1].content[0].text}' out.json`
2. Output:

   ```
   HTTP 500
   {"status":"tuple index out of range","output":null}
   ```

#### tool call and output replayed before a user message

1. `curl -s -o out.json -w 'HTTP %{http_code}\n' http://localhost:33740/v1/responses -H 'Authorization: Bearer sk-lit7604-qa' -H 'Content-Type: application/json' -d '{"model":"gpt-5.6","input":[{"role":"user","content":[{"type":"input_text","text":"Repeat my next message back verbatim."}]},{"type":"function_call","call_id":"call_lit7604","name":"get_x","arguments":"{}"},{"type":"function_call_output","call_id":"call_lit7604","output":"42"},{"role":"user","content":[{"type":"input_text","text":"my ssn is 078-05-1120"}]}]}' && jq -c '{status: (.error.message // .status), output: .output[-1].content[0].text}' out.json`
2. Output:

   ```
   HTTP 500
   {"status":"tuple index out of range","output":null}
   ```

#### plain user message

1. `curl -s -o out.json -w 'HTTP %{http_code}\n' http://localhost:33740/v1/responses -H 'Authorization: Bearer sk-lit7604-qa' -H 'Content-Type: application/json' -d '{"model":"gpt-5.6","input":[{"role":"user","content":[{"type":"input_text","text":"Repeat this back verbatim: my ssn is 078-05-1120"}]}]}' && jq -c '{status: (.error.message // .status), output: .output[-1].content[0].text}' out.json`
2. Output:

   ```
   HTTP 200
   {"status":"completed","output":"my ssn is <US_SSN>"}
   ```

#### one user message with two text parts

1. `curl -s -o out.json -w 'HTTP %{http_code}\n' http://localhost:33740/v1/responses -H 'Authorization: Bearer sk-lit7604-qa' -H 'Content-Type: application/json' -d '{"model":"gpt-5.6","input":[{"role":"user","content":[{"type":"input_text","text":"Repeat both of my sentences back verbatim."},{"type":"input_text","text":"My ssn is 078-05-1120."}]}]}' && jq -c '{status: (.error.message // .status), output: .output[-1].content[0].text}' out.json`
2. Output:

   ```
   HTTP 200
   {"status":"completed","output":"My ssn is <US_SSN>. My ssn is [REDACTED]."}
   ```

#### system plus a user message (control on /v1/chat/completions, untouched by this PR)

1. `curl -s -o out.json -w 'HTTP %{http_code}\n' http://localhost:33740/v1/chat/completions -H 'Authorization: Bearer sk-lit7604-qa' -H 'Content-Type: application/json' -d '{"model":"gpt-5.6","messages":[{"role":"system","content":"Repeat the user message back verbatim."},{"role":"user","content":"my ssn is 078-05-1120"}]}' && jq -c '{status: (.error.message // "ok"), output: .choices[0].message.content}' out.json`
2. Output:

   ```
   HTTP 200
   {"status":"ok","output":"my ssn is <US_SSN>"}
   ```

### After (e4030597d8)

#### instructions plus a user message

1. `curl -s -o out.json -w 'HTTP %{http_code}\n' http://localhost:39080/v1/responses -H 'Authorization: Bearer sk-lit7604-qa' -H 'Content-Type: application/json' -d '{"model":"gpt-5.6","instructions":"Repeat the user message back verbatim.","input":[{"role":"user","content":[{"type":"input_text","text":"my ssn is 078-05-1120"}]}]}' && jq -c '{status: (.error.message // .status), output: .output[-1].content[0].text}' out.json`
2. Output:

   ```
   HTTP 500
   {"status":"Guardrail 'message-shaped-guard' rewrote the request in a way this endpoint cannot apply, so the request was rejected rather than sent unrewritten","output":null}
   ```

#### tool call and output replayed before a user message

1. `curl -s -o out.json -w 'HTTP %{http_code}\n' http://localhost:39080/v1/responses -H 'Authorization: Bearer sk-lit7604-qa' -H 'Content-Type: application/json' -d '{"model":"gpt-5.6","input":[{"role":"user","content":[{"type":"input_text","text":"Repeat my next message back verbatim."}]},{"type":"function_call","call_id":"call_lit7604","name":"get_x","arguments":"{}"},{"type":"function_call_output","call_id":"call_lit7604","output":"42"},{"role":"user","content":[{"type":"input_text","text":"my ssn is 078-05-1120"}]}]}' && jq -c '{status: (.error.message // .status), output: .output[-1].content[0].text}' out.json`
2. Output:

   ```
   HTTP 500
   {"status":"Guardrail 'message-shaped-guard' rewrote the request in a way this endpoint cannot apply, so the request was rejected rather than sent unrewritten","output":null}
   ```

#### plain user message

1. `curl -s -o out.json -w 'HTTP %{http_code}\n' http://localhost:39080/v1/responses -H 'Authorization: Bearer sk-lit7604-qa' -H 'Content-Type: application/json' -d '{"model":"gpt-5.6","input":[{"role":"user","content":[{"type":"input_text","text":"Repeat this back verbatim: my ssn is 078-05-1120"}]}]}' && jq -c '{status: (.error.message // .status), output: .output[-1].content[0].text}' out.json`
2. Output:

   ```
   HTTP 200
   {"status":"completed","output":"my ssn is <US_SSN>"}
   ```

#### one user message with two text parts

1. `curl -s -o out.json -w 'HTTP %{http_code}\n' http://localhost:39080/v1/responses -H 'Authorization: Bearer sk-lit7604-qa' -H 'Content-Type: application/json' -d '{"model":"gpt-5.6","input":[{"role":"user","content":[{"type":"input_text","text":"Repeat both of my sentences back verbatim."},{"type":"input_text","text":"My ssn is 078-05-1120."}]}]}' && jq -c '{status: (.error.message // .status), output: .output[-1].content[0].text}' out.json`
2. Output:

   ```
   HTTP 500
   {"status":"Guardrail 'message-shaped-guard' rewrote the request in a way this endpoint cannot apply, so the request was rejected rather than sent unrewritten","output":null}
   ```

#### system plus a user message (control on /v1/chat/completions, untouched by this PR)

1. `curl -s -o out.json -w 'HTTP %{http_code}\n' http://localhost:39080/v1/chat/completions -H 'Authorization: Bearer sk-lit7604-qa' -H 'Content-Type: application/json' -d '{"model":"gpt-5.6","messages":[{"role":"system","content":"Repeat the user message back verbatim."},{"role":"user","content":"my ssn is 078-05-1120"}]}' && jq -c '{status: (.error.message // "ok"), output: .choices[0].message.content}' out.json`
2. Output:

   ```
   HTTP 200
   {"status":"ok","output":"my ssn is <US_SSN>"}
   ```

Observed along the way:

- Two-part case: the merge base leaked part two's SSN upstream
- This PR turns that leak into the named 500
- Chat completions control unchanged on both legs

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- Per-message rewrites still cannot land on `/v1/responses` turns with `instructions` or tool items
  - the merge base 500'd on them with `tuple index out of range`, and this PR keeps the 500 but names it
  - the fix is those guardrails returning `structured_messages`, tracked in LIT-7619
- A per-message rewrite of a user message with several text parts now gets that same 500 where the merge base sent a half-rewritten prompt upstream
  - observed in the two-text-parts case above: the merge base rewrote part one and let part two's SSN reach the model
  - failing closed is the deliberate choice here, since forwarding text the guardrail flagged is the bypass this PR closes; the alternative was keeping that positional partial write-back, and LIT-7619 makes the rewrite land instead
- An explicit empty `texts` rewrite (DeepKeep treats `texts: []` as a replacement, Straiker and custom-code `modify(texts=[])` do the same) now gets the 500 where the merge base forwarded the request unmodified
  - reasoned from the code, not verified live (no DeepKeep or Straiker credentials here); Generic Guardrail API and Prompt Security treat an empty list as no rewrite and are unaffected
- `/v1/chat/completions` pairs rewritten texts the same way and is not covered here
  - also tracked in LIT-7619

### Low

- The mismatch surfaces as a 500, not a 4xx, since it is a deployment configuration problem

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
- [x] e4030597d8 passes /live-pr-risk
