### PR TITLE
docs: remove duplicate 'the' in litellm test readme

### DIFF
--- a/tests/test_litellm/readme.md
+++ b/tests/test_litellm/readme.md
@@ -1,6 +1,6 @@
 # Testing for `litellm/` 
 
-This directory 1:1 maps the the `litellm/` directory, and can only contain mocked tests. 
+This directory 1:1 maps the `litellm/` directory, and can only contain mocked tests. 
 
 The point of this is to:
 1. Increase test coverage of `litellm/`


### PR DESCRIPTION
Tiny docs fix: remove duplicate `the` in the `tests/test_litellm/readme.md` intro.