### PR TITLE
test(proxy): pass the request to get_marketplace in the archive marketplace test

### DIFF
--- a/tests/test_litellm/proxy/anthropic_endpoints/test_claude_code_marketplace.py
+++ b/tests/test_litellm/proxy/anthropic_endpoints/test_claude_code_marketplace.py
@@ -481,7 +481,7 @@ async def test_archive_source_registers_and_is_served_verbatim_in_marketplace():
     assert response.action == "created"
     assert response.plugin.source == _ARCHIVE_SOURCE
 
-    marketplace = json.loads((await get_marketplace()).body)
+    marketplace = json.loads((await get_marketplace(request=MagicMock())).body)
     assert marketplace["plugins"] == [{"name": "s3-skill", "source": _ARCHIVE_SOURCE, "version": "1.0.0"}]
 
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- The base branch's `proxy-endpoints` job is red, so every open PR fails it
- #40496 added a test calling `get_marketplace()` with no arguments
- #40518 landed 27 seconds later and made `request` a required argument

How it solves it:

- The archive marketplace test passes a `MagicMock` request like its sibling tests

## User Flow

No end-user behavior changes: this only edits a unit test so the base branch's CI is green again

## Relevant issues

Unblocks the `proxy-endpoints / Run tests` required check on every open PR, including #40620

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

There is no proxy behavior to drive here, so the proof is the CI job itself

### Before (33fa195949)

1. The base branch's own `proxy-endpoints / Run tests` job at https://github.com/BerriAI/litellm/actions/runs/34533954976 fails
2. Its log ends with `FAILED tests/test_litellm/proxy/anthropic_endpoints/test_claude_code_marketplace.py::test_archive_source_registers_and_is_served_verbatim_in_marketplace - TypeError: get_marketplace() missing 1 required positional argument: 'request'`

### After (1987e6e290)

1. `uv run pytest tests/test_litellm/proxy/anthropic_endpoints/test_claude_code_marketplace.py -q`
2. `33 passed, 1 warning in 1.96s`

## Type

✅ Test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no runtime impact.
> 
> **Overview**
> Fixes a failing unit test in the Claude Code marketplace suite after `get_marketplace` started requiring a FastAPI `request` argument.
> 
> `test_archive_source_registers_and_is_served_verbatim_in_marketplace` now calls `get_marketplace(request=MagicMock())`, matching the other marketplace tests in the same file. **No production or proxy behavior changes**—only CI/test alignment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1987e6e290a8344515f595538e85c3ae00e69a96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->