### PR TITLE
test: respect optional logging payload fields

### DIFF
--- a/tests/local_testing/test_custom_callback_input.py
+++ b/tests/local_testing/test_custom_callback_input.py
@@ -1076,7 +1076,7 @@ def test_standard_logging_payload(model, turn_off_message_logging):
             )
         )
 
-        keys_list = list(StandardLoggingPayload.__annotations__.keys())
+        keys_list = list(StandardLoggingPayload.__required_keys__)
 
         for k in keys_list:
             assert (
@@ -1190,7 +1190,7 @@ def test_standard_logging_payload_audio(turn_off_message_logging, stream):
             )
         )
 
-        keys_list = list(StandardLoggingPayload.__annotations__.keys())
+        keys_list = list(StandardLoggingPayload.__required_keys__)
 
         for k in keys_list:
             assert (

--- a/tests/logging_callback_tests/test_datadog.py
+++ b/tests/logging_callback_tests/test_datadog.py
@@ -270,7 +270,7 @@ async def test_datadog_logging_http_request():
         message = json.loads(body[0]["message"])
         print("logged message", json.dumps(message, indent=4))
 
-        expected_message_fields = StandardLoggingPayload.__annotations__.keys()
+        expected_message_fields = StandardLoggingPayload.__required_keys__
 
         for field in expected_message_fields:
             assert field in message, f"Field '{field}' is missing from the message"


### PR DESCRIPTION
## TLDR

Problem this solves:

- Logging tests incorrectly require optional classifier audit fields

How it solves it:

- Check required fields using the declared logging schema

## User Flow

Before: a contributor sees four logging tests fail on valid requests

1. Run the ordinary, audio, and Datadog logging checks
2. Observe failures requiring classifier input on ordinary requests

After: the same checks accept valid requests and retain required-field validation

1. Run the ordinary, audio, and Datadog logging checks
2. Observe those four cases pass without requiring classifier-only data

## Relevant issues

Follow-up to #40638 for the remaining stale assertions after #40604 added optional classifier audit fields

## Linear ticket

## Pre-Submission checklist

- [x] I have updated meaningful test assertions
- [x] The four affected test cases pass locally
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is isolated to one problem
- [x] Greptile has posted 5/5 confidence for the current head

## Validation

All four failures reproduced on base `2f46425732d1424913c20d56ec9b07f71cd9a3af` and all four pass after the three-line correction, including both audio variants against the live provider. Fifty existing classifier capture, transport, and redaction cases also pass

The assertions now iterate `StandardLoggingPayload.__required_keys__`, so they still require all 41 mandatory fields while respecting optional audit and model-access fields. Existing payload, cost, redaction, and Datadog request assertions remain intact

Test-tree lint, the test-quality gate, and whitespace checks pass

## Screenshots / Proof of Fix

Not applicable to this test-only correction. Production behavior is unchanged; validation is recorded above

## Type

Test

## Caveats

## Final Attestation

- [x] The corrected assertions enforce required logging fields and permit declared optional fields
