### PR TITLE
fix(cache-control): honor explicit injection points

### DIFF
--- a/litellm/integrations/anthropic_cache_control_hook.py
+++ b/litellm/integrations/anthropic_cache_control_hook.py
@@ -251,14 +251,10 @@ class AnthropicCacheControlHook(CustomPromptManagement):
 
         # Points this pass did not place: non-message ones for the provider transform, and
         # the deferred role-targeted ones. Deferring is what reaches the Responses API's
-        # `instructions`, which is only a system message once the bridge builds one. The
-        # judged stamp is what makes it safe: the next pass must not re-judge points
-        # against messages this pass already marked (see `_should_stand_down`).
+        # `instructions`, which is only a system message once the bridge builds one.
         carried_points: Final[Sequence[CacheControlInjectionPoint]] = (*remaining_points, *carried_message_points)
         if carried_points:
-            non_default_params["cache_control_injection_points"] = AnthropicCacheControlHook._stamped_as_judged(
-                carried_points
-            )
+            non_default_params["cache_control_injection_points"] = list(carried_points)
 
         return model, processed_messages, non_default_params
 
@@ -555,28 +551,13 @@ class AnthropicCacheControlHook(CustomPromptManagement):
             return ChatCompletionCachedContent(type="ephemeral", ttl=ttl)
         return ChatCompletionCachedContent(type="ephemeral")
 
-    @staticmethod
-    def _stamped_as_judged(points: Sequence[CacheControlInjectionPoint]) -> Sequence[Mapping[str, object]]:
-        """Mark written-back points as having passed the client cache_control judgment.
-
-        Builds copies because config-owned point dicts are shared across
-        requests; mutating them would leak the stamp into future requests.
-        """
-        return AnthropicCacheControlHook._stamped(points, "_litellm_judged", True)
-
-    @staticmethod
-    def _judged_configured_points(
+    def _configured_points_for_request(
         points: Sequence[CacheControlInjectionPoint],
-        messages: list[AllMessageValues],
-        tools: list[object] | None,
-        cache_control: object,
         model: str,
         custom_llm_provider: str | None,
         api_base: object,
         prompt_cache_options: object,
-    ) -> Sequence[Mapping[str, object]] | None:
-        if AnthropicCacheControlHook._should_stand_down(points, messages, None, tools, cache_control):
-            return None
+    ) -> Sequence[Mapping[str, object]]:
         return AnthropicCacheControlHook._stamped_with_dialect(
             points, model, custom_llm_provider, api_base, prompt_cache_options
         )
@@ -605,28 +586,6 @@ class AnthropicCacheControlHook(CustomPromptManagement):
     ) -> Sequence[Mapping[str, object]]:
         return [{**point, key: value} for point in points]
 
-    @staticmethod
-    def _should_stand_down(
-        points: Sequence[CacheControlInjectionPoint],
-        messages: list[AllMessageValues],
-        system: str | list | None,
-        tools: list | None,
-        cache_control: object = None,
-    ) -> bool:
-        """Whether configured injection points must yield to client-set cache_control.
-
-        Points that a prior pass over this request already judged and wrote
-        back carry the internal judged stamp; any re-entry (acompletion
-        re-entering completion, the async-to-sync /v1/messages dispatch,
-        interceptor sub-calls reusing the request kwargs) must not re-judge
-        them, because by then the messages carry litellm's own injected marks
-        and the judgment would misread those as client breakpoints.
-        """
-        if all(point.get("_litellm_judged") for point in points):
-            return False
-        return AnthropicCacheControlHook._request_has_cache_control(messages, system, tools, cache_control)
-
-    @staticmethod
     def _request_has_cache_control(
         messages: list[AllMessageValues],
         system: str | list | None,
@@ -635,8 +594,9 @@ class AnthropicCacheControlHook(CustomPromptManagement):
     ) -> bool:
         """Return True if the request already carries any client-supplied cache_control.
 
-        When the client (e.g. Claude Code) already marks its own breakpoints we
-        stand down entirely rather than add more, per the auto-caching contract.
+        The automatic cache-injection path stands down when the client (e.g.
+        Claude Code) already marks its own breakpoints, per the auto-caching
+        contract.
         Tools count: they are a breakpoint the client can mark, they count toward
         the provider's four-block limit, and caching only the tool definitions is
         a common pattern, so injecting alongside them can exceed the cap. Tools
@@ -779,31 +739,24 @@ class AnthropicCacheControlHook(CustomPromptManagement):
     ) -> None:
         """For /chat/completions: resolve the injection points the request should carry.
 
