### PR TITLE
fix(vertex_ai): return 400 for invalid reasoning_effort instead of 500

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -23,6 +23,7 @@ from litellm.constants import (
     DEFAULT_REASONING_EFFORT_MINIMAL_THINKING_BUDGET_GEMINI_2_5_FLASH_LITE,
     DEFAULT_REASONING_EFFORT_MINIMAL_THINKING_BUDGET_GEMINI_2_5_PRO,
 )
+from litellm.exceptions import UnsupportedParamsError
 from litellm.litellm_core_utils.json_fragment_accumulator import JSONFragmentAccumulator
 from litellm.litellm_core_utils.prompt_templates.factory import (
     _encode_tool_call_id_with_signature,
@@ -106,6 +107,21 @@ if TYPE_CHECKING:
 else:
     LoggingClass = Any
     StreamingChoices = Any
+
+
+SUPPORTED_REASONING_EFFORTS: Final = ("minimal", "low", "medium", "high", "none", "disable")
+
+
+def _unsupported_reasoning_effort(reasoning_effort: str) -> UnsupportedParamsError:
+    return UnsupportedParamsError(
+        message=(
+            f"Invalid `reasoning_effort`: {reasoning_effort!r}. "
+            f"Must be one of: {', '.join(repr(effort) for effort in SUPPORTED_REASONING_EFFORTS)}. "
+            "To drop this param, set `litellm.drop_params = True` or pass in `(.., drop_params=True)` "
+            "in the request - https://docs.litellm.ai/docs/completion/drop_params"
+        ),
+        status_code=400,
+    )
 
 
 class VertexAIBaseConfig:
@@ -842,7 +858,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                 "includeThoughts": False,
             }
         else:
-            raise ValueError(f"Invalid reasoning effort: {reasoning_effort}")
+            raise _unsupported_reasoning_effort(reasoning_effort)
 
     @staticmethod
     def _map_reasoning_effort_to_thinking_level(
@@ -890,7 +906,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
             else:
                 return {"thinkingLevel": "low", "includeThoughts": False}
         else:
-            raise ValueError(f"Invalid reasoning effort: {reasoning_effort}")
+            raise _unsupported_reasoning_effort(reasoning_effort)
 
     @staticmethod
     def _is_thinking_budget_zero(thinking_budget: int | None) -> bool:

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -5769,3 +5769,70 @@ def test_calculate_web_search_requests_counts_unique_queries():
 
     assert VertexGeminiConfig._calculate_web_search_requests([]) is None
     assert VertexGeminiConfig._calculate_web_search_requests([{"webSearchQueries": ["", ""]}]) is None
+
+
+@pytest.mark.parametrize("custom_llm_provider", ["gemini", "vertex_ai"])
+@pytest.mark.parametrize(
+    "model",
+    ["gemini-2.5-flash", "gemini-3-pro-preview"],
+    ids=["thinking_budget_mapper", "thinking_level_mapper"],
+)
+@pytest.mark.parametrize("reasoning_effort", ["banana", "xhigh"])
+def test_invalid_reasoning_effort_is_a_400_not_a_500(custom_llm_provider, model, reasoning_effort):
+    """Regression for #40474.
+
+    Both reasoning_effort mappers used to end their if/elif chain in a bare `ValueError`, which
+    `exception_type()` has no branch for, so it fell through to `APIConnectionError` and the proxy
+    answered a malformed client request with a retryable HTTP 500. `xhigh` is covered alongside the
+    nonsense value because it is a member of litellm's own `REASONING_EFFORT` literal, so callers
+    bridging from OpenAI-shaped code reach it without typing anything wrong.
+    """
+    from litellm.utils import get_optional_params
+
+    with pytest.raises(litellm.BadRequestError) as exc_info:
+        get_optional_params(
+            model=model,
+            custom_llm_provider=custom_llm_provider,
+            reasoning_effort=reasoning_effort,
+            drop_params=True,
+        )
+
+    assert exc_info.value.status_code == 400
+    message: Final = str(exc_info.value)
+    assert reasoning_effort in message
+    for supported in ("minimal", "low", "medium", "high", "none", "disable"):
+        assert supported in message
+
+
+@pytest.mark.parametrize("custom_llm_provider", ["gemini", "vertex_ai"])
+def test_invalid_reasoning_effort_surfaces_as_400_through_completion(custom_llm_provider):
+    """The same request through `completion()` must not come back as a retryable 500.
+
+    Needs no provider credentials: param mapping runs before any network call.
+    """
+    with pytest.raises(litellm.BadRequestError) as exc_info:
+        completion(
+            model=f"{custom_llm_provider}/gemini-3-pro-preview",
+            messages=[{"role": "user", "content": "hi"}],
+            reasoning_effort="banana",
+        )
+
+    assert exc_info.value.status_code == 400
+    assert not isinstance(exc_info.value, litellm.APIConnectionError)
+
+
+@pytest.mark.parametrize("model", ["gemini-2.5-flash", "gemini-3-pro-preview"])
+def test_supported_reasoning_efforts_still_map(model):
+    """Guards the fix against over-rejecting: every advertised value must still produce a config."""
+    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+        SUPPORTED_REASONING_EFFORTS,
+    )
+
+    for effort in SUPPORTED_REASONING_EFFORTS:
+        result: Final = VertexGeminiConfig().map_openai_params(
+            non_default_params={"reasoning_effort": effort},
+            optional_params={},
+            model=model,
+            drop_params=False,
+        )
+        assert "thinkingConfig" in result


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bad `reasoning_effort` on Gemini returns HTTP 500, not 400
- Clients and routers retry a request that can never succeed
- The error never says which values are accepted
- `xhigh` and `max` hit this without the caller typing anything wrong

