### PR TITLE
feat(cost_map): add inception/mercury-2.5 pricing and model settings (#40746)

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -33891,6 +33891,22 @@
         "supports_system_messages": true,
         "supports_tool_choice": true
     },
+    "inception/mercury-2.5": {
+        "cache_read_input_token_cost": 2e-08,
+        "input_cost_per_token": 2e-07,
+        "litellm_provider": "inception",
+        "max_input_tokens": 260000,
+        "max_output_tokens": 260000,
+        "max_tokens": 260000,
+        "mode": "chat",
+        "output_cost_per_token": 7.5e-07,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true
+    },
     "text-completion-inception/mercury-edit-2": {
         "cache_read_input_token_cost": 2.5e-08,
         "input_cost_per_token": 2.5e-07,
@@ -39489,6 +39505,22 @@
         "supports_system_messages": true,
         "supports_tool_choice": true,
         "supports_vision": true
+    },
+    "openrouter/inception/mercury-2.5-preview": {
+        "cache_read_input_token_cost": 2e-08,
+        "input_cost_per_token": 2e-07,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 260000,
+        "max_output_tokens": 260000,
+        "max_tokens": 260000,
+        "mode": "chat",
+        "output_cost_per_token": 7.5e-07,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true
     },
     "openrouter/gryphe/mythomax-l2-13b": {
         "input_cost_per_token": 6e-08,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -33891,6 +33891,22 @@
         "supports_system_messages": true,
         "supports_tool_choice": true
     },
+    "inception/mercury-2.5": {
+        "cache_read_input_token_cost": 2e-08,
+        "input_cost_per_token": 2e-07,
+        "litellm_provider": "inception",
+        "max_input_tokens": 260000,
+        "max_output_tokens": 260000,
+        "max_tokens": 260000,
+        "mode": "chat",
+        "output_cost_per_token": 7.5e-07,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true
+    },
     "text-completion-inception/mercury-edit-2": {
         "cache_read_input_token_cost": 2.5e-08,
         "input_cost_per_token": 2.5e-07,
@@ -39489,6 +39505,22 @@
         "supports_system_messages": true,
         "supports_tool_choice": true,
         "supports_vision": true
+    },
+    "openrouter/inception/mercury-2.5-preview": {
+        "cache_read_input_token_cost": 2e-08,
+        "input_cost_per_token": 2e-07,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 260000,
+        "max_output_tokens": 260000,
+        "max_tokens": 260000,
+        "mode": "chat",
+        "output_cost_per_token": 7.5e-07,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true
     },
     "openrouter/gryphe/mythomax-l2-13b": {
         "input_cost_per_token": 6e-08,

--- a/tests/test_litellm/llms/inception/test_inception_chat_transformation.py
+++ b/tests/test_litellm/llms/inception/test_inception_chat_transformation.py
@@ -317,10 +317,22 @@ def test_inception_mercury_2_5_cost_and_tokens(monkeypatch):
         prompt_tokens=1000,
         completion_tokens=500,
     )
-    # $0.20 per 1M input tokens -> 1000 * 0.0000002 = 0.0002
-    # $0.75 per 1M output tokens -> 500 * 0.00000075 = 0.000375
     assert abs(prompt_cost - 0.0002) < 1e-9
     assert abs(completion_cost - 0.000375) < 1e-9
+
+    from litellm.types.utils import PromptTokensDetailsWrapper, Usage
+
+    cached_usage = Usage(
+        prompt_tokens=1000,
+        completion_tokens=500,
+        total_tokens=1500,
+        prompt_tokens_details=PromptTokensDetailsWrapper(cached_tokens=400),
+    )
+    cached_prompt_cost, _ = litellm.cost_per_token(
+        model=model,
+        usage_object=cached_usage,
+    )
+    assert abs(cached_prompt_cost - 0.000128) < 1e-9
 
     model_info = litellm.get_model_info(model)
     assert model_info["max_input_tokens"] == 260000
@@ -344,6 +356,20 @@ def test_openrouter_inception_mercury_2_5_cost_and_tokens(monkeypatch):
     )
     assert abs(prompt_cost - 0.0002) < 1e-9
     assert abs(completion_cost - 0.000375) < 1e-9
+
+    from litellm.types.utils import PromptTokensDetailsWrapper, Usage
+
+    cached_usage = Usage(
+        prompt_tokens=1000,
+        completion_tokens=500,
+        total_tokens=1500,
+        prompt_tokens_details=PromptTokensDetailsWrapper(cached_tokens=400),
+    )
+    cached_prompt_cost, _ = litellm.cost_per_token(
+        model=model,
+        usage_object=cached_usage,
+    )
+    assert abs(cached_prompt_cost - 0.000128) < 1e-9
 
     model_info = litellm.get_model_info(model)
     assert model_info["max_input_tokens"] == 260000

