### PR TITLE
feat(ui): link the Organization cell on the Teams page

### DIFF
--- a/ui/litellm-dashboard/src/components/TeamsPage/TeamsTable.test.tsx
+++ b/ui/litellm-dashboard/src/components/TeamsPage/TeamsTable.test.tsx
@@ -34,6 +34,10 @@ vi.mock("@/app/(dashboard)/hooks/teams/useTeams", () => ({
   teamsTableKeys: { all: ["teamsTable"] },
 }));
 
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
 vi.mock("@/app/(dashboard)/hooks/organizations/useOrganizations", () => ({
   useOrganizations: vi.fn().mockReturnValue({
     data: [{ organization_id: "org-1", organization_alias: "Test Organization" }],
@@ -306,10 +310,30 @@ describe("column rendering details", () => {
     });
   });
 
+  it("points the organization cell at the org's detail page, aliased or not", async () => {
+    mockUseTeamsTable.mockReturnValue(
+      teamsResult([
+        { ...mockTeam, team_id: "a", organization_id: "org-1" },
+        { ...mockTeam, team_id: "b", team_alias: "Orphan Team", organization_id: "org-unknown" },
+      ]),
+    );
+    renderTable();
+
+    expect(await screen.findByRole("link", { name: "Test Organization" })).toHaveAttribute(
+      "href",
+      "/ui/organizations?org=org-1",
+    );
+    expect(screen.getByRole("link", { name: "org-unknown" })).toHaveAttribute(
+      "href",
+      "/ui/organizations?org=org-unknown",
+    );
+  });
+
   it("renders an em dash for a team with no organization", () => {
     mockUseTeamsTable.mockReturnValue(teamsResult([{ ...mockTeam, organization_id: null as unknown as string }]));
     renderTable();
     expect(screen.getByText("—")).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /organization/i })).not.toBeInTheDocument();
   });
 
   it("falls back to keys.length when keys_count is absent", () => {

--- a/ui/litellm-dashboard/src/components/TeamsPage/teamTableColumns.tsx
+++ b/ui/litellm-dashboard/src/components/TeamsPage/teamTableColumns.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/cva.config";
+import { orgDetailHref } from "@/utils/entityLinks";
 import { copyToClipboard, formatNumberWithCommas } from "@/utils/dataUtils";
 
 import { Team } from "../key_team_helpers/key_list";
@@ -183,8 +184,8 @@ export const getTeamTableColumns = ({
         const displayValue = org?.organization_alias || orgId;
         const width = info.cell.column.getSize();
         return (
-          <span className="block truncate text-sm" style={{ maxWidth: width }} title={displayValue}>
-            {displayValue}
+          <span className="block" style={{ maxWidth: width }} title={displayValue}>
+            <IdentityCell title={displayValue} titleClassName="text-sm font-normal" href={orgDetailHref(orgId)} />
           </span>
         );
       },


### PR DESCRIPTION
## TLDR

Problem this solves:

- Teams page Organization column is dead text
- Jumping to the org means copying an id manually

How it solves it:

- Renders the cell through the shared IdentityCell with an org href
- Reuses `orgDetailHref`, so the cell matches every other entity link

## User Flow

Before: an admin triaging a team cannot get from the team row to the org that owns it

1. They open http://localhost:4000/ui/teams and find the team
2. The Organization column shows the org name, but nothing happens on click
3. They select the org name, copy it, open http://localhost:4000/ui/organizations and paste it into the search box

After: the same admin clicks the org name and lands on it

1. They open http://localhost:4000/ui/teams and find the team
2. Hovering the Organization cell highlights it and shows a chevron
3. Clicking it opens http://localhost:4000/ui/organizations?org=&lt;org id&gt; with that org selected

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Setup: proxy on :4021 and the dashboard dev server on :3021, both against the shared dev database. Seeded org `zzqa-links-org` holding team `zzqa-links-team`, then searched the Teams page for that team. The After run was captured on a local branch that merges the five sibling entity-link PRs onto db3338b206; they touch disjoint files, and this capture only exercises `teamTableColumns.tsx`

### Before (db3338b206)

1. Open http://localhost:3021/teams and search for `zzqa-links-team`
2. The Organization cell reads `zzqa-links-org` as plain text

![teams before](https://raw.githubusercontent.com/BerriAI/litellm/litellm_entity_link_shots/links1-teams-before.png)

3. Dumping the row's cells shows no link:

```
[{"column":"Organization","text":"zzqa-links-org","href":null}]
```

### After (3278325ceb)

1. Open http://localhost:3021/teams and search for `zzqa-links-team`
2. Hovering the Organization cell highlights it and reveals the chevron

![teams after hover](https://raw.githubusercontent.com/BerriAI/litellm/litellm_entity_link_shots/links1-teams-after-hover.png)

3. Dumping the same row now shows the href:

```
[{"column":"Organization","text":"zzqa-links-org","href":"/organizations?org=72b365f2-4dcf-4aff-8aa6-3aa167812795"}]
```

4. Clicking it lands on the org detail page:

```
teams-org -> http://localhost:3021/organizations/?org=72b365f2-4dcf-4aff-8aa6-3aa167812795
```

![teams landing](https://raw.githubusercontent.com/BerriAI/litellm/litellm_entity_link_shots/links1-teams-land-org.png)

## Type

🆕 New Feature

## Caveats (if any)

### Low

- Teams with no org still render the em dash, unlinked

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

https://claude.ai/code/session_01NfwfQhamRNnSqgXMUjf3h4