How it solves it:

- Raise `UnsupportedParamsError` (400) instead of a bare `ValueError`
- Error message lists the six accepted values
- Matches what the Anthropic and Bedrock transforms already do

## User Flow

Before: a developer porting an OpenAI-shaped app to Gemini sends a `reasoning_effort` value Gemini has no mapping for, and gets a server error that their client retries

1. They send POST https://litellm-domain/v1/chat/completions with `"model": "gemini-2.5-flash"` and `"reasoning_effort": "xhigh"`
2. They get back HTTP 500 with `litellm.APIConnectionError: Invalid reasoning effort: xhigh` and no list of what would have worked
3. Their client treats 500 as a transient server fault and retries, burning the retry budget on a request that can never succeed
4. They send the same request straight to Vertex and get a clean 400 naming the field, so the confusion is coming from the gateway

After: the same request comes back as a 400 that names the accepted values, and nothing retries it

1. They send the same POST https://litellm-domain/v1/chat/completions with `"reasoning_effort": "xhigh"`
2. They get back HTTP 400 with `litellm.UnsupportedParamsError: Invalid reasoning_effort: 'xhigh'. Must be one of: 'minimal', 'low', 'medium', 'high', 'none', 'disable'`
3. Their client treats 400 as their own mistake and stops, so no retries are spent
4. They change the value to `high`, resend, and get a normal 200 with reasoning tokens in the usage block

## Relevant issues

Fixes #40474

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup, a proxy against real Vertex with one model on each of the two mappers (`gemini-2.5-flash` uses the thinking-budget mapper, `gemini-3-pro-preview` uses the thinking-level mapper):

```yaml
model_list:
  - model_name: gemini-3-pro
    litellm_params:
      model: vertex_ai/gemini-3-pro-preview
      vertex_project: os.environ/VERTEXAI_PROJECT
      vertex_location: os.environ/VERTEXAI_LOCATION
  - model_name: gemini-2.5-flash
    litellm_params:
      model: vertex_ai/gemini-2.5-flash
      vertex_project: os.environ/VERTEXAI_PROJECT
      vertex_location: os.environ/VERTEXAI_LOCATION

general_settings:
  master_key: sk-1234
```

### Before (db3338b2068b)

#### Nonsense value, thinking-level mapper

1. Run:

```bash
curl -s -w "\nHTTP %{http_code}\n" -X POST http://localhost:4249/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"gemini-3-pro","messages":[{"role":"user","content":"hi"}],"reasoning_effort":"banana"}'
```

2. Observed:

```json
{"error":{"message":"litellm.APIConnectionError: Invalid reasoning effort: banana","type":"internal_server_error","param":null,"code":"500"}}
HTTP 500
```

