### PR TITLE
test(responses): fix stale Anthropic smoke request

### DIFF
--- a/tests/openai_endpoints_tests/test_e2e_openai_responses_api.py
+++ b/tests/openai_endpoints_tests/test_e2e_openai_responses_api.py
@@ -127,14 +127,14 @@ def test_bad_request_bad_param_error():
         )
 
 
-def test_anthropic_with_responses_api():
-    client = get_test_client()
-    response = client.responses.create(
-        model="anthropic/claude-sonnet-4-5-20250929",
+def test_anthropic_with_responses_api() -> None:
+    client: Final = get_test_client()
+    response: Final = client.responses.create(
+        model="anthropic/claude-sonnet-5",
         input="just respond with the word 'ping'",
-        previous_response_id="hi",
     )
-    print("anthropic response=", response)
+    assert response.status == "completed"
+    assert response.output_text.strip()
 
 
 def test_cancel_response():


### PR DESCRIPTION
## TLDR

Problem this solves:

- Anthropic smoke test sends a fabricated previous response ID
- Expected ownership rejection fails the CircleCI endpoint suite

How it solves it:

- Start a fresh response without the fabricated ID
- Assert completed status and nonempty response text
- Use Sonnet 5 from the current model catalog

## User Flow

Before: the Anthropic smoke request is rejected before model execution

1. Create a virtual key using `POST http://127.0.0.1:50300/key/generate`
2. Send `POST http://127.0.0.1:50300/responses` asking Anthropic to say `ping`, with `previous_response_id="hi"`
3. Receive HTTP 403 because the proxy never issued that ID

After: the smoke request starts a fresh response successfully

1. Create a virtual key using `POST http://127.0.0.1:50300/key/generate`
2. Send `POST http://127.0.0.1:50300/responses` asking Anthropic to say `ping`, without a previous response ID
3. Receive HTTP 200 with a completed response containing `ping`

## Relevant issues

Updates the stale test after #39548. This failure also appears on #40779

## Linear ticket

## Pre-Submission checklist

- [x] The test asserts completed status and nonempty output
- [x] Changed test passes against a live proxy
- [x] All required CI/CD checks pass
- [x] The change is limited to one existing test
- [x] Greptile has posted 5/5 for the current head

## Test plan

The exact existing test fails with HTTP 403 on base `09b694894d`. The updated test passes against the real Anthropic API, and restoring only `previous_response_id="hi"` makes it fail with the same 403

All nine existing `TestUnrecognizedResponseIdIsRejected` cases pass. Ruff and the test-quality budget gate pass. Local execution changes only the test's two hardcoded localhost origins to the isolated proxy's address

CI is green on `4423876857443a6b32731713053f9c3491b3e1f3`, including all 33 required checks. The [CircleCI endpoint suite](https://app.circleci.com/workflow/f285458f-41e5-49f5-81c3-66d529929a30/job/9b1e956b-0f66-46ae-916a-e01ad97e9479) passed 19 tests with 2 skipped. The [proxy-infra rerun](https://github.com/BerriAI/litellm/actions/runs/34646984186/job/103436059388) passed 9,920 tests with 1 skipped on the same commit after the original hosted runner lost communication with GitHub. Greptile posted 5/5 for this head

## Screenshots / Proof of Fix

An isolated proxy routes `anthropic/*` to the real Anthropic API. Runtime source is identical on both revisions; this PR changes only the smoke request and its assertions. `TEST_KEY` is a newly generated virtual key

### Before (09b694894d4b71fab0b6a194ada64689b0f59e08)

1. Send the original smoke request

   ```bash
   curl -sS http://127.0.0.1:50300/responses \
     -H "Authorization: Bearer $TEST_KEY" \
     -H 'Content-Type: application/json' \
     -d '{"model":"anthropic/claude-sonnet-4-5-20250929","input":"just respond with the word '\''ping'\''","previous_response_id":"hi"}' \
     -w '\nHTTP %{http_code}\n'
   ```

2. Observe `HTTP 403` and `Forbidden. This response id was not issued by this proxy, so the proxy cannot tell who owns it.`

### After (4423876857443a6b32731713053f9c3491b3e1f3)

1. Send the corrected smoke request

   ```bash
   curl -sS http://127.0.0.1:50300/responses \
     -H "Authorization: Bearer $TEST_KEY" \
     -H 'Content-Type: application/json' \
     -d '{"model":"anthropic/claude-sonnet-5","input":"just respond with the word '\''ping'\''"}' \
     -w '\nHTTP %{http_code}\n'
   ```

2. Observe `HTTP 200`, `"status":"completed"`, and output text `ping`. Adding `previous_response_id="hi"` to this request still returns HTTP 403

## Type

Test

## Caveats

### Low

- Existing formatting debt is outside the edited test

## Final Attestation

- [x] Successful responses and unchanged ownership rejection were verified
