### PR TITLE
feat(wandb): default unmapped W&B models to reasoning-capable

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -57258,6 +57258,14 @@
                 "model_info": {
                     "supports_mid_conversation_system": true
                 }
+            },
+            {
+                "name": "wandb-reasoning-baseline",
+                "pattern": "^wandb/",
+                "description": "Any Weights & Biases Inference model id, anchored to the wandb/ namespace so only that provider's ids match. W&B's serverless catalog is reasoning-first and grows faster than this registry names it, so an id the map has not described yet is treated as reasoning-capable and keeps the caller's reasoning_effort instead of dropping it or raising UnsupportedParamsError. Rules lose to exact entries, so a mapped non-reasoning model such as wandb/meta-llama/Llama-3.1-8B-Instruct is unaffected. Carries no mode and no pricing, so cost stays on the standard unpriced behavior and the deployment does not read as catalog-mapped to the router's reasoning-effort resolver.",
+                "model_info": {
+                    "supports_reasoning": true
+                }
             }
         ]
     },

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -3108,7 +3108,10 @@ def register_model(
                 existing_model = cast(dict, builtin_model_info)
                 model_cost_key = existing_model["key"]
             else:
-                existing_model = {}
+                # An exact entry ends the lookup ladder before the capability rules are
+                # consulted, so seed from them: otherwise registering an unmapped model
+                # shadows the very defaults it would have resolved to unregistered.
+                existing_model = dict(match_capability_generalizations(_key_str) or {})  # mutable-ok: merge target
                 model_cost_key = key
                 builtin_entry = _resolve_builtin_model_cost_entry(key=_key_str, provider=provider)
                 if builtin_entry is not None:

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -57258,6 +57258,14 @@
                 "model_info": {
                     "supports_mid_conversation_system": true
                 }
+            },
+            {
+                "name": "wandb-reasoning-baseline",
+                "pattern": "^wandb/",
+                "description": "Any Weights & Biases Inference model id, anchored to the wandb/ namespace so only that provider's ids match. W&B's serverless catalog is reasoning-first and grows faster than this registry names it, so an id the map has not described yet is treated as reasoning-capable and keeps the caller's reasoning_effort instead of dropping it or raising UnsupportedParamsError. Rules lose to exact entries, so a mapped non-reasoning model such as wandb/meta-llama/Llama-3.1-8B-Instruct is unaffected. Carries no mode and no pricing, so cost stays on the standard unpriced behavior and the deployment does not read as catalog-mapped to the router's reasoning-effort resolver.",
+                "model_info": {
+                    "supports_reasoning": true
+                }
             }
         ]
     },

--- a/tests/test_litellm/litellm_core_utils/test_fallback_generalizations.py
+++ b/tests/test_litellm/litellm_core_utils/test_fallback_generalizations.py
@@ -571,3 +571,63 @@ def test_shipped_mid_conversation_gate_on_bedrock_ids(shipped_cost_map):
     ):
         matched = match_capability_generalizations(unflagged)
         assert matched is None or not matched.get("supports_mid_conversation_system"), unflagged
