### PR TITLE
fix(deepseek): forward graded reasoning_effort instead of discarding it

### DIFF
--- a/litellm/llms/deepseek/chat/transformation.py
+++ b/litellm/llms/deepseek/chat/transformation.py
@@ -39,7 +39,8 @@ class DeepSeekChatConfig(OpenAIGPTConfig):
         Handles `thinking` and `reasoning_effort` parameters for DeepSeek reasoner models.
         DeepSeek supports `{"type": "enabled"}` and `{"type": "disabled"}` - no budget_tokens
         like Anthropic. `reasoning_effort="none"` is the OpenAI-style way to ask for thinking
-        off, so it maps to `{"type": "disabled"}`; any other effort keeps thinking on.
+        off, so it maps to `{"type": "disabled"}`; any other effort keeps thinking on and
+        is forwarded, since DeepSeek grades effort itself server-side.
 
         Reference: https://api-docs.deepseek.com/guides/thinking_mode
         """
@@ -57,7 +58,10 @@ class DeepSeekChatConfig(OpenAIGPTConfig):
 
         # Otherwise fall back to reasoning_effort: "none" disables, anything else enables
         elif reasoning_effort is not None:
-            optional_params["thinking"] = {"type": "disabled" if reasoning_effort == "none" else "enabled"}
+            thinking_enabled: Final = reasoning_effort != "none"
+            optional_params["thinking"] = {"type": "enabled" if thinking_enabled else "disabled"}
+            if thinking_enabled:
+                optional_params["reasoning_effort"] = reasoning_effort
 
         return optional_params
 

--- a/tests/test_litellm/llms/deepseek/chat/test_deepseek_chat_transformation.py
+++ b/tests/test_litellm/llms/deepseek/chat/test_deepseek_chat_transformation.py
@@ -443,6 +443,7 @@ class TestDeepSeekThinkingParams:
         )
 
         assert result["thinking"] == {"type": "enabled"}
+        assert result["reasoning_effort"] == "medium"
 
     def test_map_reasoning_effort_low(self):
         """Test that reasoning_effort='low' maps to thinking enabled."""
@@ -457,6 +458,7 @@ class TestDeepSeekThinkingParams:
         )
 
         assert result["thinking"] == {"type": "enabled"}
+        assert result["reasoning_effort"] == "low"
 
     def test_map_reasoning_effort_high(self):
         """Test that reasoning_effort='high' maps to thinking enabled."""
@@ -471,6 +473,43 @@ class TestDeepSeekThinkingParams:
         )
 
         assert result["thinking"] == {"type": "enabled"}
+        assert result["reasoning_effort"] == "high"
+
+    def test_map_graded_effort_is_forwarded_not_collapsed(self):
+        """Every effort value reaches DeepSeek, which grades it server-side."""
+        for effort in ("minimal", "low", "medium", "default", "high", "xhigh", "max", "ultra"):
+            result = self.config.map_openai_params(
+                non_default_params={"reasoning_effort": effort},
+                optional_params={},
+                model=self.model,
+                drop_params=False,
+            )
+            assert result["thinking"] == {"type": "enabled"}
+            assert result["reasoning_effort"] == effort
+
+    def test_explicit_thinking_is_honoured_exactly_as_given(self):
+        """An explicit toggle decides thinking, and no effort is merged into it."""
+        result = self.config.map_openai_params(
+            non_default_params={"thinking": {"type": "enabled"}, "reasoning_effort": "low"},
+            optional_params={},
+            model=self.model,
+            drop_params=False,
+        )
+        assert result["thinking"] == {"type": "enabled"}
+        assert "reasoning_effort" not in result
+
+    def test_disabled_thinking_carries_no_effort(self):
+        """Nothing is thinking, so an effort value would be meaningless."""
+        for params in ({"reasoning_effort": "none"},
+                       {"thinking": {"type": "disabled"}}):
+            result = self.config.map_openai_params(
+                non_default_params=params,
+                optional_params={},
+                model=self.model,
+                drop_params=False,
+            )
+            assert result["thinking"] == {"type": "disabled"}
+            assert "reasoning_effort" not in result
 
     def test_map_reasoning_effort_none_does_not_enable_thinking(self):
         """Test that reasoning_effort='none' does not enable thinking."""


### PR DESCRIPTION
## TLDR

Problem this solves:

- `reasoning_effort` is dropped for DeepSeek, so `low` behaves like `high`
- callers cannot ask a DeepSeek model to think less, at all

How it solves it:

- forward the effort value instead of collapsing it to `thinking: enabled`
- let DeepSeek grade it server-side rather than remapping in the client

## User Flow

Before: a developer running an agent loop on `deepseek-flash` tries to stop the model over-thinking, and nothing they set makes any difference

1. Their agent hits a task with an ambiguous next step, and the model deliberates until it exhausts `max_tokens`
2. The turn comes back with `finish_reason: "length"`, empty `content` and no `tool_calls`, so the loop has nothing to act on
3. They set `reasoning_effort="low"` and send the same request
4. The request body on the wire still says only `"thinking": {"type": "enabled"}`, with no effort, so the model reasons exactly as much as before
5. They raise `max_tokens` instead, and the model simply deliberates further into the larger budget

After: the same developer sets `reasoning_effort="low"` and the model reasons roughly half as much and reaches an answer

1. Their agent hits the same ambiguous task
2. They set `reasoning_effort="low"` and send the request
3. The request body on the wire now carries `"reasoning_effort": "low"` alongside `"thinking": {"type": "enabled"}`
4. The response comes back with `finish_reason: "stop"` and a usable tool call, having used about half the reasoning tokens

## Evidence

Measured against `deepseek-flash`, four samples per setting on a bounded reasoning task:

| `reasoning_effort` | reasoning tokens | median |
|---|---|---|
| `low` | 2828, 1315, 2603, 2972 | 2,716 |
| `high` | 4926, 11938, 3652, 3893 | 4,410 |

On an unbounded task with a 45,000 token budget, `low` finished at 19,554 reasoning tokens while `high` ran into the cap without finishing

## Caveats

- an explicit `thinking` toggle is still honoured exactly as given, and no effort is merged into it. I could not establish whether DeepSeek applies an effort alongside an explicit toggle: four samples per condition put the combined case between `low` and `high`, overlapping both, so the patch does not guess
- the mapping is deliberately not reimplemented here. DeepSeek publishes its own table (`minimal`/`low` → low, `medium`/`high`/`xhigh` → high, `max`/`ultra` → max) and applies it server-side, so duplicating it in the client would diverge whenever they change it. #27829 took the client-side approach and collapsed `low` into `high`, which loses the only level that shortens reasoning

## Testing

Extends `tests/test_litellm/llms/deepseek/chat/test_deepseek_chat_transformation.py`:

- every documented effort value, plus `default`, reaches the request body
- an explicit `thinking` toggle carries no effort
- disabled thinking carries no effort
- the three existing effort tests now assert the forwarded value, not just the toggle

16 thinking and effort tests pass. Two vision tests in the same file fail identically before and after this change

