### PR TITLE
fix(anthropic): tolerate a text block start without the text key

### DIFF
--- a/litellm/llms/anthropic/chat/handler.py
+++ b/litellm/llms/anthropic/chat/handler.py
@@ -891,7 +891,10 @@ class ModelResponseIterator:
                 # Track current content block type for filtering deltas
                 self.current_content_block_type = content_block_start["content_block"]["type"]
                 if content_block_start["content_block"]["type"] == "text":
-                    text = content_block_start["content_block"]["text"]
+                    # Anthropic always sends "text": "" here, but some compatible gateways omit
+                    # the key. Absence on a text block start has the same meaning as the empty
+                    # string, so read it leniently rather than dropping the stream.
+                    text = content_block_start["content_block"].get("text", "")
                 elif (
                     content_block_start["content_block"]["type"] == "tool_use"
                     or content_block_start["content_block"]["type"] == "server_tool_use"

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_handler.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_handler.py
@@ -532,6 +532,42 @@ def test_regular_tool_finish_reason():
     assert model_response.choices[0].finish_reason == "tool_calls"
 
 
+def test_content_block_start_without_text_key_does_not_kill_the_stream():
+    """Some Anthropic-compatible gateways omit "text" on a text block start.
+
+    api.anthropic.com always sends "text": "", so absence carries the same meaning.
+    https://github.com/BerriAI/litellm/issues/40689
+    """
+    chunks = [
+        {
+            "type": "message_start",
+            "message": {
+                "id": "msg_123",
+                "type": "message",
+                "role": "assistant",
+                "content": [],
+                "usage": {"input_tokens": 10, "output_tokens": 1},
+            },
+        },
+        # no "text" key, unlike the official API
+        {"type": "content_block_start", "index": 0, "content_block": {"type": "text"}},
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "text_delta", "text": "hi"},
+        },
+        {"type": "content_block_stop", "index": 0},
+    ]
+
+    iterator = ModelResponseIterator(None, sync_stream=True)
+    parsed = [iterator.chunk_parser(chunk) for chunk in chunks]
+
+    start = parsed[1]
+    assert start.choices[0].delta.content == ""
+    delta = parsed[2]
+    assert delta.choices[0].delta.content == "hi"
+
+
 def test_text_only_streaming_has_index_zero():
     """Test that text-only streaming responses have choice index=0"""
     chunks = [


### PR DESCRIPTION
## TLDR

Problem this solves:

- A text block start without `"text"` raises `KeyError`
- The first block of every stream dies on such gateways

How it solves it:

- Read the field with a default, as the neighbouring branches do

## User Flow

Before: a developer pointing the proxy at an Anthropic-compatible gateway gets no output at all from a streamed request

1. They configure a model as `anthropic/<model>` against a gateway that is not `api.anthropic.com`
2. They send POST https://litellm-domain/v1/chat/completions with `"stream": true`
3. The gateway opens with `content_block_start` carrying `{"type":"text"}` and no `text` key
4. The stream ends immediately with `KeyError: 'text'`, before any content reaches them

After: the same request streams normally

1. They use the same configuration and the same gateway
2. They send the same streamed request
3. The same `content_block_start` arrives without a `text` key
4. The block opens with empty content and the deltas that follow stream through as usual

## Relevant issues

Fixes #40689

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

This one is inside the stream parser, so the observable behaviour is what `chunk_parser` does with the event the gateway sends. The event below is the one quoted in the issue, captured from a real gateway.

### Before (e8140eb269)

1. Feed the gateway's `content_block_start` to the parser

```python
from litellm.llms.anthropic.chat.handler import ModelResponseIterator
it = ModelResponseIterator(None, sync_stream=True)
it.chunk_parser({"type": "content_block_start", "index": 0, "content_block": {"type": "text"}})
```

```text
KeyError: 'text'
  litellm/llms/anthropic/chat/handler.py:894
```

### After (8add0d1e52)

1. Feed the parser the same event

```python
from litellm.llms.anthropic.chat.handler import ModelResponseIterator
it = ModelResponseIterator(None, sync_stream=True)
print(it.chunk_parser({"type": "content_block_start", "index": 0, "content_block": {"type": "text"}}).choices[0].delta.content)
```

```text

```

(empty string, the same thing the official API's `"text": ""` produces)

2. The delta that follows still streams

```python
print(it.chunk_parser({"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "hi"}}).choices[0].delta.content)
```

```text
hi
```

3. The file's suite, including the new case

```bash
pytest tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_handler.py -q
```

```text
56 passed
```

Reverting the one line fails the new test with the same `KeyError: 'text'` at handler.py:894, so it is testing the fix rather than the parser generally.

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Only the text branch; `tool_use` and `thinking` starts are unchanged
- `ruff check` and `format` report pre-existing findings in this test file on `litellm_internal_staging`, untouched here. Both budget gates pass

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
