### PR TITLE
fix(terraform): send a vector_store_id on create and unwrap the info envelope

### DIFF
--- a/terraform/provider/litellm/resource_vector_store_crud.go
+++ b/terraform/provider/litellm/resource_vector_store_crud.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -29,7 +30,12 @@ func resourceLiteLLMVectorStoreCreate(d *schema.ResourceData, m interface{}) err
 		paramsMap[k] = v
 	}
 
+	// /vector_store/new rejects a missing vector_store_id, and the attribute is
+	// computed, so the provider has to mint the id it stores under.
+	vectorStoreID := uuid.New().String()
+
 	vectorStoreRequest := VectorStoreRequest{
+		VectorStoreID:          vectorStoreID,
 		CustomLLMProvider:      customLLMProvider,
 		VectorStoreName:        vectorStoreName,
 		VectorStoreDescription: vectorStoreDescription,
@@ -49,9 +55,7 @@ func resourceLiteLLMVectorStoreCreate(d *schema.ResourceData, m interface{}) err
 		return fmt.Errorf("failed to create vector store: %w", err)
 	}
 
-	// Set the resource ID to the vector store name for now
-	// We'll update this after reading the response to get the actual ID
-	d.SetId(vectorStoreName)
+	d.SetId(vectorStoreID)
 
 	return resourceLiteLLMVectorStoreRead(d, m)
 }
@@ -76,8 +80,11 @@ func resourceLiteLLMVectorStoreRead(d *schema.ResourceData, m interface{}) error
 		return nil
 	}
 
-	var vectorStoreResp VectorStoreResponse
-	err = handleVectorStoreAPIResponse(resp, &vectorStoreResp, client)
+	// /vector_store/info nests the store under "vector_store".
+	var infoResp struct {
+		VectorStore VectorStoreResponse `json:"vector_store"`
+	}
+	err = handleVectorStoreAPIResponse(resp, &infoResp, client)
 	if err != nil {
 		if err.Error() == "vector_store_not_found" {
 			d.SetId("")
@@ -85,6 +92,7 @@ func resourceLiteLLMVectorStoreRead(d *schema.ResourceData, m interface{}) error
 		}
 		return fmt.Errorf("failed to read vector store: %w", err)
 	}
+	vectorStoreResp := infoResp.VectorStore
 
 	// Update the resource ID to the actual vector store ID from the response
 	if vectorStoreResp.VectorStoreID != "" {

--- a/terraform/provider/litellm/resource_vector_store_crud_test.go
+++ b/terraform/provider/litellm/resource_vector_store_crud_test.go
@@ -19,7 +19,7 @@ func TestVectorStoreReadDoesNotPersistServerLitellmParams(t *testing.T) {
 			"api_base": "https://upstream.example.com",
 		},
 	}
-	body, _ := json.Marshal(resp)
+	body, _ := json.Marshal(map[string]interface{}{"vector_store": resp})
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -51,5 +51,66 @@ func TestVectorStoreReadDoesNotPersistServerLitellmParams(t *testing.T) {
 	}
 	if d.Get("vector_store_name").(string) != "kb" {
 		t.Fatalf("read did not populate non-sensitive fields")
+	}
+}
+
+// /vector_store/new 400s without a vector_store_id, and the attribute is
+// computed, so create has to mint one and key the resource on it rather than on
+// the store's name.
+func TestVectorStoreCreateSendsGeneratedIDAndUsesItAsResourceID(t *testing.T) {
+	var createBody map[string]interface{}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.URL.Path == "/vector_store/new" {
+			json.NewDecoder(r.Body).Decode(&createBody)
+			id, _ := createBody["vector_store_id"].(string)
+			if id == "" {
+				w.WriteHeader(http.StatusBadRequest)
+				w.Write([]byte(`{"detail":"vector_store_id and custom_llm_provider are required"}`))
+				return
+			}
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"status":       "success",
+				"vector_store": VectorStoreResponse{VectorStoreID: id, VectorStoreName: "kb", CustomLLMProvider: "openai"},
+			})
+			return
+		}
+
+		var info VectorStoreInfoRequest
+		json.NewDecoder(r.Body).Decode(&info)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"vector_store": VectorStoreResponse{
+				VectorStoreID:     info.VectorStoreID,
+				VectorStoreName:   "kb",
+				CustomLLMProvider: "openai",
+				CreatedAt:         "2026-01-01T00:00:00Z",
+			},
+		})
+	}))
+	defer srv.Close()
+
+	d := schema.TestResourceDataRaw(t, resourceLiteLLMVectorStore().Schema, map[string]interface{}{
+		"vector_store_name":   "kb",
+		"custom_llm_provider": "openai",
+	})
+
+	if err := resourceLiteLLMVectorStoreCreate(d, NewClient(srv.URL, "test-key", true)); err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+
+	sentID, _ := createBody["vector_store_id"].(string)
+	if sentID == "" {
+		t.Fatal("create payload omitted vector_store_id, which the proxy rejects")
+	}
+	if d.Id() != sentID {
+		t.Errorf("resource id = %q, want the created store id %q", d.Id(), sentID)
+	}
+	if d.Get("vector_store_id").(string) != sentID {
+		t.Errorf("vector_store_id = %q, want %q", d.Get("vector_store_id").(string), sentID)
+	}
+	if d.Get("created_at").(string) != "2026-01-01T00:00:00Z" {
+		t.Errorf("create did not refresh computed fields from the API: %v", d.Get("created_at"))
 	}
 }


