### PR TITLE
fix(auth): check the key allowlist on team alias targets

### DIFF
--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -3940,10 +3940,13 @@ def _check_model_access_helper(
     ## check if model in allowed model names
     from collections import defaultdict
 
+    team_alias_target: Final = team_model_aliases.get(model) if team_model_aliases else None
+    effective_model: Final = team_alias_target if team_alias_target is not None else model
+
     access_groups: dict[str, list[str]] = defaultdict(list)
 
     if llm_router:
-        access_groups = llm_router.get_model_access_groups(model_name=model, team_id=team_id)
+        access_groups = llm_router.get_model_access_groups(model_name=effective_model, team_id=team_id)
 
     models = _resolve_all_team_model_sentinel_for_auth_check(
         models=models,
@@ -3959,16 +3962,7 @@ def _check_model_access_helper(
     # Filter out models that are access_groups
     filtered_models: Final = [m for m in models if m not in access_groups]
 
-    team_alias_target: Final = team_model_aliases.get(model) if team_model_aliases else None
-    if team_alias_target is not None and _check_model_access_helper(
-        model=team_alias_target,
-        llm_router=llm_router,
-        models=models,
-        team_id=team_id,
-    ):
-        return True
-
-    if _model_matches_any_wildcard_pattern_in_list(model=model, allowed_model_list=filtered_models):
+    if _model_matches_any_wildcard_pattern_in_list(model=effective_model, allowed_model_list=filtered_models):
         return True
 
     all_model_access: bool = False
@@ -3979,7 +3973,7 @@ def _check_model_access_helper(
     if SpecialModelNames.all_proxy_models.value in filtered_models:
         all_model_access = True
 
-    if model is not None and model not in filtered_models and all_model_access is False:
+    if effective_model is not None and effective_model not in filtered_models and all_model_access is False:
         return False
     return True
 
@@ -4024,11 +4018,13 @@ def _can_object_call_model(
             )
         return True
 
-    potential_models: Final = [model]
-    if model in litellm.model_alias_map:
-        potential_models.append(litellm.model_alias_map[model])
-    elif llm_router and model in llm_router.model_group_alias:
-        _model: Final = llm_router._get_model_from_alias(model)
+    team_alias_target: Final = team_model_aliases.get(model) if team_model_aliases else None
+    resolved_model: Final = team_alias_target if team_alias_target is not None else model
+    potential_models: Final = [resolved_model]
+    if resolved_model in litellm.model_alias_map:
+        potential_models.append(litellm.model_alias_map[resolved_model])
+    elif llm_router and resolved_model in llm_router.model_group_alias:
+        _model: Final = llm_router._get_model_from_alias(resolved_model)
         if _model:
             potential_models.append(_model)
 
@@ -4038,7 +4034,6 @@ def _can_object_call_model(
             model=m,
             llm_router=llm_router,
             models=models,
-            team_model_aliases=team_model_aliases,
             team_id=team_id,
         ):
             return True

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -3959,7 +3959,13 @@ def _check_model_access_helper(
     # Filter out models that are access_groups
     filtered_models: Final = [m for m in models if m not in access_groups]
 
-    if _model_in_team_aliases(model=model, team_model_aliases=team_model_aliases):
+    team_alias_target: Final = team_model_aliases.get(model) if team_model_aliases else None
+    if team_alias_target is not None and _check_model_access_helper(
+        model=team_alias_target,
+        llm_router=llm_router,
+        models=models,
+        team_id=team_id,
+    ):
         return True
 
     if _model_matches_any_wildcard_pattern_in_list(model=model, allowed_model_list=filtered_models):
@@ -4043,24 +4049,6 @@ def _can_object_call_model(
         param="model",
         code=status.HTTP_403_FORBIDDEN,
     )
-
-
-def _model_in_team_aliases(model: str, team_model_aliases: dict[str, str] | None = None) -> bool:
-    """
-    Returns True if `model` being accessed is an alias of a team model
-
-    - `model=gpt-4o`
-    - `team_model_aliases={"gpt-4o": "gpt-4o-team-1"}`
-        - returns True
-
-    - `model=gp-4o`
-    - `team_model_aliases={"o-3": "o3-preview"}`
-        - returns False
-    """
-    if team_model_aliases:
-        if model in team_model_aliases:
-            return True
-    return False
 
 
 def _resolve_key_models_for_auth_check(valid_token: UserAPIKeyAuth) -> list[str]:

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -519,6 +519,75 @@ def test_check_model_access_helper_self_referential_alias_terminates():
     )
 
 
+def _router_with_group_alias(alias: str, target: str) -> "Router":
+    from litellm import Router
+
+    return Router(
+        model_list=[{"model_name": target, "litellm_params": {"model": "gpt-4o", "api_key": "test-api-key"}}],
+        model_group_alias={alias: {"model": target, "hidden": False}},
+    )
+
+
+@pytest.mark.asyncio
+async def test_can_key_call_model_team_alias_name_in_key_models_is_not_enough():
+    """A key that lists the alias name but not its target is denied."""
+    from litellm.proxy.auth.auth_checks import can_key_call_model
+
+    for models in (["smart"], ["sm*"]):
+        valid_token: Final = _aliased_key(models=models)
+        with pytest.raises(ProxyException) as exc_info:
+            await can_key_call_model(model="smart", llm_model_list=None, valid_token=valid_token, llm_router=None)
+        assert exc_info.value.type == ProxyErrorTypes.key_model_access_denied
+        assert "Tried to access smart" in exc_info.value.message
+
+
+def test_can_object_call_model_team_alias_target_expands_router_alias():
+    """A team alias whose target is a router alias is allowed when the key lists the underlying model."""
+    llm_router: Final = _router_with_group_alias(alias="router-fast", target="gpt-4o-group")
+
+    assert _can_object_call_model(
+        model="team-fast",
+        llm_router=llm_router,
+        models=["gpt-4o-group"],
+        team_model_aliases={"team-fast": "router-fast"},
+        object_type="key",
+    )
+    with pytest.raises(ProxyException) as exc_info:
+        _can_object_call_model(
+            model="team-fast",
+            llm_router=llm_router,
+            models=["other"],
+            team_model_aliases={"team-fast": "router-fast"},
+            object_type="key",
+        )
+    assert exc_info.value.type == ProxyErrorTypes.key_model_access_denied
+
+
+def test_can_object_call_model_team_alias_takes_precedence_over_router_alias():
+    """A name that is both a team alias and a router alias is checked against the team alias target only."""
+    llm_router: Final = _router_with_group_alias(alias="fast", target="gpt-4o-group")
+
+    with pytest.raises(ProxyException) as exc_info:
+        _can_object_call_model(
+            model="fast",
+            llm_router=llm_router,
+            models=["gpt-4o-group"],
+            team_model_aliases={"fast": "openai/gpt-4.1-mini"},
+            object_type="key",
+        )
+    assert exc_info.value.type == ProxyErrorTypes.key_model_access_denied
+    assert _can_object_call_model(
+        model="fast",
+        llm_router=llm_router,
+        models=["openai/gpt-4.1-mini"],
+        team_model_aliases={"fast": "openai/gpt-4.1-mini"},
+        object_type="key",
+    )
+    assert _can_object_call_model(
+        model="fast", llm_router=llm_router, models=["gpt-4o-group"], team_model_aliases=None, object_type="key"
+    )
+
+
 def test_resolve_key_models_teamless_all_team_models_returns_empty():
     """_resolve_key_models_for_auth_check must return [] for a teamless key
     with all-team-models, making it equivalent to an unscoped key (unrestricted

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -403,6 +403,122 @@ async def test_can_key_call_model_all_team_models_no_team_id_is_unrestricted():
     )
 
 
+_TEAM_ALIASES: Final = {
+    "fast": "openai/gpt-4.1-mini",
+    "smart": "openai/gpt-4.1",
+    "vision": "openai/gpt-4o",
+}
+
+
+def _aliased_key(models: list[str]) -> UserAPIKeyAuth:
+    return UserAPIKeyAuth(
+        api_key="sk-key",
+        team_id="team-1",
+        models=models,
+        team_models=["openai/gpt-4.1-mini", "openai/gpt-4.1"],
+        team_model_aliases=_TEAM_ALIASES,
+    )
+
+
+@pytest.mark.asyncio
+async def test_can_key_call_model_team_alias_target_outside_key_models_denied():
+    """A team alias whose target is not in key.models is denied."""
+    from litellm.proxy.auth.auth_checks import can_key_call_model
+
+    valid_token: Final = _aliased_key(models=["openai/gpt-4.1-mini"])
+
+    for alias in ("smart", "vision"):
+        with pytest.raises(ProxyException) as exc_info:
+            await can_key_call_model(model=alias, llm_model_list=None, valid_token=valid_token, llm_router=None)
+        assert exc_info.value.type == ProxyErrorTypes.key_model_access_denied
+        assert exc_info.value.code == str(status.HTTP_403_FORBIDDEN)
+
+
+@pytest.mark.asyncio
+async def test_can_key_call_model_team_alias_target_in_key_models_allowed():
+    """A team alias whose target is in key.models is allowed, and a plain model name still resolves as before."""
+    from litellm.proxy.auth.auth_checks import can_key_call_model
+
+    valid_token: Final = _aliased_key(models=["openai/gpt-4.1-mini"])
+
+    for model in ("fast", "openai/gpt-4.1-mini"):
+        assert await can_key_call_model(model=model, llm_model_list=None, valid_token=valid_token, llm_router=None)
+
+    with pytest.raises(ProxyException) as exc_info:
+        await can_key_call_model(model="openai/gpt-4.1", llm_model_list=None, valid_token=valid_token, llm_router=None)
+    assert exc_info.value.type == ProxyErrorTypes.key_model_access_denied
+
+
+@pytest.mark.asyncio
+async def test_can_key_call_model_team_alias_unrestricted_key_allowed():
+    """A key with no model restriction, or the all-proxy-models sentinel, can call any team alias."""
+    from litellm.proxy._types import SpecialModelNames
+    from litellm.proxy.auth.auth_checks import can_key_call_model
+
+    for models in ([], [SpecialModelNames.all_proxy_models.value]):
+        valid_token: Final = _aliased_key(models=models)
+        for alias in _TEAM_ALIASES:
+            assert await can_key_call_model(model=alias, llm_model_list=None, valid_token=valid_token, llm_router=None)
+
+
+@pytest.mark.asyncio
+async def test_can_key_call_model_team_alias_all_team_models_sentinel():
+    """With the all-team-models sentinel the alias target must be in team_models."""
+    from litellm.proxy._types import SpecialModelNames
+    from litellm.proxy.auth.auth_checks import can_key_call_model
+
+    valid_token: Final = _aliased_key(models=[SpecialModelNames.all_team_models.value])
+
+    for alias in ("fast", "smart"):
+        assert await can_key_call_model(model=alias, llm_model_list=None, valid_token=valid_token, llm_router=None)
+
+    with pytest.raises(ProxyException) as exc_info:
+        await can_key_call_model(model="vision", llm_model_list=None, valid_token=valid_token, llm_router=None)
+    assert exc_info.value.type == ProxyErrorTypes.key_model_access_denied
+
+
+@pytest.mark.asyncio
+async def test_can_team_access_model_team_alias_checks_target():
+    """A team alias is allowed only when its target is in team.models."""
+    from litellm.proxy.auth.auth_checks import can_team_access_model
+
+    team_object: Final = LiteLLM_TeamTable(team_id="team-1", models=["openai/gpt-4.1-mini"])
+
+    assert await can_team_access_model(
+        model="fast", team_object=team_object, llm_router=None, team_model_aliases=_TEAM_ALIASES
+    )
+
+    with pytest.raises(ProxyException) as exc_info:
+        await can_team_access_model(
+            model="smart", team_object=team_object, llm_router=None, team_model_aliases=_TEAM_ALIASES
+        )
+    assert exc_info.value.type == ProxyErrorTypes.team_model_access_denied
+
+
+def test_check_model_access_helper_team_alias_target_matches_wildcard():
+    """A team alias target is matched against wildcard entries in the allowlist."""
+    from litellm.proxy.auth.auth_checks import _check_model_access_helper
+
+    assert _check_model_access_helper(
+        model="fast", llm_router=None, models=["openai/*"], team_model_aliases=_TEAM_ALIASES, team_id="team-1"
+    )
+    assert not _check_model_access_helper(
+        model="fast", llm_router=None, models=["anthropic/*"], team_model_aliases=_TEAM_ALIASES, team_id="team-1"
+    )
+
+
+def test_check_model_access_helper_self_referential_alias_terminates():
+    """An alias that points at its own name is decided by the allowlist alone."""
+    from litellm.proxy.auth.auth_checks import _check_model_access_helper
+
+    self_alias: Final = {"same": "same"}
+
+    assert _check_model_access_helper(model="same", llm_router=None, models=["same"], team_model_aliases=self_alias)
+    assert not _check_model_access_helper(
+        model="same", llm_router=None, models=["other"], team_model_aliases=self_alias
+    )
+
+
 def test_resolve_key_models_teamless_all_team_models_returns_empty():
     """_resolve_key_models_for_auth_check must return [] for a teamless key
     with all-team-models, making it equivalent to an unscoped key (unrestricted


### PR DESCRIPTION
## TLDR

Problem this solves:

- A team model alias satisfied the model access check on its own
- A key scoped to some of the team's models could call every aliased model
- The bypass applied to the key check and the team check alike

How it solves it:

- The alias is resolved to its target before the allowlist check
- The target goes through the same allowlist, wildcard and access group rules as a plain name
- Unrestricted keys and the all-team-models sentinel behave as before

## User Flow

Before: a developer holding a key scoped to one model can call a more expensive team model by using the team's alias for it

1. The proxy admin sends POST https://litellm-domain/team/new with `"models": ["claude-haiku", "claude-sonnet"]` and `"model_aliases": {"team-fast": "claude-haiku"}`
2. The admin sends POST https://litellm-domain/key/generate for that team with `"models": ["claude-sonnet"]` and hands the key to the developer
3. The developer sends POST https://litellm-domain/v1/chat/completions with `"model": "team-fast"` using that key
4. The response is HTTP 200 with a completion from claude-haiku, a model the key was never granted, and the spend lands on that key
5. Any key on the team can do the same for every alias the team defines, whatever the key's own model list says

After: the same request is refused, and the key still works for the models it was granted

1. The proxy admin sends POST https://litellm-domain/team/new with `"models": ["claude-haiku", "claude-sonnet"]` and `"model_aliases": {"team-fast": "claude-haiku"}`
2. The admin sends POST https://litellm-domain/key/generate for that team with `"models": ["claude-sonnet"]` and hands the key to the developer
3. The developer sends POST https://litellm-domain/v1/chat/completions with `"model": "team-fast"` using that key
4. The response is HTTP 403 with `key not allowed to access model. This key can only access models=['claude-sonnet']. Tried to access team-fast`
5. The same key sending `"model": "claude-sonnet"` still gets HTTP 200, and a sibling key granted `claude-haiku` still gets HTTP 200 through `team-fast`
6. A key can no longer reach a team model through its alias unless the alias target is on the key's own model list

## Relevant issues

No existing issue. The team model alias lookup in the model access check returned an allow as soon as the requested name was an alias key, without ever comparing the alias target against the calling entity's model list. A key created with a narrower `models` list than its team therefore inherited access to every aliased team model, and a team whose own `models` list did not contain an alias target was still allowed through that alias

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Setup shared by both runs. Proxy started from the worktree with `uv run python litellm/proxy/proxy_cli.py --config config.yaml --port 4101` against a fresh `postgres:16` container. The two deployments hit a real Anthropic-compatible gateway, so every 200 below cost real tokens

```yaml
model_list:
  - model_name: claude-haiku
    litellm_params:
      model: anthropic/as-anthropic/claude-haiku-4-5-20251001
      api_key: os.environ/ANTHROPIC_API_KEY
      api_base: os.environ/ANTHROPIC_API_BASE
  - model_name: claude-sonnet
    litellm_params:
      model: anthropic/as-anthropic/claude-sonnet-5
      api_key: os.environ/ANTHROPIC_API_KEY
      api_base: os.environ/ANTHROPIC_API_BASE
general_settings:
  master_key: sk-up-team-alias-master
  database_url: postgresql://postgres:uppw@localhost:5441/litellm
```

Team and keys are created the same way on both sides. `$M` is the master key header, `$TEAM` is the id returned by `/team/new`, and the chat payload is always `{"model": ..., "messages": [{"role": "user", "content": "Reply with the single word ok"}], "max_tokens": 5}`

```bash
curl -s http://localhost:4101/team/new -H "$M" -H 'Content-Type: application/json' \
  -d '{"team_alias":"alias-demo","models":["claude-haiku","claude-sonnet"],"model_aliases":{"team-fast":"claude-haiku"}}'
curl -s http://localhost:4101/key/generate -H "$M" -H 'Content-Type: application/json' \
  -d "{\"team_id\":\"$TEAM\",\"models\":[\"claude-sonnet\"],\"key_alias\":\"sonnet-only\"}"
curl -s http://localhost:4101/key/generate -H "$M" -H 'Content-Type: application/json' \
  -d "{\"team_id\":\"$TEAM\",\"models\":[\"claude-haiku\"],\"key_alias\":\"haiku\"}"
```

### Before (9a715df212)

#### Key scoped to claude-sonnet calls the team alias team-fast

1. `curl -s -w '\nHTTP %{http_code}\n' http://localhost:4101/v1/chat/completions -H "Authorization: Bearer $SONNET_ONLY_KEY" -H 'Content-Type: application/json' -d '{"model":"team-fast", ...}'`
2. Observed: `{"model": "team-fast", "content": "ok", "usage": 17}` and `HTTP 200`. The key was granted `claude-sonnet` only, yet the alias took it to `claude-haiku`

#### Key granted claude-haiku calls the team alias team-fast

1. `curl -s -w '\nHTTP %{http_code}\n' http://localhost:4101/v1/chat/completions -H "Authorization: Bearer $HAIKU_KEY" -H 'Content-Type: application/json' -d '{"model":"team-fast", ...}'`
2. Observed: `{"model": "team-fast", "content": "ok", "usage": 17}` and `HTTP 200`

### After (83f52d8985)

#### Key scoped to claude-sonnet calls the team alias team-fast

1. `curl -s -w '\nHTTP %{http_code}\n' http://localhost:4101/v1/chat/completions -H "Authorization: Bearer $SONNET_ONLY_KEY" -H 'Content-Type: application/json' -d '{"model":"team-fast", ...}'`
2. Observed: `{"error": {"message": "key not allowed to access model. This key can only access models=['claude-sonnet']. Tried to access team-fast", "type": "key_model_access_denied", "param": "model", "code": "403"}}` and `HTTP 403`

#### Key scoped to claude-sonnet calls its own model

1. `curl -s -w '\nHTTP %{http_code}\n' http://localhost:4101/v1/chat/completions -H "Authorization: Bearer $SONNET_ONLY_KEY" -H 'Content-Type: application/json' -d '{"model":"claude-sonnet", ...}'`
2. Observed: `{"model": "claude-sonnet", "content": "ok", "usage": 19}` and `HTTP 200`

#### Key granted claude-haiku calls the team alias team-fast

1. `curl -s -w '\nHTTP %{http_code}\n' http://localhost:4101/v1/chat/completions -H "Authorization: Bearer $HAIKU_KEY" -H 'Content-Type: application/json' -d '{"model":"team-fast", ...}'`
2. Observed: `{"model": "team-fast", "content": "ok", "usage": 17}` and `HTTP 200`

## Type

🐛 Bug Fix

## Caveats (if any)

### Severe

- Keys that relied on an alias to reach a model outside their own list now get 403
- Teams whose `models` list omits an alias target now get 403 through that alias

### Low

- The header forwarding lookup by model group shares the helper and now resolves aliases to their target too
- A team alias name is no longer matched against the allowlist itself, and it is not resolved through the router or global alias maps; only its target is, so a name that is both a team alias and a router alias follows the team alias, as request routing already does

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