+
+
+def test_shipped_rules_flag_unmapped_wandb_ids_as_reasoning(shipped_cost_map):
+    """W&B ships reasoning models faster than the registry names them, so an unmapped
+    wandb id resolves as reasoning-capable and its reasoning_effort survives instead of
+    being dropped. The rule carries no mode and no pricing, so cost stays on the standard
+    unpriced behavior and the deployment does not read as catalog-mapped."""
+    model = "wandb/zai-org/GLM-6-Turbo"
+    assert model not in litellm.model_cost
+
+    info = litellm.get_model_info(model, custom_llm_provider="wandb")
+    assert info["litellm_provider"] == "wandb"
+    assert info["supports_reasoning"] is True
+    assert info.get("mode") is None
+    assert not info.get("input_cost_per_token")
+    assert not info.get("output_cost_per_token")
+
+    assert litellm.supports_reasoning(model="zai-org/GLM-6-Turbo", custom_llm_provider="wandb") is True
+
+
+def test_shipped_wandb_rule_loses_to_mapped_non_reasoning_entries(shipped_cost_map):
+    """The whole point of a fallback is that it only fills gaps. A wandb model the map
+    describes as non-reasoning must stay non-reasoning, otherwise the rule silently
+    re-introduces the blanket supports_reasoning it exists to avoid."""
+    for model in (
+        "meta-llama/Llama-3.1-8B-Instruct",
+        "microsoft/Phi-4-mini-instruct",
+        "moonshotai/Kimi-K2-Instruct",
+        "Qwen/Qwen3-Coder-480B-A35B-Instruct",
+    ):
+        assert f"wandb/{model}" in litellm.model_cost, model
+        assert litellm.supports_reasoning(model=model, custom_llm_provider="wandb") is False, model
+
+
+def test_shipped_wandb_rule_is_anchored_to_the_wandb_namespace(shipped_cost_map):
+    """``^wandb/`` is anchored, so it cannot leak onto another provider's ids."""
+    assert match_capability_generalizations("wandb/some-new-model") == {"supports_reasoning": True}
+    for foreign in ("openai/some-new-model", "notwandb/some-new-model", "together_ai/wandb/some-new-model"):
+        matched = match_capability_generalizations(foreign)
+        assert matched is None or not matched.get("supports_reasoning"), foreign
+
+
+def test_shipped_wandb_rule_keeps_reasoning_effort_on_an_unmapped_model(shipped_cost_map):
+    """End to end through the provider config: the gate WandbConfig applies reads the
+    rule, so reasoning_effort is advertised and survives get_optional_params rather than
+    raising UnsupportedParamsError."""
+    model = "zai-org/GLM-6-Turbo"
+    assert f"wandb/{model}" not in litellm.model_cost
+
+    supported = litellm.get_supported_openai_params(model=f"wandb/{model}")
+    assert supported is not None
+    assert "reasoning_effort" in supported
+
+    optional_params = litellm.utils.get_optional_params(
+        model=model,
+        custom_llm_provider="wandb",
+        reasoning_effort="medium",
+        drop_params=False,
+    )
+    assert optional_params["reasoning_effort"] == "medium"

--- a/tests/test_litellm/litellm_core_utils/test_fallback_generalizations.py
+++ b/tests/test_litellm/litellm_core_utils/test_fallback_generalizations.py
@@ -631,3 +631,49 @@ def test_shipped_wandb_rule_keeps_reasoning_effort_on_an_unmapped_model(shipped_
         drop_params=False,
     )
     assert optional_params["reasoning_effort"] == "medium"
+
+
+def test_router_registration_does_not_shadow_shipped_rules(shipped_cost_map):
+    """Regression: Router writes every configured deployment into ``litellm.model_cost``,
+    and an exact entry ends the lookup ladder before the rules are consulted. Registering
+    an unmapped model has to carry the rule defaults forward, or configuring a model on a
+    proxy silently strips the capabilities the same model resolves to off-proxy."""
+    from litellm import Router
+
+    unmapped_wandb = "wandb/zai-org/GLM-6-Turbo"
+    unmapped_claude = "anthropic/claude-opus-9"
+    assert unmapped_wandb not in litellm.model_cost
+    assert unmapped_claude not in litellm.model_cost
+
+    Router(
+        model_list=[
+            {"model_name": name, "litellm_params": {"model": name, "api_key": "fake"}}
+            for name in (unmapped_wandb, unmapped_claude)
+        ]
+    )
+
+    assert unmapped_wandb in litellm.model_cost
+    assert unmapped_claude in litellm.model_cost
+    assert litellm.supports_reasoning(model="zai-org/GLM-6-Turbo", custom_llm_provider="wandb") is True
+    assert litellm.supports_reasoning(model="claude-opus-9", custom_llm_provider="anthropic") is True
+
+
+def test_deployment_model_info_beats_the_seeded_rule_defaults(shipped_cost_map):
+    """Seeding a registration from the rules is a floor, not an override: an explicit
+    model_info on the deployment still wins, so a non-reasoning model can be configured
+    under a reasoning-first namespace."""
+    from litellm import Router
+
+    model = "wandb/some-org/NoThink-1"
+    Router(
+        model_list=[
+            {
+                "model_name": model,
+                "litellm_params": {"model": model, "api_key": "fake"},
+                "model_info": {"supports_reasoning": False},
+            }
+        ]
+    )
+
+    assert litellm.model_cost[model]["supports_reasoning"] is False
+    assert litellm.supports_reasoning(model="some-org/NoThink-1", custom_llm_provider="wandb") is False

