### PR TITLE
feat(proxy): gate organization endpoints on an enterprise license

### DIFF
--- a/litellm/proxy/management_endpoints/organization_endpoints.py
+++ b/litellm/proxy/management_endpoints/organization_endpoints.py
@@ -80,7 +80,23 @@ if TYPE_CHECKING:
     from prisma.models import LiteLLM_OrganizationTable as PrismaOrganizationTable
     from prisma.models import LiteLLM_UserTable as PrismaUserTable
 
-router: Final = APIRouter()
+
+async def _enterprise_license_required(
+    _user_api_key_dict: Annotated[UserAPIKeyAuth, Depends(user_api_key_auth)],
+) -> None:
+    from litellm.proxy.proxy_server import premium_user
+
+    if not premium_user:
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "error": "Organizations are only available for LiteLLM Enterprise users. "
+                f"{CommonProxyErrors.not_premium_user.value}"
+            },
+        )
+
+
+router: Final = APIRouter(dependencies=[Depends(_enterprise_license_required)])
 
 
 class _ObjectPermissionRow(Protocol):

--- a/tests/test_litellm/proxy/management_endpoints/test_organization_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_organization_endpoints.py
@@ -1,7 +1,8 @@
 import asyncio
 import json
 from litellm._uuid import uuid
-from typing import Optional, cast
+from types import MappingProxyType
+from typing import Final, Mapping, Optional, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -1241,15 +1242,36 @@ def _organization_route_targets() -> list[tuple[str, str]]:
     ]
 
 
+_ORGANIZATION_ROUTE_REQUESTS: Final[Mapping[tuple[str, str], Mapping[str, object]]] = MappingProxyType(
+    {
+        ("POST", "/organization/new"): {"json": {"organization_alias": "org-under-test"}},
+        ("DELETE", "/organization/delete"): {"json": {"organization_ids": ["org-under-test"]}},
+        ("GET", "/organization/info"): {"params": {"organization_id": "org-under-test"}},
+        ("POST", "/organization/info"): {"json": {"organizations": ["org-under-test"]}},
+        ("POST", "/organization/member_add"): {
+            "json": {"organization_id": "org-under-test", "member": {"user_id": "user-1", "role": "internal_user"}}
+        },
+        ("PATCH", "/organization/member_update"): {"json": {"organization_id": "org-under-test", "user_id": "user-1"}},
+        ("DELETE", "/organization/member_delete"): {"json": {"organization_id": "org-under-test", "user_id": "user-1"}},
+    }
+)
+
+
+def _organization_request(method: str, path: str) -> Mapping[str, object]:
+    return _ORGANIZATION_ROUTE_REQUESTS.get((method, path), {"json": {}})
+
+
 def _organization_test_client() -> TestClient:
     from fastapi import FastAPI
 
-    from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+    from litellm.proxy._types import LitellmUserRoles, ProxyException, UserAPIKeyAuth
     from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
     from litellm.proxy.management_endpoints.organization_endpoints import router
+    from litellm.proxy.proxy_server import openai_exception_handler
 
     app = FastAPI()
     app.include_router(router)
+    app.add_exception_handler(ProxyException, openai_exception_handler)
     app.dependency_overrides[user_api_key_auth] = lambda: UserAPIKeyAuth(
         api_key="sk-test", user_role=LitellmUserRoles.PROXY_ADMIN
     )
@@ -1258,25 +1280,30 @@ def _organization_test_client() -> TestClient:
 
 @pytest.mark.parametrize(("method", "path"), _organization_route_targets())
 def test_organization_routes_are_blocked_without_enterprise_license(monkeypatch, method, path):
-    """Every /organization route is enterprise-only, even for a proxy admin."""
+    """Every /organization route is enterprise-only, even for a proxy admin sending a valid request."""
     import litellm.proxy.proxy_server as proxy_server
 
     monkeypatch.setattr(proxy_server, "premium_user", False, raising=False)
+    monkeypatch.setattr(proxy_server, "prisma_client", None, raising=False)
 
-    response = _organization_test_client().request(method, path, json={})
+    response = _organization_test_client().request(method, path, **_organization_request(method, path))
 
     assert response.status_code == 403
     assert "Organizations" in response.json()["detail"]["error"]
 
 
 @pytest.mark.parametrize(("method", "path"), _organization_route_targets())
