### PR TITLE
feat(ui): link the entity cells on the team detail page's keys table

### DIFF
--- a/ui/litellm-dashboard/src/components/VirtualKeysPage/keyTableColumns.tsx
+++ b/ui/litellm-dashboard/src/components/VirtualKeysPage/keyTableColumns.tsx
@@ -9,17 +9,17 @@ import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/h
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   DateCell,
+  ENTITY_CELL_TITLE_CLASSES,
   IdCell,
   IdentityCell,
   ModelsCell,
   SpendBudgetCell,
   StatusBadge,
+  UserPopoverCell,
   type StatusTone,
 } from "@/components/shared/table_cells";
-import { orgDetailHref, teamDetailHref, userDetailHref } from "@/utils/entityLinks";
-import { DEFAULT_PROXY_ADMIN_USER_ID } from "@/utils/sentinels";
+import { orgDetailHref, teamDetailHref } from "@/utils/entityLinks";
 
-import DefaultProxyAdminTag from "../common_components/DefaultProxyAdminTag";
 import { KeyResponse, Team } from "../key_team_helpers/key_list";
 import { Organization } from "../networking";
 
@@ -28,8 +28,6 @@ interface KeyStatus {
   label: string;
   tooltip?: string;
 }
-
-const ENTITY_CELL_TITLE_CLASSES = "font-mono text-xs font-normal";
 
 const SPEND_BUDGET_SORT_FIELDS: DataTableSortField[] = [
   { id: "spend", label: "Spend" },
@@ -64,60 +62,6 @@ const getKeyStatus = (key: KeyResponse): KeyStatus => {
     label: "Active",
     tooltip: "This key is not blocked and has not expired.",
   };
-};
-
-const UserPopoverCell = ({
-  userAlias,
-  userEmail,
-  userId,
-  width,
-}: {
-  userAlias: string | null;
-  userEmail: string | null;
-  userId: string | null;
-  width: number;
-}) => {
-  const displayValue = userAlias || userEmail || userId;
-  const isDefaultAdmin = userId === DEFAULT_PROXY_ADMIN_USER_ID;
-
-  const popoverContent = (
-    <div className="flex flex-col gap-2 text-xs min-w-[200px] max-w-[300px]">
-      {[
-        { label: "User Alias", value: userAlias },
-        { label: "User Email", value: userEmail },
-        { label: "User ID", value: userId },
-      ].map(({ label, value }) => (
-        <div key={label} className="flex flex-col min-w-0">
-          <span className="text-muted-foreground">{label}</span>
-          {value ? (
-            <IdCell value={value} variant="plain" copyable className="max-w-full" />
-          ) : (
-            <span className="font-mono">-</span>
-          )}
-        </div>
-      ))}
-    </div>
-  );
-
-  const trigger =
-    isDefaultAdmin && !userAlias && !userEmail ? (
-      <DefaultProxyAdminTag userId={userId} />
-    ) : (
-      <IdentityCell
-        title={displayValue || "-"}
-        titleClassName={ENTITY_CELL_TITLE_CLASSES}
-        href={userId ? userDetailHref(userId) : undefined}
-      />
-    );
-
-  return (
-    <HoverCard>
-      <HoverCardTrigger render={<span className="block" style={{ maxWidth: width, overflow: "hidden" }} />}>
-        {trigger}
-      </HoverCardTrigger>
-      <HoverCardContent align="start">{popoverContent}</HoverCardContent>
-    </HoverCard>
-  );
 };
 
 const InfoHeader = ({ label, tooltip }: { label: string; tooltip: string }) => (

--- a/ui/litellm-dashboard/src/components/shared/table_cells/UserPopoverCell.tsx
+++ b/ui/litellm-dashboard/src/components/shared/table_cells/UserPopoverCell.tsx
@@ -31,7 +31,7 @@ export function UserPopoverCell({ userAlias, userEmail, userId, width }: UserPop
         <div key={label} className="flex flex-col min-w-0">
           <span className="text-muted-foreground">{label}</span>
           {value ? (
-            <IdCell value={value} variant="plain" copyable className="max-w-full" />
+            <IdCell value={value} variant="plain" copyable copyLabel={`Copy ${label}`} className="max-w-full" />
           ) : (
             <span className="font-mono">-</span>
           )}

--- a/ui/litellm-dashboard/src/components/shared/table_cells/UserPopoverCell.tsx
+++ b/ui/litellm-dashboard/src/components/shared/table_cells/UserPopoverCell.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import DefaultProxyAdminTag from "@/components/common_components/DefaultProxyAdminTag";
+import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card";
+import { userDetailHref } from "@/utils/entityLinks";
+import { DEFAULT_PROXY_ADMIN_USER_ID } from "@/utils/sentinels";
+
+import { IdCell } from "./id_cell";
+import { IdentityCell } from "./identity_cell";
+
+export const ENTITY_CELL_TITLE_CLASSES = "font-mono text-xs font-normal";
+
+interface UserPopoverCellProps {
+  userAlias: string | null;
+  userEmail: string | null;
+  userId: string | null;
+  width: number;
+}
+
+export function UserPopoverCell({ userAlias, userEmail, userId, width }: UserPopoverCellProps) {
+  const displayValue = userAlias || userEmail || userId;
+  const isDefaultAdmin = userId === DEFAULT_PROXY_ADMIN_USER_ID;
+
+  const popoverContent = (
+    <div className="flex flex-col gap-2 text-xs min-w-[200px] max-w-[300px]">
+      {[
+        { label: "User Alias", value: userAlias },
+        { label: "User Email", value: userEmail },
+        { label: "User ID", value: userId },
+      ].map(({ label, value }) => (
+        <div key={label} className="flex flex-col min-w-0">
+          <span className="text-muted-foreground">{label}</span>
+          {value ? (
+            <IdCell value={value} variant="plain" copyable className="max-w-full" />
+          ) : (
+            <span className="font-mono">-</span>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+
+  const trigger =
+    isDefaultAdmin && !userAlias && !userEmail ? (
+      <DefaultProxyAdminTag userId={userId} />
+    ) : (
+      <IdentityCell
+        title={displayValue || "-"}
+        titleClassName={ENTITY_CELL_TITLE_CLASSES}
+        href={userId ? userDetailHref(userId) : undefined}
+      />
+    );
+
+  return (
+    <HoverCard>
+      <HoverCardTrigger render={<span className="block" style={{ maxWidth: width, overflow: "hidden" }} />}>
+        {trigger}
+      </HoverCardTrigger>
+      <HoverCardContent align="start">{popoverContent}</HoverCardContent>
+    </HoverCard>
+  );
+}

--- a/ui/litellm-dashboard/src/components/shared/table_cells/id_cell.test.tsx
+++ b/ui/litellm-dashboard/src/components/shared/table_cells/id_cell.test.tsx
@@ -71,6 +71,14 @@ describe("IdCell", () => {
     expect(rowClick).not.toHaveBeenCalled();
   });
 
+  it("names the copy button after the field it copies", async () => {
+    const user = userEvent.setup();
+    render(<IdCell value="alice@example.com" copyable copyLabel="Copy User Email" />);
+    expect(screen.queryByRole("button", { name: "Copy ID" })).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Copy User Email" }));
+    expect(copyToClipboardMock).toHaveBeenCalledWith("alice@example.com");
+  });
+
   it("passes dataTestId through to the id element", () => {
     render(<IdCell value="k-1" dataTestId="key-id-cell" />);
     expect(screen.getByTestId("key-id-cell")).toHaveTextContent("k-1");

--- a/ui/litellm-dashboard/src/components/shared/table_cells/id_cell.tsx
+++ b/ui/litellm-dashboard/src/components/shared/table_cells/id_cell.tsx
@@ -15,6 +15,7 @@ interface IdCellProps {
   variant?: IdCellVariant;
   onClick?: (value: string) => void;
   copyable?: boolean;
+  copyLabel?: string;
   truncate?: boolean;
   fallback?: string;
   tooltip?: React.ReactNode;
@@ -39,6 +40,7 @@ export function IdCell({
   variant = "pill",
   onClick,
   copyable = false,
+  copyLabel = "Copy ID",
   truncate = true,
   fallback = "-",
   tooltip,
@@ -80,7 +82,7 @@ export function IdCell({
       {withTooltip}
       <button
         type="button"
-        aria-label="Copy ID"
+        aria-label={copyLabel}
         className="shrink-0 cursor-pointer text-muted-foreground hover:text-foreground"
         onClick={(event) => {
           event.stopPropagation();

--- a/ui/litellm-dashboard/src/components/shared/table_cells/index.ts
+++ b/ui/litellm-dashboard/src/components/shared/table_cells/index.ts
@@ -13,3 +13,4 @@ export { ModelsCell } from "./models_cell";
 export { MoneyCell } from "./money_cell";
 export { SpendBudgetCell } from "./spend_budget_cell";
 export { StatusBadge, type StatusTone } from "./status_badge";
+export { UserPopoverCell, ENTITY_CELL_TITLE_CLASSES } from "./UserPopoverCell";

--- a/ui/litellm-dashboard/src/components/team/TeamVirtualKeysTable.test.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamVirtualKeysTable.test.tsx
@@ -10,6 +10,8 @@ vi.mock("@/app/(dashboard)/hooks/keys/useKeys", () => ({
   useKeys: vi.fn(),
 }));
 
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }));
+
 vi.mock("../key_team_helpers/fetch_available_models_team_key", () => ({
   getModelDisplayName: vi.fn((model: string) => model),
 }));
@@ -382,6 +384,66 @@ describe("TeamVirtualKeysTable", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Key Info View")).toBeInTheDocument();
+    });
+  });
+
+  describe("entity links out of the key rows", () => {
+    const renderRow = async (key: KeyResponse, organization: Organization | null = null) => {
+      mockUseKeys.mockReturnValue({
+        data: { keys: [key], total_count: 1, current_page: 1, total_pages: 1 } as KeysResponse,
+        isPending: false,
+        isFetching: false,
+        refetch: vi.fn(),
+      } as any);
+      renderWithProviders(<TeamVirtualKeysTable {...defaultProps} organization={organization} />);
+      return (await screen.findByText(key.key_alias as string)).closest("tr") as HTMLElement;
+    };
+
+    it("points the Organization ID cell at the org's detail page", async () => {
+      const row = await renderRow(createMockKey({ organization_id: null }), mockOrganization);
+      expect(within(row).getByRole("link", { name: "org-123" })).toHaveAttribute(
+        "href",
+        "/ui/organizations?org=org-123",
+      );
+    });
+
+    it("points the User Email and User ID cells at the owning user's detail page", async () => {
+      const row = await renderRow(
+        createMockKey({ user_id: "user-1", user: { user_id: "user-1", user_email: "alice@example.com" } }),
+      );
+      expect(within(row).getByRole("link", { name: "alice@example.com" })).toHaveAttribute(
+        "href",
+        "/ui/users?user=user-1",
+      );
+      expect(within(row).getByRole("link", { name: "user-1" })).toHaveAttribute("href", "/ui/users?user=user-1");
+    });
+
+    it("points the Created By cell at the creator's detail page", async () => {
+      const row = await renderRow(
+        createMockKey({
+          created_by: "creator-1",
+          created_by_user: { user_id: "creator-1", user_email: "creator@example.com", user_alias: "The Creator" },
+        }),
+      );
+      expect(within(row).getByRole("link", { name: "The Creator" })).toHaveAttribute(
+        "href",
+        "/ui/users?user=creator-1",
+      );
+    });
+
+    it("leaves the default_user_id placeholder unlinked in the User ID and Created By cells", async () => {
+      const placeholder = { user_id: "default_user_id", user_email: "admin@example.com", user_alias: "Proxy Admin" };
+      const row = await renderRow(
+        createMockKey({
+          user_id: placeholder.user_id,
+          user: placeholder,
+          created_by: placeholder.user_id,
+          created_by_user: placeholder,
+        }),
+      );
+      expect(within(row).getByText("Default Proxy Admin")).toBeInTheDocument();
+      expect(within(row).getByText("Proxy Admin")).toBeInTheDocument();
+      expect(within(row).queryByRole("link", { name: "Proxy Admin" })).not.toBeInTheDocument();
     });
   });
 });

--- a/ui/litellm-dashboard/src/components/team/TeamVirtualKeysTable.test.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamVirtualKeysTable.test.tsx
@@ -396,7 +396,8 @@ describe("TeamVirtualKeysTable", () => {
         refetch: vi.fn(),
       } as any);
       renderWithProviders(<TeamVirtualKeysTable {...defaultProps} organization={organization} />);
-      return (await screen.findByText(key.key_alias as string)).closest("tr") as HTMLElement;
+      await screen.findByText(key.key_alias as string);
+      return screen.getByRole("row", { name: new RegExp(key.key_alias as string) });
     };
 
     it("points the Organization ID cell at the org's detail page", async () => {
@@ -433,17 +434,18 @@ describe("TeamVirtualKeysTable", () => {
 
     it("leaves the default_user_id placeholder unlinked in the User ID and Created By cells", async () => {
       const placeholder = { user_id: "default_user_id", user_email: "admin@example.com", user_alias: "Proxy Admin" };
-      const row = await renderRow(
-        createMockKey({
-          user_id: placeholder.user_id,
-          user: placeholder,
-          created_by: placeholder.user_id,
-          created_by_user: placeholder,
-        }),
-      );
+      const ownedAndCreatedByPlaceholder = {
+        user_id: placeholder.user_id,
+        user: placeholder,
+        created_by: placeholder.user_id,
+        created_by_user: placeholder,
+      };
+      const row = await renderRow(createMockKey(ownedAndCreatedByPlaceholder));
       expect(within(row).getByText("Default Proxy Admin")).toBeInTheDocument();
       expect(within(row).getByText("Proxy Admin")).toBeInTheDocument();
       expect(within(row).queryByRole("link", { name: "Proxy Admin" })).not.toBeInTheDocument();
+      expect(within(row).queryByRole("link", { name: placeholder.user_email })).not.toBeInTheDocument();
+      expect(within(row).queryByRole("link", { name: "Default Proxy Admin" })).not.toBeInTheDocument();
     });
   });
 });

--- a/ui/litellm-dashboard/src/components/team/TeamVirtualKeysTable.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamVirtualKeysTable.tsx
@@ -1,8 +1,14 @@
 "use client";
 import { useKeys } from "@/app/(dashboard)/hooks/keys/useKeys";
 import { SimpleTooltip } from "@/components/ui/tooltip";
-import CopyButton from "@/components/shared/CopyButton";
-import { DateCell, IdCell, MoneyCell } from "@/components/shared/table_cells";
+import {
+  DateCell,
+  ENTITY_CELL_TITLE_CLASSES,
+  IdCell,
+  IdentityCell,
+  MoneyCell,
+  UserPopoverCell,
+} from "@/components/shared/table_cells";
 import {
   DataTable,
   DataTableFilterDrawer,
@@ -11,8 +17,9 @@ import {
   DataTableToolbar,
 } from "@/components/shared/DataTable";
 import { Badge } from "@/components/ui/badge";
-import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card";
 import { Input } from "@/components/ui/input";
+import { orgDetailHref, userDetailHref } from "@/utils/entityLinks";
+import { DEFAULT_PROXY_ADMIN_USER_ID } from "@/utils/sentinels";
 import { DEBOUNCE_WAIT_MS } from "@/utils/debounceConstants";
 import { useDebouncedValue } from "@tanstack/react-pacer/debouncer";
 import { ColumnDef, ColumnFiltersState, OnChangeFn, PaginationState, SortingState } from "@tanstack/react-table";
@@ -168,7 +175,15 @@ export function TeamVirtualKeysTable({ teamId, teamAlias, organization }: TeamVi
         header: "Organization ID",
         size: 140,
         enableSorting: false,
-        cell: (info) => (info.getValue() ? info.renderValue() : "-"),
+        cell: (info) => {
+          const orgId = info.getValue() as string | null;
+          if (!orgId) return "-";
+          return (
+            <SimpleTooltip content={orgId}>
+              <IdentityCell title={orgId} titleClassName={ENTITY_CELL_TITLE_CLASSES} href={orgDetailHref(orgId)} />
+            </SimpleTooltip>
+          );
+        },
       },
       {
         id: "user_email",
@@ -179,9 +194,14 @@ export function TeamVirtualKeysTable({ teamId, teamAlias, organization }: TeamVi
         cell: (info) => {
           const user = info.getValue() as { user_email?: string } | undefined;
           const value = user?.user_email;
+          const userId = info.row.original.user_id;
           return (
             <SimpleTooltip content={value}>
-              <span className="block max-w-full truncate font-mono text-xs">{value ?? "-"}</span>
+              <IdentityCell
+                title={value ?? "-"}
+                titleClassName={ENTITY_CELL_TITLE_CLASSES}
+                href={value && userId ? userDetailHref(userId) : undefined}
+              />
             </SimpleTooltip>
           );
         },
@@ -194,10 +214,16 @@ export function TeamVirtualKeysTable({ teamId, teamAlias, organization }: TeamVi
         enableSorting: false,
         cell: (info) => {
           const userId = info.getValue() as string | null;
-          const displayValue = userId === "default_user_id" ? "Default Proxy Admin" : userId;
+          if (userId === DEFAULT_PROXY_ADMIN_USER_ID) {
+            return <DefaultProxyAdminTag userId={userId} />;
+          }
           return (
-            <SimpleTooltip content={displayValue}>
-              <span className="block max-w-full truncate font-mono text-xs">{displayValue ?? "-"}</span>
+            <SimpleTooltip content={userId}>
+              <IdentityCell
+                title={userId ?? "-"}
+                titleClassName={ENTITY_CELL_TITLE_CLASSES}
+                href={userId ? userDetailHref(userId) : undefined}
+              />
             </SimpleTooltip>
           );
         },
@@ -221,53 +247,13 @@ export function TeamVirtualKeysTable({ teamId, teamAlias, organization }: TeamVi
           const userId = info.getValue() as string | null;
           if (!userId) return "-";
           const { created_by_user } = info.row.original;
-          const userAlias = created_by_user?.user_alias ?? null;
-          const userEmail = created_by_user?.user_email ?? null;
-          const isDefaultAdmin = userId === "default_user_id";
-          const displayValue = userAlias || userEmail || userId;
-
-          const popoverContent = (
-            <div className="flex min-w-[200px] max-w-[300px] flex-col gap-2 text-xs">
-              {[
-                { label: "User Alias", value: userAlias },
-                { label: "User Email", value: userEmail },
-                { label: "User ID", value: userId },
-              ].map(({ label, value }) => (
-                <div key={label} className="flex flex-col min-w-0">
-                  <span className="text-muted-foreground">{label}</span>
-                  {value ? (
-                    <span className="flex items-center gap-1">
-                      <span className="min-w-0 flex-1 truncate font-mono text-xs">{value}</span>
-                      <CopyButton value={value} label={`Copy ${label}`} />
-                    </span>
-                  ) : (
-                    <span className="font-mono">-</span>
-                  )}
-                </div>
-              ))}
-            </div>
-          );
-
-          if (isDefaultAdmin && !userAlias && !userEmail) {
-            return (
-              <HoverCard>
-                <HoverCardTrigger render={<span className="cursor-default" />}>
-                  <DefaultProxyAdminTag userId={userId} />
-                </HoverCardTrigger>
-                <HoverCardContent align="start">{popoverContent}</HoverCardContent>
-              </HoverCard>
-            );
-          }
-
           return (
-            <HoverCard>
-              <HoverCardTrigger
-                render={<span className="block max-w-full cursor-default truncate font-mono text-xs" />}
-              >
-                {displayValue}
-              </HoverCardTrigger>
-              <HoverCardContent align="start">{popoverContent}</HoverCardContent>
-            </HoverCard>
+            <UserPopoverCell
+              userAlias={created_by_user?.user_alias ?? null}
+              userEmail={created_by_user?.user_email ?? null}
+              userId={userId}
+              width={130}
+            />
           );
         },
       },


### PR DESCRIPTION
## TLDR

Problem this solves:

- Team page keys table showed org and user as dead text
- Same navigation gap the Virtual Keys page just closed
- Created By popover was a verbatim copy of another file

How it solves it:

- Organization ID, User Email, User ID and Created By are links
- Sentinel ids stay plain text through the shared href helpers
- The duplicated popover moved into the shared table cells kit
- Its copy buttons now name the field they copy

## User Flow

Before: an admin on a team's Virtual Keys tab cannot get from a key to the org or user behind it

1. They open https://litellm-domain/ui/teams?team=fdf4b470-1fce-48e9-9e89-8160cae56f52 and pick the Virtual Keys tab
2. Organization ID reads `006717aa-94a1-4ed4-a5fb-80a81c0d2e57` and User ID reads `qa-team-owner`, both plain text
3. Clicking either does nothing, so they copy the id, open the Organizations or Internal Users page, and search for it by hand
4. The same key row on https://litellm-domain/ui/api-keys is already clickable, so the two tables disagree

After: the same cells take them straight to the org and user pages

1. They open https://litellm-domain/ui/teams?team=fdf4b470-1fce-48e9-9e89-8160cae56f52 and pick the Virtual Keys tab
2. Hovering Organization ID underlines it and shows a chevron
3. Clicking it lands on https://litellm-domain/ui/organizations?org=006717aa-94a1-4ed4-a5fb-80a81c0d2e57
4. User Email, User ID and Created By all land on https://litellm-domain/ui/users?user=qa-team-owner
5. A Created By of "Default Proxy Admin" stays plain text, since the built-in admin id has no user page

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Ran against a live proxy on port 4021 and the dashboard dev server on 3021. Setup was a real org, team and user in Postgres plus two keys on that team: `zzqa-linked-key` created by the team owner, and `zzqa-sentinel-key` created by the proxy admin, so both the real-user and the sentinel case show up in one table.

In both runs the steps are: open the team page, pick the Virtual Keys tab, search `zzqa-`, hover the Created By cell of `zzqa-linked-key`, then read every anchor the rows rendered.

### Before (880ccc76a5)

1. Open http://localhost:3021/teams/?team=fdf4b470-1fce-48e9-9e89-8160cae56f52, pick Virtual Keys, search `zzqa-`

   ![before](https://raw.githubusercontent.com/BerriAI/litellm/litellm_key_entity_links_screenshots/team3-before.png)

2. Hover Created By on the `zzqa-linked-key` row. The popover opens but nothing is a link

   ![before hover](https://raw.githubusercontent.com/BerriAI/litellm/litellm_key_entity_links_screenshots/team3-before-hover.png)

3. Read the anchors in both rows, there are none:

   ```json
   [[{"column":"Organization ID","text":"006717aa-94a1-4ed4-a5fb-80a81c0d2e57","href":null},
     {"column":"User Email","text":"qa-team-owner@example.com","href":null},
     {"column":"User ID","text":"qa-team-owner","href":null},
     {"column":"Created By","text":"Default Proxy Admin","href":null}],
    [{"column":"Organization ID","text":"006717aa-94a1-4ed4-a5fb-80a81c0d2e57","href":null},
     {"column":"User Email","text":"qa-team-owner@example.com","href":null},
     {"column":"User ID","text":"qa-team-owner","href":null},
     {"column":"Created By","text":"QA Team Owner","href":null}]]
   ```

### After (06b259e092)

1. Open http://localhost:3021/teams/?team=fdf4b470-1fce-48e9-9e89-8160cae56f52, pick Virtual Keys, search `zzqa-`

   ![after](https://raw.githubusercontent.com/BerriAI/litellm/litellm_key_entity_links_screenshots/team3-after.png)

2. Hover Created By on the `zzqa-linked-key` row. It now carries the chevron the Key column uses

   ![after hover](https://raw.githubusercontent.com/BerriAI/litellm/litellm_key_entity_links_screenshots/team3-after-hover.png)

3. Read the anchors in both rows. Every entity cell has one except the Created By that is the built-in admin:

   ```json
   [[{"column":"Organization ID","text":"006717aa-94a1-4ed4-a5fb-80a81c0d2e57","href":"/organizations?org=006717aa-94a1-4ed4-a5fb-80a81c0d2e57"},
     {"column":"User Email","text":"qa-team-owner@example.com","href":"/users?user=qa-team-owner"},
     {"column":"User ID","text":"qa-team-owner","href":"/users?user=qa-team-owner"},
     {"column":"Created By","text":"Default Proxy Admin","href":null}],
    [{"column":"Organization ID","text":"006717aa-94a1-4ed4-a5fb-80a81c0d2e57","href":"/organizations?org=006717aa-94a1-4ed4-a5fb-80a81c0d2e57"},
     {"column":"User Email","text":"qa-team-owner@example.com","href":"/users?user=qa-team-owner"},
     {"column":"User ID","text":"qa-team-owner","href":"/users?user=qa-team-owner"},
     {"column":"Created By","text":"QA Team Owner","href":"/users?user=qa-team-owner"}]]
   ```

4. Click Organization ID, which lands on `http://localhost:3021/organizations/?org=006717aa-94a1-4ed4-a5fb-80a81c0d2e57`

   ![org page](https://raw.githubusercontent.com/BerriAI/litellm/litellm_key_entity_links_screenshots/team3-after-land-org.png)

5. Go back and click User ID, which lands on `http://localhost:3021/users/?user=qa-team-owner`. User Email and Created By on the same row go to the same place

   ![user page](https://raw.githubusercontent.com/BerriAI/litellm/litellm_key_entity_links_screenshots/team3-after-land-user.png)

## Type

🆕 New Feature

🧹 Refactoring

## Caveats

### Low

- User ID now shows the admin badge, was plain text
- Resting cells look the same, the affordance is on hover
- Org links can 403 for viewers without org access, as they already do elsewhere

https://claude.ai/code/session_01NfwfQhamRNnSqgXMUjf3h4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard-only navigation and component extraction with tests; no auth or API behavior changes beyond richer links in one table.
> 
> **Overview**
> The team detail **Virtual Keys** table now matches the main API keys table: **Organization ID**, **User Email**, **User ID**, and **Created By** navigate to org/user detail pages via `IdentityCell` and shared `orgDetailHref` / `userDetailHref`, while the built-in proxy admin sentinel stays non-linkable (`DefaultProxyAdminTag` / no href).
> 
> **Created By** and the Virtual Keys page no longer duplicate hover-popover markup—logic moves into shared **`UserPopoverCell`** (exported with **`ENTITY_CELL_TITLE_CLASSES`**). Popover copy actions use **`IdCell`**’s new optional **`copyLabel`** so buttons read “Copy User Email” (etc.) instead of a generic “Copy ID”. Tests cover the new links on `TeamVirtualKeysTable` and the customizable copy label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06b259e0920792600c35c9951297fb83cd236c35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->