### PR TITLE
fix(reset_budget_job): reset end users by budget link, not by user id

### DIFF
--- a/litellm/proxy/common_utils/reset_budget_job.py
+++ b/litellm/proxy/common_utils/reset_budget_job.py
@@ -224,33 +224,31 @@ def _queue_budget_linked_resets(
 
 
 def _queue_enduser_resets(writes: LinkedSpendResetWrites, cascade: "_BudgetCascade") -> None:
-    """End users are matched by id rather than budget link: rows with no
-    budget_id ride the default budget tier (litellm.max_end_user_budget_id).
-    Zero-before-decrement ordering matters here too (see
-    _queue_budget_linked_resets)."""
-    if not cascade.rollover_caps:
-        if cascade.endusers:
-            writes.queue_spend_zero(
-                where={"user_id": {"in": [row.user_id for row in cascade.endusers]}}
-            )  # mutable-ok: prisma where filter must be a dict
+    """End users reset on the budget link like every other gated table, plus a
+    NULL-budget_id branch: rows created implicitly persist no link and ride the
+    default tier (litellm.max_end_user_budget_id).
+
+    Matching on the link rather than enumerating user ids keeps a statement's
+    bind count proportional to the expiring tiers instead of the customer
+    population, which past ~32,700 dependents exceeds PostgreSQL's per-statement
+    bind ceiling and wedges the cascade permanently (#40564).
+    """
+    _queue_budget_linked_resets(writes, cascade, extra=_SPENT_ROWS_WHERE)
+    default_budget_id: Final = litellm.max_end_user_budget_id
+    if default_budget_id is None or default_budget_id not in cascade.budget_ids:
         return
-    tiered: Final = tuple((row.budget_id or litellm.max_end_user_budget_id, row.user_id) for row in cascade.endusers)
-    for budget_id, cap in cascade.rollover_caps.items():
-        if not (
-            user_ids := [uid for bid, uid in tiered if bid == budget_id]
-        ):  # mutable-ok: prisma "in" filter takes a list
-            continue
+    cap: Final = cascade.rollover_caps.get(default_budget_id)
+    if cap is None:
         writes.queue_spend_zero(
-            where={"user_id": {"in": user_ids}, "spend": {"lte": cap}}
+            where={"budget_id": None, **_SPENT_ROWS_WHERE}
         )  # mutable-ok: prisma where filter must be a dict
-        writes.queue_spend_decrement(
-            where={"user_id": {"in": user_ids}, "spend": {"gt": cap}}, amount=cap
-        )  # mutable-ok: prisma where filter must be a dict
-    plain: Final = [
-        uid for bid, uid in tiered if bid is None or bid not in cascade.rollover_caps
-    ]  # mutable-ok: prisma "in" filter takes a list
-    if plain:
-        writes.queue_spend_zero(where={"user_id": {"in": plain}})  # mutable-ok: prisma where filter must be a dict
+        return
+    writes.queue_spend_zero(
+        where={"budget_id": None, "spend": {"gt": 0, "lte": cap}}
+    )  # mutable-ok: prisma where filter must be a dict
+    writes.queue_spend_decrement(
+        where={"budget_id": None, "spend": {"gt": cap}}, amount=cap
+    )  # mutable-ok: prisma where filter must be a dict
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/litellm_utils_tests/test_proxy_budget_reset.py
+++ b/tests/litellm_utils_tests/test_proxy_budget_reset.py
@@ -401,7 +401,7 @@ async def test_reset_budget_endusers_are_zeroed_with_the_budget_window_advance()
 
     enduser_writes = [c for c in batch_calls if c["table"] == "enduser"]
     assert len(enduser_writes) == 1
-    assert enduser_writes[0]["where"]["user_id"]["in"] == [f"user{i}" for i in range(1, 7)]
+    assert enduser_writes[0]["where"] == {"budget_id": {"in": ["budget1"]}, "spend": {"gt": 0}}
     assert enduser_writes[0]["data"] == {"spend": 0}
 
     budget_writes = [c for c in batch_calls if c["table"] == "budget"]
@@ -602,7 +602,7 @@ async def test_reset_budget_continues_other_categories_on_failure():
     assert len([c for c in batch_calls if c["table"] == "team_membership"]) == 1
     enduser_writes = [c for c in batch_calls if c["table"] == "enduser"]
     assert len(enduser_writes) == 1
-    assert enduser_writes[0]["where"] == {"user_id": {"in": ["user1"]}}
+    assert enduser_writes[0]["where"] == {"budget_id": {"in": ["budget1"]}, "spend": {"gt": 0}}
     assert enduser_writes[0]["data"] == {"spend": 0}
 
     # Check the new batch write path: 2 keys + 1 user (user1 failed) + 2 teams.
@@ -1031,7 +1031,7 @@ async def test_service_logger_endusers_success():
 
     enduser_writes = [c for c in batch_calls if c["table"] == "enduser"]
     assert len(enduser_writes) == 1
-    assert enduser_writes[0]["where"] == {"user_id": {"in": ["user1", "user2"]}}
+    assert enduser_writes[0]["where"] == {"budget_id": {"in": ["budget1"]}, "spend": {"gt": 0}}
 
     proxy_logging_obj.service_logging_obj.async_service_success_hook.assert_called_once()
     (

--- a/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
+++ b/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
@@ -403,7 +403,7 @@ def test_reset_budget_for_enduser(reset_budget_job, mock_prisma_client):
         {
             "table": "enduser",
             "op": "update_many",
-            "where": {"user_id": {"in": ["test-enduser-1"]}},
+            "where": {"budget_id": {"in": ["test-budget-1"]}, "spend": {"gt": 0}},
             "data": {"spend": 0},
         }
     ]
@@ -504,7 +504,7 @@ def test_reset_budget_all(reset_budget_job, mock_prisma_client):
         {
             "table": "enduser",
             "op": "update_many",
-            "where": {"user_id": {"in": ["test-enduser-1"]}},
+            "where": {"budget_id": {"in": ["test-budget-1"]}, "spend": {"gt": 0}},
             "data": {"spend": 0},
         }
     ]
