### PR TITLE
fix(mcp): explain refused OAuth registration and bound discovery retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,8 @@ curl -X POST 'http://0.0.0.0:4000/v1/chat/completions' \
 }
 ```
 
+For MCP OAuth, an upstream may advertise dynamic client registration but refuse requests with HTTP 401 or 403. If the provider requires a pre-registered OAuth app, configure its `credentials.client_id` and, when required, `credentials.client_secret` on the MCP server. This skips dynamic registration in the gateway sign-in flow. The provider must approve the app for MCP access; reaching its authorization page does not establish that login or tool calls will succeed
+
 [**Docs: MCP Gateway**](https://docs.litellm.ai/docs/mcp)
 
 </details>

--- a/litellm/proxy/_experimental/mcp_server/faults/__init__.py
+++ b/litellm/proxy/_experimental/mcp_server/faults/__init__.py
@@ -22,6 +22,7 @@ from litellm.proxy._experimental.mcp_server.faults.types import (
     GatewayRejected,
     UpstreamOAuthFault,
     UpstreamProtocolFault,
+    UpstreamRegistrationRefused,
     UpstreamReportedFault,
 )
 
@@ -31,6 +32,7 @@ __all__ = [
     "GatewayRejected",
     "UpstreamOAuthFault",
     "UpstreamProtocolFault",
+    "UpstreamRegistrationRefused",
     "UpstreamReportedFault",
     "classify_upstream_dcr_rejection",
     "classify_upstream_token_rejection",

--- a/litellm/proxy/_experimental/mcp_server/faults/classify.py
+++ b/litellm/proxy/_experimental/mcp_server/faults/classify.py
@@ -21,6 +21,7 @@ from litellm.proxy._experimental.mcp_server.faults.types import (
     GatewayRejected,
     UpstreamOAuthFault,
     UpstreamProtocolFault,
+    UpstreamRegistrationRefused,
     UpstreamReportedFault,
 )
 
@@ -122,11 +123,13 @@ def classify_upstream_dcr_rejection(response: httpx.Response, log_context: str) 
     """Classify a dynamic-client-registration rejection. RFC 7591 §3.2.2 errors carry
     ``error`` / ``error_description`` and go through the same blame assignment as token errors
     (registration sends no client credentials, so credential codes stay caller-actionable); anything
-    without a usable ``error`` field is an upstream protocol fault."""
+    without a usable ``error`` field is a registration refusal for 401/403 and a protocol fault otherwise."""
     parsed: Final = _safe_json(response)
     fields: Final = parsed if isinstance(parsed, dict) else {}
     code: Final = _bounded_field(fields.get("error"))
     if code is None:
+        if response.status_code == 401 or response.status_code == 403:
+            return UpstreamRegistrationRefused(status_code=response.status_code)
         _log_out_of_contract("registration", response, log_context)
         return UpstreamProtocolFault(note=f"upstream registration failed with HTTP {response.status_code}")
     return _classify_oauth_error_code(

--- a/litellm/proxy/_experimental/mcp_server/faults/render_oauth.py
+++ b/litellm/proxy/_experimental/mcp_server/faults/render_oauth.py
@@ -43,6 +43,16 @@ def _registration_refused_description(status_code: int) -> str:
     )
 
 
+def _render_caller_rejected(fault: CallerRejected) -> JSONResponse:
+    content: Final = {
+        "error": fault.code,
+        **({"error_description": fault.description} if fault.description else {}),
+        **({"error_uri": fault.error_uri} if fault.error_uri else {}),
+    }
+    status_code: Final = 401 if fault.code == "invalid_client" else 400
+    return JSONResponse(status_code=status_code, content=content, headers=TOKEN_NO_CACHE_HEADERS)
+
+
 def render_token_fault(fault: UpstreamOAuthFault) -> JSONResponse:
     """RFC 6749 §5.2 response for a token-endpoint fault. Caller-actionable rejections relay the
     upstream's code on the status that code implies (401 for invalid_client per §5.2, else 400);
@@ -50,13 +60,7 @@ def render_token_fault(fault: UpstreamOAuthFault) -> JSONResponse:
     blamed for, or shown the internals of, a failure only the operator can fix."""
     match fault.tag:
         case "caller_rejected":
-            content: Final = {
-                "error": fault.code,
-                **({"error_description": fault.description} if fault.description else {}),
-                **({"error_uri": fault.error_uri} if fault.error_uri else {}),
-            }
-            status_code = 401 if fault.code == "invalid_client" else 400
-            return JSONResponse(status_code=status_code, content=content, headers=TOKEN_NO_CACHE_HEADERS)
+            return _render_caller_rejected(fault)
         case "gateway_rejected":
             return JSONResponse(
                 status_code=502,
@@ -74,7 +78,7 @@ def render_token_fault(fault: UpstreamOAuthFault) -> JSONResponse:
                 headers=TOKEN_NO_CACHE_HEADERS,
             )
         case "upstream_registration_refused":
-            return render_token_fault(
+            return _render_caller_rejected(
                 CallerRejected(
                     code="unauthorized_client",
                     description=_registration_refused_description(fault.status_code),

--- a/litellm/proxy/_experimental/mcp_server/faults/render_oauth.py
+++ b/litellm/proxy/_experimental/mcp_server/faults/render_oauth.py
@@ -11,7 +11,7 @@ from typing import Final
 from fastapi.responses import JSONResponse
 from typing_extensions import assert_never
 
-from litellm.proxy._experimental.mcp_server.faults.types import UpstreamOAuthFault
+from litellm.proxy._experimental.mcp_server.faults.types import CallerRejected, UpstreamOAuthFault
 from litellm.proxy._experimental.mcp_server.oauth_utils import TOKEN_NO_CACHE_HEADERS
 
 
@@ -33,6 +33,14 @@ def _upstream_reported_status_and_description(code: str) -> tuple[int, str]:
     if code == "temporarily_unavailable":
         return 503, "the upstream authorization server is temporarily unavailable; retry shortly"
     return 502, "the upstream authorization server reported an internal error"
+
+
+def _registration_refused_description(status_code: int) -> str:
+    return (
+        f"the upstream authorization server refused dynamic client registration (HTTP {status_code}). "
+        "This provider may require a pre-registered OAuth client. Configure client_id and, if required "
+        "by the provider, client_secret for this MCP server to skip dynamic registration"
+    )
 
 
 def render_token_fault(fault: UpstreamOAuthFault) -> JSONResponse:
@@ -65,6 +73,13 @@ def render_token_fault(fault: UpstreamOAuthFault) -> JSONResponse:
                 content={"error": fault.code, "error_description": description},
                 headers=TOKEN_NO_CACHE_HEADERS,
             )
+        case "upstream_registration_refused":
+            return render_token_fault(
+                CallerRejected(
+                    code="unauthorized_client",
+                    description=_registration_refused_description(fault.status_code),
+                )
+            )
         case "upstream_protocol_fault":
             return JSONResponse(
                 status_code=502,
@@ -78,7 +93,7 @@ def render_token_fault(fault: UpstreamOAuthFault) -> JSONResponse:
 def dcr_fault_detail(fault: UpstreamOAuthFault) -> tuple[int, str]:
     """Status and detail string for a registration fault, raised as HTTPException by the caller.
     RFC 7591 §3.2.2 defines registration errors as 400, so a contract-conformant rejection is 400
-    regardless of the status the upstream chose; everything else is a 502 upstream fault."""
+    regardless of the upstream status; a bare 401/403 is a registration refusal rendered as 403."""
     match fault.tag:
         case "caller_rejected":
             detail: Final = f"{fault.code}: {fault.description}" if fault.description else fault.code
@@ -87,6 +102,8 @@ def dcr_fault_detail(fault: UpstreamOAuthFault) -> tuple[int, str]:
             return 502, _gateway_rejected_description(fault.code)
         case "upstream_reported_fault":
             return _upstream_reported_status_and_description(fault.code)
+        case "upstream_registration_refused":
+            return 403, _registration_refused_description(fault.status_code)
         case "upstream_protocol_fault":
             return 502, fault.note
         case _:

--- a/litellm/proxy/_experimental/mcp_server/faults/types.py
+++ b/litellm/proxy/_experimental/mcp_server/faults/types.py
@@ -77,4 +77,12 @@ class UpstreamProtocolFault(BaseModel):
     note: str
 
 
-UpstreamOAuthFault: TypeAlias = CallerRejected | GatewayRejected | UpstreamReportedFault | UpstreamProtocolFault
+class UpstreamRegistrationRefused(BaseModel):
+    model_config = ConfigDict(frozen=True)
+    tag: Literal["upstream_registration_refused"] = "upstream_registration_refused"
+    status_code: Literal[401, 403]
+
+
+UpstreamOAuthFault: TypeAlias = (
+    CallerRejected | GatewayRejected | UpstreamReportedFault | UpstreamProtocolFault | UpstreamRegistrationRefused
+)

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -254,6 +254,7 @@ _TRUE_ENV_VALUES: Final = frozenset(("1", "true", "yes", "on"))
 _OAUTH_DISCOVERY_RETRY_DELAYS_SECONDS: Final = (0.05, 0.15)
 _OAUTH_DISCOVERY_RETRY_BASE_SECONDS: Final = 30.0
 _OAUTH_DISCOVERY_RETRY_MAX_SECONDS: Final = 900.0
+_OAUTH_TEMPORARY_DISCOVERY_TTL_SECONDS: Final = 300.0
 
 
 def _oauth_discovery_now() -> float:
@@ -1898,6 +1899,10 @@ class MCPServerManager:
         slot: Final = self._oauth_discovery_slot(server_id)
         return slot is not None and slot.generation == generation
 
+    def _expire_temporary_oauth_discovery(self, server_id: str, generation: int) -> None:
+        if self._oauth_discovery_slot_is_current(server_id, generation):
+            self._remove_oauth_discovery_slot(server_id)
+
     def _publish_resolved_oauth_server(
         self,
         server: MCPServer,
@@ -1910,6 +1915,12 @@ class MCPServerManager:
         elif server.server_id in self.config_mcp_servers:
             self.config_mcp_servers[server.server_id] = server
         else:
+            asyncio.get_running_loop().call_later(
+                _OAUTH_TEMPORARY_DISCOVERY_TTL_SECONDS,
+                self._expire_temporary_oauth_discovery,
+                server.server_id,
+                generation,
+            )
             return server
         self._remove_oauth_discovery_slot(server.server_id)
         return server

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -1910,7 +1910,7 @@ class MCPServerManager:
         elif server.server_id in self.config_mcp_servers:
             self.config_mcp_servers[server.server_id] = server
         else:
-            return None
+            return server
         self._remove_oauth_discovery_slot(server.server_id)
         return server
 
@@ -2002,6 +2002,12 @@ class MCPServerManager:
         if slot.task is not None:
             if not slot.task.done() or _oauth_discovery_now() < slot.retry_not_before:
                 return slot.task, slot.generation
+            if (
+                not slot.task.cancelled()
+                and slot.task.exception() is None
+                and isinstance(slot.task.result(), _OAuthDiscoveryResolved)
+            ):
+                return slot.task, slot.generation
         task: Final = asyncio.create_task(
             self._run_oauth_metadata_resolution(self._registered_server(server), slot.generation)
         )
@@ -2031,7 +2037,7 @@ class MCPServerManager:
             if should_defer != has_slot:
                 self._set_oauth_discovery_deferred(server.server_id, should_defer)
 
-    async def ensure_oauth_metadata_discovered(self, server: MCPServer) -> MCPServer:
+    async def ensure_oauth_metadata_discovered(self, server: MCPServer, *, _retry_stale: bool = True) -> MCPServer:
         """Join the bounded discovery task and return the resolved server.
 
         Concurrent callers share one task per server. A failed attempt remains
@@ -2058,13 +2064,13 @@ class MCPServerManager:
             outcome: Final = await asyncio.shield(task)
         except asyncio.CancelledError:
             if task.cancelled() and not self._oauth_discovery_slot_is_current(server.server_id, generation):
-                return await self.ensure_oauth_metadata_discovered(server)
+                return await self._rejoin_oauth_metadata_discovery(server, retry_stale=_retry_stale)
             raise
         match outcome:
             case _OAuthDiscoveryResolved(resolved_server):
                 return resolved_server
             case _OAuthDiscoveryStale():
-                return await self.ensure_oauth_metadata_discovered(server)
+                return await self._rejoin_oauth_metadata_discovery(server, retry_stale=_retry_stale)
             case _OAuthDiscoveryFailed(timed_out=timed_out):
                 current: Final = self._registered_server(server)
                 if current.is_client_forwarded_token:
@@ -2075,6 +2081,14 @@ class MCPServerManager:
                     status_code=503,
                     detail=f"OAuth metadata discovery {reason} for MCP server {server_ref!r}",
                 )
+
+    async def _rejoin_oauth_metadata_discovery(self, server: MCPServer, *, retry_stale: bool) -> MCPServer:
+        if retry_stale:
+            return await self.ensure_oauth_metadata_discovered(server, _retry_stale=False)
+        current: Final = self._registered_server(server)
+        if not _oauth_endpoints_unresolved(current) or current.is_client_forwarded_token:
+            return current
+        raise HTTPException(status_code=503, detail="OAuth metadata discovery changed repeatedly; retry shortly")
 
     def _remember_upstream_initialize_instructions(self, server: MCPServer, client: MCPClient) -> None:
         raw: Final[str | None] = getattr(client, "_last_initialize_instructions", None)

--- a/tests/test_litellm/proxy/_experimental/mcp_server/faults/test_classify.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/faults/test_classify.py
@@ -1,6 +1,9 @@
 """Classification matrix for upstream OAuth/DCR rejections: who is blamed depends only on the §5.2
 code and whose credentials the gateway presented, never on the upstream's HTTP status."""
 
+from typing import Final
+
+import pytest
 import httpx
 
 from litellm.proxy._experimental.mcp_server.faults.classify import (
@@ -12,6 +15,7 @@ from litellm.proxy._experimental.mcp_server.faults.types import (
     GatewayRejected,
     UpstreamProtocolFault,
     UpstreamReportedFault,
+    UpstreamRegistrationRefused,
 )
 
 
@@ -145,3 +149,28 @@ def test_dcr_server_error_code_is_not_blamed_on_caller():
         log_context="srv",
     )
     assert isinstance(fault, UpstreamReportedFault)
+
+
+@pytest.mark.parametrize("status_code", [401, 403])
+@pytest.mark.parametrize("body", ["Forbidden", '<html>private upstream details</html>', '{"error": ""}', '{"error": 12}'])
+def test_dcr_access_refusal_without_oauth_error(status_code: int, body: str) -> None:
+    fault: Final = classify_upstream_dcr_rejection(_response(status_code, text_body=body), log_context="srv")
+    assert isinstance(fault, UpstreamRegistrationRefused)
+    assert fault.status_code == status_code
+
+
+@pytest.mark.parametrize("status_code", [401, 403])
+def test_dcr_access_refusal_preserves_oauth_error(status_code: int) -> None:
+    fault: Final = classify_upstream_dcr_rejection(
+        _response(status_code, json_body={"error": "invalid_redirect_uri", "error_description": "not allowed"}),
+        log_context="srv",
+    )
+    assert fault == CallerRejected(code="invalid_redirect_uri", description="not allowed")
+
+
+@pytest.mark.parametrize("status_code", [401, 403])
+def test_token_access_refusal_remains_protocol_fault(status_code: int) -> None:
+    fault: Final = classify_upstream_token_rejection(
+        _response(status_code, text_body="Forbidden"), credential_source="gateway_stored", log_context="srv"
+    )
+    assert isinstance(fault, UpstreamProtocolFault)

--- a/tests/test_litellm/proxy/_experimental/mcp_server/faults/test_render_oauth.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/faults/test_render_oauth.py
@@ -2,6 +2,9 @@
 code can never ship on a server-fault status and gateway-side faults never carry provider prose."""
 
 import json
+from typing import Final, Literal
+
+import pytest
 
 from litellm.proxy._experimental.mcp_server.faults.render_oauth import (
     dcr_fault_detail,
@@ -12,6 +15,7 @@ from litellm.proxy._experimental.mcp_server.faults.types import (
     GatewayRejected,
     UpstreamProtocolFault,
     UpstreamReportedFault,
+    UpstreamRegistrationRefused,
 )
 
 
@@ -94,3 +98,17 @@ def test_dcr_upstream_reported_fault_maps_to_5xx():
     status_code, detail = dcr_fault_detail(UpstreamReportedFault(code="server_error"))
     assert status_code == 502
     assert "internal error" in detail
+
+
+@pytest.mark.parametrize("upstream_status", [401, 403])
+def test_registration_refusal_gives_configuration_guidance(upstream_status: Literal[401, 403]) -> None:
+    fault: Final = UpstreamRegistrationRefused(status_code=upstream_status)
+    status, detail = dcr_fault_detail(fault)
+    assert status == 403
+    assert f"HTTP {upstream_status}" in detail
+    assert "may require a pre-registered OAuth client" in detail
+    assert "client_id" in detail and "client_secret" in detail
+    response: Final = render_token_fault(fault)
+    assert response.status_code == 400
+    assert json.loads(response.body) == {"error": "unauthorized_client", "error_description": detail}
+    assert response.headers["cache-control"] == "no-store"

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
@@ -11141,3 +11141,48 @@ async def test_enforced_login_warms_verified_token_readable_without_database_loo
     assert token.identity_binding_proof == proof
     assert token.refresh_token is None
     read.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("upstream_status", [401, 403])
+@pytest.mark.parametrize("auth_type", [MCPAuth.true_passthrough, MCPAuth.oauth_delegate])
+@pytest.mark.parametrize("dcr_bridge", [False, True])
+@pytest.mark.parametrize("flow", ["register", "mint"])
+async def test_dcr_refusal_is_actionable_without_upstream_body(
+    upstream_status: int, auth_type: MCPAuth, dcr_bridge: bool, flow: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import httpx
+    from typing import Final
+
+    from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+        mint_ephemeral_dcr_client,
+        register_client_with_server,
+    )
+
+    server: Final = _bridge_server(
+        auth_type=auth_type, dcr_bridge=dcr_bridge, server_id=f"refused-{auth_type}-{dcr_bridge}-{flow}-{upstream_status}",
+        client_id=None,
+    )
+    import respx
+
+    monkeypatch.setenv("DISABLE_AIOHTTP_TRANSPORT", "True")
+    with respx.mock as upstream:
+        registration: Final = upstream.post(server.registration_url).mock(
+            return_value=httpx.Response(upstream_status, text="Forbidden private upstream details")
+        )
+        operation: Final = (
+            mint_ephemeral_dcr_client(_bridge_mock_request(), server)
+            if flow == "mint"
+            else register_client_with_server(
+                request=_bridge_mock_request(), mcp_server=server, client_name="Test client",
+                grant_types=None, response_types=None, token_endpoint_auth_method=None,
+                client_redirect_uris=["http://localhost:9999/callback"],
+            )
+        )
+        with pytest.raises(HTTPException) as exc:
+            await operation
+        assert registration.call_count == 1
+    assert exc.value.status_code == 403
+    assert f"HTTP {upstream_status}" in str(exc.value.detail)
+    assert "pre-registered OAuth client" in str(exc.value.detail)
+    assert "private upstream details" not in str(exc.value.detail)

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -12676,3 +12676,85 @@ async def test_debug_reports_legacy_signing_and_non_http_transport(transport: Li
             assert "Credential=AKIDEXAMPLE/" in request.headers["Authorization"]
     finally:
         request_ctx.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_temporary_server_discovery_reuses_resolved_metadata_without_publishing() -> None:
+    manager: Final = MCPServerManager()
+    server: Final = MCPServer(
+        server_id="temporary-oauth-discovery", name="temporary", url="https://idp.example.com/mcp",
+        transport=MCPTransport.http, auth_type=MCPAuth.true_passthrough,
+    )
+    manager._set_oauth_discovery_deferred(server.server_id, True)
+    metadata: Final = MCPOAuthMetadata(
+        authorization_url="https://idp.example.com/authorize", token_url="https://idp.example.com/token",
+        registration_url="https://idp.example.com/register",
+    )
+    with patch.object(manager, "_discover_oauth_metadata_for_server", AsyncMock(return_value=metadata)) as discovery:
+        resolved: Final = await manager.ensure_oauth_metadata_discovered(server)
+        repeated: Final = await manager.ensure_oauth_metadata_discovered(server)
+    assert resolved.authorization_url == metadata.authorization_url
+    assert resolved.token_url == metadata.token_url
+    assert resolved.registration_url == metadata.registration_url
+    assert repeated is resolved
+    assert server.server_id not in manager.registry
+    assert server.server_id not in manager.config_mcp_servers
+    discovery.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("auth_type", [MCPAuth.oauth2, MCPAuth.true_passthrough])
+async def test_repeated_stale_oauth_discovery_is_bounded(auth_type: MCPAuth) -> None:
+    manager: Final = MCPServerManager()
+    server: Final = MCPServer(
+        server_id="repeated-stale", name="stale", url="https://idp.example.com/mcp",
+        transport=MCPTransport.http, auth_type=auth_type, oauth2_flow="authorization_code",
+    )
+    manager.registry[server.server_id] = server
+    manager._set_oauth_discovery_deferred(server.server_id, True)
+    metadata: Final = MCPOAuthMetadata(
+        authorization_url="https://idp.example.com/authorize", token_url="https://idp.example.com/token",
+    )
+    with (
+        patch.object(manager, "_discover_oauth_metadata_for_server", AsyncMock(return_value=metadata)) as discovery,
+        patch.object(manager, "_publish_resolved_oauth_server", return_value=None),
+    ):
+        if auth_type == MCPAuth.true_passthrough:
+            assert await manager.ensure_oauth_metadata_discovered(server) is server
+        else:
+            with pytest.raises(HTTPException) as exc:
+                await manager.ensure_oauth_metadata_discovered(server)
+            assert exc.value.status_code == 503
+            assert "changed repeatedly" in str(exc.value.detail)
+    assert discovery.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_stale_discovery_falls_back_to_resolved_registered_server() -> None:
+    manager: Final = MCPServerManager()
+    original: Final = MCPServer(
+        server_id="resolved-replacement", name="replacement", url="https://old.example.com/mcp",
+        transport=MCPTransport.http, auth_type=MCPAuth.oauth2, oauth2_flow="authorization_code",
+    )
+    replacement: Final = original.model_copy(update={
+        "url": "https://new.example.com/mcp", "authorization_url": "https://new.example.com/authorize",
+        "token_url": "https://new.example.com/token",
+    })
+    manager.registry[original.server_id] = replacement
+    assert await manager._rejoin_oauth_metadata_discovery(original, retry_stale=False) is replacement
+
+
+def test_stale_discovery_cannot_overwrite_new_registered_server() -> None:
+    manager: Final = MCPServerManager()
+    original: Final = MCPServer(
+        server_id="stale-publication", name="publication", url="https://old.example.com/mcp",
+        transport=MCPTransport.http, auth_type=MCPAuth.oauth2,
+    )
+    manager._set_oauth_discovery_deferred(original.server_id, True)
+    original_slot: Final = manager._oauth_discovery_slot(original.server_id)
+    assert original_slot is not None
+    replacement: Final = original.model_copy(update={"url": "https://new.example.com/mcp"})
+    manager.registry[original.server_id] = replacement
+    manager._set_oauth_discovery_deferred(original.server_id, True)
+    assert manager._publish_resolved_oauth_server(original, original_slot.generation) is None
+    assert manager.registry[original.server_id] is replacement

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -12758,3 +12758,39 @@ def test_stale_discovery_cannot_overwrite_new_registered_server() -> None:
     manager._set_oauth_discovery_deferred(original.server_id, True)
     assert manager._publish_resolved_oauth_server(original, original_slot.generation) is None
     assert manager.registry[original.server_id] is replacement
+
+
+@pytest.mark.asyncio
+async def test_temporary_oauth_discovery_expires_without_more_requests() -> None:
+    manager: Final = MCPServerManager()
+    server: Final = MCPServer(
+        server_id="expiring-session", name="temporary", url="https://idp.example.com/mcp",
+        transport=MCPTransport.http, auth_type=MCPAuth.true_passthrough,
+        authorization_url="https://idp.example.com/authorize", token_url="https://idp.example.com/token",
+    )
+    manager._set_oauth_discovery_deferred(server.server_id, True)
+    resolved: Final = await manager.ensure_oauth_metadata_discovered(server)
+    assert manager._oauth_discovery_slot(server.server_id) is not None
+    loop: Final = asyncio.get_running_loop()
+    expired: Final = loop.create_future()
+    with patch.object(loop, "time", return_value=loop.time() + 301):
+        loop.call_later(0, expired.set_result, None)
+        await expired
+    assert resolved.authorization_url == server.authorization_url
+    assert manager._oauth_discovery_slot(server.server_id) is None
+
+
+def test_old_temporary_discovery_expiry_preserves_replacement() -> None:
+    manager: Final = MCPServerManager()
+    manager._set_oauth_discovery_deferred("reused-session", True)
+    old_slot: Final = manager._oauth_discovery_slot("reused-session")
+    assert old_slot is not None
+    manager._set_oauth_discovery_deferred("reused-session", True)
+    replacement: Final = manager._oauth_discovery_slot("reused-session")
+    manager._expire_temporary_oauth_discovery("reused-session", old_slot.generation)
+    assert manager._oauth_discovery_slot("reused-session") is replacement
+    assert replacement is not None
+    manager._expire_temporary_oauth_discovery("reused-session", replacement.generation)
+    assert manager._oauth_discovery_slot("reused-session") is None
+    manager._expire_temporary_oauth_discovery("reused-session", replacement.generation)
+    assert manager._oauth_discovery_slot("reused-session") is None


### PR DESCRIPTION
## TLDR

Problem this solves:

- Refused upstream OAuth registration produces an unhelpful 502
- Temporary OAuth discovery can recurse indefinitely

How it solves it:

- Return actionable 403 guidance without exposing upstream bodies
- Reuse temporary discovery results, then expire after five minutes
- Bound stale retries and preserve cancellation behavior

## User Flow

Before: the administrator cannot authorize the MCP server and receives no actionable registration guidance

1. Open `http://localhost:47498/ui/?page=mcp-servers`, select Figma, then Settings
2. Select True Passthrough and leave OAuth client credentials empty
3. Click Authorize & Fetch Tools (browser-only)
4. See `upstream registration failed with HTTP 403`