-        Configured injection points win over the automatic defaults, but stand
-        down entirely when the client already marked its own cache_control
-        breakpoints (messages or tools): injecting alongside them clashes with
-        the client's caching strategy and can exceed the provider's four-block
-        limit. The judgment happens once per request; points a prior pass
-        wrote back carry the judged stamp and are never re-judged (see
-        ``_should_stand_down``). Seeding the param lets the existing
-        prompt-management gate and the AnthropicCacheControlHook run
-        unchanged.
+        Configured injection points are explicit operator directives and are
+        always passed through to the downstream injection logic. That logic
+        preserves client-supplied breakpoints, skips already-marked messages,
+        and enforces the provider's four-block limit. Automatic defaults still
+        stand down when the client supplies its own cache_control. Seeding the
+        param lets the existing prompt-management gate and the
+        AnthropicCacheControlHook run unchanged.
         """
         if non_default_params.get("cache_control_injection_points"):
-            judged: Final = AnthropicCacheControlHook._judged_configured_points(
-                non_default_params["cache_control_injection_points"],
-                messages,
-                tools,
-                non_default_params.get("cache_control"),
-                model,
-                custom_llm_provider,
-                api_base,
-                non_default_params.get("prompt_cache_options"),
+            non_default_params["cache_control_injection_points"] = (
+                AnthropicCacheControlHook._configured_points_for_request(
+                    non_default_params["cache_control_injection_points"],
+                    model,
+                    custom_llm_provider,
+                    api_base,
+                    non_default_params.get("prompt_cache_options"),
+                )
             )
-            if judged is None:
-                non_default_params.pop("cache_control_injection_points")
-            else:
-                non_default_params["cache_control_injection_points"] = judged
             return
         points: Final = AnthropicCacheControlHook.get_default_injection_points(
             messages=messages,
@@ -904,11 +857,10 @@ class AnthropicCacheControlHook(CustomPromptManagement):
     ) -> tuple[list[dict], str | list | None]:
         """Extract cache_control_injection_points from kwargs and apply if present.
 
-        Configured points stand down entirely when the client already marked
-        its own cache_control breakpoints anywhere in the request. The
-        judgment happens once per request; points a prior pass wrote back
-        carry the judged stamp and are never re-judged (see
-        ``_should_stand_down``). When none are configured but
+        Configured points are explicit operator directives and are always
+        passed through to the downstream injection logic, which preserves
+        client-supplied breakpoints and enforces the provider's four-block
+        limit. When none are configured but
         ``litellm.enable_anthropic_prompt_caching`` or the per-request
         ``enable_prompt_caching`` kwarg (stamped from key metadata) is on,
         synthesize default breakpoints for the native /v1/messages path. Pops
@@ -924,10 +876,6 @@ class AnthropicCacheControlHook(CustomPromptManagement):
         configured: Final = cast(  # cast-ok: kwargs is untyped; this key only holds the documented injection-point list
             list[CacheControlInjectionPoint] | None, kwargs.pop("cache_control_injection_points", None)
         )
