### PR TITLE
fix(proxy): let proxy admin keys read raw cloud storage file ids on GET /files/{id}/content

### DIFF
--- a/litellm/litellm_core_utils/cloud_storage_security.py
+++ b/litellm/litellm_core_utils/cloud_storage_security.py
@@ -1,7 +1,7 @@
 import posixpath
 import re
 from collections.abc import Mapping, Sequence
-from itertools import accumulate, pairwise, repeat
+from itertools import accumulate, repeat
 from types import MappingProxyType
 from typing import Any, Final, cast
 from urllib.parse import quote, unquote
@@ -21,21 +21,29 @@ MANAGED_CLOUD_STORAGE_SCHEMES: Final = ("s3://", "gs://")
 _MAPPING_PROXY_TYPE: Final[type] = type(MappingProxyType({}))
 
 
-def _fully_unquoted(value: str) -> str:
-    decodings: Final = accumulate(repeat(value), lambda current, _: unquote(current))
-    return next(current for current, following in pairwise(decodings) if current == following)
+MAX_FILE_ID_DECODE_PASSES: Final = 8
+
+
+def _decodings(value: str) -> tuple[str, ...]:
+    return tuple(accumulate(repeat(value, MAX_FILE_ID_DECODE_PASSES + 2), lambda current, _: unquote(current)))
 
 
 def is_managed_cloud_storage_uri(file_id: str) -> bool:
     """
     True if file_id is a raw cloud-storage object URI (e.g. ``s3://bucket/key``),
-    however many times it was percent-encoded on the way in.
+    up to ``MAX_FILE_ID_DECODE_PASSES`` layers of percent-encoding deep, or an id
+    encoded deeper than that, which no client produces and which is treated as raw
+    rather than decoded any further.
 
     These are internal provider artifacts. On the multi-tenant proxy they must be
     retrieved through their managed unified file id so owner/team access is enforced;
     a raw URI supplied by a caller bypasses that check.
     """
-    return isinstance(file_id, str) and _fully_unquoted(file_id).startswith(MANAGED_CLOUD_STORAGE_SCHEMES)
+    if not isinstance(file_id, str):
+        return False
+    decodings: Final = _decodings(file_id)
+    settled: Final = decodings[-1] == decodings[-2]
+    return decodings[-1].startswith(MANAGED_CLOUD_STORAGE_SCHEMES) or not settled
 
 
 _SAFE_OBJECT_COMPONENT_PATTERN: Final = re.compile(r"[^A-Za-z0-9._-]+")

--- a/litellm/litellm_core_utils/cloud_storage_security.py
+++ b/litellm/litellm_core_utils/cloud_storage_security.py
@@ -1,6 +1,7 @@
 import posixpath
 import re
 from collections.abc import Mapping, Sequence
+from itertools import accumulate, pairwise, repeat
 from types import MappingProxyType
 from typing import Any, Final, cast
 from urllib.parse import quote, unquote
@@ -21,8 +22,8 @@ _MAPPING_PROXY_TYPE: Final[type] = type(MappingProxyType({}))
 
 
 def _fully_unquoted(value: str) -> str:
-    decoded: Final = unquote(value)
-    return value if decoded == value else _fully_unquoted(decoded)
+    decodings: Final = accumulate(repeat(value), lambda current, _: unquote(current))
+    return next(current for current, following in pairwise(decodings) if current == following)
 
 
 def is_managed_cloud_storage_uri(file_id: str) -> bool:

--- a/litellm/litellm_core_utils/cloud_storage_security.py
+++ b/litellm/litellm_core_utils/cloud_storage_security.py
@@ -20,15 +20,21 @@ MANAGED_CLOUD_STORAGE_SCHEMES: Final = ("s3://", "gs://")
 _MAPPING_PROXY_TYPE: Final[type] = type(MappingProxyType({}))
 
 
+def _fully_unquoted(value: str) -> str:
+    decoded: Final = unquote(value)
+    return value if decoded == value else _fully_unquoted(decoded)
+
+
 def is_managed_cloud_storage_uri(file_id: str) -> bool:
     """
-    True if file_id is a raw cloud-storage object URI (e.g. ``s3://bucket/key``).
+    True if file_id is a raw cloud-storage object URI (e.g. ``s3://bucket/key``),
+    however many times it was percent-encoded on the way in.
 
     These are internal provider artifacts. On the multi-tenant proxy they must be
     retrieved through their managed unified file id so owner/team access is enforced;
     a raw URI supplied by a caller bypasses that check.
     """
-    return isinstance(file_id, str) and file_id.startswith(MANAGED_CLOUD_STORAGE_SCHEMES)
+    return isinstance(file_id, str) and _fully_unquoted(file_id).startswith(MANAGED_CLOUD_STORAGE_SCHEMES)
 
 
 _SAFE_OBJECT_COMPONENT_PATTERN: Final = re.compile(r"[^A-Za-z0-9._-]+")

--- a/litellm/litellm_core_utils/cloud_storage_security.py
+++ b/litellm/litellm_core_utils/cloud_storage_security.py
@@ -24,8 +24,12 @@ _MAPPING_PROXY_TYPE: Final[type] = type(MappingProxyType({}))
 MAX_FILE_ID_DECODE_PASSES: Final = 8
 
 
+def _unquote_once(current: str, _: str) -> str:
+    return unquote(current)
+
+
 def _decodings(value: str) -> tuple[str, ...]:
-    return tuple(accumulate(repeat(value, MAX_FILE_ID_DECODE_PASSES + 2), lambda current, _: unquote(current)))
+    return tuple(accumulate(repeat(value, MAX_FILE_ID_DECODE_PASSES + 2), _unquote_once))
 
 
 def is_managed_cloud_storage_uri(file_id: str) -> bool:

--- a/litellm/proxy/openai_files_endpoints/files_endpoints.py
+++ b/litellm/proxy/openai_files_endpoints/files_endpoints.py
@@ -892,14 +892,10 @@ async def get_file_content(
                     }
                 )
         else:
-            # A raw cloud-storage URI (s3://, gs://) supplied here would skip the
-            # managed-file owner/team check that only runs for unified ids, letting
-            # a caller read another tenant's object by its key. Such objects are only
-            # reachable through their managed unified id.
-            if is_managed_cloud_storage_uri(file_id):
+            if is_managed_cloud_storage_uri(file_id) and user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN:
                 raise HTTPException(
-                    status_code=400,
-                    detail="Raw cloud storage file ids cannot be retrieved directly. Use the LiteLLM managed file id returned when the file was created.",
+                    status_code=403,
+                    detail="Raw cloud storage file ids can only be retrieved by a proxy admin key. Use the LiteLLM managed file id returned when the file was created.",
                 )
             # Check for model-based credential routing
             (

--- a/tests/test_litellm/litellm_core_utils/test_cloud_storage_security.py
+++ b/tests/test_litellm/litellm_core_utils/test_cloud_storage_security.py
@@ -28,3 +28,11 @@ def test_is_managed_cloud_storage_uri_ignores_provider_and_unified_ids():
 )
 def test_is_managed_cloud_storage_uri_sees_through_percent_encoding(file_id: str):
     assert is_managed_cloud_storage_uri(file_id)
