### PR TITLE
fix(token_counter): handle tool array schema without items property (#40344)

### DIFF
--- a/litellm/litellm_core_utils/token_counter.py
+++ b/litellm/litellm_core_utils/token_counter.py
@@ -987,8 +987,10 @@ def _format_type(props, indent):
             return " | ".join([f'"{item}"' for item in props["enum"]])
         return "string"
     elif type == "array":
-        # items is required, OpenAI throws an error if it's missing
-        return f"{_format_type(props['items'], indent)}[]"
+        items = props.get("items")
+        if isinstance(items, dict):
+            return f"{_format_type(items, indent)}[]"
+        return "any[]"
     elif type == "object":
         return f"{{\n{_format_object_parameters(props, indent + 2)}\n}}"
     elif type in ["integer", "number"]:

--- a/tests/test_litellm/litellm_core_utils/test_token_counter_tool.py
+++ b/tests/test_litellm/litellm_core_utils/test_token_counter_tool.py
@@ -31,9 +31,7 @@ def test_token_counter_tool_increases(messages):
         conversation.append(message)
         tokens = token_counter(model="gpt-3.5-turbo", messages=conversation, tools=TOOLS)  # type: ignore
         print(f"tokens: {tokens}")
-        assert (
-            tokens > prev_tokens
-        ), f"Token did not increase: {tokens} <= {prev_tokens}"
+        assert tokens > prev_tokens, f"Token did not increase: {tokens} <= {prev_tokens}"
         prev_tokens = tokens
 
 
@@ -76,3 +74,28 @@ def assertGrow(usermessage, tool_call, assertBiggerThanBoth=True):
             f"tokens_usermessage: {tokens_usermessage}, tokens_tool_call: {tokens_tool_call}, "
             + f"tokens_both: {tokens_both} diff: {tokens_usermessage + tokens_tool_call - tokens_both}"
         )
+
+
+def test_token_counter_tool_array_schema_without_items():
+    """Test that tool array schema without 'items' property does not crash token counting (#40344)."""
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "search_data",
+                "description": "Search for data",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "tags": {
+                            "type": "array",
+                            "description": "List of tags",
+                        },
+                    },
+                },
+            },
+        }
+    ]
+    messages = [{"role": "user", "content": "Hello"}]
+    tokens = token_counter(model="gpt-3.5-turbo", messages=messages, tools=tools)
+    assert tokens > 0


### PR DESCRIPTION
## What does this PR do?

Fixes #40344.

When calculating tokens for tool definitions using `litellm.token_counter()`, `_format_type()` in `litellm/litellm_core_utils/token_counter.py` unconditionally accessed `props['items']` when encountering an array property (`type == "array"`). If a tool parameter schema omitted the `'items'` specification, `token_counter` crashed with an unhandled `KeyError: 'items'`, terminating pre-call context checks and request pipelines.

This change:
1. Safely checks for `props.get("items")` in `_format_type`. If `items` is present as a dictionary, it formats the inner type recursively; otherwise, it safely defaults to `"any[]"`.
2. Adds unit test coverage in `tests/test_litellm/litellm_core_utils/test_token_counter_tool.py` to ensure tool array schemas without `'items'` count tokens without crashing.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?
- Tested locally via `python -m pytest tests/test_litellm/litellm_core_utils/test_token_counter_tool.py` (45 passed).
- Verified clean formatting.
