### PR TITLE
docs(router): name both affinity TTL knobs in the _claim_pin docstring

### DIFF
--- a/litellm/router_utils/pre_call_checks/deployment_affinity_check.py
+++ b/litellm/router_utils/pre_call_checks/deployment_affinity_check.py
@@ -349,7 +349,9 @@ class DeploymentAffinityCheck(CustomLogger):
         first write instead of the last. Re-claiming with the stored value refreshes its
         TTL, the same keepalive the complexity router's model pin documents: an active
         session must not lose its pin mid-conversation just because it outlives the
-        original write, so `session_affinity_ttl_seconds` bounds idle time, not total
+        original write, so the affinity TTL (the Router's
+        `deployment_affinity_ttl_seconds`, or a pre-routing hook's per-request
+        `session_affinity_ttl_seconds` override) bounds idle time, not total
         session length. On Redis one Lua script does the get-or-set-or-refresh
         atomically (same registration seam the rate limiters use) and the in-memory
         tier is synchronized to the winner; without Redis, and whenever Redis is


### PR DESCRIPTION
## What

The `_claim_pin` docstring cites `session_affinity_ttl_seconds` as the keepalive bound, but the Router-level knob that actually feeds its `ttl_seconds` parameter is `deployment_affinity_ttl_seconds` (router.py, default 3600); `session_affinity_ttl_seconds` is the separate per-request override on `PreRoutingHookResponse` (types/router.py) consumed in the auto-router marker path. Anyone grepping the docstring's name to tune the Router default lands on the override instead. The docstring now names both, scoped correctly.

Docstring-only change; `tests/test_litellm/router_utils/pre_call_checks/` 109 passed.

## Type

📖 Documentation