-        if configured and AnthropicCacheControlHook._should_stand_down(
-            configured, typed_messages, system, tools, cache_control
-        ):
-            return messages, system
         injection_points: list[CacheControlInjectionPoint] = configured or []
         if not injection_points and model is not None:
             injection_points = AnthropicCacheControlHook.get_default_injection_points(
@@ -960,7 +908,7 @@ class AnthropicCacheControlHook(CustomPromptManagement):
         if openai_dialect and breakpoints_added > 0:
             kwargs.setdefault("prompt_cache_options", PromptCacheOptions(mode="explicit"))
         if remaining:
-            kwargs["cache_control_injection_points"] = AnthropicCacheControlHook._stamped_as_judged(remaining)
+            kwargs["cache_control_injection_points"] = remaining
         return messages, system
 
     @property

--- a/litellm/types/integrations/anthropic_cache_control_hook.py
+++ b/litellm/types/integrations/anthropic_cache_control_hook.py
@@ -17,7 +17,6 @@ class CacheControlMessageInjectionPoint(TypedDict):
     role: Literal["user", "system", "assistant"] | None  # Optional: target by role (user, system, assistant)
     index: int | str | None  # Optional: target by specific index
     control: ChatCompletionCachedContent | None
-    _litellm_judged: NotRequired[bool]  # Internal: written back by litellm once the client cache_control judgment ran
     _litellm_openai_dialect: NotRequired[ReadOnly[bool]]
 
 
@@ -26,7 +25,6 @@ class CacheControlToolConfigInjectionPoint(TypedDict):
 
     location: Literal["tool_config"]
     control: ChatCompletionCachedContent | None
-    _litellm_judged: NotRequired[bool]  # Internal: written back by litellm once the client cache_control judgment ran
     _litellm_openai_dialect: NotRequired[ReadOnly[bool]]
 
 

--- a/tests/test_litellm/integrations/test_anthropic_cache_control_hook.py
+++ b/tests/test_litellm/integrations/test_anthropic_cache_control_hook.py
@@ -1280,10 +1280,9 @@ def test_cache_control_hook_reserves_slot_for_tool_config_point():
     )
 
     assert _count_cache_control(processed) == 3
-    # The tool_config point is passed through for the provider transform,
-    # stamped so re-entries never re-judge it against litellm's own marks.
+    # The tool_config point is passed through for the provider transform.
     assert non_default_params["cache_control_injection_points"] == [
-        {"location": "tool_config", "_litellm_judged": True}
+        {"location": "tool_config"}
     ]
 
 
@@ -2089,11 +2088,13 @@ class TestPerKeyEnablePromptCaching:
         assert result_msgs == messages
 
 
-class TestConfiguredInjectionPointsStandDown:
-    """Configured cache_control_injection_points must stand down entirely when the
-    client already set its own cache_control anywhere in the request (LIT-4582);
-    injecting alongside client breakpoints clashes with the client's caching
-    strategy and can push the request past Anthropic's four-block limit."""
+class TestConfiguredInjectionPoints:
+    """Explicit cache_control_injection_points remain active beside client marks.
+
+    The downstream injection logic preserves existing breakpoints and enforces
+    Anthropic's four-block limit; the auto-default path is responsible for
+    standing down when the client manages caching itself.
+    """
 
     CONFIGURED = [{"location": "message", "role": "system"}]
 
@@ -2128,10 +2129,24 @@ class TestConfiguredInjectionPointsStandDown:
             tools=tools,
         )
 
-    def test_configured_points_dropped_when_messages_carry_cache_control(self):
+    def test_configured_points_kept_when_messages_carry_cache_control(self):
         params = {"cache_control_injection_points": copy.deepcopy(self.CONFIGURED)}
         self._seed(params, copy.deepcopy(self.MARKED_MESSAGES))
-        assert "cache_control_injection_points" not in params
+        assert params["cache_control_injection_points"] == self.CONFIGURED
+
+    def test_chat_path_applies_configured_points_when_messages_carry_cache_control(self):
+        params = {"cache_control_injection_points": copy.deepcopy(self.CONFIGURED)}
+        _, processed, _ = AnthropicCacheControlHook().get_chat_completion_prompt(
+            model="claude-sonnet-4-5",
+            messages=copy.deepcopy(self.MARKED_MESSAGES),
+            non_default_params=params,
+            prompt_id=None,
+            prompt_variables=None,
+            dynamic_callback_params={},
+        )
+
+        assert processed[0]["cache_control"] == {"type": "ephemeral"}
+        assert processed[1] == self.MARKED_MESSAGES[1]
 
     @pytest.mark.parametrize(
         "tool",
@@ -2141,10 +2156,10 @@ class TestConfiguredInjectionPointsStandDown:
         ],
         ids=["top_level", "nested_in_function"],
     )
