### PR TITLE
feat(ui): link the Team, Organization, User and Created By cells on the Virtual Keys page

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/access-groups/_components/AccessGroupsDetailsPage.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/access-groups/_components/AccessGroupsDetailsPage.tsx
@@ -54,7 +54,7 @@ function ResourceBadge({
   fallback,
 }: {
   resource: AccessGroupResource;
-  href: string;
+  href?: string;
   fallback: (id: string) => string;
 }) {
   const badge = (

--- a/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.test.tsx
+++ b/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.test.tsx
@@ -476,11 +476,13 @@ it("should display 'Default Proxy Admin' for user_id when value is 'default_user
 describe("entity links out of the key rows", () => {
   const keyRow = async () => (await screen.findByText("Test Key Alias")).closest("tr") as HTMLElement;
 
-  const enableCreatedByColumn = async (user: ReturnType<typeof userEvent.setup>) => {
+  const enableColumn = async (user: ReturnType<typeof userEvent.setup>, title: string) => {
     await user.click(screen.getByRole("button", { name: "Columns" }));
-    await user.click(await screen.findByText("Created By"));
+    await user.click(await screen.findByText(title));
     await user.keyboard("{Escape}");
   };
+
+  const enableCreatedByColumn = (user: ReturnType<typeof userEvent.setup>) => enableColumn(user, "Created By");
 
   it("points the User and Team cells at their detail pages", async () => {
     renderWithProviders(<VirtualKeysTable />);
@@ -491,6 +493,19 @@ describe("entity links out of the key rows", () => {
       "/ui/users?user=user-1",
     );
     expect(within(row).getByRole("link", { name: "Test Team" })).toHaveAttribute("href", "/ui/teams?team=team-1");
+  });
+
+  it("points the Organization cell at the org's detail page", async () => {
+    mockUseKeys.mockReturnValue(keysResult([{ ...mockKey, org_id: "org-1" }]));
+    const user = userEvent.setup();
+    renderWithProviders(<VirtualKeysTable />);
+    await enableColumn(user, "Organization");
+
+    const row = await keyRow();
+    expect(within(row).getByRole("link", { name: "Test Organization" })).toHaveAttribute(
+      "href",
+      "/ui/organizations?org=org-1",
+    );
   });
 
   it("points the Created By cell at the creator's detail page", async () => {

--- a/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.test.tsx
+++ b/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.test.tsx
@@ -473,6 +473,77 @@ it("should display 'Default Proxy Admin' for user_id when value is 'default_user
   });
 });
 
+describe("entity links out of the key rows", () => {
+  const keyRow = async () => (await screen.findByText("Test Key Alias")).closest("tr") as HTMLElement;
+
+  const enableCreatedByColumn = async (user: ReturnType<typeof userEvent.setup>) => {
+    await user.click(screen.getByRole("button", { name: "Columns" }));
+    await user.click(await screen.findByText("Created By"));
+    await user.keyboard("{Escape}");
+  };
+
+  it("points the User and Team cells at their detail pages", async () => {
+    renderWithProviders(<VirtualKeysTable />);
+
+    const row = await keyRow();
+    expect(within(row).getByRole("link", { name: "user@example.com" })).toHaveAttribute(
+      "href",
+      "/ui/users?user=user-1",
+    );
+    expect(within(row).getByRole("link", { name: "Test Team" })).toHaveAttribute("href", "/ui/teams?team=team-1");
+  });
+
+  it("points the Created By cell at the creator's detail page", async () => {
+    mockUseKeys.mockReturnValue(
+      keysResult([
+        {
+          ...mockKey,
+          created_by: "creator-1",
+          created_by_user: { user_id: "creator-1", user_email: "creator@example.com", user_alias: "The Creator" },
+        },
+      ]),
+    );
+    const user = userEvent.setup();
+    renderWithProviders(<VirtualKeysTable />);
+    await enableCreatedByColumn(user);
+
+    const row = await keyRow();
+    expect(within(row).getByRole("link", { name: "The Creator" })).toHaveAttribute("href", "/ui/users?user=creator-1");
+  });
+
+  it("leaves the default_user_id placeholder unlinked even once it resolves to a named user", async () => {
+    const placeholder = { user_id: "default_user_id", user_email: "admin@example.com", user_alias: "Proxy Admin" };
+    mockUseKeys.mockReturnValue(
+      keysResult([
+        {
+          ...mockKey,
+          user_id: placeholder.user_id,
+          user_email: placeholder.user_email,
+          user: placeholder,
+          created_by: placeholder.user_id,
+          created_by_user: placeholder,
+        },
+      ]),
+    );
+    const user = userEvent.setup();
+    renderWithProviders(<VirtualKeysTable />);
+    await enableCreatedByColumn(user);
+
+    const row = await keyRow();
+    expect(within(row).getAllByText("Proxy Admin")).toHaveLength(2);
+    expect(within(row).queryByRole("link", { name: "Proxy Admin" })).not.toBeInTheDocument();
+  });
+
+  it("leaves the litellm-dashboard session team unlinked", async () => {
+    mockUseKeys.mockReturnValue(keysResult([{ ...mockKey, team_id: "litellm-dashboard" }]));
+    renderWithProviders(<VirtualKeysTable />);
+
+    const row = await keyRow();
+    expect(within(row).getByText("litellm-dashboard")).toBeInTheDocument();
+    expect(within(row).queryByRole("link", { name: "litellm-dashboard" })).not.toBeInTheDocument();
+  });
+});
+
 it("should render table without crashing when models is null", async () => {
   mockUseKeys.mockReturnValue(keysResult([{ ...mockKey, models: null as unknown as string[] }]));
 

--- a/ui/litellm-dashboard/src/components/VirtualKeysPage/keyTableColumns.tsx
+++ b/ui/litellm-dashboard/src/components/VirtualKeysPage/keyTableColumns.tsx
@@ -16,6 +16,8 @@ import {
   StatusBadge,
   type StatusTone,
 } from "@/components/shared/table_cells";
+import { teamDetailHref, userDetailHref } from "@/utils/entityLinks";
+import { DEFAULT_PROXY_ADMIN_USER_ID } from "@/utils/sentinels";
 
 import DefaultProxyAdminTag from "../common_components/DefaultProxyAdminTag";
 import { KeyResponse, Team } from "../key_team_helpers/key_list";
@@ -26,6 +28,8 @@ interface KeyStatus {
   label: string;
   tooltip?: string;
 }
+
+const ENTITY_CELL_TITLE_CLASSES = "font-mono text-xs font-normal";
 
 const SPEND_BUDGET_SORT_FIELDS: DataTableSortField[] = [
   { id: "spend", label: "Spend" },
@@ -74,7 +78,7 @@ const UserPopoverCell = ({
   width: number;
 }) => {
   const displayValue = userAlias || userEmail || userId;
-  const isDefaultAdmin = userId === "default_user_id";
+  const isDefaultAdmin = userId === DEFAULT_PROXY_ADMIN_USER_ID;
 
   const popoverContent = (
     <div className="flex flex-col gap-2 text-xs min-w-[200px] max-w-[300px]">
@@ -95,28 +99,21 @@ const UserPopoverCell = ({
     </div>
   );
 
-  if (isDefaultAdmin && !userAlias && !userEmail) {
-    return (
-      <HoverCard>
-        <HoverCardTrigger render={<span className="cursor-default" />}>
-          <DefaultProxyAdminTag userId={userId} />
-        </HoverCardTrigger>
-        <HoverCardContent align="start">{popoverContent}</HoverCardContent>
-      </HoverCard>
+  const trigger =
+    isDefaultAdmin && !userAlias && !userEmail ? (
+      <DefaultProxyAdminTag userId={userId} />
+    ) : (
+      <IdentityCell
+        title={displayValue || "-"}
+        titleClassName={ENTITY_CELL_TITLE_CLASSES}
+        href={userId ? userDetailHref(userId) : undefined}
+      />
     );
-  }
 
   return (
     <HoverCard>
-      <HoverCardTrigger
-        render={
-          <span
-            className="font-mono text-xs truncate block cursor-default"
-            style={{ maxWidth: width, overflow: "hidden" }}
-          />
-        }
-      >
-        {displayValue || "-"}
+      <HoverCardTrigger render={<span className="block" style={{ maxWidth: width, overflow: "hidden" }} />}>
+        {trigger}
       </HoverCardTrigger>
       <HoverCardContent align="start">{popoverContent}</HoverCardContent>
     </HoverCard>
@@ -201,12 +198,12 @@ export const getKeyTableColumns = ({
       const teamId = info.getValue() as string | null;
       if (!teamId) return "-";
       const team = allTeams.find((t) => t.team_id === teamId);
-      const displayValue = team?.team_alias || teamId;
-      const width = info.cell.column.getSize();
       return (
-        <span className="font-mono text-xs truncate block" style={{ maxWidth: width, overflow: "hidden" }}>
-          {displayValue}
-        </span>
+        <IdentityCell
+          title={team?.team_alias || teamId}
+          titleClassName={ENTITY_CELL_TITLE_CLASSES}
+          href={teamDetailHref(teamId)}
+        />
       );
     },
   },

--- a/ui/litellm-dashboard/src/components/VirtualKeysPage/keyTableColumns.tsx
+++ b/ui/litellm-dashboard/src/components/VirtualKeysPage/keyTableColumns.tsx
@@ -16,7 +16,7 @@ import {
   StatusBadge,
   type StatusTone,
 } from "@/components/shared/table_cells";
-import { teamDetailHref, userDetailHref } from "@/utils/entityLinks";
+import { orgDetailHref, teamDetailHref, userDetailHref } from "@/utils/entityLinks";
 import { DEFAULT_PROXY_ADMIN_USER_ID } from "@/utils/sentinels";
 
 import DefaultProxyAdminTag from "../common_components/DefaultProxyAdminTag";
@@ -218,12 +218,12 @@ export const getKeyTableColumns = ({
       const orgId = info.getValue() as string | null;
       if (!orgId) return "-";
       const org = organizations.find((o) => o.organization_id === orgId);
-      const displayValue = org?.organization_alias || orgId;
-      const width = info.cell.column.getSize();
       return (
-        <span className="font-mono text-xs truncate block" style={{ maxWidth: width, overflow: "hidden" }}>
-          {displayValue}
-        </span>
+        <IdentityCell
+          title={org?.organization_alias || orgId}
+          titleClassName={ENTITY_CELL_TITLE_CLASSES}
+          href={orgDetailHref(orgId)}
+        />
       );
     },
   },

--- a/ui/litellm-dashboard/src/components/common_components/DefaultProxyAdminTag.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/DefaultProxyAdminTag.tsx
@@ -1,13 +1,12 @@
 import { Badge } from "@/components/ui/badge";
-
-const DEFAULT_USER_ID = "default_user_id";
+import { DEFAULT_PROXY_ADMIN_USER_ID } from "@/utils/sentinels";
 
 interface DefaultProxyAdminTagProps {
   userId: string | null | undefined;
 }
 
 export default function DefaultProxyAdminTag({ userId }: DefaultProxyAdminTagProps) {
-  if (userId === DEFAULT_USER_ID) {
+  if (userId === DEFAULT_PROXY_ADMIN_USER_ID) {
     return <Badge variant="secondary">Default Proxy Admin</Badge>;
   }
 

--- a/ui/litellm-dashboard/src/components/common_components/LabeledField.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/LabeledField.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import CopyButton from "@/components/shared/CopyButton";
 import { EntityLink } from "@/components/shared/EntityLink";
 import { cx } from "@/lib/cva.config";
+import { DEFAULT_PROXY_ADMIN_USER_ID } from "@/utils/sentinels";
 import DefaultProxyAdminTag from "./DefaultProxyAdminTag";
 
 interface LabeledFieldProps {
@@ -24,7 +25,7 @@ export default function LabeledField({
   defaultUserIdCheck = false,
 }: LabeledFieldProps) {
   const isEmpty = !value;
-  const isDefaultUser = defaultUserIdCheck && value === "default_user_id";
+  const isDefaultUser = defaultUserIdCheck && value === DEFAULT_PROXY_ADMIN_USER_ID;
   const displayValue = isEmpty ? "-" : value;
   const isCopyable = copyable && !isEmpty && !isDefaultUser;
   const isLink = href != null && !isEmpty && !isDefaultUser;

--- a/ui/litellm-dashboard/src/components/shared/EntityLink.test.tsx
+++ b/ui/litellm-dashboard/src/components/shared/EntityLink.test.tsx
@@ -25,6 +25,12 @@ describe("EntityLink", () => {
     expect(push).toHaveBeenCalledWith("/ui/users?user=u1");
   });
 
+  it("renders the label as plain text when there is no href to point at", () => {
+    render(<EntityLink>default_user_id</EntityLink>);
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    expect(screen.getByText("default_user_id")).toBeInTheDocument();
+  });
+
   it("leaves modified clicks to the browser so new-tab shortcuts keep working", async () => {
     const user = userEvent.setup();
     render(<EntityLink href="/ui/users?user=u1">alice</EntityLink>);

--- a/ui/litellm-dashboard/src/components/shared/EntityLink.tsx
+++ b/ui/litellm-dashboard/src/components/shared/EntityLink.tsx
@@ -19,12 +19,24 @@ export function useEntityLinkClick(href: string): (e: React.MouseEvent) => void 
 }
 
 interface EntityLinkProps {
-  href: string;
+  href?: string;
   className?: string;
   children: React.ReactNode;
 }
 
 export function EntityLink({ href, className, children }: EntityLinkProps) {
+  if (!href) {
+    return <span className={cn("inline-block min-w-0 max-w-full truncate font-semibold", className)}>{children}</span>;
+  }
+
+  return (
+    <LinkedEntity href={href} className={className}>
+      {children}
+    </LinkedEntity>
+  );
+}
+
+function LinkedEntity({ href, className, children }: EntityLinkProps & { href: string }) {
   const handleClick = useEntityLinkClick(href);
 
   return (

--- a/ui/litellm-dashboard/src/utils/entityLinks.test.ts
+++ b/ui/litellm-dashboard/src/utils/entityLinks.test.ts
@@ -2,7 +2,29 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@/components/networking", () => ({ serverRootPath: "" }));
 
-import { modelGroupHref } from "./entityLinks";
+import { modelGroupHref, teamDetailHref, userDetailHref } from "./entityLinks";
+
+describe("userDetailHref", () => {
+  it("targets the users page filtered to the encoded user id", () => {
+    expect(userDetailHref("user-1")).toMatch(/\/users\?user=user-1$/);
+    expect(userDetailHref("a b/c")).toMatch(/\?user=a%20b%2Fc$/);
+  });
+
+  it("returns no href for the proxy admin placeholder, which has no user page", () => {
+    expect(userDetailHref("default_user_id")).toBeUndefined();
+  });
+});
+
+describe("teamDetailHref", () => {
+  it("targets the teams page filtered to the encoded team id", () => {
+    expect(teamDetailHref("team-1")).toMatch(/\/teams\?team=team-1$/);
+    expect(teamDetailHref("a b/c")).toMatch(/\?team=a%20b%2Fc$/);
+  });
+
+  it("returns no href for the Admin UI session team, which has no team page", () => {
+    expect(teamDetailHref("litellm-dashboard")).toBeUndefined();
+  });
+});
 
 describe("modelGroupHref", () => {
   it("targets the models page filtered to the encoded model group", () => {

--- a/ui/litellm-dashboard/src/utils/entityLinks.ts
+++ b/ui/litellm-dashboard/src/utils/entityLinks.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_PROXY_ADMIN_USER_ID, UI_TEAM_ID } from "@/utils/sentinels";
 import { uiHref } from "@/utils/uiHref";
 
 const MODEL_GRANT_SENTINELS: ReadonlySet<string> = new Set([
@@ -6,7 +7,8 @@ const MODEL_GRANT_SENTINELS: ReadonlySet<string> = new Set([
   "no-default-models",
 ]);
 
-export function teamDetailHref(teamId: string): string {
+export function teamDetailHref(teamId: string): string | undefined {
+  if (teamId === UI_TEAM_ID) return undefined;
   return `${uiHref("teams")}?team=${encodeURIComponent(teamId)}`;
 }
 
@@ -14,7 +16,8 @@ export function keyDetailHref(keyToken: string): string {
   return `${uiHref("api-keys")}?key=${encodeURIComponent(keyToken)}`;
 }
 
-export function userDetailHref(userId: string): string {
+export function userDetailHref(userId: string): string | undefined {
+  if (userId === DEFAULT_PROXY_ADMIN_USER_ID) return undefined;
   return `${uiHref("users")}?user=${encodeURIComponent(userId)}`;
 }
 

--- a/ui/litellm-dashboard/src/utils/sentinels.ts
+++ b/ui/litellm-dashboard/src/utils/sentinels.ts
@@ -1,0 +1,3 @@
+export const DEFAULT_PROXY_ADMIN_USER_ID = "default_user_id";
+
+export const UI_TEAM_ID = "litellm-dashboard";


### PR DESCRIPTION
## TLDR

Problem this solves:

- Team, User and Created By on Virtual Keys were dead text
- Getting to the owning team meant copying an id and searching
- Same for the Organization column

How it solves it:

- Those four cells are now links to their detail pages
- Sentinel ids stay plain text instead of linking nowhere
- Reuses the hover chevron the Key column already has

## User Flow

Before: an admin looking at a key cannot get from it to the team, org or user behind it

1. They open https://litellm-domain/ui/api-keys and find a key row
2. The Team cell reads "QA Link Team" and the User cell reads "QA Team Owner", both plain text
3. Clicking either does nothing, so they copy the alias, open https://litellm-domain/ui/teams and search for it by hand
4. Same for Organization and Created By, which they turn on from the Columns menu

After: the same cells take them straight to the team, org and user pages

1. They open https://litellm-domain/ui/api-keys and find the same key row
2. Hovering the Team cell underlines it and shows a chevron
3. Clicking it lands on https://litellm-domain/ui/teams?team=71f5a45c-a295-4fd6-aa2d-6a7d99847e78, the team detail page
4. Organization lands on https://litellm-domain/ui/organizations?org=..., User and Created By on https://litellm-domain/ui/users?user=...
5. A Created By of "Default Proxy Admin" stays plain text, since the built-in admin id has no user page
6. A key owned by the UI's own internal team stays plain text for the same reason

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Ran against a live proxy on port 4021 and the dashboard dev server on 3021, so it does not collide with anything else on this box. Setup was a real org, team and user in Postgres plus two keys on that team: `zzqa-sentinel-key` created by the proxy admin, and `zzqa-linked-key` created by the team owner, so both the sentinel and the real-user case show up in one table.

In both runs the steps are: open the keys page, turn on the Organization and Created By columns from the Columns menu, search `zzqa-`, hover the Created By cell of `zzqa-linked-key`, then read every anchor the row rendered.

### Before (ef1a37795c)

1. Open http://localhost:3021/api-keys, enable Organization and Created By, search `zzqa-`
2. Hover Created By on the `zzqa-linked-key` row. Nothing is underlined, no chevron, and the cell is not clickable

   ![before hover](https://raw.githubusercontent.com/BerriAI/litellm/litellm_key_entity_links_screenshots/keys-before-hover.png)

3. Read the anchors in both rows, there are none:

   ```json
   [[{"column":"Team","text":"QA Link Team","href":null},
     {"column":"Organization","text":"QA Link Org","href":null},
     {"column":"User","text":"QA Team Owner","href":null},
     {"column":"Created By","text":"Default Proxy Admin","href":null}],
    [{"column":"Team","text":"QA Link Team","href":null},
     {"column":"Organization","text":"QA Link Org","href":null},
     {"column":"User","text":"QA Team Owner","href":null},
     {"column":"Created By","text":"QA Team Owner","href":null}]]
   ```

### After (5ea2f96982)

1. Open http://localhost:3021/api-keys, enable Organization and Created By, search `zzqa-`
2. Hover Created By on the `zzqa-linked-key` row. It now carries the chevron the Key column uses

   ![after hover](https://raw.githubusercontent.com/BerriAI/litellm/litellm_key_entity_links_screenshots/keys-after-hover.png)

3. Read the anchors in both rows. Every entity cell has one except the Created By that is the built-in admin:

   ```json
   [[{"column":"Team","text":"QA Link Team","href":"/teams?team=71f5a45c-a295-4fd6-aa2d-6a7d99847e78"},
     {"column":"Organization","text":"QA Link Org","href":"/organizations?org=ba8ed7d4-a8c7-4f09-8940-f1f4bc089f79"},
     {"column":"User","text":"QA Team Owner","href":"/users?user=qa-team-owner"},
     {"column":"Created By","text":"Default Proxy Admin","href":null}],
    [{"column":"Team","text":"QA Link Team","href":"/teams?team=71f5a45c-a295-4fd6-aa2d-6a7d99847e78"},
     {"column":"Organization","text":"QA Link Org","href":"/organizations?org=ba8ed7d4-a8c7-4f09-8940-f1f4bc089f79"},
     {"column":"User","text":"QA Team Owner","href":"/users?user=qa-team-owner"},
     {"column":"Created By","text":"QA Team Owner","href":"/users?user=qa-team-owner"}]]
   ```

4. Click Team, which lands on `http://localhost:3021/teams/?team=71f5a45c-a295-4fd6-aa2d-6a7d99847e78`

   ![team page](https://raw.githubusercontent.com/BerriAI/litellm/litellm_key_entity_links_screenshots/keys-after-land-team.png)

5. Go back and click Organization, which lands on `http://localhost:3021/organizations/?org=ba8ed7d4-a8c7-4f09-8940-f1f4bc089f79`

   ![org page](https://raw.githubusercontent.com/BerriAI/litellm/litellm_key_entity_links_screenshots/keys-after-land-org.png)

6. Go back and click User, which lands on `http://localhost:3021/users/?user=qa-team-owner`. Created By on the same row goes to the same place

   ![user page](https://raw.githubusercontent.com/BerriAI/litellm/litellm_key_entity_links_screenshots/keys-after-land-user.png)

## Type

🆕 New Feature

## Caveats

### Low

- Resting cells look the same, the affordance is on hover
- `default_user_id` and the UI's internal team never link
- Sentinel ids now live in one file, not five

https://claude.ai/code/session_01NfwfQhamRNnSqgXMUjf3h4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard-only navigation and link rendering with tests; no auth or API behavior changes.
> 
> **Overview**
> **Virtual Keys** Team, Organization, User, and Created By cells now navigate to the corresponding filtered detail pages via `IdentityCell` and shared `entityLinks` helpers, reusing the same hover/chevron pattern as other entity links.
> 
> `userDetailHref` and `teamDetailHref` can return **no URL** for sentinel ids (`default_user_id`, `litellm-dashboard`); those ids are centralized in `sentinels.ts` and consumed by `EntityLink`, `LabeledField`, and `DefaultProxyAdminTag` so placeholder users/teams stay **plain text** (including when a display name is present). `EntityLink` and access-group `ResourceBadge` accept an optional `href` to match. Tests cover Virtual Keys row links and href builder edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ea2f9698295a0e53735a9f8a001262de5a7dee6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->