### PR TITLE
fix(terraform): accept 2xx status codes in mcp server, model, key and org requests

### DIFF
--- a/terraform/provider/CHANGELOG.md
+++ b/terraform/provider/CHANGELOG.md
@@ -43,6 +43,7 @@ longer signal it.
 - **key**: Updates no longer send an empty `budget_duration`, which the proxy rejects with a 400; any update to a key without a configured `budget_duration` previously failed outright
 - **key**: A config-supplied `key` value (write-only) is now forwarded to `/key/generate`; previously it was silently dropped and the proxy generated a random key instead
 - **security**: The `litellm_key` data source and `litellm_key_block` resource normalize raw `sk-` keys to their SHA-256 token hash before building request URLs and resource IDs, so plaintext keys no longer land in reverse-proxy access logs, Terraform plan output, or state IDs
+- **mcp_server, model, key, organization_member**: Requests now accept any 2xx response instead of requiring exactly HTTP 200; the proxy legitimately returns 201 from `POST /v1/mcp/server` (and other create endpoints), so `litellm_mcp_server` create previously succeeded on the proxy but failed in the provider, leaving the resource out of state and risking a duplicate server on retry
 
 ### Changed
 

--- a/terraform/provider/litellm/client.go
+++ b/terraform/provider/litellm/client.go
@@ -422,7 +422,7 @@ func (c *Client) sendRequest(method, path string, body interface{}) (map[string]
 	log.Printf("Response status: %d", resp.StatusCode)
 	log.Printf("Response body: %s", c.redactSensitiveData(string(bodyBytes)))
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, &apiError{StatusCode: resp.StatusCode, Body: string(bodyBytes)}
 	}
 

--- a/terraform/provider/litellm/client_test.go
+++ b/terraform/provider/litellm/client_test.go
@@ -1,9 +1,66 @@
 package litellm
 
 import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 )