-def test_organization_routes_pass_the_license_gate_with_enterprise_license(monkeypatch, method, path):
-    """With a license the gate is transparent: whatever fails next, it is not the license check."""
+def test_organization_routes_reach_their_handler_with_enterprise_license(monkeypatch, method, path):
+    """The same request a license refuses above now reaches the handler, which is the code reporting the missing database."""
     import litellm.proxy.proxy_server as proxy_server
+    from litellm.proxy._types import CommonProxyErrors
 
     monkeypatch.setattr(proxy_server, "premium_user", True, raising=False)
     monkeypatch.setattr(proxy_server, "prisma_client", None, raising=False)
 
-    response = _organization_test_client().request(method, path, json={})
+    response = _organization_test_client().request(method, path, **_organization_request(method, path))
 
-    assert "LiteLLM Enterprise" not in response.text
+    assert response.status_code == 500
+    assert any(
+        message in response.text for message in (CommonProxyErrors.db_not_connected_error.value, "No db connected")
+    )

--- a/tests/test_litellm/proxy/management_endpoints/test_organization_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_organization_endpoints.py
@@ -1226,3 +1226,57 @@ def test_v2_update_organization_is_in_openapi_schema():
     v2_path = app.openapi()["paths"]["/v2/organization/{organization_id}"]
     assert v2_path["patch"]["tags"] == ["organization management"]
     assert "OrganizationUpdateRequestV2" in json.dumps(v2_path["patch"]["requestBody"])
+
+
+def _organization_route_targets() -> list[tuple[str, str]]:
+    from fastapi.routing import APIRoute
+
+    from litellm.proxy.management_endpoints.organization_endpoints import router
+
+    return [
+        (method, route.path.replace("{organization_id}", "org-under-test"))
+        for route in router.routes
+        if isinstance(route, APIRoute)
+        for method in sorted(route.methods - {"HEAD", "OPTIONS"})
+    ]
+
+
+def _organization_test_client() -> TestClient:
+    from fastapi import FastAPI
+
+    from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+    from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+    from litellm.proxy.management_endpoints.organization_endpoints import router
+
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[user_api_key_auth] = lambda: UserAPIKeyAuth(
+        api_key="sk-test", user_role=LitellmUserRoles.PROXY_ADMIN
+    )
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.mark.parametrize(("method", "path"), _organization_route_targets())
+def test_organization_routes_are_blocked_without_enterprise_license(monkeypatch, method, path):
+    """Every /organization route is enterprise-only, even for a proxy admin."""
+    import litellm.proxy.proxy_server as proxy_server
+
+    monkeypatch.setattr(proxy_server, "premium_user", False, raising=False)
+
+    response = _organization_test_client().request(method, path, json={})
+
+    assert response.status_code == 403
+    assert "Organizations" in response.json()["detail"]["error"]
+
+
+@pytest.mark.parametrize(("method", "path"), _organization_route_targets())
+def test_organization_routes_pass_the_license_gate_with_enterprise_license(monkeypatch, method, path):
+    """With a license the gate is transparent: whatever fails next, it is not the license check."""
+    import litellm.proxy.proxy_server as proxy_server
+
+    monkeypatch.setattr(proxy_server, "premium_user", True, raising=False)
+    monkeypatch.setattr(proxy_server, "prisma_client", None, raising=False)
+
+    response = _organization_test_client().request(method, path, json={})
+
+    assert "LiteLLM Enterprise" not in response.text

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/organizations/useOrganizations.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/organizations/useOrganizations.test.ts
@@ -81,7 +81,7 @@ describe("useOrganizations", () => {
       userRole: "Admin",
       token: "test-token",
       userEmail: "test@example.com",
-      premiumUser: false,
+      premiumUser: true,
       disabledPersonalKeyCreation: null,
       showSSOBanner: false,
     });
@@ -181,7 +181,7 @@ describe("useOrganizations", () => {
       userRole: "Admin",
       token: null,
       userEmail: "test@example.com",
-      premiumUser: false,
+      premiumUser: true,
       disabledPersonalKeyCreation: null,
       showSSOBanner: false,
     });
@@ -197,6 +197,26 @@ describe("useOrganizations", () => {
     expect(organizationListCall).not.toHaveBeenCalled();
   });
 