-    def test_configured_points_dropped_when_tools_carry_cache_control(self, tool):
+    def test_configured_points_kept_when_tools_carry_cache_control(self, tool):
         params = {"cache_control_injection_points": copy.deepcopy(self.CONFIGURED)}
         self._seed(params, copy.deepcopy(self.CLEAN_MESSAGES), tools=[tool])
-        assert "cache_control_injection_points" not in params
+        assert params["cache_control_injection_points"] == self.CONFIGURED
 
     def test_configured_points_kept_when_request_is_unmarked(self):
         configured = copy.deepcopy(self.CONFIGURED)
@@ -2152,42 +2167,40 @@ class TestConfiguredInjectionPointsStandDown:
         self._seed(params, copy.deepcopy(self.CLEAN_MESSAGES))
         assert params["cache_control_injection_points"] is configured
 
-    def test_judged_remainder_survives_reentry_despite_injected_marks(self):
+    def test_remainder_survives_reentry_despite_injected_marks(self):
         """acompletion() re-enters completion() after injection ran, with only the
-        stamped non-message points written back; the re-entry must not misread
-        litellm's own marks as client ones and drop that remainder."""
-        remainder = [{"location": "tool_config", "_litellm_judged": True}]
+        non-message points written back; the re-entry must keep that remainder
+        alongside LiteLLM's own marks."""
+        remainder = [{"location": "tool_config"}]
         params = {"cache_control_injection_points": remainder}
         self._seed(params, copy.deepcopy(self.MARKED_MESSAGES))
         assert params["cache_control_injection_points"] is remainder
 
-    def test_v1_messages_stand_down_when_content_block_marked(self):
+    def test_v1_messages_apply_configured_points_when_content_block_marked(self):
         messages = [
             {"role": "user", "content": [{"type": "text", "text": "hi", "cache_control": {"type": "ephemeral"}}]}
         ]
         kwargs = {"cache_control_injection_points": copy.deepcopy(self.CONFIGURED)}
         result_msgs, result_sys = self._inject(copy.deepcopy(messages), kwargs)
         assert result_msgs == messages
-        assert result_sys == "sys"
+        assert result_sys == [{"type": "text", "text": "sys", "cache_control": {"type": "ephemeral"}}]
         assert "cache_control_injection_points" not in kwargs
 
-    def test_v1_messages_stand_down_when_system_block_marked(self):
-        """A configured point targeting a message must not fire when the client
-        marked the system prompt; the old behavior injected into the message
-        because only the exact targeted position was guarded."""
+    def test_v1_messages_apply_configured_points_when_system_block_marked(self):
+        """A client mark on the system prompt must not suppress a message target."""
         system = [{"type": "text", "text": "s", "cache_control": {"type": "ephemeral"}}]
         kwargs = {"cache_control_injection_points": [{"location": "message", "role": "user"}]}
         result_msgs, result_sys = self._inject(copy.deepcopy(self.V1_MESSAGES), kwargs, system=system)
-        assert result_msgs == self.V1_MESSAGES
+        assert result_msgs[0]["content"][-1]["cache_control"] == {"type": "ephemeral"}
         assert result_sys == system
         assert "cache_control_injection_points" not in kwargs
 
-    def test_v1_messages_stand_down_when_tools_marked(self):
+    def test_v1_messages_apply_configured_points_when_tools_marked(self):
         tools = [{"name": "t", "input_schema": {}, "cache_control": {"type": "ephemeral"}}]
         kwargs = {"cache_control_injection_points": copy.deepcopy(self.CONFIGURED)}
         result_msgs, result_sys = self._inject(copy.deepcopy(self.V1_MESSAGES), kwargs, tools=tools)
         assert result_msgs == self.V1_MESSAGES