--- a/tests/test_litellm/llms/wandb/test_wandb_chat_transformation.py
+++ b/tests/test_litellm/llms/wandb/test_wandb_chat_transformation.py
@@ -249,7 +249,6 @@ class TestWandbConfig:
         "model,explicit_false",
         [
             ("meta-llama/Llama-3.1-8B-Instruct", False),
-            ("unknown-model", False),
             ("openai/gpt-oss-20b", True),
         ],
     )
@@ -290,3 +289,28 @@ class TestWandbConfig:
             supported_params = litellm.get_supported_openai_params(model=f"wandb/{model}")
             assert supported_params is not None
             assert "reasoning_effort" not in supported_params
+
+    @pytest.mark.respx()
+    def test_wandb_completion_keeps_reasoning_effort_for_an_unregistered_model(
+        self, wandb_test_config, wandb_request_mock: respx.Route
+    ):
+        """A wandb id the registry has not named yet resolves through the
+        wandb-reasoning-baseline fallback generalization, so its reasoning_effort reaches
+        the provider instead of raising. W&B adds reasoning models faster than this
+        registry names them, and an exact entry still wins wherever one exists."""
+        model: Final = "zai-org/GLM-6-Turbo"
+        assert f"wandb/{model}" not in litellm.model_cost
+
+        completion(
+            model=f"wandb/{model}",
+            messages=[{"role": "user", "content": "Hello"}],
+            api_key="fake-wandb-key",
+            api_base="https://api.inference.wandb.ai/v1",
+            reasoning_effort="medium",
+            drop_params=False,
+        )
+
+        assert wandb_request_mock.call_count == 1
+        request_body = json.loads(wandb_request_mock.calls[0].request.content)
+        assert request_body["model"] == model
+        assert request_body["reasoning_effort"] == "medium"


### PR DESCRIPTION
## TLDR

Problem this solves:

- W&B ships reasoning models faster than our registry names them
- An unnamed W&B model rejects `reasoning_effort` outright
- Configuring any model on a proxy killed the generalization rules

How it solves it:

- Default any unnamed `wandb/` id to reasoning-capable
- Registration now keeps the rule defaults instead of erasing them
- Registry entries and explicit `model_info` still win

## User Flow

Before: a developer calling a W&B model the gateway has not catalogued yet cannot send reasoning effort at all, even though the model reasons

1. They send POST http://localhost:4000/v1/chat/completions with model `wandb/zai-org/GLM-6-Turbo` and `"reasoning_effort": "medium"`
2. They get back HTTP 400 with `wandb does not support parameters: ['reasoning_effort'], for model=zai-org/GLM-6-Turbo`
3. Nothing reaches W&B, so their only options are dropping the parameter or waiting for the model to be catalogued

After: the same request goes through with the effort intact

