### PR TITLE
feat(cerebras): add qwen-3.8-27b registry pricing

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -13090,6 +13090,22 @@
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
+    "cerebras/qwen-3.8-27b": {
+        "input_cost_per_token": 9.9e-07,
+        "litellm_provider": "cerebras",
+        "max_input_tokens": 65536,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "output_cost_per_token": 1.49e-06,
+        "source": "https://api.cerebras.ai/public/v1/models/qwen-3.8-27b",
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "cerebras/zai-glm-4.6": {
         "deprecation_date": "2026-01-20",
         "input_cost_per_token": 2.25e-06,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -13090,6 +13090,22 @@
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
+    "cerebras/qwen-3.8-27b": {
+        "input_cost_per_token": 9.9e-07,
+        "litellm_provider": "cerebras",
+        "max_input_tokens": 65536,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "output_cost_per_token": 1.49e-06,
+        "source": "https://api.cerebras.ai/public/v1/models/qwen-3.8-27b",
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "cerebras/zai-glm-4.6": {
         "deprecation_date": "2026-01-20",
         "input_cost_per_token": 2.25e-06,

--- a/tests/test_litellm/llms/cerebras/test_cerebras_model_prices.py
+++ b/tests/test_litellm/llms/cerebras/test_cerebras_model_prices.py
@@ -1,0 +1,34 @@
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+REGISTRY_PATHS = (
+    REPO_ROOT / "model_prices_and_context_window.json",
+    REPO_ROOT / "litellm" / "model_prices_and_context_window_backup.json",
+)
+
+# Public Cerebras catalog: https://api.cerebras.ai/public/v1/models/qwen-3.8-27b
+EXPECTED = {
+    "input_cost_per_token": 9.9e-07,
+    "litellm_provider": "cerebras",
+    "max_input_tokens": 65536,
+    "max_output_tokens": 32768,
+    "max_tokens": 32768,
+    "mode": "chat",
+    "output_cost_per_token": 1.49e-06,
+    "supports_function_calling": True,
+    "supports_parallel_function_calling": True,
+    "supports_reasoning": True,
+    "supports_response_schema": True,
+    "supports_tool_choice": True,
+    "supports_vision": True,
+}
+
+
+def test_qwen_38_27b_matches_public_cerebras_catalog() -> None:
+    for path in REGISTRY_PATHS:
+        payload = json.loads(path.read_text())
+        entry = payload["cerebras/qwen-3.8-27b"]
+        for key, value in EXPECTED.items():
+            assert entry[key] == value, f"{path.name} {key}: {entry.get(key)!r} != {value!r}"
+        assert entry["source"] == "https://api.cerebras.ai/public/v1/models/qwen-3.8-27b"


### PR DESCRIPTION
## TLDR

Problem this solves:

- `cerebras/qwen-3.8-27b` is in Cerebras' public catalog
- LiteLLM spend tracking had no price row for it

How it solves it:

- Add the model to both price maps
- Copy catalog prices: $0.99 / $1.49 per million
- Record 65,536 context and 32,768 max output

## User Flow

Before: a developer on Cerebras Qwen 3.8 27B sees $0 spend because the model is missing from the price maps.

1. They send POST https://litellm-domain/v1/chat/completions with `"model": "cerebras/qwen-3.8-27b"`
2. The completion succeeds against Cerebras
3. They open https://litellm-domain/ui/?page=logs and the request is logged at $0 because LiteLLM has no registry price

After: the same request is costed from the public Cerebras catalog.

1. They send the same POST https://litellm-domain/v1/chat/completions with `"model": "cerebras/qwen-3.8-27b"`
2. The completion still succeeds against Cerebras
3. https://litellm-domain/ui/?page=logs now shows non-zero spend at $0.99 / $1.49 per million tokens (65,536 context, 32,768 max output, vision and tools)

## Relevant issues

None. Isolated registry add. Not stacked on #38064 / #38164 / #38071.

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Catalog source: https://api.cerebras.ai/public/v1/models/qwen-3.8-27b (`prompt` 0.00000099, `completion` 0.00000149, `max_context_length` 65536, `max_completion_tokens` 32768, vision/tools/reasoning).

Test: `tests/test_litellm/llms/cerebras/test_cerebras_model_prices.py`

### Before (67cb34c)

1. `GET https://api.cerebras.ai/public/v1/models/qwen-3.8-27b` returns the model with those prices
2. Neither `model_prices_and_context_window.json` nor `litellm/model_prices_and_context_window_backup.json` contains `cerebras/qwen-3.8-27b`

### After (239f914)

1. Same catalog GET is unchanged
2. Both price maps now have `cerebras/qwen-3.8-27b` with `input_cost_per_token` 9.9e-07, `output_cost_per_token` 1.49e-06, `max_input_tokens` 65536, `max_output_tokens` 32768, and vision/tools/reasoning flags
3. `test_qwen_38_27b_matches_public_cerebras_catalog` passes against both files

## Type

🆕 New Feature
✅ Test

## Caveats (if any)

### Low

- Registry-only: no new Cerebras adapter code
- Prices will drift if Cerebras changes the public catalog

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR