### PR TITLE
fix(proxy): treat a present-but-None model_info key as unset when enriching from the cost map

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -13465,7 +13465,10 @@ def _enrich_model_info_with_litellm_data(
             except Exception:
                 litellm_model_info = {}
     for k, v in litellm_model_info.items():
-        if k not in model_info:
+        # A key that is present but None must be treated as unset. ModelInfo's
+        # set_model_info validator writes None over absent cost fields, so
+        # "k not in model_info" leaves a priced model reading as unpriced.
+        if model_info.get(k) is None:
             model_info[k] = v
     model["model_info"] = model_info
     # don't return the api key / vertex credentials
@@ -14931,7 +14934,9 @@ def _get_proxy_model_info(model: dict) -> dict:
         except Exception:
             litellm_model_info = {}
     for k, v in litellm_model_info.items():
-        if k not in model_info:
+        # Same as _enrich_model_info_with_litellm_data: a present-but-None key
+        # is unset, not a deliberate override.
+        if model_info.get(k) is None:
             model_info[k] = v
     model["model_info"] = model_info
     # don't return the llm credentials


### PR DESCRIPTION
Fixes #40741.

## Problem

`ModelInfo.set_model_info` overwrites the declared defaults with `None` when the caller does not supply them:

```python
@model_validator(mode="before")
@classmethod
def set_model_info(cls, values):
    ...
    if values.get("input_cost_per_token") is None:
        values.update({"input_cost_per_token": None})
```

So `model_dump()` emits `input_cost_per_token: None` and `output_cost_per_token: None` for any model without custom pricing, turning an absent key into a key that is present and `None`.

Both cost-map enrichment sites fill with `if k not in model_info`, which only fills absent keys, so those `None`s are never replaced. A model that is priced in the built-in cost map reads back as unpriced. `estimate_request_max_cost` then returns `0.0`, so the atomic pre-call budget reservation reserves nothing and per-key and per-team budgets stop being enforced under concurrency. There is no error and no log line, and post-call cost tracking resolves pricing separately so spend reporting stays correct and hides the gap.

This is the `None` half of #30198. PR #30201 fixed the synthesized-zero half; the issue text also noted that the write-back leaves "dozens of explicit None fields", and that half is still present.

## Change

Treat a present-but-`None` key as unset at both sites, which matches the intent of only filling what the operator has not configured. This mirrors the existing `litellm_provider`-is-`None` guard in `register_model` and the cost-field guard added by #30201.

## Verification

Against `main`, using the built-in price for `eu.anthropic.claude-opus-5` (5.5e-06):

| case | before | after |
| --- | --- | --- |
| model_info without the cost keys | 5.5e-06 | 5.5e-06 |
| model_info from `ModelInfo(...).model_dump()` | **None** | **5.5e-06** |
| operator set a real price (9.9e-07) | 9.9e-07 | 9.9e-07 |
| operator set 0.0 deliberately | 0.0 | 0.0 |

The last row is the one to check: `0.0` is not `None`, so a deliberately free model is preserved and the zero-cost handling from #24949 is unaffected.

End to end, on the affected path, `estimate_request_max_cost` goes from `0.0` to `0.005764` for a representative request, so budget reservation runs instead of silently skipping.