After: the administrator sees guidance when the upstream refuses registration

1. Open `http://localhost:47499/ui/?page=mcp-servers`, select Figma, then Settings
2. Select True Passthrough and leave OAuth client credentials empty
3. Click Authorize & Fetch Tools (browser-only)
4. See that registration was refused and pre-registered credentials may be required

## Relevant issues

## Linear ticket

Resolves LIT-7498

https://linear.app/litellm-ai/issue/LIT-7498/mcp-figma-mcp-oauth-fails-via-litellm-true-passthrough-upstream

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible
- [x] I have received a Greptile Confidence Score of at least 4/5

## Local validation

At `40f01e2fa5832f14e4afa5ff90a5d3093b39f9fe`, 1,078 affected tests pass with line and branch coverage. `make check` passes Ruff lint/formatting, test-tree lint, strict-rule, type-discipline, test-quality, basedpyright budgets, and API-type synchronization. The recursion detector reports no unignored recursive functions

```bash
uv run --no-sync pytest \
  tests/test_litellm/proxy/_experimental/mcp_server/faults \
  tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py \
  tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py \
  --cov=litellm.proxy._experimental.mcp_server --cov-branch \
  --cov-report=json:coverage.json --cov-report=xml:coverage.xml -q
make check
uv run --no-sync python tests/code_coverage_tests/recursive_detector.py
uv run --no-sync diff-cover coverage.xml --compare-branch=origin/litellm_internal_staging
```