### PR DESCRIPTION
## TLDR

Problem this solves:

- `litellm_vector_store` cannot be created at all
- Reads come back empty, so the resource always drifts

How it solves it:

- Mint a UUID for the new store and send it
- Key the resource on that id, not the name
- Decode the `vector_store` envelope on read

## User Flow

Before: a platform engineer who wants their support knowledge base managed in Terraform cannot create it at all

1. They write a `litellm_vector_store` with `vector_store_name = "support-kb"` and `custom_llm_provider = "openai"` and apply
2. The apply fails with `500` and `{"detail":"400: vector_store_id and custom_llm_provider are required"}`
3. They check the resource's inputs for something to satisfy that, and there is none: the id is only ever an output
4. They create the store by hand at https://litellm-domain/ui/?page=vector-stores and give up on managing it in Terraform

After: the same config creates the store

1. They write the same `litellm_vector_store` with a name and a provider and apply
2. The apply succeeds and the resource's `vector_store_id` output is a real id such as `8764aa3d-25bc-42a2-8d3d-143614ae7eae`
3. https://litellm-domain/ui/?page=vector-stores lists the store under that id
4. Running plan again reports no changes, rather than offering to rebuild a store that already exists

## Relevant issues

Fixes #40706

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Shared setup. Proxy is `ghcr.io/berriai/litellm:main-stable`, image revision
`10f4033437df30b91b5dbf2b64711d0a8683fc52`, which is `v1.99.1`, against Postgres 16. Terraform
v1.10.5 on linux_amd64, with the provider built from source at each hash below and loaded through a
`dev_overrides` block, so no registry build is involved.

```yaml
model_list: []
general_settings:
  master_key: "sk-e2e-master-key"
  database_connection_pool_limit: 10
  database_url: "postgresql://litellm:litellm@postgresql:5432/litellm"
litellm_settings:
  drop_params: true
```

The config under test is a single vector store holding only a name and a provider:

```hcl
resource "litellm_vector_store" "kb" {
  vector_store_name   = "support-kb"
  custom_llm_provider = "openai"
}

output "vector_store_id" {
  value = litellm_vector_store.kb.vector_store_id
}
```

The proxy image is older than this branch's base. Both endpoint behaviours involved are unchanged
between the two, checked with `git diff v1.99.1 upstream/litellm_internal_staging -- litellm/proxy/vector_store_endpoints/management_endpoints.py`,
which touches neither the required-field check on `/vector_store/new` nor the `{"vector_store": ...}`
envelope.

### Before (9a715df212)

1. Creating the store fails

```console
$ terraform apply -auto-approve
litellm_vector_store.kb: Creating...
╷
│ Error: failed to create vector store: API request failed: Status: 500 Internal Server Error, Response: {"detail":"400: vector_store_id and custom_llm_provider are required"}
│
│   with litellm_vector_store.kb,
│   on main.tf line 14, in resource "litellm_vector_store" "kb":
│   14: resource "litellm_vector_store" "kb" {
│
╵
```

### After (0e2872c98b)

1. The same config creates the store and hands back a real id

```console
$ terraform apply -auto-approve
litellm_vector_store.kb: Creating...
litellm_vector_store.kb: Creation complete after 0s [id=8764aa3d-25bc-42a2-8d3d-143614ae7eae]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

vector_store_id = "8764aa3d-25bc-42a2-8d3d-143614ae7eae"
```

2. Plan is clean, which is what shows the read now picks the store out of the envelope. On the old
   code every attribute read back empty, so this step offered to change the resource on every run

```console
$ terraform plan

Terraform has compared your real infrastructure against your configuration
and found no differences, so no changes are needed.
```

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- The provider picks the store id, the proxy does not
  - `vector_store_id` is a computed attribute, so a config cannot supply one
  - Making it settable would be a larger change and is worth doing separately

### Low

- An existing test fixture was returning a flat body the real proxy never sends
  - Updated it to the nested shape, so it now covers the envelope instead of the bug
- `VectorStoreRequest` keeps `omitempty` on `vector_store_id`
  - Harmless now that create and update both always set it

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
