### PR TITLE
feat(ui): link the Organization and Deleted By cells on Deleted Teams

### DIFF
--- a/ui/litellm-dashboard/src/components/DeletedTeamsPage/DeletedTeamsPage.test.tsx
+++ b/ui/litellm-dashboard/src/components/DeletedTeamsPage/DeletedTeamsPage.test.tsx
@@ -5,6 +5,8 @@ import { renderWithProviders } from "../../../tests/test-utils";
 import DeletedTeamsPage from "./DeletedTeamsPage";
 import { useDeletedTeams, DeletedTeam } from "@/app/(dashboard)/hooks/teams/useTeams";
 
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }));
+
 vi.mock("@/app/(dashboard)/hooks/teams/useTeams", () => ({
   useDeletedTeams: vi.fn(),
 }));

--- a/ui/litellm-dashboard/src/components/DeletedTeamsPage/DeletedTeamsTable/DeletedTeamsTable.test.tsx
+++ b/ui/litellm-dashboard/src/components/DeletedTeamsPage/DeletedTeamsTable/DeletedTeamsTable.test.tsx
@@ -4,6 +4,8 @@ import { renderWithProviders } from "../../../../tests/test-utils";
 import { DeletedTeamsTable } from "./DeletedTeamsTable";
 import { DeletedTeam } from "@/app/(dashboard)/hooks/teams/useTeams";
 
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }));
+
 const makeDeletedTeam = (overrides: Partial<DeletedTeam> = {}): DeletedTeam => ({
   team_id: "team-1",
   team_alias: "Test Team",
@@ -80,4 +82,22 @@ it("renders the shared pagination footer with the server row count", () => {
   expect(screen.getByTestId("pagination-page-size")).toHaveTextContent("50");
   expect(screen.getByTestId("pagination-prev")).toBeEnabled();
   expect(screen.getByTestId("pagination-next")).toBeDisabled();
+});
+
+it("links the organization and deleted by cells, leaving the deleted team id unlinked", () => {
+  renderWithProviders(
+    <DeletedTeamsTable teams={[makeDeletedTeam()]} isLoading={false} rowCount={1} {...paginationProps} />,
+  );
+
+  expect(screen.getByRole("link", { name: "org-1" })).toHaveAttribute("href", "/ui/organizations?org=org-1");
+  expect(screen.getByRole("link", { name: "user-1" })).toHaveAttribute("href", "/ui/users?user=user-1");
+  expect(screen.queryByRole("link", { name: "team-1" })).not.toBeInTheDocument();
+});
+
+it("leaves the default_user_id placeholder unlinked in the deleted by cell", () => {
+  const team = makeDeletedTeam({ deleted_by: "default_user_id", organization_id: null });
+  renderWithProviders(<DeletedTeamsTable teams={[team]} isLoading={false} rowCount={1} {...paginationProps} />);
+
+  expect(screen.getByText("default_user_id")).toBeInTheDocument();
+  expect(screen.queryByRole("link", { name: "default_user_id" })).not.toBeInTheDocument();
 });

--- a/ui/litellm-dashboard/src/components/DeletedTeamsPage/DeletedTeamsTable/DeletedTeamsTableColumns.tsx
+++ b/ui/litellm-dashboard/src/components/DeletedTeamsPage/DeletedTeamsTable/DeletedTeamsTableColumns.tsx
@@ -3,8 +3,20 @@
 import { ColumnDef } from "@tanstack/react-table";
 
 import { DataTableSortHeader } from "@/components/shared/DataTable";
-import { DateCell, IdCell, ModelsCell, MoneyCell } from "@/components/shared/table_cells";
+import { DateCell, IdCell, IdentityCell, ModelsCell, MoneyCell } from "@/components/shared/table_cells";
 import { DeletedTeam } from "@/app/(dashboard)/hooks/teams/useTeams";
+import { orgDetailHref, userDetailHref } from "@/utils/entityLinks";
+
+function EntityCell({ value, href }: { value: string | null | undefined; href: string | undefined }) {
+  if (!value) {
+    return <span className="text-muted-foreground">-</span>;
+  }
+  return (
+    <span className="block max-w-60" title={value}>
+      <IdentityCell title={value} titleClassName="font-normal" href={href} />
+    </span>
+  );
+}
 
 export const getDeletedTeamsTableColumns = (): ColumnDef<DeletedTeam>[] => [
   {
@@ -78,7 +90,10 @@ export const getDeletedTeamsTableColumns = (): ColumnDef<DeletedTeam>[] => [
     header: "Organization",
     size: 150,
     enableSorting: false,
-    cell: ({ row }) => <IdCell value={row.original.organization_id} variant="plain" />,
+    cell: ({ row }) => {
+      const orgId = row.original.organization_id;
+      return <EntityCell value={orgId} href={orgId ? orgDetailHref(orgId) : undefined} />;
+    },
   },
   {
     id: "deleted_at",
@@ -97,15 +112,8 @@ export const getDeletedTeamsTableColumns = (): ColumnDef<DeletedTeam>[] => [
     size: 120,
     enableSorting: false,
     cell: ({ row }) => {
-      const value = row.original.deleted_by;
-      if (!value) {
-        return <span className="text-muted-foreground">-</span>;
-      }
-      return (
-        <span className="block max-w-60 truncate" title={value}>
-          {value}
-        </span>
-      );
+      const deletedBy = row.original.deleted_by;
+      return <EntityCell value={deletedBy} href={deletedBy ? userDetailHref(deletedBy) : undefined} />;
     },
   },
 ];


### PR DESCRIPTION
## TLDR

Problem this solves:

- Deleted Teams shows Organization and Deleted By as dead text
- Tracing a deleted team means copying ids into another page

How it solves it:

- Renders both cells through the shared IdentityCell
- Reuses `orgDetailHref` and `userDetailHref`; Team ID stays unlinked

## User Flow

Before: an admin reviewing a deleted team cannot get from the row to its org or to whoever deleted it

1. They open http://localhost:4000/ui/logs and pick the Deleted Teams tab
2. Organization and Deleted By both read as plain text
3. They select the org id, copy it, open http://localhost:4000/ui/organizations and paste it into the search box, then repeat for the user id on http://localhost:4000/ui/users

After: the same admin clicks either cell and lands on it

1. They open http://localhost:4000/ui/logs and pick the Deleted Teams tab
2. Hovering Organization or Deleted By highlights the cell and shows a chevron
3. Clicking Organization opens http://localhost:4000/ui/organizations?org=&lt;org id&gt;, clicking Deleted By opens http://localhost:4000/ui/users?user=&lt;user id&gt;
4. Team ID stays plain text, because the team it names no longer exists

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Setup: proxy on :4021 and the dashboard dev server on :3021, both against the shared dev database. Created team `zzqa-links-deleted-team` inside org `zzqa-links-org` and deleted it with `qa-links-user`'s key, so both columns carry a real id. The After run was captured on a local branch that merges the five sibling entity-link PRs onto db3338b206; they touch disjoint files, and this capture only exercises `DeletedTeamsTableColumns.tsx`

### Before (db3338b206)

1. Open http://localhost:3021/logs and click the Deleted Teams tab
2. The top row shows the org id and `qa-links-user`, both plain text

![deleted teams before](https://raw.githubusercontent.com/BerriAI/litellm/litellm_entity_link_shots/links1-dteams-before.png)

3. Dumping that row's cells shows no links:

```
[{"column":"Team ID","text":"37b42de4-a6f1-488a-bb48-991ece4828ad","href":null},
 {"column":"Organization","text":"72b365f2-4dcf-4aff-8aa6-3aa167812795","href":null},
 {"column":"Deleted By","text":"qa-links-user","href":null}]
```

### After (a78d5a4967)

1. Open http://localhost:3021/logs and click the Deleted Teams tab
2. Hovering the Organization cell highlights it and reveals the chevron

![deleted teams after hover](https://raw.githubusercontent.com/BerriAI/litellm/litellm_entity_link_shots/links1-dteams-after-hover.png)

3. Dumping the same row now shows both hrefs, with Team ID still unlinked:

```
[{"column":"Team ID","text":"37b42de4-a6f1-488a-bb48-991ece4828ad","href":null},
 {"column":"Organization","text":"72b365f2-4dcf-4aff-8aa6-3aa167812795","href":"/organizations?org=72b365f2-4dcf-4aff-8aa6-3aa167812795"},
 {"column":"Deleted By","text":"qa-links-user","href":"/users?user=qa-links-user"}]
```

4. Clicking each one lands where it should:

```
deleted-teams-org -> http://localhost:3021/organizations/?org=72b365f2-4dcf-4aff-8aa6-3aa167812795
deleted-teams-deletedby -> http://localhost:3021/users/?user=qa-links-user
```

![deleted teams org landing](https://raw.githubusercontent.com/BerriAI/litellm/litellm_entity_link_shots/links1-dteams-land-org.png)

![deleted teams user landing](https://raw.githubusercontent.com/BerriAI/litellm/litellm_entity_link_shots/links1-dteams-land-user.png)

## Type

🆕 New Feature

## Caveats (if any)

### Low

- Teams deleted before the proxy started recording who deleted them still show "-"

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

https://claude.ai/code/session_01NfwfQhamRNnSqgXMUjf3h4