+
+
+def test_is_managed_cloud_storage_uri_survives_an_id_encoded_thousands_of_times():
+    nested_gs_id = "gs" + "%" + "25" * 5000 + "3A//bucket/x"
+    nested_plain_id = "%" + "25" * 5000
+
+    assert is_managed_cloud_storage_uri(nested_gs_id)
+    assert not is_managed_cloud_storage_uri(nested_plain_id)

--- a/tests/test_litellm/litellm_core_utils/test_cloud_storage_security.py
+++ b/tests/test_litellm/litellm_core_utils/test_cloud_storage_security.py
@@ -1,3 +1,5 @@
+import pytest
+
 from litellm.litellm_core_utils.cloud_storage_security import (
     is_managed_cloud_storage_uri,
 )
@@ -13,3 +15,16 @@ def test_is_managed_cloud_storage_uri_ignores_provider_and_unified_ids():
     assert not is_managed_cloud_storage_uri("file-abc123")
     assert not is_managed_cloud_storage_uri("bGl0ZWxsbV9wcm94eQ==")
     assert not is_managed_cloud_storage_uri("")
+
+
+@pytest.mark.parametrize(
+    "file_id",
+    (
+        "gs%3A%2F%2Fbucket%2Flitellm-vertex-files%2Fprediction-model%2Fpredictions.jsonl",
+        "gs%253A%252F%252Fbucket%252Flitellm-vertex-files%252Fprediction-model%252Fpredictions.jsonl",
+        "s3%3A%2F%2Fbucket%2Flitellm-batch-outputs%2Fx.jsonl.out",
+        "s3%253A%252F%252Fbucket%252Flitellm-batch-outputs%252Fx.jsonl.out",
+    ),
+)
+def test_is_managed_cloud_storage_uri_sees_through_percent_encoding(file_id: str):
+    assert is_managed_cloud_storage_uri(file_id)

--- a/tests/test_litellm/litellm_core_utils/test_cloud_storage_security.py
+++ b/tests/test_litellm/litellm_core_utils/test_cloud_storage_security.py
@@ -1,6 +1,10 @@
+from functools import reduce
+from urllib.parse import quote
+
 import pytest
 
 from litellm.litellm_core_utils.cloud_storage_security import (
+    MAX_FILE_ID_DECODE_PASSES,
     is_managed_cloud_storage_uri,
 )
 