Changed executable-line coverage is **37/37, 100%**. Touched-function branch coverage is **52/56**: three missing arcs are unreachable exhaustive-match fall-throughs; one is the unchanged gateway-rejected DCR rendering arm, outside the bare-refusal regression. Its shared prose helper is exercised through token rendering. No coverage exclusions or budget changes were added. These are focused local results, not repository-wide coverage. Completed current-tip Codecov independently confirms 37/37 changed lines covered, with 26 coverage sessions and 80.54% repository-wide coverage. The initial 32.43% result preceded processing of the proxy-infra upload; its CI artifact and the completed report both cover every changed executable line

[Sanitized logs, coverage details, and reproduction scripts](https://github.com/BerriAI/litellm/tree/litellm_evidence_mcp_oauth_registration_7498/verification/LIT-7498)

## Screenshots / Proof of Fix

Source-built proxies use the same [configuration and runnable curl script](https://github.com/BerriAI/litellm/tree/litellm_evidence_mcp_oauth_registration_7498/verification/LIT-7498), frozen Python 3.12 proxy dependencies, generated Prisma client, and local PostgreSQL. Set `LITELLM_MASTER_KEY` locally; no Figma credentials are configured. `repro.sh` loads this variable from an untracked `local.env`

```bash
uv sync --frozen --extra proxy --group proxy-dev --group e2e-dev
uv run --no-sync prisma generate
uv run --no-sync litellm --config config.yaml --host 127.0.0.1 --port PORT --use_v2_migration_resolver
bash repro.sh LABEL http://127.0.0.1:PORT
```

### Before (9a715df212d777bbd43f4cab05731978c708ec63)

#### Registration and dashboard error

1. Run `bash repro.sh before http://127.0.0.1:47498`. The script posts the same public-client registration JSON to `/figma_{mode}_{bridge}/register` for `true_passthrough` and `oauth_delegate`, bridge false/true, plus dashboard `/v1/mcp/server/oauth/figma/register` and `/authorize`
2. All six requests return HTTP 502: `upstream registration failed with HTTP 403`
3. Log into `http://127.0.0.1:47498/ui/?page=mcp-servers`, open figma, Settings, leave client fields empty, and click Authorize & Fetch Tools (browser-only). Observe the same inline error beside the fields

![Before OAuth error](https://raw.githubusercontent.com/BerriAI/litellm/litellm_evidence_mcp_oauth_registration_7498/verification/LIT-7498/before-oauth.png)

#### Temporary automatic discovery

1. The same script creates a temporary session at `/v1/mcp/server/oauth/session` with only `https://mcp.figma.com/mcp`, HTTP transport, and `true_passthrough`, then registers using the returned server ID
2. Registration exceeds the 15-second curl timeout; the baseline server loops on stale discovery

#### Public MCP tools

1. The same script calls `GET /mcp-rest/tools/list?server_id=deepwiki`
2. HTTP 200 lists public DeepWiki tools
3. It posts `read_wiki_structure` with `repoName: BerriAI/litellm` to `/mcp-rest/tools/call`
4. HTTP 200 contains the repository wiki structure

### After (40f01e2fa5832f14e4afa5ff90a5d3093b39f9fe)

#### Registration and dashboard error

1. Run `bash repro.sh after http://127.0.0.1:47499`. The script posts the same public-client registration JSON to `/figma_{mode}_{bridge}/register` for `true_passthrough` and `oauth_delegate`, bridge false/true, plus dashboard `/v1/mcp/server/oauth/figma/register` and `/authorize`
2. All six requests return HTTP 403: `the upstream authorization server refused dynamic client registration (HTTP 403)` with `client_id` / `client_secret` guidance
3. Log into `http://127.0.0.1:47499/ui/?page=mcp-servers`, open figma, Settings, leave client fields empty, and click Authorize & Fetch Tools (browser-only). Observe the same inline error beside the fields

![After OAuth error](https://raw.githubusercontent.com/BerriAI/litellm/litellm_evidence_mcp_oauth_registration_7498/verification/LIT-7498/after-oauth.png)

#### Temporary automatic discovery

1. The same script creates a temporary session at `/v1/mcp/server/oauth/session` with only `https://mcp.figma.com/mcp`, HTTP transport, and `true_passthrough`, then registers using the returned server ID
2. Registration returns the actionable HTTP 403 promptly without recursion

#### Public MCP tools

1. The same script calls `GET /mcp-rest/tools/list?server_id=deepwiki`
2. HTTP 200 lists public DeepWiki tools
3. It posts `read_wiki_structure` with `repoName: BerriAI/litellm` to `/mcp-rest/tools/call`
4. HTTP 200 contains the repository wiki structure

## Review regression evidence

Greptile identified retained successful temporary-discovery tasks. The [live lifecycle script and logs](https://github.com/BerriAI/litellm/tree/litellm_evidence_mcp_oauth_registration_7498/verification/LIT-7498) use real Figma discovery, wait 301 seconds without further requests, and inspect retained state. At `bb9b4c4aef`, the slot remains; at `40f01e2fa5832f14e4afa5ff90a5d3093b39f9fe`, it expires. The regression test also fails against `bb9b4c4aef` and passes at the tip. An old expiry callback cannot remove a newer generation

The earlier recursion-detector finding is fixed by sharing caller-error rendering through a helper. At `40f01e2fa5832f14e4afa5ff90a5d3093b39f9fe`, Veria reports no security issues, Greptile gives 5/5 with the retention concern resolved, and Bugbot reports no issues. Both bot annotation lists are empty, and no review threads remain unresolved. All 86 reported checks pass, with one intentionally skipped job. The contributor confirmed the CLA is already signed

## Type

Bug Fix

## Caveats (if any)

### Medium

- Approved Figma credentials unavailable; consent, token exchange, tools unverified
- Provider restrictions remain; this change does not bypass approval
- Temporary UI sessions omit bridge flags; configured API matrix covers both
- Delegated bridge authorization needs client_id; unchanged missing-client response

## Final Attestation

- [x] Final current-tip CI, coverage, and review requirements are complete
