### PR TITLE
fix(realtime): dial Azure's GA realtime upstream for GA clients

### DIFF
--- a/litellm/litellm_core_utils/realtime_streaming.py
+++ b/litellm/litellm_core_utils/realtime_streaming.py
@@ -90,12 +90,12 @@ class _ResponseDoneBody(TypedDict, total=False):
     output: ReadOnly[Sequence[Mapping[str, object]]]
 
 
-class _ScopedWebSocket(Protocol):
+class ScopedWebSocket(Protocol):
     @property
     def scope(self) -> _ASGIScope: ...
 
 
-class _ClientWebSocket(_ScopedWebSocket, Protocol):
+class _ClientWebSocket(ScopedWebSocket, Protocol):
     async def send_text(self, data: str) -> None: ...
     async def receive_text(self) -> str: ...
     async def close(self, code: int = 1000, reason: str | None = None) -> None: ...
@@ -1149,7 +1149,7 @@ class RealTimeStreaming:
         )
 
     @staticmethod
-    def _detect_beta_header(websocket: _ScopedWebSocket) -> bool:
+    def _detect_beta_header(websocket: ScopedWebSocket) -> bool:
         """Return True if the client sent 'OpenAI-Beta: realtime=v1'.
 
         Checks the raw ASGI scope headers so it works for both FastAPI WebSocket
@@ -1584,6 +1584,6 @@ class RealTimeStreaming:
             verbose_logger.debug("Could not relay the upstream close to the client: %s", e)
 
 
-def client_sent_openai_beta_realtime_header(websocket: _ScopedWebSocket) -> bool:
+def client_sent_openai_beta_realtime_header(websocket: ScopedWebSocket) -> bool:
     """True when the client WebSocket includes ``OpenAI-Beta: realtime=v1``."""
     return RealTimeStreaming._detect_beta_header(websocket)

--- a/litellm/llms/azure/realtime/handler.py
+++ b/litellm/llms/azure/realtime/handler.py
@@ -6,16 +6,22 @@ This requires websockets, and is currently only supported on LiteLLM Proxy.
 
 from collections.abc import Mapping
 from types import MappingProxyType
-from typing import Any, Final, Protocol, cast
+from typing import TYPE_CHECKING, Any, Final, Protocol, cast
 
 from litellm._logging import _redact_string, verbose_proxy_logger
 from litellm.constants import REALTIME_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES
 from litellm.types.realtime import RealtimeQueryParams
 
 from ....litellm_core_utils.litellm_logging import Logging as LiteLLMLogging
-from ....litellm_core_utils.realtime_streaming import RealTimeStreaming
+from ....litellm_core_utils.realtime_streaming import (
+    RealTimeStreaming,
+    client_sent_openai_beta_realtime_header,
+)
 from ....llms.custom_httpx.http_handler import get_shared_realtime_ssl_context
 from ..azure import AzureChatCompletion
+
+if TYPE_CHECKING:
+    from fastapi import WebSocket
 
 # BACKEND_WS_URL = "ws://localhost:8080/v1/realtime?model=gpt-4o-realtime-preview-2024-10-01"
 
@@ -29,6 +35,19 @@ async def forward_messages(client_ws: Any, backend_ws: Any):
             await client_ws.send_text(message)
     except websockets.exceptions.ConnectionClosed:
         pass
+
+
+def azure_realtime_protocol_for_client(
+    configured_protocol: object,
+    *,
+    query_params: RealtimeQueryParams | None,
+    websocket: "WebSocket",
+) -> str:
+    if isinstance(configured_protocol, str) and configured_protocol:
+        return configured_protocol
+    if (query_params or {}).get("intent") == "transcription":
+        return "GA"
+    return "beta" if client_sent_openai_beta_realtime_header(websocket) else "GA"
 
 
 class _ProxyClientWebSocket(Protocol):

--- a/litellm/llms/azure/realtime/handler.py
+++ b/litellm/llms/azure/realtime/handler.py
@@ -6,7 +6,7 @@ This requires websockets, and is currently only supported on LiteLLM Proxy.
 
 from collections.abc import Mapping
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Final, Protocol, cast
+from typing import Any, Final, Protocol, cast
 
 from litellm._logging import _redact_string, verbose_proxy_logger
 from litellm.constants import REALTIME_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES
@@ -15,13 +15,11 @@ from litellm.types.realtime import RealtimeQueryParams
 from ....litellm_core_utils.litellm_logging import Logging as LiteLLMLogging
 from ....litellm_core_utils.realtime_streaming import (
     RealTimeStreaming,
+    ScopedWebSocket,
     client_sent_openai_beta_realtime_header,
 )
 from ....llms.custom_httpx.http_handler import get_shared_realtime_ssl_context
 from ..azure import AzureChatCompletion
-
-if TYPE_CHECKING:
-    from fastapi import WebSocket
 
 # BACKEND_WS_URL = "ws://localhost:8080/v1/realtime?model=gpt-4o-realtime-preview-2024-10-01"
 
@@ -41,7 +39,7 @@ def azure_realtime_protocol_for_client(
     configured_protocol: object,
     *,
     query_params: RealtimeQueryParams | None,
-    websocket: "WebSocket",
+    websocket: ScopedWebSocket,
 ) -> str:
     if isinstance(configured_protocol, str) and configured_protocol:
         return configured_protocol

--- a/litellm/realtime_api/main.py
+++ b/litellm/realtime_api/main.py
@@ -14,6 +14,7 @@ from litellm.constants import (
     request_timeout,
 )
 from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+from litellm.litellm_core_utils.realtime_streaming import client_sent_openai_beta_realtime_header
 from litellm.llms.base_llm.realtime.transformation import BaseRealtimeConfig
 from litellm.llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
 from litellm.llms.xai.common_utils import XAIModelInfo
@@ -413,14 +414,14 @@ async def _arealtime(
 
         api_version = api_version or litellm_params.api_version or "2024-10-01-preview"
 
-        realtime_protocol = (
+        configured_realtime_protocol: Final = (
             kwargs.get("realtime_protocol")
             or litellm_params.get("realtime_protocol")
             or os.environ.get("LITELLM_AZURE_REALTIME_PROTOCOL")
         )
-        if realtime_protocol is None and (query_params or {}).get("intent") == "transcription":
-            realtime_protocol = "GA"
-        realtime_protocol = realtime_protocol or "beta"
+        realtime_protocol: Final = _azure_realtime_protocol_for_client(
+            configured_realtime_protocol, query_params=query_params, websocket=websocket
+        )
         resolved_azure_ad_token: Final = (
             None if api_key else get_azure_ad_token(GenericLiteLLMParams(**kwargs, azure_ad_token=azure_ad_token))
         )
@@ -574,6 +575,19 @@ def _is_transcription_only_realtime_model(model: str, custom_llm_provider: str) 
 
 
 _TRANSCRIPTION_QUERY_PARAMS: Final[RealtimeQueryParams] = {"intent": "transcription"}
+
+
+def _azure_realtime_protocol_for_client(
+    configured_protocol: object,
+    *,
+    query_params: RealtimeQueryParams | None,
+    websocket: "WebSocket",
+) -> str:
+    if isinstance(configured_protocol, str) and configured_protocol:
+        return configured_protocol
+    if (query_params or {}).get("intent") == "transcription":
+        return "GA"
+    return "beta" if client_sent_openai_beta_realtime_header(websocket) else "GA"
 
 
 def _azure_realtime_health_protocol(

--- a/litellm/realtime_api/main.py
+++ b/litellm/realtime_api/main.py
@@ -14,7 +14,6 @@ from litellm.constants import (
     request_timeout,
 )
 from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
-from litellm.litellm_core_utils.realtime_streaming import client_sent_openai_beta_realtime_header
 from litellm.llms.base_llm.realtime.transformation import BaseRealtimeConfig
 from litellm.llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
 from litellm.llms.xai.common_utils import XAIModelInfo
@@ -34,7 +33,7 @@ from litellm.utils import ProviderConfigManager
 from ..litellm_core_utils.get_litellm_params import get_litellm_params
 from ..litellm_core_utils.litellm_logging import Logging as LiteLLMLogging
 from ..llms.azure.common_utils import get_azure_ad_token
-from ..llms.azure.realtime.handler import AzureOpenAIRealtime
+from ..llms.azure.realtime.handler import AzureOpenAIRealtime, azure_realtime_protocol_for_client
 from ..llms.bedrock.realtime.handler import BedrockRealtime
 from ..llms.custom_httpx.http_handler import get_shared_realtime_ssl_context
 from ..llms.openai.realtime.handler import OpenAIRealtime
@@ -419,7 +418,7 @@ async def _arealtime(
             or litellm_params.get("realtime_protocol")
             or os.environ.get("LITELLM_AZURE_REALTIME_PROTOCOL")
         )
-        realtime_protocol: Final = _azure_realtime_protocol_for_client(
+        realtime_protocol: Final = azure_realtime_protocol_for_client(
             configured_realtime_protocol, query_params=query_params, websocket=websocket
         )
         resolved_azure_ad_token: Final = (
@@ -575,19 +574,6 @@ def _is_transcription_only_realtime_model(model: str, custom_llm_provider: str) 
 
 
 _TRANSCRIPTION_QUERY_PARAMS: Final[RealtimeQueryParams] = {"intent": "transcription"}
-
-
-def _azure_realtime_protocol_for_client(
-    configured_protocol: object,
-    *,
-    query_params: RealtimeQueryParams | None,
-    websocket: "WebSocket",
-) -> str:
-    if isinstance(configured_protocol, str) and configured_protocol:
-        return configured_protocol
-    if (query_params or {}).get("intent") == "transcription":
-        return "GA"
-    return "beta" if client_sent_openai_beta_realtime_header(websocket) else "GA"
 
 
 def _azure_realtime_health_protocol(

--- a/tests/test_litellm/realtime_api/test_main.py
+++ b/tests/test_litellm/realtime_api/test_main.py
@@ -327,7 +327,60 @@ async def test_arealtime_azure_ai_on_a_foundry_host_connects_to_the_azure_openai
             api_key="fake-key",
             litellm_logging_obj=FakeLogging(),
         )
-    assert connect.url == (
-        "wss://my-project.services.ai.azure.com/openai/realtime"
-        "?api-version=2024-10-01-preview&deployment=gpt-realtime-mini"
+    assert connect.url == "wss://my-project.services.ai.azure.com/openai/v1/realtime?model=gpt-realtime-mini"
+
+
+class _ClientWebSocketWithHeaders:
+    def __init__(self, headers: tuple[tuple[bytes, bytes], ...]) -> None:
+        self.scope: Final = {"headers": headers}
+
+
+_GA_CLIENT: Final = _ClientWebSocketWithHeaders(headers=())
+_BETA_CLIENT: Final = _ClientWebSocketWithHeaders(headers=((b"openai-beta", b"realtime=v1"),))
+
+
+async def _azure_backend_url_dialed_for(websocket: _ClientWebSocketWithHeaders, **kwargs: object) -> str | None:
+    connect: Final = _ConnectThatStopsAfterCapturingTheUrl()
+    with patch("websockets.connect", connect):
+        await realtime_main._arealtime.__wrapped__(
+            model="azure/gpt-realtime",
+            websocket=websocket,
+            api_base="https://my-endpoint.openai.azure.com",
+            api_key="fake-key",
+            litellm_logging_obj=FakeLogging(),
+            **kwargs,
+        )
+    return connect.url
+
+
+@pytest.mark.asyncio
+async def test_arealtime_azure_ga_client_without_beta_header_dials_the_ga_upstream(monkeypatch):
+    monkeypatch.delenv("LITELLM_AZURE_REALTIME_PROTOCOL", raising=False)
+    assert (
+        await _azure_backend_url_dialed_for(_GA_CLIENT)
+        == "wss://my-endpoint.openai.azure.com/openai/v1/realtime?model=gpt-realtime"
+    )
+
+
+@pytest.mark.asyncio
+async def test_arealtime_azure_beta_header_client_keeps_the_beta_upstream(monkeypatch):
+    monkeypatch.delenv("LITELLM_AZURE_REALTIME_PROTOCOL", raising=False)
+    assert await _azure_backend_url_dialed_for(_BETA_CLIENT) == (
+        "wss://my-endpoint.openai.azure.com/openai/realtime?api-version=2024-10-01-preview&deployment=gpt-realtime"
+    )
+
+
+@pytest.mark.asyncio
+async def test_arealtime_azure_explicit_beta_protocol_wins_over_a_ga_client(monkeypatch):
+    monkeypatch.delenv("LITELLM_AZURE_REALTIME_PROTOCOL", raising=False)
+    assert await _azure_backend_url_dialed_for(_GA_CLIENT, realtime_protocol="beta") == (
+        "wss://my-endpoint.openai.azure.com/openai/realtime?api-version=2024-10-01-preview&deployment=gpt-realtime"
+    )
+
+
+@pytest.mark.asyncio
+async def test_arealtime_azure_env_beta_protocol_wins_over_a_ga_client(monkeypatch):
+    monkeypatch.setenv("LITELLM_AZURE_REALTIME_PROTOCOL", "beta")
+    assert await _azure_backend_url_dialed_for(_GA_CLIENT) == (
+        "wss://my-endpoint.openai.azure.com/openai/realtime?api-version=2024-10-01-preview&deployment=gpt-realtime"
     )


### PR DESCRIPTION
## TLDR

Problem this solves:

- GA realtime clients on Azure `gpt-realtime` get `Unknown parameter: 'session.type'`
- Azure always dialed the beta upstream when `realtime_protocol` was unset
- The client's GA `session.update` was forwarded to that beta upstream unchanged

How it solves it:

- An unset `realtime_protocol` now follows the client, like the OpenAI handler
- `OpenAI-Beta: realtime=v1` on the client socket keeps the beta upstream
- Any other client gets Azure's `/openai/v1/realtime` GA upstream
- Explicit `realtime_protocol` and `LITELLM_AZURE_REALTIME_PROTOCOL` still win

## User Flow

Before: a voice-agent developer pointing the OpenAI SDK's GA realtime client at the proxy's Azure `gpt-realtime` deployment gets the first `session.update` rejected, so the agent never gets its own instructions

1. The proxy admin adds `gpt-realtime` as `azure/gpt-realtime` with the Azure resource's `api_base` and `api_key`, and no `realtime_protocol`
2. The developer's app opens `wss://litellm-domain/v1/realtime?model=gpt-realtime` with `client.realtime.connect(model="gpt-realtime")` from the OpenAI SDK, which sends no `OpenAI-Beta` header
3. The socket opens and a `session.created` event comes back, so the app shows "Speak now"
4. The app sends its first `session.update` with `{"session": {"type": "realtime", "output_modalities": ["audio"], "instructions": "...", "audio": {...}}}`
5. The next event is `{"type": "error", "error": {"message": "Unknown parameter: 'session.type'.", "code": "unknown_parameter", "param": "session.type"}}`, and `gpt-realtime-1.5` fails the same way

After: the same GA client gets `session.updated` back, so the voice agent runs with its own instructions

1. The proxy admin adds `gpt-realtime` as `azure/gpt-realtime` with the Azure resource's `api_base` and `api_key`, and no `realtime_protocol`
2. The developer's app opens `wss://litellm-domain/v1/realtime?model=gpt-realtime` with `client.realtime.connect(model="gpt-realtime")` from the OpenAI SDK, which sends no `OpenAI-Beta` header
3. The socket opens and a `session.created` event comes back, so the app shows "Speak now"
4. The app sends its first `session.update` with `{"session": {"type": "realtime", "output_modalities": ["audio"], "instructions": "...", "audio": {...}}}`
5. The next event is `session.updated` carrying `"type": "realtime"`, `"output_modalities": ["audio"]`, and the app's instructions, and `gpt-realtime-1.5` behaves the same
6. An app still on `client.beta.realtime.connect` (which sends `OpenAI-Beta: realtime=v1`) keeps getting beta-shaped `session.updated` events exactly as before

## Relevant issues

Relates to #24212 (the same error, fixed for OpenAI by #27110; this covers the Azure path)

## Linear ticket

Resolves LIT-7451

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup: one proxy per leg booted from the named commit with `python litellm/proxy/proxy_cli.py --config config.yaml --port <port> --num_workers 2` (two uvicorn workers on both legs, one proxy at a time on a random free port). Real Azure OpenAI resource in eastus2 with `gpt-realtime` and `gpt-realtime-1.5` deployed, openai SDK 2.33.0

```yaml
model_list:
  - model_name: gpt-realtime
    litellm_params:
      model: azure/gpt-realtime
      api_base: https://<resource>.cognitiveservices.azure.com
      api_key: os.environ/AZURE_API_KEY
  - model_name: gpt-realtime-1.5
    litellm_params:
      model: azure/gpt-realtime-1.5
      api_base: https://<resource>.cognitiveservices.azure.com
      api_key: os.environ/AZURE_API_KEY
general_settings:
  master_key: sk-1234
```

`ga_client.py`, the customer's kind of client (GA realtime client, no `OpenAI-Beta` header), sends the GA-shaped `session.update` and prints each event's type plus a few session fields:

```python
import asyncio, json, sys
from openai import AsyncOpenAI

async def main() -> None:
    base_url, model, api_key = sys.argv[1], sys.argv[2], sys.argv[3]
    client = AsyncOpenAI(base_url=base_url, api_key=api_key, websocket_base_url=base_url.replace("http://", "ws://"))
    async with client.realtime.connect(model=model) as conn:
        await conn.session.update(session={
            "type": "realtime", "output_modalities": ["audio"], "instructions": "You are a voice agent. Keep answers short.",
            "audio": {"input": {"turn_detection": {"type": "server_vad"}}, "output": {"voice": "alloy"}},
        })
        async for event in conn:
            print(json.dumps({"type": event.type, **({"error": event.error.model_dump(exclude_none=True)} if event.type == "error" else {"session": {k: v for k, v in event.session.model_dump(exclude_none=True).items() if k in ("type", "model", "modalities", "output_modalities", "instructions")}})}))
            if event.type in ("session.updated", "error"):
                break

asyncio.run(main())
```

`beta_client.py` is the same script with `client.beta.realtime.connect(model=model)` (sends `OpenAI-Beta: realtime=v1`) and `session={"modalities": ["text"], "instructions": "You are a voice agent. Keep answers short."}`

### Before (692a311efb)

#### GA client, gpt-realtime

1. `python ga_client.py http://127.0.0.1:50771 gpt-realtime sk-1234`
2. Output:

```
{"type": "session.created", "session": {"instructions": "Your knowledge cutoff is 2023-10. You are a helpful, witty, and friendly AI. Act like a human, but remember that you aren't a human and that you can't do human things in the real world. Your voice and personality should be warm and engaging, with a lively and playful tone. If interacting in a non-English language, start by using the standard
{"type": "error", "error": {"message": "Unknown parameter: 'session.type'.", "type": "invalid_request_error", "code": "unknown_parameter", "param": "session.type"}}
```

#### Beta-header client, gpt-realtime

1. `python beta_client.py http://127.0.0.1:50771 gpt-realtime sk-1234`
2. Output:

```
{"type": "session.created", "session": {"instructions": "Your knowledge cutoff is 2023-10. You are a helpful, witty, and friendly AI. Act like a human, but remember that you aren't a human and that you can't do human things in the real world. Your voice and personality should be warm and engaging, with a lively and playful tone. If interacting in a non-English language, start by using the standard
{"type": "session.updated", "session": {"instructions": "You are a voice agent. Keep answers short.", "modalities": ["text"], "model": "gpt-realtime"}}
```

#### GA client, gpt-realtime-1.5

1. `python ga_client.py http://127.0.0.1:50771 gpt-realtime-1.5 sk-1234`
2. Output:

```
{"type": "session.created", "session": {"instructions": "Your knowledge cutoff is 2023-10. You are a helpful, witty, and friendly AI. Act like a human, but remember that you aren't a human and that you can't do human things in the real world. Your voice and personality should be warm and engaging, with a lively and playful tone. If interacting in a non-English language, start by using the standard
{"type": "error", "error": {"message": "Unknown parameter: 'session.type'.", "type": "invalid_request_error", "code": "unknown_parameter", "param": "session.type"}}
```

#### Beta-header client, gpt-realtime-1.5

1. `python beta_client.py http://127.0.0.1:50771 gpt-realtime-1.5 sk-1234`
2. Output:

```
{"type": "session.created", "session": {"instructions": "Your knowledge cutoff is 2023-10. You are a helpful, witty, and friendly AI. Act like a human, but remember that you aren't a human and that you can't do human things in the real world. Your voice and personality should be warm and engaging, with a lively and playful tone. If interacting in a non-English language, start by using the standard
{"type": "session.updated", "session": {"instructions": "You are a voice agent. Keep answers short.", "modalities": ["text"], "model": "gpt-realtime-1.5"}}
```

### After (4a3950cf67)

#### GA client, gpt-realtime

1. `python ga_client.py http://127.0.0.1:23472 gpt-realtime sk-1234`
2. Output:

```
{"type": "session.created", "session": {"type": "realtime", "instructions": "Your knowledge cutoff is 2023-10. You are a helpful, witty, and friendly AI. Act like a human, but remember that you aren't a human and that you can't do human things in the real world. Your voice and personality should be warm and engaging, with a lively and playful tone. If interacting in a non-English language, start b
{"type": "session.updated", "session": {"type": "realtime", "instructions": "You are a voice agent. Keep answers short.", "model": "gpt-realtime", "output_modalities": ["audio"]}}
```

#### Beta-header client, gpt-realtime

1. `python beta_client.py http://127.0.0.1:23472 gpt-realtime sk-1234`
2. Output:

```
{"type": "session.created", "session": {"instructions": "Your knowledge cutoff is 2023-10. You are a helpful, witty, and friendly AI. Act like a human, but remember that you aren't a human and that you can't do human things in the real world. Your voice and personality should be warm and engaging, with a lively and playful tone. If interacting in a non-English language, start by using the standard
{"type": "session.updated", "session": {"instructions": "You are a voice agent. Keep answers short.", "modalities": ["text"], "model": "gpt-realtime"}}
```

#### GA client, gpt-realtime-1.5

1. `python ga_client.py http://127.0.0.1:23472 gpt-realtime-1.5 sk-1234`
2. Output:

```
{"type": "session.created", "session": {"type": "realtime", "instructions": "Your knowledge cutoff is 2023-10. You are a helpful, witty, and friendly AI. Act like a human, but remember that you aren't a human and that you can't do human things in the real world. Your voice and personality should be warm and engaging, with a lively and playful tone. If interacting in a non-English language, start b
{"type": "session.updated", "session": {"type": "realtime", "instructions": "You are a voice agent. Keep answers short.", "model": "gpt-realtime-1.5", "output_modalities": ["audio"]}}
```

#### Beta-header client, gpt-realtime-1.5

1. `python beta_client.py http://127.0.0.1:23472 gpt-realtime-1.5 sk-1234`
2. Output:

```
{"type": "session.created", "session": {"instructions": "Your knowledge cutoff is 2023-10. You are a helpful, witty, and friendly AI. Act like a human, but remember that you aren't a human and that you can't do human things in the real world. Your voice and personality should be warm and engaging, with a lively and playful tone. If interacting in a non-English language, start by using the standard
{"type": "session.updated", "session": {"instructions": "You are a voice agent. Keep answers short.", "modalities": ["text"], "model": "gpt-realtime-1.5"}}
```

QA observations:

- Azure's beta endpoint accepts `deployment=gpt-realtime`, so beta clients worked before and after
- Beta-era `gpt-4o-realtime-preview` deployments are deprecated on Azure, not exercised live

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- Azure clients that send a beta-shaped `session.update` without the `OpenAI-Beta` header now get the GA upstream
  - the proxy remaps the session fields to GA and returns GA event names, which such a client may not expect
  - opt back in with `realtime_protocol: beta` in `litellm_params` or `LITELLM_AZURE_REALTIME_PROTOCOL=beta`

### Low

- The Azure realtime health probe still defaults to the beta URL, since it has no client header to read
- Docs for `realtime_protocol` and `LITELLM_AZURE_REALTIME_PROTOCOL` are coming in a separate litellm-docs PR

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
- [x] 4a3950cf67 passes /live-pr-risk
