### PR TITLE
test(e2e): wait for serving propagation in UI journeys

### DIFF
--- a/tests/e2e/ui/constants.ts
+++ b/tests/e2e/ui/constants.ts
@@ -17,6 +17,8 @@ export const ARTIFACT_DIR = process.env.E2E_UI_ARTIFACT_DIR || ".";
 
 export const MOCK_PRESIDIO_URL = (process.env.E2E_MOCK_PRESIDIO_URL || "http://127.0.0.1:8091").replace(/\/+$/, "");
 
+export const PROPAGATION_TIMEOUT_MS = 90_000;
+
 const storagePath = (name: string): string => path.join(ARTIFACT_DIR, name);
 
 // Storage state paths for each role

--- a/tests/e2e/ui/tests/guardrails/presidioUserStory.spec.ts
+++ b/tests/e2e/ui/tests/guardrails/presidioUserStory.spec.ts
@@ -1,8 +1,8 @@
-import { test, expect, type Page as PlaywrightPage } from "@playwright/test";
-import { ADMIN_STORAGE_PATH, MOCK_PRESIDIO_URL } from "../../constants";
+import { test as base, expect, type Page as PlaywrightPage } from "@playwright/test";
+import { ADMIN_STORAGE_PATH, MOCK_PRESIDIO_URL, PROPAGATION_TIMEOUT_MS } from "../../constants";
 import { navigateToPage, dismissFeedbackPopup } from "../../helpers/navigation";
 import { Page } from "../../fixtures/pages";
-import { CHAT_MODEL_A, masterKey, rootPath, waitForSpendLogByPrompt } from "../../helpers/traffic";
+import { CHAT_MODEL_A, masterKey, rootPath, uniqueSuffix, waitForSpendLog } from "../../helpers/traffic";
 import { openPlayground, selectModel, sendButton, onlyVisible } from "../../helpers/playground";
 
 const RAW_EMAIL = "jane.doe@example.com";
@@ -62,15 +62,63 @@ async function deleteGuardrail(page: PlaywrightPage, guardrailName: string): Pro
   await expect(page.getByText(`Guardrail "${guardrailName}" deleted successfully`)).toBeVisible({ timeout: 10_000 });
 }
 
