### PR TITLE
fix(responses): keep system messages at the front of the bridged request

### DIFF
--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -454,9 +454,7 @@ class LiteLLMCompletionResponsesConfig:
         )
 
         if system_contents:
-            messages.append(
-                LiteLLMCompletionResponsesConfig._merge_system_contents(system_contents)
-            )
+            messages.append(LiteLLMCompletionResponsesConfig._merge_system_contents(system_contents))
 
         messages.extend(message for message in input_messages if message.get("role") != "system")
 

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -468,12 +468,23 @@ class LiteLLMCompletionResponsesConfig:
         the backends that reject a trailing system message are the same ones that expect one.
         """
         texts: Final = tuple(
-            content
-            if isinstance(content, str)
-            else "\n\n".join(part.get("text", "") for part in content if isinstance(part, dict))
-            for content in contents
+            text for content in contents for text in LiteLLMCompletionResponsesConfig._system_content_texts(content)
         )
         return ChatCompletionSystemMessage(role="system", content="\n\n".join(text for text in texts if text))
+
+    @staticmethod
+    def _system_content_texts(content: object) -> tuple[str, ...]:
+        """Every text a system content field carries, as a plain string or as a part list
+        that may mix bare strings with text parts."""
+        if isinstance(content, str):
+            return (content,)
+        if not isinstance(content, (list, tuple)):
+            return ()
+        return tuple(
+            part if isinstance(part, str) else str(part.get("text", ""))
+            for part in content
+            if isinstance(part, (str, dict))
+        )
 
     @staticmethod
     async def async_responses_api_session_handler(

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -433,21 +433,49 @@ class LiteLLMCompletionResponsesConfig:
             | ChatCompletionResponseMessage
             | Message
         ] = []
-        if responses_api_request.get("instructions"):
-            messages.append(
-                LiteLLMCompletionResponsesConfig.transform_instructions_to_system_message(
-                    responses_api_request.get("instructions")
-                )
-            )
-
-        messages.extend(
+        input_messages: Final = tuple(
             LiteLLMCompletionResponsesConfig._transform_response_input_param_to_chat_completion_message(
                 input=input,
                 replay_reasoning=replay_reasoning,
             )
         )
 
+        # `instructions` and the input can each carry a system message, which left a
+        # conversation reading system, user, system. Chat templates that require the
+        # system message first reject that, so gather them into one leading message.
+        instructions: Final = responses_api_request.get("instructions")
+        system_contents: Final = tuple(
+            content
+            for content in (
+                instructions,
+                *(message.get("content") for message in input_messages if message.get("role") == "system"),
+            )
+            if content
+        )
+
+        if system_contents:
+            messages.append(
+                LiteLLMCompletionResponsesConfig._merge_system_contents(system_contents)
+            )
+
+        messages.extend(message for message in input_messages if message.get("role") != "system")
+
         return messages
+
+    @staticmethod
+    def _merge_system_contents(contents: tuple[Any, ...]) -> ChatCompletionSystemMessage:
+        """Join system prompts into one leading message.
+
+        Part lists collapse to their text: system content is conventionally a string, and
+        the backends that reject a trailing system message are the same ones that expect one.
+        """
+        texts: Final = tuple(
+            content
+            if isinstance(content, str)
+            else "\n\n".join(part.get("text", "") for part in content if isinstance(part, dict))
+            for content in contents
+        )
+        return ChatCompletionSystemMessage(role="system", content="\n\n".join(text for text in texts if text))
 
     @staticmethod
     async def async_responses_api_session_handler(

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_system_message_hoisting.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_system_message_hoisting.py
@@ -1,0 +1,75 @@
+"""
+Unit tests for keeping system messages at the front of the bridged chat request.
+
+``instructions`` becomes a leading system message and the Responses input can carry
+a system message of its own, so an Anthropic ``/v1/messages`` conversation bridged
+to chat completions could come out as system, user, system. Chat templates that
+require the system message to come first reject that with
+"System message must be at the beginning".
+
+See: https://github.com/BerriAI/litellm/issues/40693
+"""
+
+from litellm.responses.litellm_completion_transformation.transformation import (
+    LiteLLMCompletionResponsesConfig,
+)
+
+
+def _roles(input, responses_api_request):
+    messages = LiteLLMCompletionResponsesConfig.transform_responses_api_input_to_messages(
+        input=input, responses_api_request=responses_api_request
+    )
+    return [message.get("role") for message in messages], messages
+
+
+def test_system_message_after_user_content_is_hoisted():
+    roles, messages = _roles(
+        [
+            {"role": "user", "content": "first question"},
+            {"role": "system", "content": "mid"},
+            {"role": "user", "content": "second question"},
+        ],
+        {"instructions": "lead"},
+    )
+
+    assert roles == ["system", "user", "user"]
+    assert "system" not in roles[1:]
+
+
+def test_both_system_prompts_survive_the_merge():
+    _, messages = _roles(
+        [
+            {"role": "user", "content": "q"},
+            {"role": "system", "content": "mid"},
+        ],
+        {"instructions": "lead"},
+    )
+
+    assert messages[0]["content"] == "lead\n\nmid"
+
+
+def test_part_list_content_collapses_to_its_text():
+    """A system message given as parts still contributes its text to the merged prompt."""
+    _, messages = _roles(
+        [
+            {"role": "user", "content": "q"},
+            {"role": "system", "content": [{"type": "text", "text": "B"}]},
+        ],
+        {"instructions": "A"},
+    )
+
+    assert messages[0]["content"] == "A\n\nB"
+
+
+def test_an_already_leading_system_message_is_left_alone():
+    """The common case must not be rewritten."""
+    roles, messages = _roles([{"role": "user", "content": "q"}], {"instructions": "lead"})
+
+    assert roles == ["system", "user"]
+    assert messages[0]["content"] == "lead"
+
+
+def test_a_conversation_without_a_system_message_is_unchanged():
+    roles, _ = _roles([{"role": "user", "content": "q"}], {})
+
+    assert roles == ["user"]

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_system_message_hoisting.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_system_message_hoisting.py
@@ -73,3 +73,17 @@ def test_a_conversation_without_a_system_message_is_unchanged():
     roles, _ = _roles([{"role": "user", "content": "q"}], {})
 
     assert roles == ["user"]
+
+
+def test_bare_strings_in_a_part_list_survive_the_merge():
+    """Upstream normalization leaves plain strings in a content list, so filtering the
+    list down to dicts silently dropped part of the prompt."""
+    _, messages = _roles(
+        [
+            {"role": "user", "content": "q"},
+            {"role": "system", "content": ["B", {"type": "text", "text": "C"}]},
+        ],
+        {"instructions": "A"},
+    )
+
+    assert messages[0]["content"] == "A\n\nB\n\nC"


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bridged conversations emit a system message after user content
- Strict chat templates reject with "System message must be at the beginning"

How it solves it:

- Gather the system prompts into one leading message

## User Flow

Before: someone pointing Claude Code at the proxy in front of an OpenAI-compatible backend gets a 400 partway into a conversation

1. They set `ANTHROPIC_BASE_URL` to the proxy and talk to a model served by vLLM
2. The first turn works
3. A later turn sends POST https://litellm-domain/v1/messages carrying a system message alongside the earlier turns
4. The backend answers `400 System message must be at the beginning` and the turn is lost

After: the same conversation keeps working

1. They use the same setup and the same backend
2. The first turn works
3. The same later turn is sent
4. The backend answers normally, with both system prompts still in effect

## Relevant issues

Fixes #40693

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

The ordering is decided in `transform_responses_api_input_to_messages`, so the observable thing is the message sequence it hands to the backend. `instructions` is the leading system message and the input carries a second one, which is the shape the Anthropic adapter produces.

### Before (9a715df212)

1. Ask the bridge for the messages it would send

```python
from litellm.responses.litellm_completion_transformation.transformation import LiteLLMCompletionResponsesConfig as C
msgs = C.transform_responses_api_input_to_messages(
    input=[
        {"role": "user", "content": "first question"},
        {"role": "system", "content": "mid"},
        {"role": "user", "content": "second question"},
    ],
    responses_api_request={"instructions": "lead"},
)
print([m.get("role") for m in msgs])
```

```text
['system', 'user', 'system', 'user']
```

The third entry is what the backend rejects.

### After (18de9e6eff)

1. The same call

```text
['system', 'user', 'user']
```

2. Both prompts are still there

```python
print(repr(msgs[0]["content"]))
```

```text
'lead\n\nmid'
```

3. A conversation whose system message is already first is untouched

```python
msgs = C.transform_responses_api_input_to_messages(
    input=[{"role": "user", "content": "q"}],
    responses_api_request={"instructions": "lead"},
)
print([m.get("role") for m in msgs], repr(msgs[0]["content"]))
```

```text
['system', 'user'] 'lead'
```

4. A system content list that mixes a bare string with a text part keeps both

```python
msgs = C.transform_responses_api_input_to_messages(
    input=[
        {"role": "user", "content": "q"},
        {"role": "system", "content": ["B", {"type": "text", "text": "C"}]},
    ],
    responses_api_request={"instructions": "A"},
)
print(repr(msgs[0]["content"]))
```

```text
'A\n\nB\n\nC'
```

4. The bridge's suite

```bash
pytest tests/test_litellm/responses/litellm_completion_transformation/ -q
```

```text
235 passed
```

Reverting the change fails three of the five new tests. The two that still pass are the "leave it alone" cases, which is what they are there to pin.

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- A system message supplied as a part list collapses to its text. System content is conventionally a string, and the backends that reject a trailing system message are the same ones that expect one
- Ordering between two system prompts is preserved, `instructions` first, then the input's

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