1. They send the same POST http://localhost:4000/v1/chat/completions with model `wandb/zai-org/GLM-6-Turbo` and `"reasoning_effort": "medium"`
2. The gateway accepts it and forwards `"reasoning_effort": "medium"` to W&B
3. A W&B model the gateway already catalogues as non-reasoning, such as `wandb/meta-llama/Llama-3.1-8B-Instruct`, still returns the same HTTP 400 as before

## Relevant issues

Follow-up to #39190, which added the capability gate this default feeds

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible
- [ ] I have received a Greptile Confidence Score of at least 4/5 on the latest commit

## Screenshots / Proof of Fix

Same worktree, same config, one proxy at the merge base and then one at this PR's tip. `WANDB_API_KEY` is a placeholder, which is enough to show whether the parameter survives to the provider; see Caveats

Shared config, saved as `wandb_config.yaml`, so both a model the registry describes and one it does not are served by the same proxy:

```yaml
model_list:
  - model_name: wandb/zai-org/GLM-6-Turbo
    litellm_params:
      model: wandb/zai-org/GLM-6-Turbo
      api_base: https://api.inference.wandb.ai/v1
      api_key: os.environ/WANDB_API_KEY
  - model_name: wandb/meta-llama/Llama-3.1-8B-Instruct
    litellm_params:
      model: wandb/meta-llama/Llama-3.1-8B-Instruct
      api_base: https://api.inference.wandb.ai/v1
      api_key: os.environ/WANDB_API_KEY
```

Shared request bodies, saved as `request.json` and `request_mapped.json`, identical apart from the model:

```json
{
  "model": "wandb/zai-org/GLM-6-Turbo",
  "messages": [{ "role": "user", "content": "Reply with only OK." }],
  "reasoning_effort": "medium",
  "max_tokens": 512,
  "num_retries": 0
}
```

Start each proxy with, substituting the port and log name:

```sh
env -u DATABASE_URL PYTHONPATH="$PWD" \
  LITELLM_LOCAL_MODEL_COST_MAP=True LITELLM_DONT_SHOW_FEEDBACK_BOX=true \
  WANDB_API_KEY=<placeholder> \
  python -m litellm.proxy.proxy_cli \
  --host 127.0.0.1 --port <port> \
  --config wandb_config.yaml --detailed_debug 2>&1 | tee <before|after>.log
```

### Before (bc77aa05d2)

#### Model the registry does not describe

1. Send `request.json`

   ```sh
   curl --silent --show-error --max-time 60 \
     -H 'Content-Type: application/json' -H 'Authorization: Bearer sk-1234' \
     --data-binary @request.json --write-out '\nHTTP %{http_code}\n' \
     http://127.0.0.1:4084/v1/chat/completions
   ```

   ```text
   {"error":{"message":"litellm.UnsupportedParamsError: wandb does not support parameters: ['reasoning_effort'], for model=zai-org/GLM-6-Turbo. To drop these, set `litellm.drop_params=True` or for proxy:\n\n`litellm_settings:\n drop_params: true`\n. \n If you want to use these params dynamically send allowed_openai_params=['reasoning_effort'] in your request.. Received Model Group=wandb/zai-org/GLM-6-Turbo\nAvailable Model Group Fallbacks=None","type":"invalid_request_error","param":null,"code":"400"}}
   HTTP 400
   ```

2. Confirm nothing was sent to W&B

   ```sh
   grep -c "api.inference.wandb.ai/v1/chat/completions" before.log
   ```

   ```text
   0
   ```

#### Model the registry describes as non-reasoning

1. Send `request_mapped.json`

   ```sh
   curl --silent --show-error --max-time 60 \
     -H 'Content-Type: application/json' -H 'Authorization: Bearer sk-1234' \
     --data-binary @request_mapped.json --write-out '\nHTTP %{http_code}\n' \
     http://127.0.0.1:4084/v1/chat/completions
   ```

   ```text
   {"error":{"message":"litellm.UnsupportedParamsError: wandb does not support parameters: ['reasoning_effort'], for model=meta-llama/Llama-3.1-8B-Instruct. To drop these, set `litellm.drop_params=True` or for proxy:\n\n`litellm_settings:\n drop_params: true`\n. \n If you want to use these params dynamically send allowed_openai_params=['reasoning_effort'] in your request.. Received Model Group=wandb/meta-llama/Llama-3.1-8B-Instruct\nAvailable Model Group Fallbacks=None","type":"invalid_request_error","param":null,"code":"400"}}
   HTTP 400
   ```