-        assert result_sys == "sys"
+        assert result_sys == [{"type": "text", "text": "sys", "cache_control": {"type": "ephemeral"}}]
         assert "cache_control_injection_points" not in kwargs
 
     def test_v1_messages_configured_points_apply_when_unmarked(self):
@@ -2200,7 +2213,7 @@ class TestConfiguredInjectionPointsStandDown:
         [None, CONFIGURED],
         ids=["automatic_defaults", "configured_points"],
     )
-    def test_v1_messages_stands_down_for_root_cache_control(self, monkeypatch, configured):
+    def test_v1_messages_honors_explicit_points_but_stands_down_for_defaults(self, monkeypatch, configured):
         monkeypatch.setattr(litellm, "enable_anthropic_prompt_caching", True)
         root_cache_control = {"type": "ephemeral"}
         kwargs = {"cache_control": root_cache_control, "litellm_metadata": {}}
@@ -2209,22 +2222,29 @@ class TestConfiguredInjectionPointsStandDown:
 
         result_messages, result_system = self._inject(copy.deepcopy(self.V1_MESSAGES), kwargs)
 
-        assert result_messages == self.V1_MESSAGES
-        assert result_system == "sys"
+        if configured is None:
+            assert result_messages == self.V1_MESSAGES
+            assert result_system == "sys"
+        else:
+            assert result_messages == self.V1_MESSAGES
+            assert result_system == [{"type": "text", "text": "sys", "cache_control": {"type": "ephemeral"}}]
         assert kwargs["cache_control"] is root_cache_control
-        assert "litellm_gateway_injected_cache" not in kwargs["litellm_metadata"]
+        if configured is None:
+            assert "litellm_gateway_injected_cache" not in kwargs["litellm_metadata"]
+        else:
+            assert kwargs["litellm_metadata"]["litellm_gateway_injected_cache"] == ""
 
     def test_v1_messages_reentry_flow_preserves_tool_config_remainder(self):
         """The advisor interceptor re-enters anthropic_messages() with the outer
         request's kwargs and post-injection messages. The first pass applies the
-        message point and writes back a stamped tool_config remainder; the
-        re-entry must keep that remainder even though the messages and system
-        now carry litellm's own marks."""
+        message point and writes back a tool_config remainder; the re-entry must
+        keep that remainder even though the messages and system now carry
+        LiteLLM's own marks."""
         points = [{"location": "message", "role": "system"}, {"location": "tool_config"}]
         kwargs = {"cache_control_injection_points": copy.deepcopy(points)}
         msgs1, sys1 = self._inject(copy.deepcopy(self.V1_MESSAGES), kwargs)
         assert sys1[0]["cache_control"] == {"type": "ephemeral"}
-        expected_remainder = [{"location": "tool_config", "_litellm_judged": True}]
+        expected_remainder = [{"location": "tool_config"}]
         assert kwargs["cache_control_injection_points"] == expected_remainder
 
         msgs2, sys2 = self._inject(msgs1, kwargs, system=sys1)
@@ -2463,22 +2483,32 @@ class TestOpenAIPromptCacheBreakpoint:
         assert system == [{"type": "text", "text": "sys", "cache_control": {"type": "ephemeral"}}]
         assert kwargs == {}
 
-    def test_v1_messages_client_content_breakpoint_makes_configured_points_stand_down(self):
-        messages = [{"role": "user", "content": [{"type": "text", "text": "hi", "prompt_cache_breakpoint": self.EXPLICIT}]}]
+    def test_v1_messages_client_content_breakpoint_does_not_suppress_configured_points(self):
+        messages = [
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "hi", "prompt_cache_breakpoint": self.EXPLICIT}],
+            }
+        ]
         kwargs = {"cache_control_injection_points": copy.deepcopy(self.SYSTEM_POINT)}
         result, system = self._inject(messages, "sys", kwargs)
         assert result == messages
-        assert system == "sys"
-        assert kwargs == {}
+        assert system == [{"type": "text", "text": "sys", "prompt_cache_breakpoint": self.EXPLICIT}]
+        assert kwargs == {"prompt_cache_options": self.EXPLICIT}
 
