### PR TITLE
fix(proxy_server): populate model_info when cost keys are present but None (#40741)

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -13499,7 +13499,7 @@ def _enrich_model_info_with_litellm_data(
             except Exception:
                 litellm_model_info = {}
     for k, v in litellm_model_info.items():
-        if k not in model_info:
+        if model_info.get(k) is None:
             model_info[k] = v
     model["model_info"] = model_info
     # don't return the api key / vertex credentials
@@ -14965,7 +14965,7 @@ def _get_proxy_model_info(model: dict) -> dict:
         except Exception:
             litellm_model_info = {}
     for k, v in litellm_model_info.items():
-        if k not in model_info:
+        if model_info.get(k) is None:
             model_info[k] = v
     model["model_info"] = model_info
     # don't return the llm credentials

--- a/tests/test_litellm/proxy/proxy_server/test_routes_model_info.py
+++ b/tests/test_litellm/proxy/proxy_server/test_routes_model_info.py
@@ -546,7 +546,7 @@ def test_v2_model_info_access_group_paginates_over_the_filtered_set(client, auth
 def test_enrich_model_info_with_litellm_data_populates_none_keys(monkeypatch):
     monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
     from litellm.proxy._types import ModelInfo as ProxyModelInfo
-    from litellm.proxy.proxy_server import _enrich_model_info_with_litellm_data, _get_proxy_model_info
+    from litellm.proxy.proxy_server import _enrich_model_info_with_litellm_data
 
     backend = "bedrock/eu.anthropic.claude-opus-5"
     p_model_info = ProxyModelInfo(id="d1").model_dump()
@@ -558,7 +558,17 @@ def test_enrich_model_info_with_litellm_data_populates_none_keys(monkeypatch):
     assert mi.get("max_tokens") == 128000
     assert mi.get("mode") == "chat"
 
-    proxy_info = _get_proxy_model_info(model=model)
+
+def test_get_proxy_model_info_populates_none_keys(monkeypatch):
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    from litellm.proxy._types import ModelInfo as ProxyModelInfo
+    from litellm.proxy.proxy_server import _get_proxy_model_info
+
+    backend = "bedrock/eu.anthropic.claude-opus-5"
+    p_model_info = ProxyModelInfo(id="d1").model_dump()
+    fresh_model = {"model_name": "m", "litellm_params": {"model": backend}, "model_info": dict(p_model_info)}
+
+    proxy_info = _get_proxy_model_info(model=fresh_model)
     p_mi = proxy_info["model_info"]
     assert p_mi.get("input_cost_per_token") == 5.5e-06
     assert p_mi.get("max_tokens") == 128000
@@ -579,7 +589,8 @@ def test_enrich_model_info_with_litellm_data_preserves_custom_pricing(monkeypatc
     assert mi.get("input_cost_per_token") == 0.00099
     assert mi.get("max_tokens") == 128000
 
-    proxy_info = _get_proxy_model_info(model=model)
+    fresh_custom_model = {"model_name": "m", "litellm_params": {"model": backend}, "model_info": dict(custom_model_info)}
+    proxy_info = _get_proxy_model_info(model=fresh_custom_model)
     p_mi = proxy_info["model_info"]
     assert p_mi.get("input_cost_per_token") == 0.00099
 

--- a/tests/test_litellm/proxy/proxy_server/test_routes_model_info.py
+++ b/tests/test_litellm/proxy/proxy_server/test_routes_model_info.py
@@ -541,3 +541,45 @@ def test_v2_model_info_access_group_paginates_over_the_filtered_set(client, auth
     assert _model_names(payload) == ["openai/*"]
     assert payload["total_count"] == 2
     assert payload["total_pages"] == 2
+
+
+def test_enrich_model_info_with_litellm_data_populates_none_keys(monkeypatch):
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    from litellm.proxy._types import ModelInfo as ProxyModelInfo
+    from litellm.proxy.proxy_server import _enrich_model_info_with_litellm_data, _get_proxy_model_info
+
+    backend = "bedrock/eu.anthropic.claude-opus-5"
+    p_model_info = ProxyModelInfo(id="d1").model_dump()
+    model = {"model_name": "m", "litellm_params": {"model": backend}, "model_info": dict(p_model_info)}
+
+    enriched = _enrich_model_info_with_litellm_data(model=model, llm_router=None)
+    mi = enriched["model_info"]
+    assert mi.get("input_cost_per_token") == 5.5e-06
+    assert mi.get("max_tokens") == 128000
+    assert mi.get("mode") == "chat"
+
+    proxy_info = _get_proxy_model_info(model=model)
+    p_mi = proxy_info["model_info"]
+    assert p_mi.get("input_cost_per_token") == 5.5e-06
+    assert p_mi.get("max_tokens") == 128000
+    assert p_mi.get("mode") == "chat"
+
+
+def test_enrich_model_info_with_litellm_data_preserves_custom_pricing(monkeypatch):
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    from litellm.proxy._types import ModelInfo as ProxyModelInfo
+    from litellm.proxy.proxy_server import _enrich_model_info_with_litellm_data, _get_proxy_model_info
+
+    backend = "bedrock/eu.anthropic.claude-opus-5"
+    custom_model_info = ProxyModelInfo(id="d1", input_cost_per_token=0.00099).model_dump()
+    model = {"model_name": "m", "litellm_params": {"model": backend}, "model_info": dict(custom_model_info)}
+
+    enriched = _enrich_model_info_with_litellm_data(model=model, llm_router=None)
+    mi = enriched["model_info"]
+    assert mi.get("input_cost_per_token") == 0.00099
+    assert mi.get("max_tokens") == 128000
+
+    proxy_info = _get_proxy_model_info(model=model)
+    p_mi = proxy_info["model_info"]
+    assert p_mi.get("input_cost_per_token") == 0.00099
+


### PR DESCRIPTION
<!-- The whole description's target audience is humans, not AI agents: write it in plain, simple,
     everyday engineering language, extremely parsable and readable at a glance. This goes double for
     the TLDR, User Flow, and Caveats sections -->

## TLDR

Problem this solves:

- `ModelInfo` serialization dumps fields with `None` values
- `proxy_server.py` checked `if k not in model_info:`
- Existing `None` values blocked model cost map enrichment
- Missing pricing broke concurrent budget reservation

How it solves it:

- Check `if model_info.get(k) is None:` at both merge sites
- Missing and `None` fields get enriched with litellm cost data
- Preserves custom user-specified pricing values

## User Flow

Before: a proxy user configures a model deployment without explicit per-token pricing, and concurrent budget reservations fail to estimate spend, allowing requests through with $0 estimated spend

1. Proxy initializes a model deployment with default `ModelInfo` fields (where `input_cost_per_token=None`, etc.)
2. `proxy_server._enrich_model_info_with_litellm_data` sees `k in model_info` (with value `None`) and skips filling in litellm's default pricing
3. The model's cost map remains empty/`None`, leading concurrent request budget reservations to evaluate spend at $0.0

After: the proxy initializes the model deployment, enriches unset/`None` fields with standard model pricing, and preserves any custom pricing overrides

1. Proxy initializes the same model deployment with default `ModelInfo`
2. `proxy_server._enrich_model_info_with_litellm_data` checks `if model_info.get(k) is None:` and populates `input_cost_per_token`, `output_cost_per_token`, and other metadata from the default cost map
3. The model has accurate pricing info, enabling concurrent budget reservations to accurately track spend

## Relevant issues

Fixes #40741

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

### Before (dfab4794)

1. Run reproduction script querying `_enrich_model_info_with_litellm_data` with default `ProxyModelInfo`
2. Observed output: `input_cost_per_token: None`, `max_tokens: None`, `mode: None` (pricing was skipped because keys were present with `None` value)

### After (80f4d7ed)

1. Run reproduction script querying `_enrich_model_info_with_litellm_data` with default `ProxyModelInfo`
2. Observed output: `input_cost_per_token: 5.5e-06`, `max_tokens: 128000`, `mode: 'chat'` (pricing and token limits populated from cost map)
3. Run with custom override: `input_cost_per_token: 0.00099` is preserved

## Type

🐛 Bug Fix
✅ Test

## Caveats (if any)

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