### After (b927d5673e)

#### Model the registry does not describe

1. Send `request.json`

   ```sh
   curl --silent --show-error --max-time 60 \
     -H 'Content-Type: application/json' -H 'Authorization: Bearer sk-1234' \
     --data-binary @request.json --write-out '\nHTTP %{http_code}\n' \
     http://127.0.0.1:4083/v1/chat/completions
   ```

   ```text
   {"error":{"message":"litellm.BadRequestError: WandbException - Invalid Authentication. Received Model Group=wandb/zai-org/GLM-6-Turbo\nAvailable Model Group Fallbacks=None","type":"invalid_request_error","param":null,"code":"401"}}
   HTTP 401
   ```

   The request now reaches W&B and is refused only by the placeholder credential, where before it never left the gateway

2. Confirm the effort survived into the outbound request

   ```sh
   grep -a "reasoning_effort" after.log | grep -a -- "-d '" | tail -1
   ```

   ```text
   -d '{'model': 'zai-org/GLM-6-Turbo', 'messages': [{'role': 'user', 'content': 'Reply with only OK.'}], 'max_tokens': 512, 'reasoning_effort': 'medium', 'extra_body': {}}'
   ```

#### Model the registry describes as non-reasoning

1. Send `request_mapped.json`

   ```sh
   curl --silent --show-error --max-time 60 \
     -H 'Content-Type: application/json' -H 'Authorization: Bearer sk-1234' \
     --data-binary @request_mapped.json --write-out '\nHTTP %{http_code}\n' \
     http://127.0.0.1:4083/v1/chat/completions
   ```

   ```text
   {"error":{"message":"litellm.UnsupportedParamsError: wandb does not support parameters: ['reasoning_effort'], for model=meta-llama/Llama-3.1-8B-Instruct. To drop these, set `litellm.drop_params=True` or for proxy:\n\n`litellm_settings:\n drop_params: true`\n. \n If you want to use these params dynamically send allowed_openai_params=['reasoning_effort'] in your request.. Received Model Group=wandb/meta-llama/Llama-3.1-8B-Instruct\nAvailable Model Group Fallbacks=None","type":"invalid_request_error","param":null,"code":"400"}}
   HTTP 400
   ```

## Type

🆕 New Feature
🐛 Bug Fix

## Caveats (if any)

### Medium

- After run used a placeholder W&B credential, so the provider answered 401
  - The gateway-side change is what this PR makes, and the before/after covers it end to end: rejected before dispatch, then forwarded with the effort intact
  - Whether W&B honors `reasoning_effort` or only `chat_template_kwargs.enable_thinking` is open, and is the same question #39190 left open
- The registration fix changes more than W&B
  - Every capability rule was dead for any model configured on a proxy, the shipped Claude ones included
  - An unmapped Claude id configured on a proxy now picks up the Claude baseline, including its `mode` and token limits, which is already what it resolves to off-proxy

### Low

- Flips one case #39190 asserted, that an uncatalogued W&B model has no reasoning support
  - That param case was removed and replaced with a positive test; both real negatives stay
- A newly released non-reasoning W&B model now defaults to reasoning-capable until it is catalogued
  - Setting `supports_reasoning: false` in the deployment's `model_info` still overrides it

## Final Attestation

- [x] Regression tests cover the changed behavior and identified edge cases

https://claude.ai/code/session_01A6SkwJdfZUmkzfUkrEkqX8
