### PR TITLE
chore(github): disable blank issues so filers must use a template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: Schedule Demo
     url: https://enterprise.litellm.ai/demo


### PR DESCRIPTION
## TLDR

Problem this solves:

- The issue chooser still offers "Open a blank issue"
- Blank issues skip the bug and feature templates, so they arrive without repro or version info

How it solves it:

- Sets `blank_issues_enabled: false` in the issue template config
- GitHub then hides the blank-issue link and filers must pick a template

## User Flow

Before: a user reporting a bug can bypass the templates and file an issue with no structure

1. They open https://github.com/BerriAI/litellm/issues/new/choose
2. Below the Bug Report and Feature Request cards they see "Don't see your issue here? Open a blank issue."
3. They click it and land on https://github.com/BerriAI/litellm/issues/new with an empty title and body
4. They submit a one-line issue that has no version, no config, and no repro steps

After: the same user is steered into a template

1. They open https://github.com/BerriAI/litellm/issues/new/choose
2. The page shows only the Bug Report and Feature Request cards plus the Schedule Demo and Discord links; the blank-issue line is gone
3. They pick Bug Report and land on the form, which requires the version, repro, and expected behavior fields
4. They submit an issue that a maintainer can act on

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

GitHub reads this file from the default branch, so the chooser page only changes after merge. The proof below shows the setting GitHub will read at each commit

### Before (8c6e085796)

1. `curl -s https://raw.githubusercontent.com/BerriAI/litellm/8c6e085796/.github/ISSUE_TEMPLATE/config.yml | head -1`
2. Output: `blank_issues_enabled: true`
3. https://github.com/BerriAI/litellm/issues/new/choose shows "Don't see your issue here? Open a blank issue."

### After (6a9c953aff)

1. `curl -s https://raw.githubusercontent.com/BerriAI/litellm/6a9c953aff/.github/ISSUE_TEMPLATE/config.yml | head -1`
2. Output: `blank_issues_enabled: false`
3. Once merged, https://github.com/BerriAI/litellm/issues/new/choose drops the blank-issue line and only lists the two templates and the two contact links

## Type

🚄 Infrastructure

## Caveats (if any)

### Low

- Maintainers can still open blank issues via the API or `gh issue create`
- Not testable in CI: this is a GitHub-side setting, so the checklist's test items are marked done as not applicable

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