-    def test_v1_messages_client_system_breakpoint_makes_configured_points_stand_down(self):
+    def test_v1_messages_client_system_breakpoint_does_not_suppress_configured_points(self):
         system = [{"type": "text", "text": "sys", "prompt_cache_breakpoint": self.EXPLICIT}]
         messages = [{"role": "user", "content": [{"type": "text", "text": "hi"}]}]
         kwargs = {"cache_control_injection_points": [{"location": "message", "index": -1}]}
         result, result_system = self._inject(messages, system, kwargs)
-        assert result == messages
+        assert result == [
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "hi", "prompt_cache_breakpoint": self.EXPLICIT}],
+            }
+        ]
         assert result_system == system
-        assert kwargs == {}
+        assert kwargs == {"prompt_cache_options": self.EXPLICIT}
 
     def test_chat_system_string_wrapped_with_block_breakpoint(self):
         params = {"cache_control_injection_points": copy.deepcopy(self.SYSTEM_POINT)}
@@ -2542,7 +2572,7 @@ class TestOpenAIPromptCacheBreakpoint:
         assert processed[0] == {"role": "system", "content": "sys", "cache_control": {"type": "ephemeral"}}
         assert params == {}
 
-    def test_chat_client_breakpoint_makes_seeded_points_stand_down(self):
+    def test_chat_client_breakpoint_does_not_suppress_seeded_points(self):
         params = {"cache_control_injection_points": copy.deepcopy(self.SYSTEM_POINT)}
         AnthropicCacheControlHook.maybe_seed_default_injection_points(
             non_default_params=params,
@@ -2553,7 +2583,11 @@ class TestOpenAIPromptCacheBreakpoint:
             model="openai/gpt-5.6",
             custom_llm_provider="openai",
         )
-        assert params == {}
+        assert params == {
+            "cache_control_injection_points": [
+                {"location": "message", "role": "system", "_litellm_openai_dialect": True}
+            ]
+        }
 
     def test_cap_counts_client_breakpoints_of_both_kinds(self):
         messages = [


### PR DESCRIPTION
## TLDR

Problem this solves:

- Client markers silently erase explicit operator breakpoints
- Unrelated marks cause prompt-cache hits to disappear

How it solves it:

- Preserves explicit points for downstream per-target handling
- Keeps automatic stand-down and the four-breakpoint limit

## User Flow

Before: marking one block silently disables a configured breakpoint elsewhere

1. An operator configures a breakpoint for the rolling conversation tail.
2. A developer sends the same request with a client cache marker on the system prompt.
3. The request returns HTTP 200, but the provider receives only the client marker.

After: both independently requested breakpoints reach the provider

1. An operator keeps the same cache-control configuration.
2. A developer sends the same request with the same system marker.
3. The request returns HTTP 200, and the provider receives both markers within the four-block limit.

## Changes

- Explicit injection points are no longer removed when unrelated client markers exist.
- Native `/v1/messages` processing follows the same behavior.
- Automatic defaults retain their existing client-marker stand-down behavior.
- Removed obsolete judged-point state and type declarations.

## Relevant issues

Fixes #40675

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The targeted test file passes locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is isolated to one behavior
- [ ] I have received a Greptile confidence score of at least 4/5

## Screenshots / Proof of Fix

No live-provider run is claimed because this environment has no usable Anthropic or Bedrock credentials.

### Before (`362033cb2a703e591184a4ec5887a42ec7114873`)

1. An unrelated client cache marker causes the configured injection list to be dropped before request shaping.

### After (`b318359cc42913471dc5654f690ea7cdbd22cb81`)

1. The same request keeps the explicit point and preserves the client marker.
2. The targeted regression subset passes: `63 passed`.
3. The full hook test file passes: `226 passed, 1 warning`.

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Live-provider validation remains for the maintainer environment.

## Final Attestation

- [x] The tests cover explicit points, unrelated client markers, re-entry, and automatic defaults.