@@ -30,9 +34,19 @@ def test_is_managed_cloud_storage_uri_sees_through_percent_encoding(file_id: str
     assert is_managed_cloud_storage_uri(file_id)
 
 
-def test_is_managed_cloud_storage_uri_survives_an_id_encoded_thousands_of_times():
+def _quoted_times(value: str, times: int) -> str:
+    return reduce(lambda current, _: quote(current, safe=""), range(times), value)
+
+
+def test_is_managed_cloud_storage_uri_decodes_up_to_the_pass_cap():
+    assert is_managed_cloud_storage_uri(_quoted_times("gs://bucket/x", MAX_FILE_ID_DECODE_PASSES))
+    assert not is_managed_cloud_storage_uri(_quoted_times("file-abc/x", MAX_FILE_ID_DECODE_PASSES))
+
+
+def test_is_managed_cloud_storage_uri_fails_closed_on_an_id_encoded_past_the_pass_cap():
     nested_gs_id = "gs" + "%" + "25" * 5000 + "3A//bucket/x"
     nested_plain_id = "%" + "25" * 5000
 
+    assert is_managed_cloud_storage_uri(_quoted_times("file-abc/x", MAX_FILE_ID_DECODE_PASSES + 1))
     assert is_managed_cloud_storage_uri(nested_gs_id)
-    assert not is_managed_cloud_storage_uri(nested_plain_id)
+    assert is_managed_cloud_storage_uri(nested_plain_id)

--- a/tests/test_litellm/proxy/openai_files_endpoint/test_files_endpoint.py
+++ b/tests/test_litellm/proxy/openai_files_endpoint/test_files_endpoint.py
@@ -235,23 +235,96 @@ def test_invalid_purpose(mocker: MockerFixture, monkeypatch, llm_router: Router)
     assert error["param"] == "purpose"
 
 
-def test_get_file_content_rejects_raw_cloud_storage_uri(llm_router: Router):
-    """A raw s3:// file id must be rejected on the proxy content endpoint.
+RAW_GCS_OUTPUT_FILE_ID: Final = (
+    "gs://my-gcs-bucket/litellm-vertex-files/publishers/google/models/gemini-3.8-flash/"
+    "prediction-model-2026-09-10T20:27:18.178864Z/predictions.jsonl"
+)
+RAW_S3_OUTPUT_FILE_ID: Final = "s3://my-bucket/litellm-batch-outputs/job-123/input.jsonl.out"
 
-    Such an id is not a managed unified id, so it would otherwise skip the
-    owner/team access check and let a caller read another tenant's batch output
-    object by its key. Callers must use the managed unified file id.
-    """
+
+def _raw_cloud_file_ids_in_every_encoding() -> tuple[tuple[str, str, str], ...]:
     from urllib.parse import quote
 
-    s3_file_id = "s3://my-bucket/litellm-batch-outputs/job-123/input.jsonl.out"
-    response = client.get(
-        f"/v1/files/{quote(s3_file_id, safe='')}/content?provider=bedrock",
-        headers={"Authorization": "Bearer test-key"},
+    return tuple(
+        (encoded_id, raw_id, provider)
+        for raw_id, provider in ((RAW_GCS_OUTPUT_FILE_ID, "vertex_ai"), (RAW_S3_OUTPUT_FILE_ID, "bedrock"))
+        for encoded_id in (quote(raw_id, safe=""), quote(quote(raw_id, safe=""), safe=""))
     )
 
-    assert response.status_code == 400
-    assert "managed file id" in response.json()["error"]["message"].lower()
+
+def _override_auth(monkeypatch, mocker: MockerFixture, llm_router: Router, user_role) -> ProxyLogging:
+    import litellm.proxy.proxy_server as ps
+
+    proxy_logging_obj = setup_proxy_logging_object(monkeypatch, llm_router)
+    monkeypatch.setattr("litellm.proxy.proxy_server.master_key", None)
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", None)
+    monkeypatch.setattr("litellm.proxy.proxy_server.llm_router", llm_router)
+    proxy_logging_obj.update_request_status = mocker.AsyncMock()
+    proxy_logging_obj.post_call_failure_hook = mocker.AsyncMock()
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        api_key="test-key", user_role=user_role, user_id="test-user"
+    )
+    return proxy_logging_obj
+
+
+@pytest.mark.parametrize(("encoded_id", "raw_id", "provider"), _raw_cloud_file_ids_in_every_encoding())
+def test_get_file_content_answers_403_for_a_raw_cloud_id_from_a_non_admin_key(
+    mocker: MockerFixture, monkeypatch, llm_router: Router, encoded_id: str, raw_id: str, provider: str
+):
+    import litellm.proxy.proxy_server as ps
+    from litellm.proxy._types import LitellmUserRoles
+
+    _override_auth(monkeypatch, mocker, llm_router, LitellmUserRoles.INTERNAL_USER)
+    afile_content = mocker.AsyncMock()
+    monkeypatch.setattr(litellm, "afile_content", afile_content)
+
+    try:
+        response = client.get(
+            f"/v1/files/{encoded_id}/content?provider={provider}",
+            headers={"Authorization": "Bearer test-key"},
+        )
+    finally:
+        app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+    assert response.status_code == 403, response.text
+    assert "proxy admin" in response.json()["error"]["message"]
+    afile_content.assert_not_called()
+
+
+@pytest.mark.parametrize(("encoded_id", "raw_id", "provider"), _raw_cloud_file_ids_in_every_encoding())
+def test_get_file_content_forwards_a_raw_cloud_id_from_a_proxy_admin_key(
+    mocker: MockerFixture, monkeypatch, llm_router: Router, encoded_id: str, raw_id: str, provider: str
+):
+    import litellm.proxy.proxy_server as ps
+    from litellm.proxy._types import LitellmUserRoles
+
+    _override_auth(monkeypatch, mocker, llm_router, LitellmUserRoles.PROXY_ADMIN)
+    captured_kwargs: dict = {}
+
+    async def _mock_afile_content(**kwargs):
+        captured_kwargs.update(kwargs)
+        return HttpxBinaryResponseContent(
+            response=httpx.Response(
+                status_code=200,
+                content=b'{"custom_id": "request-1"}\n',
+                headers={"content-type": "application/octet-stream"},
+            )
+        )
+
+    monkeypatch.setattr(litellm, "afile_content", _mock_afile_content)
+
+    try:
+        response = client.get(
+            f"/v1/files/{encoded_id}/content?provider={provider}",
+            headers={"Authorization": "Bearer test-key"},
+        )
+    finally:
+        app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+    assert response.status_code == 200, response.text
+    assert response.content == b'{"custom_id": "request-1"}\n'
+    assert captured_kwargs["custom_llm_provider"] == provider
+    assert captured_kwargs["file_id"] == raw_id
 
 
 def test_mock_create_audio_file(mocker: MockerFixture, monkeypatch, llm_router: Router):

--- a/tests/test_litellm/proxy/openai_files_endpoint/test_files_endpoint.py
+++ b/tests/test_litellm/proxy/openai_files_endpoint/test_files_endpoint.py
@@ -12,7 +12,7 @@ from pytest_mock import MockerFixture
 import litellm
 from litellm import Router
 from litellm.files.types import FileContentStreamingResult
-from litellm.proxy._types import LiteLLM_UserTableFiltered, UserAPIKeyAuth
+from litellm.proxy._types import LiteLLM_UserTableFiltered, LitellmUserRoles, UserAPIKeyAuth
 from litellm.proxy.hooks import get_proxy_hook
 from litellm.proxy.management_endpoints.internal_user_endpoints import ui_view_users
 from litellm.proxy.openai_files_endpoints.file_content_streaming_handler import (
@@ -252,7 +252,9 @@ def _raw_cloud_file_ids_in_every_encoding() -> tuple[tuple[str, str, str], ...]:
     )
 
 
-def _override_auth(monkeypatch, mocker: MockerFixture, llm_router: Router, user_role) -> ProxyLogging:
+def _override_auth(
+    monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture, llm_router: Router, user_role: LitellmUserRoles
+) -> ProxyLogging:
     import litellm.proxy.proxy_server as ps
 
     proxy_logging_obj = setup_proxy_logging_object(monkeypatch, llm_router)
@@ -269,10 +271,14 @@ def _override_auth(monkeypatch, mocker: MockerFixture, llm_router: Router, user_
 
 @pytest.mark.parametrize(("encoded_id", "raw_id", "provider"), _raw_cloud_file_ids_in_every_encoding())
 def test_get_file_content_answers_403_for_a_raw_cloud_id_from_a_non_admin_key(
-    mocker: MockerFixture, monkeypatch, llm_router: Router, encoded_id: str, raw_id: str, provider: str
+    mocker: MockerFixture,
+    monkeypatch: pytest.MonkeyPatch,
+    llm_router: Router,
+    encoded_id: str,
+    raw_id: str,
+    provider: str,
 ):
     import litellm.proxy.proxy_server as ps
-    from litellm.proxy._types import LitellmUserRoles
 
     _override_auth(monkeypatch, mocker, llm_router, LitellmUserRoles.INTERNAL_USER)
     afile_content = mocker.AsyncMock()
@@ -293,25 +299,26 @@ def test_get_file_content_answers_403_for_a_raw_cloud_id_from_a_non_admin_key(
 
 @pytest.mark.parametrize(("encoded_id", "raw_id", "provider"), _raw_cloud_file_ids_in_every_encoding())
 def test_get_file_content_forwards_a_raw_cloud_id_from_a_proxy_admin_key(
-    mocker: MockerFixture, monkeypatch, llm_router: Router, encoded_id: str, raw_id: str, provider: str
+    mocker: MockerFixture,
+    monkeypatch: pytest.MonkeyPatch,
+    llm_router: Router,
+    encoded_id: str,
+    raw_id: str,
+    provider: str,
 ):
     import litellm.proxy.proxy_server as ps
-    from litellm.proxy._types import LitellmUserRoles
 
     _override_auth(monkeypatch, mocker, llm_router, LitellmUserRoles.PROXY_ADMIN)
-    captured_kwargs: dict = {}
-
-    async def _mock_afile_content(**kwargs):
-        captured_kwargs.update(kwargs)
-        return HttpxBinaryResponseContent(
+    afile_content = mocker.AsyncMock(
+        return_value=HttpxBinaryResponseContent(
             response=httpx.Response(
                 status_code=200,
                 content=b'{"custom_id": "request-1"}\n',
                 headers={"content-type": "application/octet-stream"},
             )
         )
-
-    monkeypatch.setattr(litellm, "afile_content", _mock_afile_content)
+    )
+    monkeypatch.setattr(litellm, "afile_content", afile_content)
 
     try:
         response = client.get(
@@ -323,8 +330,9 @@ def test_get_file_content_forwards_a_raw_cloud_id_from_a_proxy_admin_key(
 
     assert response.status_code == 200, response.text
     assert response.content == b'{"custom_id": "request-1"}\n'
-    assert captured_kwargs["custom_llm_provider"] == provider
-    assert captured_kwargs["file_id"] == raw_id
+    afile_content.assert_called_once()
+    assert afile_content.call_args.kwargs["custom_llm_provider"] == provider
+    assert afile_content.call_args.kwargs["file_id"] == raw_id
 
 
 def test_mock_create_audio_file(mocker: MockerFixture, monkeypatch, llm_router: Router):


### PR DESCRIPTION
## TLDR

Problem this solves:

- Since v1.90.0, `GET /files/{id}/content` refuses raw `gs://` ids with a 400
- That breaks the documented unmanaged Vertex batch flow at its last step
- The guard also missed double-encoded ids, so anyone could still read raw objects

How it solves it:

- Raw `gs://` and `s3://` ids are readable by proxy admin keys only
- Non-admin keys get 403 and keep using their managed `file-...` ids
- The guard decodes up to eight layers of encoding, so double encoding no longer bypasses it
- An id still encoded past eight layers counts as raw rather than being decoded further: unbounded decoding let any key hold a worker for minutes with a 2 MB id, and failing open past the cap would reopen the bypass

## User Flow

Before: a proxy admin running the documented unmanaged Vertex batch flow cannot read the batch results, because the raw `gs://` output id the gateway itself handed back is refused at the last step

1. They send POST https://litellm-domain/v1/files with `purpose=batch`, the jsonl file, and header `custom-llm-provider: vertex_ai`, and get back `id: "gs://my-batch-bucket/litellm-vertex-files/publishers/google/models/gemini-2.5-flash/<uuid>"`
2. They send POST https://litellm-domain/v1/batches with that `input_file_id` and the same header, and get back a numeric batch id such as `4213730575166472192`
3. They poll GET https://litellm-domain/v1/batches/4213730575166472192?provider=vertex_ai until `status` is `completed` and `output_file_id` is `gs://my-batch-bucket/.../prediction-model-<timestamp>/predictions.jsonl`
4. They send GET https://litellm-domain/v1/files/gs%3A%2F%2Fmy-batch-bucket%2F...%2Fpredictions.jsonl/content?provider=vertex_ai with the master key, the URL-encoded id the docs' Python example produces
5. They get 400 `Raw cloud storage file ids cannot be retrieved directly. Use the LiteLLM managed file id returned when the file was created.` and never see their results
6. Meanwhile any virtual key that encodes the id twice (`gs%253A%252F%252F...`, the docs' curl example) gets 200 and the file body, so a non-admin key can still read any object in the bucket by its path

After: the same admin gets the results back at step 4, and only an admin key can

1. They send POST https://litellm-domain/v1/files with `purpose=batch`, the jsonl file, and header `custom-llm-provider: vertex_ai`, and get back `id: "gs://my-batch-bucket/litellm-vertex-files/publishers/google/models/gemini-2.5-flash/<uuid>"`
2. They send POST https://litellm-domain/v1/batches with that `input_file_id` and the same header, and get back a numeric batch id such as `4213730575166472192`
3. They poll GET https://litellm-domain/v1/batches/4213730575166472192?provider=vertex_ai until `status` is `completed` and `output_file_id` is `gs://my-batch-bucket/.../prediction-model-<timestamp>/predictions.jsonl`
4. They send GET https://litellm-domain/v1/files/gs%3A%2F%2Fmy-batch-bucket%2F...%2Fpredictions.jsonl/content?provider=vertex_ai with the master key
5. They get 200 and the jsonl results, one line per request, exactly as before v1.90.0
6. A non-admin virtual key sending the same request, encoded once or twice, gets 403 `Raw cloud storage file ids can only be retrieved by a proxy admin key. Use the LiteLLM managed file id returned when the file was created.`, so it can no longer read other tenants' objects by path and keeps using its managed `file-...` ids

## Relevant issues

## Linear ticket

Resolves LIT-7343

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Setup shared by every run: a proxy booted from the named commit with a Postgres DB, `GCS_BUCKET_NAME`, `VERTEXAI_PROJECT`, `VERTEXAI_LOCATION=us-central1`, and `GOOGLE_APPLICATION_CREDENTIALS` set per the [Vertex batch docs](https://docs.litellm.ai/docs/providers/vertex_batch), and a `gemini-2.5-flash` deployment in the config. `$KEY` is the master key, `$NONADMIN` is a virtual key minted with `POST /key/generate` `{"models": ["gemini-2.5-flash"]}`. The batch was created once per the docs' unmanaged flow (real Vertex spend) and its completed `output_file_id` reused by every leg:

```
$ curl -sS -X POST http://localhost:$PORT/v1/files -H "Authorization: Bearer $KEY" -H "custom-llm-provider: vertex_ai" -F purpose=batch -F file=@batch_requests.jsonl
{"id":"gs://litellm-e2e-vertex-batch/litellm-vertex-files/publishers/google/models/gemini-2.5-flash/ce4fc78f-d726-47f8-901f-34a378b5afa3","bytes":644,"created_at":1789097238,"filename":"litellm-vertex-files/publishers/google/models/gemini-2.5-flash/ce4fc78f-d726-47f8-901f-34a378b5afa3","object":"file","purpose":"batch","status":"uploaded",...}

$ curl -sS -X POST http://localhost:$PORT/v1/batches -H "Authorization: Bearer $KEY" -H "custom-llm-provider: vertex_ai" -H "Content-Type: application/json" -d '{"input_file_id": "gs://litellm-e2e-vertex-batch/litellm-vertex-files/publishers/google/models/gemini-2.5-flash/ce4fc78f-d726-47f8-901f-34a378b5afa3", "endpoint": "/v1/chat/completions", "completion_window": "24h"}'
{"id":"4213730575166472192","object":"batch","status":"validating",...}

$ curl -sS "http://localhost:$PORT/v1/batches/4213730575166472192?provider=vertex_ai" -H "Authorization: Bearer $KEY"
{"id":"4213730575166472192","status":"completed","output_file_id":"gs://litellm-e2e-vertex-batch/litellm-vertex-files/publishers/google/models/gemini-2.5-flash/prediction-model-2026-09-10T20:27:18.178864Z/predictions.jsonl",...}

$ OUT=gs://litellm-e2e-vertex-batch/litellm-vertex-files/publishers/google/models/gemini-2.5-flash/prediction-model-2026-09-10T20:27:18.178864Z/predictions.jsonl
$ ENC=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote_plus(sys.argv[1]))" "$OUT")
$ ENC2=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote_plus(urllib.parse.quote_plus(sys.argv[1])))" "$OUT")
```

Regression table for the single-encoded id (`quote_plus`, what the docs' Python example sends) with the master key, same batch, same request at each commit:

| Commit | What it is | Master key, encoded once | Master key, encoded twice | Non-admin key, encoded once | Non-admin key, encoded twice |
| --- | --- | --- | --- | --- | --- |
| c0352c5aa8c | before #30595 | 200 results | 200 results | 401 | 200 results |
| 4c25b7a13d5 | #30595 (v1.90.0-rc.1) | 400 | 200 results | 401 | 200 results |
| a9cec50960 | merge base | 400 | 200 results | 401 | 200 results |
| a53109335f | this PR | 200 results | 200 results | 401 | 403 |

The non-admin 401 on the once-encoded id is pre-existing at every commit: the raw `/v1/files/gs://.../content` path does not match the key's allowed routes, so auth rejects it before the file endpoint runs. It is not part of this PR

Both legs ran on a proxy booted with two uvicorn workers (`--num_workers 2`), one proxy process per leg, Before at the merge base and After at the tip of this PR

### Before (a9cec50960)

#### Master key, OpenAI Python SDK per the docs (`quote_plus` once, the SDK encodes it again)

1. Command:
   ```
   python3 - <<'PY'
import urllib.parse, openai
client = openai.OpenAI(api_key="$KEY", base_url="http://localhost:$PORT")
encoded_file_id = urllib.parse.quote_plus("$OUT")
content = client.files.content(file_id=encoded_file_id, extra_headers={"custom-llm-provider": "vertex_ai"})
print(f"HTTP 200, {len(content.text.strip().splitlines())} result lines; first line head: {content.text.strip().splitlines()[0][:160]}")
PY
   ```
2. Observed output:
   ```
   HTTP 200, 2 result lines; first line head: {"id": "batch_req_d4f732d0-e5cc-45af-801a-3140f39d6989", "custom_id": "request-1", "response": {"status_code": 200, "request_id": "KhOjaoH8DIjMqMgPta6CsQc", "bo
   ```

#### Master key, curl, id encoded once, `GET /v1/files/{id}/content`

1. Command:
   ```
   curl -sS "http://localhost:$PORT/v1/files/$ENC/content?provider=vertex_ai" -H "Authorization: Bearer $KEY" -w "\nHTTP %{http_code}\n"
   ```
2. Observed output:
   ```
   HTTP 400
{"error":{"message":"Raw cloud storage file ids cannot be retrieved directly. Use the LiteLLM managed file id returned when the file was created.","type":"invalid_request_error","param":null,"code":"400"}}
   ```

#### Master key, curl, id encoded twice (the docs' curl example), `GET /v1/files/{id}/content`

1. Command:
   ```
   curl -sS "http://localhost:$PORT/v1/files/$ENC2/content?provider=vertex_ai" -H "Authorization: Bearer $KEY" -w "\nHTTP %{http_code}\n"
   ```
2. Observed output:
   ```
   HTTP 200
{"id": "batch_req_8857dd77-17eb-45a2-be40-d6cd5836dbf4", "custom_id": "request-1", "response": {"status_code": 200, "request_id": "KhOjaoH8DIjMqMgPta6CsQc", "body": {"id": "KhOjaoH8DIjMqMgPta6CsQc", "created": 1789074204, "model": "gemini-2.5-flash", "object": "chat.completion", "system_fingerprint"
   ```

#### Master key, curl, id encoded once, the `/files/{id}/content` and `/vertex_ai/v1/files/{id}/content` routes

1. Command:
   ```
   curl -sS "http://localhost:$PORT/files/$ENC/content?provider=vertex_ai" -H "Authorization: Bearer $KEY" -w "\nHTTP %{http_code}\n"
   ```
2. Observed output:
   ```
   HTTP 400
{"error":{"message":"Raw cloud storage file ids cannot be retrieved directly. Use the LiteLLM managed file id returned when the file was created.","type":"invalid_request_error","param":null,"code":"4
   ```
3. Command:
   ```
   curl -sS "http://localhost:$PORT/vertex_ai/v1/files/$ENC/content" -H "Authorization: Bearer $KEY" -w "\nHTTP %{http_code}\n"
   ```
4. Observed output:
   ```
   HTTP 400
{"error":{"message":"Raw cloud storage file ids cannot be retrieved directly. Use the LiteLLM managed file id returned when the file was created.","type":"invalid_request_error","param":null,"code":"4
   ```

#### Non-admin key, OpenAI Python SDK per the docs (`quote_plus` once, the SDK encodes it again)

1. Command:
   ```
   python3 - <<'PY'
import urllib.parse, openai
client = openai.OpenAI(api_key="$NONADMIN", base_url="http://localhost:$PORT")
encoded_file_id = urllib.parse.quote_plus("$OUT")
content = client.files.content(file_id=encoded_file_id, extra_headers={"custom-llm-provider": "vertex_ai"})
print(f"HTTP 200, {len(content.text.strip().splitlines())} result lines; first line head: {content.text.strip().splitlines()[0][:160]}")
PY
   ```
2. Observed output:
   ```
   HTTP 200, 2 result lines; first line head: {"id": "batch_req_0356f285-ffcc-492c-aebe-76805845a223", "custom_id": "request-1", "response": {"status_code": 200, "request_id": "KhOjaoH8DIjMqMgPta6CsQc", "bo
   ```

#### Non-admin key, curl, id encoded once, `GET /v1/files/{id}/content`

1. Command:
   ```
   curl -sS "http://localhost:$PORT/v1/files/$ENC/content?provider=vertex_ai" -H "Authorization: Bearer $NONADMIN" -w "\nHTTP %{http_code}\n"
   ```
2. Observed output:
   ```
   HTTP 401
{"error":{"message":"Authentication Error, Only proxy admin can be used to generate, delete, update info for new keys/users/teams. Route=/v1/files/gs://litellm-e2e-vertex-batch/litellm-vertex-files/publishers/google/models/gemini-2.5-flash/prediction-model-2026-09-10T20:27:18.178864Z/predictions.jso
   ```

#### Non-admin key, curl, id encoded twice (the docs' curl example), `GET /v1/files/{id}/content`

1. Command:
   ```
   curl -sS "http://localhost:$PORT/v1/files/$ENC2/content?provider=vertex_ai" -H "Authorization: Bearer $NONADMIN" -w "\nHTTP %{http_code}\n"
   ```
2. Observed output:
   ```
   HTTP 200
{"id": "batch_req_7567577e-f870-4ed3-9598-7b343ebfe31e", "custom_id": "request-1", "response": {"status_code": 200, "request_id": "KhOjaoH8DIjMqMgPta6CsQc", "body": {"id": "KhOjaoH8DIjMqMgPta6CsQc", "created": 1789074205, "model": "gemini-2.5-flash", "object": "chat.completion", "system_fingerprint"
   ```

#### Non-admin key, curl, id encoded once, the `/files/{id}/content` and `/vertex_ai/v1/files/{id}/content` routes

1. Command:
   ```
   curl -sS "http://localhost:$PORT/files/$ENC/content?provider=vertex_ai" -H "Authorization: Bearer $NONADMIN" -w "\nHTTP %{http_code}\n"
   ```
2. Observed output:
   ```
   HTTP 401
{"error":{"message":"Authentication Error, Only proxy admin can be used to generate, delete, update info for new keys/users/teams. Route=/files/gs://litellm-e2e-vertex-batch/litellm-vertex-files/publi
   ```
3. Command:
   ```
   curl -sS "http://localhost:$PORT/vertex_ai/v1/files/$ENC/content" -H "Authorization: Bearer $NONADMIN" -w "\nHTTP %{http_code}\n"
   ```
4. Observed output:
   ```
   HTTP 403
{"error":{"message":"key not allowed to access model. This key can only access models=['gemini-2.5-flash']. Tried to access gemini-2.5-flash/prediction-model-2026-09-10T20","type":"key_model_access_de
   ```

#### Managed `file-...` output id from a model-routed batch (the workaround in the ticket), both keys

1. Command:
   ```
   curl -sS "http://localhost:$PORT/v1/batches/batch_bGl0ZWxsbToxNTE0ODM3MTEyNzgyODQ4MDA7bW9kZWwsZ2VtaW5pLTIuNS1mbGFzaA" -H "Authorization: Bearer $KEY" -w "\nHTTP %{http_code}\n"
   ```
2. Observed output:
   ```
   {"id":"batch_bGl0ZWxsbToxNTE0ODM3MTEyNzgyODQ4MDA7bW9kZWwsZ2VtaW5pLTIuNS1mbGFzaA","completion_window":"24h","created_at":1789097183,"endpoint":"","input_file_id":"file-bGl0ZWxsbTpnczovL2xpdGVsbG0tZTJlLXZlcnRleC1iYXRjaC9saXRlbGxtLXZlcnRleC1maWxlcy9wdWJsaXNoZXJzL2dvb2dsZS9tb2RlbHMvZ2VtaW5pLTIuNS1mbGFzaC9jZTRmYzc4Zi1kNzI2LTQ3ZjgtOTAxZi0zNGEzNzhiNWFmYTM7bW9kZWwsZ2VtaW5pLTIuNS1mbGFzaA","object":"batch",
   ```
3. Command:
   ```
   curl -sS "http://localhost:$PORT/v1/files/file-bGl0ZWxsbTpnczovL2xpdGVsbG0tZTJlLXZlcnRleC1iYXRjaC9saXRlbGxtLXZlcnRleC1maWxlcy9wdWJsaXNoZXJzL2dvb2dsZS9tb2RlbHMvZ2VtaW5pLTIuNS1mbGFzaC9wcmVkaWN0aW9uLW1vZGVsLTIwMjYtMDktMTBUMjA6MjY6MjMuOTM4NDk5Wi9wcmVkaWN0aW9ucy5qc29ubDttb2RlbCxnZW1pbmktMi41LWZsYXNo/content" -H "Authorization: Bearer $KEY" -w "\nHTTP %{http_code}\n"
   ```
4. Observed output:
   ```
   HTTP 200
{"id": "batch_req_cee77663-94e3-4335-a3e3-960a4d45d436", "custom_id": "request-1", "response": {"status_code": 200, "request_id": "zxKjat2aDpGZ88AP7-mv4A8", "body": {"id": "zxKjat2aDpGZ88AP7-mv4A8", "created": 1789074206, "model": "gemini-2.5-flash", "object": "chat.completion", "system_fingerprint"
   ```
5. Command:
   ```
   curl -sS "http://localhost:$PORT/v1/files/file-bGl0ZWxsbTpnczovL2xpdGVsbG0tZTJlLXZlcnRleC1iYXRjaC9saXRlbGxtLXZlcnRleC1maWxlcy9wdWJsaXNoZXJzL2dvb2dsZS9tb2RlbHMvZ2VtaW5pLTIuNS1mbGFzaC9wcmVkaWN0aW9uLW1vZGVsLTIwMjYtMDktMTBUMjA6MjY6MjMuOTM4NDk5Wi9wcmVkaWN0aW9ucy5qc29ubDttb2RlbCxnZW1pbmktMi41LWZsYXNo/content" -H "Authorization: Bearer $NONADMIN" -w "\nHTTP %{http_code}\n"
   ```
6. Observed output:
   ```
   HTTP 200
{"id": "batch_req_552db199-cdd1-4677-b013-b1be8ca3b6d0", "custom_id": "request-1", "response": {"status_code": 200, "request_id": "zxKjat2aDpGZ88AP7-mv4A8", "body": {"id": "zxKjat2aDpGZ88AP7-mv4A8", "created": 1789074207, "model": "gemini-2.5-flash", "object": "chat.completion", "system_fingerprint"
   ```

### After (a53109335f)

#### Master key, OpenAI Python SDK per the docs (`quote_plus` once, the SDK encodes it again)

1. Command:
   ```
   python3 - <<'PY'
import urllib.parse, openai
client = openai.OpenAI(api_key="$KEY", base_url="http://localhost:$PORT")
encoded_file_id = urllib.parse.quote_plus("$OUT")
content = client.files.content(file_id=encoded_file_id, extra_headers={"custom-llm-provider": "vertex_ai"})
print(f"HTTP 200, {len(content.text.strip().splitlines())} result lines; first line head: {content.text.strip().splitlines()[0][:160]}")
PY
   ```
2. Observed output:
   ```
   HTTP 200, 2 result lines; first line head: {"id": "batch_req_35fbf5ef-fff5-4bf6-8196-cddbcb0f2f91", "custom_id": "request-1", "response": {"status_code": 200, "request_id": "KhOjaoH8DIjMqMgPta6CsQc", "bo
   ```

#### Master key, curl, id encoded once, `GET /v1/files/{id}/content`

1. Command:
   ```
   curl -sS "http://localhost:$PORT/v1/files/$ENC/content?provider=vertex_ai" -H "Authorization: Bearer $KEY" -w "\nHTTP %{http_code}\n"
   ```
2. Observed output:
   ```
   HTTP 200
{"id": "batch_req_362d755b-7975-43ee-9ba3-4858e2bf37ef", "custom_id": "request-1", "response": {"status_code": 200, "request_id": "KhOjaoH8DIjMqMgPta6CsQc", "body": {"id": "KhOjaoH8DIjMqMgPta6CsQc", "created": 1789076587, "model": "gemini-2.5-flash", "object": "chat.completion", "system_fingerprint"
   ```

#### Master key, curl, id encoded twice (the docs' curl example), `GET /v1/files/{id}/content`

1. Command:
   ```
   curl -sS "http://localhost:$PORT/v1/files/$ENC2/content?provider=vertex_ai" -H "Authorization: Bearer $KEY" -w "\nHTTP %{http_code}\n"
   ```
2. Observed output:
   ```
   HTTP 200
{"id": "batch_req_3aafc3c1-0173-4772-aa5f-12b955332183", "custom_id": "request-1", "response": {"status_code": 200, "request_id": "KhOjaoH8DIjMqMgPta6CsQc", "body": {"id": "KhOjaoH8DIjMqMgPta6CsQc", "created": 1789076587, "model": "gemini-2.5-flash", "object": "chat.completion", "system_fingerprint"
   ```

#### Master key, curl, id encoded once, the `/files/{id}/content` and `/vertex_ai/v1/files/{id}/content` routes

1. Command:
   ```
   curl -sS "http://localhost:$PORT/files/$ENC/content?provider=vertex_ai" -H "Authorization: Bearer $KEY" -w "\nHTTP %{http_code}\n"
   ```
2. Observed output:
   ```
   HTTP 200
{"id": "batch_req_102346cf-8640-4eba-bf89-6a32a2f88cfd", "custom_id": "request-1", "response": {"status_code": 200, "request_id": "KhOjaoH8DIjMqMgPta6CsQc", "body": {"id": "KhOjaoH8DIjMqMgPta6CsQc", "
   ```
3. Command:
   ```
   curl -sS "http://localhost:$PORT/vertex_ai/v1/files/$ENC/content" -H "Authorization: Bearer $KEY" -w "\nHTTP %{http_code}\n"
   ```
4. Observed output:
   ```
   HTTP 200
{"id": "batch_req_12444c39-ac65-433f-965a-27351fd5cf0f", "custom_id": "request-1", "response": {"status_code": 200, "request_id": "KhOjaoH8DIjMqMgPta6CsQc", "body": {"id": "KhOjaoH8DIjMqMgPta6CsQc", "
   ```

#### Non-admin key, OpenAI Python SDK per the docs (`quote_plus` once, the SDK encodes it again)

1. Command:
   ```
   python3 - <<'PY'
import urllib.parse, openai
client = openai.OpenAI(api_key="$NONADMIN", base_url="http://localhost:$PORT")
encoded_file_id = urllib.parse.quote_plus("$OUT")
content = client.files.content(file_id=encoded_file_id, extra_headers={"custom-llm-provider": "vertex_ai"})
print(f"HTTP 200, {len(content.text.strip().splitlines())} result lines; first line head: {content.text.strip().splitlines()[0][:160]}")
PY
   ```
2. Observed output:
   ```
   HTTP 403: Error code: 403 - {'error': {'message': 'Raw cloud storage file ids can only be retrieved by a proxy admin key. Use the LiteLLM managed file id returned when the file was created.', 'type': 'permission_error', 'param': None, 'code': '403'}}
   ```

#### Non-admin key, curl, id encoded once, `GET /v1/files/{id}/content`

1. Command:
   ```
   curl -sS "http://localhost:$PORT/v1/files/$ENC/content?provider=vertex_ai" -H "Authorization: Bearer $NONADMIN" -w "\nHTTP %{http_code}\n"
   ```
2. Observed output:
   ```
   HTTP 401
{"error":{"message":"Authentication Error, Only proxy admin can be used to generate, delete, update info for new keys/users/teams. Route=/v1/files/gs://litellm-e2e-vertex-batch/litellm-vertex-files/publishers/google/models/gemini-2.5-flash/prediction-model-2026-09-10T20:27:18.178864Z/predictions.jso
   ```

#### Non-admin key, curl, id encoded twice (the docs' curl example), `GET /v1/files/{id}/content`

1. Command:
   ```
   curl -sS "http://localhost:$PORT/v1/files/$ENC2/content?provider=vertex_ai" -H "Authorization: Bearer $NONADMIN" -w "\nHTTP %{http_code}\n"
   ```
2. Observed output:
   ```
   HTTP 403
{"error":{"message":"Raw cloud storage file ids can only be retrieved by a proxy admin key. Use the LiteLLM managed file id returned when the file was created.","type":"permission_error","param":null,"code":"403"}}
   ```

#### Non-admin key, curl, id encoded once, the `/files/{id}/content` and `/vertex_ai/v1/files/{id}/content` routes

1. Command:
   ```
   curl -sS "http://localhost:$PORT/files/$ENC/content?provider=vertex_ai" -H "Authorization: Bearer $NONADMIN" -w "\nHTTP %{http_code}\n"
   ```
2. Observed output:
   ```
   HTTP 401
{"error":{"message":"Authentication Error, Only proxy admin can be used to generate, delete, update info for new keys/users/teams. Route=/files/gs://litellm-e2e-vertex-batch/litellm-vertex-files/publi
   ```
3. Command:
   ```
   curl -sS "http://localhost:$PORT/vertex_ai/v1/files/$ENC/content" -H "Authorization: Bearer $NONADMIN" -w "\nHTTP %{http_code}\n"
   ```
4. Observed output:
   ```
   HTTP 403
{"error":{"message":"key not allowed to access model. This key can only access models=['gemini-2.5-flash']. Tried to access gemini-2.5-flash/prediction-model-2026-09-10T20","type":"key_model_access_de
   ```

#### Managed `file-...` output id from a model-routed batch (the workaround in the ticket), both keys

1. Command:
   ```
   curl -sS "http://localhost:$PORT/v1/batches/batch_bGl0ZWxsbToxNTE0ODM3MTEyNzgyODQ4MDA7bW9kZWwsZ2VtaW5pLTIuNS1mbGFzaA" -H "Authorization: Bearer $KEY" -w "\nHTTP %{http_code}\n"
   ```
2. Observed output:
   ```
   {"id":"batch_bGl0ZWxsbToxNTE0ODM3MTEyNzgyODQ4MDA7bW9kZWwsZ2VtaW5pLTIuNS1mbGFzaA","completion_window":"24h","created_at":1789097183,"endpoint":"","input_file_id":"file-bGl0ZWxsbTpnczovL2xpdGVsbG0tZTJlLXZlcnRleC1iYXRjaC9saXRlbGxtLXZlcnRleC1maWxlcy9wdWJsaXNoZXJzL2dvb2dsZS9tb2RlbHMvZ2VtaW5pLTIuNS1mbGFzaC9jZTRmYzc4Zi1kNzI2LTQ3ZjgtOTAxZi0zNGEzNzhiNWFmYTM7bW9kZWwsZ2VtaW5pLTIuNS1mbGFzaA","object":"batch",
   ```
3. Command:
   ```
   curl -sS "http://localhost:$PORT/v1/files/file-bGl0ZWxsbTpnczovL2xpdGVsbG0tZTJlLXZlcnRleC1iYXRjaC9saXRlbGxtLXZlcnRleC1maWxlcy9wdWJsaXNoZXJzL2dvb2dsZS9tb2RlbHMvZ2VtaW5pLTIuNS1mbGFzaC9wcmVkaWN0aW9uLW1vZGVsLTIwMjYtMDktMTBUMjA6MjY6MjMuOTM4NDk5Wi9wcmVkaWN0aW9ucy5qc29ubDttb2RlbCxnZW1pbmktMi41LWZsYXNo/content" -H "Authorization: Bearer $KEY" -w "\nHTTP %{http_code}\n"
   ```
4. Observed output:
   ```
   HTTP 200
{"id": "batch_req_cd03f8aa-f49f-45e0-82fb-e7e27ccc0e26", "custom_id": "request-1", "response": {"status_code": 200, "request_id": "zxKjat2aDpGZ88AP7-mv4A8", "body": {"id": "zxKjat2aDpGZ88AP7-mv4A8", "created": 1789076589, "model": "gemini-2.5-flash", "object": "chat.completion", "system_fingerprint"
   ```
5. Command:
   ```
   curl -sS "http://localhost:$PORT/v1/files/file-bGl0ZWxsbTpnczovL2xpdGVsbG0tZTJlLXZlcnRleC1iYXRjaC9saXRlbGxtLXZlcnRleC1maWxlcy9wdWJsaXNoZXJzL2dvb2dsZS9tb2RlbHMvZ2VtaW5pLTIuNS1mbGFzaC9wcmVkaWN0aW9uLW1vZGVsLTIwMjYtMDktMTBUMjA6MjY6MjMuOTM4NDk5Wi9wcmVkaWN0aW9ucy5qc29ubDttb2RlbCxnZW1pbmktMi41LWZsYXNo/content" -H "Authorization: Bearer $NONADMIN" -w "\nHTTP %{http_code}\n"
   ```
6. Observed output:
   ```
   HTTP 200
{"id": "batch_req_eed004b5-317b-483b-b23a-21617a8ed403", "custom_id": "request-1", "response": {"status_code": 200, "request_id": "zxKjat2aDpGZ88AP7-mv4A8", "body": {"id": "zxKjat2aDpGZ88AP7-mv4A8", "created": 1789076589, "model": "gemini-2.5-flash", "object": "chat.completion", "system_fingerprint"
   ```

#### Deeply nested ids from both keys (the decode cost Greptile flagged, capped at fe21f9165b)

1. Command:
   ```
   curl -s -w '
HTTP %{http_code} in %{time_total}s' "http://localhost:30680/v1/files/<'%' followed by '25' x 1500, 3001 chars>/content?provider=vertex_ai" -H "Authorization: Bearer <non-admin-key>"
   ```
2. Observed output:
   ```
   {"error":{"message":"Raw cloud storage file ids can only be retrieved by a proxy admin key. Use the LiteLLM managed file id returned when the file was created.","type":"permission_error","param":null,
HTTP 403 in 0.136004s
   ```
3. Command:
   ```
   curl -s -w '
HTTP %{http_code} in %{time_total}s' "http://localhost:30680/v1/files/<'%' followed by '25' x 1500, 3001 chars>/content?provider=vertex_ai" -H "Authorization: Bearer <master-key>"
   ```
4. Observed output:
   ```
   {"error":{"message":"file_id must be a gs:// URI","type":"internal_server_error","param":null,"code":"500"}}
HTTP 500 in 0.094103s
   ```
5. Command:
   ```
   curl -s -w '
HTTP %{http_code} in %{time_total}s' "http://localhost:30680/v1/files/<'%' followed by '25' x 60000, 120001 chars>/content?provider=vertex_ai" -H "Authorization: Bearer <non-admin-key>"
   ```
6. Observed output:
   ```
   Invalid HTTP request received.
HTTP 400 in 0.001929s
   ```
7. Command:
   ```
   curl -s -w '
HTTP %{http_code} in %{time_total}s' "http://localhost:30680/v1/files/<'%' followed by '25' x 60000, 120001 chars>/content?provider=vertex_ai" -H "Authorization: Bearer <master-key>"
   ```
8. Observed output:
   ```
   {"error":{"message":"file_id must be a gs:// URI","type":"internal_server_error","param":null,"code":"500"}}
HTTP 500 in 0.062197s
   ```
9. Command:
   ```
   for i in 1 2 3 4 5; do curl -s -o /dev/null -w 'HTTP %{http_code} in %{time_total}s
' "http://localhost:30680/v1/files/<'%' followed by '25' x 60000, 120001 chars>/content?provider=vertex_ai" -H "Authorization: Bearer <non-admin-key>"; done
   ```
10. Observed output:
   ```
   HTTP 400 in 0.001928s
HTTP 400 in 0.001692s
HTTP 403 in 0.077494s
HTTP 400 in 0.001696s
HTTP 400 in 0.001667s
   ```

Observations from the run, none of them changed by this PR unless stated:

- Non-admin once-encoded id: 401 from route auth, pre-existing
- Non-admin on `/vertex_ai/v1/files`: 403 model access check, pre-existing
- Ids nested past eight encodings count as raw, non-admin 403
- 120 KB nested id: 5.6s at effd233d961, under 0.1s now
- uvicorn drops most 120 KB request lines as invalid (400 in 2 ms), both sides, not this PR
- Non gs id with `provider=vertex_ai`: Vertex handler answers 500, untouched here
- Managed `file-...` ids answer 200 for every key on both sides

## Type

🐛 Bug Fix

## Caveats (if any)

### Severe

- Auth change: raw `gs://` and `s3://` ids are now proxy admin only
  - Non-admin keys that read raw ids double-encoded got 200 before, 403 now
  - Needs a release note callout, since #30595 shipped without one
  - Alternatives weighed: 200 for every key (reopens the cross-tenant read #30595 closed) or a per-key allowlist (new config surface for one flow)

### Medium

- `PROXY_ADMIN_VIEW_ONLY` and internal user keys get 403 too, matching #39836's delete rule
- Docs still show the `quote_plus` flow with no admin key note, BerriAI/litellm-docs#1407 adds it and merges after this PR

### Low

- Bedrock `s3://` ids covered by unit tests only, not driven live

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] effd233d961 passes /live-pr-risk
- [x] fe21f9165b passes /live-pr-risk
- [x] a53109335f passes /live-pr-risk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authorization on a security-sensitive proxy path (raw cloud object access) and alters detection logic that blocks cross-tenant reads; behavior shifts for admin vs non-admin keys.
> 
> **Overview**
> Fixes **GET `/v1/files/{id}/content`** so documented Vertex/Bedrock batch flows work again for **proxy admin** keys while tightening multi-tenant isolation for everyone else.
> 
> **`is_managed_cloud_storage_uri`** no longer checks only a literal `s3://` / `gs://` prefix. It applies up to **8** rounds of percent-decoding and treats ids that still look encoded after that as raw cloud URIs (fail-closed), closing the double-encoding bypass that let non-admin keys read objects by path.
> 
> On the file content endpoint, raw cloud storage ids are **not** universally rejected with 400 anymore. **Non-admin** keys get **403** with a message to use managed `file-...` ids; **`PROXY_ADMIN`** keys can pass raw (including once- or twice-encoded) ids through to `afile_content`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a53109335f520941642a43d528decd03aa28f45c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->