### PR TITLE
perf(proxy): make /spend/logs/ui session listing use an index and run its queries concurrently

### DIFF
--- a/litellm-proxy-extras/litellm_proxy_extras/migrations/20260911000000_spend_logs_session_window_index/migration.sql
+++ b/litellm-proxy-extras/litellm_proxy_extras/migrations/20260911000000_spend_logs_session_window_index/migration.sql
@@ -1,0 +1,14 @@
+-- CreateIndex (CONCURRENTLY)
+--
+-- Covering index for the session-grouped /spend/logs/ui listing. The page,
+-- count, and representative queries all GROUP BY
+-- COALESCE(NULLIF(session_id, ''), request_id), api_key over a startTime
+-- window; with only the plain startTime index they aggregate full heap rows
+-- (hundreds of KB each from messages/response), which is the 40s+ page load.
+-- This index makes those window scans index-only.
+--
+-- CREATE INDEX CONCURRENTLY cannot run inside a transaction, so this
+-- migration must stay a single statement (see
+-- 20260415120000_health_check_latest_per_model_index for the full
+-- disclaimer).
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "LiteLLM_SpendLogs_session_window_idx" ON "LiteLLM_SpendLogs"("startTime", session_id, request_id, api_key, status);

--- a/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
+++ b/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
@@ -665,6 +665,7 @@ model LiteLLM_SpendLogs {
   @@index([startTime, request_id])
   @@index([end_user])
   @@index([session_id])
+  @@index([startTime, session_id, request_id, api_key, status], map: "LiteLLM_SpendLogs_session_window_idx")
 }
 
 model LiteLLM_BudgetWindowSpend {

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -665,6 +665,7 @@ model LiteLLM_SpendLogs {
   @@index([startTime, request_id])
   @@index([end_user])
   @@index([session_id])
+  @@index([startTime, session_id, request_id, api_key, status], map: "LiteLLM_SpendLogs_session_window_idx")
 }
 
 model LiteLLM_BudgetWindowSpend {

--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -1,8 +1,9 @@
 #### SPEND MANAGEMENT #####
+import asyncio
 import collections
 import json
 import os
-from collections.abc import Mapping, Sequence
+from collections.abc import Awaitable, Mapping, Sequence
 from datetime import date, datetime, timedelta, timezone
 from itertools import groupby
 from types import MappingProxyType
@@ -2821,13 +2822,6 @@ async def ui_view_spend_logs(
                 LIMIT ${p}
             ) AS bounded_matches
         """
-        count_rows: Final[Sequence[_SpendLogsCountRow] | None] = await _query_raw_or_none(
-            prisma_client, count_query, *sql_params, SPEND_LOGS_PAGINATION_COUNT_CAP + 1
-        )
-        raw_total: Final = int(count_rows[0]["total_count"]) if count_rows else 0
-        total_is_capped: Final = raw_total > SPEND_LOGS_PAGINATION_COUNT_CAP
-        total_records: Final = SPEND_LOGS_PAGINATION_COUNT_CAP if total_is_capped else raw_total
-
         sql_query: Final = (
             f"""
                 SELECT * FROM (
@@ -2850,16 +2844,19 @@ async def ui_view_spend_logs(
             LIMIT ${p} OFFSET ${p + 1}
         """
         )
-        sql_params.extend([page_size, skip])
-
-        data: Final = await prisma_client.db.query_raw(sql_query, *sql_params)
+        count_task: Final[Awaitable[Sequence[_SpendLogsCountRow] | None]] = _query_raw_or_none(
+            prisma_client, count_query, *sql_params, SPEND_LOGS_PAGINATION_COUNT_CAP + 1
+        )
+        data_task: Final = prisma_client.db.query_raw(sql_query, *sql_params, page_size, skip)
+        count_rows, data = await asyncio.gather(count_task, data_task)
+        raw_total: Final = int(count_rows[0]["total_count"]) if count_rows else 0
+        total_is_capped: Final = raw_total > SPEND_LOGS_PAGINATION_COUNT_CAP
+        total_records: Final = SPEND_LOGS_PAGINATION_COUNT_CAP if total_is_capped else raw_total
 
         _hydrate_spend_log_metadata(data)
 
         # Calculate total pages
         total_pages: Final = (total_records + page_size - 1) // page_size
-
-        verbose_proxy_logger.debug("data= %s", json.dumps(data, indent=4, default=str))
 
         return await _build_ui_spend_logs_response(
             prisma_client,
@@ -2899,15 +2896,25 @@ async def _fetch_session_representatives(
     next_param_index: int,
     session_keys: Sequence[tuple[str, str]],
 ) -> list[dict[str, object]]:  # mutable-ok: _build_ui_spend_logs_response writes session counts onto each row
-    """Fetch the newest non-MCP row of each ``(session_key, api_key)`` session, in ``session_keys`` order."""
+    """Fetch the newest non-MCP row of each ``(session_key, api_key)`` session, in ``session_keys`` order.
+
+    The SQL matches candidates on the plain ``session_id`` / ``request_id`` /
+    ``api_key`` columns so the ``(startTime, session_id, request_id, api_key)``
+    index applies; a row-tuple ``IN`` on the COALESCE group key forces a full
+    window scan. That predicate admits a superset of the requested pairs (the
+    cross product of session ids and api keys, plus rows whose request_id
+    collides with a requested key), so the exact ``(session_key, api_key)``
+    pairing is restored by the ``rep_by_key`` lookup below.
+    """
     rep_query: Final = f"""
         SELECT * FROM (
             SELECT DISTINCT ON ({_SESSION_GROUP_KEY_SQL})
                 {_SPEND_LOG_LIST_COLUMNS}
             FROM "LiteLLM_SpendLogs"
             WHERE {where_clause}
-              AND ({_SESSION_GROUP_KEY_SQL}) IN (
-                  SELECT * FROM unnest(${next_param_index}::text[], ${next_param_index + 1}::text[])
+              AND (
+                  (session_id = ANY(${next_param_index}::text[]) AND api_key = ANY(${next_param_index + 1}::text[]))
+                  OR request_id = ANY(${next_param_index}::text[])
               )
             ORDER BY {_SESSION_GROUP_KEY_SQL}, call_type IN {_MCP_CALL_TYPES_SQL}, "startTime" DESC
         ) AS session_representatives
@@ -2975,18 +2982,6 @@ async def _ui_session_grouped_spend_logs(
         ORDER BY MAX("startTime") {direction}, {_SESSION_KEY_EXPR} {direction}, api_key {direction}
         LIMIT ${limit_index}
     """
-    page_rows: Final[Sequence[_SessionPageRow]] = await _query_raw(
-        prisma_client, page_query, *sql_params, *cursor_params, page_size + 1
-    )
-
-    has_more: Final = len(page_rows) > page_size
-    visible_rows: Final = page_rows[:page_size]
-    next_cursor: Final = (
-        f"{visible_rows[-1]['last_activity']}|{visible_rows[-1]['api_key']}|{visible_rows[-1]['session_key']}"
-        if has_more and visible_rows
-        else None
-    )
-
     count_query: Final = f"""
         SELECT COUNT(*) AS total_count
         FROM (
@@ -2997,8 +2992,20 @@ async def _ui_session_grouped_spend_logs(
             LIMIT ${next_param_index}
         ) AS bounded_sessions
     """
-    count_rows: Final[Sequence[_SpendLogsCountRow]] = await _query_raw(
+    page_rows_task: Final[Awaitable[Sequence[_SessionPageRow]]] = _query_raw(
+        prisma_client, page_query, *sql_params, *cursor_params, page_size + 1
+    )
+    count_rows_task: Final[Awaitable[Sequence[_SpendLogsCountRow]]] = _query_raw(
         prisma_client, count_query, *sql_params, SPEND_LOGS_PAGINATION_COUNT_CAP + 1
+    )
+    page_rows, count_rows = await asyncio.gather(page_rows_task, count_rows_task)
+
+    has_more: Final = len(page_rows) > page_size
+    visible_rows: Final = page_rows[:page_size]
+    next_cursor: Final = (
+        f"{visible_rows[-1]['last_activity']}|{visible_rows[-1]['api_key']}|{visible_rows[-1]['session_key']}"
+        if has_more and visible_rows
+        else None
     )
     raw_total: Final = int(count_rows[0]["total_count"]) if count_rows else 0
     total_is_capped: Final = raw_total > SPEND_LOGS_PAGINATION_COUNT_CAP

--- a/schema.prisma
+++ b/schema.prisma
@@ -665,6 +665,7 @@ model LiteLLM_SpendLogs {
   @@index([startTime, request_id])
   @@index([end_user])
   @@index([session_id])
+  @@index([startTime, session_id, request_id, api_key, status], map: "LiteLLM_SpendLogs_session_window_idx")
 }
 
 model LiteLLM_BudgetWindowSpend {

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -6640,6 +6640,10 @@ async def test_ui_view_spend_logs_group_by_session_first_page(client, monkeypatc
     reps = [
         _session_representative_row("req-solo", None),
         _session_representative_row("req-1", "sess-1"),
+        # The plain-column predicate admits the cross product of session ids and
+        # api keys, so the endpoint must drop rows whose (session_key, api_key)
+        # pair was never requested.
+        _session_representative_row("req-cross-product", "sess-unrequested"),
     ]
     mock_prisma = _session_grouped_mock_prisma(page_rows, 3, reps)
     monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma)
@@ -6689,6 +6693,12 @@ async def test_ui_view_spend_logs_group_by_session_first_page(client, monkeypatc
             f"ORDER BY {SESSION_GROUP_KEY_SQL}, call_type IN ('call_mcp_tool', 'list_mcp_tools'), \"startTime\" DESC"
             in rep_call[0]
         ), "the session representative must prefer the newest non-MCP call"
+        assert "session_id = ANY(" in rep_call[0] and "OR request_id = ANY(" in rep_call[0], (
+            "the representative lookup must filter on the plain session_id/request_id columns so the "
+            "(startTime, session_id, request_id, api_key, status) index applies; a row-tuple IN on the "
+            "COALESCE group key forces a full window scan (the 40s+ logs page)"
+        )
+        assert f"({SESSION_GROUP_KEY_SQL}) IN" not in rep_call[0]
         assert rep_call[-2] == ["sess-1", "req-solo"]
         assert rep_call[-1] == ["hashed-key", "hashed-key"]
     finally:


### PR DESCRIPTION
## TLDR

Problem this solves:

- Request Logs UI takes 40s-1m to load, often times out with a 500
- Every page load ran 4 heavy queries, one after another
- Session grouping aggregated full heap rows for the whole window

How it solves it:

- New covering index makes the window GROUP BYs index-only scans
- Representative-row lookup rewritten to hit that index
- Independent queries now run concurrently instead of sequentially
- Dropped a debug json.dumps of the page that ran on every request

## User Flow

Before: an admin opening Request Logs waits 40s-1m per page, or gets an error

1. They open http://localhost:4000/ui/?page=logs
2. The table spinner runs for 40s-1m on a deployment with a few million rows in the window
3. On larger windows the page shows an error toast after the request times out with a 500

After: the same page renders in about a second

1. They open http://localhost:4000/ui/?page=logs
2. The table renders in about a second, with the same rows, totals, and session grouping
3. Paging, status filters, and session expansion respond in under a second as well

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Setup: local Postgres 16 in Docker seeded with 5,000,000 synthetic spend log rows spread over 7 days (about 710k rows in a 24h window; 60% of rows carry a session_id shared by ~3 rows, JSON payload columns padded to a realistic size). Proxy from source on port 4020 pointed at that DB. All requests are the exact call the dashboard makes: GET /spend/logs/ui with a 24h window, page_size=50, group_by_session=true

### Benchmarks

Per-query timings via psql \timing on the seeded DB, warm cache, best of repeated runs. "Before" is the merge base's SQL on the existing indexes; "after" is with the new index, the rewritten representative query, and the queries running concurrently

| Query | Before | After |
| --- | --- | --- |
| Session page (GROUP BY over the window) | 36.3 s | 0.7 s |
| Bounded session count | 32.6 s | 0.5 s |
| Representative rows (DISTINCT ON) | 26.5 s | 13 ms |
| Session enrichment aggregates | 17 ms | 5 ms |
| End-to-end GET /spend/logs/ui through the live proxy | 30 to 52 s, HTTP 500 (Prisma engine read timeout) | 0.65 to 0.9 s, HTTP 200 |

Before, the first three queries ran one after another, so the endpoint sat at ~95 s of DB time and hit the Prisma engine timeout first. The two big remaining queries now also run concurrently, which is why the endpoint lands under a second rather than at their ~1.2 s sum

### Before (9a715df212)

#### Default Request Logs page load

1. `curl -G "http://localhost:4020/spend/logs/ui" --data-urlencode "start_date=2026-09-10 14:51:32" --data-urlencode "end_date=2026-09-11 14:51:32" --data-urlencode "page=1" --data-urlencode "page_size=50" --data-urlencode "group_by_session=true" -H "Authorization: Bearer sk-perf-1234" -w "%{time_total}s %{http_code}"` run 3 times
2. Observed: `30.11s 500`, `47.75s 500`, `51.59s 500`. The proxy log shows `httpx.ReadTimeout` from the Prisma engine; this is the 40s-1m hang (or error) the dashboard shows

### After (46ef016f2f)

#### Default Request Logs page load

1. Same curl, run 3 times
2. Observed: `0.90s 200`, `0.65s 200`, `0.66s 200`, returning 50 rows with `total: 10000`, `total_is_capped: true`, `has_more: true`, and populated `session_total_count` / `session_models` per row

#### Keyset pagination to page 2

1. Same curl with `page=2` and the `next_session_cursor` returned by page 1
2. Observed: `1.03s 200`, 50 rows, zero request_id overlap with page 1

#### Status filter

1. Same curl plus `--data-urlencode "status_filter=failure"`, then `status_filter=success`
2. Observed: `0.11s 200` (all 50 rows have status failure) and `0.87s 200`

#### Old vs new representative-row SQL returns identical rows

1. The rewritten predicate (plain `session_id`/`request_id` columns instead of a row-tuple IN on the COALESCE expression) was diffed against the old one on the seeded DB with EXCEPT in both directions across mixed session and singleton keys
2. Observed: `old_rows 4 | new_rows 4 | only_old 0 | only_new 0`

## Type

🚄 Infrastructure

## Caveats (if any)

### Low

- Rep-row SQL admits cross-product matches; Python re-pairs them (tested)
- After merging main (retargeted from the old staging base), the grouped count runs as a task overlapping the page query and is cancelled when a short last page totals itself, keeping main's count-skip behavior

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

