### PR TITLE
feat(ui): link the User ID, Created By and Deleted By cells on Deleted Keys

### DIFF
--- a/ui/litellm-dashboard/src/components/DeletedKeysPage/DeletedKeysPage.test.tsx
+++ b/ui/litellm-dashboard/src/components/DeletedKeysPage/DeletedKeysPage.test.tsx
@@ -5,6 +5,8 @@ import { renderWithProviders } from "../../../tests/test-utils";
 import DeletedKeysPage from "./DeletedKeysPage";
 import { useDeletedKeys, DeletedKeyResponse } from "@/app/(dashboard)/hooks/keys/useKeys";
 
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }));
+
 vi.mock("@/app/(dashboard)/hooks/keys/useKeys", () => ({
   useDeletedKeys: vi.fn(),
 }));

--- a/ui/litellm-dashboard/src/components/DeletedKeysPage/DeletedKeysTable/DeletedKeysTable.test.tsx
+++ b/ui/litellm-dashboard/src/components/DeletedKeysPage/DeletedKeysTable/DeletedKeysTable.test.tsx
@@ -5,6 +5,8 @@ import { renderWithProviders } from "../../../../tests/test-utils";
 import { DeletedKeysTable } from "./DeletedKeysTable";
 import { DeletedKeyResponse } from "@/app/(dashboard)/hooks/keys/useKeys";
 
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }));
+
 const makeDeletedKey = (overrides: Partial<DeletedKeyResponse> = {}): DeletedKeyResponse =>
   ({
     token: "sk-1234567890abcdef",
@@ -85,4 +87,20 @@ it("should show the empty state when there are no deleted keys", () => {
   renderWithProviders(<DeletedKeysTable {...defaultProps} keys={[]} totalCount={0} />);
 
   expect(screen.getByText("No deleted keys found")).toBeInTheDocument();
+});
+
+it("links the owner, creator and deleter cells to their user detail pages", () => {
+  renderWithProviders(<DeletedKeysTable {...defaultProps} keys={[makeDeletedKey({ deleted_by: "deleter-1" })]} />);
+
+  expect(screen.getByRole("link", { name: "user-1" })).toHaveAttribute("href", "/ui/users?user=user-1");
+  expect(screen.getByRole("link", { name: "creator-1" })).toHaveAttribute("href", "/ui/users?user=creator-1");
+  expect(screen.getByRole("link", { name: "deleter-1" })).toHaveAttribute("href", "/ui/users?user=deleter-1");
+});
+
+it("leaves the default_user_id placeholder unlinked", () => {
+  const placeholderKey = makeDeletedKey({ user_id: "default_user_id", created_by: "default_user_id" });
+  renderWithProviders(<DeletedKeysTable {...defaultProps} keys={[placeholderKey]} />);
+
+  expect(screen.getAllByText("default_user_id")).toHaveLength(2);
+  expect(screen.queryByRole("link", { name: "default_user_id" })).not.toBeInTheDocument();
 });

--- a/ui/litellm-dashboard/src/components/DeletedKeysPage/DeletedKeysTable/DeletedKeysTableColumns.tsx
+++ b/ui/litellm-dashboard/src/components/DeletedKeysPage/DeletedKeysTable/DeletedKeysTableColumns.tsx
@@ -3,8 +3,9 @@
 import { ColumnDef } from "@tanstack/react-table";
 
 import { DataTableSortHeader } from "@/components/shared/DataTable";
-import { DateCell, IdCell, MoneyCell } from "@/components/shared/table_cells";
+import { DateCell, IdCell, IdentityCell, MoneyCell } from "@/components/shared/table_cells";
 import { DeletedKeyResponse } from "@/app/(dashboard)/hooks/keys/useKeys";
+import { userDetailHref } from "@/utils/entityLinks";
 
 function TruncatedTextCell({ value }: { value: string | null | undefined }) {
   if (!value) {
@@ -13,6 +14,17 @@ function TruncatedTextCell({ value }: { value: string | null | undefined }) {
   return (
     <span className="block max-w-60 truncate" title={value}>
       {value}
+    </span>
+  );
+}
+
+function UserLinkCell({ userId }: { userId: string | null | undefined }) {
+  if (!userId) {
+    return <span className="text-muted-foreground">-</span>;
+  }
+  return (
+    <span className="block max-w-60" title={userId}>
+      <IdentityCell title={userId} titleClassName="font-normal" href={userDetailHref(userId)} />
     </span>
   );
 }
@@ -89,7 +101,7 @@ export const getDeletedKeysTableColumns = (): ColumnDef<DeletedKeyResponse>[] =>
     header: "User ID",
     size: 120,
     enableSorting: false,
-    cell: ({ row }) => <IdCell value={row.original.user_id} variant="plain" />,
+    cell: ({ row }) => <UserLinkCell userId={row.original.user_id} />,
   },
   {
     id: "created_at",
@@ -107,7 +119,7 @@ export const getDeletedKeysTableColumns = (): ColumnDef<DeletedKeyResponse>[] =>
     header: "Created By",
     size: 120,
     enableSorting: false,
-    cell: ({ row }) => <TruncatedTextCell value={row.original.created_by} />,
+    cell: ({ row }) => <UserLinkCell userId={row.original.created_by} />,
   },
   {
     id: "deleted_at",
@@ -125,6 +137,6 @@ export const getDeletedKeysTableColumns = (): ColumnDef<DeletedKeyResponse>[] =>
     header: "Deleted By",
     size: 120,
     enableSorting: false,
-    cell: ({ row }) => <TruncatedTextCell value={row.original.deleted_by} />,
+    cell: ({ row }) => <UserLinkCell userId={row.original.deleted_by} />,
   },
 ];


### PR DESCRIPTION
## TLDR

Problem this solves:

- Deleted Keys shows User ID, Created By, Deleted By as dead text
- Auditing a deleted key means copying ids into another page

How it solves it:

- Renders the three cells through the shared IdentityCell
- Reuses `userDetailHref`, so the proxy admin placeholder stays unlinked

## User Flow

Before: an admin auditing a deleted key cannot get from the row to the people on it

1. They open http://localhost:4000/ui/logs and pick the Deleted Keys tab
2. User ID, Created By and Deleted By all read as plain text
3. They select an id, copy it, open http://localhost:4000/ui/users and paste it into the search box

After: the same admin clicks any of the three and lands on that user

1. They open http://localhost:4000/ui/logs and pick the Deleted Keys tab
2. Hovering User ID, Created By or Deleted By highlights the cell and shows a chevron
3. Clicking it opens http://localhost:4000/ui/users?user=&lt;user id&gt; with that user selected
4. Rows owned or deleted by the built in proxy admin still render `default_user_id` as plain text, because there is no user page for it

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Setup: proxy on :4021 and the dashboard dev server on :3021, both against the shared dev database. Created key `zzqa-links-deleted-key` owned by `qa-links-user` and deleted it with that user's key, so all three columns carry a real id. The After run was captured on a local branch that merges the five sibling entity-link PRs onto db3338b206; they touch disjoint files, and this capture only exercises `DeletedKeysTableColumns.tsx`

### Before (db3338b206)

1. Open http://localhost:3021/logs and click the Deleted Keys tab
2. The top row reads `qa-links-user` in User ID, Created By and Deleted By, all plain text

![deleted keys before](https://raw.githubusercontent.com/BerriAI/litellm/litellm_entity_link_shots/links1-dkeys-before.png)

3. Dumping that row's cells shows no links:

```
[{"column":"Team Alias","text":"-","href":null},
 {"column":"User Email","text":"-","href":null},
 {"column":"User ID","text":"qa-links-user","href":null},
 {"column":"Created By","text":"qa-links-user","href":null},
 {"column":"Deleted By","text":"qa-links-user","href":null}]
```

### After (3ef7022ba5)

1. Open http://localhost:3021/logs and click the Deleted Keys tab
2. Hovering the User ID cell highlights it and reveals the chevron

![deleted keys after hover](https://raw.githubusercontent.com/BerriAI/litellm/litellm_entity_link_shots/links1-dkeys-after-hover.png)

3. Dumping the same row now shows all three hrefs, with User Email and Team Alias untouched:

```
[{"column":"Team Alias","text":"-","href":null},
 {"column":"User Email","text":"-","href":null},
 {"column":"User ID","text":"qa-links-user","href":"/users?user=qa-links-user"},
 {"column":"Created By","text":"qa-links-user","href":"/users?user=qa-links-user"},
 {"column":"Deleted By","text":"qa-links-user","href":"/users?user=qa-links-user"}]
```

4. Rows created or deleted by the built in admin keep `default_user_id` as plain text, visible in the same screenshot
5. Clicking the User ID link lands on the user detail page:

```
deleted-keys-user -> http://localhost:3021/users/?user=qa-links-user
```

![deleted keys landing](https://raw.githubusercontent.com/BerriAI/litellm/litellm_entity_link_shots/links1-dkeys-land-user.png)

## Type

🆕 New Feature

## Caveats (if any)

### Low

- User Email and Team Alias stay plain text on purpose
  - The deleted key table has no column for either, so the API always sends null and both cells read "-"

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

https://claude.ai/code/session_01NfwfQhamRNnSqgXMUjf3h4