+
+func TestSendRequestAcceptsFullSuccessRange(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		wantErr    bool
+		wantValue  string
+	}{
+		{name: "200 OK", statusCode: http.StatusOK, wantErr: false, wantValue: "ok"},
+		{name: "201 Created", statusCode: http.StatusCreated, wantErr: false, wantValue: "created"},
+		{name: "202 Accepted", statusCode: http.StatusAccepted, wantErr: false, wantValue: "accepted"},
+		{name: "400 Bad Request", statusCode: http.StatusBadRequest, wantErr: true},
+		{name: "404 Not Found", statusCode: http.StatusNotFound, wantErr: true},
+		{name: "500 Internal Server Error", statusCode: http.StatusInternalServerError, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.statusCode)
+				w.Write([]byte(`{"value":"` + tt.wantValue + `"}`))
+			}))
+			defer srv.Close()
+
+			client := NewClient(srv.URL, "test-key", true)
+			result, err := client.sendRequest("POST", "/whatever", map[string]string{"foo": "bar"})
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("sendRequest returned no error for status %d", tt.statusCode)
+				}
+				var apiErr *apiError
+				if !errors.As(err, &apiErr) {
+					t.Fatalf("error is not *apiError: %v", err)
+				}
+				if apiErr.StatusCode != tt.statusCode {
+					t.Errorf("apiErr.StatusCode = %d, want %d", apiErr.StatusCode, tt.statusCode)
+				}
+				if tt.statusCode == http.StatusNotFound && !isNotFound(err) {
+					t.Errorf("isNotFound(err) = false for 404, want true")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("sendRequest returned unexpected error: %v", err)
+			}
+			if result["value"] != tt.wantValue {
+				t.Errorf("result[value] = %v, want %q", result["value"], tt.wantValue)
+			}
+		})
+	}
+}
 
 func TestRedactSensitiveDataNestedCredentialValues(t *testing.T) {
 	c := NewClient("http://localhost:4000", "sk-test", false)

--- a/terraform/provider/litellm/resource_mcp_server_crud.go
+++ b/terraform/provider/litellm/resource_mcp_server_crud.go
@@ -270,7 +270,7 @@ func resourceLiteLLMMCPServerDelete(d *schema.ResourceData, m interface{}) error
 	defer resp.Body.Close()
 
 	// For delete operations, we expect a simple string response
-	if resp.StatusCode != 200 {
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return fmt.Errorf("failed to delete MCP server: unexpected status code %d", resp.StatusCode)
 	}
 

--- a/terraform/provider/litellm/resource_mcp_server_crud_test.go
+++ b/terraform/provider/litellm/resource_mcp_server_crud_test.go
@@ -1,10 +1,58 @@
 package litellm
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
+
+func TestMCPServerDeleteAcceptsFullSuccessRange(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		wantErr    bool
+	}{
+		{name: "200 OK", statusCode: http.StatusOK, wantErr: false},
+		{name: "202 Accepted", statusCode: http.StatusAccepted, wantErr: false},
+		{name: "404 Not Found", statusCode: http.StatusNotFound, wantErr: true},
+		{name: "500 Internal Server Error", statusCode: http.StatusInternalServerError, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.statusCode)
+			}))
+			defer srv.Close()
+
+			d := schema.TestResourceDataRaw(t, resourceLiteLLMMCPServer().Schema, map[string]interface{}{
+				"server_name": "gh",
+				"transport":   "stdio",
+				"command":     "npx",
+			})
+			d.SetId("srv-1")
+
+			client := NewClient(srv.URL, "test-key", true)
+			err := resourceLiteLLMMCPServerDelete(d, client)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("resourceLiteLLMMCPServerDelete returned no error for status %d", tt.statusCode)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("resourceLiteLLMMCPServerDelete returned unexpected error: %v", err)
+			}
+			if d.Id() != "" {
+				t.Errorf("resource ID not cleared after successful delete, got %q", d.Id())
+			}
+		})
+	}
+}
 
 func TestMCPServerReadDoesNotPersistServerEnv(t *testing.T) {
 	d := schema.TestResourceDataRaw(t, resourceLiteLLMMCPServer().Schema, map[string]interface{}{

--- a/terraform/provider/litellm/utils.go
+++ b/terraform/provider/litellm/utils.go
@@ -42,7 +42,7 @@ func handleAPIResponse(resp *http.Response, reqBody interface{}, client *Client)
 		return nil, fmt.Errorf("failed to read response body: %v", err)
 	}
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		var errResp ErrorResponse
 		if err := json.Unmarshal(bodyBytes, &errResp); err == nil {
 			if isModelNotFoundError(errResp) {
@@ -132,7 +132,7 @@ func handleMCPAPIResponse(resp *http.Response, result interface{}, client *Clien
 		return fmt.Errorf("failed to read response body: %v", err)
 	}
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		var errResp ErrorResponse
 		if err := json.Unmarshal(bodyBytes, &errResp); err == nil {
 			if isMCPServerNotFoundError(errResp) {

--- a/terraform/provider/litellm/utils.go
+++ b/terraform/provider/litellm/utils.go
@@ -54,6 +54,10 @@ func handleAPIResponse(resp *http.Response, reqBody interface{}, client *Client)
 			resp.Status, client.redactSensitiveData(string(bodyBytes)), client.redactSensitiveData(string(reqBodyBytes)))
 	}
 
+	if len(bodyBytes) == 0 || string(bodyBytes) == "null" {
+		return &ModelResponse{}, nil
+	}
+
 	var modelResp ModelResponse
 	if err := json.Unmarshal(bodyBytes, &modelResp); err != nil {
 		return nil, fmt.Errorf("failed to parse response: %v", err)
@@ -141,6 +145,10 @@ func handleMCPAPIResponse(resp *http.Response, result interface{}, client *Clien
 		}
 		return fmt.Errorf("API request failed: Status: %s, Response: %s",
 			resp.Status, client.redactSensitiveData(string(bodyBytes)))
+	}
+
+	if len(bodyBytes) == 0 || string(bodyBytes) == "null" {
+		return nil
 	}
 
 	if err := json.Unmarshal(bodyBytes, result); err != nil {

--- a/terraform/provider/litellm/utils.go
+++ b/terraform/provider/litellm/utils.go
@@ -147,10 +147,6 @@ func handleMCPAPIResponse(resp *http.Response, result interface{}, client *Clien
 			resp.Status, client.redactSensitiveData(string(bodyBytes)))
 	}
 
-	if len(bodyBytes) == 0 || string(bodyBytes) == "null" {
-		return nil
-	}
-
 	if err := json.Unmarshal(bodyBytes, result); err != nil {
 		return fmt.Errorf("failed to parse response: %v", err)
 	}

--- a/terraform/provider/litellm/utils_test.go
+++ b/terraform/provider/litellm/utils_test.go
@@ -52,6 +52,22 @@ func TestHandleAPIResponseAcceptsFullSuccessRange(t *testing.T) {
 	}
 }
 
+func TestHandleAPIResponseAcceptsEmptyBodyOn2xx(t *testing.T) {
+	rec := httptest.NewRecorder()
+	rec.WriteHeader(http.StatusNoContent)
+	resp := rec.Result()
+
+	client := NewClient("http://localhost:4000", "test-key", true)
+	got, err := handleAPIResponse(resp, map[string]interface{}{"model_name": "gpt-4o"}, client)
+
+	if err != nil {
+		t.Fatalf("handleAPIResponse returned unexpected error for empty-body 204: %v", err)
+	}
+	if got == nil {
+		t.Fatal("handleAPIResponse returned nil ModelResponse for empty-body 204")
+	}
+}
+
 func TestHandleMCPAPIResponseAcceptsFullSuccessRange(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -94,5 +110,19 @@ func TestHandleMCPAPIResponseAcceptsFullSuccessRange(t *testing.T) {
 				t.Errorf("mcpResp.ServerID = %q, want srv-1", mcpResp.ServerID)
 			}
 		})
+	}
+}
+
+func TestHandleMCPAPIResponseAcceptsEmptyBodyOn2xx(t *testing.T) {
+	rec := httptest.NewRecorder()
+	rec.WriteHeader(http.StatusNoContent)
+	resp := rec.Result()
+
+	client := NewClient("http://localhost:4000", "test-key", true)
+	var mcpResp MCPServerResponse
+	err := handleMCPAPIResponse(resp, &mcpResp, client)
+
+	if err != nil {
+		t.Fatalf("handleMCPAPIResponse returned unexpected error for empty-body 204: %v", err)
 	}
 }

