### PR TITLE
fix(google-genai): preserve Vertex location for cost tracking

### DIFF
--- a/litellm/google_genai/main.py
+++ b/litellm/google_genai/main.py
@@ -17,6 +17,7 @@ from litellm.llms.base_llm.google_genai.transformation import (
     BaseGoogleGenAIGenerateContentConfig,
 )
 from litellm.llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
+from litellm.llms.vertex_ai.vertex_llm_base import VertexBase
 from litellm.types.router import GenericLiteLLMParams
 from litellm.types.utils import CallTypes
 from litellm.utils import ProviderConfigManager, client
@@ -198,6 +199,7 @@ class GenerateContentHelper:
             optional_params=dict(generate_content_config_dict),
             litellm_params={
                 "litellm_call_id": litellm_call_id,
+                "vertex_location": VertexBase.explicit_vertex_ai_location(litellm_params.model_dump()),
             },
             custom_llm_provider=custom_llm_provider,
         )

--- a/litellm/google_genai/main.py
+++ b/litellm/google_genai/main.py
@@ -17,7 +17,6 @@ from litellm.llms.base_llm.google_genai.transformation import (
     BaseGoogleGenAIGenerateContentConfig,
 )
 from litellm.llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
-from litellm.llms.vertex_ai.vertex_llm_base import VertexBase
 from litellm.types.router import GenericLiteLLMParams
 from litellm.types.utils import CallTypes
 from litellm.utils import ProviderConfigManager, client
@@ -199,7 +198,7 @@ class GenerateContentHelper:
             optional_params=dict(generate_content_config_dict),
             litellm_params={
                 "litellm_call_id": litellm_call_id,
-                "vertex_location": VertexBase.explicit_vertex_ai_location(litellm_params.model_dump()),
+                **generate_content_provider_config.get_generate_content_logging_params(litellm_params),
             },
             custom_llm_provider=custom_llm_provider,
         )

--- a/litellm/llms/base_llm/google_genai/transformation.py
+++ b/litellm/llms/base_llm/google_genai/transformation.py
@@ -1,5 +1,6 @@
 import types
 from abc import ABC, abstractmethod
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
 import httpx
@@ -72,6 +73,9 @@ class BaseGoogleGenAIGenerateContentConfig(ABC):
         to ``config``).
         """
         return ("safetySettings", "toolConfig", "cachedContent", "labels")
+
+    def get_generate_content_logging_params(self, litellm_params: GenericLiteLLMParams) -> Mapping[str, object]:
+        return types.MappingProxyType({})
 
     @abstractmethod
     def map_generate_content_optional_params(

--- a/litellm/llms/vertex_ai/google_genai/transformation.py
+++ b/litellm/llms/vertex_ai/google_genai/transformation.py
@@ -2,6 +2,8 @@
 Transformation for Calling Google models in their native format.
 """
 
+from collections.abc import Mapping
+from types import MappingProxyType
 from typing import Any, Final, Literal
 
 from litellm.llms.gemini.google_genai.transformation import GoogleGenAIConfig
@@ -19,6 +21,9 @@ class VertexAIGoogleGenAIConfig(GoogleGenAIConfig):
     @property
     def custom_llm_provider(self) -> Literal["gemini", "vertex_ai"]:
         return "vertex_ai"
