### PR TITLE
feat(ui): link the User ID and Team ID cells on the Memory page

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/memory/_components/MemoryTable.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/memory/_components/MemoryTable.test.tsx
@@ -8,6 +8,8 @@ import { MemoryRow } from "@/components/networking";
 
 import { MemoryTable } from "./MemoryTable";
 
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }));
+
 const makeMemory = (overrides: Partial<MemoryRow> = {}): MemoryRow => ({
   memory_id: "mem-1",
   key: "user:profile",
@@ -36,6 +38,23 @@ const baseProps = {
 };
 
 describe("MemoryTable", () => {
+  it("links the User ID and Team ID cells to their detail pages", () => {
+    render(<MemoryTable {...baseProps} />);
+
+    expect(screen.getByRole("link", { name: "user-42" })).toHaveAttribute("href", "/ui/users?user=user-42");
+    expect(screen.getByRole("link", { name: "team-7" })).toHaveAttribute("href", "/ui/teams?team=team-7");
+  });
+
+  it("leaves the proxy admin and dashboard sentinels unlinked", () => {
+    const sentinelRow = makeMemory({ user_id: "default_user_id", team_id: "litellm-dashboard" });
+    render(<MemoryTable {...baseProps} data={[sentinelRow]} />);
+
+    expect(screen.getByText("default_user_id")).toBeInTheDocument();
+    expect(screen.getByText("litellm-dashboard")).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "default_user_id" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "litellm-dashboard" })).not.toBeInTheDocument();
+  });
+
   it("renders every column header", () => {
     render(<MemoryTable {...baseProps} />);
     for (const header of ["ID", "Name", "Preview", "User ID", "Team ID", "Updated"]) {

--- a/ui/litellm-dashboard/src/app/(dashboard)/memory/_components/MemoryTableColumns.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/memory/_components/MemoryTableColumns.tsx
@@ -14,6 +14,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/cva.config";
+import { teamDetailHref, userDetailHref } from "@/utils/entityLinks";
 
 interface MemoryRowActionsProps {
   row: MemoryRow;
@@ -109,7 +110,10 @@ export const getMemoryTableColumns = ({
     header: "User ID",
     size: 160,
     enableSorting: false,
-    cell: ({ row }) => <IdCell value={row.original.user_id} />,
+    cell: ({ row }) => {
+      const userId = row.original.user_id;
+      return <IdCell value={userId} href={userId ? userDetailHref(userId) : undefined} />;
+    },
   },
   {
     id: "team_id",
@@ -118,7 +122,10 @@ export const getMemoryTableColumns = ({
     header: "Team ID",
     size: 160,
     enableSorting: false,
-    cell: ({ row }) => <IdCell value={row.original.team_id} />,
+    cell: ({ row }) => {
+      const teamId = row.original.team_id;
+      return <IdCell value={teamId} href={teamId ? teamDetailHref(teamId) : undefined} />;
+    },
   },
   {
     id: "updated_at",

--- a/ui/litellm-dashboard/src/components/shared/table_cells/id_cell.test.tsx
+++ b/ui/litellm-dashboard/src/components/shared/table_cells/id_cell.test.tsx
@@ -4,6 +4,10 @@ import { describe, expect, it, vi } from "vitest";
 
 import { IdCell } from "./id_cell";
 
+const { routerPushMock } = vi.hoisted(() => ({ routerPushMock: vi.fn() }));
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: routerPushMock }) }));
+
 const { copyToClipboardMock } = vi.hoisted(() => ({ copyToClipboardMock: vi.fn() }));
 
 vi.mock("@/utils/dataUtils", async (importOriginal) => ({
@@ -82,5 +86,24 @@ describe("IdCell", () => {
   it("passes dataTestId through to the id element", () => {
     render(<IdCell value="k-1" dataTestId="key-id-cell" />);
     expect(screen.getByTestId("key-id-cell")).toHaveTextContent("k-1");
+  });
+
+  it("renders the id as a link and routes client side when href is set", async () => {
+    const user = userEvent.setup();
+    render(<IdCell value="user-42" href="/ui/users?user=user-42" />);
+
+    const link = screen.getByRole("link", { name: "user-42" });
+    expect(link).toHaveAttribute("href", "/ui/users?user=user-42");
+    expect(link).toHaveClass("cursor-pointer");
+
+    await user.click(link);
+    expect(routerPushMock).toHaveBeenCalledWith("/ui/users?user=user-42");
+  });
+
+  it("stays plain text when href is undefined", () => {
+    render(<IdCell value="default_user_id" href={undefined} />);
+
+    expect(screen.getByText("default_user_id").tagName).toBe("SPAN");
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
   });
 });

--- a/ui/litellm-dashboard/src/components/shared/table_cells/id_cell.tsx
+++ b/ui/litellm-dashboard/src/components/shared/table_cells/id_cell.tsx
@@ -3,6 +3,7 @@
 import { Copy } from "lucide-react";
 import * as React from "react";
 
+import { useEntityLinkClick } from "@/components/shared/EntityLink";
 import { cn } from "@/lib/cva.config";
 import { copyToClipboard } from "@/utils/dataUtils";
 
@@ -13,6 +14,7 @@ export type IdCellVariant = "pill" | "plain";
 interface IdCellProps {
   value: string | null | undefined;
   variant?: IdCellVariant;
+  href?: string;
   onClick?: (value: string) => void;
   copyable?: boolean;
   copyLabel?: string;
@@ -38,6 +40,7 @@ const VARIANT_CLASS: Record<IdCellVariant, { base: string; clickable: string }> 
 export function IdCell({
   value,
   variant = "pill",
+  href,
   onClick,
   copyable = false,
   copyLabel = "Copy ID",
@@ -52,16 +55,17 @@ export function IdCell({
     return <span className="text-muted-foreground">{fallback}</span>;
   }
 
+  const linked = !!href && !disabled;
   const clickable = !!onClick && !disabled;
   const classes = cn(
     VARIANT_CLASS[variant].base,
-    clickable && VARIANT_CLASS[variant].clickable,
+    (linked || clickable) && VARIANT_CLASS[variant].clickable,
     truncate && "block max-w-[15ch] truncate",
     disabled && "opacity-50",
     className,
   );
 
-  const idElement = clickable ? (
+  const unlinkedElement = clickable ? (
     <button type="button" className={classes} data-testid={dataTestId} onClick={() => onClick(value)}>
       {value}
     </button>
@@ -69,6 +73,14 @@ export function IdCell({
     <span className={classes} data-testid={dataTestId}>
       {value}
     </span>
+  );
+
+  const idElement = linked ? (
+    <IdLink href={href} className={classes} dataTestId={dataTestId}>
+      {value}
+    </IdLink>
+  ) : (
+    unlinkedElement
   );
 
   const withTooltip = <CellTooltip content={tooltip ?? value} trigger={idElement} />;
@@ -94,3 +106,21 @@ export function IdCell({
     </span>
   );
 }
+
+interface IdLinkProps extends React.ComponentPropsWithoutRef<"a"> {
+  href: string;
+  dataTestId?: string;
+}
+
+const IdLink = React.forwardRef<HTMLAnchorElement, IdLinkProps>(function IdLink(
+  { href, dataTestId, children, ...props },
+  ref,
+) {
+  const handleClick = useEntityLinkClick(href);
+
+  return (
+    <a {...props} ref={ref} href={href} data-testid={dataTestId} onClick={handleClick}>
+      {children}
+    </a>
+  );
+});


### PR DESCRIPTION
## TLDR

Problem this solves:

- Memory page shows User ID and Team ID as dead pills
- Tracing a memory row to its owner means copying an id

How it solves it:

- `IdCell` grows an `href` prop that turns the pill into a client routed link
- Memory columns pass `userDetailHref` and `teamDetailHref`, so sentinels stay unlinked

## User Flow

Before: an admin reviewing stored memories cannot get from a row to the user or team it belongs to

1. They open http://localhost:4000/ui/memory
2. The User ID and Team ID cells show ids in blue pills, but nothing happens on click
3. They select an id, copy it, open http://localhost:4000/ui/users or http://localhost:4000/ui/teams and paste it into the search box

After: the same admin clicks either pill and lands on it

1. They open http://localhost:4000/ui/memory
2. Hovering a User ID or Team ID pill shows the pointer cursor and its hover colour
3. Clicking opens http://localhost:4000/ui/users?user=&lt;user id&gt; or http://localhost:4000/ui/teams?team=&lt;team id&gt;
4. Rows owned by the built in proxy admin keep `default_user_id` as a plain pill, because there is no user page for it

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Setup: proxy on :4021 and the dashboard dev server on :3021, both against the shared dev database. Seeded memories `zzqa:timezone` and `zzqa:prefers-concise` for `qa-links-user` on team `zzqa-links-team`, alongside two older rows owned by the built in admin. The After run was captured on a local branch that merges the five sibling entity-link PRs onto db3338b206; they touch disjoint files, and this capture only exercises `id_cell.tsx` and `MemoryTableColumns.tsx`

### Before (db3338b206)

1. Open http://localhost:3021/memory
2. The User ID and Team ID pills are inert

![memory before](https://raw.githubusercontent.com/BerriAI/litellm/litellm_entity_link_shots/links1-memory-before.png)

3. Dumping the `zzqa:timezone` row shows no links:

```
[{"column":"User ID","text":"qa-links-user","href":null},
 {"column":"Team ID","text":"8733da1f-bf59-4a89-9623-b41708d99144","href":null}]
```

### After (32a6494ce5)

1. Open http://localhost:3021/memory
2. Hovering the User ID pill shows its hover colour and the full id tooltip

![memory after hover](https://raw.githubusercontent.com/BerriAI/litellm/litellm_entity_link_shots/links1-memory-after-hover.png)

3. Dumping the same row now shows both hrefs:

```
[{"column":"User ID","text":"qa-links-user","href":"/users?user=qa-links-user"},
 {"column":"Team ID","text":"8733da1f-bf59-4a89-9623-b41708d99144","href":"/teams?team=8733da1f-bf59-4a89-9623-b41708d99144"}]
```

4. The two older rows owned by the built in admin stay unlinked:

```
memory default_user_id rows: [{"name":"lit4741-decoy:prefs","userCellIsLink":false,"userCellText":"default_user_id"},
                              {"name":"lit4741-144523:profile","userCellIsLink":false,"userCellText":"default_user_id"}]
```

5. Clicking each pill lands where it should:

```
memory-user -> http://localhost:3021/users/?user=qa-links-user
memory-team -> http://localhost:3021/teams/?team=8733da1f-bf59-4a89-9623-b41708d99144
```

![memory user landing](https://raw.githubusercontent.com/BerriAI/litellm/litellm_entity_link_shots/links1-memory-land-user.png)

![memory team landing](https://raw.githubusercontent.com/BerriAI/litellm/litellm_entity_link_shots/links1-memory-land-team.png)

## Type

🆕 New Feature

## Caveats (if any)

### Low

- `IdCell` gains an `href` prop that every other caller leaves unset, so nothing else changes
- When both `href` and `onClick` are passed, `href` wins; no current caller passes both

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

https://claude.ai/code/session_01NfwfQhamRNnSqgXMUjf3h4