--- a/tests/test_litellm/llms/inception/test_inception_chat_transformation.py
+++ b/tests/test_litellm/llms/inception/test_inception_chat_transformation.py
@@ -238,6 +238,7 @@ def test_inception_model_list_populated(monkeypatch):
     litellm.add_known_models()
 
     assert "inception/mercury-2" in litellm.inception_models
+    assert "inception/mercury-2.5" in litellm.inception_models
     for model in litellm.inception_models:
         assert model.startswith("inception/")
 
@@ -304,3 +305,49 @@ def test_inception_completion_targets_inception_endpoint():
     assert captured["body"]["model"] == "mercury-2"
     assert captured["body"]["tool_choice"] == "auto"
     assert response.choices[0].message.content == "hi"
+
+
+def test_inception_mercury_2_5_cost_and_tokens(monkeypatch):
+    """Verify cost calculation and context window for inception/mercury-2.5"""
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    monkeypatch.setattr(litellm, "model_cost", litellm.get_model_cost_map(url=""))
+    model = "inception/mercury-2.5"
+    prompt_cost, completion_cost = litellm.cost_per_token(
+        model=model,
+        prompt_tokens=1000,
+        completion_tokens=500,
+    )
+    # $0.20 per 1M input tokens -> 1000 * 0.0000002 = 0.0002
+    # $0.75 per 1M output tokens -> 500 * 0.00000075 = 0.000375
+    assert abs(prompt_cost - 0.0002) < 1e-9
+    assert abs(completion_cost - 0.000375) < 1e-9
+
+    model_info = litellm.get_model_info(model)
+    assert model_info["max_input_tokens"] == 260000
+    assert model_info["max_output_tokens"] == 260000
+    assert model_info["litellm_provider"] == "inception"
+    assert model_info["mode"] == "chat"
+    assert model_info["supports_function_calling"] is True
+    assert model_info["supports_parallel_function_calling"] is True
+    assert model_info["supports_response_schema"] is True
+
+
+def test_openrouter_inception_mercury_2_5_cost_and_tokens(monkeypatch):
+    """Verify cost calculation and context window for openrouter/inception/mercury-2.5-preview"""
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    monkeypatch.setattr(litellm, "model_cost", litellm.get_model_cost_map(url=""))
+    model = "openrouter/inception/mercury-2.5-preview"
+    prompt_cost, completion_cost = litellm.cost_per_token(
+        model=model,
+        prompt_tokens=1000,
+        completion_tokens=500,
+    )
+    assert abs(prompt_cost - 0.0002) < 1e-9
+    assert abs(completion_cost - 0.000375) < 1e-9
+
+    model_info = litellm.get_model_info(model)
+    assert model_info["max_input_tokens"] == 260000
+    assert model_info["max_output_tokens"] == 260000
+    assert model_info["litellm_provider"] == "openrouter"
+    assert model_info["mode"] == "chat"
+


### PR DESCRIPTION
## TLDR

Problem this solves:

- `inception/mercury-2.5` and its OpenRouter alias were missing from the model cost map.
- Calls to Mercury 2.5 routed without cost tracking (calculating silent $0 spend).

How it solves it:

- Added `inception/mercury-2.5` and `openrouter/inception/mercury-2.5-preview` to both `model_prices_and_context_window.json` and its backup.
- Configured 260K context window limits, $0.20/1M prompt, $0.02/1M cached, and $0.75/1M completion pricing.
- Added comprehensive unit tests in `test_inception_chat_transformation.py` asserting model presence and exact cost calculations.

## User Flow

Before: A developer using Mercury 2.5 via LiteLLM sees $0 spend logged on completion calls.

1. They send POST `http://localhost:4000/v1/chat/completions` with `{"model": "mercury-2.5", "messages": [{"role": "user", "content": "hello"}]}`.
2. The completion succeeds with 200 and usage token counts.
3. They check `http://localhost:4000/spend/logs` and see `"spend": 0.0`.

After: The exact same call computes and logs accurate spend according to standard token pricing.

1. They send POST `http://localhost:4000/v1/chat/completions` with `{"model": "mercury-2.5", "messages": [{"role": "user", "content": "hello"}]}`.
2. The completion succeeds with 200 and usage token counts.
3. They check `http://localhost:4000/spend/logs` and see non-zero spend calculated ($0.20 / 1M input, $0.75 / 1M output).

## Relevant issues

Closes #40746

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Type

🆕 New Feature

## Caveats (if any)

None

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

---
*P.S. Interested in joining LiteLLM as a founding backend engineer! Reaching out on LinkedIn/X.*