#### OpenAI-namespace value, thinking-budget mapper

1. Run:

```bash
curl -s -w "\nHTTP %{http_code}\n" -X POST http://localhost:4249/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"gemini-2.5-flash","messages":[{"role":"user","content":"hi"}],"reasoning_effort":"xhigh"}'
```

2. Observed:

```json
{"error":{"message":"litellm.APIConnectionError: Invalid reasoning effort: xhigh","type":"internal_server_error","param":null,"code":"500"}}
HTTP 500
```

#### Valid value still works

1. Run:

```bash
curl -s -w "\nHTTP %{http_code}\n" -X POST http://localhost:4249/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"gemini-2.5-flash","messages":[{"role":"user","content":"reply with exactly: ok"}],"reasoning_effort":"high"}'
```

2. Observed:

```json
{"id":"7jSkauPQEt2nq8YP-9qt2A4","created":1789146349,"model":"gemini-2.5-flash","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"ok","role":"assistant","reasoning_content":"My primary directive is clear and unambiguous: the user requires a single, precise word ..."}}]}
HTTP 200
```

### After (f72b117b21e6)

#### Nonsense value, thinking-level mapper

1. Run:

```bash
curl -s -w "\nHTTP %{http_code}\n" -X POST http://localhost:4247/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"gemini-3-pro","messages":[{"role":"user","content":"hi"}],"reasoning_effort":"banana"}'
```

2. Observed:

```json
{"error":{"message":"litellm.UnsupportedParamsError: Invalid `reasoning_effort`: 'banana'. Must be one of: 'minimal', 'low', 'medium', 'high', 'none', 'disable'. To drop this param, set `litellm.drop_params = True` or pass in `(.., drop_params=True)` in the request - https://docs.litellm.ai/docs/completion/drop_params. Received Model Group=gemini-3-pro\nAvailable Model Group Fallbacks=None","type":"invalid_request_error","param":null,"code":"400"}}
HTTP 400
```

#### OpenAI-namespace value, thinking-budget mapper

1. Run:

```bash
curl -s -w "\nHTTP %{http_code}\n" -X POST http://localhost:4247/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"gemini-2.5-flash","messages":[{"role":"user","content":"hi"}],"reasoning_effort":"xhigh"}'
```

2. Observed:

```json
{"error":{"message":"litellm.UnsupportedParamsError: Invalid `reasoning_effort`: 'xhigh'. Must be one of: 'minimal', 'low', 'medium', 'high', 'none', 'disable'. To drop this param, set `litellm.drop_params = True` or pass in `(.., drop_params=True)` in the request - https://docs.litellm.ai/docs/completion/drop_params. Received Model Group=gemini-2.5-flash\nAvailable Model Group Fallbacks=None","type":"invalid_request_error","param":null,"code":"400"}}
HTTP 400
```

#### Valid value still works

1. Run:

```bash
curl -s -w "\nHTTP %{http_code}\n" -X POST http://localhost:4247/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"gemini-2.5-flash","messages":[{"role":"user","content":"reply with exactly: ok"}],"reasoning_effort":"high"}'
```

2. Observed:

```json
{"id":"ezSkasWkHenE6tkPt43RkQg","model":"gemini-2.5-flash","choices":[{"finish_reason":"stop","index":0,"message":{"content":"ok","role":"assistant","reasoning_content":"Ah, I see. The user's instruction is quite precise..."}}],"usage":{"completion_tokens":28,"prompt_tokens":5,"total_tokens":33,"completion_tokens_details":{"reasoning_tokens":27,"text_tokens":1}}}
HTTP 200
```

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- Status goes 500 to 400, so routers stop retrying this
- `except ValueError` no longer catches it, `BadRequestError` is not a `ValueError`

### Low

- `xhigh` and `max` are now a clean 400, not mapped to `high`
- Whether Gemini should accept them at all is a separate question
- The wider class stands: 768 other bare `raise ValueError` sites under `litellm/llms/`
- `exception_type()` still has no `ValueError` branch, so any of them is a 500

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


https://claude.ai/code/session_01XT1qsbjLwnhiN5sQ2hNUxr