+const test = base.extend<{ guardrailName: string }>({
+  guardrailName: async ({ page }, use) => {
+    const name = `e2e-presidio-story-${uniqueSuffix()}`;
+    await createPresidioGuardrail(page, name);
+    try {
+      await use(name);
+    } finally {
+      await deleteGuardrail(page, name);
+    }
+  },
+});
+
 test.describe("Presidio PII guardrail, end to end from the dashboard", () => {
+  test.describe.configure({ timeout: 5 * 60_000 });
   test.use({ storageState: ADMIN_STORAGE_PATH });
 
-  test("masks PII sent from the Playground and shows the run in Logs", async ({ page, request }) => {
-    const guardrailName = `e2e-presidio-story-${Date.now()}`;
+  test("masks PII sent from the Playground and shows the run in Logs", async ({ page, request, guardrailName }) => {
     const marker = `case-ref-${Math.random().toString(36).slice(2, 10)}`;
     const prompt = `${marker}. Email me at ${RAW_EMAIL} or call ${RAW_PHONE}.`;
 
-    await createPresidioGuardrail(page, guardrailName);
+    await expect
+      .poll(
+        async () => {
+          const completion = await request.post(`${rootPath()}/v1/chat/completions`, {
+            headers: { Authorization: `Bearer ${masterKey()}` },
+            data: {
+              model: CHAT_MODEL_A,
+              messages: [
+                { role: "user", content: `readiness-${uniqueSuffix()}. Email ${RAW_EMAIL}; phone ${RAW_PHONE}.` },
+              ],
+              guardrails: [guardrailName],
+            },
+          });
+          expect(completion.ok(), `guardrail readiness request failed: ${await completion.text()}`).toBe(true);
+          const { id }: { id: string } = await completion.json();
+          expect(id).toBeTruthy();
+          await waitForSpendLog(request, id);
+          const stored = await request.get(`${rootPath()}/spend/logs`, {
+            headers: { Authorization: `Bearer ${masterKey()}` },
+            params: { request_id: id },
+          });
+          expect(stored.ok(), `guardrail readiness log read failed: ${stored.status()}`).toBe(true);
+          const body = await stored.text();
+          return {
+            rawEmail: body.includes(RAW_EMAIL),
+            rawPhone: body.includes(RAW_PHONE),
+            maskedEmail: body.includes("<EMAIL_ADDRESS>"),
+            maskedPhone: body.includes("<PHONE_NUMBER>"),
+          };
+        },
+        {
+          message: `${guardrailName} never masked email and phone data in a completed request`,
+          timeout: PROPAGATION_TIMEOUT_MS,
+          intervals: [2_000],
+        },
+      )
+      .toEqual({ rawEmail: false, rawPhone: false, maskedEmail: true, maskedPhone: true });
 
     await openPlayground(page);
     await selectModel(page, CHAT_MODEL_A);
@@ -85,29 +133,31 @@ test.describe("Presidio PII guardrail, end to end from the dashboard", () => {
     const input = onlyVisible(page.getByPlaceholder("Type your message", { exact: false }));
     await expect(input).toBeVisible({ timeout: 15_000 });
 
-    await expect
-      .poll(
-        async () => {
-          await input.fill(prompt);
-          await sendButton(page).click();
-          const res = await request.get(`${rootPath()}/spend/logs`, {
-            headers: { Authorization: `Bearer ${masterKey()}` },
-          });
-          if (!res.ok()) return false;
-          const rows: { metadata?: { applied_guardrails?: string[] } }[] = await res.json();
-          return (Array.isArray(rows) ? rows : []).some((row) =>
-            (row.metadata?.applied_guardrails ?? []).includes(guardrailName),
-          );
-        },
-        {
-          message: `the playground never produced a request that ran ${guardrailName}`,
-          timeout: 90_000,
-          intervals: [5_000],
-        },
-      )
-      .toBe(true);
-
-    const requestId = await waitForSpendLogByPrompt(request, marker);
+    await input.fill(prompt);
+    const responsePromise = page.waitForResponse(
+      (response) =>
+        response.request().method() === "POST" &&
+        new URL(response.url()).pathname.endsWith("/chat/completions") &&
+        (response.request().postData()?.includes(marker) ?? false),
+    );
+    await sendButton(page).click();
+    const response = await responsePromise;
+    expect(response.ok(), `Playground completion failed: ${response.status()}`).toBe(true);
+    const responseBody = await response.text();
+    const chunks: { id?: string; error?: unknown }[] = response.headers()["content-type"]?.includes("text/event-stream")
+      ? responseBody
+          .split(/\r?\n/)
+          .filter((line) => line.startsWith("data: ") && line.trim() !== "data: [DONE]")
+          .map((line) => JSON.parse(line.slice(6)))
+      : [JSON.parse(responseBody)];
+    expect(
+      chunks.some((chunk) => chunk.error),
+      "the Playground stream returned an error",
+    ).toBe(false);
+    const requestIds = [...new Set(chunks.map((chunk) => chunk.id).filter((id): id is string => !!id))];
+    expect(requestIds, "the Playground response identifies exactly one completion").toHaveLength(1);
+    const [requestId] = requestIds;
+    await waitForSpendLog(request, requestId);
 
     const stored = await request.get(`${rootPath()}/spend/logs?request_id=${requestId}`, {
       headers: { Authorization: `Bearer ${masterKey()}` },
@@ -138,7 +188,9 @@ test.describe("Presidio PII guardrail, end to end from the dashboard", () => {
 
     const drawer = page.getByRole("dialog").first();
     await expect(onlyVisible(drawer.getByText("Guardrails & Policy Compliance"))).toBeVisible({ timeout: 20_000 });
-    await expect(onlyVisible(drawer.getByText(`Pre-call guardrail: ${guardrailName}`))).toBeVisible({ timeout: 20_000 });
+    await expect(onlyVisible(drawer.getByText(`Pre-call guardrail: ${guardrailName}`))).toBeVisible({
+      timeout: 20_000,
+    });
     const maskedPrompt = drawer.getByText(`${marker}. Email me at <EMAIL_ADDRESS> or call <PHONE_NUMBER>.`);
     await expect(onlyVisible(maskedPrompt)).toBeVisible({ timeout: 20_000 });
 
@@ -151,7 +203,5 @@ test.describe("Presidio PII guardrail, end to end from the dashboard", () => {
 
     await expect(drawer.getByText(RAW_EMAIL)).toHaveCount(0);
     await expect(drawer.getByText(RAW_PHONE)).toHaveCount(0);
-
-    await deleteGuardrail(page, guardrailName);
   });
 });

--- a/tests/e2e/ui/tests/modelsPage/modelHealthStatus.spec.ts
+++ b/tests/e2e/ui/tests/modelsPage/modelHealthStatus.spec.ts
@@ -4,7 +4,7 @@ import {
   type Locator,
   type Page as PlaywrightPage,
 } from "@playwright/test";
-import { ADMIN_STORAGE_PATH } from "../../constants";
+import { ADMIN_STORAGE_PATH, PROPAGATION_TIMEOUT_MS } from "../../constants";
 import { Page } from "../../fixtures/pages";
 import { navigateToPage } from "../../helpers/navigation";
 import { readBack } from "../../helpers/roundTrip";
@@ -145,6 +145,24 @@ async function withDeployment(
         timeout: 60_000,
       })
       .toBe(true);
+    await expect
+      .poll(
+        async () => {
+          const response = await page.request.get("/health", {
+            headers: { Authorization: `Bearer ${masterKey()}` },
+            params: { model_id: id },
+          });
+          if (![200, 503].includes(response.status())) return 0;
+          const body: { healthy_count?: number; unhealthy_count?: number } = await response.json();
+          return (body.healthy_count ?? 0) + (body.unhealthy_count ?? 0);
+        },
+        {
+          message: `deployment ${name} never became available to /health`,
+          timeout: PROPAGATION_TIMEOUT_MS,
+          intervals: [2_000],
+        },
+      )
+      .toBe(1);
     await use(name);
   } finally {
     await deleteDeployment(page, id);

--- a/tests/e2e/ui/tests/modelsPage/modelHealthStatus.spec.ts
+++ b/tests/e2e/ui/tests/modelsPage/modelHealthStatus.spec.ts
@@ -148,21 +148,20 @@ async function withDeployment(
     await expect
       .poll(
         async () => {
-          const response = await page.request.get("/health", {
+          const response = await page.request.get("/v1/models", {
             headers: { Authorization: `Bearer ${masterKey()}` },
-            params: { model_id: id },
           });
-          if (![200, 503].includes(response.status())) return 0;
-          const body: { healthy_count?: number; unhealthy_count?: number } = await response.json();
-          return (body.healthy_count ?? 0) + (body.unhealthy_count ?? 0);
+          expect(response.ok(), `/v1/models failed: ${response.status()}`).toBe(true);
+          const body: { data: { id: string }[] } = await response.json();
+          return body.data.some((model) => model.id === name);
         },
         {
-          message: `deployment ${name} never became available to /health`,
+          message: `deployment ${name} never appeared on the serving path`,
           timeout: PROPAGATION_TIMEOUT_MS,
           intervals: [2_000],
         },
       )
-      .toBe(1);
+      .toBe(true);
     await use(name);
   } finally {
     await deleteDeployment(page, id);

--- a/tests/e2e/ui/tests/modelsPage/modelHealthStatus.spec.ts
+++ b/tests/e2e/ui/tests/modelsPage/modelHealthStatus.spec.ts
@@ -178,6 +178,7 @@ const test = base.extend<{ reachableName: string; unreachableName: string }>({
 });
 
 test.describe("Model health status", () => {
+  test.describe.configure({ timeout: 8 * 60_000 });
   test.use({ storageState: ADMIN_STORAGE_PATH });
 
   test("Run Health Check reports a reachable deployment healthy and an unreachable one unhealthy", async ({

--- a/tests/e2e/ui/tests/proxy-admin/keyBlocking.spec.ts
+++ b/tests/e2e/ui/tests/proxy-admin/keyBlocking.spec.ts
@@ -1,5 +1,5 @@
 import { test as base, expect } from "@playwright/test";
-import { ADMIN_STORAGE_PATH } from "../../constants";
+import { ADMIN_STORAGE_PATH, PROPAGATION_TIMEOUT_MS } from "../../constants";
 import { Page } from "../../fixtures/pages";
 import { dismissFeedbackPopup, navigateToPage, openKeyDetail } from "../../helpers/navigation";
 import {
@@ -35,6 +35,7 @@ test.describe("Proxy Admin - Key blocking", () => {
   test.use({ storageState: ADMIN_STORAGE_PATH });
 
   test("blocking a key stops it serving and unblocking restores it", async ({ page, scopedKey }) => {
+    test.setTimeout(5 * 60_000);
     const { alias, token, apiKey } = scopedKey;
 
     await sendChatCompletion(page.request, {
@@ -70,7 +71,7 @@ test.describe("Proxy Admin - Key blocking", () => {
           }),
         {
           message: "a blocked key was still served by /v1/chat/completions",
-          timeout: 30_000,
+          timeout: PROPAGATION_TIMEOUT_MS,
         },
       )
       .toMatchObject({ status: 401, body: expect.stringContaining("blocked") });
@@ -104,7 +105,7 @@ test.describe("Proxy Admin - Key blocking", () => {
           }),
         {
           message: "an unblocked key is still refused by /v1/chat/completions",
-          timeout: 30_000,
+          timeout: PROPAGATION_TIMEOUT_MS,
         },
       )
       .toMatchObject({ status: 200, body: expect.stringContaining(MOCK_RESPONSE_TEXT) });


### PR DESCRIPTION
## TLDR

Problem this solves:

- UI tests assert serving behavior before configuration propagates
- Presidio can inspect a different request from the Playground

How it solves it:

- Poll serving model visibility before clicking Health Check
- Allow 90 seconds for key blocking and unblocking
- Verify masking, then correlate one Playground completion by ID
- Clean up the Presidio guardrail when assertions fail

## User Flow

Before: an engineer runs the UI suite and sees timing-dependent failures

1. Create a model or guardrail, or block a virtual key
2. Run Health Check, send a Playground message, or call chat
3. The test can fail while the change is still propagating

After: the same suite allows propagation and checks the intended request

1. Create a model or guardrail, or block a virtual key
2. Run Health Check, send a Playground message, or call chat
3. The test verifies the serving result within a bounded wait

Product behavior and existing masking, health-detail, and authorization assertions are unchanged

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible
- [x] I have received a Greptile Confidence Score of 5/5 for the current head

## Screenshots / Proof of Fix

The changed UI journeys use a real proxy, PostgreSQL, Redis, and browser with the existing mock LLM and Presidio fixtures. Full API CI separately exercises the configured live providers

### Before (9316b4194a24edabaa1dd5ae0159af335ed2d316)

1. The three test files are unchanged from staging 9a715df212d777bbd43f4cab05731978c708ec63, where [UI build #294](https://buildkite.com/berriai-1/litellm-e2e-ui/builds/294) failed all three on the initial attempt and both retries
2. This is inherited CI evidence; an exact-merge-base browser reproduction is not claimed

### After (b01d12154d79019fe0a902427802436e69b9a519)

1. The three changed browser tests passed three repetitions each against the isolated native stack: **9 passed in 2.3 minutes**, with retries disabled
2. [Current-head UI build #299](https://buildkite.com/berriai-1/litellm-e2e-ui/builds/299): **152 passed, 1 existing skip, no retries** in 15.9 minutes. All three repaired journeys passed on their first attempt
3. [UI build #300](https://buildkite.com/berriai-1/litellm-e2e-ui/builds/300) also passed the full suite at the preceding head: **152 passed, 1 existing skip, no retries** in 16.2 minutes
4. [Full E2E build #167](https://buildkite.com/berriai-1/litellm-e2e/builds/167): **898 API tests passed, 58 skipped, no pytest reruns**, plus **4 managed-files tests passed**. The full build passed and its ephemeral stack was cleaned up. This build tests 057d333d108d355534869a11297b53d949ee773a. The only difference from the current head is the model-health test timeout; product source and API tests are identical

All 33 required PR checks pass, and Greptile independently reviewed the current head at 5/5. TypeScript checking passes. `make check` completes but reports no applicable gates for these TypeScript test files

## Type

Test

## Caveats (if any)

### Low

- The API run is at the preceding commit, with identical product source and API tests; the current head has its own full UI run
- Polling budgets bound waiting without changing propagation behavior

## QA runbook

Use the UI harness's seeded database, mock LLM and Presidio fixtures, prompt logging, and an admin session

- `tests/e2e/ui/tests/modelsPage/modelHealthStatus.spec.ts` verifies health results and their persisted details
  - [x] Create two deployments through `/model/new`, using the mock upstream and `http://127.0.0.1:9/v1`
  - [x] Wait for both names in serving `/v1/models`, then open `/ui?page=models`
  - [x] Run each Health Check; expect healthy and unhealthy respectively, and inspect their error/success dialogs
  - [x] Reload and verify both statuses remain, then delete both deployments
  - [x] Sanity check: a missing deployment or incorrect health result still fails
- `tests/e2e/ui/tests/guardrails/presidioUserStory.spec.ts` verifies stored and displayed PII masking
  - [x] Create a pre-call Presidio guardrail in `/ui?page=guardrails`, masking email and phone entities
  - [x] Send a readiness request using that guardrail and inspect its exact completion ID in `/spend/logs`; wait for masked email and phone placeholders
  - [x] Select the guardrail in Playground and send one message containing an email and phone number
  - [x] Use that response's completion ID to find its spend log and Logs drawer
  - [x] Verify masked placeholders, both detected entities and their scores, the guardrail name, and absence of raw PII; delete the guardrail
  - [x] Sanity check: a guardrail name in metadata alone cannot satisfy readiness or the final masking assertions
- `tests/e2e/ui/tests/proxy-admin/keyBlocking.spec.ts` verifies blocking and unblocking enforcement
  - [x] Generate a virtual key and confirm a chat request succeeds
  - [x] Block it from Virtual Keys and verify `/key/info` reports blocked
  - [x] Poll chat with that same key for up to 90 seconds; require 401 identifying the blocked key
  - [x] Reload its detail page, unblock it, and require a successful mock completion within 90 seconds; delete the key
  - [x] Sanity check: a key that never stops serving still fails

## Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