--- a/terraform/provider/litellm/utils_test.go
+++ b/terraform/provider/litellm/utils_test.go
@@ -1,0 +1,98 @@
+package litellm
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestHandleAPIResponseAcceptsFullSuccessRange(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		wantErr    bool
+	}{
+		{name: "200 OK", statusCode: http.StatusOK, wantErr: false},
+		{name: "201 Created", statusCode: http.StatusCreated, wantErr: false},
+		{name: "202 Accepted", statusCode: http.StatusAccepted, wantErr: false},
+		{name: "400 Bad Request", statusCode: http.StatusBadRequest, wantErr: true},
+		{name: "404 Not Found", statusCode: http.StatusNotFound, wantErr: true},
+		{name: "500 Internal Server Error", statusCode: http.StatusInternalServerError, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			rec.WriteHeader(tt.statusCode)
+			rec.WriteString(`{"model_name":"gpt-4o"}`)
+			resp := rec.Result()
+
+			client := NewClient("http://localhost:4000", "test-key", true)
+			got, err := handleAPIResponse(resp, map[string]interface{}{"model_name": "gpt-4o"}, client)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("handleAPIResponse returned no error for status %d", tt.statusCode)
+				}
+				if !strings.Contains(err.Error(), strconv.Itoa(tt.statusCode)) {
+					t.Errorf("error %q does not mention status %d", err.Error(), tt.statusCode)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("handleAPIResponse returned unexpected error: %v", err)
+			}
+			if got.ModelName != "gpt-4o" {
+				t.Errorf("got.ModelName = %q, want gpt-4o", got.ModelName)
+			}
+		})
+	}
+}
+
+func TestHandleMCPAPIResponseAcceptsFullSuccessRange(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		wantErr    bool
+	}{
+		{name: "200 OK", statusCode: http.StatusOK, wantErr: false},
+		{name: "201 Created", statusCode: http.StatusCreated, wantErr: false},
+		{name: "202 Accepted", statusCode: http.StatusAccepted, wantErr: false},
+		{name: "400 Bad Request", statusCode: http.StatusBadRequest, wantErr: true},
+		{name: "404 Not Found", statusCode: http.StatusNotFound, wantErr: true},
+		{name: "500 Internal Server Error", statusCode: http.StatusInternalServerError, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			rec.WriteHeader(tt.statusCode)
+			rec.WriteString(`{"server_id":"srv-1","server_name":"gh"}`)
+			resp := rec.Result()
+
+			client := NewClient("http://localhost:4000", "test-key", true)
+			var mcpResp MCPServerResponse
+			err := handleMCPAPIResponse(resp, &mcpResp, client)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("handleMCPAPIResponse returned no error for status %d", tt.statusCode)
+				}
+				if !strings.Contains(err.Error(), strconv.Itoa(tt.statusCode)) {
+					t.Errorf("error %q does not mention status %d", err.Error(), tt.statusCode)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("handleMCPAPIResponse returned unexpected error: %v", err)
+			}
+			if mcpResp.ServerID != "srv-1" {
+				t.Errorf("mcpResp.ServerID = %q, want srv-1", mcpResp.ServerID)
+			}
+		})
+	}
+}

--- a/terraform/provider/litellm/utils_test.go
+++ b/terraform/provider/litellm/utils_test.go
@@ -113,7 +113,7 @@ func TestHandleMCPAPIResponseAcceptsFullSuccessRange(t *testing.T) {
 	}
 }
 
