### PR TITLE
docs(github): add an Affected release section to the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -47,6 +47,10 @@ After: the same request comes back with real token counts, so the dashboard show
 
 <!-- e.g., "Fixes #000" -->
 
+## Affected release
+
+<!-- Only for a fix to a perf, memory, or crash regression: name the released or rc version it regressed in, e.g. "regression in v1.100.0" or "since v1.101.0-rc.1", and add the `backport-stable` label so the fix is cherry-picked onto the rc line before the stable is tagged. Leave the section blank otherwise -->
+
 ## Linear ticket
 
 <!-- if you are an internal contributor, add "Resolves " followed by the Linear ticket e.g., "Resolves LIT-1234" to link the Linear ticket to the GitHub PR. If you don't have one, leave the section blank rather than guessing -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -49,7 +49,7 @@ After: the same request comes back with real token counts, so the dashboard show
 
 ## Affected release
 
-<!-- Only for a fix to a perf, memory, or crash regression: name the released or rc version it regressed in, e.g. "regression in v1.100.0" or "since v1.101.0-rc.1", and add the `backport-stable` label so the fix is cherry-picked onto the rc line before the stable is tagged. Leave the section blank otherwise -->
+<!-- Only for a fix to a regression in a released or rc version (perf, memory, crash, or behavior): name the version it regressed in, e.g. "regression in v1.100.0" or "since v1.101.0-rc.1", and add the `backport-stable` label so the fix is cherry-picked onto the rc line before the stable is tagged. Leave the section blank otherwise -->
 
 ## Linear ticket
 
@@ -156,3 +156,4 @@ Example checklists:
 ## Final Attestation
 
 - [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
+


### PR DESCRIPTION
## TLDR

Problem this solves:

- Regression fixes merged after the rc cut ship late, nothing names the affected release
- PR #39491 missed v1.100.0 that way; the customer ran the broken build four days

How it solves it:

- New `## Affected release` section in the PR template
- Names the released or rc version the fix regressed in
- Points at the `backport-stable` label the stable release gate enforces (project-releaser #234)

## User Flow

Before: a regression fix merges with nothing in its body saying which release it belongs in, and the stable ships without it

1. An engineer opens a PR fixing a memory regression at https://github.com/BerriAI/litellm/compare and fills in the template: TLDR, User Flow, Relevant issues, Linear ticket
2. Nothing in the template asks which release regressed, so the body never says it, and nobody adds a label
3. The PR merges to `litellm_internal_staging` after the rc cut; the stable tagged from the rc line ships without it
4. The fix reaches users in the next stable, about two weeks later

After: the same PR names the release it regressed in and carries the label the release gate checks

1. An engineer opens a PR fixing a memory regression at https://github.com/BerriAI/litellm/compare and fills in the template
2. The new `## Affected release` section asks for the version: they write "regression in v1.100.0" and add the `backport-stable` label
3. The PR merges to `litellm_internal_staging` after the rc cut
4. The stable dispatch in project-releaser fails its backport gate until a backport PR lands on `rc/X.Y.0`, so the stable ships with the fix

## Relevant issues

Companion to BerriAI/project-releaser#234, which adds the gate the label feeds

## Affected release

Not a regression fix

## Linear ticket


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests (template-only change, nothing to test)
- [x] The handful of test files covering my change pass locally (none apply)
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Template-only change: the new section renders in the PR body editor when a PR is opened from this branch. Diff:

```
49a50,53
> ## Affected release
>
> <!-- Only for a fix to a regression in a released or rc version (perf, memory, crash, or behavior): name the version it regressed in, e.g. "regression in v1.100.0" or "since v1.101.0-rc.1", and add the `backport-stable` label so the fix is cherry-picked onto the rc line before the stable is tagged. Leave the section blank otherwise -->
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the PR template; no runtime or CI behavior in this repo.
> 
> **Overview**
> Adds a new **## Affected release** section to `.github/pull_request_template.md`, placed after Relevant issues and before Linear ticket.
> 
> The section instructs authors of **regression fixes** (perf, memory, crash, or behavior in a shipped or rc build) to name the affected version (e.g. `regression in v1.100.0`) and use the **`backport-stable`** label so fixes can be cherry-picked onto the rc line before stable is tagged; otherwise leave it blank.
> 
> Also adds a trailing blank line under **Final Attestation** for formatting consistency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e004634396413e481185347e2ee03790847fb8d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->