@@ -524,6 +524,7 @@ _LINKED_TABLE_CASES = [
     ("org", {"budget_id": {"in": ["7d-budget-tier"]}, "spend": {"gt": 0}}),
     ("tag", {"budget_id": {"in": ["7d-budget-tier"]}, "spend": {"gt": 0}}),
     ("model_access_group", {"budget_id": {"in": ["7d-budget-tier"]}, "spend": {"gt": 0}}),
+    ("enduser", {"budget_id": {"in": ["7d-budget-tier"]}, "spend": {"gt": 0}}),
 ]
 
 
@@ -551,6 +552,48 @@ def test_budget_table_reset_zeroes_spend_on_every_linked_table(
     assert len(writes) == 1, f"expected exactly 1 {table} write, got {writes}"
     assert writes[0]["where"] == expected_where
     assert writes[0]["data"] == {"spend": 0}
+
+
+_POSTGRES_MAX_BIND_VARIABLES: Final = 32767
+
+
+def _bind_count(where: Dict[str, Any]) -> int:
+    """Bind variables one prisma where-clause compiles to: each scalar is one
+    placeholder and an ``in`` list contributes one per element."""
+    return sum(len(value["in"]) if isinstance(value, dict) and "in" in value else 1 for value in where.values())
+
+
+@pytest.mark.parametrize("population", [3, 40_000], ids=["small", "over-pg-bind-ceiling"])
+def test_enduser_reset_bind_count_does_not_scale_with_population(reset_budget_job, mock_prisma_client, population):
+    """Regression for #40564.
+
+    Enumerating every dependent user id put one bind variable per customer into
+    a single prepared statement. Past PostgreSQL's ceiling the statement could
+    not be parsed at all, so the whole atomic cascade rolled back,
+    budget_reset_at never advanced, and the tier stayed due on every later tick
+    forever. Matching on the budget link keeps the statement the same size no
+    matter how many customers share a tier.
+    """
+    budget = _budget_row(budget_id="shared-tier", budget_duration="1d")
+    mock_prisma_client.data["budget"] = [budget]
+    mock_prisma_client.data["enduser"] = [
+        types.SimpleNamespace(
+            spend=1.0,
+            litellm_budget_table=budget,
+            user_id=f"cust-{index:08d}",
+            budget_id="shared-tier",
+        )
+        for index in range(population)
+    ]
+
+    asyncio.run(reset_budget_job.reset_budget_for_litellm_budget_table())
+
+    writes = _batch_writes(mock_prisma_client, "enduser")
+    assert [_bind_count(write["where"]) for write in writes] == [2], (
+        f"the cascade must not enumerate {population} user ids: past "
+        f"{_POSTGRES_MAX_BIND_VARIABLES} binds PostgreSQL refuses the statement, got {writes[:1]}"
+    )
+    assert _batch_writes(mock_prisma_client, "budget")[0]["data"]["budget_reset_at"] is not None
 
 
 def test_budget_table_reset_writes_nothing_when_no_budget_is_due(reset_budget_job, mock_prisma_client):
@@ -720,14 +763,22 @@ def test_reset_budget_resets_endusers_with_null_budget_id(reset_budget_job, mock
 
     asyncio.run(reset_budget_job.reset_budget_for_litellm_budget_table())
 
-    # Both end users are zeroed by the same committed statement.
-    enduser_writes = _batch_writes(mock_prisma_client, "enduser")
-    assert len(enduser_writes) == 1, f"Expected a single enduser write, got {enduser_writes}"
-    assert set(enduser_writes[0]["where"]["user_id"]["in"]) == {
-        "enduser-explicit",
-        "enduser-implicit",
-    }
-    assert enduser_writes[0]["data"] == {"spend": 0}
+    # Both end users are zeroed: the linked rows on the tier's budget_id, the
+    # implicit ones on the NULL branch that stands in for the default tier.
+    assert _batch_writes(mock_prisma_client, "enduser") == [
+        {
+            "table": "enduser",
+            "op": "update_many",
+            "where": {"budget_id": {"in": [default_budget_id]}, "spend": {"gt": 0}},
+            "data": {"spend": 0},
+        },
+        {
+            "table": "enduser",
+            "op": "update_many",
+            "where": {"budget_id": None, "spend": {"gt": 0}},
+            "data": {"spend": 0},
+        },
+    ]
 
     # Verify find_many was called to fetch NULL-budget-id end users
     find_many_calls = mock_prisma_client.db.litellm_endusertable.find_many_calls
@@ -3043,13 +3094,13 @@ def test_budget_cascade_carries_enduser_overage_when_rollover_enabled(
     assert {
         "table": "enduser",
         "op": "update_many",
-        "where": {"user_id": {"in": ["enduser-roll"]}, "spend": {"gt": 10.0}},
+        "where": {"budget_id": "budget-roll", "spend": {"gt": 10.0}},
         "data": {"spend": {"decrement": 10.0}},
     } in enduser_writes
     assert {
         "table": "enduser",
         "op": "update_many",
-        "where": {"user_id": {"in": ["enduser-roll"]}, "spend": {"lte": 10.0}},
+        "where": {"budget_id": "budget-roll", "spend": {"gt": 0, "lte": 10.0}},
         "data": {"spend": 0},
     } in enduser_writes
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- A shared budget past ~32,700 customers never resets
- Those customers stay blocked forever with no signal
- Every reset attempt rolls the whole thing back

How it solves it:

- Reset customers by their budget link, not by id
- Statement size now tracks budgets, not customer count

## User Flow

Before: an operator with more than 32,700 customers sharing one budget finds that budget never resets, so every customer at the cap is blocked for good

1. The operator puts 33,000 customers on one shared budget capped at $0.01 with a 60 second window
2. Those customers spend past the cap, so `POST http://localhost:4071/v1/chat/completions` with `"user": "cust-00000000"` comes back `429` with `ExceededBudget: End User=cust-00000000 over budget. Spend=5.0, Budget=0.01`
3. The window expires and several minutes pass
4. The customer sends the exact same request and gets the exact same `429`
5. The operator checks the shared budget and finds its reset timestamp still sitting minutes in the past, with every customer's spend untouched
6. The gateway log repeats `too many bind variables in prepared statement, expected maximum of 32767, received 33001` on every tick, and will keep doing so for as long as the population stays that size

After: the same window expiry is uneventful and the customers go back to serving traffic

1. The operator has the same 33,000 customers on the same shared budget
2. Those customers spend past the cap, so the same `POST` comes back with the same `429`
3. The window expires and the next tick resets it
4. The customer sends the exact same request and gets `200` with a real completion
5. The operator checks the shared budget and finds its reset timestamp moved into the future, with every customer's spend back to `0`
6. No bind-variable errors in the log

## Relevant issues

Fixes #40564

## Linear ticket

Resolves LIT-7535

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup, applied identically before each run. One shared budget already due for reset, and 33,000 customers on it, each over the $0.01 cap:

```sql
INSERT INTO "LiteLLM_BudgetTable"
    (budget_id, max_budget, budget_duration, budget_reset_at, created_by, updated_by)
VALUES ('repro-40564-shared', 0.01, '60s', now() - interval '5 minutes', 'repro', 'repro')
ON CONFLICT (budget_id) DO UPDATE SET
    max_budget = EXCLUDED.max_budget,
    budget_duration = EXCLUDED.budget_duration,
    budget_reset_at = EXCLUDED.budget_reset_at;

INSERT INTO "LiteLLM_EndUserTable" (user_id, spend, budget_id, blocked)
SELECT 'cust-' || lpad(i::text, 8, '0'), 5.0, 'repro-40564-shared', false
FROM generate_series(0, 32999) AS series(i)
ON CONFLICT (user_id) DO UPDATE SET spend = EXCLUDED.spend, budget_id = EXCLUDED.budget_id;
```

The gateway runs on port 4071 against a real Postgres and real OpenAI, with the reset job sped up to a 30 second tick so a reviewer does not wait ten minutes per window:

```bash
PROXY_BUDGET_RESCHEDULER_MIN_TIME=30 PROXY_BUDGET_RESCHEDULER_MAX_TIME=35 \
  python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml \
  --port 4071 --detailed_debug --use_v2_migration_resolver 2>&1 | tee run.log
```

### Before (ac66754689)

1. The customer calls the gateway while over the shared cap

```bash
curl -s -w '\nHTTP %{http_code}\n' http://localhost:4071/v1/chat/completions \
  -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"model":"gpt-5.5","user":"cust-00000000","messages":[{"role":"user","content":"say hi in 3 words"}]}'
```

```text
{"error":{"message":"ExceededBudget: End User=cust-00000000 over budget. Spend=5.0, Budget=0.01","type":"budget_exceeded","param":null,"code":"429"}}
HTTP 429
```

2. Wait a little over two minutes, so the expired window gets four reset attempts, then read the log

```bash
grep -c 'too many bind variables' run.log
grep -m1 -o 'too many bind variables in prepared statement, expected maximum of [0-9]*, received [0-9]*' run.log
grep -m1 -o 'Failed to reset the budget table cascade.*next run' run.log
```

```text
4
too many bind variables in prepared statement, expected maximum of 32767, received 33001
Failed to reset the budget table cascade (team member, enduser, org, tag and model access group spend, plus budget_reset_at); nothing was committed and the budgets stay due for the next run
```

3. Check the shared budget and the customers' spend

```bash
psql "$DATABASE_URL" -c "SELECT
  (SELECT count(*) FROM \"LiteLLM_EndUserTable\" WHERE budget_id = 'repro-40564-shared' AND spend > 0) AS customers_still_over_cap,
  (SELECT budget_reset_at FROM \"LiteLLM_BudgetTable\" WHERE budget_id = 'repro-40564-shared') AS budget_reset_at,
  now() AS now;"
```

```text
 customers_still_over_cap |     budget_reset_at     |              now
--------------------------+-------------------------+-------------------------------
                    33000 | 2026-09-11 00:09:47.261 | 2026-09-11 00:17:03.775022+00
```

The reset timestamp is still more than seven minutes in the past and not one customer was cleared.

4. The customer retries the identical call

```text
{"error":{"message":"ExceededBudget: End User=cust-00000000 over budget. Spend=5.0, Budget=0.01","type":"budget_exceeded","param":null,"code":"429"}}
HTTP 429
```

### After (760043b533)

1. The customer calls the gateway while over the shared cap, same command as before

```text
{"error":{"message":"ExceededBudget: End User=cust-00000000 over budget. Spend=5.0, Budget=0.01","type":"budget_exceeded","param":null,"code":"429"}}
HTTP 429
```

2. Wait for the expired window to be reset, then read the log with the same greps

```text
0
```

No bind-variable error, and no cascade failure line.

3. Check the shared budget and the customers' spend with the same query

```text
 customers_still_over_cap |   budget_reset_at   |              now
--------------------------+---------------------+-------------------------------
                        0 | 2026-09-11 00:19:00 | 2026-09-11 00:18:05.934384+00
```

All 33,000 customers are cleared and the reset timestamp has moved into the future.

4. The customer retries the identical call and gets a real completion

```text
{"id":"chatcmpl-EMjFuRSP9xflEVOD1TQnEsIZA0xlk","created":1789085886,"model":"gpt-5.5","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"Hi there, friend","role":"assistant","provider_specific_fields":{"refusal":null},"annotations":[]},"provider_specific_fields":{}}],"usage":{"completion_tokens":30,"prompt_tokens":12,"total_tokens":42,"completion_tokens_details":{"accepted_prediction_tokens":0,"audio_tokens":0,"reasoning_tokens":17,"rejected_prediction_tokens":0},"prompt_tokens_details":{"audio_tokens":0,"cached_tokens":0}},"service_tier":"default"}
HTTP 200
```

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- The reset still reads every customer row on the tier each tick, and still invalidates their cached spend one at a time. That is memory and wall clock at 100k customers, not a failure, and it predates this PR. Worth its own issue to bound the read and batch the invalidation

### Low

- Customers already sitting at zero spend are no longer rewritten on reset, since the filter now skips them the same way the other gated tables already do

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

https://claude.ai/code/session_01Hn5E8Jz1LjGLFyiYxBRcBW
