### PR TITLE
fix(cli): preserve Codex proxy config with subcommand overrides

### DIFF
--- a/litellm/proxy/client/cli/commands/agents.py
+++ b/litellm/proxy/client/cli/commands/agents.py
@@ -2,7 +2,7 @@ import os
 import shutil
 import subprocess
 import sys
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from types import MappingProxyType
@@ -204,6 +204,37 @@ def agent_launch_args(command: str, base_url: str) -> list[str]:
     """
     builder: Final = _PROXY_ARGS.get(os.path.basename(command))
     return builder(base_url) if builder else []
+
+
+def _codex_arg_groups(user_args: Sequence[str]) -> Iterator[tuple[bool, tuple[str, ...]]]:
+    tokens: Final = iter(user_args)
+    for token in tokens:
+        if token == "--":
+            yield False, (token, *tokens)
+            return
+        if token in ("-c", "--config"):
+            if (value := next(tokens, None)) is None:
+                yield False, (token,)
+                return
+            if value.startswith("-"):
+                yield False, (token, value, *tokens)
+                return
+            yield True, (token, value)
+        else:
+            yield token.startswith(("-c", "--config=")), (token,)
+
+
+def _codex_launch_args(user_args: Sequence[str], extra_args: Sequence[str]) -> tuple[str, ...]:
+    # Codex discards root -c values when a subcommand has its own. Replay the
+    # defaults and earlier user overrides at the last config option's scope.
+    groups: Final = tuple(_codex_arg_groups(user_args))
+    last_config: Final = max((index for index, (is_config, _) in enumerate(groups) if is_config), default=0)
+    return (
+        *(arg for _, args in groups[:last_config] for arg in args),
+        *extra_args,
+        *(arg for is_config, args in groups[:last_config] if is_config for arg in args),
+        *(arg for _, args in groups[last_config:] for arg in args),
+    )
 
 
 class ListedModel(BaseModel):
@@ -513,9 +544,14 @@ def run_agent(
         }
     )
     extra_args: Final = (*agent_launch_args(command[0], base_url), *prepared_args)
+    launch_args: Final = (
+        _codex_launch_args(command[1:], extra_args)
+        if os.path.basename(command[0]) == "codex"
+        else (*extra_args, *command[1:])
+    )
     if reattach_terminal is not None:
         reattach_terminal()
-    launcher(binary, [command[0], *extra_args, *command[1:]], env)
+    launcher(binary, [command[0], *launch_args], env)
 
 
 def _is_interactive() -> bool:

--- a/tests/test_litellm/proxy/client/cli/test_agents.py
+++ b/tests/test_litellm/proxy/client/cli/test_agents.py
@@ -9,8 +9,6 @@ import pytest
 import requests
 from click.testing import CliRunner
 
-
-
 from litellm.proxy.client.cli.commands.agents import (
     AgentRunError,
     ModelSyncSkipped,
@@ -582,8 +580,146 @@ class TestRunAgent:
         assert args[-2:] == ("exec", "do a thing")
         assert 'model_provider="litellm"' in args
         assert 'model_providers.litellm.base_url="http://localhost:4000/v1"' in args
-        # overrides must precede the codex subcommand so codex parses them
         assert args.index('model_provider="litellm"') < args.index("exec")
+
+    @pytest.mark.parametrize(
+        "subcommand",
+        [
+            ("exec",),
+            ("e",),
+            ("resume", "--last"),
+            ("review",),
+            ("fork", "--last"),
+            ("exec", "resume", "--last"),
+            ("exec", "review"),
+            ("exec", "fork", "--last"),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "config_args",
+        [
+            ("-c", "model_reasoning_effort=low"),
+            ("--config", "model_reasoning_effort=low"),
+            ("--config=model_reasoning_effort=low",),
+            ("-cmodel_reasoning_effort=low",),
+            ("-c=model_reasoning_effort=low",),
+        ],
+    )
+    def test_codex_injects_proxy_overrides_at_subcommand_config_scope(self, subcommand, config_args):
+        launcher = _Recorder()
+        run_agent(
+            "http://localhost:4000",
+            "sk-key",
+            ("/usr/local/bin/codex", *subcommand, *config_args, "hello"),
+            skip_verify=True,
+            base_env={},
+            which=lambda name: name,
+            launcher=launcher,
+        )
+
+        binary, args, env = launcher.calls[0]
+        assert binary == "/usr/local/bin/codex"
+        assert args == [
+            "/usr/local/bin/codex",
+            *subcommand,
+            *agent_launch_args("codex", "http://localhost:4000"),
+            *config_args,
+            "hello",
+        ]
+        assert env["OPENAI_API_KEY"] == "sk-key"
+
+    @pytest.mark.parametrize("first_scope", [(), ("exec",)])
+    def test_codex_replays_user_overrides_after_proxy_defaults(self, first_scope):
+        launcher = _Recorder()
+        provider = ("-c", 'model_provider="custom"')
+        base_url = ("--config", 'model_providers.litellm.base_url="http://other/v1"')
+        last_config = ("-c", "model_reasoning_effort=low")
+        child_scope = () if first_scope else ("exec",)
+        prefix = (*first_scope, *provider, *child_scope, *base_url)
+        run_agent(
+            "http://localhost:4000",
+            "sk-key",
+            ("codex", *prefix, *last_config, "hello"),
+            skip_verify=True,
+            base_env={},
+            which=lambda name: name,
+            launcher=launcher,
+        )
+        assert launcher.calls[0][1] == [
+            "codex",
+            *prefix,
+            *agent_launch_args("codex", "http://localhost:4000"),
+            *provider,
+            *base_url,
+            *last_config,
+            "hello",
+        ]
+
+    @pytest.mark.parametrize(
+        "user_args",
+        [
+            ("exec", "--", "--config=model_provider=custom"),
+            ("exec", "--", "-c"),
+            ("exec", "explain --config and -c"),
+            ("exec", "-c"),
+            ("exec", "--config"),
+            ("exec", "-c", "--", "--config=literal"),
+            ("exec", "--config", "--help"),
+            ("exec", "-mcustom-model"),
+            ("exec", "--configurations=literal"),
+        ],
+    )
+    def test_codex_preserves_literals_and_missing_config_values(self, user_args):
+        launcher = _Recorder()
+        run_agent(
+            "http://localhost:4000",
+            "sk-key",
+            ("codex", *user_args),
+            skip_verify=True,
+            base_env={},
+            which=lambda name: name,
+            launcher=launcher,
+        )
+        assert launcher.calls[0][1] == [
+            "codex",
+            *agent_launch_args("codex", "http://localhost:4000"),
+            *user_args,
+        ]
+
+    def test_codex_keeps_config_flag_after_option_with_missing_operand(self):
+        launcher = _Recorder()
+        run_agent(
+            "http://localhost:4000",
+            "sk-key",
+            ("codex", "exec", "--output-schema", "-c", "model_reasoning_effort=low", "hello"),
+            skip_verify=True,
+            base_env={},
+            which=lambda name: name,
+            launcher=launcher,
+        )
+        assert launcher.calls[0][1] == [
+            "codex",
+            "exec",
+            "--output-schema",
+            *agent_launch_args("codex", "http://localhost:4000"),
+            "-c",
+            "model_reasoning_effort=low",
+            "hello",
+        ]
+
+    def test_other_agents_keep_config_arguments_in_place(self):
+        launcher = _Recorder()
+        command = ("mytool", "exec", "-c", "model=test", "--", "--config=prompt")
+        run_agent(
+            "http://localhost:4000",
+            "sk-key",
+            command,
+            skip_verify=True,
+            base_env={},
+            which=lambda name: name,
+            launcher=launcher,
+        )
+        assert launcher.calls[0][1] == list(command)
 
     def test_pi_preparer_runs_after_verify_and_before_launch(self):
         order = []


### PR DESCRIPTION
## TLDR

Problem this solves:

- Subcommand config overrides discard Codex's injected proxy provider
- The CLI reports proxy routing while Codex selects OpenAI

How it solves it:

- Inject defaults at the last config option's scope
- Replay earlier user overrides to preserve their precedence
- Keep original argument positions and missing-value errors

## User Flow

Before: adding a reasoning override silently changes the selected provider

1. Run `lite codex exec --skip-git-repo-check -c model_reasoning_effort=low "Reply with hi"`
2. Lite reports routing through the configured proxy
3. Codex reports `provider: openai`, bypassing the configured proxy

After: the same reasoning override retains the proxy provider

1. Run `lite codex exec --skip-git-repo-check -c model_reasoning_effort=low "Reply with hi"`
2. Lite reports routing through the configured proxy
3. Codex reports `provider: litellm`, retaining the configured proxy

## Relevant issues

Fixes #40651

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves one specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting maintainer review

The new regression cases produce 43 failures on the base revision. The complete CLI directory passes locally: 766 tests, with 96% coverage of `agents.py` and every added statement covered

```sh
LITELLM_MODE=PRODUCTION LITELLM_LOCAL_MODEL_COST_MAP=True python -m pytest \
  --confcutdir=tests/test_litellm/proxy/client/cli \
  -p tests.test_litellm.conftest \
  tests/test_litellm/proxy/client/cli \
  --cov=litellm.proxy.client.cli.commands.agents --cov-report=term-missing -q
```

This loads the real shared root fixtures and CLI isolation fixtures without importing the unrelated proxy-server fixture stack. Ruff 0.15.3 and production-file formatting pass. The changed files add no type-discipline, test-quality, or basedpyright diagnostics compared with the base

## Screenshots / Proof of Fix

Python 3.12, macOS, and installed Codex CLI 0.153.4. These are actual CLI startup probes with network access denied by the OS, ephemeral authentication, and a fixed invalid test key. Each process was stopped when its provider banner appeared, or allowed to exit on a configuration error. These results confirm startup configuration, not model completion

Activate the test environment and run from the corresponding checkout:

```sh
probe() {
  sandbox-exec -p '(version 1)(allow default)(deny network*)' \
    env -i PATH="$PATH" CODEX_API_KEY=sk-offline-invalid-probe \
    LITELLM_MODE=PRODUCTION LITELLM_LOCAL_MODEL_COST_MAP=True PYTHONWARNINGS=ignore \
    python -m litellm.proxy.client.cli.main \
    --base-url http://127.0.0.1:1 --api-key sk-offline-invalid-probe \
    codex --skip-verify -- "$@"
}
```

### Before (9a715df212d777bbd43f4cab05731978c708ec63)

#### Subcommand config

1. Run `probe exec --ignore-user-config --ephemeral --ignore-rules --skip-git-repo-check -c 'cli_auth_credentials_store="ephemeral"' -c model_reasoning_effort=low test`
2. The output includes `litellm: routing Codex through proxy at http://127.0.0.1:1` followed by `provider: openai`

#### Explicit user provider

1. Run `probe -c 'model_provider="wave3-user-provider"' exec --ignore-user-config --ephemeral --ignore-rules --skip-git-repo-check -c 'cli_auth_credentials_store="ephemeral"' -c model_reasoning_effort=low test`
2. Codex reports `provider: openai`, discarding the user's explicit provider too

#### Missing schema value

1. Run `probe exec --output-schema -c model_reasoning_effort=low test`
2. Codex exits with code 2 and `error: a value is required for '--output-schema <FILE>' but none was supplied`

### After (fbe7df0d20f05b85f018bf6ce32364d960133faa)

#### Subcommand config

1. Run `probe exec --ignore-user-config --ephemeral --ignore-rules --skip-git-repo-check -c 'cli_auth_credentials_store="ephemeral"' -c model_reasoning_effort=low test`
2. The output includes `litellm: routing Codex through proxy at http://127.0.0.1:1` followed by `provider: litellm`

#### Explicit user provider

1. Run `probe -c 'model_provider="wave3-user-provider"' exec --ignore-user-config --ephemeral --ignore-rules --skip-git-repo-check -c 'cli_auth_credentials_store="ephemeral"' -c model_reasoning_effort=low test`
2. Codex exits with code 1 and ``Error: Model provider `wave3-user-provider` not found``, confirming the explicit user override wins

#### Missing schema value

1. Run `probe exec --output-schema -c model_reasoning_effort=low test`
2. Codex exits with code 2 and `error: a value is required for '--output-schema <FILE>' but none was supplied`

The same startup comparison covers `--config=...`, attached `-c...`, and `exec review`. Commands without subcommand config retain `provider: litellm`. Missing `-c`, `--config --help`, `-c --`, and empty `--config=` retain their original exit codes and error messages

## Type

Bug Fix

## Caveats (if any)

### Low

- Validation stops at startup; no paid inference exercised
- Full repository CI and automated review remain pending

## Final Attestation

- [x] Tests cover the reported regression and identified argument boundaries
