### PR TITLE
fix(token-counter): count reasoning summaries in message content

### DIFF
--- a/litellm/litellm_core_utils/token_counter.py
+++ b/litellm/litellm_core_utils/token_counter.py
@@ -46,6 +46,7 @@ from litellm.types.llms.openai import (
     AllMessageValues,
     ChatCompletionDocumentObject,
     ChatCompletionNamedToolChoiceParam,
+    ChatCompletionReasoningItem,
     ChatCompletionToolParam,
     OpenAIMessageContentListBlock,
 )
@@ -846,6 +847,7 @@ def _count_content_list(
         | AnthropicMessagesTextParam
         | AnthropicMessagesImageParam
         | AnthropicMessagesDocumentParam
+        | ChatCompletionReasoningItem
     ],
     use_default_image_token_count: bool,
     default_token_count: int | None,
@@ -893,6 +895,10 @@ def _count_content_list(
                 thinking_text = str(c.get("thinking", ""))
                 if thinking_text:
                     num_tokens += count_function(thinking_text)
+            elif c["type"] == "reasoning":
+                num_tokens += sum(
+                    count_function(text) for summary in c.get("summary", ()) if (text := summary.get("text"))
+                )
             elif c["type"] == "tool_reference":
                 # Anthropic tool-search reference block: a lightweight pointer to
                 # a deferred tool, e.g. {"type": "tool_reference", "tool_name": ...}.
@@ -909,7 +915,7 @@ def _count_content_list(
                 raise ValueError(
                     f"Invalid content item type: {content_type}. "
                     f"Expected str or dict with 'type' field "
-                    f"(text, image_url, image, document, file, tool_use, tool_result, thinking, tool_reference)."
+                    f"(text, image_url, image, document, file, tool_use, tool_result, thinking, reasoning, tool_reference)."
                 )
         return num_tokens
     except Exception as e:

--- a/litellm/litellm_core_utils/token_counter.py
+++ b/litellm/litellm_core_utils/token_counter.py
@@ -892,13 +892,9 @@ def _count_content_list(
             elif c["type"] == "thinking":
                 # Claude extended thinking content block
                 # Count the thinking text and skip signature (opaque signature blob)
-                thinking_text = str(c.get("thinking", ""))
-                if thinking_text:
-                    num_tokens += count_function(thinking_text)
+                num_tokens += count_function(str(c.get("thinking", "")))
             elif c["type"] == "reasoning":
-                num_tokens += sum(
-                    count_function(text) for summary in c.get("summary", ()) if (text := summary.get("text"))
-                )
+                num_tokens += sum(count_function(summary.get("text", "")) for summary in c.get("summary", ()))
             elif c["type"] == "tool_reference":
                 # Anthropic tool-search reference block: a lightweight pointer to
                 # a deferred tool, e.g. {"type": "tool_reference", "tool_name": ...}.

--- a/litellm/litellm_core_utils/token_counter.py
+++ b/litellm/litellm_core_utils/token_counter.py
@@ -839,6 +839,10 @@ def _count_anthropic_content(
     return tokens
 
 
+def _count_nonempty_text_tokens(text: str, count_function: TokenCounterFunction) -> int:
+    return count_function(text) if text else 0
+
+
 def _count_content_list(
     count_function: TokenCounterFunction,
     content_list: str
@@ -892,9 +896,12 @@ def _count_content_list(
             elif c["type"] == "thinking":
                 # Claude extended thinking content block
                 # Count the thinking text and skip signature (opaque signature blob)
-                num_tokens += count_function(str(c.get("thinking", "")))
+                num_tokens += _count_nonempty_text_tokens(str(c.get("thinking", "")), count_function)
             elif c["type"] == "reasoning":
-                num_tokens += sum(count_function(summary.get("text", "")) for summary in c.get("summary", ()))
+                num_tokens += sum(
+                    _count_nonempty_text_tokens(summary.get("text", ""), count_function)
+                    for summary in c.get("summary", ())
+                )
             elif c["type"] == "tool_reference":
                 # Anthropic tool-search reference block: a lightweight pointer to
                 # a deferred tool, e.g. {"type": "tool_reference", "tool_name": ...}.

--- a/tests/test_litellm/litellm_core_utils/test_token_counter.py
+++ b/tests/test_litellm/litellm_core_utils/test_token_counter.py
@@ -32,7 +32,7 @@ from litellm.litellm_core_utils.token_counter import (
     offload_token_count,
 )
 from litellm.litellm_core_utils.token_counter import token_counter as token_counter_new
-from litellm.types.llms.openai import ChatCompletionReasoningItem
+from litellm.types.llms.openai import ChatCompletionReasoningItem, ChatCompletionThinkingBlock
 from tests.large_text import text
 from tests.test_litellm.litellm_core_utils.event_loop_lag import (
     assert_loop_stayed_free,
@@ -1300,6 +1300,51 @@ def test_token_counter_with_reasoning_content(
 
     assert token_counter(model=model, messages=messages) == token_counter(model=model, messages=equivalent_messages)
     assert reasoning == original
+
+
+@pytest.mark.parametrize(
+    ("block", "texts"),
+    [
+        ({"type": "thinking"}, ()),
+        ({"type": "thinking", "thinking": ""}, ()),
+        ({"type": "reasoning", "summary": []}, ()),
+        ({"type": "reasoning", "summary": [{"type": "summary_text"}]}, ()),
+        ({"type": "reasoning", "summary": [{"type": "summary_text", "text": ""}]}, ()),
+        (
+            {
+                "type": "reasoning",
+                "summary": [
+                    {"type": "summary_text", "text": ""},
+                    {"type": "summary_text", "text": "Thought"},
+                ],
+            },
+            ("Thought",),
+        ),
+    ],
+    ids=["missing-thinking", "empty-thinking", "empty-summary", "missing-text", "empty-text", "mixed-texts"],
+)
+def test_empty_reasoning_text_does_not_count_tokenizer_special_tokens(
+    block: ChatCompletionThinkingBlock | ChatCompletionReasoningItem, texts: tuple[str, ...]
+) -> None:
+    from tokenizers import Tokenizer
+    from tokenizers.models import WordLevel
+    from tokenizers.processors import TemplateProcessing
+
+    tokenizer: Final = Tokenizer(WordLevel({"[UNK]": 0, "[BOS]": 1, "[EOS]": 2, "Ready": 3, "Thought": 4}, unk_token="[UNK]"))
+    tokenizer.post_processor = TemplateProcessing(single="[BOS] $A [EOS]", special_tokens=[("[BOS]", 1), ("[EOS]", 2)])
+    custom_tokenizer: Final = {"type": "huggingface_tokenizer", "tokenizer": tokenizer}
+    messages: Final = [{"role": "assistant", "content": [block, {"type": "text", "text": "Ready"}]}]
+    equivalent_messages: Final = [
+        {
+            "role": "assistant",
+            "content": [*({"type": "text", "text": value} for value in texts), {"type": "text", "text": "Ready"}],
+        }
+    ]
+
+    assert tokenizer.encode("").ids == [1, 2]
+    assert token_counter(custom_tokenizer=custom_tokenizer, messages=messages) == token_counter(
+        custom_tokenizer=custom_tokenizer, messages=equivalent_messages
+    )
 
 
 def test_reasoning_content_preserves_prompt_cache_eligibility() -> None:

--- a/tests/test_litellm/litellm_core_utils/test_token_counter.py
+++ b/tests/test_litellm/litellm_core_utils/test_token_counter.py
@@ -7,6 +7,7 @@ import threading
 import time
 import traceback
 from concurrent.futures import Future, wait
+from copy import deepcopy
 from typing import Final
 from unittest.mock import MagicMock
 
@@ -31,6 +32,7 @@ from litellm.litellm_core_utils.token_counter import (
     offload_token_count,
 )
 from litellm.litellm_core_utils.token_counter import token_counter as token_counter_new
+from litellm.types.llms.openai import ChatCompletionReasoningItem
 from tests.large_text import text
 from tests.test_litellm.litellm_core_utils.event_loop_lag import (
     assert_loop_stayed_free,
@@ -1248,6 +1250,77 @@ def test_token_counter_with_thinking_content():
     assert (
         tokens_no_thinking < 15
     ), f"Expected minimal token count for empty thinking block, got {tokens_no_thinking}"
+
+
+@pytest.mark.parametrize("model", ["gemini/gemini-3.8-flash", "gpt-6-astra"])
+@pytest.mark.parametrize(
+    ("reasoning", "summary_texts"),
+    [
+        ({"type": "reasoning"}, ()),
+        ({"type": "reasoning", "summary": []}, ()),
+        ({"type": "reasoning", "encrypted_content": "opaque " * 1000}, ()),
+        (
+            {"type": "reasoning", "summary": [{"type": "summary_text", "text": "A short synthetic summary."}]},
+            ("A short synthetic summary.",),
+        ),
+        (
+            {
+                "type": "reasoning",
+                "summary": [
+                    {"type": "summary_text", "text": "First thought."},
+                    {"type": "summary_text", "text": ""},
+                    {"type": "summary_text", "text": "Second thought."},
+                ],
+                "id": "rs_opaque_identifier",
+                "encrypted_content": "opaque " * 1000,
+            },
+            ("First thought.", "", "Second thought."),
+        ),
+    ],
+    ids=["missing-summary", "empty-summary", "encrypted-only", "summary", "multiple-summaries-with-metadata"],
+)
+def test_token_counter_with_reasoning_content(
+    model: str, reasoning: ChatCompletionReasoningItem, summary_texts: tuple[str, ...]
+) -> None:
+    original: Final = deepcopy(reasoning)
+    messages: Final = [
+        {"role": "user", "content": "Context marker."},
+        {"role": "assistant", "content": [reasoning, {"type": "text", "text": "Ready."}]},
+    ]
+    equivalent_messages: Final = [
+        {"role": "user", "content": "Context marker."},
+        {
+            "role": "assistant",
+            "content": [
+                *({"type": "text", "text": value} for value in summary_texts),
+                {"type": "text", "text": "Ready."},
+            ],
+        },
+    ]
+
+    assert token_counter(model=model, messages=messages) == token_counter(model=model, messages=equivalent_messages)
+    assert reasoning == original
+
+
+def test_reasoning_content_preserves_prompt_cache_eligibility() -> None:
+    model: Final = "gemini/gemini-3.8-flash"
+    messages: Final = [
+        {"role": "user", "content": "Context marker. " * 1800},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "reasoning", "summary": [{"type": "summary_text", "text": "A short synthetic summary."}]},
+                {"type": "text", "text": "Ready."},
+            ],
+        },
+        {"role": "user", "content": "Reply with exactly OK."},
+    ]
+    count: Final = token_counter(model=model, messages=messages)
+
+    assert count >= litellm.utils.get_prompt_cache_min_tokens(model)
+    assert litellm.utils.is_prompt_caching_valid_prompt(model=model, messages=messages)
+    assert litellm.utils.is_prompt_caching_valid_prompt(model=model, messages=messages, min_token_count=count)
+    assert not litellm.utils.is_prompt_caching_valid_prompt(model=model, messages=messages, min_token_count=count + 1)
 
 
 def test_token_counter_with_tool_reference_block():


### PR DESCRIPTION
## TLDR

Problem this solves:

- Reasoning blocks break token estimates and prompt-cache eligibility

How it solves it:

- Count summary text while ignoring opaque reasoning metadata

## User Flow

Before: a developer cannot estimate tokens for reasoning-bearing conversation history

1. They request a local token estimate for conversation history containing a reasoning summary
2. They receive `ValueError: Invalid content item type: reasoning`
3. The same history is reported as ineligible for prompt caching

After: the developer receives a token estimate for the same history

1. They request a local token estimate for conversation history containing a reasoning summary
2. They receive an integer estimate including the summary text
3. Prompt-cache eligibility follows the configured token threshold

## Relevant issues

Fixes #40436

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves one specific problem
- [x] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

The three related token-counter and prompt-cache test files pass with 211 passed, one existing skip, and two network-dependent tests deselected. The 17 focused cases produce 15 failures and two passes on the base; all 17 pass here. They cover empty and missing summaries, encrypted-only items, multiple summaries, input preservation, cache threshold boundaries, and a local custom tokenizer that adds BOS/EOS to empty strings

Ruff, the test lint configuration, production formatting, and `git diff --check` pass. The full SDK strict-rule counts match the base, including C901: 306 on both. A shared nonempty-text helper preserves the existing thinking behavior and prevents BOS/EOS from being counted for empty reasoning text. Focused static checks introduce no new diagnostics compared with the base: type-discipline 83 on both, test-quality 15 on both, and basedpyright 136 on both

## Screenshots / Proof of Fix

This is a real local SDK run using the bundled tokenizer and cost map, with network access denied by macOS sandbox. It calls neither a mocked tokenizer nor an inference provider. Save this as `probe_reasoning.py` outside the checkout and run it from the source checkout with the SDK dependencies installed

```python
import json

from litellm import token_counter
from litellm.utils import get_prompt_cache_min_tokens, is_prompt_caching_valid_prompt

model = "gemini/gemini-3.8-flash"
summary = {"type": "reasoning", "summary": [{"type": "summary_text", "text": "A short synthetic summary."}]}
for name, blocks in (
    ("text-only", []),
    ("reasoning-summary", [summary]),
    ("encrypted-only", [{"type": "reasoning", "summary": [], "encrypted_content": "opaque " * 1000}]),
):
    messages = [
        {"role": "user", "content": "Context marker. " * 1800},
        {"role": "assistant", "content": [*blocks, {"type": "text", "text": "Ready."}]},
        {"role": "user", "content": "Reply with exactly OK."},
    ]
    result = {"case": name, "model": model, "cache_min_tokens": get_prompt_cache_min_tokens(model)}
    try:
        result["token_count"] = token_counter(model=model, messages=messages)
    except ValueError as exc:
        result["error"] = str(exc)
    result["cache_eligible"] = is_prompt_caching_valid_prompt(model=model, messages=messages)
    print(json.dumps(result))

from tokenizers import Tokenizer
from tokenizers.models import WordLevel
from tokenizers.processors import TemplateProcessing

tokenizer = Tokenizer(WordLevel({"[UNK]": 0, "[BOS]": 1, "[EOS]": 2, "Ready": 3}, unk_token="[UNK]"))
tokenizer.post_processor = TemplateProcessing(single="[BOS] $A [EOS]", special_tokens=[("[BOS]", 1), ("[EOS]", 2)])
custom_tokenizer = {"type": "huggingface_tokenizer", "tokenizer": tokenizer}
for name, blocks in (
    ("custom-tokenizer-control", []),
    ("custom-tokenizer-empty-thinking", [{"type": "thinking", "thinking": ""}]),
    ("custom-tokenizer-empty-summary", [{"type": "reasoning", "summary": [{"type": "summary_text", "text": ""}]}]),
):
    messages = [{"role": "assistant", "content": [*blocks, {"type": "text", "text": "Ready"}]}]
    result = {"case": name, "encoded_empty_ids": tokenizer.encode("").ids}
    try:
        result["token_count"] = token_counter(custom_tokenizer=custom_tokenizer, messages=messages)
    except ValueError as exc:
        result["error"] = str(exc)
    print(json.dumps(result))
```

### Before (9a715df212d777bbd43f4cab05731978c708ec63)

1. Run `PYTHONPATH=. LITELLM_LOCAL_MODEL_COST_MAP=True LITELLM_MODE=PRODUCTION sandbox-exec -p '(version 1)(allow default)(deny network*)' python /path/to/probe_reasoning.py`
2. The text-only control returns `token_count: 5451`, `cache_eligible: true`, and `cache_min_tokens: 4096`. Both reasoning-summary and encrypted-only cases report `ValueError: Invalid content item type: reasoning` and `cache_eligible: false`. With the custom tokenizer, the control and empty-thinking cases both count 12 tokens; empty-summary raises the same ValueError

### After (37ed3e5c7b244ceea69f5979740f3a8f84b405d9)

1. Run the same command
2. The output is:

```jsonl
{"case": "text-only", "model": "gemini/gemini-3.8-flash", "cache_min_tokens": 4096, "token_count": 5451, "cache_eligible": true}
{"case": "reasoning-summary", "model": "gemini/gemini-3.8-flash", "cache_min_tokens": 4096, "token_count": 5456, "cache_eligible": true}
{"case": "encrypted-only", "model": "gemini/gemini-3.8-flash", "cache_min_tokens": 4096, "token_count": 5451, "cache_eligible": true}
{"case": "custom-tokenizer-control", "encoded_empty_ids": [1, 2], "token_count": 12}
{"case": "custom-tokenizer-empty-thinking", "encoded_empty_ids": [1, 2], "token_count": 12}
{"case": "custom-tokenizer-empty-summary", "encoded_empty_ids": [1, 2], "token_count": 12}
```

## Type

Bug Fix

## Caveats (if any)

### Low

- Estimates visible summaries; opaque encrypted content remains uncounted
- HTTP proxy and live provider requests were not exercised

## Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