+
+    def get_generate_content_logging_params(self, litellm_params: GenericLiteLLMParams) -> Mapping[str, object]:
+        return MappingProxyType({"vertex_location": self.explicit_vertex_ai_location(litellm_params.model_dump())})
 
     def validate_environment(
         self,

--- a/tests/test_litellm/google_genai/test_google_genai_main.py
+++ b/tests/test_litellm/google_genai/test_google_genai_main.py
@@ -4,13 +4,115 @@ Test to verify the Google GenAI generate_content adapter functionality
 """
 
 import json
+from datetime import datetime
+from typing import Final
 
 import pytest
 
 
-
-
 import litellm
+from litellm.google_genai.main import GenerateContentHelper
+from litellm.litellm_core_utils.litellm_logging import Logging
+from litellm.llms.gemini.google_genai.transformation import GoogleGenAIConfig
+
+
+@pytest.mark.parametrize(
+    "provider,location_kwargs,environment_location,expected_location,expected_cost",
+    [
+        ("vertex_ai", {"vertex_location": "global"}, "us-central1", "global", 5.25e-6),
+        (
+            "vertex_ai",
+            {"vertex_location": "europe-west4"},
+            "global",
+            "europe-west4",
+            5.775e-6,
+        ),
+        (
+            "vertex_ai",
+            {"vertex_ai_location": "global"},
+            "us-central1",
+            "global",
+            5.25e-6,
+        ),
+        (
+            "vertex_ai",
+            {"vertex_location": "global", "vertex_ai_location": "us-central1"},
+            "europe-west4",
+            "global",
+            5.25e-6,
+        ),
+        ("vertex_ai", {}, "global", "global", 5.25e-6),
+        ("vertex_ai", {}, None, "us-central1", 5.775e-6),
+        ("gemini", {"vertex_location": "us-central1"}, "us-central1", None, 5.25e-6),
+    ],
+)
+def test_generate_content_prices_the_request_location(
+    monkeypatch: pytest.MonkeyPatch,
+    provider: str,
+    location_kwargs: dict[str, str],
+    environment_location: str | None,
+    expected_location: str | None,
+    expected_cost: float,
+) -> None:
+    monkeypatch.setattr(litellm, "vertex_location", None)
+    monkeypatch.delenv("VERTEX_LOCATION", raising=False)
+    if environment_location is None:
+        monkeypatch.delenv("VERTEXAI_LOCATION", raising=False)
+    else:
+        monkeypatch.setenv("VERTEXAI_LOCATION", environment_location)
+
+    logging_obj: Final = Logging(
+        model="gemini-flash",
+        messages=[],
+        stream=False,
+        call_type="agenerate_content",
+        start_time=datetime.now(),
+        litellm_call_id="test-vertex-location",
+        function_id="test-vertex-location",
+    )
+    setup: Final = GenerateContentHelper.setup_generate_content_call(
+        model=f"{provider}/gemini-3.8-flash",
+        contents=[{"role": "user", "parts": [{"text": "say ok"}]}],
+        config={"temperature": 0},
+        vertex_project="test-project",
+        api_key="test-key",
+        litellm_logging_obj=logging_obj,
+        **location_kwargs,
+    )
+    config: Final = setup.generate_content_provider_config
+    assert isinstance(config, GoogleGenAIConfig)
+    credentials, project, location = config._get_common_auth_components(dict(setup.litellm_params))
+    _, url = config._build_final_headers_and_url(
+        model=setup.model,
+        auth_header="test-token",
+        vertex_project=project,
+        vertex_location=location,
+        vertex_credentials=credentials,
+        stream=False,
+        api_base=None,
+        litellm_params=dict(setup.litellm_params),
+    )
+    if expected_location is None:
+        assert url.startswith("https://generativelanguage.googleapis.com/")
+    else:
+        assert f"/locations/{expected_location}/" in url
+    assert setup.generate_content_config_dict == {"temperature": 0}
+    assert "vertex_location" not in setup.request_body
+
+    response: Final = {
+        "candidates": [
+            {
+                "content": {"parts": [{"text": "ok"}], "role": "model"},
+                "finishReason": "STOP",
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 2,
+            "candidatesTokenCount": 1,
+            "totalTokenCount": 3,
+        },
+    }
+    assert logging_obj._response_cost_calculator(result=response) == pytest.approx(expected_cost)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## TLDR

Problem this solves:

- Native generateContent requests can use the wrong regional pricing

How it solves it:

- Preserve the request's explicit Vertex location in cost logging
- Reuse the existing location alias and precedence helper

The request URL already uses the configured location. The shared generateContent setup only passed generation options and the call ID to logging, so cost calculation fell back to the environment or `us-central1`. The fix gets logging parameters from the provider configuration, which keeps Vertex location normalization under llms/. It records the explicit location from the same normalized parameters used to dispatch the request, without adding provider options to Google's request body

## User Flow

Before: the global deployment in #40692 records a regional surcharge

1. Configure `gemini-flash` as `vertex_ai/gemini-3.8-flash` with `vertex_location: global`
2. Send `POST https://litellm-domain/v1beta/models/gemini-flash:generateContent` with a short text prompt
3. Inspect `GET https://litellm-domain/spend/logs`: a response with 2 input tokens and 1 output token costs $0.000005775

After: that request uses the configured global rate

1. Configure `gemini-flash` as `vertex_ai/gemini-3.8-flash` with `vertex_location: global`
2. Send `POST https://litellm-domain/v1beta/models/gemini-flash:generateContent` with a short text prompt
3. Inspect `GET https://litellm-domain/spend/logs`: the same usage costs $0.00000525

## Relevant issues

Fixes #40692

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is isolated to one problem
- [x] Greptile confidence is at least 4/5 before requesting maintainer review

## Validation

The regression compares the actual provider URL construction with the final logging cost for seven cases: explicit global and regional locations overriding the environment, the `vertex_ai_location` alias, both aliases supplied, environment fallback, default fallback, and Gemini without a Vertex surcharge. The four explicit Vertex cases fail on the base and pass with the fix

```bash
LITELLM_MODE=PRODUCTION LITELLM_LOCAL_MODEL_COST_MAP=True python -m pytest \
  tests/test_litellm/google_genai \
  tests/test_litellm/llms/vertex_ai/test_vertex_global_url_support.py -q
```

130 passed. Ruff 0.15.3 and production-file formatting pass. The changed files add no type-discipline or test-quality violations, and the production file adds no basedpyright diagnostics compared with the base

## Screenshots / Proof of Fix

No live provider call was made. The amounts above are reproduced offline with the repository's `gemini-3.8-flash` pricing and synthetic usage, rather than captured from a running proxy

## Type

Bug Fix

## Caveats

### Low

- Full proxy/Rust installation and full `make lint` were not run
- Existing async-mock warnings also occur on the unchanged base
- Hosted CI and automated review results remain pending

## Final Attestation

- [x] Tests check request routing, final spend, aliases, and fallbacks
