### PR TITLE
test: fix stale completion response fixtures

### DIFF
--- a/tests/llm_translation/test_azure_o_series.py
+++ b/tests/llm_translation/test_azure_o_series.py
@@ -159,15 +159,23 @@ def test_azure_o_series_routing():
 def test_openai_o_series_max_retries_0(mock_get_openai_client):
     import litellm
 
+    mock_get_openai_client.return_value.chat.completions.with_raw_response.create.return_value.headers = {}
+    mock_get_openai_client.return_value.chat.completions.with_raw_response.create.return_value.parse.return_value = (
+        ModelResponse(choices=[{"message": {"role": "assistant", "content": "Hello"}}])
+    )
     litellm.set_verbose = True
     response = litellm.completion(
         model="azure/o1-preview",
         messages=[{"role": "user", "content": "hi"}],
         max_retries=0,
+        api_key="fake-key",
+        api_base="https://fake-azure.openai.azure.com",
+        api_version="2024-10-21",
     )
 
     mock_get_openai_client.assert_called_once()
     assert mock_get_openai_client.call_args.kwargs["max_retries"] == 0
+    assert response.choices[0].message.content == "Hello"
 
 
 @pytest.mark.asyncio

--- a/tests/llm_translation/test_azure_openai.py
+++ b/tests/llm_translation/test_azure_openai.py
@@ -335,6 +335,10 @@ def test_azure_gpt_4o_with_tool_call_and_response_format(api_version):
     ]
 
     with patch.object(client.chat.completions.with_raw_response, "create") as mock_post:
+        mock_post.return_value.headers = {}
+        mock_post.return_value.parse.return_value = litellm.ModelResponse(
+            choices=[{"message": {"role": "assistant", "content": InvestigationOutput().model_dump_json()}}]
+        )
         response = litellm.completion(
             model="azure/gpt-4.1-mini",
             messages=[
@@ -362,6 +366,7 @@ def test_azure_gpt_4o_with_tool_call_and_response_format(api_version):
             assert "response_format" in mock_post.call_args.kwargs
         else:
             assert "response_format" not in mock_post.call_args.kwargs
+        assert response.choices[0].message.content == InvestigationOutput().model_dump_json()
 
 
 def test_map_openai_params():

--- a/tests/llm_translation/test_openai.py
+++ b/tests/llm_translation/test_openai.py
@@ -292,15 +292,21 @@ class TestOpenAIChatCompletion(BaseLLMChatTest):
 def test_openai_max_retries_0(mock_get_openai_client):
     import litellm
 
+    mock_get_openai_client.return_value.chat.completions.with_raw_response.create.return_value.headers = {}
+    mock_get_openai_client.return_value.chat.completions.with_raw_response.create.return_value.parse.return_value = (
+        ModelResponse(choices=[{"message": {"role": "assistant", "content": "Hello"}}])
+    )
     litellm.set_verbose = True
     response = litellm.completion(
         model="gpt-4o-mini",
         messages=[{"role": "user", "content": "hi"}],
         max_retries=0,
+        api_key="fake-key",
     )
 
     mock_get_openai_client.assert_called_once()
     assert mock_get_openai_client.call_args.kwargs["max_retries"] == 0
+    assert response.choices[0].message.content == "Hello"
 
 
 @patch("litellm.main.openai_chat_completions._get_openai_client")

--- a/tests/local_testing/test_completion.py
+++ b/tests/local_testing/test_completion.py
@@ -3999,10 +3999,14 @@ def test_completion_novita_ai():
     openai_client = OpenAI(api_key="fake-key")
 
     with patch.object(
-        openai_client.chat.completions, "create", new=MagicMock()
+        openai_client.chat.completions.with_raw_response, "create"
     ) as mock_call:
+        mock_call.return_value.headers = {}
+        mock_call.return_value.parse.return_value = litellm.ModelResponse(
+            choices=[{"message": {"role": "assistant", "content": "Hello"}}]
+        )
         try:
-            completion(
+            response = completion(
                 model="novita/meta-llama/llama-3.3-70b-instruct",
                 messages=messages,
                 client=openai_client,
@@ -4010,6 +4014,7 @@ def test_completion_novita_ai():
             )
 
             mock_call.assert_called_once()
+            assert response.choices[0].message.content == "Hello"
 
             # Verify model is passed correctly
             assert (


### PR DESCRIPTION
## TLDR

Problem this solves:

- Four completion tests fail on unconfigured mock responses

How it solves it:

- Return valid completion objects with real choices lists
- Preserve request assertions and check parsed response content
- Use explicit fake credentials in the retry tests

## User Flow

Before: a contributor sees four fixture failures in CircleCI

1. They run the completion and translation checks
2. Four mocked tests fail with missing-choices errors

After: the same checks exercise their intended assertions

1. They run the completion and translation checks
2. The four tests pass with valid response fixtures

## Relevant issues

Test-fixture follow-up to #40294

## Linear ticket

## Validation

The four original cases failed on base ac66754689

The repaired cases and neighboring Novita invalid-key case pass: 5 passed

Repository test-tree lint and the test-quality budget gate pass

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] Changed tests and the neighboring error case pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible
- [x] Current-head Greptile confidence is 5/5

## Screenshots / Proof of Fix

Not applicable to this fixture-only change; validation is recorded above

## Type

Test

## Caveats (if any)

### Low

- No production behavior changes or live-provider validation

## Final Attestation

- [x] Original request assertions remain active with valid response fixtures
