### PR TITLE
fix(auth): refresh lite login session token grants from the live user and team rows

### DIFF
--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -72,6 +72,7 @@ from litellm.proxy.auth.budget_throttle import (
 )
 from litellm.proxy.auth.route_checks import RouteChecks
 from litellm.proxy.common_utils.auth_cache_invalidation_pubsub import publish_auth_cache_invalidation
+from litellm.proxy.common_utils.cache_pydantic_utils import CacheCodec
 from litellm.proxy.common_utils.http_parsing_utils import (
     _safe_get_request_headers,
     _safe_get_request_query_params,
@@ -80,6 +81,7 @@ from litellm.proxy.common_utils.timezone_utils import get_budget_reset_time
 from litellm.proxy.common_utils.user_api_key_cache import (
     END_USER_RESTRICTED_REGISTRY_OVERFLOW_SENTINEL,
     MODEL_ACCESS_GROUP_REGISTRY_OVERFLOW_SENTINEL,
+    NO_TEAM_MEMBERSHIP_SENTINEL,
     TAG_REGISTRY_OVERFLOW_SENTINEL,
     UserApiKeyCache,
     end_user_cache_key,
@@ -2150,10 +2152,10 @@ async def get_team_membership(
     _key: Final = team_membership_reservation_cache_key(user_id=user_id, team_id=team_id)
 
     # check if in cache
-    cached_membership_obj: Final = await user_api_key_cache.async_get_cache(
-        key=_key,
-        model_type=LiteLLM_TeamMembership,
-    )
+    cached: Final[object] = await user_api_key_cache.async_get_cache(key=_key)
+    if cached == NO_TEAM_MEMBERSHIP_SENTINEL:
+        return None
+    cached_membership_obj: Final = CacheCodec.deserialize(cached, model_type=LiteLLM_TeamMembership)
     if cached_membership_obj is not None:
         return cached_membership_obj
 
@@ -2165,6 +2167,11 @@ async def get_team_membership(
         )
 
         if response is None:
+            await user_api_key_cache.async_set_cache(
+                key=_key,
+                value=NO_TEAM_MEMBERSHIP_SENTINEL,
+                ttl=get_management_object_ttl(user_api_key_cache),
+            )
             return None
 
         _response: Final = LiteLLM_TeamMembership.model_validate(response.dict())

--- a/litellm/proxy/auth/handle_jwt.py
+++ b/litellm/proxy/auth/handle_jwt.py
@@ -52,6 +52,7 @@ from litellm.proxy._types import (
     UserAPIKeyAuth,
 )
 from litellm.proxy.auth.auth_checks import can_team_access_model
+from litellm.proxy.auth.resolvers.grants import GrantResolver, UserLookup, canonical_user_id
 from litellm.proxy.auth.route_checks import RouteChecks
 from litellm.proxy.auth.team_grants import team_model_aliases
 from litellm.proxy.common_utils.user_api_key_cache import (
@@ -1656,9 +1657,7 @@ class JWTAuthManager:
         ``get_user_object`` resolved a legacy row with a different ``user_id``,
         use that row's id; otherwise keep the claim. GH #26789.
         """
-        if user_object is not None and user_object.user_id:
-            return user_object.user_id
-        return user_id
+        return canonical_user_id(user_id=user_id, user_object=user_object)
 
     @staticmethod
     async def get_objects(
@@ -1725,22 +1724,23 @@ class JWTAuthManager:
                 code=403,
             )
 
-        user_object: LiteLLM_UserTable | None = None
-        if user_id:
-            user_object = (
-                await get_user_object(
-                    user_id=user_id,
-                    prisma_client=prisma_client,
-                    user_api_key_cache=user_api_key_cache,
-                    user_id_upsert=jwt_handler.is_upsert_user_id(valid_user_email=valid_user_email),
-                    parent_otel_span=parent_otel_span,
-                    proxy_logging_obj=proxy_logging_obj,
-                    user_email=user_email,
-                    sso_user_id=user_id,
-                )
-                if user_id
-                else None
-            )
+        user_object, team_membership_object, effective_user_id = await GrantResolver(
+            prisma_client,
+            user_api_key_cache,
+            parent_otel_span=parent_otel_span,
+            proxy_logging_obj=proxy_logging_obj,
+            load_user=get_user_object,
+            load_team=get_team_object,
+            load_membership=get_team_membership,
+        ).resolve_identity(
+            UserLookup(
+                user_id=user_id,
+                user_email=user_email,
+                sso_user_id=user_id,
+                upsert=jwt_handler.is_upsert_user_id(valid_user_email=valid_user_email),
+            ),
+            team_id=team_id,
+        )
 
         end_user_object: LiteLLM_EndUserTable | None = None
         if end_user_id:
@@ -1757,37 +1757,12 @@ class JWTAuthManager:
                 else None
             )
 
-        # Rebind to resolved DB user_id for team_membership + auth_builder (GH #26789).
-        effective_user_id: Final = JWTAuthManager._canonical_user_id_from_db(user_id=user_id, user_object=user_object)
-        if effective_user_id != user_id:
-            verbose_proxy_logger.debug(
-                "JWT Auth: rebinding user_id %r -> DB user_id %r (email/sso match)",
-                user_id,
-                effective_user_id,
-            )
-        user_id = effective_user_id
-
-        team_membership_object: LiteLLM_TeamMembership | None = None
-        if user_id and team_id:
-            team_membership_object = (
-                await get_team_membership(
-                    user_id=user_id,
-                    team_id=team_id,
-                    prisma_client=prisma_client,
-                    user_api_key_cache=user_api_key_cache,
-                    parent_otel_span=parent_otel_span,
-                    proxy_logging_obj=proxy_logging_obj,
-                )
-                if user_id and team_id
-                else None
-            )
-
         return (
             user_object,
             org_object,
             end_user_object,
             team_membership_object,
-            user_id,
+            effective_user_id,
         )
 
     @staticmethod

--- a/litellm/proxy/auth/resolvers/grants.py
+++ b/litellm/proxy/auth/resolvers/grants.py
@@ -1,0 +1,267 @@
+"""Load a caller's user row, team row, and team membership from the database and validate them together.
+
+The virtual-key path reads these off the combined-view SQL join. Every other credential (an IdP JWT, a
+``lite login`` session token) carries only identifiers, or a snapshot of grants taken when it was minted, so
+it has to read the live rows on each request. Both of those paths resolve the same rows with the same
+membership rule, and ``GrantResolver`` is the one place that rule lives.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Coroutine, Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Final, NoReturn, Protocol, TypeAlias
+
+from fastapi import HTTPException, status
+from pydantic import BaseModel, ValidationError
+from pydantic.main import IncEx
+from typing_extensions import assert_never
+
+from litellm._logging import verbose_proxy_logger
+from litellm.proxy._types import (
+    LiteLLM_TeamMembership,
+    LiteLLM_TeamTableCachedObj,
+    LiteLLM_UserTable,
+    ProxyErrorTypes,
+    ProxyException,
+)
+from litellm.proxy.auth.auth_checks import (
+    TeamNotFoundError,
+    UserNotFoundError,
+    get_team_membership,
+    get_team_object,
+    get_user_object,
+)
+
+if TYPE_CHECKING:
+    from litellm.proxy._types import Span
+    from litellm.proxy.common_utils.user_api_key_cache import UserApiKeyCache
+    from litellm.proxy.utils import PrismaClient, ProxyLogging
+
+
+class UserLoader(Protocol):
+    def __call__(
+        self,
+        *,
+        user_id: str | None,
+        prisma_client: PrismaClient | None,
+        user_api_key_cache: UserApiKeyCache,
+        user_id_upsert: bool,
+        parent_otel_span: Span | None,
+        proxy_logging_obj: ProxyLogging | None,
+        sso_user_id: str | None,
+        user_email: str | None,
+    ) -> Coroutine[object, object, LiteLLM_UserTable | None]: ...
+
+
+class TeamLoader(Protocol):
+    def __call__(
+        self,
+        *,
+        team_id: str,
+        prisma_client: PrismaClient | None,
+        user_api_key_cache: UserApiKeyCache,
+        parent_otel_span: Span | None,
+        proxy_logging_obj: ProxyLogging | None,
+    ) -> Coroutine[object, object, LiteLLM_TeamTableCachedObj]: ...
+
+
+class MembershipLoader(Protocol):
+    def __call__(
+        self,
+        *,
+        user_id: str,
+        team_id: str,
+        prisma_client: PrismaClient | None,
+        user_api_key_cache: UserApiKeyCache,
+        parent_otel_span: Span | None,
+        proxy_logging_obj: ProxyLogging | None,
+    ) -> Coroutine[object, object, LiteLLM_TeamMembership | None]: ...
+
+
+@dataclass(frozen=True, slots=True)
+class UserLookup:
+    """The user a credential names, plus the hints ``get_user_object`` may fall back to when the id alone
+    matches no row."""
+
+    user_id: str | None
+    user_email: str | None = None
+    sso_user_id: str | None = None
+    upsert: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedGrants:
+    """The live rows behind a credential. ``effective_user_id`` is the DB row's id when a fuzzy match found a
+    legacy row under a different id (GH #26789), otherwise the id the credential named."""
+
+    user_object: LiteLLM_UserTable | None
+    team_object: LiteLLM_TeamTableCachedObj | None
+    team_membership: LiteLLM_TeamMembership | None
+    effective_user_id: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class UserGone:
+    user_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class TeamGone:
+    team_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class NotAMember:
+    user_id: str
+    team_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class LookupDegraded:
+    """A row could not be read for a reason that says nothing about the caller: the database is down or a
+    loader failed. The caller decides whether a grant it already holds may stand in."""
+
+    error: Exception
+
+
+GrantDenial: TypeAlias = UserGone | TeamGone | NotAMember
+GrantOutcome: TypeAlias = ResolvedGrants | GrantDenial | LookupDegraded
+
+
+_MODELS_COLUMN: Final[Mapping[str, IncEx | bool]] = MappingProxyType({"models": True})
+
+
+class _UserModelColumn(BaseModel):
+    """``LiteLLM_UserTable.models`` is a bare ``list``; re-read it with the shape a token's ``models`` takes."""
+
+    models: tuple[str, ...] = ()
+
+
+def user_models(user_object: LiteLLM_UserTable) -> tuple[str, ...]:
+    try:
+        return _UserModelColumn.model_validate(user_object.model_dump(include=_MODELS_COLUMN)).models
+    except ValidationError:
+        return ()
+
+
+def canonical_user_id(user_id: str | None, user_object: LiteLLM_UserTable | None) -> str | None:
+    if user_object is not None and user_object.user_id:
+        return user_object.user_id
+    return user_id
+
+
+def raise_public(denial: GrantDenial) -> NoReturn:
+    match denial:
+        case UserGone(user_id=user_id):
+            raise ProxyException(
+                message=f"Authentication Error, user '{user_id}' no longer exists.",
+                type=ProxyErrorTypes.auth_error,
+                param="user_id",
+                code=status.HTTP_401_UNAUTHORIZED,
+            )
+        case TeamGone(team_id=team_id):
+            raise TeamNotFoundError(team_id=team_id)
+        case NotAMember(team_id=team_id):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Team '{team_id}' is not in your team memberships.",
+            )
+        case _:
+            assert_never(denial)
+
+
+class GrantResolver:
+    """Reads the user, membership, and team rows for a credential through injected loaders.
+
+    The loaders default to the shared ``auth_checks`` readers. A caller passes its own module's names for them
+    so the reads stay interceptable where that module's callers already intercept them. ``resolve_identity``
+    is the JWT half: user and membership only, since the JWT builder selects the team itself and lets loader
+    errors surface as they are. ``resolve`` also reads the team row and applies the membership rule, which is
+    what a credential carrying a grant snapshot needs to refresh it.
+    """
+
+    def __init__(
+        self,
+        prisma_client: PrismaClient | None,
+        cache: UserApiKeyCache,
+        *,
+        parent_otel_span: Span | None = None,
+        proxy_logging_obj: ProxyLogging | None = None,
+        load_user: UserLoader = get_user_object,
+        load_team: TeamLoader = get_team_object,
+        load_membership: MembershipLoader = get_team_membership,
+    ) -> None:
+        self._prisma = prisma_client
+        self._cache = cache
+        self._parent_otel_span = parent_otel_span
+        self._proxy_logging_obj = proxy_logging_obj
+        self._load_user = load_user
+        self._load_team = load_team
+        self._load_membership = load_membership
+
+    async def resolve_identity(
+        self, lookup: UserLookup, team_id: str | None
+    ) -> tuple[LiteLLM_UserTable | None, LiteLLM_TeamMembership | None, str | None]:
+        user_object: Final = await self._user(lookup) if lookup.user_id else None
+        effective_user_id: Final = canonical_user_id(lookup.user_id, user_object)
+        if effective_user_id != lookup.user_id:
+            verbose_proxy_logger.debug(
+                "Auth: rebinding user_id %r -> DB user_id %r (email/sso match)",
+                lookup.user_id,
+                effective_user_id,
+            )
+        membership: Final = (
+            await self._membership(user_id=effective_user_id, team_id=team_id)
+            if effective_user_id and team_id
+            else None
+        )
+        return user_object, membership, effective_user_id
+
+    async def resolve(self, lookup: UserLookup, team_id: str | None) -> GrantOutcome:
+        try:
+            user_object, membership, effective_user_id = await self.resolve_identity(lookup, team_id)
+        except UserNotFoundError:
+            return UserGone(user_id=lookup.user_id or "")
+        except Exception as error:
+            return LookupDegraded(error=error)
+        if team_id is None:
+            return ResolvedGrants(user_object, None, membership, effective_user_id)
+        if user_object is not None and team_id not in user_object.teams:
+            return NotAMember(user_id=user_object.user_id, team_id=team_id)
+        try:
+            team_object: Final = await self._load_team(
+                team_id=team_id,
+                prisma_client=self._prisma,
+                user_api_key_cache=self._cache,
+                parent_otel_span=self._parent_otel_span,
+                proxy_logging_obj=self._proxy_logging_obj,
+            )
+        except TeamNotFoundError:
+            return TeamGone(team_id=team_id)
+        except Exception as error:
+            return LookupDegraded(error=error)
+        return ResolvedGrants(user_object, team_object, membership, effective_user_id)
+
+    async def _user(self, lookup: UserLookup) -> LiteLLM_UserTable | None:
+        return await self._load_user(
+            user_id=lookup.user_id,
+            prisma_client=self._prisma,
+            user_api_key_cache=self._cache,
+            user_id_upsert=lookup.upsert,
+            parent_otel_span=self._parent_otel_span,
+            proxy_logging_obj=self._proxy_logging_obj,
+            user_email=lookup.user_email,
+            sso_user_id=lookup.sso_user_id,
+        )
+
+    async def _membership(self, user_id: str, team_id: str) -> LiteLLM_TeamMembership | None:
+        return await self._load_membership(
+            user_id=user_id,
+            team_id=team_id,
+            prisma_client=self._prisma,
+            user_api_key_cache=self._cache,
+            parent_otel_span=self._parent_otel_span,
+            proxy_logging_obj=self._proxy_logging_obj,
+        )

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -55,6 +55,7 @@ from litellm.proxy.auth.auth_checks import (
     get_jwt_key_mapping_object,
     get_object_permission,
     get_project_object,
+    get_team_membership,
     get_team_object,
     get_user_object,
     is_valid_fallback_model,
@@ -80,6 +81,14 @@ from litellm.proxy.auth.network import TrustedProxyConfig, resolve_network_conte
 from litellm.proxy.auth.oauth2_check import Oauth2Handler
 from litellm.proxy.auth.oauth2_proxy_hook import handle_oauth2_proxy_request
 from litellm.proxy.auth.resolvers import CredentialRef, Principal
+from litellm.proxy.auth.resolvers.grants import (
+    GrantResolver,
+    LookupDegraded,
+    ResolvedGrants,
+    UserLookup,
+    raise_public,
+    user_models,
+)
 from litellm.proxy.auth.resolvers.store import IdentityStore
 from litellm.proxy.auth.route_checks import RouteChecks
 from litellm.proxy.auth.team_grants import team_grants
@@ -1222,6 +1231,52 @@ async def _record_unparsable_body_failure(
         verbose_proxy_logger.exception("Failed to log the request rejected for an unparsable body: %s", e)
 
 
+async def _refresh_session_token_grants(
+    valid_token: UserAPIKeyAuth,
+    prisma_client: PrismaClient,
+    user_api_key_cache: UserApiKeyCache,
+    parent_otel_span: Span | None,
+    proxy_logging_obj: ProxyLogging,
+) -> UserAPIKeyAuth:
+    """Rebuild a ``lite login`` session token's grants from the live user and team rows.
+
+    The blob only proves who logged in and which team they picked. Team models, aliases, the user's own model
+    list, and their role are re-read every request, so a `/team/update` or a demotion shows up without a
+    re-login, and a user removed from the team or deleted outright is refused. When a row cannot be read for
+    a reason unrelated to the caller, the minted grants stand in exactly as they did before this refresh.
+    """
+    outcome: Final = await GrantResolver(
+        prisma_client,
+        user_api_key_cache,
+        parent_otel_span=parent_otel_span,
+        proxy_logging_obj=proxy_logging_obj,
+        load_user=get_user_object,
+        load_team=get_team_object,
+        load_membership=get_team_membership,
+    ).resolve(UserLookup(user_id=valid_token.user_id), team_id=valid_token.team_id)
+    match outcome:
+        case ResolvedGrants(
+            user_object=LiteLLM_UserTable() as user_object, team_object=team_object, team_membership=team_membership
+        ):
+            return UserAPIKeyAuth.model_validate(
+                MappingProxyType(
+                    {
+                        **valid_token.model_dump(exclude_none=True),
+                        **team_grants(team_object, team_membership, user_object.user_id),
+                        "user_role": _get_user_role(user_object),
+                        "models": () if team_object is not None else user_models(user_object),
+                    }
+                )
+            )
+        case ResolvedGrants():
+            return valid_token
+        case LookupDegraded(error=error):
+            verbose_proxy_logger.debug("Session token grants not refreshed, keeping minted grants: %s", error)
+            return valid_token
+        case _:
+            raise_public(outcome)
+
+
 async def _resolve_object_permission_for_unresolvable_team(
     object_permission_id: str | None,
     prisma_client: PrismaClient | None,
@@ -1765,6 +1820,15 @@ async def _user_api_key_auth_builder(
                 and get_secret_bool("EXPERIMENTAL_UI_LOGIN") is not False
             ):
                 valid_token = ExperimentalUIJWTToken.get_key_object_from_ui_hash_key(api_key)
+
+        if valid_token is not None and valid_token.is_session_token and prisma_client is not None:
+            valid_token = await _refresh_session_token_grants(  # rebind-ok: later checks read this name
+                valid_token=valid_token,
+                prisma_client=prisma_client,
+                user_api_key_cache=user_api_key_cache,
+                parent_otel_span=parent_otel_span,
+                proxy_logging_obj=proxy_logging_obj,
+            )
 
         if (
             valid_token is not None

--- a/litellm/proxy/common_utils/user_api_key_cache.py
+++ b/litellm/proxy/common_utils/user_api_key_cache.py
@@ -246,6 +246,14 @@ def team_membership_reservation_cache_key(user_id: str, team_id: str) -> str:
     return f"team_membership:{user_id}:{team_id}"
 
 
+#: Cached under ``team_membership_reservation_cache_key`` when a member has no ``LiteLLM_TeamMembership``
+#: row, so a session-token member without a per-member budget costs no DB read per request. Lives beside
+#: the key builder because it is part of the same cache protocol: every reader of the key must know that
+#: a plain string here means "no row", distinct from a serialized membership. The two budget readers
+#: already treat a non-model value as "no row", so they need no change to stay correct.
+NO_TEAM_MEMBERSHIP_SENTINEL: Final = "__no_team_membership__"
+
+
 def get_management_object_ttl(cache: DualCache) -> float:
     """
     In-memory TTL for management-object cache writes (keys, teams, users, budgets, ...).

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -14,7 +14,7 @@ import copy
 import json
 import math
 import traceback
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from collections.abc import Set as AbstractSet
 from datetime import datetime, timezone
 from types import MappingProxyType
@@ -1902,6 +1902,39 @@ def validate_team_org_change(
     return True
 
 
+def _member_user_ids(members_with_roles: Sequence[dict[str, object]]) -> tuple[str, ...]:
+    """Extract the string ``user_id`` of each team member, dropping rows without one.
+
+    ``members_with_roles`` is a Prisma-deserialized JSON column, so its ``user_id`` is typed
+    ``object``; the ``isinstance`` narrows it to the ``str`` ``invalidate_team_member_spend_state`` needs.
+    """
+    return tuple(user_id for member in members_with_roles if isinstance((user_id := member.get("user_id")), str))
+
+
+async def _evict_created_membership_caches(
+    user_ids: Iterable[str],
+    team_id: str,
+    user_api_key_cache: UserApiKeyCache,
+) -> None:
+    """Evict the ``get_team_membership`` negative-cache sentinel for members whose row was just created.
+
+    A session-token request caches ``NO_TEAM_MEMBERSHIP_SENTINEL`` for a member with no
+    ``LiteLLM_TeamMembership`` row. When a create path (``/team/member_add`` or the ``/team/update``
+    budget backfill) later writes that row with a per-member budget, the stale sentinel keeps the
+    member's budget unenforced until the membership cache TTL expires, so it must be evicted here.
+    """
+    await asyncio.gather(
+        *(
+            invalidate_team_member_spend_state(
+                user_id=user_id,
+                team_id=team_id,
+                user_api_key_cache=user_api_key_cache,
+            )
+            for user_id in user_ids
+        )
+    )
+
+
 @router.post("/team/update", tags=["team management"], dependencies=[Depends(user_api_key_auth)])
 @management_endpoint_wrapper
 async def update_team(
@@ -2237,6 +2270,11 @@ async def update_team(
                     members_with_roles=existing_team_row.members_with_roles,
                     team_member_budget_id=_backfill_budget_id,
                     prisma_client=prisma_client,
+                )
+                await _evict_created_membership_caches(
+                    user_ids=_member_user_ids(existing_team_row.members_with_roles),
+                    team_id=data.team_id,
+                    user_api_key_cache=user_api_key_cache,
                 )
         elif _team_member_fields_in_request:
             updated_kv = await TeamMemberBudgetHandler.clear_team_member_budget_fields(
@@ -3188,6 +3226,12 @@ async def team_member_add(
         prisma_client=prisma_client,
         user_api_key_dict=user_api_key_dict,
         litellm_proxy_admin_name=litellm_proxy_admin_name,
+    )
+
+    await _evict_created_membership_caches(
+        user_ids=(tm.user_id for tm in updated_team_memberships),
+        team_id=data.team_id,
+        user_api_key_cache=user_api_key_cache,
     )
 
     _emit_team_members_metric(complete_team_data)

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -6215,6 +6215,106 @@ async def test_get_team_membership_db_fetch_returns_validated_membership():
 
 
 @pytest.mark.asyncio
+async def test_get_team_membership_negative_caches_a_missing_row():
+    """
+    Regression (LIT-7358): a member with no LiteLLM_TeamMembership row is the common lite-login case,
+    and the session-token refresh reads this loader on every request. Before the fix a missing row
+    returned None without caching, so every request re-queried the DB. The miss must be cached so the
+    second request serves from cache and never touches the DB.
+    """
+    from litellm.proxy.auth.auth_checks import get_team_membership
+    from litellm.proxy.common_utils.user_api_key_cache import (
+        NO_TEAM_MEMBERSHIP_SENTINEL,
+        team_membership_reservation_cache_key,
+    )
+
+    mock_prisma_client = MagicMock()
+    mock_prisma_client.db.litellm_teammembership.find_unique = AsyncMock(return_value=None)
+
+    cache = UserApiKeyCache()
+
+    first = await get_team_membership(
+        user_id="u-1", team_id="t-1", prisma_client=mock_prisma_client, user_api_key_cache=cache
+    )
+    second = await get_team_membership(
+        user_id="u-1", team_id="t-1", prisma_client=mock_prisma_client, user_api_key_cache=cache
+    )
+
+    assert first is None
+    assert second is None
+    mock_prisma_client.db.litellm_teammembership.find_unique.assert_awaited_once()
+    cached = await cache.async_get_cache(
+        key=team_membership_reservation_cache_key(user_id="u-1", team_id="t-1")
+    )
+    assert cached == NO_TEAM_MEMBERSHIP_SENTINEL
+
+
+@pytest.mark.asyncio
+async def test_get_team_membership_reads_sentinel_as_no_membership_not_a_model():
+    """
+    The negative-cache sentinel is a plain string sharing the key a serialized membership uses.
+    A pre-seeded sentinel must read back as None (no DB read), never be mistaken for a membership.
+    """
+    from litellm.proxy.auth.auth_checks import get_team_membership
+    from litellm.proxy.common_utils.user_api_key_cache import (
+        NO_TEAM_MEMBERSHIP_SENTINEL,
+        team_membership_reservation_cache_key,
+    )
+
+    cache = UserApiKeyCache()
+    await cache.async_set_cache(
+        key=team_membership_reservation_cache_key(user_id="u-1", team_id="t-1"),
+        value=NO_TEAM_MEMBERSHIP_SENTINEL,
+    )
+
+    mock_prisma_client = MagicMock()
+    mock_prisma_client.db.litellm_teammembership.find_unique = AsyncMock(return_value=None)
+
+    result = await get_team_membership(
+        user_id="u-1", team_id="t-1", prisma_client=mock_prisma_client, user_api_key_cache=cache
+    )
+
+    assert result is None
+    mock_prisma_client.db.litellm_teammembership.find_unique.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_invalidate_team_member_spend_state_evicts_the_negative_cache_sentinel():
+    """
+    A member who later gains a per-member budget writes a membership row and calls
+    invalidate_team_member_spend_state. That must drop a cached "no membership" sentinel so the next
+    request re-reads the DB and honors the new budget instead of serving the stale miss until TTL.
+    """
+    from litellm.proxy.auth.auth_checks import get_team_membership, invalidate_team_member_spend_state
+    from litellm.proxy.common_utils.user_api_key_cache import team_membership_reservation_cache_key
+
+    cache = UserApiKeyCache()
+    membership_row = MagicMock()
+    membership_row.dict = lambda: {"user_id": "u-1", "team_id": "t-1", "spend": 0.0}
+
+    mock_prisma_client = MagicMock()
+    mock_prisma_client.db.litellm_teammembership.find_unique = AsyncMock(side_effect=[None, membership_row])
+
+    before = await get_team_membership(
+        user_id="u-1", team_id="t-1", prisma_client=mock_prisma_client, user_api_key_cache=cache
+    )
+    assert before is None
+
+    await invalidate_team_member_spend_state(user_id="u-1", team_id="t-1", user_api_key_cache=cache)
+    assert (
+        await cache.async_get_cache(key=team_membership_reservation_cache_key(user_id="u-1", team_id="t-1"))
+        is None
+    )
+
+    after = await get_team_membership(
+        user_id="u-1", team_id="t-1", prisma_client=mock_prisma_client, user_api_key_cache=cache
+    )
+    assert after is not None
+    assert after.user_id == "u-1"
+    assert mock_prisma_client.db.litellm_teammembership.find_unique.await_count == 2
+
+
+@pytest.mark.asyncio
 async def test_get_access_object_db_fetch_returns_validated_access_group():
     from litellm.proxy._types import LiteLLM_AccessGroupTable
     from litellm.proxy.auth.auth_checks import get_access_object

--- a/tests/test_litellm/proxy/auth/test_resolvers_grants.py
+++ b/tests/test_litellm/proxy/auth/test_resolvers_grants.py
@@ -1,0 +1,201 @@
+from fastapi import HTTPException
+import pytest
+
+from litellm.proxy._types import (
+    LiteLLM_TeamMembership,
+    LiteLLM_TeamTableCachedObj,
+    LiteLLM_UserTable,
+    ProxyException,
+)
+from litellm.proxy.auth.auth_checks import TeamNotFoundError, UserNotFoundError
+from litellm.proxy.auth.resolvers.grants import (
+    GrantResolver,
+    LookupDegraded,
+    NotAMember,
+    ResolvedGrants,
+    TeamGone,
+    UserGone,
+    UserLookup,
+    raise_public,
+    user_models,
+)
+
+USER_ID = "user-1"
+TEAM_ID = "team-1"
+
+
+class _Loaders:
+    """Fake row readers standing in for the ``auth_checks`` loaders, recording every call they receive."""
+
+    def __init__(self, *, user=None, team=None, membership=None, user_error=None, team_error=None):
+        self._user = user
+        self._team = team
+        self._membership = membership
+        self._user_error = user_error
+        self._team_error = team_error
+        self.user_calls = []
+        self.team_calls = []
+        self.membership_calls = []
+
+    async def load_user(self, **kwargs):
+        self.user_calls.append(kwargs)
+        if self._user_error is not None:
+            raise self._user_error
+        return self._user
+
+    async def load_team(self, **kwargs):
+        self.team_calls.append(kwargs)
+        if self._team_error is not None:
+            raise self._team_error
+        return self._team
+
+    async def load_membership(self, **kwargs):
+        self.membership_calls.append(kwargs)
+        return self._membership
+
+    def resolver(self) -> GrantResolver:
+        return GrantResolver(
+            object(),
+            object(),
+            load_user=self.load_user,
+            load_team=self.load_team,
+            load_membership=self.load_membership,
+        )
+
+
+def _user(teams=(TEAM_ID,), user_id=USER_ID) -> LiteLLM_UserTable:
+    return LiteLLM_UserTable(user_id=user_id, user_role="internal_user", teams=list(teams), models=["gpt-5.5"])
+
+
+def _team(models=("gpt-5.5",)) -> LiteLLM_TeamTableCachedObj:
+    return LiteLLM_TeamTableCachedObj(team_id=TEAM_ID, team_alias="alias", models=list(models))
+
+
+async def test_resolve_returns_live_rows_for_a_member():
+    membership = LiteLLM_TeamMembership(user_id=USER_ID, team_id=TEAM_ID, spend=1.5)
+    loaders = _Loaders(user=_user(), team=_team(models=("new-a", "new-b")), membership=membership)
+
+    outcome = await loaders.resolver().resolve(UserLookup(user_id=USER_ID), team_id=TEAM_ID)
+
+    assert outcome == ResolvedGrants(
+        user_object=_user(),
+        team_object=_team(models=("new-a", "new-b")),
+        team_membership=membership,
+        effective_user_id=USER_ID,
+    )
+    assert loaders.team_calls[0]["team_id"] == TEAM_ID
+    assert loaders.membership_calls[0]["user_id"] == USER_ID
+    assert loaders.membership_calls[0]["team_id"] == TEAM_ID
+
+
+async def test_resolve_denies_a_user_removed_from_the_team_without_reading_the_team():
+    loaders = _Loaders(user=_user(teams=("other-team",)), team=_team())
+
+    outcome = await loaders.resolver().resolve(UserLookup(user_id=USER_ID), team_id=TEAM_ID)
+
+    assert outcome == NotAMember(user_id=USER_ID, team_id=TEAM_ID)
+    assert loaders.team_calls == []
+
+
+async def test_resolve_reports_a_deleted_user():
+    loaders = _Loaders(user_error=UserNotFoundError(user_id=USER_ID), team=_team())
+
+    outcome = await loaders.resolver().resolve(UserLookup(user_id=USER_ID), team_id=TEAM_ID)
+
+    assert outcome == UserGone(user_id=USER_ID)
+    assert loaders.team_calls == []
+
+
+async def test_resolve_reports_a_deleted_team():
+    loaders = _Loaders(user=_user(), team_error=TeamNotFoundError(team_id=TEAM_ID))
+
+    outcome = await loaders.resolver().resolve(UserLookup(user_id=USER_ID), team_id=TEAM_ID)
+
+    assert outcome == TeamGone(team_id=TEAM_ID)
+
+
+@pytest.mark.parametrize(
+    "loaders",
+    [
+        _Loaders(user_error=Exception("No db connected")),
+        _Loaders(user=_user(), team_error=HTTPException(status_code=500, detail="db timeout")),
+    ],
+    ids=["user-read-failed", "team-read-failed"],
+)
+async def test_resolve_marks_an_unreadable_row_as_degraded_not_denied(loaders):
+    outcome = await loaders.resolver().resolve(UserLookup(user_id=USER_ID), team_id=TEAM_ID)
+
+    assert isinstance(outcome, LookupDegraded)
+
+
+async def test_resolve_without_a_team_skips_team_and_membership_reads():
+    loaders = _Loaders(user=_user(teams=()))
+
+    outcome = await loaders.resolver().resolve(UserLookup(user_id=USER_ID), team_id=None)
+
+    assert outcome == ResolvedGrants(
+        user_object=_user(teams=()), team_object=None, team_membership=None, effective_user_id=USER_ID
+    )
+    assert loaders.team_calls == []
+    assert loaders.membership_calls == []
+
+
+async def test_resolve_identity_reads_membership_under_the_matched_rows_id():
+    legacy_uuid = "bb8ab11f-09aa-47ae-b063-6e80506ac3bc"
+    loaders = _Loaders(user=_user(user_id=legacy_uuid))
+
+    user_object, _membership, effective_user_id = await loaders.resolver().resolve_identity(
+        UserLookup(user_id="matt@example.com", user_email="matt@example.com", sso_user_id="matt@example.com"),
+        team_id=TEAM_ID,
+    )
+
+    assert user_object is not None and user_object.user_id == legacy_uuid
+    assert effective_user_id == legacy_uuid
+    assert loaders.membership_calls[0]["user_id"] == legacy_uuid
+    assert loaders.user_calls[0]["user_email"] == "matt@example.com"
+
+
+async def test_resolve_identity_without_a_user_id_reads_nothing():
+    loaders = _Loaders(user=_user())
+
+    outcome = await loaders.resolver().resolve_identity(UserLookup(user_id=None), team_id=TEAM_ID)
+
+    assert outcome == (None, None, None)
+    assert loaders.user_calls == []
+    assert loaders.membership_calls == []
+
+
+async def test_resolve_identity_lets_loader_errors_surface():
+    loaders = _Loaders(user_error=UserNotFoundError(user_id=USER_ID))
+
+    with pytest.raises(UserNotFoundError):
+        await loaders.resolver().resolve_identity(UserLookup(user_id=USER_ID), team_id=None)
+
+
+def test_raise_public_maps_a_deleted_user_to_401():
+    with pytest.raises(ProxyException) as exc_info:
+        raise_public(UserGone(user_id=USER_ID))
+    assert exc_info.value.code == "401"
+    assert USER_ID in exc_info.value.message
+
+
+def test_raise_public_maps_a_removed_member_to_403():
+    with pytest.raises(HTTPException) as exc_info:
+        raise_public(NotAMember(user_id=USER_ID, team_id=TEAM_ID))
+    assert exc_info.value.status_code == 403
+    assert TEAM_ID in str(exc_info.value.detail)
+
+
+def test_raise_public_maps_a_deleted_team_to_404():
+    with pytest.raises(TeamNotFoundError) as exc_info:
+        raise_public(TeamGone(team_id=TEAM_ID))
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.parametrize(
+    ("stored", "expected"),
+    [(["gpt-5.5", "claude-opus-5"], ("gpt-5.5", "claude-opus-5")), ([], ()), ([{"not": "a model"}], ())],
+    ids=["models", "empty", "unusable-column"],
+)
+def test_user_models_reads_the_column_as_a_tuple_of_names(stored, expected):
+    assert user_models(LiteLLM_UserTable(user_id=USER_ID, models=stored)) == expected

--- a/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
+++ b/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
@@ -31,7 +31,7 @@ from litellm.proxy._types import (
     JWTRoutingOverride,
 )
 from litellm.proxy.auth.handle_jwt import JWTHandler
-from litellm.proxy.auth.auth_checks import get_key_object, _cache_key_object
+from litellm.proxy.auth.auth_checks import TeamNotFoundError, UserNotFoundError, get_key_object, _cache_key_object
 from litellm.proxy.auth.route_checks import RouteChecks
 from litellm.proxy.auth.user_api_key_auth import (
     _check_key_model_budget_with_fallback,
@@ -6114,6 +6114,192 @@ async def test_non_admin_cli_session_token_reaches_production_auth_path(monkeypa
     assert call_kwargs["valid_token_dict"]["is_session_token"] is True
     assert call_kwargs["valid_token_dict"]["user_role"] == LitellmUserRoles.INTERNAL_USER
     assert result.is_session_token is True
+
+
+SESSION_TEAM_ID = "team-abc"
+SESSION_USER_ID = "member-1"
+
+
+def _mint_session_token(
+    monkeypatch,
+    *,
+    role=LitellmUserRoles.INTERNAL_USER,
+    team_id=SESSION_TEAM_ID,
+    team_models=("stale-model",),
+    models=(),
+):
+    """Mint a ``lite login`` token carrying the grants as they were at login time."""
+    monkeypatch.delenv("EXPERIMENTAL_UI_LOGIN", raising=False)
+    monkeypatch.setenv("LITELLM_SALT_KEY", "sk-salt-cli-test")
+    from litellm.proxy.auth.auth_checks import ExperimentalUIJWTToken
+
+    user_info = LiteLLM_UserTable(
+        user_id=SESSION_USER_ID, user_email="user@example.com", user_role=role.value, models=list(models)
+    )
+    return ExperimentalUIJWTToken.get_cli_jwt_auth_token(
+        user_info, team_id=team_id, team_alias="stale-alias", team_models=list(team_models)
+    )
+
+
+def _session_user_row(*, teams=(SESSION_TEAM_ID,), role=LitellmUserRoles.INTERNAL_USER, models=()):
+    return LiteLLM_UserTable(user_id=SESSION_USER_ID, user_role=role.value, teams=list(teams), models=list(models))
+
+
+async def _authenticate_session_token_against_db(
+    cli_token, *, user_row=None, team_row=None, membership_row=None, user_error=None, team_error=None
+):
+    """Drive the real builder for a session token with the DB row readers replaced by the given rows or
+    errors. Returns the ``_return_user_api_key_auth_obj`` mock so the caller can read the token it was
+    handed; a denial surfaces as the exception the builder raises."""
+    import litellm.proxy.proxy_server as _proxy_server_mod
+    from fastapi import Request
+    from starlette.datastructures import URL
+
+    attrs = _proxy_attrs_for_db_lookup()
+    attrs["prisma_client"].db.litellm_teammembership.find_first = AsyncMock(return_value=None)
+    originals = {a: getattr(_proxy_server_mod, a, None) for a in attrs}
+    assemble = AsyncMock(return_value=UserAPIKeyAuth(user_id=SESSION_USER_ID, is_session_token=True))
+    try:
+        for k, v in attrs.items():
+            setattr(_proxy_server_mod, k, v)
+        request = Request(scope={"type": "http"})
+        request._url = URL(url="/chat/completions")
+        with (
+            patch(  # test-quality-ok: the builder has no injection seam for its assembler yet
+                "litellm.proxy.auth.user_api_key_auth._return_user_api_key_auth_obj", assemble
+            ),
+            patch(  # test-quality-ok: the builder reads its DB row loaders off module globals
+                "litellm.proxy.auth.user_api_key_auth.get_user_object",
+                AsyncMock(return_value=user_row, side_effect=user_error),
+            ),
+            patch(  # test-quality-ok: the builder reads its DB row loaders off module globals
+                "litellm.proxy.auth.user_api_key_auth.get_team_object",
+                AsyncMock(return_value=team_row, side_effect=team_error),
+            ),
+            patch(  # test-quality-ok: the builder reads its DB row loaders off module globals
+                "litellm.proxy.auth.user_api_key_auth.get_team_membership",
+                AsyncMock(return_value=membership_row),
+            ),
+        ):
+            await _user_api_key_auth_builder(
+                request=request,
+                api_key=f"Bearer {cli_token}",
+                azure_api_key_header="",
+                anthropic_api_key_header=None,
+                google_ai_studio_api_key_header=None,
+                azure_apim_header=None,
+                request_data={},
+            )
+    finally:
+        for k, v in originals.items():
+            setattr(_proxy_server_mod, k, v)
+    return assemble
+
+
+@pytest.mark.asyncio
+async def test_session_token_reads_team_grants_from_the_live_team_row(monkeypatch):
+    """LIT-7358: a lite login token snapshots the team's models at login, so adding a model to the team did
+    nothing for that CLI until the user logged in again. The team row has to be re-read on every request."""
+    from litellm.models.team import LiteLLM_ModelTable
+    from litellm.proxy._types import LiteLLM_TeamMembership, LiteLLM_TeamTableCachedObj
+
+    cli_token = _mint_session_token(monkeypatch, team_models=("stale-model",))
+    live_team = LiteLLM_TeamTableCachedObj(
+        team_id=SESSION_TEAM_ID,
+        team_alias="renamed-team",
+        models=["gpt-5.5", "claude-opus-5"],
+        litellm_model_table=LiteLLM_ModelTable(model_aliases={"fast": "gpt-5.5"}, created_by="a", updated_by="a"),
+    )
+    membership = LiteLLM_TeamMembership(user_id=SESSION_USER_ID, team_id=SESSION_TEAM_ID, spend=2.5)
+
+    assemble = await _authenticate_session_token_against_db(
+        cli_token, user_row=_session_user_row(), team_row=live_team, membership_row=membership
+    )
+
+    token = assemble.call_args.kwargs["valid_token_dict"]
+    assert token["team_models"] == ["gpt-5.5", "claude-opus-5"]
+    assert token["team_alias"] == "renamed-team"
+    assert token["team_model_aliases"] == {"fast": "gpt-5.5"}
+    assert token["team_member_spend"] == 2.5
+    assert token["is_session_token"] is True
+
+
+@pytest.mark.asyncio
+async def test_session_token_without_a_team_reads_models_from_the_live_user_row(monkeypatch):
+    cli_token = _mint_session_token(monkeypatch, team_id=None, team_models=(), models=("stale-model",))
+
+    assemble = await _authenticate_session_token_against_db(
+        cli_token, user_row=_session_user_row(teams=(), models=("gpt-5.5",))
+    )
+
+    assert assemble.call_args.kwargs["valid_token_dict"]["models"] == ["gpt-5.5"]
+
+
+@pytest.mark.asyncio
+async def test_demoted_admin_session_token_loses_admin_on_the_next_request(monkeypatch):
+    """The role baked into the token used to send a former admin down the admin early return forever."""
+    from litellm.proxy._types import LiteLLM_TeamTableCachedObj
+
+    cli_token = _mint_session_token(monkeypatch, role=LitellmUserRoles.PROXY_ADMIN)
+
+    assemble = await _authenticate_session_token_against_db(
+        cli_token,
+        user_row=_session_user_row(role=LitellmUserRoles.INTERNAL_USER),
+        team_row=LiteLLM_TeamTableCachedObj(team_id=SESSION_TEAM_ID, models=["gpt-5.5"]),
+    )
+
+    assemble.assert_awaited_once()
+    assert assemble.call_args.kwargs["valid_token_dict"]["user_role"] == LitellmUserRoles.INTERNAL_USER
+
+
+@pytest.mark.asyncio
+async def test_session_token_is_refused_once_the_user_leaves_the_team(monkeypatch):
+    cli_token = _mint_session_token(monkeypatch)
+
+    with pytest.raises(ProxyException) as exc_info:
+        await _authenticate_session_token_against_db(cli_token, user_row=_session_user_row(teams=("other-team",)))
+
+    assert exc_info.value.code == str(status.HTTP_403_FORBIDDEN)
+    assert SESSION_TEAM_ID in exc_info.value.message
+
+
+@pytest.mark.asyncio
+async def test_session_token_is_refused_once_the_user_is_deleted(monkeypatch):
+    cli_token = _mint_session_token(monkeypatch)
+
+    with pytest.raises(ProxyException) as exc_info:
+        await _authenticate_session_token_against_db(cli_token, user_error=UserNotFoundError(user_id=SESSION_USER_ID))
+
+    assert exc_info.value.code == str(status.HTTP_401_UNAUTHORIZED)
+    assert exc_info.value.type == ProxyErrorTypes.auth_error
+
+
+@pytest.mark.asyncio
+async def test_session_token_is_refused_once_the_team_is_deleted(monkeypatch):
+    cli_token = _mint_session_token(monkeypatch)
+
+    with pytest.raises(ProxyException) as exc_info:
+        await _authenticate_session_token_against_db(
+            cli_token, user_row=_session_user_row(), team_error=TeamNotFoundError(team_id=SESSION_TEAM_ID)
+        )
+
+    assert exc_info.value.code == str(status.HTTP_404_NOT_FOUND)
+
+
+@pytest.mark.asyncio
+async def test_session_token_keeps_minted_grants_when_the_team_row_cannot_be_read(monkeypatch):
+    """A DB hiccup says nothing about the caller, so the grants minted at login stand for that request."""
+    from fastapi import HTTPException
+
+    cli_token = _mint_session_token(monkeypatch, team_models=("stale-model",))
+
+    assemble = await _authenticate_session_token_against_db(
+        cli_token, user_row=_session_user_row(), team_error=HTTPException(status_code=500, detail="db timeout")
+    )
+
+    token = assemble.call_args.kwargs["valid_token_dict"]
+    assert token["team_models"] == ["stale-model"]
+    assert token["team_alias"] == "stale-alias"
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
@@ -13941,6 +13941,52 @@ async def test_team_member_update_skips_invalidation_when_no_budget_fields_sent(
     assert real_spend_counter_cache.in_memory_cache.get_cache(key="spend:team_member:member-1:team-1") == 1.5
 
 
+@pytest.mark.asyncio
+async def test_evict_created_membership_caches_drops_the_negative_sentinel():
+    """
+    Regression: a membership-create path (/team/member_add, the /team/update budget backfill) must
+    evict any cached "no membership" sentinel a prior session-token read left, so a per-member budget
+    attached at create time is enforced on the next request instead of after the membership cache TTL.
+    Uses a real cache so the assertion is that the sentinel is actually gone, not that a mock was called.
+    """
+    from litellm.proxy.common_utils.user_api_key_cache import (
+        NO_TEAM_MEMBERSHIP_SENTINEL,
+        UserApiKeyCache,
+        team_membership_reservation_cache_key,
+    )
+    from litellm.proxy.management_endpoints.team_endpoints import _evict_created_membership_caches
+
+    cache = UserApiKeyCache()
+    kept_key = team_membership_reservation_cache_key(user_id="carol", team_id="team-eviction")
+    evicted_key = team_membership_reservation_cache_key(user_id="bob", team_id="team-eviction")
+    await cache.async_set_cache(key=kept_key, value=NO_TEAM_MEMBERSHIP_SENTINEL)
+    await cache.async_set_cache(key=evicted_key, value=NO_TEAM_MEMBERSHIP_SENTINEL)
+
+    await _evict_created_membership_caches(user_ids=("bob",), team_id="team-eviction", user_api_key_cache=cache)
+
+    assert await cache.async_get_cache(key=evicted_key) is None
+    assert await cache.async_get_cache(key=kept_key) == NO_TEAM_MEMBERSHIP_SENTINEL
+
+
+def test_member_user_ids_keeps_only_string_user_ids():
+    """
+    The /team/update backfill feeds Prisma-deserialized member dicts here; a row can be missing
+    user_id or carry a non-string value. Only real string ids may reach invalidate_team_member_spend_state,
+    so those get eviction and the malformed rows are dropped rather than crashing the update.
+    """
+    from litellm.proxy.management_endpoints.team_endpoints import _member_user_ids
+
+    members = [
+        {"user_id": "alice", "role": "admin"},
+        {"role": "user"},
+        {"user_id": None, "role": "user"},
+        {"user_id": 123, "role": "user"},
+        {"user_id": "bob", "role": "user"},
+    ]
+
+    assert _member_user_ids(members) == ("alice", "bob")
+
+
 def _team_spend_by_user_team(team_id: str, team_alias: str, member: Member, permissions: list[str]) -> MagicMock:
     team = MagicMock(spec=LiteLLM_TeamTable)
     team.team_id = team_id


### PR DESCRIPTION
## TLDR

Problem this solves:

- `lite login` tokens froze the team's models, aliases and the user's role at login
- Adding a model to the team did nothing for that CLI until re-login
- A user removed from the team, or demoted from admin, kept the old access

How it solves it:

- Pulls the JWT path's DB row loading into a reusable `GrantResolver`
- The session token branch now resolves user, membership and team rows per request
- Removed member gets 403, deleted user 401, demoted admin loses the admin shortcut
- Supersedes #40318

## User Flow

Before: a developer who logged in with `lite login` never sees a model their admin just added to the team, and keeps the team's access after the admin removes them

1. They run `lite login`, pick their team, and the CLI stores the session token
2. `lite models list` shows `gpt-5.5`, the team's only model at that moment
3. Their admin sends POST https://litellm-domain/team/update with `{"team_id": "...", "models": ["gpt-5.5", "gpt-4o-mini"]}` and gets the updated team back
4. `lite models list` still shows only `gpt-5.5`, a minute later too
5. POST https://litellm-domain/v1/chat/completions with `"model": "gpt-4o-mini"` returns 200 anyway, so the list the CLI shows and the models it can actually call disagree
6. Only after `lite login` again does `gpt-4o-mini` show up in the list
7. If the admin sets them a per-member rate limit with POST https://litellm-domain/team/member_update, the CLI never gets a 429
8. If the admin removes them from the team or deletes their user row, that CLI keeps listing and calling the team's models until the token expires, and a token minted while they were an admin keeps passing admin-only routes like GET https://litellm-domain/user/list after a demotion

After: the same CLI follows the team and user rows within a minute

1. They run `lite login`, pick their team, and the CLI stores the session token
2. `lite models list` shows `gpt-5.5`, the team's only model at that moment
3. Their admin sends POST https://litellm-domain/team/update with `{"team_id": "...", "models": ["gpt-5.5", "gpt-4o-mini"]}` and gets the updated team back
4. `lite models list` shows `gpt-5.5` and `gpt-4o-mini` within a minute, no new login
5. POST https://litellm-domain/v1/chat/completions with `"model": "gpt-4o-mini"` returns 200 with the completion, matching the list
6. Nothing to re-run: the CLI keeps working with the same token
7. If the admin sets them a per-member rate limit of 1 with POST https://litellm-domain/team/member_update, the second call in that minute gets 429 `Rate limit exceeded for team_member: ...`
8. If the admin removes them from the team, the next request after that minute returns 403 `Team '...' is not in your team memberships.`; if the user row is deleted the token gets 401 `Authentication Error, user '...' no longer exists.`; and a token minted while they were an admin gets `Only proxy admins and organization admins can list users.` on GET https://litellm-domain/user/list once the role changes


## Relevant issues

## Linear ticket

Resolves LIT-7358

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both runs use the multi-pod shape: two proxy processes per leg, each booted with `--num_workers 2` from `litellm/proxy/dev_config.yaml`, sharing one Postgres database and one Redis. Instance A takes the admin writes with the master key and the `lite login` (real Google SSO in the browser, team `mat438-team` picked at login). Instance B only ever sees the session token that login stored, so every read below crosses instances. The merge base `8a4fae0e17` ran as A=30288 and B=29887, the PR tip `0f10c0624180` as A=50171 and B=29441. Reads are taken right after each admin write (inside the 60s per-worker cache window) and again after `sleep 61`

The user and team were created the same way on both legs before the login (the SSO user's email is redacted here):

```bash
curl -s -X POST http://127.0.0.1:$A/user/new -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"user_id":"mat438-user","user_email":"<sso email>","user_role":"internal_user","auto_create_key":false}'
curl -s -X POST http://127.0.0.1:$A/team/new -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"team_id":"mat438-team","team_alias":"mat438-team","models":["gpt-5.5"],"members_with_roles":[{"role":"user","user_id":"mat438-user"}]}'
curl -s -X POST http://127.0.0.1:$A/user/new -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"user_id":"mat438-admin","user_email":"<sso email>","user_role":"proxy_admin","auto_create_key":false}'
env LITELLM_PROXY_URL=http://127.0.0.1:$A lite login
```

### Before (8a4fae0e17)

Team model change, member removal, and user deletion never reach the token:

```
$ TOKEN=$(lite --base-url http://127.0.0.1:30288 auth print-token)

$ lite --base-url http://127.0.0.1:30288 whoami
Authenticated
User Email: unknown
User ID: mat438-user
User Role: cli
Token age: 0.0 hours

$ lite --base-url http://127.0.0.1:29887 --api-key $TOKEN models list
                 Available Models                 
┏━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┓
┃ ID      ┃ Object ┃ Created          ┃ Owned By ┃
┡━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━┩
│ gpt-5.5 │ model  │ 2023-02-28 10:56 │ openai   │
└─────────┴────────┴──────────────────┴──────────┘

# admin adds gpt-4o-mini to the team through instance A
$ curl -s -X POST http://127.0.0.1:30288/team/update -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"team_id":"mat438-team","models":["gpt-5.5","gpt-4o-mini"]}'
{"team_id": "mat438-team"}

# right away through instance B (inside the 60s per-worker cache window)
$ lite --base-url http://127.0.0.1:29887 --api-key $TOKEN models list
                 Available Models                 
┏━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┓
┃ ID      ┃ Object ┃ Created          ┃ Owned By ┃
┡━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━┩
│ gpt-5.5 │ model  │ 2023-02-28 10:56 │ openai   │
└─────────┴────────┴──────────────────┴──────────┘

$ sleep 61

$ lite --base-url http://127.0.0.1:29887 --api-key $TOKEN models list
                 Available Models                 
┏━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┓
┃ ID      ┃ Object ┃ Created          ┃ Owned By ┃
┡━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━┩
│ gpt-5.5 │ model  │ 2023-02-28 10:56 │ openai   │
└─────────┴────────┴──────────────────┴──────────┘

$ curl -s http://127.0.0.1:29887/v1/chat/completions -H 'Authorization: Bearer $TOKEN' -H 'Content-Type: application/json' -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Say hi in three words"}]}'
{"model": "gpt-4o-mini", "content": "Hello there, friend!", "usage": {"total_tokens": 17}}

# admin removes the user from the team through instance A
$ curl -s -X POST http://127.0.0.1:30288/team/member_delete -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"team_id":"mat438-team","user_id":"mat438-user"}'
{"team_id": "mat438-team", "models": ["gpt-5.5", "gpt-4o-mini"], "members_with_roles": [{"user_id": "default_user_id", "user_email": null, "role": "admin"}]}

$ sleep 61

$ curl -s http://127.0.0.1:29887/models -H 'Authorization: Bearer $TOKEN'
{"data":[{"id":"gpt-5.5","object":"model","created":1677610602,"owned_by":"openai","mode":"chat","max_input_tokens":1050000,"max_output_tokens":128000}],"object":"list"}

# admin deletes the user through instance A
$ curl -s -X POST http://127.0.0.1:30288/user/delete -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"user_ids":["mat438-user"]}'
1

$ sleep 61

$ curl -s http://127.0.0.1:29887/models -H 'Authorization: Bearer $TOKEN'
{"data":[{"id":"gpt-5.5","object":"model","created":1677610602,"owned_by":"openai","mode":"chat","max_input_tokens":1050000,"max_output_tokens":128000}],"object":"list"}
```

A token minted as `proxy_admin` keeps the admin routes after the demotion:

```
$ TOKEN=$(lite --base-url http://127.0.0.1:30288 auth print-token)

$ lite --base-url http://127.0.0.1:30288 whoami
Authenticated
User Email: unknown
User ID: mat438-admin
User Role: cli
Token age: 0.0 hours

$ curl -s 'http://127.0.0.1:29887/user/list?page=1&page_size=50' -H 'Authorization: Bearer $TOKEN'
{"users": ["default_user_id", "mat438-admin"], "total": 2}

# admin demotes the user to internal_user through instance A
$ curl -s -X POST http://127.0.0.1:30288/user/update -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"user_id":"mat438-admin","user_role":"internal_user"}'
{"user_id": "mat438-admin", "user_role": null}

$ sleep 61

$ curl -s 'http://127.0.0.1:29887/user/list?page=1&page_size=50' -H 'Authorization: Bearer $TOKEN'
{"users": ["default_user_id", "mat438-admin"], "total": 2}
```

A per-member rpm limit set after login is never enforced for the session token:

```
$ curl -s -X POST http://127.0.0.1:30288/team/member_update -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"team_id":"mat438-team","user_id":"mat438-user","rpm_limit":1}'
{"user_id":"mat438-user","user_email":null,"team_id":"mat438-team","max_budget_in_team":null,"tpm_limit":null,"rpm_limit":1,"budget_duration":null,"allowed_models":null}

$ curl -s http://127.0.0.1:29887/v1/chat/completions -H 'Authorization: Bearer $TOKEN' -d '{"model":"gpt-4o-mini",...}'  # call 1
HTTP 200 (0.53s) {"content": "Hello there, friend!"}

$ curl -s http://127.0.0.1:29887/v1/chat/completions -H 'Authorization: Bearer $TOKEN' -d '{"model":"gpt-4o-mini",...}'  # call 2
HTTP 200 (0.39s) {"content": "Hello there, friend!"}

$ sleep 61

$ curl -s http://127.0.0.1:29887/v1/chat/completions -H 'Authorization: Bearer $TOKEN' -d '{"model":"gpt-4o-mini",...}'  # call 3
HTTP 200 (0.40s) {"content": "Hello there, friend!"}

$ curl -s http://127.0.0.1:29887/v1/chat/completions -H 'Authorization: Bearer $TOKEN' -d '{"model":"gpt-4o-mini",...}'  # call 4
HTTP 200 (0.40s) {"content": "Hello there, friend!"}
```

### After (0f10c0624180)

The same token follows the team and user rows:

```
$ TOKEN=$(lite --base-url http://127.0.0.1:50171 auth print-token)

$ lite --base-url http://127.0.0.1:50171 whoami
Authenticated
User Email: unknown
User ID: mat438-user
User Role: cli
Token age: 0.0 hours

$ lite --base-url http://127.0.0.1:29441 --api-key $TOKEN models list
                 Available Models                 
┏━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┓
┃ ID      ┃ Object ┃ Created          ┃ Owned By ┃
┡━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━┩
│ gpt-5.5 │ model  │ 2023-02-28 10:56 │ openai   │
└─────────┴────────┴──────────────────┴──────────┘

# admin adds gpt-4o-mini to the team through instance A
$ curl -s -X POST http://127.0.0.1:50171/team/update -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"team_id":"mat438-team","models":["gpt-5.5","gpt-4o-mini"]}'
{"team_id": "mat438-team"}

# right away through instance B (inside the 60s per-worker cache window)
$ lite --base-url http://127.0.0.1:29441 --api-key $TOKEN models list
                 Available Models                 
┏━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┓
┃ ID      ┃ Object ┃ Created          ┃ Owned By ┃
┡━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━┩
│ gpt-5.5 │ model  │ 2023-02-28 10:56 │ openai   │
└─────────┴────────┴──────────────────┴──────────┘

$ sleep 61

$ lite --base-url http://127.0.0.1:29441 --api-key $TOKEN models list
                   Available Models                   
┏━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┓
┃ ID          ┃ Object ┃ Created          ┃ Owned By ┃
┡━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━┩
│ gpt-4o-mini │ model  │ 2023-02-28 10:56 │ openai   │
│ gpt-5.5     │ model  │ 2023-02-28 10:56 │ openai   │
└─────────────┴────────┴──────────────────┴──────────┘

$ curl -s http://127.0.0.1:29441/v1/chat/completions -H 'Authorization: Bearer $TOKEN' -H 'Content-Type: application/json' -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Say hi in three words"}]}'
{"model": "gpt-4o-mini", "content": "Hello there, friend!", "usage": {"total_tokens": 17}}

# admin removes the user from the team through instance A
$ curl -s -X POST http://127.0.0.1:50171/team/member_delete -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"team_id":"mat438-team","user_id":"mat438-user"}'
{"team_id": "mat438-team", "models": ["gpt-5.5", "gpt-4o-mini"], "members_with_roles": [{"user_id": "default_user_id", "user_email": null, "role": "admin"}]}

$ sleep 61

$ lite --base-url http://127.0.0.1:29441 --api-key $TOKEN models list 2>&1 | tail -1
requests.exceptions.HTTPError: 403 Client Error: Forbidden for url: http://127.0.0.1:29441/models

$ curl -s http://127.0.0.1:29441/models -H 'Authorization: Bearer $TOKEN'
{"error":{"message":"Team 'mat438-team' is not in your team memberships.","type":"auth_error","param":"None","code":"403"}}

# admin deletes the user through instance A
$ curl -s -X POST http://127.0.0.1:50171/user/delete -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"user_ids":["mat438-user"]}'
1

$ sleep 61

$ curl -s http://127.0.0.1:29441/models -H 'Authorization: Bearer $TOKEN'
{"error":{"message":"Authentication Error, user 'mat438-user' no longer exists.","type":"auth_error","param":"user_id","code":"401"}}
```

The demoted admin loses the admin routes and keeps what an internal user may do:

```
$ TOKEN=$(lite --base-url http://127.0.0.1:50171 auth print-token)

$ lite --base-url http://127.0.0.1:50171 whoami
Authenticated
User Email: unknown
User ID: mat438-admin
User Role: cli
Token age: 0.0 hours

$ curl -s 'http://127.0.0.1:29441/user/list?page=1&page_size=50' -H 'Authorization: Bearer $TOKEN'
{"users": ["default_user_id", "mat438-admin"], "total": 2}

# admin demotes the user to internal_user through instance A
$ curl -s -X POST http://127.0.0.1:50171/user/update -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"user_id":"mat438-admin","user_role":"internal_user"}'
{"user_id": "mat438-admin", "user_role": null}

# right away through instance B (inside the 60s per-worker cache window)
$ curl -s 'http://127.0.0.1:29441/user/list?page=1&page_size=50' -H 'Authorization: Bearer $TOKEN'
{"users": ["default_user_id", "mat438-admin"], "total": 2}

$ sleep 61

$ curl -s 'http://127.0.0.1:29441/user/list?page=1&page_size=50' -H 'Authorization: Bearer $TOKEN'
{"detail": {"error": "Only proxy admins and organization admins can list users."}}

$ lite --base-url http://127.0.0.1:29441 --api-key $TOKEN models list
│ azure-opus-4-8              │ model  │ 2023-02-28 10:56 │ openai   │
│ gpt-5.5                     │ model  │ 2023-02-28 10:56 │ openai   │
│ gpt-4o-mini                 │ model  │ 2023-02-28 10:56 │ openai   │
└─────────────────────────────┴────────┴──────────────────┴──────────┘
```

A per-member rpm limit set after login applies on the next request, with no wait, because `/team/member_update` broadcasts the membership eviction to every instance:

```
$ curl -s -X POST http://127.0.0.1:50171/team/member_update -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"team_id":"mat438-team","user_id":"mat438-user","rpm_limit":1}'
{"user_id":"mat438-user","user_email":null,"team_id":"mat438-team","max_budget_in_team":null,"tpm_limit":null,"rpm_limit":1,"budget_duration":null,"allowed_models":null}

$ curl -s http://127.0.0.1:29441/v1/chat/completions -H 'Authorization: Bearer $TOKEN' -d '{"model":"gpt-4o-mini",...}'  # call 1
HTTP 200 (1.10s) {"content": "Hello there, friend!"}

$ curl -s http://127.0.0.1:29441/v1/chat/completions -H 'Authorization: Bearer $TOKEN' -d '{"model":"gpt-4o-mini",...}'  # call 2
HTTP 429 (0.02s) {"error": {"message": "Rate limit exceeded for team_member: mat438-team:mat438-user. Limit type: requests. Current limit: 1, Remaining: 0. Limit resets at: 2026-09-12 16:02:06 UTC", "type": "throttling_error", "param": null, "code": "429"}}

$ sleep 61

$ curl -s http://127.0.0.1:29441/v1/chat/completions -H 'Authorization: Bearer $TOKEN' -d '{"model":"gpt-4o-mini",...}'  # call 3
HTTP 200 (0.51s) {"content": "Hello there, friend!"}

$ curl -s http://127.0.0.1:29441/v1/chat/completions -H 'Authorization: Bearer $TOKEN' -d '{"model":"gpt-4o-mini",...}'  # call 4
HTTP 429 (0.02s) {"error": {"message": "Rate limit exceeded for team_member: mat438-team:mat438-user. Limit type: requests. Current limit: 1, Remaining: 0. Limit resets at: 2026-09-12 16:03:07 UTC", "type": "throttling_error", "param": null, "code": "429"}}
```

`/key/generate` with the session token answers the same on both legs (team member permission 401, and 400 for `max_budget` without a team), and `/team/info` matches too, so the token's key-delegation ceilings are untouched

The JWT auth path, which this PR also routes through the new resolver, answered the same on both legs for a member, a non-member carrying a team claim, a missing user, a missing team, a token with no team claim, a per-member rpm limit, and a removed member (same two-instance shape, base on 41917 and 41923, tip on 42811 and 42817), so nothing changed there

Staging moved after the branch point, so the tip was also merged locally with staging `b1360efc2f` (merge commit `082f242a23`, never pushed) and the same two-instance shape came up on that tree against the After leg's database, on 21626 and 25578, with the stored token's `base_url` pointed at the new instance A. The team model refresh, the 403 after `/team/member_delete`, the 401 after `/user/delete`, the immediate 429 on a per-member rpm limit of 1, and the three `/key/generate` answers all came back the same as the After leg, and `prefetch_auth_objects`, which staging now runs after the session refresh, left the refreshed grants alone

Live risk check at 0f10c0624180, two proxies with two workers each per leg, one Postgres and one Redis per leg, real Google SSO and real OpenAI calls:

- Breaking: nothing beyond the change the PR is for. A removed member gets 403, a deleted user 401, and a demoted admin loses the admin routes on the next request after the cache window; the Before leg kept all three working after the admin's change. Those three are the Severe caveat below
- Backward incompatible: `get_team_membership` now stores a plain string under the membership cache key when a member has no `LiteLLM_TeamMembership` row. Every reader of that key on the merged tree (`get_team_membership` itself, the budget reservation reader, and the staging prefetch) treats a non-model value as no row, so nothing breaks, but a pod on the old build reading a key written by a new pod during a rolling deploy logs a deserialize failure and falls back to the DB. No wire field, config key, or schema changed
- Regression risk: `/team/update` with a member budget backfill and `/team/member_add` with a budget both evict the new sentinel through `_evict_created_membership_caches`; that eviction was read, not driven, because the rig only created memberships without budgets (no row, so no eviction to observe) and through `/team/member_update` (which never wrote the sentinel first)
- Dependency graph: `_user_api_key_auth_builder` calling `_refresh_session_token_grants` (verified live, scenarios 1 to 3 on both legs and on the merged tree); `team_grants` into the per-member rate limiter (verified live, 429 on rpm 1); `_get_user_role` into the admin route gate (verified live on both legs, not re-run on the merged tree); `user_models` for a session token with no team (traced only); `GrantResolver.resolve_identity` from `JWTAuthManager` (verified live on both legs with the JWT config, not re-run on the merged tree); `key_management_endpoints` reading `is_session_token` (verified live, three `/key/generate` answers); the sentinel readers named above (two by code read, `get_team_membership` live); Admin UI tokens never set `is_session_token`, so they skip the refresh (code read, dashboard not driven); the MCP gateway's `is_session_token` is an unrelated function that shares the name
- Not verified: a Redis-backed `user_api_key_cache` (`dev_config.yaml` has no cache block, so the sentinel and the eviction only ran through each worker's in-memory cache); the budget backfill eviction path; a session token for a user with no team; scenario 2 and the JWT scenarios on the merged tree; the Admin UI in a browser

Things the run noticed, none of them caused by this PR:

- Before leg: chat to the newly added model already worked, only the list was stale
- `/user/update` echoes `user_role: null` after a successful role change, both legs
- First cross-instance read inside 60s is stale on both legs

## Type

🐛 Bug Fix
🧹 Refactoring

## Caveats (if any)

### Severe

- Changes auth behavior for `lite login` tokens on purpose
  - Removed from the team: 403 on the next request instead of login-time access
  - User row deleted: 401
  - Role changed in the DB: the token follows the DB role, so a demoted admin loses admin routes

### Medium

- The user row is cached for the management object TTL (60s by default), so a role or membership change can lag by up to that long on a pod that already has the row cached
- Each session token request now reads user, membership and team rows, served from the existing auth cache between refreshes
- Membership for a session token is judged from the user row's `teams` list (the same list login offers teams from), not the team row's `members_with_roles`. The two are written separately and can drift after login: a member whose user row lost the team id gets `403 Team '<id>' is not in your team memberships` from the CLI while `/team/info` still lists them (seen once in this run's rig before `/team/member_add` repaired the row). Which list is the source of truth is not stated in the PR

### Low

- When a row read fails for a reason unrelated to the caller (DB down), the grants minted at login stand for that request, same as before. That fallback logs at debug level only, so a DB outage that leaves login-time grants in place does not show up in default logs
- During a rolling deploy, pods still on the previous release read the new no-membership cache marker as a broken entry, log one deserialize error per request and fall through to the DB until the marker expires (60s by default); the answer they give is still correct
- Admin UI dashboard tokens are untouched: only `lite login` marks its token as a session token

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication and authorization for lite login session tokens on every request, including membership denial and role refresh, in security-sensitive proxy auth paths.
> 
> **Overview**
> **Lite login session tokens now re-resolve grants from the database on each authenticated request**, so team models/aliases, user role, and membership are no longer frozen at login time.
> 
> A new **`GrantResolver`** (`litellm/proxy/auth/resolvers/grants.py`) centralizes loading the user row, team row, and team membership with shared rules (canonical user id after email/SSO match, **403** when the user is no longer on the team, **401** when the user is gone). JWT `get_objects` uses `resolve_identity`; the API-key builder calls **`_refresh_session_token_grants`** for `is_session_token` tokens, merging live rows via `team_grants` / `user_models` while keeping minted grants on **`LookupDegraded`** (transient DB failures).
> 
> To avoid a DB read on every session request for members without a **`LiteLLM_TeamMembership`** row, **`get_team_membership`** negative-caches **`NO_TEAM_MEMBERSHIP_SENTINEL`**. **`/team/member_add`** and membership budget backfill on **`/team/update`** evict that sentinel via **`_evict_created_membership_caches`** so new per-member budgets apply immediately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f10c0624180e23fb35da1882ddbcbea1c6421cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

- [x] 0f10c0624180e23fb35da1882ddbcbea1c6421cb passes /live-pr-risk