-func TestHandleMCPAPIResponseAcceptsEmptyBodyOn2xx(t *testing.T) {
+func TestHandleMCPAPIResponseRejectsEmptyBodyOn2xx(t *testing.T) {
 	rec := httptest.NewRecorder()
 	rec.WriteHeader(http.StatusNoContent)
 	resp := rec.Result()
@@ -122,7 +122,7 @@ func TestHandleMCPAPIResponseAcceptsEmptyBodyOn2xx(t *testing.T) {
 	var mcpResp MCPServerResponse
 	err := handleMCPAPIResponse(resp, &mcpResp, client)
 
-	if err != nil {
-		t.Fatalf("handleMCPAPIResponse returned unexpected error for empty-body 204: %v", err)
+	if err == nil {
+		t.Fatal("handleMCPAPIResponse returned no error for empty-body 204; every MCP caller (create/read/update) writes the parsed result straight into Terraform state with no fallback, so a silently-accepted empty body would blank out or empty-ID the resource")
 	}
 }


### PR DESCRIPTION
## TLDR

Problem this solves:

- Terraform provider `litellm_mcp_server` create/delete fail even when the proxy succeeds
- Proxy returns 201/202 on create/delete, provider only accepted exactly 200
- Same exact-200 bug duplicated in model, key, and org-member request handling

How it solves it:

- Accept any 2xx status as success in all four affected call sites, rather than just 200

## User Flow

Before: an admin managing an MCP server through Terraform gets a failed apply even though the server was created, and a failed destroy even though the server was deleted.

1. Admin adds a `litellm_mcp_server` resource to their `.tf` and runs `terraform apply`
2. Terraform sends `POST http://<proxy>/v1/mcp/server` with the server config
3. The proxy responds `201 Created` with the new server's JSON body, including a real `server_id`
4. `terraform apply` fails with `Error: failed to create MCP server: API request failed: Status: 201 Created, Response: {...}`, and the resource never lands in Terraform state
5. Admin retries the apply; the proxy creates a second, duplicate MCP server, since Terraform has no record of the first
6. Later, admin runs `terraform destroy` on a `litellm_mcp_server` that is in state; Terraform sends `DELETE http://<proxy>/v1/mcp/server/{id}`, the proxy responds `202 Accepted`, and destroy fails with `Error: failed to delete MCP server: unexpected status code 202`, leaving the resource stuck in state pointing at an already-deleted server

After: the same admin's apply and destroy both succeed and match the proxy's actual state.

1. Admin adds a `litellm_mcp_server` resource to their `.tf` and runs `terraform apply`
2. Terraform sends `POST http://<proxy>/v1/mcp/server`
3. The proxy responds `201 Created`
4. `terraform apply` succeeds; the resource lands in state with the real `server_id`
5. Admin runs `terraform destroy`; Terraform sends `DELETE http://<proxy>/v1/mcp/server/{id}`, the proxy responds `202 Accepted`, and destroy succeeds, removing the resource from state

## Relevant issues

Fixes #40722

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)


## Screenshots / Proof of Fix

Proxy started with `litellm/proxy/dev_config.yaml` (master key `sk-1234`), a local Postgres via `DATABASE_URL`, on `http://localhost:4001`. Terraform pointed at the provider binary via `dev_overrides` so no registry publish was needed.

### Before (9a715df212)

#### Create returns 201, apply fails anyway

1. `curl -s -i -X POST http://localhost:4001/v1/mcp/server -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"server_name":"proof_server","url":"https://example.com/mcp","transport":"http","spec_version":"2025-03-26","auth_type":"none"}'` -> `HTTP/1.1 201 Created` with `{"server_id":"704156af-2ed0-4653-b4ef-7eee65c6e0e4","server_name":"proof_server",...}`
2. `terraform apply -auto-approve` against a `litellm_mcp_server` resource -> `Error: failed to create MCP server: API request failed: Status: 201 Created, Response: {"server_id":"670add50-c61d-4d8d-9ff0-2143bc0fb958","server_name":"tf_proof_server",...}`, resource not added to state

#### Delete returns 202, destroy fails anyway

1. Same resource created directly against the fixed binary to get it into state, then `terraform apply` re-run against the pre-fix binary followed by `terraform destroy -auto-approve` -> `Error: failed to delete MCP server: unexpected status code 202`

### After (98fb823dc2)

#### Create returns 201, apply succeeds

1. `terraform apply -auto-approve` -> `litellm_mcp_server.proof: Creation complete after 0s [id=b3b9d00d-1fa1-47d1-b254-44980246fe9a]` / `Apply complete! Resources: 1 added, 0 changed, 0 destroyed.`

#### Delete returns 202, destroy succeeds

1. `terraform destroy -auto-approve` -> `litellm_mcp_server.proof: Destruction complete after 0s` / `Destroy complete! Resources: 1 destroyed.`

## Type

🐛 Bug Fix


## Caveats (if any)

### Low

- Other resources with the same exact-200 pattern (`project`, `team`, `tag`) are out of scope for this PR; not touched here
- `/v1/mcp/server/register`, `/v1/mcp/toolset`, `/v1/mcp/make_public` aren't called by this provider today, so they weren't part of this fix

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
