### PR TITLE
fix(streaming): preserve provider status for string error codes

### DIFF
--- a/litellm/exceptions.py
+++ b/litellm/exceptions.py
@@ -1086,6 +1086,15 @@ class BlockedPiiEntityError(Exception):
         super().__init__(self.message)
 
 
+def _numeric_status_code(value: object) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
 class MidStreamFallbackError(ServiceUnavailableError):
     def __init__(
         self,
@@ -1100,8 +1109,13 @@ class MidStreamFallbackError(ServiceUnavailableError):
         generated_content: str = "",
         is_pre_first_chunk: bool = False,
     ):
-        original_status: Final = getattr(original_exception, "status_code", None)
-        self.status_code = int(original_status) if original_status is not None else 503
+        original_status: Final = _numeric_status_code(getattr(original_exception, "status_code", None))
+        original_response: Final = getattr(original_exception, "response", None)
+        response_status: Final = _numeric_status_code(
+            getattr(response, "status_code", getattr(original_response, "status_code", None))
+        )
+        status_code: Final = original_status or response_status or 503
+        self.status_code = status_code
         self.message = f"litellm.MidStreamFallbackError: {message}"
         self.model = model
         self.llm_provider = llm_provider
@@ -1143,7 +1157,7 @@ class MidStreamFallbackError(ServiceUnavailableError):
         )
 
         # Restore the propagated status and original response/request objects
-        self.status_code = int(original_status) if original_status is not None else 503
+        self.status_code = status_code
         self.response = _saved_response
         self.request = _saved_request
         self.message = _saved_message

--- a/tests/test_litellm/test_exception_header_preservation.py
+++ b/tests/test_litellm/test_exception_header_preservation.py
@@ -263,7 +263,6 @@ class TestExceptionAttributes:
         assert str(midstream_fallback.response.request.url) == "https://openai.com/v1/"
 
     def test_midstream_fallback_error_accepts_non_numeric_provider_status(self):
-        """Provider error codes can be strings while the response still has an HTTP status."""
         original_response = httpx.Response(
             status_code=400,
             request=httpx.Request("POST", "https://api.groq.com/openai/v1/chat/completions"),

--- a/tests/test_litellm/test_exception_header_preservation.py
+++ b/tests/test_litellm/test_exception_header_preservation.py
@@ -22,6 +22,13 @@ from litellm.exceptions import (
 )
 
 
+class ProviderToolSchemaError(Exception):
+    def __init__(self, response: httpx.Response) -> None:
+        self.status_code = "tool_use_failed"
+        self.response = response
+        super().__init__("tool call validation failed")
+
+
 class TestExceptionHeaderPreservation:
     """Test that exception classes preserve headers from provider responses."""
 
@@ -254,6 +261,25 @@ class TestExceptionAttributes:
         assert midstream_fallback.status_code == 503
         assert midstream_fallback.response.status_code == 503
         assert str(midstream_fallback.response.request.url) == "https://openai.com/v1/"
+
+    def test_midstream_fallback_error_accepts_non_numeric_provider_status(self):
+        """Provider error codes can be strings while the response still has an HTTP status."""
+        original_response = httpx.Response(
+            status_code=400,
+            request=httpx.Request("POST", "https://api.groq.com/openai/v1/chat/completions"),
+        )
+        provider_error = ProviderToolSchemaError(original_response)
+
+        midstream_error = MidStreamFallbackError(
+            message=str(provider_error),
+            model="openai/gpt-oss-120b",
+            llm_provider="groq",
+            original_exception=provider_error,
+        )
+
+        assert midstream_error.status_code == 400
+        assert midstream_error.response.status_code == 400
+        assert "tool call validation failed" in midstream_error.message
 
 
 class TestProxyHeaderExtraction:


### PR DESCRIPTION
## TLDR

Problem this solves:

- Groq uses `tool_use_failed` as a string error code.
- Streaming fallback currently casts it directly to `int`.
- This raises `ValueError` and hides the provider error.

How it solves it:

- Safely parse numeric provider status codes.
- Fall back to the original HTTP response status.
- Preserve the original provider error message.

## User Flow

Before: a Groq streaming tool call fails with an internal conversion error.

1. A client sends a streaming tool call to the Groq-compatible chat completions endpoint.
2. Groq returns an HTTP 400 response with the provider code `tool_use_failed`.
3. LiteLLM attempts to convert that string to an integer.
4. The request surfaces a `ValueError` instead of the provider's tool schema error.

After: the same request exposes the provider's HTTP status and error message.

1. A client sends the same streaming tool call to the Groq-compatible chat completions endpoint.
2. Groq returns an HTTP 400 response with the provider code `tool_use_failed`.
3. LiteLLM ignores the non-numeric provider code for status conversion.
4. The request preserves HTTP status `400` and the original tool validation error.

## Relevant issues

Fixes #40566

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] The handful of test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5

## Screenshots / Proof of Fix

### Before (merge base)

1. A regression test using `status_code = "tool_use_failed"` fails during `MidStreamFallbackError` construction with `ValueError`.

### After (57debdb)

1. The regression test constructs the fallback error successfully.
2. The resulting status code is `400`.
3. The original provider error message is preserved.
4. `git diff --check` and Python compilation checks pass.

Note: the focused pytest command could not run in this environment because the LiteLLM editable build requires the Rust MSVC linker (`link.exe`), which is unavailable.

## Type

🐛 Bug Fix
✅ Test

## Caveats

### Low

- Full pytest verification remains pending in CI.
- No live Groq credentials were used locally.

## Final Attestation

- [x] The tests check the string provider-code regression case.
- [ ] Full CI verification is pending.