### PR TITLE
fix(image-gen): stop extra_headers/extra_query leaking into the request body

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -792,6 +792,9 @@ OPENAI_TRANSCRIPTION_PARAMS: Final = [
 
 OPENAI_EMBEDDING_PARAMS: Final = ["dimensions", "encoding_format", "user"]
 
+# openai-python request-option kwargs: transport-level, never provider request body content
+OPENAI_SDK_TRANSPORT_PARAMS: Final = frozenset({"extra_headers", "extra_query", "timeout"})
+
 DEFAULT_EMBEDDING_PARAM_VALUES: Final = {
     **{k: None for k in OPENAI_EMBEDDING_PARAMS},
     "model": None,

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -792,8 +792,11 @@ OPENAI_TRANSCRIPTION_PARAMS: Final = [
 
 OPENAI_EMBEDDING_PARAMS: Final = ["dimensions", "encoding_format", "user"]
 
-# openai-python request-option kwargs: transport-level, never provider request body content
-OPENAI_SDK_TRANSPORT_PARAMS: Final = frozenset({"extra_headers", "extra_query", "timeout"})
+# openai-python request-option kwargs that already reach the provider through a working
+# path outside extra_body, so they must never also be captured as extra_body content.
+# Deliberately excludes extra_query: no such path exists for it yet, so it stays in
+# extra_body rather than trading its loud failure for a silent no-op.
+OPENAI_SDK_TRANSPORT_PARAMS: Final = frozenset({"extra_headers", "timeout"})
 
 DEFAULT_EMBEDDING_PARAM_VALUES: Final = {
     **{k: None for k in OPENAI_EMBEDDING_PARAMS},

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -792,10 +792,7 @@ OPENAI_TRANSCRIPTION_PARAMS: Final = [
 
 OPENAI_EMBEDDING_PARAMS: Final = ["dimensions", "encoding_format", "user"]
 
-# openai-python request-option kwargs that already reach the provider through a working
-# path outside extra_body, so they must never also be captured as extra_body content.
-# Deliberately excludes extra_query: no such path exists for it yet, so it stays in
-# extra_body rather than trading its loud failure for a silent no-op.
+# excludes extra_query: it has no forwarding path outside extra_body yet
 OPENAI_SDK_TRANSPORT_PARAMS: Final = frozenset({"extra_headers", "timeout"})
 
 DEFAULT_EMBEDDING_PARAM_VALUES: Final = {

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -78,6 +78,7 @@ from litellm.constants import (
     MINIMUM_PROMPT_CACHE_TOKEN_COUNT_OVERRIDE,
     NON_INFERENCE_CALL_TYPES,
     OPENAI_EMBEDDING_PARAMS,
+    OPENAI_SDK_TRANSPORT_PARAMS,
     PROVIDERS_THAT_AUTHENTICATE_ON_PROVIDER_INFO,
     TOOL_CHOICE_OBJECT_TOKEN_COUNT,
 )
@@ -4804,7 +4805,7 @@ def add_provider_specific_params_to_optional_params(
         if _should_drop_param(k="extra_body", additional_drop_params=additional_drop_params) is False:
             extra_body: Final = dict(passed_params.pop("extra_body", None) or {})
             for k in passed_params:
-                if k not in openai_params and passed_params[k] is not None:
+                if k not in openai_params and k not in OPENAI_SDK_TRANSPORT_PARAMS and passed_params[k] is not None:
                     extra_body[k] = passed_params[k]
             if not isinstance(optional_params.get("extra_body"), dict):
                 optional_params["extra_body"] = {}
@@ -4822,7 +4823,7 @@ def add_provider_specific_params_to_optional_params(
             optional_params["extra_body"] = _ensure_extra_body_is_safe(extra_body=processed_extra_body)
     else:
         for k in passed_params:
-            if k not in openai_params and passed_params[k] is not None:
+            if k not in openai_params and k not in OPENAI_SDK_TRANSPORT_PARAMS and passed_params[k] is not None:
                 if _should_drop_param(k=k, additional_drop_params=additional_drop_params):
                     continue
                 optional_params[k] = passed_params[k]

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -440,11 +440,13 @@ def test_get_optional_params_image_gen_filters_empty_values():
 def test_get_optional_params_image_gen_excludes_extra_headers_from_extra_body():
     """https://github.com/BerriAI/litellm/issues/40628
 
-    extra_headers/extra_query are openai-python SDK transport options, routed as
-    an actual HTTP request, not model input. GPTImageGenerationConfig's supported
-    params list has no notion of them, so before the fix they fell into extra_body
+    extra_headers is an openai-python SDK transport option, routed as an actual
+    HTTP header, not model input. GPTImageGenerationConfig's supported params
+    list has no notion of it, so before the fix it fell into extra_body
     pass-through, which the SDK serializes into the JSON body, producing an
-    "Unknown parameter: 'extra_headers'" 400 from OpenAI.
+    "Unknown parameter: 'extra_headers'" 400 from OpenAI. extra_query has no
+    working forwarding path for image generation yet, so it's left as before,
+    still inside extra_body.
     """
     from litellm.types.utils import LlmProviders
 
@@ -459,7 +461,7 @@ def test_get_optional_params_image_gen_excludes_extra_headers_from_extra_body():
         extra_headers={"cf-aig-authorization": "Bearer cfut_REDACTED"},
         extra_query={"foo": "bar"},
     )
-    assert optional_params == {}
+    assert optional_params == {"extra_body": {"extra_query": {"foo": "bar"}}}
 
 
 def test_gpt_image_provider_detection_covers_existing_family():
@@ -3758,15 +3760,17 @@ class TestSdkTransportParamsExcludedFromExtraBody:
     """
     Fixes https://github.com/BerriAI/litellm/issues/40628.
 
-    extra_headers/extra_query/timeout are openai-python SDK transport options,
-    routed as an actual HTTP request, not provider request-body content. A caller
-    whose openai_params list is scoped to provider content params only (image
-    generation, audio transcription) rather than the full chat-completion param
-    set previously folded them into extra_body pass-through, which the SDK
-    serializes into the JSON body.
+    extra_headers/timeout already reach the provider through a working path
+    outside extra_body, so a caller whose openai_params list is scoped to
+    provider content params only (image generation, audio transcription) rather
+    than the full chat-completion param set must not also fold them into
+    extra_body pass-through, which the SDK serializes into the JSON body.
+    extra_query has no such path yet, so it deliberately keeps landing in
+    extra_body: still wrong, but a caller gets the same loud failure as before
+    rather than a new silent no-op.
     """
 
-    def test_excluded_for_openai_family_while_unknown_params_still_pass_through(self):
+    def test_excluded_for_openai_family_while_extra_query_and_unknown_still_pass_through(self):
         from litellm.utils import add_provider_specific_params_to_optional_params
 
         passed_params = {
@@ -3787,9 +3791,14 @@ class TestSdkTransportParamsExcludedFromExtraBody:
             additional_drop_params=None,
         )
 
-        assert result == {"extra_body": {"unknown_param": "kept-in-extra-body"}}
+        assert result == {
+            "extra_body": {
+                "extra_query": {"foo": "bar"},
+                "unknown_param": "kept-in-extra-body",
+            }
+        }
 
-    def test_excluded_for_non_openai_family_while_unknown_params_still_pass_through(self):
+    def test_excluded_for_non_openai_family_while_extra_query_and_unknown_still_pass_through(self):
         from litellm.utils import add_provider_specific_params_to_optional_params
 
         passed_params = {
@@ -3808,7 +3817,7 @@ class TestSdkTransportParamsExcludedFromExtraBody:
             additional_drop_params=None,
         )
 
-        assert result == {"custom_param": "keep_me"}
+        assert result == {"extra_query": {"foo": "bar"}, "custom_param": "keep_me"}
 
 
 class TestDropParamsWithPromptCacheKey:

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -437,6 +437,31 @@ def test_get_optional_params_image_gen_filters_empty_values():
     assert optional_params == {}
 
 
+def test_get_optional_params_image_gen_excludes_extra_headers_from_extra_body():
+    """https://github.com/BerriAI/litellm/issues/40628
+
+    extra_headers/extra_query are openai-python SDK transport options, routed as
+    an actual HTTP request, not model input. GPTImageGenerationConfig's supported
+    params list has no notion of them, so before the fix they fell into extra_body
+    pass-through, which the SDK serializes into the JSON body, producing an
+    "Unknown parameter: 'extra_headers'" 400 from OpenAI.
+    """
+    from litellm.types.utils import LlmProviders
+
+    provider_config = ProviderConfigManager.get_provider_image_generation_config(
+        model="gpt-image-1", provider=LlmProviders("openai")
+    )
+    optional_params = get_optional_params_image_gen(
+        model="gpt-image-1",
+        custom_llm_provider="openai",
+        provider_config=provider_config,
+        drop_params=True,
+        extra_headers={"cf-aig-authorization": "Bearer cfut_REDACTED"},
+        extra_query={"foo": "bar"},
+    )
+    assert optional_params == {}
+
+
 def test_gpt_image_provider_detection_covers_existing_family():
     for image_model in ("gpt-image-1", "gpt-image-1-mini", "gpt-image-1.5"):
         model, custom_llm_provider, _, _ = litellm.get_llm_provider(model=image_model)
@@ -3727,6 +3752,63 @@ class TestAdditionalDropParamsForNonOpenAIProviders:
         # All params should be present when additional_drop_params is empty
         assert result.get("prompt_cache_key") == "test_key"
         assert result.get("custom_param") == "value"
+
+
+class TestSdkTransportParamsExcludedFromExtraBody:
+    """
+    Fixes https://github.com/BerriAI/litellm/issues/40628.
+
+    extra_headers/extra_query/timeout are openai-python SDK transport options,
+    routed as an actual HTTP request, not provider request-body content. A caller
+    whose openai_params list is scoped to provider content params only (image
+    generation, audio transcription) rather than the full chat-completion param
+    set previously folded them into extra_body pass-through, which the SDK
+    serializes into the JSON body.
+    """
+
+    def test_excluded_for_openai_family_while_unknown_params_still_pass_through(self):
+        from litellm.utils import add_provider_specific_params_to_optional_params
+
+        passed_params = {
+            "extra_headers": {"cf-aig-authorization": "Bearer token"},
+            "extra_query": {"foo": "bar"},
+            "timeout": 30,
+            "unknown_param": "kept-in-extra-body",
+        }
+        # mirrors GPTImageGenerationConfig.get_supported_openai_params(), which has
+        # no notion of SDK transport options
+        openai_params = ["background", "moderation", "n", "size"]
+
+        result = add_provider_specific_params_to_optional_params(
+            optional_params={},
+            passed_params=passed_params,
+            custom_llm_provider="openai",
+            openai_params=openai_params,
+            additional_drop_params=None,
+        )
+
+        assert result == {"extra_body": {"unknown_param": "kept-in-extra-body"}}
+
+    def test_excluded_for_non_openai_family_while_unknown_params_still_pass_through(self):
+        from litellm.utils import add_provider_specific_params_to_optional_params
+
+        passed_params = {
+            "extra_headers": {"x-custom": "value"},
+            "extra_query": {"foo": "bar"},
+            "timeout": 30,
+            "custom_param": "keep_me",
+        }
+        openai_params = ["temperature"]
+
+        result = add_provider_specific_params_to_optional_params(
+            optional_params={},
+            passed_params=passed_params,
+            custom_llm_provider="bedrock",
+            openai_params=openai_params,
+            additional_drop_params=None,
+        )
+
+        assert result == {"custom_param": "keep_me"}
 
 
 class TestDropParamsWithPromptCacheKey:

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -438,16 +438,8 @@ def test_get_optional_params_image_gen_filters_empty_values():
 
 
 def test_get_optional_params_image_gen_excludes_extra_headers_from_extra_body():
-    """https://github.com/BerriAI/litellm/issues/40628
-
-    extra_headers is an openai-python SDK transport option, routed as an actual
-    HTTP header, not model input. GPTImageGenerationConfig's supported params
-    list has no notion of it, so before the fix it fell into extra_body
-    pass-through, which the SDK serializes into the JSON body, producing an
-    "Unknown parameter: 'extra_headers'" 400 from OpenAI. extra_query has no
-    working forwarding path for image generation yet, so it's left as before,
-    still inside extra_body.
-    """
+    """Fixes https://github.com/BerriAI/litellm/issues/40628: extra_headers must
+    not fold into extra_body; extra_query still does, with no path elsewhere."""
     from litellm.types.utils import LlmProviders
 
     provider_config = ProviderConfigManager.get_provider_image_generation_config(
@@ -3757,18 +3749,9 @@ class TestAdditionalDropParamsForNonOpenAIProviders:
 
 
 class TestSdkTransportParamsExcludedFromExtraBody:
-    """
-    Fixes https://github.com/BerriAI/litellm/issues/40628.
-
-    extra_headers/timeout already reach the provider through a working path
-    outside extra_body, so a caller whose openai_params list is scoped to
-    provider content params only (image generation, audio transcription) rather
-    than the full chat-completion param set must not also fold them into
-    extra_body pass-through, which the SDK serializes into the JSON body.
-    extra_query has no such path yet, so it deliberately keeps landing in
-    extra_body: still wrong, but a caller gets the same loud failure as before
-    rather than a new silent no-op.
-    """
+    """Fixes https://github.com/BerriAI/litellm/issues/40628: extra_headers/timeout
+    must never fold into extra_body pass-through; extra_query still does, since it
+    has no other forwarding path yet."""
 
     def test_excluded_for_openai_family_while_extra_query_and_unknown_still_pass_through(self):
         from litellm.utils import add_provider_specific_params_to_optional_params
@@ -3779,8 +3762,6 @@ class TestSdkTransportParamsExcludedFromExtraBody:
             "timeout": 30,
             "unknown_param": "kept-in-extra-body",
         }
-        # mirrors GPTImageGenerationConfig.get_supported_openai_params(), which has
-        # no notion of SDK transport options
         openai_params = ["background", "moderation", "n", "size"]
 
         result = add_provider_specific_params_to_optional_params(


### PR DESCRIPTION
## TLDR

Problem this solves:

- OpenAI image generation sends `extra_headers` in the request body, not just as a header
- Providers that reject unknown body params (e.g. a gateway in front of OpenAI) return a 400

How it solves it:

- Excludes `extra_headers` (and `timeout`, already a first-class argument everywhere) from the provider-params pass-through that builds `extra_body`, since both already reach the provider through a working path outside it

## User Flow

Before: a developer generating images through a LiteLLM proxy whose OpenAI credential sets `extra_headers` (for example, Cloudflare AI Gateway auth) gets a 400 instead of an image.

1. The proxy admin configures an OpenAI image model (`gpt-image-1`) whose credential sets `extra_headers` to `{ "cf-aig-authorization": "Bearer cfut_REDACTED" }` and points `api_base` at the Cloudflare OpenAI gateway
2. A developer sends `POST https://litellm-domain/v1/images/generations` with `{"model":"gpt-image-1","prompt":"a small red circle on a white background","size":"1024x1024"}`
3. The proxy returns HTTP 400 with `param: "extra_headers"` and `Unknown parameter: 'extra_headers'` in the message. No image is returned
4. The same developer sends `POST https://litellm-domain/v1/chat/completions` against an OpenAI chat model using that same credential and `extra_headers`. That call succeeds

After: the same image request returns an image, and `extra_headers` stay on the HTTP request instead of leaking into the JSON body.

1. The proxy admin keeps the same OpenAI image model, credential, `api_base`, and `extra_headers`
2. The developer sends the same `POST https://litellm-domain/v1/images/generations` with the same body
3. The proxy returns HTTP 200 with image data in `data[0]`
4. `POST https://litellm-domain/v1/chat/completions` against the same credential continues to succeed

## Relevant issues

Fixes #40628

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

I don't have OpenAI API credentials in this environment, so I could not run this end to end against the real API without spending the account owner's money without asking first. Instead, both runs below install a capturing `httpx` transport in place of the real network call and print the literal outgoing request body and headers the OpenAI SDK built, which is the exact mechanism the bug and the fix are about. A maintainer with credentials can confirm the same call against a real gateway if that's wanted before merge.

```python
import httpx, litellm, openai

captured = {}

class CapturingTransport(httpx.BaseTransport):
    def handle_request(self, request):
        captured['headers'] = dict(request.headers)
        captured['body'] = request.content
        return httpx.Response(200, json={'created': 0, 'data': []}, request=request)

orig_init = openai.OpenAI.__init__
def patched_init(self, *a, **kw):
    kw['http_client'] = httpx.Client(transport=CapturingTransport())
    orig_init(self, *a, **kw)
openai.OpenAI.__init__ = patched_init

litellm.image_generation(
    model='openai/gpt-image-1',
    prompt='a small red circle on a white background',
    api_key='sk-test',
    api_base='https://gateway.ai.cloudflare.com/v1/<account>/<gateway>/openai',
    extra_headers={'cf-aig-authorization': 'Bearer cfut_REDACTED'},
    drop_params=True,
)

print('Outgoing request body:', captured['body'].decode())
h = {k.lower(): v for k, v in captured['headers'].items()}
print('cf-aig-authorization header sent:', h.get('cf-aig-authorization'))
```

### Before (9a715df2)

1. `uv run python pr_proof.py`
2. Output:
   ```
   Outgoing request body: {"prompt":"a small red circle on a white background","model":"gpt-image-1","extra_headers":{"cf-aig-authorization":"Bearer cfut_REDACTED"}}
   cf-aig-authorization header sent: Bearer cfut_REDACTED
   ```
   `extra_headers` is duplicated into the JSON body, which is what a real OpenAI-compatible endpoint rejects with `Unknown parameter: 'extra_headers'`

### After (a13e2985)

1. `uv run python pr_proof.py`
2. Output:
   ```
   Outgoing request body: {"prompt":"a small red circle on a white background","model":"gpt-image-1"}
   cf-aig-authorization header sent: Bearer cfut_REDACTED
   ```
   `extra_headers` no longer appears in the body, and the header is still sent correctly

## Type

🐛 Bug Fix
✅ Test

## Caveats (if any)

### Low

- `extra_query` has the same underlying gap (no forwarding path outside `extra_body` for image generation or audio transcription), but unlike `extra_headers` it has nowhere else to go yet, so it deliberately still lands in `extra_body` and keeps its existing loud failure mode instead of trading it for a silent no-op. Giving it a real path is a separate, larger change (new plumbing through the image/transcription handlers, mirroring how `extra_headers` is threaded today) and is left as a follow-up
- The same `add_provider_specific_params_to_optional_params` function also serves audio transcription's `openai_params` list, which had the identical `extra_headers` gap for the OpenAI provider branch specifically (Azure transcription already re-injects `extra_headers` separately and is unaffected either way). This fix covers that path too since the exclusion lives in the shared function, but no transcription-specific test was added since it wasn't the reported symptom

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
