### PR TITLE
feat(ui): link the Created By cell on the Prompts page

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/PromptTable.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/PromptTable.test.tsx
@@ -10,6 +10,8 @@ vi.mock("@/components/networking", () => ({
   modelHubCall: vi.fn().mockResolvedValue({ data: [] }),
 }));
 
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }));
+
 const mockPrompts: PromptSpec[] = [
   {
     prompt_id: "prompt-newer",
@@ -51,6 +53,15 @@ describe("PromptTable", () => {
     for (const header of ["Prompt ID", "Model", "Created At", "Updated At", "Environment", "Created By", "Type"]) {
       expect(screen.getByText(header)).toBeInTheDocument();
     }
+  });
+
+  it("links the Created By cell to the creator's detail page, leaving the placeholder unlinked", () => {
+    const prompts = [mockPrompts[0], { ...mockPrompts[1], created_by: "default_user_id" }];
+    render(<PromptTable {...defaultProps} promptsList={prompts} />);
+
+    expect(screen.getByRole("link", { name: "user-1" })).toHaveAttribute("href", "/ui/users?user=user-1");
+    expect(screen.getByText("default_user_id")).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "default_user_id" })).not.toBeInTheDocument();
   });
 
   it("should display the empty state when data is empty", () => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/PromptTableColumns.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/_components/PromptTableColumns.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/cva.config";
 import { copyToClipboard } from "@/utils/dataUtils";
+import { userDetailHref } from "@/utils/entityLinks";
 
 import { extractModel, getProviderFromModelHub, ModelGroupInfo } from "./prompt_utils";
 
@@ -191,9 +192,16 @@ export const getPromptTableColumns = ({
     enableSorting: false,
     cell: ({ row }) => {
       const createdBy = row.original.created_by;
+      if (!createdBy) {
+        return <span className="text-muted-foreground">-</span>;
+      }
       return (
-        <span className="block max-w-60 truncate text-sm text-muted-foreground" title={createdBy}>
-          {createdBy || "-"}
+        <span className="block max-w-60" title={createdBy}>
+          <IdentityCell
+            title={createdBy}
+            titleClassName="font-normal text-muted-foreground"
+            href={userDetailHref(createdBy)}
+          />
         </span>
       );
     },


### PR DESCRIPTION
## TLDR

Problem this solves:

- Prompts page shows Created By as dead text
- Finding a prompt's owner means copying an id into the Users page

How it solves it:

- Renders the cell through the shared IdentityCell with a user href
- Reuses `userDetailHref`, so the proxy admin placeholder stays unlinked

## User Flow

Before: a developer looking at a prompt cannot get from the row to whoever owns it

1. They open http://localhost:4000/ui/prompts
2. The Created By column shows the owner's id in muted text, but nothing happens on click
3. They select the id, copy it, open http://localhost:4000/ui/users and paste it into the search box

After: the same developer clicks the id and lands on that user

1. They open http://localhost:4000/ui/prompts
2. Hovering the Created By cell highlights it and shows a chevron
3. Clicking it opens http://localhost:4000/ui/users?user=&lt;user id&gt; with that user selected
4. Prompts created by the built in proxy admin still render `default_user_id` as plain text, because there is no user page for it

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Setup: proxy on :4021 and the dashboard dev server on :3021, both against the shared dev database. Registered prompt `zzqa-links-prompt` with `qa-links-user`'s key so Created By carries a real id. The After run was captured on a local branch that merges the five sibling entity-link PRs onto db3338b206; they touch disjoint files, and this capture only exercises `PromptTableColumns.tsx`

### Before (db3338b206)

1. Open http://localhost:3021/prompts
2. The Created By cell reads `qa-links-user` as plain muted text

![prompts before](https://raw.githubusercontent.com/BerriAI/litellm/litellm_entity_link_shots/links1-prompts-before.png)

3. Dumping that row's cell shows no link:

```
[{"column":"Created By","text":"qa-links-user","href":null}]
```

### After (8cc9d37eb8)

1. Open http://localhost:3021/prompts
2. Hovering the Created By cell highlights it and reveals the chevron

![prompts after hover](https://raw.githubusercontent.com/BerriAI/litellm/litellm_entity_link_shots/links1-prompts-after-hover.png)

3. Dumping the same row now shows the href:

```
[{"column":"Created By","text":"qa-links-user","href":"/users?user=qa-links-user"}]
```

4. Clicking it lands on the user detail page:

```
prompts-createdby -> http://localhost:3021/users/?user=qa-links-user
```

![prompts landing](https://raw.githubusercontent.com/BerriAI/litellm/litellm_entity_link_shots/links1-prompts-land-user.png)

## Type

🆕 New Feature

## Caveats (if any)

### Low

- Prompts with no recorded creator still render "-", unlinked

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

https://claude.ai/code/session_01NfwfQhamRNnSqgXMUjf3h4
