### PR TITLE
fix(ui): jump to last Request Logs page

### DIFF
--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -2925,6 +2925,25 @@ async def _fetch_session_representatives(
     return [rep_by_key[key] for key in session_keys if key in rep_by_key]  # mutable-ok: rows are enriched in place
 
 
+def _infer_grouped_total(
+    page: int,
+    has_cursor: bool,
+    offset: int | None,
+    page_rows: Sequence[_SessionPageRow],
+    has_more: bool,
+) -> tuple[int, bool] | None:
+    if has_cursor:
+        return None
+    if page == 1:
+        return (len(page_rows), False) if not has_more else None
+    if offset is None or not page_rows:
+        return None
+    visible_total: Final = offset + len(page_rows)
+    if visible_total > SPEND_LOGS_PAGINATION_COUNT_CAP:
+        return SPEND_LOGS_PAGINATION_COUNT_CAP, True
+    return (visible_total, False) if not has_more else None
+
+
 async def _ui_session_grouped_spend_logs(
     prisma_client: "PrismaClient",
     sql_conditions: Sequence[str],
@@ -2997,22 +3016,32 @@ async def _ui_session_grouped_spend_logs(
         else None
     )
 
-    count_query: Final = f"""
-        SELECT COUNT(*) AS total_count
-        FROM (
-            SELECT 1
-            FROM "LiteLLM_SpendLogs"
-            WHERE {where_clause}
-            GROUP BY {_SESSION_GROUP_KEY_SQL}
-            LIMIT ${next_param_index}
-        ) AS bounded_sessions
-    """
-    count_rows: Final[Sequence[_SpendLogsCountRow]] = await _query_raw(
-        prisma_client, count_query, *sql_params, SPEND_LOGS_PAGINATION_COUNT_CAP + 1
+    inferred_total: Final[tuple[int, bool] | None] = _infer_grouped_total(
+        page=page,
+        has_cursor=cursor is not None,
+        offset=offset,
+        page_rows=page_rows,
+        has_more=has_more,
     )
-    raw_total: Final = int(count_rows[0]["total_count"]) if count_rows else 0
-    total_is_capped: Final = raw_total > SPEND_LOGS_PAGINATION_COUNT_CAP
-    total_records: Final = SPEND_LOGS_PAGINATION_COUNT_CAP if total_is_capped else raw_total
+    if inferred_total is not None:
+        total_records, total_is_capped = inferred_total
+    else:
+        count_query: Final = f"""
+            SELECT COUNT(*) AS total_count
+            FROM (
+                SELECT 1
+                FROM "LiteLLM_SpendLogs"
+                WHERE {where_clause}
+                GROUP BY {_SESSION_GROUP_KEY_SQL}
+                LIMIT ${next_param_index}
+            ) AS bounded_sessions
+        """
+        count_rows: Final[Sequence[_SpendLogsCountRow]] = await _query_raw(
+            prisma_client, count_query, *sql_params, SPEND_LOGS_PAGINATION_COUNT_CAP + 1
+        )
+        raw_total: Final = int(count_rows[0]["total_count"]) if count_rows else 0
+        total_is_capped = raw_total > SPEND_LOGS_PAGINATION_COUNT_CAP
+        total_records = SPEND_LOGS_PAGINATION_COUNT_CAP if total_is_capped else raw_total
 
     session_keys: Final = tuple((row["session_key"], row["api_key"]) for row in visible_rows)
     data: Final[list[dict[str, object]]] = (  # mutable-ok: _build_ui_spend_logs_response writes onto each row

--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -2942,13 +2942,12 @@ async def _ui_session_grouped_spend_logs(
     table): rows sharing a ``session_id`` and ``api_key`` form a session, rows
     without a session id are singletons keyed by ``request_id``. A page is the
     next ``page_size`` sessions ordered by ``(MAX(startTime), session_key,
-    api_key)``, resumed from the ``session_cursor`` keyset
-    ``'<last_activity>|<api_key>|<session_key>'`` instead of an OFFSET, so
-    page depth does not degrade the query plan. Each session is represented
-    by its newest non-MCP row, enriched by ``_build_ui_spend_logs_response``
-    exactly like the flat listing, and the response carries
-    ``next_session_cursor`` / ``has_more`` while ``total`` counts sessions
-    (capped like the flat total).
+    api_key)``. Sequential pages resume from the ``session_cursor`` keyset
+    ``'<last_activity>|<api_key>|<session_key>'``; uncached jumps use the page
+    offset. Each session is represented by its newest non-MCP row, enriched by
+    ``_build_ui_spend_logs_response`` exactly like the flat listing, and the
+    response carries ``next_session_cursor`` / ``has_more`` while ``total``
+    counts sessions (capped like the flat total).
     """
     where_clause: Final = " AND ".join(sql_conditions) if sql_conditions else "TRUE"
     cmp_op: Final = "<" if sort_desc else ">"
@@ -2963,6 +2962,16 @@ async def _ui_session_grouped_spend_logs(
     )
     cursor_params: Final[tuple[object, ...]] = cursor if cursor else ()
     limit_index: Final = next_param_index + len(cursor_params)
+    offset: Final = (page - 1) * page_size if cursor is None and page > 1 else None
+    if offset is not None and offset >= SPEND_LOGS_PAGINATION_COUNT_CAP:
+        raise ProxyException(
+            message="Page exceeds the maximum supported session offset",
+            type="bad_request",
+            param="page",
+            code=status.HTTP_400_BAD_REQUEST,
+        )
+    offset_clause: Final = f"OFFSET ${limit_index + 1}" if offset is not None else ""
+    offset_params: Final[tuple[object, ...]] = (offset,) if offset is not None else ()
 
     page_query: Final = f"""
         SELECT {_SESSION_KEY_EXPR} AS session_key,
@@ -2974,9 +2983,10 @@ async def _ui_session_grouped_spend_logs(
         {having_clause}
         ORDER BY MAX("startTime") {direction}, {_SESSION_KEY_EXPR} {direction}, api_key {direction}
         LIMIT ${limit_index}
+        {offset_clause}
     """
     page_rows: Final[Sequence[_SessionPageRow]] = await _query_raw(
-        prisma_client, page_query, *sql_params, *cursor_params, page_size + 1
+        prisma_client, page_query, *sql_params, *cursor_params, page_size + 1, *offset_params
     )
 
     has_more: Final = len(page_rows) > page_size

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -6718,12 +6718,14 @@ async def test_ui_view_spend_logs_group_by_session_cursor_page(client, monkeypat
                 "end_date": end_date,
                 "group_by_session": "true",
                 "session_cursor": "2026-08-29 09:00:00|hashed-key|req-solo",
+                "page": 401,
                 "page_size": 2,
             },
             headers={"Authorization": "Bearer sk-test"},
         )
         assert response.status_code == 200, response.text
         data = response.json()
+        assert data["page"] == 401
         assert data["has_more"] is False
         assert data["next_session_cursor"] is None
         assert [row["request_id"] for row in data["data"]] == ["req-2"]
@@ -6738,6 +6740,159 @@ async def test_ui_view_spend_logs_group_by_session_cursor_page(client, monkeypat
             "req-solo",
             "hashed-key",
         ), "cursor params must line up with (MAX(startTime), session key, api_key)"
+    finally:
+        app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+
+@pytest.mark.asyncio
+async def test_ui_view_spend_logs_group_by_session_capped_cursor_continues(client, monkeypatch):
+    page_rows = [
+        _session_page_row(f"sess-{index}", f"2026-08-29 09:{59 - index:02d}:00") for index in range(26)
+    ]
+    cursor_page_rows = [_session_page_row("sess-26", "2026-08-29 09:33:00")]
+    reps = [_session_representative_row(f"req-{index}", f"sess-{index}") for index in range(27)]
+    mock_prisma = _session_grouped_mock_prisma(page_rows, 10001, reps)
+    original_query_raw = mock_prisma.db.query_raw.side_effect
+
+    async def cursor_aware_query_raw(sql_query, *params):
+        if "HAVING" in sql_query:
+            return cursor_page_rows
+        return await original_query_raw(sql_query, *params)
+
+    mock_prisma.db.query_raw.side_effect = cursor_aware_query_raw
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma)
+    monkeypatch.setattr(
+        "litellm.proxy.spend_tracking.spend_management_endpoints._is_admin_view_safe",
+        lambda user_api_key_dict: True,
+    )
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin_user"
+    )
+    try:
+        start_date, end_date = _default_date_range()
+        capped_page = client.get(
+            "/spend/logs/ui",
+            params={
+                "start_date": start_date,
+                "end_date": end_date,
+                "group_by_session": "true",
+                "page": 400,
+                "page_size": 25,
+            },
+            headers={"Authorization": "Bearer sk-test"},
+        )
+        assert capped_page.status_code == 200, capped_page.text
+        capped_data = capped_page.json()
+        assert capped_data["total"] == 10000
+        assert capped_data["total_is_capped"] is True
+        assert capped_data["has_more"] is True
+        assert capped_data["next_session_cursor"] == "2026-08-29 09:35:00|hashed-key|sess-24"
+
+        continuation = client.get(
+            "/spend/logs/ui",
+            params={
+                "start_date": start_date,
+                "end_date": end_date,
+                "group_by_session": "true",
+                "page": 401,
+                "page_size": 25,
+                "session_cursor": capped_data["next_session_cursor"],
+            },
+            headers={"Authorization": "Bearer sk-test"},
+        )
+        assert continuation.status_code == 200, continuation.text
+        continuation_data = continuation.json()
+        assert continuation_data["page"] == 401
+        assert continuation_data["has_more"] is False
+        assert [row["request_id"] for row in continuation_data["data"]] == ["req-26"]
+        continuation_query = next(
+            call.args[0] for call in mock_prisma.db.query_raw.await_args_list if "HAVING" in call.args[0]
+        )
+        assert "OFFSET" not in continuation_query
+    finally:
+        app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+
+@pytest.mark.asyncio
+async def test_ui_view_spend_logs_group_by_session_uncached_page_uses_offset(client, monkeypatch):
+    page_rows = [
+        _session_page_row("sess-7", "2026-08-29 07:00:00"),
+        _session_page_row("sess-8", "2026-08-29 06:00:00"),
+        _session_page_row("sess-9", "2026-08-29 05:00:00"),
+    ]
+    reps = [
+        _session_representative_row("req-7", "sess-7"),
+        _session_representative_row("req-8", "sess-8"),
+    ]
+    mock_prisma = _session_grouped_mock_prisma(page_rows, 9, reps)
+    original_query_raw = mock_prisma.db.query_raw.side_effect
+
+    async def page_aware_query_raw(sql_query, *params):
+        if 'MAX("startTime")::text AS last_activity' in sql_query and params[-2:] != (3, 6):
+            return []
+        return await original_query_raw(sql_query, *params)
+
+    mock_prisma.db.query_raw.side_effect = page_aware_query_raw
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma)
+    monkeypatch.setattr(
+        "litellm.proxy.spend_tracking.spend_management_endpoints._is_admin_view_safe",
+        lambda user_api_key_dict: True,
+    )
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin_user"
+    )
+    try:
+        start_date, end_date = _default_date_range()
+        response = client.get(
+            "/spend/logs/ui",
+            params={
+                "start_date": start_date,
+                "end_date": end_date,
+                "group_by_session": "true",
+                "page": 4,
+                "page_size": 2,
+            },
+            headers={"Authorization": "Bearer sk-test"},
+        )
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert data["page"] == 4
+        assert data["total"] == 9
+        assert data["total_pages"] == 5
+        assert data["has_more"] is True
+        assert data["next_session_cursor"] == "2026-08-29 06:00:00|hashed-key|sess-8"
+        assert [row["request_id"] for row in data["data"]] == ["req-7", "req-8"]
+
+        page_query_call = mock_prisma.db.query_raw.await_args_list[0]
+        page_query_sql = page_query_call.args[0]
+        assert "HAVING" not in page_query_sql
+        assert "OFFSET" in page_query_sql
+        assert page_query_call.args[-2:] == (3, 6)
+    finally:
+        app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+
+def test_ui_view_spend_logs_rejects_grouped_page_past_count_cap(client, monkeypatch):
+    mock_prisma = MagicMock()
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma)
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin_user"
+    )
+    try:
+        start_date, end_date = _default_date_range()
+        response = client.get(
+            "/spend/logs/ui",
+            params={
+                "start_date": start_date,
+                "end_date": end_date,
+                "group_by_session": "true",
+                "page": 401,
+                "page_size": 25,
+            },
+            headers={"Authorization": "Bearer sk-test"},
+        )
+        assert response.status_code == 400
+        assert response.json()["error"]["param"] == "page"
     finally:
         app.dependency_overrides.pop(ps.user_api_key_auth, None)
 
@@ -6772,6 +6927,7 @@ async def test_ui_view_spend_logs_group_by_session_offset_for_non_starttime_sort
                 "end_date": end_date,
                 "group_by_session": "true",
                 "session_cursor": "2026-08-29 09:00:00|hashed-key|req-solo",
+                "page": 401,
                 "sort_by": "spend",
             },
             headers={"Authorization": "Bearer sk-test"},
@@ -6816,6 +6972,7 @@ async def test_ui_view_spend_logs_search_returns_flat_rows_when_grouping_by_sess
             params={
                 "search": "sess-1",
                 "group_by_session": "true",
+                "page": 401,
                 "start_date": start_date,
                 "end_date": end_date,
             },
@@ -6826,6 +6983,32 @@ async def test_ui_view_spend_logs_search_returns_flat_rows_when_grouping_by_sess
         assert [row["request_id"] for row in data["data"]] == ["req-1", "req-2"]
         assert data["total"] == 2
         assert "next_session_cursor" not in data
+    finally:
+        app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+
+def test_spend_logs_v2_grouped_page_is_not_limited_by_ui_offset_cap(client, monkeypatch):
+    mock_prisma = _session_grouped_mock_prisma([], 0, [])
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma)
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin_user"
+    )
+    try:
+        start_date, end_date = _default_date_range()
+        response = client.get(
+            "/spend/logs/v2",
+            params={
+                "start_date": start_date,
+                "end_date": end_date,
+                "group_by_session": "true",
+                "page": 401,
+                "page_size": 25,
+            },
+            headers={"Authorization": "Bearer sk-test"},
+        )
+        assert response.status_code == 200, response.text
+        emitted_sql = [call.args[0] for call in mock_prisma.db.query_raw.await_args_list]
+        assert "OFFSET" in emitted_sql[1]
     finally:
         app.dependency_overrides.pop(ps.user_api_key_auth, None)
 

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -6629,6 +6629,21 @@ def _session_page_row(session_key, last_activity):
     return {"session_key": session_key, "api_key": "hashed-key", "last_activity": last_activity}
 
 
+def test_infer_grouped_total_from_page_lookahead():
+    from litellm.proxy.spend_tracking.spend_management_endpoints import _infer_grouped_total
+
+    assert _infer_grouped_total(1, False, None, [], False) == (0, False)
+    assert _infer_grouped_total(1, False, None, [_session_page_row("sess-1", "time")], False) == (1, False)
+    assert _infer_grouped_total(1, False, None, [_session_page_row("sess-1", "time")] * 2, True) is None
+    assert _infer_grouped_total(4, False, 6, [_session_page_row("sess-1", "time")], False) == (7, False)
+    assert _infer_grouped_total(4, False, 6, [], False) is None
+    assert _infer_grouped_total(400, False, 9975, [_session_page_row("sess-1", "time")] * 26, True) == (
+        10000,
+        True,
+    )
+    assert _infer_grouped_total(1, True, None, [_session_page_row("sess-1", "time")], False) is None
+
+
 @pytest.mark.asyncio
 async def test_ui_view_spend_logs_group_by_session_first_page(client, monkeypatch):
     """One row per (session, api_key), session-count total, and a keyset cursor for the next page."""

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_query_optimization.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_query_optimization.py
@@ -575,14 +575,7 @@ async def test_spend_logs_ui_group_by_session_paginates_sessions(monkeypatch):
     assert "OFFSET" not in page_sql, "the startTime page must be keyset-selected, not offset-selected"
     assert emitted[0][-1] == 51, "the page query fetches page_size + 1 sessions to detect has_more"
 
-    count_call = emitted[1]
-    count_sql = count_call[0]
-    assert f"GROUP BY {group_key}" in count_sql, f"grouped total must count sessions. SQL was:\n{count_sql}"
-    assert "COUNT(*) OVER ()" not in count_sql
-    assert "LIMIT" in count_sql and "FROM (" in count_sql, "the grouped count must stay bounded"
-    assert count_call[-1] == SPEND_LOGS_PAGINATION_COUNT_CAP + 1
-
-    rep_sql = emitted[2][0]
+    rep_sql = emitted[1][0]
     assert f"DISTINCT ON ({group_key})" in rep_sql, f"page must return one row per session. SQL was:\n{rep_sql}"
     assert f"ORDER BY {group_key}, call_type IN ('call_mcp_tool', 'list_mcp_tools'), \"startTime\" DESC" in rep_sql, (
         "the session representative must prefer the newest non-MCP call"
@@ -590,7 +583,7 @@ async def test_spend_logs_ui_group_by_session_paginates_sessions(monkeypatch):
     assert "COUNT(*) OVER ()" not in rep_sql
 
     assert [row["request_id"] for row in response["data"]] == ["req-1", "req-2"]
-    assert response["total"] == 12
+    assert response["total"] == 2
     assert response["total_is_capped"] is False
     assert response["total_pages"] == 1
     assert response["has_more"] is False

--- a/ui/litellm-dashboard/src/components/view_logs/RequestLogsPanel.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/RequestLogsPanel.test.tsx
@@ -258,6 +258,43 @@ describe("RequestLogsPanel", () => {
       });
     });
 
+    it("navigates to the last page without using the next-page cursor", async () => {
+      const firstPage = Array.from({ length: 25 }, (_, index) => logEntry({ request_id: `req-${index}` }));
+      const lastPage = Array.from({ length: 25 }, (_, index) => logEntry({ request_id: `last-${index}` }));
+      vi.mocked(uiSpendLogsCall).mockImplementation(async ({ page }) =>
+        page === 4
+          ? {
+              data: lastPage,
+              total: 100,
+              page: 4,
+              page_size: 25,
+              total_pages: 4,
+              next_session_cursor: null,
+              has_more: false,
+            }
+          : {
+              data: firstPage,
+              total: 100,
+              page: 1,
+              page_size: 25,
+              total_pages: 4,
+              next_session_cursor: "2026-07-07 09:50:13|key-1|sess-1",
+              has_more: true,
+            },
+      );
+      renderPanel();
+
+      await waitFor(() => expect(row("req-0")).not.toBeNull());
+      fireEvent.click(screen.getByTestId("pagination-last"));
+
+      await waitFor(() => expect(row("last-0")).not.toBeNull());
+      expect(lastCall()?.page).toBe(4);
+      expect(lastCall()?.params?.session_cursor).toBeUndefined();
+      expect(screen.getByTestId("pagination-page")).toHaveTextContent("Page 4 of 4");
+      expect(screen.getByTestId("pagination-next")).toBeDisabled();
+      expect(screen.getByTestId("pagination-last")).toBeDisabled();
+    });
+
     it("drops the cursor and returns to the first page when a filter changes", async () => {
       const firstPage = Array.from({ length: 50 }, (_, index) => logEntry({ request_id: `req-${index}` }));
       vi.mocked(uiSpendLogsCall).mockResolvedValue({
@@ -394,6 +431,27 @@ describe("RequestLogsPanel", () => {
         expect(call.page).toBe(1);
       });
       expect(lastCall()?.params?.request_id).toBeUndefined();
+      expect(lastCall()?.params?.session_cursor).toBeUndefined();
+    });
+
+    it("navigates search results without a session cursor", async () => {
+      const initialRows = Array.from({ length: 25 }, (_, index) => logEntry({ request_id: `initial-${index}` }));
+      const searchRows = Array.from({ length: 25 }, (_, index) => logEntry({ request_id: `search-${index}` }));
+      vi.mocked(uiSpendLogsCall).mockImplementation(async ({ params }) => ({
+        data: params?.search ? searchRows : initialRows,
+        total: 80,
+        page: 1,
+        page_size: 25,
+        total_pages: 4,
+      }));
+      renderPanel();
+
+      await waitFor(() => expect(row("initial-0")).not.toBeNull());
+      fireEvent.change(screen.getByTestId("datatable-search"), { target: { value: "req-search" } });
+      await waitFor(() => expect(row("search-0")).not.toBeNull());
+      fireEvent.click(screen.getByTestId("pagination-next"));
+
+      await waitFor(() => expect(lastCall()?.page).toBe(2));
       expect(lastCall()?.params?.session_cursor).toBeUndefined();
     });
 

--- a/ui/litellm-dashboard/src/components/view_logs/RequestLogsPanel.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/RequestLogsPanel.tsx
@@ -213,11 +213,13 @@ export default function RequestLogsPanel({ accessToken, token, userRole, userID,
         setPagination(requested);
         return;
       }
-      const nextCursor = filteredLogs.next_session_cursor;
-      if (!nextCursor || logsQuery.isPlaceholderData) return;
+      if (logsQuery.isPlaceholderData) return;
       const nextPageIndex = pagination.pageIndex + 1;
-      setSessionCursors((previous) => ({ ...previous, [nextPageIndex]: nextCursor }));
-      setPagination({ ...requested, pageIndex: nextPageIndex });
+      const nextCursor = filteredLogs.next_session_cursor;
+      if (requested.pageIndex === nextPageIndex && nextCursor) {
+        setSessionCursors((previous) => ({ ...previous, [nextPageIndex]: nextCursor }));
+      }
+      setPagination(requested);
     },
     [usesSessionCursor, pagination, filteredLogs.next_session_cursor, logsQuery.isPlaceholderData],
   );


### PR DESCRIPTION
## TLDR

Problem this solves:

- Request Logs `>>` only advances one page
- Cursorless jumps are bounded without limiting cursor traversal

How it solves it:

- Non-adjacent jumps use bounded grouped offsets
- Page lookahead reuses proven totals and count caps

## User Flow

Before: an admin cannot jump from the first Request Logs page to the displayed last page

1. They open http://localhost:3000/logs/ and see `Page 1 of 400`
2. They click `>>`, labeled `Go to last page`
3. The footer shows `Page 2 of 400`

After: the same click lands directly on the last displayed page

1. They open http://localhost:3000/logs/ and see `Page 1 of 400`
2. They click `>>`, labeled `Go to last page`
3. The footer shows `Page 400 of 400`, with `>` and `>>` disabled

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible
- [x] I have received a Greptile Confidence Score of at least 4/5

## Screenshots / Proof of Fix

Both legs used the real dashboard against a live proxy and isolated Postgres with 120,000 request-log rows

### Before (8a4fae0e17)

1. Open http://localhost:3091/logs/. The footer shows `Page 1 of 400`
2. Click `>>` once. The browser requests `page=2` and the footer shows `Page 2 of 400`

### After (1674f4a1dc)

1. Open http://localhost:3091/logs/. The footer shows `Page 1 of 400`
2. Click `>>` once. The browser requests `page=400` without a session cursor
3. The footer shows `Page 400 of 400`, with `>` and `>>` disabled
4. The 25 returned identities match an independent grouped database query at offset 9,975
5. Page 401 with that cursor returns 200; page 401 without it returns 400
6. Partial or capped cursorless pages reuse their page lookahead instead of rerunning the grouped count

The page-400 grouped query ran in 115.6 ms over 65,462 matching rows and 62,734 groups, with a 2.3 MB top-N sort

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- The existing 10,000-session count cap defines the last displayed page
- Uncached jumps cost more than sequential keyset navigation
- Cursor pages and ambiguous empty offsets still run the bounded count query

## Final Attestation

- [x] The tests check the user-visible workflow and reject incorrect row selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes spend-log grouped pagination SQL and totals inference; incorrect offset/cursor handling could return wrong rows or totals, though scope is limited to the UI grouped-by-session path with new tests.
> 
> **Overview**
> Fixes **Request Logs** pagination so **“go to last page”** and other non-adjacent jumps work when logs are **grouped by session**, instead of only advancing one keyset page at a time.
> 
> The UI now applies the requested page index directly for forward jumps; it only attaches `session_cursor` when moving to the **immediate** next page. The grouped `/spend/logs/ui` backend adds **bounded SQL `OFFSET`** for cursorless page requests (while keeping keyset `HAVING` when a cursor is present), returns **400** when the implied offset reaches the existing **10,000-session cap**, and uses **`_infer_grouped_total`** to derive totals from page lookahead when possible—skipping the extra grouped `COUNT` on many first/last-page cases. Tests cover offset vs cursor behavior, cap continuation, v2 not sharing the UI offset rejection, and dashboard last-page/search pagination.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9fb0031bb18b3cdc06575067211d7fbd7cf3c2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



