### PR TITLE
fix(terraform): omit empty team_id from /key/update payload

### DIFF
--- a/terraform/provider/litellm/client.go
+++ b/terraform/provider/litellm/client.go
@@ -125,7 +125,6 @@ func (c *Client) UpdateKey(key *Key) (*Key, error) {
 	// Create a new map with only the fields that can be updated
 	updateData := map[string]interface{}{
 		"key":              key.Key,
-		"team_id":          key.TeamID,
 		"key_alias":        key.KeyAlias,
 		"aliases":          key.Aliases,
 		"permissions":      key.Permissions,
@@ -142,6 +141,12 @@ func (c *Client) UpdateKey(key *Key) (*Key, error) {
 	}
 	if key.ModelTPMLimit != nil {
 		updateData["model_tpm_limit"] = key.ModelTPMLimit
+	}
+
+	// The proxy rejects an empty team_id with a 500 ("Team object not found"),
+	// so only send it when set.
+	if key.TeamID != "" {
+		updateData["team_id"] = key.TeamID
 	}
 
 	// The proxy rejects an empty-string budget_duration with a 400, so only

--- a/terraform/provider/litellm/resource_key_test.go
+++ b/terraform/provider/litellm/resource_key_test.go
@@ -319,6 +319,34 @@ func TestUpdateKeyOmitsEmptyBudgetDuration(t *testing.T) {
 	}
 }
 
+// The proxy 500s on team_id: "" with "Team object not found", so a teamless key
+// must omit it from the update payload entirely.
+func TestUpdateKeyOmitsEmptyTeamID(t *testing.T) {
+	var captured map[string]interface{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &captured)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"key": "sk-test"}`))
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key", true)
+	if _, err := client.UpdateKey(&Key{Key: "sk-test"}); err != nil {
+		t.Fatalf("UpdateKey returned error: %v", err)
+	}
+	if _, present := captured["team_id"]; present {
+		t.Errorf("update payload contains empty team_id: %v", captured["team_id"])
+	}
+
+	if _, err := client.UpdateKey(&Key{Key: "sk-test", TeamID: "team-1"}); err != nil {
+		t.Fatalf("UpdateKey returned error: %v", err)
+	}
+	if captured["team_id"] != "team-1" {
+		t.Errorf("team_id = %v, want team-1", captured["team_id"])
+	}
+}
+
 func TestResourceKeyUpdateFailureKeepsPriorState(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
## TLDR

Problem this solves:

- Updating a key with no team returns 500
- Terraform config and proxy drift apart permanently

How it solves it:

- Send `team_id` only when it is set
- Matches how `budget_duration` is already handled

## User Flow

Before: a platform engineer who manages virtual keys in Terraform cannot raise the budget on any key that is not attached to a team

1. They apply a config holding one `litellm_key` with `models` and `max_budget` and no `team_id`, and the key is created
2. They raise `max_budget` from 10 to 25 and apply again
3. The apply fails with `500` and `{'error': 'Team object not found for team change validation'}`
4. They open https://litellm-domain/ui/?page=api-keys, edit the same key by hand, and the budget saves fine
5. Every later apply keeps failing on the same key, so the config never matches the proxy again

After: the same budget change applies

1. They apply the same config holding one `litellm_key` with no `team_id`, and the key is created
2. They raise `max_budget` from 10 to 25 and apply again
3. The apply succeeds and reports one resource changed
4. https://litellm-domain/ui/?page=api-keys shows the key at the new budget, still with no team
5. Running plan again reports no changes

## Relevant issues

Fixes #40704

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Shared setup. Proxy is `ghcr.io/berriai/litellm:main-stable`, image revision
`10f4033437df30b91b5dbf2b64711d0a8683fc52`, which is `v1.99.1`, against Postgres 16. Terraform
v1.10.5 on linux_amd64, with the provider built from source at each hash below and loaded through a
`dev_overrides` block, so no registry build is involved.

```yaml
model_list: []
general_settings:
  master_key: "sk-e2e-master-key"
  database_connection_pool_limit: 10
  database_url: "postgresql://litellm:litellm@postgresql:5432/litellm"
litellm_settings:
  drop_params: true
```

The config under test is one `litellm_key` with no `team_id`, and `budget` moves from 10 to 25
between the two applies:

```hcl
resource "litellm_key" "app" {
  models     = ["gpt-4o-mini"]
  max_budget = var.budget
}
```

The proxy image is older than this branch's base. Both endpoint behaviours involved are unchanged
between the two, checked with `git diff v1.99.1 upstream/litellm_internal_staging -- litellm/proxy/management_endpoints/key_management_endpoints.py`,
which does not touch team change validation.

### Before (9a715df212)

1. Create the key, which works

```console
$ terraform apply -auto-approve
litellm_key.app: Creation complete after 1s [id=4a5c383485cd6d4fba7049d26c954fefa67679bad7c7475e789f2ba5ba1fa37a]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

2. Raise the budget, which fails

```console
$ terraform apply -auto-approve -var budget=25
litellm_key.app: Modifying... [id=4a5c383485cd6d4fba7049d26c954fefa67679bad7c7475e789f2ba5ba1fa37a]
╷
│ Error: error updating key: API request failed with status code 500: {"error":{"message":"{'error': 'Team object not found for team change validation'}","type":"auth_error","param":"None","code":"500"}}
│
│   with litellm_key.app,
│   on main.tf line 19, in resource "litellm_key" "app":
│   19: resource "litellm_key" "app" {
│
╵
```

### After (ed6f8216d8)

1. The same budget change now applies

```console
$ terraform apply -auto-approve -var budget=25
Plan: 0 to add, 1 to change, 0 to destroy.
litellm_key.app: Modifying... [id=4a5c383485cd6d4fba7049d26c954fefa67679bad7c7475e789f2ba5ba1fa37a]
litellm_key.app: Modifications complete after 0s [id=4a5c383485cd6d4fba7049d26c954fefa67679bad7c7475e789f2ba5ba1fa37a]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

2. Plan is clean afterwards

```console
$ terraform plan -var budget=25

Terraform has compared your real infrastructure against your configuration
and found no differences, so no changes are needed.
```

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- A key cannot be moved out of a team by clearing `team_id`
  - The proxy rejects an empty `team_id` outright, so there was never a working way to do it
  - Same trade-off `budget_duration` already makes

### Low

- Keys with no team and no alias also need #40705 to update cleanly
  - This fix alone takes them from a 500 to a 400

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
