### PR TITLE
feat(a2a): add TinyFish Agent provider with per-step spend tracking

### DIFF
--- a/litellm/a2a_protocol/main.py
+++ b/litellm/a2a_protocol/main.py
@@ -13,7 +13,7 @@ import asyncio
 import datetime
 import uuid
 from collections.abc import AsyncIterator, Coroutine, Mapping
-from types import ModuleType
+from types import MappingProxyType, ModuleType
 from typing import TYPE_CHECKING, Any, Final, Optional, cast
 
 import litellm
@@ -83,6 +83,8 @@ from litellm.a2a_protocol.exceptions import A2ALocalhostURLError
 
 # Use our custom resolver instead of the default A2A SDK resolver
 A2ACardResolver: Final = LiteLLMA2ACardResolver
+
+_EMPTY_KWARGS: Final[Mapping[str, object]] = MappingProxyType({})
 
 
 def _set_usage_on_logging_obj(
@@ -204,6 +206,7 @@ async def _send_message_via_completion_bridge(
     api_base: str | None,
     litellm_params: dict[str, object],
     agent_extra_headers: dict[str, str] | None = None,
+    kwargs: Mapping[str, object] | None = None,
 ) -> LiteLLMSendMessageResponse:
     """
     Route a send_message through the LiteLLM completion bridge (e.g. LangGraph, Bedrock AgentCore).
@@ -218,15 +221,51 @@ async def _send_message_via_completion_bridge(
 
     params = request.params.model_dump(mode="json") if hasattr(request.params, "model_dump") else dict(request.params)
 
-    response_dict: Final = await A2ACompletionBridgeHandler.handle_non_streaming(
+    raw_response_dict: Final = await A2ACompletionBridgeHandler.handle_non_streaming(
         request_id=str(request.id),
         params=params,
         litellm_params=litellm_params,
         api_base=api_base,
         agent_extra_headers=agent_extra_headers,
     )
+    response_dict: Final = _strip_provider_response_cost(raw_response_dict, kwargs=kwargs or _EMPTY_KWARGS)
+
+    prompt_tokens, completion_tokens, _ = A2ARequestUtils.calculate_usage_from_request_response(
+        request=request,
+        response_dict=response_dict,
+    )
+    _set_usage_on_logging_obj(
+        kwargs=kwargs or _EMPTY_KWARGS,
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+    )
 
     return LiteLLMSendMessageResponse.from_dict(response_dict, request_id=str(request.id))
+
+
+def _strip_provider_response_cost(
+    chunk: Mapping[str, object],
+    kwargs: Mapping[str, object],
+) -> dict[str, object]:  # mutable-ok: the response is JSON-serialized downstream; must be a plain dict
+    """Pop a provider-reported actual cost off the response and record it for spend logging."""
+    from litellm.a2a_protocol.providers.base import A2A_PROVIDER_RESPONSE_COST_KEY
+
+    if A2A_PROVIDER_RESPONSE_COST_KEY in chunk:
+        reported_cost: Final = chunk[A2A_PROVIDER_RESPONSE_COST_KEY]
+        logging_obj: Final = kwargs.get("litellm_logging_obj")
+        if isinstance(logging_obj, Logging) and isinstance(reported_cost, (int, float)):
+            logging_obj.model_call_details["response_cost"] = float(reported_cost)
+    return {  # mutable-ok: the response is JSON-serialized downstream; must be a plain dict
+        key: value for key, value in chunk.items() if key != A2A_PROVIDER_RESPONSE_COST_KEY
+    }
+
+
+async def _strip_provider_cost_from_stream(
+    stream: AsyncIterator[Mapping[str, object]],
+    kwargs: Mapping[str, object],
+) -> AsyncIterator[dict[str, object]]:  # mutable-ok: SSE chunks are JSON-serialized; must be plain dicts
+    async for chunk in stream:
+        yield _strip_provider_response_cost(chunk, kwargs=kwargs)
 
 
 def _get_a2a_call_context(a2a_client: "A2AClientType") -> Optional["A2ACallContextType"]:
@@ -451,13 +490,18 @@ async def asend_message(
     if custom_llm_provider:
         if request is None:
             raise ValueError("request is required for completion bridge")
-        return await _send_message_via_completion_bridge(
+        bridge_response: Final = await _send_message_via_completion_bridge(
             request=request,
             custom_llm_provider=custom_llm_provider,
             api_base=api_base,
             litellm_params=litellm_params,
             agent_extra_headers=agent_extra_headers,
+            kwargs=kwargs,
         )
+        # Cost params + agent_id previously reached the logging obj only on the native path, so bridge spend logged $0
+        _set_litellm_params_on_logging_obj(kwargs=kwargs, litellm_params=litellm_params)
+        _set_agent_id_on_logging_obj(kwargs=kwargs, agent_id=agent_id)
+        return bridge_response
 
     # Standard A2A client flow
     if request is None:
@@ -669,12 +713,38 @@ async def asend_message_streaming(
             request.params.model_dump(mode="json") if hasattr(request.params, "model_dump") else dict(request.params)
         )
 
-        async for chunk in A2ACompletionBridgeHandler.handle_streaming(
+        _raw_bridge_logging_obj: Final = kwargs.get("litellm_logging_obj")
+        bridge_logging_obj: Final = (
+            _raw_bridge_logging_obj
+            if isinstance(_raw_bridge_logging_obj, Logging)
+            else _build_streaming_logging_obj(
+                request=request,
+                agent_name=str(litellm_params.get("agent_name") or "unknown"),
+                agent_id=agent_id,
+                litellm_params=litellm_params,
+                metadata=metadata,
+                proxy_server_request=proxy_server_request,
+            )
+        )
+        bridge_kwargs: Final[Mapping[str, object]] = MappingProxyType(
+            {**kwargs, "litellm_logging_obj": bridge_logging_obj}
+        )
+        _set_litellm_params_on_logging_obj(kwargs=bridge_kwargs, litellm_params=litellm_params)
+        _set_agent_id_on_logging_obj(kwargs=bridge_kwargs, agent_id=agent_id)
+
+        bridge_stream: Final = A2ACompletionBridgeHandler.handle_streaming(
             request_id=str(request.id),
             params=params,
             litellm_params=litellm_params,
             api_base=api_base,
             agent_extra_headers=agent_extra_headers,
+        )
+        # A2AStreamingIterator dispatches success handlers at stream end; without it bridge streams never spend-logged
+        async for chunk in A2AStreamingIterator(
+            stream=_strip_provider_cost_from_stream(bridge_stream, kwargs=bridge_kwargs),
+            request=request,
+            logging_obj=bridge_logging_obj,
+            agent_name=str(litellm_params.get("agent_name") or "unknown"),
         ):
             yield chunk
         return

--- a/litellm/a2a_protocol/providers/base.py
+++ b/litellm/a2a_protocol/providers/base.py
@@ -4,7 +4,10 @@ Base configuration for A2A protocol providers.
 
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator
-from typing import Any
+from typing import Any, Final
+
+# Providers report actual upstream cost via this key on a returned dict/yielded chunk; the bridge strips it.
+A2A_PROVIDER_RESPONSE_COST_KEY: Final = "_litellm_response_cost"
 
 
 class BaseA2AProviderConfig(ABC):

--- a/litellm/a2a_protocol/providers/config_manager.py
+++ b/litellm/a2a_protocol/providers/config_manager.py
@@ -51,6 +51,11 @@ class A2AProviderConfigManager:
 
             return LangFlowA2AConfig()
 
+        if custom_llm_provider == "tinyfish":
+            from litellm.a2a_protocol.providers.tinyfish.config import TinyfishA2AConfig
+
+            return TinyfishA2AConfig()
+
         if custom_llm_provider == "watsonx_orchestrate":
             from litellm.a2a_protocol.providers.watsonx_orchestrate.config import (
                 WatsonxOrchestrateA2AConfig,

--- a/litellm/a2a_protocol/providers/tinyfish/__init__.py
+++ b/litellm/a2a_protocol/providers/tinyfish/__init__.py
@@ -1,0 +1,3 @@
+from litellm.a2a_protocol.providers.tinyfish.config import TinyfishA2AConfig
+
+__all__ = ("TinyfishA2AConfig",)

--- a/litellm/a2a_protocol/providers/tinyfish/config.py
+++ b/litellm/a2a_protocol/providers/tinyfish/config.py
@@ -1,0 +1,44 @@
+"""A2A provider configuration for TinyFish Agent (goal-based web automation)."""
+
+from collections.abc import AsyncIterator, Mapping
+from typing import Final
+
+from litellm.a2a_protocol.providers.base import BaseA2AProviderConfig
+from litellm.a2a_protocol.providers.tinyfish.handler import TinyfishAgentHandler
+from litellm.a2a_protocol.providers.tinyfish.transformation import EMPTY_MAPPING, as_str_object_dict
+
+
+class TinyfishA2AConfig(BaseA2AProviderConfig):
+    """A2A bridge for the TinyFish Agent REST API (run-async + poll, native SSE)."""
+
+    async def handle_non_streaming(
+        self,
+        request_id: str,
+        params: Mapping[str, object],
+        api_base: str | None = None,
+        **kwargs: object,  # kwargs-ok: BaseA2AProviderConfig passes litellm_params via kwargs
+    ) -> dict[str, object]:  # mutable-ok: BaseA2AProviderConfig contract returns a plain dict
+        litellm_params: Final = as_str_object_dict(kwargs.get("litellm_params")) or EMPTY_MAPPING
+        result: Final = await TinyfishAgentHandler.handle_non_streaming(
+            request_id=request_id,
+            params=params,
+            litellm_params=litellm_params,
+            api_base=api_base,
+        )
+        return {**result}  # mutable-ok: response is JSON-serialized downstream; must be a plain dict
+
+    async def handle_streaming(
+        self,
+        request_id: str,
+        params: Mapping[str, object],
+        api_base: str | None = None,
+        **kwargs: object,  # kwargs-ok: BaseA2AProviderConfig passes litellm_params via kwargs
+    ) -> AsyncIterator[dict[str, object]]:  # mutable-ok: BaseA2AProviderConfig contract yields plain dicts
+        litellm_params: Final = as_str_object_dict(kwargs.get("litellm_params")) or EMPTY_MAPPING
+        async for chunk in TinyfishAgentHandler.handle_streaming(
+            request_id=request_id,
+            params=params,
+            litellm_params=litellm_params,
+            api_base=api_base,
+        ):
+            yield {**chunk}  # mutable-ok: chunks are JSON-serialized downstream; must be plain dicts

--- a/litellm/a2a_protocol/providers/tinyfish/handler.py
+++ b/litellm/a2a_protocol/providers/tinyfish/handler.py
@@ -1,0 +1,428 @@
+"""
+Handler for the TinyFish Agent provider: /run-async + poll /v1/runs/{id} for non-streaming
+(runs take minutes; blocking /run is fragile behind proxies, and poll-timeout cancels the run
+so it stops billing), native /run-sse for streaming.
+"""
+
+import asyncio
+import json
+import time
+from collections.abc import AsyncIterator, Mapping
+from types import MappingProxyType
+from typing import Final, NamedTuple
+from uuid import uuid4
+
+import httpx
+from pydantic import TypeAdapter, ValidationError
+
+from litellm._logging import verbose_logger
+from litellm.a2a_protocol.providers.base import A2A_PROVIDER_RESPONSE_COST_KEY
+from litellm.a2a_protocol.providers.tinyfish.transformation import (
+    EMPTY_MAPPING,
+    TERMINAL_RUN_STATUSES,
+    TinyfishAgentTransformation,
+    TinyfishRun,
+    as_str_object_dict,
+)
+from litellm.llms.custom_httpx.http_handler import (
+    AsyncHTTPHandler,
+    get_async_httpx_client,
+)
+from litellm.secret_managers.main import get_secret_str
+from litellm.types.llms.custom_http import httpxSpecialProvider
+
+_DEFAULT_API_BASE: Final = "https://agent.tinyfish.ai"
+_POLL_INTERVAL_S: Final = 2.0
+_DEFAULT_POLLING_TIMEOUT_S: Final = 600.0
+
+_RunAdapter: Final = TypeAdapter(TinyfishRun)
+_FloatAdapter: Final = TypeAdapter(float)
+
+
+class TinyfishRequestContext(NamedTuple):
+    api_key: str
+    api_base: str
+    cost_per_step: float | None
+    polling_timeout_s: float
+    allow_authenticated_runs: bool
+    default_request_params: Mapping[str, object]
+
+
+class TinyfishAgentHandler:
+    @staticmethod
+    def _http_client(timeout: float) -> AsyncHTTPHandler:
+        return get_async_httpx_client(
+            llm_provider=httpxSpecialProvider.A2AProvider,
+            params={"timeout": timeout},  # mutable-ok: get_async_httpx_client takes a plain dict of client params
+        )
+
+    @staticmethod
+    def _extract_litellm_params(
+        litellm_params: Mapping[str, object],
+        api_base: str | None,
+    ) -> TinyfishRequestContext:
+        configured_key: Final = litellm_params.get("api_key")
+        api_key: Final = (
+            configured_key if isinstance(configured_key, str) and configured_key else get_secret_str("TINYFISH_API_KEY")
+        )
+        if not api_key:
+            raise ValueError(
+                "TinyFish Agent: no API key. Set `api_key` in the agent's litellm_params "
+                "or the TINYFISH_API_KEY environment variable."
+            )
+
+        configured_base: Final = litellm_params.get("api_base")
+        resolved_base: Final = (
+            api_base
+            or (configured_base if isinstance(configured_base, str) and configured_base else None)
+            or get_secret_str("TINYFISH_AGENT_API_BASE")
+            or _DEFAULT_API_BASE
+        )
+
+        cost_per_step: Final = _validated_float(litellm_params.get("cost_per_step"), "cost_per_step")
+        polling_timeout: Final = _validated_float(
+            litellm_params.get("polling_timeout_seconds"), "polling_timeout_seconds"
+        )
+
+        return TinyfishRequestContext(
+            api_key=api_key,
+            api_base=resolved_base.rstrip("/"),
+            cost_per_step=cost_per_step,
+            polling_timeout_s=polling_timeout if polling_timeout is not None else _DEFAULT_POLLING_TIMEOUT_S,
+            allow_authenticated_runs=bool(litellm_params.get("allow_authenticated_runs")),
+            default_request_params=_validated_request_defaults(litellm_params.get("default_request_params")),
+        )
+
+    @staticmethod
+    def _auth_headers(api_key: str, accept: str = "application/json") -> dict[str, str]:  # mutable-ok: httpx dict param
+        return {  # mutable-ok: AsyncHTTPHandler.get/post take a plain dict for headers
+            "X-API-Key": api_key,
+            "Content-Type": "application/json",
+            "Accept": accept,
+        }
+
+    @staticmethod
+    def _parse_run(payload: object) -> TinyfishRun:
+        try:
+            return _RunAdapter.validate_python(payload)
+        except ValidationError as e:
+            raise RuntimeError(TinyfishAgentTransformation.wrap_error_message(f"unexpected response shape: {e}")) from e
+
+    @staticmethod
+    async def _submit_run(
+        ctx: TinyfishRequestContext,
+        body: Mapping[str, object],
+        client: AsyncHTTPHandler,
+    ) -> str:
+        try:
+            response: Final = await client.post(
+                f"{ctx.api_base}/v1/automation/run-async",
+                json={**body},  # mutable-ok: httpx json= serializes via json.dumps, which needs a plain dict
+                headers=TinyfishAgentHandler._auth_headers(ctx.api_key),
+            )
+        except httpx.HTTPStatusError as e:
+            raise RuntimeError(TinyfishAgentTransformation.wrap_error_message(_http_error_body(e))) from e
+
+        payload: Final[object] = response.json()  # any-ok: httpx Response.json() -> Any
+        run: Final = TinyfishAgentHandler._parse_run(payload)
+        error: Final = run.get("error")
+        run_id: Final = run.get("run_id")
+        if error or not run_id:
+            raise RuntimeError(TinyfishAgentTransformation.run_failure_message(run))
+        verbose_logger.info("TinyFish Agent: submitted run_id=%s", run_id)
+        return run_id
+
+    @staticmethod
+    async def _get_run(
+        ctx: TinyfishRequestContext,
+        run_id: str,
+        client: AsyncHTTPHandler,
+    ) -> TinyfishRun:
+        # screenshots=none keeps the poll payload small (no per-step screenshot URLs needed).
+        response: Final = await client.get(
+            f"{ctx.api_base}/v1/runs/{run_id}?screenshots=none",
+            headers=TinyfishAgentHandler._auth_headers(ctx.api_key),
+        )
+        if not (200 <= response.status_code < 300):
+            raise RuntimeError(TinyfishAgentTransformation.wrap_error_message(response.text))
+        payload: Final[object] = response.json()  # any-ok: httpx Response.json() -> Any
+        return TinyfishAgentHandler._parse_run(payload)
+
+    @staticmethod
+    async def _cancel_run(
+        ctx: TinyfishRequestContext,
+        run_id: str,
+        client: AsyncHTTPHandler,
+    ) -> None:
+        try:
+            await client.post(
+                f"{ctx.api_base}/v1/runs/{run_id}/cancel",
+                headers=TinyfishAgentHandler._auth_headers(ctx.api_key),
+            )
+        except Exception as e:  # noqa: BLE001  # best-effort cancel; the timeout error below matters more
+            verbose_logger.warning("TinyFish Agent: failed to cancel run %s after timeout: %r", run_id, e)
+
+    @staticmethod
+    async def _poll_until_terminal(
+        ctx: TinyfishRequestContext,
+        run_id: str,
+        client: AsyncHTTPHandler,
+    ) -> TinyfishRun:
+        deadline: Final = time.monotonic() + ctx.polling_timeout_s
+        while time.monotonic() < deadline:
+            await asyncio.sleep(_POLL_INTERVAL_S)
+            run = await TinyfishAgentHandler._get_run(ctx, run_id, client)
+            status = run.get("status") or ""
+            verbose_logger.debug("TinyFish Agent: poll run=%s status=%s", run_id, status)
+            if status in TERMINAL_RUN_STATUSES:
+                return run
+
+        await TinyfishAgentHandler._cancel_run(ctx, run_id, client)
+        raise RuntimeError(
+            TinyfishAgentTransformation.wrap_error_message(
+                f"run {run_id} did not finish within polling_timeout_seconds={ctx.polling_timeout_s:.0f}; "
+                "the run was cancelled"
+            )
+        )
+
+    @staticmethod
+    def _run_cost(ctx: TinyfishRequestContext, run: TinyfishRun) -> float | None:
+        num_of_steps: Final = run.get("num_of_steps")
+        if ctx.cost_per_step is None or num_of_steps is None:
+            return None
+        return num_of_steps * ctx.cost_per_step
+
+    @staticmethod
+    async def handle_non_streaming(
+        request_id: str,
+        params: Mapping[str, object],
+        litellm_params: Mapping[str, object],
+        api_base: str | None = None,
+    ) -> Mapping[str, object]:
+        ctx: Final = TinyfishAgentHandler._extract_litellm_params(litellm_params, api_base)
+        body: Final = TinyfishAgentTransformation.build_run_body(
+            params=params,
+            default_request_params=ctx.default_request_params,
+            allow_authenticated_runs=ctx.allow_authenticated_runs,
+        )
+        client: Final = TinyfishAgentHandler._http_client(timeout=30.0)
+
+        run_id: Final = await TinyfishAgentHandler._submit_run(ctx, body, client)
+        run: Final = await TinyfishAgentHandler._poll_until_terminal(ctx, run_id, client)
+
+        if run.get("status") != "COMPLETED":
+            raise RuntimeError(TinyfishAgentTransformation.run_failure_message(run))
+
+        response: Final = TinyfishAgentTransformation.build_a2a_message_response(request_id, run)
+        return TinyfishAgentTransformation.with_response_cost(response, TinyfishAgentHandler._run_cost(ctx, run))
+
+    @staticmethod
+    async def handle_streaming(
+        request_id: str,
+        params: Mapping[str, object],
+        litellm_params: Mapping[str, object],
+        api_base: str | None = None,
+    ) -> AsyncIterator[Mapping[str, object]]:
+        ctx: Final = TinyfishAgentHandler._extract_litellm_params(litellm_params, api_base)
+        body: Final = TinyfishAgentTransformation.build_run_body(
+            params=params,
+            default_request_params=ctx.default_request_params,
+            allow_authenticated_runs=ctx.allow_authenticated_runs,
+        )
+        client: Final = TinyfishAgentHandler._http_client(timeout=ctx.polling_timeout_s)
+
+        try:
+            response: Final = await client.post(
+                f"{ctx.api_base}/v1/automation/run-sse",
+                json={**body},  # mutable-ok: httpx json= serializes via json.dumps, which needs a plain dict
+                headers=TinyfishAgentHandler._auth_headers(ctx.api_key, accept="text/event-stream"),
+                stream=True,
+            )
+        except httpx.HTTPStatusError as e:
+            raise RuntimeError(TinyfishAgentTransformation.wrap_error_message(_http_error_body(e))) from e
+        except httpx.TransportError as exc:
+            verbose_logger.warning(
+                "TinyFish Agent: SSE request failed before a run was submitted (%r); "
+                "falling back to run-async + synthetic stream",
+                exc,
+            )
+            async for chunk in TinyfishAgentHandler._fallback_synthetic_stream(
+                request_id=request_id,
+                params=params,
+                litellm_params=litellm_params,
+                api_base=api_base,
+            ):
+                yield chunk
+            return
+
+        context_id: Final = str(uuid4())
+        task_id = ""  # rebind-ok: filled in by the first SSE event that carries a run_id
+        saw_terminal = False  # rebind-ok: flipped when the COMPLETE event arrives
+        try:
+            async for line in response.aiter_lines():
+                if not line.startswith("data:"):
+                    continue
+                data_str = line[5:].strip()
+                if not data_str:
+                    continue
+                try:
+                    event_payload: object = json.loads(data_str)  # any-ok: json.loads -> Any
+                    event = TinyfishAgentHandler._parse_run(event_payload)
+                except (json.JSONDecodeError, RuntimeError):
+                    verbose_logger.debug("TinyFish Agent: skipping unparseable SSE line")
+                    continue
+
+                event_type = event.get("type") or ""
+                task_id = event.get("run_id") or task_id or str(uuid4())
+
+                if event_type == "STARTED":
+                    yield TinyfishAgentTransformation.task_submitted_event(request_id, task_id, context_id)
+                elif event_type == "STREAMING_URL":
+                    streaming_url = event.get("streaming_url") or ""
+                    yield TinyfishAgentTransformation.working_status_event(
+                        request_id, task_id, context_id, f"Watch live: {streaming_url}"
+                    )
+                elif event_type == "PROGRESS":
+                    yield TinyfishAgentTransformation.working_status_event(
+                        request_id, task_id, context_id, event.get("purpose") or ""
+                    )
+                elif event_type == "COMPLETE":
+                    saw_terminal = True
+                    async for chunk in TinyfishAgentHandler._terminal_events(
+                        ctx=ctx,
+                        request_id=request_id,
+                        task_id=task_id,
+                        context_id=context_id,
+                        event=event,
+                        client=client,
+                    ):
+                        yield chunk
+        finally:
+            if hasattr(response, "aclose"):
+                await response.aclose()
+
+        if saw_terminal:
+            return
+        if not task_id:
+            raise RuntimeError(
+                TinyfishAgentTransformation.wrap_error_message("SSE stream ended before a run was started")
+            )
+        # TinyFish SSE has no reconnection; the run may still finish server-side.
+        yield TinyfishAgentTransformation.final_status_event(
+            request_id,
+            task_id,
+            context_id,
+            state="failed",
+            message_text=TinyfishAgentTransformation.wrap_error_message(
+                f"SSE stream ended before the run finished; check GET /v1/runs/{task_id} for the final result"
+            ),
+        )
+
+    @staticmethod
+    async def _run_with_steps(
+        ctx: TinyfishRequestContext,
+        task_id: str,
+        client: AsyncHTTPHandler,
+        event: TinyfishRun,
+    ) -> TinyfishRun:
+        """The COMPLETE event carries no num_of_steps; one run fetch prices the run."""
+        if ctx.cost_per_step is None or not task_id:
+            return event
+        try:
+            return await TinyfishAgentHandler._get_run(ctx, task_id, client)
+        except Exception as e:  # noqa: BLE001  # never fail a finished stream over cost lookup
+            verbose_logger.warning("TinyFish Agent: could not fetch run %s for cost: %r", task_id, e)
+            return event
+
+    @staticmethod
+    async def _terminal_events(
+        ctx: TinyfishRequestContext,
+        request_id: str,
+        task_id: str,
+        context_id: str,
+        event: TinyfishRun,
+        client: AsyncHTTPHandler,
+    ) -> AsyncIterator[Mapping[str, object]]:
+        """Emit artifact + final status for a COMPLETE SSE event, with actual-cost lookup."""
+        run: Final = await TinyfishAgentHandler._run_with_steps(ctx, task_id, client, event)
+        cost: Final = TinyfishAgentHandler._run_cost(ctx, run)
+
+        if event.get("status") == "COMPLETED":
+            # The COMPLETE event's result is authoritative; the fetched run adds num_of_steps.
+            artifact_run: Final = _RunAdapter.validate_python(
+                MappingProxyType({**run, "result": event.get("result") if "result" in event else run.get("result")})
+            )
+            yield TinyfishAgentTransformation.artifact_event(request_id, task_id, context_id, artifact_run)
+            yield TinyfishAgentTransformation.with_response_cost(
+                TinyfishAgentTransformation.final_status_event(request_id, task_id, context_id, state="completed"),
+                cost,
+            )
+            return
+
+        yield TinyfishAgentTransformation.with_response_cost(
+            TinyfishAgentTransformation.final_status_event(
+                request_id,
+                task_id,
+                context_id,
+                state="failed",
+                message_text=TinyfishAgentTransformation.run_failure_message(event),
+            ),
+            cost,
+        )
+
+    @staticmethod
+    async def _fallback_synthetic_stream(
+        request_id: str,
+        params: Mapping[str, object],
+        litellm_params: Mapping[str, object],
+        api_base: str | None,
+    ) -> AsyncIterator[Mapping[str, object]]:
+        response: Final = await TinyfishAgentHandler.handle_non_streaming(
+            request_id=request_id,
+            params=params,
+            litellm_params=litellm_params,
+            api_base=api_base,
+        )
+        raw_cost: Final = response.get(A2A_PROVIDER_RESPONSE_COST_KEY)
+        cost: Final = float(raw_cost) if isinstance(raw_cost, (int, float)) else None
+        result: Final = as_str_object_dict(response.get("result")) or EMPTY_MAPPING
+
+        task_id: Final = str(uuid4())
+        context_id: Final = str(uuid4())
+        yield TinyfishAgentTransformation.task_submitted_event(request_id, task_id, context_id)
+        yield TinyfishAgentTransformation.artifact_event_from_parts(
+            request_id=request_id,
+            task_id=task_id,
+            context_id=context_id,
+            parts=result.get("parts", ()),
+            metadata=result.get("metadata", EMPTY_MAPPING),
+        )
+        yield TinyfishAgentTransformation.with_response_cost(
+            TinyfishAgentTransformation.final_status_event(request_id, task_id, context_id, state="completed"),
+            cost,
+        )
+
+
+def _validated_float(value: object, field_name: str) -> float | None:
+    if value is None:
+        return None
+    try:
+        return _FloatAdapter.validate_python(value)
+    except ValidationError:
+        raise ValueError(f"TinyFish Agent: `{field_name}` in litellm_params must be a number, got {value!r}.")
+
+
+def _validated_request_defaults(value: object) -> Mapping[str, object]:
+    if value is None:
+        return EMPTY_MAPPING
+    validated: Final = as_str_object_dict(value)
+    if validated is None:
+        raise ValueError("TinyFish Agent: `default_request_params` in litellm_params must be an object.")
+    return validated
+
+
+def _http_error_body(e: httpx.HTTPStatusError) -> str:
+    masked_body: Final = getattr(e, "message", None)
+    if isinstance(masked_body, str) and masked_body:
+        return masked_body
+    return str(e)

--- a/litellm/a2a_protocol/providers/tinyfish/transformation.py
+++ b/litellm/a2a_protocol/providers/tinyfish/transformation.py
@@ -1,0 +1,363 @@
+"""
+Transformation layer for the TinyFish Agent provider (goal-based web automation REST API).
+Docs: https://docs.tinyfish.ai/agent-api
+"""
+
+import json
+from collections.abc import Mapping
+from types import MappingProxyType
+from typing import Final
+from uuid import uuid4
+
+from pydantic import TypeAdapter, ValidationError
+from typing_extensions import NotRequired, ReadOnly, TypedDict
+
+from litellm._logging import verbose_logger
+
+TINYFISH_AGENT_DOCS_URL: Final = "https://docs.tinyfish.ai/agent-api"
+
+# Fields that run with the TinyFish account's saved logins/vault; admin-opt-in behind a shared key.
+AUTHENTICATED_RUN_FIELDS: Final = frozenset({"use_profile", "profile_id", "use_vault", "credential_item_ids"})
+
+TERMINAL_RUN_STATUSES: Final = frozenset({"COMPLETED", "FAILED", "CANCELLED"})
+
+_StrObjectDict: Final = TypeAdapter(Mapping[str, object])
+
+EMPTY_MAPPING: Final[Mapping[str, object]] = MappingProxyType({})
+
+
+class TinyfishRunError(TypedDict, total=False):
+    """Fields read from a TinyFish run-level error object."""
+
+    code: ReadOnly[str]
+    message: ReadOnly[str]
+    category: ReadOnly[str]
+    retry_after: ReadOnly[float]
+    help_url: ReadOnly[str]
+
+
+class TinyfishRun(TypedDict, total=False):
+    """Fields read from TinyFish run objects and run-async/SSE payloads; most are null until terminal."""
+
+    run_id: ReadOnly[str | None]
+    status: ReadOnly[str | None]
+    num_of_steps: ReadOnly[int | None]
+    result: ReadOnly[object]
+    error: ReadOnly[TinyfishRunError | None]
+    type: ReadOnly[str | None]
+    purpose: ReadOnly[str | None]
+    streaming_url: ReadOnly[str | None]
+
+
+class A2AJsonRpcEvent(TypedDict):
+    """JSON-RPC envelope for A2A responses/stream events, plus the reserved bridge cost key."""
+
+    jsonrpc: ReadOnly[str]
+    id: ReadOnly[str]
+    result: ReadOnly[object]
+    _litellm_response_cost: NotRequired[ReadOnly[float]]
+
+
+class A2APart(TypedDict, total=False):
+    kind: ReadOnly[str]
+    text: ReadOnly[str]
+    data: ReadOnly[object]
+
+
+class A2AAgentMessage(TypedDict, total=False):
+    contextId: ReadOnly[str]
+    kind: ReadOnly[str]
+    messageId: ReadOnly[str]
+    parts: ReadOnly[tuple[A2APart, ...]]
+    role: ReadOnly[str]
+    taskId: ReadOnly[str]
+
+
+def as_str_object_dict(value: object) -> Mapping[str, object] | None:
+    """Validated read-only view of an untyped payload; the runtime object stays a plain dict."""
+    if not isinstance(value, dict):
+        return None
+    try:
+        return _StrObjectDict.validate_python(value)
+    except ValidationError:
+        return None
+
+
+class TinyfishAgentTransformation:
+    """Request/response transformation between A2A and the TinyFish Agent REST API."""
+
+    @staticmethod
+    def build_run_body(
+        params: Mapping[str, object],
+        default_request_params: Mapping[str, object],
+        allow_authenticated_runs: bool,
+    ) -> Mapping[str, object]:
+        """Text parts form the goal, message.metadata carries url and other fields (forwarded
+        permissively); a single text part that is a JSON object with a `goal` key is the body itself."""
+        message: Final = as_str_object_dict(params.get("message")) or EMPTY_MAPPING
+
+        text_parts: Final = _text_parts(message)
+        goal_text: Final = " ".join(text_parts)
+        body_from_text: Final = _parse_json_goal(text_parts)
+        metadata: Final = as_str_object_dict(message.get("metadata")) or EMPTY_MAPPING
+
+        caller_fields: Final = MappingProxyType({**metadata, **(body_from_text or EMPTY_MAPPING)})
+        sanitized_caller_fields: Final = _strip_authenticated_fields(caller_fields, allow_authenticated_runs)
+        goal_seed: Final = (
+            MappingProxyType({"goal": goal_text}) if goal_text and body_from_text is None else EMPTY_MAPPING
+        )
+
+        merged: Final = MappingProxyType({**goal_seed, **default_request_params, **sanitized_caller_fields})
+
+        goal: Final = merged.get("goal")
+        if not isinstance(goal, str) or not goal.strip():
+            raise ValueError(
+                "TinyFish Agent: request has no goal. Send the goal as the message's text part. "
+                f"See {TINYFISH_AGENT_DOCS_URL} for details."
+            )
+        url: Final = merged.get("url")
+        if not isinstance(url, str) or not url.strip():
+            raise ValueError(
+                "TinyFish Agent: request has no target url. Set `url` in the message's `metadata` "
+                f"(or in the agent's default_request_params). See {TINYFISH_AGENT_DOCS_URL} for details."
+            )
+        return merged
+
+    @staticmethod
+    def build_a2a_message_response(request_id: str, run: TinyfishRun) -> A2AJsonRpcEvent:
+        """Build the A2A SendMessageResponse for a COMPLETED TinyFish run."""
+        response: Final[A2AJsonRpcEvent] = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": {
+                "kind": "message",
+                "role": "agent",
+                "parts": _result_parts(run.get("result")),
+                "messageId": str(uuid4()),
+                "metadata": _run_correlation_metadata(run),
+            },
+        }
+        return response
+
+    @staticmethod
+    def run_failure_message(run: TinyfishRun) -> str:
+        """Human-readable, attributed message for a FAILED/CANCELLED run."""
+        status: Final = run.get("status") or "FAILED"
+        error: Final = run.get("error")
+        if not isinstance(error, dict):
+            return TinyfishAgentTransformation.wrap_error_message(f"run ended with status {status}")
+        detail_pairs: Final = (
+            ("category", error.get("category")),
+            ("retry_after", error.get("retry_after")),
+            ("help_url", error.get("help_url")),
+        )
+        details: Final = ", ".join(f"{name}={value}" for name, value in detail_pairs if value is not None)
+        message: Final = str(error.get("message") or f"run ended with status {status}")
+        suffix: Final = f" ({details})" if details else ""
+        return TinyfishAgentTransformation.wrap_error_message(f"{message}{suffix}")
+
+    @staticmethod
+    def wrap_error_message(message: str) -> str:
+        """Attribute an error to TinyFish Agent with a docs pointer."""
+        inner: Final = _unwrap_error_envelope(message)
+        return f"TinyFish Agent: {inner}. See {TINYFISH_AGENT_DOCS_URL} for details."
+
+    @staticmethod
+    def task_submitted_event(request_id: str, task_id: str, context_id: str) -> A2AJsonRpcEvent:
+        event: Final[A2AJsonRpcEvent] = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": {
+                "contextId": context_id,
+                "id": task_id,
+                "kind": "task",
+                "status": {"state": "submitted"},
+            },
+        }
+        return event
+
+    @staticmethod
+    def working_status_event(
+        request_id: str,
+        task_id: str,
+        context_id: str,
+        message_text: str,
+    ) -> A2AJsonRpcEvent:
+        event: Final[A2AJsonRpcEvent] = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": {
+                "contextId": context_id,
+                "final": False,
+                "kind": "status-update",
+                "status": {
+                    "state": "working",
+                    "message": _agent_message(task_id, context_id, message_text),
+                },
+                "taskId": task_id,
+            },
+        }
+        return event
+
+    @staticmethod
+    def artifact_event(
+        request_id: str,
+        task_id: str,
+        context_id: str,
+        run: TinyfishRun,
+    ) -> A2AJsonRpcEvent:
+        return TinyfishAgentTransformation.artifact_event_from_parts(
+            request_id=request_id,
+            task_id=task_id,
+            context_id=context_id,
+            parts=_result_parts(run.get("result")),
+            metadata=_run_correlation_metadata(run),
+        )
+
+    @staticmethod
+    def artifact_event_from_parts(
+        request_id: str,
+        task_id: str,
+        context_id: str,
+        parts: object,
+        metadata: object,
+    ) -> A2AJsonRpcEvent:
+        event: Final[A2AJsonRpcEvent] = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": {
+                "artifact": {
+                    "artifactId": str(uuid4()),
+                    "name": "tinyfish_run_result",
+                    "parts": parts,
+                    "metadata": metadata,
+                },
+                "contextId": context_id,
+                "kind": "artifact-update",
+                "taskId": task_id,
+            },
+        }
+        return event
+
+    @staticmethod
+    def final_status_event(
+        request_id: str,
+        task_id: str,
+        context_id: str,
+        state: str,
+        message_text: str | None = None,
+    ) -> A2AJsonRpcEvent:
+        event: Final[A2AJsonRpcEvent] = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": {
+                "contextId": context_id,
+                "final": True,
+                "kind": "status-update",
+                "status": {
+                    "state": state,
+                    **({"message": _agent_message(task_id, context_id, message_text)} if message_text else {}),
+                },
+                "taskId": task_id,
+            },
+        }
+        return event
+
+    @staticmethod
+    def with_response_cost(event: A2AJsonRpcEvent, response_cost: float | None) -> A2AJsonRpcEvent:
+        """Attach the reserved bridge cost key; the bridge strips it before the wire."""
+        if response_cost is None:
+            return event
+        augmented: Final[A2AJsonRpcEvent] = {**event, "_litellm_response_cost": response_cost}
+        return augmented
+
+
+def _agent_message(task_id: str, context_id: str, message_text: str) -> A2AAgentMessage:
+    message: Final[A2AAgentMessage] = {
+        "contextId": context_id,
+        "kind": "message",
+        "messageId": str(uuid4()),
+        "parts": ({"kind": "text", "text": message_text},),
+        "role": "agent",
+        "taskId": task_id,
+    }
+    return message
+
+
+def _result_parts(result_obj: object) -> tuple[A2APart, ...]:
+    """A dict result ships as a lossless data part plus a text rendering; anything else as text."""
+    if isinstance(result_obj, dict):
+        data_part: Final[A2APart] = {"kind": "data", "data": result_obj}
+        text_part: Final[A2APart] = {"kind": "text", "text": json.dumps(result_obj, separators=(",", ":"))}
+        return (data_part, text_part)
+    text: Final = result_obj if isinstance(result_obj, str) else json.dumps(result_obj, separators=(",", ":"))
+    lone_part: Final[A2APart] = {"kind": "text", "text": text}
+    return (lone_part,)
+
+
+def _text_parts(message: Mapping[str, object]) -> tuple[str, ...]:
+    parts_obj: Final = message.get("parts")
+    parts: Final[tuple[object, ...]] = tuple(parts_obj) if isinstance(parts_obj, list) else ()
+    part_dicts: Final = tuple(part for part in (as_str_object_dict(item) for item in parts) if part is not None)
+    return tuple(
+        str(part["text"]) for part in part_dicts if part.get("kind") in (None, "", "text") and part.get("text")
+    )
+
+
+def _parse_json_goal(text_parts: tuple[str, ...]) -> Mapping[str, object] | None:
+    """A single text part that is a JSON object with a ``goal`` key is the run body."""
+    if len(text_parts) != 1:
+        return None
+    try:
+        parsed: Final[object] = json.loads(text_parts[0])  # any-ok: json.loads -> Any
+    except json.JSONDecodeError:
+        return None
+    body: Final = as_str_object_dict(parsed)
+    if body is not None and isinstance(body.get("goal"), str):
+        return body
+    return None
+
+
+def _strip_authenticated_fields(
+    caller_fields: Mapping[str, object],
+    allow_authenticated_runs: bool,
+) -> Mapping[str, object]:
+    if allow_authenticated_runs:
+        return caller_fields
+    stripped: Final = tuple(key for key in caller_fields if key in AUTHENTICATED_RUN_FIELDS)
+    if stripped:
+        verbose_logger.warning(
+            "TinyFish Agent: dropping caller-supplied credentialed-run fields %s; "
+            "set `allow_authenticated_runs: true` in the agent's litellm_params to permit them.",
+            stripped,
+        )
+    return MappingProxyType({key: value for key, value in caller_fields.items() if key not in AUTHENTICATED_RUN_FIELDS})
+
+
+def _run_correlation_metadata(run: TinyfishRun) -> dict[str, object]:  # mutable-ok: embedded in the JSON response
+    """run_id/status/num_of_steps let callers correlate with TinyFish server-side logs."""
+    return {  # mutable-ok: embedded in the JSON response; must stay a plain serializable dict
+        key: value
+        for key, value in (
+            ("tinyfish_run_id", run.get("run_id")),
+            ("tinyfish_status", run.get("status")),
+            ("tinyfish_num_of_steps", run.get("num_of_steps")),
+        )
+        if value is not None
+    }
+
+
+def _unwrap_error_envelope(message: str) -> str:
+    """Best-effort unwrap of TinyFish's ``{"error": {code, message}}`` envelope."""
+    try:
+        parsed: Final[object] = json.loads(message)  # any-ok: json.loads -> Any
+    except (json.JSONDecodeError, TypeError):
+        return message
+    body: Final = as_str_object_dict(parsed)
+    error_obj: Final = as_str_object_dict(body.get("error")) if body is not None else None
+    if error_obj is None:
+        return message
+    candidate: Final = error_obj.get("message")
+    if isinstance(candidate, str) and candidate:
+        return candidate
+    return message

--- a/litellm/a2a_protocol/streaming_iterator.py
+++ b/litellm/a2a_protocol/streaming_iterator.py
@@ -3,7 +3,7 @@ A2A Streaming Iterator with token tracking and logging support.
 """
 
 import asyncio
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Mapping
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Final
 
@@ -26,7 +26,7 @@ class A2AStreamingIterator:
 
     def __init__(
         self,
-        stream: AsyncIterator["SendStreamingMessageResponse"],
+        stream: AsyncIterator["SendStreamingMessageResponse | Mapping[str, object]"],
         request: "SendStreamingMessageRequest",
         logging_obj: LiteLLMLoggingObj,
         agent_name: str = "unknown",
@@ -45,7 +45,7 @@ class A2AStreamingIterator:
     def __aiter__(self):
         return self
 
-    async def __anext__(self) -> "SendStreamingMessageResponse":
+    async def __anext__(self) -> "SendStreamingMessageResponse | Mapping[str, object]":
         try:
             chunk: Final = await self.stream.__anext__()
 
@@ -68,11 +68,21 @@ class A2AStreamingIterator:
             await self._handle_stream_complete()
             raise
 
+    @staticmethod
+    def _chunk_as_dict(chunk: object) -> Mapping[str, object]:
+        """Bridge provider configs yield plain dicts; the native path yields SDK models."""
+        if isinstance(chunk, dict):
+            return chunk
+        dumper: Final = getattr(chunk, "model_dump", None)
+        if not callable(dumper):
+            return {}
+        dumped: Final[object] = dumper(mode="json", exclude_none=True)  # any-ok: SDK model_dump -> Any
+        return dumped if isinstance(dumped, dict) else {}
+
     def _collect_text_from_chunk(self, chunk: Any) -> None:
         """Extract text from a streaming chunk and add to collected parts."""
         try:
-            chunk_dict: Final = chunk.model_dump(mode="json", exclude_none=True) if hasattr(chunk, "model_dump") else {}
-            text: Final = A2ARequestUtils.extract_text_from_response(chunk_dict)
+            text: Final = A2ARequestUtils.extract_text_from_response(self._chunk_as_dict(chunk))
             if text:
                 self.collected_text_parts.append(text)
         except Exception:
@@ -81,7 +91,7 @@ class A2AStreamingIterator:
     def _is_completed_chunk(self, chunk: Any) -> bool:
         """Check if chunk indicates stream completion."""
         try:
-            chunk_dict: Final = chunk.model_dump(mode="json", exclude_none=True) if hasattr(chunk, "model_dump") else {}
+            chunk_dict: Final = self._chunk_as_dict(chunk)
             result: Final = chunk_dict.get("result", {})
             if isinstance(result, dict):
                 status: Final = result.get("status", {})
@@ -159,7 +169,7 @@ class A2AStreamingIterator:
         # Add final chunk result if available
         if self.final_chunk:
             try:
-                chunk_dict: Final = self.final_chunk.model_dump(mode="json", exclude_none=True)
+                chunk_dict: Final = self._chunk_as_dict(self.final_chunk)
                 result["result"] = chunk_dict.get("result", {})
             except Exception:
                 pass

--- a/litellm/proxy/agent_endpoints/a2a_endpoints.py
+++ b/litellm/proxy/agent_endpoints/a2a_endpoints.py
@@ -724,9 +724,11 @@ async def invoke_agent_a2a(
                 A2A_USER_API_KEY_HASH_PARAM,
             )
 
+            # agent_name rides along so bridge streaming spend logs name the agent instead of "unknown"
             litellm_params = {
                 **litellm_params,
                 A2A_USER_API_KEY_HASH_PARAM: user_api_key_dict.api_key,
+                "agent_name": str(agent_name),
             }
 
         # URL is required unless using completion bridge with a provider that derives endpoint from model

--- a/litellm/proxy/public_endpoints/agent_create_fields.json
+++ b/litellm/proxy/public_endpoints/agent_create_fields.json
@@ -305,6 +305,37 @@
     "litellm_params_template": {
       "custom_llm_provider": "watsonx_orchestrate"
     }
+  },
+  {
+    "agent_type": "tinyfish",
+    "agent_type_display_name": "TinyFish",
+    "description": "Goal-based web automation via the TinyFish Agent API",
+    "logo_url": "/ui/assets/logos/a2a_agent.png",
+    "credential_fields": [
+      {
+        "key": "api_key",
+        "label": "TinyFish API Key",
+        "placeholder": null,
+        "tooltip": "API key from agent.tinyfish.ai/api-keys (sent as X-API-Key). Falls back to the TINYFISH_API_KEY environment variable.",
+        "required": false,
+        "field_type": "password",
+        "default_value": null,
+        "include_in_litellm_params": true
+      },
+      {
+        "key": "cost_per_step",
+        "label": "Cost per Step (USD)",
+        "placeholder": "0.016",
+        "tooltip": "Spend logged per run = num_of_steps x this rate (TinyFish lists $0.016/step). Leave empty to log $0 or use cost_per_query for a flat per-run rate.",
+        "required": false,
+        "field_type": "text",
+        "default_value": null,
+        "include_in_litellm_params": true
+      }
+    ],
+    "litellm_params_template": {
+      "custom_llm_provider": "tinyfish"
+    }
   }
 ]
 

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -2492,7 +2492,8 @@
       "display_name": "TinyFish (`tinyfish`)",
       "url": "https://docs.tinyfish.ai/search-api",
       "endpoints": {
-        "search": true
+        "search": true,
+        "a2a": true
       }
     },
     "nimble": {

--- a/tests/test_litellm/a2a_protocol/providers/tinyfish/test_tinyfish_a2a.py
+++ b/tests/test_litellm/a2a_protocol/providers/tinyfish/test_tinyfish_a2a.py
@@ -1,0 +1,322 @@
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+from litellm.a2a_protocol.providers.base import A2A_PROVIDER_RESPONSE_COST_KEY
+from litellm.a2a_protocol.providers.config_manager import A2AProviderConfigManager
+from litellm.a2a_protocol.providers.tinyfish import handler as tinyfish_handler
+from litellm.a2a_protocol.providers.tinyfish.handler import TinyfishAgentHandler
+from litellm.a2a_protocol.providers.tinyfish.transformation import (
+    TINYFISH_AGENT_DOCS_URL,
+    TinyfishAgentTransformation,
+)
+
+_PARAMS = {
+    "message": {
+        "role": "user",
+        "parts": [{"kind": "text", "text": "Extract the page title"}],
+        "metadata": {"url": "https://example.com"},
+    }
+}
+_LITELLM_PARAMS = {"api_key": "sk-tf", "cost_per_step": 0.016}
+
+
+class _JsonResponse:
+    def __init__(self, payload, status_code=200):
+        self.payload = payload
+        self.status_code = status_code
+        self.text = json.dumps(payload)
+
+    def json(self):
+        return self.payload
+
+
+class _MaskedStatusError(httpx.HTTPStatusError):
+    def __init__(self, body, status_code=402):
+        request = httpx.Request("POST", "https://agent.tinyfish.ai/v1/automation/run-async")
+        response = httpx.Response(status_code, request=request, text=body)
+        super().__init__(body, request=request, response=response)
+        self.message = body
+
+
+class _SSEResponse:
+    def __init__(self, lines):
+        self.lines = lines
+        self.closed = False
+
+    async def aiter_lines(self):
+        for line in self.lines:
+            yield line
+
+    async def aclose(self):
+        self.closed = True
+
+
+class _FakeClient:
+    """Serves /run-async, /run-sse, /v1/runs/{id}, and /cancel from canned payloads."""
+
+    def __init__(self, run_payloads=(), sse_lines=None, submit_error=None, sse_error=None):
+        self.run_payloads = list(run_payloads)
+        self.sse_lines = sse_lines
+        self.submit_error = submit_error
+        self.sse_error = sse_error
+        self.post_urls = []
+        self.get_urls = []
+        self.post_headers = []
+        self.post_bodies = []
+
+    async def post(self, url, json=None, headers=None, stream=False):
+        self.post_urls.append(url)
+        self.post_headers.append(headers or {})
+        self.post_bodies.append(json)
+        if url.endswith("/run-sse"):
+            if self.sse_error is not None:
+                raise self.sse_error
+            return _SSEResponse(self.sse_lines or [])
+        if url.endswith("/run-async"):
+            if self.submit_error is not None:
+                raise self.submit_error
+            return _JsonResponse({"run_id": "run-123", "error": None})
+        if url.endswith("/cancel"):
+            return _JsonResponse({"run_id": "run-123", "status": "CANCELLED"})
+        raise AssertionError(url)
+
+    async def get(self, url, headers=None):
+        self.get_urls.append(url)
+        if not self.run_payloads:
+            raise AssertionError(f"unexpected GET {url}")
+        return _JsonResponse(self.run_payloads.pop(0))
+
+
+def _install_client(monkeypatch, client):
+    monkeypatch.setattr(TinyfishAgentHandler, "_http_client", staticmethod(lambda timeout: client))
+    monkeypatch.setattr(tinyfish_handler, "_POLL_INTERVAL_S", 0.0)
+
+
+class TestBuildRunBody:
+    def test_goal_from_text_and_url_from_metadata(self):
+        body = TinyfishAgentTransformation.build_run_body(_PARAMS, {}, allow_authenticated_runs=False)
+        assert body == {"url": "https://example.com", "goal": "Extract the page title"}
+
+    def test_metadata_fields_forwarded_and_override_defaults(self):
+        params = {
+            "message": {
+                "parts": [{"kind": "text", "text": "go"}],
+                "metadata": {"url": "https://a.dev", "browser_profile": "stealth", "output_schema": {"type": "object"}},
+            }
+        }
+        body = TinyfishAgentTransformation.build_run_body(
+            params, {"browser_profile": "lite", "proxy_config": {"enabled": True}}, allow_authenticated_runs=False
+        )
+        assert body["browser_profile"] == "stealth"
+        assert body["proxy_config"] == {"enabled": True}
+        assert body["output_schema"] == {"type": "object"}
+
+    def test_single_json_text_part_is_the_body(self):
+        text = json.dumps({"goal": "Buy the item", "url": "https://shop.dev", "agent_config": {"max_steps": 20}})
+        params = {"message": {"parts": [{"kind": "text", "text": text}]}}
+        body = TinyfishAgentTransformation.build_run_body(params, {}, allow_authenticated_runs=False)
+        assert body == {"goal": "Buy the item", "url": "https://shop.dev", "agent_config": {"max_steps": 20}}
+
+    def test_authenticated_fields_stripped_unless_allowed(self):
+        params = {
+            "message": {
+                "parts": [{"kind": "text", "text": "go"}],
+                "metadata": {"url": "https://a.dev", "use_vault": True, "profile_id": "prof_1", "use_profile": True},
+            }
+        }
+        stripped = TinyfishAgentTransformation.build_run_body(params, {}, allow_authenticated_runs=False)
+        assert "use_vault" not in stripped and "profile_id" not in stripped and "use_profile" not in stripped
+        allowed = TinyfishAgentTransformation.build_run_body(params, {}, allow_authenticated_runs=True)
+        assert allowed["use_vault"] is True and allowed["profile_id"] == "prof_1"
+
+    def test_admin_default_authenticated_fields_survive_stripping(self):
+        body = TinyfishAgentTransformation.build_run_body(
+            _PARAMS, {"use_profile": True, "profile_id": "prof_admin"}, allow_authenticated_runs=False
+        )
+        assert body["use_profile"] is True and body["profile_id"] == "prof_admin"
+
+    def test_missing_goal_raises(self):
+        with pytest.raises(ValueError, match="no goal"):
+            TinyfishAgentTransformation.build_run_body(
+                {"message": {"parts": [], "metadata": {"url": "https://a.dev"}}}, {}, False
+            )
+
+    def test_missing_url_raises_with_docs_pointer(self):
+        with pytest.raises(ValueError, match="metadata"):
+            TinyfishAgentTransformation.build_run_body(
+                {"message": {"parts": [{"kind": "text", "text": "go"}]}}, {}, False
+            )
+
+
+class TestResponseTransform:
+    def test_dict_result_gets_data_and_text_parts(self):
+        run = {"run_id": "r1", "status": "COMPLETED", "num_of_steps": 5, "result": {"title": "T"}}
+        response = TinyfishAgentTransformation.build_a2a_message_response("req1", run)
+        result = response["result"]
+        assert result["kind"] == "message" and result["role"] == "agent"
+        assert result["parts"][0] == {"kind": "data", "data": {"title": "T"}}
+        assert json.loads(result["parts"][1]["text"]) == {"title": "T"}
+        assert result["metadata"] == {
+            "tinyfish_run_id": "r1",
+            "tinyfish_status": "COMPLETED",
+            "tinyfish_num_of_steps": 5,
+        }
+
+    def test_string_result_is_single_text_part(self):
+        run = {"run_id": "r1", "status": "COMPLETED", "result": "plain answer"}
+        response = TinyfishAgentTransformation.build_a2a_message_response("req1", run)
+        assert response["result"]["parts"] == ({"kind": "text", "text": "plain answer"},)
+
+    def test_run_failure_message_carries_error_details(self):
+        run = {
+            "run_id": "r1",
+            "status": "FAILED",
+            "error": {"message": "Site blocked", "category": "AGENT_FAILURE", "retry_after": 60},
+        }
+        message = TinyfishAgentTransformation.run_failure_message(run)
+        assert "TinyFish Agent: Site blocked" in message
+        assert "category=AGENT_FAILURE" in message and "retry_after=60" in message
+        assert TINYFISH_AGENT_DOCS_URL in message
+
+    def test_wrap_error_unwraps_tinyfish_envelope(self):
+        wrapped = TinyfishAgentTransformation.wrap_error_message(
+            json.dumps({"error": {"code": "INVALID_API_KEY", "message": "The provided API key is invalid"}})
+        )
+        assert wrapped == f"TinyFish Agent: The provided API key is invalid. See {TINYFISH_AGENT_DOCS_URL} for details."
+
+
+@pytest.mark.asyncio
+class TestHandleNonStreaming:
+    async def test_submit_poll_complete_with_step_cost(self, monkeypatch):
+        client = _FakeClient(
+            run_payloads=[
+                {"run_id": "run-123", "status": "RUNNING"},
+                {"run_id": "run-123", "status": "COMPLETED", "num_of_steps": 7, "result": {"title": "T"}},
+            ]
+        )
+        _install_client(monkeypatch, client)
+
+        response = await TinyfishAgentHandler.handle_non_streaming("req1", _PARAMS, _LITELLM_PARAMS)
+
+        assert client.post_urls == ["https://agent.tinyfish.ai/v1/automation/run-async"]
+        assert client.post_headers[0]["X-API-Key"] == "sk-tf"
+        assert client.post_bodies[0] == {"url": "https://example.com", "goal": "Extract the page title"}
+        assert all(url.endswith("/v1/runs/run-123?screenshots=none") for url in client.get_urls)
+        assert response[A2A_PROVIDER_RESPONSE_COST_KEY] == pytest.approx(7 * 0.016)
+        assert response["result"]["metadata"]["tinyfish_num_of_steps"] == 7
+
+    async def test_no_cost_key_without_cost_per_step(self, monkeypatch):
+        client = _FakeClient(run_payloads=[{"run_id": "run-123", "status": "COMPLETED", "result": {}}])
+        _install_client(monkeypatch, client)
+        response = await TinyfishAgentHandler.handle_non_streaming("req1", _PARAMS, {"api_key": "sk-tf"})
+        assert A2A_PROVIDER_RESPONSE_COST_KEY not in response
+
+    async def test_failed_run_raises_attributed_error(self, monkeypatch):
+        client = _FakeClient(
+            run_payloads=[
+                {"run_id": "run-123", "status": "FAILED", "error": {"message": "boom", "category": "SYSTEM_FAILURE"}}
+            ]
+        )
+        _install_client(monkeypatch, client)
+        with pytest.raises(RuntimeError, match="TinyFish Agent: boom"):
+            await TinyfishAgentHandler.handle_non_streaming("req1", _PARAMS, _LITELLM_PARAMS)
+
+    async def test_submit_http_error_is_attributed(self, monkeypatch):
+        body = json.dumps({"error": {"code": "INSUFFICIENT_CREDITS", "message": "wallet balance is too low"}})
+        client = _FakeClient(submit_error=_MaskedStatusError(body))
+        _install_client(monkeypatch, client)
+        with pytest.raises(RuntimeError, match="TinyFish Agent: wallet balance is too low"):
+            await TinyfishAgentHandler.handle_non_streaming("req1", _PARAMS, _LITELLM_PARAMS)
+
+    async def test_poll_timeout_cancels_run(self, monkeypatch):
+        client = _FakeClient(run_payloads=[{"run_id": "run-123", "status": "RUNNING"}] * 50)
+        _install_client(monkeypatch, client)
+        params = {**_LITELLM_PARAMS, "polling_timeout_seconds": 0.0}
+        with pytest.raises(RuntimeError, match="did not finish within"):
+            await TinyfishAgentHandler.handle_non_streaming("req1", _PARAMS, params)
+        assert client.post_urls[-1].endswith("/v1/runs/run-123/cancel")
+
+
+@pytest.mark.asyncio
+class TestHandleStreaming:
+    async def test_sse_events_translate_to_a2a_stream(self, monkeypatch):
+        lines = [
+            'data: {"type":"STARTED","run_id":"run-123"}',
+            "",
+            'data: {"type":"HEARTBEAT"}',
+            'data: {"type":"STREAMING_URL","run_id":"run-123","streaming_url":"https://live.example"}',
+            'data: {"type":"PROGRESS","run_id":"run-123","purpose":"Clicking submit"}',
+            'data: {"type":"COMPLETE","run_id":"run-123","status":"COMPLETED","result":{"title":"T"}}',
+        ]
+        client = _FakeClient(
+            sse_lines=lines,
+            run_payloads=[{"run_id": "run-123", "status": "COMPLETED", "num_of_steps": 4, "result": {"title": "T"}}],
+        )
+        _install_client(monkeypatch, client)
+
+        events = [e async for e in TinyfishAgentHandler.handle_streaming("req1", _PARAMS, _LITELLM_PARAMS)]
+
+        kinds = [e["result"]["kind"] for e in events]
+        assert kinds == ["task", "status-update", "status-update", "artifact-update", "status-update"]
+        assert events[0]["result"]["status"]["state"] == "submitted"
+        assert "https://live.example" in events[1]["result"]["status"]["message"]["parts"][0]["text"]
+        assert events[2]["result"]["status"]["message"]["parts"][0]["text"] == "Clicking submit"
+        artifact = events[3]["result"]["artifact"]
+        assert artifact["parts"][0] == {"kind": "data", "data": {"title": "T"}}
+        assert events[4]["result"]["final"] is True
+        assert events[4]["result"]["status"]["state"] == "completed"
+        assert events[4][A2A_PROVIDER_RESPONSE_COST_KEY] == pytest.approx(4 * 0.016)
+
+    async def test_failed_complete_yields_failed_final_event(self, monkeypatch):
+        lines = [
+            'data: {"type":"STARTED","run_id":"run-123"}',
+            'data: {"type":"COMPLETE","run_id":"run-123","status":"FAILED","error":{"message":"blocked"}}',
+        ]
+        client = _FakeClient(sse_lines=lines, run_payloads=[{"run_id": "run-123", "status": "FAILED"}])
+        _install_client(monkeypatch, client)
+        events = [e async for e in TinyfishAgentHandler.handle_streaming("req1", _PARAMS, _LITELLM_PARAMS)]
+        final = events[-1]["result"]
+        assert final["final"] is True and final["status"]["state"] == "failed"
+        assert "TinyFish Agent: blocked" in final["status"]["message"]["parts"][0]["text"]
+
+    async def test_transport_error_falls_back_to_synthetic_stream(self, monkeypatch):
+        client = _FakeClient(
+            sse_error=httpx.ConnectError("boom"),
+            run_payloads=[{"run_id": "run-123", "status": "COMPLETED", "num_of_steps": 2, "result": {"ok": 1}}],
+        )
+        _install_client(monkeypatch, client)
+        events = [e async for e in TinyfishAgentHandler.handle_streaming("req1", _PARAMS, _LITELLM_PARAMS)]
+        kinds = [e["result"]["kind"] for e in events]
+        assert kinds == ["task", "artifact-update", "status-update"]
+        assert events[-1][A2A_PROVIDER_RESPONSE_COST_KEY] == pytest.approx(2 * 0.016)
+        assert any(url.endswith("/run-async") for url in client.post_urls)
+
+    async def test_stream_ending_without_complete_yields_failed_advisory(self, monkeypatch):
+        lines = ['data: {"type":"STARTED","run_id":"run-123"}']
+        client = _FakeClient(sse_lines=lines)
+        _install_client(monkeypatch, client)
+        events = [e async for e in TinyfishAgentHandler.handle_streaming("req1", _PARAMS, {"api_key": "sk-tf"})]
+        final = events[-1]["result"]
+        assert final["status"]["state"] == "failed"
+        assert "GET /v1/runs/run-123" in final["status"]["message"]["parts"][0]["text"]
+
+
+def test_config_manager_returns_tinyfish_provider():
+    config = A2AProviderConfigManager.get_provider_config(custom_llm_provider="tinyfish")
+    assert config is not None
+    assert config.__class__.__name__ == "TinyfishA2AConfig"
+
+
+def test_tinyfish_dashboard_fields():
+    fields_path = (
+        Path(__file__).resolve().parents[5] / "litellm" / "proxy" / "public_endpoints" / "agent_create_fields.json"
+    )
+    entries = json.loads(fields_path.read_text())
+    entry = next(e for e in entries if e["agent_type"] == "tinyfish")
+    assert entry["litellm_params_template"] == {"custom_llm_provider": "tinyfish"}
+    field_keys = {f["key"] for f in entry["credential_fields"]}
+    assert {"api_key", "cost_per_step"} <= field_keys
+    assert all(f["include_in_litellm_params"] for f in entry["credential_fields"])

--- a/tests/test_litellm/a2a_protocol/test_main.py
+++ b/tests/test_litellm/a2a_protocol/test_main.py
@@ -106,9 +106,7 @@ async def test_streaming_trace_id_prefers_logging_trace_id():
         captured["extra_headers"] = extra_headers
         raise RuntimeError("stop")
 
-    with patch.object(
-        a2a_main, "create_a2a_client", new=AsyncMock(side_effect=_capture)
-    ):
+    with patch.object(a2a_main, "create_a2a_client", new=AsyncMock(side_effect=_capture)):
         with pytest.raises(RuntimeError, match="stop"):
             async for _ in a2a_main.asend_message_streaming(
                 request=request,
@@ -220,9 +218,7 @@ _LOWERCASE_BINDING_CARD = {
     "defaultInputModes": ["text/plain"],
     "defaultOutputModes": ["text/plain"],
     "skills": [],
-    "supportedInterfaces": [
-        {"url": "http://127.0.0.1:9/", "protocolBinding": "jsonrpc", "protocolVersion": "1.0"}
-    ],
+    "supportedInterfaces": [{"url": "http://127.0.0.1:9/", "protocolBinding": "jsonrpc", "protocolVersion": "1.0"}],
 }
 
 
@@ -413,3 +409,138 @@ async def test_the_pooled_a2a_client_arrives_with_cookie_persistence_disabled(is
 
     assert dict(handler.client.cookies) == {}, "the pooled A2A client kept an upstream's cookie"
     await handler.close()
+
+
+def _bridge_logging_obj(call_type: str):
+    from datetime import datetime
+
+    from litellm.litellm_core_utils.litellm_logging import Logging
+
+    return Logging(
+        model="a2a_agent/tf-agent",
+        messages=[{"role": "user", "content": "hi"}],
+        stream=False,
+        call_type=call_type,
+        start_time=datetime.now(),
+        litellm_call_id="bridge-call",
+        function_id="bridge-call",
+    )
+
+
+@pytest.mark.asyncio
+async def test_bridge_non_streaming_sets_cost_params_agent_id_and_reported_cost(monkeypatch):
+    """Regression: the completion-bridge branch returned before cost params, usage, or
+    agent_id reached the logging obj, so every custom_llm_provider agent spend-logged $0."""
+    from litellm.a2a_protocol import main as a2a_main
+    from litellm.a2a_protocol.litellm_completion_bridge.handler import A2ACompletionBridgeHandler
+    from litellm.a2a_protocol.providers.base import A2A_PROVIDER_RESPONSE_COST_KEY
+
+    async def _fake_handle(request_id, params, litellm_params, api_base=None, agent_extra_headers=None, **_):
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": {
+                "kind": "message",
+                "role": "agent",
+                "parts": [{"kind": "text", "text": "done"}],
+                "messageId": "m9",
+            },
+            A2A_PROVIDER_RESPONSE_COST_KEY: 0.112,
+        }
+
+    monkeypatch.setattr(A2ACompletionBridgeHandler, "handle_non_streaming", staticmethod(_fake_handle))
+    logging_obj = _bridge_logging_obj("asend_message")
+
+    response = await a2a_main.asend_message(
+        request=_request(),
+        api_base="https://agent.tinyfish.ai",
+        litellm_params={"custom_llm_provider": "tinyfish", "cost_per_query": 0.05, "agent_name": "tf-agent"},
+        agent_id="agent-1",
+        litellm_logging_obj=logging_obj,
+    )
+
+    response_dict = response.model_dump(mode="json", exclude_none=True)
+    assert A2A_PROVIDER_RESPONSE_COST_KEY not in response_dict
+    assert logging_obj.model_call_details["response_cost"] == pytest.approx(0.112)
+    assert logging_obj.model_call_details["litellm_params"]["cost_per_query"] == 0.05
+    assert logging_obj.model_call_details["agent_id"] == "agent-1"
+    assert logging_obj.model_call_details["usage"].total_tokens > 0
+
+
+@pytest.mark.asyncio
+async def test_bridge_streaming_strips_cost_key_and_records_spend(monkeypatch):
+    """Regression: bridge streams bypassed A2AStreamingIterator entirely, so no success
+    handler ever fired and no spend log was written for provider-config streaming."""
+    from litellm.a2a_protocol import main as a2a_main
+    from litellm.a2a_protocol.litellm_completion_bridge.handler import A2ACompletionBridgeHandler
+    from litellm.a2a_protocol.providers.base import A2A_PROVIDER_RESPONSE_COST_KEY
+
+    async def _fake_stream(request_id, params, litellm_params, api_base=None, agent_extra_headers=None, **_):
+        yield {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": {"kind": "task", "id": "t1", "status": {"state": "submitted"}},
+        }
+        yield {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": {"kind": "status-update", "final": True, "status": {"state": "completed"}, "taskId": "t1"},
+            A2A_PROVIDER_RESPONSE_COST_KEY: 0.064,
+        }
+
+    monkeypatch.setattr(A2ACompletionBridgeHandler, "handle_streaming", staticmethod(_fake_stream))
+    logging_obj = _bridge_logging_obj("asend_message_streaming")
+
+    request = SendStreamingMessageRequest(
+        id="rpc-bridge-stream",
+        params=MessageSendParams(
+            message={"messageId": "m1", "role": "user", "parts": [{"kind": "text", "text": "hi"}]}
+        ),
+    )
+    chunks = [
+        chunk
+        async for chunk in a2a_main.asend_message_streaming(
+            request=request,
+            litellm_params={"custom_llm_provider": "tinyfish", "agent_name": "tf-agent"},
+            agent_id="agent-1",
+            litellm_logging_obj=logging_obj,
+        )
+    ]
+
+    assert len(chunks) == 2
+    assert all(A2A_PROVIDER_RESPONSE_COST_KEY not in chunk for chunk in chunks)
+    assert logging_obj.model_call_details["response_cost"] == pytest.approx(0.064)
+    assert logging_obj.model_call_details["agent_id"] == "agent-1"
+
+
+@pytest.mark.asyncio
+async def test_bridge_streaming_flat_cost_per_query_reaches_response_cost(monkeypatch):
+    """cost_per_query on a bridge agent must price the stream when the provider reports no cost."""
+    from litellm.a2a_protocol import main as a2a_main
+    from litellm.a2a_protocol.litellm_completion_bridge.handler import A2ACompletionBridgeHandler
+
+    async def _fake_stream(request_id, params, litellm_params, api_base=None, agent_extra_headers=None, **_):
+        yield {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": {"kind": "status-update", "final": True, "status": {"state": "completed"}, "taskId": "t1"},
+        }
+
+    monkeypatch.setattr(A2ACompletionBridgeHandler, "handle_streaming", staticmethod(_fake_stream))
+    logging_obj = _bridge_logging_obj("asend_message_streaming")
+
+    request = SendStreamingMessageRequest(
+        id="rpc-flat-cost",
+        params=MessageSendParams(
+            message={"messageId": "m1", "role": "user", "parts": [{"kind": "text", "text": "hi"}]}
+        ),
+    )
+    async for _ in a2a_main.asend_message_streaming(
+        request=request,
+        litellm_params={"custom_llm_provider": "tinyfish", "cost_per_query": 0.05, "agent_name": "tf-agent"},
+        agent_id="agent-1",
+        litellm_logging_obj=logging_obj,
+    ):
+        pass
+
+    assert logging_obj.model_call_details["response_cost"] == pytest.approx(0.05)

--- a/ui/litellm-dashboard/src/app/(dashboard)/agents/_components/agent_type_utils.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/agents/_components/agent_type_utils.ts
@@ -14,6 +14,7 @@ export const detectAgentType = (agent: Agent): string => {
   if (customProvider === "langgraph") return "langgraph";
   if (customProvider === "azure_ai") return "azure_ai_foundry";
   if (customProvider === "bedrock") return "bedrock_agentcore";
+  if (customProvider === "tinyfish") return "tinyfish";
 
   // Check by model prefix
   if (model.startsWith("langflow/")) return "langflow";


### PR DESCRIPTION
## TLDR

Problem this solves:

- LiteLLM cannot call the TinyFish Agent API (goal-based web automation)
- A customer routes TinyFish calls through LiteLLM for per-team chargeback
- Completion-bridge agents (`custom_llm_provider` set) spend-logged $0 on `message/send`
- Completion-bridge agents wrote no spend log at all on `message/stream`

How it solves it:

- New `tinyfish` A2A provider: `message/send` and `message/stream` run web automations
- Non-streaming submits via run-async and polls, cancelling the run on timeout
- Streaming translates TinyFish SSE progress events into A2A stream events
- Spend is priced from actual steps: `num_of_steps x cost_per_step`
- Bridge path now sets cost params, usage, and agent_id on the logging object
- Bridge streams now flow through the A2A streaming iterator, so spend logs fire
- Providers can report exact upstream cost via a reserved key the bridge strips

## User Flow

Before: a developer whose team is billed through LiteLLM cannot run a TinyFish web automation through the gateway

1. The proxy admin registers an agent with `custom_llm_provider: tinyfish` under `agents:` and restarts the proxy
2. The developer sends POST https://litellm-domain/a2a/tinyfish-agent/message/send with a goal ("Extract the first 2 product names and prices") and `"metadata": {"url": "https://scrapeme.live/shop"}`
3. They get a JSON-RPC internal error: the gateway tries to treat TinyFish like a chat-completions LLM and fails with "LLM Provider NOT provided"
4. https://litellm-domain/ui/?page=logs shows nothing usable to charge back

After: the same request runs the automation and bills the team for exactly what the run cost

1. The proxy admin registers the same agent, adding `cost_per_step: 0.016` (TinyFish's published rate) and restarts the proxy
2. The developer sends the same POST https://litellm-domain/a2a/tinyfish-agent/message/send
3. They get 200 with the extracted products as a structured `data` part plus a JSON text part, and `metadata` carrying `tinyfish_run_id`, `tinyfish_status`, and `tinyfish_num_of_steps` for support correlation
4. https://litellm-domain/ui/?page=logs shows the request at $0.032 (2 steps x $0.016), attributed to the developer's key and team
5. Sending the same body to POST https://litellm-domain/a2a/tinyfish-agent with `"method": "message/stream"` streams live progress ("Visit the shop page...", a watch-live browser URL) as A2A status updates, then the result artifact, and bills the same way

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy, real TinyFish API, real $. Shared setup: proxy on localhost:41777 with Postgres, config registers `tinyfish-agent` with `custom_llm_provider: tinyfish`, `api_key: os.environ/TINYFISH_API_KEY`, `cost_per_step: 0.016`; a virtual key aliased `cigna-team-a` plays the business team.

```yaml
agents:
  - agent_name: tinyfish-agent
    agent_card_params:
      name: tinyfish-agent
      description: TinyFish goal-based web automation
      url: https://agent.tinyfish.ai
      capabilities: {streaming: true}
    litellm_params:
      custom_llm_provider: tinyfish
      api_key: os.environ/TINYFISH_API_KEY
      cost_per_step: 0.016
```

### Before (09b694894d)

#### message/send runs a web automation

1. `curl -s http://127.0.0.1:41777/a2a/tinyfish-agent/message/send -H "Authorization: Bearer $TEAM_KEY" -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":"before-1","method":"message/send","params":{"message":{"role":"user","messageId":"m1","parts":[{"kind":"text","text":"Extract the first 2 product names and prices. Return JSON."}],"metadata":{"url":"https://scrapeme.live/shop"}}}}'`
2. The gateway cannot route the agent and no automation runs:

```json
{"jsonrpc": "2.0", "id": "before-1", "error": {"code": -32602, "message": "litellm.BadRequestError: LLM Provider NOT provided. Pass in the LLM provider you are trying to call. You passed model=tinyfish/agent..."}}
```

#### spend is attributed to the team key

1. `select request_id, model, spend, metadata->>'user_api_key_alias' from "LiteLLM_SpendLogs" order by "startTime" desc limit 1;`
2. No row is written for the request; there is nothing to charge back

### After (9bdd632ea9)

#### message/send runs a web automation

1. Same curl as Before, with id `proof-1`
2. 200 in 34.7s with the run result (unicode escapes come from piping through `python3 -m json.tool`):

```json
{"id": "proof-1", "jsonrpc": "2.0", "result": {"kind": "message", "role": "agent",
 "parts": [
   {"kind": "data", "data": {"products": [{"name": "Bulbasaur", "price": "\u00a363.00"}, {"name": "Ivysaur", "price": "\u00a387.00"}]}},
   {"kind": "text", "text": "{\"products\":[{\"name\":\"Bulbasaur\",\"price\":\"\\u00a363.00\"},{\"name\":\"Ivysaur\",\"price\":\"\\u00a387.00\"}]}"}],
 "messageId": "1d06b9eb-6296-4d12-a512-f3319fa11c44",
 "metadata": {"tinyfish_run_id": "64ccc872-6e6a-4ede-8512-9aadab288e7d", "tinyfish_status": "COMPLETED", "tinyfish_num_of_steps": 2}}}
```

#### spend is attributed to the team key

1. Same query as Before
2. The run cost exactly steps x rate, on the team's key:

```
 proof-1 | a2a_agent/tinyfish-agent | 0.032 | cigna-team-a
```

#### message/stream shows live progress and bills the same way

1. `curl -sN http://127.0.0.1:41777/a2a/tinyfish-agent -H "Authorization: Bearer $TEAM_KEY" -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":"proof-stream-2","method":"message/stream","params":{"message":{"role":"user","messageId":"m3","parts":[{"kind":"text","text":"Extract the page title. Return JSON."}],"metadata":{"url":"https://scrapeme.live/shop"}}}}'`
2. SSE events arrive live: task `submitted`, then working updates carrying "Watch live: https://ip-54-219-73-38.tetra-data.production.tinyfish.io/.../stream/0" and per-action purposes ("Visit the shop page to extract information."), then the result artifact, then final `completed`
3. Spend logs after the stream:

```
 proof-stream-2 | a2a_agent/tinyfish-agent | 0.048 | cigna-team-a
```

(3 steps x $0.016; the reserved internal cost key never appears in the SSE output)

#### a request without a target url fails with an attributed error

1. Same curl as case 1 but with no `metadata.url`
2. `{"jsonrpc": "2.0", "id": "proof-err-1", "error": {"code": -32603, "message": "Internal error: TinyFish Agent: request has no target url. Set 'url' in the message's 'metadata' (or in the agent's default_request_params). See https://docs.tinyfish.ai/agent-api for details."}}` and the failed request is spend-logged at $0

## Type

🆕 New Feature
🐛 Bug Fix

## Caveats (if any)

### Medium

- A2A `tasks/get` and `tasks/cancel` are not mapped; the gateway raw-forwards them upstream, which TinyFish does not speak. Poll-timeout cancellation is handled internally
- A run that FAILS upstream is spend-logged at $0 even though TinyFish bills the steps it took; failure-path cost needs its own follow-up

### Low

- `cost_per_step` is admin-configured, not hardcoded, so price changes need a config edit, not a release
- Caller-supplied `use_vault` / `use_profile` fields are stripped unless the admin sets `allow_authenticated_runs: true`, since teams share one upstream key
- The agent type reuses the generic A2A logo in the Admin UI until a brand asset lands

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