+  it("does not call the organization API when the session is not premium", async () => {
+    mockUseAuthorized.mockReturnValue({
+      accessToken: "test-access-token",
+      userId: "test-user-id",
+      userRole: "Admin",
+      token: "test-token",
+      userEmail: "test@example.com",
+      premiumUser: false,
+      disabledPersonalKeyCreation: null,
+      showSSOBanner: false,
+    });
+
+    const { result } = renderHook(() => useOrganizations(), { wrapper });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isFetched).toBe(false);
+    expect(organizationListCall).not.toHaveBeenCalled();
+  });
+
   it("should not execute query when userId is missing", async () => {
     // Mock missing userId
     mockUseAuthorized.mockReturnValue({
@@ -205,7 +225,7 @@ describe("useOrganizations", () => {
       userRole: "Admin",
       token: "test-token",
       userEmail: "test@example.com",
-      premiumUser: false,
+      premiumUser: true,
       disabledPersonalKeyCreation: null,
       showSSOBanner: false,
     });
@@ -229,7 +249,7 @@ describe("useOrganizations", () => {
       userRole: null,
       token: "test-token",
       userEmail: "test@example.com",
-      premiumUser: false,
+      premiumUser: true,
       disabledPersonalKeyCreation: null,
       showSSOBanner: false,
     });
@@ -253,7 +273,7 @@ describe("useOrganizations", () => {
       userRole: null,
       token: null,
       userEmail: "test@example.com",
-      premiumUser: false,
+      premiumUser: true,
       disabledPersonalKeyCreation: null,
       showSSOBanner: false,
     });
@@ -335,7 +355,7 @@ describe("useOrganization", () => {
       userRole: "Admin",
       token: "test-token",
       userEmail: "test@example.com",
-      premiumUser: false,
+      premiumUser: true,
       disabledPersonalKeyCreation: null,
       showSSOBanner: false,
     });
@@ -354,6 +374,26 @@ describe("useOrganization", () => {
     // initialData found org-2 in the filtered cache, so data is present on the first render.
     expect(result.current.data).toEqual(mockOrganizations[1]);
     expect(result.current.isLoading).toBe(false);
+  });
+
+  it("does not call the organization info API when the session is not premium", () => {
+    mockUseAuthorized.mockReturnValue({
+      accessToken: "test-access-token",
+      userId: "test-user-id",
+      userRole: "Admin",
+      token: "test-token",
+      userEmail: "test@example.com",
+      premiumUser: false,
+      disabledPersonalKeyCreation: null,
+      showSSOBanner: false,
+    });
+
+    const { result } = renderHook(() => useOrganization("org-1"), { wrapper });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isFetched).toBe(false);
+    expect(organizationInfoCall).not.toHaveBeenCalled();
   });
 
   it("falls through to the detail API call when no cached list contains the organization", async () => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/organizations/useOrganizations.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/organizations/useOrganizations.ts
@@ -11,9 +11,10 @@ export interface OrganizationListFilters {
 }
 
 export const useOrganizations = (filters?: OrganizationListFilters): UseQueryResult<Organization[]> => {
-  const { accessToken, userId, userRole } = useAuthorized();
+  const { accessToken, userId, userRole, premiumUser } = useAuthorized();
   const orgId = filters?.org_id || null;
   const orgAlias = filters?.org_alias || null;
+  const hasSession = Boolean(accessToken && userId && userRole);
   return useQuery<Organization[]>({
     queryKey: organizationKeys.list(
       orgId || orgAlias
@@ -21,16 +22,16 @@ export const useOrganizations = (filters?: OrganizationListFilters): UseQueryRes
         : {},
     ),
     queryFn: async () => await organizationListCall(accessToken!, orgId, orgAlias),
-    enabled: Boolean(accessToken && userId && userRole),
+    enabled: hasSession && premiumUser === true,
   });
 };
 
 export const useOrganization = (organizationID?: string) => {
   const queryClient = useQueryClient();
-  const { accessToken } = useAuthorized();
+  const { accessToken, premiumUser } = useAuthorized();
   return useQuery<Organization>({
     queryKey: organizationKeys.detail(organizationID!),
-    enabled: Boolean(accessToken && organizationID),
+    enabled: Boolean(accessToken && organizationID) && premiumUser === true,
 
     queryFn: async () => {
       if (!accessToken || !organizationID) {

--- a/ui/litellm-dashboard/src/components/TeamSSOSettings.test.tsx
+++ b/ui/litellm-dashboard/src/components/TeamSSOSettings.test.tsx
@@ -8,6 +8,19 @@ import { toast } from "@/lib/toast";
 
 vi.mock("./networking");
 
+vi.mock("@/app/(dashboard)/hooks/useAuthorized", () => ({
+  default: () => ({
+    token: "test-token",
+    accessToken: "test-token",
+    userId: "test-user",
+    userEmail: "test-user@example.com",
+    userRole: "Admin",
+    premiumUser: true,
+    disabledPersonalKeyCreation: null,
+    showSSOBanner: false,
+  }),
+}));
+
 vi.mock("./common_components/budget_duration_dropdown", () => {
   const BudgetDurationDropdown = ({ value, onChange }: { value: string | null; onChange: (value: string) => void }) => (
     <select


### PR DESCRIPTION
## TLDR

Problem this solves:

- Every `/organization` route worked without an enterprise license
- The Admin UI and the docs already call organizations enterprise-only
- An unlicensed proxy could build a whole org hierarchy over the API
- Teams, Keys and Users pages still requested `/organization/list` on unlicensed proxies

How it solves it:

- One license check on the organization router itself
- It resolves auth first, so a bad key still gets 401
- Every current and future org route inherits the gate
- The dashboard's organization hooks only fetch when the session is premium
  - Chosen: gate the two shared hooks, so no page issues a request the API will now refuse
  - Rejected: API-only 403 with the hooks left firing. Every Teams, Keys or Users page load would log a 403, retry it, and show nothing to the user
  - Rejected: gate only the write routes and leave list, info and daily activity open. That contradicts the UI's enterprise notice and the earlier ruling in #12727

## User Flow

Before: an admin on an unlicensed proxy is told organizations are enterprise-only in the UI, then creates one anyway over the API

1. They open http://localhost:4000/ui/?page=organizations and read "This is a LiteLLM Enterprise feature, and requires a valid key to use"
2. They send `POST http://localhost:4000/organization/new` with `{"organization_alias": "oss-org"}`
3. It comes back 200 with a real `organization_id`
4. `GET http://localhost:4000/organization/list` comes back 200 and lists that organization
5. They open http://localhost:4000/ui/?page=teams and the page silently calls `GET /organization/list`, which also comes back 200
6. Anyone with an admin key on that proxy can go on creating, renaming and deleting organizations the license does not cover

After: the API tells them the same thing the page does, and the other pages stop asking

1. They open the same page and read the same enterprise notice
2. They send the same `POST http://localhost:4000/organization/new`
3. It comes back 403 with "Organizations are only available for LiteLLM Enterprise users", plus the trial and pricing links
4. `GET http://localhost:4000/organization/list` comes back with the same 403
5. They open http://localhost:4000/ui/?page=teams and the page renders with no `/organization/list` request and no console error; the same holds for the Keys and Users pages
6. A request with a bad key still comes back 401, so the gate never hides an auth failure
7. Setting `LITELLM_LICENSE` and restarting brings every call back to 200, and the Teams and Organizations pages fetch and list organizations again
8. Nobody on an unlicensed proxy can create, rename or delete an organization any more

## Relevant issues

Fixes #40598

## Linear ticket

Resolves LIT-7497

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup. Two proxies boot from the same checkout against a throwaway database: the unlicensed one on port 56690 with `LITELLM_LICENSE` removed from `.env`, the licensed one on port 59134 with `LITELLM_LICENSE` exported. The master key is `sk-1234` from `dev_config.yaml`. The Admin UI is the dev server (`npm run dev` in `ui/litellm-dashboard`, http://localhost:3000) pointed at the proxy under test, logged in as `admin` / `sk-1234`, with the browser's network log filtered to `/organization`

```bash
# unlicensed proxy (no LITELLM_LICENSE in the environment)
LITELLM_CORS_ORIGINS=http://localhost:3000 LITELLM_CORS_ALLOW_CREDENTIALS=true \
  python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --port 56690 --use_v2_migration_resolver

# licensed proxy (LITELLM_LICENSE exported from .env)
LITELLM_CORS_ORIGINS=http://localhost:3000 LITELLM_CORS_ALLOW_CREDENTIALS=true \
  python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --port 59134 --use_v2_migration_resolver
```

The route sweep below runs every organization route in order with the master key, then `GET /organization/list` with a key that does not exist:

```bash
H=(-H "Authorization: Bearer sk-1234" -H "Content-Type: application/json")
curl -s -w "\nHTTP %{http_code}\n" -X POST   http://127.0.0.1:$PORT/organization/new $H -d '{"organization_alias":"oss-org","models":[]}'
curl -s -w "\nHTTP %{http_code}\n"           http://127.0.0.1:$PORT/organization/list $H
curl -s -w "\nHTTP %{http_code}\n" -X PATCH  http://127.0.0.1:$PORT/organization/update $H -d "{\"organization_id\":\"$ORG_ID\",\"organization_alias\":\"oss-org-renamed\"}"
curl -s -w "\nHTTP %{http_code}\n" -X PATCH  http://127.0.0.1:$PORT/v2/organization/$ORG_ID $H -d '{"organization_alias":"oss-org-v2"}'
curl -s -w "\nHTTP %{http_code}\n"           "http://127.0.0.1:$PORT/organization/info?organization_id=$ORG_ID" $H
curl -s -w "\nHTTP %{http_code}\n" -X POST   http://127.0.0.1:$PORT/organization/info $H -d "{\"organizations\":[\"$ORG_ID\"]}"
curl -s -w "\nHTTP %{http_code}\n" -X POST   http://127.0.0.1:$PORT/organization/member_add $H -d "{\"organization_id\":\"$ORG_ID\",\"member\":{\"role\":\"internal_user\",\"user_id\":\"$USER_ID\"}}"
curl -s -w "\nHTTP %{http_code}\n" -X PATCH  http://127.0.0.1:$PORT/organization/member_update $H -d "{\"organization_id\":\"$ORG_ID\",\"user_id\":\"$USER_ID\",\"role\":\"org_admin\"}"
curl -s -w "\nHTTP %{http_code}\n" -X DELETE http://127.0.0.1:$PORT/organization/member_delete $H -d "{\"organization_id\":\"$ORG_ID\",\"user_id\":\"$USER_ID\"}"
curl -s -w "\nHTTP %{http_code}\n"           "http://127.0.0.1:$PORT/organization/daily/activity?start_date=2026-09-01&end_date=2026-09-10" $H
curl -s -w "\nHTTP %{http_code}\n" -X DELETE http://127.0.0.1:$PORT/organization/delete $H -d "{\"organization_ids\":[\"$ORG_ID\"]}"
curl -s -w "\nHTTP %{http_code}\n"           http://127.0.0.1:$PORT/organization/list -H "Authorization: Bearer sk-not-a-real-key"
```

### Before (692a311efb)

#### Unlicensed proxy, organization API

1. Create an organization

```bash
$ curl -s -w "\nHTTP %{http_code}\n" -X POST http://127.0.0.1:56690/organization/new \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"organization_alias":"oss-org","models":[]}'
{"organization_id":"deac1c94-5bc8-4558-a838-92a1a975ce1f","organization_alias":"oss-org","budget_id":"80ef734f-4adf-4850-8e63-95b753c99122","spend":0.0,"metadata":{},"models":[],"model_spend":{},"created_by":"default_user_id",...
HTTP 200
```

2. Run the route sweep with `PORT=56690`

```text
POST   /organization/new                         HTTP 200
GET    /organization/list                        HTTP 200
PATCH  /organization/update                      HTTP 200
PATCH  /v2/organization/{organization_id}        HTTP 200
GET    /organization/info                        HTTP 200
POST   /organization/info                        HTTP 200
POST   /organization/member_add                  HTTP 200
PATCH  /organization/member_update               HTTP 200
DELETE /organization/member_delete               HTTP 200
GET    /organization/daily/activity              HTTP 200
DELETE /organization/delete                      HTTP 200
GET    /organization/list, key does not exist    HTTP 401
```

#### Unlicensed proxy, Admin UI

1. Open http://localhost:3000/teams. The page renders and the network log shows `GET /organization/list -> 200`

![before teams](https://github.com/mateo-berri/qa-screenshots/releases/download/assets/pr40613-4de441c181-lit7497_before_teams.png)

2. Open http://localhost:3000/api-keys. Same thing: `GET /organization/list -> 200`

![before api-keys](https://github.com/mateo-berri/qa-screenshots/releases/download/assets/pr40613-4de441c181-lit7497_before_api-keys.png)

3. Open http://localhost:3000/organizations. The page shows the enterprise notice and still sends `GET /organization/list -> 200` behind it

![before organizations](https://github.com/mateo-berri/qa-screenshots/releases/download/assets/pr40613-4de441c181-lit7497_before_organizations.png)

#### Licensed proxy, organization API

1. Run the route sweep with `PORT=55456` (the licensed proxy for this leg booted from the same merge base on that port)

```text
POST   /organization/new                         HTTP 200
GET    /organization/list                        HTTP 200
PATCH  /organization/update                      HTTP 200
PATCH  /v2/organization/{organization_id}        HTTP 200
GET    /organization/info                        HTTP 200
POST   /organization/info                        HTTP 200
POST   /organization/member_add                  HTTP 200
PATCH  /organization/member_update               HTTP 200
DELETE /organization/member_delete               HTTP 200
GET    /organization/daily/activity              HTTP 200
DELETE /organization/delete                      HTTP 200
GET    /organization/list, key does not exist    HTTP 401
```

### After (3b0ffaaa8d)

The route sweeps below were re-run at 3b0ffaaa8d. The Admin UI screenshots were taken at 4de441c181; the only commit since is test-only, so they still show the tip's behavior

#### Unlicensed proxy, organization API

1. Create an organization

```bash
$ curl -s -w "\nHTTP %{http_code}\n" -X POST http://127.0.0.1:56690/organization/new \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"organization_alias":"oss-org","models":[]}'
{"detail":{"error":"Organizations are only available for LiteLLM Enterprise users. You must be a LiteLLM Enterprise user to use this feature. If you have a license please set `LITELLM_LICENSE` in your env. Get a 7 day trial key here: https://www.litellm.ai/enterprise#trial. \nPricing: https://www.litellm.ai/#pricing"}}
HTTP 403
```

2. Run the route sweep with `PORT=56690`. Every route returns the 403 body above; the bad key still gets its 401

```text
POST   /organization/new                         HTTP 403
GET    /organization/list                        HTTP 403
PATCH  /organization/update                      HTTP 403
PATCH  /v2/organization/{organization_id}        HTTP 403
GET    /organization/info                        HTTP 403
POST   /organization/info                        HTTP 403
POST   /organization/member_add                  HTTP 403
PATCH  /organization/member_update               HTTP 403
DELETE /organization/member_delete               HTTP 403
GET    /organization/daily/activity              HTTP 403
DELETE /organization/delete                      HTTP 403
GET    /organization/list, key does not exist    HTTP 401
```

3. The bad key case, in full

```bash
$ curl -s -w "\nHTTP %{http_code}\n" http://127.0.0.1:56690/organization/list -H "Authorization: Bearer sk-not-a-real-key"
{"error":{"message":"Authentication Error, Invalid proxy server token passed. Received API Key = sk-...-key, Key Hash (Token) =d748053aa2a9bae8062909094b81b0d363da93c9c4ca6dc3025c66ff55933f7b. Unable to find token in cache or `LiteLLM_VerificationTokenTable`","type":"token_not_found_in_db","param":"key","code":"401"}}
HTTP 401
```

#### Unlicensed proxy, Admin UI

1. Open http://localhost:3000/teams. The page renders, the network log has no `/organization` request, and the console has 0 errors

![after teams](https://github.com/mateo-berri/qa-screenshots/releases/download/assets/pr40613-4de441c181-lit7497_after_teams.png)

2. Open http://localhost:3000/api-keys. Same thing: no `/organization` request

![after api-keys](https://github.com/mateo-berri/qa-screenshots/releases/download/assets/pr40613-4de441c181-lit7497_after_api-keys.png)

3. Open http://localhost:3000/organizations. The enterprise notice shows as before and the page no longer sends `GET /organization/list`

![after organizations](https://github.com/mateo-berri/qa-screenshots/releases/download/assets/pr40613-4de441c181-lit7497_after_organizations.png)

#### Licensed proxy, organization API

1. Run the route sweep with `PORT=49898` (a licensed proxy booted from the tip on that port)

```text
POST   /organization/new                         HTTP 200
GET    /organization/list                        HTTP 200
PATCH  /organization/update                      HTTP 200
PATCH  /v2/organization/{organization_id}        HTTP 200
GET    /organization/info                        HTTP 200
POST   /organization/info                        HTTP 200
POST   /organization/member_add                  HTTP 200
PATCH  /organization/member_update               HTTP 200
DELETE /organization/member_delete               HTTP 200
GET    /organization/daily/activity              HTTP 200
DELETE /organization/delete                      HTTP 200
GET    /organization/list, key does not exist    HTTP 401
```

2. Open http://localhost:3000/teams against the licensed proxy. The network log shows `GET /organization/list -> 200` again, so a premium session still gets its organizations

![licensed teams](https://github.com/mateo-berri/qa-screenshots/releases/download/assets/pr40613-4de441c181-lit7497_licensed_teams.png)

3. Open http://localhost:3000/organizations against the licensed proxy. `GET /organization/list -> 200` and the table lists the organization

![licensed organizations](https://github.com/mateo-berri/qa-screenshots/releases/download/assets/pr40613-4de441c181-lit7497_licensed_organizations.png)

## Type

🆕 New Feature

## Caveats (if any)

### Severe

- Unlicensed proxies lose all `/organization` access, reads included
  - That is the point of the PR, but it is a behavior change for anyone using organizations without a license today
  - Their rows stay in the database and org budgets keep applying to requests; only management goes away
  - Setting `LITELLM_LICENSE` restores everything, nothing is deleted or migrated

### Medium

- `POST /user/new` with `organizations: [...]` still adds the new user to those organizations on an unlicensed proxy, because it calls the member-add function directly instead of going through the router. Checked live: on port 56690 the call returned 200 and the licensed proxy on the same database then listed the user under the organization. Gating that field in `/user/new` was considered and left out, since it changes an unrelated endpoint; it belongs in a follow-up together with the team endpoints' direct organization helpers

### Low

- The Admin UI already showed the enterprise notice on the organizations page, so nothing changes there
- Org dropdowns and filters on the Teams, Keys and Users pages are empty on unlicensed proxies by design, since those pages no longer ask for organizations
- The team info view still calls `/organization/info` directly for a team's organization; that call is already wrapped and only logs on failure, so it is left alone here
- `/organization/spend/report` lives in the spend router and was already license-gated, so it is untouched. Checked live on the unlicensed proxy: `GET /organization/spend/report?start_date=2026-09-01&end_date=2026-09-10` returns 403 with the enterprise message
- Users whose only admin role comes from organization membership (not the proxy admin role) lose the Create Team button and org-admin sidebar entries on unlicensed proxies, since the dashboard derives that role from the organization list it no longer fetches. That matches the backend, which now refuses the same membership lookups without a license
- The docs walkthrough in `docs/proxy/access_control.md` still walks through `/organization/new` with no enterprise banner, worth a follow-up in the docs repo
- Two CircleCI jobs are red at this tip, `llm_translation_testing` and `local_testing_part1`, on tests this PR does not touch. Four of the five failing tests (`test_azure_gpt_4o_with_tool_call_and_response_format`, `test_openai_max_retries_0`, `test_openai_o_series_max_retries_0`, `test_completion_novita_ai`) fail the same way on every `litellm_internal_staging` run today, and the fifth, `test_litellm_gateway_from_sdk_embedding[True]`, passes locally at the tip alone and with its file and already failed once on another branch this morning, so it is a flake. Neither job is a required check and `build_and_test` does not depend on them

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

https://claude.ai/code/session_01Se8ERtsqMQ3eVzWiLVMyNS


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a breaking behavior change for anyone using organization APIs without a license (all org routes, including list/info, now 403). The gate is centralized and tested, but related paths like `POST /user/new` with organizations may still bypass the router per the PR caveats.
> 
> **Overview**
> **Organization management is now enterprise-only end-to-end.** The proxy organization router gets a shared `_enterprise_license_required` dependency (runs after API key auth) so every current and future `/organization` route returns **403** when `premium_user` is false, with messaging aligned to other enterprise features.
> 
> The dashboard **`useOrganizations`** and **`useOrganization`** hooks only enable their React Query fetches when `premiumUser === true`, so Teams/Keys/Users-style pages stop calling `/organization/*` on unlicensed proxies and avoid noisy 403s.
> 
> **Tests** add a parametrized sweep of all organization routes (403 without license, handlers reached with license), plus hook tests for non-premium sessions; **`TeamSSOSettings`** tests mock a premium session where org list loading is involved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b0ffaaa8d170fdb65031b1a87242a1b30141ff6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->