### PR TITLE
fix(ollama): use native tool calling for ollama/ models

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -32,6 +32,7 @@ from litellm.types.llms.openai import (
     ChatCompletionFileObject,
     ChatCompletionFunctionMessage,
     ChatCompletionImageObject,
+    ChatCompletionSystemMessage,
     ChatCompletionTextObject,
     ChatCompletionToolCallFunctionChunk,
     ChatCompletionToolMessage,
@@ -5128,6 +5129,26 @@ def _bedrock_tools_pt(tools: list, model: str | None = None) -> list[BedrockTool
             tool_block_list.append(cache_point_tool_block)
 
     return tool_block_list
+
+
+def _append_function_prompt(message: ChatCompletionSystemMessage, text: str) -> ChatCompletionSystemMessage:
+    content: Final = message["content"]
+    if isinstance(content, str):
+        return {**message, "content": content + text}
+    return {**message, "content": [*content, ChatCompletionTextObject(type="text", text=text)]}
+
+
+def function_call_prompt(messages: Sequence[AllMessageValues], function_descriptions: str) -> list[AllMessageValues]:
+    function_prompt: Final = (
+        'Produce JSON OUTPUT ONLY! Adhere to this format {"name": "function_name", "arguments":{"argument_name": '
+        '"argument_value"}} The following functions are available to you:' + function_descriptions
+    )
+    if not any(message["role"] == "system" for message in messages):
+        return [*messages, ChatCompletionSystemMessage(role="system", content=function_prompt)]
+    return [
+        _append_function_prompt(message, f" {function_prompt}") if message["role"] == "system" else message
+        for message in messages
+    ]
 
 
 def response_schema_prompt(model: str, response_schema: dict) -> str:

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -5130,27 +5130,6 @@ def _bedrock_tools_pt(tools: list, model: str | None = None) -> list[BedrockTool
     return tool_block_list
 
 
-# Function call template
-def function_call_prompt(messages: list, functions: list):
-    function_prompt = """Produce JSON OUTPUT ONLY! Adhere to this format {"name": "function_name", "arguments":{"argument_name": "argument_value"}} The following functions are available to you:"""
-    for function in functions:
-        function_prompt += f"""\n{function}\n"""
-
-    function_added_to_prompt = False
-    for message in messages:
-        if "system" in message["role"]:
-            if isinstance(message["content"], str):
-                message["content"] += f""" {function_prompt}"""
-            else:
-                message["content"].append({"type": "text", "text": f""" {function_prompt}"""})
-            function_added_to_prompt = True
-
-    if function_added_to_prompt is False:
-        messages.append({"role": "system", "content": f"""{function_prompt}"""})
-
-    return messages
-
-
 def response_schema_prompt(model: str, response_schema: dict) -> str:
     """
     Decides if a user-defined custom prompt or default needs to be used

--- a/litellm/llms/ollama/chat/transformation.py
+++ b/litellm/llms/ollama/chat/transformation.py
@@ -24,7 +24,6 @@ from litellm.types.llms.ollama import (
 from litellm.types.llms.openai import (
     AllMessageValues,
     ChatCompletionAssistantToolCall,
-    ChatCompletionToolParam,
     ChatCompletionUsageBlock,
 )
 from litellm.types.utils import ModelResponse, ModelResponseStream
@@ -184,10 +183,8 @@ class OllamaChatConfig(BaseConfig):
             if param == "tools":
                 optional_params["tools"] = value
 
-            if param == "functions":
-                optional_params["tools"] = tuple(
-                    ChatCompletionToolParam(type="function", function=function) for function in value
-                )
+            if param == "functions" and value:
+                optional_params["tools"] = [{"type": "function", "function": function} for function in value]
         non_default_params.pop("tool_choice", None)  # causes ollama requests to hang
         non_default_params.pop("functions", None)  # causes ollama requests to hang
         return optional_params

--- a/litellm/llms/ollama/chat/transformation.py
+++ b/litellm/llms/ollama/chat/transformation.py
@@ -222,14 +222,8 @@ class OllamaChatConfig(BaseConfig):
 
         Some providers need `model` in `api_base`
         """
-        if api_base is None:
-            api_base = "http://localhost:11434"
-        if api_base.endswith("/api/chat"):
-            url = api_base
-        else:
-            url = f"{api_base}/api/chat"
-
-        return url
+        base: Final = (api_base or "http://localhost:11434").rstrip("/").removesuffix("/api/generate")
+        return base if base.endswith("/api/chat") else f"{base}/api/chat"
 
     def transform_request(
         self,

--- a/litellm/llms/ollama/chat/transformation.py
+++ b/litellm/llms/ollama/chat/transformation.py
@@ -24,6 +24,7 @@ from litellm.types.llms.ollama import (
 from litellm.types.llms.openai import (
     AllMessageValues,
     ChatCompletionAssistantToolCall,
+    ChatCompletionToolParam,
     ChatCompletionUsageBlock,
 )
 from litellm.types.utils import ModelResponse, ModelResponseStream
@@ -184,7 +185,9 @@ class OllamaChatConfig(BaseConfig):
                 optional_params["tools"] = value
 
             if param == "functions":
-                optional_params["tools"] = value
+                optional_params["tools"] = tuple(
+                    ChatCompletionToolParam(type="function", function=function) for function in value
+                )
         non_default_params.pop("tool_choice", None)  # causes ollama requests to hang
         non_default_params.pop("functions", None)  # causes ollama requests to hang
         return optional_params

--- a/litellm/llms/ollama/common_utils.py
+++ b/litellm/llms/ollama/common_utils.py
@@ -11,6 +11,18 @@ class OllamaError(BaseLLMException):
         super().__init__(status_code=status_code, message=message, headers=headers)
 
 
+def resolve_ollama_tool_calling_provider(
+    custom_llm_provider: str, has_tools: bool, add_function_to_prompt: bool
+) -> str:
+    """
+    /api/generate has no native tool calling, so ollama/ tool requests go through the ollama_chat
+    adapter unless add_function_to_prompt opts back into the legacy JSON prompt emulation
+    """
+    if custom_llm_provider == "ollama" and has_tools and not add_function_to_prompt:
+        return "ollama_chat"
+    return custom_llm_provider
+
+
 def _convert_image(image):
     """
     Convert image to base64 encoded image if not already in base64 format

--- a/litellm/llms/ollama/common_utils.py
+++ b/litellm/llms/ollama/common_utils.py
@@ -11,14 +11,12 @@ class OllamaError(BaseLLMException):
         super().__init__(status_code=status_code, message=message, headers=headers)
 
 
-def resolve_ollama_tool_calling_provider(
-    custom_llm_provider: str, has_tools: bool, add_function_to_prompt: bool
-) -> str:
+def resolve_ollama_tool_calling_provider(custom_llm_provider: str, add_function_to_prompt: bool) -> str:
     """
-    /api/generate has no native tool calling, so ollama/ tool requests go through the ollama_chat
-    adapter unless add_function_to_prompt opts back into the legacy JSON prompt emulation
+    For requests with tools: /api/generate has no native tool calling, so ollama/ goes through the
+    ollama_chat adapter unless add_function_to_prompt opts back into the legacy JSON prompt emulation
     """
-    if custom_llm_provider == "ollama" and has_tools and not add_function_to_prompt:
+    if custom_llm_provider == "ollama" and not add_function_to_prompt:
         return "ollama_chat"
     return custom_llm_provider
 

--- a/litellm/llms/ollama/completion/transformation.py
+++ b/litellm/llms/ollama/completion/transformation.py
@@ -14,6 +14,7 @@ from litellm.litellm_core_utils.prompt_templates.common_utils import (
 from litellm.litellm_core_utils.prompt_templates.factory import (
     convert_to_ollama_image,
     custom_prompt,
+    function_call_prompt,
     ollama_pt,
 )
 from litellm.litellm_core_utils.prompt_templates.image_handling import (
@@ -159,6 +160,9 @@ class OllamaConfig(BaseConfig):
             "response_format",
             "max_completion_tokens",
             "reasoning_effort",
+            "tools",
+            "tool_choice",
+            "functions",
         ]
 
     def map_openai_params(
@@ -193,6 +197,9 @@ class OllamaConfig(BaseConfig):
                     optional_params["format"] = "json"
                 elif value["type"] == "json_schema":
                     optional_params["format"] = value["json_schema"]["schema"]
+            elif param in ("tools", "functions") and value:
+                optional_params["format"] = "json"
+                optional_params["prompted_functions"] = "".join(f"\n{function}\n" for function in value)
 
         return optional_params
 
@@ -377,6 +384,12 @@ class OllamaConfig(BaseConfig):
         headers: dict,
     ) -> dict:
         custom_prompt_dict: Final = litellm_params.get("custom_prompt_dict") or litellm.custom_prompt_dict
+        prompted_functions: Final = optional_params.pop("prompted_functions", None)
+        prompt_messages: Final = (
+            function_call_prompt(messages=messages, function_descriptions=prompted_functions)
+            if isinstance(prompted_functions, str)
+            else messages
+        )
 
         text_completion_request: Final = litellm_params.get("text_completion")
         if model in custom_prompt_dict:
@@ -386,12 +399,12 @@ class OllamaConfig(BaseConfig):
                 role_dict=model_prompt_details["roles"],
                 initial_prompt_value=model_prompt_details["initial_prompt_value"],
                 final_prompt_value=model_prompt_details["final_prompt_value"],
-                messages=messages,
+                messages=prompt_messages,
             )
         elif text_completion_request:  # handle `/completions` requests
-            ollama_prompt = get_str_from_messages(messages=messages)
+            ollama_prompt = get_str_from_messages(messages=prompt_messages)
         else:  # handle `/chat/completions` requests
-            modified_prompt: Final = ollama_pt(model=model, messages=messages)
+            modified_prompt: Final = ollama_pt(model=model, messages=prompt_messages)
             if isinstance(modified_prompt, dict):
                 ollama_prompt, images = (
                     modified_prompt["prompt"],

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -5308,6 +5308,8 @@ def completion(
                 GenericLiteLLMParams(**_supplemental_provider_params) if _supplemental_provider_params else None
             ),
         )
+        if custom_llm_provider == "ollama" and (tools is not None or functions is not None):
+            custom_llm_provider = "ollama_chat"  # rebind-ok: /api/generate has no native tool calling
 
         ## RESPONSES API BRIDGE LOGIC ## - check early and normalize model name
         responses_api_model_info, model = responses_api_bridge_check(

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -5309,8 +5309,6 @@ def completion(
         )
         if custom_llm_provider == "ollama" and (tools or functions):
             custom_llm_provider = "ollama_chat"  # rebind-ok: /api/generate has no native tool calling
-            if api_base is not None:
-                api_base = api_base.rstrip("/").removesuffix("/api/generate")  # rebind-ok: chat path
         elif custom_llm_provider == "ollama":
             tools = None  # rebind-ok: empty tools must not change plain completion behavior
             functions = None  # rebind-ok: empty functions must not change plain completion behavior

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -5307,8 +5307,15 @@ def completion(
                 GenericLiteLLMParams(**_supplemental_provider_params) if _supplemental_provider_params else None
             ),
         )
-        if custom_llm_provider == "ollama" and (tools is not None or functions is not None):
+        if custom_llm_provider == "ollama" and (tools or functions):
             custom_llm_provider = "ollama_chat"  # rebind-ok: /api/generate has no native tool calling
+            if api_base is not None:
+                api_base = api_base.rstrip("/").removesuffix(
+                    "/api/generate"
+                )  # rebind-ok: preserve generate URLs for native tool requests
+        elif custom_llm_provider == "ollama":
+            tools = None  # rebind-ok: empty tools must not change plain completion behavior
+            functions = None  # rebind-ok: empty functions must not change plain completion behavior
 
         ## RESPONSES API BRIDGE LOGIC ## - check early and normalize model name
         responses_api_model_info, model = responses_api_bridge_check(

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -5310,9 +5310,7 @@ def completion(
         if custom_llm_provider == "ollama" and (tools or functions):
             custom_llm_provider = "ollama_chat"  # rebind-ok: /api/generate has no native tool calling
             if api_base is not None:
-                api_base = api_base.rstrip("/").removesuffix(
-                    "/api/generate"
-                )  # rebind-ok: preserve generate URLs for native tool requests
+                api_base = api_base.rstrip("/").removesuffix("/api/generate")  # rebind-ok: chat path
         elif custom_llm_provider == "ollama":
             tools = None  # rebind-ok: empty tools must not change plain completion behavior
             functions = None  # rebind-ok: empty functions must not change plain completion behavior

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -5308,11 +5308,10 @@ def completion(
                 GenericLiteLLMParams(**_supplemental_provider_params) if _supplemental_provider_params else None
             ),
         )
-        custom_llm_provider = resolve_ollama_tool_calling_provider(  # rebind-ok: ollama tools use the chat adapter
-            custom_llm_provider,
-            has_tools=True if tools or functions else False,
-            add_function_to_prompt=litellm.add_function_to_prompt,
-        )
+        if tools or functions:
+            custom_llm_provider = resolve_ollama_tool_calling_provider(  # rebind-ok: ollama tools use the chat adapter
+                custom_llm_provider, add_function_to_prompt=litellm.add_function_to_prompt
+            )
 
         ## RESPONSES API BRIDGE LOGIC ## - check early and normalize model name
         responses_api_model_info, model = responses_api_bridge_check(

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -180,7 +180,6 @@ from .litellm_core_utils.prompt_templates.common_utils import (
 )
 from .litellm_core_utils.prompt_templates.factory import (
     custom_prompt,
-    function_call_prompt,
     map_system_message_pt,
     ollama_pt,
     prompt_factory,
@@ -5466,12 +5465,6 @@ def completion(
             add_provider_specific_params=True,
             provider_config=provider_config,
         )
-
-        if litellm.add_function_to_prompt and optional_params.get(
-            "functions_unsupported_model", None
-        ):  # if user opts to add it to prompt, when API doesn't support function calling
-            functions_unsupported_model: Final = optional_params.pop("functions_unsupported_model")
-            messages = function_call_prompt(messages=messages, functions=functions_unsupported_model)
 
         # For logging - save the values of the litellm-specific params passed in
         litellm_params = get_litellm_params(

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -220,6 +220,7 @@ from .llms.nvidia_riva.audio_transcription.transformation import (
     NvidiaRivaAudioTranscriptionConfig,
 )
 from .llms.oci.chat.transformation import OCIChatConfig
+from .llms.ollama.common_utils import resolve_ollama_tool_calling_provider
 from .llms.ollama.completion import handler as ollama
 from .llms.oobabooga.chat import oobabooga
 from .llms.openai.completion.handler import OpenAITextCompletion
@@ -5307,11 +5308,11 @@ def completion(
                 GenericLiteLLMParams(**_supplemental_provider_params) if _supplemental_provider_params else None
             ),
         )
-        if custom_llm_provider == "ollama" and (tools or functions):
-            custom_llm_provider = "ollama_chat"  # rebind-ok: /api/generate has no native tool calling
-        elif custom_llm_provider == "ollama":
-            tools = None  # rebind-ok: empty tools must not change plain completion behavior
-            functions = None  # rebind-ok: empty functions must not change plain completion behavior
+        custom_llm_provider = resolve_ollama_tool_calling_provider(  # rebind-ok: ollama tools use the chat adapter
+            custom_llm_provider,
+            has_tools=True if tools or functions else False,
+            add_function_to_prompt=litellm.add_function_to_prompt,
+        )
 
         ## RESPONSES API BRIDGE LOGIC ## - check early and normalize model name
         responses_api_model_info, model = responses_api_bridge_check(

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -4098,54 +4098,6 @@ def pre_process_optional_params(passed_params: dict, non_default_params: dict, c
                 non_default_params=passed_params, optional_params=optional_params
             )
 
-    ## raise exception if function calling passed in for a provider that doesn't support it
-    if "functions" in non_default_params or "function_call" in non_default_params or "tools" in non_default_params:
-        if (
-            custom_llm_provider == "ollama"
-            and custom_llm_provider != "text-completion-openai"
-            and custom_llm_provider != "azure"
-            and custom_llm_provider != "vertex_ai"
-            and custom_llm_provider != "anyscale"
-            and custom_llm_provider != "together_ai"
-            and custom_llm_provider != "groq"
-            and custom_llm_provider != "nvidia_nim"
-            and custom_llm_provider != "cerebras"
-            and custom_llm_provider != "xai"
-            and custom_llm_provider != "ai21_chat"
-            and custom_llm_provider != "volcengine"
-            and custom_llm_provider != "deepseek"
-            and custom_llm_provider != "codestral"
-            and custom_llm_provider != "mistral"
-            and custom_llm_provider != "anthropic"
-            and custom_llm_provider != "cohere_chat"
-            and custom_llm_provider != "cohere"
-            and custom_llm_provider != "bedrock"
-            and custom_llm_provider != "ollama_chat"
-            and custom_llm_provider != "openrouter"
-            and custom_llm_provider != "vercel_ai_gateway"
-            and custom_llm_provider != "nebius"
-            and custom_llm_provider != "wandb"
-            and custom_llm_provider not in litellm.openai_compatible_providers
-        ):
-            if custom_llm_provider == "ollama":
-                # ollama actually supports json output
-                optional_params["format"] = "json"
-                litellm.add_function_to_prompt = True  # so that main.py adds the function call to the prompt
-                if "tools" in non_default_params:
-                    optional_params["functions_unsupported_model"] = non_default_params.pop("tools")
-                    non_default_params.pop("tool_choice", None)  # causes ollama requests to hang
-                elif "functions" in non_default_params:
-                    optional_params["functions_unsupported_model"] = non_default_params.pop("functions")
-            elif litellm.add_function_to_prompt:  # if user opts to add it to prompt instead
-                optional_params["functions_unsupported_model"] = non_default_params.pop(
-                    "tools", non_default_params.pop("functions", None)
-                )
-            else:
-                raise UnsupportedParamsError(
-                    status_code=500,
-                    message=f"Function calling is not supported by {custom_llm_provider}.",
-                )
-
     return optional_params
 
 

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -20,6 +20,7 @@ from litellm.litellm_core_utils.prompt_templates.factory import (
     _convert_to_bedrock_tool_call_result,
     anthropic_messages_pt,
     convert_to_gemini_tool_call_result,
+    function_call_prompt,
     make_valid_bedrock_tool_name,
     ollama_pt,
     sanitize_messages_for_tool_calling,
@@ -3721,3 +3722,37 @@ def test_convert_to_anthropic_tool_invoke_keeps_paired_server_tool_use():
         },
         server_result,
     ]
+
+
+FUNCTION_PROMPT_DESCRIPTIONS: Final = "\n{'name': 'graph_stats'}\n"
+
+
+@pytest.mark.parametrize(
+    ("messages", "expected_system_contents"),
+    [
+        ([{"role": "user", "content": "hi"}], None),
+        ([{"role": "system", "content": "Be brief."}, {"role": "user", "content": "hi"}], "Be brief. "),
+        (
+            [{"role": "system", "content": [{"type": "text", "text": "Be brief."}]}, {"role": "user", "content": "hi"}],
+            [{"type": "text", "text": "Be brief."}],
+        ),
+    ],
+)
+def test_function_call_prompt_returns_new_messages(messages, expected_system_contents):
+    original: Final = json.loads(json.dumps(messages))
+
+    result: Final = function_call_prompt(messages=messages, function_descriptions=FUNCTION_PROMPT_DESCRIPTIONS)
+
+    assert messages == original
+    system_messages: Final = [m for m in result if m["role"] == "system"]
+    assert len(system_messages) == 1
+    content: Final = system_messages[0]["content"]
+    prompt_text: Final = content if isinstance(content, str) else content[-1]["text"]
+    assert "Produce JSON OUTPUT ONLY" in prompt_text
+    assert "graph_stats" in prompt_text
+    if expected_system_contents is None:
+        assert result[:-1] == original
+    elif isinstance(expected_system_contents, str):
+        assert content.startswith(expected_system_contents)
+    else:
+        assert content[:-1] == expected_system_contents

--- a/tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py
+++ b/tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py
@@ -944,3 +944,23 @@ class TestOllamaToolCallTransformation:
         assert tool_msg["content"] == "Sunny, 72°F"
         assert "tool_call_id" in tool_msg, "tool_call_id must be forwarded to Ollama"
         assert tool_msg["tool_call_id"] == "call_abc123"
+
+
+@pytest.mark.parametrize(
+    ("api_base", "expected_url"),
+    [
+        (None, "http://localhost:11434/api/chat"),
+        ("http://ollama.example:11434", "http://ollama.example:11434/api/chat"),
+        ("http://ollama.example:11434/", "http://ollama.example:11434/api/chat"),
+        ("http://ollama.example:11434/api/chat", "http://ollama.example:11434/api/chat"),
+        ("http://ollama.example:11434/api/chat/", "http://ollama.example:11434/api/chat"),
+        ("http://ollama.example:11434/api/generate", "http://ollama.example:11434/api/chat"),
+        ("http://ollama.example:11434/prefix/api/generate/", "http://ollama.example:11434/prefix/api/chat"),
+    ],
+)
+def test_get_complete_url_points_at_chat_endpoint(api_base, expected_url):
+    url = OllamaChatConfig().get_complete_url(
+        api_base=api_base, api_key=None, model="qwen3.8:27b", optional_params={}, litellm_params={}
+    )
+
+    assert url == expected_url

--- a/tests/test_litellm/llms/ollama/test_ollama_completion_transformation.py
+++ b/tests/test_litellm/llms/ollama/test_ollama_completion_transformation.py
@@ -727,3 +727,37 @@ async def test_ollama_async_native_tools(legacy_functions: bool) -> None:
             client=handler,
         )
     assert response.choices[0].message.content == "Hello"
+
+
+def test_ollama_add_function_to_prompt_keeps_legacy_json_emulation(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(litellm, "add_function_to_prompt", True)
+    requests = []
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        requests.append((request.url.path, json.loads(request.content)))
+        return httpx.Response(
+            200, json={"response": '{"name": "graph_stats", "arguments": {}}', "done": True, "prompt_eval_count": 1}
+        )
+
+    messages: Final = [
+        {"role": "system", "content": "You are a graph assistant."},
+        {"role": "user", "content": "How many nodes does the graph have?"},
+    ]
+
+    response: Final = litellm.completion(
+        model="ollama/qwen3.8:27b",
+        messages=messages,
+        tools=GRAPH_STATS_TOOLS,
+        tool_choice="auto",
+        api_base="http://ollama.example:11434",
+        client=HTTPHandler(client=httpx.Client(transport=httpx.MockTransport(handle))),
+    )
+
+    assert [path for path, _ in requests] == ["/api/generate"]
+    body: Final = requests[0][1]
+    assert body["format"] == "json"
+    assert "Produce JSON OUTPUT ONLY" in body["prompt"]
+    assert "graph_stats" in body["prompt"]
+    assert "prompted_functions" not in body["options"]
+    assert response.choices[0].message.tool_calls[0].function.name == "graph_stats"
+    assert response.choices[0].finish_reason == "tool_calls"

--- a/tests/test_litellm/llms/ollama/test_ollama_completion_transformation.py
+++ b/tests/test_litellm/llms/ollama/test_ollama_completion_transformation.py
@@ -6,7 +6,7 @@ import httpx
 import pytest
 
 import litellm
-from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
+from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler, HTTPHandler
 from litellm.llms.ollama.completion.transformation import (
     OllamaConfig,
     OllamaTextCompletionResponseIterator,
@@ -544,3 +544,105 @@ async def test_ollama_async_completion_inlines_remote_images_off_the_event_loop(
     assert response.choices[0].message.content == "Green"
     assert async_only_image_fetch.fetched == [image_url]
     assert captured["body"]["images"] == [async_only_image_fetch.base64_png]
+
+
+GRAPH_STATS_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "graph_stats",
+            "description": "Return node and edge counts of the code graph",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+]
+
+
+def test_ollama_tool_result_turn_is_sent_to_native_chat_api():
+    """https://github.com/BerriAI/litellm/issues/40575"""
+    requests = []
+
+    def handle(request):
+        requests.append((request.url.path, json.loads(request.content)))
+        return httpx.Response(
+            200,
+            json={
+                "model": "qwen3.8:27b",
+                "message": {"role": "assistant", "content": "The graph has 190921 nodes."},
+                "done": True,
+                "done_reason": "stop",
+                "prompt_eval_count": 1,
+                "eval_count": 1,
+            },
+        )
+
+    response = litellm.completion(
+        model="ollama/qwen3.8:27b",
+        messages=[
+            {"role": "user", "content": "How many nodes does the graph have?"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {"id": "call_1", "type": "function", "function": {"name": "graph_stats", "arguments": "{}"}}
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "name": "graph_stats", "content": '{"nodes": 190921}'},
+        ],
+        tools=GRAPH_STATS_TOOLS,
+        api_base="http://ollama.example:11434",
+        client=HTTPHandler(client=httpx.Client(transport=httpx.MockTransport(handle))),
+    )
+
+    assert [path for path, _ in requests] == ["/api/chat"]
+    body = requests[0][1]
+    assert body["tools"] == GRAPH_STATS_TOOLS
+    assert "format" not in body
+    assert [m["role"] for m in body["messages"]] == ["user", "assistant", "tool"]
+    assert body["messages"][2]["content"] == '{"nodes": 190921}'
+    assert response.choices[0].message.content == "The graph has 190921 nodes."
+    assert response.choices[0].message.tool_calls is None
+    assert response.choices[0].finish_reason == "stop"
+
+
+def test_ollama_streamed_tool_call_is_returned_as_tool_call():
+    """https://github.com/BerriAI/litellm/issues/35711"""
+    chunks = [
+        {
+            "model": "qwen3.8:27b",
+            "message": {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{"function": {"name": "graph_stats", "arguments": {}}}],
+            },
+            "done": False,
+        },
+        {
+            "model": "qwen3.8:27b",
+            "message": {"role": "assistant", "content": ""},
+            "done": True,
+            "done_reason": "stop",
+            "prompt_eval_count": 1,
+            "eval_count": 1,
+        },
+    ]
+
+    def handle(request):
+        assert request.url.path == "/api/chat"
+        return httpx.Response(200, content="\n".join(json.dumps(chunk) for chunk in chunks).encode())
+
+    streamed = list(
+        litellm.completion(
+            model="ollama/qwen3.8:27b",
+            messages=[{"role": "user", "content": "How many nodes does the graph have?"}],
+            tools=GRAPH_STATS_TOOLS,
+            stream=True,
+            api_base="http://ollama.example:11434",
+            client=HTTPHandler(client=httpx.Client(transport=httpx.MockTransport(handle))),
+        )
+    )
+
+    tool_calls = [tool_call for chunk in streamed for tool_call in chunk.choices[0].delta.tool_calls or []]
+    assert [tool_call.function.name for tool_call in tool_calls] == ["graph_stats"]
+    assert "".join(chunk.choices[0].delta.content or "" for chunk in streamed) == ""
+    assert streamed[-1].choices[0].finish_reason == "tool_calls"

--- a/tests/test_litellm/llms/ollama/test_ollama_completion_transformation.py
+++ b/tests/test_litellm/llms/ollama/test_ollama_completion_transformation.py
@@ -1,11 +1,12 @@
 import json
-from litellm._uuid import uuid
+from typing import Final
 from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
 
 import litellm
+from litellm._uuid import uuid
 from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler, HTTPHandler
 from litellm.llms.ollama.completion.transformation import (
     OllamaConfig,
@@ -476,7 +477,7 @@ class TestOllamaTextCompletionResponseIterator:
         # Updated to handle ModelResponseStream return type
         assert isinstance(result, ModelResponseStream)
         assert result.choices and result.choices[0].delta is not None
-        assert result.choices[0].delta.content == None
+        assert result.choices[0].delta.content is None
         assert getattr(result.choices[0].delta, "reasoning_content", None) == ""
 
     def test_chunk_parser_done_chunk(self):
@@ -558,7 +559,17 @@ GRAPH_STATS_TOOLS = [
 ]
 
 
-def test_ollama_tool_result_turn_is_sent_to_native_chat_api():
+@pytest.mark.parametrize(
+    "api_base",
+    [
+        "http://ollama.example:11434",
+        "http://ollama.example:11434/",
+        "http://ollama.example:11434/api/generate",
+        "http://ollama.example:11434/api/generate/",
+        "http://ollama.example:11434/api/chat",
+    ],
+)
+def test_ollama_tool_result_turn_is_sent_to_native_chat_api(api_base: str):
     """https://github.com/BerriAI/litellm/issues/40575"""
     requests = []
 
@@ -590,7 +601,7 @@ def test_ollama_tool_result_turn_is_sent_to_native_chat_api():
             {"role": "tool", "tool_call_id": "call_1", "name": "graph_stats", "content": '{"nodes": 190921}'},
         ],
         tools=GRAPH_STATS_TOOLS,
-        api_base="http://ollama.example:11434",
+        api_base=api_base,
         client=HTTPHandler(client=httpx.Client(transport=httpx.MockTransport(handle))),
     )
 
@@ -646,3 +657,73 @@ def test_ollama_streamed_tool_call_is_returned_as_tool_call():
     assert [tool_call.function.name for tool_call in tool_calls] == ["graph_stats"]
     assert "".join(chunk.choices[0].delta.content or "" for chunk in streamed) == ""
     assert streamed[-1].choices[0].finish_reason == "tool_calls"
+
+
+@pytest.mark.parametrize("empty_parameter", ["none", "tools", "functions"])
+def test_ollama_empty_tools_preserve_generate_request(empty_parameter: str) -> None:
+    def handle(request: httpx.Request) -> httpx.Response:
+        body: Final = json.loads(request.content)
+        assert request.url.path == "/api/generate"
+        assert "format" not in body
+        assert "tools" not in body
+        return httpx.Response(200, json={"response": "Hello", "done": True})
+
+    response: Final = litellm.completion(
+        model="ollama/qwen3.8:27b",
+        messages=[{"role": "user", "content": "Hello"}],
+        tools=[] if empty_parameter == "tools" else None,
+        functions=[] if empty_parameter == "functions" else None,
+        api_base="http://ollama.example:11434/api/generate",
+        client=HTTPHandler(client=httpx.Client(transport=httpx.MockTransport(handle))),
+    )
+    assert response.choices[0].message.content == "Hello"
+
+
+def test_ollama_native_tool_support_error_is_preserved() -> None:
+    def handle(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/chat"
+        return httpx.Response(400, json={"error": "model does not support tools"})
+
+    with pytest.raises(litellm.BadRequestError, match="does not support tools"):
+        litellm.completion(
+            model="ollama/qwen3.8:27b",
+            messages=[{"role": "user", "content": "Hello"}],
+            tools=GRAPH_STATS_TOOLS,
+            api_base="http://ollama.example:11434/api/generate",
+            client=HTTPHandler(client=httpx.Client(transport=httpx.MockTransport(handle))),
+            num_retries=0,
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("legacy_functions", [False, True])
+async def test_ollama_async_native_tools(legacy_functions: bool) -> None:
+    def handle(request: httpx.Request) -> httpx.Response:
+        body: Final = json.loads(request.content)
+        assert request.url.path == "/prefix/api/chat"
+        assert body["tools"] == GRAPH_STATS_TOOLS
+        return httpx.Response(
+            200,
+            json={
+                "model": "qwen3.8:27b",
+                "message": {"role": "assistant", "content": "Hello"},
+                "done": True,
+                "done_reason": "stop",
+                "prompt_eval_count": 1,
+                "eval_count": 1,
+            },
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handle)) as client:
+        handler: Final = AsyncHTTPHandler()
+        await handler.client.aclose()
+        handler.client = client
+        response: Final = await litellm.acompletion(
+            model="ollama/qwen3.8:27b",
+            messages=[{"role": "user", "content": "Hello"}],
+            tools=None if legacy_functions else GRAPH_STATS_TOOLS,
+            functions=[GRAPH_STATS_TOOLS[0]["function"]] if legacy_functions else None,
+            api_base="http://ollama.example:11434/prefix/api/generate/",
+            client=handler,
+        )
+    assert response.choices[0].message.content == "Hello"

--- a/tests/test_litellm/test_system_message_format_bug.py
+++ b/tests/test_litellm/test_system_message_format_bug.py
@@ -2,6 +2,7 @@
 Test for GitHub issue #11267 - System message format issue with Ollama + tools
 """
 
+import copy
 from unittest.mock import patch
 
 
@@ -49,6 +50,8 @@ def test_system_message_format_issue_reproduction():
         }
     ]
 
+    original_messages = copy.deepcopy(messages)
+
     response = completion(
         model=model,
         messages=messages,
@@ -57,7 +60,7 @@ def test_system_message_format_issue_reproduction():
         mock_response=True,
     )
 
-    assert len(messages[1]["content"]) == 2
+    assert messages == original_messages
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## TLDR

Problem this solves:

- `ollama/` agents loop forever after sending a tool result
- Streamed `ollama/` tool calls arrive as plain text
- `tools: []` forces JSON-only output on normal chats
- Tools were faked with a "JSON OUTPUT ONLY" prompt

How it solves it:

- Send non-empty tools or functions to Ollama's `/api/chat`
- Keep empty tool lists on `/api/generate`
- Preserve server prefixes and `/api/generate` base URLs
- Convert legacy functions into native tool definitions
- Keep the old JSON prompt path behind `add_function_to_prompt`

## User Flow

Before: an agent using Qwen3.8 through the proxy never finishes a tool call because it keeps calling the same tool

1. The proxy admin routes `local-main` to `ollama/qwen3.8:27b` with `think: false`
2. The agent sends POST http://localhost:4000/v1/chat/completions with model `local-main` and a `graph_stats` tool
3. It gets back `finish_reason: "tool_calls"` asking for `graph_stats`
4. The agent runs the tool and sends the same POST with the assistant tool call and a `role: "tool"` result appended
5. It gets back another `graph_stats` tool call instead of an answer, so the agent loops until it gives up

After: the same agent reads the tool result and gets its answer

1. The proxy admin routes `local-main` to `ollama/qwen3.8:27b` with `think: false`
2. The agent sends POST http://localhost:4000/v1/chat/completions with model `local-main` and a `graph_stats` tool
3. It gets back `finish_reason: "tool_calls"` asking for `graph_stats`
4. The agent runs the tool and sends the same POST with the assistant tool call and a `role: "tool"` result appended
5. It gets back `finish_reason: "stop"` and an answer with 190,921 nodes and 459,280 edges

## Relevant issues

Fixes #40575
Fixes #35711

Related: #24091 and #19742 look like the same `ollama/` tool emulation, but I did not re-test them with those reporters' setups

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Real Ollama 0.34.0 serving `qwen3.8:27b` on a Tesla T4, with 31%/69% CPU/GPU placement and a 4096-token context

The proxy was restarted at each commit with `python litellm/proxy/proxy_cli.py --config /content/config.yaml --port 4000`

<details>
<summary>/content/config.yaml</summary>

```yaml
model_list:
  - model_name: local-main
    litellm_params:
      model: ollama/qwen3.8:27b
      api_base: http://localhost:11434
      think: false
```

</details>

<details>
<summary>/content/turn1.json</summary>

```json
{
  "model": "local-main",
  "messages": [
    {
      "role": "user",
      "content": "How many nodes and edges does the code graph have? Use the tool."
    }
  ],
  "tools": [
    {
      "type": "function",
      "function": {
        "name": "graph_stats",
        "description": "Return node and edge counts of the code graph",
        "parameters": {
          "type": "object",
          "properties": {}
        }
      }
    }
  ]
}
```

</details>

<details>
<summary>/content/turn2.json</summary>

```json
{
  "model": "local-main",
  "messages": [
    {
      "role": "user",
      "content": "How many nodes and edges does the code graph have? Use the tool."
    },
    {
      "role": "assistant",
      "content": null,
      "tool_calls": [
        {
          "id": "call_1",
          "type": "function",
          "function": {
            "name": "graph_stats",
            "arguments": "{}"
          }
        }
      ]
    },
    {
      "role": "tool",
      "tool_call_id": "call_1",
      "name": "graph_stats",
      "content": "{\"nodes\":190921,\"edges\":459280}"
    }
  ],
  "tools": [
    {
      "type": "function",
      "function": {
        "name": "graph_stats",
        "description": "Return node and edge counts of the code graph",
        "parameters": {
          "type": "object",
          "properties": {}
        }
      }
    }
  ]
}
```

</details>

<details>
<summary>/content/stream.json</summary>

```json
{
  "model": "local-main",
  "messages": [
    {
      "role": "user",
      "content": "How many nodes and edges does the code graph have? Use the tool."
    }
  ],
  "tools": [
    {
      "type": "function",
      "function": {
        "name": "graph_stats",
        "description": "Return node and edge counts of the code graph",
        "parameters": {
          "type": "object",
          "properties": {}
        }
      }
    }
  ],
  "stream": true
}
```

</details>

The second-turn payload uses a fixed `call_1` ID consistently in its assistant and tool messages

### Before (e907e5ee9)

#### Tool result turn

1. `curl -s --max-time 1500 http://localhost:4000/v1/chat/completions -H 'Content-Type: application/json' -d @/content/turn1.json | jq '.choices[0] | {finish_reason, content: .message.content, tool_calls: .message.tool_calls}'`

   ```json
   {
     "finish_reason": "tool_calls",
     "content": null,
     "tool_calls": [
       {
         "function": {
           "arguments": "{}",
           "name": "graph_stats"
         },
         "id": "call_5ba9a7fa-a1c2-4b76-8f1d-3b4503941837",
         "type": "function"
       }
     ]
   }
   ```

2. `curl -s --max-time 1500 http://localhost:4000/v1/chat/completions -H 'Content-Type: application/json' -d @/content/turn2.json | jq '.choices[0] | {finish_reason, content: .message.content, tool_calls: .message.tool_calls}'`

   ```json
   {
     "finish_reason": "tool_calls",
     "content": null,
     "tool_calls": [
       {
         "function": {
           "arguments": "{}",
           "name": "graph_stats"
         },
         "id": "call_db845f01-f528-464c-8feb-32cad7ffc77f",
         "type": "function"
       }
     ]
   }
   ```

#### Streamed tool call

1. `curl -s --max-time 1500 http://localhost:4000/v1/chat/completions -H 'Content-Type: application/json' -N -d @/content/stream.json | sed -n 's/^data: //p' | grep -v DONE | jq -c '.choices[0] | {delta: {content: .delta.content, tool_calls: .delta.tool_calls}, finish_reason}'`

   ```json
   {"delta":{"content":"{\"","tool_calls":null},"finish_reason":null}
   {"delta":{"content":"name","tool_calls":null},"finish_reason":null}
   {"delta":{"content":"\":","tool_calls":null},"finish_reason":null}
   {"delta":{"content":" \"","tool_calls":null},"finish_reason":null}
   {"delta":{"content":"graph","tool_calls":null},"finish_reason":null}
   {"delta":{"content":"_stats","tool_calls":null},"finish_reason":null}
   {"delta":{"content":"\",","tool_calls":null},"finish_reason":null}
   {"delta":{"content":" \"","tool_calls":null},"finish_reason":null}
   {"delta":{"content":"arguments","tool_calls":null},"finish_reason":null}
   {"delta":{"content":"\":","tool_calls":null},"finish_reason":null}
   {"delta":{"content":" {","tool_calls":null},"finish_reason":null}
   {"delta":{"content":"}}","tool_calls":null},"finish_reason":null}
   {"delta":{"content":null,"tool_calls":null},"finish_reason":"stop"}
   ```

### After (5476e05bb)

#### Tool result turn

1. `curl -s --max-time 1500 http://localhost:4000/v1/chat/completions -H 'Content-Type: application/json' -d @/content/turn1.json | jq '.choices[0] | {finish_reason, content: .message.content, tool_calls: .message.tool_calls}'`

   ```json
   {
     "finish_reason": "tool_calls",
     "content": "",
     "tool_calls": [
       {
         "function": {
           "arguments": "{}",
           "name": "graph_stats"
         },
         "id": "call_2ahmislq",
         "type": "function"
       }
     ]
   }
   ```

2. `curl -s --max-time 1500 http://localhost:4000/v1/chat/completions -H 'Content-Type: application/json' -d @/content/turn2.json | jq '.choices[0] | {finish_reason, content: .message.content, tool_calls: .message.tool_calls}'`

   ```json
   {
     "finish_reason": "stop",
     "content": "The code graph has **190,921 nodes** and **459,280 edges**.",
     "tool_calls": null
   }
   ```

#### Streamed tool call

1. `curl -s --max-time 1500 http://localhost:4000/v1/chat/completions -H 'Content-Type: application/json' -N -d @/content/stream.json | sed -n 's/^data: //p' | grep -v DONE | jq -c '.choices[0] | {delta: {content: .delta.content, tool_calls: .delta.tool_calls}, finish_reason}'`

   ```json
   {"delta":{"content":null,"tool_calls":[{"id":"call_o5yilwq9","function":{"arguments":"{}","name":"graph_stats"},"type":"function","index":0}]},"finish_reason":null}
   {"delta":{"content":null,"tool_calls":null},"finish_reason":"tool_calls"}
   ```

## Type

🐛 Bug Fix

## Caveats (if any)

### Severe

- By default, `ollama/` models without native tool support now get Ollama's "does not support tools" error
  - To keep the old JSON prompt path, set `litellm.add_function_to_prompt = True`
    - On the proxy: `litellm_settings: {add_function_to_prompt: true}` or `--add_function_to_prompt`
  - That old path only produces a single call, since every follow-up turn is forced back into function-call JSON
  - #18924 made the same default change for `ollama_chat/`

### Medium

- `ollama/` tool requests now share two existing `ollama_chat/` behaviors
  - Remote image URLs are sent as-is instead of being downloaded, #31913 fixes that path
  - With no Ollama key set, a global `litellm.api_key` goes out as the Bearer token, also noted in #40326

### Low

- Responses to tool requests report `model` as `ollama_chat/...`
- Custom prompt templates for `ollama/` models don't apply to native tool requests
- `ollama_chat/` now also turns a trailing slash or `/api/generate` in `api_base` into `/api/chat`
- `ollama/` no longer flips `litellm.add_function_to_prompt` on globally (the Lakera guardrail reads it)
- Open PRs #34769 and #36341 patch the JSON prompt path, which now only runs behind the flag

## Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

Left unchecked on purpose: the Medium caveats list two `ollama/` tool-request changes that the tests don't prevent
