### PR TITLE
fix(terraform): omit empty key_alias from /key/update payload

### DIFF
--- a/terraform/provider/litellm/client.go
+++ b/terraform/provider/litellm/client.go
@@ -126,11 +126,17 @@ func (c *Client) UpdateKey(key *Key) (*Key, error) {
 	updateData := map[string]interface{}{
 		"key":              key.Key,
 		"team_id":          key.TeamID,
-		"key_alias":        key.KeyAlias,
 		"aliases":          key.Aliases,
 		"permissions":      key.Permissions,
 		"model_max_budget": key.ModelMaxBudget,
 		"blocked":          key.Blocked,
+	}
+
+	// /key/generate omits an empty key_alias, so sending "" here would store an
+	// alias the key never had and collide with every other aliasless key on the
+	// proxy's uniqueness check.
+	if key.KeyAlias != "" {
+		updateData["key_alias"] = key.KeyAlias
 	}
 
 	// The proxy keeps the stored metadata only when the field is absent, so nil means omit.

--- a/terraform/provider/litellm/resource_key_test.go
+++ b/terraform/provider/litellm/resource_key_test.go
@@ -319,6 +319,35 @@ func TestUpdateKeyOmitsEmptyBudgetDuration(t *testing.T) {
 	}
 }
 
+// /key/generate omits an empty key_alias, so an update that sends "" stores an
+// alias the key never had, and the proxy then 400s every other aliasless key on
+// its unique-alias check.
+func TestUpdateKeyOmitsEmptyKeyAlias(t *testing.T) {
+	var captured map[string]interface{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &captured)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"key": "sk-test"}`))
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key", true)
+	if _, err := client.UpdateKey(&Key{Key: "sk-test"}); err != nil {
+		t.Fatalf("UpdateKey returned error: %v", err)
+	}
+	if _, present := captured["key_alias"]; present {
+		t.Errorf("update payload contains empty key_alias: %v", captured["key_alias"])
+	}
+
+	if _, err := client.UpdateKey(&Key{Key: "sk-test", KeyAlias: "alias-1"}); err != nil {
+		t.Fatalf("UpdateKey returned error: %v", err)
+	}
+	if captured["key_alias"] != "alias-1" {
+		t.Errorf("key_alias = %v, want alias-1", captured["key_alias"])
+	}
+}
+
 func TestResourceKeyUpdateFailureKeepsPriorState(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
## TLDR

Problem this solves:

- Updates write an empty alias onto every key
- The next aliasless key then 400s on a collision

How it solves it:

- Send `key_alias` only when it is set
- Matches what `/key/generate` already does

## User Flow

Before: a platform engineer managing several unnamed virtual keys in one Terraform config can only ever update one of them

1. They apply a config with a team and two `litellm_key` resources in it, neither with a `key_alias`, and all three are created
2. They raise `max_budget` from 10 to 25 on both keys and apply again
3. The first key updates and reports success
4. The second fails with `400` and `Key with alias '' already exists. Unique key aliases across all keys are required.`
5. They open https://litellm-domain/ui/?page=api-keys and see neither key showing an alias, so the message points at something they cannot see or clear
6. Re-running apply keeps failing on whichever key did not get in first

After: both keys update

1. They apply the same config with a team and two aliasless `litellm_key` resources, and all three are created
2. They raise `max_budget` from 10 to 25 on both keys and apply again
3. Both keys update and the apply reports success
4. https://litellm-domain/ui/?page=api-keys shows both at the new budget and still with no alias
5. Running plan again reports no changes

## Relevant issues

Fixes #40705

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Shared setup. Proxy is `ghcr.io/berriai/litellm:main-stable`, image revision
`10f4033437df30b91b5dbf2b64711d0a8683fc52`, which is `v1.99.1`, against Postgres 16. Terraform
v1.10.5 on linux_amd64, with the provider built from source at each hash below and loaded through a
`dev_overrides` block, so no registry build is involved.

```yaml
model_list: []
general_settings:
  master_key: "sk-e2e-master-key"
  database_connection_pool_limit: 10
  database_url: "postgresql://litellm:litellm@postgresql:5432/litellm"
litellm_settings:
  drop_params: true
```

The config under test is one team and two keys, neither carrying a `key_alias`. Both keys sit in the
team deliberately, so the separate empty-`team_id` failure in #40704 cannot fire here and hide the
alias collision that is actually under test. `budget` moves from 10 to 25 between the two applies:

```hcl
resource "litellm_team" "eng" {
  team_alias = "engineering"
}

resource "litellm_key" "a" {
  team_id    = litellm_team.eng.id
  models     = ["gpt-4o-mini"]
  max_budget = var.budget
}

resource "litellm_key" "b" {
  team_id    = litellm_team.eng.id
  models     = ["gpt-4o-mini"]
  max_budget = var.budget
}
```

Applies run with `-parallelism=1` so the two key updates are ordered. In parallel, whichever key
lands first is the one that succeeds, and the error moves between resources run to run.

The proxy image is older than this branch's base. The uniqueness check involved is unchanged between
the two, checked with `git diff v1.99.1 upstream/litellm_internal_staging -- litellm/proxy/management_endpoints/key_management_endpoints.py`,
which does not touch `_enforce_unique_key_alias`.

### Before (9a715df212)

1. Create the team and both keys, which works

```console
$ terraform apply -auto-approve -parallelism=1

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
```

2. Raise the budget on both, and the second key collides on the empty alias the first one just stored

```console
$ terraform apply -auto-approve -parallelism=1 -var budget=25
Plan: 0 to add, 2 to change, 0 to destroy.
litellm_key.b: Modifying... [id=a0782690c701a5a5bf4c5dee7ecc625d0c829be5b860ef61fa558a0016e4d781]
litellm_key.b: Modifications complete after 0s [id=a0782690c701a5a5bf4c5dee7ecc625d0c829be5b860ef61fa558a0016e4d781]
litellm_key.a: Modifying... [id=c5925479d415352c15de4097ea06e9f766c64e6212a60eafbc390d21bf39f3a5]
╷
│ Error: error updating key: API request failed with status code 400: {"error":{"message":"Key with alias '' already exists. Unique key aliases across all keys are required.","type":"bad_request_error","param":"key_alias","code":"400"}}
│
│   with litellm_key.a,
│   on main.tf line 25, in resource "litellm_key" "a":
│   25: resource "litellm_key" "a" {
│
╵
```

### After (c64f6429ec)

1. The key that could not update now does

```console
$ terraform apply -auto-approve -parallelism=1 -var budget=25
Plan: 0 to add, 1 to change, 0 to destroy.
litellm_key.a: Modifying... [id=c5925479d415352c15de4097ea06e9f766c64e6212a60eafbc390d21bf39f3a5]
litellm_key.a: Modifications complete after 0s [id=c5925479d415352c15de4097ea06e9f766c64e6212a60eafbc390d21bf39f3a5]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

2. Plan is clean afterwards

```console
$ terraform plan -var budget=25

Terraform has compared your real infrastructure against your configuration
and found no differences, so no changes are needed.
```

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- An alias cannot be cleared by blanking `key_alias`
  - Setting it to "" was never a working way to do that: it stored a literal empty alias that broke the next key
  - Clearing an alias still needs the Admin UI or a direct API call

### Low

- Keys already carrying a stored `""` alias from an earlier provider version keep it until changed
  - No new ones are created from this point on, but existing rows are not cleaned up
- `aliases`, `permissions` and `model_max_budget` are still sent when unset
  - Left alone deliberately: they carry the config's own desired state, and no failure could be reproduced from them

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
